### PR TITLE
fix(core): add diagnostics for silent PTY shell execution failures on macOS

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -31,6 +31,7 @@ const mockPtySpawn = vi.hoisted(() => vi.fn());
 const mockCpSpawn = vi.hoisted(() => vi.fn());
 const mockIsBinary = vi.hoisted(() => vi.fn());
 const mockPlatform = vi.hoisted(() => vi.fn());
+const mockArch = vi.hoisted(() => vi.fn().mockReturnValue('x64'));
 const mockGetPty = vi.hoisted(() => vi.fn());
 const mockSerializeTerminalToObject = vi.hoisted(() => vi.fn());
 const mockGetShellConfiguration = vi.hoisted(() =>
@@ -54,6 +55,8 @@ vi.mock('../utils/textUtils.js', () => ({
 vi.mock('os', () => ({
   default: {
     platform: mockPlatform,
+    arch: mockArch,
+    release: vi.fn().mockReturnValue('25.0.0'),
     constants: {
       signals: {
         SIGTERM: 15,
@@ -62,6 +65,8 @@ vi.mock('os', () => ({
     },
   },
   platform: mockPlatform,
+  arch: mockArch,
+  release: vi.fn().mockReturnValue('25.0.0'),
   constants: {
     signals: {
       SIGTERM: 15,

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -10,10 +10,13 @@ import { getPty } from '../utils/getPty.js';
 import { spawn as cpSpawn, spawnSync } from 'node:child_process';
 import { TextDecoder } from 'node:util';
 import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs';
 import type { IPty } from '@lydell/node-pty';
 import { getCachedEncodingForBuffer } from '../utils/systemEncoding.js';
 import { isBinary } from '../utils/textUtils.js';
 import { getShellConfiguration } from '../utils/shell-utils.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
 import pkg from '@xterm/headless';
 import {
   serializeTerminalToObject,
@@ -21,6 +24,7 @@ import {
 } from '../utils/terminalSerializer.js';
 const { Terminal } = pkg;
 
+const debugLogger = createDebugLogger('SHELL_EXEC');
 const SIGKILL_TIMEOUT_MS = 200;
 const WINDOWS_PATH_DELIMITER = ';';
 let cachedWindowsPathFingerprint: string | undefined;
@@ -301,6 +305,7 @@ const getCleanupStrategy = () =>
 export class ShellExecutionService {
   private static activePtys = new Map<number, ActivePty>();
   private static activeChildProcesses = new Set<number>();
+  private static spawnHelperChecked = false;
 
   static cleanup() {
     const strategy = getCleanupStrategy();
@@ -324,6 +329,53 @@ export class ShellExecutionService {
   }
 
   /**
+   * One-time diagnostic check for the node-pty spawn-helper binary on macOS.
+   * Logs a warning if it's missing or lacks execute permission — a known cause
+   * of silent "exit code 1, no output" failures (microsoft/node-pty#850).
+   */
+  private static checkSpawnHelperOnce(ptyInfo: PtyImplementation): void {
+    if (this.spawnHelperChecked || os.platform() !== 'darwin' || !ptyInfo) {
+      return;
+    }
+    this.spawnHelperChecked = true;
+
+    try {
+      const ptyPackageName = `@lydell/node-pty-darwin-${os.arch()}`;
+      const ptyMainPath = require.resolve(ptyPackageName);
+      const pkgRoot = path.dirname(ptyMainPath);
+      const helperPath = path.join(
+        pkgRoot,
+        'prebuilds',
+        `darwin-${os.arch()}`,
+        'spawn-helper',
+      );
+
+      if (!fs.existsSync(helperPath)) {
+        debugLogger.warn(
+          `spawn-helper not found at ${helperPath} — PTY commands may fail silently`,
+        );
+        return;
+      }
+
+      const stats = fs.statSync(helperPath);
+      const isExecutable = !!(stats.mode & 0o111);
+      if (!isExecutable) {
+        debugLogger.warn(
+          `spawn-helper at ${helperPath} lacks execute permission (mode=${stats.mode.toString(8)}). ` +
+            'This causes PTY commands to exit with code 1 and no output. ' +
+            'Fix: chmod +x "' +
+            helperPath +
+            '"',
+        );
+      } else {
+        debugLogger.debug(`spawn-helper OK: ${helperPath}`);
+      }
+    } catch {
+      // Best-effort diagnostic; don't break execution.
+    }
+  }
+
+  /**
    * Executes a shell command using `node-pty`, capturing all output and lifecycle events.
    *
    * @param commandToExecute The exact command string to run.
@@ -344,6 +396,10 @@ export class ShellExecutionService {
     if (shouldUseNodePty) {
       const ptyInfo = await getPty();
       if (ptyInfo) {
+        debugLogger.debug(
+          `Using ${ptyInfo.name} for shell execution (platform=${os.platform()}, arch=${os.arch()})`,
+        );
+        this.checkSpawnHelperOnce(ptyInfo);
         try {
           return this.executeWithPty(
             commandToExecute,
@@ -353,10 +409,18 @@ export class ShellExecutionService {
             shellExecutionConfig,
             ptyInfo,
           );
-        } catch (_e) {
-          // Fallback to child_process
+        } catch (e) {
+          debugLogger.warn(
+            `PTY execution threw, falling back to child_process: ${e instanceof Error ? e.message : String(e)}`,
+          );
         }
+      } else {
+        debugLogger.debug(
+          'node-pty not available, using child_process fallback',
+        );
       }
+    } else {
+      debugLogger.debug('PTY disabled, using child_process');
     }
 
     return this.childProcessFallback(
@@ -544,6 +608,9 @@ export class ShellExecutionService {
       return { pid: child.pid, result };
     } catch (e) {
       const error = e as Error;
+      debugLogger.warn(
+        `child_process spawn failed: ${error.message} (platform=${os.platform()}, nodeVersion=${process.version})`,
+      );
       return {
         pid: undefined,
         result: Promise.resolve({
@@ -851,6 +918,22 @@ export class ShellExecutionService {
                 } catch {
                   // Ignore fallback rendering errors and resolve with empty text.
                 }
+              }
+
+              if (
+                exitCode !== 0 &&
+                !abortSignal.aborted &&
+                fullOutput.trim().length === 0
+              ) {
+                debugLogger.warn(
+                  `PTY command exited with code ${exitCode} and no output ` +
+                    `(method=${ptyInfo?.name ?? 'node-pty'}, ` +
+                    `rawBytes=${finalBuffer.length}, ` +
+                    `platform=${os.platform()}, ` +
+                    `nodeVersion=${process.version}). ` +
+                    'This may indicate a spawn-helper issue — see ' +
+                    'https://github.com/microsoft/node-pty/issues/850',
+                );
               }
 
               resolve({

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -12,6 +12,7 @@ import { TextDecoder } from 'node:util';
 import os from 'node:os';
 import path from 'node:path';
 import fs from 'node:fs';
+import { createRequire } from 'node:module';
 import type { IPty } from '@lydell/node-pty';
 import { getCachedEncodingForBuffer } from '../utils/systemEncoding.js';
 import { isBinary } from '../utils/textUtils.js';
@@ -341,7 +342,8 @@ export class ShellExecutionService {
 
     try {
       const ptyPackageName = `@lydell/node-pty-darwin-${os.arch()}`;
-      const ptyMainPath = require.resolve(ptyPackageName);
+      const esmRequire = createRequire(import.meta.url);
+      const ptyMainPath = esmRequire.resolve(ptyPackageName);
       const pkgRoot = path.dirname(ptyMainPath);
       const helperPath = path.join(
         pkgRoot,

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -412,6 +412,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
           `Exit Code: ${result.exitCode ?? '(none)'}`,
           `Signal: ${result.signal ?? '(none)'}`,
           `Process Group PGID: ${result.pid ?? '(none)'}`,
+          `Execution Method: ${result.executionMethod}`,
         ].join('\n');
       }
 
@@ -441,6 +442,9 @@ export class ShellToolInvocation extends BaseToolInvocation<
             )}`;
           } else if (result.exitCode !== null && result.exitCode !== 0) {
             returnDisplayMessage = `Command exited with code: ${result.exitCode}`;
+            if (!result.output.trim()) {
+              returnDisplayMessage += `\n(Command produced no output. Execution method: ${result.executionMethod})`;
+            }
           }
           // If output is empty and command succeeded (code 0, no error/signal/abort),
           // returnDisplayMessage will remain empty, which is fine.


### PR DESCRIPTION
## TLDR

Add debug logging and user-facing diagnostics for silent shell execution failures on macOS. When PTY commands fail with exit code 1 and no output (a known node-pty issue), users and developers now get actionable information instead of a cryptic "Command exited with code: 1" message.

## Screenshots / Video Demo

N/A — no user-facing UI change in the normal path. When the failure occurs, the error display now includes the execution method:

```
Command exited with code: 1
(Command produced no output. Execution method: lydell-node-pty)
```

Previously it only showed:
```
Command exited with code: 1
```

## Dive Deeper

**Context:** Issue #3230 reports shell commands failing on macOS with exit code 1 and no output. Investigation traced this to known node-pty issues:
- `spawn-helper` binary missing execute permission (microsoft/node-pty#850) — especially with pnpm
- `spawn-helper` segfaults on newer macOS versions (openai/codex#13926)
- PTY file descriptor leaks (microsoft/node-pty#882, our own #2313)

The identical symptom (exit 1, no output) was independently reported in openclaw/openclaw#11589 and other CLI tools.

**Problem:** These failures are nearly impossible to diagnose because:
1. The shell execution service has no logging — silent fallback, silent failure
2. The user sees "Command exited with code: 1" with no clue about which execution method was used
3. The spawn-helper permission issue produces zero error messages

**Changes in `shellExecutionService.ts`:**
- `SHELL_EXEC` debug logger throughout the execution pipeline
- Log which method is selected (PTY name, child_process) and why (PTY threw, unavailable, disabled)
- `checkSpawnHelperOnce()`: on macOS, checks spawn-helper existence and execute permission on first PTY use, warns with the exact `chmod +x` fix command
- Warn when PTY exits non-zero with empty output (the signature symptom), including platform, node version, raw byte count, and a link to the upstream issue

**Changes in `shell.ts`:**
- Include `Execution Method` in the structured result sent to the LLM (visible in debug mode)
- When a command fails with no output, surface the execution method in the user-facing error display

## Reviewer Test Plan

1. **Build and run on macOS:** `npm run build && npm run bundle`, then run `node dist/cli.js` with `DEBUG=SHELL_EXEC` to see the new debug logs
2. **Verify spawn-helper check:** On macOS, the first shell command should log `spawn-helper OK: /path/to/spawn-helper`
3. **Simulate permission issue:** `chmod 644` the spawn-helper binary, run a command, verify the warning is logged with the fix command
4. **Verify error display:** Run a command that fails — the "(Command produced no output. Execution method: ...)" suffix should appear when output is empty
5. **Verify no regression:** Run `cd packages/core && npx vitest run src/tools/shell.test.ts src/utils/shell-utils.test.ts` — all 155 tests pass

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to #3230
Related to #2313

Made with [Cursor](https://cursor.com)