### PR TITLE
Fix /usage autocomplete suggestion

### DIFF
--- a/packages/cli/src/ui/hooks/useSlashCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.test.ts
@@ -116,8 +116,8 @@ describe('useSlashCompletion', () => {
 
       expect(result.current.suggestions).toEqual([
         {
-          label: 'stats',
-          value: 'stats',
+          label: 'usage',
+          value: 'usage',
           description: 'check session stats. Usage: /stats [model|tools]',
         },
       ]);

--- a/packages/cli/src/ui/hooks/useSlashCompletion.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.ts
@@ -159,11 +159,22 @@ export function useSlashCompletion(props: UseSlashCompletionProps): {
         }
       }
 
-      const finalSuggestions = potentialSuggestions.map((cmd) => ({
-        label: cmd.name,
-        value: cmd.name,
-        description: cmd.description,
-      }));
+      const finalSuggestions = potentialSuggestions.map((cmd) => {
+        // If the partial matches an altName, suggest the altName instead of the primary name
+        const matchingAltName = cmd.altNames?.find((alt) => alt.startsWith(partial));
+        if (matchingAltName && !cmd.name.startsWith(partial)) {
+          return {
+            label: matchingAltName,
+            value: matchingAltName,
+            description: cmd.description,
+          };
+        }
+        return {
+          label: cmd.name,
+          value: cmd.name,
+          description: cmd.description,
+        };
+      });
 
       setSuggestions(finalSuggestions);
       return;

--- a/packages/cli/src/ui/hooks/useSlashCompletion.ts
+++ b/packages/cli/src/ui/hooks/useSlashCompletion.ts
@@ -161,7 +161,9 @@ export function useSlashCompletion(props: UseSlashCompletionProps): {
 
       const finalSuggestions = potentialSuggestions.map((cmd) => {
         // If the partial matches an altName, suggest the altName instead of the primary name
-        const matchingAltName = cmd.altNames?.find((alt) => alt.startsWith(partial));
+        const matchingAltName = cmd.altNames?.find((alt) =>
+          alt.startsWith(partial),
+        );
         if (matchingAltName && !cmd.name.startsWith(partial)) {
           return {
             label: matchingAltName,


### PR DESCRIPTION
## Description
Fixes issue #389 where the /usage command existed but had no autocomplete suggestion.
## Problem
The /usage command is an alternative name (altNames) for the /stats command, but when users typed /usag or /usa, the autocomplete would only suggest stats or other commands instead of usage, making the command hard to discover.
## Solution
Modified the useSlashCompletion hook to suggest the matching altName when that's what the user is typing, rather than always suggesting the primary command name.
## Changes
- **Modified**: packages/cli/src/ui/hooks/useSlashCompletion.ts
  - Added logic to detect when a partial input matches an altName but not the primary name
  - In such cases, suggest the altName instead of the primary name
- **Updated**: packages/cli/src/ui/hooks/useSlashCompletion.test.ts
  - Updated test expectations to reflect the new behavior
  - Test now expects 'usage' suggestion when typing /usag instead of 'stats'
## Testing
- ✅ All existing tests pass
- ✅ New behavior verified: typing /u or /usa now suggests /usage
- ✅ Command functionality remains unchanged - /usage still works as expected
## Impact
Users can now discover the /usage command through autocomplete, improving the user experience and making the command more accessible.
Closes #389