### PR TITLE
feat(tools): add universal tool result budgeting for large outputs

### DIFF
--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -57,6 +57,7 @@ import {
 } from './permission-helpers.js';
 import { getResponseTextFromParts } from '../utils/generateContentResponseUtilities.js';
 import type { ModifyContext } from '../tools/modifiable-tool.js';
+import { truncateToolOutput } from '../utils/truncation.js';
 import {
   isModifiableDeclarativeTool,
   modifyWithEditor,
@@ -1476,6 +1477,19 @@ export class CoreToolScheduler {
             this.setStatusInternal(callId, 'error', errorResponse);
             return;
           }
+        }
+
+        // Universal tool result budgeting: truncate large string results and
+        // persist full output to disk. Tools that already self-truncate (shell,
+        // MCP) will pass through harmlessly since their output is already under
+        // the threshold.
+        if (typeof content === 'string') {
+          const truncated = await truncateToolOutput(
+            this.config,
+            toolName,
+            content,
+          );
+          content = truncated.content;
         }
 
         const response = convertToFunctionResponse(toolName, callId, content);


### PR DESCRIPTION
Apply universal tool result budgeting so all tools benefit from large output truncation and disk persistence, not just shell and MCP.

## TLDR

Adds universal tool result truncation in the core tool scheduler. Previously, only `run_shell_command` and MCP tools truncated oversized outputs. Now ALL tool results (grep, glob, read_file, edit, etc.) are subject to the same budgeting: when output exceeds the configured threshold (default 25,000 chars / 1,000 lines), the full result is saved to a temp file and a truncated head/tail preview with a file path pointer is sent to the model.

## Screenshots / Video Demo

N/A — no user-facing UI change. The behavior is the same truncation users already see for shell output, now applied universally.

## Dive Deeper

- Single integration point in `coreToolScheduler.ts` (line ~1481) — after `execute()` returns but before `convertToFunctionResponse()` builds the chat history entry
- Uses the existing `truncateToolOutput()` utility from `utils/truncation.ts` which handles threshold checking, head/tail extraction, disk persistence, and telemetry logging
- Tools that already self-truncate (shell, MCP) pass through harmlessly since their output is already under the threshold — no double-truncation
- Respects existing user-configurable thresholds: `tools.truncateToolOutputThreshold` and `tools.truncateToolOutputLines`
- Only applies to string `llmContent` — media results (images, PDFs) are unaffected

**Modified files:**
- `packages/core/src/core/coreToolScheduler.ts` — Added universal truncation + import

## Reviewer Test Plan

1. Run a grep that returns thousands of matches — verify output is truncated with head/tail and a temp file path
2. Read a very large file — verify same truncation behavior
3. Run a shell command with large output — verify it still works (no double truncation)
4. Check the temp file referenced in truncation message actually contains full output
5. Use `read_file` on the temp file path — verify full content is accessible
6. Run existing scheduler tests: `npx vitest run src/core/coreToolScheduler.test.ts` (all 53 pass)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ✅  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

New feature to prevent context window waste from oversized tool outputs.
Fixes #2818 