### PR TITLE
fix(tools): fix spacing errors in CJK and Latin mixed paths

### DIFF
--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -436,6 +436,26 @@ describe('EditTool', () => {
       expect(display.fileName).toBe(testFile);
     });
 
+    it('should handle mixed CJK/Latin spacing mistakes in file paths', async () => {
+      const realDir = path.join(rootDir, 'image图片');
+      fs.mkdirSync(realDir, { recursive: true });
+      const realFilePath = path.join(realDir, 'target.txt');
+      fs.writeFileSync(realFilePath, 'old value', 'utf8');
+
+      const mangledFilePath = path.join(rootDir, 'image 图片', 'target.txt');
+      const params: EditToolParams = {
+        file_path: mangledFilePath,
+        old_string: 'old',
+        new_string: 'new',
+      };
+
+      const invocation = tool.build(params);
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(result.error).toBeUndefined();
+      expect(fs.readFileSync(realFilePath, 'utf8')).toBe('new value');
+    });
+
     it('should create a new file if old_string is empty and file does not exist, and return created message', async () => {
       const newFileName = 'brand_new_file.txt';
       const newFilePath = path.join(rootDir, newFileName);

--- a/packages/core/src/tools/ls.test.ts
+++ b/packages/core/src/tools/ls.test.ts
@@ -118,6 +118,19 @@ describe('LSTool', () => {
       expect(result.returnDisplay).toBe('Listed 1 item(s).');
     });
 
+    it('should handle mixed CJK/Latin spacing mistakes in directory paths', async () => {
+      const realDir = path.join(tempRootDir, 'image图片');
+      await fs.mkdir(realDir, { recursive: true });
+      await fs.writeFile(path.join(realDir, 'clipboard.txt'), 'x');
+
+      const mangledDir = path.join(tempRootDir, 'image 图片');
+      const invocation = lsTool.build({ path: mangledDir });
+      const result = await invocation.execute(abortSignal);
+
+      expect(result.llmContent).toContain('clipboard.txt');
+      expect(result.returnDisplay).toBe('Listed 1 item(s).');
+    });
+
     it('should handle empty directories', async () => {
       const emptyDir = path.join(tempRootDir, 'empty');
       await fs.mkdir(emptyDir);

--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -424,6 +424,28 @@ describe('ReadFileTool', () => {
       expect(result.returnDisplay).toBe('');
     });
 
+    it('should handle mixed CJK/Latin spacing mistakes in path segments', async () => {
+      const realDir = path.join(tempRootDir, 'image图片');
+      await fsp.mkdir(realDir, { recursive: true });
+      const realFilePath = path.join(realDir, 'clipboard.txt');
+      await fsp.writeFile(realFilePath, 'content-from-cjk-path', 'utf-8');
+
+      const mangledPath = path.join(
+        tempRootDir,
+        'image 图片',
+        'clipboard.txt',
+      );
+      const params: ReadFileToolParams = { absolute_path: mangledPath };
+      const invocation = tool.build(params) as ToolInvocation<
+        ReadFileToolParams,
+        ToolResult
+      >;
+
+      const result = await invocation.execute(abortSignal);
+      expect(result.llmContent).toBe('content-from-cjk-path');
+      expect(result.returnDisplay).toBe('');
+    });
+
     describe('with .qwenignore', () => {
       beforeEach(async () => {
         await fsp.writeFile(


### PR DESCRIPTION
## TLDR

本PR修复了LLM在生成路径时，会错误在CJK字符集（中日韩）与拉丁字符（a-zA-Z0-9）混用的路径段中插入空格的问题。
（例如，`image 图片` 与真实文件夹 `image图片` ）。

> 在issue #1897中，@pomelo-nwu  提到“通过最严厉的prompt也无法绕过去这个问题”，说明通过prompt这块去优化比较困难。同时，`qwen-code`支持多模型、多Provider。不同模型对prompt的遵循程度也会有所不同。所以此处并没有采用优化prompt的方式来约束模型以解决问题。

本PR添加了一个回退机制：
- 如果原始路径存在，则原样使用。
- 如果不存在，则仅针对CJK字符集与拉丁字符的间距错误做修正。
- 且仅在修正后路径实际存在时才会接受，否则保持正常的报错行为。

## Dive Deeper

### Root Cause
LLM有时会把路径字符串当成自然语言格式化掉，而不会遵循严格的字符串规矩。（英文与中文相邻时，LLM会倾向于插入空格来提高回复的可读性。）
所以LLM会偶发地在中英混合的路径段上错误地加上空格。

### Fix
添加了 `resolvePathWithMixedScriptSpacingFix(...)` 函数，并设有严格的边界：
- 仅在原始路径缺失时才会触发。
- 仅修正`中文` `平假名` `片假名` `韩文字母`和`A-Z` `a-z` `0-9`之间的间距。
- 修正后需要进行路径是否存在的检查。

应用于：
- `packages/core/src/tools/read-file.ts`
- `packages/core/src/tools/ls.ts`
- `packages/core/src/tools/edit.ts`

### Tests
在以下位置添加了测试，可供参考：
  - `packages/core/src/tools/read-file.test.ts`
  - `packages/core/src/tools/ls.test.ts`
  - `packages/core/src/tools/edit.test.ts`
  - `packages/core/src/utils/paths.test.ts`

## Reviewer Test Plan

1. 目标问题验证:
```bash
npm run test --workspace packages/core -- src/tools/read-file.test.ts -t "mixed CJK/Latin spacing mistakes" --coverage.enabled false
npm run test --workspace packages/core -- src/tools/ls.test.ts -t "mixed CJK/Latin spacing mistakes" --coverage.enabled false
npm run test --workspace packages/core -- src/tools/edit.test.ts -t "mixed CJK/Latin spacing mistakes" --coverage.enabled false
```

2. 回归验证:
```bash
npm run test --workspace packages/core -- src/tools/read-file.test.ts src/tools/ls.test.ts src/tools/edit.test.ts --coverage.enabled false
```

3. 函数测试:
```bash
npm run test --workspace packages/core -- src/utils/paths.test.ts -t "resolvePathWithMixedScriptSpacingFix" --coverage.enabled false
```

## Testing Matrix

|          | Win | Linux | macOS |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

## Linked issues / bugs
Fixes #1897
Fixes #1923 