### PR TITLE
fix: updating Dockerfile to fix sandbox image building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ packages/vscode-ide-companion/*.vsix
 # Qwen Code Configs
 .qwen/
 logs/
+
+/*.tgz

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,10 @@ ENV PATH=$PATH:/usr/local/share/npm-global/bin
 USER node
 
 # install qwen-code and clean up
-COPY packages/cli/dist/qwen-code-*.tgz /usr/local/share/npm-global/qwen-code.tgz
-COPY packages/core/dist/qwen-code-qwen-code-core-*.tgz /usr/local/share/npm-global/qwen-code-core.tgz
-RUN npm install -g /usr/local/share/npm-global/qwen-code.tgz /usr/local/share/npm-global/qwen-code-core.tgz \
+COPY qwen-code-*.tgz /usr/local/share/npm-global/
+RUN npm install -g /usr/local/share/npm-global/qwen-code*.tgz \
   && npm cache clean --force \
-  && rm -f /usr/local/share/npm-global/qwen-{code,code-core}.tgz
+  && rm -f /usr/local/share/npm-global/qwen-code*.tgz
 
 # default entrypoint when none specified
 CMD ["qwen"]


### PR DESCRIPTION
## TLDR

This patch fixes sandbox image building process by updating the Dockerfile with some wildcards.

## Reviewer Test Plan

Build the sandbox image:

```bash
npm i
npm run build
bash ./scripts/pack.sh
docker buildx build -t qwen-code-sandbox:latest .
```

And the sandbox image works after this patch:

```bash
node qwen-code.js --sandbox --sandbox-image qwen-code-sandbox:latest
```

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   |✅| ✅  | ✅  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A
