### PR TITLE
feat(skills): add model override support via skill frontmatter

### DIFF
--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -371,8 +371,10 @@ export async function runNonInteractive(
               toolResponseParts.push(...toolResponse.responseParts);
             }
 
-            // Capture model override from skill tool results
-            if (toolResponse.modelOverride) {
+            // Capture model override from skill tool results.
+            // Use `in` so that undefined (from inherit/no-model skills) clears a prior override,
+            // while non-skill tools (field absent) leave the current override intact.
+            if ('modelOverride' in toolResponse) {
               modelOverride = toolResponse.modelOverride;
             }
           }

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -409,6 +409,7 @@ export async function runNonInteractive(
                       { role: 'user', parts: [{ text: cronPrompt }] },
                     ];
                     let cronIsFirstTurn = true;
+                    let cronModelOverride: string | undefined;
 
                     while (true) {
                       const cronToolCallRequests: ToolCallRequestInfo[] = [];
@@ -421,6 +422,7 @@ export async function runNonInteractive(
                           type: cronIsFirstTurn
                             ? SendMessageType.Cron
                             : SendMessageType.ToolResult,
+                          modelOverride: cronModelOverride,
                         },
                       );
                       cronIsFirstTurn = false;
@@ -484,6 +486,10 @@ export async function runNonInteractive(
                             cronToolResponseParts.push(
                               ...toolResponse.responseParts,
                             );
+                          }
+
+                          if ('modelOverride' in toolResponse) {
+                            cronModelOverride = toolResponse.modelOverride;
                           }
                         }
                         cronMessages = [

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -251,6 +251,7 @@ export async function runNonInteractive(
       let currentMessages: Content[] = [{ role: 'user', parts: initialParts }];
 
       let isFirstTurn = true;
+      let modelOverride: string | undefined;
       while (true) {
         turnCount++;
         if (
@@ -270,6 +271,7 @@ export async function runNonInteractive(
             type: isFirstTurn
               ? SendMessageType.UserQuery
               : SendMessageType.ToolResult,
+            modelOverride,
           },
         );
         isFirstTurn = false;
@@ -367,6 +369,11 @@ export async function runNonInteractive(
 
             if (toolResponse.responseParts) {
               toolResponseParts.push(...toolResponse.responseParts);
+            }
+
+            // Capture model override from skill tool results
+            if (toolResponse.modelOverride) {
+              modelOverride = toolResponse.modelOverride;
             }
           }
           currentMessages = [{ role: 'user', parts: toolResponseParts }];

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -199,6 +199,7 @@ export const useGeminiStream = (
     null,
   );
   const processedMemoryToolsRef = useRef<Set<string>>(new Set());
+  const modelOverrideRef = useRef<string | undefined>(undefined);
   const {
     startNewPrompt,
     getPromptCount,
@@ -1165,7 +1166,6 @@ export const useGeminiStream = (
       query: PartListUnion,
       submitType: SendMessageType = SendMessageType.UserQuery,
       prompt_id?: string,
-      modelOverride?: string,
     ) => {
       const allowConcurrentBtwDuringResponse =
         submitType === SendMessageType.UserQuery &&
@@ -1202,6 +1202,7 @@ export const useGeminiStream = (
         !allowConcurrentBtwDuringResponse
       ) {
         setModelSwitchedFromQuotaError(false);
+        modelOverrideRef.current = undefined;
         // Commit any pending retry error to history (without hint) since the
         // user is starting a new conversation turn.
         // Clear both countdown-based errors AND static errors (those without
@@ -1301,7 +1302,7 @@ export const useGeminiStream = (
             finalQueryToSend,
             abortSignal,
             prompt_id!,
-            { type: submitType, modelOverride },
+            { type: submitType, modelOverride: modelOverrideRef.current },
           );
 
           const processingStatus = await processGeminiStreamEvents(
@@ -1567,11 +1568,12 @@ export const useGeminiStream = (
         (toolCall) => toolCall.request.prompt_id,
       );
 
-      // Extract model override from skill tool results (last one wins)
-      let toolModelOverride: string | undefined;
+      // Persist model override from skill tool results (last one wins).
+      // Uses `in` so that undefined (from inherit/no-model skills) clears a
+      // prior override, while non-skill tools (field absent) leave it intact.
       for (const toolCall of geminiTools) {
         if ('modelOverride' in toolCall.response) {
-          toolModelOverride = toolCall.response.modelOverride;
+          modelOverrideRef.current = toolCall.response.modelOverride;
         }
       }
 
@@ -1599,12 +1601,7 @@ export const useGeminiStream = (
         }
       }
 
-      submitQuery(
-        responsesToSend,
-        SendMessageType.ToolResult,
-        prompt_ids[0],
-        toolModelOverride,
-      );
+      submitQuery(responsesToSend, SendMessageType.ToolResult, prompt_ids[0]);
     },
     [
       isResponding,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1165,6 +1165,7 @@ export const useGeminiStream = (
       query: PartListUnion,
       submitType: SendMessageType = SendMessageType.UserQuery,
       prompt_id?: string,
+      modelOverride?: string,
     ) => {
       const allowConcurrentBtwDuringResponse =
         submitType === SendMessageType.UserQuery &&
@@ -1300,7 +1301,7 @@ export const useGeminiStream = (
             finalQueryToSend,
             abortSignal,
             prompt_id!,
-            { type: submitType },
+            { type: submitType, modelOverride },
           );
 
           const processingStatus = await processGeminiStreamEvents(
@@ -1566,6 +1567,14 @@ export const useGeminiStream = (
         (toolCall) => toolCall.request.prompt_id,
       );
 
+      // Extract model override from skill tool results (last one wins)
+      let toolModelOverride: string | undefined;
+      for (const toolCall of geminiTools) {
+        if ('modelOverride' in toolCall.response) {
+          toolModelOverride = toolCall.response.modelOverride;
+        }
+      }
+
       markToolsAsSubmitted(callIdsToMarkAsSubmitted);
 
       // Don't continue if model was switched due to quota error
@@ -1590,7 +1599,12 @@ export const useGeminiStream = (
         }
       }
 
-      submitQuery(responsesToSend, SendMessageType.ToolResult, prompt_ids[0]);
+      submitQuery(
+        responsesToSend,
+        SendMessageType.ToolResult,
+        prompt_ids[0],
+        toolModelOverride,
+      );
     },
     [
       isResponding,

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1202,7 +1202,11 @@ export const useGeminiStream = (
         !allowConcurrentBtwDuringResponse
       ) {
         setModelSwitchedFromQuotaError(false);
-        modelOverrideRef.current = undefined;
+        // Clear model override for new user turns, but preserve it on retry
+        // so the same skill-selected model is used again.
+        if (submitType !== SendMessageType.Retry) {
+          modelOverrideRef.current = undefined;
+        }
         // Commit any pending retry error to history (without hint) since the
         // user is starting a new conversation turn.
         // Clear both countdown-based errors AND static errors (those without

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -109,6 +109,8 @@ export interface SendMessageOptions {
     iterationCount: number;
     reasons: string[];
   };
+  /** Model override from skill execution. When present, overrides the session model for this turn. */
+  modelOverride?: string;
 }
 
 export class GeminiClient {
@@ -626,6 +628,9 @@ export class GeminiClient {
 
     const turn = new Turn(this.getChat(), prompt_id);
 
+    // Determine the model to use for this turn
+    const model = options?.modelOverride ?? this.config.getModel();
+
     // append system reminders to the request
     let requestToSent = await flatMapTextParts(request, async (text) => [text]);
     if (
@@ -668,11 +673,7 @@ export class GeminiClient {
       requestToSent = [...systemReminders, ...requestToSent];
     }
 
-    const resultStream = turn.run(
-      this.config.getModel(),
-      requestToSent,
-      signal,
-    );
+    const resultStream = turn.run(model, requestToSent, signal);
     for await (const event of resultStream) {
       if (!this.config.getSkipLoopDetection()) {
         if (this.loopDetector.addAndCheck(event)) {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -800,6 +800,7 @@ export class GeminiClient {
           prompt_id,
           {
             type: SendMessageType.Hook,
+            modelOverride: options?.modelOverride,
             stopHookState: {
               iterationCount: currentIterationCount,
               reasons: currentReasons,

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1486,6 +1486,7 @@ export class CoreToolScheduler {
           error: undefined,
           errorType: undefined,
           contentLength,
+          modelOverride: toolResult.modelOverride,
         };
         this.setStatusInternal(callId, 'success', successResponse);
       } else {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1486,7 +1486,9 @@ export class CoreToolScheduler {
           error: undefined,
           errorType: undefined,
           contentLength,
-          ...(toolResult.modelOverride
+          // Propagate modelOverride from skill tools. Use `in` to distinguish
+          // "skill returned undefined (inherit)" from "non-skill tool (no field)".
+          ...('modelOverride' in toolResult
             ? { modelOverride: toolResult.modelOverride }
             : {}),
         };

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1486,7 +1486,9 @@ export class CoreToolScheduler {
           error: undefined,
           errorType: undefined,
           contentLength,
-          modelOverride: toolResult.modelOverride,
+          ...(toolResult.modelOverride
+            ? { modelOverride: toolResult.modelOverride }
+            : {}),
         };
         this.setStatusInternal(callId, 'success', successResponse);
       } else {

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -108,6 +108,7 @@ export interface ToolCallResponseInfo {
   error: Error | undefined;
   errorType: ToolErrorType | undefined;
   contentLength?: number;
+  modelOverride?: string;
 }
 
 export interface ServerToolCallConfirmationDetails {

--- a/packages/core/src/skills/skill-load.test.ts
+++ b/packages/core/src/skills/skill-load.test.ts
@@ -10,6 +10,7 @@ import {
   loadSkillsFromDir,
   validateConfig,
 } from './skill-load.js';
+import { parseModelField } from './types.js';
 import * as fs from 'fs/promises';
 
 // Mock file system operations
@@ -298,6 +299,94 @@ Valid skill.
 
       expect(result.isValid).toBe(true);
       expect(result.warnings).toContain('Skill body is empty');
+    });
+  });
+
+  describe('parseModelField', () => {
+    it('should return the model string for a valid model', () => {
+      expect(parseModelField({ model: 'qwen-max' })).toBe('qwen-max');
+    });
+
+    it('should return undefined when model is omitted', () => {
+      expect(parseModelField({})).toBeUndefined();
+    });
+
+    it('should return undefined for "inherit"', () => {
+      expect(parseModelField({ model: 'inherit' })).toBeUndefined();
+    });
+
+    it('should return undefined for empty string', () => {
+      expect(parseModelField({ model: '' })).toBeUndefined();
+    });
+
+    it('should return undefined for whitespace-only string', () => {
+      expect(parseModelField({ model: '   ' })).toBeUndefined();
+    });
+
+    it('should trim whitespace from model string', () => {
+      expect(parseModelField({ model: '  qwen-max  ' })).toBe('qwen-max');
+    });
+
+    it('should throw for non-string types', () => {
+      expect(() => parseModelField({ model: 123 })).toThrow(
+        '"model" must be a string',
+      );
+      expect(() => parseModelField({ model: true })).toThrow(
+        '"model" must be a string',
+      );
+    });
+
+    it('should treat "inherit" case-sensitively', () => {
+      expect(parseModelField({ model: 'Inherit' })).toBe('Inherit');
+      expect(parseModelField({ model: 'INHERIT' })).toBe('INHERIT');
+    });
+  });
+
+  describe('parseSkillContent model field', () => {
+    const testFilePath = '/test/extension/skills/model-test/SKILL.md';
+
+    it('should parse model from frontmatter', () => {
+      mockParseYaml.mockReturnValue({
+        name: 'model-test',
+        description: 'Test skill with model',
+        model: 'qwen-max',
+      });
+
+      const config = parseSkillContent(
+        `---\nname: model-test\ndescription: Test skill with model\nmodel: qwen-max\n---\n\nBody text.`,
+        testFilePath,
+      );
+
+      expect(config.model).toBe('qwen-max');
+    });
+
+    it('should set model to undefined when omitted', () => {
+      mockParseYaml.mockReturnValue({
+        name: 'model-test',
+        description: 'Test skill without model',
+      });
+
+      const config = parseSkillContent(
+        `---\nname: model-test\ndescription: Test skill without model\n---\n\nBody text.`,
+        testFilePath,
+      );
+
+      expect(config.model).toBeUndefined();
+    });
+
+    it('should set model to undefined for "inherit"', () => {
+      mockParseYaml.mockReturnValue({
+        name: 'model-test',
+        description: 'Test skill with inherit',
+        model: 'inherit',
+      });
+
+      const config = parseSkillContent(
+        `---\nname: model-test\ndescription: Test skill with inherit\nmodel: inherit\n---\n\nBody text.`,
+        testFilePath,
+      );
+
+      expect(config.model).toBeUndefined();
     });
   });
 });

--- a/packages/core/src/skills/skill-load.ts
+++ b/packages/core/src/skills/skill-load.ts
@@ -1,4 +1,8 @@
-import type { SkillConfig, SkillValidationResult } from './types.js';
+import {
+  type SkillConfig,
+  type SkillValidationResult,
+  parseModelField,
+} from './types.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { parse as parseYaml } from '../utils/yaml-parser.js';
@@ -109,15 +113,7 @@ export function parseSkillContent(
   }
 
   // Extract optional model field
-  const modelRaw = frontmatter['model'];
-  let model: string | undefined;
-  if (modelRaw !== undefined) {
-    if (typeof modelRaw !== 'string') {
-      throw new Error('"model" must be a string');
-    }
-    // "inherit" means explicitly use the session model — treat as no override
-    model = modelRaw.trim() === 'inherit' ? undefined : modelRaw.trim();
-  }
+  const model = parseModelField(frontmatter);
 
   const config: SkillConfig = {
     name,

--- a/packages/core/src/skills/skill-load.ts
+++ b/packages/core/src/skills/skill-load.ts
@@ -108,10 +108,22 @@ export function parseSkillContent(
     }
   }
 
+  // Extract optional model field
+  const modelRaw = frontmatter['model'];
+  let model: string | undefined;
+  if (modelRaw !== undefined) {
+    if (typeof modelRaw !== 'string') {
+      throw new Error('"model" must be a string');
+    }
+    // "inherit" means explicitly use the session model — treat as no override
+    model = modelRaw.trim() === 'inherit' ? undefined : modelRaw.trim();
+  }
+
   const config: SkillConfig = {
     name,
     description,
     allowedTools,
+    model,
     filePath,
     body: body.trim(),
     level: 'extension',

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -17,7 +17,7 @@ import type {
   ListSkillsOptions,
   SkillValidationResult,
 } from './types.js';
-import { SkillError, SkillErrorCode } from './types.js';
+import { SkillError, SkillErrorCode, parseModelField } from './types.js';
 import type { Config } from '../config/config.js';
 import { validateConfig } from './skill-load.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
@@ -397,14 +397,7 @@ export class SkillManager {
       }
 
       // Extract optional model field
-      const modelRaw = frontmatter['model'];
-      let model: string | undefined;
-      if (modelRaw !== undefined) {
-        if (typeof modelRaw !== 'string') {
-          throw new Error('"model" must be a string');
-        }
-        model = modelRaw.trim() === 'inherit' ? undefined : modelRaw.trim();
-      }
+      const model = parseModelField(frontmatter);
 
       const config: SkillConfig = {
         name,

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -396,10 +396,21 @@ export class SkillManager {
         }
       }
 
+      // Extract optional model field
+      const modelRaw = frontmatter['model'];
+      let model: string | undefined;
+      if (modelRaw !== undefined) {
+        if (typeof modelRaw !== 'string') {
+          throw new Error('"model" must be a string');
+        }
+        model = modelRaw.trim() === 'inherit' ? undefined : modelRaw.trim();
+      }
+
       const config: SkillConfig = {
         name,
         description,
         allowedTools,
+        model,
         level,
         filePath,
         body: body.trim(),

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -32,6 +32,14 @@ export interface SkillConfig {
   allowedTools?: string[];
 
   /**
+   * Optional model override for this skill's execution.
+   * Uses the same selector syntax as subagent model selectors:
+   * bare model ID (e.g., `qwen-coder-plus`), `authType:modelId`
+   * for cross-provider, or omitted/`inherit` to use the session model.
+   */
+  model?: string;
+
+  /**
    * Storage level - determines where the configuration file is stored
    */
   level: SkillLevel;

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -67,6 +67,27 @@ export interface SkillConfig {
 export type SkillRuntimeConfig = SkillConfig;
 
 /**
+ * Parse the `model` field from skill frontmatter.
+ * Returns `undefined` for omitted, empty, or "inherit" values.
+ */
+export function parseModelField(
+  frontmatter: Record<string, unknown>,
+): string | undefined {
+  const raw = frontmatter['model'];
+  if (raw === undefined) {
+    return undefined;
+  }
+  if (typeof raw !== 'string') {
+    throw new Error('"model" must be a string');
+  }
+  const trimmed = raw.trim();
+  if (trimmed === '' || trimmed === 'inherit') {
+    return undefined;
+  }
+  return trimmed;
+}
+
+/**
  * Result of a validation operation on a skill configuration.
  */
 export interface SkillValidationResult {

--- a/packages/core/src/tools/skill.test.ts
+++ b/packages/core/src/tools/skill.test.ts
@@ -11,6 +11,7 @@ import type { ToolResultDisplay } from './tools.js';
 import type { Config } from '../config/config.js';
 import { SkillManager } from '../skills/skill-manager.js';
 import type { SkillConfig } from '../skills/types.js';
+import type { ToolResult } from './tools.js';
 import { partToString } from '../utils/partUtils.js';
 
 // Type for accessing protected methods in tests
@@ -430,6 +431,71 @@ describe('SkillTool', () => {
       expect(result.returnDisplay).toBe(
         'Specialized skill for reviewing code quality',
       );
+    });
+  });
+
+  describe('modelOverride propagation', () => {
+    it('should propagate model from skill config to ToolResult', async () => {
+      const skillWithModel: SkillConfig = {
+        ...mockSkills[0],
+        model: 'qwen-max',
+      };
+      vi.mocked(mockSkillManager.loadSkillForRuntime).mockResolvedValue(
+        skillWithModel,
+      );
+
+      const invocation = (
+        skillTool as SkillToolWithProtectedMethods
+      ).createInvocation({ skill: 'code-review' });
+      const result = (await invocation.execute()) as unknown as ToolResult;
+
+      expect(result.modelOverride).toBe('qwen-max');
+    });
+
+    it('should set modelOverride to undefined when skill has no model', async () => {
+      const skillWithoutModel: SkillConfig = {
+        ...mockSkills[0],
+        // model is undefined (omitted)
+      };
+      vi.mocked(mockSkillManager.loadSkillForRuntime).mockResolvedValue(
+        skillWithoutModel,
+      );
+
+      const invocation = (
+        skillTool as SkillToolWithProtectedMethods
+      ).createInvocation({ skill: 'code-review' });
+      const result = (await invocation.execute()) as unknown as ToolResult;
+
+      // modelOverride should be present (via `in` check) but undefined,
+      // signaling "clear any prior override"
+      expect('modelOverride' in result).toBe(true);
+      expect(result.modelOverride).toBeUndefined();
+    });
+
+    it('should not include modelOverride when skill is not found', async () => {
+      vi.mocked(mockSkillManager.loadSkillForRuntime).mockResolvedValue(null);
+
+      const invocation = (
+        skillTool as SkillToolWithProtectedMethods
+      ).createInvocation({ skill: 'non-existent' });
+      const result = (await invocation.execute()) as unknown as ToolResult;
+
+      // No modelOverride field — prior override should persist
+      expect('modelOverride' in result).toBe(false);
+    });
+
+    it('should not include modelOverride when skill load throws', async () => {
+      vi.mocked(mockSkillManager.loadSkillForRuntime).mockRejectedValue(
+        new Error('load error'),
+      );
+
+      const invocation = (
+        skillTool as SkillToolWithProtectedMethods
+      ).createInvocation({ skill: 'code-review' });
+      const result = (await invocation.execute()) as unknown as ToolResult;
+
+      // No modelOverride field — prior override should persist
+      expect('modelOverride' in result).toBe(false);
     });
   });
 });

--- a/packages/core/src/tools/skill.ts
+++ b/packages/core/src/tools/skill.ts
@@ -281,6 +281,7 @@ class SkillToolInvocation extends BaseToolInvocation<SkillParams, ToolResult> {
       return {
         llmContent: [{ text: llmContent }],
         returnDisplay: skill.description,
+        modelOverride: skill.model,
       };
     } catch (error) {
       const errorMessage =

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -396,6 +396,13 @@ export interface ToolResult {
     message: string; // raw error message
     type?: ToolErrorType; // An optional machine-readable error type (e.g., 'FILE_NOT_FOUND').
   };
+
+  /**
+   * Optional model override propagated from skill execution.
+   * When present, the client should use this model for subsequent
+   * turns within the same agentic loop.
+   */
+  modelOverride?: string;
 }
 
 /**


### PR DESCRIPTION
## TLDR

Add `model` field to skill YAML frontmatter, enabling skills to override which model is used for subsequent turns within the same agentic loop. When a skill specifies `model: qwen-coder-plus`, the API requests after the skill tool call use that model instead of the session default. The override naturally expires when the agentic loop ends.

This implements same-provider model switching (phase 1). Cross-provider switching (requiring ContentGenerator threading) is deferred to a follow-up.

## Screenshots / Video Demo

N/A — no user-facing UI change. The feature is exercised via skill frontmatter configuration. E2E validation was done by inspecting OpenAI-format API logs (`--openai-logging`):

- **Before skill call**: `"model": "glm-5"` (session default)
- **After skill call**: `"model": "qwen3-coder-plus"` (skill override)

## Dive Deeper

**How it works**: The `model` string flows through a simple pipeline:

1. Skill frontmatter → `SkillConfig.model` (parsed in both `skill-load.ts` and `skill-manager.ts`)
2. `SkillToolInvocation.execute()` → `ToolResult.modelOverride`
3. `CoreToolScheduler` → `ToolCallResponseInfo.modelOverride`
4. Client loop (e.g., `nonInteractiveCli.ts`) captures the override and passes it as `SendMessageOptions.modelOverride`
5. `GeminiClient.sendMessageStream()` uses the override instead of `config.getModel()` when calling `Turn.run()`

**Scoping**: The override lives in the `SendMessageOptions` parameter, not in persistent config. It naturally expires when the agentic loop ends (no more tool calls). The next user message starts fresh.

**`inherit` handling**: `model: inherit` is treated as no override (stored as `undefined`), same as omitting the field entirely.

**Cross-provider limitation**: The current implementation only swaps the model string. Same-provider switches work because the existing `ContentGenerator` handles different model IDs within the same provider. Cross-provider switches (e.g., `anthropic:kimi-k2.5`) require threading a separate `ContentGenerator` through the call chain — this is the `resolveModelOverride()` work described in the design doc (sections 4a-4c) and will be a follow-up PR.

## Reviewer Test Plan

Build and bundle: `npm run build && npm run bundle`

**Quick unit test validation:**
```bash
cd packages/core && npx vitest run src/skills/skill-load.test.ts
cd packages/core && npx vitest run src/skills/skill-manager.test.ts
cd packages/core && npx vitest run src/tools/skill.test.ts
```

**E2E validation (same-provider override):**

1. Create a skill directory:
```bash
mkdir -p /tmp/test-skill/.qwen/skills/test-override
cat > /tmp/test-skill/.qwen/skills/test-override/SKILL.md << 'SKILLEOF'
---
name: test-override
description: Test model override
model: qwen-coder-plus
---

Respond with exactly: "Override works"
SKILLEOF
```

2. Run headless with API logging:
```bash
cd /tmp/test-skill && node dist/cli.js "use the test-override skill" \
  --approval-mode yolo --output-format json \
  --openai-logging --openai-logging-dir /tmp/api-logs 2>/dev/null
```

3. Inspect the API logs in `/tmp/api-logs/` — the second request's `model` field should differ from the first.

**Additional scenarios to verify:**
- Skill with `model: inherit` → all requests use session default
- Skill with no `model` field → all requests use session default (backwards compat)
- Skill with `model: nonexistent-model` → skill loads OK, API handles the unknown model

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #2052