### PR TITLE
fix(core): show clear error when MCP server cwd does not exist

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -294,6 +294,29 @@ describe('mcp-client', () => {
       });
     });
 
+    it('should connect via command without cwd', async () => {
+      const mockedTransport = vi
+        .spyOn(SdkClientStdioLib, 'StdioClientTransport')
+        .mockReturnValue({} as SdkClientStdioLib.StdioClientTransport);
+
+      await createTransport(
+        'test-server',
+        {
+          command: 'test-command',
+          args: ['--foo', 'bar'],
+        },
+        false,
+      );
+
+      expect(mockedTransport).toHaveBeenCalledWith({
+        command: 'test-command',
+        args: ['--foo', 'bar'],
+        cwd: undefined,
+        env: expect.any(Object),
+        stderr: 'pipe',
+      });
+    });
+
     it('should throw if cwd does not exist', async () => {
       mockExistsSync.mockReturnValueOnce(false);
 

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -23,6 +23,11 @@ import {
 } from './mcp-client.js';
 import type { ToolRegistry } from './tool-registry.js';
 
+const mockExistsSync = vi.hoisted(() => vi.fn(() => true));
+
+vi.mock('node:fs', () => ({
+  existsSync: mockExistsSync,
+}));
 vi.mock('@modelcontextprotocol/sdk/client/stdio.js');
 vi.mock('@modelcontextprotocol/sdk/client/index.js');
 vi.mock('@google/genai');
@@ -287,6 +292,23 @@ describe('mcp-client', () => {
         env: { ...process.env, FOO: 'bar' },
         stderr: 'pipe',
       });
+    });
+
+    it('should throw if cwd does not exist', async () => {
+      mockExistsSync.mockReturnValueOnce(false);
+
+      await expect(
+        createTransport(
+          'test-server',
+          {
+            command: 'test-command',
+            cwd: '/nonexistent/path',
+          },
+          false,
+        ),
+      ).rejects.toThrow(
+        "MCP server 'test-server': configured cwd does not exist: /nonexistent/path",
+      );
     });
 
     describe('useGoogleCredentialProvider', () => {

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -34,6 +34,7 @@ import { SdkControlClientTransport } from './sdk-control-client-transport.js';
 
 import type { FunctionDeclaration } from '@google/genai';
 import { mcpToTool } from '@google/genai';
+import { existsSync } from 'node:fs';
 import { basename } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { MCPOAuthProvider } from '../mcp/oauth-provider.js';
@@ -1402,6 +1403,12 @@ export async function createTransport(
   }
 
   if (mcpServerConfig.command) {
+    if (mcpServerConfig.cwd && !existsSync(mcpServerConfig.cwd)) {
+      throw new Error(
+        `MCP server '${mcpServerName}': configured cwd does not exist: ${mcpServerConfig.cwd}`,
+      );
+    }
+
     const transport = new StdioClientTransport({
       command: mcpServerConfig.command,
       args: mcpServerConfig.args || [],


### PR DESCRIPTION
## TLDR

When an MCP server is configured with a `cwd` that doesn't exist, Node.js `spawn()` emits `spawn <cmd> ENOENT` — the same error as a missing binary. Users have no way to tell the real problem is the directory. This PR adds an `existsSync` check in `createTransport()` before spawning and throws a descriptive error: `MCP server '<name>': configured cwd does not exist: <path>`.

## Screenshots / Video Demo

**Before:**
```
[ERROR] [MCP] MCP ERROR (playwright): Error: spawn npx ENOENT
[ERROR] [MCP] Error during discovery for server 'playwright': spawn npx ENOENT
```

**After:**
```
[ERROR] [MCP] Error during discovery for server 'playwright': MCP server 'playwright': configured cwd does not exist: /tmp/this-directory-does-not-exist/mcp-servers/playwright
```

## Dive Deeper

The root cause is a Node.js quirk: `child_process.spawn()` with a non-existent `cwd` fires an `error` event with `{ code: 'ENOENT' }` — indistinguishable from the command binary not being found. The fix validates `cwd` existence before constructing `StdioClientTransport`, so the user gets an actionable message instead of a misleading one.

## Reviewer Test Plan

1. Create a settings file with an MCP server whose `cwd` points to a non-existent directory
2. Run `qwen --debug -p "hello"` from that directory
3. Check `~/.qwen/debug/<session>.txt` — should see the new descriptive error, not `spawn npx ENOENT`
4. Verify that an MCP server with a valid (or no) `cwd` still connects normally

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3163