### PR TITLE
fix(cli): fallback to local filesystem when ACP writeTextFile fails with invalid path

### DIFF
--- a/packages/cli/src/acp-integration/service/filesystem.test.ts
+++ b/packages/cli/src/acp-integration/service/filesystem.test.ts
@@ -179,4 +179,69 @@ describe('AcpFileSystemService', () => {
       expect(client.readTextFile).not.toHaveBeenCalled();
     });
   });
+
+  describe('writeTextFile invalid path fallback', () => {
+    it('falls back to local filesystem when ACP write fails with invalid path', async () => {
+      const invalidPathError = {
+        code: INTERNAL_ERROR_CODE,
+        message: 'Internal error',
+        data: 'invalid path',
+      };
+      const client = {
+        writeTextFile: vi.fn().mockRejectedValue(invalidPathError),
+      } as unknown as AgentSideConnection;
+
+      const fallback = createFallback();
+      (fallback.writeTextFile as ReturnType<typeof vi.fn>).mockResolvedValue(
+        undefined,
+      );
+
+      const svc = new AcpFileSystemService(
+        client,
+        'session-4',
+        { readTextFile: true, writeTextFile: true },
+        fallback,
+      );
+
+      await expect(
+        svc.writeTextFile('/some/file.txt', 'hello world'),
+      ).resolves.toBeUndefined();
+
+      expect(client.writeTextFile).toHaveBeenCalledWith({
+        path: '/some/file.txt',
+        content: 'hello world',
+        sessionId: 'session-4',
+      });
+      expect(fallback.writeTextFile).toHaveBeenCalledWith(
+        '/some/file.txt',
+        'hello world',
+        undefined,
+      );
+    });
+
+    it('rethrows ACP write errors that are not invalid path', async () => {
+      const writeError = {
+        code: INTERNAL_ERROR_CODE,
+        message: 'Internal error',
+        data: 'permission denied',
+      };
+      const client = {
+        writeTextFile: vi.fn().mockRejectedValue(writeError),
+      } as unknown as AgentSideConnection;
+
+      const fallback = createFallback();
+
+      const svc = new AcpFileSystemService(
+        client,
+        'session-5',
+        { readTextFile: true, writeTextFile: true },
+        fallback,
+      );
+
+      await expect(
+        svc.writeTextFile('/some/file.txt', 'hello world'),
+      ).rejects.toMatchObject(writeError);
+      expect(fallback.writeTextFile).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/cli/src/acp-integration/service/filesystem.ts
+++ b/packages/cli/src/acp-integration/service/filesystem.ts
@@ -16,6 +16,29 @@ import type {
 
 const RESOURCE_NOT_FOUND_CODE = -32002;
 
+function isInvalidPathWriteError(error: unknown): boolean {
+  const data =
+    typeof error === 'object' && error !== null && 'data' in error
+      ? (error as { data?: unknown }).data
+      : undefined;
+
+  if (typeof data === 'string') {
+    return data.toLowerCase() === 'invalid path';
+  }
+
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === 'object' && error !== null && 'message' in error
+        ? (error as { message?: unknown }).message
+        : undefined;
+
+  return (
+    typeof message === 'string' &&
+    message.toLowerCase().includes('invalid path')
+  );
+}
+
 export class AcpFileSystemService implements FileSystemService {
   constructor(
     private readonly connection: AgentSideConnection,
@@ -75,12 +98,19 @@ export class AcpFileSystemService implements FileSystemService {
     }
 
     const finalContent = options?.bom ? '\uFEFF' + content : content;
-
-    await this.connection.writeTextFile({
-      path: filePath,
-      content: finalContent,
-      sessionId: this.sessionId,
-    });
+    try {
+      await this.connection.writeTextFile({
+        path: filePath,
+        content: finalContent,
+        sessionId: this.sessionId,
+      });
+    } catch (error) {
+      if (isInvalidPathWriteError(error)) {
+        await this.fallback.writeTextFile(filePath, content, options);
+        return;
+      }
+      throw error;
+    }
   }
 
   async detectFileBOM(filePath: string): Promise<boolean> {


### PR DESCRIPTION
## TLDR

Fix ACP `writeTextFile` failing when the target file path does not exist. When ACP returns an "invalid path" error, automatically fall back to the local filesystem to perform the write, ensuring new file creation works correctly.

## Dive Deeper

When calling `writeTextFile` via the ACP protocol to write to a file path that does not yet exist (i.e., creating a new file), the IDE side returns an error containing "invalid path", causing the write to fail.

This PR adds a fallback mechanism to `AcpFileSystemService.writeTextFile` on the CLI side:
- Adds an `isInvalidPathWriteError()` helper that checks whether the error's `data` or `message` field contains "invalid path"
- When this specific error is detected, falls back to the local filesystem service which supports `mkdir -p` + `writeFile` to create directories and files
- Other error types are re-thrown as-is, preserving existing behavior

## Reviewer Test Plan

1. In the IDE, use ACP mode and have the agent write to a non-existent file path (e.g., a new file under a new directory)
2. Verify the file is created successfully with correct content
3. Verify that writing to an existing file still goes through the ACP channel with unchanged behavior
4. Verify that non-"invalid path" write errors are still properly thrown

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #2294