### PR TITLE
feat: bind `M-d` to a reasonable (Emacs-like) default

### DIFF
--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2298,6 +2298,7 @@ export function useTextBuffer({
       else if (key.meta && key.name === 'b') move('wordLeft');
       else if ((key.ctrl || key.meta) && key.name === 'right')
         move('wordRight');
+      else if (key.meta && key.name === 'd') deleteWordRight();
       else if (key.meta && key.name === 'f') move('wordRight');
       else if (key.name === 'home') move('home');
       else if (key.ctrl && key.name === 'a') move('home');


### PR DESCRIPTION
## TLDR

`M-d` was not bond.  Many users might miss the behavior introduced by this commit.  Emacs, Bash, other coding agents, etc. bind `M-d` to the behavior of deleting the next word.

## Screenshots / Video Demo

N/A.  Too simple for screenshots.

## Dive Deeper

Use the function `deleteWordRight` (already in the codebase) with `M-d` binding.

## Reviewer Test Plan

Open `qwen`. Type "word". Press `M-b`. Press `M-d`. If the word "word" disappeared, it is working.

Previous to this commit, `M-d` did nothing.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

No issue found when searching for "M-d" and "deleteWordRight". No other pull request similar to this one was found either.
