### PR TITLE
fix(cli): honor --openai-api-key in non-interactive auth validation

### DIFF
--- a/packages/cli/src/config/auth.test.ts
+++ b/packages/cli/src/config/auth.test.ts
@@ -186,6 +186,7 @@ describe('validateAuthMethod', () => {
     const mockConfig = {
       getModelsConfig: vi.fn().mockReturnValue({
         getModel: vi.fn().mockReturnValue('cli-model'),
+        getGenerationConfig: vi.fn().mockReturnValue({}),
       }),
     } as unknown as import('@qwen-code/qwen-code-core').Config;
 
@@ -219,6 +220,7 @@ describe('validateAuthMethod', () => {
     const mockConfig = {
       getModelsConfig: vi.fn().mockReturnValue({
         getModel: vi.fn().mockReturnValue('cli-model'),
+        getGenerationConfig: vi.fn().mockReturnValue({}),
       }),
     } as unknown as import('@qwen-code/qwen-code-core').Config;
 
@@ -226,5 +228,55 @@ describe('validateAuthMethod', () => {
     const result = validateAuthMethod(AuthType.USE_OPENAI, mockConfig);
     expect(result).not.toBeNull();
     expect(result).toContain('CLI_API_KEY');
+  });
+
+  // Regression test for #3171: validation must accept the API key resolved
+  // into generationConfig.apiKey (e.g. from --openai-api-key) instead of
+  // requiring an OPENAI_API_KEY env var.
+  it('should accept API key resolved into generationConfig from CLI flag', () => {
+    delete process.env['OPENAI_API_KEY'];
+    vi.mocked(settings.loadSettings).mockReturnValue({
+      merged: {},
+    } as unknown as ReturnType<typeof settings.loadSettings>);
+
+    const mockConfig = {
+      getModelsConfig: vi.fn().mockReturnValue({
+        getModel: vi.fn().mockReturnValue('gpt-4'),
+        getGenerationConfig: vi
+          .fn()
+          .mockReturnValue({ apiKey: 'cli-provided-key' }),
+      }),
+    } as unknown as import('@qwen-code/qwen-code-core').Config;
+
+    const result = validateAuthMethod(AuthType.USE_OPENAI, mockConfig);
+    expect(result).toBeNull();
+  });
+
+  // Regression test for #3171: when a modelProvider has a custom envKey but
+  // the user passes --openai-api-key on the CLI, the resolver picks the CLI
+  // value. Validation should match the resolver and accept it instead of
+  // demanding the env var.
+  it('should accept CLI-resolved key even when modelProvider declares a custom envKey', () => {
+    delete process.env['CUSTOM_API_KEY'];
+    vi.mocked(settings.loadSettings).mockReturnValue({
+      merged: {
+        model: { name: 'custom-model' },
+        modelProviders: {
+          openai: [{ id: 'custom-model', envKey: 'CUSTOM_API_KEY' }],
+        },
+      },
+    } as unknown as ReturnType<typeof settings.loadSettings>);
+
+    const mockConfig = {
+      getModelsConfig: vi.fn().mockReturnValue({
+        getModel: vi.fn().mockReturnValue('custom-model'),
+        getGenerationConfig: vi
+          .fn()
+          .mockReturnValue({ apiKey: 'cli-provided-key' }),
+      }),
+    } as unknown as import('@qwen-code/qwen-code-core').Config;
+
+    const result = validateAuthMethod(AuthType.USE_OPENAI, mockConfig);
+    expect(result).toBeNull();
   });
 });

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -66,6 +66,26 @@ function hasApiKeyForAuth(
 
   // Try to find model-specific envKey from modelProviders
   const modelConfig = findModelConfig(modelProviders, authType, modelId);
+
+  // If a Config is available, prefer the API key already resolved into the
+  // generation config. The unified resolver folds CLI flags (e.g.
+  // --openai-api-key), env vars, settings.security.auth.apiKey, and
+  // modelProvider envKey lookups into this single value, so it is the same
+  // key that refreshAuth will actually use at runtime. Validating against it
+  // keeps pre-flight checks consistent with runtime behavior — without this,
+  // CLI-provided credentials are silently ignored when no env var is set
+  // (issue #3171).
+  const resolvedApiKey = config
+    ?.getModelsConfig()
+    .getGenerationConfig()?.apiKey;
+  if (resolvedApiKey) {
+    return {
+      hasKey: true,
+      checkedEnvKey: modelConfig?.envKey ?? DEFAULT_ENV_KEYS[authType],
+      isExplicitEnvKey: !!modelConfig?.envKey,
+    };
+  }
+
   if (modelConfig?.envKey) {
     // Explicit envKey configured - only check this env var, no apiKey fallback
     const hasKey = !!process.env[modelConfig.envKey];

--- a/packages/cli/src/validateNonInterActiveAuth.test.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.test.ts
@@ -29,6 +29,7 @@ function createMockConfig(overrides?: Partial<Config>): Config {
   const baseModelsConfig = {
     getModel: vi.fn().mockReturnValue('default-model'),
     getCurrentAuthType: vi.fn().mockReturnValue(AuthType.QWEN_OAUTH),
+    getGenerationConfig: vi.fn().mockReturnValue({}),
   } as unknown as ModelsConfig;
   const baseConfig: Partial<Config> = {
     refreshAuth: vi.fn().mockResolvedValue('refreshed'),
@@ -169,6 +170,7 @@ describe('validateNonInterActiveAuth', () => {
       getModelsConfig: vi.fn().mockReturnValue({
         getModel: vi.fn().mockReturnValue('default-model'),
         getCurrentAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+        getGenerationConfig: vi.fn().mockReturnValue({}),
       }),
     });
     await validateNonInteractiveAuth(
@@ -185,6 +187,7 @@ describe('validateNonInterActiveAuth', () => {
       getModelsConfig: vi.fn().mockReturnValue({
         getModel: vi.fn().mockReturnValue('default-model'),
         getCurrentAuthType: vi.fn().mockReturnValue(AuthType.QWEN_OAUTH),
+        getGenerationConfig: vi.fn().mockReturnValue({}),
       }),
     });
     await validateNonInteractiveAuth(
@@ -249,6 +252,7 @@ describe('validateNonInterActiveAuth', () => {
       getModelsConfig: vi.fn().mockReturnValue({
         getModel: vi.fn().mockReturnValue('default-model'),
         getCurrentAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+        getGenerationConfig: vi.fn().mockReturnValue({}),
       }),
     });
     await validateNonInteractiveAuth(
@@ -267,6 +271,7 @@ describe('validateNonInterActiveAuth', () => {
       getModelsConfig: vi.fn().mockReturnValue({
         getModel: vi.fn().mockReturnValue('default-model'),
         getCurrentAuthType: vi.fn().mockReturnValue(AuthType.USE_OPENAI),
+        getGenerationConfig: vi.fn().mockReturnValue({}),
       }),
     });
     try {


### PR DESCRIPTION
## TLDR

Fixes #3171. Pre-flight `validateAuthMethod` only checked `OPENAI_API_KEY` env var (and `settings.security.auth.apiKey`) — it never inspected the API key already resolved into `generationConfig.apiKey` from the `--openai-api-key` CLI flag. As a result, `qwen --auth-type openai --openai-base-url <url> --openai-api-key <key>` was rejected on Linux with "Missing API key for OpenAI-compatible auth". macOS users were unaffected because `OPENAI_API_KEY` is commonly set in their shell profile.

## Screenshots / Video Demo

N/A — CLI bug fix, no UI change. Headless reproduction:

**Before** (CLI flag rejected even though it was passed):

```
$ HOME=/tmp/clean qwen --auth-type openai --openai-base-url http://localhost:9999/v1 \
    --openai-api-key sk-test --model gpt-4 --output-format json -p "say hello"
{"type":"result","subtype":"error_during_execution","is_error":true,
 "error":{"message":"Missing API key for OpenAI-compatible auth.
   Set settings.security.auth.apiKey, or set the 'OPENAI_API_KEY' environment variable."}}
exit 1
```

**After** (validation passes; the connection error is expected because the base URL is fake):

```
$ HOME=/tmp/clean node dist/cli.js --auth-type openai --openai-base-url http://localhost:9999/v1 \
    --openai-api-key sk-test --model gpt-4 --output-format json -p "say hello"
... fetch failed (connection refused on fake URL — auth pre-flight passed)
exit 0
```

## Dive Deeper

`hasApiKeyForAuth` in `packages/cli/src/config/auth.ts` walked an env-var-only ladder: explicit `modelProvider.envKey` → `OPENAI_API_KEY` → `settings.security.auth.apiKey`. None of those branches looked at `config.getModelsConfig().getGenerationConfig().apiKey`, which is the value the unified resolver (`resolveModelConfig`) folds CLI flags, env vars, settings, and modelProvider envKey lookups into. That same resolved value is what `refreshAuth` would have used at runtime, so the pre-flight check and the runtime path disagreed.

The fix adds an early-return that prefers the resolved key when a `Config` is provided. The existing env/settings fallbacks are kept intact for the `config === undefined` case (the type signature still allows it) and for backwards-compatible behavior when nothing has been resolved yet.

This also incidentally fixes a related case: when a user has a `modelProviders[].envKey` configured but overrides it with `--openai-api-key` on the CLI, the resolver was already picking up the CLI value at runtime — but pre-flight was rejecting the run because the strict envKey check ignored CLI flags. Both paths are now consistent.

A separate but analogous gap exists for Anthropic `baseUrl` (`ANTHROPIC_BASE_URL` vs CLI-resolved `generationConfig.baseUrl`). It is intentionally **not** addressed in this PR to keep the change scoped to the reported issue and tracked as a follow-up.

## Reviewer Test Plan

Pull the branch and verify on Linux (or in a clean shell with `OPENAI_API_KEY` unset):

```bash
npm install && npm run build && npm run bundle

# 1. CLI flag should work (was broken pre-fix)
unset OPENAI_API_KEY
HOME=/tmp/qwen-test node dist/cli.js \
  --auth-type openai \
  --openai-base-url http://localhost:9999/v1 \
  --openai-api-key sk-test-key \
  --model gpt-4 --output-format json -p "say hello"
# Expected: passes auth, attempts API call, fetch error from fake URL, exit 0

# 2. Env var should still work
OPENAI_API_KEY=sk-env-key HOME=/tmp/qwen-test node dist/cli.js \
  --auth-type openai \
  --openai-base-url http://localhost:9999/v1 \
  --model gpt-4 --output-format json -p "say hello"
# Expected: passes auth, attempts API call, fetch error from fake URL, exit 0

# 3. No key should still error
unset OPENAI_API_KEY
HOME=/tmp/qwen-test node dist/cli.js \
  --auth-type openai \
  --openai-base-url http://localhost:9999/v1 \
  --model gpt-4 --output-format json -p "say hello"
# Expected: "Missing API key for OpenAI-compatible auth", exit 1
```

Unit tests:

```bash
cd packages/cli
npx vitest run src/config/auth.test.ts
npx vitest run src/validateNonInterActiveAuth.test.ts
```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3171