### PR TITLE
fix(auth-model-login-ui): prevent Enter key from triggering empty message submission

### DIFF
--- a/packages/vscode-ide-companion/src/webview/components/layout/ModelSelector.tsx
+++ b/packages/vscode-ide-companion/src/webview/components/layout/ModelSelector.tsx
@@ -61,12 +61,10 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
       switch (event.key) {
         case 'ArrowDown':
           event.preventDefault();
-          event.stopPropagation();
           setSelected((prev) => Math.min(prev + 1, models.length - 1));
           break;
         case 'ArrowUp':
           event.preventDefault();
-          event.stopPropagation();
           setSelected((prev) => Math.max(prev - 1, 0));
           break;
         case 'Enter':
@@ -81,7 +79,6 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
           break;
         case 'Escape':
           event.preventDefault();
-          event.stopPropagation();
           onClose();
           break;
         default:
@@ -90,10 +87,9 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
     };
 
     document.addEventListener('mousedown', handleClickOutside);
-    // Use capture phase so this handler fires BEFORE any bubble-phase
-    // handlers on child elements (e.g. the InputForm's Enter-to-submit).
-    // Combined with stopPropagation this prevents an empty user message
-    // from being created when the user presses Enter to confirm a model.
+    // Use capture phase so Enter is handled before bubble-phase handlers
+    // (e.g. the InputForm's Enter-to-submit) and stopPropagation can
+    // prevent an empty user message.
     document.addEventListener('keydown', handleKeyDown, true);
 
     return () => {

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
@@ -12,21 +12,6 @@ import { ACP_ERROR_CODES } from '../../constants/acpSchema.js';
 
 const AUTH_REQUIRED_CODE_PATTERN = `(code: ${ACP_ERROR_CODES.AUTH_REQUIRED})`;
 
-/** Prefix that separates the human-readable ACP error from its JSON data payload. */
-const ACP_ERROR_DATA_PREFIX = '\nData: ';
-
-/**
- * Strip the trailing `\nData: {...}` payload from an ACP error message so that
- * only the human-readable portion is shown to the user.
- */
-function stripAcpErrorData(message: string): string {
-  const idx = message.indexOf(ACP_ERROR_DATA_PREFIX);
-  if (idx === -1) {
-    return message;
-  }
-  return message.slice(0, idx).trim();
-}
-
 /**
  * Session message handler
  * Handles all session-related messages
@@ -1084,12 +1069,11 @@ export class SessionMessageHandler extends BaseMessageHandler {
       );
     } catch (error) {
       const errorMsg = error instanceof Error ? error.message : String(error);
-      const cleanMsg = stripAcpErrorData(errorMsg);
       console.error('[SessionMessageHandler] Failed to set model:', error);
-      vscode.window.showErrorMessage(`Failed to switch model: ${cleanMsg}`);
+      vscode.window.showErrorMessage(`Failed to switch model: ${errorMsg}`);
       this.sendToWebView({
         type: 'error',
-        data: { message: `Failed to set model: ${cleanMsg}` },
+        data: { message: `Failed to set model: ${errorMsg}` },
       });
     }
   }


### PR DESCRIPTION
sh# PR Description

If a model switch exception occurs, only this error message will be reported, and there will be no empty user message message.

<img width="758" height="556" alt="image" src="https://github.com/user-attachments/assets/377151db-5079-46ba-a3dc-46ad734a5eab" />

## Changes

This PR fixes two interaction issues in the auth model selector UI:

### 1. Fix ModelSelector Enter Key Triggering Form Submission (ModelSelector.tsx)

**Problem**: Pressing Enter in the model selector to select a model would accidentally trigger the input form's submission, causing empty messages to be sent.

**Solution**:
- Added `event.stopPropagation()` in `handleKeyDown` to prevent event bubbling
- Changed `keydown` event listener to capture phase (using `true` parameter) to ensure Enter key is handled before form's bubble-phase handlers

### 2. Fix Empty Message Submission (SessionMessageHandler.ts)

**Problem**: After using slash command completions or model selector interactions, the input might be cleared but still trigger submission, resulting in empty user message bubbles.

**Solution**:
- Added guard check at the beginning of `handleSendMessage`
- Remove zero-width space (`\u200B`) before checking if text is empty
- Return early for empty messages with warning log

## Test Plan

- [ ] Press Enter in model selector to select a model, confirm no empty messages are sent
- [ ] After using slash command completion, confirm no empty messages are sent
- [ ] Confirm installation script works correctly in various scenarios
