### PR TITLE
Enable tool call type coersion

### DIFF
--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -8,7 +8,7 @@ import AjvPkg from 'ajv';
 // Ajv's ESM/CJS interop: use 'any' for compatibility as recommended by Ajv docs
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const AjvClass = (AjvPkg as any).default || AjvPkg;
-const ajValidator = new AjvClass();
+const ajValidator = new AjvClass({ coerceTypes: true });
 
 /**
  * Simple utility to validate objects against JSON Schemas
@@ -28,8 +28,27 @@ export class SchemaValidator {
     const validate = ajValidator.compile(schema);
     const valid = validate(data);
     if (!valid && validate.errors) {
-      return ajValidator.errorsText(validate.errors, { dataVar: 'params' });
+      // Find any True or False values and lowercase them
+      fixBooleanCasing(data as Record<string, unknown>);
+
+      const validate = ajValidator.compile(schema);
+      const valid = validate(data);
+
+      if (!valid && validate.errors) {
+        return ajValidator.errorsText(validate.errors, { dataVar: 'params' });
+      }
     }
     return null;
+  }
+}
+
+function fixBooleanCasing(data: Record<string, unknown>) {
+  for (const key of Object.keys(data)) {
+    if (!(key in data)) continue;
+
+    if (typeof data[key] === 'object') {
+      fixBooleanCasing(data[key] as Record<string, unknown>);
+    } else if (data[key] === 'True') data[key] = 'true';
+    else if (data[key] === 'False') data[key] = 'false';
   }
 }


### PR DESCRIPTION
## TLDR

Some models struggle to produce tool calls that conform to a strict JSON schema. Ajv has built-in support for coercing types to the expected ones. This PR just enables that functionality

## Dive Deeper

A tool call might have something like an offset provided as a string when it's supposed to be a number, or a boolean value wrapped in a string.

Input (incorrect):
```json
{
  "path": "foo.txt",
  "offset": "200",
  "limit": "100"
}
```

Corrected by coercion:
```json
{
  "path": "foo.txt",
  "offset": 200,
  "limit": 100
}
```

Ajv can automatically provide this coercion and update the values in the passed object.

https://ajv.js.org/guide/modifying-data.html#coercing-data-types

However I had to manually handle the cases when Qwen would provide `"False"` instead of `"false"` or `false`, but this is only done as a fallback.

## Reviewer Test Plan

Testing this can be tricky because we need to somehow get the model to use the wrong types in tool calls.

I managed this with the following prompt:
```
Use shell tool with `is_background: "False"` to run ls
```

Testing without this patch, this prompt fails the first tool call 

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  |:heavy_check_mark: |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Hopefully resolves #472
