### PR TITLE
feat(cli): change temporary filename prefix to qwen-edit-

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -1840,7 +1840,7 @@ export function useTextBuffer({
         process.env['VISUAL'] ??
         process.env['EDITOR'] ??
         (process.platform === 'win32' ? 'notepad' : 'vi');
-      const tmpDir = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'gemini-edit-'));
+      const tmpDir = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'qwen-edit-'));
       const filePath = pathMod.join(tmpDir, 'buffer.txt');
       fs.writeFileSync(filePath, text, 'utf8');
 


### PR DESCRIPTION
## TLDR

When using `ctrl-x` to edit input content in editor, will open a tmp file. Change the temporary filename prefix from `/tmp/gemini-edit-` to `/tmp/qwen-edit-`
