### PR TITLE
feat(tools): add Jupyter notebook read/edit support

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -67,6 +67,7 @@ import { LspTool } from '../tools/lsp.js';
 import { CronCreateTool } from '../tools/cron-create.js';
 import { CronListTool } from '../tools/cron-list.js';
 import { CronDeleteTool } from '../tools/cron-delete.js';
+import { NotebookEditTool } from '../tools/notebook-edit.js';
 import type { LspClient } from '../lsp/types.js';
 
 // Other modules
@@ -2207,6 +2208,7 @@ export class Config {
 
     await registerCoreTool(GlobTool, this);
     await registerCoreTool(EditTool, this);
+    await registerCoreTool(NotebookEditTool, this);
     await registerCoreTool(WriteFileTool, this);
     await registerCoreTool(ShellTool, this);
     await registerCoreTool(MemoryTool);

--- a/packages/core/src/tools/notebook-edit.ts
+++ b/packages/core/src/tools/notebook-edit.ts
@@ -1,0 +1,426 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as Diff from 'diff';
+import type {
+  ToolCallConfirmationDetails,
+  ToolEditConfirmationDetails,
+  ToolInvocation,
+  ToolLocation,
+  ToolResult,
+} from './tools.js';
+import type { PermissionDecision } from '../permissions/types.js';
+import { BaseDeclarativeTool, Kind, ToolConfirmationOutcome } from './tools.js';
+import { ToolErrorType } from './tool-error.js';
+import { makeRelative, shortenPath } from '../utils/paths.js';
+import { isNodeError } from '../utils/errors.js';
+import type { Config } from '../config/config.js';
+import { ApprovalMode } from '../config/config.js';
+import { DEFAULT_DIFF_OPTIONS, getDiffStat } from './diffOptions.js';
+import { ToolNames, ToolDisplayNames } from './tool-names.js';
+import { logFileOperation } from '../telemetry/loggers.js';
+import { FileOperationEvent } from '../telemetry/types.js';
+import { FileOperation } from '../telemetry/metrics.js';
+import { parseNotebook, findCellIndex } from '../utils/notebookUtils.js';
+import type { NotebookCell } from '../utils/notebookUtils.js';
+import { IdeClient } from '../ide/ide-client.js';
+import { detectLineEnding } from '../services/fileSystemService.js';
+import type { LineEnding } from '../services/fileSystemService.js';
+
+/**
+ * Parameters for the NotebookEdit tool
+ */
+export interface NotebookEditToolParams {
+  /** Absolute path to the .ipynb file */
+  notebook_path: string;
+  /** Cell ID or "cell-N" index. Required for replace/delete. For insert, new cell goes after this cell (or at start if omitted). */
+  cell_id?: string;
+  /** The new source content for the cell */
+  new_source: string;
+  /** Cell type: code or markdown. Required for insert mode. */
+  cell_type?: 'code' | 'markdown';
+  /** Edit mode: replace (default), insert, or delete */
+  edit_mode?: 'replace' | 'insert' | 'delete';
+}
+
+class NotebookEditToolInvocation
+  implements ToolInvocation<NotebookEditToolParams, ToolResult>
+{
+  constructor(
+    private readonly config: Config,
+    public params: NotebookEditToolParams,
+  ) {}
+
+  toolLocations(): ToolLocation[] {
+    return [{ path: this.params.notebook_path }];
+  }
+
+  async getDefaultPermission(): Promise<PermissionDecision> {
+    return 'ask';
+  }
+
+  getDescription(): string {
+    const relativePath = makeRelative(
+      this.params.notebook_path,
+      this.config.getTargetDir(),
+    );
+    const mode = this.params.edit_mode ?? 'replace';
+    const cellRef = this.params.cell_id ?? 'start';
+    return `${shortenPath(relativePath)} (${mode} cell ${cellRef})`;
+  }
+
+  async getConfirmationDetails(
+    abortSignal: AbortSignal,
+  ): Promise<ToolCallConfirmationDetails> {
+    let originalContent: string;
+    try {
+      originalContent = await fs.promises.readFile(
+        this.params.notebook_path,
+        'utf-8',
+      );
+    } catch (err) {
+      if (abortSignal.aborted) throw err;
+      throw new Error(
+        `Cannot read notebook: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    let newContent: string;
+    try {
+      newContent = this.applyNotebookEdit(originalContent);
+    } catch (err) {
+      if (abortSignal.aborted) throw err;
+      throw new Error(
+        `Edit error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    const fileName = path.basename(this.params.notebook_path);
+    const fileDiff = Diff.createPatch(
+      fileName,
+      originalContent,
+      newContent,
+      'Current',
+      'Proposed',
+      DEFAULT_DIFF_OPTIONS,
+    );
+
+    const approvalMode = this.config.getApprovalMode();
+    const ideClient = await IdeClient.getInstance();
+    const ideConfirmation =
+      this.config.getIdeMode() &&
+      ideClient.isDiffingEnabled() &&
+      approvalMode !== ApprovalMode.AUTO_EDIT &&
+      approvalMode !== ApprovalMode.YOLO
+        ? ideClient.openDiff(this.params.notebook_path, newContent)
+        : undefined;
+
+    const confirmationDetails: ToolEditConfirmationDetails = {
+      type: 'edit',
+      title: `Confirm Notebook Edit: ${shortenPath(makeRelative(this.params.notebook_path, this.config.getTargetDir()))}`,
+      fileName,
+      filePath: this.params.notebook_path,
+      fileDiff,
+      originalContent,
+      newContent,
+      onConfirm: async (outcome: ToolConfirmationOutcome) => {
+        if (outcome === ToolConfirmationOutcome.ProceedAlways) {
+          this.config.setApprovalMode(ApprovalMode.AUTO_EDIT);
+        }
+        if (ideConfirmation) {
+          const result = await ideConfirmation;
+          if (result.status === 'accepted' && result.content) {
+            // IDE modified the content; we'll use it directly in execute
+          }
+        }
+      },
+      ideConfirmation,
+    };
+    return confirmationDetails;
+  }
+
+  /**
+   * Apply the notebook edit to the raw JSON content and return the new content string.
+   */
+  private applyNotebookEdit(rawContent: string): string {
+    const notebook = parseNotebook(rawContent);
+    const editMode = this.params.edit_mode ?? 'replace';
+    let cellType = this.params.cell_type;
+
+    let cellIndex: number;
+    if (!this.params.cell_id) {
+      cellIndex = 0;
+    } else {
+      cellIndex = findCellIndex(notebook, this.params.cell_id);
+      if (cellIndex === -1) {
+        throw new Error(`Cell "${this.params.cell_id}" not found in notebook.`);
+      }
+      if (editMode === 'insert') {
+        cellIndex += 1; // Insert after the specified cell
+      }
+    }
+
+    // If replacing one-past-end, convert to insert
+    let effectiveMode = editMode;
+    if (effectiveMode === 'replace' && cellIndex === notebook.cells.length) {
+      effectiveMode = 'insert';
+      if (!cellType) cellType = 'code';
+    }
+
+    const generateCellId =
+      notebook.nbformat > 4 ||
+      (notebook.nbformat === 4 && notebook.nbformat_minor >= 5);
+
+    if (effectiveMode === 'delete') {
+      notebook.cells.splice(cellIndex, 1);
+    } else if (effectiveMode === 'insert') {
+      const newCell: NotebookCell = {
+        cell_type: cellType ?? 'code',
+        source: this.params.new_source,
+        metadata: {},
+        ...(generateCellId
+          ? { id: Math.random().toString(36).substring(2, 15) }
+          : {}),
+        ...((cellType ?? 'code') === 'code'
+          ? { execution_count: null, outputs: [] }
+          : {}),
+      };
+      notebook.cells.splice(cellIndex, 0, newCell);
+    } else {
+      // replace
+      const target = notebook.cells[cellIndex]!;
+      target.source = this.params.new_source;
+      if (target.cell_type === 'code') {
+        target.execution_count = null;
+        target.outputs = [];
+      }
+      if (cellType && cellType !== target.cell_type) {
+        target.cell_type = cellType;
+      }
+    }
+
+    return JSON.stringify(notebook, null, 1) + '\n';
+  }
+
+  async execute(signal: AbortSignal): Promise<ToolResult> {
+    let originalContent: string;
+    let detectedLineEnding: LineEnding = 'lf';
+
+    try {
+      originalContent = await fs.promises.readFile(
+        this.params.notebook_path,
+        'utf-8',
+      );
+      detectedLineEnding = detectLineEnding(originalContent);
+    } catch (err) {
+      if (signal.aborted) throw err;
+      if (isNodeError(err) && err.code === 'ENOENT') {
+        return {
+          llmContent: `Notebook file not found: ${this.params.notebook_path}`,
+          returnDisplay: 'Notebook file not found.',
+          error: {
+            message: `File not found: ${this.params.notebook_path}`,
+            type: ToolErrorType.FILE_NOT_FOUND,
+          },
+        };
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        llmContent: `Error reading notebook: ${msg}`,
+        returnDisplay: `Error reading notebook: ${msg}`,
+        error: { message: msg, type: ToolErrorType.READ_CONTENT_FAILURE },
+      };
+    }
+
+    let newContent: string;
+    try {
+      newContent = this.applyNotebookEdit(originalContent);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        llmContent: `Error applying notebook edit: ${msg}`,
+        returnDisplay: `Error: ${msg}`,
+        error: { message: msg, type: ToolErrorType.NOTEBOOK_EDIT_FAILURE },
+      };
+    }
+
+    // Restore original line endings if CRLF
+    let contentToWrite = newContent;
+    if (detectedLineEnding === 'crlf') {
+      contentToWrite = newContent.replace(/\n/g, '\r\n');
+    }
+
+    try {
+      // Ensure parent directory exists
+      const dirName = path.dirname(this.params.notebook_path);
+      if (!fs.existsSync(dirName)) {
+        fs.mkdirSync(dirName, { recursive: true });
+      }
+
+      await fs.promises.writeFile(
+        this.params.notebook_path,
+        contentToWrite,
+        'utf-8',
+      );
+
+      const fileName = path.basename(this.params.notebook_path);
+      const fileDiff = Diff.createPatch(
+        fileName,
+        originalContent,
+        newContent,
+        'Current',
+        'Proposed',
+        DEFAULT_DIFF_OPTIONS,
+      );
+      const diffStat = getDiffStat(
+        fileName,
+        originalContent,
+        newContent,
+        newContent,
+      );
+
+      const editMode = this.params.edit_mode ?? 'replace';
+      const cellRef = this.params.cell_id ?? 'start';
+
+      logFileOperation(
+        this.config,
+        new FileOperationEvent(
+          NotebookEditTool.Name,
+          FileOperation.UPDATE,
+          newContent.split('\n').length,
+          'application/x-ipynb+json',
+          '.ipynb',
+          undefined,
+        ),
+      );
+
+      const llmMessage =
+        editMode === 'delete'
+          ? `Deleted cell ${cellRef} from ${this.params.notebook_path}.`
+          : editMode === 'insert'
+            ? `Inserted new cell after ${cellRef} in ${this.params.notebook_path}.`
+            : `Updated cell ${cellRef} in ${this.params.notebook_path}.`;
+
+      return {
+        llmContent: llmMessage,
+        returnDisplay: {
+          fileDiff,
+          fileName,
+          originalContent,
+          newContent,
+          diffStat,
+        },
+      };
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return {
+        llmContent: `Error writing notebook: ${msg}`,
+        returnDisplay: `Error writing notebook: ${msg}`,
+        error: { message: msg, type: ToolErrorType.FILE_WRITE_FAILURE },
+      };
+    }
+  }
+}
+
+/**
+ * Tool for editing Jupyter notebook (.ipynb) cells.
+ * Supports replacing, inserting, and deleting cells.
+ */
+export class NotebookEditTool extends BaseDeclarativeTool<
+  NotebookEditToolParams,
+  ToolResult
+> {
+  static readonly Name = ToolNames.NOTEBOOK_EDIT;
+
+  constructor(private readonly config: Config) {
+    super(
+      NotebookEditTool.Name,
+      ToolDisplayNames.NOTEBOOK_EDIT,
+      `Edits a Jupyter notebook (.ipynb) file by modifying, inserting, or deleting cells.
+
+Operations:
+- **replace** (default): Replaces the source of an existing cell. Resets execution count and clears outputs for code cells.
+- **insert**: Inserts a new cell after the specified cell_id (or at the beginning if cell_id is omitted). Requires cell_type.
+- **delete**: Removes the specified cell.
+
+Cell identification: Use the cell's ID (as shown when reading the notebook) or numeric "cell-N" format (0-indexed).
+
+Always read the notebook first with the ${ToolNames.READ_FILE} tool before editing.`,
+      Kind.Edit,
+      {
+        properties: {
+          notebook_path: {
+            description:
+              'The absolute path to the Jupyter notebook (.ipynb) file to edit. Must be an absolute path.',
+            type: 'string',
+          },
+          cell_id: {
+            description:
+              'The ID of the cell to edit (from notebook read output) or "cell-N" format (0-indexed). Required for replace and delete. For insert, the new cell is placed after this cell (or at the start if omitted).',
+            type: 'string',
+          },
+          new_source: {
+            description:
+              'The new source content for the cell. For delete mode, this is ignored.',
+            type: 'string',
+          },
+          cell_type: {
+            description:
+              "The cell type: 'code' or 'markdown'. Required when inserting a new cell. For replace, changes the cell type if specified.",
+            type: 'string',
+            enum: ['code', 'markdown'],
+          },
+          edit_mode: {
+            description:
+              "The edit operation: 'replace' (default), 'insert', or 'delete'.",
+            type: 'string',
+            enum: ['replace', 'insert', 'delete'],
+          },
+        },
+        required: ['notebook_path', 'new_source'],
+        type: 'object',
+      },
+    );
+  }
+
+  protected override validateToolParamValues(
+    params: NotebookEditToolParams,
+  ): string | null {
+    if (!params.notebook_path || params.notebook_path.trim() === '') {
+      return "The 'notebook_path' parameter must be non-empty.";
+    }
+
+    if (!path.isAbsolute(params.notebook_path)) {
+      return `Notebook path must be absolute: ${params.notebook_path}`;
+    }
+
+    if (path.extname(params.notebook_path).toLowerCase() !== '.ipynb') {
+      return 'File must be a Jupyter notebook (.ipynb). Use the edit tool for other file types.';
+    }
+
+    const editMode = params.edit_mode ?? 'replace';
+    if (!['replace', 'insert', 'delete'].includes(editMode)) {
+      return "edit_mode must be 'replace', 'insert', or 'delete'.";
+    }
+
+    if (editMode === 'insert' && !params.cell_type) {
+      return "cell_type is required when using edit_mode='insert'.";
+    }
+
+    if (editMode !== 'insert' && !params.cell_id) {
+      return 'cell_id is required for replace and delete operations.';
+    }
+
+    const fileService = this.config.getFileService();
+    if (fileService.shouldQwenIgnoreFile(params.notebook_path)) {
+      return `File path '${params.notebook_path}' is ignored by .qwenignore pattern(s).`;
+    }
+
+    return null;
+  }
+
+  protected createInvocation(
+    params: NotebookEditToolParams,
+  ): ToolInvocation<NotebookEditToolParams, ToolResult> {
+    return new NotebookEditToolInvocation(this.config, params);
+  }
+}

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -173,7 +173,7 @@ export class ReadFileTool extends BaseDeclarativeTool<
     super(
       ReadFileTool.Name,
       ToolDisplayNames.READ_FILE,
-      `Reads and returns the content of a specified file. If the file is large, the content will be truncated. The tool's response will clearly indicate if truncation has occurred and will provide details on how to read more of the file using the 'offset' and 'limit' parameters. Handles text, images (PNG, JPG, GIF, WEBP, SVG, BMP), and PDF files. For text files, it can read specific line ranges.`,
+      `Reads and returns the content of a specified file. If the file is large, the content will be truncated. The tool's response will clearly indicate if truncation has occurred and will provide details on how to read more of the file using the 'offset' and 'limit' parameters. Handles text, images (PNG, JPG, GIF, WEBP, SVG, BMP), PDF files, and Jupyter notebooks (.ipynb). For text files, it can read specific line ranges. For notebooks, it renders cells with their outputs.`,
       Kind.Read,
       {
         properties: {

--- a/packages/core/src/tools/tool-error.ts
+++ b/packages/core/src/tools/tool-error.ts
@@ -67,6 +67,11 @@ export enum ToolErrorType {
   // WebSearch-specific Errors
   WEB_SEARCH_FAILED = 'web_search_failed',
 
+  // Notebook-specific Errors
+  NOTEBOOK_EDIT_FAILURE = 'notebook_edit_failure',
+  NOTEBOOK_INVALID_JSON = 'notebook_invalid_json',
+  NOTEBOOK_CELL_NOT_FOUND = 'notebook_cell_not_found',
+
   // Truncation Errors
   OUTPUT_TRUNCATED = 'output_truncated',
 }

--- a/packages/core/src/tools/tool-names.ts
+++ b/packages/core/src/tools/tool-names.ts
@@ -29,6 +29,7 @@ export const ToolNames = {
   CRON_CREATE: 'cron_create',
   CRON_LIST: 'cron_list',
   CRON_DELETE: 'cron_delete',
+  NOTEBOOK_EDIT: 'notebook_edit',
 } as const;
 
 /**
@@ -56,6 +57,7 @@ export const ToolDisplayNames = {
   CRON_CREATE: 'CronCreate',
   CRON_LIST: 'CronList',
   CRON_DELETE: 'CronDelete',
+  NOTEBOOK_EDIT: 'NotebookEdit',
 } as const;
 
 // Migration from old tool names to new tool names

--- a/packages/core/src/utils/fileUtils.ts
+++ b/packages/core/src/utils/fileUtils.ts
@@ -20,6 +20,7 @@ import type { Config } from '../config/config.js';
 import { createDebugLogger } from './debugLogger.js';
 import type { InputModalities } from '../core/contentGenerator.js';
 import { detectEncodingFromBuffer } from './systemEncoding.js';
+import { readNotebook, formatNotebookForLLM } from './notebookUtils.js';
 
 const debugLogger = createDebugLogger('FILE_UTILS');
 
@@ -453,8 +454,15 @@ export async function isBinaryFile(filePath: string): Promise<boolean> {
  */
 export async function detectFileType(
   filePath: string,
-): Promise<'text' | 'image' | 'pdf' | 'audio' | 'video' | 'binary' | 'svg'> {
+): Promise<
+  'text' | 'image' | 'pdf' | 'audio' | 'video' | 'binary' | 'svg' | 'notebook'
+> {
   const ext = path.extname(filePath).toLowerCase();
+
+  // Jupyter notebooks get special cell-aware rendering
+  if (ext === '.ipynb') {
+    return 'notebook';
+  }
 
   // The mimetype for various TypeScript extensions (ts, mts, cts, tsx) can be
   // MPEG transport stream (a video format), but we want to assume these are
@@ -513,7 +521,15 @@ export interface ProcessedFileReadResult {
  * Returns undefined for non-media types (text, binary, svg) which are always supported.
  */
 function mediaModalityKey(
-  fileType: 'image' | 'pdf' | 'audio' | 'video' | 'text' | 'binary' | 'svg',
+  fileType:
+    | 'image'
+    | 'pdf'
+    | 'audio'
+    | 'video'
+    | 'text'
+    | 'binary'
+    | 'svg'
+    | 'notebook',
 ): keyof InputModalities | undefined {
   if (
     fileType === 'image' ||
@@ -638,6 +654,28 @@ export async function processSingleFileContent(
           llmContent: content,
           returnDisplay: `Read SVG as text: ${relativePathForDisplay}`,
         };
+      }
+      case 'notebook': {
+        try {
+          const cells = await readNotebook(filePath);
+          const llmContent = formatNotebookForLLM(cells);
+          const cellCount = cells.length;
+          return {
+            llmContent,
+            returnDisplay: `Read notebook: ${relativePathForDisplay} (${cellCount} cell${cellCount !== 1 ? 's' : ''})`,
+          };
+        } catch (notebookError) {
+          // Fall back to raw text if notebook parsing fails
+          debugLogger.warn(
+            `Failed to parse notebook ${filePath}, falling back to text: ${notebookError instanceof Error ? notebookError.message : String(notebookError)}`,
+          );
+          // Fall through to text case by reading as plain text
+          const rawContent = await readFileWithEncoding(filePath);
+          return {
+            llmContent: rawContent,
+            returnDisplay: `Read notebook as raw JSON: ${relativePathForDisplay}`,
+          };
+        }
       }
       case 'text': {
         // Use BOM-aware reader to avoid leaving a BOM character in content and to support UTF-16/32 transparently

--- a/packages/core/src/utils/notebookUtils.ts
+++ b/packages/core/src/utils/notebookUtils.ts
@@ -1,0 +1,248 @@
+/**
+ * Utilities for reading and processing Jupyter notebook (.ipynb) files.
+ */
+
+import fs from 'node:fs';
+
+// --- Notebook JSON types ---------------------------------------------------
+
+export interface NotebookContent {
+  cells: NotebookCell[];
+  metadata: {
+    language_info?: {
+      name: string;
+    };
+    [key: string]: unknown;
+  };
+  nbformat: number;
+  nbformat_minor: number;
+}
+
+export interface NotebookCell {
+  cell_type: 'code' | 'markdown' | 'raw';
+  id?: string;
+  source: string | string[];
+  metadata: Record<string, unknown>;
+  execution_count?: number | null;
+  outputs?: NotebookCellOutput[];
+}
+
+export interface NotebookCellOutput {
+  output_type: 'stream' | 'execute_result' | 'display_data' | 'error';
+  text?: string | string[];
+  data?: Record<string, unknown>;
+  ename?: string;
+  evalue?: string;
+  traceback?: string[];
+}
+
+// --- Processed cell types --------------------------------------------------
+
+export interface ProcessedCell {
+  cellType: string;
+  source: string;
+  cell_id: string;
+  language?: string;
+  execution_count?: number;
+  outputs?: ProcessedCellOutput[];
+}
+
+export interface ProcessedCellOutput {
+  output_type: string;
+  text?: string;
+}
+
+// --- Constants -------------------------------------------------------------
+
+const LARGE_OUTPUT_THRESHOLD = 10_000;
+
+// --- Processing helpers ----------------------------------------------------
+
+function joinSource(source: string | string[]): string {
+  return Array.isArray(source) ? source.join('') : source;
+}
+
+function processOutputText(text: string | string[] | undefined): string {
+  if (!text) return '';
+  return Array.isArray(text) ? text.join('') : text;
+}
+
+function processOutput(output: NotebookCellOutput): ProcessedCellOutput {
+  switch (output.output_type) {
+    case 'stream':
+      return {
+        output_type: output.output_type,
+        text: processOutputText(output.text),
+      };
+    case 'execute_result':
+    case 'display_data': {
+      const textData = output.data?.['text/plain'];
+      return {
+        output_type: output.output_type,
+        text: processOutputText(
+          typeof textData === 'string' || Array.isArray(textData)
+            ? (textData as string | string[])
+            : undefined,
+        ),
+      };
+    }
+    case 'error':
+      return {
+        output_type: output.output_type,
+        text: processOutputText(
+          `${output.ename ?? 'Error'}: ${output.evalue ?? ''}\n${(output.traceback ?? []).join('\n')}`,
+        ),
+      };
+    default:
+      return { output_type: output.output_type };
+  }
+}
+
+function isLargeOutputs(outputs: ProcessedCellOutput[]): boolean {
+  let size = 0;
+  for (const o of outputs) {
+    size += o.text?.length ?? 0;
+    if (size > LARGE_OUTPUT_THRESHOLD) return true;
+  }
+  return false;
+}
+
+function processCell(
+  cell: NotebookCell,
+  index: number,
+  codeLanguage: string,
+  includeLargeOutputs: boolean,
+): ProcessedCell {
+  const cellId = cell.id ?? `cell-${index}`;
+  const processed: ProcessedCell = {
+    cellType: cell.cell_type,
+    source: joinSource(cell.source),
+    cell_id: cellId,
+  };
+
+  if (cell.cell_type === 'code') {
+    processed.language = codeLanguage;
+    if (cell.execution_count != null) {
+      processed.execution_count = cell.execution_count;
+    }
+  }
+
+  if (cell.cell_type === 'code' && cell.outputs?.length) {
+    const outputs = cell.outputs.map(processOutput);
+    if (!includeLargeOutputs && isLargeOutputs(outputs)) {
+      processed.outputs = [
+        {
+          output_type: 'stream',
+          text: `[Outputs too large to display. Use run_shell_command with: cat <notebook_path> | jq '.cells[${index}].outputs']`,
+        },
+      ];
+    } else {
+      processed.outputs = outputs;
+    }
+  }
+
+  return processed;
+}
+
+// --- Public API ------------------------------------------------------------
+
+/**
+ * Parse raw notebook JSON string into a NotebookContent object.
+ * Throws if the content is not valid JSON.
+ */
+export function parseNotebook(content: string): NotebookContent {
+  return JSON.parse(content) as NotebookContent;
+}
+
+/**
+ * Read and parse a Jupyter notebook file, returning processed cell data.
+ * If `cellId` is specified, returns only that cell.
+ */
+export async function readNotebook(
+  notebookPath: string,
+  cellId?: string,
+): Promise<ProcessedCell[]> {
+  const content = await fs.promises.readFile(notebookPath, 'utf-8');
+  const notebook = parseNotebook(content);
+  const language = notebook.metadata.language_info?.name ?? 'python';
+
+  if (cellId) {
+    const index = findCellIndex(notebook, cellId);
+    if (index === -1) {
+      throw new Error(`Cell with ID "${cellId}" not found in notebook`);
+    }
+    return [processCell(notebook.cells[index]!, index, language, true)];
+  }
+
+  return notebook.cells.map((cell, index) =>
+    processCell(cell, index, language, false),
+  );
+}
+
+/**
+ * Format processed cells as a readable text representation for the LLM.
+ */
+export function formatNotebookForLLM(cells: ProcessedCell[]): string {
+  const parts: string[] = [];
+
+  for (const cell of cells) {
+    const metaParts: string[] = [];
+    if (cell.cellType !== 'code') {
+      metaParts.push(`<cell_type>${cell.cellType}</cell_type>`);
+    }
+    if (
+      cell.language &&
+      cell.language !== 'python' &&
+      cell.cellType === 'code'
+    ) {
+      metaParts.push(`<language>${cell.language}</language>`);
+    }
+    const meta = metaParts.join('');
+    parts.push(`<cell id="${cell.cell_id}">${meta}\n${cell.source}\n</cell>`);
+
+    if (cell.outputs?.length) {
+      const outputTexts = cell.outputs
+        .filter((o) => o.text)
+        .map((o) => o.text!);
+      if (outputTexts.length > 0) {
+        parts.push(`<output>\n${outputTexts.join('\n')}\n</output>`);
+      }
+    }
+  }
+
+  return parts.join('\n\n');
+}
+
+/**
+ * Parse a cell ID in the "cell-N" numeric format.
+ * Returns the numeric index or undefined if the format doesn't match.
+ */
+export function parseCellId(cellId: string): number | undefined {
+  const match = cellId.match(/^cell-(\d+)$/);
+  if (match?.[1]) {
+    const index = parseInt(match[1], 10);
+    return isNaN(index) ? undefined : index;
+  }
+  return undefined;
+}
+
+/**
+ * Find a cell's index in the notebook by cell ID or "cell-N" format.
+ * Returns -1 if not found.
+ */
+export function findCellIndex(
+  notebook: NotebookContent,
+  cellId: string,
+): number {
+  // Try actual cell ID first
+  const idx = notebook.cells.findIndex((c) => c.id === cellId);
+  if (idx !== -1) return idx;
+
+  // Try "cell-N" numeric format
+  const parsed = parseCellId(cellId);
+  if (parsed !== undefined && parsed >= 0 && parsed < notebook.cells.length) {
+    return parsed;
+  }
+
+  return -1;
+}


### PR DESCRIPTION
Add NotebookEditTool for editing .ipynb cells (replace, insert, delete) and enhance ReadFile to render notebook cells with outputs instead of raw JSON.

## TLDR

Adds Jupyter notebook (.ipynb) support to Qwen Code with two changes:
1. **NotebookEditTool** — a new tool that can replace, insert, and delete notebook cells, with proper execution state cleanup (resets execution_count, clears outputs on code cell edits)
2. **ReadFile notebook rendering** — when reading .ipynb files, cells are now rendered with `<cell>` tags and their outputs instead of dumping raw JSON, making notebooks actually usable for the LLM

## Screenshots / Video Demo

N/A — no user-facing UI change. The changes affect tool behavior: ReadFile now returns structured cell content for .ipynb files, and a new NotebookEdit tool appears in the tool list.

## Dive Deeper

- Notebook cells are identified by their native ID or `cell-N` (0-indexed) format, so it works whether the notebook has UUIDs (nbformat >= 4.5) or not
- Large cell outputs (>10K chars) are truncated with a hint to use `run_shell_command` + jq to inspect them directly
- If notebook JSON parsing fails, ReadFile falls back to raw text rendering rather than erroring
- Line endings (CRLF/LF) are preserved on write
- New files: `packages/core/src/tools/notebook-edit.ts`, `packages/core/src/utils/notebookUtils.ts`

## Reviewer Test Plan

1. Read a `.ipynb` file — verify cells render with `<cell id="...">` tags and outputs appear in `<output>` blocks
2. Replace a code cell (`edit_mode=replace`) — verify execution_count resets to null and outputs are cleared
3. Insert a new markdown cell (`edit_mode=insert`, `cell_type=markdown`) — verify it appears after the specified cell_id
4. Delete a cell (`edit_mode=delete`) — verify removal
5. Use `cell-0`, `cell-1` numeric format — verify it resolves correctly
6. Read a malformed/corrupt `.ipynb` — verify it falls back to raw JSON text
7. Try a notebook path matching `.qwenignore` — verify it's rejected

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ✅  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

This is a new feature adding notebook support for data science/ML workflows.
Fixes #2816