### PR TITLE
add smart-edit

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -18,6 +18,7 @@ import { ReadFileTool } from '../tools/read-file.js';
 import { GrepTool } from '../tools/grep.js';
 import { GlobTool } from '../tools/glob.js';
 import { EditTool } from '../tools/edit.js';
+import { SmartEditTool } from '../tools/smart-edit.js';
 import { ShellTool } from '../tools/shell.js';
 import { WriteFileTool } from '../tools/write-file.js';
 import { WebFetchTool } from '../tools/web-fetch.js';
@@ -233,6 +234,7 @@ export interface ConfigParameters {
   trustedFolder?: boolean;
   shouldUseNodePtyShell?: boolean;
   skipNextSpeakerCheck?: boolean;
+  useSmartEdit?: boolean;
 }
 
 export class Config {
@@ -318,6 +320,7 @@ export class Config {
   private readonly trustedFolder: boolean | undefined;
   private readonly shouldUseNodePtyShell: boolean;
   private readonly skipNextSpeakerCheck: boolean;
+  private readonly useSmartEdit: boolean;
   private initialized: boolean = false;
 
   constructor(params: ConfigParameters) {
@@ -399,6 +402,7 @@ export class Config {
     this.trustedFolder = params.trustedFolder;
     this.shouldUseNodePtyShell = params.shouldUseNodePtyShell ?? false;
     this.skipNextSpeakerCheck = params.skipNextSpeakerCheck ?? false;
+    this.useSmartEdit = params.useSmartEdit ?? true;
 
     // Web search
     this.tavilyApiKey = params.tavilyApiKey;
@@ -861,6 +865,10 @@ export class Config {
     return this.skipNextSpeakerCheck;
   }
 
+  getUseSmartEdit(): boolean {
+    return this.useSmartEdit;
+  }
+
   async getGitService(): Promise<GitService> {
     if (!this.gitService) {
       this.gitService = new GitService(this.targetDir);
@@ -914,7 +922,11 @@ export class Config {
     registerCoreTool(ReadFileTool, this);
     registerCoreTool(GrepTool, this);
     registerCoreTool(GlobTool, this);
-    registerCoreTool(EditTool, this);
+    if (this.getUseSmartEdit()) {
+      registerCoreTool(SmartEditTool, this);
+    } else {
+      registerCoreTool(EditTool, this);
+    }
     registerCoreTool(WriteFileTool, this);
     registerCoreTool(WebFetchTool, this);
     registerCoreTool(ReadManyFilesTool, this);

--- a/packages/core/src/tools/smart-edit.test.ts
+++ b/packages/core/src/tools/smart-edit.test.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SmartEditTool } from './smart-edit.js';
+
+// This is a simple test to verify that the SmartEditTool can be imported without errors
+console.log('SmartEditTool imported successfully:', SmartEditTool);

--- a/packages/core/src/tools/smart-edit.ts
+++ b/packages/core/src/tools/smart-edit.ts
@@ -1,0 +1,817 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as Diff from 'diff';
+import {
+  BaseDeclarativeTool,
+  Kind,
+  type ToolCallConfirmationDetails,
+  ToolConfirmationOutcome,
+  type ToolEditConfirmationDetails,
+  type ToolInvocation,
+  type ToolLocation,
+  type ToolResult,
+  type ToolResultDisplay,
+} from './tools.js';
+import { ToolErrorType } from './tool-error.js';
+import { makeRelative, shortenPath } from '../utils/paths.js';
+import { isNodeError } from '../utils/errors.js';
+import { type Config, ApprovalMode } from '../config/config.js';
+import { DEFAULT_DIFF_OPTIONS, getDiffStat } from './diffOptions.js';
+import { ReadFileTool } from './read-file.js';
+import {
+  type ModifiableDeclarativeTool,
+  type ModifyContext,
+} from './modifiable-tool.js';
+import { FixLLMEditWithInstruction } from '../utils/llm-edit-fixer.js';
+import { applyReplacement } from './edit.js';
+import { safeLiteralReplace } from '../utils/textUtils.js';
+
+interface ReplacementContext {
+  params: SmartEditToolParams;
+  currentContent: string;
+  abortSignal: AbortSignal;
+}
+
+interface ReplacementResult {
+  newContent: string;
+  occurrences: number;
+  finalOldString: string;
+  finalNewString: string;
+}
+
+function restoreTrailingNewline(
+  originalContent: string,
+  modifiedContent: string,
+): string {
+  const hadTrailingNewline = originalContent.endsWith('\n');
+  if (hadTrailingNewline && !modifiedContent.endsWith('\n')) {
+    return modifiedContent + '\n';
+  } else if (!hadTrailingNewline && modifiedContent.endsWith('\n')) {
+    return modifiedContent.replace(/\n$/, '');
+  }
+  return modifiedContent;
+}
+
+async function calculateExactReplacement(
+  context: ReplacementContext,
+): Promise<ReplacementResult | null> {
+  const { currentContent, params } = context;
+  const { old_string, new_string } = params;
+
+  const normalizedCode = currentContent;
+  const normalizedSearch = old_string.replace(/\r\n/g, '\n');
+  const normalizedReplace = new_string.replace(/\r\n/g, '\n');
+
+  const exactOccurrences = normalizedCode.split(normalizedSearch).length - 1;
+  if (exactOccurrences > 0) {
+    let modifiedCode = safeLiteralReplace(
+      normalizedCode,
+      normalizedSearch,
+      normalizedReplace,
+    );
+    modifiedCode = restoreTrailingNewline(currentContent, modifiedCode);
+    return {
+      newContent: modifiedCode,
+      occurrences: exactOccurrences,
+      finalOldString: normalizedSearch,
+      finalNewString: normalizedReplace,
+    };
+  }
+
+  return null;
+}
+
+async function calculateFlexibleReplacement(
+  context: ReplacementContext,
+): Promise<ReplacementResult | null> {
+  const { currentContent, params } = context;
+  const { old_string, new_string } = params;
+
+  const normalizedCode = currentContent;
+  const normalizedSearch = old_string.replace(/\r\n/g, '\n');
+  const normalizedReplace = new_string.replace(/\r\n/g, '\n');
+
+  const sourceLines = normalizedCode.match(/.*(?:\n|$)/g)?.slice(0, -1) ?? [];
+  const searchLinesStripped = normalizedSearch
+    .split('\n')
+    .map((line: string) => line.trim());
+  const replaceLines = normalizedReplace.split('\n');
+
+  let flexibleOccurrences = 0;
+  let i = 0;
+  while (i <= sourceLines.length - searchLinesStripped.length) {
+    const window = sourceLines.slice(i, i + searchLinesStripped.length);
+    const windowStripped = window.map((line: string) => line.trim());
+    const isMatch = windowStripped.every(
+      (line: string, index: number) => line === searchLinesStripped[index],
+    );
+
+    if (isMatch) {
+      flexibleOccurrences++;
+      const firstLineInMatch = window[0];
+      const indentationMatch = firstLineInMatch.match(/^(\s*)/);
+      const indentation = indentationMatch ? indentationMatch[1] : '';
+      const newBlockWithIndent = replaceLines.map(
+        (line: string) => `${indentation}${line}`,
+      );
+      sourceLines.splice(
+        i,
+        searchLinesStripped.length,
+        newBlockWithIndent.join('\n'),
+      );
+      i += replaceLines.length;
+    } else {
+      i++;
+    }
+  }
+
+  if (flexibleOccurrences > 0) {
+    let modifiedCode = sourceLines.join('');
+    modifiedCode = restoreTrailingNewline(currentContent, modifiedCode);
+    return {
+      newContent: modifiedCode,
+      occurrences: flexibleOccurrences,
+      finalOldString: normalizedSearch,
+      finalNewString: normalizedReplace,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Detects the line ending style of a string.
+ * @param content The string content to analyze.
+ * @returns '\r\n' for Windows-style, '\n' for Unix-style.
+ */
+function detectLineEnding(content: string): '\r\n' | '\n' {
+  // If a Carriage Return is found, assume Windows-style endings.
+  // This is a simple but effective heuristic.
+  return content.includes('\r\n') ? '\r\n' : '\n';
+}
+
+export async function calculateReplacement(
+  context: ReplacementContext,
+): Promise<ReplacementResult> {
+  const { currentContent, params } = context;
+  const { old_string, new_string } = params;
+  const normalizedSearch = old_string.replace(/\r\n/g, '\n');
+  const normalizedReplace = new_string.replace(/\r\n/g, '\n');
+
+  if (normalizedSearch === '') {
+    return {
+      newContent: currentContent,
+      occurrences: 0,
+      finalOldString: normalizedSearch,
+      finalNewString: normalizedReplace,
+    };
+  }
+
+  const exactResult = await calculateExactReplacement(context);
+  if (exactResult) {
+    return exactResult;
+  }
+
+  const flexibleResult = await calculateFlexibleReplacement(context);
+  if (flexibleResult) {
+    return flexibleResult;
+  }
+
+  return {
+    newContent: currentContent,
+    occurrences: 0,
+    finalOldString: normalizedSearch,
+    finalNewString: normalizedReplace,
+  };
+}
+
+export function getErrorReplaceResult(
+  params: SmartEditToolParams,
+  occurrences: number,
+  expectedReplacements: number,
+  finalOldString: string,
+  finalNewString: string,
+) {
+  let error: { display: string; raw: string; type: ToolErrorType } | undefined =
+    undefined;
+  if (occurrences === 0) {
+    error = {
+      display: `Failed to edit, could not find the string to replace.`,
+      raw: `Failed to edit, 0 occurrences found for old_string (${finalOldString}). Original old_string was (${params.old_string}) in ${params.file_path}. No edits made. The exact text in old_string was not found. Ensure you're not escaping content incorrectly and check whitespace, indentation, and context. Use ${ReadFileTool.Name} tool to verify.`,
+      type: ToolErrorType.EDIT_NO_OCCURRENCE_FOUND,
+    };
+  } else if (occurrences !== expectedReplacements) {
+    const occurrenceTerm =
+      expectedReplacements === 1 ? 'occurrence' : 'occurrences';
+
+    error = {
+      display: `Failed to edit, expected ${expectedReplacements} ${occurrenceTerm} but found ${occurrences}.`,
+      raw: `Failed to edit, Expected ${expectedReplacements} ${occurrenceTerm} but found ${occurrences} for old_string in file: ${params.file_path}`,
+      type: ToolErrorType.EDIT_EXPECTED_OCCURRENCE_MISMATCH,
+    };
+  } else if (finalOldString === finalNewString) {
+    error = {
+      display: `No changes to apply. The old_string and new_string are identical.`,
+      raw: `No changes to apply. The old_string and new_string are identical in file: ${params.file_path}`,
+      type: ToolErrorType.EDIT_NO_CHANGE,
+    };
+  }
+  return error;
+}
+
+/**
+ * Parameters for the Edit tool
+ */
+export interface SmartEditToolParams {
+  /**
+   * The absolute path to the file to modify
+   */
+  file_path: string;
+
+  /**
+   * The text to replace
+   */
+  old_string: string;
+
+  /**
+   * The text to replace it with
+   */
+  new_string: string;
+
+  /**
+   * The instruction for what needs to be done.
+   */
+  instruction: string;
+
+  /**
+   * Whether the edit was modified manually by the user.
+   */
+  modified_by_user?: boolean;
+
+  /**
+   * Initially proposed string.
+   */
+  ai_proposed_string?: string;
+}
+
+interface CalculatedEdit {
+  currentContent: string | null;
+  newContent: string;
+  occurrences: number;
+  error?: { display: string; raw: string; type: ToolErrorType };
+  isNewFile: boolean;
+  originalLineEnding: '\r\n' | '\n';
+}
+
+class EditToolInvocation
+  implements ToolInvocation<SmartEditToolParams, ToolResult>
+{
+  constructor(
+    private readonly config: Config,
+    public params: SmartEditToolParams,
+  ) {}
+
+  toolLocations(): ToolLocation[] {
+    return [{ path: this.params.file_path }];
+  }
+
+  private async attemptSelfCorrection(
+    params: SmartEditToolParams,
+    currentContent: string,
+    initialError: { display: string; raw: string; type: ToolErrorType },
+    abortSignal: AbortSignal,
+    originalLineEnding: '\r\n' | '\n',
+  ): Promise<CalculatedEdit> {
+    const fixedEdit = await FixLLMEditWithInstruction(
+      params.instruction,
+      params.old_string,
+      params.new_string,
+      initialError.raw,
+      currentContent,
+      this.config.getGeminiClient(),
+      abortSignal,
+    );
+
+    if (fixedEdit.noChangesRequired) {
+      return {
+        currentContent,
+        newContent: currentContent,
+        occurrences: 0,
+        isNewFile: false,
+        error: {
+          display: `No changes required. The file already meets the specified conditions.`,
+          raw: `A secondary check determined that no changes were necessary to fulfill the instruction. Explanation: ${fixedEdit.explanation}. Original error with the parameters given: ${initialError.raw}`,
+          type: ToolErrorType.EDIT_NO_CHANGE,
+        },
+        originalLineEnding,
+      };
+    }
+
+    const secondAttemptResult = await calculateReplacement({
+      params: {
+        ...params,
+        old_string: fixedEdit.search,
+        new_string: fixedEdit.replace,
+      },
+      currentContent,
+      abortSignal,
+    });
+
+    const secondError = getErrorReplaceResult(
+      params,
+      secondAttemptResult.occurrences,
+      1, // expectedReplacements is always 1 for smart_edit
+      secondAttemptResult.finalOldString,
+      secondAttemptResult.finalNewString,
+    );
+
+    if (secondError) {
+      // The fix failed, return the original error
+      return {
+        currentContent,
+        newContent: currentContent,
+        occurrences: 0,
+        isNewFile: false,
+        error: initialError,
+        originalLineEnding,
+      };
+    }
+
+    return {
+      currentContent,
+      newContent: secondAttemptResult.newContent,
+      occurrences: secondAttemptResult.occurrences,
+      isNewFile: false,
+      error: undefined,
+      originalLineEnding,
+    };
+  }
+
+  /**
+   * Calculates the potential outcome of an edit operation.
+   * @param params Parameters for the edit operation
+   * @returns An object describing the potential edit outcome
+   * @throws File system errors if reading the file fails unexpectedly (e.g., permissions)
+   */
+  private async calculateEdit(
+    params: SmartEditToolParams,
+    abortSignal: AbortSignal,
+  ): Promise<CalculatedEdit> {
+    const expectedReplacements = 1;
+    let currentContent: string | null = null;
+    let fileExists = false;
+    let originalLineEnding: '\r\n' | '\n' = '\n'; // Default for new files
+
+    try {
+      currentContent = await this.config
+        .getFileSystemService()
+        .readTextFile(params.file_path);
+      originalLineEnding = detectLineEnding(currentContent);
+      currentContent = currentContent.replace(/\r\n/g, '\n');
+      fileExists = true;
+    } catch (err: unknown) {
+      if (!isNodeError(err) || err.code !== 'ENOENT') {
+        throw err;
+      }
+      fileExists = false;
+    }
+
+    const isNewFile = params.old_string === '' && !fileExists;
+
+    if (isNewFile) {
+      return {
+        currentContent,
+        newContent: params.new_string,
+        occurrences: 1,
+        isNewFile: true,
+        error: undefined,
+        originalLineEnding,
+      };
+    }
+
+    // after this point, it's not a new file/edit
+    if (!fileExists) {
+      return {
+        currentContent,
+        newContent: '',
+        occurrences: 0,
+        isNewFile: false,
+        error: {
+          display: `File not found. Cannot apply edit. Use an empty old_string to create a new file.`,
+          raw: `File not found: ${params.file_path}`,
+          type: ToolErrorType.FILE_NOT_FOUND,
+        },
+        originalLineEnding,
+      };
+    }
+
+    if (currentContent === null) {
+      return {
+        currentContent,
+        newContent: '',
+        occurrences: 0,
+        isNewFile: false,
+        error: {
+          display: `Failed to read content of file.`,
+          raw: `Failed to read content of existing file: ${params.file_path}`,
+          type: ToolErrorType.READ_CONTENT_FAILURE,
+        },
+        originalLineEnding,
+      };
+    }
+
+    if (params.old_string === '') {
+      return {
+        currentContent,
+        newContent: currentContent,
+        occurrences: 0,
+        isNewFile: false,
+        error: {
+          display: `Failed to edit. Attempted to create a file that already exists.`,
+          raw: `File already exists, cannot create: ${params.file_path}`,
+          type: ToolErrorType.ATTEMPT_TO_CREATE_EXISTING_FILE,
+        },
+        originalLineEnding,
+      };
+    }
+
+    const replacementResult = await calculateReplacement({
+      params,
+      currentContent,
+      abortSignal,
+    });
+
+    const initialError = getErrorReplaceResult(
+      params,
+      replacementResult.occurrences,
+      expectedReplacements,
+      replacementResult.finalOldString,
+      replacementResult.finalNewString,
+    );
+
+    if (!initialError) {
+      return {
+        currentContent,
+        newContent: replacementResult.newContent,
+        occurrences: replacementResult.occurrences,
+        isNewFile: false,
+        error: undefined,
+        originalLineEnding,
+      };
+    }
+
+    // If there was an error, try to self-correct.
+    return this.attemptSelfCorrection(
+      params,
+      currentContent,
+      initialError,
+      abortSignal,
+      originalLineEnding,
+    );
+  }
+
+  /**
+   * Handles the confirmation prompt for the Edit tool in the CLI.
+   * It needs to calculate the diff to show the user.
+   */
+  async shouldConfirmExecute(
+    abortSignal: AbortSignal,
+  ): Promise<ToolCallConfirmationDetails | false> {
+    if (this.config.getApprovalMode() === ApprovalMode.AUTO_EDIT) {
+      return false;
+    }
+
+    let editData: CalculatedEdit;
+    try {
+      editData = await this.calculateEdit(this.params, abortSignal);
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      console.log(`Error preparing edit: ${errorMsg}`);
+      return false;
+    }
+
+    if (editData.error) {
+      console.log(`Error: ${editData.error.display}`);
+      return false;
+    }
+
+    const fileName = path.basename(this.params.file_path);
+    const fileDiff = Diff.createPatch(
+      fileName,
+      editData.currentContent ?? '',
+      editData.newContent,
+      'Current',
+      'Proposed',
+      DEFAULT_DIFF_OPTIONS,
+    );
+
+    const confirmationDetails: ToolEditConfirmationDetails = {
+      type: 'edit',
+      title: `Confirm Edit: ${shortenPath(makeRelative(this.params.file_path, this.config.getTargetDir()))}`,
+      fileName,
+      filePath: this.params.file_path,
+      fileDiff,
+      originalContent: editData.currentContent,
+      newContent: editData.newContent,
+      onConfirm: async (outcome: ToolConfirmationOutcome) => {
+        if (outcome === ToolConfirmationOutcome.ProceedAlways) {
+          this.config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+        }
+      },
+    };
+    return confirmationDetails;
+  }
+
+  getDescription(): string {
+    const relativePath = makeRelative(
+      this.params.file_path,
+      this.config.getTargetDir(),
+    );
+    if (this.params.old_string === '') {
+      return `Create ${shortenPath(relativePath)}`;
+    }
+
+    const oldStringSnippet =
+      this.params.old_string.split('\n')[0].substring(0, 30) +
+      (this.params.old_string.length > 30 ? '...' : '');
+    const newStringSnippet =
+      this.params.new_string.split('\n')[0].substring(0, 30) +
+      (this.params.new_string.length > 30 ? '...' : '');
+
+    if (this.params.old_string === this.params.new_string) {
+      return `No file changes to ${shortenPath(relativePath)}`;
+    }
+    return `${shortenPath(relativePath)}: ${oldStringSnippet} => ${newStringSnippet}`;
+  }
+
+  /**
+   * Executes the edit operation with the given parameters.
+   * @param params Parameters for the edit operation
+   * @returns Result of the edit operation
+   */
+  async execute(signal: AbortSignal): Promise<ToolResult> {
+    let editData: CalculatedEdit;
+    try {
+      editData = await this.calculateEdit(this.params, signal);
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      return {
+        llmContent: `Error preparing edit: ${errorMsg}`,
+        returnDisplay: `Error preparing edit: ${errorMsg}`,
+        error: {
+          message: errorMsg,
+          type: ToolErrorType.EDIT_PREPARATION_FAILURE,
+        },
+      };
+    }
+
+    if (editData.error) {
+      return {
+        llmContent: editData.error.raw,
+        returnDisplay: `Error: ${editData.error.display}`,
+        error: {
+          message: editData.error.raw,
+          type: editData.error.type,
+        },
+      };
+    }
+
+    try {
+      this.ensureParentDirectoriesExist(this.params.file_path);
+      let finalContent = editData.newContent;
+
+      // Restore original line endings if they were CRLF
+      if (!editData.isNewFile && editData.originalLineEnding === '\r\n') {
+        finalContent = finalContent.replace(/\n/g, '\r\n');
+      }
+      await this.config
+        .getFileSystemService()
+        .writeTextFile(this.params.file_path, finalContent);
+
+      let displayResult: ToolResultDisplay;
+      if (editData.isNewFile) {
+        displayResult = `Created ${shortenPath(makeRelative(this.params.file_path, this.config.getTargetDir()))}`;
+      } else {
+        // Generate diff for display, even though core logic doesn't technically need it
+        // The CLI wrapper will use this part of the ToolResult
+        const fileName = path.basename(this.params.file_path);
+        const fileDiff = Diff.createPatch(
+          fileName,
+          editData.currentContent ?? '', // Should not be null here if not isNewFile
+          editData.newContent,
+          'Current',
+          'Proposed',
+          DEFAULT_DIFF_OPTIONS,
+        );
+        const originallyProposedContent =
+          this.params.ai_proposed_string || this.params.new_string;
+        const diffStat = getDiffStat(
+          fileName,
+          editData.currentContent ?? '',
+          originallyProposedContent,
+          this.params.new_string,
+        );
+        displayResult = {
+          fileDiff,
+          fileName,
+          originalContent: editData.currentContent,
+          newContent: editData.newContent,
+          diffStat,
+        };
+      }
+
+      const llmSuccessMessageParts = [
+        editData.isNewFile
+          ? `Created new file: ${this.params.file_path} with provided content.`
+          : `Successfully modified file: ${this.params.file_path} (${editData.occurrences} replacements).`,
+      ];
+      if (this.params.modified_by_user) {
+        llmSuccessMessageParts.push(
+          `User modified the \`new_string\` content to be: ${this.params.new_string}.`,
+        );
+      }
+
+      return {
+        llmContent: llmSuccessMessageParts.join(' '),
+        returnDisplay: displayResult,
+      };
+    } catch (error) {
+      const errorMsg = error instanceof Error ? error.message : String(error);
+      return {
+        llmContent: `Error executing edit: ${errorMsg}`,
+        returnDisplay: `Error writing file: ${errorMsg}`,
+        error: {
+          message: errorMsg,
+          type: ToolErrorType.FILE_WRITE_FAILURE,
+        },
+      };
+    }
+  }
+
+  /**
+   * Creates parent directories if they don't exist
+   */
+  private ensureParentDirectoriesExist(filePath: string): void {
+    const dirName = path.dirname(filePath);
+    if (!fs.existsSync(dirName)) {
+      fs.mkdirSync(dirName, { recursive: true });
+    }
+  }
+}
+
+/**
+ * Implementation of the Edit tool logic
+ */
+export class SmartEditTool
+  extends BaseDeclarativeTool<SmartEditToolParams, ToolResult>
+  implements ModifiableDeclarativeTool<SmartEditToolParams>
+{
+  static readonly Name = 'replace';
+
+  constructor(private readonly config: Config) {
+    super(
+      SmartEditTool.Name,
+      'Edit',
+      `Replaces text within a file. Replaces a single occurrence. This tool requires providing significant context around the change to ensure precise targeting. Always use the ${ReadFileTool.Name} tool to examine the file's current content before attempting a text replacement.
+
+      The user has the ability to modify the \`new_string\` content. If modified, this will be stated in the response.
+
+      Expectation for required parameters:
+      1. \`file_path\` MUST be an absolute path; otherwise an error will be thrown.
+      2. \`old_string\` MUST be the exact literal text to replace (including all whitespace, indentation, newlines, and surrounding code etc.).
+      3. \`new_string\` MUST be the exact literal text to replace \`old_string\` with (also including all whitespace, indentation, newlines, and surrounding code etc.). Ensure the resulting code is correct and idiomatic and that \`old_string\` and \`new_string\` are different.
+      4. \`instruction\` is the detailed instruction of what needs to be changed. It is important to Make it specific and detailed so developers or large language models can understand what needs to be changed and perform the changes on their own if necessary.
+      5. NEVER escape \`old_string\` or \`new_string\`, that would break the exact literal text requirement.
+      **Important:** If ANY of the above are not satisfied, the tool will fail. CRITICAL for \`old_string\`: Must uniquely identify the single instance to change. Include at least 3 lines of context BEFORE and AFTER the target text, matching whitespace and indentation precisely. If this string matches multiple locations, or does not match exactly, the tool will fail.
+      6. Prefer to break down complex and long changes into multiple smaller atomic calls to this tool. Always check the content of the file after changes or not finding a string to match.
+      **Multiple replacements:** If there are multiple and ambiguous occurences of the \`old_string\` in the file, the tool will also fail.`,
+      Kind.Edit,
+      {
+        properties: {
+          file_path: {
+            description:
+              "The absolute path to the file to modify. Must start with '/'.",
+            type: 'string',
+          },
+          instruction: {
+            description: `A clear, semantic instruction for the code change, acting as a high-quality prompt for an expert LLM assistant. It must be self-contained and explain the goal of the change.
+
+A good instruction should concisely answer:
+1.  WHY is the change needed? (e.g., "To fix a bug where users can be null...")
+2.  WHERE should the change happen? (e.g., "...in the 'renderUserProfile' function...")
+3.  WHAT is the high-level change? (e.g., "...add a null check for the 'user' object...")
+4.  WHAT is the desired outcome? (e.g., "...so that it displays a loading spinner instead of crashing.")
+
+**GOOD Example:** "In the 'calculateTotal' function, correct the sales tax calculation by updating the 'taxRate' constant from 0.05 to 0.075 to reflect the new regional tax laws."
+
+**BAD Examples:**
+- "Change the text." (Too vague)
+- "Fix the bug." (Doesn't explain the bug or the fix)
+- "Replace the line with this new line." (Brittle, just repeats the other parameters)
+`,
+            type: 'string',
+          },
+          old_string: {
+            description:
+              'The exact literal text to replace, preferably unescaped. Include at least 3 lines of context BEFORE and AFTER the target text, matching whitespace and indentation precisely. If this string is not the exact literal text (i.e. you escaped it) or does not match exactly, the tool will fail.',
+            type: 'string',
+          },
+          new_string: {
+            description:
+              'The exact literal text to replace `old_string` with, preferably unescaped. Provide the EXACT text. Ensure the resulting code is correct and idiomatic.',
+            type: 'string',
+          },
+        },
+        required: ['file_path', 'instruction', 'old_string', 'new_string'],
+        type: 'object',
+      },
+    );
+  }
+
+  /**
+   * Validates the parameters for the Edit tool
+   * @param params Parameters to validate
+   * @returns Error message string or null if valid
+   */
+  protected override validateToolParamValues(
+    params: SmartEditToolParams,
+  ): string | null {
+    if (!params.file_path) {
+      return "The 'file_path' parameter must be non-empty.";
+    }
+
+    if (!path.isAbsolute(params.file_path)) {
+      return `File path must be absolute: ${params.file_path}`;
+    }
+
+    const workspaceContext = this.config.getWorkspaceContext();
+    if (!workspaceContext.isPathWithinWorkspace(params.file_path)) {
+      const directories = workspaceContext.getDirectories();
+      return `File path must be within one of the workspace directories: ${directories.join(', ')}`;
+    }
+
+    return null;
+  }
+
+  protected createInvocation(
+    params: SmartEditToolParams,
+  ): ToolInvocation<SmartEditToolParams, ToolResult> {
+    return new EditToolInvocation(this.config, params);
+  }
+
+  getModifyContext(_: AbortSignal): ModifyContext<SmartEditToolParams> {
+    return {
+      getFilePath: (params: SmartEditToolParams) => params.file_path,
+      getCurrentContent: async (
+        params: SmartEditToolParams,
+      ): Promise<string> => {
+        try {
+          return this.config
+            .getFileSystemService()
+            .readTextFile(params.file_path);
+        } catch (err) {
+          if (!isNodeError(err) || err.code !== 'ENOENT') throw err;
+          return '';
+        }
+      },
+      getProposedContent: async (
+        params: SmartEditToolParams,
+      ): Promise<string> => {
+        try {
+          const currentContent = await this.config
+            .getFileSystemService()
+            .readTextFile(params.file_path);
+          return applyReplacement(
+            currentContent,
+            params.old_string,
+            params.new_string,
+            params.old_string === '' && currentContent === '',
+          );
+        } catch (err) {
+          if (!isNodeError(err) || err.code !== 'ENOENT') throw err;
+          return '';
+        }
+      },
+      createUpdatedParams: (
+        oldContent: string,
+        modifiedProposedContent: string,
+        originalParams: SmartEditToolParams,
+      ): SmartEditToolParams => {
+        const content = originalParams.new_string;
+        return {
+          ...originalParams,
+          ai_proposed_string: content,
+          old_string: oldContent,
+          new_string: modifiedProposedContent,
+          modified_by_user: true,
+        };
+      },
+    };
+  }
+}

--- a/packages/core/src/utils/llm-edit-fixer.ts
+++ b/packages/core/src/utils/llm-edit-fixer.ts
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Content, GenerateContentConfig } from '@google/genai';
+import { LruCache } from './LruCache.js';
+import { DEFAULT_QWEN_FLASH_MODEL } from '../config/models.js';
+import { promptIdContext } from './promptIdContext.js';
+
+const MAX_CACHE_SIZE = 50;
+
+const EDIT_SYS_PROMPT = `
+You are an expert code-editing assistant specializing in debugging and correcting failed search-and-replace operations.
+
+# Primary Goal
+Your task is to analyze a failed edit attempt and provide a corrected \`search\` string that will match the text in the file precisely. The correction should be as minimal as possible, staying very close to the original, failed \`search\` string. Do NOT invent a completely new edit based on the instruction; your job is to fix the provided parameters.
+
+It is important that you do no try to figure out if the instruction is correct. DO NOT GIVE ADVICE. Your only goal here is to do your best to perform the search and replace task! 
+
+# Input Context
+You will be given:
+1. The high-level instruction for the original edit.
+2. The exact \`search\` and \`replace\` strings that failed.
+3. The error message that was produced.
+4. The full content of the source file.
+
+# Rules for Correction
+1.  **Minimal Correction:** Your new \`search\` string must be a close variation of the original. Focus on fixing issues like whitespace, indentation, line endings, or small contextual differences.
+2.  **Explain the Fix:** Your \`explanation\` MUST state exactly why the original \`search\` failed and how your new \`search\` string resolves that specific failure. (e.g., "The original search failed due to incorrect indentation; the new search corrects the indentation to match the source file.").
+3.  **Preserve the \`replace\` String:** Do NOT modify the \`replace\` string unless the instruction explicitly requires it and it was the source of the error. Your primary focus is fixing the \`search\` string.
+4.  **No Changes Case:** CRUCIAL: if the change is already present in the file,  set \`noChangesRequired\` to True and explain why in the \`explanation\`. It is crucial that you only do this if the changes outline in \`replace\` are alredy in the file and suits the instruction!! 
+5.  **Exactness:** The final \`search\` field must be the EXACT literal text from the file. Do not escape characters.
+`;
+
+const EDIT_USER_PROMPT = `
+# Goal of the Original Edit
+<instruction>
+{instruction}
+</instruction>
+
+# Failed Attempt Details
+- **Original \`search\` parameter (failed):**
+<search>
+{old_string}
+</search>
+- **Original \`replace\` parameter:**
+<replace>
+{new_string}
+</replace>
+- **Error Encountered:**
+<error>
+{error}
+</error>
+
+# Full File Content
+<file_content>
+{current_content}
+</file_content>
+
+# Your Task
+Based on the error and the file content, provide a corrected \`search\` string that will succeed. Remember to keep your correction minimal and explain the precise reason for the failure in your \`explanation\`.
+`;
+
+export interface SearchReplaceEdit {
+  search: string;
+  replace: string;
+  noChangesRequired: boolean;
+  explanation: string;
+}
+
+const SearchReplaceEditSchema = {
+  type: 'object',
+  properties: {
+    explanation: { type: 'string' },
+    search: { type: 'string' },
+    replace: { type: 'string' },
+    noChangesRequired: { type: 'boolean' },
+  },
+  required: ['search', 'replace', 'explanation'],
+};
+
+const editCorrectionWithInstructionCache = new LruCache<
+  string,
+  SearchReplaceEdit
+>(MAX_CACHE_SIZE);
+
+const EditConfig: GenerateContentConfig = {
+  thinkingConfig: {
+    thinkingBudget: 0,
+  },
+};
+
+/**
+ * Attempts to fix a failed edit by using an LLM to generate a new search and replace pair.
+ * @param instruction The instruction for what needs to be done.
+ * @param old_string The original string to be replaced.
+ * @param new_string The original replacement string.
+ * @param error The error that occurred during the initial edit.
+ * @param current_content The current content of the file.
+ * @param baseLlmClient The GeminiClient to use for the LLM call.
+ * @param abortSignal An abort signal to cancel the operation.
+ * @returns A new search and replace pair.
+ */
+export async function FixLLMEditWithInstruction(
+  instruction: string,
+  old_string: string,
+  new_string: string,
+  error: string,
+  current_content: string,
+  baseLlmClient: any,
+  abortSignal: AbortSignal,
+): Promise<SearchReplaceEdit> {
+  let promptId = promptIdContext.getStore();
+  if (!promptId) {
+    promptId = `llm-fixer-fallback-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    console.warn(
+      `Could not find promptId in context. This is unexpected. Using a fallback ID: ${promptId}`,
+    );
+  }
+
+  const cacheKey = `${instruction}---${old_string}---${new_string}--${current_content}--${error}`;
+  const cachedResult = editCorrectionWithInstructionCache.get(cacheKey);
+  if (cachedResult) {
+    return cachedResult;
+  }
+  const userPrompt = EDIT_USER_PROMPT.replace('{instruction}', instruction)
+    .replace('{old_string}', old_string)
+    .replace('{new_string}', new_string)
+    .replace('{error}', error)
+    .replace('{current_content}', current_content);
+
+  const contents: Content[] = [
+    {
+      role: 'user',
+      parts: [{ text: userPrompt }],
+    },
+  ];
+
+  const result = (await baseLlmClient.generateJson({
+    contents,
+    schema: SearchReplaceEditSchema,
+    abortSignal,
+    model: DEFAULT_QWEN_FLASH_MODEL,
+    systemInstruction: EDIT_SYS_PROMPT,
+    promptId,
+    config: EditConfig,
+  })) as unknown as SearchReplaceEdit;
+
+  editCorrectionWithInstructionCache.set(cacheKey, result);
+  return result;
+}
+
+export function resetLlmEditFixerCaches_TEST_ONLY() {
+  editCorrectionWithInstructionCache.clear();
+}

--- a/packages/core/src/utils/promptIdContext.ts
+++ b/packages/core/src/utils/promptIdContext.ts
@@ -1,0 +1,9 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export const promptIdContext = new AsyncLocalStorage<string>();

--- a/packages/core/src/utils/textUtils.ts
+++ b/packages/core/src/utils/textUtils.ts
@@ -32,3 +32,32 @@ export function isBinary(
   // If no NULL bytes were found in the sample, we assume it's text.
   return false;
 }
+
+/**
+ * Safely replaces all occurrences of a string with another string.
+ * This is a simple implementation that doesn't use regex, so it's safe from regex injection.
+ * @param str The string to search in
+ * @param search The string to search for
+ * @param replace The string to replace with
+ * @returns The string with all occurrences replaced
+ */
+export function safeLiteralReplace(
+  str: string,
+  search: string,
+  replace: string,
+): string {
+  if (search === '') {
+    return str;
+  }
+  let result = str;
+  let index = result.indexOf(search);
+  while (index !== -1) {
+    result =
+      result.substring(0, index) +
+      replace +
+      result.substring(index + search.length);
+    // Start the next search after the replacement to avoid infinite loops
+    index = result.indexOf(search, index + replace.length);
+  }
+  return result;
+}


### PR DESCRIPTION
## TLDR

When writing code, I often encounter issues with generated code containing escape characters, where \n\t is output as the literal string "\n\t". This is a serious problem, and I feel that the smart-edit feature on gemini-cli could help resolve it.

https://github.com/google-gemini/gemini-cli/pull/6823

This is the Smart Edit tool, a potential replacement for the current 'replace/edit' tool.

The main differences:

Smart Edit takes four arguments: the usual old_string, new_string, file_path and instructions describing the change that it's trying to perform. It only works on editing one occurrence at a time.
The flow is as following:
2.1. It tries an exact match, if not succeed, continue
2.3 It tries a flexible match where we loose the constrains mostly on spaces. If not succeed, continues
2.4 It asks Gemini to Fix the old_string and potentially the new_string taking into consideration the instructions it received using gemini 2.5 flash
2.5 Tries the exact match and flexible match one last time.
I did some tests with the tool running it on swebench verify and swebench lite. The error rate for the editing action dropped from around 20% to 6%.

We are not making it the default tool yet. In order to run it, you have to enable it in your .gemini/settings.json file

{ .... "useSmartEdit": true }
Token usage.
The current EditTool can do up to two LLM calls, this new tool do only up to one. In experiments, we noticed a drop in input_token_count of about 30%.

Escaping characters
The current EditTool tries multiple character escaping strategies. We removed those strategies without harming the the performance.

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
