### PR TITLE
fix(core): Preserve trailing whitespace in newString during edits

### DIFF
--- a/packages/core/src/utils/editHelper.test.ts
+++ b/packages/core/src/utils/editHelper.test.ts
@@ -16,11 +16,11 @@ describe('normalizeEditStrings', () => {
 const two = 2;
 `;
 
-  it('returns literal matches unchanged and trims new_string trailing whitespace', () => {
+  it('returns literal matches unchanged', () => {
     const result = normalizeEditStrings(
       file,
       'const two = 2;',
-      '  const two = 42;  ',
+      '  const two = 42;',
     );
     expect(result).toEqual({
       oldString: 'const two = 2;',
@@ -32,11 +32,11 @@ const two = 2;
     const result = normalizeEditStrings(
       "const greeting = 'Don't';\n",
       'const greeting = ‘Don’t’;',
-      'const greeting = “Hello”;   ',
+      'const greeting = "Hello";',
     );
     expect(result).toEqual({
       oldString: "const greeting = 'Don't';",
-      newString: 'const greeting = “Hello”;',
+      newString: 'const greeting = "Hello";',
     });
   });
 
@@ -48,15 +48,7 @@ const two = 2;
     });
   });
 
-  it('still trims new_string when editing a brand-new file', () => {
-    const result = normalizeEditStrings(null, '', 'new file contents   ');
-    expect(result).toEqual({
-      oldString: '',
-      newString: 'new file contents',
-    });
-  });
-
-  it('matches unicode dash variants', () => {
+  it('matches unicode dash variants and preserves newString', () => {
     const result = normalizeEditStrings(
       'const range = "1-2";\n',
       'const range = "1\u20132";',
@@ -64,19 +56,7 @@ const two = 2;
     );
     expect(result).toEqual({
       oldString: 'const range = "1-2";',
-      newString: 'const range = "3\u20135";',
-    });
-  });
-
-  it('matches when trailing whitespace differs only at line ends', () => {
-    const result = normalizeEditStrings(
-      'value = 1;\n',
-      'value = 1;   \n',
-      'value = 2;   \n',
-    );
-    expect(result).toEqual({
-      oldString: 'value = 1;\n',
-      newString: 'value = 2;\n',
+      newString: 'const range = "3\u20135";   ',
     });
   });
 
@@ -101,6 +81,83 @@ const two = 2;
     expect(result).toEqual({
       oldString: 'console.log("hi")',
       newString: 'console.log("bye")',
+    });
+  });
+
+  // Tests for issue #1618: Preserve trailing whitespace in newString
+  describe('trailing whitespace preservation in newString', () => {
+    it('preserves trailing whitespace when intentionally adding to end of line', () => {
+      // Test with tab
+      const result1 = normalizeEditStrings(
+        'value = 1;\n',
+        'value = 1;\n',
+        'value = 1;\t\n',
+      );
+      expect(result1.newString).toBe('value = 1;\t\n');
+
+      // Test with spaces (same behavior, just different whitespace char)
+      const result2 = normalizeEditStrings('text\n', 'text\n', 'text   \n');
+      expect(result2.newString).toBe('text   \n');
+    });
+
+    it('preserves newString trailing whitespace even when oldString is fuzzy matched', () => {
+      const result = normalizeEditStrings(
+        'value = 1;\n', // File has no trailing spaces
+        'value = 1;   \n', // LLM copied with extra spaces (will be fuzzy matched)
+        'value = 2;   \n', // LLM replacement also has spaces
+      );
+      expect(result).toEqual({
+        oldString: 'value = 1;\n', // Canonical from file
+        newString: 'value = 2;   \n', // Preserved as LLM intended
+      });
+    });
+
+    it('preserves trailing whitespace in multi-line template literals', () => {
+      const file = 'const s = "";\n';
+      const result = normalizeEditStrings(
+        file,
+        'const s = "";',
+        'const s = `line1  \nline2`;', // Trailing spaces after line1 are significant
+      );
+      expect(result.newString).toBe('const s = `line1  \nline2`;');
+    });
+
+    it('preserves trailing whitespace when creating new file', () => {
+      const result = normalizeEditStrings(
+        null,
+        '',
+        'content with trailing tab\t\n',
+      );
+      expect(result).toEqual({
+        oldString: '',
+        newString: 'content with trailing tab\t\n',
+      });
+    });
+
+    it('still supports fuzzy matching after trailing whitespace was added in previous edit', () => {
+      // Round 1: Add trailing spaces to a line
+      let fileContent = 'value = 1;\n';
+      const round1 = normalizeEditStrings(
+        fileContent,
+        'value = 1;\n',
+        'value = 1;   \n', // Adding trailing spaces
+      );
+      expect(round1.newString).toBe('value = 1;   \n');
+
+      // Simulate the edit being applied
+      fileContent = fileContent.replace(round1.oldString, round1.newString);
+      expect(fileContent).toBe('value = 1;   \n'); // File now has trailing spaces
+
+      // Round 2: LLM tries to edit again, but its oldString doesn't have trailing spaces
+      // (because LLM context may not preserve exact whitespace)
+      const round2 = normalizeEditStrings(
+        fileContent,
+        'value = 1;\n', // LLM thinks there's no trailing spaces
+        'value = 2;\n',
+      );
+      // Fuzzy matching should still find the line and return canonical slice WITH trailing spaces
+      expect(round2.oldString).toBe('value = 1;   \n');
+      expect(round2.newString).toBe('value = 2;\n');
     });
   });
 });


### PR DESCRIPTION
## TLDR

Fixes an issue where trailing whitespace in `newString` was being unconditionally stripped during file edits, breaking legitimate use cases like multi-line strings with intentional trailing spaces.

## Dive Deeper

The `normalizeEditStrings()` function in `editHelper.ts` previously stripped trailing whitespace from `newString` as a "cleanup" step. However, this broke valid editing scenarios where trailing whitespace is intentional:

- Multi-line template literals with trailing spaces
- Heredocs and raw string blocks
- Files where users explicitly added trailing whitespace for formatting

This change removes the `stripTrailingWhitespacePreserveNewlines()` function and preserves `newString` exactly as provided by the LLM. The `oldString` fuzzy matching continues to work correctly (finding the canonical text from disk), but the replacement text is now preserved verbatim.

Key changes:
- Removed `stripTrailingWhitespacePreserveNewlines()` function
- Modified `normalizeEditStrings()` to pass `newString` through unchanged
- Added comprehensive test suite for trailing whitespace preservation scenarios
- Fixed test cases that previously expected stripped output

## Reviewer Test Plan

1. Run the new test suite:
   ```bash
   cd packages/core && npx vitest run src/utils/editHelper.test.ts
   ```

2. Verify the fix works with a real edit scenario:
   - Create a file with trailing whitespace that should be preserved
   - Ask Qwen Code to make an edit that preserves or adds trailing whitespace
   - Confirm the whitespace is retained in the final file

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

*Note: Tests were run on macOS with `npx vitest run src/utils/editHelper.test.ts` - all 34 tests passing.*

## Linked issues / bugs

Fixes #1618

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)
