### PR TITLE
feat(webui): unify shell tool label to Shell

### DIFF
--- a/packages/webui/src/components/toolcalls/ShellToolCall.tsx
+++ b/packages/webui/src/components/toolcalls/ShellToolCall.tsx
@@ -3,7 +3,7 @@
  * Copyright 2025 Qwen Team
  * SPDX-License-Identifier: Apache-2.0
  *
- * Shell tool call component for Execute/Bash/Command
+ * Shell tool call component for shell command variants.
  * Pure UI component - platform interactions via usePlatform hook
  */
 
@@ -25,7 +25,7 @@ import './ShellToolCall.css';
 type ShellVariant = 'execute' | 'bash';
 
 /**
- * Custom container for Execute variant with different styling
+ * Custom container for the execute variant with different styling
  */
 const ExecuteToolCallContainer: FC<ToolCallContainerProps> = ({
   label,
@@ -129,7 +129,7 @@ const ShellToolCallImpl: FC<BaseToolCallProps & { variant: ShellVariant }> = ({
 
   const Container =
     variant === 'execute' ? ExecuteToolCallContainer : ToolCallContainer;
-  const label = variant === 'execute' ? 'Execute' : 'Bash';
+  const label = 'Shell';
 
   // Group content by type
   const { textOutputs, errors } = groupContent(content);


### PR DESCRIPTION
## Summary
- use a single `Shell` label for shell command tool calls in the web UI
- keep execute/bash variant styling while removing the user-facing naming mismatch
- align the first visible shell tool label with the CLI naming direction described in #1367

Related to #1367

## Validation
- `npm run build --workspace=@qwen-code/webui`