### PR TITLE
fix(telegram): send only failed chunk as plaintext fallback

### DIFF
--- a/packages/channels/telegram/src/TelegramAdapter.ts
+++ b/packages/channels/telegram/src/TelegramAdapter.ts
@@ -188,9 +188,8 @@ export class TelegramChannel extends ChannelBase {
           parse_mode: 'HTML',
         });
       } catch {
-        // Fallback to plain text if HTML parsing fails
-        await this.bot.api.sendMessage(chatId, text);
-        return;
+        // Fallback to plain text for the failed chunk only
+        await this.bot.api.sendMessage(chatId, chunk.replace(/<[^>]*>/g, ''));
       }
     }
   }


### PR DESCRIPTION
Fix Telegram sendMessage fallback sending full text instead of failed chunk.

## TLDR

Fixes the HTML send fallback in `TelegramAdapter.sendMessage()` to strip HTML from only the failed chunk (instead of sending the entire original text) and continue sending remaining chunks (instead of returning early).

## Screenshots / Video Demo

N/A — affects Telegram channel message delivery.

## Dive Deeper

When sending chunked HTML messages, if a chunk failed to parse as HTML, the fallback had two bugs:

1. **Sent entire `text` instead of failed `chunk`**: If text was split into 3 chunks and chunk 2 failed, users would receive chunk 1 (HTML) + full original text (plain) = duplicated content
2. **`return` skipped remaining chunks**: Chunks after the failure were never sent

```typescript
// Before — sends entire text and skips remaining chunks
} catch {
  await this.bot.api.sendMessage(chatId, text);
  return;
}

// After — strips HTML from failed chunk only and continues
} catch {
  await this.bot.api.sendMessage(chatId, chunk.replace(/<[^>]*>/g, ''));
}
```

**Modified file:**
- `packages/channels/telegram/src/TelegramAdapter.ts` — Fix fallback to send only failed chunk and continue (2 insertions, 3 deletions)

## Reviewer Test Plan

1. Send a message that produces multiple chunks where one has invalid HTML — verify correct delivery
2. Verify no content duplication or missing chunks

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |

## Linked issues / bugs

NA; quick bug fix
