### PR TITLE
fix(ui): Remove dead dirs state and unused hook parameter from InputPrompt

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -849,7 +849,6 @@ describe('InputPrompt', () => {
       // Verify useCompletion was called with correct signature
       expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
         mockBuffer,
-        ['/test/project/src'],
         path.join('test', 'project', 'src'),
         mockSlashCommands,
         mockCommandContext,
@@ -878,7 +877,6 @@ describe('InputPrompt', () => {
 
       expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
         mockBuffer,
-        ['/test/project/src'],
         path.join('test', 'project', 'src'),
         mockSlashCommands,
         mockCommandContext,
@@ -907,7 +905,6 @@ describe('InputPrompt', () => {
 
       expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
         mockBuffer,
-        ['/test/project/src'],
         path.join('test', 'project', 'src'),
         mockSlashCommands,
         mockCommandContext,
@@ -936,7 +933,6 @@ describe('InputPrompt', () => {
 
       expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
         mockBuffer,
-        ['/test/project/src'],
         path.join('test', 'project', 'src'),
         mockSlashCommands,
         mockCommandContext,
@@ -965,7 +961,6 @@ describe('InputPrompt', () => {
 
       expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
         mockBuffer,
-        ['/test/project/src'],
         path.join('test', 'project', 'src'),
         mockSlashCommands,
         mockCommandContext,
@@ -995,7 +990,6 @@ describe('InputPrompt', () => {
       // Verify useCompletion was called with the buffer
       expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
         mockBuffer,
-        ['/test/project/src'],
         path.join('test', 'project', 'src'),
         mockSlashCommands,
         mockCommandContext,
@@ -1024,7 +1018,6 @@ describe('InputPrompt', () => {
 
       expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
         mockBuffer,
-        ['/test/project/src'],
         path.join('test', 'project', 'src'),
         mockSlashCommands,
         mockCommandContext,
@@ -1054,7 +1047,6 @@ describe('InputPrompt', () => {
 
       expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
         mockBuffer,
-        ['/test/project/src'],
         path.join('test', 'project', 'src'),
         mockSlashCommands,
         mockCommandContext,
@@ -1084,7 +1076,6 @@ describe('InputPrompt', () => {
 
       expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
         mockBuffer,
-        ['/test/project/src'],
         path.join('test', 'project', 'src'),
         mockSlashCommands,
         mockCommandContext,
@@ -1114,7 +1105,6 @@ describe('InputPrompt', () => {
 
       expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
         mockBuffer,
-        ['/test/project/src'],
         path.join('test', 'project', 'src'),
         mockSlashCommands,
         mockCommandContext,
@@ -1144,7 +1134,6 @@ describe('InputPrompt', () => {
 
       expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
         mockBuffer,
-        ['/test/project/src'],
         path.join('test', 'project', 'src'),
         mockSlashCommands,
         mockCommandContext,
@@ -1176,7 +1165,6 @@ describe('InputPrompt', () => {
 
       expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
         mockBuffer,
-        ['/test/project/src'],
         path.join('test', 'project', 'src'),
         mockSlashCommands,
         mockCommandContext,
@@ -1206,7 +1194,6 @@ describe('InputPrompt', () => {
 
       expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
         mockBuffer,
-        ['/test/project/src'],
         path.join('test', 'project', 'src'),
         mockSlashCommands,
         mockCommandContext,
@@ -1238,7 +1225,6 @@ describe('InputPrompt', () => {
 
       expect(mockedUseCommandCompletion).toHaveBeenCalledWith(
         mockBuffer,
-        ['/test/project/src'],
         path.join('test', 'project', 'src'),
         mockSlashCommands,
         mockCommandContext,

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -168,12 +168,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     }
   }, []);
 
-  const currentDirs = config.getWorkspaceContext().getDirectories();
-  const dirKey = currentDirs.join('\0');
-  const [dirs, setDirs] = useState<readonly string[]>(currentDirs);
-  useEffect(() => {
-    setDirs(currentDirs);
-  }, [dirKey]); // eslint-disable-line react-hooks/exhaustive-deps
   const [reverseSearchActive, setReverseSearchActive] = useState(false);
   const [commandSearchActive, setCommandSearchActive] = useState(false);
   const [textBeforeReverseSearch, setTextBeforeReverseSearch] = useState('');
@@ -187,7 +181,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const completion = useCommandCompletion(
     buffer,
-    dirs,
     config.getTargetDir(),
     slashCommands,
     commandContext,

--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.ts
@@ -84,7 +84,6 @@ const setupMocks = ({
 describe('useCommandCompletion', () => {
   const mockCommandContext = {} as CommandContext;
   const mockConfig = {} as Config;
-  const testDirs: string[] = [];
   const testRootDir = '/';
 
   // Helper to create real TextBuffer objects within renderHook
@@ -114,7 +113,6 @@ describe('useCommandCompletion', () => {
         const { result } = renderHook(() =>
           useCommandCompletion(
             useTextBufferForTest(''),
-            testDirs,
             testRootDir,
             [],
             mockCommandContext,
@@ -139,7 +137,6 @@ describe('useCommandCompletion', () => {
           const textBuffer = useTextBufferForTest('@file');
           const completion = useCommandCompletion(
             textBuffer,
-            testDirs,
             testRootDir,
             [],
             mockCommandContext,
@@ -172,7 +169,6 @@ describe('useCommandCompletion', () => {
         const { result } = renderHook(() =>
           useCommandCompletion(
             useTextBufferForTest('@files'),
-            testDirs,
             testRootDir,
             [],
             mockCommandContext,
@@ -200,7 +196,6 @@ describe('useCommandCompletion', () => {
         renderHook(() =>
           useCommandCompletion(
             useTextBufferForTest(text),
-            testDirs,
             testRootDir,
             [],
             mockCommandContext,
@@ -226,7 +221,6 @@ describe('useCommandCompletion', () => {
         renderHook(() =>
           useCommandCompletion(
             useTextBufferForTest(text, cursorOffset),
-            testDirs,
             testRootDir,
             [],
             mockCommandContext,
@@ -265,7 +259,6 @@ describe('useCommandCompletion', () => {
         const { result } = renderHook(() =>
           useCommandCompletion(
             useTextBufferForTest('/'),
-            testDirs,
             testRootDir,
             [],
             mockCommandContext,
@@ -286,7 +279,6 @@ describe('useCommandCompletion', () => {
         const { result } = renderHook(() =>
           useCommandCompletion(
             useTextBufferForTest('/'),
-            testDirs,
             testRootDir,
             [],
             mockCommandContext,
@@ -306,7 +298,6 @@ describe('useCommandCompletion', () => {
         const { result } = renderHook(() =>
           useCommandCompletion(
             useTextBufferForTest('/'),
-            testDirs,
             testRootDir,
             [],
             mockCommandContext,
@@ -332,7 +323,6 @@ describe('useCommandCompletion', () => {
         const { result } = renderHook(() =>
           useCommandCompletion(
             useTextBufferForTest('/'),
-            testDirs,
             testRootDir,
             [],
             mockCommandContext,
@@ -361,7 +351,6 @@ describe('useCommandCompletion', () => {
         const { result } = renderHook(() =>
           useCommandCompletion(
             useTextBufferForTest('/'),
-            testDirs,
             testRootDir,
             [],
             mockCommandContext,
@@ -398,7 +387,6 @@ describe('useCommandCompletion', () => {
         const { result } = renderHook(() =>
           useCommandCompletion(
             useTextBufferForTest('/'),
-            testDirs,
             testRootDir,
             [],
             mockCommandContext,
@@ -427,7 +415,6 @@ describe('useCommandCompletion', () => {
       renderHook(() =>
         useCommandCompletion(
           useTextBufferForTest(text),
-          testDirs,
           testRootDir,
           [],
           mockCommandContext,
@@ -455,7 +442,6 @@ describe('useCommandCompletion', () => {
       renderHook(() =>
         useCommandCompletion(
           useTextBufferForTest(text),
-          testDirs,
           testRootDir,
           [],
           mockCommandContext,
@@ -484,7 +470,6 @@ describe('useCommandCompletion', () => {
         const textBuffer = useTextBufferForTest(text);
         const completion = useCommandCompletion(
           textBuffer,
-          testDirs,
           testRootDir,
           [],
           mockCommandContext,
@@ -517,7 +502,6 @@ describe('useCommandCompletion', () => {
         const textBuffer = useTextBufferForTest('/mem');
         const completion = useCommandCompletion(
           textBuffer,
-          testDirs,
           testRootDir,
           [],
           mockCommandContext,
@@ -547,7 +531,6 @@ describe('useCommandCompletion', () => {
         const textBuffer = useTextBufferForTest('@src/fi');
         const completion = useCommandCompletion(
           textBuffer,
-          testDirs,
           testRootDir,
           [],
           mockCommandContext,
@@ -580,7 +563,6 @@ describe('useCommandCompletion', () => {
         const textBuffer = useTextBufferForTest(text, cursorOffset);
         const completion = useCommandCompletion(
           textBuffer,
-          testDirs,
           testRootDir,
           [],
           mockCommandContext,

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -39,7 +39,6 @@ export interface UseCommandCompletionReturn {
 
 export function useCommandCompletion(
   buffer: TextBuffer,
-  dirs: readonly string[],
   cwd: string,
   slashCommands: readonly SlashCommand[],
   commandContext: CommandContext,


### PR DESCRIPTION
Remove dead `dirs` state and unused hook parameter from InputPrompt.

## TLDR

The `dirs` parameter passed to `useCommandCompletion()` was never referenced inside the hook body — only declared on line 42. The `dirs` state, its sync `useEffect`, and the parameter itself were all dead code. This PR removes them entirely instead of optimizing the sync effect.

## Screenshots / Video Demo

N/A — no user-facing change. Pure dead-code removal.

## Dive Deeper

Thanks to the reviewer for catching this. The original PR tried to fix an effect that was running on every render (because `getDirectories()` returns a new array each call). The first attempted fix used a serialized dependency key to stabilize the dep. The reviewer correctly pointed out that the whole thing was pointless:

> The `dirs` parameter passed to `useCommandCompletion()` is never actually read inside that hook — it's declared on line 42 but not referenced anywhere in the function body. This makes the `dirs` state and its syncing effect dead code.

Verified: `grep dirs` in `useCommandCompletion.tsx` returns only the parameter declaration.

So instead of optimizing dead code, this PR deletes it:

1. **`useCommandCompletion.tsx`** — removed the `dirs: readonly string[]` parameter
2. **`InputPrompt.tsx`** — removed the `dirs` state, the `currentDirs`/`dirKey` locals, the sync `useEffect`, and the `dirs` argument at the call site
3. **`useCommandCompletion.test.ts`** — removed `testDirs` local and the `testDirs,` argument from all 17 call sites
4. **`InputPrompt.test.tsx`** — removed the `['/test/project/src']` second argument from all `toHaveBeenCalledWith` assertions

Net: **40 lines deleted, 0 lines added.** No behavior change — the hook never used the value.

**Modified files:**
- `packages/cli/src/ui/components/InputPrompt.tsx`
- `packages/cli/src/ui/components/InputPrompt.test.tsx`
- `packages/cli/src/ui/hooks/useCommandCompletion.tsx`
- `packages/cli/src/ui/hooks/useCommandCompletion.test.ts`

## Reviewer Test Plan

1. Run `useCommandCompletion` tests: `pnpm --filter=@qwen-code/qwen-code exec npx vitest run src/ui/hooks/useCommandCompletion.test.ts` — 17 pass
2. Run `InputPrompt` tests: `pnpm --filter=@qwen-code/qwen-code exec npx vitest run src/ui/components/InputPrompt.test.tsx` — 103 pass, 2 skipped
3. Grep the repo for any remaining references to the removed parameter: `grep -r "useCommandCompletion" packages/cli/src` — all call sites match the new 8-arg signature
4. Manual smoke: add/remove working directories with `/add-dir` during a session — prompt still works correctly (directory state lives in `config.getWorkspaceContext()`, not in the removed local state)

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |

## Linked issues / bugs

Linked to bug report issue for useEffect running every render in InputPrompt. The reviewer correctly identified that the root cause was dead code, not a missing optimization.
