### PR TITLE
fix(vscode): limit session tab title length to prevent tab bar overflow

### DIFF
--- a/packages/vscode-ide-companion/src/services/qwenSessionReader.ts
+++ b/packages/vscode-ide-companion/src/services/qwenSessionReader.ts
@@ -182,22 +182,18 @@ export class QwenSessionReader {
    */
   getSessionTitle(session: QwenSession): string {
     // Prefer cached prompt text to avoid loading messages for JSONL sessions
-    if (session.firstUserText) {
-      return (
-        session.firstUserText.substring(0, 50) +
-        (session.firstUserText.length > 50 ? '...' : '')
-      );
+    const text = session.firstUserText
+      ? session.firstUserText
+      : (session.messages.find((m) => m.type === 'user')?.content ?? '');
+
+    if (!text) {
+      return 'Untitled Session';
     }
 
-    const firstUserMessage = session.messages.find((m) => m.type === 'user');
-    if (firstUserMessage) {
-      // Extract first 50 characters as title
-      return (
-        firstUserMessage.content.substring(0, 50) +
-        (firstUserMessage.content.length > 50 ? '...' : '')
-      );
-    }
-    return 'Untitled Session';
+    const codePoints = [...text];
+    return codePoints.length <= 50
+      ? text
+      : codePoints.slice(0, 50).join('') + '…';
   }
 
   /**

--- a/packages/vscode-ide-companion/src/services/qwenSessionReader.ts
+++ b/packages/vscode-ide-companion/src/services/qwenSessionReader.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import * as os from 'os';
 import * as readline from 'readline';
 import { getProjectHash } from '@qwen-code/qwen-code-core/src/utils/paths.js';
+import { truncatePanelTitle } from '../webview/utils/panelTitleUtils.js';
 
 export interface QwenMessage {
   id: string;
@@ -190,10 +191,7 @@ export class QwenSessionReader {
       return 'Untitled Session';
     }
 
-    const codePoints = [...text];
-    return codePoints.length <= 50
-      ? text
-      : codePoints.slice(0, 50).join('') + '…';
+    return truncatePanelTitle(text);
   }
 
   /**

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
@@ -393,13 +393,11 @@ export class SessionMessageHandler extends BaseMessageHandler {
 
     // Generate title for first message, but only if it hasn't been set yet
     if (isFirstMessage && !this.isTitleSet) {
-      const title =
-        displayText.substring(0, 50) + (displayText.length > 50 ? '...' : '');
       this.sendToWebView({
         type: 'sessionTitleUpdated',
         data: {
           sessionId: this.currentConversationId,
-          title,
+          title: displayText,
         },
       });
       this.isTitleSet = true; // Mark title as set

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.test.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.test.ts
@@ -95,6 +95,7 @@ vi.mock('./PanelManager.js', async (importOriginal) => {
       getPanel() {
         return mockGetPanel();
       }
+      setPanel = vi.fn();
     },
   };
 });
@@ -137,6 +138,10 @@ vi.mock('../../utils/errorMessage.js', () => ({
 }));
 
 import { WebViewProvider } from './WebViewProvider.js';
+import {
+  truncatePanelTitle,
+  MAX_PANEL_TITLE_LENGTH,
+} from '../utils/panelTitleUtils.js';
 
 describe('WebViewProvider.attachToView', () => {
   beforeEach(() => {
@@ -327,6 +332,46 @@ describe('WebViewProvider.createNewSession', () => {
       { forceNew: true },
     );
     expect(messageHandler.setCurrentConversationId).toHaveBeenCalledWith(null);
+  });
+});
+
+describe('truncatePanelTitle', () => {
+  it('passes through a short title unchanged', () => {
+    expect(truncatePanelTitle('Short title')).toBe('Short title');
+  });
+
+  it('passes through an empty string unchanged', () => {
+    expect(truncatePanelTitle('')).toBe('');
+  });
+
+  it(`passes through a title of exactly ${MAX_PANEL_TITLE_LENGTH} code points unchanged`, () => {
+    const title = 'a'.repeat(MAX_PANEL_TITLE_LENGTH);
+    expect(truncatePanelTitle(title)).toBe(title);
+  });
+
+  it('truncates a title of MAX+1 characters to MAX content chars + ellipsis', () => {
+    const title = 'a'.repeat(MAX_PANEL_TITLE_LENGTH + 1);
+    const result = truncatePanelTitle(title);
+    expect(result).toBe('a'.repeat(MAX_PANEL_TITLE_LENGTH) + '…');
+    expect([...result].length).toBe(MAX_PANEL_TITLE_LENGTH + 1);
+  });
+
+  it('truncates a very long title to MAX content code points + ellipsis', () => {
+    const title = 'a'.repeat(200);
+    const result = truncatePanelTitle(title);
+    expect(result).toBe('a'.repeat(MAX_PANEL_TITLE_LENGTH) + '…');
+    expect([...result].length).toBe(MAX_PANEL_TITLE_LENGTH + 1);
+  });
+
+  it('does not split a surrogate pair (emoji) at the truncation boundary', () => {
+    // 49 ASCII chars + emoji (1 code point, 2 UTF-16 code units) + trailing text
+    // Total: 49 + 1 + 5 = 55 code points → needs truncation
+    const emoji = '😀';
+    const title = 'a'.repeat(MAX_PANEL_TITLE_LENGTH - 1) + emoji + 'extra';
+    const result = truncatePanelTitle(title);
+    // First 50 code points: 49 'a's + emoji, then '…' — emoji is not split
+    expect(result).toBe('a'.repeat(MAX_PANEL_TITLE_LENGTH - 1) + emoji + '…');
+    expect([...result].length).toBe(MAX_PANEL_TITLE_LENGTH + 1);
   });
 });
 

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
@@ -668,7 +668,7 @@ export class WebViewProvider {
           ).trim();
           const panelRef = this.panelManager.getPanel();
           if (panelRef) {
-            panelRef.title = truncatePanelTitle(title || 'Qwen Code');
+            panelRef.title = title ? truncatePanelTitle(title) : 'Qwen Code';
           }
           return;
         }
@@ -1504,7 +1504,7 @@ export class WebViewProvider {
           ).trim();
           const panelRef = this.panelManager.getPanel();
           if (panelRef) {
-            panelRef.title = truncatePanelTitle(title || 'Qwen Code');
+            panelRef.title = title ? truncatePanelTitle(title) : 'Qwen Code';
           }
           return;
         }

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
@@ -20,6 +20,7 @@ import { PanelManager, getLocalResourceRoots } from './PanelManager.js';
 import { MessageHandler } from './MessageHandler.js';
 import { WebViewContent } from './WebViewContent.js';
 import { getFileName } from '../utils/webviewUtils.js';
+import { truncatePanelTitle } from '../utils/panelTitleUtils.js';
 import { createImagePathResolver } from '../utils/imageHandler.js';
 import { type ApprovalModeValue } from '../../types/approvalModeValueTypes.js';
 import { isAuthenticationRequiredError } from '../../utils/authErrors.js';
@@ -667,7 +668,7 @@ export class WebViewProvider {
           ).trim();
           const panelRef = this.panelManager.getPanel();
           if (panelRef) {
-            panelRef.title = title || 'Qwen Code';
+            panelRef.title = truncatePanelTitle(title || 'Qwen Code');
           }
           return;
         }
@@ -1503,7 +1504,7 @@ export class WebViewProvider {
           ).trim();
           const panelRef = this.panelManager.getPanel();
           if (panelRef) {
-            panelRef.title = title || 'Qwen Code';
+            panelRef.title = truncatePanelTitle(title || 'Qwen Code');
           }
           return;
         }

--- a/packages/vscode-ide-companion/src/webview/utils/panelTitleUtils.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/panelTitleUtils.ts
@@ -1,0 +1,28 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Maximum number of Unicode code points shown before truncation in VS Code panel tab titles.
+ * Titles longer than this are shown as the first MAX_PANEL_TITLE_LENGTH code points + "…".
+ * Prevents a long session title from stretching the editor tab bar.
+ * Note: VS Code measures tab width in rendered pixels, not character count, so this is
+ * a reasonable approximation rather than a precise pixel limit.
+ */
+export const MAX_PANEL_TITLE_LENGTH = 50;
+
+/**
+ * Truncate a title to fit within the VS Code editor tab, appending "…" if needed.
+ * Operates on Unicode code points (not UTF-16 code units) to avoid splitting surrogate pairs,
+ * e.g. emoji that are encoded as two UTF-16 code units.
+ * If truncated, the result is MAX_PANEL_TITLE_LENGTH content code points + "…".
+ */
+export function truncatePanelTitle(title: string): string {
+  const codePoints = [...title];
+  if (codePoints.length <= MAX_PANEL_TITLE_LENGTH) {
+    return title;
+  }
+  return codePoints.slice(0, MAX_PANEL_TITLE_LENGTH).join('') + '…';
+}


### PR DESCRIPTION
## TLDR

Fixes #2873

Long session titles were causing the VS Code editor tab bar to overflow. This PR introduces a uniform truncation strategy using `truncatePanelTitle()` (max 50 Unicode code points + `…`), which operates on code points rather than raw string length to avoid splitting emoji surrogate pairs.

Changes:
- Extract `truncatePanelTitle()` into `panelTitleUtils.ts` for shared use
- Apply truncation in `WebViewProvider` for all `updatePanelTitle` paths (create & restore)
- Remove redundant truncation in `SessionMessageHandler`; raw title is now passed through
- Align `getSessionTitle()` in `QwenSessionReader` to use the same 50-code-point limit

## Screenshots / Video Demo
- Before
![before](https://github.com/user-attachments/assets/2b8076d9-cea0-4477-8d63-f76a223bd5cc)
- After
![after](https://github.com/user-attachments/assets/8e303005-59db-447b-937f-accd204788d6)

<!--
Please attach a screenshot or short video showing your change in action.
-->

## Dive Deeper

The root cause was that VS Code measures tab width in rendered pixels, not character count, so a long title could stretch the tab bar unpredictably. We chose 50 code points as a practical approximation — it is not a precise pixel limit, but it works well across typical font sizes and common title lengths.

`truncatePanelTitle` uses the spread operator (`[...title]`) to iterate over Unicode code points, which correctly handles characters encoded as surrogate pairs (e.g. emoji like `😀`). This prevents garbled titles where an emoji gets split in half.

## Reviewer Test Plan

1. Open the VS Code companion extension in development mode.
2. Start a new session with a prompt longer than 50 characters (include emoji if possible).
3. Verify the tab title shows the first 50 code points followed by `…` and does not overflow the tab bar.
4. Switch away from and back to the session — the restored panel should show the same truncated title.
5. Check the session list sidebar — titles should be truncated consistently with the tab title.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes #2873

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)