### PR TITLE
fix: update TOS link in VS Code extension README

### DIFF
--- a/packages/vscode-ide-companion/README.md
+++ b/packages/vscode-ide-companion/README.md
@@ -63,7 +63,7 @@ We welcome contributions! See our [Contributing Guide](https://github.com/QwenLM
 
 ## Terms of Service and Privacy Notice
 
-By installing this extension, you agree to the [Terms of Service](https://github.com/QwenLM/qwen-code/blob/main/docs/tos-privacy.md).
+By installing this extension, you agree to the [Terms of Service](https://qwenlm.github.io/qwen-code-docs/en/users/support/tos-privacy/).
 
 ## License
 


### PR DESCRIPTION
## TLDR

Fix the broken Terms of Service link in the VS Code extension README. The old link (`docs/tos-privacy.md`) returns 404 — updated to the correct docs site URL.

## Dive Deeper

The TOS file was moved from `docs/tos-privacy.md` to `docs/users/support/tos-privacy.md`. The CLI auth dialog already uses the correct URL (`qwenlm.github.io/qwen-code-docs/en/users/support/tos-privacy/`), but the VS Code extension README was not updated.

## Reviewer Test Plan

Click the TOS link in the updated README to verify it resolves correctly.

## Testing Matrix

N/A — documentation-only change.

## Linked issues / bugs

Closes #1066