### PR TITLE
Change deepseek token limits regex patterns for deepseek-chat

### DIFF
--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -200,9 +200,9 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
 
   // Deepseek-chat: 8k max tokens
   [/^deepseek-chat$/, LIMITS['8k']],
-  
+
   // Deepseek-reasoner: 64k max tokens
-  [/^deepseek-reasoner$/, LIMITS['64k']]
+  [/^deepseek-reasoner$/, LIMITS['64k']],
 ];
 
 /**


### PR DESCRIPTION
## TLDR

Change deepseek token limits regex patterns for `deepseek-chat` and `deepseek-reasoner` as https://api-docs.deepseek.com/ said

