### PR TITLE
fix(cli): restore space/printable key input for kitty CSI-u sequences

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -380,6 +380,76 @@ describe('KeypressContext - Kitty Protocol', () => {
     });
   });
 
+  describe('Printable character handling', () => {
+    it('should recognize space key (keycode 32) in kitty protocol', async () => {
+      const keyHandler = vi.fn();
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper,
+      });
+      act(() => result.current.subscribe(keyHandler));
+
+      act(() => {
+        stdin.sendKittySequence('\x1b[32u');
+      });
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: '',
+          sequence: ' ',
+          kittyProtocol: true,
+          ctrl: false,
+          meta: false,
+          shift: false,
+        }),
+      );
+    });
+
+    it('should recognize letter keys in kitty protocol', async () => {
+      const keyHandler = vi.fn();
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper,
+      });
+      act(() => result.current.subscribe(keyHandler));
+
+      act(() => {
+        stdin.sendKittySequence('\x1b[97u');
+      });
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: '',
+          sequence: 'a',
+          kittyProtocol: true,
+          shift: false,
+        }),
+      );
+    });
+
+    it('should recognize shifted letter keys with text codepoints in kitty protocol', async () => {
+      const keyHandler = vi.fn();
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper,
+      });
+      act(() => result.current.subscribe(keyHandler));
+
+      // KeyCode remains unshifted (97 = 'a'); text parameter carries "A" (65).
+      act(() => {
+        stdin.sendKittySequence('\x1b[97;2;65u');
+      });
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: '',
+          sequence: 'A',
+          kittyProtocol: true,
+          shift: true,
+          ctrl: false,
+          meta: false,
+        }),
+      );
+    });
+  });
+
   describe('paste mode', () => {
     it('should handle multiline paste as a single event', async () => {
       const keyHandler = vi.fn();

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -252,7 +252,9 @@ export function KeypressProvider({
       // 3) CSI-u form: ESC [ <code> ; <mods> (u|~)
       // 3) CSI-u and tilde-coded functional keys: ESC [ <code> ; <mods> (u|~)
       //    'u' terminator: Kitty CSI-u; '~' terminator: tilde-coded function keys.
-      const csiUPrefix = new RegExp(`^${ESC}\\[(\\d+)(;(\\d+))?([u~])`);
+      const csiUPrefix = new RegExp(
+        `^${ESC}\\[(\\d+)(;(\\d+))?(;([0-9:]+))?([u~])`,
+      );
       m = buffer.match(csiUPrefix);
       if (m) {
         const keyCode = parseInt(m[1], 10);
@@ -265,7 +267,8 @@ export function KeypressProvider({
           (modifierBits & MODIFIER_SHIFT_BIT) === MODIFIER_SHIFT_BIT;
         const alt = (modifierBits & MODIFIER_ALT_BIT) === MODIFIER_ALT_BIT;
         const ctrl = (modifierBits & MODIFIER_CTRL_BIT) === MODIFIER_CTRL_BIT;
-        const terminator = m[4];
+        const textCodepoints = m[5];
+        const terminator = m[6];
 
         // Tilde-coded functional keys (Delete, Insert, PageUp/Down, Home/End)
         if (terminator === '~') {
@@ -326,6 +329,34 @@ export function KeypressProvider({
               shift,
               paste: false,
               sequence: buffer.slice(0, m[0].length),
+              kittyProtocol: true,
+            },
+            length: m[0].length,
+          };
+        }
+
+        // Printable keys may be encoded in CSI-u form when kitty protocol is enabled.
+        // Some terminals include a text parameter with codepoints (e.g. ESC[97;2;65u).
+        if (terminator === 'u' && keyCode >= 32 && !ctrl && !alt) {
+          let sequence = String.fromCodePoint(keyCode);
+          if (textCodepoints) {
+            const codepoints = textCodepoints
+              .split(':')
+              .map((value) => parseInt(value, 10))
+              .filter((value) => Number.isFinite(value) && value > 0);
+            if (codepoints.length > 0) {
+              sequence = String.fromCodePoint(...codepoints);
+            }
+          }
+
+          return {
+            key: {
+              name: '',
+              ctrl: false,
+              meta: false,
+              shift,
+              paste: false,
+              sequence,
               kittyProtocol: true,
             },
             length: m[0].length,


### PR DESCRIPTION
## Summary
- parse printable Kitty CSI-u keys so `ESC[32u` is emitted as a normal space key event
- support optional CSI-u text codepoints field (for terminals that report shifted text like `ESC[97;2;65u`)
- add regression tests for space, printable letters, and shifted letter text-codepoint form

## Background
Issue #2123 reports that spacebar stopped working in terminal sessions. This aligns with terminal behavior changes observed after VS Code 1.110.0 updates where printable keys can arrive in CSI-u form.

## Testing
- `npm run test --workspace=packages/cli -- src/ui/contexts/KeypressContext.test.tsx`

Closes #2123
