### PR TITLE
feat: add PostTurn hook event for turn-level post-processing

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -420,7 +420,10 @@ export class Session implements SessionContext {
           ) {
             postTurnIndex++;
             const turnIdx = postTurnIndex;
-            const hasToolCalls = functionCalls.length > 0;
+            const turnToolCalls = functionCalls.map((fc) => ({
+              name: fc.name ?? '',
+              args: fc.args as Record<string, unknown> | undefined,
+            }));
             pendingPostTurnHooks.push(
               (async () => {
                 const result = await firePostTurnHook(
@@ -428,7 +431,7 @@ export class Session implements SessionContext {
                   turnIdx,
                   turnThoughts,
                   turnMessages,
-                  hasToolCalls,
+                  turnToolCalls,
                   pendingSend.signal,
                 );
                 if (result.acpMessage) {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -327,6 +327,7 @@ export class Session implements SessionContext {
           this.config.hasHooksForEvent?.('PostTurn');
         let postTurnIndex = 0;
         const pendingPostTurnHooks: Array<Promise<void>> = [];
+        const rewriteHistory: string[] = [];
 
         while (nextMessage !== null) {
           if (pendingSend.signal.aborted) {
@@ -429,9 +430,11 @@ export class Session implements SessionContext {
                   turnThoughts,
                   turnMessages,
                   hasToolCalls,
+                  [...rewriteHistory],
                   pendingSend.signal,
                 );
                 if (result.acpMessage) {
+                  rewriteHistory.push(result.acpMessage);
                   await this.sendUpdate({
                     sessionUpdate: 'agent_message_chunk',
                     content: { type: 'text', text: result.acpMessage },

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -327,7 +327,7 @@ export class Session implements SessionContext {
           this.config.hasHooksForEvent?.('PostTurn');
         let postTurnIndex = 0;
         const pendingPostTurnHooks: Array<Promise<void>> = [];
-        const rewriteHistory: string[] = [];
+        const hookOutputHistory: string[] = [];
 
         while (nextMessage !== null) {
           if (pendingSend.signal.aborted) {
@@ -430,15 +430,15 @@ export class Session implements SessionContext {
                   turnThoughts,
                   turnMessages,
                   hasToolCalls,
-                  [...rewriteHistory],
+                  [...hookOutputHistory],
                   pendingSend.signal,
                 );
                 if (result.acpMessage) {
-                  rewriteHistory.push(result.acpMessage);
+                  hookOutputHistory.push(result.acpMessage);
                   await this.sendUpdate({
                     sessionUpdate: 'agent_message_chunk',
                     content: { type: 'text', text: result.acpMessage },
-                    _meta: { rewritten: true, turnIndex: turnIdx },
+                    _meta: { postTurnHook: true, turnIndex: turnIdx },
                   } as SessionUpdate);
                 }
               })(),

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -40,6 +40,7 @@ import {
   evaluatePermissionRules,
   fireNotificationHook,
   firePermissionRequestHook,
+  firePostTurnHook,
   injectPermissionRulesIfMissing,
   NotificationType,
   persistPermissionOutcome,
@@ -318,6 +319,15 @@ export class Session implements SessionContext {
 
         let nextMessage: Content | null = { role: 'user', parts };
 
+        const hooksEnabled = !this.config.getDisableAllHooks?.();
+        const messageBus = this.config.getMessageBus?.();
+        const hasPostTurnHook =
+          hooksEnabled &&
+          messageBus &&
+          this.config.hasHooksForEvent?.('PostTurn');
+        let postTurnIndex = 0;
+        const pendingPostTurnHooks: Array<Promise<void>> = [];
+
         while (nextMessage !== null) {
           if (pendingSend.signal.aborted) {
             chat.addHistory(nextMessage);
@@ -327,6 +337,10 @@ export class Session implements SessionContext {
           const functionCalls: FunctionCall[] = [];
           let usageMetadata: GenerateContentResponseUsageMetadata | null = null;
           const streamStartTime = Date.now();
+
+          // Accumulate turn content for PostTurn hook
+          const turnThoughts: string[] = [];
+          const turnMessages: string[] = [];
 
           try {
             const responseStream = await chat.sendMessageStream(
@@ -362,6 +376,15 @@ export class Session implements SessionContext {
                     'assistant',
                     part.thought,
                   );
+
+                  // Accumulate for PostTurn hook
+                  if (hasPostTurnHook) {
+                    if (part.thought) {
+                      turnThoughts.push(part.text);
+                    } else {
+                      turnMessages.push(part.text);
+                    }
+                  }
                 }
               }
 
@@ -390,6 +413,35 @@ export class Session implements SessionContext {
             throw error;
           }
 
+          // Fire PostTurn hook (fire-and-forget, does not block agent loop)
+          if (
+            hasPostTurnHook &&
+            (turnThoughts.length > 0 || turnMessages.length > 0)
+          ) {
+            postTurnIndex++;
+            const turnIdx = postTurnIndex;
+            const hasToolCalls = functionCalls.length > 0;
+            pendingPostTurnHooks.push(
+              (async () => {
+                const result = await firePostTurnHook(
+                  messageBus,
+                  turnIdx,
+                  turnThoughts,
+                  turnMessages,
+                  hasToolCalls,
+                  pendingSend.signal,
+                );
+                if (result.acpMessage) {
+                  await this.sendUpdate({
+                    sessionUpdate: 'agent_message_chunk',
+                    content: { type: 'text', text: result.acpMessage },
+                    _meta: { rewritten: true, turnIndex: turnIdx },
+                  } as SessionUpdate);
+                }
+              })(),
+            );
+          }
+
           if (usageMetadata) {
             const durationMs = Date.now() - streamStartTime;
             await this.messageEmitter.emitUsageMetadata(
@@ -414,6 +466,12 @@ export class Session implements SessionContext {
             nextMessage = { role: 'user', parts: toolResponseParts };
           }
         }
+
+        // Wait for all pending PostTurn hooks before session ends
+        if (pendingPostTurnHooks.length > 0) {
+          await Promise.allSettled(pendingPostTurnHooks);
+        }
+
         return { stopReason: 'end_turn' };
       },
     );

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -413,11 +413,9 @@ export class Session implements SessionContext {
             throw error;
           }
 
-          // Fire PostTurn hook (fire-and-forget, does not block agent loop)
-          if (
-            hasPostTurnHook &&
-            (turnThoughts.length > 0 || turnMessages.length > 0)
-          ) {
+          // Fire PostTurn hook at every turn boundary (fire-and-forget).
+          // Hook scripts decide whether to process based on content.
+          if (hasPostTurnHook) {
             postTurnIndex++;
             const turnIdx = postTurnIndex;
             const turnToolCalls = functionCalls.map((fc) => ({

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -435,11 +435,14 @@ export class Session implements SessionContext {
                 );
                 if (result.acpMessage) {
                   hookOutputHistory.push(result.acpMessage);
-                  await this.sendUpdate({
+                  const update: Record<string, unknown> = {
                     sessionUpdate: 'agent_message_chunk',
                     content: { type: 'text', text: result.acpMessage },
-                    _meta: { postTurnHook: true, turnIndex: turnIdx },
-                  } as SessionUpdate);
+                  };
+                  if (result.acpMeta) {
+                    update['_meta'] = result.acpMeta;
+                  }
+                  await this.sendUpdate(update as SessionUpdate);
                 }
               })(),
             );

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -327,7 +327,6 @@ export class Session implements SessionContext {
           this.config.hasHooksForEvent?.('PostTurn');
         let postTurnIndex = 0;
         const pendingPostTurnHooks: Array<Promise<void>> = [];
-        const hookOutputHistory: string[] = [];
 
         while (nextMessage !== null) {
           if (pendingSend.signal.aborted) {
@@ -430,11 +429,9 @@ export class Session implements SessionContext {
                   turnThoughts,
                   turnMessages,
                   hasToolCalls,
-                  [...hookOutputHistory],
                   pendingSend.signal,
                 );
                 if (result.acpMessage) {
-                  hookOutputHistory.push(result.acpMessage);
                   const update: Record<string, unknown> = {
                     sessionUpdate: 'agent_message_chunk',
                     content: { type: 'text', text: result.acpMessage },

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1686,6 +1686,18 @@ const SETTINGS_SCHEMA = {
         mergeStrategy: MergeStrategy.CONCAT,
         items: HOOK_DEFINITION_ITEMS,
       },
+      PostTurn: {
+        type: 'array',
+        label: 'Post Turn Hooks',
+        category: 'Advanced',
+        requiresRestart: false,
+        default: [],
+        description:
+          'Hooks that execute after each model turn completes (at tool_call boundary or end of response). Can inject ACP messages via acpMessage output.',
+        showInDialog: false,
+        mergeStrategy: MergeStrategy.CONCAT,
+        items: HOOK_DEFINITION_ITEMS,
+      },
     },
   },
 

--- a/packages/cli/src/ui/components/hooks/constants.ts
+++ b/packages/cli/src/ui/components/hooks/constants.ts
@@ -94,6 +94,15 @@ export function getHookExitCodes(eventName: string): HookExitCode[] {
       { code: 0, description: t('use hook decision if provided') },
       { code: 'Other', description: t('show stderr to user only') },
     ],
+    [HookEventName.PostTurn]: [
+      {
+        code: 0,
+        description: t(
+          'inject acpMessage into ACP stream if provided in stdout',
+        ),
+      },
+      { code: 'Other', description: t('show stderr to user only') },
+    ],
   };
   return exitCodesMap[eventName] || [];
 }
@@ -120,6 +129,9 @@ export function getHookShortDescription(eventName: string): string {
     [HookEventName.SessionEnd]: t('When a session is ending'),
     [HookEventName.PermissionRequest]: t(
       'When a permission dialog is displayed',
+    ),
+    [HookEventName.PostTurn]: t(
+      'After each model turn completes (at tool call or response end)',
     ),
   };
   return descriptions[eventName] || '';
@@ -163,6 +175,9 @@ export function getHookDescription(eventName: string): string {
     ),
     [HookEventName.PermissionRequest]: t(
       'Input to command is JSON with tool_name, tool_input, and tool_use_id. Output JSON with hookSpecificOutput containing decision to allow or deny.',
+    ),
+    [HookEventName.PostTurn]: t(
+      'Input to command is JSON with turn_index, thoughts, messages, and tool_calls. Output JSON with hookSpecificOutput containing acpMessage (text to inject into ACP stream) and acpMeta (optional metadata).',
     ),
   };
   return descriptions[eventName] || '';

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -956,6 +956,22 @@ export class Config {
                   signal,
                 );
                 break;
+              case 'PostTurn': {
+                const postTurnResult = await hookSystem.firePostTurnEvent(
+                  (input['turn_index'] as number) || 0,
+                  (input['thoughts'] as string[]) || [],
+                  (input['messages'] as string[]) || [],
+                  (input['tool_calls'] as Array<{
+                    name: string;
+                    args?: Record<string, unknown>;
+                  }>) || [],
+                  signal,
+                );
+                result = postTurnResult.finalOutput
+                  ? createHookOutput('PostTurn', postTurnResult.finalOutput)
+                  : undefined;
+                break;
+              }
               default:
                 this.debugLogger.warn(
                   `Unknown hook event: ${request.eventName}`,

--- a/packages/core/src/core/toolHookTriggers.ts
+++ b/packages/core/src/core/toolHookTriggers.ts
@@ -510,7 +510,6 @@ export async function firePostTurnHook(
   thoughts: string[],
   messages: string[],
   hasToolCalls: boolean,
-  previousHookOutputs: string[],
   signal?: AbortSignal,
 ): Promise<PostTurnHookResult> {
   if (!messageBus) {
@@ -530,7 +529,6 @@ export async function firePostTurnHook(
           thoughts,
           messages,
           has_tool_calls: hasToolCalls,
-          previous_hook_outputs: previousHookOutputs,
         },
         signal,
       },

--- a/packages/core/src/core/toolHookTriggers.ts
+++ b/packages/core/src/core/toolHookTriggers.ts
@@ -18,6 +18,7 @@ import {
   type NotificationType,
   type PermissionRequestHookOutput,
   type PermissionSuggestion,
+  type PostTurnHookOutput,
 } from '../hooks/types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import type { Part, PartListUnion } from '@google/genai';
@@ -485,4 +486,70 @@ export function appendAdditionalContext(
 
   // For non-array content that's still PartListUnion, return as-is
   return content;
+}
+
+/**
+ * Result of PostTurn hook execution
+ */
+export interface PostTurnHookResult {
+  /** ACP message to inject with _meta.rewritten: true */
+  acpMessage?: string;
+}
+
+/**
+ * Fire a PostTurn hook event.
+ * Fire-and-forget: errors are silently ignored, never blocks agent execution.
+ *
+ * @returns PostTurnHookResult with optional acpMessage to inject
+ */
+export async function firePostTurnHook(
+  messageBus: MessageBus | undefined,
+  turnIndex: number,
+  thoughts: string[],
+  messages: string[],
+  hasToolCalls: boolean,
+  signal?: AbortSignal,
+): Promise<PostTurnHookResult> {
+  if (!messageBus) {
+    return {};
+  }
+
+  try {
+    const response = await messageBus.request<
+      HookExecutionRequest,
+      HookExecutionResponse
+    >(
+      {
+        type: MessageBusType.HOOK_EXECUTION_REQUEST,
+        eventName: 'PostTurn',
+        input: {
+          turn_index: turnIndex,
+          thoughts,
+          messages,
+          has_tool_calls: hasToolCalls,
+        },
+        signal,
+      },
+      MessageBusType.HOOK_EXECUTION_RESPONSE,
+    );
+
+    if (!response.success || !response.output) {
+      return {};
+    }
+
+    const postTurnOutput = createHookOutput(
+      'PostTurn',
+      response.output,
+    ) as PostTurnHookOutput;
+
+    return {
+      acpMessage: postTurnOutput.getAcpMessage(),
+    };
+  } catch (error) {
+    // PostTurn hook errors must not affect agent execution
+    debugLogger.warn(
+      `PostTurn hook error: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return {};
+  }
 }

--- a/packages/core/src/core/toolHookTriggers.ts
+++ b/packages/core/src/core/toolHookTriggers.ts
@@ -492,8 +492,10 @@ export function appendAdditionalContext(
  * Result of PostTurn hook execution
  */
 export interface PostTurnHookResult {
-  /** ACP message to inject with _meta.rewritten: true */
+  /** Message text to inject into ACP stream as agent_message_chunk. */
   acpMessage?: string;
+  /** Optional metadata for the injected ACP message. Defined by hook scripts, passed through as-is. */
+  acpMeta?: Record<string, unknown>;
 }
 
 /**
@@ -546,6 +548,7 @@ export async function firePostTurnHook(
 
     return {
       acpMessage: postTurnOutput.getAcpMessage(),
+      acpMeta: postTurnOutput.getAcpMeta(),
     };
   } catch (error) {
     // PostTurn hook errors must not affect agent execution

--- a/packages/core/src/core/toolHookTriggers.ts
+++ b/packages/core/src/core/toolHookTriggers.ts
@@ -509,7 +509,7 @@ export async function firePostTurnHook(
   turnIndex: number,
   thoughts: string[],
   messages: string[],
-  hasToolCalls: boolean,
+  toolCalls: Array<{ name: string; args?: Record<string, unknown> }>,
   signal?: AbortSignal,
 ): Promise<PostTurnHookResult> {
   if (!messageBus) {
@@ -528,7 +528,7 @@ export async function firePostTurnHook(
           turn_index: turnIndex,
           thoughts,
           messages,
-          has_tool_calls: hasToolCalls,
+          tool_calls: toolCalls,
         },
         signal,
       },

--- a/packages/core/src/core/toolHookTriggers.ts
+++ b/packages/core/src/core/toolHookTriggers.ts
@@ -508,6 +508,7 @@ export async function firePostTurnHook(
   thoughts: string[],
   messages: string[],
   hasToolCalls: boolean,
+  previousRewrites: string[],
   signal?: AbortSignal,
 ): Promise<PostTurnHookResult> {
   if (!messageBus) {
@@ -527,6 +528,7 @@ export async function firePostTurnHook(
           thoughts,
           messages,
           has_tool_calls: hasToolCalls,
+          previous_rewrites: previousRewrites,
         },
         signal,
       },

--- a/packages/core/src/core/toolHookTriggers.ts
+++ b/packages/core/src/core/toolHookTriggers.ts
@@ -508,7 +508,7 @@ export async function firePostTurnHook(
   thoughts: string[],
   messages: string[],
   hasToolCalls: boolean,
-  previousRewrites: string[],
+  previousHookOutputs: string[],
   signal?: AbortSignal,
 ): Promise<PostTurnHookResult> {
   if (!messageBus) {
@@ -528,7 +528,7 @@ export async function firePostTurnHook(
           thoughts,
           messages,
           has_tool_calls: hasToolCalls,
-          previous_rewrites: previousRewrites,
+          previous_hook_outputs: previousHookOutputs,
         },
         signal,
       },

--- a/packages/core/src/hooks/hookAggregator.ts
+++ b/packages/core/src/hooks/hookAggregator.ts
@@ -57,13 +57,22 @@ export class HookAggregator {
 
     // PostTurn: fire-and-forget but preserve outputs (needed for acpMessage extraction).
     // Ignore errors — hook failures must not block agent execution.
+    // When multiple hooks return acpMessage, first non-empty one wins.
     if (eventName === HookEventName.PostTurn) {
       const allOutputs: HookOutput[] = [];
       let totalDuration = 0;
+      let firstAcpOutput: HookOutput | undefined;
       for (const result of results) {
         totalDuration += result.duration;
         if (result.output) {
           allOutputs.push(result.output);
+          if (
+            !firstAcpOutput &&
+            (result.output.hookSpecificOutput as { acpMessage?: string })
+              ?.acpMessage
+          ) {
+            firstAcpOutput = result.output;
+          }
         }
       }
       return {
@@ -71,7 +80,7 @@ export class HookAggregator {
         allOutputs,
         errors: [],
         totalDuration,
-        finalOutput: allOutputs.length > 0 ? allOutputs[0] : undefined,
+        finalOutput: firstAcpOutput ?? allOutputs[0],
       };
     }
 

--- a/packages/core/src/hooks/hookAggregator.ts
+++ b/packages/core/src/hooks/hookAggregator.ts
@@ -40,7 +40,7 @@ export class HookAggregator {
     results: HookExecutionResult[],
     eventName: HookEventName,
   ): AggregatedHookResult {
-    // StopFailure special handling: fire-and-forget, ignore all outputs and errors
+    // StopFailure: fire-and-forget, ignore all outputs and errors
     if (eventName === HookEventName.StopFailure) {
       let totalDuration = 0;
       for (const result of results) {
@@ -52,6 +52,26 @@ export class HookAggregator {
         errors: [], // Ignore errors
         totalDuration,
         finalOutput: undefined,
+      };
+    }
+
+    // PostTurn: fire-and-forget but preserve outputs (needed for acpMessage extraction).
+    // Ignore errors — hook failures must not block agent execution.
+    if (eventName === HookEventName.PostTurn) {
+      const allOutputs: HookOutput[] = [];
+      let totalDuration = 0;
+      for (const result of results) {
+        totalDuration += result.duration;
+        if (result.output) {
+          allOutputs.push(result.output);
+        }
+      }
+      return {
+        success: true,
+        allOutputs,
+        errors: [],
+        totalDuration,
+        finalOutput: allOutputs.length > 0 ? allOutputs[0] : undefined,
       };
     }
 

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -114,6 +114,7 @@ export class HookEventHandler {
     thoughts: string[],
     messages: string[],
     hasToolCalls: boolean,
+    previousRewrites: string[],
     signal?: AbortSignal,
   ): Promise<AggregatedHookResult> {
     const input: PostTurnInput = {
@@ -122,6 +123,7 @@ export class HookEventHandler {
       thoughts,
       messages,
       has_tool_calls: hasToolCalls,
+      previous_rewrites: previousRewrites,
     };
 
     return this.executeHooks(HookEventName.PostTurn, input, undefined, signal);

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -35,6 +35,7 @@ import type {
   SubagentStopInput,
   StopFailureInput,
   StopFailureErrorType,
+  PostTurnInput,
 } from './types.js';
 import { PermissionMode } from './types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
@@ -101,6 +102,29 @@ export class HookEventHandler {
     };
 
     return this.executeHooks(HookEventName.Stop, input, undefined, signal);
+  }
+
+  /**
+   * Fire a PostTurn event
+   * Called after each model turn completes (at tool_call boundary or end of response).
+   * Fire-and-forget: does not block agent execution.
+   */
+  async firePostTurnEvent(
+    turnIndex: number,
+    thoughts: string[],
+    messages: string[],
+    hasToolCalls: boolean,
+    signal?: AbortSignal,
+  ): Promise<AggregatedHookResult> {
+    const input: PostTurnInput = {
+      ...this.createBaseInput(HookEventName.PostTurn),
+      turn_index: turnIndex,
+      thoughts,
+      messages,
+      has_tool_calls: hasToolCalls,
+    };
+
+    return this.executeHooks(HookEventName.PostTurn, input, undefined, signal);
   }
 
   /**

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -114,7 +114,7 @@ export class HookEventHandler {
     thoughts: string[],
     messages: string[],
     hasToolCalls: boolean,
-    previousRewrites: string[],
+    previousHookOutputs: string[],
     signal?: AbortSignal,
   ): Promise<AggregatedHookResult> {
     const input: PostTurnInput = {
@@ -123,7 +123,7 @@ export class HookEventHandler {
       thoughts,
       messages,
       has_tool_calls: hasToolCalls,
-      previous_rewrites: previousRewrites,
+      previous_hook_outputs: previousHookOutputs,
     };
 
     return this.executeHooks(HookEventName.PostTurn, input, undefined, signal);

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -114,7 +114,6 @@ export class HookEventHandler {
     thoughts: string[],
     messages: string[],
     hasToolCalls: boolean,
-    previousHookOutputs: string[],
     signal?: AbortSignal,
   ): Promise<AggregatedHookResult> {
     const input: PostTurnInput = {
@@ -123,7 +122,6 @@ export class HookEventHandler {
       thoughts,
       messages,
       has_tool_calls: hasToolCalls,
-      previous_hook_outputs: previousHookOutputs,
     };
 
     return this.executeHooks(HookEventName.PostTurn, input, undefined, signal);

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -113,7 +113,7 @@ export class HookEventHandler {
     turnIndex: number,
     thoughts: string[],
     messages: string[],
-    hasToolCalls: boolean,
+    toolCalls: Array<{ name: string; args?: Record<string, unknown> }>,
     signal?: AbortSignal,
   ): Promise<AggregatedHookResult> {
     const input: PostTurnInput = {
@@ -121,7 +121,7 @@ export class HookEventHandler {
       turn_index: turnIndex,
       thoughts,
       messages,
-      has_tool_calls: hasToolCalls,
+      tool_calls: toolCalls,
     };
 
     return this.executeHooks(HookEventName.PostTurn, input, undefined, signal);

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -131,7 +131,6 @@ export class HookSystem {
     thoughts: string[],
     messages: string[],
     hasToolCalls: boolean,
-    previousHookOutputs: string[],
     signal?: AbortSignal,
   ): Promise<AggregatedHookResult> {
     return this.hookEventHandler.firePostTurnEvent(
@@ -139,7 +138,6 @@ export class HookSystem {
       thoughts,
       messages,
       hasToolCalls,
-      previousHookOutputs,
       signal,
     );
   }

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -130,14 +130,14 @@ export class HookSystem {
     turnIndex: number,
     thoughts: string[],
     messages: string[],
-    hasToolCalls: boolean,
+    toolCalls: Array<{ name: string; args?: Record<string, unknown> }>,
     signal?: AbortSignal,
   ): Promise<AggregatedHookResult> {
     return this.hookEventHandler.firePostTurnEvent(
       turnIndex,
       thoughts,
       messages,
-      hasToolCalls,
+      toolCalls,
       signal,
     );
   }

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -126,6 +126,22 @@ export class HookSystem {
     );
   }
 
+  async firePostTurnEvent(
+    turnIndex: number,
+    thoughts: string[],
+    messages: string[],
+    hasToolCalls: boolean,
+    signal?: AbortSignal,
+  ): Promise<AggregatedHookResult> {
+    return this.hookEventHandler.firePostTurnEvent(
+      turnIndex,
+      thoughts,
+      messages,
+      hasToolCalls,
+      signal,
+    );
+  }
+
   async fireSessionStartEvent(
     source: SessionStartSource,
     model: string,

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -131,7 +131,7 @@ export class HookSystem {
     thoughts: string[],
     messages: string[],
     hasToolCalls: boolean,
-    previousRewrites: string[],
+    previousHookOutputs: string[],
     signal?: AbortSignal,
   ): Promise<AggregatedHookResult> {
     return this.hookEventHandler.firePostTurnEvent(
@@ -139,7 +139,7 @@ export class HookSystem {
       thoughts,
       messages,
       hasToolCalls,
-      previousRewrites,
+      previousHookOutputs,
       signal,
     );
   }

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -131,6 +131,7 @@ export class HookSystem {
     thoughts: string[],
     messages: string[],
     hasToolCalls: boolean,
+    previousRewrites: string[],
     signal?: AbortSignal,
   ): Promise<AggregatedHookResult> {
     return this.hookEventHandler.firePostTurnEvent(
@@ -138,6 +139,7 @@ export class HookSystem {
       thoughts,
       messages,
       hasToolCalls,
+      previousRewrites,
       signal,
     );
   }

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -368,7 +368,7 @@ export class StopHookOutput extends DefaultHookOutput {
 
 /**
  * Specific hook output class for PostTurn events.
- * Supports ACP message injection via acpMessage field.
+ * Supports ACP message injection via hookSpecificOutput.acpMessage.
  */
 export class PostTurnHookOutput extends DefaultHookOutput {
   constructor(data: Partial<HookOutput> = {}) {
@@ -826,8 +826,8 @@ export interface PostTurnInput extends HookInput {
   thoughts: string[];
   messages: string[];
   has_tool_calls: boolean;
-  /** Previous successful rewrite outputs (most recent last), for context coherence. */
-  previous_rewrites: string[];
+  /** Previous acpMessage outputs from earlier PostTurn hooks in this session (most recent last). */
+  previous_hook_outputs: string[];
 }
 
 /**

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -826,6 +826,8 @@ export interface PostTurnInput extends HookInput {
   thoughts: string[];
   messages: string[];
   has_tool_calls: boolean;
+  /** Previous successful rewrite outputs (most recent last), for context coherence. */
+  previous_rewrites: string[];
 }
 
 /**

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -46,6 +46,8 @@ export enum HookEventName {
   PermissionRequest = 'PermissionRequest',
   // StopFailure - When the turn ends due to an API error (instead of Stop)
   StopFailure = 'StopFailure',
+  // PostTurn - After each model turn completes (at tool_call boundary or end of response)
+  PostTurn = 'PostTurn',
 }
 
 /**
@@ -141,6 +143,8 @@ export function createHookOutput(
       return new StopHookOutput(data);
     case HookEventName.PermissionRequest:
       return new PermissionRequestHookOutput(data);
+    case HookEventName.PostTurn:
+      return new PostTurnHookOutput(data);
     default:
       return new DefaultHookOutput(data);
   }
@@ -359,6 +363,30 @@ export class StopHookOutput extends DefaultHookOutput {
       return undefined;
     }
     return `Stop hook feedback:\n${this.stopReason}`;
+  }
+}
+
+/**
+ * Specific hook output class for PostTurn events.
+ * Supports ACP message injection via acpMessage field.
+ */
+export class PostTurnHookOutput extends DefaultHookOutput {
+  constructor(data: Partial<HookOutput> = {}) {
+    super(data);
+  }
+
+  /**
+   * Get the ACP message to inject (with _meta.rewritten), if any.
+   */
+  getAcpMessage(): string | undefined {
+    const specific = this.hookSpecificOutput as
+      | { acpMessage?: string }
+      | undefined;
+    const msg = specific?.acpMessage;
+    if (!msg || typeof msg !== 'string' || msg.trim().length < 5) {
+      return undefined;
+    }
+    return msg.trim();
   }
 }
 
@@ -787,6 +815,30 @@ export interface StopFailureInput extends HookInput {
  * This type alias is used instead of an empty interface to satisfy ESLint rules
  */
 export type StopFailureOutput = HookOutput;
+
+/**
+ * PostTurn hook input
+ * Fired after each model turn completes (at tool_call boundary or end of response).
+ * Receives accumulated thoughts and messages from the turn.
+ */
+export interface PostTurnInput extends HookInput {
+  turn_index: number;
+  thoughts: string[];
+  messages: string[];
+  has_tool_calls: boolean;
+}
+
+/**
+ * PostTurn hook output
+ * Supports ACP message injection via hookSpecificOutput.acpMessage.
+ * Fire-and-forget: does not block agent execution.
+ */
+export interface PostTurnOutput extends HookOutput {
+  hookSpecificOutput?: {
+    hookEventName: 'PostTurn';
+    acpMessage?: string;
+  };
+}
 
 /**
  * Hook execution result

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -837,8 +837,6 @@ export interface PostTurnInput extends HookInput {
   thoughts: string[];
   messages: string[];
   has_tool_calls: boolean;
-  /** Previous acpMessage outputs from earlier PostTurn hooks in this session (most recent last). */
-  previous_hook_outputs: string[];
 }
 
 /**

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -832,11 +832,16 @@ export type StopFailureOutput = HookOutput;
  * Fired after each model turn completes (at tool_call boundary or end of response).
  * Receives accumulated thoughts and messages from the turn.
  */
+export interface PostTurnToolCall {
+  name: string;
+  args?: Record<string, unknown>;
+}
+
 export interface PostTurnInput extends HookInput {
   turn_index: number;
   thoughts: string[];
   messages: string[];
-  has_tool_calls: boolean;
+  tool_calls: PostTurnToolCall[];
 }
 
 /**

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -388,6 +388,17 @@ export class PostTurnHookOutput extends DefaultHookOutput {
     }
     return msg.trim();
   }
+
+  /**
+   * Get optional metadata to attach to the injected ACP message.
+   * Hook scripts define this freely; qwen-code passes it through as-is.
+   */
+  getAcpMeta(): Record<string, unknown> | undefined {
+    const specific = this.hookSpecificOutput as
+      | { acpMeta?: Record<string, unknown> }
+      | undefined;
+    return specific?.acpMeta;
+  }
 }
 
 /**
@@ -838,7 +849,10 @@ export interface PostTurnInput extends HookInput {
 export interface PostTurnOutput extends HookOutput {
   hookSpecificOutput?: {
     hookEventName: 'PostTurn';
+    /** Message text to inject into ACP stream as agent_message_chunk. */
     acpMessage?: string;
+    /** Optional metadata attached to the injected ACP message. Hook scripts define this freely. */
+    acpMeta?: Record<string, unknown>;
   };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -273,9 +273,11 @@ export * from './hooks/types.js';
 export { HookSystem, HookRegistry } from './hooks/index.js';
 export type { HookRegistryEntry } from './hooks/index.js';
 
-// Export hook triggers for notification hooks
+// Export hook triggers for notification and PostTurn hooks
 export {
   fireNotificationHook,
   firePermissionRequestHook,
+  firePostTurnHook,
   type NotificationHookResult,
+  type PostTurnHookResult,
 } from './core/toolHookTriggers.js';


### PR DESCRIPTION
## Summary

Add a new `PostTurn` hook event that fires at every model turn boundary (tool_call or end of response). Hook scripts receive the turn's accumulated thoughts, messages, and tool calls, and can optionally inject a message into the ACP stream with custom metadata.

Closes #3265

### Changes (10 files, +319 lines)

**Core hook framework** (`packages/core`):
- `types.ts`: New `PostTurn` enum, `PostTurnInput`, `PostTurnOutput`, `PostTurnHookOutput` class with `getAcpMessage()` / `getAcpMeta()`
- `hookEventHandler.ts`: `firePostTurnEvent()`
- `hookSystem.ts`: Public `firePostTurnEvent()`
- `hookAggregator.ts`: PostTurn fire-and-forget handling (preserve outputs, ignore errors, first non-empty acpMessage wins)
- `toolHookTriggers.ts`: `firePostTurnHook()` via MessageBus
- `config.ts`: PostTurn case in MessageBus hook dispatcher

**ACP integration** (`packages/cli`):
- `Session.ts`: Accumulate turn content during streaming, fire-and-forget PostTurn hook at every turn boundary, pass through `acpMessage` + `acpMeta` to ACP stream
- `settingsSchema.ts`: PostTurn in hooks schema
- `hooks/constants.ts`: PostTurn descriptions and exit codes

### Hook Protocol

**Input** (stdin JSON):
```json
{
  "turn_index": 3,
  "thoughts": ["..."],
  "messages": ["..."],
  "tool_calls": [{ "name": "read_file", "args": { "file_path": "..." } }]
}
```

**Output** (stdout JSON):
```json
{
  "decision": "allow",
  "hookSpecificOutput": {
    "hookEventName": "PostTurn",
    "acpMessage": "Message to inject into ACP stream",
    "acpMeta": { "custom": "metadata passed through as _meta" }
  }
}
```

### Configuration
```json
{
  "hooks": {
    "PostTurn": [{
      "hooks": [{
        "type": "command",
        "command": "python3 .qwen/hooks/my_script.py",
        "timeout": 30000
      }]
    }]
  }
}
```

### Design Decisions
- **Async fire-and-forget**: Does not block agent execution
- **ACP-only**: Fires in Session path, not in non-interactive CLI mode
- **Framework-agnostic metadata**: `acpMeta` defined by hook scripts, framework passes through as-is
- **Single hook limit**: Multiple PostTurn hooks → first non-empty `acpMessage` wins
- **Safe degradation**: Hook failures silently ignored, original messages unaffected
- **Backward compatible**: Old qwen-code versions ignore unknown `PostTurn` hook config with zero side effects

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint passes
- [x] Hook script unit test (stdin/stdout JSON protocol)
- [ ] End-to-end ACP eval with PostTurn hook (in progress)