### PR TITLE
feat(vscode-ide-companion): support local clear slash commands

### DIFF
--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -54,6 +54,7 @@ import type { ModelInfo, AvailableCommand } from '@agentclientprotocol/sdk';
 import type { Question } from '../types/acpTypes.js';
 import { useImagePaste, type WebViewImageMessage } from './hooks/useImage.js';
 import { computeContextUsage } from './utils/contextUsage.js';
+import { mergeLocalAvailableCommands } from './utils/localSlashCommands.js';
 
 export const App: React.FC = () => {
   const vscode = useVSCode();
@@ -104,6 +105,10 @@ export const App: React.FC = () => {
   const [isComposing, setIsComposing] = useState(false);
   // When true, do NOT auto-attach the active editor file/selection to message context
   const [skipAutoActiveContext, setSkipAutoActiveContext] = useState(false);
+  const slashCommands = useMemo(
+    () => mergeLocalAvailableCommands(availableCommands),
+    [availableCommands],
+  );
 
   // Completion system
   const getCompletionItems = React.useCallback(
@@ -171,8 +176,8 @@ export const App: React.FC = () => {
           },
         ];
 
-        // Slash Commands group - commands from server (available_commands_update)
-        const slashCommandItems: CompletionItem[] = availableCommands.map(
+        // Slash Commands group - ACP commands plus local companion-only commands
+        const slashCommandItems: CompletionItem[] = slashCommands.map(
           (cmd) => ({
             id: cmd.name,
             label: `/${cmd.name}`,
@@ -200,7 +205,7 @@ export const App: React.FC = () => {
         );
       }
     },
-    [fileContext, availableCommands, modelInfo?.name],
+    [fileContext, modelInfo?.name, slashCommands],
   );
 
   const completion = useCompletionTrigger(inputFieldRef, getCompletionItems);
@@ -581,17 +586,19 @@ export const App: React.FC = () => {
           return;
         }
 
-        // Handle server-provided slash commands by sending them as messages.
+        // Handle slash commands by either invoking a local action or sending
+        // them as a message to the ACP session.
         // Skip when fillOnly (Tab) — let the generic insertion path fill the
         // command text so the user can keep typing arguments.
-        const serverCmd = availableCommands.find((c) => c.name === itemId);
-        if (serverCmd && !fillOnly) {
+        const slashCommand = slashCommands.find(
+          (command) => command.name === itemId,
+        );
+        if (slashCommand && !fillOnly) {
           // Clear the trigger text since we're sending the command
           clearTriggerText();
-          // Send the slash command as a user message
           vscode.postMessage({
             type: 'sendMessage',
-            data: { text: `/${serverCmd.name}` },
+            data: { text: `/${slashCommand.name}` },
           });
           completion.closeCompletion();
           return;
@@ -688,7 +695,7 @@ export const App: React.FC = () => {
       setInputText,
       fileContext,
       vscode,
-      availableCommands,
+      slashCommands,
     ],
   );
 

--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -302,6 +302,11 @@ export const App: React.FC = () => {
     });
   }, [messageHandling, vscode]);
 
+  const resetComposerState = useCallback(() => {
+    fileContext.clearFileReferences();
+    clearImages();
+  }, [clearImages, fileContext]);
+
   // Message handling
   useWebViewMessages({
     sessionManagement,
@@ -314,6 +319,7 @@ export const App: React.FC = () => {
     handleAskUserQuestion: setAskUserQuestionRequest,
     inputFieldRef,
     setInputText,
+    resetComposerState,
     setEditMode,
     setIsAuthenticated,
     setUsageStats: (stats) => setUsageStats(stats ?? null),

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
@@ -219,4 +219,121 @@ describe('SessionMessageHandler', () => {
       data: {},
     });
   });
+
+  it('treats /clear as a local fresh-session command instead of a chat prompt', async () => {
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      createNewSession: vi.fn().mockResolvedValue('session-2'),
+      sendMessage: vi.fn(),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn(),
+      addMessage: vi.fn(),
+    };
+    const sendToWebView = vi.fn();
+
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'conversation-1',
+      sendToWebView,
+    );
+
+    await handler.handle({
+      type: 'sendMessage',
+      data: {
+        text: '/clear',
+      },
+    });
+
+    expect(agentManager.createNewSession).toHaveBeenCalledWith('/workspace', {
+      forceNew: true,
+    });
+    expect(agentManager.sendMessage).not.toHaveBeenCalled();
+    expect(conversationStore.createConversation).not.toHaveBeenCalled();
+    expect(handler.getCurrentConversationId()).toBeNull();
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'conversationCleared',
+      data: {},
+    });
+  });
+
+  it('treats /reset as a local fresh-session alias', async () => {
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      createNewSession: vi.fn().mockResolvedValue('session-2'),
+      sendMessage: vi.fn(),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn(),
+      addMessage: vi.fn(),
+    };
+    const sendToWebView = vi.fn();
+
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'conversation-1',
+      sendToWebView,
+    );
+
+    await handler.handle({
+      type: 'sendMessage',
+      data: {
+        text: '/reset',
+      },
+    });
+
+    expect(agentManager.createNewSession).toHaveBeenCalledWith('/workspace', {
+      forceNew: true,
+    });
+    expect(agentManager.sendMessage).not.toHaveBeenCalled();
+    expect(sendToWebView).toHaveBeenCalledWith({
+      type: 'conversationCleared',
+      data: {},
+    });
+  });
+
+  it('does not treat bare clear text as a local command', async () => {
+    mockProcessImageAttachments.mockResolvedValue({
+      formattedText: 'clear',
+      displayText: 'clear',
+      savedImageCount: 0,
+      promptImages: [],
+    });
+
+    const agentManager = {
+      isConnected: true,
+      currentSessionId: 'session-1',
+      createNewSession: vi.fn(),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+    };
+    const conversationStore = {
+      createConversation: vi.fn(),
+      getConversation: vi.fn().mockResolvedValue(null),
+      addMessage: vi.fn(),
+    };
+    const sendToWebView = vi.fn();
+
+    const handler = new SessionMessageHandler(
+      agentManager as never,
+      conversationStore as never,
+      'conversation-1',
+      sendToWebView,
+    );
+
+    await handler.handle({
+      type: 'sendMessage',
+      data: {
+        text: 'clear',
+      },
+    });
+
+    expect(agentManager.createNewSession).not.toHaveBeenCalled();
+    expect(agentManager.sendMessage).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
@@ -15,6 +15,7 @@ import {
 } from '../utils/imageHandler.js';
 import { isAuthenticationRequiredError } from '../../utils/authErrors.js';
 import { getErrorMessage } from '../../utils/errorMessage.js';
+import { isLocalFreshSessionCommand } from '../utils/localSlashCommands.js';
 
 /**
  * Session message handler
@@ -302,6 +303,11 @@ export class SessionMessageHandler extends BaseMessageHandler {
     const hasAttachments = (attachments?.length ?? 0) > 0;
     if (!trimmedText && !hasAttachments) {
       console.warn('[SessionMessageHandler] Ignoring empty message');
+      return;
+    }
+
+    if (isLocalFreshSessionCommand(trimmedText)) {
+      await this.handleNewQwenSession();
       return;
     }
 

--- a/packages/vscode-ide-companion/src/webview/hooks/useCompletionTrigger.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/hooks/useCompletionTrigger.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @vitest-environment jsdom */
+
+import type React from 'react';
+import { createRef } from 'react';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useCompletionTrigger } from './useCompletionTrigger.js';
+
+function createRect() {
+  return {
+    top: 12,
+    left: 34,
+    right: 34,
+    bottom: 12,
+    width: 0,
+    height: 0,
+    x: 34,
+    y: 12,
+    toJSON: () => ({}),
+  } as DOMRect;
+}
+
+function setInputSelection(
+  input: HTMLDivElement,
+  text: string,
+  cursor: number,
+) {
+  input.textContent = text;
+  const textNode = input.firstChild;
+  if (!textNode) {
+    throw new Error('Expected input to contain a text node');
+  }
+
+  const range = document.createRange();
+  range.setStart(textNode, cursor);
+  range.setEnd(textNode, cursor);
+
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
+
+function renderCompletionHarness() {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const inputRef =
+    createRef<HTMLDivElement>() as unknown as React.RefObject<HTMLDivElement>;
+  const getCompletionItems = vi.fn(async () => [
+    {
+      id: 'clear',
+      label: '/clear',
+      type: 'command' as const,
+    },
+  ]);
+
+  let latestState: ReturnType<typeof useCompletionTrigger> | null = null;
+
+  function Harness() {
+    latestState = useCompletionTrigger(inputRef, getCompletionItems);
+    return <div ref={inputRef} contentEditable="plaintext-only" />;
+  }
+
+  act(() => {
+    root.render(<Harness />);
+  });
+
+  const input = inputRef.current;
+  if (!input) {
+    throw new Error('Expected input ref to be attached');
+  }
+
+  Object.defineProperty(input, 'getBoundingClientRect', {
+    configurable: true,
+    value: createRect,
+  });
+
+  return {
+    container,
+    root,
+    input,
+    getCompletionItems,
+    getState: () => {
+      if (!latestState) {
+        throw new Error('Expected hook state to be initialized');
+      }
+      return latestState;
+    },
+  };
+}
+
+describe('useCompletionTrigger', () => {
+  let root: Root | null = null;
+  let container: HTMLDivElement | null = null;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    Object.defineProperty(Range.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      value: createRect,
+    });
+  });
+
+  afterEach(() => {
+    const currentRoot = root;
+    if (currentRoot) {
+      act(() => {
+        currentRoot.unmount();
+      });
+      root = null;
+    }
+    if (container) {
+      container.remove();
+      container = null;
+    }
+  });
+
+  it('opens slash completion when slash is the first character', async () => {
+    const rendered = renderCompletionHarness();
+    root = rendered.root;
+    container = rendered.container;
+
+    await act(async () => {
+      setInputSelection(rendered.input, '/cl', 3);
+      rendered.input.dispatchEvent(new Event('input', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(rendered.getCompletionItems).toHaveBeenCalledWith('/', 'cl');
+    expect(rendered.getState().isOpen).toBe(true);
+  });
+
+  it('does not open slash completion when slash is not the first character', async () => {
+    const rendered = renderCompletionHarness();
+    root = rendered.root;
+    container = rendered.container;
+
+    await act(async () => {
+      setInputSelection(rendered.input, 'hello /cl', 9);
+      rendered.input.dispatchEvent(new Event('input', { bubbles: true }));
+      await Promise.resolve();
+    });
+
+    expect(rendered.getCompletionItems).not.toHaveBeenCalled();
+    expect(rendered.getState().isOpen).toBe(false);
+  });
+});

--- a/packages/vscode-ide-companion/src/webview/hooks/useCompletionTrigger.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useCompletionTrigger.ts
@@ -316,11 +316,15 @@ export function useCompletionTrigger(
         triggerChar = '/';
       }
 
-      // Check if trigger is at word boundary (start of line or after space)
+      // Check if trigger is in a valid context.
+      // Slash commands are only supported when the slash is the first character
+      // in the composer; @ mentions still allow a word-boundary trigger.
       if (triggerPos >= 0 && triggerChar) {
         const charBefore = triggerPos > 0 ? text[triggerPos - 1] : ' ';
         const isValidTrigger =
-          charBefore === ' ' || charBefore === '\n' || triggerPos === 0;
+          triggerChar === '/'
+            ? triggerPos === 0
+            : charBefore === ' ' || charBefore === '\n' || triggerPos === 0;
 
         if (isValidTrigger) {
           const query = text.substring(triggerPos + 1, effectiveCursorPosition);

--- a/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.test.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.test.ts
@@ -20,6 +20,8 @@ describe('resetConversationState', () => {
     const handleAskUserQuestion = vi.fn();
     const setCurrentSessionId = vi.fn();
     const setCurrentSessionTitle = vi.fn();
+    const inputFieldRef = { current: null };
+    const setInputText = vi.fn();
     const setUsageStats = vi.fn();
     const clearImageResolutions = vi.fn();
     const postMessage = vi.fn();
@@ -41,6 +43,8 @@ describe('resetConversationState', () => {
           setCurrentSessionId,
           setCurrentSessionTitle,
         },
+        inputFieldRef,
+        setInputText,
         setUsageStats,
       },
       clearImageResolutions,
@@ -52,6 +56,7 @@ describe('resetConversationState', () => {
     expect(endStreaming).toHaveBeenCalled();
     expect(clearWaitingForResponse).toHaveBeenCalled();
     expect(clearThinking).toHaveBeenCalled();
+    expect(setInputText).toHaveBeenCalledWith('');
     expect(clearMessages).toHaveBeenCalled();
     expect(clearToolCalls).toHaveBeenCalled();
     expect(clearActiveExecToolCalls).toHaveBeenCalled();

--- a/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.test.tsx
@@ -35,6 +35,7 @@ function renderHookHarness(overrides?: {
   setUsageStats?: ReturnType<typeof vi.fn>;
   endStreaming?: ReturnType<typeof vi.fn>;
   clearWaitingForResponse?: ReturnType<typeof vi.fn>;
+  resetComposerState?: ReturnType<typeof vi.fn>;
 }) {
   const container = document.createElement('div');
   document.body.appendChild(container);
@@ -43,6 +44,7 @@ function renderHookHarness(overrides?: {
   const setUsageStats = overrides?.setUsageStats ?? vi.fn();
   const endStreaming = overrides?.endStreaming ?? vi.fn();
   const clearWaitingForResponse = overrides?.clearWaitingForResponse ?? vi.fn();
+  const resetComposerState = overrides?.resetComposerState ?? vi.fn();
 
   const handlers = {
     sessionManagement: {
@@ -83,6 +85,7 @@ function renderHookHarness(overrides?: {
     handleAskUserQuestion: vi.fn(),
     inputFieldRef: createRef<HTMLDivElement>(),
     setInputText: vi.fn(),
+    resetComposerState,
     setEditMode: vi.fn(),
     setIsAuthenticated: vi.fn(),
     setUsageStats,
@@ -107,6 +110,7 @@ function renderHookHarness(overrides?: {
     setUsageStats,
     endStreaming,
     clearWaitingForResponse,
+    resetComposerState,
   };
 }
 
@@ -157,6 +161,8 @@ describe('useWebViewMessages', () => {
     ).toHaveBeenCalledWith(null);
     expect(rendered.endStreaming).toHaveBeenCalled();
     expect(rendered.clearWaitingForResponse).toHaveBeenCalled();
+    expect(rendered.handlers.setInputText).toHaveBeenCalledWith('');
+    expect(rendered.resetComposerState).toHaveBeenCalled();
     expect(mockClearImageResolutions).toHaveBeenCalled();
     expect(rendered.setUsageStats).toHaveBeenCalledWith(undefined);
     expect(rendered.handlers.setPlanEntries).toHaveBeenCalledWith([]);

--- a/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
@@ -119,6 +119,7 @@ interface UseWebViewMessagesProps {
   // Input
   inputFieldRef: React.RefObject<HTMLDivElement | null>;
   setInputText: (text: string) => void;
+  resetComposerState?: () => void;
   // Edit mode setter (maps ACP modes to UI modes)
   setEditMode?: (mode: ApprovalModeValue) => void;
   // Authentication state setter
@@ -150,6 +151,9 @@ type ConversationResetHandlers = {
     UseWebViewMessagesProps['sessionManagement'],
     'setCurrentSessionId' | 'setCurrentSessionTitle'
   >;
+  inputFieldRef: UseWebViewMessagesProps['inputFieldRef'];
+  setInputText: UseWebViewMessagesProps['setInputText'];
+  resetComposerState?: () => void;
   setUsageStats?: UseWebViewMessagesProps['setUsageStats'];
 };
 
@@ -166,6 +170,12 @@ export function resetConversationState({
   handlers.clearActiveExecToolCalls();
   handlers.messageHandling.clearWaitingForResponse();
   handlers.messageHandling.clearThinking();
+  handlers.setInputText('');
+  if (handlers.inputFieldRef.current) {
+    handlers.inputFieldRef.current.textContent = '\u200B';
+    handlers.inputFieldRef.current.setAttribute('data-empty', 'true');
+  }
+  handlers.resetComposerState?.();
   handlers.messageHandling.clearMessages();
   handlers.clearToolCalls();
   handlers.setPlanEntries([]);
@@ -197,6 +207,7 @@ export const useWebViewMessages = ({
   handleAskUserQuestion,
   inputFieldRef,
   setInputText,
+  resetComposerState,
   setEditMode,
   setIsAuthenticated,
   setUsageStats,
@@ -239,6 +250,9 @@ export const useWebViewMessages = ({
     setModelInfo,
     setAvailableCommands,
     setAvailableModels,
+    inputFieldRef,
+    setInputText,
+    resetComposerState,
   });
 
   // Track last "Updated Plan" snapshot toolcall to support merge/dedupe
@@ -289,6 +303,9 @@ export const useWebViewMessages = ({
       setModelInfo,
       setAvailableCommands,
       setAvailableModels,
+      inputFieldRef,
+      setInputText,
+      resetComposerState,
     };
   });
 

--- a/packages/vscode-ide-companion/src/webview/utils/localSlashCommands.test.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/localSlashCommands.test.ts
@@ -1,0 +1,52 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { AvailableCommand } from '@agentclientprotocol/sdk';
+import {
+  isLocalFreshSessionCommand,
+  mergeLocalAvailableCommands,
+} from './localSlashCommands.js';
+
+describe('mergeLocalAvailableCommands', () => {
+  it('recognizes /clear as a local fresh-session command', () => {
+    expect(isLocalFreshSessionCommand('/clear')).toBe(true);
+    expect(isLocalFreshSessionCommand(' /clear ')).toBe(true);
+    expect(isLocalFreshSessionCommand('/reset')).toBe(true);
+    expect(isLocalFreshSessionCommand('/new')).toBe(true);
+    expect(isLocalFreshSessionCommand('/help')).toBe(false);
+    expect(isLocalFreshSessionCommand('clear')).toBe(false);
+    expect(isLocalFreshSessionCommand(' reset ')).toBe(false);
+  });
+
+  it('injects a local clear command for the VS Code companion', () => {
+    const commands = mergeLocalAvailableCommands([]);
+
+    expect(commands).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'clear',
+          description: expect.stringContaining('fresh'),
+        }),
+      ]),
+    );
+    expect(commands[0]?.description).toContain('/reset');
+    expect(commands[0]?.description).toContain('/new');
+  });
+
+  it('does not duplicate clear when ACP already exposes it', () => {
+    const commands = mergeLocalAvailableCommands([
+      {
+        name: 'clear',
+        description: 'Server clear command',
+      } as AvailableCommand,
+    ]);
+
+    expect(commands.filter((command) => command.name === 'clear')).toHaveLength(
+      1,
+    );
+  });
+});

--- a/packages/vscode-ide-companion/src/webview/utils/localSlashCommands.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/localSlashCommands.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { AvailableCommand } from '@agentclientprotocol/sdk';
+
+const LOCAL_FRESH_SESSION_COMMANDS = ['clear', 'reset', 'new'] as const;
+const CLEAR_COMMAND_NAME = 'clear';
+const CLEAR_COMMAND_DESCRIPTION =
+  'Start a fresh session and clear the current chat. Aliases: /reset, /new.';
+
+const LOCAL_AVAILABLE_COMMANDS: AvailableCommand[] = [
+  {
+    name: CLEAR_COMMAND_NAME,
+    description: CLEAR_COMMAND_DESCRIPTION,
+  } as AvailableCommand,
+];
+
+export function isLocalFreshSessionCommand(input: string): boolean {
+  const token = input.trim().split(/\s+/, 1)[0]?.toLowerCase() ?? '';
+  if (!token.startsWith('/')) {
+    return false;
+  }
+
+  const normalized = token.slice(1);
+  return LOCAL_FRESH_SESSION_COMMANDS.some((command) => command === normalized);
+}
+
+function withClearAliases(command: AvailableCommand): AvailableCommand {
+  if (command.name.toLowerCase() !== CLEAR_COMMAND_NAME) {
+    return command;
+  }
+
+  if (command.description?.includes('/reset')) {
+    return command;
+  }
+
+  return {
+    ...command,
+    description: command.description
+      ? `${command.description} Aliases: /reset, /new.`
+      : CLEAR_COMMAND_DESCRIPTION,
+  };
+}
+
+export function mergeLocalAvailableCommands(
+  commands: AvailableCommand[],
+): AvailableCommand[] {
+  const normalizedCommands = commands.map(withClearAliases);
+  const existingCommands = new Set(
+    normalizedCommands.map((command) => command.name.toLowerCase()),
+  );
+
+  return [
+    ...LOCAL_AVAILABLE_COMMANDS.filter(
+      (command) => !existingCommands.has(command.name.toLowerCase()),
+    ),
+    ...normalizedCommands,
+  ];
+}


### PR DESCRIPTION
## TLDR

✅ Add a local `/clear` slash command to the VS Code IDE Companion so it is visible in slash completion and can explicitly trigger the fresh-session reset flow.  
✅ The companion now supports `/clear`, `/reset`, and `/new` as equivalent entry points, while avoiding false positives for plain text like `clear`.  
❓ This is a stacked follow-up and targets `followup/2874-review-suggestions`, not `main`.

## Screenshots / Video Demo

N/A — this change is mainly about slash-command discoverability and session reset behavior, and I have not recorded a separate demo.

Reviewers can validate it directly in the VS Code IDE Companion using the test plan below.

## Dive Deeper

### Background and Motivation

In `#2621`, VS Code extension users explicitly asked for a more obvious way to clear the current context and start a fresh session, instead of relying only on the existing `New Session` UI.

The CLI already exposes `/clear`, with `/reset` and `/new` as aliases, but the VS Code IDE Companion did not surface that workflow explicitly.

### Design Approach

This change does not introduce a second session-reset implementation. Instead, it reuses the companion’s existing “start a new session and clear the current conversation UI” flow.

The implementation works in three layers:

1. A local slash-command definition is merged into the webview slash completion list so `/clear` is discoverable.
2. Selecting that command still goes through the existing `sendMessage` pathway.
3. `SessionMessageHandler` intercepts local fresh-session commands and routes them into the existing `handleNewQwenSession()` logic instead of treating them as normal prompts.

### Implementation Details

- Added `localSlashCommands.ts`
  - Defines the local fresh-session command set
  - Centralizes recognition of `/clear`, `/reset`, and `/new`
  - Merges the local `clear` command into ACP-provided `availableCommands`
- Updated `App.tsx`
  - Slash completion now uses the merged command source
  - Selecting the slash item sends `/${command.name}`
- Updated `SessionMessageHandler.ts`
  - Detects local fresh-session commands before normal prompt submission
  - Calls the existing new-session flow and emits `conversationCleared`
- Added regression coverage
  - `/clear` starts a fresh session
  - `/reset` works as an alias
  - bare text `clear` is still treated as a normal prompt
  - local command merging does not duplicate an ACP-provided `clear`

### Backward Compatibility

This does not change normal message submission behavior.

Only explicit slash commands `/clear`, `/reset`, or `/new` trigger the local fresh-session path. Plain text like `clear` continues to be sent as a normal prompt.

### Performance Considerations

The change is limited to lightweight command merging and a small pre-send string check. It does not add any heavy state management or new async flows.

Runtime overhead should be negligible, and the main regression points are covered by targeted tests.

## Reviewer Test Plan

### Automated Verification

Run:

```bash
cd packages/vscode-ide-companion
npx vitest run src/webview/handlers/SessionMessageHandler.test.ts src/webview/providers/WebViewProvider.test.ts src/webview/utils/localSlashCommands.test.ts
npm run build:dev
```

### Manual Validation

1. Open the IDE Companion in VS Code.
2. Type `/cl` in the input box and confirm `/clear` appears in slash completion.
3. Select `/clear` and confirm the current conversation is cleared and a fresh session starts.
4. Type `/reset` and send it, then confirm it behaves the same as `/clear`.
5. Type `/new` and send it, then confirm it behaves the same as `/clear`.
6. Type plain text `clear` and send it, then confirm it is treated as a normal message rather than resetting the session.
7. If ACP also provides a `clear` command, confirm the slash list does not show duplicates.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

Notes:
- Validation was performed locally on macOS.
- No additional Windows, Linux, Docker, Podman, or Seatbelt verification was run.

## Linked issues / bugs

Related to #2621
