### PR TITLE
fix(cli): add 'detail' subcommand to /context command

### DIFF
--- a/docs/users/features/commands.md
+++ b/docs/users/features/commands.md
@@ -34,6 +34,7 @@ Commands for adjusting interface appearance and work environment.
 | ------------ | ---------------------------------------- | ----------------------------- |
 | `/clear`     | Clear terminal screen content            | `/clear` (shortcut: `Ctrl+L`) |
 | `/context`   | Show context window usage breakdown      | `/context`                    |
+| → `detail`   | Show per-item context usage breakdown    | `/context detail`             |
 | `/theme`     | Change Qwen Code visual theme            | `/theme`                      |
 | `/vim`       | Turn input area Vim editing mode on/off  | `/vim`                        |
 | `/directory` | Manage multi-directory support workspace | `/dir add ./src,./tests`      |

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1713,6 +1713,8 @@ export default {
   'Show context window usage breakdown.': '显示上下文窗口使用情况分解。',
   'Run /context detail for per-item breakdown.':
     '运行 /context detail 查看详细分解。',
+  'Show context window usage breakdown. Use "/context detail" for per-item breakdown.':
+    '显示上下文窗口使用情况分解。输入 "/context detail" 查看详细分解。',
   'body loaded': '内容已加载',
   memory: '记忆',
   '{{region}} configuration updated successfully.': '{{region}} 配置更新成功。',

--- a/packages/cli/src/ui/commands/contextCommand.ts
+++ b/packages/cli/src/ui/commands/contextCommand.ts
@@ -373,4 +373,17 @@ export const contextCommand: SlashCommand = {
 
     context.ui.addItem(contextUsageItem, Date.now());
   },
+  subCommands: [
+    {
+      name: 'detail',
+      get description() {
+        return t('Show per-item context usage breakdown.');
+      },
+      kind: CommandKind.BUILT_IN,
+      action: async (context: CommandContext) => {
+        // Delegate to main action with 'detail' arg to show detailed view
+        await contextCommand.action!(context, 'detail');
+      },
+    },
+  ],
 };


### PR DESCRIPTION
## Summary

Fixes #3040

The `/context` command was missing the `detail` subcommand in the autocomplete dropdown. When users type `/context ` (with a trailing space), no suggestions appeared — unlike `/stats ` which correctly shows `model` and `tools`.

## Changes

| File | Description |
|------|-------------|
| `packages/cli/src/ui/commands/contextCommand.ts` | Added `subCommands` array with `detail` entry (+13 lines) |
| `packages/cli/src/i18n/locales/zh.js` | Added missing translation key for full description (+2 lines) |
| `docs/users/features/commands.md` | Updated documentation to show `/context detail` usage (+1 line) |

## How it works

The `detail` subcommand delegates to the main action with `"detail"` as the argument, reusing existing logic — no code duplication.

```typescript
subCommands: [
  {
    name: "detail",
    get description() {
      return t("Show per-item context usage breakdown.");
    },
    kind: CommandKind.BUILT_IN,
    action: async (context: CommandContext) => {
      await contextCommand.action!(context, "detail");
    },
  },
],
```

## Before / After

**Before:** Typing `/context ` shows no suggestions.

**After:** Typing `/context ` shows `detail` with description "Show per-item context usage breakdown."

## Checklist

- [x] Code follows project conventions (Conventional Commits, ESM, strict TypeScript)
- [x] Unit tests pass (`useSlashCompletion.test.ts` covers subcommand completion)
- [x] Documentation updated (`docs/users/features/commands.md`)
- [x] Small, atomic change — 3 files, +16 lines