### PR TITLE
fix: adapt keyboard shortcut display for macOS

### DIFF
--- a/packages/cli/src/ui/components/KeyboardShortcuts.tsx
+++ b/packages/cli/src/ui/components/KeyboardShortcuts.tsx
@@ -9,6 +9,7 @@ import { Box, Text } from 'ink';
 import { theme } from '../semantic-colors.js';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
 import { t } from '../../i18n/index.js';
+import { formatShortcut } from '../utils/shortcutFormatter.js';
 
 interface Shortcut {
   key: string;
@@ -47,7 +48,8 @@ const getShortcuts = (): Shortcut[] => [
 
 const ShortcutItem: React.FC<{ shortcut: Shortcut }> = ({ shortcut }) => (
   <Text color={theme.text.secondary}>
-    <Text color={theme.text.accent}>{shortcut.key}</Text> {shortcut.description}
+    <Text color={theme.text.accent}>{formatShortcut(shortcut.key)}</Text>{' '}
+    {shortcut.description}
   </Text>
 );
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -77,6 +77,7 @@ import { useSessionStats } from '../contexts/SessionContext.js';
 import type { LoadedSettings } from '../../config/settings.js';
 import { t } from '../../i18n/index.js';
 import { useDualOutput } from '../../dualOutput/DualOutputContext.js';
+import { formatShortcut } from '../utils/shortcutFormatter.js';
 
 const debugLogger = createDebugLogger('GEMINI_STREAM');
 
@@ -867,8 +868,11 @@ export const useGeminiStream = (
       );
 
       if (!isShowingAutoRetry) {
-        const retryHint = t('Press Ctrl+Y to retry');
-        // Store error with hint as a pending item (not in history).
+        const retryKey = formatShortcut('ctrl+y');
+        const retryHint = t('Press Ctrl+Y to retry').replace(
+          'Ctrl+Y',
+          retryKey,
+        );
         // This allows the hint to be removed when the user retries with Ctrl+Y,
         // since pending items are in the dynamic rendering area (not <Static>).
         setPendingRetryErrorItem({
@@ -1475,8 +1479,10 @@ export const useGeminiStream = (
             onAuthError('Session expired or is unauthorized.');
           } else if (!isNodeError(error) || error.name !== 'AbortError') {
             lastPromptErroredRef.current = true;
-            const retryHint = t('Press Ctrl+Y to retry');
-            // Store error with hint as a pending item (same as handleErrorEvent)
+            const retryHint = t('Press Ctrl+Y to retry').replace(
+              'Ctrl+Y',
+              formatShortcut('ctrl+y'),
+            );
             setPendingRetryErrorItem({
               type: 'error' as const,
               text: parseAndFormatApiError(

--- a/packages/cli/src/ui/utils/shortcutFormatter.test.ts
+++ b/packages/cli/src/ui/utils/shortcutFormatter.test.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+describe('formatShortcut', () => {
+  const originalPlatform = process.platform;
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
+    vi.resetModules();
+  });
+
+  it('converts modifier keys to Mac symbols on darwin', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const { formatShortcut } = await import('./shortcutFormatter.js');
+    expect(formatShortcut('ctrl+y')).toBe('⌃Y');
+    expect(formatShortcut('cmd+v')).toBe('⌘V');
+    expect(formatShortcut('alt+v')).toBe('⌥V');
+    expect(formatShortcut('shift+tab')).toBe('⇧TAB');
+  });
+
+  it('handles multi-part shortcuts on darwin', async () => {
+    Object.defineProperty(process, 'platform', { value: 'darwin' });
+    const { formatShortcut } = await import('./shortcutFormatter.js');
+    expect(formatShortcut('esc esc')).toBe('ESC ESC');
+  });
+
+  it('returns input unchanged on non-darwin', async () => {
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    const { formatShortcut } = await import('./shortcutFormatter.js');
+    expect(formatShortcut('ctrl+y')).toBe('ctrl+y');
+    expect(formatShortcut('ctrl+c')).toBe('ctrl+c');
+  });
+});

--- a/packages/cli/src/ui/utils/shortcutFormatter.ts
+++ b/packages/cli/src/ui/utils/shortcutFormatter.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const isMac = process.platform === 'darwin';
+
+/**
+ * Maps modifier names to macOS symbol equivalents.
+ */
+const MAC_MODIFIERS: Record<string, string> = {
+  ctrl: '⌃',
+  cmd: '⌘',
+  alt: '⌥',
+  shift: '⇧',
+};
+
+/**
+ * Formats a keyboard shortcut string for display, using macOS symbols when
+ * running on Darwin.
+ *
+ * Examples (on macOS):
+ *   "ctrl+y"  → "⌃Y"
+ *   "cmd+v"   → "⌘V"
+ *   "ctrl+c"  → "⌃C"
+ *
+ * On other platforms the input is returned unchanged.
+ */
+export function formatShortcut(shortcut: string): string {
+  if (!isMac) {
+    return shortcut;
+  }
+
+  return shortcut
+    .split(/\s+/)
+    .map((combo) => {
+      const parts = combo.split('+');
+      let result = '';
+      for (const part of parts) {
+        const lower = part.toLowerCase();
+        if (MAC_MODIFIERS[lower]) {
+          result += MAC_MODIFIERS[lower];
+        } else {
+          result += part.toUpperCase();
+        }
+      }
+      return result;
+    })
+    .join(' ');
+}


### PR DESCRIPTION
## TLDR

On macOS, keyboard shortcut hints now use native modifier symbols (`⌃` for Ctrl, `⌘` for Cmd, `⌥` for Alt, `⇧` for Shift) instead of the generic text format.

Closes #2227

## Dive Deeper

The CLI keyboard shortcut panel and error retry hints displayed shortcuts like `ctrl+y`, `cmd+v` regardless of platform. On macOS, the convention is to use symbolic modifiers (`⌃Y`, `⌘V`).

**Changes:**
- `packages/cli/src/ui/utils/shortcutFormatter.ts` — New `formatShortcut()` utility that converts modifier names to macOS symbols when `process.platform === "darwin"`
- `packages/cli/src/ui/components/KeyboardShortcuts.tsx` — Apply `formatShortcut()` to shortcut key display
- `packages/cli/src/ui/hooks/useGeminiStream.ts` — Apply `formatShortcut()` to "Press Ctrl+Y to retry" hint messages
- `packages/cli/src/ui/utils/shortcutFormatter.test.ts` — Tests for Mac symbol conversion, multi-part shortcuts, and non-Mac passthrough

Non-macOS platforms are completely unaffected — the formatter is a no-op on Linux/Windows.

## Reviewer Test Plan

1. Run on macOS — verify shortcut panel shows `⌃Y`, `⌃C`, `⌘V` etc.
2. Trigger an API error — verify retry hint shows `⌃Y` instead of `Ctrl+Y`
3. Run on Linux/Windows — verify shortcuts display unchanged (`ctrl+y`, `ctrl+c`)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |

## Linked issues / bugs

Closes #2227