### PR TITLE
fix(ui): resolve model not updating in top-right corner

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -142,9 +142,6 @@ describe('AppContainer State Management', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Increase max listeners to prevent EventEmitter memory leak warnings in tests
-    process.setMaxListeners(20);
-
     // Initialize mock stdout for terminal title tests
     mockStdout = { write: vi.fn() };
 
@@ -308,8 +305,6 @@ describe('AppContainer State Management', () => {
 
   afterEach(() => {
     cleanup();
-    // Reset max listeners to default
-    process.setMaxListeners(10);
   });
 
   describe('Basic Rendering', () => {

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -142,6 +142,9 @@ describe('AppContainer State Management', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
+    // Increase max listeners to prevent EventEmitter memory leak warnings in tests
+    process.setMaxListeners(20);
+
     // Initialize mock stdout for terminal title tests
     mockStdout = { write: vi.fn() };
 
@@ -305,6 +308,8 @@ describe('AppContainer State Management', () => {
 
   afterEach(() => {
     cleanup();
+    // Reset max listeners to default
+    process.setMaxListeners(10);
   });
 
   describe('Basic Rendering', () => {

--- a/packages/cli/src/ui/components/AppHeader.test.tsx
+++ b/packages/cli/src/ui/components/AppHeader.test.tsx
@@ -42,6 +42,7 @@ const createMockUIState = (overrides: Partial<UIState> = {}): UIState =>
     branchName: 'main',
     nightly: false,
     debugMessage: '',
+    currentModel: 'gemini-pro',
     sessionStats: {
       lastPromptTokenCount: 0,
     },

--- a/packages/cli/src/ui/components/AppHeader.tsx
+++ b/packages/cli/src/ui/components/AppHeader.tsx
@@ -9,6 +9,7 @@ import { Header } from './Header.js';
 import { Tips } from './Tips.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
+import { useUIState } from '../contexts/UIStateContext.js';
 
 interface AppHeaderProps {
   version: string;
@@ -17,10 +18,11 @@ interface AppHeaderProps {
 export const AppHeader = ({ version }: AppHeaderProps) => {
   const settings = useSettings();
   const config = useConfig();
+  const uiState = useUIState();
 
   const contentGeneratorConfig = config.getContentGeneratorConfig();
   const authType = contentGeneratorConfig?.authType;
-  const model = config.getModel();
+  const model = uiState.currentModel; // Use currentModel from UIState instead of config.getModel()
   const targetDir = config.getTargetDir();
   const showBanner = !config.getScreenReader();
   const showTips = !(settings.merged.ui?.hideTips || config.getScreenReader());

--- a/packages/cli/src/ui/components/AppHeader.tsx
+++ b/packages/cli/src/ui/components/AppHeader.tsx
@@ -22,7 +22,7 @@ export const AppHeader = ({ version }: AppHeaderProps) => {
 
   const contentGeneratorConfig = config.getContentGeneratorConfig();
   const authType = contentGeneratorConfig?.authType;
-  const model = uiState.currentModel; // Use currentModel from UIState instead of config.getModel()
+  const model = uiState.currentModel;
   const targetDir = config.getTargetDir();
   const showBanner = !config.getScreenReader();
   const showTips = !(settings.merged.ui?.hideTips || config.getScreenReader());

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -32,7 +32,7 @@ export const MainContent = () => {
   return (
     <>
       <Static
-        key={uiState.historyRemountKey}
+        key={`${uiState.historyRemountKey}-${uiState.currentModel}`}
         items={[
           <AppHeader key="app-header" version={version} />,
           ...uiState.history.map((h) => (


### PR DESCRIPTION
## TLDR

https://github.com/QwenLM/qwen-code/issues/1648 When switching AI models, the model name in the top-right corner failed to update, causing UI to show an outdated model. This PR ensures the indicator correctly reflects the active model by syncing UI state with the current selection.

## Dive Deeper

The issue was that when users switched models via `/model` slash commands, the information bar in the upper right corner did not update to reflect the change. The root cause is the Config object reference remains constant throughout the application lifecycle. When config.switchModel() is called, only the internal state of the Config object changes , but the object reference itself stays the same.

Changes:

- The `useEffect` polling detects the change and updates the state
- The `uiState` object is recreated via useMemo
- `AppHeader` receives the new `currentModel` value and updates the display

## Reviewer Test Plan

- Launch the qwen code cli via `qwen`
- Using `/model` command to switch models
- Press Enter to confirm selection

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fix https://github.com/QwenLM/qwen-code/issues/1648 issue 2