### PR TITLE
fix: coerce non-string tool params to strings for self-hosted LLMs

### DIFF
--- a/packages/core/src/utils/schemaValidator.test.ts
+++ b/packages/core/src/utils/schemaValidator.test.ts
@@ -294,4 +294,47 @@ describe('SchemaValidator', () => {
       expect(SchemaValidator.validate(schema, params)).toBeNull();
     });
   });
+
+  describe('non-string to string coercion', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        old_string: { type: 'string' },
+        content: { type: 'string' },
+        count: { type: 'integer' },
+      },
+      required: ['old_string', 'content'],
+    };
+
+    it('should coerce number values to strings', () => {
+      const params = { old_string: 123, content: 'hello' };
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect(params.old_string).toBe('123');
+    });
+
+    it('should coerce boolean values to strings', () => {
+      const params = { old_string: true, content: false };
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect(params.old_string).toBe('true');
+      expect(params.content).toBe('false');
+    });
+
+    it('should not coerce values that are already strings', () => {
+      const params = { old_string: 'original', content: 'text' };
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect(params.old_string).toBe('original');
+    });
+
+    it('should not coerce non-string schema fields', () => {
+      const params = { old_string: 'text', content: 'hello', count: 42 };
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect(params.count).toBe(42);
+    });
+
+    it('should coerce float to string', () => {
+      const params = { old_string: 3.14, content: 'hello' };
+      expect(SchemaValidator.validate(schema, params)).toBeNull();
+      expect(params.old_string).toBe('3.14');
+    });
+  });
 });

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -102,6 +102,11 @@ export class SchemaValidator {
     if (!valid && validate.errors) {
       // Coerce string boolean values ("true"/"false") to actual booleans
       fixBooleanValues(data as Record<string, unknown>);
+      // Coerce non-string values to strings where the schema expects strings
+      fixStringValues(
+        data as Record<string, unknown>,
+        anySchema as Record<string, unknown>,
+      );
 
       valid = validate(data);
       if (!valid && validate.errors) {
@@ -135,6 +140,38 @@ function fixBooleanValues(data: Record<string, unknown>) {
       } else if (lower === 'false') {
         data[key] = false;
       }
+    }
+  }
+}
+
+/**
+ * Coerces non-string values to strings where the schema expects a string type.
+ * This handles cases where LLMs return numbers or booleans instead of string values
+ * for tool parameters like `old_string`, `content`, etc.
+ * Common with self-hosted LLMs (e.g., via LMStudio, sglang, vllm).
+ */
+function fixStringValues(
+  data: Record<string, unknown>,
+  schema: Record<string, unknown>,
+) {
+  const properties = schema?.properties as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  if (!properties) return;
+
+  for (const key of Object.keys(data)) {
+    if (!(key in data)) continue;
+    const value = data[key];
+    const propSchema = properties[key];
+    if (!propSchema) continue;
+
+    if (
+      propSchema.type === 'string' &&
+      typeof value !== 'string' &&
+      value !== null &&
+      value !== undefined
+    ) {
+      data[key] = String(value);
     }
   }
 }


### PR DESCRIPTION
## TLDR

Self-hosted LLMs (via LMStudio, sglang, vllm) sometimes return numbers or booleans for tool parameters that expect strings (e.g., `old_string`, `content`). This causes `SchemaValidator` to reject the params with errors like `params/old_string must be string`, making edit/write_file operations fail entirely.

## Dive Deeper

The `SchemaValidator` already has `fixBooleanValues()` to coerce `"true"`/`"false"` strings to booleans. This PR adds an analogous `fixStringValues()` that converts non-string values (numbers, booleans) to strings when the JSON schema declares `type: "string"` for that property.

The coercion only triggers when initial validation fails (same retry pattern as boolean coercion), so there is zero overhead for well-formed inputs.

### Root Cause

Local inference servers sometimes return structured tool_call arguments where a field like `old_string` or `content` is a number (e.g., `123` instead of `"123"`) or a boolean. This is valid JSON but fails the JSON Schema `type: "string"` constraint. The model then enters a failure loop, wasting tokens on retries.

## Reviewer Test Plan

1. Run `npx vitest run packages/core/src/utils/schemaValidator.test.ts`
2. Verify all 27 tests pass (5 new tests for string coercion)
3. To manually reproduce the original issue: use a local LLM via LMStudio/sglang that sends numeric `old_string` values in edit_file tool calls

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #535