### PR TITLE
fix(cli): default sandbox UID/GID mapping on Linux

### DIFF
--- a/docs/users/features/sandbox.md
+++ b/docs/users/features/sandbox.md
@@ -49,6 +49,8 @@ Cross-platform sandboxing with complete process isolation.
 
 By default, Qwen Code uses a published sandbox image (configured in the CLI package) and will pull it as needed.
 
+The container sandbox mounts your workspace and your `~/.qwen` directory into the container so auth and settings persist between runs.
+
 **Best for**: Strong isolation on any OS, consistent tooling inside a known image.
 
 ### Choosing a method
@@ -157,7 +159,7 @@ For a working allowlist-style proxy example, see: [Example Proxy Script](/develo
 
 ## Linux UID/GID handling
 
-The sandbox automatically handles user permissions on Linux. Override these permissions with:
+On Linux, Qwen Code defaults to enabling UID/GID mapping so the sandbox runs as your user (and reuses the mounted `~/.qwen`). Override with:
 
 ```bash
 export SANDBOX_SET_UID_GID=true   # Force host UID/GID


### PR DESCRIPTION
Fixes #1359 

When using container sandboxing on Linux, the CLI could run as root inside the container unless UID/GID mapping was enabled. In that case Qwen Code resolves HOME to /root and stores auth/state under /root/.qwen, which is lost on exit because the container runs with --rm — leading to OAuth prompts on every run.

This makes UID/GID mapping the default on Linux (still overridable via SANDBOX_SET_UID_GID=false), so qwen runs under a user that matches the host UID/GID and reuses the mounted ~/.qwen for auth/settings persistence.

## Docs: 

mention that container sandbox mounts ~/.qwen for persistence.

## Test: 

npm run lint --workspace=packages/cli