### PR TITLE
fix(cli): handle PAT tokens and credentials in git remote URL parsing

### DIFF
--- a/packages/cli/src/utils/gitUtils.test.ts
+++ b/packages/cli/src/utils/gitUtils.test.ts
@@ -76,6 +76,105 @@ describe('getGitHubRepoInfo', async () => {
     );
     expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
   });
+
+  // Tests for credential formats
+
+  it('returns the owner and repo for URL with classic PAT token (ghp_)', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx@github.com/owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('returns the owner and repo for URL with fine-grained PAT token (github_pat_)', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://github_pat_xxxxxxxxxxxxxxxxxxxxxx_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx@github.com/owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('returns the owner and repo for URL with username:password format', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://username:password@github.com/owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('returns the owner and repo for URL with OAuth token (oauth2:token)', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://oauth2:gho_xxxxxxxxxxxx@github.com/owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('returns the owner and repo for URL with GitHub Actions token (x-access-token)', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://x-access-token:ghs_xxxxxxxxxxxx@github.com/owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  // Tests for case insensitivity
+
+  it('returns the owner and repo for URL with uppercase GITHUB.COM', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://GITHUB.COM/owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('returns the owner and repo for URL with mixed case GitHub.Com', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://GitHub.Com/owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  // Tests for SSH format
+
+  it('returns the owner and repo for SSH URL', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'git@github.com:owner/repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('throws for non-GitHub SSH URL', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'git@gitlab.com:owner/repo.git',
+    );
+    expect(() => {
+      getGitHubRepoInfo();
+    }).toThrowError(/Owner & repo could not be extracted from remote URL/);
+  });
+
+  // Tests for edge cases
+
+  it('returns the owner and repo for URL without .git suffix', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://github.com/owner/repo',
+    );
+    expect(getGitHubRepoInfo()).toEqual({ owner: 'owner', repo: 'repo' });
+  });
+
+  it('throws for non-GitHub HTTPS URL', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://gitlab.com/owner/repo.git',
+    );
+    expect(() => {
+      getGitHubRepoInfo();
+    }).toThrowError(/Owner & repo could not be extracted from remote URL/);
+  });
+
+  it('handles repo names containing .git substring', async () => {
+    vi.mocked(child_process.execSync).mockReturnValueOnce(
+      'https://github.com/owner/my.git.repo.git',
+    );
+    expect(getGitHubRepoInfo()).toEqual({
+      owner: 'owner',
+      repo: 'my.git.repo',
+    });
+  });
 });
 
 describe('getGitRepoRoot', async () => {


### PR DESCRIPTION
## TLDR

Replace the regex-based git remote URL parser with JavaScript's native URL constructor to properly handle URLs containing PAT tokens and other credentials.

## Dive Deeper

The previous regex `/(?:https?:\/\/|git@)github\.com(?::|\/)([^/]+)\/([^/]+?)(?:\.git)?$/` couldn't parse URLs like `https://ghp_xxx@github.com/owner/repo.git` because it didn't account for credentials between the protocol and hostname.

The new implementation:

- Uses JavaScript's native URL constructor which automatically ignores credentials when parsing
- Handles SSH URLs (`git@github.com:owner/repo.git`) by converting them to a parseable format
- Rejects non-GitHub providers (GitLab, Bitbucket) with a clear error
- Fixes case sensitivity bug (uppercase GITHUB.COM now works)
- Properly handles repo names containing .git substring

This is a port of the upstream fix from google-gemini/gemini-cli#14650

## Reviewer Test Plan

1. Run the new tests:
`  npm run test --workspace=packages/cli -- gitUtils`
2. Manual test with a PAT URL:
```
git remote set-url origin https://ghp_testtoken@github.com/owner/repo.git
qwen
# Run /setup-github - should no longer fail with "Owner & repo could not be extracted"
git remote set-url origin https://github.com/owner/repo.git  # restore

```
## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | yes | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1224

