### PR TITLE
feat(auth): Adjust Qwen OAuth free tier quota from 1,000 to 100 requests/day

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 Qwen Code is an open-source AI agent for the terminal, optimized for Qwen series models. It helps you understand large codebases, automate tedious work, and ship faster.
 
-- **Multi-protocol, OAuth free tier**: use OpenAI / Anthropic / Gemini-compatible APIs, or sign in with Qwen OAuth for 1,000 free requests/day.
+- **Multi-protocol, OAuth free tier**: use OpenAI / Anthropic / Gemini-compatible APIs, or sign in with Qwen OAuth for 100 free requests/day.
 - **Open-source, co-evolving**: both the framework and the Qwen3-Coder model are open-source—and they ship and evolve together.
 - **Agentic workflow, feature-rich**: rich built-in tools (Skills, SubAgents) for a full agentic workflow and a Claude Code-like experience.
 - **Terminal-first, IDE-friendly**: built for developers who live in the command line, with optional integration for VS Code, Zed, and JetBrains IDEs.

--- a/docs/developers/tools/web-search.md
+++ b/docs/developers/tools/web-search.md
@@ -8,7 +8,7 @@ Use `web_search` to perform a web search and get information from the internet. 
 
 ### Supported Providers
 
-1. **DashScope** (Official, Free) - Automatically available for Qwen OAuth users (200 requests/minute, 1000 requests/day)
+1. **DashScope** (Official, Free) - Automatically available for Qwen OAuth users (200 requests/minute, 100 requests/day)
 2. **Tavily** - High-quality search API with built-in answer generation
 3. **Google Custom Search** - Google's Custom Search JSON API
 
@@ -135,7 +135,7 @@ web_search(query="best practices for React 19", provider="dashscope")
 - **Cost:** Free
 - **Authentication:** Automatically available when using Qwen OAuth authentication
 - **Configuration:** No API key required, automatically added to provider list for Qwen OAuth users
-- **Quota:** 200 requests/minute, 1000 requests/day
+- **Quota:** 200 requests/minute, 100 requests/day
 - **Best for:** General queries, always available as fallback for Qwen OAuth users
 - **Auto-registration:** If you're using Qwen OAuth, DashScope is automatically added to your provider list even if you don't configure it explicitly
 

--- a/docs/users/configuration/auth.md
+++ b/docs/users/configuration/auth.md
@@ -13,7 +13,7 @@ Use this if you want the simplest setup and you're using Qwen models.
 - **How it works**: on first start, Qwen Code opens a browser login page. After you finish, credentials are cached locally so you usually won't need to log in again.
 - **Requirements**: a `qwen.ai` account + internet access (at least for the first login).
 - **Benefits**: no API key management, automatic credential refresh.
-- **Cost & quota**: free, with a quota of **60 requests/minute** and **1,000 requests/day**.
+- **Cost & quota**: free, with a quota of **60 requests/minute** and **100 requests/day**.
 
 Start the CLI and follow the browser flow:
 
@@ -327,7 +327,7 @@ You'll see a selector with arrow-key navigation:
 ```
 Select authentication method:
 
-> Qwen OAuth - Free · Up to 1,000 requests/day · Qwen latest models
+> Qwen OAuth - Free · Up to 100 requests/day · Qwen latest models
   Alibaba Cloud Coding Plan - Paid · Up to 6,000 requests/5 hrs · All Alibaba Cloud Coding Plan Models
 
 (Use ↑ ↓ arrows to navigate, Enter to select, Ctrl+C to exit)

--- a/packages/cli/src/commands/auth/handler.ts
+++ b/packages/cli/src/commands/auth/handler.ts
@@ -429,7 +429,7 @@ export async function showAuthStatus(): Promise<void> {
     if (selectedType === AuthType.QWEN_OAUTH) {
       writeStdoutLine(t('✓ Authentication Method: Qwen OAuth'));
       writeStdoutLine(t('  Type: Free tier'));
-      writeStdoutLine(t('  Limit: Up to 1,000 requests/day'));
+      writeStdoutLine(t('  Limit: Up to 100 requests/day'));
       writeStdoutLine(t('  Models: Qwen latest models\n'));
     } else if (selectedType === AuthType.USE_OPENAI) {
       // Check for Coding Plan configuration

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -1245,8 +1245,8 @@ export default {
   'Terms of Services and Privacy Notice':
     'Nutzungsbedingungen und Datenschutzhinweis',
   'Qwen OAuth': 'Qwen OAuth',
-  'Free \u00B7 Up to 1,000 requests/day \u00B7 Qwen latest models':
-    'Kostenlos \u00B7 Bis zu 1.000 Anfragen/Tag \u00B7 Qwen neueste Modelle',
+  'Free \u00B7 Up to 100 requests/day \u00B7 Qwen latest models':
+    'Kostenlos \u00B7 Bis zu 100 Anfragen/Tag \u00B7 Qwen neueste Modelle',
   'Login with QwenChat account to use daily free quota.':
     'Melden Sie sich mit Ihrem QwenChat-Konto an, um das tägliche kostenlose Kontingent zu nutzen.',
   'Paid \u00B7 Up to 6,000 requests/5 hrs \u00B7 All Alibaba Cloud Coding Plan Models':
@@ -1948,7 +1948,7 @@ export default {
   '✓ Authentication Method: Qwen OAuth':
     '✓ Authentifizierungsmethode: Qwen OAuth',
   '  Type: Free tier': '  Typ: Kostenlos',
-  '  Limit: Up to 1,000 requests/day': '  Limit: Bis zu 1.000 Anfragen/Tag',
+  '  Limit: Up to 100 requests/day': '  Limit: Bis zu 100 Anfragen/Tag',
   '  Models: Qwen latest models\n': '  Modelle: Qwen neueste Modelle\n',
   '✓ Authentication Method: Alibaba Cloud Coding Plan':
     '✓ Authentifizierungsmethode: Alibaba Cloud Coding Plan',

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1298,8 +1298,8 @@ export default {
   'Terms of Services and Privacy Notice':
     'Terms of Services and Privacy Notice',
   'Qwen OAuth': 'Qwen OAuth',
-  'Free \u00B7 Up to 1,000 requests/day \u00B7 Qwen latest models':
-    'Free \u00B7 Up to 1,000 requests/day \u00B7 Qwen latest models',
+  'Free \u00B7 Up to 100 requests/day \u00B7 Qwen latest models':
+    'Free \u00B7 Up to 100 requests/day \u00B7 Qwen latest models',
   'Login with QwenChat account to use daily free quota.':
     'Login with QwenChat account to use daily free quota.',
   'Paid \u00B7 Up to 6,000 requests/5 hrs \u00B7 All Alibaba Cloud Coding Plan Models':

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -1329,8 +1329,8 @@ export default {
   'Terms of Services and Privacy Notice':
     "Conditions d'utilisation et avis de confidentialité",
   'Qwen OAuth': 'Qwen OAuth',
-  'Free \u00B7 Up to 1,000 requests/day \u00B7 Qwen latest models':
-    "Gratuit · Jusqu'à 1 000 requêtes/jour · Derniers modèles Qwen",
+  'Free \u00B7 Up to 100 requests/day \u00B7 Qwen latest models':
+    "Gratuit · Jusqu'à 100 requêtes/jour · Derniers modèles Qwen",
   'Login with QwenChat account to use daily free quota.':
     'Connectez-vous avec un compte QwenChat pour utiliser le quota gratuit quotidien.',
   'Paid \u00B7 Up to 6,000 requests/5 hrs \u00B7 All Alibaba Cloud Coding Plan Models':
@@ -2039,7 +2039,7 @@ export default {
   '✓ Authentication Method: Qwen OAuth':
     "✓ Méthode d'authentification : Qwen OAuth",
   '  Type: Free tier': '  Type : Niveau gratuit',
-  '  Limit: Up to 1,000 requests/day': "  Limite : Jusqu'à 1 000 requêtes/jour",
+  '  Limit: Up to 100 requests/day': "  Limite : Jusqu'à 100 requêtes/jour",
   '  Models: Qwen latest models\n': '  Modèles : Derniers modèles Qwen\n',
   '✓ Authentication Method: Alibaba Cloud Coding Plan':
     "✓ Méthode d'authentification : Alibaba Cloud Coding Plan",

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -966,8 +966,8 @@ export default {
     '続行するには認証方法を選択してください。Ctrl+C をもう一度押すと終了します',
   'Terms of Services and Privacy Notice': '利用規約とプライバシー通知',
   'Qwen OAuth': 'Qwen OAuth',
-  'Free \u00B7 Up to 1,000 requests/day \u00B7 Qwen latest models':
-    '無料 \u00B7 1日最大1,000リクエスト \u00B7 Qwen最新モデル',
+  'Free \u00B7 Up to 100 requests/day \u00B7 Qwen latest models':
+    '無料 \u00B7 1日最大100リクエスト \u00B7 Qwen最新モデル',
   'Login with QwenChat account to use daily free quota.':
     'QwenChatアカウントでログインして、毎日の無料クォータをご利用ください。',
   'Paid \u00B7 Up to 6,000 requests/5 hrs \u00B7 All Alibaba Cloud Coding Plan Models':
@@ -1439,7 +1439,7 @@ export default {
     '  qwen auth                - インタラクティブ認証セットアップ\n',
   '✓ Authentication Method: Qwen OAuth': '✓ 認証方法: Qwen OAuth',
   '  Type: Free tier': '  タイプ: 無料プラン',
-  '  Limit: Up to 1,000 requests/day': '  制限: 1日最大1,000リクエスト',
+  '  Limit: Up to 100 requests/day': '  制限: 1日最大100リクエスト',
   '  Models: Qwen latest models\n': '  モデル: Qwen 最新モデル\n',
   '✓ Authentication Method: Alibaba Cloud Coding Plan':
     '✓ 認証方法: Alibaba Cloud Coding Plan',

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -1251,8 +1251,8 @@ export default {
   'Terms of Services and Privacy Notice':
     'Termos de Serviço e Aviso de Privacidade',
   'Qwen OAuth': 'Qwen OAuth',
-  'Free \u00B7 Up to 1,000 requests/day \u00B7 Qwen latest models':
-    'Gratuito \u00B7 Até 1.000 solicitações/dia \u00B7 Modelos Qwen mais recentes',
+  'Free \u00B7 Up to 100 requests/day \u00B7 Qwen latest models':
+    'Gratuito \u00B7 Até 100 solicitações/dia \u00B7 Modelos Qwen mais recentes',
   'Login with QwenChat account to use daily free quota.':
     'Faça login com sua conta QwenChat para usar a cota gratuita diária.',
   'Paid \u00B7 Up to 6,000 requests/5 hrs \u00B7 All Alibaba Cloud Coding Plan Models':
@@ -1938,7 +1938,7 @@ export default {
     '  qwen auth                - Configuração interativa de autenticação\n',
   '✓ Authentication Method: Qwen OAuth': '✓ Método de autenticação: Qwen OAuth',
   '  Type: Free tier': '  Tipo: Gratuito',
-  '  Limit: Up to 1,000 requests/day': '  Limite: Até 1.000 solicitações/dia',
+  '  Limit: Up to 100 requests/day': '  Limite: Até 100 solicitações/dia',
   '  Models: Qwen latest models\n': '  Modelos: Modelos Qwen mais recentes\n',
   '✓ Authentication Method: Alibaba Cloud Coding Plan':
     '✓ Método de autenticação: Alibaba Cloud Coding Plan',

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -1175,8 +1175,8 @@ export default {
   'Terms of Services and Privacy Notice':
     'Условия обслуживания и уведомление о конфиденциальности',
   'Qwen OAuth': 'Qwen OAuth',
-  'Free \u00B7 Up to 1,000 requests/day \u00B7 Qwen latest models':
-    'Бесплатно \u00B7 До 1 000 запросов/день \u00B7 Новейшие модели Qwen',
+  'Free \u00B7 Up to 100 requests/day \u00B7 Qwen latest models':
+    'Бесплатно \u00B7 До 100 запросов/день \u00B7 Новейшие модели Qwen',
   'Login with QwenChat account to use daily free quota.':
     'Войдите с помощью аккаунта QwenChat, чтобы использовать ежедневную бесплатную квоту.',
   'Paid \u00B7 Up to 6,000 requests/5 hrs \u00B7 All Alibaba Cloud Coding Plan Models':
@@ -1945,7 +1945,7 @@ export default {
     '  qwen auth                - Интерактивная настройка аутентификации\n',
   '✓ Authentication Method: Qwen OAuth': '✓ Метод аутентификации: Qwen OAuth',
   '  Type: Free tier': '  Тип: Бесплатный',
-  '  Limit: Up to 1,000 requests/day': '  Лимит: До 1 000 запросов/день',
+  '  Limit: Up to 100 requests/day': '  Лимит: До 100 запросов/день',
   '  Models: Qwen latest models\n': '  Модели: Последние модели Qwen\n',
   '✓ Authentication Method: Alibaba Cloud Coding Plan':
     '✓ Метод аутентификации: Alibaba Cloud Coding Plan',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1227,8 +1227,8 @@ export default {
     '您必须选择认证方法才能继续。再次按 Ctrl+C 退出',
   'Terms of Services and Privacy Notice': '服务条款和隐私声明',
   'Qwen OAuth': 'Qwen OAuth (免费)',
-  'Free \u00B7 Up to 1,000 requests/day \u00B7 Qwen latest models':
-    '免费 \u00B7 每天最多 1,000 次请求 \u00B7 Qwen 最新模型',
+  'Free \u00B7 Up to 100 requests/day \u00B7 Qwen latest models':
+    '免费 \u00B7 每天最多 100 次请求 \u00B7 Qwen 最新模型',
   'Login with QwenChat account to use daily free quota.':
     '使用 QwenChat 账号登录，享受每日免费额度。',
   'Paid \u00B7 Up to 6,000 requests/5 hrs \u00B7 All Alibaba Cloud Coding Plan Models':
@@ -1794,7 +1794,7 @@ export default {
     '  qwen auth                - 交互式认证配置\n',
   '✓ Authentication Method: Qwen OAuth': '✓ 认证方式：Qwen OAuth',
   '  Type: Free tier': '  类型：免费版',
-  '  Limit: Up to 1,000 requests/day': '  限额：每天最多 1,000 次请求',
+  '  Limit: Up to 100 requests/day': '  限额：每天最多 100 次请求',
   '  Models: Qwen latest models\n': '  模型：Qwen 最新模型\n',
   '✓ Authentication Method: Alibaba Cloud Coding Plan':
     '✓ 认证方式：阿里云百炼 Coding Plan',

--- a/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -107,7 +107,7 @@ export function AuthDialog(): React.JSX.Element {
       title: t('Qwen OAuth'),
       label: t('Qwen OAuth'),
       description: t(
-        'Free \u00B7 Up to 1,000 requests/day \u00B7 Qwen latest models',
+        'Free \u00B7 Up to 100 requests/day \u00B7 Qwen latest models',
       ),
       value: AuthType.QWEN_OAUTH as MainOption,
     },


### PR DESCRIPTION
## Summary

This PR adjusts the Qwen OAuth free tier policy as part of the product strategy update (tracked in issue #3203).

## Changes

### User-Facing Copy Updates
- **AuthDialog.tsx**: Updated description from `1,000 requests/day` to `100 requests/day`
- **CLI auth status**: Updated limit display in `handler.ts`

### Internationalization (i18n)
Updated all 7 locale files with new quota messaging:
- ✅ en.js (English)
- ✅ zh.js (Chinese Simplified)
- ✅ ja.js (Japanese)
- ✅ de.js (German)
- ✅ fr.js (French)
- ✅ ru.js (Russian)
- ✅ pt.js (Portuguese)

### Documentation
- **README.md**: Updated feature description
- **docs/users/configuration/auth.md**: Updated cost & quota section and CLI selector example
- **docs/developers/tools/web-search.md**: Updated DashScope quota info

## Note

This is **PR 1 of 2** for the OAuth free tier policy adjustment:
- **PR 1** (this PR): Updates文案 to reflect the new 100 requests/day quota (effective immediately)
- **PR 2**: Will hide the OAuth entry point entirely (scheduled for 2026-04-15 merge)

## Testing
- ✅ Build passes (`npm run build`)
- ✅ Type check passes (`npm run typecheck`)