### PR TITLE
fix(cli): restore ? shortcuts in vim normal mode

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -1300,6 +1300,23 @@ describe('InputPrompt', () => {
       expect(mockBuffer.handleInput).toHaveBeenCalled();
       unmount();
     });
+
+    it('should toggle shortcuts when vim passes through ? on an empty prompt', async () => {
+      props.vimHandleInput = vi.fn().mockReturnValue(false);
+      props.onToggleShortcuts = vi.fn();
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('?');
+      await wait();
+
+      expect(props.vimHandleInput).toHaveBeenCalled();
+      expect(props.onToggleShortcuts).toHaveBeenCalled();
+      unmount();
+    });
   });
 
   describe('unfocused paste', () => {

--- a/packages/cli/src/ui/hooks/vim.test.ts
+++ b/packages/cli/src/ui/hooks/vim.test.ts
@@ -215,6 +215,31 @@ describe('useVim hook', () => {
 
       expect(testBuffer.vimMoveWordBackward).toHaveBeenCalledWith(1);
     });
+
+    it('should pass through ? in NORMAL mode when the buffer is empty', () => {
+      const emptyBuffer = createMockBuffer('', [0, 0]);
+      emptyBuffer.lines = [''];
+      emptyBuffer.text = '';
+      const { result } = renderVimHook(emptyBuffer);
+
+      let handled = true;
+      act(() => {
+        handled = result.current.handleInput({ sequence: '?', name: '' });
+      });
+
+      expect(handled).toBe(false);
+    });
+
+    it('should still handle ? in NORMAL mode when the buffer is not empty', () => {
+      const { result } = renderVimHook();
+
+      let handled = false;
+      act(() => {
+        handled = result.current.handleInput({ sequence: '?', name: '' });
+      });
+
+      expect(handled).toBe(true);
+    });
   });
 
   describe('Navigation commands', () => {

--- a/packages/cli/src/ui/hooks/vim.ts
+++ b/packages/cli/src/ui/hooks/vim.ts
@@ -411,6 +411,17 @@ export function useVim(buffer: TextBuffer, onSubmit?: (value: string) => void) {
 
       // Handle NORMAL mode
       if (state.mode === 'NORMAL') {
+        // Let the documented shortcuts panel toggle handle plain `?` when the
+        // prompt is empty and vim is otherwise idle.
+        if (
+          normalizedKey.sequence === '?' &&
+          buffer.text.length === 0 &&
+          state.pendingOperator === null &&
+          state.count === 0
+        ) {
+          return false;
+        }
+
         // If in NORMAL mode, allow escape to pass through to other handlers
         // if there's no pending operation.
         if (normalizedKey.name === 'escape') {


### PR DESCRIPTION
## TLDR

This PR restores the documented `?` keyboard shortcut in Vim `NORMAL` mode when the prompt is empty.

Before this change, pressing `?` in Vim `NORMAL` mode was swallowed by the Vim input handler, so the shortcuts panel never opened. Now that keypress falls through to the existing `InputPrompt` shortcut handling in the one safe case where we want it:
- Vim mode is enabled
- the prompt is empty
- there is no pending operator
- there is no numeric count in progress

This keeps the fix small and avoids changing normal Vim behavior for non-empty input or operator/count sequences.

## Screenshots / Video Demo

<img width="649" height="121" alt="截屏2026-04-04 22 28 34" src="https://github.com/user-attachments/assets/2f5962a6-b6c6-4c33-aa83-1240e5b3b4f5" />

Behavior before:
- Enable `/vim`
- Stay in `NORMAL` mode with an empty prompt
- Press `?`
- Nothing happens

Behavior after:
- Enable `/vim`
- Stay in `NORMAL` mode with an empty prompt
- Press `?`
- The keyboard shortcuts panel opens as documented

## Dive Deeper

The existing shortcuts toggle logic already lives in `InputPrompt`. The bug was that `useVim` consumed plain `?` too early in `NORMAL` mode, even when the prompt was empty.

This PR fixes that by returning `false` from the Vim handler for the narrow pass-through case above, allowing the existing shortcut toggle path to run unchanged.

I also added regression coverage for:
- `useVim` passing through `?` in `NORMAL` mode with an empty buffer
- `useVim` continuing to handle `?` when the buffer is non-empty
- `InputPrompt` toggling shortcuts when Vim passes `?` through

## Reviewer Test Plan

1. Run `npm run preflight`
2. Start the local CLI
3. Enter `/vim`
4. Make sure the prompt is empty
5. Press `Esc` to confirm you are in `NORMAL` mode
6. Press `?`

Expected result:
- The keyboard shortcuts panel opens

Regression checks:
1. In Vim `INSERT` mode, typing `?` should still insert `?`
2. In Vim `NORMAL` mode with non-empty input, Vim should continue handling `?` as before
3. Non-Vim shortcut behavior should remain unchanged

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

Validated on macOS with `npm run preflight` and manual local CLI verification.

## Linked issues / bugs

Fixes #2779

