### PR TITLE
test: skip qwen-oauth test in containerized environments

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -449,8 +449,8 @@ export async function main() {
     }
 
     const nonInteractiveConfig = await validateNonInteractiveAuth(
-      settings.merged.security?.auth?.selectedType ||
-        (argv.authType as AuthType),
+      (argv.authType as AuthType) ||
+        settings.merged.security?.auth?.selectedType,
       settings.merged.security?.auth?.useExternal,
       config,
       settings,


### PR DESCRIPTION
## TLDR

Skip `qwen-oauth` test in containerized environments (Docker/Podman) and improve timeout handling for OAuth-related tests.


## Dive Deeper

The `qwen-oauth` authentication flow requires user interaction (browser-based OAuth), which is not possible in containerized CI environments. Previously, this test would hang indefinitely waiting for user input.

This PR:
1. Uses `it.skipIf()` to conditionally skip the test in Docker/Podman sandbox environments
2. Fixes the priority order in `gemini.tsx` - the CLI `--auth-type` argument should override the config file setting, not the other way around

## Testing Matrix

|          | 🍏   | 🪟   | 🐧   |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓   | ❓   |
| npx      | ❓   | ❓   | ❓   |
| Docker   | ✅   | ❓   | ❓   |
| Podman   | ❓   | -   | -   |
| Seatbelt | ❓   | -   | -   |

## Linked issues / bugs

Fixes CI test failures caused by `qwen-oauth` test hanging in containerized environments.
