### PR TITLE
feat: add Avian as an OpenAI-compatible LLM provider

### DIFF
--- a/docs/users/configuration/model-providers.md
+++ b/docs/users/configuration/model-providers.md
@@ -109,6 +109,71 @@ This auth type supports not only OpenAI's official API but also any OpenAI-compa
 }
 ```
 
+### Avian (`openai`)
+
+[Avian](https://avian.io) is an OpenAI-compatible LLM inference provider offering access to models like DeepSeek-V3.2, Kimi-K2.5, GLM-5, and MiniMax-M2.5. It uses the `openai` auth type with Bearer token authentication.
+
+```bash
+export AVIAN_API_KEY="your-avian-api-key"
+```
+
+```json
+{
+  "modelProviders": {
+    "openai": [
+      {
+        "id": "deepseek/deepseek-v3.2",
+        "name": "DeepSeek V3.2 (Avian)",
+        "envKey": "AVIAN_API_KEY",
+        "baseUrl": "https://api.avian.io/v1",
+        "generationConfig": {
+          "contextWindowSize": 164000,
+          "samplingParams": {
+            "max_tokens": 65000
+          }
+        }
+      },
+      {
+        "id": "moonshotai/kimi-k2.5",
+        "name": "Kimi K2.5 (Avian)",
+        "envKey": "AVIAN_API_KEY",
+        "baseUrl": "https://api.avian.io/v1",
+        "generationConfig": {
+          "contextWindowSize": 131000,
+          "samplingParams": {
+            "max_tokens": 8000
+          }
+        }
+      },
+      {
+        "id": "z-ai/glm-5",
+        "name": "GLM-5 (Avian)",
+        "envKey": "AVIAN_API_KEY",
+        "baseUrl": "https://api.avian.io/v1",
+        "generationConfig": {
+          "contextWindowSize": 131000,
+          "samplingParams": {
+            "max_tokens": 16000
+          }
+        }
+      },
+      {
+        "id": "minimax/minimax-m2.5",
+        "name": "MiniMax M2.5 (Avian)",
+        "envKey": "AVIAN_API_KEY",
+        "baseUrl": "https://api.avian.io/v1",
+        "generationConfig": {
+          "contextWindowSize": 1000000,
+          "samplingParams": {
+            "max_tokens": 1000000
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
 ### Anthropic (`anthropic`)
 
 ```json

--- a/packages/core/src/core/openaiContentGenerator/index.ts
+++ b/packages/core/src/core/openaiContentGenerator/index.ts
@@ -11,6 +11,7 @@ import type {
 import type { Config } from '../../config/config.js';
 import { OpenAIContentGenerator } from './openaiContentGenerator.js';
 import {
+  AvianOpenAICompatibleProvider,
   DashScopeOpenAICompatibleProvider,
   DeepSeekOpenAICompatibleProvider,
   ModelScopeOpenAICompatibleProvider,
@@ -24,6 +25,7 @@ export { ContentGenerationPipeline, type PipelineConfig } from './pipeline.js';
 
 export {
   type OpenAICompatibleProvider,
+  AvianOpenAICompatibleProvider,
   DashScopeOpenAICompatibleProvider,
   DeepSeekOpenAICompatibleProvider,
   OpenRouterOpenAICompatibleProvider,
@@ -77,6 +79,11 @@ export function determineProvider(
       contentGeneratorConfig,
       cliConfig,
     );
+  }
+
+  // Check for Avian provider
+  if (AvianOpenAICompatibleProvider.isAvianProvider(config)) {
+    return new AvianOpenAICompatibleProvider(contentGeneratorConfig, cliConfig);
   }
 
   // Check for ModelScope provider

--- a/packages/core/src/core/openaiContentGenerator/provider/README.md
+++ b/packages/core/src/core/openaiContentGenerator/provider/README.md
@@ -25,6 +25,10 @@ The `DashScopeOpenAICompatibleProvider` handles DashScope (Qwen) specific featur
 
 The `OpenRouterOpenAICompatibleProvider` handles OpenRouter specific headers and configurations.
 
+### Avian Provider
+
+The `AvianOpenAICompatibleProvider` handles Avian (https://avian.io) specific headers. Avian is an OpenAI-compatible LLM inference provider.
+
 ## Adding a New Provider
 
 To add a new provider:

--- a/packages/core/src/core/openaiContentGenerator/provider/avian.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/avian.test.ts
@@ -1,0 +1,210 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type OpenAI from 'openai';
+import { AvianOpenAICompatibleProvider } from './avian.js';
+import { DefaultOpenAICompatibleProvider } from './default.js';
+import type { Config } from '../../../config/config.js';
+import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+
+describe('AvianOpenAICompatibleProvider', () => {
+  let provider: AvianOpenAICompatibleProvider;
+  let mockContentGeneratorConfig: ContentGeneratorConfig;
+  let mockCliConfig: Config;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockContentGeneratorConfig = {
+      apiKey: 'test-api-key',
+      baseUrl: 'https://api.avian.io/v1',
+      timeout: 60000,
+      maxRetries: 2,
+      model: 'deepseek/deepseek-v3.2',
+    } as ContentGeneratorConfig;
+
+    mockCliConfig = {
+      getCliVersion: vi.fn().mockReturnValue('1.0.0'),
+    } as unknown as Config;
+
+    provider = new AvianOpenAICompatibleProvider(
+      mockContentGeneratorConfig,
+      mockCliConfig,
+    );
+  });
+
+  describe('constructor', () => {
+    it('should extend DefaultOpenAICompatibleProvider', () => {
+      expect(provider).toBeInstanceOf(DefaultOpenAICompatibleProvider);
+      expect(provider).toBeInstanceOf(AvianOpenAICompatibleProvider);
+    });
+  });
+
+  describe('isAvianProvider', () => {
+    it('should return true for api.avian.io URLs', () => {
+      const configs = [
+        { baseUrl: 'https://api.avian.io/v1' },
+        { baseUrl: 'https://api.avian.io' },
+        { baseUrl: 'http://api.avian.io/v1' },
+      ];
+
+      configs.forEach((config) => {
+        const result = AvianOpenAICompatibleProvider.isAvianProvider(
+          config as ContentGeneratorConfig,
+        );
+        expect(result).toBe(true);
+      });
+    });
+
+    it('should return false for non-avian URLs', () => {
+      const configs = [
+        { baseUrl: 'https://api.openai.com/v1' },
+        { baseUrl: 'https://api.anthropic.com/v1' },
+        { baseUrl: 'https://openrouter.ai/api/v1' },
+        { baseUrl: 'https://example.com/api/v1' },
+        { baseUrl: '' },
+        { baseUrl: undefined },
+      ];
+
+      configs.forEach((config) => {
+        const result = AvianOpenAICompatibleProvider.isAvianProvider(
+          config as ContentGeneratorConfig,
+        );
+        expect(result).toBe(false);
+      });
+    });
+
+    it('should handle missing baseUrl gracefully', () => {
+      const config = {} as ContentGeneratorConfig;
+      const result = AvianOpenAICompatibleProvider.isAvianProvider(config);
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('buildHeaders', () => {
+    it('should include base headers from parent class', () => {
+      const headers = provider.buildHeaders();
+
+      expect(headers['User-Agent']).toBe(
+        `QwenCode/1.0.0 (${process.platform}; ${process.arch})`,
+      );
+    });
+
+    it('should add Avian-specific headers', () => {
+      const headers = provider.buildHeaders();
+
+      expect(headers).toEqual({
+        'User-Agent': `QwenCode/1.0.0 (${process.platform}; ${process.arch})`,
+        'HTTP-Referer': 'https://github.com/QwenLM/qwen-code.git',
+        'X-Avian-Title': 'Qwen Code',
+      });
+    });
+
+    it('should override parent headers if there are conflicts', () => {
+      const parentBuildHeaders = vi.spyOn(
+        DefaultOpenAICompatibleProvider.prototype,
+        'buildHeaders',
+      );
+      parentBuildHeaders.mockReturnValue({
+        'User-Agent': 'ParentAgent/1.0.0',
+        'HTTP-Referer': 'https://parent.com',
+      });
+
+      const headers = provider.buildHeaders();
+
+      expect(headers).toEqual({
+        'User-Agent': 'ParentAgent/1.0.0',
+        'HTTP-Referer': 'https://github.com/QwenLM/qwen-code.git',
+        'X-Avian-Title': 'Qwen Code',
+      });
+
+      parentBuildHeaders.mockRestore();
+    });
+
+    it('should handle unknown CLI version from parent', () => {
+      vi.mocked(mockCliConfig.getCliVersion).mockReturnValue(undefined);
+
+      const headers = provider.buildHeaders();
+
+      expect(headers['User-Agent']).toBe(
+        `QwenCode/unknown (${process.platform}; ${process.arch})`,
+      );
+      expect(headers['HTTP-Referer']).toBe(
+        'https://github.com/QwenLM/qwen-code.git',
+      );
+      expect(headers['X-Avian-Title']).toBe('Qwen Code');
+    });
+  });
+
+  describe('buildClient', () => {
+    it('should inherit buildClient behavior from parent', () => {
+      const mockClient = { test: 'client' };
+      const parentBuildClient = vi.spyOn(
+        DefaultOpenAICompatibleProvider.prototype,
+        'buildClient',
+      );
+      parentBuildClient.mockReturnValue(mockClient as unknown as OpenAI);
+
+      const result = provider.buildClient();
+
+      expect(parentBuildClient).toHaveBeenCalled();
+      expect(result).toBe(mockClient);
+
+      parentBuildClient.mockRestore();
+    });
+  });
+
+  describe('buildRequest', () => {
+    it('should inherit buildRequest behavior from parent', () => {
+      const mockRequest: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'deepseek/deepseek-v3.2',
+        messages: [{ role: 'user', content: 'Hello' }],
+      };
+      const mockUserPromptId = 'test-prompt-id';
+      const mockResult = { ...mockRequest, modified: true };
+
+      const parentBuildRequest = vi.spyOn(
+        DefaultOpenAICompatibleProvider.prototype,
+        'buildRequest',
+      );
+      parentBuildRequest.mockReturnValue(mockResult);
+
+      const result = provider.buildRequest(mockRequest, mockUserPromptId);
+
+      expect(parentBuildRequest).toHaveBeenCalledWith(
+        mockRequest,
+        mockUserPromptId,
+      );
+      expect(result).toBe(mockResult);
+
+      parentBuildRequest.mockRestore();
+    });
+  });
+
+  describe('integration with parent class', () => {
+    it('should properly call parent constructor', () => {
+      const newProvider = new AvianOpenAICompatibleProvider(
+        mockContentGeneratorConfig,
+        mockCliConfig,
+      );
+
+      expect(newProvider).toHaveProperty('buildHeaders');
+      expect(newProvider).toHaveProperty('buildClient');
+      expect(newProvider).toHaveProperty('buildRequest');
+    });
+
+    it('should maintain parent functionality while adding Avian specifics', () => {
+      const headers = provider.buildHeaders();
+
+      expect(headers['User-Agent']).toBeDefined();
+      expect(headers['HTTP-Referer']).toBe(
+        'https://github.com/QwenLM/qwen-code.git',
+      );
+      expect(headers['X-Avian-Title']).toBe('Qwen Code');
+    });
+  });
+});

--- a/packages/core/src/core/openaiContentGenerator/provider/avian.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/avian.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '../../../config/config.js';
+import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+import { DefaultOpenAICompatibleProvider } from './default.js';
+
+/**
+ * Avian provider for the Avian LLM API.
+ *
+ * Avian (https://avian.io) is an OpenAI-compatible LLM inference provider
+ * offering models like DeepSeek-V3.2, Kimi-K2.5, GLM-5, and MiniMax-M2.5.
+ *
+ * API Base URL: https://api.avian.io/v1
+ * Auth: Bearer token via AVIAN_API_KEY environment variable
+ */
+export class AvianOpenAICompatibleProvider extends DefaultOpenAICompatibleProvider {
+  constructor(
+    contentGeneratorConfig: ContentGeneratorConfig,
+    cliConfig: Config,
+  ) {
+    super(contentGeneratorConfig, cliConfig);
+  }
+
+  static isAvianProvider(
+    contentGeneratorConfig: ContentGeneratorConfig,
+  ): boolean {
+    const baseURL = contentGeneratorConfig.baseUrl || '';
+    return baseURL.includes('api.avian.io');
+  }
+
+  override buildHeaders(): Record<string, string | undefined> {
+    const baseHeaders = super.buildHeaders();
+
+    return {
+      ...baseHeaders,
+      'HTTP-Referer': 'https://github.com/QwenLM/qwen-code.git',
+      'X-Avian-Title': 'Qwen Code',
+    };
+  }
+}

--- a/packages/core/src/core/openaiContentGenerator/provider/index.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/index.ts
@@ -1,3 +1,4 @@
+export { AvianOpenAICompatibleProvider } from './avian.js';
 export { ModelScopeOpenAICompatibleProvider } from './modelscope.js';
 export { DashScopeOpenAICompatibleProvider } from './dashscope.js';
 export { DeepSeekOpenAICompatibleProvider } from './deepseek.js';


### PR DESCRIPTION
## Summary

- Add [Avian](https://avian.io) as a recognized OpenAI-compatible LLM provider with automatic detection for `api.avian.io` base URLs
- Add `AvianOpenAICompatibleProvider` class following the same pattern as `OpenRouterOpenAICompatibleProvider` (extends `DefaultOpenAICompatibleProvider`, adds tracking headers)
- Add Avian configuration examples to model-providers documentation with all available models and their context window sizes

## Details

Avian is an OpenAI-compatible LLM inference provider. This PR adds first-class provider detection so that when users configure `baseUrl: "https://api.avian.io/v1"`, Qwen Code automatically uses the Avian provider with appropriate HTTP headers (`HTTP-Referer`, `X-Avian-Title`) for request attribution.

### Available Models

| Model | Context Window | Max Output |
|-------|---------------|------------|
| `deepseek/deepseek-v3.2` | 164K | 65K |
| `moonshotai/kimi-k2.5` | 131K | 8K |
| `z-ai/glm-5` | 131K | 16K |
| `minimax/minimax-m2.5` | 1M | 1M |

### Quick Setup

```bash
export AVIAN_API_KEY="your-api-key"
```

```json
{
  "modelProviders": {
    "openai": [
      {
        "id": "deepseek/deepseek-v3.2",
        "name": "DeepSeek V3.2 (Avian)",
        "envKey": "AVIAN_API_KEY",
        "baseUrl": "https://api.avian.io/v1"
      }
    ]
  }
}
```

## Files Changed

- `packages/core/src/core/openaiContentGenerator/provider/avian.ts` — New provider class
- `packages/core/src/core/openaiContentGenerator/provider/avian.test.ts` — 12 unit tests
- `packages/core/src/core/openaiContentGenerator/provider/index.ts` — Export new provider
- `packages/core/src/core/openaiContentGenerator/index.ts` — Register in `determineProvider()`
- `packages/core/src/core/openaiContentGenerator/provider/README.md` — Document new provider
- `docs/users/configuration/model-providers.md` — Add configuration examples

## Test Plan

- [x] All 12 new Avian provider tests pass
- [x] All 89 existing provider tests pass (no regressions)
- [x] All 259 openaiContentGenerator tests pass
- [x] Pre-commit hooks (prettier, eslint) pass
- [ ] Verify Avian provider is auto-detected when `baseUrl` contains `api.avian.io`
- [ ] Verify models work via `AVIAN_API_KEY` env var + modelProviders config