### PR TITLE
fix(channels): SessionRouter prefix collision and scope-blind sender lookup

### DIFF
--- a/packages/channels/base/src/SessionRouter.test.ts
+++ b/packages/channels/base/src/SessionRouter.test.ts
@@ -188,6 +188,36 @@ describe('SessionRouter', () => {
       router.removeSession('ch', 'alice', 'chat1');
       expect(router.getTarget(sid)).toBeUndefined();
     });
+
+    it('does not collide on sender IDs with shared prefix', async () => {
+      const router = new SessionRouter(bridge, '/tmp');
+      const sidA = await router.resolve('ch', 'user1', 'chat1');
+      const sidB = await router.resolve('ch', 'user12', 'chat1');
+
+      // hasSession must distinguish 'user1' from 'user12'
+      expect(router.hasSession('ch', 'user1')).toBe(true);
+      expect(router.hasSession('ch', 'user12')).toBe(true);
+
+      // Removing 'user1' must NOT touch 'user12'
+      const removed = router.removeSession('ch', 'user1');
+      expect(removed).toEqual([sidA]);
+      expect(router.hasSession('ch', 'user1')).toBe(false);
+      expect(router.hasSession('ch', 'user12')).toBe(true);
+      expect(router.getTarget(sidB)).toBeDefined();
+    });
+
+    it('finds and removes sessions under thread scope without senderId in key', async () => {
+      const router = new SessionRouter(bridge, '/tmp');
+      router.setChannelScope('ch', 'thread');
+      const sid = await router.resolve('ch', 'alice', 'chat1', 'thread-1');
+
+      // Under thread scope, the key is `ch:thread-1` — no senderId.
+      // hasSession/removeSession by senderId must still find it via target metadata.
+      expect(router.hasSession('ch', 'alice')).toBe(true);
+      const removed = router.removeSession('ch', 'alice');
+      expect(removed).toEqual([sid]);
+      expect(router.hasSession('ch', 'alice')).toBe(false);
+    });
   });
 
   describe('getAll', () => {

--- a/packages/channels/base/src/SessionRouter.ts
+++ b/packages/channels/base/src/SessionRouter.ts
@@ -85,14 +85,45 @@ export class SessionRouter {
     return this.toTarget.get(sessionId);
   }
 
+  /**
+   * Build the prefix used to scan keys belonging to a given sender on a
+   * channel when no chatId is supplied. Includes the trailing separator so
+   * `user1` doesn't match `user12`. For non-`user` scopes the senderId is
+   * not part of the key, so we have to fall back to a target-based filter.
+   */
+  private senderKeyPrefix(channelName: string, senderId: string): string {
+    return `${channelName}:${senderId}:`;
+  }
+
+  private *senderKeys(
+    channelName: string,
+    senderId: string,
+  ): IterableIterator<string> {
+    const scope = this.channelScopes.get(channelName) || this.defaultScope;
+    if (scope === 'user') {
+      const prefix = this.senderKeyPrefix(channelName, senderId);
+      for (const k of this.toSession.keys()) {
+        if (k.startsWith(prefix)) yield k;
+      }
+      return;
+    }
+    // thread/single scopes don't encode senderId in the key — fall back to
+    // matching via stored target metadata.
+    for (const [k, sessionId] of this.toSession) {
+      const target = this.toTarget.get(sessionId);
+      if (target?.channelName === channelName && target.senderId === senderId) {
+        yield k;
+      }
+    }
+  }
+
   hasSession(channelName: string, senderId: string, chatId?: string): boolean {
-    const key = chatId
-      ? this.routingKey(channelName, senderId, chatId)
-      : `${channelName}:${senderId}`;
-    // If chatId is provided, do exact lookup; otherwise prefix-scan for any match
-    if (chatId) return this.toSession.has(key);
-    for (const k of this.toSession.keys()) {
-      if (k.startsWith(`${channelName}:${senderId}`)) return true;
+    if (chatId) {
+      const key = this.routingKey(channelName, senderId, chatId);
+      return this.toSession.has(key);
+    }
+    for (const _ of this.senderKeys(channelName, senderId)) {
+      return true;
     }
     return false;
   }
@@ -111,13 +142,12 @@ export class SessionRouter {
       const sessionId = this.deleteByKey(key);
       if (sessionId) removedIds.push(sessionId);
     } else {
-      // No chatId: remove all sessions for this sender on this channel
-      const prefix = `${channelName}:${senderId}`;
-      for (const k of [...this.toSession.keys()]) {
-        if (k.startsWith(prefix)) {
-          const sessionId = this.deleteByKey(k);
-          if (sessionId) removedIds.push(sessionId);
-        }
+      // No chatId: remove all sessions for this sender on this channel.
+      // Materialize keys first so we can delete during iteration.
+      const keys = [...this.senderKeys(channelName, senderId)];
+      for (const k of keys) {
+        const sessionId = this.deleteByKey(k);
+        if (sessionId) removedIds.push(sessionId);
       }
     }
     if (removedIds.length > 0) this.persist();


### PR DESCRIPTION
Fix `SessionRouter.hasSession`/`removeSession` prefix collision and scope blindness.

## TLDR

`SessionRouter.hasSession` and `removeSession` use `${channelName}:${senderId}` as a prefix when `chatId` is omitted — without a trailing separator and without considering the channel's `SessionScope`. Three failure modes follow: (1) `senderId` prefix collisions cross-match unrelated users (`user1` matches `user12`), (2) `removeSession('telegram', 'user1')` silently deletes sessions belonging to `user12`, `user100`, etc., and (3) under `'thread'` or `'single'` scopes the sender ID isn't in the key at all, so the prefix matches nothing and both methods are no-ops even when sessions exist. Add a trailing separator and special-case non-`'user'` scopes by walking stored target metadata.

## Screenshots / Video Demo

N/A — routing/session-management logic, no UI. Repro is unit-testable.

## Dive Deeper

Stored key shapes by scope (`SessionRouter.routingKey`):

- `user` (default) → `${channelName}:${senderId}:${chatId}`
- `thread` → `${channelName}:${threadId || chatId}`
- `single` → `${channelName}:__single__`

Before:

```typescript
hasSession(channelName, senderId, chatId?): boolean {
  const key = chatId
    ? this.routingKey(channelName, senderId, chatId)
    : `${channelName}:${senderId}`;
  if (chatId) return this.toSession.has(key);
  for (const k of this.toSession.keys()) {
    if (k.startsWith(`${channelName}:${senderId}`)) return true;
  }
  return false;
}

removeSession(channelName, senderId, chatId?): string[] {
  // ...
  const prefix = `${channelName}:${senderId}`;
  for (const k of [...this.toSession.keys()]) {
    if (k.startsWith(prefix)) { /* delete */ }
  }
}
```

Failure modes:

1. **Sender-ID prefix collision (false positive).** `'telegram:user12:chat1'.startsWith('telegram:user1')` is true. `hasSession('telegram', 'user1')` returns true even when only `user12` has a session. Telegram and DingTalk both use numeric user IDs where `123` and `1234` are common neighbors.

2. **Cross-user deletion (data loss).** `removeSession('telegram', 'user1')` deletes every key starting with `telegram:user1` — including `user12`, `user100`, `user1000`. Calling logout/reset for one user wipes the others. This is the worst failure mode because it's silent and destructive.

3. **Wrong scope, total miss.** Under `'thread'` scope the key is `${channelName}:${threadId}`; the sender ID never appears. `removeSession('ch', 'alice')` finds nothing and returns `[]` even when alice has live sessions. Same for `'single'` scope. Callers think they're managing sessions but the operations are no-ops.

After: introduce a `senderKeys` helper that returns the keys belonging to a sender, scope-aware:

```typescript
private senderKeyPrefix(channelName: string, senderId: string): string {
  return `${channelName}:${senderId}:`;  // trailing separator fixes collision
}

private *senderKeys(
  channelName: string,
  senderId: string,
): IterableIterator<string> {
  const scope = this.channelScopes.get(channelName) || this.defaultScope;
  if (scope === 'user') {
    const prefix = this.senderKeyPrefix(channelName, senderId);
    for (const k of this.toSession.keys()) {
      if (k.startsWith(prefix)) yield k;
    }
    return;
  }
  // thread/single scopes don't encode senderId in the key — fall back to
  // matching via stored target metadata.
  for (const [k, sessionId] of this.toSession) {
    const target = this.toTarget.get(sessionId);
    if (target?.channelName === channelName && target.senderId === senderId) {
      yield k;
    }
  }
}

hasSession(channelName, senderId, chatId?): boolean {
  if (chatId) {
    return this.toSession.has(this.routingKey(channelName, senderId, chatId));
  }
  for (const _ of this.senderKeys(channelName, senderId)) return true;
  return false;
}

removeSession(channelName, senderId, chatId?): string[] {
  const removedIds: string[] = [];
  if (chatId) {
    const sessionId = this.deleteByKey(this.routingKey(channelName, senderId, chatId));
    if (sessionId) removedIds.push(sessionId);
  } else {
    const keys = [...this.senderKeys(channelName, senderId)];
    for (const k of keys) {
      const sessionId = this.deleteByKey(k);
      if (sessionId) removedIds.push(sessionId);
    }
  }
  if (removedIds.length > 0) this.persist();
  return removedIds;
}
```

The trailing-separator prefix (`telegram:user1:`) cannot prefix-collide with `telegram:user12:`. The non-`'user'` scope branch consults `toTarget` (which always stores the real `senderId`) so thread/single deployments can also enumerate sessions per sender.

Two regression tests added in `SessionRouter.test.ts`:

- **Prefix collision** — sets up `user1` and `user12` under user scope, asserts that `hasSession('ch', 'user1')` returns false when only `user12` exists, and that `removeSession('ch', 'user1')` does not touch `user12`.
- **Thread-scope removal** — sets up sessions under thread scope, asserts that `hasSession`/`removeSession` by senderId still finds and removes the right entries via the target-metadata fallback.

**Modified files:**
- `packages/channels/base/src/SessionRouter.ts` — add `senderKeys`/`senderKeyPrefix`, scope-aware `hasSession`/`removeSession`
- `packages/channels/base/src/SessionRouter.test.ts` — add prefix-collision and thread-scope regression tests

## Reviewer Test Plan

1. `vitest run packages/channels/base/src/SessionRouter.test.ts` — 25 tests pass (was 23 + 2 new).
2. Manual: in a multi-user Telegram deployment with senderIds `123`, `1234`, and `12345`, call `removeSession('telegram', '123')`. Before fix: all three are wiped. After fix: only `123` is removed.
3. Manual: configure a channel with `setChannelScope('ch', 'thread')`, create a session, call `hasSession('ch', '<senderId>')`. Before fix: returns false. After fix: returns true.
4. Confirm exact-`chatId` lookups (the pre-existing happy path) are unchanged for both methods.

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ?     | pass    | ?     |
| npx      | ?     | ?       | ?     |
| Docker   | ?     | ?       | ?     |
| Podman   | ?     | -       | -     |
| Seatbelt | ?     | -       | -     |
