### PR TITLE
fix(cli): block Tab key during AI streaming to prevent mode switch interruption

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -674,7 +674,10 @@ export const AppContainer = (props: AppContainerProps) => {
     config,
     addItem: historyManager.addItem,
     onApprovalModeChange: handleApprovalModeChange,
-    shouldBlockTab: () => hasSuggestionsVisible,
+    // Block Tab key when suggestions are visible (autocomplete) or when AI is actively responding
+    // This prevents accidental mode switches from interrupting ongoing AI responses and edits
+    shouldBlockTab: () =>
+      hasSuggestionsVisible || streamingState === StreamingState.Responding,
   });
 
   const { messageQueue, addMessage, clearQueue, getQueuedMessagesText } =


### PR DESCRIPTION
## TLDR

Fixes issue #2210 where accidentally pressing Tab while AI is actively responding would switch approval modes and interrupt the ongoing response and file edits.

## Dive Deeper

The `shouldBlockTab` function in `AppContainer.tsx` previously only checked if autocomplete suggestions were visible. This PR adds an additional check for when the AI is actively streaming/responding.

**Changes made:**
- Modified `packages/cli/src/ui/AppContainer.tsx` line 677
- Updated `shouldBlockTab` to check both:
  - `hasSuggestionsVisible` (autocomplete is showing)
  - `streamingState === StreamingState.Responding` (AI is actively responding)

This ensures Tab key mode cycling is blocked during active AI operations, preventing accidental interruption of YOLO/auto-accept-edits mode workflows.

## Reviewer Test Plan

1. Start Qwen Code in YOLO mode: `qwen -y`
2. Give the AI a task requiring multiple file edits
3. While AI is responding/editing, press Tab
4. Verify that mode does NOT switch and the response continues uninterrupted
5. Verify Tab still works for autocomplete when AI is idle
6. Verify Tab still cycles approval modes when AI is idle

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |

## Linked issues / bugs

Fixes #2210