### PR TITLE
Fix: Include macOS Seatbelt Sandbox Files in NPM Package

### DIFF
--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -85,7 +85,7 @@ const distPackageJson = {
   bin: {
     qwen: 'cli.js',
   },
-  files: ['cli.js', 'vendor', 'README.md', 'LICENSE'],
+  files: ['cli.js', 'vendor', '*.sb', 'README.md', 'LICENSE'],
   config: rootPackageJson.config,
   dependencies: runtimeDependencies,
   optionalDependencies: {


### PR DESCRIPTION
## Problem

The NPM package distribution was missing critical macOS sandbox profile files (`*.sb`), which are required for the sandboxing functionality on macOS systems. When users installed `qwen-code` from NPM, these six seatbelt files were not included in the package:

- `sandbox-macos-permissive-closed.sb`
- `sandbox-macos-permissive-open.sb`
- `sandbox-macos-permissive-proxied.sb`
- `sandbox-macos-restrictive-closed.sb`
- `sandbox-macos-restrictive-open.sb`
- `sandbox-macos-restrictive-proxied.sb`

This caused the tool execution sandbox feature to fail on macOS when users tried to run the CLI with sandbox restrictions enabled.

## Root Cause

The `scripts/prepare-package.js` script, which generates the `package.json` for the published NPM package, was only including specific files in its `files` array:

```javascript
files: ['cli.js', 'vendor', 'README.md', 'LICENSE']
```

While the build process correctly copied the `.sb` files to the `dist/` directory, they were excluded from the published package due to the missing glob pattern.

## Solution

Updated the `files` array in `scripts/prepare-package.js` to include the glob pattern `'*.sb'`:

```javascript
files: ['cli.js', 'vendor', '*.sb', 'README.md', 'LICENSE']
```

This ensures all macOS Seatbelt sandbox profile files are included when the package is published to NPM.

## Impact

- ✅ macOS users can now use sandbox features with NPM-installed packages
- ✅ No breaking changes to existing functionality
- ✅ File size impact: ~13KB total (six small `.sb` text files)

## Linked issues / bugs

- Fixes #923 
