### PR TITLE
fix: resolve /clear command and ESC key lag caused by hooks system

### DIFF
--- a/packages/cli/src/ui/commands/clearCommand.test.ts
+++ b/packages/cli/src/ui/commands/clearCommand.test.ts
@@ -140,6 +140,71 @@ describe('clearCommand', () => {
     expect(mockContext.ui.clear).toHaveBeenCalledTimes(1);
   });
 
+  it('should clear UI before resetChat for immediate responsiveness', async () => {
+    if (!clearCommand.action) {
+      throw new Error('clearCommand must have an action.');
+    }
+
+    const callOrder: string[] = [];
+    (mockContext.ui.clear as ReturnType<typeof vi.fn>).mockImplementation(
+      () => {
+        callOrder.push('ui.clear');
+      },
+    );
+    mockResetChat.mockImplementation(async () => {
+      callOrder.push('resetChat');
+    });
+
+    await clearCommand.action(mockContext, '');
+
+    // ui.clear should be called before resetChat for immediate UI feedback
+    const clearIndex = callOrder.indexOf('ui.clear');
+    const resetIndex = callOrder.indexOf('resetChat');
+    expect(clearIndex).toBeGreaterThanOrEqual(0);
+    expect(resetIndex).toBeGreaterThanOrEqual(0);
+    expect(clearIndex).toBeLessThan(resetIndex);
+  });
+
+  it('should not await hook events (fire-and-forget)', async () => {
+    if (!clearCommand.action) {
+      throw new Error('clearCommand must have an action.');
+    }
+
+    // Make hooks take a long time - they should not block
+    let sessionEndResolved = false;
+    let sessionStartResolved = false;
+    mockFireSessionEndEvent.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            sessionEndResolved = true;
+            resolve(undefined);
+          }, 5000);
+        }),
+    );
+    mockFireSessionStartEvent.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => {
+            sessionStartResolved = true;
+            resolve(undefined);
+          }, 5000);
+        }),
+    );
+
+    await clearCommand.action(mockContext, '');
+
+    // The action should complete immediately without waiting for hooks
+    expect(mockContext.ui.clear).toHaveBeenCalledTimes(1);
+    expect(mockResetChat).toHaveBeenCalledTimes(1);
+    // Hooks should have been called but not necessarily resolved
+    expect(mockFireSessionEndEvent).toHaveBeenCalled();
+    expect(mockFireSessionStartEvent).toHaveBeenCalled();
+    // Hooks should NOT have resolved yet since they have 5s timeouts
+    expect(sessionEndResolved).toBe(false);
+    expect(sessionStartResolved).toBe(false);
+  });
+
   it('should not attempt to reset chat if config service is not available', async () => {
     if (!clearCommand.action) {
       throw new Error('clearCommand must have an action.');

--- a/packages/cli/src/ui/commands/clearCommand.ts
+++ b/packages/cli/src/ui/commands/clearCommand.ts
@@ -27,14 +27,13 @@ export const clearCommand: SlashCommand = {
     const { config } = context.services;
 
     if (config) {
-      // Fire SessionEnd event before clearing (current session ends)
-      try {
-        await config
-          .getHookSystem()
-          ?.fireSessionEndEvent(SessionEndReason.Clear);
-      } catch (err) {
-        config.getDebugLogger().warn(`SessionEnd hook failed: ${err}`);
-      }
+      // Fire SessionEnd event (non-blocking to avoid UI lag)
+      config
+        .getHookSystem()
+        ?.fireSessionEndEvent(SessionEndReason.Clear)
+        .catch((err) => {
+          config.getDebugLogger().warn(`SessionEnd hook failed: ${err}`);
+        });
 
       const newSessionId = config.startNewSession();
 
@@ -54,6 +53,9 @@ export const clearCommand: SlashCommand = {
         context.session.startNewSession(newSessionId);
       }
 
+      // Clear UI first for immediate responsiveness
+      context.ui.clear();
+
       const geminiClient = config.getGeminiClient();
       if (geminiClient) {
         context.ui.setDebugMessage(
@@ -66,22 +68,20 @@ export const clearCommand: SlashCommand = {
         context.ui.setDebugMessage(t('Starting a new session and clearing.'));
       }
 
-      // Fire SessionStart event after clearing (new session starts)
-      try {
-        await config
-          .getHookSystem()
-          ?.fireSessionStartEvent(
-            SessionStartSource.Clear,
-            config.getModel() ?? '',
-            String(config.getApprovalMode()) as PermissionMode,
-          );
-      } catch (err) {
-        config.getDebugLogger().warn(`SessionStart hook failed: ${err}`);
-      }
+      // Fire SessionStart event (non-blocking to avoid UI lag)
+      config
+        .getHookSystem()
+        ?.fireSessionStartEvent(
+          SessionStartSource.Clear,
+          config.getModel() ?? '',
+          String(config.getApprovalMode()) as PermissionMode,
+        )
+        .catch((err) => {
+          config.getDebugLogger().warn(`SessionStart hook failed: ${err}`);
+        });
     } else {
       context.ui.setDebugMessage(t('Starting a new session and clearing.'));
+      context.ui.clear();
     }
-
-    context.ui.clear();
   },
 };

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -1582,4 +1582,37 @@ describe('Model Switching and Config Updates', () => {
     const updatedConfig = config.getContentGeneratorConfig();
     expect(updatedConfig['contextWindowSize']).toBe(128_000);
   });
+
+  describe('hasHooksForEvent', () => {
+    it('should return false when hookSystem is not initialized', () => {
+      const config = new Config(baseParams);
+      expect(config.hasHooksForEvent('Stop')).toBe(false);
+    });
+
+    it('should delegate to hookSystem.hasHooksForEvent when hookSystem exists', () => {
+      const config = new Config(baseParams);
+      const mockHasHooksForEvent = vi.fn().mockReturnValue(true);
+      const mockHookSystem = {
+        hasHooksForEvent: mockHasHooksForEvent,
+      };
+      // @ts-expect-error - accessing private for testing
+      config['hookSystem'] = mockHookSystem;
+
+      expect(config.hasHooksForEvent('UserPromptSubmit')).toBe(true);
+      expect(mockHasHooksForEvent).toHaveBeenCalledWith('UserPromptSubmit');
+    });
+
+    it('should return false when hookSystem has no hooks for the event', () => {
+      const config = new Config(baseParams);
+      const mockHasHooksForEvent = vi.fn().mockReturnValue(false);
+      const mockHookSystem = {
+        hasHooksForEvent: mockHasHooksForEvent,
+      };
+      // @ts-expect-error - accessing private for testing
+      config['hookSystem'] = mockHookSystem;
+
+      expect(config.hasHooksForEvent('Stop')).toBe(false);
+      expect(mockHasHooksForEvent).toHaveBeenCalledWith('Stop');
+    });
+  });
 });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1770,6 +1770,15 @@ export class Config {
   }
 
   /**
+   * Fast-path check: returns true only when hooks are enabled AND there are
+   * registered hooks for the given event name.  Callers can use this to skip
+   * expensive MessageBus round-trips when no hooks are configured.
+   */
+  hasHooksForEvent(eventName: string): boolean {
+    return this.hookSystem?.hasHooksForEvent(eventName) ?? false;
+  }
+
+  /**
    * Check if hooks are enabled.
    */
   getEnableHooks(): boolean {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -363,6 +363,7 @@ describe('Gemini Client (client.ts)', () => {
       getEnableHooks: vi.fn().mockReturnValue(false),
       getArenaManager: vi.fn().mockReturnValue(null),
       getMessageBus: vi.fn().mockReturnValue(undefined),
+      hasHooksForEvent: vi.fn().mockReturnValue(false),
       getHookSystem: vi.fn().mockReturnValue(undefined),
       getDebugLogger: vi.fn().mockReturnValue({
         debug: vi.fn(),
@@ -2382,6 +2383,105 @@ Other open files:
         }
 
         expect(client['sessionTurnCount']).toBe(turnCountBefore);
+      });
+    });
+
+    describe('hooks fast-path optimization', () => {
+      let mockChat: Partial<GeminiChat>;
+
+      beforeEach(() => {
+        vi.spyOn(client, 'tryCompressChat').mockResolvedValue({
+          originalTokenCount: 0,
+          newTokenCount: 0,
+          compressionStatus: CompressionStatus.COMPRESSED,
+        });
+
+        const mockStream = (async function* () {
+          yield { type: 'content', value: 'Hello' };
+        })();
+        mockTurnRunFn.mockReturnValue(mockStream);
+
+        mockChat = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([]),
+          stripThoughtsFromHistory: vi.fn(),
+        };
+        client['chat'] = mockChat as GeminiChat;
+      });
+
+      it('should skip messageBus.request for UserPromptSubmit when hasHooksForEvent returns false', async () => {
+        // Enable hooks and provide messageBus
+        const mockMessageBus = {
+          request: vi.fn(),
+          response: vi.fn(),
+        };
+        vi.spyOn(client['config'], 'getEnableHooks').mockReturnValue(true);
+        vi.spyOn(client['config'], 'getMessageBus').mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        vi.spyOn(client['config'], 'hasHooksForEvent').mockReturnValue(false);
+
+        const stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-hooks-1',
+        );
+        for await (const _ of stream) {
+          // consume stream
+        }
+
+        // messageBus.request should NOT be called because hasHooksForEvent returned false
+        expect(mockMessageBus.request).not.toHaveBeenCalled();
+      });
+
+      it('should skip messageBus.request for Stop when hasHooksForEvent returns false', async () => {
+        const mockMessageBus = {
+          request: vi.fn(),
+          response: vi.fn(),
+        };
+        vi.spyOn(client['config'], 'getEnableHooks').mockReturnValue(true);
+        vi.spyOn(client['config'], 'getMessageBus').mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        vi.spyOn(client['config'], 'hasHooksForEvent').mockReturnValue(false);
+
+        const stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-hooks-2',
+        );
+        for await (const _ of stream) {
+          // consume stream
+        }
+
+        // messageBus.request should NOT be called for Stop hook either
+        expect(mockMessageBus.request).not.toHaveBeenCalled();
+      });
+
+      it('should not skip hooks when hasHooksForEvent returns true', async () => {
+        const mockMessageBus = {
+          request: vi.fn().mockResolvedValue({ modifiedPrompt: undefined }),
+          response: vi.fn(),
+        };
+        vi.spyOn(client['config'], 'getEnableHooks').mockReturnValue(true);
+        vi.spyOn(client['config'], 'getMessageBus').mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        vi.spyOn(client['config'], 'hasHooksForEvent').mockImplementation(
+          (event: string) => event === 'UserPromptSubmit',
+        );
+
+        const stream = client.sendMessageStream(
+          [{ text: 'Hi' }],
+          new AbortController().signal,
+          'prompt-hooks-3',
+        );
+        for await (const _ of stream) {
+          // consume stream
+        }
+
+        // messageBus.request SHOULD be called for UserPromptSubmit
+        expect(mockMessageBus.request).toHaveBeenCalled();
       });
     });
   });

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -465,7 +465,12 @@ export class GeminiClient {
     // Fire UserPromptSubmit hook through MessageBus (only if hooks are enabled)
     const hooksEnabled = this.config.getEnableHooks();
     const messageBus = this.config.getMessageBus();
-    if (messageType !== SendMessageType.Retry && hooksEnabled && messageBus) {
+    if (
+      messageType !== SendMessageType.Retry &&
+      hooksEnabled &&
+      messageBus &&
+      this.config.hasHooksForEvent('UserPromptSubmit')
+    ) {
       const promptText = partToString(request);
       const response = await messageBus.request<
         HookExecutionRequest,
@@ -675,14 +680,15 @@ export class GeminiClient {
         return turn;
       }
     }
-    // Fire Stop hook through MessageBus (only if hooks are enabled)
+    // Fire Stop hook through MessageBus (only if hooks are enabled and registered)
     // This must be done before any early returns to ensure hooks are always triggered
     if (
       hooksEnabled &&
       messageBus &&
       !turn.pendingToolCalls.length &&
       signal &&
-      !signal.aborted
+      !signal.aborted &&
+      this.config.hasHooksForEvent('Stop')
     ) {
       // Get response text from the chat history
       const history = this.getHistory();

--- a/packages/core/src/hooks/hookSystem.test.ts
+++ b/packages/core/src/hooks/hookSystem.test.ts
@@ -65,6 +65,7 @@ describe('HookSystem', () => {
       initialize: vi.fn().mockResolvedValue(undefined),
       setHookEnabled: vi.fn(),
       getAllHooks: vi.fn().mockReturnValue([]),
+      getHooksForEvent: vi.fn().mockReturnValue([]),
     } as unknown as HookRegistry;
 
     mockHookRunner = {
@@ -183,6 +184,52 @@ describe('HookSystem', () => {
 
       expect(hooks).toEqual(mockHooks);
       expect(mockHookRegistry.getAllHooks).toHaveBeenCalled();
+    });
+  });
+
+  describe('hasHooksForEvent', () => {
+    it('should return false when no hooks are registered for the event', () => {
+      vi.mocked(mockHookRegistry.getHooksForEvent).mockReturnValue([]);
+
+      expect(hookSystem.hasHooksForEvent('Stop')).toBe(false);
+      expect(mockHookRegistry.getHooksForEvent).toHaveBeenCalledWith('Stop');
+    });
+
+    it('should return true when hooks are registered for the event', () => {
+      vi.mocked(mockHookRegistry.getHooksForEvent).mockReturnValue([
+        {
+          config: {
+            type: HookType.Command,
+            command: 'echo test',
+            source: HooksConfigSource.Project,
+          },
+          source: HooksConfigSource.Project,
+          eventName: HookEventName.Stop,
+          enabled: true,
+        },
+      ]);
+
+      expect(hookSystem.hasHooksForEvent('Stop')).toBe(true);
+    });
+
+    it('should check the correct event name for UserPromptSubmit', () => {
+      vi.mocked(mockHookRegistry.getHooksForEvent).mockReturnValue([]);
+
+      hookSystem.hasHooksForEvent('UserPromptSubmit');
+
+      expect(mockHookRegistry.getHooksForEvent).toHaveBeenCalledWith(
+        'UserPromptSubmit',
+      );
+    });
+
+    it('should check the correct event name for SessionEnd', () => {
+      vi.mocked(mockHookRegistry.getHooksForEvent).mockReturnValue([]);
+
+      hookSystem.hasHooksForEvent('SessionEnd');
+
+      expect(mockHookRegistry.getHooksForEvent).toHaveBeenCalledWith(
+        'SessionEnd',
+      );
     });
   });
 

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -22,6 +22,7 @@ import type {
   PreCompactTrigger,
   NotificationType,
   PermissionSuggestion,
+  HookEventName,
 } from './types.js';
 
 const debugLogger = createDebugLogger('TRUSTED_HOOKS');
@@ -85,6 +86,17 @@ export class HookSystem {
    */
   getAllHooks(): HookRegistryEntry[] {
     return this.hookRegistry.getAllHooks();
+  }
+
+  /**
+   * Check if there are any enabled hooks registered for a specific event.
+   * This is a fast-path check to avoid expensive MessageBus round-trips
+   * when no hooks are configured for a given event.
+   */
+  hasHooksForEvent(eventName: string): boolean {
+    return (
+      this.hookRegistry.getHooksForEvent(eventName as HookEventName).length > 0
+    );
   }
 
   async fireUserPromptSubmitEvent(


### PR DESCRIPTION
## TLDR

Fix performance lag when using `/clear` command and pressing ESC to stop conversations. The hooks system was introducing unnecessary blocking `await` calls and MessageBus round-trips even when no hooks were registered.

## Screenshots / Video Demo

N/A — no user-facing visual change. This is a performance fix that eliminates noticeable lag/delay.

## Dive Deeper

### Root Cause

Two main sources of lag were identified:

1. **`/clear` command** (`clearCommand.ts`): Two sequential `await` calls to `fireSessionEndEvent()` and `fireSessionStartEvent()` blocked before `context.ui.clear()` was called. Even with no hooks registered, these async calls introduced latency.

2. **ESC key** (`client.ts`): `sendMessageStream()` always performed `messageBus.request()` for `UserPromptSubmit` and `Stop` hook events when `enableHooks` was `true`, regardless of whether any hooks were actually registered. Each `messageBus.request()` involves `randomUUID()`, Promise creation, EventEmitter subscription, and timeout setup.

### Fix

- **Fire-and-forget hooks in `/clear`**: Changed hook event calls from `await` to fire-and-forget (`.catch()` for error handling), and moved `context.ui.clear()` before `resetChat()` for immediate UI responsiveness.

- **Fast-path check**: Added `hasHooksForEvent(eventName)` method to `HookSystem` and `Config` that checks the `HookRegistry` for registered hooks. This is an O(1) check that completely skips the expensive MessageBus round-trip when no hooks are configured for a given event.

### Files Changed

| File | Change |
|------|--------|
| `packages/cli/src/ui/commands/clearCommand.ts` | Hook calls → fire-and-forget; UI clear moved earlier |
| `packages/core/src/hooks/hookSystem.ts` | Added `hasHooksForEvent()` method |
| `packages/core/src/config/config.ts` | Added `hasHooksForEvent()` proxy method |
| `packages/core/src/core/client.ts` | Added fast-path checks for UserPromptSubmit and Stop hooks |
| `**/**.test.ts` (4 files) | Comprehensive unit tests for all changes |

## Reviewer Test Plan

1. Start the CLI with `npm start`
2. Have a conversation, then type `/clear` — should clear instantly with no lag
3. Start a new conversation, press ESC while the model is responding — should stop immediately
4. Enable hooks (`--experimental-hooks`) and repeat steps 2-3 — behavior should be the same
5. Run `npm run test` to verify all tests pass

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2651