### PR TITLE
chore: adjust workflow to run PR review

### DIFF
--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -1,7 +1,7 @@
 name: 🧐 Qwen Pull Request Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
   pull_request_review_comment:
     types: [created]


### PR DESCRIPTION
## TLDR

Allow PR code review action run in current repo.

## Dive Deeper

Set workflow `Qwen Pull Request Review` run on `pull_request_target`.

## Reviewer Test Plan

No function code modified.

## Testing Matrix

No function code modified.

## Linked issues / bugs

None
