### PR TITLE
feat: parallel execution for sub-agent tool calls in CoreToolScheduler

### DIFF
--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1088,157 +1088,170 @@ export class CoreToolScheduler {
         (call) => call.status === 'scheduled',
       );
 
-      for (const toolCall of callsToExecute) {
-        if (toolCall.status !== 'scheduled') continue;
+      // Execute all scheduled tool calls in parallel.
+      // When the model returns multiple tool calls in a single response,
+      // they are inherently independent — no tool call can reference
+      // another's output within the same response turn. This makes
+      // parallel execution safe and aligns with the LLM tool calling
+      // protocol. Node.js single-threaded event loop ensures that
+      // synchronous state mutations (e.g. setStatusInternal) do not race.
+      await Promise.allSettled(
+        callsToExecute.map((toolCall) =>
+          this.executeSingleToolCall(toolCall, signal),
+        ),
+      );
+    }
+  }
 
-        const scheduledCall = toolCall;
-        const { callId, name: toolName } = scheduledCall.request;
-        const invocation = scheduledCall.invocation;
-        this.setStatusInternal(callId, 'executing');
+  /**
+   * Executes a single scheduled tool call.
+   * Extracted to support parallel execution via Promise.allSettled.
+   */
+  private async executeSingleToolCall(
+    toolCall: ToolCall,
+    signal: AbortSignal,
+  ): Promise<void> {
+    if (toolCall.status !== 'scheduled') return;
 
-        const liveOutputCallback = scheduledCall.tool.canUpdateOutput
-          ? (outputChunk: ToolResultDisplay) => {
-              if (this.outputUpdateHandler) {
-                this.outputUpdateHandler(callId, outputChunk);
-              }
-              this.toolCalls = this.toolCalls.map((tc) =>
-                tc.request.callId === callId && tc.status === 'executing'
-                  ? { ...tc, liveOutput: outputChunk }
-                  : tc,
-              );
-              this.notifyToolCallsUpdate();
-            }
-          : undefined;
+    const scheduledCall = toolCall;
+    const { callId, name: toolName } = scheduledCall.request;
+    const invocation = scheduledCall.invocation;
+    this.setStatusInternal(callId, 'executing');
 
-        const shellExecutionConfig = this.config.getShellExecutionConfig();
-
-        // TODO: Refactor to remove special casing for ShellToolInvocation.
-        // Introduce a generic callbacks object for the execute method to handle
-        // things like `onPid` and `onLiveOutput`. This will make the scheduler
-        // agnostic to the invocation type.
-        let promise: Promise<ToolResult>;
-        if (invocation instanceof ShellToolInvocation) {
-          const setPidCallback = (pid: number) => {
-            this.toolCalls = this.toolCalls.map((tc) =>
-              tc.request.callId === callId && tc.status === 'executing'
-                ? { ...tc, pid }
-                : tc,
-            );
-            this.notifyToolCallsUpdate();
-          };
-          promise = invocation.execute(
-            signal,
-            liveOutputCallback,
-            shellExecutionConfig,
-            setPidCallback,
-          );
-        } else {
-          promise = invocation.execute(
-            signal,
-            liveOutputCallback,
-            shellExecutionConfig,
-          );
-        }
-
-        try {
-          const toolResult: ToolResult = await promise;
-          if (signal.aborted) {
-            this.setStatusInternal(
-              callId,
-              'cancelled',
-              'User cancelled tool execution.',
-            );
-            continue;
+    const liveOutputCallback = scheduledCall.tool.canUpdateOutput
+      ? (outputChunk: ToolResultDisplay) => {
+          if (this.outputUpdateHandler) {
+            this.outputUpdateHandler(callId, outputChunk);
           }
+          this.toolCalls = this.toolCalls.map((tc) =>
+            tc.request.callId === callId && tc.status === 'executing'
+              ? { ...tc, liveOutput: outputChunk }
+              : tc,
+          );
+          this.notifyToolCallsUpdate();
+        }
+      : undefined;
 
-          if (toolResult.error === undefined) {
-            let content = toolResult.llmContent;
-            let outputFile: string | undefined = undefined;
-            const contentLength =
-              typeof content === 'string' ? content.length : undefined;
-            if (
-              typeof content === 'string' &&
-              toolName === ShellTool.Name &&
-              this.config.getEnableToolOutputTruncation() &&
-              this.config.getTruncateToolOutputThreshold() > 0 &&
-              this.config.getTruncateToolOutputLines() > 0
-            ) {
-              const originalContentLength = content.length;
-              const threshold = this.config.getTruncateToolOutputThreshold();
-              const lines = this.config.getTruncateToolOutputLines();
-              const truncatedResult = await truncateAndSaveToFile(
-                content,
-                callId,
-                this.config.storage.getProjectTempDir(),
+    const shellExecutionConfig = this.config.getShellExecutionConfig();
+
+    // TODO: Refactor to remove special casing for ShellToolInvocation.
+    // Introduce a generic callbacks object for the execute method to handle
+    // things like `onPid` and `onLiveOutput`. This will make the scheduler
+    // agnostic to the invocation type.
+    let promise: Promise<ToolResult>;
+    if (invocation instanceof ShellToolInvocation) {
+      const setPidCallback = (pid: number) => {
+        this.toolCalls = this.toolCalls.map((tc) =>
+          tc.request.callId === callId && tc.status === 'executing'
+            ? { ...tc, pid }
+            : tc,
+        );
+        this.notifyToolCallsUpdate();
+      };
+      promise = invocation.execute(
+        signal,
+        liveOutputCallback,
+        shellExecutionConfig,
+        setPidCallback,
+      );
+    } else {
+      promise = invocation.execute(
+        signal,
+        liveOutputCallback,
+        shellExecutionConfig,
+      );
+    }
+
+    try {
+      const toolResult: ToolResult = await promise;
+      if (signal.aborted) {
+        this.setStatusInternal(
+          callId,
+          'cancelled',
+          'User cancelled tool execution.',
+        );
+        return;
+      }
+
+      if (toolResult.error === undefined) {
+        let content = toolResult.llmContent;
+        let outputFile: string | undefined = undefined;
+        const contentLength =
+          typeof content === 'string' ? content.length : undefined;
+        if (
+          typeof content === 'string' &&
+          toolName === ShellTool.Name &&
+          this.config.getEnableToolOutputTruncation() &&
+          this.config.getTruncateToolOutputThreshold() > 0 &&
+          this.config.getTruncateToolOutputLines() > 0
+        ) {
+          const originalContentLength = content.length;
+          const threshold = this.config.getTruncateToolOutputThreshold();
+          const lines = this.config.getTruncateToolOutputLines();
+          const truncatedResult = await truncateAndSaveToFile(
+            content,
+            callId,
+            this.config.storage.getProjectTempDir(),
+            threshold,
+            lines,
+          );
+          content = truncatedResult.content;
+          outputFile = truncatedResult.outputFile;
+
+          if (outputFile) {
+            logToolOutputTruncated(
+              this.config,
+              new ToolOutputTruncatedEvent(scheduledCall.request.prompt_id, {
+                toolName,
+                originalContentLength,
+                truncatedContentLength: content.length,
                 threshold,
                 lines,
-              );
-              content = truncatedResult.content;
-              outputFile = truncatedResult.outputFile;
-
-              if (outputFile) {
-                logToolOutputTruncated(
-                  this.config,
-                  new ToolOutputTruncatedEvent(
-                    scheduledCall.request.prompt_id,
-                    {
-                      toolName,
-                      originalContentLength,
-                      truncatedContentLength: content.length,
-                      threshold,
-                      lines,
-                    },
-                  ),
-                );
-              }
-            }
-
-            const response = convertToFunctionResponse(
-              toolName,
-              callId,
-              content,
-            );
-            const successResponse: ToolCallResponseInfo = {
-              callId,
-              responseParts: response,
-              resultDisplay: toolResult.returnDisplay,
-              error: undefined,
-              errorType: undefined,
-              outputFile,
-              contentLength,
-            };
-            this.setStatusInternal(callId, 'success', successResponse);
-          } else {
-            // It is a failure
-            const error = new Error(toolResult.error.message);
-            const errorResponse = createErrorResponse(
-              scheduledCall.request,
-              error,
-              toolResult.error.type,
-            );
-            this.setStatusInternal(callId, 'error', errorResponse);
-          }
-        } catch (executionError: unknown) {
-          if (signal.aborted) {
-            this.setStatusInternal(
-              callId,
-              'cancelled',
-              'User cancelled tool execution.',
-            );
-          } else {
-            this.setStatusInternal(
-              callId,
-              'error',
-              createErrorResponse(
-                scheduledCall.request,
-                executionError instanceof Error
-                  ? executionError
-                  : new Error(String(executionError)),
-                ToolErrorType.UNHANDLED_EXCEPTION,
-              ),
+              }),
             );
           }
         }
+
+        const response = convertToFunctionResponse(toolName, callId, content);
+        const successResponse: ToolCallResponseInfo = {
+          callId,
+          responseParts: response,
+          resultDisplay: toolResult.returnDisplay,
+          error: undefined,
+          errorType: undefined,
+          outputFile,
+          contentLength,
+        };
+        this.setStatusInternal(callId, 'success', successResponse);
+      } else {
+        // It is a failure
+        const error = new Error(toolResult.error.message);
+        const errorResponse = createErrorResponse(
+          scheduledCall.request,
+          error,
+          toolResult.error.type,
+        );
+        this.setStatusInternal(callId, 'error', errorResponse);
+      }
+    } catch (executionError: unknown) {
+      if (signal.aborted) {
+        this.setStatusInternal(
+          callId,
+          'cancelled',
+          'User cancelled tool execution.',
+        );
+      } else {
+        this.setStatusInternal(
+          callId,
+          'error',
+          createErrorResponse(
+            scheduledCall.request,
+            executionError instanceof Error
+              ? executionError
+              : new Error(String(executionError)),
+            ToolErrorType.UNHANDLED_EXCEPTION,
+          ),
+        );
       }
     }
   }


### PR DESCRIPTION
## TLDR

Changed sub-agent tool calls in `CoreToolScheduler` from **sequential execution** to **parallel execution**, significantly improving performance in multi-tool call scenarios. When the model returns multiple tool calls in a single response, these calls are inherently independent, and parallel execution can greatly reduce total execution time.

> On the left is local debugging: node packages/cli/dist/index.js. The right side is straight qwen. 
<img width="1410" height="870" alt="image" src="https://github.com/user-attachments/assets/f9e64097-1d3f-49cc-a8ca-701faebfe706" />

## Dive Deeper

### Background

In the original implementation, `CoreToolScheduler` used a `for...of` loop to execute each planned tool call sequentially. This meant that if there were N tool calls, each taking time T, the total execution time would be N × T.

### Implementation

1. **Parallel Execution**: Replaced sequential loops with `Promise.allSettled()` to launch all planned tool calls simultaneously
2. **Code Refactoring**: Extracted single tool call execution logic into `executeSingleToolCall()` method for cleaner, more testable code
3. **State Management**: Maintained the original state management mechanism where each tool call independently manages its own state (scheduled → executing → completed/failed)

### Technical Details

- **Thread Safety**: Node.js single-threaded event loop ensures synchronous state changes (like `setStatusInternal`) won't cause race conditions
- **Error Handling**: Uses `Promise.allSettled()` to ensure that even if one tool call fails, others continue executing
- **Protocol Compatibility**: Compliant with LLM tool call protocol — multiple tool calls in the same response cannot reference each other's outputs, making parallel execution safe

### Test Updates

- Updated existing sequential execution tests to verify parallel execution
- Added new test cases to verify parallel execution timing characteristics (two 50ms calls should take ~50ms total, not 100ms)
- Verified timestamp overlap to ensure calls are truly parallel, not sequential

## Reviewer Test Plan

1. **Functional Verification**:
   - Trigger scenarios requiring multiple tool calls (e.g., reading multiple files simultaneously)
   - Verify all tool calls complete correctly
   - Verify result order matches request order

2. **Performance Verification**:
   - Compare response times before and after parallel execution
   - Multi-tool call scenarios should show significant performance improvement

3. **Edge Cases**:
   - Single tool call scenario (should work normally)
   - Tool call failure scenario (should handle errors correctly without affecting other calls)
   - Large number of tool calls scenario (verify system stability)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to sub-agents performance optimization

---

## FAQ

### When does parallel execution happen? When doesn't it?

The key point: **Parallelism only occurs when there are multiple tool calls in the same batch (same `schedule()` call).**

Let me illustrate with actual execution flows:

#### Scenario 1: Model returns 1 tool call (most common, 90%+)

```
Model response: "Let me read this file" → [read_file("a.ts")]
                                    ↓
schedule([1 request]) → _schedule() → attemptExecution()
                                    ↓
callsToExecute = [read_file]   ← only 1
                                    ↓
Promise.allSettled([1 promise])  ← equivalent to await single promise
```

**Behavior is identical to before.** `Promise.allSettled([single])` and `await single` are functionally equivalent.

#### Scenario 2: Model returns 2+ tool calls (the only scenario that triggers parallelism)

```
Model response: "I need to check both files" → [read_file("a.ts"), read_file("b.ts")]
                                    ↓
schedule([2 requests]) → _schedule() → attemptExecution()
                                    ↓
callsToExecute = [read_a, read_b]   ← 2 calls
                                    ↓
Promise.allSettled([promise_a, promise_b])  ← parallel execution!
```

**This is new behavior.** Sequential before, parallel after.

#### Scenario 3: Model returns 1 tool call per turn, across multiple turns

```
Turn 1: Model response → [read_file("a.ts")]
  schedule([1]) → execute → complete → checkAndNotifyCompletion()
  → result returned to model

Turn 2: Model response → [edit("a.ts", ...)]
  schedule([1]) → execute → complete
```

**Only 1 tool call per turn, no parallelism triggered.** Behavior identical to before.

### Key Safety Mechanism: `schedule()` Queue Logic

```typescript
schedule(
  request: ToolCallRequestInfo | ToolCallRequestInfo[],
  signal: AbortSignal,
): Promise<void> {
  if (this.isRunning() || this.isScheduling) {
    return new Promise((resolve, reject) => {
      // ... queued, processed after current batch completes
      this.requestQueue.push({
        request,
        signal,
        resolve: () => { ... },
        reject: (reason?: Error) => { ... },
      });
    });
  }
  return this._schedule(request, signal);
}
```

If a batch is currently executing (`isRunning()`), new `schedule()` calls are **queued** and processed only after the previous batch completes. So **tool calls from different turns will never be mixed and executed in parallel**.

---

## Summary: When Parallelism Happens

```
How many tool calls in the model response?
  │
  ├── 1 ──→ Promise.allSettled([single]) = same as before
  │
  └── 2+ ──→ Promise.allSettled([multiple]) = parallel execution ← only new behavior
```

The deciding factor is not our code, but **how many tool calls the model returns in a single response**.

---

## Do we need to explicitly tell the model to execute in parallel?

**No.** The model decides on its own:

- If the model considers two operations independent, it **will naturally** return multiple tool calls in one response
- If the model considers operations dependent, it **will naturally** return them across multiple turns
- The system prompt already includes guidance like "Launch multiple agents concurrently whenever possible" — this isn't new

You can certainly guide it more explicitly through prompts ("please search these two directories in parallel"), but it's not required.

---

## Will this affect existing task execution logic?

Analyzing real-world scenarios case by case:

| Model Behavior | Before | After | Impact? |
|---------------|--------|-------|---------|
| Returns 1 read_file | Execute 1 sequentially | `Promise.allSettled([1])` = sequential | None |
| Returns 1 edit | Execute 1 sequentially | `Promise.allSettled([1])` = sequential | None |
| Returns 1 shell | Execute 1 sequentially | `Promise.allSettled([1])` = sequential | None |
| Returns 1 task (subagent) | Execute 1 sequentially | `Promise.allSettled([1])` = sequential | None |
| Returns 2 read_file (different files) | Read files sequentially | Read files in parallel | **Faster, no risk** |
| Returns 2 task (subagent) | Run agents sequentially | Run agents in parallel | **Faster, main goal** |
| Returns 2 edit (different files) | Edit sequentially | Edit in parallel | **Faster, no risk** (different files) |
| Returns 2 edit (same file) | Edit sequentially, both succeed | Edit in parallel, second may fail | **Extremely rare; failure feeds back to model for retry** |

The last case (same file double edit) is the only theoretically different scenario, but:
1. The model almost never does this (it knows to merge two edits to the same file into one)
2. Even if it happens, the second edit will error with "string not found", and the model retries in the next turn
3. This is identical to how we handle incorrect parameters from the model — self-correction through error feedback

**Summary: For cases where the model returns only 1 tool call at a time (the vast majority), behavior is 100% identical to before. Only when the model proactively returns multiple tool calls in a single response does parallelism trigger, and these are exactly the cases where parallelism is safe and beneficial.**
