### PR TITLE
Fix resume command broken after new chat

### DIFF
--- a/packages/cli/src/ui/components/StandaloneSessionPicker.tsx
+++ b/packages/cli/src/ui/components/StandaloneSessionPicker.tsx
@@ -121,6 +121,7 @@ export async function showResumeSessionPicker(
       if (process.stdin.isTTY && !wasRaw && !selectedId) {
         process.stdin.setRawMode(false);
       }
+
       resolve(selectedId);
     });
   });


### PR DESCRIPTION
## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->
When user creates a new chat and everything works, but when he wants to continues to use qwen --resume command on windows, the chat does not work. However this does not appear on Linux/Mac.

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->
This PR addresses the issue https://github.com/QwenLM/qwen-code/issues/1361. The issue lies in the fact that the **KeypressProvider** in **SessionPicker** is not passing the **pasteWorkaround** prop on Windows. The **SessionPicker** uses the default **pasteWorkaround=false**, meaning it operates in stdin.on('keypress') mode. This works on Linux/Mac but not works on windows.

Changes:

- pass **pasteWorkaround** to **KeypressProvider** 

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->
1. Start a new Qwen CLI session
``
qwen
``
2. Start another Qwen CLI seesion and input
``
qwen --resume
``
3. Choose random history session and try to input something


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | √  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
--> Fix #1361 