### PR TITLE
fix: use latest token count when resuming compressed sessions

### DIFF
--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -19,6 +19,7 @@ import { getProjectHash } from '../utils/paths.js';
 import {
   SessionService,
   buildApiHistoryFromConversation,
+  getResumePromptTokenCount,
   type ConversationRecord,
 } from './sessionService.js';
 import { CompressionStatus } from '../core/turn.js';
@@ -716,6 +717,81 @@ describe('SessionService', () => {
         recordB2.message,
         postCompressionRecord.message,
       ]);
+    });
+  });
+
+  describe('getResumePromptTokenCount', () => {
+    it('should return undefined for empty conversation', () => {
+      const conversation: ConversationRecord = {
+        sessionId: sessionIdA,
+        messages: [],
+      };
+      expect(getResumePromptTokenCount(conversation)).toBeUndefined();
+    });
+
+    it('should return compression newTokenCount when no messages follow', () => {
+      const conversation: ConversationRecord = {
+        sessionId: sessionIdA,
+        messages: [
+          {
+            ...recordA1,
+            type: 'system',
+            subtype: 'chat_compression',
+            systemPayload: {
+              info: {
+                originalTokenCount: 50000,
+                newTokenCount: 18000,
+                compressionStatus: CompressionStatus.SUCCESS,
+              },
+              compressedHistory: [],
+            },
+          } as ChatRecord,
+        ],
+      };
+      expect(getResumePromptTokenCount(conversation)).toBe(18000);
+    });
+
+    it('should prefer newer assistant usage over compression checkpoint', () => {
+      const conversation: ConversationRecord = {
+        sessionId: sessionIdA,
+        messages: [
+          {
+            ...recordA1,
+            type: 'system',
+            subtype: 'chat_compression',
+            systemPayload: {
+              info: {
+                originalTokenCount: 50000,
+                newTokenCount: 18000,
+                compressionStatus: CompressionStatus.SUCCESS,
+              },
+              compressedHistory: [],
+            },
+          } as ChatRecord,
+          // User chatted after compression, so there's a newer assistant
+          // message with an updated token count.
+          {
+            ...recordB2,
+            type: 'assistant',
+            usageMetadata: { totalTokenCount: 17900 },
+          } as ChatRecord,
+        ],
+      };
+      expect(getResumePromptTokenCount(conversation)).toBe(17900);
+    });
+
+    it('should fall back to assistant usage when no compression exists', () => {
+      const conversation: ConversationRecord = {
+        sessionId: sessionIdA,
+        messages: [
+          {
+            ...recordB2,
+            type: 'assistant',
+            usageMetadata: { totalTokenCount: 25000 },
+          } as ChatRecord,
+        ],
+      };
+      expect(getResumePromptTokenCount(conversation)).toBe(25000);
     });
   });
 });

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -690,7 +690,10 @@ export function getResumePromptTokenCount(
         | ChatCompressionRecordPayload
         | undefined;
       if (payload?.info) {
-        return payload.info.newTokenCount;
+        // Prefer a newer assistant message's usage data (already captured in
+        // fallback) over the compression checkpoint, since the user may have
+        // continued chatting after compression.
+        return fallback ?? payload.info.newTokenCount;
       }
     }
 


### PR DESCRIPTION
## Summary

- Fix `getResumePromptTokenCount()` to prefer the most recent assistant message's usage metadata over the compression checkpoint when both exist
- Adds tests for the `getResumePromptTokenCount` function covering the key scenarios

Closes #3107

## Root cause

`getResumePromptTokenCount()` iterates backward through messages. When it finds a `chat_compression` record, it immediately returns `payload.info.newTokenCount`, even if a newer assistant message (found earlier in the backward scan) already has more accurate usage data in `fallback`.

This means if the user compresses (e.g., down to 18k tokens), then continues chatting (context drifts to 17.9k), exits and resumes — the status line shows 18k instead of 17.9k.

## Fix

One-line change: `return payload.info.newTokenCount` → `return fallback ?? payload.info.newTokenCount`

This prefers the newer assistant usage data when available, falling back to the compression checkpoint only when no subsequent messages exist.

## Test plan

- [x] Added unit tests for `getResumePromptTokenCount`:
  - Empty conversation returns `undefined`
  - Compression-only returns checkpoint value
  - **Compression + newer assistant message returns the assistant's token count** (the bug scenario)
  - No compression falls back to assistant usage
- [x] All 29 existing `sessionService.test.ts` tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)