### PR TITLE
fix(core): convert array content to string for DeepSeek API

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/deepseek.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/deepseek.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type OpenAI from 'openai';
 import { DeepSeekOpenAICompatibleProvider } from './deepseek.js';
 import type { ContentGeneratorConfig } from '../../contentGenerator.js';
 import type { Config } from '../../../config/config.js';
@@ -17,6 +18,7 @@ vi.mock('openai', () => ({
 }));
 
 describe('DeepSeekOpenAICompatibleProvider', () => {
+  let provider: DeepSeekOpenAICompatibleProvider;
   let mockContentGeneratorConfig: ContentGeneratorConfig;
   let mockCliConfig: Config;
 
@@ -32,6 +34,11 @@ describe('DeepSeekOpenAICompatibleProvider', () => {
     mockCliConfig = {
       getCliVersion: vi.fn().mockReturnValue('1.0.0'),
     } as unknown as Config;
+
+    provider = new DeepSeekOpenAICompatibleProvider(
+      mockContentGeneratorConfig,
+      mockCliConfig,
+    );
   });
 
   describe('isDeepSeekProvider', () => {
@@ -54,12 +61,102 @@ describe('DeepSeekOpenAICompatibleProvider', () => {
     });
   });
 
+  describe('buildRequest', () => {
+    const userPromptId = 'prompt-123';
+
+    it('converts array content into a string', () => {
+      const originalRequest: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'deepseek-chat',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Hello' },
+              { type: 'text', text: ' world' },
+            ],
+          },
+        ],
+      };
+
+      const result = provider.buildRequest(originalRequest, userPromptId);
+
+      expect(result.messages).toHaveLength(1);
+      expect(result.messages?.[0]).toEqual({
+        role: 'user',
+        content: 'Hello\n\n world',
+      });
+      expect(originalRequest.messages?.[0].content).toEqual([
+        { type: 'text', text: 'Hello' },
+        { type: 'text', text: ' world' },
+      ]);
+    });
+
+    it('leaves string content unchanged', () => {
+      const originalRequest: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'deepseek-chat',
+        messages: [
+          {
+            role: 'user',
+            content: 'Hello world',
+          },
+        ],
+      };
+
+      const result = provider.buildRequest(originalRequest, userPromptId);
+
+      expect(result.messages?.[0].content).toBe('Hello world');
+    });
+
+    it('handles plain string parts in the content array', () => {
+      const originalRequest = {
+        model: 'deepseek-chat',
+        messages: [
+          {
+            role: 'user' as const,
+            content: [
+              'Hello',
+              { type: 'text' as const, text: ' world' },
+            ] as unknown as OpenAI.Chat.ChatCompletionContentPart[],
+          },
+        ],
+      };
+
+      const result = provider.buildRequest(originalRequest, userPromptId);
+
+      expect(result.messages?.[0]).toEqual({
+        role: 'user',
+        content: 'Hello\n\n world',
+      });
+    });
+
+    it('replaces non-text parts with a placeholder', () => {
+      const originalRequest: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'deepseek-chat',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Hello ' },
+              {
+                type: 'image_url',
+                image_url: { url: 'https://example.com/image.png' },
+              },
+            ],
+          },
+        ],
+      };
+
+      const result = provider.buildRequest(originalRequest, userPromptId);
+
+      expect(result.messages?.[0]).toEqual({
+        role: 'user',
+        content: 'Hello \n\n[Unsupported content type: image_url]',
+      });
+    });
+  });
+
   describe('getDefaultGenerationConfig', () => {
     it('returns temperature 0', () => {
-      const provider = new DeepSeekOpenAICompatibleProvider(
-        mockContentGeneratorConfig,
-        mockCliConfig,
-      );
       expect(provider.getDefaultGenerationConfig()).toEqual({
         temperature: 0,
       });

--- a/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type OpenAI from 'openai';
 import type { Config } from '../../../config/config.js';
 import type { ContentGeneratorConfig } from '../../contentGenerator.js';
 import { DefaultOpenAICompatibleProvider } from './default.js';
@@ -23,6 +24,63 @@ export class DeepSeekOpenAICompatibleProvider extends DefaultOpenAICompatiblePro
     const baseUrl = contentGeneratorConfig.baseUrl ?? '';
 
     return baseUrl.toLowerCase().includes('api.deepseek.com');
+  }
+
+  /**
+   * DeepSeek's API requires message content to be a plain string, not an
+   * array of content parts. Flatten any text-part arrays into joined strings
+   * and reject non-text parts that DeepSeek cannot handle.
+   */
+  override buildRequest(
+    request: OpenAI.Chat.ChatCompletionCreateParams,
+    userPromptId: string,
+  ): OpenAI.Chat.ChatCompletionCreateParams {
+    const baseRequest = super.buildRequest(request, userPromptId);
+    if (!baseRequest.messages?.length) {
+      return baseRequest;
+    }
+
+    const messages = baseRequest.messages.map((message) => {
+      if (!('content' in message)) {
+        return message;
+      }
+
+      const { content } = message;
+
+      if (
+        typeof content === 'string' ||
+        content === null ||
+        content === undefined
+      ) {
+        return message;
+      }
+
+      if (!Array.isArray(content)) {
+        return message;
+      }
+
+      const text = content
+        .map((part) => {
+          if (typeof part === 'string') {
+            return part;
+          }
+          if (part.type === 'text') {
+            return part.text ?? '';
+          }
+          return `[Unsupported content type: ${part.type}]`;
+        })
+        .join('\n\n');
+
+      return {
+        ...message,
+        content: text,
+      } as OpenAI.Chat.ChatCompletionMessageParam;
+    });
+
+    return {
+      ...baseRequest,
+      messages,
+    };
   }
 
   override getDefaultGenerationConfig(): GenerateContentConfig {


### PR DESCRIPTION
## TLDR

Fixes DeepSeek API errors when message content is sent as an array instead of a string. DeepSeek's API requires message content to be a plain string, not an array of content parts. This PR adds a `buildRequest` override in `DeepSeekOpenAICompatibleProvider` that converts array content to string format.

## Dive Deeper

DeepSeek's API has a strict requirement that message content must be a string, not an array of content parts. When Qwen Code sends messages with array content (e.g., multi-part messages with text and other content types), DeepSeek returns a 400 error:

```
Failed to deserialize the JSON body into the target type: messages[N]: invalid type: sequence, expected a string
```

This fix:
1. Overrides `buildRequest` in `DeepSeekOpenAICompatibleProvider`
2. Converts array content to a string by joining text parts with double newlines
3. Replaces non-text parts (like images) with a placeholder: `[Unsupported content type: <type>]`
4. Preserves the original request object (does not mutate it)

## Reviewer Test Plan

1. Configure Qwen Code to use DeepSeek API:
   - Set `QWEN_API_KEY` to your DeepSeek API key
   - Set `QWEN_API_BASE_URL` to `https://api.deepseek.com/v1`
   - Set `QWEN_MODEL` to `deepseek-chat` or `deepseek-reasoner`

2. Run the test suite:
   ```bash
   cd packages/core && npx vitest run src/core/openaiContentGenerator/provider/deepseek.test.ts
   ```

3. Test interactively with Qwen Code using DeepSeek and verify no 400 errors occur

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2158
Fixes #2318

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)