### PR TITLE
fix(extensions): support non-GitHub git URLs for extension installation

### DIFF
--- a/packages/core/src/extension/extensionManager.test.ts
+++ b/packages/core/src/extension/extensionManager.test.ts
@@ -755,6 +755,20 @@ describe('extension tests', () => {
         const id = getExtensionId(config, metadata);
         expect(id).toBe(hashValue('https://github.com/owner/repo'));
       });
+
+      it('should use source as-is for non-GitHub git URLs (e.g., GitLab)', () => {
+        // For non-GitHub git servers, fall back to using the source URL directly
+        const config: ExtensionConfig = { name: 'test-ext', version: '1.0.0' };
+        const metadata = {
+          type: 'git' as const,
+          source: 'https://gitlab.company.com/team/extension-repo',
+        };
+
+        const id = getExtensionId(config, metadata);
+        expect(id).toBe(
+          hashValue('https://gitlab.company.com/team/extension-repo'),
+        );
+      });
     });
   });
 

--- a/packages/core/src/extension/extensionManager.ts
+++ b/packages/core/src/extension/extensionManager.ts
@@ -1321,12 +1321,18 @@ export function getExtensionId(
   installMetadata?: ExtensionInstallMetadata,
 ): string {
   let idValue = config.name;
-  const githubUrlParts =
+  let githubUrlParts = null;
+  if (
     installMetadata &&
     (installMetadata.type === 'git' ||
       installMetadata.type === 'github-release')
-      ? parseGitHubRepoForReleases(installMetadata.source)
-      : null;
+  ) {
+    try {
+      githubUrlParts = parseGitHubRepoForReleases(installMetadata.source);
+    } catch {
+      // Non-GitHub URL (GitLab, Bitbucket, etc.) - use source as-is
+    }
+  }
   if (githubUrlParts) {
     idValue = `https://github.com/${githubUrlParts.owner}/${githubUrlParts.repo}`;
   } else {


### PR DESCRIPTION
## TLDR

Fixes extension installation from local domain git servers (GitLab, Bitbucket, etc.) by catching errors from parseGitHubRepoForReleases and falling back to use the source URL directly.

## Dive Deeper
When installing an extension from a self-hosted git server (e.g., https://gitlab.company.com/team/my-extension), the installation failed after user confirmation with:

     Invalid GitHub repository source: https://gitlab.company.com/team/my-extension. Expected "owner/repo" or a github repo uri.

The root cause was in packages/core/src/extension/extensionManager.ts - the getExtensionId function unconditionally called parseGitHubRepoForReleases() which only supports GitHub URLs.

Solution: Wrapped the call in try-catch. If parsing fails (non-GitHub URL), use the source URL as-is for generating the extension ID - same behavior as local type installations.

## Reviewer Test Plan

1. Run npm install and npm run build
2. Try installing an extension from a non-GitHub git URL:
     qwen extensions install https://gitlab.company.com/team/test-extension
4. Verify the extension installs successfully
5. Run qwen extensions list to confirm the extension appears

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅   |
| npx      | ❓  | ❓  | ✅   |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2538