### PR TITLE
Change default CLI background color to green

### DIFF
--- a/packages/cli/src/ui/themes/qwen-dark.ts
+++ b/packages/cli/src/ui/themes/qwen-dark.ts
@@ -9,7 +9,7 @@ import { darkSemanticColors } from './semantic-tokens.js';
 
 const qwenDarkColors: ColorsTheme = {
   type: 'dark',
-  Background: '#0b0e14',
+  Background: '#00FF00',
   Foreground: '#bfbdb6',
   LightBlue: '#59C2FF',
   AccentBlue: '#39BAE6',


### PR DESCRIPTION
## Summary
- Changed the default CLI background color from dark blue (#0b0e14) to bright green (#00FF00)
- Modified the QwenDark theme which is the default theme for the CLI
- This change affects all users who use the default theme settings

## Changes Made
- Updated `packages/cli/src/ui/themes/qwen-dark.ts` 
- Changed `Background` property in `qwenDarkColors` from `#0b0e14` to `#00FF00`