### PR TITLE
fix(cli): show newest-first history for Ctrl+R command search

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -1956,6 +1956,25 @@ describe('InputPrompt', () => {
   });
 
   describe('command search (Ctrl+R when not in shell)', () => {
+    it('passes newest-first user history to command search', async () => {
+      props.shellModeActive = false;
+      props.userMessages = ['oldest', 'middle', 'newest'];
+
+      const { unmount } = renderWithProviders(<InputPrompt {...props} />);
+      await wait();
+
+      const commandSearchCall =
+        mockedUseReverseSearchCompletion.mock.calls.find(
+          ([, history]) =>
+            Array.isArray(history) &&
+            history.length === 3 &&
+            history.includes('newest'),
+        );
+
+      expect(commandSearchCall?.[1]).toEqual(['newest', 'middle', 'oldest']);
+      unmount();
+    });
+
     it('enters command search on Ctrl+R and shows suggestions', async () => {
       props.shellModeActive = false;
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -5,7 +5,7 @@
  */
 
 import type React from 'react';
-import { useCallback, useEffect, useState, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { Box, Text } from 'ink';
 import { SuggestionsDisplay, MAX_WIDTH } from './SuggestionsDisplay.js';
 import { theme } from '../semantic-colors.js';
@@ -213,9 +213,14 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     reverseSearchActive,
   );
 
+  const commandSearchHistory = useMemo(
+    () => [...userMessages].reverse(),
+    [userMessages],
+  );
+
   const commandSearchCompletion = useReverseSearchCompletion(
     buffer,
-    userMessages,
+    commandSearchHistory,
     commandSearchActive,
   );
 


### PR DESCRIPTION
## Summary
- make non-shell command search show the most recent user inputs first
- keep the existing input history navigation behavior unchanged
- add a test to lock the command-search ordering

## Why
Shell-mode already surfaces history in newest-first order, but non-shell command search was using in oldest-first order. That made the two reverse-search experiences inconsistent and pushed recent entries below older ones.

## Testing

 ✓ |@qwen-code/qwen-code| src/ui/components/InputPrompt.test.tsx (97 tests | 1 skipped) 12537ms
   ✓ InputPrompt > paste auto-submission protection > should allow submission after paste protection timeout  760ms
   ✓ InputPrompt > large paste placeholder > should expand placeholder to full content on submit  762ms
   ✓ InputPrompt > large paste placeholder > should expand same-size placeholders correctly when #2 appears first  817ms
   ✓ InputPrompt > large paste placeholder > should write expanded placeholder content to shell history  761ms

 Test Files  1 passed (1)
      Tests  96 passed | 1 skipped (97)
   Start at  14:16:59
   Duration  17.44s (transform 2.14s, setup 40ms, collect 4.10s, tests 12.54s, environment 381ms, prepare 99ms)