### PR TITLE
fix(cli): add -r and -C aliases for --resume and --continue options

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -212,8 +212,8 @@ describe('parseArguments', () => {
     expect(argv.resume).toBe('session-123');
   });
 
-  it('should allow -C flag as alias for --continue', async () => {
-    process.argv = ['node', 'script.js', '-C'];
+  it('should allow -c flag as alias for --continue', async () => {
+    process.argv = ['node', 'script.js', '-c'];
     const argv = await parseArguments({} as Settings);
     expect(argv.continue).toBe(true);
   });

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -299,7 +299,6 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
             'Set the approval mode: plan (plan only), default (prompt for approval), auto-edit (auto-approve edit tools), yolo (auto-approve all tools)',
         })
         .option('checkpointing', {
-          alias: 'c',
           type: 'boolean',
           description: 'Enables checkpointing of file edits',
           default: false,
@@ -422,7 +421,7 @@ export async function parseArguments(settings: Settings): Promise<CliArgs> {
           default: false,
         })
         .option('continue', {
-          alias: 'C',
+          alias: 'c',
           type: 'boolean',
           description:
             'Resume the most recent session for the current project.',


### PR DESCRIPTION
## TLDR

  Add missing `-r` short alias for `--resume` and `-c` alias for `--continue` CLI options. The original Gemini CLI had   
  `-r, --resume` but qwen-code only showed `--resume` in help output.                                                    
                                                                                                                         
## Dive Deeper                                                                                                         
                                                                                                                         
  The `--resume` and `--continue` options were the only two session-related CLI flags without short aliases. Most other  
  options already have single-letter aliases (`-d`, `-m`, `-p`, `-i`, `-s`, `-a`, `-y`, `-e`, `-l`, `-o`).               
                                                                                                                         
Changes:                                                                                                               
                                                                                                                         
- Added `alias: 'r'` to `--resume` option in `config.ts`                                                               
- Added `alias: 'c'` to `--continue` option                                                                            
- Removed `alias: 'c'` from `--checkpointing` option (rarely used, per reviewer feedback)                              
- Added unit tests for both aliases                                                                                    
                                                                                                                         
## Reviewer Test Plan                                                                                                  
                                                                                                                         
1. Build and run `qwen -h` — verify output shows:                                                                      
   -c, --continue    Resume the most recent session for the current project.                                             
   -r, --resume      Resume a specific session by its ID...                                                              
2. Test `qwen -r` opens session picker                                                                                 
3. Test `qwen -r <session-id>` resumes specific session                                                                
4. Test `qwen -c` resumes most recent session                                                                          
5. Run `npm run test --workspace=packages/cli -- src/config/config.test.ts`   

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | yes | ❓  | yes |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1220
