### PR TITLE
feat(i18n): strengthen output-language.md template to enforce language compliance

### DIFF
--- a/packages/cli/src/utils/languageUtils.test.ts
+++ b/packages/cli/src/utils/languageUtils.test.ts
@@ -218,6 +218,43 @@ describe('languageUtils', () => {
         '<!-- qwen-code:llm-output-language: TestLanguage -->',
       );
     });
+
+    it('should use mandatory language rule instead of preference', () => {
+      writeOutputLanguageFile('Chinese');
+
+      const writtenContent = vi.mocked(fs.writeFileSync).mock
+        .calls[0][1] as string;
+      expect(writtenContent).toContain(
+        'You MUST always respond in **Chinese**',
+      );
+      expect(writtenContent).toContain(
+        'This is a mandatory requirement, not a preference.',
+      );
+      expect(writtenContent).not.toContain('Prefer responding');
+    });
+
+    it('should include exception clause for explicit user language requests', () => {
+      writeOutputLanguageFile('English');
+
+      const writtenContent = vi.mocked(fs.writeFileSync).mock
+        .calls[0][1] as string;
+      expect(writtenContent).toContain('## Exception');
+      expect(writtenContent).toContain(
+        "switch to the user's requested language for the remainder of the conversation",
+      );
+    });
+
+    it('should use the correct language name throughout the template', () => {
+      writeOutputLanguageFile('Japanese');
+
+      const writtenContent = vi.mocked(fs.writeFileSync).mock
+        .calls[0][1] as string;
+      expect(writtenContent).toContain(
+        'You MUST always respond in **Japanese**',
+      );
+      expect(writtenContent).toContain('## Rule');
+      expect(writtenContent).toContain('## Exception');
+    });
   });
 
   describe('updateOutputLanguageFile', () => {

--- a/packages/cli/src/utils/languageUtils.ts
+++ b/packages/cli/src/utils/languageUtils.ts
@@ -89,16 +89,17 @@ function generateOutputLanguageFileContent(language: string): string {
   return `# Output language preference: ${language}
 <!-- ${LLM_OUTPUT_LANGUAGE_MARKER_PREFIX} ${safeLanguage} -->
 
-## Goal
-Prefer responding in **${language}** for normal assistant messages and explanations.
+## Rule
+You MUST always respond in **${language}** regardless of the user's input language.
+This is a mandatory requirement, not a preference.
+
+## Exception
+If the user **explicitly** requests a response in a specific language (e.g., "please reply in English", "用中文回答"), switch to the user's requested language for the remainder of the conversation.
 
 ## Keep technical artifacts unchanged
 Do **not** translate or rewrite:
 - Code blocks, CLI commands, file paths, stack traces, logs, JSON keys, identifiers
 - Exact quoted text from the user (keep quotes verbatim)
-
-## When a conflict exists
-If higher-priority instructions (system/developer) require a different behavior, follow them.
 
 ## Tool / system outputs
 Raw tool/system outputs may contain fixed-format English. Preserve them verbatim, and if needed, add a short **${language}** explanation below.


### PR DESCRIPTION
## Summary

- Strengthen the `output-language.md` template wording from soft preference ("Prefer responding") to mandatory rule ("You MUST always respond"), resolving inconsistent output language in multi-turn conversations
- This fixes two classes of language inconsistency:
  - LLM mirroring user's input language instead of the configured output language
  - LLM being influenced by mixed-language content from QWEN.md, downloaded Skills, Agents, and Extensions, causing mid-session language switching or Chinese-English mixed responses
- Add an exception clause allowing users to explicitly override the language for the remainder of a conversation
- Remove the "When a conflict exists" escape clause that allowed injected context to silently override the language setting
- Add 3 unit tests validating the new template content

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/utils/languageUtils.ts` | Update `generateOutputLanguageFileContent()` template |
| `packages/cli/src/utils/languageUtils.test.ts` | Add 3 tests for new template wording |

### Before

```
## Goal
Prefer responding in **${language}** for normal assistant messages and explanations.

## When a conflict exists
If higher-priority instructions (system/developer) require a different behavior, follow them.
```

### After

```
## Rule
You MUST always respond in **${language}** regardless of the user's input language.
This is a mandatory requirement, not a preference.

## Exception
If the user **explicitly** requests a response in a specific language, switch to the
user's requested language for the remainder of the conversation.
```

## Test Plan

- [x] `npx vitest run src/utils/languageUtils.test.ts` — 41 tests pass (3 new)
- [x] Manual: set `output-language.md` to English, send Chinese input -> LLM should respond in English
- [x] Manual: install an English-language Skill/Agent, set output language to Chinese -> LLM should consistently respond in Chinese without mixing English
- [x] Manual: after language enforcement, say "please reply in English" -> LLM should switch to English for the rest of the session

## Linked Issues

Closes #2003
