### PR TITLE
fix: improve ACP connection reliability with spawn retry and auto-reconnect

### DIFF
--- a/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
+++ b/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
@@ -294,6 +294,16 @@ export class QwenAgentManager {
         console.warn('[QwenAgentManager] onInitialized parse error:', err);
       }
     };
+
+    this.connection.onDisconnected = (
+      code: number | null,
+      signal: string | null,
+    ) => {
+      console.log(
+        `[QwenAgentManager] Process disconnected (code: ${code}, signal: ${signal})`,
+      );
+      this.callbacks.onDisconnected?.(code, signal);
+    };
   }
 
   /**
@@ -345,6 +355,23 @@ export class QwenAgentManager {
       });
     }
     return res;
+  }
+
+  /**
+   * Reconnect after unexpected disconnect.
+   * Re-spawns the ACP process and creates a new session.
+   */
+  async reconnect(
+    cliEntryPath: string,
+    options?: AgentConnectOptions,
+  ): Promise<QwenConnectionResult> {
+    console.log('[QwenAgentManager] Attempting reconnection...');
+    try {
+      this.connection.disconnect();
+    } catch (_e) {
+      // Already disconnected
+    }
+    return this.connect(this.currentWorkingDir, cliEntryPath, options);
   }
 
   /**
@@ -1409,6 +1436,15 @@ export class QwenAgentManager {
   onAvailableModels(callback: (models: ModelInfo[]) => void): void {
     this.callbacks.onAvailableModels = callback;
     this.sessionUpdateHandler.updateCallbacks(this.callbacks);
+  }
+
+  /**
+   * Register callback for unexpected process disconnection
+   */
+  onDisconnected(
+    callback: (code: number | null, signal: string | null) => void,
+  ): void {
+    this.callbacks.onDisconnected = callback;
   }
 
   /**

--- a/packages/vscode-ide-companion/src/services/qwenConnectionHandler.test.ts
+++ b/packages/vscode-ide-companion/src/services/qwenConnectionHandler.test.ts
@@ -133,4 +133,53 @@ describe('QwenConnectionHandler', () => {
       expect(connectArgs[2]).not.toContain('--proxy');
     });
   });
+
+  describe('connect retry logic', () => {
+    beforeEach(() => {
+      mockGetConfiguration.mockReturnValue({
+        get: () => undefined,
+      });
+      // Speed up tests by mocking setTimeout-based delays
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('succeeds on first attempt without retry', async () => {
+      await handler.connect(mockConnection, '/workspace', '/path/to/cli.js');
+
+      expect(mockConnection.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries connect on spawn failure and succeeds on second attempt', async () => {
+      (mockConnection.connect as ReturnType<typeof vi.fn>)
+        .mockRejectedValueOnce(
+          new Error(
+            'Qwen ACP process failed to start (exit code: null, signal: SIGTERM)',
+          ),
+        )
+        .mockResolvedValueOnce(undefined);
+
+      await handler.connect(mockConnection, '/workspace', '/path/to/cli.js');
+
+      expect(mockConnection.connect).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws after exhausting all connect retry attempts (3 attempts)', async () => {
+      const spawnError = new Error(
+        'Qwen ACP process failed to start (exit code: null, signal: SIGTERM)',
+      );
+      (mockConnection.connect as ReturnType<typeof vi.fn>).mockRejectedValue(
+        spawnError,
+      );
+
+      await expect(
+        handler.connect(mockConnection, '/workspace', '/path/to/cli.js'),
+      ).rejects.toThrow(spawnError);
+
+      expect(mockConnection.connect).toHaveBeenCalledTimes(3);
+    });
+  });
 });

--- a/packages/vscode-ide-companion/src/services/qwenConnectionHandler.ts
+++ b/packages/vscode-ide-companion/src/services/qwenConnectionHandler.ts
@@ -85,7 +85,30 @@ export class QwenConnectionHandler {
       );
     }
 
-    await connection.connect(cliEntryPath!, workingDir, extraArgs);
+    // Retry loop for connection.connect() to handle transient spawn failures
+    // (e.g., SIGTERM during the 1-second startup grace period)
+    const maxConnectAttempts = 3;
+    for (let attempt = 1; attempt <= maxConnectAttempts; attempt++) {
+      try {
+        console.log(
+          `[QwenAgentManager] Connecting to ACP process (attempt ${attempt}/${maxConnectAttempts})...`,
+        );
+        await connection.connect(cliEntryPath!, workingDir, extraArgs);
+        console.log('[QwenAgentManager] ACP process connected successfully');
+        break;
+      } catch (connectError) {
+        console.error(
+          `[QwenAgentManager] Connect attempt ${attempt} failed:`,
+          getErrorMessage(connectError),
+        );
+        if (attempt === maxConnectAttempts) {
+          throw connectError;
+        }
+        const delay = Math.min(1000 * Math.pow(2, attempt - 1), 4000);
+        console.log(`[QwenAgentManager] Retrying connect in ${delay}ms...`);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
 
     // Try to restore existing session or create new session
     // Note: Auto-restore on connect is disabled to avoid surprising loads

--- a/packages/vscode-ide-companion/src/types/chatTypes.ts
+++ b/packages/vscode-ide-companion/src/types/chatTypes.ts
@@ -78,6 +78,7 @@ export interface QwenAgentCallbacks {
   onModelChanged?: (model: ModelInfo) => void;
   onAvailableCommands?: (commands: AvailableCommand[]) => void;
   onAvailableModels?: (models: ModelInfo[]) => void;
+  onDisconnected?: (code: number | null, signal: string | null) => void;
 }
 
 export interface ToolCallUpdate {

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.test.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.test.ts
@@ -67,6 +67,7 @@ vi.mock('../../services/qwenAgentManager.js', () => ({
     onPlan = vi.fn();
     onPermissionRequest = vi.fn();
     onAskUserQuestion = vi.fn();
+    onDisconnected = vi.fn();
     disconnect = vi.fn();
   },
 }));

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
@@ -57,6 +57,7 @@ export class WebViewProvider {
   private isViewHost = false;
   /** Guards against concurrent auth-restore / connection init */
   private initializationPromise: Promise<void> | null = null;
+  private isReconnecting = false;
 
   constructor(
     private context: vscode.ExtensionContext,
@@ -437,6 +438,16 @@ export class WebViewProvider {
         });
       },
     );
+
+    this.agentManager.onDisconnected((code, signal) => {
+      console.log(
+        `[WebViewProvider] Agent disconnected (code: ${code}, signal: ${signal})`,
+      );
+      // Only auto-reconnect for unexpected disconnects
+      if (this.agentInitialized && !this.isReconnecting) {
+        this.attemptAutoReconnect();
+      }
+    });
   }
 
   /**
@@ -963,6 +974,53 @@ export class WebViewProvider {
         }
       },
     );
+  }
+
+  /**
+   * Attempt to automatically reconnect after unexpected ACP process death.
+   * Uses exponential backoff with a maximum number of attempts.
+   */
+  private async attemptAutoReconnect(): Promise<void> {
+    if (this.isReconnecting) {
+      return;
+    }
+    this.isReconnecting = true;
+    this.agentInitialized = false;
+
+    const maxAttempts = 3;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      console.log(
+        `[WebViewProvider] Auto-reconnect attempt ${attempt}/${maxAttempts}`,
+      );
+
+      const delay = Math.min(1000 * Math.pow(2, attempt - 1), 5000);
+      await new Promise((resolve) => setTimeout(resolve, delay));
+
+      try {
+        await this.doInitializeAgentConnection();
+        console.log('[WebViewProvider] Auto-reconnect succeeded');
+        this.isReconnecting = false;
+        return;
+      } catch (error) {
+        console.error(
+          `[WebViewProvider] Auto-reconnect attempt ${attempt} failed:`,
+          error,
+        );
+      }
+    }
+
+    // All attempts exhausted
+    this.isReconnecting = false;
+    console.error('[WebViewProvider] Auto-reconnect failed after all attempts');
+
+    this.sendMessageToWebView({
+      type: 'agentConnectionError',
+      data: {
+        message:
+          'Lost connection to Qwen agent and auto-reconnect failed. Please use the refresh button to try again.',
+      },
+    });
   }
 
   /**


### PR DESCRIPTION
## TLDR

Improve ACP connection reliability by adding spawn retry logic and automatic reconnection when the ACP process dies unexpectedly.

## Screenshots / Video Demo

N/A — no user-facing UI change. This is a resilience improvement for the ACP connection layer. When the ACP process crashes, users will now see an automatic reconnection attempt instead of a silent failure, and a clear error message if reconnection fails.

## Dive Deeper

This PR addresses connection reliability issues where the ACP process could fail to start (e.g., SIGTERM during the 1-second startup grace period) or die unexpectedly during a session.

**Three key changes:**

1. **Spawn retry with exponential backoff** (`qwenConnectionHandler.ts`): `connection.connect()` now retries up to 3 times with exponential backoff (1s, 2s, 4s) on transient spawn failures, instead of failing immediately.

2. **Disconnect event propagation** (`qwenAgentManager.ts` + `chatTypes.ts`): Added `onDisconnected` callback that fires when the ACP child process exits unexpectedly. This event propagates from the connection layer through `QwenAgentManager` to `WebViewProvider`.

3. **Auto-reconnect on unexpected disconnect** (`WebViewProvider.ts`): When an initialized agent disconnects unexpectedly, `WebViewProvider` automatically attempts to re-establish the connection (up to 3 attempts with exponential backoff). If all attempts fail, a user-facing error message is shown prompting them to use the refresh button.

## Reviewer Test Plan

1. Pull the branch and run `npm run test` in `packages/vscode-ide-companion` — new tests cover the retry logic.
2. To manually test spawn retry: temporarily break the CLI entry path or add a short delay/kill in the spawn process, and observe retry logs in the Output panel.
3. To manually test auto-reconnect: start a session, then kill the ACP child process (`kill <pid>`), and verify:
   - Console logs show reconnect attempts
   - Connection re-establishes automatically
   - If you kill it repeatedly to exhaust retries, the `agentConnectionError` message appears in the webview

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Reverts the revert in #2792 (which reverted #2666), reimplementing the reconnect logic with a more robust approach that includes spawn-level retry.
