### PR TITLE
feat(auth): discontinue Qwen OAuth free tier (2026-04-15 cutoff)

### DIFF
--- a/.qwen/skills/qwen-code-claw/SKILL.md
+++ b/.qwen/skills/qwen-code-claw/SKILL.md
@@ -182,7 +182,7 @@ Full reference: https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/ma
 
 ### Authentication
 
-Supports Qwen OAuth (browser-based, 100 free requests/day, ending 2026-04-15 — switch to OpenRouter, Fireworks AI, or Alibaba Cloud ModelStudio after that) and OpenAI-compatible API keys.
+Supports Alibaba Cloud Coding Plan, OpenAI-compatible API keys, and Qwen OAuth (free tier discontinued 2026-04-15).
 
 Full reference: https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/docs/users/configuration/auth.md
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@
 
 ## 🎉 News
 
-- **2026-04-13**: Qwen OAuth free tier policy update: daily quota adjusted to 100 requests/day (from 1,000). The free tier will be discontinued on 2026-04-15. Consider using [OpenRouter](https://openrouter.ai), [Fireworks AI](https://app.fireworks.ai), or [Alibaba Cloud ModelStudio](https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&url=2840914_2&modelId=qwen3.6-plus) as alternatives.
+- **2026-04-15**: Qwen OAuth free tier has been discontinued. To continue using Qwen Code, switch to [Alibaba Cloud Coding Plan](https://modelstudio.console.alibabacloud.com/?tab=coding-plan#/efm/coding-plan-index), [OpenRouter](https://openrouter.ai), [Fireworks AI](https://app.fireworks.ai), or bring your own API key. Run `qwen auth` to configure.
+
+- **2026-04-13**: Qwen OAuth free tier policy update: daily quota adjusted to 100 requests/day (from 1,000).
 
 - **2026-04-02**: Qwen3.6-Plus is now live! Sign in via Qwen OAuth to use it directly, or get an API key from [Alibaba Cloud ModelStudio](https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&url=2840914_2&modelId=qwen3.6-plus) to access it through the OpenAI-compatible API.
 
@@ -30,7 +32,7 @@
 
 Qwen Code is an open-source AI agent for the terminal, optimized for Qwen series models. It helps you understand large codebases, automate tedious work, and ship faster.
 
-- **Multi-protocol, OAuth free tier**: use OpenAI / Anthropic / Gemini-compatible APIs, or sign in with Qwen OAuth for 100 free requests/day (free tier ending 2026-04-15). After that, switch to [OpenRouter](https://openrouter.ai), [Fireworks AI](https://app.fireworks.ai), or [Alibaba Cloud ModelStudio](https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&url=2840914_2&modelId=qwen3.6-plus).
+- **Multi-protocol, flexible providers**: use OpenAI / Anthropic / Gemini-compatible APIs, [Alibaba Cloud Coding Plan](https://modelstudio.console.alibabacloud.com/?tab=coding-plan#/efm/coding-plan-index), [OpenRouter](https://openrouter.ai), [Fireworks AI](https://app.fireworks.ai), or bring your own API key.
 - **Open-source, co-evolving**: both the framework and the Qwen3-Coder model are open-source—and they ship and evolve together.
 - **Agentic workflow, feature-rich**: rich built-in tools (Skills, SubAgents) for a full agentic workflow and a Claude Code-like experience.
 - **Terminal-first, IDE-friendly**: built for developers who live in the command line, with optional integration for VS Code, Zed, and JetBrains IDEs.

--- a/docs/developers/tools/web-search.md
+++ b/docs/developers/tools/web-search.md
@@ -8,7 +8,7 @@ Use `web_search` to perform a web search and get information from the internet. 
 
 ### Supported Providers
 
-1. **DashScope** (Official, Free) - Automatically available for Qwen OAuth users (200 requests/minute, 100 requests/day; free tier ending 2026-04-15)
+1. **DashScope** (Official) - Available when explicitly configured in settings (Qwen OAuth free tier auto-injection discontinued 2026-04-15)
 2. **Tavily** - High-quality search API with built-in answer generation
 3. **Google Custom Search** - Google's Custom Search JSON API
 
@@ -132,12 +132,11 @@ web_search(query="best practices for React 19", provider="dashscope")
 
 ### DashScope (Official)
 
-- **Cost:** Free
-- **Authentication:** Automatically available when using Qwen OAuth authentication
-- **Configuration:** No API key required, automatically added to provider list for Qwen OAuth users
-- **Quota:** 200 requests/minute, 100 requests/day (free tier ending 2026-04-15)
-- **Best for:** General queries, always available as fallback for Qwen OAuth users
-- **Auto-registration:** If you're using Qwen OAuth, DashScope is automatically added to your provider list even if you don't configure it explicitly
+- **Cost:** Free (requires Qwen OAuth credentials)
+- **Authentication:** Requires Qwen OAuth credentials
+- **Configuration:** Must be explicitly configured in `settings.json` web search providers (auto-injection for Qwen OAuth users was removed when the free tier was discontinued on 2026-04-15)
+- **Quota:** 200 requests/minute, 100 requests/day
+- **Best for:** General queries when you have Qwen OAuth credentials
 
 ### Tavily
 

--- a/docs/users/configuration/auth.md
+++ b/docs/users/configuration/auth.md
@@ -2,18 +2,20 @@
 
 Qwen Code supports three authentication methods. Pick the one that matches how you want to run the CLI:
 
-- **Qwen OAuth**: sign in with your `qwen.ai` account in a browser. Free with a daily quota.
+- **Qwen OAuth**: sign in with your `qwen.ai` account in a browser. **Free tier discontinued on 2026-04-15** — switch to another method.
 - **Alibaba Cloud Coding Plan**: use an API key from Alibaba Cloud. Paid subscription with diverse model options and higher quotas.
 - **API Key**: bring your own API key. Flexible to your own needs — supports OpenAI, Anthropic, Gemini, and other compatible endpoints.
 
-## Option 1: Qwen OAuth (Free)
+## Option 1: Qwen OAuth (Discontinued)
 
-Use this if you want the simplest setup and you're using Qwen models.
+> [!warning]
+>
+> The Qwen OAuth free tier was discontinued on 2026-04-15. Existing cached tokens may continue working briefly, but new requests will be rejected. Please switch to Alibaba Cloud Coding Plan, [OpenRouter](https://openrouter.ai), [Fireworks AI](https://app.fireworks.ai), or another provider. Run `qwen auth` to configure.
 
 - **How it works**: on first start, Qwen Code opens a browser login page. After you finish, credentials are cached locally so you usually won't need to log in again.
 - **Requirements**: a `qwen.ai` account + internet access (at least for the first login).
 - **Benefits**: no API key management, automatic credential refresh.
-- **Cost & quota**: free, with a quota of **60 requests/minute** and **100 requests/day**. Note: the free tier will be discontinued on 2026-04-15. After that, consider switching to [OpenRouter](https://openrouter.ai), [Fireworks AI](https://app.fireworks.ai), or [Alibaba Cloud ModelStudio](https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&url=2840914_2&modelId=qwen3.6-plus) — run `qwen auth` to configure your new provider.
+- **Cost & quota**: the free tier has been discontinued as of 2026-04-15.
 
 Start the CLI and follow the browser flow:
 
@@ -327,8 +329,8 @@ You'll see a selector with arrow-key navigation:
 ```
 Select authentication method:
 
-> Qwen OAuth - Free · 100 requests/day · Ending 2026-04-15
   Alibaba Cloud Coding Plan - Paid · Up to 6,000 requests/5 hrs · All Alibaba Cloud Coding Plan Models
+  Qwen OAuth - Discontinued — switch to Coding Plan or API Key
 
 (Use ↑ ↓ arrows to navigate, Enter to select, Ctrl+C to exit)
 ```

--- a/docs/users/support/tos-privacy.md
+++ b/docs/users/support/tos-privacy.md
@@ -6,7 +6,7 @@ Qwen Code is an open-source AI coding assistant tool maintained by the Qwen Code
 
 Qwen Code supports three authentication methods to access AI models. Your authentication method determines which terms of service and privacy policies apply to your usage:
 
-1. **Qwen OAuth** — Log in with your qwen.ai account (free daily quota, ending 2026-04-15)
+1. **Qwen OAuth** — Log in with your qwen.ai account (free tier discontinued 2026-04-15)
 2. **Alibaba Cloud Coding Plan** — Use an API key from Alibaba Cloud
 3. **API Key** — Bring your own API key
 

--- a/packages/cli/src/acp-integration/authMethods.ts
+++ b/packages/cli/src/acp-integration/authMethods.ts
@@ -21,8 +21,7 @@ export function buildAuthMethods(): AuthMethod[] {
     {
       id: AuthType.QWEN_OAUTH,
       name: 'Qwen OAuth',
-      description:
-        'OAuth authentication for Qwen models with free daily requests (ending 2026-04-15)',
+      description: 'Qwen OAuth (free tier discontinued 2026-04-15)',
       _meta: {
         type: 'terminal',
         args: ['--auth-type=qwen-oauth'],

--- a/packages/cli/src/commands/auth/handler.ts
+++ b/packages/cli/src/commands/auth/handler.ts
@@ -368,27 +368,35 @@ export async function runInteractiveAuth() {
   const selector = new InteractiveSelector(
     [
       {
-        value: 'qwen-oauth' as const,
-        label: t('Qwen OAuth'),
-        description: t('Free · 100 requests/day · Ending 2026-04-15'),
-      },
-      {
         value: 'coding-plan' as const,
         label: t('Alibaba Cloud Coding Plan'),
         description: t(
           'Paid · Up to 6,000 requests/5 hrs · All Alibaba Cloud Coding Plan Models',
         ),
       },
+      {
+        value: 'qwen-oauth' as const,
+        label: t('Qwen OAuth'),
+        description: t('Discontinued — switch to Coding Plan or API Key'),
+      },
     ],
     t('Select authentication method:'),
   );
 
-  const choice = await selector.select();
+  let choice = await selector.select();
+
+  // If user selects discontinued Qwen OAuth, warn and re-prompt
+  while (choice === 'qwen-oauth') {
+    writeStdoutLine(
+      t(
+        '\n⚠ Qwen OAuth free tier was discontinued on 2026-04-15. Please select another option.\n',
+      ),
+    );
+    choice = await selector.select();
+  }
 
   if (choice === 'coding-plan') {
     await handleQwenAuth('coding-plan', {});
-  } else {
-    await handleQwenAuth('qwen-oauth', {});
   }
 }
 
@@ -428,9 +436,12 @@ export async function showAuthStatus(): Promise<void> {
     // Display status based on auth type
     if (selectedType === AuthType.QWEN_OAUTH) {
       writeStdoutLine(t('✓ Authentication Method: Qwen OAuth'));
-      writeStdoutLine(t('  Type: Free tier (ending 2026-04-15)'));
-      writeStdoutLine(t('  Limit: 100 requests/day'));
-      writeStdoutLine(t('  Models: Qwen latest models\n'));
+      writeStdoutLine(t('  Type: Free tier (discontinued 2026-04-15)'));
+      writeStdoutLine(t('  Limit: No longer available'));
+      writeStdoutLine(t('  Models: Qwen latest models'));
+      writeStdoutLine(
+        t('\n  ⚠ Run /auth to switch to Coding Plan or another provider.\n'),
+      );
     } else if (selectedType === AuthType.USE_OPENAI) {
       // Check for Coding Plan configuration
       const codingPlanRegion = mergedSettings.codingPlan?.region;

--- a/packages/cli/src/commands/auth/status.test.ts
+++ b/packages/cli/src/commands/auth/status.test.ts
@@ -82,10 +82,10 @@ describe('showAuthStatus', () => {
       expect.stringContaining('Qwen OAuth'),
     );
     expect(writeStdoutLine).toHaveBeenCalledWith(
-      expect.stringContaining('Free tier (ending 2026-04-15)'),
+      expect.stringContaining('Free tier (discontinued 2026-04-15)'),
     );
     expect(writeStdoutLine).toHaveBeenCalledWith(
-      expect.stringContaining('100 requests/day'),
+      expect.stringContaining('No longer available'),
     );
     expect(process.exit).toHaveBeenCalledWith(0);
   });

--- a/packages/cli/src/config/auth.test.ts
+++ b/packages/cli/src/config/auth.test.ts
@@ -107,8 +107,9 @@ describe('validateAuthMethod', () => {
     expect(result).toContain('GEMINI_API_KEY_ALTERED');
   });
 
-  it('should return null for QWEN_OAUTH', () => {
-    expect(validateAuthMethod(AuthType.QWEN_OAUTH)).toBeNull();
+  it('should return an error for QWEN_OAUTH (free tier discontinued)', () => {
+    const result = validateAuthMethod(AuthType.QWEN_OAUTH);
+    expect(result).toContain('discontinued on 2026-04-15');
   });
 
   it('should return an error message for an invalid auth method', () => {

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -189,9 +189,11 @@ export function validateAuthMethod(
   }
 
   if (authMethod === AuthType.QWEN_OAUTH) {
-    // Qwen OAuth doesn't require any environment variables for basic setup
-    // The OAuth flow will handle authentication
-    return null;
+    // Qwen OAuth free tier was discontinued on 2026-04-15.
+    // Block new OAuth setups; existing cached tokens still work until server rejects them.
+    return t(
+      'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch to Coding Plan, OpenRouter, Fireworks AI, or another provider.',
+    );
   }
 
   if (authMethod === AuthType.USE_ANTHROPIC) {

--- a/packages/cli/src/config/webSearch.ts
+++ b/packages/cli/src/config/webSearch.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { AuthType } from '@qwen-code/qwen-code-core';
 import type { WebSearchProviderConfig } from '@qwen-code/qwen-code-core';
 import type { Settings } from './settings.js';
 
@@ -40,10 +39,8 @@ export interface WebSearchConfig {
 export function buildWebSearchConfig(
   argv: WebSearchCliArgs,
   settings: Settings,
-  authType?: string,
+  _authType?: string,
 ): WebSearchConfig | undefined {
-  const isQwenOAuth = authType === AuthType.QWEN_OAUTH;
-
   // Step 1: Collect providers from settings or command line/env
   let providers: WebSearchProviderConfig[] = [];
   let userDefault: string | undefined;
@@ -77,13 +74,9 @@ export function buildWebSearchConfig(
     }
   }
 
-  // Step 2: Ensure dashscope is available for qwen-oauth users
-  if (isQwenOAuth) {
-    const hasDashscope = providers.some((p) => p.type === 'dashscope');
-    if (!hasDashscope) {
-      providers.push({ type: 'dashscope' } as WebSearchProviderConfig);
-    }
-  }
+  // Step 2: DashScope auto-injection for qwen-oauth was removed when the
+  // free tier was discontinued on 2026-04-15.  Users who explicitly configure
+  // a dashscope provider in settings.json still get it (handled in Step 1).
 
   // Step 3: If no providers available, return undefined
   if (providers.length === 0) {

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -49,6 +49,7 @@ vi.mock('./config/config.js', () => ({
     getQuestion: vi.fn(() => ''),
     isInteractive: () => false,
     getWarnings: vi.fn(() => []),
+    getModelsConfig: vi.fn(() => ({ getCurrentAuthType: () => null })),
   } as unknown as Config),
   parseArguments: vi.fn().mockResolvedValue({}),
   isDebugMode: vi.fn(() => false),
@@ -179,6 +180,7 @@ describe('gemini.tsx main function', () => {
         getProjectRoot: () => '/',
         getOutputFormat: () => OutputFormat.TEXT,
         getWarnings: () => [],
+        getModelsConfig: () => ({ getCurrentAuthType: () => null }),
         getSessionId: () => 'test-session-id',
       } as unknown as Config;
     });
@@ -347,6 +349,7 @@ describe('gemini.tsx main function', () => {
       getInputFormat: () => 'stream-json',
       getContentGeneratorConfig: () => ({ authType: 'test-auth' }),
       getWarnings: () => [],
+      getModelsConfig: () => ({ getCurrentAuthType: () => null }),
       getUsageStatisticsEnabled: () => true,
       getSessionId: () => 'test-session-id',
       getOutputFormat: () => OutputFormat.TEXT,
@@ -448,6 +451,7 @@ describe('gemini.tsx main function kitty protocol', () => {
       getScreenReader: () => false,
       getGeminiMdFileCount: () => 0,
       getWarnings: () => [],
+      getModelsConfig: () => ({ getCurrentAuthType: () => null }),
       getUsageStatisticsEnabled: () => true,
       getSessionId: () => 'test-session-id',
     } as unknown as Config);

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -5,6 +5,7 @@
  */
 
 import {
+  AuthType,
   InputFormat,
   isDebugLoggingDegraded,
   logUserPrompt,
@@ -436,6 +437,12 @@ export async function main() {
         })),
         ...getSettingsWarnings(settings),
         ...config.getWarnings(),
+        ...(config.getModelsConfig().getCurrentAuthType() ===
+        AuthType.QWEN_OAUTH
+          ? [
+              'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch to Coding Plan or another provider.',
+            ]
+          : []),
       ]),
     ];
 

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -1245,10 +1245,14 @@ export default {
   'Terms of Services and Privacy Notice':
     'Nutzungsbedingungen und Datenschutzhinweis',
   'Qwen OAuth': 'Qwen OAuth',
-  'Free \u00B7 100 requests/day \u00B7 Ending 2026-04-15':
-    'Kostenlos \u00B7 100 Anfragen/Tag \u00B7 Endet am 2026-04-15',
-  'Login with QwenChat account to use daily free quota.':
-    'Melden Sie sich mit Ihrem QwenChat-Konto an, um das tägliche kostenlose Kontingent zu nutzen.',
+  'Discontinued — switch to Coding Plan or API Key':
+    'Eingestellt — wechseln Sie zu Coding Plan oder API Key',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch provider.':
+    'Das kostenlose Qwen OAuth-Kontingent wurde am 2026-04-15 eingestellt. Führen Sie /auth aus, um den Anbieter zu wechseln.',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Please select Coding Plan or API Key instead.':
+    'Das kostenlose Qwen OAuth-Kontingent wurde am 2026-04-15 eingestellt. Bitte wählen Sie Coding Plan oder API Key.',
+  '\n⚠ Qwen OAuth free tier was discontinued on 2026-04-15. Please select another option.\n':
+    '\n⚠ Das kostenlose Qwen OAuth-Kontingent wurde am 2026-04-15 eingestellt. Bitte wählen Sie eine andere Option.\n',
   'Paid \u00B7 Up to 6,000 requests/5 hrs \u00B7 All Alibaba Cloud Coding Plan Models':
     'Kostenpflichtig \u00B7 Bis zu 6.000 Anfragen/5 Std. \u00B7 Alle Alibaba Cloud Coding Plan Modelle',
   'Alibaba Cloud Coding Plan': 'Alibaba Cloud Coding Plan',
@@ -1948,8 +1952,8 @@ export default {
     '⚠️  Keine Authentifizierungsmethode konfiguriert.\n',
   'Run one of the following commands to get started:\n':
     'Führen Sie einen der folgenden Befehle aus, um zu beginnen:\n',
-  '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (free tier)':
-    '  qwen auth qwen-oauth     - Mit Qwen OAuth authentifizieren (kostenlos)',
+  '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (discontinued)':
+    '  qwen auth qwen-oauth     - Mit Qwen OAuth authentifizieren (eingestellt)',
   '  qwen auth coding-plan      - Authenticate with Alibaba Cloud Coding Plan\n':
     '  qwen auth coding-plan      - Mit Alibaba Cloud Coding Plan authentifizieren\n',
   'Or simply run:': 'Oder einfach ausführen:',
@@ -1957,9 +1961,11 @@ export default {
     '  qwen auth                - Interaktive Authentifizierungseinrichtung\n',
   '✓ Authentication Method: Qwen OAuth':
     '✓ Authentifizierungsmethode: Qwen OAuth',
-  '  Type: Free tier (ending 2026-04-15)':
-    '  Typ: Kostenlos (endet am 2026-04-15)',
-  '  Limit: 100 requests/day': '  Limit: 100 Anfragen/Tag',
+  '  Type: Free tier (discontinued 2026-04-15)':
+    '  Typ: Kostenloses Kontingent (eingestellt 2026-04-15)',
+  '  Limit: No longer available': '  Limit: Nicht mehr verfügbar',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch to Coding Plan, OpenRouter, Fireworks AI, or another provider.':
+    'Das kostenlose Qwen OAuth-Kontingent wurde am 2026-04-15 eingestellt. Führen Sie /auth aus, um zu Coding Plan, OpenRouter, Fireworks AI oder einem anderen Anbieter zu wechseln.',
   '  Models: Qwen latest models\n': '  Modelle: Qwen neueste Modelle\n',
   '✓ Authentication Method: Alibaba Cloud Coding Plan':
     '✓ Authentifizierungsmethode: Alibaba Cloud Coding Plan',

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1298,10 +1298,14 @@ export default {
   'Terms of Services and Privacy Notice':
     'Terms of Services and Privacy Notice',
   'Qwen OAuth': 'Qwen OAuth',
-  'Free \u00B7 100 requests/day \u00B7 Ending 2026-04-15':
-    'Free \u00B7 100 requests/day \u00B7 Ending 2026-04-15',
-  'Login with QwenChat account to use daily free quota.':
-    'Login with QwenChat account to use daily free quota.',
+  'Discontinued — switch to Coding Plan or API Key':
+    'Discontinued — switch to Coding Plan or API Key',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch provider.':
+    'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch provider.',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Please select Coding Plan or API Key instead.':
+    'Qwen OAuth free tier was discontinued on 2026-04-15. Please select Coding Plan or API Key instead.',
+  '\n⚠ Qwen OAuth free tier was discontinued on 2026-04-15. Please select another option.\n':
+    '\n⚠ Qwen OAuth free tier was discontinued on 2026-04-15. Please select another option.\n',
   'Paid \u00B7 Up to 6,000 requests/5 hrs \u00B7 All Alibaba Cloud Coding Plan Models':
     'Paid \u00B7 Up to 6,000 requests/5 hrs \u00B7 All Alibaba Cloud Coding Plan Models',
   'Alibaba Cloud Coding Plan': 'Alibaba Cloud Coding Plan',
@@ -1989,17 +1993,19 @@ export default {
     '⚠️  No authentication method configured.\n',
   'Run one of the following commands to get started:\n':
     'Run one of the following commands to get started:\n',
-  '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (free tier)':
-    '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (free tier)',
+  '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (discontinued)':
+    '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (discontinued)',
   '  qwen auth coding-plan      - Authenticate with Alibaba Cloud Coding Plan\n':
     '  qwen auth coding-plan      - Authenticate with Alibaba Cloud Coding Plan\n',
   'Or simply run:': 'Or simply run:',
   '  qwen auth                - Interactive authentication setup\n':
     '  qwen auth                - Interactive authentication setup\n',
   '✓ Authentication Method: Qwen OAuth': '✓ Authentication Method: Qwen OAuth',
-  '  Type: Free tier (ending 2026-04-15)':
-    '  Type: Free tier (ending 2026-04-15)',
-  '  Limit: 100 requests/day': '  Limit: 100 requests/day',
+  '  Type: Free tier (discontinued 2026-04-15)':
+    '  Type: Free tier (discontinued 2026-04-15)',
+  '  Limit: No longer available': '  Limit: No longer available',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch to Coding Plan, OpenRouter, Fireworks AI, or another provider.':
+    'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch to Coding Plan, OpenRouter, Fireworks AI, or another provider.',
   '  Models: Qwen latest models\n': '  Models: Qwen latest models\n',
   '✓ Authentication Method: Alibaba Cloud Coding Plan':
     '✓ Authentication Method: Alibaba Cloud Coding Plan',

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -1329,10 +1329,14 @@ export default {
   'Terms of Services and Privacy Notice':
     "Conditions d'utilisation et avis de confidentialité",
   'Qwen OAuth': 'Qwen OAuth',
-  'Free \u00B7 100 requests/day \u00B7 Ending 2026-04-15':
-    'Gratuit \u00B7 100 requêtes/jour \u00B7 Fin le 2026-04-15',
-  'Login with QwenChat account to use daily free quota.':
-    'Connectez-vous avec un compte QwenChat pour utiliser le quota gratuit quotidien.',
+  'Discontinued — switch to Coding Plan or API Key':
+    'Abandonné — passez à Coding Plan ou API Key',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch provider.':
+    'Le niveau gratuit Qwen OAuth a été abandonné le 2026-04-15. Exécutez /auth pour changer de fournisseur.',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Please select Coding Plan or API Key instead.':
+    'Le niveau gratuit Qwen OAuth a été abandonné le 2026-04-15. Veuillez sélectionner Coding Plan ou API Key.',
+  '\n⚠ Qwen OAuth free tier was discontinued on 2026-04-15. Please select another option.\n':
+    '\n⚠ Le niveau gratuit Qwen OAuth a été abandonné le 2026-04-15. Veuillez sélectionner une autre option.\n',
   'Paid \u00B7 Up to 6,000 requests/5 hrs \u00B7 All Alibaba Cloud Coding Plan Models':
     "Payant · Jusqu'à 6 000 requêtes/5h · Tous les modèles Alibaba Cloud Coding Plan",
   'Alibaba Cloud Coding Plan': 'Plan de codage Alibaba Cloud',
@@ -2029,8 +2033,8 @@ export default {
     "⚠️  Aucune méthode d'authentification configurée.\n",
   'Run one of the following commands to get started:\n':
     "Exécutez l'une des commandes suivantes pour commencer :\n",
-  '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (free tier)':
-    '  qwen auth qwen-oauth     - Authentifier avec Qwen OAuth (niveau gratuit)',
+  '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (discontinued)':
+    '  qwen auth qwen-oauth     - Authentification avec Qwen OAuth (abandonné)',
   '  qwen auth coding-plan      - Authenticate with Alibaba Cloud Coding Plan\n':
     '  qwen auth coding-plan      - Authentifier avec Alibaba Cloud Coding Plan\n',
   'Or simply run:': 'Ou simplement exécutez :',
@@ -2038,9 +2042,11 @@ export default {
     "  qwen auth                - Configuration d'authentification interactive\n",
   '✓ Authentication Method: Qwen OAuth':
     "✓ Méthode d'authentification : Qwen OAuth",
-  '  Type: Free tier (ending 2026-04-15)':
-    '  Type : Niveau gratuit (fin le 2026-04-15)',
-  '  Limit: 100 requests/day': '  Limite : 100 requêtes/jour',
+  '  Type: Free tier (discontinued 2026-04-15)':
+    '  Type : Niveau gratuit (abandonné 2026-04-15)',
+  '  Limit: No longer available': '  Limite : Plus disponible',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch to Coding Plan, OpenRouter, Fireworks AI, or another provider.':
+    'Le niveau gratuit Qwen OAuth a été abandonné le 2026-04-15. Exécutez /auth pour passer à Coding Plan, OpenRouter, Fireworks AI ou un autre fournisseur.',
   '  Models: Qwen latest models\n': '  Modèles : Derniers modèles Qwen\n',
   '✓ Authentication Method: Alibaba Cloud Coding Plan':
     "✓ Méthode d'authentification : Alibaba Cloud Coding Plan",

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -966,10 +966,14 @@ export default {
     '続行するには認証方法を選択してください。Ctrl+C をもう一度押すと終了します',
   'Terms of Services and Privacy Notice': '利用規約とプライバシー通知',
   'Qwen OAuth': 'Qwen OAuth',
-  'Free \u00B7 100 requests/day \u00B7 Ending 2026-04-15':
-    '無料 \u00B7 1日100リクエスト \u00B7 2026-04-15に終了',
-  'Login with QwenChat account to use daily free quota.':
-    'QwenChatアカウントでログインして、毎日の無料クォータをご利用ください。',
+  'Discontinued — switch to Coding Plan or API Key':
+    '終了 — Coding Plan または API Key に切り替えてください',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch provider.':
+    'Qwen OAuth 無料枠は 2026-04-15 に終了しました。/auth を実行してプロバイダーを切り替えてください。',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Please select Coding Plan or API Key instead.':
+    'Qwen OAuth 無料枠は 2026-04-15 に終了しました。Coding Plan または API Key を選択してください。',
+  '\n⚠ Qwen OAuth free tier was discontinued on 2026-04-15. Please select another option.\n':
+    '\n⚠ Qwen OAuth 無料枠は 2026-04-15 に終了しました。他のオプションを選択してください。\n',
   'Paid \u00B7 Up to 6,000 requests/5 hrs \u00B7 All Alibaba Cloud Coding Plan Models':
     '有料 \u00B7 5時間最大6,000リクエスト \u00B7 すべての Alibaba Cloud Coding Plan モデル',
   'Alibaba Cloud Coding Plan': 'Alibaba Cloud Coding Plan',
@@ -1440,17 +1444,19 @@ export default {
     '⚠️  認証方法が設定されていません。\n',
   'Run one of the following commands to get started:\n':
     '以下のコマンドのいずれかを実行して開始してください:\n',
-  '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (free tier)':
-    '  qwen auth qwen-oauth     - Qwen OAuth で認証（無料）',
+  '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (discontinued)':
+    '  qwen auth qwen-oauth     - Qwen OAuth で認証（終了）',
   '  qwen auth coding-plan      - Authenticate with Alibaba Cloud Coding Plan\n':
     '  qwen auth coding-plan      - Alibaba Cloud Coding Plan で認証\n',
   'Or simply run:': 'または以下を実行:',
   '  qwen auth                - Interactive authentication setup\n':
     '  qwen auth                - インタラクティブ認証セットアップ\n',
   '✓ Authentication Method: Qwen OAuth': '✓ 認証方法: Qwen OAuth',
-  '  Type: Free tier (ending 2026-04-15)':
-    '  タイプ: 無料プラン（2026-04-15に終了）',
-  '  Limit: 100 requests/day': '  制限: 1日100リクエスト',
+  '  Type: Free tier (discontinued 2026-04-15)':
+    '  タイプ: 無料枠（2026-04-15 終了）',
+  '  Limit: No longer available': '  制限: 利用不可',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch to Coding Plan, OpenRouter, Fireworks AI, or another provider.':
+    'Qwen OAuth 無料枠は 2026-04-15 に終了しました。/auth を実行して Coding Plan、OpenRouter、Fireworks AI、または他のプロバイダーに切り替えてください。',
   '  Models: Qwen latest models\n': '  モデル: Qwen 最新モデル\n',
   '✓ Authentication Method: Alibaba Cloud Coding Plan':
     '✓ 認証方法: Alibaba Cloud Coding Plan',

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -1251,10 +1251,14 @@ export default {
   'Terms of Services and Privacy Notice':
     'Termos de Serviço e Aviso de Privacidade',
   'Qwen OAuth': 'Qwen OAuth',
-  'Free \u00B7 100 requests/day \u00B7 Ending 2026-04-15':
-    'Gratuito \u00B7 100 solicitações/dia \u00B7 Encerra em 2026-04-15',
-  'Login with QwenChat account to use daily free quota.':
-    'Faça login com sua conta QwenChat para usar a cota gratuita diária.',
+  'Discontinued — switch to Coding Plan or API Key':
+    'Descontinuado — mude para Coding Plan ou API Key',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch provider.':
+    'O nível gratuito do Qwen OAuth foi descontinuado em 2026-04-15. Execute /auth para trocar de provedor.',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Please select Coding Plan or API Key instead.':
+    'O nível gratuito do Qwen OAuth foi descontinuado em 2026-04-15. Selecione Coding Plan ou API Key.',
+  '\n⚠ Qwen OAuth free tier was discontinued on 2026-04-15. Please select another option.\n':
+    '\n⚠ O nível gratuito do Qwen OAuth foi descontinuado em 2026-04-15. Selecione outra opção.\n',
   'Paid \u00B7 Up to 6,000 requests/5 hrs \u00B7 All Alibaba Cloud Coding Plan Models':
     'Pago \u00B7 Até 6.000 solicitações/5 hrs \u00B7 Todos os modelos Alibaba Cloud Coding Plan',
   'Alibaba Cloud Coding Plan': 'Alibaba Cloud Coding Plan',
@@ -1939,17 +1943,19 @@ export default {
     '⚠️  Nenhum método de autenticação configurado.\n',
   'Run one of the following commands to get started:\n':
     'Execute um dos seguintes comandos para começar:\n',
-  '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (free tier)':
-    '  qwen auth qwen-oauth     - Autenticar com Qwen OAuth (gratuito)',
+  '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (discontinued)':
+    '  qwen auth qwen-oauth     - Autenticar com Qwen OAuth (descontinuado)',
   '  qwen auth coding-plan      - Authenticate with Alibaba Cloud Coding Plan\n':
     '  qwen auth coding-plan      - Autenticar com Alibaba Cloud Coding Plan\n',
   'Or simply run:': 'Ou simplesmente execute:',
   '  qwen auth                - Interactive authentication setup\n':
     '  qwen auth                - Configuração interativa de autenticação\n',
   '✓ Authentication Method: Qwen OAuth': '✓ Método de autenticação: Qwen OAuth',
-  '  Type: Free tier (ending 2026-04-15)':
-    '  Tipo: Gratuito (encerra em 2026-04-15)',
-  '  Limit: 100 requests/day': '  Limite: 100 solicitações/dia',
+  '  Type: Free tier (discontinued 2026-04-15)':
+    '  Tipo: Nível gratuito (descontinuado 2026-04-15)',
+  '  Limit: No longer available': '  Limite: Não mais disponível',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch to Coding Plan, OpenRouter, Fireworks AI, or another provider.':
+    'O nível gratuito do Qwen OAuth foi descontinuado em 2026-04-15. Execute /auth para mudar para Coding Plan, OpenRouter, Fireworks AI ou outro provedor.',
   '  Models: Qwen latest models\n': '  Modelos: Modelos Qwen mais recentes\n',
   '✓ Authentication Method: Alibaba Cloud Coding Plan':
     '✓ Método de autenticação: Alibaba Cloud Coding Plan',

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -1175,10 +1175,14 @@ export default {
   'Terms of Services and Privacy Notice':
     'Условия обслуживания и уведомление о конфиденциальности',
   'Qwen OAuth': 'Qwen OAuth',
-  'Free \u00B7 100 requests/day \u00B7 Ending 2026-04-15':
-    'Бесплатно \u00B7 100 запросов/день \u00B7 Завершение 2026-04-15',
-  'Login with QwenChat account to use daily free quota.':
-    'Войдите с помощью аккаунта QwenChat, чтобы использовать ежедневную бесплатную квоту.',
+  'Discontinued — switch to Coding Plan or API Key':
+    'Прекращено — переключитесь на Coding Plan или API Key',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch provider.':
+    'Бесплатный уровень Qwen OAuth прекращён 2026-04-15. Выполните /auth для смены провайдера.',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Please select Coding Plan or API Key instead.':
+    'Бесплатный уровень Qwen OAuth прекращён 2026-04-15. Выберите Coding Plan или API Key.',
+  '\n⚠ Qwen OAuth free tier was discontinued on 2026-04-15. Please select another option.\n':
+    '\n⚠ Бесплатный уровень Qwen OAuth прекращён 2026-04-15. Выберите другую опцию.\n',
   'Paid \u00B7 Up to 6,000 requests/5 hrs \u00B7 All Alibaba Cloud Coding Plan Models':
     'Платно \u00B7 До 6 000 запросов/5 часов \u00B7 Все модели Alibaba Cloud Coding Plan',
   'Alibaba Cloud Coding Plan': 'Alibaba Cloud Coding Plan',
@@ -1946,17 +1950,19 @@ export default {
     '⚠️  Метод аутентификации не настроен.\n',
   'Run one of the following commands to get started:\n':
     'Выполните одну из следующих команд для начала:\n',
-  '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (free tier)':
-    '  qwen auth qwen-oauth     - Аутентификация через Qwen OAuth (бесплатно)',
+  '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (discontinued)':
+    '  qwen auth qwen-oauth     - Аутентификация через Qwen OAuth (прекращено)',
   '  qwen auth coding-plan      - Authenticate with Alibaba Cloud Coding Plan\n':
     '  qwen auth coding-plan      - Аутентификация через Alibaba Cloud Coding Plan\n',
   'Or simply run:': 'Или просто выполните:',
   '  qwen auth                - Interactive authentication setup\n':
     '  qwen auth                - Интерактивная настройка аутентификации\n',
   '✓ Authentication Method: Qwen OAuth': '✓ Метод аутентификации: Qwen OAuth',
-  '  Type: Free tier (ending 2026-04-15)':
-    '  Тип: Бесплатный (завершение 2026-04-15)',
-  '  Limit: 100 requests/day': '  Лимит: 100 запросов/день',
+  '  Type: Free tier (discontinued 2026-04-15)':
+    '  Тип: Бесплатный уровень (прекращено 2026-04-15)',
+  '  Limit: No longer available': '  Лимит: Больше не доступен',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch to Coding Plan, OpenRouter, Fireworks AI, or another provider.':
+    'Бесплатный уровень Qwen OAuth прекращён 2026-04-15. Выполните /auth для переключения на Coding Plan, OpenRouter, Fireworks AI или другого провайдера.',
   '  Models: Qwen latest models\n': '  Модели: Последние модели Qwen\n',
   '✓ Authentication Method: Alibaba Cloud Coding Plan':
     '✓ Метод аутентификации: Alibaba Cloud Coding Plan',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1227,10 +1227,14 @@ export default {
     '您必须选择认证方法才能继续。再次按 Ctrl+C 退出',
   'Terms of Services and Privacy Notice': '服务条款和隐私声明',
   'Qwen OAuth': 'Qwen OAuth (免费)',
-  'Free \u00B7 100 requests/day \u00B7 Ending 2026-04-15':
-    '免费 \u00B7 每天 100 次请求 \u00B7 将于 2026-04-15 停止',
-  'Login with QwenChat account to use daily free quota.':
-    '使用 QwenChat 账号登录，享受每日免费额度。',
+  'Discontinued — switch to Coding Plan or API Key':
+    '已停用 — 请切换到 Coding Plan 或 API Key',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch provider.':
+    'Qwen OAuth 免费额度已于 2026-04-15 停用。请运行 /auth 切换服务商。',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Please select Coding Plan or API Key instead.':
+    'Qwen OAuth 免费额度已于 2026-04-15 停用。请选择 Coding Plan 或 API Key。',
+  '\n⚠ Qwen OAuth free tier was discontinued on 2026-04-15. Please select another option.\n':
+    '\n⚠ Qwen OAuth 免费额度已于 2026-04-15 停用。请选择其他选项。\n',
   'Paid \u00B7 Up to 6,000 requests/5 hrs \u00B7 All Alibaba Cloud Coding Plan Models':
     '付费 \u00B7 每 5 小时最多 6,000 次请求 \u00B7 支持阿里云百炼 Coding Plan 全部模型',
   'Alibaba Cloud Coding Plan': '阿里云百炼 Coding Plan',
@@ -1795,17 +1799,19 @@ export default {
   '⚠️  No authentication method configured.\n': '⚠️  未配置认证方式。\n',
   'Run one of the following commands to get started:\n':
     '运行以下命令之一开始配置：\n',
-  '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (free tier)':
-    '  qwen auth qwen-oauth     - 使用 Qwen OAuth 认证（免费）',
+  '  qwen auth qwen-oauth     - Authenticate with Qwen OAuth (discontinued)':
+    '  qwen auth qwen-oauth     - 使用 Qwen OAuth 登录（已停用）',
   '  qwen auth coding-plan      - Authenticate with Alibaba Cloud Coding Plan\n':
     '  qwen auth coding-plan      - 使用阿里云百炼 Coding Plan 认证\n',
   'Or simply run:': '或者直接运行：',
   '  qwen auth                - Interactive authentication setup\n':
     '  qwen auth                - 交互式认证配置\n',
   '✓ Authentication Method: Qwen OAuth': '✓ 认证方式：Qwen OAuth',
-  '  Type: Free tier (ending 2026-04-15)':
-    '  类型：免费版（将于 2026-04-15 停止）',
-  '  Limit: 100 requests/day': '  限额：每天 100 次请求',
+  '  Type: Free tier (discontinued 2026-04-15)':
+    '  类型：免费额度（2026-04-15 已停用）',
+  '  Limit: No longer available': '  限额：已不可用',
+  'Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch to Coding Plan, OpenRouter, Fireworks AI, or another provider.':
+    'Qwen OAuth 免费额度已于 2026-04-15 停用。请运行 /auth 切换到 Coding Plan、OpenRouter、Fireworks AI 或其他服务商。',
   '  Models: Qwen latest models\n': '  模型：Qwen 最新模型\n',
   '✓ Authentication Method: Alibaba Cloud Coding Plan':
     '✓ 认证方式：阿里云百炼 Coding Plan',

--- a/packages/cli/src/ui/auth/AuthDialog.test.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.test.tsx
@@ -348,8 +348,8 @@ describe('AuthDialog', () => {
 
       const { lastFrame } = renderAuthDialog(settings);
 
-      // Default is Qwen OAuth (first option)
-      expect(lastFrame()).toContain('Qwen OAuth');
+      // Default is Coding Plan (first option); Qwen OAuth is last (discontinued)
+      expect(lastFrame()).toContain('Alibaba Cloud Coding Plan');
     });
 
     it('should show an error and fall back to default if QWEN_DEFAULT_AUTH_TYPE is invalid', () => {

--- a/packages/cli/src/ui/auth/AuthDialog.tsx
+++ b/packages/cli/src/ui/auth/AuthDialog.tsx
@@ -103,13 +103,6 @@ export function AuthDialog(): React.JSX.Element {
   // Main authentication entries (flat three-option layout)
   const mainItems = [
     {
-      key: AuthType.QWEN_OAUTH,
-      title: t('Qwen OAuth'),
-      label: t('Qwen OAuth'),
-      description: t('Free \u00B7 100 requests/day \u00B7 Ending 2026-04-15'),
-      value: AuthType.QWEN_OAUTH as MainOption,
-    },
-    {
       key: 'CODING_PLAN',
       title: t('Alibaba Cloud Coding Plan'),
       label: t('Alibaba Cloud Coding Plan'),
@@ -124,6 +117,13 @@ export function AuthDialog(): React.JSX.Element {
       label: t('API Key'),
       description: t('Bring your own API key'),
       value: 'API_KEY' as MainOption,
+    },
+    {
+      key: AuthType.QWEN_OAUTH,
+      title: t('Qwen OAuth'),
+      label: t('Qwen OAuth'),
+      description: t('Discontinued — switch to Coding Plan or API Key'),
+      value: AuthType.QWEN_OAUTH as MainOption,
     },
   ];
 
@@ -289,7 +289,16 @@ export function AuthDialog(): React.JSX.Element {
       return;
     }
 
-    // For Qwen OAuth, proceed directly
+    // Qwen OAuth free tier discontinued — show warning instead of proceeding
+    if (value === AuthType.QWEN_OAUTH) {
+      setErrorMessage(
+        t(
+          'Qwen OAuth free tier was discontinued on 2026-04-15. Please select Coding Plan or API Key instead.',
+        ),
+      );
+      return;
+    }
+
     await onAuthSelect(value);
   };
 

--- a/packages/cli/src/validateNonInterActiveAuth.test.ts
+++ b/packages/cli/src/validateNonInterActiveAuth.test.ts
@@ -181,7 +181,7 @@ describe('validateNonInterActiveAuth', () => {
     expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.USE_OPENAI);
   });
 
-  it('uses configured QWEN_OAUTH if provided', async () => {
+  it('exits with error for QWEN_OAUTH (free tier discontinued)', async () => {
     const nonInteractiveConfig = createMockConfig({
       refreshAuth: refreshAuthMock,
       getModelsConfig: vi.fn().mockReturnValue({
@@ -190,12 +190,12 @@ describe('validateNonInterActiveAuth', () => {
         getGenerationConfig: vi.fn().mockReturnValue({}),
       }),
     });
-    await validateNonInteractiveAuth(
-      undefined,
-      nonInteractiveConfig,
-      mockSettings,
+    await expect(
+      validateNonInteractiveAuth(undefined, nonInteractiveConfig, mockSettings),
+    ).rejects.toThrow('process.exit(1)');
+    expect(mockWriteStderrLine).toHaveBeenCalledWith(
+      expect.stringContaining('discontinued'),
     );
-    expect(refreshAuthMock).toHaveBeenCalledWith(AuthType.QWEN_OAUTH);
   });
 
   it('exits if validateAuthMethod returns error', async () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2298,8 +2298,6 @@ export class Config {
     !this.sdkMode && (await registerCoreTool(ExitPlanModeTool, this));
     await registerCoreTool(WebFetchTool, this);
     // Conditionally register web search tool if web search provider is configured
-    // buildWebSearchConfig ensures qwen-oauth users get dashscope provider, so
-    // if tool is registered, config must exist
     if (this.getWebSearchConfig()) {
       await registerCoreTool(WebSearchTool, this);
     }

--- a/packages/core/src/utils/errorParsing.ts
+++ b/packages/core/src/utils/errorParsing.ts
@@ -32,7 +32,10 @@ export function parseAndFormatApiError(
 ): string {
   if (isStructuredError(error)) {
     // Qwen OAuth quota errors have their own user-friendly message; don't wrap them
-    if (error.message.startsWith('Qwen OAuth quota exceeded:')) {
+    if (
+      error.message.startsWith('Qwen OAuth quota exceeded:') ||
+      error.message.startsWith('Qwen OAuth free tier has been discontinued')
+    ) {
       return error.message;
     }
 

--- a/packages/core/src/utils/retry.test.ts
+++ b/packages/core/src/utils/retry.test.ts
@@ -328,7 +328,7 @@ describe('retryWithBackoff', () => {
       });
 
       await expect(promise).rejects.toThrow(
-        /Qwen OAuth free tier quota exceeded/,
+        /Qwen OAuth free tier has been discontinued/,
       );
 
       // Should be called only once (no retries)
@@ -351,7 +351,7 @@ describe('retryWithBackoff', () => {
       });
 
       await expect(promise).rejects.toThrow(
-        /Qwen OAuth free tier quota exceeded/,
+        /Qwen OAuth free tier has been discontinued/,
       );
 
       // Should be called only once (no retries)
@@ -427,7 +427,7 @@ describe('retryWithBackoff', () => {
       });
 
       await expect(promise).rejects.toThrow(
-        /Qwen OAuth free tier quota exceeded/,
+        /Qwen OAuth free tier has been discontinued/,
       );
 
       // Should be called only once (no retries)

--- a/packages/core/src/utils/retry.ts
+++ b/packages/core/src/utils/retry.ts
@@ -111,7 +111,7 @@ export async function retryWithBackoff<T>(
       // Check for Qwen OAuth quota exceeded error - throw immediately without retry
       if (authType === AuthType.QWEN_OAUTH && isQwenQuotaExceededError(error)) {
         throw new Error(
-          `Qwen OAuth free tier quota exceeded. Note: Qwen OAuth free tier will be discontinued on 2026-04-15.\n\n` +
+          `Qwen OAuth free tier has been discontinued as of 2026-04-15.\n\n` +
             `To continue using Qwen Code, try one of these alternatives:\n` +
             `  - OpenRouter:    https://openrouter.ai/docs/quickstart\n` +
             `  - Fireworks AI:  https://docs.fireworks.ai/api-reference/introduction\n` +


### PR DESCRIPTION
## TLDR

The Qwen OAuth free tier reached its end-of-life on 2026-04-15. This PR updates all client-side messaging from future tense ("ending") to past tense ("discontinued"), blocks new OAuth signups, adds a persistent startup warning for existing OAuth users, and removes DashScope web search auto-injection.

Follows up on #3217 which reduced the quota from 1,000 to 100 requests/day.

## Screenshots / Video Demo

N/A — messaging and validation changes only. No new UI components. Key user-visible changes:

- **Auth dialog**: OAuth moved to bottom of list with "Discontinued" label. Selecting it shows an inline warning instead of proceeding.
- **Startup**: OAuth users see a persistent warning: "Qwen OAuth free tier was discontinued on 2026-04-15. Run /auth to switch..."
- **Quota error**: Message now reads "has been discontinued" instead of "will be discontinued"
- **Auth status**: Shows "No longer available" instead of "100 requests/day"

## Dive Deeper

**Design decisions (documented in knowledge/qwen-code/design/qwen-oauth-free-tier-cutoff.md):**

1. **Soft cutoff** — existing cached tokens continue working until the server rejects them. Server is the source of truth.
2. **Persistent startup warning** — shown on every launch for OAuth users (no state tracking). Goes away when user switches auth method.
3. **OAuth stays in auth menu** — moved to bottom with "Discontinued" label. Selecting it shows a warning and stays on the selector screen.
4. **OAuth infrastructure preserved** — the OAuth flow will be reused for paid tiers. Only messaging changed.
5. **Model dialog unchanged** — `[qwen-oauth] coder-model` stays as-is. Server rejection handles it via the existing error path.

**Changes by area (25 files, +195 −127):**

| Area | Files | What changed |
|---|---|---|
| Core error handling | `retry.ts`, `errorParsing.ts` | Past-tense error message |
| Auth validation | `auth.ts` | Block new OAuth signups |
| Auth UI | `handler.ts`, `AuthDialog.tsx`, `authMethods.ts` | Reorder, warn on select |
| Startup warning | `gemini.tsx` | Persistent warning for OAuth users |
| Web search | `webSearch.ts`, `config.ts` | Remove DashScope auto-injection |
| i18n | 7 locale files (en/zh/fr/de/ja/ru/pt) | Updated + new string keys |
| Docs | `README.md`, `auth.md`, `tos-privacy.md`, `web-search.md`, `SKILL.md` | Past-tense, discontinuation notices |
| Tests | `retry.test.ts`, `status.test.ts`, `auth.test.ts`, `AuthDialog.test.tsx` | Updated expected strings |

## Reviewer Test Plan

1. Run `qwen auth` — verify OAuth is last in the list with "Discontinued" label
2. Select OAuth in the auth dialog — verify inline warning appears and it doesn't proceed
3. Set `selectedType: "qwen-oauth"` in settings, launch `qwen` — verify startup warning in the notification box
4. Run `qwen auth status` with OAuth configured — verify "discontinued" and "No longer available" text
5. Run unit tests: `cd packages/core && npx vitest run src/utils/retry.test.ts` and `cd packages/cli && npx vitest run src/commands/auth/status.test.ts src/config/auth.test.ts src/ui/auth/AuthDialog.test.tsx`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Follow-up to #3217 (quota downgrade from 1,000 to 100 and end-date messaging)