### PR TITLE
feat: /insight report respects user language settings

### DIFF
--- a/packages/cli/src/i18n/languages.ts
+++ b/packages/cli/src/i18n/languages.ts
@@ -73,6 +73,15 @@ export function getLanguageNameFromLocale(locale: SupportedLanguage): string {
 }
 
 /**
+ * Get language display name (native name).
+ * Used for showing the user which language is being used.
+ */
+export function getLanguageDisplayName(lang: SupportedLanguage): string {
+  const language = SUPPORTED_LANGUAGES.find((l) => l.code === lang);
+  return language?.nativeName || language?.fullName || 'English';
+}
+
+/**
  * Gets the language options for the settings schema.
  */
 export function getLanguageSettingsOptions(): Array<{

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1137,6 +1137,27 @@ export default {
     'Try /insight to generate personalized insights from your chat history.',
 
   // ============================================================================
+  // Insight Command
+  // ============================================================================
+  'generate personalized programming insights from your chat history':
+    'generate personalized programming insights from your chat history',
+  'Generating insights...': 'Generating insights...',
+  'Generating insights in {{language}}...':
+    'Generating insights in {{language}}...',
+  'This may take a couple minutes. Sit tight!':
+    'This may take a couple minutes. Sit tight!',
+  'Starting insight generation...': 'Starting insight generation...',
+  'Insight report generated successfully!':
+    'Insight report generated successfully!',
+  'Opening insights in your browser: {{path}}':
+    'Opening insights in your browser: {{path}}',
+  'Insights generated at: {{path}}. Please open this file in your browser.':
+    'Insights generated at: {{path}}. Please open this file in your browser.',
+  'Failed to generate insights: {{error}}':
+    'Failed to generate insights: {{error}}',
+  'Insights ready.': 'Insights ready.',
+
+  // ============================================================================
   // Exit Screen / Stats
   // ============================================================================
   'Agent powering down. Goodbye!': 'Agent powering down. Goodbye!',

--- a/packages/cli/src/services/insight/generators/DataProcessor.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.ts
@@ -17,6 +17,7 @@ import type {
   StreakData,
   SessionFacets,
   InsightProgressCallback,
+  SupportedLanguage,
 } from '../types/StaticInsightTypes.js';
 import type {
   QualitativeInsights,
@@ -34,13 +35,21 @@ import {
   type Config,
   type ChatRecord,
 } from '@qwen-code/qwen-code-core';
+import { getLanguageNameFromLocale } from '../../../i18n/languages.js';
 
 const logger = createDebugLogger('DataProcessor');
 
 const CONCURRENCY_LIMIT = 4;
 
 export class DataProcessor {
-  constructor(private config: Config) {}
+  private userLanguage: SupportedLanguage;
+
+  constructor(
+    private config: Config,
+    language?: SupportedLanguage,
+  ) {
+    this.userLanguage = language ?? 'en';
+  }
 
   // Helper function to format date as YYYY-MM-DD
   private formatDate(date: Date): string {
@@ -283,7 +292,13 @@ export class DataProcessor {
     baseDir: string,
     facetsOutputDir?: string,
     onProgress?: InsightProgressCallback,
+    language?: SupportedLanguage,
   ): Promise<InsightData> {
+    // Update language if provided
+    if (language) {
+      this.userLanguage = language;
+    }
+
     if (onProgress) onProgress('Scanning chat history...', 0);
     const allChatFiles = await this.scanChatFiles(baseDir);
 
@@ -298,7 +313,11 @@ export class DataProcessor {
     );
 
     if (onProgress) onProgress('Generating personalized insights...', 80);
-    const qualitative = await this.generateQualitativeInsights(metrics, facets);
+    const qualitative = await this.generateQualitativeInsights(
+      metrics,
+      facets,
+      this.userLanguage,
+    );
 
     // Aggregate satisfaction, friction, success and outcome data from facets
     const {
@@ -376,6 +395,7 @@ export class DataProcessor {
   private async generateQualitativeInsights(
     metrics: Omit<InsightData, 'facets' | 'qualitative'>,
     facets: SessionFacets[],
+    language: SupportedLanguage = 'en',
   ): Promise<QualitativeInsights | undefined> {
     if (facets.length === 0) {
       return undefined;
@@ -385,11 +405,16 @@ export class DataProcessor {
 
     const commonData = this.prepareCommonPromptData(metrics, facets);
 
+    // Get the language name for the LLM instruction
+    const languageName = getLanguageNameFromLocale(language);
+
     const generate = async <T>(
       promptTemplate: string,
       schema: Record<string, unknown>,
     ): Promise<T> => {
-      const prompt = `${promptTemplate}\n\n${commonData}`;
+      // Add language instruction to the prompt
+      const languageInstruction = `Respond in ${languageName}. All output text (intro, descriptions, titles, summaries, etc.) must be written in ${languageName}.`;
+      const prompt = `${promptTemplate}\n\n${languageInstruction}\n\n${commonData}`;
       try {
         const result = await this.config.getBaseLlmClient().generateJson({
           model: this.config.getModel(),

--- a/packages/cli/src/services/insight/generators/StaticInsightGenerator.ts
+++ b/packages/cli/src/services/insight/generators/StaticInsightGenerator.ts
@@ -12,19 +12,48 @@ import { TemplateRenderer } from './TemplateRenderer.js';
 import type {
   InsightData,
   InsightProgressCallback,
+  SupportedLanguage,
 } from '../types/StaticInsightTypes.js';
 
 import { createDebugLogger, type Config } from '@qwen-code/qwen-code-core';
+import { getCurrentLanguage } from '../../../i18n/index.js';
 
 const logger = createDebugLogger('StaticInsightGenerator');
 
 export class StaticInsightGenerator {
   private dataProcessor: DataProcessor;
   private templateRenderer: TemplateRenderer;
+  private userLanguage: SupportedLanguage;
 
   constructor(config: Config) {
     this.dataProcessor = new DataProcessor(config);
     this.templateRenderer = new TemplateRenderer();
+    // Get user's UI language preference
+    this.userLanguage = this.resolveUserLanguage();
+  }
+
+  /**
+   * Resolve the user's language preference from settings
+   */
+  private resolveUserLanguage(): SupportedLanguage {
+    try {
+      const currentLang = getCurrentLanguage();
+      // Map to supported languages for insight report
+      const supportedLanguages: SupportedLanguage[] = [
+        'en',
+        'zh',
+        'ja',
+        'pt',
+        'ru',
+        'de',
+      ];
+      if (supportedLanguages.includes(currentLang as SupportedLanguage)) {
+        return currentLang as SupportedLanguage;
+      }
+      return 'en';
+    } catch {
+      return 'en';
+    }
   }
 
   // Ensure the output directory exists
@@ -100,15 +129,18 @@ export class StaticInsightGenerator {
     const facetsDir = path.join(outputDir, 'facets');
     await fs.mkdir(facetsDir, { recursive: true });
 
-    // Process data
+    // Process data with user's language preference
     const insights: InsightData = await this.dataProcessor.generateInsights(
       baseDir,
       facetsDir,
       onProgress,
+      this.userLanguage,
     );
 
-    // Render HTML
-    const html = await this.templateRenderer.renderInsightHTML(insights);
+    // Render HTML with user's language preference
+    const html = await this.templateRenderer.renderInsightHTML(insights, {
+      language: this.userLanguage,
+    });
 
     // Generate timestamped output path
     const outputPath = await this.generateOutputPath(outputDir);

--- a/packages/cli/src/services/insight/generators/TemplateRenderer.ts
+++ b/packages/cli/src/services/insight/generators/TemplateRenderer.ts
@@ -5,13 +5,21 @@
  */
 
 import { INSIGHT_JS, INSIGHT_CSS } from '@qwen-code/web-templates';
-import type { InsightData } from '../types/StaticInsightTypes.js';
+import type { InsightData , SupportedLanguage } from '../types/StaticInsightTypes.js';
+
+export interface RenderInsightHTMLOptions {
+  language?: SupportedLanguage;
+}
 
 export class TemplateRenderer {
-  // Render the complete HTML file
-  async renderInsightHTML(insights: InsightData): Promise<string> {
+  // Render the complete HTML file with optional localization
+  async renderInsightHTML(
+    insights: InsightData,
+    options?: RenderInsightHTMLOptions,
+  ): Promise<string> {
+    const language = options?.language ?? 'en';
     const html = `<!doctype html>
-<html lang="en">
+<html lang="${language}">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -38,6 +46,7 @@ export class TemplateRenderer {
     <!-- Application Data -->
     <script>
       window.INSIGHT_DATA = ${JSON.stringify(insights)};
+      window.INSIGHT_LANGUAGE = ${JSON.stringify(language)};
     </script>
 
     <!-- App Script -->

--- a/packages/cli/src/services/insight/types/StaticInsightTypes.ts
+++ b/packages/cli/src/services/insight/types/StaticInsightTypes.ts
@@ -6,6 +6,8 @@
 
 import type { QualitativeInsights } from './QualitativeInsightTypes.js';
 
+export type SupportedLanguage = 'en' | 'zh' | 'ja' | 'pt' | 'ru' | 'de';
+
 export interface HeatMapData {
   [date: string]: number;
 }

--- a/packages/cli/src/ui/commands/insightCommand.ts
+++ b/packages/cli/src/ui/commands/insightCommand.ts
@@ -8,12 +8,13 @@ import type { CommandContext, SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
 import { MessageType } from '../types.js';
 import type { HistoryItemInsightProgress } from '../types.js';
-import { t } from '../../i18n/index.js';
+import { t, getCurrentLanguage } from '../../i18n/index.js';
 import { join } from 'path';
 import os from 'os';
 import { StaticInsightGenerator } from '../../services/insight/generators/StaticInsightGenerator.js';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
 import open from 'open';
+import { getLanguageDisplayName } from '../../i18n/languages.js';
 
 const logger = createDebugLogger('DataProcessor');
 
@@ -27,7 +28,15 @@ export const insightCommand: SlashCommand = {
   kind: CommandKind.BUILT_IN,
   action: async (context: CommandContext) => {
     try {
-      context.ui.setDebugMessage(t('Generating insights...'));
+      // Get user's language preference and show info message
+      const userLanguage = getCurrentLanguage();
+      const languageDisplayName = getLanguageDisplayName(userLanguage);
+
+      context.ui.setDebugMessage(
+        t('Generating insights in {{language}}...', {
+          language: languageDisplayName,
+        }),
+      );
 
       const projectsDir = join(os.homedir(), '.qwen', 'projects');
       if (!context.services.config) {

--- a/packages/web-templates/src/insight/build.mjs
+++ b/packages/web-templates/src/insight/build.mjs
@@ -41,6 +41,34 @@ try {
   }
 }
 
+// Load translations for embedding
+const translationsDir = join(assetsDir, 'translations');
+const translationFiles = ['en', 'zh', 'ja', 'pt', 'ru', 'de'];
+const embeddedTranslations = {};
+
+for (const lang of translationFiles) {
+  try {
+    // Read the TypeScript file and extract the default export
+    const translationPath = join(translationsDir, `${lang}.ts`);
+    const translationContent = await readFile(translationPath, 'utf-8');
+    
+    // Parse the TypeScript file to extract the object
+    // The file format is: export default { ... } as Record<string, string>;
+    const match = translationContent.match(/export default\s+({[\s\S]*?})\s+as\s+Record/);
+    if (match && match[1]) {
+      // Use Function constructor to safely evaluate the object literal
+      // eslint-disable-next-line no-new-func
+      const parseObject = new Function(`return ${match[1]}`);
+      embeddedTranslations[lang] = parseObject();
+    } else {
+      throw new Error('Could not parse translation object');
+    }
+  } catch (e) {
+    console.warn(`Failed to load translation for ${lang}:`, e.message);
+    embeddedTranslations[lang] = {};
+  }
+}
+
 const templateModule = `/**
  * @license
  * Copyright 2025 Qwen Team
@@ -51,6 +79,7 @@ const templateModule = `/**
 
 export const INSIGHT_JS = ${JSON.stringify(jsContent.trim())};
 export const INSIGHT_CSS = ${JSON.stringify(cssContent.trim())};
+export const INSIGHT_TRANSLATIONS = ${JSON.stringify(embeddedTranslations)};
 `;
 
 await writeFile(templateModulePath, templateModule);

--- a/packages/web-templates/src/insight/src/App.tsx
+++ b/packages/web-templates/src/insight/src/App.tsx
@@ -17,6 +17,19 @@ import './styles.css';
 import type { InsightData } from './types';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
+import { initializeTranslations, t } from './i18n';
+
+// Declare global variables from HTML
+declare global {
+  interface Window {
+    INSIGHT_DATA?: InsightData;
+    INSIGHT_LANGUAGE?: string;
+    INSIGHT_TRANSLATIONS?: Record<string, Record<string, string>>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    html2canvas?: any;
+    ReactDOM?: typeof ReactDOM;
+  }
+}
 
 // Main App Component
 function InsightApp({ data }: { data: InsightData }) {
@@ -79,7 +92,7 @@ function InsightApp({ data }: { data: InsightData }) {
   if (!data) {
     return (
       <div className="text-center text-slate-600">
-        No insight data available
+        {t('No insight data available')}
       </div>
     );
   }
@@ -102,11 +115,14 @@ function InsightApp({ data }: { data: InsightData }) {
       <header className="insights-header">
         <div className="header-content">
           <div className="header-title-section">
-            <h1 className="header-title">Qwen Code Insights</h1>
+            <h1 className="header-title">{t('Qwen Code Insights')}</h1>
             <p className="header-subtitle">
               {data.totalMessages
-                ? `${data.totalMessages.toLocaleString()} messages across ${data.totalSessions?.toLocaleString()} sessions`
-                : 'Your personalized coding journey and patterns'}
+                ? t('{{messages}} messages across {{sessions}} sessions', {
+                    messages: data.totalMessages.toLocaleString(),
+                    sessions: (data.totalSessions ?? 0).toLocaleString(),
+                  })
+                : t('Your personalized coding journey and patterns')}
               {dateRangeStr && ` · ${dateRangeStr}`}
             </p>
           </div>
@@ -205,7 +221,7 @@ function ExportCardButton({ onExport }: { onExport: (theme: Theme) => void }) {
           <polyline points="16 6 12 2 8 6" />
           <line x1="12" y1="2" x2="12" y2="15" />
         </svg>
-        <span>Export Card</span>
+        <span>{t('Export Card')}</span>
         <svg
           width="12"
           height="12"
@@ -247,7 +263,7 @@ function ExportCardButton({ onExport }: { onExport: (theme: Theme) => void }) {
               <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
               <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
             </svg>
-            <span>Light Theme</span>
+            <span>{t('Light Theme')}</span>
           </button>
           <button
             className="export-dropdown-item"
@@ -265,7 +281,7 @@ function ExportCardButton({ onExport }: { onExport: (theme: Theme) => void }) {
             >
               <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
             </svg>
-            <span>Dark Theme</span>
+            <span>{t('Dark Theme')}</span>
           </button>
         </div>
       )}
@@ -276,6 +292,11 @@ function ExportCardButton({ onExport }: { onExport: (theme: Theme) => void }) {
 // App Initialization - Mount React app when DOM is ready
 const container = document.getElementById('react-root');
 if (container && window.INSIGHT_DATA && ReactDOM) {
+  // Initialize translations from window global
+  const language = window.INSIGHT_LANGUAGE || 'en';
+  const translations = window.INSIGHT_TRANSLATIONS || {};
+  initializeTranslations(language, translations[language] || {});
+
   const root = ReactDOM.createRoot(container);
   root.render(<InsightApp data={window.INSIGHT_DATA} />);
 } else {

--- a/packages/web-templates/src/insight/src/Components.tsx
+++ b/packages/web-templates/src/insight/src/Components.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 import { useState } from 'react';
+import { t } from './i18n';
 
 // Simple Markdown Parser Component
 export function MarkdownText({ children }: { children: string }) {
@@ -39,7 +40,7 @@ export function CopyButton({
 
   return (
     <button className="copy-btn" onClick={handleCopy}>
-      {copied ? 'Copied!' : label}
+      {copied ? t('Copied!') : t(label)}
     </button>
   );
 }

--- a/packages/web-templates/src/insight/src/Header.tsx
+++ b/packages/web-templates/src/insight/src/Header.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 import type { InsightData } from './types';
+import { t } from './i18n';
 
 // Header Component
 export function Header({
@@ -15,12 +16,15 @@ export function Header({
   return (
     <header className="mb-8 space-y-3 text-center">
       <h1 className="text-3xl font-semibold text-slate-900 md:text-4xl">
-        Qwen Code Insights
+        {t('Qwen Code Insights')}
       </h1>
       <p className="text-sm text-slate-600">
         {totalMessages
-          ? `${totalMessages} messages across ${totalSessions} sessions`
-          : 'Your personalized coding journey and patterns'}
+          ? t('{{messages}} messages across {{sessions}} sessions', {
+              messages: totalMessages.toString(),
+              sessions: totalSessions?.toString() ?? '0',
+            })
+          : t('Your personalized coding journey and patterns')}
         {dateRangeStr && ` | ${dateRangeStr}`}
       </p>
     </header>
@@ -54,25 +58,25 @@ export function StatsRow({ data }: { data: InsightData }) {
     <div className="stats-row">
       <div className="stat">
         <div className="stat-value">{totalMessages}</div>
-        <div className="stat-label">Messages</div>
+        <div className="stat-label">{t('Messages')}</div>
       </div>
       <div className="stat">
         <div className="stat-value">
           +{totalLinesAdded}/-{totalLinesRemoved}
         </div>
-        <div className="stat-label">Lines</div>
+        <div className="stat-label">{t('Lines')}</div>
       </div>
       <div className="stat">
         <div className="stat-value">{totalFiles}</div>
-        <div className="stat-label">Files</div>
+        <div className="stat-label">{t('Files')}</div>
       </div>
       <div className="stat">
         <div className="stat-value">{daysSpan}</div>
-        <div className="stat-label">Days</div>
+        <div className="stat-label">{t('Days')}</div>
       </div>
       <div className="stat">
         <div className="stat-value">{msgsPerDay}</div>
-        <div className="stat-label">Msgs/Day</div>
+        <div className="stat-label">{t('Msgs/Day')}</div>
       </div>
     </div>
   );

--- a/packages/web-templates/src/insight/src/Qualitative.tsx
+++ b/packages/web-templates/src/insight/src/Qualitative.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { DashboardCards, HeatmapSection } from './Charts';
 import type { InsightData, QualitativeData } from './types';
 import { CopyButton, MarkdownText } from './Components';
+import { t } from './i18n';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 
@@ -16,34 +17,34 @@ export function AtAGlance({ qualitative }: { qualitative: QualitativeData }) {
 
   return (
     <div className="at-a-glance">
-      <div className="glance-title">At a Glance</div>
+      <div className="glance-title">{t('At a Glance')}</div>
       <div className="glance-sections">
         <div className="glance-section">
-          <strong>What&apos;s working:</strong>{' '}
+          <strong>{t("What's working:")} </strong>
           <MarkdownText>{atAGlance.whats_working}</MarkdownText>
           <a href="#section-wins" className="see-more">
-            Impressive Things You Did →
+            {t('Impressive Things You Did →')}
           </a>
         </div>
         <div className="glance-section">
-          <strong>What&apos;s hindering you:</strong>{' '}
+          <strong>{t("What's hindering you:")} </strong>
           <MarkdownText>{atAGlance.whats_hindering}</MarkdownText>
           <a href="#section-friction" className="see-more">
-            Where Things Go Wrong →
+            {t('Where Things Go Wrong →')}
           </a>
         </div>
         <div className="glance-section">
-          <strong>Quick wins to try:</strong>{' '}
+          <strong>{t('Quick wins to try:')} </strong>
           <MarkdownText>{atAGlance.quick_wins}</MarkdownText>
           <a href="#section-features" className="see-more">
-            Features to Try →
+            {t('Features to Try →')}
           </a>
         </div>
         <div className="glance-section">
-          <strong>Ambitious workflows:</strong>{' '}
+          <strong>{t('Ambitious workflows:')} </strong>
           <MarkdownText>{atAGlance.ambitious_workflows}</MarkdownText>
           <a href="#section-horizon" className="see-more">
-            On the Horizon →
+            {t('On the Horizon →')}
           </a>
         </div>
       </div>
@@ -54,13 +55,13 @@ export function AtAGlance({ qualitative }: { qualitative: QualitativeData }) {
 export function NavToc() {
   return (
     <nav className="nav-toc">
-      <a href="#section-work">What You Work On</a>
-      <a href="#section-usage">How You Use Qwen Code</a>
-      <a href="#section-wins">Impressive Things</a>
-      <a href="#section-friction">Where Things Go Wrong</a>
-      <a href="#section-features">Features to Try</a>
-      <a href="#section-patterns">New Usage Patterns</a>
-      <a href="#section-horizon">On the Horizon</a>
+      <a href="#section-work">{t('What You Work On')}</a>
+      <a href="#section-usage">{t('How You Use Qwen Code')}</a>
+      <a href="#section-wins">{t('Impressive Things')}</a>
+      <a href="#section-friction">{t('Where Things Go Wrong')}</a>
+      <a href="#section-features">{t('Features to Try')}</a>
+      <a href="#section-patterns">{t('New Usage Patterns')}</a>
+      <a href="#section-horizon">{t('On the Horizon')}</a>
     </nav>
   );
 }
@@ -87,7 +88,7 @@ export function ProjectAreas({
         id="section-work"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        What You Work On
+        {t('What You Work On')}
       </h2>
 
       {Array.isArray(projectAreas?.areas) && projectAreas.areas.length > 0 && (
@@ -97,7 +98,9 @@ export function ProjectAreas({
               <div className="area-header">
                 <span className="area-name">{area.name}</span>
                 <span className="area-count">
-                  ~{area.session_count} sessions
+                  {t('~{{count}} sessions', {
+                    count: area.session_count.toString(),
+                  })}
                 </span>
               </div>
               <div className="area-desc">
@@ -151,7 +154,7 @@ export function InteractionStyle({
         id="section-usage"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        How You Use Qwen Code
+        {t('How You Use Qwen Code')}
       </h2>
       <div className="narrative">
         <p>
@@ -159,7 +162,7 @@ export function InteractionStyle({
         </p>
         {interactionStyle.key_pattern && (
           <div className="key-insight">
-            <strong>Key pattern:</strong>{' '}
+            <strong>{t('Key pattern:')} </strong>
             <MarkdownText>{interactionStyle.key_pattern}</MarkdownText>
           </div>
         )}
@@ -189,7 +192,7 @@ export function ImpressiveWorkflows({
         id="section-wins"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        Impressive Things You Did
+        {t('Impressive Things You Did')}
       </h2>
       {impressiveWorkflows.intro && (
         <p className="section-intro">
@@ -220,7 +223,7 @@ export function ImpressiveWorkflows({
         {primarySuccess && Object.keys(primarySuccess).length > 0 && (
           <HorizontalBarChart
             data={primarySuccess}
-            title="What Helped Most (Qwen's Capabilities)"
+            title={t("What Helped Most (Qwen's Capabilities)")}
             color="#3b82f6"
             allowedKeys={[
               'fast_accurate_search',
@@ -235,7 +238,7 @@ export function ImpressiveWorkflows({
         {outcomes && Object.keys(outcomes).length > 0 && (
           <HorizontalBarChart
             data={outcomes}
-            title="Outcomes"
+            title={t('Outcomes')}
             color="#8b5cf6"
             allowedKeys={[
               'fully_achieved',
@@ -253,13 +256,8 @@ export function ImpressiveWorkflows({
 
 // Format label for display (capitalize and replace underscores with spaces)
 function formatLabel(label: string) {
-  if (label === 'unclear_from_transcript') {
-    return 'Unclear';
-  }
-  return label
-    .split('_')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
+  // Use translation key if available
+  return t(label);
 }
 
 // Horizontal Bar Chart Component
@@ -413,7 +411,7 @@ export function FrictionPoints({
         id="section-friction"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        Where Things Go Wrong
+        {t('Where Things Go Wrong')}
       </h2>
       {frictionPoints.intro && (
         <p className="section-intro">
@@ -454,7 +452,7 @@ export function FrictionPoints({
         {friction && Object.keys(friction).length > 0 && (
           <HorizontalBarChart
             data={friction}
-            title="Primary Friction Types"
+            title={t('Primary Friction Types')}
             color="#ef4444"
             allowedKeys={[
               'misunderstood_request',
@@ -468,7 +466,7 @@ export function FrictionPoints({
         {satisfaction && Object.keys(satisfaction).length > 0 && (
           <HorizontalBarChart
             data={satisfaction}
-            title="Inferred Satisfaction (model-estimated)"
+            title={t('Inferred Satisfaction (model-estimated)')}
             color="#10b981"
             allowedKeys={[
               'happy',
@@ -522,9 +520,9 @@ function QwenMdAdditionsSection({
 
   return (
     <div className="qwen-md-section">
-      <h3>Suggested QWEN.md Additions</h3>
+      <h3>{t('Suggested QWEN.md Additions')}</h3>
       <p className="text-xs text-slate-500 mb-3">
-        Just copy this into Qwen Code to add it to your QWEN.md.
+        {t('Just copy this into Qwen Code to add it to your QWEN.md.')}
       </p>
 
       <div className="qwen-md-actions" style={{ marginBottom: '12px' }}>
@@ -533,7 +531,11 @@ function QwenMdAdditionsSection({
           onClick={handleCopyAll}
           disabled={checkedCount === 0}
         >
-          {copiedAll ? 'Copied All!' : `Copy All Checked (${checkedCount})`}
+          {copiedAll
+            ? t('Copied All!')
+            : t('Copy All Checked ({{count}})', {
+                count: checkedCount.toString(),
+              })}
         </button>
       </div>
 
@@ -572,7 +574,7 @@ export function Improvements({
         id="section-features"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        Existing Qwen Code Features to Try
+        {t('Existing Qwen Code Features to Try')}
       </h2>
 
       {/* QWEN.md Additions */}
@@ -582,7 +584,7 @@ export function Improvements({
         )}
 
       <p className="text-xs text-slate-500 mb-3">
-        Just copy this into Qwen Code and it&apos;ll set it up for you.
+        {t("Just copy this into Qwen Code and it'll set it up for you.")}
       </p>
 
       {/* Features to Try */}
@@ -595,7 +597,7 @@ export function Improvements({
                 <MarkdownText>{feat.one_liner}</MarkdownText>
               </div>
               <div className="feature-why">
-                <strong>Why for you:</strong>{' '}
+                <strong>{t('Why for you:')} </strong>
                 <MarkdownText>{feat.why_for_you}</MarkdownText>
               </div>
               <div className="feature-examples">
@@ -614,10 +616,10 @@ export function Improvements({
         id="section-patterns"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        New Ways to Use Qwen Code
+        {t('New Ways to Use Qwen Code')}
       </h2>
       <p className="text-xs text-slate-500 mb-3">
-        Just copy this into Qwen Code and it&apos;ll walk you through it.
+        {t("Just copy this into Qwen Code and it'll walk you through it.")}
       </p>
 
       <div className="patterns-section">
@@ -632,7 +634,7 @@ export function Improvements({
                 <MarkdownText>{pat.detail}</MarkdownText>
               </div>
               <div className="copyable-prompt-section">
-                <div className="prompt-label">Paste into Qwen Code:</div>
+                <div className="prompt-label">{t('Paste into Qwen Code:')}</div>
                 <div className="copyable-prompt-row">
                   <code className="copyable-prompt">{pat.copyable_prompt}</code>
                   <CopyButton text={pat.copyable_prompt} />
@@ -659,7 +661,7 @@ export function FutureOpportunities({
         id="section-horizon"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        On the Horizon
+        {t('On the Horizon')}
       </h2>
       {futureOpportunities.intro && (
         <p className="section-intro">
@@ -676,11 +678,11 @@ export function FutureOpportunities({
                 <MarkdownText>{opp.whats_possible}</MarkdownText>
               </div>
               <div className="horizon-tip">
-                <strong>Getting started:</strong>{' '}
+                <strong>{t('Getting started:')} </strong>
                 <MarkdownText>{opp.how_to_try}</MarkdownText>
               </div>
               <div className="pattern-prompt">
-                <div className="prompt-label">Paste into Qwen Code:</div>
+                <div className="prompt-label">{t('Paste into Qwen Code:')}</div>
                 <div
                   style={{
                     display: 'flex',

--- a/packages/web-templates/src/insight/src/i18n.ts
+++ b/packages/web-templates/src/insight/src/i18n.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Lightweight i18n system for the Insight report
+// Translations are embedded in the HTML at generation time
+
+export type SupportedLanguage = 'en' | 'zh' | 'ja' | 'pt' | 'ru' | 'de';
+
+export interface TranslationDict {
+  [key: string]: string;
+}
+
+// Built-in translations (embedded at generation time)
+let currentLanguage: SupportedLanguage = 'en';
+let translations: TranslationDict = {};
+
+/**
+ * Initialize translations from window.INSIGHT_TRANSLATIONS
+ * Called when the app loads
+ */
+export function initializeTranslations(
+  lang: string,
+  trans: Record<string, string>,
+): void {
+  currentLanguage = lang as SupportedLanguage;
+  translations = trans;
+}
+
+/**
+ * Get current language
+ */
+export function getCurrentLanguage(): SupportedLanguage {
+  return currentLanguage;
+}
+
+/**
+ * Translate a key with optional interpolation
+ * @param key - Translation key (also serves as default English text)
+ * @param params - Optional parameters for interpolation {{param}}
+ */
+export function t(key: string, params?: Record<string, string>): string {
+  const translation = translations[key] ?? key;
+  return interpolate(translation, params);
+}
+
+/**
+ * Simple string interpolation
+ * Replaces {{key}} with params[key]
+ */
+function interpolate(
+  template: string,
+  params?: Record<string, string>,
+): string {
+  if (!params) return template;
+  return template.replace(
+    /\{\{(\w+)\}\}/g,
+    (match, key) => params[key] ?? match,
+  );
+}
+
+/**
+ * Get language display name
+ */
+export function getLanguageDisplayName(lang: SupportedLanguage): string {
+  const names: Record<SupportedLanguage, string> = {
+    en: 'English',
+    zh: '中文',
+    ja: '日本語',
+    pt: 'Português',
+    ru: 'Русский',
+    de: 'Deutsch',
+  };
+  return names[lang] || 'English';
+}

--- a/packages/web-templates/src/insight/translations/de.ts
+++ b/packages/web-templates/src/insight/translations/de.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Insight Report Translations - German (Deutsch)
+
+export default {
+  // Header
+  'Qwen Code Insights': 'Qwen Code Einblicke',
+  '{{messages}} messages across {{sessions}} sessions':
+    '{{messages}} Nachrichten in {{sessions}} Sitzungen',
+  'Your personalized coding journey and patterns':
+    'Ihre personalisierte Coding-Reise und Muster',
+
+  // Export Card Button
+  'Export Card': 'Karte exportieren',
+  'Light Theme': 'Helles Design',
+  'Dark Theme': 'Dunkles Design',
+
+  // At a Glance Section
+  'At a Glance': 'Auf einen Blick',
+  "What's working:": 'Was funktioniert:',
+  "What's hindering you:": 'Was hindert Sie:',
+  'Quick wins to try:': 'Schnelle Verbesserungen:',
+  'Ambitious workflows:': 'Anspruchsvolle Arbeitsabläufe:',
+  'Impressive Things You Did →': 'Ihre beeindruckenden Leistungen →',
+  'Where Things Go Wrong →': 'Wo Dinge schiefgehen →',
+  'Features to Try →': 'Funktionen zum Ausprobieren →',
+  'On the Horizon →': 'Ausblick →',
+
+  // Navigation TOC
+  'What You Work On': 'Woran Sie arbeiten',
+  'How You Use Qwen Code': 'Wie Sie Qwen Code verwenden',
+  'Impressive Things': 'Beeindruckende Leistungen',
+  'Where Things Go Wrong': 'Wo Dinge schiefgehen',
+  'Features to Try': 'Funktionen zum Ausprobieren',
+  'New Usage Patterns': 'Neue Verwendungsmuster',
+  'On the Horizon': 'Ausblick',
+
+  // Project Areas Section
+  '~{{count}} sessions': '~{{count}} Sitzungen',
+
+  // Interaction Style Section
+  'Key pattern:': 'Hauptmuster:',
+
+  // Impressive Workflows Section
+  'Impressive Things You Did': 'Ihre beeindruckenden Leistungen',
+  "What Helped Most (Qwen's Capabilities)":
+    'Was am meisten geholfen hat (Qwen-Funktionen)',
+  Outcomes: 'Ergebnisse',
+
+  // Friction Points Section
+  'Primary Friction Types': 'Hauptproblemtypen',
+  'Inferred Satisfaction (model-estimated)':
+    'Abgeleitete Zufriedenheit (Modellschätzung)',
+
+  // Improvements Section
+  'Existing Qwen Code Features to Try':
+    'Vorhandene Qwen Code-Funktionen zum Ausprobieren',
+  'Suggested QWEN.md Additions': 'Vorgeschlagene QWEN.md-Ergänzungen',
+  'Just copy this into Qwen Code to add it to your QWEN.md.':
+    'Einfach in Qwen Code kopieren, um es zu Ihrer QWEN.md hinzuzufügen.',
+  "Just copy this into Qwen Code and it'll set it up for you.":
+    'Einfach in Qwen Code kopieren und es wird für Sie eingerichtet.',
+  'Copy All Checked ({{count}})': 'Alle markierten kopieren ({{count}})',
+  'Copied All!': 'Alle kopiert!',
+  "Just copy this into Qwen Code and it'll walk you through it.":
+    'Einfach in Qwen Code kopieren und es führt Sie durch den Prozess.',
+
+  // Usage Patterns Section
+  'New Ways to Use Qwen Code': 'Neue Wege, Qwen Code zu verwenden',
+  'Paste into Qwen Code:': 'In Qwen Code einfügen:',
+
+  // Future Opportunities Section
+  'Getting started:': 'Erste Schritte:',
+
+  // Memorable Moment Section
+  'Why for you:': 'Warum für Sie:',
+
+  // Stats Row
+  Messages: 'Nachrichten',
+  Lines: 'Zeilen',
+  Files: 'Dateien',
+  Days: 'Tage',
+  'Msgs/Day': 'Nachrichten/Tag',
+
+  // Copy Button
+  Copy: 'Kopieren',
+  'Copied!': 'Kopiert!',
+
+  // Outcome labels
+  fully_achieved: 'Vollständig erreicht',
+  mostly_achieved: 'Überwiegend erreicht',
+  partially_achieved: 'Teilweise erreicht',
+  not_achieved: 'Nicht erreicht',
+  unclear_from_transcript: 'Unklar',
+
+  // Friction types
+  misunderstood_request: 'Missverstandene Anfrage',
+  wrong_approach: 'Falscher Ansatz',
+  buggy_code: 'Fehlerhafter Code',
+  user_rejected_action: 'Vom Benutzer abgelehnt',
+  excessive_changes: 'Übermäßige Änderungen',
+
+  // Satisfaction levels
+  happy: 'Glücklich',
+  satisfied: 'Zufrieden',
+  likely_satisfied: 'Wahrscheinlich zufrieden',
+  dissatisfied: 'Unzufrieden',
+  frustrated: 'Frustriert',
+
+  // Success types
+  fast_accurate_search: 'Schnelle und genaue Suche',
+  correct_code_edits: 'Korrekte Code-Bearbeitungen',
+  good_explanations: 'Gute Erklärungen',
+  proactive_help: 'Proaktive Hilfe',
+  multi_file_changes: 'Mehrere Dateiänderungen',
+  good_debugging: 'Gutes Debugging',
+} as Record<string, string>;

--- a/packages/web-templates/src/insight/translations/en.ts
+++ b/packages/web-templates/src/insight/translations/en.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Insight Report Translations - English (default)
+// These are embedded in the HTML at generation time
+
+export default {
+  // Header
+  'Qwen Code Insights': 'Qwen Code Insights',
+  '{{messages}} messages across {{sessions}} sessions':
+    '{{messages}} messages across {{sessions}} sessions',
+  'Your personalized coding journey and patterns':
+    'Your personalized coding journey and patterns',
+
+  // Export Card Button
+  'Export Card': 'Export Card',
+  'Light Theme': 'Light Theme',
+  'Dark Theme': 'Dark Theme',
+
+  // At a Glance Section
+  'At a Glance': 'At a Glance',
+  "What's working:": "What's working:",
+  "What's hindering you:": "What's hindering you:",
+  'Quick wins to try:': 'Quick wins to try:',
+  'Ambitious workflows:': 'Ambitious workflows:',
+  'Impressive Things You Did →': 'Impressive Things You Did →',
+  'Where Things Go Wrong →': 'Where Things Go Wrong →',
+  'Features to Try →': 'Features to Try →',
+  'On the Horizon →': 'On the Horizon →',
+
+  // Navigation TOC
+  'What You Work On': 'What You Work On',
+  'How You Use Qwen Code': 'How You Use Qwen Code',
+  'Impressive Things': 'Impressive Things',
+  'Where Things Go Wrong': 'Where Things Go Wrong',
+  'Features to Try': 'Features to Try',
+  'New Usage Patterns': 'New Usage Patterns',
+  'On the Horizon': 'On the Horizon',
+
+  // Project Areas Section
+  '~{{count}} sessions': '~{{count}} sessions',
+
+  // Interaction Style Section
+  'Key pattern:': 'Key pattern:',
+
+  // Impressive Workflows Section
+  'Impressive Things You Did': 'Impressive Things You Did',
+  "What Helped Most (Qwen's Capabilities)":
+    "What Helped Most (Qwen's Capabilities)",
+  Outcomes: 'Outcomes',
+
+  // Friction Points Section
+  'Primary Friction Types': 'Primary Friction Types',
+  'Inferred Satisfaction (model-estimated)':
+    'Inferred Satisfaction (model-estimated)',
+
+  // Improvements Section
+  'Existing Qwen Code Features to Try': 'Existing Qwen Code Features to Try',
+  'Suggested QWEN.md Additions': 'Suggested QWEN.md Additions',
+  'Just copy this into Qwen Code to add it to your QWEN.md.':
+    'Just copy this into Qwen Code to add it to your QWEN.md.',
+  "Just copy this into Qwen Code and it'll set it up for you.":
+    "Just copy this into Qwen Code and it'll set it up for you.",
+  'Copy All Checked ({{count}})': 'Copy All Checked ({{count}})',
+  'Copied All!': 'Copied All!',
+  "Just copy this into Qwen Code and it'll walk you through it.":
+    "Just copy this into Qwen Code and it'll walk you through it.",
+
+  // Usage Patterns Section
+  'New Ways to Use Qwen Code': 'New Ways to Use Qwen Code',
+  'Paste into Qwen Code:': 'Paste into Qwen Code:',
+
+  // Future Opportunities Section
+  'Getting started:': 'Getting started:',
+
+  // Memorable Moment Section
+  'Why for you:': 'Why for you:',
+
+  // Stats Row
+  Messages: 'Messages',
+  Lines: 'Lines',
+  Files: 'Files',
+  Days: 'Days',
+  'Msgs/Day': 'Msgs/Day',
+
+  // Copy Button
+  Copy: 'Copy',
+  'Copied!': 'Copied!',
+
+  // Outcome labels (these are shown as-is in charts)
+  fully_achieved: 'Fully Achieved',
+  mostly_achieved: 'Mostly Achieved',
+  partially_achieved: 'Partially Achieved',
+  not_achieved: 'Not Achieved',
+  unclear_from_transcript: 'Unclear',
+
+  // Friction types
+  misunderstood_request: 'Misunderstood Request',
+  wrong_approach: 'Wrong Approach',
+  buggy_code: 'Buggy Code',
+  user_rejected_action: 'User Rejected Action',
+  excessive_changes: 'Excessive Changes',
+
+  // Satisfaction levels
+  happy: 'Happy',
+  satisfied: 'Satisfied',
+  likely_satisfied: 'Likely Satisfied',
+  dissatisfied: 'Dissatisfied',
+  frustrated: 'Frustrated',
+
+  // Success types
+  fast_accurate_search: 'Fast & Accurate Search',
+  correct_code_edits: 'Correct Code Edits',
+  good_explanations: 'Good Explanations',
+  proactive_help: 'Proactive Help',
+  multi_file_changes: 'Multi-file Changes',
+  good_debugging: 'Good Debugging',
+} as Record<string, string>;

--- a/packages/web-templates/src/insight/translations/index.ts
+++ b/packages/web-templates/src/insight/translations/index.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Insight Report Translations Index
+// Re-exports all translation files and provides a helper to get translations by language
+
+import en from './en.js';
+import zh from './zh.js';
+import ja from './ja.js';
+import pt from './pt.js';
+import ru from './ru.js';
+import de from './de.js';
+
+export { en, zh, ja, pt, ru, de };
+
+export type SupportedLanguage = 'en' | 'zh' | 'ja' | 'pt' | 'ru' | 'de';
+
+/**
+ * Get translations for a specific language
+ * @param lang - Language code
+ * @returns Translation dictionary
+ */
+export function getTranslations(
+  lang: SupportedLanguage,
+): Record<string, string> {
+  const translations: Record<SupportedLanguage, Record<string, string>> = {
+    en,
+    zh,
+    ja,
+    pt,
+    ru,
+    de,
+  };
+  return translations[lang] || en;
+}
+
+/**
+ * Get language display name
+ */
+export function getLanguageDisplayName(lang: SupportedLanguage): string {
+  const names: Record<SupportedLanguage, string> = {
+    en: 'English',
+    zh: '中文',
+    ja: '日本語',
+    pt: 'Português',
+    ru: 'Русский',
+    de: 'Deutsch',
+  };
+  return names[lang] || 'English';
+}

--- a/packages/web-templates/src/insight/translations/ja.ts
+++ b/packages/web-templates/src/insight/translations/ja.ts
@@ -1,0 +1,118 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Insight Report Translations - Japanese (日本語)
+
+export default {
+  // Header
+  'Qwen Code Insights': 'Qwen Code インサイト',
+  '{{messages}} messages across {{sessions}} sessions':
+    '{{messages}} 件のメッセージ、{{sessions}} セッション',
+  'Your personalized coding journey and patterns':
+    'あなたのパーソナライズされたコーディングの旅とパターン',
+
+  // Export Card Button
+  'Export Card': 'カードをエクスポート',
+  'Light Theme': 'ライトテーマ',
+  'Dark Theme': 'ダークテーマ',
+
+  // At a Glance Section
+  'At a Glance': '概要',
+  "What's working:": 'うまくいっていること：',
+  "What's hindering you:": '妨げになっていること：',
+  'Quick wins to try:': '簡単に試せる改善：',
+  'Ambitious workflows:': '高度なワークフロー：',
+  'Impressive Things You Did →': 'あなたの素晴らしい成果 →',
+  'Where Things Go Wrong →': '問題が発生する場所 →',
+  'Features to Try →': '試す機能 →',
+  'On the Horizon →': '今後の展望 →',
+
+  // Navigation TOC
+  'What You Work On': '作業内容',
+  'How You Use Qwen Code': 'Qwen Code の使用方法',
+  'Impressive Things': '素晴らしい成果',
+  'Where Things Go Wrong': '問題が発生する場所',
+  'Features to Try': '試す機能',
+  'New Usage Patterns': '新しい使用パターン',
+  'On the Horizon': '今後の展望',
+
+  // Project Areas Section
+  '~{{count}} sessions': '約 {{count}} セッション',
+
+  // Interaction Style Section
+  'Key pattern:': 'キーパターン：',
+
+  // Impressive Workflows Section
+  'Impressive Things You Did': 'あなたの素晴らしい成果',
+  "What Helped Most (Qwen's Capabilities)": '最も役立った機能（Qwen の能力）',
+  Outcomes: '結果',
+
+  // Friction Points Section
+  'Primary Friction Types': '主な問題の種類',
+  'Inferred Satisfaction (model-estimated)': '推定満足度（モデル推定）',
+
+  // Improvements Section
+  'Existing Qwen Code Features to Try': '試す既存の Qwen Code 機能',
+  'Suggested QWEN.md Additions': 'QWEN.md に追加 suggested',
+  'Just copy this into Qwen Code to add it to your QWEN.md.':
+    'これを Qwen Code にコピーして QWEN.md に追加します。',
+  "Just copy this into Qwen Code and it'll set it up for you.":
+    'これを Qwen Code にコピーするだけで設定が完了します。',
+  'Copy All Checked ({{count}})': 'チェックしたすべてをコピー（{{count}}）',
+  'Copied All!': 'すべてコピーしました！',
+  "Just copy this into Qwen Code and it'll walk you through it.":
+    'これを Qwen Code にコピーすると、手順を案内します。',
+
+  // Usage Patterns Section
+  'New Ways to Use Qwen Code': 'Qwen Code の新しい使い方',
+  'Paste into Qwen Code:': 'Qwen Code に貼り付け：',
+
+  // Future Opportunities Section
+  'Getting started:': '始め方：',
+
+  // Memorable Moment Section
+  'Why for you:': 'あなたにとっての理由：',
+
+  // Stats Row
+  Messages: 'メッセージ',
+  Lines: '行',
+  Files: 'ファイル',
+  Days: '日',
+  'Msgs/Day': 'メッセージ/日',
+
+  // Copy Button
+  Copy: 'コピー',
+  'Copied!': 'コピーしました！',
+
+  // Outcome labels
+  fully_achieved: '完全に達成',
+  mostly_achieved: 'ほぼ達成',
+  partially_achieved: '部分的に達成',
+  not_achieved: '未達成',
+  unclear_from_transcript: '不明',
+
+  // Friction types
+  misunderstood_request: 'リクエストの誤解',
+  wrong_approach: '間違ったアプローチ',
+  buggy_code: 'バグのあるコード',
+  user_rejected_action: 'ユーザーが拒否',
+  excessive_changes: '過度な変更',
+
+  // Satisfaction levels
+  happy: '幸せ',
+  satisfied: '満足',
+  likely_satisfied: 'おそらく満足',
+  dissatisfied: '不満',
+  frustrated: '苛立ち',
+
+  // Success types
+  fast_accurate_search: '高速で正確な検索',
+  correct_code_edits: '正確なコード編集',
+  good_explanations: '良い説明',
+  proactive_help: '積極的なサポート',
+  multi_file_changes: '複数ファイルの変更',
+  good_debugging: '優れたデバッグ',
+} as Record<string, string>;

--- a/packages/web-templates/src/insight/translations/pt.ts
+++ b/packages/web-templates/src/insight/translations/pt.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Insight Report Translations - Portuguese (Português)
+
+export default {
+  // Header
+  'Qwen Code Insights': 'Insights do Qwen Code',
+  '{{messages}} messages across {{sessions}} sessions':
+    '{{messages}} mensagens em {{sessions}} sessões',
+  'Your personalized coding journey and patterns':
+    'Sua jornada de programação personalizada e padrões',
+
+  // Export Card Button
+  'Export Card': 'Exportar Cartão',
+  'Light Theme': 'Tema Claro',
+  'Dark Theme': 'Tema Escuro',
+
+  // At a Glance Section
+  'At a Glance': 'Resumo',
+  "What's working:": 'O que está funcionando:',
+  "What's hindering you:": 'O que está dificultando:',
+  'Quick wins to try:': 'Vitórias rápidas para tentar:',
+  'Ambitious workflows:': 'Fluxos de trabalho ambiciosos:',
+  'Impressive Things You Did →': 'Coisas Impressionantes que Você Fez →',
+  'Where Things Go Wrong →': 'Onde as Coisas Dão Errado →',
+  'Features to Try →': 'Recursos para Experimentar →',
+  'On the Horizon →': 'No Horizonte →',
+
+  // Navigation TOC
+  'What You Work On': 'No Que Você Trabalha',
+  'How You Use Qwen Code': 'Como Você Usa o Qwen Code',
+  'Impressive Things': 'Coisas Impressionantes',
+  'Where Things Go Wrong': 'Onde as Coisas Dão Errado',
+  'Features to Try': 'Recursos para Experimentar',
+  'New Usage Patterns': 'Novos Padrões de Uso',
+  'On the Horizon': 'No Horizonte',
+
+  // Project Areas Section
+  '~{{count}} sessions': '~{{count}} sessões',
+
+  // Interaction Style Section
+  'Key pattern:': 'Padrão principal:',
+
+  // Impressive Workflows Section
+  'Impressive Things You Did': 'Coisas Impressionantes que Você Fez',
+  "What Helped Most (Qwen's Capabilities)":
+    'O Que Mais Ajudou (Recursos do Qwen)',
+  Outcomes: 'Resultados',
+
+  // Friction Points Section
+  'Primary Friction Types': 'Tipos Principais de Fricção',
+  'Inferred Satisfaction (model-estimated)':
+    'Satisfação Inferida (estimativa do modelo)',
+
+  // Improvements Section
+  'Existing Qwen Code Features to Try':
+    'Recursos Existentes do Qwen Code para Experimentar',
+  'Suggested QWEN.md Additions': 'Sugestões de Adições ao QWEN.md',
+  'Just copy this into Qwen Code to add it to your QWEN.md.':
+    'Basta copiar isso para o Qwen Code para adicionar ao seu QWEN.md.',
+  "Just copy this into Qwen Code and it'll set it up for you.":
+    'Basta copiar isso para o Qwen Code e ele configurará para você.',
+  'Copy All Checked ({{count}})': 'Copiar Todos Marcados ({{count}})',
+  'Copied All!': 'Tudo Copiado!',
+  "Just copy this into Qwen Code and it'll walk you through it.":
+    'Basta copiar isso para o Qwen Code e ele o guiará.',
+
+  // Usage Patterns Section
+  'New Ways to Use Qwen Code': 'Novas Maneiras de Usar o Qwen Code',
+  'Paste into Qwen Code:': 'Cole no Qwen Code:',
+
+  // Future Opportunities Section
+  'Getting started:': 'Começando:',
+
+  // Memorable Moment Section
+  'Why for you:': 'Por que para você:',
+
+  // Stats Row
+  Messages: 'Mensagens',
+  Lines: 'Linhas',
+  Files: 'Arquivos',
+  Days: 'Dias',
+  'Msgs/Day': 'Mensagens/Dia',
+
+  // Copy Button
+  Copy: 'Copiar',
+  'Copied!': 'Copiado!',
+
+  // Outcome labels
+  fully_achieved: 'Totalmente Alcançado',
+  mostly_achieved: 'Quase Alcançado',
+  partially_achieved: 'Parcialmente Alcançado',
+  not_achieved: 'Não Alcançado',
+  unclear_from_transcript: 'Incerto',
+
+  // Friction types
+  misunderstood_request: 'Pedido Mal Entendido',
+  wrong_approach: 'Abordagem Errada',
+  buggy_code: 'Código com Bugs',
+  user_rejected_action: 'Ação Rejeitada pelo Usuário',
+  excessive_changes: 'Mudanças Excessivas',
+
+  // Satisfaction levels
+  happy: 'Feliz',
+  satisfied: 'Satisfeito',
+  likely_satisfied: 'Provavelmente Satisfeito',
+  dissatisfied: 'Insatisfeito',
+  frustrated: 'Frustrado',
+
+  // Success types
+  fast_accurate_search: 'Busca Rápida e Precisa',
+  correct_code_edits: 'Edições de Código Corretas',
+  good_explanations: 'Boas Explicações',
+  proactive_help: 'Ajuda Proativa',
+  multi_file_changes: 'Alterações em Múltiplos Arquivos',
+  good_debugging: 'Boa Depuração',
+} as Record<string, string>;

--- a/packages/web-templates/src/insight/translations/ru.ts
+++ b/packages/web-templates/src/insight/translations/ru.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Insight Report Translations - Russian (Русский)
+
+export default {
+  // Header
+  'Qwen Code Insights': 'Инсайты Qwen Code',
+  '{{messages}} messages across {{sessions}} sessions':
+    '{{messages}} сообщений в {{sessions}} сессиях',
+  'Your personalized coding journey and patterns':
+    'Ваш персональный путь программирования и паттерны',
+
+  // Export Card Button
+  'Export Card': 'Экспорт карточки',
+  'Light Theme': 'Светлая тема',
+  'Dark Theme': 'Тёмная тема',
+
+  // At a Glance Section
+  'At a Glance': 'Вкратце',
+  "What's working:": 'Что работает:',
+  "What's hindering you:": 'Что мешает:',
+  'Quick wins to try:': 'Быстрые улучшения:',
+  'Ambitious workflows:': 'Продвинутые рабочие процессы:',
+  'Impressive Things You Did →': 'Ваши впечатляющие достижения →',
+  'Where Things Go Wrong →': 'Где возникают проблемы →',
+  'Features to Try →': 'Функции для проверки →',
+  'On the Horizon →': 'На горизонте →',
+
+  // Navigation TOC
+  'What You Work On': 'Над чем вы работаете',
+  'How You Use Qwen Code': 'Как вы используете Qwen Code',
+  'Impressive Things': 'Впечатляющие достижения',
+  'Where Things Go Wrong': 'Где возникают проблемы',
+  'Features to Try': 'Функции для проверки',
+  'New Usage Patterns': 'Новые паттерны использования',
+  'On the Horizon': 'На горизонте',
+
+  // Project Areas Section
+  '~{{count}} sessions': '~{{count}} сессий',
+
+  // Interaction Style Section
+  'Key pattern:': 'Ключевой паттерн:',
+
+  // Impressive Workflows Section
+  'Impressive Things You Did': 'Ваши впечатляющие достижения',
+  "What Helped Most (Qwen's Capabilities)":
+    'Что помогло больше всего (возможности Qwen)',
+  Outcomes: 'Результаты',
+
+  // Friction Points Section
+  'Primary Friction Types': 'Основные типы проблем',
+  'Inferred Satisfaction (model-estimated)':
+    'Предполагаемая удовлетворённость (оценка модели)',
+
+  // Improvements Section
+  'Existing Qwen Code Features to Try':
+    'Существующие функции Qwen Code для проверки',
+  'Suggested QWEN.md Additions': 'Рекомендуемые дополнения QWEN.md',
+  'Just copy this into Qwen Code to add it to your QWEN.md.':
+    'Просто скопируйте это в Qwen Code, чтобы добавить в ваш QWEN.md.',
+  "Just copy this into Qwen Code and it'll set it up for you.":
+    'Просто скопируйте это в Qwen Code, и он настроит это для вас.',
+  'Copy All Checked ({{count}})': 'Скопировать все отмеченные ({{count}})',
+  'Copied All!': 'Всё скопировано!',
+  "Just copy this into Qwen Code and it'll walk you through it.":
+    'Просто скопируйте это в Qwen Code, и он проведёт вас через это.',
+
+  // Usage Patterns Section
+  'New Ways to Use Qwen Code': 'Новые способы использования Qwen Code',
+  'Paste into Qwen Code:': 'Вставить в Qwen Code:',
+
+  // Future Opportunities Section
+  'Getting started:': 'Начало работы:',
+
+  // Memorable Moment Section
+  'Why for you:': 'Почему для вас:',
+
+  // Stats Row
+  Messages: 'Сообщения',
+  Lines: 'Строки',
+  Files: 'Файлы',
+  Days: 'Дни',
+  'Msgs/Day': 'Сообщений/день',
+
+  // Copy Button
+  Copy: 'Копировать',
+  'Copied!': 'Скопировано!',
+
+  // Outcome labels
+  fully_achieved: 'Полностью достигнуто',
+  mostly_achieved: 'В основном достигнуто',
+  partially_achieved: 'Частично достигнуто',
+  not_achieved: 'Не достигнуто',
+  unclear_from_transcript: 'Неясно',
+
+  // Friction types
+  misunderstood_request: 'Непонятый запрос',
+  wrong_approach: 'Неправильный подход',
+  buggy_code: 'Баги в коде',
+  user_rejected_action: 'Пользователь отклонил действие',
+  excessive_changes: 'Чрезмерные изменения',
+
+  // Satisfaction levels
+  happy: 'Счастлив',
+  satisfied: 'Удовлетворён',
+  likely_satisfied: 'Вероятно удовлетворён',
+  dissatisfied: 'Не удовлетворён',
+  frustrated: 'Расстроен',
+
+  // Success types
+  fast_accurate_search: 'Быстрый и точный поиск',
+  correct_code_edits: 'Правильные правки кода',
+  good_explanations: 'Хорошие объяснения',
+  proactive_help: 'Проактивная помощь',
+  multi_file_changes: 'Изменения в нескольких файлах',
+  good_debugging: 'Хорошая отладка',
+} as Record<string, string>;

--- a/packages/web-templates/src/insight/translations/zh.ts
+++ b/packages/web-templates/src/insight/translations/zh.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Insight Report Translations - Chinese (中文)
+
+export default {
+  // Header
+  'Qwen Code Insights': 'Qwen Code 洞察报告',
+  '{{messages}} messages across {{sessions}} sessions':
+    '{{messages}} 条消息，共 {{sessions}} 个会话',
+  'Your personalized coding journey and patterns': '您的个性化编程之旅和模式',
+
+  // Export Card Button
+  'Export Card': '导出卡片',
+  'Light Theme': '浅色主题',
+  'Dark Theme': '深色主题',
+
+  // At a Glance Section
+  'At a Glance': '总览',
+  "What's working:": '有效的方法：',
+  "What's hindering you:": '遇到的阻碍：',
+  'Quick wins to try:': '可尝试的快速改进：',
+  'Ambitious workflows:': '进阶工作流：',
+  'Impressive Things You Did →': '您的出色成果 →',
+  'Where Things Go Wrong →': '问题所在 →',
+  'Features to Try →': '可尝试的功能 →',
+  'On the Horizon →': '未来展望 →',
+
+  // Navigation TOC
+  'What You Work On': '工作内容',
+  'How You Use Qwen Code': '如何使用 Qwen Code',
+  'Impressive Things': '出色成果',
+  'Where Things Go Wrong': '问题所在',
+  'Features to Try': '可尝试的功能',
+  'New Usage Patterns': '新使用模式',
+  'On the Horizon': '未来展望',
+
+  // Project Areas Section
+  '~{{count}} sessions': '约 {{count}} 个会话',
+
+  // Interaction Style Section
+  'Key pattern:': '关键模式：',
+
+  // Impressive Workflows Section
+  'Impressive Things You Did': '您的出色成果',
+  "What Helped Most (Qwen's Capabilities)": '最有帮助的功能（Qwen 的能力）',
+  Outcomes: '结果',
+
+  // Friction Points Section
+  'Primary Friction Types': '主要问题类型',
+  'Inferred Satisfaction (model-estimated)': '推断满意度（模型估算）',
+
+  // Improvements Section
+  'Existing Qwen Code Features to Try': '可尝试的现有 Qwen Code 功能',
+  'Suggested QWEN.md Additions': '建议添加到 QWEN.md',
+  'Just copy this into Qwen Code to add it to your QWEN.md.':
+    '只需将其复制到 Qwen Code 即可添加到您的 QWEN.md。',
+  "Just copy this into Qwen Code and it'll set it up for you.":
+    '只需将其复制到 Qwen Code，它将为您设置。',
+  'Copy All Checked ({{count}})': '复制所有已选项（{{count}}）',
+  'Copied All!': '已全部复制！',
+  "Just copy this into Qwen Code and it'll walk you through it.":
+    '只需将其复制到 Qwen Code，它将引导您完成。',
+
+  // Usage Patterns Section
+  'New Ways to Use Qwen Code': '使用 Qwen Code 的新方式',
+  'Paste into Qwen Code:': '粘贴到 Qwen Code：',
+
+  // Future Opportunities Section
+  'Getting started:': '开始使用：',
+
+  // Memorable Moment Section
+  'Why for you:': '为什么适合您：',
+
+  // Stats Row
+  Messages: '消息',
+  Lines: '代码行',
+  Files: '文件',
+  Days: '天数',
+  'Msgs/Day': '消息/天',
+
+  // Copy Button
+  Copy: '复制',
+  'Copied!': '已复制！',
+
+  // Outcome labels
+  fully_achieved: '完全达成',
+  mostly_achieved: '大部分达成',
+  partially_achieved: '部分达成',
+  not_achieved: '未达成',
+  unclear_from_transcript: '不明确',
+
+  // Friction types
+  misunderstood_request: '误解请求',
+  wrong_approach: '方法错误',
+  buggy_code: '代码有 bug',
+  user_rejected_action: '用户拒绝操作',
+  excessive_changes: '过度修改',
+
+  // Satisfaction levels
+  happy: '开心',
+  satisfied: '满意',
+  likely_satisfied: '可能满意',
+  dissatisfied: '不满意',
+  frustrated: '沮丧',
+
+  // Success types
+  fast_accurate_search: '快速准确搜索',
+  correct_code_edits: '正确的代码编辑',
+  good_explanations: '清晰的解释',
+  proactive_help: '主动帮助',
+  multi_file_changes: '多文件修改',
+  good_debugging: '优秀的调试能力',
+} as Record<string, string>;


### PR DESCRIPTION
## What this PR does

This PR implements language localization for the `/insight` HTML report, addressing issue #2022.

### Changes

1. **i18n Infrastructure**: Added a lightweight i18n system to the insight report frontend
2. **Translation Files**: Created translations for 6 languages:
   - English (en)
   - 中文 (zh)
   - 日本語 (ja)
   - Português (pt)
   - Русский (ru)
   - Deutsch (de)

3. **LLM Localization**: The LLM now generates insight content (workflows, friction points, recommendations, etc.) in the user's preferred language
4. **UI Localization**: All static text in the report (headers, labels, buttons, chart titles) is now translated
5. **Language Info Message**: Shows which language is being used when generating insights

### How to test

1. Set your UI language: `/language ui <lang>` (e.g., `/language ui zh`)
2. Run `/insight` command
3. The generated HTML report should be in your selected language

### Technical Details

- Translations are embedded in the HTML at build time
- The user's language preference is read from the i18n system
- Language instruction is passed to the LLM for generating localized insights
- Build system parses TypeScript translation files and embeds them as JSON

Fixes: #2022