### PR TITLE
fix: resolve examples path for bundled CLI on Windows (#1862)

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "files": [
     "dist/",
+    "packages/cli/src/commands/extensions/examples/",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
## Problem

`qwen extensions new <name> <template>` fails on Windows (and any npm global install) with:

```
Error: ENOENT: no such file or directory, scandir 'C:\Users\...\npm\node_modules\@qwen-code\qwen-code\examples'
```

## Root Cause

Two issues:

1. **Path resolution**: After esbuild bundles everything into `dist/cli.js`, `__dirname` points to the `dist/` folder. `EXAMPLES_PATH = join(__dirname, 'examples')` resolves to `dist/examples/` which doesn't exist.

2. **Missing from npm package**: The `examples` directory is not included in the published npm package (`files` only lists `dist/`, `README.md`, `LICENSE`).

## Fix

1. Added `packages/cli/src/commands/extensions/examples/` to `package.json` `files` so it's included in the npm package
2. Replaced the static `EXAMPLES_PATH` with a `resolveExamplesPath()` function that:
   - Tries the source-relative path first (for development)
   - Falls back to finding the package root via `readPackageUp` and resolving the published examples path
   - Returns the dev path as final fallback (clear ENOENT error)

## Testing

- Existing tests mock `fs/promises` so path resolution is transparent
- The fix is backward-compatible: dev path is tried first

Fixes #1862