### PR TITLE
fix(cli): skip update check when disableUpdateNag is true

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -639,4 +639,37 @@ describe('startInteractiveUI', () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(checkForUpdates).toHaveBeenCalledTimes(1);
   });
+
+  it('should not check for updates when update nag is disabled', async () => {
+    const { checkForUpdates } = await import('./ui/utils/updateCheck.js');
+
+    const mockInitializationResult = {
+      authError: null,
+      themeError: null,
+      shouldOpenAuthDialog: false,
+      geminiMdFileCount: 0,
+    };
+
+    const settingsWithUpdateNagDisabled = {
+      merged: {
+        general: {
+          disableUpdateNag: true,
+        },
+        ui: {
+          hideWindowTitle: false,
+        },
+      },
+    } as LoadedSettings;
+
+    await startInteractiveUI(
+      mockConfig,
+      settingsWithUpdateNagDisabled,
+      mockStartupWarnings,
+      mockWorkspaceRoot,
+      mockInitializationResult,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(checkForUpdates).not.toHaveBeenCalled();
+  });
 });

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -183,16 +183,18 @@ export async function startInteractiveUI(
     },
   );
 
-  checkForUpdates()
-    .then((info) => {
-      handleAutoUpdate(info, settings, config.getProjectRoot());
-    })
-    .catch((err) => {
-      // Silently ignore update check errors.
-      if (config.getDebugMode()) {
-        console.error('Update check failed:', err);
-      }
-    });
+  if (!settings.merged.general?.disableUpdateNag) {
+    checkForUpdates()
+      .then((info) => {
+        handleAutoUpdate(info, settings, config.getProjectRoot());
+      })
+      .catch((err) => {
+        // Silently ignore update check errors.
+        if (config.getDebugMode()) {
+          console.error('Update check failed:', err);
+        }
+      });
+  }
 
   registerCleanup(() => instance.unmount());
 }


### PR DESCRIPTION
Fixes #1304.

- Skip `checkForUpdates()` on startup when `general.disableUpdateNag` is enabled (prevents network calls in air-gapped setups).
- Add unit test to ensure update checks are skipped when disabled.

Tests:
- `npm test --workspace=packages/cli`
- `npm run typecheck --workspace=packages/cli`
- `npm run lint --workspace=packages/cli`