### PR TITLE
fix(cli): drop stale ESC[ kitty buffer prefix so IME-committed CJK isn't lost

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -230,6 +230,79 @@ describe('KeypressContext - Kitty Protocol', () => {
       );
     });
 
+    it('preserves UTF-8 chars that arrive after a stale ESC[ prefix', async () => {
+      // Regression test for the IME drop bug observed in Ghostty + Sogou
+      // pinyin on macOS: an interrupted/stray `ESC[` lingered in the kitty
+      // sequence buffer, then the user's CJK commit (raw UTF-8 multibyte
+      // bytes) was appended. Neither parseKittyPrefix nor parsePlainTextPrefix
+      // could match (the latter rejects ESC-prefixed buffers), the loop hit
+      // its silent `return`, and 200 ms later the timeout cleared the whole
+      // buffer — the typed characters never reached the input field.
+      const keyHandler = vi.fn();
+
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper: ({ children }) =>
+          wrapper({ children, kittyProtocolEnabled: true }),
+      });
+      act(() => {
+        result.current.subscribe(keyHandler);
+      });
+
+      // Stray `ESC[` (e.g. from an interrupted escape sequence) followed
+      // immediately by CJK bytes from an IME commit.
+      act(() => {
+        stdin.sendKittySequence('\x1b[');
+      });
+      act(() => {
+        stdin.sendKittySequence('初步');
+      });
+
+      // Wait past the kitty sequence timeout to ensure the salvage path
+      // also runs.
+      await new Promise((r) => setTimeout(r, 350));
+
+      const sequences = keyHandler.mock.calls.map(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (c: any) => c[0]?.sequence,
+      );
+      expect(sequences).toContain('初');
+      expect(sequences).toContain('步');
+    });
+
+    it('salvages UTF-8 chars from a stale ESC[ buffer when the timeout fires', async () => {
+      // Same shape as above but the stray `ESC[` and the CJK bytes arrive
+      // far enough apart that the main loop is exercised independently for
+      // each chunk. The timeout-triggered salvage path must also drop the
+      // stale prefix instead of clearing the whole buffer.
+      const keyHandler = vi.fn();
+
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper: ({ children }) =>
+          wrapper({ children, kittyProtocolEnabled: true }),
+      });
+      act(() => {
+        result.current.subscribe(keyHandler);
+      });
+
+      act(() => {
+        stdin.sendKittySequence('\x1b[');
+      });
+      // Wait *just under* the 200 ms kitty timeout, then send CJK so the
+      // bytes are appended to the still-pending buffer.
+      await new Promise((r) => setTimeout(r, 150));
+      act(() => {
+        stdin.sendKittySequence('调研');
+      });
+      await new Promise((r) => setTimeout(r, 350));
+
+      const sequences = keyHandler.mock.calls.map(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (c: any) => c[0]?.sequence,
+      );
+      expect(sequences).toContain('调');
+      expect(sequences).toContain('研');
+    });
+
     it('should not process kitty sequences when kitty protocol is disabled', async () => {
       const keyHandler = vi.fn();
 

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -206,6 +206,24 @@ export function KeypressProvider({
               broadcast(plain.key);
               continue;
             }
+            // Drop a stale `ESC[` prefix when the byte after it cannot
+            // possibly belong to a CSI sequence (CSI parameters live in
+            // 0x20-0x3F, terminators in 0x40-0x7E). UTF-8 multibyte (0x80+)
+            // from an IME commit lands here. Without this, the salvage
+            // loop gives up and the next block clears the buffer entirely,
+            // dropping every character the user just typed.
+            if (
+              kittySequenceBufferRef.current.length >= 3 &&
+              kittySequenceBufferRef.current.startsWith(`${ESC}[`)
+            ) {
+              const thirdCharCode =
+                kittySequenceBufferRef.current.charCodeAt(2);
+              if (thirdCharCode < 0x20 || thirdCharCode > 0x7e) {
+                kittySequenceBufferRef.current =
+                  kittySequenceBufferRef.current.slice(2);
+                continue;
+              }
+            }
             break;
           }
           // Clear any remaining unparseable content
@@ -821,6 +839,34 @@ export function KeypressProvider({
               broadcast(plainTextPrefix.key);
               bufferedInputHandled = true;
               continue;
+            }
+
+            // The buffer starts with `ESC[` (otherwise parsePlainTextPrefix
+            // would have matched). If the third byte is outside the valid
+            // CSI parameter (0x20-0x3F) and terminator (0x40-0x7E) ranges
+            // — for example a UTF-8 multibyte from an IME commit (0x80+)
+            // arriving while we were buffering an interrupted escape — the
+            // `ESC[` cannot possibly become a valid CSI sequence. Drop the
+            // stale prefix so the rest of the buffer can be reparsed as
+            // plain text. Without this, parsers loop forever and the 200ms
+            // timeout silently discards the typed CJK characters.
+            if (kittySequenceBufferRef.current.length >= 3) {
+              const thirdCharCode =
+                kittySequenceBufferRef.current.charCodeAt(2);
+              if (thirdCharCode < 0x20 || thirdCharCode > 0x7e) {
+                if (debugKeystrokeLogging) {
+                  debugLogger.debug(
+                    '[DEBUG] Dropping stale ESC[ before non-CSI byte:',
+                    `0x${thirdCharCode.toString(16)}`,
+                  );
+                }
+                updateKittyBuffer(kittySequenceBufferRef.current.slice(2));
+                if (!kittySequenceBufferRef.current) {
+                  clearKittyTimeout();
+                }
+                bufferedInputHandled = true;
+                continue;
+              }
             }
 
             // Look for the next potential CSI start beyond index 0


### PR DESCRIPTION
## Summary

Fixes an intermittent bug where typing in qwen-code appears to "have no effect" — keystrokes are silently dropped — when **all** of the following are true:

- The terminal supports the kitty keyboard protocol and qwen-code has it enabled (e.g. **Ghostty** on macOS)
- The user is typing **CJK** text via an IME (reproduced with **Sogou pinyin**)
- A stray `ESC[` happens to be sitting in the kitty sequence buffer when the IME commits its UTF-8 bytes

When this race lines up, the IME-committed characters never reach the input field. The user types `初步调研`, sees nothing, and concludes the input box is broken.

## Root cause

`KeypressContext.tsx` accumulates incoming bytes in `kittySequenceBufferRef` while waiting for a complete CSI sequence. If a stray `ESC[` is already buffered (e.g. from an interrupted escape) and the user then commits CJK via an IME, the multibyte UTF-8 bytes are appended to the stale prefix:

```
buffer:  "ESC[" + "初步"  →  "ESC[初步"
```

The parsers then all fail in turn:

1. `parseKittyPrefix()` finds no matching kitty CSI form.
2. `getCompleteCsiSequenceLength()` returns `0` because the third byte (`0xE5`, the lead byte of `初` in UTF-8) is outside the CSI parameter range `0x20–0x3F`. The call site at line 783 treats `0` as falsy and skips the branch.
3. `parsePlainTextPrefix()` rejects the buffer because it starts with `ESC`.
4. The "skip to next `ESC[`" search finds nothing and the loop hits its silent `return` at line 876.
5. 200 ms later `startKittyTimeout` fires its salvage loop, which fails the same way, then unconditionally clears the buffer at line 219 — **the typed CJK characters are lost**.

The bug is intermittent because it depends on whether a stray `ESC[` happens to be sitting in the buffer at the moment the IME commit arrives.

## Fix

In both the main parse loop and the salvage loop, when the buffer starts with `ESC[` and the third byte is outside both the CSI parameter range (`0x20–0x3F`) and the CSI terminator range (`0x40–0x7E`), the prefix cannot possibly become a valid CSI sequence. Drop the two `ESC[` bytes and continue parsing. The remaining UTF-8 chars then flow through `parsePlainTextPrefix` and reach the input buffer normally.

```diff
+            // The buffer starts with `ESC[` (otherwise parsePlainTextPrefix
+            // would have matched). If the third byte is outside the valid
+            // CSI parameter (0x20-0x3F) and terminator (0x40-0x7E) ranges
+            // — for example a UTF-8 multibyte from an IME commit (0x80+)
+            // arriving while we were buffering an interrupted escape — the
+            // `ESC[` cannot possibly become a valid CSI sequence. Drop the
+            // stale prefix so the rest of the buffer can be reparsed as
+            // plain text.
+            if (kittySequenceBufferRef.current.length >= 3) {
+              const thirdCharCode =
+                kittySequenceBufferRef.current.charCodeAt(2);
+              if (thirdCharCode < 0x20 || thirdCharCode > 0x7e) {
+                updateKittyBuffer(kittySequenceBufferRef.current.slice(2));
+                ...
+                continue;
+              }
+            }
```

The same check is added to the timeout salvage loop so that even if the main loop is bypassed, the buffer doesn't get nuked on the way out.

## Why this is safe

A valid CSI sequence after `ESC[` must consist of zero or more parameter bytes in `0x20–0x3F` followed by a terminator in `0x40–0x7E`. **Anything else is, by definition, not a CSI sequence**. The fix only kicks in when the byte after `ESC[` proves it can't ever become a CSI, so it never affects in-flight valid sequences (those still hit the existing "wait for more data" path because their third byte is in `0x20–0x3F`).

The 200 ms timeout for incomplete-but-valid CSI sequences is unchanged.

## Test plan

Two new regression tests added to `KeypressContext.test.tsx`:

1. **`preserves UTF-8 chars that arrive after a stale ESC[ prefix`** — sends `ESC[` then `初步` in quick succession, asserts both characters are broadcast as plain-text keypresses.
2. **`salvages UTF-8 chars from a stale ESC[ buffer when the timeout fires`** — sends `ESC[`, waits 150 ms (just under the kitty timeout), then sends `调研`, asserts both characters survive.

Both fail without the fix and pass with it.

- [x] `KeypressContext.test.tsx` — 90/90 pass (88 existing + 2 new)
- [x] Full `packages/cli` suite — 3,968 pass / 7 skipped, no regressions

I could not reproduce the bug under a synthetic Python pty driver because qwen-code's kitty protocol detection requires a handshake (`ESC[?u` + `ESC[c` query/response) that a bare pty doesn't satisfy. The repro tests above bypass that by using the existing `MockStdin` test wrapper with `kittyProtocolEnabled={true}`.

## Reporter context

Reported by a user on macOS Ghostty using Sogou pinyin in a tiny working directory (3 files, no subdirectories), so the bug is unrelated to file-search performance, project size, or completion logic — it's purely in the input dispatch path and only manifests when kitty protocol meets IME.
