### PR TITLE
feat(skills): add allowed and excluded skills configuration

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -975,6 +975,8 @@ export async function loadCliConfig(
     excludedMcpServers: excludedMcpServers
       ? Array.from(excludedMcpServers)
       : undefined,
+    allowedSkills: settings.skills?.allowed,
+    excludedSkills: settings.skills?.excluded,
     approvalMode,
     accessibility: {
       ...settings.ui?.accessibility,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1012,6 +1012,38 @@ const SETTINGS_SCHEMA = {
       },
     },
   },
+  skills: {
+    type: 'object',
+    label: 'Skills',
+    category: 'Skills',
+    requiresRestart: true,
+    default: {},
+    description: 'Settings for skill filtering and availability.',
+    showInDialog: false,
+    properties: {
+      allowed: {
+        type: 'array',
+        label: 'Allowed Skills',
+        category: 'Skills',
+        requiresRestart: true,
+        default: undefined as string[] | undefined,
+        description:
+          'A list of skill names that are allowed to be invoked. If empty or undefined, all skills are allowed.',
+        showInDialog: false,
+      },
+      excluded: {
+        type: 'array',
+        label: 'Excluded Skills',
+        category: 'Skills',
+        requiresRestart: true,
+        default: undefined as string[] | undefined,
+        description: 'A list of skill names to exclude from availability.',
+        showInDialog: false,
+        mergeStrategy: MergeStrategy.UNION,
+      },
+    },
+  },
+
   security: {
     type: 'object',
     label: 'Security',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -337,6 +337,8 @@ export interface ConfigParameters {
   overrideExtensions?: string[];
   allowedMcpServers?: string[];
   excludedMcpServers?: string[];
+  allowedSkills?: string[];
+  excludedSkills?: string[];
   noBrowser?: boolean;
   summarizeToolOutput?: Record<string, SummarizeToolOutputSettings>;
   folderTrustFeature?: boolean;
@@ -461,6 +463,8 @@ export class Config {
   private lspClient?: LspClient;
   private readonly allowedMcpServers?: string[];
   private excludedMcpServers?: string[];
+  private readonly allowedSkills?: string[];
+  private readonly excludedSkills?: string[];
   private sessionSubagents: SubagentConfig[];
   private userMemory: string;
   private sdkMode: boolean;
@@ -571,6 +575,8 @@ export class Config {
     this.lspClient = params.lspClient;
     this.allowedMcpServers = params.allowedMcpServers;
     this.excludedMcpServers = params.excludedMcpServers;
+    this.allowedSkills = params.allowedSkills;
+    this.excludedSkills = params.excludedSkills;
     this.sessionSubagents = params.sessionSubagents ?? [];
     this.sdkMode = params.sdkMode ?? false;
     this.userMemory = params.userMemory ?? '';
@@ -1270,6 +1276,13 @@ export class Config {
 
   isMcpServerDisabled(serverName: string): boolean {
     return this.excludedMcpServers?.includes(serverName) ?? false;
+  }
+
+  getSkillsFilter(): { allowed?: string[]; excluded?: string[] } {
+    return {
+      allowed: this.allowedSkills,
+      excluded: this.excludedSkills,
+    };
   }
 
   addMcpServers(servers: Record<string, MCPServerConfig>): void {

--- a/packages/core/src/skills/skill-manager.test.ts
+++ b/packages/core/src/skills/skill-manager.test.ts
@@ -73,6 +73,15 @@ describe('SkillManager', () => {
       if (yamlString.includes('name: regular-skill')) {
         return { name: 'regular-skill', description: 'A regular skill' };
       }
+      if (yamlString.includes('name: pdf')) {
+        return { name: 'pdf', description: 'PDF skill' };
+      }
+      if (yamlString.includes('name: xlsx')) {
+        return { name: 'xlsx', description: 'XLSX skill' };
+      }
+      if (yamlString.includes('name: internal')) {
+        return { name: 'internal', description: 'Internal skill' };
+      }
       if (!yamlString.includes('name:')) {
         return { description: 'A test skill' }; // Missing name case
       }
@@ -687,6 +696,154 @@ Symlinked skill content`);
         'regular-skill',
         'symlink-skill',
       ]);
+    });
+  });
+
+  describe('skill filtering', () => {
+    it('should return all skills when no filter configured', async () => {
+      vi.mocked(fs.readdir).mockResolvedValue([]);
+      vi.spyOn(mockConfig, 'getSkillsFilter').mockReturnValue({});
+      await manager.listSkills();
+      expect(mockConfig.getSkillsFilter).toHaveBeenCalled();
+    });
+
+    it('should filter skills by allowed list', async () => {
+      vi.mocked(fs.readdir)
+        .mockResolvedValueOnce([
+          {
+            name: 'pdf',
+            isDirectory: () => true,
+            isFile: () => false,
+            isSymbolicLink: () => false,
+          },
+          {
+            name: 'xlsx',
+            isDirectory: () => true,
+            isFile: () => false,
+            isSymbolicLink: () => false,
+          },
+        ] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+        .mockResolvedValueOnce([]);
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readFile)
+        .mockResolvedValueOnce(
+          '---\nname: pdf\ndescription: PDF skill\n---\ncontent',
+        )
+        .mockResolvedValueOnce(
+          '---\nname: xlsx\ndescription: XLSX skill\n---\ncontent',
+        );
+      vi.spyOn(mockConfig, 'getSkillsFilter').mockReturnValue({
+        allowed: ['pdf'],
+      });
+
+      const skills = await manager.listSkills({ force: true });
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0].name).toBe('pdf');
+    });
+
+    it('should filter skills by excluded list', async () => {
+      vi.mocked(fs.readdir)
+        .mockResolvedValueOnce([
+          {
+            name: 'pdf',
+            isDirectory: () => true,
+            isFile: () => false,
+            isSymbolicLink: () => false,
+          },
+          {
+            name: 'xlsx',
+            isDirectory: () => true,
+            isFile: () => false,
+            isSymbolicLink: () => false,
+          },
+        ] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+        .mockResolvedValueOnce([]);
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readFile)
+        .mockResolvedValueOnce(
+          '---\nname: pdf\ndescription: PDF skill\n---\ncontent',
+        )
+        .mockResolvedValueOnce(
+          '---\nname: xlsx\ndescription: XLSX skill\n---\ncontent',
+        );
+      vi.spyOn(mockConfig, 'getSkillsFilter').mockReturnValue({
+        excluded: ['xlsx'],
+      });
+
+      const skills = await manager.listSkills({ force: true });
+
+      expect(skills).toHaveLength(1);
+      expect(skills[0].name).toBe('pdf');
+    });
+
+    it('should apply allowed list before excluded list', async () => {
+      vi.mocked(fs.readdir)
+        .mockResolvedValueOnce([
+          {
+            name: 'pdf',
+            isDirectory: () => true,
+            isFile: () => false,
+            isSymbolicLink: () => false,
+          },
+          {
+            name: 'xlsx',
+            isDirectory: () => true,
+            isFile: () => false,
+            isSymbolicLink: () => false,
+          },
+          {
+            name: 'internal',
+            isDirectory: () => true,
+            isFile: () => false,
+            isSymbolicLink: () => false,
+          },
+        ] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+        .mockResolvedValueOnce([]);
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readFile)
+        .mockResolvedValueOnce(
+          '---\nname: pdf\ndescription: PDF skill\n---\ncontent',
+        )
+        .mockResolvedValueOnce(
+          '---\nname: xlsx\ndescription: XLSX skill\n---\ncontent',
+        )
+        .mockResolvedValueOnce(
+          '---\nname: internal\ndescription: Internal skill\n---\ncontent',
+        );
+      vi.spyOn(mockConfig, 'getSkillsFilter').mockReturnValue({
+        allowed: ['pdf', 'xlsx', 'internal'],
+        excluded: ['internal'],
+      });
+
+      const skills = await manager.listSkills({ force: true });
+
+      expect(skills).toHaveLength(2);
+      expect(skills.map((s) => s.name).sort()).toEqual(['pdf', 'xlsx']);
+    });
+
+    it('should return empty array when no skills match allowed list', async () => {
+      vi.mocked(fs.readdir)
+        .mockResolvedValueOnce([
+          {
+            name: 'pdf',
+            isDirectory: () => true,
+            isFile: () => false,
+            isSymbolicLink: () => false,
+          },
+        ] as unknown as Awaited<ReturnType<typeof fs.readdir>>)
+        .mockResolvedValueOnce([]);
+      vi.mocked(fs.access).mockResolvedValue(undefined);
+      vi.mocked(fs.readFile).mockResolvedValue(
+        '---\nname: pdf\ndescription: PDF skill\n---\ncontent',
+      );
+      vi.spyOn(mockConfig, 'getSkillsFilter').mockReturnValue({
+        allowed: ['nonexistent'],
+      });
+
+      const skills = await manager.listSkills({ force: true });
+
+      expect(skills).toHaveLength(0);
     });
   });
 });

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -126,8 +126,43 @@ export class SkillManager {
     // Sort by name for consistent ordering
     skills.sort((a, b) => a.name.localeCompare(b.name));
 
-    debugLogger.info(`Listed ${skills.length} unique skills`);
-    return skills;
+    const filteredSkills = this.filterSkills(skills);
+
+    debugLogger.info(`Listed ${filteredSkills.length} unique skills`);
+    return filteredSkills;
+  }
+
+  /**
+   * Filters skills based on allowed and excluded lists from config.
+   *
+   * @param skills - Skills to filter
+   * @returns Filtered skills
+   */
+  private filterSkills(skills: SkillConfig[]): SkillConfig[] {
+    const filter = this.config.getSkillsFilter();
+    const allowed = filter.allowed;
+    const excluded = filter.excluded || [];
+
+    if (!allowed || allowed.length === 0) {
+      if (excluded.length === 0) {
+        return skills;
+      }
+      const result = skills.filter((skill) => !excluded.includes(skill.name));
+      if (result.length < skills.length) {
+        debugLogger.debug(
+          `Filtered out ${skills.length - result.length} excluded skills`,
+        );
+      }
+      return result;
+    }
+
+    const result = skills.filter(
+      (skill) => allowed.includes(skill.name) && !excluded.includes(skill.name),
+    );
+    debugLogger.debug(
+      `Filtered skills by allowed list: ${result.length}/${skills.length}`,
+    );
+    return result;
   }
 
   /**

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -82,6 +82,14 @@ export interface ListSkillsOptions {
   force?: boolean;
 }
 
+export interface SkillFilterConfig {
+  /** Whitelist of skill names that can be invoked. If empty, all skills are candidates. */
+  allowed?: string[];
+
+  /** Blacklist of skill names that should be disabled. */
+  excluded?: string[];
+}
+
 /**
  * Error thrown when a skill operation fails.
  */

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -534,6 +534,26 @@
         }
       }
     },
+    "skills": {
+      "description": "Settings for skill filtering and availability.",
+      "type": "object",
+      "properties": {
+        "allowed": {
+          "description": "A list of skill names that are allowed to be invoked. If empty or undefined, all skills are allowed.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "excluded": {
+          "description": "A list of skill names to exclude from availability.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "advanced": {
       "description": "Advanced settings for power users.",
       "type": "object",


### PR DESCRIPTION
## TLDR

Added `skills.allowed` and `skills.excluded` configuration options to control which skills can be activated during a session. This enables teams to restrict skill availability for security/compliance, reduce noise, and enforce governance.

## Dive Deeper

**Configuration Options:**

- `skills.allowed`: Whitelist of skill names that can be invoked. If empty/undefined, all skills are candidates.
- `skills.excluded`: Blacklist of skill names to disable.

**Merge Strategy:**

- `allowed`: Project settings REPLACE user settings (project maintainer has final say)
- `excluded`: Project and user settings UNION (both exclusions apply)

**Implementation:**

- Added `skills` section to `settingsSchema.ts` with proper merge strategies
- Added `SkillFilterConfig` interface in `packages/core/src/skills/types.ts`
- Added `getSkillsFilter()` method to Config class
- Implemented `filterSkills()` private method in SkillManager that applies allowlist then denylist
- Filtering happens in `listSkills()` before returning results

**Files Changed:**

- `packages/cli/src/config/settingsSchema.ts`
- `packages/core/src/skills/types.ts`
- `packages/core/src/config/config.ts`
- `packages/cli/src/config/config.ts`
- `packages/core/src/skills/skill-manager.ts`
- `packages/core/src/skills/skill-manager.test.ts`
- `packages/vscode-ide-companion/schemas/settings.schema.json`

## Reviewer Test Plan

1. Create test skills:

```bash
mkdir -p .qwen/skills/skill-a && echo '---\nname: skill-a\ndescription: Skill A\n---\nContent' > .qwen/skills/skill-a/SKILL.md
mkdir -p .qwen/skills/skill-b && echo '---\nname: skill-b\ndescription: Skill B\n---\nContent' > .qwen/skills/skill-b/SKILL.md
mkdir -p .qwen/skills/skill-c && echo '---\nname: skill-c\ndescription: Skill C\n---\nContent' > .qwen/skills/skill-c/SKILL.md
```

2. Test `allowed` whitelist (project level):

```json
// .qwen/settings.json
{ "skills": { "allowed": ["skill-a"] } }
```

Run `qwen-code` and invoke the skill tool - only `skill-a` should be available.

3. Test `excluded` denylist (project level):

```json
{ "skills": { "excluded": ["skill-b"] } }
```

Only `skill-a` and `skill-c` should be available.

4. Test both combined:

```json
{ "skills": { "allowed": ["skill-a", "skill-b"], "excluded": ["skill-b"] } }
```

Only `skill-a` should be available (allowed applies first, then excluded removes).

5. Test global user settings (`~/.qwen/settings.json`):

```json
// ~/.qwen/settings.json
{ "skills": { "excluded": ["skill-a"] } }
```

```json
// .qwen/settings.json (empty or no skills config)
{}
```

`skill-a` should be excluded (global excluded applies).

6. Test merge behavior (global + project):

```json
// ~/.qwen/settings.json
{ "skills": { "excluded": ["skill-a"] } }
```

```json
// .qwen/settings.json
{ "skills": { "excluded": ["skill-b"] } }
```

Both `skill-a` and `skill-b` should be excluded (UNION merge for excluded).

7. Test `allowed` override (project overrides user):

```json
// ~/.qwen/settings.json
{ "skills": { "allowed": ["skill-a", "skill-b"] } }
```

```json
// .qwen/settings.json
{ "skills": { "allowed": ["skill-c"] } }
```

Only `skill-c` should be available (project allowed REPLACES user allowed).

8. Run unit tests:

```bash
npm test -w @qwen-code/qwen-code-core -- src/skills/skill-manager.test.ts --run
```

2. Test `allowed` whitelist:

```json
// .qwen/settings.json
{ "skills": { "allowed": ["skill-a"] } }
```

Run `qwen-code` and invoke the skill tool - only `skill-a` should be available.

3. Test `excluded` denylist:

```json
{ "skills": { "excluded": ["skill-b"] } }
```

Only `skill-a` should be available, `skill-b` excluded.

4. Test both combined:

```json
{ "skills": { "allowed": ["skill-a", "skill-b"], "excluded": ["skill-b"] } }
```

Only `skill-a` should be available (allowed applies first, then excluded removes).

5. Run unit tests:

```bash
npm test -w @qwen-code/qwen-code-core -- src/skills/skill-manager.test.ts --run
```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #2216 
