### PR TITLE
fix: correct MiniMax-M2.5 context window size

### DIFF
--- a/packages/cli/src/constants/codingPlan.ts
+++ b/packages/cli/src/constants/codingPlan.ts
@@ -97,7 +97,7 @@ export function generateCodingPlanTemplate(
           extra_body: {
             enable_thinking: true,
           },
-          contextWindowSize: 1000000,
+          contextWindowSize: 196608,
         },
       },
       {
@@ -222,7 +222,7 @@ export function generateCodingPlanTemplate(
         extra_body: {
           enable_thinking: true,
         },
-        contextWindowSize: 1000000,
+        contextWindowSize: 196608,
       },
     },
     {

--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -192,8 +192,8 @@ describe('tokenLimit', () => {
   });
 
   describe('MiniMax', () => {
-    it('should return 1M for MiniMax-M2.5 (latest)', () => {
-      expect(tokenLimit('MiniMax-M2.5')).toBe(1000000);
+    it('should return 192K for MiniMax-M2.5 (latest)', () => {
+      expect(tokenLimit('MiniMax-M2.5')).toBe(196608);
     });
 
     it('should return 200K for MiniMax fallback', () => {

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -21,6 +21,7 @@ const LIMITS = {
   '32k': 32_768,
   '64k': 65_536,
   '128k': 131_072,
+  '192k': 196_608, // 192 * 1024, MiniMax-M2.5 context window
   '200k': 200_000, // vendor-declared decimal, used by OpenAI, Anthropic, etc.
   '256k': 262_144,
   '272k': 272_000, // vendor-declared decimal, GPT-5.x input (400K total - 128K output)
@@ -128,7 +129,7 @@ const PATTERNS: Array<[RegExp, TokenCount]> = [
   // -------------------
   // MiniMax
   // -------------------
-  [/^minimax-m2\.5/i, LIMITS['1m']], // MiniMax-M2.5: 1,000,000
+  [/^minimax-m2\.5/i, LIMITS['192k']], // MiniMax-M2.5: 196,608
   [/^minimax-/i, LIMITS['200k']], // MiniMax fallback: 200K
 
   // -------------------


### PR DESCRIPTION
## TLDR

Fixes the incorrect `contextWindowSize` for MiniMax-M2.5. Changed from `1000000` (1M) to `196608` (192K) to match the vendor-declared context window.

## Dive Deeper

The MiniMax-M2.5 model was configured with a context window of 1,000,000 tokens, but the actual supported context window is 196,608 tokens (192K) per [official Alibaba Coding Plan documentation](https://www.alibabacloud.com/help/en/model-studio/openclaw-coding-plan).

### Changes:
- **`packages/cli/src/constants/codingPlan.ts`**: Updated `contextWindowSize` from `1000000` to `196608` for both the domestic and international Bailian Coding Plan entries.
- **`packages/core/src/core/tokenLimits.ts`**: Added `192k: 196_608` to LIMITS and updated the MiniMax-M2.5 input pattern to use it.
- **`packages/core/src/core/tokenLimits.test.ts`**: Updated test expectation to match the corrected value.

## Reviewer Test Plan

1. Run `npx vitest run packages/core/src/core/tokenLimits.test.ts` — all 51 tests should pass.
2. Verify that connecting to Bailian Coding Plan with MiniMax-M2.5 generates a config with `contextWindowSize: 196608`.

## Testing Matrix

| Test | Result |
|------|--------|
| `tokenLimits.test.ts` (51 tests) | ✅ Pass |

## Linked issues

Fixes #2465