### PR TITLE
chore: add yiliang114 as code owner for vscode-ide-companion and webui

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 * @tanzhenxin @DennisYu07 @gwinthis @LaZzyMan @pomelo-nwu @Mingholy @DragonnZhang
 # SDK TypeScript package changes require review from Mingholy
 packages/sdk-typescript/** @Mingholy
+# vscode-ide-companion and webui packages require review from yiliang114
+packages/vscode-ide-companion/** @yiliang114
+packages/webui/** @yiliang114


### PR DESCRIPTION
## Summary
- Add @yiliang114 as code owner for `packages/vscode-ide-companion/` and `packages/webui/`

## Changes
Updated `.github/CODEOWNERS` to include:
- `packages/vscode-ide-companion/** @yiliang114`
- `packages/webui/** @yiliang114`

## Test plan
- [ ] Verify the CODEOWNERS syntax is correct
- [ ] Confirm that @yiliang114 will be automatically requested for review on PRs affecting these directories