### PR TITLE
feat: show description for active setting in /settings dialog

### DIFF
--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -130,6 +130,9 @@ export function SettingsDialog({
           : key,
         value: key,
         type: definition?.type,
+        description: definition?.description
+          ? t(definition.description) || definition.description
+          : undefined,
         toggle: () => {
           if (!TOGGLE_TYPES.has(definition?.type)) {
             return;
@@ -385,10 +388,17 @@ export function SettingsDialog({
     setMode('settings');
   };
 
+  // Get the description for the currently active setting
+  const activeDescription =
+    mode === 'settings' && items[activeSettingIndex]?.description
+      ? items[activeSettingIndex].description
+      : undefined;
+
   // Height constraint calculations similar to ThemeDialog
   const DIALOG_PADDING = 2;
   const SETTINGS_TITLE_HEIGHT = 2; // "Settings" title + spacing
   const SCROLL_ARROWS_HEIGHT = 2; // Up and down arrows
+  const DESCRIPTION_HEIGHT = 2; // Description line + margin
   const BOTTOM_HELP_TEXT_HEIGHT = 1; // Help text
   const RESTART_PROMPT_HEIGHT = showRestartPrompt ? 1 : 0;
 
@@ -401,6 +411,7 @@ export function SettingsDialog({
     DIALOG_PADDING +
     SETTINGS_TITLE_HEIGHT +
     SCROLL_ARROWS_HEIGHT +
+    DESCRIPTION_HEIGHT +
     BOTTOM_HELP_TEXT_HEIGHT +
     RESTART_PROMPT_HEIGHT;
 
@@ -881,7 +892,14 @@ export function SettingsDialog({
           initialScope={selectedScope}
         />
       )}
-      <Box marginTop={1}>
+      {activeDescription && mode === 'settings' && (
+        <Box marginTop={1}>
+          <Text color={theme.text.secondary} wrap="truncate-end" italic>
+            {activeDescription}
+          </Text>
+        </Box>
+      )}
+      <Box marginTop={activeDescription && mode === 'settings' ? 0 : 1}>
         <Text color={theme.text.secondary} wrap="truncate">
           {mode === 'settings'
             ? t('(Use Enter to select, Tab to configure scope)')

--- a/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`SettingsDialog > Snapshot Tests > should render default state correctly
 │   Auto-connect to IDE                                                                      false │
 │ ▼                                                                                                │
 │                                                                                                  │
+│ Approval mode for tool usage. Controls how tools are approved before execution.                  │
 │ (Use Enter to select, Tab to configure scope)                                                    │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
@@ -37,6 +38,7 @@ exports[`SettingsDialog > Snapshot Tests > should render focused on scope select
 │   Auto-connect to IDE                                                                      false │
 │ ▼                                                                                                │
 │                                                                                                  │
+│ Approval mode for tool usage. Controls how tools are approved before execution.                  │
 │ (Use Enter to select, Tab to configure scope)                                                    │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
@@ -58,6 +60,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with accessibility sett
 │   Auto-connect to IDE                                                                      false │
 │ ▼                                                                                                │
 │                                                                                                  │
+│ Approval mode for tool usage. Controls how tools are approved before execution.                  │
 │ (Use Enter to select, Tab to configure scope)                                                    │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
@@ -79,6 +82,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with all boolean settin
 │   Auto-connect to IDE                                                                     false* │
 │ ▼                                                                                                │
 │                                                                                                  │
+│ Approval mode for tool usage. Controls how tools are approved before execution.                  │
 │ (Use Enter to select, Tab to configure scope)                                                    │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
@@ -100,6 +104,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with different scope se
 │   Auto-connect to IDE                                                                      false │
 │ ▼                                                                                                │
 │                                                                                                  │
+│ Approval mode for tool usage. Controls how tools are approved before execution.                  │
 │ (Use Enter to select, Tab to configure scope)                                                    │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
@@ -121,6 +126,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with different scope se
 │   Auto-connect to IDE                                                                      false │
 │ ▼                                                                                                │
 │                                                                                                  │
+│ Approval mode for tool usage. Controls how tools are approved before execution.                  │
 │ (Use Enter to select, Tab to configure scope)                                                    │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
@@ -142,6 +148,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with file filtering set
 │   Auto-connect to IDE                                                                      false │
 │ ▼                                                                                                │
 │                                                                                                  │
+│ Approval mode for tool usage. Controls how tools are approved before execution.                  │
 │ (Use Enter to select, Tab to configure scope)                                                    │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
@@ -163,6 +170,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with mixed boolean and 
 │   Auto-connect to IDE                                                                      false │
 │ ▼                                                                                                │
 │                                                                                                  │
+│ Approval mode for tool usage. Controls how tools are approved before execution.                  │
 │ (Use Enter to select, Tab to configure scope)                                                    │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
@@ -184,6 +192,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with tools and security
 │   Auto-connect to IDE                                                                      false │
 │ ▼                                                                                                │
 │                                                                                                  │
+│ Approval mode for tool usage. Controls how tools are approved before execution.                  │
 │ (Use Enter to select, Tab to configure scope)                                                    │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"
@@ -205,6 +214,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with various boolean se
 │   Auto-connect to IDE                                                                      true* │
 │ ▼                                                                                                │
 │                                                                                                  │
+│ Approval mode for tool usage. Controls how tools are approved before execution.                  │
 │ (Use Enter to select, Tab to configure scope)                                                    │
 │                                                                                                  │
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────╯"


### PR DESCRIPTION
## Problem

The `/settings` dialog only shows setting labels (e.g. "Vim Mode") and their values, but no explanation of what each setting does. Users have to guess or check external docs to understand the purpose of each option.

## Solution

Display the `description` from the settings schema below the settings list for the currently highlighted item. The description updates as the user navigates between settings.

```
╭ Settings ─────────────────────────────────────────╮
│                                                   │
│  ● Vim Mode                                  off  │
│    Language: UI                              auto  │
│    Language: Model                           auto  │
│                                                   │
│  Enable Vim keybindings                           │
│  (Use Enter to select, Tab to configure scope)    │
╰───────────────────────────────────────────────────╯
```

### Changes
- Pass `description` field from settings schema into dialog items, with i18n support via `t()`
- Reserve height for description area in terminal height calculations to prevent layout overflow
- Render description in secondary color with italic style between settings list and help text

<img width="1990" height="1820" alt="image" src="https://github.com/user-attachments/assets/cd07427d-3a9b-41fb-bf64-7d7041afb3b3" />


## Test plan
- [ ] Run `/settings` and verify a description line appears below the settings list for the highlighted item
- [ ] Navigate up/down and verify the description updates to match the selected setting
- [ ] Verify layout is correct when terminal height is small (description area is accounted for in height calculations)
- [ ] Switch to scope selector view (Tab) and verify description is hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)