### PR TITLE
fix(cli): stop refilling input with prior prompt on cancel

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -477,6 +477,194 @@ describe('AppContainer State Management', () => {
     });
   });
 
+  describe('Cancel Handler (issue #3204)', () => {
+    // The cancel handler is wired through useGeminiStream's onCancelSubmit
+    // arg (positional index 14 — see the useGeminiStream call site in
+    // AppContainer.tsx). We capture it via mockImplementation so a future
+    // signature change surfaces as a clear test failure rather than silently
+    // grabbing the wrong callback.
+    const ON_CANCEL_SUBMIT_ARG_INDEX = 14;
+    let capturedOnCancelSubmit: (() => void) | null = null;
+
+    const installCancelCapture = (
+      streamReturnValue: Record<string, unknown>,
+    ) => {
+      capturedOnCancelSubmit = null;
+      mockedUseGeminiStream.mockImplementation((...args: unknown[]) => {
+        const candidate = args[ON_CANCEL_SUBMIT_ARG_INDEX];
+        if (typeof candidate === 'function') {
+          capturedOnCancelSubmit = candidate as () => void;
+        }
+        return streamReturnValue;
+      });
+    };
+
+    const triggerCancel = () => {
+      if (!capturedOnCancelSubmit) {
+        throw new Error(
+          `onCancelSubmit was not captured at arg index ${ON_CANCEL_SUBMIT_ARG_INDEX} — useGeminiStream signature may have changed`,
+        );
+      }
+      capturedOnCancelSubmit();
+    };
+
+    it('does not repopulate the buffer with the previous prompt on ESC cancel', async () => {
+      const mockSetText = vi.fn();
+      mockedUseTextBuffer.mockReturnValue({
+        text: '',
+        setText: mockSetText,
+      });
+      // Simulate logger returning a previously submitted prompt — this is
+      // what the old buggy handler would read via userMessages.at(-1) and
+      // unconditionally restore into the buffer.
+      mockedUseLogger.mockReturnValue({
+        getPreviousUserMessages: vi
+          .fn()
+          .mockResolvedValue(['the previous prompt']),
+      });
+      installCancelCapture({
+        streamingState: 'responding',
+        submitQuery: vi.fn(),
+        initError: null,
+        pendingHistoryItems: [],
+        thought: null,
+        cancelOngoingRequest: vi.fn(),
+        retryLastPrompt: vi.fn(),
+      });
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: [],
+        addMessage: vi.fn(),
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue(''),
+        popAllMessages: vi.fn().mockReturnValue(null),
+        drainQueue: vi.fn().mockReturnValue([]),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      // Let the userMessages-fetching effect resolve.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      triggerCancel();
+
+      // Regression: the previous prompt must NOT be restored into the buffer.
+      expect(mockSetText).not.toHaveBeenCalledWith('the previous prompt');
+      // With no queued messages and no tool execution, the cancel handler
+      // should leave the buffer untouched (so any in-progress typing the
+      // user did since submitting is preserved).
+      expect(mockSetText).not.toHaveBeenCalled();
+    });
+
+    it('moves queued follow-up messages into an empty buffer on cancel', async () => {
+      const mockSetText = vi.fn();
+      const mockPopAllMessages = vi.fn().mockReturnValue('queued follow-up');
+      mockedUseTextBuffer.mockReturnValue({
+        text: '',
+        setText: mockSetText,
+      });
+      mockedUseLogger.mockReturnValue({
+        getPreviousUserMessages: vi
+          .fn()
+          .mockResolvedValue(['the previous prompt']),
+      });
+      installCancelCapture({
+        streamingState: 'responding',
+        submitQuery: vi.fn(),
+        initError: null,
+        pendingHistoryItems: [],
+        thought: null,
+        cancelOngoingRequest: vi.fn(),
+        retryLastPrompt: vi.fn(),
+      });
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: ['queued follow-up'],
+        addMessage: vi.fn(),
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue('queued follow-up'),
+        popAllMessages: mockPopAllMessages,
+        drainQueue: vi.fn().mockReturnValue(['queued follow-up']),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      triggerCancel();
+
+      // The queued message should be moved into the buffer for editing —
+      // and crucially, it should NOT be prefixed with the previous prompt.
+      expect(mockSetText).toHaveBeenCalledWith('queued follow-up');
+      expect(mockSetText).not.toHaveBeenCalledWith(
+        expect.stringContaining('the previous prompt'),
+      );
+      expect(mockPopAllMessages).toHaveBeenCalled();
+    });
+
+    it('preserves an in-progress draft when restoring queued messages on cancel', async () => {
+      // Simulates: user submits P1, queues P2, then types draft P3, then
+      // hits Ctrl+C. The Ctrl+C cancel path (unlike ESC) does NOT pre-clear
+      // the buffer, so P3 must be preserved.
+      const mockSetText = vi.fn();
+      mockedUseTextBuffer.mockReturnValue({
+        text: 'in-progress draft',
+        setText: mockSetText,
+      });
+      installCancelCapture({
+        streamingState: 'responding',
+        submitQuery: vi.fn(),
+        initError: null,
+        pendingHistoryItems: [],
+        thought: null,
+        cancelOngoingRequest: vi.fn(),
+        retryLastPrompt: vi.fn(),
+      });
+      mockedUseMessageQueue.mockReturnValue({
+        messageQueue: ['queued follow-up'],
+        addMessage: vi.fn(),
+        clearQueue: vi.fn(),
+        getQueuedMessagesText: vi.fn().mockReturnValue('queued follow-up'),
+        popAllMessages: vi.fn().mockReturnValue('queued follow-up'),
+        drainQueue: vi.fn().mockReturnValue(['queued follow-up']),
+      });
+
+      render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      await Promise.resolve();
+      await Promise.resolve();
+
+      triggerCancel();
+
+      // Queued text is prepended to the existing draft (matches the
+      // popQueueIntoInput convention used elsewhere in the input prompt).
+      expect(mockSetText).toHaveBeenCalledWith(
+        'queued follow-up\nin-progress draft',
+      );
+    });
+  });
+
   describe('Settings Integration', () => {
     it('handles settings with all display options disabled', () => {
       const settingsAllHidden = {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -776,18 +776,12 @@ export const AppContainer = (props: AppContainerProps) => {
     disabled: agentViewState.activeView !== 'main',
   });
 
-  const {
-    messageQueue,
-    addMessage,
-    clearQueue,
-    getQueuedMessagesText,
-    popAllMessages,
-    drainQueue,
-  } = useMessageQueue({
-    isConfigInitialized,
-    streamingState,
-    submitQuery,
-  });
+  const { messageQueue, addMessage, popAllMessages, drainQueue } =
+    useMessageQueue({
+      isConfigInitialized,
+      streamingState,
+      submitQuery,
+    });
 
   // Bridge message queue to mid-turn drain via ref.
   // drainQueue reads the synchronous queueRef inside the hook, so it
@@ -977,23 +971,24 @@ export const AppContainer = (props: AppContainerProps) => {
       return;
     }
 
-    const lastUserMessage = userMessages.at(-1);
-    let textToSet = lastUserMessage || '';
-
-    const queuedText = getQueuedMessagesText();
-    if (queuedText) {
-      textToSet = textToSet ? `${textToSet}\n\n${queuedText}` : queuedText;
-      clearQueue();
-    }
-
-    if (textToSet) {
-      buffer.setText(textToSet);
+    // Move any queued follow-up messages back into the buffer so the user
+    // can edit or resubmit them. Otherwise leave the buffer alone — in
+    // particular, do NOT repopulate it with the previous prompt; the user
+    // can still recall it via history navigation (Up/Ctrl+P).
+    //
+    // popAllMessages is atomic via the queue's synchronous ref, matching
+    // the drain behavior used during tool completion.
+    const popped = popAllMessages();
+    if (popped) {
+      const currentText = buffer.text;
+      // Preserve any in-progress draft the user typed since submitting (this
+      // is reachable via Ctrl+C cancel, which fires regardless of buffer
+      // content). Mirrors the popQueueIntoInput convention in InputPrompt.
+      buffer.setText(currentText ? `${popped}\n${currentText}` : popped);
     }
   }, [
     buffer,
-    userMessages,
-    getQueuedMessagesText,
-    clearQueue,
+    popAllMessages,
     pendingSlashCommandHistoryItems,
     pendingGeminiHistoryItems,
   ]);


### PR DESCRIPTION
## TLDR

Pressing ESC (or Ctrl+C) to cancel a streaming response was repopulating the input box with the prompt the user had just submitted. The handler unconditionally called `buffer.setText(userMessages.at(-1))`, so users who expected ESC to leave the input clean kept seeing their previous prompt re-appear. This PR removes the prior-prompt restoration. The previous prompt is still recoverable via Up arrow / Ctrl+P history navigation.

While doing this, also harden the queued-message restoration path so it (a) uses the atomic `popAllMessages` helper instead of the state-backed `getQueuedMessagesText` + `clearQueue` pair, and (b) preserves any in-progress draft the user typed (mirroring the existing `popQueueIntoInput` convention in `InputPrompt.tsx`).

## Screenshots / Video Demo

N/A — text-only TUI behavior change. See the verification report posted as a follow-up comment for the before/after results across four scenarios.

## Dive Deeper

The cancel handler in `AppContainer.tsx` had three branches:

1. Tool executing → clear buffer (unchanged).
2. Otherwise → read `lastUserMessage = userMessages.at(-1)`, optionally append queued text, and call `buffer.setText` with the result.
3. Restore queued text via `clearQueue()`.

Branch 2 is the bug. `userMessages` is the deduplicated history of *all* user messages (used for Up-arrow recall), so `at(-1)` is the just-submitted prompt. The behavior was inherited from a Gemini-CLI upstream sync, but issue #3204 makes clear it conflicts with what users expect from ESC.

The new handler:

- Tool execution path: unchanged (clear buffer).
- Otherwise: `popAllMessages()` atomically drains the queue. If anything was queued, prepend it to whatever is currently in the buffer (so a Ctrl+C cancel that fires while the user has an in-progress draft does not lose that draft). If the queue was empty, leave the buffer alone — there is nothing to restore, and `handleSubmitAndClear` already cleared the buffer at submission time.

Why `popAllMessages` instead of `getQueuedMessagesText` + `clearQueue`: the queue hook already exposes a synchronous-ref-backed atomic drain (`popAllMessages` and `drainQueue`). `useGeminiStream` itself relies on the atomic helpers for mid-turn drains, so using the same primitive in the cancel handler keeps the "tools just finished, queue not yet React-flushed" transition obviously safe.

Note that the `userMessages` state is still maintained for history navigation in `InputPrompt` — only the cancel handler stops reading it.

## Reviewer Test Plan

1. Run `npm run build && npm run bundle` and start `node dist/cli.js` in any directory.
2. Submit a long prompt (e.g. `write a long explanation of how sorting algorithms work`) and press ESC while the spinner is visible. Buffer should be empty.
3. Press Up arrow. The previous prompt should populate (history navigation still works).
4. Submit a long prompt, then while it is streaming type a follow-up and press Enter (it should queue with the \"Press ↑ to edit queued messages\" hint). Press ESC. Buffer should contain only the queued message.
5. Repeat step 4 but after queueing, type some more text as a draft (do not press Enter). Press Ctrl+C once. Buffer should contain `<queued>\n<draft>` — the queued message prepended to the draft, neither lost.

Also: `cd packages/cli && npx vitest run src/ui/AppContainer.test.tsx` — three new regression tests cover the scenarios above.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3204