### PR TITLE
fix(hooks): parse JSON output on exit code 2 to preserve hook additionalContext

### DIFF
--- a/packages/core/src/hooks/hookRunner.test.ts
+++ b/packages/core/src/hooks/hookRunner.test.ts
@@ -231,6 +231,65 @@ describe('HookRunner', () => {
       expect(result.output?.reason).toBe('stderr error message');
     });
 
+    it('should parse JSON from stderr on exit code 2 to preserve additionalContext', async () => {
+      // Exit code 2 with JSON in stderr should parse structured output
+      // to preserve hookSpecificOutput.additionalContext
+      const jsonOutput = JSON.stringify({
+        decision: 'deny',
+        reason: 'blocked by policy',
+        hookSpecificOutput: {
+          hookEventName: 'PostToolUse',
+          additionalContext: '[Hook] Tool execution blocked with context',
+        },
+      });
+      const mockProcess = createMockProcess(2, 'stdout ignored', jsonOutput);
+      mockSpawn.mockImplementation(() => mockProcess);
+
+      const hookConfig: HookConfig = {
+        type: HookType.Command,
+        command: 'exit 2',
+        source: HooksConfigSource.Project,
+      };
+      const input = createMockInput();
+
+      const result = await hookRunner.executeHook(
+        hookConfig,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.output?.decision).toBe('deny');
+      expect(result.output?.reason).toBe('blocked by policy');
+      expect(result.output?.hookSpecificOutput).toEqual({
+        hookEventName: 'PostToolUse',
+        additionalContext: '[Hook] Tool execution blocked with context',
+      });
+    });
+
+    it('should fall back to plain text when stderr JSON is invalid on exit code 2', async () => {
+      const mockProcess = createMockProcess(2, '', 'plain blocking error');
+      mockSpawn.mockImplementation(() => mockProcess);
+
+      const hookConfig: HookConfig = {
+        type: HookType.Command,
+        command: 'exit 2',
+        source: HooksConfigSource.Project,
+      };
+      const input = createMockInput();
+
+      const result = await hookRunner.executeHook(
+        hookConfig,
+        HookEventName.PreToolUse,
+        input,
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.output?.decision).toBe('deny');
+      expect(result.output?.reason).toBe('plain blocking error');
+      expect(result.output?.hookSpecificOutput).toBeUndefined();
+    });
+
     it('should not parse JSON on exit code 2', async () => {
       // Exit code 2 should ignore JSON in stdout
       const mockProcess = createMockProcess(

--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -401,26 +401,22 @@ export class HookRunner {
           : stdout.trim() || stderr.trim();
 
         if (textToParse) {
-          // Only parse JSON on exit 0
-          if (!isBlockingError) {
-            try {
-              let parsed = JSON.parse(textToParse);
-              if (typeof parsed === 'string') {
-                parsed = JSON.parse(parsed);
-              }
-              if (parsed && typeof parsed === 'object') {
-                output = parsed as HookOutput;
-              }
-            } catch {
-              // Not JSON, convert plain text to structured output
-              output = this.convertPlainTextToHookOutput(
-                textToParse,
-                exitCode || EXIT_CODE_SUCCESS,
-              );
+          // Try parsing as JSON to preserve structured output like
+          // hookSpecificOutput.additionalContext (applies to both exit 0 and exit 2)
+          try {
+            let parsed = JSON.parse(textToParse);
+            if (typeof parsed === 'string') {
+              parsed = JSON.parse(parsed);
             }
-          } else {
-            // Exit code 2: blocking error, use stderr as reason
-            output = this.convertPlainTextToHookOutput(textToParse, exitCode);
+            if (parsed && typeof parsed === 'object') {
+              output = parsed as HookOutput;
+            }
+          } catch {
+            // Not JSON, convert plain text to structured output
+            output = this.convertPlainTextToHookOutput(
+              textToParse,
+              isBlockingError ? exitCode : exitCode || EXIT_CODE_SUCCESS,
+            );
           }
         }
 


### PR DESCRIPTION
## TLDR

Fixes hookSpecificOutput.additionalContext from `PostToolUse` / `PostToolUseFailure` hooks was not surfaced to the model when the hook exited with `code 2` (blocking error).

The exit `code 2` path skipped JSON parsing entirely, converting stderr to plain text and losing all structured output fields. Now exit `code 2` also attempts JSON parsing first, falling back to plain text only when stderr is not valid JSON.

## Screenshots / Video Demo
When stderr the `hookSpecificOutput.additionalContext` will be injected to `transcript`:
<img width="1045" height="383" alt="截屏2026-04-02 11 06 50" src="https://github.com/user-attachments/assets/7d59b670-3961-4a70-8e42-125350eca7f0" />



## Dive Deeper

Origin implementation only affected hooks that exited with `code 2` (blocking decision). The root cause was in `hookRunner.ts` where the exit code 2 branch called `convertPlainTextToHookOutput` directly without attempting JSON parsing first. This meant any structured output — hookSpecificOutput.additionalContext, hookSpecificOutput.decision, or other typed fields — was silently discarded and the entire stderr was used as the plain text reason.

`Exit codes 0` and `1` already attempted JSON parsing, so this was purely an omission in the blocking error path. 


## Reviewer Test Plan
 1. Configure a PostToolUse hook that exits with `code 2` and outputs JSON to stderr:
```
# ~/.qwen/hooks/test.sh
cat <<EOF >&2
{"decision":"deny","reason":"blocked","hookSpecificOutput":{"hookEventName":"PostToolUse","additionalContext":"[Hook] This context should appear in tool response"}}
EOF
exit 2
```
2. Run any tool call (e.g., `glob`, `read_file`) in qwen-code.
3. Check the transcript (`~/.qwen/projects/.../chats/<session>.jsonl`) — the tool response should end with [Hook] This context should appear in tool response.



## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/QwenLM/qwen-code/issues/2809