### PR TITLE
feat(permissions): add permission denial tracking with escalating con…

### DIFF
--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -65,6 +65,7 @@ import * as Diff from 'diff';
 import levenshtein from 'fast-levenshtein';
 import { getPlanModeSystemReminder } from './prompts.js';
 import { ShellToolInvocation } from '../tools/shell.js';
+import { PermissionDenialTracker } from '../services/permissionDenialTracker.js';
 
 const TRUNCATION_PARAM_GUIDANCE =
   'Note: Your previous response was truncated due to max_tokens limit, ' +
@@ -339,6 +340,7 @@ export class CoreToolScheduler {
   private config: Config;
   private onEditorClose: () => void;
   private chatRecordingService?: ChatRecordingService;
+  private permissionDenialTracker = new PermissionDenialTracker();
   private isFinalizingToolCalls = false;
   private isScheduling = false;
   private requestQueue: Array<{
@@ -711,7 +713,11 @@ export class CoreToolScheduler {
           const ruleInfo = matchingRule
             ? ` Matching deny rule: "${matchingRule}".`
             : '';
-          const permissionErrorMessage = `Qwen Code requires permission to use "${reqInfo.name}", but that permission was declined.${ruleInfo}`;
+          const permissionErrorMessage =
+            this.permissionDenialTracker.recordDenial(
+              reqInfo.name,
+              `Qwen Code requires permission to use "${reqInfo.name}", but that permission was declined.${ruleInfo}`,
+            );
           newToolCalls.push({
             status: 'error',
             request: reqInfo,
@@ -735,7 +741,11 @@ export class CoreToolScheduler {
                 excludedTool.toLowerCase().trim() === normalizedToolName,
             );
             if (excludedMatch) {
-              const permissionErrorMessage = `Qwen Code requires permission to use ${excludedMatch}, but that permission was declined.`;
+              const permissionErrorMessage =
+                this.permissionDenialTracker.recordDenial(
+                  reqInfo.name,
+                  `Qwen Code requires permission to use ${excludedMatch}, but that permission was declined.`,
+                );
               newToolCalls.push({
                 status: 'error',
                 request: reqInfo,
@@ -885,6 +895,10 @@ export class CoreToolScheduler {
                 : '';
               denyMessage = `Tool "${reqInfo.name}" is denied by permission rules.${ruleInfo}`;
             }
+            denyMessage = this.permissionDenialTracker.recordDenial(
+              reqInfo.name,
+              denyMessage,
+            );
             this.setStatusInternal(
               reqInfo.callId,
               'error',
@@ -961,7 +975,10 @@ export class CoreToolScheduler {
               this.config.getInputFormat() !== InputFormat.STREAM_JSON;
 
             if (shouldAutoDeny) {
-              const errorMessage = `Qwen Code requires permission to use "${reqInfo.name}", but that permission was declined (non-interactive mode cannot prompt for confirmation).`;
+              const errorMessage = this.permissionDenialTracker.recordDenial(
+                reqInfo.name,
+                `Qwen Code requires permission to use "${reqInfo.name}", but that permission was declined (non-interactive mode cannot prompt for confirmation).`,
+              );
               this.setStatusInternal(
                 reqInfo.callId,
                 'error',
@@ -1057,15 +1074,17 @@ export class CoreToolScheduler {
                     reqInfo.callId,
                     ToolConfirmationOutcome.Cancel,
                   );
+                  const hookDenyMsg = this.permissionDenialTracker.recordDenial(
+                    reqInfo.name,
+                    hookResult.denyMessage ||
+                      `Permission denied by hook for "${reqInfo.name}"`,
+                  );
                   this.setStatusInternal(
                     reqInfo.callId,
                     'error',
                     createErrorResponse(
                       reqInfo,
-                      new Error(
-                        hookResult.denyMessage ||
-                          `Permission denied by hook for "${reqInfo.name}"`,
-                      ),
+                      new Error(hookDenyMsg),
                       ToolErrorType.EXECUTION_DENIED,
                     ),
                   );
@@ -1346,8 +1365,10 @@ export class CoreToolScheduler {
 
       if (!preHookResult.shouldProceed) {
         // Hook blocked the execution
-        const blockMessage =
-          preHookResult.blockReason || 'Tool execution blocked by hook';
+        const blockMessage = this.permissionDenialTracker.recordDenial(
+          toolName,
+          preHookResult.blockReason || 'Tool execution blocked by hook',
+        );
         const errorResponse = createErrorResponse(
           scheduledCall.request,
           new Error(blockMessage),
@@ -1466,8 +1487,10 @@ export class CoreToolScheduler {
 
           // Check if hook requested to stop execution
           if (postHookResult.shouldStop) {
-            const stopMessage =
-              postHookResult.stopReason || 'Execution stopped by hook';
+            const stopMessage = this.permissionDenialTracker.recordDenial(
+              toolName,
+              postHookResult.stopReason || 'Execution stopped by hook',
+            );
             const errorResponse = createErrorResponse(
               scheduledCall.request,
               new Error(stopMessage),

--- a/packages/core/src/services/permissionDenialTracker.ts
+++ b/packages/core/src/services/permissionDenialTracker.ts
@@ -1,0 +1,88 @@
+/**
+ * Tracks permission denials per tool across a session and provides escalating
+ * context messages to help the model avoid futile retries.
+ */
+
+/** Threshold after which denial messages include "try a different approach" guidance. */
+const SOFT_THRESHOLD = 2;
+
+/** Threshold after which denial messages strongly suggest stopping retries. */
+const HARD_THRESHOLD = 4;
+
+interface DenialRecord {
+  /** Total denials for this tool across the entire session. */
+  sessionTotal: number;
+  /** Denials for this tool in the current agentic turn. */
+  turnCount: number;
+}
+
+export class PermissionDenialTracker {
+  private denials = new Map<string, DenialRecord>();
+
+  /**
+   * Records a permission denial for the given tool and returns an augmented
+   * error message if the denial count has crossed a threshold.
+   *
+   * @param toolName - The tool that was denied.
+   * @param originalMessage - The original denial error message.
+   * @returns The original message, possibly with escalating guidance appended.
+   */
+  recordDenial(toolName: string, originalMessage: string): string {
+    const record = this.denials.get(toolName) ?? {
+      sessionTotal: 0,
+      turnCount: 0,
+    };
+    record.sessionTotal++;
+    record.turnCount++;
+    this.denials.set(toolName, record);
+
+    const count = record.sessionTotal;
+
+    if (count >= HARD_THRESHOLD) {
+      return (
+        `${originalMessage}\n\n` +
+        `[This tool has been denied ${count} times this session. ` +
+        `STOP retrying this tool. Ask the user for guidance or use a different approach entirely.]`
+      );
+    }
+
+    if (count >= SOFT_THRESHOLD) {
+      return (
+        `${originalMessage}\n\n` +
+        `[This tool has been denied ${count} times this session. ` +
+        `Consider trying a different approach instead of retrying.]`
+      );
+    }
+
+    return originalMessage;
+  }
+
+  /**
+   * Resets per-turn counters. Call this at the start of each agentic turn
+   * so that turn-level counts stay accurate while session totals accumulate.
+   */
+  resetTurn(): void {
+    for (const record of this.denials.values()) {
+      record.turnCount = 0;
+    }
+  }
+
+  /** Returns the session-level denial count for a given tool. */
+  getDenialCount(toolName: string): number {
+    return this.denials.get(toolName)?.sessionTotal ?? 0;
+  }
+
+  /** Returns all tools that have been denied at least once, with their counts. */
+  getSummary(): Map<string, number> {
+    const summary = new Map<string, number>();
+    for (const [tool, record] of this.denials) {
+      summary.set(tool, record.sessionTotal);
+    }
+    return summary;
+  }
+
+  /** Fully resets all tracking state. */
+  reset(): void {
+    this.denials.clear();
+  }
+}


### PR DESCRIPTION
Add permission denial tracking with escalating context to prevent the model from endlessly retrying denied tool calls.

## TLDR

Adds a `PermissionDenialTracker` that monitors per-tool permission denials across a session. When the model repeatedly attempts a denied tool, the error message escalates with contextual guidance: after 2 denials it suggests trying a different approach, and after 4 denials it strongly instructs the model to stop retrying and ask the user for help.

## Screenshots / Video Demo

N/A — no user-facing UI change. The behavior manifests as augmented error messages in the model's tool response when denials repeat.

Example progression:
- **1st denial**: `Qwen Code requires permission to use "run_shell_command", but that permission was declined.`
- **2nd denial**: Same message + `[This tool has been denied 2 times this session. Consider trying a different approach instead of retrying.]`
- **4th denial**: Same message + `[This tool has been denied 4 times this session. STOP retrying this tool. Ask the user for guidance or use a different approach entirely.]`

## Dive Deeper

- New `PermissionDenialTracker` class in `packages/core/src/services/permissionDenialTracker.ts`
  - Tracks per-tool denial counts at both session and turn granularity
  - `recordDenial(toolName, message)` increments count and returns augmented message if threshold crossed
  - `resetTurn()` resets per-turn counters while preserving session totals
  - `getSummary()` returns all denial counts for downstream consumers
- Integrated at all 7 `EXECUTION_DENIED` error paths in `coreToolScheduler.ts`:
  - `isToolEnabled()` check (PM disabled tool)
  - Legacy `getPermissionsDeny()` fallback
  - PM `finalPermission === 'deny'` (security/rule violation)
  - Non-interactive mode auto-deny
  - PermissionRequest hook denial
  - PreToolUse hook block
  - PostToolUse hook stop

**Modified files:**
- `packages/core/src/services/permissionDenialTracker.ts` — New tracker service
- `packages/core/src/core/coreToolScheduler.ts` — Import tracker, instantiate as field, wrap all EXECUTION_DENIED paths

## Reviewer Test Plan

1. Configure a deny rule for a tool (e.g., `run_shell_command`) and ask the model to use it repeatedly
2. Verify first denial shows the standard message
3. Verify second denial appends "Consider trying a different approach" guidance
4. Verify fourth denial appends "STOP retrying" guidance
5. Run existing scheduler tests: `npx vitest run src/core/coreToolScheduler.test.ts` (all 53 pass)

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |

## Linked issues / bugs

Fixes #2819 