### PR TITLE
fix(cli): prevent statusline spawn EBADF from crashing CLI (#3264)

### DIFF
--- a/packages/cli/src/ui/hooks/useStatusLine.test.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.test.ts
@@ -581,4 +581,57 @@ describe('useStatusLine', () => {
       expect(firstKill).toHaveBeenCalled();
     });
   });
+
+  // --- Spawn failure handling (issue #3264) ---
+  //
+  // On macOS with Node 22, exec() can throw synchronously with EBADF when
+  // stdio pipe setup fails. The throw must not escape doUpdate() — or the
+  // setTimeout callback — or the whole CLI crashes.
+
+  describe('spawn failure handling', () => {
+    it('does not crash when exec throws synchronously (EBADF)', () => {
+      vi.mocked(child_process.exec).mockImplementationOnce((() => {
+        const err = new Error('spawn EBADF') as NodeJS.ErrnoException;
+        err.code = 'EBADF';
+        throw err;
+      }) as unknown as typeof child_process.exec);
+
+      setStatusLineConfig({ type: 'command', command: 'echo test' });
+
+      let result: { current: { text: string | null } } | undefined;
+      expect(() => {
+        result = renderHook(() => useStatusLine()).result;
+      }).not.toThrow();
+      expect(result!.current.text).toBeNull();
+    });
+
+    it('recovers on subsequent state changes after a sync exec failure', async () => {
+      // First call throws, subsequent calls succeed with the default mock.
+      // Verifies activeChildRef and generationRef don't get wedged.
+      vi.mocked(child_process.exec).mockImplementationOnce((() => {
+        const err = new Error('spawn EBADF') as NodeJS.ErrnoException;
+        err.code = 'EBADF';
+        throw err;
+      }) as unknown as typeof child_process.exec);
+
+      setStatusLineConfig({ type: 'command', command: 'echo test' });
+      const { result, rerender } = renderHook(() => useStatusLine());
+
+      expect(result.current.text).toBeNull();
+      expect(child_process.exec).toHaveBeenCalledTimes(1);
+
+      // Trigger a re-execution via state change — should use the default mock.
+      mockUIState.currentModel = 'new-model';
+      rerender();
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(child_process.exec).toHaveBeenCalledTimes(2);
+      await act(async () => {
+        execCallback(null, 'recovered\n', '');
+      });
+      expect(result.current.text).toBe('recovered');
+    });
+  });
 });

--- a/packages/cli/src/ui/hooks/useStatusLine.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.ts
@@ -269,21 +269,33 @@ export function useStatusLine(): {
     // Bump generation so earlier in-flight callbacks are ignored.
     const gen = ++generationRef.current;
 
-    const child = exec(
-      cmd,
-      { cwd: cfg.getTargetDir(), timeout: 5000, maxBuffer: 1024 * 10 },
-      (error, stdout) => {
-        if (gen !== generationRef.current) return; // stale
-        activeChildRef.current = undefined;
-        if (!error && stdout) {
-          // Strip only the trailing newline to preserve intentional whitespace.
-          const line = stdout.replace(/\r?\n$/, '').split(/\r?\n/, 1)[0];
-          setOutput(line || null);
-        } else {
-          setOutput(null);
-        }
-      },
-    );
+    // exec() can throw synchronously: libuv reports a handful of spawn
+    // errors (EACCES, ENOENT, …) via the async 'error' event, but anything
+    // else — including EBADF, reported on macOS Node 22 in issue #3264 — is
+    // thrown from ChildProcess.spawn. Without this guard the throw escapes
+    // the setTimeout callback and crashes the CLI as uncaughtException.
+    let child: ChildProcess;
+    try {
+      child = exec(
+        cmd,
+        { cwd: cfg.getTargetDir(), timeout: 5000, maxBuffer: 1024 * 10 },
+        (error, stdout) => {
+          if (gen !== generationRef.current) return; // stale
+          activeChildRef.current = undefined;
+          if (!error && stdout) {
+            // Strip only the trailing newline to preserve intentional whitespace.
+            const line = stdout.replace(/\r?\n$/, '').split(/\r?\n/, 1)[0];
+            setOutput(line || null);
+          } else {
+            setOutput(null);
+          }
+        },
+      );
+    } catch (err) {
+      debugLog.error('statusline exec error:', (err as Error).message);
+      setOutput(null);
+      return;
+    }
 
     activeChildRef.current = child;
 


### PR DESCRIPTION
## Summary

Fixes #3264.

`child_process.exec()` can throw **synchronously** for spawn errors that libuv does not report via the async `'error'` event. On macOS with Node 22, `EBADF` surfaces from `ChildProcess.spawn` (during stdio pipe setup), and the uncaught throw escapes the debounce `setTimeout` callback → `uncaughtException` → CLI crashes after every assistant response when `ui.statusLine` is configured.

Node reports a short allowlist of errors (`EACCES`, `EAGAIN`, `EMFILE`, `ENFILE`, `ENOENT`, `ENOSYS`, `EPERM`) asynchronously via `'error'`; everything else — including `EBADF` — is thrown directly from `ChildProcess.prototype.spawn`.

This PR wraps the `exec()` call in `useStatusLine` with a `try/catch` so a failing statusline degrades to no output while the rest of the CLI keeps running. The hook's generation counter already invalidates in-flight callbacks, so subsequent state changes recover normally.

## Scope and caveats

- **This fixes the symptom, not the root cause.** We don't know why `EBADF` happens on macOS Node 22 during stdio pipe setup — it may be a Node.js / libuv bug, a TTY-raw-mode race, or FD pressure from Ink's rendering. Regardless, a failing statusline command should never take the CLI down, so catching at the caller is the right layer.
- **User-visible behavior change:** on affected machines the statusline silently disappears (the error is routed to the `STATUS_LINE` debug logger, visible only with `qwen -d`). This matches the existing EPIPE handling a few lines below and is strictly better than crashing, but worth flagging.
- **Scope is intentionally narrow:** only the `useStatusLine` exec callsite is patched. Other `child_process.exec` / `spawn` call sites in the codebase may have the same sync-throw exposure — they are **not** audited by this PR. Happy to do a follow-up sweep if desired.
- **Secondary `ansiRegex3 is not a function` bug still exists.** It's an esbuild ESM/CJS interop issue in the bundled `boxen` → `string-width` → `ansi-regex` chain that fires from the error renderer. This PR prevents the path that was reaching it, so the symptom is gone, but the underlying bundling bug remains latent and will resurface for any other unhandled error that reaches `boxen`. Worth tracking in a separate issue.

## Changes

- `packages/cli/src/ui/hooks/useStatusLine.ts` — wrap `exec()` in `try/catch`; on failure log to the `STATUS_LINE` debug logger, clear output, and return. Generation counter and `activeChildRef` already handle recovery on the next state change.
- `packages/cli/src/ui/hooks/useStatusLine.test.ts` — two new tests: (1) synchronous `EBADF` throw does not crash the hook, (2) subsequent state changes recover and re-execute successfully (verifies no wedged refs).

## Test plan

- [x] `npx vitest run packages/cli/src/ui/hooks/useStatusLine.test.ts` — 32/32 pass
- [x] `npx vitest run packages/cli/src/ui/hooks/` — 635/635 pass (no regressions in neighbor hooks)
- [x] `npx tsc --noEmit -p packages/cli/tsconfig.json` — clean
- [x] `npx eslint` on modified files — clean
- [ ] Manual reproduction on macOS Node 22 with `ui.statusLine` configured (requires a macOS environment; reporter's repro steps in #3264 can be used)