### PR TITLE
feat(core): resilient subagent tool rejection with contextual feedback

### DIFF
--- a/packages/core/src/agents/runtime/agent-core.ts
+++ b/packages/core/src/agents/runtime/agent-core.ts
@@ -557,7 +557,8 @@ export class AgentCore {
 
       if (!allowedToolNames.has(fc.name)) {
         const toolName = String(fc.name);
-        const errorMessage = `Tool "${toolName}" not found. Tools must use the exact names provided.`;
+        const availableToolsList = Array.from(allowedToolNames).join(', ');
+        const errorMessage = `Tool "${toolName}" is not available. You must acknowledge this, rethink your strategy, and use only the available tools: [${availableToolsList}]. Do NOT retry with the same tool name.`;
 
         // Emit TOOL_CALL event for visibility
         this.eventEmitter?.emit(AgentEventType.TOOL_CALL, {

--- a/packages/core/src/agents/runtime/agent-headless.test.ts
+++ b/packages/core/src/agents/runtime/agent-headless.test.ts
@@ -1184,7 +1184,7 @@ describe('subagent.ts', () => {
         const editResult = toolResultEvents.find((e) => e.name === 'edit_file');
         expect(editResult).toBeDefined();
         expect(editResult!.success).toBe(false);
-        expect(editResult!.error).toContain('not found');
+        expect(editResult!.error).toContain('not available');
         expect(editResult!.callId).toBe('call_edit');
 
         // 5. Verify allowed tool result has success=true


### PR DESCRIPTION
## Summary
- Enhances tool rejection in subagent execution with available tools list
- Model self-corrects instead of retrying unavailable tools
- Ported from Gemini CLI #22951

## Changes
| File | Change |
|------|--------|
| `packages/core/src/agents/runtime/agent-core.ts` | Enhanced rejection message in processFunctionCalls |

## Test plan
- `npx vitest run packages/core/src/agents/` — all agent tests pass
- Verification: rejected tool calls now include `[available_tools_list]` in error response

Fixes #2578

Made with [Cursor](https://cursor.com)