### PR TITLE
feat(cli): support bare exit/quit commands to exit the CLI

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -475,6 +475,45 @@ describe('AppContainer State Management', () => {
       expect(mockSubmitQuery).toHaveBeenCalledWith('/btw quick side question');
       expect(mockQueueMessage).not.toHaveBeenCalled();
     });
+
+    it.each(['exit', 'quit', ':q', ':q!', ':wq', ':wq!'])(
+      'routes bare "%s" to /quit instead of sending as a message',
+      (command) => {
+        const mockHandleSlashCommand = vi.fn();
+        const mockQueueMessage = vi.fn();
+
+        mockedUseSlashCommandProcessor.mockReturnValue({
+          handleSlashCommand: mockHandleSlashCommand,
+          slashCommands: [],
+          pendingHistoryItems: [],
+          commandContext: {},
+          shellConfirmationRequest: null,
+          confirmationRequest: null,
+        });
+        mockedUseMessageQueue.mockReturnValue({
+          messageQueue: [],
+          addMessage: mockQueueMessage,
+          clearQueue: vi.fn(),
+          getQueuedMessagesText: vi.fn().mockReturnValue(''),
+          popAllMessages: vi.fn().mockReturnValue(null),
+          drainQueue: vi.fn().mockReturnValue([]),
+        });
+
+        render(
+          <AppContainer
+            config={mockConfig}
+            settings={mockSettings}
+            version="1.0.0"
+            initializationResult={mockInitResult}
+          />,
+        );
+
+        capturedUIActions.handleFinalSubmit(command);
+
+        expect(mockHandleSlashCommand).toHaveBeenCalledWith('/quit');
+        expect(mockQueueMessage).not.toHaveBeenCalled();
+      },
+    );
   });
 
   describe('Settings Integration', () => {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -813,6 +813,16 @@ export const AppContainer = (props: AppContainerProps) => {
         return;
       }
 
+      // Handle bare exit/quit commands (without the / prefix)
+      if (
+        ['exit', 'quit', ':q', ':q!', ':wq', ':wq!'].includes(
+          submittedValue.trim(),
+        )
+      ) {
+        void handleSlashCommand('/quit');
+        return;
+      }
+
       // Check if speculation has results for this submission
       const spec = speculationRef.current;
       if (
@@ -938,6 +948,7 @@ export const AppContainer = (props: AppContainerProps) => {
       agentViewState,
       streamingState,
       submitQuery,
+      handleSlashCommand,
       config,
       geminiClient,
       historyManager,


### PR DESCRIPTION
## TLDR

Typing `exit`, `quit`, `:q`, `:q!`, `:wq`, or `:wq!` at the prompt now exits the CLI — same as `/quit`. This matches Claude Code behavior and helps users on mobile (e.g. Termux) where Ctrl+C is harder to type.

## Screenshots / Video Demo

N/A — terminal exit behavior; the CLI prints session duration and terminates, identical to `/quit`.

## Dive Deeper

Added an intercept in `handleFinalSubmit` (AppContainer.tsx) that checks if the trimmed input matches any of the bare exit keywords before it's sent to the model. If it matches, redirects to `handleSlashCommand('/quit')`. This is the same approach used by Claude Code in their `handlePromptSubmit`.

The `!`-suffixed variants (`:q!`, `:wq!`) work correctly because the shell-mode toggle only activates when `!` is typed into an empty buffer — when preceded by `:q` or `:wq`, the buffer is non-empty so shell mode doesn't interfere.

## Reviewer Test Plan

1. `npm run build && npm run bundle`
2. Run `node dist/cli.js`
3. At the prompt, type `exit` and press Enter → CLI should exit
4. Repeat with `quit`, `:q`, `:q!`, `:wq`, `:wq!` → all should exit
5. Type `exit now`, `please quit`, `exitcode`, `quitting` → these should be sent to the model as normal messages, NOT trigger exit

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes #3169