### PR TITLE
fix: 修复在docker环境中无法连接ide的问题

### DIFF
--- a/packages/vscode-ide-companion/src/ide-server.ts
+++ b/packages/vscode-ide-companion/src/ide-server.ts
@@ -164,7 +164,7 @@ export class IDEServer {
         const allowedHosts = [
           `localhost:${this.port}`,
           `127.0.0.1:${this.port}`,
-          `host.docker.internal:${this.port}`, // 添加Docker支持
+          `host.docker.internal:${this.port}`, // Add Docker support
         ];
         if (!allowedHosts.includes(host)) {
           return res.status(403).json({ error: 'Invalid Host header' });


### PR DESCRIPTION
## TLDR
> Users who enable qwen-code in the docker environment cannot connect to the ide:

## Dive Deeper
> This issue is caused by the conflict of Host header verification mechanisms in two places:
1. Host header verification in the VSCode extension
```bash
app.use((req, res, next) => {
  const host = req.headers.host || '';
  const allowedHosts = [
    `localhost:${this.port}`,
    `127.0.0.1:${this.port}`,
  ];
  if (!allowedHosts.includes(host)) {
    return res.status(403).json({ error: 'Invalid Host header' });
  }
  next();
});
```
2. Host selection logic for CLI clients
```bash
function getIdeServerHost() {
  const isInContainer =
    fs.existsSync('/.dockerenv') || fs.existsSync('/run/.containerenv');
  return isInContainer ? 'host.docker.internal' : '127.0.0.1';
}
```
> When running qwen-code CLI in a Docker container:
- The CLI detects the container environment and uses host.docker.internal as the hostname
- The host header of the sent HTTP request is: host.docker.internal: port number
- However, the VSCode extension only allows localhost: port number and 127.0.0.1: port number
- Therefore, the request is rejected and returns {"error":"Invalid Host header"}

### Solution
> The host header verification logic of the VSCode extension needs to be modified to add support for host.docker.internal:
```bash
app.use((req, res, next) => {
  const host = req.headers.host || '';
  const allowedHosts = [
    `localhost:${this.port}`,
    `127.0.0.1:${this.port}`,
    `host.docker.internal:${this.port}`, // 添加Docker支持
  ];
  if (!allowedHosts.includes(host)) {
    return res.status(403).json({ error: 'Invalid Host header' });
  }
  next();
});
```
### Working principle
1. Container detection: CLI determines whether a container is running by checking the /.dockerenv or /run/.containerenv files

2. host selection: If in a container, use host.docker.internal; Otherwise, use 127.0.0.1

3. docker Network: host.docker.internal is a special DNS name provided by docker, pointing to the IP address of the host machine

4. Host header verification: The extension needs to allow this special hostname to pass verification

## Reviewer Test Plan

1. Uninstall the original plugin extension

2. Install new extensions

3. Start docker in the new terminal

4. Run qwen-code to connect to the ide

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | yes  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | yes  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
- Fixes #1209 #984 #1081 #1094 

## Before repair
<img width="2644" height="1488" alt="943DB039-3D73-4C48-BAA8-CD507EC0EF03" src="https://github.com/user-attachments/assets/a6f9a215-15e9-405d-9566-c43a84dda8a6" />

https://github.com/user-attachments/assets/75735d50-e84b-4f8b-9ea0-3f84fcf1a69d


## After repair
<img width="2644" height="1488" alt="EDFDD74F-549A-422C-B119-2482D61FEDDC" src="https://github.com/user-attachments/assets/0cffbdbb-9554-43a3-9ad5-03a38c387c6c" />

https://github.com/user-attachments/assets/cd877732-09f4-420b-b0f8-9ee8932dc725



