### PR TITLE
fix(web-fetch): add simplified system instruction to prevent AI greeting responses

### DIFF
--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -111,7 +111,11 @@ ${textContent}
 
       const result = await geminiClient.generateContent(
         [{ role: 'user', parts: [{ text: fallbackPrompt }] }],
-        {},
+        {
+          systemInstruction:
+            'Extract and summarize the requested information from the provided web content. ' +
+            'Be concise and accurate. Respond only with the requested information.',
+        },
         signal,
         this.config.getModel() || DEFAULT_QWEN_MODEL,
       );


### PR DESCRIPTION
## Summary

This PR fixes issue #2609 where the `web_fetch` tool returns AI model greetings instead of actual web content.

## Root Cause

When using models like GLM-5, the web_fetch tool was inheriting the main session's complex system instruction, causing the model to respond with greetings or unrelated content instead of processing the fetched web content.

## Solution

Add a dedicated, simplified system instruction for web content processing:

```
Extract and summarize the requested information from the provided web content. Be concise and accurate. Respond only with the requested information.
```

This ensures the model focuses on extracting information from the fetched content rather than using the main session's prompt.

## Testing

- Tested with GLM-5 model via Bailian Coding Plan API
- Verified web content is now properly fetched and processed
- No more AI greeting responses

## Related Issues

- Fixes #2609
- Related to #2542 (GLM-5 model integration issues)
- Related to #1128 (web fetch accessibility issues)