### PR TITLE
fix(vscode-ide-companion): fix race conditions and improve @ file completion search

### DIFF
--- a/packages/vscode-ide-companion/src/services/qwenConnectionHandler.ts
+++ b/packages/vscode-ide-companion/src/services/qwenConnectionHandler.ts
@@ -55,7 +55,7 @@ export class QwenConnectionHandler {
     let availableModels: ModelInfo[] | undefined;
 
     // Build extra CLI arguments (only essential parameters)
-    const extraArgs: string[] = [];
+    const extraArgs: string[] = ['--experimental-skills'];
 
     await connection.connect(cliEntryPath!, workingDir, extraArgs);
 

--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -264,16 +264,11 @@ export const App: React.FC = () => {
     [fileContext.workspaceFiles],
   );
 
-  // When workspace files update while menu open for @, refresh items so the first @ shows the list
+  // When workspace files update while menu open for @, refresh items to reflect latest search results.
   // Note: Avoid depending on the entire `completion` object here, since its identity
   // changes on every render which would retrigger this effect and can cause a refresh loop.
   useEffect(() => {
-    // Only auto-refresh when there's no query (first @ popup) to avoid repeated refreshes during search
-    if (
-      completion.isOpen &&
-      completion.triggerChar === '@' &&
-      !completion.query
-    ) {
+    if (completion.isOpen && completion.triggerChar === '@') {
       // Only refresh items; do not change other completion state to avoid re-renders loops
       completion.refreshCompletion();
     }

--- a/packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/FileMessageHandler.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { QwenAgentManager } from '../../services/qwenAgentManager.js';
+import type { ConversationStore } from '../../services/conversationStore.js';
+import { FileMessageHandler } from './FileMessageHandler.js';
+import * as vscode from 'vscode';
+
+const shouldIgnoreFileMock = vi.hoisted(() => vi.fn());
+const vscodeMock = vi.hoisted(() => {
+  class Uri {
+    fsPath: string;
+    constructor(fsPath: string) {
+      this.fsPath = fsPath;
+    }
+    static file(fsPath: string) {
+      return new Uri(fsPath);
+    }
+  }
+
+  return {
+    Uri,
+    workspace: {
+      findFiles: vi.fn(),
+      getWorkspaceFolder: vi.fn(),
+      asRelativePath: vi.fn(),
+      workspaceFolders: [],
+    },
+    window: {
+      activeTextEditor: undefined,
+      tabGroups: {
+        all: [],
+      },
+    },
+  };
+});
+
+vi.mock('vscode', () => vscodeMock);
+vi.mock(
+  '@qwen-code/qwen-code-core/src/services/fileDiscoveryService.js',
+  () => ({
+    FileDiscoveryService: class {
+      shouldIgnoreFile(filePath: string, options?: unknown) {
+        return shouldIgnoreFileMock(filePath, options);
+      }
+    },
+  }),
+);
+
+describe('FileMessageHandler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('filters ignored paths and includes request metadata in workspace files', async () => {
+    const rootPath = '/workspace';
+    const allowedPath = `${rootPath}/allowed.txt`;
+    const ignoredPath = `${rootPath}/ignored.log`;
+
+    const allowedUri = vscode.Uri.file(allowedPath);
+    const ignoredUri = vscode.Uri.file(ignoredPath);
+
+    vscodeMock.workspace.findFiles.mockResolvedValue([allowedUri, ignoredUri]);
+    vscodeMock.workspace.getWorkspaceFolder.mockImplementation(() => ({
+      uri: vscode.Uri.file(rootPath),
+    }));
+    vscodeMock.workspace.asRelativePath.mockImplementation((uri: vscode.Uri) =>
+      uri.fsPath.replace(`${rootPath}/`, ''),
+    );
+
+    shouldIgnoreFileMock.mockImplementation((filePath: string) =>
+      filePath.includes('ignored'),
+    );
+
+    const sendToWebView = vi.fn();
+    const handler = new FileMessageHandler(
+      {} as QwenAgentManager,
+      {} as ConversationStore,
+      null,
+      sendToWebView,
+    );
+
+    await handler.handle({
+      type: 'getWorkspaceFiles',
+      data: { query: 'txt', requestId: 7 },
+    });
+
+    expect(vscodeMock.workspace.findFiles).toHaveBeenCalledWith(
+      '**/*[tT][xX][tT]*',
+      '**/{.git,node_modules}/**',
+      50,
+    );
+    expect(shouldIgnoreFileMock).toHaveBeenCalledWith(ignoredPath, {
+      respectGitIgnore: true,
+      respectQwenIgnore: false,
+    });
+
+    expect(sendToWebView).toHaveBeenCalledTimes(1);
+    const payload = sendToWebView.mock.calls[0]?.[0] as {
+      type: string;
+      data: {
+        files: Array<{ path: string }>;
+        query?: string;
+        requestId?: number;
+      };
+    };
+
+    expect(payload.type).toBe('workspaceFiles');
+    expect(payload.data.requestId).toBe(7);
+    expect(payload.data.query).toBe('txt');
+    expect(payload.data.files).toHaveLength(1);
+    expect(payload.data.files[0]?.path).toBe(allowedPath);
+  });
+});

--- a/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
@@ -54,13 +54,14 @@ interface UseWebViewMessagesProps {
     setActiveSelection: (
       selection: { startLine: number; endLine: number } | null,
     ) => void;
-    setWorkspaceFiles: (
+    setWorkspaceFilesFromResponse: (
       files: Array<{
         id: string;
         label: string;
         description: string;
         path: string;
       }>,
+      requestId?: number,
     ) => void;
     addFileReference: (name: string, path: string) => void;
   };
@@ -923,9 +924,13 @@ export const useWebViewMessages = ({
             description: string;
             path: string;
           }>;
+          const requestId = message.data?.requestId as number | undefined;
           if (files) {
             console.log('[WebView] Received workspaceFiles:', files.length);
-            handlers.fileContext.setWorkspaceFiles(files);
+            handlers.fileContext.setWorkspaceFilesFromResponse(
+              files,
+              requestId,
+            );
           }
           break;
         }


### PR DESCRIPTION
## TLDR

Fix multiple issues with the `@` file completion feature in VSCode IDE Companion:

- **Race condition fix**: Add `requestId` mechanism to ensure async responses are applied in order, preventing slow requests from overwriting faster ones
- **Case-insensitive search**: File search now ignores case, so `readme` and `README` return the same results
- **Gitignore filtering**: Files ignored by `.gitignore` (e.g., `node_modules`, build artifacts) no longer appear in the completion list
- **Real-time refresh during search**: Remove the condition that prevented refresh during search, allowing results to update in real-time
- **Enable experimental skills**: Add `--experimental-skills` to CLI connection arguments

## Dive Deeper

### Problem Background

Users encountered the following issues when using `@` to trigger file completion:

1. **Race condition**: When typing quickly, earlier requests could return after newer ones due to inconsistent network latency, causing stale search results to be displayed
2. **Case sensitivity**: Searching for `App` would not match `app.tsx`, resulting in poor user experience
3. **Noisy files**: Files in `node_modules`, `.git`, and other gitignored locations appeared in results, cluttering user selection
4. **No refresh during search**: After entering a query, the completion list could not update in real-time based on workspace file changes

### Technical Solution

| Problem | Solution |
|---------|----------|
| Race condition | Add `requestId` to requests/responses; frontend only applies responses matching the latest request ID |
| Case sensitivity | Add `buildCaseInsensitiveGlob()` method to convert query to glob pattern like `[aA][pP][pP]` |
| Noisy files | Integrate `FileDiscoveryService` to reuse core module's gitignore parsing logic for filtering |
| No refresh during search | Remove `!completion.query` condition check in `App.tsx` |

### File Changes

| File | Description |
|------|-------------|
| `FileMessageHandler.ts` | Add `requestId` support, integrate `FileDiscoveryService`, implement case-insensitive glob |
| `useFileContext.ts` | Add request ID tracking, add `setWorkspaceFilesFromResponse` to validate response validity |
| `useCompletionTrigger.ts` | Add `requestIdRef` to prevent stale async callbacks from updating state |
| `useWebViewMessages.ts` | Adapt to new `setWorkspaceFilesFromResponse` API |
| `App.tsx` | Remove `!completion.query` condition to allow refresh during search |
| `qwenConnectionHandler.ts` | Add `--experimental-skills` CLI argument |
| `FileMessageHandler.test.ts` | Add unit tests |

## Reviewer Test Plan

1. **Verify race condition fix**:
   - Open IDE Companion and type `@` in the input box
   - Quickly type consecutive search terms (e.g., `ap` → `app` → `appx`)
   - Confirm the displayed results always correspond to the last typed search term and don't flash back to old results

2. **Verify case-insensitive search**:
   - Type `@readme` and `@README`
   - Confirm both return the same file list

3. **Verify gitignore filtering**:
   - Type `@package`
   - Confirm results do not include `package.json` files from `node_modules/`

4. **Verify refresh during search**:
   - Type `@test`
   - In another window, create a new file `test-new.ts`
   - Confirm the completion list refreshes to show the new file

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- Add related issue links here if any -->