### PR TITLE
fix: prioritize @ file search over slash command completion

### DIFF
--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.ts
@@ -244,6 +244,33 @@ describe('useCommandCompletion', () => {
           );
         });
       });
+
+      it('should enable AT completion when @ appears after a slash command', async () => {
+        // Regression test for #2518: typing @ after a custom slash command
+        // should trigger file search, not remain in SLASH mode.
+        const text = '/qc:create-issue @readme';
+
+        renderHook(() =>
+          useCommandCompletion(
+            useTextBufferForTest(text),
+            testDirs,
+            testRootDir,
+            [],
+            mockCommandContext,
+            false,
+            mockConfig,
+          ),
+        );
+
+        await waitFor(() => {
+          expect(useAtCompletion).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              enabled: true,
+              pattern: 'readme',
+            }),
+          );
+        });
+      });
     });
 
     describe('Navigation', () => {

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -74,15 +74,10 @@ export function useCommandCompletion(
   const { completionMode, query, completionStart, completionEnd } =
     useMemo(() => {
       const currentLine = buffer.lines[cursorRow] || '';
-      if (cursorRow === 0 && isSlashCommand(currentLine.trim())) {
-        return {
-          completionMode: CompletionMode.SLASH,
-          query: currentLine,
-          completionStart: 0,
-          completionEnd: currentLine.length,
-        };
-      }
 
+      // Check for @ file reference first — it takes priority over slash
+      // command completion so that typing `@` after a slash command on the
+      // same line still triggers file search (see #2518).
       const codePoints = toCodePoints(currentLine);
       for (let i = cursorCol - 1; i >= 0; i--) {
         const char = codePoints[i];
@@ -119,6 +114,15 @@ export function useCommandCompletion(
             completionEnd: end,
           };
         }
+      }
+
+      if (cursorRow === 0 && isSlashCommand(currentLine.trim())) {
+        return {
+          completionMode: CompletionMode.SLASH,
+          query: currentLine,
+          completionStart: 0,
+          completionEnd: currentLine.length,
+        };
       }
 
       return {


### PR DESCRIPTION
## TLDR

Fix `@` file search not working after selecting a custom slash command on the same line.

Fixes #2518

## Dive Deeper

### Root Cause

In `useCommandCompletion`, the completion mode detection checks for slash commands _before_ checking for `@` file references:

```typescript
if (cursorRow === 0 && isSlashCommand(currentLine.trim())) {
  return { completionMode: CompletionMode.SLASH, ... };
}
// @ detection never reached when line starts with /
```

Since `isSlashCommand()` returns `true` for any line starting with `/` (excluding `//` and `/*`), typing `@` after a completed slash command like `/qc:create-issue @readme` still matches the slash command check first, and the `@` file search code is never executed.

### Fix

Reorder the completion mode detection to check for `@` file references _before_ slash commands. When the cursor is positioned after an `@` character (within the current word boundary), `AT` mode takes priority. If no `@` is found, the slash command check runs as before.

This preserves all existing behaviors:
- `/help` → SLASH mode (no `@` in text) ✓
- `/model qwen3` → SLASH mode (no `@` in text) ✓
- `/qc:create-issue @readme` → AT mode (`@` found before cursor) ✓
- `@file` → AT mode (no change) ✓
- `plain text` → IDLE mode (no change) ✓

## Testing Matrix

- [x] All 15 existing + new tests pass (`useCommandCompletion.test.ts`)
- [x] Added regression test: `@` after slash command triggers AT completion
- [x] Pre-commit hooks (prettier + eslint) pass