### PR TITLE
🎯 Enhance QwenLogger with OS Platform and Version Metadata

### DIFF
--- a/packages/core/src/telemetry/qwen-logger/event-types.ts
+++ b/packages/core/src/telemetry/qwen-logger/event-types.ts
@@ -19,6 +19,21 @@ export interface RumView {
   name: string;
 }
 
+export interface RumOS {
+  type?: string;
+  version?: string;
+  container?: string;
+  container_version?: string;
+}
+
+export interface RumDevice {
+  id?: string;
+  name?: string;
+  type?: string;
+  brand?: string;
+  model?: string;
+}
+
 export interface RumEvent {
   timestamp?: number;
   event_type?: 'view' | 'action' | 'exception' | 'resource';
@@ -78,6 +93,8 @@ export interface RumPayload {
   user: RumUser;
   session: RumSession;
   view: RumView;
+  os?: RumOS;
+  device?: RumDevice;
   events: RumEvent[];
   properties?: Record<string, unknown>;
   _v: string;

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
@@ -6,6 +6,7 @@
 
 import { Buffer } from 'buffer';
 import * as https from 'https';
+import * as os from 'node:os';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 
 import type {
@@ -45,6 +46,7 @@ import type {
   RumResourceEvent,
   RumExceptionEvent,
   RumPayload,
+  RumOS,
 } from './event-types.js';
 import type { Config } from '../../config/config.js';
 import { safeJsonStringify } from '../../utils/safeJsonStringify.js';
@@ -214,9 +216,17 @@ export class QwenLogger {
     return this.createRumEvent('exception', type, name, properties);
   }
 
+  private getOsMetadata(): RumOS {
+    return {
+      type: os.platform(),
+      version: os.release(),
+    };
+  }
+
   async createRumPayload(): Promise<RumPayload> {
     const authType = this.config?.getAuthType();
     const version = this.config?.getCliVersion() || 'unknown';
+    const osMetadata = this.getOsMetadata();
 
     return {
       app: {
@@ -235,6 +245,7 @@ export class QwenLogger {
         id: this.sessionId,
         name: 'qwen-code-cli',
       },
+      os: osMetadata,
 
       events: this.events.toArray() as RumEvent[],
       properties: {


### PR DESCRIPTION
## Summary

This PR adds operating system platform and version information to the telemetry payload in `QwenLogger`, providing valuable insights into the runtime environment of Qwen Code CLI users.