### PR TITLE
fix: prioritize local path detection in extension installation

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -214,7 +214,7 @@ export type ExtensionOriginSource = 'QwenCode' | 'Claude' | 'Gemini';
 
 export interface ExtensionInstallMetadata {
   source: string;
-  type: 'git' | 'local' | 'link' | 'github-release' | 'marketplace';
+  type: 'git' | 'local' | 'link' | 'github-release';
   originSource?: ExtensionOriginSource;
   releaseTag?: string; // Only present for github-release installs.
   ref?: string;

--- a/packages/core/src/extension/extensionManager.ts
+++ b/packages/core/src/extension/extensionManager.ts
@@ -763,7 +763,7 @@ export class ExtensionManager {
       let tempDir: string | undefined;
 
       if (
-        installMetadata.type === 'marketplace' &&
+        installMetadata.originSource === 'Claude' &&
         installMetadata.marketplaceConfig &&
         !installMetadata.pluginName
       ) {
@@ -774,7 +774,6 @@ export class ExtensionManager {
       }
 
       if (
-        installMetadata.type === 'marketplace' ||
         installMetadata.type === 'git' ||
         installMetadata.type === 'github-release'
       ) {
@@ -793,10 +792,7 @@ export class ExtensionManager {
           }
         } catch (_error) {
           await cloneFromGit(installMetadata, tempDir);
-          if (
-            installMetadata.type === 'git' ||
-            installMetadata.type === 'github-release'
-          ) {
+          if (installMetadata.type === 'github-release') {
             installMetadata.type = 'git';
           }
         }

--- a/packages/core/src/extension/github.test.ts
+++ b/packages/core/src/extension/github.test.ts
@@ -117,25 +117,6 @@ describe('git extension helpers', () => {
         'Failed to clone Git repository from http://my-repo.com',
       );
     });
-
-    it('should use source for marketplace type without marketplace metadata', async () => {
-      const installMetadata = {
-        source: 'http://fallback-repo.com',
-        type: 'marketplace' as const,
-      };
-      const destination = '/dest';
-      mockGit.getRemotes.mockResolvedValue([
-        { name: 'origin', refs: { fetch: 'http://fallback-repo.com' } },
-      ]);
-
-      await cloneFromGit(installMetadata, destination);
-
-      expect(mockGit.clone).toHaveBeenCalledWith(
-        'http://fallback-repo.com',
-        './',
-        ['--depth', '1'],
-      );
-    });
   });
 
   describe('checkForExtensionUpdate', () => {


### PR DESCRIPTION
## TLDR

Fix extension installation to correctly prioritize local path detection over pattern matching. Relative paths like `../extension` or `./extension` now work correctly instead of being misinterpreted as GitHub `owner/repo` format.

## Dive Deeper

**Root Cause:**
The previous implementation checked source types in the wrong order:
1. Git URL check
2. `owner/repo` pattern check (regex: `/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/`)
3. Local path existence check (last resort)

This caused relative paths like `../claude-code` to match the `owner/repo` regex pattern and be incorrectly converted to `https://github.com/../claude-code`, leading to git clone failures.

**Solution:**
Reorder detection logic to check local path existence first:
1. **Priority 1:** Check if path exists using `fs.stat()` - handles all local paths universally
2. **Priority 2:** Check if it's a Git URL (`http://`, `https://`, `git@`, `sso://`)
3. **Priority 3:** Check if it matches `owner/repo` format
4. **Fallback:** Throw error if none match

**Additional Improvements:**
- Removed `marketplace` as a separate installation type - now identified via `originSource === 'Claude'`
- Simplified type system from 5 types to 4 (removed redundant `marketplace` type)
- This approach works universally across macOS/Windows/Linux as it relies on filesystem checks rather than path pattern matching

## Reviewer Test Plan

1. **Test relative path installation:**
   ```bash
   /extensions install ../local-extension
   /extensions install ./../local-extension
   /extensions install ./local-extension
   ```
   Should correctly detect as local paths and install successfully.

2. **Test owner/repo format still works:**
   ```bash
   /extensions install anthropics/skills
   ```
   Should convert to GitHub URL and install.

3. **Test Git URLs still work:**
   ```bash
   /extensions install https://github.com/owner/repo
   /extensions install git@github.com:owner/repo.git
   ```

4. **Test with marketplace plugins:**
   Install a Claude marketplace extension and verify plugin selection UI appears correctly.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

This PR addresses the issue where local extension paths were incorrectly parsed as GitHub repository identifiers.