### PR TITLE
fix(cli): defer update notifications until model response completes

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -360,10 +360,25 @@ export const AppContainer = (props: AppContainerProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [config]);
 
-  useEffect(
-    () => setUpdateHandler(historyManager.addItem, setUpdateInfo),
-    [historyManager.addItem],
-  );
+  // Track idle state via ref so the update handler can defer notifications
+  // while the model is streaming, without triggering re-renders.
+  // Note: isIdleRef.current is assigned after streamingState becomes available
+  // (see the assignment below useGeminiStream).
+  const isIdleRef = useRef(true);
+  const updateHandlerRef = useRef<{
+    cleanup: () => void;
+    flush: () => void;
+  } | null>(null);
+
+  useEffect(() => {
+    const handler = setUpdateHandler(
+      historyManager.addItem,
+      setUpdateInfo,
+      isIdleRef,
+    );
+    updateHandlerRef.current = handler;
+    return () => handler?.cleanup();
+  }, [historyManager.addItem]);
 
   // Watch for model changes (e.g., user switches model via /model)
   useEffect(() => {
@@ -748,6 +763,16 @@ export const AppContainer = (props: AppContainerProps) => {
     terminalHeight,
     midTurnDrainRef,
   );
+
+  // Now that streamingState is available, keep isIdleRef in sync and
+  // flush any deferred update notifications when the model finishes responding.
+  isIdleRef.current = streamingState === StreamingState.Idle;
+
+  useEffect(() => {
+    if (streamingState === StreamingState.Idle) {
+      updateHandlerRef.current?.flush();
+    }
+  }, [streamingState]);
 
   // Contextual tips — show tips based on context usage after model responses
   // Defer TipHistory loading when tips are disabled to avoid side effects

--- a/packages/cli/src/utils/handleAutoUpdate.test.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.test.ts
@@ -11,7 +11,8 @@ import { updateEventEmitter } from './updateEventEmitter.js';
 import type { UpdateObject } from '../ui/utils/updateCheck.js';
 import type { LoadedSettings } from '../config/settings.js';
 import EventEmitter from 'node:events';
-import { handleAutoUpdate } from './handleAutoUpdate.js';
+import { handleAutoUpdate, setUpdateHandler } from './handleAutoUpdate.js';
+import { MessageType } from '../ui/types.js';
 
 vi.mock('./installationInfo.js', async () => {
   const actual = await vi.importActual('./installationInfo.js');
@@ -22,13 +23,9 @@ vi.mock('./installationInfo.js', async () => {
 });
 
 vi.mock('./updateEventEmitter.js', async () => {
-  const actual = await vi.importActual('./updateEventEmitter.js');
+  const { EventEmitter } = await import('node:events');
   return {
-    ...actual,
-    updateEventEmitter: {
-      ...actual.updateEventEmitter,
-      emit: vi.fn(),
-    },
+    updateEventEmitter: new EventEmitter(),
   };
 });
 
@@ -41,17 +38,18 @@ interface MockChildProcess extends EventEmitter {
 }
 
 const mockGetInstallationInfo = vi.mocked(getInstallationInfo);
-const mockUpdateEventEmitter = vi.mocked(updateEventEmitter);
 
 describe('handleAutoUpdate', () => {
   let mockSpawn: Mock;
   let mockUpdateInfo: UpdateObject;
   let mockSettings: LoadedSettings;
   let mockChildProcess: MockChildProcess;
+  let emitSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     mockSpawn = vi.fn();
     vi.clearAllMocks();
+    emitSpy = vi.spyOn(updateEventEmitter, 'emit');
     mockUpdateInfo = {
       update: {
         latest: '2.0.0',
@@ -84,13 +82,13 @@ describe('handleAutoUpdate', () => {
   });
 
   afterEach(() => {
-    vi.clearAllMocks();
+    vi.restoreAllMocks();
   });
 
   it('should do nothing if update info is null', () => {
     handleAutoUpdate(null, mockSettings, '/root', mockSpawn);
     expect(mockGetInstallationInfo).not.toHaveBeenCalled();
-    expect(mockUpdateEventEmitter.emit).not.toHaveBeenCalled();
+    expect(emitSpy).not.toHaveBeenCalled();
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
@@ -109,13 +107,10 @@ describe('handleAutoUpdate', () => {
     handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
 
     // Should still emit update-received with manual update message
-    expect(mockUpdateEventEmitter.emit).toHaveBeenCalledWith(
-      'update-received',
-      {
-        message:
-          'An update is available!\nPlease run npm i -g @qwen-code/qwen-code@latest to update',
-      },
-    );
+    expect(emitSpy).toHaveBeenCalledWith('update-received', {
+      message:
+        'An update is available!\nPlease run npm i -g @qwen-code/qwen-code@latest to update',
+    });
     // Should NOT spawn update when enableAutoUpdate is false
     expect(mockSpawn).not.toHaveBeenCalled();
   });
@@ -130,13 +125,10 @@ describe('handleAutoUpdate', () => {
 
     handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
 
-    expect(mockUpdateEventEmitter.emit).toHaveBeenCalledTimes(1);
-    expect(mockUpdateEventEmitter.emit).toHaveBeenCalledWith(
-      'update-received',
-      {
-        message: 'An update is available!\nCannot determine update command.',
-      },
-    );
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    expect(emitSpy).toHaveBeenCalledWith('update-received', {
+      message: 'An update is available!\nCannot determine update command.',
+    });
     expect(mockSpawn).not.toHaveBeenCalled();
   });
 
@@ -150,13 +142,10 @@ describe('handleAutoUpdate', () => {
 
     handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
 
-    expect(mockUpdateEventEmitter.emit).toHaveBeenCalledTimes(1);
-    expect(mockUpdateEventEmitter.emit).toHaveBeenCalledWith(
-      'update-received',
-      {
-        message: 'An update is available!\nThis is an additional message.',
-      },
-    );
+    expect(emitSpy).toHaveBeenCalledTimes(1);
+    expect(emitSpy).toHaveBeenCalledWith('update-received', {
+      message: 'An update is available!\nThis is an additional message.',
+    });
   });
 
   it('should attempt to perform an update when conditions are met', async () => {
@@ -196,7 +185,7 @@ describe('handleAutoUpdate', () => {
       handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
     });
 
-    expect(mockUpdateEventEmitter.emit).toHaveBeenCalledWith('update-failed', {
+    expect(emitSpy).toHaveBeenCalledWith('update-failed', {
       message:
         'Automatic update failed. Please try updating manually. (command: npm i -g @qwen-code/qwen-code@2.0.0, stderr: An error occurred)',
     });
@@ -220,7 +209,7 @@ describe('handleAutoUpdate', () => {
       handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
     });
 
-    expect(mockUpdateEventEmitter.emit).toHaveBeenCalledWith('update-failed', {
+    expect(emitSpy).toHaveBeenCalledWith('update-failed', {
       message:
         'Automatic update failed. Please try updating manually. (error: Spawn error)',
     });
@@ -267,9 +256,225 @@ describe('handleAutoUpdate', () => {
       handleAutoUpdate(mockUpdateInfo, mockSettings, '/root', mockSpawn);
     });
 
-    expect(mockUpdateEventEmitter.emit).toHaveBeenCalledWith('update-success', {
+    expect(emitSpy).toHaveBeenCalledWith('update-success', {
       message:
         'Update successful! The new version will be used on your next run.',
     });
+  });
+});
+
+describe('setUpdateHandler', () => {
+  let addItem: Mock;
+  let setUpdateInfo: Mock;
+
+  beforeEach(() => {
+    addItem = vi.fn();
+    setUpdateInfo = vi.fn();
+    updateEventEmitter.removeAllListeners();
+  });
+
+  afterEach(() => {
+    updateEventEmitter.removeAllListeners();
+  });
+
+  it('should call addItem immediately when idle', () => {
+    const isIdleRef = { current: true };
+    const { cleanup } = setUpdateHandler(addItem, setUpdateInfo, isIdleRef);
+
+    updateEventEmitter.emit('update-success', {
+      message: 'Update successful!',
+    });
+
+    expect(addItem).toHaveBeenCalledWith(
+      {
+        type: MessageType.INFO,
+        text: 'Update successful! The new version will be used on your next run.',
+      },
+      expect.any(Number),
+    );
+
+    cleanup();
+  });
+
+  it('should defer addItem when not idle (update-success)', () => {
+    const isIdleRef = { current: false };
+    const { cleanup } = setUpdateHandler(addItem, setUpdateInfo, isIdleRef);
+
+    updateEventEmitter.emit('update-success', {
+      message: 'Update successful!',
+    });
+
+    expect(addItem).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('should defer addItem when not idle (update-failed)', () => {
+    const isIdleRef = { current: false };
+    const { cleanup } = setUpdateHandler(addItem, setUpdateInfo, isIdleRef);
+
+    updateEventEmitter.emit('update-failed', {
+      message: 'Update failed',
+    });
+
+    expect(addItem).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('should flush deferred notifications when flush is called', () => {
+    const isIdleRef = { current: false };
+    const { cleanup, flush } = setUpdateHandler(
+      addItem,
+      setUpdateInfo,
+      isIdleRef,
+    );
+
+    updateEventEmitter.emit('update-success', {
+      message: 'Update successful!',
+    });
+
+    expect(addItem).not.toHaveBeenCalled();
+
+    isIdleRef.current = true;
+    flush();
+
+    expect(addItem).toHaveBeenCalledWith(
+      {
+        type: MessageType.INFO,
+        text: 'Update successful! The new version will be used on your next run.',
+      },
+      expect.any(Number),
+    );
+
+    cleanup();
+  });
+
+  it('should flush update-failed notifications correctly', () => {
+    const isIdleRef = { current: false };
+    const { cleanup, flush } = setUpdateHandler(
+      addItem,
+      setUpdateInfo,
+      isIdleRef,
+    );
+
+    updateEventEmitter.emit('update-failed', {
+      message: 'Update failed',
+    });
+
+    expect(addItem).not.toHaveBeenCalled();
+
+    flush();
+
+    expect(addItem).toHaveBeenCalledWith(
+      {
+        type: MessageType.ERROR,
+        text: 'Automatic update failed. Please try updating manually',
+      },
+      expect.any(Number),
+    );
+
+    cleanup();
+  });
+
+  it('should flush multiple deferred notifications in order', () => {
+    const isIdleRef = { current: false };
+    const { cleanup, flush } = setUpdateHandler(
+      addItem,
+      setUpdateInfo,
+      isIdleRef,
+    );
+
+    updateEventEmitter.emit('update-info', { message: 'Info message' });
+    updateEventEmitter.emit('update-success', { message: 'Success!' });
+
+    expect(addItem).not.toHaveBeenCalled();
+
+    flush();
+
+    expect(addItem).toHaveBeenCalledTimes(2);
+    expect(addItem).toHaveBeenNthCalledWith(
+      1,
+      { type: MessageType.INFO, text: 'Info message' },
+      expect.any(Number),
+    );
+    expect(addItem).toHaveBeenNthCalledWith(
+      2,
+      {
+        type: MessageType.INFO,
+        text: 'Update successful! The new version will be used on your next run.',
+      },
+      expect.any(Number),
+    );
+
+    cleanup();
+  });
+
+  it('should clear pending notifications on cleanup', () => {
+    const isIdleRef = { current: false };
+    const { cleanup, flush } = setUpdateHandler(
+      addItem,
+      setUpdateInfo,
+      isIdleRef,
+    );
+
+    updateEventEmitter.emit('update-success', { message: 'Success!' });
+    expect(addItem).not.toHaveBeenCalled();
+
+    cleanup();
+    flush();
+
+    // Pending queue was cleared by cleanup, so addItem should not be called
+    expect(addItem).not.toHaveBeenCalled();
+  });
+
+  it('should be a no-op when flushing an empty queue', () => {
+    const isIdleRef = { current: true };
+    const { cleanup, flush } = setUpdateHandler(
+      addItem,
+      setUpdateInfo,
+      isIdleRef,
+    );
+
+    flush();
+
+    expect(addItem).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it('should deliver immediately after transitioning from busy to idle', () => {
+    const isIdleRef = { current: false };
+    const { cleanup, flush } = setUpdateHandler(
+      addItem,
+      setUpdateInfo,
+      isIdleRef,
+    );
+
+    // First event while busy — deferred
+    updateEventEmitter.emit('update-info', { message: 'Deferred msg' });
+    expect(addItem).not.toHaveBeenCalled();
+
+    // Transition to idle
+    isIdleRef.current = true;
+
+    // Next event while idle — delivered immediately
+    updateEventEmitter.emit('update-info', { message: 'Immediate msg' });
+    expect(addItem).toHaveBeenCalledTimes(1);
+    expect(addItem).toHaveBeenCalledWith(
+      { type: MessageType.INFO, text: 'Immediate msg' },
+      expect.any(Number),
+    );
+
+    // The earlier deferred message should still be in the queue
+    flush();
+    expect(addItem).toHaveBeenCalledTimes(2);
+    expect(addItem).toHaveBeenNthCalledWith(
+      2,
+      { type: MessageType.INFO, text: 'Deferred msg' },
+      expect.any(Number),
+    );
+
+    cleanup();
   });
 });

--- a/packages/cli/src/utils/handleAutoUpdate.ts
+++ b/packages/cli/src/utils/handleAutoUpdate.ts
@@ -86,20 +86,28 @@ export function handleAutoUpdate(
 export function setUpdateHandler(
   addItem: (item: Omit<HistoryItem, 'id'>, timestamp: number) => void,
   setUpdateInfo: (info: UpdateObject | null) => void,
+  isIdleRef: { current: boolean } = { current: true },
 ) {
   let successfullyInstalled = false;
+  const pendingNotifications: Array<Omit<HistoryItem, 'id'>> = [];
+
+  const addItemOrDefer = (item: Omit<HistoryItem, 'id'>) => {
+    if (isIdleRef.current) {
+      addItem(item, Date.now());
+    } else {
+      pendingNotifications.push(item);
+    }
+  };
+
   const handleUpdateRecieved = (info: UpdateObject) => {
     setUpdateInfo(info);
     const savedMessage = info.message;
     setTimeout(() => {
       if (!successfullyInstalled) {
-        addItem(
-          {
-            type: MessageType.INFO,
-            text: savedMessage,
-          },
-          Date.now(),
-        );
+        addItemOrDefer({
+          type: MessageType.INFO,
+          text: savedMessage,
+        });
       }
       setUpdateInfo(null);
     }, 60000);
@@ -107,35 +115,26 @@ export function setUpdateHandler(
 
   const handleUpdateFailed = () => {
     setUpdateInfo(null);
-    addItem(
-      {
-        type: MessageType.ERROR,
-        text: `Automatic update failed. Please try updating manually`,
-      },
-      Date.now(),
-    );
+    addItemOrDefer({
+      type: MessageType.ERROR,
+      text: `Automatic update failed. Please try updating manually`,
+    });
   };
 
   const handleUpdateSuccess = () => {
     successfullyInstalled = true;
     setUpdateInfo(null);
-    addItem(
-      {
-        type: MessageType.INFO,
-        text: `Update successful! The new version will be used on your next run.`,
-      },
-      Date.now(),
-    );
+    addItemOrDefer({
+      type: MessageType.INFO,
+      text: `Update successful! The new version will be used on your next run.`,
+    });
   };
 
   const handleUpdateInfo = (data: { message: string }) => {
-    addItem(
-      {
-        type: MessageType.INFO,
-        text: data.message,
-      },
-      Date.now(),
-    );
+    addItemOrDefer({
+      type: MessageType.INFO,
+      text: data.message,
+    });
   };
 
   updateEventEmitter.on('update-received', handleUpdateRecieved);
@@ -143,10 +142,20 @@ export function setUpdateHandler(
   updateEventEmitter.on('update-success', handleUpdateSuccess);
   updateEventEmitter.on('update-info', handleUpdateInfo);
 
-  return () => {
+  const cleanup = () => {
     updateEventEmitter.off('update-received', handleUpdateRecieved);
     updateEventEmitter.off('update-failed', handleUpdateFailed);
     updateEventEmitter.off('update-success', handleUpdateSuccess);
     updateEventEmitter.off('update-info', handleUpdateInfo);
+    pendingNotifications.length = 0;
   };
+
+  const flush = () => {
+    while (pendingNotifications.length > 0) {
+      const item = pendingNotifications.shift()!;
+      addItem(item, Date.now());
+    }
+  };
+
+  return { cleanup, flush };
 }


### PR DESCRIPTION
When a background auto-update finished while the model was streaming,
the success/failure notification was inserted mid-conversation via
addItem(), disrupting the user's reading flow.

Introduce a "defer until idle" mechanism in setUpdateHandler():
- Accept an `isIdleRef` param that tracks whether StreamingState is Idle
- Queue notifications in a `pendingNotifications` array when not idle
- Expose a `flush()` method that drains the queue once idle
- AppContainer keeps `isIdleRef.current` in sync with `streamingState`
  and calls `flush()` via a useEffect when transitioning back to Idle

All four event types (update-received, update-success, update-failed,
update-info) are routed through the same addItemOrDefer() helper.
The third parameter defaults to `{ current: true }` for backward
compatibility.

## TLDR

When a background auto-update completed while the model was streaming a response, the success/failure notification was inserted mid-conversation via `addItem()`, visually disrupting the user's reading flow. This PR introduces a "defer until idle" mechanism that queues notifications and flushes them only after the model finishes responding.

## Screenshots / Video Demo

**Before:**

```
User: What does this command mean?
AI: This is a command using Homebrew to install...
● Update successful! The new version will be used on your next run.   ← interrupts mid-stream
AI: ...continuing the explanation...
```

**After:**

```
User: What does this command mean?
AI: This is a command using Homebrew to install... (complete response)
● Update successful! The new version will be used on your next run.   ← appears after response completes
```

## Dive Deeper

The fix adds an `isIdleRef` parameter to `setUpdateHandler()` that tracks whether `StreamingState` is `Idle`. All four event types (`update-received`, `update-success`, `update-failed`, `update-info`) are routed through a unified `addItemOrDefer()` helper:

- **Idle** → notification is delivered immediately via `addItem()`
- **Not idle** (streaming) → notification is pushed into a `pendingNotifications` queue
- **Transition back to idle** → `AppContainer` calls `flush()` via a `useEffect` to drain the queue

The third parameter defaults to `{ current: true }` for backward compatibility, so existing callers are unaffected.

## Reviewer Test Plan

**Unit tests (primary validation):**

```bash
cd packages/cli && npx vitest run src/utils/handleAutoUpdate.test.ts
```

18 tests cover the core scenarios: immediate delivery when idle, deferral when streaming, flush on idle transition, multi-notification ordering, cleanup clearing the queue, and empty-queue no-ops.

**Code review checklist:**

- [ ] `addItemOrDefer()` correctly checks `isIdleRef.current` before deciding to deliver or queue
- [ ] `flush()` drains `pendingNotifications` in FIFO order via `shift()`
- [ ] `cleanup()` removes all event listeners **and** clears the pending queue
- [ ] `AppContainer` keeps `isIdleRef.current` in sync with `streamingState` on every render
- [ ] `useEffect` on `streamingState` calls `flush()` only when transitioning to `Idle`
- [ ] Default parameter `isIdleRef = { current: true }` preserves backward compatibility for any other callers

**Smoke test (optional):**

Normal auto-update behavior (idle delivery, no mid-stream interruption) is fully covered by unit tests. Manual E2E verification is not required.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3046
