### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: 'Checkout repository'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
         with:
           ref: '${{ github.ref }}'
 

--- a/.github/workflows/check-issue-completeness.yml
+++ b/.github/workflows/check-issue-completeness.yml
@@ -95,7 +95,7 @@ jobs:
       - name: 'Comment on Issue if Information is Missing'
         if: |-
           ${{ steps.check_info.outputs.info_complete == 'false' }}
-        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7
+        uses: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3'  # v9.0.0
         env:
           MISSING_INFO: '${{ steps.check_info.outputs.missing_info }}'
         with:
@@ -164,7 +164,7 @@ jobs:
       - name: 'Add status/need-information Label'
         if: |-
           ${{ steps.check_info.outputs.info_complete == 'false' }}
-        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7
+        uses: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3'  # v9.0.0
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           script: |
@@ -179,7 +179,7 @@ jobs:
       - name: 'Remove status/need-information Label if Complete'
         if: |-
           ${{ steps.check_info.outputs.info_complete == 'true' }}
-        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7
+        uses: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3'  # v9.0.0
         continue-on-error: true
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,13 +91,13 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
         with:
           ref: '${{ github.event.inputs.branch_ref || github.ref }}'
           fetch-depth: 0
 
       - name: 'Set up Node.js 22.x'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4.4.0
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
         with:
           node-version: '22.x'
           cache: 'npm'
@@ -173,10 +173,10 @@ jobs:
             upload-coverage: 'false'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
 
       - name: 'Set up Node.js ${{ matrix.node-version }}'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
         with:
           node-version: '${{ matrix.node-version }}'
           cache: 'npm'
@@ -212,7 +212,7 @@ jobs:
       - name: 'Upload Test Results Artifact (for forks)'
         if: |-
           ${{ always() && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) }}
-        uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
+        uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a'  # v7.0.1
         with:
           name: 'test-results-fork-${{ matrix.node-version }}-${{ matrix.os }}'
           path: 'packages/*/junit.xml'
@@ -220,7 +220,7 @@ jobs:
       - name: 'Upload coverage reports'
         if: |-
           ${{ always() && matrix.upload-coverage == 'true' }}
-        uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
+        uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a'  # v7.0.1
         with:
           name: 'coverage-reports-${{ matrix.node-version }}-${{ matrix.os }}'
           path: 'packages/*/coverage'
@@ -251,10 +251,10 @@ jobs:
           - '22.x'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
 
       - name: 'Download coverage reports artifact'
-        uses: 'actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0' # ratchet:actions/download-artifact@v5
+        uses: 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c'  # v8.0.1
         with:
           name: 'coverage-reports-${{ matrix.node-version }}-${{ matrix.os }}'
           path: 'coverage_artifact' # Download to a specific directory
@@ -281,7 +281,7 @@ jobs:
       security-events: 'write'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
 
       - name: 'Initialize CodeQL'
         uses: 'github/codeql-action/init@df559355d593797519d70b90fc8edd5db049e7a2' # ratchet:github/codeql-action/init@v3

--- a/.github/workflows/docs-page-action.yml
+++ b/.github/workflows/docs-page-action.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
 
       - name: 'Setup Pages'
         uses: 'actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b' # ratchet:actions/configure-pages@v5

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,10 +20,10 @@ jobs:
           - '22.x'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
 
       - name: 'Set up Node.js ${{ matrix.node-version }}'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
         with:
           node-version: '${{ matrix.node-version }}'
           cache: 'npm'
@@ -82,10 +82,10 @@ jobs:
     runs-on: 'macos-latest'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
 
       - name: 'Set up Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/gemini-scheduled-pr-triage.yml
+++ b/.github/workflows/gemini-scheduled-pr-triage.yml
@@ -20,7 +20,7 @@ jobs:
       prs_needing_comment: '${{ steps.run_triage.outputs.prs_needing_comment }}'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
 
       - name: 'Run PR Triage Script'
         id: 'run_triage'

--- a/.github/workflows/qwen-automated-issue-triage.yml
+++ b/.github/workflows/qwen-automated-issue-triage.yml
@@ -187,7 +187,7 @@ jobs:
       - name: 'Post Issue Analysis Failure Comment'
         if: |-
           ${{ failure() && steps.qwen_issue_analysis.outcome == 'failure' }}
-        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7
+        uses: 'actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3'  # v9.0.0
         env:
           ISSUE_NUMBER: '${{ github.event.issue.number }}'
           REPOSITORY: '${{ github.repository }}'

--- a/.github/workflows/qwen-code-pr-review.yml
+++ b/.github/workflows/qwen-code-pr-review.yml
@@ -48,7 +48,7 @@ jobs:
       issues: 'write'
     steps:
       - name: 'Checkout PR code'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
           fetch-depth: 0

--- a/.github/workflows/release-sdk-python.yml
+++ b/.github/workflows/release-sdk-python.yml
@@ -100,7 +100,7 @@ jobs:
           fi
 
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
@@ -136,7 +136,7 @@ jobs:
           echo "sha=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -203,7 +203,7 @@ jobs:
           MANUAL_VERSION: '${{ inputs.version }}'
 
       - name: 'Setup Python'
-        uses: 'actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065' # ratchet:actions/setup-python@v5
+        uses: 'actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405'  # v6.2.0
         with:
           # Keep in sync with packages/sdk-python/pyproject.toml [project] requires-python.
           python-version: '3.11'

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
@@ -95,7 +95,7 @@ jobs:
           echo "is_dry_run=${is_dry_run}" >> "${GITHUB_OUTPUT}"
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/release-vscode-companion.yml
+++ b/.github/workflows/release-vscode-companion.yml
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
@@ -73,7 +73,7 @@ jobs:
           echo "is_dry_run=${is_dry_run}" >> "${GITHUB_OUTPUT}"
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -185,13 +185,13 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -249,7 +249,7 @@ jobs:
         shell: 'bash'
 
       - name: 'Upload VSIX Artifact'
-        uses: 'actions/upload-artifact@v4'
+        uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a'  # v7.0.1
         with:
           name: "vsix-${{ matrix.target || 'universal' }}"
           path: 'qwen-code-vscode-companion-${{ needs.prepare.outputs.release_version }}-*.vsix'
@@ -270,12 +270,12 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
 
       - name: 'Download all VSIX artifacts'
-        uses: 'actions/download-artifact@v4'
+        uses: 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c'  # v8.0.1
         with:
           pattern: 'vsix-*'
           path: 'vsix-artifacts'
@@ -319,7 +319,7 @@ jobs:
 
       - name: 'Upload all VSIXes as release artifacts (dry run)'
         if: "${{ needs.prepare.outputs.is_dry_run == 'true' }}"
-        uses: 'actions/upload-artifact@v4'
+        uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a'  # v7.0.1
         with:
           name: 'all-vsix-packages-${{ needs.prepare.outputs.release_version }}'
           path: 'vsix-artifacts/*.vsix'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
@@ -89,7 +89,7 @@ jobs:
           echo "is_dry_run=${is_dry_run}" >> "${GITHUB_OUTPUT}"
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -153,13 +153,13 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -206,13 +206,13 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -247,13 +247,13 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'
@@ -317,13 +317,13 @@ jobs:
 
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
         with:
           ref: '${{ github.event.inputs.ref || github.sha }}'
           fetch-depth: 0
 
       - name: 'Setup Node.js'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
         with:
           node-version-file: '.nvmrc'
           cache: 'npm'

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -72,10 +72,10 @@ jobs:
         python-version: ['3.10', '3.11', '3.12']
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
 
       - name: 'Set up Python'
-        uses: 'actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065' # ratchet:actions/setup-python@v5
+        uses: 'actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405'  # v6.2.0
         with:
           python-version: '${{ matrix.python-version }}'
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       group: '${{ github.workflow }}-stale'
       cancel-in-progress: true
     steps:
-      - uses: 'actions/stale@5bef64f19d7facfb25b37b414482c7164d639639' # ratchet:actions/stale@v9
+      - uses: 'actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f'  # v10.2.0
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
           # Issues are intentionally disabled here; a separate policy will

--- a/.github/workflows/terminal-bench.yml
+++ b/.github/workflows/terminal-bench.yml
@@ -26,7 +26,7 @@ jobs:
           - 'swe-bench-astropy-1'
     steps:
       - name: 'Checkout'
-        uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
         with:
           submodules: 'recursive'
       - name: 'Install uv and set the python version'
@@ -35,7 +35,7 @@ jobs:
           python-version: '3.12'
 
       - name: 'Set up Node.js 22.x'
-        uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4
+        uses: 'actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e'  # v6.4.0
         with:
           node-version: '22.x'
           cache: 'npm'
@@ -84,7 +84,7 @@ jobs:
 
       - name: 'Upload test artifacts'
         if: 'always()'
-        uses: 'actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b' # ratchet:actions/upload-artifact@v4
+        uses: 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a'  # v7.0.1
         with:
           name: 'terminal-bench-${{ matrix.task_id }}-output'
           path: |


### PR DESCRIPTION
> [!WARNING]
> You may currently be seeing a warning like this in your workflow runs:
>
> ```
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20
> and may not work as expected: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8, actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea, actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020, actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02, actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0, actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065, actions/upload-artifact@v4, actions/download-artifact@v4, actions/stale@5bef64f19d7facfb25b37b414482c7164d639639, actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b.
> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
> Please check if updated versions of these actions are available that support Node.js 24.
> To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment
> variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you
> can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
> For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
> ```
>
> The exact actions listed will vary per workflow.

Upgrades GitHub Actions to versions that support Node 24, since Node 20 is reaching EOL in April 2026.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`08c6903`](https://github.com/actions/checkout/commit/08c6903cd8c0fde910a37f88322edcfb5dd907a8) | [`de0fac2`](https://github.com/actions/checkout/commit/de0fac2e4500dabe0009e67214ff5f5447ce83dd) | [Diff](https://github.com/actions/checkout/compare/08c6903cd8c0...de0fac2e4500) | build-and-publish-image.yml, ci.yml, docs-page-action.yml, e2e.yml, gemini-scheduled-pr-triage.yml, qwen-code-pr-review.yml, release-sdk-python.yml, release-sdk.yml, release-vscode-companion.yml, release.yml, sdk-python.yml, terminal-bench.yml |
| `actions/download-artifact` | [`634f93c`](https://github.com/actions/download-artifact/commit/634f93cb2916e3fdff6788551b99b062d0335ce0), [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`3e5f45b`](https://github.com/actions/download-artifact/commit/3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c) | [Diff](https://github.com/actions/download-artifact/compare/634f93cb2916...3e5f45b2cfb9) | ci.yml, release-vscode-companion.yml |
| `actions/github-script` | [`60a0d83`](https://github.com/actions/github-script/commit/60a0d83039c74a4aee543508d2ffcb1c3799cdea) | [`3a2844b`](https://github.com/actions/github-script/commit/3a2844b7e9c422d3c10d287c895573f7108da1b3) | [Diff](https://github.com/actions/github-script/compare/60a0d83039c7...3a2844b7e9c4) | check-issue-completeness.yml, qwen-automated-issue-triage.yml |
| `actions/setup-node` | [`49933ea`](https://github.com/actions/setup-node/commit/49933ea5288caeca8642d1e84afbd3f7d6820020) | [`48b55a0`](https://github.com/actions/setup-node/commit/48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e) | [Diff](https://github.com/actions/setup-node/compare/49933ea5288c...48b55a011bda) | ci.yml, e2e.yml, release-sdk-python.yml, release-sdk.yml, release-vscode-companion.yml, release.yml, terminal-bench.yml |
| `actions/setup-python` | [`a26af69`](https://github.com/actions/setup-python/commit/a26af69be951a213d495a4c3e4e4022e16d87065) | [`a309ff8`](https://github.com/actions/setup-python/commit/a309ff8b426b58ec0e2a45f0f869d46889d02405) | [Diff](https://github.com/actions/setup-python/compare/a26af69be951...a309ff8b426b) | release-sdk-python.yml, sdk-python.yml |
| `actions/stale` | [`5bef64f`](https://github.com/actions/stale/commit/5bef64f19d7facfb25b37b414482c7164d639639) | [`b5d41d4`](https://github.com/actions/stale/commit/b5d41d4e1d5dceea10e7104786b73624c18a190f) | [Diff](https://github.com/actions/stale/compare/5bef64f19d7f...b5d41d4e1d5d) | stale.yml |
| `actions/upload-artifact` | [`6f51ac0`](https://github.com/actions/upload-artifact/commit/6f51ac03b9356f520e9adb1b1b7802705f340c2b), [`ea165f8`](https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02), [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`043fb46`](https://github.com/actions/upload-artifact/commit/043fb46d1a93c77aae656e7c1c64a875d1fc6a0a) | [Diff](https://github.com/actions/upload-artifact/compare/6f51ac03b935...043fb46d1a93) | ci.yml, release-vscode-companion.yml, terminal-bench.yml |
## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will default to Node 24 starting June 2nd, 2026.

- Node 20 EOL: April 2026
- Node 24 becomes default: June 2nd, 2026

## Notes

All actions are pinned to commit SHAs for supply-chain security. Version comments are included for readability (e.g. `actions/checkout@abc123 # v6`).

Worth running the workflows on a branch before merging to make sure everything still works.
