### PR TITLE
fix: use latest assistant token count on resume instead of stale compression checkpoint

### DIFF
--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -19,6 +19,7 @@ import { getProjectHash } from '../utils/paths.js';
 import {
   SessionService,
   buildApiHistoryFromConversation,
+  getResumePromptTokenCount,
   type ConversationRecord,
 } from './sessionService.js';
 import { CompressionStatus } from '../core/turn.js';
@@ -628,6 +629,71 @@ describe('SessionService', () => {
       const exists = await sessionService.sessionExists(sessionIdA);
 
       expect(exists).toBe(false);
+    });
+  });
+
+  describe('getResumePromptTokenCount', () => {
+    const baseRecord: ChatRecord = {
+      uuid: 'r1',
+      parentUuid: null,
+      sessionId: sessionIdA,
+      timestamp: '2024-01-01T00:00:00Z',
+      type: 'user',
+      cwd: '/test/project/root',
+      version: '1.0.0',
+    };
+
+    const makeConversation = (messages: ChatRecord[]): ConversationRecord => ({
+      sessionId: sessionIdA,
+      projectHash: 'test-project-hash',
+      startTime: '2024-01-01T00:00:00Z',
+      lastUpdated: '2024-01-01T00:00:00Z',
+      messages,
+    });
+
+    const compressionRecord: ChatRecord = {
+      ...baseRecord,
+      uuid: 'comp',
+      type: 'system',
+      subtype: 'chat_compression',
+      systemPayload: {
+        info: {
+          originalTokenCount: 1000,
+          newTokenCount: 300,
+          compressionStatus: CompressionStatus.COMPRESSED,
+        },
+        compressedHistory: [],
+      },
+    };
+
+    it('should return latest assistant usage without scanning further back', () => {
+      const assistant: ChatRecord = {
+        ...baseRecord,
+        uuid: 'a1',
+        parentUuid: 'comp',
+        type: 'assistant',
+        usageMetadata: { totalTokenCount: 450 },
+      };
+      expect(
+        getResumePromptTokenCount(
+          makeConversation([compressionRecord, assistant]),
+        ),
+      ).toBe(450);
+    });
+
+    it('should fall back to compression when latest assistant has zero usage', () => {
+      const assistant: ChatRecord = {
+        ...baseRecord,
+        uuid: 'a1',
+        parentUuid: 'comp',
+        type: 'assistant',
+        usageMetadata: { totalTokenCount: 0, promptTokenCount: 0 },
+      };
+      expect(
+        getResumePromptTokenCount(
+          makeConversation([compressionRecord, assistant]),
+        ),
+      ).toBe(300);
     });
   });
 

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -690,7 +690,7 @@ export function getResumePromptTokenCount(
         | ChatCompressionRecordPayload
         | undefined;
       if (payload?.info) {
-        return payload.info.newTokenCount;
+        return fallback ?? payload.info.newTokenCount;
       }
     }
 

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -674,33 +674,34 @@ export function replayUiTelemetryFromConversation(
 }
 
 /**
- * Returns the best available prompt token count for resuming telemetry:
- * - If a chat compression checkpoint exists, use its new token count.
- * - Otherwise, use the last assistant usageMetadata input (fallback to total).
+ * Returns the best available prompt token count for resuming telemetry.
+ * Walks backward through messages and returns the first valid value:
+ * - The latest assistant's non-zero usage (totalTokenCount ?? promptTokenCount).
+ * - The most recent chat compression checkpoint's newTokenCount.
  */
 export function getResumePromptTokenCount(
   conversation: ConversationRecord,
 ): number | undefined {
-  let fallback: number | undefined;
-
   for (let i = conversation.messages.length - 1; i >= 0; i--) {
     const record = conversation.messages[i];
+
+    if (record.type === 'assistant') {
+      const usage = record.usageMetadata;
+      const candidate = usage?.totalTokenCount ?? usage?.promptTokenCount;
+      if (candidate) {
+        return candidate;
+      }
+    }
+
     if (record.type === 'system' && record.subtype === 'chat_compression') {
       const payload = record.systemPayload as
         | ChatCompressionRecordPayload
         | undefined;
       if (payload?.info) {
-        return fallback ?? payload.info.newTokenCount;
-      }
-    }
-
-    if (fallback === undefined && record.type === 'assistant') {
-      const usage = record.usageMetadata;
-      if (usage) {
-        fallback = usage.totalTokenCount ?? usage.promptTokenCount;
+        return payload.info.newTokenCount;
       }
     }
   }
 
-  return fallback;
+  return undefined;
 }


### PR DESCRIPTION
## TLDR

One-line fix: when resuming a session that had `/compress` followed by more messages, the status line showed a stale context usage value from the compression checkpoint instead of the actual last API call's token count.

`getResumePromptTokenCount` iterates backwards through messages and captures the most recent assistant record's token count as `fallback`, but then unconditionally returns the compression checkpoint's `newTokenCount` when it finds one — discarding the correct value. The fix is `return fallback ?? payload.info.newTokenCount`, so a more recent assistant record takes precedence.

## Screenshots / Video Demo

N/A — the status line percentage difference is small (e.g., 8.0% vs 8.2%) and hard to capture meaningfully in a screenshot. See E2E verification below.

## Dive Deeper

The backwards loop in `getResumePromptTokenCount` was written with the assumption that the compression checkpoint is always the most authoritative source. But after compression, subsequent API calls produce assistant records with their own `totalTokenCount` that reflects the actual context size — which may differ from the compression checkpoint.

## Reviewer Test Plan

1. Start `qwen --approval-mode yolo`
2. Send a short prompt, wait for response
3. `/compress`, wait for it to finish
4. Send another short prompt, wait for response
5. `/exit`, note the session ID
6. `qwen --resume <id>` — the status line context usage should match the last API call's token count, not the compression checkpoint

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3107