### PR TITLE
fix(sandbox): fall back to 'latest' tag when image name has no colon

### DIFF
--- a/scripts/build_sandbox.js
+++ b/scripts/build_sandbox.js
@@ -135,7 +135,7 @@ function buildImage(imageName, dockerfile) {
   ).version;
 
   const imageTag =
-    process.env.QWEN_SANDBOX_IMAGE_TAG || imageName.split(':')[1];
+    process.env.QWEN_SANDBOX_IMAGE_TAG || imageName.split(':')[1] || 'latest';
   const finalImageName = `${imageName.split(':')[0]}:${imageTag}`;
 
   try {


### PR DESCRIPTION
Fall back to `latest` tag in sandbox build when image name has no colon.

## TLDR

`scripts/build_sandbox.js` resolved the image tag via `imageName.split(':')[1]` with no fallback. If `imageName` has no explicit tag and `QWEN_SANDBOX_IMAGE_TAG` is unset, `split(':')[1]` returns `undefined`, producing a literal `"myimage:undefined"` build target that Docker/Podman reject with a confusing error. This PR adds a `'latest'` fallback to match Docker's conventional default.

## Screenshots / Video Demo

N/A — build script fix, no user-facing UI.

## Dive Deeper

Before:

```javascript
const imageTag =
  process.env.QWEN_SANDBOX_IMAGE_TAG || imageName.split(':')[1];
const finalImageName = `${imageName.split(':')[0]}:${imageTag}`;
```

When a user passes `-i myimage` (no tag) and has no `QWEN_SANDBOX_IMAGE_TAG` set:
- `imageName.split(':')[1]` → `undefined`
- `imageTag` → `undefined`
- `finalImageName` → `"myimage:undefined"`
- `docker build -t myimage:undefined ...` fails with an invalid reference format error

In practice the default image name in `packages/cli/package.json` (`cliPkgJson.config.sandboxImageUri`) does contain a tag, so this bug bites only users who override the image via the `-i` / `--image` flag and forget to include a colon-tag. The symptom is a build failure with an opaque "invalid reference format" error pointing at `undefined`.

After:

```javascript
const imageTag =
  process.env.QWEN_SANDBOX_IMAGE_TAG ||
  imageName.split(':')[1] ||
  'latest';
```

`'latest'` is the established Docker default when no tag is specified, so this matches user expectations for untagged image references.

**Modified file:**
- `scripts/build_sandbox.js` — add `'latest'` fallback

## Reviewer Test Plan

1. `node scripts/build_sandbox.js -i "test-image"` (no colon) — verify the build command uses `test-image:latest`
2. `node scripts/build_sandbox.js -i "test-image:v2"` — verify tag is still `v2`
3. `QWEN_SANDBOX_IMAGE_TAG=custom node scripts/build_sandbox.js -i "test-image"` — verify env var still wins
4. Default case (no `-i`, no env var) — should behave identically to before since the default `sandboxImageUri` has a tag

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |
