### PR TITLE
fix(dingtalk): remove reactionContext map to stop leak on blocked messages

### DIFF
--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -82,8 +82,6 @@ export class DingtalkChannel extends ChannelBase {
   private dedupTimer?: ReturnType<typeof setInterval>;
   /** Map conversationId → latest sessionWebhook URL for sending replies. */
   private webhooks: Map<string, string> = new Map();
-  /** Map messageId → conversationId for reaction attach/recall in hooks. */
-  private reactionContext: Map<string, string> = new Map();
 
   constructor(
     name: string,
@@ -239,29 +237,31 @@ export class DingtalkChannel extends ChannelBase {
     process.stderr.write(`[DingTalk:${this.name}] Disconnected.\n`);
   }
 
+  /**
+   * The chatId passed to onPromptStart/onPromptEnd is `conversationId ||
+   * sessionWebhook` (see message handler below). Reactions require a real
+   * conversation ID — skip the webhook-URL fallback case.
+   */
+  private isConversationId(chatId: string): boolean {
+    return !!chatId && !chatId.startsWith('http');
+  }
+
   protected override onPromptStart(
-    _chatId: string,
+    chatId: string,
     _sessionId: string,
     messageId?: string,
   ): void {
-    if (!messageId) return;
-    const convId = this.reactionContext.get(messageId);
-    if (convId) {
-      this.attachReaction(messageId, convId).catch(() => {});
-    }
+    if (!messageId || !this.isConversationId(chatId)) return;
+    this.attachReaction(messageId, chatId).catch(() => {});
   }
 
   protected override onPromptEnd(
-    _chatId: string,
+    chatId: string,
     _sessionId: string,
     messageId?: string,
   ): void {
-    if (!messageId) return;
-    const convId = this.reactionContext.get(messageId);
-    if (convId) {
-      this.recallReaction(messageId, convId).catch(() => {});
-      this.reactionContext.delete(messageId);
-    }
+    if (!messageId || !this.isConversationId(chatId)) return;
+    this.recallReaction(messageId, chatId).catch(() => {});
   }
 
   /**
@@ -544,11 +544,9 @@ export class DingtalkChannel extends ChannelBase {
         referencedText: quoted.referencedText,
       };
 
-      // Store messageId + conversationId for reaction hooks
+      // Reactions are resolved later via the chatId passed to
+      // onPromptStart/onPromptEnd — no extra bookkeeping needed.
       envelope.messageId = msgId;
-      if (msgId && conversationId) {
-        this.reactionContext.set(msgId, conversationId);
-      }
 
       const processMessage = async () => {
         // Download media if present (first downloadCode only for images)
@@ -560,9 +558,6 @@ export class DingtalkChannel extends ChannelBase {
             content.fileName,
           );
         }
-        // reactionContext cleanup is handled by onPromptEnd (not here),
-        // because in collect mode handleInbound returns immediately after
-        // buffering — the context must survive until the prompt actually runs.
         await this.handleInbound(envelope);
       };
 


### PR DESCRIPTION
Fix DingTalk `reactionContext` map leaking entries for blocked messages.

## TLDR

`DingtalkAdapter` populates `reactionContext` (map of `messageId → conversationId` used for emoji-reaction lifecycle) unconditionally, *before* `handleInbound` runs the sender allowlist / pairing / group gates. Cleanup only happens in `onPromptEnd`. Messages that are rejected by `handleInbound` never reach `onPromptStart`/`onPromptEnd`, so their entries leak forever. On a public-facing bot with a strict allowlist, the map grows unboundedly with every blocked message. The fix removes the intermediate map entirely — `chatId` is already passed through to `onPromptStart`/`onPromptEnd` by `ChannelBase`, so no parallel state is needed.

## Screenshots / Video Demo

N/A — internal memory leak, no UI surface.

## Dive Deeper

Before (`packages/channels/dingtalk/src/DingtalkAdapter.ts`):

```typescript
private reactionContext: Map<string, string> = new Map();

// ...inside processMessage, before handleInbound:
envelope.messageId = msgId;
if (msgId && conversationId) {
  this.reactionContext.set(msgId, conversationId);   // unconditional
}

const processMessage = async () => {
  // ...
  await this.handleInbound(envelope);                // may reject silently
};

// ...later:
protected override onPromptEnd(_chatId, _sessionId, messageId?): void {
  if (!messageId) return;
  const convId = this.reactionContext.get(messageId);
  if (convId) {
    this.recallReaction(messageId, convId).catch(() => {});
    this.reactionContext.delete(messageId);
  }
}
```

When `handleInbound` rejects a message (sender not on allowlist, group not paired, channel disabled, etc.), it returns without calling `onPromptStart` or `onPromptEnd`. The `reactionContext.set` from a few lines earlier is never cleared. The only paths that ever clean up entries are the ones gated on a successful prompt lifecycle.

Impact scales linearly with rejected traffic:

- Bot with restrictive allowlist on a public channel
- Bot in a group it isn't paired with that still sees inbound webhooks
- Bot that's been temporarily disabled but the webhook is still alive

Each blocked message adds an `(messageId, conversationId)` pair (~80–120 bytes of strings plus Map overhead). On a busy public bot this can reach tens of thousands of entries per day. Only a process restart clears it.

After: remove the intermediate map. `ChannelBase` already passes `chatId` through to `onPromptStart`/`onPromptEnd`, and `chatId` for DingTalk *is* the conversation identifier (or a webhook URL for incoming-only flows). Use it directly, with a guard for the webhook-URL case where reactions don't apply:

```typescript
private isConversationId(chatId: string): boolean {
  return !!chatId && !chatId.startsWith('http');
}

protected override onPromptStart(
  chatId: string,
  _sessionId: string,
  messageId?: string,
): void {
  if (!messageId || !this.isConversationId(chatId)) return;
  this.attachReaction(messageId, chatId).catch(() => {});
}

protected override onPromptEnd(
  chatId: string,
  _sessionId: string,
  messageId?: string,
): void {
  if (!messageId || !this.isConversationId(chatId)) return;
  this.recallReaction(messageId, chatId).catch(() => {});
}
```

The `private reactionContext: Map<string, string>` field and the unconditional `set` block are deleted entirely. Verified there are zero remaining references to `reactionContext` in the file after the change.

This is cleaner than the alternative ("only set after `handleInbound` accepts") because it eliminates the parallel state instead of trying to keep it consistent with the prompt lifecycle. The webhook-URL guard is necessary because outgoing-only webhook flows have no conversation to react in.

**Modified file:**
- `packages/channels/dingtalk/src/DingtalkAdapter.ts` — remove `reactionContext` map, use `chatId` directly in `onPromptStart`/`onPromptEnd`, gate on `isConversationId`

## Reviewer Test Plan

1. Configure a DingTalk bot with a sender allowlist that excludes a test user.
2. Send 100 messages from the excluded user. Inspect the bot process memory; `reactionContext` no longer exists, so no growth from blocked messages.
3. Send a message from an allowed user. Confirm the "thinking" emoji is attached on prompt start and recalled on prompt end (the reaction lifecycle still works through `chatId`).
4. Trigger an inbound flow whose `chatId` is a webhook URL (`https://...`). Confirm `attachReaction`/`recallReaction` are skipped (no API errors against an HTTP URL).
5. `vitest run packages/channels/dingtalk` — markdown tests pass; no DingTalk adapter unit tests exist for the reaction path so verification is by code review and manual run.

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |
