### PR TITLE
feat(lsp): use official LSP SDK and implement didSave for real-time diagnostics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16254,6 +16254,31 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
     "node_modules/vscode-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -17637,6 +17662,7 @@
         "tar": "^7.5.2",
         "undici": "^6.22.0",
         "uuid": "^9.0.1",
+        "vscode-languageserver-protocol": "^3.17.5",
         "web-tree-sitter": "^0.24.7",
         "ws": "^8.18.0"
       },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -70,6 +70,7 @@
     "tar": "^7.5.2",
     "undici": "^6.22.0",
     "uuid": "^9.0.1",
+    "vscode-languageserver-protocol": "^3.17.5",
     "web-tree-sitter": "^0.24.7",
     "ws": "^8.18.0"
   },

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -43,6 +43,7 @@ import type { HookExecutionResponse } from '../confirmation-bus/types.js';
 import { type NotificationType } from '../hooks/types.js';
 import type { MessageBus } from '../confirmation-bus/message-bus.js';
 import { IdeClient } from '../ide/ide-client.js';
+import { pathToFileURL } from 'node:url';
 
 vi.mock('fs/promises', () => ({
   writeFile: vi.fn(),
@@ -3625,5 +3626,185 @@ describe('CoreToolScheduler IDE interaction', () => {
     // Tool should be awaiting approval but openDiff was never called
     await waitForStatus(onToolCallsUpdate, 'awaiting_approval');
     expect(mockIdeClient.openDiff).not.toHaveBeenCalled();
+  });
+});
+
+describe('LSP Integration', () => {
+  // Helper function to create mock LSP client
+  const createMockLspClient = () => ({
+    notifyDocumentSaved: vi.fn().mockResolvedValue(undefined),
+  });
+
+  // Helper function to create mock config with optional LSP client
+  const createLspMockConfig = (
+    mockToolRegistry: ToolRegistry,
+    mockLspClient?: { notifyDocumentSaved: ReturnType<typeof vi.fn> },
+  ) =>
+    ({
+      getSessionId: () => 'test-session-id',
+      getUsageStatisticsEnabled: () => true,
+      getDebugMode: () => false,
+      getApprovalMode: () => ApprovalMode.YOLO,
+      getPermissionsAllow: () => [],
+      getContentGeneratorConfig: () => ({
+        model: 'test-model',
+        authType: 'gemini',
+      }),
+      getShellExecutionConfig: () => ({
+        terminalWidth: 90,
+        terminalHeight: 30,
+      }),
+      storage: {
+        getProjectTempDir: () => '/tmp',
+      },
+      getTruncateToolOutputThreshold: () => 500,
+      getTruncateToolOutputLines: () => 100,
+      getToolRegistry: () => mockToolRegistry,
+      getUseModelRouter: () => false,
+      getGeminiClient: () => null,
+      isInteractive: () => true,
+      getMessageBus: vi.fn().mockReturnValue(undefined),
+      getDisableAllHooks: vi.fn().mockReturnValue(true),
+      getLspClient: () => mockLspClient,
+      getChatRecordingService: () => undefined,
+    }) as unknown as Config;
+
+  it('should call notifyDocumentSaved after edit tool execution', async () => {
+    const mockLspClient = createMockLspClient();
+    const mockEditTool = new MockTool({
+      name: 'edit',
+      description: 'Edit a file',
+      kind: Kind.Edit,
+      execute: async (params: { [key: string]: unknown }) => ({
+        llmContent: `File ${params['file_path']} edited successfully.`,
+        returnDisplay: `File edited.`,
+      }),
+    });
+
+    const mockToolRegistry = {
+      getTool: vi.fn((name) => (name === 'edit' ? mockEditTool : null)),
+      getAllToolNames: vi.fn(() => ['edit']),
+      registerTool: vi.fn(),
+    } as unknown as ToolRegistry;
+
+    const mockConfig = createLspMockConfig(mockToolRegistry, mockLspClient);
+    const onAllToolCallsComplete = vi.fn();
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      onAllToolCallsComplete,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    const filePath = '/test/workspace/example.ts';
+    const request = {
+      callId: 'edit-1',
+      name: 'edit',
+      args: {
+        file_path: filePath,
+        old_string: 'old',
+        new_string: 'new',
+      },
+      isClientInitiated: false,
+      prompt_id: 'prompt-edit-1',
+    };
+
+    const abortController = new AbortController();
+    await scheduler.schedule([request], abortController.signal);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // Use pathToFileURL to ensure cross-platform compatibility
+    const expectedUri = pathToFileURL(filePath).toString();
+    expect(mockLspClient.notifyDocumentSaved).toHaveBeenCalledTimes(1);
+    expect(mockLspClient.notifyDocumentSaved).toHaveBeenCalledWith(expectedUri);
+  });
+
+  it('should not call notifyDocumentSaved for non-edit tools', async () => {
+    const mockLspClient = createMockLspClient();
+    const mockReadTool = new MockTool({
+      name: 'read_file',
+      description: 'Read a file',
+      kind: Kind.Read,
+      execute: async (params: { [key: string]: unknown }) => ({
+        llmContent: `File ${params['file_path']} content`,
+        returnDisplay: `File read.`,
+      }),
+    });
+
+    const mockToolRegistry = {
+      getTool: vi.fn((name) => (name === 'read_file' ? mockReadTool : null)),
+      getAllToolNames: vi.fn(() => ['read_file']),
+      registerTool: vi.fn(),
+    } as unknown as ToolRegistry;
+
+    const mockConfig = createLspMockConfig(mockToolRegistry, mockLspClient);
+    const onAllToolCallsComplete = vi.fn();
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      onAllToolCallsComplete,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    const request = {
+      callId: 'read-1',
+      name: 'read_file',
+      args: { file_path: '/test/workspace/example.ts' },
+      isClientInitiated: false,
+      prompt_id: 'prompt-read-1',
+    };
+
+    const abortController = new AbortController();
+    await scheduler.schedule([request], abortController.signal);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(mockLspClient.notifyDocumentSaved).not.toHaveBeenCalled();
+  });
+
+  it('should handle missing LSP client gracefully', async () => {
+    const mockEditTool = new MockTool({
+      name: 'edit',
+      description: 'Edit a file',
+      kind: Kind.Edit,
+      execute: async (params: { [key: string]: unknown }) => ({
+        llmContent: `File ${params['file_path']} edited successfully.`,
+        returnDisplay: `File edited.`,
+      }),
+    });
+
+    const mockToolRegistry = {
+      getTool: vi.fn((name) => (name === 'edit' ? mockEditTool : null)),
+      getAllToolNames: vi.fn(() => ['edit']),
+      registerTool: vi.fn(),
+    } as unknown as ToolRegistry;
+
+    // No LSP client
+    const mockConfig = createLspMockConfig(mockToolRegistry);
+    const onAllToolCallsComplete = vi.fn();
+    const scheduler = new CoreToolScheduler({
+      config: mockConfig,
+      onAllToolCallsComplete,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    const request = {
+      callId: 'edit-2',
+      name: 'edit',
+      args: {
+        file_path: '/test/workspace/example.ts',
+        old_string: 'old',
+        new_string: 'new',
+      },
+      isClientInitiated: false,
+      prompt_id: 'prompt-edit-2',
+    };
+
+    const abortController = new AbortController();
+    await expect(
+      scheduler.schedule([request], abortController.signal),
+    ).resolves.toBeUndefined();
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
   });
 });

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -18,6 +18,7 @@ import type {
   AnyToolInvocation,
   ChatRecordingService,
 } from '../index.js';
+import { pathToFileURL } from 'url';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import {
   generateToolUseId,
@@ -1365,7 +1366,7 @@ export class CoreToolScheduler {
     const scheduledCall = toolCall;
     const { callId, name: toolName } = scheduledCall.request;
     const invocation = scheduledCall.invocation;
-    const toolInput = scheduledCall.request.args as Record<string, unknown>;
+    const toolInput = scheduledCall.request.args;
 
     // Generate unique tool_use_id for hook tracking
     const toolUseId = generateToolUseId();
@@ -1517,6 +1518,19 @@ export class CoreToolScheduler {
             );
             this.setStatusInternal(callId, 'error', errorResponse);
             return;
+          }
+        }
+
+        // Notify LSP servers if this was a file edit operation
+        // Goes after hooks because hook may modify the content too.
+        if (scheduledCall.tool.kind === Kind.Edit) {
+          const filePath = toolInput['file_path'] as string | undefined;
+          if (filePath && typeof filePath === 'string') {
+            const uri = pathToFileURL(filePath).toString();
+            const lspClient = this.config.getLspClient();
+            if (lspClient) {
+              await lspClient.notifyDocumentSaved(uri);
+            }
           }
         }
 

--- a/packages/core/src/lsp/LspConnectionFactory.ts
+++ b/packages/core/src/lsp/LspConnectionFactory.ts
@@ -6,6 +6,7 @@
 
 import * as cp from 'node:child_process';
 import * as net from 'node:net';
+import type * as lsp from 'vscode-languageserver-protocol';
 import { DEFAULT_LSP_REQUEST_TIMEOUT_MS } from './constants.js';
 import type { JsonRpcMessage } from './types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
@@ -55,8 +56,11 @@ class JsonRpcConnection {
     this.requestHandlers.push(handler);
   }
 
-  async initialize(params: unknown): Promise<unknown> {
-    return this.sendRequest('initialize', params);
+  async initialize(params: lsp.InitializeParams) {
+    return (await this.sendRequest(
+      'initialize',
+      params,
+    )) as lsp.InitializeResult;
   }
 
   async shutdown(): Promise<void> {

--- a/packages/core/src/lsp/LspServerManager.ts
+++ b/packages/core/src/lsp/LspServerManager.ts
@@ -7,6 +7,7 @@
 import type { Config as CoreConfig } from '../config/config.js';
 import type { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import type { WorkspaceContext } from '../utils/workspaceContext.js';
+import type * as lsp from 'vscode-languageserver-protocol';
 import { spawn, type ChildProcess } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'path';
@@ -265,7 +266,7 @@ export class LspServerManager {
       handle.process = connection.process;
 
       // Initialize LSP server
-      await this.initializeLspServer(connection, handle.config);
+      await this.initializeLspServer(connection, handle);
 
       handle.status = 'READY';
       this.attachRestartHandler(name, handle);
@@ -449,8 +450,7 @@ export class LspServerManager {
           }
           lspConnection.connection.end();
         },
-        initialize: async (params: unknown) =>
-          lspConnection.connection.initialize(params),
+        initialize: (params) => lspConnection.connection.initialize(params),
       };
     } else if (config.transport === 'tcp' || config.transport === 'socket') {
       if (!config.socket) {
@@ -487,8 +487,7 @@ export class LspServerManager {
           exit: () => {
             lspConnection.connection.end();
           },
-          initialize: async (params: unknown) =>
-            lspConnection.connection.initialize(params),
+          initialize: (params) => lspConnection.connection.initialize(params),
         };
       } catch (error) {
         if (process && process.exitCode === null) {
@@ -506,21 +505,23 @@ export class LspServerManager {
    */
   private async initializeLspServer(
     connection: LspConnectionResult,
-    config: LspServerConfig,
+    handle: LspServerHandle,
   ): Promise<void> {
+    const config = handle.config;
     const workspaceFolderPath = config.workspaceFolder ?? this.workspaceRoot;
     const workspaceFolder = {
       name: path.basename(workspaceFolderPath) || workspaceFolderPath,
       uri: config.rootUri,
     };
 
-    const initializeParams = {
+    const initializeParams: lsp.InitializeParams = {
       processId: process.pid,
       rootUri: config.rootUri,
       rootPath: workspaceFolderPath,
       workspaceFolders: [workspaceFolder],
       capabilities: {
         textDocument: {
+          synchronization: { didSave: true },
           completion: { dynamicRegistration: true },
           hover: { dynamicRegistration: true },
           definition: { dynamicRegistration: true },
@@ -535,7 +536,14 @@ export class LspServerManager {
       initializationOptions: config.initializationOptions,
     };
 
-    await connection.initialize(initializeParams);
+    const result = await connection.initialize(initializeParams);
+
+    // Store server capabilities for later use (e.g., checking didSave support)
+    handle.serverCapabilities = result.capabilities;
+    debugLogger.debug(
+      `Server '${config.name}' capabilities:`,
+      JSON.stringify(result.capabilities, null, 2),
+    );
 
     // Send initialized notification and workspace folders change to help servers (e.g. tsserver)
     // create projects in the correct workspace.

--- a/packages/core/src/lsp/NativeLspClient.ts
+++ b/packages/core/src/lsp/NativeLspClient.ts
@@ -256,4 +256,15 @@ export class NativeLspClient implements LspClient {
   ): Promise<boolean> {
     return this.service.applyWorkspaceEdit(edit, serverName);
   }
+
+  /**
+   * Notify LSP servers that a document has been saved.
+   * This triggers servers to re-read the file from disk and update diagnostics.
+   *
+   * @param uri - The document URI (file:// path)
+   * @param serverName - Optional specific LSP server to notify
+   */
+  notifyDocumentSaved(uri: string, serverName?: string): Promise<void> {
+    return this.service.notifyDocumentSaved(uri, serverName);
+  }
 }

--- a/packages/core/src/lsp/NativeLspService.test.ts
+++ b/packages/core/src/lsp/NativeLspService.test.ts
@@ -1099,4 +1099,255 @@ describe('NativeLspService', () => {
       fs.rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  describe('notifyDocumentSaved', () => {
+    test('should send didSave notification to servers that support it', async () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lsp-save-'));
+      const filePath = path.join(tempDir, 'test.ts');
+      fs.writeFileSync(filePath, 'const x = 1;', 'utf-8');
+      const uri = pathToFileURL(filePath).toString();
+
+      const sentMessages: Array<{ method: string; params: unknown }> = [];
+      const connection = {
+        send: vi.fn((message: { method: string; params?: unknown }) => {
+          sentMessages.push({ method: message.method, params: message.params });
+        }),
+      };
+
+      const handle = {
+        config: { name: 'tsserver', languages: ['typescript'] },
+        status: 'READY' as const,
+        connection,
+        serverCapabilities: {
+          textDocumentSync: { save: { includeText: false } },
+        },
+      };
+
+      const serverManager = {
+        getHandles: () => new Map([['tsserver', handle]]),
+      };
+
+      const service = new NativeLspService(
+        mockConfig as unknown as CoreConfig,
+        mockWorkspace as unknown as WorkspaceContext,
+        eventEmitter,
+        mockFileDiscovery as unknown as FileDiscoveryService,
+        mockIdeStore as unknown as IdeContextStore,
+      );
+      (service as unknown as { serverManager: unknown }).serverManager =
+        serverManager;
+
+      await service.notifyDocumentSaved(uri);
+
+      expect(connection.send).toHaveBeenCalledTimes(1);
+      expect(sentMessages[0]).toEqual({
+        method: 'textDocument/didSave',
+        params: { textDocument: { uri } },
+      });
+
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    test('should not send didSave when server does not support it', async () => {
+      const uri = 'file:///test/workspace/test.ts';
+
+      const connection = { send: vi.fn() };
+      const handle = {
+        config: { name: 'some-server', languages: ['typescript'] },
+        status: 'READY' as const,
+        connection,
+        serverCapabilities: {
+          textDocumentSync: 0, // TextDocumentSyncKind.None
+        },
+      };
+
+      const serverManager = {
+        getHandles: () => new Map([['some-server', handle]]),
+      };
+
+      const service = new NativeLspService(
+        mockConfig as unknown as CoreConfig,
+        mockWorkspace as unknown as WorkspaceContext,
+        eventEmitter,
+        mockFileDiscovery as unknown as FileDiscoveryService,
+        mockIdeStore as unknown as IdeContextStore,
+      );
+      (service as unknown as { serverManager: unknown }).serverManager =
+        serverManager;
+
+      await service.notifyDocumentSaved(uri);
+
+      expect(connection.send).not.toHaveBeenCalled();
+    });
+
+    test('should send didSave when textDocumentSync is a number (Full or Incremental)', async () => {
+      const uri = 'file:///test/workspace/test.ts';
+
+      const sentMessages: Array<{ method: string }> = [];
+      const connection = {
+        send: vi.fn((message: { method: string }) => {
+          sentMessages.push({ method: message.method });
+        }),
+      };
+
+      // TextDocumentSyncKind.Full (1)
+      const handle = {
+        config: { name: 'clangd', languages: ['cpp'] },
+        status: 'READY' as const,
+        connection,
+        serverCapabilities: {
+          textDocumentSync: 1, // TextDocumentSyncKind.Full
+        },
+      };
+
+      const serverManager = {
+        getHandles: () => new Map([['clangd', handle]]),
+      };
+
+      const service = new NativeLspService(
+        mockConfig as unknown as CoreConfig,
+        mockWorkspace as unknown as WorkspaceContext,
+        eventEmitter,
+        mockFileDiscovery as unknown as FileDiscoveryService,
+        mockIdeStore as unknown as IdeContextStore,
+      );
+      (service as unknown as { serverManager: unknown }).serverManager =
+        serverManager;
+
+      await service.notifyDocumentSaved(uri);
+
+      expect(connection.send).toHaveBeenCalledTimes(1);
+      expect(sentMessages[0].method).toBe('textDocument/didSave');
+    });
+
+    test('should send didSave when save capability is true (boolean)', async () => {
+      const uri = 'file:///test/workspace/test.ts';
+
+      const sentMessages: Array<{ method: string }> = [];
+      const connection = {
+        send: vi.fn((message: { method: string }) => {
+          sentMessages.push({ method: message.method });
+        }),
+      };
+
+      const handle = {
+        config: { name: 'pyright', languages: ['python'] },
+        status: 'READY' as const,
+        connection,
+        serverCapabilities: {
+          textDocumentSync: { save: true },
+        },
+      };
+
+      const serverManager = {
+        getHandles: () => new Map([['pyright', handle]]),
+      };
+
+      const service = new NativeLspService(
+        mockConfig as unknown as CoreConfig,
+        mockWorkspace as unknown as WorkspaceContext,
+        eventEmitter,
+        mockFileDiscovery as unknown as FileDiscoveryService,
+        mockIdeStore as unknown as IdeContextStore,
+      );
+      (service as unknown as { serverManager: unknown }).serverManager =
+        serverManager;
+
+      await service.notifyDocumentSaved(uri);
+
+      expect(connection.send).toHaveBeenCalledTimes(1);
+      expect(sentMessages[0].method).toBe('textDocument/didSave');
+    });
+
+    test('should send didSave to specific server when serverName is provided', async () => {
+      const uri = 'file:///test/workspace/test.ts';
+
+      const server1Sent: Array<{ method: string }> = [];
+      const server2Sent: Array<{ method: string }> = [];
+
+      const connection1 = {
+        send: vi.fn((message: { method: string }) => {
+          server1Sent.push({ method: message.method });
+        }),
+      };
+      const connection2 = {
+        send: vi.fn((message: { method: string }) => {
+          server2Sent.push({ method: message.method });
+        }),
+      };
+
+      const handle1 = {
+        config: { name: 'server1', languages: ['typescript'] },
+        status: 'READY' as const,
+        connection: connection1,
+        serverCapabilities: { textDocumentSync: { save: true } },
+      };
+      const handle2 = {
+        config: { name: 'server2', languages: ['python'] },
+        status: 'READY' as const,
+        connection: connection2,
+        serverCapabilities: { textDocumentSync: { save: true } },
+      };
+
+      const serverManager = {
+        getHandles: () =>
+          new Map([
+            ['server1', handle1],
+            ['server2', handle2],
+          ]),
+      };
+
+      const service = new NativeLspService(
+        mockConfig as unknown as CoreConfig,
+        mockWorkspace as unknown as WorkspaceContext,
+        eventEmitter,
+        mockFileDiscovery as unknown as FileDiscoveryService,
+        mockIdeStore as unknown as IdeContextStore,
+      );
+      (service as unknown as { serverManager: unknown }).serverManager =
+        serverManager;
+
+      // Only notify server1
+      await service.notifyDocumentSaved(uri, 'server1');
+
+      expect(connection1.send).toHaveBeenCalledTimes(1);
+      expect(connection2.send).not.toHaveBeenCalled();
+      expect(server1Sent[0].method).toBe('textDocument/didSave');
+    });
+
+    test('should handle connection errors gracefully', async () => {
+      const uri = 'file:///test/workspace/test.ts';
+
+      const connection = {
+        send: vi.fn(() => {
+          throw new Error('Connection failed');
+        }),
+      };
+
+      const handle = {
+        config: { name: 'error-server', languages: ['typescript'] },
+        status: 'READY' as const,
+        connection,
+        serverCapabilities: { textDocumentSync: { save: true } },
+      };
+
+      const serverManager = {
+        getHandles: () => new Map([['error-server', handle]]),
+      };
+
+      const service = new NativeLspService(
+        mockConfig as unknown as CoreConfig,
+        mockWorkspace as unknown as WorkspaceContext,
+        eventEmitter,
+        mockFileDiscovery as unknown as FileDiscoveryService,
+        mockIdeStore as unknown as IdeContextStore,
+      );
+      (service as unknown as { serverManager: unknown }).serverManager =
+        serverManager;
+
+      // Should not throw
+      await expect(service.notifyDocumentSaved(uri)).resolves.toBeUndefined();
+      expect(connection.send).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/packages/core/src/lsp/NativeLspService.ts
+++ b/packages/core/src/lsp/NativeLspService.ts
@@ -27,6 +27,7 @@ import type {
   LspWorkspaceEdit,
 } from './types.js';
 import type { EventEmitter } from 'events';
+import type * as lsp from 'vscode-languageserver-protocol';
 import {
   DEFAULT_LSP_DOCUMENT_OPEN_DELAY_MS,
   DEFAULT_LSP_DOCUMENT_RETRY_DELAY_MS,
@@ -1219,6 +1220,81 @@ export class NativeLspService {
       debugLogger.error('Failed to apply workspace edit:', error);
       return false;
     }
+  }
+
+  /**
+   * Notify LSP servers that a document has been saved.
+   * This sends textDocument/didSave to all ready servers that support it,
+   * triggering them to re-read the file from disk and update their internal state.
+   *
+   * @param uri - The document URI (file:// path)
+   * @param serverName - Optional specific server to notify
+   */
+  async notifyDocumentSaved(uri: string, serverName?: string): Promise<void> {
+    const handles = this.getReadyHandles(serverName);
+
+    for (const [name, handle] of handles) {
+      try {
+        // Check if server supports didSave notification
+        const saveCap = this.getSaveCapability(handle);
+        if (!saveCap) {
+          debugLogger.debug(
+            `Server ${name} does not support didSave, skipping`,
+          );
+          continue;
+        }
+
+        const params: lsp.DidSaveTextDocumentParams = {
+          textDocument: { uri },
+        };
+
+        // We don't support saveCap.includeText, because we don't have
+        // the file content at hand (can be modified by hooks).
+        // Let LSP read the file itself.
+        handle.connection.send({
+          jsonrpc: '2.0',
+          method: 'textDocument/didSave',
+          params,
+        });
+      } catch (error) {
+        debugLogger.warn(
+          `Failed to send didSave notification to ${name}:`,
+          error,
+        );
+      }
+    }
+  }
+
+  /**
+   * Get the save capability from server capabilities.
+   * Returns undefined if not supported, SaveOptions if supported.
+   */
+  private getSaveCapability(
+    handle: LspServerHandle,
+  ): lsp.SaveOptions | undefined {
+    const caps = handle.serverCapabilities;
+    if (!caps) {
+      // If we don't have capabilities, assume support (fallback)
+      return {};
+    }
+
+    const sync = caps.textDocumentSync;
+    if (!sync) {
+      return undefined;
+    }
+
+    // TextDocumentSyncKind (number)
+    if (typeof sync === 'number') {
+      // 0 = None already handled above.
+      // Any non-zero value means some form of sync is enabled
+      return {};
+    }
+
+    // sync is TextDocumentSyncOptions (object)
+    if (sync.save && typeof sync.save === 'object') {
+      return sync.save;
+    }
+    return sync.save ? {} : undefined;
   }
 
   /**

--- a/packages/core/src/lsp/types.ts
+++ b/packages/core/src/lsp/types.ts
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type * as lsp from 'vscode-languageserver-protocol';
+
 export interface LspPosition {
   line: number;
   character: number;
@@ -358,6 +360,12 @@ export interface LspClient {
     edit: LspWorkspaceEdit,
     serverName?: string,
   ): Promise<boolean>;
+
+  /**
+   * Notify LSP servers that a document has been saved.
+   * This triggers servers to re-read the file from disk and update diagnostics.
+   */
+  notifyDocumentSaved(uri: string, serverName?: string): Promise<void>;
 }
 
 // ============================================================================
@@ -456,7 +464,7 @@ export interface LspConnectionInterface {
   /** Send a request and wait for response */
   request: (method: string, params: unknown) => Promise<unknown>;
   /** Send initialize request */
-  initialize: (params: unknown) => Promise<unknown>;
+  initialize: (params: lsp.InitializeParams) => Promise<lsp.InitializeResult>;
   /** Send shutdown request */
   shutdown: () => Promise<void>;
   /** End the connection */
@@ -494,6 +502,8 @@ export interface LspServerHandle {
   restartAttempts?: number;
   /** Lock to prevent concurrent startup attempts */
   startingPromise?: Promise<void>;
+  /** Server capabilities returned from initialize */
+  serverCapabilities?: lsp.ServerCapabilities;
 }
 
 /**
@@ -519,5 +529,5 @@ export interface LspConnectionResult {
   /** Force exit the connection */
   exit: () => void;
   /** Send initialize request */
-  initialize: (params: unknown) => Promise<unknown>;
+  initialize: (params: lsp.InitializeParams) => Promise<lsp.InitializeResult>;
 }

--- a/packages/core/src/test-utils/mock-tool.ts
+++ b/packages/core/src/test-utils/mock-tool.ts
@@ -24,6 +24,7 @@ interface MockToolOptions {
   name: string;
   displayName?: string;
   description?: string;
+  kind?: Kind;
   canUpdateOutput?: boolean;
   isOutputMarkdown?: boolean;
   getDefaultPermission?: () => Promise<PermissionDecision>;
@@ -97,7 +98,7 @@ export class MockTool extends BaseDeclarativeTool<
       options.name,
       options.displayName ?? options.name,
       options.description ?? options.name,
-      Kind.Other,
+      options.kind ?? Kind.Other,
       options.params,
       options.isOutputMarkdown ?? false,
       options.canUpdateOutput ?? false,


### PR DESCRIPTION
## TLDR

Integrate official vscode-languageserver-protocol SDK for LSP types and implement textDocument/didSave notification to enable real-time diagnostics updates after file edits.

## Screenshots / Video Demo

N/A — this is an internal infrastructure change. The effect is that LSP diagnostics now update immediately after edits are applied.

## Dive Deeper

### Problem
Previously, after applying code edits via the Edit tool, LSP diagnostics would not update until the user manually triggered a refresh. This made it difficult to verify fixes immediately.

### Solution
1. **Official LSP SDK**: Added `vscode-languageserver-protocol` dependency and use official types (`InitializeParams`, `InitializeResult`, `ServerCapabilities`) instead of custom definitions. This ensures type compatibility with the LSP specification.

2. **didSave Notification**: Implemented `notifyDocumentSaved` that sends `textDocument/didSave` to LSP servers after edits. This triggers servers (like gopls, typescript-language-server) to re-read the file from disk and update their diagnostics.

3. **Capability Handling**: 
   - Client now declares `synchronization.didSave: true` capability
   - Server capabilities are stored from `initialize` result
   - `getSaveCapability` properly handles `TextDocumentSyncOptions` and `TextDocumentSyncKind` variants

### Files Changed
- `types.ts`: Use `lsp.InitializeParams/InitializeResult/ServerCapabilities`
- `LspServerManager.ts`: Store capabilities from initialize result, declare didSave capability
- `NativeLspService.ts`: Implement `notifyDocumentSaved` and `getSaveCapability`
- `NativeLspClient.ts`: Add `notifyDocumentSaved` method
- `coreToolScheduler.ts`: Call `notifyDocumentSaved` after Edit tool execution

### Test Coverage
Added comprehensive tests for `notifyDocumentSaved`:
- Server with `save` capability (object with `includeText`)
- Server without save support (`TextDocumentSyncKind.None`)
- `textDocumentSync` as number (`Full` or `Incremental`)
- `save` capability as boolean
- Targeting specific server via `serverName` parameter
- Graceful error handling when connection fails
- Integration with `CoreToolScheduler` (edit tool triggers notification)

### Known Limitations
- Some LSP servers (e.g., `typescript-language-server`) do not support `textDocument/didSave`. For such servers, consider implementing `didChange` notifications or combining with PR #3034's `publishDiagnostics` caching approach.

## Reviewer Test Plan

1. Start qwen-code in a Go project with gopls configured
2. Use the LSP tool to get diagnostics on a file
3. Introduce a syntax error via Edit tool
4. Run diagnostics again - should immediately show the new error
5. Fix the error via Edit tool
6. Run diagnostics again - should show no errors

### Verified with gopls
Tested in a single session with edit + diagnostics invoked together:
- Introduced error: `unknown field undefinedField in struct literal`
- Diagnostics immediately detected: `[ERROR] 28:28 (MissingLitField) [compiler]: unknown field undefinedField`
- Fixed the error, diagnostics returned: `No diagnostics found`

This confirms that `didSave` notification triggers gopls to re-analyze the file and update diagnostics in real-time.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to #3029 - This PR provides an alternative approach to PR #3034 for triggering LSP diagnostics refresh after edits. While PR #3034 uses `didClose + didOpen` with `publishDiagnostics` caching, this PR uses `didSave` which is lighter and more semantically correct for post-edit updates. Both approaches are complementary: PR #3034's caching is essential for push-only servers (like typescript-language-server), while this PR's `didSave` provides a cleaner refresh mechanism for edit operations.

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)