### PR TITLE
fix: rename make run-npx from gemini to qwen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ debug:
 
 
 run-npx:
-	npx https://github.com/google-gemini/gemini-cli
+	npx https://github.com/QwenLM/qwen-code
 
 create-alias:
 	scripts/create_alias.sh


### PR DESCRIPTION
## TLDR

Change command `make run-npx` repository url from gemini to qwen

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
