### PR TITLE
fix: make list_directory integration test more deterministic

### DIFF
--- a/integration-tests/list_directory.test.ts
+++ b/integration-tests/list_directory.test.ts
@@ -29,7 +29,7 @@ describe('list_directory', () => {
       50, // check every 50ms
     );
 
-    const prompt = `Can you list the files in the current directory.`;
+    const prompt = `Use the list_directory tool to list the files in the current directory.`;
 
     const result = await rig.run(prompt);
 


### PR DESCRIPTION
## TLDR

Fix flaky `list_directory` integration test by updating the prompt to explicitly request the `list_directory` tool. The original prompt was too open-ended, allowing the model to choose alternative methods like `glob` or `run_shell_command` with `ls`.

## Screenshots / Video Demo
No UI changes

## Dive Deeper
**Root cause:** The original prompt `Can you list the files in the current directory`. is an open-ended request. The model has multiple ways to accomplish this task:
- Use `list_directory` tool
- Use `glob` tool
- Use `run_shell_command` to execute `ls`

This caused intermittent test failures (flaky test).

**Solution:** Changed the prompt to Use the `list_directory` tool to list the files in the current directory. to explicitly specify the tool to use.


## Reviewer Test Plan
```
npm run test:e2e -- list_directory.test.ts
```

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs
https://github.com/QwenLM/qwen-code/issues/2751