### PR TITLE
feat(openaiContentGenerator): Avoid quantized models on OpenRouter

### DIFF
--- a/packages/core/src/core/openaiContentGenerator.ts
+++ b/packages/core/src/core/openaiContentGenerator.ts
@@ -82,6 +82,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
   protected client: OpenAI;
   private model: string;
   private config: Config;
+  private isOpenRouter: boolean;
   private streamingToolCalls: Map<
     number,
     {
@@ -137,6 +138,8 @@ export class OpenAIContentGenerator implements ContentGenerator {
       maxRetries: timeoutConfig.maxRetries,
       defaultHeaders,
     });
+
+    this.isOpenRouter = isOpenRouter;
   }
 
   /**
@@ -246,6 +249,14 @@ export class OpenAIContentGenerator implements ContentGenerator {
         messages,
         ...samplingParams,
         ...(this.buildMetadata(userPromptId) || {}),
+        // Add quantizations parameter for OpenRouter to avoid quantized models
+        ...(this.isOpenRouter
+          ? {
+              provider: {
+                quantizations: ['fp8', 'fp16', 'bf16'],
+              },
+            }
+          : {}),
       };
 
       if (request.config?.tools) {
@@ -358,6 +369,14 @@ export class OpenAIContentGenerator implements ContentGenerator {
         stream: true,
         stream_options: { include_usage: true },
         ...(this.buildMetadata(userPromptId) || {}),
+        // Add quantizations parameter for OpenRouter to avoid quantized models
+        ...(this.isOpenRouter
+          ? {
+              provider: {
+                quantizations: ['fp8', 'fp16', 'bf16'],
+              },
+            }
+          : {}),
       };
 
       if (request.config?.tools) {


### PR DESCRIPTION
## TLDR

By default OpenRouter can route your request to providers that serve quantized versions of the model [1], which can result in substantially worse output for coding.

This patch is an attempt at avoiding getting quantized models by setting the `provider.quantizations` parameter to full precision (fp8 or better) when using OpenRouter.

[1] https://openrouter.ai/docs/features/provider-routing#quantization

## Dive Deeper

**I'm not totally sure this is working at the moment...** I tried testing this by setting quantizations field to just `['fp4']`, but my requests aren't being routed to the `fp4` provider that I know is available for the model I was testing...

So for now this PR is more for discussion about feasibility of this approach. If the maintainers are open to this I'll keep pounding on it and will also add new tests.

## Reviewer Test Plan

- Configure qwen-code to use OpenRouter and the `qwen/qwen3-coder` model.
- Temporarily modify the `quantizations` field in this patch to be `['fp4']` and start qwen-code.
- Make some requests and verify in your OpenRouter activity dashboard that your requests are being routed to a provider serving the fp4 version of the model (_DeepInfra (Turbo)_ is serving an fp4 version at the moment).

<img width="2607" height="1646" alt="image" src="https://github.com/user-attachments/assets/791d9687-6b5c-4c87-b79a-e5671fcf8941" />


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
