### PR TITLE
docs: add security note and PATH info to installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ curl -fsSL https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/installation/in
 curl -fsSL -o %TEMP%\install-qwen.bat https://qwen-code-assets.oss-cn-hangzhou.aliyuncs.com/installation/install-qwen.bat && %TEMP%\install-qwen.bat
 ```
 
-> **Note**: It's recommended to restart your terminal after installation to ensure environment variables take effect.
+> **Note**: It's recommended to restart your terminal after installation to ensure environment variables take effect. The installation script adds `qwen` to your PATH automatically.
+
+> **Security**: The quick install script downloads and executes a shell script. For production environments or security-sensitive setups, please use the manual installation method below to review the code before execution.
 
 ### Manual Installation
 


### PR DESCRIPTION
## Description

Add security note and clarify PATH auto-configuration in the installation section.

## Changes

- Added security note about the quick install script for production environments
- Clarified that the installation script automatically adds 'qwen' to PATH
- Helps users make informed decisions about which installation method to use

## Benefits

- Improves security awareness for production deployments
- Reduces confusion about PATH configuration
- Provides actionable information for security-conscious users

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>