### PR TITLE
fix: add /copy code command to extract clean code blocks without line numbers

### DIFF
--- a/packages/cli/src/ui/commands/copyCommand.test.ts
+++ b/packages/cli/src/ui/commands/copyCommand.test.ts
@@ -6,7 +6,7 @@
 
 import type { Mock } from 'vitest';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { copyCommand } from './copyCommand.js';
+import { copyCommand, extractCodeBlocks } from './copyCommand.js';
 import { type CommandContext } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import { copyToClipboard } from '../utils/commandUtils.js';
@@ -300,5 +300,106 @@ describe('copyCommand', () => {
     });
 
     expect(mockCopyToClipboard).not.toHaveBeenCalled();
+  });
+
+  describe('/copy code', () => {
+    it('should extract and copy only code blocks when args is "code"', async () => {
+      if (!copyCommand.action) throw new Error('Command has no action');
+
+      const markdownWithCode = [
+        {
+          role: 'model',
+          parts: [
+            {
+              text: 'Here is the code:\n```python\nprint("hello")\n```\nDone!',
+            },
+          ],
+        },
+      ];
+
+      mockGetHistory.mockReturnValue(markdownWithCode);
+      mockCopyToClipboard.mockResolvedValue(undefined);
+
+      const result = await copyCommand.action(mockContext, 'code');
+
+      expect(mockCopyToClipboard).toHaveBeenCalledWith('print("hello")');
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: 'Code block copied to the clipboard',
+      });
+    });
+
+    it('should copy multiple code blocks separated by blank lines', async () => {
+      if (!copyCommand.action) throw new Error('Command has no action');
+
+      const markdownWithMultipleBlocks = [
+        {
+          role: 'model',
+          parts: [
+            {
+              text: '```js\nconst a = 1;\n```\nAnd:\n```ts\nconst b: number = 2;\n```',
+            },
+          ],
+        },
+      ];
+
+      mockGetHistory.mockReturnValue(markdownWithMultipleBlocks);
+      mockCopyToClipboard.mockResolvedValue(undefined);
+
+      const result = await copyCommand.action(mockContext, 'code');
+
+      expect(mockCopyToClipboard).toHaveBeenCalledWith(
+        'const a = 1;\n\nconst b: number = 2;',
+      );
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: '2 code blocks copied to the clipboard',
+      });
+    });
+
+    it('should return info when no code blocks found', async () => {
+      if (!copyCommand.action) throw new Error('Command has no action');
+
+      const markdownWithoutCode = [
+        {
+          role: 'model',
+          parts: [{ text: 'Just plain text, no code here.' }],
+        },
+      ];
+
+      mockGetHistory.mockReturnValue(markdownWithoutCode);
+
+      const result = await copyCommand.action(mockContext, 'code');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: 'No code blocks found in the last AI output.',
+      });
+      expect(mockCopyToClipboard).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('extractCodeBlocks', () => {
+  it('should extract a single code block', () => {
+    const md = '```python\nprint("hello")\n```';
+    expect(extractCodeBlocks(md)).toEqual(['print("hello")']);
+  });
+
+  it('should extract multiple code blocks', () => {
+    const md = '```js\nconst a = 1;\n```\ntext\n```ts\nconst b = 2;\n```';
+    expect(extractCodeBlocks(md)).toEqual(['const a = 1;', 'const b = 2;']);
+  });
+
+  it('should return empty array when no code blocks', () => {
+    expect(extractCodeBlocks('just text')).toEqual([]);
+  });
+
+  it('should preserve multi-line code content', () => {
+    const md = '```python\nline1\nline2\nline3\n```';
+    expect(extractCodeBlocks(md)).toEqual(['line1\nline2\nline3']);
   });
 });

--- a/packages/cli/src/ui/commands/copyCommand.ts
+++ b/packages/cli/src/ui/commands/copyCommand.ts
@@ -9,13 +9,27 @@ import type { SlashCommand, SlashCommandActionReturn } from './types.js';
 import { CommandKind } from './types.js';
 import { t } from '../../i18n/index.js';
 
+/**
+ * Extracts all fenced code blocks from a markdown string,
+ * returning only the code content without the fence markers or language tags.
+ */
+export function extractCodeBlocks(markdown: string): string[] {
+  const codeBlockRegex = /^```[^\n]*\n([\s\S]*?)^```/gm;
+  const blocks: string[] = [];
+  let match;
+  while ((match = codeBlockRegex.exec(markdown)) !== null) {
+    blocks.push(match[1].replace(/\n$/, ''));
+  }
+  return blocks;
+}
+
 export const copyCommand: SlashCommand = {
   name: 'copy',
   get description() {
     return t('Copy the last result or code snippet to clipboard');
   },
   kind: CommandKind.BUILT_IN,
-  action: async (context, _args): Promise<SlashCommandActionReturn | void> => {
+  action: async (context, args): Promise<SlashCommandActionReturn | void> => {
     const chat = await context.services.config?.getGeminiClient()?.getChat();
     const history = chat?.getHistory();
 
@@ -37,30 +51,54 @@ export const copyCommand: SlashCommand = {
       .map((part) => part.text)
       .join('');
 
-    if (lastAiOutput) {
-      try {
-        await copyToClipboard(lastAiOutput);
-
-        return {
-          type: 'message',
-          messageType: 'info',
-          content: 'Last output copied to the clipboard',
-        };
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        context.services.config?.getDebugLogger().debug(message);
-
-        return {
-          type: 'message',
-          messageType: 'error',
-          content: `Failed to copy to the clipboard. ${message}`,
-        };
-      }
-    } else {
+    if (!lastAiOutput) {
       return {
         type: 'message',
         messageType: 'info',
         content: 'Last AI output contains no text to copy.',
+      };
+    }
+
+    const trimmedArgs = args?.trim().toLowerCase() ?? '';
+    let textToCopy: string;
+    let successMessage: string;
+
+    if (trimmedArgs === 'code') {
+      // Extract only fenced code blocks, without line numbers or UI decorations
+      const blocks = extractCodeBlocks(lastAiOutput);
+      if (blocks.length === 0) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: 'No code blocks found in the last AI output.',
+        };
+      }
+      textToCopy = blocks.join('\n\n');
+      successMessage =
+        blocks.length === 1
+          ? 'Code block copied to the clipboard'
+          : `${blocks.length} code blocks copied to the clipboard`;
+    } else {
+      textToCopy = lastAiOutput;
+      successMessage = 'Last output copied to the clipboard';
+    }
+
+    try {
+      await copyToClipboard(textToCopy);
+
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: successMessage,
+      };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      context.services.config?.getDebugLogger().debug(message);
+
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `Failed to copy to the clipboard. ${message}`,
       };
     }
   },


### PR DESCRIPTION
## TLDR

Add a `/copy code` subcommand that extracts only fenced code block contents from the last AI response, providing clean code ready to paste into an editor — without line numbers or UI decorations.

Closes #1388

## Dive Deeper

When using read-only mode, code blocks are rendered with line numbers and separator characters (`│`). Terminal text selection inevitably includes these decorations, making pasted code invalid.

While `showLineNumbers` can be toggled off in settings, a more ergonomic solution is to offer `/copy code` that extracts raw code from fenced blocks in the markdown source — before any TUI rendering.

**Changes:**
- `copyCommand.ts`: Added `extractCodeBlocks()` helper using multiline regex to extract fenced code block contents. Extended the `/copy` action to accept an optional `code` argument.
- `copyCommand.test.ts`: Added 7 new tests covering `/copy code` behavior and `extractCodeBlocks()` edge cases.

The original `/copy` behavior (copying full output) remains unchanged when no argument is provided.

## Reviewer Test Plan

1. Ask the AI to generate code (e.g., "write a Python hello world")
2. Run `/copy code` — verify only the code block content is in clipboard, without language tags or fence markers
3. Run `/copy` — verify the full markdown output is still copied as before
4. Ask for a response with no code blocks, then run `/copy code` — verify the "No code blocks found" info message

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |

## Linked issues / bugs

Closes #1388