### PR TITLE
fix(insight): handle individual LLM failures in qualitative insights (#2341)

### DIFF
--- a/packages/cli/src/services/insight/generators/DataProcessor.test.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.test.ts
@@ -24,6 +24,7 @@ vi.mock('@qwen-code/qwen-code-core', async () => {
       info: vi.fn(),
       error: vi.fn(),
       warn: vi.fn(),
+      debug: vi.fn(),
     })),
   };
 });
@@ -1134,6 +1135,102 @@ describe('DataProcessor', () => {
       const hasNonEmptyFrictionDetail =
         frictionSection.trim().length > 0 && frictionSection.includes('-');
       expect(hasNonEmptyFrictionDetail).toBe(false);
+    });
+  });
+
+  describe('generateQualitativeInsights', () => {
+    const mockMetrics = {
+      totalSessions: 5,
+      totalMessages: 50,
+      totalHours: 2,
+      heatmap: { '2025-01-15': 3 },
+      topTools: [['read_file', 10]] as Array<[string, number]>,
+      activeDays: 1,
+      activeHours: { '10': 5 },
+      totalLinesAdded: 100,
+      totalLinesRemoved: 50,
+      totalFiles: 10,
+      streak: { currentStreak: 1, longestStreak: 1, dates: [] },
+    } as unknown as Omit<InsightData, 'facets' | 'qualitative'>;
+
+    const mockFacets: SessionFacets[] = [
+      {
+        session_id: 'test-1',
+        underlying_goal: 'Fix bug',
+        goal_categories: { debugging: 1 },
+        outcome: 'fully_achieved',
+        user_satisfaction_counts: { satisfied: 1 },
+        Qwen_helpfulness: 'very_helpful',
+        session_type: 'single_task',
+        friction_counts: {},
+        friction_detail: '',
+        primary_success: 'correct_code_edits',
+        brief_summary: 'Fixed a bug',
+      },
+    ];
+
+    it('should return partial qualitative data when some LLM calls fail', async () => {
+      let callIndex = 0;
+      mockGenerateJson.mockImplementation(() => {
+        callIndex++;
+        if (callIndex % 2 === 0) {
+          return Promise.reject(new Error('LLM timeout'));
+        }
+        return Promise.resolve({ intro: 'test', areas: [], opportunities: [] });
+      });
+
+      const result = await (
+        dataProcessor as unknown as {
+          generateQualitativeInsights(
+            metrics: Omit<InsightData, 'facets' | 'qualitative'>,
+            facets: SessionFacets[],
+          ): Promise<
+            | import('../types/QualitativeInsightTypes.js').QualitativeInsights
+            | undefined
+          >;
+        }
+      ).generateQualitativeInsights(mockMetrics, mockFacets);
+
+      expect(result).toBeDefined();
+      expect(result!.impressiveWorkflows).toBeDefined();
+      expect(result!.projectAreas).toBeUndefined();
+      expect(result!.futureOpportunities).toBeDefined();
+      expect(result!.frictionPoints).toBeUndefined();
+    });
+
+    it('should return undefined when facets are empty', async () => {
+      const result = await (
+        dataProcessor as unknown as {
+          generateQualitativeInsights(
+            metrics: Omit<InsightData, 'facets' | 'qualitative'>,
+            facets: SessionFacets[],
+          ): Promise<
+            | import('../types/QualitativeInsightTypes.js').QualitativeInsights
+            | undefined
+          >;
+        }
+      ).generateQualitativeInsights(mockMetrics, []);
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return full qualitative data when all LLM calls succeed', async () => {
+      mockGenerateJson.mockResolvedValue({ intro: 'test', areas: [] });
+
+      const result = await (
+        dataProcessor as unknown as {
+          generateQualitativeInsights(
+            metrics: Omit<InsightData, 'facets' | 'qualitative'>,
+            facets: SessionFacets[],
+          ): Promise<
+            | import('../types/QualitativeInsightTypes.js').QualitativeInsights
+            | undefined
+          >;
+        }
+      ).generateQualitativeInsights(mockMetrics, mockFacets);
+
+      expect(result).toBeDefined();
+      expect(mockGenerateJson).toHaveBeenCalledTimes(8);
     });
   });
 

--- a/packages/cli/src/services/insight/generators/DataProcessor.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.ts
@@ -388,7 +388,7 @@ export class DataProcessor {
     const generate = async <T>(
       promptTemplate: string,
       schema: Record<string, unknown>,
-    ): Promise<T> => {
+    ): Promise<T | undefined> => {
       const prompt = `${promptTemplate}\n\n${commonData}`;
       try {
         const result = await this.config.getBaseLlmClient().generateJson({
@@ -400,7 +400,7 @@ export class DataProcessor {
         return result as T;
       } catch (error) {
         logger.error('Failed to generate insight:', error);
-        throw error;
+        return undefined;
       }
     };
 

--- a/packages/cli/src/services/insight/types/QualitativeInsightTypes.ts
+++ b/packages/cli/src/services/insight/types/QualitativeInsightTypes.ts
@@ -71,12 +71,12 @@ export interface InsightAtAGlance {
 }
 
 export interface QualitativeInsights {
-  impressiveWorkflows: InsightImpressiveWorkflows;
-  projectAreas: InsightProjectAreas;
-  futureOpportunities: InsightFutureOpportunities;
-  frictionPoints: InsightFrictionPoints;
-  memorableMoment: InsightMemorableMoment;
-  improvements: InsightImprovements;
-  interactionStyle: InsightInteractionStyle;
-  atAGlance: InsightAtAGlance;
+  impressiveWorkflows?: InsightImpressiveWorkflows;
+  projectAreas?: InsightProjectAreas;
+  futureOpportunities?: InsightFutureOpportunities;
+  frictionPoints?: InsightFrictionPoints;
+  memorableMoment?: InsightMemorableMoment;
+  improvements?: InsightImprovements;
+  interactionStyle?: InsightInteractionStyle;
+  atAGlance?: InsightAtAGlance;
 }


### PR DESCRIPTION
Fixes #2341

## Root Cause

`generateQualitativeInsights` runs 8 parallel LLM calls via `Promise.all`. The inner `generate` helper re-throws errors, so a **single** LLM call failure (timeout, rate limit, JSON parse error) rejects the entire `Promise.all`, catches at the outer `try/catch`, and returns `undefined` for the whole `qualitative` object.

In the React report, every detailed section is gated by `{data.qualitative && (...)}` — so when `qualitative` is `undefined`, **all** sections disappear. Only the header and stats row survive.

## Fix

- **`DataProcessor.ts`**: Changed the `generate` helper to catch errors and return `undefined` instead of re-throwing. Individual LLM call failures no longer crash the entire qualitative section — surviving calls still populate their sections.
- **`QualitativeInsightTypes.ts`**: Made all fields on `QualitativeInsights` optional so partial results are type-safe.
- Each React section component already handles missing data (`if (!field) return null`), so no frontend changes needed.

## Test

Added 3 unit tests:
- Partial failure: some LLM calls fail → `qualitative` is defined, failed sections are `undefined`, successful sections populate
- Empty facets: returns `undefined` as before
- Full success: all 8 calls succeed, `qualitative` is complete

Made with [Cursor](https://cursor.com)