### PR TITLE
fix: omit empty tools array from API requests

### DIFF
--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -189,9 +189,12 @@ export class AnthropicContentGenerator implements ContentGenerator {
     const { system, messages } =
       this.converter.convertGeminiRequestToAnthropic(request);
 
-    const tools = request.config?.tools
-      ? await this.converter.convertGeminiToolsToAnthropic(request.config.tools)
-      : undefined;
+    const tools =
+      request.config?.tools && request.config.tools.length > 0
+        ? await this.converter.convertGeminiToolsToAnthropic(
+            request.config.tools,
+          )
+        : undefined;
 
     const sampling = this.buildSamplingParameters(request);
     const thinking = this.buildThinkingConfig(request);

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -254,10 +254,13 @@ export class LoggingContentGenerator implements ContentGenerator {
       messages,
     };
 
-    if (request.config?.tools) {
-      openaiRequest.tools = await converter.convertGeminiToolsToOpenAI(
+    if (request.config?.tools && request.config.tools.length > 0) {
+      const tools = await converter.convertGeminiToolsToOpenAI(
         request.config.tools,
       );
+      if (tools.length > 0) {
+        openaiRequest.tools = tools;
+      }
     }
 
     if (request.config?.temperature !== undefined) {

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -331,11 +331,14 @@ export class ContentGenerationPipeline {
       baseRequest.stream_options = { include_usage: true };
     }
 
-    // Add tools if present
-    if (request.config?.tools) {
-      baseRequest.tools = await this.converter.convertGeminiToolsToOpenAI(
+    // Add tools if present — omit empty array to avoid API validation errors
+    if (request.config?.tools && request.config.tools.length > 0) {
+      const tools = await this.converter.convertGeminiToolsToOpenAI(
         request.config.tools,
       );
+      if (tools.length > 0) {
+        baseRequest.tools = tools;
+      }
     }
 
     // Let provider enhance the request (e.g., add metadata, cache control)


### PR DESCRIPTION
## TLDR

Sending `tools: []` to OpenAI-compatible APIs causes validation errors like `"[] is too short - 'tools'"`. This happens when no tools are available (e.g., certain model configurations or modes that disable tools). The fix guards all three content generator code paths to only include the `tools` field when the array is non-empty.

## Dive Deeper

### Root Cause

Three content generators (`OpenAI pipeline`, `Anthropic generator`, `logging generator`) unconditionally assign the `tools` field after conversion, even when the result is an empty array:

```typescript
// Before — sends tools: [] to the API
if (request.config?.tools) {
  baseRequest.tools = await this.converter.convertGeminiToolsToOpenAI(request.config.tools);
}
```

An empty `request.config.tools` array is truthy in JavaScript, so the guard passes. The conversion then returns `[]`, which gets sent as `tools: []` in the request body. OpenAI's API (and compatible endpoints) rejects this with a validation error.

### Fix

Added length checks at both the input and output stages:

```typescript
// After — only sends tools when non-empty
if (request.config?.tools && request.config.tools.length > 0) {
  const tools = await this.converter.convertGeminiToolsToOpenAI(request.config.tools);
  if (tools.length > 0) {
    baseRequest.tools = tools;
  }
}
```

The outer check avoids unnecessary conversion of empty input. The inner check handles edge cases where tools have no valid function declarations after conversion.

### Files Changed

- `packages/core/src/core/openaiContentGenerator/pipeline.ts`
- `packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts`
- `packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts`

## Reviewer Test Plan

1. `npx vitest run packages/core/src/core/openaiContentGenerator/` — 280 tests pass
2. `npx vitest run packages/core/src/core/anthropicContentGenerator/` — 44 tests pass

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2054