### PR TITLE
fix: unable to remove MCP server when only one element exists

### DIFF
--- a/packages/cli/src/utils/commentJson.test.ts
+++ b/packages/cli/src/utils/commentJson.test.ts
@@ -8,7 +8,10 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { updateSettingsFilePreservingFormat } from './commentJson.js';
+import {
+  updateSettingsFilePreservingFormat,
+  applyUpdates,
+} from './commentJson.js';
 
 describe('commentJson', () => {
   let tempDir: string;
@@ -178,5 +181,20 @@ describe('commentJson', () => {
 
       consoleSpy.mockRestore();
     });
+  });
+});
+
+describe('applyUpdates', () => {
+  it('should apply updates correctly', () => {
+    const original = { a: 1, b: { c: 2 } };
+    const updates = { b: { c: 3 } };
+    const result = applyUpdates(original, updates);
+    expect(result).toEqual({ a: 1, b: { c: 3 } });
+  });
+  it('should apply updates correctly when empty', () => {
+    const original = { a: 1, b: { c: 2 } };
+    const updates = { b: {} };
+    const result = applyUpdates(original, updates);
+    expect(result).toEqual({ a: 1, b: {} });
   });
 });

--- a/packages/cli/src/utils/commentJson.ts
+++ b/packages/cli/src/utils/commentJson.ts
@@ -38,7 +38,7 @@ export function updateSettingsFilePreservingFormat(
   fs.writeFileSync(filePath, updatedContent, 'utf-8');
 }
 
-function applyUpdates(
+export function applyUpdates(
   current: Record<string, unknown>,
   updates: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -50,6 +50,7 @@ function applyUpdates(
       typeof value === 'object' &&
       value !== null &&
       !Array.isArray(value) &&
+      Object.keys(value).length > 0 &&
       typeof result[key] === 'object' &&
       result[key] !== null &&
       !Array.isArray(result[key])


### PR DESCRIPTION
## TLDR

Fixed bug where MCP server cannot be removed when the list has only one element.

## Dive Deeper

**Issue**: When the MCP server list has only one element, attempting to remove it fails.

**Root Cause**: The `applyUpdates` function incorrectly treats empty objects as objects requiring recursive merge instead of replacement.

**Solution**: Added `Object.keys(value).length > 0` check in the merge condition to ensure empty objects are properly handled as replacements.

## Reviewer Test Plan

1. Add one MCP server configuration
2. Attempt to remove this single MCP server
3. Verify the removal succeeds and config file is correctly updated

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1487