### PR TITLE
rename GEMINI.md to QWEN.md across the codebase

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -148,7 +148,7 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
           getUserTier: vi.fn(),
         })),
         getCheckpointingEnabled: vi.fn(() => opts.checkpointing ?? true),
-        getAllGeminiMdFilenames: vi.fn(() => ['GEMINI.md']),
+        getAllGeminiMdFilenames: vi.fn(() => ['QWEN.md']),
         setFlashFallbackHandler: vi.fn(),
         getSessionId: vi.fn(() => 'test-session-id'),
         getUserTier: vi.fn().mockResolvedValue(undefined),
@@ -169,7 +169,7 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
     ...actualCore,
     Config: ConfigClassMock,
     MCPServerConfig: actualCore.MCPServerConfig,
-    getAllGeminiMdFilenames: vi.fn(() => ['GEMINI.md']),
+    getAllGeminiMdFilenames: vi.fn(() => ['QWEN.md']),
     ideContext: ideContextMock,
     isGitRepository: vi.fn(),
   };
@@ -577,7 +577,7 @@ describe('App UI', () => {
       },
     });
     mockConfig.getGeminiMdFileCount.mockReturnValue(1);
-    mockConfig.getAllGeminiMdFilenames.mockReturnValue(['GEMINI.md']);
+    mockConfig.getAllGeminiMdFilenames.mockReturnValue(['QWEN.md']);
 
     const { lastFrame, unmount } = render(
       <App
@@ -589,13 +589,13 @@ describe('App UI', () => {
     currentUnmount = unmount;
     await Promise.resolve();
     expect(lastFrame()).toContain(
-      'Using: 1 open file (ctrl+e to view) | 1 GEMINI.md file',
+      'Using: 1 open file (ctrl+e to view) | 1 QWEN.md file',
     );
   });
 
-  it('should display default "GEMINI.md" in footer when contextFileName is not set and count is 1', async () => {
+  it('should display default "QWEN.md" in footer when contextFileName is not set and count is 1', async () => {
     mockConfig.getGeminiMdFileCount.mockReturnValue(1);
-    mockConfig.getAllGeminiMdFilenames.mockReturnValue(['GEMINI.md']);
+    mockConfig.getAllGeminiMdFilenames.mockReturnValue(['QWEN.md']);
     // For this test, ensure showMemoryUsage is false or debugMode is false if it relies on that
     mockConfig.getDebugMode.mockReturnValue(false);
     mockConfig.getShowMemoryUsage.mockReturnValue(false);
@@ -609,14 +609,14 @@ describe('App UI', () => {
     );
     currentUnmount = unmount;
     await Promise.resolve(); // Wait for any async updates
-    expect(lastFrame()).toContain('Using: 1 GEMINI.md file');
+    expect(lastFrame()).toContain('Using: 1 QWEN.md file');
   });
 
-  it('should display default "GEMINI.md" with plural when contextFileName is not set and count is > 1', async () => {
+  it('should display default "QWEN.md" with plural when contextFileName is not set and count is > 1', async () => {
     mockConfig.getGeminiMdFileCount.mockReturnValue(2);
     mockConfig.getAllGeminiMdFilenames.mockReturnValue([
-      'GEMINI.md',
-      'GEMINI.md',
+      'QWEN.md',
+      'QWEN.md',
     ]);
     mockConfig.getDebugMode.mockReturnValue(false);
     mockConfig.getShowMemoryUsage.mockReturnValue(false);
@@ -630,7 +630,7 @@ describe('App UI', () => {
     );
     currentUnmount = unmount;
     await Promise.resolve();
-    expect(lastFrame()).toContain('Using: 2 GEMINI.md files');
+    expect(lastFrame()).toContain('Using: 2 QWEN.md files');
   });
 
   it('should display custom contextFileName in footer when set and count is 1', async () => {
@@ -727,11 +727,11 @@ describe('App UI', () => {
     expect(lastFrame()).not.toContain('ANY_FILE.MD');
   });
 
-  it('should display GEMINI.md and MCP server count when both are present', async () => {
+  it('should display QWEN.md and MCP server count when both are present', async () => {
     mockConfig.getGeminiMdFileCount.mockReturnValue(2);
     mockConfig.getAllGeminiMdFilenames.mockReturnValue([
-      'GEMINI.md',
-      'GEMINI.md',
+      'QWEN.md',
+      'QWEN.md',
     ]);
     mockConfig.getMcpServers.mockReturnValue({
       server1: {} as MCPServerConfig,
@@ -751,7 +751,7 @@ describe('App UI', () => {
     expect(lastFrame()).toContain('1 MCP server');
   });
 
-  it('should display only MCP server count when GEMINI.md count is 0', async () => {
+  it('should display only MCP server count when QWEN.md count is 0', async () => {
     mockConfig.getGeminiMdFileCount.mockReturnValue(0);
     mockConfig.getAllGeminiMdFilenames.mockReturnValue([]);
     mockConfig.getMcpServers.mockReturnValue({

--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -614,10 +614,7 @@ describe('App UI', () => {
 
   it('should display default "QWEN.md" with plural when contextFileName is not set and count is > 1', async () => {
     mockConfig.getGeminiMdFileCount.mockReturnValue(2);
-    mockConfig.getAllGeminiMdFilenames.mockReturnValue([
-      'QWEN.md',
-      'QWEN.md',
-    ]);
+    mockConfig.getAllGeminiMdFilenames.mockReturnValue(['QWEN.md', 'QWEN.md']);
     mockConfig.getDebugMode.mockReturnValue(false);
     mockConfig.getShowMemoryUsage.mockReturnValue(false);
 
@@ -729,10 +726,7 @@ describe('App UI', () => {
 
   it('should display QWEN.md and MCP server count when both are present', async () => {
     mockConfig.getGeminiMdFileCount.mockReturnValue(2);
-    mockConfig.getAllGeminiMdFilenames.mockReturnValue([
-      'QWEN.md',
-      'QWEN.md',
-    ]);
+    mockConfig.getAllGeminiMdFilenames.mockReturnValue(['QWEN.md', 'QWEN.md']);
     mockConfig.getMcpServers.mockReturnValue({
       server1: {} as MCPServerConfig,
     });

--- a/packages/cli/src/ui/commands/initCommand.test.ts
+++ b/packages/cli/src/ui/commands/initCommand.test.ts
@@ -20,7 +20,7 @@ vi.mock('fs', () => ({
 describe('initCommand', () => {
   let mockContext: CommandContext;
   const targetDir = '/test/dir';
-  const geminiMdPath = path.join(targetDir, 'GEMINI.md');
+  const geminiMdPath = path.join(targetDir, 'QWEN.md');
 
   beforeEach(() => {
     // Create a fresh mock context for each test
@@ -38,7 +38,7 @@ describe('initCommand', () => {
     vi.clearAllMocks();
   });
 
-  it('should inform the user if GEMINI.md already exists', async () => {
+  it('should inform the user if QWEN.md already exists', async () => {
     // Arrange: Simulate that the file exists
     vi.mocked(fs.existsSync).mockReturnValue(true);
 
@@ -50,13 +50,13 @@ describe('initCommand', () => {
       type: 'message',
       messageType: 'info',
       content:
-        'A GEMINI.md file already exists in this directory. No changes were made.',
+        'A QWEN.md file already exists in this directory. No changes were made.',
     });
     // Assert: Ensure no file was written
     expect(fs.writeFileSync).not.toHaveBeenCalled();
   });
 
-  it('should create GEMINI.md and submit a prompt if it does not exist', async () => {
+  it('should create QWEN.md and submit a prompt if it does not exist', async () => {
     // Arrange: Simulate that the file does not exist
     vi.mocked(fs.existsSync).mockReturnValue(false);
 
@@ -70,7 +70,7 @@ describe('initCommand', () => {
     expect(mockContext.ui.addItem).toHaveBeenCalledWith(
       {
         type: 'info',
-        text: 'Empty GEMINI.md created. Now analyzing the project to populate it.',
+        text: 'Empty QWEN.md created. Now analyzing the project to populate it.',
       },
       expect.any(Number),
     );

--- a/packages/cli/src/ui/commands/initCommand.ts
+++ b/packages/cli/src/ui/commands/initCommand.ts
@@ -15,7 +15,7 @@ import {
 
 export const initCommand: SlashCommand = {
   name: 'init',
-  description: 'Analyzes the project and creates a tailored GEMINI.md file.',
+  description: 'Analyzes the project and creates a tailored QWEN.md file.',
   kind: CommandKind.BUILT_IN,
   action: async (
     context: CommandContext,
@@ -29,24 +29,24 @@ export const initCommand: SlashCommand = {
       };
     }
     const targetDir = context.services.config.getTargetDir();
-    const geminiMdPath = path.join(targetDir, 'GEMINI.md');
+    const geminiMdPath = path.join(targetDir, 'QWEN.md');
 
     if (fs.existsSync(geminiMdPath)) {
       return {
         type: 'message',
         messageType: 'info',
         content:
-          'A GEMINI.md file already exists in this directory. No changes were made.',
+          'A QWEN.md file already exists in this directory. No changes were made.',
       };
     }
 
-    // Create an empty GEMINI.md file
+    // Create an empty QWEN.md file
     fs.writeFileSync(geminiMdPath, '', 'utf8');
 
     context.ui.addItem(
       {
         type: 'info',
-        text: 'Empty GEMINI.md created. Now analyzing the project to populate it.',
+        text: 'Empty QWEN.md created. Now analyzing the project to populate it.',
       },
       Date.now(),
     );
@@ -54,7 +54,7 @@ export const initCommand: SlashCommand = {
     return {
       type: 'submit_prompt',
       content: `
-You are an AI agent that brings the power of Gemini directly into the terminal. Your task is to analyze the current directory and generate a comprehensive GEMINI.md file to be used as instructional context for future interactions.
+You are an AI agent that brings the power of Gemini directly into the terminal. Your task is to analyze the current directory and generate a comprehensive QWEN.md file to be used as instructional context for future interactions.
 
 **Analysis Process:**
 
@@ -70,7 +70,7 @@ You are an AI agent that brings the power of Gemini directly into the terminal. 
     *   **Code Project:** Look for clues like \`package.json\`, \`requirements.txt\`, \`pom.xml\`, \`go.mod\`, \`Cargo.toml\`, \`build.gradle\`, or a \`src\` directory. If you find them, this is likely a software project.
     *   **Non-Code Project:** If you don't find code-related files, this might be a directory for documentation, research papers, notes, or something else.
 
-**GEMINI.md Content Generation:**
+**QWEN.md Content Generation:**
 
 **For a Code Project:**
 
@@ -86,7 +86,7 @@ You are an AI agent that brings the power of Gemini directly into the terminal. 
 
 **Final Output:**
 
-Write the complete content to the \`GEMINI.md\` file. The output must be well-formatted Markdown.
+Write the complete content to the \`QWEN.md\` file. The output must be well-formatted Markdown.
 `,
     };
   },

--- a/packages/cli/src/ui/hooks/useShowMemoryCommand.ts
+++ b/packages/cli/src/ui/hooks/useShowMemoryCommand.ts
@@ -66,8 +66,8 @@ export function createShowMemoryAction(
         type: MessageType.INFO,
         content:
           fileCount > 0
-            ? 'Hierarchical memory (GEMINI.md or other context files) is loaded but content is empty.'
-            : 'No hierarchical memory (GEMINI.md or other context files) is currently loaded.',
+            ? 'Hierarchical memory (QWEN.md or other context files) is loaded but content is empty.'
+            : 'No hierarchical memory (QWEN.md or other context files) is currently loaded.',
         timestamp: new Date(),
       });
     }

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -60,8 +60,8 @@ vi.mock('../tools/read-many-files');
 vi.mock('../tools/memoryTool', () => ({
   MemoryTool: vi.fn(),
   setGeminiMdFilename: vi.fn(),
-  getCurrentGeminiMdFilename: vi.fn(() => 'GEMINI.md'), // Mock the original filename
-  DEFAULT_CONTEXT_FILENAME: 'GEMINI.md',
+  getCurrentGeminiMdFilename: vi.fn(() => 'QWEN.md'), // Mock the original filename
+  DEFAULT_CONTEXT_FILENAME: 'QWEN.md',
   GEMINI_CONFIG_DIR: '.gemini',
 }));
 

--- a/packages/core/src/tools/memoryTool.ts
+++ b/packages/core/src/tools/memoryTool.ts
@@ -60,7 +60,7 @@ export const GEMINI_CONFIG_DIR = '.qwen';
 export const DEFAULT_CONTEXT_FILENAME = 'QWEN.md';
 export const MEMORY_SECTION_HEADER = '## Qwen Added Memories';
 
-// This variable will hold the currently configured filename for GEMINI.md context files.
+// This variable will hold the currently configured filename for QWEN.md context files.
 // It defaults to DEFAULT_CONTEXT_FILENAME but can be overridden by setGeminiMdFilename.
 let currentGeminiMdFilename: string | string[] = DEFAULT_CONTEXT_FILENAME;
 

--- a/packages/core/src/utils/bfsFileSearch.test.ts
+++ b/packages/core/src/utils/bfsFileSearch.test.ts
@@ -202,8 +202,8 @@ describe('bfsFileSearch', () => {
       await createEmptyDir(`dir${i}`, 'subdir1', 'deep');
       if (i < 10) {
         // Add target files in some directories
-        await createTestFile('content', `dir${i}`, 'GEMINI.md');
-        await createTestFile('content', `dir${i}`, 'subdir1', 'GEMINI.md');
+        await createTestFile('content', `dir${i}`, 'QWEN.md');
+        await createTestFile('content', `dir${i}`, 'subdir1', 'QWEN.md');
       }
     }
 
@@ -216,7 +216,7 @@ describe('bfsFileSearch', () => {
     for (let i = 0; i < iterations; i++) {
       const searchStartTime = performance.now();
       const result = await bfsFileSearch(testRootDir, {
-        fileName: 'GEMINI.md',
+        fileName: 'QWEN.md',
         maxDirs: 200,
         debug: false,
       });
@@ -242,7 +242,7 @@ describe('bfsFileSearch', () => {
     console.log(
       `📊 Min/Max Duration: ${minDuration.toFixed(2)}ms / ${maxDuration.toFixed(2)}ms`,
     );
-    console.log(`📁 Found ${foundFiles} GEMINI.md files`);
+    console.log(`📁 Found ${foundFiles} QWEN.md files`);
     console.log(
       `🏎️  Processing ~${Math.round(200 / (avgDuration / 1000))} dirs/second`,
     );

--- a/packages/core/src/utils/memoryDiscovery.test.ts
+++ b/packages/core/src/utils/memoryDiscovery.test.ts
@@ -365,7 +365,7 @@ My code memory
 
   it('should load extension context file paths', async () => {
     const extensionFilePath = await createTestFile(
-      path.join(testRootDir, 'extensions/ext1/GEMINI.md'),
+      path.join(testRootDir, 'extensions/ext1/QWEN.md'),
       'Extension memory content',
     );
 

--- a/packages/core/src/utils/memoryDiscovery.ts
+++ b/packages/core/src/utils/memoryDiscovery.ts
@@ -252,7 +252,7 @@ function concatenateInstructions(
 }
 
 /**
- * Loads hierarchical GEMINI.md files and concatenates their content.
+ * Loads hierarchical QWEN.md files and concatenates their content.
  * This function is intended for use by the server.
  */
 export async function loadServerHierarchicalMemory(
@@ -282,7 +282,7 @@ export async function loadServerHierarchicalMemory(
     maxDirs,
   );
   if (filePaths.length === 0) {
-    if (debugMode) logger.debug('No GEMINI.md files found in hierarchy.');
+    if (debugMode) logger.debug('No QWEN.md files found in hierarchy.');
     return { memoryContent: '', fileCount: 0 };
   }
   const contentsWithPaths = await readGeminiMdFiles(

--- a/packages/core/src/utils/memoryImportProcessor.ts
+++ b/packages/core/src/utils/memoryImportProcessor.ts
@@ -191,7 +191,7 @@ function findCodeRegions(content: string): Array<[number, number]> {
 }
 
 /**
- * Processes import statements in GEMINI.md content
+ * Processes import statements in QWEN.md content
  * Supports @path/to/file syntax for importing content from other files
  * @param content - The content to process for imports
  * @param basePath - The directory path where the current file is located


### PR DESCRIPTION
## TLDR

Hello, you have used QWEN.md as the memory file in README and initial prompts, but it is still GEMINI.md in the code. I have made the modification.

## Dive Deeper

## Reviewer Test Plan

## Testing Matrix

all tests passed

## Linked issues / bugs
