### PR TITLE
fix(cli): commit pending AI response before adding hook system message

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1101,6 +1101,11 @@ export const useGeminiStream = (
             break;
           case ServerGeminiEventType.HookSystemMessage:
             // Display system message from Stop hooks with "Stop says:" prefix
+            // First commit any pending AI response to ensure correct ordering
+            if (pendingHistoryItemRef.current) {
+              addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+              setPendingHistoryItem(null);
+            }
             addItem(
               {
                 type: 'stop_hook_system_message',


### PR DESCRIPTION
Commit pending AI response before adding HookSystemMessage to history to prevent "Stop says:" block from appearing above the AI's reply.

## TLDR

When a `HookSystemMessage` event arrives while an AI response is still pending in `pendingHistoryItemRef`, the system message would be inserted into history before the AI response is committed. This causes the "Stop says:" block to appear above the actual AI reply instead of below it.

This fix ensures that any pending AI response is committed to history before adding the hook system message, maintaining the correct display order. This follows the same pattern used by other event handlers in the codebase (`handleErrorEvent`, `handleCitationEvent`, `handleStopHookLoopEvent`, etc.).

## Screenshots / Video Demo

### Before (bug)

```
  > hello

  ✦ The user is greeting me, so I should respond with a brief, friendly greeting and offer assistance.


   ⎿ Stop says:
      ---
      █████
      █████
      █████
      ---

  ✦ Hello! How can I help you today?
```
### After (fixed)

```
  > hello

  ✦ The user is greeting me, so I should respond with a brief, friendly greeting and offer assistance.


  ✦ Hello! How can I help you today?

   ⎿ Stop says:
      ---
      █████
      █████
      █████
      ---
```

## Dive Deeper

Other event handlers in `useGeminiStream.ts` already follow this pattern:

- `handleErrorEvent` (line 786): commits pending before adding error message
- `handleCitationEvent` (line 827): commits pending before adding citation
- `handleChatCompressionEvent` (line 891): commits pending before adding compression info
- `handleUserPromptSubmitBlockedEvent` (line 979): commits pending before adding blocked message
- `handleStopHookLoopEvent` (line 1004): commits pending before adding loop message

The `HookSystemMessage` case was missing this step, causing the ordering issue.

**Modified file:** `packages/cli/src/ui/hooks/useGeminiStream.ts` — Added pending response commit before adding hook system message (5 insertions)

## Reviewer Test Plan

1. Configure Stop hooks in `~/.qwen`
2. Send a simple message (e.g., "test")
3. Verify that "Stop says:" block appears **below** the AI response, not above it

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓ | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

No related issues — discovered during local testing.
