### PR TITLE
fix: prevent /model command from overwriting externally-added settings

### DIFF
--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -375,7 +375,7 @@ export class LoadedSettings {
     setNestedPropertySafe(settingsFile.settings, key, value);
     setNestedPropertySafe(settingsFile.originalSettings, key, value);
     this._merged = this.computeMergedSettings();
-    saveSettings(settingsFile);
+    saveSettingsKey(settingsFile.path, key, value);
   }
 }
 
@@ -786,6 +786,33 @@ export function saveSettings(settingsFile: SettingsFile): void {
     );
   } catch (error) {
     debugLogger.error('Error saving user settings file.');
+    debugLogger.error(error instanceof Error ? error.message : String(error));
+    throw error;
+  }
+}
+
+/**
+ * Saves only a single key-value pair to the settings file on disk.
+ * Unlike saveSettings(), this builds a minimal update object so that
+ * only the specified key is written — all other content in the file
+ * (including entries added externally while the app was running) is preserved.
+ */
+export function saveSettingsKey(
+  filePath: string,
+  key: string,
+  value: unknown,
+): void {
+  try {
+    const dirPath = path.dirname(filePath);
+    if (!fs.existsSync(dirPath)) {
+      fs.mkdirSync(dirPath, { recursive: true });
+    }
+
+    const update: Record<string, unknown> = {};
+    setNestedPropertySafe(update, key, value);
+    updateSettingsFilePreservingFormat(filePath, update);
+  } catch (error) {
+    debugLogger.error('Error saving settings key.');
     debugLogger.error(error instanceof Error ? error.message : String(error));
     throw error;
   }

--- a/packages/cli/src/utils/commentJson.test.ts
+++ b/packages/cli/src/utils/commentJson.test.ts
@@ -167,6 +167,28 @@ describe('commentJson', () => {
       const unchangedContent = fs.readFileSync(testFilePath, 'utf-8');
       expect(unchangedContent).toBe(corruptedContent);
     });
+
+    it('should preserve keys not present in the update object', () => {
+      const originalContent = `{
+        "model": { "name": "old-model" },
+        "modelProviders": [
+          { "name": "provider1" },
+          { "name": "provider2" }
+        ]
+      }`;
+
+      fs.writeFileSync(testFilePath, originalContent, 'utf-8');
+
+      // Only update model.name — modelProviders should be untouched
+      updateSettingsFilePreservingFormat(testFilePath, {
+        model: { name: 'new-model' },
+      });
+
+      const updatedContent = fs.readFileSync(testFilePath, 'utf-8');
+      expect(updatedContent).toContain('"name": "new-model"');
+      expect(updatedContent).toContain('"provider1"');
+      expect(updatedContent).toContain('"provider2"');
+    });
   });
 });
 


### PR DESCRIPTION
## TLDR

The `/model` command (and any `setValue()` call) silently removes entries manually added to `settings.json` while the app is running. This fix ensures only the changed key is written to disk.

## Dive Deeper

**Root cause:** `setValue()` called `saveSettings(settingsFile)`, which passed the entire in-memory `originalSettings` object to `updateSettingsFilePreservingFormat()`. The merge function (`applyUpdates()`) iterates over keys in the update object — for array-valued keys (like `modelProviders`), the stale in-memory version completely replaces the on-disk version, silently dropping entries the user added after app startup.

**Fix:** Added `saveSettingsKey(filePath, key, value)` which:
1. Builds a minimal update object containing only the changed key path (e.g., `{ model: { name: "new-model" } }`)
2. Passes only this minimal object to `updateSettingsFilePreservingFormat()`
3. Since `applyUpdates()` only touches keys present in the update, all other file content is preserved

The existing `saveSettings()` function is kept for backward compatibility but is no longer called from `setValue()`.

## Testing Matrix

- [x] All 87 existing settings tests pass
- [x] All 8 existing commentJson tests pass
- [x] New test: verifies that updating only `model.name` preserves a `modelProviders` array on disk

Closes #2454