### PR TITLE
feat(webui): align web fetch labels with core tool names

### DIFF
--- a/packages/webui/src/components/toolcalls/WebFetchToolCall.tsx
+++ b/packages/webui/src/components/toolcalls/WebFetchToolCall.tsx
@@ -121,7 +121,7 @@ const WebFetchToolCallImpl: FC<BaseToolCallProps & { variant: WebVariant }> = ({
   const { title, content, rawInput, toolCallId } = toolCall;
 
   const webTarget = getWebTarget(variant, title, rawInput);
-  const label = variant === 'fetch' ? 'Web Fetch' : 'Web Search';
+  const label = variant === 'fetch' ? 'WebFetch' : 'WebSearch';
 
   // Group content by type
   const { textOutputs, errors } = groupContent(content);


### PR DESCRIPTION
## Summary
- rename VSCode companion web fetch cards from `Web Fetch` to `WebFetch`
- rename VSCode companion web search cards from `Web Search` to `WebSearch`

Closes #1367

## Testing
- npm run build --workspace=@qwen-code/webui