### PR TITLE
feat: add .agents/skills as a skill provider directory

### DIFF
--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -12,7 +12,7 @@ import { getProjectHash, sanitizeCwd } from '../utils/paths.js';
 export const QWEN_DIR = '.qwen';
 export const GOOGLE_ACCOUNTS_FILENAME = 'google_accounts.json';
 export const OAUTH_FILE = 'oauth_creds.json';
-export const SKILL_PROVIDER_CONFIG_DIRS = ['.qwen', '.agent'];
+export const SKILL_PROVIDER_CONFIG_DIRS = ['.qwen', '.agents'];
 const TMP_DIR_NAME = 'tmp';
 const BIN_DIR_NAME = 'bin';
 const PROJECT_DIR_NAME = 'projects';

--- a/packages/core/src/skills/skill-manager.test.ts
+++ b/packages/core/src/skills/skill-manager.test.ts
@@ -449,7 +449,7 @@ You are a helpful assistant.
             },
           ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
         }
-        // Other provider dirs (.agent, .cursor, .codex, .claude) return empty
+        // Other provider dirs (.agents, .cursor, .codex, .claude) return empty
         return Promise.resolve(
           [] as unknown as Awaited<ReturnType<typeof fs.readdir>>,
         );
@@ -511,10 +511,10 @@ Skill 3 content`);
     });
 
     it('should deduplicate same-name skills across provider dirs within a level', async () => {
-      // Override readdir to return the same skill name from both .qwen and .agent dirs
+      // Override readdir to return the same skill name from both .qwen and .agents dirs
       vi.mocked(fs.readdir).mockReset();
       const projectQwenDir = path.join('/test/project', '.qwen', 'skills');
-      const projectAgentDir = path.join('/test/project', '.agent', 'skills');
+      const projectAgentDir = path.join('/test/project', '.agents', 'skills');
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       vi.mocked(fs.readdir).mockImplementation((dirPath: any) => {
@@ -551,9 +551,9 @@ Skill 3 content`);
             `---\nname: shared-skill\ndescription: From qwen dir\n---\nQwen content`,
           );
         }
-        if (pathStr.includes('.agent') && pathStr.includes('shared-skill')) {
+        if (pathStr.includes('.agents') && pathStr.includes('shared-skill')) {
           return Promise.resolve(
-            `---\nname: shared-skill\ndescription: From agent dir\n---\nAgent content`,
+            `---\nname: shared-skill\ndescription: From agents dir\n---\nAgents content`,
           );
         }
         return Promise.reject(new Error('File not found'));
@@ -598,7 +598,7 @@ Skill 3 content`);
       expect(baseDirs).toHaveLength(2);
       expect(baseDirs).toContain(path.join('/test/project', '.qwen', 'skills'));
       expect(baseDirs).toContain(
-        path.join('/test/project', '.agent', 'skills'),
+        path.join('/test/project', '.agents', 'skills'),
       );
     });
 
@@ -607,7 +607,7 @@ Skill 3 content`);
 
       expect(baseDirs).toHaveLength(2);
       expect(baseDirs).toContain(path.join('/home/user', '.qwen', 'skills'));
-      expect(baseDirs).toContain(path.join('/home/user', '.agent', 'skills'));
+      expect(baseDirs).toContain(path.join('/home/user', '.agents', 'skills'));
     });
 
     it('should return bundled-level base dir', () => {


### PR DESCRIPTION
## TLDR

Adds `.agents` (with an "s") as a skill provider directory, following the emerging cross-tool convention ([agentskills/agentskills#15](https://github.com/agentskills/agentskills/issues/15)). One-line change to `SKILL_PROVIDER_CONFIG_DIRS` with updated tests.

## Dive Deeper

Currently only `.qwen/skills` and `.agent/skills` are recognized. Multiple AI agent tools are converging on `.agents/skills` as a standard directory (Cursor, Claude Code, etc.). This adds it as a third option.

**Change:** `packages/core/src/config/storage.ts` line 15:
```diff
- export const SKILL_PROVIDER_CONFIG_DIRS = ['.'qwen\, '.'agent'];
+ export const SKILL_PROVIDER_CONFIG_DIRS = ['.'qwen\, '.'agent', '.'agents'];
```

Precedence order: `.qwen` > `.agent` > `.agents` (first match wins in deduplication). All downstream code (`skill-manager.ts`, `storage.ts getUserSkillsDirs()`) automatically picks up the new directory via the shared constant.

## Reviewer Test Plan

1. Create `.agents/skills/test-skill/SKILL.md` in project root
2. Run `qwen` and verify the skill appears in `/skills` listing
3. Verify `.qwen` and `.agent` skills still take precedence over `.agents` duplicates

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |

## Linked issues / bugs

Closes #2155