### PR TITLE
Fix: Update Qwen OAuth model information

### DIFF
--- a/packages/core/src/models/constants.ts
+++ b/packages/core/src/models/constants.ts
@@ -102,16 +102,14 @@ export const QWEN_OAUTH_ALLOWED_MODELS = [
 export const QWEN_OAUTH_MODELS: ModelConfig[] = [
   {
     id: 'coder-model',
-    name: 'Qwen Coder',
-    description:
-      'The latest Qwen Coder model from Alibaba Cloud ModelStudio (version: qwen3-coder-plus-2025-09-23)',
+    name: 'coder-model',
+    description: 'The latest Qwen Coder model from Alibaba Cloud ModelStudio',
     capabilities: { vision: false },
   },
   {
     id: 'vision-model',
-    name: 'Qwen Vision',
-    description:
-      'The latest Qwen Vision model from Alibaba Cloud ModelStudio (version: qwen3-vl-plus-2025-09-23)',
+    name: 'vision-model',
+    description: 'The latest Qwen Vision model from Alibaba Cloud ModelStudio',
     capabilities: { vision: true },
   },
 ];


### PR DESCRIPTION
## TLDR

This pull request updates the Qwen OAuth model information by removing version numbers from the model descriptions and simplifying the model names in the constants file.

## Dive Deeper

The changes modify the `QWEN_OAUTH_MODELS` constant in `packages/core/src/models/constants.ts` to remove specific version numbers from the model descriptions. Previously, the descriptions included version details like `(version: qwen3-coder-plus-2025-09-23)` and `(version: qwen3-vl-plus-2025-09-23)`, which have been removed to simplify the descriptions. Additionally, the model names have been changed from descriptive names like 'Qwen Coder' and 'Qwen Vision' to their respective IDs ('coder-model' and 'vision-model').

## Reviewer Test Plan

1. Pull the branch and verify that the OAuth model configurations load correctly
2. Check that the updated model names and descriptions appear properly in the UI
3. Ensure that the model selection functionality still works as expected
4. Verify that there are no broken references to the old model names in the codebase

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ✅  | ❓  | ❓  |
| Podman   | ✅  | -   | -   |
| Seatbelt | ✅  | -   | -   |

## Linked issues / bugs

This PR addresses inconsistencies in model naming and removes hardcoded version numbers that could become outdated.