### PR TITLE
fixbug: fix qwen help des

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -194,7 +194,7 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
     .option('proxy', {
       type: 'string',
       description:
-        'Proxy for gemini client, like schema://user:password@host:port',
+        'Proxy for Qwen Code, like schema://user:password@host:port',
     })
     .deprecateOption(
       'proxy',


### PR DESCRIPTION
## TLDR
Fixed misleading help text for the `--proxy` parameter in `qwen --help` command, changing the description from "Proxy for gemini client" to "Proxy for qwen-code" to accurately reflect the functionality.

## Dive Deeper
The current help information incorrectly described the `--proxy` parameter as "for gemini client", which could confuse users since this proxy setting is actually for Qwen code model services. This modification includes: **Accuracy Fix**: Corrected the help text from "gemini client" to "qwen-code"; **Consistency Maintenance**: Ensured command line help information aligns with actual functionality; **User Experience**: Prevented users from misconfiguring proxy settings due to misleading descriptions. This is a simple documentation fix that doesn't involve any code logic changes, but is important for improving user experience and documentation accuracy.

## Reviewer Test Plan
1. **Check Modification Content**: Confirm only the help text was updated without accidental changes to other code.
2. **Verify Help Output**: Run the following command to verify the fix:
   ```bash
   qwen --help | grep proxy


--proxy Proxy for qwen-code, like schema://user:password@host:port [deprecated: Use the "proxy" setting in settings.json instead. This flag will be removed in a future version.] [string]


Fixes #901 