### PR TITLE
fix: lazy-load channel plugins to eliminate DEP0040 startup warning

### DIFF
--- a/packages/cli/src/commands/channel/channel-registry.ts
+++ b/packages/cli/src/commands/channel/channel-registry.ts
@@ -1,13 +1,21 @@
 import type { ChannelPlugin } from '@qwen-code/channel-base';
-import { plugin as telegramPlugin } from '@qwen-code/channel-telegram';
-import { plugin as weixinPlugin } from '@qwen-code/channel-weixin';
-import { plugin as dingtalkPlugin } from '@qwen-code/channel-dingtalk';
 
 const registry = new Map<string, ChannelPlugin>();
+let builtinsLoaded = false;
 
-// Register built-in channel types
-for (const p of [telegramPlugin, weixinPlugin, dingtalkPlugin]) {
-  registry.set(p.channelType, p);
+async function ensureBuiltins(): Promise<void> {
+  if (builtinsLoaded) return;
+  builtinsLoaded = true;
+
+  const [telegram, weixin, dingtalk] = await Promise.all([
+    import('@qwen-code/channel-telegram'),
+    import('@qwen-code/channel-weixin'),
+    import('@qwen-code/channel-dingtalk'),
+  ]);
+
+  for (const mod of [telegram, weixin, dingtalk]) {
+    registry.set(mod.plugin.channelType, mod.plugin);
+  }
 }
 
 export function registerPlugin(plugin: ChannelPlugin): void {
@@ -19,10 +27,14 @@ export function registerPlugin(plugin: ChannelPlugin): void {
   registry.set(plugin.channelType, plugin);
 }
 
-export function getPlugin(channelType: string): ChannelPlugin | undefined {
+export async function getPlugin(
+  channelType: string,
+): Promise<ChannelPlugin | undefined> {
+  await ensureBuiltins();
   return registry.get(channelType);
 }
 
-export function supportedTypes(): string[] {
+export async function supportedTypes(): Promise<string[]> {
+  await ensureBuiltins();
   return [...registry.keys()];
 }

--- a/packages/cli/src/commands/channel/channel-registry.ts
+++ b/packages/cli/src/commands/channel/channel-registry.ts
@@ -1,21 +1,23 @@
 import type { ChannelPlugin } from '@qwen-code/channel-base';
 
 const registry = new Map<string, ChannelPlugin>();
-let builtinsLoaded = false;
+let builtinsPromise: Promise<void> | null = null;
 
-async function ensureBuiltins(): Promise<void> {
-  if (builtinsLoaded) return;
-  builtinsLoaded = true;
+function ensureBuiltins(): Promise<void> {
+  if (!builtinsPromise) {
+    builtinsPromise = (async () => {
+      const [telegram, weixin, dingtalk] = await Promise.all([
+        import('@qwen-code/channel-telegram'),
+        import('@qwen-code/channel-weixin'),
+        import('@qwen-code/channel-dingtalk'),
+      ]);
 
-  const [telegram, weixin, dingtalk] = await Promise.all([
-    import('@qwen-code/channel-telegram'),
-    import('@qwen-code/channel-weixin'),
-    import('@qwen-code/channel-dingtalk'),
-  ]);
-
-  for (const mod of [telegram, weixin, dingtalk]) {
-    registry.set(mod.plugin.channelType, mod.plugin);
+      for (const mod of [telegram, weixin, dingtalk]) {
+        registry.set(mod.plugin.channelType, mod.plugin);
+      }
+    })();
   }
+  return builtinsPromise;
 }
 
 export function registerPlugin(plugin: ChannelPlugin): void {

--- a/packages/cli/src/commands/channel/config-utils.test.ts
+++ b/packages/cli/src/commands/channel/config-utils.test.ts
@@ -3,7 +3,7 @@ import { resolveEnvVars, parseChannelConfig } from './config-utils.js';
 
 // Mock the channel-registry so we don't pull in real plugins
 vi.mock('./channel-registry.js', () => ({
-  getPlugin: (type: string) => {
+  getPlugin: async (type: string) => {
     const plugins: Record<
       string,
       { channelType: string; requiredConfigFields?: string[] }
@@ -17,7 +17,7 @@ vi.mock('./channel-registry.js', () => ({
     };
     return plugins[type];
   },
-  supportedTypes: () => ['telegram', 'dingtalk', 'bare'],
+  supportedTypes: async () => ['telegram', 'dingtalk', 'bare'],
 }));
 
 describe('resolveEnvVars', () => {
@@ -49,26 +49,26 @@ describe('resolveEnvVars', () => {
 });
 
 describe('parseChannelConfig', () => {
-  it('throws when type is missing', () => {
-    expect(() => parseChannelConfig('bot', {})).toThrow(
+  it('throws when type is missing', async () => {
+    await expect(parseChannelConfig('bot', {})).rejects.toThrow(
       'missing required field "type"',
     );
   });
 
-  it('throws for unsupported channel type', () => {
-    expect(() => parseChannelConfig('bot', { type: 'slack' })).toThrow(
+  it('throws for unsupported channel type', async () => {
+    await expect(parseChannelConfig('bot', { type: 'slack' })).rejects.toThrow(
       '"slack" is not supported',
     );
   });
 
-  it('throws when plugin-required fields are missing', () => {
-    expect(() => parseChannelConfig('bot', { type: 'telegram' })).toThrow(
-      'requires "token"',
-    );
+  it('throws when plugin-required fields are missing', async () => {
+    await expect(
+      parseChannelConfig('bot', { type: 'telegram' }),
+    ).rejects.toThrow('requires "token"');
   });
 
-  it('parses minimal valid config with defaults', () => {
-    const result = parseChannelConfig('bot', {
+  it('parses minimal valid config with defaults', async () => {
+    const result = await parseChannelConfig('bot', {
       type: 'bare',
     });
 
@@ -82,12 +82,12 @@ describe('parseChannelConfig', () => {
     expect(result.groups).toEqual({});
   });
 
-  it('resolves env vars in token, clientId, clientSecret', () => {
+  it('resolves env vars in token, clientId, clientSecret', async () => {
     process.env['TEST_TOKEN'] = 'tok123';
     process.env['TEST_CID'] = 'cid456';
     process.env['TEST_SEC'] = 'sec789';
 
-    const result = parseChannelConfig('bot', {
+    const result = await parseChannelConfig('bot', {
       type: 'bare',
       token: '$TEST_TOKEN',
       clientId: '$TEST_CID',
@@ -103,8 +103,8 @@ describe('parseChannelConfig', () => {
     delete process.env['TEST_SEC'];
   });
 
-  it('preserves explicit config values over defaults', () => {
-    const result = parseChannelConfig('bot', {
+  it('preserves explicit config values over defaults', async () => {
+    const result = await parseChannelConfig('bot', {
       type: 'bare',
       token: 'literal-tok',
       senderPolicy: 'open',
@@ -130,8 +130,8 @@ describe('parseChannelConfig', () => {
     expect(result.groups).toEqual({ g1: { mentionKeywords: ['@bot'] } });
   });
 
-  it('spreads extra fields from raw config', () => {
-    const result = parseChannelConfig('bot', {
+  it('spreads extra fields from raw config', async () => {
+    const result = await parseChannelConfig('bot', {
       type: 'bare',
       customField: 42,
     });

--- a/packages/cli/src/commands/channel/config-utils.ts
+++ b/packages/cli/src/commands/channel/config-utils.ts
@@ -24,19 +24,20 @@ export function findCliEntryPath(): string {
   throw new Error('Cannot determine CLI entry path');
 }
 
-export function parseChannelConfig(
+export async function parseChannelConfig(
   name: string,
   rawConfig: Record<string, unknown>,
-): ChannelConfig & Record<string, unknown> {
+): Promise<ChannelConfig & Record<string, unknown>> {
   if (!rawConfig['type']) {
     throw new Error(`Channel "${name}" is missing required field "type".`);
   }
 
   const channelType = rawConfig['type'] as string;
-  const plugin = getPlugin(channelType);
+  const plugin = await getPlugin(channelType);
   if (!plugin) {
+    const types = await supportedTypes();
     throw new Error(
-      `Channel type "${channelType}" is not supported. Available: ${supportedTypes().join(', ')}`,
+      `Channel type "${channelType}" is not supported. Available: ${types.join(', ')}`,
     );
   }
 

--- a/packages/cli/src/commands/channel/start.ts
+++ b/packages/cli/src/commands/channel/start.ts
@@ -48,7 +48,7 @@ async function loadChannelsFromExtensions(): Promise<number> {
 
     for (const ext of extensions) {
       for (const [channelType, channelDef] of Object.entries(ext.channels!)) {
-        if (getPlugin(channelType)) {
+        if (await getPlugin(channelType)) {
           writeStderrLine(
             `[Extensions] Skipping channel "${channelType}" from "${ext.name}": type already registered`,
           );
@@ -96,13 +96,13 @@ async function loadChannelsFromExtensions(): Promise<number> {
   return loaded;
 }
 
-function createChannel(
+async function createChannel(
   name: string,
-  config: ReturnType<typeof parseChannelConfig>,
+  config: Awaited<ReturnType<typeof parseChannelConfig>>,
   bridge: AcpBridge,
   options?: { router?: SessionRouter },
-): ChannelBase {
-  const channelPlugin = getPlugin(config.type);
+): Promise<ChannelBase> {
+  const channelPlugin = await getPlugin(config.type);
   if (!channelPlugin) {
     throw new Error(`Unknown channel type: "${config.type}".`);
   }
@@ -153,7 +153,7 @@ async function startSingle(name: string): Promise<void> {
 
   let config;
   try {
-    config = parseChannelConfig(
+    config = await parseChannelConfig(
       name,
       channelsConfig[name] as Record<string, unknown>,
     );
@@ -180,7 +180,7 @@ async function startSingle(name: string): Promise<void> {
   );
   const channels: Map<string, ChannelBase> = new Map();
 
-  const channel = createChannel(name, config, bridge, { router });
+  const channel = await createChannel(name, config, bridge, { router });
   channels.set(name, channel);
   registerToolCallDispatch(bridge, router, channels);
 
@@ -272,13 +272,13 @@ async function startAll(): Promise<void> {
   // Parse all configs upfront — fail fast on bad config
   const parsed: Array<{
     name: string;
-    config: ReturnType<typeof parseChannelConfig>;
+    config: Awaited<ReturnType<typeof parseChannelConfig>>;
   }> = [];
   for (const [name, raw] of Object.entries(channelsConfig)) {
     try {
       parsed.push({
         name,
-        config: parseChannelConfig(name, raw as Record<string, unknown>),
+        config: await parseChannelConfig(name, raw as Record<string, unknown>),
       });
     } catch (err) {
       writeStderrLine(
@@ -323,7 +323,7 @@ async function startAll(): Promise<void> {
   );
 
   for (const { name, config } of parsed) {
-    channels.set(name, createChannel(name, config, bridge, { router }));
+    channels.set(name, await createChannel(name, config, bridge, { router }));
   }
   registerToolCallDispatch(bridge, router, channels);
 


### PR DESCRIPTION
## TLDR

Lazy-load channel plugins (telegram/weixin/dingtalk) to eliminate the `DEP0040` (`punycode` module deprecated) warning that prints on **every** CLI invocation on Node 22+.

The root cause: `channel-registry.ts` eagerly imported all three channel plugins at module load time. Since `config.ts` (loaded on every startup) imports `channelCommand` → `channel.ts` → `start.ts` → `channel-registry.ts`, this transitively pulled in `grammy` → `node-fetch@2` → `whatwg-url@5.0.0` → `require("punycode")` — triggering DEP0040 even for `qwen --version`.

The fix switches to dynamic `import()` so channel plugins are only loaded when a user actually runs a `qwen channel` subcommand.

## Screenshots / Video Demo

**Before** (every invocation on Node 22+):
```
$ qwen --version
(node:63599) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
0.14.3
```

**After:**
```
$ qwen --version
0.14.3
```

## Dive Deeper

- `channel-registry.ts`: Replaced top-level static imports with a lazy `ensureBuiltins()` that uses `Promise.all([import(...)])` on first access.
- `getPlugin()` and `supportedTypes()` are now `async` — callers are all in the `channel/` command subtree and already in async contexts (yargs handlers).
- `config-utils.ts`: `parseChannelConfig` is now `async`.
- `start.ts`: Added `await` at all `getPlugin`, `createChannel`, and `parseChannelConfig` call sites.
- Updated test mocks and assertions to match the async signatures.

No new dependencies. No changes outside the `channel/` command directory.

## Reviewer Test Plan

1. Run `node packages/cli/dist/index.js --version` — should print version with **no warnings**
2. Run `node --pending-deprecation --trace-deprecation packages/cli/dist/index.js -p "hello"` — should have **no DEP0040 or DEP0169 warnings**
3. Run `npx vitest run packages/cli/src/commands/channel/` — all 23 tests should pass
4. If you have a Telegram channel configured: `qwen channel start <name>` should still work (grammy loads on demand)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to #2865 (DEP0169 fix) — this PR addresses the separate DEP0040 warning from the same investigation.