### PR TITLE
fix(cli): check NEWLINE before SUBMIT in TextInput multiline mode

### DIFF
--- a/packages/cli/src/ui/components/shared/TextInput.test.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render } from 'ink-testing-library';
+import { TextInput } from './TextInput.js';
+import { useKeypress } from '../../hooks/useKeypress.js';
+import type { Key } from '../../hooks/useKeypress.js';
+
+vi.mock('../../hooks/useKeypress.js', () => ({
+  useKeypress: vi.fn(),
+}));
+
+vi.mock('../../semantic-colors.js', () => ({
+  theme: {
+    text: { accent: 'cyan' },
+    status: { error: 'red' },
+  },
+}));
+
+const mockedUseKeypress = vi.mocked(useKeypress);
+
+function makeKey(overrides: Partial<Key>): Key {
+  return {
+    name: '',
+    ctrl: false,
+    meta: false,
+    shift: false,
+    paste: false,
+    sequence: '',
+    ...overrides,
+  };
+}
+
+function captureKeypressHandler(): (key: Key) => void {
+  const calls = mockedUseKeypress.mock.calls;
+  if (calls.length === 0) {
+    throw new Error('useKeypress was not called');
+  }
+  // Return the most recent handler
+  return calls[calls.length - 1]![0] as (key: Key) => void;
+}
+
+describe('TextInput', () => {
+  let onChange: ReturnType<typeof vi.fn>;
+  let onSubmit: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onChange = vi.fn();
+    onSubmit = vi.fn();
+  });
+
+  describe('multiline mode (height > 1)', () => {
+    it('submits on plain Enter', () => {
+      render(
+        <TextInput
+          value=""
+          onChange={onChange}
+          onSubmit={onSubmit}
+          height={5}
+        />,
+      );
+
+      const handler = captureKeypressHandler();
+      handler(makeKey({ name: 'return', sequence: '\r' }));
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT submit on Shift+Enter — inserts newline instead', () => {
+      render(
+        <TextInput
+          value=""
+          onChange={onChange}
+          onSubmit={onSubmit}
+          height={5}
+        />,
+      );
+
+      const handler = captureKeypressHandler();
+      handler(makeKey({ name: 'return', shift: true, sequence: '\r' }));
+
+      expect(onSubmit).not.toHaveBeenCalled();
+      // onChange should be called with the newline character
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('does NOT submit on Ctrl+Enter — inserts newline instead', () => {
+      render(
+        <TextInput
+          value=""
+          onChange={onChange}
+          onSubmit={onSubmit}
+          height={5}
+        />,
+      );
+
+      const handler = captureKeypressHandler();
+      handler(makeKey({ name: 'return', ctrl: true, sequence: '\r' }));
+
+      expect(onSubmit).not.toHaveBeenCalled();
+      expect(onChange).toHaveBeenCalled();
+    });
+  });
+
+  describe('single-line mode (height = 1)', () => {
+    it('submits on plain Enter', () => {
+      render(
+        <TextInput
+          value=""
+          onChange={onChange}
+          onSubmit={onSubmit}
+          height={1}
+        />,
+      );
+
+      const handler = captureKeypressHandler();
+      handler(makeKey({ name: 'return', sequence: '\r' }));
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it('submits on Shift+Enter (no newline concept in single-line)', () => {
+      render(
+        <TextInput
+          value=""
+          onChange={onChange}
+          onSubmit={onSubmit}
+          height={1}
+        />,
+      );
+
+      const handler = captureKeypressHandler();
+      handler(makeKey({ name: 'return', shift: true, sequence: '\r' }));
+
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/cli/src/ui/components/shared/TextInput.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.tsx
@@ -93,27 +93,20 @@ export function TextInput({
         return;
       }
 
-      // Submit on Enter
-      if (keyMatchers[Command.SUBMIT](key) || key.name === 'return') {
-        if (allowMultiline) {
-          const [row, col] = buffer.cursor;
-          const line = buffer.lines[row];
-          const charBefore = col > 0 ? cpSlice(line, col - 1, col) : '';
-          if (charBefore === '\\') {
-            buffer.backspace();
-            buffer.newline();
-          } else {
-            handleSubmit();
-          }
-        } else {
-          handleSubmit();
-        }
+      // Multiline newline insertion (Shift+Enter etc.) — check before SUBMIT
+      // so that modified-Return keys aren't swallowed by the submit branch.
+      if (allowMultiline && keyMatchers[Command.NEWLINE](key)) {
+        buffer.newline();
         return;
       }
 
-      // Multiline newline insertion (Shift+Enter etc.)
-      if (allowMultiline && keyMatchers[Command.NEWLINE](key)) {
-        buffer.newline();
+      // Submit on Enter (plain Return). In single-line mode any Return
+      // variant submits since there is no newline concept.
+      if (
+        keyMatchers[Command.SUBMIT](key) ||
+        (!allowMultiline && key.name === 'return')
+      ) {
+        handleSubmit();
         return;
       }
 


### PR DESCRIPTION
## TLDR

Fixes the `/agent create` wizard (Step 3: Describe Your Subagent) treating the editor newline keypress (Shift+Enter, Ctrl+Enter) as a submit instead of inserting a newline.

The root cause was in `TextInput.tsx` — the submit branch had `keyMatchers[Command.SUBMIT](key) || key.name === 'return'`, where the `key.name === 'return'` fallback matched *every* Return keypress regardless of modifiers, making the NEWLINE handler below it dead code.

The fix reorders checks so NEWLINE is evaluated before SUBMIT in multiline mode, and restricts the broad `key.name === 'return'` fallback to single-line inputs only (where there is no newline concept).

## Screenshots / Video Demo

N/A — this is a keyboard input handling fix that's hard to capture in a screenshot. Reproduction: run `/agent create`, select "Generate with Qwen Code", then press Shift+Enter in the description prompt. Before: submits. After: inserts a newline.

## Dive Deeper

The `TextInput` component is used across the CLI for various input prompts (auth dialogs, settings, permissions, agent wizard). The fix preserves existing behavior for single-line inputs (`height=1`) where any Return variant submits, while correctly handling multiline inputs (`height > 1`) where Shift+Enter/Ctrl+Enter should insert newlines.

The backslash-escape workaround (`\` + Enter → newline) that was part of the old code has been removed since it was a workaround for the broken NEWLINE handling and is no longer needed.

For reference, claw-code's `useTextInput.ts` handles this by checking `key.shift || key.meta` before falling through to submit — same logic, different implementation.

## Reviewer Test Plan

1. `npm run dev`
2. Run `/agent create` → select location → select "Generate with Qwen Code"
3. In the description prompt, press Shift+Enter → should insert a newline
4. Press Ctrl+Enter → should insert a newline
5. Press plain Enter → should submit
6. Also verify single-line inputs still work: `/config set` a non-sensitive setting, press Enter → should submit

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3068