### PR TITLE
fix: apply auth type from arg or env variables

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -41,6 +41,9 @@ import { annotateActiveExtensions } from './extension.js';
 import { loadSandboxConfig } from './sandboxConfig.js';
 
 import { isWorkspaceTrusted } from './trustedFolders.js';
+import {
+  getAuthTypeFromEnv
+} from "../validateNonInterActiveAuth.js";
 
 // Simple console logger for now - replace with actual logger if available
 const logger = {
@@ -415,6 +418,10 @@ export async function loadCliConfig(
     process.env['OPENAI_API_KEY'] = argv.openaiApiKey;
   }
 
+  // Determine authType from env, falling back to settings.json selectedAuthType.
+  // If undefined, the "Get started" wizard is run to configure settings.json.
+  const authType = getAuthTypeFromEnv() || settings.security?.auth?.selectedType;
+
   // Handle OpenAI base URL from command line
   if (argv.openaiBaseUrl) {
     process.env['OPENAI_BASE_URL'] = argv.openaiBaseUrl;
@@ -647,7 +654,7 @@ export async function loadCliConfig(
           'SYSTEM_TEMPLATE:{"name":"qwen3_coder","params":{"is_git_repository":{RUNTIME_VARS_IS_GIT_REPO},"sandbox":"{RUNTIME_VARS_SANDBOX}"}}',
       },
     ]) as ConfigParameters['systemPromptMappings'],
-    authType: settings.security?.auth?.selectedType,
+    authType: authType,
     contentGenerator: settings.contentGenerator,
     cliVersion,
     tavilyApiKey:

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -190,6 +190,7 @@ export async function main() {
     sessionId,
     argv,
   );
+  settings.applyConfiguredAuthType(config.getAuthType());
 
   const consolePatcher = new ConsolePatcher({
     stderr: true,

--- a/packages/cli/src/validateNonInterActiveAuth.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.ts
@@ -8,7 +8,7 @@ import { AuthType, type Config } from '@qwen-code/qwen-code-core';
 import { USER_SETTINGS_PATH } from './config/settings.js';
 import { validateAuthMethod } from './config/auth.js';
 
-function getAuthTypeFromEnv(): AuthType | undefined {
+export function getAuthTypeFromEnv(): AuthType | undefined {
   if (process.env['GOOGLE_GENAI_USE_GCA'] === 'true') {
     return AuthType.LOGIN_WITH_GOOGLE;
   }


### PR DESCRIPTION
## Bugfix

### Run local LLM when passing --openai-api-key or configuring env variables

After the "Get started" wizard has been completed, or settings.json has been configured manually, the command line flag `--openai-api-key` and env variables are not being respected anymore to determine the authType.

For example, if settings.json contains `{ "selectedAuthType": "qwen-oauth" }`, local LLMs can't be used anymore by providing the `OPENAI_...` env variables, the login page is being opened instead.

This implementation configures this setting now:
1. command line arg --openai-api-key "my-key" implicitly sets "openai"
2. env variables or .env file (i.e. OPENAI_API_KEY) sets their corresponding authType
3. <code>{ "selectedAuthType": "openai" }</code> in settings.json is used
4. If authType couldn't be determined, the "Get started" wizard is run (user has to choose between qwen-oauth and openai) in order to fill settings.json

Workaround for the current release:
The user always has to keep settings.json in sync with his intended use, for example if he now passes the `--openai-api-key` flag or switches providers in the .env file, i.e. from OPENAI to GEMINI or GOOGLE (vertex.ai).

## Dive Deeper

Please note that not only OPENAI is affected, even if the env is configured with other providers, only settings.json is being respected at the moment to determine the authType.

This also means, that the user has to change settings.json after the "Get started" wizard if he doesn't want to use qwen-oauth or openai.

## Reviewer Test Plan

Install the current release, then try all steps:
1. Complete "Get started" with qwen-oauth (first option) -> login dialog page is opened
2. Run with --openai-api-key my-key -> login dialog page is opened nevertheless
3. Run with OPENAI_API_KEY=my-key -> login dialog page is opened nevertheless
4. Run with .env containing OPENAI_API_KEY=my-key -> login dialog page is opened nevertheless
5. Change settings.json to `{ "selectedAuthType": "openai" }` -> OPENAI is being used (no login page)

Checkout/install this PR, delete settings.json, then retry all steps:
1. Complete "Get started" with qwen-oauth (first option) -> login dialog page is opened
2. Run with --openai-api-key my-key -> OPENAI is being used (no login page although settings.json contains qwen-oauth)
3. Run with OPENAI_API_KEY=my-key -> OPENAI is being used (no login page although settings.json contains qwen-oauth)
4. Run with .env containing OPENAI_API_KEY=my-key -> OPENAI is being used (no login page although settings.json contains qwen-oauth)
5. Change settings.json to `{ "selectedAuthType": "openai" }` -> OPENAI is being used (no login page)

Keep in mind that qwen doesn't respect Ctrl+C or Escape even if `(Press ESC to cancel)` is being displayed while waiting for the qwen-oauth login page, the node process has to be stopped (`killall -9 node`).

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Fixes #599