### PR TITLE
fix(core): auto-enable WebFetch and WebSearch tools in Plan mode

### DIFF
--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -148,7 +148,11 @@ ${textContent}
   override async shouldConfirmExecute(): Promise<
     ToolCallConfirmationDetails | false
   > {
-    if (this.config.getApprovalMode() === ApprovalMode.AUTO_EDIT) {
+    // Auto-execute in AUTO_EDIT mode and PLAN mode (read-only tool)
+    if (
+      this.config.getApprovalMode() === ApprovalMode.AUTO_EDIT ||
+      this.config.getApprovalMode() === ApprovalMode.PLAN
+    ) {
       return false;
     }
 

--- a/packages/core/src/tools/web-search/index.ts
+++ b/packages/core/src/tools/web-search/index.ts
@@ -55,7 +55,11 @@ class WebSearchToolInvocation extends BaseToolInvocation<
   override async shouldConfirmExecute(
     _abortSignal: AbortSignal,
   ): Promise<ToolCallConfirmationDetails | false> {
-    if (this.config.getApprovalMode() === ApprovalMode.AUTO_EDIT) {
+    // Auto-execute in AUTO_EDIT mode and PLAN mode (read-only tool)
+    if (
+      this.config.getApprovalMode() === ApprovalMode.AUTO_EDIT ||
+      this.config.getApprovalMode() === ApprovalMode.PLAN
+    ) {
       return false;
     }
 


### PR DESCRIPTION
## TLDR

Allow `web_fetch` and `web_search` tools to auto-execute in Plan mode without requiring confirmation

## Dive Deeper

In `coreToolScheduler.ts`, Plan mode blocks any tool where `shouldConfirmExecute()` returns confirmation details. Both `web-fetch.ts` and `web-search/index.ts` only returned `false` for `AUTO_EDIT` mode, causing them to be blocked in Plan mode  despite being read-only.                                                                                                       
                                                                                                                                 
- Add `ApprovalMode.PLAN` check to `shouldConfirmExecute()` in `web-fetch.ts`                                                  
- Add `ApprovalMode.PLAN` check to `shouldConfirmExecute()` in `web-search/index.ts`

## Reviewer Test Plan

1. Run `npm run build && npm start`                                                                                            
2. Type `/approval-mode plan` to enable Plan mode                                                                              
3. Ask the model to fetch a URL or search the web                                                                              
4. Verify the tool executes without a confirmation prompt 

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | yes | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1394
