### PR TITLE
fix: normalize CRLF line endings in edit tool parameters

### DIFF
--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -647,6 +647,27 @@ describe('EditTool', () => {
       });
     });
 
+    it('should match CRLF old_string against LF-normalized file content', async () => {
+      // File on disk has CRLF line endings (Windows-style)
+      fs.writeFileSync(filePath, 'line1\r\nline2\r\nline3', 'utf8');
+      const params: EditToolParams = {
+        file_path: filePath,
+        // old_string from LLM or IDE may contain CRLF
+        old_string: 'line1\r\nline2',
+        new_string: 'replaced1\nreplaced2',
+      };
+
+      const invocation = tool.build(params);
+      const result = await invocation.execute(new AbortController().signal);
+
+      expect(result.llmContent).toMatch(
+        /Showing lines \d+-\d+ of \d+ from the edited file/,
+      );
+      const content = fs.readFileSync(filePath, 'utf8');
+      expect(content).toContain('replaced1');
+      expect(content).toContain('replaced2');
+    });
+
     it('should return error if trying to create a file that already exists (empty old_string)', async () => {
       fs.writeFileSync(filePath, 'Existing content', 'utf8');
       const params: EditToolParams = {

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -172,6 +172,11 @@ class EditToolInvocation implements ToolInvocation<EditToolParams, ToolResult> {
       }
     }
 
+    // Normalize line endings in edit strings to match the LF-normalized file content.
+    // This prevents CRLF/LF mismatch when old_string comes from a Windows environment.
+    finalOldString = finalOldString.replace(/\r\n/g, '\n');
+    finalNewString = finalNewString.replace(/\r\n/g, '\n');
+
     const normalizedStrings = normalizeEditStrings(
       currentContent,
       finalOldString,


### PR DESCRIPTION
## TLDR

Fixes the Edit tool failing on multi-line edits when `old_string` contains CRLF (`\r\n`) line endings but the file content has been normalized to LF (`\n`). This is a one-line root cause fix plus a regression test.

## Dive Deeper

The Edit tool already normalizes file content from CRLF to LF on read (`edit.ts:163`):

```typescript
currentContent = fileInfo.content.replace(/\r\n/g, '\n\);
```

However, the `old_string` and `new_string` parameters were **not** normalized, so when an LLM or Windows IDE provides `old_string` with CRLF line endings, `indexOf()` fails to find a match against the LF-normalized content. This is especially common with UTF-8 BOM + CRLF projects on Windows (as reported in #2257).

The fix adds matching CRLF→LF normalization for `old_string` and `new_string` before the matching logic runs:

```typescript
finalOldString = finalOldString.replace(/\r\n/g, '\n\);
finalNewString = finalNewString.replace(/\r\n/g, '\n\);
```

## Reviewer Test Plan

1. Create a file with CRLF line endings on Windows (or `printf "line1\r\nline2\r\nline3" > test.txt`)
2. Use the Edit tool with a multi-line `old_string` containing CRLF
3. Verify the edit succeeds (previously would fail with "no match found")

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |

## Linked issues / bugs

Fixes #2257