### PR TITLE
fix: include --acp flag in tool exclusion check

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -874,11 +874,10 @@ export async function loadCliConfig(
     }
   };
 
-  if (
-    !interactive &&
-    !argv.experimentalAcp &&
-    inputFormat !== InputFormat.STREAM_JSON
-  ) {
+  // ACP mode check: must include both --acp (current) and --experimental-acp (deprecated).
+  // Without this check, edit, write_file, run_shell_command would be excluded in ACP mode.
+  const isAcpMode = argv.acp || argv.experimentalAcp;
+  if (!interactive && !isAcpMode && inputFormat !== InputFormat.STREAM_JSON) {
     switch (approvalMode) {
       case ApprovalMode.PLAN:
       case ApprovalMode.DEFAULT:


### PR DESCRIPTION
## Problem

In VS Code extension, `edit`, `write_file`, and `run_shell_command` tools were unavailable when using Qwen Code.

## Root Cause

The tool exclusion logic only checked `--experimental-acp` flag, but VS Code extension actually uses `--acp` flag (migrated in commit fe7ff5b1). This caused these tools to be incorrectly excluded in ACP mode.

## Solution

Changed the condition from `!argv.experimentalAcp` to `!(argv.acp || argv.experimentalAcp)` to ensure both flags correctly skip the tool exclusion logic.

## Resolved
<img width="1052" height="1214" alt="image" src="https://github.com/user-attachments/assets/3c484686-2a3d-4628-83b7-a9ca5cb4bb1e" />


## Changes

- `packages/cli/src/config/config.ts`: Fix ACP mode check condition

Fixes #1498