### PR TITLE
Simplify permission response handling and fix edit failure and VSCode diff issues

### DIFF
--- a/packages/vscode-ide-companion/src/types/webviewMessageTypes.ts
+++ b/packages/vscode-ide-companion/src/types/webviewMessageTypes.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface PermissionResponsePayload {
+  optionId: string;
+}
+
+export interface PermissionResponseMessage {
+  type: string;
+  data: PermissionResponsePayload;
+}

--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -424,30 +424,17 @@ export const App: React.FC = () => {
 
   // Handle permission response
   const handlePermissionResponse = useCallback(
-    (optionId: string, customMessage?: string) => {
+    (optionId: string) => {
       // Forward the selected optionId directly to extension as ACP permission response
       // Expected values include: 'proceed_once', 'proceed_always', 'cancel', 'proceed_always_server', etc.
-      // If customMessage is provided, it will be sent as user feedback to the AI
       vscode.postMessage({
         type: 'permissionResponse',
-        data: { optionId, customMessage },
+        data: { optionId },
       });
-
-      // If user provided custom feedback, display it as a user message in the chat
-      // This provides visual feedback that the message was sent to the AI
-      if (customMessage?.trim()) {
-        messageHandling.addMessage({
-          role: 'user',
-          content: customMessage.trim(),
-          timestamp: Date.now(),
-        });
-        // Set waiting state since AI will respond to this feedback
-        messageHandling.setWaitingForResponse('Processing your feedback...');
-      }
 
       setPermissionRequest(null);
     },
-    [vscode, messageHandling],
+    [vscode],
   );
 
   // Handle completion selection

--- a/packages/vscode-ide-companion/src/webview/MessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/MessageHandler.ts
@@ -6,6 +6,7 @@
 
 import type { QwenAgentManager } from '../services/qwenAgentManager.js';
 import type { ConversationStore } from '../services/conversationStore.js';
+import type { PermissionResponseMessage } from '../types/webviewMessageTypes.js';
 import { MessageRouter } from './handlers/MessageRouter.js';
 
 /**
@@ -55,10 +56,7 @@ export class MessageHandler {
    * Set permission handler
    */
   setPermissionHandler(
-    handler: (message: {
-      type: string;
-      data: { optionId: string; customMessage?: string };
-    }) => void,
+    handler: (message: PermissionResponseMessage) => void,
   ): void {
     this.router.setPermissionHandler(handler);
   }

--- a/packages/vscode-ide-companion/src/webview/WebViewProvider.ts
+++ b/packages/vscode-ide-companion/src/webview/WebViewProvider.ts
@@ -8,6 +8,7 @@ import * as vscode from 'vscode';
 import { QwenAgentManager } from '../services/qwenAgentManager.js';
 import { ConversationStore } from '../services/conversationStore.js';
 import type { AcpPermissionRequest } from '../types/acpTypes.js';
+import type { PermissionResponseMessage } from '../types/webviewMessageTypes.js';
 import { PanelManager } from '../webview/PanelManager.js';
 import { MessageHandler } from '../webview/MessageHandler.js';
 import { WebViewContent } from '../webview/WebViewContent.js';
@@ -251,21 +252,17 @@ export class WebViewProvider {
               }
             }
           };
-          const handler = (message: {
-            type: string;
-            data: { optionId: string; customMessage?: string };
-          }) => {
+          const handler = (message: PermissionResponseMessage) => {
             if (message.type !== 'permissionResponse') {
               return;
             }
 
             const optionId = message.data.optionId || '';
-            const customMessage = message.data.customMessage || '';
 
             // 1) First resolve the optionId back to ACP so the agent isn't blocked
             this.pendingPermissionResolve?.(optionId);
 
-            // 2) If user cancelled/rejected, handle based on whether there's custom feedback
+            // 2) If user cancelled/rejected, proactively stop current generation
             const isCancel =
               optionId === 'cancel' ||
               optionId.toLowerCase().includes('reject');
@@ -281,148 +278,73 @@ export class WebViewProvider {
                 );
               }
 
-              // If user provided custom feedback, send it as a new message to continue the conversation
-              // instead of completely cancelling the request
-              if (customMessage.trim()) {
-                // Fire and forget – do not block the ACP resolve
-                (async () => {
-                  // Update the tool call status to 'failed' in UI
-                  try {
-                    const toolCallId =
-                      (request.toolCall as { toolCallId?: string } | undefined)
-                        ?.toolCallId || '';
-                    const title =
-                      (request.toolCall as { title?: string } | undefined)
-                        ?.title || '';
-                    let kind = ((
-                      request.toolCall as { kind?: string } | undefined
-                    )?.kind || 'execute') as string;
-                    if (!kind && title) {
-                      const t = title.toLowerCase();
-                      if (t.includes('read') || t.includes('cat')) {
-                        kind = 'read';
-                      } else if (t.includes('write') || t.includes('edit')) {
-                        kind = 'edit';
-                      } else {
-                        kind = 'execute';
-                      }
+              // Fire and forget – do not block the ACP resolve
+              (async () => {
+                try {
+                  // Stop server-side generation
+                  await this.agentManager.cancelCurrentPrompt();
+                } catch (err) {
+                  console.warn(
+                    '[WebViewProvider] cancelCurrentPrompt error:',
+                    err,
+                  );
+                }
+
+                // Ensure the webview exits streaming state immediately
+                this.sendMessageToWebView({
+                  type: 'streamEnd',
+                  data: { timestamp: Date.now(), reason: 'user_cancelled' },
+                });
+
+                // Synthesize a failed tool_call_update to match CLI UX
+                try {
+                  const toolCallId =
+                    (request.toolCall as { toolCallId?: string } | undefined)
+                      ?.toolCallId || '';
+                  const title =
+                    (request.toolCall as { title?: string } | undefined)
+                      ?.title || '';
+                  let kind = ((
+                    request.toolCall as { kind?: string } | undefined
+                  )?.kind || 'execute') as string;
+                  if (!kind && title) {
+                    const t = title.toLowerCase();
+                    if (t.includes('read') || t.includes('cat')) {
+                      kind = 'read';
+                    } else if (t.includes('write') || t.includes('edit')) {
+                      kind = 'edit';
+                    } else {
+                      kind = 'execute';
                     }
-
-                    this.sendMessageToWebView({
-                      type: 'toolCall',
-                      data: {
-                        type: 'tool_call_update',
-                        toolCallId,
-                        title,
-                        kind,
-                        status: 'failed',
-                        rawInput: (request.toolCall as { rawInput?: unknown })
-                          ?.rawInput,
-                        locations: (
-                          request.toolCall as {
-                            locations?: Array<{
-                              path: string;
-                              line?: number | null;
-                            }>;
-                          }
-                        )?.locations,
-                      },
-                    });
-                  } catch (err) {
-                    console.warn(
-                      '[WebViewProvider] failed to synthesize failed tool_call_update:',
-                      err,
-                    );
                   }
 
-                  // Send the custom feedback as a new user message to continue the conversation
-                  // This allows the AI to understand user's intent and try a different approach
-                  try {
-                    await this.agentManager.sendMessage(customMessage.trim());
-                  } catch (err) {
-                    console.warn(
-                      '[WebViewProvider] failed to send custom feedback as new prompt:',
-                      err,
-                    );
-                    // If sending fails, notify the webview
-                    this.sendMessageToWebView({
-                      type: 'error',
-                      data: {
-                        message: 'Failed to send feedback to AI',
-                        error: String(err),
-                      },
-                    });
-                  }
-                })();
-              } else {
-                // No custom feedback - completely cancel the request (original behavior)
-                (async () => {
-                  try {
-                    // Stop server-side generation
-                    await this.agentManager.cancelCurrentPrompt();
-                  } catch (err) {
-                    console.warn(
-                      '[WebViewProvider] cancelCurrentPrompt error:',
-                      err,
-                    );
-                  }
-
-                  // Ensure the webview exits streaming state immediately
                   this.sendMessageToWebView({
-                    type: 'streamEnd',
-                    data: { timestamp: Date.now(), reason: 'user_cancelled' },
+                    type: 'toolCall',
+                    data: {
+                      type: 'tool_call_update',
+                      toolCallId,
+                      title,
+                      kind,
+                      status: 'failed',
+                      rawInput: (request.toolCall as { rawInput?: unknown })
+                        ?.rawInput,
+                      locations: (
+                        request.toolCall as {
+                          locations?: Array<{
+                            path: string;
+                            line?: number | null;
+                          }>;
+                        }
+                      )?.locations,
+                    },
                   });
-
-                  // Synthesize a failed tool_call_update to match CLI UX
-                  try {
-                    const toolCallId =
-                      (request.toolCall as { toolCallId?: string } | undefined)
-                        ?.toolCallId || '';
-                    const title =
-                      (request.toolCall as { title?: string } | undefined)
-                        ?.title || '';
-                    let kind = ((
-                      request.toolCall as { kind?: string } | undefined
-                    )?.kind || 'execute') as string;
-                    if (!kind && title) {
-                      const t = title.toLowerCase();
-                      if (t.includes('read') || t.includes('cat')) {
-                        kind = 'read';
-                      } else if (t.includes('write') || t.includes('edit')) {
-                        kind = 'edit';
-                      } else {
-                        kind = 'execute';
-                      }
-                    }
-
-                    this.sendMessageToWebView({
-                      type: 'toolCall',
-                      data: {
-                        type: 'tool_call_update',
-                        toolCallId,
-                        title,
-                        kind,
-                        status: 'failed',
-                        rawInput: (request.toolCall as { rawInput?: unknown })
-                          ?.rawInput,
-                        locations: (
-                          request.toolCall as {
-                            locations?: Array<{
-                              path: string;
-                              line?: number | null;
-                            }>;
-                          }
-                        )?.locations,
-                      },
-                    });
-                  } catch (err) {
-                    console.warn(
-                      '[WebViewProvider] failed to synthesize failed tool_call_update:',
-                      err,
-                    );
-                  }
-                })();
-              }
+                } catch (err) {
+                  console.warn(
+                    '[WebViewProvider] failed to synthesize failed tool_call_update:',
+                    err,
+                  );
+                }
+              })();
             }
             // If user allowed/proceeded, proactively close any open qwen-diff editors and suppress re-open briefly
             else {

--- a/packages/vscode-ide-companion/src/webview/components/PermissionDrawer/PermissionDrawer.tsx
+++ b/packages/vscode-ide-companion/src/webview/components/PermissionDrawer/PermissionDrawer.tsx
@@ -12,7 +12,7 @@ interface PermissionDrawerProps {
   isOpen: boolean;
   options: PermissionOption[];
   toolCall: ToolCall;
-  onResponse: (optionId: string, customMessage?: string) => void;
+  onResponse: (optionId: string) => void;
   onClose?: () => void;
 }
 
@@ -24,10 +24,7 @@ export const PermissionDrawer: React.FC<PermissionDrawerProps> = ({
   onClose,
 }) => {
   const [focusedIndex, setFocusedIndex] = useState(0);
-  const [customMessage, setCustomMessage] = useState('');
   const containerRef = useRef<HTMLDivElement>(null);
-  // Correct the ref type for custom input to HTMLInputElement to avoid subsequent forced casting
-  const customInputRef = useRef<HTMLInputElement>(null);
 
   console.log('PermissionDrawer rendered with isOpen:', isOpen, toolCall);
   // Prefer file name from locations, fall back to content[].path if present
@@ -94,10 +91,7 @@ export const PermissionDrawer: React.FC<PermissionDrawerProps> = ({
 
       // Number keys 1-9 for quick select
       const numMatch = e.key.match(/^[1-9]$/);
-      if (
-        numMatch &&
-        !customInputRef.current?.contains(document.activeElement)
-      ) {
+      if (numMatch) {
         const index = parseInt(e.key, 10) - 1;
         if (index < options.length) {
           e.preventDefault();
@@ -109,7 +103,10 @@ export const PermissionDrawer: React.FC<PermissionDrawerProps> = ({
       // Arrow keys for navigation
       if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
         e.preventDefault();
-        const totalItems = options.length + 1; // +1 for custom input
+        if (options.length === 0) {
+          return;
+        }
+        const totalItems = options.length;
         if (e.key === 'ArrowDown') {
           setFocusedIndex((prev) => (prev + 1) % totalItems);
         } else {
@@ -118,10 +115,7 @@ export const PermissionDrawer: React.FC<PermissionDrawerProps> = ({
       }
 
       // Enter to select
-      if (
-        e.key === 'Enter' &&
-        !customInputRef.current?.contains(document.activeElement)
-      ) {
+      if (e.key === 'Enter') {
         e.preventDefault();
         if (focusedIndex < options.length) {
           onResponse(options[focusedIndex].optionId);
@@ -234,31 +228,6 @@ export const PermissionDrawer: React.FC<PermissionDrawerProps> = ({
               </button>
             );
           })}
-
-          {/* Custom message input (extracted component) */}
-          {(() => {
-            const isFocused = focusedIndex === options.length;
-            const rejectOptionId = options.find((o) =>
-              o.kind.includes('reject'),
-            )?.optionId;
-            return (
-              <CustomMessageInputRow
-                isFocused={isFocused}
-                customMessage={customMessage}
-                setCustomMessage={setCustomMessage}
-                onFocusRow={() => setFocusedIndex(options.length)}
-                onSubmitWithFeedback={(message: string) => {
-                  // When user submits custom feedback, reject the current operation
-                  // and pass the feedback message to the AI
-                  const optionId = rejectOptionId || 'reject_once';
-                  onResponse(optionId, message);
-                  // Clear the custom message after submission
-                  setCustomMessage('');
-                }}
-                inputRef={customInputRef}
-              />
-            );
-          })()}
         </div>
       </div>
 
@@ -266,50 +235,3 @@ export const PermissionDrawer: React.FC<PermissionDrawerProps> = ({
     </div>
   );
 };
-
-/**
- * CustomMessageInputRow: Reusable custom input row component (without hooks)
- */
-interface CustomMessageInputRowProps {
-  isFocused: boolean;
-  customMessage: string;
-  setCustomMessage: (val: string) => void;
-  onFocusRow: () => void; // Set focus when mouse enters or input box is focused
-  onSubmitWithFeedback: (customMessage: string) => void; // Triggered when Enter is pressed with custom message
-  inputRef: React.RefObject<HTMLInputElement | null>;
-}
-
-const CustomMessageInputRow: React.FC<CustomMessageInputRowProps> = ({
-  isFocused,
-  customMessage,
-  setCustomMessage,
-  onFocusRow,
-  onSubmitWithFeedback,
-  inputRef,
-}) => (
-  <div
-    className={`flex items-center gap-2 px-2 py-1.5 text-left w-full box-border rounded-[4px] border-0 shadow-[inset_0_0_0_1px_var(--app-transparent-inner-border)] cursor-text text-[var(--app-primary-foreground)] ${
-      isFocused ? 'text-[var(--app-list-active-foreground)]' : ''
-    }`}
-    onMouseEnter={onFocusRow}
-    onClick={() => inputRef.current?.focus()}
-  >
-    <input
-      ref={inputRef as React.LegacyRef<HTMLInputElement> | undefined}
-      type="text"
-      placeholder="Tell Qwen what to do instead"
-      spellCheck={false}
-      className="flex-1 bg-transparent border-0 outline-none text-sm placeholder:opacity-70"
-      style={{ color: 'var(--app-input-foreground)' }}
-      value={customMessage}
-      onChange={(e) => setCustomMessage(e.target.value)}
-      onFocus={onFocusRow}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' && !e.shiftKey && customMessage.trim()) {
-          e.preventDefault();
-          onSubmitWithFeedback(customMessage.trim());
-        }
-      }}
-    />
-  </div>
-);

--- a/packages/vscode-ide-companion/src/webview/handlers/MessageRouter.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/MessageRouter.ts
@@ -7,6 +7,7 @@
 import type { IMessageHandler } from './BaseMessageHandler.js';
 import type { QwenAgentManager } from '../../services/qwenAgentManager.js';
 import type { ConversationStore } from '../../services/conversationStore.js';
+import type { PermissionResponseMessage } from '../../types/webviewMessageTypes.js';
 import { SessionMessageHandler } from './SessionMessageHandler.js';
 import { FileMessageHandler } from './FileMessageHandler.js';
 import { EditorMessageHandler } from './EditorMessageHandler.js';
@@ -22,10 +23,7 @@ export class MessageRouter {
   private authHandler: AuthMessageHandler;
   private currentConversationId: string | null = null;
   private permissionHandler:
-    | ((message: {
-        type: string;
-        data: { optionId: string; customMessage?: string };
-      }) => void)
+    | ((message: PermissionResponseMessage) => void)
     | null = null;
 
   constructor(
@@ -83,12 +81,7 @@ export class MessageRouter {
     // Handle permission response specially
     if (message.type === 'permissionResponse') {
       if (this.permissionHandler) {
-        this.permissionHandler(
-          message as {
-            type: string;
-            data: { optionId: string; customMessage?: string };
-          },
-        );
+        this.permissionHandler(message as PermissionResponseMessage);
       }
       return;
     }
@@ -137,10 +130,7 @@ export class MessageRouter {
    * Set permission handler
    */
   setPermissionHandler(
-    handler: (message: {
-      type: string;
-      data: { optionId: string; customMessage?: string };
-    }) => void,
+    handler: (message: PermissionResponseMessage) => void,
   ): void {
     this.permissionHandler = handler;
   }


### PR DESCRIPTION

## What would you like to be added?

Simplify the permission response handling mechanism in the VSCode IDE companion by removing the custom message functionality from the permission drawer to improve user experience. Additionally, address issues related to edit operations failing and VSCode diff display problems.

## Why is this needed?

The current implementation of the permission response system is overly complex with an unnecessary custom message feature. The PermissionDrawer component includes a custom message input field that allows users to provide feedback when rejecting operations, but this adds complexity and potential confusion for users. Additionally, there are issues with edit operations failing and VSCode diff display functionality that need to be addressed to improve the overall user experience.

## Additional context

Changes would involve:
- Removing the custom message input field from the `PermissionDrawer` component
- Simplifying the `handlePermissionResponse` function to no longer pass custom message parameters
- Updating related message type definitions for clarity
- Improving the handling of rejection operations to directly cancel instead of waiting for user feedback

Affected files:
- `packages/vscode-ide-companion/src/webview/components/PermissionDrawer/PermissionDrawer.tsx` - Permission drawer component
- `packages/vscode-ide-companion/src/webview/App.tsx` - Main application component
- `packages/vscode-ide-companion/src/webview/MessageHandler.ts` - Message handling
- `packages/vscode-ide-companion/src/webview/WebViewProvider.ts` - WebView provider
- `packages/vscode-ide-companion/src/webview/handlers/MessageRouter.ts` - Message router
- `packages/vscode-ide-companion/src/types/webviewMessageTypes.ts` - Message type definitions

Related to: Fixes #1524