### PR TITLE
fix: prevent subagent telemetry from overwriting main agent footer context

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -788,6 +788,48 @@ describe('GeminiChat', async () => {
       );
     });
 
+    it('should not update global telemetry when no telemetryService is provided (subagent isolation)', async () => {
+      // Simulate a subagent GeminiChat: created without a telemetryService
+      const subagentChat = new GeminiChat(mockConfig, config, []);
+
+      const response = (async function* () {
+        yield {
+          candidates: [
+            {
+              content: {
+                parts: [{ text: 'subagent response' }],
+                role: 'model',
+              },
+              finishReason: 'STOP',
+              index: 0,
+              safetyRatings: [],
+            },
+          ],
+          text: () => 'subagent response',
+          usageMetadata: {
+            promptTokenCount: 12000,
+            candidatesTokenCount: 500,
+            totalTokenCount: 12500,
+          },
+        } as unknown as GenerateContentResponse;
+      })();
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        response,
+      );
+
+      const stream = await subagentChat.sendMessageStream(
+        'test-model',
+        { message: 'subagent task' },
+        'prompt-id-subagent',
+      );
+      for await (const _ of stream) {
+        // consume stream
+      }
+
+      // The global uiTelemetryService must NOT be called by subagent chats
+      expect(uiTelemetryService.setLastPromptTokenCount).not.toHaveBeenCalled();
+    });
+
     it('should keep parts with thoughtSignature when consolidating history', async () => {
       const stream = (async function* () {
         yield {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -35,7 +35,6 @@ import {
   ContentRetryFailureEvent,
 } from '../telemetry/types.js';
 import type { UiTelemetryService } from '../telemetry/uiTelemetry.js';
-import { uiTelemetryService } from '../telemetry/uiTelemetry.js';
 
 const debugLogger = createDebugLogger('QWEN_CODE_CHAT');
 
@@ -659,15 +658,11 @@ export class GeminiChat {
         // Some providers omit total_tokens or return 0 in streaming usage chunks.
         const lastPromptTokenCount =
           usageMetadata.totalTokenCount || usageMetadata.promptTokenCount;
-        if (lastPromptTokenCount) {
-          (this.telemetryService ?? uiTelemetryService).setLastPromptTokenCount(
-            lastPromptTokenCount,
-          );
+        if (lastPromptTokenCount && this.telemetryService) {
+          this.telemetryService.setLastPromptTokenCount(lastPromptTokenCount);
         }
-        if (usageMetadata.cachedContentTokenCount) {
-          (
-            this.telemetryService ?? uiTelemetryService
-          ).setLastCachedContentTokenCount(
+        if (usageMetadata.cachedContentTokenCount && this.telemetryService) {
+          this.telemetryService.setLastCachedContentTokenCount(
             usageMetadata.cachedContentTokenCount,
           );
         }


### PR DESCRIPTION
## TLDR

Fix subagent token counts leaking into the main agent's footer context usage display. When multiple subagents run concurrently, the footer would flicker between their different token counts instead of showing the main agent's actual context usage.

Root cause: a bad merge in PR #1835 (`feat/context-usage`) overwrote PR #1912's correct telemetry isolation, replacing `this.telemetryService` guard with a `(this.telemetryService ?? uiTelemetryService)` fallback that let subagents write to the global singleton. This PR restores the original guard logic and removes the now-unused `uiTelemetryService` import from `geminiChat.ts`.

## Screenshots / Video Demo

<!--
Please attach a screenshot or short video showing your change in action.
This helps reviewers understand the change quickly and prioritize reviews.

- For bug fixes: show the before/after behavior.
- For features: show the new functionality in use.
- For refactors or internal changes with no visible effect: write "N/A — no user-facing change" and briefly explain why.

PRs with visual demos typically get reviewed much faster!
-->

## Dive Deeper

### How the bug was introduced

1. **PR #1912** (`feature/arena-agent-collaboration`, merged 2026-03-18 11:36 UTC) correctly introduced `telemetryService` as an optional param on `GeminiChat`, with the intent that subagent chats pass `undefined` to avoid polluting the main agent's display:
   ```typescript
   if (lastPromptTokenCount && this.telemetryService) {
     this.telemetryService.setLastPromptTokenCount(lastPromptTokenCount);
   }
   ```

2. **PR #1835** (`feat/context-usage`, merged 2026-03-18 13:58 UTC) merged main into its branch after #1912 landed. The merge conflict in `geminiChat.ts` was resolved incorrectly — it kept the old `uiTelemetryService` direct call.

3. A follow-up commit (`bb99755b21` "fix: resolve TypeScript errors") noticed `this.telemetryService` existed but wasn't used, and "fixed" it by creating the hybrid `(this.telemetryService ?? uiTelemetryService)` — reintroducing the global fallback.

### The fix

Restore PR #1912's original logic: only call `setLastPromptTokenCount` / `setLastCachedContentTokenCount` when `this.telemetryService` is provided. The main agent's `GeminiChat` (created in `client.ts`) explicitly passes `uiTelemetryService`, so its footer continues to work. Subagent `GeminiChat` instances (created in `agent-core.ts` with no telemetry param) simply don't update the global singleton.

## Reviewer Test Plan

1. **Unit tests pass:**
   ```bash
   cd packages/core && npx vitest run src/core/geminiChat.test.ts
   cd packages/core && npx vitest run src/core/client.test.ts
   ```

2. **Verify main agent footer still works:**
   - Start a normal conversation (no subagents)
   - Confirm the footer context % updates after each response

3. **Verify the fix:**
   - Launch qwen-code, give it a task that spawns multiple subagents (e.g. use the Agent tool 2-3 times in parallel), and observe the footer context usage — it should remain stable at the main agent's token count

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to PR #1912 and PR #1835 — this restores the telemetry isolation that #1912 introduced but #1835 accidentally overwrote during a bad merge conflict resolution.

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)
