### PR TITLE
feat: add yolo mode support to auto vision model switch

### DIFF
--- a/packages/cli/src/ui/hooks/useVisionAutoSwitch.ts
+++ b/packages/cli/src/ui/hooks/useVisionAutoSwitch.ts
@@ -5,7 +5,7 @@
  */
 
 import { type PartListUnion, type Part } from '@google/genai';
-import { AuthType, type Config } from '@qwen-code/qwen-code-core';
+import { AuthType, type Config, ApprovalMode } from '@qwen-code/qwen-code-core';
 import { useCallback, useRef } from 'react';
 import { VisionSwitchOutcome } from '../components/ModelSwitchDialog.js';
 import {
@@ -250,6 +250,17 @@ export function useVisionAutoSwitch(
         )
       ) {
         return { shouldProceed: true };
+      }
+
+      // In YOLO mode, automatically switch to vision model without user interaction
+      if (config.getApprovalMode() === ApprovalMode.YOLO) {
+        const vlModelId = getDefaultVisionModel();
+        originalModelRef.current = config.getModel();
+        config.setModel(vlModelId);
+        return {
+          shouldProceed: true,
+          originalModel: originalModelRef.current,
+        };
       }
 
       try {


### PR DESCRIPTION
## TLDR

In YOLO mode, when users input messages containing images, the system automatically switches to a vision model to process the request without requiring manual user selection. After processing, it automatically restores to the original coder model, enhancing qwen-code's autonomy and avoiding frequent user interruptions.

## Todo Actions

- [x] Auto switch once to vlm in yolo mode
- [ ] Add option to insist on using a non-vision model with image input
- [ ] Add settings to control default behavior

## Dive Deeper

### Core Changes

- Modified `useVisionAutoSwitch` hook to automatically execute `SwitchOnce` operation when images are detected in YOLO mode
- Skip the vision switch dialog and directly switch to the default vision model
- Maintain original model reference for subsequent automatic restoration

### Technical Implementation

- Added YOLO mode detection logic in `handleVisionSwitch` function
- Automatically execute model switching when `config.getApprovalMode() === ApprovalMode.YOLO`
- Maintain full compatibility with existing functionality, non-YOLO mode behavior unchanged


## Reviewer Test Plan

1. **YOLO Mode Testing**:
   - Start qwen-code with `--yolo` parameter
   - Send messages containing images and verify automatic switch to the vision model
   - Confirm automatic restoration to the coder model after processing
2. **Compatibility Testing**:
   - Send images in non-YOLO mode and confirm the vision switch dialog still appears
   - Verify existing functionality is not affected

## Testing Matrix

|          | 🍏   | 🪟   | 🐧   |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓   | ❓   |
| npx      | ✅   | ❓   | ❓   |
| Docker   | ❓   | ❓   | ❓   |
| Podman   | ❓   | -   | -   |
| Seatbelt | ❓   | -   | -   |

## Linked issues / bugs

None.
