### PR TITLE
fix(hooks): preserve null exit code from signal kills instead of collapsing to 0

### DIFF
--- a/packages/core/src/hooks/hookRunner.ts
+++ b/packages/core/src/hooks/hookRunner.ts
@@ -420,6 +420,7 @@ export class HookRunner {
           }
         }
 
+        const killedBySignal = exitCode === null;
         resolve({
           hookConfig,
           eventName,
@@ -427,8 +428,11 @@ export class HookRunner {
           output,
           stdout,
           stderr,
-          exitCode: exitCode || EXIT_CODE_SUCCESS,
+          exitCode: exitCode ?? -1,
           duration,
+          ...(killedBySignal && {
+            error: new Error('Hook killed by signal'),
+          }),
         });
       });
 


### PR DESCRIPTION
Fix hook results reporting `exitCode: 0` when child was killed by a signal.

## TLDR

When a hook child process is killed by a signal (`SIGTERM`, `SIGKILL`, OOM killer, etc.), `child.on('close')` fires with `exitCode = null`. The result builder then sets `exitCode: exitCode || EXIT_CODE_SUCCESS`, which collapses `null` to `0`. The result object now reports `success: false` and `exitCode: 0` simultaneously — a contradictory state that misleads any downstream consumer that branches on `exitCode` to distinguish blocking errors (2), soft failures (1), and success (0). Preserve `null` as a sentinel and surface it as `-1` plus an explicit error.

## Screenshots / Video Demo

N/A — hook result struct, no UI.

## Dive Deeper

Before (`packages/core/src/hooks/hookRunner.ts:426, 430`):

```typescript
resolve({
  hookConfig,
  eventName,
  success: exitCode === EXIT_CODE_SUCCESS,   // null === 0 → false ✓
  output,
  stdout,
  stderr,
  exitCode: exitCode || EXIT_CODE_SUCCESS,    // null || 0 → 0 ✗
  duration,
});
```

The signal-kill path is distinct from the `timedOut` and `aborted` paths, both of which `return` early with their own dedicated flags. Signal kills bypass both flags and fall through to this generic close handler, where the bug lives.

`success: false` and `exitCode: 0` cannot both be true under the documented exit-code convention (`0` = success, `1` = soft failure, `2` = blocking). Consumers that read `exitCode` directly (telemetry, hook chain decisions, surfaced error messages) will treat the kill as success and silently miss the failure mode.

After:

```typescript
const killedBySignal = exitCode === null;
resolve({
  hookConfig,
  eventName,
  success: exitCode === EXIT_CODE_SUCCESS,
  output,
  stdout,
  stderr,
  exitCode: exitCode ?? -1,                // distinguish kill from success
  duration,
  ...(killedBySignal && {
    error: new Error('Hook killed by signal'),
  }),
});
```

`-1` is outside the documented exit-code range so consumers cannot misread it as success/soft/blocking, and an attached `error` makes the failure surface explicitly. Existing consumers that only read `success` are unaffected.

**Modified file:**
- `packages/core/src/hooks/hookRunner.ts` — preserve `null` exit code as `-1`, attach explicit error on signal kill

## Reviewer Test Plan

1. Configure a hook that runs `sleep 60`.
2. Trigger the hook and `kill -TERM <child-pid>` from another shell while it's running.
3. Inspect the resolved result. Before fix: `{ success: false, exitCode: 0 }`. After fix: `{ success: false, exitCode: -1, error: Error("Hook killed by signal") }`.
4. Confirm `timedOut`/`aborted` paths still return their own flags unchanged (kill via timeout cancellation is handled separately).
5. `vitest run packages/core/src/hooks/hookRunner.test.ts` — all 28 tests pass.

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |
