### PR TITLE
fix: clear saved creds when switching authType

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -321,7 +321,8 @@ const ToolInfo: React.FC<ToolInfo> = ({
       >
         <Text color={nameColor} bold>
           {name}
-        </Text>{' '}
+        </Text>
+        <Text> </Text>
         <Text color={Colors.Gray}>{description}</Text>
       </Text>
     </Box>

--- a/packages/core/src/code_assist/oauth2.test.ts
+++ b/packages/core/src/code_assist/oauth2.test.ts
@@ -548,6 +548,17 @@ describe('oauth2', () => {
       expect(updatedAccountData.old).toContain('test@example.com');
     });
 
+    it('should handle Qwen module clearing gracefully', async () => {
+      // This test verifies that clearCachedCredentialFile doesn't throw
+      // when Qwen modules are available and can be cleared
+
+      // Since dynamic imports in tests are complex, we'll just verify
+      // that the function completes without error and doesn't throw
+      await expect(clearCachedCredentialFile()).resolves.not.toThrow();
+
+      // The actual Qwen clearing logic is tested separately in the Qwen module tests
+    });
+
     it('should clear the in-memory OAuth client cache', async () => {
       const mockSetCredentials = vi.fn();
       const mockGetAccessToken = vi

--- a/packages/core/src/code_assist/oauth2.ts
+++ b/packages/core/src/code_assist/oauth2.ts
@@ -402,6 +402,25 @@ export async function clearCachedCredentialFile() {
     await clearCachedGoogleAccount();
     // Clear the in-memory OAuth client cache to force re-authentication
     clearOauthClientCache();
+
+    /**
+     * Also clear Qwen SharedTokenManager cache and credentials file to prevent stale credentials
+     * when switching between auth types
+     * TODO: We do not depend on code_assist, we'll have to build an independent auth-cleaning procedure.
+     */
+    try {
+      const { SharedTokenManager } = await import(
+        '../qwen/sharedTokenManager.js'
+      );
+      const { clearQwenCredentials } = await import('../qwen/qwenOAuth2.js');
+
+      const sharedManager = SharedTokenManager.getInstance();
+      sharedManager.clearCache();
+
+      await clearQwenCredentials();
+    } catch (qwenError) {
+      console.debug('Could not clear Qwen credentials:', qwenError);
+    }
   } catch (e) {
     console.error('Failed to clear cached credentials:', e);
   }


### PR DESCRIPTION
## TLDR

Previous versions did not properly clear the qwen-oauth credentials both in the file system and memory, resulting in users not being prompted to log in again in a timely manner when switching auth type.

## Reviewer Test Plan

Will be prompted to log in via Qwen-OAuth whenever switching back from OpenAI.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

None