### PR TITLE
fix(cli): remove quote-based drag detection to prevent input lag

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -1639,7 +1639,7 @@ describe('Drag and Drop Handling', () => {
   });
 
   describe('drag start by quotes', () => {
-    it('should start collecting when single quote arrives and not broadcast immediately', async () => {
+    it('should broadcast single quote immediately without lag', async () => {
       const keyHandler = vi.fn();
 
       const { result } = renderHook(() => useKeypressContext(), { wrapper });
@@ -1659,10 +1659,17 @@ describe('Drag and Drop Handling', () => {
         });
       });
 
-      expect(keyHandler).not.toHaveBeenCalled();
+      // Quote should be broadcast immediately without any delay
+      expect(keyHandler).toHaveBeenCalledTimes(1);
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sequence: SINGLE_QUOTE,
+          paste: false,
+        }),
+      );
     });
 
-    it('should start collecting when double quote arrives and not broadcast immediately', async () => {
+    it('should broadcast double quote immediately without lag', async () => {
       const keyHandler = vi.fn();
 
       const { result } = renderHook(() => useKeypressContext(), { wrapper });
@@ -1682,12 +1689,19 @@ describe('Drag and Drop Handling', () => {
         });
       });
 
-      expect(keyHandler).not.toHaveBeenCalled();
+      // Quote should be broadcast immediately without any delay
+      expect(keyHandler).toHaveBeenCalledTimes(1);
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sequence: DOUBLE_QUOTE,
+          paste: false,
+        }),
+      );
     });
   });
 
   describe('drag collection and completion', () => {
-    it('should collect single character inputs during drag mode', async () => {
+    it('should broadcast all characters immediately (no quote-based drag detection)', async () => {
       const keyHandler = vi.fn();
 
       const { result } = renderHook(() => useKeypressContext(), { wrapper });
@@ -1696,7 +1710,7 @@ describe('Drag and Drop Handling', () => {
         result.current.subscribe(keyHandler);
       });
 
-      // Start by single quote
+      // Send quote
       act(() => {
         stdin.pressKey({
           name: undefined,
@@ -1708,7 +1722,9 @@ describe('Drag and Drop Handling', () => {
         });
       });
 
-      // Send single character
+      expect(keyHandler).toHaveBeenCalledTimes(1);
+
+      // Send path characters - all should be broadcast immediately
       act(() => {
         stdin.pressKey({
           name: undefined,
@@ -1716,50 +1732,10 @@ describe('Drag and Drop Handling', () => {
           meta: false,
           shift: false,
           paste: false,
-          sequence: 'a',
+          sequence: '/',
         });
       });
 
-      // Character should not be immediately broadcast
-      expect(keyHandler).not.toHaveBeenCalled();
-
-      // Fast-forward to completion timeout
-      act(() => {
-        vi.advanceTimersByTime(DRAG_COMPLETION_TIMEOUT_MS + 10);
-      });
-
-      // Should broadcast the collected path as paste (includes starting quote)
-      expect(keyHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: '',
-          paste: true,
-          sequence: `${SINGLE_QUOTE}a`,
-        }),
-      );
-    });
-
-    it('should collect multiple characters and complete on timeout', async () => {
-      const keyHandler = vi.fn();
-
-      const { result } = renderHook(() => useKeypressContext(), { wrapper });
-
-      act(() => {
-        result.current.subscribe(keyHandler);
-      });
-
-      // Start by single quote
-      act(() => {
-        stdin.pressKey({
-          name: undefined,
-          ctrl: false,
-          meta: false,
-          shift: false,
-          paste: false,
-          sequence: SINGLE_QUOTE,
-        });
-      });
-
-      // Send multiple characters
       act(() => {
         stdin.pressKey({
           name: undefined,
@@ -1804,22 +1780,16 @@ describe('Drag and Drop Handling', () => {
         });
       });
 
-      // Characters should not be immediately broadcast
-      expect(keyHandler).not.toHaveBeenCalled();
+      // All characters should be broadcast immediately
+      expect(keyHandler).toHaveBeenCalledTimes(6);
 
-      // Fast-forward to completion timeout
+      // Fast-forward timeout - should not trigger any additional broadcasts
       act(() => {
         vi.advanceTimersByTime(DRAG_COMPLETION_TIMEOUT_MS + 10);
       });
 
-      // Should broadcast the collected path as paste (includes starting quote)
-      expect(keyHandler).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: '',
-          paste: true,
-          sequence: `${SINGLE_QUOTE}path`,
-        }),
-      );
+      // Still 6 broadcasts - no drag detection
+      expect(keyHandler).toHaveBeenCalledTimes(6);
     });
   });
 });

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -137,9 +137,6 @@ export function KeypressProvider({
 }) {
   const { stdin, setRawMode } = useStdin();
   const subscribers = useRef<Set<KeypressHandler>>(new Set()).current;
-  const isDraggingRef = useRef(false);
-  const dragBufferRef = useRef('');
-  const draggingTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const subscribe = useCallback(
     (handler: KeypressHandler) => {
@@ -156,13 +153,6 @@ export function KeypressProvider({
   );
 
   useEffect(() => {
-    const clearDraggingTimer = () => {
-      if (draggingTimerRef.current) {
-        clearTimeout(draggingTimerRef.current);
-        draggingTimerRef.current = null;
-      }
-    };
-
     const wasRaw = stdin.isRaw;
     if (wasRaw === false) {
       setRawMode(true);
@@ -627,26 +617,9 @@ export function KeypressProvider({
         return;
       }
 
-      if (
-        key.sequence === SINGLE_QUOTE ||
-        key.sequence === DOUBLE_QUOTE ||
-        isDraggingRef.current
-      ) {
-        isDraggingRef.current = true;
-        dragBufferRef.current += key.sequence;
-
-        clearDraggingTimer();
-        draggingTimerRef.current = setTimeout(() => {
-          isDraggingRef.current = false;
-          const seq = dragBufferRef.current;
-          dragBufferRef.current = '';
-          if (seq) {
-            broadcast({ ...key, name: '', paste: true, sequence: seq });
-          }
-        }, DRAG_COMPLETION_TIMEOUT_MS);
-
-        return;
-      }
+      // Note: We no longer treat quotes specially for drag-and-drop detection.
+      // Modern terminals use bracketed paste mode (PASTE_MODE_PREFIX) for file drops,
+      // which is handled above. This prevents input lag on quote keystrokes.
 
       if (key.name === 'return' && waitingForEnterAfterBackslash) {
         if (backslashTimeout) {
@@ -1050,23 +1023,6 @@ export function KeypressProvider({
           sequence: pasteBuffer.toString(),
         });
         pasteBuffer = Buffer.alloc(0);
-      }
-
-      if (draggingTimerRef.current) {
-        clearTimeout(draggingTimerRef.current);
-        draggingTimerRef.current = null;
-      }
-      if (isDraggingRef.current && dragBufferRef.current) {
-        broadcast({
-          name: '',
-          ctrl: false,
-          meta: false,
-          shift: false,
-          paste: true,
-          sequence: dragBufferRef.current,
-        });
-        isDraggingRef.current = false;
-        dragBufferRef.current = '';
       }
     };
   }, [


### PR DESCRIPTION
## TLDR

Fixes significant input lag when typing single quote (`'`) and double quote (`"`) characters by removing the quote-based drag-and-drop detection mechanism. The previous implementation delayed broadcasting quote characters by 100ms, causing noticeable lag during normal typing. Modern terminals use bracketed paste mode for file drag-and-drop, making the quote-based heuristic unnecessary.

## Dive Deeper

### Root Cause
The `KeypressContext` had a quote-based drag-and-drop detection mechanism that:
1. Detected when a quote character was typed
2. Buffered the character for 100ms waiting to see if more characters followed (indicating a file path from drag-and-drop)
3. Only then broadcast the character

This caused a **100ms delay on every quote keystroke**, which is very noticeable during typing.

### The Fix
Removed the quote-based drag detection entirely because:
- Modern terminals use **bracketed paste mode** (`PASTE_MODE_PREFIX = ESC[200~`) for file drag-and-drop operations
- The bracketed paste handling is already implemented and working correctly
- The quote-based heuristic was a fallback for legacy terminals that compromised the typing experience for all users

### Changes
- Removed quote character special handling (SINGLE_QUOTE, DOUBLE_QUOTE detection)
- Removed unused drag-related refs and timers (`isDraggingRef`, `dragBufferRef`, `draggingTimerRef`)
- Removed drag cleanup code on exit
- Updated tests to reflect new behavior (quotes broadcast immediately)
- Total: ~75 lines of code removed

### Impact
✅ **Eliminates input lag** when typing quotes and all other characters  
✅ **Maintains drag-and-drop support** via bracketed paste mode (modern terminals)  
✅ **Cleaner, simpler code** with less complexity  
⚠️ **Legacy terminals** that don't support bracketed paste for file drops may need to use Ctrl+V for pasting file paths (this is already supported)

## Reviewer Test Plan

1. Pull and run the code: `bun install && bun start`
2. Type messages containing single and double quotes:
   - `It's working!`
   - `echo "hello world"`
   - `const x = 'test';`
3. Verify quotes appear immediately without any lag
4. Test file drag-and-drop (if your terminal supports it):
   - Drag a file into the terminal window
   - The file path should still appear correctly via bracketed paste mode
5. Run tests: `bun test`

## Testing Matrix

|          | 🍏 macOS | 🪟 Windows | 🐧 Linux |
| -------- | ------- | ---------- | -------- |
| npm run  | ❓      | ❓         | ✅       |
| npx      | ❓      | ❓         | ❓       |
| Docker   | ❓      | ❓         | ❓       |
| Podman   | ❓      | -          | ❓       |

Tested on Linux with bun - quotes now appear instantly with no lag.

## Linked issues / bug

Fixes input lag when typing quote characters (no existing issue filed)