### PR TITLE
Docs/subagent system prompt limits

### DIFF
--- a/docs/users/features/sub-agents.md
+++ b/docs/users/features/sub-agents.md
@@ -505,7 +505,7 @@ Always follow these standards:
 
 ## Limits
 
-The following limits apply to Subagent configurations:
+The following soft warnings apply to Subagent configurations (no hard limits are enforced):
 
-- **Description Field**: Limited to 300 characters
-- **System Prompt**: Limited to 10,000 characters
+- **Description Field**: A warning is shown for descriptions exceeding 1,000 characters
+- **System Prompt**: A warning is shown for system prompts exceeding 10,000 characters

--- a/packages/cli/src/ui/components/subagents/create/CreationSummary.tsx
+++ b/packages/cli/src/ui/components/subagents/create/CreationSummary.tsx
@@ -94,7 +94,7 @@ export function CreationSummary({
       }
 
       // Check length warnings
-      if (state.generatedDescription.length > 300) {
+      if (state.generatedDescription.length > 1000) {
         allWarnings.push(
           t('Description is over {{length}} characters', {
             length: state.generatedDescription.length.toString(),

--- a/packages/core/src/subagents/validation.test.ts
+++ b/packages/core/src/subagents/validation.test.ts
@@ -164,21 +164,12 @@ describe('SubagentValidator', () => {
       );
     });
 
-    it('should reject prompts that are too long', () => {
-      const longPrompt = 'a'.repeat(10001);
-      const result = validator.validateSystemPrompt(longPrompt);
-      expect(result.isValid).toBe(false);
-      expect(result.errors).toContain(
-        'System prompt is too long (>10,000 characters)',
-      );
-    });
-
     it('should warn about long prompts', () => {
-      const longPrompt = 'a'.repeat(5001);
+      const longPrompt = 'a'.repeat(10001);
       const result = validator.validateSystemPrompt(longPrompt);
       expect(result.isValid).toBe(true);
       expect(result.warnings).toContain(
-        'System prompt is quite long (>5,000 characters), consider shortening',
+        'System prompt is quite long (>10,000 characters), consider shortening',
       );
     });
   });
@@ -372,7 +363,7 @@ describe('SubagentValidator', () => {
       const configWithWarnings: SubagentConfig = {
         ...validConfig,
         name: 'TestAgent', // Will generate warning about case
-        description: 'A'.repeat(501), // Will generate warning about long description
+        description: 'A'.repeat(1001), // Will generate warning about long description
       };
 
       const result = validator.validateConfig(configWithWarnings);

--- a/packages/core/src/subagents/validation.ts
+++ b/packages/core/src/subagents/validation.ts
@@ -36,9 +36,9 @@ export class SubagentValidator {
     // Validate description
     if (!config.description || config.description.trim().length === 0) {
       errors.push('Description is required and cannot be empty');
-    } else if (config.description.length > 500) {
+    } else if (config.description.length > 1000) {
       warnings.push(
-        'Description is quite long (>500 chars), consider shortening for better readability',
+        'Description is quite long (>1,000 chars), consider shortening for better readability',
       );
     }
 
@@ -181,12 +181,10 @@ export class SubagentValidator {
       errors.push('System prompt must be at least 10 characters long');
     }
 
-    // Check maximum length to prevent token issues
+    // Warn for very long prompts
     if (trimmedPrompt.length > 10000) {
-      errors.push('System prompt is too long (>10,000 characters)');
-    } else if (trimmedPrompt.length > 5000) {
       warnings.push(
-        'System prompt is quite long (>5,000 characters), consider shortening',
+        'System prompt is quite long (>10,000 characters), consider shortening',
       );
     }
 


### PR DESCRIPTION
## TLDR

PR adds documentation for the previously undocumented character limits for sub-agent configurations. These limits exist in the code but are undocumented.
- Documents the description field limit of 300 characters
- Documents the system prompt limit of 10,000 

### Dive Deeper

This documentation is  important for users who create agent configurations outside of the built-in /agent create command in Qwen, e.g. when users ask Qwen to create agents by prompting via Qwen CLI.

There is currently no warning or feedback in Qwen itself if users exceed these limits when creating agents outside the /agent create command. The agents just don't show up in the `/agent manage` command, Qwen won't make use of these subagents configs that exceed the limit.

Where these limits are checked: /packages/cli/src/ui/components/subagents/create/CreationSummary.tsx

## To reproduce

Just ask Qwen to write a very detailed agent for a software engineer without going through the /agent create interface, and then tell Qwen to move that into `~/.qwen/agents/`

 If the chars is >10k it will not show up under `/agent manage`

Deleting the system prompt so that it is under 10k chars will allow the sub-agent to show up

## Linked issues / bugs

I was going to raise an issue about externally created agents not being able to be detected by qwen, but i found the 'fix' (i.e. lack of docs) first.

Happy to raise an issue if needed.
