### PR TITLE
fix(core): skip fzf index in large projects to keep @-completion responsive

### DIFF
--- a/packages/core/src/utils/filesearch/fileSearch.ts
+++ b/packages/core/src/utils/filesearch/fileSearch.ts
@@ -23,6 +23,18 @@ import { unescapePath } from '../paths.js';
  */
 const MAX_CRAWL_FILES = 100_000;
 
+/**
+ * Threshold above which we skip building the fzf fuzzy index. The fzf
+ * constructor does a synchronous `list.map(item => strToRunes(item.normalize()))`
+ * pass — roughly O(total path characters) — which blocks the UI main
+ * thread and gets visible to the user as "typing has no effect" the
+ * moment `@` triggers FileSearch.initialize(). Above this threshold we
+ * fall through to the picomatch substring filter (which is ~30× cheaper
+ * per query and yields to the event loop), at the cost of losing fuzzy
+ * scoring on result sets where it delivers little value anyway.
+ */
+const MAX_FZF_FILES = 50_000;
+
 export interface FileSearchOptions {
   projectRoot: string;
   ignoreDirs: string[];
@@ -126,13 +138,12 @@ class RecursiveFileSearch implements FileSearch {
     pattern: string,
     options: SearchOptions = {},
   ): Promise<string[]> {
-    // Check if engine is properly initialized.
-    // If fuzzy search is enabled (or undefined, default true), fzf must be initialized.
-    if (
-      !this.resultCache ||
-      (!this.fzf && this.options.enableFuzzySearch !== false) ||
-      !this.ignore
-    ) {
+    // Check if engine is properly initialized. `this.fzf` can legitimately
+    // be undefined after initialize() when the result set is above
+    // MAX_FZF_FILES — we deliberately skip fzf in that regime and let the
+    // picomatch fallback handle the query, so we can't treat a missing fzf
+    // as "not initialized".
+    if (!this.resultCache || !this.ignore) {
       throw new Error('Engine not initialized. Call initialize() first.');
     }
 
@@ -191,8 +202,13 @@ class RecursiveFileSearch implements FileSearch {
 
   private buildResultCache(): void {
     this.resultCache = new ResultCache(this.allFiles);
-    // Initialize fuzzy search if enabled (or undefined, default true).
-    if (this.options.enableFuzzySearch !== false) {
+    // Initialize fuzzy search if enabled (or undefined, default true) and
+    // the result set is small enough that the sync fzf constructor pass
+    // won't block the UI noticeably. See MAX_FZF_FILES for rationale.
+    if (
+      this.options.enableFuzzySearch !== false &&
+      this.allFiles.length <= MAX_FZF_FILES
+    ) {
       // The v1 algorithm is much faster since it only looks at the first
       // occurence of the pattern. We use it for search spaces that have >20k
       // files, because the v2 algorithm is just too slow in those cases.


### PR DESCRIPTION
## Summary

- In projects with 100k+ files, typing `@` to trigger file completion makes the input box appear unresponsive: subsequent keystrokes land in the buffer but don't appear on screen, which users experience as *"typing has no effect"*.
- Root cause is that `new AsyncFzf(allFiles)` runs a synchronous `list.map(item => strToRunes(item.normalize()))` pass over every candidate path. This is O(total path characters), blocks the UI main thread for hundreds of milliseconds, and prevents Ink from flushing renders during the window.
- Fix: skip fzf entirely when the crawl returns more than `MAX_FZF_FILES` (50,000) files and fall through to the existing picomatch substring filter path (which is ~30× cheaper per query and yields to the event loop). At that scale fuzzy scoring already delivers little value (too many candidates).

## Measurements

Reproduced in a scratch directory with 325,000 files and no `.gitignore`, driving the CLI through a pty harness that records how many milliseconds each keystroke waits before appearing in the rendered input box:

| Keystroke after `@` | Before | After |
|---|---:|---:|
| First character render lag | ~319 ms | ~202 ms |
| Subsequent characters | ~15 ms | ~15 ms |

The ~117 ms improvement is the sync cost of `new AsyncFzf(100k files)` plus the first `fzf.find()` call, both of which are now skipped. The remaining ~202 ms is `crawl()` walking the first 100k directory entries under the existing `MAX_CRAWL_FILES` cap; it can be addressed in a follow-up by pre-warming `FileSearch.initialize()` off the keystroke critical path (e.g. when `cwd` becomes stable at startup).

Control run in this repo (2,614 files, `.gitignore` in effect): no change — 17–22 ms per keystroke. The fzf path still runs unchanged for small and medium projects.

## Behaviour change

When `allFiles.length > 50,000`, the search pipeline for that workspace is silently downgraded from fzf fuzzy matching to picomatch substring matching. Consequences:

- Query `@foo` no longer gets fuzzy scoring; it becomes a case-insensitive substring match.
- Result ordering changes from fuzzy score to alphabetical (directories first) — the same ordering the existing `pattern.includes('*')` branch already produces.
- Characters that are meaningful to picomatch (`?`, `[`, `(`, etc.) are interpreted as globs — same behaviour as the existing `pattern.includes('*')` branch, so it is not a new regression.

The `enableFuzzySearch` setting still controls whether fzf is used for smaller projects; above the threshold it has no effect. If a user wants fuzzy scoring in a very large workspace, they can narrow the crawl via `.gitignore` / `.qwenignore`.

## Test plan

- [x] `packages/core/src/utils/filesearch/**` — 72/72 pass
- [x] `packages/cli/src/ui/hooks/useAtCompletion.test.ts` + `useCommandCompletion.test.ts` — 30/30 pass
- [x] Full `packages/core` suite — 5,381 pass (the 2 pre-existing env failures in `edit.test.ts` and `pathReader.test.ts` are unrelated — they reproduce on an unchanged tree and are caused by running as root, which bypasses `chmod 000`)
- [x] Manual repro via pty harness on a 325k-file tree — first character after `@` blocks **319 ms** before, **202 ms** after
- [x] Manual repro in this repo (2,614 files, `.gitignore` in effect) — unchanged: 17–22 ms per keystroke
- [x] The existing `should not use fzf for fuzzy matching when enableFuzzySearch is false` test already covers the `!this.fzf` fallback path that this change now also routes through when the file-count threshold is exceeded