### PR TITLE
fix(mcp): restore trust+isTrustedFolder permission check in getDefaultPermission

### DIFF
--- a/packages/core/src/tools/mcp-tool.test.ts
+++ b/packages/core/src/tools/mcp-tool.test.ts
@@ -736,7 +736,7 @@ describe('DiscoveredMCPTool', () => {
   });
 
   describe('getDefaultPermission and getConfirmationDetails', () => {
-    it('should return ask even if trust is true and folder is trusted (trust logic moved to PM)', async () => {
+    it('should return allow when trust is true', async () => {
       const trustedTool = new DiscoveredMCPTool(
         mockCallableToolInstance,
         serverName,
@@ -748,7 +748,7 @@ describe('DiscoveredMCPTool', () => {
         { isTrustedFolder: () => true } as any,
       );
       const invocation = trustedTool.build({ param: 'mock' });
-      expect(await invocation.getDefaultPermission()).toBe('ask');
+      expect(await invocation.getDefaultPermission()).toBe('allow');
     });
 
     it('should return ask if not trusted', async () => {
@@ -808,7 +808,7 @@ describe('DiscoveredMCPTool', () => {
       isTrustedFolder: () => isTrusted,
     });
 
-    it('should return ask even if trust is true and folder is trusted (trust logic moved to PM)', async () => {
+    it('should return allow when trust is true and folder is trusted', async () => {
       const trustedTool = new DiscoveredMCPTool(
         mockCallableToolInstance,
         serverName,
@@ -820,7 +820,7 @@ describe('DiscoveredMCPTool', () => {
         mockConfig(true) as any, // isTrustedFolder = true
       );
       const invocation = trustedTool.build({ param: 'mock' });
-      expect(await invocation.getDefaultPermission()).toBe('ask');
+      expect(await invocation.getDefaultPermission()).toBe('allow');
     });
 
     it('should return ask if trust is true but folder is not trusted', async () => {

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -124,14 +124,17 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
   }
 
   /**
-   * MCP tool default permission based on annotations:
+   * MCP tool default permission based on trust and annotations:
+   * - trust: true in a trusted folder → 'allow' (server explicitly trusted by user config)
    * - readOnlyHint → 'allow'
    * - All other MCP tools → 'ask'
-   *
-   * Note: trust/isTrustedFolder logic is now handled by PM rules,
-   * not by getDefaultPermission().
    */
   override async getDefaultPermission(): Promise<PermissionDecision> {
+    // MCP servers explicitly marked as trusted bypass confirmation,
+    // but only when the workspace folder is also trusted (security gate).
+    if (this.trust === true && this.cliConfig?.isTrustedFolder()) {
+      return 'allow';
+    }
     // MCP tools annotated with readOnlyHint: true are safe
     if (this.annotations?.readOnlyHint === true) {
       return 'allow';


### PR DESCRIPTION
## TLDR

The `trust: true` setting on MCP servers stopped working in v0.13.0 after the permission system refactor (PR #2283). This PR restores the original behavior.

## Screenshots / Video Demo

<img width="906" height="968" alt="image" src="https://github.com/user-attachments/assets/d8c05515-cc64-4248-a76f-f201ff902d04" />

- Above: this PR, auto allow
- Below: v0.13.0, ask

## Dive Deeper

### Root Cause

PR #2283 (`feat/support-permission`) refactored MCP tool confirmation from the old `shouldConfirmExecute()` API to the new `getDefaultPermission()` + `getConfirmationDetails()` split.

The original `shouldConfirmExecute()` had an explicit trust check:
```typescript
if (this.cliConfig?.isTrustedFolder() && this.trust) {
  return false; // server is trusted, no confirmation needed
}
```

The refactored `getDefaultPermission()` omitted this check entirely, leaving only a comment: _"Note: trust/isTrustedFolder logic is now handled by PM rules"_. However, **no PM rules were ever generated from the `trust` setting**, making `trust: true` completely non-functional — the field is stored, passed through the entire config → mcp-client → DiscoveredMCPTool → Invocation chain, but never consulted during permission evaluation.

### Fix

Restore the original two-condition check in `getDefaultPermission()`:
- `trust === true` on the MCP server config
- `isTrustedFolder()` on the workspace (security gate)

Both conditions must be true, preserving the security invariant that `trust` settings (including user-level `~/.qwen/settings.json`) cannot bypass confirmation in untrusted workspaces.

## Reviewer Test Plan

Add to your project's `.qwen/settings.json` (trusted workspace):

```json
{
  "mcpServers": {
    "my-server": {
      "command": "...",
      "trust": true
    }
  }
}
```

MCP tools from `my-server` should now execute without a confirmation dialog. Before this fix they always prompted regardless of the `trust` setting.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | -   | -   |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to #861

---
🤖 Generated with Qoder