### PR TITLE
fix(cli): persist model selection from /model command to settings.json

### DIFF
--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -16,6 +16,8 @@ import { useKeypress } from '../hooks/useKeypress.js';
 import { theme } from '../semantic-colors.js';
 import { DescriptiveRadioButtonSelect } from './shared/DescriptiveRadioButtonSelect.js';
 import { ConfigContext } from '../contexts/ConfigContext.js';
+import { SettingsContext } from '../contexts/SettingsContext.js';
+import { SettingScope } from '../../config/settings.js';
 import {
   getAvailableModelsForAuthType,
   MAINLINE_CODER,
@@ -28,6 +30,7 @@ interface ModelDialogProps {
 
 export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
   const config = useContext(ConfigContext);
+  const settings = useContext(SettingsContext);
 
   // Get auth type from config, default to QWEN_OAUTH if not available
   const authType = config?.getAuthType() ?? AuthType.QWEN_OAUTH;
@@ -74,10 +77,15 @@ export function ModelDialog({ onClose }: ModelDialogProps): React.JSX.Element {
         config.setModel(model);
         const event = new ModelSlashCommandEvent(model);
         logModelSlashCommand(config, event);
+
+        // Persist the selected model to settings.json
+        if (settings) {
+          settings.setValue(SettingScope.User, 'model.name', model);
+        }
       }
       onClose();
     },
-    [config, onClose],
+    [config, settings, onClose],
   );
 
   return (


### PR DESCRIPTION
## Summary

When users select a model via the `/model` command, the selection was only stored in-memory. After restarting the CLI, the selected model was lost and defaulted back to environment variables or hardcoded settings.

This fix adds persistence by calling `settings.setValue()` to save the selected model to `~/.qwen/settings.json`, consistent with how other settings like theme are persisted.

**Changes:**
- Add `SettingsContext` to `ModelDialog` component
- Call `settings.setValue(SettingScope.User, 'model.name', model)` when a model is selected
- Add tests to verify persistence behavior

## Test plan

- [x] Added test verifying `settings.setValue` is called with correct arguments
- [x] Added test verifying persistence works for different models
- [x] Added test verifying graceful handling when settings context is unavailable
- [x] All existing ModelDialog tests pass (11 tests total)
- [x] TypeScript type check passes
- [x] ESLint check passes

Fixes #1222