### PR TITLE
Refactor the SDK release workflow

### DIFF
--- a/.github/actions/generate-release-notes/action.yml
+++ b/.github/actions/generate-release-notes/action.yml
@@ -1,0 +1,101 @@
+# Copyright 2025 Qwen Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Generate SDK Release Notes'
+description: 'Generate release notes for an SDK release based on git history.'
+
+inputs:
+  release-tag:
+    description: 'The release tag (e.g., v0.1.11)'
+    required: true
+  previous-release-tag:
+    description: 'The previous release tag for changelog diff'
+    required: true
+  ref:
+    description: 'The git ref being released'
+    required: true
+  cli-version:
+    description: 'The bundled CLI version'
+    required: true
+  cli-source-mode:
+    description: 'CLI source mode (npm_latest or build_from_source)'
+    required: true
+  tag-prefix:
+    description: 'Git tag prefix for SDK releases'
+    required: false
+    default: 'sdk-typescript-'
+  path-filter:
+    description: 'Git path filter for changelog generation'
+    required: false
+    default: 'packages/sdk-typescript'
+
+outputs:
+  notes-file:
+    description: 'Path to the generated release notes file'
+    value: '${{ steps.generate.outputs.NOTES_FILE }}'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Generate release notes'
+      id: 'generate'
+      shell: 'bash'
+      env:
+        RELEASE_TAG: '${{ inputs.release-tag }}'
+        PREVIOUS_RELEASE_TAG: '${{ inputs.previous-release-tag }}'
+        REF: '${{ inputs.ref }}'
+        CLI_VERSION: '${{ inputs.cli-version }}'
+        CLI_SOURCE_MODE: '${{ inputs.cli-source-mode }}'
+        TAG_PREFIX: '${{ inputs.tag-prefix }}'
+        PATH_FILTER: '${{ inputs.path-filter }}'
+      run: |
+        set -euo pipefail
+        NOTES_FILE="${RUNNER_TEMP}/sdk-release-notes.md"
+
+        if [[ "${CLI_SOURCE_MODE}" == "npm_latest" ]]; then
+          CLI_SOURCE_DESC="latest stable CLI from npm"
+        else
+          CLI_SOURCE_DESC="CLI built from source (same branch/ref as SDK)"
+        fi
+
+        {
+          echo "## Bundled CLI Version"
+          echo ""
+          echo "This SDK release bundles CLI version: \`${CLI_VERSION}\`"
+          echo ""
+          echo "Source: ${CLI_SOURCE_DESC}"
+          echo ""
+          echo "---"
+          echo ""
+          echo "## SDK Changes"
+          echo ""
+        } > "${NOTES_FILE}"
+
+        START_TAG="${TAG_PREFIX}${PREVIOUS_RELEASE_TAG}"
+        if git rev-parse -q --verify "refs/tags/${START_TAG}" >/dev/null; then
+          RANGE="${START_TAG}..${REF}"
+          CHANGES=$(git log "${RANGE}" --pretty=format:"- %s (%h)" --reverse -- "${PATH_FILTER}")
+        else
+          echo "_Previous SDK tag not found; listing recent SDK changes from ${REF}_." >> "${NOTES_FILE}"
+          echo "" >> "${NOTES_FILE}"
+          CHANGES=$(git log "${REF}" --pretty=format:"- %s (%h)" --reverse --max-count=100 -- "${PATH_FILTER}")
+        fi
+
+        if [[ -z "${CHANGES}" ]]; then
+          echo "No SDK changes detected." >> "${NOTES_FILE}"
+        else
+          echo "${CHANGES}" >> "${NOTES_FILE}"
+        fi
+
+        echo "NOTES_FILE=${NOTES_FILE}" >> "${GITHUB_OUTPUT}"

--- a/.github/actions/post-release-pr/action.yml
+++ b/.github/actions/post-release-pr/action.yml
@@ -1,0 +1,125 @@
+# Copyright 2025 Qwen Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Post-Release PR'
+description: 'Create a release branch, bump version, and open an auto-merge PR.'
+
+inputs:
+  release-version:
+    description: 'The release version to set in package.json'
+    required: true
+  release-tag:
+    description: 'The release tag (used for branch name and commit message)'
+    required: true
+  workspace-package:
+    description: 'npm workspace package name (e.g., @qwen-code/sdk)'
+    required: true
+  branch-prefix:
+    description: 'Prefix for the release branch name'
+    required: false
+    default: 'release/sdk-typescript'
+  base-branch:
+    description: 'The base branch to merge into'
+    required: false
+    default: 'main'
+  github-token:
+    description: 'PAT with permissions to create branches, PRs, and enable auto-merge'
+    required: true
+
+outputs:
+  pr-url:
+    description: 'URL of the created pull request'
+    value: '${{ steps.create_pr.outputs.PR_URL }}'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Configure Git User'
+      shell: 'bash'
+      run: |
+        set -euo pipefail
+        git config user.name "github-actions[bot]"
+        git config user.email "github-actions[bot]@users.noreply.github.com"
+
+    - name: 'Set package version'
+      shell: 'bash'
+      env:
+        RELEASE_VERSION: '${{ inputs.release-version }}'
+        WORKSPACE_PACKAGE: '${{ inputs.workspace-package }}'
+      run: |
+        set -euo pipefail
+        npm version -w "${WORKSPACE_PACKAGE}" "${RELEASE_VERSION}" --no-git-tag-version --allow-same-version
+
+    - name: 'Create and switch to release branch'
+      shell: 'bash'
+      env:
+        BRANCH_PREFIX: '${{ inputs.branch-prefix }}'
+        RELEASE_TAG: '${{ inputs.release-tag }}'
+      run: |
+        set -euo pipefail
+        BRANCH_NAME="${BRANCH_PREFIX}/${RELEASE_TAG}"
+        if git ls-remote --exit-code --heads origin "${BRANCH_NAME}" >/dev/null 2>&1; then
+          echo "::warning::Branch ${BRANCH_NAME} already exists on remote, force-recreating."
+          git switch -C "${BRANCH_NAME}"
+        else
+          git switch -c "${BRANCH_NAME}"
+        fi
+        echo "BRANCH_NAME=${BRANCH_NAME}" >> "${GITHUB_ENV}"
+
+    - name: 'Commit and push package version'
+      shell: 'bash'
+      env:
+        RELEASE_TAG: '${{ inputs.release-tag }}'
+        WORKSPACE_PACKAGE: '${{ inputs.workspace-package }}'
+      run: |
+        set -euo pipefail
+        git add -u
+        if git diff --staged --quiet; then
+          echo "No version changes to commit"
+        else
+          git commit -m "chore(release): ${WORKSPACE_PACKAGE} ${RELEASE_TAG}"
+        fi
+        git push --set-upstream origin "${BRANCH_NAME}" --force --follow-tags
+
+    - name: 'Create PR to merge release branch'
+      id: 'create_pr'
+      shell: 'bash'
+      env:
+        GITHUB_TOKEN: '${{ inputs.github-token }}'
+        RELEASE_BRANCH: '${{ env.BRANCH_NAME }}'
+        RELEASE_TAG: '${{ inputs.release-tag }}'
+        BASE_BRANCH: '${{ inputs.base-branch }}'
+        WORKSPACE_PACKAGE: '${{ inputs.workspace-package }}'
+      run: |
+        set -euo pipefail
+
+        pr_url="$(gh pr list --head "${RELEASE_BRANCH}" --base "${BASE_BRANCH}" --json url --jq '.[0].url')"
+        if [[ -z "${pr_url}" ]]; then
+          pr_url="$(gh pr create \
+            --base "${BASE_BRANCH}" \
+            --head "${RELEASE_BRANCH}" \
+            --title "chore(release): ${WORKSPACE_PACKAGE} ${RELEASE_TAG}" \
+            --body "Automated release PR for ${WORKSPACE_PACKAGE} ${RELEASE_TAG}.")"
+        fi
+
+        echo "PR_URL=${pr_url}" >> "${GITHUB_OUTPUT}"
+
+    - name: 'Enable auto-merge for release PR'
+      shell: 'bash'
+      env:
+        GITHUB_TOKEN: '${{ inputs.github-token }}'
+        PR_URL: '${{ steps.create_pr.outputs.PR_URL }}'
+      run: |
+        set -euo pipefail
+        gh pr merge "${PR_URL}" --merge --auto --delete-branch

--- a/.github/actions/setup-sdk-env/action.yml
+++ b/.github/actions/setup-sdk-env/action.yml
@@ -1,0 +1,43 @@
+# Copyright 2025 Qwen Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Setup SDK Environment'
+description: 'Setup Node.js and optionally install dependencies for SDK release workflows.'
+
+inputs:
+  node-version:
+    description: 'Explicit Node.js version. If empty, reads from .nvmrc.'
+    required: false
+    default: ''
+  install-deps:
+    description: 'Whether to run npm ci to install dependencies.'
+    required: false
+    default: 'true'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Setup Node.js'
+      uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+      with:
+        node-version: '${{ inputs.node-version }}'
+        node-version-file: "${{ inputs.node-version == '' && '.nvmrc' || '' }}"
+        cache: 'npm'
+        registry-url: 'https://registry.npmjs.org'
+        scope: '@qwen-code'
+
+    - name: 'Install Dependencies'
+      if: "inputs.install-deps == 'true'"
+      shell: 'bash'
+      run: 'npm ci'

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -174,7 +174,7 @@ jobs:
   # Phase 2a: Build CLI - Download from npm or build from source
   # =============================================================================
   build-cli:
-    name: 'Build CLI (${{ needs.prepare.outputs.CLI_SOURCE_MODE }})'
+    name: 'Build CLI'
     runs-on: 'ubuntu-latest'
     needs: 'prepare'
     if: "github.repository == 'QwenLM/qwen-code'"
@@ -387,7 +387,7 @@ jobs:
   # Phase 4b: Integration Tests (Matrix)
   # =============================================================================
   test-integration:
-    name: 'Integration Test (${{ matrix.os }}, Node ${{ matrix.node-version }}, ${{ matrix.sandbox }})'
+    name: 'Integration Tests'
     runs-on: '${{ matrix.os }}'
     needs: ['prepare', 'bundle-cli-into-sdk', 'test-unit']
     if: |

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -41,8 +41,11 @@ on:
         type: 'boolean'
         default: false
 
+permissions:
+  contents: 'read'
+
 concurrency:
-  group: '${{ github.workflow }}-${{ github.event.inputs.ref || github.sha }}'
+  group: '${{ github.workflow }}-${{ github.event.inputs.ref || github.sha }}-${{ github.event.inputs.create_nightly_release }}-${{ github.event.inputs.create_preview_release }}'
   cancel-in-progress: "${{ github.event.inputs.create_nightly_release == 'true' || github.event.inputs.create_preview_release == 'true' }}"
 
 jobs:
@@ -95,17 +98,19 @@ jobs:
           fi
           echo "is_dry_run=${is_dry_run}" >> "${GITHUB_OUTPUT}"
 
-      - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@qwen-code'
+      - name: 'Validate force_skip_tests for stable releases'
+        env:
+          IS_NIGHTLY: '${{ steps.vars.outputs.is_nightly }}'
+          IS_PREVIEW: '${{ steps.vars.outputs.is_preview }}'
+          FORCE_SKIP_TESTS: '${{ github.event.inputs.force_skip_tests }}'
+        run: |
+          set -euo pipefail
+          if [[ "${IS_NIGHTLY}" == "false" && "${IS_PREVIEW}" == "false" && "${FORCE_SKIP_TESTS}" == "true" ]]; then
+            echo "::warning::force_skip_tests is enabled for a stable release. Tests SHOULD be run for production releases."
+          fi
 
-      - name: 'Install Dependencies'
-        run: |-
-          npm ci
+      - name: 'Setup SDK Environment'
+        uses: './.github/actions/setup-sdk-env'
 
       - name: 'Get the version'
         id: 'version'
@@ -132,13 +137,11 @@ jobs:
           NPM_TAG=$(echo "$VERSION_JSON" | jq -r .npmTag)
           PREVIOUS_RELEASE_TAG=$(echo "$VERSION_JSON" | jq -r .previousReleaseTag)
 
-          # 输出到 GITHUB_OUTPUT
           echo "RELEASE_TAG=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
           echo "RELEASE_VERSION=${RELEASE_VERSION}" >> "$GITHUB_OUTPUT"
           echo "NPM_TAG=${NPM_TAG}" >> "$GITHUB_OUTPUT"
           echo "PREVIOUS_RELEASE_TAG=${PREVIOUS_RELEASE_TAG}" >> "$GITHUB_OUTPUT"
 
-          # 打印版本信息到日志
           echo "========================================"
           echo "SDK Release Version Info"
           echo "========================================"
@@ -185,16 +188,8 @@ jobs:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 
-      - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@qwen-code'
-
-      - name: 'Install Dependencies'
-        run: 'npm ci'
+      - name: 'Setup SDK Environment'
+        uses: './.github/actions/setup-sdk-env'
 
       # ----- CLI from npm -----
       - name: 'Get CLI version from npm'
@@ -231,11 +226,11 @@ jobs:
 
       - name: 'Upload CLI package artifact'
         if: "needs.prepare.outputs.CLI_SOURCE_MODE == 'npm_latest'"
-        uses: 'actions/upload-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/upload-artifact@v4
+        uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
           name: 'cli-bundle'
           path: '${{ steps.cli_download.outputs.CLI_TMP_DIR }}/package'
-          retention-days: 1
+          retention-days: 3
 
       # ----- CLI from source -----
       - name: 'Build CLI from source'
@@ -260,14 +255,14 @@ jobs:
 
       - name: 'Upload CLI dist artifact'
         if: "needs.prepare.outputs.CLI_SOURCE_MODE == 'build_from_source'"
-        uses: 'actions/upload-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/upload-artifact@v4
+        uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
           name: 'cli-bundle'
           path: |
             dist/cli.js
             dist/vendor/
             dist/locales/
-          retention-days: 1
+          retention-days: 3
 
   # =============================================================================
   # Phase 2b: Build SDK - Compile TypeScript SDK
@@ -285,16 +280,8 @@ jobs:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 
-      - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@qwen-code'
-
-      - name: 'Install Dependencies'
-        run: 'npm ci'
+      - name: 'Setup SDK Environment'
+        uses: './.github/actions/setup-sdk-env'
 
       - name: 'Set SDK package version'
         env:
@@ -308,11 +295,11 @@ jobs:
         run: 'npm run build'
 
       - name: 'Upload SDK dist artifact'
-        uses: 'actions/upload-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/upload-artifact@v4
+        uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
           name: 'sdk-dist'
           path: 'packages/sdk-typescript/dist/'
-          retention-days: 1
+          retention-days: 3
 
   # =============================================================================
   # Phase 3: Bundle - Combine CLI into SDK
@@ -330,25 +317,17 @@ jobs:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 
-      - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@qwen-code'
-
-      - name: 'Install Dependencies'
-        run: 'npm ci'
+      - name: 'Setup SDK Environment'
+        uses: './.github/actions/setup-sdk-env'
 
       - name: 'Download CLI artifact'
-        uses: 'actions/download-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/download-artifact@v4
+        uses: 'actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093' # ratchet:actions/download-artifact@v4
         with:
           name: 'cli-bundle'
           path: 'cli-bundle/'
 
       - name: 'Download SDK artifact'
-        uses: 'actions/download-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/download-artifact@v4
+        uses: 'actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093' # ratchet:actions/download-artifact@v4
         with:
           name: 'sdk-dist'
           path: 'packages/sdk-typescript/dist/'
@@ -370,18 +349,15 @@ jobs:
           fi
 
       - name: 'Upload bundled SDK artifact'
-        uses: 'actions/upload-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/upload-artifact@v4
+        uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
           name: 'sdk-with-cli'
           path: 'packages/sdk-typescript/dist/'
-          retention-days: 1
+          retention-days: 3
 
   # =============================================================================
   # Phase 4a: Unit Tests
   # =============================================================================
-  # SECURITY NOTE: OPENAI secrets are exposed to test jobs.
-  # TODO: Consider using GitHub Environment Secrets with protection rules
-  # to limit access to required reviewers for additional security.
   test-unit:
     name: 'Unit Tests'
     runs-on: 'ubuntu-latest'
@@ -396,16 +372,8 @@ jobs:
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
 
-      - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@qwen-code'
-
-      - name: 'Install Dependencies'
-        run: 'npm ci'
+      - name: 'Setup SDK Environment'
+        uses: './.github/actions/setup-sdk-env'
 
       - name: 'Run Unit Tests'
         working-directory: 'packages/sdk-typescript'
@@ -418,9 +386,6 @@ jobs:
   # =============================================================================
   # Phase 4b: Integration Tests (Matrix)
   # =============================================================================
-  # SECURITY NOTE: OPENAI secrets are exposed to matrix tests across multiple OS/Node versions.
-  # TODO: Consider using mock/stub for integration tests to avoid real API calls,
-  # or restrict to a single test job with environment protection rules.
   test-integration:
     name: 'Integration Test (${{ matrix.os }}, Node ${{ matrix.node-version }}, ${{ matrix.sandbox }})'
     runs-on: '${{ matrix.os }}'
@@ -469,37 +434,24 @@ jobs:
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
 
-      - name: 'Setup Node.js ${{ matrix.node-version }}'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+      - name: 'Setup SDK Environment'
+        uses: './.github/actions/setup-sdk-env'
         with:
           node-version: '${{ matrix.node-version }}'
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@qwen-code'
-
-      - name: 'Install Dependencies'
-        run: 'npm ci'
 
       - name: 'Set up Docker'
         if: "matrix.sandbox == 'docker'"
         uses: 'docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435' # ratchet:docker/setup-buildx-action@v3
 
       - name: 'Download bundled SDK artifact'
-        uses: 'actions/download-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/download-artifact@v4
+        uses: 'actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093' # ratchet:actions/download-artifact@v4
         with:
           name: 'sdk-with-cli'
           path: 'packages/sdk-typescript/dist/'
 
       - name: 'Run Integration Tests'
-        run: |
-          set -euo pipefail
-          if [[ "${SANDBOX}" == "docker" ]]; then
-            npm run test:integration:sdk:sandbox:docker
-          else
-            npm run test:integration:sdk:sandbox:none
-          fi
+        run: 'npm run ${{ matrix.test-command }}'
         env:
-          SANDBOX: '${{ matrix.sandbox }}'
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
           OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
@@ -510,8 +462,18 @@ jobs:
   publish-npm:
     name: 'Publish to NPM'
     runs-on: 'ubuntu-latest'
-    needs: ['prepare', 'build-cli', 'bundle-cli-into-sdk', 'test-integration']
-    if: "github.repository == 'QwenLM/qwen-code'"
+    needs:
+      [
+        'prepare',
+        'build-cli',
+        'bundle-cli-into-sdk',
+        'test-unit',
+        'test-integration',
+      ]
+    if: |
+      github.repository == 'QwenLM/qwen-code' &&
+      (needs.test-unit.result == 'success' || needs.test-unit.result == 'skipped') &&
+      (needs.test-integration.result == 'success' || needs.test-integration.result == 'skipped')
     environment:
       name: 'production-release'
       url: '${{ github.server_url }}/${{ github.repository }}/releases/tag/sdk-typescript-${{ needs.prepare.outputs.RELEASE_TAG }}'
@@ -522,16 +484,18 @@ jobs:
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
 
-      - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@qwen-code'
+      - name: 'Setup SDK Environment'
+        uses: './.github/actions/setup-sdk-env'
+
+      - name: 'Set SDK package version'
+        env:
+          RELEASE_VERSION: '${{ needs.prepare.outputs.RELEASE_VERSION }}'
+        run: |
+          set -euo pipefail
+          npm version -w @qwen-code/sdk "${RELEASE_VERSION}" --no-git-tag-version --allow-same-version
 
       - name: 'Download bundled SDK artifact'
-        uses: 'actions/download-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/download-artifact@v4
+        uses: 'actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093' # ratchet:actions/download-artifact@v4
         with:
           name: 'sdk-with-cli'
           path: 'packages/sdk-typescript/dist/'
@@ -578,24 +542,30 @@ jobs:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 
+      - name: 'Generate SDK release notes'
+        id: 'release_notes'
+        uses: './.github/actions/generate-release-notes'
+        with:
+          release-tag: '${{ needs.prepare.outputs.RELEASE_TAG }}'
+          previous-release-tag: '${{ needs.prepare.outputs.PREVIOUS_RELEASE_TAG }}'
+          ref: '${{ github.event.inputs.ref || github.sha }}'
+          cli-version: '${{ needs.build-cli.outputs.CLI_VERSION }}'
+          cli-source-mode: '${{ needs.prepare.outputs.CLI_SOURCE_MODE }}'
+
       - name: 'Create GitHub Release and Tag'
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
           RELEASE_TAG: '${{ needs.prepare.outputs.RELEASE_TAG }}'
-          PREVIOUS_RELEASE_TAG: '${{ needs.prepare.outputs.PREVIOUS_RELEASE_TAG }}'
           IS_NIGHTLY: '${{ needs.prepare.outputs.IS_NIGHTLY }}'
           IS_PREVIEW: '${{ needs.prepare.outputs.IS_PREVIEW }}'
           REF: '${{ github.event.inputs.ref || github.sha }}'
-          CLI_VERSION: '${{ needs.build-cli.outputs.CLI_VERSION }}'
-          CLI_SOURCE_MODE: '${{ needs.prepare.outputs.CLI_SOURCE_MODE }}'
+          NOTES_FILE: '${{ steps.release_notes.outputs.notes-file }}'
         run: |
           set -euo pipefail
-          # For nightly/preview, use the current ref; for stable, we'll use the release branch created later
           if [[ "${IS_NIGHTLY}" == "true" || "${IS_PREVIEW}" == "true" ]]; then
             TARGET="${REF}"
             PRERELEASE_FLAG="--prerelease"
           else
-            # For stable releases, use the ref for now (release branch will be created in post-release)
             TARGET="${REF}"
             PRERELEASE_FLAG=""
           fi
@@ -628,9 +598,11 @@ jobs:
           gh release create "sdk-typescript-${RELEASE_TAG}" \
             --target "${TARGET}" \
             --title "SDK TypeScript Release ${RELEASE_TAG}" \
-            --notes-start-tag "sdk-typescript-${PREVIOUS_RELEASE_TAG}" \
-            --notes "${NOTES}$(gh release view "sdk-typescript-${PREVIOUS_RELEASE_TAG}" --json body -q '.body' 2>/dev/null || echo 'See commit history for changes.')" \
+            --notes-file "${NOTES_FILE}" \
             ${PRERELEASE_FLAG}
+
+          # Cleanup
+          rm -f "${NOTES_FILE}"
 
   # =============================================================================
   # Phase 6b: Post-Release (Stable Only)
@@ -644,6 +616,8 @@ jobs:
       needs.prepare.outputs.IS_DRY_RUN == 'false' &&
       needs.prepare.outputs.IS_NIGHTLY == 'false' &&
       needs.prepare.outputs.IS_PREVIEW == 'false'
+    environment:
+      name: 'production-release'
     permissions:
       contents: 'write'
       pull-requests: 'write'
@@ -655,76 +629,18 @@ jobs:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 
-      - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+      - name: 'Setup SDK Environment'
+        uses: './.github/actions/setup-sdk-env'
         with:
-          node-version-file: '.nvmrc'
-          cache: 'npm'
-          registry-url: 'https://registry.npmjs.org'
-          scope: '@qwen-code'
+          install-deps: 'false'
 
-      - name: 'Configure Git User'
-        run: |
-          set -euo pipefail
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: 'Set SDK package version'
-        env:
-          RELEASE_VERSION: '${{ needs.prepare.outputs.RELEASE_VERSION }}'
-        run: |
-          set -euo pipefail
-          npm version -w @qwen-code/sdk "${RELEASE_VERSION}" --no-git-tag-version --allow-same-version
-
-      - name: 'Create and switch to release branch'
-        env:
-          RELEASE_TAG: '${{ needs.prepare.outputs.RELEASE_TAG }}'
-        run: |
-          set -euo pipefail
-          BRANCH_NAME="release/sdk-typescript/${RELEASE_TAG}"
-          git switch -c "${BRANCH_NAME}"
-          echo "BRANCH_NAME=${BRANCH_NAME}" >> "${GITHUB_ENV}"
-
-      - name: 'Commit and push package version'
-        env:
-          RELEASE_TAG: '${{ needs.prepare.outputs.RELEASE_TAG }}'
-        run: |
-          set -euo pipefail
-          git add packages/sdk-typescript/package.json package-lock.json
-          if git diff --staged --quiet; then
-            echo "No version changes to commit"
-          else
-            git commit -m "chore(release): sdk-typescript ${RELEASE_TAG}"
-          fi
-          git push --set-upstream origin "${BRANCH_NAME}" --follow-tags
-
-      - name: 'Create PR to merge release branch into main'
-        id: 'pr'
-        env:
-          GITHUB_TOKEN: '${{ secrets.CI_BOT_PAT }}'
-          RELEASE_BRANCH: '${{ env.BRANCH_NAME }}'
-          RELEASE_TAG: '${{ needs.prepare.outputs.RELEASE_TAG }}'
-        run: |
-          set -euo pipefail
-
-          pr_url="$(gh pr list --head "${RELEASE_BRANCH}" --base main --json url --jq '.[0].url')"
-          if [[ -z "${pr_url}" ]]; then
-            pr_url="$(gh pr create \
-              --base main \
-              --head "${RELEASE_BRANCH}" \
-              --title "chore(release): sdk-typescript ${RELEASE_TAG}" \
-              --body "Automated release PR for sdk-typescript ${RELEASE_TAG}.")"
-          fi
-
-          echo "PR_URL=${pr_url}" >> "${GITHUB_OUTPUT}"
-
-      - name: 'Enable auto-merge for release PR'
-        env:
-          GITHUB_TOKEN: '${{ secrets.CI_BOT_PAT }}'
-          PR_URL: '${{ steps.pr.outputs.PR_URL }}'
-        run: |
-          set -euo pipefail
-          gh pr merge "${PR_URL}" --merge --auto --delete-branch
+      - name: 'Create release branch and PR'
+        uses: './.github/actions/post-release-pr'
+        with:
+          release-version: '${{ needs.prepare.outputs.RELEASE_VERSION }}'
+          release-tag: '${{ needs.prepare.outputs.RELEASE_TAG }}'
+          workspace-package: '@qwen-code/sdk'
+          github-token: '${{ secrets.CI_BOT_PAT }}'
 
   # =============================================================================
   # Phase 7: Failure Notification
@@ -747,8 +663,7 @@ jobs:
     if: |
       failure() &&
       github.repository == 'QwenLM/qwen-code' &&
-      needs.prepare.result == 'success' &&
-      needs.prepare.outputs.IS_DRY_RUN == 'false'
+      github.event.inputs.dry_run != 'true'
     permissions:
       issues: 'write'
 

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -42,25 +42,26 @@ on:
         default: false
 
 concurrency:
-  group: '${{ github.workflow }}'
-  cancel-in-progress: false
+  group: '${{ github.workflow }}-${{ github.event.inputs.ref || github.sha }}'
+  cancel-in-progress: ${{ github.event.inputs.create_nightly_release == 'true' || github.event.inputs.create_preview_release == 'true' }}
 
 jobs:
-  release-sdk:
+  # =============================================================================
+  # Phase 1: Prepare - Calculate versions, set flags, setup environment
+  # =============================================================================
+  prepare:
+    name: 'Prepare Release'
     runs-on: 'ubuntu-latest'
-    environment:
-      name: 'production-release'
-      url: '${{ github.server_url }}/${{ github.repository }}/releases/tag/sdk-typescript-${{ steps.version.outputs.RELEASE_TAG }}'
-    if: |-
-      ${{ github.repository == 'QwenLM/qwen-code' }}
-    permissions:
-      contents: 'write'
-      packages: 'write'
-      id-token: 'write'
-      issues: 'write'
-      pull-requests: 'write'
+    if: github.repository == 'QwenLM/qwen-code'
     outputs:
       RELEASE_TAG: '${{ steps.version.outputs.RELEASE_TAG }}'
+      RELEASE_VERSION: '${{ steps.version.outputs.RELEASE_VERSION }}'
+      NPM_TAG: '${{ steps.version.outputs.NPM_TAG }}'
+      PREVIOUS_RELEASE_TAG: '${{ steps.version.outputs.PREVIOUS_RELEASE_TAG }}'
+      IS_NIGHTLY: '${{ steps.vars.outputs.is_nightly }}'
+      IS_PREVIEW: '${{ steps.vars.outputs.is_preview }}'
+      IS_DRY_RUN: '${{ steps.vars.outputs.is_dry_run }}'
+      CLI_SOURCE_MODE: '${{ steps.cli_source.outputs.mode }}'
 
     steps:
       - name: 'Checkout'
@@ -109,6 +110,7 @@ jobs:
       - name: 'Get the version'
         id: 'version'
         run: |
+          set -euo pipefail
           VERSION_ARGS=()
           if [[ "${IS_NIGHTLY}" == "true" ]]; then
             VERSION_ARGS+=(--type=nightly)
@@ -151,76 +153,103 @@ jobs:
           IS_PREVIEW: '${{ steps.vars.outputs.is_preview }}'
           MANUAL_VERSION: '${{ inputs.version }}'
 
-      - name: 'Set SDK package version (local only)'
-        env:
-          RELEASE_VERSION: '${{ steps.version.outputs.RELEASE_VERSION }}'
-        run: |-
-          # Ensure the package version matches the computed release version.
-          # This is required for nightly/preview because npm does not allow re-publishing the same version.
-          npm version -w @qwen-code/sdk "${RELEASE_VERSION}" --no-git-tag-version --allow-same-version
-
-      - name: 'Determine CLI source and version'
+      - name: 'Determine CLI source mode'
         id: 'cli_source'
         env:
           CLI_SOURCE_INPUT: '${{ github.event.inputs.cli_source }}'
         run: |
-          # Determine CLI source mode
+          set -euo pipefail
           if [[ "${CLI_SOURCE_INPUT}" == "npm_latest" ]]; then
             echo "mode=npm_latest" >> "$GITHUB_OUTPUT"
-            echo "Building SDK with latest stable CLI from npm"
+            echo "CLI source: npm_latest"
           else
             echo "mode=build_from_source" >> "$GITHUB_OUTPUT"
-            echo "Building SDK with CLI built from current branch/ref"
+            echo "CLI source: build_from_source"
           fi
 
-      - name: 'Get CLI version from npm (for npm_latest mode)'
+  # =============================================================================
+  # Phase 2a: Build CLI - Download from npm or build from source
+  # =============================================================================
+  build-cli:
+    name: 'Build CLI (${{ needs.prepare.outputs.CLI_SOURCE_MODE }})'
+    runs-on: 'ubuntu-latest'
+    needs: 'prepare'
+    if: github.repository == 'QwenLM/qwen-code'
+    outputs:
+      CLI_VERSION: '${{ steps.cli_version_npm.outputs.CLI_VERSION || steps.cli_build.outputs.CLI_VERSION }}'
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          ref: '${{ github.event.inputs.ref || github.sha }}'
+          fetch-depth: 0
+
+      - name: 'Setup Node.js'
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@qwen-code'
+
+      - name: 'Install Dependencies'
+        run: npm ci
+
+      # ----- CLI from npm -----
+      - name: 'Get CLI version from npm'
         id: 'cli_version_npm'
-        if: "steps.cli_source.outputs.mode == 'npm_latest'"
+        if: "needs.prepare.outputs.CLI_SOURCE_MODE == 'npm_latest'"
         run: |
+          set -euo pipefail
           CLI_VERSION=$(npm view @qwen-code/qwen-code version --tag=latest)
           if [[ -z "${CLI_VERSION}" ]]; then
             echo '::error::Could not get latest stable CLI version from npm'
             exit 1
           fi
           echo "CLI_VERSION=${CLI_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Using latest stable CLI version from npm: ${CLI_VERSION}"
+          echo "Using CLI version from npm: ${CLI_VERSION}"
 
       - name: 'Download CLI package from npm'
         id: 'cli_download'
-        if: "steps.cli_source.outputs.mode == 'npm_latest'"
+        if: "needs.prepare.outputs.CLI_SOURCE_MODE == 'npm_latest'"
         env:
           CLI_VERSION: '${{ steps.cli_version_npm.outputs.CLI_VERSION }}'
         run: |
-          # Create temp directory for CLI package
+          set -euo pipefail
           CLI_TMP_DIR=$(mktemp -d)
           echo "CLI_TMP_DIR=${CLI_TMP_DIR}" >> "$GITHUB_OUTPUT"
 
-          # Download CLI package
           echo "Downloading @qwen-code/qwen-code@${CLI_VERSION}..."
           npm pack "@qwen-code/qwen-code@${CLI_VERSION}" --pack-destination "${CLI_TMP_DIR}"
 
-          # Extract package
           cd "${CLI_TMP_DIR}"
           tar -xzf qwen-code-qwen-code-*.tgz
 
           echo "CLI package extracted to: ${CLI_TMP_DIR}/package"
-          echo "CLI package contents:"
           ls -la "${CLI_TMP_DIR}/package/"
 
+      - name: 'Upload CLI package artifact'
+        if: "needs.prepare.outputs.CLI_SOURCE_MODE == 'npm_latest'"
+        uses: 'actions/upload-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/upload-artifact@v4
+        with:
+          name: 'cli-bundle'
+          path: '${{ steps.cli_download.outputs.CLI_TMP_DIR }}/package'
+          retention-days: 1
+
+      # ----- CLI from source -----
       - name: 'Build CLI from source'
         id: 'cli_build'
-        if: "steps.cli_source.outputs.mode == 'build_from_source'"
+        if: "needs.prepare.outputs.CLI_SOURCE_MODE == 'build_from_source'"
         run: |
-          # Build the CLI bundle from source
+          set -euo pipefail
           echo "Building CLI from source..."
           npm run bundle
 
-          # Get the CLI version from the built package
           CLI_VERSION=$(node -p "require('./packages/cli/package.json').version")
           echo "CLI_VERSION=${CLI_VERSION}" >> "$GITHUB_OUTPUT"
           echo "Built CLI version: ${CLI_VERSION}"
 
-          # Verify dist exists
           if [[ ! -f "./dist/cli.js" ]]; then
             echo "::error::CLI bundle not found at ./dist/cli.js"
             exit 1
@@ -229,115 +258,345 @@ jobs:
           echo "CLI bundle built successfully at ./dist/"
           ls -la ./dist/
 
-      - name: 'Configure Git User'
+      - name: 'Upload CLI dist artifact'
+        if: "needs.prepare.outputs.CLI_SOURCE_MODE == 'build_from_source'"
+        uses: 'actions/upload-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/upload-artifact@v4
+        with:
+          name: 'cli-bundle'
+          path: |
+            dist/cli.js
+            dist/vendor/
+            dist/locales/
+          retention-days: 1
+
+  # =============================================================================
+  # Phase 2b: Build SDK - Compile TypeScript SDK
+  # =============================================================================
+  build-sdk:
+    name: 'Build SDK'
+    runs-on: 'ubuntu-latest'
+    needs: 'prepare'
+    if: github.repository == 'QwenLM/qwen-code'
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          ref: '${{ github.event.inputs.ref || github.sha }}'
+          fetch-depth: 0
+
+      - name: 'Setup Node.js'
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@qwen-code'
+
+      - name: 'Install Dependencies'
+        run: npm ci
+
+      - name: 'Set SDK package version'
+        env:
+          RELEASE_VERSION: '${{ needs.prepare.outputs.RELEASE_VERSION }}'
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          set -euo pipefail
+          npm version -w @qwen-code/sdk "${RELEASE_VERSION}" --no-git-tag-version --allow-same-version
 
       - name: 'Build SDK'
         working-directory: 'packages/sdk-typescript'
-        run: |-
-          npm run build
+        run: npm run build
 
-      - name: 'Bundle CLI into SDK (from npm)'
-        if: "steps.cli_source.outputs.mode == 'npm_latest'"
+      - name: 'Upload SDK dist artifact'
+        uses: 'actions/upload-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/upload-artifact@v4
+        with:
+          name: 'sdk-dist'
+          path: 'packages/sdk-typescript/dist/'
+          retention-days: 1
+
+  # =============================================================================
+  # Phase 3: Bundle - Combine CLI into SDK
+  # =============================================================================
+  bundle-cli-into-sdk:
+    name: 'Bundle CLI into SDK'
+    runs-on: 'ubuntu-latest'
+    needs: ['prepare', 'build-cli', 'build-sdk']
+    if: github.repository == 'QwenLM/qwen-code'
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          ref: '${{ github.event.inputs.ref || github.sha }}'
+          fetch-depth: 0
+
+      - name: 'Setup Node.js'
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@qwen-code'
+
+      - name: 'Install Dependencies'
+        run: npm ci
+
+      - name: 'Download CLI artifact'
+        uses: 'actions/download-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/download-artifact@v4
+        with:
+          name: 'cli-bundle'
+          path: 'cli-bundle/'
+
+      - name: 'Download SDK artifact'
+        uses: 'actions/download-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/download-artifact@v4
+        with:
+          name: 'sdk-dist'
+          path: 'packages/sdk-typescript/dist/'
+
+      - name: 'Bundle CLI into SDK'
         working-directory: 'packages/sdk-typescript'
         env:
-          CLI_PACKAGE_PATH: '${{ steps.cli_download.outputs.CLI_TMP_DIR }}/package'
+          CLI_SOURCE_MODE: '${{ needs.prepare.outputs.CLI_SOURCE_MODE }}'
         run: |
-          node scripts/bundle-cli-from-npm.js
+          set -euo pipefail
+          if [[ "${CLI_SOURCE_MODE}" == "npm_latest" ]]; then
+            CLI_PACKAGE_PATH="${GITHUB_WORKSPACE}/cli-bundle" \
+              node scripts/bundle-cli-from-npm.js
+          else
+            # Copy CLI dist to expected location for bundle-cli.js
+            mkdir -p "${GITHUB_WORKSPACE}/dist"
+            cp -r "${GITHUB_WORKSPACE}/cli-bundle/"* "${GITHUB_WORKSPACE}/dist/"
+            node scripts/bundle-cli.js
+          fi
 
-      - name: 'Bundle CLI into SDK (from source)'
-        if: "steps.cli_source.outputs.mode == 'build_from_source'"
-        working-directory: 'packages/sdk-typescript'
-        run: |
-          node scripts/bundle-cli.js
+      - name: 'Upload bundled SDK artifact'
+        uses: 'actions/upload-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/upload-artifact@v4
+        with:
+          name: 'sdk-with-cli'
+          path: 'packages/sdk-typescript/dist/'
+          retention-days: 1
 
-      - name: 'Run Tests'
-        if: |-
-          ${{ github.event.inputs.force_skip_tests != 'true' }}
+  # =============================================================================
+  # Phase 4a: Unit Tests
+  # =============================================================================
+  # SECURITY NOTE: OPENAI secrets are exposed to test jobs.
+  # TODO: Consider using GitHub Environment Secrets with protection rules
+  # to limit access to required reviewers for additional security.
+  test-unit:
+    name: 'Unit Tests'
+    runs-on: 'ubuntu-latest'
+    needs: 'prepare'
+    if: |
+      github.repository == 'QwenLM/qwen-code' &&
+      github.event.inputs.force_skip_tests != 'true'
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          ref: '${{ github.event.inputs.ref || github.sha }}'
+
+      - name: 'Setup Node.js'
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@qwen-code'
+
+      - name: 'Install Dependencies'
+        run: npm ci
+
+      - name: 'Run Unit Tests'
         working-directory: 'packages/sdk-typescript'
-        run: |
-          npm run test:ci
+        run: npm run test:ci
         env:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
           OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
 
-      - name: 'Run SDK Integration Tests'
-        if: |-
-          ${{ github.event.inputs.force_skip_tests != 'true' }}
+  # =============================================================================
+  # Phase 4b: Integration Tests (Matrix)
+  # =============================================================================
+  # SECURITY NOTE: OPENAI secrets are exposed to matrix tests across multiple OS/Node versions.
+  # TODO: Consider using mock/stub for integration tests to avoid real API calls,
+  # or restrict to a single test job with environment protection rules.
+  test-integration:
+    name: 'Integration Test (${{ matrix.os }}, Node ${{ matrix.node-version }}, ${{ matrix.sandbox }})'
+    runs-on: '${{ matrix.os }}'
+    needs: ['prepare', 'bundle-cli-into-sdk', 'test-unit']
+    if: |
+      github.repository == 'QwenLM/qwen-code' &&
+      github.event.inputs.force_skip_tests != 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Ubuntu + Node 20.x + sandbox:none
+          - os: 'ubuntu-latest'
+            node-version: '20.x'
+            sandbox: 'none'
+            test-command: 'test:integration:sdk:sandbox:none'
+          # Ubuntu + Node 20.x + sandbox:docker
+          - os: 'ubuntu-latest'
+            node-version: '20.x'
+            sandbox: 'docker'
+            test-command: 'test:integration:sdk:sandbox:docker'
+          # Ubuntu + Node 22.x + sandbox:none
+          - os: 'ubuntu-latest'
+            node-version: '22.x'
+            sandbox: 'none'
+            test-command: 'test:integration:sdk:sandbox:none'
+          # Ubuntu + Node 22.x + sandbox:docker
+          - os: 'ubuntu-latest'
+            node-version: '22.x'
+            sandbox: 'docker'
+            test-command: 'test:integration:sdk:sandbox:docker'
+          # macOS + Node 20.x + sandbox:none (no docker on macOS)
+          - os: 'macos-latest'
+            node-version: '20.x'
+            sandbox: 'none'
+            test-command: 'test:integration:sdk:sandbox:none'
+          # macOS + Node 22.x + sandbox:none
+          - os: 'macos-latest'
+            node-version: '22.x'
+            sandbox: 'none'
+            test-command: 'test:integration:sdk:sandbox:none'
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          ref: '${{ github.event.inputs.ref || github.sha }}'
+
+      - name: 'Setup Node.js ${{ matrix.node-version }}'
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        with:
+          node-version: '${{ matrix.node-version }}'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@qwen-code'
+
+      - name: 'Install Dependencies'
+        run: npm ci
+
+      - name: 'Set up Docker'
+        if: matrix.sandbox == 'docker'
+        uses: 'docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435' # ratchet:docker/setup-buildx-action@v3
+
+      - name: 'Download bundled SDK artifact'
+        uses: 'actions/download-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/download-artifact@v4
+        with:
+          name: 'sdk-with-cli'
+          path: 'packages/sdk-typescript/dist/'
+
+      - name: 'Run Integration Tests'
         run: |
-          npm run test:integration:sdk:sandbox:none
-          npm run test:integration:sdk:sandbox:docker
+          set -euo pipefail
+          if [[ "${SANDBOX}" == "docker" ]]; then
+            npm run test:integration:sdk:sandbox:docker
+          else
+            npm run test:integration:sdk:sandbox:none
+          fi
         env:
+          SANDBOX: '${{ matrix.sandbox }}'
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
           OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
+
+  # =============================================================================
+  # Phase 5: Publish to NPM
+  # =============================================================================
+  publish-npm:
+    name: 'Publish to NPM'
+    runs-on: 'ubuntu-latest'
+    needs: ['prepare', 'bundle-cli-into-sdk', 'test-integration']
+    if: github.repository == 'QwenLM/qwen-code'
+    environment:
+      name: 'production-release'
+      url: '${{ github.server_url }}/${{ github.repository }}/releases/tag/sdk-typescript-${{ needs.prepare.outputs.RELEASE_TAG }}'
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          ref: '${{ github.event.inputs.ref || github.sha }}'
+
+      - name: 'Setup Node.js'
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@qwen-code'
+
+      - name: 'Download bundled SDK artifact'
+        uses: 'actions/download-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/download-artifact@v4
+        with:
+          name: 'sdk-with-cli'
+          path: 'packages/sdk-typescript/dist/'
 
       - name: 'Record bundled CLI version'
         env:
-          CLI_VERSION: "${{ steps.cli_source.outputs.mode == 'npm_latest' && steps.cli_version_npm.outputs.CLI_VERSION || steps.cli_build.outputs.CLI_VERSION }}"
+          CLI_VERSION: '${{ needs.build-cli.outputs.CLI_VERSION }}'
         run: |
-          # Create a metadata file to record which CLI version was bundled
+          set -euo pipefail
           echo "${CLI_VERSION}" > packages/sdk-typescript/dist/BUNDLED_CLI_VERSION
           echo "Bundled CLI version: ${CLI_VERSION}"
 
       - name: 'Publish @qwen-code/sdk'
         working-directory: 'packages/sdk-typescript'
-        run: |-
-          npm publish --access public --tag=${{ steps.version.outputs.NPM_TAG }} ${{ steps.vars.outputs.is_dry_run == 'true' && '--dry-run' || '' }}
+        run: |
+          set -euo pipefail
+          DRY_RUN_FLAG=""
+          if [[ "${IS_DRY_RUN}" == "true" ]]; then
+            DRY_RUN_FLAG="--dry-run"
+          fi
+          npm publish --access public --tag="${NPM_TAG}" ${DRY_RUN_FLAG}
         env:
           NODE_AUTH_TOKEN: '${{ secrets.NPM_TOKEN }}'
+          IS_DRY_RUN: '${{ needs.prepare.outputs.IS_DRY_RUN }}'
+          NPM_TAG: '${{ needs.prepare.outputs.NPM_TAG }}'
 
-      - name: 'Create and switch to a release branch'
-        if: |-
-          ${{ steps.vars.outputs.is_dry_run == 'false' && steps.vars.outputs.is_nightly == 'false' && steps.vars.outputs.is_preview == 'false' }}
-        id: 'release_branch'
-        env:
-          RELEASE_TAG: '${{ steps.version.outputs.RELEASE_TAG }}'
-        run: |-
-          BRANCH_NAME="release/sdk-typescript/${RELEASE_TAG}"
-          git switch -c "${BRANCH_NAME}"
-          echo "BRANCH_NAME=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
+  # =============================================================================
+  # Phase 6a: Create GitHub Release
+  # =============================================================================
+  create-release:
+    name: 'Create GitHub Release'
+    runs-on: 'ubuntu-latest'
+    needs: ['prepare', 'publish-npm', 'build-cli']
+    if: |
+      github.repository == 'QwenLM/qwen-code' &&
+      needs.prepare.outputs.IS_DRY_RUN == 'false'
+    permissions:
+      contents: 'write'
 
-      - name: 'Commit and Push package version (stable only)'
-        if: |-
-          ${{ steps.vars.outputs.is_dry_run == 'false' && steps.vars.outputs.is_nightly == 'false' && steps.vars.outputs.is_preview == 'false' }}
-        env:
-          BRANCH_NAME: '${{ steps.release_branch.outputs.BRANCH_NAME }}'
-          RELEASE_TAG: '${{ steps.version.outputs.RELEASE_TAG }}'
-        run: |-
-          # Only persist version bumps after a successful publish.
-          git add packages/sdk-typescript/package.json package-lock.json
-          if git diff --staged --quiet; then
-            echo "No version changes to commit"
-          else
-            git commit -m "chore(release): sdk-typescript ${RELEASE_TAG}"
-          fi
-          echo "Pushing release branch to remote..."
-          git push --set-upstream origin "${BRANCH_NAME}" --follow-tags
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          ref: '${{ github.event.inputs.ref || github.sha }}'
+          fetch-depth: 0
 
       - name: 'Create GitHub Release and Tag'
-        if: |-
-          ${{ steps.vars.outputs.is_dry_run == 'false' }}
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          RELEASE_BRANCH: '${{ steps.release_branch.outputs.BRANCH_NAME }}'
-          RELEASE_TAG: '${{ steps.version.outputs.RELEASE_TAG }}'
-          PREVIOUS_RELEASE_TAG: '${{ steps.version.outputs.PREVIOUS_RELEASE_TAG }}'
-          IS_NIGHTLY: '${{ steps.vars.outputs.is_nightly }}'
-          IS_PREVIEW: '${{ steps.vars.outputs.is_preview }}'
+          RELEASE_TAG: '${{ needs.prepare.outputs.RELEASE_TAG }}'
+          PREVIOUS_RELEASE_TAG: '${{ needs.prepare.outputs.PREVIOUS_RELEASE_TAG }}'
+          IS_NIGHTLY: '${{ needs.prepare.outputs.IS_NIGHTLY }}'
+          IS_PREVIEW: '${{ needs.prepare.outputs.IS_PREVIEW }}'
           REF: '${{ github.event.inputs.ref || github.sha }}'
-          CLI_VERSION: "${{ steps.cli_source.outputs.mode == 'npm_latest' && steps.cli_version_npm.outputs.CLI_VERSION || steps.cli_build.outputs.CLI_VERSION }}"
-          CLI_SOURCE_MODE: '${{ steps.cli_source.outputs.mode }}'
-        run: |-
-          # For stable releases, use the release branch; for nightly/preview, use the current ref
+          CLI_VERSION: '${{ needs.build-cli.outputs.CLI_VERSION }}'
+          CLI_SOURCE_MODE: '${{ needs.prepare.outputs.CLI_SOURCE_MODE }}'
+        run: |
+          set -euo pipefail
+          # For nightly/preview, use the current ref; for stable, we'll use the release branch created later
           if [[ "${IS_NIGHTLY}" == "true" || "${IS_PREVIEW}" == "true" ]]; then
             TARGET="${REF}"
             PRERELEASE_FLAG="--prerelease"
           else
-            TARGET="${RELEASE_BRANCH}"
+            # For stable releases, use the ref for now (release branch will be created in post-release)
+            TARGET="${REF}"
             PRERELEASE_FLAG=""
           fi
 
@@ -369,21 +628,83 @@ jobs:
           gh release create "sdk-typescript-${RELEASE_TAG}" \
             --target "${TARGET}" \
             --title "SDK TypeScript Release ${RELEASE_TAG}" \
-            --notes-file "${NOTES_FILE}" \
+            --notes-start-tag "sdk-typescript-${PREVIOUS_RELEASE_TAG}" \
+            --notes "${NOTES}$(gh release view "sdk-typescript-${PREVIOUS_RELEASE_TAG}" --json body -q '.body' 2>/dev/null || echo 'See commit history for changes.')" \
             ${PRERELEASE_FLAG}
 
-          # Cleanup
-          rm -f "${NOTES_FILE}"
+  # =============================================================================
+  # Phase 6b: Post-Release (Stable Only)
+  # =============================================================================
+  post-release:
+    name: 'Post-Release Tasks'
+    runs-on: 'ubuntu-latest'
+    needs: ['prepare', 'create-release']
+    if: |
+      github.repository == 'QwenLM/qwen-code' &&
+      needs.prepare.outputs.IS_DRY_RUN == 'false' &&
+      needs.prepare.outputs.IS_NIGHTLY == 'false' &&
+      needs.prepare.outputs.IS_PREVIEW == 'false'
+    permissions:
+      contents: 'write'
+      pull-requests: 'write'
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        with:
+          ref: '${{ github.event.inputs.ref || github.sha }}'
+          fetch-depth: 0
+
+      - name: 'Setup Node.js'
+        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@qwen-code'
+
+      - name: 'Configure Git User'
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: 'Set SDK package version'
+        env:
+          RELEASE_VERSION: '${{ needs.prepare.outputs.RELEASE_VERSION }}'
+        run: |
+          set -euo pipefail
+          npm version -w @qwen-code/sdk "${RELEASE_VERSION}" --no-git-tag-version --allow-same-version
+
+      - name: 'Create and switch to release branch'
+        env:
+          RELEASE_TAG: '${{ needs.prepare.outputs.RELEASE_TAG }}'
+        run: |
+          set -euo pipefail
+          BRANCH_NAME="release/sdk-typescript/${RELEASE_TAG}"
+          git switch -c "${BRANCH_NAME}"
+          echo "BRANCH_NAME=${BRANCH_NAME}" >> "${GITHUB_ENV}"
+
+      - name: 'Commit and push package version'
+        env:
+          RELEASE_TAG: '${{ needs.prepare.outputs.RELEASE_TAG }}'
+        run: |
+          set -euo pipefail
+          git add packages/sdk-typescript/package.json package-lock.json
+          if git diff --staged --quiet; then
+            echo "No version changes to commit"
+          else
+            git commit -m "chore(release): sdk-typescript ${RELEASE_TAG}"
+          fi
+          git push --set-upstream origin "${BRANCH_NAME}" --follow-tags
 
       - name: 'Create PR to merge release branch into main'
-        if: |-
-          ${{ steps.vars.outputs.is_dry_run == 'false' && steps.vars.outputs.is_nightly == 'false' && steps.vars.outputs.is_preview == 'false' }}
         id: 'pr'
         env:
           GITHUB_TOKEN: '${{ secrets.CI_BOT_PAT }}'
-          RELEASE_BRANCH: '${{ steps.release_branch.outputs.BRANCH_NAME }}'
-          RELEASE_TAG: '${{ steps.version.outputs.RELEASE_TAG }}'
-        run: |-
+          RELEASE_BRANCH: '${{ env.BRANCH_NAME }}'
+          RELEASE_TAG: '${{ needs.prepare.outputs.RELEASE_TAG }}'
+        run: |
           set -euo pipefail
 
           pr_url="$(gh pr list --head "${RELEASE_BRANCH}" --base main --json url --jq '.[0].url')"
@@ -398,23 +719,36 @@ jobs:
           echo "PR_URL=${pr_url}" >> "${GITHUB_OUTPUT}"
 
       - name: 'Enable auto-merge for release PR'
-        if: |-
-          ${{ steps.vars.outputs.is_dry_run == 'false' && steps.vars.outputs.is_nightly == 'false' && steps.vars.outputs.is_preview == 'false' }}
         env:
           GITHUB_TOKEN: '${{ secrets.CI_BOT_PAT }}'
           PR_URL: '${{ steps.pr.outputs.PR_URL }}'
-        run: |-
+        run: |
           set -euo pipefail
           gh pr merge "${PR_URL}" --merge --auto --delete-branch
 
+  # =============================================================================
+  # Phase 7: Failure Notification
+  # =============================================================================
+  failure-notification:
+    name: 'Failure Notification'
+    runs-on: 'ubuntu-latest'
+    needs: ['prepare', 'build-cli', 'build-sdk', 'bundle-cli-into-sdk', 'test-unit', 'test-integration', 'publish-npm', 'create-release', 'post-release']
+    if: |
+      failure() &&
+      github.repository == 'QwenLM/qwen-code' &&
+      needs.prepare.result == 'success' &&
+      needs.prepare.outputs.IS_DRY_RUN == 'false'
+    permissions:
+      issues: 'write'
+
+    steps:
       - name: 'Create Issue on Failure'
-        if: |-
-          ${{ failure() && steps.vars.outputs.is_dry_run == 'false' }}
         env:
           GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
-          RELEASE_TAG: "${{ steps.version.outputs.RELEASE_TAG || 'N/A' }}"
+          RELEASE_TAG: "${{ needs.prepare.outputs.RELEASE_TAG || 'N/A' }}"
           DETAILS_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
-        run: |-
+        run: |
+          set -euo pipefail
           gh issue create \
             --title "SDK Release Failed for ${RELEASE_TAG} on $(date +'%Y-%m-%d')" \
             --body "The SDK release workflow failed. See the full run for details: ${DETAILS_URL}"

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -43,7 +43,7 @@ on:
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.event.inputs.ref || github.sha }}'
-  cancel-in-progress: ${{ github.event.inputs.create_nightly_release == 'true' || github.event.inputs.create_preview_release == 'true' }}
+  cancel-in-progress: "${{ github.event.inputs.create_nightly_release == 'true' || github.event.inputs.create_preview_release == 'true' }}"
 
 jobs:
   # =============================================================================
@@ -52,7 +52,7 @@ jobs:
   prepare:
     name: 'Prepare Release'
     runs-on: 'ubuntu-latest'
-    if: github.repository == 'QwenLM/qwen-code'
+    if: "github.repository == 'QwenLM/qwen-code'"
     outputs:
       RELEASE_TAG: '${{ steps.version.outputs.RELEASE_TAG }}'
       RELEASE_VERSION: '${{ steps.version.outputs.RELEASE_VERSION }}'
@@ -174,7 +174,7 @@ jobs:
     name: 'Build CLI (${{ needs.prepare.outputs.CLI_SOURCE_MODE }})'
     runs-on: 'ubuntu-latest'
     needs: 'prepare'
-    if: github.repository == 'QwenLM/qwen-code'
+    if: "github.repository == 'QwenLM/qwen-code'"
     outputs:
       CLI_VERSION: '${{ steps.cli_version_npm.outputs.CLI_VERSION || steps.cli_build.outputs.CLI_VERSION }}'
 
@@ -194,7 +194,7 @@ jobs:
           scope: '@qwen-code'
 
       - name: 'Install Dependencies'
-        run: npm ci
+        run: 'npm ci'
 
       # ----- CLI from npm -----
       - name: 'Get CLI version from npm'
@@ -276,7 +276,7 @@ jobs:
     name: 'Build SDK'
     runs-on: 'ubuntu-latest'
     needs: 'prepare'
-    if: github.repository == 'QwenLM/qwen-code'
+    if: "github.repository == 'QwenLM/qwen-code'"
 
     steps:
       - name: 'Checkout'
@@ -294,7 +294,7 @@ jobs:
           scope: '@qwen-code'
 
       - name: 'Install Dependencies'
-        run: npm ci
+        run: 'npm ci'
 
       - name: 'Set SDK package version'
         env:
@@ -305,7 +305,7 @@ jobs:
 
       - name: 'Build SDK'
         working-directory: 'packages/sdk-typescript'
-        run: npm run build
+        run: 'npm run build'
 
       - name: 'Upload SDK dist artifact'
         uses: 'actions/upload-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/upload-artifact@v4
@@ -321,7 +321,7 @@ jobs:
     name: 'Bundle CLI into SDK'
     runs-on: 'ubuntu-latest'
     needs: ['prepare', 'build-cli', 'build-sdk']
-    if: github.repository == 'QwenLM/qwen-code'
+    if: "github.repository == 'QwenLM/qwen-code'"
 
     steps:
       - name: 'Checkout'
@@ -339,7 +339,7 @@ jobs:
           scope: '@qwen-code'
 
       - name: 'Install Dependencies'
-        run: npm ci
+        run: 'npm ci'
 
       - name: 'Download CLI artifact'
         uses: 'actions/download-artifact@b4b15b8c7c6ac15eaab7bd0ec3505b7d0b7b8b8b' # ratchet:actions/download-artifact@v4
@@ -405,11 +405,11 @@ jobs:
           scope: '@qwen-code'
 
       - name: 'Install Dependencies'
-        run: npm ci
+        run: 'npm ci'
 
       - name: 'Run Unit Tests'
         working-directory: 'packages/sdk-typescript'
-        run: npm run test:ci
+        run: 'npm run test:ci'
         env:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
@@ -478,10 +478,10 @@ jobs:
           scope: '@qwen-code'
 
       - name: 'Install Dependencies'
-        run: npm ci
+        run: 'npm ci'
 
       - name: 'Set up Docker'
-        if: matrix.sandbox == 'docker'
+        if: "matrix.sandbox == 'docker'"
         uses: 'docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435' # ratchet:docker/setup-buildx-action@v3
 
       - name: 'Download bundled SDK artifact'
@@ -510,8 +510,8 @@ jobs:
   publish-npm:
     name: 'Publish to NPM'
     runs-on: 'ubuntu-latest'
-    needs: ['prepare', 'bundle-cli-into-sdk', 'test-integration']
-    if: github.repository == 'QwenLM/qwen-code'
+    needs: ['prepare', 'build-cli', 'bundle-cli-into-sdk', 'test-integration']
+    if: "github.repository == 'QwenLM/qwen-code'"
     environment:
       name: 'production-release'
       url: '${{ github.server_url }}/${{ github.repository }}/releases/tag/sdk-typescript-${{ needs.prepare.outputs.RELEASE_TAG }}'
@@ -732,7 +732,18 @@ jobs:
   failure-notification:
     name: 'Failure Notification'
     runs-on: 'ubuntu-latest'
-    needs: ['prepare', 'build-cli', 'build-sdk', 'bundle-cli-into-sdk', 'test-unit', 'test-integration', 'publish-npm', 'create-release', 'post-release']
+    needs:
+      [
+        'prepare',
+        'build-cli',
+        'build-sdk',
+        'bundle-cli-into-sdk',
+        'test-unit',
+        'test-integration',
+        'publish-npm',
+        'create-release',
+        'post-release',
+      ]
     if: |
       failure() &&
       github.repository == 'QwenLM/qwen-code' &&


### PR DESCRIPTION
## TLDR

Refactored the SDK release workflow from a single monolithic job into 8 phased jobs with artifact passing and matrix testing across multiple OS and Node versions. This improves build reliability, enables better parallelization, and provides more comprehensive test coverage.

## Dive Deeper

**Problem:**
The original `release-sdk.yml` workflow was a single large job that performed all tasks sequentially: preparing versions, building CLI, building SDK, bundling, testing, publishing, and creating releases. This design had several issues:

- No parallelization - all steps ran sequentially even when they could be parallelized
- Limited test coverage - integration tests only ran on a single environment
- Difficult to debug - failures required re-running the entire workflow
- No artifact reuse - builds couldn't be separated from tests

**Solution:**
The workflow has been restructured into 8 distinct phases:

1. **Prepare** - Calculates versions, sets flags, and determines CLI source mode
2. **Build CLI** - Downloads CLI from npm or builds from source (parallelizable)
3. **Build SDK** - Compiles the TypeScript SDK (parallelizable)
4. **Bundle CLI into SDK** - Combines CLI artifacts with SDK build output
5. **Unit Tests** - Runs unit tests in parallel with integration test setup
6. **Integration Tests** - Matrix testing across:
   - OS: Ubuntu, macOS
   - Node versions: 20.x, 22.x
   - Sandbox modes: none, docker
7. **Publish to NPM** - Publishes the SDK package
8. **Create Release** - Creates GitHub release and tag
9. **Post-Release** - Creates release branch and PR (stable releases only)
10. **Failure Notification** - Creates an issue on workflow failure

**Additional improvements:**

- Added `set -euo pipefail` to all shell scripts for better error handling
- Added artifact upload/download between dependent jobs
- Updated concurrency settings to allow canceling in-progress nightly/preview releases
- Added security notes about OPENAI secrets exposure in test jobs

## Reviewer Test Plan

1. **Verify workflow syntax:**

   ```bash
   # Install actionlint if not already installed
   # Validate the workflow file
   actionlint .github/workflows/release-sdk.yml
   ```

2. **Test with dry-run mode:**
   - Trigger the workflow manually from the Actions tab
   - Set `dry_run: true` to test without publishing
   - Verify all jobs complete successfully

3. **Check artifact handling:**
   - Verify CLI bundle artifacts are created in `build-cli` job
   - Verify SDK dist artifacts are created in `build-sdk` job
   - Verify bundled SDK artifacts are created in `bundle-cli-into-sdk` job
   - Verify artifacts are downloaded correctly in dependent jobs

4. **Validate matrix configuration:**
   - Confirm integration tests run on all matrix combinations
   - Check that docker sandbox tests are skipped on macOS
   - Verify Node 20.x and 22.x are both tested

5. **Review security notes:**
   - Verify security comments are present in test jobs
   - Confirm failure notification job has appropriate conditions

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❌  | ❓  | ✅  |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

Notes:

- Docker sandbox is not supported on macOS runners (GitHub Actions limitation)
- Windows testing not included in matrix (would require additional runner configuration)

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->

Related to CI/CD improvements for the SDK release process.
