### PR TITLE
fix(vscode-ide-companion): map ENOENT errors to ACP RESOURCE_NOT_FOUND in readTextFile

### DIFF
--- a/packages/vscode-ide-companion/src/services/acpConnection.test.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.test.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { RequestError } from '@agentclientprotocol/sdk';
+import { AcpConnection } from './acpConnection.js';
+import { ACP_ERROR_CODES } from '../constants/acpSchema.js';
+
+describe('AcpConnection readTextFile error mapping', () => {
+  it('maps ENOENT to RESOURCE_NOT_FOUND RequestError', () => {
+    const conn = new AcpConnection() as unknown as {
+      mapReadTextFileError: (error: unknown, filePath: string) => unknown;
+    };
+    const enoent = Object.assign(new Error('missing file'), { code: 'ENOENT' });
+
+    expect(() =>
+      conn.mapReadTextFileError(enoent, '/tmp/missing.txt'),
+    ).toThrowError(
+      expect.objectContaining({
+        code: ACP_ERROR_CODES.RESOURCE_NOT_FOUND,
+      }),
+    );
+  });
+
+  it('keeps non-ENOENT RequestError unchanged', () => {
+    const conn = new AcpConnection() as unknown as {
+      mapReadTextFileError: (error: unknown, filePath: string) => unknown;
+    };
+    const requestError = new RequestError(
+      ACP_ERROR_CODES.INTERNAL_ERROR,
+      'Internal error',
+    );
+
+    expect(conn.mapReadTextFileError(requestError, '/tmp/file.txt')).toBe(
+      requestError,
+    );
+  });
+});

--- a/packages/vscode-ide-companion/src/services/acpConnection.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.ts
@@ -8,6 +8,7 @@ import {
   ClientSideConnection,
   ndJsonStream,
   PROTOCOL_VERSION,
+  RequestError,
 } from '@agentclientprotocol/sdk';
 import type {
   Client,
@@ -37,6 +38,7 @@ import { spawn } from 'child_process';
 import { Readable, Writable } from 'node:stream';
 import * as fs from 'node:fs';
 import { AcpFileHandler } from './acpFileHandler.js';
+import { ACP_ERROR_CODES } from '../constants/acpSchema.js';
 
 /**
  * ACP Connection Handler for VSCode Extension
@@ -163,7 +165,7 @@ export class AcpConnection {
 
     const stream = ndJsonStream(stdin, stdout);
 
-    // Build the SDK Client implementation that bridges to our callbacks
+    // Build the SDK Client implementation that bridges to our callbacks.
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
     this.sdkConnection = new ClientSideConnection(
@@ -266,13 +268,17 @@ export class AcpConnection {
         async readTextFile(
           params: ReadTextFileRequest,
         ): Promise<ReadTextFileResponse> {
-          const result = await self.fileHandler.handleReadTextFile({
-            path: params.path,
-            sessionId: params.sessionId,
-            line: params.line ?? null,
-            limit: params.limit ?? null,
-          });
-          return { content: result.content };
+          try {
+            const result = await self.fileHandler.handleReadTextFile({
+              path: params.path,
+              sessionId: params.sessionId,
+              line: params.line ?? null,
+              limit: params.limit ?? null,
+            });
+            return { content: result.content };
+          } catch (error) {
+            throw self.mapReadTextFileError(error, params.path);
+          }
         },
 
         async writeTextFile(
@@ -332,6 +338,22 @@ export class AcpConnection {
       throw new Error('Not connected to ACP agent');
     }
     return this.sdkConnection;
+  }
+
+  private mapReadTextFileError(error: unknown, filePath: string): unknown {
+    const errorCode =
+      typeof error === 'object' && error !== null && 'code' in error
+        ? (error as { code?: unknown }).code
+        : undefined;
+
+    if (errorCode === 'ENOENT') {
+      throw new RequestError(
+        ACP_ERROR_CODES.RESOURCE_NOT_FOUND,
+        `File not found: ${filePath}`,
+      );
+    }
+
+    return error;
   }
 
   private resolvePermissionOptionId(


### PR DESCRIPTION
## TLDR

This PR adds error handling to the `readTextFile` method in the VSCode IDE companion's ACP connection. When a file is not found (ENOENT error), it now returns a proper ACP protocol `RESOURCE_NOT_FOUND` error instead of propagating the raw filesystem error. Unit tests are included.

## Dive Deeper

The `readTextFile` implementation in `acpConnection.ts` was not handling filesystem errors properly. When a file didn't exist, the raw ENOENT error would propagate up without being mapped to the ACP protocol's error format.

Changes:
- Added a `mapReadTextFileError` private method that inspects error codes and converts ENOENT to a `RequestError` with `ACP_ERROR_CODES.RESOURCE_NOT_FOUND`
- Wrapped the `handleReadTextFile` call in a try-catch block to intercept and map errors
- Added two unit tests in `acpConnection.test.ts` to verify ENOENT mapping and passthrough behavior for other error types

This ensures consistent error responses that conform to the ACP specification.

## Reviewer Test Plan

1. Run the unit tests:
   ```bash
   npm run test -- packages/vscode-ide-companion/src/services/acpConnection.test.ts
   ```

2. Verify the error mapping logic handles both ENOENT and non-ENOENT cases correctly by reviewing the test assertions.

3. If testing with a running VSCode extension, attempt to read a non-existent file via ACP and confirm the response contains the `RESOURCE_NOT_FOUND` error code.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
