### PR TITLE
Fix race condition in submitQuery preventing tool response continuations

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -644,8 +644,9 @@ export const useGeminiStream = (
       options?: { isContinuation: boolean },
       prompt_id?: string,
     ) => {
-      // Prevent concurrent executions of submitQuery
-      if (isSubmittingQueryRef.current) {
+      // Prevent concurrent executions of submitQuery, but allow continuations
+      // which are part of the same logical flow (tool responses)
+      if (isSubmittingQueryRef.current && !options?.isContinuation) {
         return;
       }
 


### PR DESCRIPTION
### Problem

There was a subtle race condition in the `submitQuery` method that could break the conversation flow when tool calls failed synchronously (e.g., due to parameter validation errors).

#### The Race Condition Flow

1. **User submits query** → `submitQuery()` sets `isSubmittingQueryRef.current = true`
2. **Stream processing** → `processGeminiStreamEvents()` calls `scheduleToolCalls()`  
3. **Synchronous tool failure** → Tool validation fails immediately (not async)
4. **Immediate completion** → `scheduleToolCalls()` synchronously calls `handleCompletedTools()`
5. **Blocked continuation** → `handleCompletedTools()` tries to call `submitQuery()` with tool responses, but it's **blocked** because `isSubmittingQueryRef.current` is still `true`
6. **Flag reset too late** → Original `submitQuery()` eventually reaches `finally` block and resets flag, but the continuation call was already rejected
7. **Broken flow** → Conversation stops, tool responses never get sent to the model

#### When This Happens

This race condition occurs specifically when:
- Tool calls fail **synchronously** during validation (bad parameters, tool not found, etc.)
- The core scheduler completes immediately instead of going async
- `handleCompletedTools` executes before the original `submitQuery` finishes

### Why This Works

- **Original queries** are still properly serialized (prevents concurrent user submissions)
- **Tool response continuations** can proceed immediately as part of the same logical flow
- **No behavior change** for normal async tool execution paths
- **Fixes the deadlock** when tools complete synchronously

### Testing

This fix resolves cases where:
- Tool calls with invalid parameters would break the conversation
- Rapid tool failures would stop the response flow
- Users had to restart conversations after certain tool errors

## Linked issues / bugs

- Fixes #455 
- Fixes #448 
- Fixes #442 
- Fixes #425 

**Reminder: the model might still emits invalid tool call invocation, but now the model has a chance to recover from error instead of stopping execution loop immediately.**