### PR TITLE
fix: cli input stream handling and error management

### DIFF
--- a/integration-tests/sdk-typescript/tool-control.test.ts
+++ b/integration-tests/sdk-typescript/tool-control.test.ts
@@ -12,7 +12,12 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { query, isSDKAssistantMessage, type SDKMessage } from '@qwen-code/sdk';
+import {
+  query,
+  isSDKAssistantMessage,
+  type SDKMessage,
+  type SDKUserMessage,
+} from '@qwen-code/sdk';
 import {
   SDKTestHelper,
   extractText,
@@ -732,6 +737,231 @@ describe('Tool Control Parameters (E2E)', () => {
 
           // Should work normally
           expect(toolNames).toContain('read_file');
+        } finally {
+          await q.close();
+        }
+      },
+      TEST_TIMEOUT,
+    );
+  });
+
+  describe('canUseTool with asyncGenerator prompt', () => {
+    it(
+      'should invoke canUseTool callback when using asyncGenerator as prompt',
+      async () => {
+        await helper.createFile('test.txt', 'original content');
+
+        const canUseToolCalls: Array<{
+          toolName: string;
+          input: Record<string, unknown>;
+        }> = [];
+
+        // Create an async generator that yields a single message
+        async function* createPrompt(): AsyncIterable<SDKUserMessage> {
+          yield {
+            type: 'user',
+            session_id: crypto.randomUUID(),
+            message: {
+              role: 'user',
+              content: 'Read test.txt and then write "updated" to it.',
+            },
+            parent_tool_use_id: null,
+          };
+
+          await new Promise((resolve) => setTimeout(resolve, 3000));
+        }
+
+        const q = query({
+          prompt: createPrompt(),
+          options: {
+            ...SHARED_TEST_OPTIONS,
+            cwd: testDir,
+            permissionMode: 'default',
+            coreTools: ['read_file', 'write_file'],
+            allowedTools: [],
+            canUseTool: async (toolName, input) => {
+              canUseToolCalls.push({ toolName, input });
+              return {
+                behavior: 'allow',
+                updatedInput: input,
+              };
+            },
+            debug: false,
+          },
+        });
+
+        const messages: SDKMessage[] = [];
+
+        try {
+          for await (const message of q) {
+            messages.push(message);
+          }
+
+          const toolCalls = findToolCalls(messages);
+          const toolNames = toolCalls.map((tc) => tc.toolUse.name);
+
+          // Both tools should have been executed
+          expect(toolNames).toContain('read_file');
+          expect(toolNames).toContain('write_file');
+
+          const toolsCalledInCallback = canUseToolCalls.map(
+            (call) => call.toolName,
+          );
+          expect(toolsCalledInCallback).toContain('write_file');
+
+          const writeFileResults = findToolResults(messages, 'write_file');
+          expect(writeFileResults.length).toBeGreaterThan(0);
+
+          // Verify file was modified
+          const content = await helper.readFile('test.txt');
+          expect(content).toBe('updated');
+        } finally {
+          await q.close();
+        }
+      },
+      TEST_TIMEOUT,
+    );
+
+    it(
+      'should deny tool when canUseTool returns deny with asyncGenerator prompt',
+      async () => {
+        await helper.createFile('test.txt', 'original content');
+
+        // Create an async generator that yields a single message
+        async function* createPrompt(): AsyncIterable<SDKUserMessage> {
+          yield {
+            type: 'user',
+            session_id: crypto.randomUUID(),
+            message: {
+              role: 'user',
+              content: 'Write "modified" to test.txt.',
+            },
+            parent_tool_use_id: null,
+          };
+          await new Promise((resolve) => setTimeout(resolve, 3000));
+        }
+
+        const q = query({
+          prompt: createPrompt(),
+          options: {
+            ...SHARED_TEST_OPTIONS,
+            cwd: testDir,
+            permissionMode: 'default',
+            coreTools: ['read_file', 'write_file'],
+            canUseTool: async (toolName) => {
+              if (toolName === 'write_file') {
+                return {
+                  behavior: 'deny',
+                  message: 'Write operations are not allowed',
+                };
+              }
+              return { behavior: 'allow', updatedInput: {} };
+            },
+            debug: false,
+          },
+        });
+
+        const messages: SDKMessage[] = [];
+
+        try {
+          for await (const message of q) {
+            messages.push(message);
+          }
+
+          // write_file should have been attempted but stream was closed
+          const writeFileResults = findToolResults(messages, 'write_file');
+          expect(writeFileResults.length).toBeGreaterThan(0);
+          for (const result of writeFileResults) {
+            expect(result.content).toContain(
+              '[Operation Cancelled] Reason: Write operations are not allowed',
+            );
+          }
+
+          // File content should remain unchanged (because write was denied)
+          const content = await helper.readFile('test.txt');
+          expect(content).toBe('original content');
+        } finally {
+          await q.close();
+        }
+      },
+      TEST_TIMEOUT,
+    );
+
+    it(
+      'should support multi-turn conversation with canUseTool using asyncGenerator',
+      async () => {
+        await helper.createFile('data.txt', 'initial data');
+
+        const canUseToolCalls: string[] = [];
+
+        // Create an async generator that yields multiple messages
+        async function* createMultiTurnPrompt(): AsyncIterable<SDKUserMessage> {
+          const sessionId = crypto.randomUUID();
+
+          yield {
+            type: 'user',
+            session_id: sessionId,
+            message: {
+              role: 'user',
+              content: 'Read data.txt and tell me what it contains.',
+            },
+            parent_tool_use_id: null,
+          };
+
+          // Small delay to simulate multi-turn conversation
+          await new Promise((resolve) => setTimeout(resolve, 100));
+
+          yield {
+            type: 'user',
+            session_id: sessionId,
+            message: {
+              role: 'user',
+              content: 'Now append " - updated" to the file content.',
+            },
+            parent_tool_use_id: null,
+          };
+        }
+
+        const q = query({
+          prompt: createMultiTurnPrompt(),
+          options: {
+            ...SHARED_TEST_OPTIONS,
+            cwd: testDir,
+            permissionMode: 'default',
+            coreTools: ['read_file', 'write_file'],
+            canUseTool: async (toolName) => {
+              canUseToolCalls.push(toolName);
+              return { behavior: 'allow', updatedInput: {} };
+            },
+            debug: false,
+          },
+        });
+
+        const messages: SDKMessage[] = [];
+
+        try {
+          for await (const message of q) {
+            messages.push(message);
+          }
+
+          const toolCalls = findToolCalls(messages);
+          const toolNames = toolCalls.map((tc) => tc.toolUse.name);
+
+          // Should have read_file and write_file calls
+          expect(toolNames).toContain('read_file');
+          expect(toolNames).toContain('write_file');
+
+          // canUseTool should not be called once stream is closed
+          expect(canUseToolCalls).toHaveLength(0);
+
+          const writeFileResults = findToolResults(messages, 'write_file');
+          expect(writeFileResults.length).toBeGreaterThan(0);
+          for (const result of writeFileResults) {
+            expect(result.content).toContain('Error: Input closed');
+          }
+
+          const content = await helper.readFile('data.txt');
+          expect(content).toBe('initial data');
         } finally {
           await q.close();
         }

--- a/packages/cli/src/nonInteractive/control/ControlContext.ts
+++ b/packages/cli/src/nonInteractive/control/ControlContext.ts
@@ -35,6 +35,7 @@ export interface IControlContext {
   permissionMode: PermissionMode;
   sdkMcpServers: Set<string>;
   mcpClients: Map<string, { client: Client; config: MCPServerConfig }>;
+  inputClosed: boolean;
 
   onInterrupt?: () => void;
 }
@@ -52,6 +53,7 @@ export class ControlContext implements IControlContext {
   permissionMode: PermissionMode;
   sdkMcpServers: Set<string>;
   mcpClients: Map<string, { client: Client; config: MCPServerConfig }>;
+  inputClosed: boolean;
 
   onInterrupt?: () => void;
 
@@ -71,6 +73,7 @@ export class ControlContext implements IControlContext {
     this.permissionMode = options.permissionMode || 'default';
     this.sdkMcpServers = new Set();
     this.mcpClients = new Map();
+    this.inputClosed = false;
     this.onInterrupt = options.onInterrupt;
   }
 }

--- a/packages/cli/src/nonInteractive/control/controllers/baseController.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/baseController.ts
@@ -124,6 +124,11 @@ export abstract class BaseController {
     timeoutMs: number = DEFAULT_REQUEST_TIMEOUT_MS,
     signal?: AbortSignal,
   ): Promise<ControlResponse> {
+    // Check if stream is closed
+    if (this.context.inputClosed) {
+      throw new Error('Input closed');
+    }
+
     // Check if already aborted
     if (signal?.aborted) {
       throw new Error('Request aborted');

--- a/packages/cli/src/nonInteractive/control/controllers/permissionController.ts
+++ b/packages/cli/src/nonInteractive/control/controllers/permissionController.ts
@@ -469,21 +469,27 @@ export class PermissionController extends BaseController {
           error,
         );
       }
-      // On error, use default cancel message
+
+      // Extract error message
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
+      // On error, pass error message as cancel message
       // Only pass payload for exec and mcp types that support it
       const confirmationType = toolCall.confirmationDetails.type;
       if (['edit', 'exec', 'mcp'].includes(confirmationType)) {
         const execOrMcpDetails = toolCall.confirmationDetails as
           | ToolExecuteConfirmationDetails
           | ToolMcpConfirmationDetails;
-        await execOrMcpDetails.onConfirm(
-          ToolConfirmationOutcome.Cancel,
-          undefined,
-        );
+        await execOrMcpDetails.onConfirm(ToolConfirmationOutcome.Cancel, {
+          cancelMessage: `Error: ${errorMessage}`,
+        });
       } else {
-        // For other types, don't pass payload (backward compatible)
         await toolCall.confirmationDetails.onConfirm(
           ToolConfirmationOutcome.Cancel,
+          {
+            cancelMessage: `Error: ${errorMessage}`,
+          },
         );
       }
     } finally {

--- a/packages/cli/src/nonInteractive/session.test.ts
+++ b/packages/cli/src/nonInteractive/session.test.ts
@@ -153,6 +153,7 @@ describe('runNonInteractiveStreamJson', () => {
     handleControlResponse: ReturnType<typeof vi.fn>;
     handleCancel: ReturnType<typeof vi.fn>;
     shutdown: ReturnType<typeof vi.fn>;
+    markInputClosed: ReturnType<typeof vi.fn>;
     getPendingIncomingRequestCount: ReturnType<typeof vi.fn>;
     waitForPendingIncomingRequests: ReturnType<typeof vi.fn>;
     sdkMcpController: {
@@ -192,6 +193,7 @@ describe('runNonInteractiveStreamJson', () => {
       handleControlResponse: vi.fn(),
       handleCancel: vi.fn(),
       shutdown: vi.fn(),
+      markInputClosed: vi.fn(),
       getPendingIncomingRequestCount: vi.fn().mockReturnValue(0),
       waitForPendingIncomingRequests: vi.fn().mockResolvedValue(undefined),
       sdkMcpController: {

--- a/packages/cli/src/nonInteractive/session.ts
+++ b/packages/cli/src/nonInteractive/session.ts
@@ -596,7 +596,14 @@ class Session {
         throw streamError;
       }
 
-      // Stream ended - wait for all pending work before shutdown
+      // Stdin closed - mark input as closed in dispatcher
+      // This will reject all current pending outgoing requests AND any future requests
+      // that might be registered by async message handlers still running
+      if (this.dispatcher) {
+        this.dispatcher.markInputClosed();
+      }
+
+      // Wait for all pending work before shutdown
       await this.waitForAllPendingWork();
       await this.shutdown();
     } catch (error) {

--- a/packages/sdk-typescript/test/unit/ProcessTransport.test.ts
+++ b/packages/sdk-typescript/test/unit/ProcessTransport.test.ts
@@ -647,7 +647,7 @@ describe('ProcessTransport', () => {
       );
     });
 
-    it('should throw if writing to ended stream', () => {
+    it('should not throw when writing to ended stream (soft-fail)', () => {
       mockPrepareSpawnInfo.mockReturnValue({
         command: 'qwen',
         args: [],
@@ -664,9 +664,8 @@ describe('ProcessTransport', () => {
 
       mockStdin.end();
 
-      expect(() => transport.write('test')).toThrow(
-        'Cannot write to ended stream',
-      );
+      // Should not throw - soft-fail behavior
+      expect(() => transport.write('test')).not.toThrow();
     });
 
     it('should throw if writing to terminated process', () => {


### PR DESCRIPTION
## TLDR

Make async-generator prompts safe when stdin closes by rejecting control requests early and soft-failing SDK writes.

## Dive Deeper

### Problem (before)

Two issues when stdin closed after the last async-generator prompt: the CLI could wait forever for control responses, and the SDK could throw `Cannot write to ended stream`, causing abnormal termination.

```mermaid
sequenceDiagram
  participant SDK
  participant CLI
  participant Ctrl as ControlDispatcher
  SDK->>CLI: streamInput completes
  CLI-->>SDK: stdin closed
  CLI->>Ctrl: emit control_request (e.g., canUseTool)
  Ctrl-->>Ctrl: register outgoing request
  Ctrl-->>Ctrl: wait for response (may hang)
```

### Fix (after)

CLI marks input closed when stdin ends, rejects pending/new outgoing control requests immediately, and propagates a clear cancel reason. SDK transport soft-fails on closed stdin writes and reports control-request send failures.

```mermaid
sequenceDiagram
  participant SDK
  participant CLI
  participant Ctrl as ControlDispatcher
  SDK->>CLI: streamInput completes
  CLI->>Ctrl: markInputClosed()
  Ctrl-->>Ctrl: reject pending outgoing requests
  CLI->>Ctrl: emit control_request (late)
  Ctrl-->>CLI: error "Input closed"
  CLI-->>SDK: tool result contains cancel reason
```

## Reviewer Test Plan

- Run `integration-tests/sdk-typescript/abort-and-lifecycle.test.ts` and `integration-tests/sdk-typescript/tool-control.test.ts`.
- Or construct your own tests:
  - use AsyncGenerator as `prompt`
  - the last message prompts a complicated task which may keep `query` generating for a while
  - use `canUseTool` or other SDK's API such as `setModel` or `setPermission` mode after yielding the last message
  - check if `query` ends with no unhandled error
  - check if the result contains `Input closed` errors that prevent the LLM from attempting tool calls
- Check tool-call results contain explicit error text when CLI stdin is closed (for example `Error: Input closed`).

## Testing Matrix

|          | 🍏   | 🪟   | 🐧   |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓   | ❓   |
| npx      | ❓   | ❓   | ❓   |
| Docker   | ❓   | ❓   | ❓   |
| Podman   | ❓   | -   | -   |
| Seatbelt | ❓   | -   | -   |

## Linked issues / bugs

None.
