### PR TITLE
[codex] fix checkpointing init in non-repo directories

### DIFF
--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -170,6 +170,15 @@ describe('GitService', () => {
       expect(hoistedMockInit).toHaveBeenCalled();
     });
 
+    it('should initialize git repo when root repo check throws', async () => {
+      hoistedMockCheckIsRepo.mockRejectedValueOnce(
+        new Error('fatal: not a git repository'),
+      );
+      const service = new GitService(projectRoot, storage);
+      await expect(service.setupShadowGitRepository()).resolves.toBeUndefined();
+      expect(hoistedMockInit).toHaveBeenCalled();
+    });
+
     it('should not initialize git repo if already initialized', async () => {
       hoistedMockCheckIsRepo.mockResolvedValue(true);
       const service = new GitService(projectRoot, storage);

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -58,7 +58,14 @@ export class GitService {
     await fs.writeFile(gitConfigPath, gitConfigContent);
 
     const repo = simpleGit(repoDir);
-    const isRepoDefined = await repo.checkIsRepo(CheckRepoActions.IS_REPO_ROOT);
+    let isRepoDefined = false;
+    try {
+      isRepoDefined = await repo.checkIsRepo(CheckRepoActions.IS_REPO_ROOT);
+    } catch {
+      // Some Git/simple-git combinations throw for non-repo directories
+      // instead of returning false. Treat that as "not initialized yet".
+      isRepoDefined = false;
+    }
 
     if (!isRepoDefined) {
       await repo.init(false, {


### PR DESCRIPTION
## Summary
- handle `checkIsRepo(CheckRepoActions.IS_REPO_ROOT)` failures during shadow checkpoint repository setup
- treat thrown non-repository checks as an uninitialized shadow repo and continue with `git init`
- add a regression test covering the throw path

## Root Cause
`simple-git` can throw from `checkIsRepo(CheckRepoActions.IS_REPO_ROOT)` in some environments instead of returning `false` for non-repository directories. That exception bubbled out of checkpointing initialization and caused startup to fail when checkpointing was enabled outside a Git repository.

## User Impact
Users can now start Qwen Code with checkpointing enabled from non-Git directories without crashing during startup in those environments.

## Validation
- `npm run test --workspace @qwen-code/qwen-code-core -- src/services/gitService.test.ts`

Fixes #1104