### PR TITLE
Try to use the model specified in --model even with OpenAI

### DIFF
--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -133,7 +133,7 @@ export function createContentGeneratorConfig(
   if (authType === AuthType.USE_OPENAI && openaiApiKey) {
     contentGeneratorConfig.apiKey = openaiApiKey;
     contentGeneratorConfig.baseUrl = openaiBaseUrl;
-    contentGeneratorConfig.model = openaiModel || DEFAULT_QWEN_MODEL;
+    contentGeneratorConfig.model = openaiModel || effectiveModel || DEFAULT_QWEN_MODEL;
 
     return contentGeneratorConfig;
   }
@@ -145,7 +145,7 @@ export function createContentGeneratorConfig(
 
     // Prefer to use qwen3-coder-plus as the default Qwen model if QWEN_MODEL is not set.
     contentGeneratorConfig.model =
-      process.env['QWEN_MODEL'] || DEFAULT_QWEN_MODEL;
+      process.env['QWEN_MODEL'] || effectiveModel || DEFAULT_QWEN_MODEL;
 
     return contentGeneratorConfig;
   }


### PR DESCRIPTION
## TLDR

When specifying an openai-base-url and an openai-api-key via CLI args, the CLI silently falls back to the default model, regardless of what model is specified using --model. This is fixed here, by using --model.

## Dive Deeper

Appearently, it is possible to specify all OpenAI API parameters using Environment variables, but this is undocumented. --help shows that --openai-api-key and --openai-base-url are supported as CLI parameters. Thus it would seem natural that the model is specified via --model. It turns out that it is entirely impossible to specify the model used when specifying openai-api-key etc and instead the code tries to infer the model from environment variables (`OPENAI_MODEL`) or falls back to the default model.

Another way to fix this would be to not provide a path through the CLI arguments to control OpenAI API usage but only through environment variables, and to adequately document this option.

## Reviewer Test Plan

Check that the following command works after the change
```
qwen --openai-api-key <openrouter key> --openai-base-url https://openrouter.ai/api/v1  --openai-model qwen/qwen3-coder-30b-a3b-instruct --openai-logging true -p "Write a hello world python program"
```
## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
