### PR TITLE
fix: normalize CRLF in edit tool old_string and new_string params

### DIFF
--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -136,8 +136,8 @@ class EditToolInvocation implements ToolInvocation<EditToolParams, ToolResult> {
     let currentContent: string | null = null;
     let fileExists = await isFilefileExists(params.file_path);
     let isNewFile = false;
-    let finalNewString = params.new_string;
-    let finalOldString = params.old_string;
+    let finalNewString = params.new_string.replace(/\r\n/g, '\n');
+    let finalOldString = params.old_string.replace(/\r\n/g, '\n');
     let occurrences = 0;
     let error:
       | { display: string; raw: string; type: ToolErrorType }


### PR DESCRIPTION
## TLDR

The edit tool normalizes file content from CRLF to LF (line 161 of `edit.ts`), but does NOT normalize the `old_string` and `new_string` parameters from the LLM. When a model sends `\r\n` in these parameters, the substring match against the LF-normalized file content fails, producing `"0 occurrences found for old_string"`.

## Dive Deeper

The edit tool already handles CRLF for file content:
```ts
currentContent = fileInfo.content.replace(/\r\n/g, '\n');
```

But `old_string` and `new_string` pass through without CRLF normalization. This is a problem with:
- Self-hosted LLMs that preserve CRLF from the read_file output
- Windows environments where the model or proxy injects `\r\n`
- UTF-8 BOM + CRLF formatted projects (as reported in #2257)

The fix applies the same `\r\n` → `\n` replacement to both params before entering the matching pipeline, consistent with how file content is already handled.

## Reviewer Test Plan

1. Run `npx vitest run packages/core/src/tools/edit.test.ts` — all 54 tests pass
2. Run `npx vitest run packages/core/src/utils/editHelper.test.ts` — all 17 tests pass
3. To reproduce: open a CRLF file, attempt an edit — without this fix, multi-line `old_string` fails to match

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2257