### PR TITLE
fix: support JSON Schema draft-2020-12 for MCP tools (fixes #1818)

### DIFF
--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -4,33 +4,68 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import AjvPkg from 'ajv';
+import AjvPkg, { type AnySchema, type Ajv } from 'ajv';
+// Ajv2020 is the documented way to use draft-2020-12: https://ajv.js.org/json-schema.html#draft-2020-12
+// eslint-disable-next-line import/no-internal-modules
+import Ajv2020Pkg from 'ajv/dist/2020.js';
 import * as addFormats from 'ajv-formats';
+import { createDebugLogger } from './debugLogger.js';
+
 // Ajv's ESM/CJS interop: use 'any' for compatibility as recommended by Ajv docs
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const AjvClass = (AjvPkg as any).default || AjvPkg;
-const ajValidator = new AjvClass(
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Ajv2020Class = (Ajv2020Pkg as any).default || Ajv2020Pkg;
+
+const debugLogger = createDebugLogger('SchemaValidator');
+
+const ajvOptions = {
   // See: https://ajv.js.org/options.html#strict-mode-options
-  {
-    // strictSchema defaults to true and prevents use of JSON schemas that
-    // include unrecognized keywords. The JSON schema spec specifically allows
-    // for the use of non-standard keywords and the spec-compliant behavior
-    // is to ignore those keywords. Note that setting this to false also
-    // allows use of non-standard or custom formats (the unknown format value
-    // will be logged but the schema will still be considered valid).
-    strictSchema: false,
-  },
-);
+  // strictSchema defaults to true and prevents use of JSON schemas that
+  // include unrecognized keywords. The JSON schema spec specifically allows
+  // for the use of non-standard keywords and the spec-compliant behavior
+  // is to ignore those keywords. Note that setting this to false also
+  // allows use of non-standard or custom formats (the unknown format value
+  // will be logged but the schema will still be considered valid).
+  strictSchema: false,
+};
+
+// Draft-07 validator (default)
+const ajvDefault: Ajv = new AjvClass(ajvOptions);
+
+// Draft-2020-12 validator for MCP servers using rmcp
+const ajv2020: Ajv = new Ajv2020Class(ajvOptions);
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const addFormatsFunc = (addFormats as any).default || addFormats;
-addFormatsFunc(ajValidator);
+addFormatsFunc(ajvDefault);
+addFormatsFunc(ajv2020);
+
+// Canonical draft-2020-12 meta-schema URI (used by rmcp MCP servers)
+const DRAFT_2020_12_SCHEMA = 'https://json-schema.org/draft/2020-12/schema';
 
 /**
- * Simple utility to validate objects against JSON Schemas
+ * Returns the appropriate validator based on schema's $schema field.
+ */
+function getValidator(schema: AnySchema): Ajv {
+  if (
+    typeof schema === 'object' &&
+    schema !== null &&
+    '$schema' in schema &&
+    schema.$schema === DRAFT_2020_12_SCHEMA
+  ) {
+    return ajv2020;
+  }
+  return ajvDefault;
+}
+
+/**
+ * Simple utility to validate objects against JSON Schemas.
+ * Supports both draft-07 (default) and draft-2020-12 schemas.
  */
 export class SchemaValidator {
   /**
-   * Returns null if the data confroms to the schema described by schema (or if schema
+   * Returns null if the data conforms to the schema described by schema (or if schema
    *  is null). Otherwise, returns a string describing the error.
    */
   static validate(schema: unknown | undefined, data: unknown): string | null {
@@ -40,7 +75,30 @@ export class SchemaValidator {
     if (typeof data !== 'object' || data === null) {
       return 'Value of params must be an object';
     }
-    const validate = ajValidator.compile(schema);
+
+    const anySchema = schema as AnySchema;
+    const validator = getValidator(anySchema);
+
+    // Try to compile and validate; skip validation if schema can't be compiled.
+    // This handles schemas using JSON Schema versions AJV doesn't support
+    // (e.g., draft-2019-09, future versions).
+    // This matches LenientJsonSchemaValidator behavior in mcp-client.ts.
+    let validate;
+    try {
+      validate = validator.compile(anySchema);
+    } catch (error) {
+      // Schema compilation failed (unsupported version, invalid $ref, etc.)
+      // Skip validation rather than blocking tool usage.
+      debugLogger.warn(
+        `Failed to compile schema (${
+           
+          (schema as Record<string, unknown>)?.['$schema'] ?? '<no $schema>'
+        }): ${error instanceof Error ? error.message : String(error)}. ` +
+          'Skipping parameter validation.',
+      );
+      return null;
+    }
+
     let valid = validate(data);
     if (!valid && validate.errors) {
       // Coerce string boolean values ("true"/"false") to actual booleans
@@ -48,7 +106,7 @@ export class SchemaValidator {
 
       valid = validate(data);
       if (!valid && validate.errors) {
-        return ajValidator.errorsText(validate.errors, { dataVar: 'params' });
+        return validator.errorsText(validate.errors, { dataVar: 'params' });
       }
     }
     return null;


### PR DESCRIPTION
## Problem

When using playwright-mcp (Microsoft's Playwright MCP server), calling MCP tools fails with:
```
no schema with key or ref "https://json-schema.org/draft/2020-12/schema"
```

This is because Ajv 8.x does not have built-in meta-schema support for JSON Schema draft-2020-12 by default.

## Solution

Following the [gemini-cli implementation pattern](https://github.com/google-gemini/gemini-cli/blob/main/packages/core/src/utils/schemaValidator.ts):

1. **Add Ajv2020 validator**: Import `ajv/dist/2020.js` to support draft-2020-12 schemas
2. **Auto-select validator**: Based on the `$schema` field in the schema
3. **Graceful degradation**: When schema compilation fails, skip validation and log a warning instead of blocking tool usage

## Changes

- Modified `packages/core/src/utils/schemaValidator.ts`:
  - Added `Ajv2020` import for draft-2020-12 support
  - Added `getValidator()` function to auto-select the appropriate validator
  - Wrapped `compile()` in try-catch for graceful error handling

- Added tests in `packages/core/src/utils/schemaValidator.test.ts`:
  - JSON Schema draft-2020-12 support
  - JSON Schema draft-07 support  
  - Nested schemas with `$schema`
  - 2020-12 specific keywords (`prefixItems`)
  - Graceful handling of unsupported schema versions

## Testing

- ✅ All 22 tests pass
- ✅ Build successful

## Fixes

Fixes #1818