### PR TITLE
fix(cli): sync packages/cli version and sandboxImageUri to 0.14.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "workspaces": [
         "packages/*",
         "packages/channels/base",
@@ -16873,7 +16873,7 @@
     },
     "packages/channels/base": {
       "name": "@qwen-code/channel-base",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1"
       },
@@ -16883,7 +16883,7 @@
     },
     "packages/channels/dingtalk": {
       "name": "@qwen-code/channel-dingtalk",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base",
         "dingtalk-stream-sdk-nodejs": "^2.0.4"
@@ -16894,7 +16894,7 @@
     },
     "packages/channels/plugin-example": {
       "name": "@qwen-code/channel-plugin-example",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base",
         "ws": "^8.18.0"
@@ -16908,7 +16908,7 @@
     },
     "packages/channels/telegram": {
       "name": "@qwen-code/channel-telegram",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base",
         "grammy": "^1.41.1",
@@ -16920,7 +16920,7 @@
     },
     "packages/channels/weixin": {
       "name": "@qwen-code/channel-weixin",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base"
       },
@@ -16930,7 +16930,7 @@
     },
     "packages/cli": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
         "@google/genai": "1.30.0",
@@ -17591,7 +17591,7 @@
     },
     "packages/core": {
       "name": "@qwen-code/qwen-code-core",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.36.1",
@@ -21024,7 +21024,7 @@
     },
     "packages/test-utils": {
       "name": "@qwen-code/qwen-code-test-utils",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
@@ -21036,7 +21036,7 @@
     },
     "packages/vscode-ide-companion": {
       "name": "qwen-code-vscode-ide-companion",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "LICENSE",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
@@ -21283,7 +21283,7 @@
     },
     "packages/web-templates": {
       "name": "@qwen-code/web-templates",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "devDependencies": {
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
@@ -21811,7 +21811,7 @@
     },
     "packages/webui": {
       "name": "@qwen-code/webui",
-      "version": "0.14.1",
+      "version": "0.14.2",
       "license": "MIT",
       "dependencies": {
         "markdown-it": "^14.1.0"
@@ -21840,7 +21840,6 @@
         "vite-plugin-dts": "^4.5.4"
       },
       "peerDependencies": {
-        "@qwen-code/qwen-code-core": ">=0.13.0",
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }

--- a/packages/channels/base/package.json
+++ b/packages/channels/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-base",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Base channel infrastructure for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/dingtalk/package.json
+++ b/packages/channels/dingtalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-dingtalk",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "DingTalk channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/plugin-example/package.json
+++ b/packages/channels/plugin-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-plugin-example",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/telegram/package.json
+++ b/packages/channels/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-telegram",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Telegram channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/weixin/package.json
+++ b/packages/channels/weixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-weixin",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "WeChat (Weixin) channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Qwen Code",
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
     "dist"
   ],
   "config": {
-    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.14.1"
+    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.14.2"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.14.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code-core",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Qwen Code Core",
   "repository": {
     "type": "git",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code-test-utils",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "private": true,
   "main": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/web-templates/package.json
+++ b/packages/web-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/web-templates",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Web templates bundled as embeddable JS/CSS strings",
   "repository": {
     "type": "git",

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/webui",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "Shared UI components for Qwen Code packages",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## 问题分析

Release workflow ([job 70424966323](https://github.com/QwenLM/qwen-code/actions/runs/24135197272/job/70424966323)) 在 `npm run test:integration:cli:sandbox:docker` 步骤失败，错误信息：

```
Checking for sandbox image: ghcr.io/qwenlm/qwen-code:0.14.2
Sandbox image ghcr.io/qwenlm/qwen-code:0.14.2 not found locally.
Attempting to pull image ghcr.io/qwenlm/qwen-code:0.14.2 using docker...
Error response from daemon: manifest unknown
Fatal error: Failed to relaunch the CLI process.
```

## 根本原因

版本 bump 时出现了不一致：

| 文件 | version | sandboxImageUri |
|------|---------|----------------|
| `package.json` (root) | `0.14.2` | `ghcr.io/qwenlm/qwen-code:0.14.2` |
| `packages/cli/package.json` | **`0.14.1`** ❌ | **`ghcr.io/qwenlm/qwen-code:0.14.1`** ❌ |

**调用链：**
1. `test:integration:cli:sandbox:docker` = `npm run build:sandbox && QWEN_SANDBOX=docker vitest run`
2. `build_sandbox.js` 读取 **`packages/cli/package.json`** 的 `sandboxImageUri`，构建镜像 `ghcr.io/qwenlm/qwen-code:0.14.1`
3. 运行测试时，`sandboxConfig.ts` 读取**根 `package.json`** 的 `config.sandboxImageUri`，期望找到 `ghcr.io/qwenlm/qwen-code:0.14.2`
4. 找不到 `0.14.2` 镜像 → 尝试 pull → `manifest unknown` → 测试失败

## 修复

将 `packages/cli/package.json` 的 `version` 和 `sandboxImageUri` 同步为 `0.14.2`，与根 `package.json` 一致。

`scripts/version.js` 脚本（step 6）本应同步这两个值，但此次版本 bump 跳过了该步骤导致不同步。