### PR TITLE
Fix CLI argument parsing for /dist/cli/cli.js entry point

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -166,7 +166,8 @@ export async function parseArguments(): Promise<CliArgs> {
   if (
     rawArgv.length > 0 &&
     (rawArgv[0].endsWith('/dist/qwen-cli/cli.js') ||
-      rawArgv[0].endsWith('/dist/cli.js'))
+      rawArgv[0].endsWith('/dist/cli.js') ||
+      rawArgv[0].endsWith('/dist/cli/cli.js'))
   ) {
     rawArgv = rawArgv.slice(1);
   }


### PR DESCRIPTION
## TLDR

Adds `/dist/cli/cli.js` to the list of recognized CLI entry point paths to fix argument parsing when the CLI is invoked from this location.

## Background / Context

When Electron integrates the SDK to use qwen-code, the default invocation uses `dist/cli/cli.js` from the SDK package as the script path. Because this path was not in the recognized CLI entry list, `parseArguments` treated it as the first user argument and incorrectly parsed it as the **question/query**. As a result:

- The user's actual prompt was ignored or misparsed.
- The CLI fell back to **non-SDK mode**, breaking multi-turn conversation.

This PR fixes the above by recognizing `dist/cli/cli.js` as a valid CLI entry so the script path is stripped from `argv` and the real user input is parsed correctly in SDK mode.

## Dive Deeper

The CLI argument parsing logic strips out the script path from `rawArgv` when it matches known CLI entry point patterns. A new build output path `/dist/cli/cli.js` was not included in the existing patterns, causing the argument parsing to fail to properly handle the first argument when the CLI is invoked from this location.

The fix adds a check for `rawArgv[0].endsWith('/dist/cli/cli.js')` alongside the existing checks for `/dist/qwen-cli/cli.js` and `/dist/cli.js`.

## Reviewer Test Plan

1. Build the CLI package: `npm run build`
2. Invoke the CLI from the `/dist/cli/cli.js` path
3. Verify that arguments are parsed correctly (the script path should be stripped from argv)
4. Test various CLI commands to ensure they work as expected

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏   | 🪟   | 🐧   |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓   | ❓   |
| npx      | ❓   | ❓   | ❓   |
| Docker   | ❓   | ❓   | ❓   |
| Podman   | ❓   | -   | -   |
| Seatbelt | ❓   | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
