### PR TITLE
fix(core): add deepseek-r1 to output token limit patterns

### DIFF
--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -284,6 +284,8 @@ describe('tokenLimit with output type', () => {
   describe('other output limits', () => {
     it('should return correct output limits for DeepSeek', () => {
       expect(tokenLimit('deepseek-reasoner', 'output')).toBe(65536);
+      expect(tokenLimit('deepseek-r1', 'output')).toBe(65536);
+      expect(tokenLimit('deepseek-r1-0528', 'output')).toBe(65536);
       expect(tokenLimit('deepseek-chat', 'output')).toBe(8192);
     });
 

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -169,6 +169,7 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
 
   // DeepSeek
   [/^deepseek-reasoner/, LIMITS['64k']],
+  [/^deepseek-r1/, LIMITS['64k']],
   [/^deepseek-chat/, LIMITS['8k']],
 
   // Zhipu GLM


### PR DESCRIPTION
## Summary

`deepseek-r1` normalizes to `deepseek-r1` which does not match the existing `^deepseek-reasoner` output pattern in `tokenLimits.ts`. It falls through all `OUTPUT_PATTERNS` and gets the 8K default output limit. DeepSeek R1 is a reasoning model with 64K output capacity — the same as `deepseek-reasoner`, which it's an alias for.

This causes silent response truncation for users running `deepseek-r1` through OpenAI-compatible providers.

## Fix

Added `[/^deepseek-r1/, LIMITS['64k']]` to `OUTPUT_PATTERNS`, placed before the `deepseek-chat` fallback.

## Test

Added test assertions for `deepseek-r1` and `deepseek-r1-0528` (date-suffixed variant) to confirm 64K output limit.

Made with [Cursor](https://cursor.com)