### PR TITLE
fix: handle escaped pipe characters in markdown table cells

### DIFF
--- a/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.test.tsx
@@ -155,6 +155,21 @@ Some text before.
       expect(lastFrame()).toMatchSnapshot();
     });
 
+    it('renders escaped pipe characters inside table cells', () => {
+      const text = `
+| Type | Example |
+|------|---------|
+| Union | A\\|B |
+| Plain | Hello |
+`.replace(/\n/g, eol);
+      const { lastFrame } = renderWithProviders(
+        <MarkdownDisplay {...baseProps} text={text} />,
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('A|B');
+      expect(frame).not.toContain('A\\|B');
+    });
+
     it('inserts a single space between paragraphs', () => {
       const text = `Paragraph 1.
 

--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -27,6 +27,16 @@ const CODE_BLOCK_PREFIX_PADDING = 1;
 const LIST_ITEM_PREFIX_PADDING = 1;
 const LIST_ITEM_TEXT_FLEX_GROW = 1;
 
+/**
+ * Splits a markdown table row on unescaped `|` delimiters,
+ * then un-escapes any `\|` sequences within each cell.
+ */
+function splitTableCells(row: string): string[] {
+  return row
+    .split(/(?<!\\)\|/)
+    .map((cell) => cell.replace(/\\\|/g, '|').trim());
+}
+
 const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   text,
   isPending,
@@ -111,7 +121,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
         lines[index + 1].match(tableSeparatorRegex)
       ) {
         inTable = true;
-        tableHeaders = tableRowMatch[1].split('|').map((cell) => cell.trim());
+        tableHeaders = splitTableCells(tableRowMatch[1]);
         tableRows = [];
       } else {
         // Not a table, treat as regular text
@@ -127,7 +137,7 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
       // Skip separator line - already handled
     } else if (inTable && tableRowMatch) {
       // Add table row
-      const cells = tableRowMatch[1].split('|').map((cell) => cell.trim());
+      const cells = splitTableCells(tableRowMatch[1]);
       // Ensure row has same column count as headers
       while (cells.length < tableHeaders.length) {
         cells.push('');


### PR DESCRIPTION
## TLDR

Table cells containing literal `|` characters (e.g. `A|B`) were incorrectly split across columns. This fixes the markdown table parser to respect escaped `\|` sequences.

## Dive Deeper

The `MarkdownDisplay.tsx` component parses markdown tables by splitting rows on `|` using `split("|")`. This treats every `|` as a column delimiter, even when the character is part of the cell content (e.g. type unions `A|B`, regex patterns `[a|b]`).

**Root cause:** Lines 114 and 130 of `MarkdownDisplay.tsx` used naive `split("|")`.

**Fix:** Added a `splitTableCells()` helper that:
1. Splits on unescaped `|` only, using a negative lookbehind regex: `/(?<!\\)\|/`
2. Un-escapes `\|` back to `|` in each cell via `.replace(/\\\|/g, "|")`

This follows standard markdown table escaping conventions (e.g. GitHub Flavored Markdown).

## Testing Matrix

- [x] Existing 32 MarkdownDisplay tests pass
- [x] New test: table with `A\|B` renders as `A|B` in a single cell
- [x] New test: verifies `\|` is not left as literal escaped text

Closes #2461