### PR TITLE
feat(cli): warn when workspace overrides global modelProviders

### DIFF
--- a/packages/cli/src/config/modelProvidersScope.ts
+++ b/packages/cli/src/config/modelProvidersScope.ts
@@ -6,7 +6,7 @@
 
 import { SettingScope, type LoadedSettings } from './settings.js';
 
-function hasOwnModelProviders(settingsObj: unknown): boolean {
+export function hasOwnModelProviders(settingsObj: unknown): boolean {
   if (!settingsObj || typeof settingsObj !== 'object') {
     return false;
   }

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -496,6 +496,98 @@ describe('Settings Loading and Merging', () => {
       expect(getSettingsWarnings(settings)).toEqual([]);
     });
 
+    it('should warn when trusted workspace empty modelProviders overrides user modelProviders', () => {
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) =>
+          p === USER_SETTINGS_PATH || p === MOCK_WORKSPACE_SETTINGS_PATH,
+      );
+      const userSettingsContent = {
+        modelProviders: {
+          openai: [{ id: 'gpt-4o', envKey: 'OPENAI_API_KEY' }],
+        },
+      };
+      const workspaceSettingsContent = {
+        modelProviders: {},
+      };
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(getSettingsWarnings(settings)).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("defines an empty 'modelProviders' object"),
+        ]),
+      );
+    });
+
+    it('should not warn when workspace does not define modelProviders', () => {
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) =>
+          p === USER_SETTINGS_PATH || p === MOCK_WORKSPACE_SETTINGS_PATH,
+      );
+      const userSettingsContent = {
+        modelProviders: {
+          openai: [{ id: 'gpt-4o', envKey: 'OPENAI_API_KEY' }],
+        },
+      };
+      const workspaceSettingsContent = {
+        model: { name: 'workspace-model' },
+      };
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(getSettingsWarnings(settings)).toEqual([]);
+    });
+
+    it('should not warn when workspace is untrusted', () => {
+      vi.mocked(isWorkspaceTrusted).mockReturnValue({
+        isTrusted: false,
+        source: 'file',
+      });
+      (mockFsExistsSync as Mock).mockImplementation(
+        (p: fs.PathLike) =>
+          p === USER_SETTINGS_PATH || p === MOCK_WORKSPACE_SETTINGS_PATH,
+      );
+      const userSettingsContent = {
+        modelProviders: {
+          openai: [{ id: 'gpt-4o', envKey: 'OPENAI_API_KEY' }],
+        },
+      };
+      const workspaceSettingsContent = {
+        modelProviders: {},
+      };
+      (fs.readFileSync as Mock).mockImplementation(
+        (p: fs.PathOrFileDescriptor) => {
+          if (p === USER_SETTINGS_PATH)
+            return JSON.stringify(userSettingsContent);
+          if (p === MOCK_WORKSPACE_SETTINGS_PATH)
+            return JSON.stringify(workspaceSettingsContent);
+          return '{}';
+        },
+      );
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+
+      expect(getSettingsWarnings(settings)).toEqual([]);
+    });
+
     it('should rewrite allowedTools to tools.allowed during migration', () => {
       (mockFsExistsSync as Mock).mockImplementation(
         (p: fs.PathLike) => p === USER_SETTINGS_PATH,

--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -524,6 +524,8 @@ describe('Settings Loading and Merging', () => {
       expect(getSettingsWarnings(settings)).toEqual(
         expect.arrayContaining([
           expect.stringContaining("defines an empty 'modelProviders' object"),
+          expect.stringContaining('has no effect with current merge behavior'),
+          expect.stringContaining('may indicate a configuration error'),
         ]),
       );
     });

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -249,6 +249,62 @@ function getSettingsFileKeyWarnings(
   return warnings;
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasOwnModelProviders(
+  settingsObj: Record<string, unknown>,
+): boolean {
+  return Object.prototype.hasOwnProperty.call(settingsObj, 'modelProviders');
+}
+
+function hasAnyProviderEntries(modelProviders: unknown): boolean {
+  if (!isPlainObject(modelProviders)) {
+    return false;
+  }
+
+  return Object.values(modelProviders).some(
+    (providerModels) => Array.isArray(providerModels) && providerModels.length > 0,
+  );
+}
+
+function getModelProvidersOverrideWarnings(
+  loadedSettings: LoadedSettings,
+): string[] {
+  // Untrusted workspaces are ignored in merge, so they cannot shadow user modelProviders.
+  if (!loadedSettings.isTrusted) {
+    return [];
+  }
+
+  const userOriginal =
+    loadedSettings.user.originalSettings as unknown as Record<string, unknown>;
+  const workspaceOriginal =
+    loadedSettings.workspace.originalSettings as unknown as Record<
+      string,
+      unknown
+    >;
+
+  if (!hasOwnModelProviders(userOriginal) || !hasOwnModelProviders(workspaceOriginal)) {
+    return [];
+  }
+
+  const userModelProviders = userOriginal['modelProviders'];
+  const workspaceModelProviders = workspaceOriginal['modelProviders'];
+  const workspaceIsEmptyModelProviders =
+    isPlainObject(workspaceModelProviders) &&
+    Object.keys(workspaceModelProviders).length === 0;
+
+  if (!workspaceIsEmptyModelProviders || !hasAnyProviderEntries(userModelProviders)) {
+    return [];
+  }
+
+  return [
+    `Warning: '${loadedSettings.workspace.path}' defines an empty 'modelProviders' object. ` +
+      `Because 'modelProviders' uses REPLACE merge strategy, this overrides user-level model providers in '${loadedSettings.user.path}' for this project.`,
+  ];
+}
+
 /**
  * Collects warnings for ignored legacy and unknown settings keys,
  * as well as migration warnings.
@@ -281,6 +337,10 @@ export function getSettingsWarnings(loadedSettings: LoadedSettings): string[] {
     )) {
       warningSet.add(warning);
     }
+  }
+
+  for (const warning of getModelProvidersOverrideWarnings(loadedSettings)) {
+    warningSet.add(warning);
   }
 
   return [...warningSet];

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -20,6 +20,7 @@ import stripJsonComments from 'strip-json-comments';
 import { DefaultLight } from '../ui/themes/default-light.js';
 import { DefaultDark } from '../ui/themes/default.js';
 import { isWorkspaceTrusted } from './trustedFolders.js';
+import { hasOwnModelProviders } from './modelProvidersScope.js';
 import {
   type Settings,
   type MemoryImportFormat,
@@ -253,12 +254,6 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
-function hasOwnModelProviders(
-  settingsObj: Record<string, unknown>,
-): boolean {
-  return Object.prototype.hasOwnProperty.call(settingsObj, 'modelProviders');
-}
-
 function hasAnyProviderEntries(modelProviders: unknown): boolean {
   if (!isPlainObject(modelProviders)) {
     return false;
@@ -301,7 +296,8 @@ function getModelProvidersOverrideWarnings(
 
   return [
     `Warning: '${loadedSettings.workspace.path}' defines an empty 'modelProviders' object. ` +
-      `Because 'modelProviders' uses REPLACE merge strategy, this overrides user-level model providers in '${loadedSettings.user.path}' for this project.`,
+      `This has no effect with current merge behavior, but may indicate a configuration error. ` +
+      `If REPLACE semantics are introduced for 'modelProviders' in the future, this would override user-level model providers in '${loadedSettings.user.path}'.`,
   ];
 }
 


### PR DESCRIPTION
## Summary
- add startup warning when trusted workspace settings define an empty `modelProviders` object while user settings contain valid `modelProviders`
- make the warning explain that `modelProviders` uses REPLACE merge strategy and can override user-level global providers
- add focused tests for warning behavior (trusted/untrusted workspace and missing workspace override cases)

## Why
Issue #146 reported repeated per-project auth/model setup. The project already supports user-level global configuration via `~/.qwen/settings.json`, but users can still be confused when project settings shadow global providers. This PR improves observability with an explicit warning.

## Validation
- `npx vitest run packages/cli/src/config/settings.test.ts`
- `npx vitest run packages/cli/src/config/auth.test.ts packages/cli/src/core/initializer.test.ts packages/core/src/models/modelConfigResolver.test.ts`

Closes #146


---

> **📝 描述准确性更新（2026-05-31，作者自查）**
>
> 更正：modelProviders 的 REPLACE 策略当前未被 deepMerge 兑现；告警实际针对空对象 no-op（与正文 REPLACE 覆盖措辞不一致）。
