### PR TITLE
fix(dingtalk): preserve empty text after @mention strip instead of falling back

### DIFF
--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -532,12 +532,17 @@ export class DingtalkChannel extends ChannelBase {
 
       const chatId = conversationId || sessionWebhook;
 
+      // After stripping the bot @mention, cleanText may legitimately be empty
+      // (user pinged the bot with no other text). Don't fall back to the
+      // original text in that case — it would re-introduce the @mention.
+      const envelopeText = isMentioned ? cleanText : cleanText || content.text;
+
       const envelope: Envelope = {
         channelName: this.name,
         senderId: data.senderId || data.senderStaffId || '',
         senderName: data.senderNick || 'Unknown',
         chatId,
-        text: cleanText || content.text,
+        text: envelopeText,
         isGroup,
         isMentioned,
         isReplyToBot: quoted.isReplyToBot,


### PR DESCRIPTION
Fix DingTalk @mention strip being defeated by fallback to the original text.

## TLDR

When the bot is @-mentioned in a DingTalk group, `DingtalkAdapter` strips the mention from the user's text, then constructs the envelope as `text: cleanText || content.text`. If a user pings the bot with only `"@BotName"` (a common "are you alive?" gesture in groups), the strip produces `""`, the `||` falls back to the original text, and the agent receives its own `@BotName` as the prompt — exactly what the strip was preventing. The bot then responds to its own name as if it were user input. Distinguish "stripped to empty" from "no strip" so the empty-after-strip case isn't clobbered.

## Screenshots / Video Demo

N/A — text-processing fix, no UI surface. Repro: send `"@BotName"` (just the mention) in a group.

## Dive Deeper

Before (`packages/channels/dingtalk/src/DingtalkAdapter.ts:526-528, 540`):

```typescript
const isMentioned = Boolean(data.isInAtList);
const content = this.extractContent(data);
let cleanText = content.text;

if (isMentioned) {
  cleanText = cleanText.replace(/@\S+/, '').trim();
}
// ...
const envelope: Envelope = {
  // ...
  text: cleanText || content.text,   // empty cleanText → fallback to original
};
```

Walkthrough for a `"@BotName"` message:

1. `content.text === "@BotName"`.
2. `isMentioned === true`, so `cleanText = "@BotName".replace(/@\S+/, '').trim() === ""`.
3. `"" || "@BotName"` → envelope text becomes `"@BotName"`.
4. Agent receives `"@BotName"` as the prompt and either responds to its own name or treats it as a directive.

The intent of the strip is "remove the bot's mention so the agent sees only the user's actual content"; the fallback violates that intent for the empty-strip case.

After:

```typescript
// After stripping the bot @mention, cleanText may legitimately be empty
// (user pinged the bot with no other text). Don't fall back to the
// original text in that case — it would re-introduce the @mention.
const envelopeText = isMentioned ? cleanText : cleanText || content.text;
const envelope: Envelope = {
  // ...
  text: envelopeText,
};
```

When `isMentioned` is true, the strip ran, and we trust its result even when empty. When `isMentioned` is false, we keep the original fallback semantics (defensive against other places `cleanText` could end up empty).

**Modified file:**
- `packages/channels/dingtalk/src/DingtalkAdapter.ts` — distinguish mentioned-then-empty from non-mentioned-empty

## Reviewer Test Plan

1. In a DingTalk group, send `"@YourBot"` with no other text.
2. Before fix: bot replies as if you'd asked it about its own name.
3. After fix: envelope text is `""`, agent sees an empty prompt and the upstream empty-prompt handling kicks in (no nonsense response).
4. Send `"@YourBot what's the weather?"` and confirm the agent receives `"what's the weather?"` (mention stripped, real text preserved).
5. Send a non-mention message in a private DM and confirm nothing changed for the unmentioned path.

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |
