### PR TITLE
fix: auth hang when select qwen-oauth in Zed

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -101,6 +101,13 @@
       "env": {
         "GEMINI_SANDBOX": "false"
       }
+    },
+    {
+      "name": "Attach by Process ID",
+      "processId": "${command:PickProcess}",
+      "request": "attach",
+      "skipFiles": ["<node_internals>/**"],
+      "type": "node"
     }
   ],
   "inputs": [
@@ -115,6 +122,12 @@
       "type": "promptString",
       "description": "Enter your prompt for non-interactive mode",
       "default": "Explain this code"
+    },
+    {
+      "id": "debugPort",
+      "type": "promptString",
+      "description": "Enter the debug port number (default: 9229)",
+      "default": "9229"
     }
   ]
 }

--- a/packages/core/src/qwen/qwenOAuth2.ts
+++ b/packages/core/src/qwen/qwenOAuth2.ts
@@ -712,8 +712,6 @@ async function authWithQwenDeviceFlow(
             `Polling... (attempt ${attempt + 1}/${maxAttempts})`,
           );
 
-          process.stdout.write('.');
-
           // Wait with cancellation check every 100ms
           await new Promise<void>((resolve) => {
             const checkInterval = 100; // Check every 100ms


### PR DESCRIPTION
## TLDR

Fixes the authentication hang issue when selecting qwen-oauth in Zed by removing stdout pollution that corrupted ACP messages.

## Dive Deeper

The root cause was a `process.stdout.write('.')` call in the OAuth device flow polling loop that was corrupting ACP messages in Zed. This prevented authentication responses from being properly transmitted to the client, causing the authentication to appear stuck in the "authenticating" state indefinitely.

**Key Changes:**
- **Primary Fix**: Removed `process.stdout.write('.')` from OAuth polling loop in `qwenOAuth2.ts`
- **Secondary Improvement**: Added `withTimeout<T>()` utility method in `SharedTokenManager` for better timeout handling and resource cleanup during debugging

The stdout pollution was breaking the structured communication protocol between qwen-code and Zed, where any unexpected output to stdout interferes with the JSON-based message exchange. Removing this debug output allows authentication responses to flow correctly through the ACP channel.

## Reviewer Test Plan

As the same as #678

## Testing Matrix

|          | 🍏   | 🪟   | 🐧   |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓   | ❓   |
| npx      | ✅   | ❓   | ❓   |
| Docker   | ❓   | ❓   | ❓   |
| Podman   | ❓   | -   | -   |
| Seatbelt | ❓   | -   | -   |

## Linked issues / bugs

Still, slash commands are not available in Zed. Will fix in another PR.
