### PR TITLE
fix(cli): recover from stuck bracketed-paste mode and keep Ctrl+C reachable

### DIFF
--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -13,6 +13,7 @@ import {
   KeypressProvider,
   useKeypressContext,
   DRAG_COMPLETION_TIMEOUT_MS,
+  PASTE_IDLE_TIMEOUT_MS,
   // CSI_END_O,
   // SS3_END,
   SINGLE_QUOTE,
@@ -286,7 +287,9 @@ describe('KeypressContext - Kitty Protocol', () => {
       });
 
       // Wait long enough for the paste idle timeout to trigger recovery.
-      await new Promise((r) => setTimeout(r, 1500));
+      // Derived from the production constant so the test stays in sync
+      // if the timeout is ever tuned.
+      await new Promise((r) => setTimeout(r, PASTE_IDLE_TIMEOUT_MS + 200));
 
       // A plain ASCII key after recovery must reach the handler.
       act(() => {

--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -230,6 +230,76 @@ describe('KeypressContext - Kitty Protocol', () => {
       );
     });
 
+    it('Ctrl+C escapes a paste mode that never received its paste-end marker', async () => {
+      // Regression test for the "must restart terminal" lockup reported by
+      // a user on Ghostty + Sogou pinyin: bracketed-paste-start arrived,
+      // isPaste was set true, and paste-end never followed. Every
+      // subsequent keystroke — including Ctrl+C — was silently buffered.
+      // This test checks that Ctrl+C is always dispatched regardless of
+      // paste mode state.
+      const keyHandler = vi.fn();
+
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper: ({ children }) =>
+          wrapper({ children, kittyProtocolEnabled: true }),
+      });
+      act(() => {
+        result.current.subscribe(keyHandler);
+      });
+
+      // Send ONLY the paste-start marker (no paste-end) — this puts the
+      // dispatcher into the broken state.
+      act(() => {
+        stdin.emit('data', Buffer.from('\x1b[200~'));
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Ctrl+C should fire now, not get buffered into the stuck paste.
+      act(() => {
+        stdin.emit('data', Buffer.from('\x03'));
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      const ctrlCSeen = keyHandler.mock.calls.some(
+        (c) => c[0]?.ctrl === true && c[0]?.name === 'c',
+      );
+      expect(ctrlCSeen).toBe(true);
+    });
+
+    it('auto-recovers from a stuck paste mode via idle timeout', async () => {
+      // Secondary fix: if paste-end never arrives, an idle timeout should
+      // flush whatever is in the paste buffer and reset paste state so
+      // normal typing resumes automatically (without requiring the user
+      // to hit Ctrl+C or restart the terminal).
+      const keyHandler = vi.fn();
+
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper: ({ children }) =>
+          wrapper({ children, kittyProtocolEnabled: true }),
+      });
+      act(() => {
+        result.current.subscribe(keyHandler);
+      });
+
+      act(() => {
+        stdin.emit('data', Buffer.from('\x1b[200~hello'));
+      });
+
+      // Wait long enough for the paste idle timeout to trigger recovery.
+      await new Promise((r) => setTimeout(r, 1500));
+
+      // A plain ASCII key after recovery must reach the handler.
+      act(() => {
+        stdin.emit('data', Buffer.from('z'));
+      });
+      await new Promise((r) => setTimeout(r, 50));
+
+      const zSeen = keyHandler.mock.calls.some(
+        (c) => c[0]?.sequence === 'z' && c[0]?.paste !== true,
+      );
+      expect(zSeen).toBe(true);
+    });
+
     it('should not process kitty sequences when kitty protocol is disabled', async () => {
       const keyHandler = vi.fn();
 

--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -268,10 +268,11 @@ describe('KeypressContext - Kitty Protocol', () => {
     });
 
     it('auto-recovers from a stuck paste mode via idle timeout', async () => {
-      // Secondary fix: if paste-end never arrives, an idle timeout should
-      // flush whatever is in the paste buffer and reset paste state so
-      // normal typing resumes automatically (without requiring the user
-      // to hit Ctrl+C or restart the terminal).
+      // Automatic recovery safety net for the same "must restart terminal"
+      // lockup the Ctrl+C test above covers manually: if paste-end never
+      // arrives, an idle timeout should flush whatever is in the paste
+      // buffer and reset paste state so normal typing resumes automatically
+      // (without requiring the user to hit Ctrl+C or restart the terminal).
       const keyHandler = vi.fn();
 
       const { result } = renderHook(() => useKeypressContext(), {

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -49,6 +49,15 @@ export const DRAG_COMPLETION_TIMEOUT_MS = 100; // Broadcast full path after 100m
 // - Too long: delayed recovery from interrupted sequences (e.g., IME interruptions)
 // Based on empirical testing with IME input patterns in VS Code integrated terminal.
 export const KITTY_SEQUENCE_TIMEOUT_MS = 200;
+
+// Paste idle timeout: auto-recovers from a stuck bracketed-paste mode
+// when `paste-end` (`ESC[201~`) never arrives. Without this safety net, a
+// lost paste-end marker leaves `isPaste = true` forever, every subsequent
+// keystroke (including Ctrl+C) is silently buffered, and the only way to
+// recover is to kill the terminal. 1000ms is long enough to cover slow
+// chunked pastes on cold terminals yet short enough that users don't
+// perceive the recovery as a hang.
+export const PASTE_IDLE_TIMEOUT_MS = 1000;
 export const SINGLE_QUOTE = "'";
 export const DOUBLE_QUOTE = '"';
 
@@ -167,6 +176,12 @@ export function KeypressProvider({
 
     let isPaste = false;
     let pasteBuffer = Buffer.alloc(0);
+    // Set to true when paste mode is ended by something other than a
+    // received paste-end event (idle timeout or Ctrl+C escape). The next
+    // real paste-end event that arrives — if any — is then a stale echo
+    // and must be swallowed instead of producing a spurious empty paste.
+    let pasteAlreadyFlushed = false;
+    let pasteIdleTimeout: NodeJS.Timeout | null = null;
     const kittySequenceBufferRef = { current: '' };
     let kittySequenceTimeout: NodeJS.Timeout | null = null;
     let backslashTimeout: NodeJS.Timeout | null = null;
@@ -225,6 +240,44 @@ export function KeypressProvider({
     const clearKittyBufferAndTimeout = () => {
       clearKittyTimeout();
       kittySequenceBufferRef.current = '';
+    };
+
+    const clearPasteIdleTimeout = () => {
+      if (pasteIdleTimeout) {
+        clearTimeout(pasteIdleTimeout);
+        pasteIdleTimeout = null;
+      }
+    };
+
+    // Force-flush a paste that has gone too long without its paste-end
+    // marker. Rather than dropping whatever the user typed, broadcast the
+    // buffered content as a regular paste event and reset state so the
+    // next keystroke is handled normally.
+    const forceFlushStuckPaste = () => {
+      clearPasteIdleTimeout();
+      if (!isPaste && pasteBuffer.length === 0) return;
+      const buffered = pasteBuffer.toString();
+      isPaste = false;
+      pasteBuffer = Buffer.alloc(0);
+      pasteAlreadyFlushed = true;
+      if (buffered.length > 0) {
+        broadcast({
+          name: '',
+          ctrl: false,
+          meta: false,
+          shift: false,
+          paste: true,
+          sequence: buffered,
+        });
+      }
+    };
+
+    const startPasteIdleTimeout = () => {
+      clearPasteIdleTimeout();
+      pasteIdleTimeout = setTimeout(
+        forceFlushStuckPaste,
+        PASTE_IDLE_TIMEOUT_MS,
+      );
     };
 
     const createPrintableKey = (char: string): Key => {
@@ -607,11 +660,62 @@ export function KeypressProvider({
       if (key.sequence === FOCUS_IN || key.sequence === FOCUS_OUT) {
         return;
       }
+
+      // Ctrl+C is an always-available escape hatch. It MUST be processed
+      // before the `isPaste` branch below, otherwise a stuck paste mode
+      // (paste-start without paste-end) silently buffers every key —
+      // including Ctrl+C itself — and the user has no way to recover
+      // without killing the terminal.
+      const isCtrlCKey =
+        (key.ctrl && key.name === 'c') ||
+        key.sequence === `${ESC}${KITTY_CTRL_C}`;
+      if (isCtrlCKey) {
+        if (isPaste || pasteBuffer.length > 0) {
+          isPaste = false;
+          pasteBuffer = Buffer.alloc(0);
+          pasteAlreadyFlushed = true;
+          clearPasteIdleTimeout();
+        }
+        if (kittySequenceBufferRef.current && debugKeystrokeLogging) {
+          debugLogger.debug(
+            '[DEBUG] Kitty buffer cleared on Ctrl+C:',
+            kittySequenceBufferRef.current,
+          );
+        }
+        clearKittyBufferAndTimeout();
+        if (key.sequence === `${ESC}${KITTY_CTRL_C}`) {
+          broadcast({
+            name: 'c',
+            ctrl: true,
+            meta: false,
+            shift: false,
+            paste: false,
+            sequence: key.sequence,
+            kittyProtocol: true,
+          });
+        } else {
+          broadcast(key);
+        }
+        return;
+      }
+
       if (key.name === 'paste-start') {
         isPaste = true;
+        pasteAlreadyFlushed = false;
+        startPasteIdleTimeout();
         return;
       }
       if (key.name === 'paste-end') {
+        clearPasteIdleTimeout();
+        // A stale paste-end may arrive after we force-flushed the paste
+        // via the idle timeout or Ctrl+C escape — swallow it so we don't
+        // broadcast a spurious empty/image paste event.
+        if (pasteAlreadyFlushed) {
+          pasteAlreadyFlushed = false;
+          isPaste = false;
+          pasteBuffer = Buffer.alloc(0);
+          return;
+        }
         isPaste = false;
         if (pasteBuffer.toString().length > 0) {
           broadcast({
@@ -641,6 +745,7 @@ export function KeypressProvider({
 
       if (isPaste) {
         pasteBuffer = Buffer.concat([pasteBuffer, Buffer.from(key.sequence)]);
+        startPasteIdleTimeout();
         return;
       }
 
@@ -694,32 +799,8 @@ export function KeypressProvider({
         return;
       }
 
-      if (
-        (key.ctrl && key.name === 'c') ||
-        key.sequence === `${ESC}${KITTY_CTRL_C}`
-      ) {
-        if (kittySequenceBufferRef.current && debugKeystrokeLogging) {
-          debugLogger.debug(
-            '[DEBUG] Kitty buffer cleared on Ctrl+C:',
-            kittySequenceBufferRef.current,
-          );
-        }
-        clearKittyBufferAndTimeout();
-        if (key.sequence === `${ESC}${KITTY_CTRL_C}`) {
-          broadcast({
-            name: 'c',
-            ctrl: true,
-            meta: false,
-            shift: false,
-            paste: false,
-            sequence: key.sequence,
-            kittyProtocol: true,
-          });
-        } else {
-          broadcast(key);
-        }
-        return;
-      }
+      // Ctrl+C is handled earlier, above the paste-state branches, so
+      // that it remains an escape hatch even when paste mode is stuck.
 
       if (kittyProtocolEnabled) {
         if (
@@ -1033,6 +1114,7 @@ export function KeypressProvider({
       }
 
       clearKittyBufferAndTimeout();
+      clearPasteIdleTimeout();
 
       if (rawFlushTimeout) {
         clearTimeout(rawFlushTimeout);

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -255,6 +255,10 @@ export function KeypressProvider({
     // next keystroke is handled normally.
     const forceFlushStuckPaste = () => {
       clearPasteIdleTimeout();
+      // Nothing to recover from: not in paste mode AND no buffered content.
+      // We still run when either condition is true — e.g. isPaste=true with
+      // an empty buffer (need to clear the flag) or isPaste=false with stale
+      // buffered content (e.g. after a race between Ctrl+C and the timer).
       if (!isPaste && pasteBuffer.length === 0) return;
       const buffered = pasteBuffer.toString();
       isPaste = false;
@@ -711,6 +715,7 @@ export function KeypressProvider({
         // via the idle timeout or Ctrl+C escape — swallow it so we don't
         // broadcast a spurious empty/image paste event.
         if (pasteAlreadyFlushed) {
+          // Reset for the next paste cycle.
           pasteAlreadyFlushed = false;
           isPaste = false;
           pasteBuffer = Buffer.alloc(0);


### PR DESCRIPTION
> This PR description is written in both English and Chinese for clarity.
> 本 PR 描述以中英文对照方式书写,方便不同背景的 reviewer。

## Summary / 概述

**EN.** Fixes the "input stops working, must restart terminal" lockup reported by a user on **Ghostty + Sogou pinyin IME on macOS** in a tiny working directory (3 files, no subdirs). The bug is completely unrelated to file-search performance — it's an input-dispatch state machine getting stuck when a bracketed-paste-start (`ESC[200~`) arrives without a matching paste-end (`ESC[201~`).

**中.** 修复一位用户在 **macOS Ghostty + 搜狗拼音输入法** 下报告的"输入不起作用、必须重开终端"卡死问题。复现环境是一个只有 3 个文件、没有子目录的小目录,所以与文件搜索性能完全无关 —— 真正的根因是当 bracketed-paste 的起始标记 `ESC[200~` 到达后,配套的结束标记 `ESC[201~` 丢失或未送达时,输入调度状态机被永久卡住。

## Root cause / 根本原因

**EN.** Inside `handleKeypress` the checks run in this order:

1. `key.name === 'paste-start'` → set `isPaste = true`, return
2. `key.name === 'paste-end'` → reset + flush + return
3. `if (isPaste) { pasteBuffer.append; return }` ← **swallows everything**
4. backslash / return handling
5. arrow keys
6. Ctrl+C

If paste-end never arrives, `isPaste` stays `true` forever. Every subsequent key — **including Ctrl+C** — is appended to the paste buffer and silently returned. The user has no keyboard escape hatch and must kill the process. This exactly matches the reported symptoms: typing has no effect, Ctrl+C is unresponsive, only a terminal restart recovers.

**中.** `handleKeypress` 里的检查顺序:

1. `key.name === 'paste-start'` → 设置 `isPaste = true`,直接 return
2. `key.name === 'paste-end'` → 重置并 flush,return
3. `if (isPaste) { pasteBuffer.append; return }` ← **所有按键在这里被吞**
4. 反斜杠 / 回车处理
5. 方向键
6. Ctrl+C

如果 paste-end 永远不来,`isPaste` 就永远 `true`。此后每一个按键(**包括 Ctrl+C**)都会被追加到 pasteBuffer 并静默 return。用户没有任何键盘逃生通道,只能 kill 进程。这完全匹配用户反馈的症状:输入没反应、Ctrl+C 无效、只有重开终端才能恢复。

## Fix / 修复方案

Two layered fixes, both in `KeypressContext.tsx`.
两层叠加的修复,均在 `KeypressContext.tsx` 内。

### 1. Ctrl+C escape hatch / Ctrl+C 逃生舱

**EN.** Move the Ctrl+C check **above** the `isPaste` branch, and clear paste state (`isPaste = false`, empty `pasteBuffer`, clear idle timer, set `pasteAlreadyFlushed`) when it fires. Ctrl+C now always reaches the broadcast regardless of any stuck paste state, guaranteeing the user a manual recovery path.

**中.** 把 Ctrl+C 的检查**上移**到 `isPaste` 分支之前,并在触发时清理 paste 状态(`isPaste = false`、清空 `pasteBuffer`、清除 idle 定时器、设置 `pasteAlreadyFlushed`)。这样无论 paste 状态是否卡住,Ctrl+C 始终能走到 broadcast,用户永远有一条手动恢复的路径。

### 2. Idle timeout auto-recovery / 闲置超时自动恢复

**EN.** Add `PASTE_IDLE_TIMEOUT_MS = 1000`. On paste-start start a timer; on each paste content byte reset the timer; on paste-end clear the timer. If the timer fires without a paste-end:

- Force-flush `pasteBuffer` as a regular paste event (don't discard what the user typed)
- Reset `isPaste = false`
- Set `pasteAlreadyFlushed = true` so that a late paste-end arriving later is ignored instead of producing a spurious empty/image paste broadcast

1000 ms is long enough to cover slow chunked pastes on cold terminals yet short enough that a stuck terminal feels like it self-heals rather than hangs.

**中.** 新增常量 `PASTE_IDLE_TIMEOUT_MS = 1000`。规则:paste-start 时启动定时器,每接收一个 paste 内容字节就重置定时器,paste-end 到达时清除定时器。如果定时器在没收到 paste-end 的情况下触发:

- 将 `pasteBuffer` 以正常的 paste 事件强制 flush(保留用户敲过的内容,不丢弃)
- 重置 `isPaste = false`
- 设置 `pasteAlreadyFlushed = true`,以便稍后迟到的 paste-end 会被忽略,而不是触发一次多余的空/图片 paste 广播

1000 ms 既足够覆盖冷启动终端下分块到达的慢速 paste,又足够短,让用户对"卡住"的感知变成"自愈"而不是"真·挂起"。

## End-to-end reproduction / 端到端复现

**EN.** Beyond the unit tests, this PR has been verified end-to-end by spawning the built CLI in a PTY and injecting a bracketed-paste-start marker with no matching paste-end, then observing what actually lands in the input field on both branches.

**中.** 除了单元测试,这个 PR 还通过 PTY 端到端验证:脚本在 PTY 里启动编译后的 CLI,注入一个没有配套 `ESC[201~` 的 `ESC[200~`,然后观察两个分支上输入框实际渲染出的内容。

**Run it yourself / 本地运行:**

```bash
npm install
node esbuild.config.js    # rebuild dist/cli.js for the current branch
                          # 为当前分支重建 dist/cli.js
python3 audit_repro.py    # run the repro harness below
                          # 运行下方的复现脚本
```

**Observed results (same script, two branches) / 实测结果(同一脚本,两个分支):**

| Phase / 阶段 | `main` (before fix / 修复前) | `fix/paste-mode-stuck` (after fix / 修复后) |
|---|---|---|
| type `hello` / 键入 `hello` | `> hello` rendered / 正常渲染 | `> hello` rendered / 正常渲染 |
| inject `\x1b[200~` / 注入 `\x1b[200~` | no render / 无渲染 | no render / 无渲染 |
| type ` world` / 键入 ` world` | **no render — swallowed** / **无渲染 — 被吞** | **no render — buffered** / **无渲染 — 进入 pasteBuffer** |
| Ctrl+C (`\x03`) | **no render — also swallowed!** / **连 Ctrl+C 都被吞!** | input cleared / 输入框被清空 → `> Type your message …` + `Press Ctrl+C again to exit` |
| wait 1.5 s / 等待 1.5 秒 | still stuck / 仍然卡死 | (already recovered / 已恢复) |
| type `z` / 键入 `z` | **still no render — `z` also swallowed** / **仍然无渲染 — `z` 也被吞** | `> z` rendered normally / 正常渲染 |
| Full raw render size / 整个 session 原始渲染字节数 | **477 bytes** — Ink never re-rendered after `hello` / Ink 在 `hello` 之后再也没 re-render | **1985 bytes** — 3 additional full re-renders / 额外 3 次完整 re-render |

**EN.** The `main` captured stream contains **one and only one** input-line render for the entire session:

**中.** `main` 分支抓到的输出里,整个 session **只有唯一一行**输入行渲染:

```
  4: > hello ​
```

**EN.** The fix branch shows the full escape-then-recover sequence:

**中.** 修复分支完整走过了"逃生 → 恢复"的全流程:

```
  4: > hello ​
 14: >   Type your message or @path/to/file         ← Ctrl+C cleared the buffer / Ctrl+C 清空了缓冲区
 18:   Press Ctrl+C again to exit.                  ← application received the Ctrl+C / 应用层收到了 Ctrl+C
 34: > z ​                                           ← subsequent typing works / 之后键入正常
```

**EN.** Both outcomes are 100% deterministic — the PTY injection removes the real-world race window so each run behaves the same.

**中.** 两种结果都是 100% 确定性的 —— PTY 注入把真实世界里的竞态窗口固化下来,所以每次运行行为一致。

<details>
<summary><strong>Repro script / 复现脚本 (<code>audit_repro.py</code>)</strong></summary>

```python
#!/usr/bin/env python3
"""
Deterministic reproduction of the stuck bracketed-paste bug.
端到端确定性复现 bracketed-paste 卡死 bug。

Spawns qwen-code in a PTY, waits for the TUI, types 'hello' normally,
injects a bracketed-paste-start marker WITHOUT its matching paste-end,
and observes what the rendered input line shows at each step.
在 PTY 里启动 qwen-code,等 TUI 就绪,正常键入 'hello',注入一个
没有配套 paste-end 的 `ESC[200~`,然后逐步观察输入行的渲染状态。

On main (buggy): ' world' / Ctrl+C / later typing are all silently
swallowed and only a kill recovers.
main 分支(有 bug): ' world' / Ctrl+C / 后续键入全部被静默吞掉,只能 kill 恢复。

On fix/paste-mode-stuck: either Ctrl+C or a 1-second idle timeout
recovers automatically.
fix/paste-mode-stuck 分支: Ctrl+C 或 1 秒 idle timeout 二者皆可自动恢复。

Usage / 用法: python3 audit_repro.py [path/to/dist/cli.js]
"""
import os, pty, re, select, struct, sys, termios, fcntl, time

CLI_ENTRY = sys.argv[1] if len(sys.argv) > 1 else os.path.join(
    os.getcwd(), "dist", "cli.js"
)
CWD = "/tmp"

ANSI_RE = re.compile(
    r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~]|\][^\x07\x1B]*(?:\x07|\x1B\\)|P[^\x1B]*\x1B\\)"
)


def find_input_line(text):
    stripped = ANSI_RE.sub("", text)
    stripped = re.sub(r"\r+", "\n", stripped)
    candidate = None
    for line in stripped.split("\n"):
        s = line.strip()
        if s.startswith("> ") and "Type your message" not in s and s != "> /quit":
            candidate = s
    return candidate


def main():
    env = os.environ.copy()
    env["TERM"] = "xterm-256color"
    env["FORCE_COLOR"] = "1"

    pid, fd = pty.fork()
    if pid == 0:
        os.chdir(CWD)
        os.execvpe("node", ["node", CLI_ENTRY], env)

    try:
        fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 150, 0, 0))
    except Exception:
        pass

    start = time.monotonic()
    all_text = ""

    def drain(t=0.05):
        nonlocal all_text
        deadline = time.monotonic() + t
        while time.monotonic() < deadline:
            r, _, _ = select.select([fd], [], [], 0.01)
            if fd in r:
                try:
                    chunk = os.read(fd, 65536)
                except OSError:
                    return
                if not chunk:
                    return
                all_text += chunk.decode("utf-8", errors="replace")
            else:
                break

    def log(msg):
        print(f"[{(time.monotonic() - start) * 1000:6.0f}ms] {msg}", flush=True)

    def snapshot(label):
        drain(0.1)
        log(f"{label:18s} input = {find_input_line(all_text)!r}")

    # Wait for TUI ready / 等待 TUI 就绪
    while time.monotonic() - start < 25.0:
        r, _, _ = select.select([fd], [], [], 0.25)
        if fd in r:
            try:
                chunk = os.read(fd, 65536)
            except OSError:
                break
            if not chunk:
                break
            all_text += chunk.decode("utf-8", errors="replace")
        else:
            if len(all_text) > 500:
                break

    # Dismiss any first-run dialog / 关掉首次运行对话框
    if "New model configurations" in all_text:
        os.write(fd, b"2\r")
        time.sleep(0.5)
        drain(0.3)
    all_text = ""
    drain(0.3)

    log("TUI ready")
    snapshot("baseline")

    os.write(fd, b"hello"); time.sleep(0.2); drain(0.2)
    snapshot("after 'hello'")

    log("INJECT \\x1b[200~ (paste-start, NO paste-end)")
    os.write(fd, b"\x1b[200~"); time.sleep(0.1); drain(0.1)
    snapshot("after inject")

    os.write(fd, b" world"); time.sleep(0.3); drain(0.3)
    snapshot("after ' world'")

    log("sending Ctrl+C")
    os.write(fd, b"\x03"); time.sleep(0.3); drain(0.3)
    snapshot("after Ctrl+C")

    log("waiting 1500ms for paste idle timeout")
    time.sleep(1.5); drain(0.3)
    snapshot("after wait")

    os.write(fd, b"z"); time.sleep(0.3); drain(0.3)
    snapshot("after 'z'")

    try:
        os.kill(pid, 9)
    except ProcessLookupError:
        pass
    os.waitpid(pid, 0)

    # Dump stripped render-line view / 输出去掉 ANSI 的渲染行
    stripped = re.sub(r"\r+", "\n", ANSI_RE.sub("", all_text))
    print("\n=== rendered lines / 渲染行 ===")
    for i, line in enumerate(stripped.split("\n")):
        s = line.rstrip()
        if s:
            print(f"{i:3d}: {s}")


if __name__ == "__main__":
    main()
```

</details>

## Why this is safe / 为什么这个改动是安全的

**EN.**

- Ctrl+C reordering only changes behaviour **when isPaste is true**. In all other paths Ctrl+C is handled exactly as before (same `clearKittyBufferAndTimeout` + broadcast code, now at the top of the dispatcher). The "should clear kitty buffer on Ctrl+C" existing test path is preserved.
- The idle timeout only fires if the paste has been idle for 1 second — legitimate pastes arrive as bulk data in far less than 1 second per chunk. A large file paste (e.g. 1 MB from the clipboard) still completes well under the threshold because terminals deliver it in one chunk.
- The `pasteAlreadyFlushed` guard means a delayed paste-end is ignored instead of producing a second broadcast. No double-broadcast, no spurious image-paste trigger.
- `enableFuzzySearch` / file search behaviour — completely untouched.

**中.**

- Ctrl+C 的位置调整**只在 `isPaste === true` 时**改变行为。其他路径下 Ctrl+C 的处理逻辑和之前完全相同(同一段 `clearKittyBufferAndTimeout` + broadcast 代码,只是被放到了 dispatcher 的更前面),既有的 "should clear kitty buffer on Ctrl+C" 测试路径不受影响。
- Idle timeout 只在 paste 闲置 1 秒后触发 —— 合法 paste 是批量到达的,每个分块之间的间隔远小于 1 秒。从剪贴板粘贴 1 MB 这种大文件也远低于阈值,因为终端会一次性送过来。
- `pasteAlreadyFlushed` 标志保证迟到的 paste-end 会被忽略,不会触发第二次 broadcast 或意外的图片粘贴。
- `enableFuzzySearch` / 文件搜索逻辑 —— 完全没动。

## Test plan / 测试计划

**EN.**

- [x] `KeypressContext.test.tsx`: 90/90 pass, including two new regression tests
  - `Ctrl+C escapes a paste mode that never received its paste-end marker` — sends paste-start then Ctrl+C, asserts the Ctrl+C event reaches the handler.
  - `auto-recovers from a stuck paste mode via idle timeout` — sends paste-start + content, waits 1.5 s, asserts a subsequent plain keystroke is broadcast normally (not buffered).
- [x] Full `packages/cli` suite: 3968 pass / 7 skipped, no regressions.
- [x] Existing paste tests (`should handle multiline paste as a single event`, `should handle complete paste sequence with markers`, ...) continue to pass — the paste-end path is unchanged for legitimate pastes.
- [x] End-to-end PTY repro (see above): deterministic behaviour change between `main` and `fix/paste-mode-stuck`.

**中.**

- [x] `KeypressContext.test.tsx`:90/90 通过,包括两个新增的 regression test
  - `Ctrl+C escapes a paste mode that never received its paste-end marker` —— 先发 paste-start 再发 Ctrl+C,断言 Ctrl+C 事件确实到达了 handler。
  - `auto-recovers from a stuck paste mode via idle timeout` —— 发送 paste-start + 内容,等 1.5 秒,断言之后的普通按键能被正常广播(而非被继续 buffer)。
- [x] `packages/cli` 整个测试套件:3968 通过 / 7 skipped,**0 regression**。
- [x] 既有的 paste 测试(`should handle multiline paste as a single event`、`should handle complete paste sequence with markers`...)继续通过 —— 合法 paste 的 paste-end 路径完全没动。
- [x] PTY 端到端复现(见上文):`main` 与 `fix/paste-mode-stuck` 之间呈现确定性的行为差异。

## Relationship to #3179 / 与 #3179 的关系

**EN.** This is a **separate bug** from the one fixed in #3179. That PR addresses a transient 200 ms input loss when a stale `ESC[` lingers in the kitty sequence buffer before an IME commit — the buffer self-recovers via the kitty timeout and input resumes within ~200 ms. This PR addresses a persistent lockup where `isPaste` never recovers and the user must restart the terminal. Both bugs can exist simultaneously in Ghostty + IME environments.

**中.** 这是与 #3179 **完全不同的两个 bug**。#3179 修的是:一个残留的 `ESC[` 赖在 kitty 序列缓冲区里、紧跟着 IME 提交,导致 200 毫秒窗口内字符被丢失 —— 缓冲区会通过 kitty timeout 自行恢复,200 毫秒后输入就正常了。本 PR 修的是:`isPaste` 永不回落导致的**永久锁死**,用户必须重开终端。在 Ghostty + IME 环境下这两个 bug 可以同时存在。

**EN.** The user's reported scenario (typing has no effect, **must restart terminal**, 3-file dir) maps to this fix, not #3179.

**中.** 用户反馈的场景(输入不起作用、**必须重开终端**、3 文件小目录)对应的是本 PR,不是 #3179。