### PR TITLE
fix(cli): set qwen3.5-plus as default model for Coding Plan

### DIFF
--- a/packages/cli/src/constants/codingPlan.ts
+++ b/packages/cli/src/constants/codingPlan.ts
@@ -53,8 +53,8 @@ export function generateCodingPlanTemplate(
     // This ensures existing users don't get prompted for unnecessary updates
     return [
       {
-        id: 'qwen3.6-plus',
-        name: '[ModelStudio Coding Plan] qwen3.6-plus',
+        id: 'qwen3.5-plus',
+        name: '[ModelStudio Coding Plan] qwen3.5-plus',
         baseUrl: 'https://coding.dashscope.aliyuncs.com/v1',
         envKey: CODING_PLAN_ENV_KEY,
         generationConfig: {
@@ -65,8 +65,9 @@ export function generateCodingPlanTemplate(
         },
       },
       {
-        id: 'qwen3.5-plus',
-        name: '[ModelStudio Coding Plan] qwen3.5-plus',
+        id: 'qwen3.6-plus',
+        name: '[ModelStudio Coding Plan] qwen3.6-plus',
+        description: 'Currently available to Pro subscribers only.',
         baseUrl: 'https://coding.dashscope.aliyuncs.com/v1',
         envKey: CODING_PLAN_ENV_KEY,
         generationConfig: {
@@ -160,8 +161,8 @@ export function generateCodingPlanTemplate(
   // Global region uses ModelStudio Coding Plan branding for Global/Intl
   return [
     {
-      id: 'qwen3.6-plus',
-      name: '[ModelStudio Coding Plan for Global/Intl] qwen3.6-plus',
+      id: 'qwen3.5-plus',
+      name: '[ModelStudio Coding Plan for Global/Intl] qwen3.5-plus',
       baseUrl: 'https://coding-intl.dashscope.aliyuncs.com/v1',
       envKey: CODING_PLAN_ENV_KEY,
       generationConfig: {
@@ -172,8 +173,9 @@ export function generateCodingPlanTemplate(
       },
     },
     {
-      id: 'qwen3.5-plus',
-      name: '[ModelStudio Coding Plan for Global/Intl] qwen3.5-plus',
+      id: 'qwen3.6-plus',
+      name: '[ModelStudio Coding Plan for Global/Intl] qwen3.6-plus',
+      description: 'Currently available to Pro subscribers only.',
       baseUrl: 'https://coding-intl.dashscope.aliyuncs.com/v1',
       envKey: CODING_PLAN_ENV_KEY,
       generationConfig: {

--- a/packages/core/src/config/models.ts
+++ b/packages/core/src/config/models.ts
@@ -7,4 +7,4 @@
 export const DEFAULT_QWEN_MODEL = 'coder-model';
 export const DEFAULT_QWEN_FLASH_MODEL = 'coder-model';
 export const DEFAULT_QWEN_EMBEDDING_MODEL = 'text-embedding-v4';
-export const MAINLINE_CODER_MODEL = 'qwen3.6-plus';
+export const MAINLINE_CODER_MODEL = 'qwen3.5-plus';


### PR DESCRIPTION
## Summary

This PR fixes issue #3037 where Lite users encounter API errors when the default qwen3.6-plus model is selected.

## Changes

- **Default model change**: Changed the default model from `qwen3.6-plus` to `qwen3.5-plus` for both China and Global/Intl regions in Coding Plan
- **Pro subscription notice**: Added description to `qwen3.6-plus` indicating "Currently available to Pro subscribers only."
- **OpenAI-compatible API default**: Updated `MAINLINE_CODER_MODEL` to `qwen3.5-plus`

## Rationale

- `qwen3.6-plus` requires Pro subscription and is not available to Lite users
- Setting `qwen3.5-plus` as the default ensures all users (Lite and Pro) can use Coding Plan out of the box
- Users who want to use `qwen3.6-plus` will see a clear description about the Pro subscription requirement

## Impact

- ✅ New Coding Plan users will default to `qwen3.5-plus` (available to both Lite and Pro)
- ✅ Users selecting `qwen3.6-plus` will see the Pro subscription requirement in the model description
- ✅ Prevents Lite users from encountering API errors with the default configuration

Fixes #3037