### PR TITLE
fix: ensure output-language.md is created before config initialization

### DIFF
--- a/packages/cli/src/core/initializer.ts
+++ b/packages/cli/src/core/initializer.ts
@@ -15,7 +15,6 @@ import { type LoadedSettings, SettingScope } from '../config/settings.js';
 import { performInitialAuth } from './auth.js';
 import { validateTheme } from './theme.js';
 import { initializeI18n, type SupportedLanguage } from '../i18n/index.js';
-import { initializeLlmOutputLanguage } from '../utils/languageUtils.js';
 
 export interface InitializationResult {
   authError: string | null;
@@ -41,9 +40,6 @@ export async function initializeApp(
     (settings.merged.general?.language as string) ||
     'auto';
   await initializeI18n(languageSetting as SupportedLanguage | 'auto');
-
-  // Auto-detect and set LLM output language on first use
-  initializeLlmOutputLanguage(settings.merged.general?.outputLanguage);
 
   // Use authType from modelsConfig which respects CLI --auth-type argument
   // over settings.security.auth.selectedType

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -53,6 +53,7 @@ import { getCliVersion } from './utils/version.js';
 import { computeWindowTitle } from './utils/windowTitle.js';
 import { validateNonInteractiveAuth } from './validateNonInterActiveAuth.js';
 import { showResumeSessionPicker } from './ui/components/StandaloneSessionPicker.js';
+import { initializeLlmOutputLanguage } from './utils/languageUtils.js';
 
 export function validateDnsResolutionOrder(
   order: string | undefined,
@@ -327,6 +328,10 @@ export async function main() {
   // We are now past the logic handling potentially launching a child process
   // to run Gemini CLI. It is now safe to perform expensive initialization that
   // may have side effects.
+
+  // Initialize output language file before config loads to ensure it's included in context
+  initializeLlmOutputLanguage(settings.merged.general?.outputLanguage);
+
   {
     const config = await loadCliConfig(
       settings.merged,


### PR DESCRIPTION
## TLDR

Fix a timing issue where `output-language.md` was created after config initialization, causing the LLM output language instruction to not be included in the context on first run.

## Dive Deeper

The output language file (`~/.qwen/output-language.md`) instructs the LLM to respond in the user's preferred language. This file is automatically created on first startup based on system locale detection.

However, there was a race condition in the initialization sequence:
1. `loadCliConfig()` checked for the file's existence → file not found → `outputLanguageFilePath` set to `undefined`
2. `initializeApp()` then created the file via `initializeLlmOutputLanguage()`
3. The config already had `outputLanguageFilePath = undefined`, so the language instruction was never added to the LLM context

This fix moves `initializeLlmOutputLanguage()` to execute **before** `loadCliConfig()`, ensuring the file exists when the config checks for it.

### Changes
- `packages/cli/src/gemini.tsx`: Added `initializeLlmOutputLanguage()` call before `loadCliConfig()`
- `packages/cli/src/core/initializer.ts`: Removed the duplicate call (no longer needed here)

## Reviewer Test Plan

1. **Clean environment test:**
   - Delete `~/.qwen/output-language.md` if it exists
   - Run the CLI with a non-English locale (e.g., `QWEN_CODE_LANG=zh`)
   - Verify the file is created with the correct language
   - Verify the LLM responds in the expected language

2. **Regression test:**
   - Verify existing functionality still works when the file already exists
   - Test with `/language output <lang>` command to change language

3. **Code review:**
   - Confirm the initialization order is now correct
   - Verify no duplicate calls remain

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Tested on macOS with:
- `npm run build` ✓
- `npx vitest run src/utils/languageUtils.test.ts` (38 tests passed) ✓

---

*No linked issues*

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)