### PR TITLE
fix(ui): prevent slash commands from being queued during AI response

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -471,6 +471,82 @@ describe('AppContainer State Management', () => {
       expect(mockSubmitQuery).toHaveBeenCalledWith('/btw quick side question');
       expect(mockQueueMessage).not.toHaveBeenCalled();
     });
+
+    it('ignores slash commands instead of queueing while responding', () => {
+      const mockSubmitQuery = vi.fn();
+      const mockQueueMessage = vi.fn();
+
+      mockedUseGeminiStream.mockReturnValue({
+        streamingState: 'responding',
+        submitQuery: mockSubmitQuery,
+        initError: null,
+        pendingHistoryItems: [],
+        thought: null,
+        cancelOngoingRequest: vi.fn(),
+        retryLastPrompt: vi.fn(),
+      });
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [],
+        addMessage: mockQueueMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      // Test various slash commands
+      capturedUIActions.handleFinalSubmit('/settings');
+      capturedUIActions.handleFinalSubmit('/help');
+      capturedUIActions.handleFinalSubmit('/clear');
+      capturedUIActions.handleFinalSubmit('/compress');
+
+      // None should be queued or submitted
+      expect(mockSubmitQuery).not.toHaveBeenCalled();
+      expect(mockQueueMessage).not.toHaveBeenCalled();
+    });
+
+    it('allows slash commands to be queued when idle', () => {
+      const mockSubmitQuery = vi.fn();
+      const mockQueueMessage = vi.fn();
+
+      mockedUseGeminiStream.mockReturnValue({
+        streamingState: 'idle',
+        submitQuery: mockSubmitQuery,
+        initError: null,
+        pendingHistoryItems: [],
+        thought: null,
+        cancelOngoingRequest: vi.fn(),
+        retryLastPrompt: vi.fn(),
+      });
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [],
+        addMessage: mockQueueMessage,
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      // When idle, slash commands should be queued (they will be processed when submitted)
+      capturedUIActions.handleFinalSubmit('/settings');
+
+      expect(mockQueueMessage).toHaveBeenCalledWith('/settings');
+      expect(mockSubmitQuery).not.toHaveBeenCalled();
+    });
   });
 
   describe('Settings Integration', () => {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -72,7 +72,7 @@ import { useTextBuffer } from './components/shared/text-buffer.js';
 import { useLogger } from './hooks/useLogger.js';
 import { useGeminiStream } from './hooks/useGeminiStream.js';
 import { useVim } from './hooks/vim.js';
-import { isBtwCommand } from './utils/commandUtils.js';
+import { isBtwCommand, isSlashCommand } from './utils/commandUtils.js';
 import { type LoadedSettings, SettingScope } from '../config/settings.js';
 import { type InitializationResult } from '../core/initializer.js';
 import { useFocus } from './hooks/useFocus.js';
@@ -758,6 +758,11 @@ export const AppContainer = (props: AppContainerProps) => {
       if (agentViewState.activeView !== 'main') {
         const agent = agentViewState.agents.get(agentViewState.activeView);
         if (agent) {
+          // Block slash commands from being sent to sub-agents.
+          // Slash commands must be handled by the main CLI, not processed as prompts.
+          if (isSlashCommand(submittedValue)) {
+            return;
+          }
           agent.interactiveAgent.enqueueMessage(submittedValue.trim());
           return;
         }
@@ -767,6 +772,14 @@ export const AppContainer = (props: AppContainerProps) => {
         isBtwCommand(submittedValue)
       ) {
         void submitQuery(submittedValue);
+        return;
+      }
+      // Ignore slash commands when streaming - they should not be queued or sent to the LLM.
+      // Slash commands must be handled immediately by the CLI, not processed as prompts.
+      if (
+        streamingState === StreamingState.Responding &&
+        isSlashCommand(submittedValue)
+      ) {
         return;
       }
       addMessage(submittedValue);


### PR DESCRIPTION
## Problem

When the AI is responding, slash commands like `/settings`, `/help`, `/clear` etc. were being queued and sent to the LLM as regular messages instead of being handled as CLI commands.

This is visible when users type a slash command while the AI is thinking - the command gets displayed in the queued messages area and eventually gets sent to the model as part of the prompt.

## Root Cause

The `handleFinalSubmit` function in `AppContainer.tsx` didn't check for slash commands before queueing messages during the `Responding` state. All non-`/btw` input was simply added to the message queue.

## Solution

Added slash command detection in `handleFinalSubmit` to:

1. **Block slash commands from being queued while streaming** - When the AI is responding and a slash command is submitted, it's now silently ignored instead of being queued.

2. **Block slash commands from being sent to sub-agents** - When viewing a sub-agent tab, slash commands are now blocked from being sent to the sub-agent model.

## Changes

- `packages/cli/src/ui/AppContainer.tsx` - Added `isSlashCommand` import and two guard clauses
- `packages/cli/src/ui/AppContainer.test.tsx` - Added two test cases:
  - Verifies slash commands are ignored while responding
  - Verifies slash commands are still queued when idle (normal behavior)