### PR TITLE
fix(cli): ensure ToolRegistry is initialized in headless mode

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1161,12 +1161,23 @@ export class Config {
       if (isToolEnabled(toolName, coreToolsConfig, excludeToolsConfig)) {
         try {
           registry.registerTool(new ToolClass(...args));
+          if (this.debugMode) {
+            console.debug(
+              `[Config] Registered tool: ${className} (${toolName})`,
+            );
+          }
         } catch (error) {
           console.error(
             `[Config] Failed to register tool ${className} (${toolName}):`,
             error,
           );
           throw error; // Re-throw after logging context
+        }
+      } else {
+        if (this.debugMode) {
+          console.debug(
+            `[Config] Tool ${className} (${toolName}) is disabled by configuration`,
+          );
         }
       }
     };


### PR DESCRIPTION
- Add proper error handling in buildSystemMessage() when ToolRegistry is not initialized
- Return empty tools list instead of throwing error to prevent crashes
- Add debug logging for tool registration in config.ts to help diagnose issues
- Log when tools are disabled by configuration for better debugging

Fixes #1099

This fixes the issue where run_shell_command tool was not found in registry
when running in headless mode (e.g., 'echo test | qwen'). The fix ensures
that:
1. ToolRegistry initialization is properly handled in headless mode
2. Tools are properly registered even when configuration filters are applied
3. Better error messages and debugging information are available