### PR TITLE
chore: Reduce Qwen OAuth free quota from 2000 to 1000 requests per day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,6 @@
 
 ## 0.0.5
 
-- Added Qwen OAuth login and up to 2,000 free requests per day.
+- Added Qwen OAuth login and up to 1,000 free requests per day.
 - Synced upstream `gemini-cli` to v0.1.17.
 - Added the `systemPromptMappings` configuration option.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Qwen Code is an open-source AI agent for the terminal, optimized for [Qwen3-Code
 
 ## Why Qwen Code?
 
-- **OpenAI-compatible, OAuth free tier**: use an OpenAI-compatible API, or sign in with Qwen OAuth to get 2,000 free requests/day.
+- **OpenAI-compatible, OAuth free tier**: use an OpenAI-compatible API, or sign in with Qwen OAuth to get 1,000 free requests/day.
 - **Open-source, co-evolving**: both the framework and the Qwen3-Coder model are open-source—and they ship and evolve together.
 - **Agentic workflow, feature-rich**: rich built-in tools (Skills, SubAgents, Plan Mode) for a full agentic workflow and a Claude Code-like experience.
 - **Terminal-first, IDE-friendly**: built for developers who live in the command line, with optional integration for VS Code, Zed, and JetBrains IDEs.

--- a/docs/developers/tools/web-search.md
+++ b/docs/developers/tools/web-search.md
@@ -8,7 +8,7 @@ Use `web_search` to perform a web search and get information from the internet. 
 
 ### Supported Providers
 
-1. **DashScope** (Official, Free) - Automatically available for Qwen OAuth users (200 requests/minute, 2000 requests/day)
+1. **DashScope** (Official, Free) - Automatically available for Qwen OAuth users (200 requests/minute, 1000 requests/day)
 2. **Tavily** - High-quality search API with built-in answer generation
 3. **Google Custom Search** - Google's Custom Search JSON API
 
@@ -135,7 +135,7 @@ web_search(query="best practices for React 19", provider="dashscope")
 - **Cost:** Free
 - **Authentication:** Automatically available when using Qwen OAuth authentication
 - **Configuration:** No API key required, automatically added to provider list for Qwen OAuth users
-- **Quota:** 200 requests/minute, 2000 requests/day
+- **Quota:** 200 requests/minute, 1000 requests/day
 - **Best for:** General queries, always available as fallback for Qwen OAuth users
 - **Auto-registration:** If you're using Qwen OAuth, DashScope is automatically added to your provider list even if you don't configure it explicitly
 

--- a/docs/users/configuration/auth.md
+++ b/docs/users/configuration/auth.md
@@ -14,7 +14,7 @@ Use this if you want the simplest setup and you're using Qwen models.
 - **How it works**: on first start, Qwen Code opens a browser login page. After you finish, credentials are cached locally so you usually won't need to log in again.
 - **Requirements**: a `qwen.ai` account + internet access (at least for the first login).
 - **Benefits**: no API key management, automatic credential refresh.
-- **Cost & quota**: free, with a quota of **60 requests/minute** and **2,000 requests/day**.
+- **Cost & quota**: free, with a quota of **60 requests/minute** and **1,000 requests/day**.
 
 Start the CLI and follow the browser flow:
 


### PR DESCRIPTION
## Summary

Reduce Qwen OAuth free quota from 2,000 to 1,000 requests per day to allow more users to access Qwen Code.

## Changes

This PR updates the quota information in the following documentation:

- **CHANGELOG.md**: Updated quota description in version notes
- **README.md**: Updated free tier description in feature overview
- **docs/developers/tools/web-search.md**: Updated DashScope quota in Web Search tool documentation
- **docs/users/configuration/auth.md**: Updated quota description in authentication documentation

## Details

Changed all references to Qwen OAuth free quota from **2,000 requests/day** to **1,000 requests/day**.

## Rationale

Lowering the free quota allows more users to access Qwen Code, especially during user growth phases. This enables fairer resource distribution and prevents a small number of users from consuming a disproportionate share of the free quota.
