### PR TITLE
ci(stale): enable 60+30 stale/close policy for pull requests

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,8 +11,6 @@ on:
 jobs:
   stale:
     runs-on: 'ubuntu-latest'
-    if: |-
-      ${{ github.repository == 'QwenLM/qwen-code' }}
     permissions:
       issues: 'write'
       pull-requests: 'write'
@@ -44,4 +42,6 @@ jobs:
           exempt-pr-labels: 'pinned,security,status/blocked,status/on-hold,status/ready-for-merge'
           remove-stale-when-updated: true
           ascending: true
+          # Cap per-run API operations to stay well under GitHub's hourly rate limit
+          # and give the current PR backlog (~150) enough headroom across a few runs.
           operations-per-run: 100

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,18 +25,18 @@ jobs:
           # be introduced once issue triage labels are in place.
           days-before-issue-stale: -1
           days-before-issue-close: -1
-          # Pull requests: 4 weeks to stale + 4 weeks to close.
-          days-before-pr-stale: 28
-          days-before-pr-close: 28
+          # Pull requests: 5 weeks to stale + 5 weeks to close.
+          days-before-pr-stale: 35
+          days-before-pr-close: 35
           stale-pr-label: 'status/stale'
           stale-pr-message: >-
-            This pull request has had no activity for 4 weeks and is being marked as stale.
-            It will be closed in another 4 weeks if no further activity occurs.
+            This pull request has had no activity for 5 weeks and is being marked as stale.
+            It will be closed in another 5 weeks if no further activity occurs.
             To keep it open, push a new commit or leave a comment.
             Maintainers may apply `pinned`, `status/blocked`, `status/on-hold`,
             or `status/ready-for-merge` to exempt it from auto-close.
           close-pr-message: >-
-            This pull request has been closed after 4 additional weeks of inactivity.
+            This pull request has been closed after 5 additional weeks of inactivity.
             You are welcome to reopen it or submit a new pull request if the change is still relevant.
             Thanks for contributing!
           exempt-pr-labels: 'pinned,security,status/blocked,status/on-hold,status/ready-for-merge'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,9 +1,11 @@
 name: 'Mark stale issues and pull requests'
 
-# Run as a daily cron at 1:30 AM
+# Run as a daily cron at 00:30 UTC (Beijing time 08:30).
+# Avoid the top of the hour to dodge GitHub's high-contention window,
+# and stay 30 minutes after release.yml (00:00 UTC) to reduce overlap.
 on:
   schedule:
-    - cron: '30 1 * * *'
+    - cron: '30 0 * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
   stale:
     runs-on: 'ubuntu-latest'
     if: |-
-      ${{ github.repository == 'google-gemini/gemini-cli' }}
+      ${{ github.repository == 'QwenLM/qwen-code' }}
     permissions:
       issues: 'write'
       pull-requests: 'write'
@@ -21,19 +21,25 @@ jobs:
       - uses: 'actions/stale@5bef64f19d7facfb25b37b414482c7164d639639' # ratchet:actions/stale@v9
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          stale-issue-message: >-
-            This issue has been automatically marked as stale due to 60 days of inactivity.
-            It will be closed in 14 days if no further activity occurs.
+          # Issues are intentionally disabled here; a separate policy will
+          # be introduced once issue triage labels are in place.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          # Pull requests: 4 weeks to stale + 4 weeks to close.
+          days-before-pr-stale: 28
+          days-before-pr-close: 28
+          stale-pr-label: 'status/stale'
           stale-pr-message: >-
-            This pull request has been automatically marked as stale due to 60 days of inactivity.
-            It will be closed in 14 days if no further activity occurs.
-          close-issue-message: >-
-            This issue has been closed due to 14 additional days of inactivity after being marked as stale.
-            If you believe this is still relevant, feel free to comment or reopen the issue. Thank you!
+            This pull request has had no activity for 4 weeks and is being marked as stale.
+            It will be closed in another 4 weeks if no further activity occurs.
+            To keep it open, push a new commit or leave a comment.
+            Maintainers may apply `pinned`, `status/blocked`, `status/on-hold`,
+            or `status/ready-for-merge` to exempt it from auto-close.
           close-pr-message: >-
-            This pull request has been closed due to 14 additional days of inactivity after being marked as stale.
-            If this is still relevant, you are welcome to reopen or leave a comment. Thanks for contributing!
-          days-before-stale: 60
-          days-before-close: 14
-          exempt-issue-labels: 'pinned,security'
-          exempt-pr-labels: 'pinned,security'
+            This pull request has been closed after 4 additional weeks of inactivity.
+            You are welcome to reopen it or submit a new pull request if the change is still relevant.
+            Thanks for contributing!
+          exempt-pr-labels: 'pinned,security,status/blocked,status/on-hold,status/ready-for-merge'
+          remove-stale-when-updated: true
+          ascending: true
+          operations-per-run: 100

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -25,18 +25,18 @@ jobs:
           # be introduced once issue triage labels are in place.
           days-before-issue-stale: -1
           days-before-issue-close: -1
-          # Pull requests: 5 weeks to stale + 5 weeks to close.
-          days-before-pr-stale: 35
-          days-before-pr-close: 35
+          # Pull requests: 60 days to stale + 30 days to close.
+          days-before-pr-stale: 60
+          days-before-pr-close: 30
           stale-pr-label: 'status/stale'
           stale-pr-message: >-
-            This pull request has had no activity for 5 weeks and is being marked as stale.
-            It will be closed in another 5 weeks if no further activity occurs.
+            This pull request has had no activity for 60 days and is being marked as stale.
+            It will be closed in another 30 days if no further activity occurs.
             To keep it open, push a new commit or leave a comment.
             Maintainers may apply `pinned`, `status/blocked`, `status/on-hold`,
             or `status/ready-for-merge` to exempt it from auto-close.
           close-pr-message: >-
-            This pull request has been closed after 5 additional weeks of inactivity.
+            This pull request has been closed after 30 additional days of inactivity.
             You are welcome to reopen it or submit a new pull request if the change is still relevant.
             Thanks for contributing!
           exempt-pr-labels: 'pinned,security,status/blocked,status/on-hold,status/ready-for-merge'


### PR DESCRIPTION
## Background

qwen-code currently has **139 open PRs**, 36 of which have had no activity for more than 60 days. One direct reason: the pre-existing `if` guard in `.github/workflows/stale.yml` was hard-coded to `google-gemini/gemini-cli`, so the workflow **never executed** in `QwenLM/qwen-code` — the stale automation has in fact never been active.

## What this PR does

- Drop the obsolete `if` guard entirely. Scheduled runs are already disabled on forks by GitHub, and `workflow_dispatch` is manually-triggered, so the guard added no real safety — only maintenance overhead.
- Scope this change to pull requests only; issues are deliberately left untouched for now (see "Why issues are deferred" below).
- When a PR has no activity for **60 days** → apply the `status/stale` label and post a reminder comment.
- After another **30 days** with still no activity → auto-close the PR.
- Exempt labels: `pinned`, `security`, `status/blocked`, `status/on-hold`, `status/ready-for-merge`.
- `remove-stale-when-updated: true` — any push by the author or any comment automatically strips the stale label on the next cron run.
- `ascending: true` + `operations-per-run: 100` — older PRs are processed first, and each run is capped at 100 operations to stay well under GitHub's hourly rate limit.

## Why 60 + 30

Calibrated against common industry practice:

| Project | stale | close | total window |
|---|---|---|---|
| OpenJDK (Skara) | 28 days | 28 days | 56 days |
| Kubernetes | 90 days | 30 days | 120 days |
| **qwen-code (this PR)** | **60 days** | **30 days** | **90 days** |

Reasons for choosing 60 + 30:
- A longer pre-stale window (60 vs. 35 days) reduces false positives while review SLA is still unstable — authors and reviewers get a full two-month buffer before the first nag.
- A shorter post-stale grace (30 vs. 35 days) matches the Kubernetes pattern: once the stale signal has landed, 30 days of silence is a strong indicator that the PR is truly dead.
- The 90-day total sits comfortably between OpenJDK and Kubernetes.

These numbers are not final. I recommend **revisiting the false-close rate after 2–3 months of operation** and adjusting the windows once the backlog stabilizes.

## Why issues are deferred

- The vast majority of open issues have **not been triaged**; opening auto-close on them today would close valid bug reports.
- The safer sequence is to first build out the triage label taxonomy (`type/bug-confirmed` etc.), then introduce an issue-level stale policy in a separate PR.

## Expected first-run impact (based on the current 139 open PRs)

| Bucket | Count |
|---|---|
| Silent for 60–89 days → will be marked stale + commented on this run | **6** |
| Silent for ≥ 90 days → will be marked stale on this run, closed 30 days later | **30** |
| Already carries an exempt label | 0 |
| Fresh (< 60 days) | 103 |

**Nothing closes on day one** — every affected PR gets a full 30-day reaction window. Authors can push or comment to keep it alive, and maintainers can apply an exempt label to block auto-close.

## Trigger mechanism

- Daily cron at **UTC 00:30** (Beijing time 08:30).
- Can also be triggered manually via `workflow_dispatch` in the Actions tab.
- Worst-case latency: 24 hours (the next cron window).

## Follow-ups (after merge)

1. Scan every workflow for the same `google-gemini/gemini-cli` guard bug (at minimum `gemini-self-assign-issue.yml` has this problem).
2. Encourage reviewers to apply `status/ready-for-merge` after approving, so PRs waiting only on a merge are not mis-closed.
3. After 2–3 months of operation, measure the false-close rate and the rebound rate, then adjust the windows based on data.
4. Once triage labels are ready, open a separate PR introducing the issue-level stale policy.

## Test plan

- [ ] After merge, trigger `workflow_dispatch` once manually to validate the ascending order, exempt-label handling, and the `operations-per-run: 100` batching.
- [ ] Verify that a PR carrying `status/ready-for-merge` is skipped.

---

## 背景

qwen-code 当前有 **139 个 open PR**，其中 36 个已经超过 60 天没有活动。一个直接原因：原先 `.github/workflows/stale.yml` 的 `if` 守卫写死的是 `google-gemini/gemini-cli`，在 `QwenLM/qwen-code` 仓库里**永远不会执行**，也就是 stale 自动化从来没生效过。

## 这个 PR 做了什么

- 彻底去掉过时的 `if` 守卫。GitHub 对 fork 默认禁用 scheduled workflow，`workflow_dispatch` 本身又只有写权限者能触发，所以这层守卫没有实际安全收益，只增加维护负担。
- 本次只处理 PR，issue 暂时保留（见下方「为什么 issue 先不动」）。
- PR 连续 **60 天**无活动 → 打 `status/stale` 标签 + 发提醒评论。
- 再过 **30 天**仍无活动 → 自动关闭。
- 豁免标签：`pinned`、`security`、`status/blocked`、`status/on-hold`、`status/ready-for-merge`。
- `remove-stale-when-updated: true`——作者 push 或任何人评论后，下一次 cron 自动撕掉 stale 标签。
- `ascending: true` + `operations-per-run: 100`——老 PR 优先处理，每次最多操作 100 条，远离 GitHub 小时级限流红线。

## 为什么是 60 + 30

对标业界常见做法：

| 项目 | stale | close | 总窗口 |
|---|---|---|---|
| OpenJDK (Skara) | 28 天 | 28 天 | 56 天 |
| Kubernetes | 90 天 | 30 天 | 120 天 |
| **qwen-code (本 PR)** | **60 天** | **30 天** | **90 天** |

选 60 + 30 的理由：
- 更长的 pre-stale 窗口（60 vs. 35 天）在 review SLA 还不稳定时能减少误判——作者和 reviewer 在首次提醒前有完整的两个月缓冲。
- 更短的 post-stale 宽限（30 vs. 35 天）沿用 Kubernetes 的做法：既然 stale 信号已经到位，再 30 天无响应基本可以判定 PR 已死。
- 90 天总窗口正好介于 OpenJDK 和 Kubernetes 之间。

数字不是最终的。建议**运行 2–3 个月后复盘误关率**，再根据数据调整。

## 为什么 issue 先不动

- 当前 open issue 绝大多数**没被分诊**，直接开 auto-close 会误关有效 bug 报告。
- 更合理的顺序是先完善 `type/bug-confirmed` 等分诊标签体系，再用单独 PR 处理 issue 的 stale 策略。

## 首次运行预估影响（基于当前 139 个 open PR）

| 分类 | 数量 |
|---|---|
| 已静默 60–89 天 → 本次打 stale 标签 + 评论 | **6** |
| 已静默 ≥ 90 天 → 本次打 stale 标签，30 天后关闭 | **30** |
| 带豁免标签 | 0 |
| Fresh(< 60 天) | 103 |

**第一天不会关任何 PR**——每个受影响的 PR 都有完整的 30 天反应窗口，作者可以 push / 评论续命，maintainer 也可以打豁免标签拦住。

## 触发机制

- 每天 **UTC 00:30**（北京时间 08:30）cron 触发。
- 也可以在 Actions 页面手动 `workflow_dispatch`。
- 最坏情况延迟 24 小时（下一个 cron 窗口）。

## 合并后的 Follow-ups

1. 扫一遍所有 workflow，找出其他写死 `google-gemini/gemini-cli` 的坏守卫（至少 `gemini-self-assign-issue.yml` 有同样问题）。
2. 推动 reviewer 在 approve 之后打 `status/ready-for-merge` 豁免标签，避免长期 approve 但卡在等合并的 PR 被误关。
3. 运行 2–3 个月后统计误关率和反弹率，根据数据调整窗口。
4. 等分诊标签完善后，单独开 PR 引入 issue 的 stale policy。

## Test plan

- [ ] 合并后手动 `workflow_dispatch` 一次，验证 ascending 顺序、豁免标签、`operations-per-run: 100` 的批量行为。
- [ ] 验证带 `status/ready-for-merge` 的 PR 被豁免不处理。
