### PR TITLE
feat: add a link to Gemini CLI Desktop for Qwen Code users who prefer desktop UIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 Qwen Code is a powerful command-line AI workflow tool adapted from [**Gemini CLI**](https://github.com/google-gemini/gemini-cli) ([details](./README.gemini.md)), specifically optimized for [Qwen3-Coder](https://github.com/QwenLM/Qwen3-Coder) models. It enhances your development workflow with advanced code understanding, automated tasks, and intelligent assistance.
 
 > [!NOTE]
-> 🖥️ There is also a powerful **desktop/web/mobile** UI for Qwen Code/Gemini CLI called [**Gemini Desktop**](https://github.com/Piebald-AI/gemini-desktop).
+> 🖥️ There is also a powerful **desktop/web/mobile** UI for Qwen Code/Gemini CLI called [**Gemini CLI Desktop**](https://github.com/Piebald-AI/gemini-cli-desktop).
 
 ## 💡 Free Options Available
 


### PR DESCRIPTION
We've developed a desktop/web UI for Qwen Code and other Gemini CLI-based tools called Gemini CLI Desktop.  I'm adding a link to it to Qwen Code's README to provide Qwen Code to a larger audience&mdash;users who prefer desktop UIs and users who need to access Qwen Code remotely with a web-based UI.

<img width="2660" height="1682" alt="Screenshot From 2025-10-23 14-18-49" src="https://github.com/user-attachments/assets/c878bcf1-a54f-4563-9a10-281299447b41" />
