### PR TITLE
Fixed the issue where launching Qwencode: run via a shortcut failed

### DIFF
--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -312,8 +312,16 @@ export async function activate(context: vscode.ExtensionContext) {
             'qwen-cli',
             'cli.js',
           ).fsPath;
-          const quote = (s: string) => `"${s.replaceAll('"', '\\"')}"`;
-          const qwenCmd = `${quote(process.execPath)} ${quote(cliEntry)}`;
+          const isWindows = process.platform === 'win32';
+          let qwenCmd: string;
+          if (isWindows) {
+            const escapedPath = cliEntry.replace(/'/g, "''");
+            qwenCmd = `node '${escapedPath}'`;
+          } else {
+            const quote = (s: string) => `"${s.replaceAll('"', '\\"')}"`;
+            qwenCmd = `node ${quote(cliEntry)}`;
+          }
+
           const terminal = vscode.window.createTerminal({
             name: `Qwen Code (${selectedFolder.name})`,
             cwd: selectedFolder.uri.fsPath,


### PR DESCRIPTION
In the windows environment, starting Qwen Code: RUN via the shortcut will result in an error
## TLDR
<img width="1773" height="200" alt="image" src="https://github.com/user-attachments/assets/a0e6a78a-5d5a-4e01-86fa-bf6e9b254aec" />

- Error message: ParserError: (:) [], ParentContainsErrorRecordException
Executed command: "D:\Microsoft VS Code\Code.exe"  "C: \ Users \ pikaq \. Vscode \ extensions \ qwenlm qwen - code - vscode - ide - companion - 0.5.0 \ dist \ qwen - cli \ cli js." "

- The core issue: On the Windows system, VSCode attempts to execute the cli.js file using Code.exe (VSCode itself) instead of using node. This leads to a PowerShell parsing error.
## Dive Deeper
- Problems may occur in Windows' PowerShell because:
- The path contains Spaces (such as D:\Microsoft VS Code\ code.exe)
- PowerShell handles quotation marks differently from bash
- Backslash escaping behaves differently in PowerShell
## Reviewer Test Plan

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | yes  | yes  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1416 

