### PR TITLE
fix(core): handle heredoc in command substitution guard

### DIFF
--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -228,6 +228,31 @@ describe('isCommandAllowed', () => {
         const result = isCommandAllowed(cmd, config);
         expect(result.allowed).toBe(true);
       });
+
+      it('should block command substitution split by line continuation in an unquoted heredoc body', () => {
+        const cmd = [
+          'cat <<EOF > user_session.md',
+          '$\\',
+          '(rm -rf /)',
+          'EOF',
+        ].join('\n');
+
+        const result = isCommandAllowed(cmd, config);
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toContain('Command substitution');
+      });
+
+      it('should allow escaped command substitution split by line continuation in an unquoted heredoc body', () => {
+        const cmd = [
+          'cat <<EOF > user_session.md',
+          '\\$\\',
+          '(rm -rf /)',
+          'EOF',
+        ].join('\n');
+
+        const result = isCommandAllowed(cmd, config);
+        expect(result.allowed).toBe(true);
+      });
     });
 
     describe('comments', () => {


### PR DESCRIPTION
Fixes #1698

### What
- Teach `detectCommandSubstitution()` to understand heredocs.
- Allow substitution-like text in heredoc bodies when the delimiter is quoted (e.g. `<<'EOF'`).
- Block `$()` / backticks in heredoc bodies when the delimiter is unquoted (because bash would execute them).

### Why
Users saving sessions/logs to Markdown often include ``` and `$()`/backticks as plain text. The previous detector could false-positive on these, blocking safe file writes.

### Test
- npm test -w packages/core -- src/utils/shell-utils.test.ts
