### PR TITLE
fix(core): exclude empty tools array from DashScope API requests

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -469,6 +469,41 @@ describe('DashScopeOpenAICompatibleProvider', () => {
       });
     });
 
+    it('should not include empty tools array in request', () => {
+      const requestWithEmptyTools: OpenAI.Chat.ChatCompletionCreateParams = {
+        ...baseRequest,
+        tools: [],
+      };
+
+      const result = provider.buildRequest(
+        requestWithEmptyTools,
+        'test-prompt-id',
+      );
+
+      // Empty tools array should be excluded to avoid API errors like "[] is too short - 'tools'"
+      expect(result.tools).toBeUndefined();
+    });
+
+    it('should include non-empty tools array in request', () => {
+      const requestWithTools: OpenAI.Chat.ChatCompletionCreateParams = {
+        ...baseRequest,
+        tools: [
+          {
+            type: 'function',
+            function: {
+              name: 'test_function',
+              description: 'A test function',
+            },
+          },
+        ],
+      };
+
+      const result = provider.buildRequest(requestWithTools, 'test-prompt-id');
+
+      expect(result.tools).toHaveLength(1);
+      expect(result.tools?.[0].function.name).toBe('test_function');
+    });
+
     it('should preserve all original request parameters', () => {
       const complexRequest: OpenAI.Chat.ChatCompletionCreateParams = {
         ...baseRequest,

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -121,13 +121,21 @@ export class DashScopeOpenAICompatibleProvider
     // This ensures max_tokens doesn't exceed the model's maximum output limit
     const requestWithTokenLimits = this.applyOutputTokenLimit(request);
 
+    // Exclude tools from requestWithTokenLimits since we handle it separately
+     
+    const { tools: _unusedTools, ...requestWithoutTools } =
+      requestWithTokenLimits;
+
     const extraBody = this.contentGeneratorConfig.extra_body;
+
+    // Only include tools if the array has items - empty arrays can cause API errors like "[] is too short - 'tools'"
+    const toolsParam = tools && tools.length > 0 ? { tools } : {};
 
     if (this.isVisionModel(request.model)) {
       return {
-        ...requestWithTokenLimits,
+        ...requestWithoutTools,
         messages,
-        ...(tools ? { tools } : {}),
+        ...toolsParam,
         ...(this.buildMetadata(userPromptId) || {}),
         /* @ts-expect-error dashscope exclusive */
         vl_high_resolution_images: true,
@@ -136,9 +144,9 @@ export class DashScopeOpenAICompatibleProvider
     }
 
     return {
-      ...requestWithTokenLimits, // Preserve all original parameters including sampling params and adjusted max_tokens
+      ...requestWithoutTools, // Preserve all original parameters including sampling params and adjusted max_tokens
       messages,
-      ...(tools ? { tools } : {}),
+      ...toolsParam,
       ...(this.buildMetadata(userPromptId) || {}),
       ...(extraBody ? extraBody : {}),
     } as OpenAI.Chat.ChatCompletionCreateParams;
@@ -201,10 +209,13 @@ export class DashScopeOpenAICompatibleProvider
             } as OpenAI.Chat.ChatCompletionMessageParam;
           });
 
+    // Only include tools if the array has items - empty arrays can cause API errors like "[] is too short - 'tools'"
     const updatedTools =
       cacheControl === 'all' && request.tools?.length
         ? this.addCacheControlToTools(request.tools)
-        : (request.tools as ChatCompletionToolWithCache[] | undefined);
+        : request.tools?.length
+          ? (request.tools as ChatCompletionToolWithCache[] | undefined)
+          : undefined;
 
     return {
       messages: updatedMessages,


### PR DESCRIPTION
Fixes #2054

When using qwen ai model via Xcode26, the API returns error about tools being too short.

This happens when the tools array is empty but still included in the request.

## Solution
- Filter out empty tools arrays in addDashScopeCacheControl
- Exclude tools from request spread to avoid overriding processed tools
- Only include tools param when array has items

## Changes
- packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
- packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts

## Testing
All 43 tests pass including 2 new test cases.