### PR TITLE
fix: update Discord invite link to permanent URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ To report a bug from within the CLI, run `/bug` and include a short title and re
 
 ## Connect with Us
 
-- Discord: https://discord.gg/ycKBjdNd
+- Discord: https://discord.gg/RN7tqZCeDK
 - Dingtalk: https://qr.dingtalk.com/action/joingroup?code=v1,k1,+FX6Gf/ZDlTahTIRi8AEQhIaBlqykA0j+eBKKdhLeAE=&_dt_no_comment=1&origin=1
 
 ## Acknowledgments


### PR DESCRIPTION
## Summary
- Update Discord invite link from invalid URL to permanent URL
- Fixes #2103

## Test Plan
- Verified the new Discord link works correctly

Closes #2103