### PR TITLE
fix(cli): remove unused debug log session setup in loadSettings

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -14,8 +14,6 @@ import {
   QWEN_DIR,
   getErrorMessage,
   Storage,
-  setDebugLogSession,
-  sanitizeCwd,
   createDebugLogger,
 } from '@qwen-code/qwen-code-core';
 import stripJsonComments from 'strip-json-comments';
@@ -476,16 +474,6 @@ export function loadEnvironment(settings: Settings): void {
 export function loadSettings(
   workspaceDir: string = process.cwd(),
 ): LoadedSettings {
-  // Set up a temporary debug log session for the startup phase.
-  // This allows migration errors to be logged to file instead of being
-  // exposed to users via stderr. The Config class will override this
-  // with the actual session once initialized.
-  const resolvedWorkspaceDir = path.resolve(workspaceDir);
-  const sanitizedProjectId = sanitizeCwd(resolvedWorkspaceDir);
-  setDebugLogSession({
-    getSessionId: () => `startup-${sanitizedProjectId}`,
-  });
-
   let systemSettings: Settings = {};
   let systemDefaultSettings: Settings = {};
   let userSettings: Settings = {};
@@ -496,7 +484,7 @@ export function loadSettings(
   const migratedInMemorScopes = new Set<SettingScope>();
 
   // Resolve paths to their canonical representation to handle symlinks
-  // Note: resolvedWorkspaceDir is already defined at the top of the function
+  const resolvedWorkspaceDir = path.resolve(workspaceDir);
   const resolvedHomeDir = path.resolve(homedir());
 
   let realWorkspaceDir = resolvedWorkspaceDir;


### PR DESCRIPTION
## TLDR

Removes unused debug log session setup code and imports from `loadSettings()` function in `packages/cli/src/config/settings.ts`. This fixes a merge error where dead code was left behind.

## Dive Deeper

The `loadSettings()` function previously had a temporary debug log session setup at the start of the function that was intended to capture migration errors during startup. This setup:

1. Imported `setDebugLogSession` and `sanitizeCwd` from core
2. Created a temporary session with ID `startup-{sanitizedProjectId}`
3. Was supposed to be overridden by the Config class later

However, this code is no longer needed and was causing issues. The fix:
- Removes the unused imports (`setDebugLogSession`, `sanitizeCwd`)
- Removes the temporary debug log session setup block
- Moves `resolvedWorkspaceDir` definition to where it is actually used

## Reviewer Test Plan

1. Pull the branch and run `npm install && npm run build`
2. Verify the build succeeds without errors
3. Run `npm run typecheck` to ensure no type errors
4. Test the CLI starts normally: `npm start -- --help`
5. Verify settings load correctly in a project directory

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

No linked issues

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)