### PR TITLE
feat: auto-detect terminal dark/light theme via OSC 11 and COLORFGBG

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -244,6 +244,9 @@ export async function main() {
     }
   } else {
     // No explicit theme configured — auto-detect terminal background.
+    // Most terminals respond to OSC 11 within ~50ms; the 300ms timeout
+    // covers high-latency scenarios (e.g. SSH).  Once the user sets a
+    // theme via /theme this branch is skipped entirely.
     const background = await detectTerminalBackground({ timeoutMs: 300 });
     themeManager.setActiveTheme(
       background === 'light' ? 'Qwen Light' : 'Qwen Dark',

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -37,6 +37,7 @@ import { SettingsContext } from './ui/contexts/SettingsContext.js';
 import { VimModeProvider } from './ui/contexts/VimModeContext.js';
 import { AgentViewProvider } from './ui/contexts/AgentViewContext.js';
 import { useKittyKeyboardProtocol } from './ui/hooks/useKittyKeyboardProtocol.js';
+import { detectTerminalBackground } from './ui/themes/detect-terminal-theme.js';
 import { themeManager } from './ui/themes/theme-manager.js';
 import { detectAndEnableKittyProtocol } from './ui/utils/kittyProtocolDetector.js';
 import { checkForUpdates } from './ui/utils/updateCheck.js';
@@ -241,6 +242,12 @@ export async function main() {
         `Warning: Theme "${settings.merged.ui?.theme}" not found.`,
       );
     }
+  } else {
+    // No explicit theme configured — auto-detect terminal background.
+    const background = await detectTerminalBackground({ timeoutMs: 300 });
+    themeManager.setActiveTheme(
+      background === 'light' ? 'Qwen Light' : 'Qwen Dark',
+    );
   }
 
   // hop into sandbox if we are outside and sandboxing is enabled

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -38,7 +38,8 @@ import { VimModeProvider } from './ui/contexts/VimModeContext.js';
 import { AgentViewProvider } from './ui/contexts/AgentViewContext.js';
 import { useKittyKeyboardProtocol } from './ui/hooks/useKittyKeyboardProtocol.js';
 import { detectTerminalBackground } from './ui/themes/detect-terminal-theme.js';
-import { themeManager } from './ui/themes/theme-manager.js';
+import { themeManager, DEFAULT_THEME } from './ui/themes/theme-manager.js';
+import { QwenLight } from './ui/themes/qwen-light.js';
 import { detectAndEnableKittyProtocol } from './ui/utils/kittyProtocolDetector.js';
 import { checkForUpdates } from './ui/utils/updateCheck.js';
 import {
@@ -249,7 +250,7 @@ export async function main() {
     // theme via /theme this branch is skipped entirely.
     const background = await detectTerminalBackground({ timeoutMs: 300 });
     themeManager.setActiveTheme(
-      background === 'light' ? 'Qwen Light' : 'Qwen Dark',
+      background === 'light' ? QwenLight.name : DEFAULT_THEME.name,
     );
   }
 

--- a/packages/cli/src/ui/themes/detect-terminal-theme.test.ts
+++ b/packages/cli/src/ui/themes/detect-terminal-theme.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2025 Qwen
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/packages/cli/src/ui/themes/detect-terminal-theme.test.ts
+++ b/packages/cli/src/ui/themes/detect-terminal-theme.test.ts
@@ -173,6 +173,33 @@ describe('detectTerminalBackground', () => {
       expect(result).toBe('light');
     });
 
+    it('handles chunked OSC 11 response', async () => {
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+
+      // Simulate response arriving in two chunks
+      stdout.on('data', (chunk: Buffer) => {
+        if (chunk.toString().includes('\x1b]11;?')) {
+          setTimeout(() => {
+            const pt = stdin as unknown as PassThrough;
+            pt.push(Buffer.from('\x1b]11;rgb:ffff/ff'));
+            // Second chunk arrives 10ms later
+            setTimeout(() => {
+              pt.push(Buffer.from('ff/ffff\x07'));
+            }, 10);
+          }, 20);
+        }
+      });
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        timeoutMs: 500,
+      });
+
+      expect(result).toBe('light');
+    });
+
     it('handles mid-luminance boundary (just above 0.5 = light)', async () => {
       const stdin = createMockStdin();
       const stdout = createMockStdout();
@@ -350,6 +377,50 @@ describe('detectTerminalBackground', () => {
       });
 
       expect(result).toBe('dark');
+    });
+  });
+
+  describe('Windows legacy console', () => {
+    it('skips OSC 11 on Windows without WT_SESSION', async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        env: { COLORFGBG: '0;7' }, // no WT_SESSION
+      });
+
+      // Should skip OSC 11 and use COLORFGBG
+      expect(result).toBe('light');
+      expect(stdin.setRawMode).not.toHaveBeenCalled();
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    });
+
+    it('allows OSC 11 on Windows Terminal (WT_SESSION set)', async () => {
+      const originalPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+      simulateOSC11Response(stdin, stdout, '0000', '0000', '0000');
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        timeoutMs: 500,
+        env: { WT_SESSION: 'some-guid' },
+      });
+
+      expect(result).toBe('dark');
+      // setRawMode should have been called (OSC 11 was attempted)
+      expect(stdin.setRawMode).toHaveBeenCalledWith(true);
+
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
     });
   });
 

--- a/packages/cli/src/ui/themes/detect-terminal-theme.test.ts
+++ b/packages/cli/src/ui/themes/detect-terminal-theme.test.ts
@@ -220,6 +220,58 @@ describe('detectTerminalBackground', () => {
       expect(result).toBe('light');
     });
 
+    it('tolerates setRawMode throwing during cleanup', async () => {
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+      let callCount = 0;
+      stdin.setRawMode = vi.fn(() => {
+        callCount++;
+        // First call (enter raw mode) succeeds; second call (restore) throws
+        if (callCount > 1) {
+          throw new Error('stdin destroyed');
+        }
+      }) as unknown as typeof stdin.setRawMode;
+      simulateOSC11Response(stdin, stdout, 'ffff', 'ffff', 'ffff');
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        timeoutMs: 500,
+      });
+
+      // Should still return the detected result despite cleanup error
+      expect(result).toBe('light');
+    });
+
+    it('handles cleanup called multiple times (settled guard)', async () => {
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+
+      // Simulate both a fast response AND a subsequent 'end' on stdin,
+      // which would trigger cleanup twice (onData + onAbort).
+      // We use 'end' instead of 'error' because once cleanup removes the
+      // error listener, an unhandled 'error' event would throw.
+      stdout.on('data', (chunk: Buffer) => {
+        if (chunk.toString().includes('\x1b]11;?')) {
+          setTimeout(() => {
+            const pt = stdin as unknown as PassThrough;
+            pt.push(Buffer.from('\x1b]11;rgb:ffff/ffff/ffff\x07'));
+            // 'end' arrives right after data — second cleanup path
+            setTimeout(() => pt.emit('end'), 5);
+          }, 20);
+        }
+      });
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        timeoutMs: 500,
+      });
+
+      // Should resolve from the first (data) path, not crash from the second
+      expect(result).toBe('light');
+    });
+
     it('OSC 11 takes priority over COLORFGBG', async () => {
       const stdin = createMockStdin();
       const stdout = createMockStdout();

--- a/packages/cli/src/ui/themes/detect-terminal-theme.test.ts
+++ b/packages/cli/src/ui/themes/detect-terminal-theme.test.ts
@@ -56,12 +56,13 @@ function simulateOSC11Response(
 ) {
   stdout.on('data', (chunk: Buffer) => {
     if (chunk.toString().includes('\x1b]11;?')) {
-      // Reply after a tiny delay to simulate real terminal round-trip.
+      // Reply after a short delay to simulate real terminal round-trip.
+      // Use 20ms (not lower) to avoid flakiness on loaded CI runners.
       setTimeout(() => {
         (stdin as unknown as PassThrough).push(
           Buffer.from(`\x1b]11;rgb:${r}/${g}/${b}\x07`),
         );
-      }, 5);
+      }, 20);
     }
   });
 }
@@ -235,6 +236,55 @@ describe('detectTerminalBackground', () => {
       expect(result).toBe('light');
     });
 
+    it('falls back on stdin error', async () => {
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+
+      // Emit error shortly after query is sent
+      stdout.on('data', (chunk: Buffer) => {
+        if (chunk.toString().includes('\x1b]11;?')) {
+          setTimeout(() => {
+            (stdin as unknown as PassThrough).emit(
+              'error',
+              new Error('read error'),
+            );
+          }, 20);
+        }
+      });
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        timeoutMs: 500,
+        env: {},
+      });
+
+      expect(result).toBe('dark');
+    });
+
+    it('falls back on stdin end', async () => {
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+
+      stdout.on('data', (chunk: Buffer) => {
+        if (chunk.toString().includes('\x1b]11;?')) {
+          setTimeout(() => {
+            (stdin as unknown as PassThrough).emit('end');
+          }, 20);
+        }
+      });
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        timeoutMs: 500,
+        env: { COLORFGBG: '0;7' },
+      });
+
+      // Falls through OSC 11 (end) → COLORFGBG → light
+      expect(result).toBe('light');
+    });
+
     it('falls back when terminal does not respond (timeout)', async () => {
       const stdin = createMockStdin();
       const stdout = createMockStdout();
@@ -323,6 +373,23 @@ describe('detectTerminalBackground', () => {
       const result = await detectTerminalBackground({
         stdin,
         stdout,
+        env: {},
+      });
+
+      expect(result).toBe('dark');
+    });
+
+    it('returns dark when an unexpected error is thrown', async () => {
+      // Pass a completely broken stdin that throws on property access
+      const brokenStdin = {
+        get isTTY(): boolean {
+          throw new Error('broken');
+        },
+      } as unknown as NodeJS.ReadStream & { fd: 0 };
+
+      const result = await detectTerminalBackground({
+        stdin: brokenStdin,
+        stdout: createMockStdout(),
         env: {},
       });
 

--- a/packages/cli/src/ui/themes/detect-terminal-theme.test.ts
+++ b/packages/cli/src/ui/themes/detect-terminal-theme.test.ts
@@ -1,0 +1,332 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  detectTerminalBackground,
+  parseColorFGBG,
+} from './detect-terminal-theme.js';
+import { PassThrough } from 'node:stream';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Create a fake TTY stdin that supports setRawMode. */
+function createMockStdin() {
+  const stream = new PassThrough() as unknown as NodeJS.ReadStream & {
+    fd: 0;
+    isTTY: boolean;
+    isRaw: boolean;
+    setRawMode: (mode: boolean) => void;
+  };
+  stream.fd = 0 as const;
+  stream.isTTY = true;
+  stream.isRaw = false;
+  stream.setRawMode = vi.fn((mode: boolean) => {
+    stream.isRaw = mode;
+  });
+  return stream;
+}
+
+/** Create a fake TTY stdout. */
+function createMockStdout() {
+  const stream = new PassThrough() as unknown as NodeJS.WriteStream & {
+    fd: 1;
+    isTTY: boolean;
+  };
+  stream.fd = 1 as const;
+  stream.isTTY = true;
+  return stream;
+}
+
+/**
+ * Simulate a terminal replying with an OSC 11 response after a short delay.
+ * Intercepts the query write on stdout, then pushes the response to stdin.
+ */
+function simulateOSC11Response(
+  stdin: ReturnType<typeof createMockStdin>,
+  stdout: ReturnType<typeof createMockStdout>,
+  r: string,
+  g: string,
+  b: string,
+) {
+  stdout.on('data', (chunk: Buffer) => {
+    if (chunk.toString().includes('\x1b]11;?')) {
+      // Reply after a tiny delay to simulate real terminal round-trip.
+      setTimeout(() => {
+        (stdin as unknown as PassThrough).push(
+          Buffer.from(`\x1b]11;rgb:${r}/${g}/${b}\x07`),
+        );
+      }, 5);
+    }
+  });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// parseColorFGBG
+// ---------------------------------------------------------------------------
+
+describe('parseColorFGBG', () => {
+  it('returns dark for black background (index 0)', () => {
+    expect(parseColorFGBG('15;0')).toBe('dark');
+  });
+
+  it('returns light for white background (index 7)', () => {
+    expect(parseColorFGBG('0;7')).toBe('light');
+  });
+
+  it('returns dark for dark-gray background (index 8)', () => {
+    expect(parseColorFGBG('15;8')).toBe('dark');
+  });
+
+  it('returns light for bright white (index 15)', () => {
+    expect(parseColorFGBG('0;15')).toBe('light');
+  });
+
+  it('handles three-component format (fg;extra;bg)', () => {
+    expect(parseColorFGBG('15;0;7')).toBe('light');
+    expect(parseColorFGBG('7;0;0')).toBe('dark');
+  });
+
+  it('returns undefined for empty string', () => {
+    expect(parseColorFGBG('')).toBeUndefined();
+  });
+
+  it('returns undefined for non-numeric values', () => {
+    expect(parseColorFGBG('abc;xyz')).toBeUndefined();
+  });
+
+  it('returns undefined for out-of-range values', () => {
+    expect(parseColorFGBG('0;16')).toBeUndefined();
+    expect(parseColorFGBG('0;-1')).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectTerminalBackground — OSC 11
+// ---------------------------------------------------------------------------
+
+describe('detectTerminalBackground', () => {
+  describe('OSC 11 query', () => {
+    it('returns dark for black background (16-bit)', async () => {
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+      simulateOSC11Response(stdin, stdout, '0000', '0000', '0000');
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        timeoutMs: 500,
+      });
+
+      expect(result).toBe('dark');
+    });
+
+    it('returns light for white background (16-bit)', async () => {
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+      simulateOSC11Response(stdin, stdout, 'ffff', 'ffff', 'ffff');
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        timeoutMs: 500,
+      });
+
+      expect(result).toBe('light');
+    });
+
+    it('returns dark for a dark gray background (8-bit)', async () => {
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+      simulateOSC11Response(stdin, stdout, '1a', '1a', '2e');
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        timeoutMs: 500,
+      });
+
+      expect(result).toBe('dark');
+    });
+
+    it('returns light for a pastel background (8-bit)', async () => {
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+      simulateOSC11Response(stdin, stdout, 'f0', 'f0', 'f0');
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        timeoutMs: 500,
+      });
+
+      expect(result).toBe('light');
+    });
+
+    it('handles mid-luminance boundary (just above 0.5 = light)', async () => {
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+      // Pure green at ~72% luminance weight: rgb(00,b5,00)
+      // Luminance = 0.7152 * 0xb5 / 0xff ≈ 0.506 → light
+      simulateOSC11Response(stdin, stdout, '00', 'b5', '00');
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        timeoutMs: 500,
+      });
+
+      expect(result).toBe('light');
+    });
+
+    it('restores stdin raw mode after detection', async () => {
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+      simulateOSC11Response(stdin, stdout, 'ffff', 'ffff', 'ffff');
+
+      await detectTerminalBackground({ stdin, stdout, timeoutMs: 500 });
+
+      // setRawMode should have been called with true (enter) then false (restore)
+      expect(stdin.setRawMode).toHaveBeenCalledWith(true);
+      expect(stdin.setRawMode).toHaveBeenLastCalledWith(false);
+      expect(stdin.isRaw).toBe(false);
+    });
+
+    it('falls back gracefully when setRawMode throws', async () => {
+      const stdin = createMockStdin();
+      stdin.setRawMode = vi.fn(() => {
+        throw new Error('not supported');
+      });
+      const stdout = createMockStdout();
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        timeoutMs: 50,
+        env: { COLORFGBG: '0;7' },
+      });
+
+      // Should fall through to COLORFGBG
+      expect(result).toBe('light');
+    });
+
+    it('OSC 11 takes priority over COLORFGBG', async () => {
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+      // OSC 11 says light, COLORFGBG says dark
+      simulateOSC11Response(stdin, stdout, 'ffff', 'ffff', 'ffff');
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        timeoutMs: 500,
+        env: { COLORFGBG: '15;0' },
+      });
+
+      expect(result).toBe('light');
+    });
+
+    it('falls back when terminal does not respond (timeout)', async () => {
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+      // No OSC 11 response simulated — will time out.
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        timeoutMs: 50,
+        env: {},
+      });
+
+      expect(result).toBe('dark');
+    });
+  });
+
+  describe('non-TTY fallback', () => {
+    it('skips OSC 11 when stdin is not a TTY', async () => {
+      const stdin = createMockStdin();
+      stdin.isTTY = false;
+      const stdout = createMockStdout();
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        env: { COLORFGBG: '0;15' },
+      });
+
+      expect(result).toBe('light');
+      // setRawMode should never have been called.
+      expect(stdin.setRawMode).not.toHaveBeenCalled();
+    });
+
+    it('skips OSC 11 when stdout is not a TTY', async () => {
+      const stdin = createMockStdin();
+      const stdout = createMockStdout();
+      stdout.isTTY = false;
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        env: {},
+      });
+
+      expect(result).toBe('dark');
+    });
+  });
+
+  describe('COLORFGBG fallback', () => {
+    it('uses COLORFGBG when OSC 11 is unavailable', async () => {
+      const stdin = createMockStdin();
+      stdin.isTTY = false;
+      const stdout = createMockStdout();
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        env: { COLORFGBG: '15;0' },
+      });
+
+      expect(result).toBe('dark');
+    });
+
+    it('returns light from COLORFGBG', async () => {
+      const stdin = createMockStdin();
+      stdin.isTTY = false;
+      const stdout = createMockStdout();
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        env: { COLORFGBG: '0;7' },
+      });
+
+      expect(result).toBe('light');
+    });
+  });
+
+  describe('default fallback', () => {
+    it('returns dark when no detection method succeeds', async () => {
+      const stdin = createMockStdin();
+      stdin.isTTY = false;
+      const stdout = createMockStdout();
+      stdout.isTTY = false;
+
+      const result = await detectTerminalBackground({
+        stdin,
+        stdout,
+        env: {},
+      });
+
+      expect(result).toBe('dark');
+    });
+  });
+});

--- a/packages/cli/src/ui/themes/detect-terminal-theme.ts
+++ b/packages/cli/src/ui/themes/detect-terminal-theme.ts
@@ -1,12 +1,21 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2025 Qwen
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import process from 'node:process';
 
-/** Dark ANSI color indices (standard 0-15 palette). */
+/**
+ * Dark ANSI color indices (standard 0-15 palette).
+ *
+ * Indices 0-6 and 8 are classified as dark backgrounds following the
+ * convention used by vim and other tools.  Indices 3 (yellow/brown) and
+ * 6 (cyan) are borderline — their actual brightness depends on the
+ * terminal's palette — but standard VGA/xterm defaults render them dark
+ * enough to warrant dark-theme text.  7 (white/light-gray) and 9-15
+ * (bright variants) are classified as light.
+ */
 const DARK_BG_INDICES = new Set([0, 1, 2, 3, 4, 5, 6, 8]);
 
 export interface DetectOptions {
@@ -73,6 +82,10 @@ async function queryOSC11(
       settled = true;
       clearTimeout(timer);
       stdin.removeListener('data', onData);
+      // Restore stdin to paused (non-flowing) mode — .on('data') switched it
+      // to flowing, and leaving it flowing could cause data loss before ink
+      // attaches its own listeners.
+      stdin.pause();
       try {
         stdin.setRawMode(wasRaw ?? false);
       } catch {
@@ -121,9 +134,14 @@ async function queryOSC11(
  * Determines if the background is light from hex color components.
  * X11 rgb: format allows 1–4 hex digits per channel; the max value
  * for N digits is (16^N - 1), e.g. 1-digit → 0xF, 4-digit → 0xFFFF.
+ *
+ * Per the X11 spec all three channels use the same precision, so we
+ * derive maxVal from rHex.length. If a malformed response has mixed
+ * lengths we use the longest channel to avoid division overflow.
  */
 function isLightBackground(rHex: string, gHex: string, bHex: string): boolean {
-  const maxVal = (1 << (4 * rHex.length)) - 1;
+  const hexLen = Math.max(rHex.length, gHex.length, bHex.length);
+  const maxVal = (1 << (4 * hexLen)) - 1;
   const r = parseInt(rHex, 16);
   const g = parseInt(gHex, 16);
   const b = parseInt(bHex, 16);

--- a/packages/cli/src/ui/themes/detect-terminal-theme.ts
+++ b/packages/cli/src/ui/themes/detect-terminal-theme.ts
@@ -43,7 +43,11 @@ export async function detectTerminalBackground(
     const timeoutMs = options?.timeoutMs ?? 300;
 
     // Try OSC 11 first (only when both stdin and stdout are TTYs).
-    if (stdin.isTTY && stdout.isTTY) {
+    // Skip on Windows unless running in Windows Terminal (WT_SESSION),
+    // because legacy cmd.exe / PowerShell without VT processing renders
+    // the escape sequence as visible garbage.
+    const isWinLegacy = process.platform === 'win32' && !env['WT_SESSION'];
+    if (stdin.isTTY && stdout.isTTY && !isWinLegacy) {
       const osc11Result = await queryOSC11(stdin, stdout, timeoutMs);
       if (osc11Result !== undefined) {
         return osc11Result;
@@ -151,13 +155,11 @@ async function queryOSC11(
  * X11 rgb: format allows 1–4 hex digits per channel; the max value
  * for N digits is (16^N - 1), e.g. 1-digit → 0xF, 4-digit → 0xFFFF.
  *
- * Per the X11 spec all three channels use the same precision, so we
- * derive maxVal from rHex.length. If a malformed response has mixed
- * lengths we use the longest channel to avoid division overflow.
+ * Per the X11 spec (and enforced by the {1,4} regex) all three channels
+ * use the same precision, so we derive maxVal from rHex.length alone.
  */
 function isLightBackground(rHex: string, gHex: string, bHex: string): boolean {
-  const hexLen = Math.max(rHex.length, gHex.length, bHex.length);
-  const maxVal = (1 << (4 * hexLen)) - 1;
+  const maxVal = (1 << (4 * rHex.length)) - 1;
   const r = parseInt(rHex, 16);
   const g = parseInt(gHex, 16);
   const b = parseInt(bHex, 16);

--- a/packages/cli/src/ui/themes/detect-terminal-theme.ts
+++ b/packages/cli/src/ui/themes/detect-terminal-theme.ts
@@ -36,26 +36,30 @@ export interface DetectOptions {
 export async function detectTerminalBackground(
   options?: DetectOptions,
 ): Promise<'dark' | 'light'> {
-  const stdin = options?.stdin ?? process.stdin;
-  const stdout = options?.stdout ?? process.stdout;
-  const env = options?.env ?? process.env;
-  const timeoutMs = options?.timeoutMs ?? 300;
+  try {
+    const stdin = options?.stdin ?? process.stdin;
+    const stdout = options?.stdout ?? process.stdout;
+    const env = options?.env ?? process.env;
+    const timeoutMs = options?.timeoutMs ?? 300;
 
-  // Try OSC 11 first (only when both stdin and stdout are TTYs).
-  if (stdin.isTTY && stdout.isTTY) {
-    const osc11Result = await queryOSC11(stdin, stdout, timeoutMs);
-    if (osc11Result !== undefined) {
-      return osc11Result;
+    // Try OSC 11 first (only when both stdin and stdout are TTYs).
+    if (stdin.isTTY && stdout.isTTY) {
+      const osc11Result = await queryOSC11(stdin, stdout, timeoutMs);
+      if (osc11Result !== undefined) {
+        return osc11Result;
+      }
     }
-  }
 
-  // Fallback: COLORFGBG environment variable.
-  const colorfgbg = env['COLORFGBG'];
-  if (colorfgbg) {
-    const result = parseColorFGBG(colorfgbg);
-    if (result !== undefined) {
-      return result;
+    // Fallback: COLORFGBG environment variable.
+    const colorfgbg = env['COLORFGBG'];
+    if (colorfgbg) {
+      const result = parseColorFGBG(colorfgbg);
+      if (result !== undefined) {
+        return result;
+      }
     }
+  } catch {
+    // Best-effort detection — never crash the process.
   }
 
   // Default: dark (preserves current QwenDark default).
@@ -82,6 +86,8 @@ async function queryOSC11(
       settled = true;
       clearTimeout(timer);
       stdin.removeListener('data', onData);
+      stdin.removeListener('error', onAbort);
+      stdin.removeListener('end', onAbort);
       // Restore stdin to paused (non-flowing) mode — .on('data') switched it
       // to flowing, and leaving it flowing could cause data loss before ink
       // attaches its own listeners.
@@ -93,10 +99,17 @@ async function queryOSC11(
       }
     };
 
+    const onAbort = () => {
+      cleanup();
+      resolve(undefined);
+    };
+
     const timer = setTimeout(() => {
       cleanup();
       resolve(undefined);
     }, timeoutMs);
+    // Don't let this timer keep the process alive (e.g. on early Ctrl+C).
+    timer.unref?.();
 
     const onData = (data: Buffer) => {
       accumulated += data.toString();
@@ -104,7 +117,7 @@ async function queryOSC11(
       // Response: \x1b]11;rgb:RRRR/GGGG/BBBB\x07  (or \x1b\\ as ST)
       const match = accumulated.match(
         // eslint-disable-next-line no-control-regex
-        /\x1b\]11;rgb:([0-9a-fA-F]+)\/([0-9a-fA-F]+)\/([0-9a-fA-F]+)/,
+        /\x1b\]11;rgb:([0-9a-fA-F]{1,4})\/([0-9a-fA-F]{1,4})\/([0-9a-fA-F]{1,4})/,
       );
       if (match) {
         cleanup();
@@ -124,6 +137,8 @@ async function queryOSC11(
     }
 
     stdin.on('data', onData);
+    stdin.on('error', onAbort);
+    stdin.on('end', onAbort);
 
     // Send OSC 11 query: "\x1b]11;?\x07"
     stdout.write('\x1b]11;?\x07');

--- a/packages/cli/src/ui/themes/detect-terminal-theme.ts
+++ b/packages/cli/src/ui/themes/detect-terminal-theme.ts
@@ -88,10 +88,11 @@ async function queryOSC11(
       stdin.removeListener('data', onData);
       stdin.removeListener('error', onAbort);
       stdin.removeListener('end', onAbort);
-      // Restore stdin to paused (non-flowing) mode — .on('data') switched it
-      // to flowing, and leaving it flowing could cause data loss before ink
-      // attaches its own listeners.
-      stdin.pause();
+      // Note: do NOT call stdin.pause() here.  Removing all 'data' listeners
+      // already switches the stream back to paused mode (Node.js Readable
+      // contract).  An explicit pause() would leave the stream in a state
+      // that interferes with the later Kitty protocol detection, causing its
+      // query responses ("[?0u", "[?62c") to leak into the input buffer.
       try {
         stdin.setRawMode(wasRaw ?? false);
       } catch {

--- a/packages/cli/src/ui/themes/detect-terminal-theme.ts
+++ b/packages/cli/src/ui/themes/detect-terminal-theme.ts
@@ -1,0 +1,147 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import process from 'node:process';
+
+/** Dark ANSI color indices (standard 0-15 palette). */
+const DARK_BG_INDICES = new Set([0, 1, 2, 3, 4, 5, 6, 8]);
+
+export interface DetectOptions {
+  timeoutMs?: number;
+  stdin?: NodeJS.ReadStream & { fd: 0 };
+  stdout?: NodeJS.WriteStream & { fd: 1 };
+  env?: Record<string, string | undefined>;
+}
+
+/**
+ * Determines whether the terminal background is dark or light.
+ *
+ * Strategy:
+ * 1. OSC 11 query — asks the terminal for its background color.
+ * 2. COLORFGBG env var — common fallback set by some terminals.
+ * 3. Default to 'dark' (preserves existing behaviour).
+ */
+export async function detectTerminalBackground(
+  options?: DetectOptions,
+): Promise<'dark' | 'light'> {
+  const stdin = options?.stdin ?? process.stdin;
+  const stdout = options?.stdout ?? process.stdout;
+  const env = options?.env ?? process.env;
+  const timeoutMs = options?.timeoutMs ?? 300;
+
+  // Try OSC 11 first (only when both stdin and stdout are TTYs).
+  if (stdin.isTTY && stdout.isTTY) {
+    const osc11Result = await queryOSC11(stdin, stdout, timeoutMs);
+    if (osc11Result !== undefined) {
+      return osc11Result;
+    }
+  }
+
+  // Fallback: COLORFGBG environment variable.
+  const colorfgbg = env['COLORFGBG'];
+  if (colorfgbg) {
+    const result = parseColorFGBG(colorfgbg);
+    if (result !== undefined) {
+      return result;
+    }
+  }
+
+  // Default: dark (preserves current QwenDark default).
+  return 'dark';
+}
+
+/**
+ * Sends an OSC 11 query and parses the terminal response.
+ * Returns undefined if the terminal does not respond within the timeout.
+ */
+async function queryOSC11(
+  stdin: NodeJS.ReadStream & { fd: 0 },
+  stdout: NodeJS.WriteStream & { fd: 1 },
+  timeoutMs: number,
+): Promise<'dark' | 'light' | undefined> {
+  const wasRaw = stdin.isRaw;
+
+  return new Promise<'dark' | 'light' | undefined>((resolve) => {
+    let settled = false;
+    let accumulated = '';
+
+    const cleanup = () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      stdin.removeListener('data', onData);
+      try {
+        stdin.setRawMode(wasRaw ?? false);
+      } catch {
+        // stdin may have been destroyed
+      }
+    };
+
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve(undefined);
+    }, timeoutMs);
+
+    const onData = (data: Buffer) => {
+      accumulated += data.toString();
+
+      // Response: \x1b]11;rgb:RRRR/GGGG/BBBB\x07  (or \x1b\\ as ST)
+      const match = accumulated.match(
+        // eslint-disable-next-line no-control-regex
+        /\x1b\]11;rgb:([0-9a-fA-F]+)\/([0-9a-fA-F]+)\/([0-9a-fA-F]+)/,
+      );
+      if (match) {
+        cleanup();
+        const [, rHex, gHex, bHex] = match;
+        resolve(isLightBackground(rHex!, gHex!, bHex!) ? 'light' : 'dark');
+      }
+    };
+
+    try {
+      stdin.setRawMode(true);
+    } catch {
+      // If we can't set raw mode, give up on OSC 11.
+      settled = true;
+      clearTimeout(timer);
+      resolve(undefined);
+      return;
+    }
+
+    stdin.on('data', onData);
+
+    // Send OSC 11 query: "\x1b]11;?\x07"
+    stdout.write('\x1b]11;?\x07');
+  });
+}
+
+/**
+ * Determines if the background is light from hex color components.
+ * X11 rgb: format allows 1–4 hex digits per channel; the max value
+ * for N digits is (16^N - 1), e.g. 1-digit → 0xF, 4-digit → 0xFFFF.
+ */
+function isLightBackground(rHex: string, gHex: string, bHex: string): boolean {
+  const maxVal = (1 << (4 * rHex.length)) - 1;
+  const r = parseInt(rHex, 16);
+  const g = parseInt(gHex, 16);
+  const b = parseInt(bHex, 16);
+  // Relative luminance (ITU-R BT.709).
+  const luminance = (0.2126 * r + 0.7152 * g + 0.0722 * b) / maxVal;
+  return luminance > 0.5;
+}
+
+/**
+ * Parses the COLORFGBG environment variable.
+ * Format: "fg;bg" where fg/bg are ANSI color indices (0-15).
+ * Some terminals use "fg;extra;bg" — we always take the last component.
+ */
+export function parseColorFGBG(value: string): 'dark' | 'light' | undefined {
+  const parts = value.split(';');
+  const bgStr = parts[parts.length - 1];
+  if (!bgStr) return undefined;
+  const bg = parseInt(bgStr, 10);
+  if (isNaN(bg) || bg < 0 || bg > 15) return undefined;
+  return DARK_BG_INDICES.has(bg) ? 'dark' : 'light';
+}


### PR DESCRIPTION
## Summary

Closes #2998

- Auto-detect terminal background color at startup when no theme is explicitly configured
- Primary method: **OSC 11 query** — sends `\x1b]11;?\x07` to the terminal and parses the RGB response to compute luminance
- Fallback: **COLORFGBG env var** — parses the standard `fg;bg` format used by many terminals
- Default: `'dark'` (preserves existing QwenDark behavior when detection fails)
- Maps result to `Qwen Light` or `Qwen Dark` accordingly

### Files changed
- `packages/cli/src/ui/themes/detect-terminal-theme.ts` — new detection module
- `packages/cli/src/ui/themes/detect-terminal-theme.test.ts` — 22 tests
- `packages/cli/src/gemini.tsx` — integrate detection into startup flow

## Test plan

- [x] 30 unit tests covering OSC 11 (dark/light/8-bit/16-bit/timeout/setRawMode failure/priority), COLORFGBG parsing, non-TTY fallback, default fallback
- [x] ESLint clean
- [ ] Manual: dark terminal → QwenDark selected
- [ ] Manual: light terminal → QwenLight selected
- [ ] Manual: explicit `/theme` config → detection skipped
- [ ] Manual: piped input (`echo "test" | qwen-code`) → no hang