### PR TITLE
feat: add support for printable CSI-u keys in KeypressContext

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -1335,6 +1335,40 @@ describe('KeypressContext - Kitty Protocol', () => {
     );
   });
 
+  describe('Printable CSI-u keys', () => {
+    it('parses kitty CSI-u space as a space key with literal sequence', () => {
+      const keyHandler = vi.fn();
+      const { result } = renderHook(() => useKeypressContext(), { wrapper });
+      act(() => result.current.subscribe(keyHandler));
+
+      act(() => stdin.sendKittySequence(`\x1b[32u`));
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'space',
+          sequence: ' ',
+          kittyProtocol: true,
+        }),
+      );
+    });
+
+    it('parses kitty CSI-u printable letters as literal input', () => {
+      const keyHandler = vi.fn();
+      const { result } = renderHook(() => useKeypressContext(), { wrapper });
+      act(() => result.current.subscribe(keyHandler));
+
+      act(() => stdin.sendKittySequence(`\x1b[100u`)); // 'd'
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'd',
+          sequence: 'd',
+          kittyProtocol: true,
+        }),
+      );
+    });
+  });
+
   describe('Shift+Tab forms', () => {
     it.each([
       { sequence: `\x1b[Z`, description: 'legacy reverse Tab' },

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -330,6 +330,36 @@ export function KeypressProvider({
           };
         }
 
+        // Printable CSI-u keys (including space) should behave like regular
+        // character input so downstream text inputs receive the literal char.
+        if (
+          terminator === 'u' &&
+          !ctrl &&
+          keyCode >= 32 &&
+          keyCode !== 127 &&
+          keyCode <= 0x10ffff
+        ) {
+          const char = String.fromCodePoint(keyCode);
+          const printableName =
+            char === ' '
+              ? 'space'
+              : /^[A-Za-z]$/.test(char)
+                ? char.toLowerCase()
+                : char;
+          return {
+            key: {
+              name: printableName,
+              ctrl: false,
+              meta: alt,
+              shift,
+              paste: false,
+              sequence: char,
+              kittyProtocol: true,
+            },
+            length: m[0].length,
+          };
+        }
+
         // Ctrl+letters
         if (
           ctrl &&


### PR DESCRIPTION
## TLDR

Add support for printable CSI-u keys (including space) in the KeypressContext to ensure they behave like regular character input when using the Kitty protocol. This allows downstream text inputs to receive the literal character.

## Dive Deeper

The Kitty protocol uses CSI-u sequences for enhanced keyboard reporting. Previously, printable CSI-u keys were not being handled correctly, which could cause issues with text input in CLI applications.

This change adds a new handler for printable CSI-u keys (keyCode >= 32 and <= 0x10ffff, excluding 127 DEL). When such a key is detected, it returns the literal character as the sequence, ensuring that text inputs receive the actual character rather than a special key code.

The implementation:
- Checks if the terminator is 'u' and no Ctrl modifier is present
- Validates the keyCode is in the printable range
- Returns the character with appropriate name (e.g., 'space' for space character)
- Marks the key as using the Kitty protocol

## Reviewer Test Plan

To validate this change works correctly:

1. Run the test suite: `npm test` or `vitest`
2. Specifically run the KeypressContext tests: `npm test -- KeypressContext.test.tsx`
3. Verify the new tests for printable CSI-u keys pass
4. Test manually in a CLI application that uses KeypressContext with Kitty protocol enabled
5. Try typing various printable characters (letters, space) and verify they appear correctly

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | -   | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to improved Kitty protocol support in CLI applications.