### PR TITLE
Update README.md to clarify the requirement for using Modelscope inference API

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ export OPENAI_BASE_URL="https://dashscope.aliyuncs.com/compatible-mode/v1"
 export OPENAI_MODEL="qwen3-coder-plus"
 ```
 
-If you are in mainland China, ModelScope offers 2,000 free model inference API calls per day:
+If you are in mainland China, ModelScope offers 2,000 free model inference API calls per day.Please make sure you connect your aliyun account to ModelScope so that you won't receive the API error like `API Error: OpenAI API error`.
 
 ```bash
 export OPENAI_API_KEY="your_api_key_here"


### PR DESCRIPTION
## TLDR

solve the configuration problem and the crazy error message - **OpenAI API Error**

## Dive Deeper

Modelscope looks like requires users to connect their aliyun account 

## Reviewer Test Plan

- Login to Modelscope by using GitHub account, but not connect to a valid aliyun account, you won't able to use Modelscope inference API in qwen code, or even in the pure Python code.
- After you connect your account to aliyun account, everything will be good

## Testing Matrix



## Linked issues / bugs

- Fixes #96 , #6 