### PR TITLE
fix(cli): `/memory show --project` and `--global` now display all configured context files

### DIFF
--- a/packages/cli/src/ui/commands/memoryCommand.test.ts
+++ b/packages/cli/src/ui/commands/memoryCommand.test.ts
@@ -168,6 +168,116 @@ describe('memoryCommand', () => {
         expect.any(Number),
       );
     });
+
+    it('should fall back to AGENTS.md when QWEN.md does not exist for --project', async () => {
+      const projectCommand = showCommand.subCommands?.find(
+        (cmd) => cmd.name === '--project',
+      );
+      if (!projectCommand?.action) throw new Error('Command has no action');
+
+      setGeminiMdFilename(['QWEN.md', 'AGENTS.md']);
+      vi.spyOn(process, 'cwd').mockReturnValue('/test/project');
+      mockReadFile.mockImplementation(async (filePath: string) => {
+        if (filePath.endsWith('AGENTS.md')) return 'agents memory content';
+        throw new Error('ENOENT');
+      });
+
+      await projectCommand.action(mockContext, '');
+
+      const expectedPath = path.join('/test/project', 'AGENTS.md');
+      expect(mockReadFile).toHaveBeenCalledWith(expectedPath, 'utf-8');
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: expect.stringContaining('agents memory content'),
+        },
+        expect.any(Number),
+      );
+    });
+
+    it('should fall back to AGENTS.md when QWEN.md does not exist for --global', async () => {
+      const globalCommand = showCommand.subCommands?.find(
+        (cmd) => cmd.name === '--global',
+      );
+      if (!globalCommand?.action) throw new Error('Command has no action');
+
+      setGeminiMdFilename(['QWEN.md', 'AGENTS.md']);
+      vi.spyOn(os, 'homedir').mockReturnValue('/home/user');
+      mockReadFile.mockImplementation(async (filePath: string) => {
+        if (filePath.endsWith('AGENTS.md')) return 'global agents memory';
+        throw new Error('ENOENT');
+      });
+
+      await globalCommand.action(mockContext, '');
+
+      const expectedPath = path.join('/home/user', QWEN_DIR, 'AGENTS.md');
+      expect(mockReadFile).toHaveBeenCalledWith(expectedPath, 'utf-8');
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: expect.stringContaining('global agents memory'),
+        },
+        expect.any(Number),
+      );
+    });
+
+    it('should show content from both QWEN.md and AGENTS.md for --project when both exist', async () => {
+      const projectCommand = showCommand.subCommands?.find(
+        (cmd) => cmd.name === '--project',
+      );
+      if (!projectCommand?.action) throw new Error('Command has no action');
+
+      setGeminiMdFilename(['QWEN.md', 'AGENTS.md']);
+      vi.spyOn(process, 'cwd').mockReturnValue('/test/project');
+      mockReadFile.mockImplementation(async (filePath: string) => {
+        if (filePath.endsWith('QWEN.md')) return 'qwen memory';
+        if (filePath.endsWith('AGENTS.md')) return 'agents memory';
+        throw new Error('ENOENT');
+      });
+
+      await projectCommand.action(mockContext, '');
+
+      expect(mockReadFile).toHaveBeenCalledWith(
+        path.join('/test/project', 'QWEN.md'),
+        'utf-8',
+      );
+      expect(mockReadFile).toHaveBeenCalledWith(
+        path.join('/test/project', 'AGENTS.md'),
+        'utf-8',
+      );
+      const addItemCall = (mockContext.ui.addItem as Mock).mock.calls[0][0];
+      expect(addItemCall.text).toContain('qwen memory');
+      expect(addItemCall.text).toContain('agents memory');
+    });
+
+    it('should show content from both files for --global when both exist', async () => {
+      const globalCommand = showCommand.subCommands?.find(
+        (cmd) => cmd.name === '--global',
+      );
+      if (!globalCommand?.action) throw new Error('Command has no action');
+
+      setGeminiMdFilename(['QWEN.md', 'AGENTS.md']);
+      vi.spyOn(os, 'homedir').mockReturnValue('/home/user');
+      mockReadFile.mockImplementation(async (filePath: string) => {
+        if (filePath.endsWith('QWEN.md')) return 'global qwen memory';
+        if (filePath.endsWith('AGENTS.md')) return 'global agents memory';
+        throw new Error('ENOENT');
+      });
+
+      await globalCommand.action(mockContext, '');
+
+      expect(mockReadFile).toHaveBeenCalledWith(
+        path.join('/home/user', QWEN_DIR, 'QWEN.md'),
+        'utf-8',
+      );
+      expect(mockReadFile).toHaveBeenCalledWith(
+        path.join('/home/user', QWEN_DIR, 'AGENTS.md'),
+        'utf-8',
+      );
+      const addItemCall = (mockContext.ui.addItem as Mock).mock.calls[0][0];
+      expect(addItemCall.text).toContain('global qwen memory');
+      expect(addItemCall.text).toContain('global agents memory');
+    });
   });
 
   describe('/memory add', () => {

--- a/packages/cli/src/ui/commands/memoryCommand.ts
+++ b/packages/cli/src/ui/commands/memoryCommand.ts
@@ -6,7 +6,7 @@
 
 import {
   getErrorMessage,
-  getCurrentGeminiMdFilename,
+  getAllGeminiMdFilenames,
   loadServerHierarchicalMemory,
   QWEN_DIR,
 } from '@qwen-code/qwen-code-core';
@@ -17,6 +17,28 @@ import { MessageType } from '../types.js';
 import type { SlashCommand, SlashCommandActionReturn } from './types.js';
 import { CommandKind } from './types.js';
 import { t } from '../../i18n/index.js';
+
+/**
+ * Read all existing memory files from the configured filenames in a directory.
+ * Returns an array of found files with their paths and contents.
+ */
+async function findAllExistingMemoryFiles(
+  dir: string,
+): Promise<Array<{ filePath: string; content: string }>> {
+  const results: Array<{ filePath: string; content: string }> = [];
+  for (const filename of getAllGeminiMdFilenames()) {
+    const filePath = path.join(dir, filename);
+    try {
+      const content = await fs.readFile(filePath, 'utf-8');
+      if (content.trim().length > 0) {
+        results.push({ filePath, content });
+      }
+    } catch {
+      // File doesn't exist, try next
+    }
+  }
+  return results;
+}
 
 export const memoryCommand: SlashCommand = {
   name: 'memory',
@@ -56,37 +78,27 @@ export const memoryCommand: SlashCommand = {
           },
           kind: CommandKind.BUILT_IN,
           action: async (context) => {
-            try {
-              const workingDir =
-                context.services.config?.getWorkingDir?.() ?? process.cwd();
-              const projectMemoryPath = path.join(
-                workingDir,
-                getCurrentGeminiMdFilename(),
-              );
-              const memoryContent = await fs.readFile(
-                projectMemoryPath,
-                'utf-8',
-              );
+            const workingDir =
+              context.services.config?.getWorkingDir?.() ?? process.cwd();
+            const results = await findAllExistingMemoryFiles(workingDir);
 
-              const messageContent =
-                memoryContent.trim().length > 0
-                  ? t(
-                      'Project memory content from {{path}}:\n\n---\n{{content}}\n---',
-                      {
-                        path: projectMemoryPath,
-                        content: memoryContent,
-                      },
-                    )
-                  : t('Project memory is currently empty.');
-
+            if (results.length > 0) {
+              const combined = results
+                .map((r) =>
+                  t(
+                    'Project memory content from {{path}}:\n\n---\n{{content}}\n---',
+                    { path: r.filePath, content: r.content },
+                  ),
+                )
+                .join('\n\n');
               context.ui.addItem(
                 {
                   type: MessageType.INFO,
-                  text: messageContent,
+                  text: combined,
                 },
                 Date.now(),
               );
-            } catch (_error) {
+            } else {
               context.ui.addItem(
                 {
                   type: MessageType.INFO,
@@ -106,32 +118,25 @@ export const memoryCommand: SlashCommand = {
           },
           kind: CommandKind.BUILT_IN,
           action: async (context) => {
-            try {
-              const globalMemoryPath = path.join(
-                os.homedir(),
-                QWEN_DIR,
-                getCurrentGeminiMdFilename(),
-              );
-              const globalMemoryContent = await fs.readFile(
-                globalMemoryPath,
-                'utf-8',
-              );
+            const globalDir = path.join(os.homedir(), QWEN_DIR);
+            const results = await findAllExistingMemoryFiles(globalDir);
 
-              const messageContent =
-                globalMemoryContent.trim().length > 0
-                  ? t('Global memory content:\n\n---\n{{content}}\n---', {
-                      content: globalMemoryContent,
-                    })
-                  : t('Global memory is currently empty.');
-
+            if (results.length > 0) {
+              const combined = results
+                .map((r) =>
+                  t('Global memory content:\n\n---\n{{content}}\n---', {
+                    content: r.content,
+                  }),
+                )
+                .join('\n\n');
               context.ui.addItem(
                 {
                   type: MessageType.INFO,
-                  text: messageContent,
+                  text: combined,
                 },
                 Date.now(),
               );
-            } catch (_error) {
+            } else {
               context.ui.addItem(
                 {
                   type: MessageType.INFO,


### PR DESCRIPTION
## TLDR

`/memory show --project` and `/memory show --global` only checked the first filename (`QWEN.md`) from the configured context files array, ignoring `AGENTS.md`. After #2018 added multi-file support (`['QWEN.md', 'AGENTS.md']`), these commands would report empty when only `AGENTS.md` existed, even though the actual loading mechanism (`loadServerHierarchicalMemory`) correctly loaded it.

## Dive Deeper

The root cause is that `getCurrentGeminiMdFilename()` returns only the first element of the configured filenames array. While #1428 fixed the hardcoded `QWEN.md` by using this function, it still only reads one file — insufficient after #2018 introduced the multi-filename array.

**Changes:**
- Replace `getCurrentGeminiMdFilename()` with `getAllGeminiMdFilenames()` in `memoryCommand.ts`
- Add `findAllExistingMemoryFiles()` helper that iterates all configured filenames and aggregates content from all existing files
- Update both `--project` and `--global` subcommands to display content from all found memory files
- Add tests for fallback (only `AGENTS.md` exists) and dual-file scenarios (both `QWEN.md` and `AGENTS.md` exist)

## Reviewer Test Plan

1. Create only an `AGENTS.md` file (no `QWEN.md`) in a project directory
2. Run `qwen` and execute `/memory show --project` — should display `AGENTS.md` content (previously showed empty)
3. Create both `QWEN.md` and `AGENTS.md` — should display content from both files
4. Run `/memory show` (without flags) — should still work as before (reads from cached aggregated memory)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to #968 (memory display inconsistency)
Related to #727 (context.fileName not respected — partially fixed by #1428, this PR completes the fix for multi-file case)

---

🤖 Generated with Qoder