### PR TITLE
fix(webui): add Tab key support to CompletionMenu

### DIFF
--- a/packages/webui/src/components/layout/CompletionMenu.tsx
+++ b/packages/webui/src/components/layout/CompletionMenu.tsx
@@ -123,6 +123,7 @@ export const CompletionMenu: FC<CompletionMenuProps> = ({
           setSelected((prev) => Math.max(prev - 1, 0));
           break;
         case 'Enter':
+        case 'Tab':
           event.preventDefault();
           if (items[selected]) {
             onSelect(items[selected]);


### PR DESCRIPTION
## TLDR

Fixes #2293 - Adds Tab key support to the completion menu in the VSCode extension. Users can now press Tab to select highlighted completion items (slash commands, file references) instead of only Enter.

**Changes:**
- Add Tab key handling in CompletionMenu component (`packages/webui/src/components/layout/CompletionMenu.tsx`)
- Tab key now selects the highlighted item (same behavior as Enter)
- Prevents default browser Tab focus behavior when completion menu is open
- Combines Enter and Tab handlers for DRY code (both keys perform identical action)

## Dive Deeper

### Problem
When the slash command completion menu is open (triggered by typing `/`), pressing Tab doesn't select the highlighted item - it just moves focus away following default browser behavior. Users expect Tab to work like Enter, selecting the currently highlighted completion item. This is inconsistent with other AI coding assistants like Claude Code.

### Solution
Modified the `handleKeyDown` function in `CompletionMenu.tsx` to:
1. Listen for the Tab key alongside Enter
2. Call `event.preventDefault()` to prevent default browser focus behavior
3. Select the currently highlighted item via `onSelect(items[selected])`

The Enter and Tab handlers were combined since they perform identical actions, following the DRY principle.

### Code Change
```diff
- case 'Enter':
-   event.preventDefault();
-   if (items[selected]) {
-     onSelect(items[selected]);
-   }
-   break;
  case 'Tab':
+ case 'Enter':
+ case 'Tab':
    event.preventDefault();
    if (items[selected]) {
      onSelect(items[selected]);
    }
    break;
```

### Testing
- Build passes: `bun run build` ✅
- All existing tests pass: 2000+ tests ✅
- Manual testing required: Type `/` in VSCode extension, use Tab to select commands

## Reviewer Test Plan

1. **Pull the branch** and build the project: `bun run build`
2. **Run the VSCode extension** in development mode (F5)
3. **Test completion menu:**
   - Type `/` to open slash command menu
   - Use Arrow keys to navigate to a command
   - Press **Tab** - should select the command (not move focus)
   - Type `/` again, navigate, press **Enter** - should still work as before
4. **Verify both keys work identically** for:
   - Slash commands (`/help`, `/etc.`)
   - File references (`@filename`)

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ❓    | ✅      | ❓    |
| npx      | ❓    | ✅      | ❓    |
| Docker   | ❓    | ❓      | ❓    |

## Linked issues

Fixes #2293
