### PR TITLE
fix: make /compress handle tool-heavy conversations correctly

### DIFF
--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -139,7 +139,7 @@ describe('findCompressSplitPoint', () => {
     expect(findCompressSplitPoint(history, 0.7)).toBe(5);
   });
 
-  it('should use tool completion split point when only one user query exists', () => {
+  it('should return primary split point when tool completions have no subsequent regular user message', () => {
     const history: Content[] = [
       { role: 'user', parts: [{ text: 'Fix this' }] },
       {
@@ -179,12 +179,12 @@ describe('findCompressSplitPoint', () => {
     ];
     // Only one non-functionResponse user message (index 0) -> lastSplitPoint=0
     // Last message has functionCall -> can't compress everything
-    // But tool completion split points exist (at indices 3 and 5)
-    // Should use lastToolCompletionSplitPoint=5 instead of lastSplitPoint=0
-    expect(findCompressSplitPoint(history, 0.7)).toBe(5);
+    // historyToKeep must start with a regular user message, so split at 0
+    // (compress nothing) is the only valid option.
+    expect(findCompressSplitPoint(history, 0.7)).toBe(0);
   });
 
-  it('should prefer larger split point between primary and tool completion', () => {
+  it('should prefer primary split point when tool completions yield no valid user-starting split', () => {
     const longContent = 'a'.repeat(10000);
     const history: Content[] = [
       { role: 'user', parts: [{ text: 'Fix bug A' }] },
@@ -225,11 +225,10 @@ describe('findCompressSplitPoint', () => {
         parts: [{ functionCall: { name: 'write1', args: {} } }],
       },
     ];
-    // Primary split points at 0 and 2 (early, before the bulky tool outputs)
-    // Tool completion split points at 5 and 7 (after tool call pairs)
+    // Primary split points at 0 and 2 (regular user messages before the bulky tool outputs)
     // Last message has functionCall -> can't compress everything
-    // Should use max(lastSplitPoint=2, lastToolCompletionSplitPoint=7) = 7
-    expect(findCompressSplitPoint(history, 0.7)).toBe(7);
+    // Should return lastSplitPoint=2 (last valid primary split point)
+    expect(findCompressSplitPoint(history, 0.7)).toBe(2);
   });
 
   it('should still prefer primary split point when it is better', () => {
@@ -264,9 +263,8 @@ describe('findCompressSplitPoint', () => {
       },
     ];
     // Primary split points: 0, 2, 5, 7
-    // Tool completion: 5
     // Last message has functionCall -> can't compress everything
-    // At 0.99 fraction, lastSplitPoint should be 7 which is > lastToolCompletion=5
+    // At 0.99 fraction, lastSplitPoint should be 7
     expect(findCompressSplitPoint(history, 0.99)).toBe(7);
   });
 });
@@ -407,6 +405,47 @@ describe('ChatCompressionService', () => {
     });
     expect(mockGenerateContent).not.toHaveBeenCalled();
     expect(tokenLimit).not.toHaveBeenCalled();
+  });
+
+  it('should return NOOP when historyToCompress is below MIN_COMPRESSION_FRACTION of total', async () => {
+    // Construct a history where the split point lands on the 2nd regular user
+    // message (index 2), but indices 0-1 are tiny relative to the huge content
+    // at index 2. historyToCompress = [0,1] will be << 5% of totalCharCount.
+    const hugeContent = 'x'.repeat(100000);
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'hello' }] },
+      { role: 'model', parts: [{ text: 'world' }] },
+      // Huge user message pushes the cumulative well past the split threshold
+      { role: 'user', parts: [{ text: hugeContent }] },
+      // Pending functionCall prevents returning contents.length,
+      // so the fallback split at index 2 is used
+      {
+        role: 'model',
+        parts: [{ functionCall: { name: 'process', args: {} } }],
+      },
+    ];
+    vi.mocked(mockChat.getHistory).mockReturnValue(history);
+    vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(100);
+    vi.mocked(tokenLimit).mockReturnValue(1000);
+
+    const mockGenerateContent = vi.fn();
+    vi.mocked(mockConfig.getContentGenerator).mockReturnValue({
+      generateContent: mockGenerateContent,
+    } as unknown as ContentGenerator);
+
+    // force=true bypasses the token threshold gate so we exercise the 5% guard
+    const result = await service.compress(
+      mockChat,
+      mockPromptId,
+      true,
+      mockModel,
+      mockConfig,
+      false,
+    );
+
+    expect(result.info.compressionStatus).toBe(CompressionStatus.NOOP);
+    expect(result.newHistory).toBeNull();
+    expect(mockGenerateContent).not.toHaveBeenCalled();
   });
 
   it('should compress if over token threshold', async () => {
@@ -1101,6 +1140,151 @@ describe('ChatCompressionService', () => {
       expect(result.newHistory).not.toBeNull();
       // mockFirePreCompactEvent should not be called since hookSystem is null
       expect(mockFirePreCompactEvent).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('orphaned trailing funcCall handling', () => {
+    it('should compress everything when force=true and last message is an orphaned funcCall', async () => {
+      // Issue #2647: tool-heavy conversation interrupted/crashed while a tool
+      // was still running. The funcCall will never get a response since the agent
+      // is idle. Manual /compress strips the orphaned funcCall, then compresses
+      // the remaining history normally.
+      const history: Content[] = [
+        { role: 'user', parts: [{ text: 'Fix all TypeScript errors.' }] },
+        {
+          role: 'model',
+          parts: [{ functionCall: { name: 'glob', args: {} } }],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                name: 'glob',
+                response: { result: 'files...' },
+              },
+            },
+          ],
+        },
+        {
+          role: 'model',
+          parts: [{ functionCall: { name: 'readFile', args: {} } }],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                name: 'readFile',
+                response: { result: 'code...' },
+              },
+            },
+          ],
+        },
+        // orphaned funcCall — agent was interrupted before getting a response
+        {
+          role: 'model',
+          parts: [{ functionCall: { name: 'editFile', args: {} } }],
+        },
+      ];
+      vi.mocked(mockChat.getHistory).mockReturnValue(history);
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        100,
+      );
+      vi.mocked(tokenLimit).mockReturnValue(1000);
+
+      const mockGenerateContent = vi.fn().mockResolvedValue({
+        candidates: [
+          { content: { parts: [{ text: 'Summary of all work done' }] } },
+        ],
+        usageMetadata: {
+          promptTokenCount: 1100,
+          candidatesTokenCount: 50,
+          totalTokenCount: 1150,
+        },
+      } as unknown as GenerateContentResponse);
+      vi.mocked(mockConfig.getContentGenerator).mockReturnValue({
+        generateContent: mockGenerateContent,
+      } as unknown as ContentGenerator);
+
+      const result = await service.compress(
+        mockChat,
+        mockPromptId,
+        true, // force=true (manual /compress)
+        mockModel,
+        mockConfig,
+        false,
+      );
+
+      // Should compress successfully — orphaned funcCall is stripped first, then
+      // normal compression runs on the remaining history, historyToKeep is empty
+      expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
+      expect(result.newHistory).not.toBeNull();
+      // Reconstructed history: [User(summary), Model("Got it...")] — valid structure
+      expect(result.newHistory).toHaveLength(2);
+      expect(result.newHistory![0].role).toBe('user');
+      expect(result.newHistory![1].role).toBe('model');
+      // The orphaned funcCall is stripped before compression, so only the first 5
+      // messages are sent, plus the compression instruction (+1) = history.length total.
+      const callArg = mockGenerateContent.mock.calls[0][0];
+      expect(callArg.contents.length).toBe(history.length); // (history.length - 1) messages + 1 instruction
+    });
+
+    it('should NOT compress orphaned funcCall when force=false (auto-compress)', async () => {
+      // Auto-compress fires BEFORE the matching funcResponse is sent back to the
+      // model. Compressing the funcCall away would orphan the upcoming funcResponse
+      // and cause an API error. So force=false must NOT take this path.
+      const history: Content[] = [
+        { role: 'user', parts: [{ text: 'Fix all TypeScript errors.' }] },
+        {
+          role: 'model',
+          parts: [{ functionCall: { name: 'glob', args: {} } }],
+        },
+        {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                name: 'glob',
+                response: { result: 'files...' },
+              },
+            },
+          ],
+        },
+        // Pending funcCall: tool is currently executing, funcResponse is coming
+        {
+          role: 'model',
+          parts: [{ functionCall: { name: 'readFile', args: {} } }],
+        },
+      ];
+      vi.mocked(mockChat.getHistory).mockReturnValue(history);
+      // Use a token count above threshold to ensure auto-compress isn't skipped
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        800,
+      );
+      vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
+        model: 'gemini-pro',
+        contextWindowSize: 1000,
+      } as unknown as ReturnType<typeof mockConfig.getContentGeneratorConfig>);
+
+      const mockGenerateContent = vi.fn();
+      vi.mocked(mockConfig.getContentGenerator).mockReturnValue({
+        generateContent: mockGenerateContent,
+      } as unknown as ContentGenerator);
+
+      const result = await service.compress(
+        mockChat,
+        mockPromptId,
+        false, // force=false (auto-compress)
+        mockModel,
+        mockConfig,
+        false,
+      );
+
+      // Must return NOOP — compressing would orphan the upcoming funcResponse
+      expect(result.info.compressionStatus).toBe(CompressionStatus.NOOP);
+      expect(result.newHistory).toBeNull();
+      expect(mockGenerateContent).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -30,6 +30,13 @@ export const COMPRESSION_TOKEN_THRESHOLD = 0.7;
 export const COMPRESSION_PRESERVE_THRESHOLD = 0.3;
 
 /**
+ * Minimum fraction of history (by character count) that must be compressible
+ * to proceed with a compression API call. Prevents futile calls where the
+ * model receives almost no context and generates a useless summary.
+ */
+export const MIN_COMPRESSION_FRACTION = 0.05;
+
+/**
  * Returns the index of the oldest item to keep when compressing. May return
  * contents.length which indicates that everything should be compressed.
  *
@@ -48,11 +55,6 @@ export function findCompressSplitPoint(
   const targetCharCount = totalCharCount * fraction;
 
   let lastSplitPoint = 0; // 0 is always valid (compress nothing)
-  // In tool-heavy conversations, non-functionResponse user messages are rare.
-  // Track positions after tool call completions (functionResponse) as fallback
-  // split points, ensuring all function calls in the compressed portion have
-  // matching responses.
-  let lastToolCompletionSplitPoint = 0;
   let cumulativeCharCount = 0;
   for (let i = 0; i < contents.length; i++) {
     const content = contents[i];
@@ -64,14 +66,6 @@ export function findCompressSplitPoint(
         return i;
       }
       lastSplitPoint = i;
-    }
-    // After a functionResponse, all preceding function calls are properly
-    // paired, making the next position (i+1) a safe place to split.
-    if (
-      content.role === 'user' &&
-      content.parts?.some((part) => !!part.functionResponse)
-    ) {
-      lastToolCompletionSplitPoint = i + 1;
     }
     cumulativeCharCount += charCounts[i];
   }
@@ -94,11 +88,7 @@ export function findCompressSplitPoint(
     return contents.length;
   }
 
-  // Use the split point that provides the most content to compress.
-  // In tool-heavy conversations with few user queries, lastSplitPoint may be
-  // near the beginning of the history while lastToolCompletionSplitPoint
-  // provides much better coverage.
-  return Math.max(lastSplitPoint, lastToolCompletionSplitPoint);
+  return lastSplitPoint;
 }
 
 export class ChatCompressionService {
@@ -162,13 +152,31 @@ export class ChatCompressionService {
       }
     }
 
+    // For manual /compress (force=true), if the last message is an orphaned model
+    // funcCall (agent interrupted/crashed before the response arrived), strip it
+    // before computing the split point. After stripping, the history ends cleanly
+    // (typically with a user funcResponse) and findCompressSplitPoint handles it
+    // through its normal logic — no special-casing needed.
+    //
+    // auto-compress (force=false) must NOT strip: it fires inside
+    // sendMessageStream() before the matching funcResponse is pushed onto the
+    // history, so the trailing funcCall is still active, not orphaned.
+    const lastMessage = curatedHistory[curatedHistory.length - 1];
+    const hasOrphanedFuncCall =
+      force &&
+      lastMessage?.role === 'model' &&
+      lastMessage.parts?.some((p) => !!p.functionCall);
+    const historyForSplit = hasOrphanedFuncCall
+      ? curatedHistory.slice(0, -1)
+      : curatedHistory;
+
     const splitPoint = findCompressSplitPoint(
-      curatedHistory,
+      historyForSplit,
       1 - COMPRESSION_PRESERVE_THRESHOLD,
     );
 
-    const historyToCompress = curatedHistory.slice(0, splitPoint);
-    const historyToKeep = curatedHistory.slice(splitPoint);
+    const historyToCompress = historyForSplit.slice(0, splitPoint);
+    const historyToKeep = historyForSplit.slice(splitPoint);
 
     if (historyToCompress.length === 0) {
       return {
@@ -184,15 +192,22 @@ export class ChatCompressionService {
     // Guard: if historyToCompress is too small relative to the total history,
     // skip compression. This prevents futile API calls where the model receives
     // almost no context and generates a useless "summary" that inflates tokens.
+    //
+    // Note: findCompressSplitPoint already computes charCounts internally but
+    // returns only the split index. We intentionally recompute here to keep
+    // the function signature simple; this is a minor, acceptable duplication.
     const compressCharCount = historyToCompress.reduce(
       (sum, c) => sum + JSON.stringify(c).length,
       0,
     );
-    const totalCharCount = curatedHistory.reduce(
+    const totalCharCount = historyForSplit.reduce(
       (sum, c) => sum + JSON.stringify(c).length,
       0,
     );
-    if (totalCharCount > 0 && compressCharCount / totalCharCount < 0.05) {
+    if (
+      totalCharCount > 0 &&
+      compressCharCount / totalCharCount < MIN_COMPRESSION_FRACTION
+    ) {
       return {
         newHistory: null,
         info: {


### PR DESCRIPTION
## TL;DR

Fix `/compress` for tool-heavy conversations by handling trailing orphaned `funcCall` messages during manual compression, preventing empty or near-empty compression requests, and simplifying the split-point logic.

## Root cause

In tool-heavy conversations, the history can end with a trailing `model` `funcCall` that is no longer actionable by the time a user manually runs `/compress`.

At that point:

1. `historyToKeep` still needs to start with a regular user message
2. `findCompressSplitPoint()` can legitimately return `0`
3. the trailing orphaned `funcCall` should not block compression, because manual `/compress` runs after the agent is idle
4. compression should never call the model with an empty or trivially small history slice

## What changed

1. **Strip orphaned trailing `funcCall` for forced compression only**
   - When `force=true` and the curated history ends with a trailing `model` `funcCall`, drop that final message before computing the split point.
   - This lets the existing split logic naturally compress the completed tool interaction history.

2. **Keep split-point logic strict and remove redundant fallback tracking**
   - `findCompressSplitPoint()` now relies on the primary valid user-starting split logic only.
   - Removed the redundant `lastToolCompletionSplitPoint` path.

3. **Guard against useless compression requests**
   - Return `NOOP` when `historyToCompress` is empty.
   - Keep the minimum compression threshold via `MIN_COMPRESSION_FRACTION = 0.05` so we skip compressing trivial slices.

4. **Expand test coverage**
   - Added coverage for orphaned trailing `funcCall` handling in forced compression.
   - Added coverage to confirm auto-compression does not treat active tool calls as orphaned.
   - Updated the split-point tests to match the cleaned-up logic.

## Reviewer test plan

1. Run:
   - `npx vitest run packages/core/src/services/chatCompressionService.test.ts`
2. Verify all 36 tests pass.
3. Optionally reproduce with a long tool-heavy conversation and manually run `/compress` after the agent becomes idle.

## Testing matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npx      | ✅  | ❓  | ❓  |
| npm run  | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2647
