### PR TITLE
feat(compression): add microcompact strategy for zero-cost context tr…

### DIFF
--- a/packages/cli/src/ui/components/messages/CompressionMessage.tsx
+++ b/packages/cli/src/ui/components/messages/CompressionMessage.tsx
@@ -43,6 +43,14 @@ export function CompressionMessage({
             newTokens: String(newTokens),
           },
         );
+      case CompressionStatus.MICROCOMPACTED:
+        return t(
+          'Old tool results trimmed, freeing context from {{originalTokens}} to {{newTokens}} tokens.',
+          {
+            originalTokens: String(originalTokens),
+            newTokens: String(newTokens),
+          },
+        );
       case CompressionStatus.COMPRESSION_FAILED_INFLATED_TOKEN_COUNT:
         // For smaller histories (< 50k tokens), compression overhead likely exceeds benefits
         if (originalTokens < 50000) {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -552,7 +552,10 @@ export class GeminiClient {
 
     const compressed = await this.tryCompressChat(prompt_id, false, signal);
 
-    if (compressed.compressionStatus === CompressionStatus.COMPRESSED) {
+    if (
+      compressed.compressionStatus === CompressionStatus.COMPRESSED ||
+      compressed.compressionStatus === CompressionStatus.MICROCOMPACTED
+    ) {
       yield { type: GeminiEventType.ChatCompressed, value: compressed };
     }
 
@@ -926,7 +929,10 @@ export class GeminiClient {
     );
 
     // Handle compression result
-    if (info.compressionStatus === CompressionStatus.COMPRESSED) {
+    if (
+      info.compressionStatus === CompressionStatus.COMPRESSED ||
+      info.compressionStatus === CompressionStatus.MICROCOMPACTED
+    ) {
       // Success: update chat with new compressed history
       if (newHistory) {
         const chatRecordingService = this.config.getChatRecordingService();

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -162,6 +162,9 @@ export enum CompressionStatus {
   /** The compression failed due to receiving an empty or null summary */
   COMPRESSION_FAILED_EMPTY_SUMMARY,
 
+  /** Old tool results were truncated without an LLM call (microcompact) */
+  MICROCOMPACTED,
+
   /** The compression was not necessary and no action was taken */
   NOOP,
 }

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -16,6 +16,7 @@ import { logChatCompression } from '../telemetry/loggers.js';
 import { makeChatCompressionEvent } from '../telemetry/types.js';
 import type { PermissionMode } from '../hooks/types.js';
 import { SessionStartSource, PreCompactTrigger } from '../hooks/types.js';
+import { microcompact, estimateTokensSaved } from './microcompact.js';
 
 /**
  * Threshold for compression token count as a fraction of the model's token limit.
@@ -125,21 +126,59 @@ export class ChatCompressionService {
     const originalTokenCount = uiTelemetryService.getLastPromptTokenCount();
 
     // Don't compress if not forced and we are under the limit.
-    if (!force) {
-      const contextLimit =
-        config.getContentGeneratorConfig()?.contextWindowSize ??
-        DEFAULT_TOKEN_LIMIT;
-      if (originalTokenCount < threshold * contextLimit) {
+    const contextLimit =
+      config.getContentGeneratorConfig()?.contextWindowSize ??
+      DEFAULT_TOKEN_LIMIT;
+    if (!force && originalTokenCount < threshold * contextLimit) {
+      return {
+        newHistory: null,
+        info: {
+          originalTokenCount,
+          newTokenCount: originalTokenCount,
+          compressionStatus: CompressionStatus.NOOP,
+        },
+      };
+    }
+
+    // -----------------------------------------------------------------------
+    // Phase 1: Microcompact — truncate old tool results (zero LLM cost)
+    // -----------------------------------------------------------------------
+    const charsSaved = microcompact(curatedHistory);
+
+    if (charsSaved > 0) {
+      const estimatedTokensSaved = estimateTokensSaved(charsSaved);
+      const postMicrocompactTokens = Math.max(
+        0,
+        originalTokenCount - estimatedTokensSaved,
+      );
+
+      // If microcompact alone brought us under the threshold, we're done —
+      // no need for the expensive LLM summarization call.
+      if (!force && postMicrocompactTokens < threshold * contextLimit) {
+        uiTelemetryService.setLastPromptTokenCount(postMicrocompactTokens);
+
+        logChatCompression(
+          config,
+          makeChatCompressionEvent({
+            tokens_before: originalTokenCount,
+            tokens_after: postMicrocompactTokens,
+          }),
+        );
+
         return {
-          newHistory: null,
+          newHistory: curatedHistory,
           info: {
             originalTokenCount,
-            newTokenCount: originalTokenCount,
-            compressionStatus: CompressionStatus.NOOP,
+            newTokenCount: postMicrocompactTokens,
+            compressionStatus: CompressionStatus.MICROCOMPACTED,
           },
         };
       }
     }
+
+    // -----------------------------------------------------------------------
+    // Phase 2: LLM-based summarization (expensive, but thorough)
+    // -----------------------------------------------------------------------
 
     // Fire PreCompact hook before compression begins
     const hookSystem = config.getHookSystem();

--- a/packages/core/src/services/microcompact.ts
+++ b/packages/core/src/services/microcompact.ts
@@ -1,0 +1,143 @@
+/**
+ * Microcompact: a lightweight, zero-LLM-call compression strategy.
+ *
+ * Shrinks chat history by truncating large tool result contents that are
+ * unlikely to still be relevant (older results further from the current
+ * conversation focus). Runs before the expensive LLM-based compression
+ * to avoid unnecessary API calls.
+ */
+
+import type { Content, Part } from '@google/genai';
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+/** Tools whose results can be safely truncated during microcompact. */
+const COMPACTABLE_TOOLS = new Set<string>([
+  'read_file',
+  'run_shell_command',
+  'grep_search',
+  'glob',
+  'list_directory',
+  'web_fetch',
+  'web_search',
+  'edit',
+  'write_file',
+  'notebook_edit',
+]);
+
+/** Results smaller than this are left alone (bytes of JSON-serialized text). */
+const MIN_RESULT_SIZE_TO_COMPACT = 500;
+
+/** Number of most-recent tool results to keep intact. */
+const DEFAULT_KEEP_RECENT = 5;
+
+/** Replacement text for cleared results. */
+const CLEARED_MESSAGE = '[Old tool result cleared to save context space]';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ToolResultRef {
+  /** Index into the contents array */
+  contentIndex: number;
+  /** Index into the parts array within that content */
+  partIndex: number;
+  /** Original size in characters */
+  size: number;
+  /** Tool name */
+  toolName: string;
+}
+
+// ---------------------------------------------------------------------------
+// Core logic
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect references to all compactable tool results in the history,
+ * ordered from oldest to newest.
+ */
+function collectToolResults(contents: Content[]): ToolResultRef[] {
+  const refs: ToolResultRef[] = [];
+
+  for (let ci = 0; ci < contents.length; ci++) {
+    const content = contents[ci];
+    if (content.role !== 'user' || !content.parts) continue;
+
+    for (let pi = 0; pi < content.parts.length; pi++) {
+      const part = content.parts[pi];
+      if (!part.functionResponse) continue;
+
+      const name = part.functionResponse.name ?? '';
+      if (!COMPACTABLE_TOOLS.has(name)) continue;
+
+      const response = part.functionResponse.response;
+      const output =
+        typeof response === 'object' && response !== null
+          ? (response as Record<string, unknown>)['output']
+          : undefined;
+
+      if (typeof output !== 'string') continue;
+      if (output === CLEARED_MESSAGE) continue; // Already cleared
+      if (output.length < MIN_RESULT_SIZE_TO_COMPACT) continue;
+
+      refs.push({
+        contentIndex: ci,
+        partIndex: pi,
+        size: output.length,
+        toolName: name,
+      });
+    }
+  }
+
+  return refs;
+}
+
+/**
+ * Apply microcompact to a chat history **in place**.
+ *
+ * Clears old, large tool results while keeping the `keepRecent` most recent
+ * ones intact. Returns the number of characters freed.
+ *
+ * @param contents  The mutable chat history array.
+ * @param keepRecent Number of recent tool results to preserve (default 5).
+ * @returns Total characters freed by clearing old results.
+ */
+export function microcompact(
+  contents: Content[],
+  keepRecent: number = DEFAULT_KEEP_RECENT,
+): number {
+  const refs = collectToolResults(contents);
+
+  // Nothing to compact, or not enough results to be worth it
+  if (refs.length <= keepRecent) {
+    return 0;
+  }
+
+  const toClear = refs.slice(0, refs.length - keepRecent);
+  let freedChars = 0;
+
+  for (const ref of toClear) {
+    const part = contents[ref.contentIndex].parts![ref.partIndex] as Part & {
+      functionResponse: {
+        name: string;
+        response: Record<string, unknown>;
+      };
+    };
+    const oldOutput = part.functionResponse.response['output'] as string;
+    part.functionResponse.response = { output: CLEARED_MESSAGE };
+    freedChars += oldOutput.length - CLEARED_MESSAGE.length;
+  }
+
+  return freedChars;
+}
+
+/**
+ * Estimate the character reduction as a rough token count saving.
+ * Uses a ~4 chars per token heuristic.
+ */
+export function estimateTokensSaved(charsSaved: number): number {
+  return Math.floor(charsSaved / 4);
+}


### PR DESCRIPTION
Add a lightweight microcompact compression strategy that truncates old tool results without making an LLM API call, reducing compression costs and latency.

## TLDR

Adds a zero-cost "microcompact" phase that runs before the existing LLM-based compression. It clears old, large tool result contents from chat history (replacing them with a short placeholder). If this alone frees enough tokens to stay under the context threshold, the expensive LLM summarization call is skipped entirely.

## Screenshots / Video Demo

N/A — no user-facing UI change beyond a slightly different compression status message ("Old tool results trimmed...") when microcompact is sufficient.

## Dive Deeper

**How it works:**
- Scans chat history for `functionResponse` parts from compactable tools (read_file, run_shell_command, grep_search, glob, edit, write_file, etc.)
- Keeps the 5 most recent tool results intact, clears older large results (>500 chars) with `[Old tool result cleared to save context space]`
- Estimates token savings at ~4 chars/token and checks if we're back under the compression threshold
- If still over threshold, falls through to the existing LLM-based summarization (which now operates on already-shrunk history, making it cheaper too)

**New files:**
- `packages/core/src/services/microcompact.ts` — Core microcompact logic (collect, clear, estimate)

**Modified files:**
- `packages/core/src/services/chatCompressionService.ts` — Integrated microcompact as Phase 1 before LLM compression
- `packages/core/src/core/turn.ts` — Added `MICROCOMPACTED` to `CompressionStatus` enum
- `packages/core/src/core/client.ts` — Handle `MICROCOMPACTED` status same as `COMPRESSED`
- `packages/cli/src/ui/components/messages/CompressionMessage.tsx` — Display message for microcompact

## Reviewer Test Plan

1. Start a long session with many tool calls (read files, run commands, grep, etc.)
2. When context approaches 70% threshold, verify microcompact triggers and older tool results are cleared
3. Verify the 5 most recent tool results remain intact
4. If microcompact isn't sufficient, verify LLM summarization still runs as fallback
5. Run `/compress` manually and verify it works with both phases
6. Run existing compression tests: `npx vitest run src/services/chatCompressionService.test.ts` (all 36 pass)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ✅  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

New feature to reduce API costs during context compression.
Fixes #2817