### PR TITLE
fix(core): disable node-pty on older Windows builds with broken ConPTY

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -96,6 +96,7 @@ import {
 // Utils
 import { shouldAttemptBrowserLaunch } from '../utils/browser.js';
 import { FileExclusions } from '../utils/ignorePatterns.js';
+import { shouldDefaultToNodePty } from '../utils/shell-utils.js';
 import { WorkspaceContext } from '../utils/workspaceContext.js';
 import { isToolEnabled, type ToolName } from '../utils/tool-utils.js';
 import { getErrorMessage } from '../utils/errors.js';
@@ -636,7 +637,8 @@ export class Config {
     this.webSearch = params.webSearch;
     this.useRipgrep = params.useRipgrep ?? true;
     this.useBuiltinRipgrep = params.useBuiltinRipgrep ?? true;
-    this.shouldUseNodePtyShell = params.shouldUseNodePtyShell ?? true;
+    this.shouldUseNodePtyShell =
+      params.shouldUseNodePtyShell ?? shouldDefaultToNodePty();
     this.skipNextSpeakerCheck = params.skipNextSpeakerCheck ?? true;
     this.shellExecutionConfig = {
       terminalWidth: params.shellExecutionConfig?.terminalWidth ?? 80,

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -913,3 +913,13 @@ export function isCommandNeedsPermission(command: string): {
     reason: 'Command requires permission to execute.',
   };
 }
+
+// ConPTY on Windows builds <= 19041 has known reliability issues (missing
+// output, hangs). VS Code uses the same cutoff: microsoft/vscode#123725.
+const CONPTY_MIN_WINDOWS_BUILD = 19042;
+
+export function shouldDefaultToNodePty(): boolean {
+  if (os.platform() !== 'win32') return true;
+  const build = parseInt(os.release().split('.')[2] ?? '', 10);
+  return !isNaN(build) && build >= CONPTY_MIN_WINDOWS_BUILD;
+}


### PR DESCRIPTION
## TLDR

Fixes `run_shell_command` returning empty output on Windows by disabling node-pty (ConPTY) on Windows builds <= 19041, which have known reliability issues. Falls back to spawn-based execution on affected systems.

## Dive Deeper

ConPTY (Windows Pseudo Console) has known bugs on Windows builds 19041 and earlier, including:
- Missing output from commands
- Random hangs
- Incomplete command results

VS Code uses the same build cutoff (19042+) for this reason (microsoft/vscode#123725).

The fix:
1. Adds `shouldDefaultToNodePty()` function in `shell-utils.ts` that checks Windows build version
2. Returns `false` on Windows builds < 19042, `true` otherwise (including non-Windows platforms)
3. Updates `Config` to use this function instead of hardcoding `true` as the default

This ensures affected Windows systems fall back to spawn-based shell execution, which doesn't rely on ConPTY.

## Reviewer Test Plan

1. On a Windows 10/11 machine with build >= 19042, verify shell commands work normally
2. On older Windows builds (if available), verify commands return output correctly
3. On macOS/Linux, verify no regression in shell command behavior

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2244

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)