### PR TITLE
fix: prevent TypeError in RadioButtonSelect component

### DIFF
--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -65,6 +65,7 @@ export function AuthDialog({
 
     return item.value === AuthType.LOGIN_WITH_GOOGLE;
   });
+  const validInitialAuthIndex = initialAuthIndex >= 0 ? initialAuthIndex : 0;
 
   const handleAuthSelect = (authMethod: AuthType) => {
     const error = validateAuthMethod(authMethod);
@@ -145,7 +146,7 @@ export function AuthDialog({
       <Box marginTop={1}>
         <RadioButtonSelect
           items={items}
-          initialIndex={initialAuthIndex}
+          initialIndex={validInitialAuthIndex}
           onSelect={handleAuthSelect}
           isFocused={true}
         />

--- a/packages/cli/src/ui/components/ThemeDialog.tsx
+++ b/packages/cli/src/ui/components/ThemeDialog.tsx
@@ -53,6 +53,7 @@ export function ThemeDialog({
   const initialThemeIndex = themeItems.findIndex(
     (item) => item.value === (settings.merged.theme || DEFAULT_THEME.name),
   );
+  const validInitialThemeIndex = initialThemeIndex >= 0 ? initialThemeIndex : 0;
 
   const scopeItems = [
     { label: 'User Settings', value: SettingScope.User },
@@ -198,7 +199,7 @@ export function ThemeDialog({
           <RadioButtonSelect
             key={selectInputKey}
             items={themeItems}
-            initialIndex={initialThemeIndex}
+            initialIndex={validInitialThemeIndex}
             onSelect={handleThemeSelect}
             onHighlight={onHighlight}
             isFocused={currenFocusedSection === 'theme'}

--- a/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
+++ b/packages/cli/src/ui/components/shared/RadioButtonSelect.tsx
@@ -56,7 +56,8 @@ export function RadioButtonSelect<T>({
   showScrollArrows = false,
   maxItemsToShow = 10,
 }: RadioButtonSelectProps<T>): React.JSX.Element {
-  const [activeIndex, setActiveIndex] = useState(initialIndex);
+  const validInitialIndex = items.length > 0 && initialIndex >= 0 && initialIndex < items.length ? initialIndex : 0;
+  const [activeIndex, setActiveIndex] = useState(validInitialIndex);
   const [scrollOffset, setScrollOffset] = useState(0);
 
   useEffect(() => {
@@ -76,15 +77,21 @@ export function RadioButtonSelect<T>({
       if (input === 'k' || key.upArrow) {
         const newIndex = activeIndex > 0 ? activeIndex - 1 : items.length - 1;
         setActiveIndex(newIndex);
-        onHighlight?.(items[newIndex]!.value);
+        if (items[newIndex]) {
+          onHighlight?.(items[newIndex].value);
+        }
       }
       if (input === 'j' || key.downArrow) {
         const newIndex = activeIndex < items.length - 1 ? activeIndex + 1 : 0;
         setActiveIndex(newIndex);
-        onHighlight?.(items[newIndex]!.value);
+        if (items[newIndex]) {
+          onHighlight?.(items[newIndex].value);
+        }
       }
       if (key.return) {
-        onSelect(items[activeIndex]!.value);
+        if (items[activeIndex]) {
+          onSelect(items[activeIndex].value);
+        }
       }
 
       // Enable selection directly from number keys.


### PR DESCRIPTION
## Summary
- Fixed TypeError in RadioButtonSelect when `items[activeIndex]` is undefined
- Added validation for `initialIndex` parameter to handle invalid values from `findIndex()`
- Added null checks in keyboard event handlers before accessing array elements
- Updated ThemeDialog and AuthDialog to validate initial index values

## Root Cause
The error occurred when parent components passed `-1` as `initialIndex` (from `findIndex()` returning -1 when no match found), causing `items[activeIndex]` to be undefined in keyboard handlers.

## Changes
- **RadioButtonSelect.tsx**: Added `validInitialIndex` validation and null checks
- **ThemeDialog.tsx**: Added `validInitialThemeIndex` validation  
- **AuthDialog.tsx**: Added `validInitialAuthIndex` validation

## Test Plan
- [x] Verify RadioButtonSelect handles invalid initialIndex gracefully
- [x] Test keyboard navigation doesn't crash on edge cases
- [x] Confirm theme and auth dialogs work with missing/invalid selections

**Resolves**: `TypeError: Cannot read properties of undefined (reading 'value')`

**Files changed**: 3 files, 15 insertions, 6 deletions
**Commit**: 21030f0