### PR TITLE
feat(vscode-ide-companion): add /account for account display

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -370,6 +370,15 @@ class QwenAgent implements Agent {
     method: string,
     _params: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
+    if (method === 'getAccountInfo') {
+      const cfg = this.config.getContentGeneratorConfig();
+      return {
+        authType: cfg?.authType ?? this.config.getAuthType() ?? null,
+        model: cfg?.model ?? this.config.getModel() ?? null,
+        baseUrl: cfg?.baseUrl ?? null,
+        apiKeyEnvKey: cfg?.apiKeyEnvKey ?? null,
+      };
+    }
     throw RequestError.methodNotFound(method);
   }
 

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -368,13 +368,16 @@ class QwenAgent implements Agent {
 
   async extMethod(
     method: string,
-    _params: Record<string, unknown>,
+    params: Record<string, unknown>,
   ): Promise<Record<string, unknown>> {
     if (method === 'getAccountInfo') {
-      const cfg = this.config.getContentGeneratorConfig();
+      const sessionId = params['sessionId'] as string | undefined;
+      const session = sessionId ? this.sessions.get(sessionId) : undefined;
+      const config = session ? session.getConfig() : this.config;
+      const cfg = config.getContentGeneratorConfig();
       return {
-        authType: cfg?.authType ?? this.config.getAuthType() ?? null,
-        model: cfg?.model ?? this.config.getModel() ?? null,
+        authType: cfg?.authType ?? config.getAuthType() ?? null,
+        model: cfg?.model ?? config.getModel() ?? null,
         baseUrl: cfg?.baseUrl ?? null,
         apiKeyEnvKey: cfg?.apiKeyEnvKey ?? null,
       };

--- a/packages/vscode-ide-companion/src/services/acpConnection.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.ts
@@ -565,6 +565,22 @@ export class AcpConnection {
     return res;
   }
 
+  async getAccountInfo(): Promise<{
+    authType: string | null;
+    model: string | null;
+    baseUrl: string | null;
+    apiKeyEnvKey: string | null;
+  }> {
+    const conn = this.ensureConnection();
+    const result = await conn.extMethod('getAccountInfo', {});
+    return {
+      authType: (result['authType'] as string | null) ?? null,
+      model: (result['model'] as string | null) ?? null,
+      baseUrl: (result['baseUrl'] as string | null) ?? null,
+      apiKeyEnvKey: (result['apiKeyEnvKey'] as string | null) ?? null,
+    };
+  }
+
   async setModel(modelId: string): Promise<SetSessionModelResponse> {
     const conn = this.ensureConnection();
     if (!this.sessionId) {

--- a/packages/vscode-ide-companion/src/services/acpConnection.ts
+++ b/packages/vscode-ide-companion/src/services/acpConnection.ts
@@ -572,7 +572,9 @@ export class AcpConnection {
     apiKeyEnvKey: string | null;
   }> {
     const conn = this.ensureConnection();
-    const result = await conn.extMethod('getAccountInfo', {});
+    const result = await conn.extMethod('getAccountInfo', {
+      sessionId: this.sessionId,
+    });
     return {
       authType: (result['authType'] as string | null) ?? null,
       model: (result['model'] as string | null) ?? null,

--- a/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
+++ b/packages/vscode-ide-companion/src/services/qwenAgentManager.ts
@@ -424,6 +424,15 @@ export class QwenAgentManager {
     }
   }
 
+  async getAccountInfo(): Promise<{
+    authType: string | null;
+    model: string | null;
+    baseUrl: string | null;
+    apiKeyEnvKey: string | null;
+  }> {
+    return this.connection.getAccountInfo();
+  }
+
   /**
    * Validate if current session is still active
    * This is a lightweight check to verify session validity

--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -47,6 +47,10 @@ import {
   SessionSelector,
 } from '@qwen-code/webui';
 import { InputForm } from './components/layout/InputForm.js';
+import {
+  AccountInfoDialog,
+  type AccountInfo,
+} from './components/AccountInfoDialog.js';
 import { ApprovalMode, NEXT_APPROVAL_MODE } from '../types/acpTypes.js';
 import type { ApprovalModeValue } from '../types/approvalModeValueTypes.js';
 import type { PlanEntry, UsageStatsPayload } from '../types/chatTypes.js';
@@ -92,6 +96,7 @@ export const App: React.FC = () => {
   >([]);
   const [availableModels, setAvailableModels] = useState<ModelInfo[]>([]);
   const [showModelSelector, setShowModelSelector] = useState(false);
+  const [accountInfo, setAccountInfo] = useState<AccountInfo | null>(null);
   const messagesEndRef = useRef<HTMLDivElement | null>(null);
   // Scroll container for message list; used to keep the view anchored to the latest content
   const messagesContainerRef = useRef<HTMLDivElement | null>(null);
@@ -166,6 +171,13 @@ export const App: React.FC = () => {
             id: 'login',
             label: 'Login',
             description: 'Login to Qwen Code',
+            type: 'command',
+            group: 'Account',
+          },
+          {
+            id: 'account',
+            label: 'Account',
+            description: 'Show current account and authentication info',
             type: 'command',
             group: 'Account',
           },
@@ -362,6 +374,9 @@ export const App: React.FC = () => {
     },
     setAvailableModels: (models) => {
       setAvailableModels(models);
+    },
+    setAccountInfo: (info) => {
+      setAccountInfo(info);
     },
   });
 
@@ -612,6 +627,13 @@ export const App: React.FC = () => {
         if (itemId === 'login') {
           clearTriggerText();
           vscode.postMessage({ type: 'login', data: {} });
+          completion.closeCompletion();
+          return;
+        }
+
+        if (itemId === 'account') {
+          clearTriggerText();
+          vscode.postMessage({ type: 'getAccountInfo', data: {} });
           completion.closeCompletion();
           return;
         }
@@ -1097,6 +1119,13 @@ export const App: React.FC = () => {
           questions={askUserQuestionRequest.questions}
           onSubmit={handleAskUserQuestionResponse}
           onCancel={handleAskUserQuestionCancel}
+        />
+      )}
+
+      {accountInfo && (
+        <AccountInfoDialog
+          info={accountInfo}
+          onClose={() => setAccountInfo(null)}
         />
       )}
     </div>

--- a/packages/vscode-ide-companion/src/webview/components/AccountInfoDialog.tsx
+++ b/packages/vscode-ide-companion/src/webview/components/AccountInfoDialog.tsx
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { FC } from 'react';
+import { useEffect } from 'react';
+
+export interface AccountInfo {
+  authType?: string | null;
+  baseUrl?: string | null;
+  envKey?: string | null;
+  modelId?: string | null;
+  error?: string;
+}
+
+interface AccountInfoDialogProps {
+  info: AccountInfo;
+  onClose: () => void;
+}
+
+const AUTH_LABELS: Record<string, string> = {
+  'qwen-oauth': 'Qwen OAuth',
+  openai: 'OpenAI-compatible',
+  gemini: 'Gemini',
+  anthropic: 'Anthropic',
+  'vertex-ai': 'Vertex AI',
+};
+
+export const AccountInfoDialog: FC<AccountInfoDialogProps> = ({
+  info,
+  onClose,
+}) => {
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const rows: Array<{ label: string; value: string; accent?: boolean }> = [];
+
+  if (info.error) {
+    rows.push({ label: 'Error', value: info.error });
+  } else {
+    const authLabel =
+      AUTH_LABELS[info.authType ?? ''] ?? info.authType ?? 'Unknown';
+    rows.push({ label: 'Auth Method', value: authLabel });
+
+    if (info.envKey) {
+      rows.push({ label: 'API Key Env', value: info.envKey });
+    }
+
+    if (info.baseUrl) {
+      rows.push({ label: 'Base URL', value: info.baseUrl });
+    }
+
+    if (info.modelId) {
+      rows.push({ label: 'Current Model', value: info.modelId });
+    }
+  }
+
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-[1000] flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.45)' }}
+      onClick={onClose}
+    >
+      {/* Card */}
+      <div
+        className="relative w-[480px] rounded-lg border p-5 shadow-xl"
+        style={{
+          backgroundColor: 'var(--app-input-secondary-background)',
+          borderColor: 'var(--app-input-border)',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between mb-4">
+          <span
+            className="font-semibold text-base"
+            style={{ color: 'var(--app-primary-foreground)' }}
+          >
+            Account Information
+          </span>
+          <button
+            className="flex items-center justify-center w-6 h-6 rounded cursor-pointer border-none text-lg leading-none hover:opacity-70"
+            style={{
+              backgroundColor: 'transparent',
+              color: 'var(--app-secondary-foreground)',
+            }}
+            onClick={onClose}
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </div>
+
+        {/* Rows */}
+        <div className="flex flex-col gap-2">
+          {rows.map(({ label, value, accent }) => (
+            <div key={label} className="flex justify-between items-start gap-3">
+              <span
+                className="text-sm shrink-0"
+                style={{ color: 'var(--app-secondary-foreground)' }}
+              >
+                {label}
+              </span>
+              <span
+                className="text-sm text-right break-all"
+                style={{
+                  color: accent
+                    ? 'var(--app-link-color)'
+                    : 'var(--app-primary-foreground)',
+                }}
+              >
+                {value}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/vscode-ide-companion/src/webview/handlers/AuthMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/AuthMessageHandler.ts
@@ -16,7 +16,7 @@ export class AuthMessageHandler extends BaseMessageHandler {
   private loginHandler: (() => Promise<void>) | null = null;
 
   canHandle(messageType: string): boolean {
-    return ['login'].includes(messageType);
+    return ['login', 'getAccountInfo'].includes(messageType);
   }
 
   async handle(message: { type: string; data?: unknown }): Promise<void> {
@@ -24,6 +24,11 @@ export class AuthMessageHandler extends BaseMessageHandler {
       case 'login':
         await this.handleLogin();
         break;
+
+      case 'getAccountInfo': {
+        await this.handleGetAccountInfo();
+        break;
+      }
 
       default:
         console.warn(
@@ -39,6 +44,31 @@ export class AuthMessageHandler extends BaseMessageHandler {
    */
   setLoginHandler(handler: () => Promise<void>): void {
     this.loginHandler = handler;
+  }
+
+  /**
+   * Handle getAccountInfo request - queries ACP for live account info
+   */
+  private async handleGetAccountInfo(): Promise<void> {
+    try {
+      const info = await this.agentManager.getAccountInfo();
+      this.sendToWebView({
+        type: 'accountInfo',
+        data: {
+          authType: info.authType,
+          baseUrl: info.baseUrl,
+          envKey: info.apiKeyEnvKey,
+          modelId: info.model,
+        },
+      });
+    } catch (error) {
+      const errorMsg = getErrorMessage(error);
+      console.error('[AuthMessageHandler] getAccountInfo failed:', error);
+      this.sendToWebView({
+        type: 'accountInfo',
+        data: { error: errorMsg },
+      });
+    }
   }
 
   /**

--- a/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.ts
@@ -89,6 +89,17 @@ export const useMessageSubmit = ({
         return;
       }
 
+      // Handle /account command - show account info dialog
+      if (textToSend.trim() === '/account') {
+        setInputText('');
+        if (inputFieldRef.current) {
+          inputFieldRef.current.textContent = '\u200B';
+          inputFieldRef.current.setAttribute('data-empty', 'true');
+        }
+        vscode.postMessage({ type: 'getAccountInfo', data: {} });
+        return;
+      }
+
       // Handle /login command - show inline loading while extension authenticates
       if (textToSend.trim() === '/login') {
         setInputText('');

--- a/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
@@ -131,6 +131,16 @@ interface UseWebViewMessagesProps {
   setAvailableCommands?: (commands: AvailableCommand[]) => void;
   // Available models setter
   setAvailableModels?: (models: ModelInfo[]) => void;
+  // Account info setter (triggers dialog)
+  setAccountInfo?: (
+    info: {
+      authType?: string | null;
+      baseUrl?: string | null;
+      envKey?: string | null;
+      modelId?: string | null;
+      error?: string;
+    } | null,
+  ) => void;
 }
 
 /**
@@ -154,6 +164,7 @@ export const useWebViewMessages = ({
   setModelInfo,
   setAvailableCommands,
   setAvailableModels,
+  setAccountInfo,
 }: UseWebViewMessagesProps) => {
   // VS Code API for posting messages back to the extension host
   const vscode = useVSCode();
@@ -190,6 +201,7 @@ export const useWebViewMessages = ({
     setModelInfo,
     setAvailableCommands,
     setAvailableModels,
+    setAccountInfo,
   });
 
   // Track last "Updated Plan" snapshot toolcall to support merge/dedupe
@@ -240,6 +252,7 @@ export const useWebViewMessages = ({
       setModelInfo,
       setAvailableCommands,
       setAvailableModels,
+      setAccountInfo,
     };
   });
 
@@ -421,6 +434,20 @@ export const useWebViewMessages = ({
           } else {
             handlers.setIsAuthenticated?.(null);
           }
+          break;
+        }
+
+        case 'accountInfo': {
+          const info = message?.data as
+            | {
+                authType?: string | null;
+                baseUrl?: string | null;
+                envKey?: string | null;
+                modelId?: string | null;
+                error?: string;
+              }
+            | undefined;
+          handlers.setAccountInfo?.(info ?? null);
           break;
         }
 


### PR DESCRIPTION
## TLDR

Adds a `/account` slash command to the VS Code extension's chat input. When selected, a modal dialog pops up showing the user's current authentication method, API key env var, base URL, and active model — all sourced live from the CLI via ACP `extMethod`, so the info is always accurate.

Closes #2772

## Screenshots / Video Demo


![account](https://github.com/user-attachments/assets/e2799c2d-c213-4092-98f3-f0e282bf9eaa)



Typing `/` in the chat input now surfaces an **Account** group with a new `Account` item alongside the existing `Login`:

```
/
  ├── Model
  │   └── Switch model...
  ├── Account
  │   ├── Login
  │   └── Account   ← new
  └── Slash Commands
      └── ...
```

Selecting `/account` opens a centered modal:

```
┌─────────────────────────────────────────────────┐
│ Account Information                          ×  │
├─────────────────────────────────────────────────┤
│ Auth Method     OpenAI-compatible               │
│ API Key Env     OPENAI_API_KEY                  │
│ Base URL        https://dashscope.aliyun...     │
│ Current Model   qwen3-max                       │
└─────────────────────────────────────────────────┘
```

Close by clicking the backdrop, pressing `Escape`, or the `×` button.

## Dive Deeper

### Data flow

```
User selects /account
  → webview postMessage('getAccountInfo')
  → AuthMessageHandler.handleGetAccountInfo()
  → QwenAgentManager.getAccountInfo()
  → AcpConnection.extMethod('getAccountInfo', {})
  → [ACP protocol] → CLI acpAgent.extMethod()
  → config.getContentGeneratorConfig()   ← runtime config, always current
  → { authType, model, baseUrl, apiKeyEnvKey }
  → AccountInfoDialog renders
```

The key design decision is to query the CLI process directly via `extMethod` rather than reading `~/.qwen/settings.json` from the extension side. This ensures the displayed info matches exactly what the CLI is using at runtime (after any hot-reload, model switch, etc.).

### Files changed

| File | Change |
|------|--------|
| `packages/cli/src/acp-integration/acpAgent.ts` | Implement `extMethod('getAccountInfo')` — returns authType, model, baseUrl, apiKeyEnvKey from live `ContentGeneratorConfig` |
| `packages/vscode-ide-companion/src/services/acpConnection.ts` | Add `getAccountInfo()` method that calls `conn.extMethod(...)` |
| `packages/vscode-ide-companion/src/services/qwenAgentManager.ts` | Expose `getAccountInfo()` proxy method |
| `packages/vscode-ide-companion/src/webview/handlers/AuthMessageHandler.ts` | Handle `getAccountInfo` message from webview; send back `accountInfo` |
| `packages/vscode-ide-companion/src/webview/components/AccountInfoDialog.tsx` | New modal dialog component (theme-aware, Escape/backdrop to close) |
| `packages/vscode-ide-companion/src/webview/App.tsx` | Add `account` to slash command palette; handle selection; render dialog |
| `packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts` | Handle `accountInfo` message; forward to `setAccountInfo` state setter |

## Reviewer Test Plan

1. Open the VS Code extension (reload window after building)
2. In the chat input, type `/` — verify **Account → Account** appears in the completion list
3. Select it — a modal should appear with your current auth method, base URL, model, etc.
4. Verify the values match your `~/.qwen/settings.json` active model configuration
5. Press `Escape` or click the backdrop — modal should close cleanly
6. Switch models via `/model`, then open `/account` again — model name should reflect the switch
7. Verify `/login` still works normally

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes #2772
