### PR TITLE
Fix parallel tool use

### DIFF
--- a/packages/core/src/core/openaiContentGenerator.ts
+++ b/packages/core/src/core/openaiContentGenerator.ts
@@ -1283,7 +1283,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
             // Check if we already have a complete JSON object
             const currentArgs = accumulatedCall.arguments;
             const newArgs = toolCall.function.arguments;
-            
+
             // If current arguments already form a complete JSON and new arguments start a new object,
             // this indicates a new tool call with the same name
             let shouldReset = false;
@@ -1297,7 +1297,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
                 // Current arguments are not complete JSON, continue accumulating
               }
             }
-            
+
             if (shouldReset) {
               accumulatedCall.arguments = newArgs;
             } else {

--- a/packages/core/src/core/openaiContentGenerator.ts
+++ b/packages/core/src/core/openaiContentGenerator.ts
@@ -1249,7 +1249,11 @@ export class OpenAIContentGenerator implements ContentGenerator {
 
       // Handle text content
       if (choice.delta?.content) {
-        parts.push({ text: choice.delta.content });
+        if (typeof choice.delta.content === 'string') {
+          parts.push({ text: choice.delta.content });
+        } else {
+          parts.push({ text: choice.delta.content });
+        }
       }
 
       // Handle tool calls - only accumulate during streaming, emit when complete
@@ -1269,10 +1273,36 @@ export class OpenAIContentGenerator implements ContentGenerator {
             accumulatedCall.id = toolCall.id;
           }
           if (toolCall.function?.name) {
+            // If this is a new function name, reset the arguments
+            if (accumulatedCall.name !== toolCall.function.name) {
+              accumulatedCall.arguments = '';
+            }
             accumulatedCall.name = toolCall.function.name;
           }
           if (toolCall.function?.arguments) {
-            accumulatedCall.arguments += toolCall.function.arguments;
+            // Check if we already have a complete JSON object
+            const currentArgs = accumulatedCall.arguments;
+            const newArgs = toolCall.function.arguments;
+            
+            // If current arguments already form a complete JSON and new arguments start a new object,
+            // this indicates a new tool call with the same name
+            let shouldReset = false;
+            if (currentArgs && newArgs.trim().startsWith('{')) {
+              try {
+                JSON.parse(currentArgs);
+                // If we can parse current arguments as complete JSON and new args start with {,
+                // this is likely a new tool call
+                shouldReset = true;
+              } catch {
+                // Current arguments are not complete JSON, continue accumulating
+              }
+            }
+            
+            if (shouldReset) {
+              accumulatedCall.arguments = newArgs;
+            } else {
+              accumulatedCall.arguments += newArgs;
+            }
           }
         }
       }
@@ -1768,7 +1798,7 @@ export class OpenAIContentGenerator implements ContentGenerator {
         }
       }
 
-      messageContent = textParts.join('');
+      messageContent = textParts.join('').trimEnd();
     }
 
     const choice: OpenAIChoice = {


### PR DESCRIPTION
I think we have some issues regarding parallel tool use, the original `accumulatedCall` does not properly handle the situation where the tool calls include a series of same tool with different parameters.

p.s.: I still think the trailing whitespace issue should be handled, although I made the stupid mistake in https://github.com/QwenLM/qwen-code/pull/326 . In this PR, I add one `trimEnd` in line 1801.

```
messageContent = textParts.join('').trimEnd();
```

which will not remove the whitespace in streaming chunk, but also fix the trailing whitespace issue.

So @tanzhenxin @ranpox can you have a look? 