### PR TITLE
fix: exit with non-zero code on API errors in text mode

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -771,6 +771,52 @@ describe('runNonInteractive', () => {
     );
   });
 
+  it('should handle API errors in text mode and exit with error code', async () => {
+    (mockConfig.getOutputFormat as Mock).mockReturnValue(OutputFormat.TEXT);
+    setupMetricsMock();
+
+    // Simulate an API error event (like 401 unauthorized)
+    const apiErrorEvent: ServerGeminiStreamEvent = {
+      type: GeminiEventType.Error,
+      value: {
+        error: {
+          message: '401 Incorrect API key provided',
+          status: 401,
+        },
+      },
+    };
+
+    mockGeminiClient.sendMessageStream.mockReturnValue(
+      createStreamFromEvents([apiErrorEvent]),
+    );
+
+    let thrownError: Error | null = null;
+    try {
+      await runNonInteractive(
+        mockConfig,
+        mockSettings,
+        'Test input',
+        'prompt-id-api-error',
+      );
+      // Should not reach here
+      expect.fail('Expected error to be thrown');
+    } catch (error) {
+      thrownError = error as Error;
+    }
+
+    // Should throw with the API error message
+    expect(thrownError).toBeTruthy();
+    expect(thrownError?.message).toContain('401');
+    expect(thrownError?.message).toContain('Incorrect API key provided');
+
+    // Verify error was written to stderr
+    expect(processStderrSpy).toHaveBeenCalled();
+    const stderrCalls = processStderrSpy.mock.calls;
+    const errorOutput = stderrCalls.map((call) => call[0]).join('');
+    expect(errorOutput).toContain('401');
+    expect(errorOutput).toContain('Incorrect API key provided');
+  });
+
   it('should handle FatalInputError with custom exit code in JSON format', async () => {
     (mockConfig.getOutputFormat as Mock).mockReturnValue(OutputFormat.JSON);
     setupMetricsMock();

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -308,6 +308,8 @@ export async function runNonInteractive(
                 config.getContentGeneratorConfig()?.authType,
               );
               process.stderr.write(`${errorText}\n`);
+              // Throw error to exit with non-zero code
+              throw new Error(errorText);
             }
           }
         }


### PR DESCRIPTION
## TLDR

When API errors occur (e.g., 401 Incorrect API key), the Qwen CLI process exits with code 0 instead of a non-zero exit code. This makes it impossible for external scripts to detect that an error occurred via the exit code.

## Dive Deeper

The issue occurs in TEXT output mode when handling `GeminiEventType.Error` events in the non-interactive CLI flow:

**Root Cause:**
In [`nonInteractiveCli.ts`](https://github.com/QwenLM/qwen-code/blob/main/packages/cli/src/nonInteractiveCli.ts#L304-L311), when a `GeminiEventType.Error` event is received, the code writes the error message to stderr but **continues execution** instead of throwing an error. This causes the process to complete normally with exit code 0.

**Solution:**
After writing the error to stderr, throw an error to interrupt the flow. The error will be caught by the catch block and processed through `handleError`, which will exit the process with a non-zero exit code.

**Changes:**
- Modified `nonInteractiveCli.ts` to throw error after writing to stderr when `GeminiEventType.Error` is received in TEXT mode
- Added test case `should handle API errors in text mode and exit with error code` to verify the fix

**Impact:**
- Only affects TEXT output mode error handling
- JSON and STREAM_JSON modes are unaffected (they already have correct error handling)
- Tool execution errors are unaffected (they should be handled by the LLM, not cause process exit)

## Reviewer Test Plan

### Manual Testing

Create a simple Python script to test the exit code behavior:

```python
import subprocess

# Test with an invalid API key to trigger a 401 error
result = subprocess.run(
    ['qwen', 'test prompt'],
    capture_output=True,
    text=True,
    check=False
)

print(f"Exit code: {result.returncode}")
print(f"Stderr: {result.stderr}")

# Before fix: Exit code would be 0 even with API error
# After fix: Exit code should be 1 (non-zero) when API error occurs
assert result.returncode != 0, "Expected non-zero exit code on API error"
```

### Unit Tests

All existing tests pass to ensure no regression:
```bash
npm test packages/cli/src/nonInteractiveCli.test.ts
```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1375