### PR TITLE
feat: Add channel field support for client identification

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -138,6 +138,7 @@ export interface CliArgs {
   coreTools: string[] | undefined;
   excludeTools: string[] | undefined;
   authType: string | undefined;
+  channel: string | undefined;
 }
 
 function normalizeOutputFormat(
@@ -296,6 +297,11 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
         .option('experimental-acp', {
           type: 'boolean',
           description: 'Starts the agent in ACP mode',
+        })
+        .option('channel', {
+          type: 'string',
+          choices: ['VSCode', 'ACP', 'SDK', 'CI'],
+          description: 'Channel identifier (VSCode, ACP, SDK, CI)',
         })
         .option('allowed-mcp-server-names', {
           type: 'array',
@@ -559,6 +565,12 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
 
   // The import format is now only controlled by settings.memoryImportFormat
   // We no longer accept it as a CLI argument
+
+  // Apply ACP fallback: if experimental-acp is present but no explicit --channel, treat as ACP
+  if (result['experimentalAcp'] && !result['channel']) {
+    (result as Record<string, unknown>)['channel'] = 'ACP';
+  }
+
   return result as unknown as CliArgs;
 }
 
@@ -983,6 +995,7 @@ export async function loadCliConfig(
     output: {
       format: outputSettingsFormat,
     },
+    channel: argv.channel,
   });
 }
 

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -485,6 +485,7 @@ describe('gemini.tsx main function kitty protocol', () => {
       excludeTools: undefined,
       authType: undefined,
       maxSessionTurns: undefined,
+      channel: undefined,
     });
 
     await main();

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -349,6 +349,7 @@ export interface ConfigParameters {
   skipStartupContext?: boolean;
   sdkMode?: boolean;
   sessionSubagents?: SubagentConfig[];
+  channel?: string;
 }
 
 function normalizeConfigOutputFormat(
@@ -485,6 +486,7 @@ export class Config {
   private readonly enableToolOutputTruncation: boolean;
   private readonly eventEmitter?: EventEmitter;
   private readonly useSmartEdit: boolean;
+  private readonly channel: string | undefined;
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId ?? randomUUID();
@@ -598,6 +600,7 @@ export class Config {
     this.enableToolOutputTruncation = params.enableToolOutputTruncation ?? true;
     this.useSmartEdit = params.useSmartEdit ?? false;
     this.extensionManagement = params.extensionManagement ?? true;
+    this.channel = params.channel;
     this.storage = new Storage(this.targetDir);
     this.vlmSwitchMode = params.vlmSwitchMode;
     this.inputFormat = params.inputFormat ?? InputFormat.TEXT;
@@ -1142,6 +1145,10 @@ export class Config {
 
   getCliVersion(): string | undefined {
     return this.cliVersion;
+  }
+
+  getChannel(): string | undefined {
+    return this.channel;
   }
 
   /**

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -130,10 +130,13 @@ export class DashScopeOpenAICompatibleProvider
   }
 
   buildMetadata(userPromptId: string): DashScopeRequestMetadata {
+    const channel = this.cliConfig.getChannel?.();
+
     return {
       metadata: {
         sessionId: this.cliConfig.getSessionId?.(),
         promptId: userPromptId,
+        ...(channel ? { channel } : {}),
       },
     };
   }

--- a/packages/core/src/core/openaiContentGenerator/provider/types.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/types.ts
@@ -28,5 +28,6 @@ export type DashScopeRequestMetadata = {
   metadata: {
     sessionId?: string;
     promptId: string;
+    channel?: string;
   };
 };

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
@@ -249,6 +249,9 @@ export class QwenLogger {
           authType === AuthType.USE_OPENAI
             ? this.config?.getContentGeneratorConfig().baseUrl || ''
             : '',
+        ...(this.config?.getChannel?.()
+          ? { channel: this.config.getChannel() }
+          : {}),
       },
       _v: `qwen-code@${version}`,
     } as RumPayload;

--- a/packages/sdk-typescript/src/transport/ProcessTransport.ts
+++ b/packages/sdk-typescript/src/transport/ProcessTransport.ts
@@ -139,6 +139,7 @@ export class ProcessTransport implements Transport {
       'stream-json',
       '--output-format',
       'stream-json',
+      '--channel=SDK',
     ];
 
     if (this.options.model) {

--- a/packages/vscode-ide-companion/src/services/acpConnection.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.ts
@@ -94,7 +94,12 @@ export class AcpConnection {
     if (cliPath.startsWith('npx ')) {
       const parts = cliPath.split(' ');
       spawnCommand = isWindows ? 'npx.cmd' : 'npx';
-      spawnArgs = [...parts.slice(1), '--experimental-acp', ...extraArgs];
+      spawnArgs = [
+        ...parts.slice(1),
+        '--experimental-acp',
+        '--channel=VSCode',
+        ...extraArgs,
+      ];
     } else {
       // For qwen CLI, ensure we use the correct Node.js version
       // Handle various Node.js version managers (nvm, n, manual installations)
@@ -103,11 +108,16 @@ export class AcpConnection {
         const nodePathResult = determineNodePathForCli(cliPath);
         if (nodePathResult.path) {
           spawnCommand = nodePathResult.path;
-          spawnArgs = [cliPath, '--experimental-acp', ...extraArgs];
+          spawnArgs = [
+            cliPath,
+            '--experimental-acp',
+            '--channel=VSCode',
+            ...extraArgs,
+          ];
         } else {
           // Fallback to direct execution
           spawnCommand = cliPath;
-          spawnArgs = ['--experimental-acp', ...extraArgs];
+          spawnArgs = ['--experimental-acp', '--channel=VSCode', ...extraArgs];
 
           // Log any error for debugging
           if (nodePathResult.error) {
@@ -118,7 +128,7 @@ export class AcpConnection {
         }
       } else {
         spawnCommand = cliPath;
-        spawnArgs = ['--experimental-acp', ...extraArgs];
+        spawnArgs = ['--experimental-acp', '--channel=VSCode', ...extraArgs];
       }
     }
 


### PR DESCRIPTION
## Summary

This PR adds support for a `channel` field across the CLI, Core, and SDK packages to identify the client source making API requests. This enables better tracking and analytics of usage patterns across different integration points.

## Changes

### CLI Package (`packages/cli`)
- Added `channel` CLI argument with predefined choices: `VSCode`, `ACP`, `SDK`, `CI`
- Implemented automatic fallback: when `--experimental-acp` is used without explicit `--channel`, defaults to `ACP`
- Pass channel value to core config initialization

### Core Package (`packages/core`)
- Added `channel` field to `ConfigParameters` interface
- Exposed `getChannel()` method in `Config` class
- Integrated channel into DashScope API metadata for request tracking
- Included channel in telemetry/logging payloads (QwenLogger)

### SDK Package (`packages/sdk-typescript`)
- Automatically sets `--channel=SDK` in ProcessTransport for SDK-initiated requests

### VSCode Extension (`packages/vscode-ide-companion`)
- Automatically sets `--channel=VSCode` in ACP connection for VS Code extension requests

## Benefits

1. **Analytics & Monitoring**: Track usage patterns across different client types
2. **Debugging**: Easier identification of request sources during troubleshooting
3. **Metrics**: Better understanding of which integration points are most popular
4. **Backward Compatible**: Channel field is optional and doesn't break existing functionality

## Testing

- ✅ CLI argument parsing with valid channel values
- ✅ Automatic fallback for ACP mode
- ✅ SDK transport integration
- ✅ VS Code extension integration
- ✅ DashScope API metadata inclusion

## Related Issues

N/A

---

**Type of Change:**
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing functionality)

**Checklist:**
- [x] Code follows the project's coding conventions
- [x] Changes maintain backward compatibility
- [x] All integration points updated (CLI, Core, SDK, VS Code)
- [x] Commit message follows conventional commits format