### PR TITLE
feat(cli): Allow SEATBELT profiles in user settings directory

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -77,6 +77,8 @@ Built-in profiles (set via `SEATBELT_PROFILE` env var):
 - `restrictive-open`: Strict restrictions, network allowed
 - `restrictive-closed`: Maximum restrictions
 
+For custom profiles, the system first looks for a file `.qwen/sandbox-macos-<profile>.sb` under your project settings directory. If not found there, it will check for the file in your user settings directory at `~/.qwen/sandbox-macos-<profile>.sb`.
+
 ### Custom Sandbox Flags
 
 For container-based sandboxing, you can inject custom flags into the `docker` or `podman` command using the `SANDBOX_FLAGS` environment variable. This is useful for advanced configurations, such as disabling security features for specific use cases.

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -209,6 +209,13 @@ export async function start_sandbox(
           `sandbox-macos-${profile}.sb`,
         );
       }
+      // if not found, look for file under user settings directory
+      if (!fs.existsSync(profileFile)) {
+        profileFile = path.join(
+          USER_SETTINGS_DIR,
+          `sandbox-macos-${profile}.sb`,
+        );
+      }
       if (!fs.existsSync(profileFile)) {
         console.error(
           `ERROR: missing macos seatbelt profile file '${profileFile}'`,


### PR DESCRIPTION
### Description: 

This PR enhances the SEATBELT profile resolution logic to support both project-local and global user profiles. Specifically, the resolver now: 

* First checks for profile files in the project’s .qwen/ directory.
* If not found, falls back to the user’s global .qwen/ directory (~/.qwen/ by default).
     
This change enables users to define and reuse global SEATBELT sandbox profiles across multiple projects — eliminating the need to duplicate profile files in every project directory. 

### Background: 

Currently, SEATBELT supports the following predefined profiles: 

-    permissive-closed
-    permissive-open
-    permissive-proxied
-    restrictive-closed
-    restrictive-proxied
     
As documented in `docs/sandbox.md`, users may also define custom profiles via the `SEATBELT_PROFILE` environment variable. However, the system previously only looked for custom profile files (e.g., `sandbox-macos-<profile>.sb`) within `<project>/.qwen/name.sb`. If the file was absent, resolution would fail — even if a valid profile existed in the user’s global settings directory. 

### Impact: 

With this change, users can now place commonly used sandbox profiles in their global `~/.qwen/` directory and reference them from any project — streamlining setup and reducing redundancy. 

## Reviewer Test Plan

This only applies to macOS (because Seatbelt).

- Write a seatbelt profile in your `~/.qwen`. You may copy and modify one e.g. `packages/cli/src/utils/sandbox-macos-permissive-open.sb` into `~/.qwen/sandbox-macos-custom.sb`,
- Launch qwen with `SEATBELT_PROFILE=custom qwen -s`,
- It should now show `macOS Seatbelt (custom)` in the status.

Fixes #559