### PR TITLE
fix(core): limit skill watcher depth to prevent FD exhaustion

### DIFF
--- a/packages/core/src/skills/skill-manager.test.ts
+++ b/packages/core/src/skills/skill-manager.test.ts
@@ -950,9 +950,11 @@ Symlinked skill content`);
     });
 
     it('watcherIgnored should reject .git directories', () => {
-      expect(watcherIgnored('/skills/.git/config')).toBe(true);
-      expect(watcherIgnored('/skills/.git')).toBe(true);
-      expect(watcherIgnored('/skills/my-skill/SKILL.md')).toBe(false);
+      expect(watcherIgnored(path.join('/skills', '.git', 'config'))).toBe(true);
+      expect(watcherIgnored(path.join('/skills', '.git'))).toBe(true);
+      expect(watcherIgnored(path.join('/skills', 'my-skill', 'SKILL.md'))).toBe(
+        false,
+      );
     });
 
     it('watcherIgnored should reject special file types', () => {

--- a/packages/core/src/skills/skill-manager.test.ts
+++ b/packages/core/src/skills/skill-manager.test.ts
@@ -6,10 +6,15 @@
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs/promises';
+import * as fsSync from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import * as yaml from 'yaml';
-import { SkillManager } from './skill-manager.js';
+import {
+  SkillManager,
+  watcherIgnored,
+  WATCHER_MAX_DEPTH,
+} from './skill-manager.js';
 import { type SkillConfig, SkillError } from './types.js';
 import type { Config } from '../config/config.js';
 import { makeFakeConfig } from '../test-utils/config.js';
@@ -17,6 +22,24 @@ import { makeFakeConfig } from '../test-utils/config.js';
 // Mock file system operations
 vi.mock('fs/promises');
 vi.mock('os');
+
+const { mockWatch, mockWatcher } = vi.hoisted(() => {
+  const mockWatcher = {
+    on: vi.fn().mockReturnThis(),
+    close: vi.fn().mockResolvedValue(undefined),
+  };
+  const mockWatch = vi.fn().mockReturnValue(mockWatcher);
+  return { mockWatch, mockWatcher };
+});
+
+vi.mock('chokidar', () => ({
+  watch: mockWatch,
+}));
+
+vi.mock('fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('fs')>();
+  return { ...actual, existsSync: vi.fn(actual.existsSync) };
+});
 
 // Mock yaml parser - use vi.hoisted for proper hoisting
 const mockParseYaml = vi.hoisted(() => vi.fn());
@@ -899,6 +922,56 @@ Symlinked skill content`);
         'regular-skill',
         'symlink-skill',
       ]);
+    });
+  });
+
+  describe('file watchers', () => {
+    it('should pass ignored function and shallow depth to chokidar', async () => {
+      const projectSkillsDir = path.join('/test/project', '.qwen', 'skills');
+      vi.mocked(fsSync.existsSync).mockImplementation(
+        (p) => String(p) === projectSkillsDir,
+      );
+
+      vi.mocked(fs.readdir).mockResolvedValue(
+        [] as unknown as Awaited<ReturnType<typeof fs.readdir>>,
+      );
+
+      mockWatch.mockClear();
+      mockWatcher.on.mockClear();
+
+      await manager.startWatching();
+
+      expect(mockWatch).toHaveBeenCalledWith(projectSkillsDir, {
+        ignoreInitial: true,
+        ignored: watcherIgnored,
+        depth: WATCHER_MAX_DEPTH,
+      });
+      expect(WATCHER_MAX_DEPTH).toBe(2);
+    });
+
+    it('watcherIgnored should reject .git directories', () => {
+      expect(watcherIgnored('/skills/.git/config')).toBe(true);
+      expect(watcherIgnored('/skills/.git')).toBe(true);
+      expect(watcherIgnored('/skills/my-skill/SKILL.md')).toBe(false);
+    });
+
+    it('watcherIgnored should reject special file types', () => {
+      const socketStats = {
+        isFile: () => false,
+        isDirectory: () => false,
+      } as fsSync.Stats;
+      const fileStats = {
+        isFile: () => true,
+        isDirectory: () => false,
+      } as fsSync.Stats;
+      const dirStats = {
+        isFile: () => false,
+        isDirectory: () => true,
+      } as fsSync.Stats;
+
+      expect(watcherIgnored('/skills/some.sock', socketStats)).toBe(true);
+      expect(watcherIgnored('/skills/SKILL.md', fileStats)).toBe(false);
+      expect(watcherIgnored('/skills/my-skill', dirStats)).toBe(false);
     });
   });
 

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -39,6 +39,21 @@ const QWEN_CONFIG_DIR = '.qwen';
 const SKILLS_CONFIG_DIR = 'skills';
 const SKILL_MANIFEST_FILE = 'SKILL.md';
 
+// Skills have a fixed layout (<skill-name>/SKILL.md), so depth 2 is enough to
+// detect any change. This keeps chokidar out of heavy subtrees like node_modules
+// that would otherwise exhaust file descriptors (see #3289).
+export const WATCHER_MAX_DEPTH = 2;
+
+// Reject special file types (sockets, FIFOs, devices) that cannot be watched
+// and would error with EOPNOTSUPP, plus .git directories.
+export function watcherIgnored(
+  filePath: string,
+  stats?: fsSync.Stats,
+): boolean {
+  if (stats && !stats.isFile() && !stats.isDirectory()) return true;
+  return filePath.split(path.sep).includes('.git');
+}
+
 /**
  * Manages skill configurations stored as directories containing SKILL.md files.
  * Provides discovery, parsing, validation, and caching for skills.
@@ -814,6 +829,8 @@ export class SkillManager {
       try {
         const watcher = watchFs(watchPath, {
           ignoreInitial: true,
+          ignored: watcherIgnored,
+          depth: WATCHER_MAX_DEPTH,
         })
           .on('all', () => {
             this.scheduleRefresh();


### PR DESCRIPTION
## TLDR

The skill file watcher had no depth limit, causing it to recursively watch entire subtrees (including `node_modules`) inside skill directories. This exhausted file descriptors, which broke shell command execution — `node-pty` could spawn processes but its I/O callbacks silently stopped firing, making every shell command return exit code 1 with no output.

The fix limits watcher depth to 2 levels (matching the `<skill-name>/SKILL.md` layout) and filters out `.git` directories and special file types (sockets, FIFOs, devices).

## Screenshots / Video Demo

N/A — no user-facing change beyond restoring correct shell command behavior.

## Dive Deeper

The root cause chain:

1. `SkillManager.updateWatchersFromCache()` calls chokidar `watch()` with no `depth` or `ignored` options
2. If a skill directory contains `node_modules` (e.g., a skill that depends on `electron`), chokidar opens a file handle for every file recursively
3. This exhausts the OS file descriptor limit (typically 4096 on macOS/Linux)
4. Once FDs are exhausted, `node-pty.spawn()` succeeds but `onData`/`onExit` callbacks never fire
5. Shell commands time out and return exit code 1 with empty output

The depth limit of 2 is sufficient because skills follow a flat `<skill-name>/SKILL.md` convention — there's no reason to watch deeper. The `ignored` function additionally filters out special file types that cause `EOPNOTSUPP` errors on `lstat`.

## Reviewer Test Plan

1. Install a skill that has a `node_modules` directory with many files (or create a dummy one with 500+ files)
2. Start qwen-code and run `!pwd` or `!ls` — should return output normally
3. Check `lsof -p <pid> | wc -l` — FD count should stay reasonable (not climb into thousands)
4. Verify skill hot-reload still works: edit a `SKILL.md` file and confirm the change is picked up

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

- Resolves #3289 — shell commands silently fail when skills contain node_modules
- Resolves #3230 — shell commands fail with exit code 1 on macOS (same root cause)
