### PR TITLE
fix(extension): disable symlinks on Windows during git clone to fix install failure

### DIFF
--- a/packages/core/src/extension/github.test.ts
+++ b/packages/core/src/extension/github.test.ts
@@ -56,6 +56,7 @@ describe('git extension helpers', () => {
     });
 
     it('should clone, fetch and checkout a repo', async () => {
+      mockPlatform.mockReturnValue('linux');
       const installMetadata = {
         source: 'http://my-repo.com',
         ref: 'my-ref',
@@ -77,6 +78,50 @@ describe('git extension helpers', () => {
       expect(mockGit.getRemotes).toHaveBeenCalledWith(true);
       expect(mockGit.fetch).toHaveBeenCalledWith('origin', 'my-ref');
       expect(mockGit.checkout).toHaveBeenCalledWith('FETCH_HEAD');
+    });
+
+    it('should use core.symlinks=false on Windows to avoid permission errors', async () => {
+      mockPlatform.mockReturnValue('win32');
+      const installMetadata = {
+        source: 'http://my-repo.com',
+        ref: 'my-ref',
+        type: 'git' as const,
+      };
+      const destination = '/dest';
+      mockGit.getRemotes.mockResolvedValue([
+        { name: 'origin', refs: { fetch: 'http://my-repo.com' } },
+      ]);
+
+      await cloneFromGit(installMetadata, destination);
+
+      expect(mockGit.clone).toHaveBeenCalledWith('http://my-repo.com', './', [
+        '-c',
+        'core.symlinks=false',
+        '--depth',
+        '1',
+      ]);
+    });
+
+    it('should use core.symlinks=true on non-Windows platforms', async () => {
+      mockPlatform.mockReturnValue('darwin');
+      const installMetadata = {
+        source: 'http://my-repo.com',
+        ref: 'my-ref',
+        type: 'git' as const,
+      };
+      const destination = '/dest';
+      mockGit.getRemotes.mockResolvedValue([
+        { name: 'origin', refs: { fetch: 'http://my-repo.com' } },
+      ]);
+
+      await cloneFromGit(installMetadata, destination);
+
+      expect(mockGit.clone).toHaveBeenCalledWith('http://my-repo.com', './', [
+        '-c',
+        'core.symlinks=true',
+        '--depth',
+        '1',
+      ]);
     });
 
     it('should use HEAD if ref is not provided', async () => {

--- a/packages/core/src/extension/github.ts
+++ b/packages/core/src/extension/github.ts
@@ -75,9 +75,12 @@ export async function cloneFromGit(
         // We let git handle the source as is.
       }
     }
+    // On Windows, symlinks require elevated privileges by default, so we
+    // disable them to avoid "Permission denied" errors during checkout.
+    const symlinkValue = os.platform() === 'win32' ? 'false' : 'true';
     await git.clone(sourceUrl, './', [
       '-c',
-      'core.symlinks=true',
+      `core.symlinks=${symlinkValue}`,
       '--depth',
       '1',
     ]);


### PR DESCRIPTION
## TLDR

Fix extension installation failure on Windows caused by `Permission denied` errors when git tries to create symlinks during checkout. On Windows, non-administrator users cannot create symlinks by default. This PR dynamically sets `core.symlinks` based on the current platform during `git clone`.

## Dive Deeper

When installing an extension via `/extensions install <url>`, the `cloneFromGit` function was hardcoding `-c core.symlinks=true` in the git clone command. On Windows, creating symlinks requires the `SeCreateSymbolicLinkPrivilege` privilege, which is not granted to standard users by default.

This caused the following error on Windows:
```
error: unable to create symlink .claude-plugin/marketplace.json: Permission denied
fatal: unable to checkout working tree
warning: Clone succeeded, but checkout failed.
```

**Fix:** Detect the current platform using `os.platform()` and set `core.symlinks` accordingly:
- `win32` → `core.symlinks=false` (avoids symlink permission errors)
- All other platforms → `core.symlinks=true` (preserves existing behavior)

The tradeoff is that symlinks in the repository will be materialized as regular files/directories on Windows, which is acceptable since extension installation does not depend on symlinks for functionality.

## Reviewer Test Plan

1. On Windows (as a standard non-admin user), run:
   ```
   /extensions install https://github.com/dotnet/skills
   ```
   Verify the extension installs successfully without `Permission denied` errors.

2. On macOS/Linux, run the same command and verify existing behavior is unchanged.

3. Run the unit tests:
   ```
   cd packages/core && npx vitest run src/extension/github.test.ts
   ```
   All 30 tests should pass.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2243