### PR TITLE
fix(core): detect rate-limit errors from streamed SSE frames

### DIFF
--- a/packages/core/src/utils/errors.ts
+++ b/packages/core/src/utils/errors.ts
@@ -59,6 +59,10 @@ export function getErrorMessage(error: unknown): string {
  * 2. `error.statusCode` - Some HTTP client libraries
  * 3. `error.response.status` - Axios-style errors
  * 4. `error.error.code` - Nested error objects
+ * 5. `HTTP_STATUS/NNN` pattern in `error.message` - SSE-embedded streaming
+ *    errors where the SDK never sees a real HTTP status because the stream
+ *    opened with 200 OK and the provider signaled the error mid-stream.
+ *    DashScope uses `:HTTP_STATUS/429` as an SSE comment on throttling.
  *
  * @returns The HTTP status code (100-599), or undefined if not found.
  */
@@ -72,14 +76,27 @@ export function getErrorStatus(error: unknown): number | undefined {
     statusCode?: unknown;
     response?: { status?: unknown };
     error?: { code?: unknown };
+    message?: unknown;
   };
 
   const value =
     err.status ?? err.statusCode ?? err.response?.status ?? err.error?.code;
 
-  return typeof value === 'number' && value >= 100 && value <= 599
-    ? value
-    : undefined;
+  if (typeof value === 'number' && value >= 100 && value <= 599) {
+    return value;
+  }
+
+  if (typeof err.message === 'string') {
+    const match = err.message.match(/HTTP_STATUS\/(\d{3})\b/);
+    if (match) {
+      const parsed = Number(match[1]);
+      if (parsed >= 100 && parsed <= 599) {
+        return parsed;
+      }
+    }
+  }
+
+  return undefined;
 }
 
 /**

--- a/packages/core/src/utils/rateLimit.test.ts
+++ b/packages/core/src/utils/rateLimit.test.ts
@@ -99,4 +99,41 @@ describe('isRateLimitError — return shape', () => {
   it('should return null for non-rate-limit errors', () => {
     expect(isRateLimitError(new Error('Connection refused'))).toBe(false);
   });
+
+  it('should fall through JSON-in-message non-numeric code when Error has .status', () => {
+    // Some middleware wraps errors into plain Error instances with the
+    // provider error serialised into .message AND augments .status. The
+    // JSON-in-message parse must not short-circuit with null when the
+    // embedded code is non-numeric — the .status on the Error should win.
+    const error: HttpError = new Error(
+      '{"error":{"code":"Throttling.AllocationQuota","message":"Allocated quota exceeded"}}',
+    );
+    error.status = 429;
+    expect(isRateLimitError(error)).toBe(true);
+  });
+
+  it('should fall through ApiError with non-numeric code when .status is set', () => {
+    // DashScope/OpenAI-SDK shape: RateLimitError with .status=429 but
+    // .error.code is a non-numeric string. Must still be recognised as a
+    // rate limit via the .status fallback.
+    const error = Object.assign(new Error('429 Allocated quota exceeded'), {
+      status: 429,
+      error: {
+        code: 'Throttling.AllocationQuota',
+        message: 'Allocated quota exceeded',
+      },
+    });
+    expect(isRateLimitError(error)).toBe(true);
+  });
+
+  it('should detect DashScope SSE-embedded 429 (Throttling.AllocationQuota)', () => {
+    // Reproduces the production error seen from DashScope when the stream
+    // opens with HTTP 200 and the throttling is surfaced mid-stream as an
+    // SSE `event:error` frame. The OpenAI SDK preserves the raw SSE payload
+    // in error.message, with no numeric `.status` on the error object.
+    const error = new Error(
+      'id:1\nevent:error\n:HTTP_STATUS/429\ndata:{"request_id":"70acdc21-a546-489a-b5d6-650df970a4ef","code":"Throttling.AllocationQuota","message":"Allocated quota exceeded, please increase your quota limit."}',
+    );
+    expect(isRateLimitError(error)).toBe(true);
+  });
 });

--- a/packages/core/src/utils/rateLimit.ts
+++ b/packages/core/src/utils/rateLimit.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { getErrorStatus } from './errors.js';
 import { isApiError, isStructuredError } from './quotaErrorDetection.js';
 
 // Known rate-limit error codes across providers.
@@ -49,7 +50,13 @@ export function isRateLimitError(
  * Mirrors the same parsing patterns used by parseAndFormatApiError.
  */
 function getErrorCode(error: unknown): number | null {
-  if (isApiError(error)) return Number(error.error.code) || null;
+  // ApiError (.error.code) — fall through when the code is not a finite number
+  // (e.g. DashScope `"code":"Throttling.AllocationQuota"`) so later handlers
+  // can still recover a status from `.status` or the message.
+  if (isApiError(error)) {
+    const n = Number(error.error.code);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
 
   // JSON in string / Error.message — check BEFORE isStructuredError because
   // Error instances also satisfy isStructuredError (both have .message).
@@ -64,16 +71,21 @@ function getErrorCode(error: unknown): number | null {
     if (i !== -1) {
       try {
         const p = JSON.parse(msg.substring(i)) as unknown;
-        if (isApiError(p)) return Number(p.error.code) || null;
+        if (isApiError(p)) {
+          const n = Number(p.error.code);
+          if (Number.isFinite(n) && n > 0) return n;
+        }
       } catch {
         /* not valid JSON */
       }
     }
   }
 
-  // StructuredError (.status) — plain objects from Gemini SDK
-  if (isStructuredError(error)) {
-    return typeof error.status === 'number' ? error.status : null;
+  // StructuredError (.status) — plain objects from Gemini SDK.
+  // Fall through when .status is missing so the getErrorStatus fallback
+  // below can still recover a status from streamed SSE error frames.
+  if (isStructuredError(error) && typeof error.status === 'number') {
+    return error.status;
   }
 
   // HttpError (.status on Error)
@@ -82,5 +94,9 @@ function getErrorCode(error: unknown): number | null {
     if (typeof s === 'number') return s;
   }
 
-  return null;
+  // Final fallback: delegate to getErrorStatus which also parses
+  // `HTTP_STATUS/NNN` out of streamed SSE error frames (e.g. DashScope
+  // `Throttling.AllocationQuota` where the SDK never surfaces a real HTTP
+  // status because the stream opened with 200 OK).
+  return getErrorStatus(error) ?? null;
 }

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -545,4 +545,29 @@ describe('getErrorStatus', () => {
     expect(getErrorStatus({ response: {} })).toBeUndefined();
     expect(getErrorStatus({ error: {} })).toBeUndefined();
   });
+
+  it('should parse HTTP_STATUS/NNN from streamed SSE error messages', () => {
+    // DashScope throttling: error opens with 200 OK, then surfaces as an SSE
+    // error frame. The SDK preserves the raw SSE text in error.message.
+    const dashscopeThrottle = new Error(
+      'id:1\nevent:error\n:HTTP_STATUS/429\ndata:{"request_id":"x","code":"Throttling.AllocationQuota","message":"Allocated quota exceeded"}',
+    );
+    expect(getErrorStatus(dashscopeThrottle)).toBe(429);
+
+    expect(getErrorStatus(new Error('upstream :HTTP_STATUS/503'))).toBe(503);
+  });
+
+  it('should prefer numeric status fields over HTTP_STATUS/NNN in message', () => {
+    const error: HttpError = new Error(':HTTP_STATUS/500');
+    error.status = 429;
+    expect(getErrorStatus(error)).toBe(429);
+  });
+
+  it('should ignore HTTP_STATUS/NNN outside the valid range', () => {
+    expect(getErrorStatus(new Error('HTTP_STATUS/999'))).toBeUndefined();
+  });
+
+  it('should not match HTTP_STATUS/NNN when adjacent to more digits', () => {
+    expect(getErrorStatus(new Error('HTTP_STATUS/4291'))).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Problem

Subagents using DashScope hit `Throttling.AllocationQuota` and immediately failed with:

```
Failed to run subagent: id:1
event:error
:HTTP_STATUS/429
data:{"request_id":"...","code":"Throttling.AllocationQuota","message":"Allocated quota exceeded, please increase your quota limit..."}
```

No retry fired — the user expected the rate-limit retry loop in `geminiChat.ts:408` to kick in but it never saw the error as a rate-limit.

## Root causes

There are **two independent gaps** in the detection chain. We don't know for certain which path the production error takes (the two DashScope delivery modes produce different error shapes), so both had to be closed.

### Gap 1 — `getErrorCode` swallows fall-through on non-numeric codes

`rateLimit.ts:getErrorCode` has three early-return sites that each use the pattern `Number(x) || null`. If the provider returns a non-numeric error code (DashScope uses the string `"Throttling.AllocationQuota"`), these sites return `null` and the function exits before checking `.status` or later fallbacks — even when `.status` is a perfectly valid `429`.

Affected sites:
- `isApiError` branch at the top of `getErrorCode`
- `isApiError` branch inside the JSON-in-message parse
- `isStructuredError` branch (slightly different pattern — returns `null` when `.status` is missing instead of when it's non-numeric, but with the same fall-through-swallowing effect because every `Error` instance matches `isStructuredError`)

### Gap 2 — `getErrorStatus` only checks numeric fields

For the mid-stream delivery mode, the OpenAI SDK opens the HTTP response with 200 OK and throws an error only when it parses a later SSE frame. The SDK's `APIError` is constructed with `status: undefined` because the HTTP response itself was 2xx. `getErrorStatus` then has no numeric field to read. The raw SSE frame — including the server's hint `:HTTP_STATUS/429` — sits in `error.message` but was never consulted.

## Fix

**`errors.ts:getErrorStatus`** — add a final fallback that parses `HTTP_STATUS/NNN\b` out of `error.message`, range-checked to 100–599. The `\b` prevents `HTTP_STATUS/4291` from being mis-read as `429`; range-checking filters invalid inputs. Numeric fields still take priority over the message fallback, so this only activates when the SDK couldn't propagate a real status.

Why pattern-match text at all: this is the standard technique for the "SDK can't propagate status through streaming" class of problem. Using the `HTTP_STATUS/NNN` SSE-comment convention instead of hard-coding provider error strings (`"Throttling.*"`, `"overloaded_error"`, etc.) keeps the fix generic — any provider that follows the SSE-comment convention is covered without touching this code again.

**`rateLimit.ts:getErrorCode`** — all three early-return sites now use `Number.isFinite(n) && n > 0` and fall through when the check fails, so `.status` or the new `getErrorStatus` fallback can recover the real code downstream. The `isStructuredError` branch gains the same fall-through when `.status` is missing.

Once `isRateLimitError` returns `true`, the existing retry loop at `geminiChat.ts:408` handles the retry with its fixed delay and UI event — no changes needed there.

## Test plan

Regression tests added, all covered by unit tests against the exact production error shape:

- [x] DashScope SSE payload verbatim (copied from the reported error) — detected as rate-limit
- [x] `APIError` with non-numeric `.error.code` + numeric `.status` — falls through to `.status` path
- [x] JSON-in-message non-numeric code + Error-level `.status` — falls through
- [x] `getErrorStatus` — `HTTP_STATUS/NNN` parsing, `\b` boundary (rejects `HTTP_STATUS/4291`), out-of-range rejection (`HTTP_STATUS/999`), priority of numeric fields over message pattern

Full regression: `npx vitest run packages/core/src/utils/rateLimit.test.ts packages/core/src/utils/retry.test.ts packages/core/src/utils/errors packages/core/src/core/geminiChat.test.ts packages/core/src/utils/quotaErrorDetection packages/core/src/utils/errorParsing` — 131/131 passing.

The production error format is reproduced verbatim in the new test case, so no additional manual reproduction is required.