### PR TITLE
fix: correct showLineNumbers default value to true

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -373,7 +373,7 @@ const SETTINGS_SCHEMA = {
         label: 'Show Line Numbers in Code',
         category: 'UI',
         requiresRestart: false,
-        default: false,
+        default: true,
         description: 'Show line numbers in the code output.',
         showInDialog: true,
       },


### PR DESCRIPTION
## Description
This PR fixes the inconsistency in the `showLineNumbers` setting's default value reported in issue #1764.

## Problem
The `showLineNumbers` setting had conflicting default values across different parts of the codebase:
- **Schema definition**: `default: false` ❌
- **Code implementation**: `?? true` fallback in CodeColorizer.tsx and DiffRenderer.tsx ✅
- **Documentation**: states default is `true` ✅
- **Tests**: expect line numbers to show by default ✅

This caused confusion as the schema suggested line numbers would be hidden by default, but they were actually shown due to the `?? true` fallback in the code.

## Changes
- Changed `showLineNumbers` default value from `false` to `true` in settingsSchema.ts

## Impact
- **User Experience**: No change for users who haven't configured this setting (line numbers still show by default)
- **Consistency**: Schema, code implementation, documentation, and tests are now aligned
- **Backward Compatibility**: Users who explicitly set `showLineNumbers` are unaffected

## Testing
All related tests pass:
- ✅ settingsSchema.test.ts (14 tests)
- ✅ MarkdownDisplay.test.tsx (31 tests)
- ✅ DiffRenderer.test.tsx (16 tests)

Fixes #1764