### PR TITLE
fix(cli): serialize subagent confirmation focus to prevent concurrent input conflicts

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -179,6 +179,12 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
           isFocused &&
           !toolAwaitingApproval &&
           focusedSubagentCallId === tool.callId;
+        // Show the waiting indicator only when this subagent genuinely has a
+        // pending confirmation AND another subagent holds the focus lock.
+        const isWaitingForOtherApproval =
+          isAgentWithPendingConfirmation(tool.resultDisplay) &&
+          focusedSubagentCallId !== null &&
+          focusedSubagentCallId !== tool.callId;
         return (
           <Box key={tool.callId} flexDirection="column" minHeight={1}>
             <Box flexDirection="row" alignItems="center">
@@ -202,6 +208,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
                   tool.status === ToolCallStatus.Error
                 }
                 isFocused={isSubagentFocused}
+                isWaitingForOtherApproval={isWaitingForOtherApproval}
               />
             </Box>
             {tool.status === ToolCallStatus.Confirming &&

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -5,7 +5,7 @@
  */
 
 import type React from 'react';
-import { useMemo } from 'react';
+import { useMemo, useRef } from 'react';
 import { Box } from 'ink';
 import type { IndividualToolCallDisplay } from '../../types.js';
 import { ToolCallStatus } from '../../types.js';
@@ -16,6 +16,19 @@ import { theme } from '../../semantic-colors.js';
 import { SHELL_COMMAND_NAME, SHELL_NAME } from '../../constants.js';
 import { useConfig } from '../../contexts/ConfigContext.js';
 import { useVerboseMode } from '../../contexts/VerboseModeContext.js';
+import type { AgentResultDisplay } from '@qwen-code/qwen-code-core';
+
+function isAgentWithPendingConfirmation(
+  rd: IndividualToolCallDisplay['resultDisplay'],
+): rd is AgentResultDisplay {
+  return (
+    typeof rd === 'object' &&
+    rd !== null &&
+    'type' in rd &&
+    (rd as AgentResultDisplay).type === 'task_execution' &&
+    (rd as AgentResultDisplay).pendingConfirmation !== undefined
+  );
+}
 
 interface ToolGroupMessageProps {
   groupId: number;
@@ -59,6 +72,32 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
     () => toolCalls.find((tc) => tc.status === ToolCallStatus.Confirming),
     [toolCalls],
   );
+
+  // Determine which subagent tools currently have a pending confirmation.
+  // Must be called unconditionally (Rules of Hooks) — before any early return.
+  const subagentsAwaitingApproval = useMemo(
+    () =>
+      toolCalls.filter((tc) =>
+        isAgentWithPendingConfirmation(tc.resultDisplay),
+      ),
+    [toolCalls],
+  );
+
+  // "First-come, first-served" focus lock: once a subagent's confirmation
+  // appears, it keeps keyboard focus until the user resolves it. Only then
+  // does focus move to the next pending subagent. This prevents the jarring
+  // experience of focus jumping away while the user is mid-selection.
+  const focusedSubagentRef = useRef<string | null>(null);
+
+  const stillPending = subagentsAwaitingApproval.some(
+    (tc) => tc.callId === focusedSubagentRef.current,
+  );
+  if (!stillPending) {
+    // Release stale lock and promote the next pending subagent (if any).
+    focusedSubagentRef.current = subagentsAwaitingApproval[0]?.callId ?? null;
+  }
+
+  const focusedSubagentCallId = focusedSubagentRef.current;
 
   // Compact mode: entire group → single line summary
   // Force-expand when: user must interact (Confirming), tool errored,
@@ -133,6 +172,13 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
     >
       {toolCalls.map((tool) => {
         const isConfirming = toolAwaitingApproval?.callId === tool.callId;
+        // A subagent's inline confirmation should only receive keyboard focus
+        // when (1) there is no direct tool-level confirmation active, and
+        // (2) this tool currently holds the focus lock.
+        const isSubagentFocused =
+          isFocused &&
+          !toolAwaitingApproval &&
+          focusedSubagentCallId === tool.callId;
         return (
           <Box key={tool.callId} flexDirection="column" minHeight={1}>
             <Box flexDirection="row" alignItems="center">
@@ -155,6 +201,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
                   tool.status === ToolCallStatus.Confirming ||
                   tool.status === ToolCallStatus.Error
                 }
+                isFocused={isSubagentFocused}
               />
             </Box>
             {tool.status === ToolCallStatus.Confirming &&

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -173,12 +173,14 @@ const SubagentExecutionRenderer: React.FC<{
   availableHeight?: number;
   childWidth: number;
   config: Config;
-}> = ({ data, availableHeight, childWidth, config }) => (
+  isFocused?: boolean;
+}> = ({ data, availableHeight, childWidth, config, isFocused }) => (
   <AgentExecutionDisplay
     data={data}
     availableHeight={availableHeight}
     childWidth={childWidth}
     config={config}
+    isFocused={isFocused}
   />
 );
 
@@ -249,6 +251,8 @@ export interface ToolMessageProps extends IndividualToolCallDisplay {
   embeddedShellFocused?: boolean;
   config?: Config;
   forceShowResult?: boolean;
+  /** Whether this tool's subagent confirmation prompt should respond to keyboard input. */
+  isFocused?: boolean;
 }
 
 export const ToolMessage: React.FC<ToolMessageProps> = ({
@@ -265,6 +269,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   ptyId,
   config,
   forceShowResult,
+  isFocused,
 }) => {
   const settings = useSettings();
   const isThisShellFocused =
@@ -370,6 +375,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
                 availableHeight={availableHeight}
                 childWidth={innerWidth}
                 config={config}
+                isFocused={isFocused}
               />
             )}
             {effectiveDisplayRenderer.type === 'diff' && (

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -174,13 +174,22 @@ const SubagentExecutionRenderer: React.FC<{
   childWidth: number;
   config: Config;
   isFocused?: boolean;
-}> = ({ data, availableHeight, childWidth, config, isFocused }) => (
+  isWaitingForOtherApproval?: boolean;
+}> = ({
+  data,
+  availableHeight,
+  childWidth,
+  config,
+  isFocused,
+  isWaitingForOtherApproval,
+}) => (
   <AgentExecutionDisplay
     data={data}
     availableHeight={availableHeight}
     childWidth={childWidth}
     config={config}
     isFocused={isFocused}
+    isWaitingForOtherApproval={isWaitingForOtherApproval}
   />
 );
 
@@ -253,6 +262,8 @@ export interface ToolMessageProps extends IndividualToolCallDisplay {
   forceShowResult?: boolean;
   /** Whether this tool's subagent confirmation prompt should respond to keyboard input. */
   isFocused?: boolean;
+  /** Whether another subagent's approval currently holds the focus lock, blocking this one. */
+  isWaitingForOtherApproval?: boolean;
 }
 
 export const ToolMessage: React.FC<ToolMessageProps> = ({
@@ -270,6 +281,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   config,
   forceShowResult,
   isFocused,
+  isWaitingForOtherApproval,
 }) => {
   const settings = useSettings();
   const isThisShellFocused =
@@ -376,6 +388,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
                 childWidth={innerWidth}
                 config={config}
                 isFocused={isFocused}
+                isWaitingForOtherApproval={isWaitingForOtherApproval}
               />
             )}
             {effectiveDisplayRenderer.type === 'diff' && (

--- a/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.tsx
+++ b/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.tsx
@@ -26,6 +26,8 @@ export interface AgentExecutionDisplayProps {
   config: Config;
   /** Whether this display's confirmation prompt should respond to keyboard input. */
   isFocused?: boolean;
+  /** Whether another subagent's approval currently holds the focus lock, blocking this one. */
+  isWaitingForOtherApproval?: boolean;
 }
 
 const getStatusColor = (
@@ -81,6 +83,7 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
   childWidth,
   config,
   isFocused = true,
+  isWaitingForOtherApproval = false,
 }) => {
   const [displayMode, setDisplayMode] = React.useState<DisplayMode>('compact');
 
@@ -171,7 +174,7 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
             {/* Inline approval prompt when awaiting confirmation */}
             {data.pendingConfirmation && (
               <Box flexDirection="column" marginTop={1} paddingLeft={1}>
-                {!isFocused && (
+                {isWaitingForOtherApproval && (
                   <Box marginBottom={0}>
                     <Text color={theme.text.secondary} dimColor>
                       ⏳ Waiting for other approval...
@@ -247,7 +250,7 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
       {/* Inline approval prompt when awaiting confirmation */}
       {data.pendingConfirmation && (
         <Box flexDirection="column">
-          {!isFocused && (
+          {isWaitingForOtherApproval && (
             <Box marginBottom={0}>
               <Text color={theme.text.secondary} dimColor>
                 ⏳ Waiting for other approval...

--- a/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.tsx
+++ b/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.tsx
@@ -24,6 +24,8 @@ export interface AgentExecutionDisplayProps {
   availableHeight?: number;
   childWidth: number;
   config: Config;
+  /** Whether this display's confirmation prompt should respond to keyboard input. */
+  isFocused?: boolean;
 }
 
 const getStatusColor = (
@@ -78,6 +80,7 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
   availableHeight,
   childWidth,
   config,
+  isFocused = true,
 }) => {
   const [displayMode, setDisplayMode] = React.useState<DisplayMode>('compact');
 
@@ -168,9 +171,16 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
             {/* Inline approval prompt when awaiting confirmation */}
             {data.pendingConfirmation && (
               <Box flexDirection="column" marginTop={1} paddingLeft={1}>
+                {!isFocused && (
+                  <Box marginBottom={0}>
+                    <Text color={theme.text.secondary} dimColor>
+                      ⏳ Waiting for other approval...
+                    </Text>
+                  </Box>
+                )}
                 <ToolConfirmationMessage
                   confirmationDetails={data.pendingConfirmation}
-                  isFocused={true}
+                  isFocused={isFocused}
                   availableTerminalHeight={availableHeight}
                   contentWidth={childWidth - 4}
                   compactMode={true}
@@ -237,10 +247,17 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
       {/* Inline approval prompt when awaiting confirmation */}
       {data.pendingConfirmation && (
         <Box flexDirection="column">
+          {!isFocused && (
+            <Box marginBottom={0}>
+              <Text color={theme.text.secondary} dimColor>
+                ⏳ Waiting for other approval...
+              </Text>
+            </Box>
+          )}
           <ToolConfirmationMessage
             confirmationDetails={data.pendingConfirmation}
             config={config}
-            isFocused={true}
+            isFocused={isFocused}
             availableTerminalHeight={availableHeight}
             contentWidth={childWidth - 4}
             compactMode={true}


### PR DESCRIPTION
## TLDR

When multiple subagents run in parallel and each triggers a confirmation prompt, all prompts simultaneously receive keyboard focus (`isFocused={true}` is hardcoded in `AgentExecutionDisplay`). This means pressing ↑/↓/Enter dispatches to every active confirmation at once, causing unintended approvals.

This fix introduces a "first-come, first-served" focus lock so only one confirmation is interactive at a time, while others show "⏳ Waiting for other approval...".

## Screenshots / Video Demo

**Before (bug)** — all three prompts show `›` on option 2 simultaneously; pressing ↑/↓ moves the selection in all prompts at once:

```
  ╭─────────────────────────────────────────────────────────────────────────────╮
  │ ⊷  Agent Fetch httpbin.org/get                                            │
  │     ?  web_fetch Fetching content from https://httpbin.org/get ...         │
  │     Do you want to proceed?                                               │
  │       1. Yes, allow once                                                  │
  │     › 2. Allow always                                                     │
  │       3. No                                                               │
  │                                                                           │
  │ ⊷  Agent Write content to test file                                       │
  │     ?  write_file Writing to /tmp/test-agent-b.txt                        │
  │     Do you want to proceed?                                               │
  │       1. Yes, allow once                                                  │
  │     › 2. Allow always                                                     │
  │       3. No                                                               │
  │                                                                           │
  │ ⊷  Agent Echo hello to file                                               │
  │     ?  run_shell_command echo "hello from agent C" > /tmp/test-agent-c... │
  │     Do you want to proceed?                                               │
  │       1. Yes, allow once                                                  │
  │     › 2. Allow always                                                     │
  │       3. No                                                               │
  ╰─────────────────────────────────────────────────────────────────────────────╯
```

**After (fixed)** — only the first prompt is focused (`›` on option 2); the other two show "⏳ Waiting for other approval..." and their selections are frozen at option 1:

```
  ╭─────────────────────────────────────────────────────────────────────────────╮
  │ ⊷  Agent Fetch httpbin.org/get                                            │
  │     ?  web_fetch Fetching content from https://httpbin.org/get ...         │
  │     Do you want to proceed?                                               │
  │       1. Yes, allow once                                                  │
  │     › 2. Allow always                                                     │
  │       3. No                                                               │
  │                                                                           │
  │ ⊷  Agent Write content to test file                                       │
  │     ?  write_file Writing to /tmp/test-agent-b.txt                        │
  │     ⏳ Waiting for other approval...                                      │
  │     Do you want to proceed?                                               │
  │     › 1. Yes, allow once                                                  │
  │       2. Allow always                                                     │
  │       3. No                                                               │
  │                                                                           │
  │ ⊷  Agent Echo hello to file                                               │
  │     ?  run_shell_command echo "hello from agent C" > /tmp/test-agent-c... │
  │     ⏳ Waiting for other approval...                                      │
  │     Do you want to proceed?                                               │
  │     › 1. Yes, allow once                                                  │
  │       2. Allow always                                                     │
  │       3. No                                                               │
  ╰─────────────────────────────────────────────────────────────────────────────╯
```

## Dive Deeper

In `AgentExecutionDisplay.tsx`, `ToolConfirmationMessage` was rendered with `isFocused={true}` hardcoded. When multiple subagents run in parallel and each triggers a confirmation, all prompts simultaneously capture keyboard input.

The fix introduces a focus lock mechanism in `ToolGroupMessage`:

1. **Type guard** (`isAgentWithPendingConfirmation`): cleanly identifies subagent tool calls with pending confirmations, replacing scattered `as` casts.
2. **`useRef`-based lock**: the first subagent to present a confirmation acquires focus. The lock is released only when that confirmation is resolved, then automatically promotes to the next pending subagent.
3. **Prop passthrough**: `isFocused` flows down `ToolGroupMessage` → `ToolMessage` → `SubagentExecutionRenderer` → `AgentExecutionDisplay` → `ToolConfirmationMessage`.
4. **Waiting indicator**: non-focused confirmations render "⏳ Waiting for other approval..." so users understand why they can't interact yet.
5. **Priority**: tool-level confirmations (`toolAwaitingApproval`) always take priority over subagent-level confirmations.

`isFocused` defaults to `true` in `AgentExecutionDisplay`, so all existing call sites are unaffected. No new dependencies introduced.

Modified files:
- `packages/cli/src/ui/components/messages/ToolGroupMessage.tsx` — Core focus-lock logic (type guard, `useRef`, `isSubagentFocused` computation)
- `packages/cli/src/ui/components/messages/ToolMessage.tsx` — Prop passthrough (`isFocused?: boolean`)
- `packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.tsx` — Consume `isFocused`, render waiting indicator, forward to `ToolConfirmationMessage`

## Reviewer Test Plan

1. Launch a session that triggers 3 subagents in parallel (e.g., `"Launch 3 subagents: one fetches a URL, one writes a file, one runs a shell command"`)
2. Wait for all three subagents to each reach a confirmation prompt
3. Verify that only the **first** confirmation prompt has an active selection indicator (`›`)
4. Verify that the other two prompts show "⏳ Waiting for other approval..."
5. Resolve the focused confirmation → verify focus automatically moves to the next pending one
6. Test with a single subagent to confirm no regression (behaves exactly as before)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2929
