### PR TITLE
fix(cli): restore previous theme on /theme cancel (refs #2833)

### DIFF
--- a/packages/cli/src/ui/hooks/useThemeCommand.test.ts
+++ b/packages/cli/src/ui/hooks/useThemeCommand.test.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { act } from 'react';
+import { renderHook } from '@testing-library/react';
+import type { LoadedSettings } from '../../config/settings.js';
+import { SettingScope } from '../../config/settings.js';
+import { useThemeCommand } from './useThemeCommand.js';
+import { themeManager } from '../themes/theme-manager.js';
+
+describe('useThemeCommand', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    themeManager.setActiveTheme('Qwen Dark');
+  });
+
+  it('restores previous theme on cancel (Esc)', () => {
+    const setValue =
+      vi.fn<(scope: SettingScope, key: string, value: unknown) => void>();
+    const settings = {
+      merged: { ui: { theme: 'Qwen Dark' } },
+      user: { settings: { ui: {} } },
+      workspace: { settings: { ui: {} } },
+      setValue,
+    } as unknown as LoadedSettings;
+
+    const setThemeError = vi.fn<(error: string | null) => void>();
+    const addItem = vi.fn();
+
+    const { result } = renderHook(() =>
+      useThemeCommand(settings, setThemeError, addItem, null),
+    );
+
+    act(() => {
+      themeManager.setActiveTheme('Dracula');
+      result.current.openThemeDialog();
+      result.current.handleThemeHighlight('Default');
+    });
+    expect(themeManager.getActiveTheme().name).toBe('Default');
+
+    act(() => {
+      result.current.handleThemeSelect(undefined, SettingScope.User);
+    });
+
+    expect(themeManager.getActiveTheme().name).toBe('Dracula');
+    expect(setValue).not.toHaveBeenCalled();
+    expect(result.current.isThemeDialogOpen).toBe(false);
+  });
+});

--- a/packages/cli/src/ui/hooks/useThemeCommand.ts
+++ b/packages/cli/src/ui/hooks/useThemeCommand.ts
@@ -29,6 +29,9 @@ export const useThemeCommand = (
 ): UseThemeCommandReturn => {
   const [isThemeDialogOpen, setIsThemeDialogOpen] =
     useState(!!initialThemeError);
+  const [themeBeforeDialogOpen, setThemeBeforeDialogOpen] = useState<
+    string | undefined
+  >(themeManager.getActiveTheme().name);
 
   const openThemeDialog = useCallback(() => {
     if (process.env['NO_COLOR']) {
@@ -43,6 +46,9 @@ export const useThemeCommand = (
       );
       return;
     }
+    // The theme may temporarily change while navigating the list; keep the
+    // original value to restore it if user cancels with Esc/Ctrl+C.
+    setThemeBeforeDialogOpen(themeManager.getActiveTheme().name);
     setIsThemeDialogOpen(true);
   }, [addItem]);
 
@@ -72,6 +78,14 @@ export const useThemeCommand = (
 
   const handleThemeSelect = useCallback(
     (themeName: string | undefined, scope: SettingScope) => {
+      // Undefined means "cancel": close dialog and restore original theme.
+      if (themeName === undefined) {
+        applyTheme(themeBeforeDialogOpen);
+        setThemeError(null);
+        setIsThemeDialogOpen(false);
+        return;
+      }
+
       try {
         // Merge user and workspace custom themes (workspace takes precedence)
         const mergedCustomThemes = {
@@ -100,7 +114,7 @@ export const useThemeCommand = (
         setIsThemeDialogOpen(false); // Close the dialog
       }
     },
-    [applyTheme, loadedSettings, setThemeError],
+    [applyTheme, loadedSettings, setThemeError, themeBeforeDialogOpen],
   );
 
   return {


### PR DESCRIPTION
## TLDR

Fixes `/theme` cancel behavior: pressing `Esc` in the theme dialog now restores the theme that was active before opening the dialog, instead of resetting to default.

This PR introduces a cancel-safe flow in `useThemeCommand`:

- saves `themeBeforeDialogOpen` on dialog open
- treats `themeName === undefined` as cancel
- restores previous theme, closes dialog, and does not persist `ui.theme` on cancel

## Screenshots / Video Demo

N/A — no stable user-facing visual artifact to attach here.
This is a keyboard interaction fix in terminal UI (`/theme` + `Esc`) and is covered by a focused unit test.

## Dive Deeper

Root cause:

- `Esc` in `ThemeDialog` triggers `onSelect(undefined, scope)`.
- In theme manager flow, `undefined` resolves to default theme, so cancel acted like an implicit reset.

What changed:

- `packages/cli/src/ui/hooks/useThemeCommand.ts`
  - added `themeBeforeDialogOpen` state initialized from current active theme
  - `openThemeDialog()` now captures the current active theme before preview interactions
  - `handleThemeSelect(undefined, ...)` now means cancel:
    - `applyTheme(themeBeforeDialogOpen)`
    - clear error
    - close dialog
    - skip settings write
- `packages/cli/src/ui/hooks/useThemeCommand.test.ts`
  - added test to verify:
    - open dialog
    - highlight another theme (preview applies)
    - cancel with `Esc` path (`undefined`)
    - previous theme is restored
    - `loadedSettings.setValue` is not called

## Reviewer Test Plan

1. Start from a non-default theme (e.g. `Dracula`).
2. Run `/theme`.
3. Move selection to another theme (preview should change).
4. Press `Esc`.
5. Verify:
   - dialog closes
   - theme returns to original (`Dracula`)
   - no config write occurs for canceled action

Automated:

1. `cd packages/cli`
2. `npx vitest run src/ui/hooks/useThemeCommand.test.ts`
3. Expect: `1 passed`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | N/A | ❓  |
| npx      | ❓  | ✅  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Notes:

- Verified on Windows locally via `npx vitest run src/ui/hooks/useThemeCommand.test.ts` in `packages/cli`.
- Full cross-platform matrix not executed in this local run.

## Linked issues / bugs

Closes https://github.com/QwenLM/qwen-code/issues/2833
