### PR TITLE
fix(cli): fix csiUPrefix error in Linux/Wayland

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -189,13 +189,35 @@ export function KeypressProvider({
       clearKittyTimeout();
       kittySequenceTimeout = setTimeout(() => {
         if (kittySequenceBufferRef.current) {
-          if (debugKeystrokeLogging) {
-            debugLogger.debug(
-              '[DEBUG] Kitty buffer timeout, clearing:',
-              kittySequenceBufferRef.current,
-            );
+          // Before discarding, try to salvage any parseable sequences
+          // that may have been missed (e.g., due to chunked input).
+          while (kittySequenceBufferRef.current) {
+            const parsed = parseKittyPrefix(kittySequenceBufferRef.current);
+            if (parsed) {
+              kittySequenceBufferRef.current =
+                kittySequenceBufferRef.current.slice(parsed.length);
+              broadcast(parsed.key);
+              continue;
+            }
+            const plain = parsePlainTextPrefix(kittySequenceBufferRef.current);
+            if (plain) {
+              kittySequenceBufferRef.current =
+                kittySequenceBufferRef.current.slice(plain.length);
+              broadcast(plain.key);
+              continue;
+            }
+            break;
           }
-          kittySequenceBufferRef.current = '';
+          // Clear any remaining unparseable content
+          if (kittySequenceBufferRef.current) {
+            if (debugKeystrokeLogging) {
+              debugLogger.debug(
+                '[DEBUG] Kitty buffer timeout, clearing:',
+                kittySequenceBufferRef.current,
+              );
+            }
+            kittySequenceBufferRef.current = '';
+          }
         }
       }, KITTY_SEQUENCE_TIMEOUT_MS);
     };
@@ -331,14 +353,19 @@ export function KeypressProvider({
         };
       }
 
-      // 3) CSI-u form: ESC [ <code> ; <mods> (u|~)
-      // 3) CSI-u and tilde-coded functional keys: ESC [ <code> ; <mods> (u|~)
+      // 3) CSI-u form: ESC [ <code>[:<shifted>][:<base>] ; <mods>[:<event>] [; <text>] (u|~)
+      // 3) CSI-u and tilde-coded functional keys with optional kitty extensions:
+      //    Full kitty format: ESC [ code:shifted:base ; mods:event ; text u
       //    'u' terminator: Kitty CSI-u; '~' terminator: tilde-coded function keys.
-      const csiUPrefix = new RegExp(`^${ESC}\\[(\\d+)(;(\\d+))?([u~])`);
+      //    The colon-separated fields (shifted key, base key, event type, text)
+      //    are optional extensions that some terminals send.
+      const csiUPrefix = new RegExp(
+        `^${ESC}\\[(\\d+)(?::\\d+)*(?:;(\\d+)(?::\\d+)*)?(?:;\\d+)?([u~])`,
+      );
       m = buffer.match(csiUPrefix);
       if (m) {
         const keyCode = parseInt(m[1], 10);
-        let modifiers = m[3] ? parseInt(m[3], 10) : KITTY_MODIFIER_BASE;
+        let modifiers = m[2] ? parseInt(m[2], 10) : KITTY_MODIFIER_BASE;
         if (modifiers >= KITTY_MODIFIER_EVENT_TYPES_OFFSET) {
           modifiers -= KITTY_MODIFIER_EVENT_TYPES_OFFSET;
         }
@@ -347,7 +374,7 @@ export function KeypressProvider({
           (modifierBits & MODIFIER_SHIFT_BIT) === MODIFIER_SHIFT_BIT;
         const alt = (modifierBits & MODIFIER_ALT_BIT) === MODIFIER_ALT_BIT;
         const ctrl = (modifierBits & MODIFIER_CTRL_BIT) === MODIFIER_CTRL_BIT;
-        const terminator = m[4];
+        const terminator = m[3];
 
         // Tilde-coded functional keys (Delete, Insert, PageUp/Down, Home/End)
         if (terminator === '~') {


### PR DESCRIPTION
## TLDR

Fix CSI-u sequence parsing errors on Linux/Wayland (e.g., Kitty terminal). The regex for `csiUPrefix` did not account for optional colon-separated fields in the full Kitty keyboard protocol, causing keypress parsing failures. Also improve the Kitty buffer timeout handler to salvage parseable sequences before discarding the buffer.

## Screenshots / Video Demo

N/A — no user-facing visual change. The fix resolves keypress parsing errors (e.g., keys not registering or producing errors) when running in terminals that send extended Kitty keyboard protocol sequences on Linux/Wayland.

## Dive Deeper

The [Kitty keyboard protocol](https://sw.kovidgoyal.net/kitty/keyboard-protocol/) defines an extended CSI-u format:

```
ESC [ code:shifted:base ; mods:event ; text u
```

The previous regex only handled the basic form `ESC [ code ; mods (u|~)`, which broke when terminals sent the full format with colon-separated sub-fields (shifted key, base key, event type, text).

**Changes:**

1. **Updated `csiUPrefix` regex** — Now correctly matches the full Kitty CSI-u format with optional `:shifted`, `:base`, `:event`, and `;text` fields, while still extracting only the key code, modifier, and terminator we need.

2. **Improved Kitty buffer timeout handler** — Instead of immediately discarding the entire buffer on timeout, the handler now attempts to parse any remaining sequences (via `parseKittyPrefix` and `parsePlainTextPrefix`) before clearing. This handles cases where chunked input left valid sequences in the buffer.

## Reviewer Test Plan

1. Run on a Linux machine with Kitty terminal (or any terminal using the Kitty keyboard protocol)
2. Verify basic keystrokes work: typing text, Enter, Backspace, Delete, arrow keys
3. Verify modifier combos work: Ctrl+C, Ctrl+Z, Shift+Enter, Alt+key
4. Test on macOS terminal to ensure no regression
5. Enable debug keystroke logging and verify no `csiUPrefix` parse errors in the logs

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

fix: #2885 
