### PR TITLE
fix: clear retry error even without countdown timer

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1081,7 +1081,10 @@ export const useGeminiStream = (
         setModelSwitchedFromQuotaError(false);
         // Commit any pending retry error to history (without hint) since the
         // user is starting a new conversation turn
-        if (pendingRetryCountdownItemRef.current) {
+        if (
+          pendingRetryCountdownItemRef.current ||
+          pendingRetryErrorItemRef.current
+        ) {
           clearRetryCountdown();
         }
       }
@@ -1223,6 +1226,7 @@ export const useGeminiStream = (
       handleLoopDetectedEvent,
       clearRetryCountdown,
       pendingRetryCountdownItemRef,
+      pendingRetryErrorItemRef,
       setPendingRetryErrorItem,
     ],
   );


### PR DESCRIPTION
## Description

Fixes issue #2105 where error messages persist after switching models.

## Root Cause

The `submitQuery` function only checked `pendingRetryCountdownItemRef.current` before clearing retry errors. However, errors can exist without a countdown timer (when there's no retry info), stored in `pendingRetryErrorItemRef.current`.

## Fix

Updated the condition to check both refs:
```typescript
if (pendingRetryCountdownItemRef.current || pendingRetryErrorItemRef.current) {
  clearRetryCountdown();
}
```

Also added `pendingRetryErrorItemRef` to the dependency array of the `submitQuery` useCallback to satisfy React hooks linting.

## Testing

- All 45 existing tests in useGeminiStream.test.tsx pass
- No new TypeScript errors introduced

## Related

Fixes #2105