### PR TITLE
fix(text-buffer): unify offset-to-position logic

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -363,40 +363,30 @@ export const findPrevWordAcrossLines = (
 };
 
 // Helper functions for vim line operations
+const offsetToRowCol = (
+  offset: number,
+  lines: string[],
+): { row: number; col: number } => {
+  let running = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const lineLength = lines[i].length + 1; // include implicit newline
+    if (running + lineLength > offset) {
+      return { row: i, col: offset - running };
+    }
+    running += lineLength;
+  }
+  // Offset is at or past end of text — clamp to end of last line
+  const last = Math.max(0, lines.length - 1);
+  return { row: last, col: lines[last]?.length ?? 0 };
+};
+
 export const getPositionFromOffsets = (
   startOffset: number,
   endOffset: number,
   lines: string[],
 ) => {
-  let offset = 0;
-  let startRow = 0;
-  let startCol = 0;
-  let endRow = 0;
-  let endCol = 0;
-
-  // Find start position
-  for (let i = 0; i < lines.length; i++) {
-    const lineLength = lines[i].length + 1; // +1 for newline
-    if (offset + lineLength > startOffset) {
-      startRow = i;
-      startCol = startOffset - offset;
-      break;
-    }
-    offset += lineLength;
-  }
-
-  // Find end position
-  offset = 0;
-  for (let i = 0; i < lines.length; i++) {
-    const lineLength = lines[i].length + (i < lines.length - 1 ? 1 : 0); // +1 for newline except last line
-    if (offset + lineLength >= endOffset) {
-      endRow = i;
-      endCol = endOffset - offset;
-      break;
-    }
-    offset += lineLength;
-  }
-
+  const { row: startRow, col: startCol } = offsetToRowCol(startOffset, lines);
+  const { row: endRow, col: endCol } = offsetToRowCol(endOffset, lines);
   return { startRow, startCol, endRow, endCol };
 };
 

--- a/packages/cli/src/ui/components/shared/vim-buffer-actions.test.ts
+++ b/packages/cli/src/ui/components/shared/vim-buffer-actions.test.ts
@@ -845,11 +845,11 @@ describe('vim-buffer-actions', () => {
 
         const result = handleVimAction(state, action);
         expect(result).toHaveOnlyValidCharacters();
-        // The movement 'j' with count 2 changes 2 lines starting from cursor row
-        // Since we're at cursor position 2, it changes lines starting from current row
-        expect(result.lines).toEqual(['line1', 'line2', 'line3']); // No change because count > available lines
+        // 'j' with count 2 changes 2 lines starting at the cursor row,
+        // so lines 0 and 1 are removed, leaving only line 2.
+        expect(result.lines).toEqual(['line3']);
         expect(result.cursorRow).toBe(0);
-        expect(result.cursorCol).toBe(2);
+        expect(result.cursorCol).toBe(0);
       });
     });
   });


### PR DESCRIPTION
Fix `getPositionFromOffsets` returning out-of-bounds column at line boundaries.

## TLDR

`getPositionFromOffsets` used different per-line length logic and different comparison operators for start vs. end offsets, producing asymmetric and sometimes invalid results. At certain line-boundary offsets, the end calculation returned a column past the end of the target row. Downstream, `replaceRangeInternal` rejects `endCol > currentLineLen(endRow)` as an invalid range and silently returns state unchanged — so vim line-change commands (`cj`, `ck`) spanning row boundaries no-opped while still pushing an empty undo frame. This PR unifies both calculations behind a single helper.

## Screenshots / Video Demo

N/A — behavioral fix; symptoms and trace described below.

## Dive Deeper

Before:

```typescript
export const getPositionFromOffsets = (
  startOffset: number,
  endOffset: number,
  lines: string[],
) => {
  // ...

  // Find start position — always +1 for newline, strict >
  for (let i = 0; i < lines.length; i++) {
    const lineLength = lines[i].length + 1;
    if (offset + lineLength > startOffset) { ... break; }
    offset += lineLength;
  }

  // Find end position — no newline on last line, non-strict >=
  offset = 0;
  for (let i = 0; i < lines.length; i++) {
    const lineLength = lines[i].length + (i < lines.length - 1 ? 1 : 0);
    if (offset + lineLength >= endOffset) { ... break; }
    offset += lineLength;
  }
```

**Concrete failure**, `lines = ['abc','def']`, `endOffset = 4` (the position right after the `\n` at offset 3):
- Start calc: `4 > 4` false, `8 > 4` true → `(row=1, col=0)` ✓
- End calc: `0+4=4 >= 4` true → `(row=0, col=4)` ✗ — column 4 on a 3-char row

**Where it surfaces:** `vim-buffer-actions.ts` calls `getPositionFromOffsets` after computing a line-range via `getLineRangeOffsets` for `vim_change_line`, `vim_change_movement j`, and `vim_change_movement k`. With `lines = ['line1','line2','line3']`, cursor on row 0, action `cj` count=2:

- `getLineRangeOffsets(0, 2)` → `startOffset=0, endOffset=12`
- Old end calc: `(row=1, col=6)` — column 6 on 5-char row
- `replaceRangeInternal` at line 449 rejects as invalid range, returns state unchanged
- User sees a no-op, but an empty undo frame was already pushed on `pushUndo(state)`

A test in `vim-buffer-actions.test.ts` explicitly asserted this silent no-op — the assertion comment even said "No change because count > available lines", which is factually wrong (count=2 ≤ 2 lines below cursor). The test was documenting broken behavior rather than correct behavior.

After — one helper, used for both offsets:

```typescript
const offsetToRowCol = (
  offset: number,
  lines: string[],
): { row: number; col: number } => {
  let running = 0;
  for (let i = 0; i < lines.length; i++) {
    const lineLength = lines[i].length + 1; // include implicit newline
    if (running + lineLength > offset) {
      return { row: i, col: offset - running };
    }
    running += lineLength;
  }
  // Offset is at or past end of text — clamp to end of last line
  const last = Math.max(0, lines.length - 1);
  return { row: last, col: lines[last]?.length ?? 0 };
};

export const getPositionFromOffsets = (
  startOffset: number,
  endOffset: number,
  lines: string[],
) => {
  const { row: startRow, col: startCol } = offsetToRowCol(startOffset, lines);
  const { row: endRow, col: endCol } = offsetToRowCol(endOffset, lines);
  return { startRow, startCol, endRow, endCol };
};
```

Verification traces:
- `lines=['abc','def']`, offset=4 → `(1, 0)` ✓
- `lines=['abc','def']`, offset=7 → `(1, 3)` ✓ (matches old end-calc at total length)
- `lines=['hello world']`, offset=11 → `(0, 11)` ✓ (no regression for single-line change)
- `lines=['abc','def']`, `getLineRangeOffsets(1,1)` endOffset=7 → `(1, 3)` ✓ (matches old behavior — still uses inline deletion semantics for last-line range)

**Behavioral change for vim `cj` count=2:** `lines=['line1','line2','line3']`, cursor (0,2):
- Before: silent no-op, cursor stays at (0, 2)
- After: `['line3']`, cursor at (0, 0)

The updated test assertion reflects the now-correct behavior.

**Modified files:**
- `packages/cli/src/ui/components/shared/text-buffer.ts` — replaced the two-loop `getPositionFromOffsets` with a single `offsetToRowCol` helper used twice
- `packages/cli/src/ui/components/shared/vim-buffer-actions.test.ts` — updated the `should change multiple lines down` test to expect correct behavior instead of the silent no-op

## Reviewer Test Plan

1. Run text-buffer tests: `pnpm --filter=@qwen-code/qwen-code exec npx vitest run src/ui/components/shared/text-buffer.test.ts` — 115 tests pass
2. Run vim action tests: `pnpm --filter=@qwen-code/qwen-code exec npx vitest run src/ui/components/shared/vim-buffer-actions.test.ts` — 74 tests pass (including the updated multi-line-change test)
3. Manual vim test: open a multi-line input buffer with vim mode, place cursor on the first line, run `cj` — verify the first two lines are changed and the third line remains
4. Manual regression: single-line `cc` (`vim_change_line`) on `'hello world'` should still clear the line to `''`, cursor at 0

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |
