### PR TITLE
fix: terminal flicker when waiting for login

### DIFF
--- a/packages/cli/src/ui/components/QwenOAuthProgress.tsx
+++ b/packages/cli/src/ui/components/QwenOAuthProgress.tsx
@@ -17,18 +17,24 @@ interface QwenOAuthProgressProps {
   onCancel: () => void;
   deviceAuth?: DeviceAuthorizationInfo;
   authStatus?:
-  | 'idle'
-  | 'polling'
-  | 'success'
-  | 'error'
-  | 'timeout'
-  | 'rate_limit';
+    | 'idle'
+    | 'polling'
+    | 'success'
+    | 'error'
+    | 'timeout'
+    | 'rate_limit';
   authMessage?: string | null;
 }
 
 interface StaticItem {
   key: string;
-  type: 'title' | 'instructions' | 'url' | 'qr-instructions' | 'qr-code' | 'auth-content';
+  type:
+    | 'title'
+    | 'instructions'
+    | 'url'
+    | 'qr-instructions'
+    | 'qr-code'
+    | 'auth-content';
   url?: string;
   qrCode?: string;
 }
@@ -172,11 +178,19 @@ export function QwenOAuthProgress({
   return (
     <>
       {qrCodeData && (
-        <Static items={[
-          { key: 'auth-content', type: 'auth-content' as const, url: deviceAuth.verification_uri_complete, qrCode: qrCodeData }
-        ] as StaticItem[]}
+        <Static
+          items={
+            [
+              {
+                key: 'auth-content',
+                type: 'auth-content' as const,
+                url: deviceAuth.verification_uri_complete,
+                qrCode: qrCodeData,
+              },
+            ] as StaticItem[]
+          }
           style={{
-            width: "100%"
+            width: '100%',
           }}
         >
           {(item: StaticItem) => (
@@ -220,7 +234,6 @@ export function QwenOAuthProgress({
         padding={1}
         width="100%"
       >
-
         <Box marginTop={1}>
           <Text>
             <Spinner type="dots" /> Waiting for authorization{dots}


### PR DESCRIPTION
## TLDR

Use `<Static />` to render QRCode for easy scanning.


## Dive Deeper

- [`<Static />`](https://github.com/vadimdemedes/ink?tab=readme-ov-file#static)

Be aware:  **`<Static />` cannot handle terminal dimension changes, thus the QR code disappears whenever we resize the terminal.**

This depends on https://github.com/vadimdemedes/ink/pull/708 and for now we have to accept that if you resize terminal the QR code will disappear.

## TODO

~~- [x] Terminal dimension aware~~

## Reviewer Test Plan

Stay on Qwen OAuth process and observe the terminal flicker.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ✅  | ❓  |
| npx      | ✅  | ✅  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

#245 #278 