### PR TITLE
fix(cli): improve error message display for object errors

### DIFF
--- a/packages/cli/src/utils/errors.test.ts
+++ b/packages/cli/src/utils/errors.test.ts
@@ -125,6 +125,15 @@ describe('errors', () => {
       const obj = { message: 123 };
       expect(getErrorMessage(obj)).toBe('{"message":123}');
     });
+
+    it('should fallback to String() when toJSON returns undefined', () => {
+      const obj = {
+        toJSON() {
+          return undefined;
+        },
+      };
+      expect(getErrorMessage(obj)).toBe('[object Object]');
+    });
   });
 
   describe('handleError', () => {

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -31,7 +31,9 @@ export function getErrorMessage(error: unknown): string {
   // Handle plain objects by stringifying them
   if (error !== null && typeof error === 'object') {
     try {
-      return JSON.stringify(error);
+      const stringified = JSON.stringify(error);
+      // JSON.stringify can return undefined for objects with toJSON() returning undefined
+      return stringified ?? String(error);
     } catch {
       // If JSON.stringify fails (circular reference, etc.), fall back to String
       return String(error);


### PR DESCRIPTION
## Summary

Fixes #1338

Previously, when a tool execution failed with an error object (not an Error instance), `getErrorMessage()` would return `[object Object]`, hiding useful error information from users.

## Changes

This PR improves `getErrorMessage()` to properly handle non-Error objects:

1. Extract the `message` property from error-like objects (e.g., `{ message: 'test' }` → `'test'`)
2. JSON.stringify plain objects to show their full content (e.g., `{ code: 500 }` → `'{"code":500}'`)
3. Fall back to `String()` only when JSON.stringify fails (circular references, etc.)

## Test plan

- [x] Updated existing tests to reflect new behavior
- [x] Added tests for error-like objects with `message` property
- [x] Added tests for plain objects without `message` property
- [x] Added tests for edge cases (empty objects, non-string message)
- [x] All existing tests pass

## AI Assistance Disclosure

I used Codex to review the changes, sanity-check the implementation against existing patterns, and help spot potential edge cases.