### PR TITLE
fix: docs(subagents): convert tools to YAML list and PascalCase

### DIFF
--- a/docs/subagents.md
+++ b/docs/subagents.md
@@ -106,7 +106,10 @@ Subagents are configured using Markdown files with YAML frontmatter. This format
 ---
 name: agent-name
 description: Brief description of when and how to use this agent
-tools: tool1, tool2, tool3 # Optional
+tools:    # Optional
+ - tool1
+ - tool2
+ - tool3
 ---
 
 System prompt content goes here.
@@ -167,7 +170,11 @@ Perfect for comprehensive test creation and test-driven development.
 ---
 name: testing-expert
 description: Writes comprehensive unit tests, integration tests, and handles test automation with best practices
-tools: read_file, write_file, read_many_files, run_shell_command
+tools:
+ - ReadFile
+ - WriteFile
+ - ReadManyFiles
+ - RunShellCommand
 ---
 
 You are a testing specialist focused on creating high-quality, maintainable tests.
@@ -207,7 +214,11 @@ Specialized in creating clear, comprehensive documentation.
 ---
 name: documentation-writer
 description: Creates comprehensive documentation, README files, API docs, and user guides
-tools: read_file, write_file, read_many_files, web_search
+tools:
+ - ReadFile
+ - WriteFile
+ - ReadManyFiles
+ - WebSearch
 ---
 
 You are a technical documentation specialist for ${project_name}.
@@ -256,7 +267,9 @@ Focused on code quality, security, and best practices.
 ---
 name: code-reviewer
 description: Reviews code for best practices, security issues, performance, and maintainability
-tools: read_file, read_many_files
+tools:
+ - ReadFile
+ - ReadManyFiles
 ---
 
 You are an experienced code reviewer focused on quality, security, and maintainability.
@@ -298,7 +311,11 @@ Optimized for React development, hooks, and component patterns.
 ---
 name: react-specialist
 description: Expert in React development, hooks, component patterns, and modern React best practices
-tools: read_file, write_file, read_many_files, run_shell_command
+tools:
+ - ReadFile
+ - WriteFile
+ - ReadManyFiles
+ - RunShellCommand
 ---
 
 You are a React specialist with deep expertise in modern React development.
@@ -339,7 +356,11 @@ Specialized in Python development, frameworks, and best practices.
 ---
 name: python-expert
 description: Expert in Python development, frameworks, testing, and Python-specific best practices
-tools: read_file, write_file, read_many_files, run_shell_command
+tools:
+ - ReadFile
+ - WriteFile
+ - ReadManyFiles
+ - RunShellCommand
 ---
 
 You are a Python expert with deep knowledge of the Python ecosystem.


### PR DESCRIPTION
This change updates the tools configuration in subagents documentation from comma-separated strings to YAML list format and standardizes tool names to PascalCase.

## TLDR

This corrects the tool selection format used in the subagents documentation. The previously used tool selection format is incorrect and leads to invalid subagents which cannot be spawned.

## Dive Deeper

When I followed the documentation, using the comma-separated tool list with snake_case, I ended up with a subagent which couldn't be spawned. It cost me a lot of time to realize that the documentation was at fault and I should be using YAML lists with PascalCase. This change will prevent others from experiencing the same issue.

## Reviewer Test Plan

### Confirm the issue

Use this example from the original document version:

```markdown
---
name: testing-expert
description: Writes comprehensive unit tests, integration tests, and handles test automation with best practices
tools: read_file, write_file, read_many_files, run_shell_command
---
 
You are a testing specialist focused on creating high-quality, maintainable tests.
 
Your expertise includes:
 
- Unit testing with appropriate mocking and isolation
- Integration testing for component interactions
- Test-driven development practices
- Edge case identification and comprehensive coverage
- Performance and load testing when appropriate
 
For each testing task:
 
1. Analyze the code structure and dependencies
2. Identify key functionality, edge cases, and error conditions
3. Create comprehensive test suites with descriptive names
4. Include proper setup/teardown and meaningful assertions
5. Add comments explaining complex test scenarios
6. Ensure tests are maintainable and follow DRY principles
 
Always follow testing best practices for the detected language and framework.
Focus on both positive and negative test cases.
```

  1. Save it as a subagent in your `.qwen/agents/` directory
  2. Run qwen-code
  3. Run the `/agents manage` command
  4. Confirm that the newly created subagent is not listed.
 
### Confirm the fix

Use the same example but from the corrected document version:

```markdown
---
name: testing-expert
description: Writes comprehensive unit tests, integration tests, and handles test automation with best practices
tools:
 - ReadFile
 - WriteFile
 - ReadManyFiles
 - RunShellCommand
---

You are a testing specialist focused on creating high-quality, maintainable tests.

Your expertise includes:

- Unit testing with appropriate mocking and isolation
- Integration testing for component interactions
- Test-driven development practices
- Edge case identification and comprehensive coverage
- Performance and load testing when appropriate

For each testing task:

1. Analyze the code structure and dependencies
2. Identify key functionality, edge cases, and error conditions
3. Create comprehensive test suites with descriptive names
4. Include proper setup/teardown and meaningful assertions
5. Add comments explaining complex test scenarios
6. Ensure tests are maintainable and follow DRY principles

Always follow testing best practices for the detected language and framework.
Focus on both positive and negative test cases.
```

  1. Save it as a subagent in your `.qwen/agents/` directory
  2. Run qwen-code
  3. Run the `/agents manage` command
  4. Confirm that the newly created subagent is now listed.

## Testing Matrix

This is a documentation change so these tests are not relevant.
