### PR TITLE
Reduce slow quit by trimming skills watchers

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1441,12 +1441,7 @@ export class Config {
     return this.subagentManager;
   }
 
-  getSkillManager(): SkillManager {
-    if (!this.skillManager) {
-      throw new Error(
-        'Skills are disabled. Enable with --experimental-skills to use SkillManager.',
-      );
-    }
+  getSkillManager(): SkillManager | null {
     return this.skillManager;
   }
 

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -245,14 +245,9 @@ export class SkillManager {
    */
   stopWatching(): void {
     for (const watcher of this.watchers.values()) {
-      try {
-        const closePromise = watcher.close();
-        void closePromise.catch((error) => {
-          console.warn('Failed to close skills watcher:', error);
-        });
-      } catch (error) {
+      void watcher.close().catch((error) => {
         console.warn('Failed to close skills watcher:', error);
-      }
+      });
     }
     this.watchers.clear();
     this.watchStarted = false;

--- a/packages/core/src/tools/skill.ts
+++ b/packages/core/src/tools/skill.ts
@@ -53,7 +53,7 @@ export class SkillTool extends BaseDeclarativeTool<SkillParams, ToolResult> {
       false, // canUpdateOutput
     );
 
-    this.skillManager = config.getSkillManager();
+    this.skillManager = config.getSkillManager()!;
     this.skillManager.addChangeListener(() => {
       void this.refreshSkills();
     });


### PR DESCRIPTION
## TLDR

Reduce slow quit behavior by limiting skills directory watchers, creating the user skills dir proactively, and only initializing SkillManager when `--experimental-skills` is enabled.

## Dive Deeper

- Watch only base skills directories (no parent or per-skill watches) to reduce teardown time.
- Ensure `~/.qwen/skills` exists so we never watch parent directories.
- Guard SkillManager lifecycle behind `--experimental-skills`.

## Reviewer Test Plan

1) Run `npm run build --workspace=packages/cli`
2) Start CLI with `--experimental-skills`, add a skill under `~/.qwen/skills`, and confirm skills load as expected.
3) Try `/quit` and confirm exit no longer stalls.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add issue links if applicable -->
