### PR TITLE
fix: change NoColorTheme gradient from empty array to undefined

### DIFF
--- a/packages/cli/src/ui/themes/no-color.ts
+++ b/packages/cli/src/ui/themes/no-color.ts
@@ -49,7 +49,7 @@ const noColorSemanticColors: SemanticColors = {
   ui: {
     comment: '',
     symbol: '',
-    gradient: [],
+    gradient: undefined,
   },
   status: {
     error: '',


### PR DESCRIPTION
## Problem

When the CLI detects a terminal without color support (or when  is set), it uses the . This theme had  (empty array), which causes a crash:



The  library requires at least 2 color stops, but an empty array provides 0.

## Solution

Change  to  in . This allows the code to properly fall back to the default gradient colors defined in the UI components (line 484666 in bundled code):



## Testing

Tested on Windows 11 with PowerShell and Windows Terminal. Before fix: crash with NO_COLOR=1. After fix: works correctly.

## Related Issues

This fixes the crash for users who:
- Have  environment variable set
- Are running in terminals where color detection fails
- Use Windows PowerShell with certain configurations

---
*One-line fix, no breaking changes*