### PR TITLE
fix: Stream parsing for Windows Zed integration

### DIFF
--- a/packages/cli/src/zed-integration/acp.ts
+++ b/packages/cli/src/zed-integration/acp.ts
@@ -7,7 +7,6 @@
 /* ACP defines a schema for a simple (experimental) JSON-RPC protocol that allows GUI applications to interact with agents. */
 
 import { z } from 'zod';
-import { EOL } from 'node:os';
 import * as schema from './schema.js';
 export * from './schema.js';
 
@@ -173,7 +172,7 @@ class Connection {
     const decoder = new TextDecoder();
     for await (const chunk of output) {
       content += decoder.decode(chunk, { stream: true });
-      const lines = content.split(EOL);
+      const lines = content.split('\n');
       content = lines.pop() || '';
 
       for (const line of lines) {


### PR DESCRIPTION
## TLDR
Fixes the connection issue with qwen-code on Windows (#963) by replacing platform-specific `EOL` with universal `\n` for line splitting in ACP output processing, ensuring cross-platform compatibility.

## Dive Deeper
The root cause was using `EOL` from Node.js's `os` module for splitting output lines. On Windows, `EOL` is `\r\n`, while text decoders output `\n` regardless of platform. This mismatch prevented proper ACP message parsing on Windows, causing indefinite connection hangs.

Standardizing on `\n` ensures consistent parsing across macOS, Linux, and Windows. Aligns with google-gemini/gemini-cli#7880  and maintains backward compatibility.

## Reviewer Test Plan
1. Pull branch and install dependencies
2. Windows (primary target):
   - Configure Zed with qwen-code agent
   - Open Agent Panel and send a message
   - Verify connection establishes without freezing
3. macOS/Linux:
   - Perform same test for regression check
   - Verify normal message send/receive

Example config:
```json
{
  "agent_servers": {
    "Qwen Code": {
      "command": "C:\\PATH\\npm\\qwen.cmd",
      "args": ["--experimental-acp"],
      "env": {}
    }
  }
}
```

## Linked issues / bugs
Fixes #963 