### PR TITLE
[codex] Fix outdated contributor setup docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ This command typically compiles TypeScript to JavaScript, bundles assets, and pr
 
 ### Enabling Sandboxing
 
-[Sandboxing](#sandboxing) is highly recommended and requires, at a minimum, setting `QWEN_SANDBOX=true` in your `~/.env` and ensuring a sandboxing provider (e.g. `macOS Seatbelt`, `docker`, or `podman`) is available. See [Sandboxing](#sandboxing) for details.
+Sandboxing is highly recommended and requires, at a minimum, setting `QWEN_SANDBOX=true` in your `~/.env` and ensuring a sandboxing provider (e.g. `macOS Seatbelt`, `docker`, or `podman`) is available. See the [Sandbox guide](./docs/users/features/sandbox.md) for supported providers, configuration, and troubleshooting details.
 
 To build both the `qwen-code` CLI utility and the sandbox container, run `build:all` from the root directory:
 
@@ -119,7 +119,7 @@ To start the Qwen Code application from the source code (after building), run th
 npm start
 ```
 
-If you'd like to run the source build outside of the qwen-code folder, you can utilize `npm link path/to/qwen-code/packages/cli` (see: [docs](https://docs.npmjs.com/cli/v9/commands/npm-link)) to run with `qwen-code`
+If you'd like to run the source build outside of the `qwen-code` folder, you can use `npm link path/to/qwen-code/packages/cli` (see: [docs](https://docs.npmjs.com/cli/v9/commands/npm-link)) and then run it with `qwen`.
 
 ### Running Tests
 
@@ -264,10 +264,10 @@ Alternatively, you can use the "Launch Program" configuration in VS Code if you 
 To hit a breakpoint inside the sandbox container run:
 
 ```bash
-DEBUG=1 qwen-code
+DEBUG=1 qwen
 ```
 
-**Note:** If you have `DEBUG=true` in a project's `.env` file, it won't affect qwen-code due to automatic exclusion. Use `.qwen-code/.env` files for qwen-code specific debug settings.
+**Note:** If you have `DEBUG=true` in a project's `.env` file, it won't affect Qwen Code due to automatic exclusion. Use `~/.qwen/.env` for user-level settings or `.qwen/.env` for project-specific settings.
 
 ### React DevTools
 
@@ -298,7 +298,7 @@ To debug the CLI's React-based UI, you can use React DevTools. Ink, the library 
 
 ## Sandboxing
 
-> TBD
+See the dedicated [Sandbox guide](./docs/users/features/sandbox.md) for setup instructions, provider selection, and troubleshooting.
 
 ## Manual Publish
 

--- a/docs/developers/contributing.md
+++ b/docs/developers/contributing.md
@@ -91,7 +91,7 @@ This command typically compiles TypeScript to JavaScript, bundles assets, and pr
 
 ### Enabling Sandboxing
 
-[Sandboxing](#sandboxing) is highly recommended and requires, at a minimum, setting `QWEN_SANDBOX=true` in your `~/.env` and ensuring a sandboxing provider (e.g. `macOS Seatbelt`, `docker`, or `podman`) is available. See [Sandboxing](#sandboxing) for details.
+Sandboxing is highly recommended and requires, at a minimum, setting `QWEN_SANDBOX=true` in your `~/.env` and ensuring a sandboxing provider (e.g. `macOS Seatbelt`, `docker`, or `podman`) is available. See the [Sandbox guide](../users/features/sandbox.md) for supported providers, configuration, and troubleshooting details.
 
 To build both the `qwen-code` CLI utility and the sandbox container, run `build:all` from the root directory:
 
@@ -109,7 +109,7 @@ To start the Qwen Code application from the source code (after building), run th
 npm start
 ```
 
-If you'd like to run the source build outside of the qwen-code folder, you can utilize `npm link path/to/qwen-code/packages/cli` (see: [docs](https://docs.npmjs.com/cli/v9/commands/npm-link)) to run with `qwen-code`
+If you'd like to run the source build outside of the `qwen-code` folder, you can use `npm link path/to/qwen-code/packages/cli` (see: [docs](https://docs.npmjs.com/cli/v9/commands/npm-link)) and then run it with `qwen`.
 
 ### Running Tests
 
@@ -254,10 +254,10 @@ Alternatively, you can use the "Launch Program" configuration in VS Code if you 
 To hit a breakpoint inside the sandbox container run:
 
 ```bash
-DEBUG=1 qwen-code
+DEBUG=1 qwen
 ```
 
-**Note:** If you have `DEBUG=true` in a project's `.env` file, it won't affect qwen-code due to automatic exclusion. Use `.qwen-code/.env` files for qwen-code specific debug settings.
+**Note:** If you have `DEBUG=true` in a project's `.env` file, it won't affect Qwen Code due to automatic exclusion. Use `~/.qwen/.env` for user-level settings or `.qwen/.env` for project-specific settings.
 
 ### React DevTools
 
@@ -288,7 +288,7 @@ To debug the CLI's React-based UI, you can use React DevTools. Ink, the library 
 
 ## Sandboxing
 
-> TBD
+See the dedicated [Sandbox guide](../users/features/sandbox.md) for setup instructions, provider selection, and troubleshooting.
 
 ## Manual Publish
 

--- a/docs/developers/tools/web-search.md
+++ b/docs/developers/tools/web-search.md
@@ -183,4 +183,4 @@ web_search(query="best practices for React 19", provider="dashscope")
 **Need help?**
 
 - Check your configuration: Run `qwen` and use the settings dialog
-- View your current settings in `~/.qwen-code/settings.json` (macOS/Linux) or `%USERPROFILE%\.qwen-code\settings.json` (Windows)
+- View your current settings in `~/.qwen/settings.json` (macOS/Linux) or `%USERPROFILE%\.qwen\settings.json` (Windows)


### PR DESCRIPTION
## Summary
- fix outdated contributor docs to use the `qwen` binary and `~/.qwen` config paths
- replace the empty sandboxing section with links to the dedicated sandbox guide
- align the web-search developer doc with the current settings file location

## Why
The contributor docs still contained legacy `qwen-code` / `.qwen-code` references and pointed readers to a sandbox section that was still `TBD`, which makes onboarding harder than it needs to be.

## Validation
- reviewed the updated markdown diff locally
