### PR TITLE
feat: Add Qwen3-VL-Plus token limits (256K input, 32K output)

### DIFF
--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -278,6 +278,11 @@ describe('tokenLimit with output type', () => {
       expect(tokenLimit('qwen-vl-max-latest', 'output')).toBe(8192); // 8K output
     });
 
+    it('should return different limits for input vs output for qwen3-vl-plus', () => {
+      expect(tokenLimit('qwen3-vl-plus', 'input')).toBe(262144); // 256K input
+      expect(tokenLimit('qwen3-vl-plus', 'output')).toBe(32768); // 32K output
+    });
+
     it('should return same default limits for unknown models', () => {
       expect(tokenLimit('unknown-model', 'input')).toBe(DEFAULT_TOKEN_LIMIT); // 128K input
       expect(tokenLimit('unknown-model', 'output')).toBe(

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -135,6 +135,7 @@ const PATTERNS: Array<[RegExp, TokenCount]> = [
   [/^qwen-turbo.*$/, LIMITS['128k']],
 
   // Qwen Vision Models
+  [/^qwen3-vl-plus$/, LIMITS['256k']], // Qwen3-VL-Plus: 256K input
   [/^qwen-vl-max.*$/, LIMITS['128k']],
 
   // Generic vision-model: same as qwen-vl-max (128K token context)
@@ -187,8 +188,8 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
   // Generic vision-model: same as qwen-vl-max-latest (8K max output tokens)
   [/^vision-model$/, LIMITS['8k']],
 
-  // Qwen3-VL-Plus: 8,192 max output tokens
-  [/^qwen3-vl-plus$/, LIMITS['8k']],
+  // Qwen3-VL-Plus: 32K max output tokens
+  [/^qwen3-vl-plus$/, LIMITS['32k']],
 ];
 
 /**


### PR DESCRIPTION
- Added 256K input context window limit for Qwen3-VL-Plus model
- Updated output token limit from 8K to 32K for Qwen3-VL-Plus
- Added comprehensive tests for both input and output limits

As requested by Qwen maintainers for proper model support.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
