### PR TITLE
feat(core): tool output masking service for context reclamation

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1117,6 +1117,7 @@ export async function loadCliConfig(
     skipStartupContext: settings.model?.skipStartupContext ?? false,
     truncateToolOutputThreshold: settings.tools?.truncateToolOutputThreshold,
     truncateToolOutputLines: settings.tools?.truncateToolOutputLines,
+    toolOutputMasking: settings.experimental?.toolOutputMasking,
     eventEmitter: appEvents,
     gitCoAuthor: settings.general?.gitCoAuthor,
     output: {

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1586,7 +1586,59 @@ const SETTINGS_SCHEMA = {
     default: {},
     description: 'Setting to enable experimental features',
     showInDialog: false,
-    properties: {},
+    properties: {
+      toolOutputMasking: {
+        type: 'object',
+        label: 'Tool Output Masking',
+        category: 'Experimental',
+        requiresRestart: true,
+        default: {},
+        description:
+          'Mask older bulky tool outputs to save context (full output kept on disk).',
+        showInDialog: false,
+        properties: {
+          enabled: {
+            type: 'boolean',
+            label: 'Enable Tool Output Masking',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: true,
+            description: 'Enables tool output masking to save tokens.',
+            showInDialog: false,
+          },
+          toolProtectionThreshold: {
+            type: 'number',
+            label: 'Tool Protection Threshold',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: 50_000,
+            description:
+              'Token budget of the newest tool outputs to keep unmasked.',
+            showInDialog: false,
+          },
+          minPrunableTokensThreshold: {
+            type: 'number',
+            label: 'Min Prunable Tokens Threshold',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: 30_000,
+            description:
+              'Minimum prunable tokens required before a masking pass runs.',
+            showInDialog: false,
+          },
+          protectLatestTurn: {
+            type: 'boolean',
+            label: 'Protect Latest Turn',
+            category: 'Experimental',
+            requiresRestart: true,
+            default: true,
+            description:
+              'When true, the most recent conversation turn is never masked.',
+            showInDialog: false,
+          },
+        },
+      },
+    },
   },
 } as const satisfies SettingsSchema;
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -71,6 +71,11 @@ import { InputFormat, OutputFormat } from '../output/types.js';
 import { PromptRegistry } from '../prompts/prompt-registry.js';
 import { SkillManager } from '../skills/skill-manager.js';
 import { PermissionManager } from '../permissions/permission-manager.js';
+import {
+  DEFAULT_MIN_PRUNABLE_TOKENS_THRESHOLD,
+  DEFAULT_PROTECT_LATEST_TURN,
+  DEFAULT_TOOL_PROTECTION_THRESHOLD,
+} from '../services/toolOutputMaskingService.js';
 import { SubagentManager } from '../subagents/subagent-manager.js';
 import type { SubagentConfig } from '../subagents/types.js';
 import {
@@ -293,6 +298,13 @@ export interface SandboxConfig {
   image: string;
 }
 
+export interface ToolOutputMaskingConfig {
+  enabled: boolean;
+  toolProtectionThreshold: number;
+  minPrunableTokensThreshold: number;
+  protectLatestTurn: boolean;
+}
+
 /**
  * Settings shared across multi-agent collaboration features
  * (Arena, Team, Swarm).
@@ -406,6 +418,7 @@ export interface ConfigParameters {
   skipLoopDetection?: boolean;
   truncateToolOutputThreshold?: number;
   truncateToolOutputLines?: number;
+  toolOutputMasking?: Partial<ToolOutputMaskingConfig>;
   eventEmitter?: EventEmitter;
   output?: OutputSettings;
   inputFormat?: InputFormat;
@@ -590,6 +603,7 @@ export class Config {
   private readonly fileExclusions: FileExclusions;
   private readonly truncateToolOutputThreshold: number;
   private readonly truncateToolOutputLines: number;
+  private readonly toolOutputMasking: ToolOutputMaskingConfig;
   private readonly eventEmitter?: EventEmitter;
   private readonly channel: string | undefined;
   private readonly defaultFileEncoding: FileEncodingType | undefined;
@@ -715,6 +729,18 @@ export class Config {
       DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD;
     this.truncateToolOutputLines =
       params.truncateToolOutputLines ?? DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES;
+    this.toolOutputMasking = {
+      enabled: params.toolOutputMasking?.enabled ?? true,
+      toolProtectionThreshold:
+        params.toolOutputMasking?.toolProtectionThreshold ??
+        DEFAULT_TOOL_PROTECTION_THRESHOLD,
+      minPrunableTokensThreshold:
+        params.toolOutputMasking?.minPrunableTokensThreshold ??
+        DEFAULT_MIN_PRUNABLE_TOKENS_THRESHOLD,
+      protectLatestTurn:
+        params.toolOutputMasking?.protectLatestTurn ??
+        DEFAULT_PROTECT_LATEST_TURN,
+    };
     this.channel = params.channel;
     this.defaultFileEncoding = params.defaultFileEncoding;
     this.storage = new Storage(this.targetDir);
@@ -1996,6 +2022,14 @@ export class Config {
     }
 
     return this.truncateToolOutputLines;
+  }
+
+  getToolOutputMaskingEnabled(): boolean {
+    return this.toolOutputMasking.enabled;
+  }
+
+  async getToolOutputMaskingConfig(): Promise<ToolOutputMaskingConfig> {
+    return { ...this.toolOutputMasking };
   }
 
   getOutputFormat(): OutputFormat {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -338,6 +338,13 @@ describe('Gemini Client (client.ts)', () => {
       }),
       getCliVersion: vi.fn().mockReturnValue('1.0.0'),
       getChatCompression: vi.fn().mockReturnValue(undefined),
+      getToolOutputMaskingEnabled: vi.fn().mockReturnValue(false),
+      getToolOutputMaskingConfig: vi.fn().mockResolvedValue({
+        enabled: false,
+        toolProtectionThreshold: 50000,
+        minPrunableTokensThreshold: 30000,
+        protectLatestTurn: true,
+      }),
       getSkipNextSpeakerCheck: vi.fn().mockReturnValue(false),
       getUseModelRouter: vi.fn().mockReturnValue(false),
       getProjectRoot: vi.fn().mockReturnValue('/test/project/root'),

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -44,6 +44,7 @@ import {
   COMPRESSION_TOKEN_THRESHOLD,
 } from '../services/chatCompressionService.js';
 import { LoopDetectionService } from '../services/loopDetectionService.js';
+import { ToolOutputMaskingService } from '../services/toolOutputMaskingService.js';
 
 // Tools
 import { AgentTool } from '../tools/agent.js';
@@ -102,6 +103,7 @@ export class GeminiClient {
   private sessionTurnCount = 0;
 
   private readonly loopDetector: LoopDetectionService;
+  private readonly toolOutputMaskingService: ToolOutputMaskingService;
   private lastPromptId: string | undefined = undefined;
   private lastSentIdeContext: IdeContext | undefined;
   private forceFullIdeContext = true;
@@ -114,6 +116,7 @@ export class GeminiClient {
 
   constructor(private readonly config: Config) {
     this.loopDetector = new LoopDetectionService(config);
+    this.toolOutputMaskingService = new ToolOutputMaskingService();
   }
 
   async initialize() {
@@ -600,6 +603,8 @@ export class GeminiClient {
       }
     }
 
+    await this.tryMaskToolOutputs(this.getHistory());
+
     const turn = new Turn(this.getChat(), prompt_id);
 
     // append system reminders to the request
@@ -879,6 +884,19 @@ export class GeminiClient {
     }
 
     return info;
+  }
+
+  private async tryMaskToolOutputs(history: Content[]): Promise<void> {
+    if (!this.config.getToolOutputMaskingEnabled()) {
+      return;
+    }
+    const result = await this.toolOutputMaskingService.mask(
+      history,
+      this.config,
+    );
+    if (result.maskedCount > 0) {
+      this.getChat().setHistory(result.newHistory);
+    }
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -102,6 +102,7 @@ export * from './tools/write-file.js';
 // ============================================================================
 
 export * from './services/chatRecordingService.js';
+export * from './services/toolOutputMaskingService.js';
 export * from './services/fileDiscoveryService.js';
 export * from './services/fileSystemService.js';
 export * from './services/gitService.js';

--- a/packages/core/src/services/toolOutputMaskingService.test.ts
+++ b/packages/core/src/services/toolOutputMaskingService.test.ts
@@ -145,8 +145,9 @@ describe('ToolOutputMaskingService', () => {
     const result = await service.mask(history, config);
     const maskedHistory = result.newHistory;
     const skillResponse = maskedHistory[1].parts![0].functionResponse;
-    const skillOutput = (skillResponse!.response as Record<string, unknown>)
-      .output;
+    const skillOutput = (skillResponse!.response as Record<string, unknown>)[
+      'output'
+    ];
     expect(typeof skillOutput === 'string' && skillOutput).toBe(bigOutput);
   });
 
@@ -180,7 +181,7 @@ describe('ToolOutputMaskingService', () => {
         string,
         unknown
       >
-    ).output;
+    )['output'];
     expect(firstToolOutput).toBe(maskedContent);
   });
 

--- a/packages/core/src/services/toolOutputMaskingService.test.ts
+++ b/packages/core/src/services/toolOutputMaskingService.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  ToolOutputMaskingService,
+  MASKING_INDICATOR_TAG,
+} from './toolOutputMaskingService.js';
+import type { Content } from '@google/genai';
+import type { Config, ToolOutputMaskingConfig } from '../config/config.js';
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../telemetry/loggers.js', () => ({
+  logToolOutputMasking: vi.fn(),
+}));
+
+function createMockConfig(
+  overrides: Partial<ToolOutputMaskingConfig> = {},
+): Config {
+  const maskingConfig: ToolOutputMaskingConfig = {
+    enabled: true,
+    toolProtectionThreshold: 50_000,
+    minPrunableTokensThreshold: 1_000,
+    protectLatestTurn: true,
+    ...overrides,
+  };
+  return {
+    getToolOutputMaskingEnabled: () => maskingConfig.enabled,
+    getToolOutputMaskingConfig: async () => maskingConfig,
+    getSessionId: () => 'test-session',
+    storage: {
+      getProjectTempDir: () => '/tmp/test',
+    },
+  } as unknown as Config;
+}
+
+function toolResponseContent(
+  name: string,
+  output: string,
+  id?: string,
+): Content {
+  return {
+    role: 'model',
+    parts: [
+      {
+        functionResponse: {
+          name,
+          id: id || `call-${name}`,
+          response: { output },
+        },
+      },
+    ],
+  };
+}
+
+describe('ToolOutputMaskingService', () => {
+  let service: ToolOutputMaskingService;
+
+  beforeEach(() => {
+    service = new ToolOutputMaskingService();
+    vi.clearAllMocks();
+  });
+
+  it('should return unmodified history when masking is disabled', async () => {
+    const config = createMockConfig({ enabled: false });
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'hi' }] },
+      toolResponseContent('read_file', 'x'.repeat(100_000)),
+    ];
+    const result = await service.mask(history, config);
+    expect(result.maskedCount).toBe(0);
+    expect(result.newHistory).toBe(history);
+  });
+
+  it('should return unmodified history when empty', async () => {
+    const config = createMockConfig();
+    const result = await service.mask([], config);
+    expect(result.maskedCount).toBe(0);
+  });
+
+  it('should not mask when prunable tokens are below threshold', async () => {
+    const config = createMockConfig({ minPrunableTokensThreshold: 999_999 });
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'hi' }] },
+      toolResponseContent('read_file', 'small output'),
+    ];
+    const result = await service.mask(history, config);
+    expect(result.maskedCount).toBe(0);
+  });
+
+  it('should mask old tool outputs when above threshold', async () => {
+    const config = createMockConfig({
+      toolProtectionThreshold: 100,
+      minPrunableTokensThreshold: 100,
+      protectLatestTurn: false,
+    });
+    const bigOutput = 'x'.repeat(50_000);
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'start' }] },
+      toolResponseContent('read_file', bigOutput, 'old-call'),
+      { role: 'user', parts: [{ text: 'continue' }] },
+      toolResponseContent('read_file', bigOutput, 'new-call'),
+    ];
+    const result = await service.mask(history, config);
+    expect(result.maskedCount).toBeGreaterThan(0);
+    expect(result.tokensSaved).toBeGreaterThan(0);
+  });
+
+  it('should protect the latest turn when configured', async () => {
+    const config = createMockConfig({
+      toolProtectionThreshold: 1,
+      minPrunableTokensThreshold: 1,
+      protectLatestTurn: true,
+    });
+    const bigOutput = 'x'.repeat(50_000);
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'hi' }] },
+      toolResponseContent('read_file', bigOutput, 'latest'),
+    ];
+    const result = await service.mask(history, config);
+    expect(result.maskedCount).toBe(0);
+  });
+
+  it('should not mask exempt tools (skill, memory, ask_user_question)', async () => {
+    const config = createMockConfig({
+      toolProtectionThreshold: 1,
+      minPrunableTokensThreshold: 1,
+      protectLatestTurn: false,
+    });
+    const bigOutput = 'x'.repeat(50_000);
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'hi' }] },
+      toolResponseContent('skill', bigOutput, 'skill-call'),
+      toolResponseContent('memory', bigOutput, 'memory-call'),
+      { role: 'user', parts: [{ text: 'next' }] },
+      toolResponseContent('read_file', bigOutput, 'read-call'),
+    ];
+    const result = await service.mask(history, config);
+    const maskedHistory = result.newHistory;
+    const skillResponse = maskedHistory[1].parts![0].functionResponse;
+    const skillOutput = (skillResponse!.response as Record<string, unknown>)
+      .output;
+    expect(typeof skillOutput === 'string' && skillOutput).toBe(bigOutput);
+  });
+
+  it('should not re-mask already masked outputs', async () => {
+    const config = createMockConfig({
+      toolProtectionThreshold: 1,
+      minPrunableTokensThreshold: 1,
+      protectLatestTurn: false,
+    });
+    const maskedContent = `<${MASKING_INDICATOR_TAG}>preview</${MASKING_INDICATOR_TAG}>`;
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'hi' }] },
+      {
+        role: 'model',
+        parts: [
+          {
+            functionResponse: {
+              name: 'read_file',
+              id: 'already-masked',
+              response: { output: maskedContent },
+            },
+          },
+        ],
+      },
+      { role: 'user', parts: [{ text: 'next' }] },
+      toolResponseContent('read_file', 'x'.repeat(50_000), 'new-call'),
+    ];
+    const result = await service.mask(history, config);
+    const firstToolOutput = (
+      result.newHistory[1].parts![0].functionResponse!.response as Record<
+        string,
+        unknown
+      >
+    ).output;
+    expect(firstToolOutput).toBe(maskedContent);
+  });
+
+  it('should include masking indicator tag in masked output', async () => {
+    const config = createMockConfig({
+      toolProtectionThreshold: 1,
+      minPrunableTokensThreshold: 1,
+      protectLatestTurn: false,
+    });
+    const bigOutput = 'x'.repeat(50_000);
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'start' }] },
+      toolResponseContent('read_file', bigOutput, 'old'),
+      { role: 'user', parts: [{ text: 'continue' }] },
+      toolResponseContent('read_file', 'y'.repeat(50_000), 'new'),
+    ];
+    const result = await service.mask(history, config);
+    if (result.maskedCount > 0) {
+      const masked = JSON.stringify(result.newHistory);
+      expect(masked).toContain(MASKING_INDICATOR_TAG);
+    }
+  });
+});

--- a/packages/core/src/services/toolOutputMaskingService.ts
+++ b/packages/core/src/services/toolOutputMaskingService.ts
@@ -1,300 +1,73 @@
-/**
- * @license
- * Copyright 2026 Google LLC
- * SPDX-License-Identifier: Apache-2.0
- */
+commit efce83c9f6a085ba4defe4d356ca1ed8f386d6c8
+Author: netbrah <162479981+netbrah@users.noreply.github.com>
+Date:   Sat Mar 21 23:52:56 2026 -0400
 
-import type { Content, Part } from '@google/genai';
-import path from 'node:path';
-import * as fsPromises from 'node:fs/promises';
-import { estimateTokenCountSync } from '../utils/tokenCalculation.js';
-import { createDebugLogger } from '../utils/debugLogger.js';
-import type { Config } from '../config/config.js';
-import { logToolOutputMasking } from '../telemetry/loggers.js';
-import { ToolNames } from '../tools/tool-names.js';
-import { ToolOutputMaskingEvent } from '../telemetry/types.js';
+    fix: review round 4 findings from Copilot
+    
+    Made-with: Cursor
 
-const debugLogger = createDebugLogger('TOOL_OUTPUT_MASKING');
-
-export const DEFAULT_TOOL_PROTECTION_THRESHOLD = 50000;
-export const DEFAULT_MIN_PRUNABLE_TOKENS_THRESHOLD = 30000;
-export const DEFAULT_PROTECT_LATEST_TURN = true;
-export const MASKING_INDICATOR_TAG = 'tool_output_masked';
-
-export const TOOL_OUTPUTS_DIR = 'tool-outputs';
-
-const EXEMPT_TOOLS: ReadonlySet<string> = new Set([
-  ToolNames.SKILL,
-  ToolNames.MEMORY,
-  ToolNames.ASK_USER_QUESTION,
-  ToolNames.EXIT_PLAN_MODE,
-]);
-
-export interface MaskingResult {
-  newHistory: Content[];
-  maskedCount: number;
-  tokensSaved: number;
-}
-
-function sanitizeFilenamePart(part: string): string {
-  return part.replace(/[^a-zA-Z0-9_-]/g, '_');
-}
-
-export class ToolOutputMaskingService {
-  async mask(history: Content[], config: Config): Promise<MaskingResult> {
-    const maskingConfig = await config.getToolOutputMaskingConfig();
-    if (!maskingConfig.enabled || history.length === 0) {
-      return { newHistory: history, maskedCount: 0, tokensSaved: 0 };
-    }
-
-    let cumulativeToolTokens = 0;
-    let protectionBoundaryReached = false;
-    let totalPrunableTokens = 0;
-    let maskedCount = 0;
-
-    const prunableParts: Array<{
-      contentIndex: number;
-      partIndex: number;
-      tokens: number;
-      content: string;
-      originalPart: Part;
-    }> = [];
-
-    const scanStartIdx = maskingConfig.protectLatestTurn
-      ? history.length - 2
-      : history.length - 1;
-
-    for (let i = scanStartIdx; i >= 0; i--) {
-      const content = history[i];
-      const parts = content.parts || [];
-
-      for (let j = parts.length - 1; j >= 0; j--) {
-        const part = parts[j];
-
-        if (!part.functionResponse) continue;
-
-        const toolName = part.functionResponse.name;
-        if (toolName && EXEMPT_TOOLS.has(toolName)) {
-          continue;
-        }
-
-        const toolOutputContent = this.getToolOutputContent(part);
-        if (!toolOutputContent || this.isAlreadyMasked(toolOutputContent)) {
-          continue;
-        }
-
-        const partTokens = estimateTokenCountSync([part]);
-
-        if (!protectionBoundaryReached) {
-          cumulativeToolTokens += partTokens;
-          if (cumulativeToolTokens > maskingConfig.toolProtectionThreshold) {
-            protectionBoundaryReached = true;
-            totalPrunableTokens += partTokens;
-            prunableParts.push({
-              contentIndex: i,
-              partIndex: j,
-              tokens: partTokens,
-              content: toolOutputContent,
-              originalPart: part,
-            });
-          }
-        } else {
-          totalPrunableTokens += partTokens;
-          prunableParts.push({
-            contentIndex: i,
-            partIndex: j,
-            tokens: partTokens,
-            content: toolOutputContent,
-            originalPart: part,
-          });
-        }
-      }
-    }
-
-    if (totalPrunableTokens < maskingConfig.minPrunableTokensThreshold) {
-      return { newHistory: history, maskedCount: 0, tokensSaved: 0 };
-    }
-
-    debugLogger.debug(
-      `[ToolOutputMasking] Triggering masking. Prunable tool tokens: ${totalPrunableTokens.toLocaleString()} (> ${maskingConfig.minPrunableTokensThreshold.toLocaleString()})`,
-    );
-
-    const newHistory = [...history];
-    let actualTokensSaved = 0;
-    let toolOutputsDir = path.join(
-      config.storage.getProjectTempDir(),
-      TOOL_OUTPUTS_DIR,
-    );
-    const sessionId = config.getSessionId();
-    if (sessionId) {
-      const safeSessionId = sanitizeFilenamePart(sessionId);
-      toolOutputsDir = path.join(toolOutputsDir, `session-${safeSessionId}`);
-    }
-    await fsPromises.mkdir(toolOutputsDir, { recursive: true });
-
-    for (const item of prunableParts) {
-      const { contentIndex, partIndex, content, tokens } = item;
-      const contentRecord = newHistory[contentIndex];
-      const part = contentRecord.parts![partIndex];
-
-      if (!part.functionResponse) continue;
-
-      const toolName = part.functionResponse.name || 'unknown_tool';
-      const callId = part.functionResponse.id || Date.now().toString();
-      const safeToolName = sanitizeFilenamePart(toolName).toLowerCase();
-      const safeCallId = sanitizeFilenamePart(callId).toLowerCase();
-      const fileName = `${safeToolName}_${safeCallId}_${Math.random()
-        .toString(36)
-        .substring(7)}.txt`;
-      const filePath = path.join(toolOutputsDir, fileName);
-
-      await fsPromises.writeFile(filePath, content, 'utf-8');
-
-      const originalResponse =
-        (part.functionResponse.response as Record<string, unknown>) || {};
-
-      let preview = '';
-      if (toolName === ToolNames.SHELL) {
-        preview = this.formatShellPreview(originalResponse);
-      } else {
-        if (content.length > 500) {
-          preview = `${content.slice(0, 250)}\n... [TRUNCATED] ...\n${content.slice(-250)}`;
-        } else {
-          preview = content;
-        }
-      }
-
-      const maskedSnippet = this.formatMaskedSnippet(filePath, preview);
-
-      const maskedPart = {
-        ...part,
-        functionResponse: {
-          ...part.functionResponse,
-          response: { output: maskedSnippet },
-        },
-      };
-
-      const newTaskTokens = estimateTokenCountSync([maskedPart]);
-      const savings = tokens - newTaskTokens;
-
-      if (savings > 0) {
-        const newParts = [...contentRecord.parts!];
-        newParts[partIndex] = maskedPart;
-        newHistory[contentIndex] = { ...contentRecord, parts: newParts };
-        actualTokensSaved += savings;
-        maskedCount++;
-      }
-    }
-
-    debugLogger.debug(
-      `[ToolOutputMasking] Masked ${maskedCount} tool outputs. Saved ~${actualTokensSaved.toLocaleString()} tokens.`,
-    );
-
-    const result = {
-      newHistory,
-      maskedCount,
-      tokensSaved: actualTokensSaved,
-    };
-
-    if (actualTokensSaved <= 0) {
-      return result;
-    }
-
-    logToolOutputMasking(
-      config,
-      new ToolOutputMaskingEvent({
-        tokens_before: totalPrunableTokens,
-        tokens_after: totalPrunableTokens - actualTokensSaved,
-        masked_count: maskedCount,
-        total_prunable_tokens: totalPrunableTokens,
-      }),
-    );
-
-    return result;
-  }
-
-  private getToolOutputContent(part: Part): string | null {
-    if (!part.functionResponse) return null;
-    const response = part.functionResponse.response as Record<string, unknown>;
-    if (!response) return null;
-
-    const content = JSON.stringify(response, null, 2);
-
-    return content;
-  }
-
-  private isAlreadyMasked(content: string): boolean {
-    return content.includes(`<${MASKING_INDICATOR_TAG}`);
-  }
-
-  private formatShellPreview(response: Record<string, unknown>): string {
-    const content = (response['output'] || response['stdout'] || '') as string;
-    if (typeof content !== 'string') {
-      return typeof content === 'object'
-        ? JSON.stringify(content)
-        : String(content);
-    }
-
-    const sectionRegex =
-      /^(Output|Error|Exit Code|Signal|Background PIDs|Process Group PGID): /m;
-    const parts = content.split(sectionRegex);
-
-    if (parts.length < 3) {
-      return this.formatSimplePreview(content);
-    }
-
-    const previewParts: string[] = [];
-    if (parts[0].trim()) {
-      previewParts.push(this.formatSimplePreview(parts[0].trim()));
-    }
-
-    for (let i = 1; i < parts.length; i += 2) {
-      const name = parts[i];
-      const sectionContent = parts[i + 1]?.trim() || '';
-
-      if (name === 'Output') {
-        previewParts.push(
-          `Output: ${this.formatSimplePreview(sectionContent)}`,
-        );
-      } else {
-        previewParts.push(`${name}: ${sectionContent}`);
-      }
-    }
-
-    let preview = previewParts.join('\n');
-
-    const exitCode = response['exitCode'] ?? response['exit_code'];
-    const error = response['error'];
-    if (
-      exitCode !== undefined &&
-      exitCode !== 0 &&
-      exitCode !== null &&
-      !content.includes(`Exit Code: ${exitCode}`)
-    ) {
-      preview += `\n[Exit Code: ${exitCode}]`;
-    }
-    if (error && !content.includes(`Error: ${error}`)) {
-      preview += `\n[Error: ${error}]`;
-    }
-
-    return preview;
-  }
-
-  private formatSimplePreview(content: string): string {
-    const lines = content.split('\n');
-    if (lines.length <= 20) return content;
-    const head = lines.slice(0, 10);
-    const tail = lines.slice(-10);
-    return `${head.join('\n')}\n\n... [${
-      lines.length - head.length - tail.length
-    } lines omitted] ...\n\n${tail.join('\n')}`;
-  }
-
-  private formatMaskedSnippet(filePath: string, preview: string): string {
-    return `<${MASKING_INDICATOR_TAG}>
-${preview}
-
-Output too large. Full output available at: ${filePath}
-</${MASKING_INDICATOR_TAG}>`;
-  }
-}
+diff --git a/packages/core/src/services/toolOutputMaskingService.ts b/packages/core/src/services/toolOutputMaskingService.ts
+index 27ee911b6..0fa182233 100644
+--- a/packages/core/src/services/toolOutputMaskingService.ts
++++ b/packages/core/src/services/toolOutputMaskingService.ts
+@@ -121,16 +121,22 @@ export class ToolOutputMaskingService {
+ 
+     const newHistory = [...history];
+     let actualTokensSaved = 0;
+-    let toolOutputsDir = path.join(
+-      config.storage.getProjectTempDir(),
+-      TOOL_OUTPUTS_DIR,
+-    );
+-    const sessionId = config.getSessionId();
+-    if (sessionId) {
+-      const safeSessionId = sanitizeFilenamePart(sessionId);
+-      toolOutputsDir = path.join(toolOutputsDir, `session-${safeSessionId}`);
++    let toolOutputsDir: string;
++    try {
++      toolOutputsDir = path.join(
++        config.storage.getProjectTempDir(),
++        TOOL_OUTPUTS_DIR,
++      );
++      const sessionId = config.getSessionId();
++      if (sessionId) {
++        const safeSessionId = sanitizeFilenamePart(sessionId);
++        toolOutputsDir = path.join(toolOutputsDir, `session-${safeSessionId}`);
++      }
++      await fsPromises.mkdir(toolOutputsDir, { recursive: true });
++    } catch (fsErr) {
++      debugLogger.warn(`[ToolOutputMasking] FS setup failed, skipping: ${fsErr}`);
++      return { newHistory: history, maskedCount: 0, tokensSaved: 0 };
+     }
+-    await fsPromises.mkdir(toolOutputsDir, { recursive: true });
+ 
+     for (const item of prunableParts) {
+       const { contentIndex, partIndex, content, tokens } = item;
+@@ -148,7 +154,12 @@ export class ToolOutputMaskingService {
+         .substring(7)}.txt`;
+       const filePath = path.join(toolOutputsDir, fileName);
+ 
+-      await fsPromises.writeFile(filePath, content, 'utf-8');
++      try {
++        await fsPromises.writeFile(filePath, content, { encoding: 'utf-8', mode: 0o600 });
++      } catch {
++        debugLogger.warn(`[ToolOutputMasking] Failed to write ${filePath}, skipping`);
++        continue;
++      }
+ 
+       const originalResponse =
+         (part.functionResponse.response as Record<string, unknown>) || {};
+@@ -218,9 +229,11 @@ export class ToolOutputMaskingService {
+     const response = part.functionResponse.response as Record<string, unknown>;
+     if (!response) return null;
+ 
+-    const content = JSON.stringify(response, null, 2);
+-
+-    return content;
++    try {
++      return JSON.stringify(response, null, 2);
++    } catch {
++      return String(response);
++    }
+   }
+ 
+   private isAlreadyMasked(content: string): boolean {

--- a/packages/core/src/services/toolOutputMaskingService.ts
+++ b/packages/core/src/services/toolOutputMaskingService.ts
@@ -1,0 +1,300 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Content, Part } from '@google/genai';
+import path from 'node:path';
+import * as fsPromises from 'node:fs/promises';
+import { estimateTokenCountSync } from '../utils/tokenCalculation.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
+import type { Config } from '../config/config.js';
+import { logToolOutputMasking } from '../telemetry/loggers.js';
+import { ToolNames } from '../tools/tool-names.js';
+import { ToolOutputMaskingEvent } from '../telemetry/types.js';
+
+const debugLogger = createDebugLogger('TOOL_OUTPUT_MASKING');
+
+export const DEFAULT_TOOL_PROTECTION_THRESHOLD = 50000;
+export const DEFAULT_MIN_PRUNABLE_TOKENS_THRESHOLD = 30000;
+export const DEFAULT_PROTECT_LATEST_TURN = true;
+export const MASKING_INDICATOR_TAG = 'tool_output_masked';
+
+export const TOOL_OUTPUTS_DIR = 'tool-outputs';
+
+const EXEMPT_TOOLS: ReadonlySet<string> = new Set([
+  ToolNames.SKILL,
+  ToolNames.MEMORY,
+  ToolNames.ASK_USER_QUESTION,
+  ToolNames.EXIT_PLAN_MODE,
+]);
+
+export interface MaskingResult {
+  newHistory: Content[];
+  maskedCount: number;
+  tokensSaved: number;
+}
+
+function sanitizeFilenamePart(part: string): string {
+  return part.replace(/[^a-zA-Z0-9_-]/g, '_');
+}
+
+export class ToolOutputMaskingService {
+  async mask(history: Content[], config: Config): Promise<MaskingResult> {
+    const maskingConfig = await config.getToolOutputMaskingConfig();
+    if (!maskingConfig.enabled || history.length === 0) {
+      return { newHistory: history, maskedCount: 0, tokensSaved: 0 };
+    }
+
+    let cumulativeToolTokens = 0;
+    let protectionBoundaryReached = false;
+    let totalPrunableTokens = 0;
+    let maskedCount = 0;
+
+    const prunableParts: Array<{
+      contentIndex: number;
+      partIndex: number;
+      tokens: number;
+      content: string;
+      originalPart: Part;
+    }> = [];
+
+    const scanStartIdx = maskingConfig.protectLatestTurn
+      ? history.length - 2
+      : history.length - 1;
+
+    for (let i = scanStartIdx; i >= 0; i--) {
+      const content = history[i];
+      const parts = content.parts || [];
+
+      for (let j = parts.length - 1; j >= 0; j--) {
+        const part = parts[j];
+
+        if (!part.functionResponse) continue;
+
+        const toolName = part.functionResponse.name;
+        if (toolName && EXEMPT_TOOLS.has(toolName)) {
+          continue;
+        }
+
+        const toolOutputContent = this.getToolOutputContent(part);
+        if (!toolOutputContent || this.isAlreadyMasked(toolOutputContent)) {
+          continue;
+        }
+
+        const partTokens = estimateTokenCountSync([part]);
+
+        if (!protectionBoundaryReached) {
+          cumulativeToolTokens += partTokens;
+          if (cumulativeToolTokens > maskingConfig.toolProtectionThreshold) {
+            protectionBoundaryReached = true;
+            totalPrunableTokens += partTokens;
+            prunableParts.push({
+              contentIndex: i,
+              partIndex: j,
+              tokens: partTokens,
+              content: toolOutputContent,
+              originalPart: part,
+            });
+          }
+        } else {
+          totalPrunableTokens += partTokens;
+          prunableParts.push({
+            contentIndex: i,
+            partIndex: j,
+            tokens: partTokens,
+            content: toolOutputContent,
+            originalPart: part,
+          });
+        }
+      }
+    }
+
+    if (totalPrunableTokens < maskingConfig.minPrunableTokensThreshold) {
+      return { newHistory: history, maskedCount: 0, tokensSaved: 0 };
+    }
+
+    debugLogger.debug(
+      `[ToolOutputMasking] Triggering masking. Prunable tool tokens: ${totalPrunableTokens.toLocaleString()} (> ${maskingConfig.minPrunableTokensThreshold.toLocaleString()})`,
+    );
+
+    const newHistory = [...history];
+    let actualTokensSaved = 0;
+    let toolOutputsDir = path.join(
+      config.storage.getProjectTempDir(),
+      TOOL_OUTPUTS_DIR,
+    );
+    const sessionId = config.getSessionId();
+    if (sessionId) {
+      const safeSessionId = sanitizeFilenamePart(sessionId);
+      toolOutputsDir = path.join(toolOutputsDir, `session-${safeSessionId}`);
+    }
+    await fsPromises.mkdir(toolOutputsDir, { recursive: true });
+
+    for (const item of prunableParts) {
+      const { contentIndex, partIndex, content, tokens } = item;
+      const contentRecord = newHistory[contentIndex];
+      const part = contentRecord.parts![partIndex];
+
+      if (!part.functionResponse) continue;
+
+      const toolName = part.functionResponse.name || 'unknown_tool';
+      const callId = part.functionResponse.id || Date.now().toString();
+      const safeToolName = sanitizeFilenamePart(toolName).toLowerCase();
+      const safeCallId = sanitizeFilenamePart(callId).toLowerCase();
+      const fileName = `${safeToolName}_${safeCallId}_${Math.random()
+        .toString(36)
+        .substring(7)}.txt`;
+      const filePath = path.join(toolOutputsDir, fileName);
+
+      await fsPromises.writeFile(filePath, content, 'utf-8');
+
+      const originalResponse =
+        (part.functionResponse.response as Record<string, unknown>) || {};
+
+      let preview = '';
+      if (toolName === ToolNames.SHELL) {
+        preview = this.formatShellPreview(originalResponse);
+      } else {
+        if (content.length > 500) {
+          preview = `${content.slice(0, 250)}\n... [TRUNCATED] ...\n${content.slice(-250)}`;
+        } else {
+          preview = content;
+        }
+      }
+
+      const maskedSnippet = this.formatMaskedSnippet(filePath, preview);
+
+      const maskedPart = {
+        ...part,
+        functionResponse: {
+          ...part.functionResponse,
+          response: { output: maskedSnippet },
+        },
+      };
+
+      const newTaskTokens = estimateTokenCountSync([maskedPart]);
+      const savings = tokens - newTaskTokens;
+
+      if (savings > 0) {
+        const newParts = [...contentRecord.parts!];
+        newParts[partIndex] = maskedPart;
+        newHistory[contentIndex] = { ...contentRecord, parts: newParts };
+        actualTokensSaved += savings;
+        maskedCount++;
+      }
+    }
+
+    debugLogger.debug(
+      `[ToolOutputMasking] Masked ${maskedCount} tool outputs. Saved ~${actualTokensSaved.toLocaleString()} tokens.`,
+    );
+
+    const result = {
+      newHistory,
+      maskedCount,
+      tokensSaved: actualTokensSaved,
+    };
+
+    if (actualTokensSaved <= 0) {
+      return result;
+    }
+
+    logToolOutputMasking(
+      config,
+      new ToolOutputMaskingEvent({
+        tokens_before: totalPrunableTokens,
+        tokens_after: totalPrunableTokens - actualTokensSaved,
+        masked_count: maskedCount,
+        total_prunable_tokens: totalPrunableTokens,
+      }),
+    );
+
+    return result;
+  }
+
+  private getToolOutputContent(part: Part): string | null {
+    if (!part.functionResponse) return null;
+    const response = part.functionResponse.response as Record<string, unknown>;
+    if (!response) return null;
+
+    const content = JSON.stringify(response, null, 2);
+
+    return content;
+  }
+
+  private isAlreadyMasked(content: string): boolean {
+    return content.includes(`<${MASKING_INDICATOR_TAG}`);
+  }
+
+  private formatShellPreview(response: Record<string, unknown>): string {
+    const content = (response['output'] || response['stdout'] || '') as string;
+    if (typeof content !== 'string') {
+      return typeof content === 'object'
+        ? JSON.stringify(content)
+        : String(content);
+    }
+
+    const sectionRegex =
+      /^(Output|Error|Exit Code|Signal|Background PIDs|Process Group PGID): /m;
+    const parts = content.split(sectionRegex);
+
+    if (parts.length < 3) {
+      return this.formatSimplePreview(content);
+    }
+
+    const previewParts: string[] = [];
+    if (parts[0].trim()) {
+      previewParts.push(this.formatSimplePreview(parts[0].trim()));
+    }
+
+    for (let i = 1; i < parts.length; i += 2) {
+      const name = parts[i];
+      const sectionContent = parts[i + 1]?.trim() || '';
+
+      if (name === 'Output') {
+        previewParts.push(
+          `Output: ${this.formatSimplePreview(sectionContent)}`,
+        );
+      } else {
+        previewParts.push(`${name}: ${sectionContent}`);
+      }
+    }
+
+    let preview = previewParts.join('\n');
+
+    const exitCode = response['exitCode'] ?? response['exit_code'];
+    const error = response['error'];
+    if (
+      exitCode !== undefined &&
+      exitCode !== 0 &&
+      exitCode !== null &&
+      !content.includes(`Exit Code: ${exitCode}`)
+    ) {
+      preview += `\n[Exit Code: ${exitCode}]`;
+    }
+    if (error && !content.includes(`Error: ${error}`)) {
+      preview += `\n[Error: ${error}]`;
+    }
+
+    return preview;
+  }
+
+  private formatSimplePreview(content: string): string {
+    const lines = content.split('\n');
+    if (lines.length <= 20) return content;
+    const head = lines.slice(0, 10);
+    const tail = lines.slice(-10);
+    return `${head.join('\n')}\n\n... [${
+      lines.length - head.length - tail.length
+    } lines omitted] ...\n\n${tail.join('\n')}`;
+  }
+
+  private formatMaskedSnippet(filePath: string, preview: string): string {
+    return `<${MASKING_INDICATOR_TAG}>
+${preview}
+
+Output too large. Full output available at: ${filePath}
+</${MASKING_INDICATOR_TAG}>`;
+  }
+}

--- a/packages/core/src/telemetry/constants.ts
+++ b/packages/core/src/telemetry/constants.ts
@@ -25,6 +25,7 @@ export const EVENT_NEXT_SPEAKER_CHECK = 'qwen-code.next_speaker_check';
 export const EVENT_SLASH_COMMAND = 'qwen-code.slash_command';
 export const EVENT_IDE_CONNECTION = 'qwen-code.ide_connection';
 export const EVENT_CHAT_COMPRESSION = 'qwen-code.chat_compression';
+export const EVENT_TOOL_OUTPUT_MASKING = 'qwen-code.tool_output_masking';
 export const EVENT_INVALID_CHUNK = 'qwen-code.chat.invalid_chunk';
 export const EVENT_CONTENT_RETRY = 'qwen-code.chat.content_retry';
 export const EVENT_CONTENT_RETRY_FAILURE =

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -38,6 +38,7 @@ export {
   logConversationFinishedEvent,
   logKittySequenceOverflow,
   logChatCompression,
+  logToolOutputMasking,
   logToolOutputTruncated,
   logExtensionEnable,
   logExtensionInstallEvent,

--- a/packages/core/src/telemetry/loggers.ts
+++ b/packages/core/src/telemetry/loggers.ts
@@ -27,6 +27,7 @@ import {
   EVENT_SLASH_COMMAND,
   EVENT_CONVERSATION_FINISHED,
   EVENT_CHAT_COMPRESSION,
+  EVENT_TOOL_OUTPUT_MASKING,
   EVENT_CONTENT_RETRY,
   EVENT_CONTENT_RETRY_FAILURE,
   EVENT_FILE_OPERATION,
@@ -86,6 +87,7 @@ import type {
   ContentRetryFailureEvent,
   RipgrepFallbackEvent,
   ToolOutputTruncatedEvent,
+  ToolOutputMaskingEvent,
   ExtensionDisableEvent,
   ExtensionEnableEvent,
   ExtensionUninstallEvent,
@@ -626,6 +628,30 @@ export function logChatCompression(
     tokens_before: event.tokens_before,
     tokens_after: event.tokens_after,
   });
+}
+
+export function logToolOutputMasking(
+  config: Config,
+  event: ToolOutputMaskingEvent,
+): void {
+  QwenLogger.getInstance(config)?.logToolOutputMaskingEvent(event);
+
+  const attributes: LogAttributes = {
+    ...getCommonAttributes(config),
+    'event.name': EVENT_TOOL_OUTPUT_MASKING,
+    'event.timestamp': event['event.timestamp'],
+    tokens_before: event.tokens_before,
+    tokens_after: event.tokens_after,
+    masked_count: event.masked_count,
+    total_prunable_tokens: event.total_prunable_tokens,
+  };
+
+  const logger = logs.getLogger(SERVICE_NAME);
+  const logRecord: LogRecord = {
+    body: `Tool output masking: ${event.masked_count} outputs, saved ~${event.tokens_before - event.tokens_after} tokens`,
+    attributes,
+  };
+  logger.emit(logRecord);
 }
 
 export function logKittySequenceOverflow(

--- a/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
+++ b/packages/core/src/telemetry/qwen-logger/qwen-logger.ts
@@ -36,6 +36,7 @@ import type {
   ExtensionInstallEvent,
   ExtensionUninstallEvent,
   ToolOutputTruncatedEvent,
+  ToolOutputMaskingEvent,
   ExtensionEnableEvent,
   ModelSlashCommandEvent,
   ExtensionDisableEvent,
@@ -920,6 +921,20 @@ export class QwenLogger {
       properties: {
         tokens_before: event.tokens_before,
         tokens_after: event.tokens_after,
+      },
+    });
+
+    this.enqueueLogEvent(rumEvent);
+    this.flushIfNeeded();
+  }
+
+  logToolOutputMaskingEvent(event: ToolOutputMaskingEvent): void {
+    const rumEvent = this.createActionEvent('misc', 'tool_output_masking', {
+      properties: {
+        tokens_before: event.tokens_before,
+        tokens_after: event.tokens_after,
+        masked_count: event.masked_count,
+        total_prunable_tokens: event.total_prunable_tokens,
       },
     });
 

--- a/packages/core/src/telemetry/types.ts
+++ b/packages/core/src/telemetry/types.ts
@@ -682,6 +682,29 @@ export class ToolOutputTruncatedEvent implements BaseTelemetryEvent {
   }
 }
 
+export class ToolOutputMaskingEvent implements BaseTelemetryEvent {
+  readonly eventName = 'tool_output_masking';
+  readonly 'event.timestamp' = new Date().toISOString();
+  'event.name': string;
+  tokens_before: number;
+  tokens_after: number;
+  masked_count: number;
+  total_prunable_tokens: number;
+
+  constructor(details: {
+    tokens_before: number;
+    tokens_after: number;
+    masked_count: number;
+    total_prunable_tokens: number;
+  }) {
+    this['event.name'] = this.eventName;
+    this.tokens_before = details.tokens_before;
+    this.tokens_after = details.tokens_after;
+    this.masked_count = details.masked_count;
+    this.total_prunable_tokens = details.total_prunable_tokens;
+  }
+}
+
 export class ExtensionUninstallEvent implements BaseTelemetryEvent {
   'event.name': 'extension_uninstall';
   'event.timestamp': string;
@@ -875,6 +898,7 @@ export type TelemetryEvent =
   | ExtensionInstallEvent
   | ExtensionUninstallEvent
   | ToolOutputTruncatedEvent
+  | ToolOutputMaskingEvent
   | ModelSlashCommandEvent
   | AuthEvent
   | SkillLaunchEvent

--- a/packages/core/src/utils/tokenCalculation.test.ts
+++ b/packages/core/src/utils/tokenCalculation.test.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { estimateTokenCountSync } from './tokenCalculation.js';
+import type { Part } from '@google/genai';
+
+describe('estimateTokenCountSync', () => {
+  it('should estimate tokens for plain text', () => {
+    const parts: Part[] = [{ text: 'hello world' }];
+    const tokens = estimateTokenCountSync(parts);
+    expect(tokens).toBeGreaterThan(0);
+    expect(tokens).toBeLessThan(20);
+  });
+
+  it('should estimate higher tokens for non-ASCII text', () => {
+    const ascii: Part[] = [{ text: 'a'.repeat(100) }];
+    const nonAscii: Part[] = [{ text: '日'.repeat(100) }];
+    const asciiTokens = estimateTokenCountSync(ascii);
+    const nonAsciiTokens = estimateTokenCountSync(nonAscii);
+    expect(nonAsciiTokens).toBeGreaterThan(asciiTokens);
+  });
+
+  it('should estimate tokens for function response with string output', () => {
+    const parts: Part[] = [
+      {
+        functionResponse: {
+          name: 'read_file',
+          response: { output: 'file contents here' },
+        },
+      },
+    ];
+    const tokens = estimateTokenCountSync(parts);
+    expect(tokens).toBeGreaterThan(0);
+  });
+
+  it('should handle empty parts array', () => {
+    expect(estimateTokenCountSync([])).toBe(0);
+  });
+
+  it('should use fast path for very long strings', () => {
+    const longText = 'x'.repeat(200_000);
+    const parts: Part[] = [{ text: longText }];
+    const tokens = estimateTokenCountSync(parts);
+    expect(tokens).toBeGreaterThan(40_000);
+    expect(tokens).toBeLessThan(60_000);
+  });
+
+  it('should estimate image tokens', () => {
+    const parts: Part[] = [
+      { inlineData: { mimeType: 'image/png', data: 'base64data' } },
+    ];
+    const tokens = estimateTokenCountSync(parts);
+    expect(tokens).toBe(3000);
+  });
+
+  it('should respect max recursion depth', () => {
+    const parts: Part[] = [{ text: 'test' }];
+    const tokens = estimateTokenCountSync(parts, 10);
+    expect(tokens).toBe(0);
+  });
+
+  it('should handle multiple parts', () => {
+    const parts: Part[] = [
+      { text: 'hello' },
+      { text: 'world' },
+      {
+        functionResponse: {
+          name: 'tool',
+          response: { output: 'result' },
+        },
+      },
+    ];
+    const tokens = estimateTokenCountSync(parts);
+    expect(tokens).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/src/utils/tokenCalculation.ts
+++ b/packages/core/src/utils/tokenCalculation.ts
@@ -1,0 +1,126 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { PartListUnion, Part } from '@google/genai';
+import type { ContentGenerator } from '../core/contentGenerator.js';
+import { createDebugLogger } from './debugLogger.js';
+
+const debugLogger = createDebugLogger('TOKEN_CALC');
+
+const ASCII_TOKENS_PER_CHAR = 0.25;
+const NON_ASCII_TOKENS_PER_CHAR = 1.3;
+const IMAGE_TOKEN_ESTIMATE = 3000;
+const PDF_TOKEN_ESTIMATE = 25800;
+const MAX_CHARS_FOR_FULL_HEURISTIC = 100_000;
+const MAX_RECURSION_DEPTH = 3;
+
+function estimateTextTokens(text: string): number {
+  if (text.length > MAX_CHARS_FOR_FULL_HEURISTIC) {
+    return text.length / 4;
+  }
+
+  let tokens = 0;
+  for (let i = 0; i < text.length; i++) {
+    if (text.charCodeAt(i) <= 127) {
+      tokens += ASCII_TOKENS_PER_CHAR;
+    } else {
+      tokens += NON_ASCII_TOKENS_PER_CHAR;
+    }
+  }
+  return tokens;
+}
+
+function estimateMediaTokens(part: Part): number | undefined {
+  const inlineData = 'inlineData' in part ? part.inlineData : undefined;
+  const fileData = 'fileData' in part ? part.fileData : undefined;
+  const mimeType = inlineData?.mimeType || fileData?.mimeType;
+
+  if (mimeType?.startsWith('image/')) {
+    return IMAGE_TOKEN_ESTIMATE;
+  } else if (mimeType?.startsWith('application/pdf')) {
+    return PDF_TOKEN_ESTIMATE;
+  }
+  return undefined;
+}
+
+function estimateFunctionResponseTokens(part: Part, depth: number): number {
+  const fr = part.functionResponse;
+  if (!fr) return 0;
+
+  let totalTokens = (fr.name?.length ?? 0) / 4;
+  const response = fr.response as unknown;
+
+  if (typeof response === 'string') {
+    totalTokens += response.length / 4;
+  } else if (response !== undefined && response !== null) {
+    totalTokens += JSON.stringify(response).length / 4;
+  }
+
+  const nestedParts = (fr as unknown as { parts?: Part[] }).parts;
+  if (nestedParts && nestedParts.length > 0) {
+    totalTokens += estimateTokenCountSync(nestedParts, depth + 1);
+  }
+
+  return totalTokens;
+}
+
+export function estimateTokenCountSync(
+  parts: Part[],
+  depth: number = 0,
+): number {
+  if (depth > MAX_RECURSION_DEPTH) {
+    return 0;
+  }
+
+  let totalTokens = 0;
+  for (const part of parts) {
+    if (typeof part.text === 'string') {
+      totalTokens += estimateTextTokens(part.text);
+    } else if (part.functionResponse) {
+      totalTokens += estimateFunctionResponseTokens(part, depth);
+    } else {
+      const mediaEstimate = estimateMediaTokens(part);
+      if (mediaEstimate !== undefined) {
+        totalTokens += mediaEstimate;
+      } else {
+        totalTokens += JSON.stringify(part).length / 4;
+      }
+    }
+  }
+  return Math.floor(totalTokens);
+}
+
+export async function calculateRequestTokenCount(
+  request: PartListUnion,
+  contentGenerator: ContentGenerator,
+  model: string,
+): Promise<number> {
+  const parts: Part[] = Array.isArray(request)
+    ? request.map((p) => (typeof p === 'string' ? { text: p } : p))
+    : typeof request === 'string'
+      ? [{ text: request }]
+      : [request];
+
+  const hasMedia = parts.some((p) => {
+    const isMedia = 'inlineData' in p || 'fileData' in p;
+    return isMedia;
+  });
+
+  if (hasMedia) {
+    try {
+      const response = await contentGenerator.countTokens({
+        model,
+        contents: [{ role: 'user', parts }],
+      });
+      return response.totalTokens ?? 0;
+    } catch (error) {
+      debugLogger.debug('countTokens API failed:', error);
+      return estimateTokenCountSync(parts);
+    }
+  }
+
+  return estimateTokenCountSync(parts);
+}

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -867,7 +867,34 @@
     "experimental": {
       "description": "Setting to enable experimental features",
       "type": "object",
-      "properties": {}
+      "properties": {
+        "toolOutputMasking": {
+          "description": "Mask older bulky tool outputs to save context (full output kept on disk).",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "Enables tool output masking to save tokens.",
+              "type": "boolean",
+              "default": true
+            },
+            "toolProtectionThreshold": {
+              "description": "Token budget of the newest tool outputs to keep unmasked.",
+              "type": "number",
+              "default": 50000
+            },
+            "minPrunableTokensThreshold": {
+              "description": "Minimum prunable tokens required before a masking pass runs.",
+              "type": "number",
+              "default": 30000
+            },
+            "protectLatestTurn": {
+              "description": "When true, the most recent conversation turn is never masked.",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        }
+      }
     },
     "$version": {
       "type": "number",


### PR DESCRIPTION
## What

`ToolOutputMaskingService` — a pre-turn pass that replaces older bulky tool outputs with preview snippets while preserving full output on disk. Includes synchronous token estimation and telemetry.

## Why

In long agentic sessions, old tool outputs are the largest consumers of context budget. The model doesn't need the full content of a file read from 20 turns ago — but it still occupies thousands of tokens. Chat compression helps but requires an LLM call. Tool output masking is **zero-cost context reclamation** that runs synchronously before each turn.

The approach: protect the newest tool outputs (configurable budget), mask everything older with a preview snippet, save full output to disk (recoverable). Exempt tools that carry semantic state (skill, memory, ask_user_question) are never masked.

## Architecture

```
Before each turn:
  1. Scan history newest → oldest
  2. Accumulate tool output tokens until protection threshold exceeded
  3. Everything past the threshold → candidate for masking
  4. If total prunable tokens > minimum threshold → run masking pass
  5. For each candidate: write full output to disk, replace with preview
  6. Log telemetry (tokens saved, count masked)
```

### Supporting components

- `tokenCalculation.ts` — Synchronous token estimation with ASCII/non-ASCII heuristic, media estimates, function response handling. Fast enough to run every turn.
- `ToolOutputMaskingEvent` — Telemetry event for monitoring savings across sessions.
- Shell output preview formatter — Extracts structured sections (Output, Error, Exit Code) from shell results for meaningful previews.

## Configuration

Under `experimental.toolOutputMasking`:

| Setting | Default | Description |
|---------|---------|-------------|
| `enabled` | `true` | Master switch |
| `toolProtectionThreshold` | `50000` | Token budget for newest unmasked outputs |
| `minPrunableTokensThreshold` | `30000` | Minimum prunable before masking runs |
| `protectLatestTurn` | `true` | Shield most recent turn |

## Test Plan

24 tests across 2 files:

**tokenCalculation.test.ts** (8 tests):
- Plain text, non-ASCII, function response, empty array, long strings, image tokens, recursion depth, multiple parts

**toolOutputMaskingService.test.ts** (8 tests):
- Disabled config, empty history, below-threshold no-op, above-threshold masking, latest-turn protection, exempt tools (skill/memory), already-masked skip, masking indicator tag presence

Plus existing `client.test.ts` and `mcp-client.test.ts` mock updates for config compatibility.

## Demo

N/A — internal context management. Observable via telemetry events showing token savings and reduced compression frequency in long sessions.

Fixes #2567