### PR TITLE
fix(core): remove duplicate exports in packages/core/src/index.ts

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,6 @@
 // Core configuration
 export * from './config/config.js';
 export { Storage } from './config/storage.js';
-export * from './utils/configResolver.js';
 
 // Model configuration
 export {
@@ -60,103 +59,28 @@ export * from './core/nonInteractiveToolExecutor.js';
 export * from './core/prompts.js';
 export * from './core/tokenLimits.js';
 export * from './core/turn.js';
-export * from './core/geminiRequest.js';
-export * from './core/coreToolScheduler.js';
-export * from './core/nonInteractiveToolExecutor.js';
-export * from './tools/tool-names.js';
 
 // ============================================================================
 // Tools
 // ============================================================================
 
-// Export utilities
-export * from './utils/paths.js';
-export * from './utils/schemaValidator.js';
-export * from './utils/errors.js';
-export * from './utils/debugLogger.js';
-export * from './utils/symlink.js';
-export * from './utils/getFolderStructure.js';
-export * from './utils/memoryDiscovery.js';
-export * from './utils/gitIgnoreParser.js';
-export * from './utils/gitUtils.js';
-export * from './utils/editor.js';
-export * from './utils/quotaErrorDetection.js';
-export * from './utils/fileUtils.js';
-export * from './utils/retry.js';
-export * from './utils/shell-utils.js';
-export * from './utils/tool-utils.js';
-export * from './utils/terminalSerializer.js';
-export * from './utils/systemEncoding.js';
-export * from './utils/textUtils.js';
-export * from './utils/formatters.js';
-export * from './utils/generateContentResponseUtilities.js';
-export * from './utils/ripgrepUtils.js';
-export * from './utils/filesearch/fileSearch.js';
-export * from './utils/errorParsing.js';
-export * from './utils/workspaceContext.js';
-export * from './utils/ignorePatterns.js';
-export * from './utils/partUtils.js';
-export * from './utils/subagentGenerator.js';
-export * from './utils/projectSummary.js';
-export * from './utils/promptIdContext.js';
-export * from './utils/thoughtUtils.js';
-export * from './utils/toml-to-markdown-converter.js';
-export * from './utils/yaml-parser.js';
-
-// Config resolution utilities
-export * from './utils/configResolver.js';
-
-// Export services
-export * from './services/fileDiscoveryService.js';
-export * from './services/gitService.js';
-export * from './services/chatRecordingService.js';
-export * from './services/sessionService.js';
-export * from './services/fileSystemService.js';
-
-// Export IDE specific logic
-export * from './ide/ide-client.js';
-export * from './ide/ideContext.js';
-export * from './ide/ide-installer.js';
-export { IDE_DEFINITIONS, type IdeInfo } from './ide/detect-ide.js';
-export * from './ide/constants.js';
-export * from './ide/types.js';
-
-// Export Shell Execution Service
-export * from './services/shellExecutionService.js';
-
-// Export base tool definitions
-export * from './tools/tools.js';
+// Tool names and registry
+export * from './tools/tool-names.js';
 export * from './tools/tool-error.js';
 export * from './tools/tool-registry.js';
+export * from './tools/tools.js';
 
-// Export subagents (Phase 1)
-export * from './subagents/index.js';
-
-// Export skills
-export * from './skills/index.js';
-
-// Export extension
-export * from './extension/index.js';
-
-// Export prompt logic
-export * from './prompts/mcp-prompts.js';
-
-// Export specific tool logic
-export * from './tools/read-file.js';
-export * from './tools/ls.js';
-export * from './tools/grep.js';
-export * from './tools/ripGrep.js';
-export * from './tools/glob.js';
+// Individual tools
 export * from './tools/edit.js';
 export * from './tools/exitPlanMode.js';
 export * from './tools/glob.js';
 export * from './tools/grep.js';
 export * from './tools/ls.js';
 export * from './tools/lsp.js';
-export * from './tools/memoryTool.js';
 export * from './tools/mcp-client.js';
 export * from './tools/mcp-client-manager.js';
 export * from './tools/mcp-tool.js';
+export * from './tools/memoryTool.js';
 export * from './tools/read-file.js';
 export * from './tools/ripGrep.js';
 export * from './tools/sdk-control-client-transport.js';
@@ -164,9 +88,6 @@ export * from './tools/shell.js';
 export * from './tools/skill.js';
 export * from './tools/task.js';
 export * from './tools/todoWrite.js';
-export * from './tools/tool-error.js';
-export * from './tools/tool-registry.js';
-export * from './tools/tools.js';
 export * from './tools/web-fetch.js';
 export * from './tools/web-search/index.js';
 export * from './tools/write-file.js';
@@ -183,10 +104,20 @@ export * from './services/sessionService.js';
 export * from './services/shellExecutionService.js';
 
 // ============================================================================
+// IDE Support
+// ============================================================================
+
+export * from './ide/ide-client.js';
+export * from './ide/ideContext.js';
+export * from './ide/ide-installer.js';
+export { IDE_DEFINITIONS, type IdeInfo } from './ide/detect-ide.js';
+export * from './ide/constants.js';
+export * from './ide/types.js';
+
+// ============================================================================
 // LSP Support
 // ============================================================================
 
-// LSP support
 export * from './lsp/constants.js';
 export * from './lsp/LspConfigLoader.js';
 export * from './lsp/LspConnectionFactory.js';
@@ -240,7 +171,7 @@ export {
 } from './telemetry/types.js';
 
 // ============================================================================
-// Extensions & Subagents
+// Extensions, Skills & Subagents
 // ============================================================================
 
 export * from './extension/index.js';
@@ -253,6 +184,8 @@ export * from './subagents/index.js';
 // ============================================================================
 
 export * from './utils/browser.js';
+export * from './utils/configResolver.js';
+export * from './utils/debugLogger.js';
 export * from './utils/editor.js';
 export * from './utils/errorParsing.js';
 export * from './utils/errors.js';
@@ -264,13 +197,14 @@ export * from './utils/getFolderStructure.js';
 export * from './utils/gitIgnoreParser.js';
 export * from './utils/gitUtils.js';
 export * from './utils/ignorePatterns.js';
+export * from './utils/jsonl-utils.js';
 export * from './utils/memoryDiscovery.js';
 export { OpenAILogger, openaiLogger } from './utils/openaiLogger.js';
 export * from './utils/partUtils.js';
 export * from './utils/pathReader.js';
 export * from './utils/paths.js';
-export * from './utils/promptIdContext.js';
 export * from './utils/projectSummary.js';
+export * from './utils/promptIdContext.js';
 export * from './utils/quotaErrorDetection.js';
 export * from './utils/readManyFiles.js';
 export * from './utils/request-tokenizer/supportedImageFormats.js';
@@ -279,6 +213,7 @@ export * from './utils/ripgrepUtils.js';
 export * from './utils/schemaValidator.js';
 export * from './utils/shell-utils.js';
 export * from './utils/subagentGenerator.js';
+export * from './utils/symlink.js';
 export * from './utils/systemEncoding.js';
 export * from './utils/terminalSerializer.js';
 export * from './utils/textUtils.js';
@@ -287,8 +222,6 @@ export * from './utils/toml-to-markdown-converter.js';
 export * from './utils/tool-utils.js';
 export * from './utils/workspaceContext.js';
 export * from './utils/yaml-parser.js';
-export * from './utils/jsonl-utils.js';
-export * from './utils/symlink.js';
 
 // ============================================================================
 // OAuth & Authentication
@@ -303,7 +236,10 @@ export * from './qwen/qwenOAuth2.js';
 export { makeFakeConfig } from './test-utils/config.js';
 export * from './test-utils/index.js';
 
-// Export hook types and components
+// ============================================================================
+// Hooks
+// ============================================================================
+
 export * from './hooks/types.js';
 export { HookSystem, HookRegistry } from './hooks/index.js';
 export type { HookRegistryEntry } from './hooks/index.js';


### PR DESCRIPTION
The index.ts barrel file had 30+ modules exported multiple times across scattered sections. This consolidates all exports into a single well-organized structure with clear section headers, removing 90 lines of redundant export statements. No functional changes.

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
