### PR TITLE
Fix/qwen3 vl plus highres

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -688,6 +688,60 @@ describe('DashScopeOpenAICompatibleProvider', () => {
       ).toBe(true); // Vision-specific parameter should be preserved
     });
 
+    it('should set high resolution flag for qwen3-vl-plus', () => {
+      const request: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'qwen3-vl-plus',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Please inspect the image.' },
+              {
+                type: 'image_url',
+                image_url: { url: 'https://example.com/vl.jpg' },
+              },
+            ],
+          },
+        ],
+        max_tokens: 50000,
+      };
+
+      const result = provider.buildRequest(request, 'test-prompt-id');
+
+      expect(result.max_tokens).toBe(32768);
+      expect(
+        (result as { vl_high_resolution_images?: boolean })
+          .vl_high_resolution_images,
+      ).toBe(true);
+    });
+
+    it('should set high resolution flag for the vision-model alias', () => {
+      const request: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'vision-model',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Alias payload' },
+              {
+                type: 'image_url',
+                image_url: { url: 'https://example.com/alias.png' },
+              },
+            ],
+          },
+        ],
+        max_tokens: 9000,
+      };
+
+      const result = provider.buildRequest(request, 'test-prompt-id');
+
+      expect(result.max_tokens).toBe(8192);
+      expect(
+        (result as { vl_high_resolution_images?: boolean })
+          .vl_high_resolution_images,
+      ).toBe(true);
+    });
+
     it('should handle streaming requests with output token limits', () => {
       const request: OpenAI.Chat.ChatCompletionCreateParams = {
         model: 'qwen3-coder-plus',

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -100,7 +100,7 @@ export class DashScopeOpenAICompatibleProvider
       request.model,
     );
 
-    if (request.model.startsWith('qwen-vl')) {
+    if (this.isVisionModel(request.model)) {
       return {
         ...requestWithTokenLimits,
         messages,
@@ -265,6 +265,28 @@ export class DashScopeOpenAICompatibleProvider
     }
 
     return contentArray;
+  }
+
+  private isVisionModel(model: string | undefined): boolean {
+    if (!model) {
+      return false;
+    }
+
+    const normalized = model.toLowerCase();
+
+    if (normalized === 'vision-model') {
+      return true;
+    }
+
+    if (normalized.startsWith('qwen-vl')) {
+      return true;
+    }
+
+    if (normalized.startsWith('qwen3-vl-plus')) {
+      return true;
+    }
+
+    return false;
   }
 
   /**

--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -278,6 +278,11 @@ describe('tokenLimit with output type', () => {
       expect(tokenLimit('qwen-vl-max-latest', 'output')).toBe(8192); // 8K output
     });
 
+    it('should return different limits for input vs output for qwen3-vl-plus', () => {
+      expect(tokenLimit('qwen3-vl-plus', 'input')).toBe(262144); // 256K input
+      expect(tokenLimit('qwen3-vl-plus', 'output')).toBe(32768); // 32K output
+    });
+
     it('should return same default limits for unknown models', () => {
       expect(tokenLimit('unknown-model', 'input')).toBe(DEFAULT_TOKEN_LIMIT); // 128K input
       expect(tokenLimit('unknown-model', 'output')).toBe(

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -135,6 +135,7 @@ const PATTERNS: Array<[RegExp, TokenCount]> = [
   [/^qwen-turbo.*$/, LIMITS['128k']],
 
   // Qwen Vision Models
+  [/^qwen3-vl-plus$/, LIMITS['256k']], // Qwen3-VL-Plus: 256K input
   [/^qwen-vl-max.*$/, LIMITS['128k']],
 
   // Generic vision-model: same as qwen-vl-max (128K token context)
@@ -187,8 +188,8 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
   // Generic vision-model: same as qwen-vl-max-latest (8K max output tokens)
   [/^vision-model$/, LIMITS['8k']],
 
-  // Qwen3-VL-Plus: 8,192 max output tokens
-  [/^qwen3-vl-plus$/, LIMITS['8k']],
+  // Qwen3-VL-Plus: 32K max output tokens
+  [/^qwen3-vl-plus$/, LIMITS['32k']],
 ];
 
 /**


### PR DESCRIPTION
  Summary

  - update the DashScope provider to treat all supported Qwen VL ids (vision-
  model, qwen-vl*, qwen3-vl-plus) as vision-capable so vl_high_resolution_images
  is always applied
  - add regression tests covering qwen3-vl-plus and the vision-model alias to
  ensure the flag and token limits stay correct

  Testing

  - pnpm vitest run packages/core/src/core/openaiContentGenerator/provider/
  dashscope.test.ts