### PR TITLE
feat: Modify the selection order of user Settings and workspace Settings

### DIFF
--- a/packages/cli/src/ui/components/ApprovalModeDialog.tsx
+++ b/packages/cli/src/ui/components/ApprovalModeDialog.tsx
@@ -14,6 +14,7 @@ import type { LoadedSettings } from '../../config/settings.js';
 import { SettingScope } from '../../config/settings.js';
 import { getScopeMessageForSetting } from '../../utils/dialogScopeUtils.js';
 import { useKeypress } from '../hooks/useKeypress.js';
+import { ScopeSelector } from './shared/ScopeSelector.js';
 import { t } from '../../i18n/index.js';
 
 interface ApprovalModeDialogProps {
@@ -56,23 +57,6 @@ export function ApprovalModeDialog({
     SettingScope.Workspace,
   );
 
-  const scopeItems = [
-    {
-      get label() {
-        return t('Workspace Settings');
-      },
-      value: SettingScope.Workspace,
-      key: SettingScope.Workspace,
-    },
-    {
-      get label() {
-        return t('User Settings');
-      },
-      value: SettingScope.User,
-      key: SettingScope.User,
-    },
-  ];
-
   // Track the currently highlighted approval mode
   const [highlightedMode, setHighlightedMode] = useState<ApprovalMode>(
     currentMode || ApprovalMode.DEFAULT,
@@ -102,10 +86,13 @@ export function ApprovalModeDialog({
     setHighlightedMode(mode);
   };
 
+  const handleScopeHighlight = useCallback((scope: SettingScope) => {
+    setSelectedScope(scope);
+  }, []);
+
   const handleScopeSelect = useCallback(
     (scope: SettingScope) => {
       onSelect(highlightedMode, scope);
-      setSelectedScope(scope);
     },
     [onSelect, highlightedMode],
   );
@@ -168,11 +155,11 @@ export function ApprovalModeDialog({
 
         {/* Scope Selection */}
         <Box marginTop={1}>
-          <RadioButtonSelect
-            items={scopeItems}
-            initialIndex={0}
+          <ScopeSelector
             onSelect={handleScopeSelect}
+            onHighlight={handleScopeHighlight}
             isFocused={focusSection === 'scope'}
+            initialScope={selectedScope}
           />
         </Box>
 


### PR DESCRIPTION
## TLDR

At present, in terms of the order of user Settings and workspace Settings, user Settings take the lead. However, the priority of workspace Settings is higher than that of user Settings, which may cause confusion for users when making a choice. We should modify the order of the two options to relieve users of this confusion

## Dive Deeper
# User Settings and Workspace Settings Feature Analysis
components:

## Related Dialog Components

###  ApprovalModeDialog (Approval Mode Dialog)

- **File Location**: `packages/cli/src/ui/components/ApprovalModeDialog.tsx`
- **Function**: Configure tool approval mode
- **Supported Modes**: `PLAN`, `DEFAULT`, `AUTO_EDIT`, `YOLO`
- **Implementation**: Uses `ScopeSelector` component to provide options
- **Available Options**:
  - User Settings
  - Workspace Settings

### Storage Locations

| Setting Type | Storage Path | Description |
|-------------|-------------|-------------|
| **User Settings** | `~/.qwen/settings.json` | Stored in user home directory |
| **Workspace Settings** | `{project-root}/.qwen/settings.json` | Stored in project root directory |

### Priority Rules

When both scopes have settings configured:
- **Workspace Settings** has higher priority
- Will override the same configuration items in **User Settings**

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | yes  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
<img width="1571" height="312" alt="image" src="https://github.com/user-attachments/assets/8380cf62-8ee0-4f30-b5d0-2ae15bd621b3" />


- Fixes #1429 
