### PR TITLE
fix(shell): remove command substitution deny check from getDefaultPermission

### DIFF
--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -37,7 +37,6 @@ import {
   getCommandRoots,
   splitCommands,
   stripShellWrapper,
-  detectCommandSubstitution,
 } from '../utils/shell-utils.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import {
@@ -92,17 +91,11 @@ export class ShellToolInvocation extends BaseToolInvocation<
 
   /**
    * AST-based permission check for the shell command.
-   * - Command substitution → 'deny' (security)
    * - Read-only commands (via AST analysis) → 'allow'
    * - All other commands → 'ask'
    */
   override async getDefaultPermission(): Promise<PermissionDecision> {
     const command = stripShellWrapper(this.params.command);
-
-    // Security: command substitution ($(), ``, <(), >()) → deny
-    if (detectCommandSubstitution(command)) {
-      return 'deny';
-    }
 
     // AST-based read-only detection
     try {
@@ -598,18 +591,10 @@ ${processGroupNote}
 }
 
 function getCommandDescription(): string {
-  const cmd_substitution_warning =
-    '\n*** WARNING: Command substitution using $(), `` ` ``, <(), or >() is not allowed for security reasons.';
   if (os.platform() === 'win32') {
-    return (
-      'Exact command to execute as `cmd.exe /c <command>`' +
-      cmd_substitution_warning
-    );
+    return 'Exact command to execute as `cmd.exe /c <command>`';
   } else {
-    return (
-      'Exact bash command to execute as `bash -c <command>`' +
-      cmd_substitution_warning
-    );
+    return 'Exact bash command to execute as `bash -c <command>`';
   }
 }
 
@@ -662,9 +647,9 @@ export class ShellTool extends BaseDeclarativeTool<
   protected override validateToolParamValues(
     params: ShellToolParams,
   ): string | null {
-    // NOTE: Permission checks (command substitution, read-only detection, PM rules)
-    // are now handled at L3 (getDefaultPermission) and L4 (PM override) in
-    // coreToolScheduler. This method only performs pure parameter validation.
+    // NOTE: Permission checks (read-only detection, PM rules) are handled at
+    // L3 (getDefaultPermission) and L4 (PM override) in coreToolScheduler.
+    // This method only performs pure parameter validation.
     if (!params.command.trim()) {
       return 'Command cannot be empty.';
     }


### PR DESCRIPTION
## TLDR

Remove the `detectCommandSubstitution` check from `ShellToolInvocation.getDefaultPermission()` in `shell.ts`.

The command substitution denial is already enforced in two other places:
- `PermissionManager.isCommandAllowed()` ([permission-manager.ts](packages/core/src/permissions/permission-manager.ts))
- `checkCommandPermissions()` in [shell-utils.ts](packages/core/src/utils/shell-utils.ts)

Having a third deny point in `getDefaultPermission` is redundant. In addition, the `isShellCommandReadOnlyAST` function (called right after) already returns `false` for commands containing command substitution nodes, so the AST layer also provides the same protection. Removing the duplicate check simplifies the permission flow without weakening security.

Also removed the `*** WARNING` annotation from the `command` parameter description in the tool schema, which was surfaced to the model on every call.

## Screenshots / Video Demo

N/A — no user-facing change

## Dive Deeper

Before this change, `getDefaultPermission` had three branches:
1. Command substitution detected → `deny`
2. Read-only AST check passes → `allow`
3. Otherwise → `ask`

After this change:
1. Read-only AST check passes → `allow`
2. Otherwise → `ask`

The `deny` for command substitution is still enforced by `PermissionManager` and `checkCommandPermissions`, so the net security posture is unchanged.

## Reviewer Test Plan

1. Run `npm run test` — all unit tests should pass.
2. Try asking the agent to execute a command with command substitution (e.g. `echo $(whoami)`) — it should still be denied by the permission manager.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A