### PR TITLE
fix(integration-tests): correct MCP tool name in simple-mcp-server test

### DIFF
--- a/integration-tests/simple-mcp-server.test.ts
+++ b/integration-tests/simple-mcp-server.test.ts
@@ -215,7 +215,9 @@ describe('simple-mcp-server', () => {
     // Just run the command - MCP server config is in settings.json
     const output = await rig.run('add 5 and 10, use tool if you can.');
 
-    const foundToolCall = await rig.waitForToolCall('add');
+    const foundToolCall = await rig.waitForToolCall(
+      'mcp__addition-server__add',
+    );
 
     expect(foundToolCall, 'Expected to find an add tool call').toBeTruthy();
 


### PR DESCRIPTION
## TLDR

Fixes the `simple-mcp-server.test.ts` integration test by updating the expected MCP tool name from `'add'` to `'mcp__addition-server__add'` to match the actual telemetry naming convention.

## Dive Deeper

The test was failing because it was looking for a tool named `'add'`, but MCP tools are recorded in telemetry with a prefixed naming convention: `mcp__{server-name}__{tool-name}`. The actual tool name logged was `mcp__addition-server__add`.

This fix updates the test assertion to use the correct tool name, allowing the test to properly validate that the MCP server integration is working correctly.

## Reviewer Test Plan

1. Run the integration test locally:
   ```bash
   cd integration-tests && npx vitest run simple-mcp-server.test.ts
   ```
2. Verify the test passes

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

*Tested on macOS (darwin/arm64) with `npx vitest run simple-mcp-server.test.ts`*

## Linked issues / bugs

No linked issues

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)
