### PR TITLE
fix(cli): treat CRLF as paste in passthrough mode

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -850,6 +850,33 @@ describe('KeypressContext - Kitty Protocol', () => {
         vi.useRealTimers();
       }
     });
+
+    it('treats standalone CRLF as a paste event in passthrough mode', async () => {
+      const keyHandler = vi.fn();
+
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper: ({ children }) => wrapper({ children, pasteWorkaround: true }),
+      });
+
+      act(() => {
+        result.current.subscribe(keyHandler);
+      });
+
+      act(() => {
+        stdin.emit('data', Buffer.from('\r\n'));
+      });
+
+      await waitFor(() => {
+        expect(keyHandler).toHaveBeenCalledTimes(1);
+      });
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          paste: true,
+          sequence: '\r\n',
+        }),
+      );
+    });
   });
 
   describe('Raw keypress pipeline', () => {


### PR DESCRIPTION
Fixes #299.

Windows paste workaround (stdin passthrough) can receive a standalone CRLF chunk during multiline paste. Treating it as a normal return can trigger submit and break pasting.

Changes:
- Treat standalone `
` as a paste event in passthrough mode.
- Add a regression test for the CRLF case.

Tests:
- `npx vitest packages/cli/src/ui/contexts/KeypressContext.test.tsx --run`