### PR TITLE
fix(auth): only release token refresh lock if it was acquired

### DIFF
--- a/packages/core/src/qwen/sharedTokenManager.ts
+++ b/packages/core/src/qwen/sharedTokenManager.ts
@@ -468,6 +468,7 @@ export class SharedTokenManager {
   ): Promise<QwenCredentials> {
     const startTime = Date.now();
     const lockPath = this.getLockFilePath();
+    let lockAcquired = false;
 
     try {
       // Check if we have a refresh token before attempting refresh
@@ -482,6 +483,7 @@ export class SharedTokenManager {
 
       // Acquire distributed file lock
       await this.acquireLock(lockPath);
+      lockAcquired = true;
 
       // Check if the operation is taking too long
       const lockAcquisitionTime = Date.now() - startTime;
@@ -596,8 +598,10 @@ export class SharedTokenManager {
         error,
       );
     } finally {
-      // Always release the file lock
-      await this.releaseLock(lockPath);
+      // Only release the file lock if it was successfully acquired
+      if (lockAcquired) {
+        await this.releaseLock(lockPath);
+      }
     }
   }
 


### PR DESCRIPTION
Guard token refresh lock release to only run when lock was acquired.

## TLDR

Adds a `lockAcquired` flag to `performTokenRefresh()` so the `finally` block only calls `releaseLock()` when the lock was actually acquired. Previously, the lock was unconditionally released even when it was never acquired (e.g., no refresh token, or lock timeout), which could delete another process's lock file.

## Screenshots / Video Demo

N/A — no user-facing UI change.

## Dive Deeper

The `finally` block always called `releaseLock()`, which calls `fs.unlink(lockPath)`. Two paths skip lock acquisition:

1. **NO_REFRESH_TOKEN** (line 477): Throws before `acquireLock()` is called
2. **LOCK_TIMEOUT**: `acquireLock()` itself throws after failing to acquire

In both cases, `releaseLock()` would attempt to delete the lock file. If another process held the lock at that moment, this deletes THEIR lock file, destroying mutual exclusion. A third process could then immediately acquire the lock, leading to concurrent token refreshes and potential credential corruption.

```typescript
// Before — always releases
} finally {
  await this.releaseLock(lockPath);
}

// After — only releases if acquired
let lockAcquired = false;
try {
  // ...
  await this.acquireLock(lockPath);
  lockAcquired = true;
  // ...
} finally {
  if (lockAcquired) {
    await this.releaseLock(lockPath);
  }
}
```

**Modified file:**
- `packages/core/src/qwen/sharedTokenManager.ts` — Add lock acquisition guard (6 insertions, 2 deletions)

## Reviewer Test Plan

1. Trigger token refresh with no refresh token — verify lock file is not deleted
2. Run token manager tests: `npx vitest run src/qwen/sharedTokenManager.test.ts` (all 31 pass)
3. Run type check: `tsc --noEmit` (clean)

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |

## Linked issues / bugs

NA; quick bug fix