### PR TITLE
feat: implement subagent fullscreen panel functionality

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -49,6 +49,7 @@ describe('App', () => {
     quittingMessages: null,
     dialogsVisible: false,
     mainControlsRef: { current: null },
+    subagentFullscreenPanel: null,
     historyManager: {
       addItem: vi.fn(),
       history: [],

--- a/packages/cli/src/ui/App.tsx
+++ b/packages/cli/src/ui/App.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useIsScreenReaderEnabled } from 'ink';
+import { Box, useIsScreenReaderEnabled } from 'ink';
 import { useTerminalSize } from './hooks/useTerminalSize.js';
 import { lerp } from '../utils/math.js';
 import { useUIState } from './contexts/UIStateContext.js';
@@ -12,6 +12,7 @@ import { StreamingContext } from './contexts/StreamingContext.js';
 import { QuittingDisplay } from './components/QuittingDisplay.js';
 import { ScreenReaderAppLayout } from './layouts/ScreenReaderAppLayout.js';
 import { DefaultAppLayout } from './layouts/DefaultAppLayout.js';
+import { SubagentFullscreenPanel } from './components/subagents/runtime/SubagentFullscreenPanel.js';
 
 const getContainerWidth = (terminalWidth: number): string => {
   if (terminalWidth <= 80) {
@@ -38,12 +39,18 @@ export const App = () => {
     return <QuittingDisplay />;
   }
 
+  const showFullscreen = Boolean(uiState.subagentFullscreenPanel);
+  const mainLayout = isScreenReaderEnabled ? (
+    <ScreenReaderAppLayout />
+  ) : (
+    <DefaultAppLayout width={containerWidth} />
+  );
+
   return (
     <StreamingContext.Provider value={uiState.streamingState}>
-      {isScreenReaderEnabled ? (
-        <ScreenReaderAppLayout />
-      ) : (
-        <DefaultAppLayout width={containerWidth} />
+      <Box display={showFullscreen ? 'none' : 'flex'}>{mainLayout}</Box>
+      {showFullscreen && uiState.subagentFullscreenPanel && (
+        <SubagentFullscreenPanel panel={uiState.subagentFullscreenPanel} />
       )}
     </StreamingContext.Provider>
   );

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -634,6 +634,34 @@ describe('AppContainer State Management', () => {
       capturedUIActions.handleProQuotaChoice('auth');
       expect(mockHandler).toHaveBeenCalledWith('auth');
     });
+
+    it('disables the input prompt when subagent fullscreen panel is open', async () => {
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      expect(capturedUIState.isInputActive).toBe(true);
+
+      capturedUIActions.openSubagentFullscreenPanel({
+        panelId: 'test-panel',
+        subagentName: 'Agent',
+        status: 'running',
+        content: [],
+        getSnapshot: () => [],
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(capturedUIState.isInputActive).toBe(false);
+
+      capturedUIActions.closeSubagentFullscreenPanel('test-panel');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(capturedUIState.isInputActive).toBe(true);
+    });
   });
 
   describe('Terminal Title Update Feature', () => {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -26,6 +26,7 @@ import {
   ToolCallStatus,
   type HistoryItemWithoutId,
   AuthState,
+  type SubagentFullscreenPanelState,
 } from './types.js';
 import { MessageType, StreamingState } from './types.js';
 import {
@@ -149,6 +150,8 @@ export const AppContainer = (props: AppContainerProps) => {
     initializationResult.geminiMdFileCount,
   );
   const [shellModeActive, setShellModeActive] = useState(false);
+  const [subagentFullscreenPanel, setSubagentFullscreenPanel] =
+    useState<SubagentFullscreenPanelState | null>(null);
   const [modelSwitchedFromQuotaError, setModelSwitchedFromQuotaError] =
     useState<boolean>(false);
   const [historyRemountKey, setHistoryRemountKey] = useState(0);
@@ -450,6 +453,46 @@ export const AppContainer = (props: AppContainerProps) => {
     closeAgentsManagerDialog,
   } = useAgentsManagerDialog();
 
+  const openSubagentFullscreenPanel = useCallback(
+    (panel: SubagentFullscreenPanelState) => {
+      setSubagentFullscreenPanel(panel);
+    },
+    [],
+  );
+
+  const closeSubagentFullscreenPanel = useCallback((panelId: string) => {
+    setSubagentFullscreenPanel((current) => {
+      if (!current || current.panelId !== panelId) {
+        return current;
+      }
+      current.onClose?.();
+      return null;
+    });
+  }, []);
+
+  const updateSubagentFullscreenPanel = useCallback(
+    (
+      panelId: string,
+      updates: Partial<
+        Pick<
+          SubagentFullscreenPanelState,
+          'content' | 'status' | 'subagentName'
+        >
+      >,
+    ) => {
+      setSubagentFullscreenPanel((current) => {
+        if (!current || current.panelId !== panelId) {
+          return current;
+        }
+        return {
+          ...current,
+          ...updates,
+        };
+      });
+    },
+    [],
+  );
+
   // Vision model auto-switch dialog state (must be before slashCommandActions)
   const [isVisionSwitchDialogOpen, setIsVisionSwitchDialogOpen] =
     useState(false);
@@ -730,7 +773,8 @@ export const AppContainer = (props: AppContainerProps) => {
     !isProcessing &&
     (streamingState === StreamingState.Idle ||
       streamingState === StreamingState.Responding) &&
-    !proQuotaRequest;
+    !proQuotaRequest &&
+    !subagentFullscreenPanel;
 
   const [controlsHeight, setControlsHeight] = useState(0);
 
@@ -1294,6 +1338,7 @@ export const AppContainer = (props: AppContainerProps) => {
       // Subagent dialogs
       isSubagentCreateDialogOpen,
       isAgentsManagerDialogOpen,
+      subagentFullscreenPanel,
     }),
     [
       isThemeDialogOpen,
@@ -1389,6 +1434,7 @@ export const AppContainer = (props: AppContainerProps) => {
       // Subagent dialogs
       isSubagentCreateDialogOpen,
       isAgentsManagerDialogOpen,
+      subagentFullscreenPanel,
     ],
   );
 
@@ -1427,6 +1473,9 @@ export const AppContainer = (props: AppContainerProps) => {
       // Subagent dialogs
       closeSubagentCreateDialog,
       closeAgentsManagerDialog,
+      openSubagentFullscreenPanel,
+      closeSubagentFullscreenPanel,
+      updateSubagentFullscreenPanel,
     }),
     [
       handleThemeSelect,
@@ -1460,6 +1509,9 @@ export const AppContainer = (props: AppContainerProps) => {
       // Subagent dialogs
       closeSubagentCreateDialog,
       closeAgentsManagerDialog,
+      openSubagentFullscreenPanel,
+      closeSubagentFullscreenPanel,
+      updateSubagentFullscreenPanel,
     ],
   );
 

--- a/packages/cli/src/ui/components/Composer.test.tsx
+++ b/packages/cli/src/ui/components/Composer.test.tsx
@@ -124,6 +124,7 @@ const createMockUIState = (overrides: Partial<UIState> = {}): UIState =>
     errorCount: 0,
     nightly: false,
     isTrustedFolder: true,
+    subagentFullscreenPanel: null,
     ...overrides,
   }) as UIState;
 
@@ -134,6 +135,9 @@ const createMockUIActions = (): UIActions =>
     setShellModeActive: vi.fn(),
     onEscapePromptChange: vi.fn(),
     vimHandleInput: vi.fn(),
+    openSubagentFullscreenPanel: vi.fn(),
+    closeSubagentFullscreenPanel: vi.fn(),
+    updateSubagentFullscreenPanel: vi.fn(),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }) as any;
 

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -52,6 +52,7 @@ const createMockUIState = (overrides: Partial<UIState> = {}): UIState =>
       lastPromptTokenCount: 100,
     },
     branchName: defaultProps.branchName,
+    subagentFullscreenPanel: null,
     ...overrides,
   }) as UIState;
 

--- a/packages/cli/src/ui/components/subagents/runtime/SubagentFullscreenPanel.tsx
+++ b/packages/cli/src/ui/components/subagents/runtime/SubagentFullscreenPanel.tsx
@@ -1,0 +1,171 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { Box, Text } from 'ink';
+import { useTerminalSize } from '../../../hooks/useTerminalSize.js';
+import { useKeypress } from '../../../hooks/useKeypress.js';
+import { theme } from '../../../semantic-colors.js';
+import { useUIActions } from '../../../contexts/UIActionsContext.js';
+import type { SubagentFullscreenPanelState } from '../../../types.js';
+import { getStatusColor, getStatusText } from './status.js';
+import { CTRL_ALT_E_SEQUENCE } from './fullscreenKeys.js';
+
+const FULLSCREEN_INSTRUCTION_TEXT =
+  '↑/↓ scroll   PgUp/PgDn page   Home/End jump   q quit   ctrl+alt+e close';
+
+interface SubagentFullscreenPanelProps {
+  panel: SubagentFullscreenPanelState;
+}
+
+export const SubagentFullscreenPanel: React.FC<
+  SubagentFullscreenPanelProps
+> = ({ panel }) => {
+  const { closeSubagentFullscreenPanel } = useUIActions();
+  const { rows, columns } = useTerminalSize();
+  const viewportHeight = Math.max(1, rows - 10); // header/footer padding
+  const panelWidth = Math.max(6, columns - 2); // keep space for borders + padding at minimum
+  const content = React.useMemo(
+    () => panel.content ?? panel.getSnapshot?.() ?? [],
+    [panel],
+  );
+  const previousContentLengthRef = React.useRef(content.length);
+  const [scrollOffset, setScrollOffset] = React.useState(() =>
+    Math.max(0, content.length - viewportHeight),
+  );
+  const [lastRefreshedAt, setLastRefreshedAt] = React.useState<Date | null>(
+    new Date(),
+  );
+
+  const panelId = panel.panelId;
+
+  const closePanel = React.useCallback(() => {
+    closeSubagentFullscreenPanel(panelId);
+  }, [closeSubagentFullscreenPanel, panelId]);
+
+  React.useEffect(() => {
+    const maxOffset = Math.max(0, content.length - viewportHeight);
+    setScrollOffset((previous) => {
+      const previousLength = previousContentLengthRef.current;
+      const previousMaxOffset = Math.max(0, previousLength - viewportHeight);
+      const wasPinnedToBottom = previous >= previousMaxOffset;
+      previousContentLengthRef.current = content.length;
+      return wasPinnedToBottom ? maxOffset : Math.min(previous, maxOffset);
+    });
+    setLastRefreshedAt(new Date());
+  }, [content, viewportHeight]);
+
+  useKeypress(
+    (key) => {
+      const sequence = key.sequence ?? '';
+      const isCtrlAltE =
+        (key.ctrl && key.meta && key.name === 'e') ||
+        sequence === CTRL_ALT_E_SEQUENCE;
+
+      if (isCtrlAltE) {
+        closePanel();
+        return;
+      }
+
+      if (key.ctrl || key.meta) {
+        return;
+      }
+
+      const maxOffset = Math.max(0, content.length - viewportHeight);
+
+      switch (key.name) {
+        case 'q':
+        case 'escape':
+          closePanel();
+          return;
+        case 'up':
+          setScrollOffset((previous) => Math.max(0, previous - 1));
+          return;
+        case 'down':
+          setScrollOffset((previous) => Math.min(maxOffset, previous + 1));
+          return;
+        case 'pageup':
+          setScrollOffset((previous) => Math.max(0, previous - viewportHeight));
+          return;
+        case 'pagedown':
+          setScrollOffset((previous) =>
+            Math.min(maxOffset, previous + viewportHeight),
+          );
+          return;
+        case 'home':
+          setScrollOffset(0);
+          return;
+        case 'end':
+          setScrollOffset(maxOffset);
+          return;
+        default:
+          break;
+      }
+    },
+    { isActive: true },
+  );
+
+  const visibleLines = content.slice(
+    scrollOffset,
+    scrollOffset + viewportHeight,
+  );
+  const paddingLineCount = Math.max(0, viewportHeight - visibleLines.length);
+  const rangeText =
+    content.length > 0
+      ? `Lines ${Math.min(scrollOffset + 1, content.length)}-${Math.min(
+          scrollOffset + viewportHeight,
+          content.length,
+        )} / ${content.length}`
+      : 'Waiting for execution data';
+  const lastRefreshText = lastRefreshedAt
+    ? `Last updated at ${lastRefreshedAt.toLocaleTimeString()}`
+    : 'Waiting for execution data';
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      width={panelWidth}
+      paddingX={1}
+    >
+      <Box
+        flexDirection="row"
+        justifyContent="space-between"
+        marginBottom={1}
+        flexShrink={0}
+      >
+        <Text bold color={theme.text.primary} wrap="truncate-end">
+          {panel.subagentName}
+        </Text>
+        <Text color={theme.text.secondary} wrap="truncate-end">
+          {lastRefreshText}
+        </Text>
+      </Box>
+
+      <Box flexDirection="row" justifyContent="space-between" marginBottom={1}>
+        <Text color={getStatusColor(panel.status)}>
+          {getStatusText(panel.status)}
+        </Text>
+        <Text color={theme.text.secondary}>{rangeText}</Text>
+      </Box>
+
+      <Box flexDirection="column" flexShrink={0}>
+        {visibleLines.map((line, index) => (
+          <Text key={`line-${scrollOffset + index}`} wrap="truncate-end">
+            {line}
+          </Text>
+        ))}
+        {Array.from({ length: paddingLineCount }).map((_, index) => (
+          <Text key={`pad-${index}`}> </Text>
+        ))}
+      </Box>
+
+      <Box flexDirection="column" gap={0} flexShrink={0} marginTop={1}>
+        <Text color={theme.text.secondary}>{FULLSCREEN_INSTRUCTION_TEXT}</Text>
+      </Box>
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/components/subagents/runtime/fullscreenKeys.ts
+++ b/packages/cli/src/ui/components/subagents/runtime/fullscreenKeys.ts
@@ -1,0 +1,7 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const CTRL_ALT_E_SEQUENCE = '\u001b\u0005';

--- a/packages/cli/src/ui/components/subagents/runtime/status.ts
+++ b/packages/cli/src/ui/components/subagents/runtime/status.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { TaskResultDisplay } from '@qwen-code/qwen-code-core';
+import { theme } from '../../../semantic-colors.js';
+
+export const getStatusColor = (
+  status:
+    | TaskResultDisplay['status']
+    | 'executing'
+    | 'success'
+    | 'awaiting_approval',
+) => {
+  switch (status) {
+    case 'running':
+    case 'executing':
+    case 'awaiting_approval':
+      return theme.status.warning;
+    case 'completed':
+    case 'success':
+      return theme.status.success;
+    case 'cancelled':
+      return theme.status.warning;
+    case 'failed':
+      return theme.status.error;
+    default:
+      return theme.text.secondary;
+  }
+};
+
+export const getStatusText = (status: TaskResultDisplay['status']) => {
+  switch (status) {
+    case 'running':
+      return 'Running';
+    case 'completed':
+      return 'Completed';
+    case 'cancelled':
+      return 'User Cancelled';
+    case 'failed':
+      return 'Failed';
+    default:
+      return 'Unknown';
+  }
+};

--- a/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -10,7 +10,7 @@ import { type IdeIntegrationNudgeResult } from '../IdeIntegrationNudge.js';
 import { type FolderTrustChoice } from '../components/FolderTrustDialog.js';
 import { type AuthType, type EditorType } from '@qwen-code/qwen-code-core';
 import { type SettingScope } from '../../config/settings.js';
-import type { AuthState } from '../types.js';
+import type { AuthState, SubagentFullscreenPanelState } from '../types.js';
 import { type VisionSwitchOutcome } from '../components/ModelSwitchDialog.js';
 
 export interface UIActions {
@@ -56,6 +56,14 @@ export interface UIActions {
   // Subagent dialogs
   closeSubagentCreateDialog: () => void;
   closeAgentsManagerDialog: () => void;
+  openSubagentFullscreenPanel: (panel: SubagentFullscreenPanelState) => void;
+  closeSubagentFullscreenPanel: (panelId: string) => void;
+  updateSubagentFullscreenPanel: (
+    panelId: string,
+    updates: Partial<
+      Pick<SubagentFullscreenPanelState, 'content' | 'status' | 'subagentName'>
+    >,
+  ) => void;
 }
 
 export const UIActionsContext = createContext<UIActions | null>(null);

--- a/packages/cli/src/ui/contexts/UIStateContext.tsx
+++ b/packages/cli/src/ui/contexts/UIStateContext.tsx
@@ -15,7 +15,7 @@ import type {
   QuitConfirmationRequest,
   HistoryItemWithoutId,
   StreamingState,
-} from '../types.js';
+ SubagentFullscreenPanelState } from '../types.js';
 import type { DeviceAuthorizationInfo } from '../hooks/useQwenAuth.js';
 import type { CommandContext, SlashCommand } from '../commands/types.js';
 import type { TextBuffer } from '../components/shared/text-buffer.js';
@@ -145,6 +145,7 @@ export interface UIState {
   // Subagent dialogs
   isSubagentCreateDialogOpen: boolean;
   isAgentsManagerDialogOpen: boolean;
+  subagentFullscreenPanel: SubagentFullscreenPanelState | null;
 }
 
 export const UIStateContext = createContext<UIState | null>(null);

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -11,6 +11,7 @@ import type {
   ToolCallConfirmationDetails,
   ToolConfirmationOutcome,
   ToolResultDisplay,
+  TaskResultDisplay,
 } from '@qwen-code/qwen-code-core';
 import type { PartListUnion } from '@google/genai';
 import { type ReactNode } from 'react';
@@ -161,6 +162,15 @@ export type HistoryItemToolGroup = HistoryItemBase & {
   type: 'tool_group';
   tools: IndividualToolCallDisplay[];
 };
+
+export interface SubagentFullscreenPanelState {
+  panelId: string;
+  subagentName: string;
+  status: TaskResultDisplay['status'];
+  content: string[];
+  getSnapshot?: () => string[];
+  onClose?: () => void;
+}
 
 export type HistoryItemUserShell = HistoryItemBase & {
   type: 'user_shell';


### PR DESCRIPTION
## TLDR

- 新增任务执行全屏面板，支持 ctrl+alt+e 快捷键提示与实时同步。
- AgentExecutionDisplay 与全屏面板双向同步内容，保持原有 ctrl+e/ctrl+r 显示模式逻辑不变。
- 紧凑模式与任务详情区域均提示全屏快捷键，避免用户错过。

## Dive Deeper

### 核心改动
- AgentExecutionDisplay
  - 引入 `fullscreenContent` useMemo 与 `updateSubagentFullscreenPanel`，保持实时同步。
  - 默认/详尽模式在任务详情下方显示 `ctrl+alt+e` 提示，紧凑模式末尾也显示提示。
- SubagentFullscreenPanel
  - 使用上层提供的 `content` 渲染，移除 `r` 刷新逻辑。
  - 帮助文案移至底部，提示滚动、翻页、退出和 `ctrl+alt+e`。
  - 全屏状态下禁用底部输入框，避免按键写入。
- UIState/UIActions/AppContainer
  - 新增 `updateSubagentFullscreenPanel`，并在 `UIState` 持有当前面板状态。
  - `isInputActive` 仅在面板关闭时才允许输入。

### 其他
- ctrl+e / ctrl+r 对显示模式的切换逻辑未变，compact、default、verbose 三种模式保持原状。
- 更新相关测试（AppContainer、Composer、Footer）以覆盖新增状态与操作。
- 保持 `TaskPromptSection` 兼容 compact 模式（无提示），default/verbose 模式显示提示。

## Reviewer Test Plan

1. npm run build
2. npx vitest run packages/cli/src/ui/AppContainer.test.tsx packages/cli/src/ui/components/Composer.test.tsx packages/cli/src/ui/components/Footer.test.tsx
3. 手动：运行 CLI，触发子代理任务，使用 ctrl+alt+e 开启/关闭全屏，观察输入框禁用与提示文案。

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ✅  | ❓  | ✅  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- https://github.com/QwenLM/qwen-code/pull/942

## 实现效果

PS: 因为GitHub上传的视频有大小限制，所以视频加速了3倍播放，并做了压缩处理，所以很不清晰。

https://github.com/user-attachments/assets/80a0c687-6aeb-45ed-94f8-360f02d2864c


