### PR TITLE
Fix SDK MCP integration tests by updating hardcoded tool names to use constants

### DIFF
--- a/integration-tests/sdk-typescript/mcp-server.test.ts
+++ b/integration-tests/sdk-typescript/mcp-server.test.ts
@@ -35,6 +35,10 @@ const SHARED_TEST_OPTIONS = {
   permissionMode: 'yolo' as const,
 };
 
+// MCP tool names are generated with the pattern: mcp__<serverName>__<toolName>
+const MCP_ADD_TOOL = 'mcp__test-math-server__add';
+const MCP_MULTIPLY_TOOL = 'mcp__test-math-server__multiply';
+
 describe('MCP Server Integration (E2E)', () => {
   let helper: SDKTestHelper;
   let serverScriptPath: string;
@@ -82,7 +86,7 @@ describe('MCP Server Integration (E2E)', () => {
           messages.push(message);
 
           if (isSDKAssistantMessage(message)) {
-            const toolUseBlocks = findToolUseBlocks(message, 'add');
+            const toolUseBlocks = findToolUseBlocks(message, MCP_ADD_TOOL);
             if (toolUseBlocks.length > 0) {
               foundToolUse = true;
             }
@@ -133,7 +137,7 @@ describe('MCP Server Integration (E2E)', () => {
           messages.push(message);
 
           if (isSDKAssistantMessage(message)) {
-            const toolUseBlocks = findToolUseBlocks(message, 'multiply');
+            const toolUseBlocks = findToolUseBlocks(message, MCP_MULTIPLY_TOOL);
             if (toolUseBlocks.length > 0) {
               foundToolUse = true;
             }
@@ -238,8 +242,8 @@ describe('MCP Server Integration (E2E)', () => {
         }
 
         // Validate both tools were called
-        expect(toolCalls).toContain('add');
-        expect(toolCalls).toContain('multiply');
+        expect(toolCalls).toContain(MCP_ADD_TOOL);
+        expect(toolCalls).toContain(MCP_MULTIPLY_TOOL);
 
         // Validate result: (10 + 5) * 2 = 30
         expect(assistantText).toMatch(/30/);
@@ -278,7 +282,7 @@ describe('MCP Server Integration (E2E)', () => {
           messages.push(message);
 
           if (isSDKAssistantMessage(message)) {
-            const toolUseBlocks = findToolUseBlocks(message, 'add');
+            const toolUseBlocks = findToolUseBlocks(message, MCP_ADD_TOOL);
             addToolCalls.push(...toolUseBlocks);
             assistantText += extractText(message.message.content);
           }
@@ -366,8 +370,8 @@ describe('MCP Server Integration (E2E)', () => {
           }
         }
 
-        expect(toolCalls).toContain('add');
-        expect(toolCalls).toContain('multiply');
+        expect(toolCalls).toContain(MCP_ADD_TOOL);
+        expect(toolCalls).toContain(MCP_MULTIPLY_TOOL);
         expect(assistantText).toMatch(/5/);
         expect(assistantText).toMatch(/20/);
 
@@ -454,10 +458,10 @@ describe('MCP Server Integration (E2E)', () => {
           }
         }
 
-        expect(toolCalls).toContain('add');
-        expect(toolCalls).toContain('multiply');
+        expect(toolCalls).toContain(MCP_ADD_TOOL);
+        expect(toolCalls).toContain(MCP_MULTIPLY_TOOL);
         expect(canUseToolCalls.map((call) => call.toolName)).toEqual(
-          expect.arrayContaining(['add', 'multiply']),
+          expect.arrayContaining([MCP_ADD_TOOL, MCP_MULTIPLY_TOOL]),
         );
         expect(assistantText).toMatch(/10/);
         expect(assistantText).toMatch(/12/);
@@ -499,7 +503,7 @@ describe('MCP Server Integration (E2E)', () => {
             const toolUseBlocks = findToolUseBlocks(message);
             if (toolUseBlocks.length > 0) {
               foundToolUse = true;
-              expect(toolUseBlocks[0].name).toBe('add');
+              expect(toolUseBlocks[0].name).toBe(MCP_ADD_TOOL);
               expect(toolUseBlocks[0].input).toBeDefined();
             }
           }

--- a/integration-tests/sdk-typescript/sdk-mcp-server.test.ts
+++ b/integration-tests/sdk-typescript/sdk-mcp-server.test.ts
@@ -35,6 +35,14 @@ const SHARED_TEST_OPTIONS = {
   permissionMode: 'yolo' as const,
 };
 
+// MCP tool names are generated with the pattern: mcp__<serverName>__<toolName>
+const MCP_CALCULATE_SUM = 'mcp__sdk-calculator__calculate_sum';
+const MCP_REVERSE_STRING = 'mcp__sdk-string-utils__reverse_string';
+const MCP_SDK_ADD = 'mcp__sdk-math__sdk_add';
+const MCP_SDK_MULTIPLY = 'mcp__sdk-math__sdk_multiply';
+const MCP_MAYBE_FAIL = 'mcp__sdk-error-test__maybe_fail';
+const MCP_DELAYED_RESPONSE = 'mcp__sdk-async__delayed_response';
+
 describe('SDK MCP Server Integration (E2E)', () => {
   let helper: SDKTestHelper;
   let testDir: string;
@@ -91,7 +99,7 @@ describe('SDK MCP Server Integration (E2E)', () => {
           messages.push(message);
 
           if (isSDKAssistantMessage(message)) {
-            const toolUseBlocks = findToolUseBlocks(message, 'calculate_sum');
+            const toolUseBlocks = findToolUseBlocks(message, MCP_CALCULATE_SUM);
             if (toolUseBlocks.length > 0) {
               foundToolUse = true;
             }
@@ -157,7 +165,10 @@ describe('SDK MCP Server Integration (E2E)', () => {
           messages.push(message);
 
           if (isSDKAssistantMessage(message)) {
-            const toolUseBlocks = findToolUseBlocks(message, 'reverse_string');
+            const toolUseBlocks = findToolUseBlocks(
+              message,
+              MCP_REVERSE_STRING,
+            );
             if (toolUseBlocks.length > 0) {
               foundToolUse = true;
             }
@@ -244,8 +255,8 @@ describe('SDK MCP Server Integration (E2E)', () => {
         }
 
         // Validate both tools were called
-        expect(toolCalls).toContain('sdk_add');
-        expect(toolCalls).toContain('sdk_multiply');
+        expect(toolCalls).toContain(MCP_SDK_ADD);
+        expect(toolCalls).toContain(MCP_SDK_MULTIPLY);
 
         // Validate result: (10 + 5) * 3 = 45
         expect(assistantText).toMatch(/45/);
@@ -361,7 +372,7 @@ describe('SDK MCP Server Integration (E2E)', () => {
           messages.push(message);
 
           if (isSDKAssistantMessage(message)) {
-            const toolUseBlocks = findToolUseBlocks(message, 'maybe_fail');
+            const toolUseBlocks = findToolUseBlocks(message, MCP_MAYBE_FAIL);
             if (toolUseBlocks.length > 0) {
               foundToolUse = true;
             }
@@ -430,7 +441,7 @@ describe('SDK MCP Server Integration (E2E)', () => {
           if (isSDKAssistantMessage(message)) {
             const toolUseBlocks = findToolUseBlocks(
               message,
-              'delayed_response',
+              MCP_DELAYED_RESPONSE,
             );
             if (toolUseBlocks.length > 0) {
               foundToolUse = true;


### PR DESCRIPTION
## TLDR

This pull request fixes integration tests for SDK MCP (Model Context Protocol) servers by updating hardcoded tool names to use properly defined constants that follow the MCP naming convention `mcp__<serverName>__<toolName>`.

## Dive Deeper

The changes address an issue in the SDK MCP integration tests where hardcoded tool names like 'add', 'multiply', etc. were being used instead of the proper MCP-formatted tool names. MCP tools follow the naming pattern `mcp__<serverName>__<toolName>`, so 'add' becomes 'mcp__test-math-server__add', 'calculate_sum' becomes 'mcp__sdk-calculator__calculate_sum', etc. The fix involves defining constants for these properly formatted tool names and updating all test assertions and tool usage checks to use these constants instead of hardcoded strings.

## Reviewer Test Plan

1. Pull the branch and run the integration tests: `npm run test` or equivalent test command
2. Verify that the SDK MCP integration tests pass: `integration-tests/sdk-typescript/mcp-server.test.ts` and `integration-tests/sdk-typescript/sdk-mcp-server.test.ts`
3. Check that the constants are correctly defined and follow the expected MCP naming pattern
4. Confirm that all tool name references in the tests have been updated consistently

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->