### PR TITLE
fix: enforce plan mode restrictions in ACP sessions

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -516,6 +516,18 @@ export class Session implements SessionContext {
           ? await invocation.shouldConfirmExecute(abortSignal)
           : false;
 
+      // Check for plan mode enforcement - block non-read-only tools
+      const isPlanMode = this.config.getApprovalMode() === ApprovalMode.PLAN;
+      if (isPlanMode && !isExitPlanModeTool && confirmationDetails) {
+        // In plan mode, block any tool that requires confirmation (write operations)
+        return errorResponse(
+          new Error(
+            `Plan mode is active. The tool "${fc.name}" cannot be executed because it modifies the system. ` +
+              'Please use the exit_plan_mode tool to present your plan and exit plan mode before making changes.',
+          ),
+        );
+      }
+
       if (confirmationDetails) {
         const content: acp.ToolCallContent[] = [];
 


### PR DESCRIPTION
## TLDR

Fixes #1806 - ACP session/set_mode("plan") now correctly blocks write tools (edit, write_file, run_shell_command) to enforce read-only/analysis-only behavior.

## Dive Deeper

### Problem
When using ACP protocol, calling `session/set_mode` with `modeId: "plan"` returned success but didn't enforce plan mode restrictions - the agent could still execute file edits and commands.

### Root Cause
`Session.runTool()` in ACP integration lacked plan mode enforcement logic that exists in `CoreToolScheduler` (used by CLI interactive mode and SDK).

### Solution
Added plan mode check in `Session.runTool()` to block tools requiring confirmation (write operations) when in plan mode, except `exit_plan_mode` tool. This aligns ACP behavior with CoreToolScheduler.

### Changes
- **packages/cli/src/acp-integration/session/Session.ts**: Added plan mode enforcement check before tool execution
- **integration-tests/acp-integration.test.ts**: Added test case `blocks write tools in plan mode (issue #1806)` to verify enforcement

## Reviewer Test Plan

1. Start Qwen in ACP mode: `qwen --acp`
2. Initialize and authenticate
3. Create a session and set mode to plan: `session/set_mode {modeId: "plan"}`
4. Send a prompt that triggers write operations (e.g., "Create a file")
5. Verify write tools are blocked with error message mentioning plan mode
6. Verify read-only tools (read_file, grep_search) still work
7. Verify exit_plan_mode tool is allowed

## Testing Matrix

|          | 🍏  | ��  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #1806