### PR TITLE
  feat(cli): add /history command to manage saved chat sessions

### DIFF
--- a/docs/users/features/commands.md
+++ b/docs/users/features/commands.md
@@ -23,8 +23,14 @@ These commands help you save, restore, and summarize work progress.
 | `/init`     | Analyze current directory and create initial context file | `/init`                              |
 | `/summary`  | Generate project summary based on conversation history    | `/summary`                           |
 | `/compress` | Replace chat history with summary to save Tokens          | `/compress`                          |
+| `/history`  | List saved chat history for the current project           | `/history`, `/history list`          |
+| → `clear`   | Delete saved chat history by session ID or with `--all`   | `/history clear <ID>`, `--all`       |
 | `/resume`   | Resume a previous conversation session                    | `/resume`                            |
 | `/restore`  | Restore files to state before tool execution              | `/restore` (list) or `/restore <ID>` |
+
+`/history` works on saved session files for the current project. For safety, the
+active session is left untouched by `/history clear --all`, and it cannot be
+deleted by ID until you start a new session.
 
 ### 1.2 Interface and Workspace Control
 

--- a/packages/cli/src/services/BuiltinCommandLoader.test.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.test.ts
@@ -86,6 +86,13 @@ vi.mock('../ui/commands/extensionsCommand.js', () => ({
   extensionsCommand: {},
 }));
 vi.mock('../ui/commands/helpCommand.js', () => ({ helpCommand: {} }));
+vi.mock('../ui/commands/historyCommand.js', () => ({
+  historyCommand: {
+    name: 'history',
+    description: 'History command',
+    kind: 'BUILT_IN',
+  },
+}));
 vi.mock('../ui/commands/memoryCommand.js', () => ({ memoryCommand: {} }));
 vi.mock('../ui/commands/modelCommand.js', () => ({
   modelCommand: { name: 'model' },
@@ -182,6 +189,9 @@ describe('BuiltinCommandLoader', () => {
 
     const modelCmd = commands.find((c) => c.name === 'model');
     expect(modelCmd).toBeDefined();
+
+    const historyCmd = commands.find((c) => c.name === 'history');
+    expect(historyCmd).toBeDefined();
   });
 
   it('should include trust command when folder trust is enabled', async () => {

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -24,6 +24,7 @@ import { editorCommand } from '../ui/commands/editorCommand.js';
 import { exportCommand } from '../ui/commands/exportCommand.js';
 import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
+import { historyCommand } from '../ui/commands/historyCommand.js';
 import { hooksCommand } from '../ui/commands/hooksCommand.js';
 import { ideCommand } from '../ui/commands/ideCommand.js';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
@@ -98,6 +99,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       exportCommand,
       extensionsCommand,
       helpCommand,
+      historyCommand,
       hooksCommand,
       resolvedIdeCommand,
       initCommand,

--- a/packages/cli/src/ui/commands/historyCommand.test.ts
+++ b/packages/cli/src/ui/commands/historyCommand.test.ts
@@ -1,0 +1,226 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const { mockListSessions, mockRemoveSession, mockSessionServiceConstructor } =
+  vi.hoisted(() => ({
+    mockListSessions: vi.fn(),
+    mockRemoveSession: vi.fn(),
+    mockSessionServiceConstructor: vi.fn(),
+  }));
+
+vi.mock('@qwen-code/qwen-code-core', async () => {
+  const actual = await vi.importActual('@qwen-code/qwen-code-core');
+  return {
+    ...actual,
+    SessionService: vi.fn().mockImplementation((cwd: string) => {
+      mockSessionServiceConstructor(cwd);
+      return {
+        listSessions: mockListSessions,
+        removeSession: mockRemoveSession,
+      };
+    }),
+  };
+});
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { historyCommand } from './historyCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import type { CommandContext } from './types.js';
+
+describe('historyCommand', () => {
+  let mockContext: CommandContext;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListSessions.mockResolvedValue({
+      items: [],
+      hasMore: false,
+      nextCursor: undefined,
+    });
+    mockRemoveSession.mockResolvedValue(true);
+
+    mockContext = createMockCommandContext({
+      services: {
+        config: {
+          getWorkingDir: () => '/repo',
+          getProjectRoot: () => '/repo',
+          getSessionId: () => 'current-session',
+        },
+      },
+    });
+  });
+
+  it('lists saved chat history by default', async () => {
+    mockListSessions.mockResolvedValue({
+      items: [
+        {
+          sessionId: 'current-session',
+          cwd: '/repo',
+          startTime: '2026-04-14T00:00:00.000Z',
+          mtime: 1,
+          prompt: 'Current prompt',
+          gitBranch: 'main',
+          filePath: '/repo/.qwen/chats/current-session.jsonl',
+          messageCount: 3,
+        },
+        {
+          sessionId: 'older-session',
+          cwd: '/repo',
+          startTime: '2026-04-13T00:00:00.000Z',
+          mtime: 2,
+          prompt: 'Older prompt',
+          gitBranch: undefined,
+          filePath: '/repo/.qwen/chats/older-session.jsonl',
+          messageCount: 1,
+        },
+      ],
+      hasMore: false,
+      nextCursor: undefined,
+    });
+
+    const result = await historyCommand.action?.(mockContext, '');
+
+    expect(mockSessionServiceConstructor).toHaveBeenCalledWith('/repo');
+    expect(mockListSessions).toHaveBeenCalledWith({
+      size: 100,
+      cursor: undefined,
+    });
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: expect.stringContaining('Saved chat history for this project:'),
+    });
+    expect(result?.type).toBe('message');
+    if (result?.type === 'message') {
+      expect(result.content).toContain('current-session (current)');
+      expect(result.content).toContain('Older prompt');
+    }
+  });
+
+  it('returns a helpful message when no saved history exists', async () => {
+    const result = await historyCommand.action?.(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'No saved chat history found for this project.',
+    });
+  });
+
+  it('returns usage information when clear is missing arguments', async () => {
+    const clearCommand = historyCommand.subCommands?.find(
+      (command) => command.name === 'clear',
+    );
+
+    const result = await clearCommand?.action?.(mockContext, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Usage: /history clear <session-id> or /history clear --all',
+    });
+  });
+
+  it('deletes a specific inactive session by id', async () => {
+    const clearCommand = historyCommand.subCommands?.find(
+      (command) => command.name === 'clear',
+    );
+
+    const result = await clearCommand?.action?.(mockContext, 'older-session');
+
+    expect(mockRemoveSession).toHaveBeenCalledWith('older-session');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Deleted saved chat history for session older-session.',
+    });
+  });
+
+  it('refuses to delete the active session history', async () => {
+    const clearCommand = historyCommand.subCommands?.find(
+      (command) => command.name === 'clear',
+    );
+
+    const result = await clearCommand?.action?.(mockContext, 'current-session');
+
+    expect(mockRemoveSession).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content:
+        'Cannot delete the active session history while this session is running. Start a new session first, then delete it by ID.',
+    });
+  });
+
+  it('deletes all inactive sessions and leaves the active session untouched', async () => {
+    mockListSessions
+      .mockResolvedValueOnce({
+        items: [
+          {
+            sessionId: 'current-session',
+            cwd: '/repo',
+            startTime: '2026-04-14T00:00:00.000Z',
+            mtime: 3,
+            prompt: 'Current prompt',
+            gitBranch: 'main',
+            filePath: '/repo/.qwen/chats/current-session.jsonl',
+            messageCount: 3,
+          },
+          {
+            sessionId: 'older-session',
+            cwd: '/repo',
+            startTime: '2026-04-13T00:00:00.000Z',
+            mtime: 2,
+            prompt: 'Older prompt',
+            gitBranch: undefined,
+            filePath: '/repo/.qwen/chats/older-session.jsonl',
+            messageCount: 1,
+          },
+        ],
+        hasMore: true,
+        nextCursor: 2,
+      })
+      .mockResolvedValueOnce({
+        items: [
+          {
+            sessionId: 'oldest-session',
+            cwd: '/repo',
+            startTime: '2026-04-12T00:00:00.000Z',
+            mtime: 1,
+            prompt: 'Oldest prompt',
+            gitBranch: undefined,
+            filePath: '/repo/.qwen/chats/oldest-session.jsonl',
+            messageCount: 2,
+          },
+        ],
+        hasMore: false,
+        nextCursor: undefined,
+      });
+
+    const clearCommand = historyCommand.subCommands?.find(
+      (command) => command.name === 'clear',
+    );
+    const result = await clearCommand?.action?.(mockContext, '--all');
+
+    expect(mockListSessions).toHaveBeenNthCalledWith(1, {
+      size: 100,
+      cursor: undefined,
+    });
+    expect(mockListSessions).toHaveBeenNthCalledWith(2, {
+      size: 100,
+      cursor: 2,
+    });
+    expect(mockRemoveSession).toHaveBeenCalledTimes(2);
+    expect(mockRemoveSession).toHaveBeenNthCalledWith(1, 'older-session');
+    expect(mockRemoveSession).toHaveBeenNthCalledWith(2, 'oldest-session');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content:
+        'Deleted 2 saved chat history session(s) for this project. The active session was left untouched.',
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/historyCommand.ts
+++ b/packages/cli/src/ui/commands/historyCommand.ts
@@ -1,0 +1,282 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  SessionService,
+  type SessionListItem,
+} from '@qwen-code/qwen-code-core';
+import {
+  type CommandContext,
+  type MessageActionReturn,
+  type SlashCommand,
+  CommandKind,
+} from './types.js';
+import { t } from '../../i18n/index.js';
+
+const HISTORY_PAGE_SIZE = 100;
+
+interface HistoryCommandDependencies {
+  config: NonNullable<CommandContext['services']['config']>;
+  sessionService: SessionService;
+}
+
+function getHistoryCommandDependencies(
+  context: CommandContext,
+): HistoryCommandDependencies | MessageActionReturn {
+  const { config } = context.services;
+  if (!config) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: t('Configuration not available.'),
+    };
+  }
+
+  const cwd = config.getWorkingDir() || config.getProjectRoot();
+  if (!cwd) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: t('Could not determine current working directory.'),
+    };
+  }
+
+  return {
+    config,
+    sessionService: new SessionService(cwd),
+  };
+}
+
+async function loadAllSessions(
+  sessionService: SessionService,
+): Promise<SessionListItem[]> {
+  const sessions: SessionListItem[] = [];
+  let cursor: number | undefined;
+
+  while (true) {
+    const result = await sessionService.listSessions({
+      size: HISTORY_PAGE_SIZE,
+      cursor,
+    });
+    sessions.push(...result.items);
+
+    if (!result.hasMore || result.nextCursor === undefined) {
+      return sessions;
+    }
+
+    cursor = result.nextCursor;
+  }
+}
+
+function formatSessionSummary(
+  session: SessionListItem,
+  currentSessionId: string,
+): string {
+  const metadata = [
+    session.startTime,
+    `${session.messageCount} ${session.messageCount === 1 ? 'message' : 'messages'}`,
+    ...(session.gitBranch ? [session.gitBranch] : []),
+  ];
+  const currentSuffix =
+    session.sessionId === currentSessionId ? ` ${t('(current)')}` : '';
+  const prompt = session.prompt || t('(empty prompt)');
+
+  return `${session.sessionId}${currentSuffix} | ${metadata.join(' | ')}\n${prompt}`;
+}
+
+async function listHistoryAction(
+  context: CommandContext,
+): Promise<MessageActionReturn> {
+  const dependencies = getHistoryCommandDependencies(context);
+  if ('type' in dependencies) {
+    return dependencies;
+  }
+
+  const { config, sessionService } = dependencies;
+  try {
+    const sessions = await loadAllSessions(sessionService);
+
+    if (sessions.length === 0) {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: t('No saved chat history found for this project.'),
+      };
+    }
+
+    const currentSessionId = config.getSessionId();
+    const lines = sessions.map((session) =>
+      formatSessionSummary(session, currentSessionId),
+    );
+
+    return {
+      type: 'message',
+      messageType: 'info',
+      content: `${t('Saved chat history for this project:')}\n\n${lines.join('\n\n')}`,
+    };
+  } catch (error) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: t('Failed to load saved chat history: {{message}}', {
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    };
+  }
+}
+
+function getClearUsage(): string {
+  return t('Usage: /history clear <session-id> or /history clear --all');
+}
+
+async function clearHistoryAction(
+  context: CommandContext,
+  args: string,
+): Promise<MessageActionReturn> {
+  const dependencies = getHistoryCommandDependencies(context);
+  if ('type' in dependencies) {
+    return dependencies;
+  }
+
+  const { config, sessionService } = dependencies;
+  const trimmedArgs = args.trim();
+  if (!trimmedArgs) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: getClearUsage(),
+    };
+  }
+
+  const currentSessionId = config.getSessionId();
+  try {
+    if (trimmedArgs === '--all') {
+      const sessions = await loadAllSessions(sessionService);
+      if (sessions.length === 0) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: t('No saved chat history found for this project.'),
+        };
+      }
+
+      const deletableSessions = sessions.filter(
+        (session) => session.sessionId !== currentSessionId,
+      );
+      const skippedCurrent = deletableSessions.length !== sessions.length;
+
+      let deletedCount = 0;
+      for (const session of deletableSessions) {
+        const deleted = await sessionService.removeSession(session.sessionId);
+        if (deleted) {
+          deletedCount++;
+        }
+      }
+
+      if (deletedCount === 0 && skippedCurrent) {
+        return {
+          type: 'message',
+          messageType: 'info',
+          content: t(
+            'No inactive saved chat history found for this project. The active session was left untouched.',
+          ),
+        };
+      }
+
+      const skippedSuffix = skippedCurrent
+        ? ` ${t('The active session was left untouched.')}`
+        : '';
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: t(
+          'Deleted {{count}} saved chat history session(s) for this project.{{suffix}}',
+          {
+            count: String(deletedCount),
+            suffix: skippedSuffix,
+          },
+        ),
+      };
+    }
+
+    const parts = trimmedArgs.split(/\s+/);
+    if (parts.length !== 1) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: getClearUsage(),
+      };
+    }
+
+    const sessionId = parts[0];
+    if (sessionId === currentSessionId) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: t(
+          'Cannot delete the active session history while this session is running. Start a new session first, then delete it by ID.',
+        ),
+      };
+    }
+
+    const deleted = await sessionService.removeSession(sessionId);
+    if (!deleted) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: t(
+          'No saved chat history found with session ID {{sessionId}} in this project.',
+          { sessionId },
+        ),
+      };
+    }
+
+    return {
+      type: 'message',
+      messageType: 'info',
+      content: t('Deleted saved chat history for session {{sessionId}}.', {
+        sessionId,
+      }),
+    };
+  } catch (error) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: t('Failed to delete saved chat history: {{message}}', {
+        message: error instanceof Error ? error.message : String(error),
+      }),
+    };
+  }
+}
+
+export const historyCommand: SlashCommand = {
+  name: 'history',
+  get description() {
+    return t('List and clear saved chat history for this project.');
+  },
+  kind: CommandKind.BUILT_IN,
+  action: async (context) => listHistoryAction(context),
+  subCommands: [
+    {
+      name: 'list',
+      get description() {
+        return t('List saved chat history for this project.');
+      },
+      kind: CommandKind.BUILT_IN,
+      action: async (context) => listHistoryAction(context),
+    },
+    {
+      name: 'clear',
+      get description() {
+        return t(
+          'Delete saved chat history by session ID or delete all inactive history with --all.',
+        );
+      },
+      kind: CommandKind.BUILT_IN,
+      action: async (context, args) => clearHistoryAction(context, args),
+    },
+  ],
+};


### PR DESCRIPTION


## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->


  This PR adds a new built-in `/history` command for project-scoped saved chat history management.

  It exposes existing session deletion capability through the CLI without changing the behavior of `/clear` or any existing
  session persistence flow.

  Supported commands:
  - `/history`
  - `/history list`
  - `/history clear <session-id>`
  - `/history clear --all`

  For safety, the active session is never deleted by `/history clear --all`, and deleting the currently running session by
  ID is rejected.

## Screenshots / Video Demo

```
 > /history list

  ● Saved chat history for this project:

    6ca1e2bc-b560-4c69-846e-995cf0030ab8 (current) | 2026-04-14T12:36:10.950Z | 0 messages | issue
    (empty prompt)

    2de3d7e8-a8ca-40d6-adac-39f382b31765 | 2026-04-14T12:32:44.765Z | 0 messages | issue-2
    (empty prompt)

    1d06124d-fef2-40ee-b799-68ffea8862c6 | 2026-04-14T10:42:06.169Z | 0 messages | main
    (empty prompt)

    bf7c003f-7981-48ee-8d55-61cbc786f738 | 2026-04-14T10:41:09.061Z | 0 messages | main



$ ls ~/.qwen/projects/-home-xx-github-qwen-code/chats/
1fc76993-c903-4fa5-a7eb-26a58d5ad2e7.jsonl  

  > /history clear 1fc76993-c903-4fa5-a7eb-26a58d5ad2e7

  ● Deleted saved chat history for session 1fc76993-c903-4fa5-a7eb-26a58d5ad2e7.


$ ls ~/.qwen/projects/-home-xx-github-qwen-code/chats/1fc76993-c903-4fa5-a7eb-26a58d5ad2e7.jsonl
ls: cannot access '/home/reid/.qwen/projects/-home-reid-github-qwen-code/chats/1fc76993-c903-4fa5-a7eb-26a58d5ad2e7.jsonl': No such file or directory


  > /history clear --all

  ● Deleted 22 saved chat history session(s) for this project. The active session was left untouched.
```

<!--
Please attach a screenshot or short video showing your change in action.
This helps reviewers understand the change quickly and prioritize reviews.

- For bug fixes: show the before/after behavior.
- For features: show the new functionality in use.
- For refactors or internal changes with no visible effect: write "N/A — no user-facing change" and briefly explain why.

PRs with visual demos typically get reviewed much faster!
-->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

  |          | 🍏  | 🪟  | 🐧  |
  | -------- | --- | --- | --- |
  | npm run  | ❓  | ❓  | ✅ `npm run build`, `npm run lint` |
  | npx      | ❓  | ❓  | ✅ `cd packages/cli && npx vitest run src/ui/commands/historyCommand.test.ts src/services/
  BuiltinCommandLoader.test.ts` |
  | Docker   | ❓  | ❓  | ❓  |
  | Podman   | ❓  | -   | ❓  |
  | Seatbelt | ❓  | -   | ❓  |

## Linked issues / bugs

Closes #2487

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
