### PR TITLE
docs: clarify envKey usage and add env field examples

### DIFF
--- a/docs/users/configuration/model-providers.md
+++ b/docs/users/configuration/model-providers.md
@@ -51,6 +51,10 @@ This auth type supports not only OpenAI's official API but also any OpenAI-compa
 
 ```json
 {
+  "env": {
+    "OPENAI_API_KEY": "sk-your-actual-openai-key-here",
+    "OPENROUTER_API_KEY": "sk-or-your-actual-openrouter-key-here"
+  },
   "modelProviders": {
     "openai": [
       {
@@ -117,6 +121,9 @@ This auth type supports not only OpenAI's official API but also any OpenAI-compa
 
 ```json
 {
+  "env": {
+    "ANTHROPIC_API_KEY": "sk-ant-your-actual-anthropic-key-here"
+  },
   "modelProviders": {
     "anthropic": [
       {
@@ -157,6 +164,9 @@ This auth type supports not only OpenAI's official API but also any OpenAI-compa
 
 ```json
 {
+  "env": {
+    "GEMINI_API_KEY": "AIza-your-actual-gemini-key-here"
+  },
   "modelProviders": {
     "gemini": [
       {
@@ -191,6 +201,11 @@ Most local inference servers (vLLM, Ollama, LM Studio, etc.) provide an OpenAI-c
 
 ```json
 {
+  "env": {
+    "OLLAMA_API_KEY": "ollama",
+    "VLLM_API_KEY": "not-needed",
+    "LMSTUDIO_API_KEY": "lm-studio"
+  },
   "modelProviders": {
     "openai": [
       {
@@ -254,6 +269,27 @@ export VLLM_API_KEY="not-needed"
 > [!note]
 >
 > The `extra_body` parameter is **only supported for OpenAI-compatible providers** (`openai`, `qwen-oauth`). It is ignored for Anthropic, and Gemini providers.
+
+> [!note]
+>
+> **About `envKey`**: The `envKey` field specifies the **name of an environment variable**, not the actual API key value. For the configuration to work, you need to ensure the corresponding environment variable is set with your real API key. There are two ways to do this:
+>
+> - **Option 1: Using a `.env` file** (recommended for security):
+>   ```bash
+>   # ~/.qwen/.env (or project root)
+>   OPENAI_API_KEY=sk-your-actual-key-here
+>   ```
+>   Be sure to add `.env` to your `.gitignore` to prevent accidentally committing secrets.
+> - **Option 2: Using the `env` field in `settings.json`** (as shown in the examples above):
+>   ```json
+>   {
+>     "env": {
+>       "OPENAI_API_KEY": "sk-your-actual-key-here"
+>     }
+>   }
+>   ```
+>
+> Each provider example includes an `env` field to illustrate how the API key should be configured.
 
 ## Alibaba Cloud Coding Plan
 


### PR DESCRIPTION
## TLDR

Clarify that `envKey` in `modelProviders` refers to the environment variable name, not the API key itself. Add `env` field examples to all provider configuration blocks to show users where to place their actual API keys.

## Screenshots / Video Demo

N/A — documentation-only change

## Dive Deeper

This PR improves the `model-providers.md` documentation to help users understand how `envKey` works:

1. **Added explanatory note**: A new note at the end of the "Configuration Examples by Auth Type" section explains that `envKey` specifies the environment variable name, not the API key value. It documents two ways to set environment variables:
   - Using a `.env` file (recommended for security)
   - Using the `env` field in `settings.json`

2. **Added `env` field to examples**: Each provider configuration example (OpenAI, Anthropic, Gemini, Local self-hosted) now includes an `env` field showing where the actual API keys should be configured.

This addresses confusion where users might mistakenly put the API key value directly in the `envKey` field instead of setting it as an environment variable.

## Reviewer Test Plan

1. Review the documentation changes in `docs/users/configuration/model-providers.md`
2. Verify the note is clearly placed after all provider examples
3. Check that each example includes appropriate `env` field configuration
4. Confirm the explanation is clear and actionable

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | N/A | N/A | N/A |
| npx      | N/A | N/A | N/A |
| Docker   | N/A | N/A | N/A |
| Podman   | -   | -   | -   |
| Seatbelt | N/A | -   | -   |

N/A — documentation-only change, no code testing required

## Linked issues / bugs

<!-- Add any linked issues here -->
