### PR TITLE
feat(cli): improve custom input hints in AskUserQuestion dialog

### DIFF
--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -1750,6 +1750,14 @@ export default {
   'Ready to submit your answers?': 'Bereit, Ihre Antworten zu senden?',
   '↑/↓: Navigate | ←/→: Switch tabs | Enter: Select':
     '↑/↓: Navigieren | ←/→: Tabs wechseln | Enter: Auswählen',
+  '↑/↓: Navigate | ←/→: Switch tabs | Space: Toggle | Enter: Confirm | Esc: Cancel':
+    '↑/↓: Navigieren | ←/→: Tabs wechseln | Space: Umschalten | Enter: Bestätigen | Esc: Abbrechen',
+  '↑/↓: Navigate | Space: Toggle | Enter: Confirm | Esc: Cancel':
+    '↑/↓: Navigieren | Space: Umschalten | Enter: Bestätigen | Esc: Abbrechen',
+  '↑/↓: Navigate | Enter: Toggle | Ctrl+Enter: Confirm | Esc: Cancel':
+    '↑/↓: Navigieren | Enter: Umschalten | Strg+Enter: Bestätigen | Esc: Abbrechen',
+  'Enter: Save answer | ↑/↓: Navigate | Esc: Cancel':
+    'Enter: Antwort speichern | ↑/↓: Navigieren | Esc: Abbrechen',
   '↑/↓: Navigate | ←/→: Switch tabs | Space/Enter: Toggle | Esc: Cancel':
     '↑/↓: Navigieren | ←/→: Tabs wechseln | Space/Enter: Umschalten | Esc: Abbrechen',
   '↑/↓: Navigate | Space/Enter: Toggle | Esc: Cancel':

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1797,6 +1797,14 @@ export default {
   'Ready to submit your answers?': 'Ready to submit your answers?',
   '↑/↓: Navigate | ←/→: Switch tabs | Enter: Select':
     '↑/↓: Navigate | ←/→: Switch tabs | Enter: Select',
+  '↑/↓: Navigate | ←/→: Switch tabs | Space: Toggle | Enter: Confirm | Esc: Cancel':
+    '↑/↓: Navigate | ←/→: Switch tabs | Space: Toggle | Enter: Confirm | Esc: Cancel',
+  '↑/↓: Navigate | Space: Toggle | Enter: Confirm | Esc: Cancel':
+    '↑/↓: Navigate | Space: Toggle | Enter: Confirm | Esc: Cancel',
+  '↑/↓: Navigate | Enter: Toggle | Ctrl+Enter: Confirm | Esc: Cancel':
+    '↑/↓: Navigate | Enter: Toggle | Ctrl+Enter: Confirm | Esc: Cancel',
+  'Enter: Save answer | ↑/↓: Navigate | Esc: Cancel':
+    'Enter: Save answer | ↑/↓: Navigate | Esc: Cancel',
   '↑/↓: Navigate | ←/→: Switch tabs | Space/Enter: Toggle | Esc: Cancel':
     '↑/↓: Navigate | ←/→: Switch tabs | Space/Enter: Toggle | Esc: Cancel',
   '↑/↓: Navigate | Space/Enter: Toggle | Esc: Cancel':

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -1251,6 +1251,14 @@ export default {
   'Ready to submit your answers?': '回答を送信しますか？',
   '↑/↓: Navigate | ←/→: Switch tabs | Enter: Select':
     '↑/↓: ナビゲート | ←/→: タブ切り替え | Enter: 選択',
+  '↑/↓: Navigate | ←/→: Switch tabs | Space: Toggle | Enter: Confirm | Esc: Cancel':
+    '↑/↓: ナビゲート | ←/→: タブ切り替え | Space: 切り替え | Enter: 確認 | Esc: キャンセル',
+  '↑/↓: Navigate | Space: Toggle | Enter: Confirm | Esc: Cancel':
+    '↑/↓: ナビゲート | Space: 切り替え | Enter: 確認 | Esc: キャンセル',
+  '↑/↓: Navigate | Enter: Toggle | Ctrl+Enter: Confirm | Esc: Cancel':
+    '↑/↓: ナビゲート | Enter: 切り替え | Ctrl+Enter: 確認 | Esc: キャンセル',
+  'Enter: Save answer | ↑/↓: Navigate | Esc: Cancel':
+    'Enter: 回答を保存 | ↑/↓: ナビゲート | Esc: キャンセル',
   '↑/↓: Navigate | ←/→: Switch tabs | Space/Enter: Toggle | Esc: Cancel':
     '↑/↓: ナビゲート | ←/→: タブ切り替え | Space/Enter: 切り替え | Esc: キャンセル',
   '↑/↓: Navigate | Space/Enter: Toggle | Esc: Cancel':

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -1743,6 +1743,14 @@ export default {
   'Ready to submit your answers?': 'Pronto para enviar suas respostas?',
   '↑/↓: Navigate | ←/→: Switch tabs | Enter: Select':
     '↑/↓: Navegar | ←/→: Alternar abas | Enter: Selecionar',
+  '↑/↓: Navigate | ←/→: Switch tabs | Space: Toggle | Enter: Confirm | Esc: Cancel':
+    '↑/↓: Navegar | ←/→: Alternar abas | Space: Alternar | Enter: Confirmar | Esc: Cancelar',
+  '↑/↓: Navigate | Space: Toggle | Enter: Confirm | Esc: Cancel':
+    '↑/↓: Navegar | Space: Alternar | Enter: Confirmar | Esc: Cancelar',
+  '↑/↓: Navigate | Enter: Toggle | Ctrl+Enter: Confirm | Esc: Cancel':
+    '↑/↓: Navegar | Enter: Alternar | Ctrl+Enter: Confirmar | Esc: Cancelar',
+  'Enter: Save answer | ↑/↓: Navigate | Esc: Cancel':
+    'Enter: Salvar resposta | ↑/↓: Navegar | Esc: Cancelar',
   '↑/↓: Navigate | ←/→: Switch tabs | Space/Enter: Toggle | Esc: Cancel':
     '↑/↓: Navegar | ←/→: Alternar abas | Space/Enter: Alternar | Esc: Cancelar',
   '↑/↓: Navigate | Space/Enter: Toggle | Esc: Cancel':

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -1752,6 +1752,14 @@ export default {
   'Ready to submit your answers?': 'Готовы отправить свои ответы?',
   '↑/↓: Navigate | ←/→: Switch tabs | Enter: Select':
     '↑/↓: Навигация | ←/→: Переключение вкладок | Enter: Выбор',
+  '↑/↓: Navigate | ←/→: Switch tabs | Space: Toggle | Enter: Confirm | Esc: Cancel':
+    '↑/↓: Навигация | ←/→: Переключение вкладок | Space: Переключить | Enter: Подтвердить | Esc: Отмена',
+  '↑/↓: Navigate | Space: Toggle | Enter: Confirm | Esc: Cancel':
+    '↑/↓: Навигация | Space: Переключить | Enter: Подтвердить | Esc: Отмена',
+  '↑/↓: Navigate | Enter: Toggle | Ctrl+Enter: Confirm | Esc: Cancel':
+    '↑/↓: Навигация | Enter: Переключить | Ctrl+Enter: Подтвердить | Esc: Отмена',
+  'Enter: Save answer | ↑/↓: Navigate | Esc: Cancel':
+    'Enter: Сохранить ответ | ↑/↓: Навигация | Esc: Отмена',
   '↑/↓: Navigate | ←/→: Switch tabs | Space/Enter: Toggle | Esc: Cancel':
     '↑/↓: Навигация | ←/→: Переключение вкладок | Space/Enter: Переключить | Esc: Отмена',
   '↑/↓: Navigate | Space/Enter: Toggle | Esc: Cancel':

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1614,6 +1614,14 @@ export default {
   'Ready to submit your answers?': '准备好提交您的答案了吗？',
   '↑/↓: Navigate | ←/→: Switch tabs | Enter: Select':
     '↑/↓: 导航 | ←/→: 切换标签页 | Enter: 选择',
+  '↑/↓: Navigate | ←/→: Switch tabs | Space: Toggle | Enter: Confirm | Esc: Cancel':
+    '↑/↓: 导航 | ←/→: 切换标签页 | Space: 切换 | Enter: 确认 | Esc: 取消',
+  '↑/↓: Navigate | Space: Toggle | Enter: Confirm | Esc: Cancel':
+    '↑/↓: 导航 | Space: 切换 | Enter: 确认 | Esc: 取消',
+  '↑/↓: Navigate | Enter: Toggle | Ctrl+Enter: Confirm | Esc: Cancel':
+    '↑/↓: 导航 | Enter: 切换 | Ctrl+Enter: 确认 | Esc: 取消',
+  'Enter: Save answer | ↑/↓: Navigate | Esc: Cancel':
+    'Enter: 保存答案 | ↑/↓: 导航 | Esc: 取消',
   '↑/↓: Navigate | ←/→: Switch tabs | Space/Enter: Toggle | Esc: Cancel':
     '↑/↓: 导航 | ←/→: 切换标签页 | Space/Enter: 切换 | Esc: 取消',
   '↑/↓: Navigate | Space/Enter: Toggle | Esc: Cancel':

--- a/packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx
+++ b/packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx
@@ -244,6 +244,74 @@ describe('<AskUserQuestionDialog />', () => {
       expect(lastFrame()).toContain('[✓]');
       unmount();
     });
+
+    it('switches help text and uses text input keys for custom multi-select input', async () => {
+      const onConfirm = vi.fn();
+      const details = createConfirmationDetails({
+        questions: [createSingleQuestion({ multiSelect: true })],
+      });
+
+      const { stdin, lastFrame, unmount } = renderWithProviders(
+        <AskUserQuestionDialog
+          confirmationDetails={details}
+          onConfirm={onConfirm}
+        />,
+      );
+      await wait();
+
+      stdin.write('4');
+      await wait();
+
+      const focusedOutput = lastFrame();
+      expect(focusedOutput).toContain('Enter: Toggle');
+      expect(focusedOutput).toContain('Ctrl+Enter: Confirm');
+      expect(focusedOutput).not.toContain('Space: Insert space');
+      expect(focusedOutput).not.toContain('Space: Toggle');
+
+      stdin.write('foo bar');
+      await wait();
+
+      expect(lastFrame()).toContain('foo bar');
+      expect(lastFrame()).toContain('[✓]');
+
+      stdin.write('\r');
+      await wait();
+
+      expect(lastFrame()).toContain('[ ]');
+      expect(onConfirm).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('keeps left and right available for text editing while custom input is focused', async () => {
+      const onConfirm = vi.fn();
+      const details = createConfirmationDetails({
+        questions: [
+          createSingleQuestion({ header: 'Q1', multiSelect: true }),
+          createSingleQuestion({ header: 'Q2', multiSelect: true }),
+        ],
+      });
+
+      const { stdin, lastFrame, unmount } = renderWithProviders(
+        <AskUserQuestionDialog
+          confirmationDetails={details}
+          onConfirm={onConfirm}
+        />,
+      );
+      await wait();
+
+      stdin.write('4');
+      await wait();
+      stdin.write('abc');
+      await wait();
+      stdin.write('\u001B[C');
+      await wait();
+
+      const output = lastFrame();
+      expect(output).toContain('▸ Q1');
+      expect(output).toContain('abc');
+      expect(output).not.toContain('←/→: Switch tabs');
+      unmount();
+    });
   });
 
   describe('multiple questions', () => {

--- a/packages/cli/src/ui/components/messages/AskUserQuestionDialog.tsx
+++ b/packages/cli/src/ui/components/messages/AskUserQuestionDialog.tsx
@@ -13,7 +13,7 @@ import {
   type ToolConfirmationPayload,
 } from '@qwen-code/qwen-code-core';
 import { theme } from '../../semantic-colors.js';
-import { useKeypress } from '../../hooks/useKeypress.js';
+import { type Key, useKeypress } from '../../hooks/useKeypress.js';
 import { TextInput } from '../shared/TextInput.js';
 import { t } from '../../../i18n/index.js';
 
@@ -129,10 +129,15 @@ export const AskUserQuestionDialog: React.FC<AskUserQuestionDialogProps> = ({
     }
   };
 
-  const handleCustomInputSubmit = () => {
+  const handleCustomInputSubmit = (key?: Key) => {
     const trimmedValue = currentCustomInputValue.trim();
 
     if (isMultiSelect) {
+      if (key?.ctrl || key?.meta || key?.shift) {
+        handleMultiSelectSubmit();
+        return;
+      }
+
       // Toggle custom input checked state
       if (!trimmedValue) return;
       setCustomInputChecked((prev) => ({
@@ -168,12 +173,34 @@ export const AskUserQuestionDialog: React.FC<AskUserQuestionDialogProps> = ({
     }
   };
 
+  const helpText = isCustomInputSelected
+    ? isMultiSelect
+      ? t(
+          hasMultipleQuestions
+            ? '↑/↓: Navigate | Enter: Toggle | Ctrl+Enter: Confirm | Esc: Cancel'
+            : '↑/↓: Navigate | Enter: Toggle | Ctrl+Enter: Confirm | Esc: Cancel',
+        )
+      : t(
+          hasMultipleQuestions
+            ? 'Enter: Save answer | ↑/↓: Navigate | Esc: Cancel'
+            : 'Enter: Save answer | ↑/↓: Navigate | Esc: Cancel',
+        )
+    : hasMultipleQuestions
+      ? isMultiSelect
+        ? t(
+            '↑/↓: Navigate | ←/→: Switch tabs | Space: Toggle | Enter: Confirm | Esc: Cancel',
+          )
+        : t('↑/↓: Navigate | ←/→: Switch tabs | Enter: Select | Esc: Cancel')
+      : isMultiSelect
+        ? t('↑/↓: Navigate | Space: Toggle | Enter: Confirm | Esc: Cancel')
+        : t('↑/↓: Navigate | Enter: Select | Esc: Cancel');
+
   // Handle navigation and selection
   useKeypress(
     (key) => {
       if (!isFocused) return;
 
-      // When custom input is focused, still allow up/down navigation, tab switch and escape
+      // When custom input is focused, still allow navigation and escape.
       if (isCustomInputSelected) {
         if (key.name === 'up') {
           setSelectedIndex(Math.max(0, selectedIndex - 1));
@@ -550,21 +577,7 @@ export const AskUserQuestionDialog: React.FC<AskUserQuestionDialogProps> = ({
       {/* Help text */}
       <Box flexDirection="column" marginTop={1}>
         <Box>
-          <Text dimColor>
-            {hasMultipleQuestions
-              ? isMultiSelect
-                ? t(
-                    '↑/↓: Navigate | ←/→: Switch tabs | Space: Toggle | Enter: Confirm | Esc: Cancel',
-                  )
-                : t(
-                    '↑/↓: Navigate | ←/→: Switch tabs | Enter: Select | Esc: Cancel',
-                  )
-              : isMultiSelect
-                ? t(
-                    '↑/↓: Navigate | Space: Toggle | Enter: Confirm | Esc: Cancel',
-                  )
-                : t('↑/↓: Navigate | Enter: Select | Esc: Cancel')}
-          </Text>
+          <Text dimColor>{helpText}</Text>
         </Box>
       </Box>
     </Box>

--- a/packages/cli/src/ui/components/shared/TextInput.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.tsx
@@ -20,7 +20,7 @@ import { useCallback, useRef, useEffect } from 'react';
 export interface TextInputProps {
   value: string;
   onChange: (text: string) => void;
-  onSubmit?: () => void;
+  onSubmit?: (key?: Key) => void;
   /** Called when Tab is pressed; if provided, prevents the default tab-insertion behaviour. */
   onTab?: () => void;
   /** Called when ↑ is pressed; if provided, prevents cursor-up in the buffer. */
@@ -68,9 +68,9 @@ export function TextInput({
     onChange: stableOnChange,
   });
 
-  const handleSubmit = () => {
+  const handleSubmit = (key?: Key) => {
     if (!onSubmit) return;
-    onSubmit();
+    onSubmit(key);
   };
 
   useKeypress(
@@ -103,10 +103,10 @@ export function TextInput({
             buffer.backspace();
             buffer.newline();
           } else {
-            handleSubmit();
+            handleSubmit(key);
           }
         } else {
-          handleSubmit();
+          handleSubmit(key);
         }
         return;
       }


### PR DESCRIPTION
## Summary

This PR improves the `AskUserQuestionDialog` experience when the user focuses the custom input option, especially for multi-select questions.

### What changed

- updates the help text to reflect the active input mode
- uses `Enter` to toggle the custom input option in multi-select mode
- uses `Ctrl+Enter` to confirm multi-select answers while editing custom input
- keeps left/right available for text editing instead of tab switching when the custom input is focused
- forwards the triggering key from `TextInput` to submit handlers so dialogs can distinguish `Enter` from modified enter keys
- adds locale strings for the updated help text across supported languages
- adds regression tests covering custom multi-select input behavior and focused text editing behavior

## Why

The previous help text was misleading once focus moved into the custom input field. It still advertised actions like tab switching or space toggling even though the actual interaction model had changed.

This PR makes the on-screen hints match the current keyboard behavior and improves the multi-select custom input flow by separating:
- `Enter` for toggling the custom option
- `Ctrl+Enter` for confirming the selection set

## Testing

- `npm run test --workspace=@qwen-code/qwen-code -- src/ui/components/messages/AskUserQuestionDialog.test.tsx`
