### PR TITLE
Keep rejected plan content visible in plan mode

### DIFF
--- a/packages/cli/src/ui/components/PlanSummaryDisplay.tsx
+++ b/packages/cli/src/ui/components/PlanSummaryDisplay.tsx
@@ -21,12 +21,13 @@ export const PlanSummaryDisplay: React.FC<PlanSummaryDisplayProps> = ({
   availableHeight,
   childWidth,
 }) => {
-  const { message, plan } = data;
+  const { message, plan, rejected } = data;
+  const messageColor = rejected ? Colors.AccentYellow : Colors.AccentGreen;
 
   return (
     <Box flexDirection="column">
       <Box marginBottom={1}>
-        <Text color={Colors.AccentGreen} wrap="wrap">
+        <Text color={messageColor} wrap="wrap">
           {message}
         </Text>
       </Box>

--- a/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
@@ -300,4 +300,55 @@ describe('<ToolMessage />', () => {
     );
     expect(lastFrame()).toContain('MockAnsiOutput:hello');
   });
+
+  it('renders rejected plan content with plan text still visible', () => {
+    const planResultDisplay = {
+      type: 'plan_summary' as const,
+      message: 'Plan was rejected. Remaining in plan mode.',
+      plan: '# My Plan\n- Step 1: Do something\n- Step 2: Do another thing',
+      rejected: true,
+    };
+
+    const { lastFrame } = renderWithContext(
+      <ToolMessage
+        {...baseProps}
+        name="ExitPlanMode"
+        description="Plan:"
+        status={ToolCallStatus.Canceled}
+        resultDisplay={planResultDisplay}
+      />,
+      StreamingState.Idle,
+    );
+
+    const output = lastFrame();
+    expect(output).toContain('Plan was rejected. Remaining in plan mode.');
+    expect(output).toContain('MockMarkdown:# My Plan');
+    expect(output).toContain('- Step 1: Do something');
+    expect(output).toContain('- Step 2: Do another thing');
+  });
+
+  it('renders approved plan content with approval message', () => {
+    const planResultDisplay = {
+      type: 'plan_summary' as const,
+      message: 'User approved the plan.',
+      plan: '# My Plan\n- Step 1\n- Step 2',
+    };
+
+    const { lastFrame } = renderWithContext(
+      <ToolMessage
+        {...baseProps}
+        name="ExitPlanMode"
+        description="Plan:"
+        status={ToolCallStatus.Success}
+        resultDisplay={planResultDisplay}
+      />,
+      StreamingState.Idle,
+    );
+
+    const output = lastFrame();
+    expect(output).toContain('User approved the plan.');
+    expect(output).toContain('MockMarkdown:# My Plan');
+    expect(output).toContain('- Step 1');
+    expect(output).toContain('- Step 2');
+  });
 });

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -509,6 +509,7 @@ export class CoreToolScheduler {
             : undefined;
 
           // Preserve diff for cancelled edit operations
+          // Preserve plan content for cancelled plan operations
           let resultDisplay: ToolResultDisplay | undefined = undefined;
           if (currentCall.status === 'awaiting_approval') {
             const waitingCall = currentCall as WaitingToolCall;
@@ -519,6 +520,13 @@ export class CoreToolScheduler {
                 originalContent:
                   waitingCall.confirmationDetails.originalContent,
                 newContent: waitingCall.confirmationDetails.newContent,
+              };
+            } else if (waitingCall.confirmationDetails.type === 'plan') {
+              resultDisplay = {
+                type: 'plan_summary',
+                message: 'Plan was rejected. Remaining in plan mode.',
+                plan: waitingCall.confirmationDetails.plan,
+                rejected: true,
               };
             }
           } else if (currentCall.status === 'executing') {

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -525,6 +525,7 @@ export interface PlanResultDisplay {
   type: 'plan_summary';
   message: string;
   plan: string;
+  rejected?: boolean;
 }
 
 export interface ToolEditConfirmationDetails {


### PR DESCRIPTION
## TLDR

When a plan is rejected, preserve and display the plan content so users can still see what was proposed. The rejection message is now shown in yellow instead of green to visually indicate the rejected state.

<img width="860" height="1002" alt="image" src="https://github.com/user-attachments/assets/0ff8391c-e08c-4fcd-8df2-1f75e3a00cb8" />

![streaming](https://github.com/user-attachments/assets/3b4d1cf0-6d8d-4c68-87d9-e4f889c014f4)

## Dive Deeper

Previously, when a user rejected a plan, the plan content would disappear and only a generic rejection message was shown. This change preserves the plan content in the UI even after rejection, making it easier for users to review what was proposed before deciding on next steps.

The implementation:
- Adds a 'rejected' flag to the PlanResultDisplay interface
- Updates PlanSummaryDisplay to conditionally color the message (yellow for rejected, green for approved)
- Modifies coreToolScheduler to preserve plan content when a plan operation is cancelled
- Adds comprehensive tests for both rejected and approved plan rendering

## Reviewer Test Plan

1. Start a plan mode session with /plan
2. Propose a plan with multiple steps
3. Reject the plan
4. Verify the plan content is still visible with the rejection message in yellow
5. Approve a plan and verify it shows in green as before

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Tests pass: npm test -- packages/cli/src/ui/components/messages/ToolMessage.test.tsx