### PR TITLE
fix: unable to quit when auth dialog is opened

### DIFF
--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -913,7 +913,21 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
         return;
       }
 
-      // 1. Close other dialogs (highest priority)
+      /**
+       * For AuthDialog it is required to complete the authentication process,
+       * otherwise user cannot proceed to the next step.
+       * So a quit on AuthDialog should go with normal two press quit
+       * and without quit-confirm dialog.
+       */
+      if (isAuthDialogOpen) {
+        setPressedOnce(true);
+        timerRef.current = setTimeout(() => {
+          setPressedOnce(false);
+        }, 500);
+        return;
+      }
+
+      //1. Close other dialogs (highest priority)
       if (closeAnyOpenDialog()) {
         return; // Dialog closed, end processing
       }
@@ -934,6 +948,7 @@ const App = ({ config, settings, startupWarnings = [], version }: AppProps) => {
       handleSlashCommand('/quit-confirm');
     },
     [
+      isAuthDialogOpen,
       handleSlashCommand,
       quitConfirmationRequest,
       closeAnyOpenDialog,

--- a/packages/cli/src/ui/components/QwenOAuthProgress.test.tsx
+++ b/packages/cli/src/ui/components/QwenOAuthProgress.test.tsx
@@ -81,7 +81,7 @@ describe('QwenOAuthProgress', () => {
       const output = lastFrame();
       expect(output).toContain('MockSpinner(dots)');
       expect(output).toContain('Waiting for Qwen OAuth authentication...');
-      expect(output).toContain('(Press ESC to cancel)');
+      expect(output).toContain('(Press ESC or CTRL+C to cancel)');
     });
 
     it('should render loading state with gray border', () => {
@@ -105,7 +105,7 @@ describe('QwenOAuthProgress', () => {
       expect(output).toContain('MockSpinner(dots)');
       expect(output).toContain('Waiting for authorization');
       expect(output).toContain('Time remaining: 5:00');
-      expect(output).toContain('(Press ESC to cancel)');
+      expect(output).toContain('(Press ESC or CTRL+C to cancel)');
     });
 
     it('should display correct URL in Static component when QR code is generated', async () => {

--- a/packages/cli/src/ui/components/QwenOAuthProgress.tsx
+++ b/packages/cli/src/ui/components/QwenOAuthProgress.tsx
@@ -110,7 +110,7 @@ function StatusDisplay({
         <Text color={Colors.Gray}>
           Time remaining: {formatTime(timeRemaining)}
         </Text>
-        <Text color={Colors.AccentPurple}>(Press ESC to cancel)</Text>
+        <Text color={Colors.AccentPurple}>(Press ESC or CTRL+C to cancel)</Text>
       </Box>
     </Box>
   );
@@ -132,7 +132,7 @@ export function QwenOAuthProgress({
     if (authStatus === 'timeout') {
       // Any key press in timeout state should trigger cancel to return to auth dialog
       onCancel();
-    } else if (key.escape) {
+    } else if (key.escape || (key.ctrl && input === 'c')) {
       onCancel();
     }
   });
@@ -250,7 +250,9 @@ export function QwenOAuthProgress({
             Time remaining: {Math.floor(timeRemaining / 60)}:
             {(timeRemaining % 60).toString().padStart(2, '0')}
           </Text>
-          <Text color={Colors.AccentPurple}>(Press ESC to cancel)</Text>
+          <Text color={Colors.AccentPurple}>
+            (Press ESC or CTRL+C to cancel)
+          </Text>
         </Box>
       </Box>
     );

--- a/packages/cli/src/ui/hooks/useDialogClose.ts
+++ b/packages/cli/src/ui/hooks/useDialogClose.ts
@@ -61,16 +61,6 @@ export function useDialogClose(options: DialogCloseOptions) {
       return true;
     }
 
-    if (options.isAuthDialogOpen) {
-      // Mimic ESC behavior: only close if already authenticated (same as AuthDialog ESC logic)
-      if (options.selectedAuthType !== undefined) {
-        // Note: We don't await this since we want non-blocking behavior like ESC
-        void options.handleAuthSelect(undefined, SettingScope.User);
-      }
-      // Note: AuthDialog prevents ESC exit if not authenticated, we follow same logic
-      return true;
-    }
-
     if (options.isEditorDialogOpen) {
       // Mimic ESC behavior: call onExit() directly
       options.exitEditorDialog();


### PR DESCRIPTION
## TLDR

Fixes an issue where users were unable to quit the application when the authentication dialog was open. The fix ensures that pressing CTRL+C twice in the auth dialog follows the normal quit flow instead of getting stuck in a loop.

## Dive Deeper

### Problem
Previously, when the authentication dialog was open, users couldn't quit the application using the standard CTRL+C twice pattern. The quit handler was trying to close the auth dialog first, but since the auth dialog requires completion of the authentication process, this created a loop where users couldn't exit.

### Solution

When the auth dialog is open, CTRL+C bypasses the dialog closing logic and goes directly to the normal two-press quit mechanism.

## Reviewer Test Plan

To test this fix:

1. **Test normal quit behavior**: 
   - Start the CLI application
   - Press CTRL+C twice to quit - should work normally

2. **Test auth dialog quit behavior**:
   - Start the CLI application without valid authentication
   - When the auth dialog appears, press CTRL+C twice
   - The application should quit normally without getting stuck

3. **Test OAuth progress quit behavior**:
   - Start the OAuth authentication flow
   - During the OAuth progress screen, try both ESC and CTRL+C
   - Both should cancel the OAuth process and return to the auth dialog
   - From the auth dialog, CTRL+C twice should quit the application

4. **Test other dialogs still work**:
   - Open other dialogs (editor, migration, etc.)
   - Verify CTRL+C still closes those dialogs first before quitting

## Testing Matrix


|          | 🍏   | 🪟   | 🐧   |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓   | ❓   |
| npx      | ✅   | ❓   | ❓   |
| Docker   | ❓   | ❓   | ❓   |
| Podman   | ❓   | -   | -   |
| Seatbelt | ❓   | -   | -   |

## Linked issues / bugs

Fixes #148 
Fixes #496 
