### PR TITLE
fix(core): handle missing delta in OpenAI stream chunks

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -207,6 +207,27 @@ describe('OpenAIContentConverter', () => {
         expect.objectContaining({ text: 'visible text' }),
       );
     });
+
+    it('should not throw when streaming chunk has no delta', () => {
+      const chunk = converter.convertOpenAIChunkToGemini({
+        object: 'chat.completion.chunk',
+        id: 'chunk-2',
+        created: 456,
+        choices: [
+          {
+            index: 0,
+            // Some OpenAI-compatible providers may omit delta entirely.
+            delta: undefined,
+            finish_reason: null,
+            logprobs: null,
+          },
+        ],
+        model: 'gpt-test',
+      } as unknown as OpenAI.Chat.ChatCompletionChunk);
+
+      const parts = chunk.candidates?.[0]?.content?.parts;
+      expect(parts).toEqual([]);
+    });
   });
 
   describe('convertGeminiToolsToOpenAI', () => {

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -799,7 +799,7 @@ export class OpenAIContentConverter {
       const parts: Part[] = [];
 
       const reasoningText = (choice.delta as ExtendedCompletionChunkDelta)
-        .reasoning_content;
+        ?.reasoning_content;
       if (reasoningText) {
         parts.push({ text: reasoningText, thought: true });
       }


### PR DESCRIPTION
## TLDR

Guard streaming `reasoning_content` access when a provider omits `choices[].delta` in `chat.completion.chunk`, and add a regression test.

## Dive Deeper

Some OpenAI-compatible backends can emit chunk choices with `delta: undefined`. We now safely read `reasoning_content` via optional chaining so chunk conversion does not throw.

## Reviewer Test Plan

- `npm test -w packages/core -- converter.test.ts`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- none -->