### PR TITLE
fix: @ file search stops working after selecting a slash command

### DIFF
--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.ts
@@ -417,6 +417,95 @@ describe('useCommandCompletion', () => {
     });
   });
 
+  describe('Completion mode detection', () => {
+    it('should switch to AT mode when typing @ after a slash command (#2518)', async () => {
+      setupMocks({
+        atSuggestions: [{ label: 'src/file.txt', value: 'src/file.txt' }],
+      });
+
+      const text = '/qc:create-issue @file';
+      renderHook(() =>
+        useCommandCompletion(
+          useTextBufferForTest(text),
+          testDirs,
+          testRootDir,
+          [],
+          mockCommandContext,
+          false,
+          mockConfig,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(useAtCompletion).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            enabled: true,
+            pattern: 'file',
+          }),
+        );
+      });
+    });
+
+    it('should remain in SLASH mode when no @ is typed after slash command', async () => {
+      setupMocks({
+        slashSuggestions: [{ label: 'help', value: 'help' }],
+      });
+
+      const text = '/help';
+      renderHook(() =>
+        useCommandCompletion(
+          useTextBufferForTest(text),
+          testDirs,
+          testRootDir,
+          [],
+          mockCommandContext,
+          false,
+          mockConfig,
+        ),
+      );
+
+      await waitFor(() => {
+        expect(useSlashCompletion).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            enabled: true,
+            query: '/help',
+          }),
+        );
+      });
+    });
+
+    it('should complete a file path when @ appears after a slash command', async () => {
+      setupMocks({
+        atSuggestions: [{ label: 'src/index.ts', value: 'src/index.ts' }],
+      });
+
+      const text = '/review @src/ind';
+      const { result } = renderHook(() => {
+        const textBuffer = useTextBufferForTest(text);
+        const completion = useCommandCompletion(
+          textBuffer,
+          testDirs,
+          testRootDir,
+          [],
+          mockCommandContext,
+          false,
+          mockConfig,
+        );
+        return { ...completion, textBuffer };
+      });
+
+      await waitFor(() => {
+        expect(result.current.suggestions.length).toBe(1);
+      });
+
+      act(() => {
+        result.current.handleAutocomplete(0);
+      });
+
+      expect(result.current.textBuffer.text).toBe('/review @src/index.ts ');
+    });
+  });
+
   describe('handleAutocomplete', () => {
     it('should complete a partial command', async () => {
       setupMocks({

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -74,15 +74,9 @@ export function useCommandCompletion(
   const { completionMode, query, completionStart, completionEnd } =
     useMemo(() => {
       const currentLine = buffer.lines[cursorRow] || '';
-      if (cursorRow === 0 && isSlashCommand(currentLine.trim())) {
-        return {
-          completionMode: CompletionMode.SLASH,
-          query: currentLine,
-          completionStart: 0,
-          completionEnd: currentLine.length,
-        };
-      }
 
+      // Check for @ completion first, so that typing @ after a slash command
+      // still triggers file search (see #2518).
       const codePoints = toCodePoints(currentLine);
       for (let i = cursorCol - 1; i >= 0; i--) {
         const char = codePoints[i];
@@ -119,6 +113,15 @@ export function useCommandCompletion(
             completionEnd: end,
           };
         }
+      }
+
+      if (cursorRow === 0 && isSlashCommand(currentLine.trim())) {
+        return {
+          completionMode: CompletionMode.SLASH,
+          query: currentLine,
+          completionStart: 0,
+          completionEnd: currentLine.length,
+        };
       }
 
       return {


### PR DESCRIPTION
## TLDR

Fix `@` file search not working after selecting a custom slash command (e.g., `/qc:create-issue`).

The completion mode detection in `useCommandCompletion` checked for SLASH mode before AT mode. When the line started with `/`, it immediately entered SLASH mode and never reached the `@` detection logic. This PR reorders the checks so `@` detection runs first, allowing file search to work correctly even after a slash command.

## Screenshots / Video Demo

N/A — CLI input behavior fix. The `@` file search suggestions now correctly appear when typing `@` after a slash command on the same line.

## Dive Deeper

**Root Cause**: In `useCommandCompletion.tsx`, the `useMemo` that determines `completionMode` had this order:
1. Check if line starts with `/` → return `CompletionMode.SLASH`
2. Scan backward from cursor for `@` → return `CompletionMode.AT`

When typing `/qc:create-issue @file`, the entire line starts with `/`, so `isSlashCommand()` returned `true` and the function returned SLASH mode immediately, never reaching the `@` scan.

**Fix**: Swap the detection order — scan for `@` first (from cursor position backward), then fall back to SLASH check. This ensures:
- `/help` → SLASH mode (no `@` found, works as before)
- `/qc:create-issue @file` → AT mode (`@` found near cursor, triggers file search)

## Reviewer Test Plan

1. Run `npm start` to enter the interactive CLI
2. Type `/` and select a custom slash command (e.g., `/qc:create-issue`)
3. On the same line, type `@` followed by a partial filename
4. Verify that file search suggestions appear
5. Also verify that plain `/` commands still show slash command suggestions
6. Run `npx vitest run packages/cli/src/ui/hooks/useCommandCompletion.test.ts` — all 17 tests pass

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2518
