### PR TITLE
fix: update OpenAIKeyPrompt test to expect Alibaba Cloud API URL

### DIFF
--- a/packages/cli/src/ui/components/OpenAIKeyPrompt.test.tsx
+++ b/packages/cli/src/ui/components/OpenAIKeyPrompt.test.tsx
@@ -18,7 +18,9 @@ describe('OpenAIKeyPrompt', () => {
     );
 
     expect(lastFrame()).toContain('OpenAI Configuration Required');
-    expect(lastFrame()).toContain('https://platform.openai.com/api-keys');
+    expect(lastFrame()).toContain(
+      'https://bailian.console.aliyun.com/?tab=model#/api-key',
+    );
     expect(lastFrame()).toContain(
       'Press Enter to continue, Tab/↑↓ to navigate, Esc to cancel',
     );


### PR DESCRIPTION
- Fixes failing test in OpenAIKeyPrompt.test.tsx
- Aligns test with actual implementation that uses Alibaba Cloud API
