### PR TITLE
fix: avoid orphan ACP processes by skipping relaunch wrapper

### DIFF
--- a/packages/vscode-ide-companion/src/services/acpConnection.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.ts
@@ -87,7 +87,7 @@ export class AcpConnection {
     this.lastExitSignal = null;
     this.workingDir = workingDir;
 
-    const env = { ...process.env };
+    const env = { ...process.env, QWEN_CODE_NO_RELAUNCH: 'true' };
 
     const proxyArg = extraArgs.find(
       (arg, i) => arg === '--proxy' && i + 1 < extraArgs.length,


### PR DESCRIPTION
## Summary
When VS Code or JetBrains spawns the ACP CLI, it previously spawned the outer wrapper process, which would then spawn an inner process to run the actual agent. When the IDE was closed or killed the outer process, the inner process would be orphaned and left running in the background.

By setting `QWEN_CODE_NO_RELAUNCH=true` in the spawn environment, we ensure the CLI runs directly in the spawned process, so the IDE's process management (and `disconnect` kill) targets the actual agent process.

## Test plan
- Run VS Code extension
- Check `ps aux | grep qwen` to see only one process per ACP connection
- Close VS Code
- Check `ps aux | grep qwen` to verify the process is gone

Closes #2433