### PR TITLE
feat(sdk): add resume, continue options and extend authType support

### DIFF
--- a/packages/sdk-typescript/src/transport/ProcessTransport.ts
+++ b/packages/sdk-typescript/src/transport/ProcessTransport.ts
@@ -180,6 +180,8 @@ export class ProcessTransport implements Transport {
 
     if (this.options.resume) {
       args.push('--resume', this.options.resume);
+    } else if (this.options.continue) {
+      args.push('--continue');
     }
 
     return args;

--- a/packages/sdk-typescript/src/types/protocol.ts
+++ b/packages/sdk-typescript/src/types/protocol.ts
@@ -233,6 +233,17 @@ export interface SDKPartialAssistantMessage {
 export type PermissionMode = 'default' | 'plan' | 'auto-edit' | 'yolo';
 
 /**
+ * Authentication types supported by the CLI.
+ * Aligns with CLI's --auth-type parameter.
+ */
+export type AuthType =
+  | 'openai'
+  | 'anthropic'
+  | 'qwen-oauth'
+  | 'gemini'
+  | 'vertex-ai';
+
+/**
  * TODO: Align with `ToolCallConfirmationDetails`
  */
 export interface PermissionSuggestion {

--- a/packages/sdk-typescript/src/types/queryOptionsSchema.ts
+++ b/packages/sdk-typescript/src/types/queryOptionsSchema.ts
@@ -148,7 +148,9 @@ export const QueryOptionsSchema = z
     coreTools: z.array(z.string()).optional(),
     excludeTools: z.array(z.string()).optional(),
     allowedTools: z.array(z.string()).optional(),
-    authType: z.enum(['openai', 'qwen-oauth']).optional(),
+    authType: z
+      .enum(['openai', 'anthropic', 'qwen-oauth', 'gemini', 'vertex-ai'])
+      .optional(),
     agents: z
       .array(
         z.custom<SubagentConfig>(

--- a/packages/sdk-typescript/src/types/types.ts
+++ b/packages/sdk-typescript/src/types/types.ts
@@ -3,10 +3,11 @@ import type {
   PermissionSuggestion,
   SubagentConfig,
   SDKMcpServerConfig,
+  AuthType,
 } from './protocol.js';
 import type { SpawnInfo } from '../utils/cliPath.js';
 
-export type { PermissionMode };
+export type { PermissionMode, AuthType };
 
 export type TransportOptions = {
   pathToQwenExecutable?: string;
@@ -23,8 +24,19 @@ export type TransportOptions = {
   coreTools?: string[];
   excludeTools?: string[];
   allowedTools?: string[];
-  authType?: string;
+  authType?: AuthType;
   includePartialMessages?: boolean;
+  /**
+   * Resume the most recent session for the current project.
+   * Equivalent to CLI's --continue flag.
+   * @default false
+   */
+  continue?: boolean;
+  /**
+   * Resume a specific session by its ID.
+   * Equivalent to CLI's --resume flag.
+   * When provided, takes precedence over `continue`.
+   */
   resume?: string;
 };
 
@@ -385,7 +397,7 @@ export interface QueryOptions {
    * Though we support 'qwen-oauth', it's not recommended to use it in the SDK.
    * Because the credentials are stored in `~/.qwen` and may need to refresh periodically.
    */
-  authType?: 'openai' | 'qwen-oauth';
+  authType?: AuthType;
 
   /**
    * Configuration for subagents that can be invoked during the session.


### PR DESCRIPTION
## TLDR

Extends the TypeScript SDK to support the `--continue` flag for resuming the most recent session and expands `authType` to support all CLI authentication options (`use_openai`, `use_anthropic`, `qwen_oauth`, `use_gemini`, `use_vertex_ai`).

## Dive Deeper

This change adds two new transport options to the TypeScript SDK:

1. **`continue` option**: A boolean flag that, when set to `true`, passes `--continue` to the CLI to resume the most recent session for the current project. This is mutually exclusive with the existing `resume` option (which resumes a specific session by ID).

2. **Extended `authType` support**: The SDK previously only supported `'openai'` and `'qwen-oauth'` auth types. This PR fixes and adds support for all CLI authentication types:
   - `'openai'`
   - `'anthropic'`
   - `'qwen-oauth'`
   - `'gemini'`
   - `'vertex-ai'`

   These auth types are designed to be used together with the `--model` option to configure model providers. Setting both `--auth-type` and `--model` allows users to specify which provider and model to use for the session.

A new `AuthType` type is exported from `protocol.ts` and used consistently across `TransportOptions`, `QueryOptions`, and the Zod schema for validation.

## Reviewer Test Plan

1. Verify the `continue` option works:
   ```typescript
   const transport = new ProcessTransport({
     continue: true,
   });
   ```
   This should pass `--continue` to the CLI process.

2. Verify `authType` validation accepts all new values:
   ```typescript
   const queryOptions = {
     authType: 'anthropic', // or any other supported value: 'openai', 'qwen-oauth', 'gemini', 'vertex-ai'
   };
   ```

3. Confirm TypeScript compilation passes with `npm run build` or `tsc --noEmit`.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
