### PR TITLE
feat(core): add truncation support to LS tool

### DIFF
--- a/packages/core/src/tools/ls.test.ts
+++ b/packages/core/src/tools/ls.test.ts
@@ -41,6 +41,7 @@ describe('LSTool', () => {
         respectGitIgnore: true,
         respectQwenIgnore: true,
       }),
+      getTruncateToolOutputLines: () => 1000,
       storage: {
         getUserSkillsDir: () => userSkillsBase,
       },
@@ -100,7 +101,7 @@ describe('LSTool', () => {
 
       expect(result.llmContent).toContain('[DIR] subdir');
       expect(result.llmContent).toContain('file1.txt');
-      expect(result.returnDisplay).toBe('Listed 2 item(s).');
+      expect(result.returnDisplay).toBe('Listed 2 item(s)');
     });
 
     it('should list files from secondary workspace directory', async () => {
@@ -115,7 +116,7 @@ describe('LSTool', () => {
       const result = await invocation.execute(abortSignal);
 
       expect(result.llmContent).toContain('secondary-file.txt');
-      expect(result.returnDisplay).toBe('Listed 1 item(s).');
+      expect(result.returnDisplay).toBe('Listed 1 item(s)');
     });
 
     it('should handle empty directories', async () => {
@@ -140,7 +141,7 @@ describe('LSTool', () => {
 
       expect(result.llmContent).toContain('file1.txt');
       expect(result.llmContent).not.toContain('file2.log');
-      expect(result.returnDisplay).toBe('Listed 1 item(s).');
+      expect(result.returnDisplay).toBe('Listed 1 item(s)');
     });
 
     it('should respect gitignore patterns', async () => {
@@ -154,7 +155,7 @@ describe('LSTool', () => {
       expect(result.llmContent).toContain('file1.txt');
       expect(result.llmContent).not.toContain('file2.log');
       // .git is always ignored by default.
-      expect(result.returnDisplay).toBe('Listed 2 item(s). (2 git-ignored)');
+      expect(result.returnDisplay).toBe('Listed 2 item(s) (2 git-ignored)');
     });
 
     it('should respect qwenignore patterns', async () => {
@@ -166,7 +167,7 @@ describe('LSTool', () => {
 
       expect(result.llmContent).toContain('file1.txt');
       expect(result.llmContent).not.toContain('file2.log');
-      expect(result.returnDisplay).toBe('Listed 2 item(s). (1 qwen-ignored)');
+      expect(result.returnDisplay).toBe('Listed 2 item(s) (1 qwen-ignored)');
     });
 
     it('should handle non-directory paths', async () => {
@@ -204,7 +205,7 @@ describe('LSTool', () => {
         typeof result.llmContent === 'string' ? result.llmContent : ''
       )
         .split('\n')
-        .filter(Boolean);
+        .filter((l) => l.trim() && l.trim() !== '---');
       const entries = lines.slice(1); // Skip header
 
       expect(entries[0]).toBe('[DIR] x-dir');
@@ -259,9 +260,67 @@ describe('LSTool', () => {
       // Should still list the other files
       expect(result.llmContent).toContain('file1.txt');
       expect(result.llmContent).not.toContain('problematic.txt');
-      expect(result.returnDisplay).toBe('Listed 1 item(s).');
+      expect(result.returnDisplay).toBe('Listed 1 item(s)');
 
       statSpy.mockRestore();
+    });
+  });
+
+  describe('truncation', () => {
+    it('should truncate when entries exceed config line limit', async () => {
+      const lowLimitConfig = {
+        ...mockConfig,
+        getTruncateToolOutputLines: () => 5,
+      } as unknown as Config;
+      const lowLimitTool = new LSTool(lowLimitConfig);
+
+      for (let i = 0; i < 10; i++) {
+        await fs.writeFile(
+          path.join(tempRootDir, `file${String(i).padStart(2, '0')}.txt`),
+          `content${i}`,
+        );
+      }
+
+      const invocation = lowLimitTool.build({ path: tempRootDir });
+      const result = await invocation.execute(abortSignal);
+
+      expect(result.llmContent).toContain('[5 items truncated]');
+      expect(result.returnDisplay).toBe('Listed 10 item(s) (truncated)');
+    });
+
+    it('should not truncate when entries are within limit', async () => {
+      for (let i = 0; i < 3; i++) {
+        await fs.writeFile(
+          path.join(tempRootDir, `file${i}.txt`),
+          `content${i}`,
+        );
+      }
+
+      const invocation = lsTool.build({ path: tempRootDir });
+      const result = await invocation.execute(abortSignal);
+
+      expect(result.llmContent).not.toContain('truncated');
+      expect(result.returnDisplay).toBe('Listed 3 item(s)');
+    });
+
+    it('should use singular "entry" when exactly one entry is truncated', async () => {
+      const lowLimitConfig = {
+        ...mockConfig,
+        getTruncateToolOutputLines: () => 2,
+      } as unknown as Config;
+      const lowLimitTool = new LSTool(lowLimitConfig);
+
+      for (let i = 0; i < 3; i++) {
+        await fs.writeFile(
+          path.join(tempRootDir, `file${i}.txt`),
+          `content${i}`,
+        );
+      }
+
+      const invocation = lowLimitTool.build({ path: tempRootDir });
+      const result = await invocation.execute(abortSignal);
+
+      expect(result.llmContent).toContain('[1 item truncated]');
     });
   });
 
@@ -319,7 +378,7 @@ describe('LSTool', () => {
       const result = await invocation.execute(abortSignal);
 
       expect(result.llmContent).toContain('secondary-file.txt');
-      expect(result.returnDisplay).toBe('Listed 1 item(s).');
+      expect(result.returnDisplay).toBe('Listed 1 item(s)');
     });
   });
 });

--- a/packages/core/src/tools/ls.ts
+++ b/packages/core/src/tools/ls.ts
@@ -18,6 +18,8 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 
 const debugLogger = createDebugLogger('LS');
 
+const MAX_ENTRY_COUNT = 100;
+
 /**
  * Parameters for the LS tool
  */
@@ -216,12 +218,27 @@ class LSToolInvocation extends BaseToolInvocation<LSToolParams, ToolResult> {
         return a.name.localeCompare(b.name);
       });
 
-      // Create formatted content for LLM
-      const directoryContent = entries
+      const totalEntryCount = entries.length;
+      const entryLimit = Math.min(
+        MAX_ENTRY_COUNT,
+        this.config.getTruncateToolOutputLines(),
+      );
+      const truncated = totalEntryCount > entryLimit;
+
+      const entriesToShow = truncated ? entries.slice(0, entryLimit) : entries;
+
+      const directoryContent = entriesToShow
         .map((entry) => `${entry.isDirectory ? '[DIR] ' : ''}${entry.name}`)
         .join('\n');
 
-      let resultMessage = `Directory listing for ${this.params.path}:\n${directoryContent}`;
+      let resultMessage = `Listed ${totalEntryCount} item(s) in ${this.params.path}:\n---\n${directoryContent}`;
+
+      if (truncated) {
+        const omittedEntries = totalEntryCount - entryLimit;
+        const entryTerm = omittedEntries === 1 ? 'item' : 'items';
+        resultMessage += `\n---\n[${omittedEntries} ${entryTerm} truncated] ...`;
+      }
+
       const ignoredMessages = [];
       if (gitIgnoredCount > 0) {
         ignoredMessages.push(`${gitIgnoredCount} git-ignored`);
@@ -233,9 +250,12 @@ class LSToolInvocation extends BaseToolInvocation<LSToolParams, ToolResult> {
         resultMessage += `\n\n(${ignoredMessages.join(', ')})`;
       }
 
-      let displayMessage = `Listed ${entries.length} item(s).`;
+      let displayMessage = `Listed ${totalEntryCount} item(s)`;
       if (ignoredMessages.length > 0) {
         displayMessage += ` (${ignoredMessages.join(', ')})`;
+      }
+      if (truncated) {
+        displayMessage += ' (truncated)';
       }
 
       return {


### PR DESCRIPTION
## TLDR

Add output truncation for the LS (list directory) tool to prevent overwhelming output when directories contain many entries. The tool now respects the configured line limit and displays a clear message when content is truncated.

## Dive Deeper

The LS tool previously had no limit on the number of entries it would return, which could lead to excessive output for large directories. This change introduces:

- **MAX_ENTRY_COUNT constant (100)**: An upper bound to prevent unreasonably large listings
- **Dynamic truncation**: Uses `getTruncateToolOutputLines()` config to respect user preferences
- **Clear truncation indicators**: Shows `[N items truncated] ...` with proper singular/plural handling
- **Updated output format**: Uses `---` separators for better readability between header, content, and truncation notice

Example truncated output:
```
Listed 150 item(s) in /path/to/dir:
---
[DIR] folder1
file1.txt
file2.txt
...
---
[50 items truncated] ...
```

## Reviewer Test Plan

1. Run the LS tool tests: `cd packages/core && npx vitest run src/tools/ls.test.ts`
2. Test with a directory containing many files to verify truncation kicks in
3. Verify the `returnDisplay` message shows "(truncated)" when applicable
4. Check that singular "item" is used when exactly 1 item is truncated

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #2319

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)