### PR TITLE
fix: prevent output-language.md from being overwritten on startup

### DIFF
--- a/packages/cli/src/ui/commands/languageCommand.test.ts
+++ b/packages/cli/src/ui/commands/languageCommand.test.ts
@@ -750,7 +750,7 @@ describe('languageCommand', () => {
       expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
 
-    it('should overwrite existing file when output language setting differs', () => {
+    it('should NOT overwrite existing file even when output language setting differs', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue(
         `# Output language preference: English
@@ -760,11 +760,8 @@ describe('languageCommand', () => {
 
       initializeLlmOutputLanguage('Japanese');
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        expect.stringContaining('output-language.md'),
-        expect.stringContaining('Japanese'),
-        'utf-8',
-      );
+      // Should NOT overwrite - user's existing file takes precedence
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
 
     it('should resolve auto setting to detected system language', () => {

--- a/packages/cli/src/utils/languageUtils.test.ts
+++ b/packages/cli/src/utils/languageUtils.test.ts
@@ -309,12 +309,12 @@ describe('languageUtils', () => {
       );
     });
 
-    it('should NOT overwrite file when content matches resolved language', () => {
+    it('should NOT overwrite file when it already exists with valid content', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(i18n.detectSystemLanguage).mockReturnValue('en');
       vi.mocked(fs.readFileSync).mockReturnValue(
-        `# Output language preference: English
-<!-- qwen-code:llm-output-language: English -->
+        `# Output language preference: French
+<!-- qwen-code:llm-output-language: French -->
 `,
       );
 
@@ -323,21 +323,18 @@ describe('languageUtils', () => {
       expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
 
-    it('should overwrite file when language setting differs', () => {
+    it('should NOT overwrite file even when setting differs from existing content', () => {
       vi.mocked(fs.existsSync).mockReturnValue(true);
       vi.mocked(fs.readFileSync).mockReturnValue(
-        `# Output language preference: English
-<!-- qwen-code:llm-output-language: English -->
+        `# Output language preference: French
+<!-- qwen-code:llm-output-language: French -->
 `,
       );
 
       initializeLlmOutputLanguage('Japanese');
 
-      expect(fs.writeFileSync).toHaveBeenCalledWith(
-        expect.stringContaining('output-language.md'),
-        expect.stringContaining('Japanese'),
-        'utf-8',
-      );
+      // Should NOT overwrite - user's existing file takes precedence
+      expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
 
     it('should resolve "auto" to detected system language', () => {

--- a/packages/cli/src/utils/languageUtils.ts
+++ b/packages/cli/src/utils/languageUtils.ts
@@ -175,17 +175,19 @@ export function updateOutputLanguageFile(settingValue: string): void {
  * @param outputLanguage - The output language setting value (e.g., 'auto', 'Chinese', etc.)
  *
  * Behavior:
- * - Resolves the setting value ('auto' -> detected system language, or use as-is)
- * - Ensures the rule file matches the resolved language
- * - Creates the file if it doesn't exist
+ * - If the rule file already exists and contains a valid language setting, do nothing (preserve user modifications)
+ * - If the rule file doesn't exist, create it with the resolved language ('auto' -> detected system language, or use as-is)
  */
 export function initializeLlmOutputLanguage(outputLanguage?: string): void {
-  // Resolve 'auto' or undefined to the detected system language
-  const resolved = resolveOutputLanguage(outputLanguage);
+  // Check if the file already exists and has valid content
   const currentFileLanguage = readOutputLanguageFromFile();
 
-  // Only write if the file doesn't match the resolved language
-  if (currentFileLanguage !== resolved) {
-    writeOutputLanguageFile(resolved);
+  // If file exists with valid language, preserve user's setting - do nothing
+  if (currentFileLanguage) {
+    return;
   }
+
+  // File doesn't exist or has invalid content, create it with resolved language
+  const resolved = resolveOutputLanguage(outputLanguage);
+  writeOutputLanguageFile(resolved);
 }


### PR DESCRIPTION
## TLDR

Fix `output-language.md` being regenerated at every session startup, which was overwriting user modifications. Now the file is only created on first startup if it doesn't exist, preserving any user edits across sessions.

## Screenshots / Video Demo


## Dive Deeper

### Problem
The `initializeLlmOutputLanguage()` function was called on every session startup (in `gemini.tsx:355`). It would:
1. Resolve the system language from settings (e.g., `'auto'` → `'English'`)
2. Read the current file content (e.g., user changed to `'French'`)
3. Compare the two values
4. If they differed, overwrite the file with the system language
 
This meant users whose system locale differed from their preferred output language couldn't persist their changes - the file would be overwritten on every new session.
 
### Solution
Changed the initialization logic to only create the file if it doesn't exist or contains invalid content. If the file already exists with valid language settings, it's left untouched. This respects user modifications while still ensuring the file is created on first startup.

## Reviewer Test Plan
**Test file preservation after manual edit:**
Edit the file manually
```
echo "# Output language preference: French
<!-- qwen-code:llm-output-language: French -->" > ~/.qwen/output-language.md
```
Restart Qwen Code
```
npm start
```
Verify file was NOT overwritten
```
cat ~/.qwen/output-language.md  # Should still show French
```

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/QwenLM/qwen-code/issues/2830