### PR TITLE
fix: include bundled skills directory in published package

### DIFF
--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -150,7 +150,15 @@ const distPackageJson = {
   bin: {
     qwen: 'cli.js',
   },
-  files: ['cli.js', 'vendor', '*.sb', 'README.md', 'LICENSE', 'locales'],
+  files: [
+    'cli.js',
+    'vendor',
+    '*.sb',
+    'README.md',
+    'LICENSE',
+    'locales',
+    'bundled',
+  ],
   config: rootPackageJson.config,
   dependencies: {},
   optionalDependencies: {


### PR DESCRIPTION
## TLDR

Bundled skills (e.g. `/review`) were missing after `npm publish` because the `bundled` directory was not included in the `files` whitelist of the generated `dist/package.json`.

## Dive Deeper

The build pipeline has two relevant steps:

1. **`npm run bundle`** → `copy_bundle_assets.js` correctly copies `packages/core/src/skills/bundled/` to `dist/bundled/`.
2. **`prepare-package.js`** → Generates a `dist/package.json` for npm publishing with a `files` field that controls which files are included in the published tarball.

The `files` array was:
```js
['cli.js', 'vendor', '*.sb', 'README.md', 'LICENSE', 'locales']
```

Missing `'bundled'` meant npm excluded the entire `dist/bundled/` directory during publish. At runtime, `SkillManager` resolves `bundledSkillsDir` to `<install-path>/bundled/` (via `import.meta.url`), finds the directory missing, and logs a warning — silently returning zero bundled skills.

The fix adds `'bundled'` to the `files` array so bundled skills are shipped with the published package.

## Reviewer Test Plan

1. Run `npm run bundle && node scripts/prepare-package.js`
2. Verify `dist/bundled/review/SKILL.md` exists
3. Run `npm pack ./dist` and inspect the tarball — confirm `bundled/review/SKILL.md` is included
4. Install from the tarball and run `qwen /skills` — the `review` skill should appear in the list

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- No linked issue -->"