### PR TITLE
Fix Claude plugin resource collection to respect marketplace config

### DIFF
--- a/packages/core/src/extension/claude-converter.test.ts
+++ b/packages/core/src/extension/claude-converter.test.ts
@@ -4,13 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import {
   convertClaudeToQwenConfig,
   mergeClaudeConfigs,
   isClaudePluginConfig,
+  convertClaudePluginPackage,
   type ClaudePluginConfig,
   type ClaudeMarketplacePluginConfig,
+  type ClaudeMarketplaceConfig,
 } from './claude-converter.js';
 
 describe('convertClaudeToQwenConfig', () => {
@@ -117,5 +122,230 @@ describe('isClaudePluginConfig', () => {
     expect(typeof isClaudePluginConfig(extensionDir, marketplace)).toBe(
       'boolean',
     );
+  });
+});
+
+describe('convertClaudePluginPackage', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    // Create a temporary directory for test files
+    testDir = fs.mkdtempSync(path.join(os.tmpdir(), 'claude-test-'));
+  });
+
+  afterEach(() => {
+    // Clean up test directory
+    if (fs.existsSync(testDir)) {
+      fs.rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should only collect specified skills when config provides explicit list', async () => {
+    // Setup: Create a plugin source with multiple skills
+    const pluginSourceDir = path.join(testDir, 'plugin-source');
+    fs.mkdirSync(pluginSourceDir, { recursive: true });
+
+    // Create skills directory with 6 skills
+    const skillsDir = path.join(pluginSourceDir, 'skills');
+    fs.mkdirSync(skillsDir, { recursive: true });
+
+    const allSkills = ['xlsx', 'docx', 'pptx', 'pdf', 'csv', 'txt'];
+    for (const skill of allSkills) {
+      const skillDir = path.join(skillsDir, skill);
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(skillDir, 'SKILL.md'),
+        `# ${skill} skill`,
+        'utf-8',
+      );
+      fs.writeFileSync(
+        path.join(skillDir, 'index.js'),
+        `module.exports = {};`,
+        'utf-8',
+      );
+    }
+
+    // Create marketplace.json that only specifies 4 skills
+    const marketplaceDir = path.join(pluginSourceDir, '.claude-plugin');
+    fs.mkdirSync(marketplaceDir, { recursive: true });
+
+    const marketplaceConfig: ClaudeMarketplaceConfig = {
+      name: 'test-marketplace',
+      owner: { name: 'Test Owner', email: 'test@example.com' },
+      plugins: [
+        {
+          name: 'document-skills',
+          version: '1.0.0',
+          description: 'Test document skills',
+          source: './',
+          strict: false,
+          skills: [
+            './skills/xlsx',
+            './skills/docx',
+            './skills/pptx',
+            './skills/pdf',
+          ],
+        },
+      ],
+    };
+
+    fs.writeFileSync(
+      path.join(marketplaceDir, 'marketplace.json'),
+      JSON.stringify(marketplaceConfig, null, 2),
+      'utf-8',
+    );
+
+    // Execute: Convert the plugin
+    const result = await convertClaudePluginPackage(
+      pluginSourceDir,
+      'document-skills',
+    );
+
+    // Verify: Only specified skills should be present
+    const convertedSkillsDir = path.join(result.convertedDir, 'skills');
+    expect(fs.existsSync(convertedSkillsDir)).toBe(true);
+
+    const installedSkills = fs.readdirSync(convertedSkillsDir);
+    expect(installedSkills.sort()).toEqual(['docx', 'pdf', 'pptx', 'xlsx']);
+
+    // Verify each skill has its own directory with proper structure
+    for (const skill of ['xlsx', 'docx', 'pptx', 'pdf']) {
+      const skillDir = path.join(convertedSkillsDir, skill);
+      expect(fs.existsSync(skillDir)).toBe(true);
+      expect(fs.existsSync(path.join(skillDir, 'SKILL.md'))).toBe(true);
+      expect(fs.existsSync(path.join(skillDir, 'index.js'))).toBe(true);
+    }
+
+    // Verify csv and txt skills are NOT installed
+    expect(fs.existsSync(path.join(convertedSkillsDir, 'csv'))).toBe(false);
+    expect(fs.existsSync(path.join(convertedSkillsDir, 'txt'))).toBe(false);
+
+    // Clean up converted directory
+    fs.rmSync(result.convertedDir, { recursive: true, force: true });
+  });
+
+  it('should use all skills from folder when config does not specify skills', async () => {
+    // Setup: Create a plugin source with skills but no skills config
+    const pluginSourceDir = path.join(testDir, 'plugin-source-default');
+    fs.mkdirSync(pluginSourceDir, { recursive: true });
+
+    // Create skills directory with 3 skills
+    const skillsDir = path.join(pluginSourceDir, 'skills');
+    fs.mkdirSync(skillsDir, { recursive: true });
+
+    const allSkills = ['skill-a', 'skill-b', 'skill-c'];
+    for (const skill of allSkills) {
+      const skillDir = path.join(skillsDir, skill);
+      fs.mkdirSync(skillDir, { recursive: true });
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), `# ${skill}`, 'utf-8');
+    }
+
+    // Create marketplace.json WITHOUT skills field
+    const marketplaceDir = path.join(pluginSourceDir, '.claude-plugin');
+    fs.mkdirSync(marketplaceDir, { recursive: true });
+
+    const marketplaceConfig: ClaudeMarketplaceConfig = {
+      name: 'test-marketplace',
+      owner: { name: 'Test Owner', email: 'test@example.com' },
+      plugins: [
+        {
+          name: 'default-skills',
+          version: '1.0.0',
+          description: 'Test default skills behavior',
+          source: './',
+          strict: false,
+          // No skills field - should use all skills from folder
+        },
+      ],
+    };
+
+    fs.writeFileSync(
+      path.join(marketplaceDir, 'marketplace.json'),
+      JSON.stringify(marketplaceConfig, null, 2),
+      'utf-8',
+    );
+
+    // Execute: Convert the plugin
+    const result = await convertClaudePluginPackage(
+      pluginSourceDir,
+      'default-skills',
+    );
+
+    // Verify: All skills should be present
+    const convertedSkillsDir = path.join(result.convertedDir, 'skills');
+    expect(fs.existsSync(convertedSkillsDir)).toBe(true);
+
+    const installedSkills = fs.readdirSync(convertedSkillsDir);
+    expect(installedSkills.sort()).toEqual(['skill-a', 'skill-b', 'skill-c']);
+
+    // Clean up converted directory
+    fs.rmSync(result.convertedDir, { recursive: true, force: true });
+  });
+
+  it('should preserve directory structure when collecting skills', async () => {
+    // Setup: Create a plugin with nested skill structure
+    const pluginSourceDir = path.join(testDir, 'plugin-nested');
+    fs.mkdirSync(pluginSourceDir, { recursive: true });
+
+    // Create nested skill directory
+    const skillsDir = path.join(pluginSourceDir, 'skills');
+    const nestedSkillDir = path.join(skillsDir, 'nested-skill', 'subdir');
+    fs.mkdirSync(nestedSkillDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(skillsDir, 'nested-skill', 'SKILL.md'),
+      '# Nested Skill',
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(nestedSkillDir, 'helper.js'),
+      'module.exports = {};',
+      'utf-8',
+    );
+
+    // Create marketplace.json
+    const marketplaceDir = path.join(pluginSourceDir, '.claude-plugin');
+    fs.mkdirSync(marketplaceDir, { recursive: true });
+
+    const marketplaceConfig: ClaudeMarketplaceConfig = {
+      name: 'test-marketplace',
+      owner: { name: 'Test Owner', email: 'test@example.com' },
+      plugins: [
+        {
+          name: 'nested-plugin',
+          version: '1.0.0',
+          description: 'Test nested structure',
+          source: './',
+          strict: false,
+          skills: ['./skills/nested-skill'],
+        },
+      ],
+    };
+
+    fs.writeFileSync(
+      path.join(marketplaceDir, 'marketplace.json'),
+      JSON.stringify(marketplaceConfig, null, 2),
+      'utf-8',
+    );
+
+    // Execute: Convert the plugin
+    const result = await convertClaudePluginPackage(
+      pluginSourceDir,
+      'nested-plugin',
+    );
+
+    // Verify: Nested structure should be preserved
+    const convertedSkillsDir = path.join(result.convertedDir, 'skills');
+    expect(fs.existsSync(convertedSkillsDir)).toBe(true);
+
+    const nestedSkillPath = path.join(convertedSkillsDir, 'nested-skill');
+    expect(fs.existsSync(nestedSkillPath)).toBe(true);
+    expect(fs.existsSync(path.join(nestedSkillPath, 'SKILL.md'))).toBe(true);
+    expect(
+      fs.existsSync(path.join(nestedSkillPath, 'subdir', 'helper.js')),
+    ).toBe(true);
+
+    // Clean up converted directory
+    fs.rmSync(result.convertedDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## TLDR

Fixed a bug where Claude plugin installation would collect all resources from the source directory instead of only those specified in the marketplace configuration.

## Dive Deeper

### Problem
When installing a Claude plugin (e.g., `anthropics/skills:document-skills`), the converter was:
1. Copying the entire plugin source directory (including all skills)
2. Then collecting specified skills, but NOT removing the unspecified ones
3. Result: All skills were installed instead of only the configured subset

### Root Cause
In `collectResources`, when copying a directory like `./skills/xlsx`, files were being flattened directly into `tmpDir/skills/` instead of preserving the subdirectory structure as `tmpDir/skills/xlsx/`.

### Solution
1. **Clean before collect**: Remove existing resource folders before collecting specified ones
2. **Preserve directory names**: When collecting `./skills/xlsx`, maintain it as `skills/xlsx/` 
3. **Default fallback**: If config doesn't specify resources, keep all resources from the source folder

## Reviewer Test Plan

1. Install a plugin with partial resource specification:
   ```bash
   tsx packages/cli/index.ts extensions install anthropics/skills:document-skills
   ```
   Verify only the 4 configured skills (xlsx, docx, pptx, pdf) are installed, not all skills in the folder.

2. Run the new unit tests:
   ```bash
   npx vitest run packages/core/src/extension/claude-converter.test.ts
   ```
   All 10 tests should pass, including 3 new tests covering explicit config, default behavior, and nested structures.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |