### PR TITLE
fix: preserve manually-added models when using /model command

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -307,7 +307,10 @@ export class LoadedSettings {
     setNestedPropertySafe(settingsFile.settings, key, value);
     setNestedPropertySafe(settingsFile.originalSettings, key, value);
     this._merged = this.computeMergedSettings();
-    saveSettings(settingsFile);
+    // Only write the changed key to disk to preserve externally-added settings
+    const updates: Record<string, unknown> = {};
+    setNestedPropertySafe(updates, key, value);
+    saveSettings(settingsFile, updates);
   }
 }
 
@@ -703,7 +706,10 @@ export function loadSettings(
   );
 }
 
-export function saveSettings(settingsFile: SettingsFile): void {
+export function saveSettings(
+  settingsFile: SettingsFile,
+  updates?: Record<string, unknown>,
+): void {
   try {
     // Ensure the directory exists
     const dirPath = path.dirname(settingsFile.path);
@@ -711,10 +717,12 @@ export function saveSettings(settingsFile: SettingsFile): void {
       fs.mkdirSync(dirPath, { recursive: true });
     }
 
-    // Use the format-preserving update function
+    // Use the format-preserving update function.
+    // When targeted updates are provided, only those keys are written to disk,
+    // preserving any settings that were externally added to the file.
     updateSettingsFilePreservingFormat(
       settingsFile.path,
-      settingsFile.originalSettings as Record<string, unknown>,
+      updates ?? (settingsFile.originalSettings as Record<string, unknown>),
     );
   } catch (error) {
     debugLogger.error('Error saving user settings file.');

--- a/packages/cli/src/utils/commentJson.test.ts
+++ b/packages/cli/src/utils/commentJson.test.ts
@@ -148,6 +148,41 @@ describe('commentJson', () => {
       expect(updatedContent).toContain('"API_KEY": "new-test-key"');
     });
 
+    it('should preserve externally-added settings when updating a single key', () => {
+      // Simulates the scenario from issue #2454: user manually adds custom
+      // models to the config file, then uses /model to switch models.
+      // Only the changed key should be written, preserving the rest.
+      const originalContent = JSON.stringify(
+        {
+          model: { name: 'qwen-2.5' },
+          modelProviders: {
+            'api-key': [
+              { id: 'qwen-2.5', label: 'Qwen 2.5' },
+              { id: 'custom-model', label: 'My Custom Model' },
+            ],
+          },
+        },
+        null,
+        2,
+      );
+
+      fs.writeFileSync(testFilePath, originalContent, 'utf-8');
+
+      // Only update model.name, not the entire settings object
+      updateSettingsFilePreservingFormat(testFilePath, {
+        model: { name: 'qwen-plus' },
+      });
+
+      const updatedContent = fs.readFileSync(testFilePath, 'utf-8');
+      const parsed = JSON.parse(updatedContent);
+
+      // The model name should be updated
+      expect(parsed.model.name).toBe('qwen-plus');
+      // The custom model should still be present
+      expect(parsed.modelProviders['api-key']).toHaveLength(2);
+      expect(parsed.modelProviders['api-key'][1].id).toBe('custom-model');
+    });
+
     it('should handle corrupted JSON files gracefully', () => {
       const corruptedContent = `{
         "model": "gemini-2.5-pro",
@@ -182,5 +217,20 @@ describe('applyUpdates', () => {
     const updates = { b: {} };
     const result = applyUpdates(original, updates);
     expect(result).toEqual({ a: 1, b: {} });
+  });
+  it('should not remove keys from current that are absent in updates', () => {
+    const current = {
+      model: { name: 'qwen-2.5' },
+      modelProviders: {
+        'api-key': [{ id: 'qwen-2.5' }, { id: 'custom-model' }],
+      },
+    };
+    const updates = { model: { name: 'qwen-plus' } };
+    const result = applyUpdates(
+      current as Record<string, unknown>,
+      updates as Record<string, unknown>,
+    );
+    expect((result as any).model.name).toBe('qwen-plus');
+    expect((result as any).modelProviders['api-key']).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## TLDR

Fix `/model` command silently removing manually-added custom models from `settings.json`.

Closes #2454

## Dive Deeper

When using `/model` to switch models, `setValue()` called `saveSettings()` with the full in-memory `originalSettings` snapshot (captured at startup). Any models manually added to `settings.json` after launch would be silently overwritten.

The fix makes `setValue()` build a minimal update object containing only the changed key-value pair, passing that to `saveSettings()` instead. This ensures only the specific setting (e.g. `model.name`) is written to disk, preserving all other settings including externally-added custom models.

**Changed files:**
- `packages/cli/src/config/settings.ts` — `setValue()` now builds targeted updates; `saveSettings()` accepts optional `updates` parameter
- `packages/cli/src/utils/commentJson.test.ts` — Added test verifying external settings are preserved during targeted save

## Reviewer Test Plan

1. Add a custom model entry to `~/.qwen/settings.json` manually
2. Use `/model` to switch to a different model
3. Check `settings.json` — the custom model entry should still be present

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |

## Linked issues / bugs

Closes #2454