### PR TITLE
fix(core): allow Unicode characters in agent names

### DIFF
--- a/packages/core/src/subagents/validation.test.ts
+++ b/packages/core/src/subagents/validation.test.ts
@@ -22,6 +22,11 @@ describe('SubagentValidator', () => {
         'code_reviewer',
         'agent123',
         'my-helper',
+        '项目管理',
+        'コードレビュー',
+        '코드리뷰',
+        '项目-manager',
+        'проект_менеджер',
       ];
 
       for (const name of validNames) {
@@ -116,6 +121,14 @@ describe('SubagentValidator', () => {
       const result = validator.validateName('TestAgent');
       expect(result.isValid).toBe(true);
       expect(result.warnings).toContain(
+        'Consider using lowercase names for consistency',
+      );
+    });
+
+    it('should not warn about case for non-Latin names', () => {
+      const result = validator.validateName('项目管理');
+      expect(result.isValid).toBe(true);
+      expect(result.warnings).not.toContain(
         'Consider using lowercase names for consistency',
       );
     });

--- a/packages/core/src/subagents/validation.ts
+++ b/packages/core/src/subagents/validation.ts
@@ -107,8 +107,8 @@ export class SubagentValidator {
       errors.push('Name must be 50 characters or less');
     }
 
-    // Check valid characters (alphanumeric, hyphens, underscores)
-    const validNameRegex = /^[a-zA-Z0-9_-]+$/;
+    // Check valid characters (Unicode letters/numbers, hyphens, underscores)
+    const validNameRegex = /^[\p{L}\p{N}_-]+$/u;
     if (!validNameRegex.test(trimmedName)) {
       errors.push(
         'Name can only contain letters, numbers, hyphens, and underscores',
@@ -138,8 +138,11 @@ export class SubagentValidator {
       errors.push(`"${trimmedName}" is a reserved name and cannot be used`);
     }
 
-    // Warnings for naming conventions
-    if (trimmedName !== trimmedName.toLowerCase()) {
+    // Warnings for naming conventions (only for names that have case distinctions)
+    if (
+      trimmedName !== trimmedName.toLowerCase() &&
+      /[a-zA-Z]/.test(trimmedName)
+    ) {
       warnings.push('Consider using lowercase names for consistency');
     }
 


### PR DESCRIPTION
## TLDR

Agent name validation rejected non-ASCII characters (Chinese, Japanese, Korean, Cyrillic, etc.) because the regex was ASCII-only (`/^[a-zA-Z0-9_-]+$/`). Agents with names like `项目管理` were silently dropped during loading with no user-visible error. This PR widens the regex to use Unicode property escapes (`/^[\p{L}\p{N}_-]+$/u`) so agent names can use letters and numbers from any script.

## Screenshots / Video Demo

N/A — the test engineer verified the fix end-to-end in both headless and interactive modes. Before the fix, an agent with `name: 项目管理` was absent from `/agents manage` and headless init output. After the fix, it appears correctly alongside ASCII-named agents.

## Dive Deeper

**Root cause**: `SubagentValidator.validateName()` in `packages/core/src/subagents/validation.ts` used `/^[a-zA-Z0-9_-]+$/` which only permits ASCII. When `listSubagentsAtLevel()` parsed agent files, the validation error was caught and silently ignored (`catch (_error) { continue; }`), so the agent just disappeared.

**Fix**: Two changes in `validation.ts`:
1. Replace the regex with `/^[\p{L}\p{N}_-]+$/u` — `\p{L}` matches any Unicode letter, `\p{N}` matches any Unicode number
2. Guard the "consider using lowercase" warning to only fire when the name contains ASCII letters, since case distinctions are meaningless for CJK scripts

The rest of the pipeline (file discovery, YAML parsing, name matching, agent listing) already handles Unicode correctly. The filename doesn't matter — only the `name` field in YAML frontmatter is validated.

## Reviewer Test Plan

1. Create `.qwen/agents/测试.md` with `name: 项目管理` in frontmatter
2. Run `qwen` and execute `/agents manage` — the agent should appear under "Project Level"
3. Verify ASCII-named agents still work as before
4. Run unit tests: `cd packages/core && npx vitest run src/subagents/validation.test.ts`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3149