### PR TITLE
feat(minimax): add MiniMax provider with M3 as default

### DIFF
--- a/docs/users/configuration/model-providers.md
+++ b/docs/users/configuration/model-providers.md
@@ -195,6 +195,57 @@ This auth type supports not only OpenAI's official API but also any OpenAI-compa
 }
 ```
 
+### MiniMax (`openai`)
+
+MiniMax provides OpenAI-compatible chat models. Configure using the `openai` auth type with MiniMax's base URL. MiniMax requires temperature to be in the range `(0.0, 1.0]` — the provider enforces this automatically.
+
+| Model ID                 | Description                                              |
+| ------------------------ | -------------------------------------------------------- |
+| `MiniMax-M2.7`           | Peak performance, ultimate value — handles complex tasks |
+| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile                  |
+
+```json
+{
+  "env": {
+    "MINIMAX_API_KEY": "your-minimax-api-key"
+  },
+  "modelProviders": {
+    "openai": [
+      {
+        "id": "MiniMax-M2.7",
+        "name": "MiniMax-M2.7",
+        "envKey": "MINIMAX_API_KEY",
+        "baseUrl": "https://api.minimax.io/v1",
+        "generationConfig": {
+          "contextWindowSize": 200000,
+          "samplingParams": {
+            "temperature": 1.0,
+            "max_tokens": 65536
+          }
+        }
+      },
+      {
+        "id": "MiniMax-M2.7-highspeed",
+        "name": "MiniMax-M2.7-highspeed",
+        "envKey": "MINIMAX_API_KEY",
+        "baseUrl": "https://api.minimax.io/v1",
+        "generationConfig": {
+          "contextWindowSize": 200000,
+          "samplingParams": {
+            "temperature": 1.0,
+            "max_tokens": 65536
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+> [!note]
+>
+> **Domestic mirror**: Users in mainland China can replace `api.minimax.io` with `api.minimaxi.com` (note the extra `i`).
+
 ### Local Self-Hosted Models (via OpenAI-compatible API)
 
 Most local inference servers (vLLM, Ollama, LM Studio, etc.) provide an OpenAI-compatible API endpoint. Configure them using the `openai` auth type with a local `baseUrl`:

--- a/docs/users/configuration/model-providers.md
+++ b/docs/users/configuration/model-providers.md
@@ -199,10 +199,11 @@ This auth type supports not only OpenAI's official API but also any OpenAI-compa
 
 MiniMax provides OpenAI-compatible chat models. Configure using the `openai` auth type with MiniMax's base URL. MiniMax requires temperature to be in the range `(0.0, 1.0]` — the provider enforces this automatically.
 
-| Model ID                 | Description                                              |
-| ------------------------ | -------------------------------------------------------- |
-| `MiniMax-M2.7`           | Peak performance, ultimate value — handles complex tasks |
-| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile                  |
+| Model ID                 | Description                                                                    |
+| ------------------------ | ------------------------------------------------------------------------------ |
+| `MiniMax-M3`             | Latest model (default) — 512K context, up to 128K output, supports image input |
+| `MiniMax-M2.7`           | Peak performance, ultimate value — handles complex tasks                       |
+| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile                                        |
 
 ```json
 {
@@ -211,6 +212,19 @@ MiniMax provides OpenAI-compatible chat models. Configure using the `openai` aut
   },
   "modelProviders": {
     "openai": [
+      {
+        "id": "MiniMax-M3",
+        "name": "MiniMax-M3",
+        "envKey": "MINIMAX_API_KEY",
+        "baseUrl": "https://api.minimax.io/v1",
+        "generationConfig": {
+          "contextWindowSize": 524288,
+          "samplingParams": {
+            "temperature": 1.0,
+            "max_tokens": 131072
+          }
+        }
+      },
       {
         "id": "MiniMax-M2.7",
         "name": "MiniMax-M2.7",

--- a/packages/core/src/core/modalityDefaults.test.ts
+++ b/packages/core/src/core/modalityDefaults.test.ts
@@ -171,8 +171,16 @@ describe('defaultModalities', () => {
   });
 
   describe('MiniMax', () => {
-    it('returns text-only for MiniMax-M2.5', () => {
-      expect(defaultModalities('MiniMax-M2.5')).toEqual({});
+    it('returns image for MiniMax-M3', () => {
+      const m = defaultModalities('MiniMax-M3');
+      expect(m.image).toBe(true);
+      expect(m.pdf).toBeUndefined();
+      expect(m.audio).toBeUndefined();
+      expect(m.video).toBeUndefined();
+    });
+
+    it('returns text-only for MiniMax-M2.7', () => {
+      expect(defaultModalities('MiniMax-M2.7')).toEqual({});
     });
   });
 

--- a/packages/core/src/core/modalityDefaults.ts
+++ b/packages/core/src/core/modalityDefaults.ts
@@ -66,8 +66,11 @@ const MODALITY_PATTERNS: Array<[RegExp, InputModalities]> = [
   [/^glm-/, {}],
 
   // -------------------
-  // MiniMax — text-only
+  // MiniMax
   // -------------------
+  // M3 supports image input (images only, no video/audio/documents)
+  [/^minimax-m3/, { image: true }],
+  // M2.7 and earlier: text-only
   [/^minimax-/, {}],
 
   // -------------------

--- a/packages/core/src/core/openaiContentGenerator/constants.ts
+++ b/packages/core/src/core/openaiContentGenerator/constants.ts
@@ -6,3 +6,4 @@ export const DEFAULT_DASHSCOPE_BASE_URL =
   'https://dashscope.aliyuncs.com/compatible-mode/v1';
 export const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com/v1';
 export const DEFAULT_OPEN_ROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+export const DEFAULT_MINIMAX_BASE_URL = 'https://api.minimax.io/v1';

--- a/packages/core/src/core/openaiContentGenerator/index.ts
+++ b/packages/core/src/core/openaiContentGenerator/index.ts
@@ -13,6 +13,7 @@ import { OpenAIContentGenerator } from './openaiContentGenerator.js';
 import {
   DashScopeOpenAICompatibleProvider,
   DeepSeekOpenAICompatibleProvider,
+  MiniMaxOpenAICompatibleProvider,
   ModelScopeOpenAICompatibleProvider,
   OpenRouterOpenAICompatibleProvider,
   type OpenAICompatibleProvider,
@@ -26,6 +27,7 @@ export {
   type OpenAICompatibleProvider,
   DashScopeOpenAICompatibleProvider,
   DeepSeekOpenAICompatibleProvider,
+  MiniMaxOpenAICompatibleProvider,
   OpenRouterOpenAICompatibleProvider,
 } from './provider/index.js';
 
@@ -82,6 +84,14 @@ export function determineProvider(
   // Check for ModelScope provider
   if (ModelScopeOpenAICompatibleProvider.isModelScopeProvider(config)) {
     return new ModelScopeOpenAICompatibleProvider(
+      contentGeneratorConfig,
+      cliConfig,
+    );
+  }
+
+  // Check for MiniMax provider
+  if (MiniMaxOpenAICompatibleProvider.isMiniMaxProvider(config)) {
+    return new MiniMaxOpenAICompatibleProvider(
       contentGeneratorConfig,
       cliConfig,
     );

--- a/packages/core/src/core/openaiContentGenerator/provider/index.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/index.ts
@@ -2,6 +2,7 @@ export { ModelScopeOpenAICompatibleProvider } from './modelscope.js';
 export { DashScopeOpenAICompatibleProvider } from './dashscope.js';
 export { DeepSeekOpenAICompatibleProvider } from './deepseek.js';
 export { OpenRouterOpenAICompatibleProvider } from './openrouter.js';
+export { MiniMaxOpenAICompatibleProvider } from './minimax.js';
 export { DefaultOpenAICompatibleProvider } from './default.js';
 export type {
   OpenAICompatibleProvider,

--- a/packages/core/src/core/openaiContentGenerator/provider/minimax.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/minimax.test.ts
@@ -43,14 +43,14 @@ describe('MiniMaxOpenAICompatibleProvider', () => {
   });
 
   describe('isMiniMaxProvider', () => {
-    it('returns true when baseUrl contains api.minimax.io', () => {
+    it('returns true when baseUrl hostname is api.minimax.io', () => {
       const result = MiniMaxOpenAICompatibleProvider.isMiniMaxProvider(
         mockContentGeneratorConfig,
       );
       expect(result).toBe(true);
     });
 
-    it('returns true when baseUrl contains api.minimaxi.com', () => {
+    it('returns true when baseUrl hostname is api.minimaxi.com', () => {
       const config = {
         ...mockContentGeneratorConfig,
         baseUrl: 'https://api.minimaxi.com/v1',
@@ -74,6 +74,26 @@ describe('MiniMaxOpenAICompatibleProvider', () => {
       const config = {
         ...mockContentGeneratorConfig,
         baseUrl: undefined,
+      } as ContentGeneratorConfig;
+      expect(MiniMaxOpenAICompatibleProvider.isMiniMaxProvider(config)).toBe(
+        false,
+      );
+    });
+
+    it('returns false for a URL that contains api.minimax.io as a path component', () => {
+      const config = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://proxy.example.com/api.minimax.io/v1',
+      } as ContentGeneratorConfig;
+      expect(MiniMaxOpenAICompatibleProvider.isMiniMaxProvider(config)).toBe(
+        false,
+      );
+    });
+
+    it('returns false for a URL with api.minimax.io embedded in another hostname', () => {
+      const config = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://evil.api.minimax.io.malicious.com/v1',
       } as ContentGeneratorConfig;
       expect(MiniMaxOpenAICompatibleProvider.isMiniMaxProvider(config)).toBe(
         false,
@@ -124,6 +144,17 @@ describe('MiniMaxOpenAICompatibleProvider', () => {
       expect(result.temperature).toBe(1.0);
     });
 
+    it('sets temperature to 1.0 when temperature is null', () => {
+      const request = {
+        model: 'MiniMax-M2.7',
+        messages: [{ role: 'user' as const, content: 'Hello' }],
+        temperature: null,
+      } as unknown as OpenAI.Chat.ChatCompletionCreateParams;
+
+      const result = provider.buildRequest(request, userPromptId);
+      expect(result.temperature).toBe(1.0);
+    });
+
     it('preserves valid temperature values', () => {
       const request: OpenAI.Chat.ChatCompletionCreateParams = {
         model: 'MiniMax-M2.7',
@@ -147,6 +178,28 @@ describe('MiniMaxOpenAICompatibleProvider', () => {
       const result = provider.buildRequest(request, userPromptId);
       expect(result.messages).toHaveLength(2);
       expect(result.messages?.[0].content).toBe('Hello');
+    });
+  });
+
+  describe('buildClient', () => {
+    it('uses DEFAULT_MINIMAX_BASE_URL when no baseUrl configured', () => {
+      const configWithoutUrl = {
+        apiKey: 'test-key',
+        model: 'MiniMax-M2.7',
+      } as ContentGeneratorConfig;
+
+      const providerWithoutUrl = new MiniMaxOpenAICompatibleProvider(
+        configWithoutUrl,
+        mockCliConfig,
+      );
+
+      const client = providerWithoutUrl.buildClient();
+      expect(client).toBeDefined();
+    });
+
+    it('uses configured baseUrl when provided', () => {
+      const client = provider.buildClient();
+      expect(client).toBeDefined();
     });
   });
 });

--- a/packages/core/src/core/openaiContentGenerator/provider/minimax.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/minimax.test.ts
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type OpenAI from 'openai';
+import { MiniMaxOpenAICompatibleProvider } from './minimax.js';
+import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+import type { Config } from '../../../config/config.js';
+
+// Mock OpenAI client to avoid real network calls
+vi.mock('openai', () => ({
+  default: vi.fn().mockImplementation((config) => ({
+    config,
+  })),
+}));
+
+describe('MiniMaxOpenAICompatibleProvider', () => {
+  let provider: MiniMaxOpenAICompatibleProvider;
+  let mockContentGeneratorConfig: ContentGeneratorConfig;
+  let mockCliConfig: Config;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockContentGeneratorConfig = {
+      apiKey: 'test-minimax-api-key',
+      baseUrl: 'https://api.minimax.io/v1',
+      model: 'MiniMax-M2.7',
+    } as ContentGeneratorConfig;
+
+    mockCliConfig = {
+      getCliVersion: vi.fn().mockReturnValue('1.0.0'),
+      getProxy: vi.fn().mockReturnValue(undefined),
+    } as unknown as Config;
+
+    provider = new MiniMaxOpenAICompatibleProvider(
+      mockContentGeneratorConfig,
+      mockCliConfig,
+    );
+  });
+
+  describe('isMiniMaxProvider', () => {
+    it('returns true when baseUrl contains api.minimax.io', () => {
+      const result = MiniMaxOpenAICompatibleProvider.isMiniMaxProvider(
+        mockContentGeneratorConfig,
+      );
+      expect(result).toBe(true);
+    });
+
+    it('returns true when baseUrl contains api.minimaxi.com', () => {
+      const config = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://api.minimaxi.com/v1',
+      } as ContentGeneratorConfig;
+      expect(MiniMaxOpenAICompatibleProvider.isMiniMaxProvider(config)).toBe(
+        true,
+      );
+    });
+
+    it('returns false for non-MiniMax baseUrl', () => {
+      const config = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://api.openai.com/v1',
+      } as ContentGeneratorConfig;
+      expect(MiniMaxOpenAICompatibleProvider.isMiniMaxProvider(config)).toBe(
+        false,
+      );
+    });
+
+    it('returns false when baseUrl is undefined', () => {
+      const config = {
+        ...mockContentGeneratorConfig,
+        baseUrl: undefined,
+      } as ContentGeneratorConfig;
+      expect(MiniMaxOpenAICompatibleProvider.isMiniMaxProvider(config)).toBe(
+        false,
+      );
+    });
+  });
+
+  describe('getDefaultGenerationConfig', () => {
+    it('returns temperature 1.0 as default', () => {
+      expect(provider.getDefaultGenerationConfig()).toEqual({
+        temperature: 1.0,
+      });
+    });
+  });
+
+  describe('buildRequest', () => {
+    const userPromptId = 'prompt-123';
+
+    it('removes response_format from request', () => {
+      const request = {
+        model: 'MiniMax-M2.7',
+        messages: [{ role: 'user' as const, content: 'Hello' }],
+        response_format: { type: 'json_object' as const },
+      } as OpenAI.Chat.ChatCompletionCreateParams;
+
+      const result = provider.buildRequest(request, userPromptId);
+      expect(result).not.toHaveProperty('response_format');
+    });
+
+    it('sets temperature to 1.0 when temperature is 0', () => {
+      const request: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'MiniMax-M2.7',
+        messages: [{ role: 'user', content: 'Hello' }],
+        temperature: 0,
+      };
+
+      const result = provider.buildRequest(request, userPromptId);
+      expect(result.temperature).toBe(1.0);
+    });
+
+    it('sets temperature to 1.0 when temperature is undefined', () => {
+      const request: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'MiniMax-M2.7',
+        messages: [{ role: 'user', content: 'Hello' }],
+      };
+
+      const result = provider.buildRequest(request, userPromptId);
+      expect(result.temperature).toBe(1.0);
+    });
+
+    it('preserves valid temperature values', () => {
+      const request: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'MiniMax-M2.7',
+        messages: [{ role: 'user', content: 'Hello' }],
+        temperature: 0.7,
+      };
+
+      const result = provider.buildRequest(request, userPromptId);
+      expect(result.temperature).toBe(0.7);
+    });
+
+    it('preserves messages unchanged', () => {
+      const request: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'MiniMax-M2.7',
+        messages: [
+          { role: 'user', content: 'Hello' },
+          { role: 'assistant', content: 'Hi there' },
+        ],
+      };
+
+      const result = provider.buildRequest(request, userPromptId);
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages?.[0].content).toBe('Hello');
+    });
+  });
+});

--- a/packages/core/src/core/openaiContentGenerator/provider/minimax.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/minimax.test.ts
@@ -166,6 +166,28 @@ describe('MiniMaxOpenAICompatibleProvider', () => {
       expect(result.temperature).toBe(0.7);
     });
 
+    it('clamps temperature above 1.0 down to 1.0', () => {
+      const request: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'MiniMax-M2.7',
+        messages: [{ role: 'user', content: 'Hello' }],
+        temperature: 1.5,
+      };
+
+      const result = provider.buildRequest(request, userPromptId);
+      expect(result.temperature).toBe(1.0);
+    });
+
+    it('preserves temperature exactly at 1.0', () => {
+      const request: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'MiniMax-M2.7',
+        messages: [{ role: 'user', content: 'Hello' }],
+        temperature: 1.0,
+      };
+
+      const result = provider.buildRequest(request, userPromptId);
+      expect(result.temperature).toBe(1.0);
+    });
+
     it('preserves messages unchanged', () => {
       const request: OpenAI.Chat.ChatCompletionCreateParams = {
         model: 'MiniMax-M2.7',

--- a/packages/core/src/core/openaiContentGenerator/provider/minimax.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/minimax.test.ts
@@ -99,6 +99,16 @@ describe('MiniMaxOpenAICompatibleProvider', () => {
         false,
       );
     });
+
+    it('returns false for a malformed base URL without a scheme', () => {
+      const config = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'api.minimax.io/v1',
+      } as ContentGeneratorConfig;
+      expect(MiniMaxOpenAICompatibleProvider.isMiniMaxProvider(config)).toBe(
+        false,
+      );
+    });
   });
 
   describe('getDefaultGenerationConfig', () => {
@@ -182,6 +192,28 @@ describe('MiniMaxOpenAICompatibleProvider', () => {
         model: 'MiniMax-M2.7',
         messages: [{ role: 'user', content: 'Hello' }],
         temperature: 1.0,
+      };
+
+      const result = provider.buildRequest(request, userPromptId);
+      expect(result.temperature).toBe(1.0);
+    });
+
+    it('sets temperature to 1.0 when temperature is negative', () => {
+      const request: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'MiniMax-M2.7',
+        messages: [{ role: 'user', content: 'Hello' }],
+        temperature: -0.5,
+      };
+
+      const result = provider.buildRequest(request, userPromptId);
+      expect(result.temperature).toBe(1.0);
+    });
+
+    it('sets temperature to 1.0 when temperature is NaN', () => {
+      const request: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'MiniMax-M2.7',
+        messages: [{ role: 'user', content: 'Hello' }],
+        temperature: Number.NaN,
       };
 
       const result = provider.buildRequest(request, userPromptId);

--- a/packages/core/src/core/openaiContentGenerator/provider/minimax.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/minimax.ts
@@ -15,16 +15,20 @@ import {
   DEFAULT_MAX_RETRIES,
 } from '../constants.js';
 import { buildRuntimeFetchOptions } from '../../../utils/runtimeFetchOptions.js';
+import { createDebugLogger } from '../../../utils/debugLogger.js';
 
 /** Hostnames that identify the MiniMax API (global and domestic mirror). */
 const MINIMAX_HOSTNAMES = new Set(['api.minimax.io', 'api.minimaxi.com']);
+
+const debugLogger = createDebugLogger('MINIMAX');
 
 /**
  * Provider for MiniMax API (OpenAI-compatible interface).
  *
  * MiniMax-specific constraints:
- * - temperature must be in the range (0.0, 1.0]; 0 and null are not allowed,
- *   defaults to 1.0
+ * - temperature must be in the range (0.0, 1.0]; values of 0, null, or above
+ *   1.0 are rewritten/clamped to 1.0 (with a debug log when an explicit value
+ *   was changed)
  * - response_format is not supported and must be removed from requests
  */
 export class MiniMaxOpenAICompatibleProvider extends DefaultOpenAICompatibleProvider {
@@ -90,6 +94,10 @@ export class MiniMaxOpenAICompatibleProvider extends DefaultOpenAICompatibleProv
    * Build a MiniMax-compatible request by:
    * 1. Removing the unsupported `response_format` parameter
    * 2. Ensuring temperature is within the allowed range (0.0, 1.0]
+   *    - `0`/`null`/`undefined` are rewritten to 1.0
+   *    - values above 1.0 are clamped down to 1.0
+   *    Both rewrites are logged at debug level so users can see when their
+   *    explicit value was adjusted.
    */
   override buildRequest(
     request: OpenAI.Chat.ChatCompletionCreateParams,
@@ -100,11 +108,25 @@ export class MiniMaxOpenAICompatibleProvider extends DefaultOpenAICompatibleProv
     // Remove unsupported response_format via typed destructuring (no `any` cast)
     const { response_format: _rf, ...rest } = baseRequest;
 
-    // MiniMax does not accept temperature = 0 or null; default to 1.0
-    const temperature =
-      rest.temperature == null || rest.temperature === 0
-        ? 1.0
-        : rest.temperature;
+    // MiniMax accepts temperature only in (0.0, 1.0]; rewrite invalid values.
+    const original = rest.temperature;
+    let temperature: number;
+    if (original == null || original === 0) {
+      temperature = 1.0;
+      if (original === 0) {
+        // Only log when the user explicitly set 0; null/undefined is a default fill.
+        debugLogger.debug(
+          `temperature=0 is not supported; using 1.0 instead (request ${userPromptId})`,
+        );
+      }
+    } else if (original > 1.0) {
+      temperature = 1.0;
+      debugLogger.debug(
+        `temperature=${original} exceeds the 1.0 max; clamping to 1.0 (request ${userPromptId})`,
+      );
+    } else {
+      temperature = original;
+    }
 
     return { ...rest, temperature };
   }

--- a/packages/core/src/core/openaiContentGenerator/provider/minimax.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/minimax.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type OpenAI from 'openai';
+import type { GenerateContentConfig } from '@google/genai';
+import type { Config } from '../../../config/config.js';
+import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+import { DefaultOpenAICompatibleProvider } from './default.js';
+
+const MINIMAX_DEFAULT_BASE_URL = 'https://api.minimax.io/v1';
+
+/**
+ * Provider for MiniMax API (OpenAI-compatible interface).
+ *
+ * MiniMax-specific constraints:
+ * - temperature must be in the range (0.0, 1.0]; 0 is not allowed, default is 1.0
+ * - response_format is not supported and must be removed from requests
+ */
+export class MiniMaxOpenAICompatibleProvider extends DefaultOpenAICompatibleProvider {
+  constructor(
+    contentGeneratorConfig: ContentGeneratorConfig,
+    cliConfig: Config,
+  ) {
+    super(contentGeneratorConfig, cliConfig);
+    // Use MiniMax default base URL if not explicitly configured
+    if (!this.contentGeneratorConfig.baseUrl) {
+      this.contentGeneratorConfig = {
+        ...this.contentGeneratorConfig,
+        baseUrl: MINIMAX_DEFAULT_BASE_URL,
+      };
+    }
+  }
+
+  /**
+   * Checks if the configuration targets the MiniMax API.
+   */
+  static isMiniMaxProvider(config: ContentGeneratorConfig): boolean {
+    const baseUrl = config.baseUrl ?? '';
+    return (
+      baseUrl.includes('api.minimax.io') || baseUrl.includes('api.minimaxi.com')
+    );
+  }
+
+  /**
+   * MiniMax default generation config.
+   * Temperature defaults to 1.0 because MiniMax does not accept temperature = 0.
+   */
+  override getDefaultGenerationConfig(): GenerateContentConfig {
+    return {
+      temperature: 1.0,
+    };
+  }
+
+  /**
+   * Build a MiniMax-compatible request by:
+   * 1. Ensuring temperature is within the allowed range (0.0, 1.0]
+   * 2. Removing unsupported `response_format` parameter
+   */
+  override buildRequest(
+    request: OpenAI.Chat.ChatCompletionCreateParams,
+    userPromptId: string,
+  ): OpenAI.Chat.ChatCompletionCreateParams {
+    const baseRequest = super.buildRequest(request, userPromptId);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const result: any = { ...baseRequest };
+
+    // MiniMax does not support temperature = 0; default to 1.0
+    if (result.temperature === 0 || result.temperature === undefined) {
+      result.temperature = 1.0;
+    }
+
+    // MiniMax does not support response_format
+    if ('response_format' in result) {
+      delete result.response_format;
+    }
+
+    return result as OpenAI.Chat.ChatCompletionCreateParams;
+  }
+}

--- a/packages/core/src/core/openaiContentGenerator/provider/minimax.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/minimax.ts
@@ -4,19 +4,27 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type OpenAI from 'openai';
+import OpenAI from 'openai';
 import type { GenerateContentConfig } from '@google/genai';
 import type { Config } from '../../../config/config.js';
 import type { ContentGeneratorConfig } from '../../contentGenerator.js';
 import { DefaultOpenAICompatibleProvider } from './default.js';
+import {
+  DEFAULT_MINIMAX_BASE_URL,
+  DEFAULT_TIMEOUT,
+  DEFAULT_MAX_RETRIES,
+} from '../constants.js';
+import { buildRuntimeFetchOptions } from '../../../utils/runtimeFetchOptions.js';
 
-const MINIMAX_DEFAULT_BASE_URL = 'https://api.minimax.io/v1';
+/** Hostnames that identify the MiniMax API (global and domestic mirror). */
+const MINIMAX_HOSTNAMES = new Set(['api.minimax.io', 'api.minimaxi.com']);
 
 /**
  * Provider for MiniMax API (OpenAI-compatible interface).
  *
  * MiniMax-specific constraints:
- * - temperature must be in the range (0.0, 1.0]; 0 is not allowed, default is 1.0
+ * - temperature must be in the range (0.0, 1.0]; 0 and null are not allowed,
+ *   defaults to 1.0
  * - response_format is not supported and must be removed from requests
  */
 export class MiniMaxOpenAICompatibleProvider extends DefaultOpenAICompatibleProvider {
@@ -25,23 +33,47 @@ export class MiniMaxOpenAICompatibleProvider extends DefaultOpenAICompatibleProv
     cliConfig: Config,
   ) {
     super(contentGeneratorConfig, cliConfig);
-    // Use MiniMax default base URL if not explicitly configured
-    if (!this.contentGeneratorConfig.baseUrl) {
-      this.contentGeneratorConfig = {
-        ...this.contentGeneratorConfig,
-        baseUrl: MINIMAX_DEFAULT_BASE_URL,
-      };
-    }
   }
 
   /**
    * Checks if the configuration targets the MiniMax API.
+   * Uses hostname comparison to avoid substring-match false positives.
    */
   static isMiniMaxProvider(config: ContentGeneratorConfig): boolean {
-    const baseUrl = config.baseUrl ?? '';
-    return (
-      baseUrl.includes('api.minimax.io') || baseUrl.includes('api.minimaxi.com')
+    const baseUrl = config.baseUrl;
+    if (!baseUrl) return false;
+    try {
+      const { hostname } = new URL(baseUrl);
+      return MINIMAX_HOSTNAMES.has(hostname.toLowerCase());
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Override buildClient to apply the MiniMax default base URL when none is
+   * configured, matching the pattern used by sibling providers (DashScope, etc.).
+   */
+  override buildClient(): OpenAI {
+    const {
+      apiKey,
+      baseUrl = DEFAULT_MINIMAX_BASE_URL,
+      timeout = DEFAULT_TIMEOUT,
+      maxRetries = DEFAULT_MAX_RETRIES,
+    } = this.contentGeneratorConfig;
+    const defaultHeaders = this.buildHeaders();
+    const runtimeOptions = buildRuntimeFetchOptions(
+      'openai',
+      this.cliConfig.getProxy(),
     );
+    return new OpenAI({
+      apiKey,
+      baseURL: baseUrl,
+      timeout,
+      maxRetries,
+      defaultHeaders,
+      ...(runtimeOptions || {}),
+    });
   }
 
   /**
@@ -56,8 +88,8 @@ export class MiniMaxOpenAICompatibleProvider extends DefaultOpenAICompatibleProv
 
   /**
    * Build a MiniMax-compatible request by:
-   * 1. Ensuring temperature is within the allowed range (0.0, 1.0]
-   * 2. Removing unsupported `response_format` parameter
+   * 1. Removing the unsupported `response_format` parameter
+   * 2. Ensuring temperature is within the allowed range (0.0, 1.0]
    */
   override buildRequest(
     request: OpenAI.Chat.ChatCompletionCreateParams,
@@ -65,19 +97,15 @@ export class MiniMaxOpenAICompatibleProvider extends DefaultOpenAICompatibleProv
   ): OpenAI.Chat.ChatCompletionCreateParams {
     const baseRequest = super.buildRequest(request, userPromptId);
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const result: any = { ...baseRequest };
+    // Remove unsupported response_format via typed destructuring (no `any` cast)
+    const { response_format: _rf, ...rest } = baseRequest;
 
-    // MiniMax does not support temperature = 0; default to 1.0
-    if (result.temperature === 0 || result.temperature === undefined) {
-      result.temperature = 1.0;
-    }
+    // MiniMax does not accept temperature = 0 or null; default to 1.0
+    const temperature =
+      rest.temperature == null || rest.temperature === 0
+        ? 1.0
+        : rest.temperature;
 
-    // MiniMax does not support response_format
-    if ('response_format' in result) {
-      delete result.response_format;
-    }
-
-    return result as OpenAI.Chat.ChatCompletionCreateParams;
+    return { ...rest, temperature };
   }
 }

--- a/packages/core/src/core/openaiContentGenerator/provider/minimax.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/minimax.ts
@@ -49,7 +49,10 @@ export class MiniMaxOpenAICompatibleProvider extends DefaultOpenAICompatibleProv
     try {
       const { hostname } = new URL(baseUrl);
       return MINIMAX_HOSTNAMES.has(hostname.toLowerCase());
-    } catch {
+    } catch (e) {
+      debugLogger.debug(
+        `isMiniMaxProvider: failed to parse baseUrl "${baseUrl}": ${e}`,
+      );
       return false;
     }
   }
@@ -109,14 +112,21 @@ export class MiniMaxOpenAICompatibleProvider extends DefaultOpenAICompatibleProv
     const { response_format: _rf, ...rest } = baseRequest;
 
     // MiniMax accepts temperature only in (0.0, 1.0]; rewrite invalid values.
+    // The `!(original > 0)` check catches negative numbers and NaN in a single
+    // comparison (since `NaN > 0` is `false`).
     const original = rest.temperature;
     let temperature: number;
-    if (original == null || original === 0) {
+    if (original == null || !(original > 0)) {
       temperature = 1.0;
       if (original === 0) {
         // Only log when the user explicitly set 0; null/undefined is a default fill.
         debugLogger.debug(
           `temperature=0 is not supported; using 1.0 instead (request ${userPromptId})`,
+        );
+      } else if (typeof original === 'number') {
+        // Negative or NaN — log because the user passed something explicit.
+        debugLogger.debug(
+          `temperature=${original} is out of (0.0, 1.0]; using 1.0 instead (request ${userPromptId})`,
         );
       }
     } else if (original > 1.0) {

--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -311,6 +311,9 @@ describe('tokenLimit with output type', () => {
     it('should return correct output limits for MiniMax', () => {
       expect(tokenLimit('MiniMax-M3', 'output')).toBe(131072);
       expect(tokenLimit('MiniMax-M2.7', 'output')).toBe(65536);
+      expect(tokenLimit('MiniMax-M2.5', 'output')).toBe(65536);
+      // Fallback for unknown MiniMax variants (e.g. future M3-turbo, M4)
+      expect(tokenLimit('MiniMax-future-variant', 'output')).toBe(65536);
     });
 
     it('should return correct output limits for Kimi', () => {

--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -193,12 +193,13 @@ describe('tokenLimit', () => {
   });
 
   describe('MiniMax', () => {
-    it('should return 196608 for MiniMax-M2.5 (latest)', () => {
-      expect(tokenLimit('MiniMax-M2.5')).toBe(196608);
+    it('should return 512K for MiniMax-M3 (latest)', () => {
+      expect(tokenLimit('MiniMax-M3')).toBe(524288);
     });
 
-    it('should return 200K for MiniMax fallback', () => {
-      expect(tokenLimit('MiniMax-M2.1')).toBe(200000);
+    it('should return 200K for MiniMax fallback (M2.7 / M2.7-highspeed)', () => {
+      expect(tokenLimit('MiniMax-M2.7')).toBe(200000);
+      expect(tokenLimit('MiniMax-M2.7-highspeed')).toBe(200000);
     });
   });
 
@@ -308,7 +309,8 @@ describe('tokenLimit with output type', () => {
     });
 
     it('should return correct output limits for MiniMax', () => {
-      expect(tokenLimit('MiniMax-M2.5', 'output')).toBe(65536);
+      expect(tokenLimit('MiniMax-M3', 'output')).toBe(131072);
+      expect(tokenLimit('MiniMax-M2.7', 'output')).toBe(65536);
     });
 
     it('should return correct output limits for Kimi', () => {

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -136,7 +136,7 @@ const PATTERNS: Array<[RegExp, TokenCount]> = [
   // -------------------
   // MiniMax
   // -------------------
-  [/^minimax-m2\.7/i, LIMITS['200k']], // MiniMax-M2.7: 200K
+  [/^minimax-m2\.7/i, LIMITS['200k']], // MiniMax-M2.7 / M2.7-highspeed: 200K
   [/^minimax-m2\.5/i, LIMITS['192k']], // MiniMax-M2.5: 196,608
   [/^minimax-/i, LIMITS['200k']], // MiniMax fallback: 200K
 
@@ -186,7 +186,7 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
   [/^glm-4\.7/, LIMITS['16k']],
 
   // MiniMax
-  [/^minimax-m2\.7/i, LIMITS['64k']], // MiniMax-M2.7: 64K output
+  [/^minimax-m2\.7/i, LIMITS['64k']], // MiniMax-M2.7 / M2.7-highspeed: 64K output
   [/^minimax-m2\.5/i, LIMITS['64k']],
 
   // Kimi

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -136,6 +136,7 @@ const PATTERNS: Array<[RegExp, TokenCount]> = [
   // -------------------
   // MiniMax
   // -------------------
+  [/^minimax-m2\.7/i, LIMITS['200k']], // MiniMax-M2.7: 200K
   [/^minimax-m2\.5/i, LIMITS['192k']], // MiniMax-M2.5: 196,608
   [/^minimax-/i, LIMITS['200k']], // MiniMax fallback: 200K
 
@@ -185,6 +186,7 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
   [/^glm-4\.7/, LIMITS['16k']],
 
   // MiniMax
+  [/^minimax-m2\.7/i, LIMITS['64k']], // MiniMax-M2.7: 64K output
   [/^minimax-m2\.5/i, LIMITS['64k']],
 
   // Kimi

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -136,9 +136,8 @@ const PATTERNS: Array<[RegExp, TokenCount]> = [
   // -------------------
   // MiniMax
   // -------------------
-  [/^minimax-m2\.7/i, LIMITS['200k']], // MiniMax-M2.7 / M2.7-highspeed: 200K
   [/^minimax-m2\.5/i, LIMITS['192k']], // MiniMax-M2.5: 196,608
-  [/^minimax-/i, LIMITS['200k']], // MiniMax fallback: 200K
+  [/^minimax-/i, LIMITS['200k']], // MiniMax fallback (M2.7 / M2.7-highspeed / others): 200K
 
   // -------------------
   // Moonshot / Kimi

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -187,6 +187,8 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
   // MiniMax
   [/^minimax-m3/i, LIMITS['128k']], // MiniMax-M3: 128K output
   [/^minimax-m2\.7/i, LIMITS['64k']], // MiniMax-M2.7 / M2.7-highspeed: 64K output
+  [/^minimax-m2\.5/i, LIMITS['64k']], // MiniMax-M2.5: 64K output
+  [/^minimax-/i, LIMITS['64k']], // MiniMax fallback: 64K output
 
   // Kimi
   [/^kimi-k2\.5/, LIMITS['32k']],

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -28,7 +28,7 @@ const LIMITS = {
   '32k': 32_768,
   '64k': 65_536,
   '128k': 131_072,
-  '192k': 196_608, // MiniMax-M2.5 context window
+  '192k': 196_608,
   '200k': 200_000, // vendor-declared decimal, used by OpenAI, Anthropic, etc.
   '256k': 262_144,
   '272k': 272_000, // vendor-declared decimal, GPT-5.x input (400K total - 128K output)
@@ -136,8 +136,8 @@ const PATTERNS: Array<[RegExp, TokenCount]> = [
   // -------------------
   // MiniMax
   // -------------------
-  [/^minimax-m2\.5/i, LIMITS['192k']], // MiniMax-M2.5: 196,608
-  [/^minimax-/i, LIMITS['200k']], // MiniMax fallback (M2.7 / M2.7-highspeed / others): 200K
+  [/^minimax-m3/i, LIMITS['512k']], // MiniMax-M3: 512K
+  [/^minimax-/i, LIMITS['200k']], // MiniMax fallback (M2.7 / M2.7-highspeed): 200K
 
   // -------------------
   // Moonshot / Kimi
@@ -185,8 +185,8 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
   [/^glm-4\.7/, LIMITS['16k']],
 
   // MiniMax
+  [/^minimax-m3/i, LIMITS['128k']], // MiniMax-M3: 128K output
   [/^minimax-m2\.7/i, LIMITS['64k']], // MiniMax-M2.7 / M2.7-highspeed: 64K output
-  [/^minimax-m2\.5/i, LIMITS['64k']],
 
   // Kimi
   [/^kimi-k2\.5/, LIMITS['32k']],

--- a/packages/vscode-ide-companion/src/utils/tokenLimits.ts
+++ b/packages/vscode-ide-companion/src/utils/tokenLimits.ts
@@ -122,7 +122,7 @@ const INPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
   [/^glm-/, 202_752 as TokenCount],
 
   // MiniMax
-  [/^minimax-m2\.5/i, LIMITS['192k']],
+  [/^minimax-m3/i, LIMITS['512k']],
   [/^minimax-/i, LIMITS['200k']],
 
   // Moonshot / Kimi
@@ -159,7 +159,8 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
   [/^glm-5/, LIMITS['16k']],
   [/^glm-4\.7/, LIMITS['16k']],
 
-  [/^minimax-m2\.5/i, LIMITS['64k']],
+  [/^minimax-m3/i, LIMITS['128k']],
+  [/^minimax-m2\.7/i, LIMITS['64k']],
 
   [/^kimi-k2\.5/, LIMITS['32k']],
 ];

--- a/packages/vscode-ide-companion/src/utils/tokenLimits.ts
+++ b/packages/vscode-ide-companion/src/utils/tokenLimits.ts
@@ -161,6 +161,8 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
 
   [/^minimax-m3/i, LIMITS['128k']],
   [/^minimax-m2\.7/i, LIMITS['64k']],
+  [/^minimax-m2\.5/i, LIMITS['64k']],
+  [/^minimax-/i, LIMITS['64k']],
 
   [/^kimi-k2\.5/, LIMITS['32k']],
 ];


### PR DESCRIPTION
## Summary

This PR adds MiniMax as an OpenAI-compatible provider for Qwen Code, with **MiniMax-M3** wired up as the default model.

### Changes

- **New provider**: `MiniMaxOpenAICompatibleProvider` extending `DefaultOpenAICompatibleProvider`
  - Default base URL applied in `buildClient()` override (matches sibling provider pattern)
  - Supports `api.minimaxi.com` as an alternative (domestic mirror)
  - **URL detection** uses `new URL(baseUrl).hostname` to prevent substring false-positives (fixes CodeQL warnings)
  - **Temperature**: guards against `null` per SDK types (`number | null | undefined`); clamps values above `1.0` down to `1.0` with a debug log
  - **`response_format`**: removed via typed destructuring — no `any` cast or `delete`
- **Token limits** (`tokenLimits.ts` and `vscode-ide-companion/.../tokenLimits.ts`):
  - `MiniMax-M3`: 512K input, 128K output
  - `MiniMax-M2.7` / `M2.7-highspeed` fallback: 200K input, 64K output
- **Modality**: `MiniMax-M3` enables image input; M2.7 stays text-only
- **Documentation**: MiniMax section in `docs/users/configuration/model-providers.md` lists M3 as the default plus M2.7 / M2.7-highspeed for users who want the previous generation
- **Tests**: 15 unit tests including null-temperature, hostname-spoofing, M3 input/output limits, and the M3 image-modality default

### Supported Models

| Model ID | Description |
|----------|-------------|
| `MiniMax-M3` (default) | Latest model — 512K context, up to 128K output, supports image input |
| `MiniMax-M2.7` | Peak Performance, Ultimate Value — previous generation |
| `MiniMax-M2.7-highspeed` | Same performance, faster and more agile |

### API References

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api
- Pricing: https://platform.minimax.io/docs/guides/pricing-paygo