### PR TITLE
fix(vscode-ide-companion): preserve model metadata on switch

### DIFF
--- a/packages/vscode-ide-companion/src/services/qwenAgentManager.test.ts
+++ b/packages/vscode-ide-companion/src/services/qwenAgentManager.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
-import { extractSessionListItems } from './qwenAgentManager.js';
+import {
+  extractSessionListItems,
+  QwenAgentManager,
+} from './qwenAgentManager.js';
+import type { ModelInfo } from '@agentclientprotocol/sdk';
 
 vi.mock('vscode', () => ({
   window: {
@@ -52,5 +56,50 @@ describe('extractSessionListItems', () => {
     expect(extractSessionListItems({ sessions: 'not-array' })).toEqual([]);
     expect(extractSessionListItems({ items: 123 })).toEqual([]);
     expect(extractSessionListItems({})).toEqual([]);
+  });
+});
+
+describe('QwenAgentManager.setModelFromUi', () => {
+  it('emits the selected model metadata from the available models list', async () => {
+    const manager = new QwenAgentManager();
+    const onModelChanged = vi.fn();
+    manager.onModelChanged(onModelChanged);
+
+    const selectedModel: ModelInfo = {
+      modelId: 'qwen3-coder-plus',
+      name: 'Qwen3 Coder Plus',
+      _meta: {
+        contextLimit: 262144,
+      },
+    };
+
+    (
+      manager as unknown as {
+        baselineAvailableModels: ModelInfo[];
+      }
+    ).baselineAvailableModels = [
+      {
+        modelId: 'qwen3-coder-base',
+        name: 'Qwen3 Coder Base',
+        _meta: {
+          contextLimit: 131072,
+        },
+      },
+      selectedModel,
+    ];
+
+    (
+      manager as unknown as {
+        connection: {
+          setModel: (modelId: string) => Promise<{ modelId: string }>;
+        };
+      }
+    ).connection = {
+      setModel: vi.fn().mockResolvedValue({ modelId: selectedModel.modelId }),
+    };
+
+    await manager.setModelFromUi(selectedModel.modelId);
+
+    expect(onModelChanged).toHaveBeenCalledWith(selectedModel);
   });
 });

--- a/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
+++ b/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
@@ -382,10 +382,13 @@ export class QwenAgentManager {
     try {
       await this.connection.setModel(modelId);
       const confirmedModelId = modelId;
-      const modelInfo: ModelInfo = {
+      const modelInfo = this.baselineAvailableModels.find(
+        (model) => model.modelId === confirmedModelId,
+      ) ?? {
         modelId: confirmedModelId,
         name: confirmedModelId,
       };
+      this.baselineModelInfo = modelInfo;
       this.callbacks.onModelChanged?.(modelInfo);
       return modelInfo;
     } catch (err) {


### PR DESCRIPTION
## TLDR

Fix the VSCode IDE Companion issue where the context-left indicator kept showing the previous model context window size after switching models within the same chat tab.

This change makes model switch events reuse the full cached model metadata instead of emitting a minimal model object, so _meta.contextLimit is preserved and the indicator updates immediately for the newly selected model.

## Screenshots / Video Demo

<img width="1086" height="894" alt="image" src="https://github.com/user-attachments/assets/72b13428-794b-41ff-b441-213dc3141412" />
<img width="1070" height="890" alt="image" src="https://github.com/user-attachments/assets/b8ccdf55-9579-4925-a15a-fd6674cd46a0" />

## Dive Deeper

The root cause was in `QwenAgentManager.setModelFromUi()`.

After a successful model switch, the extension proactively emitted `onModelChanged`, but it used a synthetic object containing only the selected model id and a fallback name. That object dropped `_meta.contextLimit`, which the webview uses to derive the context window limit for the indicator. As a result, switching models in place could leave the indicator showing a stale total context size until a new chat tab reinitialized the full model state.

This fix updates the switch path to:
- look up the selected model in `baselineAvailableModels`
- reuse the full `ModelInfo` when present
- refresh `baselineModelInfo`
- fall back to the minimal object only if no cached model metadata is available

A regression test was added to ensure `setModelFromUi()` emits the selected model with `_meta.contextLimit` intact.

## Reviewer Test Plan

1. Launch the VSCode IDE Companion.
2. Open an existing chat tab or start a new one.
3. Note the total context size shown by the bottom context-left indicator.
4. Switch to a model with a meaningfully different context window size.
5. Confirm the context-left indicator immediately updates to the new model total context size.
6. Repeat with multiple model switches to confirm the value stays correct.
7. Run regression tests:
   - `cd packages/vscode-ide-companion`
   - `npm test -- src/services/qwenSessionUpdateHandler.test.ts src/services/qwenAgentManager.test.ts`
8. Run type checking:
   - `cd packages/vscode-ide-companion`
   - `npm run check-types`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

Local verification completed:
- `npm test -- src/services/qwenSessionUpdateHandler.test.ts src/services/qwenAgentManager.test.ts`
- `npm run check-types`
- `npx eslint src/services/qwenAgentManager.ts src/services/qwenAgentManager.test.ts`

## Linked issues / bugs

Resolves #2515
