### PR TITLE
feat(core): pre-flight context budget trimming for Anthropic and OpenAI

### DIFF
--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -283,7 +283,7 @@ describe('AnthropicContentGenerator', () => {
       expect(anthropicRequest).toEqual(
         expect.objectContaining({
           model: 'claude-test',
-          max_tokens: 1000,
+          max_tokens: 9000,
           temperature: 0.7,
           top_p: 0.9,
           top_k: 20,
@@ -423,7 +423,7 @@ describe('AnthropicContentGenerator', () => {
         const [anthropicRequest] =
           anthropicState.lastCreateArgs as AnthropicCreateArgs;
         expect(anthropicRequest).toEqual(
-          expect.objectContaining({ max_tokens: 32000 }),
+          expect.objectContaining({ max_tokens: 40000 }),
         );
       });
 
@@ -488,7 +488,7 @@ describe('AnthropicContentGenerator', () => {
         const [anthropicRequest] =
           anthropicState.lastCreateArgs as AnthropicCreateArgs;
         expect(anthropicRequest).toEqual(
-          expect.objectContaining({ max_tokens: 32000 }),
+          expect.objectContaining({ max_tokens: 40000 }),
         );
       });
     });

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -36,6 +36,7 @@ import {
   DEFAULT_OUTPUT_TOKEN_LIMIT,
   hasExplicitOutputLimit,
 } from '../tokenLimits.js';
+import { trimAnthropicMessagesForContextBudget } from './contextBudgetTrim.js';
 
 const debugLogger = createDebugLogger('ANTHROPIC');
 
@@ -193,14 +194,29 @@ export class AnthropicContentGenerator implements ContentGenerator {
       ? await this.converter.convertGeminiToolsToAnthropic(request.config.tools)
       : undefined;
 
+    const contextLimit =
+      this.contentGeneratorConfig.contextWindowSize ??
+      tokenLimit(this.contentGeneratorConfig.model, 'input');
+    const { messages: trimmedMessages, system: trimmedSystem } =
+      trimAnthropicMessagesForContextBudget(
+        messages,
+        system,
+        tools,
+        contextLimit,
+      );
+
     const sampling = this.buildSamplingParameters(request);
     const thinking = this.buildThinkingConfig(request);
     const outputConfig = this.buildOutputConfig();
 
+    if (thinking && sampling.max_tokens <= thinking.budget_tokens) {
+      sampling.max_tokens = thinking.budget_tokens + 8_000;
+    }
+
     return {
       model: this.contentGeneratorConfig.model,
-      system,
-      messages,
+      system: trimmedSystem,
+      messages: trimmedMessages,
       tools,
       ...sampling,
       ...(thinking ? { thinking } : {}),

--- a/packages/core/src/core/anthropicContentGenerator/contextBudgetTrim.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/contextBudgetTrim.test.ts
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  trimAnthropicMessagesForContextBudget,
+  CONTEXT_BUDGET_TRIM_SKIP_THRESHOLD,
+} from './contextBudgetTrim.js';
+import type Anthropic from '@anthropic-ai/sdk';
+
+describe('trimAnthropicMessagesForContextBudget', () => {
+  it('should not modify messages when context limit is Gemini-scale', () => {
+    const huge = 'x'.repeat(500_000);
+    const messages: Anthropic.MessageParam[] = [
+      { role: 'user', content: 'hi' },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: '1',
+            content: huge,
+          },
+        ],
+      },
+    ];
+    const out = trimAnthropicMessagesForContextBudget(
+      messages,
+      undefined,
+      undefined,
+      CONTEXT_BUDGET_TRIM_SKIP_THRESHOLD,
+    );
+    expect(out.messages).toBe(messages);
+    expect(out.system).toBeUndefined();
+  });
+
+  it('should not modify messages when under budget', () => {
+    const messages: Anthropic.MessageParam[] = [
+      { role: 'user', content: 'hello' },
+      { role: 'assistant', content: 'hi' },
+    ];
+    const out = trimAnthropicMessagesForContextBudget(
+      messages,
+      'You are helpful',
+      undefined,
+      200_000,
+    );
+    expect(out.messages).toBe(messages);
+    expect(out.system).toBe('You are helpful');
+  });
+
+  it('should trim oversized tool_result string content for small context windows', () => {
+    const huge = 'y'.repeat(50_000);
+    const messages: Anthropic.MessageParam[] = [
+      { role: 'user', content: 'hi' },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'c1',
+            content: huge,
+          },
+        ],
+      },
+    ];
+    const out = trimAnthropicMessagesForContextBudget(
+      messages,
+      undefined,
+      undefined,
+      8192,
+    );
+    const toolMsg = out.messages[1];
+    expect(toolMsg.role).toBe('user');
+    if (typeof toolMsg.content === 'string') {
+      throw new Error('Expected array content');
+    }
+    const block = toolMsg.content[0] as Anthropic.ContentBlockParam;
+    expect(block.type).toBe('tool_result');
+    if (block.type !== 'tool_result') {
+      throw new Error('Expected tool_result block');
+    }
+    expect(typeof block.content).toBe('string');
+    expect((block.content as string).length).toBeLessThan(huge.length);
+    expect(block.content as string).toContain('trimmed to fit');
+  });
+
+  it('should not mutate original messages', () => {
+    const huge = 'z'.repeat(50_000);
+    const messages: Anthropic.MessageParam[] = [
+      { role: 'user', content: 'hi' },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'c1', content: huge }],
+      },
+    ];
+    trimAnthropicMessagesForContextBudget(messages, undefined, undefined, 8192);
+    const block = (
+      messages[1].content as Anthropic.ContentBlockParam[]
+    )[0] as Anthropic.ToolResultBlockParam;
+    expect(block.content).toBe(huge);
+  });
+
+  it('should drop oldest tool result pairs when trimming is insufficient', () => {
+    const huge = 'a'.repeat(100_000);
+    const messages: Anthropic.MessageParam[] = [
+      { role: 'user', content: 'start' },
+      { role: 'assistant', content: 'ok' },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'old', content: huge }],
+      },
+      { role: 'assistant', content: 'processing' },
+      {
+        role: 'user',
+        content: [{ type: 'tool_result', tool_use_id: 'new', content: huge }],
+      },
+    ];
+    const out = trimAnthropicMessagesForContextBudget(
+      messages,
+      undefined,
+      undefined,
+      4096,
+    );
+    expect(out.messages.length).toBeLessThan(messages.length);
+  });
+
+  it('should skip non-string tool_result content', () => {
+    const messages: Anthropic.MessageParam[] = [
+      { role: 'user', content: 'hi' },
+      {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: 'c1',
+            content: [{ type: 'text', text: 'structured' }],
+          },
+        ],
+      },
+    ];
+    const out = trimAnthropicMessagesForContextBudget(
+      messages,
+      undefined,
+      undefined,
+      200_000,
+    );
+    expect(out.messages).toBe(messages);
+  });
+});

--- a/packages/core/src/core/anthropicContentGenerator/contextBudgetTrim.ts
+++ b/packages/core/src/core/anthropicContentGenerator/contextBudgetTrim.ts
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type Anthropic from '@anthropic-ai/sdk';
+
+/** Gemini-scale windows — trimming is unnecessary. */
+export const CONTEXT_BUDGET_TRIM_SKIP_THRESHOLD = 1_000_000;
+
+const CONTEXT_BUDGET_RATIO = 0.7;
+const MIN_TOOL_CONTENT_CHARS = 500;
+
+type AnthropicMessageParam = Anthropic.MessageParam;
+type AnthropicContentBlockParam = Anthropic.ContentBlockParam;
+
+function estimateTokens(
+  messages: AnthropicMessageParam[],
+  system: string | Anthropic.TextBlockParam[] | undefined,
+  tools?: unknown,
+): number {
+  const msgLen = JSON.stringify(messages).length;
+  const sysLen = system ? JSON.stringify(system).length : 0;
+  const toolLen = tools ? JSON.stringify(tools).length : 0;
+  return Math.ceil((msgLen + sysLen + toolLen) / 3);
+}
+
+/**
+ * Estimates serialized request size vs context limit and trims large tool
+ * results (then drops old message pairs) so Anthropic native API is less
+ * likely to reject the request before compression runs.
+ */
+export function trimAnthropicMessagesForContextBudget(
+  messages: AnthropicMessageParam[],
+  system: string | Anthropic.TextBlockParam[] | undefined,
+  tools: unknown | undefined,
+  contextTokenLimit: number,
+): {
+  messages: AnthropicMessageParam[];
+  system: string | Anthropic.TextBlockParam[] | undefined;
+} {
+  const limit = contextTokenLimit;
+  if (limit >= CONTEXT_BUDGET_TRIM_SKIP_THRESHOLD) {
+    return { messages, system };
+  }
+
+  const budget = Math.floor(limit * CONTEXT_BUDGET_RATIO);
+  let estimate = estimateTokens(messages, system, tools);
+  if (estimate <= budget) {
+    return { messages, system };
+  }
+
+  // Find tool_result blocks in user messages and collect indices
+  const toolResultIndices: Array<{
+    msgIdx: number;
+    blockIdx: number;
+    len: number;
+  }> = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role !== 'user') continue;
+    if (typeof msg.content === 'string') continue;
+    const blocks = msg.content as AnthropicContentBlockParam[];
+    for (let j = 0; j < blocks.length; j++) {
+      const block = blocks[j];
+      if (block.type === 'tool_result') {
+        const content = block.content;
+        if (typeof content === 'string') {
+          toolResultIndices.push({
+            msgIdx: i,
+            blockIdx: j,
+            len: content.length,
+          });
+        }
+      }
+    }
+  }
+  toolResultIndices.sort((a, b) => b.len - a.len);
+
+  const trimmed = messages.map((m) => ({
+    ...m,
+    content:
+      typeof m.content === 'string'
+        ? m.content
+        : (m.content as AnthropicContentBlockParam[]).map((b) => ({ ...b })),
+  })) as AnthropicMessageParam[];
+
+  for (const { msgIdx, blockIdx } of toolResultIndices) {
+    if (estimate <= budget) break;
+
+    const msg = trimmed[msgIdx];
+    if (typeof msg.content === 'string') continue;
+    const blocks = msg.content as AnthropicContentBlockParam[];
+    const block = blocks[blockIdx];
+    if (block.type !== 'tool_result') continue;
+    const content = block.content;
+    if (
+      typeof content !== 'string' ||
+      content.length <= MIN_TOOL_CONTENT_CHARS
+    ) {
+      continue;
+    }
+
+    const maxCharsPerTool = Math.max(
+      MIN_TOOL_CONTENT_CHARS,
+      Math.floor((budget * 3) / Math.max(toolResultIndices.length, 1)),
+    );
+    const keep = Math.min(
+      Math.max(MIN_TOOL_CONTENT_CHARS, Math.floor(content.length * 0.05)),
+      maxCharsPerTool,
+    );
+    const half = Math.floor(keep / 2);
+    const head = content.slice(0, half);
+    const tail = content.slice(-half);
+    const dropped = content.length - keep;
+    block.content = `${head}\n\n[... ${dropped} characters trimmed to fit ${limit} token context window ...]\n\n${tail}`;
+
+    estimate = estimateTokens(trimmed, system, tools);
+  }
+
+  // If still over budget, drop oldest tool result pairs from the middle
+  while (estimate > budget && trimmed.length > 4) {
+    // Find earliest user message with tool_result after system/first-user block
+    const dropIdx = trimmed.findIndex((m, i) => {
+      if (i < 2) return false;
+      if (m.role !== 'user') return false;
+      if (typeof m.content === 'string') return false;
+      const blocks = m.content as AnthropicContentBlockParam[];
+      return blocks.some((b) => b.type === 'tool_result');
+    });
+    if (dropIdx === -1) break;
+    // Also remove the preceding assistant message that requested this tool call
+    if (dropIdx > 0 && trimmed[dropIdx - 1].role === 'assistant') {
+      trimmed.splice(dropIdx - 1, 2);
+    } else {
+      trimmed.splice(dropIdx, 1);
+    }
+    estimate = estimateTokens(trimmed, system, tools);
+  }
+
+  return { messages: trimmed, system };
+}

--- a/packages/core/src/core/openaiContentGenerator/contextBudgetTrim.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/contextBudgetTrim.test.ts
@@ -1,0 +1,96 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  trimMessagesForContextBudget,
+  CONTEXT_BUDGET_TRIM_SKIP_THRESHOLD,
+} from './contextBudgetTrim.js';
+import type OpenAI from 'openai';
+
+describe('trimMessagesForContextBudget', () => {
+  it('should not modify messages when context limit is Gemini-scale', () => {
+    const huge = 'x'.repeat(500_000);
+    const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'ok' },
+      { role: 'tool', tool_call_id: '1', content: huge },
+    ];
+    const out = trimMessagesForContextBudget(
+      messages,
+      undefined,
+      CONTEXT_BUDGET_TRIM_SKIP_THRESHOLD,
+    );
+    expect(out).toBe(messages);
+  });
+
+  it('should not modify messages when under budget', () => {
+    const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'hi' },
+      { role: 'tool', tool_call_id: 'c1', content: 'small result' },
+    ];
+    const out = trimMessagesForContextBudget(messages, undefined, 200_000);
+    expect(out).toBe(messages);
+  });
+
+  it('should trim oversized tool string content for small context windows', () => {
+    const huge = 'y'.repeat(50_000);
+    const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'hi' },
+      { role: 'tool', tool_call_id: 'c1', content: huge },
+    ];
+    const out = trimMessagesForContextBudget(messages, undefined, 8192);
+    const toolMsg = out[2] as OpenAI.Chat.ChatCompletionToolMessageParam;
+    expect(toolMsg.role).toBe('tool');
+    expect(typeof toolMsg.content).toBe('string');
+    expect((toolMsg.content as string).length).toBeLessThan(huge.length);
+    expect(toolMsg.content as string).toContain('trimmed to fit');
+  });
+
+  it('should not mutate original messages', () => {
+    const huge = 'z'.repeat(50_000);
+    const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'hi' },
+      { role: 'tool', tool_call_id: 'c1', content: huge },
+    ];
+    trimMessagesForContextBudget(messages, undefined, 8192);
+    expect(
+      (messages[2] as OpenAI.Chat.ChatCompletionToolMessageParam).content,
+    ).toBe(huge);
+  });
+
+  it('should drop oldest tool messages when trimming is insufficient', () => {
+    const huge = 'a'.repeat(100_000);
+    const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'hi' },
+      { role: 'assistant', content: 'calling tool' },
+      { role: 'tool', tool_call_id: 'old', content: huge },
+      { role: 'assistant', content: 'calling again' },
+      { role: 'tool', tool_call_id: 'new', content: huge },
+    ];
+    const out = trimMessagesForContextBudget(messages, undefined, 4096);
+    expect(out.length).toBeLessThan(messages.length);
+  });
+
+  it('should preserve trimmed content head and tail', () => {
+    const content = 'HEAD_MARKER' + 'x'.repeat(50_000) + 'TAIL_MARKER';
+    const messages: OpenAI.Chat.ChatCompletionMessageParam[] = [
+      { role: 'system', content: 'sys' },
+      { role: 'user', content: 'hi' },
+      { role: 'tool', tool_call_id: 'c1', content },
+    ];
+    const out = trimMessagesForContextBudget(messages, undefined, 8192);
+    const trimmed = (out[2] as OpenAI.Chat.ChatCompletionToolMessageParam)
+      .content as string;
+    expect(trimmed).toContain('HEAD_MARKER');
+    expect(trimmed).toContain('TAIL_MARKER');
+  });
+});

--- a/packages/core/src/core/openaiContentGenerator/contextBudgetTrim.ts
+++ b/packages/core/src/core/openaiContentGenerator/contextBudgetTrim.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type OpenAI from 'openai';
+
+/** Gemini-scale windows — trimming is unnecessary. */
+export const CONTEXT_BUDGET_TRIM_SKIP_THRESHOLD = 1_000_000;
+
+const CONTEXT_BUDGET_RATIO = 0.7;
+const MIN_TOOL_CONTENT_CHARS = 500;
+
+function estimateTokens(
+  messages: OpenAI.Chat.ChatCompletionMessageParam[],
+  tools?: unknown,
+): number {
+  const msgLen = JSON.stringify(messages).length;
+  const toolLen = tools ? JSON.stringify(tools).length : 0;
+  return Math.ceil((msgLen + toolLen) / 3);
+}
+
+/**
+ * Estimates serialized request size vs context limit and trims large tool
+ * results (then drops old tool pairs) so OpenAI-compatible backends are less
+ * likely to reject the request before compression runs.
+ */
+export function trimMessagesForContextBudget(
+  messages: OpenAI.Chat.ChatCompletionMessageParam[],
+  tools: unknown | undefined,
+  contextTokenLimit: number,
+): OpenAI.Chat.ChatCompletionMessageParam[] {
+  const limit = contextTokenLimit;
+  if (limit >= CONTEXT_BUDGET_TRIM_SKIP_THRESHOLD) {
+    return messages;
+  }
+
+  const budget = Math.floor(limit * CONTEXT_BUDGET_RATIO);
+  let estimate = estimateTokens(messages, tools);
+  if (estimate <= budget) {
+    return messages;
+  }
+
+  const toolIndices: Array<{ idx: number; len: number }> = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.role !== 'tool') continue;
+    const content = (msg as OpenAI.Chat.ChatCompletionToolMessageParam).content;
+    if (typeof content === 'string') {
+      toolIndices.push({ idx: i, len: content.length });
+    }
+  }
+  toolIndices.sort((a, b) => b.len - a.len);
+
+  const trimmed = messages.map((m) => ({ ...m }));
+
+  for (const { idx } of toolIndices) {
+    if (estimate <= budget) break;
+
+    const tm = trimmed[idx] as OpenAI.Chat.ChatCompletionToolMessageParam;
+    const content = tm.content;
+    if (
+      typeof content !== 'string' ||
+      content.length <= MIN_TOOL_CONTENT_CHARS
+    ) {
+      continue;
+    }
+
+    const maxCharsPerTool = Math.max(
+      MIN_TOOL_CONTENT_CHARS,
+      Math.floor((budget * 3) / Math.max(toolIndices.length, 1)),
+    );
+    const keep = Math.min(
+      Math.max(MIN_TOOL_CONTENT_CHARS, Math.floor(content.length * 0.05)),
+      maxCharsPerTool,
+    );
+    const half = Math.floor(keep / 2);
+    const head = content.slice(0, half);
+    const tail = content.slice(-half);
+    const dropped = content.length - keep;
+    tm.content = `${head}\n\n[... ${dropped} characters trimmed to fit ${limit} token context window ...]\n\n${tail}`;
+
+    estimate = estimateTokens(trimmed, tools);
+  }
+
+  while (estimate > budget && trimmed.length > 4) {
+    const dropIdx = trimmed.findIndex((m, i) => i >= 2 && m.role === 'tool');
+    if (dropIdx === -1) break;
+    if (dropIdx > 0 && trimmed[dropIdx - 1].role === 'assistant') {
+      trimmed.splice(dropIdx - 1, 2);
+    } else {
+      trimmed.splice(dropIdx, 1);
+    }
+    estimate = estimateTokens(trimmed, tools);
+  }
+
+  return trimmed;
+}

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -14,6 +14,8 @@ import type { ContentGeneratorConfig } from '../contentGenerator.js';
 import type { OpenAICompatibleProvider } from './provider/index.js';
 import { OpenAIContentConverter } from './converter.js';
 import type { ErrorHandler, RequestContext } from './errorHandler.js';
+import { tokenLimit } from '../tokenLimits.js';
+import { trimMessagesForContextBudget } from './contextBudgetTrim.js';
 
 /**
  * Error thrown when the API returns an error embedded as stream content
@@ -337,6 +339,15 @@ export class ContentGenerationPipeline {
         request.config.tools,
       );
     }
+
+    const contextLimit =
+      this.contentGeneratorConfig.contextWindowSize ??
+      tokenLimit(effectiveModel, 'input');
+    baseRequest.messages = trimMessagesForContextBudget(
+      baseRequest.messages,
+      baseRequest.tools,
+      contextLimit,
+    );
 
     // Let provider enhance the request (e.g., add metadata, cache control)
     return this.config.provider.buildRequest(baseRequest, userPromptId);


### PR DESCRIPTION
## What

Pre-flight context budget trimming for Anthropic and OpenAI content generators. Estimates request size vs context window and trims tool results before sending.

## Why

With Claude (200K) or OpenAI models, accumulated tool results can push the request past the context limit **before chat compression gets a chance to run**. The API hard-rejects, the user sees a cryptic error, and the session is stuck. This is a pre-flight safety net — trim the biggest tool results first, then drop oldest tool pairs if still over budget. Skips entirely for Gemini-scale windows (>= 1M).

## Changes

| File | What |
|------|------|
| `anthropicContentGenerator/contextBudgetTrim.ts` | Trims `tool_result` blocks in user messages (Anthropic format) |
| `openaiContentGenerator/contextBudgetTrim.ts` | Trims `tool` role messages (OpenAI format) |
| `anthropicContentGenerator.ts` | Integrates trimming into request building |
| `pipeline.ts` | Integrates trimming into OpenAI request building |
| `contextBudgetTrim.test.ts` (x2) | 12 tests covering skip, trim, no-mutate, drop, and edge cases |

## Design

- Token estimation: `ceil((chars_messages + chars_system + chars_tools) / 3)` — deliberately conservative
- Budget ratio: 70% of context window (leaves room for generation + overhead)
- Trimming strategy: largest tool results first, keep head/tail with `[... N chars trimmed ...]` notice
- Fallback: drop oldest tool result pairs from conversation middle
- Immutable: never mutates input arrays

## Test Plan

6 tests per format: Gemini-scale skip, under-budget no-op, trim with notice, no-mutation, pair dropping, non-string content skip (Anthropic) / head-tail preservation (OpenAI).

## Demo

N/A — safety mechanism. Observable via absence of "context too long" errors on smaller-window models.

Fixes #2565