### PR TITLE
fix(core): avoid passing undici agent to Anthropic SDK

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -71,7 +71,7 @@ export class DashScopeOpenAICompatibleProvider
     const defaultHeaders = this.buildHeaders();
     // Configure fetch options to ensure user-configured timeout works as expected
     // bodyTimeout is always disabled (0) to let OpenAI SDK timeout control the request
-    const fetchOptions = buildRuntimeFetchOptions(
+    const runtimeOptions = buildRuntimeFetchOptions(
       'openai',
       this.cliConfig.getProxy(),
     );
@@ -81,7 +81,7 @@ export class DashScopeOpenAICompatibleProvider
       timeout,
       maxRetries,
       defaultHeaders,
-      ...(fetchOptions ? { fetchOptions } : {}),
+      ...(runtimeOptions || {}),
     });
   }
 

--- a/packages/core/src/core/openaiContentGenerator/provider/default.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.ts
@@ -46,7 +46,7 @@ export class DefaultOpenAICompatibleProvider
     const defaultHeaders = this.buildHeaders();
     // Configure fetch options to ensure user-configured timeout works as expected
     // bodyTimeout is always disabled (0) to let OpenAI SDK timeout control the request
-    const fetchOptions = buildRuntimeFetchOptions(
+    const runtimeOptions = buildRuntimeFetchOptions(
       'openai',
       this.cliConfig.getProxy(),
     );
@@ -56,7 +56,7 @@ export class DefaultOpenAICompatibleProvider
       timeout,
       maxRetries,
       defaultHeaders,
-      ...(fetchOptions ? { fetchOptions } : {}),
+      ...(runtimeOptions || {}),
     });
   }
 


### PR DESCRIPTION
## TLDR

Fix Anthropic Node runtime client configuration by avoiding passing undici's Dispatcher as `httpAgent` (Anthropic uses `node-fetch`, which expects Node http(s).Agent). When a proxy is configured, provide a Node-compatible proxy agent; otherwise let the SDK use its default agent.

## Dive Deeper

- OpenAI SDK uses undici internally, so `dispatcher` is appropriate.
- Anthropic SDK uses `node-fetch` internally, so undici's `Agent`/`Dispatcher` is incompatible when provided as `httpAgent`.
- This change makes Anthropic options conditional:
  - No proxy: do not set `httpAgent`.
  - Proxy: set `httpAgent` to `HttpsProxyAgent(proxyUrl)`.

## Reviewer Test Plan

- From `packages/core`, run:
  - `npx vitest run src/utils/runtimeFetchOptions.test.ts`

## Linked issues / bugs

N/A