### PR TITLE
fix: change workspaceFolders capability to boolean for LSP servers

### DIFF
--- a/packages/core/src/lsp/LspServerManager.ts
+++ b/packages/core/src/lsp/LspServerManager.ts
@@ -523,7 +523,7 @@ export class LspServerManager {
           codeAction: { dynamicRegistration: true },
         },
         workspace: {
-          workspaceFolders: { supported: true },
+          workspaceFolders: true,
         },
       },
       initializationOptions: config.initializationOptions,


### PR DESCRIPTION
## TLDR

Fixes #1748 - gopls failed to start with JSON RPC parse error. Changed the workspaceFolders capability from object `{ supported: true }` to boolean `true` in initialize params, as gopls expects a boolean per the LSP spec.

## Dive Deeper

The LSP spec defines workspaceFolders as a boolean capability, not an object. gopls was rejecting the initialize request because it expected a boolean but received an object.

## Reviewer Test Plan

1. Pull the branch
2. Run `npm install && npm run build`
3. Configure gopls as an LSP server in a Go project
4. Use the LSP documentSymbol tool - should work without errors

## Testing Matrix

|          | 🍏  | 🪟  | 🐧 |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓ |
| npx      | ❓  | ❓  | ❓ |
| Docker   | ❓  | ❓  | ❓ |
| Podman   | ❓  | -   | - |
| Seatbelt | ❓  | -   | - |

## Linked issues / bugs

Fixes #1748