### PR TITLE
feat: add qwen3.6-plus model to ModelStudio Coding Plan

### DIFF
--- a/packages/cli/src/constants/codingPlan.ts
+++ b/packages/cli/src/constants/codingPlan.ts
@@ -53,6 +53,18 @@ export function generateCodingPlanTemplate(
     // This ensures existing users don't get prompted for unnecessary updates
     return [
       {
+        id: 'qwen3.6-plus',
+        name: '[ModelStudio Coding Plan] qwen3.6-plus',
+        baseUrl: 'https://coding.dashscope.aliyuncs.com/v1',
+        envKey: CODING_PLAN_ENV_KEY,
+        generationConfig: {
+          extra_body: {
+            enable_thinking: true,
+          },
+          contextWindowSize: 1000000,
+        },
+      },
+      {
         id: 'qwen3.5-plus',
         name: '[ModelStudio Coding Plan] qwen3.5-plus',
         baseUrl: 'https://coding.dashscope.aliyuncs.com/v1',
@@ -147,6 +159,18 @@ export function generateCodingPlanTemplate(
 
   // Global region uses ModelStudio Coding Plan branding for Global/Intl
   return [
+    {
+      id: 'qwen3.6-plus',
+      name: '[ModelStudio Coding Plan for Global/Intl] qwen3.6-plus',
+      baseUrl: 'https://coding-intl.dashscope.aliyuncs.com/v1',
+      envKey: CODING_PLAN_ENV_KEY,
+      generationConfig: {
+        extra_body: {
+          enable_thinking: true,
+        },
+        contextWindowSize: 1000000,
+      },
+    },
     {
       id: 'qwen3.5-plus',
       name: '[ModelStudio Coding Plan for Global/Intl] qwen3.5-plus',

--- a/packages/cli/src/ui/hooks/useCodingPlanUpdates.test.ts
+++ b/packages/cli/src/ui/hooks/useCodingPlanUpdates.test.ts
@@ -391,9 +391,9 @@ describe('useCodingPlanUpdates', () => {
       >;
 
       // Should have new China configs + custom config only (global config removed since regions are mutually exclusive)
-      // The China template has 8 models, so we expect 8 (from template) + 1 (custom) = 9
+      // The China template has 9 models, so we expect 9 (from template) + 1 (custom) = 10
       // Note: description field has been removed, only name field contains the branding
-      expect(updatedConfigs.length).toBe(9);
+      expect(updatedConfigs.length).toBe(10);
 
       // Should NOT contain the Global config (mutually exclusive)
       expect(

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -7,4 +7,4 @@
 export const DEFAULT_QWEN_MODEL = 'coder-model';
 export const DEFAULT_QWEN_FLASH_MODEL = 'coder-model';
 export const DEFAULT_QWEN_EMBEDDING_MODEL = 'text-embedding-v4';
-export const MAINLINE_CODER_MODEL = 'qwen3.5-plus';
+export const MAINLINE_CODER_MODEL = 'qwen3.6-plus';

--- a/packages/core/src/core/modalityDefaults.ts
+++ b/packages/core/src/core/modalityDefaults.ts
@@ -40,8 +40,9 @@ const MODALITY_PATTERNS: Array<[RegExp, InputModalities]> = [
   // -------------------
   // Alibaba / Qwen
   // -------------------
-  // Qwen3.5-Plus: image support
+  // Qwen3.5-Plus, Qwen3.6-Plus: image + video support
   [/^qwen3\.5-plus/, { image: true, video: true }],
+  [/^qwen3\.6-plus/, { image: true, video: true }],
   [/^coder-model$/, { image: true, video: true }],
 
   // Qwen VL (vision-language) models: image + video


### PR DESCRIPTION
## Summary

Add the new `qwen3.6-plus` model to the ModelStudio Coding Plan configuration for both China and Global/Intl regions.

## Changes

- **`codingPlan.ts`**: Add `qwen3.6-plus` model entry to both China and Global/Intl region templates with:
  - 1M context window (`contextWindowSize: 1000000`)
  - Thinking mode enabled (`enable_thinking: true`)
- **`modalityDefaults.ts`**: Add `qwen3.6-plus` pattern for image + video input modality support (matching `qwen3.5-plus` capabilities)
- **`useCodingPlanUpdates.test.ts`**: Update expected model count from 9 to 10 to reflect the new model addition

## Notes

- Token limits (input 1M / output 64K) are already covered by the existing `/^qwen3\\.\d/` regex pattern in `tokenLimits.ts`, so no changes were needed there.
- Existing Coding Plan users will be prompted to update their configuration on next session start via the `useCodingPlanUpdates` hook.