### PR TITLE
ISSUE 232/345 Add install directions for homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ npm install
 npm install -g .
 ```
 
+### Install globally with Homebrew (macOS/Linux)
+
+```bash
+brew install qwen-code
+```
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## TLDR

Qwen Code is available in Homebrew for MacOS users. Update readme with instructions to install via brew.

## Dive Deeper

NA

## Reviewer Test Plan

NA - this is just the README

## Testing Matrix

NA - this is just the README

## Linked issues / bugs

- Resolves #232
- Resolves #345 (duplicate issue)

