### PR TITLE
feat(query): add support for resuming sessions with session ID

### DIFF
--- a/packages/sdk-typescript/src/query/Query.ts
+++ b/packages/sdk-typescript/src/query/Query.ts
@@ -91,7 +91,7 @@ export class Query implements AsyncIterable<SDKMessage> {
   ) {
     this.transport = transport;
     this.options = options;
-    this.sessionId = randomUUID();
+    this.sessionId = options.resume ?? randomUUID();
     this.inputStream = new Stream<SDKMessage>();
     this.abortController = options.abortController ?? new AbortController();
     this.isSingleTurn = singleTurn;

--- a/packages/sdk-typescript/src/query/createQuery.ts
+++ b/packages/sdk-typescript/src/query/createQuery.ts
@@ -57,6 +57,7 @@ export function query({
     allowedTools: options.allowedTools,
     authType: options.authType,
     includePartialMessages: options.includePartialMessages,
+    resume: options.resume,
   });
 
   const queryOptions: QueryOptions = {

--- a/packages/sdk-typescript/src/transport/ProcessTransport.ts
+++ b/packages/sdk-typescript/src/transport/ProcessTransport.ts
@@ -178,6 +178,10 @@ export class ProcessTransport implements Transport {
       args.push('--include-partial-messages');
     }
 
+    if (this.options.resume) {
+      args.push('--resume', this.options.resume);
+    }
+
     return args;
   }
 

--- a/packages/sdk-typescript/src/types/queryOptionsSchema.ts
+++ b/packages/sdk-typescript/src/types/queryOptionsSchema.ts
@@ -164,6 +164,7 @@ export const QueryOptionsSchema = z
       )
       .optional(),
     includePartialMessages: z.boolean().optional(),
+    resume: z.string().optional(),
     timeout: TimeoutConfigSchema.optional(),
   })
   .strict();

--- a/packages/sdk-typescript/src/types/types.ts
+++ b/packages/sdk-typescript/src/types/types.ts
@@ -25,6 +25,7 @@ export type TransportOptions = {
   allowedTools?: string[];
   authType?: string;
   includePartialMessages?: boolean;
+  resume?: string;
 };
 
 type ToolInput = Record<string, unknown>;
@@ -401,6 +402,13 @@ export interface QueryOptions {
    * @default false
    */
   includePartialMessages?: boolean;
+
+  /**
+   * Resume a previous session by providing its session ID.
+   * This is equivalent to using the `--resume` flag in the Qwen CLI.
+   * @example '123e4567-e89b-12d3-a456-426614174000'
+   */
+  resume?: string;
 
   /**
    * Timeout configuration for various SDK operations.

--- a/packages/sdk-typescript/test/unit/ProcessTransport.test.ts
+++ b/packages/sdk-typescript/test/unit/ProcessTransport.test.ts
@@ -191,6 +191,32 @@ describe('ProcessTransport', () => {
       );
     });
 
+    it('should include --resume argument when provided', () => {
+      mockPrepareSpawnInfo.mockReturnValue({
+        command: 'qwen',
+        args: [],
+        type: 'native',
+        originalInput: 'qwen',
+      });
+      mockSpawn.mockReturnValue(mockChildProcess);
+
+      const options: TransportOptions = {
+        pathToQwenExecutable: 'qwen',
+        resume: '123e4567-e89b-12d3-a456-426614174000',
+      };
+
+      new ProcessTransport(options);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'qwen',
+        expect.arrayContaining([
+          '--resume',
+          '123e4567-e89b-12d3-a456-426614174000',
+        ]),
+        expect.any(Object),
+      );
+    });
+
     it('should throw if aborted before initialization', () => {
       mockPrepareSpawnInfo.mockReturnValue({
         command: 'qwen',

--- a/packages/sdk-typescript/test/unit/Query.test.ts
+++ b/packages/sdk-typescript/test/unit/Query.test.ts
@@ -329,6 +329,19 @@ describe('Query', () => {
       await transport2.close();
     });
 
+    it('should use resume parameter as session ID if provided', async () => {
+      const resumeId = '123e4567-e89b-12d3-a456-426614174000';
+      const query = new Query(transport, {
+        cwd: '/test',
+        resume: resumeId,
+      });
+
+      expect(query.getSessionId()).toBe(resumeId);
+
+      await respondToInitialize(transport, query);
+      await query.close();
+    });
+
     it('should handle initialization errors', async () => {
       const query = new Query(transport, {
         cwd: '/test',


### PR DESCRIPTION
# TLDR

This pull request adds support for resuming sessions with a session ID in the TypeScript SDK. Users can now provide a `resume` option to continue a previous session, which is equivalent to using the `--resume` flag in the Qwen CLI.

## Dive Deeper

The changes implement session resumption functionality by:

1. Adding a `resume` property to the `QueryOptions` schema and transport options
2. Modifying the `Query` class to use the provided session ID when resuming, instead of generating a new UUID
3. Updating the `ProcessTransport` to pass the `--resume` argument to the underlying Qwen executable
4. Including unit tests to verify the functionality works correctly

This enhancement allows users to continue conversations or operations from a previously saved session state, improving continuity and user experience.

## Reviewer Test Plan

1. Pull the branch and run the unit tests to ensure they pass: `npm test`
2. Check that the new `resume` functionality works by creating a query with a session ID and verifying it uses that ID instead of generating a new one
3. Verify that the `--resume` flag is properly passed to the underlying Qwen executable when using ProcessTransport
4. Test both scenarios: with and without the resume option to ensure backward compatibility

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

This PR introduces a new feature for session resumption that aligns with the Qwen CLI's `--resume` functionality.