### PR TITLE
fix(dingtalk): only suffix '(cont.)' on continuation chunks, not the first

### DIFF
--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -146,11 +146,12 @@ export class DingtalkChannel extends ChannelBase {
     const chunks = normalizeDingTalkMarkdown(text);
     const title = extractTitle(text);
 
-    for (const chunk of chunks) {
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i]!;
       const body = {
         msgtype: 'markdown',
         markdown: {
-          title: chunks.length > 1 ? `${title} (cont.)` : title,
+          title: i === 0 ? title : `${title} (cont.)`,
           text: chunk,
         },
       };


### PR DESCRIPTION
Fix DingTalk multi-chunk messages showing "(cont.)" on the first chunk.

## TLDR

`DingtalkAdapter` splits long messages into chunks, then sets the markdown card title via `chunks.length > 1 ? '${title} (cont.)' : title`. The condition is loop-invariant — it doesn't depend on the chunk index — so when a message is split, every chunk including the first is labeled "(cont.)". The intent is clearly "first chunk shows the real title; subsequent chunks show '(cont.)'." Use the loop index instead.

## Screenshots / Video Demo

N/A — affects DingTalk markdown card titles in long agent responses.

## Dive Deeper

Before (`packages/channels/dingtalk/src/DingtalkAdapter.ts:149-156`):

```typescript
for (const chunk of chunks) {
  const body = {
    msgtype: 'markdown',
    markdown: {
      title: chunks.length > 1 ? `${title} (cont.)` : title,  // same for all chunks
      text: chunk,
    },
  };
  // ...send body...
}
```

`chunks.length > 1` is constant across the loop. Once the splitter decides the message needs more than one chunk, *every* chunk — including chunk 0 — gets the "(cont.)" suffix. From the user's perspective, the first card of a long response says "Continued from where?" with no anchor.

After:

```typescript
for (let i = 0; i < chunks.length; i++) {
  const chunk = chunks[i]!;
  const body = {
    msgtype: 'markdown',
    markdown: {
      title: i === 0 ? title : `${title} (cont.)`,
      text: chunk,
    },
  };
  // ...send body...
}
```

Chunk 0 keeps the real title; chunks 1..N get "(cont.)" so the user sees a clear continuation marker. Single-chunk messages are unaffected (loop runs once with `i === 0`).

**Modified file:**
- `packages/channels/dingtalk/src/DingtalkAdapter.ts` — use indexed loop, gate "(cont.)" on `i > 0`

## Reviewer Test Plan

1. Configure a DingTalk bot and trigger a response long enough to be split into 3+ chunks (the chunker default is around 4 KB per card).
2. Before fix: all three cards show "MyTitle (cont.)".
3. After fix: card 1 shows "MyTitle"; cards 2 and 3 show "MyTitle (cont.)".
4. Send a short response (single chunk) and confirm the title is unchanged (no "(cont.)").
5. `vitest run packages/channels/dingtalk` — markdown tests pass.

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |
