### PR TITLE
chore(release): bump version to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "workspaces": [
         "packages/*"
       ],
@@ -17310,7 +17310,7 @@
     },
     "packages/cli": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "dependencies": {
         "@google/genai": "1.30.0",
         "@iarna/toml": "^2.2.5",
@@ -17947,7 +17947,7 @@
     },
     "packages/core": {
       "name": "@qwen-code/qwen-code-core",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.36.1",
@@ -21408,7 +21408,7 @@
     },
     "packages/test-utils": {
       "name": "@qwen-code/qwen-code-test-utils",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
@@ -21420,7 +21420,7 @@
     },
     "packages/vscode-ide-companion": {
       "name": "qwen-code-vscode-ide-companion",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "engines": {
     "node": ">=20.0.0"
   },
@@ -13,7 +13,7 @@
     "url": "git+https://github.com/QwenLM/qwen-code.git"
   },
   "config": {
-    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.7.1"
+    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.8.0"
   },
   "scripts": {
     "start": "cross-env node scripts/start.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Qwen Code",
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
     "dist"
   ],
   "config": {
-    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.7.1"
+    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.8.0"
   },
   "dependencies": {
     "@google/genai": "1.30.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code-core",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Qwen Code Core",
   "repository": {
     "type": "git",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code-test-utils",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "private": true,
   "main": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -2,7 +2,7 @@
   "name": "qwen-code-vscode-ide-companion",
   "displayName": "Qwen Code Companion",
   "description": "Enable Qwen Code with direct access to your VS Code workspace.",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "publisher": "qwenlm",
   "icon": "assets/icon.png",
   "repository": {


### PR DESCRIPTION
## TLDR

Bump monorepo package versions from `0.7.1` to `0.8.0` and update the `sandboxImageUri` tag accordingly.

## Dive Deeper

- Updates `package.json` versions across root + workspace packages.
- Updates `sandboxImageUri` to `ghcr.io/qwenlm/qwen-code:0.8.0`.

## Reviewer Test Plan

- Verify version + `sandboxImageUri` updates look correct.
- (Optional) Run `npm test` / `npm run preflight`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- none -->