### PR TITLE
fix(mcp): clear OAuth callback timeout on all completion paths

### DIFF
--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -261,6 +261,10 @@ export class MCPOAuthProvider {
               </html>
             `);
               activeCallbackServer = null;
+              if (activeCallbackTimeout) {
+                clearTimeout(activeCallbackTimeout);
+                activeCallbackTimeout = null;
+              }
               server.close();
               reject(new Error(`OAuth error: ${error}`));
               return;
@@ -276,6 +280,10 @@ export class MCPOAuthProvider {
               res.writeHead(400);
               res.end('Invalid state parameter');
               activeCallbackServer = null;
+              if (activeCallbackTimeout) {
+                clearTimeout(activeCallbackTimeout);
+                activeCallbackTimeout = null;
+              }
               server.close();
               reject(new Error('State mismatch - possible CSRF attack'));
               return;
@@ -294,10 +302,18 @@ export class MCPOAuthProvider {
           `);
 
             activeCallbackServer = null;
+            if (activeCallbackTimeout) {
+              clearTimeout(activeCallbackTimeout);
+              activeCallbackTimeout = null;
+            }
             server.close();
             resolve({ code, state });
           } catch (error) {
             activeCallbackServer = null;
+            if (activeCallbackTimeout) {
+              clearTimeout(activeCallbackTimeout);
+              activeCallbackTimeout = null;
+            }
             server.close();
             reject(error);
           }


### PR DESCRIPTION
Clear OAuth callback server timeout on all completion paths.

## TLDR

Adds `clearTimeout(activeCallbackTimeout)` before every `resolve()` and `reject()` call in the OAuth callback server handler. Previously, the 5-minute timeout was never cleared when the flow completed, leaving a dangling timer that would fire later and call `reject()` on a settled promise.

## Screenshots / Video Demo

N/A — no user-facing UI change. The fix ensures proper timer cleanup.

## Dive Deeper

In `startCallbackServer`, a 5-minute timeout is set at line 318. There are 4 resolution paths in the request handler:

1. OAuth error parameter present → `reject()` (line 265)
2. State mismatch → `reject()` (line 280)
3. Success → `resolve()` (line 298)
4. Catch block → `reject()` (line 302)

All four paths closed the server and nulled `activeCallbackServer`, but none cleared `activeCallbackTimeout`. The timer would fire ~5 minutes later, calling `reject()` on a settled promise and `server.close()` on an already-closed server. Both are harmless no-ops, but the timer holds references unnecessarily.

**Modified file:**
- `packages/core/src/mcp/oauth-provider.ts` — Added timeout cleanup before all 4 resolve/reject paths (16 insertions)

## Reviewer Test Plan

1. Complete an OAuth flow — verify no dangling timeout remains
2. Trigger each error path (missing params, state mismatch) — verify timeout is cleared
3. Run MCP tests: `npx vitest run src/mcp/` (all 156 pass)
4. Run type check: `tsc --noEmit` (clean)

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |

## Linked issues / bugs

Quick bug fix.