### PR TITLE
fix(extensions): await async calls in extension refresh chain

### DIFF
--- a/packages/core/src/extension/extensionManager.ts
+++ b/packages/core/src/extension/extensionManager.ts
@@ -1073,7 +1073,7 @@ export class ExtensionManager {
               'success',
             ),
           );
-          this.refreshTools();
+          await this.refreshTools();
         } else {
           logExtensionInstallEvent(
             telemetryConfig,
@@ -1186,7 +1186,7 @@ export class ExtensionManager {
     if (isUpdate) return;
 
     this.removeEnablementConfig(extension.name);
-    this.refreshTools();
+    await this.refreshTools();
 
     logExtensionUninstall(
       telemetryConfig,
@@ -1337,7 +1337,7 @@ export class ExtensionManager {
   async refreshMemory(): Promise<void> {
     if (!this.config) return;
     // refresh mcp servers
-    this.config.getToolRegistry().restartMcpServers();
+    await this.config.getToolRegistry().restartMcpServers();
     // refresh skills
     this.config.getSkillManager()?.refreshCache();
     // refresh subagents
@@ -1349,7 +1349,7 @@ export class ExtensionManager {
   async refreshTools(): Promise<void> {
     if (!this.config) return;
     // FIXME: restart all mcp servers now, this can be optimized by only restarting changed ones at here
-    this.refreshMemory();
+    await this.refreshMemory();
   }
 }
 


### PR DESCRIPTION
Fix chain of unawaited async calls in extension install/uninstall refresh flow.

## TLDR

Adds missing `await` keywords at three levels of the extension refresh chain: `installExtension()`/`uninstallExtension()` → `refreshTools()` → `refreshMemory()` → `restartMcpServers()`. Without these awaits, MCP server restarts after extension install/uninstall were fire-and-forget, meaning tools provided by newly installed extensions could appear unavailable until the background restart happened to finish.

## Screenshots / Video Demo

N/A — no user-facing UI change. The fix ensures async operations complete before the calling code continues.

## Dive Deeper

The bug is a chain of three missing `await`s:

1. **`installExtension()` (line 1076) and `uninstallExtension()` (line 1189)** called `this.refreshTools()` without `await`
2. **`refreshTools()` (line 1352)** called `this.refreshMemory()` without `await`
3. **`refreshMemory()` (line 1340)** called `this.config.getToolRegistry().restartMcpServers()` without `await` — and `restartMcpServers()` is async (calls `await this.discoverMcpTools()`)

Notably, `enableExtension()` and `disableExtension()` already had `await this.refreshTools()`, but the await was ineffective because the chain was broken inside `refreshTools()` and `refreshMemory()`.

**Modified file:**
- `packages/core/src/extension/extensionManager.ts` — Added `await` at all three levels (4 insertions, 4 deletions)

## Reviewer Test Plan

1. Install an extension that provides MCP tools — verify tools are available immediately after install completes
2. Uninstall an extension — verify its tools are removed immediately
3. Run extension tests: `npx vitest run src/extension/` (all 214 pass)
4. Run type check: `tsc --noEmit` (clean)

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |

## Linked issues / bugs

Simple bug fix