### PR TITLE
feat(insight): add language support for /insight HTML report

### DIFF
--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -1459,4 +1459,25 @@ export default {
     '{{region}}-Konfiguration erfolgreich aktualisiert. Modell auf "{{model}}" umgeschaltet.',
   'Authenticated successfully with {{region}}. API key and model configs saved to settings.json (backed up).':
     'Erfolgreich mit {{region}} authentifiziert. API-Schlüssel und Modellkonfigurationen wurden in settings.json gespeichert (gesichert).',
+
+  // ============================================================================
+  // Insight Command
+  // ============================================================================
+  'Generating insights...': 'Erstelle Einblicke...',
+  'Generating insights in {{language}}...':
+    'Erstelle Einblicke auf {{language}}...',
+  'generate personalized programming insights from your chat history':
+    'personalisierte Programmier-Einblicke aus Ihrem Chat-Verlauf erstellen',
+  'This may take a couple minutes. Sit tight!':
+    'Dies kann einige Minuten dauern. Bitte warten!',
+  'Starting insight generation...': 'Starte Erstellung der Einblicke...',
+  'Insight report generated successfully!':
+    'Einblicks-Bericht erfolgreich erstellt!',
+  'Opening insights in your browser: {{path}}':
+    'Öffne Einblicke im Browser: {{path}}',
+  'Insights generated at: {{path}}. Please open this file in your browser.':
+    'Einblicke erstellt unter: {{path}}. Bitte öffnen Sie diese Datei in Ihrem Browser.',
+  'Insights ready.': 'Einblicke bereit.',
+  'Failed to generate insights: {{error}}':
+    'Fehler beim Erstellen der Einblicke: {{error}}',
 };

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1448,4 +1448,25 @@ export default {
     '{{region}} configuration updated successfully. Model switched to "{{model}}".',
   'Authenticated successfully with {{region}}. API key and model configs saved to settings.json (backed up).':
     'Authenticated successfully with {{region}}. API key and model configs saved to settings.json (backed up).',
+
+  // ============================================================================
+  // Insight Command
+  // ============================================================================
+  'Generating insights...': 'Generating insights...',
+  'Generating insights in {{language}}...':
+    'Generating insights in {{language}}...',
+  'generate personalized programming insights from your chat history':
+    'generate personalized programming insights from your chat history',
+  'This may take a couple minutes. Sit tight!':
+    'This may take a couple minutes. Sit tight!',
+  'Starting insight generation...': 'Starting insight generation...',
+  'Insight report generated successfully!':
+    'Insight report generated successfully!',
+  'Opening insights in your browser: {{path}}':
+    'Opening insights in your browser: {{path}}',
+  'Insights generated at: {{path}}. Please open this file in your browser.':
+    'Insights generated at: {{path}}. Please open this file in your browser.',
+  'Insights ready.': 'Insights ready.',
+  'Failed to generate insights: {{error}}':
+    'Failed to generate insights: {{error}}',
 };

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -966,4 +966,25 @@ export default {
     '{{region}} の設定が正常に更新されました。モデルが "{{model}}" に切り替わりました。',
   'Authenticated successfully with {{region}}. API key and model configs saved to settings.json (backed up).':
     '{{region}} での認証に成功しました。APIキーとモデル設定が settings.json に保存されました（バックアップ済み）。',
+
+  // ============================================================================
+  // Insight Command
+  // ============================================================================
+  'Generating insights...': 'インサイトを生成中...',
+  'Generating insights in {{language}}...':
+    '{{language}} でインサイトを生成中...',
+  'generate personalized programming insights from your chat history':
+    'チャット履歴からパーソナライズされたプログラミングインサイトを生成',
+  'This may take a couple minutes. Sit tight!':
+    '数分かかる場合があります。しばらくお待ちください。',
+  'Starting insight generation...': 'インサイト生成を開始...',
+  'Insight report generated successfully!':
+    'インサイトレポートが正常に生成されました！',
+  'Opening insights in your browser: {{path}}':
+    'ブラウザでインサイトを開いています：{{path}}',
+  'Insights generated at: {{path}}. Please open this file in your browser.':
+    'インサイトが生成されました：{{path}}。ブラウザでこのファイルを開いてください。',
+  'Insights ready.': 'インサイトの準備ができました。',
+  'Failed to generate insights: {{error}}':
+    'インサイトの生成に失敗しました：{{error}}',
 };

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -1453,4 +1453,25 @@ export default {
     'Configuração do {{region}} atualizada com sucesso. Modelo alterado para "{{model}}".',
   'Authenticated successfully with {{region}}. API key and model configs saved to settings.json (backed up).':
     'Autenticado com sucesso com {{region}}. Chave de API e configurações de modelo salvas em settings.json (com backup).',
+
+  // ============================================================================
+  // Insight Command
+  // ============================================================================
+  'Generating insights...': 'Gerando insights...',
+  'Generating insights in {{language}}...':
+    'Gerando insights em {{language}}...',
+  'generate personalized programming insights from your chat history':
+    'gerar insights de programação personalizados do seu histórico de chat',
+  'This may take a couple minutes. Sit tight!':
+    'Isso pode levar alguns minutos. Aguarde!',
+  'Starting insight generation...': 'Iniciando geração de insights...',
+  'Insight report generated successfully!':
+    'Relatório de insights gerado com sucesso!',
+  'Opening insights in your browser: {{path}}':
+    'Abrindo insights no navegador: {{path}}',
+  'Insights generated at: {{path}}. Please open this file in your browser.':
+    'Insights gerados em: {{path}}. Por favor, abra este arquivo no seu navegador.',
+  'Insights ready.': 'Insights prontos.',
+  'Failed to generate insights: {{error}}':
+    'Falha ao gerar insights: {{error}}',
 };

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -1463,4 +1463,24 @@ export default {
     'Конфигурация {{region}} успешно обновлена. Модель переключена на "{{model}}".',
   'Authenticated successfully with {{region}}. API key and model configs saved to settings.json (backed up).':
     'Успешная аутентификация с {{region}}. API-ключ и конфигурации моделей сохранены в settings.json (резервная копия создана).',
+
+  // ============================================================================
+  // Insight Command
+  // ============================================================================
+  'Generating insights...': 'Генерация инсайтов...',
+  'Generating insights in {{language}}...':
+    'Генерация инсайтов на {{language}}...',
+  'generate personalized programming insights from your chat history':
+    'сгенерировать персонализированные инсайты по программированию из истории чата',
+  'This may take a couple minutes. Sit tight!':
+    'Это может занять несколько минут. Пожалуйста, подождите!',
+  'Starting insight generation...': 'Запуск генерации инсайтов...',
+  'Insight report generated successfully!': 'Отчёт с инсайтами успешно создан!',
+  'Opening insights in your browser: {{path}}':
+    'Открытие инсайтов в браузере: {{path}}',
+  'Insights generated at: {{path}}. Please open this file in your browser.':
+    'Инсайты созданы: {{path}}. Пожалуйста, откройте этот файл в браузере.',
+  'Insights ready.': 'Инсайты готовы.',
+  'Failed to generate insights: {{error}}':
+    'Не удалось создать инсайты: {{error}}',
 };

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1281,4 +1281,21 @@ export default {
     '{{region}} 配置更新成功。模型已切换至 "{{model}}"。',
   'Authenticated successfully with {{region}}. API key and model configs saved to settings.json (backed up).':
     '成功通过 {{region}} 认证。API Key 和模型配置已保存至 settings.json（已备份）。',
+
+  // ============================================================================
+  // Insight Command
+  // ============================================================================
+  'Generating insights...': '正在生成洞察...',
+  'Generating insights in {{language}}...': '正在以 {{language}} 生成洞察...',
+  'generate personalized programming insights from your chat history':
+    '从您的聊天历史生成个性化编程洞察',
+  'This may take a couple minutes. Sit tight!': '这可能需要几分钟，请稍候！',
+  'Starting insight generation...': '开始生成洞察...',
+  'Insight report generated successfully!': '洞察报告生成成功！',
+  'Opening insights in your browser: {{path}}':
+    '正在浏览器中打开洞察报告：{{path}}',
+  'Insights generated at: {{path}}. Please open this file in your browser.':
+    '洞察报告已生成：{{path}}。请在浏览器中打开此文件。',
+  'Insights ready.': '洞察报告已就绪。',
+  'Failed to generate insights: {{error}}': '生成洞察失败：{{error}}',
 };

--- a/packages/cli/src/services/insight/generators/DataProcessor.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.ts
@@ -283,6 +283,7 @@ export class DataProcessor {
     baseDir: string,
     facetsOutputDir?: string,
     onProgress?: InsightProgressCallback,
+    language?: string,
   ): Promise<InsightData> {
     if (onProgress) onProgress('Scanning chat history...', 0);
     const allChatFiles = await this.scanChatFiles(baseDir);
@@ -298,7 +299,11 @@ export class DataProcessor {
     );
 
     if (onProgress) onProgress('Generating personalized insights...', 80);
-    const qualitative = await this.generateQualitativeInsights(metrics, facets);
+    const qualitative = await this.generateQualitativeInsights(
+      metrics,
+      facets,
+      language,
+    );
 
     // Aggregate satisfaction, friction, success and outcome data from facets
     const {
@@ -319,6 +324,7 @@ export class DataProcessor {
       primarySuccess: primarySuccessAgg,
       outcomes: outcomesAgg,
       topGoals: goalsAgg,
+      language,
     };
   }
 
@@ -376,6 +382,7 @@ export class DataProcessor {
   private async generateQualitativeInsights(
     metrics: Omit<InsightData, 'facets' | 'qualitative'>,
     facets: SessionFacets[],
+    language?: string,
   ): Promise<QualitativeInsights | undefined> {
     if (facets.length === 0) {
       return undefined;
@@ -385,11 +392,17 @@ export class DataProcessor {
 
     const commonData = this.prepareCommonPromptData(metrics, facets);
 
+    // Add language instruction to prompts if a non-English language is specified
+    const languageInstruction =
+      language && language !== 'English'
+        ? `\n\nIMPORTANT: Write all narrative content, descriptions, and explanations in **${language}**. Keep section headings, field names, and JSON keys in English.`
+        : '';
+
     const generate = async <T>(
       promptTemplate: string,
       schema: Record<string, unknown>,
     ): Promise<T> => {
-      const prompt = `${promptTemplate}\n\n${commonData}`;
+      const prompt = `${promptTemplate}${languageInstruction}\n\n${commonData}`;
       try {
         const result = await this.config.getBaseLlmClient().generateJson({
           model: this.config.getModel(),

--- a/packages/cli/src/services/insight/generators/StaticInsightGenerator.ts
+++ b/packages/cli/src/services/insight/generators/StaticInsightGenerator.ts
@@ -94,6 +94,7 @@ export class StaticInsightGenerator {
   async generateStaticInsight(
     baseDir: string,
     onProgress?: InsightProgressCallback,
+    language?: string,
   ): Promise<string> {
     // Ensure output directory exists
     const outputDir = await this.ensureOutputDirectory();
@@ -105,6 +106,7 @@ export class StaticInsightGenerator {
       baseDir,
       facetsDir,
       onProgress,
+      language,
     );
 
     // Render HTML

--- a/packages/cli/src/services/insight/types/StaticInsightTypes.ts
+++ b/packages/cli/src/services/insight/types/StaticInsightTypes.ts
@@ -31,6 +31,8 @@ export interface InsightData {
   primarySuccess?: Record<string, number>;
   outcomes?: Record<string, number>;
   topGoals?: Record<string, number>;
+  /** The language used for generating this report (e.g., "Chinese", "English") */
+  language?: string;
 }
 
 export interface StreakData {

--- a/packages/cli/src/ui/commands/insightCommand.ts
+++ b/packages/cli/src/ui/commands/insightCommand.ts
@@ -13,6 +13,7 @@ import { join } from 'path';
 import os from 'os';
 import { StaticInsightGenerator } from '../../services/insight/generators/StaticInsightGenerator.js';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
+import { resolveOutputLanguage } from '../../utils/languageUtils.js';
 import open from 'open';
 
 const logger = createDebugLogger('DataProcessor');
@@ -27,6 +28,11 @@ export const insightCommand: SlashCommand = {
   kind: CommandKind.BUILT_IN,
   action: async (context: CommandContext) => {
     try {
+      // Get the user's output language setting
+      const outputLanguageSetting =
+        context.services?.settings?.merged?.general?.outputLanguage;
+      const language = resolveOutputLanguage(outputLanguageSetting);
+
       context.ui.setDebugMessage(t('Generating insights...'));
 
       const projectsDir = join(os.homedir(), '.qwen', 'projects');
@@ -53,6 +59,15 @@ export const insightCommand: SlashCommand = {
         context.ui.setPendingItem(progressItem);
       };
 
+      // Show language indicator message
+      context.ui.addItem(
+        {
+          type: MessageType.INFO,
+          text: t('Generating insights in {{language}}...', { language }),
+        },
+        Date.now(),
+      );
+
       context.ui.addItem(
         {
           type: MessageType.INFO,
@@ -68,6 +83,7 @@ export const insightCommand: SlashCommand = {
       const outputPath = await insightGenerator.generateStaticInsight(
         projectsDir,
         updateProgress,
+        language,
       );
 
       // Clear pending item

--- a/packages/web-templates/src/insight/src/App.tsx
+++ b/packages/web-templates/src/insight/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useMemo } from 'react';
 import ReactDOM from 'react-dom/client';
 import { StatsRow } from './Header';
 import {
@@ -15,6 +15,7 @@ import {
 import { ShareCard, type Theme } from './ShareCard';
 import './styles.css';
 import type { InsightData } from './types';
+import { getTranslations, interpolateTranslation } from './translations';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 
@@ -22,6 +23,9 @@ import React from 'react';
 function InsightApp({ data }: { data: InsightData }) {
   const [cardTheme, setCardTheme] = useState<Theme>('dark');
   const pendingExport = useRef(false);
+
+  // Get translations based on the language in data
+  const t = useMemo(() => getTranslations(data.language), [data.language]);
 
   const performExport = async () => {
     const card = document.getElementById('share-card');
@@ -96,33 +100,39 @@ function InsightApp({ data }: { data: InsightData }) {
     dateRangeStr = `${formatDate(minDate)} to ${formatDate(maxDate)}`;
   }
 
+  // Generate subtitle
+  const subtitle = data.totalMessages
+    ? interpolateTranslation(t.headerSubtitle, {
+        messages: data.totalMessages.toLocaleString(),
+        sessions: data.totalSessions?.toLocaleString() || '0',
+      })
+    : t.headerSubtitleFallback;
+
   return (
     <div>
       {/* Elegant Header */}
       <header className="insights-header">
         <div className="header-content">
           <div className="header-title-section">
-            <h1 className="header-title">Qwen Code Insights</h1>
+            <h1 className="header-title">{t.headerTitle}</h1>
             <p className="header-subtitle">
-              {data.totalMessages
-                ? `${data.totalMessages.toLocaleString()} messages across ${data.totalSessions?.toLocaleString()} sessions`
-                : 'Your personalized coding journey and patterns'}
+              {subtitle}
               {dateRangeStr && ` · ${dateRangeStr}`}
             </p>
           </div>
 
-          <ExportCardButton onExport={handleExportWithTheme} />
+          <ExportCardButton t={t} onExport={handleExportWithTheme} />
         </div>
       </header>
 
       {data.qualitative && (
         <>
-          <AtAGlance qualitative={data.qualitative} />
-          <NavToc />
+          <AtAGlance qualitative={data.qualitative} t={t} />
+          <NavToc t={t} />
         </>
       )}
 
-      <StatsRow data={data} />
+      <StatsRow data={data} t={t} />
 
       {data.qualitative && (
         <>
@@ -130,13 +140,18 @@ function InsightApp({ data }: { data: InsightData }) {
             qualitative={data.qualitative}
             topGoals={data.topGoals}
             topTools={data.topTools}
+            t={t}
           />
         </>
       )}
 
       {data.qualitative && (
         <>
-          <InteractionStyle qualitative={data.qualitative} insights={data} />
+          <InteractionStyle
+            qualitative={data.qualitative}
+            insights={data}
+            t={t}
+          />
         </>
       )}
 
@@ -146,14 +161,16 @@ function InsightApp({ data }: { data: InsightData }) {
             qualitative={data.qualitative}
             primarySuccess={data.primarySuccess!}
             outcomes={data.outcomes!}
+            t={t}
           />
           <FrictionPoints
             qualitative={data.qualitative}
             satisfaction={data.satisfaction}
             friction={data.friction}
+            t={t}
           />
-          <Improvements qualitative={data.qualitative} />
-          <FutureOpportunities qualitative={data.qualitative} />
+          <Improvements qualitative={data.qualitative} t={t} />
+          <FutureOpportunities qualitative={data.qualitative} t={t} />
           <MemorableMoment qualitative={data.qualitative} />
         </>
       )}
@@ -164,7 +181,13 @@ function InsightApp({ data }: { data: InsightData }) {
 }
 
 // Export Card Button with theme dropdown
-function ExportCardButton({ onExport }: { onExport: (theme: Theme) => void }) {
+function ExportCardButton({
+  t,
+  onExport,
+}: {
+  t: ReturnType<typeof getTranslations>;
+  onExport: (theme: Theme) => void;
+}) {
   const [isOpen, setIsOpen] = useState(false);
   const wrapperRef = useRef<HTMLDivElement>(null);
 
@@ -205,7 +228,7 @@ function ExportCardButton({ onExport }: { onExport: (theme: Theme) => void }) {
           <polyline points="16 6 12 2 8 6" />
           <line x1="12" y1="2" x2="12" y2="15" />
         </svg>
-        <span>Export Card</span>
+        <span>{t.exportCard}</span>
         <svg
           width="12"
           height="12"
@@ -247,7 +270,7 @@ function ExportCardButton({ onExport }: { onExport: (theme: Theme) => void }) {
               <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
               <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
             </svg>
-            <span>Light Theme</span>
+            <span>{t.lightTheme}</span>
           </button>
           <button
             className="export-dropdown-item"
@@ -265,7 +288,7 @@ function ExportCardButton({ onExport }: { onExport: (theme: Theme) => void }) {
             >
               <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
             </svg>
-            <span>Dark Theme</span>
+            <span>{t.darkTheme}</span>
           </button>
         </div>
       )}

--- a/packages/web-templates/src/insight/src/Header.tsx
+++ b/packages/web-templates/src/insight/src/Header.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 import type { InsightData } from './types';
+import type { InsightTranslations } from './translations';
 
 // Header Component
 export function Header({
@@ -27,7 +28,13 @@ export function Header({
   );
 }
 
-export function StatsRow({ data }: { data: InsightData }) {
+export function StatsRow({
+  data,
+  t,
+}: {
+  data: InsightData;
+  t: InsightTranslations;
+}) {
   const {
     totalMessages = 0,
     totalLinesAdded = 0,
@@ -54,25 +61,25 @@ export function StatsRow({ data }: { data: InsightData }) {
     <div className="stats-row">
       <div className="stat">
         <div className="stat-value">{totalMessages}</div>
-        <div className="stat-label">Messages</div>
+        <div className="stat-label">{t.statMessages}</div>
       </div>
       <div className="stat">
         <div className="stat-value">
           +{totalLinesAdded}/-{totalLinesRemoved}
         </div>
-        <div className="stat-label">Lines</div>
+        <div className="stat-label">{t.statLines}</div>
       </div>
       <div className="stat">
         <div className="stat-value">{totalFiles}</div>
-        <div className="stat-label">Files</div>
+        <div className="stat-label">{t.statFiles}</div>
       </div>
       <div className="stat">
         <div className="stat-value">{daysSpan}</div>
-        <div className="stat-label">Days</div>
+        <div className="stat-label">{t.statDays}</div>
       </div>
       <div className="stat">
         <div className="stat-value">{msgsPerDay}</div>
-        <div className="stat-label">Msgs/Day</div>
+        <div className="stat-label">{t.statMsgsPerDay}</div>
       </div>
     </div>
   );

--- a/packages/web-templates/src/insight/src/Qualitative.tsx
+++ b/packages/web-templates/src/insight/src/Qualitative.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { DashboardCards, HeatmapSection } from './Charts';
 import type { InsightData, QualitativeData } from './types';
 import { CopyButton, MarkdownText } from './Components';
+import type { InsightTranslations } from './translations';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 
@@ -10,40 +11,46 @@ import React from 'react';
 // Qualitative Insight Components
 // -----------------------------------------------------------------------------
 
-export function AtAGlance({ qualitative }: { qualitative: QualitativeData }) {
+export function AtAGlance({
+  qualitative,
+  t,
+}: {
+  qualitative: QualitativeData;
+  t: InsightTranslations;
+}) {
   const { atAGlance } = qualitative;
   if (!atAGlance) return null;
 
   return (
     <div className="at-a-glance">
-      <div className="glance-title">At a Glance</div>
+      <div className="glance-title">{t.atAGlanceTitle}</div>
       <div className="glance-sections">
         <div className="glance-section">
-          <strong>What&apos;s working:</strong>{' '}
+          <strong>{t.whatsWorking}</strong>{' '}
           <MarkdownText>{atAGlance.whats_working}</MarkdownText>
           <a href="#section-wins" className="see-more">
-            Impressive Things You Did →
+            {t.navImpressiveThings} →
           </a>
         </div>
         <div className="glance-section">
-          <strong>What&apos;s hindering you:</strong>{' '}
+          <strong>{t.whatsHindering}</strong>{' '}
           <MarkdownText>{atAGlance.whats_hindering}</MarkdownText>
           <a href="#section-friction" className="see-more">
-            Where Things Go Wrong →
+            {t.navWhereThingsGoWrong} →
           </a>
         </div>
         <div className="glance-section">
-          <strong>Quick wins to try:</strong>{' '}
+          <strong>{t.quickWins}</strong>{' '}
           <MarkdownText>{atAGlance.quick_wins}</MarkdownText>
           <a href="#section-features" className="see-more">
-            Features to Try →
+            {t.navFeaturesToTry} →
           </a>
         </div>
         <div className="glance-section">
-          <strong>Ambitious workflows:</strong>{' '}
+          <strong>{t.ambitiousWorkflows}</strong>{' '}
           <MarkdownText>{atAGlance.ambitious_workflows}</MarkdownText>
           <a href="#section-horizon" className="see-more">
-            On the Horizon →
+            {t.navOnTheHorizon} →
           </a>
         </div>
       </div>
@@ -51,16 +58,16 @@ export function AtAGlance({ qualitative }: { qualitative: QualitativeData }) {
   );
 }
 
-export function NavToc() {
+export function NavToc({ t }: { t: InsightTranslations }) {
   return (
     <nav className="nav-toc">
-      <a href="#section-work">What You Work On</a>
-      <a href="#section-usage">How You Use Qwen Code</a>
-      <a href="#section-wins">Impressive Things</a>
-      <a href="#section-friction">Where Things Go Wrong</a>
-      <a href="#section-features">Features to Try</a>
-      <a href="#section-patterns">New Usage Patterns</a>
-      <a href="#section-horizon">On the Horizon</a>
+      <a href="#section-work">{t.navWhatYouWorkOn}</a>
+      <a href="#section-usage">{t.navHowYouUse}</a>
+      <a href="#section-wins">{t.navImpressiveThings}</a>
+      <a href="#section-friction">{t.navWhereThingsGoWrong}</a>
+      <a href="#section-features">{t.navFeaturesToTry}</a>
+      <a href="#section-patterns">{t.navNewUsagePatterns}</a>
+      <a href="#section-horizon">{t.navOnTheHorizon}</a>
     </nav>
   );
 }
@@ -69,10 +76,12 @@ export function ProjectAreas({
   qualitative,
   topGoals,
   topTools,
+  t,
 }: {
   qualitative: QualitativeData;
   topGoals?: Record<string, number>;
   topTools?: Record<string, number> | Array<[string, number]>;
+  t: InsightTranslations;
 }) {
   const { projectAreas } = qualitative;
 
@@ -87,7 +96,7 @@ export function ProjectAreas({
         id="section-work"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        What You Work On
+        {t.sectionWhatYouWorkOn}
       </h2>
 
       {Array.isArray(projectAreas?.areas) && projectAreas.areas.length > 0 && (
@@ -97,7 +106,7 @@ export function ProjectAreas({
               <div className="area-header">
                 <span className="area-name">{area.name}</span>
                 <span className="area-count">
-                  ~{area.session_count} sessions
+                  ~{area.session_count} {t.sessions}
                 </span>
               </div>
               <div className="area-desc">
@@ -119,14 +128,14 @@ export function ProjectAreas({
         {topGoals && Object.keys(topGoals).length > 0 && (
           <HorizontalBarChart
             data={topGoals}
-            title="What You Wanted"
+            title={t.chartWhatYouWanted}
             color="#0ea5e9"
           />
         )}
         {topToolsObj && Object.keys(topToolsObj).length > 0 && (
           <HorizontalBarChart
             data={topToolsObj}
-            title="Top Tools Used"
+            title={t.chartTopToolsUsed}
             color="#6366f1"
           />
         )}
@@ -138,9 +147,11 @@ export function ProjectAreas({
 export function InteractionStyle({
   qualitative,
   insights,
+  t,
 }: {
   qualitative: QualitativeData;
   insights: InsightData;
+  t: InsightTranslations;
 }) {
   const { interactionStyle } = qualitative;
   if (!interactionStyle) return null;
@@ -151,7 +162,7 @@ export function InteractionStyle({
         id="section-usage"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        How You Use Qwen Code
+        {t.sectionHowYouUse}
       </h2>
       <div className="narrative">
         <p>
@@ -159,7 +170,7 @@ export function InteractionStyle({
         </p>
         {interactionStyle.key_pattern && (
           <div className="key-insight">
-            <strong>Key pattern:</strong>{' '}
+            <strong>{t.keyPattern}</strong>{' '}
             <MarkdownText>{interactionStyle.key_pattern}</MarkdownText>
           </div>
         )}
@@ -175,10 +186,12 @@ export function ImpressiveWorkflows({
   qualitative,
   primarySuccess,
   outcomes,
+  t,
 }: {
   qualitative: QualitativeData;
   primarySuccess: Record<string, number>;
   outcomes: Record<string, number>;
+  t: InsightTranslations;
 }) {
   const { impressiveWorkflows } = qualitative;
   if (!impressiveWorkflows) return null;
@@ -189,7 +202,7 @@ export function ImpressiveWorkflows({
         id="section-wins"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        Impressive Things You Did
+        {t.sectionImpressiveThings}
       </h2>
       {impressiveWorkflows.intro && (
         <p className="section-intro">
@@ -220,7 +233,7 @@ export function ImpressiveWorkflows({
         {primarySuccess && Object.keys(primarySuccess).length > 0 && (
           <HorizontalBarChart
             data={primarySuccess}
-            title="What Helped Most (Qwen's Capabilities)"
+            title={t.chartWhatHelpedMost}
             color="#3b82f6"
             allowedKeys={[
               'fast_accurate_search',
@@ -235,7 +248,7 @@ export function ImpressiveWorkflows({
         {outcomes && Object.keys(outcomes).length > 0 && (
           <HorizontalBarChart
             data={outcomes}
-            title="Outcomes"
+            title={t.chartOutcomes}
             color="#8b5cf6"
             allowedKeys={[
               'fully_achieved',
@@ -399,10 +412,12 @@ export function FrictionPoints({
   qualitative,
   satisfaction,
   friction,
+  t,
 }: {
   qualitative: QualitativeData;
   satisfaction?: Record<string, number>;
   friction?: Record<string, number>;
+  t: InsightTranslations;
 }) {
   const { frictionPoints } = qualitative;
   if (!frictionPoints) return null;
@@ -413,7 +428,7 @@ export function FrictionPoints({
         id="section-friction"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        Where Things Go Wrong
+        {t.sectionWhereThingsGoWrong}
       </h2>
       {frictionPoints.intro && (
         <p className="section-intro">
@@ -454,7 +469,7 @@ export function FrictionPoints({
         {friction && Object.keys(friction).length > 0 && (
           <HorizontalBarChart
             data={friction}
-            title="Primary Friction Types"
+            title={t.chartPrimaryFriction}
             color="#ef4444"
             allowedKeys={[
               'misunderstood_request',
@@ -468,7 +483,7 @@ export function FrictionPoints({
         {satisfaction && Object.keys(satisfaction).length > 0 && (
           <HorizontalBarChart
             data={satisfaction}
-            title="Inferred Satisfaction (model-estimated)"
+            title={t.chartInferredSatisfaction}
             color="#10b981"
             allowedKeys={[
               'happy',
@@ -487,10 +502,12 @@ export function FrictionPoints({
 // Qwen.md Additions Section Component
 function QwenMdAdditionsSection({
   additions,
+  t,
 }: {
   additions: NonNullable<
     NonNullable<QualitativeData['improvements']>['Qwen_md_additions']
   >;
+  t: InsightTranslations;
 }) {
   const [checkedState, setCheckedState] = useState(
     new Array(additions.length).fill(true),
@@ -522,10 +539,8 @@ function QwenMdAdditionsSection({
 
   return (
     <div className="qwen-md-section">
-      <h3>Suggested QWEN.md Additions</h3>
-      <p className="text-xs text-slate-500 mb-3">
-        Just copy this into Qwen Code to add it to your QWEN.md.
-      </p>
+      <h3>{t.suggestedQwenMdAdditions}</h3>
+      <p className="text-xs text-slate-500 mb-3">{t.pasteIntoQwenCode}</p>
 
       <div className="qwen-md-actions" style={{ marginBottom: '12px' }}>
         <button
@@ -533,7 +548,9 @@ function QwenMdAdditionsSection({
           onClick={handleCopyAll}
           disabled={checkedCount === 0}
         >
-          {copiedAll ? 'Copied All!' : `Copy All Checked (${checkedCount})`}
+          {copiedAll
+            ? t.copiedAll
+            : t.copyAllChecked.replace('{{count}}', String(checkedCount))}
         </button>
       </div>
 
@@ -560,8 +577,10 @@ function QwenMdAdditionsSection({
 
 export function Improvements({
   qualitative,
+  t,
 }: {
   qualitative: QualitativeData;
+  t: InsightTranslations;
 }) {
   const { improvements } = qualitative;
   if (!improvements) return null;
@@ -572,18 +591,19 @@ export function Improvements({
         id="section-features"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        Existing Qwen Code Features to Try
+        {t.sectionFeaturesToTry}
       </h2>
 
       {/* QWEN.md Additions */}
       {Array.isArray(improvements.Qwen_md_additions) &&
         improvements.Qwen_md_additions.length > 0 && (
-          <QwenMdAdditionsSection additions={improvements.Qwen_md_additions} />
+          <QwenMdAdditionsSection
+            additions={improvements.Qwen_md_additions}
+            t={t}
+          />
         )}
 
-      <p className="text-xs text-slate-500 mb-3">
-        Just copy this into Qwen Code and it&apos;ll set it up for you.
-      </p>
+      <p className="text-xs text-slate-500 mb-3">{t.pasteIntoQwenCode}</p>
 
       {/* Features to Try */}
       <div className="features-section">
@@ -595,7 +615,7 @@ export function Improvements({
                 <MarkdownText>{feat.one_liner}</MarkdownText>
               </div>
               <div className="feature-why">
-                <strong>Why for you:</strong>{' '}
+                <strong>{t.whyForYou}</strong>{' '}
                 <MarkdownText>{feat.why_for_you}</MarkdownText>
               </div>
               <div className="feature-examples">
@@ -614,11 +634,9 @@ export function Improvements({
         id="section-patterns"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        New Ways to Use Qwen Code
+        {t.sectionNewWays}
       </h2>
-      <p className="text-xs text-slate-500 mb-3">
-        Just copy this into Qwen Code and it&apos;ll walk you through it.
-      </p>
+      <p className="text-xs text-slate-500 mb-3">{t.pasteIntoQwenCode}</p>
 
       <div className="patterns-section">
         {Array.isArray(improvements.usage_patterns) &&
@@ -632,7 +650,7 @@ export function Improvements({
                 <MarkdownText>{pat.detail}</MarkdownText>
               </div>
               <div className="copyable-prompt-section">
-                <div className="prompt-label">Paste into Qwen Code:</div>
+                <div className="prompt-label">{t.pasteIntoQwenCode}</div>
                 <div className="copyable-prompt-row">
                   <code className="copyable-prompt">{pat.copyable_prompt}</code>
                   <CopyButton text={pat.copyable_prompt} />
@@ -647,8 +665,10 @@ export function Improvements({
 
 export function FutureOpportunities({
   qualitative,
+  t,
 }: {
   qualitative: QualitativeData;
+  t: InsightTranslations;
 }) {
   const { futureOpportunities } = qualitative;
   if (!futureOpportunities) return null;
@@ -659,7 +679,7 @@ export function FutureOpportunities({
         id="section-horizon"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        On the Horizon
+        {t.sectionOnTheHorizon}
       </h2>
       {futureOpportunities.intro && (
         <p className="section-intro">
@@ -676,11 +696,11 @@ export function FutureOpportunities({
                 <MarkdownText>{opp.whats_possible}</MarkdownText>
               </div>
               <div className="horizon-tip">
-                <strong>Getting started:</strong>{' '}
+                <strong>{t.gettingStarted}</strong>{' '}
                 <MarkdownText>{opp.how_to_try}</MarkdownText>
               </div>
               <div className="pattern-prompt">
-                <div className="prompt-label">Paste into Qwen Code:</div>
+                <div className="prompt-label">{t.pasteIntoQwenCode}</div>
                 <div
                   style={{
                     display: 'flex',

--- a/packages/web-templates/src/insight/src/translations.ts
+++ b/packages/web-templates/src/insight/src/translations.ts
@@ -1,0 +1,564 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Localization strings for the Insight HTML report.
+ * These are static UI strings that need to be translated.
+ * LLM-generated content is handled separately via prompt instructions.
+ */
+
+export type InsightLanguage = 'en' | 'zh' | 'ja' | 'pt' | 'ru' | 'de';
+
+export interface InsightTranslations {
+  // Header
+  headerTitle: string;
+  headerSubtitle: string;
+  headerSubtitleFallback: string;
+
+  // At a Glance section
+  atAGlanceTitle: string;
+  whatsWorking: string;
+  whatsHindering: string;
+  quickWins: string;
+  ambitiousWorkflows: string;
+  seeMore: string;
+
+  // Navigation
+  navWhatYouWorkOn: string;
+  navHowYouUse: string;
+  navImpressiveThings: string;
+  navWhereThingsGoWrong: string;
+  navFeaturesToTry: string;
+  navNewUsagePatterns: string;
+  navOnTheHorizon: string;
+
+  // Stats
+  statMessages: string;
+  statLines: string;
+  statFiles: string;
+  statDays: string;
+  statMsgsPerDay: string;
+
+  // Section titles
+  sectionWhatYouWorkOn: string;
+  sectionHowYouUse: string;
+  sectionImpressiveThings: string;
+  sectionWhereThingsGoWrong: string;
+  sectionFeaturesToTry: string;
+  sectionNewWays: string;
+  sectionOnTheHorizon: string;
+
+  // Project areas
+  sessions: string;
+
+  // Charts
+  chartWhatYouWanted: string;
+  chartTopToolsUsed: string;
+  chartWhatHelpedMost: string;
+  chartOutcomes: string;
+  chartPrimaryFriction: string;
+  chartInferredSatisfaction: string;
+
+  // Interaction style
+  keyPattern: string;
+
+  // Improvements
+  suggestedQwenMdAdditions: string;
+  copyAllChecked: string;
+  copiedAll: string;
+  whyForYou: string;
+  pasteIntoQwenCode: string;
+
+  // Future opportunities
+  gettingStarted: string;
+
+  // Export
+  exportCard: string;
+  lightTheme: string;
+  darkTheme: string;
+
+  // Misc
+  messagesAcrossSessions: string;
+}
+
+const translations: Record<InsightLanguage, InsightTranslations> = {
+  en: {
+    // Header
+    headerTitle: 'Qwen Code Insights',
+    headerSubtitle: '{{messages}} messages across {{sessions}} sessions',
+    headerSubtitleFallback: 'Your personalized coding journey and patterns',
+
+    // At a Glance section
+    atAGlanceTitle: 'At a Glance',
+    whatsWorking: "What's working:",
+    whatsHindering: "What's hindering you:",
+    quickWins: 'Quick wins to try:',
+    ambitiousWorkflows: 'Ambitious workflows:',
+    seeMore: 'See more →',
+
+    // Navigation
+    navWhatYouWorkOn: 'What You Work On',
+    navHowYouUse: 'How You Use Qwen Code',
+    navImpressiveThings: 'Impressive Things',
+    navWhereThingsGoWrong: 'Where Things Go Wrong',
+    navFeaturesToTry: 'Features to Try',
+    navNewUsagePatterns: 'New Usage Patterns',
+    navOnTheHorizon: 'On the Horizon',
+
+    // Stats
+    statMessages: 'Messages',
+    statLines: 'Lines',
+    statFiles: 'Files',
+    statDays: 'Days',
+    statMsgsPerDay: 'Msgs/Day',
+
+    // Section titles
+    sectionWhatYouWorkOn: 'What You Work On',
+    sectionHowYouUse: 'How You Use Qwen Code',
+    sectionImpressiveThings: 'Impressive Things You Did',
+    sectionWhereThingsGoWrong: 'Where Things Go Wrong',
+    sectionFeaturesToTry: 'Existing Qwen Code Features to Try',
+    sectionNewWays: 'New Ways to Use Qwen Code',
+    sectionOnTheHorizon: 'On the Horizon',
+
+    // Project areas
+    sessions: 'sessions',
+
+    // Charts
+    chartWhatYouWanted: 'What You Wanted',
+    chartTopToolsUsed: 'Top Tools Used',
+    chartWhatHelpedMost: "What Helped Most (Qwen's Capabilities)",
+    chartOutcomes: 'Outcomes',
+    chartPrimaryFriction: 'Primary Friction Types',
+    chartInferredSatisfaction: 'Inferred Satisfaction (model-estimated)',
+
+    // Interaction style
+    keyPattern: 'Key pattern:',
+
+    // Improvements
+    suggestedQwenMdAdditions: 'Suggested QWEN.md Additions',
+    copyAllChecked: 'Copy All Checked ({{count}})',
+    copiedAll: 'Copied All!',
+    whyForYou: 'Why for you:',
+    pasteIntoQwenCode: 'Paste into Qwen Code:',
+
+    // Future opportunities
+    gettingStarted: 'Getting started:',
+
+    // Export
+    exportCard: 'Export Card',
+    lightTheme: 'Light Theme',
+    darkTheme: 'Dark Theme',
+
+    // Misc
+    messagesAcrossSessions:
+      '{{messages}} messages across {{sessions}} sessions',
+  },
+
+  zh: {
+    // Header
+    headerTitle: 'Qwen Code 洞察报告',
+    headerSubtitle: '{{sessions}} 个会话中的 {{messages}} 条消息',
+    headerSubtitleFallback: '您的个性化编程旅程和模式',
+
+    // At a Glance section
+    atAGlanceTitle: '概览',
+    whatsWorking: '效果良好的方面：',
+    whatsHindering: '阻碍因素：',
+    quickWins: '快速改进建议：',
+    ambitiousWorkflows: '进阶工作流：',
+    seeMore: '查看详情 →',
+
+    // Navigation
+    navWhatYouWorkOn: '工作内容',
+    navHowYouUse: '使用方式',
+    navImpressiveThings: '精彩表现',
+    navWhereThingsGoWrong: '问题所在',
+    navFeaturesToTry: '推荐功能',
+    navNewUsagePatterns: '新使用模式',
+    navOnTheHorizon: '未来展望',
+
+    // Stats
+    statMessages: '消息数',
+    statLines: '代码行数',
+    statFiles: '文件数',
+    statDays: '天数',
+    statMsgsPerDay: '日均消息',
+
+    // Section titles
+    sectionWhatYouWorkOn: '您的工作内容',
+    sectionHowYouUse: '您如何使用 Qwen Code',
+    sectionImpressiveThings: '您的精彩表现',
+    sectionWhereThingsGoWrong: '问题所在',
+    sectionFeaturesToTry: '值得尝试的 Qwen Code 功能',
+    sectionNewWays: '使用 Qwen Code 的新方式',
+    sectionOnTheHorizon: '未来展望',
+
+    // Project areas
+    sessions: '个会话',
+
+    // Charts
+    chartWhatYouWanted: '您的目标',
+    chartTopToolsUsed: '常用工具',
+    chartWhatHelpedMost: '最有帮助的能力',
+    chartOutcomes: '结果',
+    chartPrimaryFriction: '主要摩擦类型',
+    chartInferredSatisfaction: '推断满意度（模型估算）',
+
+    // Interaction style
+    keyPattern: '关键模式：',
+
+    // Improvements
+    suggestedQwenMdAdditions: '建议添加到 QWEN.md',
+    copyAllChecked: '复制已选 ({{count}})',
+    copiedAll: '已全部复制！',
+    whyForYou: '为什么适合您：',
+    pasteIntoQwenCode: '粘贴到 Qwen Code：',
+
+    // Future opportunities
+    gettingStarted: '入门指南：',
+
+    // Export
+    exportCard: '导出卡片',
+    lightTheme: '浅色主题',
+    darkTheme: '深色主题',
+
+    // Misc
+    messagesAcrossSessions: '{{sessions}} 个会话中的 {{messages}} 条消息',
+  },
+
+  ja: {
+    // Header
+    headerTitle: 'Qwen Code インサイト',
+    headerSubtitle: '{{sessions}} セッションで {{messages}} 件のメッセージ',
+    headerSubtitleFallback:
+      'あなたのパーソナライズされたコーディングの旅とパターン',
+
+    // At a Glance section
+    atAGlanceTitle: '概要',
+    whatsWorking: 'うまくいっていること：',
+    whatsHindering: '妨げていること：',
+    quickWins: 'すぐに試せる改善：',
+    ambitiousWorkflows: '野心的なワークフロー：',
+    seeMore: '詳細を見る →',
+
+    // Navigation
+    navWhatYouWorkOn: '取り組んだ内容',
+    navHowYouUse: '使い方',
+    navImpressiveThings: '素晴らしい成果',
+    navWhereThingsGoWrong: '問題点',
+    navFeaturesToTry: '試すべき機能',
+    navNewUsagePatterns: '新しい使用パターン',
+    navOnTheHorizon: '今後の展望',
+
+    // Stats
+    statMessages: 'メッセージ',
+    statLines: '行数',
+    statFiles: 'ファイル',
+    statDays: '日数',
+    statMsgsPerDay: '日平均メッセージ',
+
+    // Section titles
+    sectionWhatYouWorkOn: '取り組んだ内容',
+    sectionHowYouUse: 'Qwen Code の使い方',
+    sectionImpressiveThings: 'あなたの素晴らしい成果',
+    sectionWhereThingsGoWrong: '問題点',
+    sectionFeaturesToTry: '試すべき Qwen Code 機能',
+    sectionNewWays: 'Qwen Code の新しい使い方',
+    sectionOnTheHorizon: '今後の展望',
+
+    // Project areas
+    sessions: 'セッション',
+
+    // Charts
+    chartWhatYouWanted: 'あなたの目標',
+    chartTopToolsUsed: 'よく使うツール',
+    chartWhatHelpedMost: '最も役立った機能',
+    chartOutcomes: '結果',
+    chartPrimaryFriction: '主な摩擦タイプ',
+    chartInferredSatisfaction: '推定満足度（モデル推定）',
+
+    // Interaction style
+    keyPattern: '主要パターン：',
+
+    // Improvements
+    suggestedQwenMdAdditions: 'QWEN.md への追加提案',
+    copyAllChecked: '選択項目をコピー ({{count}})',
+    copiedAll: 'コピー完了！',
+    whyForYou: 'あなたにおすすめの理由：',
+    pasteIntoQwenCode: 'Qwen Code に貼り付け：',
+
+    // Future opportunities
+    gettingStarted: '始め方：',
+
+    // Export
+    exportCard: 'カードをエクスポート',
+    lightTheme: 'ライトテーマ',
+    darkTheme: 'ダークテーマ',
+
+    // Misc
+    messagesAcrossSessions:
+      '{{sessions}} セッションで {{messages}} 件のメッセージ',
+  },
+
+  pt: {
+    // Header
+    headerTitle: 'Insights do Qwen Code',
+    headerSubtitle: '{{messages}} mensagens em {{sessions}} sessões',
+    headerSubtitleFallback:
+      'Sua jornada de programação personalizada e padrões',
+
+    // At a Glance section
+    atAGlanceTitle: 'Visão Geral',
+    whatsWorking: 'O que está funcionando:',
+    whatsHindering: 'O que está atrapalhando:',
+    quickWins: 'Vitórias rápidas:',
+    ambitiousWorkflows: 'Fluxos de trabalho ambiciosos:',
+    seeMore: 'Ver mais →',
+
+    // Navigation
+    navWhatYouWorkOn: 'No Que Você Trabalha',
+    navHowYouUse: 'Como Você Usa',
+    navImpressiveThings: 'Coisas Impressionantes',
+    navWhereThingsGoWrong: 'Onde as Coisas Dão Errado',
+    navFeaturesToTry: 'Recursos para Experimentar',
+    navNewUsagePatterns: 'Novos Padrões de Uso',
+    navOnTheHorizon: 'No Horizonte',
+
+    // Stats
+    statMessages: 'Mensagens',
+    statLines: 'Linhas',
+    statFiles: 'Arquivos',
+    statDays: 'Dias',
+    statMsgsPerDay: 'Msgs/Dia',
+
+    // Section titles
+    sectionWhatYouWorkOn: 'No Que Você Trabalha',
+    sectionHowYouUse: 'Como Você Usa o Qwen Code',
+    sectionImpressiveThings: 'Coisas Impressionantes Que Você Fez',
+    sectionWhereThingsGoWrong: 'Onde as Coisas Dão Errado',
+    sectionFeaturesToTry: 'Recursos do Qwen Code para Experimentar',
+    sectionNewWays: 'Novas Formas de Usar o Qwen Code',
+    sectionOnTheHorizon: 'No Horizonte',
+
+    // Project areas
+    sessions: 'sessões',
+
+    // Charts
+    chartWhatYouWanted: 'O Que Você Queria',
+    chartTopToolsUsed: 'Ferramentas Mais Usadas',
+    chartWhatHelpedMost: 'O Que Mais Ajudou',
+    chartOutcomes: 'Resultados',
+    chartPrimaryFriction: 'Tipos de Fricção',
+    chartInferredSatisfaction: 'Satisfação Inferida (estimada pelo modelo)',
+
+    // Interaction style
+    keyPattern: 'Padrão principal:',
+
+    // Improvements
+    suggestedQwenMdAdditions: 'Sugestões para QWEN.md',
+    copyAllChecked: 'Copiar Selecionados ({{count}})',
+    copiedAll: 'Copiados!',
+    whyForYou: 'Por que para você:',
+    pasteIntoQwenCode: 'Cole no Qwen Code:',
+
+    // Future opportunities
+    gettingStarted: 'Para começar:',
+
+    // Export
+    exportCard: 'Exportar Cartão',
+    lightTheme: 'Tema Claro',
+    darkTheme: 'Tema Escuro',
+
+    // Misc
+    messagesAcrossSessions: '{{messages}} mensagens em {{sessions}} sessões',
+  },
+
+  ru: {
+    // Header
+    headerTitle: 'Инсайты Qwen Code',
+    headerSubtitle: '{{messages}} сообщений в {{sessions}} сессиях',
+    headerSubtitleFallback:
+      'Ваш персонализированный путь программирования и паттерны',
+
+    // At a Glance section
+    atAGlanceTitle: 'Обзор',
+    whatsWorking: 'Что работает:',
+    whatsHindering: 'Что мешает:',
+    quickWins: 'Быстрые улучшения:',
+    ambitiousWorkflows: 'Амбициозные рабочие процессы:',
+    seeMore: 'Подробнее →',
+
+    // Navigation
+    navWhatYouWorkOn: 'Над чем вы работаете',
+    navHowYouUse: 'Как вы используете',
+    navImpressiveThings: 'Впечатляющие результаты',
+    navWhereThingsGoWrong: 'Где возникают проблемы',
+    navFeaturesToTry: 'Функции для尝试',
+    navNewUsagePatterns: 'Новые паттерны использования',
+    navOnTheHorizon: 'На горизонте',
+
+    // Stats
+    statMessages: 'Сообщений',
+    statLines: 'Строк',
+    statFiles: 'Файлов',
+    statDays: 'Дней',
+    statMsgsPerDay: 'Сообщ/День',
+
+    // Section titles
+    sectionWhatYouWorkOn: 'Над чем вы работаете',
+    sectionHowYouUse: 'Как вы используете Qwen Code',
+    sectionImpressiveThings: 'Ваши впечатляющие результаты',
+    sectionWhereThingsGoWrong: 'Где возникают проблемы',
+    sectionFeaturesToTry: 'Функции Qwen Code для尝试',
+    sectionNewWays: 'Новые способы использования Qwen Code',
+    sectionOnTheHorizon: 'На горизонте',
+
+    // Project areas
+    sessions: 'сессий',
+
+    // Charts
+    chartWhatYouWanted: 'Ваши цели',
+    chartTopToolsUsed: 'Частые инструменты',
+    chartWhatHelpedMost: 'Что помогло больше всего',
+    chartOutcomes: 'Результаты',
+    chartPrimaryFriction: 'Типы проблем',
+    chartInferredSatisfaction: 'Удовлетворённость (оценка модели)',
+
+    // Interaction style
+    keyPattern: 'Ключевой паттерн:',
+
+    // Improvements
+    suggestedQwenMdAdditions: 'Предложения для QWEN.md',
+    copyAllChecked: 'Копировать выбранные ({{count}})',
+    copiedAll: 'Скопировано!',
+    whyForYou: 'Почему для вас:',
+    pasteIntoQwenCode: 'Вставить в Qwen Code:',
+
+    // Future opportunities
+    gettingStarted: 'Как начать:',
+
+    // Export
+    exportCard: 'Экспорт карточки',
+    lightTheme: 'Светлая тема',
+    darkTheme: 'Тёмная тема',
+
+    // Misc
+    messagesAcrossSessions: '{{messages}} сообщений в {{sessions}} сессиях',
+  },
+
+  de: {
+    // Header
+    headerTitle: 'Qwen Code Einblicke',
+    headerSubtitle: '{{messages}} Nachrichten in {{sessions}} Sitzungen',
+    headerSubtitleFallback: 'Ihre personalisierte Programmierreise und Muster',
+
+    // At a Glance section
+    atAGlanceTitle: 'Überblick',
+    whatsWorking: 'Was funktioniert:',
+    whatsHindering: 'Was hindert Sie:',
+    quickWins: 'Schnelle Verbesserungen:',
+    ambitiousWorkflows: 'Ambitionierte Workflows:',
+    seeMore: 'Mehr anzeigen →',
+
+    // Navigation
+    navWhatYouWorkOn: 'Woran Sie arbeiten',
+    navHowYouUse: 'Wie Sie nutzen',
+    navImpressiveThings: 'Beeindruckende Ergebnisse',
+    navWhereThingsGoWrong: 'Wo Probleme auftreten',
+    navFeaturesToTry: 'Funktionen zum Ausprobieren',
+    navNewUsagePatterns: 'Neue Nutzungsmuster',
+    navOnTheHorizon: 'Am Horizont',
+
+    // Stats
+    statMessages: 'Nachrichten',
+    statLines: 'Zeilen',
+    statFiles: 'Dateien',
+    statDays: 'Tage',
+    statMsgsPerDay: 'Nachr/Tag',
+
+    // Section titles
+    sectionWhatYouWorkOn: 'Woran Sie arbeiten',
+    sectionHowYouUse: 'Wie Sie Qwen Code nutzen',
+    sectionImpressiveThings: 'Ihre beeindruckenden Ergebnisse',
+    sectionWhereThingsGoWrong: 'Wo Probleme auftreten',
+    sectionFeaturesToTry: 'Qwen Code Funktionen zum Ausprobieren',
+    sectionNewWays: 'Neue Möglichkeiten, Qwen Code zu nutzen',
+    sectionOnTheHorizon: 'Am Horizont',
+
+    // Project areas
+    sessions: 'Sitzungen',
+
+    // Charts
+    chartWhatYouWanted: 'Ihre Ziele',
+    chartTopToolsUsed: 'Meistgenutzte Tools',
+    chartWhatHelpedMost: 'Was am meisten half',
+    chartOutcomes: 'Ergebnisse',
+    chartPrimaryFriction: 'Hauptproblemtypen',
+    chartInferredSatisfaction: 'Geschätzte Zufriedenheit (Modell)',
+
+    // Interaction style
+    keyPattern: 'Hauptmuster:',
+
+    // Improvements
+    suggestedQwenMdAdditions: 'Vorschläge für QWEN.md',
+    copyAllChecked: 'Ausgewählte kopieren ({{count}})',
+    copiedAll: 'Kopiert!',
+    whyForYou: 'Warum für Sie:',
+    pasteIntoQwenCode: 'In Qwen Code einfügen:',
+
+    // Future opportunities
+    gettingStarted: 'Erste Schritte:',
+
+    // Export
+    exportCard: 'Karte exportieren',
+    lightTheme: 'Helles Thema',
+    darkTheme: 'Dunkles Thema',
+
+    // Misc
+    messagesAcrossSessions:
+      '{{messages}} Nachrichten in {{sessions}} Sitzungen',
+  },
+};
+
+/**
+ * Maps language names to language codes.
+ */
+function getLanguageCode(language: string | undefined): InsightLanguage {
+  if (!language) return 'en';
+
+  const lower = language.toLowerCase();
+  if (lower.includes('zh') || lower.includes('chinese')) return 'zh';
+  if (lower.includes('ja') || lower.includes('japanese')) return 'ja';
+  if (lower.includes('pt') || lower.includes('portuguese')) return 'pt';
+  if (lower.includes('ru') || lower.includes('russian')) return 'ru';
+  if (lower.includes('de') || lower.includes('german')) return 'de';
+
+  return 'en';
+}
+
+/**
+ * Get translations for a specific language.
+ */
+export function getTranslations(
+  language: string | undefined,
+): InsightTranslations {
+  const code = getLanguageCode(language);
+  return translations[code] || translations['en'];
+}
+
+/**
+ * Interpolate a translation string with parameters.
+ */
+export function interpolateTranslation(
+  template: string,
+  params: Record<string, string | number>,
+): string {
+  return template.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+    const value = params[key];
+    return value !== undefined ? String(value) : match;
+  });
+}


### PR DESCRIPTION
## Summary

This PR adds language support for the `/insight` HTML report, addressing issue #2022.

### Changes Made

1. **Language parameter in insight generation pipeline**
   - Added `language` parameter to `StaticInsightGenerator.generateStaticInsight()`
   - Added `language` parameter to `DataProcessor.generateInsights()`
   - Added `language` field to `InsightData` type

2. **LLM-generated content localization**
   - Modified insight prompts to include language instructions when a non-English language is specified
   - LLM-generated narrative content (insights, recommendations, etc.) is now produced in the user's preferred language

3. **Static UI text localization**
   - Created `translations.ts` with translations for all static UI text (headings, labels, buttons)
   - Supports 6 languages: English, Chinese, Japanese, Portuguese, Russian, German
   - Updated React components to use translations

4. **Language indicator message**
   - Added a message at the start of insight generation indicating which language will be used
   - Example: "Generating insights in 中文..."

5. **CLI i18n updates**
   - Added insight-related translation strings to all locale files

### Testing

- Build passes successfully
- All existing tests pass
- Lint passes

### Screenshot

When a user has their output language set to Chinese, the report will show:
- Chinese headings and labels
- LLM-generated content in Chinese
- Language indicator: "正在以 中文 生成洞察..."

Fixes #2022