### PR TITLE
feat(cli): add /branch command for session forking

### DIFF
--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -9,6 +9,7 @@ import type { SlashCommand } from '../ui/commands/types.js';
 import type { Config } from '@qwen-code/qwen-code-core';
 import { aboutCommand } from '../ui/commands/aboutCommand.js';
 import { agentsCommand } from '../ui/commands/agentsCommand.js';
+import { branchCommand } from '../ui/commands/branchCommand.js';
 import { arenaCommand } from '../ui/commands/arenaCommand.js';
 import { approvalModeCommand } from '../ui/commands/approvalModeCommand.js';
 import { authCommand } from '../ui/commands/authCommand.js';
@@ -82,6 +83,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       aboutCommand,
       agentsCommand,
       arenaCommand,
+      branchCommand,
       approvalModeCommand,
       authCommand,
       btwCommand,

--- a/packages/cli/src/ui/commands/branchCommand.ts
+++ b/packages/cli/src/ui/commands/branchCommand.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  CommandContext,
+  SlashCommand,
+  SlashCommandActionReturn,
+} from './types.js';
+import { CommandKind } from './types.js';
+import { t } from '../../i18n/index.js';
+import { SessionService } from '@qwen-code/qwen-code-core';
+import { resumeIntoSession } from './resumeSessionHelper.js';
+
+export const branchCommand: SlashCommand = {
+  name: 'branch',
+  altNames: ['fork'],
+  get description() {
+    return t('Create a branch (fork) of the current conversation');
+  },
+  kind: CommandKind.BUILT_IN,
+  action: branchAction,
+};
+
+async function branchAction(
+  context: CommandContext,
+  args: string,
+): Promise<void | SlashCommandActionReturn> {
+  const { config } = context.services;
+
+  if (!config) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: t('No active session to branch.'),
+    };
+  }
+
+  const originalSessionId = config.getSessionId();
+  const cwd = config.getTargetDir();
+  const sessionService = new SessionService(cwd);
+  const customTitle = args?.trim() || undefined;
+
+  if (context.abortSignal?.aborted) return;
+
+  // Fork the session
+  const forkResult = await sessionService.forkSession(
+    originalSessionId,
+    customTitle ? { customTitle } : undefined,
+  );
+
+  if (!forkResult) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: t('No conversation to branch.'),
+    };
+  }
+
+  if (context.abortSignal?.aborted) return;
+
+  // Load the forked session data for resume
+  const sessionData = await sessionService.loadSession(forkResult.sessionId);
+
+  if (!sessionData) {
+    // Fork file was written but load failed — clean up the orphan
+    await sessionService.removeSession(forkResult.sessionId);
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: t('Failed to load branched session.'),
+    };
+  }
+
+  // Resume into the forked session
+  await resumeIntoSession(context, config, forkResult.sessionId, sessionData);
+
+  // Show success message
+  const titleInfo = customTitle ? ` "${customTitle}"` : '';
+  context.ui.addItem(
+    {
+      type: 'info',
+      text: t(
+        `Branched conversation${titleInfo} as "${forkResult.title}". You are now in the branch.\nTo resume the original: /resume ${originalSessionId}`,
+      ),
+    },
+    Date.now(),
+  );
+}

--- a/packages/cli/src/ui/commands/resumeCommand.ts
+++ b/packages/cli/src/ui/commands/resumeCommand.ts
@@ -4,9 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { SlashCommand, SlashCommandActionReturn } from './types.js';
+import type {
+  CommandContext,
+  SlashCommand,
+  SlashCommandActionReturn,
+} from './types.js';
 import { CommandKind } from './types.js';
 import { t } from '../../i18n/index.js';
+import { SessionService } from '@qwen-code/qwen-code-core';
+import { resumeIntoSession } from './resumeSessionHelper.js';
 
 export const resumeCommand: SlashCommand = {
   name: 'resume',
@@ -14,8 +20,47 @@ export const resumeCommand: SlashCommand = {
   get description() {
     return t('Resume a previous session');
   },
-  action: async (): Promise<SlashCommandActionReturn> => ({
-    type: 'dialog',
-    dialog: 'resume',
-  }),
+  action: async (
+    context: CommandContext,
+    args: string,
+  ): Promise<SlashCommandActionReturn | void> => {
+    const sessionId = args?.trim();
+
+    // No session ID provided — open the session picker dialog
+    if (!sessionId) {
+      return { type: 'dialog', dialog: 'resume' };
+    }
+
+    // Session ID provided — resume directly
+    const { config } = context.services;
+    if (!config) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: t('No active configuration.'),
+      };
+    }
+
+    const cwd = config.getTargetDir();
+    const sessionService = new SessionService(cwd);
+    const sessionData = await sessionService.loadSession(sessionId);
+
+    if (!sessionData) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: t(`Session not found: ${sessionId}`),
+      };
+    }
+
+    await resumeIntoSession(context, config, sessionId, sessionData);
+
+    context.ui.addItem(
+      {
+        type: 'info',
+        text: t(`Resumed session ${sessionId}`),
+      },
+      Date.now(),
+    );
+  },
 };

--- a/packages/cli/src/ui/commands/resumeSessionHelper.ts
+++ b/packages/cli/src/ui/commands/resumeSessionHelper.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  SessionStartSource,
+  type PermissionMode,
+  type ResumedSessionData,
+  type Config,
+} from '@qwen-code/qwen-code-core';
+import { buildResumedHistoryItems } from '../utils/resumeHistoryUtils.js';
+import type { CommandContext } from './types.js';
+
+/**
+ * Shared logic for resuming into a session (used by both /branch and /resume).
+ *
+ * Ordering follows the existing useResumeCommand pattern:
+ * 1. Reset UI session stats
+ * 2. Build UI history (before config.startNewSession mutates state)
+ * 3. Clear + load UI history
+ * 4. Update core config
+ * 5. Re-initialize Gemini client
+ * 6. Fire SessionStart hook
+ */
+export async function resumeIntoSession(
+  context: CommandContext,
+  config: Config,
+  sessionId: string,
+  sessionData: ResumedSessionData,
+): Promise<void> {
+  // 1. Reset UI session stats
+  if (context.session.startNewSession) {
+    context.session.startNewSession(sessionId);
+  }
+
+  // 2. Build UI history BEFORE config.startNewSession (which resets internal state)
+  const uiHistoryItems = buildResumedHistoryItems(sessionData, config);
+
+  // 3. Clear and load UI history
+  context.ui.clear();
+  context.ui.loadHistory(uiHistoryItems);
+
+  // 4. Update core config with session data
+  config.startNewSession(sessionId, sessionData);
+
+  // 5. Re-initialize Gemini client with the session history
+  await config.getGeminiClient()?.initialize?.();
+
+  // 6. Fire SessionStart event (non-blocking)
+  config
+    .getHookSystem()
+    ?.fireSessionStartEvent(
+      SessionStartSource.Resume,
+      config.getModel() ?? '',
+      String(config.getApprovalMode()) as PermissionMode,
+    )
+    .catch((err) => {
+      config.getDebugLogger().warn(`SessionStart hook failed: ${err}`);
+    });
+}

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -57,7 +57,8 @@ export interface ChatRecord {
     | 'chat_compression'
     | 'slash_command'
     | 'ui_telemetry'
-    | 'at_command';
+    | 'at_command'
+    | 'session_title';
   /** Working directory at time of message */
   cwd: string;
   /** CLI version for compatibility tracking */
@@ -97,7 +98,19 @@ export interface ChatRecord {
     | ChatCompressionRecordPayload
     | SlashCommandRecordPayload
     | UiTelemetryRecordPayload
-    | AtCommandRecordPayload;
+    | AtCommandRecordPayload
+    | SessionTitleRecordPayload;
+
+  /**
+   * Traceability info for forked (branched) sessions.
+   * Present only on records that were copied from another session via fork.
+   */
+  forkedFrom?: {
+    /** Original session ID this record was forked from */
+    sessionId: string;
+    /** UUID of the original message in the source session */
+    messageUuid: string;
+  };
 }
 
 /**
@@ -146,6 +159,17 @@ export interface AtCommandRecordPayload {
  */
 export interface UiTelemetryRecordPayload {
   uiEvent: UiEvent;
+}
+
+/**
+ * Stored payload for session title metadata.
+ * Appended as a system record to store custom or derived session titles.
+ */
+export interface SessionTitleRecordPayload {
+  /** Custom title set by user or derived during fork */
+  customTitle: string;
+  /** Source of the title */
+  source: 'user' | 'fork';
 }
 
 /**

--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -62,6 +62,8 @@ describe('SessionService', () => {
     // Mock jsonl-utils
     vi.mocked(jsonl.read).mockResolvedValue([]);
     vi.mocked(jsonl.readLines).mockResolvedValue([]);
+    vi.mocked(jsonl.write).mockImplementation(() => {});
+    vi.mocked(jsonl.writeLine).mockResolvedValue();
   });
 
   afterEach(() => {
@@ -628,6 +630,195 @@ describe('SessionService', () => {
       const exists = await sessionService.sessionExists(sessionIdA);
 
       expect(exists).toBe(false);
+    });
+  });
+
+  describe('forkSession', () => {
+    it('should fork an existing session with a new sessionId and forkedFrom traceability', async () => {
+      vi.mocked(jsonl.read).mockResolvedValue([recordB1, recordB2]);
+
+      const result = await sessionService.forkSession(sessionIdB);
+
+      expect(result).toBeDefined();
+      expect(result!.sessionId).not.toBe(sessionIdB);
+      expect(result!.sessionId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+      );
+      expect(result!.filePath).toContain(result!.sessionId);
+
+      // Verify jsonl.write was called with records having new sessionId and forkedFrom
+      expect(jsonl.write).toHaveBeenCalledTimes(1);
+      const writeCall = vi.mocked(jsonl.write).mock.calls[0];
+      const writtenRecords = writeCall[1] as ChatRecord[];
+      expect(writtenRecords).toHaveLength(2);
+      expect(writtenRecords[0].sessionId).toBe(result!.sessionId);
+      expect(writtenRecords[1].sessionId).toBe(result!.sessionId);
+
+      // forkedFrom traceability
+      expect(writtenRecords[0].forkedFrom).toEqual({
+        sessionId: sessionIdB,
+        messageUuid: 'b1',
+      });
+      expect(writtenRecords[1].forkedFrom).toEqual({
+        sessionId: sessionIdB,
+        messageUuid: 'b2',
+      });
+
+      // parentUuid chain rebuilt
+      expect(writtenRecords[0].parentUuid).toBeNull();
+      expect(writtenRecords[1].parentUuid).toBe('b1');
+
+      // Original content preserved
+      expect(writtenRecords[0].message).toEqual(recordB1.message);
+    });
+
+    it('should derive title from first user prompt with (Branch) suffix', async () => {
+      vi.mocked(jsonl.read).mockResolvedValue([recordB1, recordB2]);
+
+      const result = await sessionService.forkSession(sessionIdB);
+
+      expect(result).toBeDefined();
+      // Title should be derived from first prompt + " (Branch)"
+      expect(result!.title).toBe('hi session b (Branch)');
+
+      // Should save title via jsonl.writeLine
+      expect(jsonl.writeLine).toHaveBeenCalled();
+    });
+
+    it('should use custom title when provided', async () => {
+      vi.mocked(jsonl.read).mockResolvedValue([recordB1, recordB2]);
+
+      const result = await sessionService.forkSession(sessionIdB, {
+        customTitle: 'My Experiment',
+      });
+
+      expect(result).toBeDefined();
+      expect(result!.title).toBe('My Experiment (Branch)');
+    });
+
+    it('should return undefined when session file is empty', async () => {
+      vi.mocked(jsonl.read).mockResolvedValue([]);
+
+      const result = await sessionService.forkSession('nonexistent');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('should return undefined for session from different project', async () => {
+      const differentProjectRecord: ChatRecord = {
+        ...recordA1,
+        cwd: '/different/project',
+      };
+      vi.mocked(jsonl.read).mockResolvedValue([differentProjectRecord]);
+      vi.mocked(getProjectHash).mockImplementation((cwd: string) =>
+        cwd === '/test/project/root'
+          ? 'test-project-hash'
+          : 'other-project-hash',
+      );
+
+      const result = await sessionService.forkSession(sessionIdA);
+
+      expect(result).toBeUndefined();
+      expect(jsonl.write).not.toHaveBeenCalled();
+    });
+
+    it('should produce a session that loadSession can correctly reconstruct', async () => {
+      // Capture what forkSession writes
+      const writtenData: unknown[][] = [];
+      vi.mocked(jsonl.write).mockImplementation((_path, data) => {
+        writtenData.push(data as unknown[]);
+      });
+      vi.mocked(jsonl.read).mockResolvedValue([recordB1, recordB2]);
+
+      const result = await sessionService.forkSession(sessionIdB);
+      expect(result).toBeDefined();
+
+      // Now mock jsonl.read to return the forked records PLUS the appended title record
+      // (simulating what the file looks like after forkSession writes + saveSessionTitle appends)
+      const forkedRecords = writtenData[0] as ChatRecord[];
+      const titleRecord: ChatRecord = {
+        uuid: 'title-uuid',
+        parentUuid: null,
+        sessionId: result!.sessionId,
+        timestamp: '2024-01-02T03:00:00Z',
+        type: 'system',
+        subtype: 'session_title',
+        cwd: '/test/project/root',
+        version: '1.0.0',
+        systemPayload: {
+          customTitle: result!.title,
+          source: 'fork' as const,
+        },
+      };
+      vi.mocked(jsonl.read).mockResolvedValue([...forkedRecords, titleRecord]);
+
+      const loaded = await sessionService.loadSession(result!.sessionId);
+
+      // Must reconstruct the full conversation, NOT just the title record
+      expect(loaded).toBeDefined();
+      expect(loaded!.conversation.messages).toHaveLength(2);
+      expect(loaded!.conversation.messages[0].uuid).toBe('b1');
+      expect(loaded!.conversation.messages[1].uuid).toBe('b2');
+    });
+
+    it('should filter out session_title system records from forked data', async () => {
+      const titleRecord: ChatRecord = {
+        uuid: 'title1',
+        parentUuid: 'b2',
+        sessionId: sessionIdB,
+        timestamp: '2024-01-02T03:00:00Z',
+        type: 'system',
+        subtype: 'session_title',
+        cwd: '/test/project/root',
+        version: '1.0.0',
+        systemPayload: {
+          customTitle: 'Old Title',
+          source: 'user' as const,
+        },
+      };
+      vi.mocked(jsonl.read).mockResolvedValue([
+        recordB1,
+        recordB2,
+        titleRecord,
+      ]);
+
+      const result = await sessionService.forkSession(sessionIdB);
+
+      expect(result).toBeDefined();
+      const writeCall = vi.mocked(jsonl.write).mock.calls[0];
+      const writtenRecords = writeCall[1] as ChatRecord[];
+      // Should only have 2 records (title record filtered out)
+      expect(writtenRecords).toHaveLength(2);
+      expect(writtenRecords.every((r) => r.subtype !== 'session_title')).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('saveSessionTitle', () => {
+    it('should append a session_title system record via writeLine', async () => {
+      await sessionService.saveSessionTitle(sessionIdA, 'My Title', 'user');
+
+      expect(jsonl.writeLine).toHaveBeenCalledTimes(1);
+      const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+      expect(record.type).toBe('system');
+      expect(record.subtype).toBe('session_title');
+      expect(record.sessionId).toBe(sessionIdA);
+      expect(
+        (record.systemPayload as { customTitle: string }).customTitle,
+      ).toBe('My Title');
+      expect((record.systemPayload as { source: string }).source).toBe('user');
+    });
+  });
+
+  describe('getUniqueForkName', () => {
+    it('should return "baseName (Branch)" when no collision', async () => {
+      // listSessions returns empty — no collisions
+      readdirSyncSpy.mockReturnValue([]);
+
+      const name = await sessionService.getUniqueForkName('My Session');
+
+      expect(name).toBe('My Session (Branch)');
     });
   });
 

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -8,12 +8,14 @@ import { Storage } from '../config/storage.js';
 import { getProjectHash } from '../utils/paths.js';
 import path from 'node:path';
 import fs from 'node:fs';
+import crypto from 'node:crypto';
 import readline from 'node:readline';
 import type { Content, Part } from '@google/genai';
 import * as jsonl from '../utils/jsonl-utils.js';
 import type {
   ChatCompressionRecordPayload,
   ChatRecord,
+  SessionTitleRecordPayload,
   UiTelemetryRecordPayload,
 } from './chatRecordingService.js';
 import { uiTelemetryService } from '../telemetry/uiTelemetry.js';
@@ -36,12 +38,22 @@ export interface SessionListItem {
   mtime: number;
   /** First user prompt text (truncated for display) */
   prompt: string;
+  /** Custom title set by user or derived during fork (highest display priority) */
+  customTitle?: string;
   /** Git branch at session start, if available */
   gitBranch?: string;
   /** Full path to the session file */
   filePath: string;
   /** Number of messages in the session (unique message UUIDs) */
   messageCount: number;
+}
+
+/**
+ * Options for forking a session.
+ */
+export interface ForkSessionOptions {
+  /** Custom title for the forked session. If not provided, derived from first prompt. */
+  customTitle?: string;
 }
 
 /**
@@ -128,10 +140,12 @@ const MAX_PROMPT_SCAN_LINES = 10;
 export class SessionService {
   private readonly storage: Storage;
   private readonly projectHash: string;
+  private readonly cwd: string;
 
   constructor(cwd: string) {
     this.storage = new Storage(cwd);
     this.projectHash = getProjectHash(cwd);
+    this.cwd = cwd;
   }
 
   private getChatsDir(): string {
@@ -166,6 +180,44 @@ export class SessionService {
       if (prompt) return prompt;
     }
     return '';
+  }
+
+  /**
+   * Extracts the custom title from a session file by scanning for session_title
+   * system records. Returns the last title found (most recent takes priority).
+   */
+  private async extractCustomTitle(
+    filePath: string,
+  ): Promise<string | undefined> {
+    let customTitle: string | undefined;
+    try {
+      const fileStream = fs.createReadStream(filePath);
+      const rl = readline.createInterface({
+        input: fileStream,
+        crlfDelay: Infinity,
+      });
+
+      for await (const line of rl) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        try {
+          const record = JSON.parse(trimmed) as ChatRecord;
+          if (record.type === 'system' && record.subtype === 'session_title') {
+            const payload = record.systemPayload as
+              | SessionTitleRecordPayload
+              | undefined;
+            if (payload?.customTitle) {
+              customTitle = payload.customTitle;
+            }
+          }
+        } catch {
+          continue;
+        }
+      }
+    } catch {
+      // Ignore read errors
+    }
+    return customTitle;
   }
 
   /**
@@ -288,8 +340,11 @@ export class SessionService {
       const recordProjectHash = getProjectHash(firstRecord.cwd);
       if (recordProjectHash !== this.projectHash) continue;
 
-      // Count messages for this session
-      const messageCount = await this.countSessionMessages(filePath);
+      // Count messages and extract custom title in parallel
+      const [messageCount, customTitle] = await Promise.all([
+        this.countSessionMessages(filePath),
+        this.extractCustomTitle(filePath),
+      ]);
 
       const prompt = this.extractFirstPromptFromRecords(records);
 
@@ -299,6 +354,7 @@ export class SessionService {
         startTime: firstRecord.timestamp,
         mtime: file.mtime,
         prompt,
+        customTitle,
         gitBranch: firstRecord.gitBranch,
         filePath,
         messageCount,
@@ -452,8 +508,15 @@ export class SessionService {
       return;
     }
 
+    // Filter out metadata-only records (e.g., session_title) that are not part
+    // of the conversation tree. These records have parentUuid: null and would
+    // break reconstructHistory which walks backwards from the last record.
+    const conversationRecords = records.filter(
+      (r) => r.subtype !== 'session_title',
+    );
+
     // Reconstruct linear history
-    const messages = this.reconstructHistory(records);
+    const messages = this.reconstructHistory(conversationRecords);
     if (messages.length === 0) {
       return;
     }
@@ -542,6 +605,199 @@ export class SessionService {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * Saves a custom title for a session by appending a session_title system record.
+   *
+   * @param sessionId The session ID to set the title for
+   * @param title The custom title to save
+   * @param source The source of the title ('user' for manual rename, 'fork' for auto-derived)
+   */
+  async saveSessionTitle(
+    sessionId: string,
+    title: string,
+    source: 'user' | 'fork' = 'user',
+  ): Promise<void> {
+    const chatsDir = this.getChatsDir();
+    const filePath = path.join(chatsDir, `${sessionId}.jsonl`);
+
+    const titleRecord: ChatRecord = {
+      uuid: crypto.randomUUID(),
+      parentUuid: null,
+      sessionId,
+      timestamp: new Date().toISOString(),
+      type: 'system',
+      subtype: 'session_title',
+      cwd: this.cwd,
+      version: process.env['CLI_VERSION'] || '0.0.0',
+      systemPayload: {
+        customTitle: title,
+        source,
+      } as SessionTitleRecordPayload,
+    };
+
+    await jsonl.writeLine(filePath, titleRecord);
+  }
+
+  /**
+   * Generates a unique fork name by checking for collisions with existing session titles.
+   * If "baseName (Branch)" already exists, tries "baseName (Branch 2)", etc.
+   *
+   * @param baseName The base name to derive the fork name from
+   * @returns A unique fork name like "baseName (Branch)" or "baseName (Branch 2)"
+   */
+  async getUniqueForkName(baseName: string): Promise<string> {
+    const candidateName = `${baseName} (Branch)`;
+
+    // Single listSessions call, reused for both exact and prefix matching
+    const allSessions = await this.listSessions({ size: 200 });
+    const sessionsWithTitles = allSessions.items.filter(
+      (item) => !!item.customTitle,
+    );
+
+    const existingWithExactName = sessionsWithTitles.filter(
+      (item) => item.customTitle === candidateName,
+    );
+    if (existingWithExactName.length === 0) {
+      return candidateName;
+    }
+
+    // Name collision — find a unique numbered suffix
+    const existingForks = sessionsWithTitles.filter((item) =>
+      item.customTitle!.startsWith(`${baseName} (Branch`),
+    );
+
+    const usedNumbers = new Set<number>([1]); // " (Branch)" = 1
+    const escapedBase = baseName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const forkNumberPattern = new RegExp(
+      `^${escapedBase} \\(Branch(?: (\\d+))?\\)$`,
+    );
+
+    for (const session of existingForks) {
+      const match = session.customTitle?.match(forkNumberPattern);
+      if (match) {
+        if (match[1]) {
+          usedNumbers.add(parseInt(match[1], 10));
+        } else {
+          usedNumbers.add(1);
+        }
+      }
+    }
+
+    let nextNumber = 2;
+    while (usedNumbers.has(nextNumber)) {
+      nextNumber++;
+    }
+
+    return `${baseName} (Branch ${nextNumber})`;
+  }
+
+  /**
+   * Derives a single-line title from the first user message in a list of records.
+   * Collapses whitespace so multiline first messages don't break display.
+   */
+  private deriveFirstPromptTitle(records: ChatRecord[]): string {
+    for (const record of records) {
+      if (record.type !== 'user') continue;
+      // Extract raw text directly instead of using extractPromptText
+      // (which truncates at 200 chars with "..." — double truncation)
+      const parts = record.message?.parts;
+      if (!parts) continue;
+      for (const part of parts as Part[]) {
+        if ('text' in part) {
+          const raw = (part as { text: string }).text;
+          const collapsed = raw.replace(/\s+/g, ' ').trim();
+          if (collapsed) {
+            return collapsed.slice(0, 100);
+          }
+        }
+      }
+    }
+    return 'Branched conversation';
+  }
+
+  /**
+   * Forks an existing session to create a new independent session.
+   *
+   * Copies all records from the original session into a new JSONL file with a
+   * new sessionId while preserving conversation history and metadata. Adds
+   * forkedFrom traceability to each record, rebuilds the parentUuid chain,
+   * derives a title, and handles naming collisions with "(Branch N)" suffixes.
+   *
+   * @param originalSessionId The session ID to fork
+   * @param options Optional fork configuration (custom title, etc.)
+   * @returns Fork result with new session ID, title, and file path, or undefined if not found
+   */
+  async forkSession(
+    originalSessionId: string,
+    options?: ForkSessionOptions,
+  ): Promise<
+    { sessionId: string; filePath: string; title: string } | undefined
+  > {
+    const chatsDir = this.getChatsDir();
+    const originalFilePath = path.join(chatsDir, `${originalSessionId}.jsonl`);
+
+    // Read all records from the original session
+    const records = await this.readAllRecords(originalFilePath);
+    if (records.length === 0) {
+      return undefined;
+    }
+
+    // Verify the session belongs to the current project
+    const recordProjectHash = getProjectHash(records[0].cwd);
+    if (recordProjectHash !== this.projectHash) {
+      return undefined;
+    }
+
+    // Generate a new session ID for the fork
+    const newSessionId = crypto.randomUUID();
+    const newFilePath = path.join(chatsDir, `${newSessionId}.jsonl`);
+
+    // Filter to only conversation messages (exclude system metadata like titles)
+    const conversationRecords = records.filter(
+      (record) =>
+        record.type === 'user' ||
+        record.type === 'assistant' ||
+        record.type === 'tool_result' ||
+        (record.type === 'system' && record.subtype !== 'session_title'),
+    );
+
+    if (conversationRecords.length === 0) {
+      return undefined;
+    }
+
+    // Build forked entries with new sessionId, rebuilt parentUuid chain, and forkedFrom traceability
+    let parentUuid: string | null = null;
+    const forkedRecords: ChatRecord[] = [];
+
+    for (const record of conversationRecords) {
+      const forkedRecord: ChatRecord = {
+        ...record,
+        sessionId: newSessionId,
+        parentUuid,
+        forkedFrom: {
+          sessionId: originalSessionId,
+          messageUuid: record.uuid,
+        },
+      };
+      forkedRecords.push(forkedRecord);
+      parentUuid = record.uuid;
+    }
+
+    jsonl.write(newFilePath, forkedRecords);
+
+    // Derive and save the title with collision-aware naming
+    const baseName =
+      options?.customTitle || this.deriveFirstPromptTitle(records);
+    const effectiveTitle = await this.getUniqueForkName(baseName);
+    await this.saveSessionTitle(newSessionId, effectiveTitle, 'fork');
+
+    return {
+      sessionId: newSessionId,
+      filePath: newFilePath,
+      title: effectiveTitle,
+    };
   }
 }
 


### PR DESCRIPTION
## TLDR

This PR adds a `/branch` command that lets users fork the current conversation at any point. The forked session is a fully independent copy — continuing the conversation in either branch doesn't affect the other. Title naming is collision-aware (`"My Task (Branch)"`, `"My Task (Branch 2)"`, etc.), and `/resume {sessionId}` now supports jumping directly to a specific session without opening the picker.

**Key changes:**

| Layer | What changed |
|-------|-------------|
| **Core types** | `ChatRecord` gains `forkedFrom` field and `session_title` subtype |
| **SessionService** | New methods: `forkSession()`, `saveSessionTitle()`, `getUniqueForkName()` |
| **SessionService** | Bug fix: `loadSession()` now filters `session_title` metadata records before `reconstructHistory()` |
| **CLI commands** | New `/branch` (alias `/fork`), enhanced `/resume {id}` |
| **Shared logic** | `resumeSessionHelper.ts` deduplicates resume flow between `/branch` and `/resume` |

## Screenshots / Video Demo


https://github.com/user-attachments/assets/6447aa2a-bfb0-4fee-8ea7-6fb753739b63



## Dive Deeper

### Fork data flow

```
/branch [title]
  |
  v
SessionService.forkSession(originalSessionId, { customTitle })
  |-- Read all ChatRecords from original JSONL
  |-- Filter out session_title metadata records
  |-- Copy records with:
  |     - New sessionId (crypto.randomUUID)
  |     - Rebuilt parentUuid chain (null -> r1 -> r2 -> ...)
  |     - forkedFrom traceability { sessionId, messageUuid }
  |-- Write to new JSONL file
  |-- Derive title: customTitle || firstUserPrompt
  |-- getUniqueForkName("title") -> "title (Branch)" / "title (Branch 2)"
  |-- saveSessionTitle() appends session_title system record
  |
  v
resumeIntoSession(context, config, forkedSessionId, sessionData)
  |-- Reset UI session stats
  |-- buildResumedHistoryItems() -> UI history
  |-- Clear + load UI
  |-- config.startNewSession() -> core config
  |-- geminiClient.initialize() -> loads API history from session
  |-- Fire SessionStart hook
```

### Key design decisions

1. **Title as JSONL metadata, not filename** — Titles are stored as append-only `session_title` system records inside the JSONL file, following the same pattern as `chat_compression` checkpoints. This avoids file rename issues and supports title updates.

2. **`loadSession` filters `session_title` before `reconstructHistory`** — Title records have `parentUuid: null` (they're metadata, not conversation). Without filtering, `reconstructHistory` would start from the title record and lose the entire conversation chain.

3. **Shared `resumeIntoSession` helper** — The resume flow (UI reset -> history rebuild -> config switch -> Gemini init -> hook fire) is identical between `/branch` and `/resume {id}`, so it's extracted to avoid divergence.

4. **Operation ordering matches `useResumeCommand`** — `buildResumedHistoryItems` runs *before* `config.startNewSession()` to avoid reading mutated config state.

## Reviewer Test Plan

### Basic fork flow
1. Start a conversation with a few turns
2. Run `/branch` — should see success message with branch title and original session ID
3. Continue chatting — conversation should have full history from before the branch
4. Run `/resume {originalSessionId}` from the success message — should jump back to original
5. Verify original session is at the state before branching (no messages from the branch)

### Custom title
1. Run `/branch my-experiment` — title should be `"my-experiment (Branch)"`
2. Run `/branch my-experiment` again — title should be `"my-experiment (Branch 2)"`

### Edge cases
1. Run `/branch` with no conversation history — should show error "No conversation to branch"
2. Run `/resume nonexistent-uuid` — should show error "Session not found"
3. Run `/resume` with no args — should open the session picker dialog (unchanged behavior)

### Unit tests
```bash
npx vitest run packages/core/src/services/sessionService.test.ts
# Expected: 34 tests pass
```

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | ✅    | ❓      | ❓    |
| npx      | ❓    | ❓      | ❓    |
| Docker   | ❓    | ❓      | ❓    |
| Podman   | ❓    | -       | -     |
| Seatbelt | ❓    | -       | -     |

## Linked issues / bugs

Resolves #2994
