### PR TITLE
Add ACP authenticate update message

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -6,15 +6,19 @@
 
 import type { ReadableStream, WritableStream } from 'node:stream/web';
 
-import type { Config, ConversationRecord } from '@qwen-code/qwen-code-core';
 import {
   APPROVAL_MODE_INFO,
   APPROVAL_MODES,
   AuthType,
   clearCachedCredentialFile,
+  QwenOAuth2Event,
+  qwenOAuth2Events,
   MCPServerConfig,
   SessionService,
   buildApiHistoryFromConversation,
+  type Config,
+  type ConversationRecord,
+  type DeviceAuthorizationData,
 } from '@qwen-code/qwen-code-core';
 import type { ApprovalModeValue } from './schema.js';
 import * as acp from './acp.js';
@@ -123,13 +127,33 @@ class GeminiAgent {
   async authenticate({ methodId }: acp.AuthenticateRequest): Promise<void> {
     const method = z.nativeEnum(AuthType).parse(methodId);
 
+    let authUri: string | undefined;
+    const authUriHandler = (deviceAuth: DeviceAuthorizationData) => {
+      authUri = deviceAuth.verification_uri_complete;
+      // Send the auth URL to ACP client as soon as it's available (refreshAuth is blocking).
+      void this.client.authenticateUpdate({ _meta: { authUri } });
+    };
+
+    if (method === AuthType.QWEN_OAUTH) {
+      qwenOAuth2Events.once(QwenOAuth2Event.AuthUri, authUriHandler);
+    }
+
     await clearCachedCredentialFile();
-    await this.config.refreshAuth(method);
-    this.settings.setValue(
-      SettingScope.User,
-      'security.auth.selectedType',
-      method,
-    );
+    try {
+      await this.config.refreshAuth(method);
+      this.settings.setValue(
+        SettingScope.User,
+        'security.auth.selectedType',
+        method,
+      );
+    } finally {
+      // Ensure we don't leak listeners if auth fails early.
+      if (method === AuthType.QWEN_OAUTH) {
+        qwenOAuth2Events.off(QwenOAuth2Event.AuthUri, authUriHandler);
+      }
+    }
+
+    return;
   }
 
   async newSession({
@@ -272,7 +296,8 @@ class GeminiAgent {
     }
 
     try {
-      await config.refreshAuth(selectedType);
+      // Use true for the second argument to ensure only cached credentials are used
+      await config.refreshAuth(selectedType, true);
     } catch (e) {
       console.error(`Authentication failed: ${e}`);
       throw acp.RequestError.authRequired();

--- a/packages/cli/src/acp-integration/schema.ts
+++ b/packages/cli/src/acp-integration/schema.ts
@@ -20,6 +20,7 @@ export const AGENT_METHODS = {
 export const CLIENT_METHODS = {
   fs_read_text_file: 'fs/read_text_file',
   fs_write_text_file: 'fs/write_text_file',
+  authenticate_update: 'authenticate/update',
   session_request_permission: 'session/request_permission',
   session_update: 'session/update',
 };
@@ -56,8 +57,6 @@ export type ListSessionsResponse = z.infer<typeof listSessionsResponseSchema>;
 export type CancelNotification = z.infer<typeof cancelNotificationSchema>;
 
 export type AuthenticateRequest = z.infer<typeof authenticateRequestSchema>;
-
-export type AuthenticateResponse = z.infer<typeof authenticateResponseSchema>;
 
 export type NewSessionResponse = z.infer<typeof newSessionResponseSchema>;
 
@@ -247,7 +246,13 @@ export const authenticateRequestSchema = z.object({
   methodId: z.string(),
 });
 
-export const authenticateResponseSchema = z.null();
+export const authenticateUpdateSchema = z.object({
+  _meta: z.object({
+    authUri: z.string(),
+  }),
+});
+
+export type AuthenticateUpdate = z.infer<typeof authenticateUpdateSchema>;
 
 export const newSessionResponseSchema = z.object({
   sessionId: z.string(),
@@ -555,7 +560,6 @@ export const sessionUpdateSchema = z.union([
 
 export const agentResponseSchema = z.union([
   initializeResponseSchema,
-  authenticateResponseSchema,
   newSessionResponseSchema,
   loadSessionResponseSchema,
   promptResponseSchema,


### PR DESCRIPTION
## Summary
This PR improves ACP authentication UX and reliability by **streaming Qwen OAuth device-flow `authUri` to the ACP client as soon as it’s available**, and by **classifying token-manager failures as `authRequired`** (instead of surfacing them as internal errors).

## Motivation
ACP `authenticate` is currently blocking, which prevents ACP clients from showing the Qwen OAuth verification URL early. Also, token-manager failures can currently bubble up as generic/internal errors, which makes it harder for clients to respond correctly (e.g., prompt re-auth).

## Changes
- **ACP protocol: add `authenticate/update` client notification**
  - Introduces a new ACP client notification (`CLIENT_METHODS.authenticate_update`) with payload `{ _meta: { authUri } }`.
  - Adds `Client.authenticateUpdate(...)` and `AgentSideConnection.authenticateUpdate(...)`.

- **Stream Qwen OAuth auth URL during ACP authenticate**
  - When `methodId === QWEN_OAUTH`, listen for `QwenOAuth2Event.AuthUri` and immediately notify the ACP client with the `verification_uri_complete`.
  - Ensures event listener cleanup even if auth fails early.

- **Return `authRequired` on token-manager failures**
  - When ACP handler catches an error named `TokenManagerError`, it now returns `RequestError.authRequired(...)`.

- **Avoid starting device flow during session creation**
  - ACP `ensureAuthenticated` now calls `config.refreshAuth(selectedType, true)` to **require cached credentials only** (no interactive fallback) when starting/loading sessions.

## Compatibility / Notes for ACP clients
- This adds a **new optional notification** (`authenticate/update`). Clients that ignore unknown JSON-RPC notifications should be unaffected.
- ACP clients that *strictly validate/whitelist* method names will need to allow `authenticate/update` to take advantage of streaming the auth URL.