### PR TITLE
fix(channels): apply proxy settings to channel start command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16907,6 +16907,7 @@
       "dependencies": {
         "@qwen-code/channel-base": "file:../base",
         "grammy": "^1.41.1",
+        "https-proxy-agent": "^7.0.6",
         "telegram-markdown-formatter": "^0.1.2"
       },
       "devDependencies": {

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -8,6 +8,7 @@ import type { AcpBridge, ToolCallEvent } from './AcpBridge.js';
 
 export interface ChannelBaseOptions {
   router?: SessionRouter;
+  proxy?: string;
 }
 
 /** Handler for a slash command. Return true if handled, false to forward to agent. */
@@ -20,6 +21,8 @@ export abstract class ChannelBase {
   protected gate: SenderGate;
   protected router: SessionRouter;
   protected name: string;
+  /** Resolved proxy URL, available to subclasses for adapter-specific clients. */
+  protected proxy?: string;
   private instructedSessions: Set<string> = new Set();
   private commands: Map<string, CommandHandler> = new Map();
   /** Per-session promise chain to serialize prompt + send (followup mode). */
@@ -45,6 +48,7 @@ export abstract class ChannelBase {
     this.name = name;
     this.config = config;
     this.bridge = bridge;
+    this.proxy = options?.proxy;
 
     this.groupGate = new GroupGate(config.groupPolicy, config.groups);
 

--- a/packages/channels/telegram/package.json
+++ b/packages/channels/telegram/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@qwen-code/channel-base": "file:../base",
     "grammy": "^1.41.1",
+    "https-proxy-agent": "^7.0.6",
     "telegram-markdown-formatter": "^0.1.2"
   },
   "devDependencies": {

--- a/packages/channels/telegram/src/TelegramAdapter.ts
+++ b/packages/channels/telegram/src/TelegramAdapter.ts
@@ -3,6 +3,7 @@ import { randomUUID } from 'node:crypto';
 import { basename, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { Bot } from 'grammy';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import {
   telegramFormat,
   splitHtmlForTelegram,
@@ -27,7 +28,14 @@ export class TelegramChannel extends ChannelBase {
     options?: ChannelBaseOptions,
   ) {
     super(name, config, bridge, options);
-    this.bot = new Bot(config.token);
+    const botConfig = this.proxy
+      ? {
+          client: {
+            baseFetchConfig: { agent: new HttpsProxyAgent(this.proxy) },
+          },
+        }
+      : undefined;
+    this.bot = new Bot(config.token, botConfig);
   }
 
   private getFileUrl(filePath: string): string {

--- a/packages/cli/src/commands/channel/start.ts
+++ b/packages/cli/src/commands/channel/start.ts
@@ -1,6 +1,8 @@
 import * as path from 'node:path';
 import * as os from 'node:os';
 import type { CommandModule } from 'yargs';
+import { ProxyAgent, setGlobalDispatcher } from 'undici';
+import { normalizeProxyUrl } from '@qwen-code/qwen-code-core';
 import { loadSettings } from '../../config/settings.js';
 import { writeStderrLine, writeStdoutLine } from '../../utils/stdioHelpers.js';
 import { AcpBridge, SessionRouter } from '@qwen-code/channel-base';
@@ -21,6 +23,31 @@ import { getExtensionManager } from '../extensions/utils.js';
 const MAX_CRASH_RESTARTS = 3;
 const CRASH_WINDOW_MS = 5 * 60 * 1000; // 5-minute window for counting crashes
 const RESTART_DELAY_MS = 3000;
+
+/**
+ * Resolve and apply proxy settings for the channel service process.
+ *
+ * The normal CLI path applies proxy via loadCliConfig → Config constructor →
+ * setGlobalDispatcher, but `channel start` never calls loadCliConfig. This
+ * replicates the same resolution logic (--proxy flag → HTTPS_PROXY →
+ * HTTP_PROXY) and applies the global dispatcher for native fetch() calls.
+ * The resolved URL is also passed to channels via ChannelBaseOptions so
+ * adapters can configure their own HTTP clients (e.g. grammy uses node-fetch
+ * which needs a separate agent).
+ */
+function resolveProxy(cliProxy?: string): string | undefined {
+  const proxyUrl = normalizeProxyUrl(
+    cliProxy ||
+      process.env['HTTPS_PROXY'] ||
+      process.env['https_proxy'] ||
+      process.env['HTTP_PROXY'] ||
+      process.env['http_proxy'],
+  );
+  if (proxyUrl) {
+    setGlobalDispatcher(new ProxyAgent(proxyUrl));
+  }
+  return proxyUrl;
+}
 
 function sessionsPath(): string {
   return path.join(os.homedir(), '.qwen', 'channels', 'sessions.json');
@@ -100,7 +127,7 @@ function createChannel(
   name: string,
   config: ReturnType<typeof parseChannelConfig>,
   bridge: AcpBridge,
-  options?: { router?: SessionRouter },
+  options?: { router?: SessionRouter; proxy?: string },
 ): ChannelBase {
   const channelPlugin = getPlugin(config.type);
   if (!channelPlugin) {
@@ -138,7 +165,7 @@ function checkDuplicateInstance(): void {
 }
 
 /** Start a single channel with its own bridge + crash recovery. */
-async function startSingle(name: string): Promise<void> {
+async function startSingle(name: string, proxy?: string): Promise<void> {
   checkDuplicateInstance();
   const channelsConfig = loadChannelsConfig();
 
@@ -180,7 +207,7 @@ async function startSingle(name: string): Promise<void> {
   );
   const channels: Map<string, ChannelBase> = new Map();
 
-  const channel = createChannel(name, config, bridge, { router });
+  const channel = createChannel(name, config, bridge, { router, proxy });
   channels.set(name, channel);
   registerToolCallDispatch(bridge, router, channels);
 
@@ -256,7 +283,7 @@ async function startSingle(name: string): Promise<void> {
 }
 
 /** Start all configured channels with a shared bridge + crash recovery. */
-async function startAll(): Promise<void> {
+async function startAll(proxy?: string): Promise<void> {
   checkDuplicateInstance();
   const channelsConfig = loadChannelsConfig();
 
@@ -323,7 +350,7 @@ async function startAll(): Promise<void> {
   );
 
   for (const { name, config } of parsed) {
-    channels.set(name, createChannel(name, config, bridge, { router }));
+    channels.set(name, createChannel(name, config, bridge, { router, proxy }));
   }
   registerToolCallDispatch(bridge, router, channels);
 
@@ -433,10 +460,13 @@ export const startCommand: CommandModule<object, { name?: string }> = {
       describe: 'Channel name (omit to start all configured channels)',
     }),
   handler: async (argv) => {
+    const proxy = resolveProxy(
+      (argv as Record<string, unknown>)['proxy'] as string | undefined,
+    );
     if (argv.name) {
-      await startSingle(argv.name);
+      await startSingle(argv.name, proxy);
     } else {
-      await startAll();
+      await startAll(proxy);
     }
   },
 };


### PR DESCRIPTION
## TLDR

`qwen channel start` ignores `--proxy` flag and `HTTPS_PROXY`/`HTTP_PROXY` environment variables. All channel HTTP traffic (Telegram `getMe`, long polling, file downloads, and traffic from other channels like DingTalk/WeChat) bypasses the configured proxy entirely.

**Root cause:** `channel start` never calls `loadCliConfig`, which is where `setGlobalDispatcher(new ProxyAgent(...))` is normally invoked. Additionally, grammy (the Telegram bot library) uses `node-fetch` internally, which doesn't respect undici's global dispatcher even if it were set.

**Fix:** Resolve proxy in the `channel start` bootstrap (same logic as `loadCliConfig`) and apply it at two levels:
1. `setGlobalDispatcher` for native `fetch()` calls — file downloads, DingTalk/WeChat API calls
2. `HttpsProxyAgent` passed to grammy's `baseFetchConfig.agent` — Telegram Bot API calls via `node-fetch`

## Screenshots / Video Demo

N/A — no user-facing change beyond proxy traffic now correctly routing through the configured proxy. Verified by observing `CONNECT api.telegram.org:443` on a local HTTP proxy that previously saw no connections.

## Dive Deeper

The channel service process has a separate lifecycle from the main CLI. When `qwen channel start` runs, it parses channel config via `loadSettings()` but never constructs the core `Config` object (which is where the main CLI applies the global proxy). This means the `--proxy` flag is parsed by yargs but never acted on.

The fix mirrors the main CLI's proxy resolution pattern:
- **`start.ts`** (bootstrap entry point): resolves proxy URL from `--proxy` / env vars and calls `setGlobalDispatcher` — same role as `Config` constructor in the main CLI
- **`ChannelBase`**: stores the resolved proxy URL as `protected proxy?: string` so subclasses can access it for adapter-specific HTTP clients
- **`TelegramAdapter`**: reads `this.proxy` to create an `HttpsProxyAgent` and passes it to grammy's `Bot` constructor via `client.baseFetchConfig.agent`, since grammy uses `node-fetch` which doesn't use undici's dispatcher

Two layers are needed because the channel code uses two different HTTP client stacks:
- Native `fetch()` (undici-backed) → covered by `setGlobalDispatcher`
- grammy's `node-fetch` → covered by `HttpsProxyAgent` on `baseFetchConfig.agent`

## Reviewer Test Plan

1. Set up a local HTTP proxy (e.g. `privoxy` on port 8118, or a simple Node CONNECT logger)
2. Configure a Telegram channel in `~/.qwen/settings.json` with a valid bot token
3. Run `node dist/cli.js --proxy http://127.0.0.1:8118 channel start my-telegram`
4. Verify the proxy sees a `CONNECT api.telegram.org:443` request (the `getMe` call)
5. Also test with `HTTPS_PROXY=http://127.0.0.1:8118 node dist/cli.js channel start my-telegram` (env var instead of flag)
6. Verify without proxy flag/env that behavior is unchanged (direct connection)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3122