### PR TITLE
fix(scripts): Fix `"undefined Options: ..."` in generated JSON schema for enum settings without descriptions.

### DIFF
--- a/scripts/generate-settings-schema.ts
+++ b/scripts/generate-settings-schema.ts
@@ -121,8 +121,11 @@ function convertSettingToJsonSchema(
     case 'enum':
       if (setting.options && setting.options.length > 0) {
         schema.enum = setting.options.map((o) => o.value);
-        schema.description +=
-          ' Options: ' + setting.options.map((o) => `${o.value}`).join(', ');
+        const optionsText =
+          'Options: ' + setting.options.map((o) => `${o.value}`).join(', ');
+        schema.description = schema.description
+          ? `${schema.description} ${optionsText}`
+          : optionsText;
       } else {
         // Enum without predefined options - accept any string
         schema.type = 'string';


### PR DESCRIPTION
Fix `"undefined Options: ..."` in generated JSON schema for enum settings without descriptions.

## TLDR

`scripts/generate-settings-schema.ts` only assigned `schema.description` when the setting had a description, then appended enum options with `+=`. For enum settings missing a description, the `+=` ran against `undefined` and produced the literal string `"undefined Options: foo, bar"` in the generated JSON schema. This PR initializes the field cleanly instead of concatenating onto `undefined`.

## Screenshots / Video Demo

Before (generated JSON schema entry):
```json
{
  "type": "string",
  "enum": ["fast", "accurate"],
  "description": "undefined Options: fast, accurate"
}
```

After:
```json
{
  "type": "string",
  "enum": ["fast", "accurate"],
  "description": "Options: fast, accurate"
}
```

## Dive Deeper

`convertSettingToJsonSchema` initializes `schema` as an empty object, then conditionally assigns `description`:

```typescript
const schema: JsonSchemaProperty = {};                       // line 97

if (setting.description) {
  schema.description = setting.description;                 // only if truthy
}
```

Later, for the `'enum'` case:

```typescript
case 'enum':
  if (setting.options && setting.options.length > 0) {
    schema.enum = setting.options.map((o) => o.value);
    schema.description +=                                    // line 124 — BUG
      ' Options: ' + setting.options.map((o) => `${o.value}`).join(', ');
  }
```

For any enum setting declared without a `description`, `schema.description` is `undefined` at the point of `+=`, and JavaScript coerces to `"undefined Options: fast, accurate"`.

The fix initializes cleanly:

```typescript
case 'enum':
  if (setting.options && setting.options.length > 0) {
    schema.enum = setting.options.map((o) => o.value);
    const optionsText =
      'Options: ' + setting.options.map((o) => `${o.value}`).join(', ');
    schema.description = schema.description
      ? `${schema.description} ${optionsText}`
      : optionsText;
  }
```

Settings that already had a description are unaffected — only the previously-broken `undefined` path changes.

**Modified file:**
- `scripts/generate-settings-schema.ts` — initialize `schema.description` cleanly for enums

## Reviewer Test Plan

1. Regenerate the settings schema: `pnpm tsx scripts/generate-settings-schema.ts` (or whatever the project's generation command is)
2. Grep the generated JSON for `"undefined Options:"` — should be empty
3. Grep for any enum with an existing description (e.g. check one from `packages/cli/src/config/settingsSchema.ts`) — verify it still reads `"<original description> Options: ..."`
4. Open the regenerated schema and spot-check a few enum entries

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |
