### PR TITLE
fix(cli): re-arm disconnected listener on rebuilt AcpBridge after crash

### DIFF
--- a/packages/cli/src/commands/channel/start.ts
+++ b/packages/cli/src/commands/channel/start.ts
@@ -188,48 +188,52 @@ async function startSingle(name: string): Promise<void> {
   writeServiceInfo([name]);
   writeStdoutLine(`[Channel] "${name}" is running. Press Ctrl+C to stop.`);
 
-  bridge.on('disconnected', async () => {
-    if (shuttingDown) return;
+  const attachDisconnectHandler = (b: AcpBridge): void => {
+    b.on('disconnected', async () => {
+      if (shuttingDown) return;
 
-    const now = Date.now();
-    crashTimestamps.push(now);
-    // Only count crashes within the recent window
-    const recentCrashes = crashTimestamps.filter(
-      (ts) => now - ts < CRASH_WINDOW_MS,
-    );
+      const now = Date.now();
+      crashTimestamps.push(now);
+      // Only count crashes within the recent window
+      const recentCrashes = crashTimestamps.filter(
+        (ts) => now - ts < CRASH_WINDOW_MS,
+      );
 
-    if (recentCrashes.length > MAX_CRASH_RESTARTS) {
+      if (recentCrashes.length > MAX_CRASH_RESTARTS) {
+        writeStderrLine(
+          `[Channel] Bridge crashed ${recentCrashes.length} times in ${CRASH_WINDOW_MS / 1000}s. Giving up.`,
+        );
+        channel.disconnect();
+        router.clearAll();
+        removeServiceInfo();
+        process.exit(1);
+      }
+
       writeStderrLine(
-        `[Channel] Bridge crashed ${recentCrashes.length} times in ${CRASH_WINDOW_MS / 1000}s. Giving up.`,
+        `[Channel] Bridge crashed (${recentCrashes.length}/${MAX_CRASH_RESTARTS} in window). Restarting in ${RESTART_DELAY_MS / 1000}s...`,
       );
-      channel.disconnect();
-      router.clearAll();
-      removeServiceInfo();
-      process.exit(1);
-    }
+      await new Promise((r) => setTimeout(r, RESTART_DELAY_MS));
 
-    writeStderrLine(
-      `[Channel] Bridge crashed (${recentCrashes.length}/${MAX_CRASH_RESTARTS} in window). Restarting in ${RESTART_DELAY_MS / 1000}s...`,
-    );
-    await new Promise((r) => setTimeout(r, RESTART_DELAY_MS));
+      try {
+        bridge = new AcpBridge(bridgeOpts);
+        await bridge.start();
+        router.setBridge(bridge);
+        channel.setBridge(bridge);
+        registerToolCallDispatch(bridge, router, channels);
+        attachDisconnectHandler(bridge);
 
-    try {
-      bridge = new AcpBridge(bridgeOpts);
-      await bridge.start();
-      router.setBridge(bridge);
-      channel.setBridge(bridge);
-      registerToolCallDispatch(bridge, router, channels);
-
-      const result = await router.restoreSessions();
-      writeStdoutLine(
-        `[Channel] Bridge restarted. Sessions restored: ${result.restored}, failed: ${result.failed}`,
-      );
-    } catch (err) {
-      writeStderrLine(
-        `[Channel] Failed to restart bridge: ${err instanceof Error ? err.message : String(err)}`,
-      );
-    }
-  });
+        const result = await router.restoreSessions();
+        writeStdoutLine(
+          `[Channel] Bridge restarted. Sessions restored: ${result.restored}, failed: ${result.failed}`,
+        );
+      } catch (err) {
+        writeStderrLine(
+          `[Channel] Failed to restart bridge: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    });
+  };
+  attachDisconnectHandler(bridge);
 
   const shutdown = () => {
     shuttingDown = true;
@@ -343,55 +347,59 @@ async function startAll(): Promise<void> {
     `[Channel] Running ${connectedCount} channel(s). Press Ctrl+C to stop.`,
   );
 
-  bridge.on('disconnected', async () => {
-    if (shuttingDown) return;
+  const attachDisconnectHandler = (b: AcpBridge): void => {
+    b.on('disconnected', async () => {
+      if (shuttingDown) return;
 
-    const now = Date.now();
-    crashTimestamps.push(now);
-    const recentCrashes = crashTimestamps.filter(
-      (ts) => now - ts < CRASH_WINDOW_MS,
-    );
-
-    if (recentCrashes.length > MAX_CRASH_RESTARTS) {
-      writeStderrLine(
-        `[Channel] Bridge crashed ${recentCrashes.length} times in ${CRASH_WINDOW_MS / 1000}s. Giving up.`,
+      const now = Date.now();
+      crashTimestamps.push(now);
+      const recentCrashes = crashTimestamps.filter(
+        (ts) => now - ts < CRASH_WINDOW_MS,
       );
-      for (const channel of channels.values()) {
-        try {
-          channel.disconnect();
-        } catch {
-          // best-effort
+
+      if (recentCrashes.length > MAX_CRASH_RESTARTS) {
+        writeStderrLine(
+          `[Channel] Bridge crashed ${recentCrashes.length} times in ${CRASH_WINDOW_MS / 1000}s. Giving up.`,
+        );
+        for (const channel of channels.values()) {
+          try {
+            channel.disconnect();
+          } catch {
+            // best-effort
+          }
         }
+        router.clearAll();
+        removeServiceInfo();
+        process.exit(1);
       }
-      router.clearAll();
-      removeServiceInfo();
-      process.exit(1);
-    }
 
-    writeStderrLine(
-      `[Channel] Bridge crashed (${recentCrashes.length}/${MAX_CRASH_RESTARTS} in window). Restarting in ${RESTART_DELAY_MS / 1000}s...`,
-    );
-    await new Promise((r) => setTimeout(r, RESTART_DELAY_MS));
-
-    try {
-      bridge = new AcpBridge(bridgeOpts);
-      await bridge.start();
-      router.setBridge(bridge);
-      for (const channel of channels.values()) {
-        channel.setBridge(bridge);
-      }
-      registerToolCallDispatch(bridge, router, channels);
-
-      const result = await router.restoreSessions();
-      writeStdoutLine(
-        `[Channel] Bridge restarted. Sessions restored: ${result.restored}, failed: ${result.failed}`,
-      );
-    } catch (err) {
       writeStderrLine(
-        `[Channel] Failed to restart bridge: ${err instanceof Error ? err.message : String(err)}`,
+        `[Channel] Bridge crashed (${recentCrashes.length}/${MAX_CRASH_RESTARTS} in window). Restarting in ${RESTART_DELAY_MS / 1000}s...`,
       );
-    }
-  });
+      await new Promise((r) => setTimeout(r, RESTART_DELAY_MS));
+
+      try {
+        bridge = new AcpBridge(bridgeOpts);
+        await bridge.start();
+        router.setBridge(bridge);
+        for (const channel of channels.values()) {
+          channel.setBridge(bridge);
+        }
+        registerToolCallDispatch(bridge, router, channels);
+        attachDisconnectHandler(bridge);
+
+        const result = await router.restoreSessions();
+        writeStdoutLine(
+          `[Channel] Bridge restarted. Sessions restored: ${result.restored}, failed: ${result.failed}`,
+        );
+      } catch (err) {
+        writeStderrLine(
+          `[Channel] Failed to restart bridge: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    });
+  };
+  attachDisconnectHandler(bridge);
 
   const shutdown = () => {
     shuttingDown = true;


### PR DESCRIPTION
Fix crash recovery silently failing on second disconnect in `channel start`/`startAll`.

## TLDR

The `disconnected` handler in `start.ts` is registered on the *original* `AcpBridge` instance. When that handler fires after a crash, it constructs a fresh `AcpBridge` and reassigns the local `bridge` variable, but never re-registers a `disconnected` listener on the new instance. The first crash recovers, the second crash silently no-ops — the channel service stays alive but stops processing messages, with no log indication that anything went wrong. Extract listener registration into a function that calls itself after each rebuild.

## Screenshots / Video Demo

N/A — failure mode is silent (no logs, no UI), surfaces only after the second crash as "bot stopped responding."

## Dive Deeper

Before (`packages/cli/src/commands/channel/start.ts`, both `start()` ~191 and `startAll()` ~346/377):

```typescript
let bridge = new AcpBridge(bridgeOpts);
await bridge.start();
// ...
bridge.on('disconnected', async () => {
  // ...crash threshold logic...
  bridge = new AcpBridge(bridgeOpts);   // new instance — no listener attached
  await bridge.start();
  router.setBridge(bridge);
  channel.setBridge(bridge);
  registerToolCallDispatch(bridge, router, channels);
  // ← second `disconnected` from this bridge will go nowhere
});
```

Sequence to reproduce:

1. Bridge starts. Listener attached to instance A.
2. Bridge crashes. Listener on A fires, builds instance B, reassigns `bridge = B`. Channel keeps running.
3. Bridge B crashes. Instance B emits `disconnected` — no listener. The handler that would have built instance C, updated `crashTimestamps`, or tripped the give-up threshold never runs.
4. The channel process is still alive (the listener was never an awaited promise), but `router` and `channel` still point at the dead bridge B. All inbound messages fail silently. No log line is emitted.

The same pattern is duplicated in `startAll` for the multi-channel path; both call sites need the same fix.

After: extract the registration into a self-referential helper:

```typescript
const attachDisconnectHandler = (b: AcpBridge): void => {
  b.on('disconnected', async () => {
    // ...threshold/give-up logic unchanged...
    try {
      bridge = new AcpBridge(bridgeOpts);
      await bridge.start();
      router.setBridge(bridge);
      channel.setBridge(bridge); // or for-of in startAll
      registerToolCallDispatch(bridge, router, channels);
      attachDisconnectHandler(bridge); // re-arm
      // ...
    } catch (err) {
      writeStderrLine(...);
    }
  });
};
attachDisconnectHandler(bridge);
```

`attachDisconnectHandler` re-binds the listener to whatever the new bridge instance is, so each generation of the bridge can survive a crash.

**Modified file:**
- `packages/cli/src/commands/channel/start.ts` — extract `attachDisconnectHandler` in both `start()` and `startAll()`, call it after each `new AcpBridge`

## Reviewer Test Plan

1. Start a channel via `qwen channel start <name>`.
2. Force the bridge process to die (`kill -9 <bridge-pid>`); confirm the recovery log line and that the channel keeps responding.
3. Force-kill the bridge a second time. Before fix: channel goes silent, no logs. After fix: a second recovery log line appears and the channel resumes.
4. Repeat with `qwen channel start --all` to exercise the `startAll` path.
5. Verify `crashTimestamps` continues to grow across crashes so the give-up threshold trips after enough rapid failures.

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |
