### PR TITLE
Fix: Preserve relative paths for macOS sandbox profile files

### DIFF
--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -18,7 +18,7 @@
 // limitations under the License.
 
 import { copyFileSync, existsSync, mkdirSync, statSync } from 'node:fs';
-import { dirname, join, basename } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { glob } from 'glob';
 import fs from 'node:fs';
@@ -33,10 +33,18 @@ if (!existsSync(distDir)) {
   mkdirSync(distDir);
 }
 
-// Find and copy all .sb files from packages to the root of the dist directory
+// Find and copy all .sb files from packages to preserve their relative paths in the dist directory
 const sbFiles = glob.sync('packages/**/*.sb', { cwd: root });
 for (const file of sbFiles) {
-  copyFileSync(join(root, file), join(distDir, basename(file)));
+  const sourcePath = join(root, file);
+  const destPath = join(distDir, file); // Preserve the relative path from packages/
+  const destDir = dirname(destPath);
+
+  if (!existsSync(destDir)) {
+    mkdirSync(destDir, { recursive: true });
+  }
+
+  copyFileSync(sourcePath, destPath);
 }
 
 console.log('Copied sandbox profiles to dist/');


### PR DESCRIPTION
This commit fixes issue #923 where Homebrew-installed Qwen Code would fail to start with sandbox mode enabled due to missing macOS Seatbelt profile files.

The problem was in the copy_bundle_assets.js script which was copying .sb files to the root of the dist directory instead of preserving their relative paths.

Now the .sb files are copied to match their source directory structure, ensuring they can be found at runtime by the sandbox.ts module when using new URL(`sandbox-macos-${profile}.sb`, import.meta.url).

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
