### PR TITLE
fix: improve /model --fast description clarity

### DIFF
--- a/docs/users/configuration/settings.md
+++ b/docs/users/configuration/settings.md
@@ -203,9 +203,9 @@ The `extra_body` field allows you to add custom parameters to the request body s
 
 #### fastModel
 
-| Setting     | Type   | Description                                                                                                                                                                                                                                           | Default |
-| ----------- | ------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
-| `fastModel` | string | Model for background tasks ([suggestion generation](../features/followup-suggestions), speculation). Leave empty to use the main model. A smaller/faster model (e.g., `qwen3.5-flash`) reduces latency and cost. Can also be set via `/model --fast`. | `""`    |
+| Setting     | Type   | Description                                                                                                                                                                                                                                                      | Default |
+| ----------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `fastModel` | string | Model used for generating [prompt suggestions](../features/followup-suggestions) and speculative execution. Leave empty to use the main model. A smaller/faster model (e.g., `qwen3-coder-flash`) reduces latency and cost. Can also be set via `/model --fast`. | `""`    |
 
 #### context
 

--- a/docs/users/features/commands.md
+++ b/docs/users/features/commands.md
@@ -56,21 +56,21 @@ Commands specifically for controlling interface and output language.
 
 Commands for managing AI tools and models.
 
-| Command          | Description                                       | Usage Examples                                |
-| ---------------- | ------------------------------------------------- | --------------------------------------------- |
-| `/mcp`           | List configured MCP servers and tools             | `/mcp`, `/mcp desc`                           |
-| `/tools`         | Display currently available tool list             | `/tools`, `/tools desc`                       |
-| `/skills`        | List and run available skills                     | `/skills`, `/skills <name>`                   |
-| `/plan`          | Switch to plan mode or exit plan mode             | `/plan`, `/plan <task>`, `/plan exit`         |
-| `/approval-mode` | Change approval mode for tool usage               | `/approval-mode <mode (auto-edit)> --project` |
-| →`plan`          | Analysis only, no execution                       | Secure review                                 |
-| →`default`       | Require approval for edits                        | Daily use                                     |
-| →`auto-edit`     | Automatically approve edits                       | Trusted environment                           |
-| →`yolo`          | Automatically approve all                         | Quick prototyping                             |
-| `/model`         | Switch model used in current session              | `/model`                                      |
-| `/model --fast`  | Set or select the fast model for background tasks | `/model --fast qwen3.5-flash`                 |
-| `/extensions`    | List all active extensions in current session     | `/extensions`                                 |
-| `/memory`        | Manage AI's instruction context                   | `/memory add Important Info`                  |
+| Command          | Description                                   | Usage Examples                                |
+| ---------------- | --------------------------------------------- | --------------------------------------------- |
+| `/mcp`           | List configured MCP servers and tools         | `/mcp`, `/mcp desc`                           |
+| `/tools`         | Display currently available tool list         | `/tools`, `/tools desc`                       |
+| `/skills`        | List and run available skills                 | `/skills`, `/skills <name>`                   |
+| `/plan`          | Switch to plan mode or exit plan mode         | `/plan`, `/plan <task>`, `/plan exit`         |
+| `/approval-mode` | Change approval mode for tool usage           | `/approval-mode <mode (auto-edit)> --project` |
+| →`plan`          | Analysis only, no execution                   | Secure review                                 |
+| →`default`       | Require approval for edits                    | Daily use                                     |
+| →`auto-edit`     | Automatically approve edits                   | Trusted environment                           |
+| →`yolo`          | Automatically approve all                     | Quick prototyping                             |
+| `/model`         | Switch model used in current session          | `/model`                                      |
+| `/model --fast`  | Set a lighter model for prompt suggestions    | `/model --fast qwen3-coder-flash`             |
+| `/extensions`    | List all active extensions in current session | `/extensions`                                 |
+| `/memory`        | Manage AI's instruction context               | `/memory add Important Info`                  |
 
 ### 1.5 Built-in Skills
 

--- a/docs/users/features/followup-suggestions.md
+++ b/docs/users/features/followup-suggestions.md
@@ -49,7 +49,7 @@ By default, suggestions use the same model as your main conversation. For faster
 ### Via command
 
 ```
-/model --fast qwen3.5-flash
+/model --fast qwen3-coder-flash
 ```
 
 Or use `/model --fast` (without a model name) to open a selection dialog.
@@ -58,11 +58,11 @@ Or use `/model --fast` (without a model name) to open a selection dialog.
 
 ```json
 {
-  "fastModel": "qwen3.5-flash"
+  "fastModel": "qwen3-coder-flash"
 }
 ```
 
-The fast model is used for background tasks like suggestion generation. When not configured, the main conversation model is used as fallback.
+The fast model is used for prompt suggestions and speculative execution. When not configured, the main conversation model is used as fallback.
 
 Thinking/reasoning mode is automatically disabled for all background tasks (suggestion generation and speculation), regardless of your main model's thinking configuration. This avoids wasting tokens on internal reasoning that isn't needed for these tasks.
 
@@ -75,13 +75,13 @@ These settings can be configured in `settings.json`:
 | `ui.enableFollowupSuggestions` | boolean | `true`  | Enable or disable followup suggestions                             |
 | `ui.enableCacheSharing`        | boolean | `true`  | Use cache-aware forked queries to reduce cost (experimental)       |
 | `ui.enableSpeculation`         | boolean | `false` | Speculatively execute suggestions before submission (experimental) |
-| `fastModel`                    | string  | `""`    | Model for background tasks (suggestion generation, speculation)    |
+| `fastModel`                    | string  | `""`    | Model for prompt suggestions and speculative execution             |
 
 ### Example
 
 ```json
 {
-  "fastModel": "qwen3.5-flash",
+  "fastModel": "qwen3-coder-flash",
   "ui": {
     "enableFollowupSuggestions": true,
     "enableCacheSharing": true

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -672,7 +672,7 @@ const SETTINGS_SCHEMA = {
     requiresRestart: false,
     default: '',
     description:
-      'Model for background tasks (suggestion generation, speculation). Leave empty to use the main model. A smaller/faster model (e.g., qwen3.5-flash) reduces latency and cost.',
+      'Model used for generating prompt suggestions and speculative execution. Leave empty to use the main model. A smaller/faster model (e.g., qwen3-coder-flash) reduces latency and cost.',
     showInDialog: true,
   },
 

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -990,8 +990,8 @@ export default {
   // Commands - Model
   // ============================================================================
   'Switch the model for this session': 'Modell für diese Sitzung wechseln',
-  'Set fast model for background tasks':
-    'Schnelles Modell für Hintergrundaufgaben festlegen',
+  'Set a lighter model for prompt suggestions and speculative execution':
+    'Leichteres Modell für Eingabevorschläge und spekulative Ausführung festlegen',
   'Content generator configuration not available.':
     'Inhaltsgenerator-Konfiguration nicht verfügbar.',
   'Authentication type not available.':

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1152,7 +1152,8 @@ export default {
   // Commands - Model
   // ============================================================================
   'Switch the model for this session': 'Switch the model for this session',
-  'Set fast model for background tasks': 'Set fast model for background tasks',
+  'Set a lighter model for prompt suggestions and speculative execution':
+    'Set a lighter model for prompt suggestions and speculative execution',
   'Content generator configuration not available.':
     'Content generator configuration not available.',
   'Authentication type not available.': 'Authentication type not available.',

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -744,8 +744,8 @@ export default {
     'サマリーの生成に失敗 - LLMレスポンスからテキストコンテンツを受信できませんでした',
   // Model
   'Switch the model for this session': 'このセッションのモデルを切り替え',
-  'Set fast model for background tasks':
-    'バックグラウンドタスク用の高速モデルを設定',
+  'Set a lighter model for prompt suggestions and speculative execution':
+    'プロンプト提案と投機的実行用の軽量モデルを設定',
   'Content generator configuration not available.':
     'コンテンツジェネレーター設定が利用できません',
   'Authentication type not available.': '認証タイプが利用できません',

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -997,8 +997,8 @@ export default {
   // Commands - Model
   // ============================================================================
   'Switch the model for this session': 'Trocar o modelo para esta sessão',
-  'Set fast model for background tasks':
-    'Definir modelo rápido para tarefas em segundo plano',
+  'Set a lighter model for prompt suggestions and speculative execution':
+    'Definir modelo mais leve para sugestões de prompt e execução especulativa',
   'Content generator configuration not available.':
     'Configuração do gerador de conteúdo não disponível.',
   'Authentication type not available.': 'Tipo de autenticação não disponível.',

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -998,8 +998,8 @@ export default {
   // Команды - Модель
   // ============================================================================
   'Switch the model for this session': 'Переключение модели для этой сессии',
-  'Set fast model for background tasks':
-    'Установить быструю модель для фоновых задач',
+  'Set a lighter model for prompt suggestions and speculative execution':
+    'Установить облегчённую модель для подсказок и спекулятивного выполнения',
   'Content generator configuration not available.':
     'Конфигурация генератора содержимого недоступна.',
   'Authentication type not available.': 'Тип авторизации недоступен.',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1093,7 +1093,8 @@ export default {
   // Commands - Model
   // ============================================================================
   'Switch the model for this session': '切换此会话的模型',
-  'Set fast model for background tasks': '设置后台任务的快速模型',
+  'Set a lighter model for prompt suggestions and speculative execution':
+    '设置用于输入建议和推测执行的轻量模型',
   'Content generator configuration not available.': '内容生成器配置不可用',
   'Authentication type not available.': '认证类型不可用',
   'No models available for the current authentication type ({{authType}}).':

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -21,11 +21,13 @@ export const modelCommand: SlashCommand = {
   },
   kind: CommandKind.BUILT_IN,
   completion: async (_context, partialArg) => {
-    if ('--fast'.startsWith(partialArg)) {
+    if (partialArg && '--fast'.startsWith(partialArg)) {
       return [
         {
           value: '--fast',
-          description: t('Set fast model for background tasks'),
+          description: t(
+            'Set a lighter model for prompt suggestions and speculative execution',
+          ),
         },
       ];
     }

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -260,7 +260,7 @@
       "additionalProperties": true
     },
     "fastModel": {
-      "description": "Model for background tasks (suggestion generation, speculation). Leave empty to use the main model. A smaller/faster model (e.g., qwen3.5-flash) reduces latency and cost.",
+      "description": "Model used for generating prompt suggestions and speculative execution. Leave empty to use the main model. A smaller/faster model (e.g., qwen3-coder-flash) reduces latency and cost.",
       "type": "string",
       "default": ""
     },


### PR DESCRIPTION
## Motivation

Users reported that the `/model --fast` description "Set fast model for background tasks" is unclear — they don't understand what "fast model" or "background tasks" means. Additionally, `/model` → Tab → Enter accidentally triggers `--fast` mode instead of opening the model selection dialog, breaking the expected workflow.

用户反馈 `/model --fast` 的描述"设置后台任务的快速模型"含义不清——不理解"快速模型"和"后台任务"具体指什么。此外，输入 `/model` → Tab → Enter 会误触 `--fast` 模式，而非打开模型选择对话框，与预期操作习惯不符。

## Changes

### 1. Clarify description text (11 files — mostly i18n sync)

Replace vague wording with specific feature names across code, 6 i18n locales, 3 docs, and VS Code schema:

| Location | Before | After |
|----------|--------|-------|
| Completion hint | Set fast model for background tasks | Set a lighter model for prompt suggestions and speculative execution |
| Settings description | Model for background tasks (suggestion generation, speculation)... | Model used for generating prompt suggestions and speculative execution... |
| Example model | `qwen3.5-flash` | `qwen3-coder-flash` |

### 2. Fix accidental --fast activation (1 file)

`modelCommand.ts`: `'--fast'.startsWith(partialArg)` matches empty string, so Tab-completing `/model` immediately shows `--fast` as the only suggestion, and Enter selects it.

Fix: `partialArg && '--fast'.startsWith(partialArg)` — only suggest `--fast` when the user starts typing (e.g. `-`, `--f`).

## Test plan
- [x] `modelCommand.test.ts` — 8/8 passed
- [ ] `/model` → Tab → Enter → opens model dialog (no longer triggers `--fast`)
- [ ] `/model` → Tab → type `--` → Tab → shows `--fast` completion
- [ ] `/model --fast` → opens fast model selection dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)
