### PR TITLE
Fix: config error message

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -178,10 +178,10 @@ export async function main() {
       (error) => `Error in ${error.path}: ${error.message}`,
     );
     const configPaths = [
-      `User configuration: ${process.env.HOME}/.qwen/settings.json`,
-      `Workspace configuration: ${process.cwd()}/.qwen/settings.json`
+      `User configuration: ${process.env['HOME']}/.qwen/settings.json`,
+      `Workspace configuration: ${process.cwd()}/.qwen/settings.json`,
     ].join('\n');
-    
+
     throw new FatalConfigError(
       `${errorMessages.join('\n')}\n\nPlease fix the configuration file(s) and try again.\n\nConfiguration file locations:\n${configPaths}\n\nYou can edit these files with any text editor.`,
     );

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -177,8 +177,13 @@ export async function main() {
     const errorMessages = settings.errors.map(
       (error) => `Error in ${error.path}: ${error.message}`,
     );
+    const configPaths = [
+      `User configuration: ${process.env.HOME}/.qwen/settings.json`,
+      `Workspace configuration: ${process.cwd()}/.qwen/settings.json`
+    ].join('\n');
+    
     throw new FatalConfigError(
-      `${errorMessages.join('\n')}\nPlease fix the configuration file(s) and try again.`,
+      `${errorMessages.join('\n')}\n\nPlease fix the configuration file(s) and try again.\n\nConfiguration file locations:\n${configPaths}\n\nYou can edit these files with any text editor.`,
     );
   }
 


### PR DESCRIPTION
TLDR

  Improve configuration error message to include file locations. When configuration files have
  errors, users need to know where to find these files to fix them. This change enhances the
  error message to include the exact paths to the user and workspace configuration files.

  Fixes #2

  Dive Deeper

  The issue reported in #2 was that when configuration files contain syntax errors, users
  couldn't easily locate and fix them because the error message didn't specify where the
  configuration files are stored. This led to frustration as users had to search for the file
  locations or ask for help.

  This change enhances the error handling in the CLI to provide clear guidance to users on where
  to find their configuration files when errors occur. The enhanced error message now includes:

   1. Clear paths to both user and workspace configuration files
   2. Instructions on how to edit these files
   3. Better formatting to make the information more accessible

  Reviewer Test Plan

  To validate this change:

   1. Create a configuration file with a syntax error (e.g., add an extra comma or missing brace)
   2. Run the CLI and observe the enhanced error message
   3. Verify that the error message now includes the exact paths to the configuration files
   4. Verify that the paths are correctly formatted and point to the right locations

  Example test:

   1 # Create an invalid settings.json file
   2 echo '{"invalid": json}' > ~/.qwen/settings.json
   3 # Run the CLI and check the error message
   4 npx gemini

  The error message should now include clear instructions on where to find the configuration
  files.

  Testing Matrix


  ┌──────────┬────┬────┬────┐
  │          │ 🍏 │ 🪟 │ 🐧 │
  ├──────────┼────┼────┼────┤
  │ npm run  │ ✅ │ ✅ │ ✅ │
  │ npx      │ ✅ │ ✅ │ ✅ │
  │ Docker   │ ✅ │ ✅ │ ✅ │
  │ Podman   │ ✅ │ -  │ -  │
  │ Seatbelt │ ✅ │ -  │ -  │
  └──────────┴────┴────┴────┘


  Linked issues / bugs

  Fixes #2