### PR TITLE
fix(mcp): clean up directory listener on connect failure

### DIFF
--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -884,10 +884,14 @@ export async function connectToMcpServer(
       });
       return mcpClient;
     } catch (error) {
+      unlistenDirectories?.();
+      unlistenDirectories = undefined;
       await transport.close();
       throw error;
     }
   } catch (error) {
+    unlistenDirectories?.();
+    unlistenDirectories = undefined;
     // Check if this is a 401 error that might indicate OAuth is required
     const errorString = String(error);
     if (errorString.includes('401') && hasNetworkTransport(mcpServerConfig)) {


### PR DESCRIPTION
Clean up directory listener on MCP connect failure.

## TLDR

Adds `unlistenDirectories?.()` cleanup to both the inner and outer catch blocks in `createMcpClient()`. Previously, if `connect()` or `createTransport()` threw, the `onDirectoriesChanged` listener registered before the connection attempt was never cleaned up, leaking on the workspace context.

## Screenshots / Video Demo

N/A — no user-facing UI change. The fix prevents listener leaks on failed MCP connections.

## Dive Deeper

The `onDirectoriesChanged` listener is registered at line 848, before `connect()` is called. If `connect()` throws (line 886-888), the catch block closed the transport but didn't clean up the listener. The `mcpClient.onclose` handler (line 867) never fires because the client never connected.

The leaked listener would fire on every directory change, attempting to send notifications to a non-existent connection. The inner try/catch in the listener would eventually trigger self-cleanup, but until a directory change happened, the listener held references to the dead mcpClient.

Similarly, if `createTransport()` throws, the outer catch also didn't clean up.

**Modified file:**
- `packages/core/src/tools/mcp-client.ts` — Added listener cleanup to both inner and outer catch blocks (4 insertions)

## Reviewer Test Plan

1. Configure an MCP server with an unreachable endpoint — verify no listener leak after connection failure
2. Run MCP client tests: `npx vitest run src/tools/mcp-client.test.ts` (all 26 pass)
3. Run type check: `tsc --noEmit` (clean)

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |

## Linked issues / bugs

NA; quick bug fix