### PR TITLE
fix(weixin): add missing iLink-App-Id and iLink-App-ClientVersion headers

### DIFF
--- a/packages/channels/weixin/src/api.ts
+++ b/packages/channels/weixin/src/api.ts
@@ -12,10 +12,21 @@ import type {
   BaseInfo,
 } from './types.js';
 
-const CHANNEL_VERSION = '0.1.0';
+// iLink Bot API protocol version we are compatible with.
+// Used both in the request body (base_info.channel_version) and in the
+// iLink-App-ClientVersion header (encoded as 0x00MMNNPP).
+const ILINK_PROTOCOL_VERSION = '2.1.3';
+
+function buildClientVersion(version: string): number {
+  const parts = version.split('.').map((p) => parseInt(p, 10));
+  const major = parts[0] ?? 0;
+  const minor = parts[1] ?? 0;
+  const patch = parts[2] ?? 0;
+  return ((major & 0xff) << 16) | ((minor & 0xff) << 8) | (patch & 0xff);
+}
 
 function baseInfo(): BaseInfo {
-  return { channel_version: CHANNEL_VERSION };
+  return { channel_version: ILINK_PROTOCOL_VERSION };
 }
 
 function randomUin(): string {
@@ -28,6 +39,10 @@ function buildHeaders(token?: string): Record<string, string> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     'X-WECHAT-UIN': randomUin(),
+    'iLink-App-Id': 'bot',
+    'iLink-App-ClientVersion': String(
+      buildClientVersion(ILINK_PROTOCOL_VERSION),
+    ),
   };
   if (token) {
     headers['AuthorizationType'] = 'ilink_bot_token';


### PR DESCRIPTION
## TLDR

Add two required HTTP headers (`iLink-App-Id` and `iLink-App-ClientVersion`) to the WeChat channel's API requests. Without these, the iLink Bot API returns `errcode: -14` (session timeout), making the WeChat channel unusable.

Also aligns `base_info.channel_version` in the request body to use the same protocol version.

## Screenshots / Video Demo

N/A — no user-facing change beyond fixing the connection. The channel should now connect and poll successfully instead of immediately erroring out.

## Dive Deeper

The iLink Bot API requires two headers for client identification:
- `iLink-App-Id: bot` — identifies the caller as a bot client
- `iLink-App-ClientVersion` — a uint32-encoded version (`major<<16 | minor<<8 | patch`)

Our `buildHeaders()` was missing both. The official Tencent WeChat plugin (`@tencent-weixin/openclaw-weixin`) sends these alongside the `base_info.channel_version` in the request body — they serve different purposes (gateway identification vs body payload).

The protocol version (`2.1.3` → `131331`) is tracked via a single `ILINK_PROTOCOL_VERSION` constant, used for both the header and body, matching the official plugin's current version.

## Reviewer Test Plan

1. Build and bundle: `npm run build && npm run bundle`
2. Configure WeChat: `node dist/cli.js channel configure-weixin` (scan QR code)
3. Start channel: `node dist/cli.js channel start my-weixin`
4. Verify the channel connects without `errcode: -14`
5. Send a message from WeChat and confirm a response is received

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #2908
Related to #2882