### PR TITLE
fix: handle escaped pipe characters in markdown table cells

### DIFF
--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -155,6 +155,22 @@ Some text before.
       expect(lastFrame()).toMatchSnapshot();
     });
 
+    it('handles escaped pipe characters in table cells', () => {
+      const text = `
+| Type | Example |
+|------|---------|
+| Union | A\\|B |
+| Plain | C |
+`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} />,
+      );
+      const frame = lastFrame() ?? '';
+      // The escaped pipe should appear as literal "A|B" in the rendered output,
+      // not split into a third column.
+      expect(frame).toContain('A|B');
+    });
+
     it('inserts a single space between paragraphs', () => {
       const text = `Paragraph 1.
 

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -45,6 +45,13 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   const tableRowRegex = /^\s*\|(.+)\|\s*$/;
   const tableSeparatorRegex = /^\s*\|?\s*(:?-+:?)\s*(\|\s*(:?-+:?)\s*)+\|?\s*$/;
 
+  /** Split a table row on unescaped `|` delimiters, then unescape `\|` → `|`. */
+  function splitTableRow(raw: string): string[] {
+    return raw
+      .split(/(?<!\\)\|/)
+      .map((cell) => cell.replace(/\\\|/g, '|').trim());
+  }
+
   const contentBlocks: React.ReactNode[] = [];
   let inCodeBlock = false;
   let lastLineEmpty = true;
@@ -111,7 +118,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
         lines[index + 1].match(tableSeparatorRegex)
       ) {
         inTable = true;
-        tableHeaders = tableRowMatch[1].split('|').map((cell) => cell.trim());
+        tableHeaders = splitTableRow(tableRowMatch[1]);
         tableRows = [];
       } else {
         // Not a table, treat as regular text
@@ -127,7 +134,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
       // Skip separator line - already handled
     } else if (inTable && tableRowMatch) {
       // Add table row
-      const cells = tableRowMatch[1].split('|').map((cell) => cell.trim());
+      const cells = splitTableRow(tableRowMatch[1]);
       // Ensure row has same column count as headers
       while (cells.length < tableHeaders.length) {
         cells.push('');


### PR DESCRIPTION
## TLDR

Fixes table rendering when cells contain literal `|` characters (e.g. `A|B`). Previously, the naive `.split("|")` incorrectly broke such content into separate columns. Now uses a regex split on unescaped pipes with `\|` → `|` unescaping.

## Dive Deeper

**Root cause**: `MarkdownDisplay.tsx` lines 114 and 130 used `.split("|")` to parse table rows, which cannot distinguish between structural column delimiters and literal pipe characters in cell content.

**Fix**: Added a `splitTableRow()` helper that:
1. Splits on unescaped pipes using negative lookbehind: `(?<!\\)\|`
2. Unescapes `\|` → `|` in the resulting cell text
3. Trims whitespace from each cell

LLMs can output `A\|B` in table cells and it renders correctly as `A|B` in a single column. This follows the standard Markdown table escaping convention.

## Reviewer Test Plan

1. Ask the model to output a table where cells contain `|` (e.g. union types like `string|number`)
2. In the system prompt or QWEN.md, instruct the model to escape pipes as `\|` in tables
3. Verify the table renders with correct column alignment

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |

## Linked issues / bugs

Fixes #2461