### PR TITLE
feat(cli): enhance Header component to display git branch information

### DIFF
--- a/packages/cli/src/ui/components/Header.tsx
+++ b/packages/cli/src/ui/components/Header.tsx
@@ -7,7 +7,13 @@
 import type React from 'react';
 import { Box, Text } from 'ink';
 import Gradient from 'ink-gradient';
-import { AuthType, shortenPath, tildeifyPath } from '@qwen-code/qwen-code-core';
+import {
+  AuthType,
+  isGitRepository,
+  getGitBranch,
+  shortenPath,
+  tildeifyPath,
+} from '@qwen-code/qwen-code-core';
 import { theme } from '../semantic-colors.js';
 import { shortAsciiLogo } from './AsciiArt.js';
 import { getAsciiArtWidth, getCachedStringWidth } from '../utils/textUtils.js';
@@ -121,6 +127,11 @@ export const Header: React.FC<HeaderProps> = ({
         ? shortenedPath.slice(0, maxPathLength)
         : shortenedPath;
 
+  // Get git branch if cwd is in a legitimate git repo
+  const gitBranch = isGitRepository(workingDirectory)
+    ? getGitBranch(workingDirectory)
+    : undefined;
+
   // Use theme gradient colors if available, otherwise use text colors (excluding primary)
   const gradientColors = theme.ui.gradient || [
     theme.text.secondary,
@@ -175,6 +186,8 @@ export const Header: React.FC<HeaderProps> = ({
         </Text>
         {/* Directory line */}
         <Text color={theme.text.secondary}>{displayPath}</Text>
+        {/* Git branch line (only if in a git repo) */}
+        {gitBranch && <Text color={theme.text.secondary}> ({gitBranch})</Text>}
       </Box>
     </Box>
   );


### PR DESCRIPTION
## TLDR

Add git branch display in the CLI header when running inside a git repository. This helps users quickly identify which branch they're working on without leaving the terminal.

## Dive Deeper

The `Header` component now checks if the current working directory is a git repository using `isGitRepository()` and displays the branch name via `getGitBranch()` when available. The branch appears in parentheses after the working directory path (e.g., `(main)` or `(feature/new-feature)`).

Changes:
- **Header.tsx**: Added imports for `isGitRepository` and `getGitBranch`, and conditional rendering of the git branch text
- **Header.test.tsx**: Added unit tests to verify branch display behavior when inside/outside a git repo, and with different branch names

No changes to existing functionality - only adds an optional line of information.

## Reviewer Test Plan

Test the Header component by running it in different scenarios:

```bash
# Run tests to verify behavior
npm run test -- packages/cli/src/ui/components/Header.test.tsx

# Manually test by starting the CLI:
npm run start
```

Expected behaviors:
1. When inside a git repository: branch name should appear after working directory (e.g., `/path/to/repo (main)`)
2. When outside a git repository: no branch text should appear
3. Different branch names (e.g., `feature/new-feature`) should display correctly

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->

No linked issues.
