### PR TITLE
fix(core): resolve Issue #319 - path handling for multi-directory workspace access

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
         "packages/*"
       ],
       "dependencies": {
-        "node-fetch": "^3.3.2",
-        "fzf": "^0.5.2"
+        "fzf": "^0.5.2",
+        "node-fetch": "^3.3.2"
       },
       "bin": {
         "qwen": "bundle/gemini.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "packages/*"
       ],
       "dependencies": {
-        "node-fetch": "^3.3.2"
+        "node-fetch": "^3.3.2",
+        "fzf": "^0.5.2"
       },
       "bin": {
         "qwen": "bundle/gemini.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
         "packages/*"
       ],
       "dependencies": {
-        "fzf": "^0.5.2",
-        "node-fetch": "^3.3.2"
+        "node-fetch": "^3.3.2",
+        "fzf": "^0.5.2"
       },
       "bin": {
         "qwen": "bundle/gemini.js"

--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
     "yargs": "^17.7.2"
   },
   "dependencies": {
-    "node-fetch": "^3.3.2"
+
+    "node-fetch": "^3.3.2",
+    "fzf": "^0.5.2"
   }
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -688,7 +688,14 @@ export class Config {
 
   getFileService(): FileDiscoveryService {
     if (!this.fileDiscoveryService) {
-      this.fileDiscoveryService = new FileDiscoveryService(this.targetDir);
+      // Use the primary workspace directory for FileDiscoveryService
+      // This ensures compatibility with existing ignore file patterns
+      const workspaceDirectories = this.workspaceContext.getDirectories();
+      const primaryDirectory =
+        workspaceDirectories.length > 0
+          ? workspaceDirectories[0]
+          : this.targetDir;
+      this.fileDiscoveryService = new FileDiscoveryService(primaryDirectory);
     }
     return this.fileDiscoveryService;
   }

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -13,7 +13,6 @@ import {
   GenerateContentResponse,
   FunctionDeclaration,
   Schema,
-  Part,
 } from '@google/genai';
 import {
   getDirectoryContextString,
@@ -49,7 +48,6 @@ import { ideContext } from '../ide/ideContext.js';
 import { logNextSpeakerCheck } from '../telemetry/loggers.js';
 import { NextSpeakerCheckEvent } from '../telemetry/types.js';
 import { IdeContext, File } from '../ide/ideContext.js';
-import { getFolderStructure } from '../utils/getFolderStructure.js';
 
 function isThinkingSupported(model: string) {
   if (model.startsWith('gemini-2.5')) return true;
@@ -215,100 +213,6 @@ export class GeminiClient {
     });
   }
 
-  private async getDirectoryContext(): Promise<string> {
-    const workspaceContext = this.config.getWorkspaceContext();
-    const workspaceDirectories = workspaceContext.getDirectories();
-
-    const folderStructures = await Promise.allSettled(
-      workspaceDirectories.map(async (dir) => {
-        try {
-          return await getFolderStructure(dir, {
-            fileService: this.config.getFileService(),
-          });
-        } catch (error) {
-          console.warn(
-            `Warning: Could not get folder structure for ${dir}:`,
-            error,
-          );
-          return `Error reading directory: ${dir} - ${error instanceof Error ? error.message : String(error)}`;
-        }
-      }),
-    );
-
-    const folderStructure = folderStructures
-      .map((result) =>
-        result.status === 'fulfilled' ? result.value : result.reason,
-      )
-      .join('\n');
-    const dirList = workspaceDirectories.map((dir) => `  - ${dir}`).join('\n');
-    const workingDirPreamble = `I'm currently working in the following directories:\n${dirList}\n Folder structures are as follows:\n${folderStructure}`;
-    return workingDirPreamble;
-  }
-
-  private async getEnvironment(): Promise<Part[]> {
-    const today = new Date().toLocaleDateString(undefined, {
-      weekday: 'long',
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    });
-    const platform = process.platform;
-
-    const workspaceContext = this.config.getWorkspaceContext();
-    const workspaceDirectories = workspaceContext.getDirectories();
-
-    const folderStructures = await Promise.allSettled(
-      workspaceDirectories.map(async (dir) => {
-        try {
-          return await getFolderStructure(dir, {
-            fileService: this.config.getFileService(),
-          });
-        } catch (error) {
-          console.warn(
-            `Warning: Could not get folder structure for ${dir}:`,
-            error,
-          );
-          return `Error reading directory: ${dir} - ${error instanceof Error ? error.message : String(error)}`;
-        }
-      }),
-    );
-
-    const folderStructure = folderStructures
-      .map((result) =>
-        result.status === 'fulfilled' ? result.value : result.reason,
-      )
-      .join('\n');
-
-    let workingDirPreamble: string;
-    if (workspaceDirectories.length === 1) {
-      workingDirPreamble = `I'm currently working in the directory: ${workspaceDirectories[0]}`;
-    } else {
-      const dirList = workspaceDirectories
-        .map((dir) => `  - ${dir}`)
-        .join('\n');
-      workingDirPreamble = `I'm currently working in the following directories:\n${dirList}`;
-    }
-
-    const context = `
-  This is the Qwen Code. We are setting up the context for our chat.
-  Today's date is ${today}.
-  My operating system is: ${platform}
-  ${workingDirPreamble}
-  Here is the folder structure of the current working directories:\n
-  ${folderStructure}
-          `.trim();
-
-    const initialParts: Part[] = [{ text: context }];
-
-    // Add full file context if the flag is set
-    if (this.config.getFullContext()) {
-      console.warn(
-        'Full context requested, but this feature is not available in this context.',
-      );
-    }
-
-    return initialParts;
-  }
 
   async startChat(extraHistory?: Content[]): Promise<GeminiChat> {
     this.forceFullIdeContext = true;

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -226,14 +226,19 @@ export class GeminiClient {
             fileService: this.config.getFileService(),
           });
         } catch (error) {
-          console.warn(`Warning: Could not get folder structure for ${dir}:`, error);
+          console.warn(
+            `Warning: Could not get folder structure for ${dir}:`,
+            error,
+          );
           return `Error reading directory: ${dir} - ${error instanceof Error ? error.message : String(error)}`;
         }
       }),
     );
 
     const folderStructure = folderStructures
-      .map((result) => result.status === 'fulfilled' ? result.value : result.reason)
+      .map((result) =>
+        result.status === 'fulfilled' ? result.value : result.reason,
+      )
       .join('\n');
     const dirList = workspaceDirectories.map((dir) => `  - ${dir}`).join('\n');
     const workingDirPreamble = `I'm currently working in the following directories:\n${dirList}\n Folder structures are as follows:\n${folderStructure}`;
@@ -259,14 +264,19 @@ export class GeminiClient {
             fileService: this.config.getFileService(),
           });
         } catch (error) {
-          console.warn(`Warning: Could not get folder structure for ${dir}:`, error);
+          console.warn(
+            `Warning: Could not get folder structure for ${dir}:`,
+            error,
+          );
           return `Error reading directory: ${dir} - ${error instanceof Error ? error.message : String(error)}`;
         }
       }),
     );
 
     const folderStructure = folderStructures
-      .map((result) => result.status === 'fulfilled' ? result.value : result.reason)
+      .map((result) =>
+        result.status === 'fulfilled' ? result.value : result.reason,
+      )
       .join('\n');
 
     let workingDirPreamble: string;

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -207,7 +207,11 @@ class LSToolInvocation extends BaseToolInvocation<LSToolParams, ToolResult> {
         }
 
         // Check if this file should be ignored based on git or gemini ignore rules
+        // Only apply ignore rules if the file is within the main project directory
+        const isInMainProject = fullPath.startsWith(this.config.getTargetDir());
+        
         if (
+          isInMainProject &&
           fileFilteringOptions.respectGitIgnore &&
           fileDiscovery.shouldGitIgnoreFile(relativePath)
         ) {
@@ -215,6 +219,7 @@ class LSToolInvocation extends BaseToolInvocation<LSToolParams, ToolResult> {
           continue;
         }
         if (
+          isInMainProject &&
           fileFilteringOptions.respectGeminiIgnore &&
           fileDiscovery.shouldGeminiIgnoreFile(relativePath)
         ) {

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -283,7 +283,7 @@ export class LSTool extends BaseTool<LSToolParams, ToolResult> {
         // Check if this file should be ignored based on git or gemini ignore rules
         // Only apply ignore rules if the file is within the main project directory
         const isInMainProject = fullPath.startsWith(this.config.getTargetDir());
-        
+
         if (
           isInMainProject &&
           fileFilteringOptions.respectGitIgnore &&

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -186,6 +186,26 @@ class LSToolInvocation extends BaseToolInvocation<LSToolParams, ToolResult> {
           fullPath,
         );
 
+        const fullPath = path.join(params.path, file);
+
+        // Find the appropriate workspace directory for calculating relative path
+        const workspaceContext = this.config.getWorkspaceContext();
+        const workspaceDirectories = workspaceContext.getDirectories();
+
+        let relativePath = fullPath;
+        // Find which workspace directory contains this file
+        for (const workspaceDir of workspaceDirectories) {
+          if (fullPath.startsWith(workspaceDir)) {
+            relativePath = path.relative(workspaceDir, fullPath);
+            break;
+          }
+        }
+
+        // If no workspace directory contains this file, fall back to target dir
+        if (relativePath === fullPath) {
+          relativePath = path.relative(this.config.getTargetDir(), fullPath);
+        }
+
         // Check if this file should be ignored based on git or gemini ignore rules
         if (
           fileFilteringOptions.respectGitIgnore &&

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -76,80 +76,6 @@ class LSToolInvocation extends BaseToolInvocation<LSToolParams, ToolResult> {
     params: LSToolParams,
   ) {
     super(params);
-/**
- * Implementation of the LS tool logic
- */
-export class LSTool extends BaseTool<LSToolParams, ToolResult> {
-  static readonly Name = 'list_directory';
-
-  constructor(private config: Config) {
-    super(
-      LSTool.Name,
-      'ReadFolder',
-      'Lists the names of files and subdirectories directly within a specified directory path. Can optionally ignore entries matching provided glob patterns.',
-      Icon.Folder,
-      {
-        properties: {
-          path: {
-            description:
-              'The absolute path to the directory to list (must be absolute, not relative)',
-            type: 'string',
-          },
-          ignore: {
-            description: 'List of glob patterns to ignore',
-            items: {
-              type: 'string',
-            },
-            type: 'array',
-          },
-          file_filtering_options: {
-            description:
-              'Optional: Whether to respect ignore patterns from .gitignore or .geminiignore',
-            type: 'object',
-            properties: {
-              respect_git_ignore: {
-                description:
-                  'Optional: Whether to respect .gitignore patterns when listing files. Only available in git repositories. Defaults to true.',
-                type: 'boolean',
-              },
-              respect_gemini_ignore: {
-                description:
-                  'Optional: Whether to respect .geminiignore patterns when listing files. Defaults to true.',
-                type: 'boolean',
-              },
-            },
-          },
-        },
-        required: ['path'],
-        type: 'object',
-      },
-    );
-  }
-
-  /**
-   * Validates the parameters for the tool
-   * @param params Parameters to validate
-   * @returns An error message string if invalid, null otherwise
-   */
-  validateToolParams(params: LSToolParams): string | null {
-    const errors = SchemaValidator.validate(
-      this.schema.parametersJsonSchema,
-      params,
-    );
-    if (errors) {
-      return errors;
-    }
-    if (!path.isAbsolute(params.path)) {
-      return `Path must be absolute: ${params.path}`;
-    }
-
-    const workspaceContext = this.config.getWorkspaceContext();
-    if (!workspaceContext.isPathWithinWorkspace(params.path)) {
-      const directories = workspaceContext.getDirectories();
-      return `Directory access restricted. I can only access files within the configured workspace directories: ${directories.join(', ')}. The requested path "${params.path}" is outside these allowed directories.`;
-    }
-    return null;
-    
   }
 
   /**
@@ -234,7 +160,6 @@ export class LSTool extends BaseTool<LSToolParams, ToolResult> {
       };
 
       // Get centralized file discovery service
-
       const fileDiscovery = this.config.getFileService();
 
       const entries: FileEntry[] = [];
@@ -255,12 +180,6 @@ export class LSTool extends BaseTool<LSToolParams, ToolResult> {
         }
 
         const fullPath = path.join(this.params.path, file);
-        const relativePath = path.relative(
-          this.config.getTargetDir(),
-          fullPath,
-        );
-
-        const fullPath = path.join(params.path, file);
 
         // Find the appropriate workspace directory for calculating relative path
         const workspaceContext = this.config.getWorkspaceContext();

--- a/packages/core/src/utils/getFolderStructure.ts
+++ b/packages/core/src/utils/getFolderStructure.ts
@@ -129,13 +129,18 @@ async function readFullStructure(
         const fileName = entry.name;
         const filePath = path.join(currentPath, fileName);
         if (options.fileService) {
-          const shouldIgnore =
-            (options.fileFilteringOptions.respectGitIgnore &&
-              options.fileService.shouldGitIgnoreFile(filePath)) ||
-            (options.fileFilteringOptions.respectGeminiIgnore &&
-              options.fileService.shouldGeminiIgnoreFile(filePath));
-          if (shouldIgnore) {
-            continue;
+          try {
+            const shouldIgnore =
+              (options.fileFilteringOptions.respectGitIgnore &&
+                options.fileService.shouldGitIgnoreFile(filePath)) ||
+              (options.fileFilteringOptions.respectGeminiIgnore &&
+                options.fileService.shouldGeminiIgnoreFile(filePath));
+            if (shouldIgnore) {
+              continue;
+            }
+          } catch (error) {
+            // If ignore file checking fails, just continue processing the file
+            console.warn(`Warning: Could not check ignore status for file ${filePath}:`, error);
           }
         }
         if (
@@ -169,11 +174,17 @@ async function readFullStructure(
 
         let isIgnored = false;
         if (options.fileService) {
-          isIgnored =
-            (options.fileFilteringOptions.respectGitIgnore &&
-              options.fileService.shouldGitIgnoreFile(subFolderPath)) ||
-            (options.fileFilteringOptions.respectGeminiIgnore &&
-              options.fileService.shouldGeminiIgnoreFile(subFolderPath));
+          try {
+            isIgnored =
+              (options.fileFilteringOptions.respectGitIgnore &&
+                options.fileService.shouldGitIgnoreFile(subFolderPath)) ||
+              (options.fileFilteringOptions.respectGeminiIgnore &&
+                options.fileService.shouldGeminiIgnoreFile(subFolderPath));
+          } catch (error) {
+            // If ignore file checking fails, treat as not ignored and continue
+            console.warn(`Warning: Could not check ignore status for directory ${subFolderPath}:`, error);
+            isIgnored = false;
+          }
         }
 
         if (options.ignoredFolders.has(subFolderName) || isIgnored) {

--- a/packages/core/src/utils/getFolderStructure.ts
+++ b/packages/core/src/utils/getFolderStructure.ts
@@ -140,7 +140,10 @@ async function readFullStructure(
             }
           } catch (error) {
             // If ignore file checking fails, just continue processing the file
-            console.warn(`Warning: Could not check ignore status for file ${filePath}:`, error);
+            console.warn(
+              `Warning: Could not check ignore status for file ${filePath}:`,
+              error,
+            );
           }
         }
         if (
@@ -182,7 +185,10 @@ async function readFullStructure(
                 options.fileService.shouldGeminiIgnoreFile(subFolderPath));
           } catch (error) {
             // If ignore file checking fails, treat as not ignored and continue
-            console.warn(`Warning: Could not check ignore status for directory ${subFolderPath}:`, error);
+            console.warn(
+              `Warning: Could not check ignore status for directory ${subFolderPath}:`,
+              error,
+            );
             isIgnored = false;
           }
         }

--- a/packages/core/src/utils/workspaceContext.ts
+++ b/packages/core/src/utils/workspaceContext.ts
@@ -138,8 +138,12 @@ export class WorkspaceContext {
         }
       }
 
+      // Normalize paths for consistent comparison on Windows
+      const normalizedResolvedPath = path.normalize(resolvedPath).toLowerCase();
+
       for (const dir of this.directories) {
-        if (this.isPathWithinRoot(resolvedPath, dir)) {
+        const normalizedDir = path.normalize(dir).toLowerCase();
+        if (this.isPathWithinRoot(normalizedResolvedPath, normalizedDir)) {
           return true;
         }
       }

--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,34 @@
+# 🚀 Enhance Your Rough Prompt, Now Available in Qwen
+
+> This PR adds a new prompt enhancement feature that allows users to improve their prompts using AI assistance.
+
+## ✨ Features Added
+
+- **🤖 AI-Powered Prompt Enhancement**: Users can press `Ctrl+B` to send their current prompt to Qwen AI for improvement
+- **Seamless Integration**: Enhanced prompts automatically replace the original text in the input field  
+- **Visual Feedback**: Footer shows enhancement status ("Enhance Prompt (Ctrl+B)" when idle, "Enhancing..." during processing)
+- **Keyboard Shortcut**: `Ctrl+B` trigger that avoids conflicts with existing shortcuts
+
+## 🔧 Technical Implementation
+
+- **New Hook**: `usePromptEnhancement` for handling AI prompt improvement requests
+- **Key Binding**: Added `ENHANCE_PROMPT` command to the keyboard shortcut system  
+- **UI Integration**: Updated InputPrompt and Footer components with enhancement functionality
+- **Error Handling**: Proper loading states and error management
+
+## 🧪 Testing
+
+-  All existing tests pass (32/32)
+-  Updated UI snapshots to reflect new functionality  
+-  No regressions in existing features
+
+## 📝 How to Use
+
+1. **Type** your prompt in the input field
+2. **Press** `Ctrl+B` to enhance the prompt
+3. **Watch** the enhanced version replace your original text
+4. **Submit** the improved prompt
+
+---
+
+**💡 Summary**: This feature helps users write clearer, more effective prompts by leveraging AI assistance directly within the interface.


### PR DESCRIPTION
## TLDR

This PR resolves Issue #319 by fixing path handling issues when accessing files across multiple workspace directories. The fix prevents application crashes when users include external directories in their includeDirectories settings or add directories dynamically (via /directory add path/to/directory) and also resolves the "I couldn't fully process the contents of /path/to/directory due to path formatting issue" error, enabling robust multi-directory workspace support.

## Dive Deeper

### **Problem Analysis - The Error Scenario:**

**User Configuration in settings.json:**
```json
{
  "includeDirectories": [
    "F:/qwencode/qwen-code",
    "E:/filefolder"
  ]
}
```
Or If You Are In Window, this could be:
```json
{
  "includeDirectories": [
    "F:\\qwencode\\qwen-code",
    "E:\\filefolder"
  ]
}
```
Or Adding Directory via Command:
```
/directory add E:/filefolder
```

**User Prompt:**
```
> What's inside E:/filefolder
```

**Result - Application Crashed with Error:**
```
Error: path should be a path.relative()d string
    at async Promise.all (index 1)
    at async GeminiClient.getEnvironment
    (file:///F:/qwencode/qwen-code/packages/core/dist/src/core/client.js:152:34)
```

Or Partial Processing Error:
```
I couldn't fully process the contents of E:/filefolder due to path formatting issue
```

**Root Cause Analysis:**
1. FileDiscoveryService was only initialized with the main target directory (`F:/qwencode/qwen-code`)
2. When user asked about `E:/filefolder`, the system tried to calculate relative paths from the main directory
3. `path.relative('F:/qwencode/qwen-code', 'E:/filefolder')` generated invalid paths like `../../E:/filefolder`
4. The ignore file validation failed because it expected relative paths within the project root
5. Promise.all crashed when any directory access failed, bringing down the entire application

### **Solution Implementation:**

**Same User Configuration & Prompt - Now Working:**
```
✔ ReadFolder E:/filefolder

Listed 3 item(s).

The contents of E:/filefolder are:
- A directory named myfolder  
- Two files: computer.txt and test.txt
```

**Technical Fixes Applied:**
1. **Enhanced FileDiscoveryService**: Now properly handles multiple workspace directories
2. **Smart Path Resolution**: LSTool.execute() finds the appropriate workspace directory for each path
3. **Graceful Error Handling**: Promise.allSettled replaces Promise.all, preventing crashes
4. **Skip External Validation**: Ignore file validation is skipped for external directories
5. **Robust Directory Processing**: Each directory is processed independently with proper error recovery

### **Key Changes Made:**

1. **Fixed FileDiscoveryService initialization** to use primary workspace directory
2. **Enhanced LSTool.execute()** to properly calculate relative paths for files in multiple workspace directories  
3. **Added skip logic for ignore file validation** for external workspace directories to prevent path.relative() validation errors
4. **Replaced Promise.all with Promise.allSettled** in getEnvironment() and getDirectoryContext() methods
5. **Added comprehensive error handling** for ignore file checking operations

## Reviewer Test Plan

To validate this fix works correctly:

1. **Setup Test Environment:**
   - Create a settings.json with multiple directories in `includeDirectories`
   - Include at least one external directory (outside main project)

2. **Test the Fix:**
   - Start the CLI: `npm start`
   - Try accessing external directory: `"What's inside <external_directory>"`
   - Verify it lists contents without crashing

3. **Test Edge Cases:**
   - Try with non-existent directories
   - Test with directories that have permission issues
   - Verify main project directory still works normally

4. **Regression Testing:**
   - Test single directory workspaces still work
   - Verify ignore files (.gitignore, .geminiignore) still function properly within main project

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ✅  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #319
