### PR TITLE
fix: clear retry error messages promptly after auto-retry succeeds

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -2244,6 +2244,7 @@ describe('useGeminiStream', () => {
     it('should show a retry countdown and update pending history over time', async () => {
       vi.useFakeTimers();
       try {
+        let continueToRetryAttempt: (() => void) | undefined;
         let resolveStream: (() => void) | undefined;
         mockSendMessageStream.mockReturnValue(
           (async function* () {
@@ -2256,6 +2257,9 @@ describe('useGeminiStream', () => {
                 delayMs: 3000,
               },
             };
+            await new Promise<void>((resolve) => {
+              continueToRetryAttempt = resolve;
+            });
             yield {
               type: ServerGeminiEventType.Retry,
             };
@@ -2330,6 +2334,12 @@ describe('useGeminiStream', () => {
           '2s',
         );
 
+        continueToRetryAttempt?.();
+
+        await act(async () => {
+          await Promise.resolve();
+        });
+
         resolveStream?.();
 
         await act(async () => {
@@ -2338,6 +2348,103 @@ describe('useGeminiStream', () => {
         });
 
         // Error item (with hint) should be cleared after retry succeeds
+        const remainingError = result.current.pendingHistoryItems.find(
+          (item) => item.type === MessageType.ERROR,
+        );
+        expect(remainingError).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should clear retry errors after auto-retry succeeds once the countdown has elapsed', async () => {
+      vi.useFakeTimers();
+      try {
+        let continueAfterCountdown: (() => void) | undefined;
+        mockSendMessageStream.mockReturnValue(
+          (async function* () {
+            yield {
+              type: ServerGeminiEventType.Retry,
+              retryInfo: {
+                message: '[API Error: Rate limit exceeded]',
+                attempt: 1,
+                maxRetries: 3,
+                delayMs: 1000,
+              },
+            };
+            await new Promise<void>((resolve) => {
+              continueAfterCountdown = resolve;
+            });
+            yield {
+              type: ServerGeminiEventType.Retry,
+            };
+            yield {
+              type: ServerGeminiEventType.Text,
+              value: 'Success after retry',
+            };
+            yield {
+              type: ServerGeminiEventType.Finished,
+              value: { reason: 'STOP', usageMetadata: undefined },
+            };
+          })(),
+        );
+
+        const { result } = renderHook(() =>
+          useGeminiStream(
+            new MockedGeminiClientClass(mockConfig),
+            [],
+            mockAddItem,
+            mockConfig,
+            mockLoadedSettings,
+            mockOnDebugMessage,
+            mockHandleSlashCommand,
+            false,
+            () => 'vscode' as EditorType,
+            () => {},
+            () => Promise.resolve(),
+            false,
+            () => {},
+            () => {},
+            () => {},
+            () => {},
+            80,
+            24,
+          ),
+        );
+
+        act(() => {
+          void result.current.submitQuery('Trigger retry after countdown');
+        });
+
+        let errorItem = result.current.pendingHistoryItems.find(
+          (item) => item.type === MessageType.ERROR,
+        ) as { hint?: string } | undefined;
+        for (let attempts = 0; attempts < 5 && !errorItem; attempts++) {
+          await act(async () => {
+            await Promise.resolve();
+          });
+          errorItem = result.current.pendingHistoryItems.find(
+            (item) => item.type === MessageType.ERROR,
+          ) as { hint?: string } | undefined;
+        }
+        expect(errorItem?.hint).toContain('1s');
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1000);
+        });
+
+        const staleErrorBeforeRetryCompletes =
+          result.current.pendingHistoryItems.find(
+            (item) => item.type === MessageType.ERROR,
+          ) as { hint?: string } | undefined;
+        expect(staleErrorBeforeRetryCompletes?.hint).toContain('0s');
+
+        await act(async () => {
+          continueAfterCountdown?.();
+          await Promise.resolve();
+          await Promise.resolve();
+        });
+
         const remainingError = result.current.pendingHistoryItems.find(
           (item) => item.type === MessageType.ERROR,
         );

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1034,7 +1034,8 @@ export const useGeminiStream = (
             // Show retry info if available (rate-limit / throttling errors)
             if (event.retryInfo) {
               startRetryCountdown(event.retryInfo);
-            } else if (!pendingRetryCountdownItemRef.current) {
+            } else {
+              // The retry attempt is starting now, so any prior retry UI is stale.
               clearRetryCountdown();
             }
             break;
@@ -1075,7 +1076,6 @@ export const useGeminiStream = (
       setThought,
       pendingHistoryItemRef,
       setPendingHistoryItem,
-      pendingRetryCountdownItemRef,
     ],
   );
 
@@ -1301,24 +1301,13 @@ export const useGeminiStream = (
       return;
     }
 
-    // Commit the error to history (without hint) before clearing
-    const errorItem = pendingRetryErrorItemRef.current;
-    if (errorItem) {
-      addItem({ type: errorItem.type, text: errorItem.text }, Date.now());
-    }
     clearRetryCountdown();
 
     await submitQuery(lastPrompt, {
       isContinuation: false,
       skipPreparation: true,
     });
-  }, [
-    streamingState,
-    addItem,
-    clearRetryCountdown,
-    submitQuery,
-    pendingRetryErrorItemRef,
-  ]);
+  }, [streamingState, addItem, clearRetryCountdown, submitQuery]);
 
   const handleApprovalModeChange = useCallback(
     async (newApprovalMode: ApprovalMode) => {


### PR DESCRIPTION
## TLDR

Fix stale error messages not being cleared after auto-retry succeeds and after Ctrl+Y manual retry. Unify error cleanup behavior across all retry paths.

## Dive Deeper

### Problem

After introducing the Ctrl+Y retry feature, error messages from auto-retry (e.g., 429 rate-limit errors) were not cleared in a timely manner:

1. **Auto-retry scenario**: After the server successfully auto-retried, the countdown error message persisted in the UI until the user manually initiated a new request.
2. **Ctrl+Y scenario**: When the user pressed Ctrl+Y to retry, the old error message was committed to permanent chat history (without the hint) instead of being discarded — inconsistent with auto-retry behavior.

### Root Cause

In `processGeminiStreamEvents`, the `Retry` event handler had a flawed guard condition:

```typescript
// Old code
} else if (!pendingRetryCountdownItemRef.current) {
    clearRetryCountdown();
}
```

The server retry protocol sends two events:
1. `Retry` with `retryInfo` → starts the countdown UI
2. `Retry` without `retryInfo` → signals the actual retry attempt is starting

When the countdown reached 0, `stopRetryCountdownTimer()` only cleared the interval timer but did not reset `pendingRetryCountdownItem`. So when the second Retry event arrived, `pendingRetryCountdownItemRef.current` was still truthy, causing `clearRetryCountdown()` to be skipped.

### Fix

1. **Auto-retry cleanup**: Remove the `!pendingRetryCountdownItemRef.current` guard — always call `clearRetryCountdown()` when a `Retry` event without `retryInfo` is received.
2. **Ctrl+Y consistency**: Remove the error-to-history commit in `retryLastPrompt`, aligning with auto-retry behavior where errors are silently discarded on retry.
3. **Dependency cleanup**: Remove the now-unused `pendingRetryCountdownItemRef` from the `processGeminiStreamEvents` useCallback dependency array.

## Reviewer Test Plan

1. Trigger a 429 rate-limit error and observe the countdown UI
2. Wait for auto-retry to succeed — verify the error message is cleared (not lingering)
3. Trigger an API error, press Ctrl+Y to retry — verify the old error is cleared (not committed to history)
4. Switch models and send a new message — verify the old error is cleared
5. Run `npx vitest run packages/cli/src/ui/hooks/useGeminiStream.test.tsx` — all 47 tests should pass

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes #2310
Related to #2105
