### PR TITLE
fix(cli): clear static error message when starting new query

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -2526,6 +2526,77 @@ describe('useGeminiStream', () => {
         expect.any(String),
       );
     });
+
+    it('should clear static error when starting a new query', async () => {
+      // First, mock a stream that yields an error (static error without countdown)
+      mockSendMessageStream.mockReturnValueOnce(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Error,
+            value: { error: { message: 'First error' } },
+          };
+        })(),
+      );
+
+      const { result } = renderHook(() =>
+        useGeminiStream(
+          new MockedGeminiClientClass(mockConfig),
+          [],
+          mockAddItem,
+          mockConfig,
+          mockLoadedSettings,
+          mockOnDebugMessage,
+          mockHandleSlashCommand,
+          false,
+          () => 'vscode' as EditorType,
+          () => {},
+          () => Promise.resolve(),
+          false,
+          () => {},
+          () => {},
+          () => {},
+          () => {},
+          80,
+          24,
+        ),
+      );
+
+      // Submit first query that will fail
+      await act(async () => {
+        await result.current.submitQuery('First query');
+      });
+
+      // Verify error appears in pending history items
+      await waitFor(() => {
+        const errorItem = result.current.pendingHistoryItems.find(
+          (item) => item.type === 'error',
+        );
+        expect(errorItem).toBeDefined();
+      });
+
+      // Now mock a successful stream for the second query
+      mockSendMessageStream.mockReturnValueOnce(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Text,
+            value: 'Success response',
+          };
+        })(),
+      );
+
+      // Submit second query
+      await act(async () => {
+        await result.current.submitQuery('Second query');
+      });
+
+      // Verify the error is cleared (no longer in pending history items)
+      await waitFor(() => {
+        const errorItem = result.current.pendingHistoryItems.find(
+          (item) => item.type === 'error',
+        );
+        expect(errorItem).toBeUndefined();
+      });
+    });
   });
 
   describe('Concurrent Execution Prevention', () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1080,8 +1080,13 @@ export const useGeminiStream = (
       if (!options?.isContinuation) {
         setModelSwitchedFromQuotaError(false);
         // Commit any pending retry error to history (without hint) since the
-        // user is starting a new conversation turn
-        if (pendingRetryCountdownItemRef.current) {
+        // user is starting a new conversation turn.
+        // Clear both countdown-based errors AND static errors (those without
+        // an active countdown timer, e.g. "Press Ctrl+Y to retry").
+        if (
+          pendingRetryCountdownItemRef.current ||
+          pendingRetryErrorItemRef.current
+        ) {
           clearRetryCountdown();
         }
       }
@@ -1176,7 +1181,8 @@ export const useGeminiStream = (
           }
           // Only clear auto-retry countdown errors (those with an active timer).
           // Do NOT clear static error+hint from handleErrorEvent — those should
-          // remain visible until the user presses Ctrl+Y to retry.
+          // remain visible until the user presses Ctrl+Y to retry or starts
+          // a new conversation turn (cleared in submitQuery).
           if (retryCountdownTimerRef.current) {
             clearRetryCountdown();
           }
@@ -1223,6 +1229,7 @@ export const useGeminiStream = (
       handleLoopDetectedEvent,
       clearRetryCountdown,
       pendingRetryCountdownItemRef,
+      pendingRetryErrorItemRef,
       setPendingRetryErrorItem,
     ],
   );


### PR DESCRIPTION
## TLDR

Fixes an issue where static error messages (e.g., "Press Ctrl+Y to retry") were not cleared when the user starts a new query.

**Changes**:
- `submitQuery` function now checks both `pendingRetryCountdownItemRef` and `pendingRetryErrorItemRef`
- Both types of error messages are now properly cleared when the user starts a new conversation turn

when error:
<img width="1302" height="406" alt="image" src="https://github.com/user-attachments/assets/2a5f2209-e325-4d68-9cb5-e3972f3cafae" />
enter something or change model:
<img width="1322" height="528" alt="image" src="https://github.com/user-attachments/assets/a4c98d8a-c23e-4f3e-b679-c0f34cab33f6" />

## Dive Deeper

**Problem**:
- The original logic only checked `pendingRetryCountdownItemRef` (countdown-based errors)
- Static errors (without countdown timer, e.g., "Press Ctrl+Y to retry" shown after API errors) were missed
- This caused stale error messages to remain visible after the user input a new query

**Solution**:
- Added `pendingRetryErrorItemRef.current` to the condition check
- Reused existing `clearRetryCountdown()` function to clear both error types
- Fixed React Hook dependency array warning by adding `pendingRetryErrorItemRef` to dependencies

## Reviewer Test Plan

1. Run unit tests:
   ```bash
   npm run test -- --filter useGeminiStream
   ```

2. Manual testing:
   - Start the CLI
   - Trigger an API error (e.g., disconnect network or simulate error)
   - Confirm error message appears (static error without countdown)
   - Input a new query
   - **Expected**: Error message is cleared, UI is clean

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2105