### PR TITLE
fix: update tool name from Gemini to Qwen Code in ToolsList component…

### DIFF
--- a/packages/cli/src/ui/components/views/ToolsList.tsx
+++ b/packages/cli/src/ui/components/views/ToolsList.tsx
@@ -23,7 +23,7 @@ export const ToolsList: React.FC<ToolsListProps> = ({
 }) => (
   <Box flexDirection="column" marginBottom={1}>
     <Text bold color={theme.text.primary}>
-      Available Gemini CLI tools:
+      Available Qwen Code CLI tools:
     </Text>
     <Box height={1} />
     {tools.length > 0 ? (

--- a/packages/cli/src/ui/components/views/__snapshots__/ToolsList.test.tsx.snap
+++ b/packages/cli/src/ui/components/views/__snapshots__/ToolsList.test.tsx.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`<ToolsList /> > renders correctly with descriptions 1`] = `
-"Available Gemini CLI tools:
+"Available Qwen Code CLI tools:
 
   - Test Tool One (test-tool-one)
     This is the first test tool.
@@ -16,14 +16,14 @@ exports[`<ToolsList /> > renders correctly with descriptions 1`] = `
 `;
 
 exports[`<ToolsList /> > renders correctly with no tools 1`] = `
-"Available Gemini CLI tools:
+"Available Qwen Code CLI tools:
 
  No tools available
 "
 `;
 
 exports[`<ToolsList /> > renders correctly without descriptions 1`] = `
-"Available Gemini CLI tools:
+"Available Qwen Code CLI tools:
 
   - Test Tool One
   - Test Tool Two


### PR DESCRIPTION
# PR Description Update

   ## TLDR

   When invoking `/tools`, the title "Available Qwen Code CLI tools" has been properly updated from the original "Available Gemini CLI tools" to reflect the Qwen Code CLI branding. This
   change ensures consistency with the rebranded application throughout the UI.

   ## Dive Deeper

   The `/tools` command in the Qwen Code CLI displays a list of available tools with the header "Available Qwen Code CLI tools:", which correctly reflects the rebranded application.
   This update maintains consistency with the renaming from "Gemini CLI" to "Qwen Code CLI" across the entire codebase.

   ## Reviewer Test Plan

   1. Pull the changes and run the Qwen Code CLI
   2. Execute the `/tools` command
   3. Verify that the header shows "Available Qwen Code CLI tools:"
   4. Verify that all functionality works as expected
   5. Test other commands to ensure no regressions were introduced

   ## Testing Matrix

   |          | 🍏  | 🪟  | 🐧  |
   | -------- | --- | --- | --- |
   | npm run  | ✅  | ✅  | ✅  |
   | npx      | ✅  | ✅  | ✅  |
   | Docker   | ✅  | ✅  | ✅  |
   | Podman   | ✅  | -   | -   |
   | Seatbelt | ✅  | -   | -   |

   ## Linked issues / bugs

   This PR ensures consistent branding throughout the application after the transition from Google's Gemini CLI to the Qwen Code CLI.