### PR TITLE
fix: fall back to local filesystem when ACP writeTextFile fails

### DIFF
--- a/packages/cli/src/acp-integration/service/filesystem.test.ts
+++ b/packages/cli/src/acp-integration/service/filesystem.test.ts
@@ -127,4 +127,81 @@ describe('AcpFileSystemService', () => {
       expect(client.readTextFile).not.toHaveBeenCalled();
     });
   });
+
+  describe('writeTextFile', () => {
+    it('falls back to local filesystem when ACP write fails', async () => {
+      const client = {
+        writeTextFile: vi.fn().mockRejectedValue(new Error('invalid path')),
+      } as unknown as AgentSideConnection;
+
+      const fallback = createFallback();
+      const svc = new AcpFileSystemService(
+        client,
+        'session-1',
+        { readTextFile: true, writeTextFile: true },
+        fallback,
+      );
+
+      await svc.writeTextFile({
+        path: '/some/new-dir/file.txt',
+        content: 'hello',
+      });
+
+      expect(fallback.writeTextFile).toHaveBeenCalledWith({
+        path: '/some/new-dir/file.txt',
+        content: 'hello',
+      });
+    });
+
+    it('writes through ACP when connection succeeds', async () => {
+      const client = {
+        writeTextFile: vi.fn().mockResolvedValue(undefined),
+      } as unknown as AgentSideConnection;
+
+      const fallback = createFallback();
+      const svc = new AcpFileSystemService(
+        client,
+        'session-1',
+        { readTextFile: true, writeTextFile: true },
+        fallback,
+      );
+
+      await svc.writeTextFile({
+        path: '/some/file.txt',
+        content: 'hello',
+      });
+
+      expect(client.writeTextFile).toHaveBeenCalledWith({
+        path: '/some/file.txt',
+        content: 'hello',
+        sessionId: 'session-1',
+      });
+      expect(fallback.writeTextFile).not.toHaveBeenCalled();
+    });
+
+    it('uses fallback when writeTextFile capability is disabled', async () => {
+      const client = {
+        writeTextFile: vi.fn(),
+      } as unknown as AgentSideConnection;
+
+      const fallback = createFallback();
+      const svc = new AcpFileSystemService(
+        client,
+        'session-1',
+        { readTextFile: true, writeTextFile: false },
+        fallback,
+      );
+
+      await svc.writeTextFile({
+        path: '/some/file.txt',
+        content: 'hello',
+      });
+
+      expect(fallback.writeTextFile).toHaveBeenCalledWith({
+        path: '/some/file.txt',
+        content: 'hello',
+      });
+      expect(client.writeTextFile).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/cli/src/acp-integration/service/filesystem.ts
+++ b/packages/cli/src/acp-integration/service/filesystem.ts
@@ -84,11 +84,17 @@ export class AcpFileSystemService implements FileSystemService {
       ? '\uFEFF' + params.content
       : params.content;
 
-    await this.connection.writeTextFile({
-      ...params,
-      content: finalContent,
-      sessionId: this.sessionId,
-    });
+    try {
+      await this.connection.writeTextFile({
+        ...params,
+        content: finalContent,
+        sessionId: this.sessionId,
+      });
+    } catch {
+      // Fall back to local filesystem if ACP write fails (e.g. file does not
+      // yet exist and the IDE companion rejects the path).
+      return this.fallback.writeTextFile(params);
+    }
 
     return { _meta: params._meta };
   }


### PR DESCRIPTION
## TLDR

When the IDE companion rejects a `writeTextFile` request (e.g. because the target file does not yet exist), the ACP filesystem service now falls back to the local filesystem service instead of propagating the error.

Closes #2294

## Dive Deeper

The `readTextFile` method already handles ACP errors gracefully (converting `RESOURCE_NOT_FOUND` to `ENOENT`), but `writeTextFile` had no error handling — any ACP failure would bubble up and crash the write operation.

The local filesystem fallback (`FileSystemService.writeTextFile`) works correctly for new files because the `WriteFileTool` creates parent directories before calling `writeTextFile`. By falling back on ACP error, new file creation succeeds transparently.

**Changed files:**
- `packages/cli/src/acp-integration/service/filesystem.ts` — Wrapped `connection.writeTextFile()` in try/catch with fallback
- `packages/cli/src/acp-integration/service/filesystem.test.ts` — Added 3 test cases for writeTextFile (success, fallback on error, capability disabled)

## Reviewer Test Plan

1. Open a project in VS Code with the Qwen extension
2. Ask the agent to create a new file in a subdirectory that does not exist
3. Verify the file is created successfully (previously would fail with "invalid path")

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |

## Linked issues / bugs

Closes #2294