### PR TITLE
fix: add .qwen path replacement in markdown files during extension install

### DIFF
--- a/packages/core/src/extension/variables.test.ts
+++ b/packages/core/src/extension/variables.test.ts
@@ -263,6 +263,34 @@ describe('performVariableReplacement', () => {
     expect(result).not.toContain('```!');
   });
 
+  it('should replace .claude with .qwen in markdown files', () => {
+    const extDir = path.join(testDir, 'ext');
+    fs.mkdirSync(extDir, { recursive: true });
+
+    const mdContent = [
+      '---',
+      'description: "Cancel active loop"',
+      '---',
+      '',
+      '# Cancel',
+      '',
+      'Check if `.claude/loop.local.md` exists.',
+      'Remove the file: `rm .claude/loop.local.md`',
+      'Path: `$HOME/.claude/cache`',
+      'Local: `./.claude/local`',
+    ].join('\n');
+    fs.writeFileSync(path.join(extDir, 'cancel.md'), mdContent, 'utf-8');
+
+    performVariableReplacement(extDir);
+
+    const result = fs.readFileSync(path.join(extDir, 'cancel.md'), 'utf-8');
+    expect(result).toContain('.qwen/loop.local.md');
+    expect(result).toContain('rm .qwen/loop.local.md');
+    expect(result).toContain('$HOME/.qwen/cache');
+    expect(result).toContain('./.qwen/local');
+    expect(result).not.toContain('.claude/');
+  });
+
   it('should replace "role":"assistant" with "type":"assistant" in shell scripts', () => {
     const extDir = path.join(testDir, 'ext');
     fs.mkdirSync(extDir, { recursive: true });

--- a/packages/core/src/extension/variables.ts
+++ b/packages/core/src/extension/variables.ts
@@ -148,16 +148,24 @@ export function performVariableReplacement(extensionPath: string): void {
 
         // Replace Markdown shell syntax ```! ... ``` with system-recognized !{...} syntax
         // This regex finds code blocks with ! language identifier and captures their content
-        const updatedMdContent = updatedContent.replace(
+        const syntaxUpdatedContent = updatedContent.replace(
           /```!(?:\s*\n)?([\s\S]*?)\n*```/g,
           '!{$1}',
+        );
+
+        // Replace references to ".claude" directory with ".qwen" in markdown files
+        // Only match path references (e.g., ~/.claude/, $HOME/.claude, ./.claude/)
+        // Avoid matching URLs, comments, or string literals containing .claude
+        const updatedMdContent = syntaxUpdatedContent.replace(
+          /(\$\{?HOME\}?\/|~\/)?\.claude(\/|$)/g,
+          '$1.qwen$2',
         );
 
         // Only write if content was actually changed
         if (updatedMdContent !== content) {
           fs.writeFileSync(filePath, updatedMdContent, 'utf8');
           debugLogger.debug(
-            `Updated variables and syntax in file: ${filePath}`,
+            `Updated variables, syntax, and .claude paths in file: ${filePath}`,
           );
         }
       } catch (error) {


### PR DESCRIPTION
## TLDR

Added .qwen path replacement in markdown files during extension install. Previously, only shell scripts (.sh) had this conversion, causing markdown files like cancel-ralph.md and help.md to retain incorrect .claude paths.

## Screenshots / Video Demo



https://github.com/user-attachments/assets/360b5cf7-bf82-4593-b1d3-6d72db030f5e




## Dive Deeper

The `performVariableReplacement` function in `variables.ts` processes extension files during installation to convert legacy paths. It was replacing `.claude` → `.qwen` only in shell scripts (.sh), but markdown files (.md) were missing this conversion.

This fix adds the same regex pattern `/(\$\{?HOME\}?\/|~\/)?\.claude(\/|$)/g` to markdown file processing, ensuring consistent path replacement across all extension files.

## Reviewer Test Plan

 1. Pull the branch and run tests: `npm run test`
 2. Verify the new test case should replace .claude with .qwen in markdown files passes
 3. Optionally: Install a Claude extension and check that .md files have .qwen paths instead of .claude


## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/QwenLM/qwen-code/issues/2657
