### PR TITLE
fix: seperate static QR code and dynamic spin components

### DIFF
--- a/packages/cli/src/ui/components/QwenOAuthProgress.tsx
+++ b/packages/cli/src/ui/components/QwenOAuthProgress.tsx
@@ -17,12 +17,12 @@ interface QwenOAuthProgressProps {
   onCancel: () => void;
   deviceAuth?: DeviceAuthorizationInfo;
   authStatus?:
-  | 'idle'
-  | 'polling'
-  | 'success'
-  | 'error'
-  | 'timeout'
-  | 'rate_limit';
+    | 'idle'
+    | 'polling'
+    | 'success'
+    | 'error'
+    | 'timeout'
+    | 'rate_limit';
   authMessage?: string | null;
 }
 


### PR DESCRIPTION
## TLDR

Separate static and dynamic contents in `QwenOAuthProgress` to prevent potential memory leak when using `<Static />`.

**NOTE: Due to a known issue: https://github.com/vadimdemedes/ink/issues/359, you should always keep your terminal higher than the QR code at least to avoid terminal flickering.**

Windows PowerShell 的中文用户可能需要调整字体，或使用`chcp 437`使二维码能正常显示以获得更好的体验。

## Dive Deeper

Using `<Static />` may not be appropriate for displaying a QR code in the previous release, since the target of the component is to render static content. Either the authentication passed or was cancelled, the code should be erased.

## Reviewer Test Plan

1. Normal auth process on Windows: no flicker;
2. Cancel at will, no memory leak crash expected.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ✅  | ❓  |
| npx      | ✅  | ✅  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues/bugs

- Fixes #245
- Fixes #295
- Fixes #278 
