### PR TITLE
fix(pipeline): handle duplicate finish_reason chunks from OpenRouter

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -255,9 +255,23 @@ export class ContentGenerationPipeline {
         .candidates?.[0]?.finishReason;
 
     if (isFinishChunk) {
-      // This is a finish reason chunk
-      collectedGeminiResponses.push(response);
-      setPendingFinish(response);
+      if (hasPendingFinish) {
+        // Duplicate finish chunk (e.g. from OpenRouter providers that send two
+        // finish_reason chunks for tool calls). The streaming tool call parser
+        // was already reset after the first finish chunk, so the second one
+        // carries no functionCall parts. Merge only usageMetadata and keep the
+        // candidates (including functionCall parts) from the first finish chunk.
+        const lastResponse =
+          collectedGeminiResponses[collectedGeminiResponses.length - 1];
+        if (response.usageMetadata) {
+          lastResponse.usageMetadata = response.usageMetadata;
+        }
+        setPendingFinish(lastResponse);
+      } else {
+        // This is a finish reason chunk
+        collectedGeminiResponses.push(response);
+        setPendingFinish(response);
+      }
       return false; // Don't yield yet, wait for potential subsequent chunks to merge
     } else if (hasPendingFinish) {
       // We have a pending finish chunk, merge this chunk's data into it


### PR DESCRIPTION
Fixes #2402

## Problem

Some OpenRouter model providers (e.g. `google/gemini-3.1-flash-lite-preview`) send **two** consecutive SSE chunks with `finish_reason: "tool_calls"`. The second chunk arrives after `streamingToolCallParser.reset()` has already been called, so it carries empty `parts` — no `functionCall` entries.

`handleChunkMerging` treated every finish chunk as authoritative and overwrote `pendingFinishResponse` with the empty duplicate, discarding the `functionCall` parts correctly assembled from the first finish chunk.

This caused `processStreamResponse` to see `hasToolCall=false` and throw:
```
Model stream ended with empty response text.
```

## Fix

In `handleChunkMerging`: when a second finish chunk arrives and a `pendingFinishResponse` already exists, only merge `usageMetadata` (if present) and keep the `candidates` from the first finish chunk.

```typescript
if (isFinishChunk) {
  if (hasPendingFinish) {
    // Duplicate finish chunk — keep candidates from first, merge only metadata
    const lastResponse = collectedGeminiResponses[...];
    if (response.usageMetadata) lastResponse.usageMetadata = response.usageMetadata;
    setPendingFinish(lastResponse);
  } else {
    collectedGeminiResponses.push(response);
    setPendingFinish(response);
  }
  return false;
}
```

## Testing

The existing `pipeline.test.ts` suite should cover regressions. A new test case can be added for the duplicate-finish-chunk scenario if desired.