### PR TITLE
fix: refresh cached version after successful auto-update

### DIFF
--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -12,6 +12,7 @@ import type { HistoryItem } from '../ui/types.js';
 import { MessageType } from '../ui/types.js';
 import { spawnWrapper } from './spawnWrapper.js';
 import type { spawn } from 'node:child_process';
+import { clearPackageJsonCache } from './package.js';
 import os from 'node:os';
 
 export function handleAutoUpdate(
@@ -64,6 +65,7 @@ export function handleAutoUpdate(
 
   updateProcess.on('close', (code) => {
     if (code === 0) {
+      clearPackageJsonCache();
       updateEventEmitter.emit('update-success', {
         message:
           'Update successful! The new version will be used on your next run.',

--- a/packages/cli/src/utils/package.ts
+++ b/packages/cli/src/utils/package.ts
@@ -36,3 +36,7 @@ export async function getPackageJson(): Promise<PackageJson | undefined> {
   packageJson = result.packageJson;
   return packageJson;
 }
+
+export function clearPackageJsonCache(): void {
+  packageJson = undefined;
+}


### PR DESCRIPTION
## TLDR

After auto-update completes successfully, `/about` still shows the old CLI version until restart. This PR clears the package.json cache after auto-update so the version is refreshed immediately.

## Dive Deeper

`getPackageJson()` in `utils/package.ts` caches the result in a module-level variable on first call. After auto-update installs a new version, this stale cache causes `/about` to display the pre-update version.

The fix adds a `clearPackageJsonCache()` function and calls it in `handleAutoUpdate.ts` when the update process exits with code 0. The next call to `getCliVersion()` will re-read the package.json from disk, picking up the new version.

## Reviewer Test Plan

1. Start qwen-code with auto-update enabled
2. When an update is available and installed, run `/about`
3. The CLI Version field should show the newly installed version without needing to restart

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |

## Linked issues / bugs

Closes #1305