### PR TITLE
fix(hooks): clean up abort listener in error handler

### DIFF
--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -439,6 +439,10 @@ export class HookRunner {
       // Handle process errors
       child.on('error', (error) => {
         clearTimeout(timeoutHandle);
+        // Clean up abort listener
+        if (signal) {
+          signal.removeEventListener('abort', abortHandler);
+        }
         const duration = Date.now() - startTime;
 
         resolve({


### PR DESCRIPTION
Fix abort listener leak in hook runner error handler.

## TLDR

Adds missing `signal.removeEventListener('abort', abortHandler)` cleanup to the `error` event handler in `hookRunner.ts`. Without this, when a child process emits an `error` event (e.g., executable not found, spawn failure), the abort listener remains registered on the signal, leaking memory if the same signal is reused across multiple hook executions.

## Screenshots / Video Demo

N/A — no user-facing UI change. The fix ensures proper cleanup of event listeners on process error.

## Dive Deeper

The `close` handler (line 358-364) correctly cleans up both the timeout and the abort listener:

```typescript
child.on('close', (exitCode) => {
  clearTimeout(timeoutHandle);
  if (signal) {
    signal.removeEventListener('abort', abortHandler);
  }
  // ...
});
```

But the `error` handler (line 440-453) only cleared the timeout:

```typescript
child.on('error', (error) => {
  clearTimeout(timeoutHandle);
  // abort listener NOT removed
  // ...
});
```

Per Node.js docs, when `spawn` fails (e.g., executable not found), the `error` event fires but `close` is NOT guaranteed. So the abort listener remains registered on the signal. If the same `AbortSignal` is used for multiple hook executions, stale handlers accumulate.

**Modified file:**
- `packages/core/src/hooks/hookRunner.ts` — Added abort listener cleanup to error handler (4 insertions)

## Reviewer Test Plan

1. Trigger a hook with an invalid executable path — verify no listener leak
2. Run hook tests: `npx vitest run src/hooks/` (all 274 pass)
3. Run type check: `tsc --noEmit` (clean)

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |
