### PR TITLE
fix(cli): prevent duplicate output on stream retry

### DIFF
--- a/packages/cli/src/ui/App.test.tsx
+++ b/packages/cli/src/ui/App.test.tsx
@@ -62,6 +62,7 @@ describe('App', () => {
       addItem: vi.fn(),
       history: [],
       updateItem: vi.fn(),
+      removeItemsById: vi.fn(),
       clearItems: vi.fn(),
       loadHistory: vi.fn(),
     },

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -825,6 +825,7 @@ export const AppContainer = (props: AppContainerProps) => {
     terminalWidth,
     terminalHeight,
     midTurnDrainRef,
+    historyManager.removeItemsById,
   );
 
   // Now that streamingState is available, keep isIdleRef in sync and

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -10,6 +10,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useGeminiStream, classifyApiError } from './useGeminiStream.js';
 import * as atCommandProcessor from './atCommandProcessor.js';
+import { findLastSafeSplitPoint } from '../utils/markdownUtilities.js';
 import type {
   TrackedToolCall,
   TrackedCompletedToolCall,
@@ -2268,6 +2269,445 @@ describe('useGeminiStream', () => {
       expect.any(String), // Argument 3: The prompt_id string
       { type: SendMessageType.UserQuery }, // Argument 4: The options
     );
+  });
+
+  describe('Retry Handling', () => {
+    it('should discard streamed content on Retry to avoid duplicates', async () => {
+      let idCounter = 0;
+      mockAddItem.mockImplementation(() => {
+        idCounter += 1;
+        return idCounter;
+      });
+
+      const mockOnEditorClose = vi.fn();
+      const mockRemoveHistoryItemsById = vi.fn();
+      let continueRetry!: () => void;
+      const retryBlocker = new Promise<void>((resolve) => {
+        continueRetry = resolve;
+      });
+
+      (findLastSafeSplitPoint as unknown as Mock).mockImplementationOnce(
+        () => 3,
+      );
+
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'abcdef',
+          };
+          await retryBlocker;
+          yield {
+            type: ServerGeminiEventType.Retry,
+          };
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'abcdef',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: 'STOP', usageMetadata: undefined },
+          };
+        })(),
+      );
+
+      const { result } = renderHook(() =>
+        useGeminiStream(
+          new MockedGeminiClientClass(mockConfig),
+          [],
+          mockAddItem,
+          mockConfig,
+          mockLoadedSettings,
+          mockOnDebugMessage,
+          mockHandleSlashCommand,
+          false,
+          () => 'vscode' as EditorType,
+          () => {},
+          () => Promise.resolve(),
+          false,
+          () => {},
+          mockOnEditorClose,
+          () => {},
+          () => {},
+          80,
+          24,
+          undefined,
+          mockRemoveHistoryItemsById,
+        ),
+      );
+
+      let request!: Promise<void>;
+      await act(async () => {
+        request = result.current.submitQuery('test query');
+      });
+
+      try {
+        await waitFor(() => {
+          expect(mockAddItem).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'gemini', text: 'abc' }),
+            expect.any(Number),
+          );
+        });
+
+        await act(async () => {
+          continueRetry();
+          await request;
+        });
+
+        expect(mockRemoveHistoryItemsById).toHaveBeenCalledWith([2]);
+        expect(mockOnEditorClose).toHaveBeenCalledTimes(1);
+
+        const fullResponses = mockAddItem.mock.calls.filter(
+          (call) => call[0].type === 'gemini' && call[0].text === 'abcdef',
+        );
+        expect(fullResponses).toHaveLength(1);
+      } finally {
+        continueRetry();
+        await request;
+      }
+    });
+
+    it('should discard content finalized by citation before Retry', async () => {
+      let idCounter = 0;
+      mockAddItem.mockImplementation(() => {
+        idCounter += 1;
+        return idCounter;
+      });
+
+      const mockOnEditorClose = vi.fn();
+      const mockRemoveHistoryItemsById = vi.fn();
+
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'truncated response',
+          };
+          yield {
+            type: ServerGeminiEventType.Citation,
+            value: 'Citations:\n(Source) https://example.com',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: 'MAX_TOKENS', usageMetadata: undefined },
+          };
+          yield {
+            type: ServerGeminiEventType.Retry,
+          };
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'expanded response',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: 'STOP', usageMetadata: undefined },
+          };
+        })(),
+      );
+
+      const { result } = renderHook(() =>
+        useGeminiStream(
+          new MockedGeminiClientClass(mockConfig),
+          [],
+          mockAddItem,
+          mockConfig,
+          mockLoadedSettings,
+          mockOnDebugMessage,
+          mockHandleSlashCommand,
+          false,
+          () => 'vscode' as EditorType,
+          () => {},
+          () => Promise.resolve(),
+          false,
+          () => {},
+          mockOnEditorClose,
+          () => {},
+          () => {},
+          80,
+          24,
+          undefined,
+          mockRemoveHistoryItemsById,
+        ),
+      );
+
+      await act(async () => {
+        await result.current.submitQuery('test query');
+      });
+
+      expect(mockRemoveHistoryItemsById).toHaveBeenCalledWith([2, 3, 4]);
+      expect(mockOnEditorClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should only discard static chunks from the current retry attempt', async () => {
+      let idCounter = 0;
+      mockAddItem.mockImplementation(() => {
+        idCounter += 1;
+        return idCounter;
+      });
+
+      const mockOnEditorClose = vi.fn();
+      const mockRemoveHistoryItemsById = vi.fn();
+      let continueRetry!: () => void;
+      const retryBlocker = new Promise<void>((resolve) => {
+        continueRetry = resolve;
+      });
+
+      (findLastSafeSplitPoint as unknown as Mock)
+        .mockImplementationOnce(() => 3)
+        .mockImplementationOnce(() => 3);
+
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'abcdef',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: 'STOP', usageMetadata: undefined },
+          };
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'ghijkl',
+          };
+          await retryBlocker;
+          yield {
+            type: ServerGeminiEventType.Retry,
+          };
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'mnopqr',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: 'STOP', usageMetadata: undefined },
+          };
+        })(),
+      );
+
+      const { result } = renderHook(() =>
+        useGeminiStream(
+          new MockedGeminiClientClass(mockConfig),
+          [],
+          mockAddItem,
+          mockConfig,
+          mockLoadedSettings,
+          mockOnDebugMessage,
+          mockHandleSlashCommand,
+          false,
+          () => 'vscode' as EditorType,
+          () => {},
+          () => Promise.resolve(),
+          false,
+          () => {},
+          mockOnEditorClose,
+          () => {},
+          () => {},
+          80,
+          24,
+          undefined,
+          mockRemoveHistoryItemsById,
+        ),
+      );
+
+      let request!: Promise<void>;
+      await act(async () => {
+        request = result.current.submitQuery('test query');
+      });
+
+      try {
+        await waitFor(() => {
+          expect(mockAddItem).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'gemini', text: 'ghi' }),
+            expect.any(Number),
+          );
+        });
+
+        await act(async () => {
+          continueRetry();
+          await request;
+        });
+
+        expect(mockRemoveHistoryItemsById).toHaveBeenCalledTimes(1);
+        expect(mockRemoveHistoryItemsById).toHaveBeenCalledWith([4]);
+        expect(mockOnEditorClose).toHaveBeenCalledTimes(1);
+      } finally {
+        continueRetry();
+        await request;
+      }
+    });
+
+    it('should discard content finalized by Finished before production-path Retry', async () => {
+      let idCounter = 0;
+      mockAddItem.mockImplementation(() => {
+        idCounter += 1;
+        return idCounter;
+      });
+
+      const mockOnEditorClose = vi.fn();
+      const mockRemoveHistoryItemsById = vi.fn();
+
+      (findLastSafeSplitPoint as unknown as Mock).mockImplementationOnce(
+        () => 3,
+      );
+
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'abcdef',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: 'STOP', usageMetadata: undefined },
+          };
+          yield {
+            type: ServerGeminiEventType.Retry,
+          };
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'abcdef',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: 'STOP', usageMetadata: undefined },
+          };
+        })(),
+      );
+
+      const { result } = renderHook(() =>
+        useGeminiStream(
+          new MockedGeminiClientClass(mockConfig),
+          [],
+          mockAddItem,
+          mockConfig,
+          mockLoadedSettings,
+          mockOnDebugMessage,
+          mockHandleSlashCommand,
+          false,
+          () => 'vscode' as EditorType,
+          () => {},
+          () => Promise.resolve(),
+          false,
+          () => {},
+          mockOnEditorClose,
+          () => {},
+          () => {},
+          80,
+          24,
+          undefined,
+          mockRemoveHistoryItemsById,
+        ),
+      );
+
+      await act(async () => {
+        await result.current.submitQuery('test query');
+      });
+
+      expect(mockRemoveHistoryItemsById).toHaveBeenCalledTimes(1);
+      expect(mockRemoveHistoryItemsById).toHaveBeenCalledWith([2, 3]);
+      expect(mockOnEditorClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should preserve retry discard IDs across concurrent /btw commands', async () => {
+      let idCounter = 0;
+      mockAddItem.mockImplementation(() => {
+        idCounter += 1;
+        return idCounter;
+      });
+
+      const mockOnEditorClose = vi.fn();
+      const mockRemoveHistoryItemsById = vi.fn();
+      let continueMainStream!: () => void;
+      const mainStreamBlocker = new Promise<void>((resolve) => {
+        continueMainStream = resolve;
+      });
+
+      (findLastSafeSplitPoint as unknown as Mock).mockImplementationOnce(
+        () => 3,
+      );
+
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'abcdef',
+          };
+          await mainStreamBlocker;
+          yield {
+            type: ServerGeminiEventType.Retry,
+          };
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'abcdef',
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: 'STOP', usageMetadata: undefined },
+          };
+        })(),
+      );
+      mockHandleSlashCommand.mockImplementation(async (command) => {
+        if (command === '/btw quick side question') {
+          return { type: 'handled' };
+        }
+        return false;
+      });
+
+      const { result } = renderHook(() =>
+        useGeminiStream(
+          new MockedGeminiClientClass(mockConfig),
+          [],
+          mockAddItem,
+          mockConfig,
+          mockLoadedSettings,
+          mockOnDebugMessage,
+          mockHandleSlashCommand,
+          false,
+          () => 'vscode' as EditorType,
+          () => {},
+          () => Promise.resolve(),
+          false,
+          () => {},
+          mockOnEditorClose,
+          () => {},
+          () => {},
+          80,
+          24,
+          undefined,
+          mockRemoveHistoryItemsById,
+        ),
+      );
+
+      let mainRequest!: Promise<void>;
+      await act(async () => {
+        mainRequest = result.current.submitQuery('test query');
+      });
+
+      try {
+        await waitFor(() => {
+          expect(mockAddItem).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'gemini', text: 'abc' }),
+            expect.any(Number),
+          );
+        });
+
+        await act(async () => {
+          await result.current.submitQuery('/btw quick side question');
+        });
+
+        await act(async () => {
+          continueMainStream();
+          await mainRequest;
+        });
+
+        expect(mockRemoveHistoryItemsById).toHaveBeenCalledWith([2]);
+        expect(mockOnEditorClose).toHaveBeenCalledTimes(1);
+      } finally {
+        continueMainStream();
+        await mainRequest;
+      }
+    });
   });
 
   describe('Thought Reset', () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -179,6 +179,12 @@ enum StreamProcessingStatus {
 
 const EDIT_TOOL_NAMES = new Set(['replace', 'write_file']);
 const STREAM_UPDATE_THROTTLE_MS = 60;
+const RETRY_DISCARD_HISTORY_ITEM_TYPES = new Set<HistoryItemWithoutId['type']>([
+  'gemini',
+  'gemini_content',
+  'gemini_thought',
+  'gemini_thought_content',
+]);
 
 type BufferedStreamEvent =
   | { kind: 'content'; value: string }
@@ -218,6 +224,7 @@ export const useGeminiStream = (
   terminalWidth: number,
   terminalHeight: number,
   midTurnDrainRef?: React.RefObject<(() => string[]) | null>,
+  removeHistoryItemsById?: UseHistoryManagerReturn['removeItemsById'],
 ) => {
   const [initError, setInitError] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -681,6 +688,7 @@ export const useGeminiStream = (
       eventValue: ContentEvent['value'],
       currentGeminiMessageBuffer: string,
       userMessageTimestamp: number,
+      retryDiscardHistoryItemIds: Set<number>,
     ): string => {
       if (turnCancelledRef.current) {
         // Prevents additional output after a user initiated cancel.
@@ -695,7 +703,17 @@ export const useGeminiStream = (
         pendingHistoryItemRef.current?.type !== 'gemini_content'
       ) {
         if (pendingHistoryItemRef.current) {
-          addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+          const id = addItem(
+            pendingHistoryItemRef.current,
+            userMessageTimestamp,
+          );
+          if (
+            RETRY_DISCARD_HISTORY_ITEM_TYPES.has(
+              pendingHistoryItemRef.current.type,
+            )
+          ) {
+            retryDiscardHistoryItemIds.add(id);
+          }
         }
         setPendingHistoryItem({ type: 'gemini', text: '' });
         newGeminiMessageBuffer = eventValue;
@@ -720,7 +738,7 @@ export const useGeminiStream = (
         // broken up so that there are more "statically" rendered.
         const beforeText = newGeminiMessageBuffer.substring(0, splitPoint);
         const afterText = newGeminiMessageBuffer.substring(splitPoint);
-        addItem(
+        const id = addItem(
           {
             type: pendingHistoryItemRef.current?.type as
               | 'gemini'
@@ -729,6 +747,7 @@ export const useGeminiStream = (
           },
           userMessageTimestamp,
         );
+        retryDiscardHistoryItemIds.add(id);
         setPendingHistoryItem({ type: 'gemini_content', text: afterText });
         newGeminiMessageBuffer = afterText;
       }
@@ -756,6 +775,7 @@ export const useGeminiStream = (
       eventValue: ThoughtSummary,
       currentThoughtBuffer: string,
       userMessageTimestamp: number,
+      retryDiscardHistoryItemIds: Set<number>,
     ): string => {
       if (turnCancelledRef.current) {
         return '';
@@ -778,7 +798,17 @@ export const useGeminiStream = (
       if (!isPendingThought) {
         // If there's a pending non-thought item, finalize it first
         if (pendingHistoryItemRef.current) {
-          addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+          const id = addItem(
+            pendingHistoryItemRef.current,
+            userMessageTimestamp,
+          );
+          if (
+            RETRY_DISCARD_HISTORY_ITEM_TYPES.has(
+              pendingHistoryItemRef.current.type,
+            )
+          ) {
+            retryDiscardHistoryItemIds.add(id);
+          }
         }
         setPendingHistoryItem({ type: 'gemini_thought', text: '' });
       }
@@ -801,13 +831,14 @@ export const useGeminiStream = (
       } else {
         const beforeText = newThoughtBuffer.substring(0, splitPoint);
         const afterText = newThoughtBuffer.substring(splitPoint);
-        addItem(
+        const id = addItem(
           {
             type: nextPendingType,
             text: beforeText,
           },
           userMessageTimestamp,
         );
+        retryDiscardHistoryItemIds.add(id);
         setPendingHistoryItem({
           type: 'gemini_thought_content',
           text: afterText,
@@ -922,25 +953,59 @@ export const useGeminiStream = (
   );
 
   const handleCitationEvent = useCallback(
-    (text: string, userMessageTimestamp: number) => {
+    (
+      text: string,
+      userMessageTimestamp: number,
+      retryDiscardHistoryItemIds: Set<number>,
+    ) => {
       if (!showCitations(settings)) {
         return;
       }
 
       if (pendingHistoryItemRef.current) {
-        addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+        const id = addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+        if (
+          RETRY_DISCARD_HISTORY_ITEM_TYPES.has(
+            pendingHistoryItemRef.current.type,
+          )
+        ) {
+          retryDiscardHistoryItemIds.add(id);
+        }
         setPendingHistoryItem(null);
       }
-      addItem({ type: MessageType.INFO, text }, userMessageTimestamp);
+      const id = addItem(
+        { type: MessageType.INFO, text },
+        userMessageTimestamp,
+      );
+      retryDiscardHistoryItemIds.add(id);
     },
     [addItem, pendingHistoryItemRef, setPendingHistoryItem, settings],
   );
 
   const handleFinishedEvent = useCallback(
-    (event: ServerGeminiFinishedEvent, userMessageTimestamp: number) => {
+    (
+      event: ServerGeminiFinishedEvent,
+      userMessageTimestamp: number,
+      retryDiscardHistoryItemIds: Set<number>,
+    ) => {
       const finishReason = event.value.reason;
       if (!finishReason) {
         return;
+      }
+
+      if (
+        finishReason !== FinishReason.MAX_TOKENS &&
+        pendingHistoryItemRef.current
+      ) {
+        const id = addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+        if (
+          RETRY_DISCARD_HISTORY_ITEM_TYPES.has(
+            pendingHistoryItemRef.current.type,
+          )
+        ) {
+          retryDiscardHistoryItemIds.add(id);
+        }
+        setPendingHistoryItem(null);
       }
 
       const finishReasonMessages: Record<FinishReason, string | undefined> = {
@@ -970,20 +1035,26 @@ export const useGeminiStream = (
 
       const message = finishReasonMessages[finishReason];
       if (message) {
-        addItem(
+        const id = addItem(
           {
             type: 'info',
             text: `⚠️  ${message}`,
           },
           userMessageTimestamp,
         );
+        retryDiscardHistoryItemIds.add(id);
       }
       // Only clear auto-retry countdown errors (those with active timer)
       if (retryCountdownTimerRef.current) {
         clearRetryCountdown();
       }
     },
-    [addItem, clearRetryCountdown],
+    [
+      addItem,
+      clearRetryCountdown,
+      pendingHistoryItemRef,
+      setPendingHistoryItem,
+    ],
   );
 
   const handleChatCompressionEvent = useCallback(
@@ -1130,6 +1201,8 @@ export const useGeminiStream = (
       let geminiMessageBuffer = '';
       let thoughtBuffer = '';
       const toolCallRequests: ToolCallRequestInfo[] = [];
+      const retryDiscardHistoryItemIds = new Set<number>();
+      let waitingForRetryAfterFinished = false;
       const bufferedEvents: BufferedStreamEvent[] = [];
       let flushTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -1169,6 +1242,7 @@ export const useGeminiStream = (
               mergedContent,
               geminiMessageBuffer,
               userMessageTimestamp,
+              retryDiscardHistoryItemIds,
             );
             continue;
           }
@@ -1192,6 +1266,7 @@ export const useGeminiStream = (
             mergedThought,
             thoughtBuffer,
             userMessageTimestamp,
+            retryDiscardHistoryItemIds,
           );
         }
       };
@@ -1211,6 +1286,13 @@ export const useGeminiStream = (
       try {
         for await (const event of stream) {
           dualOutput?.processEvent(event);
+          if (
+            waitingForRetryAfterFinished &&
+            event.type !== ServerGeminiEventType.Retry
+          ) {
+            retryDiscardHistoryItemIds.clear();
+            waitingForRetryAfterFinished = false;
+          }
           switch (event.type) {
             case ServerGeminiEventType.Thought:
               // If the thought has a subject, it's a discrete status update rather than
@@ -1268,11 +1350,19 @@ export const useGeminiStream = (
               handleFinishedEvent(
                 event as ServerGeminiFinishedEvent,
                 userMessageTimestamp,
+                retryDiscardHistoryItemIds,
               );
+              waitingForRetryAfterFinished = true;
+              geminiMessageBuffer = '';
+              thoughtBuffer = '';
               break;
             case ServerGeminiEventType.Citation:
               flushBufferedStreamEvents();
-              handleCitationEvent(event.value, userMessageTimestamp);
+              handleCitationEvent(
+                event.value,
+                userMessageTimestamp,
+                retryDiscardHistoryItemIds,
+              );
               break;
             case ServerGeminiEventType.LoopDetected:
               flushBufferedStreamEvents();
@@ -1281,6 +1371,7 @@ export const useGeminiStream = (
               loopDetectedRef.current = true;
               break;
             case ServerGeminiEventType.Retry:
+              waitingForRetryAfterFinished = false;
               // On fresh restart (escalation / rate-limit / invalid stream),
               // clear pending content and buffers to discard the failed attempt.
               // On continuation (recovery), keep the pending gemini item AND
@@ -1293,10 +1384,20 @@ export const useGeminiStream = (
                 if (pendingHistoryItemRef.current) {
                   setPendingHistoryItem(null);
                 }
+                setThought(null);
+                if (
+                  removeHistoryItemsById &&
+                  retryDiscardHistoryItemIds.size > 0
+                ) {
+                  removeHistoryItemsById([...retryDiscardHistoryItemIds]);
+                  onEditorClose();
+                }
+                retryDiscardHistoryItemIds.clear();
                 geminiMessageBuffer = '';
                 thoughtBuffer = '';
               } else {
                 flushBufferedStreamEvents();
+                retryDiscardHistoryItemIds.clear();
               }
               // Always discard tool call requests from the truncated/failed
               // attempt to prevent duplicate execution after escalation or
@@ -1377,6 +1478,8 @@ export const useGeminiStream = (
       handleStopHookLoopEvent,
       addItem,
       dualOutput,
+      onEditorClose,
+      removeHistoryItemsById,
     ],
   );
 

--- a/packages/cli/src/ui/hooks/useHistoryManager.test.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.test.ts
@@ -139,6 +139,35 @@ describe('useHistoryManager', () => {
     expect(result.current.history).toEqual([]);
   });
 
+  it('should remove items by ID', () => {
+    const { result } = renderHook(() => useHistory());
+    const timestamp = Date.now();
+    const itemData1: Omit<HistoryItem, 'id'> = {
+      type: 'user',
+      text: 'Keep me',
+    };
+    const itemData2: Omit<HistoryItem, 'id'> = {
+      type: 'gemini',
+      text: 'Remove me',
+    };
+
+    let id1!: number;
+    let id2!: number;
+    act(() => {
+      id1 = result.current.addItem(itemData1, timestamp);
+      id2 = result.current.addItem(itemData2, timestamp + 1);
+    });
+
+    expect(result.current.history).toHaveLength(2);
+
+    act(() => {
+      result.current.removeItemsById([id2]);
+    });
+
+    expect(result.current.history).toHaveLength(1);
+    expect(result.current.history[0]).toEqual({ ...itemData1, id: id1 });
+  });
+
   it('should not add consecutive duplicate user messages', () => {
     const { result } = renderHook(() => useHistory());
     const timestamp = Date.now();

--- a/packages/cli/src/ui/hooks/useHistoryManager.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.ts
@@ -19,6 +19,7 @@ export interface UseHistoryManagerReturn {
     id: number,
     updates: Partial<Omit<HistoryItem, 'id'>> | HistoryItemUpdater,
   ) => void;
+  removeItemsById: (ids: Iterable<number>) => void;
   clearItems: () => void;
   loadHistory: (newHistory: HistoryItem[]) => void;
 }
@@ -95,6 +96,16 @@ export function useHistory(): UseHistoryManagerReturn {
     [],
   );
 
+  const removeItemsById = useCallback((ids: Iterable<number>) => {
+    const idsToRemove = new Set(ids);
+    if (idsToRemove.size === 0) {
+      return;
+    }
+    setHistory((prevHistory) =>
+      prevHistory.filter((item) => !idsToRemove.has(item.id)),
+    );
+  }, []);
+
   // Clears the entire history state and resets the ID counter.
   const clearItems = useCallback(() => {
     setHistory([]);
@@ -106,9 +117,10 @@ export function useHistory(): UseHistoryManagerReturn {
       history,
       addItem,
       updateItem,
+      removeItemsById,
       clearItems,
       loadHistory,
     }),
-    [history, addItem, updateItem, clearItems, loadHistory],
+    [history, addItem, updateItem, removeItemsById, clearItems, loadHistory],
   );
 }


### PR DESCRIPTION
Fixes #1591.

Core emits GeminiEventType.Retry when a streaming attempt is retried due to invalid/partial output. The interactive UI previously ignored this event, so partial output from the failed attempt remained in the Ink <Static> history and the retried attempt re-streamed the same text, causing duplicated messages.

Changes:
- Add removeItemsById to the history manager.
- Track streamed history item ids for the current attempt and remove them on Retry.
- Clear pending buffers/thought state and refresh the static UI.
- Add regression tests for Retry handling.

Tests:
- cd packages/cli && npx vitest run src/ui/hooks/useGeminiStream.test.tsx src/ui/hooks/useHistoryManager.test.ts src/ui/App.test.tsx