### PR TITLE
Add parentToolCallId and subagentType for ACP subagent tracking

### DIFF
--- a/packages/cli/src/acp-integration/schema.ts
+++ b/packages/cli/src/acp-integration/schema.ts
@@ -367,6 +367,8 @@ export const sessionUpdateMetaSchema = z.object({
   usage: usageSchema.optional().nullable(),
   durationMs: z.number().optional().nullable(),
   toolName: z.string().optional().nullable(),
+  parentToolCallId: z.string().optional().nullable(),
+  subagentType: z.string().optional().nullable(),
 });
 
 export type SessionUpdateMeta = z.infer<typeof sessionUpdateMetaSchema>;

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -474,8 +474,17 @@ export class Session implements SessionContext {
           }
         ).eventEmitter;
 
+        // Extract subagent metadata from TaskTool call
+        const parentToolCallId = callId;
+        const subagentType = (args['subagent_type'] as string) ?? '';
+
         // Create a SubAgentTracker for this tool execution
-        const subAgentTracker = new SubAgentTracker(this, this.client);
+        const subAgentTracker = new SubAgentTracker(
+          this,
+          this.client,
+          parentToolCallId,
+          subagentType,
+        );
 
         // Set up sub-agent tool tracking
         subAgentCleanupFunctions = subAgentTracker.setup(

--- a/packages/cli/src/acp-integration/session/SubAgentTracker.test.ts
+++ b/packages/cli/src/acp-integration/session/SubAgentTracker.test.ts
@@ -132,7 +132,12 @@ describe('SubAgentTracker', () => {
       requestPermission: requestPermissionSpy,
     } as unknown as acp.Client;
 
-    tracker = new SubAgentTracker(mockContext, mockClient);
+    tracker = new SubAgentTracker(
+      mockContext,
+      mockClient,
+      'parent-call-123',
+      'test-subagent',
+    );
     eventEmitter = new EventEmitter() as unknown as SubAgentEventEmitter;
     abortController = new AbortController();
   });
@@ -214,6 +219,11 @@ describe('SubAgentTracker', () => {
           locations: [],
           kind: 'other',
           rawInput: { path: '/test.ts' },
+          _meta: expect.objectContaining({
+            toolName: 'read_file',
+            parentToolCallId: 'parent-call-123',
+            subagentType: 'test-subagent',
+          }),
         }),
       );
     });
@@ -283,6 +293,11 @@ describe('SubAgentTracker', () => {
             sessionUpdate: 'tool_call_update',
             toolCallId: 'call-123',
             status: 'completed',
+            _meta: expect.objectContaining({
+              toolName: 'read_file',
+              parentToolCallId: 'parent-call-123',
+              subagentType: 'test-subagent',
+            }),
           }),
         );
       });
@@ -305,6 +320,11 @@ describe('SubAgentTracker', () => {
           expect.objectContaining({
             sessionUpdate: 'tool_call_update',
             status: 'failed',
+            _meta: expect.objectContaining({
+              toolName: 'read_file',
+              parentToolCallId: 'parent-call-123',
+              subagentType: 'test-subagent',
+            }),
           }),
         );
       });

--- a/packages/cli/src/acp-integration/session/emitters/MessageEmitter.ts
+++ b/packages/cli/src/acp-integration/session/emitters/MessageEmitter.ts
@@ -53,6 +53,7 @@ export class MessageEmitter extends BaseEmitter {
     usageMetadata: GenerateContentResponseUsageMetadata,
     text: string = '',
     durationMs?: number,
+    subagentMeta?: import('../types.js').SubagentMeta,
   ): Promise<void> {
     const usage: Usage = {
       promptTokens: usageMetadata.promptTokenCount,
@@ -63,7 +64,9 @@ export class MessageEmitter extends BaseEmitter {
     };
 
     const meta =
-      typeof durationMs === 'number' ? { usage, durationMs } : { usage };
+      typeof durationMs === 'number'
+        ? { usage, durationMs, ...subagentMeta }
+        : { usage, ...subagentMeta };
 
     await this.sendUpdate({
       sessionUpdate: 'agent_message_chunk',

--- a/packages/cli/src/acp-integration/session/emitters/ToolCallEmitter.ts
+++ b/packages/cli/src/acp-integration/session/emitters/ToolCallEmitter.ts
@@ -11,6 +11,7 @@ import type {
   ToolCallStartParams,
   ToolCallResultParams,
   ResolvedToolMetadata,
+  SubagentMeta,
 } from '../types.js';
 import type * as acp from '../../acp.js';
 import type { Part } from '@google/genai';
@@ -65,7 +66,10 @@ export class ToolCallEmitter extends BaseEmitter {
       locations,
       kind,
       rawInput: params.args ?? {},
-      _meta: { toolName: params.toolName },
+      _meta: {
+        toolName: params.toolName,
+        ...params.subagentMeta,
+      },
     });
 
     return true;
@@ -121,7 +125,10 @@ export class ToolCallEmitter extends BaseEmitter {
       toolCallId: params.callId,
       status: params.success ? 'completed' : 'failed',
       content: contentArray,
-      _meta: { toolName: params.toolName },
+      _meta: {
+        toolName: params.toolName,
+        ...params.subagentMeta,
+      },
     };
 
     // Add rawOutput from resultDisplay
@@ -137,12 +144,15 @@ export class ToolCallEmitter extends BaseEmitter {
    * Use this for explicit error handling when not using emitResult.
    *
    * @param callId - The tool call ID
+   * @param toolName - The tool name
    * @param error - The error that occurred
+   * @param subagentMeta - Optional subagent metadata
    */
   async emitError(
     callId: string,
     toolName: string,
     error: Error,
+    subagentMeta?: SubagentMeta,
   ): Promise<void> {
     await this.sendUpdate({
       sessionUpdate: 'tool_call_update',
@@ -151,7 +161,10 @@ export class ToolCallEmitter extends BaseEmitter {
       content: [
         { type: 'content', content: { type: 'text', text: error.message } },
       ],
-      _meta: { toolName },
+      _meta: {
+        toolName,
+        ...subagentMeta,
+      },
     });
   }
 

--- a/packages/cli/src/acp-integration/session/types.ts
+++ b/packages/cli/src/acp-integration/session/types.ts
@@ -26,6 +26,16 @@ export interface SessionContext extends SessionUpdateSender {
 }
 
 /**
+ * Subagent metadata for tracking parent tool call context.
+ */
+export interface SubagentMeta {
+  /** ID of the parent TaskTool call that created this subagent */
+  parentToolCallId?: string;
+  /** Type of subagent (from TaskParams.subagent_type) */
+  subagentType?: string;
+}
+
+/**
  * Parameters for emitting a tool call start event.
  */
 export interface ToolCallStartParams {
@@ -37,6 +47,8 @@ export interface ToolCallStartParams {
   args?: Record<string, unknown>;
   /** Status of the tool call */
   status?: 'pending' | 'in_progress' | 'completed' | 'failed';
+  /** Optional subagent metadata */
+  subagentMeta?: SubagentMeta;
 }
 
 /**
@@ -57,6 +69,8 @@ export interface ToolCallResultParams {
   error?: Error;
   /** Original args (fallback for TodoWriteTool todos extraction) */
   args?: Record<string, unknown>;
+  /** Optional subagent metadata */
+  subagentMeta?: SubagentMeta;
 }
 
 /**


### PR DESCRIPTION
## TLDR

Add subagent tracking capabilities by introducing parentToolCallId and subagentType metadata to track sub-agent activities in ACP sessions. This enhancement allows better monitoring and debugging of sub-agent executions initiated by TaskTool calls.

## Dive Deeper

The changes introduce subagent metadata tracking to improve observability of sub-agent operations within the ACP integration. Key modifications include:

1. Schema updates: Added `parentToolCallId` and `subagentType` fields to the `sessionUpdateMetaSchema` to store contextual information about sub-agents.

2. SubAgentTracker enhancements: Modified the `SubAgentTracker` class to accept and store parent tool call ID and subagent type, allowing it to propagate this metadata to all related events.

3. Emitter updates: Updated `ToolCallEmitter` and `MessageEmitter` to include subagent metadata in emitted events, ensuring the information flows through the entire event pipeline.

4. Type definitions: Added `SubagentMeta` interface and integrated it into relevant function signatures to properly type the new metadata.

5. Test updates: Modified tests to reflect the new constructor parameters and verify that subagent metadata is correctly included in emitted events.

The changes enable better traceability of sub-agent activities by linking them back to their originating TaskTool calls, which is crucial for debugging and monitoring complex agent interactions.

## Reviewer Test Plan

1. Pull the branch and run the tests to ensure all changes work correctly:
   ```bash
   npm test
   ```

2. Specifically run the SubAgentTracker tests to verify the new functionality:
   ```bash
   npm test -- packages/cli/src/acp-integration/session/SubAgentTracker.test.ts
   ```

3. Verify that the new metadata fields (`parentToolCallId` and `subagentType`) appear in session update events when sub-agents are executed.

4. Check that the schema changes properly validate the new optional fields.

5. Test an end-to-end scenario where a TaskTool creates a sub-agent and verify that the metadata is correctly propagated through the event system.

## Testing Matrix

|          | 🍏   | 🪟   | 🐧   |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓   | ❓   |
| npx      | ✅   | ❓   | ❓   |
| Docker   | ❓   | ❓   | ❓   |
| Podman   | ❓   | -   | -   |
| Seatbelt | ❓   | -   | -   |

## Linked issues / bugs

Related to #1594.
