### PR TITLE
fix: custom API's trailing space and empty tool id issues

### DIFF
--- a/packages/core/src/core/openaiContentGenerator.ts
+++ b/packages/core/src/core/openaiContentGenerator.ts
@@ -351,6 +351,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
         );
       }
 
+
       // console.log('createParams', createParams);
 
       const stream = (await this.client.chat.completions.create(
@@ -587,7 +588,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
 
     // Add combined text if any
     if (combinedText) {
-      combinedParts.push({ text: combinedText });
+      combinedParts.push({ text: combinedText.trimEnd() });
     }
 
     // Add function calls
@@ -1161,7 +1162,11 @@ export class OpenAIContentGenerator implements ContentGenerator {
 
     // Handle text content
     if (choice.message.content) {
-      parts.push({ text: choice.message.content });
+      if (typeof choice.message.content === 'string') {
+        parts.push({ text: choice.message.content.trimEnd() });
+      } else {
+        parts.push({ text: choice.message.content });
+      }
     }
 
     // Handle tool calls
@@ -1251,7 +1256,11 @@ export class OpenAIContentGenerator implements ContentGenerator {
 
       // Handle text content
       if (choice.delta?.content) {
-        parts.push({ text: choice.delta.content });
+        if (typeof choice.delta.content === 'string') {
+          parts.push({ text: choice.delta.content.trimEnd() });
+        } else {
+          parts.push({ text: choice.delta.content });
+        }
       }
 
       // Handle tool calls - only accumulate during streaming, emit when complete
@@ -1299,7 +1308,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
 
             parts.push({
               functionCall: {
-                id: accumulatedCall.id,
+                id: accumulatedCall.id || `call_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`,
                 name: accumulatedCall.name,
                 args,
               },
@@ -1775,7 +1784,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
         }
       }
 
-      messageContent = textParts.join('');
+      messageContent = textParts.join('').trimEnd();
     }
 
     const choice: OpenAIChoice = {


### PR DESCRIPTION
- Generate random tool call id when serving API does not have one
- Remove trailing space in text block.