### PR TITLE
fix(ci): honor manual preview version input

### DIFF
--- a/.github/workflows/release-vscode-companion.yml
+++ b/.github/workflows/release-vscode-companion.yml
@@ -299,7 +299,7 @@ jobs:
           echo "Publishing to Microsoft Marketplace..."
           for vsix in vsix-artifacts/*.vsix; do
             echo "Publishing: ${vsix}"
-            vsce publish --packagePath "${vsix}" --pat "${VSCE_PAT}"
+            vsce publish --packagePath "${vsix}" --pat "${VSCE_PAT}" --skip-duplicate
           done
 
       - name: 'Publish to OpenVSX'


### PR DESCRIPTION
## TLDR

- Preview releases for the VSCode IDE companion workflow now honor the manual `version` input.
- If `version` already includes `-preview.<id>` (e.g. `v0.9.0-preview.0`), it is used as-is (no timestamp appended).

## Dive Deeper

The workflow previously ignored `inputs.version` whenever `create_preview_release=true`, always deriving preview versions from `packages/vscode-ide-companion/package.json` plus a timestamp.

This change makes the preview flow align with operator intent:

- `create_preview_release=true` + `version=v0.9.0-preview.0` -> `release_version=0.9.0-preview.0`
- `create_preview_release=true` + `version=v0.9.0` -> `release_version=0.9.0-preview.<timestamp>`
- `create_preview_release=true` + no `version` -> `release_version=<package.json>-preview.<timestamp>`

Also updates the input description to match behavior and makes `release_tag` match the computed preview version.

## Reviewer Test Plan

- Trigger `Release VSCode IDE Companion` via `workflow_dispatch` with `dry_run=true`.
- Set `create_preview_release=true` and try:
  - `version=v0.9.0-preview.0` (expect exact version)
  - `version=v0.9.0` (expect timestamp appended)
  - omit `version` (expect package.json base + timestamp)
- Confirm the produced VSIX filenames and the `npm run release:version` argument match the expected `release_version`.

## Linked issues / bugs

- None