### PR TITLE
fix(channels/dingtalk): prioritize senderStaffId over senderId for allowedUsers matching

### DIFF
--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -534,7 +534,7 @@ export class DingtalkChannel extends ChannelBase {
 
       const envelope: Envelope = {
         channelName: this.name,
-        senderId: data.senderId || data.senderStaffId || '',
+        senderId: data.senderStaffId || data.senderId || '',
         senderName: data.senderNick || 'Unknown',
         chatId,
         text: cleanText || content.text,


### PR DESCRIPTION
## TLDR

Swaps the priority of DingTalk user identifiers when constructing the `Envelope` — `senderStaffId` is now preferred over `senderId`. This fixes `allowedUsers` not being able to match DingTalk users because the opaque internal `senderId` was used instead of the human-readable staff ID.

## Screenshots / Video Demo

N/A — no user-facing UI change. This is an internal ID resolution fix in the DingTalk channel adapter.

## Dive Deeper

DingTalk message callbacks include two user identifiers:

| Field | Description | Example |
|---|---|---|
| `senderId` | Internal DingTalk platform ID | `$:LWCP_v1:$xxxxxxxxxx` |
| `senderStaffId` | Enterprise staff/employee ID | `employee_001` |

The `SenderGate` checks `allowedUsers.has(envelope.senderId)` to enforce allowlist-based access control. Since users naturally configure `allowedUsers` with the staff ID they can see in the DingTalk admin console, the Envelope must use `senderStaffId` when available.

**Before:** `senderId: data.senderId || data.senderStaffId || ''` — always uses the opaque internal ID
**After:** `senderId: data.senderStaffId || data.senderId || ''` — prefers the staff ID, falls back to internal ID

This is backward-compatible: if `senderStaffId` is absent (e.g., external users or older DingTalk API versions), the behavior is unchanged.

## Reviewer Test Plan

1. Configure a DingTalk channel with `senderPolicy: "allowlist"` and `allowedUsers: ["<your-staff-id>"]`
2. Send a message from DingTalk — it should now be accepted
3. Test with an unlisted staff ID — it should be rejected
4. Test with `senderPolicy: "open"` — all messages should still work regardless

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3293