### PR TITLE
fix(vscode): allow thinking role in chat message type

### DIFF
--- a/packages/vscode-ide-companion/src/types/chatTypes.ts
+++ b/packages/vscode-ide-companion/src/types/chatTypes.ts
@@ -11,7 +11,7 @@ import type {
 import type { ApprovalModeValue } from './approvalModeValueTypes.js';
 
 export interface ChatMessage {
-  role: 'user' | 'assistant';
+  role: 'user' | 'assistant' | 'thinking';
   content: string;
   timestamp: number;
 }


### PR DESCRIPTION
## Summary
- add `thinking` to the VSCode companion `ChatMessage` role union
- align the shared type with existing webview message handling code

Related to #2112

## Testing
- npm run build:vscode