### PR TITLE
chore(CODEOWNERS): remove required reviewers for vscode-ide-companion and webui packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,3 @@
 * @tanzhenxin @DennisYu07 @gwinthis @LaZzyMan @pomelo-nwu @Mingholy @DragonnZhang
 # SDK TypeScript package changes require review from Mingholy
 packages/sdk-typescript/** @Mingholy
-# vscode-ide-companion and webui packages require review from yiliang114
-packages/vscode-ide-companion/** @yiliang114
-packages/webui/** @yiliang114


### PR DESCRIPTION
## TLDR

Remove required reviewers for `packages/vscode-ide-companion` and `packages/webui` packages.

This change removes the configuration requiring `@yiliang114` as a mandatory reviewer for these two packages, simplifying the PR review process.

## Dive Deeper

### Changes

- Removed `@yiliang114` reviewer configuration for `packages/vscode-ide-companion/**`
- Removed `@yiliang114` reviewer configuration for `packages/webui/**`

### Rationale

Removing mandatory reviewer restrictions for specific packages allows the default reviewer team to handle code reviews for these packages, improving PR merge efficiency.

## Reviewer Test Plan

1. Review the `.github/CODEOWNERS` file changes
2. Confirm the removed configuration lines are as expected
3. Verify the default reviewer rules still apply

## Testing Matrix

This is a configuration file change, no runtime testing required.

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| Config check | ✅  | ✅  | ✅  |

## Linked issues / bugs

None
