### PR TITLE
refactor(tools): remove duplicate proxy setup in WebFetchTool

### DIFF
--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -5,7 +5,6 @@
  */
 
 import { convert } from 'html-to-text';
-import { ProxyAgent, setGlobalDispatcher } from 'undici';
 import type { Config } from '../config/config.js';
 import { fetchWithTimeout, isPrivateIp } from '../utils/fetch.js';
 import { getResponseText } from '../utils/partUtils.js';
@@ -239,10 +238,6 @@ export class WebFetchTool extends BaseDeclarativeTool<
         type: 'object',
       },
     );
-    const proxy = config.getProxy();
-    if (proxy) {
-      setGlobalDispatcher(new ProxyAgent(proxy as string));
-    }
   }
 
   protected override validateToolParamValues(


### PR DESCRIPTION
The global proxy dispatcher is already configured in Config constructor, so the duplicate `setGlobalDispatcher` call in WebFetchTool is unnecessary.

## TLDR

This PR removes the redundant proxy setup code from WebFetchTool constructor, eliminating duplicate `setGlobalDispatcher` calls that were being executed during initialization.

## Screenshots / Video Demo

N/A — no user-facing change. This is an internal refactoring that removes duplicate code. The proxy configuration behavior remains unchanged since the global dispatcher is already set up once in the Config constructor.

## Dive Deeper

### Background

The proxy configuration was centralized in the Config constructor, which calls `setGlobalDispatcher(new ProxyAgent(proxyUrl))` during initialization. However, the WebFetchTool constructor also had a duplicate call to `setGlobalDispatcher`, which was redundant because:

1. `setGlobalDispatcher` sets the **process-wide global dispatcher** in undici — calling it once affects all subsequent fetch/undici requests
2. Config constructor calls `setGlobalDispatcher` during initialization, and tools are only registered later via `Config.createToolRegistry()`
3. WebFetchTool's duplicate call was unnecessary and could potentially cause confusion

### What This PR Changes

**Before:**
```typescript
// WebFetchTool constructor
const proxy = config.getProxy();
if (proxy) {
  setGlobalDispatcher(new ProxyAgent(proxy as string));  // ← duplicate
}
```

**After:**
```typescript
// Removed — proxy is already set in Config constructor
```

- Removes the duplicate `setGlobalDispatcher` call from WebFetchTool constructor
- Removes unused imports (`ProxyAgent`, `setGlobalDispatcher`) from web-fetch.ts
- No functional changes - proxy behavior remains exactly the same

### Why This Matters

- **Code clarity**: Eliminates redundant code that could confuse developers about where proxy configuration actually happens
- **DRY principle**: Proxy setup should have a single source of truth (Config constructor)
- **Maintainability**: Reduces the risk of future bugs if someone modifies proxy logic in one place but not the other

## Reviewer Test Plan

1. Verify proxy configuration still works by setting a proxy URL in config
2. Check that WebFetchTool can still make requests through the proxy
3. Confirm no regressions in tool initialization or fetch operations

To test:
- Set `proxy` in settings or environment variables
- Use the web_fetch tool to fetch a URL
- Verify the request goes through the proxy as expected

## Testing Matrix

|         | 🍏  |
| ------- | --- |
| npm run | ✅  |
| npx     | ✅  |

## Linked issues / bugs

N/A — internal refactoring, no related issue.
