### PR TITLE
Fix Default Model Configuration and Fallback Behavior

### DIFF
--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export const DEFAULT_GEMINI_MODEL = 'qwen3-coder-max';
+export const DEFAULT_GEMINI_MODEL = 'qwen3-coder-plus';
 export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
 export const DEFAULT_GEMINI_EMBEDDING_MODEL = 'gemini-embedding-001';

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -116,7 +116,8 @@ export async function createContentGeneratorConfig(
 
   if (authType === AuthType.USE_OPENAI && openaiApiKey) {
     contentGeneratorConfig.apiKey = openaiApiKey;
-    contentGeneratorConfig.model = process.env.OPENAI_MODEL || DEFAULT_GEMINI_MODEL;
+    contentGeneratorConfig.model =
+      process.env.OPENAI_MODEL || DEFAULT_GEMINI_MODEL;
 
     return contentGeneratorConfig;
   }

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -116,7 +116,7 @@ export async function createContentGeneratorConfig(
 
   if (authType === AuthType.USE_OPENAI && openaiApiKey) {
     contentGeneratorConfig.apiKey = openaiApiKey;
-    contentGeneratorConfig.model = process.env.OPENAI_MODEL || '';
+    contentGeneratorConfig.model = process.env.OPENAI_MODEL || DEFAULT_GEMINI_MODEL;
 
     return contentGeneratorConfig;
   }

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -17,6 +17,7 @@ import { WriteFileTool } from '../tools/write-file.js';
 import process from 'node:process';
 import { isGitRepository } from '../utils/gitUtils.js';
 import { MemoryTool, GEMINI_CONFIG_DIR } from '../tools/memoryTool.js';
+import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
 
 export interface ModelTemplateMapping {
   baseUrls?: string[];
@@ -65,7 +66,7 @@ export function getCoreSystemPrompt(
 
   // Check for system prompt mappings from global config
   if (config?.systemPromptMappings) {
-    const currentModel = process.env.OPENAI_MODEL || '';
+    const currentModel = process.env.OPENAI_MODEL || DEFAULT_GEMINI_MODEL;
     const currentBaseUrl = process.env.OPENAI_BASE_URL || '';
 
     const matchedMapping = config.systemPromptMappings.find((mapping) => {


### PR DESCRIPTION
### 🎯 **Summary**
This PR addresses model configuration issues by updating the default model and fixing fallback behavior when the `OPENAI_MODEL` environment variable is unset.

### 🔧 **Changes Made**

#### 1. **Updated Default Model** (`packages/core/src/config/models.ts`)
- Changed `DEFAULT_GEMINI_MODEL` from `'qwen3-coder-max'` to `'qwen3-coder-plus'`

#### 2. **Fixed Model Fallback Logic** (`packages/core/src/core/contentGenerator.ts` & `packages/core/src/core/prompts.ts`)
- **Problem**: When `OPENAI_MODEL` environment variable is unset, the system was falling back to an empty string (`''`) instead of using a valid default model
- **Solution**: Updated fallback logic to use `DEFAULT_GEMINI_MODEL` when `OPENAI_MODEL` is not configured
- **Files affected**:
  - `contentGenerator.ts`: Line 119 - Fixed model assignment in OpenAI auth configuration
  - `prompts.ts`: Line 69 - Fixed model resolution in system prompt mappings

### 🐛 **Bug Fix Details**

**Before:**
```typescript
contentGeneratorConfig.model = process.env.OPENAI_MODEL || '';
const currentModel = process.env.OPENAI_MODEL || '';
```

**After:**
```typescript
contentGeneratorConfig.model = process.env.OPENAI_MODEL || DEFAULT_GEMINI_MODEL;
const currentModel = process.env.OPENAI_MODEL || DEFAULT_GEMINI_MODEL;
```

### 🎯 **Impact**
- **Improved Reliability**: Eliminates empty model strings that could cause API failures
- **Better Defaults**: Users get a working model configuration even when `OPENAI_MODEL` is not set
- **Consistent Behavior**: Both content generation and prompt mapping use the same fallback logic

### 📝 **Related Issues**
This PR fixes configuration issues that could lead to API failures when environment variables are not properly set.