### PR TITLE
fix: display ">100%" when context usage exceeds limit

### DIFF
--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -1814,6 +1814,11 @@ export default {
   // Context Usage Component
   // ============================================================================
   'Context Usage': 'Kontextnutzung',
+  '% used': '% verwendet',
+  '% context used': '% Kontext verwendet',
+  'Context exceeds limit! Use /compress or /clear to reduce.':
+    'Kontext überschreitet Limit! Verwenden Sie /compress oder /clear zum Reduzieren.',
+  'Use /compress or /clear': 'Verwenden Sie /compress oder /clear',
   'No API response yet. Send a message to see actual usage.':
     'Noch keine API-Antwort. Senden Sie eine Nachricht, um die tatsächliche Nutzung anzuzeigen.',
   'Estimated pre-conversation overhead':

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1861,6 +1861,11 @@ export default {
   // Context Usage Component
   // ============================================================================
   'Context Usage': 'Context Usage',
+  '% used': '% used',
+  '% context used': '% context used',
+  'Context exceeds limit! Use /compress or /clear to reduce.':
+    'Context exceeds limit! Use /compress or /clear to reduce.',
+  'Use /compress or /clear': 'Use /compress or /clear',
   'No API response yet. Send a message to see actual usage.':
     'No API response yet. Send a message to see actual usage.',
   'Estimated pre-conversation overhead': 'Estimated pre-conversation overhead',

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -1314,6 +1314,11 @@ export default {
   // Context Usage Component
   // ============================================================================
   'Context Usage': 'コンテキスト使用量',
+  '% used': '% 使用',
+  '% context used': '% コンテキスト使用',
+  'Context exceeds limit! Use /compress or /clear to reduce.':
+    'コンテキストが制限を超えています！/compress または /clear を使用して減らしてください。',
+  'Use /compress or /clear': '/compress または /clear を使用',
   'No API response yet. Send a message to see actual usage.':
     'API応答はありません。メッセージを送信して実際の使用量を確認してください。',
   'Estimated pre-conversation overhead': '推定事前会話オーバーヘッド',

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -1807,6 +1807,11 @@ export default {
   // Context Usage Component
   // ============================================================================
   'Context Usage': 'Uso do Contexto',
+  '% used': '% usado',
+  '% context used': '% contexto usado',
+  'Context exceeds limit! Use /compress or /clear to reduce.':
+    'Contexto excede o limite! Use /compress ou /clear para reduzir.',
+  'Use /compress or /clear': 'Use /compress ou /clear',
   'No API response yet. Send a message to see actual usage.':
     'Ainda não há resposta da API. Envie uma mensagem para ver o uso real.',
   'Estimated pre-conversation overhead': 'Sobrecarga estimada pré-conversa',

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -1740,6 +1740,11 @@ export default {
   // Context Usage Component
   // ============================================================================
   'Context Usage': 'Использование контекста',
+  '% used': '% использовано',
+  '% context used': '% контекста использовано',
+  'Context exceeds limit! Use /compress or /clear to reduce.':
+    'Контекст превышает лимит! Используйте /compress или /clear для уменьшения.',
+  'Use /compress or /clear': 'Используйте /compress или /clear',
   'No API response yet. Send a message to see actual usage.':
     'Пока нет ответа от API. Отправьте сообщение, чтобы увидеть фактическое использование.',
   'Estimated pre-conversation overhead':

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1677,6 +1677,11 @@ export default {
   // Context Usage
   // ============================================================================
   'Context Usage': '上下文使用情况',
+  '% used': '% 已用',
+  '% context used': '% 上下文已用',
+  'Context exceeds limit! Use /compress or /clear to reduce.':
+    '上下文超出限制！请使用 /compress 或 /clear 来减少上下文。',
+  'Use /compress or /clear': '使用 /compress 或 /clear',
   'Context window': '上下文窗口',
   Used: '已用',
   Free: '空闲',

--- a/packages/cli/src/ui/components/ContextUsageDisplay.tsx
+++ b/packages/cli/src/ui/components/ContextUsageDisplay.tsx
@@ -6,6 +6,17 @@
 
 import { Text } from 'ink';
 import { theme } from '../semantic-colors.js';
+import { t } from '../../i18n/index.js';
+
+/**
+ * Format percentage for display, showing ">100" when exceeding limit.
+ */
+function formatPercentageUsed(percentage: number): string {
+  if (percentage > 1) {
+    return '>100';
+  }
+  return (percentage * 100).toFixed(1);
+}
 
 export const ContextUsageDisplay = ({
   promptTokenCount,
@@ -21,9 +32,22 @@ export const ContextUsageDisplay = ({
   }
 
   const percentage = promptTokenCount / contextWindowSize;
-  const percentageUsed = (percentage * 100).toFixed(1);
+  const percentageUsed = formatPercentageUsed(percentage);
+  const isOverLimit = percentage > 1;
 
-  const label = terminalWidth < 100 ? '% used' : '% context used';
+  const label = terminalWidth < 100 ? t('% used') : t('% context used');
+
+  // Show warning when over limit
+  if (isOverLimit) {
+    return (
+      <>
+        <Text color={theme.status.error}>
+          {percentageUsed}
+          {label}
+        </Text>
+      </>
+    );
+  }
 
   return (
     <Text color={theme.text.secondary}>

--- a/packages/cli/src/ui/components/views/ContextUsage.tsx
+++ b/packages/cli/src/ui/components/views/ContextUsage.tsx
@@ -91,6 +91,18 @@ const ProgressBar: React.FC<{
 };
 
 /**
+ * Format percentage for display, showing ">100%" when exceeding limit.
+ */
+function formatPercentage(tokens: number, contextWindowSize: number): string {
+  if (contextWindowSize <= 0) return '0.0';
+  const percentage = (tokens / contextWindowSize) * 100;
+  if (percentage > 100) {
+    return '>100';
+  }
+  return percentage.toFixed(1);
+}
+
+/**
  * A row showing a category with its token count and percentage.
  */
 const CategoryRow: React.FC<{
@@ -99,9 +111,17 @@ const CategoryRow: React.FC<{
   tokens: number;
   contextWindowSize: number;
   symbolColor?: string;
-}> = ({ symbol, label, tokens, contextWindowSize, symbolColor }) => {
-  const percentage = ((tokens / contextWindowSize) * 100).toFixed(1);
-  const tokenStr = `${formatTokens(tokens)} ${t('tokens')} (${percentage}%)`;
+  isOverLimit?: boolean;
+}> = ({
+  symbol,
+  label,
+  tokens,
+  contextWindowSize,
+  symbolColor,
+  isOverLimit,
+}) => {
+  const percentageStr = formatPercentage(tokens, contextWindowSize);
+  const tokenStr = `${formatTokens(tokens)} ${t('tokens')} (${percentageStr}%)`;
 
   return (
     <Box width={CONTENT_WIDTH}>
@@ -112,7 +132,9 @@ const CategoryRow: React.FC<{
         <Text color={theme.text.primary}>{label}</Text>
       </Box>
       <Box flexGrow={1} justifyContent="flex-end">
-        <Text color={theme.text.secondary}>{tokenStr}</Text>
+        <Text color={isOverLimit ? theme.status.error : theme.text.secondary}>
+          {tokenStr}
+        </Text>
       </Box>
     </Box>
   );
@@ -158,6 +180,7 @@ export const ContextUsage: React.FC<ContextUsageProps> = ({
 }) => {
   const percentage =
     contextWindowSize > 0 ? (totalTokens / contextWindowSize) * 100 : 0;
+  const isOverLimit = percentage > 100;
 
   // Sort detail items by token count (descending) for better readability
   const sortedBuiltinTools = [...builtinTools].sort(
@@ -236,6 +259,14 @@ export const ContextUsage: React.FC<ContextUsageProps> = ({
               width={CONTENT_WIDTH}
             />
           </Box>
+          {/* Warning when context exceeds limit */}
+          {isOverLimit && (
+            <Box marginBottom={1}>
+              <Text color={theme.status.error}>
+                {t('Context exceeds limit! Use /compress or /clear to reduce.')}
+              </Text>
+            </Box>
+          )}
           <Box height={1} />
           {/* Legend — same layout as CategoryRow for alignment */}
           <CategoryRow
@@ -243,7 +274,8 @@ export const ContextUsage: React.FC<ContextUsageProps> = ({
             label={t('Used')}
             tokens={totalTokens}
             contextWindowSize={contextWindowSize}
-            symbolColor={theme.text.accent}
+            symbolColor={isOverLimit ? theme.status.error : theme.text.accent}
+            isOverLimit={isOverLimit}
           />
           <CategoryRow
             symbol={EMPTY}

--- a/packages/web-templates/src/export-html/src/components/MetadataSidebar.tsx
+++ b/packages/web-templates/src/export-html/src/components/MetadataSidebar.tsx
@@ -42,7 +42,10 @@ export const MetadataSidebar = ({ metadata }: MetadataSidebarProps) => (
         metadata.contextWindowSize !== undefined && (
           <MetadataItem
             label="Context"
-            value={`${metadata.contextUsagePercent}% of ${formatTokenLimit(metadata.contextWindowSize)}`}
+            value={`${metadata.contextUsagePercent > 100 ? '>100' : metadata.contextUsagePercent}% of ${formatTokenLimit(metadata.contextWindowSize)}`}
+            valueClass={
+              metadata.contextUsagePercent > 100 ? 'text-red' : undefined
+            }
           />
         )}
       {metadata.totalTokens !== undefined && (


### PR DESCRIPTION
## TLDR

Fix context usage display to show ">100%" when the percentage exceeds 100%, instead of showing incorrect values. Adds visual warning (red color) and a helpful message guiding users to use /compress or /clear commands when context exceeds the limit.
## Screenshots / Video Demo
before:
<img width="758" height="506" alt="截屏2026-03-31 17 30 56" src="https://github.com/user-attachments/assets/3254f27f-00b2-48f6-8a51-e6c6dca70514" />

<img width="760" height="502" alt="截屏2026-03-31 17 31 09" src="https://github.com/user-attachments/assets/c9afe752-d7af-4623-9cfe-e961af958a60" />

after:
<img width="875" height="516" alt="截屏2026-03-31 17 24 26" src="https://github.com/user-attachments/assets/d3846b46-cbac-49c1-bc3a-64d7798e39c4" />

<img width="876" height="462" alt="截屏2026-03-31 17 24 40" src="https://github.com/user-attachments/assets/83c499d6-b72f-45f6-826f-44c36bb84060" />


## Dive Deeper

When context window usage exceeds 100% (which can happen due to conversation history growing beyond the model's context limit), the previous implementation would display misleading values like "105.3%". This fix:
1. Displays ">100" instead of incorrect percentage - When usage exceeds 100%, the UI now shows ">100%" to clearly indicate overflow
2. Visual warning - Uses red color (error theme) to draw attention to the problem
3. Actionable guidance - Shows a message: "Context exceeds limit! Use /compress or /clear to reduce."
4. i18n support - Added translations for all supported languages (en, zh, de, ja, pt, ru)
5. Web export support - Also fixed the MetadataSidebar component in web-templates for HTML exports

## Reviewer Test Plan
1. Pull the branch and build: npm run build
2. Start the CLI: npm start
3. Have a long conversation or use a model with small context window to trigger >100% usage
4. Verify the status bar shows ">100%" in red
5. Run /context to see the detailed view with warning message

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅ | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/QwenLM/qwen-code/issues/2762