### PR TITLE
fix: WriteFile error with object content (#535)

### DIFF
--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -171,6 +171,18 @@ export abstract class DeclarativeTool<
   }
 
   /**
+   * Regularize the raw tool parameters.
+   * Subclasses may override this to add custom regularization logic
+   * before the JSON schema check.
+   * @param params The raw parameters from the model.
+   * @returns The regularized parameters.
+   */
+  protected regularizeToolParams(_params: TParams): TParams {
+    // Base implementation can be extended by subclasses.
+    return _params;
+  }
+
+  /**
    * Validates the raw tool parameters.
    * Subclasses should override this to add custom validation logic
    * beyond the JSON schema check.
@@ -279,11 +291,17 @@ export abstract class BaseDeclarativeTool<
   TResult extends ToolResult,
 > extends DeclarativeTool<TParams, TResult> {
   build(params: TParams): ToolInvocation<TParams, TResult> {
+    params = this.regularizeToolParams(params);
+
     const validationError = this.validateToolParams(params);
     if (validationError) {
       throw new Error(validationError);
     }
     return this.createInvocation(params);
+  }
+
+  protected override regularizeToolParams(_params: TParams): TParams {
+    return _params;
   }
 
   override validateToolParams(params: TParams): string | null {

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -384,6 +384,17 @@ export class WriteFileTool
     );
   }
 
+  protected override regularizeToolParams(
+    _params: WriteFileToolParams,
+  ): WriteFileToolParams {
+    // Issue: https://github.com/QwenLM/qwen-code/issues/535
+    // Workaround issue of some _params.content type is object, but their schema type is string.
+    if (typeof _params.content !== 'string') {
+      _params.content = JSON.stringify(_params.content, null, 2);
+    }
+    return _params;
+  }
+
   protected override validateToolParamValues(
     params: WriteFileToolParams,
   ): string | null {


### PR DESCRIPTION
## TLDR

A workaround for WriteFile issue in #535.

## Dive Deeper

Some original params.content type is object, but their schema type is string. My workaround checks this case and convert the object to string. I agree that this workaround is a bit ugly😅, but it just works.

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

A partial fix for WriteFile issue in #535. "Edit" issue in #535 is not addressed in this PR.

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
