### PR TITLE
feat: support MCP readOnlyHint annotation in plan mode (#1826)

### DIFF
--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -29,6 +29,7 @@ import { AuthProviderType, isSdkMcpServerConfig } from '../config/config.js';
 import { GoogleCredentialProvider } from '../mcp/google-auth-provider.js';
 import { ServiceAccountImpersonationProvider } from '../mcp/sa-impersonation-provider.js';
 import { DiscoveredMCPTool } from './mcp-tool.js';
+import type { McpToolAnnotations } from './mcp-tool.js';
 import { SdkControlClientTransport } from './sdk-control-client-transport.js';
 
 import type { FunctionDeclaration } from '@google/genai';
@@ -638,6 +639,23 @@ export async function discoverTools(
       return [];
     }
 
+    // Fetch raw tool list from MCP client to get annotations (readOnlyHint, etc.)
+    // that are not preserved by mcpToTool's functionDeclarations conversion.
+    const annotationsMap = new Map<string, McpToolAnnotations>();
+    try {
+      const listToolsResult = await mcpClient.listTools();
+      for (const mcpTool of listToolsResult.tools) {
+        if (mcpTool.annotations) {
+          annotationsMap.set(mcpTool.name, mcpTool.annotations);
+        }
+      }
+    } catch {
+      // If listTools fails, proceed without annotations — non-critical
+      debugLogger.error(
+        `Failed to fetch tool annotations from MCP server '${mcpServerName}'`,
+      );
+    }
+
     const mcpTimeout = mcpServerConfig.timeout ?? MCP_DEFAULT_TIMEOUT_MSEC;
     const discoveredTools: DiscoveredMCPTool[] = [];
     for (const funcDecl of tool.functionDeclarations) {
@@ -658,6 +676,7 @@ export async function discoverTools(
             cliConfig,
             mcpClient, // raw MCP Client for direct callTool with progress
             mcpTimeout,
+            annotationsMap.get(funcDecl.name!),
           ),
         );
       } catch (error) {


### PR DESCRIPTION
## Summary

MCP tools annotated with `readOnlyHint: true` are now allowed to execute in plan mode without being blocked.

## Problem

Previously, all MCP tools were assigned `Kind.Other` and required user confirmation. In plan mode, any tool requiring confirmation is blocked with:

> "Plan mode blocked a non-read-only tool call."

This means MCP tools that are explicitly marked as read-only (via the MCP `readOnlyHint` annotation) cannot be used in plan mode, even though they are safe to execute. Users cannot gather information from MCP sources while in plan mode.

## Solution

1. **Fetch tool annotations** — During MCP tool discovery, call `mcpClient.listTools()` to retrieve the raw tool list with annotations (which `mcpToTool`'s `functionDeclarations` conversion does not preserve).
2. **Pass annotations through** — Store `McpToolAnnotations` in both `DiscoveredMCPTool` and `DiscoveredMCPToolInvocation`.
3. **Set correct Kind** — Tools with `readOnlyHint: true` get `Kind.Read` instead of `Kind.Other`.
4. **Skip confirmation** — In `shouldConfirmExecute()`, tools with `readOnlyHint: true` return `false` (no confirmation needed), so plan mode does not block them.

## Changes

- `packages/core/src/tools/mcp-tool.ts`: Add `McpToolAnnotations` interface, accept annotations in constructors, use `Kind.Read` for read-only tools, skip confirmation for `readOnlyHint: true`
- `packages/core/src/tools/mcp-client.ts`: Fetch annotations via `mcpClient.listTools()` during discovery, pass to `DiscoveredMCPTool`

## Testing

- MCP tools with `readOnlyHint: true` annotation now execute in plan mode without being blocked
- MCP tools without annotations or with `readOnlyHint: false` behave as before (require confirmation, blocked in plan mode)
- If `listTools()` fails, discovery proceeds gracefully without annotations (non-breaking)

Fixes #1826