### PR TITLE
fix(cli): isolate modelConfigUtils tests from system env vars

### DIFF
--- a/packages/cli/src/utils/modelConfigUtils.test.ts
+++ b/packages/cli/src/utils/modelConfigUtils.test.ts
@@ -31,7 +31,8 @@ describe('modelConfigUtils', () => {
 
     beforeEach(() => {
       vi.resetModules();
-      process.env = { ...originalEnv };
+      // Start with a clean env - getAuthTypeFromEnv only checks auth-related vars
+      process.env = {};
     });
 
     afterEach(() => {


### PR DESCRIPTION
## TLDR

Fix flaky `modelConfigUtils.test.ts` tests that fail when system has auth-related environment variables set (e.g., `OPENAI_API_KEY`, `OPENAI_MODEL`, `OPENAI_BASE_URL`).

The fix uses a clean `process.env = {}` instead of shallow-copying the original environment, since `getAuthTypeFromEnv` only checks auth-related vars and doesn't need other system vars.

## Dive Deeper

The previous approach used `process.env = { ...originalEnv }` which preserved all system environment variables. Tests like "should return undefined when no auth env vars are set" would fail if the system already had those vars defined.

The new approach starts with a clean env object, which:
- Makes tests deterministic regardless of system environment
- Is simpler and more explicit about test intent
- Is safe because `getAuthTypeFromEnv` only inspects auth-related vars

## Reviewer Test Plan

1. Set some auth env vars on your system:
   ```bash
   export OPENAI_API_KEY=test OPENAI_MODEL=gpt-4 OPENAI_BASE_URL=https://api.openai.com
   ```
2. Run tests without this fix - they should fail
3. Run tests with this fix - they should pass:
   ```bash
   cd packages/cli && npx vitest run modelConfigUtils.test.ts
   ```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A - discovered while running tests locally with auth env vars configured.