### PR TITLE
Add /bug command to non-interactive mode

### DIFF
--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -38,6 +38,7 @@ export const ALLOWED_BUILTIN_COMMANDS_NON_INTERACTIVE = [
   'init',
   'summary',
   'compress',
+  'bug',
 ] as const;
 
 /**


### PR DESCRIPTION
## TLDR

Adds the `/bug` command to the list of allowed built-in commands in non-interactive mode (CLI and ACP). This enables users to report bugs directly from automated workflows without requiring interactive UI.

## Dive Deeper

The `/bug` command was already implemented but not exposed in non-interactive mode. This change adds `'bug'` to the `ALLOWED_BUILTIN_COMMANDS_NON_INTERACTIVE` array, allowing it to be executed via CLI or ACP integration.

No new functionality is added - this is purely an enabling change that exposes an existing feature.

## Reviewer Test Plan

1. Build and run the CLI: `npm run build && npx qwen-code /bug "test bug report"`
2. Verify the `/bug` command is recognized in non-interactive mode without errors
3. Confirm the command behaves the same as in interactive mode (opens a dialog for bug reporting)

For ACP testing, use a zed integration setup and run: `/bug "describe issue"`

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to #1551
