### PR TITLE
fix(tools): enforce read-before-write guard for write_file

### DIFF
--- a/packages/core/src/core/__snapshots__/prompts.test.ts.snap
+++ b/packages/core/src/core/__snapshots__/prompts.test.ts.snap
@@ -15,6 +15,7 @@ exports[`Core System Prompt (prompts.ts) > should append userMemory with separat
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with 'write_file', always read it first using 'read_file' to understand its current content. For targeted changes to existing files, prefer the 'edit' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the todo_write tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
@@ -237,6 +238,7 @@ exports[`Core System Prompt (prompts.ts) > should include git instructions when 
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with 'write_file', always read it first using 'read_file' to understand its current content. For targeted changes to existing files, prefer the 'edit' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the todo_write tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
@@ -469,6 +471,7 @@ exports[`Core System Prompt (prompts.ts) > should include non-sandbox instructio
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with 'write_file', always read it first using 'read_file' to understand its current content. For targeted changes to existing files, prefer the 'edit' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the todo_write tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
@@ -686,6 +689,7 @@ exports[`Core System Prompt (prompts.ts) > should include sandbox-specific instr
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with 'write_file', always read it first using 'read_file' to understand its current content. For targeted changes to existing files, prefer the 'edit' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the todo_write tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
@@ -903,6 +907,7 @@ exports[`Core System Prompt (prompts.ts) > should include seatbelt-specific inst
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with 'write_file', always read it first using 'read_file' to understand its current content. For targeted changes to existing files, prefer the 'edit' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the todo_write tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
@@ -1120,6 +1125,7 @@ exports[`Core System Prompt (prompts.ts) > should not include git instructions w
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with 'write_file', always read it first using 'read_file' to understand its current content. For targeted changes to existing files, prefer the 'edit' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the todo_write tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
@@ -1337,6 +1343,7 @@ exports[`Core System Prompt (prompts.ts) > should return the base prompt when no
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with 'write_file', always read it first using 'read_file' to understand its current content. For targeted changes to existing files, prefer the 'edit' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the todo_write tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
@@ -1554,6 +1561,7 @@ exports[`Core System Prompt (prompts.ts) > should return the base prompt when us
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with 'write_file', always read it first using 'read_file' to understand its current content. For targeted changes to existing files, prefer the 'edit' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the todo_write tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
@@ -1771,6 +1779,7 @@ exports[`Core System Prompt (prompts.ts) > should return the base prompt when us
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with 'write_file', always read it first using 'read_file' to understand its current content. For targeted changes to existing files, prefer the 'edit' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the todo_write tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
@@ -1988,6 +1997,7 @@ exports[`Model-specific tool call formats > should preserve model-specific forma
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with 'write_file', always read it first using 'read_file' to understand its current content. For targeted changes to existing files, prefer the 'edit' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the todo_write tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
@@ -2228,6 +2238,7 @@ exports[`Model-specific tool call formats > should preserve model-specific forma
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with 'write_file', always read it first using 'read_file' to understand its current content. For targeted changes to existing files, prefer the 'edit' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the todo_write tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
@@ -2531,6 +2542,7 @@ exports[`Model-specific tool call formats > should use JSON format for qwen-vl m
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with 'write_file', always read it first using 'read_file' to understand its current content. For targeted changes to existing files, prefer the 'edit' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the todo_write tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
@@ -2771,6 +2783,7 @@ exports[`Model-specific tool call formats > should use XML format for qwen3-code
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with 'write_file', always read it first using 'read_file' to understand its current content. For targeted changes to existing files, prefer the 'edit' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the todo_write tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
@@ -3070,6 +3083,7 @@ exports[`Model-specific tool call formats > should use bracket format for generi
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with 'write_file', always read it first using 'read_file' to understand its current content. For targeted changes to existing files, prefer the 'edit' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the todo_write tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.
@@ -3287,6 +3301,7 @@ exports[`Model-specific tool call formats > should use bracket format when no mo
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., read_file' or 'write_file'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with 'write_file', always read it first using 'read_file' to understand its current content. For targeted changes to existing files, prefer the 'edit' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the todo_write tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -157,6 +157,7 @@ You are Qwen Code, an interactive CLI agent developed by Alibaba Group, speciali
 - **Explaining Changes:** After completing a code modification or file operation *do not* provide summaries unless asked.
 - **Path Construction:** Before using any file system tool (e.g., ${ToolNames.READ_FILE}' or '${ToolNames.WRITE_FILE}'), you must construct the full absolute path for the file_path argument. Always combine the absolute path of the project's root directory with the file's path relative to the root. For example, if the project root is /path/to/project/ and the file is foo/bar/baz.txt, the final path you must use is /path/to/project/foo/bar/baz.txt. If the user provides a relative path, you must resolve it against the root directory to create an absolute path.
 - **Do Not revert changes:** Do not revert changes to the codebase unless asked to do so by the user. Only revert changes made by you if they have resulted in an error or if the user has explicitly asked you to revert the changes.
+- **Read Before Write:** Before overwriting an existing file with '${ToolNames.WRITE_FILE}', always read it first using '${ToolNames.READ_FILE}' to understand its current content. For targeted changes to existing files, prefer the '${ToolNames.EDIT}' tool. Writing to an existing file without reading it first risks data loss.
 
 # Task Management
 You have access to the ${ToolNames.TODO_WRITE} tool to help you manage and plan tasks. Use these tools VERY frequently to ensure that you are tracking your tasks and giving the user visibility into your progress.

--- a/packages/core/src/tools/tool-error.ts
+++ b/packages/core/src/tools/tool-error.ts
@@ -26,6 +26,7 @@ export enum ToolErrorType {
   PERMISSION_DENIED = 'permission_denied',
   NO_SPACE_LEFT = 'no_space_left',
   TARGET_IS_DIRECTORY = 'target_is_directory',
+  WRITE_CONTENT_LOSS_WARNING = 'write_content_loss_warning',
   PATH_NOT_IN_WORKSPACE = 'path_not_in_workspace',
   SEARCH_PATH_NOT_FOUND = 'search_path_not_found',
   SEARCH_PATH_NOT_A_DIRECTORY = 'search_path_not_a_directory',

--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -844,4 +844,97 @@ describe('WriteFileTool', () => {
       }
     });
   });
+
+  describe('content-loss guard', () => {
+    const abortSignal = new AbortController().signal;
+
+    it('should block overwrite when proposed content is significantly shorter than existing file', async () => {
+      const filePath = path.join(rootDir, 'guard-large-file.txt');
+      const originalContent = 'a'.repeat(200);
+      fs.writeFileSync(filePath, originalContent, 'utf-8');
+
+      const params: WriteFileToolParams = {
+        file_path: filePath,
+        content: 'short replacement',
+      };
+      const invocation = tool.build(params);
+      const result = await invocation.execute(abortSignal);
+
+      expect(result.error).toBeDefined();
+      expect(result.error!.type).toBe(ToolErrorType.WRITE_CONTENT_LOSS_WARNING);
+      // Verify original file is not modified
+      expect(fs.readFileSync(filePath, 'utf-8')).toBe(originalContent);
+    });
+
+    it('should allow overwrite when proposed content is similar length', async () => {
+      const filePath = path.join(rootDir, 'guard-similar-length.txt');
+      fs.writeFileSync(filePath, 'a'.repeat(200), 'utf-8');
+
+      const params: WriteFileToolParams = {
+        file_path: filePath,
+        content: 'b'.repeat(150),
+      };
+      const invocation = tool.build(params);
+      const result = await invocation.execute(abortSignal);
+
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should allow creation of new files regardless of content length', async () => {
+      const filePath = path.join(rootDir, 'guard-new-file.txt');
+
+      const params: WriteFileToolParams = {
+        file_path: filePath,
+        content: 'short',
+      };
+      const invocation = tool.build(params);
+      const result = await invocation.execute(abortSignal);
+
+      expect(result.error).toBeUndefined();
+      expect(fs.readFileSync(filePath, 'utf-8')).toBe('short');
+    });
+
+    it('should allow overwrite of small files even with shorter content', async () => {
+      const filePath = path.join(rootDir, 'guard-small-file.txt');
+      fs.writeFileSync(filePath, 'a'.repeat(50), 'utf-8');
+
+      const params: WriteFileToolParams = {
+        file_path: filePath,
+        content: 'tiny',
+      };
+      const invocation = tool.build(params);
+      const result = await invocation.execute(abortSignal);
+
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should allow overwrite of empty files', async () => {
+      const filePath = path.join(rootDir, 'guard-empty-file.txt');
+      fs.writeFileSync(filePath, '', 'utf-8');
+
+      const params: WriteFileToolParams = {
+        file_path: filePath,
+        content: 'new content',
+      };
+      const invocation = tool.build(params);
+      const result = await invocation.execute(abortSignal);
+
+      expect(result.error).toBeUndefined();
+    });
+
+    it('should skip guard when content was modified by user', async () => {
+      const filePath = path.join(rootDir, 'guard-user-modified.txt');
+      fs.writeFileSync(filePath, 'a'.repeat(200), 'utf-8');
+
+      const params: WriteFileToolParams = {
+        file_path: filePath,
+        content: 'short user edit',
+        modified_by_user: true,
+      };
+      const invocation = tool.build(params);
+      const result = await invocation.execute(abortSignal);
+
+      expect(result.error).toBeUndefined();
+    });
+  });
 });

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -217,6 +217,28 @@ class WriteFileToolInvocation extends BaseToolInvocation<
       }
     }
 
+    // Content-loss guard: detect potential data loss when overwriting existing files.
+    // If proposed content is significantly shorter than original, refuse the write
+    // and instruct the LLM to read the file first.
+    if (fileExists && originalContent.length >= 100 && !modified_by_user) {
+      const ratio = content.length / originalContent.length;
+      if (ratio < 0.5) {
+        const warningMsg =
+          `Warning: Proposed content (${content.length} chars) is significantly shorter than the existing file ` +
+          `(${originalContent.length} chars), which may indicate data loss. ` +
+          `Please use ${ReadFileTool.Name} to read the current file content before overwriting. ` +
+          `If you intend to replace the file with shorter content, read the file first to confirm your intent.`;
+        return {
+          llmContent: warningMsg,
+          returnDisplay: warningMsg,
+          error: {
+            message: warningMsg,
+            type: ToolErrorType.WRITE_CONTENT_LOSS_WARNING,
+          },
+        };
+      }
+    }
+
     if (!fileExists) {
       fs.mkdirSync(dirName, { recursive: true });
       const userEncoding = this.config.getDefaultFileEncoding();

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -43,6 +43,7 @@ import {
   fileExists as isFilefileExists,
 } from '../utils/fileUtils.js';
 import { getLanguageFromFilePath } from '../utils/language-detection.js';
+import { ReadFileTool } from './read-file.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 
 const debugLogger = createDebugLogger('WRITE_FILE');
@@ -366,7 +367,7 @@ export class WriteFileTool
     super(
       WriteFileTool.Name,
       ToolDisplayNames.WRITE_FILE,
-      `Writes content to a specified file in the local filesystem.
+      `Writes content to a specified file in the local filesystem. IMPORTANT: When overwriting an existing file, you MUST first read the file using ${ReadFileTool.Name} to understand its current content. Failure to do so may result in data loss. For targeted changes to existing files, prefer using the ${ToolNames.EDIT} tool instead.
 
       The user has the ability to modify \`content\`. If modified, this will be stated in the response.`,
       Kind.Edit,


### PR DESCRIPTION
## TLDR

Prevents `write_file` from overwriting existing files with hallucinated/truncated content by adding a 3-layer defense: system prompt instruction, tool description warning, and a runtime content-loss guard that blocks writes when proposed content is significantly shorter than the original.

## Screenshots / Video Demo

**Before (the problem):** The agent calls `write_file` on an existing 200-line file without reading it first, replacing it with ~20 lines of hallucinated content. Data loss.

**After (the fix):** When the proposed content is &lt;50% of the original file length, the write is blocked with an educational error:
```
Warning: Proposed content (17 chars) is significantly shorter than the existing file
(200 chars), which may indicate data loss. Please use read_file to read the current
file content before overwriting. If you intend to replace the file with shorter
content, read the file first to confirm your intent.
```
The original file is preserved. The LLM is guided to read first, then retry.

## Dive Deeper

### Approach & Rationale

**Problem:** `write_file` is stateless — no instruction or mechanism tells the LLM to read before writing. The `edit` tool avoids this by design (its `old_string` param forces knowledge of current content), but `write_file` has no equivalent.

**Alternatives considered:**
1. **Session-level read tracking** — Track which files the LLM has read and refuse writes to unread files. Rejected: requires architectural changes to the tool system (shared state across tool invocations) that are beyond the scope of a bugfix.
2. **Pre-hook validation** — Use the hook system to intercept `write_file` calls. Rejected: hooks are user-configurable, not a reliable default safeguard.
3. **Content-loss heuristic (chosen)** — Compare proposed content length to original. Simple, stateless, catches the most damaging case. Combined with prompt-level instructions for broader coverage.

**Decision:** Defense-in-depth with 3 complementary layers, each independently useful:

| Layer | File | What |
|-------|------|------|
| System prompt | `prompts.ts` | "Read Before Write" mandate in Core Mandates |
| Tool description | `write-file.ts` | Warning in schema, following `edit` tool pattern |
| Runtime guard | `write-file.ts` | Block writes when `proposed.length / original.length < 0.5` (files ≥100 chars) |

**Guard bypass conditions:** new files, small files (&lt;100 chars), empty files, user-modified content.

## Reviewer Test Plan

1. Run unit tests: `npx vitest run packages/core/src/tools/write-file.test.ts` (6 new tests for the guard)
2. Run prompt snapshot tests: `npx vitest run packages/core/src/core/prompts.test.ts`
3. Manual test:
   - Create a file with >100 chars of content
   - Ask the agent to write to that file with significantly shorter content (without reading first)
   - Expected: write blocked with content-loss warning
   - Then ask the agent to read the file first, then write
   - Expected: write proceeds normally

| Edge case | Guard behavior |
|-----------|---------------|
| New file creation | Skipped (file doesn't exist) |
| Empty existing file | Skipped (length &lt; 100) |
| Small file (&lt;100 chars) | Skipped (below threshold) |
| Content >50% of original | Skipped (ratio check passes) |
| User-modified content | Skipped (explicit bypass) |

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2499