### PR TITLE
fix(cli): resume previous session from welcome-back instead of duplicating

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -960,7 +960,13 @@ export const AppContainer = (props: AppContainerProps) => {
     welcomeBackChoice,
     handleWelcomeBackSelection,
     handleWelcomeBackClose,
-  } = useWelcomeBack(config, handleFinalSubmit, buffer, settings.merged);
+  } = useWelcomeBack(
+    config,
+    handleFinalSubmit,
+    buffer,
+    settings.merged,
+    handleResume,
+  );
 
   const pendingHistoryItems = useMemo(
     () => [...pendingSlashCommandHistoryItems, ...pendingGeminiHistoryItems],

--- a/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -98,7 +98,7 @@ export interface UIActions {
   // Resume session dialog
   openResumeDialog: () => void;
   closeResumeDialog: () => void;
-  handleResume: (sessionId: string) => void;
+  handleResume: (sessionId: string) => Promise<boolean>;
   // Feedback dialog
   openFeedbackDialog: () => void;
   closeFeedbackDialog: () => void;

--- a/packages/cli/src/ui/hooks/useResumeCommand.test.ts
+++ b/packages/cli/src/ui/hooks/useResumeCommand.test.ts
@@ -107,7 +107,7 @@ describe('useResumeCommand', () => {
     expect(result.current.handleResume).toBe(initialHandleResume);
   });
 
-  it('handleResume no-ops when config is null', async () => {
+  it('handleResume no-ops and returns false when config is null', async () => {
     const historyManager = { clearItems: vi.fn(), loadHistory: vi.fn() };
     const startNewSession = vi.fn();
 
@@ -119,16 +119,58 @@ describe('useResumeCommand', () => {
       }),
     );
 
+    let returnValue: boolean | undefined;
     await act(async () => {
-      await result.current.handleResume('session-1');
+      returnValue = await result.current.handleResume('session-1');
     });
 
+    expect(returnValue).toBe(false);
     expect(startNewSession).not.toHaveBeenCalled();
     expect(historyManager.clearItems).not.toHaveBeenCalled();
     expect(historyManager.loadHistory).not.toHaveBeenCalled();
   });
 
-  it('handleResume closes the dialog immediately and restores session state', async () => {
+  it('handleResume returns false when loadSession yields no data', async () => {
+    resumeMocks.reset();
+    const historyManager = { clearItems: vi.fn(), loadHistory: vi.fn() };
+    const startNewSession = vi.fn();
+    const config = {
+      getTargetDir: () => '/tmp',
+      getGeminiClient: () => ({ initialize: vi.fn() }),
+      startNewSession: vi.fn(),
+      getDebugLogger: () => ({
+        warn: vi.fn(),
+        debug: vi.fn(),
+        error: vi.fn(),
+      }),
+    } as unknown as import('@qwen-code/qwen-code-core').Config;
+
+    // Force the mocked loadSession to resolve with undefined, simulating a
+    // listed session whose file disappeared or has malformed lines.
+    resumeMocks.createPendingLoadSession();
+    resumeMocks.resolvePendingLoadSession(undefined);
+
+    const { result } = renderHook(() =>
+      useResumeCommand({
+        config,
+        historyManager,
+        startNewSession,
+      }),
+    );
+
+    let returnValue: boolean | undefined;
+    await act(async () => {
+      returnValue = await result.current.handleResume('stale-session');
+    });
+
+    expect(returnValue).toBe(false);
+    expect(startNewSession).not.toHaveBeenCalled();
+    expect(config.startNewSession).not.toHaveBeenCalled();
+    expect(historyManager.clearItems).not.toHaveBeenCalled();
+    expect(historyManager.loadHistory).not.toHaveBeenCalled();
+  });
+
+  it('handleResume closes the dialog immediately, restores session state, and returns true', async () => {
     resumeMocks.reset();
     resumeMocks.createPendingLoadSession();
 
@@ -163,13 +205,11 @@ describe('useResumeCommand', () => {
     });
     expect(result.current.isResumeDialogOpen).toBe(true);
 
-    let resumePromise: Promise<void> | undefined;
+    let resumePromise: Promise<boolean> | undefined;
     act(() => {
       // Start resume but do not await it yet — we want to assert the dialog
       // closes immediately before the async session load completes.
-      resumePromise = result.current.handleResume('session-2') as unknown as
-        | Promise<void>
-        | undefined;
+      resumePromise = result.current.handleResume('session-2');
     });
     expect(result.current.isResumeDialogOpen).toBe(false);
 
@@ -177,10 +217,12 @@ describe('useResumeCommand', () => {
     resumeMocks.resolvePendingLoadSession({
       conversation: [{ role: 'user', parts: [{ text: 'hello' }] }],
     });
+    let returnValue: boolean | undefined;
     await act(async () => {
-      await resumePromise;
+      returnValue = await resumePromise;
     });
 
+    expect(returnValue).toBe(true);
     expect(config.startNewSession).toHaveBeenCalledWith(
       'session-2',
       expect.objectContaining({

--- a/packages/cli/src/ui/hooks/useResumeCommand.ts
+++ b/packages/cli/src/ui/hooks/useResumeCommand.ts
@@ -25,7 +25,14 @@ export interface UseResumeCommandResult {
   isResumeDialogOpen: boolean;
   openResumeDialog: () => void;
   closeResumeDialog: () => void;
-  handleResume: (sessionId: string) => void;
+  /**
+   * Resumes a session by ID. Returns true if the session was actually
+   * loaded and applied; false if the call short-circuited (missing config,
+   * loadSession returned no data, etc.). Callers that want to know whether
+   * the resume succeeded — e.g., the welcome-back fallback — must check
+   * the return value.
+   */
+  handleResume: (sessionId: string) => Promise<boolean>;
 }
 
 export function useResumeCommand(
@@ -44,9 +51,9 @@ export function useResumeCommand(
   const { config, historyManager, startNewSession, remount } = options ?? {};
 
   const handleResume = useCallback(
-    async (sessionId: string) => {
+    async (sessionId: string): Promise<boolean> => {
       if (!config || !historyManager || !startNewSession) {
-        return;
+        return false;
       }
 
       // Close dialog immediately to prevent input capture during async operations.
@@ -57,7 +64,7 @@ export function useResumeCommand(
       const sessionData = await sessionService.loadSession(sessionId);
 
       if (!sessionData) {
-        return;
+        return false;
       }
 
       // Start new session in UI context.
@@ -87,6 +94,7 @@ export function useResumeCommand(
 
       // Refresh terminal UI.
       remount?.();
+      return true;
     },
     [closeResumeDialog, config, historyManager, startNewSession, remount],
   );

--- a/packages/cli/src/ui/hooks/useWelcomeBack.test.ts
+++ b/packages/cli/src/ui/hooks/useWelcomeBack.test.ts
@@ -1,0 +1,318 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useWelcomeBack } from './useWelcomeBack.js';
+import { type Settings } from '../../config/settingsSchema.js';
+
+const welcomeBackMocks = vi.hoisted(() => {
+  const getProjectSummaryInfo = vi.fn();
+  const listSessions = vi.fn();
+
+  return {
+    getProjectSummaryInfo,
+    listSessions,
+    sessionServiceCtor: vi.fn(),
+  };
+});
+
+vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
+
+  class SessionService {
+    constructor(cwd: string) {
+      welcomeBackMocks.sessionServiceCtor(cwd);
+    }
+    listSessions(...args: unknown[]) {
+      return welcomeBackMocks.listSessions(...args);
+    }
+  }
+
+  return {
+    ...actual,
+    SessionService,
+    getProjectSummaryInfo: welcomeBackMocks.getProjectSummaryInfo,
+  };
+});
+
+function makeConfig() {
+  return {
+    getTargetDir: () => '/tmp/test-project',
+    getDebugLogger: () => ({
+      debug: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  } as unknown as import('@qwen-code/qwen-code-core').Config;
+}
+
+function makeBuffer() {
+  return { setText: vi.fn() };
+}
+
+const summaryWithHistory = {
+  hasHistory: true,
+  content: '# Project Summary\n\n## Overall Goal\nBuild things',
+};
+
+describe('useWelcomeBack', () => {
+  beforeEach(() => {
+    welcomeBackMocks.getProjectSummaryInfo.mockReset();
+    welcomeBackMocks.listSessions.mockReset();
+    welcomeBackMocks.sessionServiceCtor.mockReset();
+  });
+
+  it('shows the welcome-back dialog when a project summary exists', async () => {
+    welcomeBackMocks.getProjectSummaryInfo.mockResolvedValue(
+      summaryWithHistory,
+    );
+
+    const config = makeConfig();
+    const buffer = makeBuffer();
+    const submitQuery = vi.fn();
+    const settings = {} as Settings;
+
+    const { result } = renderHook(() =>
+      useWelcomeBack(config, submitQuery, buffer, settings),
+    );
+
+    await waitFor(() => {
+      expect(result.current.showWelcomeBackDialog).toBe(true);
+    });
+    expect(result.current.welcomeBackInfo).toEqual(summaryWithHistory);
+  });
+
+  it('does not show the dialog when enableWelcomeBack is false', async () => {
+    welcomeBackMocks.getProjectSummaryInfo.mockResolvedValue(
+      summaryWithHistory,
+    );
+
+    const config = makeConfig();
+    const buffer = makeBuffer();
+    const submitQuery = vi.fn();
+    const settings = { ui: { enableWelcomeBack: false } } as Settings;
+
+    const { result } = renderHook(() =>
+      useWelcomeBack(config, submitQuery, buffer, settings),
+    );
+
+    // Allow any pending microtasks to flush.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(welcomeBackMocks.getProjectSummaryInfo).not.toHaveBeenCalled();
+    expect(result.current.showWelcomeBackDialog).toBe(false);
+  });
+
+  it('resumes the most recent session when "continue" is selected and a session exists', async () => {
+    welcomeBackMocks.getProjectSummaryInfo.mockResolvedValue(
+      summaryWithHistory,
+    );
+    welcomeBackMocks.listSessions.mockResolvedValue({
+      items: [{ sessionId: 'session-abc' }],
+      hasMore: false,
+    });
+
+    const config = makeConfig();
+    const buffer = makeBuffer();
+    const submitQuery = vi.fn();
+    const settings = {} as Settings;
+    const handleResume = vi.fn().mockResolvedValue(true);
+
+    const { result } = renderHook(() =>
+      useWelcomeBack(config, submitQuery, buffer, settings, handleResume),
+    );
+
+    await waitFor(() => {
+      expect(result.current.showWelcomeBackDialog).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.handleWelcomeBackSelection('continue');
+    });
+
+    expect(welcomeBackMocks.sessionServiceCtor).toHaveBeenCalledWith(
+      '/tmp/test-project',
+    );
+    expect(welcomeBackMocks.listSessions).toHaveBeenCalledWith({ size: 1 });
+    expect(handleResume).toHaveBeenCalledWith('session-abc');
+    // Fallback path must NOT fire when resume succeeds.
+    expect(buffer.setText).not.toHaveBeenCalled();
+    expect(result.current.shouldFillInput).toBe(false);
+    expect(result.current.welcomeBackChoice).toBe('continue');
+    expect(result.current.showWelcomeBackDialog).toBe(false);
+  });
+
+  it('falls back to input fill when handleResume reports failure (e.g. loadSession returned undefined)', async () => {
+    welcomeBackMocks.getProjectSummaryInfo.mockResolvedValue(
+      summaryWithHistory,
+    );
+    welcomeBackMocks.listSessions.mockResolvedValue({
+      items: [{ sessionId: 'session-stale' }],
+      hasMore: false,
+    });
+
+    const config = makeConfig();
+    const buffer = makeBuffer();
+    const submitQuery = vi.fn();
+    const settings = {} as Settings;
+    // handleResume short-circuits and returns false (e.g., the listed session
+    // file disappeared between listSessions and loadSession, or is malformed).
+    const handleResume = vi.fn().mockResolvedValue(false);
+
+    const { result } = renderHook(() =>
+      useWelcomeBack(config, submitQuery, buffer, settings, handleResume),
+    );
+
+    await waitFor(() => {
+      expect(result.current.showWelcomeBackDialog).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.handleWelcomeBackSelection('continue');
+    });
+
+    expect(handleResume).toHaveBeenCalledWith('session-stale');
+    // Fallback should fire because the resume reported failure.
+    await waitFor(() => {
+      expect(buffer.setText).toHaveBeenCalledWith(
+        "@.qwen/PROJECT_SUMMARY.md, Based on our previous conversation,Let's continue?",
+      );
+    });
+  });
+
+  it('falls back to input fill when no session exists for the project', async () => {
+    welcomeBackMocks.getProjectSummaryInfo.mockResolvedValue(
+      summaryWithHistory,
+    );
+    welcomeBackMocks.listSessions.mockResolvedValue({
+      items: [],
+      hasMore: false,
+    });
+
+    const config = makeConfig();
+    const buffer = makeBuffer();
+    const submitQuery = vi.fn();
+    const settings = {} as Settings;
+    const handleResume = vi.fn();
+
+    const { result } = renderHook(() =>
+      useWelcomeBack(config, submitQuery, buffer, settings, handleResume),
+    );
+
+    await waitFor(() => {
+      expect(result.current.showWelcomeBackDialog).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.handleWelcomeBackSelection('continue');
+    });
+
+    expect(handleResume).not.toHaveBeenCalled();
+    // The effect that flushes inputFillText to the buffer runs on the next
+    // render; waitFor lets us observe it deterministically.
+    await waitFor(() => {
+      expect(buffer.setText).toHaveBeenCalledWith(
+        "@.qwen/PROJECT_SUMMARY.md, Based on our previous conversation,Let's continue?",
+      );
+    });
+  });
+
+  it('falls back to input fill when handleResume is not provided', async () => {
+    welcomeBackMocks.getProjectSummaryInfo.mockResolvedValue(
+      summaryWithHistory,
+    );
+
+    const config = makeConfig();
+    const buffer = makeBuffer();
+    const submitQuery = vi.fn();
+    const settings = {} as Settings;
+
+    const { result } = renderHook(() =>
+      useWelcomeBack(config, submitQuery, buffer, settings),
+    );
+
+    await waitFor(() => {
+      expect(result.current.showWelcomeBackDialog).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.handleWelcomeBackSelection('continue');
+    });
+
+    expect(welcomeBackMocks.listSessions).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(buffer.setText).toHaveBeenCalledWith(
+        "@.qwen/PROJECT_SUMMARY.md, Based on our previous conversation,Let's continue?",
+      );
+    });
+  });
+
+  it('falls back to input fill when listSessions throws', async () => {
+    welcomeBackMocks.getProjectSummaryInfo.mockResolvedValue(
+      summaryWithHistory,
+    );
+    welcomeBackMocks.listSessions.mockRejectedValue(new Error('disk error'));
+
+    const config = makeConfig();
+    const buffer = makeBuffer();
+    const submitQuery = vi.fn();
+    const settings = {} as Settings;
+    const handleResume = vi.fn();
+
+    const { result } = renderHook(() =>
+      useWelcomeBack(config, submitQuery, buffer, settings, handleResume),
+    );
+
+    await waitFor(() => {
+      expect(result.current.showWelcomeBackDialog).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.handleWelcomeBackSelection('continue');
+    });
+
+    expect(handleResume).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(buffer.setText).toHaveBeenCalledWith(
+        "@.qwen/PROJECT_SUMMARY.md, Based on our previous conversation,Let's continue?",
+      );
+    });
+  });
+
+  it('does nothing on "restart" beyond closing the dialog', async () => {
+    welcomeBackMocks.getProjectSummaryInfo.mockResolvedValue(
+      summaryWithHistory,
+    );
+
+    const config = makeConfig();
+    const buffer = makeBuffer();
+    const submitQuery = vi.fn();
+    const settings = {} as Settings;
+    const handleResume = vi.fn();
+
+    const { result } = renderHook(() =>
+      useWelcomeBack(config, submitQuery, buffer, settings, handleResume),
+    );
+
+    await waitFor(() => {
+      expect(result.current.showWelcomeBackDialog).toBe(true);
+    });
+
+    await act(async () => {
+      await result.current.handleWelcomeBackSelection('restart');
+    });
+
+    expect(handleResume).not.toHaveBeenCalled();
+    expect(welcomeBackMocks.listSessions).not.toHaveBeenCalled();
+    expect(buffer.setText).not.toHaveBeenCalled();
+    expect(result.current.welcomeBackChoice).toBe('restart');
+    expect(result.current.showWelcomeBackDialog).toBe(false);
+  });
+});

--- a/packages/cli/src/ui/hooks/useWelcomeBack.ts
+++ b/packages/cli/src/ui/hooks/useWelcomeBack.ts
@@ -7,6 +7,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import {
   getProjectSummaryInfo,
+  SessionService,
   type ProjectSummaryInfo,
   type Config,
 } from '@qwen-code/qwen-code-core';
@@ -32,6 +33,7 @@ export function useWelcomeBack(
   submitQuery: (query: string) => void,
   buffer: { setText: (text: string) => void },
   settings: Settings,
+  handleResume?: (sessionId: string) => Promise<boolean>,
 ): WelcomeBackState & WelcomeBackActions {
   const [welcomeBackInfo, setWelcomeBackInfo] =
     useState<ProjectSummaryInfo | null>(null);
@@ -63,21 +65,44 @@ export function useWelcomeBack(
 
   // Handle welcome back dialog selection
   const handleWelcomeBackSelection = useCallback(
-    (choice: 'restart' | 'continue') => {
+    async (choice: 'restart' | 'continue') => {
       setWelcomeBackChoice(choice);
       setShowWelcomeBackDialog(false);
 
       if (choice === 'continue' && welcomeBackInfo?.content) {
-        // Create the context message to fill in the input box
-        const contextMessage = `@.qwen/PROJECT_SUMMARY.md, Based on our previous conversation,Let's continue?`;
+        // Try to resume the most recent session for this project so the user
+        // gets the actual conversation history back, not just the summary text.
+        // If no session JSONL exists (e.g., PROJECT_SUMMARY.md was committed
+        // without chat history), or if the listed session can't be loaded,
+        // fall back to injecting the summary as context. handleResume returns
+        // false when it short-circuits (e.g., loadSession returns nothing
+        // because the file disappeared or has malformed lines), so we check
+        // its result rather than treating any fulfilled call as success.
+        let didResume = false;
+        if (handleResume) {
+          try {
+            const sessionService = new SessionService(config.getTargetDir());
+            const result = await sessionService.listSessions({ size: 1 });
+            if (result.items.length > 0) {
+              didResume = await handleResume(result.items[0].sessionId);
+            }
+          } catch (error) {
+            config.getDebugLogger().debug('Welcome back resume failed:', error);
+          }
+        }
 
-        // Set the input fill state instead of directly submitting
-        setInputFillText(contextMessage);
-        setShouldFillInput(true);
+        if (!didResume) {
+          // Create the context message to fill in the input box
+          const contextMessage = `@.qwen/PROJECT_SUMMARY.md, Based on our previous conversation,Let's continue?`;
+
+          // Set the input fill state instead of directly submitting
+          setInputFillText(contextMessage);
+          setShouldFillInput(true);
+        }
       }
       // If choice is 'restart', just close the dialog and continue normally
     },
-    [welcomeBackInfo],
+    [config, handleResume, welcomeBackInfo],
   );
 
   const handleWelcomeBackClose = useCallback(() => {


### PR DESCRIPTION
## TLDR

Fixes the welcome-back "Continue previous conversation" flow so it actually reopens the previous session instead of creating a brand new one each visit. Previously, every time a user re-entered a project that had a `.qwen/PROJECT_SUMMARY.md` and chose "Continue", a fresh session was created with an auto-injected `@.qwen/PROJECT_SUMMARY.md, Based on our previous conversation, Let's continue?` prompt — accumulating duplicates and discarding the actual conversation history.

## Screenshots / Video Demo

N/A — terminal UI behavior change, no visual diff. The observable effect is that selecting "Continue previous conversation" now re-renders the prior conversation history inline instead of starting an empty session with an injected summary prompt, and `/resume` no longer shows a growing pile of duplicate sessions.

## Dive Deeper

**Root cause.** The welcome-back dialog and the `/resume` slash command were two completely independent code paths. `useResumeCommand.handleResume` correctly loads a session JSONL, restores UI history, and calls `config.startNewSession(sessionId, sessionData)` to swap the in-memory chat. `useWelcomeBack.handleWelcomeBackSelection` did none of that — on "continue" it merely prefilled the composer with a hardcoded summary prompt and let the user submit it, which got recorded as the first message of the *fresh startup session*. Each visit therefore minted a new JSONL file, and the original conversation was unreachable through the welcome-back flow.

**Fix.** Wire `useWelcomeBack` to the same resume path that `/resume` uses.

- `useWelcomeBack` now accepts an optional `handleResume` parameter. On `"continue"`, it instantiates `SessionService(config.getTargetDir())`, calls `listSessions({ size: 1 })` to find the most recent session for the current project, and invokes `handleResume(sessionId)` — the same function `/resume` uses, which loads the full conversation and renders it in the UI.
- `AppContainer` passes `handleResume` from `useResumeCommand` into the `useWelcomeBack` call site.
- The original input-fill behavior is preserved as a fallback, used when `handleResume` is not provided, when no session exists yet (e.g., `PROJECT_SUMMARY.md` was committed without chat history), when `listSessions` throws, *or* when `handleResume` reports failure.

**`handleResume` now returns `Promise<boolean>`.** The previous interface declared `(sessionId: string) => void`, but the implementation was already `async` and could silently no-op when `loadSession` returned `undefined` (a real edge case if the listed session file disappeared between `listSessions` and `loadSession`, or if its first line is malformed). Treating any fulfilled `handleResume` call as "success" would have suppressed the welcome-back fallback in that case, leaving the user in the startup session with neither the resumed history nor the summary context. The new return type makes success/failure explicit; `useWelcomeBack` only suppresses the fallback when `handleResume` returns `true`. The `UIActionsContext.handleResume` signature was updated to match. Existing callers (`StandaloneSessionPicker` via `useSelectionList`) already discard the return value, so this change is backwards compatible.

**Known limitations / followups.** Both the welcome-back path and the existing `/resume` path close their dialog *before* the async session load finishes. There is a narrow race window where the composer becomes interactive and a startup `initialPrompt` (or fast manual input) could submit against the still-loading new session. This is a pre-existing issue with `/resume` that the welcome-back fix inherits unchanged; addressing it cleanly would require an `isResuming` state in `useResumeCommand` and a guard in the composer. Out of scope for this bugfix.

## Reviewer Test Plan

1. `cd` into a fresh test project. Run `qwen --approval-mode yolo`, send a few messages, then `/summary` to generate `.qwen/PROJECT_SUMMARY.md`. Exit.
2. Re-enter the same directory with `qwen`. The welcome-back dialog should appear.
3. Select **"Continue previous conversation"**. Expected: the prior conversation history renders inline immediately (no `@.qwen/PROJECT_SUMMARY.md, Based on our previous conversation, Let's continue?` injection, no fresh session file created).
4. Run `/resume`. Expected: only one session for this project, with its original first user message — not the injected summary prompt.
5. Repeat steps 2–4 a couple more times. Expected: still one session, no duplicate accumulation.
6. **Fallback case**: in a project that has `.qwen/PROJECT_SUMMARY.md` but no session JSONL files (e.g., delete `~/.qwen/projects/<sanitized-cwd>/chats/*.jsonl`), select "Continue previous conversation". Expected: the composer is prefilled with `@.qwen/PROJECT_SUMMARY.md, Based on our previous conversation, Let's continue?` (the original behavior, which is now correctly scoped to the no-session case).
7. **`/resume` regression check**: open `/resume` directly and pick a session. Expected: still works as before — return value is ignored by the picker.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3152