### PR TITLE
fix: use config working directory for OpenAI logger path resolution in ACP mode

### DIFF
--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
@@ -66,6 +66,7 @@ const createConfig = (overrides: Record<string, unknown> = {}): Config => {
   return {
     getContentGeneratorConfig: () => configContent,
     getAuthType: () => configContent.authType as AuthType | undefined,
+    getWorkingDir: () => process.cwd(),
   } as Config;
 };
 

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -62,7 +62,10 @@ export class LoggingContentGenerator implements ContentGenerator {
     // Extract fields needed for initialization from passed config
     // (config.getContentGeneratorConfig() may not be available yet during refreshAuth)
     if (generatorConfig.enableOpenAILogging) {
-      this.openaiLogger = new OpenAILogger(generatorConfig.openAILoggingDir);
+      this.openaiLogger = new OpenAILogger(
+        generatorConfig.openAILoggingDir,
+        config.getWorkingDir(),
+      );
       this.schemaCompliance = generatorConfig.schemaCompliance;
     }
   }

--- a/packages/core/src/utils/openaiLogger.test.ts
+++ b/packages/core/src/utils/openaiLogger.test.ts
@@ -387,4 +387,86 @@ describe('OpenAILogger', () => {
       expect(logPath).toContain(specialPath);
     });
   });
+
+  describe('cwd parameter', () => {
+    it('should use provided cwd for default log directory instead of process.cwd()', async () => {
+      const customCwd = path.join(testTempDir, 'project-root');
+      await fs.mkdir(customCwd, { recursive: true });
+      const logger = new OpenAILogger(undefined, customCwd);
+      await logger.initialize();
+
+      const request = { test: 'request' };
+      const response = { test: 'response' };
+
+      const logPath = await logger.logInteraction(request, response);
+      const expectedDir = path.join(customCwd, 'logs', 'openai');
+      createdDirs.push(expectedDir);
+
+      expect(logPath).toContain(expectedDir);
+    });
+
+    it('should resolve relative customLogDir against provided cwd', async () => {
+      const customCwd = path.join(testTempDir, 'project-root-2');
+      await fs.mkdir(customCwd, { recursive: true });
+      const relativeDir = 'my-logs';
+      const logger = new OpenAILogger(relativeDir, customCwd);
+      await logger.initialize();
+
+      const request = { test: 'request' };
+      const response = { test: 'response' };
+
+      const logPath = await logger.logInteraction(request, response);
+      const expectedDir = path.resolve(customCwd, relativeDir);
+      createdDirs.push(expectedDir);
+
+      expect(logPath).toContain(expectedDir);
+    });
+
+    it('should not use cwd when customLogDir is an absolute path', async () => {
+      const customCwd = path.join(testTempDir, 'project-root-3');
+      const absoluteLogDir = path.join(testTempDir, 'absolute-logs');
+      const logger = new OpenAILogger(absoluteLogDir, customCwd);
+      await logger.initialize();
+
+      const request = { test: 'request' };
+      const response = { test: 'response' };
+
+      const logPath = await logger.logInteraction(request, response);
+      createdDirs.push(absoluteLogDir);
+
+      expect(logPath).toContain(absoluteLogDir);
+      expect(logPath).not.toContain(customCwd);
+    });
+
+    it('should not use cwd when customLogDir starts with ~', async () => {
+      const customCwd = path.join(testTempDir, 'project-root-4');
+      const logger = new OpenAILogger('~/test-openai-logs', customCwd);
+      await logger.initialize();
+
+      const request = { test: 'request' };
+      const response = { test: 'response' };
+
+      const logPath = await logger.logInteraction(request, response);
+      const expectedDir = path.join(os.homedir(), 'test-openai-logs');
+      createdDirs.push(expectedDir);
+
+      expect(logPath).toContain(expectedDir);
+      expect(logPath).not.toContain(customCwd);
+    });
+
+    it('should fall back to process.cwd() when cwd is not provided', async () => {
+      const relativeDir = 'test-relative-logs';
+      const logger = new OpenAILogger(relativeDir);
+      await logger.initialize();
+
+      const request = { test: 'request' };
+      const response = { test: 'response' };
+
+      const logPath = await logger.logInteraction(request, response);
+      const expectedDir = path.resolve(process.cwd(), relativeDir);
+      createdDirs.push(expectedDir);
+
+      expect(logPath).toContain(expectedDir);
+    });
+  });
 });

--- a/packages/core/src/utils/openaiLogger.ts
+++ b/packages/core/src/utils/openaiLogger.ts
@@ -22,8 +22,12 @@ export class OpenAILogger {
   /**
    * Creates a new OpenAI logger
    * @param customLogDir Optional custom log directory path (supports relative paths, absolute paths, and ~ expansion)
+   * @param cwd Optional working directory for resolving relative paths. Defaults to process.cwd().
+   *            In ACP mode, process.cwd() may be '/' (filesystem root), so callers should
+   *            pass the project working directory from Config.getWorkingDir().
    */
-  constructor(customLogDir?: string) {
+  constructor(customLogDir?: string, cwd?: string) {
+    const baseCwd = cwd || process.cwd();
     if (customLogDir) {
       // Resolve relative paths to absolute paths
       // Handle ~ expansion
@@ -31,12 +35,12 @@ export class OpenAILogger {
       if (customLogDir === '~' || customLogDir.startsWith('~/')) {
         resolvedPath = path.join(os.homedir(), customLogDir.slice(1));
       } else if (!path.isAbsolute(customLogDir)) {
-        // If it's a relative path, resolve it relative to current working directory
-        resolvedPath = path.resolve(process.cwd(), customLogDir);
+        // If it's a relative path, resolve it relative to provided working directory
+        resolvedPath = path.resolve(baseCwd, customLogDir);
       }
       this.logDir = path.normalize(resolvedPath);
     } else {
-      this.logDir = path.join(process.cwd(), 'logs', 'openai');
+      this.logDir = path.join(baseCwd, 'logs', 'openai');
     }
   }
 


### PR DESCRIPTION
## TLDR

Fix OpenAI logger failing to initialize in ACP mode (e.g., Zed editor) because `process.cwd()` returns `/` (filesystem root), causing `mkdir '/logs'` to fail with ENOENT.

Adds an optional `cwd` parameter to `OpenAILogger` constructor and passes `config.getWorkingDir()` from `LoggingContentGenerator`, so log directories are resolved relative to the project working directory instead of `process.cwd()`.

## Screenshots / Video Demo

N/A — no user-facing change in interactive CLI. This fixes an internal path resolution issue only observable in ACP mode.

## Dive Deeper

### Root Cause

In ACP mode (e.g., when launched by Zed editor), `process.cwd()` may return `/` (the filesystem root). The `OpenAILogger` constructor previously used `process.cwd()` to build the default log directory path (`logs/openai`), which resolved to `/logs/openai`. On macOS, creating directories at the filesystem root fails with `ENOENT`.

### Fix

- **`OpenAILogger`** (`packages/core/src/utils/openaiLogger.ts`): Added an optional `cwd` parameter to the constructor. When provided, it is used instead of `process.cwd()` for resolving the default log directory and relative custom paths. Falls back to `process.cwd()` when `cwd` is not provided (backward compatible).

- **`LoggingContentGenerator`** (`packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts`): Passes `config.getWorkingDir()` as the `cwd` parameter when constructing `OpenAILogger`, ensuring the correct project directory is used.

### Changes Summary

| File | Change |
|------|--------|
| `packages/core/src/utils/openaiLogger.ts` | Added optional `cwd` param to constructor |
| `packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts` | Pass `config.getWorkingDir()` to `OpenAILogger` |
| `packages/core/src/utils/openaiLogger.test.ts` | Added 5 test cases for `cwd` parameter behavior |
| `packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts` | Added `getWorkingDir` to config mock |

## Reviewer Test Plan

1. Enable OpenAI logging in settings (`enableOpenAILogging: true`)
2. Run Qwen Code in ACP mode (e.g., via Zed editor)
3. Verify no `Failed to initialize OpenAI logger` error occurs
4. Verify logs are written under the project's `logs/openai/` directory
5. Run unit tests: `npx vitest run packages/core/src/utils/openaiLogger.test.ts packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2671
