### PR TITLE
Add `skipLoopDetection` Configuration Option

### DIFF
--- a/docs/cli/configuration.md
+++ b/docs/cli/configuration.md
@@ -311,6 +311,22 @@ In addition to a project settings file, a project's `.qwen` directory can contai
     "showLineNumbers": false
     ```
 
+- **`skipNextSpeakerCheck`** (boolean):
+  - **Description:** Skips the next speaker check after text responses. When enabled, the system bypasses analyzing whether the AI should continue speaking.
+  - **Default:** `false`
+  - **Example:**
+    ```json
+    "skipNextSpeakerCheck": true
+    ```
+
+- **`skipLoopDetection`** (boolean):
+  - **Description:** Disables all loop detection checks (streaming and LLM-based). Loop detection prevents infinite loops in AI responses but can generate false positives that interrupt legitimate workflows. Enable this option if you experience frequent false positive loop detection interruptions.
+  - **Default:** `false`
+  - **Example:**
+    ```json
+    "skipLoopDetection": true
+    ```
+
 ### Example `settings.json`:
 
 ```json
@@ -338,6 +354,8 @@ In addition to a project settings file, a project's `.qwen` directory can contai
   "usageStatisticsEnabled": true,
   "hideTips": false,
   "hideBanner": false,
+  "skipNextSpeakerCheck": false,
+  "skipLoopDetection": false,
   "maxSessionTurns": 10,
   "summarizeToolOutput": {
     "run_shell_command": {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -604,6 +604,7 @@ export async function loadCliConfig(
     trustedFolder,
     shouldUseNodePtyShell: settings.shouldUseNodePtyShell,
     skipNextSpeakerCheck: settings.skipNextSpeakerCheck,
+    skipLoopDetection: settings.skipLoopDetection ?? false,
   });
 }
 

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -604,6 +604,15 @@ export const SETTINGS_SCHEMA = {
     description: 'Skip the next speaker check.',
     showInDialog: true,
   },
+  skipLoopDetection: {
+    type: 'boolean',
+    label: 'Skip Loop Detection',
+    category: 'General',
+    requiresRestart: false,
+    default: false,
+    description: 'Disable all loop detection checks (streaming and LLM).',
+    showInDialog: true,
+  },
   enableWelcomeBack: {
     type: 'boolean',
     label: 'Enable Welcome Back',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -233,6 +233,7 @@ export interface ConfigParameters {
   trustedFolder?: boolean;
   shouldUseNodePtyShell?: boolean;
   skipNextSpeakerCheck?: boolean;
+  skipLoopDetection?: boolean;
 }
 
 export class Config {
@@ -318,6 +319,7 @@ export class Config {
   private readonly trustedFolder: boolean | undefined;
   private readonly shouldUseNodePtyShell: boolean;
   private readonly skipNextSpeakerCheck: boolean;
+  private readonly skipLoopDetection: boolean;
   private initialized: boolean = false;
 
   constructor(params: ConfigParameters) {
@@ -399,6 +401,7 @@ export class Config {
     this.trustedFolder = params.trustedFolder;
     this.shouldUseNodePtyShell = params.shouldUseNodePtyShell ?? false;
     this.skipNextSpeakerCheck = params.skipNextSpeakerCheck ?? false;
+    this.skipLoopDetection = params.skipLoopDetection ?? false;
 
     // Web search
     this.tavilyApiKey = params.tavilyApiKey;
@@ -859,6 +862,10 @@ export class Config {
 
   getSkipNextSpeakerCheck(): boolean {
     return this.skipNextSpeakerCheck;
+  }
+
+  getSkipLoopDetection(): boolean {
+    return this.skipLoopDetection;
   }
 
   async getGitService(): Promise<GitService> {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -233,6 +233,7 @@ describe('Gemini Client (client.ts)', () => {
       getCliVersion: vi.fn().mockReturnValue('1.0.0'),
       getChatCompression: vi.fn().mockReturnValue(undefined),
       getSkipNextSpeakerCheck: vi.fn().mockReturnValue(false),
+      getSkipLoopDetection: vi.fn().mockReturnValue(false),
     };
     const MockedConfig = vi.mocked(Config, true);
     MockedConfig.mockImplementation(
@@ -1986,6 +1987,100 @@ ${JSON.stringify(
 
       // Assert
       expect(mockCheckNextSpeaker).not.toHaveBeenCalled();
+    });
+
+    it('does not run loop checks when skipLoopDetection is true', async () => {
+      // Arrange
+      // Ensure config returns true for skipLoopDetection
+      vi.spyOn(client['config'], 'getSkipLoopDetection').mockReturnValue(true);
+
+      // Replace loop detector with spies
+      const ldMock = {
+        turnStarted: vi.fn().mockResolvedValue(false),
+        addAndCheck: vi.fn().mockReturnValue(false),
+        reset: vi.fn(),
+      };
+      // @ts-expect-error override private for testing
+      client['loopDetector'] = ldMock;
+
+      const mockStream = (async function* () {
+        yield { type: 'content', value: 'Hello' };
+        yield { type: 'content', value: 'World' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      const mockChat: Partial<GeminiChat> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      const mockGenerator: Partial<ContentGenerator> = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+        generateContent: mockGenerateContentFn,
+      };
+      client['contentGenerator'] = mockGenerator as ContentGenerator;
+
+      // Act
+      const stream = client.sendMessageStream(
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+        'prompt-id-loop-skip',
+      );
+      for await (const _ of stream) {
+        // consume
+      }
+
+      // Assert: methods not called due to skip
+      const ld = client['loopDetector'] as unknown as {
+        turnStarted: ReturnType<typeof vi.fn>;
+        addAndCheck: ReturnType<typeof vi.fn>;
+      };
+      expect(ld.turnStarted).not.toHaveBeenCalled();
+      expect(ld.addAndCheck).not.toHaveBeenCalled();
+    });
+
+    it('runs loop checks when skipLoopDetection is false', async () => {
+      // Arrange
+      vi.spyOn(client['config'], 'getSkipLoopDetection').mockReturnValue(false);
+
+      const turnStarted = vi.fn().mockResolvedValue(false);
+      const addAndCheck = vi.fn().mockReturnValue(false);
+      const reset = vi.fn();
+      // @ts-expect-error override private for testing
+      client['loopDetector'] = { turnStarted, addAndCheck, reset };
+
+      const mockStream = (async function* () {
+        yield { type: 'content', value: 'Hello' };
+        yield { type: 'content', value: 'World' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      const mockChat: Partial<GeminiChat> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      const mockGenerator: Partial<ContentGenerator> = {
+        countTokens: vi.fn().mockResolvedValue({ totalTokens: 0 }),
+        generateContent: mockGenerateContentFn,
+      };
+      client['contentGenerator'] = mockGenerator as ContentGenerator;
+
+      // Act
+      const stream = client.sendMessageStream(
+        [{ text: 'Hi' }],
+        new AbortController().signal,
+        'prompt-id-loop-run',
+      );
+      for await (const _ of stream) {
+        // consume
+      }
+
+      // Assert
+      expect(turnStarted).toHaveBeenCalledTimes(1);
+      expect(addAndCheck).toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
### Summary

This PR introduces a new configuration setting `skipLoopDetection` that allows users to completely disable all loop detection mechanisms in Qwen Code. When enabled, this setting bypasses both streaming content loop detection and LLM-based loop detection checks.

### Motivation

Loop detection is a safety mechanism that prevents infinite loops in AI responses by monitoring:
- Tool call repetitions (threshold: 5 identical calls)
- Content streaming patterns (threshold: 10 repeated chunks)
- LLM conversation patterns (using AI analysis after 30+ turns)

However, the current loop detection implementation suffers from reliability issues and generates frequent false positives that interrupt legitimate workflows:

- **False positive tool calls**: Valid repetitive operations (like processing multiple similar files) are incorrectly flagged as loops
- **Content pattern misdetection**: Legitimate repetitive content (code generation, documentation, structured outputs) triggers false alarms
- **Workflow interruption**: Users experience unexpected conversation termination during normal operations
- **Inconsistent behavior**: The detection logic doesn't reliably distinguish between actual infinite loops and valid repetitive patterns

This configuration option provides users with a way to disable the unreliable loop detection when it interferes with their workflows, while maintaining it as the default for users who prefer the safety mechanism despite its limitations.

### Backward Compatibility

- ✅ **Fully backward compatible** - defaults to `false` (existing behavior)
- ✅ **No breaking changes** - all existing APIs remain unchanged
- ✅ **Safe rollout** - can be enabled/disabled per user preference

### Security Considerations

- ⚠️ **Trade-off acknowledged** - disabling removes safety mechanism but eliminates false positive interruptions
- 📝 **Clear documentation** - setting description informs users about disabling loop detection
- 🔒 **Opt-in only** - feature must be explicitly enabled by users who experience false positive issues

### Linked issues / bugs

- #578 
- #571
- #249 
- #223 
- #67 