### PR TITLE
fix(cli): disable follow-up suggestions by default

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -518,7 +518,7 @@ const SETTINGS_SCHEMA = {
         label: 'Enable Follow-up Suggestions',
         category: 'UI',
         requiresRestart: false,
-        default: true,
+        default: false,
         description:
           'Show context-aware follow-up suggestions after task completion. Press Tab or Right Arrow to accept, Enter to accept and submit.',
         showInDialog: true,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1113,7 +1113,7 @@ export const AppContainer = (props: AppContainerProps) => {
 
   // Generate prompt suggestions when streaming completes
   const followupSuggestionsEnabled =
-    settings.merged.ui?.enableFollowupSuggestions !== false;
+    settings.merged.ui?.enableFollowupSuggestions === true;
 
   useEffect(() => {
     // Clear suggestion when feature is disabled at runtime

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -183,7 +183,7 @@
         "enableFollowupSuggestions": {
           "description": "Show context-aware follow-up suggestions after task completion. Press Tab or Right Arrow to accept, Enter to accept and submit.",
           "type": "boolean",
-          "default": true
+          "default": false
         },
         "enableCacheSharing": {
           "description": "Use cache-aware forked queries for suggestion generation. Reduces cost on providers that support prefix caching (experimental).",


### PR DESCRIPTION
## TLDR

Disable follow-up suggestions by default. Most Qwen OAuth users don't have a fast model configured for this feature, so it fires a wasted API request on every turn with no visible benefit. Users can still opt in via `ui.enableFollowupSuggestions: true` in settings.

## Screenshots / Video Demo

N/A — no user-facing change for the majority of users (feature was already invisible to them since suggestions never rendered without a fast model). Users who had it working and want to keep it can flip the setting.

## Dive Deeper

The follow-up suggestion feature generates a context-aware prompt suggestion after each turn by making an additional API call. For users on Qwen OAuth (the majority), there is no dedicated fast model for this, so the request either fails silently or returns a low-quality result that is never shown. This wastes one API request per turn.

Changes:
- `packages/cli/src/config/settingsSchema.ts` — default `false`
- `packages/cli/src/ui/AppContainer.tsx` — flip runtime check from `!== false` to `=== true`
- `packages/vscode-ide-companion/schemas/settings.schema.json` — default `false`

## Reviewer Test Plan

1. Fresh config (no `ui.enableFollowupSuggestions` in settings): run a multi-turn session, check API logs — no suggestion requests should appear
2. Set `"ui": {"enableFollowupSuggestions": true}` in `~/.qwen/settings.json`: run a session — suggestions should still work as before

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- No specific issue — discovered during API cache analysis -->