### PR TITLE
fix(anthropic): ensure max_tokens exceeds thinking.budget_tokens

### DIFF
--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -283,7 +283,7 @@ describe('AnthropicContentGenerator', () => {
       expect(anthropicRequest).toEqual(
         expect.objectContaining({
           model: 'claude-test',
-          max_tokens: 1000,
+          max_tokens: 9000,
           temperature: 0.7,
           top_p: 0.9,
           top_k: 20,
@@ -423,7 +423,7 @@ describe('AnthropicContentGenerator', () => {
         const [anthropicRequest] =
           anthropicState.lastCreateArgs as AnthropicCreateArgs;
         expect(anthropicRequest).toEqual(
-          expect.objectContaining({ max_tokens: 32000 }),
+          expect.objectContaining({ max_tokens: 40000 }),
         );
       });
 
@@ -488,7 +488,147 @@ describe('AnthropicContentGenerator', () => {
         const [anthropicRequest] =
           anthropicState.lastCreateArgs as AnthropicCreateArgs;
         expect(anthropicRequest).toEqual(
-          expect.objectContaining({ max_tokens: 32000 }),
+          expect.objectContaining({ max_tokens: 40000 }),
+        );
+      });
+    });
+
+    describe('max_tokens vs thinking.budget_tokens guard', () => {
+      it('bumps max_tokens when it equals budget_tokens', async () => {
+        const { AnthropicContentGenerator } = await importGenerator();
+        anthropicState.createImpl.mockResolvedValue({
+          id: 'anthropic-1',
+          model: 'claude-test',
+          content: [{ type: 'text', text: 'hi' }],
+        });
+
+        const generator = new AnthropicContentGenerator(
+          {
+            model: 'claude-test',
+            apiKey: 'test-key',
+            timeout: 10_000,
+            maxRetries: 2,
+            samplingParams: { max_tokens: 32_000 },
+            schemaCompliance: 'auto',
+            reasoning: { budget_tokens: 32_000 },
+          },
+          mockConfig,
+        );
+
+        await generator.generateContent({
+          model: 'models/ignored',
+          contents: 'Hello',
+        } as unknown as GenerateContentParameters);
+
+        const [req] = anthropicState.lastCreateArgs as AnthropicCreateArgs;
+        expect(req).toEqual(
+          expect.objectContaining({
+            max_tokens: 40_000,
+            thinking: { type: 'enabled', budget_tokens: 32_000 },
+          }),
+        );
+      });
+
+      it('bumps max_tokens when it is less than budget_tokens', async () => {
+        const { AnthropicContentGenerator } = await importGenerator();
+        anthropicState.createImpl.mockResolvedValue({
+          id: 'anthropic-1',
+          model: 'claude-test',
+          content: [{ type: 'text', text: 'hi' }],
+        });
+
+        const generator = new AnthropicContentGenerator(
+          {
+            model: 'claude-test',
+            apiKey: 'test-key',
+            timeout: 10_000,
+            maxRetries: 2,
+            samplingParams: { max_tokens: 5_000 },
+            schemaCompliance: 'auto',
+            reasoning: { budget_tokens: 64_000 },
+          },
+          mockConfig,
+        );
+
+        await generator.generateContent({
+          model: 'models/ignored',
+          contents: 'Hello',
+        } as unknown as GenerateContentParameters);
+
+        const [req] = anthropicState.lastCreateArgs as AnthropicCreateArgs;
+        expect(req).toEqual(
+          expect.objectContaining({
+            max_tokens: 72_000,
+            thinking: { type: 'enabled', budget_tokens: 64_000 },
+          }),
+        );
+      });
+
+      it('does not modify max_tokens when it already exceeds budget_tokens', async () => {
+        const { AnthropicContentGenerator } = await importGenerator();
+        anthropicState.createImpl.mockResolvedValue({
+          id: 'anthropic-1',
+          model: 'custom-model',
+          content: [{ type: 'text', text: 'hi' }],
+        });
+
+        const generator = new AnthropicContentGenerator(
+          {
+            model: 'custom-model',
+            apiKey: 'test-key',
+            timeout: 10_000,
+            maxRetries: 2,
+            samplingParams: { max_tokens: 128_000 },
+            schemaCompliance: 'auto',
+            reasoning: { budget_tokens: 64_000 },
+          },
+          mockConfig,
+        );
+
+        await generator.generateContent({
+          model: 'models/ignored',
+          contents: 'Hello',
+        } as unknown as GenerateContentParameters);
+
+        const [req] = anthropicState.lastCreateArgs as AnthropicCreateArgs;
+        expect(req).toEqual(
+          expect.objectContaining({
+            max_tokens: 128_000,
+            thinking: { type: 'enabled', budget_tokens: 64_000 },
+          }),
+        );
+      });
+
+      it('does not modify max_tokens when thinking is disabled', async () => {
+        const { AnthropicContentGenerator } = await importGenerator();
+        anthropicState.createImpl.mockResolvedValue({
+          id: 'anthropic-1',
+          model: 'claude-test',
+          content: [{ type: 'text', text: 'hi' }],
+        });
+
+        const generator = new AnthropicContentGenerator(
+          {
+            model: 'claude-test',
+            apiKey: 'test-key',
+            timeout: 10_000,
+            maxRetries: 2,
+            samplingParams: { max_tokens: 500 },
+            schemaCompliance: 'auto',
+            reasoning: false,
+          },
+          mockConfig,
+        );
+
+        await generator.generateContent({
+          model: 'models/ignored',
+          contents: 'Hello',
+        } as unknown as GenerateContentParameters);
+
+        const [req] = anthropicState.lastCreateArgs as AnthropicCreateArgs;
+        expect(req).toEqual(expect.objectContaining({ max_tokens: 500 }));
+        expect(req).toEqual(
+          expect.not.objectContaining({ thinking: expect.anything() }),
         );
       });
     });

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -197,6 +197,10 @@ export class AnthropicContentGenerator implements ContentGenerator {
     const thinking = this.buildThinkingConfig(request);
     const outputConfig = this.buildOutputConfig();
 
+    if (thinking && sampling.max_tokens <= thinking.budget_tokens) {
+      sampling.max_tokens = thinking.budget_tokens + 8_000;
+    }
+
     return {
       model: this.contentGeneratorConfig.model,
       system,


### PR DESCRIPTION
## TLDR

When extended thinking is enabled (the default for the Anthropic provider), the request fails with a `400 invalid_request_error` because `max_tokens` can equal `thinking.budget_tokens`. Anthropic requires `max_tokens` to be **strictly greater than** `budget_tokens`. This PR adds a guard in `buildRequest()` that bumps `max_tokens` to `budget_tokens + 8_000` when the constraint is violated.

**Files changed:**
- `packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts` — 4-line guard in `buildRequest()`
- `packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts` — 4 new dedicated tests + 3 updated expectations

## Dive Deeper

`buildSamplingParameters` and `buildThinkingConfig` compute their values independently. `DEFAULT_OUTPUT_TOKEN_LIMIT` is 32,000 and the default medium-effort `budget_tokens` is also 32,000, so any model without an explicit `samplingParams.max_tokens` or `reasoning` config hits the equality case and gets rejected by the API.

The fix is intentionally minimal — a post-computation guard rather than coupling the two methods — so the existing resolution logic for token limits, model caps, and effort levels remains untouched.

Separately noted in the issue: model names using dot notation (e.g. `claude-opus-4.6`) don't match the dash-based regex patterns in `tokenLimits.ts` (`/^claude-opus-4-6/`), causing them to fall through to the generic `/^claude-/` 64K limit instead of the intended 128K. That's a separate fix not included here.

## Reviewer Test Plan

1. `npm ci && npm run build`
2. `npm run preflight` — all 4723 tests pass (19 in the anthropic generator file, 4 new)
3. To exercise the fix directly, run the targeted test suite:
   ```bash
   cd packages/core && npx vitest run src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
   ```
4. The new `max_tokens vs thinking.budget_tokens guard` describe block covers:
   - `max_tokens == budget_tokens` → bumped to `budget_tokens + 8000`
   - `max_tokens < budget_tokens` → bumped to `budget_tokens + 8000`
   - `max_tokens > budget_tokens` → unchanged
   - thinking disabled (`reasoning: false`) → `max_tokens` unchanged, no thinking block sent

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2508
