### PR TITLE
Skip flaky permission control test

### DIFF
--- a/integration-tests/sdk-typescript/permission-control.test.ts
+++ b/integration-tests/sdk-typescript/permission-control.test.ts
@@ -831,7 +831,7 @@ describe('Permission Control (E2E)', () => {
         TEST_TIMEOUT,
       );
 
-      it(
+      it.skip(
         'should execute dangerous commands without confirmation',
         async () => {
           const q = query({


### PR DESCRIPTION
## TLDR

This pull request skips a flaky and ambiguous SDK end-to-end test case in the permission control integration tests. The test `should execute dangerous commands without confirmation` has been marked as skipped to improve test reliability.

## Dive Deeper

The change modifies the integration test file `integration-tests/sdk-typescript/permission-control.test.ts` by changing an `it` block to `it.skip`. This addresses a known flaky test that was causing unreliable CI builds. The test appears to be related to dangerous command execution without confirmation, but the implementation details were ambiguous enough to cause inconsistent results during testing.

Skipping this test allows for more reliable CI runs while the underlying issue with the test can be investigated separately. This improves the overall stability of the test suite.
