### PR TITLE
fix: return the concat content for array type of function response.

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -594,10 +594,9 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { output: 'Tool execution succeeded.' },
+          response: { output: 'Some textual descriptionAnother text part' },
         },
       },
-      ...llmContent,
     ]);
   });
 
@@ -656,7 +655,7 @@ describe('convertToFunctionResponse', () => {
         functionResponse: {
           name: toolName,
           id: callId,
-          response: { output: 'Tool execution succeeded.' },
+          response: { output: '' },
         },
       },
     ]);

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -31,6 +31,7 @@ import {
 import type { Part, PartListUnion } from '@google/genai';
 import { getResponseTextFromParts } from '../utils/generateContentResponseUtilities.js';
 import type { ModifyContext } from '../tools/modifiable-tool.js';
+import { partToString } from '../utils/partUtils.js';
 import {
   isModifiableDeclarativeTool,
   modifyWithEditor,
@@ -174,12 +175,13 @@ export function convertToFunctionResponse(
   }
 
   if (Array.isArray(contentToProcess)) {
-    const functionResponse = createFunctionResponsePart(
-      callId,
-      toolName,
-      'Tool execution succeeded.',
-    );
-    return [functionResponse, ...toParts(contentToProcess)];
+    return [
+      createFunctionResponsePart(
+        callId,
+        toolName,
+        partToString(contentToProcess),
+      ),
+    ];
   }
 
   // After this point, contentToProcess is a single Part object.
@@ -218,18 +220,6 @@ export function convertToFunctionResponse(
   return [
     createFunctionResponsePart(callId, toolName, 'Tool execution succeeded.'),
   ];
-}
-
-function toParts(input: PartListUnion): Part[] {
-  const parts: Part[] = [];
-  for (const part of Array.isArray(input) ? input : [input]) {
-    if (typeof part === 'string') {
-      parts.push({ text: part });
-    } else if (part) {
-      parts.push(part);
-    }
-  }
-  return parts;
 }
 
 const createErrorResponse = (


### PR DESCRIPTION
The functionResponse should contain the content of the function response, not the generic message for default/unhandled case.

This change fixes commonly used tools like ReadManyFiles, making them correctly return the file contents to LLM.

## TLDR

This change fixes commonly used tools like ReadManyFiles, making them correctly return the file contents to LLM.

## Reviewer Test Plan

The difference before/after the change can be directly verified by
- open qwen-code in a directory containing some files.
- Write instructions like "read @file1 and @file2 to understand them".
- Catch and view the tool request to the server. 

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | 👍  | ❓  | ❓  |
| npx      | 👍  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |
