### PR TITLE
feat: clarify output formats for non-interactive mode

### DIFF
--- a/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.ts
+++ b/packages/cli/src/nonInteractive/io/BaseJsonOutputAdapter.ts
@@ -64,7 +64,6 @@ export interface ResultOptions {
   readonly stats?: SessionMetrics;
   readonly summary?: string;
   readonly subtype?: string;
-  readonly showResult?: boolean;
 }
 
 /**

--- a/packages/cli/src/nonInteractive/io/JsonOutputAdapter.ts
+++ b/packages/cli/src/nonInteractive/io/JsonOutputAdapter.ts
@@ -67,7 +67,7 @@ export class JsonOutputAdapter
     );
     this.messages.push(resultMessage);
 
-    if (options.showResult) {
+    if (this.config.getOutputFormat() === 'text') {
       if (resultMessage.is_error) {
         process.stderr.write(`${resultMessage.error?.message || ''}`);
       } else {

--- a/packages/cli/src/utils/nonInteractiveHelpers.test.ts
+++ b/packages/cli/src/utils/nonInteractiveHelpers.test.ts
@@ -984,26 +984,6 @@ describe('createTaskToolProgressHandler', () => {
     expect(mockAdapter.emitToolResult).not.toHaveBeenCalled();
   });
 
-  it('should work without adapter (non-JSON mode)', () => {
-    const { handler } = createTaskToolProgressHandler(
-      mockConfig,
-      'parent-tool-id',
-      undefined,
-    );
-
-    const taskDisplay: TaskResultDisplay = {
-      type: 'task_execution',
-      subagentName: 'test-agent',
-      taskDescription: 'Test task',
-      taskPrompt: 'Test prompt',
-      status: 'running',
-      toolCalls: [],
-    };
-
-    // Should not throw
-    expect(() => handler('task-call-id', taskDisplay)).not.toThrow();
-  });
-
   it('should work with adapter that does not support subagent APIs', () => {
     const limitedAdapter = {
       emitToolResult: vi.fn(),

--- a/packages/cli/src/utils/nonInteractiveHelpers.ts
+++ b/packages/cli/src/utils/nonInteractiveHelpers.ts
@@ -306,7 +306,7 @@ export async function buildSystemMessage(
 export function createTaskToolProgressHandler(
   config: Config,
   taskToolCallId: string,
-  adapter: JsonOutputAdapterInterface | undefined,
+  adapter: JsonOutputAdapterInterface,
 ): {
   handler: OutputUpdateHandler;
 } {
@@ -406,7 +406,7 @@ export function createTaskToolProgressHandler(
       toolCallToEmit.status === 'executing' ||
       toolCallToEmit.status === 'awaiting_approval'
     ) {
-      if (adapter?.processSubagentToolCall) {
+      if (adapter.processSubagentToolCall) {
         adapter.processSubagentToolCall(toolCallToEmit, taskToolCallId);
         emittedToolUseIds.add(toolCall.callId);
       }
@@ -432,19 +432,17 @@ export function createTaskToolProgressHandler(
     // Mark as emitted even if we skip, to prevent duplicate emits
     emittedToolResultIds.add(toolCall.callId);
 
-    if (adapter) {
-      const request = buildRequest(toolCall);
-      const response = buildResponse(toolCall);
-      // For subagent tool results, we need to pass parentToolUseId
-      // The adapter implementations accept an optional parentToolUseId parameter
-      if (
-        'emitToolResult' in adapter &&
-        typeof adapter.emitToolResult === 'function'
-      ) {
-        adapter.emitToolResult(request, response, taskToolCallId);
-      } else {
-        adapter.emitToolResult(request, response);
-      }
+    const request = buildRequest(toolCall);
+    const response = buildResponse(toolCall);
+    // For subagent tool results, we need to pass parentToolUseId
+    // The adapter implementations accept an optional parentToolUseId parameter
+    if (
+      'emitToolResult' in adapter &&
+      typeof adapter.emitToolResult === 'function'
+    ) {
+      adapter.emitToolResult(request, response, taskToolCallId);
+    } else {
+      adapter.emitToolResult(request, response);
     }
   };
 
@@ -500,12 +498,6 @@ export function createTaskToolProgressHandler(
     ) {
       const taskDisplay = outputChunk as TaskResultDisplay;
       const previous = previousTaskStates.get(callId);
-
-      // If no adapter, just track state (for non-JSON modes)
-      if (!adapter) {
-        previousTaskStates.set(callId, taskDisplay);
-        return;
-      }
 
       // Only process if adapter supports subagent APIs
       if (


### PR DESCRIPTION
## TLDR

Clarify the three output formats in non-interactive mode: json (non-streaming structured output), stream-json (streaming structured output), and text (non-streaming final result only, similar to Claude Code).

## Dive Deeper

### Output Format Behavior

- **json**: Non-streaming output of all structured LLM content (complete JSON at the end)
- **stream-json**: Streaming output of structured LLM content (JSON chunks as they arrive)
- **text** (default): Non-streaming output of final result only for better readability

### Implementation Details

- Unified JSON and TEXT modes to use the same JsonOutputAdapter internally
- TEXT mode now outputs only the final result/error via `showResult` flag
- Removed redundant streaming text output handlers for TEXT mode
- Simplified tool output handling by removing non-Task tool output handlers in TEXT mode

## Reviewer Test Plan

Run non-interactive mode with different output formats:

```bash
# Test json mode
echo "hello" | qwen-code -p "say hi" --output-format json

# Test stream-json mode  
echo "hello" | qwen-code -p "say hi" --output-format stream-json

# Test text mode (default)
echo "hello" | qwen-code -p "say hi" --output-format text
```

Verify:
- json: outputs complete JSON array at the end
- stream-json: outputs JSON chunks as they stream
- text: outputs only the final result text

## Testing Matrix

|          | macOS  | Windows | Linux |
| -------- | --- | --- | --- |
| npm run  | Y  | -  | -  |
| npx      | -  | -  | -  |
| Docker   | -  | -  | -  |
| Podman   | -  | -  | -  |
| Seatbelt | -  | -  | -  |

## Linked issues / bugs

N/A