### PR TITLE
test(cli): stabilize AuthDialog ESC assertion

### DIFF
--- a/packages/cli/src/ui/auth/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.test.tsx
@@ -439,9 +439,10 @@ describe('AuthDialog', () => {
 
     // Should show error message instead of calling handleAuthSelect
     await vi.waitFor(() => {
-      expect(lastFrame()).toContain('You must select an auth method');
+      const frame = lastFrame();
+      expect(frame).toContain('You must select an auth method');
+      expect(frame).toContain('Press Ctrl+C again to exit');
     });
-    expect(lastFrame()).toContain('Press Ctrl+C again to exit');
     expect(handleAuthSelect).not.toHaveBeenCalled();
     unmount();
   });


### PR DESCRIPTION
## TLDR

- Stabilize the AuthDialog ESC-key test by waiting for the async frame update before asserting.

## Dive Deeper

AuthDialog renders the ESC error output asynchronously. The test could sometimes assert against a previous frame and flake. This change uses `vi.waitFor` to wait until the frame contains both:

- "You must select an auth method"
- "Press Ctrl+C again to exit"

This PR is split out from #1531 to keep the MCP resource expansion PR focused.

## Reviewer Test Plan

1. Run `npx vitest packages/cli/src/ui/auth/AuthDialog.test.tsx`.
2. Optional: `npx vitest packages/cli/src/ui/auth/AuthDialog.test.tsx -t "escape key"`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Split out from #1531
