### PR TITLE
feat: add qwen3.5-plus model support for Coding Plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,18 @@ Use the `/model` command at any time to switch between all configured models.
   "modelProviders": {
     "openai": [
       {
+        "id": "qwen3.5-plus",
+        "name": "qwen3.5-plus (Coding Plan)",
+        "baseUrl": "https://coding.dashscope.aliyuncs.com/v1",
+        "description": "qwen3.5-plus with thinking enabled from Bailian Coding Plan",
+        "envKey": "BAILIAN_CODING_PLAN_API_KEY",
+        "generationConfig": {
+          "extra_body": {
+            "enable_thinking": true
+          }
+        }
+      },
+      {
         "id": "qwen3-coder-plus",
         "name": "qwen3-coder-plus (Coding Plan)",
         "baseUrl": "https://coding.dashscope.aliyuncs.com/v1",
@@ -212,7 +224,7 @@ Use the `/model` command at any time to switch between all configured models.
 }
 ```
 
-> Subscribe to the Coding Plan at [Alibaba Cloud Bailian](https://bailian.console.aliyun.com/cn-beijing/?tab=globalset#/efm/coding_plan).
+> Subscribe to the Coding Plan and get your API key at [Alibaba Cloud Bailian](https://modelstudio.console.aliyun.com/?tab=dashboard#/efm/coding_plan).
 
 </details>
 

--- a/packages/cli/src/constants/codingPlan.ts
+++ b/packages/cli/src/constants/codingPlan.ts
@@ -53,6 +53,19 @@ export function generateCodingPlanTemplate(
     // This ensures existing users don't get prompted for unnecessary updates
     return [
       {
+        id: 'qwen3.5-plus',
+        name: 'qwen3.5-plus',
+        description:
+          'qwen3.5-plus model with thinking enabled from Bailian Coding Plan',
+        baseUrl: 'https://coding.dashscope.aliyuncs.com/v1',
+        envKey: CODING_PLAN_ENV_KEY,
+        generationConfig: {
+          extra_body: {
+            enable_thinking: true,
+          },
+        },
+      },
+      {
         id: 'qwen3-coder-plus',
         name: 'qwen3-coder-plus',
         baseUrl: 'https://coding.dashscope.aliyuncs.com/v1',
@@ -77,6 +90,19 @@ export function generateCodingPlanTemplate(
 
   // Global region uses new description with region indicator
   return [
+    {
+      id: 'qwen3.5-plus',
+      name: 'qwen3.5-plus',
+      description:
+        'qwen3.5-plus model with thinking enabled from Coding Plan (Global/Intl)',
+      baseUrl: 'https://coding-intl.dashscope.aliyuncs.com/v1',
+      envKey: CODING_PLAN_ENV_KEY,
+      generationConfig: {
+        extra_body: {
+          enable_thinking: true,
+        },
+      },
+    },
     {
       id: 'qwen3-coder-plus',
       name: 'qwen3-coder-plus',

--- a/packages/cli/src/ui/components/ApiKeyInput.tsx
+++ b/packages/cli/src/ui/components/ApiKeyInput.tsx
@@ -24,7 +24,7 @@ const CODING_PLAN_API_KEY_URL =
   'https://bailian.console.aliyun.com/?tab=model#/efm/coding_plan';
 
 const CODING_PLAN_INTL_API_KEY_URL =
-  'https://modelstudio.console.alibabacloud.com/ap-southeast-1/?tab=globalset#/efm/api_key';
+  'https://modelstudio.console.alibabacloud.com/?tab=dashboard#/efm/coding_plan';
 
 export function ApiKeyInput({
   onSubmit,

--- a/packages/cli/src/ui/hooks/useCodingPlanUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useCodingPlanUpdates.test.ts
@@ -391,8 +391,8 @@ describe('useCodingPlanUpdates', () => {
       >;
 
       // Should have new China configs + custom config only (global config removed since regions are mutually exclusive)
-      // The template has 2 models, so we expect 2 (from template) + 1 (custom) = 3
-      expect(updatedConfigs.length).toBe(3);
+      // The template has 3 models, so we expect 3 (from template) + 1 (custom) = 4
+      expect(updatedConfigs.length).toBe(4);
 
       // Should NOT contain the Global config (mutually exclusive)
       expect(


### PR DESCRIPTION
## Summary
This PR adds support for the qwen3.5-plus model in the Coding Plan configuration.

<img width="1298" height="518" alt="image" src="https://github.com/user-attachments/assets/d3d2f734-5e2a-4436-a452-47c950e1002e" />
<img width="1330" height="426" alt="image" src="https://github.com/user-attachments/assets/1540801e-e855-446b-9e2a-68a77b130cce" />

## Changes
- Added qwen3.5-plus configuration for both China and Global regions with thinking enabled
- Updated README with qwen3.5-plus setup instructions  
- Fixed Coding Plan console URL for international users
- Updated tests to reflect new model count

## Related
- Updates Coding Plan integration with the latest qwen3.5-plus model