### PR TITLE
fix(vscode): inherit model selection for new chat tabs

### DIFF
--- a/packages/vscode-ide-companion/src/commands/index.test.ts
+++ b/packages/vscode-ide-companion/src/commands/index.test.ts
@@ -70,6 +70,7 @@ describe('registerNewCommands', () => {
     const provider = {
       show: vi.fn().mockResolvedValue(undefined),
       createNewSession: vi.fn().mockResolvedValue(undefined),
+      setInitialModelId: vi.fn(),
     };
 
     registerNewCommands(
@@ -80,10 +81,13 @@ describe('registerNewCommands', () => {
       () => provider as never,
     );
 
-    await getRegisteredHandler(openNewChatTabCommand)();
+    await getRegisteredHandler(openNewChatTabCommand)({
+      initialModelId: 'glm-5',
+    });
 
     expect(provider.show).toHaveBeenCalledTimes(1);
     expect(provider.createNewSession).not.toHaveBeenCalled();
+    expect(provider.setInitialModelId).toHaveBeenCalledWith('glm-5');
   });
 
   it('focusChat focuses the secondary sidebar when it is supported', async () => {

--- a/packages/vscode-ide-companion/src/commands/index.ts
+++ b/packages/vscode-ide-companion/src/commands/index.ts
@@ -90,10 +90,14 @@ export function registerNewCommands(
 
   // Open New Chat Tab: always create a new editor tab
   disposables.push(
-    vscode.commands.registerCommand(openNewChatTabCommand, async () => {
-      const provider = createWebViewProvider();
-      await provider.show();
-    }),
+    vscode.commands.registerCommand(
+      openNewChatTabCommand,
+      async (args?: { initialModelId?: string }) => {
+        const provider = createWebViewProvider();
+        provider.setInitialModelId(args?.initialModelId);
+        await provider.show();
+      },
+    ),
   );
 
   disposables.push(

--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -958,7 +958,9 @@ export const App: React.FC = () => {
       <ChatHeader
         currentSessionTitle={sessionManagement.currentSessionTitle}
         onLoadSessions={sessionManagement.handleLoadQwenSessions}
-        onNewSession={sessionManagement.handleNewQwenSession}
+        onNewSession={() =>
+          sessionManagement.handleNewQwenSession(modelInfo?.modelId ?? null)
+        }
       />
 
       <div

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
@@ -12,6 +12,9 @@ const { mockProcessImageAttachments, mockShowErrorMessage } = vi.hoisted(
     mockShowErrorMessage: vi.fn(),
   }),
 );
+const { mockExecuteCommand } = vi.hoisted(() => ({
+  mockExecuteCommand: vi.fn(),
+}));
 
 vi.mock('vscode', () => ({
   window: {
@@ -19,7 +22,7 @@ vi.mock('vscode', () => ({
     showErrorMessage: mockShowErrorMessage,
   },
   commands: {
-    executeCommand: vi.fn(),
+    executeCommand: mockExecuteCommand,
   },
   workspace: {
     workspaceFolders: [{ uri: { fsPath: '/workspace' } }],
@@ -45,6 +48,27 @@ describe('SessionMessageHandler', () => {
       displayText: '',
       savedImageCount: 0,
       promptImages: [],
+    });
+  });
+
+  it('forwards the active model when opening a new chat tab', async () => {
+    const handler = new SessionMessageHandler(
+      {
+        isConnected: true,
+        currentSessionId: 'session-1',
+      } as never,
+      {} as never,
+      null,
+      vi.fn(),
+    );
+
+    await handler.handle({
+      type: 'openNewChatTab',
+      data: { modelId: 'glm-5' },
+    });
+
+    expect(mockExecuteCommand).toHaveBeenCalledWith('qwenCode.openNewChatTab', {
+      initialModelId: 'glm-5',
     });
   });
 

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
@@ -100,7 +100,13 @@ export class SessionMessageHandler extends BaseMessageHandler {
         // This does not alter the current conversation in this tab; the new tab
         // will initialize its own state and (optionally) create a new session.
         try {
-          await vscode.commands.executeCommand('qwenCode.openNewChatTab');
+          const modelId =
+            typeof data?.modelId === 'string' && data.modelId.trim().length > 0
+              ? data.modelId.trim()
+              : undefined;
+          await vscode.commands.executeCommand('qwenCode.openNewChatTab', {
+            initialModelId: modelId,
+          });
         } catch (error) {
           console.error(
             '[SessionMessageHandler] Failed to open new chat tab:',

--- a/packages/vscode-ide-companion/src/webview/hooks/session/useSessionManagement.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/session/useSessionManagement.ts
@@ -71,10 +71,20 @@ export const useSessionManagement = (vscode: VSCodeAPI) => {
   /**
    * Create new session
    */
-  const handleNewQwenSession = useCallback(() => {
-    vscode.postMessage({ type: 'openNewChatTab', data: {} });
-    setShowSessionSelector(false);
-  }, [vscode]);
+  const handleNewQwenSession = useCallback(
+    (modelId?: string | null) => {
+      const trimmedModelId =
+        typeof modelId === 'string' && modelId.trim().length > 0
+          ? modelId.trim()
+          : undefined;
+      vscode.postMessage({
+        type: 'openNewChatTab',
+        data: trimmedModelId ? { modelId: trimmedModelId } : {},
+      });
+      setShowSessionSelector(false);
+    },
+    [vscode],
+  );
 
   /**
    * Switch session

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.test.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.test.ts
@@ -52,6 +52,9 @@ vi.mock('../../services/qwenAgentManager.js', () => ({
   QwenAgentManager: class {
     isConnected = false;
     currentSessionId = null;
+    connect = vi.fn();
+    createNewSession = vi.fn();
+    setModelFromUi = vi.fn();
     onMessage = vi.fn();
     onStreamChunk = vi.fn();
     onThoughtChunk = vi.fn();
@@ -74,6 +77,10 @@ vi.mock('../../services/qwenAgentManager.js', () => ({
 vi.mock('../../services/conversationStore.js', () => ({
   ConversationStore: class {
     constructor(_context: unknown) {}
+    createConversation = vi.fn().mockResolvedValue({
+      id: 'conversation-1',
+      messages: [],
+    });
   },
 }));
 
@@ -102,6 +109,8 @@ vi.mock('./MessageHandler.js', () => ({
     setLoginHandler = vi.fn();
     setPermissionHandler = vi.fn();
     setAskUserQuestionHandler = vi.fn();
+    setCurrentConversationId = vi.fn();
+    getCurrentConversationId = vi.fn(() => 'conversation-1');
     setupFileWatchers = vi.fn(() => ({ dispose: vi.fn() }));
     appendStreamContent = vi.fn();
     route = vi.fn();
@@ -286,5 +295,49 @@ describe('WebViewProvider.attachToView', () => {
       },
     });
     expect(panelPostMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('WebViewProvider initial model inheritance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPanel.mockReturnValue(null);
+  });
+
+  it('applies the requested initial model after creating a new session', async () => {
+    const provider = new WebViewProvider(
+      { subscriptions: [] } as never,
+      { fsPath: '/extension-root' } as never,
+    );
+    provider.setInitialModelId('glm-5');
+
+    const agentManager = (
+      provider as unknown as {
+        agentManager: {
+          currentSessionId: string | null;
+          createNewSession: ReturnType<typeof vi.fn>;
+          setModelFromUi: ReturnType<typeof vi.fn>;
+        };
+      }
+    ).agentManager;
+    agentManager.createNewSession.mockResolvedValue('session-1');
+    agentManager.setModelFromUi.mockResolvedValue({
+      modelId: 'glm-5',
+      name: 'GLM-5',
+    });
+
+    await (
+      provider as unknown as {
+        loadCurrentSessionMessages: (options?: {
+          autoAuthenticate?: boolean;
+        }) => Promise<boolean>;
+      }
+    ).loadCurrentSessionMessages();
+
+    expect(agentManager.createNewSession).toHaveBeenCalledWith(
+      '/workspace-root',
+      { autoAuthenticate: true },
+    );
+    expect(agentManager.setModelFromUi).toHaveBeenCalledWith('glm-5');
   });
 });

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
@@ -47,6 +47,8 @@ export class WebViewProvider {
   private authState: boolean | null = null;
   /** Cached available models for re-sending on webview ready */
   private cachedAvailableModels: ModelInfo[] | null = null;
+  /** Model to apply once a new editor-tab session is initialized */
+  private initialModelId: string | null = null;
   /** Reference to a WebviewView webview (sidebar/panel/secondary) when attached via attachToView */
   private attachedWebview: vscode.Webview | null = null;
   /**
@@ -763,6 +765,13 @@ export class WebViewProvider {
     await this.attemptAuthStateRestoration();
   }
 
+  setInitialModelId(modelId: string | null | undefined): void {
+    this.initialModelId =
+      typeof modelId === 'string' && modelId.trim().length > 0
+        ? modelId.trim()
+        : null;
+  }
+
   /**
    * Attempt to restore authentication state and initialize connection
    * This is called when the webview is first shown
@@ -1077,6 +1086,10 @@ export class WebViewProvider {
         sessionReady = true;
       }
 
+      if (sessionReady) {
+        await this.applyInitialModelSelection();
+      }
+
       await this.initializeEmptyConversation();
     } catch (_error) {
       const errorMsg = getErrorMessage(_error);
@@ -1092,6 +1105,24 @@ export class WebViewProvider {
     }
 
     return sessionReady;
+  }
+
+  private async applyInitialModelSelection(): Promise<void> {
+    if (!this.initialModelId) {
+      return;
+    }
+
+    const modelId = this.initialModelId;
+    this.initialModelId = null;
+
+    try {
+      await this.agentManager.setModelFromUi(modelId);
+    } catch (error) {
+      console.warn(
+        '[WebViewProvider] Failed to apply initial model selection:',
+        error,
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## TLDR

Preserve the active model selection when opening a new VS Code chat tab so new panes no longer fall back to the default model.

## Screenshots / Video Demo

N/A — this is a small VS Code companion behavior fix. No visual capture was recorded in this CLI workflow.

## Dive Deeper

The bug was caused by dropping the selected `modelId` when the webview requested `openNewChatTab`. The new editor-tab provider always booted a fresh session with default model state.

This change threads the active `modelId` through the new-tab flow:

- `App` passes the current pane model into the new-session action
- `useSessionManagement` includes that model in the `openNewChatTab` message
- `SessionMessageHandler` forwards it to `qwenCode.openNewChatTab`
- `WebViewProvider` stores the requested model and applies it after the new session is ready

Regression coverage was added for the message handler, command registration, and provider initialization flow.

## Reviewer Test Plan

1. Open the VS Code companion in an editor chat tab.
2. Change the model from the default to another available model such as `glm-5`.
3. Open a new chat tab from the current pane.
4. Confirm the new tab shows the same selected model instead of resetting to the default.
5. Run:
   - `npm --workspace packages/vscode-ide-companion test -- src/commands/index.test.ts src/webview/handlers/SessionMessageHandler.test.ts src/webview/providers/WebViewProvider.test.ts`
   - `npm --workspace packages/vscode-ide-companion run check-types`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | -   | -   | -   |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

## Linked issues / bugs

Resolves #2794
