### PR TITLE
fix(test): handle thinking model assistant messages in SDK E2E tests

### DIFF
--- a/integration-tests/sdk-typescript/abort-and-lifecycle.test.ts
+++ b/integration-tests/sdk-typescript/abort-and-lifecycle.test.ts
@@ -160,6 +160,7 @@ describe('AbortController and Process Lifecycle (E2E)', () => {
       let completedSuccessfully = false;
 
       try {
+        let hasTextContent = false;
         for await (const message of q) {
           if (isSDKAssistantMessage(message)) {
             const textBlocks = message.message.content.filter(
@@ -169,10 +170,15 @@ describe('AbortController and Process Lifecycle (E2E)', () => {
               .map((b) => b.text)
               .join('')
               .slice(0, 100);
-            expect(text.length).toBeGreaterThan(0);
+            // Thinking models may emit assistant messages with only thinking
+            // blocks before the text content arrives, so skip those.
+            if (text.length > 0) {
+              hasTextContent = true;
+            }
           }
         }
 
+        expect(hasTextContent).toBe(true);
         completedSuccessfully = true;
       } catch (error) {
         // Should not throw for normal completion
@@ -239,10 +245,14 @@ describe('AbortController and Process Lifecycle (E2E)', () => {
             );
             const text = textBlocks.map((b: TextBlock) => b.text).join('');
 
-            expect(text.length).toBeGreaterThan(0);
+            // Thinking models may emit assistant messages with only thinking
+            // blocks before the text content arrives, so skip those.
+            if (text.length === 0) {
+              continue;
+            }
             receivedResponse = true;
 
-            // End input after receiving first response
+            // End input after receiving first response with text
             q.endInput();
             endInputCalled = true;
           }
@@ -496,6 +506,7 @@ describe('AbortController and Process Lifecycle (E2E)', () => {
         },
       });
 
+      let hasTextContent = false;
       try {
         for await (const message of q) {
           if (isSDKAssistantMessage(message)) {
@@ -506,11 +517,16 @@ describe('AbortController and Process Lifecycle (E2E)', () => {
               .map((b) => b.text)
               .join('')
               .slice(0, 50);
-            expect(text.length).toBeGreaterThan(0);
+            // Thinking models may emit assistant messages with only thinking
+            // blocks before the text content arrives, so skip those.
+            if (text.length > 0) {
+              hasTextContent = true;
+            }
           }
         }
       } finally {
         await q.close();
+        expect(hasTextContent).toBe(true);
         expect(stderrMessages.length).toBeGreaterThan(0);
       }
     });

--- a/integration-tests/sdk-typescript/multi-turn.test.ts
+++ b/integration-tests/sdk-typescript/multi-turn.test.ts
@@ -147,12 +147,16 @@ describe('Multi-Turn Conversations (E2E)', () => {
           if (isSDKAssistantMessage(message)) {
             assistantMessages.push(message);
             const text = extractText(message.message.content);
-            assistantTexts.push(text);
+            // Thinking models may emit assistant messages with only thinking
+            // blocks before the text content arrives, so skip those.
+            if (text.length > 0) {
+              assistantTexts.push(text);
+            }
           }
         }
 
         expect(messages.length).toBeGreaterThan(0);
-        expect(assistantMessages.length).toBeGreaterThanOrEqual(3);
+        expect(assistantTexts.length).toBeGreaterThanOrEqual(3);
 
         // Validate content of responses
         expect(assistantTexts[0]).toMatch(/2/);


### PR DESCRIPTION
Thinking models (e.g. glm-5) emit assistant messages with only thinking blocks before sending text content. The tests incorrectly assumed every assistant message contains text blocks, causing failures. Skip thinking-only messages when checking for text content.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
