### PR TITLE
feat(core): add worktree detection and change tracking utilities

### DIFF
--- a/packages/core/src/services/gitWorktreeService.ts
+++ b/packages/core/src/services/gitWorktreeService.ts
@@ -5,6 +5,7 @@
  */
 
 import * as fs from 'node:fs/promises';
+import fsSync from 'node:fs';
 import * as path from 'node:path';
 import { execSync } from 'node:child_process';
 import { simpleGit, CheckRepoActions } from 'simple-git';
@@ -822,5 +823,69 @@ export class GitWorktreeService {
     } catch {
       return false;
     }
+  }
+}
+
+/**
+ * Detects if a directory path is inside a managed qwen-code worktree.
+ * Uses realpath resolution to handle symlinks correctly.
+ */
+export function isQwenWorktree(
+  dirPath: string,
+  _projectRoot?: string,
+): boolean {
+  try {
+    const realDir = fsSync.realpathSync(dirPath);
+    const worktreesBase = path.join(Storage.getGlobalTempDir(), WORKTREES_DIR);
+    const realWorktrees = fsSync.realpathSync(worktreesBase);
+    const relative = path.relative(realWorktrees, realDir);
+    return !relative.startsWith('..');
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolves the main repository root from inside a git worktree
+ * by inspecting `git rev-parse --git-common-dir`.
+ */
+export function getProjectRootForWorktree(cwd: string): string | null {
+  try {
+    const commonDir = execSync('git rev-parse --git-common-dir', {
+      cwd,
+      encoding: 'utf8',
+    }).trim();
+    if (commonDir === '.git') {
+      return cwd;
+    }
+    const resolved = path.resolve(cwd, commonDir);
+    return path.dirname(resolved);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Checks if a worktree has uncommitted changes or diverges from a base SHA.
+ */
+export function hasWorktreeChanges(dirPath: string, baseSha?: string): boolean {
+  try {
+    const status = execSync('git status --porcelain', {
+      cwd: dirPath,
+      encoding: 'utf8',
+    }).trim();
+    if (status.length > 0) return true;
+
+    if (baseSha) {
+      const headSha = execSync('git rev-parse HEAD', {
+        cwd: dirPath,
+        encoding: 'utf8',
+      }).trim();
+      return headSha !== baseSha;
+    }
+
+    return false;
+  } catch {
+    return false;
   }
 }


### PR DESCRIPTION
## Summary
- Adds 3 utility functions for worktree-aware operations
- Enables detection, root resolution, and change tracking
- Inspired by Gemini CLI worktree service

## Changes
| File | Change |
|------|--------|
| `packages/core/src/services/gitWorktreeService.ts` | Add isQwenWorktree, getProjectRootForWorktree, hasWorktreeChanges |

## Test plan
- `npx vitest run packages/core/src/services/` — all service tests pass
- Manual: verified `getProjectRootForWorktree` resolves correct root from worktree cwd

Fixes #2579

Made with [Cursor](https://cursor.com)