### PR TITLE
feat(vscode): support skills slash command

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -65,6 +65,7 @@ import { loadCliConfig } from '../config/config.js';
 import { Session } from './session/Session.js';
 import { formatAcpModelId } from '../utils/acpModelUtils.js';
 import { runWithAcpRuntimeOutputDir } from './runtimeOutputDirContext.js';
+import { getSlashCommandArgumentCompletions } from '../nonInteractiveCliCommands.js';
 
 const debugLogger = createDebugLogger('ACP_AGENT');
 
@@ -369,8 +370,35 @@ class QwenAgent implements Agent {
 
   async extMethod(
     method: string,
-    _params: Record<string, unknown>,
+    params: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    if (method === '_qwencode/slash_command_completion') {
+      const parsed = z
+        .object({
+          sessionId: z.string().min(1),
+          query: z.string(),
+        })
+        .parse(params);
+
+      const session = this.sessions.get(parsed.sessionId);
+      if (!session) {
+        throw RequestError.invalidParams(
+          undefined,
+          `Session not found: ${parsed.sessionId}`,
+        );
+      }
+
+      const abortController = new AbortController();
+      const items = await getSlashCommandArgumentCompletions(
+        parsed.query,
+        session.getConfig(),
+        this.settings,
+        abortController.signal,
+      );
+
+      return { items };
+    }
+
     throw RequestError.methodNotFound(method);
   }
 

--- a/packages/cli/src/nonInteractiveCliCommands.test.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.test.ts
@@ -5,7 +5,10 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { handleSlashCommand } from './nonInteractiveCliCommands.js';
+import {
+  getSlashCommandArgumentCompletions,
+  handleSlashCommand,
+} from './nonInteractiveCliCommands.js';
 import type { Config } from '@qwen-code/qwen-code-core';
 import type { LoadedSettings } from './config/settings.js';
 import { CommandKind } from './ui/commands/types.js';
@@ -176,6 +179,34 @@ describe('handleSlashCommand', () => {
     }
   });
 
+  it('should execute /skills when using the default allowed list', async () => {
+    const mockSkillsCommand = {
+      name: 'skills',
+      description: 'List available skills',
+      kind: CommandKind.BUILT_IN,
+      action: vi.fn().mockResolvedValue({
+        type: 'message',
+        messageType: 'info',
+        content: 'Available skills:\n- review',
+      }),
+    };
+    mockGetCommands.mockReturnValue([mockSkillsCommand]);
+
+    const result = await handleSlashCommand(
+      '/skills',
+      abortController,
+      mockConfig,
+      mockSettings,
+    );
+
+    expect(mockSkillsCommand.action).toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Available skills:\n- review',
+    });
+  });
+
   it('should execute file commands regardless of allowed list', async () => {
     const mockFileCommand = {
       name: 'custom',
@@ -265,5 +296,121 @@ describe('handleSlashCommand', () => {
       expect(result.content).toBe('Command executed successfully.');
       expect(result.messageType).toBe('info');
     }
+  });
+});
+
+describe('getSlashCommandArgumentCompletions', () => {
+  let mockConfig: Config;
+  let mockSettings: LoadedSettings;
+  let abortController: AbortController;
+
+  beforeEach(() => {
+    mockCommandServiceCreate.mockResolvedValue({
+      getCommands: mockGetCommands,
+    });
+
+    mockConfig = {
+      getExperimentalZedIntegration: vi.fn().mockReturnValue(true),
+      isInteractive: vi.fn().mockReturnValue(false),
+      getSessionId: vi.fn().mockReturnValue('test-session'),
+      getFolderTrustFeature: vi.fn().mockReturnValue(false),
+      getFolderTrust: vi.fn().mockReturnValue(false),
+      getProjectRoot: vi.fn().mockReturnValue('/test/project'),
+      storage: {},
+    } as unknown as Config;
+
+    mockSettings = {
+      system: { path: '', settings: {} },
+      systemDefaults: { path: '', settings: {} },
+      user: { path: '', settings: {} },
+      workspace: { path: '', settings: {} },
+    } as LoadedSettings;
+
+    abortController = new AbortController();
+  });
+
+  it('returns completion items for exact command matches', async () => {
+    const completion = vi
+      .fn()
+      .mockResolvedValue([{ value: 'review', description: 'Review code' }]);
+    mockGetCommands.mockReturnValue([
+      {
+        name: 'skills',
+        description: 'List available skills',
+        kind: CommandKind.BUILT_IN,
+        completion,
+      },
+    ]);
+
+    const result = await getSlashCommandArgumentCompletions(
+      '/skills',
+      mockConfig,
+      mockSettings,
+      abortController.signal,
+    );
+
+    expect(completion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invocation: {
+          raw: '/skills',
+          name: 'skills',
+          args: '',
+        },
+      }),
+      '',
+    );
+    expect(result).toEqual([{ value: 'review', description: 'Review code' }]);
+  });
+
+  it('passes partial args to command completion', async () => {
+    const completion = vi
+      .fn()
+      .mockResolvedValue([{ value: 'review', description: 'Review code' }]);
+    mockGetCommands.mockReturnValue([
+      {
+        name: 'skills',
+        description: 'List available skills',
+        kind: CommandKind.BUILT_IN,
+        completion,
+      },
+    ]);
+
+    await getSlashCommandArgumentCompletions(
+      '/skills re',
+      mockConfig,
+      mockSettings,
+      abortController.signal,
+    );
+
+    expect(completion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        invocation: {
+          raw: '/skills re',
+          name: 'skills',
+          args: 're',
+        },
+      }),
+      're',
+    );
+  });
+
+  it('returns empty list when command has no argument completion context', async () => {
+    mockGetCommands.mockReturnValue([
+      {
+        name: 'skills',
+        description: 'List available skills',
+        kind: CommandKind.BUILT_IN,
+        completion: vi.fn(),
+      },
+    ]);
+
+    const result = await getSlashCommandArgumentCompletions(
+      '/ski',
+      mockConfig,
+      mockSettings,
+      abortController.signal,
+    );
+
+    expect(result).toEqual([]);
   });
 });

--- a/packages/cli/src/nonInteractiveCliCommands.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.ts
@@ -18,6 +18,7 @@ import { BundledSkillLoader } from './services/BundledSkillLoader.js';
 import { FileCommandLoader } from './services/FileCommandLoader.js';
 import {
   CommandKind,
+  type CommandCompletionItem,
   type CommandContext,
   type SlashCommand,
   type SlashCommandActionReturn,
@@ -37,11 +38,13 @@ const debugLogger = createDebugLogger('NON_INTERACTIVE_COMMANDS');
  * - init: Initialize project configuration
  * - summary: Generate session summary
  * - compress: Compress conversation history
+ * - skills: List available skills or invoke a specific skill
  */
 export const ALLOWED_BUILTIN_COMMANDS_NON_INTERACTIVE = [
   'init',
   'summary',
   'compress',
+  'skills',
   'btw',
   'bug',
 ] as const;
@@ -82,6 +85,115 @@ export type NonInteractiveSlashCommandResult =
   | {
       type: 'no_command';
     };
+
+function createCommandContext(
+  raw: string,
+  name: string,
+  args: string,
+  executionMode: 'interactive' | 'non_interactive' | 'acp',
+  config: Config,
+  settings: LoadedSettings,
+): CommandContext {
+  const sessionStats: SessionStatsState = {
+    sessionId: config?.getSessionId(),
+    sessionStartTime: new Date(),
+    metrics: uiTelemetryService.getMetrics(),
+    lastPromptTokenCount: 0,
+    promptCount: 1,
+  };
+
+  const logger = new Logger(config?.getSessionId() || '', config?.storage);
+
+  return {
+    executionMode,
+    services: {
+      config,
+      settings,
+      git: undefined,
+      logger,
+    },
+    ui: createNonInteractiveUI(),
+    session: {
+      stats: sessionStats,
+      sessionShellAllowlist: new Set(),
+    },
+    invocation: {
+      raw,
+      name,
+      args,
+    },
+  };
+}
+
+function getExecutionMode(
+  config: Config,
+): 'interactive' | 'non_interactive' | 'acp' {
+  const isAcpMode = config.getExperimentalZedIntegration();
+  const isInteractive = config.isInteractive();
+
+  return isAcpMode ? 'acp' : isInteractive ? 'interactive' : 'non_interactive';
+}
+
+export const getSlashCommandArgumentCompletions = async (
+  rawQuery: string,
+  config: Config,
+  settings: LoadedSettings,
+  abortSignal: AbortSignal,
+  allowedBuiltinCommandNames: string[] = [
+    ...ALLOWED_BUILTIN_COMMANDS_NON_INTERACTIVE,
+  ],
+): Promise<CommandCompletionItem[]> => {
+  const trimmed = rawQuery.trim();
+  if (!trimmed.startsWith('/')) {
+    return [];
+  }
+
+  const allowedBuiltinSet = new Set(allowedBuiltinCommandNames ?? []);
+  const commands = await getAvailableCommands(
+    config,
+    abortSignal,
+    allowedBuiltinCommandNames,
+  );
+  const { commandToExecute, args, canonicalPath } = parseSlashCommand(
+    rawQuery,
+    filterCommandsForNonInteractive(commands, allowedBuiltinSet),
+  );
+
+  if (!commandToExecute?.completion) {
+    return [];
+  }
+
+  const canonicalCommand = `/${canonicalPath.join(' ')}`;
+  if (!canonicalCommand || canonicalCommand === '/') {
+    return [];
+  }
+
+  const normalizedQuery = trimmed.toLowerCase();
+  const normalizedCanonical = canonicalCommand.toLowerCase();
+  const isExactCommand = normalizedQuery === normalizedCanonical;
+  const isArgumentContext = normalizedQuery.startsWith(
+    `${normalizedCanonical} `,
+  );
+
+  if (!isExactCommand && !isArgumentContext) {
+    return [];
+  }
+
+  const argString = isExactCommand ? '' : args;
+  const context = createCommandContext(
+    isExactCommand ? canonicalCommand : trimmed,
+    commandToExecute.name,
+    argString,
+    getExecutionMode(config),
+    config,
+    settings,
+  );
+
+  const completions = await commandToExecute.completion(context, argString);
+  return (completions || []).map((item) =>
+    typeof item === 'string' ? { value: item } : item,
+  );
+};
 
 /**
  * Converts a SlashCommandActionReturn to a NonInteractiveSlashCommandResult.
@@ -221,7 +333,8 @@ function filterCommandsForNonInteractive(
  * @param config The configuration object
  * @param settings The loaded settings
  * @param allowedBuiltinCommandNames Optional array of built-in command names that are
- *   allowed. Defaults to ALLOWED_BUILTIN_COMMANDS_NON_INTERACTIVE (init, summary, compress).
+ *   allowed. Defaults to ALLOWED_BUILTIN_COMMANDS_NON_INTERACTIVE (init, summary,
+ *   compress, skills, btw, bug).
  *   Pass an empty array to only allow file commands.
  * @returns A Promise that resolves to a `NonInteractiveSlashCommandResult` describing
  *   the outcome of the command execution.
@@ -239,15 +352,7 @@ export const handleSlashCommand = async (
   if (!trimmed.startsWith('/')) {
     return { type: 'no_command' };
   }
-
-  const isAcpMode = config.getExperimentalZedIntegration();
-  const isInteractive = config.isInteractive();
-
-  const executionMode = isAcpMode
-    ? 'acp'
-    : isInteractive
-      ? 'interactive'
-      : 'non_interactive';
+  const executionMode = getExecutionMode(config);
 
   const allowedBuiltinSet = new Set(allowedBuiltinCommandNames ?? []);
 
@@ -300,36 +405,14 @@ export const handleSlashCommand = async (
     return { type: 'no_command' };
   }
 
-  // Not used by custom commands but may be in the future.
-  const sessionStats: SessionStatsState = {
-    sessionId: config?.getSessionId(),
-    sessionStartTime: new Date(),
-    metrics: uiTelemetryService.getMetrics(),
-    lastPromptTokenCount: 0,
-    promptCount: 1,
-  };
-
-  const logger = new Logger(config?.getSessionId() || '', config?.storage);
-
-  const context: CommandContext = {
+  const context = createCommandContext(
+    trimmed,
+    commandToExecute.name,
+    args,
     executionMode,
-    services: {
-      config,
-      settings,
-      git: undefined,
-      logger,
-    },
-    ui: createNonInteractiveUI(),
-    session: {
-      stats: sessionStats,
-      sessionShellAllowlist: new Set(),
-    },
-    invocation: {
-      raw: trimmed,
-      name: commandToExecute.name,
-      args,
-    },
-  };
+    config,
+    settings,
+  );
 
   const result = await commandToExecute.action(context, args);
 
@@ -352,7 +435,8 @@ export const handleSlashCommand = async (
  * @param config The configuration object
  * @param abortSignal Signal to cancel the loading process
  * @param allowedBuiltinCommandNames Optional array of built-in command names that are
- *   allowed. Defaults to ALLOWED_BUILTIN_COMMANDS_NON_INTERACTIVE (init, summary, compress).
+ *   allowed. Defaults to ALLOWED_BUILTIN_COMMANDS_NON_INTERACTIVE (init, summary,
+ *   compress, skills, btw, bug).
  *   Pass an empty array to only include file commands.
  * @returns A Promise that resolves to an array of SlashCommand objects
  */

--- a/packages/cli/src/ui/commands/skillsCommand.test.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.test.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { skillsCommand } from './skillsCommand.js';
+import type { CommandContext } from './types.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { MessageType } from '../types.js';
+import type { SkillConfig } from '@qwen-code/qwen-code-core';
+
+vi.mock('../../i18n/index.js', () => ({
+  t: (key: string, params?: Record<string, string>) => {
+    if (params) {
+      return Object.entries(params).reduce(
+        (str, [paramKey, value]) => str.replace(`{{${paramKey}}}`, value),
+        key,
+      );
+    }
+    return key;
+  },
+}));
+
+describe('skillsCommand', () => {
+  let mockContext: CommandContext;
+  let listSkills: ReturnType<typeof vi.fn>;
+  const reviewSkill: SkillConfig = {
+    name: 'review',
+    description: 'Review code changes',
+    level: 'project',
+    filePath: '/test/project/.qwen/skills/review/SKILL.md',
+    body: '# review',
+  };
+  const testSkill: SkillConfig = {
+    name: 'test',
+    description: 'Generate tests',
+    level: 'user',
+    filePath: '/test/home/.qwen/skills/test/SKILL.md',
+    body: '# test',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    listSkills = vi.fn().mockResolvedValue([testSkill, reviewSkill]);
+
+    mockContext = createMockCommandContext({
+      services: {
+        config: {
+          getSkillManager: vi.fn().mockReturnValue({
+            listSkills,
+          }),
+        },
+      },
+    });
+  });
+
+  it('returns a text list in ACP mode', async () => {
+    mockContext.executionMode = 'acp';
+
+    const result = await skillsCommand.action!(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Available skills:\n- review\n- test',
+    });
+    expect(mockContext.ui.addItem).not.toHaveBeenCalled();
+  });
+
+  it('returns an error message in ACP mode when skill name is unknown', async () => {
+    mockContext.executionMode = 'acp';
+
+    const result = await skillsCommand.action!(mockContext, 'unknown');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Unknown skill: unknown',
+    });
+    expect(mockContext.ui.addItem).not.toHaveBeenCalled();
+  });
+
+  it('returns submit_prompt in ACP mode when skill name exists', async () => {
+    mockContext.executionMode = 'acp';
+    mockContext.invocation = {
+      raw: '/skills review',
+      name: 'skills',
+      args: 'review',
+    };
+
+    const result = await skillsCommand.action!(mockContext, 'review');
+
+    expect(result).toEqual({
+      type: 'submit_prompt',
+      content: [{ text: '/skills review' }],
+    });
+  });
+
+  it('adds a skills list item in interactive mode', async () => {
+    mockContext.executionMode = 'interactive';
+
+    const result = await skillsCommand.action!(mockContext, '');
+
+    expect(result).toBeUndefined();
+    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+      {
+        type: MessageType.SKILLS_LIST,
+        skills: [{ name: 'review' }, { name: 'test' }],
+      },
+      expect.any(Number),
+    );
+  });
+});

--- a/packages/cli/src/ui/commands/skillsCommand.ts
+++ b/packages/cli/src/ui/commands/skillsCommand.ts
@@ -25,11 +25,21 @@ export const skillsCommand: SlashCommand = {
   },
   kind: CommandKind.BUILT_IN,
   action: async (context: CommandContext, args?: string) => {
+    const executionMode = context.executionMode ?? 'interactive';
+    const isNonInteractive = executionMode !== 'interactive';
     const rawArgs = args?.trim() ?? '';
     const [skillName = ''] = rawArgs.split(/\s+/);
 
     const skillManager = context.services.config?.getSkillManager();
     if (!skillManager) {
+      if (isNonInteractive) {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: t('Could not retrieve skill manager.'),
+        };
+      }
+
       context.ui.addItem(
         {
           type: MessageType.ERROR,
@@ -42,6 +52,14 @@ export const skillsCommand: SlashCommand = {
 
     const skills = await skillManager.listSkills();
     if (skills.length === 0) {
+      if (isNonInteractive) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: t('No skills are currently available.'),
+        };
+      }
+
       context.ui.addItem(
         {
           type: MessageType.INFO,
@@ -52,10 +70,19 @@ export const skillsCommand: SlashCommand = {
       return;
     }
 
+    const sortedSkills = [...skills].sort((left, right) =>
+      left.name.localeCompare(right.name),
+    );
+
     if (!skillName) {
-      const sortedSkills = [...skills].sort((left, right) =>
-        left.name.localeCompare(right.name),
-      );
+      if (isNonInteractive) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: formatSkillsList(sortedSkills),
+        };
+      }
+
       const skillsListItem: HistoryItemSkillsList = {
         type: MessageType.SKILLS_LIST,
         skills: sortedSkills.map((skill) => ({ name: skill.name })),
@@ -69,10 +96,19 @@ export const skillsCommand: SlashCommand = {
     );
 
     if (!hasSkill) {
+      const content = t('Unknown skill: {{name}}', { name: skillName });
+      if (isNonInteractive) {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content,
+        };
+      }
+
       context.ui.addItem(
         {
           type: MessageType.ERROR,
-          text: t('Unknown skill: {{name}}', { name: skillName }),
+          text: content,
         },
         Date.now(),
       );
@@ -104,6 +140,12 @@ export const skillsCommand: SlashCommand = {
     }));
   },
 };
+
+function formatSkillsList(skills: SkillConfig[]): string {
+  return [t('Available skills:'), ...skills.map((skill) => `- ${skill.name}`)]
+    .join('\n')
+    .trim();
+}
 
 async function getSkillMatches(
   skills: SkillConfig[],

--- a/packages/vscode-ide-companion/src/services/acpConnection.test.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.test.ts
@@ -23,6 +23,11 @@ type AcpConnectionInternal = {
   lastExitSignal: string | null;
   mapReadTextFileError: (error: unknown, filePath: string) => unknown;
   ensureConnection: () => unknown;
+  handleExtensionNotification: (
+    method: string,
+    params: Record<string, unknown>,
+  ) => void;
+  onSessionUpdate: (data: unknown) => void;
 };
 
 function createConnection(overrides?: Partial<AcpConnectionInternal>) {
@@ -214,6 +219,76 @@ describe('AcpConnection onDisconnected callback', () => {
 
     acpConn.onDisconnected(1, null);
     expect(spy).toHaveBeenCalledWith(1, null);
+  });
+});
+
+describe('AcpConnection.getSlashCommandCompletions', () => {
+  it('calls ACP extMethod and returns completion items', async () => {
+    const extMethod = vi.fn().mockResolvedValue({
+      items: [{ value: 'review', description: 'Review code' }],
+    });
+    const conn = createConnection({
+      sdkConnection: { extMethod },
+      child: { killed: false, exitCode: null },
+      sessionId: 'session-1',
+    }) as unknown as AcpConnection;
+
+    const result = await conn.getSlashCommandCompletions('/skills');
+
+    expect(extMethod).toHaveBeenCalledWith(
+      '_qwencode/slash_command_completion',
+      {
+        sessionId: 'session-1',
+        query: '/skills',
+      },
+    );
+    expect(result).toEqual([{ value: 'review', description: 'Review code' }]);
+  });
+
+  it('returns empty list when there is no active session', async () => {
+    const extMethod = vi.fn();
+    const conn = createConnection({
+      sdkConnection: { extMethod },
+      child: { killed: false, exitCode: null },
+      sessionId: null,
+    }) as unknown as AcpConnection;
+
+    await expect(conn.getSlashCommandCompletions('/skills')).resolves.toEqual(
+      [],
+    );
+    expect(extMethod).not.toHaveBeenCalled();
+  });
+});
+
+describe('AcpConnection extension notifications', () => {
+  it('routes slash command notifications into assistant message chunks', () => {
+    const onSessionUpdate = vi.fn();
+    const conn = createConnection({
+      child: { killed: false, exitCode: null },
+      sessionId: 'session-1',
+      onSessionUpdate,
+    });
+
+    conn.handleExtensionNotification('_qwencode/slash_command', {
+      sessionId: 'session-1',
+      command: '/skills',
+      messageType: 'info',
+      message: 'Available skills:\n- review',
+    });
+
+    expect(onSessionUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-1',
+        update: expect.objectContaining({
+          sessionUpdate: 'agent_message_chunk',
+          content: { text: 'Available skills:\n- review' },
+          _meta: expect.objectContaining({
+            slashCommand: '/skills',
+            slashCommandMessageType: 'info',
+          }),
+        }),
+      }),
+    );
   });
 });
 

--- a/packages/vscode-ide-companion/src/services/acpConnection.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.ts
@@ -75,6 +75,58 @@ export class AcpConnection {
   }> = () => Promise.resolve({ optionId: 'cancel' });
   onInitialized: (init: unknown) => void = () => {};
 
+  private handleExtensionNotification(
+    method: string,
+    params: Record<string, unknown>,
+  ): void {
+    if (method === 'authenticate/update') {
+      console.log(
+        '[ACP] >>> Processing authenticate_update:',
+        JSON.stringify(params).substring(0, 300),
+      );
+      this.onAuthenticateUpdate(
+        params as unknown as AuthenticateUpdateNotification,
+      );
+      return;
+    }
+
+    if (method === '_qwencode/slash_command') {
+      const message =
+        typeof params['message'] === 'string' ? params['message'] : '';
+      if (!message) {
+        return;
+      }
+
+      const sessionId =
+        typeof params['sessionId'] === 'string'
+          ? params['sessionId']
+          : this.sessionId;
+      if (!sessionId) {
+        return;
+      }
+
+      this.onSessionUpdate({
+        sessionId,
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { text: message },
+          _meta: {
+            timestamp: Date.now(),
+            slashCommand:
+              typeof params['command'] === 'string' ? params['command'] : '',
+            slashCommandMessageType:
+              typeof params['messageType'] === 'string'
+                ? params['messageType']
+                : 'info',
+          },
+        },
+      } as unknown as SessionNotification);
+      return;
+    }
+
+    console.warn(`[ACP] Unhandled extension notification: ${method}`);
+  }
+
   async connect(
     cliEntryPath: string,
     workingDir: string = process.cwd(),
@@ -314,17 +366,7 @@ export class AcpConnection {
           method: string,
           params: Record<string, unknown>,
         ): Promise<void> => {
-          if (method === 'authenticate/update') {
-            console.log(
-              '[ACP] >>> Processing authenticate_update:',
-              JSON.stringify(params).substring(0, 300),
-            );
-            this.onAuthenticateUpdate(
-              params as unknown as AuthenticateUpdateNotification,
-            );
-          } else {
-            console.warn(`[ACP] Unhandled extension notification: ${method}`);
-          }
+          this.handleExtensionNotification(method, params);
         },
       }),
       stream,
@@ -551,6 +593,31 @@ export class AcpConnection {
     });
     console.log('[ACP] set_model response:', res);
     return res;
+  }
+
+  async getSlashCommandCompletions(
+    query: string,
+  ): Promise<Array<{ value: string; description?: string; label?: string }>> {
+    const conn = this.ensureConnection();
+    if (!this.sessionId) {
+      return [];
+    }
+
+    const response = await conn.extMethod(
+      '_qwencode/slash_command_completion',
+      {
+        sessionId: this.sessionId,
+        query,
+      },
+    );
+    const items = response['items'];
+    return Array.isArray(items)
+      ? (items as Array<{
+          value: string;
+          description?: string;
+          label?: string;
+        }>)
+      : [];
   }
 
   disconnect(): void {

--- a/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
+++ b/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
@@ -394,6 +394,12 @@ export class QwenAgentManager {
     }
   }
 
+  async getSlashCommandCompletions(
+    query: string,
+  ): Promise<Array<{ value: string; description?: string; label?: string }>> {
+    return this.connection.getSlashCommandCompletions(query);
+  }
+
   /**
    * Validate if current session is still active
    * This is a lightweight check to verify session validity

--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -99,6 +99,18 @@ export const App: React.FC = () => {
   // Scroll container for message list; used to keep the view anchored to the latest content
   const messagesContainerRef = useRef<HTMLDivElement | null>(null);
   const inputFieldRef = useRef<HTMLDivElement | null>(null);
+  const slashCompletionRequestIdRef = useRef(0);
+  const pendingSlashCompletionRequestsRef = useRef(
+    new Map<
+      number,
+      {
+        resolve: (
+          items: Array<{ value: string; description?: string; label?: string }>,
+        ) => void;
+        timeoutId: ReturnType<typeof setTimeout>;
+      }
+    >(),
+  );
 
   const [editMode, setEditMode] = useState<ApprovalModeValue>(
     ApprovalMode.DEFAULT,
@@ -107,6 +119,68 @@ export const App: React.FC = () => {
   const [isComposing, setIsComposing] = useState(false);
   // When true, do NOT auto-attach the active editor file/selection to message context
   const [skipAutoActiveContext, setSkipAutoActiveContext] = useState(false);
+
+  useEffect(() => {
+    const pendingRequests = pendingSlashCompletionRequestsRef.current;
+    return () => {
+      for (const pending of pendingRequests.values()) {
+        clearTimeout(pending.timeoutId);
+        pending.resolve([]);
+      }
+      pendingRequests.clear();
+    };
+  }, []);
+
+  const handleSlashCommandCompletions = useCallback(
+    (payload: {
+      requestId?: number;
+      items: Array<{ value: string; description?: string; label?: string }>;
+    }) => {
+      const requestId = payload.requestId;
+      if (typeof requestId !== 'number') {
+        return;
+      }
+
+      const pending = pendingSlashCompletionRequestsRef.current.get(requestId);
+      if (!pending) {
+        return;
+      }
+
+      clearTimeout(pending.timeoutId);
+      pendingSlashCompletionRequestsRef.current.delete(requestId);
+      pending.resolve(payload.items);
+    },
+    [],
+  );
+
+  const requestSlashCommandCompletions = useCallback(
+    (
+      query: string,
+    ): Promise<
+      Array<{ value: string; description?: string; label?: string }>
+    > =>
+      new Promise((resolve) => {
+        const requestId = ++slashCompletionRequestIdRef.current;
+        const timeoutId = setTimeout(() => {
+          pendingSlashCompletionRequestsRef.current.delete(requestId);
+          resolve([]);
+        }, 5000);
+
+        pendingSlashCompletionRequestsRef.current.set(requestId, {
+          resolve,
+          timeoutId,
+        });
+
+        vscode.postMessage({
+          type: 'requestSlashCommandCompletions',
+          data: {
+            query: `/${query}`,
+            requestId,
+          },
+        });
+      }),
+    [vscode],
+  );
 
   // Completion system
   const getCompletionItems = React.useCallback(
@@ -151,6 +225,28 @@ export const App: React.FC = () => {
 
         return allItems;
       } else {
+        const normalizedQuery = query.trim();
+        const shouldRequestArgumentCompletions =
+          normalizedQuery.length > 0 &&
+          (normalizedQuery.includes(' ') ||
+            availableCommands.some(
+              (cmd) => cmd.name.toLowerCase() === normalizedQuery.toLowerCase(),
+            ));
+
+        if (shouldRequestArgumentCompletions) {
+          const argumentItems = await requestSlashCommandCompletions(query);
+          if (argumentItems.length > 0) {
+            return argumentItems.map((item) => ({
+              id: `slash-arg-${item.value}`,
+              label: item.label || item.value,
+              description: item.description,
+              type: 'command' as const,
+              group: 'Arguments',
+              value: item.value,
+            }));
+          }
+        }
+
         // Handle slash commands with grouping
         // Model group - special items without / prefix
         const modelGroupItems: CompletionItem[] = [
@@ -203,7 +299,12 @@ export const App: React.FC = () => {
         );
       }
     },
-    [fileContext, availableCommands, modelInfo?.name],
+    [
+      fileContext,
+      availableCommands,
+      modelInfo?.name,
+      requestSlashCommandCompletions,
+    ],
   );
 
   const completion = useCompletionTrigger(inputFieldRef, getCompletionItems);
@@ -366,6 +467,7 @@ export const App: React.FC = () => {
     setAvailableModels: (models) => {
       setAvailableModels(models);
     },
+    handleSlashCommandCompletions,
   });
 
   // Auto-scroll handling: keep the view pinned to bottom when new content arrives,
@@ -538,6 +640,24 @@ export const App: React.FC = () => {
         return;
       }
 
+      const getCompletionPosition = (): { top: number; left: number } => {
+        const selection = window.getSelection();
+        if (selection && selection.rangeCount > 0) {
+          try {
+            const range = selection.getRangeAt(0);
+            const rect = range.getBoundingClientRect();
+            if (rect.top > 0 && rect.left > 0) {
+              return { top: rect.top, left: rect.left };
+            }
+          } catch (error) {
+            console.warn('[App] Failed to read completion position:', error);
+          }
+        }
+
+        const inputRect = inputElement.getBoundingClientRect();
+        return { top: inputRect.top, left: inputRect.left };
+      };
+
       // Ignore info items (placeholders like "Searching files…")
       if (item.type === 'info') {
         completion.closeCompletion();
@@ -698,8 +818,13 @@ export const App: React.FC = () => {
       if (triggerPos >= 0) {
         const insertValue =
           typeof item.value === 'string' ? item.value : String(item.label);
+        let replacementStart = triggerPos + 1;
+        if (completion.triggerChar === '/' && completion.query.includes(' ')) {
+          const lastSpaceIndex = completion.query.lastIndexOf(' ');
+          replacementStart = triggerPos + lastSpaceIndex + 2;
+        }
         const newText =
-          text.substring(0, triggerPos + 1) + // keep the trigger symbol
+          text.substring(0, replacementStart) +
           insertValue +
           ' ' +
           text.substring(cursorPos);
@@ -718,6 +843,19 @@ export const App: React.FC = () => {
 
       // Close the completion menu
       completion.closeCompletion();
+
+      if (
+        fillOnly &&
+        item.type === 'command' &&
+        availableCommands.some((cmd) => cmd.name === item.id)
+      ) {
+        const commandName =
+          typeof item.value === 'string' ? item.value : String(item.label);
+        const position = getCompletionPosition();
+        void requestAnimationFrame(() => {
+          void completion.openCompletion('/', `${commandName} `, position);
+        });
+      }
     },
     [
       completion,

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
@@ -161,4 +161,41 @@ describe('SessionMessageHandler', () => {
       },
     ]);
   });
+
+  it('returns slash command completion results to the webview', async () => {
+    const agentManager = {
+      getSlashCommandCompletions: vi
+        .fn()
+        .mockResolvedValue([{ value: 'review', description: 'Review code' }]),
+    };
+    const conversationStore = {};
+    const sendToWebView = vi.fn();
+
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      null,
+      sendToWebView,
+    );
+
+    await handler.handle({
+      type: 'requestSlashCommandCompletions',
+      data: {
+        query: '/skills',
+        requestId: 7,
+      },
+    });
+
+    expect(agentManager.getSlashCommandCompletions).toHaveBeenCalledWith(
+      '/skills',
+    );
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'slashCommandCompletions',
+      data: {
+        query: '/skills',
+        requestId: 7,
+        items: [{ value: 'review', description: 'Review code' }],
+      },
+    });
+  });
 });

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
@@ -28,6 +28,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
   canHandle(messageType: string): boolean {
     return [
       'sendMessage',
+      'requestSlashCommandCompletions',
       'newQwenSession',
       'switchQwenSession',
       'getQwenSessions',
@@ -73,6 +74,13 @@ export class SessionMessageHandler extends BaseMessageHandler {
               }
             | undefined,
           data?.attachments as ImageAttachment[] | undefined,
+        );
+        break;
+
+      case 'requestSlashCommandCompletions':
+        await this.handleRequestSlashCommandCompletions(
+          (data?.query as string) || '',
+          typeof data?.requestId === 'number' ? data.requestId : undefined,
         );
         break;
 
@@ -1011,6 +1019,37 @@ export class SessionMessageHandler extends BaseMessageHandler {
       this.sendToWebView({
         type: 'error',
         data: { message: `Failed to set model: ${errorMsg}` },
+      });
+    }
+  }
+
+  private async handleRequestSlashCommandCompletions(
+    query: string,
+    requestId?: number,
+  ): Promise<void> {
+    try {
+      const items = await this.agentManager.getSlashCommandCompletions(query);
+      this.sendToWebView({
+        type: 'slashCommandCompletions',
+        data: {
+          query,
+          requestId,
+          items,
+        },
+      });
+    } catch (error) {
+      console.warn(
+        '[SessionMessageHandler] Failed to load slash command completions:',
+        error,
+      );
+      this.sendToWebView({
+        type: 'slashCommandCompletions',
+        data: {
+          query,
+          requestId,
+          items: [],
+          error: this.getErrorMessage(error),
+        },
       });
     }
   }

--- a/packages/vscode-ide-companion/src/webview/hooks/useCompletionTrigger.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useCompletionTrigger.ts
@@ -325,8 +325,14 @@ export function useCompletionTrigger(
         if (isValidTrigger) {
           const query = text.substring(triggerPos + 1, effectiveCursorPosition);
 
-          // Only show if query doesn't contain spaces (still typing the reference)
-          if (!query.includes(' ') && !query.includes('\n')) {
+          // Slash commands may keep completing after the first space so users can
+          // get argument suggestions like `/skills review`.
+          const shouldOpenCompletion =
+            triggerChar === '@'
+              ? !query.includes(' ') && !query.includes('\n')
+              : !query.includes('\n');
+
+          if (shouldOpenCompletion) {
             // Get precise cursor position for menu
             const cursorPos = getCursorPosition();
             if (cursorPos) {

--- a/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
@@ -131,6 +131,11 @@ interface UseWebViewMessagesProps {
   setAvailableCommands?: (commands: AvailableCommand[]) => void;
   // Available models setter
   setAvailableModels?: (models: ModelInfo[]) => void;
+  // Slash command argument completion responses
+  handleSlashCommandCompletions?: (payload: {
+    requestId?: number;
+    items: Array<{ value: string; description?: string; label?: string }>;
+  }) => void;
 }
 
 /**
@@ -154,6 +159,7 @@ export const useWebViewMessages = ({
   setModelInfo,
   setAvailableCommands,
   setAvailableModels,
+  handleSlashCommandCompletions,
 }: UseWebViewMessagesProps) => {
   // VS Code API for posting messages back to the extension host
   const vscode = useVSCode();
@@ -190,6 +196,7 @@ export const useWebViewMessages = ({
     setModelInfo,
     setAvailableCommands,
     setAvailableModels,
+    handleSlashCommandCompletions,
   });
 
   // Track last "Updated Plan" snapshot toolcall to support merge/dedupe
@@ -240,6 +247,7 @@ export const useWebViewMessages = ({
       setModelInfo,
       setAvailableCommands,
       setAvailableModels,
+      handleSlashCommandCompletions,
     };
   });
 
@@ -319,6 +327,25 @@ export const useWebViewMessages = ({
               _error,
             );
           }
+          break;
+        }
+
+        case 'slashCommandCompletions': {
+          const requestId =
+            typeof message.data?.requestId === 'number'
+              ? message.data.requestId
+              : undefined;
+          const items = Array.isArray(message.data?.items)
+            ? (message.data.items as Array<{
+                value: string;
+                description?: string;
+                label?: string;
+              }>)
+            : [];
+          handlers.handleSlashCommandCompletions?.({
+            requestId,
+            items,
+          });
           break;
         }
 


### PR DESCRIPTION
## Summary
- expose /skills to ACP and VSCode so direct execution returns visible output
- add slash-command argument completion plumbing so VSCode can show skill suggestions
- route slash completion responses through the centralized webview message handler

## Testing
- npm exec vitest run packages/cli/src/ui/commands/skillsCommand.test.ts packages/cli/src/nonInteractiveCliCommands.test.ts packages/vscode-ide-companion/src/services/acpConnection.test.ts packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
- npm --prefix packages/cli run typecheck
- npm --prefix packages/vscode-ide-companion run check-types
- npm --prefix packages/vscode-ide-companion run build