### PR TITLE
Fix: Use runtime session ID in /bug command

### DIFF
--- a/packages/cli/src/ui/commands/bugCommand.test.ts
+++ b/packages/cli/src/ui/commands/bugCommand.test.ts
@@ -27,7 +27,6 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
         getDetectedIdeDisplayName: vi.fn().mockReturnValue('VSCode'),
       }),
     },
-    sessionId: 'test-session-id',
   };
 });
 vi.mock('node:process', () => ({
@@ -59,6 +58,7 @@ describe('bugCommand', () => {
           getModel: () => 'qwen3-coder-plus',
           getBugCommand: () => undefined,
           getIdeMode: () => true,
+          getSessionId: () => 'test-session-id',
         },
         settings: {
           merged: {
@@ -102,6 +102,7 @@ describe('bugCommand', () => {
           getModel: () => 'qwen3-coder-plus',
           getBugCommand: () => ({ urlTemplate: customTemplate }),
           getIdeMode: () => true,
+          getSessionId: () => 'test-session-id',
         },
         settings: {
           merged: {
@@ -143,6 +144,7 @@ describe('bugCommand', () => {
           getModel: () => 'qwen3-coder-plus',
           getBugCommand: () => undefined,
           getIdeMode: () => true,
+          getSessionId: () => 'test-session-id',
           getContentGeneratorConfig: () => ({
             baseUrl: 'https://api.openai.com/v1',
           }),

--- a/packages/cli/src/ui/commands/bugCommand.ts
+++ b/packages/cli/src/ui/commands/bugCommand.ts
@@ -15,7 +15,7 @@ import { MessageType } from '../types.js';
 import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
 import { formatMemoryUsage } from '../utils/formatters.js';
 import { getCliVersion } from '../../utils/version.js';
-import { IdeClient, sessionId, AuthType } from '@qwen-code/qwen-code-core';
+import { IdeClient, AuthType } from '@qwen-code/qwen-code-core';
 
 export const bugCommand: SlashCommand = {
   name: 'bug',
@@ -48,7 +48,7 @@ export const bugCommand: SlashCommand = {
     let info = `
 * **CLI Version:** ${cliVersion}
 * **Git Commit:** ${GIT_COMMIT_INFO}
-* **Session ID:** ${sessionId}
+* **Session ID:** ${config?.getSessionId() || 'unknown'}
 * **Operating System:** ${osVersion}
 * **Sandbox Environment:** ${sandboxEnv}
 * **Auth Type:** ${selectedAuthType}`;


### PR DESCRIPTION
## TLDR

Fixed `/bug` command to use the correct session ID from the `Config` instance instead of a static module-level UUID. The bug command was incorrectly importing a global static `sessionId` that was generated once at module load time, rather than using the session-specific ID stored in each `Config` instance.

## Dive Deeper


**The Problem:**
1. `packages/core/src/utils/session.ts` exports a static `sessionId` that is generated once when the module loads:
   ```typescript
   export const sessionId = randomUUID(); // Generated ONCE at module load
   ```

2. The `Config` class has its own instance-level `sessionId` that is passed in during construction and stored per instance:
   ```typescript
   export interface ConfigParameters {
     sessionId: string;  // Each Config instance has its own sessionId
     // ...
   }
   ```

3. The `/bug` command was importing and using the **static module-level** `sessionId`, which meant all bug reports would show the same ID regardless of which Config instance (session) was active.

**The Fix:**
Changed the `/bug` command to call `config.getSessionId()` to retrieve the **instance-level** session ID from the active Config object, ensuring each bug report contains the correct session ID for that specific session/Config instance.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

**Testing performed:**
- ✅ Unit tests pass on macOS (3/3 tests passing)
- ✅ Code compiles without errors
- ✅ No linter errors introduced

This PR fixes a code logic bug where the `/bug` command was using a static module-level session ID instead of the correct instance-level session ID from the Config object.