### PR TITLE
fix: correct hooks JSON schema type definition

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -85,7 +85,7 @@ export interface SettingDefinition {
  * Supports simple types (string, number, boolean) and complex object types.
  */
 export interface SettingItemDefinition {
-  type: 'string' | 'number' | 'boolean' | 'object';
+  type: 'string' | 'number' | 'boolean' | 'object' | 'array';
   properties?: Record<
     string,
     SettingItemDefinition & {
@@ -125,7 +125,7 @@ const HOOK_DEFINITION_ITEMS: SettingItemDefinition = {
         'Whether the hooks should be executed sequentially instead of in parallel.',
     },
     hooks: {
-      type: 'object',
+      type: 'array',
       description: 'The list of hook configurations to execute.',
       required: true,
       items: {

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -643,7 +643,10 @@
                     },
                     "env": {
                       "description": "Environment variables to set when executing the hook command.",
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [
@@ -705,7 +708,10 @@
                     },
                     "env": {
                       "description": "Environment variables to set when executing the hook command.",
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": [

--- a/scripts/generate-settings-schema.ts
+++ b/scripts/generate-settings-schema.ts
@@ -71,15 +71,15 @@ function convertItemDefinitionToJsonSchema(
     if (requiredFields.length > 0) {
       schema.required = requiredFields;
     }
+  }
 
-    if (itemDef.additionalProperties !== undefined) {
-      if (typeof itemDef.additionalProperties === 'boolean') {
-        schema.additionalProperties = itemDef.additionalProperties;
-      } else {
-        schema.additionalProperties = convertItemDefinitionToJsonSchema(
-          itemDef.additionalProperties,
-        );
-      }
+  if (itemDef.type === 'object' && itemDef.additionalProperties !== undefined) {
+    if (typeof itemDef.additionalProperties === 'boolean') {
+      schema.additionalProperties = itemDef.additionalProperties;
+    } else {
+      schema.additionalProperties = convertItemDefinitionToJsonSchema(
+        itemDef.additionalProperties,
+      );
     }
   }
 


### PR DESCRIPTION
# Pull Request Description

## English Version

### Fix: Correct hooks JSON schema type definition

**Issue:** #2246

#### Problem

When configuring Hooks in `settings.json`, VS Code shows type errors for `HookDefinition` objects under `hooks.UserPromptSubmit` and `hooks.Stop`:

> **Type is incorrect. Expected "string"**

This is because `settings.schema.json` incorrectly defines the array element type as `string` for these hook events, while the actual runtime expects `HookDefinition` object structures.

#### Impact

- **VS Code IntelliSense**: Users cannot get proper auto-completion and type hints when configuring hooks
- **Schema Validation**: Correct `HookDefinition` object configurations are marked as type errors, causing confusion
- **Runtime**: No impact - runtime parsing doesn't depend on JSON Schema, functionality works correctly

#### Solution

This PR adds proper schema support for complex array item types:

1. **New Interface**: Added `SettingItemDefinition` interface to define schema for array item types, supporting simple types (string, number, boolean) and complex object types

2. **Schema Definition**: Added complete `items` schema for `UserPromptSubmit` and `Stop` hooks with full `HookDefinition` structure:
   - `matcher`: Optional matcher pattern
   - `sequential`: Whether to execute hooks sequentially
   - `hooks`: Array of hook configurations (required)
     - `type`: Hook type (required, currently only 'command')
     - `command`: Command to execute (required)
     - `name`, `description`, `timeout`, `env`: Optional fields

3. **Generator Update**: Updated `generate-settings-schema.ts` with `convertItemDefinitionToJsonSchema` function to convert complex item definitions to standard JSON Schema format

#### Files Changed

| File | Change |
|------|--------|
| `packages/cli/src/config/settingsSchema.ts` | Added `SettingItemDefinition` interface and items schema for hooks |
| `packages/vscode-ide-companion/schemas/settings.schema.json` | Updated hooks items type from `string` to proper object schema |
| `scripts/generate-settings-schema.ts` | Added conversion function for complex item types |

#### Testing

- [x] VS Code no longer shows type errors for valid hook configurations
- [x] Auto-completion works correctly for hook properties
- [x] Required fields validation works properly
- [x] `npm run generate-settings-schema` generates correct schema

---
## Screenshots
### Before Fix
<img width="1538" height="1268" alt="Image" src="https://github.com/user-attachments/assets/d8e3adb8-ae46-474f-b380-cef4f84adf5d" />
### After Fix
<img width="1436" height="1092" alt="image" src="https://github.com/user-attachments/assets/3e25ce66-6525-4caf-80ae-7504a51bd8f7" />
