### PR TITLE
chore: 降低 Qwen OAuth 免费配额从每天 2000 次到 1000 次

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,6 @@
 
 ## 0.0.5
 
-- Added Qwen OAuth login and up to 2,000 free requests per day.
+- Added Qwen OAuth login and up to 1,000 free requests per day.
 - Synced upstream `gemini-cli` to v0.1.17.
 - Added the `systemPromptMappings` configuration option.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Qwen Code is an open-source AI agent for the terminal, optimized for [Qwen3-Code
 
 ## Why Qwen Code?
 
-- **OpenAI-compatible, OAuth free tier**: use an OpenAI-compatible API, or sign in with Qwen OAuth to get 2,000 free requests/day.
+- **OpenAI-compatible, OAuth free tier**: use an OpenAI-compatible API, or sign in with Qwen OAuth to get 1,000 free requests/day.
 - **Open-source, co-evolving**: both the framework and the Qwen3-Coder model are open-source—and they ship and evolve together.
 - **Agentic workflow, feature-rich**: rich built-in tools (Skills, SubAgents, Plan Mode) for a full agentic workflow and a Claude Code-like experience.
 - **Terminal-first, IDE-friendly**: built for developers who live in the command line, with optional integration for VS Code, Zed, and JetBrains IDEs.

--- a/docs/developers/tools/web-search.md
+++ b/docs/developers/tools/web-search.md
@@ -8,7 +8,7 @@ Use `web_search` to perform a web search and get information from the internet. 
 
 ### Supported Providers
 
-1. **DashScope** (Official, Free) - Automatically available for Qwen OAuth users (200 requests/minute, 2000 requests/day)
+1. **DashScope** (Official, Free) - Automatically available for Qwen OAuth users (200 requests/minute, 1000 requests/day)
 2. **Tavily** - High-quality search API with built-in answer generation
 3. **Google Custom Search** - Google's Custom Search JSON API
 
@@ -135,7 +135,7 @@ web_search(query="best practices for React 19", provider="dashscope")
 - **Cost:** Free
 - **Authentication:** Automatically available when using Qwen OAuth authentication
 - **Configuration:** No API key required, automatically added to provider list for Qwen OAuth users
-- **Quota:** 200 requests/minute, 2000 requests/day
+- **Quota:** 200 requests/minute, 1000 requests/day
 - **Best for:** General queries, always available as fallback for Qwen OAuth users
 - **Auto-registration:** If you're using Qwen OAuth, DashScope is automatically added to your provider list even if you don't configure it explicitly
 

--- a/docs/users/configuration/auth.md
+++ b/docs/users/configuration/auth.md
@@ -14,7 +14,7 @@ Use this if you want the simplest setup and you're using Qwen models.
 - **How it works**: on first start, Qwen Code opens a browser login page. After you finish, credentials are cached locally so you usually won't need to log in again.
 - **Requirements**: a `qwen.ai` account + internet access (at least for the first login).
 - **Benefits**: no API key management, automatic credential refresh.
-- **Cost & quota**: free, with a quota of **60 requests/minute** and **2,000 requests/day**.
+- **Cost & quota**: free, with a quota of **60 requests/minute** and **1,000 requests/day**.
 
 Start the CLI and follow the browser flow:
 


### PR DESCRIPTION
## 概述

为了让更多用户能够使用 Qwen Code，本 PR 将 Qwen OAuth 的免费额度从每天 2000 次降低到每天 1000 次。

## 变更内容

本 PR 更新了以下文档中的配额信息：

- **CHANGELOG.md**: 更新版本说明中的配额描述
- **README.md**: 更新功能介绍中的免费额度说明
- **docs/developers/tools/web-search.md**: 更新 Web Search 工具文档中的 DashScope 配额
- **docs/users/configuration/auth.md**: 更新认证文档中的配额说明

## 变更详情

将所有提及 Qwen OAuth 免费额度的文档从 **2000 requests/day** 更新为 **1000 requests/day**。

## 理由

降低免费配额可以让更多的用户使用 Qwen Code，特别是在用户增长阶段，这样可以更公平地分配资源，避免少数用户占用过多免费配额。
