### PR TITLE
feat(vscode): use TodoWrite title for plan snapshots

### DIFF
--- a/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
@@ -653,7 +653,7 @@ export const useWebViewMessages = ({
                   type: 'tool_call_update',
                   toolCallId: prev.id,
                   kind: 'todo_write',
-                  title: 'Updated Plan',
+                  title: 'TodoWrite',
                   status: 'completed',
                   content: [
                     {
@@ -671,7 +671,7 @@ export const useWebViewMessages = ({
                   type: 'tool_call',
                   toolCallId,
                   kind: 'todo_write',
-                  title: 'Updated Plan',
+                  title: 'TodoWrite',
                   status: 'completed',
                   content: [
                     {


### PR DESCRIPTION
## Summary
- replace `Updated Plan` with `TodoWrite` for todo-write snapshot cards in the VSCode companion
- keep the existing merge/dedupe behavior unchanged
- align another visible tool title with the CLI naming direction from #1367

Related to #1367

## Validation
- `npm run build:vscode`