### PR TITLE
fix(subagents): preserve session subagents during cache refresh

### DIFF
--- a/packages/core/src/subagents/subagent-manager.ts
+++ b/packages/core/src/subagents/subagent-manager.ts
@@ -496,6 +496,12 @@ export class SubagentManager {
       subagentsCache.set(level, levelSubagents);
     }
 
+    // Preserve session subagents from old cache
+    const sessionSubagents = this.subagentsCache?.get('session');
+    if (sessionSubagents) {
+      subagentsCache.set('session', sessionSubagents);
+    }
+
     this.subagentsCache = subagentsCache;
     this.notifyChangeListeners();
   }


### PR DESCRIPTION
Preserve session subagents during cache refresh.

## TLDR

Fixes `SubagentManager.refreshCache()` to preserve session-level subagents from the old cache. Previously, `refreshCache()` created a new Map with only `project/user/builtin/extension` levels, silently discarding any session subagents loaded via `loadSessionSubagents()`.

## Screenshots / Video Demo

N/A — no user-facing UI change.

## Dive Deeper

`loadSessionSubagents()` stores session-level subagents in the cache under the `'session'` key. But `refreshCache()` creates a brand new Map with only the four disk-backed levels, completely dropping the `'session'` entry:

```typescript
// Before — session subagents lost
async refreshCache(): Promise<void> {
  const subagentsCache = new Map();
  const levels: SubagentLevel[] = ['project', 'user', 'builtin', 'extension'];
  for (const level of levels) {
    subagentsCache.set(level, await this.listSubagentsAtLevel(level));
  }
  this.subagentsCache = subagentsCache; // 'session' key is gone
}
```

Any call to `listSubagents({ force: true })` triggers `refreshCache()`, which silently loses all session-level subagents until `loadSessionSubagents` is called again.

**Modified file:**
- `packages/core/src/subagents/subagent-manager.ts` — Preserve session subagents during refresh (6 insertions)

## Reviewer Test Plan

1. Load session subagents, then trigger a force refresh — verify session subagents are still available
2. Run subagent tests: `npx vitest run src/subagents/` (all 114 pass)
3. Run type check: `tsc --noEmit` (clean)

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |

## Linked issues / bugs

Quick bug fix