### PR TITLE
feat: support AGENTS.md as default context file

### DIFF
--- a/packages/core/src/tools/memoryTool.ts
+++ b/packages/core/src/tools/memoryTool.ts
@@ -80,10 +80,11 @@ export const AGENT_CONTEXT_FILENAME = 'AGENTS.md';
 export const MEMORY_SECTION_HEADER = '## Qwen Added Memories';
 
 // This variable will hold the currently configured filename for context files.
-// It defaults to include both AGENTS.md and QWEN.md but can be overridden by setGeminiMdFilename.
+// It defaults to include both QWEN.md and AGENTS.md but can be overridden by setGeminiMdFilename.
+// QWEN.md is first to maintain backward compatibility (used by /init command and save_memory tool).
 let currentGeminiMdFilename: string | string[] = [
-  AGENT_CONTEXT_FILENAME,
   DEFAULT_CONTEXT_FILENAME,
+  AGENT_CONTEXT_FILENAME,
 ];
 
 export function setGeminiMdFilename(newFilename: string | string[]): void {


### PR DESCRIPTION
## TLDR

Add support for `AGENTS.md` as a default context file alongside `QWEN.md`, enabling out-of-the-box compatibility with the [AGENTS.md standard](https://agents.md/) without requiring manual configuration.

## Dive Deeper

This PR implements the feature requested in #2006. Previously, users had to explicitly configure `context.fileName` to use `AGENTS.md`. Now Qwen Code will automatically detect and load both `AGENTS.md` and `QWEN.md` files by default.

**Changes:**
- Added `AGENT_CONTEXT_FILENAME = 'AGENTS.md'` constant
- Updated `currentGeminiMdFilename` default to include both `AGENTS.md` and `QWEN.md`
- `AGENTS.md` takes precedence (first in array) as the de facto standard

**Backward Compatibility:**
- Existing `QWEN.md` files continue to work without changes
- Users can still override via `context.fileName` configuration
- No breaking changes to the API

## Reviewer Test Plan

1. Create an `AGENTS.md` file in a project directory
2. Run Qwen Code and verify the context file is loaded (check `/memory show` command)
3. Verify `QWEN.md` files are still loaded correctly
4. Test that `context.fileName` configuration still overrides defaults

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Tested on macOS with `npm run test` - all memoryTool and memoryDiscovery tests pass.

## Linked issues / bugs

Resolves #2006