### PR TITLE
fix(vscode-ide-companion): improve ACP error handling to prevent silent loading hangs

### DIFF
--- a/packages/vscode-ide-companion/src/services/acpConnection.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.ts
@@ -132,9 +132,16 @@ export class AcpConnection {
 
   private async setupChildProcessHandlers(): Promise<void> {
     let spawnError: Error | null = null;
+    const stderrChunks: string[] = [];
+
+    let rejectOnExit: ((error: Error) => void) | null = null;
+    const processExitPromise = new Promise<never>((_resolve, reject) => {
+      rejectOnExit = reject;
+    });
 
     this.child!.stderr?.on('data', (data: Buffer) => {
       const message = data.toString();
+      stderrChunks.push(message);
       if (
         message.toLowerCase().includes('error') &&
         !message.includes('Loaded cached')
@@ -155,6 +162,17 @@ export class AcpConnection {
       );
       this.lastExitCode = code;
       this.lastExitSignal = signal;
+
+      const stderrOutput = stderrChunks.join('').trim();
+      const stderrSuffix = stderrOutput
+        ? `\nCLI stderr: ${stderrOutput.slice(-500)}`
+        : '';
+      rejectOnExit?.(
+        new Error(
+          `Qwen ACP process exited unexpectedly (exit code: ${code}, signal: ${signal})${stderrSuffix}`,
+        ),
+      );
+
       if (this.child) {
         this.sdkConnection = null;
         this.sessionId = null;
@@ -172,8 +190,12 @@ export class AcpConnection {
     if (!this.child || this.child.killed) {
       const code = this.lastExitCode ?? this.child?.exitCode ?? null;
       const signal = this.lastExitSignal;
+      const stderrOutput = stderrChunks.join('').trim();
+      const stderrSuffix = stderrOutput
+        ? `\nCLI stderr: ${stderrOutput.slice(-500)}`
+        : '';
       throw new Error(
-        `Qwen ACP process failed to start (exit code: ${code}, signal: ${signal})`,
+        `Qwen ACP process failed to start (exit code: ${code}, signal: ${signal})${stderrSuffix}`,
       );
     }
 
@@ -330,17 +352,21 @@ export class AcpConnection {
       stream,
     );
 
-    // Initialize protocol via SDK
+    // Race the SDK initialize against process exit so we don't hang forever
+    // if the CLI crashes before responding.
     console.log('[ACP] Sending initialize request...');
-    const initResponse = await this.sdkConnection.initialize({
-      protocolVersion: PROTOCOL_VERSION,
-      clientCapabilities: {
-        fs: {
-          readTextFile: true,
-          writeTextFile: true,
+    const initResponse = await Promise.race([
+      this.sdkConnection.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {
+          fs: {
+            readTextFile: true,
+            writeTextFile: true,
+          },
         },
-      },
-    });
+      }),
+      processExitPromise,
+    ]);
 
     console.log('[ACP] Initialize successful');
     console.log('[ACP] Initialization response:', initResponse);

--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -481,10 +481,18 @@ export const App: React.FC = () => {
 
   // Set loading state to false after initial mount and when we have authentication info
   useEffect(() => {
-    // If we have determined authentication status, we're done loading
     if (isAuthenticated !== null) {
       setIsLoading(false);
+      return;
     }
+
+    // Safety-net timeout: if initialization takes too long (e.g. CLI crashed
+    // before the error could be surfaced), stop the spinner and let the user
+    // see the onboarding / error UI instead of hanging forever.
+    const timeout = setTimeout(() => {
+      setIsLoading(false);
+    }, 30_000);
+    return () => clearTimeout(timeout);
   }, [isAuthenticated]);
 
   // Handle permission response


### PR DESCRIPTION
## TLDR

Fix the VS Code extension silently hanging on "Preparing Qwen Code..." when the ACP CLI process crashes during initialization (e.g. due to a malformed `settings.json`). The extension now surfaces the actual error instead of leaving users stuck.

## Dive Deeper

**Root cause:**
When the CLI child process crashes during initialization (for example, a syntax error in `.qwen/settings.json` causes MCP initialization to fail), the `initialize()` SDK call never resolves or rejects. This leaves the extension's `await` hanging indefinitely, and the UI displays the loading spinner forever with no error feedback.

**Fix — three layers of defense:**

1. **Collect stderr output**: The child process's stderr handler now accumulates all output chunks. When an error occurs, the last 500 characters of stderr are appended to the error message, giving users actionable diagnostic information.

2. **Promise.race to prevent hanging**: A `processExitPromise` is created that rejects when the child process exits. The `initialize()` call is raced against this promise, so if the CLI crashes before responding, the await rejects immediately with a descriptive error (including stderr) instead of hanging forever.

3. **Safety-net timeout in App.tsx**: A 30-second timeout clears the loading spinner if initialization stalls for any reason, allowing users to see the onboarding/error UI instead of being stuck on the loading screen indefinitely.

**Changed files:**
- `src/services/acpConnection.ts` — stderr collection, `processExitPromise`, `Promise.race` for `initialize()`
- `src/webview/App.tsx` — 30-second safety-net timeout for loading state

## Reviewer Test Plan

1. Introduce a syntax error in `.qwen/settings.json` (e.g. trailing comma in JSON), open the extension, and verify:
   - The loading spinner stops within a few seconds
   - An error message is surfaced (in console / notification) containing stderr output
   - The user is not stuck on "Preparing Qwen Code..." indefinitely
2. With a valid configuration, verify normal initialization still works correctly
3. Run `npm run test` to verify all unit tests pass

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes #2382

Made with [Cursor](https://cursor.com)