### PR TITLE
fix(cli): show tool execution details in headless mode

### DIFF
--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -1967,7 +1967,7 @@ describe('runNonInteractive', () => {
     // Verify tool header is printed before tool output
     const calls = processStdoutSpy.mock.calls.map((call) => call[0]);
     const headerIndex = calls.findIndex(
-      (s) => typeof s === 'string' && s.includes('Shell find . -type f'),
+      (s) => typeof s === 'string' && s.includes('Shell: find . -type f'),
     );
     const outputIndex = calls.findIndex(
       (s) => typeof s === 'string' && s.includes('692'),
@@ -2030,7 +2030,7 @@ describe('runNonInteractive', () => {
 
     // Verify tool header includes file path
     expect(processStdoutSpy).toHaveBeenCalledWith(
-      'Read /path/to/file.txt\n',
+      'Read: /path/to/file.txt\n',
     );
   });
 
@@ -2091,7 +2091,7 @@ describe('runNonInteractive', () => {
     // In JSON mode, the plain text header should NOT appear
     const calls = processStdoutSpy.mock.calls.map((call) => call[0]);
     const hasPlainHeader = calls.some(
-      (s) => typeof s === 'string' && s === 'Shell echo hello\n',
+      (s) => typeof s === 'string' && s === 'Shell: echo hello\n',
     );
     expect(hasPlainHeader).toBe(false);
   });

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -108,7 +108,7 @@ function formatToolHeader(
     (toolName === 'run_shell_command' || toolName === 'Shell') &&
     typeof args['command'] === 'string'
   ) {
-    return `${toolName} ${args['command']}\n`;
+    return `${toolName}: ${args['command']}\n`;
   }
 
   // For Read tool, show the file path
@@ -116,7 +116,7 @@ function formatToolHeader(
     (toolName === 'read_file' || toolName === 'Read') &&
     typeof args['file_path'] === 'string'
   ) {
-    return `${toolName} ${args['file_path']}\n`;
+    return `${toolName}: ${args['file_path']}\n`;
   }
 
   // For Edit tool, show the file path
@@ -124,7 +124,7 @@ function formatToolHeader(
     (toolName === 'edit' || toolName === 'Edit') &&
     typeof args['file_path'] === 'string'
   ) {
-    return `${toolName} ${args['file_path']}\n`;
+    return `${toolName}: ${args['file_path']}\n`;
   }
 
   // For Write tool, show the file path
@@ -132,7 +132,7 @@ function formatToolHeader(
     (toolName === 'write_file' || toolName === 'Write') &&
     typeof args['file_path'] === 'string'
   ) {
-    return `${toolName} ${args['file_path']}\n`;
+    return `${toolName}: ${args['file_path']}\n`;
   }
 
   // For Glob tool, show the pattern
@@ -140,7 +140,7 @@ function formatToolHeader(
     (toolName === 'glob' || toolName === 'Glob') &&
     typeof args['pattern'] === 'string'
   ) {
-    return `${toolName} ${args['pattern']}\n`;
+    return `${toolName}: ${args['pattern']}\n`;
   }
 
   // For Grep tool, show the pattern
@@ -148,7 +148,7 @@ function formatToolHeader(
     (toolName === 'grep_search' || toolName === 'Grep') &&
     typeof args['pattern'] === 'string'
   ) {
-    return `${toolName} ${args['pattern']}\n`;
+    return `${toolName}: ${args['pattern']}\n`;
   }
 
   // Fallback: show tool name with first string arg if available
@@ -156,7 +156,7 @@ function formatToolHeader(
     (v) => typeof v === 'string',
   );
   if (typeof firstStringArg === 'string' && firstStringArg.length < 200) {
-    return `${toolName} ${firstStringArg}\n`;
+    return `${toolName}: ${firstStringArg}\n`;
   }
 
   return `${toolName}\n`;


### PR DESCRIPTION
## TLDR

Display tool name and arguments before tool output in headless/non-interactive text mode. Previously only raw output was shown (e.g., `692`), now users see what command produced it (e.g., `Shell find . -type f | wc -l`).

## Dive Deeper

In interactive mode, tool executions are displayed with a formatted header showing the tool name and arguments. In headless mode (`-p` flag), this context was missing - users only saw raw output with no indication of what command produced it.                                                                                                            
                                                                                                                                                                                 
The fix adds a `formatToolHeader()` function that formats tool-specific information:                                                                                           
- Shell: `Shell <command>`                                                                                                                                                     
- Read: `Read <file_path>`                                                                                                                                                     
- Edit/Write: `<tool> <file_path>`                                                                                                                                             
- Glob/Grep: `<tool> <pattern>`                                                                                                                                                
- Other tools: just the tool name                                                                                                                                              
                                                                                                                                                                                 
The header is printed only in text output mode (not JSON/stream-json) and skipped for Task tool (subagents handle their own output). 

## Reviewer Test Plan

Run:

```bash                                                                                                                                                                     
npm run build && npm run start -- -p "count the files in this directory" -y
```

Verify you see Shell <command> before the output, not just the raw number.   

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | yes |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1435 
