### PR TITLE
chore: bump version to 0.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## 0.0.9
+
+- Synced upstream `gemini-cli` to v0.1.21.
+- Fixed token synchronization among multiple Qwen sessions.
+- Improved tool execution with early stop on invalid tool calls.
+- Added explicit `is_background` parameter for shell tool.
+- Enhanced memory management with sub-commands to switch between project and global memory operations.
+- Renamed `GEMINI_DIR` to `QWEN_DIR` for better branding consistency.
+- Added support for Qwen Markdown selection.
+- Fixed parallel tool usage and improved tool reliability.
+- Upgraded integration tests to use Vitest framework.
+- Enhanced VS Code IDE integration with launch configurations.
+- Added terminal setup command for Shift+Enter and Ctrl+Enter support.
+- Fixed GitHub Workflows configuration issues.
+- Improved settings directory and command descriptions.
+- Fixed locale handling in yargs configuration.
+- Added support for `trustedFolders.json` configuration file.
+- Enhanced cross-platform compatibility for sandbox build scripts.
+- Improved error handling and fixed ambiguous literals.
+- Updated documentation links and added IDE integration documentation.
+- Miscellaneous improvements and bug fixes.
+
 ## 0.0.8
 
 - Synced upstream `gemini-cli` to v0.1.19.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -41,7 +41,7 @@ For security and isolation, Qwen Code can be run inside a container. This is the
   You can run the published sandbox image directly. This is useful for environments where you only have Docker and want to run the CLI.
   ```bash
   # Run the published sandbox image
-  docker run --rm -it ghcr.io/qwenlm/qwen-code:0.0.8
+  docker run --rm -it ghcr.io/qwenlm/qwen-code:0.0.9
   ```
 - **Using the `--sandbox` flag:**
   If you have Qwen Code installed locally (using the standard installation described above), you can instruct it to run inside the sandbox container.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "workspaces": [
         "packages/*"
       ],
@@ -12336,7 +12336,7 @@
     },
     "packages/cli": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "@google/genai": "1.9.0",
         "@iarna/toml": "^2.2.5",
@@ -12520,7 +12520,7 @@
     },
     "packages/core": {
       "name": "@qwen-code/qwen-code-core",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "dependencies": {
         "@google/genai": "1.13.0",
         "@modelcontextprotocol/sdk": "^1.11.0",
@@ -12671,7 +12671,7 @@
     },
     "packages/test-utils": {
       "name": "@qwen-code/qwen-code-test-utils",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "Apache-2.0",
       "devDependencies": {
         "typescript": "^5.3.3"
@@ -12682,7 +12682,7 @@
     },
     "packages/vscode-ide-companion": {
       "name": "qwen-code-vscode-ide-companion",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.15.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "engines": {
     "node": ">=20.0.0"
   },
@@ -13,7 +13,7 @@
     "url": "git+https://github.com/QwenLM/qwen-code.git"
   },
   "config": {
-    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.0.8"
+    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.0.9"
   },
   "scripts": {
     "start": "node scripts/start.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Qwen Code",
   "repository": {
     "type": "git",
@@ -25,7 +25,7 @@
     "dist"
   ],
   "config": {
-    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.0.8"
+    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.0.9"
   },
   "dependencies": {
     "@google/genai": "1.9.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code-core",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Qwen Code Core",
   "repository": {
     "type": "git",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code-test-utils",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "main": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -2,7 +2,7 @@
   "name": "qwen-code-vscode-ide-companion",
   "displayName": "Qwen Code Companion",
   "description": "Enable Qwen Code with direct access to your VS Code workspace.",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "publisher": "qwenlm",
   "icon": "assets/icon.png",
   "repository": {


### PR DESCRIPTION
This is a follow-up update to release v0.0.9