### PR TITLE
fix(vscode-ide-companion): update URI handling for Windows paths

### DIFF
--- a/packages/vscode-ide-companion/src/diff-manager.ts
+++ b/packages/vscode-ide-companion/src/diff-manager.ts
@@ -192,17 +192,17 @@ export class DiffManager {
       return;
     }
     // Left side: old content using qwen-diff scheme
-    const leftDocUri = vscode.Uri.from({
+    // Use Uri.file() to properly handle Windows paths (e.g., C:\Users\...)
+    // then change the scheme to our custom diff scheme
+    const leftDocUri = vscode.Uri.file(normalizedPath).with({
       scheme: DIFF_SCHEME,
-      path: normalizedPath,
       query: `old&rand=${Math.random()}`,
     });
     this.diffContentProvider.setContent(leftDocUri, oldContent);
 
     // Right side: new content using qwen-diff scheme
-    const rightDocUri = vscode.Uri.from({
+    const rightDocUri = vscode.Uri.file(normalizedPath).with({
       scheme: DIFF_SCHEME,
-      path: normalizedPath,
       query: `new&rand=${Math.random()}`,
     });
     this.diffContentProvider.setContent(rightDocUri, newContent);


### PR DESCRIPTION
## TLDR

Fixes URI construction in DiffManager to properly handle Windows file paths (e.g., `C:\Users\...`) by using `Uri.file()` instead of `Uri.from()`.

## Dive Deeper

The previous implementation used `vscode.Uri.from({ scheme, path, query })` to construct URIs for the diff view. This approach does not correctly handle Windows-style paths that contain drive letters and backslashes.

**Before:**
```typescript
const leftDocUri = vscode.Uri.from({
  scheme: DIFF_SCHEME,
  path: normalizedPath,
  query: `old&rand=${Math.random()}`,
});
```

**After:**
```typescript
const leftDocUri = vscode.Uri.file(normalizedPath).with({
  scheme: DIFF_SCHEME,
  query: `old&rand=${Math.random()}`,
});
```

By using `Uri.file()` first, the path is properly parsed and normalized for the current platform, then `.with()` is used to change the scheme to our custom diff scheme. This ensures Windows paths are handled correctly while maintaining the same behavior on macOS and Linux.

## Reviewer Test Plan

1. Open the VS Code IDE Companion extension
2. Trigger a diff view for a file edit operation
3. Verify the diff view opens correctly showing old vs new content
4. On Windows: Test with files under `C:\Users\...` or other drive letters
5. On macOS/Linux: Verify existing functionality is not affected

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #1767