### PR TITLE
fix: openaiContentGenerator

### DIFF
--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -5,6 +5,7 @@
  */
 
 export const DEFAULT_QWEN_MODEL = 'qwen3-coder-plus';
+// We do not have a fallback model for now, but note it here anyway.
 export const DEFAULT_QWEN_FLASH_MODEL = 'qwen3-coder-flash';
 
 export const DEFAULT_GEMINI_MODEL = 'qwen3-coder-plus';

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+export const DEFAULT_QWEN_MODEL = 'qwen3-coder-plus';
+export const DEFAULT_QWEN_FLASH_MODEL = 'qwen3-coder-flash';
+
 export const DEFAULT_GEMINI_MODEL = 'qwen3-coder-plus';
 export const DEFAULT_GEMINI_FLASH_MODEL = 'gemini-2.5-flash';
 export const DEFAULT_GEMINI_FLASH_LITE_MODEL = 'gemini-2.5-flash-lite';

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -14,7 +14,7 @@ import {
   GoogleGenAI,
 } from '@google/genai';
 import { createCodeAssistContentGenerator } from '../code_assist/codeAssist.js';
-import { DEFAULT_GEMINI_MODEL } from '../config/models.js';
+import { DEFAULT_GEMINI_MODEL, DEFAULT_QWEN_MODEL } from '../config/models.js';
 import { Config } from '../config/config.js';
 import { getEffectiveModel } from './modelCheck.js';
 import { UserTierId } from '../code_assist/types.js';
@@ -136,7 +136,9 @@ export function createContentGeneratorConfig(
     // For Qwen OAuth, we'll handle the API key dynamically in createContentGenerator
     // Set a special marker to indicate this is Qwen OAuth
     contentGeneratorConfig.apiKey = 'QWEN_OAUTH_DYNAMIC_TOKEN';
-    contentGeneratorConfig.model = config.getModel() || DEFAULT_GEMINI_MODEL;
+
+    // Prefer to use qwen3-coder-plus as the default Qwen model if QWEN_MODEL is not set.
+    contentGeneratorConfig.model = process.env.QWEN_MODEL || DEFAULT_QWEN_MODEL;
 
     return contentGeneratorConfig;
   }


### PR DESCRIPTION
## TLDR

Include `metadata` only for qwen models/endpoints.

## Dive Deeper

- remove `metadata` when using unspported models/providers
- use `qwen3-code-plus` as default, fix picking wrong model when refresh auth

## Reviewer Test Plan


## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #260 #255 #243 
