### PR TITLE
fix: persist ProceedAlways permission outcome in compact mode

### DIFF
--- a/packages/core/src/core/permission-helpers.ts
+++ b/packages/core/src/core/permission-helpers.ts
@@ -174,6 +174,7 @@ export async function persistPermissionOutcome(
   payload?: ToolConfirmationPayload,
 ): Promise<void> {
   if (
+    outcome !== ToolConfirmationOutcome.ProceedAlways &&
     outcome !== ToolConfirmationOutcome.ProceedAlwaysProject &&
     outcome !== ToolConfirmationOutcome.ProceedAlwaysUser
   ) {
@@ -181,9 +182,9 @@ export async function persistPermissionOutcome(
   }
 
   const scope =
-    outcome === ToolConfirmationOutcome.ProceedAlwaysProject
-      ? 'project'
-      : 'user';
+    outcome === ToolConfirmationOutcome.ProceedAlwaysUser
+      ? 'user'
+      : 'project';
 
   // Read permissionRules from the stored confirmation details first,
   // falling back to payload for backward compatibility.


### PR DESCRIPTION
## TLDR

Fixes a bug where selecting "Allow always" in compact mode did not persist the permission.

**Key change**: `persistPermissionOutcome()` now correctly handles `ProceedAlways` outcome (compact mode's "Allow always" option), treating it as project scope for persistence.

## Screenshots / Video Demo

N/A — no user-facing visual change. Behavior change can be verified through testing.

## Dive Deeper

**Background**

Sub-agent permission confirmation dialogs use compact mode UI with only three options:
- "Yes, allow once" → `ProceedOnce`
- "Allow always" → `ProceedAlways`  
- "No" → `Cancel`

However, `persistPermissionOutcome()` only handled `ProceedAlwaysProject` and `ProceedAlwaysUser`, completely ignoring `ProceedAlways`. This caused users selecting "Allow always" to have permissions neither written to `settings.json` nor updated in the in-memory `PermissionManager`, requiring confirmation again on subsequent tool calls.

**Implementation**

Modified `packages/core/src/core/permission-helpers.ts`:

1. Added `ProceedAlways` to the persistence condition check (no longer dropped by early return)
2. Treat `ProceedAlways` as project scope (same behavior as `ProceedAlwaysProject`)

```typescript
// Before
if (
  outcome !== ToolConfirmationOutcome.ProceedAlwaysProject &&
  outcome !== ToolConfirmationOutcome.ProceedAlwaysUser
) { return; }

const scope = outcome === ToolConfirmationOutcome.ProceedAlwaysProject ? 'project' : 'user';

// After
if (
  outcome !== ToolConfirmationOutcome.ProceedAlways &&
  outcome !== ToolConfirmationOutcome.ProceedAlwaysProject &&
  outcome !== ToolConfirmationOutcome.ProceedAlwaysUser
) { return; }

const scope = outcome === ToolConfirmationOutcome.ProceedAlwaysUser ? 'user' : 'project';
```

**Backward compatibility**: No impact. `ProceedAlways` was previously ignored; now it's handled as project scope, matching user expectations.

## Reviewer Test Plan

1. Create a scenario where a sub-agent needs to execute a shell command
2. Observe compact mode confirmation dialog appearing
3. Select "Allow always"
4. Execute the same command again, confirm no confirmation dialog appears
5. Check `.qwen/settings.json` to verify the corresponding permission rule was written

## Testing Matrix

Local TypeScript compilation passed. Full test matrix not run.

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |

## Linked issues / bugs

Resolves #3067