### PR TITLE
fix(tools): exit_plan_mode now exits correctly in YOLO mode

### DIFF
--- a/packages/core/src/tools/exitPlanMode.test.ts
+++ b/packages/core/src/tools/exitPlanMode.test.ts
@@ -240,4 +240,35 @@ describe('ExitPlanModeTool', () => {
       expect(tool.description).toContain('Help me implement yank mode for vim');
     });
   });
+
+  describe('YOLO mode', () => {
+    it('should exit plan mode without onConfirm being called when approval mode is YOLO', async () => {
+      // Simulate YOLO: scheduler sets approvalMode=YOLO but never calls onConfirm
+      approvalMode = ApprovalMode.YOLO;
+      const params: ExitPlanModeParams = { plan: 'YOLO test plan' };
+      const signal = new AbortController().signal;
+
+      const invocation = tool.build(params);
+      // Do NOT call onConfirm — this mirrors what the YOLO scheduler does
+      const result = await invocation.execute(signal);
+
+      expect(result.llmContent).toContain(
+        'User has approved your plan. You can now start coding',
+      );
+      expect(result.llmContent).not.toContain('not approved');
+    });
+
+    it('should not downgrade approval mode to AUTO_EDIT when YOLO', async () => {
+      approvalMode = ApprovalMode.YOLO;
+      const params: ExitPlanModeParams = { plan: 'YOLO test plan' };
+      const signal = new AbortController().signal;
+
+      const invocation = tool.build(params);
+      await invocation.execute(signal);
+
+      // Approval mode must remain YOLO — do not downgrade to AUTO_EDIT
+      expect(mockConfig.setApprovalMode).not.toHaveBeenCalled();
+      expect(approvalMode).toBe(ApprovalMode.YOLO);
+    });
+  });
 });

--- a/packages/core/src/tools/exitPlanMode.ts
+++ b/packages/core/src/tools/exitPlanMode.ts
@@ -133,7 +133,12 @@ class ExitPlanModeToolInvocation extends BaseToolInvocation<
     const { plan } = this.params;
 
     try {
-      if (!this.wasApproved) {
+      // In YOLO mode the scheduler auto-approves without calling onConfirm(),
+      // so wasApproved stays false. Treat YOLO as implicit approval.
+      const isYolo = this.config.getApprovalMode() === ApprovalMode.YOLO;
+      const effectivelyApproved = this.wasApproved || isYolo;
+
+      if (!effectivelyApproved) {
         const rejectionMessage =
           'Plan execution was not approved. Remaining in plan mode.';
         return {


### PR DESCRIPTION
## Summary

`exit_plan_mode` fails silently in YOLO mode — the tool is scheduled and
executed, but always returns "Plan execution was not approved. Remaining
in plan mode." instead of actually exiting plan mode.

**Root cause:** The YOLO fast-path in `coreToolScheduler` sets the
`ProceedAlways` outcome but skips `getConfirmationDetails()` and
`onConfirm()`. Because `wasApproved` is only set inside `onConfirm`, it
remains `false`. `execute()` sees `wasApproved=false` and returns the
rejection message unconditionally.

**Fix:** Added a YOLO fallback in `ExitPlanModeToolInvocation.execute()`.
If `config.getApprovalMode() === YOLO`, the tool treats the call as
approved. Approval mode is **not** downgraded to `AUTO_EDIT` — the
user's `--yolo` intent is preserved for the remainder of the session.
The non-interactive headless auto-deny path (`shouldAutoDeny`) is
intentionally unchanged.

**Scope:** 2 files touched — production fix is a 4-line change. No
breaking changes to any other approval path.

## Test plan

| Test | Command | Result |
|------|---------|--------|
| YOLO exits without `onConfirm` | `npx vitest run ...exitPlanMode.test.ts` | ✅ |
| YOLO does not downgrade to `AUTO_EDIT` | `npx vitest run ...exitPlanMode.test.ts` | ✅ |
| All existing `exit_plan_mode` tests | `npx vitest run ...exitPlanMode.test.ts` | ✅ 18/18 |
| Full core package | `npx vitest run packages/core` | ✅ 189 files, 4804 tests |
| Lint | `npm run lint` | ✅ |
| Typecheck | `npm run typecheck` | ✅ |
| Full suite | `npm run test` | ✅ |

## Testing matrix

| Platform | Method | Status |
|----------|--------|--------|
| 🐧 Linux (WSL2) | `npm run test` | ✅ Pass |

## Checklist

- [x] Fixes #2522
- [x] Single focused commit with clear attribution
- [x] 2 new unit tests covering the YOLO fix
- [x] No breaking changes — non-YOLO paths are unchanged
- [x] Non-interactive auto-deny path is intentionally preserved

---

🤖 Generated by Nuno Salvação <nuno.salvacao@gmail.com> & Co-Authored with Nexo <nexo.modeling@gmail.com>