### PR TITLE
fix: character encoding corruption when executing the /copy command on Windows.

### DIFF
--- a/packages/cli/src/ui/utils/commandUtils.test.ts
+++ b/packages/cli/src/ui/utils/commandUtils.test.ts
@@ -13,6 +13,7 @@ import {
   isSlashCommand,
   copyToClipboard,
   getUrlOpenCommand,
+  CodePage,
 } from './commandUtils.js';
 
 // Mock child_process
@@ -188,7 +189,10 @@ describe('commandUtils', () => {
 
         await copyToClipboard(testText);
 
-        expect(mockSpawn).toHaveBeenCalledWith('clip', []);
+        expect(mockSpawn).toHaveBeenCalledWith('cmd', [
+          '/c',
+          `chcp ${CodePage.UTF8} >nul && clip`,
+        ]);
         expect(mockChild.stdin.write).toHaveBeenCalledWith(testText);
         expect(mockChild.stdin.end).toHaveBeenCalled();
       });

--- a/packages/cli/src/ui/utils/commandUtils.ts
+++ b/packages/cli/src/ui/utils/commandUtils.ts
@@ -5,7 +5,7 @@
  */
 
 import type { SpawnOptions } from 'node:child_process';
-import { spawn, execSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
 
 /**
  * Common Windows console code pages (CP) used for encoding conversions.
@@ -96,14 +96,8 @@ export const copyToClipboard = async (text: string): Promise<void> => {
   const linuxOptions: SpawnOptions = { stdio: ['pipe', 'inherit', 'pipe'] };
 
   switch (process.platform) {
-    case 'win32': {
-      const chcpOut = execSync('chcp', { encoding: 'utf8' });
-      const originalCp = chcpOut.match(/\d+/)?.[0] ?? String(CodePage.GBK);
-      return run('cmd', [
-        '/c',
-        `chcp ${CodePage.UTF8} >nul && clip && chcp ${originalCp} >nul`,
-      ]);
-    }
+    case 'win32':
+      return run('cmd', ['/c', `chcp ${CodePage.UTF8} >nul && clip`]);
     case 'darwin':
       return run('pbcopy', []);
     case 'linux':


### PR DESCRIPTION
## TLDR

When executing the /copy command on Windows, garbled text occurs because the child process's code page doesn't match the main process's encoding. Therefore, before running /copy, we need to switch the child process's code page to UTF-8 to ensure consistent encoding.

## Dive Deeper


## Reviewer Test Plan

Use this prompt: "请使用中文介绍JavaScript中??和||的区别", then run `/copy` command.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1016 
