### PR TITLE
fix(core): respect respectGitIgnore setting in @file injection path

### DIFF
--- a/packages/core/src/utils/pathReader.test.ts
+++ b/packages/core/src/utils/pathReader.test.ts
@@ -20,6 +20,10 @@ const createMockConfig = (
   cwd: string,
   otherDirs: string[] = [],
   mockFileService?: FileDiscoveryService,
+  fileFilteringOptions?: {
+    respectGitIgnore: boolean;
+    respectQwenIgnore: boolean;
+  },
 ): Config => {
   const workspace = new WorkspaceContext(cwd, otherDirs);
   const fileSystemService = new StandardFileSystemService();
@@ -29,6 +33,11 @@ const createMockConfig = (
     getTargetDir: () => cwd,
     getFileSystemService: () => fileSystemService,
     getFileService: () => mockFileService,
+    getFileFilteringOptions: () =>
+      fileFilteringOptions ?? {
+        respectGitIgnore: true,
+        respectQwenIgnore: true,
+      },
     getTruncateToolOutputThreshold: () => 2500,
     getTruncateToolOutputLines: () => 500,
     getContentGeneratorConfig: () => ({
@@ -339,6 +348,29 @@ describe('readPathFromWorkspace', () => {
       expect(resultText).toContain('visible');
       expect(resultText).not.toContain('invisible');
       expect(mockFileService.filterFiles).toHaveBeenCalled();
+    });
+
+    it('should pass respectGitIgnore: false from config to filterFiles', async () => {
+      mock({
+        [CWD]: {
+          'ignored.txt': 'ignored content',
+        },
+      });
+      const mockFileService = {
+        filterFiles: vi.fn((files) => files),
+      } as unknown as FileDiscoveryService;
+      const config = createMockConfig(CWD, [], mockFileService, {
+        respectGitIgnore: false,
+        respectQwenIgnore: true,
+      });
+      await readPathFromWorkspace('ignored.txt', config);
+      expect(mockFileService.filterFiles).toHaveBeenCalledWith(
+        ['ignored.txt'],
+        {
+          respectGitIgnore: false,
+          respectQwenIgnore: true,
+        },
+      );
     });
   });
 

--- a/packages/core/src/utils/pathReader.ts
+++ b/packages/core/src/utils/pathReader.ts
@@ -72,9 +72,10 @@ export async function readPathFromWorkspace(
     const relativeFiles = files.map((p) =>
       path.relative(config.getTargetDir(), p),
     );
+    const filteringOptions = config.getFileFilteringOptions();
     const filteredFiles = fileService.filterFiles(relativeFiles, {
-      respectGitIgnore: true,
-      respectQwenIgnore: true,
+      respectGitIgnore: filteringOptions.respectGitIgnore,
+      respectQwenIgnore: filteringOptions.respectQwenIgnore,
     });
     const finalFiles = filteredFiles.map((p) =>
       path.resolve(config.getTargetDir(), p),
@@ -93,9 +94,10 @@ export async function readPathFromWorkspace(
   } else {
     // It's a single file, check if it's ignored.
     const relativePath = path.relative(config.getTargetDir(), absolutePath);
+    const singleFileFilteringOptions = config.getFileFilteringOptions();
     const filtered = fileService.filterFiles([relativePath], {
-      respectGitIgnore: true,
-      respectQwenIgnore: true,
+      respectGitIgnore: singleFileFilteringOptions.respectGitIgnore,
+      respectQwenIgnore: singleFileFilteringOptions.respectQwenIgnore,
     });
 
     if (filtered.length === 0) {


### PR DESCRIPTION
## TLDR

`pathReader.ts` hardcoded `respectGitIgnore: true` when filtering files for `@{path}` injection (used by slash commands), ignoring the user's `context.fileFiltering.respectGitIgnore` setting. Gitignored files were silently dropped even when the user explicitly set the setting to `false`. Now reads the filtering options from config.

## Screenshots / Video Demo

N/A — no user-facing change in the UI. The fix changes internal behavior: `@{file}` references in slash commands now respect the `respectGitIgnore` setting instead of always filtering out gitignored files.

## Dive Deeper

Two call sites in `readPathFromWorkspace()` (`pathReader.ts`) passed `{ respectGitIgnore: true, respectQwenIgnore: true }` to `fileService.filterFiles()` instead of reading from `config.getFileFilteringOptions()`. This affected both the single-file and directory-expansion branches.

Other code paths (`useAtCompletion.ts` for autocomplete, `atCommandProcessor.ts` for direct `@path` input) already read from config correctly — only the `@{path}` injection path used by slash commands was broken.

## Reviewer Test Plan

1. Create a project with a `.gitignore` that ignores a file (e.g., `secret.txt`)
2. Add `{ "context": { "fileFiltering": { "respectGitIgnore": false } } }` to `.qwen/settings.json`
3. Create a slash command in `.qwen/commands/test.md` that references `@{secret.txt}`
4. Run the slash command — the file content should be injected into the prompt
5. Remove the setting (or set to `true`) — the file should be filtered out with the "was ignored" info message

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3142