### PR TITLE
fix: OpenAI tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7493,6 +7493,15 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonrepair": {
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/jsonrepair/-/jsonrepair-3.13.0.tgz",
+      "integrity": "sha512-5YRzlAQ7tuzV1nAJu3LvDlrKtBFIALHN2+a+I1MGJCt3ldRDBF/bZuvIPzae8Epot6KBXd0awRZZcuoeAsZ/mw==",
+      "license": "ISC",
+      "bin": {
+        "jsonrepair": "bin/cli.js"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -11914,6 +11923,7 @@
         "html-to-text": "^9.0.5",
         "https-proxy-agent": "^7.0.6",
         "ignore": "^7.0.0",
+        "jsonrepair": "^3.13.0",
         "marked": "^15.0.12",
         "micromatch": "^4.0.8",
         "open": "^10.1.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,6 +38,7 @@
     "html-to-text": "^9.0.5",
     "https-proxy-agent": "^7.0.6",
     "ignore": "^7.0.0",
+    "jsonrepair": "^3.13.0",
     "marked": "^15.0.12",
     "micromatch": "^4.0.8",
     "open": "^10.1.2",

--- a/packages/core/src/utils/safeJsonParse.test.ts
+++ b/packages/core/src/utils/safeJsonParse.test.ts
@@ -1,0 +1,149 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { safeJsonParse } from './safeJsonParse.js';
+
+describe('safeJsonParse', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('valid JSON parsing', () => {
+    it('should parse valid JSON correctly', () => {
+      const validJson = '{"name": "test", "value": 123}';
+      const result = safeJsonParse(validJson);
+
+      expect(result).toEqual({ name: 'test', value: 123 });
+    });
+
+    it('should parse valid JSON arrays', () => {
+      const validArray = '["item1", "item2", "item3"]';
+      const result = safeJsonParse(validArray);
+
+      expect(result).toEqual(['item1', 'item2', 'item3']);
+    });
+
+    it('should parse valid JSON with nested objects', () => {
+      const validNested =
+        '{"config": {"paths": ["testlogs/*.py"], "options": {"recursive": true}}}';
+      const result = safeJsonParse(validNested);
+
+      expect(result).toEqual({
+        config: {
+          paths: ['testlogs/*.py'],
+          options: { recursive: true },
+        },
+      });
+    });
+  });
+
+  describe('malformed JSON with jsonrepair fallback', () => {
+    it('should handle malformed JSON with single quotes', () => {
+      const malformedJson = "{'name': 'test', 'value': 123}";
+      const result = safeJsonParse(malformedJson);
+
+      expect(result).toEqual({ name: 'test', value: 123 });
+    });
+
+    it('should handle malformed JSON with unquoted keys', () => {
+      const malformedJson = '{name: "test", value: 123}';
+      const result = safeJsonParse(malformedJson);
+
+      expect(result).toEqual({ name: 'test', value: 123 });
+    });
+
+    it('should handle malformed JSON with trailing commas', () => {
+      const malformedJson = '{"name": "test", "value": 123,}';
+      const result = safeJsonParse(malformedJson);
+
+      expect(result).toEqual({ name: 'test', value: 123 });
+    });
+
+    it('should handle malformed JSON with comments', () => {
+      const malformedJson = '{"name": "test", // comment\n "value": 123}';
+      const result = safeJsonParse(malformedJson);
+
+      expect(result).toEqual({ name: 'test', value: 123 });
+    });
+  });
+
+  describe('fallback behavior', () => {
+    it('should return fallback value for empty string', () => {
+      const emptyString = '';
+      const fallback = { default: 'value' };
+
+      const result = safeJsonParse(emptyString, fallback);
+
+      expect(result).toEqual(fallback);
+    });
+
+    it('should return fallback value for null input', () => {
+      const nullInput = null as unknown as string;
+      const fallback = { default: 'value' };
+
+      const result = safeJsonParse(nullInput, fallback);
+
+      expect(result).toEqual(fallback);
+    });
+
+    it('should return fallback value for undefined input', () => {
+      const undefinedInput = undefined as unknown as string;
+      const fallback = { default: 'value' };
+
+      const result = safeJsonParse(undefinedInput, fallback);
+
+      expect(result).toEqual(fallback);
+    });
+
+    it('should return empty object as default fallback', () => {
+      const invalidJson = 'invalid json';
+
+      const result = safeJsonParse(invalidJson);
+
+      // jsonrepair returns the original string for completely invalid JSON
+      expect(result).toEqual('invalid json');
+    });
+
+    it('should return custom fallback when parsing fails', () => {
+      const invalidJson = 'invalid json';
+      const customFallback = { error: 'parsing failed', data: null };
+
+      const result = safeJsonParse(invalidJson, customFallback);
+
+      // jsonrepair returns the original string for completely invalid JSON
+      expect(result).toEqual('invalid json');
+    });
+  });
+
+  describe('type safety', () => {
+    it('should preserve generic type when parsing valid JSON', () => {
+      const validJson = '{"name": "test", "value": 123}';
+      const result = safeJsonParse<{ name: string; value: number }>(validJson);
+
+      expect(result).toEqual({ name: 'test', value: 123 });
+      // TypeScript should infer the correct type
+      expect(typeof result.name).toBe('string');
+      expect(typeof result.value).toBe('number');
+    });
+
+    it('should return fallback type when parsing fails', () => {
+      const invalidJson = 'invalid json';
+      const fallback = { error: 'fallback' } as const;
+
+      const result = safeJsonParse(invalidJson, fallback);
+
+      // jsonrepair returns the original string for completely invalid JSON
+      expect(result).toEqual('invalid json');
+      // TypeScript should preserve the fallback type
+      expect(typeof result).toBe('string');
+    });
+  });
+});

--- a/packages/core/src/utils/safeJsonParse.ts
+++ b/packages/core/src/utils/safeJsonParse.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { jsonrepair } from 'jsonrepair';
+
+/**
+ * Safely parse JSON string with jsonrepair fallback for malformed JSON.
+ * This function attempts to parse JSON normally first, and if that fails,
+ * it uses jsonrepair to fix common JSON formatting issues before parsing.
+ *
+ * @param jsonString - The JSON string to parse
+ * @param fallbackValue - The value to return if parsing fails completely
+ * @returns The parsed object or the fallback value
+ */
+export function safeJsonParse<T = Record<string, unknown>>(
+  jsonString: string,
+  fallbackValue: T = {} as T,
+): T {
+  if (!jsonString || typeof jsonString !== 'string') {
+    return fallbackValue;
+  }
+
+  try {
+    // First attempt: try normal JSON.parse
+    return JSON.parse(jsonString) as T;
+  } catch (error) {
+    try {
+      // Second attempt: use jsonrepair to fix common JSON issues
+      const repairedJson = jsonrepair(jsonString);
+
+      // jsonrepair always returns a string, so we need to parse it
+      return JSON.parse(repairedJson) as T;
+    } catch (repairError) {
+      console.error('Failed to parse JSON even with jsonrepair:', {
+        originalError: error,
+        repairError,
+        jsonString,
+      });
+      return fallbackValue;
+    }
+  }
+}


### PR DESCRIPTION
## TLDR

Fixes:
- The MCP tool params schema is lost, causing almost all MCPs not to work well
- Compatible with occasional tool call parameters returned by LLM that are invalid JSON

## Dive Deeper

1. Current tool converter `convertGeminiToolsToOpenAI` does not handle the MCP tools definition correctly, thus no parameter schema is sent to LLM, causing most of the MCPs not to work. Did a little adjustment to maintain compatibility.
2. Parameters are supposed to be returned from LLMs as multiple segments of one valid JSON string, while the reality is not always like this. Sometimes we may get a string like: `{"paths": ['testlogs/*.py', 'testlogs/*/*.py']}`, causing the common error recently: ` Failed to parse final tool call arguments: SyntaxError: Unexpected token ''', ...""paths": ... is not valid JSON`

This PR should fix most of the exceptions above.

NOTE: Too many MCP servers/tools may not get a proper return from the model.

## Reviewer Test Plan

1. Add a minimum MCP server and check if the tool can be called with correct parameters.
2. Try to use the built-in `ReadFile`, `FindFile`, or other tools to confirm that they get valid parameters.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues/bugs

- Fixes #324
- Fixes #321 
- Fixes #306 
- Fixes #237 

- Related to #301
- Related to #288
- Related to #250
