### PR TITLE
feat(extensions): add detail command and improve extension validation

### DIFF
--- a/packages/cli/src/commands/extensions/utils.test.ts
+++ b/packages/cli/src/commands/extensions/utils.test.ts
@@ -5,7 +5,8 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getExtensionManager } from './utils.js';
+import { getExtensionManager, extensionToOutputString } from './utils.js';
+import type { Extension, ExtensionManager } from '@qwen-code/qwen-code-core';
 
 const mockRefreshCache = vi.fn();
 const mockExtensionManagerInstance = {
@@ -62,5 +63,72 @@ describe('getExtensionManager', () => {
         workspaceDir: process.cwd(),
       }),
     );
+  });
+});
+
+describe('extensionToOutputString', () => {
+  const mockIsEnabled = vi.fn();
+  const mockExtensionManager = {
+    isEnabled: mockIsEnabled,
+  } as unknown as ExtensionManager;
+
+  const createMockExtension = (overrides = {}): Extension => ({
+    id: 'test-ext-id',
+    name: 'test-extension',
+    version: '1.0.0',
+    isActive: true,
+    path: '/path/to/extension',
+    contextFiles: [],
+    config: { name: 'test-extension', version: '1.0.0' },
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsEnabled.mockReturnValue(true);
+  });
+
+  it('should include status icon when inline is false', () => {
+    const extension = createMockExtension();
+    const result = extensionToOutputString(
+      extension,
+      mockExtensionManager,
+      '/workspace',
+      false,
+    );
+
+    // Should contain either ✓ or ✗ (with ANSI color codes)
+    expect(result).toMatch(/test-extension/);
+    expect(result).toContain('(1.0.0)');
+  });
+
+  it('should exclude status icon when inline is true', () => {
+    const extension = createMockExtension();
+    const result = extensionToOutputString(
+      extension,
+      mockExtensionManager,
+      '/workspace',
+      true,
+    );
+
+    // Should start with extension name (after stripping potential whitespace)
+    expect(result.trim()).toMatch(/^test-extension/);
+  });
+
+  it('should default inline to false', () => {
+    const extension = createMockExtension();
+    const resultWithoutInline = extensionToOutputString(
+      extension,
+      mockExtensionManager,
+      '/workspace',
+    );
+    const resultWithInlineFalse = extensionToOutputString(
+      extension,
+      mockExtensionManager,
+      '/workspace',
+      false,
+    );
+
+    expect(resultWithoutInline).toEqual(resultWithInlineFalse);
   });
 });

--- a/packages/cli/src/commands/extensions/utils.ts
+++ b/packages/cli/src/commands/extensions/utils.ts
@@ -32,6 +32,7 @@ export function extensionToOutputString(
   extension: Extension,
   extensionManager: ExtensionManager,
   workspaceDir: string,
+  inline = false,
 ): string {
   const cwd = workspaceDir;
   const userEnabled = extensionManager.isEnabled(
@@ -44,7 +45,7 @@ export function extensionToOutputString(
   );
 
   const status = workspaceEnabled ? chalk.green('✓') : chalk.red('✗');
-  let output = `${status} ${extension.config.name} (${extension.config.version})`;
+  let output = `${inline ? '' : status} ${extension.config.name} (${extension.config.version})`;
   output += `\n Path: ${extension.path}`;
   if (extension.installMetadata) {
     output += `\n Source: ${extension.installMetadata.source} (Type: ${extension.installMetadata.type})`;

--- a/packages/core/src/extension/extensionManager.ts
+++ b/packages/core/src/extension/extensionManager.ts
@@ -190,7 +190,7 @@ function filterMcpConfig(original: MCPServerConfig): MCPServerConfig {
 }
 
 function getContextFileNames(config: ExtensionConfig): string[] {
-  if (!config.contextFileName) {
+  if (!config.contextFileName || config.contextFileName.length === 0) {
     return ['QWEN.md'];
   } else if (!Array.isArray(config.contextFileName)) {
     return [config.contextFileName];
@@ -1244,9 +1244,9 @@ export function hashValue(value: string): string {
 }
 
 export function validateName(name: string) {
-  if (!/^[a-zA-Z0-9-]+$/.test(name)) {
+  if (!/^[a-zA-Z0-9-_.]+$/.test(name)) {
     throw new Error(
-      `Invalid extension name: "${name}". Only letters (a-z, A-Z), numbers (0-9), and dashes (-) are allowed.`,
+      `Invalid extension name: "${name}". Only letters (a-z, A-Z), numbers (0-9), underscores (_), dots (.), and dashes (-) are allowed.`,
     );
   }
 }

--- a/packages/core/src/extension/github.test.ts
+++ b/packages/core/src/extension/github.test.ts
@@ -117,6 +117,51 @@ describe('git extension helpers', () => {
         'Failed to clone Git repository from http://my-repo.com',
       );
     });
+
+    it('should use marketplace source for marketplace type extensions', async () => {
+      const installMetadata = {
+        source: 'marketplace:my-plugin',
+        type: 'marketplace' as const,
+        marketplace: {
+          pluginName: 'my-plugin',
+          marketplaceSource: 'https://github.com/marketplace/my-plugin',
+        },
+      };
+      const destination = '/dest';
+      mockGit.getRemotes.mockResolvedValue([
+        {
+          name: 'origin',
+          refs: { fetch: 'https://github.com/marketplace/my-plugin' },
+        },
+      ]);
+
+      await cloneFromGit(installMetadata, destination);
+
+      expect(mockGit.clone).toHaveBeenCalledWith(
+        'https://github.com/marketplace/my-plugin',
+        './',
+        ['--depth', '1'],
+      );
+    });
+
+    it('should use source for marketplace type without marketplace metadata', async () => {
+      const installMetadata = {
+        source: 'http://fallback-repo.com',
+        type: 'marketplace' as const,
+      };
+      const destination = '/dest';
+      mockGit.getRemotes.mockResolvedValue([
+        { name: 'origin', refs: { fetch: 'http://fallback-repo.com' } },
+      ]);
+
+      await cloneFromGit(installMetadata, destination);
+
+      expect(mockGit.clone).toHaveBeenCalledWith(
+        'http://fallback-repo.com',
+        './',
+        ['--depth', '1'],
+      );
+    });
   });
 
   describe('checkForExtensionUpdate', () => {

--- a/packages/core/src/extension/github.ts
+++ b/packages/core/src/extension/github.ts
@@ -53,7 +53,10 @@ export async function cloneFromGit(
 ): Promise<void> {
   try {
     const git = simpleGit(destination);
-    let sourceUrl = installMetadata.source;
+    let sourceUrl =
+      installMetadata.type === 'marketplace' && installMetadata.marketplace
+        ? installMetadata.marketplace.marketplaceSource
+        : installMetadata.source;
     const token = getGitHubToken();
     if (token) {
       try {


### PR DESCRIPTION
## TLDR

Add `/extensions detail` command and fix several extension-related issues:
- New command to view extension details inline
- Relaxed extension naming rules to allow underscores and dots
- Fixed edge cases in contextFileName and marketplace clone

## Dive Deeper

### Features
- **`/extensions detail <name>`**: Query specific extension info without status icons (inline mode)
- **Extended naming validation**: Now accepts `my_extension`, `my.extension` patterns

### Bug Fixes
- **Empty contextFileName array**: Falls back to default `QWEN.md` when array is empty
- **Marketplace clone URL**: Uses `marketplace.marketplaceSource` instead of generic source

## Reviewer Test Plan

1. Run `/extensions detail <extension-name>` to verify detail output
2. Install extension with underscore/dot in name (e.g., `my_ext.v1`)
3. Test extension with empty `contextFileName: []` in config

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A