### PR TITLE
Feat: Support GitHub Copilot Provider

### DIFF
--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -51,6 +51,12 @@ export const validateAuthMethod = (authMethod: string): string | null => {
     return null;
   }
 
+  if (authMethod === AuthType.GITHUB_COPILOT_OAUTH) {
+    // GitHub Copilot OAuth doesn't require any environment variables for basic setup
+    // The OAuth flow will handle authentication
+    return null;
+  }
+
   return 'Invalid auth method selected.';
 };
 

--- a/packages/cli/src/ui/components/AuthDialog.tsx
+++ b/packages/cli/src/ui/components/AuthDialog.tsx
@@ -47,6 +47,7 @@ export function AuthDialog({
   const [showOpenAIKeyPrompt, setShowOpenAIKeyPrompt] = useState(false);
   const items = [
     { label: 'Qwen OAuth', value: AuthType.QWEN_OAUTH },
+    { label: 'GitHub Copilot', value: AuthType.GITHUB_COPILOT_OAUTH },
     { label: 'OpenAI', value: AuthType.USE_OPENAI },
   ];
 

--- a/packages/cli/src/ui/components/GitHubCopilotOAuthProgress.tsx
+++ b/packages/cli/src/ui/components/GitHubCopilotOAuthProgress.tsx
@@ -1,0 +1,249 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState, useEffect, useMemo } from 'react';
+import { Box, Text, useInput } from 'ink';
+import Spinner from 'ink-spinner';
+import Link from 'ink-link';
+import { Colors } from '../colors.js';
+import { GitHubCopilotDeviceAuthorization } from '@qwen-code/qwen-code-core';
+
+interface GitHubCopilotOAuthProgressProps {
+  onTimeout: () => void;
+  onCancel: () => void;
+  deviceAuth?: GitHubCopilotDeviceAuthorization;
+  authStatus?:
+    | 'idle'
+    | 'polling'
+    | 'success'
+    | 'error'
+    | 'timeout'
+    | 'rate_limit';
+  authMessage?: string | null;
+}
+
+/**
+ * Static Auth Display Component
+ * Renders the authentication URL and code once and doesn't re-render unless the URL changes
+ */
+function AuthDisplay({
+  verificationUrl,
+  verificationUrlComplete,
+  userCode,
+}: {
+  verificationUrl: string;
+  verificationUrlComplete: string;
+  userCode: string;
+}): React.JSX.Element {
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={Colors.AccentBlue}
+      flexDirection="column"
+      padding={1}
+      width="100%"
+    >
+      <Text bold color={Colors.AccentBlue}>
+        GitHub Copilot OAuth Authentication
+      </Text>
+
+      <Box marginTop={1}>
+        <Text>Please visit this URL to authorize:</Text>
+      </Box>
+
+      <Link url={verificationUrlComplete} fallback={false}>
+        <Text color={Colors.AccentGreen} bold>
+          {verificationUrl}
+        </Text>
+      </Link>
+
+      <Box marginTop={1}>
+        <Text>
+          And enter the code: <Text bold color={Colors.AccentYellow}>{userCode}</Text>
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Dynamic Status Display Component
+ * Shows the loading spinner, timer, and status messages
+ */
+function StatusDisplay({
+  timeRemaining,
+  dots,
+}: {
+  timeRemaining: number;
+  dots: string;
+}): React.JSX.Element {
+  const formatTime = (seconds: number): string => {
+    const minutes = Math.floor(seconds / 60);
+    const remainingSeconds = seconds % 60;
+    return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
+  };
+
+  return (
+    <Box
+      borderStyle="round"
+      borderColor={Colors.AccentBlue}
+      flexDirection="column"
+      padding={1}
+      width="100%"
+    >
+      <Box marginTop={1}>
+        <Text>
+          <Spinner type="dots" /> Waiting for authorization{dots}
+        </Text>
+      </Box>
+
+      <Box marginTop={1} justifyContent="space-between">
+        <Text color={Colors.Gray}>
+          Time remaining: {formatTime(timeRemaining)}
+        </Text>
+        <Text color={Colors.AccentPurple}>(Press ESC to cancel)</Text>
+      </Box>
+    </Box>
+  );
+}
+
+export function GitHubCopilotOAuthProgress({
+  onTimeout,
+  onCancel,
+  deviceAuth,
+  authStatus,
+  authMessage,
+}: GitHubCopilotOAuthProgressProps): React.JSX.Element {
+  const defaultTimeout = deviceAuth?.expires_in || 300; // Default 5 minutes
+  const [timeRemaining, setTimeRemaining] = useState<number>(defaultTimeout);
+  const [dots, setDots] = useState<string>('');
+
+  useInput((input, key) => {
+    if (authStatus === 'timeout') {
+      // Any key press in timeout state should trigger cancel to return to auth dialog
+      onCancel();
+    } else if (key.escape) {
+      onCancel();
+    }
+  });
+
+  // Update timeRemaining when deviceAuth changes
+  useEffect(() => {
+    if (deviceAuth?.expires_in) {
+      setTimeRemaining(deviceAuth.expires_in);
+    }
+  }, [deviceAuth?.expires_in]);
+
+  // Countdown timer - only start when we have deviceAuth
+  useEffect(() => {
+    if (!deviceAuth) {
+      return; // Don't start timer until we have device auth
+    }
+
+    const timer = setInterval(() => {
+      setTimeRemaining((prev) => {
+        if (prev <= 1) {
+          onTimeout();
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [onTimeout, deviceAuth]);
+
+  // Animated dots
+  useEffect(() => {
+    const dotsTimer = setInterval(() => {
+      setDots((prev) => {
+        if (prev.length >= 3) return '';
+        return prev + '.';
+      });
+    }, 500);
+
+    return () => clearInterval(dotsTimer);
+  }, []);
+
+  // Memoize the auth display to prevent unnecessary re-renders
+  const authDisplay = useMemo(() => {
+    if (!deviceAuth?.verification_uri || !deviceAuth?.user_code) return null;
+
+    return (
+      <AuthDisplay
+        verificationUrl={deviceAuth.verification_uri}
+        verificationUrlComplete={deviceAuth.verification_uri}
+        userCode={deviceAuth.user_code}
+      />
+    );
+  }, [deviceAuth?.verification_uri, deviceAuth?.user_code]);
+
+  // Handle timeout state
+  if (authStatus === 'timeout') {
+    return (
+      <Box
+        borderStyle="round"
+        borderColor={Colors.AccentRed}
+        flexDirection="column"
+        padding={1}
+        width="100%"
+      >
+        <Text bold color={Colors.AccentRed}>
+          GitHub Copilot OAuth Authentication Timeout
+        </Text>
+
+        <Box marginTop={1}>
+          <Text>
+            {authMessage ||
+              `OAuth token expired (over ${defaultTimeout} seconds). Please select authentication method again.`}
+          </Text>
+        </Box>
+
+        <Box marginTop={1}>
+          <Text color={Colors.Gray}>
+            Press any key to return to authentication type selection.
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  // Show loading state when no device auth is available yet
+  if (!deviceAuth) {
+    return (
+      <Box
+        borderStyle="round"
+        borderColor={Colors.Gray}
+        flexDirection="column"
+        padding={1}
+        width="100%"
+      >
+        <Box>
+          <Text>
+            <Spinner type="dots" /> Waiting for GitHub Copilot OAuth authentication...
+          </Text>
+        </Box>
+        <Box marginTop={1} justifyContent="space-between">
+          <Text color={Colors.Gray}>
+            Time remaining: {Math.floor(timeRemaining / 60)}:
+            {(timeRemaining % 60).toString().padStart(2, '0')}
+          </Text>
+          <Text color={Colors.AccentPurple}>(Press ESC to cancel)</Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  return (
+    <Box flexDirection="column" width="100%">
+      {/* Static Auth Display */}
+      {authDisplay}
+
+      {/* Dynamic Status Display */}
+      <StatusDisplay timeRemaining={timeRemaining} dots={dots} />
+    </Box>
+  );
+}

--- a/packages/cli/src/ui/hooks/useGitHubCopilotAuth.ts
+++ b/packages/cli/src/ui/hooks/useGitHubCopilotAuth.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useEffect, useState } from 'react';
+import {
+  AuthType,
+  GitHubCopilotOAuth2Event,
+  githubCopilotOAuth2Events,
+  GitHubCopilotDeviceAuthorization,
+} from '@qwen-code/qwen-code-core';
+import { LoadedSettings } from '../../config/settings.js';
+
+export interface GitHubCopilotAuthState {
+  isGitHubCopilotAuthenticating: boolean;
+  deviceAuth: GitHubCopilotDeviceAuthorization | null;
+  authStatus:
+    | 'idle'
+    | 'polling'
+    | 'success'
+    | 'error'
+    | 'timeout'
+    | 'rate_limit';
+  authMessage: string | null;
+}
+
+export function useGitHubCopilotAuth(
+  settings: LoadedSettings,
+  isAuthenticating: boolean,
+) {
+  const [authState, setAuthState] = useState<GitHubCopilotAuthState>({
+    isGitHubCopilotAuthenticating: false,
+    deviceAuth: null,
+    authStatus: 'idle',
+    authMessage: null,
+  });
+
+  const isGitHubCopilotAuth = settings.merged.selectedAuthType === AuthType.GITHUB_COPILOT_OAUTH;
+
+  useEffect(() => {
+    if (!isGitHubCopilotAuth || !isAuthenticating) {
+      // Reset state when not authenticating or not GitHub Copilot auth
+      setAuthState({
+        isGitHubCopilotAuthenticating: false,
+        deviceAuth: null,
+        authStatus: 'idle',
+        authMessage: null,
+      });
+      return;
+    }
+
+    setAuthState((prev) => ({
+      ...prev,
+      isGitHubCopilotAuthenticating: true,
+      authStatus: 'idle',
+    }));
+
+    const handleAuthUri = (deviceAuth: GitHubCopilotDeviceAuthorization) => {
+      setAuthState(prev => ({
+        ...prev,
+        deviceAuth,
+        authStatus: 'polling',
+      }));
+    };
+
+    const handleAuthProgress = (
+      status: 'success' | 'error' | 'polling' | 'timeout' | 'rate_limit',
+      message?: string,
+    ) => {
+      setAuthState(prev => ({
+        ...prev,
+        authStatus: status,
+        authMessage: message || null,
+      }));
+    };
+
+    const handleAuthComplete = () => {
+      setAuthState(prev => ({
+        ...prev,
+        isGitHubCopilotAuthenticating: false,
+        authStatus: 'success',
+        authMessage: 'Authentication completed successfully!',
+      }));
+    };
+
+    const handleAuthError = (error: string) => {
+      setAuthState(prev => ({
+        ...prev,
+        isGitHubCopilotAuthenticating: false,
+        authStatus: 'error',
+        authMessage: error,
+      }));
+    };
+
+    // Subscribe to GitHub Copilot OAuth events
+    githubCopilotOAuth2Events.on(GitHubCopilotOAuth2Event.AuthUri, handleAuthUri);
+    githubCopilotOAuth2Events.on(GitHubCopilotOAuth2Event.AuthProgress, handleAuthProgress);
+    githubCopilotOAuth2Events.on(GitHubCopilotOAuth2Event.AuthComplete, handleAuthComplete);
+    githubCopilotOAuth2Events.on(GitHubCopilotOAuth2Event.AuthError, handleAuthError);
+
+    return () => {
+      githubCopilotOAuth2Events.off(GitHubCopilotOAuth2Event.AuthUri, handleAuthUri);
+      githubCopilotOAuth2Events.off(GitHubCopilotOAuth2Event.AuthProgress, handleAuthProgress);
+      githubCopilotOAuth2Events.off(GitHubCopilotOAuth2Event.AuthComplete, handleAuthComplete);
+      githubCopilotOAuth2Events.off(GitHubCopilotOAuth2Event.AuthError, handleAuthError);
+    };
+  }, [isGitHubCopilotAuth, isAuthenticating]);
+
+  const cancelGitHubCopilotAuth = () => {
+    githubCopilotOAuth2Events.emit(GitHubCopilotOAuth2Event.AuthCancel);
+    setAuthState({
+      isGitHubCopilotAuthenticating: false,
+      deviceAuth: null,
+      authStatus: 'idle',
+      authMessage: null,
+    });
+  };
+
+  return {
+    ...authState,
+    isGitHubCopilotAuth,
+    cancelGitHubCopilotAuth,
+  };
+}

--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -47,6 +47,7 @@ export enum AuthType {
   CLOUD_SHELL = 'cloud-shell',
   USE_OPENAI = 'openai',
   QWEN_OAUTH = 'qwen-oauth',
+  GITHUB_COPILOT_OAUTH = 'github-copilot-oauth',
 }
 
 export type ContentGeneratorConfig = {
@@ -143,6 +144,17 @@ export function createContentGeneratorConfig(
     return contentGeneratorConfig;
   }
 
+  if (authType === AuthType.GITHUB_COPILOT_OAUTH) {
+    // For GitHub Copilot OAuth, we'll handle the API key dynamically in createContentGenerator
+    // Set a special marker to indicate this is GitHub Copilot OAuth
+    contentGeneratorConfig.apiKey = 'GITHUB_COPILOT_OAUTH_DYNAMIC_TOKEN';
+
+    // Use gpt-4 as the default GitHub Copilot model
+    contentGeneratorConfig.model = process.env.GITHUB_COPILOT_MODEL || 'gpt-4.1';
+
+    return contentGeneratorConfig;
+  }
+
   return contentGeneratorConfig;
 }
 
@@ -218,6 +230,40 @@ export async function createContentGenerator(
     } catch (error) {
       throw new Error(
         `Failed to initialize Qwen: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  }
+
+  if (config.authType === AuthType.GITHUB_COPILOT_OAUTH) {
+    if (config.apiKey !== 'GITHUB_COPILOT_OAUTH_DYNAMIC_TOKEN') {
+      throw new Error('Invalid GitHub Copilot OAuth configuration');
+    }
+
+    // Import required classes dynamically
+    const { getGitHubCopilotOAuthClient } = await import(
+      '../github-copilot/githubCopilotOAuth2.js'
+    );
+    const { GitHubCopilotContentGenerator } = await import(
+      '../github-copilot/githubCopilotContentGenerator.js'
+    );
+
+    try {
+      console.log('Getting GitHub Copilot OAuth client...');
+      // Get the GitHub Copilot OAuth client (includes integrated token management)
+      const githubCopilotClient = await getGitHubCopilotOAuthClient(gcConfig);
+      console.log('GitHub Copilot OAuth client obtained successfully');
+
+      // Create the content generator with dynamic token management
+      return new GitHubCopilotContentGenerator(githubCopilotClient, config.model, gcConfig);
+    } catch (error) {
+      // Check if the error is specifically about authentication being required
+      if (error instanceof Error && error.message === 'GITHUB_COPILOT_AUTH_REQUIRED') {
+        // Re-throw this specific error to be handled by the UI layer
+        throw error;
+      }
+      
+      throw new Error(
+        `Failed to initialize GitHub Copilot: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }

--- a/packages/core/src/core/openaiContentGenerator.ts
+++ b/packages/core/src/core/openaiContentGenerator.ts
@@ -80,8 +80,8 @@ interface OpenAIResponseFormat {
 
 export class OpenAIContentGenerator implements ContentGenerator {
   protected client: OpenAI;
-  private model: string;
-  private config: Config;
+  protected model: string;
+  protected config: Config;
   private streamingToolCalls: Map<
     number,
     {
@@ -563,7 +563,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
 
     // Add combined text if any
     if (combinedText) {
-      combinedParts.push({ text: combinedText.trimEnd() });
+      combinedParts.push({ text: combinedText });
     }
 
     // Add function calls
@@ -750,7 +750,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
    * @param geminiTools - Array of Gemini tools to convert
    * @returns Promise resolving to array of OpenAI-compatible tools
    */
-  private async convertGeminiToolsToOpenAI(
+  protected async convertGeminiToolsToOpenAI(
     geminiTools: ToolListUnion,
   ): Promise<OpenAI.Chat.ChatCompletionTool[]> {
     const openAITools: OpenAI.Chat.ChatCompletionTool[] = [];
@@ -809,7 +809,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
     return openAITools;
   }
 
-  private convertToOpenAIFormat(
+  protected convertToOpenAIFormat(
     request: GenerateContentParameters,
   ): OpenAI.Chat.ChatCompletionMessageParam[] {
     const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [];
@@ -1154,7 +1154,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
     return merged;
   }
 
-  private convertToGeminiFormat(
+  protected convertToGeminiFormat(
     openaiResponse: OpenAI.Chat.ChatCompletion,
   ): GenerateContentResponse {
     const choice = openaiResponse.choices[0];
@@ -1165,7 +1165,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
     // Handle text content
     if (choice.message.content) {
       if (typeof choice.message.content === 'string') {
-        parts.push({ text: choice.message.content.trimEnd() });
+        parts.push({ text: choice.message.content });
       } else {
         parts.push({ text: choice.message.content });
       }
@@ -1242,7 +1242,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
     return response;
   }
 
-  private convertStreamChunkToGeminiFormat(
+  protected convertStreamChunkToGeminiFormat(
     chunk: OpenAI.Chat.ChatCompletionChunk,
   ): GenerateContentResponse {
     const choice = chunk.choices?.[0];
@@ -1254,7 +1254,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
       // Handle text content
       if (choice.delta?.content) {
         if (typeof choice.delta.content === 'string') {
-          parts.push({ text: choice.delta.content.trimEnd() });
+          parts.push({ text: choice.delta.content });
         } else {
           parts.push({ text: choice.delta.content });
         }
@@ -1373,7 +1373,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
    * 2. Request-level parameters (medium priority)
    * 3. Default values (lowest priority)
    */
-  private buildSamplingParameters(
+  protected buildSamplingParameters(
     request: GenerateContentParameters,
   ): Record<string, unknown> {
     const configSamplingParams =
@@ -1776,7 +1776,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
         }
       }
 
-      messageContent = textParts.join('').trimEnd();
+      messageContent = textParts.join('');
     }
 
     const choice: OpenAIChoice = {

--- a/packages/core/src/github-copilot/githubCopilotContentGenerator.ts
+++ b/packages/core/src/github-copilot/githubCopilotContentGenerator.ts
@@ -1,0 +1,362 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CountTokensResponse,
+  GenerateContentResponse,
+  GenerateContentParameters,
+  CountTokensParameters,
+  EmbedContentResponse,
+  EmbedContentParameters,
+  Part,
+  Content,
+  FinishReason,
+} from '@google/genai';
+import { OpenAIContentGenerator } from '../core/openaiContentGenerator.js';
+import { Config } from '../config/config.js';
+import { GitHubCopilotOAuth2Client } from './githubCopilotOAuth2.js';
+import { getErrorMessage } from '../utils/errors.js';
+
+/**
+ * GitHub Copilot API response interface
+ */
+interface GitHubCopilotResponse {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    message: {
+      role: string;
+      content: string | null;
+      tool_calls?: Array<{
+        id: string;
+        type: 'function';
+        function: {
+          name: string;
+          arguments: string;
+        };
+      }>;
+    };
+    finish_reason: string;
+  }>;
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+/**
+ * GitHub Copilot streaming response interface
+ */
+interface GitHubCopilotStreamResponse {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: Array<{
+    index: number;
+    delta: {
+      role?: string;
+      content?: string;
+      tool_calls?: Array<{
+        index?: number;
+        id?: string;
+        type?: 'function';
+        function?: {
+          name?: string;
+          arguments?: string;
+        };
+      }>;
+    };
+    finish_reason?: string;
+  }>;
+}
+
+/**
+ * Content generator implementation for GitHub Copilot
+ */
+export class GitHubCopilotContentGenerator extends OpenAIContentGenerator {
+  private static readonly COPILOT_API_BASE = 'https://api.githubcopilot.com';
+  private static readonly DEFAULT_MODEL = 'gpt-4';
+  private copilotClient: GitHubCopilotOAuth2Client;
+
+  constructor(
+    client: GitHubCopilotOAuth2Client,
+    model: string,
+    config: Config,
+  ) {
+    // Create a dummy API key since we'll override the HTTP calls
+    super('dummy-key', model, config);
+    this.copilotClient = client;
+  }
+
+  /**
+   * Override to suppress error logging for authentication failures
+   */
+  protected shouldSuppressErrorLogging(
+    error: unknown,
+    _request: GenerateContentParameters,
+  ): boolean {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    return errorMessage.includes('GitHub Copilot authentication');
+  }
+
+  async generateContent(
+    request: GenerateContentParameters,
+    userPromptId: string,
+  ): Promise<GenerateContentResponse> {
+    return this.withValidToken(async (token) => {
+      const messages = this.convertToOpenAIFormat(request);
+      const samplingParams = this.buildSamplingParameters(request);
+      
+      const requestBody: any = {
+        model: this.model || GitHubCopilotContentGenerator.DEFAULT_MODEL,
+        messages,
+        ...samplingParams,
+        stream: false,
+      };
+
+      // Add tools if present
+      if (request.config?.tools) {
+        requestBody.tools = await this.convertGeminiToolsToOpenAI(request.config.tools);
+      }
+
+      const response = await fetch(`${GitHubCopilotContentGenerator.COPILOT_API_BASE}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'User-Agent': 'GitHubCopilotChat/0.26.7',
+          'Editor-Version': 'vscode/1.99.3',
+          'Editor-Plugin-Version': 'copilot-chat/0.26.7',
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        // If we get a 401, it means the token is invalid, so we should clear credentials
+        if (response.status === 401) {
+          await this.copilotClient.clearCredentials();
+          throw new Error('GitHub Copilot authentication has expired. Please authenticate with GitHub Copilot again.');
+        }
+        throw new Error(`GitHub Copilot API error: ${response.status} ${response.statusText} - ${errorText}`);
+      }
+
+      const copilotResponse = await response.json() as GitHubCopilotResponse;
+      // Convert GitHub Copilot response to OpenAI format for parent class method
+      const openaiResponse = this.convertCopilotToOpenAIResponse(copilotResponse);
+      return this.convertToGeminiFormat(openaiResponse);
+    });
+  }
+
+  async generateContentStream(
+    request: GenerateContentParameters,
+    userPromptId: string,
+  ): Promise<AsyncGenerator<GenerateContentResponse>> {
+    return this.withValidTokenForStream(async (token) => {
+      const messages = this.convertToOpenAIFormat(request);
+      const samplingParams = this.buildSamplingParameters(request);
+      
+      const requestBody: any = {
+        model: this.model || GitHubCopilotContentGenerator.DEFAULT_MODEL,
+        messages,
+        ...samplingParams,
+        stream: true,
+        stream_options: { include_usage: true },
+      };
+
+      // Add tools if present
+      if (request.config?.tools) {
+        requestBody.tools = await this.convertGeminiToolsToOpenAI(request.config.tools);
+      }
+
+      const response = await fetch(`${GitHubCopilotContentGenerator.COPILOT_API_BASE}/chat/completions`, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          'User-Agent': 'GitHubCopilotChat/0.26.7',
+          'Editor-Version': 'vscode/1.99.3',
+          'Editor-Plugin-Version': 'copilot-chat/0.26.7',
+        },
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        // If we get a 401, it means the token is invalid, so we should clear credentials
+        if (response.status === 401) {
+          await this.copilotClient.clearCredentials();
+          throw new Error('GitHub Copilot authentication has expired. Please authenticate with GitHub Copilot again.');
+        }
+        throw new Error(`GitHub Copilot API error: ${response.status} ${response.statusText} - ${errorText}`);
+      }
+
+      if (!response.body) {
+        throw new Error('No response body received from GitHub Copilot API');
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      // Create and return an async generator function
+      const self = this;
+      async function* streamGenerator() {
+        try {
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split('\n');
+            buffer = lines.pop() || '';
+
+            for (const line of lines) {
+              if (line.trim() === '') continue;
+              if (line.startsWith('data: ')) {
+                const data = line.slice(6);
+                if (data === '[DONE]') {
+                  return;
+                }
+
+                try {
+                  const parsed = JSON.parse(data) as GitHubCopilotStreamResponse;
+                  // Convert GitHub Copilot stream response to OpenAI format for parent class method
+                  const openaiChunk = self.convertCopilotToOpenAIStreamChunk(parsed);
+                  const geminiResponse = self.convertStreamChunkToGeminiFormat(openaiChunk);
+                  if (geminiResponse) {
+                    yield geminiResponse;
+                  }
+                } catch (error) {
+                  console.warn('Failed to parse streaming response:', error);
+                }
+              }
+            }
+          }
+        } finally {
+          reader.releaseLock();
+        }
+      }
+
+      // Return the async generator
+      return streamGenerator();
+    });
+  }
+
+  async embedContent(request: EmbedContentParameters): Promise<EmbedContentResponse> {
+    throw new Error('GitHub Copilot does not support embedding content');
+  }
+
+  /**
+   * Execute operation with a valid token, with retry on auth failure
+   */
+  private async withValidToken<T>(
+    operation: (token: string) => Promise<T>,
+  ): Promise<T> {
+    const token = await this.getTokenWithRetry();
+    return await operation(token);
+  }
+
+  /**
+   * Execute operation with a valid token for streaming, with retry on auth failure
+   */
+  private async withValidTokenForStream<T>(
+    operation: (token: string) => Promise<T>,
+  ): Promise<T> {
+    const token = await this.getTokenWithRetry();
+    return await operation(token);
+  }
+
+  /**
+   * Get token with retry logic
+   */
+  private async getTokenWithRetry(): Promise<string> {
+    try {
+      return await this.getValidToken();
+    } catch (error) {
+      console.error('Failed to get valid GitHub Copilot token:', error);
+      throw new Error(
+        'Failed to obtain valid GitHub Copilot access token. Please re-authenticate.',
+      );
+    }
+  }
+
+  /**
+   * Get a valid access token, attempting to trigger OAuth flow if needed
+   */
+  private async getValidToken(): Promise<string> {
+    // Try to get a valid token first
+    let token = await this.copilotClient.getValidAccessToken();
+    if (token) {
+      return token;
+    }
+
+    // If we don't have a valid token, try to trigger the OAuth flow
+    console.log('No valid GitHub Copilot token found, attempting to trigger OAuth flow...');
+    const success = await this.copilotClient.triggerOAuthFlow();
+    if (success) {
+      // Try to get the token again after OAuth flow
+      token = await this.copilotClient.getValidAccessToken();
+      if (token) {
+        return token;
+      }
+    }
+
+    // If we still don't have a valid token, throw an error
+    throw new Error('GitHub Copilot authentication required. Please authenticate with GitHub Copilot first.');
+  }
+
+  /**
+   * Convert GitHub Copilot response to OpenAI format
+   */
+  private convertCopilotToOpenAIResponse(copilotResponse: GitHubCopilotResponse): any {
+    return {
+      id: copilotResponse.id,
+      object: copilotResponse.object,
+      created: copilotResponse.created,
+      model: copilotResponse.model,
+      choices: copilotResponse.choices.map(choice => ({
+        index: choice.index,
+        message: {
+          role: choice.message.role as 'assistant',
+          content: choice.message.content,
+          ...(choice.message.tool_calls && { tool_calls: choice.message.tool_calls }),
+        },
+        finish_reason: choice.finish_reason,
+        logprobs: null, // GitHub Copilot doesn't provide logprobs
+      })),
+      usage: copilotResponse.usage,
+    };
+  }
+
+  /**
+   * Convert GitHub Copilot stream chunk to OpenAI format
+   */
+  private convertCopilotToOpenAIStreamChunk(copilotChunk: GitHubCopilotStreamResponse): any {
+    return {
+      id: copilotChunk.id,
+      object: copilotChunk.object,
+      created: copilotChunk.created,
+      model: copilotChunk.model,
+      choices: copilotChunk.choices.map(choice => ({
+        index: choice.index,
+        delta: {
+          role: choice.delta.role as 'assistant' | undefined,
+          content: choice.delta.content,
+          ...(choice.delta.tool_calls && { tool_calls: choice.delta.tool_calls }),
+        },
+        finish_reason: choice.finish_reason,
+        logprobs: null,
+      })),
+    };
+  }
+
+}

--- a/packages/core/src/github-copilot/githubCopilotOAuth2.ts
+++ b/packages/core/src/github-copilot/githubCopilotOAuth2.ts
@@ -1,0 +1,547 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import crypto from 'crypto';
+import path from 'node:path';
+import { promises as fs } from 'node:fs';
+import * as os from 'os';
+import { EventEmitter } from 'events';
+import { Config } from '../config/config.js';
+import open from 'open';
+
+// GitHub OAuth Endpoints
+const GITHUB_CLIENT_ID = "Iv1.b507a08c87ecfe98";
+const GITHUB_DEVICE_CODE_URL = "https://github.com/login/device/code";
+const GITHUB_ACCESS_TOKEN_URL = "https://github.com/login/oauth/access_token";
+const GITHUB_COPILOT_API_KEY_URL = "https://api.github.com/copilot_internal/v2/token";
+
+// File System Configuration
+const GITHUB_COPILOT_DIR = '.qwen/github_copilot';
+const GITHUB_COPILOT_CREDENTIAL_FILENAME = 'oauth_creds.json';
+
+// Token Configuration
+const TOKEN_REFRESH_BUFFER_MS = 30 * 1000; // 30 seconds
+
+/**
+ * GitHub OAuth device code response interface
+ */
+export interface GitHubDeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+}
+
+/**
+ * GitHub OAuth access token response interface
+ */
+export interface GitHubAccessTokenResponse {
+  access_token?: string;
+  error?: string;
+  error_description?: string;
+}
+
+/**
+ * GitHub Copilot API token response interface
+ */
+export interface GitHubCopilotTokenResponse {
+  token: string;
+  expires_at: number;
+  refresh_in: number;
+  endpoints: {
+    api: string;
+  };
+}
+
+/**
+ * GitHub Copilot OAuth2 credentials interface
+ */
+export interface GitHubCopilotOAuth2Credentials {
+  access_token: string; // GitHub OAuth token
+  copilot_token?: string; // Copilot API token
+  copilot_expires_at?: number; // Copilot token expiry timestamp
+  created_at: number;
+  updated_at: number;
+}
+
+/**
+ * GitHub Copilot OAuth2 device authorization interface
+ */
+export interface GitHubCopilotDeviceAuthorization {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  interval: number;
+  expires_in: number;
+}
+
+/**
+ * GitHub Copilot OAuth2 client interface
+ */
+export interface IGitHubCopilotOAuth2Client {
+  getCredentialsPath(): string;
+  hasValidCredentials(): Promise<boolean>;
+  getValidAccessToken(): Promise<string | null>;
+  loadCredentials(): Promise<GitHubCopilotOAuth2Credentials | null>;
+  startDeviceAuthorization(): Promise<GitHubCopilotDeviceAuthorization>;
+  pollForAccessToken(deviceCode: string): Promise<'complete' | 'pending' | 'failed'>;
+  clearCredentials(): Promise<void>;
+  triggerOAuthFlow(): Promise<boolean>;
+}
+
+/**
+ * GitHub Copilot OAuth2 client implementation
+ */
+export class GitHubCopilotOAuth2Client implements IGitHubCopilotOAuth2Client {
+  private credentialsPath: string;
+
+  constructor(private config: Config) {
+    const homeDir = os.homedir();
+    const githubCopilotDir = path.join(homeDir, ...GITHUB_COPILOT_DIR.split('/'));
+    this.credentialsPath = path.join(githubCopilotDir, GITHUB_COPILOT_CREDENTIAL_FILENAME);
+  }
+
+  getCredentialsPath(): string {
+    return this.credentialsPath;
+  }
+
+  private async ensureCredentialsDirectory(): Promise<void> {
+    const dir = path.dirname(this.credentialsPath);
+    try {
+      await fs.access(dir);
+    } catch {
+      await fs.mkdir(dir, { recursive: true });
+    }
+  }
+
+  public async loadCredentials(): Promise<GitHubCopilotOAuth2Credentials | null> {
+    try {
+      const data = await fs.readFile(this.credentialsPath, 'utf8');
+      return JSON.parse(data) as GitHubCopilotOAuth2Credentials;
+    } catch {
+      return null;
+    }
+  }
+
+  private async saveCredentials(credentials: GitHubCopilotOAuth2Credentials): Promise<void> {
+    await this.ensureCredentialsDirectory();
+    await fs.writeFile(this.credentialsPath, JSON.stringify(credentials, null, 2));
+    await fs.chmod(this.credentialsPath, 0o600);
+  }
+
+  async hasValidCredentials(): Promise<boolean> {
+    const credentials = await this.loadCredentials();
+    
+    if (!credentials?.access_token) {
+      return false;
+    }
+
+    // Check if we have a valid Copilot token
+    if (credentials.copilot_token && credentials.copilot_expires_at) {
+      const now = Date.now();
+      const isValid = credentials.copilot_expires_at > now + TOKEN_REFRESH_BUFFER_MS;
+      return isValid;
+    }
+
+    // If we have GitHub token but no Copilot token, we still have valid credentials
+    // The Copilot token will be obtained when needed
+    return true;
+  }
+
+  async getValidAccessToken(): Promise<string | null> {
+    let credentials = await this.loadCredentials();
+    
+    // If we don't have any credentials, return null (OAuth flow should already be triggered)
+    if (!credentials?.access_token) {
+      console.log('No GitHub Copilot credentials found');
+      return null;
+    }
+
+    // Check if we have a valid Copilot token
+    if (credentials.copilot_token && credentials.copilot_expires_at) {
+      const now = Date.now();
+      if (credentials.copilot_expires_at > now + TOKEN_REFRESH_BUFFER_MS) {
+        return credentials.copilot_token;
+      }
+    }
+
+    // Try to get a new Copilot token using the GitHub OAuth token
+    try {
+      console.log('Attempting to refresh Copilot token using existing GitHub OAuth token...');
+      const copilotToken = await this.getCopilotToken(credentials.access_token!);
+      if (copilotToken) {
+        console.log('Successfully refreshed Copilot token');
+        // Update credentials with new Copilot token
+        const updatedCredentials: GitHubCopilotOAuth2Credentials = {
+          ...credentials,
+          copilot_token: copilotToken.token,
+          copilot_expires_at: copilotToken.expires_at * 1000,
+          updated_at: Date.now(),
+        };
+        await this.saveCredentials(updatedCredentials);
+        return copilotToken.token;
+      } else {
+        console.error('Copilot token refresh returned null - this should not happen');
+      }
+    } catch (error) {
+      console.error('Failed to refresh Copilot token:', error);
+      
+      // Check if this is a token expiration error (401)
+      if (error instanceof Error && error.message.includes('401')) {
+        console.error('GitHub OAuth token has expired. Clearing credentials to trigger re-authentication.');
+        // Clear the expired credentials so the user can re-authenticate
+        await this.clearCredentials();
+      } else {
+        console.error('This likely means:');
+        console.error('1. GitHub account does not have Copilot access');
+        console.error('2. Copilot API is experiencing issues');
+      }
+    }
+
+    return null;
+  }
+
+  private async getCopilotToken(githubToken: string): Promise<GitHubCopilotTokenResponse | null> {
+    const response = await fetch(GITHUB_COPILOT_API_KEY_URL, {
+      headers: {
+        Accept: 'application/json',
+        Authorization: `Bearer ${githubToken}`,
+        'User-Agent': 'GitHubCopilotChat/0.26.7',
+        'Editor-Version': 'vscode/1.99.3',
+        'Editor-Plugin-Version': 'copilot-chat/0.26.7',
+      },
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      let errorMessage = `Failed to get Copilot token: ${response.status} ${response.statusText}`;
+      
+      if (response.status === 401) {
+        errorMessage += ' - GitHub OAuth token is invalid or expired';
+      } else if (response.status === 403) {
+        errorMessage += ' - GitHub account does not have Copilot access or insufficient permissions';
+      } else if (response.status === 404) {
+        errorMessage += ' - Copilot API endpoint not found';
+      }
+      
+      if (errorText) {
+        errorMessage += ` - Response: ${errorText}`;
+      }
+      
+      throw new Error(errorMessage);
+    }
+
+    return await response.json() as GitHubCopilotTokenResponse;
+  }
+
+  async startDeviceAuthorization(): Promise<GitHubCopilotDeviceAuthorization> {
+    const response = await fetch(GITHUB_DEVICE_CODE_URL, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'User-Agent': 'GitHubCopilotChat/0.26.7',
+      },
+      body: JSON.stringify({
+        client_id: GITHUB_CLIENT_ID,
+        scope: 'read:user',
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to start device authorization: ${response.status} ${response.statusText}`);
+    }
+
+    const data = await response.json() as GitHubDeviceCodeResponse;
+    return {
+      device_code: data.device_code,
+      user_code: data.user_code,
+      verification_uri: data.verification_uri,
+      interval: data.interval || 5,
+      expires_in: data.expires_in,
+    };
+  }
+
+  async pollForAccessToken(deviceCode: string): Promise<'complete' | 'pending' | 'failed'> {
+    const response = await fetch(GITHUB_ACCESS_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'User-Agent': 'GitHubCopilotChat/0.26.7',
+      },
+      body: JSON.stringify({
+        client_id: GITHUB_CLIENT_ID,
+        device_code: deviceCode,
+        grant_type: 'urn:ietf:params:oauth:grant-type:device_code',
+      }),
+    });
+
+    if (!response.ok) {
+      return 'failed';
+    }
+
+    const data = await response.json() as GitHubAccessTokenResponse;
+
+    if (data.access_token) {
+      // Save the GitHub OAuth token
+      const credentials: GitHubCopilotOAuth2Credentials = {
+        access_token: data.access_token,
+        created_at: Date.now(),
+        updated_at: Date.now(),
+      };
+      await this.saveCredentials(credentials);
+      return 'complete';
+    }
+
+    if (data.error === 'authorization_pending') {
+      return 'pending';
+    }
+
+    return 'failed';
+  }
+
+  async clearCredentials(): Promise<void> {
+    try {
+      await fs.unlink(this.credentialsPath);
+    } catch {
+      // File doesn't exist, which is fine
+    }
+  }
+
+  /**
+   * Trigger the OAuth flow programmatically
+   */
+  async triggerOAuthFlow(): Promise<boolean> {
+    try {
+      const result = await performGitHubCopilotOAuthFlow(this, this.config);
+      return result === 'complete';
+    } catch (error) {
+      console.error('Failed to trigger GitHub Copilot OAuth flow:', error);
+      return false;
+    }
+  }
+}
+
+/**
+ * GitHub Copilot OAuth2 events
+ */
+export enum GitHubCopilotOAuth2Event {
+  AuthUri = 'auth_uri',
+  AuthProgress = 'auth_progress',
+  AuthComplete = 'auth_complete',
+  AuthCancel = 'auth_cancel',
+  AuthError = 'auth_error',
+}
+
+/**
+ * Global event emitter instance for GitHub Copilot OAuth2 authentication events
+ */
+export const githubCopilotOAuth2Events = new EventEmitter();
+
+export async function getGitHubCopilotOAuthClient(
+  config: Config,
+): Promise<GitHubCopilotOAuth2Client> {
+  const client = new GitHubCopilotOAuth2Client(config);
+  
+  // If there are cached creds on disk, they always take precedence
+  const credentials = await client.loadCredentials();
+  if (credentials?.access_token) {
+    console.log('Loaded cached GitHub Copilot credentials.');
+    
+    try {
+      // Try to get a valid access token (this will refresh if needed)
+      const token = await client.getValidAccessToken();
+      if (token) {
+        console.log('GitHub Copilot token is valid or successfully refreshed.');
+        return client;
+      }
+    } catch (error: unknown) {
+      // Handle token refresh errors
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      console.error('GitHub Copilot token refresh failed:', errorMessage);
+      
+      // Clear invalid credentials
+      await client.clearCredentials();
+      console.log('Cleared invalid GitHub Copilot credentials.');
+    }
+  }
+  
+  // Use device authorization flow for authentication
+  console.log('No valid GitHub Copilot credentials found, triggering OAuth flow');
+  const result = await performGitHubCopilotOAuthFlow(client, config);
+  if (result !== 'complete') {
+    // Handle different failure reasons
+    switch (result) {
+      case 'timeout':
+        throw new Error('GitHub Copilot OAuth authentication timed out');
+      case 'cancelled':
+        throw new Error('GitHub Copilot OAuth authentication was cancelled by user');
+      case 'rate_limited':
+        throw new Error('Too many requests for GitHub Copilot OAuth authentication, please try again later.');
+      case 'failed':
+      default:
+        throw new Error('GitHub Copilot OAuth authentication failed');
+    }
+  }
+  
+  console.log('GitHub Copilot OAuth client initialized');
+  return client;
+}
+
+async function performGitHubCopilotOAuthFlow(
+  client: GitHubCopilotOAuth2Client,
+  config: Config,
+): Promise<'complete' | 'timeout' | 'cancelled' | 'rate_limited' | 'failed'> {
+  let cancelHandler: () => void;
+  let timeoutId: NodeJS.Timeout;
+
+  const cleanup = () => {
+    githubCopilotOAuth2Events.off(GitHubCopilotOAuth2Event.AuthCancel, cancelHandler);
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+  };
+
+  try {
+    // Set up cancellation handler
+    cancelHandler = () => {
+      cleanup();
+    };
+    githubCopilotOAuth2Events.once(GitHubCopilotOAuth2Event.AuthCancel, cancelHandler);
+
+    console.log('Starting GitHub Copilot device authorization...');
+    // Start device authorization
+    const deviceAuth = await client.startDeviceAuthorization();
+    console.log('Device authorization successful:', deviceAuth);
+
+    // Emit the authorization URI for the UI to handle
+    githubCopilotOAuth2Events.emit(GitHubCopilotOAuth2Event.AuthUri, deviceAuth);
+
+    const showFallbackMessage = () => {
+      console.log('\n=== GitHub Copilot OAuth Device Authorization ===');
+      console.log(`Please visit: ${deviceAuth.verification_uri}`);
+      console.log(`And enter the code: ${deviceAuth.user_code}`);
+      console.log('Waiting for authorization...\n');
+    };
+
+    // If browser launch is not suppressed, try to open the URL
+    if (!config.isBrowserLaunchSuppressed()) {
+      try {
+        const childProcess = await open(deviceAuth.verification_uri);
+
+        // IMPORTANT: Attach an error handler to the returned child process.
+        // Without this, if `open` fails to spawn a process (e.g., `xdg-open` is not found
+        // in a minimal Docker container), it will emit an unhandled 'error' event,
+        // causing the entire Node.js process to crash.
+        if (childProcess) {
+          childProcess.on('error', () => {
+            console.log('Failed to open browser. Visit this URL to authorize:');
+            showFallbackMessage();
+          });
+        }
+      } catch (_err) {
+        showFallbackMessage();
+      }
+    } else {
+      // Browser launch is suppressed, show fallback message
+      showFallbackMessage();
+    }
+
+    // Set up timeout
+    const timeoutMs = deviceAuth.expires_in * 1000;
+    timeoutId = setTimeout(() => {
+      githubCopilotOAuth2Events.emit(
+        GitHubCopilotOAuth2Event.AuthProgress,
+        'timeout',
+        'Authentication timed out',
+      );
+    }, timeoutMs);
+
+    // Start polling
+    const pollInterval = deviceAuth.interval * 1000;
+    let attempts = 0;
+    const maxAttempts = Math.floor(timeoutMs / pollInterval);
+
+    while (attempts < maxAttempts) {
+      try {
+        githubCopilotOAuth2Events.emit(
+          GitHubCopilotOAuth2Event.AuthProgress,
+          'polling',
+          `Polling for authorization... (${attempts + 1}/${maxAttempts})`,
+        );
+
+        const result = await client.pollForAccessToken(deviceAuth.device_code);
+        console.log('Poll result:', result);
+
+        if (result === 'complete') {
+          githubCopilotOAuth2Events.emit(
+            GitHubCopilotOAuth2Event.AuthProgress,
+            'success',
+            'Authentication successful!',
+          );
+
+          githubCopilotOAuth2Events.emit(GitHubCopilotOAuth2Event.AuthComplete);
+          cleanup();
+          return 'complete';
+        }
+
+        if (result === 'failed') {
+          githubCopilotOAuth2Events.emit(
+            GitHubCopilotOAuth2Event.AuthProgress,
+            'error',
+            'Authentication failed',
+          );
+          cleanup();
+          return 'failed';
+        }
+
+        // result === 'pending', continue polling
+        attempts++;
+        
+        if (attempts < maxAttempts) {
+          await new Promise(resolve => setTimeout(resolve, pollInterval));
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Unknown error occurred';
+        
+        if (message.includes('rate limit') || message.includes('too many requests')) {
+          githubCopilotOAuth2Events.emit(GitHubCopilotOAuth2Event.AuthProgress, 'error', message);
+          cleanup();
+          return 'rate_limited';
+        }
+
+        githubCopilotOAuth2Events.emit(GitHubCopilotOAuth2Event.AuthProgress, 'error', message);
+        cleanup();
+        return 'failed';
+      }
+    }
+
+    // Timeout reached
+    githubCopilotOAuth2Events.emit(
+      GitHubCopilotOAuth2Event.AuthProgress,
+      'timeout',
+      'Authentication timed out',
+    );
+    cleanup();
+    return 'timeout';
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error occurred';
+    githubCopilotOAuth2Events.emit(GitHubCopilotOAuth2Event.AuthError, message);
+    cleanup();
+    return 'failed';
+  } finally {
+    cleanup();
+  }
+}
+
+async function refreshGitHubCopilotToken(
+  client: GitHubCopilotOAuth2Client,
+  config: Config,
+): Promise<string | null> {
+  return await client.getValidAccessToken();
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export * from './core/nonInteractiveToolExecutor.js';
 export * from './code_assist/codeAssist.js';
 export * from './code_assist/oauth2.js';
 export * from './qwen/qwenOAuth2.js';
+export * from './github-copilot/githubCopilotOAuth2.js';
 export * from './code_assist/server.js';
 export * from './code_assist/types.js';
 


### PR DESCRIPTION
feat: Integrate GitHub Copilot OAuth authentication and refactor content generator

- Add GitHub Copilot OAuth2 device flow authentication, enabling users to access Copilot models via qwen-code.
- Implement GitHubCopilotContentGenerator, extending OpenAIContentGenerator for seamless API integration and streaming.
- Create UI components and React hooks for authentication flow and state management.
- Support automatic token refresh and secure credential storage.
- Integrate Copilot as an authentication option in AuthDialog; update AuthType enum and config.
- Refactor: Make key OpenAIContentGenerator methods protected for proper inheritance.
- Add tool calling support to Copilot responses; preserve tool_calls in conversion methods.
- Eliminate duplicate code, improve error handling, and ensure feature parity with OpenAI generators.

This commit enables direct Copilot authentication and usage, improves maintainability, and ensures consistent behavior across providers.

Co-authored-by: Qwen-Coder <qwen-coder@alibabacloud.com>
