### PR TITLE
fix(cli): allow /dev/ptmx and /dev/ttys* in macOS permissive sandbox

### DIFF
--- a/packages/cli/src/utils/sandbox-macos-permissive-open.sb
+++ b/packages/cli/src/utils/sandbox-macos-permissive-open.sb
@@ -22,4 +22,6 @@
     (literal "/dev/stdout")
     (literal "/dev/stderr")
     (literal "/dev/null")
+    (literal "/dev/ptmx")
+    (regex #"^/dev/ttys[0-9]*$")
 )


### PR DESCRIPTION
## Summary
- add /dev/ptmx to sandbox-macos-permissive-open.sb write allowlist
- add ^/dev/ttys[0-9]*$ regex rule for interactive PTY slave device paths

## Why
qwen-code now supports interactive CLI workflows and hits the same macOS sandbox PTY write restriction described in https://github.com/google-gemini/gemini-cli/issues/11402.

This aligns permissive-open sandbox behavior with interactive terminal device usage on macOS.