### PR TITLE
Related to #5: Fixed bounds checking in RadioButtonSelect component to ensure active…

### DIFF
--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -56,8 +56,19 @@ export function RadioButtonSelect<T>({
   showScrollArrows = false,
   maxItemsToShow = 10,
 }: RadioButtonSelectProps<T>): React.JSX.Element {
-  const [activeIndex, setActiveIndex] = useState(initialIndex);
+  // Ensure initialIndex is within bounds
+  const safeInitialIndex = items.length > 0 ? Math.max(0, Math.min(initialIndex, items.length - 1)) : 0;
+  const [activeIndex, setActiveIndex] = useState(safeInitialIndex);
   const [scrollOffset, setScrollOffset] = useState(0);
+
+  // Ensure activeIndex stays within bounds when items change
+  useEffect(() => {
+    if (items.length === 0) {
+      setActiveIndex(0);
+    } else if (activeIndex >= items.length) {
+      setActiveIndex(items.length - 1);
+    }
+  }, [items.length, activeIndex]);
 
   useEffect(() => {
     const newScrollOffset = Math.max(
@@ -73,18 +84,21 @@ export function RadioButtonSelect<T>({
 
   useInput(
     (input, key) => {
-      if (input === 'k' || key.upArrow) {
+      if ((input === 'k' || key.upArrow) && items.length > 0) {
         const newIndex = activeIndex > 0 ? activeIndex - 1 : items.length - 1;
         setActiveIndex(newIndex);
         onHighlight?.(items[newIndex]!.value);
       }
-      if (input === 'j' || key.downArrow) {
+      if ((input === 'j' || key.downArrow) && items.length > 0) {
         const newIndex = activeIndex < items.length - 1 ? activeIndex + 1 : 0;
         setActiveIndex(newIndex);
         onHighlight?.(items[newIndex]!.value);
       }
       if (key.return) {
-        onSelect(items[activeIndex]!.value);
+        // Add boundary check before accessing items[activeIndex]
+        if (activeIndex >= 0 && activeIndex < items.length && items[activeIndex]) {
+          onSelect(items[activeIndex]!.value);
+        }
       }
 
       // Enable selection directly from number keys.


### PR DESCRIPTION
…Index and initialIndex are in valid range to avoid accessing out-of-bounds items.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

This PR fixes the `TypeError: Cannot read properties of undefined (reading 'value')` error in the RadioButtonSelect component by adding proper bounds checking for array access. The fix ensures safe handling of edge cases like empty arrays, out-of-bounds initial indices, and dynamic array changes.

## Dive Deeper

<!-- more thoughts and in depth discussion here -->

The RadioButtonSelect component was vulnerable to runtime errors when:
1. `initialIndex` was greater than or equal to `items.length`
2. The `items` array was empty
3. `activeIndex` became out-of-bounds due to dynamic array changes
4. User interactions (Enter key, arrow keys) occurred with invalid indices

**Key changes:**
- Added safe initial index calculation that clamps values within array bounds
- Implemented a useEffect to monitor array length changes and adjust activeIndex accordingly
- Added bounds checking before accessing `items[activeIndex]` in all user input handlers
- Protected navigation (up/down arrows) to only work when items exist

The fixes maintain the component's existing behavior while preventing all boundary condition crashes.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #5
- Fixes #5 
- Resolves #5 

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
