### PR TITLE
fix(vscode): Tab key fills completion without sending

### DIFF
--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -43,6 +43,7 @@ export const ALLOWED_BUILTIN_COMMANDS_NON_INTERACTIVE = [
   'summary',
   'compress',
   'bug',
+  'skills',
 ] as const;
 
 /**

--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -715,6 +715,195 @@ export const App: React.FC = () => {
     ],
   );
 
+  // Handle Tab key completion selection - fills input without sending
+  const handleCompletionTabSelect = useCallback(
+    (item: CompletionItem) => {
+      // Handle completion selection by inserting the value into the input field
+      const inputElement = inputFieldRef.current;
+      if (!inputElement) {
+        return;
+      }
+
+      // Ignore info items (placeholders like "Searching files…")
+      if (item.type === 'info') {
+        completion.closeCompletion();
+        return;
+      }
+
+      // For Tab key: commands should fill input but NOT execute
+      if (item.type === 'command') {
+        const itemId = item.id;
+
+        // Helper to replace trigger text with command in input
+        const replaceTriggerWithCommand = () => {
+          const text = inputElement.textContent || '';
+          const selection = window.getSelection();
+          if (!selection || selection.rangeCount === 0) {
+            // Fallback: just set the command text
+            inputElement.textContent = `/${itemId} `;
+            setInputText(`/${itemId} `);
+            return;
+          }
+
+          // Find and replace the slash command trigger
+          const range = selection.getRangeAt(0);
+          let cursorPos = text.length;
+          if (range.startContainer === inputElement) {
+            const childIndex = range.startOffset;
+            let offset = 0;
+            for (
+              let i = 0;
+              i < childIndex && i < inputElement.childNodes.length;
+              i++
+            ) {
+              offset += inputElement.childNodes[i].textContent?.length || 0;
+            }
+            cursorPos = offset || text.length;
+          } else if (range.startContainer.nodeType === Node.TEXT_NODE) {
+            const walker = document.createTreeWalker(
+              inputElement,
+              NodeFilter.SHOW_TEXT,
+              null,
+            );
+            let offset = 0;
+            let found = false;
+            let node: Node | null = walker.nextNode();
+            while (node) {
+              if (node === range.startContainer) {
+                offset += range.startOffset;
+                found = true;
+                break;
+              }
+              offset += node.textContent?.length || 0;
+              node = walker.nextNode();
+            }
+            cursorPos = found ? offset : text.length;
+          }
+
+          const textBeforeCursor = text.substring(0, cursorPos);
+          const slashPos = textBeforeCursor.lastIndexOf('/');
+          if (slashPos >= 0) {
+            const newText =
+              text.substring(0, slashPos) +
+              `/${itemId} ` +
+              text.substring(cursorPos);
+            inputElement.textContent = newText;
+            setInputText(newText);
+
+            // Move caret to after the inserted command
+            const newRange = document.createRange();
+            const sel = window.getSelection();
+            newRange.setStart(
+              inputElement.firstChild || inputElement,
+              slashPos + itemId.length + 2,
+            );
+            newRange.collapse(true);
+            sel?.removeAllRanges();
+            sel?.addRange(newRange);
+          }
+        };
+
+        // Handle special commands - for Tab, just fill input (don't execute)
+        if (itemId === 'login' || itemId === 'model') {
+          replaceTriggerWithCommand();
+          completion.closeCompletion();
+          return;
+        }
+
+        // Handle server-provided slash commands - fill input only, don't send
+        const serverCmd = availableCommands.find((c) => c.name === itemId);
+        if (serverCmd) {
+          replaceTriggerWithCommand();
+          completion.closeCompletion();
+          return;
+        }
+      }
+
+      // For file types: same behavior as Enter (add reference and fill input)
+      if (item.type === 'file' && item.value && item.path) {
+        try {
+          fileContext.addFileReference(item.value, item.path);
+        } catch (err) {
+          console.warn('[App] addFileReference failed:', err);
+        }
+      }
+
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0) {
+        return;
+      }
+
+      // Current text and cursor
+      const text = inputElement.textContent || '';
+      const range = selection.getRangeAt(0);
+
+      // Compute total text offset for contentEditable
+      let cursorPos = text.length;
+      if (range.startContainer === inputElement) {
+        const childIndex = range.startOffset;
+        let offset = 0;
+        for (
+          let i = 0;
+          i < childIndex && i < inputElement.childNodes.length;
+          i++
+        ) {
+          offset += inputElement.childNodes[i].textContent?.length || 0;
+        }
+        cursorPos = offset || text.length;
+      } else if (range.startContainer.nodeType === Node.TEXT_NODE) {
+        const walker = document.createTreeWalker(
+          inputElement,
+          NodeFilter.SHOW_TEXT,
+          null,
+        );
+        let offset = 0;
+        let found = false;
+        let node: Node | null = walker.nextNode();
+        while (node) {
+          if (node === range.startContainer) {
+            offset += range.startOffset;
+            found = true;
+            break;
+          }
+          offset += node.textContent?.length || 0;
+          node = walker.nextNode();
+        }
+        cursorPos = found ? offset : text.length;
+      }
+
+      // Replace from trigger to cursor with selected value
+      const textBeforeCursor = text.substring(0, cursorPos);
+      const atPos = textBeforeCursor.lastIndexOf('@');
+      const slashPos = textBeforeCursor.lastIndexOf('/');
+      const triggerPos = Math.max(atPos, slashPos);
+
+      if (triggerPos >= 0) {
+        const insertValue =
+          typeof item.value === 'string' ? item.value : String(item.label);
+        const newText =
+          text.substring(0, triggerPos + 1) + // keep the trigger symbol
+          insertValue +
+          ' ' +
+          text.substring(cursorPos);
+
+        // Update DOM and state, and move caret to end
+        inputElement.textContent = newText;
+        setInputText(newText);
+
+        const newRange = document.createRange();
+        const sel = window.getSelection();
+        newRange.selectNodeContents(inputElement);
+        newRange.collapse(false);
+        sel?.removeAllRanges();
+        sel?.addRange(newRange);
+      }
+
+      // Close the completion menu
+      completion.closeCompletion();
+    },
+    [completion, inputFieldRef, setInputText, fileContext, availableCommands],
+  );
+
   // Handle model selection
   const handleModelSelect = useCallback(
     (modelId: string) => {
@@ -1031,6 +1220,7 @@ export const App: React.FC = () => {
           completionIsOpen={completion.isOpen}
           completionItems={completion.items}
           onCompletionSelect={handleCompletionSelect}
+          onCompletionTabSelect={handleCompletionTabSelect}
           onCompletionClose={completion.closeCompletion}
           showModelSelector={showModelSelector}
           availableModels={availableModels}

--- a/packages/webui/src/components/layout/CompletionMenu.tsx
+++ b/packages/webui/src/components/layout/CompletionMenu.tsx
@@ -17,8 +17,10 @@ import type { CompletionItem } from '../../types/completion.js';
 export interface CompletionMenuProps {
   /** List of completion items to display */
   items: CompletionItem[];
-  /** Callback when an item is selected */
+  /** Callback when an item is selected (Enter key or click) */
   onSelect: (item: CompletionItem) => void;
+  /** Callback when an item is selected via Tab key (fill only, don't send) */
+  onTabSelect?: (item: CompletionItem) => void;
   /** Callback when menu should close */
   onClose: () => void;
   /** Optional section title */
@@ -75,6 +77,7 @@ const groupItems = (
 export const CompletionMenu: FC<CompletionMenuProps> = ({
   items,
   onSelect,
+  onTabSelect,
   onClose,
   title,
   selectedIndex = 0,
@@ -123,10 +126,18 @@ export const CompletionMenu: FC<CompletionMenuProps> = ({
           setSelected((prev) => Math.max(prev - 1, 0));
           break;
         case 'Enter':
-        case 'Tab':
           event.preventDefault();
           if (items[selected]) {
             onSelect(items[selected]);
+          }
+          break;
+        case 'Tab':
+          event.preventDefault();
+          if (items[selected]) {
+            // Use onTabSelect if provided (fills input without sending),
+            // otherwise fall back to onSelect
+            const handler = onTabSelect ?? onSelect;
+            handler(items[selected]);
           }
           break;
         case 'Escape':
@@ -144,7 +155,7 @@ export const CompletionMenu: FC<CompletionMenuProps> = ({
       document.removeEventListener('mousedown', handleClickOutside);
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [items, selected, onSelect, onClose]);
+  }, [items, selected, onSelect, onTabSelect, onClose]);
 
   useEffect(() => {
     // Only scroll into view for keyboard navigation, not mouse hover

--- a/packages/webui/src/components/layout/InputForm.tsx
+++ b/packages/webui/src/components/layout/InputForm.tsx
@@ -111,8 +111,10 @@ export interface InputFormProps {
   completionIsOpen: boolean;
   /** Completion items */
   completionItems?: CompletionItem[];
-  /** Completion select callback */
+  /** Completion select callback (Enter key or click) */
   onCompletionSelect?: (item: CompletionItem) => void;
+  /** Completion tab select callback (Tab key only, fills without sending) */
+  onCompletionTabSelect?: (item: CompletionItem) => void;
   /** Completion close callback */
   onCompletionClose?: () => void;
   /** Placeholder text */
@@ -170,6 +172,7 @@ export const InputForm: FC<InputFormProps> = ({
   completionIsOpen,
   completionItems,
   onCompletionSelect,
+  onCompletionTabSelect,
   onCompletionClose,
   placeholder = 'Ask Qwen Code …',
 }) => {
@@ -242,6 +245,7 @@ export const InputForm: FC<InputFormProps> = ({
               <CompletionMenu
                 items={completionItemsResolved}
                 onSelect={onCompletionSelect}
+                onTabSelect={onCompletionTabSelect}
                 onClose={onCompletionClose}
                 title={undefined}
               />


### PR DESCRIPTION
## TLDR

Fix Tab key behavior in VSCode extension completion menu. Tab now fills the input field without sending, allowing users to add parameters before execution. Enter key still sends immediately.

## Dive Deeper

The original PR #2308 incorrectly made Tab and Enter behave identically - both would send the command immediately. This was not the intended behavior.

**Problem:**
- Tab key was treated the same as Enter, causing commands to be sent immediately
- Users couldn't use Tab to autocomplete a command and then add additional parameters

**Solution:**
- Added `onTabSelect` prop to `CompletionMenu` component to distinguish Tab from Enter
- Tab key: fills input with command (e.g., `/help `) and positions cursor for additional input
- Enter key: sends the command immediately (unchanged behavior)

**Changes:**
1. `CompletionMenu.tsx`: Added `onTabSelect` callback prop
2. `InputForm.tsx`: Passed new callback through component
3. `App.tsx`: Implemented `handleCompletionTabSelect` that fills input without calling `sendMessage`
4. Also added 'skills' to `ALLOWED_BUILTIN_COMMANDS_NON_INTERACTIVE` whitelist

## Reviewer Test Plan

1. Build and run the VSCode extension
2. Type `/` to open the completion menu
3. Navigate to a command (e.g., `/help`)
4. Press **Tab**: command should fill input box with trailing space, cursor positioned after
5. Add more text (e.g., `/help how to use git`)
6. Press **Enter**: full message should be sent
7. Test that Enter key still works as before (immediate send)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2293
Fixes #2394
