### PR TITLE
fix: skip non-existent file imports instead of warning (ENOENT)

### DIFF
--- a/packages/core/src/utils/memoryImportProcessor.test.ts
+++ b/packages/core/src/utils/memoryImportProcessor.test.ts
@@ -92,11 +92,15 @@ const findCodeBlocks = (
 
 describe('memoryImportProcessor', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks(); // Use resetAllMocks to clear mock implementations
     // Mock console methods
     console.warn = vi.fn();
     console.error = vi.fn();
     console.debug = vi.fn();
+    // Default mock for lstat (used by findProjectRoot)
+    mockedFs.lstat.mockRejectedValue(
+      Object.assign(new Error('ENOENT'), { code: 'ENOENT' }),
+    );
   });
 
   afterEach(() => {
@@ -204,20 +208,43 @@ describe('memoryImportProcessor', () => {
       );
     });
 
-    it('should handle file not found errors', async () => {
+    it('should silently preserve content when file not found (ENOENT)', async () => {
       const content = 'Content @./nonexistent.md more content';
       const basePath = testPath('test', 'path');
 
-      mockedFs.access.mockRejectedValue(new Error('File not found'));
+      // Mock ENOENT error (file not found)
+      mockedFs.access.mockRejectedValue(
+        Object.assign(new Error('ENOENT: no such file or directory'), {
+          code: 'ENOENT',
+        }),
+      );
 
       const result = await processImports(content, basePath, true);
 
+      // Content should be preserved as-is when file doesn't exist
+      expect(result.content).toBe(content);
+      // No error should be logged for ENOENT
+      expect(console.error).not.toHaveBeenCalled();
+    });
+
+    it('should log error for non-ENOENT file access errors', async () => {
+      const content = 'Content @./permission-denied.md more content';
+      const basePath = testPath('test', 'path');
+
+      // Mock a permission denied error (not ENOENT)
+      mockedFs.access.mockRejectedValue(
+        Object.assign(new Error('Permission denied'), { code: 'EACCES' }),
+      );
+
+      const result = await processImports(content, basePath, true);
+
+      // Should show error comment for non-ENOENT errors
       expect(result.content).toContain(
-        '<!-- Import failed: ./nonexistent.md - File not found -->',
+        '<!-- Import failed: ./permission-denied.md - Permission denied -->',
       );
       expect(console.error).toHaveBeenCalledWith(
         '[ERROR] [ImportProcessor]',
-        'Failed to import ./nonexistent.md: File not found',
+        'Failed to import ./permission-denied.md: Permission denied',
       );
     });
 
@@ -446,6 +473,50 @@ describe('memoryImportProcessor', () => {
       const result = await processImports(content, testRootDir);
       expect(result.content).toBe(content);
       expect(result.importTree.imports).toBeUndefined();
+    });
+
+    it('should still import valid paths while ignoring non-existent paths', async () => {
+      const content = '使用 @./valid.md 文件和 @中文路径 注解';
+      const basePath = testPath('test', 'path');
+      const importedContent = 'Valid imported content';
+
+      // Mock: valid.md exists, 中文路径 doesn't exist
+      mockedFs.access
+        .mockResolvedValueOnce(undefined) // ./valid.md exists
+        .mockRejectedValueOnce(
+          Object.assign(new Error('ENOENT'), { code: 'ENOENT' }),
+        ); // 中文路径 doesn't exist
+      mockedFs.readFile.mockResolvedValue(importedContent);
+
+      const result = await processImports(content, basePath, true);
+
+      // Should import valid.md
+      expect(result.content).toContain(importedContent);
+      expect(result.content).toContain('<!-- Imported from: ./valid.md -->');
+      // The non-existent path should remain as-is
+      expect(result.content).toContain('@中文路径');
+    });
+
+    it('should import Chinese file names if they exist', async () => {
+      const content = '导入 @./中文文档.md 文件';
+      const projectRoot = testPath('test', 'project');
+      const basePath = testPath(projectRoot, 'src');
+      const importedContent = '这是中文文档的内容';
+
+      mockedFs.access.mockResolvedValue(undefined);
+      mockedFs.readFile.mockResolvedValue(importedContent);
+
+      const result = await processImports(
+        content,
+        basePath,
+        true,
+        undefined,
+        projectRoot,
+      );
+
+      // Should successfully import the Chinese-named file
+      expect(result.content).toContain(importedContent);
+      expect(result.content).toContain('<!-- Imported from: ./中文文档.md -->');
     });
 
     it('should allow imports from parent and subdirectories within project root', async () => {


### PR DESCRIPTION
## TLDR

When processing markdown files with `@path` imports, the memory import processor now silently skips non-existent files (ENOENT errors) instead of logging warnings. This prevents false error messages when markdown content contains text like `@Slf4j` that gets incorrectly interpreted as file imports.

## Dive Deeper

The root cause: markdown files may contain text patterns like `@Slf4j注解` or `@LogRecord` that look like import directives but are actually just documentation text. When these "paths" don't exist as files, the processor was logging warnings, which confused users.

The fix:
- Added `isFileNotFoundError()` helper to detect ENOENT errors
- For non-existent files in nested imports: silently skip without warning
- For non-existent files in top-level imports: preserve original `@path` text in output
- Other errors (permission denied, etc.) still get logged as before

## Reviewer Test Plan

1. Create a markdown file with content like: `使用@LogRecord注解，使用SLF4J @Slf4j注解`
2. Place it in a project directory and run qwen-code
3. Verify no ENOENT warnings appear in logs
4. Verify the original text is preserved in output

## Testing Matrix

|          | npm run  | npx | Docker | Podman | Seatbelt |
| -------- | --- | --- | --- | --- | --- |
| macOS    | ?  | ?  | ?  | ?  | ?  |
| Windows  | ?  | ?  | ?  | -  | -  |
| Linux    | ?  | ?  | ?  | -  | -  |

## Linked issues / bugs

Fixes #1549