### PR TITLE
fix(build): invoke tsx directly via node --import instead of npx

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dev": "node scripts/dev.js",
     "debug": "cross-env DEBUG=1 node --inspect-brk scripts/start.js",
     "generate": "node scripts/generate-git-commit-info.js",
-    "generate:settings-schema": "tsx scripts/generate-settings-schema.ts",
+    "generate:settings-schema": "node --import tsx/esm scripts/generate-settings-schema.ts",
     "build": "node scripts/build.js",
     "build-and-start": "npm run build && npm run start",
     "build:vscode": "node scripts/build_vscode_companion.js",

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -65,7 +65,7 @@ for (const workspace of buildOrder) {
   // After cli is built, generate the JSON Schema for settings
   // so the vscode-ide-companion extension can provide IntelliSense
   if (workspace === 'packages/cli') {
-    execSync('npx tsx scripts/generate-settings-schema.ts', {
+    execSync('node --import tsx/esm scripts/generate-settings-schema.ts', {
       stdio: 'inherit',
       cwd: root,
     });


### PR DESCRIPTION
## Summary
`scripts/build.js` calls `execSync('npx tsx scripts/generate-settings-schema.ts', ...)`. When the build is invoked under bun (e.g. \`bun run build\`), bun's \`npx\` wrapper intercepts the call and runs \`tsx\` inside bun's runtime, where tsx's CJS entry fails to resolve with:

\`\`\`
error: Cannot find module './cjs/index.cjs' from ''
\`\`\`

Switching to \`node --import tsx/esm\` bypasses the npx layer and works identically under npm and bun, since \`node\` is always a real node binary.

## Test plan
- [x] \`bun run build\` completes successfully
- [ ] \`npm run build\` still completes successfully
- [ ] \`packages/vscode-ide-companion/schemas/settings.schema.json\` is regenerated as before