### PR TITLE
Add voice and image input features

### DIFF
--- a/packages/webui/src/components/icons/MicrophoneIcon.tsx
+++ b/packages/webui/src/components/icons/MicrophoneIcon.tsx
@@ -1,0 +1,35 @@
+/**
+ * Microphone icon for voice input
+ */
+
+import type { FC, SVGProps } from 'react';
+
+export interface MicrophoneIconProps extends SVGProps<SVGSVGElement> {
+  size?: number;
+}
+
+export const MicrophoneIcon: FC<MicrophoneIconProps> = ({
+  size = 16,
+  className = '',
+  ...props
+}) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      {...props}
+    >
+      <path d="M12 1a3 3 0 0 0-3 3v8a3 3 0 0 0 6 0V4a3 3 0 0 0-3-3z" />
+      <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+      <line x1="12" y1="19" x2="12" y2="23" />
+      <line x1="8" y1="23" x2="16" y2="23" />
+    </svg>
+  );
+};

--- a/packages/webui/src/components/icons/index.ts
+++ b/packages/webui/src/components/icons/index.ts
@@ -58,3 +58,6 @@ export { ThinkingIcon, TerminalIcon } from './SpecialIcons.js';
 
 // Stop icon
 export { StopIcon } from './StopIcon.js';
+
+// Microphone icon (for voice input)
+export { MicrophoneIcon } from './MicrophoneIcon.js';

--- a/packages/webui/src/components/layout/ImagePreview.tsx
+++ b/packages/webui/src/components/layout/ImagePreview.tsx
@@ -1,0 +1,138 @@
+/**
+ * Image preview component
+ * 
+ * Shows thumbnails of pasted images with a remove button.
+ */
+
+import type { FC } from 'react';
+import { PastedImage } from '../hooks/useImagePaste';
+import { CloseIcon } from '../icons/CloseIcon';
+
+export interface ImagePreviewProps {
+  image: PastedImage;
+  isProcessing?: boolean;
+  onRemove: (imageId: string) => void;
+  showRemove?: boolean;
+}
+
+export const ImagePreview: FC<ImagePreviewProps> = ({
+  image,
+  isProcessing = false,
+  onRemove,
+  showRemove = true,
+}) => {
+  const handleRemove = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    onRemove(image.id);
+  };
+
+  return (
+    <div
+      className={`
+        relative inline-block
+        border border-gray-300 dark:border-gray-600
+        rounded-lg overflow-hidden
+        bg-gray-50 dark:bg-gray-800
+        transition-all duration-200
+        ${isProcessing ? 'opacity-50 animate-pulse' : 'opacity-100'}
+        hover:shadow-md
+      `}
+      title={image.fileName || 'Pasted image'}
+    >
+      <img
+        src={image.dataUrl}
+        alt={image.fileName || 'Pasted image'}
+        className="w-20 h-20 object-cover"
+        loading="lazy"
+      />
+
+      {isProcessing && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-30">
+          <div className="w-6 h-6 border-2 border-white border-t-transparent rounded-full animate-spin" />
+        </div>
+      )}
+
+      {showRemove && (
+        <button
+          type="button"
+          onClick={handleRemove}
+          className="
+            absolute top-1 right-1
+            w-5 h-5 flex items-center justify-center
+            bg-red-500 hover:bg-red-600
+            text-white rounded-full
+            opacity-0 group-hover:opacity-100
+            transition-opacity duration-200
+            focus:opacity-100
+          "
+          title="Remove image"
+          aria-label="Remove image"
+        >
+          <CloseIcon size={12} />
+        </button>
+      )}
+
+      <div
+        className="
+          absolute bottom-0 left-0 right-0
+          bg-black bg-opacity-75
+          text-white text-xs
+          px-2 py-1
+          opacity-0 hover:opacity-100
+          transition-opacity duration-200
+          truncate
+        "
+      >
+        {image.fileName || 'image'}
+        {image.size && ` (${formatFileSize(image.size)})`}
+      </div>
+    </div>
+  );
+};
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  } else if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  } else {
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  }
+}
+
+export interface ImagePreviewListProps {
+  images: PastedImage[];
+  isProcessing?: boolean;
+  onRemove: (imageId: string) => void;
+}
+
+export const ImagePreviewList: FC<ImagePreviewListProps> = ({
+  images,
+  isProcessing = false,
+  onRemove,
+}) => {
+  if (images.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="
+        flex flex-wrap gap-2
+        p-2
+        border-t border-gray-200 dark:border-gray-700
+        bg-gray-50 dark:bg-gray-900
+      "
+    >
+      {images.map((image) => (
+        <div key={image.id} className="group">
+          <ImagePreview
+            image={image}
+            isProcessing={isProcessing}
+            onRemove={onRemove}
+          />
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/packages/webui/src/components/layout/InputForm.tsx
+++ b/packages/webui/src/components/layout/InputForm.tsx
@@ -9,6 +9,7 @@
 
 import type { FC } from 'react';
 import type { ReactNode } from 'react';
+import { useState, useEffect } from 'react';
 import {
   EditPencilIcon,
   AutoEditIcon,
@@ -18,8 +19,10 @@ import { CodeBracketsIcon, HideContextIcon } from '../icons/EditIcons.js';
 import { SlashCommandIcon, LinkIcon } from '../icons/EditIcons.js';
 import { ArrowUpIcon } from '../icons/NavigationIcons.js';
 import { StopIcon } from '../icons/StopIcon.js';
+import { MicrophoneIcon } from '../icons/MicrophoneIcon.js';
 import { CompletionMenu } from './CompletionMenu.js';
 import { ContextIndicator } from './ContextIndicator.js';
+import { ImagePreviewList, type PastedImage } from './ImagePreview.js';
 import type { CompletionItem } from '../../types/completion.js';
 import type { ContextUsage } from './ContextIndicator.js';
 
@@ -117,6 +120,26 @@ export interface InputFormProps {
   onCompletionClose?: () => void;
   /** Placeholder text */
   placeholder?: string;
+  /** Voice input: whether voice is currently listening */
+  isVoiceListening?: boolean;
+  /** Voice input: whether speech recognition is supported */
+  isVoiceSupported?: boolean;
+  /** Voice input: whether voice input has an error */
+  hasVoiceError?: boolean;
+  /** Voice input: callback to start listening */
+  onStartVoiceListening?: () => void;
+  /** Voice input: callback to stop listening */
+  onStopVoiceListening?: () => void;
+  /** Image paste: list of pasted images */
+  pastedImages?: PastedImage[];
+  /** Image paste: callback to remove image */
+  onRemoveImage?: (imageId: string) => void;
+  /** Image paste: whether images are being processed */
+  isProcessingImages?: boolean;
+  /** Drag and drop handler */
+  onDrop?: (event: React.DragEvent) => void;
+  /** Drag over handler */
+  onDragOver?: (event: React.DragEvent) => void;
 }
 
 /**
@@ -172,6 +195,18 @@ export const InputForm: FC<InputFormProps> = ({
   onCompletionSelect,
   onCompletionClose,
   placeholder = 'Ask Qwen Code …',
+  // Voice input props
+  isVoiceListening = false,
+  isVoiceSupported = false,
+  hasVoiceError = false,
+  onStartVoiceListening,
+  onStopVoiceListening,
+  // Image paste props
+  pastedImages = [],
+  onRemoveImage,
+  isProcessingImages = false,
+  onDrop,
+  onDragOver,
 }) => {
   const composerDisabled = isStreaming || isWaitingForResponse;
   const completionItemsResolved = completionItems ?? [];
@@ -230,7 +265,7 @@ export const InputForm: FC<InputFormProps> = ({
   return (
     <div className="p-1 px-4 pb-4 absolute bottom-0 left-0 right-0 bg-gradient-to-b from-transparent to-[var(--app-primary-background)]">
       <div className="block">
-        <form className="composer-form" onSubmit={onSubmit}>
+        <form className="composer-form" onSubmit={onSubmit} onDrop={onDrop} onDragOver={onDragOver}>
           {/* Inner background layer */}
           <div className="composer-overlay" />
 
@@ -255,8 +290,6 @@ export const InputForm: FC<InputFormProps> = ({
               aria-label="Message input"
               aria-multiline="true"
               data-placeholder={placeholder}
-              // Use a data flag so CSS can show placeholder even if the browser
-              // inserts an invisible <br> into contentEditable (so :empty no longer matches)
               data-empty={
                 inputText.replace(/\u200B/g, '').trim().length === 0
                   ? 'true'
@@ -264,7 +297,6 @@ export const InputForm: FC<InputFormProps> = ({
               }
               onInput={(e) => {
                 const target = e.target as HTMLDivElement;
-                // Filter out zero-width space that we use to maintain height
                 const text = target.textContent?.replace(/\u200B/g, '') || '';
                 onInputChange(text);
               }}
@@ -274,6 +306,15 @@ export const InputForm: FC<InputFormProps> = ({
               suppressContentEditableWarning
             />
           </div>
+
+          {/* Image previews */}
+          {pastedImages.length > 0 && onRemoveImage && (
+            <ImagePreviewList
+              images={pastedImages}
+              isProcessing={isProcessingImages}
+              onRemove={onRemoveImage}
+            />
+          )}
 
           <div className="composer-actions">
             {/* Edit mode button */}
@@ -337,6 +378,25 @@ export const InputForm: FC<InputFormProps> = ({
             >
               <LinkIcon />
             </button>
+
+            {/* Voice input button */}
+            {isVoiceSupported && onStartVoiceListening && onStopVoiceListening && (
+              <button
+                type="button"
+                className={`btn-icon-compact ${
+                  isVoiceListening
+                    ? 'text-red-500 hover:text-red-600 animate-pulse'
+                    : hasVoiceError
+                      ? 'text-orange-500 hover:text-orange-600'
+                      : 'hover:text-[var(--app-primary-foreground)]'
+                }`}
+                title={isVoiceListening ? 'Stop recording' : hasVoiceError ? 'Microphone error - click to retry' : 'Voice input'}
+                aria-label={isVoiceListening ? 'Stop recording' : 'Voice input'}
+                onClick={isVoiceListening ? onStopVoiceListening : onStartVoiceListening}
+              >
+                <MicrophoneIcon />
+              </button>
+            )}
 
             {/* Send/Stop button */}
             {isStreaming || isWaitingForResponse ? (

--- a/packages/webui/src/components/layout/VoiceInputButton.tsx
+++ b/packages/webui/src/components/layout/VoiceInputButton.tsx
@@ -1,0 +1,94 @@
+/**
+ * Microphone button for voice input
+ * 
+ * Shows a mic button that pulses red when recording.
+ * Click to start/stop voice input.
+ */
+
+import type { FC } from 'react';
+import { MicrophoneIcon } from '../icons/MicrophoneIcon.js';
+import { StopIcon } from '../icons/StopIcon.js';
+
+/**
+ * Props for VoiceInputButton component
+ */
+export interface VoiceInputButtonProps {
+  /** Whether voice input is currently listening */
+  isListening: boolean;
+  /** Whether speech recognition is supported */
+  isSupported: boolean;
+  /** Whether an error occurred */
+  hasError: boolean;
+  /** Callback to start listening */
+  onStartListening: () => void;
+  /** Callback to stop listening */
+  onStopListening: () => void;
+}
+
+/**
+ * VoiceInputButton component
+ */
+export const VoiceInputButton: FC<VoiceInputButtonProps> = ({
+  isListening,
+  isSupported,
+  hasError,
+  onStartListening,
+  onStopListening,
+}) => {
+  const handleClick = () => {
+    if (isListening) {
+      onStopListening();
+    } else {
+      onStartListening();
+    }
+  };
+
+  // Don't render if not supported
+  if (!isSupported) {
+    return null;
+  }
+
+  return (
+    <div className={`relative group`}>
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={!isSupported}
+        className={`
+          flex items-center justify-center
+          w-8 h-8 rounded-md
+          transition-all duration-200
+          focus:outline-none focus:ring-2 focus:ring-offset-1
+          ${
+            isListening
+              ? 'bg-red-500 hover:bg-red-600 text-white animate-pulse'
+              : hasError
+                ? 'bg-orange-500 hover:bg-orange-600 text-white'
+                : 'bg-gray-100 hover:bg-gray-200 dark:bg-gray-700 dark:hover:bg-gray-600 text-gray-600 dark:text-gray-300'
+          }
+          disabled:opacity-50 disabled:cursor-not-allowed
+        `}
+        title={isListening ? 'Stop recording' : hasVoiceError ? 'Microphone error - click to retry' : 'Voice input'}
+        aria-label={isListening ? 'Stop recording' : 'Voice input'}
+      >
+        {isListening ? (
+          <StopIcon className="w-4 h-4" />
+        ) : (
+          <MicrophoneIcon className="w-4 h-4" />
+        )}
+      </button>
+
+      {/* Tooltip */}
+      <div
+        className={`
+          absolute px-2 py-1 text-xs font-medium text-white bg-gray-900 rounded
+          opacity-0 group-hover:opacity-100 transition-opacity duration-200
+          pointer-events-none whitespace-nowrap z-50
+          bottom-full left-1/2 -translate-x-1/2 mb-2
+        `}
+      >
+        {isListening ? 'Stop recording' : 'Voice input'}
+      </div>
+    </div>
+  );
+};

--- a/packages/webui/src/hooks/useImagePaste.ts
+++ b/packages/webui/src/hooks/useImagePaste.ts
@@ -1,0 +1,287 @@
+/**
+ * Image paste hook - handles clipboard and drag-drop images
+ * 
+ * Lets users paste images with Ctrl+V or drag them in.
+ * Converts to base64 so they can be sent with messages.
+ */
+
+import { useState, useCallback, useEffect } from 'react';
+
+/**
+ * Image data from paste or drop
+ */
+export interface PastedImage {
+  /** Unique identifier for the image */
+  id: string;
+  /** Base64 encoded image data */
+  dataUrl: string;
+  /** File name if available */
+  fileName?: string;
+  /** MIME type (e.g., 'image/png', 'image/jpeg') */
+  mimeType: string;
+  /** File size in bytes */
+  size?: number;
+  /** Source of the image */
+  source: 'clipboard' | 'drag-drop' | 'file-input';
+}
+
+/**
+ * Image paste state
+ */
+export interface ImagePasteState {
+  /** Whether images are currently being processed */
+  isProcessing: boolean;
+  /** List of pasted images */
+  images: PastedImage[];
+  /** Error message if any */
+  error: string | null;
+  /** Whether an error occurred */
+  hasError: boolean;
+}
+
+/**
+ * Convert File to base64 Data URL
+ */
+function fileToDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+/**
+ * Extract images from clipboard items
+ */
+async function extractImagesFromClipboard(
+  items: DataTransferItemList,
+): Promise<PastedImage[]> {
+  const images: PastedImage[] = [];
+
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+
+    if (item.type.startsWith('image/')) {
+      const file = item.getAsFile();
+      if (file) {
+        const dataUrl = await fileToDataUrl(file);
+        images.push({
+          id: `clipboard-${Date.now()}-${i}`,
+          dataUrl,
+          fileName: file.name || `pasted-image-${i}.png`,
+          mimeType: item.type,
+          size: file.size,
+          source: 'clipboard',
+        });
+      }
+    }
+  }
+
+  return images;
+}
+
+/**
+ * Extract images from drag-and-drop
+ */
+async function extractImagesFromDrop(
+  files: FileList,
+): Promise<PastedImage[]> {
+  const images: PastedImage[] = [];
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i];
+
+    if (file.type.startsWith('image/')) {
+      const dataUrl = await fileToDataUrl(file);
+      images.push({
+        id: `drop-${Date.now()}-${i}`,
+        dataUrl,
+        fileName: file.name,
+        mimeType: file.type,
+        size: file.size,
+        source: 'drag-drop',
+      });
+    }
+  }
+
+  return images;
+}
+
+/**
+ * Image paste hook
+ *
+ * Provides clipboard image paste and drag-and-drop support
+ */
+export function useImagePaste() {
+  const [state, setState] = useState<ImagePasteState>({
+    isProcessing: false,
+    images: [],
+    error: null,
+    hasError: false,
+  });
+
+  /**
+   * Handle paste event (Ctrl+V)
+   */
+  const handlePaste = useCallback(
+    async (event: ClipboardEvent) => {
+      const items = event.clipboardData?.items;
+
+      if (!items) {
+        return;
+      }
+
+      // Check if clipboard contains images
+      const hasImages = Array.from(items).some((item) =>
+        item.type.startsWith('image/'),
+      );
+
+      if (!hasImages) {
+        return; // Let default paste handling occur
+      }
+
+      event.preventDefault();
+      setState((prev) => ({ ...prev, isProcessing: true }));
+
+      try {
+        const images = await extractImagesFromClipboard(items);
+
+        setState((prev) => ({
+          ...prev,
+          images: [...prev.images, ...images],
+          isProcessing: false,
+          hasError: false,
+          error: null,
+        }));
+      } catch (error) {
+        setState((prev) => ({
+          ...prev,
+          isProcessing: false,
+          hasError: true,
+          error:
+            error instanceof Error
+              ? error.message
+              : 'Failed to process image from clipboard',
+        }));
+      }
+    },
+    [],
+  );
+
+  /**
+   * Handle drag-and-drop event
+   */
+  const handleDrop = useCallback(
+    async (event: React.DragEvent) => {
+      const files = event.dataTransfer?.files;
+
+      if (!files || files.length === 0) {
+        return;
+      }
+
+      // Check if any files are images
+      const hasImages = Array.from(files).some((file) =>
+        file.type.startsWith('image/'),
+      );
+
+      if (!hasImages) {
+        return; // Let default drop handling occur
+      }
+
+      event.preventDefault();
+      setState((prev) => ({ ...prev, isProcessing: true }));
+
+      try {
+        const images = await extractImagesFromDrop(files);
+
+        setState((prev) => ({
+          ...prev,
+          images: [...prev.images, ...images],
+          isProcessing: false,
+          hasError: false,
+          error: null,
+        }));
+      } catch (error) {
+        setState((prev) => ({
+          ...prev,
+          isProcessing: false,
+          hasError: true,
+          error:
+            error instanceof Error
+              ? error.message
+              : 'Failed to process dropped image',
+        }));
+      }
+    },
+    [],
+  );
+
+  /**
+   * Handle drag over event (required for drop to work)
+   */
+  const handleDragOver = useCallback((event: React.DragEvent) => {
+    event.preventDefault();
+  }, []);
+
+  /**
+   * Clear all pasted images
+   */
+  const clearImages = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      images: [],
+      hasError: false,
+      error: null,
+    }));
+  }, []);
+
+  /**
+   * Remove a specific image by ID
+   */
+  const removeImage = useCallback((imageId: string) => {
+    setState((prev) => ({
+      ...prev,
+      images: prev.images.filter((img) => img.id !== imageId),
+    }));
+  }, []);
+
+  /**
+   * Set images directly (for file input)
+   */
+  const setImages = useCallback((newImages: PastedImage[]) => {
+    setState((prev) => ({
+      ...prev,
+      images: [...prev.images, ...newImages],
+    }));
+  }, []);
+
+  // Register clipboard paste listener
+  useEffect(() => {
+    const handlePasteEvent = (event: ClipboardEvent) => {
+      handlePaste(event);
+    };
+
+    document.addEventListener('paste', handlePasteEvent);
+
+    return () => {
+      document.removeEventListener('paste', handlePasteEvent);
+    };
+  }, [handlePaste]);
+
+  return {
+    // State
+    images: state.images,
+    isProcessing: state.isProcessing,
+    error: state.error,
+    hasError: state.hasError,
+
+    // Handlers
+    handlePaste,
+    handleDrop,
+    handleDragOver,
+    clearImages,
+    removeImage,
+    setImages,
+  };
+}

--- a/packages/webui/src/hooks/useVoiceInput.ts
+++ b/packages/webui/src/hooks/useVoiceInput.ts
@@ -1,0 +1,290 @@
+/**
+ * Voice recognition hook for speech-to-text
+ * 
+ * Simple hook that handles voice recording and transcription
+ * using the browser's built-in Web Speech API.
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+// Type definitions for Web Speech API
+interface SpeechRecognitionEvent extends Event {
+  results: SpeechRecognitionResultList;
+  resultIndex: number;
+}
+
+interface SpeechRecognitionResultList {
+  length: number;
+  item(index: number): SpeechRecognitionResult;
+  [index: number]: SpeechRecognitionResult;
+}
+
+interface SpeechRecognitionResult {
+  isFinal: boolean;
+  length: number;
+  item(index: number): SpeechRecognitionAlternative;
+  [index: number]: SpeechRecognitionAlternative;
+}
+
+interface SpeechRecognitionAlternative {
+  transcript: string;
+  confidence: number;
+}
+
+interface SpeechRecognition extends EventTarget {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  start(): void;
+  stop(): void;
+  abort(): void;
+  onstart: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onend: ((this: SpeechRecognition, ev: Event) => void) | null;
+  onresult: ((this: SpeechRecognition, ev: SpeechRecognitionEvent) => void) | null;
+  onerror: ((this: SpeechRecognition, ev: Event) => void) | null;
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognition;
+  prototype: SpeechRecognition;
+}
+
+// Global type augmentation for browser support
+declare global {
+  interface Window {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  }
+}
+
+/**
+ * Voice input state
+ */
+export interface VoiceInputState {
+  /** Whether voice is currently recording */
+  isListening: boolean;
+  /** Current transcribed text */
+  transcript: string;
+  /** Whether browser supports speech recognition */
+  isSupported: boolean;
+  /** Error message if something went wrong */
+  error: string | null;
+  /** Whether an error occurred */
+  hasError: boolean;
+}
+
+/**
+ * Voice input hook
+ * 
+ * Provides speech-to-text using the Web Speech API.
+ * Works in Chrome, Edge, and VS Code Desktop.
+ * 
+ * @returns Voice input state and controls
+ */
+export function useVoiceInput() {
+  const [state, setState] = useState<VoiceInputState>({
+    isListening: false,
+    transcript: '',
+    isSupported: false,
+    error: null,
+    hasError: false,
+  });
+
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+
+  // Initialize speech recognition on mount
+  useEffect(() => {
+    const SpeechRecognition =
+      window.SpeechRecognition || window.webkitSpeechRecognition;
+
+    if (!SpeechRecognition) {
+      setState((prev) => ({
+        ...prev,
+        isSupported: false,
+        error: 'Speech recognition is not supported in this browser',
+      }));
+      return;
+    }
+
+    try {
+      const recognition = new SpeechRecognition();
+      recognitionRef.current = recognition;
+
+      // Configure recognition
+      recognition.continuous = true;
+      recognition.interimResults = true;
+      recognition.lang = 'en-US';
+
+      // Handle start event
+      recognition.onstart = () => {
+        setState((prev) => ({
+          ...prev,
+          isListening: true,
+          hasError: false,
+          error: null,
+        }));
+      };
+
+      // Handle end event
+      recognition.onend = () => {
+        setState((prev) => ({
+          ...prev,
+          isListening: false,
+        }));
+      };
+
+      // Handle results
+      recognition.onresult = (event: SpeechRecognitionEvent) => {
+        let finalTranscript = '';
+        let interimTranscript = '';
+
+        for (let i = event.resultIndex; i < event.results.length; ++i) {
+          const result = event.results[i];
+          if (result.isFinal) {
+            finalTranscript += result[0]?.transcript || '';
+          } else {
+            interimTranscript += result[0]?.transcript || '';
+          }
+        }
+
+        setState((prev) => ({
+          ...prev,
+          transcript: prev.transcript + finalTranscript + interimTranscript,
+          hasError: false,
+          error: null,
+        }));
+      };
+
+      // Handle errors
+      recognition.onerror = (event: Event) => {
+        const errorEvent = event as Event & { error?: string };
+        let errorMessage = 'An error occurred during speech recognition';
+
+        switch (errorEvent.error) {
+          case 'no-speech':
+            errorMessage = 'No speech detected. Please try again.';
+            break;
+          case 'audio-capture':
+            errorMessage = 'No microphone found. Please check your microphone.';
+            break;
+          case 'not-allowed':
+            errorMessage = 'Permission denied. Please allow microphone access.';
+            break;
+          case 'network':
+            errorMessage = 'Network error. Please check your connection.';
+            break;
+          default:
+            errorMessage = `Error: ${errorEvent.error || 'Unknown error'}`;
+        }
+
+        setState((prev) => ({
+          ...prev,
+          isListening: false,
+          hasError: true,
+          error: errorMessage,
+        }));
+      };
+
+      isSupportedRef.current = true;
+      setState((prev) => ({
+        ...prev,
+        isSupported: true,
+      }));
+    } catch (error) {
+      setState((prev) => ({
+        ...prev,
+        isSupported: false,
+        hasError: true,
+        error: error instanceof Error ? error.message : 'Failed to initialize speech recognition',
+      }));
+    }
+
+    // Cleanup on unmount
+    return () => {
+      if (recognitionRef.current) {
+        try {
+          recognitionRef.current.stop();
+        } catch {
+          // Ignore errors during cleanup
+        }
+        recognitionRef.current = null;
+      }
+    };
+  }, []);
+
+  /**
+   * Start listening for voice input
+   */
+  const startListening = useCallback(() => {
+    if (!recognitionRef.current || !state.isSupported) {
+      return;
+    }
+
+    setState((prev) => ({
+      ...prev,
+      transcript: '',
+      hasError: false,
+      error: null,
+    }));
+
+    try {
+      recognitionRef.current.start();
+    } catch (error) {
+      setState((prev) => ({
+        ...prev,
+        hasError: true,
+        error: error instanceof Error ? error.message : 'Failed to start listening',
+      }));
+    }
+  }, [state.isSupported]);
+
+  /**
+   * Stop listening for voice input
+   */
+  const stopListening = useCallback(() => {
+    if (!recognitionRef.current) {
+      return;
+    }
+
+    try {
+      recognitionRef.current.stop();
+    } catch (error) {
+      // Ignore errors during stop
+    }
+  }, []);
+
+  /**
+   * Clear the current transcript
+   */
+  const clearTranscript = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      transcript: '',
+    }));
+  }, []);
+
+  /**
+   * Set the transcript directly (for editing)
+   */
+  const setTranscript = useCallback((text: string) => {
+    setState((prev) => ({
+      ...prev,
+      transcript: text,
+    }));
+  }, []);
+
+  return {
+    // State
+    isListening: state.isListening,
+    transcript: state.transcript,
+    isSupported: state.isSupported,
+    error: state.error,
+    hasError: state.hasError,
+
+    // Controls
+    startListening,
+    stopListening,
+    clearTranscript,
+    setTranscript,
+  };
+}

--- a/packages/webui/src/index.ts
+++ b/packages/webui/src/index.ts
@@ -53,6 +53,10 @@ export type {
   EditModeInfo,
   EditModeIconType,
 } from './components/layout/InputForm';
+export { VoiceInputButton } from './components/layout/VoiceInputButton';
+export type { VoiceInputButtonProps } from './components/layout/VoiceInputButton';
+export { ImagePreview, ImagePreviewList } from './components/layout/ImagePreview';
+export type { ImagePreviewProps, ImagePreviewListProps } from './components/layout/ImagePreview';
 export { Onboarding } from './components/layout/Onboarding';
 export type { OnboardingProps } from './components/layout/Onboarding';
 
@@ -221,6 +225,10 @@ export { StopIcon } from './components/icons/StopIcon';
 // Hooks
 export { useTheme } from './hooks/useTheme';
 export { useLocalStorage } from './hooks/useLocalStorage';
+export { useVoiceInput } from './hooks/useVoiceInput';
+export type { VoiceInputState } from './hooks/useVoiceInput';
+export { useImagePaste } from './hooks/useImagePaste';
+export type { PastedImage, ImagePasteState } from './hooks/useImagePaste';
 
 // Types
 export type { Theme } from './types/theme';


### PR DESCRIPTION
## TLDR

Added voice-to-text and image paste support to Qwen Code. Users can now click a mic button to speak their messages and press Ctrl+V to paste screenshots directly into chat. This improves accessibility for developers with motor impairments and makes debugging faster.

## Dive Deeper

This PR adds two quality-of-life features:

1. **Voice Input**: Uses the browser's built-in Web Speech API to transcribe speech to text in real-time. Works in Chrome, Edge, and VS Code Desktop. No external dependencies required.

2. **Image Paste**: Allows users to paste images (screenshots, error messages, diagrams) with Ctrl+V or drag-and-drop. Images show as thumbnails before sending and can be removed if needed.

Both features work independently and can be used together (speak while showing a screenshot).

## Reviewer Test Plan

1. **Voice**: Open Qwen Code, click the mic button, speak a message, verify it transcribes correctly. Click again to stop.

2. **Images**: Take a screenshot, press Ctrl+V in chat, verify image thumbnail appears. Try removing it. Try sending with a message.

3. **Combined**: Use voice and paste an image together, verify both work.

Test in: VS Code Desktop, Chrome browser

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ✅  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

None yet; this is a new feature request.

-->
