### PR TITLE
perf(vscode): fix input lag in long conversations

### DIFF
--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -59,6 +59,110 @@ import type { Question } from '../types/acpTypes.js';
 import { useImagePaste, type WebViewImageMessage } from './hooks/useImage.js';
 import { computeContextUsage } from './utils/contextUsage.js';
 
+/**
+ * Memoized message list that only re-renders when messages or callbacks change,
+ * not on every keystroke in the input field.
+ */
+interface MessageListItem {
+  type: 'message' | 'in-progress-tool-call' | 'completed-tool-call';
+  data: TextMessage | ToolCallData;
+  timestamp: number;
+}
+
+interface MessageListProps {
+  allMessages: MessageListItem[];
+  onFileClick: (path: string) => void;
+}
+
+const MessageList = React.memo<MessageListProps>(
+  ({ allMessages, onFileClick }) => {
+    let imageIndex = 0;
+    return (
+      <>
+        {allMessages.map((item, index) => {
+          switch (item.type) {
+            case 'message': {
+              const msg = item.data as TextMessage;
+
+              if (msg.kind === 'image' && msg.imagePath) {
+                imageIndex += 1;
+                return (
+                  <ImageMessageRenderer
+                    key={`message-${index}`}
+                    msg={msg as WebViewImageMessage}
+                    imageIndex={imageIndex}
+                  />
+                );
+              }
+
+              if (msg.role === 'thinking') {
+                return (
+                  <ThinkingMessage
+                    key={`message-${index}`}
+                    content={msg.content || ''}
+                    timestamp={msg.timestamp || 0}
+                    onFileClick={onFileClick}
+                  />
+                );
+              }
+
+              if (msg.role === 'user') {
+                return (
+                  <UserMessage
+                    key={`message-${index}`}
+                    content={msg.content || ''}
+                    timestamp={msg.timestamp || 0}
+                    onFileClick={onFileClick}
+                    fileContext={msg.fileContext}
+                  />
+                );
+              }
+
+              {
+                const content = (msg.content || '').trim();
+                if (
+                  content === 'Interrupted' ||
+                  content === 'Tool interrupted'
+                ) {
+                  return (
+                    <InterruptedMessage
+                      key={`message-${index}`}
+                      text={content}
+                    />
+                  );
+                }
+                return (
+                  <AssistantMessage
+                    key={`message-${index}`}
+                    content={content}
+                    timestamp={msg.timestamp || 0}
+                    onFileClick={onFileClick}
+                  />
+                );
+              }
+            }
+
+            case 'in-progress-tool-call':
+            case 'completed-tool-call': {
+              return (
+                <ToolCall
+                  key={`toolcall-${(item.data as ToolCallData).toolCallId}-${item.type}`}
+                  toolCall={item.data as ToolCallData}
+                />
+              );
+            }
+
+            default:
+              return null;
+          }
+        })}
+      </>
+    );
+  },
+);
+
+MessageList.displayName = 'MessageList';
+
 export const App: React.FC = () => {
   const vscode = useVSCode();
 
@@ -752,10 +856,9 @@ export const App: React.FC = () => {
     });
   }, [vscode]);
 
-  // Handle toggle thinking
-  const handleToggleThinking = () => {
+  const handleToggleThinking = useCallback(() => {
     setThinkingEnabled((prev) => !prev);
-  };
+  }, []);
 
   // When user sends a message after scrolling up, re-pin and jump to the bottom
   const handleSubmitWithScroll = useCallback(
@@ -810,89 +913,15 @@ export const App: React.FC = () => {
     );
   }, [messageHandling.messages, inProgressToolCalls, completedToolCalls]);
 
-  console.log('[App] Rendering messages:', allMessages);
-
-  // Render all messages and tool calls
-  const renderMessages = useCallback<() => React.ReactNode>(() => {
-    let imageIndex = 0;
-    return allMessages.map((item, index) => {
-      switch (item.type) {
-        case 'message': {
-          const msg = item.data as TextMessage;
-          const handleFileClick = (path: string): void => {
-            vscode.postMessage({
-              type: 'openFile',
-              data: { path },
-            });
-          };
-
-          if (msg.kind === 'image' && msg.imagePath) {
-            imageIndex += 1;
-            return (
-              <ImageMessageRenderer
-                key={`message-${index}`}
-                msg={msg as WebViewImageMessage}
-                imageIndex={imageIndex}
-              />
-            );
-          }
-
-          if (msg.role === 'thinking') {
-            return (
-              <ThinkingMessage
-                key={`message-${index}`}
-                content={msg.content || ''}
-                timestamp={msg.timestamp || 0}
-                onFileClick={handleFileClick}
-              />
-            );
-          }
-
-          if (msg.role === 'user') {
-            return (
-              <UserMessage
-                key={`message-${index}`}
-                content={msg.content || ''}
-                timestamp={msg.timestamp || 0}
-                onFileClick={handleFileClick}
-                fileContext={msg.fileContext}
-              />
-            );
-          }
-
-          {
-            const content = (msg.content || '').trim();
-            if (content === 'Interrupted' || content === 'Tool interrupted') {
-              return (
-                <InterruptedMessage key={`message-${index}`} text={content} />
-              );
-            }
-            return (
-              <AssistantMessage
-                key={`message-${index}`}
-                content={content}
-                timestamp={msg.timestamp || 0}
-                onFileClick={handleFileClick}
-              />
-            );
-          }
-        }
-
-        case 'in-progress-tool-call':
-        case 'completed-tool-call': {
-          return (
-            <ToolCall
-              key={`toolcall-${(item.data as ToolCallData).toolCallId}-${item.type}`}
-              toolCall={item.data as ToolCallData}
-            />
-          );
-        }
-
-        default:
-          return null;
-      }
-    });
-  }, [allMessages, vscode]);
+  const handleFileClick = useCallback(
+    (path: string): void => {
+      vscode.postMessage({
+        type: 'openFile',
+        data: { path },
+      });
+    },
+    [vscode],
+  );
 
   const hasContent =
     messageHandling.messages.length > 0 ||
@@ -962,7 +991,10 @@ export const App: React.FC = () => {
         ) : (
           <>
             {/* Render all messages and tool calls */}
-            {renderMessages()}
+            <MessageList
+              allMessages={allMessages}
+              onFileClick={handleFileClick}
+            />
 
             {/* Waiting message positioned fixed above the input form to avoid layout shifts */}
             {messageHandling.isWaitingForResponse &&

--- a/packages/webui/src/components/messages/Assistant/AssistantMessage.tsx
+++ b/packages/webui/src/components/messages/Assistant/AssistantMessage.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { FC } from 'react';
+import { type FC, memo } from 'react';
 import { MessageContent } from '../MessageContent.js';
 import './AssistantMessage.css';
 
@@ -32,7 +32,7 @@ export interface AssistantMessageProps {
  * AssistantMessage component - renders AI responses with styling
  * Supports different states: default, success, error, warning, loading
  */
-export const AssistantMessage: FC<AssistantMessageProps> = ({
+const AssistantMessageBase: FC<AssistantMessageProps> = ({
   content,
   timestamp: _timestamp,
   onFileClick,
@@ -41,7 +41,6 @@ export const AssistantMessage: FC<AssistantMessageProps> = ({
   isFirst = false,
   isLast = false,
 }) => {
-  // Empty content not rendered directly
   if (!content || content.trim().length === 0) {
     return null;
   }
@@ -97,3 +96,7 @@ export const AssistantMessage: FC<AssistantMessageProps> = ({
     </div>
   );
 };
+
+AssistantMessageBase.displayName = 'AssistantMessage';
+
+export const AssistantMessage = memo(AssistantMessageBase);

--- a/packages/webui/src/components/messages/ThinkingMessage.tsx
+++ b/packages/webui/src/components/messages/ThinkingMessage.tsx
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { FC } from 'react';
-import { useState } from 'react';
+import { type FC, memo, useState } from 'react';
 import { MessageContent } from './MessageContent.js';
 import { ChevronIcon } from '../icons/index.js';
 import './ThinkingMessage.css';
@@ -35,7 +34,7 @@ export interface ThinkingMessageProps {
  * - Expanded: solid dot + "Thinking" + up arrow + thinking content
  * - Aligned with other message items, with status icon and connector line
  */
-export const ThinkingMessage: FC<ThinkingMessageProps> = ({
+const ThinkingMessageBase: FC<ThinkingMessageProps> = ({
   content,
   timestamp: _timestamp,
   onFileClick,
@@ -53,7 +52,6 @@ export const ThinkingMessage: FC<ThinkingMessageProps> = ({
       className={`qwen-message message-item thinking-message thinking-status-${status}`}
     >
       <div className="thinking-content-wrapper">
-        {/* Clickable title bar */}
         <button
           type="button"
           onClick={handleToggle}
@@ -61,9 +59,7 @@ export const ThinkingMessage: FC<ThinkingMessageProps> = ({
           aria-expanded={isExpanded}
           aria-label={isExpanded ? 'Collapse thinking' : 'Expand thinking'}
         >
-          {/* Thinking label text */}
           <span className="thinking-label">Thinking</span>
-          {/* Expand/collapse arrow */}
           <ChevronIcon
             size={12}
             direction={isExpanded ? 'up' : 'down'}
@@ -71,7 +67,6 @@ export const ThinkingMessage: FC<ThinkingMessageProps> = ({
           />
         </button>
 
-        {/* Thinking content displayed when expanded */}
         {isExpanded && (
           <div className="thinking-content">
             <MessageContent content={content} onFileClick={onFileClick} />
@@ -81,3 +76,7 @@ export const ThinkingMessage: FC<ThinkingMessageProps> = ({
     </div>
   );
 };
+
+ThinkingMessageBase.displayName = 'ThinkingMessage';
+
+export const ThinkingMessage = memo(ThinkingMessageBase);

--- a/packages/webui/src/components/messages/UserMessage.tsx
+++ b/packages/webui/src/components/messages/UserMessage.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { FC } from 'react';
+import { type FC, memo } from 'react';
 import { CollapsibleFileContent } from './CollapsibleFileContent.js';
 
 export interface FileContext {
@@ -21,7 +21,7 @@ export interface UserMessageProps {
   fileContext?: FileContext;
 }
 
-export const UserMessage: FC<UserMessageProps> = ({
+const UserMessageBase: FC<UserMessageProps> = ({
   content,
   timestamp: _timestamp,
   onFileClick,
@@ -32,7 +32,6 @@ export const UserMessage: FC<UserMessageProps> = ({
       return null;
     }
     const { fileName, startLine, endLine } = fileContext;
-    // Use != null to handle line number 0 and support start-only line
     if (startLine != null) {
       if (endLine != null && endLine !== startLine) {
         return `${fileName}#${startLine}-${endLine}`;
@@ -89,3 +88,7 @@ export const UserMessage: FC<UserMessageProps> = ({
     </div>
   );
 };
+
+UserMessageBase.displayName = 'UserMessage';
+
+export const UserMessage = memo(UserMessageBase);


### PR DESCRIPTION
## TLDR

Fix severe input lag (5+ second delay) in VS Code IDE Companion when conversations get long. The root cause is that every keystroke triggers a full `App` re-render including the entire chat message list (O(n) cost). By extracting the message list into a `React.memo` component and memoizing individual message components, keystroke handling is reduced to O(1).

## Screenshots / Video Demo

N/A — no user-facing change, this is a performance optimization.

**Before**: In long conversations (many turns), each keystroke triggers a full `App` re-render → reconciles all message DOM nodes → latency grows linearly with message count (5+ seconds).

**After**: Each keystroke only updates `inputText` state → `MessageList` props (`allMessages`, `onFileClick`) are unchanged → `React.memo` skips the entire message list re-render → constant O(1) response time.

## Dive Deeper

### Root Cause Analysis

1. **`inputText` state lives on `App`** — every keystroke calls `setInputText` which re-renders the entire `App` subtree
2. **Message components lack `React.memo`** — `UserMessage`, `AssistantMessage`, `ThinkingMessage` are plain FCs that fully reconcile on every parent render
3. **`onFileClick` recreated inside `.map()` on every render** — defeats the existing `memo` on `MessageContent`
4. **`console.log` in render path** — serializes the entire message array on every keystroke
5. These factors compound, causing latency to grow linearly with conversation length

### Fix Summary

| Change | Impact |
|--------|--------|
| Extract `MessageList` as a `React.memo` component | **Core fix** — message list skips re-render entirely on keystroke |
| Wrap `UserMessage`/`AssistantMessage`/`ThinkingMessage` with `React.memo` | Defense in depth — individual messages only update when their props change |
| Move `handleFileClick` to `App` top-level with `useCallback` | Stable reference avoids defeating child memo |
| Remove `console.log('[App] Rendering messages:', allMessages)` | Eliminates per-keystroke message array serialization |
| Wrap `handleToggleThinking` with `useCallback` | Reduces unstable prop passed to InputForm |

## Reviewer Test Plan

1. Launch the VS Code IDE Companion extension
2. Start a long conversation (20+ turns) with tool calls and assistant messages
3. Type rapidly in the input box — verify no noticeable delay (should be < 100ms)
4. Verify pasting text still works correctly
5. Verify sending messages, canceling generation, etc. still work
6. Verify `@` file completion and `/` command completion still work
7. Verify clicking file links in messages still opens the correct file

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2395
