### PR TITLE
refactor(cli): unify Escape key handling in AppContainer

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -688,7 +688,6 @@ export const AppContainer = (props: AppContainerProps) => {
     terminalWidth,
     terminalHeight,
     handleVisionSwitchRequired, // onVisionSwitchRequired
-    embeddedShellFocused,
   );
 
   // Track whether suggestions are visible for Tab key handling
@@ -896,6 +895,8 @@ export const AppContainer = (props: AppContainerProps) => {
   const ctrlCTimerRef = useRef<NodeJS.Timeout | null>(null);
   const [ctrlDPressedOnce, setCtrlDPressedOnce] = useState(false);
   const ctrlDTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const [escapePressedOnce, setEscapePressedOnce] = useState(false);
+  const escapeTimerRef = useRef<NodeJS.Timeout | null>(null);
   const [constrainHeight, setConstrainHeight] = useState<boolean>(true);
   const [ideContextState, setIdeContextState] = useState<
     IdeContext | undefined
@@ -1172,6 +1173,47 @@ export const AppContainer = (props: AppContainerProps) => {
         }
         handleExit(ctrlDPressedOnce, setCtrlDPressedOnce, ctrlDTimerRef);
         return;
+      } else if (keyMatchers[Command.ESCAPE](key)) {
+        // Escape key handling
+        // Skip if shell is focused (to allow shell's own escape handling)
+        if (embeddedShellFocused) {
+          return;
+        }
+
+        // If input has content, use double-press to clear
+        if (buffer.text.length > 0) {
+          if (escapePressedOnce) {
+            // Second press: clear input, keep the flag to allow immediate cancel
+            buffer.setText('');
+            return;
+          }
+          // First press: set flag and show prompt
+          setEscapePressedOnce(true);
+          escapeTimerRef.current = setTimeout(() => {
+            setEscapePressedOnce(false);
+            escapeTimerRef.current = null;
+          }, CTRL_EXIT_PROMPT_DURATION_MS);
+          return;
+        }
+
+        // Input is empty, cancel request immediately (no double-press needed)
+        if (streamingState === StreamingState.Responding) {
+          if (escapeTimerRef.current) {
+            clearTimeout(escapeTimerRef.current);
+            escapeTimerRef.current = null;
+          }
+          cancelOngoingRequest?.();
+          setEscapePressedOnce(false);
+          return;
+        }
+
+        // No action available, reset the flag
+        if (escapeTimerRef.current) {
+          clearTimeout(escapeTimerRef.current);
+          escapeTimerRef.current = null;
+        }
+        setEscapePressedOnce(false);
+        return;
       }
 
       let enteringConstrainHeightMode = false;
@@ -1216,10 +1258,15 @@ export const AppContainer = (props: AppContainerProps) => {
       ctrlCPressedOnce,
       setCtrlCPressedOnce,
       ctrlCTimerRef,
-      buffer.text.length,
       ctrlDPressedOnce,
       setCtrlDPressedOnce,
       ctrlDTimerRef,
+      escapePressedOnce,
+      setEscapePressedOnce,
+      escapeTimerRef,
+      streamingState,
+      cancelOngoingRequest,
+      buffer,
       handleSlashCommand,
       activePtyId,
       embeddedShellFocused,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -63,7 +63,6 @@ import {
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { useSessionStats } from '../contexts/SessionContext.js';
-import { useKeypress } from './useKeypress.js';
 import type { LoadedSettings } from '../../config/settings.js';
 
 const debugLogger = createDebugLogger('GEMINI_STREAM');
@@ -115,7 +114,6 @@ export const useGeminiStream = (
     persistSessionModel?: string;
     showGuidance?: boolean;
   }>,
-  isShellFocused?: boolean,
 ) => {
   const [initError, setInitError] = useState<string | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -308,15 +306,6 @@ export const useGeminiStream = (
     config,
     getPromptCount,
   ]);
-
-  useKeypress(
-    (key) => {
-      if (key.name === 'escape' && !isShellFocused) {
-        cancelOngoingRequest();
-      }
-    },
-    { isActive: streamingState === StreamingState.Responding },
-  );
 
   const prepareQueryForGemini = useCallback(
     async (


### PR DESCRIPTION
## TLDR

Unifies Escape key handling in `AppContainer.tsx` to resolve conflicts between input clearing and request cancellation. Input clearing requires double-press, while request cancellation works immediately when input is empty.

## Dive Deeper

Previously, Escape key handling was split between `useGeminiStream.ts` (for canceling requests) and `AppContainer.tsx` (for other actions). This caused inconsistent behavior where pressing Escape with content in the input would immediately cancel the request instead of clearing the input first.

Changes made:
- Moved all Escape key logic to `AppContainer.tsx` in the `handleGlobalKeypress` callback
- Removed the `useKeypress` hook and `isShellFocused` parameter from `useGeminiStream.ts`
- Implemented a two-tier behavior:
  - Input with content: Double-press Escape to clear, then single-press to cancel request
  - Empty input: Single-press immediately cancels the ongoing request
- Preserved `embeddedShellFocused` check to allow embedded shells (like Vim) to handle their own Escape key behavior
- Updated tests to call `cancelOngoingRequest` directly instead of simulating keypress events

## Reviewer Test Plan

1. Pull the branch and run `npm run build` in the `packages/cli` directory
2. Start the CLI and type some text in the input prompt
3. Press Escape once - verify a prompt appears indicating another press will clear input
4. Press Escape again - verify input is cleared but request is not canceled
5. Start a query (e.g., ask a question) and while it's responding, press Escape once - verify the request is canceled immediately (since input is empty)
6. Test with embedded shell (Ctrl+F to toggle shell focus, then open Vim) - verify Escape works normally in Vim

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Tests were run on macOS (`npm test` in packages/cli) and all 3338 tests passed.

## Linked issues / bugs

<!-- No linked issues -->
