### PR TITLE
fix(channels): default dispatchMode to 'collect' to match documented contract

### DIFF
--- a/packages/channels/base/src/ChannelBase.test.ts
+++ b/packages/channels/base/src/ChannelBase.test.ts
@@ -570,7 +570,7 @@ describe('ChannelBase', () => {
       ]);
     });
 
-    it('steer is the default mode when dispatchMode not set', async () => {
+    it('collect is the default mode when dispatchMode not set', async () => {
       let resolveFirst!: (v: string) => void;
       const firstPrompt = new Promise<string>((r) => {
         resolveFirst = r;
@@ -579,35 +579,39 @@ describe('ChannelBase', () => {
       (bridge.prompt as ReturnType<typeof vi.fn>).mockImplementation(() => {
         callCount++;
         if (callCount === 1) return firstPrompt;
-        return Promise.resolve('steered response');
+        return Promise.resolve('coalesced response');
       });
 
-      // Add cancelSession mock
-      (bridge as unknown as Record<string, unknown>).cancelSession = vi
-        .fn()
-        .mockImplementation(() => {
-          resolveFirst('cancelled');
-          return Promise.resolve();
-        });
+      // cancelSession should NOT be called under collect — provide a mock so
+      // we can assert it stays untouched.
+      const cancelSessionMock = vi.fn().mockResolvedValue(undefined);
+      (bridge as unknown as Record<string, unknown>).cancelSession =
+        cancelSessionMock;
 
-      // No dispatchMode set — should default to steer
+      // No dispatchMode set — should default to collect (matches the
+      // documented default in ChannelConfig.dispatchMode JSDoc).
       const ch = createChannel();
 
       const p1 = ch.handleInbound(envelope({ text: 'first' }));
       await new Promise((r) => setTimeout(r, 10));
 
-      // Second message should cancel the first (steer behavior)
+      // Second message arrives while first is in flight — collect mode
+      // buffers it instead of cancelling the first.
       const p2 = ch.handleInbound(envelope({ text: 'second' }));
+      await p2; // returns immediately after buffering
 
+      // First still running, only one prompt call so far.
+      expect(callCount).toBe(1);
+
+      // Let the first prompt finish; the buffered second message drains as
+      // a coalesced follow-up.
+      resolveFirst('first response');
       await p1;
-      await p2;
+      await new Promise((r) => setTimeout(r, 50));
 
-      // cancelSession should have been called (steer behavior)
-      expect(
-        (bridge as unknown as Record<string, () => unknown>).cancelSession,
-      ).toHaveBeenCalledTimes(1);
-
-      // Both prompts ran
+      // cancelSession should never be called under collect.
+      expect(cancelSessionMock).not.toHaveBeenCalled();
+      // Both prompts ran (first + coalesced follow-up).
       expect(callCount).toBe(2);
     });
 

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -305,7 +305,7 @@ export abstract class ChannelBase {
       ? this.config.groups[envelope.chatId] || this.config.groups['*']
       : undefined;
     const mode: DispatchMode =
-      groupCfg?.dispatchMode || this.config.dispatchMode || 'steer';
+      groupCfg?.dispatchMode || this.config.dispatchMode || 'collect';
 
     const active = this.activePrompts.get(sessionId);
 


### PR DESCRIPTION
Fix `ChannelBase` default `dispatchMode` to match documented `'collect'`.

## TLDR

`ChannelConfig.dispatchMode` JSDoc says the default is `'collect'`, but `ChannelBase.dispatchMessage` falls back to `'steer'`. Consumers who read the type and omit the field get the opposite behavior: instead of buffering concurrent messages and coalescing them, the in-flight prompt is cancelled on every new message. Switch the fallback to `'collect'` so the runtime matches the documented contract.

## Screenshots / Video Demo

N/A — internal channel dispatch behavior, no UI surface.

## Dive Deeper

Before (`packages/channels/base/src/ChannelBase.ts:307-308`):

```typescript
const mode: DispatchMode =
  groupCfg?.dispatchMode || this.config.dispatchMode || 'steer';
```

Documented contract (`packages/channels/base/src/types.ts:42-43`):

```typescript
/** Dispatch mode for concurrent messages. Default: 'collect'. */
dispatchMode?: DispatchMode;
```

`'collect'` and `'steer'` are not interchangeable:

- **collect** — buffers messages that arrive while a prompt is running, then dispatches a single coalesced followup once the active prompt ends. Good for chat channels where multiple users (or one user typing fast) shouldn't kill each other's responses.
- **steer** — cancels the running prompt and immediately starts a new one with the new input. Useful when the user explicitly wants to redirect, but destructive when used as the default in group chats: every interjection from another participant aborts the current answer mid-generation.

For DingTalk/Telegram/Weixin group bots — the primary consumers of `ChannelBase` — the `'steer'` default produces "agent never finishes a response" once a second message lands.

After:

```typescript
const mode: DispatchMode =
  groupCfg?.dispatchMode || this.config.dispatchMode || 'collect';
```

The existing tests for both modes still pass; one test that asserted the default-was-steer behavior was rewritten to assert collect-default semantics (cancelSession is not called, the buffered message is delivered as a coalesced followup).

**Modified files:**
- `packages/channels/base/src/ChannelBase.ts` — flip fallback from `'steer'` to `'collect'`
- `packages/channels/base/src/ChannelBase.test.ts` — update default-mode test to assert collect behavior

## Reviewer Test Plan

1. Configure a channel with no `dispatchMode` set in `ChannelConfig` and no group override.
2. Send a message; before it finishes, send a second message from the same chat.
3. Before fix: the first prompt is cancelled and only the second message gets a response.
4. After fix: the first prompt runs to completion, then a coalesced followup containing the second message is dispatched. Both messages get answered.
5. Set `dispatchMode: 'steer'` explicitly and confirm steer still works (cancellation observable).
6. Run `vitest run packages/channels/base/src/ChannelBase.test.ts` — all 40 tests pass.

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |
