### PR TITLE
Fix issue #654  Respect --model parameter when using custom base URL

### DIFF
--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -133,7 +133,10 @@ export function createContentGeneratorConfig(
   if (authType === AuthType.USE_OPENAI && openaiApiKey) {
     contentGeneratorConfig.apiKey = openaiApiKey;
     contentGeneratorConfig.baseUrl = openaiBaseUrl;
-    contentGeneratorConfig.model = openaiModel || DEFAULT_QWEN_MODEL;
+    // Prioritize: 1) Model from config (CLI --model), 2) OPENAI_MODEL env var, 3) DEFAULT_QWEN_MODEL
+    // Only use effectiveModel if it came from config, not from DEFAULT_GEMINI_MODEL fallback
+    const modelFromConfig = config.getModel();
+    contentGeneratorConfig.model = modelFromConfig || openaiModel || DEFAULT_QWEN_MODEL;
 
     return contentGeneratorConfig;
   }
@@ -143,9 +146,10 @@ export function createContentGeneratorConfig(
     // Set a special marker to indicate this is Qwen OAuth
     contentGeneratorConfig.apiKey = 'QWEN_OAUTH_DYNAMIC_TOKEN';
 
-    // Prefer to use qwen3-coder-plus as the default Qwen model if QWEN_MODEL is not set.
+    // Prioritize: 1) Model from config (CLI --model), 2) QWEN_MODEL env var, 3) DEFAULT_QWEN_MODEL
+    const modelFromConfig = config.getModel();
     contentGeneratorConfig.model =
-      process.env['QWEN_MODEL'] || DEFAULT_QWEN_MODEL;
+      modelFromConfig || process.env['QWEN_MODEL'] || DEFAULT_QWEN_MODEL;
 
     return contentGeneratorConfig;
   }


### PR DESCRIPTION
## TLDR

Fixed the `--model` parameter being ignored when using a custom base URL. The CLI now correctly respects the model specified via `-m` or `--model` flags when using alternative API endpoints.

## Dive Deeper

The issue was in the `createContentGeneratorConfig` function in `packages/core/src/core/contentGenerator.ts`. When using OpenAI auth type (triggered when a custom base URL is set), the code was overriding the model selection with the `OPENAI_MODEL` environment variable or falling back to `DEFAULT_QWEN_MODEL`, completely bypassing the model specified through the CLI's `--model` parameter.

The fix ensures proper priority ordering:
1. Model from config (includes CLI `--model` parameter) - highest priority
2. Environment variable (`OPENAI_MODEL` or `QWEN_MODEL`) - fallback
3. Default model constant - last resort

This same logic was applied to both OpenAI and QWEN OAuth authentication paths to ensure consistency.

## Reviewer Test Plan

To validate this fix:

1. **Test with custom base URL and model parameter:**
   ```bash
   export OPENAI_API_KEY="your-key"
   export OPENAI_BASE_URL="https://your-custom-endpoint.com"
   qwen --model gpt-4 "test prompt"
   # Should use gpt-4, not qwen3-coder-plus or coder-model
   ```

2. **Test that environment variable still works as fallback:**
   ```bash
   export OPENAI_MODEL="gpt-3.5-turbo"
   qwen "test prompt"  # No --model flag
   # Should use gpt-3.5-turbo from env var
   ```

3. **Test precedence (CLI flag should override env var):**
   ```bash
   export OPENAI_MODEL="gpt-3.5-turbo"
   qwen --model gpt-4 "test prompt"
   # Should use gpt-4 from CLI, not gpt-3.5-turbo from env
   ```

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #654