### PR TITLE
fix(cli): ignore literal Tab input in BaseTextInput

### DIFF
--- a/packages/cli/src/ui/components/BaseTextInput.tsx
+++ b/packages/cli/src/ui/components/BaseTextInput.tsx
@@ -211,6 +211,12 @@ export const BaseTextInput: React.FC<BaseTextInputProps> = ({
         return;
       }
 
+      // Tab — never insert literal tab characters into the buffer;
+      // consumers that need Tab behaviour should intercept it via onKeypress.
+      if ((key.name === 'tab' || key.sequence === '\t') && !key.paste) {
+        return;
+      }
+
       // Backspace
       if (
         key.name === 'backspace' ||

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2320,7 +2320,13 @@ export function useTextBuffer({
       else if (key.name === 'delete' || (key.ctrl && key.name === 'd')) del();
       else if (key.ctrl && !key.shift && key.name === 'z') undo();
       else if (key.ctrl && key.shift && key.name === 'z') redo();
-      else if (input && !key.ctrl && !key.meta) {
+      else if (
+        input &&
+        !key.ctrl &&
+        !key.meta &&
+        key.name !== 'tab' &&
+        input !== '\t'
+      ) {
         insert(input, { paste: key.paste });
       }
     },

--- a/packages/cli/src/ui/contexts/KeypressContext.test.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.test.tsx
@@ -959,6 +959,63 @@ describe('KeypressContext - Kitty Protocol', () => {
       }
     });
 
+    it('should keep a literal tab key as a non-paste keypress', () => {
+      vi.useFakeTimers();
+      const keyHandler = vi.fn();
+
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper: ({ children }) => wrapper({ children, pasteWorkaround: true }),
+      });
+
+      act(() => {
+        result.current.subscribe(keyHandler);
+      });
+
+      try {
+        act(() => {
+          stdin.emit('data', Buffer.from('\t'));
+        });
+
+        expect(keyHandler).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'tab',
+            sequence: '\t',
+            paste: false,
+          }),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should mark single-line tabbed raw chunks as paste', async () => {
+      const keyHandler = vi.fn();
+
+      const { result } = renderHook(() => useKeypressContext(), {
+        wrapper: ({ children }) => wrapper({ children, pasteWorkaround: true }),
+      });
+
+      act(() => {
+        result.current.subscribe(keyHandler);
+      });
+
+      act(() => {
+        stdin.emit('data', Buffer.from('first\tsecond'));
+      });
+
+      await waitFor(() => {
+        expect(keyHandler).toHaveBeenCalledTimes(1);
+      });
+
+      expect(keyHandler).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: '',
+          sequence: 'first\tsecond',
+          paste: true,
+        }),
+      );
+    });
+
     it('should concatenate new data and reset timeout', () => {
       vi.useFakeTimers();
       const keyHandler = vi.fn();

--- a/packages/cli/src/ui/contexts/KeypressContext.tsx
+++ b/packages/cli/src/ui/contexts/KeypressContext.tsx
@@ -989,6 +989,14 @@ export function KeypressProvider({
       sequence,
     });
 
+    const shouldFlushRawDataAsPaste = (data: Buffer) => {
+      const hasReturn = data.includes(0x0d);
+      const hasEmbeddedTab = data.length > 1 && data.includes(0x09);
+      const isSingleReturn = data.length <= 2 && hasReturn;
+
+      return !isSingleReturn && (hasReturn || hasEmbeddedTab);
+    };
+
     const flushRawBuffer = () => {
       if (!rawDataBuffer.length) {
         return;
@@ -1045,11 +1053,7 @@ export function KeypressProvider({
         return;
       }
 
-      if (
-        (rawDataBuffer.length <= 2 && rawDataBuffer.includes(0x0d)) ||
-        !rawDataBuffer.includes(0x0d) ||
-        isPaste
-      ) {
+      if (isPaste || !shouldFlushRawDataAsPaste(rawDataBuffer)) {
         keypressStream.write(rawDataBuffer);
       } else {
         // Flush raw data buffer as a paste event


### PR DESCRIPTION
## TLDR

Fixes Tab key handling in `BaseTextInput` / `useTextBuffer` so pressing Tab as a keypress no longer inserts a literal `\t` into the input buffer.

## Screenshots / Video Demo

The before-fix behavior is shown in the video attached to the linked issue: #3268.

After fix: pressing Tab no longer changes the buffer content unless a consumer handles Tab explicitly.

No additional video is attached to this PR. The behavior was validated manually by pressing Tab in the interactive prompt and confirming that no literal tab was inserted.

## Dive Deeper

Tab is used as a control key for completion, focus switching, and other consumer-specific behavior. When no consumer intercepted Tab, the default text-buffer insertion path could treat it as normal input and insert `\t`.

This change makes both `BaseTextInput` and `useTextBuffer` ignore non-paste Tab keypresses by default. Consumers that need Tab behavior should continue to intercept it via `onKeypress`.

## Reviewer Test Plan

1. Run Qwen Code interactively.
2. Focus an input backed by `BaseTextInput`.
3. Press Tab when no completion or consumer Tab handler is active.
4. Confirm the input buffer does not receive a literal tab character.

## Testing Matrix

|          | 🍏  | 🪟 | 🐧 |
| -------- | --- | -- | -- |
| npm run  | ❓  | ✅ | ❓ |
| npx      | ❓  | ❓ | ❓ |
| Docker   | ❓  | ❓ | ❓ |
| Podman   | ❓  | -  | -  |
| Seatbelt | ❓  | -  | -  |

Windows validation:
- Built locally with `npm run build`.
- Bundled locally with `npm run bundle`.
- Manual interactive check with `node dist/cli.js`.
- Confirmed pressing Tab in the interactive prompt no longer inserts a literal tab character.
- Environment: Windows `win32 x64`, Qwen Code `0.14.4`.

## Linked issues / bugs

Fixes #3268
