### PR TITLE
Fix auth UI to use semantic theme colors and correct selection sync

### DIFF
--- a/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -10,7 +10,6 @@ import { AuthType } from '@qwen-code/qwen-code-core';
 import { Box, Text } from 'ink';
 import Link from 'ink-link';
 import { theme } from '../semantic-colors.js';
-import { Colors } from '../colors.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { RadioButtonSelect } from '../components/shared/RadioButtonSelect.js';
 import { ApiKeyInput } from '../components/ApiKeyInput.js';
@@ -160,6 +159,8 @@ export function AuthDialog(): React.JSX.Element {
 
     if (viewLevel === 'api-key-sub') {
       setViewLevel('main');
+      // Reset selectedIndex to ensure UI syncs with initialAuthIndex
+      setSelectedIndex(null);
     } else if (viewLevel === 'api-key-input' || viewLevel === 'custom-info') {
       setViewLevel('api-key-sub');
     }
@@ -215,7 +216,7 @@ export function AuthDialog(): React.JSX.Element {
         />
       </Box>
       <Box marginTop={1} paddingLeft={2}>
-        <Text color={Colors.Gray}>
+        <Text color={theme.text.secondary}>
           {currentSelectedAuthType === AuthType.QWEN_OAUTH
             ? t('Login with QwenChat account to use daily free quota.')
             : t('Use coding plan credentials or your own api-keys/providers.')}
@@ -244,7 +245,7 @@ export function AuthDialog(): React.JSX.Element {
         />
       </Box>
       <Box marginTop={1} paddingLeft={2}>
-        <Text color={Colors.Gray}>
+        <Text color={theme.text.secondary}>
           {apiKeySubItems[apiKeySubModeIndex]?.value === 'coding-plan'
             ? t("Paste your api key of Bailian Coding Plan and you're all set!")
             : t(
@@ -282,12 +283,12 @@ export function AuthDialog(): React.JSX.Element {
         <Text>{t('Please configure your models in settings.json:')}</Text>
       </Box>
       <Box marginTop={1} paddingLeft={2}>
-        <Text color={Colors.AccentYellow}>
+        <Text color={theme.status.warning}>
           1. {t('Set API key via environment variable (e.g., OPENAI_API_KEY)')}
         </Text>
       </Box>
       <Box marginTop={0} paddingLeft={2}>
-        <Text color={Colors.AccentYellow}>
+        <Text color={theme.status.warning}>
           2.{' '}
           {t(
             "Add model configuration to modelProviders['openai'] (or other auth types)",
@@ -295,7 +296,7 @@ export function AuthDialog(): React.JSX.Element {
         </Text>
       </Box>
       <Box marginTop={0} paddingLeft={2}>
-        <Text color={Colors.AccentYellow}>
+        <Text color={theme.status.warning}>
           3.{' '}
           {t(
             'Each provider needs: id, envKey (required), plus optional baseUrl, generationConfig',
@@ -303,7 +304,7 @@ export function AuthDialog(): React.JSX.Element {
         </Text>
       </Box>
       <Box marginTop={0} paddingLeft={2}>
-        <Text color={Colors.AccentYellow}>
+        <Text color={theme.status.warning}>
           4.{' '}
           {t(
             'Use /model command to select your preferred model from the configured list',
@@ -324,7 +325,7 @@ export function AuthDialog(): React.JSX.Element {
       </Box>
       <Box marginTop={0}>
         <Link url={MODEL_PROVIDERS_DOCUMENTATION_URL} fallback={false}>
-          <Text color={Colors.AccentGreen} underline>
+          <Text color={theme.status.success} underline>
             {MODEL_PROVIDERS_DOCUMENTATION_URL}
           </Text>
         </Link>
@@ -369,14 +370,14 @@ export function AuthDialog(): React.JSX.Element {
 
       {(authError || errorMessage) && (
         <Box marginTop={1}>
-          <Text color={Colors.AccentRed}>{authError || errorMessage}</Text>
+          <Text color={theme.status.error}>{authError || errorMessage}</Text>
         </Box>
       )}
 
       {viewLevel === 'main' && (
         <>
           <Box marginTop={1}>
-            <Text color={Colors.AccentPurple}>
+            <Text color={theme.text.accent}>
               {t('(Use Enter to Set Auth)')}
             </Text>
           </Box>
@@ -395,7 +396,7 @@ export function AuthDialog(): React.JSX.Element {
             </Text>
           </Box>
           <Box marginTop={1}>
-            <Text color={Colors.AccentBlue}>
+            <Text color={theme.text.link}>
               {
                 'https://qwenlm.github.io/qwen-code-docs/en/users/support/tos-privacy/'
               }

--- a/packages/cli/src/ui/components/ApiKeyInput.tsx
+++ b/packages/cli/src/ui/components/ApiKeyInput.tsx
@@ -8,7 +8,7 @@ import type React from 'react';
 import { useState } from 'react';
 import { Box, Text } from 'ink';
 import { TextInput } from './shared/TextInput.js';
-import { Colors } from '../colors.js';
+import { theme } from '../semantic-colors.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { t } from '../../i18n/index.js';
 import Link from 'ink-link';
@@ -52,7 +52,7 @@ export function ApiKeyInput({
       <TextInput value={apiKey} onChange={setApiKey} placeholder="sk-sp-..." />
       {error && (
         <Box marginTop={1}>
-          <Text color={Colors.AccentRed}>{error}</Text>
+          <Text color={theme.status.error}>{error}</Text>
         </Box>
       )}
       <Box marginTop={1}>
@@ -60,13 +60,13 @@ export function ApiKeyInput({
       </Box>
       <Box marginTop={0}>
         <Link url={CODING_PLAN_API_KEY_URL} fallback={false}>
-          <Text color={Colors.AccentGreen} underline>
+          <Text color={theme.status.success} underline>
             {CODING_PLAN_API_KEY_URL}
           </Text>
         </Link>
       </Box>
       <Box marginTop={1}>
-        <Text color={Colors.Gray}>
+        <Text color={theme.text.secondary}>
           {t('(Press Enter to submit, Escape to cancel)')}
         </Text>
       </Box>


### PR DESCRIPTION
## TLDR

Replaces hardcoded color values with semantic theme colors in authentication UI components (`AuthDialog.tsx` and `ApiKeyInput.tsx`). Also fixes a UI synchronization issue where the selected authentication option and tip text would be out of sync when navigating back from the API-KEY sub-view.

## Dive Deeper

This change migrates the authentication dialogs to use the semantic color system (`theme.text.secondary`, `theme.status.error`, etc.) instead of hardcoded color constants (`Colors.Gray`, `Colors.AccentRed`, etc.). This ensures consistent theming across the application and allows colors to adapt to different themes (light, dark, ANSI).

**Color mapping changes:**
- `Colors.Gray` → `theme.text.secondary`
- `Colors.AccentYellow` → `theme.status.warning`
- `Colors.AccentGreen` → `theme.status.success`
- `Colors.AccentRed` → `theme.status.error`
- `Colors.AccentPurple` → `theme.text.accent`
- `Colors.AccentBlue` → `theme.text.link`

**Bug fix:** When navigating back from the API-KEY sub-view to the main authentication view, the `selectedIndex` state is now reset to `null`. This ensures the UI displays the correct initial selection and matching tip text instead of showing a mismatch between the highlighted option and the descriptive text.

## Reviewer Test Plan

1. Run `npm run build` to ensure the code compiles without errors
2. Run `npm run lint` to verify no linting issues
3. Start the CLI and navigate to the authentication dialog (if testing manually):
   - Check that all text colors display correctly
   - Navigate to API-KEY option, then press Escape to go back
   - Verify the selection returns to Qwen OAuth and the tip text matches

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->

