### PR TITLE
feat(channels): add voice message support in TelegramAdapter

### DIFF
--- a/packages/channels/telegram/src/TelegramAdapter.ts
+++ b/packages/channels/telegram/src/TelegramAdapter.ts
@@ -155,6 +155,59 @@ export class TelegramChannel extends ChannelBase {
       });
     });
 
+    // Voice messages
+    this.bot.on('message:voice', async (ctx) => {
+      const msg = ctx.message;
+      const voice = msg.voice;
+      const fileName = `voice_${Date.now()}.ogg`;
+
+      const envelope = this.buildEnvelope(
+        msg,
+        msg.caption || '(voice message)',
+        msg.caption_entities,
+      );
+
+      try {
+        const file = await ctx.api.getFile(voice.file_id);
+        const fileUrl = this.getFileUrl(file.file_path!);
+        const resp = await fetch(fileUrl);
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const buf = Buffer.from(await resp.arrayBuffer());
+
+        // Save to temp dir so the agent can read it via read-file tool
+        const dir = join(tmpdir(), 'channel-files', randomUUID());
+        mkdirSync(dir, { recursive: true });
+        const filePath = join(dir, fileName);
+        writeFileSync(filePath, buf);
+
+        envelope.text = msg.caption || '';
+        envelope.attachments = [
+          {
+            type: 'audio',
+            filePath,
+            mimeType: voice.mime_type || 'audio/ogg',
+            fileName,
+          },
+        ];
+      } catch (err) {
+        process.stderr.write(
+          `[Telegram:${this.name}] Failed to download voice message: ${err instanceof Error ? err.message : err}\n`,
+        );
+        envelope.text =
+          (msg.caption || '') +
+          `\n\n(User sent a voice message but download failed)`;
+      }
+
+      this.handleInbound(envelope).catch((err) => {
+        process.stderr.write(
+          `[Telegram:${this.name}] Error handling message: ${err}\n`,
+        );
+        ctx
+          .reply('Sorry, something went wrong processing your message.')
+          .catch(() => {});
+      });
+    });
+
     this.bot.start({ drop_pending_updates: true }).catch((err) => {
       process.stderr.write(
         `[Telegram:${this.name}] Bot launch error: ${err}\n`,


### PR DESCRIPTION
## Summary
- Add `message:voice` handler in `TelegramAdapter`, following the same pattern as `message:document`
- Voice messages are downloaded via Telegram Bot API (`getFile` → `fetch`)
- Saved to temp directory and passed as `attachment` with `type: 'audio'` in the Envelope
- Enables voice message processing through model's native audio capabilities or user-configured transcription skills

## Motivation
Currently, voice messages sent through Telegram are silently ignored by the channel adapter. The `Envelope` type already supports `audio` attachments (in `Attachment.type`), but `TelegramAdapter` has no handler for `message:voice`. This is a gap compared to `message:photo` and `message:document` which are both handled.

## Changes
- **Modified**: `packages/channels/telegram/src/TelegramAdapter.ts`
- **Added**: 53 lines — `message:voice` handler block between the existing `message:document` handler and `bot.start()`

### Implementation details
1. Register `this.bot.on('message:voice', ...)` handler
2. Extract `voice.file_id` from `ctx.message.voice`
3. Download file via `ctx.api.getFile()` → `getFileUrl()` → `fetch()`
4. Save to temp directory (`os.tmpdir()/channel-files/<uuid>/voice_<ts>.ogg`)
5. Attach to envelope as `{ type: 'audio', filePath, mimeType, fileName }`
6. Call `this.handleInbound(envelope)` with the same error-handling pattern as other handlers

No new dependencies. No changes to existing handlers or types.

## Testing
- Tested locally with Qwen Code + Telegram channel
- Voice messages (.ogg) are successfully downloaded and passed to the model
- Verified no impact on existing text/photo/document handling
- No existing tests for TelegramAdapter in the repo to extend