### PR TITLE
feat: add OpenAI and Qwen OAuth auth support to Zed ACP integration

### DIFF
--- a/packages/cli/src/validateNonInterActiveAuth.test.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.test.ts
@@ -126,6 +126,18 @@ describe('validateNonInterActiveAuth', () => {
     expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.USE_OPENAI);
   });
 
+  it('uses configured QWEN_OAUTH if provided', async () => {
+    const nonInteractiveConfig: NonInteractiveConfig = {
+      refreshAuth: refreshAuthMock,
+    };
+    await validateNonInteractiveAuth(
+      AuthType.QWEN_OAUTH,
+      undefined,
+      nonInteractiveConfig,
+    );
+    expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.QWEN_OAUTH);
+  });
+
   it('uses USE_VERTEX_AI if GOOGLE_GENAI_USE_VERTEXAI is true (with GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION)', async () => {
     process.env['GOOGLE_GENAI_USE_VERTEXAI'] = 'true';
     process.env['GOOGLE_CLOUD_PROJECT'] = 'test-project';

--- a/packages/cli/src/zed-integration/zedIntegration.ts
+++ b/packages/cli/src/zed-integration/zedIntegration.ts
@@ -97,6 +97,18 @@ class GeminiAgent {
         name: 'Vertex AI',
         description: null,
       },
+      {
+        id: AuthType.USE_OPENAI,
+        name: 'Use OpenAI API key',
+        description:
+          'Requires setting the `OPENAI_API_KEY` environment variable',
+      },
+      {
+        id: AuthType.QWEN_OAUTH,
+        name: 'Qwen OAuth',
+        description:
+          'OAuth authentication for Qwen models with 2000 daily requests',
+      },
     ];
 
     return {


### PR DESCRIPTION
## TLDR

This PR adds OpenAI and Qwen OAuth authentication support to the Zed editor ACP integration. Previously, Zed integration only supported Google-based auth methods, but now it supports all authentication options available in the CLI, providing users with more flexibility and consistency across interfaces.

## Dive Deeper

The Zed editor integration uses the Agent Communication Protocol (ACP) to communicate with qwen-code. The current implementation in `zedIntegration.ts` only exposed 3 authentication methods in the `authMethods` array:
- LOGIN_WITH_GOOGLE
- USE_GEMINI
- USE_VERTEX_AI

However, the core system supports 5 authentication types total, including `USE_OPENAI` and `QWEN_OAUTH`. This created an inconsistency where CLI users could authenticate with OpenAI or Qwen OAuth, but Zed users could not.

This PR:
1. **Adds `USE_OPENAI` auth method** - Enables Zed users to authenticate using OpenAI API keys
2. **Adds `QWEN_OAUTH` auth method** - Enables Zed users to use the free OAuth tier (2000 daily requests)
3. **Adds test coverage** - Ensures the new authentication method is properly tested
4. **Maintains backward compatibility** - All existing Google auth methods continue to work unchanged

## Reviewer Test Plan

To test this change:

1. **Build the project**: `npm run build`
2. **Start ACP mode**: `node scripts/start.js --experimental-acp`
3. **Verify auth methods**: The ACP initialization should now return 5 auth methods instead of 3
4. **Test OpenAI auth**: Set `OPENAI_API_KEY` and verify authentication works
5. **Test Qwen OAuth**: Verify OAuth flow works through the ACP interface
6. **Run tests**: `npm test --workspace=packages/cli` (specifically `validateNonInterActiveAuth.test.ts`)

Example ACP initialization response should include:
```json
{
  "authMethods": [
    {"id": "oauth-personal", "name": "Log in with Google"},
    {"id": "gemini-api-key", "name": "Use Gemini API key"},
    {"id": "vertex-ai", "name": "Vertex AI"},
    {"id": "openai", "name": "Use OpenAI API key"},
    {"id": "qwen-oauth", "name": "Qwen OAuth"}
  ]
}
```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

- ✅ **macOS npm run**: Tested locally, all tests pass including new QWEN_OAUTH test case
- **Other platforms**: Need testing by reviewers/CI

**Test Results:**
- `validateNonInterActiveAuth.test.ts`: 13/13 tests passing ✅
- TypeScript compilation: Success ✅
- ESLint: No issues ✅

## Linked issues / bugs

This PR addresses the inconsistency between CLI and Zed integration authentication options. While not linked to a specific issue, it improves feature parity and user experience by:

- Enabling Zed users to access the same authentication methods as CLI users
- Supporting users who prefer OpenAI-compatible APIs or the free Qwen OAuth tier
- Maintaining consistency across different interfaces of the same tool

*Note: No existing issues were found specifically requesting this feature, but it's a natural enhancement for feature completeness.*