### PR TITLE
fix(core): add getDefaultPermission and allowExternalPaths to ripGrep tool

### DIFF
--- a/packages/core/src/tools/ripGrep.test.ts
+++ b/packages/core/src/tools/ripGrep.test.ts
@@ -590,11 +590,12 @@ describe('RipGrepTool', () => {
   });
 
   describe('error handling and edge cases', () => {
-    it('should handle workspace boundary violations', () => {
+    it('should handle workspace boundary violations', async () => {
       const params: RipGrepToolParams = { pattern: 'test', path: '../outside' };
-      expect(() => grepTool.build(params)).toThrow(
-        /Path is not within workspace/,
-      );
+      // External paths are allowed; permission is deferred to getDefaultPermission()
+      const invocation = grepTool.build(params);
+      const permission = await invocation.getDefaultPermission();
+      expect(permission).toBe('ask');
     });
 
     it('should handle empty directories gracefully', async () => {
@@ -862,6 +863,36 @@ describe('RipGrepTool', () => {
       const params: RipGrepToolParams = { pattern: 'testPattern', path: '.' };
       const invocation = grepTool.build(params);
       expect(invocation.getDescription()).toBe("'testPattern' in path '.'");
+    });
+  });
+
+  describe('getDefaultPermission', () => {
+    it('should return allow when no path is specified', async () => {
+      const params: RipGrepToolParams = { pattern: 'hello' };
+      const invocation = grepTool.build(params);
+      const permission = await invocation.getDefaultPermission();
+      expect(permission).toBe('allow');
+    });
+
+    it('should return allow for paths within workspace', async () => {
+      const params: RipGrepToolParams = { pattern: 'hello', path: '.' };
+      const invocation = grepTool.build(params);
+      const permission = await invocation.getDefaultPermission();
+      expect(permission).toBe('allow');
+    });
+
+    it('should return allow for subdirectories within workspace', async () => {
+      const params: RipGrepToolParams = { pattern: 'hello', path: 'sub' };
+      const invocation = grepTool.build(params);
+      const permission = await invocation.getDefaultPermission();
+      expect(permission).toBe('allow');
+    });
+
+    it('should return ask for paths outside workspace', async () => {
+      const params: RipGrepToolParams = { pattern: 'hello', path: '/tmp' };
+      const invocation = grepTool.build(params);
+      const permission = await invocation.getDefaultPermission();
+      expect(permission).toBe('ask');
     });
   });
 });

--- a/packages/core/src/tools/ripGrep.ts
+++ b/packages/core/src/tools/ripGrep.ts
@@ -17,6 +17,7 @@ import { SchemaValidator } from '../utils/schemaValidator.js';
 import type { FileFilteringOptions } from '../config/constants.js';
 import { DEFAULT_FILE_FILTERING_OPTIONS } from '../config/constants.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import type { PermissionDecision } from '../permissions/types.js';
 
 const debugLogger = createDebugLogger('RIPGREP');
 
@@ -56,6 +57,25 @@ class GrepToolInvocation extends BaseToolInvocation<
     super(params);
   }
 
+  /**
+   * Returns 'ask' for paths outside the workspace, so that external grep
+   * searches require user confirmation.
+   */
+  override async getDefaultPermission(): Promise<PermissionDecision> {
+    if (!this.params.path) {
+      return 'allow'; // Default workspace directory
+    }
+    const workspaceContext = this.config.getWorkspaceContext();
+    const resolvedPath = path.resolve(
+      this.config.getTargetDir(),
+      this.params.path,
+    );
+    if (workspaceContext.isPathWithinWorkspace(resolvedPath)) {
+      return 'allow';
+    }
+    return 'ask';
+  }
+
   async execute(signal: AbortSignal): Promise<ToolResult> {
     try {
       // Determine which paths to search
@@ -67,7 +87,7 @@ class GrepToolInvocation extends BaseToolInvocation<
         const searchDirAbs = resolveAndValidatePath(
           this.config,
           this.params.path,
-          { allowFiles: true },
+          { allowFiles: true, allowExternalPaths: true },
         );
         searchPaths.push(searchDirAbs);
         searchDirDisplay = this.params.path;
@@ -364,7 +384,10 @@ export class RipGrepTool extends BaseDeclarativeTool<
     // Only validate path if one is provided
     if (params.path) {
       try {
-        resolveAndValidatePath(this.config, params.path, { allowFiles: true });
+        resolveAndValidatePath(this.config, params.path, {
+          allowFiles: true,
+          allowExternalPaths: true,
+        });
       } catch (error) {
         return getErrorMessage(error);
       }


### PR DESCRIPTION
## TLDR

`RipGrepTool` was missing a `getDefaultPermission()` override and passing `allowExternalPaths: true` to `resolveAndValidatePath`, unlike its sibling `GrepTool` (grep.ts) which has both. This caused grep searches in arbitrary workspace paths to fail with **"Path is not within workspace"** even when the user explicitly specified an external path.

This PR adds:
1. **`getDefaultPermission()` override** in `GrepToolInvocation` (ripGrep.ts) — returns `"allow"` for workspace-internal paths and `"ask"` for external paths, matching `grep.ts` behavior.
2. **`allowExternalPaths: true`** in both `execute()` and `validateToolParamValues()` — so external paths are not rejected at the validation layer; permission checks are deferred to `getDefaultPermission()` as designed.
3. **Updated test** — the old "workspace boundary violations" test expected a throw; it now verifies `getDefaultPermission()` returns `"ask"` for external paths.
4. **4 new tests** for `getDefaultPermission()` covering no-path, workspace-internal, subdirectory, and external-path scenarios.

## Screenshots / Video Demo

N/A — no user-facing change. This is a bug fix that aligns `ripGrep.ts` permission handling with `grep.ts` and fixes the "Path is not within workspace" error when searching external directories.

## Dive Deeper

The root cause is a long-standing inconsistency between two grep tool implementations:

| File | `getDefaultPermission()` | `allowExternalPaths` |
|------|------------------------|---------------------|
| `grep.ts` | ✅ Override present | ✅ `true` |
| `ripGrep.ts` | ❌ Missing (inherited default `"allow"`) | ❌ `false` |

When commit `217d59c89` ("feat enable other dirs with core tools") added `getDefaultPermission()` and `allowExternalPaths: true` to grep.ts, glob.ts, ls.ts, read-file.ts, and other core tools, **ripGrep.ts was accidentally omitted**. The subsequent PR #2637 ("fix search tool for multi dirs") added multi-directory search support to ripgrep but did not address this underlying permission/ validation gap.

The fix ensures that:
- Workspace paths → `"allow"` (no confirmation needed)
- External paths → `"ask"` (user confirmation required)
- YOLO mode properly respects the permission decision flow

## Reviewer Test Plan

Run the ripGrep tests to verify all 48 tests pass:
```bash
npx vitest run packages/core/src/tools/ripGrep.test.ts
```

To manually validate the behavior change:
1. Start qwen code with a workspace directory
2. Ask it to search for a pattern in a path **outside** the workspace (e.g., `/tmp` or `../sibling-project`)
3. **Before this PR**: fails with `"Path is not within workspace"`
4. **After this PR**: prompts for confirmation (or auto-approves in YOLO mode)

## Testing Matrix

|          | 🍏 macOS | 🪟 Windows | 🐧 Linux |
| -------- | -------- | ---------- | -------- |
| npm run  | ✔️       | ❓         | ❓       |

## Linked issues / bugs

Fixes #2919