### PR TITLE
fix: export command should use current session ID instead of loadLastSession

### DIFF
--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -19,14 +19,14 @@ import {
 } from '../utils/export/index.js';
 
 const mockSessionServiceMocks = vi.hoisted(() => ({
-  loadLastSession: vi.fn(),
+  loadSession: vi.fn(),
 }));
 
 vi.mock('@qwen-code/qwen-code-core', () => {
   class SessionService {
     constructor(_cwd: string) {}
-    async loadLastSession() {
-      return mockSessionServiceMocks.loadLastSession();
+    async loadSession(_sessionId: string) {
+      return mockSessionServiceMocks.loadSession();
     }
   }
 
@@ -68,13 +68,14 @@ describe('exportCommand', () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    mockSessionServiceMocks.loadLastSession.mockResolvedValue(mockSessionData);
+    mockSessionServiceMocks.loadSession.mockResolvedValue(mockSessionData);
 
     mockContext = createMockCommandContext({
       services: {
         config: {
           getWorkingDir: vi.fn().mockReturnValue('/test/dir'),
           getProjectRoot: vi.fn().mockReturnValue('/test/project'),
+          getSessionId: vi.fn().mockReturnValue('test-session-id'),
         },
       },
     });
@@ -132,7 +133,7 @@ describe('exportCommand', () => {
         content: expect.stringContaining('export-2025-01-01T00-00-00-000Z.md'),
       });
 
-      expect(mockSessionServiceMocks.loadLastSession).toHaveBeenCalled();
+      expect(mockSessionServiceMocks.loadSession).toHaveBeenCalled();
       expect(collectSessionData).toHaveBeenCalledWith(
         mockSessionData.conversation,
         expect.anything(),
@@ -191,7 +192,7 @@ describe('exportCommand', () => {
     });
 
     it('should return error when no session is found', async () => {
-      mockSessionServiceMocks.loadLastSession.mockResolvedValue(undefined);
+      mockSessionServiceMocks.loadSession.mockResolvedValue(undefined);
 
       const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
       if (!mdCommand?.action) {
@@ -260,7 +261,7 @@ describe('exportCommand', () => {
         ),
       });
 
-      expect(mockSessionServiceMocks.loadLastSession).toHaveBeenCalled();
+      expect(mockSessionServiceMocks.loadSession).toHaveBeenCalled();
       expect(collectSessionData).toHaveBeenCalledWith(
         mockSessionData.conversation,
         expect.anything(),
@@ -323,7 +324,7 @@ describe('exportCommand', () => {
     });
 
     it('should return error when no session is found', async () => {
-      mockSessionServiceMocks.loadLastSession.mockResolvedValue(undefined);
+      mockSessionServiceMocks.loadSession.mockResolvedValue(undefined);
 
       const htmlCommand = exportCommand.subCommands?.find(
         (c) => c.name === 'html',

--- a/packages/cli/src/ui/commands/exportCommand.ts
+++ b/packages/cli/src/ui/commands/exportCommand.ts
@@ -50,9 +50,10 @@ async function exportMarkdownAction(
   }
 
   try {
-    // Load the current session
+    // Load the current session using the current session ID
     const sessionService = new SessionService(cwd);
-    const sessionData = await sessionService.loadLastSession();
+    const sessionId = config.getSessionId();
+    const sessionData = await sessionService.loadSession(sessionId);
 
     if (!sessionData) {
       return {
@@ -122,9 +123,10 @@ async function exportHtmlAction(
   }
 
   try {
-    // Load the current session
+    // Load the current session using the current session ID
     const sessionService = new SessionService(cwd);
-    const sessionData = await sessionService.loadLastSession();
+    const sessionId = config.getSessionId();
+    const sessionData = await sessionService.loadSession(sessionId);
 
     if (!sessionData) {
       return {
@@ -194,9 +196,10 @@ async function exportJsonAction(
   }
 
   try {
-    // Load the current session
+    // Load the current session using the current session ID
     const sessionService = new SessionService(cwd);
-    const sessionData = await sessionService.loadLastSession();
+    const sessionId = config.getSessionId();
+    const sessionData = await sessionService.loadSession(sessionId);
 
     if (!sessionData) {
       return {
@@ -266,9 +269,10 @@ async function exportJsonlAction(
   }
 
   try {
-    // Load the current session
+    // Load the current session using the current session ID
     const sessionService = new SessionService(cwd);
-    const sessionData = await sessionService.loadLastSession();
+    const sessionId = config.getSessionId();
+    const sessionData = await sessionService.loadSession(sessionId);
 
     if (!sessionData) {
       return {


### PR DESCRIPTION
## Summary

Fixes #2267

The `/export` commands (html, md, json, jsonl) were incorrectly using `loadLastSession()` which loads the last modified session from disk, rather than the currently active session.

## Changes

- Modified all export actions to use `config.getSessionId()` to get the current session ID
- Use `loadSession(sessionId)` to load the correct session instead of `loadLastSession()`

## Root Cause

`loadLastSession()` returns the session with the most recent file modification time, which may not be the currently active session when multiple sessions exist in the same directory.

## Test Plan

- [x] All existing tests pass
- [x] Updated unit tests to mock `loadSession` instead of `loadLastSession`
- [x] Added `getSessionId` mock to test context

## Affected Commands

- `/export html`
- `/export md`
- `/export json`
- `/export jsonl`