### PR TITLE
fix: print request errors for logging only in debug mode

### DIFF
--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
@@ -48,7 +48,6 @@ import type {
 } from './event-types.js';
 import type { Config } from '../../config/config.js';
 import { safeJsonStringify } from '../../utils/safeJsonStringify.js';
-import { type HttpError, retryWithBackoff } from '../../utils/retry.js';
 import { InstallationManager } from '../../utils/installationManager.js';
 import { FixedDeque } from 'mnemonist';
 import { AuthType } from '../../core/contentGenerator.js';
@@ -288,8 +287,8 @@ export class QwenLogger {
     const rumPayload = await this.createRumPayload();
     // Override events with the ones we're sending
     rumPayload.events = eventsToSend;
-    const flushFn = () =>
-      new Promise<Buffer>((resolve, reject) => {
+    try {
+      await new Promise<Buffer>((resolve, reject) => {
         const body = safeJsonStringify(rumPayload);
         const options = {
           hostname: USAGE_STATS_HOSTNAME,
@@ -311,10 +310,9 @@ export class QwenLogger {
               res.statusCode &&
               (res.statusCode < 200 || res.statusCode >= 300)
             ) {
-              const err: HttpError = new Error(
+              const err = new Error(
                 `Request failed with status ${res.statusCode}`,
               );
-              err.status = res.statusCode;
               res.resume();
               return reject(err);
             }
@@ -326,26 +324,11 @@ export class QwenLogger {
         req.end(body);
       });
 
-    try {
-      await retryWithBackoff(flushFn, {
-        maxAttempts: 3,
-        initialDelayMs: 200,
-        shouldRetryOnError: (err: unknown) => {
-          if (!(err instanceof Error)) return false;
-          const status = (err as HttpError).status as number | undefined;
-          // If status is not available, it's likely a network error
-          if (status === undefined) return true;
-
-          // Retry on 429 (Too many Requests) and 5xx server errors.
-          return status === 429 || (status >= 500 && status < 600);
-        },
-      });
-
       this.lastFlushTime = Date.now();
       return {};
     } catch (error) {
       if (this.config?.getDebugMode()) {
-        console.error('RUM flush failed after multiple retries.', error);
+        console.error('RUM flush failed.', error);
       }
 
       // Re-queue failed events for retry


### PR DESCRIPTION
## TLDR

This PR addresses the request failures of logging service, with the following changes:
- Remove retry logic, enqueue failed log events with limited queue size
- Enable request failure logging only in debug mode
