### PR TITLE
docs: add news banner about Qwen3.5-Plus launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 </div>
 
+> 🎉 **News (2026-02-16)**: Qwen3.5-Plus is now live! Sign in via Qwen OAuth to use it directly, or get an API key from [Alibaba Cloud ModelStudio](https://modelstudio.console.alibabacloud.com?tab=doc#/doc/?type=model&url=2840914_2&modelId=group-qwen3.5-plus) to access it through the OpenAI-compatible API.
+
 Qwen Code is an open-source AI agent for the terminal, optimized for [Qwen3-Coder](https://github.com/QwenLM/Qwen3-Coder). It helps you understand large codebases, automate tedious work, and ship faster.
 
 ![](https://gw.alicdn.com/imgextra/i1/O1CN01D2DviS1wwtEtMwIzJ_!!6000000006373-2-tps-1600-900.png)


### PR DESCRIPTION
## Summary
This PR adds a news banner to the README announcing the launch of Qwen3.5-Plus.

## Changes
- Added news banner with 🎉 emoji highlighting Qwen3.5-Plus availability
- Included two access methods: Qwen OAuth sign-in and Alibaba Cloud ModelStudio API key

## Related
- News date: 2026-02-16