### PR TITLE
[OpenaiContentGenerate] convertOpenAIResponseToGemini record thoughtsTokenCount

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -242,25 +242,6 @@ export class ContentGenerationPipeline {
       baseRequest.stream_options = { include_usage: true };
     }
 
-    // Add thinking options if present
-    if (
-      request.config?.thinkingConfig &&
-      request.config.thinkingConfig.includeThoughts
-    ) {
-      (
-        baseRequest as OpenAI.Chat.ChatCompletionCreateParams & {
-          enable_thinking?: boolean;
-        }
-      ).enable_thinking = true;
-      if (request.config.thinkingConfig.thinkingBudget) {
-        (
-          baseRequest as OpenAI.Chat.ChatCompletionCreateParams & {
-            thinking_budget?: number;
-          }
-        ).thinking_budget = request.config.thinkingConfig.thinkingBudget;
-      }
-    }
-
     // Add tools if present
     if (request.config?.tools) {
       baseRequest.tools = await this.converter.convertGeminiToolsToOpenAI(


### PR DESCRIPTION
## TLDR

- buildRequest support thinking config：`enable_thinking`, `thinking_budget`, `extra_body.enable_thinking`
- convert to gemini response support `reasoning_content`

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
