### PR TITLE
fix: replace unsupported 'file' content type with text fallback for PDF (#1832)

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -345,16 +345,12 @@ describe('OpenAIContentConverter', () => {
       const contentArray = toolMessage?.content as Array<{
         type: string;
         text?: string;
-        file?: { filename: string; file_data: string };
       }>;
       expect(contentArray).toHaveLength(2);
       expect(contentArray[0].type).toBe('text');
       expect(contentArray[0].text).toBe('PDF content');
-      expect(contentArray[1].type).toBe('file');
-      expect(contentArray[1].file?.filename).toBe('document.pdf');
-      expect(contentArray[1].file?.file_data).toBe(
-        'data:application/pdf;base64,base64pdfdata',
-      );
+      expect(contentArray[1].type).toBe('text');
+      expect(contentArray[1].text).toContain('PDF file: document.pdf');
 
       // No separate user message should be created
       const userMessage = messages.find((message) => message.role === 'user');
@@ -534,16 +530,12 @@ describe('OpenAIContentConverter', () => {
       const contentArray = toolMessage?.content as Array<{
         type: string;
         text?: string;
-        file?: { filename: string; file_data: string };
       }>;
       expect(contentArray).toHaveLength(2);
       expect(contentArray[0].type).toBe('text');
       expect(contentArray[0].text).toBe('PDF content');
-      expect(contentArray[1].type).toBe('file');
-      expect(contentArray[1].file?.filename).toBe('document.pdf');
-      expect(contentArray[1].file?.file_data).toBe(
-        'https://assets.anthropic.com/m/1cd9d098ac3e6467/original/Claude-3-Model-Card-October-Addendum.pdf',
-      );
+      expect(contentArray[1].type).toBe('text');
+      expect(contentArray[1].text).toContain('PDF file: document.pdf');
     });
 
     it('should convert video inlineData to tool message with embedded video_url', () => {

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -71,20 +71,11 @@ type OpenAIContentPartVideoUrl = {
   };
 };
 
-type OpenAIContentPartFile = {
-  type: 'file';
-  file: {
-    filename: string;
-    file_data: string;
-  };
-};
-
 type OpenAIContentPart =
   | OpenAI.Chat.ChatCompletionContentPartText
   | OpenAI.Chat.ChatCompletionContentPartImage
   | OpenAI.Chat.ChatCompletionContentPartInputAudio
-  | OpenAIContentPartVideoUrl
-  | OpenAIContentPartFile;
+  | OpenAIContentPartVideoUrl;
 
 /**
  * Converter class for transforming data between Gemini and OpenAI formats
@@ -600,13 +591,10 @@ export class OpenAIContentConverter {
       }
 
       if (mimeType === 'application/pdf') {
-        const filename = part.inlineData.displayName || 'document.pdf';
+        const displayName = part.inlineData.displayName || 'document.pdf';
         return {
-          type: 'file' as const,
-          file: {
-            filename,
-            file_data: `data:${mimeType};base64,${part.inlineData.data}`,
-          },
+          type: 'text' as const,
+          text: `[PDF file: ${displayName} - PDF content cannot be directly displayed in this context. Please use a text extraction tool or ask the user to provide the content in text format.]`,
         };
       }
 
@@ -656,11 +644,8 @@ export class OpenAIContentConverter {
 
       if (mimeType === 'application/pdf') {
         return {
-          type: 'file' as const,
-          file: {
-            filename,
-            file_data: fileUri,
-          },
+          type: 'text' as const,
+          text: `[PDF file: ${filename} - PDF content cannot be directly displayed in this context. Please use a text extraction tool or ask the user to provide the content in text format.]`,
         };
       }
 


### PR DESCRIPTION
## Problem

When `read_file` reads a PDF file, the OpenAI content converter generates content parts with `type: 'file'`, but DashScope/Qwen API only supports `text`, `image_url`, `video_url`, and `video` content types. This causes a 400 error:

```
Error: Internal error (code: -32603)
Data: {"details":"400 Invalid value: file. Supported values are: 'text','image_url','video_url' and 'video'."}
```

## Root Cause

In `converter.ts`, the `createMediaContentPart` method converts PDF `inlineData` and `fileData` parts to `type: 'file'` format (`OpenAIContentPartFile`), which is not supported by the DashScope API.

## Fix

- Replace PDF content parts with a descriptive text fallback instead of the unsupported `type: 'file'` format
- Remove the unused `OpenAIContentPartFile` type definition
- Update converter tests to match the new behavior

All 49 existing tests pass.

Fixes #1832