### PR TITLE
docs: update authentication methods to reflect OAuth discontinuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 - **2026-04-13**: Qwen OAuth free tier policy update: daily quota adjusted to 100 requests/day (from 1,000).
 
-- **2026-04-02**: Qwen3.6-Plus is now live! Sign in via Qwen OAuth to use it directly, or get an API key from [Alibaba Cloud ModelStudio](https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&url=2840914_2&modelId=qwen3.6-plus) to access it through the OpenAI-compatible API.
+- **2026-04-02**: Qwen3.6-Plus is now live! Get an API key from [Alibaba Cloud ModelStudio](https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&url=2840914_2&modelId=qwen3.6-plus) to access it through the OpenAI-compatible API, or run it locally via Ollama/vLLM.
 
 - **2026-02-16**: Qwen3.5-Plus is now live!
 
@@ -118,26 +118,17 @@ Then follow the instructions inside to install, authenticate, and use Qwen Code 
 
 ## Authentication
 
-Qwen Code supports two authentication methods:
+Qwen Code supports the following authentication methods:
 
-- **Qwen OAuth (recommended & free)**: sign in with your `qwen.ai` account in a browser.
-- **API-KEY**: use an API key to connect to any supported provider (OpenAI, Anthropic, Google GenAI, Alibaba Cloud ModelStudio, and other compatible endpoints).
+- **API Key (recommended)**: use an API key from [Alibaba Cloud Model Studio](https://modelstudio.console.alibabacloud.com/) or any supported provider (OpenAI, Anthropic, Google GenAI, and other compatible endpoints).
+- **Coding Plan**: subscribe to the [Alibaba Cloud Coding Plan](https://modelstudio.console.alibabacloud.com/?tab=coding-plan#/efm/coding-plan-index) for a fixed monthly fee with higher quotas.
+- **Local Inference**: run models locally via [Ollama](https://ollama.com/) or [vLLM](https://github.com/vllm-project/vllm) — completely free and private.
 
-#### Qwen OAuth (recommended)
+> ⚠️ **Qwen OAuth was discontinued on April 15, 2026.** If you were previously using Qwen OAuth, please switch to one of the methods above. Run `qwen` and then `/auth` to reconfigure.
 
-Start `qwen`, then run:
+#### API Key (recommended)
 
-```bash
-/auth
-```
-
-Choose **Qwen OAuth** and complete the browser flow. Your credentials are cached locally so you usually won't need to log in again.
-
-> **Note:** In non-interactive or headless environments (e.g., CI, SSH, containers), you typically **cannot** complete the OAuth browser login flow. In these cases, please use the API-KEY authentication method.
-
-#### API-KEY (flexible)
-
-Use this if you want more flexibility over which provider and model to use. Supports multiple protocols:
+Use an API key to connect to Alibaba Cloud Model Studio or any supported provider. Supports multiple protocols:
 
 - **OpenAI-compatible**: Alibaba Cloud ModelStudio, ModelScope, OpenAI, OpenRouter, and other OpenAI-compatible providers
 - **Anthropic**: Claude models
@@ -357,6 +348,74 @@ Use the `/model` command at any time to switch between all configured models.
 
 > **Security note:** Never commit API keys to version control. The `~/.qwen/settings.json` file is in your home directory and should stay private.
 
+#### Local Inference (free & private)
+
+Run models locally using [Ollama](https://ollama.com/) or [vLLM](https://github.com/vllm-project/vllm) — no API key or cloud account needed.
+
+<details>
+<summary>Ollama setup</summary>
+
+1. Install Ollama from [ollama.com](https://ollama.com/)
+2. Pull a model: `ollama pull qwen3:32b`
+3. Configure `~/.qwen/settings.json`:
+
+```json
+{
+  "modelProviders": {
+    "openai": [
+      {
+        "id": "qwen3:32b",
+        "name": "Qwen3 32B (Ollama)",
+        "baseUrl": "http://localhost:11434/v1",
+        "description": "Qwen3 32B running locally via Ollama"
+      }
+    ]
+  },
+  "security": {
+    "auth": {
+      "selectedType": "openai"
+    }
+  },
+  "model": {
+    "name": "qwen3:32b"
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>vLLM setup</summary>
+
+1. Install vLLM: `pip install vllm`
+2. Start the server: `vllm serve Qwen/Qwen3-32B`
+3. Configure `~/.qwen/settings.json`:
+
+```json
+{
+  "modelProviders": {
+    "openai": [
+      {
+        "id": "Qwen/Qwen3-32B",
+        "name": "Qwen3 32B (vLLM)",
+        "baseUrl": "http://localhost:8000/v1",
+        "description": "Qwen3 32B running locally via vLLM"
+      }
+    ]
+  },
+  "security": {
+    "auth": {
+      "selectedType": "openai"
+    }
+  },
+  "model": {
+    "name": "Qwen/Qwen3-32B"
+  }
+}
+```
+
+</details>
+
 ## Usage
 
 As an open-source terminal agent, you can use Qwen Code in four primary ways:
@@ -458,6 +517,10 @@ Looking for a graphical interface?
 ## Troubleshooting
 
 If you encounter issues, check the [troubleshooting guide](https://qwenlm.github.io/qwen-code-docs/en/users/support/troubleshooting/).
+
+**Common issues:**
+
+- **`Qwen OAuth free tier was discontinued on 2026-04-15`**: Qwen OAuth is no longer available. Run `qwen` → `/auth` and switch to API Key, Coding Plan, or Local Inference. See the [Authentication](#authentication) section above for setup instructions.
 
 To report a bug from within the CLI, run `/bug` and include a short title and repro steps.
 

--- a/README.md
+++ b/README.md
@@ -120,9 +120,8 @@ Then follow the instructions inside to install, authenticate, and use Qwen Code 
 
 Qwen Code supports the following authentication methods:
 
-- **API Key (recommended)**: use an API key from [Alibaba Cloud Model Studio](https://modelstudio.console.alibabacloud.com/) or any supported provider (OpenAI, Anthropic, Google GenAI, and other compatible endpoints).
-- **Coding Plan**: subscribe to the [Alibaba Cloud Coding Plan](https://modelstudio.console.alibabacloud.com/?tab=coding-plan#/efm/coding-plan-index) for a fixed monthly fee with higher quotas.
-- **Local Inference**: run models locally via [Ollama](https://ollama.com/) or [vLLM](https://github.com/vllm-project/vllm) — completely free and private.
+- **API Key (recommended)**: use an API key from Alibaba Cloud Model Studio ([Beijing](https://bailian.console.aliyun.com/) / [intl](https://modelstudio.console.alibabacloud.com/)) or any supported provider (OpenAI, Anthropic, Google GenAI, and other compatible endpoints).
+- **Coding Plan**: subscribe to the Alibaba Cloud Coding Plan ([Beijing](https://bailian.console.aliyun.com/cn-beijing?tab=coding-plan#/efm/coding-plan-index) / [intl](https://modelstudio.console.alibabacloud.com/?tab=coding-plan#/efm/coding-plan-index)) for a fixed monthly fee with higher quotas.
 
 > ⚠️ **Qwen OAuth was discontinued on April 15, 2026.** If you were previously using Qwen OAuth, please switch to one of the methods above. Run `qwen` and then `/auth` to reconfigure.
 
@@ -348,9 +347,73 @@ Use the `/model` command at any time to switch between all configured models.
 
 > **Security note:** Never commit API keys to version control. The `~/.qwen/settings.json` file is in your home directory and should stay private.
 
-#### Local Inference (free & private)
+#### Local Model Setup (Ollama / vLLM)
 
-Run models locally using [Ollama](https://ollama.com/) or [vLLM](https://github.com/vllm-project/vllm) — no API key or cloud account needed.
+You can also run models locally — no API key or cloud account needed. This is not an authentication method; instead, configure your local model endpoint in `~/.qwen/settings.json` using the `modelProviders` field.
+
+<details>
+<summary>Ollama setup</summary>
+
+1. Install Ollama from [ollama.com](https://ollama.com/)
+2. Pull a model: `ollama pull qwen3:32b`
+3. Configure `~/.qwen/settings.json`:
+
+```json
+{
+  "modelProviders": {
+    "openai": [
+      {
+        "id": "qwen3:32b",
+        "name": "Qwen3 32B (Ollama)",
+        "baseUrl": "http://localhost:11434/v1",
+        "description": "Qwen3 32B running locally via Ollama"
+      }
+    ]
+  },
+  "security": {
+    "auth": {
+      "selectedType": "openai"
+    }
+  },
+  "model": {
+    "name": "qwen3:32b"
+  }
+}
+```
+
+</details>
+
+<details>
+<summary>vLLM setup</summary>
+
+1. Install vLLM: `pip install vllm`
+2. Start the server: `vllm serve Qwen/Qwen3-32B`
+3. Configure `~/.qwen/settings.json`:
+
+```json
+{
+  "modelProviders": {
+    "openai": [
+      {
+        "id": "Qwen/Qwen3-32B",
+        "name": "Qwen3 32B (vLLM)",
+        "baseUrl": "http://localhost:8000/v1",
+        "description": "Qwen3 32B running locally via vLLM"
+      }
+    ]
+  },
+  "security": {
+    "auth": {
+      "selectedType": "openai"
+    }
+  },
+  "model": {
+    "name": "Qwen/Qwen3-32B"
+  }
+}
+```
+
+</details>
 
 ## Usage
 
@@ -456,7 +519,7 @@ If you encounter issues, check the [troubleshooting guide](https://qwenlm.github
 
 **Common issues:**
 
-- **`Qwen OAuth free tier was discontinued on 2026-04-15`**: Qwen OAuth is no longer available. Run `qwen` → `/auth` and switch to API Key, Coding Plan, or Local Inference. See the [Authentication](#authentication) section above for setup instructions.
+- **`Qwen OAuth free tier was discontinued on 2026-04-15`**: Qwen OAuth is no longer available. Run `qwen` → `/auth` and switch to API Key or Coding Plan. See the [Authentication](#authentication) section above for setup instructions.
 
 To report a bug from within the CLI, run `/bug` and include a short title and repro steps.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 - **2026-04-13**: Qwen OAuth free tier policy update: daily quota adjusted to 100 requests/day (from 1,000).
 
-- **2026-04-02**: Qwen3.6-Plus is now live! Get an API key from [Alibaba Cloud ModelStudio](https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&url=2840914_2&modelId=qwen3.6-plus) to access it through the OpenAI-compatible API, or run it locally via Ollama/vLLM.
+- **2026-04-02**: Qwen3.6-Plus is now live! Get an API key from [Alibaba Cloud ModelStudio](https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&url=2840914_2&modelId=qwen3.6-plus) to access it through the OpenAI-compatible API.
 
 - **2026-02-16**: Qwen3.5-Plus is now live!
 
@@ -351,70 +351,6 @@ Use the `/model` command at any time to switch between all configured models.
 #### Local Inference (free & private)
 
 Run models locally using [Ollama](https://ollama.com/) or [vLLM](https://github.com/vllm-project/vllm) — no API key or cloud account needed.
-
-<details>
-<summary>Ollama setup</summary>
-
-1. Install Ollama from [ollama.com](https://ollama.com/)
-2. Pull a model: `ollama pull qwen3:32b`
-3. Configure `~/.qwen/settings.json`:
-
-```json
-{
-  "modelProviders": {
-    "openai": [
-      {
-        "id": "qwen3:32b",
-        "name": "Qwen3 32B (Ollama)",
-        "baseUrl": "http://localhost:11434/v1",
-        "description": "Qwen3 32B running locally via Ollama"
-      }
-    ]
-  },
-  "security": {
-    "auth": {
-      "selectedType": "openai"
-    }
-  },
-  "model": {
-    "name": "qwen3:32b"
-  }
-}
-```
-
-</details>
-
-<details>
-<summary>vLLM setup</summary>
-
-1. Install vLLM: `pip install vllm`
-2. Start the server: `vllm serve Qwen/Qwen3-32B`
-3. Configure `~/.qwen/settings.json`:
-
-```json
-{
-  "modelProviders": {
-    "openai": [
-      {
-        "id": "Qwen/Qwen3-32B",
-        "name": "Qwen3 32B (vLLM)",
-        "baseUrl": "http://localhost:8000/v1",
-        "description": "Qwen3 32B running locally via vLLM"
-      }
-    ]
-  },
-  "security": {
-    "auth": {
-      "selectedType": "openai"
-    }
-  },
-  "model": {
-    "name": "Qwen/Qwen3-32B"
-  }
-}
-```
-
-</details>
 
 ## Usage
 

--- a/docs/users/configuration/settings.md
+++ b/docs/users/configuration/settings.md
@@ -2,7 +2,7 @@
 
 > [!tip]
 >
-> **Authentication / API keys:** Authentication (API Key, Alibaba Cloud Coding Plan, or Local Inference) and auth-related environment variables (like `OPENAI_API_KEY`) are documented in **[Authentication](../configuration/auth)**.
+> **Authentication / API keys:** Authentication (API Key, Alibaba Cloud Coding Plan) and auth-related environment variables (like `OPENAI_API_KEY`) are documented in **[Authentication](../configuration/auth)**.
 
 > [!note]
 >

--- a/docs/users/configuration/settings.md
+++ b/docs/users/configuration/settings.md
@@ -2,7 +2,7 @@
 
 > [!tip]
 >
-> **Authentication / API keys:** Authentication (Qwen OAuth, Alibaba Cloud Coding Plan, or API Key) and auth-related environment variables (like `OPENAI_API_KEY`) are documented in **[Authentication](../configuration/auth)**.
+> **Authentication / API keys:** Authentication (API Key, Alibaba Cloud Coding Plan, or Local Inference) and auth-related environment variables (like `OPENAI_API_KEY`) are documented in **[Authentication](../configuration/auth)**.
 
 > [!note]
 >

--- a/docs/users/features/commands.md
+++ b/docs/users/features/commands.md
@@ -182,13 +182,13 @@ Commands for obtaining information and performing system settings.
 
 In addition to the in-session `/auth` slash command, Qwen Code provides standalone CLI subcommands for managing authentication directly from the terminal:
 
-| Command                                              | Description                                       |
-| ---------------------------------------------------- | ------------------------------------------------- |
-| `qwen auth`                                          | Interactive authentication setup                  |
-| `qwen auth qwen-oauth`                               | Authenticate with Qwen OAuth                      |
-| `qwen auth coding-plan`                              | Authenticate with Alibaba Cloud Coding Plan       |
-| `qwen auth coding-plan --region china --key sk-sp-…` | Non-interactive Coding Plan setup (for scripting) |
-| `qwen auth status`                                   | Show current authentication status                |
+| Command                                              | Description                                                   |
+| ---------------------------------------------------- | ------------------------------------------------------------- |
+| `qwen auth`                                          | Interactive authentication setup                              |
+| `qwen auth qwen-oauth`                               | ~~Authenticate with Qwen OAuth~~ (discontinued on 2026-04-15) |
+| `qwen auth coding-plan`                              | Authenticate with Alibaba Cloud Coding Plan                   |
+| `qwen auth coding-plan --region china --key sk-sp-…` | Non-interactive Coding Plan setup (for scripting)             |
+| `qwen auth status`                                   | Show current authentication status                            |
 
 > [!tip]
 >

--- a/docs/users/overview.md
+++ b/docs/users/overview.md
@@ -32,7 +32,7 @@ cd your-project
 qwen
 ```
 
-Choose your authentication method — **API Key**, **[Alibaba Cloud Coding Plan](https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-index)**, or **Local Inference** — and follow the prompts to configure. See the [API setup guide](https://bailian.console.aliyun.com/cn-beijing/?tab=doc#/doc/?type=model&url=3023091) for step-by-step instructions. Then let's start with understanding your codebase. Try one of these commands:
+Choose your authentication method — **API Key** or **[Alibaba Cloud Coding Plan](https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-index)** ([intl](https://modelstudio.console.alibabacloud.com/?tab=coding-plan#/efm/coding-plan-index)) — and follow the prompts to configure. See the API setup guide ([Beijing](https://bailian.console.aliyun.com/cn-beijing/?tab=doc#/doc/?type=model&url=3023091) / [intl](https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&url=2974721)) for step-by-step instructions. Then let's start with understanding your codebase. Try one of these commands:
 
 ```
 what does this project do?

--- a/docs/users/overview.md
+++ b/docs/users/overview.md
@@ -32,7 +32,7 @@ cd your-project
 qwen
 ```
 
-Select **Qwen OAuth (Free)** authentication and follow the prompts to log in. Then let's start with understanding your codebase. Try one of these commands:
+Choose your authentication method — **API Key**, **[Alibaba Cloud Coding Plan](https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-index)**, or **Local Inference** — and follow the prompts to configure. See the [API setup guide](https://bailian.console.aliyun.com/cn-beijing/?tab=doc#/doc/?type=model&url=3023091) for step-by-step instructions. Then let's start with understanding your codebase. Try one of these commands:
 
 ```
 what does this project do?

--- a/docs/users/quickstart.md
+++ b/docs/users/quickstart.md
@@ -73,7 +73,7 @@ Choose your preferred authentication method:
 - **Local Inference**: Configure Ollama or vLLM in `~/.qwen/settings.json` to run models locally — completely free and private.
 
 > [!warning]
-
+>
 > Qwen OAuth was discontinued on April 15, 2026. If you were previously using Qwen OAuth, please switch to one of the methods above.
 
 > [!note]

--- a/docs/users/quickstart.md
+++ b/docs/users/quickstart.md
@@ -10,7 +10,7 @@ Make sure you have:
 
 - A **terminal** or command prompt open
 - A code project to work with
-- An API key from [Alibaba Cloud Model Studio](https://bailian.console.aliyun.com/), an [Alibaba Cloud Coding Plan](https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-index) subscription, or a local model setup (Ollama/vLLM)
+- An API key from Alibaba Cloud Model Studio ([Beijing](https://bailian.console.aliyun.com/) / [intl](https://modelstudio.console.alibabacloud.com/)), or an Alibaba Cloud Coding Plan ([Beijing](https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-index) / [intl](https://modelstudio.console.alibabacloud.com/?tab=coding-plan#/efm/coding-plan-index)) subscription
 
 ## Step 1: Install Qwen Code
 
@@ -68,17 +68,14 @@ qwen
 
 Choose your preferred authentication method:
 
-- **Alibaba Cloud Coding Plan**: Select `Alibaba Cloud Coding Plan` for a fixed monthly fee with diverse model options. See the [Coding Plan guide](https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-index) for setup instructions.
-- **API Key (recommended)**: Select `API Key`, then enter your API key from [Alibaba Cloud Model Studio](https://bailian.console.aliyun.com/) or another supported provider. See the [API setup guide](https://bailian.console.aliyun.com/cn-beijing/?tab=doc#/doc/?type=model&url=3023091) for details.
-- **Local Inference**: Configure Ollama or vLLM in `~/.qwen/settings.json` to run models locally — completely free and private.
+- **Alibaba Cloud Coding Plan**: Select `Alibaba Cloud Coding Plan` for a fixed monthly fee with diverse model options. See the [Coding Plan guide](https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-index) ([intl](https://modelstudio.console.alibabacloud.com/?tab=coding-plan#/efm/coding-plan-index)) for setup instructions.
+- **API Key**: Select `API Key`, then enter your API key from Alibaba Cloud Model Studio ([Beijing](https://bailian.console.aliyun.com/) / [intl](https://modelstudio.console.alibabacloud.com/)). See the API setup guide ([Beijing](https://bailian.console.aliyun.com/cn-beijing/?tab=doc#/doc/?type=model&url=3023091) / [intl](https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&url=2974721)) for details.
 
-> [!warning]
->
-> Qwen OAuth was discontinued on April 15, 2026. If you were previously using Qwen OAuth, please switch to one of the methods above.
+> ⚠️ **Note**: Qwen OAuth was discontinued on April 15, 2026. If you were previously using Qwen OAuth, please switch to one of the methods above.
 
 > [!note]
 >
-> When you first set up Qwen Code, a workspace called ".qwen" is automatically created in your home directory. This workspace stores your authentication credentials, configuration, and session data.
+> When you first authenticate Qwen Code with your Qwen account, a workspace called ".qwen" is automatically created for you. This workspace provides centralized cost tracking and management for all Qwen Code usage in your organization.
 
 > [!tip]
 >

--- a/docs/users/quickstart.md
+++ b/docs/users/quickstart.md
@@ -72,11 +72,13 @@ Choose your preferred authentication method:
 - **API Key (recommended)**: Select `API Key`, then enter your API key from [Alibaba Cloud Model Studio](https://bailian.console.aliyun.com/) or another supported provider. See the [API setup guide](https://bailian.console.aliyun.com/cn-beijing/?tab=doc#/doc/?type=model&url=3023091) for details.
 - **Local Inference**: Configure Ollama or vLLM in `~/.qwen/settings.json` to run models locally — completely free and private.
 
-> ⚠️ **Note**: Qwen OAuth was discontinued on April 15, 2026. If you were previously using Qwen OAuth, please switch to one of the methods above.
+> [!warning]
+
+> Qwen OAuth was discontinued on April 15, 2026. If you were previously using Qwen OAuth, please switch to one of the methods above.
 
 > [!note]
 >
-> When you first authenticate Qwen Code with your Qwen account, a workspace called ".qwen" is automatically created for you. This workspace provides centralized cost tracking and management for all Qwen Code usage in your organization.
+> When you first set up Qwen Code, a workspace called ".qwen" is automatically created in your home directory. This workspace stores your authentication credentials, configuration, and session data.
 
 > [!tip]
 >

--- a/docs/users/quickstart.md
+++ b/docs/users/quickstart.md
@@ -10,7 +10,7 @@ Make sure you have:
 
 - A **terminal** or command prompt open
 - A code project to work with
-- A [Qwen Code](https://chat.qwen.ai/auth?mode=register) account
+- An API key from [Alibaba Cloud Model Studio](https://bailian.console.aliyun.com/), an [Alibaba Cloud Coding Plan](https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-index) subscription, or a local model setup (Ollama/vLLM)
 
 ## Step 1: Install Qwen Code
 
@@ -52,9 +52,9 @@ npm install -g @qwen-code/qwen-code@latest
 brew install qwen-code
 ```
 
-## Step 2: Log in to your account
+## Step 2: Set up authentication
 
-Qwen Code requires an account to use. When you start an interactive session with the `qwen` command, you'll be prompted to log in:
+When you start an interactive session with the `qwen` command, you'll be prompted to configure authentication:
 
 ```bash
 # You'll be prompted to log in on first use
@@ -66,7 +66,13 @@ qwen
 /auth
 ```
 
-Select `Qwen OAuth`, log in to your account and follow the prompts to confirm. Once logged in, your credentials are stored and you won't need to log in again.
+Choose your preferred authentication method:
+
+- **API Key (recommended)**: Select `API Key`, then enter your API key from [Alibaba Cloud Model Studio](https://bailian.console.aliyun.com/) or another supported provider. See the [API setup guide](https://bailian.console.aliyun.com/cn-beijing/?tab=doc#/doc/?type=model&url=3023091) for details.
+- **Alibaba Cloud Coding Plan**: Select `Alibaba Cloud Coding Plan` for a fixed monthly fee with diverse model options. See the [Coding Plan guide](https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-index) for setup instructions.
+- **Local Inference**: Configure Ollama or vLLM in `~/.qwen/settings.json` to run models locally — completely free and private.
+
+> ⚠️ **Note**: Qwen OAuth was discontinued on April 15, 2026. If you were previously using Qwen OAuth, please switch to one of the methods above.
 
 > [!note]
 >

--- a/docs/users/quickstart.md
+++ b/docs/users/quickstart.md
@@ -57,19 +57,19 @@ brew install qwen-code
 When you start an interactive session with the `qwen` command, you'll be prompted to configure authentication:
 
 ```bash
-# You'll be prompted to log in on first use
+# You'll be prompted to set up authentication on first use
 qwen
 ```
 
 ```bash
-# Follow the prompts to log in with your account
+# Or run /auth anytime to change authentication method
 /auth
 ```
 
 Choose your preferred authentication method:
 
-- **API Key (recommended)**: Select `API Key`, then enter your API key from [Alibaba Cloud Model Studio](https://bailian.console.aliyun.com/) or another supported provider. See the [API setup guide](https://bailian.console.aliyun.com/cn-beijing/?tab=doc#/doc/?type=model&url=3023091) for details.
 - **Alibaba Cloud Coding Plan**: Select `Alibaba Cloud Coding Plan` for a fixed monthly fee with diverse model options. See the [Coding Plan guide](https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-index) for setup instructions.
+- **API Key (recommended)**: Select `API Key`, then enter your API key from [Alibaba Cloud Model Studio](https://bailian.console.aliyun.com/) or another supported provider. See the [API setup guide](https://bailian.console.aliyun.com/cn-beijing/?tab=doc#/doc/?type=model&url=3023091) for details.
 - **Local Inference**: Configure Ollama or vLLM in `~/.qwen/settings.json` to run models locally — completely free and private.
 
 > ⚠️ **Note**: Qwen OAuth was discontinued on April 15, 2026. If you were previously using Qwen OAuth, please switch to one of the methods above.

--- a/docs/users/support/troubleshooting.md
+++ b/docs/users/support/troubleshooting.md
@@ -9,15 +9,22 @@ This guide provides solutions to common issues and debugging tips, including top
 
 ## Authentication or login errors
 
+- **Error: `Qwen OAuth free tier was discontinued on 2026-04-15`**
+  - **Cause:** Qwen OAuth is no longer available as of April 15, 2026.
+  - **Solution:** Switch to a different authentication method. Run `qwen` → `/auth` and choose one of:
+    - **API Key**: Use an API key from [Alibaba Cloud Model Studio](https://bailian.console.aliyun.com/) or another provider. See the [API setup guide](https://bailian.console.aliyun.com/cn-beijing/?tab=doc#/doc/?type=model&url=3023091).
+    - **Alibaba Cloud Coding Plan**: Subscribe for a fixed monthly fee with higher quotas. See the [Coding Plan guide](https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-index).
+    - **Local Inference**: Run models locally via Ollama or vLLM — completely free and private. See the [Authentication](../configuration/auth) page for configuration details.
+
 - **Error: `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`, `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, or `unable to get local issuer certificate`**
   - **Cause:** You may be on a corporate network with a firewall that intercepts and inspects SSL/TLS traffic. This often requires a custom root CA certificate to be trusted by Node.js.
   - **Solution:** Set the `NODE_EXTRA_CA_CERTS` environment variable to the absolute path of your corporate root CA certificate file.
     - Example: `export NODE_EXTRA_CA_CERTS=/path/to/your/corporate-ca.crt`
 
 - **Error: `Device authorization flow failed: fetch failed`**
-  - **Cause:** Node.js could not reach Qwen OAuth endpoints (often a proxy or SSL/TLS trust issue). When available, Qwen Code will also print the underlying error cause (for example: `UNABLE_TO_VERIFY_LEAF_SIGNATURE`).
+  - **Cause:** Node.js could not reach API endpoints (often a proxy or SSL/TLS trust issue). When available, Qwen Code will also print the underlying error cause (for example: `UNABLE_TO_VERIFY_LEAF_SIGNATURE`).
   - **Solution:**
-    - Confirm you can access `https://chat.qwen.ai` from the same machine/network.
+    - Confirm you can access your API provider's endpoint from the same machine/network.
     - If you are behind a proxy, set it via `qwen --proxy <url>` (or the `proxy` setting in `settings.json`).
     - If your network uses a corporate TLS inspection CA, set `NODE_EXTRA_CA_CERTS` as described above.
 
@@ -41,7 +48,7 @@ This guide provides solutions to common issues and debugging tips, including top
     Refer to [Qwen Code Configuration](../configuration/settings) for more details.
 
 - **Q: Why don't I see cached token counts in my stats output?**
-  - A: Cached token information is only displayed when cached tokens are being used. This feature is available for API key users (Qwen API key or Google Cloud Vertex AI) but not for OAuth users (such as Google Personal/Enterprise accounts like Google Gmail or Google Workspace, respectively). This is because the Qwen Code Assist API does not support cached content creation. You can still view your total token usage using the `/stats` command.
+  - A: Cached token information is only displayed when cached tokens are being used. This feature is available for API key users (e.g., Alibaba Cloud Model Studio API key or Google Cloud Vertex AI). You can still view your total token usage using the `/stats` command.
 
 ## Common error messages and solutions
 

--- a/docs/users/support/troubleshooting.md
+++ b/docs/users/support/troubleshooting.md
@@ -12,9 +12,8 @@ This guide provides solutions to common issues and debugging tips, including top
 - **Error: `Qwen OAuth free tier was discontinued on 2026-04-15`**
   - **Cause:** Qwen OAuth is no longer available as of April 15, 2026.
   - **Solution:** Switch to a different authentication method. Run `qwen` → `/auth` and choose one of:
-    - **API Key**: Use an API key from [Alibaba Cloud Model Studio](https://bailian.console.aliyun.com/) or another provider. See the [API setup guide](https://bailian.console.aliyun.com/cn-beijing/?tab=doc#/doc/?type=model&url=3023091).
-    - **Alibaba Cloud Coding Plan**: Subscribe for a fixed monthly fee with higher quotas. See the [Coding Plan guide](https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-index).
-    - **Local Inference**: Run models locally via Ollama or vLLM — completely free and private. See the [Authentication](../configuration/auth) page for configuration details.
+    - **API Key**: Use an API key from Alibaba Cloud Model Studio ([Beijing](https://bailian.console.aliyun.com/) / [intl](https://modelstudio.console.alibabacloud.com/)). See the API setup guide ([Beijing](https://bailian.console.aliyun.com/cn-beijing/?tab=doc#/doc/?type=model&url=3023091) / [intl](https://modelstudio.console.alibabacloud.com/ap-southeast-1?tab=doc#/doc/?type=model&url=2974721)).
+    - **Alibaba Cloud Coding Plan**: Subscribe for a fixed monthly fee with higher quotas. See the Coding Plan guide ([Beijing](https://bailian.console.aliyun.com/cn-beijing/?tab=coding-plan#/efm/coding-plan-index) / [intl](https://modelstudio.console.alibabacloud.com/?tab=coding-plan#/efm/coding-plan-index)).
 
 - **Error: `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`, `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, or `unable to get local issuer certificate`**
   - **Cause:** You may be on a corporate network with a firewall that intercepts and inspects SSL/TLS traffic. This often requires a custom root CA certificate to be trusted by Node.js.
@@ -22,9 +21,9 @@ This guide provides solutions to common issues and debugging tips, including top
     - Example: `export NODE_EXTRA_CA_CERTS=/path/to/your/corporate-ca.crt`
 
 - **Error: `Device authorization flow failed: fetch failed`**
-  - **Cause:** Node.js could not reach API endpoints (often a proxy or SSL/TLS trust issue). When available, Qwen Code will also print the underlying error cause (for example: `UNABLE_TO_VERIFY_LEAF_SIGNATURE`).
+  - **Cause:** Node.js could not reach Qwen OAuth endpoints (often a proxy or SSL/TLS trust issue). When available, Qwen Code will also print the underlying error cause (for example: `UNABLE_TO_VERIFY_LEAF_SIGNATURE`). Note: this error is specific to the legacy Qwen OAuth flow.
   - **Solution:**
-    - Confirm you can access your API provider's endpoint from the same machine/network.
+    - If you are still using Qwen OAuth, switch to API Key or Coding Plan via `/auth`.
     - If you are behind a proxy, set it via `qwen --proxy <url>` (or the `proxy` setting in `settings.json`).
     - If your network uses a corporate TLS inspection CA, set `NODE_EXTRA_CA_CERTS` as described above.
 


### PR DESCRIPTION
## Summary

Update documentation to reflect the Qwen OAuth free tier discontinuation on 2026-04-15, directing users to valid authentication methods (API Key, Coding Plan, or Local Inference).

Closes #3316

## Changes

### `README.md`
- **Authentication section**: Replaced OAuth-first approach with three active methods: **API Key (recommended)**, **Coding Plan**, and **Local Inference**
- **Removed Qwen OAuth subsection**: Deleted the entire "Qwen OAuth (recommended)" section (browser login flow, `/auth` instructions) since the service is discontinued
- **Renamed API-KEY subsection**: From "API-KEY (flexible)" to "API Key (recommended)"
- **Added Local Inference section**: Complete setup guides for both Ollama and vLLM with `settings.json` examples
- **Updated Troubleshooting**: Added `Qwen OAuth free tier was discontinued on 2026-04-15` error message and migration instructions
- **Updated News**: Removed "Sign in via Qwen OAuth" from the 2026-04-02 entry

### `docs/users/overview.md`
- Replaced "Select **Qwen OAuth (Free)**" with guidance to choose API Key / Coding Plan / Local Inference, with links to setup guides

### `docs/users/quickstart.md`
- **Before you begin**: Changed prerequisite from "A Qwen Code account" to API key / Coding Plan / local model setup
- **Step 2**: Renamed from "Log in to your account" to "Set up authentication"; replaced OAuth login flow with three authentication methods and deprecation notice

### `docs/users/support/troubleshooting.md`
- **Added new error entry**: `Qwen OAuth free tier was discontinued on 2026-04-15` with solution pointing to API Key, Coding Plan, and Local Inference
- **Updated existing entries**: Removed OAuth-specific wording from "Device authorization flow failed" error
- **Updated FAQ**: Simplified cached token FAQ by removing OAuth user references

### `docs/users/configuration/settings.md`
- Updated authentication method list in tip from "Qwen OAuth, Alibaba Cloud Coding Plan, or API Key" to "API Key, Alibaba Cloud Coding Plan, or Local Inference"

### `docs/users/features/commands.md`
- Marked `qwen auth qwen-oauth` command as ~~discontinued on 2026-04-15~~

## Not changed (intentionally)
- `docs/users/configuration/auth.md` — Already has proper `[!warning]` and "Discontinued" markers
- `docs/users/configuration/model-providers.md` — Technical reference; `qwen-oauth` remains a valid auth type in code
- `docs/users/features/token-caching.md`, `docs/users/support/tos-privacy.md` — OAuth references are historical/factual