### PR TITLE
feat(core): parallelize contiguous read-only tool calls

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -2227,6 +2227,112 @@ describe('CoreToolScheduler Sequential Execution', () => {
   });
 });
 
+describe('CoreToolScheduler contiguous read-only parallel execution', () => {
+  it('should run consecutive Kind.Read tools concurrently (non-agent)', async () => {
+    const executionLog: string[] = [];
+
+    const readTool = new MockTool({
+      name: 'read_file',
+      kind: Kind.Read,
+      execute: async (params) => {
+        const id = (params as { id: string }).id;
+        executionLog.push(`read:start:${id}`);
+        await new Promise((r) => setTimeout(r, 40));
+        executionLog.push(`read:end:${id}`);
+        return {
+          llmContent: `Read ${id} done`,
+          returnDisplay: `Read ${id} done`,
+        };
+      },
+    });
+
+    const tools = new Map<string, MockTool>([['read_file', readTool]]);
+    const onAllToolCallsComplete = vi.fn();
+    const onToolCallsUpdate = vi.fn();
+
+    const mockToolRegistry = {
+      getTool: (name: string) => tools.get(name),
+      getFunctionDeclarations: () => [],
+      tools,
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: (name: string) => tools.get(name),
+      getToolByDisplayName: () => undefined,
+      getTools: () => [...tools.values()],
+      discoverTools: async () => {},
+      getAllTools: () => [...tools.values()],
+      getToolsByServer: () => [],
+    } as unknown as ToolRegistry;
+
+    const mockConfig = {
+      getSessionId: () => 'test-session-id',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => ApprovalMode.YOLO,
+      getAllowedTools: () => [],
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'gemini',
+      }),
+      getShellExecutionConfig: () => ({
+        terminalWidth: 90,
+        terminalHeight: 30,
+      }),
+      storage: {
+        getProjectTempDir: () => '/tmp',
+      },
+      getTruncateToolOutputThreshold: () =>
+        DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
+      getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
+      getToolRegistry: () => mockToolRegistry,
+      getUseModelRouter: () => false,
+      getGeminiClient: () => null,
+      getChatRecordingService: () => undefined,
+      getMessageBus: vi.fn().mockReturnValue(undefined),
+      getEnableHooks: vi.fn().mockReturnValue(false),
+    } as unknown as Config;
+
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      onAllToolCallsComplete,
+      onToolCallsUpdate,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    const abortController = new AbortController();
+    await scheduler.schedule(
+      [
+        {
+          callId: '1',
+          name: 'read_file',
+          args: { id: 'a' },
+          isClientInitiated: false,
+          prompt_id: 'p1',
+        },
+        {
+          callId: '2',
+          name: 'read_file',
+          args: { id: 'b' },
+          isClientInitiated: false,
+          prompt_id: 'p1',
+        },
+      ],
+      abortController.signal,
+    );
+
+    expect(onAllToolCallsComplete).toHaveBeenCalled();
+    const readAStart = executionLog.indexOf('read:start:a');
+    const readBStart = executionLog.indexOf('read:start:b');
+    const firstReadEnd = Math.min(
+      executionLog.indexOf('read:end:a'),
+      executionLog.indexOf('read:end:b'),
+    );
+    expect(readAStart).toBeLessThan(firstReadEnd);
+    expect(readBStart).toBeLessThan(firstReadEnd);
+  });
+});
+
 describe('CoreToolScheduler plan mode with ask_user_question', () => {
   function createAskUserQuestionMockTool() {
     let wasAnswered = false;

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1335,32 +1335,61 @@ export class CoreToolScheduler {
 
     if (allCallsFinalOrScheduled) {
       const callsToExecute = this.toolCalls.filter(
-        (call) => call.status === 'scheduled',
+        (call): call is ScheduledToolCall => call.status === 'scheduled',
       );
 
-      // Task tools are safe to run concurrently — they spawn independent
-      // sub-agents with no shared mutable state.  All other tools run
-      // sequentially in their original order to preserve any implicit
-      // ordering the model may rely on.
-      const taskCalls = callsToExecute.filter(
-        (call) => call.request.name === ToolNames.AGENT,
+      const agentCalls = callsToExecute.filter((call) =>
+        this.isAgentScheduledCall(call),
       );
-      const otherCalls = callsToExecute.filter(
-        (call) => call.request.name !== ToolNames.AGENT,
+      const nonAgentCalls = callsToExecute.filter(
+        (call) => !this.isAgentScheduledCall(call),
       );
 
-      const taskPromise = Promise.all(
-        taskCalls.map((tc) => this.executeSingleToolCall(tc, signal)),
+      const agentPromise = Promise.all(
+        agentCalls.map((tc) => this.executeSingleToolCall(tc, signal)),
       );
 
-      const othersPromise = (async () => {
-        for (const toolCall of otherCalls) {
-          await this.executeSingleToolCall(toolCall, signal);
+      const nonAgentPromise = (async () => {
+        let i = 0;
+        while (i < nonAgentCalls.length) {
+          if (this.isReadOnlyParallelizableScheduledCall(nonAgentCalls[i])) {
+            const batch: ScheduledToolCall[] = [];
+            while (
+              i < nonAgentCalls.length &&
+              this.isReadOnlyParallelizableScheduledCall(nonAgentCalls[i])
+            ) {
+              batch.push(nonAgentCalls[i]);
+              i++;
+            }
+            await Promise.all(
+              batch.map((tc) => this.executeSingleToolCall(tc, signal)),
+            );
+          } else {
+            await this.executeSingleToolCall(nonAgentCalls[i], signal);
+            i++;
+          }
         }
       })();
 
-      await Promise.all([taskPromise, othersPromise]);
+      await Promise.all([agentPromise, nonAgentPromise]);
     }
+  }
+
+  private isAgentScheduledCall(call: ScheduledToolCall): boolean {
+    const name = call.request.name;
+    return name === ToolNames.AGENT || name === 'task';
+  }
+
+  private isReadOnlyParallelizableScheduledCall(
+    call: ScheduledToolCall,
+  ): boolean {
+    if (this.isAgentScheduledCall(call)) {
+      return false;
+    }
+    if (call.request.name === ToolNames.SKILL) {
+      return false;
+    }
+    return call.tool.isReadOnly;
   }
 
   private async executeSingleToolCall(

--- a/packages/core/src/test-utils/mock-tool.ts
+++ b/packages/core/src/test-utils/mock-tool.ts
@@ -22,6 +22,7 @@ import {
 
 interface MockToolOptions {
   name: string;
+  kind?: Kind;
   displayName?: string;
   description?: string;
   canUpdateOutput?: boolean;
@@ -97,7 +98,7 @@ export class MockTool extends BaseDeclarativeTool<
       options.name,
       options.displayName ?? options.name,
       options.description ?? options.name,
-      Kind.Other,
+      options.kind ?? Kind.Other,
       options.params,
       options.isOutputMarkdown ?? false,
       options.canUpdateOutput ?? false,

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -215,6 +215,10 @@ export abstract class DeclarativeTool<
     };
   }
 
+  get isReadOnly(): boolean {
+    return (READ_ONLY_KINDS as readonly Kind[]).includes(this.kind);
+  }
+
   /**
    * Validates the raw tool parameters.
    * Subclasses should override this to add custom validation logic
@@ -734,6 +738,13 @@ export const MUTATOR_KINDS: Kind[] = [
   Kind.Delete,
   Kind.Move,
   Kind.Execute,
+] as const;
+
+/** Safe to run concurrently with other read-only tools (contiguous batches only). */
+export const READ_ONLY_KINDS: Kind[] = [
+  Kind.Read,
+  Kind.Search,
+  Kind.Fetch,
 ] as const;
 
 export interface ToolLocation {


### PR DESCRIPTION
## What

Batch contiguous read-only tool calls (`Kind.Read`, `Kind.Search`, `Kind.Fetch`) for parallel execution via `Promise.all`.

## Why

When the model issues 3-5 file reads or greps in a single turn (extremely common pattern), they execute sequentially even though they have no shared mutable state. Each read might take 50-200ms of I/O — multiply that by 5 sequential calls and you're adding 250ms-1s of dead wait per turn. Parallelizing these cuts wall-clock time to the single longest call.

Agent/task calls were already parallelized. This extends the same principle to safe read operations with a clean abstraction: `READ_ONLY_KINDS` constant and `isReadOnly` getter on `DeclarativeTool`.

## Changes

| File | What |
|------|------|
| `coreToolScheduler.ts` | Detect contiguous read-only runs, batch via `Promise.all` |
| `tools.ts` | `READ_ONLY_KINDS` constant, `isReadOnly` getter |
| `mock-tool.ts` | `kind` option for testing |
| `coreToolScheduler.test.ts` | Verifies parallel execution via execution log timing |

## Test Plan

The test schedules two `Kind.Read` tools with 40ms sleep each. It asserts both starts occur before either end — proving concurrency, not sequentiality.

## Demo

N/A — internal performance. Latency reduction is proportional to the number of consecutive reads per turn.

Fixes #2563