### PR TITLE
fix: unexpected re-auth when auth-token is expired

### DIFF
--- a/packages/core/src/qwen/qwenContentGenerator.ts
+++ b/packages/core/src/qwen/qwenContentGenerator.ts
@@ -153,17 +153,10 @@ export class QwenContentGenerator extends OpenAIContentGenerator {
       return await attemptOperation();
     } catch (error) {
       if (this.isAuthError(error)) {
-        try {
-          // Use SharedTokenManager to properly refresh and persist the token
-          // This ensures the refreshed token is saved to oauth_creds.json
-          await this.sharedManager.getValidCredentials(this.qwenClient, true);
-          // Retry the operation once with fresh credentials
-          return await attemptOperation();
-        } catch (_refreshError) {
-          throw new Error(
-            'Failed to obtain valid Qwen access token. Please re-authenticate.',
-          );
-        }
+        // Use SharedTokenManager to properly refresh and persist the token
+        // This ensures the refreshed token is saved to oauth_creds.json
+        await this.sharedManager.getValidCredentials(this.qwenClient, true);
+        return await attemptOperation();
       }
       throw error;
     }


### PR DESCRIPTION
# Fix: Unexpected Re-auth When Auth-token Is Expired

## TLDR

Fixed unexpected re-authentication prompts when starting qwen-code after auth tokens expire (6-hour validity). The issue was caused by SharedTokenManager incorrectly using empty credentials from qwenClient to determine if re-authentication was needed, always triggering re-auth when credentials were empty. This PR fixes the logic to properly check token validity from persistent storage.

修复了在认证令牌过期（6小时有效期）后启动qwen-code时出现的意外重新认证提示。问题是由于SharedTokenManager错误地使用qwenClient中的空凭据来判断是否需要重新认证，当凭据为空时总是触发重新认证。此PR修复了逻辑，使其能够正确地从持久化存储中检查令牌有效性。

## Dive Deeper

### Problem

Users were experiencing unexpected re-authentication prompts when starting qwen-code after auth tokens expired (6-hour validity period), even when valid refresh tokens were available in the persistent storage. The root cause was that SharedTokenManager incorrectly relied on qwenClient's empty credentials to determine authentication status. When starting a fresh qwen-code session, qwenClient has no loaded credentials, causing the system to assume no valid credentials exist and trigger unnecessary re-authentication instead of checking the persistent oauth_creds.json file.

用户在认证令牌过期（6小时有效期）后启动qwen-code时遇到意外的重新认证提示，即使持久化存储中有有效的刷新令牌。根本原因是SharedTokenManager错误地依赖qwenClient的空凭据来判断认证状态。当启动新的qwen-code会话时，qwenClient没有加载凭据，导致系统认为没有有效凭据存在，触发不必要的重新认证，而不是检查持久化的oauth_creds.json文件。

This was caused by:

这是由以下原因造成的：

1. **Empty credentials on startup** - Fresh sessions had no loaded credentials in qwenClient to evaluate
2. **Incorrect authentication logic** - System assumed empty qwenClient credentials meant no valid credentials
3. **Missing persistent storage check** - Failed to verify tokens in oauth_creds.json before prompting re-auth

1. **启动时凭据为空** - 新会话在qwenClient中没有加载的凭据可供评估
2. **错误的认证逻辑** - 系统假设qwenClient凭据为空意味着没有有效凭据
3. **缺少持久化存储检查** - 在提示重新认证之前未能验证oauth_creds.json中的令牌

https://github.com/QwenLM/qwen-code/blob/17fd843af6059876e7f2cfbcbf55a616a3f4d1f7/packages/core/src/qwen/sharedTokenManager.ts#L331
https://github.com/QwenLM/qwen-code/blob/17fd843af6059876e7f2cfbcbf55a616a3f4d1f7/packages/core/src/qwen/qwenOAuth2.ts#L252

### Solution

This PR implements several improvements to fix the empty credentials dependency issue and ensure proper token validation from persistent storage:

此PR实现了几个改进，以修复空凭据依赖问题并确保从持久化存储进行正确的令牌验证：

1. **Enhanced persistent storage checking** - Always verify credentials from oauth_creds.json file before determining authentication status, not just relying on qwenClient's loaded credentials

**增强的持久化存储检查** - 在确定认证状态之前始终从oauth_creds.json文件验证凭据，而不仅仅依赖qwenClient的已加载凭据

2. **Improved token refresh logic** - Eliminated fallback to potentially stale local credentials in `QwenOAuth2Client.getAccessToken()` to ensure single source of truth through `SharedTokenManager`

**改进的Token刷新逻辑** - 在`QwenOAuth2Client.getAccessToken()`中消除了对可能过时的本地凭据的回退，确保通过`SharedTokenManager`实现单一数据源

3. **Enhanced error handling** with new `CredentialsClearRequiredError` class for better handling of 400 status errors during token refresh

**增强的错误处理** - 新增`CredentialsClearRequiredError`类，更好地处理令牌刷新期间的400状态错误

5. **Improved SharedTokenManager synchronization**:
   - Added promise-based locking for file check operations to prevent concurrent access
   - Implemented atomic cache state updates to avoid inconsistent intermediate states
   - Added atomic file write operations using temporary files and rename for consistency
   - Enhanced stale lock removal with atomic rename operations

**改进的SharedTokenManager同步机制**：

- 为文件检查操作添加基于Promise的锁定，防止并发访问
- 实现原子缓存状态更新，避免不一致的中间状态
- 使用临时文件和重命名添加原子文件写入操作，确保一致性
- 通过原子重命名操作增强过期锁的移除


### Key Changes

- **QwenContentGenerator**: Simplified retry logic by removing nested try-catch and relying on SharedTokenManager
- **QwenOAuth2Client**: Removed `isTokenValid()` method and fallback logic to prevent race conditions
- **SharedTokenManager**: Added comprehensive synchronization mechanisms and atomic operations
- **Error Handling**: New error class for clearer credential clearing requirements

## Reviewer Test Plan

1. **Token Expiration Handling**:
   - Set up Qwen authentication with valid credentials
   - Wait for access token to expire (or manually modify expiry time in `oauth_creds.json`)
   - Run any Qwen command - should automatically refresh without prompting for re-auth
   - Verify that `oauth_creds.json` is updated with new tokens

2. **Multi-Session Race Conditions**:
   - Open multiple terminal sessions
   - Simultaneously run Qwen commands when tokens are expired
   - Verify only one session performs the refresh and others wait appropriately
   - Check that all sessions end up with the same valid credentials

3. **Invalid Refresh Token Handling**:
   - Manually corrupt the refresh token in `oauth_creds.json`
   - Run a Qwen command
   - Should prompt for re-authentication with clear error message
   - Verify credentials file is properly cleared

4. **File System Edge Cases**:
   - Test with concurrent file access (multiple processes)
   - Test with temporary file system issues (permissions, disk space)
   - Verify proper cleanup of temporary and lock files

## Testing Matrix

|          | 🍏   | 🪟   | 🐧   |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓   | ❓   |
| npx      | ✅   | ❓   | ❓   |
| Docker   | ❓   | ❓   | ❓   |
| Podman   | ❓   | -   | -   |
| Seatbelt | ❓   | -   | -   |


## Linked issues / bugs

Fixes #533 
Fixes #524 
Fixes #503 
Fixes #378 
