### PR TITLE
fix(scripts): remove duplicate bundle rmSync in clean script

### DIFF
--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -33,7 +33,6 @@ rmSync(join(root, 'packages/cli/src/generated/'), {
   force: true,
 });
 const RMRF_OPTIONS = { recursive: true, force: true };
-rmSync(join(root, 'bundle'), RMRF_OPTIONS);
 // Dynamically clean dist directories in all workspaces
 const rootPackageJson = JSON.parse(
   readFileSync(join(root, 'package.json'), 'utf-8'),


### PR DESCRIPTION
Remove duplicate `bundle` directory rmSync in clean script.

## TLDR

`scripts/clean.js` deleted the `bundle` directory twice — once on line 30 and again on line 36 (after the `RMRF_OPTIONS` constant was introduced). The second call was a harmless no-op but clearly a copy-paste leftover from when the helper constant was added. This PR removes the duplicate.

## Screenshots / Video Demo

N/A — build-tooling cleanup, no user-visible behavior change.

## Dive Deeper

Before:

```javascript
// remove npm install/build artifacts
rmSync(join(root, 'node_modules'), { recursive: true, force: true });
rmSync(join(root, 'bundle'), { recursive: true, force: true });        // line 30
rmSync(join(root, 'packages/cli/src/generated/'), {
  recursive: true,
  force: true,
});
const RMRF_OPTIONS = { recursive: true, force: true };
rmSync(join(root, 'bundle'), RMRF_OPTIONS);                            // line 36 — duplicate
```

The `bundle` path is deleted on line 30, then again on line 36 after the `RMRF_OPTIONS` constant appears. When the constant was introduced, the author likely meant to clean a *different* directory and never updated the path argument — the second call is effectively dead code.

It's harmless (`rmSync` with `force: true` is idempotent against missing paths) but it's a bug of intent: either the original call on line 30 should use `RMRF_OPTIONS`, or the line 36 call should target a different path, or — the simplest resolution — the duplicate should just be deleted.

This PR deletes line 36.

**Modified file:**
- `scripts/clean.js` — remove duplicate `bundle` rmSync

## Reviewer Test Plan

1. `pnpm clean` (or `node scripts/clean.js`) — verify the `bundle` directory is still removed
2. Confirm no other directories relied on this second call — `grep -n "bundle" scripts/clean.js` should show a single remaining reference
3. CI clean/build should pass unchanged

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |
