### PR TITLE
Rename GEMINI_CLI_INTEGRATION_TEST to QWEN_CODE_INTEGRATION_TEST and refactor sandbox user handling

### DIFF
--- a/integration-tests/globalSetup.ts
+++ b/integration-tests/globalSetup.ts
@@ -94,7 +94,7 @@ export async function setup() {
 
   // Environment variables for CLI integration tests
   process.env['INTEGRATION_TEST_FILE_DIR'] = runDir;
-  process.env['GEMINI_CLI_INTEGRATION_TEST'] = 'true';
+  process.env['QWEN_CODE_INTEGRATION_TEST'] = 'true';
   process.env['TELEMETRY_LOG_FILE'] = join(runDir, 'telemetry.log');
 
   // Environment variables for SDK E2E tests

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build:vscode": "node scripts/build_vscode_companion.js",
     "build:all": "npm run build && npm run build:sandbox && npm run build:vscode",
     "build:packages": "npm run build --workspaces",
-    "build:sandbox": "node scripts/build_sandbox.js -s",
+    "build:sandbox": "node scripts/build_sandbox.js",
     "bundle": "npm run generate && node esbuild.config.js && node scripts/copy_bundle_assets.js",
     "test": "npm run test --workspaces --if-present --parallel",
     "test:ci": "npm run test:ci --workspaces --if-present --parallel && npm run test:scripts",

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -541,7 +541,7 @@ export async function start_sandbox(
   // name container after image, plus random suffix to avoid conflicts
   const imageName = parseImageName(image);
   const isIntegrationTest =
-    process.env['GEMINI_CLI_INTEGRATION_TEST'] === 'true';
+    process.env['QWEN_CODE_INTEGRATION_TEST'] === 'true';
   let containerName;
   if (isIntegrationTest) {
     containerName = `qwen-code-integration-test-${randomBytes(4).toString(
@@ -721,11 +721,10 @@ export async function start_sandbox(
   // tests that need to access host's ~/.qwen (e.g., --resume functionality)
   const useCurrentUser = await shouldUseCurrentUserInSandbox();
 
-  if (!useCurrentUser) {
-    // Use root user (default for integration tests or when explicitly disabled)
-    args.push('--user', 'root');
-    userFlag = '--user root';
-  } else {
+  if (useCurrentUser) {
+    // SANDBOX_SET_UID_GID is enabled: create user with host's UID/GID
+    // This includes integration test mode with SANDBOX_SET_UID_GID=true,
+    // allowing tests that need to access host's ~/.qwen (e.g., --resume) to work.
     // For the user-creation logic to work, the container must start as root.
     // The entrypoint script then handles dropping privileges to the correct user.
     args.push('--user', 'root');
@@ -735,10 +734,10 @@ export async function start_sandbox(
 
     // Instead of passing --user to the main sandbox container, we let it
     // start as root, then create a user with the host's UID/GID, and
-    // finally switch to that user to run the gemini process. This is
+    // finally switch to that user to run the qwen process. This is
     // necessary on Linux to ensure the user exists within the
     // container's /etc/passwd file, which is required by os.userInfo().
-    const username = 'gemini';
+    const username = 'qwen';
     const homeDir = getContainerPath(os.homedir());
 
     const setupUserCommands = [
@@ -761,7 +760,12 @@ export async function start_sandbox(
     userFlag = `--user ${uid}:${gid}`;
     // When forcing a UID in the sandbox, $HOME can be reset to '/', so we copy $HOME as well.
     args.push('--env', `HOME=${os.homedir()}`);
+  } else if (isIntegrationTest) {
+    // Integration test mode with UID/GID matching disabled: use root
+    args.push('--user', 'root');
+    userFlag = '--user root';
   }
+  // else: non-IT mode with UID/GID matching disabled - use image default user (node)
 
   // push container image name
   args.push(image);


### PR DESCRIPTION
## TLDR

Renamed the environment variable `GEMINI_CLI_INTEGRATION_TEST` to `QWEN_CODE_INTEGRATION_TEST` to align with the project name. Refactored sandbox container user handling to support integration tests that need access to the host's `~/.qwen` directory while maintaining backward compatibility for standard test runs.

## Dive Deeper

This PR addresses naming consistency and improves sandbox user handling for integration tests:

**Environment Variable Rename:**
- Changed `GEMINI_CLI_INTEGRATION_TEST` to `QWEN_CODE_INTEGRATION_TEST` in:
  - `integration-tests/globalSetup.ts` - sets the variable for test runs
  - `packages/cli/src/utils/sandbox.ts` - reads the variable to detect integration test mode

**Sandbox User Handling Refactoring:**
The previous logic had a bug where integration tests that need to access the host's `~/.qwen` directory (e.g., for `--resume` functionality) couldn't work properly. The new logic distinguishes four cases based on `QWEN_CODE_INTEGRATION_TEST` and `SANDBOX_SET_UID_GID`:

| Integration Test | SANDBOX_SET_UID_GID | User                                                                      |
| ---------------- | ------------------- | ------------------------------------------------------------------------- |
| `true`           | `true`              | Host's UID/GID (creates matching user, allows access to host's `~/.qwen`) |
| `true`           | `false`             | root (previous default behavior for tests)                                |
| `false`          | `true`              | Host's UID/GID (creates matching user for Linux file permissions)         |
| `false`          | `false`             | Image default (node)                                                      |

**Additional Changes:**
- Removed `-s` flag from `build:sandbox` npm script in `package.json`
- Changed hardcoded username from 'gemini' to 'qwen' in container user creation

## Reviewer Test Plan

1. Run the build to ensure no compilation errors:
   ```
   npm run build
   ```

2. Run integration tests to verify sandbox container creation works:
   ```
   npm run test:integration
   ```

3. Verify that containers are named correctly with `qwen-code-integration-test-` prefix during integration tests.

4. If testing `--resume` functionality in integration tests, ensure `SANDBOX_SET_UID_GID=true` is set and verify the container can access the host's `~/.qwen` directory.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏   | 🪟   | 🐧   |
| -------- | --- | --- | --- |
| npm run  | ✅   | ❓   | ❓   |
| npx      | ❓   | ❓   | ❓   |
| Docker   | ✅   | ❓   | ❓   |
| Podman   | ❓   | -   | -   |
| Seatbelt | ❓   | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
