### PR TITLE
chore: bump version to 0.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "workspaces": [
         "packages/*"
       ],
@@ -18780,7 +18780,7 @@
     },
     "packages/cli": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "dependencies": {
         "@google/genai": "1.30.0",
         "@iarna/toml": "^2.2.5",
@@ -19437,7 +19437,7 @@
     },
     "packages/core": {
       "name": "@qwen-code/qwen-code-core",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.36.1",
@@ -22917,7 +22917,7 @@
     },
     "packages/test-utils": {
       "name": "@qwen-code/qwen-code-test-utils",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
@@ -22929,7 +22929,7 @@
     },
     "packages/vscode-ide-companion": {
       "name": "qwen-code-vscode-ide-companion",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "LICENSE",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.1",
@@ -23176,7 +23176,7 @@
     },
     "packages/web-templates": {
       "name": "@qwen-code/web-templates",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "devDependencies": {
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
@@ -23704,7 +23704,7 @@
     },
     "packages/webui": {
       "name": "@qwen-code/webui",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "markdown-it": "^14.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "engines": {
     "node": ">=20.0.0"
   },
@@ -13,7 +13,7 @@
     "url": "git+https://github.com/QwenLM/qwen-code.git"
   },
   "config": {
-    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.11.1"
+    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.12.0"
   },
   "scripts": {
     "start": "cross-env node scripts/start.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Qwen Code",
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
     "dist"
   ],
   "config": {
-    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.11.1"
+    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.12.0"
   },
   "dependencies": {
     "@google/genai": "1.30.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code-core",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Qwen Code Core",
   "repository": {
     "type": "git",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code-test-utils",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "private": true,
   "main": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -2,7 +2,7 @@
   "name": "qwen-code-vscode-ide-companion",
   "displayName": "Qwen Code Companion",
   "description": "Enable Qwen Code with direct access to your VS Code workspace.",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "publisher": "qwenlm",
   "icon": "assets/icon.png",
   "repository": {

--- a/packages/web-templates/package.json
+++ b/packages/web-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/web-templates",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Web templates bundled as embeddable JS/CSS strings",
   "repository": {
     "type": "git",

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/webui",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Shared UI components for Qwen Code packages",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## TLDR

Bump version from 0.11.1 to 0.12.0 across all packages in the monorepo.

## Dive Deeper

This PR updates the version number in all package.json files and the corresponding sandbox image URI references. This is a routine version bump for the upcoming release.

Affected packages:
- Root package
- packages/cli
- packages/core
- packages/test-utils
- packages/vscode-ide-companion
- packages/web-templates
- packages/webui

## Reviewer Test Plan

1. Verify version numbers are correctly updated in all package.json files
2. Run `npm install` to ensure package-lock.json is consistent
3. Run `npm run build` to verify the build passes

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

No linked issues

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)