### PR TITLE
fix: add explicit is_background param for shell tool

### DIFF
--- a/docs/tools/shell.md
+++ b/docs/tools/shell.md
@@ -13,15 +13,19 @@ Use `run_shell_command` to interact with the underlying system, run scripts, or 
 - `command` (string, required): The exact shell command to execute.
 - `description` (string, optional): A brief description of the command's purpose, which will be shown to the user.
 - `directory` (string, optional): The directory (relative to the project root) in which to execute the command. If not provided, the command runs in the project root.
-- `is_background` (boolean, optional): Whether to run the command in background. Default is false. Set to true for long-running processes like development servers, watchers, or daemons that should continue running without blocking further commands.
+- `is_background` (boolean, required): Whether to run the command in background. This parameter is required to ensure explicit decision-making about command execution mode. Set to true for long-running processes like development servers, watchers, or daemons that should continue running without blocking further commands. Set to false for one-time commands that should complete before proceeding.
 
 ## How to use `run_shell_command` with Qwen Code
 
 When using `run_shell_command`, the command is executed as a subprocess. You can control whether commands run in background or foreground using the `is_background` parameter, or by explicitly adding `&` to commands. The tool returns detailed information about the execution, including:
 
+### Required Background Parameter
+
+The `is_background` parameter is **required** for all command executions. This design ensures that the LLM (and users) must explicitly decide whether each command should run in the background or foreground, promoting intentional and predictable command execution behavior. By making this parameter mandatory, we avoid unintended fallback to foreground execution, which could block subsequent operations when dealing with long-running processes.
+
 ### Background vs Foreground Execution
 
-The tool intelligently handles background and foreground execution:
+The tool intelligently handles background and foreground execution based on your explicit choice:
 
 **Use background execution (`is_background: true`) for:**
 
@@ -31,7 +35,7 @@ The tool intelligently handles background and foreground execution:
 - Web servers: `python -m http.server`, `php -S localhost:8000`
 - Any command expected to run indefinitely until manually stopped
 
-**Use foreground execution (`is_background: false`, default) for:**
+**Use foreground execution (`is_background: false`) for:**
 
 - One-time commands: `ls`, `cat`, `grep`
 - Build commands: `npm run build`, `make`
@@ -54,45 +58,47 @@ The tool returns detailed information about the execution, including:
 
 Usage:
 
-```
+```bash
 run_shell_command(command="Your commands.", description="Your description of the command.", directory="Your execution directory.", is_background=false)
 ```
+
+**Note:** The `is_background` parameter is required and must be explicitly specified for every command execution.
 
 ## `run_shell_command` examples
 
 List files in the current directory:
 
-```
-run_shell_command(command="ls -la")
+```bash
+run_shell_command(command="ls -la", is_background=false)
 ```
 
 Run a script in a specific directory:
 
-```
-run_shell_command(command="./my_script.sh", directory="scripts", description="Run my custom script")
+```bash
+run_shell_command(command="./my_script.sh", directory="scripts", description="Run my custom script", is_background=false)
 ```
 
 Start a background development server (recommended approach):
 
-```
+```bash
 run_shell_command(command="npm run dev", description="Start development server in background", is_background=true)
 ```
 
 Start a background server (alternative with explicit &):
 
-```
-run_shell_command(command="npm run dev &", description="Start development server in background")
+```bash
+run_shell_command(command="npm run dev &", description="Start development server in background", is_background=false)
 ```
 
 Run a build command in foreground:
 
-```
+```bash
 run_shell_command(command="npm run build", description="Build the project", is_background=false)
 ```
 
 Start multiple background services:
 
-```
+```bash
 run_shell_command(command="docker-compose up", description="Start all services", is_background=true)
 ```
 
@@ -102,7 +108,7 @@ run_shell_command(command="docker-compose up", description="Start all services",
 - **Interactive commands:** Avoid commands that require interactive user input, as this can cause the tool to hang. Use non-interactive flags if available (e.g., `npm init -y`).
 - **Error handling:** Check the `Stderr`, `Error`, and `Exit Code` fields to determine if a command executed successfully.
 - **Background processes:** When `is_background=true` or when a command contains `&`, the tool will return immediately and the process will continue to run in the background. The `Background PIDs` field will contain the process ID of the background process.
-- **Background execution choices:** Use `is_background=true` for explicit control, or add `&` to the command for manual background execution. The `is_background` parameter provides clearer intent and automatically handles the background execution setup.
+- **Background execution choices:** The `is_background` parameter is required and provides explicit control over execution mode. You can also add `&` to the command for manual background execution, but the `is_background` parameter must still be specified. The parameter provides clearer intent and automatically handles the background execution setup.
 - **Command descriptions:** When using `is_background=true`, the command description will include a `[background]` indicator to clearly show the execution mode.
 
 ## Environment Variables

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -39,6 +39,7 @@ export interface ShellToolParams {
   command: string;
   description?: string;
   directory?: string;
+  is_background?: boolean;
 }
 
 class ShellToolInvocation extends BaseToolInvocation<
@@ -59,6 +60,10 @@ class ShellToolInvocation extends BaseToolInvocation<
     // note description is needed even if validation fails due to absolute path
     if (this.params.directory) {
       description += ` [in ${this.params.directory}]`;
+    }
+    // append background indicator
+    if (this.params.is_background) {
+      description += ` [background]`;
     }
     // append optional (description), replacing any line breaks with spaces
     if (this.params.description) {
@@ -117,12 +122,21 @@ class ShellToolInvocation extends BaseToolInvocation<
       // Add co-author to git commit commands
       const processedCommand = this.addCoAuthorToGitCommit(strippedCommand);
 
+      // Handle background execution based on is_background parameter
+      const shouldRunInBackground = this.params.is_background || false;
+      let finalCommand = processedCommand;
+
+      // If explicitly marked as background and doesn't already end with &, add it
+      if (shouldRunInBackground && !finalCommand.trim().endsWith('&')) {
+        finalCommand = finalCommand.trim() + ' &';
+      }
+
       // pgrep is not available on Windows, so we can't get background PIDs
       const commandToExecute = isWindows
-        ? processedCommand
+        ? finalCommand
         : (() => {
             // wrap command to append subprocess pids (via pgrep) to temporary file
-            let command = processedCommand.trim();
+            let command = finalCommand.trim();
             if (!command.endsWith('&')) command += ';';
             return `{ ${command} }; __code=$?; pgrep -g 0 >${tempFilePath} 2>&1; exit $__code;`;
           })();
@@ -343,7 +357,26 @@ export class ShellTool extends BaseDeclarativeTool<
     super(
       ShellTool.Name,
       'Shell',
-      `This tool executes a given shell command as \`bash -c <command>\`. Command can start background processes using \`&\`. Command is executed as a subprocess that leads its own process group. Command process group can be terminated as \`kill -- -PGID\` or signaled as \`kill -s SIGNAL -- -PGID\`.
+      `This tool executes a given shell command as \`bash -c <command>\`. 
+
+      **Background vs Foreground Execution:**
+      You should decide whether commands should run in background or foreground based on their nature:
+      
+      **Use background execution (is_background: true) for:**
+      - Long-running development servers: \`npm run start\`, \`npm run dev\`, \`yarn dev\`, \`bun run start\`
+      - Build watchers: \`npm run watch\`, \`webpack --watch\`
+      - Database servers: \`mongod\`, \`mysql\`, \`redis-server\`
+      - Web servers: \`python -m http.server\`, \`php -S localhost:8000\`
+      - Any command expected to run indefinitely until manually stopped
+      
+      **Use foreground execution (is_background: false, default) for:**
+      - One-time commands: \`ls\`, \`cat\`, \`grep\`
+      - Build commands: \`npm run build\`, \`make\`
+      - Installation commands: \`npm install\`, \`pip install\`
+      - Git operations: \`git commit\`, \`git push\`
+      - Test runs: \`npm test\`, \`pytest\`
+      
+      Command is executed as a subprocess that leads its own process group. Command process group can be terminated as \`kill -- -PGID\` or signaled as \`kill -s SIGNAL -- -PGID\`.
 
       The following information is returned:
 
@@ -364,6 +397,11 @@ export class ShellTool extends BaseDeclarativeTool<
             type: 'string',
             description: 'Exact bash command to execute as `bash -c <command>`',
           },
+          is_background: {
+            type: 'boolean',
+            description:
+              'Whether to run the command in background. Default is false. Set to true for long-running processes like development servers, watchers, or daemons that should continue running without blocking further commands.',
+          },
           description: {
             type: 'string',
             description:
@@ -375,7 +413,7 @@ export class ShellTool extends BaseDeclarativeTool<
               '(OPTIONAL) Directory to run the command in, if not the project root directory. Must be relative to the project root directory and must already exist.',
           },
         },
-        required: ['command'],
+        required: ['command', 'is_background'],
       },
       false, // output is not markdown
       true, // output can be updated

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -37,9 +37,9 @@ export const OUTPUT_UPDATE_INTERVAL_MS = 1000;
 
 export interface ShellToolParams {
   command: string;
+  is_background: boolean;
   description?: string;
   directory?: string;
-  is_background: boolean;
 }
 
 class ShellToolInvocation extends BaseToolInvocation<
@@ -122,8 +122,7 @@ class ShellToolInvocation extends BaseToolInvocation<
       // Add co-author to git commit commands
       const processedCommand = this.addCoAuthorToGitCommit(strippedCommand);
 
-      // Handle background execution based on is_background parameter
-      const shouldRunInBackground = this.params.is_background || false;
+      const shouldRunInBackground = this.params.is_background;
       let finalCommand = processedCommand;
 
       // If explicitly marked as background and doesn't already end with &, add it
@@ -369,7 +368,7 @@ export class ShellTool extends BaseDeclarativeTool<
       - Web servers: \`python -m http.server\`, \`php -S localhost:8000\`
       - Any command expected to run indefinitely until manually stopped
       
-      **Use foreground execution (is_background: false, default) for:**
+      **Use foreground execution (is_background: false) for:**
       - One-time commands: \`ls\`, \`cat\`, \`grep\`
       - Build commands: \`npm run build\`, \`make\`
       - Installation commands: \`npm install\`, \`pip install\`

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -39,7 +39,7 @@ export interface ShellToolParams {
   command: string;
   description?: string;
   directory?: string;
-  is_background?: boolean;
+  is_background: boolean;
 }
 
 class ShellToolInvocation extends BaseToolInvocation<


### PR DESCRIPTION
## TLDR

_**Experimental optimization requests for review and evaluation.**_

Added explicit `is_background` parameter to the shell tool to provide better control over background vs foreground execution of shell commands. This improvement makes it clearer when commands should run in the background (like development servers) versus foreground (like build commands), enhancing user experience and tool reliability.

## Dive Deeper

Added an explicit `is_background` boolean parameter to the shell tool for better control over command execution modes.

**What Changed:**

- New `is_background` parameter (defaults to false)
- Background commands show `[background]` indicator in descriptions
- Updated documentation with clear usage examples
- Maintains backward compatibility with existing `&` syntax

**Why This Matters:**

- Makes intent explicit: background for long-running processes (servers, watchers), foreground for one-time commands (build, lint, test)
- Improves user experience with clearer execution control
- Reduces confusion about when commands will block vs run in background

## Reviewer Test Plan

Create a simple Hono HTTP server project to test the new `is_background` parameter:

1. **Setup Test Project:**

   ```bash
   mkdir test-hono-server && cd test-hono-server
   npm init -y
   npm install hono @types/node typescript eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin
   ```

2. **Create Basic Files:**
   - `src/server.ts`: Simple Hono server
   - `eslint.config.js`: ESLint configuration
   - `tsconfig.json`: TypeScript configuration
   - `package.json`: Add dev/build scripts

3. **Test Foreground Commands (should wait for completion):**

   ```bash
   # These should block and show results
   run_shell_command(command="npx eslint src/", is_background=false, description="Run ESLint")
   run_shell_command(command="npx tsc --noEmit", is_background=false, description="TypeScript check")
   run_shell_command(command="npm run build", is_background=false, description="Build project")
   ```

4. **Test Background Commands (should return immediately):**

   ```bash
   # This should start server in background and return immediately
   run_shell_command(command="npm run dev", is_background=true, description="Start Hono dev server")
   ```

5. **Verify Behavior:**
   - Foreground commands should show complete output and wait for finish
   - Background command should return immediately with `[background]` indicator
   - Dev server should be accessible on localhost while other commands can run
   - Background processes should appear in Background PIDs field

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏   | 🪟   | 🐧   |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓   | ❓   |
| npx      | ✅   | ❓   | ❓   |
| Docker   | ❓   | ❓   | ❓   |
| Podman   | ❓   | -   | -   |
| Seatbelt | ❓   | -   | -   |

## Linked issues / bugs

Fixes #346 
