### PR TITLE
feat(tools): add omission placeholder detector for edit and write

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -84,6 +84,7 @@ export * from './tools/mcp-client.js';
 export * from './tools/mcp-client-manager.js';
 export * from './tools/mcp-tool.js';
 export * from './tools/memoryTool.js';
+export * from './tools/omissionPlaceholderDetector.js';
 export * from './tools/read-file.js';
 export * from './tools/ripGrep.js';
 export * from './tools/sdk-control-client-transport.js';

--- a/packages/core/src/tools/edit.ts
+++ b/packages/core/src/tools/edit.ts
@@ -25,6 +25,7 @@ import { FileEncoding, needsUtf8Bom } from '../services/fileSystemService.js';
 import { DEFAULT_DIFF_OPTIONS, getDiffStat } from './diffOptions.js';
 import { ReadFileTool } from './read-file.js';
 import { ToolNames, ToolDisplayNames } from './tool-names.js';
+import { detectOmissionPlaceholders } from './omissionPlaceholderDetector.js';
 import { logFileOperation } from '../telemetry/loggers.js';
 import { FileOperationEvent } from '../telemetry/types.js';
 import { FileOperation } from '../telemetry/metrics.js';
@@ -576,6 +577,19 @@ Expectation for required parameters:
 
     if (!path.isAbsolute(params.file_path)) {
       return `File path must be absolute: ${params.file_path}`;
+    }
+
+    const newPlaceholders = detectOmissionPlaceholders(params.new_string);
+    if (newPlaceholders.length > 0) {
+      const oldPlaceholders = new Set(
+        detectOmissionPlaceholders(params.old_string),
+      );
+
+      for (const placeholder of newPlaceholders) {
+        if (!oldPlaceholders.has(placeholder)) {
+          return "`new_string` contains an omission placeholder (for example 'rest of methods ...'). Provide exact literal replacement text.";
+        }
+      }
     }
 
     return null;

--- a/packages/core/src/tools/omissionPlaceholderDetector.test.ts
+++ b/packages/core/src/tools/omissionPlaceholderDetector.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { detectOmissionPlaceholders } from './omissionPlaceholderDetector.js';
+
+describe('detectOmissionPlaceholders', () => {
+  it('detects standalone placeholder lines', () => {
+    expect(detectOmissionPlaceholders('(rest of methods ...)')).toEqual([
+      'rest of methods ...',
+    ]);
+    expect(detectOmissionPlaceholders('(rest of code ...)')).toEqual([
+      'rest of code ...',
+    ]);
+    expect(detectOmissionPlaceholders('(unchanged code ...)')).toEqual([
+      'unchanged code ...',
+    ]);
+    expect(detectOmissionPlaceholders('// rest of methods ...')).toEqual([
+      'rest of methods ...',
+    ]);
+  });
+
+  it('detects case-insensitive placeholders', () => {
+    expect(detectOmissionPlaceholders('(Rest Of Methods ...)')).toEqual([
+      'rest of methods ...',
+    ]);
+  });
+
+  it('detects multiple placeholder lines in one input', () => {
+    const text = `class Example {
+  run() {}
+  (rest of methods ...)
+  (unchanged code ...)
+}`;
+    expect(detectOmissionPlaceholders(text)).toEqual([
+      'rest of methods ...',
+      'unchanged code ...',
+    ]);
+  });
+
+  it('does not detect placeholders embedded in normal code', () => {
+    expect(
+      detectOmissionPlaceholders(
+        'const note = "(rest of methods ...)";\nconsole.log(note);',
+      ),
+    ).toEqual([]);
+  });
+
+  it('does not detect omission phrase when inline in a comment', () => {
+    expect(
+      detectOmissionPlaceholders('return value; // rest of methods ...'),
+    ).toEqual([]);
+  });
+
+  it('does not detect unrelated ellipsis text', () => {
+    expect(detectOmissionPlaceholders('const message = "loading...";')).toEqual(
+      [],
+    );
+  });
+});

--- a/packages/core/src/tools/omissionPlaceholderDetector.ts
+++ b/packages/core/src/tools/omissionPlaceholderDetector.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const OMITTED_PREFIXES = new Set([
+  'rest of',
+  'rest of method',
+  'rest of methods',
+  'rest of code',
+  'unchanged code',
+  'unchanged method',
+  'unchanged methods',
+]);
+
+function isAllDots(str: string): boolean {
+  if (str.length === 0) {
+    return false;
+  }
+  for (let i = 0; i < str.length; i++) {
+    if (str[i] !== '.') {
+      return false;
+    }
+  }
+  return true;
+}
+
+function normalizeWhitespace(input: string): string {
+  const segments: string[] = [];
+  let current = '';
+
+  for (const char of input) {
+    if (char === ' ' || char === '\t' || char === '\n' || char === '\r') {
+      if (current.length > 0) {
+        segments.push(current);
+        current = '';
+      }
+      continue;
+    }
+    current += char;
+  }
+
+  if (current.length > 0) {
+    segments.push(current);
+  }
+
+  return segments.join(' ');
+}
+
+function normalizePlaceholder(line: string): string | null {
+  let text = line.trim();
+  if (!text) {
+    return null;
+  }
+
+  if (text.startsWith('//')) {
+    text = text.slice(2).trim();
+  }
+
+  if (text.startsWith('(') && text.endsWith(')')) {
+    text = text.slice(1, -1).trim();
+  }
+
+  const ellipsisStart = text.indexOf('...');
+  if (ellipsisStart < 0) {
+    return null;
+  }
+
+  const prefixRaw = text.slice(0, ellipsisStart).trim().toLowerCase();
+  const suffixRaw = text.slice(ellipsisStart + 3).trim();
+  const prefix = normalizeWhitespace(prefixRaw);
+
+  if (!OMITTED_PREFIXES.has(prefix)) {
+    return null;
+  }
+
+  if (suffixRaw.length > 0 && !isAllDots(suffixRaw)) {
+    return null;
+  }
+
+  return `${prefix} ...`;
+}
+
+/**
+ * Detects shorthand omission placeholders such as:
+ * - (rest of methods ...)
+ * - (rest of code ...)
+ * - (unchanged code ...)
+ * - // rest of methods ...
+ *
+ * Returns all placeholders found as normalized tokens.
+ */
+export function detectOmissionPlaceholders(text: string): string[] {
+  const lines = text.replaceAll('\r\n', '\n').split('\n');
+  const matches: string[] = [];
+
+  for (const rawLine of lines) {
+    const normalized = normalizePlaceholder(rawLine);
+    if (normalized) {
+      matches.push(normalized);
+    }
+  }
+
+  return matches;
+}

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -30,6 +30,7 @@ import { makeRelative, shortenPath } from '../utils/paths.js';
 import { getErrorMessage, isNodeError } from '../utils/errors.js';
 import { DEFAULT_DIFF_OPTIONS, getDiffStat } from './diffOptions.js';
 import { ToolNames, ToolDisplayNames } from './tool-names.js';
+import { detectOmissionPlaceholders } from './omissionPlaceholderDetector.js';
 import type {
   ModifiableDeclarativeTool,
   ModifyContext,
@@ -412,6 +413,11 @@ export class WriteFileTool
       return `Error accessing path properties for validation: ${filePath}. Reason: ${
         statError instanceof Error ? statError.message : String(statError)
       }`;
+    }
+
+    const omissionPlaceholders = detectOmissionPlaceholders(params.content);
+    if (omissionPlaceholders.length > 0) {
+      return "`content` contains an omission placeholder (for example 'rest of methods ...'). Provide complete file content.";
     }
 
     return null;


### PR DESCRIPTION
## Summary
- Detects lazy model output like `(rest of methods ...)` in edit/write tool calls
- Prevents accidental code deletion by blocking at validation time
- Ported from Google Gemini CLI, adapted for Qwen Code tool validation

## Changes
| File | Change |
|------|--------|
| `packages/core/src/tools/omissionPlaceholderDetector.ts` | New detector |
| `packages/core/src/tools/omissionPlaceholderDetector.test.ts` | 6 unit tests |
| `packages/core/src/tools/edit.ts` | Validate new_string vs old_string |
| `packages/core/src/tools/write-file.ts` | Validate content |
| `packages/core/src/index.ts` | Export detector |

## Test plan
- `npx vitest run packages/core/src/tools/omissionPlaceholderDetector.test.ts` — 6/6 pass
- `npx vitest run packages/core/src/tools/edit.test.ts` — 54/54 pass (no regressions)
- `npx vitest run packages/core/src/tools/write-file.test.ts` — 33/33 pass (no regressions)

Fixes #2575

Made with [Cursor](https://cursor.com)