### PR TITLE
fix(core): strip thinking blocks from history on model switch

### DIFF
--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -469,6 +469,45 @@ describe('Server Config (config.ts)', () => {
       ).toHaveBeenCalledTimes(2);
       expect(vi.mocked(createContentGenerator)).toHaveBeenCalledTimes(1);
     });
+
+    it('should strip thoughts from history on model switch (#3304)', async () => {
+      const config = new Config(baseParams);
+
+      const mockContentConfig: ContentGeneratorConfig = {
+        authType: AuthType.QWEN_OAUTH,
+        model: 'coder-model',
+        apiKey: 'QWEN_OAUTH_DYNAMIC_TOKEN',
+        baseUrl: DEFAULT_DASHSCOPE_BASE_URL,
+        timeout: 60000,
+        maxRetries: 3,
+      } as ContentGeneratorConfig;
+
+      vi.mocked(resolveContentGeneratorConfigWithSources).mockImplementation(
+        (_config, authType, generationConfig) => ({
+          config: {
+            ...mockContentConfig,
+            authType,
+            model: generationConfig?.model ?? mockContentConfig.model,
+          } as ContentGeneratorConfig,
+          sources: {},
+        }),
+      );
+      vi.mocked(createContentGenerator).mockResolvedValue({
+        generateContent: vi.fn(),
+        generateContentStream: vi.fn(),
+        countTokens: vi.fn(),
+        embedContent: vi.fn(),
+      } as unknown as ContentGenerator);
+
+      await config.refreshAuth(AuthType.QWEN_OAUTH);
+
+      const stripSpy = config.getGeminiClient().stripThoughtsFromHistory;
+      vi.mocked(stripSpy).mockClear();
+
+      await config.switchModel(AuthType.QWEN_OAUTH, 'coder-model');
+
+      expect(stripSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('model switching with different credentials (OpenAI)', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1276,6 +1276,12 @@ export class Config {
       return;
     }
 
+    // Strip thinking blocks from conversation history on model switch.
+    // reasoning_content is a non-standard field that causes strict
+    // OpenAI-compatible providers to reject requests with 422 errors
+    // when thought parts from a previous model leak into the payload (#3304).
+    this.geminiClient.stripThoughtsFromHistory();
+
     // Hot update path: only supported for qwen-oauth.
     // For other auth types we always refresh to recreate the ContentGenerator.
     //


### PR DESCRIPTION
## TLDR

When switching models mid-session, `reasoning_content` fields from thinking-capable models leaked into API requests sent to the new provider, causing 422 errors on strict OpenAI-compatible endpoints. The fix calls `stripThoughtsFromHistory()` in `handleModelChange()` so thought parts are removed from conversation history before the next request is built for the new model.

## Screenshots / Video Demo

N/A — no user-facing change beyond eliminating the 422 error on model switch.

## Dive Deeper

The conversation history is stored in Gemini format with `thought` parts. When converted to OpenAI format for API requests, these become `reasoning_content` fields on assistant messages. This is a non-standard extension — strict OpenAI-compatible providers (e.g., Mistral, Groq) reject requests containing unknown fields.

The fix is a single call to `stripThoughtsFromHistory()` at the top of `handleModelChange()`, which runs on every model switch regardless of path (hot-update or full-refresh). Thinking blocks are preserved for same-model multi-turn conversations since `handleModelChange` is only invoked on actual model changes.

## Reviewer Test Plan

1. Start a session with a thinking-capable model (e.g., `qwen3.5-plus`)
2. Send a prompt that triggers thinking (e.g., "Think step by step: what is 17 * 23?")
3. Switch to a different model via `/model` (e.g., `qwen3-coder-next`)
4. Send a follow-up prompt — should succeed without 422 errors
5. **Regression**: start a session with a thinking model, send two prompts without switching — thinking context from the first turn should still be present in the second request (enable `--openai-logging` to verify)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3304