### PR TITLE
fix(core): handle null command in IDE detection

### DIFF
--- a/packages/core/src/ide/detect-ide.ts
+++ b/packages/core/src/ide/detect-ide.ts
@@ -101,7 +101,7 @@ function verifyVSCode(
   if (ide !== DetectedIde.VSCode) {
     return ide;
   }
-  if (ideProcessInfo.command.toLowerCase().includes('code')) {
+  if (ideProcessInfo.command?.toLowerCase().includes('code')) {
     return DetectedIde.VSCode;
   }
   return DetectedIde.VSCodeFork;

--- a/packages/core/src/ide/process-utils.ts
+++ b/packages/core/src/ide/process-utils.ts
@@ -44,7 +44,11 @@ async function getProcessInfo(pid: number): Promise<{
         ParentProcessId = 0,
         CommandLine = '',
       } = JSON.parse(output);
-      return { parentPid: ParentProcessId, name: Name, command: CommandLine ?? '' };
+      return {
+        parentPid: ParentProcessId,
+        name: Name,
+        command: CommandLine ?? '',
+      };
     } else {
       const command = `ps -o ppid=,command= -p ${pid}`;
       const { stdout } = await execAsync(command);

--- a/packages/core/src/ide/process-utils.ts
+++ b/packages/core/src/ide/process-utils.ts
@@ -44,7 +44,7 @@ async function getProcessInfo(pid: number): Promise<{
         ParentProcessId = 0,
         CommandLine = '',
       } = JSON.parse(output);
-      return { parentPid: ParentProcessId, name: Name, command: CommandLine };
+      return { parentPid: ParentProcessId, name: Name, command: CommandLine ?? '' };
     } else {
       const command = `ps -o ppid=,command= -p ${pid}`;
       const { stdout } = await execAsync(command);


### PR DESCRIPTION
Fixes #813

Prevented `TypeError: Cannot read properties of null (reading 'toLowerCase')`
by adding null safety in IDE detection.

✅ Added `?? ''` in process-utils.ts  
✅ Added `?.` in detect-ide.ts  
✅ All tests passed — no crash on null command