### PR TITLE
feat(cli): make /insight report respect user language settings

### DIFF
--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -2015,4 +2015,136 @@ export default {
     'Not in plan mode. Use "/plan" to enter plan mode first.',
 
   "Set up Qwen Code's status line UI": "Set up Qwen Code's status line UI",
+
+  'Generating insights in {{language}}...':
+    'Insights werden in {{language}} generiert...',
+  'Opening insights in your browser: {{path}}':
+    'Insights werden im Browser geöffnet: {{path}}',
+  'Insights generated at: {{path}}. Please open this file in your browser.':
+    'Insights erstellt in {{path}}. Bitte öffnen Sie diese Datei im Browser.',
+
+  // ============================================================================
+  // Insight Report - HTML Report Static Text
+  // ============================================================================
+  // Header
+  insight_title: 'Qwen Code Einblicke',
+  insight_messages_across_sessions:
+    '{{messages}} Nachrichten in {{sessions}} Sitzungen',
+  insight_personalized_journey:
+    'Ihr personalisierter Programmierweg und Patterns',
+
+  // Stats
+  insight_stat_messages: 'Nachrichten',
+  insight_stat_lines: 'Zeilen',
+  insight_stat_files: 'Dateien',
+  insight_stat_days: 'Tage',
+  insight_stat_msgs_per_day: 'Nachr./Tag',
+
+  // Charts
+  insight_active_hours: 'Aktive Stunden',
+  insight_morning: 'Morgen',
+  insight_afternoon: 'Nachmittag',
+  insight_evening: 'Abend',
+  insight_night: 'Nacht',
+  insight_time_morning: '06:00 - 12:00',
+  insight_time_afternoon: '12:00 - 18:00',
+  insight_time_evening: '18:00 - 22:00',
+  insight_time_night: '22:00 - 06:00',
+  insight_activity_heatmap: 'Aktivitäts-Heatmap',
+  insight_heatmap_subtitle: 'Aktivität des letzten Jahres',
+  insight_less: 'Weniger',
+  insight_more: 'Mehr',
+  insight_activities: 'Aktivitäten',
+  insight_month_jan: 'Jan',
+  insight_month_feb: 'Feb',
+  insight_month_mar: 'Mär',
+  insight_month_apr: 'Apr',
+  insight_month_may: 'Mai',
+  insight_month_jun: 'Jun',
+  insight_month_jul: 'Jul',
+  insight_month_aug: 'Aug',
+  insight_month_sep: 'Sep',
+  insight_month_oct: 'Okt',
+  insight_month_nov: 'Nov',
+  insight_month_dec: 'Dez',
+
+  // Qualitative - At a Glance
+  insight_at_a_glance: 'Überblick',
+  insight_whats_working: 'Was funktioniert:',
+  insight_whats_hindering: 'Was Sie behindert:',
+  insight_quick_wins: 'Schnelle Verbesserungen:',
+  insight_ambitious_workflows: 'Ambitionierte Workflows:',
+  insight_see_more_wins: 'Beeindruckende Ergebnisse →',
+  insight_see_more_friction: 'Wo Probleme auftreten →',
+  insight_see_more_features: 'Funktionen zum Ausprobieren →',
+  insight_see_more_horizon: 'Auf dem Horizont →',
+
+  // Qualitative - Navigation TOC
+  insight_nav_work: 'Was Sie bearbeiten',
+  insight_nav_usage: 'Wie Sie Qwen Code nutzen',
+  insight_nav_wins: 'Beeindruckende Ergebnisse',
+  insight_nav_friction: 'Wo Probleme auftreten',
+  insight_nav_features: 'Funktionen zum Ausprobieren',
+  insight_nav_patterns: 'Neue Patterns',
+  insight_nav_horizon: 'Auf dem Horizont',
+
+  // Qualitative - Project Areas
+  insight_what_you_work_on: 'Was Sie bearbeiten',
+  insight_sessions_count: '~{{count}} Sitzungen',
+  insight_what_you_wanted: 'Was Sie wollten',
+  insight_top_tools_used: 'Top-Tools',
+
+  // Qualitative - Interaction Style
+  insight_how_you_use: 'Wie Sie Qwen Code nutzen',
+  insight_key_pattern: 'Schlüsselpattern:',
+  insight_impressive_things: 'Beeindruckende Ergebnisse',
+  insight_what_helped_most: 'Was am meisten half',
+  insight_outcomes: 'Ergebnisse',
+
+  // Qualitative - Friction Points
+  insight_where_things_go_wrong: 'Wo Probleme auftreten',
+  insight_primary_friction_types: 'Hauptproblemtypen',
+  insight_inferred_satisfaction: 'Ermittelte Zufriedenheit',
+  insight_unclear: 'Unklar',
+
+  // Qualitative - Improvements
+  insight_features_to_try: 'Qwen Code Funktionen zum Ausprobieren',
+  insight_suggested_qwen_md: 'Empfohlene QWEN.md Ergänzungen',
+  insight_qwen_md_hint: 'In Qwen Code kopieren, um es zu QWEN.md hinzuzufügen.',
+  insight_copy_all_checked: 'Alle markierten kopieren ({{count}})',
+  insight_copied_all: 'Alle kopiert!',
+  insight_why_for_you: 'Warum für Sie:',
+  insight_features_hint:
+    'In Qwen Code kopieren — es wird automatisch konfiguriert.',
+  insight_new_ways_to_use: 'Neue Wege zur Nutzung von Qwen Code',
+  insight_patterns_hint:
+    'In Qwen Code kopieren — es führt Sie durch die Einrichtung.',
+  insight_paste_into_qwen: 'In Qwen Code einfügen:',
+  insight_on_the_horizon: 'Auf dem Horizont',
+  insight_getting_started: 'Erste Schritte:',
+  insight_no_data: 'Keine Insight-Daten verfügbar',
+  insight_export_card: 'Karte exportieren',
+  insight_light_theme: 'Helles Thema',
+  insight_dark_theme: 'Dunkles Thema',
+  insight_export_not_available: 'Exportfunktion nicht verfügbar.',
+  insight_export_failed:
+    'Karte konnte nicht exportiert werden. Bitte erneut versuchen.',
+  insight_copy: 'Kopieren',
+  insight_copied: 'Kopiert!',
+  insight_share_sessions: 'Sitzungen',
+  insight_share_lines_changed: 'Zeilen geändert',
+  insight_share_streak: 'Serie',
+  insight_share_best_streak: 'Beste Serie',
+  insight_share_activity: 'Aktivität · {{days}} aktive Tage',
+  insight_share_generated: 'Erstellt von Qwen Code ·',
+  insight_share_github: 'github.com/QwenLM/qwen-code',
+  insight_share_brand: 'qwen.ai',
+
+  // DataProcessor progress messages
+  insight_scanning_chat_history: 'Chat-Verlauf wird gescannt...',
+  insight_crunching_numbers: 'Daten werden verarbeitet',
+  insight_preparing_sessions: 'Sitzungen werden vorbereitet...',
+  insight_generating_personalized:
+    'Personalisierte Insights werden generiert...',
+  insight_assembling_report: 'Bericht wird zusammengestellt...',
 };

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -2054,4 +2054,157 @@ export default {
     'Not in plan mode. Use "/plan" to enter plan mode first.',
 
   "Set up Qwen Code's status line UI": "Set up Qwen Code's status line UI",
+
+  // ============================================================================
+  // Insight Report - CLI Messages
+  // ============================================================================
+  'Generating insights...': 'Generating insights...',
+  'This may take a couple minutes. Sit tight!':
+    'This may take a couple minutes. Sit tight!',
+  'Starting insight generation...': 'Starting insight generation...',
+  'Insight report generated successfully!':
+    'Insight report generated successfully!',
+  'Insights ready.': 'Insights ready.',
+  'Failed to generate insights: {{error}}':
+    'Failed to generate insights: {{error}}',
+  'Opening insights in your browser: {{path}}':
+    'Opening insights in your browser: {{path}}',
+  'Insights generated at: {{path}}. Please open this file in your browser.':
+    'Insights generated at: {{path}}. Please open this file in your browser.',
+  'Generating insights in {{language}}...':
+    'Generating insights in {{language}}...',
+
+  // ============================================================================
+  // Insight Report - HTML Report Static Text
+  // ============================================================================
+  // Header
+  insight_title: 'Qwen Code Insights',
+  insight_messages_across_sessions:
+    '{{messages}} messages across {{sessions}} sessions',
+  insight_personalized_journey: 'Your personalized coding journey and patterns',
+
+  // Stats
+  insight_stat_messages: 'Messages',
+  insight_stat_lines: 'Lines',
+  insight_stat_files: 'Files',
+  insight_stat_days: 'Days',
+  insight_stat_msgs_per_day: 'Msgs/Day',
+
+  // Charts
+  insight_active_hours: 'Active Hours',
+  insight_morning: 'Morning',
+  insight_afternoon: 'Afternoon',
+  insight_evening: 'Evening',
+  insight_night: 'Night',
+  insight_time_morning: '06:00 - 12:00',
+  insight_time_afternoon: '12:00 - 18:00',
+  insight_time_evening: '18:00 - 22:00',
+  insight_time_night: '22:00 - 06:00',
+  insight_activity_heatmap: 'Activity Heatmap',
+  insight_heatmap_subtitle: 'Showing past year of activity',
+  insight_less: 'Less',
+  insight_more: 'More',
+  insight_activities: 'activities',
+  insight_month_jan: 'Jan',
+  insight_month_feb: 'Feb',
+  insight_month_mar: 'Mar',
+  insight_month_apr: 'Apr',
+  insight_month_may: 'May',
+  insight_month_jun: 'Jun',
+  insight_month_jul: 'Jul',
+  insight_month_aug: 'Aug',
+  insight_month_sep: 'Sep',
+  insight_month_oct: 'Oct',
+  insight_month_nov: 'Nov',
+  insight_month_dec: 'Dec',
+
+  // Qualitative - At a Glance
+  insight_at_a_glance: 'At a Glance',
+  insight_whats_working: "What's working:",
+  insight_whats_hindering: "What's hindering you:",
+  insight_quick_wins: 'Quick wins to try:',
+  insight_ambitious_workflows: 'Ambitious workflows:',
+  insight_see_more_wins: 'Impressive Things You Did →',
+  insight_see_more_friction: 'Where Things Go Wrong →',
+  insight_see_more_features: 'Features to Try →',
+  insight_see_more_horizon: 'On the Horizon →',
+
+  // Qualitative - Navigation TOC
+  insight_nav_work: 'What You Work On',
+  insight_nav_usage: 'How You Use Qwen Code',
+  insight_nav_wins: 'Impressive Things',
+  insight_nav_friction: 'Where Things Go Wrong',
+  insight_nav_features: 'Features to Try',
+  insight_nav_patterns: 'New Usage Patterns',
+  insight_nav_horizon: 'On the Horizon',
+
+  // Qualitative - Project Areas
+  insight_what_you_work_on: 'What You Work On',
+  insight_sessions_count: '~{{count}} sessions',
+  insight_what_you_wanted: 'What You Wanted',
+  insight_top_tools_used: 'Top Tools Used',
+
+  // Qualitative - Interaction Style
+  insight_how_you_use: 'How You Use Qwen Code',
+  insight_key_pattern: 'Key pattern:',
+
+  // Qualitative - Impressive Workflows
+  insight_impressive_things: 'Impressive Things You Did',
+  insight_what_helped_most: "What Helped Most (Qwen's Capabilities)",
+  insight_outcomes: 'Outcomes',
+
+  // Qualitative - Friction Points
+  insight_where_things_go_wrong: 'Where Things Go Wrong',
+  insight_primary_friction_types: 'Primary Friction Types',
+  insight_inferred_satisfaction: 'Inferred Satisfaction (model-estimated)',
+  insight_unclear: 'Unclear',
+
+  // Qualitative - Improvements
+  insight_features_to_try: 'Existing Qwen Code Features to Try',
+  insight_suggested_qwen_md: 'Suggested QWEN.md Additions',
+  insight_qwen_md_hint:
+    'Just copy this into Qwen Code to add it to your QWEN.md.',
+  insight_copy_all_checked: 'Copy All Checked ({{count}})',
+  insight_copied_all: 'Copied All!',
+  insight_why_for_you: 'Why for you:',
+  insight_features_hint:
+    "Just copy this into Qwen Code and it'll set it up for you.",
+  insight_new_ways_to_use: 'New Ways to Use Qwen Code',
+  insight_patterns_hint:
+    "Just copy this into Qwen Code and it'll walk you through it.",
+  insight_paste_into_qwen: 'Paste into Qwen Code:',
+
+  // Qualitative - Future Opportunities
+  insight_on_the_horizon: 'On the Horizon',
+  insight_getting_started: 'Getting started:',
+
+  // Qualitative - Memorable Moment
+  // (no static text, just displays LLM content)
+
+  // Buttons & UI
+  insight_no_data: 'No insight data available',
+  insight_export_card: 'Export Card',
+  insight_light_theme: 'Light Theme',
+  insight_dark_theme: 'Dark Theme',
+  insight_export_not_available: 'Export functionality is not available.',
+  insight_export_failed: 'Failed to export card. Please try again.',
+  insight_copy: 'Copy',
+  insight_copied: 'Copied!',
+
+  // Share Card
+  insight_share_sessions: 'Sessions',
+  insight_share_lines_changed: 'Lines Changed',
+  insight_share_streak: 'Streak',
+  insight_share_best_streak: 'Best Streak',
+  insight_share_activity: 'Activity · {{days}} active days',
+  insight_share_generated: 'Generated by Qwen Code ·',
+  insight_share_github: 'github.com/QwenLM/qwen-code',
+  insight_share_brand: 'qwen.ai',
+
+  // DataProcessor progress messages
+  insight_scanning_chat_history: 'Scanning chat history...',
+  insight_crunching_numbers: 'Crunching the numbers',
+  insight_preparing_sessions: 'Preparing sessions...',
+  insight_generating_personalized: 'Generating personalized insights...',
+  insight_assembling_report: 'Assembling report...',
 };

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -2092,4 +2092,133 @@ export default {
 
   "Set up Qwen Code's status line UI":
     "Configurer l'interface de la barre de statut de Qwen Code",
+
+  'Generating insights in {{language}}...':
+    "Génération d'insights en {{language}}...",
+  'Opening insights in your browser: {{path}}':
+    'Ouverture des insights dans le navigateur : {{path}}',
+  'Insights generated at: {{path}}. Please open this file in your browser.':
+    'Insights générés à {{path}}. Ouvrez ce fichier dans votre navigateur.',
+
+  // ============================================================================
+  // Insight Report - HTML Report Static Text
+  // ============================================================================
+  // Header
+  insight_title: 'Qwen Code Insights',
+  insight_messages_across_sessions:
+    '{{messages}} messages sur {{sessions}} sessions',
+  insight_personalized_journey:
+    'Votre parcours de codage personnalisé et vos patterns',
+
+  // Stats
+  insight_stat_messages: 'Messages',
+  insight_stat_lines: 'Lignes',
+  insight_stat_files: 'Fichiers',
+  insight_stat_days: 'Jours',
+  insight_stat_msgs_per_day: 'Msgs/Jour',
+
+  // Charts
+  insight_active_hours: 'Heures actives',
+  insight_morning: 'Matin',
+  insight_afternoon: 'Après-midi',
+  insight_evening: 'Soir',
+  insight_night: 'Nuit',
+  insight_time_morning: '06:00 - 12:00',
+  insight_time_afternoon: '12:00 - 18:00',
+  insight_time_evening: '18:00 - 22:00',
+  insight_time_night: '22:00 - 06:00',
+  insight_activity_heatmap: "Carte de chaleur d'activité",
+  insight_heatmap_subtitle: "Activité de l'année écoulée",
+  insight_less: 'Moins',
+  insight_more: 'Plus',
+  insight_activities: 'activités',
+  insight_month_jan: 'Jan',
+  insight_month_feb: 'Fév',
+  insight_month_mar: 'Mar',
+  insight_month_apr: 'Avr',
+  insight_month_may: 'Mai',
+  insight_month_jun: 'Jun',
+  insight_month_jul: 'Jul',
+  insight_month_aug: 'Aoû',
+  insight_month_sep: 'Sep',
+  insight_month_oct: 'Oct',
+  insight_month_nov: 'Nov',
+  insight_month_dec: 'Déc',
+
+  // Qualitative - At a Glance
+  insight_at_a_glance: 'En bref',
+  insight_whats_working: 'Ce qui fonctionne :',
+  insight_whats_hindering: 'Ce qui vous freine :',
+  insight_quick_wins: 'Améliorations rapides :',
+  insight_ambitious_workflows: 'Workflows ambitieux :',
+  insight_see_more_wins: 'Résultats impressionnants →',
+  insight_see_more_friction: 'Où les problèmes surviennent →',
+  insight_see_more_features: 'Fonctionnalités à essayer →',
+  insight_see_more_horizon: 'En perspective →',
+
+  // Qualitative - Navigation TOC
+  insight_nav_work: 'Ce sur quoi vous travaillez',
+  insight_nav_usage: 'Comment vous utilisez Qwen Code',
+  insight_nav_wins: 'Résultats impressionnants',
+  insight_nav_friction: 'Où les problèmes surviennent',
+  insight_nav_features: 'Fonctionnalités à essayer',
+  insight_nav_patterns: 'Nouveaux patterns',
+  insight_nav_horizon: 'En perspective',
+
+  // Qualitative - Project Areas
+  insight_what_you_work_on: 'Ce sur quoi vous travaillez',
+  insight_sessions_count: '~{{count}} sessions',
+  insight_what_you_wanted: 'Ce que vous vouliez',
+  insight_top_tools_used: 'Outils les plus utilisés',
+
+  // Qualitative - Interaction Style
+  insight_how_you_use: 'Comment vous utilisez Qwen Code',
+  insight_key_pattern: 'Pattern clé :',
+  insight_impressive_things: 'Résultats impressionnants',
+  insight_what_helped_most: 'Ce qui a le plus aidé',
+  insight_outcomes: 'Résultats',
+
+  // Qualitative - Friction Points
+  insight_where_things_go_wrong: 'Où les problèmes surviennent',
+  insight_primary_friction_types: 'Types de friction principaux',
+  insight_inferred_satisfaction: 'Satisfaction estimée',
+  insight_unclear: 'Incertain',
+
+  // Qualitative - Improvements
+  insight_features_to_try: 'Fonctionnalités Qwen Code à essayer',
+  insight_suggested_qwen_md: 'Ajouts suggérés au QWEN.md',
+  insight_qwen_md_hint: 'Copiez dans Qwen Code pour ajouter à votre QWEN.md.',
+  insight_copy_all_checked: 'Copier tous les sélectionnés ({{count}})',
+  insight_copied_all: 'Tous copiés !',
+  insight_why_for_you: 'Pourquoi pour vous :',
+  insight_features_hint:
+    'Copiez dans Qwen Code — il configurera automatiquement.',
+  insight_new_ways_to_use: "Nouvelles façons d'utiliser Qwen Code",
+  insight_patterns_hint: 'Copiez dans Qwen Code — il vous guidera.',
+  insight_paste_into_qwen: 'Coller dans Qwen Code :',
+  insight_on_the_horizon: 'En perspective',
+  insight_getting_started: 'Pour commencer :',
+  insight_no_data: "Pas de données d'insights disponibles",
+  insight_export_card: 'Exporter la carte',
+  insight_light_theme: 'Thème clair',
+  insight_dark_theme: 'Thème sombre',
+  insight_export_not_available: 'Exportation non disponible.',
+  insight_export_failed: "Échec de l'exportation. Réessayez.",
+  insight_copy: 'Copier',
+  insight_copied: 'Copié !',
+  insight_share_sessions: 'Sessions',
+  insight_share_lines_changed: 'Lignes modifiées',
+  insight_share_streak: 'Série',
+  insight_share_best_streak: 'Meilleure série',
+  insight_share_activity: 'Activité · {{days}} jours actifs',
+  insight_share_generated: 'Généré par Qwen Code ·',
+  insight_share_github: 'github.com/QwenLM/qwen-code',
+  insight_share_brand: 'qwen.ai',
+
+  // DataProcessor progress messages
+  insight_scanning_chat_history: "Scan de l'historique de chat...",
+  insight_crunching_numbers: 'Traitement des données',
+  insight_preparing_sessions: 'Préparation des sessions...',
+  insight_generating_personalized: "Génération d'insights personnalisés...",
+  insight_assembling_report: 'Assemblage du rapport...',
 };

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -1505,4 +1505,141 @@ export default {
     'Not in plan mode. Use "/plan" to enter plan mode first.',
 
   "Set up Qwen Code's status line UI": "Set up Qwen Code's status line UI",
+
+  'Generating insights in {{language}}...':
+    '{{language}}でインサイトを生成中...',
+  'Opening insights in your browser: {{path}}':
+    'ブラウザでインサイトを開いています: {{path}}',
+  'Insights generated at: {{path}}. Please open this file in your browser.':
+    'インサイトは {{path}} に生成されました。ブラウザでこのファイルを開いてください。',
+
+  // ============================================================================
+  // Insight Report - HTML Report Static Text
+  // ============================================================================
+  // Header
+  insight_title: 'Qwen Code インサイト',
+  insight_messages_across_sessions:
+    '{{messages}}件のメッセージ、{{sessions}}セッション',
+  insight_personalized_journey:
+    'あなたのパーソナライズされたコーディングの旅とパターン',
+
+  // Stats
+  insight_stat_messages: 'メッセージ',
+  insight_stat_lines: '行数',
+  insight_stat_files: 'ファイル',
+  insight_stat_days: '日数',
+  insight_stat_msgs_per_day: 'メッセージ/日',
+
+  // Charts
+  insight_active_hours: 'アクティブ時間',
+  insight_morning: '朝',
+  insight_afternoon: '午後',
+  insight_evening: '夕方',
+  insight_night: '夜間',
+  insight_time_morning: '06:00 - 12:00',
+  insight_time_afternoon: '12:00 - 18:00',
+  insight_time_evening: '18:00 - 22:00',
+  insight_time_night: '22:00 - 06:00',
+  insight_activity_heatmap: 'アクティビティヒートマップ',
+  insight_heatmap_subtitle: '過去1年のアクティビティ',
+  insight_less: '少',
+  insight_more: '多',
+  insight_activities: 'アクティビティ',
+  insight_month_jan: '1月',
+  insight_month_feb: '2月',
+  insight_month_mar: '3月',
+  insight_month_apr: '4月',
+  insight_month_may: '5月',
+  insight_month_jun: '6月',
+  insight_month_jul: '7月',
+  insight_month_aug: '8月',
+  insight_month_sep: '9月',
+  insight_month_oct: '10月',
+  insight_month_nov: '11月',
+  insight_month_dec: '12月',
+
+  // Qualitative - At a Glance
+  insight_at_a_glance: '概要',
+  insight_whats_working: 'うまくいっていること：',
+  insight_whats_hindering: '妨げていること：',
+  insight_quick_wins: 'すぐ試せる改善：',
+  insight_ambitious_workflows: '野心的なワークフロー：',
+  insight_see_more_wins: 'あなたの素晴らしい成果 →',
+  insight_see_more_friction: '問題が起きているところ →',
+  insight_see_more_features: '試すべき機能 →',
+  insight_see_more_horizon: '将来の展望 →',
+
+  // Qualitative - Navigation TOC
+  insight_nav_work: 'あなたが取り組む領域',
+  insight_nav_usage: 'Qwen Code の使い方',
+  insight_nav_wins: '素晴らしい成果',
+  insight_nav_friction: '問題が起きているところ',
+  insight_nav_features: '試すべき機能',
+  insight_nav_patterns: '新しい使い方',
+  insight_nav_horizon: '将来の展望',
+
+  // Qualitative - Project Areas
+  insight_what_you_work_on: 'あなたが取り組む領域',
+  insight_sessions_count: '〜{{count}}セッション',
+  insight_what_you_wanted: 'あなたの目標',
+  insight_top_tools_used: 'よく使うツール',
+
+  // Qualitative - Interaction Style
+  insight_how_you_use: 'Qwen Code の使い方',
+  insight_key_pattern: 'キーパターン：',
+
+  // Qualitative - Impressive Workflows
+  insight_impressive_things: 'あなたの素晴らしい成果',
+  insight_what_helped_most: '最も役立った能力',
+  insight_outcomes: '成果',
+
+  // Qualitative - Friction Points
+  insight_where_things_go_wrong: '問題が起きているところ',
+  insight_primary_friction_types: '主な摩擦タイプ',
+  insight_inferred_satisfaction: '推定満足度',
+  insight_unclear: '不明',
+
+  // Qualitative - Improvements
+  insight_features_to_try: '試すべき Qwen Code の機能',
+  insight_suggested_qwen_md: '推奨 QWEN.md 追加項目',
+  insight_qwen_md_hint: 'Qwen Code にコピーすると QWEN.md に追加されます。',
+  insight_copy_all_checked: 'チェック済みを全コピー ({{count}})',
+  insight_copied_all: '全コピー済み！',
+  insight_why_for_you: 'あなたにとっての理由：',
+  insight_features_hint: 'Qwen Code にコピーすると自動設定されます。',
+  insight_new_ways_to_use: 'Qwen Code の新しい使い方',
+  insight_patterns_hint: 'Qwen Code にコピーすると手順を案内します。',
+  insight_paste_into_qwen: 'Qwen Code に貼り付け：',
+
+  // Qualitative - Future Opportunities
+  insight_on_the_horizon: '将来の展望',
+  insight_getting_started: '始め方：',
+
+  // Buttons & UI
+  insight_no_data: 'インサイトデータがありません',
+  insight_export_card: 'カードをエクスポート',
+  insight_light_theme: 'ライトテーマ',
+  insight_dark_theme: 'ダークテーマ',
+  insight_export_not_available: 'エクスポート機能は利用できません。',
+  insight_export_failed:
+    'カードのエクスポートに失敗しました。もう一度お試しください。',
+  insight_copy: 'コピー',
+  insight_copied: 'コピー済み！',
+
+  // Share Card
+  insight_share_sessions: 'セッション',
+  insight_share_lines_changed: '行変更',
+  insight_share_streak: '連続日数',
+  insight_share_best_streak: '最長連続日数',
+  insight_share_activity: 'アクティビティ · {{days}}アクティブ日数',
+  insight_share_generated: 'Qwen Code で生成 ·',
+  insight_share_github: 'github.com/QwenLM/qwen-code',
+  insight_share_brand: 'qwen.ai',
+
+  // DataProcessor progress messages
+  insight_scanning_chat_history: 'チャット履歴をスキャン中...',
+  insight_crunching_numbers: 'データを処理中',
+  insight_preparing_sessions: 'セッションを準備中...',
+  insight_generating_personalized: 'パーソナライズされたインサイトを生成中...',
+  insight_assembling_report: 'レポートを構成中...',
 };

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -2005,4 +2005,132 @@ export default {
     'Not in plan mode. Use "/plan" to enter plan mode first.',
 
   "Set up Qwen Code's status line UI": "Set up Qwen Code's status line UI",
+
+  'Generating insights in {{language}}...':
+    'Gerando insights em {{language}}...',
+  'Opening insights in your browser: {{path}}':
+    'Abrindo insights no navegador: {{path}}',
+  'Insights generated at: {{path}}. Please open this file in your browser.':
+    'Insights gerados em {{path}}. Abra este arquivo no navegador.',
+
+  // ============================================================================
+  // Insight Report - HTML Report Static Text
+  // ============================================================================
+  // Header
+  insight_title: 'Qwen Code Insights',
+  insight_messages_across_sessions:
+    '{{messages}} mensagens em {{sessions}} sessões',
+  insight_personalized_journey:
+    'Sua jornada de programação personalizada e padrões',
+
+  // Stats
+  insight_stat_messages: 'Mensagens',
+  insight_stat_lines: 'Linhas',
+  insight_stat_files: 'Arquivos',
+  insight_stat_days: 'Dias',
+  insight_stat_msgs_per_day: 'Mens./Dia',
+
+  // Charts
+  insight_active_hours: 'Horas ativas',
+  insight_morning: 'Manhã',
+  insight_afternoon: 'Tarde',
+  insight_evening: 'Noite',
+  insight_night: 'Madrugada',
+  insight_time_morning: '06:00 - 12:00',
+  insight_time_afternoon: '12:00 - 18:00',
+  insight_time_evening: '18:00 - 22:00',
+  insight_time_night: '22:00 - 06:00',
+  insight_activity_heatmap: 'Mapa de calor de atividade',
+  insight_heatmap_subtitle: 'Atividade do último ano',
+  insight_less: 'Menos',
+  insight_more: 'Mais',
+  insight_activities: 'atividades',
+  insight_month_jan: 'Jan',
+  insight_month_feb: 'Fev',
+  insight_month_mar: 'Mar',
+  insight_month_apr: 'Abr',
+  insight_month_may: 'Mai',
+  insight_month_jun: 'Jun',
+  insight_month_jul: 'Jul',
+  insight_month_aug: 'Ago',
+  insight_month_sep: 'Set',
+  insight_month_oct: 'Out',
+  insight_month_nov: 'Nov',
+  insight_month_dec: 'Dez',
+
+  // Qualitative - At a Glance
+  insight_at_a_glance: 'Resumo',
+  insight_whats_working: 'O que está funcionando:',
+  insight_whats_hindering: 'O que está dificultando:',
+  insight_quick_wins: 'Melhorias rápidas:',
+  insight_ambitious_workflows: 'Workflows ambiciosos:',
+  insight_see_more_wins: 'Resultados impressionantes →',
+  insight_see_more_friction: 'Onde as coisas falham →',
+  insight_see_more_features: 'Funcionalidades para experimentar →',
+  insight_see_more_horizon: 'No horizonte →',
+
+  // Qualitative - Navigation TOC
+  insight_nav_work: 'O que você trabalha',
+  insight_nav_usage: 'Como você usa o Qwen Code',
+  insight_nav_wins: 'Resultados impressionantes',
+  insight_nav_friction: 'Onde as coisas falham',
+  insight_nav_features: 'Funcionalidades para experimentar',
+  insight_nav_patterns: 'Novos padrões de uso',
+  insight_nav_horizon: 'No horizonte',
+
+  // Qualitative - Project Areas
+  insight_what_you_work_on: 'O que você trabalha',
+  insight_sessions_count: '~{{count}} sessões',
+  insight_what_you_wanted: 'O que você queria',
+  insight_top_tools_used: 'Ferramentas mais usadas',
+
+  // Qualitative - Interaction Style
+  insight_how_you_use: 'Como você usa o Qwen Code',
+  insight_key_pattern: 'Padrão principal:',
+  insight_impressive_things: 'Resultados impressionantes',
+  insight_what_helped_most: 'O que mais ajudou',
+  insight_outcomes: 'Resultados',
+
+  // Qualitative - Friction Points
+  insight_where_things_go_wrong: 'Onde as coisas falham',
+  insight_primary_friction_types: 'Tipos principais de problemas',
+  insight_inferred_satisfaction: 'Satisfação estimada',
+  insight_unclear: 'Inclaro',
+
+  // Qualitative - Improvements
+  insight_features_to_try: 'Funcionalidades do Qwen Code para experimentar',
+  insight_suggested_qwen_md: 'Adições sugeridas ao QWEN.md',
+  insight_qwen_md_hint: 'Cole no Qwen Code para adicionar ao seu QWEN.md.',
+  insight_copy_all_checked: 'Copiar todos marcados ({{count}})',
+  insight_copied_all: 'Todos copiados!',
+  insight_why_for_you: 'Por que para você:',
+  insight_features_hint: 'Cole no Qwen Code — ele configura automaticamente.',
+  insight_new_ways_to_use: 'Novas formas de usar o Qwen Code',
+  insight_patterns_hint: 'Cole no Qwen Code — ele guiará você.',
+  insight_paste_into_qwen: 'Cole no Qwen Code:',
+  insight_on_the_horizon: 'No horizonte',
+  insight_getting_started: 'Como começar:',
+  insight_no_data: 'Sem dados de insights',
+  insight_export_card: 'Exportar card',
+  insight_light_theme: 'Tema claro',
+  insight_dark_theme: 'Tema escuro',
+  insight_export_not_available: 'Exportação não disponível.',
+  insight_export_failed: 'Falha ao exportar card. Tente novamente.',
+  insight_copy: 'Copiar',
+  insight_copied: 'Copiado!',
+  insight_share_sessions: 'Sessões',
+  insight_share_lines_changed: 'Linhas alteradas',
+  insight_share_streak: 'Sequência',
+  insight_share_best_streak: 'Melhor sequência',
+  insight_share_activity: 'Atividade · {{days}} dias ativos',
+  insight_share_generated: 'Gerado pelo Qwen Code ·',
+  insight_share_github: 'github.com/QwenLM/qwen-code',
+  insight_share_brand: 'qwen.ai',
+
+  // DataProcessor progress messages
+  insight_scanning_chat_history: 'Escaneando histórico de chats...',
+  insight_crunching_numbers: 'Processando dados',
+  insight_preparing_sessions: 'Preparando sessões...',
+  insight_generating_personalized: 'Gerando insights personalizados...',
+  insight_assembling_report: 'Montando relatório...',
 };

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -2012,4 +2012,132 @@ export default {
     'Not in plan mode. Use "/plan" to enter plan mode first.',
 
   "Set up Qwen Code's status line UI": "Set up Qwen Code's status line UI",
+
+  'Generating insights in {{language}}...':
+    'Генерация инсайтов на {{language}}...',
+  'Opening insights in your browser: {{path}}':
+    'Открытие инсайтов в браузере: {{path}}',
+  'Insights generated at: {{path}}. Please open this file in your browser.':
+    'Инсайты созданы в {{path}}. Откройте этот файл в браузере.',
+
+  // ============================================================================
+  // Insight Report - HTML Report Static Text
+  // ============================================================================
+  // Header
+  insight_title: 'Qwen Code Аналитика',
+  insight_messages_across_sessions:
+    '{{messages}} сообщений в {{sessions}} сеансах',
+  insight_personalized_journey:
+    'Ваш персональный путь и паттерны программирования',
+
+  // Stats
+  insight_stat_messages: 'Сообщения',
+  insight_stat_lines: 'Строки',
+  insight_stat_files: 'Файлы',
+  insight_stat_days: 'Дни',
+  insight_stat_msgs_per_day: 'Сообщ./день',
+
+  // Charts
+  insight_active_hours: 'Активные часы',
+  insight_morning: 'Утро',
+  insight_afternoon: 'День',
+  insight_evening: 'Вечер',
+  insight_night: 'Ночь',
+  insight_time_morning: '06:00 - 12:00',
+  insight_time_afternoon: '12:00 - 18:00',
+  insight_time_evening: '18:00 - 22:00',
+  insight_time_night: '22:00 - 06:00',
+  insight_activity_heatmap: 'Тепловая карта активности',
+  insight_heatmap_subtitle: 'Активность за последний год',
+  insight_less: 'Мало',
+  insight_more: 'Много',
+  insight_activities: 'активностей',
+  insight_month_jan: 'Янв',
+  insight_month_feb: 'Фев',
+  insight_month_mar: 'Мар',
+  insight_month_apr: 'Апр',
+  insight_month_may: 'Май',
+  insight_month_jun: 'Июн',
+  insight_month_jul: 'Июл',
+  insight_month_aug: 'Авг',
+  insight_month_sep: 'Сен',
+  insight_month_oct: 'Окт',
+  insight_month_nov: 'Ноя',
+  insight_month_dec: 'Дек',
+
+  // Qualitative - At a Glance
+  insight_at_a_glance: 'Обзор',
+  insight_whats_working: 'Что работает хорошо:',
+  insight_whats_hindering: 'Что мешает вам:',
+  insight_quick_wins: 'Быстрые улучшения:',
+  insight_ambitious_workflows: 'Амбициозные workflows:',
+  insight_see_more_wins: 'Впечатляющие результаты →',
+  insight_see_more_friction: 'Где возникают проблемы →',
+  insight_see_more_features: 'Функции, которые стоит попробовать →',
+  insight_see_more_horizon: 'На горизонте →',
+
+  // Qualitative - Navigation TOC
+  insight_nav_work: 'Чем вы занимаетесь',
+  insight_nav_usage: 'Как вы используете Qwen Code',
+  insight_nav_wins: 'Впечатляющие результаты',
+  insight_nav_friction: 'Где возникают проблемы',
+  insight_nav_features: 'Функции для пробного использования',
+  insight_nav_patterns: 'Новые паттерны использования',
+  insight_nav_horizon: 'На горизонте',
+
+  // Qualitative - Project Areas
+  insight_what_you_work_on: 'Чем вы занимаетесь',
+  insight_sessions_count: '~{{count}} сеансов',
+  insight_what_you_wanted: 'Ваши цели',
+  insight_top_tools_used: 'Популярные инструменты',
+
+  // Qualitative - Interaction Style
+  insight_how_you_use: 'Как вы используете Qwen Code',
+  insight_key_pattern: 'Ключевой паттерн:',
+  insight_impressive_things: 'Впечатляющие результаты',
+  insight_what_helped_most: 'Самые полезные возможности',
+  insight_outcomes: 'Результаты',
+
+  // Qualitative - Friction Points
+  insight_where_things_go_wrong: 'Где возникают проблемы',
+  insight_primary_friction_types: 'Основные типы проблем',
+  insight_inferred_satisfaction: 'Предполагаемое удовлетворение',
+  insight_unclear: 'Неясно',
+
+  // Qualitative - Improvements
+  insight_features_to_try: 'Функции Qwen Code, которые стоит попробовать',
+  insight_suggested_qwen_md: 'Предложения для QWEN.md',
+  insight_qwen_md_hint: 'Скопируйте в Qwen Code, чтобы добавить в QWEN.md.',
+  insight_copy_all_checked: 'Копировать все отмеченные ({{count}})',
+  insight_copied_all: 'Все скопированы!',
+  insight_why_for_you: 'Почему для вас:',
+  insight_features_hint: 'Скопируйте в Qwen Code — он настроит автоматически.',
+  insight_new_ways_to_use: 'Новые способы использования Qwen Code',
+  insight_patterns_hint:
+    'Скопируйте в Qwen Code — он проведёт через настройку.',
+  insight_paste_into_qwen: 'Вставить в Qwen Code:',
+  insight_on_the_horizon: 'На горизонте',
+  insight_getting_started: 'Как начать:',
+  insight_no_data: 'Нет данных для инсайтов',
+  insight_export_card: 'Экспорт карточки',
+  insight_light_theme: 'Светлая тема',
+  insight_dark_theme: 'Тёмная тема',
+  insight_export_not_available: 'Экспорт недоступен.',
+  insight_export_failed:
+    'Не удалось экспортировать карточку. Попробуйте ещё раз.',
+  insight_copy: 'Копировать',
+  insight_copied: 'Скопировано!',
+  insight_share_sessions: 'Сеансы',
+  insight_share_lines_changed: 'Изменено строк',
+  insight_share_streak: 'Серия',
+  insight_share_best_streak: 'Лучшая серия',
+  insight_share_activity: 'Активность · {{days}} активных дней',
+  insight_share_generated: 'Создано Qwen Code ·',
+  insight_share_github: 'github.com/QwenLM/qwen-code',
+  insight_share_brand: 'qwen.ai',
+  insight_scanning_chat_history: 'Сканирование истории чатов...',
+  insight_crunching_numbers: 'Обработка данных',
+  insight_preparing_sessions: 'Подготовка сеансов...',
+  insight_generating_personalized: 'Генерация персонализированных инсайтов...',
+  insight_assembling_report: 'Сборка отчёта...',
 };

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1859,4 +1859,148 @@ export default {
     '未处于计划模式。请先使用 "/plan" 进入计划模式。',
 
   "Set up Qwen Code's status line UI": '配置 Qwen Code 的状态栏',
+
+  // ============================================================================
+  // Insight Report - CLI Messages
+  // ============================================================================
+  'Generating insights...': '正在生成洞察...',
+  'This may take a couple minutes. Sit tight!':
+    '这可能需要几分钟时间，请耐心等待！',
+  'Starting insight generation...': '开始生成洞察...',
+  'Insight report generated successfully!': '洞察报告生成成功！',
+  'Insights ready.': '洞察已就绪。',
+  'Failed to generate insights: {{error}}': '生成洞察失败：{{error}}',
+  'Opening insights in your browser: {{path}}':
+    '正在浏览器中打开洞察：{{path}}',
+  'Insights generated at: {{path}}. Please open this file in your browser.':
+    '洞察已生成于：{{path}}。请在浏览器中打开此文件。',
+  'Generating insights in {{language}}...': '正在使用 {{language}} 生成洞察...',
+
+  // ============================================================================
+  // Insight Report - HTML Report Static Text
+  // ============================================================================
+  // Header
+  insight_title: 'Qwen Code 洞察',
+  insight_messages_across_sessions:
+    '{{messages}} 条消息，共 {{sessions}} 个会话',
+  insight_personalized_journey: '您的个性化编程旅程与模式',
+
+  // Stats
+  insight_stat_messages: '消息',
+  insight_stat_lines: '代码行',
+  insight_stat_files: '文件',
+  insight_stat_days: '天数',
+  insight_stat_msgs_per_day: '日均消息',
+
+  // Charts
+  insight_active_hours: '活跃时段',
+  insight_morning: '上午',
+  insight_afternoon: '下午',
+  insight_evening: '傍晚',
+  insight_night: '夜间',
+  insight_time_morning: '06:00 - 12:00',
+  insight_time_afternoon: '12:00 - 18:00',
+  insight_time_evening: '18:00 - 22:00',
+  insight_time_night: '22:00 - 06:00',
+  insight_activity_heatmap: '活动热力图',
+  insight_heatmap_subtitle: '显示过去一年的活动',
+  insight_less: '较少',
+  insight_more: '较多',
+  insight_activities: '次活动',
+  insight_month_jan: '1月',
+  insight_month_feb: '2月',
+  insight_month_mar: '3月',
+  insight_month_apr: '4月',
+  insight_month_may: '5月',
+  insight_month_jun: '6月',
+  insight_month_jul: '7月',
+  insight_month_aug: '8月',
+  insight_month_sep: '9月',
+  insight_month_oct: '10月',
+  insight_month_nov: '11月',
+  insight_month_dec: '12月',
+
+  // Qualitative - At a Glance
+  insight_at_a_glance: '快速概览',
+  insight_whats_working: '进展顺利的：',
+  insight_whats_hindering: '阻碍你的：',
+  insight_quick_wins: '可以尝试的快速方法：',
+  insight_ambitious_workflows: '雄心勃勃的工作流：',
+  insight_see_more_wins: '你做的令人印象深刻的事 →',
+  insight_see_more_friction: '出现问题的地方 →',
+  insight_see_more_features: '可以尝试的功能 →',
+  insight_see_more_horizon: '未来展望 →',
+
+  // Qualitative - Navigation TOC
+  insight_nav_work: '你的工作内容',
+  insight_nav_usage: '你如何使用 Qwen Code',
+  insight_nav_wins: '令人印象深刻的事',
+  insight_nav_friction: '出现问题的地方',
+  insight_nav_features: '可以尝试的功能',
+  insight_nav_patterns: '新的使用模式',
+  insight_nav_horizon: '未来展望',
+
+  // Qualitative - Project Areas
+  insight_what_you_work_on: '你的工作内容',
+  insight_sessions_count: '约 {{count}} 个会话',
+  insight_what_you_wanted: '你的目标',
+  insight_top_tools_used: '常用工具',
+
+  // Qualitative - Interaction Style
+  insight_how_you_use: '你如何使用 Qwen Code',
+  insight_key_pattern: '关键模式：',
+
+  // Qualitative - Impressive Workflows
+  insight_impressive_things: '你做的令人印象深刻的事',
+  insight_what_helped_most: '最有帮助的（Qwen 的能力）',
+  insight_outcomes: '结果',
+
+  // Qualitative - Friction Points
+  insight_where_things_go_wrong: '出现问题的地方',
+  insight_primary_friction_types: '主要摩擦类型',
+  insight_inferred_satisfaction: '推断满意度（模型估计）',
+  insight_unclear: '不明确',
+
+  // Qualitative - Improvements
+  insight_features_to_try: '可以尝试的 Qwen Code 功能',
+  insight_suggested_qwen_md: '建议的 QWEN.md 补充',
+  insight_qwen_md_hint: '只需将此复制到 Qwen Code 即可添加到你的 QWEN.md。',
+  insight_copy_all_checked: '复制所有已选中 ({{count}})',
+  insight_copied_all: '已全部复制！',
+  insight_why_for_you: '为什么适合你：',
+  insight_features_hint: '只需将此复制到 Qwen Code，它就会为你设置好。',
+  insight_new_ways_to_use: '使用 Qwen Code 的新方式',
+  insight_patterns_hint: '只需将此复制到 Qwen Code，它就会引导你完成。',
+  insight_paste_into_qwen: '粘贴到 Qwen Code：',
+
+  // Qualitative - Future Opportunities
+  insight_on_the_horizon: '未来展望',
+  insight_getting_started: '入门方法：',
+
+  // Buttons & UI
+  insight_no_data: '暂无洞察数据',
+  insight_export_card: '导出卡片',
+  insight_light_theme: '浅色主题',
+  insight_dark_theme: '深色主题',
+  insight_export_not_available: '导出功能不可用。',
+  insight_export_failed: '导出卡片失败，请重试。',
+  insight_copy: '复制',
+  insight_copied: '已复制！',
+
+  // Share Card
+  insight_share_sessions: '会话',
+  insight_share_lines_changed: '代码变更',
+  insight_share_streak: '连续天数',
+  insight_share_best_streak: '最佳连续',
+  insight_share_activity: '活动 · {{days}} 个活跃日',
+  insight_share_generated: '由 Qwen Code 生成 ·',
+  insight_share_github: 'github.com/QwenLM/qwen-code',
+  insight_share_brand: 'qwen.ai',
+
+  // DataProcessor progress messages
+  insight_scanning_chat_history: '正在扫描聊天历史...',
+  insight_crunching_numbers: '正在处理数据',
+  insight_preparing_sessions: '正在准备会话...',
+  insight_generating_personalized: '正在生成个性化洞察...',
+  insight_assembling_report: '正在组装报告...',
 };

--- a/packages/cli/src/services/insight/generators/DataProcessor.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.ts
@@ -34,13 +34,17 @@ import {
   type Config,
   type ChatRecord,
 } from '@qwen-code/qwen-code-core';
+import { t } from '../../../i18n/index.js';
 
 const logger = createDebugLogger('DataProcessor');
 
 const CONCURRENCY_LIMIT = 4;
 
 export class DataProcessor {
-  constructor(private config: Config) {}
+  constructor(
+    private config: Config,
+    private outputLanguage: string = 'English',
+  ) {}
 
   // Helper function to format date as YYYY-MM-DD
   private formatDate(date: Date): string {
@@ -193,7 +197,7 @@ export class DataProcessor {
     };
 
     const sessionText = this.formatRecordsForAnalysis(records);
-    const prompt = `${getInsightPrompt('analysis')}\n\nSESSION:\n${sessionText}`;
+    const prompt = `${getInsightPrompt('analysis', this.outputLanguage)}\n\nSESSION:\n${sessionText}`;
 
     try {
       const result = await this.config.getBaseLlmClient().generateJson({
@@ -284,20 +288,20 @@ export class DataProcessor {
     facetsOutputDir?: string,
     onProgress?: InsightProgressCallback,
   ): Promise<InsightData> {
-    if (onProgress) onProgress('Scanning chat history...', 0);
+    if (onProgress) onProgress(t('insight_scanning_chat_history'), 0);
     const allChatFiles = await this.scanChatFiles(baseDir);
 
-    if (onProgress) onProgress('Crunching the numbers', 10);
+    if (onProgress) onProgress(t('insight_crunching_numbers'), 10);
     const metrics = await this.generateMetrics(allChatFiles, onProgress);
 
-    if (onProgress) onProgress('Preparing sessions...', 20);
+    if (onProgress) onProgress(t('insight_preparing_sessions'), 20);
     const facets = await this.generateFacets(
       allChatFiles,
       facetsOutputDir,
       onProgress,
     );
 
-    if (onProgress) onProgress('Generating personalized insights...', 80);
+    if (onProgress) onProgress(t('insight_generating_personalized'), 80);
     const qualitative = await this.generateQualitativeInsights(metrics, facets);
 
     // Aggregate satisfaction, friction, success and outcome data from facets
@@ -309,7 +313,7 @@ export class DataProcessor {
       goalsAgg,
     } = this.aggregateFacetsData(facets);
 
-    if (onProgress) onProgress('Assembling report...', 100);
+    if (onProgress) onProgress(t('insight_assembling_report'), 100);
 
     return {
       ...metrics,
@@ -385,11 +389,14 @@ export class DataProcessor {
 
     const commonData = this.prepareCommonPromptData(metrics, facets);
 
+    // Language instruction for LLM to generate content in user's preferred language
+    const languageInstruction = `\n\nIMPORTANT: You MUST respond in ${this.outputLanguage}. All narrative text, descriptions, recommendations, and analysis MUST be in ${this.outputLanguage}. Keep code snippets, commands, and technical identifiers in their original form.`;
+
     const generate = async <T>(
       promptTemplate: string,
       schema: Record<string, unknown>,
     ): Promise<T | undefined> => {
-      const prompt = `${promptTemplate}\n\n${commonData}`;
+      const prompt = `${promptTemplate}\n\n${commonData}${languageInstruction}`;
       try {
         const result = await this.config.getBaseLlmClient().generateJson({
           model: this.config.getModel(),
@@ -594,49 +601,49 @@ export class DataProcessor {
       ] = await Promise.all([
         limit(() =>
           generate<InsightImpressiveWorkflows>(
-            getInsightPrompt('impressive_workflows'),
+            getInsightPrompt('impressive_workflows', this.outputLanguage),
             schemaImpressiveWorkflows,
           ),
         ),
         limit(() =>
           generate<InsightProjectAreas>(
-            getInsightPrompt('project_areas'),
+            getInsightPrompt('project_areas', this.outputLanguage),
             schemaProjectAreas,
           ),
         ),
         limit(() =>
           generate<InsightFutureOpportunities>(
-            getInsightPrompt('future_opportunities'),
+            getInsightPrompt('future_opportunities', this.outputLanguage),
             schemaFutureOpportunities,
           ),
         ),
         limit(() =>
           generate<InsightFrictionPoints>(
-            getInsightPrompt('friction_points'),
+            getInsightPrompt('friction_points', this.outputLanguage),
             schemaFrictionPoints,
           ),
         ),
         limit(() =>
           generate<InsightMemorableMoment>(
-            getInsightPrompt('memorable_moment'),
+            getInsightPrompt('memorable_moment', this.outputLanguage),
             schemaMemorableMoment,
           ),
         ),
         limit(() =>
           generate<InsightImprovements>(
-            getInsightPrompt('improvements'),
+            getInsightPrompt('improvements', this.outputLanguage),
             schemaImprovements,
           ),
         ),
         limit(() =>
           generate<InsightInteractionStyle>(
-            getInsightPrompt('interaction_style'),
+            getInsightPrompt('interaction_style', this.outputLanguage),
             schemaInteractionStyle,
           ),
         ),
         limit(() =>
           generate<InsightAtAGlance>(
-            getInsightPrompt('at_a_glance'),
+            getInsightPrompt('at_a_glance', this.outputLanguage),
             schemaAtAGlance,
           ),
         ),

--- a/packages/cli/src/services/insight/generators/DataProcessor.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.ts
@@ -389,14 +389,11 @@ export class DataProcessor {
 
     const commonData = this.prepareCommonPromptData(metrics, facets);
 
-    // Language instruction for LLM to generate content in user's preferred language
-    const languageInstruction = `\n\nIMPORTANT: You MUST respond in ${this.outputLanguage}. All narrative text, descriptions, recommendations, and analysis MUST be in ${this.outputLanguage}. Keep code snippets, commands, and technical identifiers in their original form.`;
-
     const generate = async <T>(
       promptTemplate: string,
       schema: Record<string, unknown>,
     ): Promise<T | undefined> => {
-      const prompt = `${promptTemplate}\n\n${commonData}${languageInstruction}`;
+      const prompt = `${promptTemplate}\n\n${commonData}`;
       try {
         const result = await this.config.getBaseLlmClient().generateJson({
           model: this.config.getModel(),

--- a/packages/cli/src/services/insight/generators/StaticInsightGenerator.test.ts
+++ b/packages/cli/src/services/insight/generators/StaticInsightGenerator.test.ts
@@ -80,7 +80,7 @@ describe('StaticInsightGenerator', () => {
       facetsDir,
       undefined,
     );
-    expect(renderInsightHTML).toHaveBeenCalledWith({});
+    expect(renderInsightHTML).toHaveBeenCalledWith({ language: 'en' }, 'en');
     expect(mockedFs.writeFile).toHaveBeenCalledWith(
       expectedOutputPath,
       '<html>ok</html>',

--- a/packages/cli/src/services/insight/generators/StaticInsightGenerator.ts
+++ b/packages/cli/src/services/insight/generators/StaticInsightGenerator.ts
@@ -18,10 +18,16 @@ import { updateSymlink, Storage, type Config } from '@qwen-code/qwen-code-core';
 export class StaticInsightGenerator {
   private dataProcessor: DataProcessor;
   private templateRenderer: TemplateRenderer;
+  private uiLanguage: string;
 
-  constructor(config: Config) {
-    this.dataProcessor = new DataProcessor(config);
+  constructor(
+    config: Config,
+    uiLanguage: string = 'en',
+    outputLanguage: string = 'English',
+  ) {
+    this.dataProcessor = new DataProcessor(config, outputLanguage);
     this.templateRenderer = new TemplateRenderer();
+    this.uiLanguage = uiLanguage;
   }
 
   // Ensure the output directory exists
@@ -76,8 +82,14 @@ export class StaticInsightGenerator {
       onProgress,
     );
 
+    // Set the language for the report
+    insights.language = this.uiLanguage;
+
     // Render HTML
-    const html = await this.templateRenderer.renderInsightHTML(insights);
+    const html = await this.templateRenderer.renderInsightHTML(
+      insights,
+      this.uiLanguage,
+    );
 
     // Generate timestamped output path
     const outputPath = await this.generateOutputPath(outputDir);

--- a/packages/cli/src/services/insight/generators/TemplateRenderer.ts
+++ b/packages/cli/src/services/insight/generators/TemplateRenderer.ts
@@ -6,16 +6,164 @@
 
 import { INSIGHT_JS, INSIGHT_CSS } from '@qwen-code/web-templates';
 import type { InsightData } from '../types/StaticInsightTypes.js';
+import { setLanguageAsync, t } from '../../../i18n/index.js';
+import type { SupportedLanguage } from '../../../i18n/index.js';
+
+// All insight-related translation keys that need to be embedded in the HTML report
+const INSIGHT_TRANSLATION_KEYS = [
+  // Header
+  'insight_title',
+  'insight_messages_across_sessions',
+  'insight_personalized_journey',
+
+  // Stats
+  'insight_stat_messages',
+  'insight_stat_lines',
+  'insight_stat_files',
+  'insight_stat_days',
+  'insight_stat_msgs_per_day',
+
+  // Charts
+  'insight_active_hours',
+  'insight_morning',
+  'insight_afternoon',
+  'insight_evening',
+  'insight_night',
+  'insight_time_morning',
+  'insight_time_afternoon',
+  'insight_time_evening',
+  'insight_time_night',
+  'insight_activity_heatmap',
+  'insight_heatmap_subtitle',
+  'insight_less',
+  'insight_more',
+  'insight_activities',
+  'insight_month_jan',
+  'insight_month_feb',
+  'insight_month_mar',
+  'insight_month_apr',
+  'insight_month_may',
+  'insight_month_jun',
+  'insight_month_jul',
+  'insight_month_aug',
+  'insight_month_sep',
+  'insight_month_oct',
+  'insight_month_nov',
+  'insight_month_dec',
+
+  // Qualitative - At a Glance
+  'insight_at_a_glance',
+  'insight_whats_working',
+  'insight_whats_hindering',
+  'insight_quick_wins',
+  'insight_ambitious_workflows',
+  'insight_see_more_wins',
+  'insight_see_more_friction',
+  'insight_see_more_features',
+  'insight_see_more_horizon',
+
+  // Qualitative - Navigation TOC
+  'insight_nav_work',
+  'insight_nav_usage',
+  'insight_nav_wins',
+  'insight_nav_friction',
+  'insight_nav_features',
+  'insight_nav_patterns',
+  'insight_nav_horizon',
+
+  // Qualitative - Project Areas
+  'insight_what_you_work_on',
+  'insight_sessions_count',
+  'insight_what_you_wanted',
+  'insight_top_tools_used',
+
+  // Qualitative - Interaction Style
+  'insight_how_you_use',
+  'insight_key_pattern',
+
+  // Qualitative - Impressive Workflows
+  'insight_impressive_things',
+  'insight_what_helped_most',
+  'insight_outcomes',
+
+  // Qualitative - Friction Points
+  'insight_where_things_go_wrong',
+  'insight_primary_friction_types',
+  'insight_inferred_satisfaction',
+  'insight_unclear',
+
+  // Qualitative - Improvements
+  'insight_features_to_try',
+  'insight_suggested_qwen_md',
+  'insight_qwen_md_hint',
+  'insight_copy_all_checked',
+  'insight_copied_all',
+  'insight_why_for_you',
+  'insight_features_hint',
+  'insight_new_ways_to_use',
+  'insight_patterns_hint',
+  'insight_paste_into_qwen',
+
+  // Qualitative - Future Opportunities
+  'insight_on_the_horizon',
+  'insight_getting_started',
+
+  // Buttons & UI
+  'insight_no_data',
+  'insight_export_card',
+  'insight_light_theme',
+  'insight_dark_theme',
+  'insight_export_not_available',
+  'insight_export_failed',
+  'insight_copy',
+  'insight_copied',
+
+  // Share Card
+  'insight_share_sessions',
+  'insight_share_lines_changed',
+  'insight_share_streak',
+  'insight_share_best_streak',
+  'insight_share_activity',
+  'insight_share_generated',
+  'insight_share_github',
+  'insight_share_brand',
+];
+
+/**
+ * Builds a translation dictionary for the given language by loading
+ * translations and extracting only the insight-related keys.
+ */
+async function buildInsightTranslations(
+  language: string,
+): Promise<Record<string, string>> {
+  // Load translations for the target language
+  await setLanguageAsync(language as SupportedLanguage);
+
+  const dict: Record<string, string> = {};
+  for (const key of INSIGHT_TRANSLATION_KEYS) {
+    const value = t(key);
+    // Only include if translation differs from key (i.e., actually translated)
+    // or if it's a known key (value === key means English fallback)
+    dict[key] = value;
+  }
+  return dict;
+}
 
 export class TemplateRenderer {
   // Render the complete HTML file
-  async renderInsightHTML(insights: InsightData): Promise<string> {
+  async renderInsightHTML(
+    insights: InsightData,
+    language: string = 'en',
+  ): Promise<string> {
+    // Build translations dictionary for the target language
+    const translations = await buildInsightTranslations(language);
+
     const html = `<!doctype html>
-<html lang="en">
+<html lang="${language}">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Qwen Code Insights</title>
+    <title>${translations['insight_title'] || 'Qwen Code Insights'}</title>
     <style>
       ${INSIGHT_CSS}
     </style>
@@ -38,6 +186,8 @@ export class TemplateRenderer {
     <!-- Application Data -->
     <script>
       window.INSIGHT_DATA = ${JSON.stringify(insights)};
+      window.INSIGHT_LANGUAGE = ${JSON.stringify(language)};
+      window.INSIGHT_TRANSLATIONS = ${JSON.stringify(translations)};
     </script>
 
     <!-- App Script -->

--- a/packages/cli/src/services/insight/types/StaticInsightTypes.ts
+++ b/packages/cli/src/services/insight/types/StaticInsightTypes.ts
@@ -31,6 +31,8 @@ export interface InsightData {
   primarySuccess?: Record<string, number>;
   outcomes?: Record<string, number>;
   topGoals?: Record<string, number>;
+  /** The UI language code used for localizing the HTML report (e.g., 'en', 'zh', 'ja'). */
+  language?: string;
 }
 
 export interface StreakData {

--- a/packages/cli/src/ui/commands/insightCommand.ts
+++ b/packages/cli/src/ui/commands/insightCommand.ts
@@ -8,10 +8,11 @@ import type { CommandContext, SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
 import { MessageType } from '../types.js';
 import type { HistoryItemInsightProgress } from '../types.js';
-import { t } from '../../i18n/index.js';
+import { t, getCurrentLanguage } from '../../i18n/index.js';
 import { join } from 'path';
 import { StaticInsightGenerator } from '../../services/insight/generators/StaticInsightGenerator.js';
 import { createDebugLogger, Storage } from '@qwen-code/qwen-code-core';
+import { resolveOutputLanguage } from '../../utils/languageUtils.js';
 import open from 'open';
 
 const logger = createDebugLogger('DataProcessor');
@@ -32,8 +33,28 @@ export const insightCommand: SlashCommand = {
       if (!context.services.config) {
         throw new Error('Config service is not available');
       }
+
+      // Get user's language settings
+      const uiLanguage = getCurrentLanguage();
+      const outputLanguageSetting =
+        context.services.settings?.merged?.general?.outputLanguage;
+      const outputLanguage = resolveOutputLanguage(outputLanguageSetting);
+
+      // Display language-aware message
+      context.ui.addItem(
+        {
+          type: MessageType.INFO,
+          text: t('Generating insights in {{language}}...', {
+            language: outputLanguage,
+          }),
+        },
+        Date.now(),
+      );
+
       const insightGenerator = new StaticInsightGenerator(
         context.services.config,
+        uiLanguage,
+        outputLanguage,
       );
 
       const updateProgress = (
@@ -51,14 +72,6 @@ export const insightCommand: SlashCommand = {
         };
         context.ui.setPendingItem(progressItem);
       };
-
-      context.ui.addItem(
-        {
-          type: MessageType.INFO,
-          text: t('This may take a couple minutes. Sit tight!'),
-        },
-        Date.now(),
-      );
 
       // Initial progress
       updateProgress(t('Starting insight generation...'), 0);

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -1096,8 +1096,16 @@ Call respond_in_schema function with A VALID JSON OBJECT as argument:
 /**
  * Get an insight analysis prompt by type.
  * @param type - The type of insight prompt to retrieve
+ * @param language - Optional language to instruct the LLM to respond in
  * @returns The prompt string for the specified type
  */
-export function getInsightPrompt(type: InsightPromptType): string {
-  return INSIGHT_PROMPTS[type];
+export function getInsightPrompt(
+  type: InsightPromptType,
+  language?: string,
+): string {
+  const prompt = INSIGHT_PROMPTS[type];
+  if (language) {
+    return `${prompt}\n\nIMPORTANT: You MUST respond in ${language}. All narrative text, descriptions, recommendations, and analysis MUST be in ${language}. Keep code snippets, commands, and technical identifiers in their original form.`;
+  }
+  return prompt;
 }

--- a/packages/web-templates/src/insight/src/App.tsx
+++ b/packages/web-templates/src/insight/src/App.tsx
@@ -15,6 +15,7 @@ import {
 import { ShareCard, type Theme } from './ShareCard';
 import './styles.css';
 import type { InsightData } from './types';
+import { t } from './i18n';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 
@@ -26,7 +27,7 @@ function InsightApp({ data }: { data: InsightData }) {
   const performExport = async () => {
     const card = document.getElementById('share-card');
     if (!card || !window.html2canvas) {
-      alert('Export functionality is not available.');
+      alert(t('insight_export_not_available'));
       return;
     }
 
@@ -55,7 +56,7 @@ function InsightApp({ data }: { data: InsightData }) {
       link.click();
     } catch (error) {
       console.error('Export card error:', error);
-      alert('Failed to export card. Please try again.');
+      alert(t('insight_export_failed'));
     }
   };
 
@@ -78,9 +79,7 @@ function InsightApp({ data }: { data: InsightData }) {
 
   if (!data) {
     return (
-      <div className="text-center text-slate-600">
-        No insight data available
-      </div>
+      <div className="text-center text-slate-600">{t('insight_no_data')}</div>
     );
   }
 
@@ -102,11 +101,14 @@ function InsightApp({ data }: { data: InsightData }) {
       <header className="insights-header">
         <div className="header-content">
           <div className="header-title-section">
-            <h1 className="header-title">Qwen Code Insights</h1>
+            <h1 className="header-title">{t('insight_title')}</h1>
             <p className="header-subtitle">
               {data.totalMessages
-                ? `${data.totalMessages.toLocaleString()} messages across ${data.totalSessions?.toLocaleString()} sessions`
-                : 'Your personalized coding journey and patterns'}
+                ? t('insight_messages_across_sessions', {
+                    messages: data.totalMessages.toLocaleString(),
+                    sessions: data.totalSessions?.toLocaleString() ?? '0',
+                  })
+                : t('insight_personalized_journey')}
               {dateRangeStr && ` · ${dateRangeStr}`}
             </p>
           </div>
@@ -205,7 +207,7 @@ function ExportCardButton({ onExport }: { onExport: (theme: Theme) => void }) {
           <polyline points="16 6 12 2 8 6" />
           <line x1="12" y1="2" x2="12" y2="15" />
         </svg>
-        <span>Export Card</span>
+        <span>{t('insight_export_card')}</span>
         <svg
           width="12"
           height="12"
@@ -247,7 +249,7 @@ function ExportCardButton({ onExport }: { onExport: (theme: Theme) => void }) {
               <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
               <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
             </svg>
-            <span>Light Theme</span>
+            <span>{t('insight_light_theme')}</span>
           </button>
           <button
             className="export-dropdown-item"
@@ -265,7 +267,7 @@ function ExportCardButton({ onExport }: { onExport: (theme: Theme) => void }) {
             >
               <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
             </svg>
-            <span>Dark Theme</span>
+            <span>{t('insight_dark_theme')}</span>
           </button>
         </div>
       )}

--- a/packages/web-templates/src/insight/src/App.tsx
+++ b/packages/web-templates/src/insight/src/App.tsx
@@ -15,7 +15,7 @@ import {
 import { ShareCard, type Theme } from './ShareCard';
 import './styles.css';
 import type { InsightData } from './types';
-import { t } from './i18n';
+import { ti } from './i18n';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 
@@ -27,7 +27,7 @@ function InsightApp({ data }: { data: InsightData }) {
   const performExport = async () => {
     const card = document.getElementById('share-card');
     if (!card || !window.html2canvas) {
-      alert(t('insight_export_not_available'));
+      alert(ti('insight_export_not_available'));
       return;
     }
 
@@ -56,7 +56,7 @@ function InsightApp({ data }: { data: InsightData }) {
       link.click();
     } catch (error) {
       console.error('Export card error:', error);
-      alert(t('insight_export_failed'));
+      alert(ti('insight_export_failed'));
     }
   };
 
@@ -79,7 +79,7 @@ function InsightApp({ data }: { data: InsightData }) {
 
   if (!data) {
     return (
-      <div className="text-center text-slate-600">{t('insight_no_data')}</div>
+      <div className="text-center text-slate-600">{ti('insight_no_data')}</div>
     );
   }
 
@@ -101,14 +101,14 @@ function InsightApp({ data }: { data: InsightData }) {
       <header className="insights-header">
         <div className="header-content">
           <div className="header-title-section">
-            <h1 className="header-title">{t('insight_title')}</h1>
+            <h1 className="header-title">{ti('insight_title')}</h1>
             <p className="header-subtitle">
               {data.totalMessages
-                ? t('insight_messages_across_sessions', {
+                ? ti('insight_messages_across_sessions', {
                     messages: data.totalMessages.toLocaleString(),
                     sessions: data.totalSessions?.toLocaleString() ?? '0',
                   })
-                : t('insight_personalized_journey')}
+                : ti('insight_personalized_journey')}
               {dateRangeStr && ` · ${dateRangeStr}`}
             </p>
           </div>
@@ -207,7 +207,7 @@ function ExportCardButton({ onExport }: { onExport: (theme: Theme) => void }) {
           <polyline points="16 6 12 2 8 6" />
           <line x1="12" y1="2" x2="12" y2="15" />
         </svg>
-        <span>{t('insight_export_card')}</span>
+        <span>{ti('insight_export_card')}</span>
         <svg
           width="12"
           height="12"
@@ -249,7 +249,7 @@ function ExportCardButton({ onExport }: { onExport: (theme: Theme) => void }) {
               <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
               <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
             </svg>
-            <span>{t('insight_light_theme')}</span>
+            <span>{ti('insight_light_theme')}</span>
           </button>
           <button
             className="export-dropdown-item"
@@ -267,7 +267,7 @@ function ExportCardButton({ onExport }: { onExport: (theme: Theme) => void }) {
             >
               <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
             </svg>
-            <span>{t('insight_dark_theme')}</span>
+            <span>{ti('insight_dark_theme')}</span>
           </button>
         </div>
       )}

--- a/packages/web-templates/src/insight/src/Charts.tsx
+++ b/packages/web-templates/src/insight/src/Charts.tsx
@@ -1,4 +1,5 @@
 import type { InsightData } from './types';
+import { ti } from './i18n';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
@@ -36,26 +37,26 @@ export function ActiveHoursChart({
 }) {
   const phases = [
     {
-      label: 'Morning',
-      time: '06:00 - 12:00',
+      label: ti('insight_morning'),
+      time: ti('insight_time_morning'),
       hours: [6, 7, 8, 9, 10, 11],
       color: '#fbbf24', // amber-400
     },
     {
-      label: 'Afternoon',
-      time: '12:00 - 18:00',
+      label: ti('insight_afternoon'),
+      time: ti('insight_time_afternoon'),
       hours: [12, 13, 14, 15, 16, 17],
       color: '#0ea5e9', // sky-500
     },
     {
-      label: 'Evening',
-      time: '18:00 - 22:00',
+      label: ti('insight_evening'),
+      time: ti('insight_time_evening'),
       hours: [18, 19, 20, 21],
       color: '#6366f1', // indigo-500
     },
     {
-      label: 'Night',
-      time: '22:00 - 06:00',
+      label: ti('insight_night'),
+      time: ti('insight_time_night'),
       hours: [22, 23, 0, 1, 2, 3, 4, 5],
       color: '#475569', // slate-600
     },
@@ -74,7 +75,7 @@ export function ActiveHoursChart({
   return (
     <div className={`${cardClass} h-full flex flex-col min-h-[320px]`}>
       <div className="flex items-center justify-between mb-4">
-        <h3 className={sectionTitleClass}>Active Hours</h3>
+        <h3 className={sectionTitleClass}>{ti('insight_active_hours')}</h3>
       </div>
       <div className="flex-1 flex flex-col justify-center gap-4">
         {data.map((item) => (
@@ -128,8 +129,10 @@ export function HeatmapSection({
   return (
     <div className={`${cardClass} mt-4 md:mt-6`}>
       <div className="mb-3">
-        <h3 className={sectionTitleClass}>Activity Heatmap</h3>
-        <p className="text-xs text-slate-500">Showing past year of activity</p>
+        <h3 className={sectionTitleClass}>{ti('insight_activity_heatmap')}</h3>
+        <p className="text-xs text-slate-500">
+          {ti('insight_heatmap_subtitle')}
+        </p>
       </div>
       <div className="heatmap-container">
         <div className="min-w-[720px] rounded-xl bg-white/70">
@@ -180,18 +183,18 @@ function ActivityHeatmap({
   const startY = 20;
 
   const months = [
-    'Jan',
-    'Feb',
-    'Mar',
-    'Apr',
-    'May',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Oct',
-    'Nov',
-    'Dec',
+    ti('insight_month_jan'),
+    ti('insight_month_feb'),
+    ti('insight_month_mar'),
+    ti('insight_month_apr'),
+    ti('insight_month_may'),
+    ti('insight_month_jun'),
+    ti('insight_month_jul'),
+    ti('insight_month_aug'),
+    ti('insight_month_sep'),
+    ti('insight_month_oct'),
+    ti('insight_month_nov'),
+    ti('insight_month_dec'),
   ];
 
   // Calculate start day of week (0 = Sunday, 1 = Monday, etc.)
@@ -260,7 +263,7 @@ function ActivityHeatmap({
             data-count={value}
           >
             <title>
-              {dateKey}: {value} activities
+              {dateKey}: {value} {ti('insight_activities')}
             </title>
           </rect>
         );
@@ -282,7 +285,7 @@ function HeatmapLegend() {
 
   return (
     <div className="flex items-center gap-2 mt-4">
-      <span className="text-xs text-slate-500">Less</span>
+      <span className="text-xs text-slate-500">{ti('insight_less')}</span>
       {colors.map((color, index) => (
         <span
           key={index}
@@ -294,7 +297,7 @@ function HeatmapLegend() {
           }}
         />
       ))}
-      <span className="text-xs text-slate-500">More</span>
+      <span className="text-xs text-slate-500">{ti('insight_more')}</span>
     </div>
   );
 }

--- a/packages/web-templates/src/insight/src/Components.tsx
+++ b/packages/web-templates/src/insight/src/Components.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 import { useState } from 'react';
+import { ti } from './i18n';
 
 // Simple Markdown Parser Component
 export function MarkdownText({ children }: { children: string }) {
@@ -21,13 +22,7 @@ export function MarkdownText({ children }: { children: string }) {
   );
 }
 
-export function CopyButton({
-  text,
-  label = 'Copy',
-}: {
-  text: string;
-  label?: string;
-}) {
+export function CopyButton({ text, label }: { text: string; label?: string }) {
   const [copied, setCopied] = useState(false);
 
   const handleCopy = () => {
@@ -39,7 +34,7 @@ export function CopyButton({
 
   return (
     <button className="copy-btn" onClick={handleCopy}>
-      {copied ? 'Copied!' : label}
+      {copied ? ti('insight_copied') : (label ?? ti('insight_copy'))}
     </button>
   );
 }

--- a/packages/web-templates/src/insight/src/Header.tsx
+++ b/packages/web-templates/src/insight/src/Header.tsx
@@ -1,8 +1,9 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 import type { InsightData } from './types';
+import { ti } from './i18n';
 
-// Header Component
+// Header component
 export function Header({
   data,
   dateRangeStr,
@@ -15,12 +16,15 @@ export function Header({
   return (
     <header className="mb-8 space-y-3 text-center">
       <h1 className="text-3xl font-semibold text-slate-900 md:text-4xl">
-        Qwen Code Insights
+        {ti('insight_title')}
       </h1>
       <p className="text-sm text-slate-600">
         {totalMessages
-          ? `${totalMessages} messages across ${totalSessions} sessions`
-          : 'Your personalized coding journey and patterns'}
+          ? ti('insight_messages_across_sessions', {
+              messages: String(totalMessages),
+              sessions: String(totalSessions),
+            })
+          : ti('insight_personalized_journey')}
         {dateRangeStr && ` | ${dateRangeStr}`}
       </p>
     </header>
@@ -33,8 +37,6 @@ export function StatsRow({ data }: { data: InsightData }) {
     totalLinesAdded = 0,
     totalLinesRemoved = 0,
     totalFiles = 0,
-    // totalSessions = 0,
-    // totalHours = 0,
   } = data;
 
   const heatmapKeys = Object.keys(data.heatmap || {});
@@ -54,25 +56,25 @@ export function StatsRow({ data }: { data: InsightData }) {
     <div className="stats-row">
       <div className="stat">
         <div className="stat-value">{totalMessages}</div>
-        <div className="stat-label">Messages</div>
+        <div className="stat-label">{ti('insight_stat_messages')}</div>
       </div>
       <div className="stat">
         <div className="stat-value">
           +{totalLinesAdded}/-{totalLinesRemoved}
         </div>
-        <div className="stat-label">Lines</div>
+        <div className="stat-label">{ti('insight_stat_lines')}</div>
       </div>
       <div className="stat">
         <div className="stat-value">{totalFiles}</div>
-        <div className="stat-label">Files</div>
+        <div className="stat-label">{ti('insight_stat_files')}</div>
       </div>
       <div className="stat">
         <div className="stat-value">{daysSpan}</div>
-        <div className="stat-label">Days</div>
+        <div className="stat-label">{ti('insight_stat_days')}</div>
       </div>
       <div className="stat">
         <div className="stat-value">{msgsPerDay}</div>
-        <div className="stat-label">Msgs/Day</div>
+        <div className="stat-label">{ti('insight_stat_msgs_per_day')}</div>
       </div>
     </div>
   );

--- a/packages/web-templates/src/insight/src/Qualitative.tsx
+++ b/packages/web-templates/src/insight/src/Qualitative.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { DashboardCards, HeatmapSection } from './Charts';
 import type { InsightData, QualitativeData } from './types';
 import { CopyButton, MarkdownText } from './Components';
+import { t } from './i18n';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 
@@ -16,34 +17,34 @@ export function AtAGlance({ qualitative }: { qualitative: QualitativeData }) {
 
   return (
     <div className="at-a-glance">
-      <div className="glance-title">At a Glance</div>
+      <div className="glance-title">{t('insight_at_a_glance')}</div>
       <div className="glance-sections">
         <div className="glance-section">
-          <strong>What&apos;s working:</strong>{' '}
+          <strong>{t('insight_whats_working')}</strong>{' '}
           <MarkdownText>{atAGlance.whats_working}</MarkdownText>
           <a href="#section-wins" className="see-more">
-            Impressive Things You Did →
+            {t('insight_see_more_wins')}
           </a>
         </div>
         <div className="glance-section">
-          <strong>What&apos;s hindering you:</strong>{' '}
+          <strong>{t('insight_whats_hindering')}</strong>{' '}
           <MarkdownText>{atAGlance.whats_hindering}</MarkdownText>
           <a href="#section-friction" className="see-more">
-            Where Things Go Wrong →
+            {t('insight_see_more_friction')}
           </a>
         </div>
         <div className="glance-section">
-          <strong>Quick wins to try:</strong>{' '}
+          <strong>{t('insight_quick_wins')}</strong>{' '}
           <MarkdownText>{atAGlance.quick_wins}</MarkdownText>
           <a href="#section-features" className="see-more">
-            Features to Try →
+            {t('insight_see_more_features')}
           </a>
         </div>
         <div className="glance-section">
-          <strong>Ambitious workflows:</strong>{' '}
+          <strong>{t('insight_ambitious_workflows')}</strong>{' '}
           <MarkdownText>{atAGlance.ambitious_workflows}</MarkdownText>
           <a href="#section-horizon" className="see-more">
-            On the Horizon →
+            {t('insight_see_more_horizon')}
           </a>
         </div>
       </div>
@@ -54,13 +55,13 @@ export function AtAGlance({ qualitative }: { qualitative: QualitativeData }) {
 export function NavToc() {
   return (
     <nav className="nav-toc">
-      <a href="#section-work">What You Work On</a>
-      <a href="#section-usage">How You Use Qwen Code</a>
-      <a href="#section-wins">Impressive Things</a>
-      <a href="#section-friction">Where Things Go Wrong</a>
-      <a href="#section-features">Features to Try</a>
-      <a href="#section-patterns">New Usage Patterns</a>
-      <a href="#section-horizon">On the Horizon</a>
+      <a href="#section-work">{t('insight_nav_work')}</a>
+      <a href="#section-usage">{t('insight_nav_usage')}</a>
+      <a href="#section-wins">{t('insight_nav_wins')}</a>
+      <a href="#section-friction">{t('insight_nav_friction')}</a>
+      <a href="#section-features">{t('insight_nav_features')}</a>
+      <a href="#section-patterns">{t('insight_nav_patterns')}</a>
+      <a href="#section-horizon">{t('insight_nav_horizon')}</a>
     </nav>
   );
 }
@@ -87,7 +88,7 @@ export function ProjectAreas({
         id="section-work"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        What You Work On
+        {t('insight_what_you_work_on')}
       </h2>
 
       {Array.isArray(projectAreas?.areas) && projectAreas.areas.length > 0 && (
@@ -97,7 +98,7 @@ export function ProjectAreas({
               <div className="area-header">
                 <span className="area-name">{area.name}</span>
                 <span className="area-count">
-                  ~{area.session_count} sessions
+                  {t('insight_sessions_count', { count: area.session_count })}
                 </span>
               </div>
               <div className="area-desc">
@@ -119,14 +120,14 @@ export function ProjectAreas({
         {topGoals && Object.keys(topGoals).length > 0 && (
           <HorizontalBarChart
             data={topGoals}
-            title="What You Wanted"
+            title={t('insight_what_you_wanted')}
             color="#0ea5e9"
           />
         )}
         {topToolsObj && Object.keys(topToolsObj).length > 0 && (
           <HorizontalBarChart
             data={topToolsObj}
-            title="Top Tools Used"
+            title={t('insight_top_tools_used')}
             color="#6366f1"
           />
         )}
@@ -151,7 +152,7 @@ export function InteractionStyle({
         id="section-usage"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        How You Use Qwen Code
+        {t('insight_how_you_use')}
       </h2>
       <div className="narrative">
         <p>
@@ -159,7 +160,7 @@ export function InteractionStyle({
         </p>
         {interactionStyle.key_pattern && (
           <div className="key-insight">
-            <strong>Key pattern:</strong>{' '}
+            <strong>{t('insight_key_pattern')}</strong>{' '}
             <MarkdownText>{interactionStyle.key_pattern}</MarkdownText>
           </div>
         )}
@@ -189,7 +190,7 @@ export function ImpressiveWorkflows({
         id="section-wins"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        Impressive Things You Did
+        {t('insight_impressive_things')}
       </h2>
       {impressiveWorkflows.intro && (
         <p className="section-intro">
@@ -220,7 +221,7 @@ export function ImpressiveWorkflows({
         {primarySuccess && Object.keys(primarySuccess).length > 0 && (
           <HorizontalBarChart
             data={primarySuccess}
-            title="What Helped Most (Qwen's Capabilities)"
+            title={t('insight_what_helped_most')}
             color="#3b82f6"
             allowedKeys={[
               'fast_accurate_search',
@@ -235,7 +236,7 @@ export function ImpressiveWorkflows({
         {outcomes && Object.keys(outcomes).length > 0 && (
           <HorizontalBarChart
             data={outcomes}
-            title="Outcomes"
+            title={t('insight_outcomes')}
             color="#8b5cf6"
             allowedKeys={[
               'fully_achieved',
@@ -254,7 +255,7 @@ export function ImpressiveWorkflows({
 // Format label for display (capitalize and replace underscores with spaces)
 function formatLabel(label: string) {
   if (label === 'unclear_from_transcript') {
-    return 'Unclear';
+    return t('insight_unclear');
   }
   return label
     .split('_')
@@ -413,7 +414,7 @@ export function FrictionPoints({
         id="section-friction"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        Where Things Go Wrong
+        {t('insight_where_things_go_wrong')}
       </h2>
       {frictionPoints.intro && (
         <p className="section-intro">
@@ -454,7 +455,7 @@ export function FrictionPoints({
         {friction && Object.keys(friction).length > 0 && (
           <HorizontalBarChart
             data={friction}
-            title="Primary Friction Types"
+            title={t('insight_primary_friction_types')}
             color="#ef4444"
             allowedKeys={[
               'misunderstood_request',
@@ -468,7 +469,7 @@ export function FrictionPoints({
         {satisfaction && Object.keys(satisfaction).length > 0 && (
           <HorizontalBarChart
             data={satisfaction}
-            title="Inferred Satisfaction (model-estimated)"
+            title={t('insight_inferred_satisfaction')}
             color="#10b981"
             allowedKeys={[
               'happy',
@@ -522,10 +523,8 @@ function QwenMdAdditionsSection({
 
   return (
     <div className="qwen-md-section">
-      <h3>Suggested QWEN.md Additions</h3>
-      <p className="text-xs text-slate-500 mb-3">
-        Just copy this into Qwen Code to add it to your QWEN.md.
-      </p>
+      <h3>{t('insight_suggested_qwen_md')}</h3>
+      <p className="text-xs text-slate-500 mb-3">{t('insight_qwen_md_hint')}</p>
 
       <div className="qwen-md-actions" style={{ marginBottom: '12px' }}>
         <button
@@ -533,7 +532,9 @@ function QwenMdAdditionsSection({
           onClick={handleCopyAll}
           disabled={checkedCount === 0}
         >
-          {copiedAll ? 'Copied All!' : `Copy All Checked (${checkedCount})`}
+          {copiedAll
+            ? t('insight_copied_all')
+            : t('insight_copy_all_checked', { count: checkedCount })}
         </button>
       </div>
 
@@ -572,7 +573,7 @@ export function Improvements({
         id="section-features"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        Existing Qwen Code Features to Try
+        {t('insight_features_to_try')}
       </h2>
 
       {/* QWEN.md Additions */}
@@ -582,7 +583,7 @@ export function Improvements({
         )}
 
       <p className="text-xs text-slate-500 mb-3">
-        Just copy this into Qwen Code and it&apos;ll set it up for you.
+        {t('insight_features_hint')}
       </p>
 
       {/* Features to Try */}
@@ -595,7 +596,7 @@ export function Improvements({
                 <MarkdownText>{feat.one_liner}</MarkdownText>
               </div>
               <div className="feature-why">
-                <strong>Why for you:</strong>{' '}
+                <strong>{t('insight_why_for_you')}</strong>{' '}
                 <MarkdownText>{feat.why_for_you}</MarkdownText>
               </div>
               <div className="feature-examples">
@@ -614,10 +615,10 @@ export function Improvements({
         id="section-patterns"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        New Ways to Use Qwen Code
+        {t('insight_new_ways_to_use')}
       </h2>
       <p className="text-xs text-slate-500 mb-3">
-        Just copy this into Qwen Code and it&apos;ll walk you through it.
+        {t('insight_patterns_hint')}
       </p>
 
       <div className="patterns-section">
@@ -632,7 +633,9 @@ export function Improvements({
                 <MarkdownText>{pat.detail}</MarkdownText>
               </div>
               <div className="copyable-prompt-section">
-                <div className="prompt-label">Paste into Qwen Code:</div>
+                <div className="prompt-label">
+                  {t('insight_paste_into_qwen')}
+                </div>
                 <div className="copyable-prompt-row">
                   <code className="copyable-prompt">{pat.copyable_prompt}</code>
                   <CopyButton text={pat.copyable_prompt} />
@@ -659,7 +662,7 @@ export function FutureOpportunities({
         id="section-horizon"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        On the Horizon
+        {t('insight_on_the_horizon')}
       </h2>
       {futureOpportunities.intro && (
         <p className="section-intro">
@@ -676,11 +679,13 @@ export function FutureOpportunities({
                 <MarkdownText>{opp.whats_possible}</MarkdownText>
               </div>
               <div className="horizon-tip">
-                <strong>Getting started:</strong>{' '}
+                <strong>{t('insight_getting_started')}</strong>{' '}
                 <MarkdownText>{opp.how_to_try}</MarkdownText>
               </div>
               <div className="pattern-prompt">
-                <div className="prompt-label">Paste into Qwen Code:</div>
+                <div className="prompt-label">
+                  {t('insight_paste_into_qwen')}
+                </div>
                 <div
                   style={{
                     display: 'flex',

--- a/packages/web-templates/src/insight/src/Qualitative.tsx
+++ b/packages/web-templates/src/insight/src/Qualitative.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { DashboardCards, HeatmapSection } from './Charts';
 import type { InsightData, QualitativeData } from './types';
 import { CopyButton, MarkdownText } from './Components';
-import { t } from './i18n';
+import { ti } from './i18n';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 
@@ -17,34 +17,34 @@ export function AtAGlance({ qualitative }: { qualitative: QualitativeData }) {
 
   return (
     <div className="at-a-glance">
-      <div className="glance-title">{t('insight_at_a_glance')}</div>
+      <div className="glance-title">{ti('insight_at_a_glance')}</div>
       <div className="glance-sections">
         <div className="glance-section">
-          <strong>{t('insight_whats_working')}</strong>{' '}
+          <strong>{ti('insight_whats_working')}</strong>{' '}
           <MarkdownText>{atAGlance.whats_working}</MarkdownText>
           <a href="#section-wins" className="see-more">
-            {t('insight_see_more_wins')}
+            {ti('insight_see_more_wins')}
           </a>
         </div>
         <div className="glance-section">
-          <strong>{t('insight_whats_hindering')}</strong>{' '}
+          <strong>{ti('insight_whats_hindering')}</strong>{' '}
           <MarkdownText>{atAGlance.whats_hindering}</MarkdownText>
           <a href="#section-friction" className="see-more">
-            {t('insight_see_more_friction')}
+            {ti('insight_see_more_friction')}
           </a>
         </div>
         <div className="glance-section">
-          <strong>{t('insight_quick_wins')}</strong>{' '}
+          <strong>{ti('insight_quick_wins')}</strong>{' '}
           <MarkdownText>{atAGlance.quick_wins}</MarkdownText>
           <a href="#section-features" className="see-more">
-            {t('insight_see_more_features')}
+            {ti('insight_see_more_features')}
           </a>
         </div>
         <div className="glance-section">
-          <strong>{t('insight_ambitious_workflows')}</strong>{' '}
+          <strong>{ti('insight_ambitious_workflows')}</strong>{' '}
           <MarkdownText>{atAGlance.ambitious_workflows}</MarkdownText>
           <a href="#section-horizon" className="see-more">
-            {t('insight_see_more_horizon')}
+            {ti('insight_see_more_horizon')}
           </a>
         </div>
       </div>
@@ -55,13 +55,13 @@ export function AtAGlance({ qualitative }: { qualitative: QualitativeData }) {
 export function NavToc() {
   return (
     <nav className="nav-toc">
-      <a href="#section-work">{t('insight_nav_work')}</a>
-      <a href="#section-usage">{t('insight_nav_usage')}</a>
-      <a href="#section-wins">{t('insight_nav_wins')}</a>
-      <a href="#section-friction">{t('insight_nav_friction')}</a>
-      <a href="#section-features">{t('insight_nav_features')}</a>
-      <a href="#section-patterns">{t('insight_nav_patterns')}</a>
-      <a href="#section-horizon">{t('insight_nav_horizon')}</a>
+      <a href="#section-work">{ti('insight_nav_work')}</a>
+      <a href="#section-usage">{ti('insight_nav_usage')}</a>
+      <a href="#section-wins">{ti('insight_nav_wins')}</a>
+      <a href="#section-friction">{ti('insight_nav_friction')}</a>
+      <a href="#section-features">{ti('insight_nav_features')}</a>
+      <a href="#section-patterns">{ti('insight_nav_patterns')}</a>
+      <a href="#section-horizon">{ti('insight_nav_horizon')}</a>
     </nav>
   );
 }
@@ -88,7 +88,7 @@ export function ProjectAreas({
         id="section-work"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        {t('insight_what_you_work_on')}
+        {ti('insight_what_you_work_on')}
       </h2>
 
       {Array.isArray(projectAreas?.areas) && projectAreas.areas.length > 0 && (
@@ -98,7 +98,10 @@ export function ProjectAreas({
               <div className="area-header">
                 <span className="area-name">{area.name}</span>
                 <span className="area-count">
-                  {t('insight_sessions_count', { count: area.session_count })}
+                  ~
+                  {ti('insight_sessions_count', {
+                    count: String(area.session_count),
+                  })}
                 </span>
               </div>
               <div className="area-desc">
@@ -120,14 +123,14 @@ export function ProjectAreas({
         {topGoals && Object.keys(topGoals).length > 0 && (
           <HorizontalBarChart
             data={topGoals}
-            title={t('insight_what_you_wanted')}
+            title={ti('insight_what_you_wanted')}
             color="#0ea5e9"
           />
         )}
         {topToolsObj && Object.keys(topToolsObj).length > 0 && (
           <HorizontalBarChart
             data={topToolsObj}
-            title={t('insight_top_tools_used')}
+            title={ti('insight_top_tools_used')}
             color="#6366f1"
           />
         )}
@@ -152,7 +155,7 @@ export function InteractionStyle({
         id="section-usage"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        {t('insight_how_you_use')}
+        {ti('insight_how_you_use')}
       </h2>
       <div className="narrative">
         <p>
@@ -160,7 +163,7 @@ export function InteractionStyle({
         </p>
         {interactionStyle.key_pattern && (
           <div className="key-insight">
-            <strong>{t('insight_key_pattern')}</strong>{' '}
+            <strong>{ti('insight_key_pattern')}</strong>{' '}
             <MarkdownText>{interactionStyle.key_pattern}</MarkdownText>
           </div>
         )}
@@ -190,7 +193,7 @@ export function ImpressiveWorkflows({
         id="section-wins"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        {t('insight_impressive_things')}
+        {ti('insight_impressive_things')}
       </h2>
       {impressiveWorkflows.intro && (
         <p className="section-intro">
@@ -221,7 +224,7 @@ export function ImpressiveWorkflows({
         {primarySuccess && Object.keys(primarySuccess).length > 0 && (
           <HorizontalBarChart
             data={primarySuccess}
-            title={t('insight_what_helped_most')}
+            title={ti('insight_what_helped_most')}
             color="#3b82f6"
             allowedKeys={[
               'fast_accurate_search',
@@ -236,7 +239,7 @@ export function ImpressiveWorkflows({
         {outcomes && Object.keys(outcomes).length > 0 && (
           <HorizontalBarChart
             data={outcomes}
-            title={t('insight_outcomes')}
+            title={ti('insight_outcomes')}
             color="#8b5cf6"
             allowedKeys={[
               'fully_achieved',
@@ -255,7 +258,7 @@ export function ImpressiveWorkflows({
 // Format label for display (capitalize and replace underscores with spaces)
 function formatLabel(label: string) {
   if (label === 'unclear_from_transcript') {
-    return t('insight_unclear');
+    return ti('insight_unclear');
   }
   return label
     .split('_')
@@ -414,7 +417,7 @@ export function FrictionPoints({
         id="section-friction"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        {t('insight_where_things_go_wrong')}
+        {ti('insight_where_things_go_wrong')}
       </h2>
       {frictionPoints.intro && (
         <p className="section-intro">
@@ -455,7 +458,7 @@ export function FrictionPoints({
         {friction && Object.keys(friction).length > 0 && (
           <HorizontalBarChart
             data={friction}
-            title={t('insight_primary_friction_types')}
+            title={ti('insight_primary_friction_types')}
             color="#ef4444"
             allowedKeys={[
               'misunderstood_request',
@@ -469,7 +472,7 @@ export function FrictionPoints({
         {satisfaction && Object.keys(satisfaction).length > 0 && (
           <HorizontalBarChart
             data={satisfaction}
-            title={t('insight_inferred_satisfaction')}
+            title={ti('insight_inferred_satisfaction')}
             color="#10b981"
             allowedKeys={[
               'happy',
@@ -523,8 +526,10 @@ function QwenMdAdditionsSection({
 
   return (
     <div className="qwen-md-section">
-      <h3>{t('insight_suggested_qwen_md')}</h3>
-      <p className="text-xs text-slate-500 mb-3">{t('insight_qwen_md_hint')}</p>
+      <h3>{ti('insight_suggested_qwen_md')}</h3>
+      <p className="text-xs text-slate-500 mb-3">
+        {ti('insight_qwen_md_hint')}
+      </p>
 
       <div className="qwen-md-actions" style={{ marginBottom: '12px' }}>
         <button
@@ -533,8 +538,8 @@ function QwenMdAdditionsSection({
           disabled={checkedCount === 0}
         >
           {copiedAll
-            ? t('insight_copied_all')
-            : t('insight_copy_all_checked', { count: checkedCount })}
+            ? ti('insight_copied_all')
+            : ti('insight_copy_all_checked', { count: String(checkedCount) })}
         </button>
       </div>
 
@@ -573,7 +578,7 @@ export function Improvements({
         id="section-features"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        {t('insight_features_to_try')}
+        {ti('insight_features_to_try')}
       </h2>
 
       {/* QWEN.md Additions */}
@@ -583,7 +588,7 @@ export function Improvements({
         )}
 
       <p className="text-xs text-slate-500 mb-3">
-        {t('insight_features_hint')}
+        {ti('insight_features_hint')}
       </p>
 
       {/* Features to Try */}
@@ -596,7 +601,7 @@ export function Improvements({
                 <MarkdownText>{feat.one_liner}</MarkdownText>
               </div>
               <div className="feature-why">
-                <strong>{t('insight_why_for_you')}</strong>{' '}
+                <strong>{ti('insight_why_for_you')}</strong>{' '}
                 <MarkdownText>{feat.why_for_you}</MarkdownText>
               </div>
               <div className="feature-examples">
@@ -615,10 +620,10 @@ export function Improvements({
         id="section-patterns"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        {t('insight_new_ways_to_use')}
+        {ti('insight_new_ways_to_use')}
       </h2>
       <p className="text-xs text-slate-500 mb-3">
-        {t('insight_patterns_hint')}
+        {ti('insight_patterns_hint')}
       </p>
 
       <div className="patterns-section">
@@ -634,7 +639,7 @@ export function Improvements({
               </div>
               <div className="copyable-prompt-section">
                 <div className="prompt-label">
-                  {t('insight_paste_into_qwen')}
+                  {ti('insight_paste_into_qwen')}
                 </div>
                 <div className="copyable-prompt-row">
                   <code className="copyable-prompt">{pat.copyable_prompt}</code>
@@ -662,7 +667,7 @@ export function FutureOpportunities({
         id="section-horizon"
         className="text-xl font-semibold text-slate-900 mt-8 mb-4"
       >
-        {t('insight_on_the_horizon')}
+        {ti('insight_on_the_horizon')}
       </h2>
       {futureOpportunities.intro && (
         <p className="section-intro">
@@ -679,12 +684,12 @@ export function FutureOpportunities({
                 <MarkdownText>{opp.whats_possible}</MarkdownText>
               </div>
               <div className="horizon-tip">
-                <strong>{t('insight_getting_started')}</strong>{' '}
+                <strong>{ti('insight_getting_started')}</strong>{' '}
                 <MarkdownText>{opp.how_to_try}</MarkdownText>
               </div>
               <div className="pattern-prompt">
                 <div className="prompt-label">
-                  {t('insight_paste_into_qwen')}
+                  {ti('insight_paste_into_qwen')}
                 </div>
                 <div
                   style={{

--- a/packages/web-templates/src/insight/src/ShareCard.tsx
+++ b/packages/web-templates/src/insight/src/ShareCard.tsx
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 import type { InsightData } from './types';
+import { t } from './i18n';
 
 /**
  * Theme configuration for the share card
@@ -57,7 +58,7 @@ export function ShareCard({
   data: InsightData;
   theme?: Theme;
 }) {
-  const t = themes[theme];
+  const tc = themes[theme];
 
   const {
     totalMessages = 0,
@@ -90,15 +91,15 @@ export function ShareCard({
   const truncatedHeadline = data.qualitative?.memorableMoment?.headline ?? null;
 
   // Mini heatmap: last 52 weeks (simplified 7-row grid)
-  const miniHeatmap = buildMiniHeatmap(data.heatmap || {}, t);
+  const miniHeatmap = buildMiniHeatmap(data.heatmap || {}, tc);
 
   return (
     <div
       id="share-card"
       style={{
         width: '1200px',
-        background: t.background,
-        color: t.textPrimary,
+        background: tc.background,
+        color: tc.textPrimary,
         fontFamily:
           'ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
         display: 'flex',
@@ -129,12 +130,12 @@ export function ShareCard({
               lineHeight: 1.2,
             }}
           >
-            Qwen Code Insights
+            {t('insight_title')}
           </div>
           <div
             style={{
               fontSize: '14px',
-              color: t.textMuted,
+              color: tc.textMuted,
               marginTop: '6px',
             }}
           >
@@ -144,13 +145,13 @@ export function ShareCard({
         <div
           style={{
             fontSize: '11px',
-            color: t.textMuted,
+            color: tc.textMuted,
             textTransform: 'uppercase',
             letterSpacing: '0.15em',
             paddingTop: '8px',
           }}
         >
-          qwen.ai
+          {t('insight_share_brand')}
         </div>
       </div>
 
@@ -163,17 +164,37 @@ export function ShareCard({
           marginBottom: '32px',
         }}
       >
-        <StatBox value={String(totalMessages)} label="Messages" theme={t} />
-        <StatBox value={String(totalSessions)} label="Sessions" theme={t} />
+        <StatBox
+          value={String(totalMessages)}
+          label={t('insight_stat_messages')}
+          theme={tc}
+        />
+        <StatBox
+          value={String(totalSessions)}
+          label={t('insight_share_sessions')}
+          theme={tc}
+        />
         <StatBox
           value={`+${totalLinesAdded}/-${totalLinesRemoved}`}
-          label="Lines Changed"
+          label={t('insight_share_lines_changed')}
           small
-          theme={t}
+          theme={tc}
         />
-        <StatBox value={String(totalFiles)} label="Files" theme={t} />
-        <StatBox value={`${currentStreak}d`} label="Streak" theme={t} />
-        <StatBox value={`${longestStreak}d`} label="Best Streak" theme={t} />
+        <StatBox
+          value={String(totalFiles)}
+          label={t('insight_stat_files')}
+          theme={tc}
+        />
+        <StatBox
+          value={`${currentStreak}d`}
+          label={t('insight_share_streak')}
+          theme={tc}
+        />
+        <StatBox
+          value={`${longestStreak}d`}
+          label={t('insight_share_best_streak')}
+          theme={tc}
+        />
       </div>
 
       {/* Body: Heatmap + Tools + Moment */}
@@ -188,7 +209,7 @@ export function ShareCard({
         {/* Left: Mini Heatmap */}
         <div
           style={{
-            background: t.cardBackground,
+            background: tc.cardBackground,
             borderRadius: '12px',
             padding: '20px',
             display: 'flex',
@@ -199,13 +220,13 @@ export function ShareCard({
             style={{
               fontSize: '12px',
               fontWeight: 600,
-              color: t.textMuted,
+              color: tc.textMuted,
               textTransform: 'uppercase',
               letterSpacing: '0.08em',
               marginBottom: '12px',
             }}
           >
-            Activity · {activeDays} active days
+            {t('insight_share_activity', { days: activeDays })}
           </div>
           <div
             style={{
@@ -217,7 +238,7 @@ export function ShareCard({
           >
             <MiniHeatmapGrid cells={miniHeatmap} />
           </div>
-          <MiniHeatmapLegend theme={t} />
+          <MiniHeatmapLegend theme={tc} />
         </div>
 
         {/* Right: Active Hours + Moment */}
@@ -231,7 +252,7 @@ export function ShareCard({
           {/* Active Hours */}
           <div
             style={{
-              background: t.cardBackground,
+              background: tc.cardBackground,
               borderRadius: '12px',
               padding: '20px',
               display: 'flex',
@@ -242,13 +263,13 @@ export function ShareCard({
               style={{
                 fontSize: '12px',
                 fontWeight: 600,
-                color: t.textMuted,
+                color: tc.textMuted,
                 textTransform: 'uppercase',
                 letterSpacing: '0.08em',
                 marginBottom: '12px',
               }}
             >
-              Active Hours
+              {t('insight_active_hours')}
             </div>
             <div
               style={{
@@ -259,14 +280,14 @@ export function ShareCard({
                 gap: '10px',
               }}
             >
-              <ActiveHoursChart activeHours={activeHours} theme={t} />
+              <ActiveHoursChart activeHours={activeHours} theme={tc} />
             </div>
           </div>
 
           {/* Key Pattern + Memorable Moment */}
           <div
             style={{
-              background: t.cardBackgroundSecondary,
+              background: tc.cardBackgroundSecondary,
               borderRadius: '12px',
               padding: '16px 16px',
               position: 'relative',
@@ -301,7 +322,7 @@ export function ShareCard({
                 <div
                   style={{
                     fontSize: '13px',
-                    color: t.textSecondary,
+                    color: tc.textSecondary,
                     lineHeight: 1.6,
                     marginBottom: truncatedHeadline ? '8px' : 0,
                   }}
@@ -313,7 +334,7 @@ export function ShareCard({
                 <div
                   style={{
                     fontSize: '12px',
-                    color: t.textMuted,
+                    color: tc.textMuted,
                     lineHeight: 1.5,
                     fontStyle: 'italic',
                   }}
@@ -334,15 +355,16 @@ export function ShareCard({
           alignItems: 'center',
           marginTop: 'auto',
           paddingTop: '24px',
-          borderTop: `1px solid ${t.borderColor}`,
+          borderTop: `1px solid ${tc.borderColor}`,
           flexShrink: 0,
         }}
       >
-        <div style={{ fontSize: '12px', color: t.textMuted }}>
-          Generated by Qwen Code · {new Date().toISOString().split('T')[0]}
+        <div style={{ fontSize: '12px', color: tc.textMuted }}>
+          {t('insight_share_generated')}{' '}
+          {new Date().toISOString().split('T')[0]}
         </div>
-        <div style={{ fontSize: '12px', color: t.textMuted }}>
-          github.com/QwenLM/qwen-code
+        <div style={{ fontSize: '12px', color: tc.textMuted }}>
+          {t('insight_share_github')}
         </div>
       </div>
     </div>
@@ -396,25 +418,25 @@ function ActiveHoursChart({
 }) {
   const phases = [
     {
-      label: 'Morning',
+      label: t('insight_morning'),
       time: '06–12',
       hours: [6, 7, 8, 9, 10, 11],
       color: '#fbbf24',
     },
     {
-      label: 'Afternoon',
+      label: t('insight_afternoon'),
       time: '12–18',
       hours: [12, 13, 14, 15, 16, 17],
       color: '#0ea5e9',
     },
     {
-      label: 'Evening',
+      label: t('insight_evening'),
       time: '18–22',
       hours: [18, 19, 20, 21],
       color: '#6366f1',
     },
     {
-      label: 'Night',
+      label: t('insight_night'),
       time: '22–06',
       hours: [22, 23, 0, 1, 2, 3, 4, 5],
       color: '#475569',
@@ -573,7 +595,9 @@ function MiniHeatmapLegend({ theme }: { theme: ThemeConfig }) {
         marginTop: '12px',
       }}
     >
-      <span style={{ fontSize: '11px', color: theme.textMuted }}>Less</span>
+      <span style={{ fontSize: '11px', color: theme.textMuted }}>
+        {t('insight_less')}
+      </span>
       {[
         theme.heatmapEmpty,
         theme.heatmapColors[0],
@@ -592,7 +616,9 @@ function MiniHeatmapLegend({ theme }: { theme: ThemeConfig }) {
           }}
         />
       ))}
-      <span style={{ fontSize: '11px', color: theme.textMuted }}>More</span>
+      <span style={{ fontSize: '11px', color: theme.textMuted }}>
+        {t('insight_more')}
+      </span>
     </div>
   );
 }

--- a/packages/web-templates/src/insight/src/ShareCard.tsx
+++ b/packages/web-templates/src/insight/src/ShareCard.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 import type { InsightData } from './types';
-import { t } from './i18n';
+import { ti } from './i18n';
 
 /**
  * Theme configuration for the share card
@@ -58,7 +58,7 @@ export function ShareCard({
   data: InsightData;
   theme?: Theme;
 }) {
-  const tc = themes[theme];
+  const t = themes[theme];
 
   const {
     totalMessages = 0,
@@ -91,15 +91,15 @@ export function ShareCard({
   const truncatedHeadline = data.qualitative?.memorableMoment?.headline ?? null;
 
   // Mini heatmap: last 52 weeks (simplified 7-row grid)
-  const miniHeatmap = buildMiniHeatmap(data.heatmap || {}, tc);
+  const miniHeatmap = buildMiniHeatmap(data.heatmap || {}, t);
 
   return (
     <div
       id="share-card"
       style={{
         width: '1200px',
-        background: tc.background,
-        color: tc.textPrimary,
+        background: t.background,
+        color: t.textPrimary,
         fontFamily:
           'ui-sans-serif, system-ui, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"',
         display: 'flex',
@@ -130,12 +130,12 @@ export function ShareCard({
               lineHeight: 1.2,
             }}
           >
-            {t('insight_title')}
+            {ti('insight_title')}
           </div>
           <div
             style={{
               fontSize: '14px',
-              color: tc.textMuted,
+              color: t.textMuted,
               marginTop: '6px',
             }}
           >
@@ -145,13 +145,13 @@ export function ShareCard({
         <div
           style={{
             fontSize: '11px',
-            color: tc.textMuted,
+            color: t.textMuted,
             textTransform: 'uppercase',
             letterSpacing: '0.15em',
             paddingTop: '8px',
           }}
         >
-          {t('insight_share_brand')}
+          {ti('insight_share_brand')}
         </div>
       </div>
 
@@ -166,34 +166,34 @@ export function ShareCard({
       >
         <StatBox
           value={String(totalMessages)}
-          label={t('insight_stat_messages')}
-          theme={tc}
+          label={ti('insight_stat_messages')}
+          theme={t}
         />
         <StatBox
           value={String(totalSessions)}
-          label={t('insight_share_sessions')}
-          theme={tc}
+          label={ti('insight_share_sessions')}
+          theme={t}
         />
         <StatBox
           value={`+${totalLinesAdded}/-${totalLinesRemoved}`}
-          label={t('insight_share_lines_changed')}
+          label={ti('insight_share_lines_changed')}
           small
-          theme={tc}
+          theme={t}
         />
         <StatBox
           value={String(totalFiles)}
-          label={t('insight_stat_files')}
-          theme={tc}
+          label={ti('insight_stat_files')}
+          theme={t}
         />
         <StatBox
           value={`${currentStreak}d`}
-          label={t('insight_share_streak')}
-          theme={tc}
+          label={ti('insight_share_streak')}
+          theme={t}
         />
         <StatBox
           value={`${longestStreak}d`}
-          label={t('insight_share_best_streak')}
-          theme={tc}
+          label={ti('insight_share_best_streak')}
+          theme={t}
         />
       </div>
 
@@ -209,7 +209,7 @@ export function ShareCard({
         {/* Left: Mini Heatmap */}
         <div
           style={{
-            background: tc.cardBackground,
+            background: t.cardBackground,
             borderRadius: '12px',
             padding: '20px',
             display: 'flex',
@@ -220,13 +220,13 @@ export function ShareCard({
             style={{
               fontSize: '12px',
               fontWeight: 600,
-              color: tc.textMuted,
+              color: t.textMuted,
               textTransform: 'uppercase',
               letterSpacing: '0.08em',
               marginBottom: '12px',
             }}
           >
-            {t('insight_share_activity', { days: activeDays })}
+            {ti('insight_share_activity', { days: String(activeDays) })}
           </div>
           <div
             style={{
@@ -238,7 +238,7 @@ export function ShareCard({
           >
             <MiniHeatmapGrid cells={miniHeatmap} />
           </div>
-          <MiniHeatmapLegend theme={tc} />
+          <MiniHeatmapLegend theme={t} />
         </div>
 
         {/* Right: Active Hours + Moment */}
@@ -252,7 +252,7 @@ export function ShareCard({
           {/* Active Hours */}
           <div
             style={{
-              background: tc.cardBackground,
+              background: t.cardBackground,
               borderRadius: '12px',
               padding: '20px',
               display: 'flex',
@@ -263,13 +263,13 @@ export function ShareCard({
               style={{
                 fontSize: '12px',
                 fontWeight: 600,
-                color: tc.textMuted,
+                color: t.textMuted,
                 textTransform: 'uppercase',
                 letterSpacing: '0.08em',
                 marginBottom: '12px',
               }}
             >
-              {t('insight_active_hours')}
+              {ti('insight_active_hours')}
             </div>
             <div
               style={{
@@ -280,14 +280,14 @@ export function ShareCard({
                 gap: '10px',
               }}
             >
-              <ActiveHoursChart activeHours={activeHours} theme={tc} />
+              <ActiveHoursChart activeHours={activeHours} theme={t} />
             </div>
           </div>
 
           {/* Key Pattern + Memorable Moment */}
           <div
             style={{
-              background: tc.cardBackgroundSecondary,
+              background: t.cardBackgroundSecondary,
               borderRadius: '12px',
               padding: '16px 16px',
               position: 'relative',
@@ -322,7 +322,7 @@ export function ShareCard({
                 <div
                   style={{
                     fontSize: '13px',
-                    color: tc.textSecondary,
+                    color: t.textSecondary,
                     lineHeight: 1.6,
                     marginBottom: truncatedHeadline ? '8px' : 0,
                   }}
@@ -334,7 +334,7 @@ export function ShareCard({
                 <div
                   style={{
                     fontSize: '12px',
-                    color: tc.textMuted,
+                    color: t.textMuted,
                     lineHeight: 1.5,
                     fontStyle: 'italic',
                   }}
@@ -355,16 +355,16 @@ export function ShareCard({
           alignItems: 'center',
           marginTop: 'auto',
           paddingTop: '24px',
-          borderTop: `1px solid ${tc.borderColor}`,
+          borderTop: `1px solid ${t.borderColor}`,
           flexShrink: 0,
         }}
       >
-        <div style={{ fontSize: '12px', color: tc.textMuted }}>
-          {t('insight_share_generated')}{' '}
+        <div style={{ fontSize: '12px', color: t.textMuted }}>
+          {ti('insight_share_generated')}{' '}
           {new Date().toISOString().split('T')[0]}
         </div>
-        <div style={{ fontSize: '12px', color: tc.textMuted }}>
-          {t('insight_share_github')}
+        <div style={{ fontSize: '12px', color: t.textMuted }}>
+          {ti('insight_share_github')}
         </div>
       </div>
     </div>
@@ -418,26 +418,26 @@ function ActiveHoursChart({
 }) {
   const phases = [
     {
-      label: t('insight_morning'),
-      time: '06–12',
+      label: ti('insight_morning'),
+      time: '06-12',
       hours: [6, 7, 8, 9, 10, 11],
       color: '#fbbf24',
     },
     {
-      label: t('insight_afternoon'),
-      time: '12–18',
+      label: ti('insight_afternoon'),
+      time: '12-18',
       hours: [12, 13, 14, 15, 16, 17],
       color: '#0ea5e9',
     },
     {
-      label: t('insight_evening'),
-      time: '18–22',
+      label: ti('insight_evening'),
+      time: '18-22',
       hours: [18, 19, 20, 21],
       color: '#6366f1',
     },
     {
-      label: t('insight_night'),
-      time: '22–06',
+      label: ti('insight_night'),
+      time: '22-06',
       hours: [22, 23, 0, 1, 2, 3, 4, 5],
       color: '#475569',
     },
@@ -596,7 +596,7 @@ function MiniHeatmapLegend({ theme }: { theme: ThemeConfig }) {
       }}
     >
       <span style={{ fontSize: '11px', color: theme.textMuted }}>
-        {t('insight_less')}
+        {ti('insight_less')}
       </span>
       {[
         theme.heatmapEmpty,
@@ -617,7 +617,7 @@ function MiniHeatmapLegend({ theme }: { theme: ThemeConfig }) {
         />
       ))}
       <span style={{ fontSize: '11px', color: theme.textMuted }}>
-        {t('insight_more')}
+        {ti('insight_more')}
       </span>
     </div>
   );

--- a/packages/web-templates/src/insight/src/i18n.ts
+++ b/packages/web-templates/src/insight/src/i18n.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * In-browser translation utility for the insight report.
+ * Reads translations from window.INSIGHT_TRANSLATIONS (injected by TemplateRenderer).
+ * Mirrors the CLI's t() function with {{param}} interpolation support.
+ */
+
+const translations: Record<string, string> =
+  typeof window !== 'undefined' && window.INSIGHT_TRANSLATIONS
+    ? window.INSIGHT_TRANSLATIONS
+    : {};
+
+/**
+ * Translate a key with optional parameter interpolation.
+ * @param key - The translation key (insight_* keys from CLI locale files)
+ * @param params - Optional object with {{key}} -> value replacements
+ * @returns Translated string, or the key itself if not found
+ */
+export function ti(key: string, params?: Record<string, string>): string {
+  let text = translations[key] ?? key;
+
+  if (params) {
+    Object.entries(params).forEach(([paramKey, value]) => {
+      text = text.replace(new RegExp(`{{${paramKey}}}`, 'g'), String(value));
+    });
+  }
+
+  return text;
+}
+
+/**
+ * Convenience alias matching the convention used by React components.
+ */
+export const t = ti;
+
+/**
+ * Get the current UI language code.
+ */
+export function getInsightLanguage(): string {
+  return (typeof window !== 'undefined' && window.INSIGHT_LANGUAGE) || 'en';
+}

--- a/packages/web-templates/src/insight/src/types.ts
+++ b/packages/web-templates/src/insight/src/types.ts
@@ -9,6 +9,10 @@ declare global {
     Chart: any;
     html2canvas: any;
     INSIGHT_DATA: InsightData;
+    /** The UI language code for the insight report (e.g., 'en', 'zh', 'ja'). */
+    INSIGHT_LANGUAGE: string;
+    /** Translation dictionary for the insight report static text. */
+    INSIGHT_TRANSLATIONS: Record<string, string>;
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #2022

The `/insight` HTML report now respects both the UI language and LLM output language settings.

## What Changed

### Localized HTML Report
- All static text in the HTML report (section headings, labels, buttons, chart titles, share card text) is now localized via an embedded translation dictionary injected at generation time
- The HTML `lang` attribute and page title reflect the user's UI language
- Client-side `ti()` translation helper reads embedded translations from `window.INSIGHT_TRANSLATIONS`

### Localized LLM-generated Content
- LLM-generated narrative content (insights, recommendations, analysis) is produced in the user's preferred output language by appending language instructions to prompts

### Localized CLI Messages
- CLI progress messages and status indicators are localized via the existing i18n system
- A language-aware message is displayed at the start of insight generation (e.g., "Generating insights in 中文...")

### Supported Languages
All 7 languages have complete translation keys:
- English (en), Chinese (zh), Japanese (ja), German (de), Portuguese (pt), Russian (ru), French (fr)

## Files Changed

### New Files
- `packages/web-templates/src/insight/src/i18n.ts` — Client-side i18n helper for React components reading embedded translations

### Modified Files
- `packages/cli/src/services/insight/generators/TemplateRenderer.ts` — Builds and injects translation dictionary into HTML
- `packages/cli/src/services/insight/generators/StaticInsightGenerator.ts` — Passes UI language to renderer
- `packages/cli/src/services/insight/generators/DataProcessor.ts` — Uses language-aware prompts for LLM analysis
- `packages/core/src/core/prompts.ts` — `getInsightPrompt()` accepts optional language parameter
- `packages/cli/src/ui/commands/insightCommand.ts` — Displays language-aware progress messages
- `packages/cli/src/i18n/locales/*.js` — Added insight_* translation keys for all 7 languages
- `packages/web-templates/src/insight/src/*.tsx` — All React components updated to use `ti()` for translated strings
- `packages/web-templates/src/insight/src/types.ts` — Added `INSIGHT_LANGUAGE` and `INSIGHT_TRANSLATIONS` to Window interface