### PR TITLE
fix: prevent tool call loss from late-arriving names and duplicate finish chunks

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -1014,20 +1014,6 @@ describe('OpenAIContentConverter', () => {
     });
   });
 
-  describe('convertOpenAIResponseToGemini', () => {
-    it('should handle empty choices array without crashing', () => {
-      const response = converter.convertOpenAIResponseToGemini({
-        object: 'chat.completion',
-        id: 'chatcmpl-empty',
-        created: 123,
-        model: 'test-model',
-        choices: [],
-      } as unknown as OpenAI.Chat.ChatCompletion);
-
-      expect(response.candidates).toEqual([]);
-    });
-  });
-
   describe('OpenAI -> Gemini reasoning content', () => {
     it('should convert reasoning_content to a thought part for non-streaming responses', () => {
       const response = converter.convertOpenAIResponseToGemini({
@@ -2215,6 +2201,171 @@ describe('Truncated tool call detection in streaming', () => {
     } as unknown as OpenAI.Chat.ChatCompletionChunk);
 
     expect(result.candidates?.[0]?.finishReason).toBe(FinishReason.MAX_TOKENS);
+  });
+});
+
+describe('Streaming tool call emission', () => {
+  let converter: OpenAIContentConverter;
+
+  beforeEach(() => {
+    converter = new OpenAIContentConverter('test-model', 'auto');
+  });
+
+  it('should emit tool call immediately when JSON completes during streaming', () => {
+    // Simulate streaming: name arrives first, then JSON
+    const chunk1 = {
+      id: 'chunk1',
+      created: 123,
+      model: 'test',
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                id: 'call_abc',
+                function: { name: 'test_func', arguments: '' },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    } as unknown as OpenAI.Chat.ChatCompletionChunk;
+
+    const chunk2 = {
+      id: 'chunk2',
+      created: 123,
+      model: 'test',
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                function: { arguments: '{"key": "value"}' },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    } as unknown as OpenAI.Chat.ChatCompletionChunk;
+
+    // First chunk: name arrives
+    const result1 = converter.convertOpenAIChunkToGemini(chunk1);
+    expect(result1.candidates?.[0]?.content?.parts).toEqual([]);
+
+    // Second chunk: JSON completes, should emit immediately
+    const result2 = converter.convertOpenAIChunkToGemini(chunk2);
+    const parts = result2.candidates?.[0]?.content?.parts || [];
+    const functionCall = parts.find((p) => 'functionCall' in p);
+    expect(functionCall).toBeDefined();
+    expect(
+      (functionCall as { functionCall: { name: string } }).functionCall.name,
+    ).toBe('test_func');
+  });
+
+  it('should not emit duplicate tool calls at finish_reason', () => {
+    converter.resetStreamingToolCalls();
+
+    // Simulate complete tool call during streaming
+    const chunk1 = {
+      id: 'chunk1',
+      created: 123,
+      model: 'test',
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                id: 'call_abc',
+                function: { name: 'test_func', arguments: '{"key": "value"}' },
+              },
+            ],
+          },
+          finish_reason: null,
+        },
+      ],
+    } as unknown as OpenAI.Chat.ChatCompletionChunk;
+
+    // Emit during streaming
+    converter.convertOpenAIChunkToGemini(chunk1);
+
+    // Finish chunk
+    const finishChunk = {
+      id: 'finish',
+      created: 123,
+      model: 'test',
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason: 'tool_calls',
+        },
+      ],
+    } as unknown as OpenAI.Chat.ChatCompletionChunk;
+
+    const result = converter.convertOpenAIChunkToGemini(finishChunk);
+    const parts = result.candidates?.[0]?.content?.parts || [];
+    const functionCalls = parts.filter((p) => 'functionCall' in p);
+
+    // Should not have duplicates - tool call was already emitted during streaming
+    expect(functionCalls).toHaveLength(0);
+  });
+
+  it('should handle multiple finish_reason chunks without duplicates', () => {
+    converter.resetStreamingToolCalls();
+
+    // First finish chunk
+    const finishChunk1 = {
+      id: 'finish1',
+      created: 123,
+      model: 'test',
+      choices: [
+        {
+          index: 0,
+          delta: {
+            tool_calls: [
+              {
+                index: 0,
+                id: 'call_abc',
+                function: { name: 'test_func', arguments: '{"key": "value"}' },
+              },
+            ],
+          },
+          finish_reason: 'tool_calls',
+        },
+      ],
+    } as unknown as OpenAI.Chat.ChatCompletionChunk;
+
+    const result1 = converter.convertOpenAIChunkToGemini(finishChunk1);
+    const parts1 = result1.candidates?.[0]?.content?.parts || [];
+    expect(parts1.filter((p) => 'functionCall' in p)).toHaveLength(1);
+
+    // Second finish chunk (some providers send finish twice)
+    const finishChunk2 = {
+      id: 'finish2',
+      created: 123,
+      model: 'test',
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason: 'tool_calls',
+        },
+      ],
+    } as unknown as OpenAI.Chat.ChatCompletionChunk;
+
+    const result2 = converter.convertOpenAIChunkToGemini(finishChunk2);
+    const parts2 = result2.candidates?.[0]?.content?.parts || [];
+
+    // Should not emit duplicate
+    expect(parts2.filter((p) => 'functionCall' in p)).toHaveLength(0);
   });
 });
 

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -99,6 +99,7 @@ export class OpenAIContentConverter {
   private modalities: InputModalities;
   private streamingToolCallParser: StreamingToolCallParser =
     new StreamingToolCallParser();
+  private emittedToolCallIds: Set<string> = new Set();
 
   constructor(
     model: string,
@@ -132,6 +133,7 @@ export class OpenAIContentConverter {
    */
   resetStreamingToolCalls(): void {
     this.streamingToolCallParser.reset();
+    this.emittedToolCallIds.clear();
   }
 
   /**
@@ -821,66 +823,62 @@ export class OpenAIContentConverter {
   convertOpenAIResponseToGemini(
     openaiResponse: OpenAI.Chat.ChatCompletion,
   ): GenerateContentResponse {
-    const choice = openaiResponse.choices?.[0];
+    const choice = openaiResponse.choices[0];
     const response = new GenerateContentResponse();
 
-    if (choice) {
-      const parts: Part[] = [];
+    const parts: Part[] = [];
 
-      // Handle reasoning content (thoughts)
-      const reasoningText =
-        (choice.message as ExtendedCompletionMessage).reasoning_content ??
-        (choice.message as ExtendedCompletionMessage).reasoning;
-      if (reasoningText) {
-        parts.push({ text: reasoningText, thought: true });
-      }
+    // Handle reasoning content (thoughts)
+    const reasoningText =
+      (choice.message as ExtendedCompletionMessage).reasoning_content ??
+      (choice.message as ExtendedCompletionMessage).reasoning;
+    if (reasoningText) {
+      parts.push({ text: reasoningText, thought: true });
+    }
 
-      // Handle text content
-      if (choice.message.content) {
-        parts.push({ text: choice.message.content });
-      }
+    // Handle text content
+    if (choice.message.content) {
+      parts.push({ text: choice.message.content });
+    }
 
-      // Handle tool calls
-      if (choice.message.tool_calls) {
-        for (const toolCall of choice.message.tool_calls) {
-          if (toolCall.function) {
-            let args: Record<string, unknown> = {};
-            if (toolCall.function.arguments) {
-              args = safeJsonParse(toolCall.function.arguments, {});
-            }
-
-            parts.push({
-              functionCall: {
-                id: toolCall.id,
-                name: toolCall.function.name,
-                args,
-              },
-            });
+    // Handle tool calls
+    if (choice.message.tool_calls) {
+      for (const toolCall of choice.message.tool_calls) {
+        if (toolCall.function) {
+          let args: Record<string, unknown> = {};
+          if (toolCall.function.arguments) {
+            args = safeJsonParse(toolCall.function.arguments, {});
           }
+
+          parts.push({
+            functionCall: {
+              id: toolCall.id,
+              name: toolCall.function.name,
+              args,
+            },
+          });
         }
       }
-
-      response.candidates = [
-        {
-          content: {
-            parts,
-            role: 'model' as const,
-          },
-          finishReason: this.mapOpenAIFinishReasonToGemini(
-            choice.finish_reason || 'stop',
-          ),
-          index: 0,
-          safetyRatings: [],
-        },
-      ];
-    } else {
-      response.candidates = [];
     }
 
     response.responseId = openaiResponse.id;
     response.createTime = openaiResponse.created
       ? openaiResponse.created.toString()
       : new Date().getTime().toString();
+
+    response.candidates = [
+      {
+        content: {
+          parts,
+          role: 'model' as const,
+        },
+        finishReason: this.mapOpenAIFinishReasonToGemini(
+          choice.finish_reason || 'stop',
+        ),
+        index: 0,
+        safetyRatings: [],
+      },
+    ];
 
     response.modelVersion = this.model;
     response.promptFeedback = { safetyRatings: [] };
@@ -957,26 +955,42 @@ export class OpenAIContentConverter {
           const index = toolCall.index ?? 0;
 
           // Process the tool call chunk through the streaming parser
-          if (toolCall.function?.arguments) {
-            this.streamingToolCallParser.addChunk(
-              index,
-              toolCall.function.arguments,
-              toolCall.id,
-              toolCall.function.name,
-            );
-          } else {
-            // Handle metadata-only chunks (id and/or name without arguments)
-            this.streamingToolCallParser.addChunk(
-              index,
-              '', // Empty chunk for metadata-only updates
-              toolCall.id,
-              toolCall.function?.name,
-            );
+          const result = this.streamingToolCallParser.addChunk(
+            index,
+            toolCall.function?.arguments || '',
+            toolCall.id,
+            toolCall.function?.name,
+          );
+
+          // If this chunk completed a tool call, emit it immediately
+          // This prevents tool calls from being lost when JSON completes before
+          // the function name arrives in a later chunk
+          if (result.complete && result.value) {
+            const meta = this.streamingToolCallParser.getToolCallMeta(index);
+            if (meta.name) {
+              const id =
+                meta.id ||
+                `call_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+              const functionCall = {
+                functionCall: {
+                  id,
+                  name: meta.name,
+                  args: result.value,
+                },
+              };
+              parts.push(functionCall);
+
+              // Track emitted tool call ID to prevent duplicates at finish_reason
+              if (meta.id) {
+                this.emittedToolCallIds.add(meta.id);
+              }
+            }
           }
         }
       }
 
-      // Only emit function calls when streaming is complete (finish_reason is present)
+      // Only emit remaining function calls when streaming is complete (finish_reason is present)
+      // This handles cases where JSON was valid but not auto-detected as complete by addChunk
       let toolCallsTruncated = false;
       if (choice.finish_reason) {
         // Detect truncation the provider may not report correctly.
@@ -989,6 +1003,11 @@ export class OpenAIContentConverter {
           this.streamingToolCallParser.getCompletedToolCalls();
 
         for (const toolCall of completedToolCalls) {
+          // Skip if already emitted during streaming (prevents duplicates)
+          if (toolCall.id && this.emittedToolCallIds.has(toolCall.id)) {
+            continue;
+          }
+
           if (toolCall.name) {
             parts.push({
               functionCall: {

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -1687,4 +1687,125 @@ describe('ContentGenerationPipeline', () => {
       expect(responses[0]).toBe(finalGeminiResponse);
     });
   });
+
+  describe('Finish chunk handling', () => {
+    it('should skip finish chunk without tool calls when pending finish has tool calls', async () => {
+      // Setup converter to return finish chunk with tool calls first,
+      // then finish chunk without tool calls (simulating duplicate finish)
+      const finishChunkWithToolCalls = {
+        id: 'finish1',
+        created: 123,
+        model: 'test',
+        choices: [
+          {
+            index: 0,
+            delta: {
+              tool_calls: [
+                {
+                  index: 0,
+                  id: 'call_abc',
+                  function: {
+                    name: 'test_func',
+                    arguments: '{"key": "value"}',
+                  },
+                },
+              ],
+            },
+            finish_reason: 'tool_calls',
+          },
+        ],
+      } as unknown as OpenAI.Chat.ChatCompletionChunk;
+
+      const finishChunkWithoutToolCalls = {
+        id: 'finish2',
+        created: 123,
+        model: 'test',
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: 'tool_calls',
+          },
+        ],
+      } as unknown as OpenAI.Chat.ChatCompletionChunk;
+
+      const geminiResponseWithToolCalls = new GenerateContentResponse();
+      geminiResponseWithToolCalls.candidates = [
+        {
+          content: {
+            parts: [
+              {
+                functionCall: {
+                  id: 'call_abc',
+                  name: 'test_func',
+                  args: { key: 'value' },
+                },
+              },
+            ],
+            role: 'model',
+          },
+          finishReason: FinishReason.STOP,
+          index: 0,
+          safetyRatings: [],
+        },
+      ];
+
+      const geminiResponseWithoutToolCalls = new GenerateContentResponse();
+      geminiResponseWithoutToolCalls.candidates = [
+        {
+          content: {
+            parts: [],
+            role: 'model',
+          },
+          finishReason: FinishReason.STOP,
+          index: 0,
+          safetyRatings: [],
+        },
+      ];
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'test' },
+      ]);
+      (mockConverter.convertOpenAIChunkToGemini as Mock)
+        .mockReturnValueOnce(geminiResponseWithToolCalls)
+        .mockReturnValueOnce(geminiResponseWithoutToolCalls);
+
+      const mockStream = {
+        async *[Symbol.asyncIterator]() {
+          yield finishChunkWithToolCalls;
+          yield finishChunkWithoutToolCalls;
+        },
+      };
+
+      (mockClient.chat.completions.create as Mock).mockResolvedValue(
+        mockStream,
+      );
+
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [{ role: 'user', parts: [{ text: 'test' }] }],
+      };
+
+      const responses: GenerateContentResponse[] = [];
+      const resultGenerator = await pipeline.executeStream(
+        request,
+        'test-prompt-id',
+      );
+      for await (const response of resultGenerator) {
+        responses.push(response);
+      }
+
+      // Should yield the response with tool calls, not the empty one
+      expect(responses.length).toBeGreaterThan(0);
+      const toolCallParts =
+        responses[0].candidates?.[0]?.content?.parts?.filter(
+          (p) => 'functionCall' in p,
+        );
+      expect(toolCallParts).toHaveLength(1);
+      expect(
+        (toolCallParts?.[0] as { functionCall: { name: string } }).functionCall
+          .name,
+      ).toBe('test_func');
+    });
+  });
 });

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -9,6 +9,7 @@ import {
   type GenerateContentParameters,
   GenerateContentResponse,
 } from '@google/genai';
+import type { Part } from '@google/genai';
 import type { Config } from '../../config/config.js';
 import type { ContentGeneratorConfig } from '../contentGenerator.js';
 import type { OpenAICompatibleProvider } from './provider/index.js';
@@ -254,23 +255,20 @@ export class ContentGenerationPipeline {
         .candidates?.[0]?.finishReason;
 
     if (isFinishChunk) {
-      if (hasPendingFinish) {
-        // Duplicate finish chunk (e.g. from OpenRouter providers that send two
-        // finish_reason chunks for tool calls). The streaming tool call parser
-        // was already reset after the first finish chunk, so the second one
-        // carries no functionCall parts. Merge only usageMetadata and keep the
-        // candidates (including functionCall parts) from the first finish chunk.
-        const lastResponse =
-          collectedGeminiResponses[collectedGeminiResponses.length - 1];
-        if (response.usageMetadata) {
-          lastResponse.usageMetadata = response.usageMetadata;
-        }
-        setPendingFinish(lastResponse);
-      } else {
-        // This is a finish reason chunk
-        collectedGeminiResponses.push(response);
-        setPendingFinish(response);
+      // This is a finish reason chunk
+      // Don't overwrite a pending finish that already has tool calls
+      const lastCollected =
+        collectedGeminiResponses[collectedGeminiResponses.length - 1];
+      const pendingToolCallCount =
+        lastCollected?.candidates?.[0]?.content?.parts?.filter(
+          (p: Part) => 'functionCall' in p,
+        ).length || 0;
+      if (hasPendingFinish && pendingToolCallCount > 0) {
+        // Skip this finish chunk - preserve the one with tool calls
+        return false;
       }
+      collectedGeminiResponses.push(response);
+      setPendingFinish(response);
       return false; // Don't yield yet, wait for potential subsequent chunks to merge
     } else if (hasPendingFinish) {
       // We have a pending finish chunk, merge this chunk's data into it

--- a/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.test.ts
@@ -861,4 +861,53 @@ describe('StreamingToolCallParser', () => {
       expect(parser.getState(0).depth).toBe(1);
     });
   });
+
+  describe('Name arrives after JSON completion', () => {
+    it('should keep name at correct index when it arrives after JSON', () => {
+      // JSON completes before name arrives
+      parser.addChunk(0, '{"file":', 'call_abc', undefined);
+      parser.addChunk(0, '"test.txt"}', undefined, undefined);
+
+      // Name arrives in separate chunk
+      parser.addChunk(0, '', undefined, 'write_file');
+
+      const completed = parser.getCompletedToolCalls();
+      expect(completed).toHaveLength(1);
+      expect(completed[0].id).toBe('call_abc');
+      expect(completed[0].name).toBe('write_file');
+      expect(completed[0].args).toEqual({ file: 'test.txt' });
+    });
+
+    it('should not reassign index when name arrives after JSON', () => {
+      // Setup: JSON complete, no name yet
+      parser.addChunk(0, '{"param": "value"}', 'call_1', undefined);
+
+      // Name arrives later
+      parser.addChunk(0, '', undefined, 'function1');
+
+      // Tool call should be at index 0, not reassigned
+      const meta = parser.getToolCallMeta(0);
+      expect(meta.id).toBe('call_1');
+      expect(meta.name).toBe('function1');
+
+      const completed = parser.getCompletedToolCalls();
+      expect(completed).toHaveLength(1);
+      expect(completed[0].name).toBe('function1');
+    });
+
+    it('should handle multiple tool calls with late names', () => {
+      // First tool call: JSON then name
+      parser.addChunk(0, '{"a": 1}', 'call_1', undefined);
+      parser.addChunk(0, '', undefined, 'func1');
+
+      // Second tool call: JSON then name
+      parser.addChunk(1, '{"b": 2}', 'call_2', undefined);
+      parser.addChunk(1, '', undefined, 'func2');
+
+      const completed = parser.getCompletedToolCalls();
+      expect(completed).toHaveLength(2);
+      expect(completed.find((c) => c.id === 'call_1')?.name).toBe('func1');
+      expect(completed.find((c) => c.id === 'call_2')?.name).toBe('func2');
+    });
+  });
 });

--- a/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.ts
+++ b/packages/core/src/core/openaiContentGenerator/streamingToolCallParser.ts
@@ -297,8 +297,9 @@ export class StreamingToolCallParser {
       const depth = this.depths.get(this.nextAvailableIndex)!;
       const meta = this.toolCallMeta.get(this.nextAvailableIndex);
 
-      // If buffer is empty or incomplete (depth > 0), this index is available
-      if (!buffer.trim() || depth > 0 || !meta?.id) {
+      // Tool call is incomplete if: JSON open, buffer empty, missing ID, or missing name
+      // Any condition true → index available for reuse
+      if (!buffer.trim() || depth > 0 || !meta?.id || !meta.name) {
         return this.nextAvailableIndex;
       }
 
@@ -336,8 +337,8 @@ export class StreamingToolCallParser {
       const depth = this.depths.get(index)!;
       const meta = this.toolCallMeta.get(index);
 
-      // Check if this tool call is incomplete
-      if (meta?.id && (depth > 0 || !buffer.trim())) {
+      // Tool call incomplete if: has ID but JSON open, buffer empty, or missing name
+      if (meta?.id && (depth > 0 || !buffer.trim() || !meta.name)) {
         maxIndex = Math.max(maxIndex, index);
       } else if (buffer.trim()) {
         // Check if buffer is parseable (complete)


### PR DESCRIPTION
## Summary

Fixes three complementary bugs that cause tool calls to disappear during streaming:

1. **Parser bug**: Function name arriving after JSON completion causes index reassignment
2. **Converter bug**: Waiting until finish_reason to emit allows parser state changes to lose tool calls  
3. **Pipeline bug**: Duplicate finish_reason chunks cause second chunk to overwrite first chunk's tool calls

## Root Causes

### Bug 1: Parser Index Reassignment (`streamingToolCallParser.ts`)
`findMostRecentIncompleteIndex()` and `findNextAvailableIndex()` considered tool calls "complete" based on JSON state alone (depth=0, non-empty buffer, has ID), without checking if `meta.name` exists. When name arrived in a later chunk, parser reassigned it to a new index, leaving JSON at the old index → `getCompletedToolCalls()` returned empty.

### Bug 2: Late Emission (`converter.ts`)
Tool calls were only emitted at `finish_reason`, not during streaming. This allowed parser state changes between JSON completion and name arrival to cause tool call loss.

### Bug 3: Finish Chunk Overwriting (`pipeline.ts`)
`handleChunkMerging()` unconditionally stored every finish chunk. Some providers send finish_reason twice (first with tool calls, second with usage metadata only). Second chunk overwrote the first → tool calls lost.

## Changes

### `streamingToolCallParser.ts`
- Check `meta.name` when determining if tool call is complete in `findMostRecentIncompleteIndex()`
- Check `meta.name` when determining if index is available in `findNextAvailableIndex()`
- Prevents index reassignment when name arrives late

### `converter.ts`
- Emit tool calls immediately during streaming when `result.complete && result.value && meta.name`
- Track emitted tool call IDs in `emittedToolCallIds` Set
- Skip already-emitted IDs at `finish_reason` to prevent duplicates
- Clear `emittedToolCallIds` in `resetStreamingToolCalls()`

### `pipeline.ts`
- Skip finish chunks without tool calls when pending finish already has tool calls
- Preserves first finish chunk's tool calls from being overwritten

## Testing

Unit tests added for all three fixes:

**Parser tests:**
- should keep name at correct index when it arrives after JSON
- should not reassign index when name arrives after JSON
- should handle multiple tool calls with late names

**Converter tests:**
- should emit tool call immediately when JSON completes during streaming
- should not emit duplicate tool calls at finish_reason
- should handle multiple finish_reason chunks without duplicates

**Pipeline tests:**
- should skip finish chunk without tool calls when pending finish has tool calls

All tests pass, confirming the fixes work correctly.

## Related

These fixes work together for defense-in-depth:
- Parser fix prevents index corruption
- Converter fix emits early + prevents duplicates
- Pipeline fix prevents finish chunk overwriting

Complements existing streaming handling. Works with providers that send chunks in non-standard order or send finish_reason multiple times.