### PR TITLE
fix(vscode-ide-companion): silence secondary sidebar warning on older VS Code versions

### DIFF
--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -49,7 +49,7 @@
           "id": "qwen-code-sidebar",
           "title": "Qwen Code",
           "icon": "assets/sidebar-icon.svg",
-          "when": "qwen-code:doesNotSupportSecondarySidebar"
+          "when": "!qwen-code:supportsSecondarySidebar"
         }
       ],
       "secondarySidebar": [
@@ -57,7 +57,7 @@
           "id": "qwen-code-secondary",
           "title": "Qwen Code",
           "icon": "assets/sidebar-icon.svg",
-          "when": "!qwen-code:doesNotSupportSecondarySidebar"
+          "when": "qwen-code:supportsSecondarySidebar"
         }
       ]
     },
@@ -68,7 +68,7 @@
           "id": "qwen-code.chatView.sidebar",
           "name": "Qwen Code",
           "icon": "assets/sidebar-icon.svg",
-          "when": "qwen-code:doesNotSupportSecondarySidebar"
+          "when": "!qwen-code:supportsSecondarySidebar"
         }
       ],
       "qwen-code-secondary": [
@@ -77,7 +77,7 @@
           "id": "qwen-code.chatView.secondary",
           "name": "Qwen Code",
           "icon": "assets/sidebar-icon.svg",
-          "when": "!qwen-code:doesNotSupportSecondarySidebar"
+          "when": "qwen-code:supportsSecondarySidebar"
         }
       ]
     },

--- a/packages/vscode-ide-companion/src/constants/viewIds.ts
+++ b/packages/vscode-ide-companion/src/constants/viewIds.ts
@@ -9,7 +9,7 @@
  * These IDs must match the `views` contributions declared in package.json.
  *
  * Only one of sidebar / secondary is visible at runtime — controlled by the
- * `qwen-code:doesNotSupportSecondarySidebar` context key in package.json.
+ * `qwen-code:supportsSecondarySidebar` context key in package.json.
  * The secondary sidebar is preferred; the primary sidebar is a fallback for
  * VS Code versions that lack secondary sidebar support.
  */

--- a/packages/vscode-ide-companion/src/webview/providers/chatViewRegistration.test.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/chatViewRegistration.test.ts
@@ -71,11 +71,15 @@ describe('registerChatViewProviders', () => {
     expect(calls[0]?.[2]).toEqual({
       webviewOptions: { retainContextWhenHidden: true },
     });
-    expect(executeCommand).not.toHaveBeenCalled();
+    expect(executeCommand).toHaveBeenCalledWith(
+      'setContext',
+      'qwen-code:supportsSecondarySidebar',
+      true,
+    );
     expect(context.subscriptions).toHaveLength(2);
   });
 
-  it('sets the fallback context key when secondary sidebar is unavailable', () => {
+  it('sets context key to false when secondary sidebar is unavailable', () => {
     registerChatViewProviders({
       context: context as never,
       createViewProvider: vi.fn(),
@@ -84,8 +88,8 @@ describe('registerChatViewProviders', () => {
 
     expect(executeCommand).toHaveBeenCalledWith(
       'setContext',
-      'qwen-code:doesNotSupportSecondarySidebar',
-      true,
+      'qwen-code:supportsSecondarySidebar',
+      false,
     );
   });
 });

--- a/packages/vscode-ide-companion/src/webview/providers/chatViewRegistration.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/chatViewRegistration.ts
@@ -14,8 +14,7 @@ import {
   type WebViewProviderFactory,
 } from './ChatWebviewViewProvider.js';
 
-const SECONDARY_SIDEBAR_CONTEXT_KEY =
-  'qwen-code:doesNotSupportSecondarySidebar';
+const SECONDARY_SIDEBAR_CONTEXT_KEY = 'qwen-code:supportsSecondarySidebar';
 
 export function detectSecondarySidebarSupport(vscodeVersion: string): boolean {
   const [major, minor] = vscodeVersion.split('.').map(Number);
@@ -35,13 +34,16 @@ export function registerChatViewProviders(params: {
 
   const supportsSecondarySidebar = detectSecondarySidebarSupport(vscodeVersion);
 
-  if (!supportsSecondarySidebar) {
-    void vscode.commands.executeCommand(
-      'setContext',
-      SECONDARY_SIDEBAR_CONTEXT_KEY,
-      true,
-    );
-  }
+  // Set the context key so package.json `when` clauses can gate the
+  // secondarySidebar view container. The key defaults to undefined (falsy),
+  // which keeps the secondary container hidden until we explicitly enable it.
+  // This prevents the "view container not found" warning on older VS Code
+  // versions that don't recognise the `secondarySidebar` location.
+  void vscode.commands.executeCommand(
+    'setContext',
+    SECONDARY_SIDEBAR_CONTEXT_KEY,
+    supportsSecondarySidebar,
+  );
 
   const sidebarViewProvider = new ChatWebviewViewProvider(createViewProvider);
   const secondaryViewProvider = new ChatWebviewViewProvider(createViewProvider);


### PR DESCRIPTION
## TLDR

Fix the "container 'qwen-code-secondary' does not exist" warning on VS Code versions below 1.106, and prevent the extension from accidentally relocating other extensions' secondary sidebar views into the Explorer container.

## Dive Deeper

**Root cause:**
The `package.json` used a negative-logic context key `qwen-code:doesNotSupportSecondarySidebar`. On older VS Code versions, this key was never explicitly set, so it evaluated to `undefined` (falsy). This caused `when: "!qwen-code:doesNotSupportSecondarySidebar"` to evaluate to `true`, which registered the `secondarySidebar` view container even though the VS Code version didn't support it. VS Code then moved all views registered to that non-existent container into the Explorer, including views from other extensions (e.g., Cline).

**Fix:**
Flip the context key from negative logic (`doesNotSupportSecondarySidebar`) to positive logic (`supportsSecondarySidebar`), and always explicitly call `setContext` in `chatViewRegistration.ts`. On older VS Code versions, the key defaults to `undefined` (falsy), so `when: "qwen-code:supportsSecondarySidebar"` evaluates to `false` — the secondary sidebar container is never declared, avoiding the warning and layout disruption entirely.

**Changed files:**
- `package.json` — flip 4 `when` clause conditions
- `src/constants/viewIds.ts` — update comment to reflect new key name
- `src/webview/providers/chatViewRegistration.ts` — refactor context key setting logic
- `src/webview/providers/chatViewRegistration.test.ts` — update test assertions

## Reviewer Test Plan

1. Install the extension on VS Code < 1.106 and verify:
   - No "container does not exist" warning appears
   - The Qwen Code view shows up in the primary sidebar
   - Other extensions' secondary sidebar views are not affected
2. Install the extension on VS Code >= 1.106 and verify:
   - The Qwen Code view appears in the secondary sidebar as expected
3. Run `npm run test` to verify all unit tests pass

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes #2432
Closes #2416

Made with [Cursor](https://cursor.com)