### PR TITLE
fix(cli): suppress Windows pty resize race condition

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -9,8 +9,30 @@
 import './src/gemini.js';
 import { main } from './src/gemini.js';
 import { FatalError } from '@qwen-code/qwen-code-core';
+import { writeStderrLine } from './src/utils/stdioHelpers.js';
 
 // --- Global Entry Point ---
+
+// Suppress known race condition in @lydell/node-pty on Windows where a
+// deferred resize fires after the pty process has already exited.
+// Tracking bug: https://github.com/microsoft/node-pty/issues/827
+process.on('uncaughtException', (error) => {
+  if (
+    process.platform === 'win32' &&
+    error instanceof Error &&
+    error.message === 'Cannot resize a pty that has already exited'
+  ) {
+    return;
+  }
+
+  if (error instanceof Error) {
+    writeStderrLine(error.stack ?? error.message);
+  } else {
+    writeStderrLine(String(error));
+  }
+  process.exit(1);
+});
+
 main().catch((error) => {
   if (error instanceof FatalError) {
     let errorMessage = error.message;


### PR DESCRIPTION
## TLDR

Add a global uncaught exception handler to suppress a known race condition in `@lydell/node-pty` on Windows where a deferred resize fires after the pty process has already exited. This prevents the CLI from crashing with an unhandled exception on Windows.

## Dive Deeper

On Windows, there's a known race condition in node-pty where a deferred resize operation can fire after the pty process has already exited. This results in an uncaught exception with the message "Cannot resize a pty that has already exited".

This PR adds a global `uncaughtException` handler that:
1. Specifically detects and suppresses this Windows-specific pty resize error
2. For all other uncaught exceptions, logs the error and exits with code 1 (preserving the original behavior)

Tracking bug: https://github.com/microsoft/node-pty/issues/827

## Reviewer Test Plan

1. Pull the branch and build the CLI
2. On Windows: Run the CLI and verify it doesn't crash with pty resize errors
3. On macOS/Linux: Verify normal operation is unaffected
4. Test that other uncaught exceptions still cause proper exit with error logging

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #2242
Resolves #2250
Resolves #2276 
Resolves #2278 

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)