### PR TITLE
feat: add skills and agents display to extension list with i18n support

### DIFF
--- a/packages/cli/src/commands/extensions/utils.ts
+++ b/packages/cli/src/commands/extensions/utils.ts
@@ -14,6 +14,7 @@ import {
 import { isWorkspaceTrusted } from '../../config/trustedFolders.js';
 import * as os from 'node:os';
 import chalk from 'chalk';
+import { t } from '../../i18n/index.js';
 
 export async function getExtensionManager(): Promise<ExtensionManager> {
   const workspaceDir = process.cwd();
@@ -48,32 +49,44 @@ export function extensionToOutputString(
 
   const status = workspaceEnabled ? chalk.green('✓') : chalk.red('✗');
   let output = `${inline ? '' : status} ${extension.config.name} (${extension.config.version})`;
-  output += `\n Path: ${extension.path}`;
+  output += `\n ${t('Path:')} ${extension.path}`;
   if (extension.installMetadata) {
-    output += `\n Source: ${extension.installMetadata.source} (Type: ${extension.installMetadata.type})`;
+    output += `\n ${t('Source:')} ${extension.installMetadata.source} (${t('Type:')} ${extension.installMetadata.type})`;
     if (extension.installMetadata.ref) {
-      output += `\n Ref: ${extension.installMetadata.ref}`;
+      output += `\n ${t('Ref:')} ${extension.installMetadata.ref}`;
     }
     if (extension.installMetadata.releaseTag) {
-      output += `\n Release tag: ${extension.installMetadata.releaseTag}`;
+      output += `\n ${t('Release tag:')} ${extension.installMetadata.releaseTag}`;
     }
   }
-  output += `\n Enabled (User): ${userEnabled}`;
-  output += `\n Enabled (Workspace): ${workspaceEnabled}`;
+  output += `\n ${t('Enabled (User):')} ${userEnabled}`;
+  output += `\n ${t('Enabled (Workspace):')} ${workspaceEnabled}`;
   if (extension.contextFiles.length > 0) {
-    output += `\n Context files:`;
+    output += `\n ${t('Context files:')}`;
     extension.contextFiles.forEach((contextFile) => {
       output += `\n  ${contextFile}`;
     });
   }
   if (extension.commands && extension.commands.length > 0) {
-    output += `\n Commands:`;
+    output += `\n ${t('Commands:')}`;
     extension.commands.forEach((command) => {
       output += `\n  /${command}`;
     });
   }
+  if (extension.skills && extension.skills.length > 0) {
+    output += `\n ${t('Skills:')}`;
+    extension.skills.forEach((skill) => {
+      output += `\n  ${skill.name}`;
+    });
+  }
+  if (extension.agents && extension.agents.length > 0) {
+    output += `\n ${t('Agents:')}`;
+    extension.agents.forEach((agent) => {
+      output += `\n  ${agent.name}`;
+    });
+  }
   if (extension.config.mcpServers) {
-    output += `\n MCP servers:`;
+    output += `\n ${t('MCP servers:')}`;
     Object.keys(extension.config.mcpServers).forEach((key) => {
       output += `\n  ${key}`;
     });

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -480,6 +480,17 @@ export default {
   'Either an extension name or --all must be provided':
     'Entweder ein Erweiterungsname oder --all muss angegeben werden',
   'Lists installed extensions.': 'Listet installierte Erweiterungen auf.',
+  'Path:': 'Pfad:',
+  'Source:': 'Quelle:',
+  'Type:': 'Typ:',
+  'Ref:': 'Ref:',
+  'Release tag:': 'Release-Tag:',
+  'Enabled (User):': 'Aktiviert (Benutzer):',
+  'Enabled (Workspace):': 'Aktiviert (Arbeitsbereich):',
+  'Context files:': 'Kontextdateien:',
+  'Skills:': 'Skills:',
+  'Agents:': 'Agents:',
+  'MCP servers:': 'MCP-Server:',
   'Link extension failed to install.':
     'Verknüpfte Erweiterung konnte nicht installiert werden.',
   'Extension "{{name}}" linked successfully and enabled.':

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -492,6 +492,17 @@ export default {
   'Either an extension name or --all must be provided':
     'Either an extension name or --all must be provided',
   'Lists installed extensions.': 'Lists installed extensions.',
+  'Path:': 'Path:',
+  'Source:': 'Source:',
+  'Type:': 'Type:',
+  'Ref:': 'Ref:',
+  'Release tag:': 'Release tag:',
+  'Enabled (User):': 'Enabled (User):',
+  'Enabled (Workspace):': 'Enabled (Workspace):',
+  'Context files:': 'Context files:',
+  'Skills:': 'Skills:',
+  'Agents:': 'Agents:',
+  'MCP servers:': 'MCP servers:',
   'Link extension failed to install.': 'Link extension failed to install.',
   'Extension "{{name}}" linked successfully and enabled.':
     'Extension "{{name}}" linked successfully and enabled.',

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -496,6 +496,17 @@ export default {
   'Either an extension name or --all must be provided':
     'Необходимо указать имя расширения или --all',
   'Lists installed extensions.': 'Показывает установленные расширения.',
+  'Path:': 'Путь:',
+  'Source:': 'Источник:',
+  'Type:': 'Тип:',
+  'Ref:': 'Ссылка:',
+  'Release tag:': 'Тег релиза:',
+  'Enabled (User):': 'Включено (Пользователь):',
+  'Enabled (Workspace):': 'Включено (Рабочее пространство):',
+  'Context files:': 'Контекстные файлы:',
+  'Skills:': 'Навыки:',
+  'Agents:': 'Агенты:',
+  'MCP servers:': 'MCP-серверы:',
   'Link extension failed to install.':
     'Не удалось установить связанное расширение.',
   'Extension "{{name}}" linked successfully and enabled.':

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -469,6 +469,17 @@ export default {
   'Either an extension name or --all must be provided':
     '必须提供扩展名称或 --all',
   'Lists installed extensions.': '列出已安装的扩展。',
+  'Path:': '路径：',
+  'Source:': '来源：',
+  'Type:': '类型：',
+  'Ref:': '引用：',
+  'Release tag:': '发布标签：',
+  'Enabled (User):': '已启用（用户）：',
+  'Enabled (Workspace):': '已启用（工作区）：',
+  'Context files:': '上下文文件：',
+  'Skills:': '技能：',
+  'Agents:': '代理：',
+  'MCP servers:': 'MCP 服务器：',
   'Link extension failed to install.': '链接扩展安装失败。',
   'Extension "{{name}}" linked successfully and enabled.':
     '扩展 "{{name}}" 链接成功并已启用。',


### PR DESCRIPTION
## TLDR

This PR adds support for displaying skills and agents in the extension list command and implements full internationalization (i18n) for all extension information labels.

## Dive Deeper

### Changes Made:
1. **Extended Extension Display**: Modified `extensionToOutputString()` to show skills and agents sections when available
2. **Internationalization**: Replaced all hardcoded labels with `t()` function calls to support multiple languages
3. **Multi-language Support**: Added translations for 4 languages:
   - English (en)
   - Chinese (zh) - 简体中文
   - German (de) - Deutsch
   - Russian (ru) - Русский

### Technical Details:
- Added checks for `extension.skills` and `extension.agents` arrays
- Each skill and agent is displayed by name
- All labels now use the i18n system: Path, Source, Type, Ref, Release tag, Enabled (User/Workspace), Context files, Commands, Skills, Agents, MCP servers

## Reviewer Test Plan

1. **Install an extension with skills and agents**:
   ```bash
   # Install an extension that includes skills/agents
   qwen-code extensions install <extension-with-skills-agents>
   ```

2. **List extensions**:
   ```bash
   qwen-code extensions list
   ```

3. **Verify the output shows**:
   - ✅ Skills section (if extension has skills)
   - ✅ Agents section (if extension has agents)
   - ✅ All labels are properly translated

4. **Test i18n**:
   ```bash
   # Test in Chinese
   QWEN_CODE_LANG=zh qwen-code extensions list
   
   # Test in English
   QWEN_CODE_LANG=en qwen-code extensions list
   ```

5. **Verify existing functionality**:
   - Commands still display correctly
   - MCP servers still display correctly
   - Context files still display correctly

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

This PR addresses the missing display of skills and agents in the extension list output and improves the user experience with proper internationalization support.