### PR TITLE
docs: add explanatory comment for 'any' type in runtimeFetchOptions

### DIFF
--- a/packages/core/src/utils/runtimeFetchOptions.ts
+++ b/packages/core/src/utils/runtimeFetchOptions.ts
@@ -44,6 +44,8 @@ export type AnthropicRuntimeFetchOptions = {
     dispatcher?: Dispatcher;
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // The fetch type must be 'any' to match Anthropic SDK's expected fetch signature
+  // which is more permissive than the standard Web Fetch API type
   fetch?: any;
 };
 


### PR DESCRIPTION
## Description

Add a clarifying comment explaining why the 'any' type is necessary for the fetch property in AnthropicRuntimeFetchOptions.

## Changes

- Added explanatory comment for the 'any' type on line 47
- Documents that the type is required to match Anthropic SDK's expected fetch signature
- Explains that the SDK's signature is more permissive than standard Web Fetch API

## Benefits

- Improves code maintainability
- Documents the rationale behind the type choice
- Helps future maintainers understand why 'any' is used here

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>