### PR TITLE
fix(weixin): add missing iLink headers to QR code login flow

### DIFF
--- a/packages/channels/weixin/src/api.ts
+++ b/packages/channels/weixin/src/api.ts
@@ -35,7 +35,7 @@ function randomUin(): string {
   return btoa(String.fromCharCode(...buf));
 }
 
-function buildHeaders(token?: string): Record<string, string> {
+export function buildHeaders(token?: string): Record<string, string> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
     'X-WECHAT-UIN': randomUin(),

--- a/packages/channels/weixin/src/login.ts
+++ b/packages/channels/weixin/src/login.ts
@@ -2,6 +2,8 @@
  * QR code login flow for WeChat iLink Bot.
  */
 
+import { buildHeaders } from './api.js';
+
 export interface LoginResult {
   connected: boolean;
   token?: string;
@@ -54,7 +56,7 @@ export async function waitForLogin(params: {
       const resp = await fetch(
         `${apiBaseUrl}/ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(currentQrcodeId)}`,
         {
-          headers: { 'iLink-App-ClientVersion': '1' },
+          headers: buildHeaders(),
           signal: controller.signal,
         },
       );

--- a/packages/cli/src/commands/channel/start.ts
+++ b/packages/cli/src/commands/channel/start.ts
@@ -183,7 +183,16 @@ async function startSingle(name: string): Promise<void> {
   const channel = createChannel(name, config, bridge, { router });
   channels.set(name, channel);
   registerToolCallDispatch(bridge, router, channels);
-  await channel.connect();
+
+  try {
+    await channel.connect();
+  } catch (err) {
+    writeStderrLine(
+      `Error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    bridge.stop();
+    process.exit(1);
+  }
 
   writeServiceInfo([name]);
   writeStdoutLine(`[Channel] "${name}" is running. Press Ctrl+C to stop.`);


### PR DESCRIPTION
## TLDR

PR #2943 fixed the missing `iLink-App-Id` and `iLink-App-ClientVersion` headers in `buildHeaders()` (api.ts), but the QR code login flow in `waitForLogin()` (login.ts) still had a hardcoded incomplete header object. This PR reuses the shared `buildHeaders()` so all endpoints send consistent headers.

Also fixes noisy error output when running `qwen channel start` with unconfigured WeChat — previously it dumped the full yargs help text and a stack trace.

## Screenshots / Video Demo

**Before (error output):**
```
[Extensions] Loaded channel "plugin-example" from "qwen-channel-plugin-example"
qwen channel start [name]

Start channels (all if no name given, or a single named channel)

Positionals:
  name  Channel name (omit to start all configured channels)  [string]
Options:
  ... (full yargs help dumped) ...

Error: WeChat account not configured. Run "qwen channel configure-weixin" first.
    at WeixinChannel.connect (file:///...)
    at startSingle (file:///...)
```

**After:**
```
[Extensions] Loaded channel "plugin-example" from "qwen-channel-plugin-example"
Error: WeChat account not configured. Run "qwen channel configure-weixin" first.
```

## Dive Deeper

Two changes:

1. **`login.ts`** — replaced hardcoded `{ 'iLink-App-ClientVersion': '1' }` with `buildHeaders()` from api.ts, which includes both `iLink-App-Id: 'bot'` and the properly encoded `iLink-App-ClientVersion`. Exported `buildHeaders()` from api.ts to make this possible.

2. **`start.ts`** — wrapped `channel.connect()` in `startSingle()` with a try/catch (matching how `startAll()` already handles it) so configuration errors produce a clean one-line message instead of yargs help + stack trace.

## Reviewer Test Plan

1. Remove WeChat credentials: `rm ~/.qwen/channels/weixin/account.json`
2. Run `qwen channel start my-weixin` — verify clean error message, no help text or stack trace
3. Run `qwen channel configure-weixin` — scan QR code with WeChat, confirm login
4. Verify `account.json` is created and "Connected to WeChat successfully!" is printed
5. Run `qwen channel start my-weixin` — verify channel connects and runs normally

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3036