### PR TITLE
Remove CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-* @tanzhenxin @DennisYu07 @gwinthis @LaZzyMan @pomelo-nwu @Mingholy @DragonnZhang
-# SDK TypeScript package changes require review from Mingholy
-packages/sdk-typescript/** @Mingholy


### PR DESCRIPTION
## Summary
- Remove the broad `CODEOWNERS` wildcard that was adding notification noise without providing meaningful ownership boundaries
- Any team member with write access can now provide approving reviews

## Note
The `require_code_owner_review` setting in the repo ruleset should also be disabled to keep things clean, though it becomes a no-op without a CODEOWNERS file.