### PR TITLE
fix(logging): reduce excessive streaming output in session history logs

### DIFF
--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -154,7 +154,6 @@ export class LoggingContentGenerator implements ContentGenerator {
         response.modelVersion || req.model,
         userPromptId,
         response.usageMetadata,
-        JSON.stringify(response),
       );
       await this.logOpenAIInteraction(openaiRequest, response);
       return response;
@@ -219,7 +218,6 @@ export class LoggingContentGenerator implements ContentGenerator {
         responses[0]?.modelVersion || model,
         userPromptId,
         lastUsageMetadata,
-        JSON.stringify(responses),
       );
       const consolidatedResponse =
         this.consolidateGeminiResponsesForLogging(responses);


### PR DESCRIPTION
## TLDR

Removes `JSON.stringify()` calls for full response objects in `LoggingContentGenerator` to reduce excessive log output in session history files.

## Dive Deeper

The `LoggingContentGenerator` was stringifying entire response objects (including streaming chunks) when logging interactions for OpenAI and Gemini models. This caused session history logs to become extremely large and difficult to read, especially during streaming responses.

The fix removes the stringified response parameters from `logInteraction()` calls while preserving the essential metadata (model version, usage stats, user prompt ID) that is useful for debugging.

### Changes
- Removed `JSON.stringify(response)` from OpenAI logging path
- Removed `JSON.stringify(responses)` from Gemini logging path

## Reviewer Test Plan

1. Run any query that generates streaming output (e.g., `qwen 'explain this code'`)
2. Check the session history log file (located in `~/.qwen/sessions/`)
3. Verify that the logs no longer contain massive JSON blobs of the full response objects
4. Confirm that essential metadata (model, usage) is still present

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

## Linked issues / bugs

No linked issues

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)
