### PR TITLE
fix: show auth url in headless mode

### DIFF
--- a/packages/core/src/qwen/qwenOAuth2.ts
+++ b/packages/core/src/qwen/qwenOAuth2.ts
@@ -593,12 +593,12 @@ async function authWithQwenDeviceFlow(
     qwenOAuth2Events.emit(QwenOAuth2Event.AuthUri, deviceAuth);
 
     const showFallbackMessage = () => {
-      console.log('\n=== Qwen OAuth Device Authorization ===');
-      console.log(
+      process.stdout.write('\n=== Qwen OAuth Device Authorization ===');
+      process.stdout.write(
         'Please visit the following URL in your browser to authorize:',
       );
-      console.log(`\n${deviceAuth.verification_uri_complete}\n`);
-      console.log('Waiting for authorization to complete...\n');
+      process.stdout.write(`\n${deviceAuth.verification_uri_complete}\n`);
+      process.stdout.write('Waiting for authorization to complete...\n');
     };
 
     // Always show the fallback message in non-interactive environments to ensure


### PR DESCRIPTION
## TLDR

in https://github.com/QwenLM/qwen-code/pull/1426 i fix the bug but the console.log only show information in debug mode, so i change it to process.stdout.write

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

