### PR TITLE
feat: add support for alternative cached_tokens format in OpenAI conv…

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -24,6 +24,14 @@ import { safeJsonParse } from '../../utils/safeJsonParse.js';
 import { StreamingToolCallParser } from './streamingToolCallParser.js';
 
 /**
+ * Extended usage type that supports both OpenAI standard format and alternative formats
+ * Some models return cached_tokens at the top level instead of in prompt_tokens_details
+ */
+interface ExtendedCompletionUsage extends OpenAI.CompletionUsage {
+  cached_tokens?: number;
+}
+
+/**
  * Tool call accumulator for streaming responses
  */
 export interface ToolCallAccumulator {
@@ -582,7 +590,13 @@ export class OpenAIContentConverter {
       const promptTokens = usage.prompt_tokens || 0;
       const completionTokens = usage.completion_tokens || 0;
       const totalTokens = usage.total_tokens || 0;
-      const cachedTokens = usage.prompt_tokens_details?.cached_tokens || 0;
+      // Support both formats: prompt_tokens_details.cached_tokens (OpenAI standard)
+      // and cached_tokens (some models return it at top level)
+      const extendedUsage = usage as ExtendedCompletionUsage;
+      const cachedTokens =
+        usage.prompt_tokens_details?.cached_tokens ??
+        extendedUsage.cached_tokens ??
+        0;
 
       // If we only have total tokens but no breakdown, estimate the split
       // Typically input is ~70% and output is ~30% for most conversations
@@ -707,7 +721,13 @@ export class OpenAIContentConverter {
       const promptTokens = usage.prompt_tokens || 0;
       const completionTokens = usage.completion_tokens || 0;
       const totalTokens = usage.total_tokens || 0;
-      const cachedTokens = usage.prompt_tokens_details?.cached_tokens || 0;
+      // Support both formats: prompt_tokens_details.cached_tokens (OpenAI standard)
+      // and cached_tokens (some models return it at top level)
+      const extendedUsage = usage as ExtendedCompletionUsage;
+      const cachedTokens =
+        usage.prompt_tokens_details?.cached_tokens ??
+        extendedUsage.cached_tokens ??
+        0;
 
       // If we only have total tokens but no breakdown, estimate the split
       // Typically input is ~70% and output is ~30% for most conversations


### PR DESCRIPTION
## TLDR

**Problem**: Different model providers return cached token counts in different formats - some use OpenAI's standard `usage.prompt_tokens_details.cached_tokens`, while others use `usage.cached_tokens` at the top level.
https://platform.moonshot.cn/docs/api/chat#%E8%BF%94%E5%9B%9E%E5%86%85%E5%AE%B9

**Solution**: Extended the cached token extraction logic to support both formats with fallback priority. Added type-safe `ExtendedCompletionUsage` interface to avoid ESLint violations. Changes applied to both `convertOpenAIResponseToGemini` and `convertOpenAIChunkToGemini` methods.

## Test screenshot
### Official version
<img width="990" height="713" alt="path-image-20b8276239184c26946fac191cc978dc" src="https://github.com/user-attachments/assets/551ad8d1-b17f-4dba-b7ad-fb832a7292bb" />

### Development branch
<img width="990" height="713" alt="path-image-1e5ed6dac78d44a0b43aa3f1f2d7b9ef" src="https://github.com/user-attachments/assets/c50a1cb0-99fe-427b-b5e9-a50e550fd9f6" />
I think it's 100% because I asked the same question.The change itself is very small.
<img width="990" height="713" alt="path-image-51f08ea983f14a1a910569f92d483004" src="https://github.com/user-attachments/assets/540bfdb7-bf2e-42fb-84f7-0f7409cea163" />

## Testing Matrix
|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
https://github.com/QwenLM/qwen-code/issues/1033
