### PR TITLE
feat(webui): derive think labels from tool titles

### DIFF
--- a/packages/webui/src/components/toolcalls/ThinkToolCall.tsx
+++ b/packages/webui/src/components/toolcalls/ThinkToolCall.tsx
@@ -12,6 +12,7 @@ import {
   ToolCallCard,
   ToolCallRow,
   groupContent,
+  safeTitle,
 } from './shared/index.js';
 import type { BaseToolCallProps } from './shared/index.js';
 
@@ -25,7 +26,9 @@ export const ThinkToolCall: FC<BaseToolCallProps> = ({
   isFirst,
   isLast,
 }) => {
-  const { content } = toolCall;
+  const { content, title } = toolCall;
+  const resolvedTitle = safeTitle(title);
+  const label = resolvedTitle.split(':', 1)[0] || 'Think';
 
   // Group content by type
   const { textOutputs, errors } = groupContent(content);
@@ -34,7 +37,7 @@ export const ThinkToolCall: FC<BaseToolCallProps> = ({
   if (errors.length > 0) {
     return (
       <ToolCallContainer
-        label="Think"
+        label={label}
         status="error"
         isFirst={isFirst}
         isLast={isLast}
@@ -55,7 +58,7 @@ export const ThinkToolCall: FC<BaseToolCallProps> = ({
 
       return (
         <ToolCallCard icon="💭">
-          <ToolCallRow label="Think">
+          <ToolCallRow label={label}>
             <div className="italic opacity-90 leading-relaxed">
               {truncatedThoughts}
             </div>
@@ -71,7 +74,7 @@ export const ThinkToolCall: FC<BaseToolCallProps> = ({
         : 'default';
     return (
       <ToolCallContainer
-        label="Think"
+        label={label}
         status={status}
         isFirst={isFirst}
         isLast={isLast}


### PR DESCRIPTION
## Summary
- derive the think card label from the tool title prefix when present
- keep `Think` as a fallback when the title is empty

Closes #1367

## Testing
- npm run build --workspace=@qwen-code/webui