### PR TITLE
refactor(auth): enhance useAuthCommand to include history management …

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -353,7 +353,7 @@ export const AppContainer = (props: AppContainerProps) => {
     handleAuthSelect,
     openAuthDialog,
     cancelAuthentication,
-  } = useAuthCommand(settings, config);
+  } = useAuthCommand(settings, config, historyManager.addItem);
 
   const { proQuotaRequest, handleProQuotaChoice } = useQuotaAndFallback({
     config,

--- a/packages/cli/src/ui/auth/useAuth.ts
+++ b/packages/cli/src/ui/auth/useAuth.ts
@@ -4,23 +4,28 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useCallback, useEffect } from 'react';
-import type { LoadedSettings, SettingScope } from '../../config/settings.js';
 import type { Config } from '@qwen-code/qwen-code-core';
 import {
+  AuthEvent,
   AuthType,
   clearCachedCredentialFile,
   getErrorMessage,
   logAuth,
-  AuthEvent,
 } from '@qwen-code/qwen-code-core';
-import { AuthState } from '../types.js';
-import { useQwenAuth } from '../hooks/useQwenAuth.js';
+import { useCallback, useEffect, useState } from 'react';
+import type { LoadedSettings, SettingScope } from '../../config/settings.js';
 import type { OpenAICredentials } from '../components/OpenAIKeyPrompt.js';
+import { useQwenAuth } from '../hooks/useQwenAuth.js';
+import { AuthState, MessageType } from '../types.js';
+import type { HistoryItem } from '../types.js';
 
 export type { QwenAuthState } from '../hooks/useQwenAuth.js';
 
-export const useAuthCommand = (settings: LoadedSettings, config: Config) => {
+export const useAuthCommand = (
+  settings: LoadedSettings,
+  config: Config,
+  addItem: (item: Omit<HistoryItem, 'id'>, timestamp: number) => void,
+) => {
   const unAuthenticated =
     settings.merged.security?.auth?.selectedType === undefined;
 
@@ -117,8 +122,17 @@ export const useAuthCommand = (settings: LoadedSettings, config: Config) => {
       // Log authentication success
       const authEvent = new AuthEvent(authType, 'manual', 'success');
       logAuth(config, authEvent);
+
+      // Show success message
+      addItem(
+        {
+          type: MessageType.INFO,
+          text: `Authenticated successfully with ${authType} credentials.`,
+        },
+        Date.now(),
+      );
     },
-    [settings, handleAuthFailure, config],
+    [settings, handleAuthFailure, config, addItem],
   );
 
   const performAuth = useCallback(

--- a/packages/core/src/qwen/qwenOAuth2.test.ts
+++ b/packages/core/src/qwen/qwenOAuth2.test.ts
@@ -623,14 +623,16 @@ describe('QwenOAuth2Client', () => {
     });
 
     it('should handle authorization_pending with HTTP 400 according to RFC 8628', async () => {
+      const errorData = {
+        error: 'authorization_pending',
+        error_description: 'The authorization request is still pending',
+      };
       const mockResponse = {
         ok: false,
         status: 400,
         statusText: 'Bad Request',
-        json: async () => ({
-          error: 'authorization_pending',
-          error_description: 'The authorization request is still pending',
-        }),
+        text: async () => JSON.stringify(errorData),
+        json: async () => errorData,
       };
 
       vi.mocked(global.fetch).mockResolvedValue(mockResponse as Response);
@@ -646,14 +648,16 @@ describe('QwenOAuth2Client', () => {
     });
 
     it('should handle slow_down with HTTP 429 according to RFC 8628', async () => {
+      const errorData = {
+        error: 'slow_down',
+        error_description: 'The client is polling too frequently',
+      };
       const mockResponse = {
         ok: false,
         status: 429,
         statusText: 'Too Many Requests',
-        json: async () => ({
-          error: 'slow_down',
-          error_description: 'The client is polling too frequently',
-        }),
+        text: async () => JSON.stringify(errorData),
+        json: async () => errorData,
       };
 
       vi.mocked(global.fetch).mockResolvedValue(mockResponse as Response);
@@ -1993,14 +1997,16 @@ describe('Enhanced Error Handling and Edge Cases', () => {
     });
 
     it('should handle authorization_pending with correct status', async () => {
+      const errorData = {
+        error: 'authorization_pending',
+        error_description: 'Authorization request is pending',
+      };
       const mockResponse = {
         ok: false,
         status: 400,
         statusText: 'Bad Request',
-        json: vi.fn().mockResolvedValue({
-          error: 'authorization_pending',
-          error_description: 'Authorization request is pending',
-        }),
+        text: vi.fn().mockResolvedValue(JSON.stringify(errorData)),
+        json: vi.fn().mockResolvedValue(errorData),
       };
 
       vi.mocked(global.fetch).mockResolvedValue(


### PR DESCRIPTION
## TLDR

This PR fixes two issues in the authentication flow:
1. Fix body consumed twice errors in OAuth2 token polling and show proper error messages
2. Show authentication success message after auth completed

## Dive Deeper

**Fix body consumed twice error:**
The `pollDeviceToken` method in `qwenOAuth2.ts` was attempting to parse the response as JSON first, and if that failed, it would try to read it as text. However, once a response body is read, it cannot be read again. The fix reads the response body as text first (which can only be done once), then attempts to parse it as JSON, ensuring proper error handling for both JSON and non-JSON error responses.

**Show authentication success message:**
Added user feedback by displaying a success message in the history when authentication completes successfully. This is implemented by passing the `addItem` callback to `useAuthCommand` hook.

## Reviewer Test Plan

1. **Test OAuth2 authentication:**
   - Run the CLI and select Qwen OAuth2 authentication
   - Complete the device authorization flow
   - Verify authentication succeeds without "body already consumed" errors
   - Verify success message appears: "Authenticated successfully with QWEN_OAUTH credentials."

2. **Test error handling:**
   - Test scenarios where token polling fails (network issues, expired device codes, etc.)
   - Verify proper error messages are displayed

3. **Test other auth methods:**
   - Verify OpenAI authentication still works
   - Verify success messages appear for all authentication types

## Testing Matrix

|          | 🍏   | 🪟   | 🐧   |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓   | ❓   |
| npx      | ❓   | ❓   | ❓   |
| Docker   | ❓   | ❓   | ❓   |
| Podman   | ❓   | -   | -   |
| Seatbelt | ❓   | -   | -   |

## Linked issues / bugs

None.