### PR TITLE
fix: prevent Shift+Tab from accepting prompt placeholder suggestion

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -225,6 +225,19 @@ describe('InputPrompt', () => {
       unmount();
     });
 
+    it('does not accept the prompt suggestion on shift+tab', async () => {
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} promptSuggestion="commit this" />,
+      );
+      await wait(350);
+
+      stdin.write('\x1b[Z'); // shift+tab
+      await wait();
+
+      expect(mockBuffer.insert).not.toHaveBeenCalled();
+      unmount();
+    });
+
     it('accepts and submits the prompt suggestion on Enter when the buffer is empty', async () => {
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} promptSuggestion="commit this" />,

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -719,6 +719,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       // because ACCEPT_SUGGESTION also matches Enter which must fall through to SUBMIT.
       if (
         key.name === 'tab' &&
+        !key.shift &&
         buffer.text.length === 0 &&
         !completion.showSuggestions &&
         !reverseSearchActive &&


### PR DESCRIPTION
## Summary

- Fixes #3051: Shift+Tab was simultaneously toggling approval mode **and** inserting the prompt placeholder into the input, because the Tab handler did not check for the Shift modifier.
- Added `!key.shift` guard to the Tab key handler in `InputPrompt.tsx` so that Shift+Tab passes through exclusively to the approval mode toggle.
- Added a test verifying Shift+Tab does not accept the prompt suggestion.

## Test plan

- [x] Existing test `accepts the visible prompt suggestion on tab when the buffer is empty` still passes
- [x] New test `does not accept the prompt suggestion on shift+tab` passes
- [x] Manual: verify Shift+Tab only toggles approval mode without filling the placeholder
