### PR TITLE
fix(core): prevent duplicate function-call yields from trailing stream chunks

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -980,6 +980,147 @@ describe('ContentGenerationPipeline', () => {
         totalTokenCount: 30,
       });
     });
+
+    it('should not duplicate function calls when trailing chunks arrive after finish+usage merge', async () => {
+      // Reproduces the real-world bug: some providers (e.g. bailian/glm-5)
+      // send trailing empty chunks AFTER the finish+usage pair. Before the
+      // fix, each trailing chunk re-triggered the merge logic and yielded
+      // the finish response again (with the same function-call parts),
+      // causing duplicate tool-call execution in the UI.
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
+      };
+      const userPromptId = 'test-prompt-id';
+
+      // Chunk 1: content text
+      const mockChunk1 = {
+        id: 'chunk-1',
+        choices: [
+          { delta: { content: 'I will create a todo' }, finish_reason: null },
+        ],
+      } as OpenAI.Chat.ChatCompletionChunk;
+
+      // Chunk 2: finish reason (with tool calls)
+      const mockChunk2 = {
+        id: 'chunk-2',
+        choices: [{ delta: {}, finish_reason: 'tool_calls' }],
+      } as OpenAI.Chat.ChatCompletionChunk;
+
+      // Chunk 3: usage metadata only
+      const mockChunk3 = {
+        id: 'chunk-3',
+        choices: [],
+        usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      } as unknown as OpenAI.Chat.ChatCompletionChunk;
+
+      // Chunk 4: trailing empty chunk (the problematic one)
+      const mockChunk4 = {
+        id: 'chunk-4',
+        choices: [],
+      } as unknown as OpenAI.Chat.ChatCompletionChunk;
+
+      const mockStream = {
+        async *[Symbol.asyncIterator]() {
+          yield mockChunk1;
+          yield mockChunk2;
+          yield mockChunk3;
+          yield mockChunk4;
+        },
+      };
+
+      // Converter output for chunk 1: text content
+      const mockContentResponse = new GenerateContentResponse();
+      mockContentResponse.candidates = [
+        {
+          content: {
+            parts: [{ text: 'I will create a todo' }],
+            role: 'model',
+          },
+        },
+      ];
+
+      // Converter output for chunk 2: finish + function call
+      const mockFinishResponse = new GenerateContentResponse();
+      mockFinishResponse.candidates = [
+        {
+          content: {
+            parts: [
+              {
+                functionCall: {
+                  name: 'todoWrite',
+                  args: { text: 'buy milk' },
+                },
+              },
+            ],
+            role: 'model',
+          },
+          finishReason: FinishReason.STOP,
+        },
+      ];
+
+      // Converter output for chunk 3: usage only
+      const mockUsageResponse = new GenerateContentResponse();
+      mockUsageResponse.candidates = [];
+      mockUsageResponse.usageMetadata = {
+        promptTokenCount: 10,
+        candidatesTokenCount: 20,
+        totalTokenCount: 30,
+      };
+
+      // Converter output for chunk 4: trailing empty
+      const mockTrailingResponse = new GenerateContentResponse();
+      mockTrailingResponse.candidates = [];
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([]);
+      (mockConverter.convertOpenAIChunkToGemini as Mock)
+        .mockReturnValueOnce(mockContentResponse)
+        .mockReturnValueOnce(mockFinishResponse)
+        .mockReturnValueOnce(mockUsageResponse)
+        .mockReturnValueOnce(mockTrailingResponse);
+      (mockClient.chat.completions.create as Mock).mockResolvedValue(
+        mockStream,
+      );
+
+      // Act
+      const resultGenerator = await pipeline.executeStream(
+        request,
+        userPromptId,
+      );
+      const results = [];
+      for await (const result of resultGenerator) {
+        results.push(result);
+      }
+
+      // Assert: exactly 2 results — content chunk + ONE merged finish chunk.
+      // Before the fix this was 3 (the trailing chunk triggered a duplicate).
+      expect(results).toHaveLength(2);
+      expect(results[0]).toBe(mockContentResponse);
+
+      // The merged result should have the function call and usage metadata
+      const mergedResult = results[1]!;
+      expect(mergedResult.candidates?.[0]?.finishReason).toBe(
+        FinishReason.STOP,
+      );
+      expect(
+        mergedResult.candidates?.[0]?.content?.parts?.[0]?.functionCall?.name,
+      ).toBe('todoWrite');
+      expect(mergedResult.usageMetadata).toEqual({
+        promptTokenCount: 10,
+        candidatesTokenCount: 20,
+        totalTokenCount: 30,
+      });
+
+      // Count function-call parts across ALL yielded results — must be exactly 1
+      let totalFunctionCalls = 0;
+      for (const result of results) {
+        const parts = result.candidates?.[0]?.content?.parts ?? [];
+        totalFunctionCalls += parts.filter(
+          (p: { functionCall?: unknown }) => p.functionCall,
+        ).length;
+      }
+      expect(totalFunctionCalls).toBe(1);
+    });
   });
 
   describe('buildRequest', () => {

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -127,8 +127,15 @@ export class ContentGenerationPipeline {
     // Reset streaming tool calls to prevent data pollution from previous streams
     this.converter.resetStreamingToolCalls();
 
-    // State for handling chunk merging
+    // State for handling chunk merging.
+    // pendingFinishResponse holds a finish chunk waiting to be merged with
+    // a subsequent usage-metadata chunk before yielding.
+    // finishYielded is set to true once the merged finish response has been
+    // yielded, so that any further trailing chunks are treated as normal
+    // chunks instead of triggering another merge (which would duplicate the
+    // function-call parts from the finish chunk).
     let pendingFinishResponse: GenerateContentResponse | null = null;
+    let finishYielded = false;
 
     try {
       // Stage 2a: Convert and yield each chunk while preserving original
@@ -155,7 +162,29 @@ export class ContentGenerationPipeline {
           continue;
         }
 
-        // Stage 2c: Handle chunk merging for providers that send finishReason and usageMetadata separately
+        // Stage 2c: Handle chunk merging for providers that send
+        // finishReason and usageMetadata in separate chunks.
+        // Once the merged finish response has been yielded, skip
+        // further merging so trailing chunks don't duplicate the
+        // function-call parts carried by the finish chunk.
+        if (finishYielded) {
+          // Finish already yielded — absorb any remaining usage
+          // metadata but do NOT yield another response.
+          // Note: pendingFinishResponse is guaranteed non-null here because
+          // finishYielded is only set to true inside the `if (pendingFinishResponse)`
+          // block below. TypeScript cannot infer this through the callback
+          // assignment in handleChunkMerging, so an explicit cast is needed.
+          if (response.usageMetadata) {
+            const pending =
+              pendingFinishResponse as GenerateContentResponse | null;
+            if (pending) {
+              pending.usageMetadata = response.usageMetadata;
+            }
+          }
+          collectedGeminiResponses.push(response);
+          continue;
+        }
+
         const shouldYield = this.handleChunkMerging(
           response,
           collectedGeminiResponses,
@@ -168,15 +197,18 @@ export class ContentGenerationPipeline {
           // If we have a pending finish response, yield it instead
           if (pendingFinishResponse) {
             yield pendingFinishResponse;
-            pendingFinishResponse = null;
+            finishYielded = true;
+            // Keep pendingFinishResponse alive so late-arriving usage
+            // metadata can still be merged (see finishYielded block above).
           } else {
             yield response;
           }
         }
       }
 
-      // Stage 2d: If there's still a pending finish response at the end, yield it
-      if (pendingFinishResponse) {
+      // Stage 2d: If there's still a pending finish response at the end
+      // (e.g. no usage chunk arrived after the finish chunk), yield it.
+      if (pendingFinishResponse && !finishYielded) {
         yield pendingFinishResponse;
       }
 


### PR DESCRIPTION
## TLDR

Fix duplicate function-call yields caused by trailing stream chunks from some OpenAI-compatible providers (e.g. `bailian/glm-5`), which resulted in duplicate tool-call executions in the UI.

## Dive Deeper

**Root cause**: State leak in `handleChunkMerging` within `processStreamWithLogging`:

1. Chunk A (finish chunk) arrives — carries `finishReason` + `functionCall` → held pending, not yielded
2. Chunk B (usage chunk) arrives → detects pending finish → merges usage → yields merged result ✅
3. Chunk C (trailing empty chunk) arrives → last entry in `collectedGeminiResponses` still has `finishReason` (reference assignment `mergedResponse.candidates = lastResponse.candidates`) → `hasPendingFinish` remains true → triggers another merge and yield ❌

**Fix**: Add a `finishYielded` flag in `processStreamWithLogging`. Once the merged finish response is yielded, all subsequent chunks skip `handleChunkMerging` entirely, only absorbing late-arriving usage metadata without producing further yields.

## Reviewer Test Plan

1. `npx vitest run packages/core/src/core/openaiContentGenerator/pipeline.test.ts` — includes new test for duplicate function-call prevention
2. `npm run build` — confirm clean build
3. Manual testing with a provider that sends trailing chunks (e.g. `bailian/glm-5`)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2121