### PR TITLE
feat(runner): support auth_type for model configuration

### DIFF
--- a/integration-tests/concurrent-runner/config.example.json
+++ b/integration-tests/concurrent-runner/config.example.json
@@ -31,5 +31,9 @@
       ]
     }
   ],
-  "models": ["claude-3-5-sonnet-20241022", "qwen3-coder-plus"]
+  "models": [
+    "qwen3-coder-plus",
+    { "name": "glm-4.7", "auth_type": "anthropic" },
+    { "name": "claude-4-5-sonnet-20260219", "auth_type": "anthropic" }
+  ]
 }


### PR DESCRIPTION
## Description
- Add ModelSpec dataclass to hold model name and optional auth_type
- Update RunConfig.models to use List[ModelSpec]
- Add auth_type field to RunRecord with serialization support
- Parse models from config as string or {name, auth_type} dict
- Pass --auth-type flag to qwen command when specified

This enables running models that require non-OpenAI protocols (e.g., glm-4.7 with anthropic auth).

```json
{
  "concurrency": 3,
  "yolo": true,
  "source_repo": ".",
  "branch": "main",
  "worktree_base": "~/.qwen/worktrees",
  "outputs_dir": "./outputs",
  "results_file": "./results.json",
  "tasks": [
    {
      "id": "code-review",
      "name": "Security Code Review",
      "prompts": [
        "Review the codebase for security vulnerabilities.",
        "Focus on input validation, authentication, and data handling."
      ]
    },
    {
      "id": "refactor",
      "name": "Refactoring Suggestions",
      "prompts": [
        "Analyze the code structure and suggest refactoring improvements.",
        "Prioritize changes that improve maintainability and performance."
      ]
    },
    {
      "id": "docs",
      "name": "Documentation Generation",
      "prompts": [
        "Generate comprehensive API documentation for the main modules."
      ]
    }
  ],
  "models": [
    "qwen3-coder-plus",
    { "name": "glm-4.7", "auth_type": "anthropic" },
    { "name": "claude-4-5-sonnet-20260219", "auth_type": "anthropic" }
  ]
}

```
<img width="2550" height="1042" alt="image" src="https://github.com/user-attachments/assets/49792835-2ec4-4758-af61-46286d6e9780" />

