### PR TITLE
feat(core): improve error message when skill is invoked as tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3878,6 +3878,7 @@
       "version": "2.4.9",
       "resolved": "https://registry.npmjs.org/@types/prompts/-/prompts-2.4.9.tgz",
       "integrity": "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -17329,7 +17330,6 @@
         "@iarna/toml": "^2.2.5",
         "@modelcontextprotocol/sdk": "^1.25.1",
         "@qwen-code/qwen-code-core": "file:../core",
-        "@types/prompts": "^2.4.9",
         "@types/update-notifier": "^6.0.8",
         "ansi-regex": "^6.2.2",
         "command-exists": "^1.2.9",
@@ -17373,6 +17373,7 @@
         "@types/diff": "^7.0.2",
         "@types/dotenv": "^6.1.1",
         "@types/node": "^20.11.24",
+        "@types/prompts": "^2.4.9",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
         "@types/semver": "^7.7.0",


### PR DESCRIPTION
## TLDR

When models incorrectly invoke a skill name directly as a tool (e.g., `Tool: pdf` instead of `Tool: Skill` with `skill: "pdf"`), provide a clear, skill-specific error message explaining the correct usage.

**Before:** `Tool "pdf" not found in registry. Tools must use the exact names that are registered. Did you mean one of: "skill", "Task", "Read"?`

**After:** `"pdf" is a skill name, not a tool name. To use this skill, invoke the "skill" tool with parameter: skill: "pdf"`

## Dive Deeper

- Added `getToolNotFoundMessage()` method that returns early with skill-specific feedback when the unknown tool name matches an available skill
- Falls back to standard Levenshtein-based suggestions for non-skill tool names
- Only active when `experimentalSkills` is enabled (SkillTool must be registered)
- Added unit tests for skill name detection

## Reviewer Test Plan

1. Enable experimental skills: `experimentalSkills: true` in settings
2. Create a skill (e.g., add a `pdf` skill in `.qwen/skills/`)
3. Prompt the model in a way that might cause it to invoke `Tool: pdf` directly
4. Verify the error message guides toward proper `Skill` tool usage

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Related to skill tool invocation feedback improvements -->