### PR TITLE
fix(core): allow thought-only responses in GeminiChat stream validation

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -617,17 +617,17 @@ describe('GeminiChat', async () => {
       }
     });
 
-    it('should throw InvalidStreamError when no tool call and empty response text', async () => {
+    it('should throw InvalidStreamError when there is finish reason but truly empty response (no text, no thought)', async () => {
       vi.useFakeTimers();
       try {
-        // Setup: Stream with finish reason but empty response (only thoughts)
+        // Setup: Stream with finish reason but completely empty parts
         const streamWithEmptyResponse = (async function* () {
           yield {
             candidates: [
               {
                 content: {
                   role: 'model',
-                  parts: [{ thought: 'thinking...' }],
+                  parts: [],
                 },
                 finishReason: 'STOP',
               },
@@ -648,6 +648,58 @@ describe('GeminiChat', async () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it('should succeed when there is finish reason and only thought content (reasoning models)', async () => {
+      // This test verifies that responses containing only thought/reasoning content
+      // are accepted as valid.
+      const thoughtOnlyStream = (async function* () {
+        yield {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [
+                  {
+                    thought: true,
+                    text: 'Let me think through this problem step by step...',
+                  },
+                ],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+      })();
+
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        thoughtOnlyStream,
+      );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'test' },
+        'prompt-id-thought-only',
+      );
+
+      // Should NOT throw - thought-only responses are valid
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            // consume stream
+          }
+        })(),
+      ).resolves.not.toThrow();
+
+      // Verify history contains the thought content
+      const history = chat.getHistory();
+      expect(history.length).toBe(2); // user turn + model turn
+      const modelTurn = history[1]!;
+      expect(modelTurn.parts?.length).toBe(1);
+      expect(modelTurn.parts![0]).toEqual({
+        thought: true,
+        text: 'Let me think through this problem step by step...',
+      });
     });
 
     it('should succeed when there is finish reason and response text', async () => {
@@ -728,6 +780,109 @@ describe('GeminiChat', async () => {
           }
         })(),
       ).resolves.not.toThrow();
+    });
+
+    it('should succeed for thought-only content when finish reason arrives in a later chunk', async () => {
+      const streamWithDelayedFinishReason = (async function* () {
+        // First chunk contains only thought content.
+        yield {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{ thought: true, text: 'Thinking through options...' }],
+              },
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+
+        // Second chunk carries only finishReason.
+        yield {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+      })();
+
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        streamWithDelayedFinishReason,
+      );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'test' },
+        'prompt-id-thought-delayed-finish',
+      );
+
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            // consume stream
+          }
+        })(),
+      ).resolves.not.toThrow();
+
+      const history = chat.getHistory();
+      expect(history.length).toBe(2);
+      expect(history[1]!.parts).toEqual([
+        { thought: true, text: 'Thinking through options...' },
+      ]);
+    });
+
+    it('should succeed for thought-only responses with finish reason followed by usage-only chunk', async () => {
+      const thoughtThenUsageOnlyStream = (async function* () {
+        yield {
+          candidates: [
+            {
+              content: {
+                role: 'model',
+                parts: [{ thought: true, text: 'Let me reason this out...' }],
+              },
+              finishReason: 'STOP',
+            },
+          ],
+        } as unknown as GenerateContentResponse;
+
+        // Provider can emit trailing usage-only chunk after finish.
+        yield {
+          candidates: [],
+          usageMetadata: {
+            promptTokenCount: 12,
+            candidatesTokenCount: 4,
+            totalTokenCount: 16,
+          },
+        } as unknown as GenerateContentResponse;
+      })();
+
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        thoughtThenUsageOnlyStream,
+      );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'test' },
+        'prompt-id-thought-usage-tail',
+      );
+
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            // consume stream
+          }
+        })(),
+      ).resolves.not.toThrow();
+
+      const history = chat.getHistory();
+      expect(history.length).toBe(2);
+      expect(history[1]!.parts).toEqual([
+        { thought: true, text: 'Let me reason this out...' },
+      ]);
     });
 
     it('should call generateContentStream with the correct parameters', async () => {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -931,12 +931,16 @@ export class GeminiChat {
 
     // Stream validation logic: A stream is considered successful if:
     // 1. There's a tool call (tool calls can end without explicit finish reasons), OR
-    // 2. There's a finish reason AND we have non-empty response text
+    // 2. There's a finish reason AND we have non-empty response text or thought text
     //
     // We throw an error only when there's no tool call AND:
     // - No finish reason, OR
-    // - Empty response text (e.g., only thoughts with no actual content)
-    if (!hasToolCall && (!hasFinishReason || !contentText)) {
+    // - Empty response text (e.g., no actual content and no thoughts)
+    //
+    // Note: Thoughts-only responses are valid for models that use thinking modes
+    // These models may send only reasoning content without explicit text output.
+    const hasAnyContent = contentText || thoughtText;
+    if (!hasToolCall && (!hasFinishReason || !hasAnyContent)) {
       if (!hasFinishReason) {
         throw new InvalidStreamError(
           'Model stream ended without a finish reason.',


### PR DESCRIPTION
## Problem

Subagents running against thinking/reasoning models (qwen3-thinking, qwen-plus-thinking, etc.) hit `Failed to run subagent: Model stream ended with empty response text.` on code-review-style tasks like `/review`'s undirected audit:

```
✓ Agent Review undirected audit
general-purpose ● Failed
Failed: Failed to run subagent: Model stream ended with empty response text.
```

The existing transient-stream retry budget (`INVALID_STREAM_RETRY_CONFIG.maxRetries = 2`) retries twice, but the same prompt + same model consistently produces the same thought-only response, so all three attempts fail.

## Root cause

`packages/core/src/core/geminiChat.ts:939` validates that a successful stream has either a tool call or non-empty `contentText`. `contentText` is built from `consolidatedHistoryParts`, which **filters out parts where `part.thought === true`**:

```ts
const contentParts = allModelParts.filter((part) => !part.thought);
```

So when a reasoning model emits only `thought: true` parts and finishes with a valid `finishReason: STOP`, `contentText` is empty and the validator throws `InvalidStreamError('NO_RESPONSE_TEXT')`. This is a legitimate response shape for thinking-mode providers — they emit internal reasoning and sometimes end without producing a distinct visible-text part.

## Fix

Accept responses that contain thought text when no visible-text content is present. The validator now asks "is there *any* content?" instead of "is there visible text?":

```ts
const hasAnyContent = contentText || thoughtText;
if (!hasToolCall && (!hasFinishReason || !hasAnyContent)) {
  // throw InvalidStreamError
}
```

Truly empty responses (no text AND no thought AND no tool call) still throw — only the "thought-only is empty" misclassification is fixed.

## Attribution

This is **cherry-picked from the previously abandoned [PR #2636](https://github.com/QwenLM/qwen-code/pull/2636)** by @mingholy (commit `a0b13911f`), which was closed on 2026-03-26 without human review despite being a correct fix for two user-reported issues (#2530 and #1700). The authorship on the commit is preserved via `git cherry-pick -x`. Reopening here so the fix is not lost — it matches a production failure hit today on a `/review` subagent.

## Test plan

- [x] `npx vitest run packages/core/src/core/geminiChat.test.ts` — **46 tests pass** (43 pre-existing + 3 new thought-only coverage cases)

The three new test cases (from mingholy's original PR) cover:
- Thought-only content with finish reason in the same chunk
- Thought content with finish reason arriving in a later chunk
- Thought-only content followed by a usage-only trailing chunk

The existing "empty response" test is retained but restructured to assert that **truly empty** responses (no text, no thoughts, no tool call) still throw — regression-proofing the negative case.

## Related issues

- Fixes #2530
- Fixes #1700
