### PR TITLE
fix(core): parse skills frontmatter with CRLF/BOM

### DIFF
--- a/packages/core/src/skills/skill-manager.test.ts
+++ b/packages/core/src/skills/skill-manager.test.ts
@@ -112,6 +112,62 @@ You are a helpful assistant with this skill.
       expect(config.filePath).toBe(validSkillConfig.filePath);
     });
 
+    it('should parse markdown with CRLF line endings', () => {
+      const markdownCrlf = `---\r
+name: test-skill\r
+description: A test skill\r
+---\r
+\r
+You are a helpful assistant with this skill.\r
+`;
+
+      const config = manager.parseSkillContent(
+        markdownCrlf,
+        validSkillConfig.filePath,
+        'project',
+      );
+
+      expect(config.name).toBe('test-skill');
+      expect(config.description).toBe('A test skill');
+      expect(config.body).toBe('You are a helpful assistant with this skill.');
+    });
+
+    it('should parse markdown with UTF-8 BOM', () => {
+      const markdownWithBom = `\uFEFF---
+name: test-skill
+description: A test skill
+---
+
+You are a helpful assistant with this skill.
+`;
+
+      const config = manager.parseSkillContent(
+        markdownWithBom,
+        validSkillConfig.filePath,
+        'project',
+      );
+
+      expect(config.name).toBe('test-skill');
+      expect(config.description).toBe('A test skill');
+    });
+
+    it('should parse markdown when body is empty and file ends after frontmatter', () => {
+      const frontmatterOnly = `---
+name: test-skill
+description: A test skill
+---`;
+
+      const config = manager.parseSkillContent(
+        frontmatterOnly,
+        validSkillConfig.filePath,
+        'project',
+      );
+
+      expect(config.name).toBe('test-skill');
+      expect(config.description).toBe('A test skill');
+      expect(config.body).toBe('');
+    });
+
     it('should parse content with allowedTools', () => {
       const markdownWithTools = `---
 name: test-skill

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -307,9 +307,11 @@ export class SkillManager {
     level: SkillLevel,
   ): SkillConfig {
     try {
+      const normalizedContent = normalizeSkillFileContent(content);
+
       // Split frontmatter and content
-      const frontmatterRegex = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/;
-      const match = content.match(frontmatterRegex);
+      const frontmatterRegex = /^---\n([\s\S]*?)\n---(?:\n|$)([\s\S]*)$/;
+      const match = normalizedContent.match(frontmatterRegex);
 
       if (!match) {
         throw new Error('Invalid format: missing YAML frontmatter');
@@ -555,4 +557,14 @@ export class SkillManager {
       );
     }
   }
+}
+
+function normalizeSkillFileContent(content: string): string {
+  // Strip UTF-8 BOM to ensure frontmatter starts at the first character.
+  let normalized = content.replace(/^\uFEFF/, '');
+
+  // Normalize line endings so skills authored on Windows (CRLF) parse correctly.
+  normalized = normalized.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+  return normalized;
 }


### PR DESCRIPTION
## TLDR

Fix skills parsing on Windows by normalizing `SKILL.md` content so YAML frontmatter works with CRLF line endings and UTF-8 BOM.

## Dive Deeper

`SkillManager.parseSkillContent()` previously used an LF-only frontmatter regex, which fails to match Windows-authored CRLF files.

This change:
- strips UTF-8 BOM at file start
- normalizes `\r\n`/`\r` to `\n`
- relaxes the frontmatter boundary to allow EOF after closing `---`

## Reviewer Test Plan

- (Windows) Create `%USERPROFILE%\\.qwen\\skills\\demo\\SKILL.md` using CRLF (e.g. Notepad) with valid YAML frontmatter.
- Run `qwen --experimental-skills` and verify the skill is listed/usable.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1512
