### PR TITLE
chore: bump version to 0.14.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "workspaces": [
         "packages/*",
         "packages/channels/base",
@@ -16888,7 +16888,7 @@
     },
     "packages/channels/base": {
       "name": "@qwen-code/channel-base",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1"
       },
@@ -16898,7 +16898,7 @@
     },
     "packages/channels/dingtalk": {
       "name": "@qwen-code/channel-dingtalk",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base",
         "dingtalk-stream-sdk-nodejs": "^2.0.4"
@@ -16909,7 +16909,7 @@
     },
     "packages/channels/plugin-example": {
       "name": "@qwen-code/channel-plugin-example",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base",
         "ws": "^8.18.0"
@@ -16923,7 +16923,7 @@
     },
     "packages/channels/telegram": {
       "name": "@qwen-code/channel-telegram",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base",
         "grammy": "^1.41.1",
@@ -16935,7 +16935,7 @@
     },
     "packages/channels/weixin": {
       "name": "@qwen-code/channel-weixin",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base"
       },
@@ -16945,7 +16945,7 @@
     },
     "packages/cli": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
         "@google/genai": "1.30.0",
@@ -17606,7 +17606,7 @@
     },
     "packages/core": {
       "name": "@qwen-code/qwen-code-core",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.36.1",
@@ -21039,7 +21039,7 @@
     },
     "packages/test-utils": {
       "name": "@qwen-code/qwen-code-test-utils",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "dev": true,
       "license": "Apache-2.0",
       "devDependencies": {
@@ -21051,7 +21051,7 @@
     },
     "packages/vscode-ide-companion": {
       "name": "qwen-code-vscode-ide-companion",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "license": "LICENSE",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
@@ -21298,7 +21298,7 @@
     },
     "packages/web-templates": {
       "name": "@qwen-code/web-templates",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "devDependencies": {
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
@@ -21826,7 +21826,7 @@
     },
     "packages/webui": {
       "name": "@qwen-code/webui",
-      "version": "0.14.2",
+      "version": "0.14.3",
       "license": "MIT",
       "dependencies": {
         "markdown-it": "^14.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "engines": {
     "node": ">=20.0.0"
   },
@@ -18,7 +18,7 @@
     "url": "git+https://github.com/QwenLM/qwen-code.git"
   },
   "config": {
-    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.14.2"
+    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.14.3"
   },
   "scripts": {
     "start": "cross-env node scripts/start.js",

--- a/packages/channels/base/package.json
+++ b/packages/channels/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-base",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Base channel infrastructure for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/dingtalk/package.json
+++ b/packages/channels/dingtalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-dingtalk",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "DingTalk channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/plugin-example/package.json
+++ b/packages/channels/plugin-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-plugin-example",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/telegram/package.json
+++ b/packages/channels/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-telegram",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Telegram channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/weixin/package.json
+++ b/packages/channels/weixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-weixin",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "WeChat (Weixin) channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Qwen Code",
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
     "dist"
   ],
   "config": {
-    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.14.2"
+    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.14.3"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.14.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code-core",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Qwen Code Core",
   "repository": {
     "type": "git",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code-test-utils",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "private": true,
   "main": "src/index.ts",
   "license": "Apache-2.0",

--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -2,7 +2,7 @@
   "name": "qwen-code-vscode-ide-companion",
   "displayName": "Qwen Code Companion",
   "description": "Enable Qwen Code with direct access to your VS Code workspace.",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "publisher": "qwenlm",
   "icon": "assets/icon.png",
   "repository": {

--- a/packages/web-templates/package.json
+++ b/packages/web-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/web-templates",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Web templates bundled as embeddable JS/CSS strings",
   "repository": {
     "type": "git",

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/webui",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Shared UI components for Qwen Code packages",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary

- Bump version from `0.14.2` to `0.14.3` across all packages (root, CLI, core, channels, webui, web-templates, test-utils, vscode-ide-companion)
- Update `sandboxImageUri` in root and CLI package.json to reference `0.14.3`
- Regenerate `package-lock.json` via `npm install --package-lock-only`
- Note: `@qwen-code/sdk` version remains at `0.1.6` (excluded from versioning script)

## Changed Files

| Package | Change |
|---|---|
| root | `0.14.2` → `0.14.3`, sandboxImageUri updated |
| @qwen-code/qwen-code (cli) | `0.14.2` → `0.14.3`, sandboxImageUri updated |
| @qwen-code/qwen-code-core | `0.14.2` → `0.14.3` |
| @qwen-code/channel-base | `0.14.2` → `0.14.3` |
| @qwen-code/channel-dingtalk | `0.14.2` → `0.14.3` |
| @qwen-code/channel-telegram | `0.14.2` → `0.14.3` |
| @qwen-code/channel-weixin | `0.14.2` → `0.14.3` |
| @qwen-code/channel-plugin-example | `0.14.2` → `0.14.3` |
| @qwen-code/webui | `0.14.2` → `0.14.3` |
| @qwen-code/web-templates | `0.14.2` → `0.14.3` |
| @qwen-code/test-utils | `0.14.2` → `0.14.3` |
| qwen-code-vscode-ide-companion | `0.14.2` → `0.14.3` |

## Test plan

- [x] Version bump script completed successfully
- [x] All packages rebuilt without errors
- [x] package-lock.json regenerated