### PR TITLE
feat: update /docs link

### DIFF
--- a/packages/cli/src/ui/commands/docsCommand.test.ts
+++ b/packages/cli/src/ui/commands/docsCommand.test.ts
@@ -35,7 +35,7 @@ describe('docsCommand', () => {
       throw new Error('docsCommand must have an action.');
     }
 
-    const docsUrl = 'https://github.com/QwenLM/qwen-code';
+    const docsUrl = 'https://qwenlm.github.io/qwen-code-docs/en';
 
     await docsCommand.action(mockContext, '');
 
@@ -57,7 +57,7 @@ describe('docsCommand', () => {
 
     // Simulate a sandbox environment
     process.env.SANDBOX = 'gemini-sandbox';
-    const docsUrl = 'https://github.com/QwenLM/qwen-code';
+    const docsUrl = 'https://qwenlm.github.io/qwen-code-docs/en';
 
     await docsCommand.action(mockContext, '');
 
@@ -80,7 +80,7 @@ describe('docsCommand', () => {
 
     // Simulate the specific 'sandbox-exec' environment
     process.env.SANDBOX = 'sandbox-exec';
-    const docsUrl = 'https://github.com/QwenLM/qwen-code';
+    const docsUrl = 'https://qwenlm.github.io/qwen-code-docs/en';
 
     await docsCommand.action(mockContext, '');
 

--- a/packages/cli/src/ui/commands/docsCommand.ts
+++ b/packages/cli/src/ui/commands/docsCommand.ts
@@ -18,7 +18,7 @@ export const docsCommand: SlashCommand = {
   description: 'open full Qwen Code documentation in your browser',
   kind: CommandKind.BUILT_IN,
   action: async (context: CommandContext): Promise<void> => {
-    const docsUrl = 'https://github.com/QwenLM/qwen-code';
+    const docsUrl = 'https://qwenlm.github.io/qwen-code-docs/en';
 
     if (process.env.SANDBOX && process.env.SANDBOX !== 'sandbox-exec') {
       context.ui.addItem(


### PR DESCRIPTION
## TLDR

Updated the `/docs` command to point to the new Qwen Code documentation [URL](https://qwenlm.github.io/qwen-code-docs/en) instead of the previous documentation link. 

## Linked issues / bugs

- Closes #361 
