### PR TITLE
feat(cli): headless support and SDK task events for background agents

### DIFF
--- a/.qwen/skills/structured-debugging/SKILL.md
+++ b/.qwen/skills/structured-debugging/SKILL.md
@@ -32,11 +32,9 @@ Good: "The leader hangs because `hasActiveTeammates()` returns true after all ag
 have reported completed, likely because terminal status isn't being set on the agent
 object after the backend process exits."
 
-For bugs you expect to take more than one round, create a side note file for
-the investigation. Use whichever path the project conventionally uses for
-investigation notes (e.g., `notes/<issue>.md`, `docs/investigations/<issue>.md`)
-or fall back to `<repo>/.notes/<issue>.md`. In the qwen-code workspace this
-is `knowledge/qwen-code/investigations/<issue>.md`.
+For bugs you expect to take more than one round, create a side note file
+for the investigation in whichever location the project uses for such
+notes.
 
 Write your hypothesis there. This file persists across conversation turns and even
 across sessions — it's your investigation journal.

--- a/.qwen/skills/structured-debugging/SKILL.md
+++ b/.qwen/skills/structured-debugging/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: structured-debugging
-description:
+description: >
   Hypothesis-driven debugging methodology for hard bugs. Use this skill whenever
   you're investigating non-trivial bugs, unexpected behavior, flaky tests, or
   tracing issues through complex systems. Activate proactively when debugging
@@ -35,7 +35,7 @@ object after the backend process exits."
 Create a side note file for the investigation:
 
 ```
-~/.qwen/investigations/<project>-<issue>.md
+knowledge/qwen-code/investigations/<issue>.md
 ```
 
 Write your hypothesis there. This file persists across conversation turns and even
@@ -164,3 +164,10 @@ Fix: [what you're changing and why it addresses the root cause]
 ```
 
 Then apply the fix, remove instrumentation, and verify with a clean run.
+
+## Worked examples
+
+- [`examples/headless-bg-agent-empty-stdout.md`](examples/headless-bg-agent-empty-stdout.md)
+  — pipe-captured runs all passed; the user's TTY printed nothing. The
+  contradiction _was_ the bug. Illustrates _reproduction contradiction is
+  data_ and _instrument data, not code paths_.

--- a/.qwen/skills/structured-debugging/SKILL.md
+++ b/.qwen/skills/structured-debugging/SKILL.md
@@ -32,11 +32,11 @@ Good: "The leader hangs because `hasActiveTeammates()` returns true after all ag
 have reported completed, likely because terminal status isn't being set on the agent
 object after the backend process exits."
 
-Create a side note file for the investigation:
-
-```
-knowledge/qwen-code/investigations/<issue>.md
-```
+For bugs you expect to take more than one round, create a side note file for
+the investigation. Use whichever path the project conventionally uses for
+investigation notes (e.g., `notes/<issue>.md`, `docs/investigations/<issue>.md`)
+or fall back to `<repo>/.notes/<issue>.md`. In the qwen-code workspace this
+is `knowledge/qwen-code/investigations/<issue>.md`.
 
 Write your hypothesis there. This file persists across conversation turns and even
 across sessions — it's your investigation journal.
@@ -48,6 +48,12 @@ confirm or reject your hypothesis. Think about what data you need to see.
 
 Don't scatter `console.log` everywhere. Identify the 2-3 places where your
 hypothesis makes a testable prediction, and instrument those.
+
+Prefer logging _values_ (return codes, payload contents, stream types,
+message bodies, env state) over _presence checks_ ("was this function
+called?", "was this branch taken?"). Code-path traces tell you what ran;
+data traces tell you what it ran on. Most non-trivial bugs are correct
+code processing wrong data.
 
 Ask yourself: "If my hypothesis is correct, what will I see at point X?
 If it's wrong, what will I see instead?"
@@ -128,6 +134,23 @@ is still broken if the inbox contains stale messages from a previous run.
 
 Always inspect the _content_ flowing through the code, not just whether the code
 runs. Check payloads, message contents, file data, and database state.
+
+### Reframing the user's report instead of investigating it
+
+When the user reports a symptom your own run doesn't reproduce, the
+contradiction _is_ the evidence — the two environments differ in some way
+you haven't identified yet. The wrong move is to reframe their report
+("they must be on a stale SHA", "they must be confused about what they
+saw", "must be a flake") so that your run becomes the ground truth. Once
+you do that, every later piece of evidence gets bent to defend the
+reframing, and the actual bug stays hidden.
+
+The right move: catalogue what differs between their environment and
+yours (TTY vs pipe, terminal emulator, shell, locale, env vars, prior
+state, build artifacts) before forming any hypothesis. For ambiguous
+symptoms ("no output", "it's slow", "it's wrong") ask one disambiguating
+question first — e.g., "does it hang or exit cleanly?" — that prunes the
+hypothesis space cheaply before any test run.
 
 ### Losing context across attempts
 

--- a/.qwen/skills/structured-debugging/examples/headless-bg-agent-empty-stdout.md
+++ b/.qwen/skills/structured-debugging/examples/headless-bg-agent-empty-stdout.md
@@ -1,0 +1,59 @@
+# Worked example: headless run prints empty stdout in zsh TTY
+
+A short qwen-code case to illustrate two failure modes from `SKILL.md`:
+_reproduction contradiction is data_, and _instrument the data flow, not
+just the code path_.
+
+## The bug
+
+User: `npm run dev -- -p "..."` in zsh prints nothing. Process exits clean,
+`~/.qwen/logs` shows the model returned proper text. Stdout was empty.
+
+Cause: `JsonOutputAdapter.emitResult` wrote `resultMessage.result` without
+a trailing `\n`. zsh's `PROMPT_SP` (powerlevel10k, agnoster, …) detects
+the missing newline and emits `\r\033[K` before drawing the next prompt,
+erasing the line. Pipe-captured stdout has no `PROMPT_SP`, so the bug is
+invisible there.
+
+Fix: append `\n` to the write.
+
+## What made the case instructive
+
+Every reproduction attempt from a debugging environment that captures
+stdout (Cursor's Shell tool, `out=$(...)`, `tee`, file redirect) **passed**.
+14/14 success against the user's 0/N. Same SHA, same machine, same
+command. The only variable was: pipe stdout vs TTY stdout.
+
+That contradiction was the entire investigation. Once it was named, the
+fix was one line.
+
+## Lessons mapped to SKILL.md
+
+- **Reproduction contradiction is data, not user error.** When your run
+  succeeds and the user's fails on identical state, the _difference
+  between the two environments_ is where the bug lives. Catalogue what
+  differs (TTY vs pipe, terminal emulator, shell, locale, env vars,
+  prior state) before forming any hypothesis. Reframing the user's
+  report ("they must be on stale code") burns rounds and credibility.
+
+- **Ask the one disambiguating question first.** "Does it hang or exit
+  cleanly?" would have falsified the most tempting wrong hypothesis here
+  (the recently-fixed drain-loop hang) on turn one. For any "no output"
+  report, that question is free and prunes half the hypothesis space.
+
+- **Instrument the data flow, not just the code path.** Tracing whether
+  `write` was called showed the happy path firing every time and resolved
+  nothing. The breakthrough was logging the _return value_ of
+  `process.stdout.write` together with `process.stdout.isTTY`. Code-path
+  traces tell you what ran; data traces tell you what it ran on.
+
+- **Pipe ≠ TTY.** A passing pipe-captured run does not prove a TTY user
+  sees the same output. Shell prompts can post-process trailing-newline-
+  less writes; terminals can swallow control sequences; pipes do
+  neither. When debugging interactive-shell symptoms, get evidence from
+  the user's actual terminal at least once.
+
+## Reference
+
+Fix commit: qwen-code `feadf052f` —
+`fix(cli): append newline to text-mode emitResult so zsh PROMPT_SP doesn't erase the line`

--- a/packages/cli/src/nonInteractive/io/JsonOutputAdapter.ts
+++ b/packages/cli/src/nonInteractive/io/JsonOutputAdapter.ts
@@ -67,9 +67,9 @@ export class JsonOutputAdapter
 
     if (this.config.getOutputFormat() === 'text') {
       if (resultMessage.is_error) {
-        process.stderr.write(`${resultMessage.error?.message || ''}`);
+        process.stderr.write(`${resultMessage.error?.message || ''}\n`);
       } else {
-        process.stdout.write(`${resultMessage.result}`);
+        process.stdout.write(`${resultMessage.result}\n`);
       }
     } else {
       // Emit the entire messages array as JSON (includes all main agent + subagent messages)

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -260,7 +260,7 @@ describe('runNonInteractive', () => {
       'prompt-id-1',
       { type: SendMessageType.UserQuery },
     );
-    expect(processStdoutSpy).toHaveBeenCalledWith('Hello World');
+    expect(processStdoutSpy).toHaveBeenCalledWith('Hello World\n');
     expect(mockShutdownTelemetry).toHaveBeenCalled();
   });
 
@@ -324,7 +324,7 @@ describe('runNonInteractive', () => {
       'prompt-id-2',
       { type: SendMessageType.ToolResult },
     );
-    expect(processStdoutSpy).toHaveBeenCalledWith('Final answer');
+    expect(processStdoutSpy).toHaveBeenCalledWith('Final answer\n');
   });
 
   it('should handle error during tool execution and should send error back to the model', async () => {
@@ -393,7 +393,7 @@ describe('runNonInteractive', () => {
       'prompt-id-3',
       { type: SendMessageType.ToolResult },
     );
-    expect(processStdoutSpy).toHaveBeenCalledWith('Sorry, let me try again.');
+    expect(processStdoutSpy).toHaveBeenCalledWith('Sorry, let me try again.\n');
   });
 
   it('should exit with error if sendMessageStream throws initially', async () => {
@@ -455,7 +455,7 @@ describe('runNonInteractive', () => {
     expect(mockCoreExecuteToolCall).toHaveBeenCalled();
     expect(mockGeminiClient.sendMessageStream).toHaveBeenCalledTimes(2);
     expect(processStdoutSpy).toHaveBeenCalledWith(
-      "Sorry, I can't find that tool.",
+      "Sorry, I can't find that tool.\n",
     );
   });
 
@@ -519,7 +519,7 @@ describe('runNonInteractive', () => {
     );
 
     // 6. Assert the final output is correct
-    expect(processStdoutSpy).toHaveBeenCalledWith('Summary complete.');
+    expect(processStdoutSpy).toHaveBeenCalledWith('Summary complete.\n');
   });
 
   it('should process input and write JSON output with stats', async () => {
@@ -892,7 +892,7 @@ describe('runNonInteractive', () => {
       { type: SendMessageType.UserQuery },
     );
 
-    expect(processStdoutSpy).toHaveBeenCalledWith('Response from command');
+    expect(processStdoutSpy).toHaveBeenCalledWith('Response from command\n');
   });
 
   it('should handle command that requires confirmation by returning early', async () => {
@@ -917,7 +917,7 @@ describe('runNonInteractive', () => {
 
     // Should write error message through adapter to stdout (TEXT mode goes through JsonOutputAdapter)
     expect(processStderrSpy).toHaveBeenCalledWith(
-      'Shell command confirmation is not supported in non-interactive mode. Use YOLO mode or pre-approve commands.',
+      'Shell command confirmation is not supported in non-interactive mode. Use YOLO mode or pre-approve commands.\n',
     );
   });
 
@@ -952,7 +952,7 @@ describe('runNonInteractive', () => {
       { type: SendMessageType.UserQuery },
     );
 
-    expect(processStdoutSpy).toHaveBeenCalledWith('Response to unknown');
+    expect(processStdoutSpy).toHaveBeenCalledWith('Response to unknown\n');
   });
 
   it('should handle known but unsupported slash commands like /help by returning early', async () => {
@@ -975,7 +975,7 @@ describe('runNonInteractive', () => {
 
     // Should write error message through adapter to stdout (TEXT mode goes through JsonOutputAdapter)
     expect(processStderrSpy).toHaveBeenCalledWith(
-      'The command "/help" is not supported in non-interactive mode.',
+      'The command "/help" is not supported in non-interactive mode.\n',
     );
   });
 
@@ -1000,7 +1000,7 @@ describe('runNonInteractive', () => {
 
     // Should write error message to stderr
     expect(processStderrSpy).toHaveBeenCalledWith(
-      'Unknown command result type: unhandled',
+      'Unknown command result type: unhandled\n',
     );
   });
 
@@ -1038,7 +1038,7 @@ describe('runNonInteractive', () => {
 
     expect(mockAction).toHaveBeenCalledWith(expect.any(Object), 'arg1 arg2');
 
-    expect(processStdoutSpy).toHaveBeenCalledWith('Acknowledged');
+    expect(processStdoutSpy).toHaveBeenCalledWith('Acknowledged\n');
   });
 
   it('should emit stream-json envelopes when output format is stream-json', async () => {

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -148,6 +148,7 @@ describe('runNonInteractive', () => {
       getCronScheduler: vi.fn().mockReturnValue(null),
       getBackgroundTaskRegistry: vi.fn().mockReturnValue({
         setNotificationCallback: vi.fn(),
+        setRegisterCallback: vi.fn(),
         getRunning: vi.fn().mockReturnValue([]),
       }),
     } as unknown as Config;

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -146,6 +146,10 @@ describe('runNonInteractive', () => {
       isInteractive: vi.fn().mockReturnValue(false),
       isCronEnabled: vi.fn().mockReturnValue(false),
       getCronScheduler: vi.fn().mockReturnValue(null),
+      getBackgroundTaskRegistry: vi.fn().mockReturnValue({
+        setNotificationCallback: vi.fn(),
+        getRunning: vi.fn().mockReturnValue([]),
+      }),
     } as unknown as Config;
 
     mockSettings = {

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -250,6 +250,26 @@ export async function runNonInteractive(
       const initialParts = normalizePartList(initialPartList);
       let currentMessages: Content[] = [{ role: 'user', parts: initialParts }];
 
+      // ─── Shared notification queue (cron + background agents) ──────
+      // Register the callback early so background agents launched during
+      // the main tool-call chain can push completions onto the queue.
+      interface LocalQueueItem {
+        displayText: string;
+        modelText: string;
+        sendMessageType: SendMessageType;
+      }
+      const localQueue: LocalQueueItem[] = [];
+      const registry = config.getBackgroundTaskRegistry();
+      registry.setNotificationCallback(
+        (displayText: string, modelText: string) => {
+          localQueue.push({
+            displayText,
+            modelText,
+            sendMessageType: SendMessageType.Notification,
+          });
+        },
+      );
+
       let isFirstTurn = true;
       let modelOverride: string | undefined;
       while (true) {
@@ -380,142 +400,155 @@ export async function runNonInteractive(
           }
           currentMessages = [{ role: 'user', parts: toolResponseParts }];
         } else {
-          // No more tool calls — check if cron jobs are keeping us alive
+          // No more tool calls — drain notifications and cron, then exit.
+
+          // Process one queue item through the full turn loop.
+          const drainOneItem = async () => {
+            if (localQueue.length === 0) return;
+            const item = localQueue.shift()!;
+
+            // Emit background agent notifications as a user message in the
+            // JSON stream so consumers can distinguish them from model output.
+            // Cron turns are not emitted — preserves existing headless cron output.
+            if (item.sendMessageType === SendMessageType.Notification) {
+              adapter.emitUserMessage([{ text: item.displayText }]);
+            }
+
+            turnCount++;
+            let itemMessages: Content[] = [
+              { role: 'user', parts: [{ text: item.modelText }] },
+            ];
+            let itemIsFirstTurn = true;
+            let itemModelOverride: string | undefined;
+
+            while (true) {
+              const itemToolCallRequests: ToolCallRequestInfo[] = [];
+              const itemApiStartTime = Date.now();
+              const itemStream = geminiClient.sendMessageStream(
+                itemMessages[0]?.parts || [],
+                abortController.signal,
+                prompt_id,
+                {
+                  type: itemIsFirstTurn
+                    ? item.sendMessageType
+                    : SendMessageType.ToolResult,
+                  modelOverride: itemModelOverride,
+                  ...(itemIsFirstTurn && {
+                    notificationDisplayText: item.displayText,
+                  }),
+                },
+              );
+              itemIsFirstTurn = false;
+
+              adapter.startAssistantMessage();
+
+              for await (const event of itemStream) {
+                if (abortController.signal.aborted) {
+                  return;
+                }
+                adapter.processEvent(event);
+                if (event.type === GeminiEventType.ToolCallRequest) {
+                  itemToolCallRequests.push(event.value);
+                }
+              }
+
+              adapter.finalizeAssistantMessage();
+              totalApiDurationMs += Date.now() - itemApiStartTime;
+
+              if (itemToolCallRequests.length > 0) {
+                const itemToolResponseParts: Part[] = [];
+
+                for (const requestInfo of itemToolCallRequests) {
+                  const isAgentTool = requestInfo.name === 'agent';
+                  const { handler: outputUpdateHandler } = isAgentTool
+                    ? createAgentToolProgressHandler(
+                        config,
+                        requestInfo.callId,
+                        adapter,
+                      )
+                    : createToolProgressHandler(requestInfo, adapter);
+
+                  const toolResponse = await executeToolCall(
+                    config,
+                    requestInfo,
+                    abortController.signal,
+                    { outputUpdateHandler },
+                  );
+
+                  if (toolResponse.error) {
+                    handleToolError(
+                      requestInfo.name,
+                      toolResponse.error,
+                      config,
+                      toolResponse.errorType || 'TOOL_EXECUTION_ERROR',
+                      typeof toolResponse.resultDisplay === 'string'
+                        ? toolResponse.resultDisplay
+                        : undefined,
+                    );
+                  }
+
+                  adapter.emitToolResult(requestInfo, toolResponse);
+
+                  if (toolResponse.responseParts) {
+                    itemToolResponseParts.push(...toolResponse.responseParts);
+                  }
+
+                  if ('modelOverride' in toolResponse) {
+                    itemModelOverride = toolResponse.modelOverride;
+                  }
+                }
+                itemMessages = [{ role: 'user', parts: itemToolResponseParts }];
+              } else {
+                break;
+              }
+            }
+          };
+
+          // Drain all currently queued items.
+          const drainLocalQueue = async () => {
+            while (localQueue.length > 0) {
+              await drainOneItem();
+            }
+          };
+
+          // Start cron scheduler — fires enqueue onto the shared queue.
           const scheduler = !config.isCronEnabled()
             ? null
             : config.getCronScheduler();
-          if (scheduler && scheduler.size > 0) {
-            // Start the scheduler and wait for all jobs to complete or be deleted.
-            // Each fired prompt is processed as a new turn through the same loop.
-            await new Promise<void>((resolve) => {
-              const cronQueue: string[] = [];
-              let processing = false;
 
-              const checkDone = () => {
-                if (scheduler.size === 0 && !processing) {
+          if (scheduler && scheduler.size > 0) {
+            await new Promise<void>((resolve) => {
+              const checkCronDone = () => {
+                if (scheduler.size === 0) {
                   scheduler.stop();
                   resolve();
                 }
               };
 
-              const drainQueue = async () => {
-                if (processing) return;
-                processing = true;
-                try {
-                  while (cronQueue.length > 0) {
-                    const cronPrompt = cronQueue.shift()!;
-                    turnCount++;
-                    let cronMessages: Content[] = [
-                      { role: 'user', parts: [{ text: cronPrompt }] },
-                    ];
-                    let cronIsFirstTurn = true;
-                    let cronModelOverride: string | undefined;
-
-                    while (true) {
-                      const cronToolCallRequests: ToolCallRequestInfo[] = [];
-                      const cronApiStartTime = Date.now();
-                      const cronStream = geminiClient.sendMessageStream(
-                        cronMessages[0]?.parts || [],
-                        abortController.signal,
-                        prompt_id,
-                        {
-                          type: cronIsFirstTurn
-                            ? SendMessageType.Cron
-                            : SendMessageType.ToolResult,
-                          modelOverride: cronModelOverride,
-                        },
-                      );
-                      cronIsFirstTurn = false;
-
-                      adapter.startAssistantMessage();
-
-                      for await (const event of cronStream) {
-                        if (abortController.signal.aborted) {
-                          const summary = scheduler.getExitSummary();
-                          scheduler.stop();
-                          if (summary) {
-                            process.stderr.write(summary + '\n');
-                          }
-                          resolve();
-                          return;
-                        }
-                        adapter.processEvent(event);
-                        if (event.type === GeminiEventType.ToolCallRequest) {
-                          cronToolCallRequests.push(event.value);
-                        }
-                      }
-
-                      adapter.finalizeAssistantMessage();
-                      totalApiDurationMs += Date.now() - cronApiStartTime;
-
-                      if (cronToolCallRequests.length > 0) {
-                        const cronToolResponseParts: Part[] = [];
-
-                        for (const requestInfo of cronToolCallRequests) {
-                          const isAgentTool = requestInfo.name === 'agent';
-                          const { handler: outputUpdateHandler } = isAgentTool
-                            ? createAgentToolProgressHandler(
-                                config,
-                                requestInfo.callId,
-                                adapter,
-                              )
-                            : createToolProgressHandler(requestInfo, adapter);
-
-                          const toolResponse = await executeToolCall(
-                            config,
-                            requestInfo,
-                            abortController.signal,
-                            { outputUpdateHandler },
-                          );
-
-                          if (toolResponse.error) {
-                            handleToolError(
-                              requestInfo.name,
-                              toolResponse.error,
-                              config,
-                              toolResponse.errorType || 'TOOL_EXECUTION_ERROR',
-                              typeof toolResponse.resultDisplay === 'string'
-                                ? toolResponse.resultDisplay
-                                : undefined,
-                            );
-                          }
-
-                          adapter.emitToolResult(requestInfo, toolResponse);
-
-                          if (toolResponse.responseParts) {
-                            cronToolResponseParts.push(
-                              ...toolResponse.responseParts,
-                            );
-                          }
-
-                          if ('modelOverride' in toolResponse) {
-                            cronModelOverride = toolResponse.modelOverride;
-                          }
-                        }
-                        cronMessages = [
-                          { role: 'user', parts: cronToolResponseParts },
-                        ];
-                      } else {
-                        break;
-                      }
-                    }
-                  }
-                } catch (error) {
-                  debugLogger.error('Error processing cron prompt:', error);
-                } finally {
-                  processing = false;
-                  checkDone();
-                }
-              };
-
               scheduler.start((job: { prompt: string }) => {
-                cronQueue.push(job.prompt);
-                void drainQueue();
+                const label = job.prompt.slice(0, 40);
+                localQueue.push({
+                  displayText: `Cron: ${label}`,
+                  modelText: job.prompt,
+                  sendMessageType: SendMessageType.Cron,
+                });
+                void drainLocalQueue().then(checkCronDone);
               });
 
-              // Also check immediately in case jobs were already deleted
-              checkDone();
+              // Check immediately in case jobs were already deleted
+              checkCronDone();
             });
+          }
+
+          // ─── Terminal hold-back phase ──────────────────────────
+          // Wait for running background agents to complete and drain
+          // their notifications before emitting the final result.
+           
+          while (true) {
+            await drainLocalQueue();
+            const running = registry.getRunning();
+            if (running.length === 0 && localQueue.length === 0) break;
+            await new Promise((r) => setTimeout(r, 100));
           }
 
           const metrics = uiTelemetryService.getMetrics();
@@ -567,6 +600,13 @@ export async function runNonInteractive(
       });
       handleError(error, config);
     } finally {
+      // Unregister background agent notification callback.
+      try {
+        config.getBackgroundTaskRegistry().setNotificationCallback(() => {});
+      } catch {
+        // Ignore — registry may not be initialized if we failed early.
+      }
+
       process.stdout.removeListener('error', stdoutErrorHandler);
       // Cleanup signal handlers
       process.removeListener('SIGINT', shutdownHandler);

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -589,8 +589,24 @@ export async function runNonInteractive(
 
           if (scheduler && scheduler.size > 0) {
             await new Promise<void>((resolve) => {
+              // Resolve on SIGINT/SIGTERM too — recurring cron jobs never
+              // drop scheduler.size to 0 on their own, so without this the
+              // hold-back loop below is unreachable after an abort.
+              const onAbort = () => {
+                scheduler.stop();
+                resolve();
+              };
+              if (abortController.signal.aborted) {
+                onAbort();
+                return;
+              }
+              abortController.signal.addEventListener('abort', onAbort, {
+                once: true,
+              });
+
               const checkCronDone = () => {
                 if (scheduler.size === 0 && !drainPromise) {
+                  abortController.signal.removeEventListener('abort', onAbort);
                   scheduler.stop();
                   resolve();
                 }

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -451,6 +451,17 @@ export async function runNonInteractive(
             }
 
             turnCount++;
+            // Symmetry with the main turn loop: drain-turns (cron fires and
+            // background-agent notification replies) count toward the
+            // configured budget too, otherwise a looping cron or a model
+            // that keeps replying to notifications can exceed the cap
+            // silently in headless runs.
+            if (
+              config.getMaxSessionTurns() >= 0 &&
+              turnCount > config.getMaxSessionTurns()
+            ) {
+              handleMaxTurnsExceededError(config);
+            }
             let itemMessages: Content[] = [
               { role: 'user', parts: [{ text: item.modelText }] },
             ];
@@ -480,6 +491,9 @@ export async function runNonInteractive(
 
               for await (const event of itemStream) {
                 if (abortController.signal.aborted) {
+                  // Pair the startAssistantMessage() above so stream-json
+                  // mode doesn't leave an unterminated message_start.
+                  adapter.finalizeAssistantMessage();
                   return;
                 }
                 adapter.processEvent(event);

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -483,6 +483,17 @@ export async function runNonInteractive(
                 if (event.type === GeminiEventType.ToolCallRequest) {
                   itemToolCallRequests.push(event.value);
                 }
+                if (
+                  outputFormat === OutputFormat.TEXT &&
+                  event.type === GeminiEventType.Error
+                ) {
+                  const errorText = parseAndFormatApiError(
+                    event.value.error,
+                    config.getContentGeneratorConfig()?.authType,
+                  );
+                  process.stderr.write(`${errorText}\n`);
+                  throw new Error(errorText);
+                }
               }
 
               adapter.finalizeAssistantMessage();
@@ -492,6 +503,16 @@ export async function runNonInteractive(
                 const itemToolResponseParts: Part[] = [];
 
                 for (const requestInfo of itemToolCallRequests) {
+                  const itemInputFormat =
+                    typeof config.getInputFormat === 'function'
+                      ? config.getInputFormat()
+                      : InputFormat.TEXT;
+                  const itemToolCallUpdateCallback =
+                    itemInputFormat === InputFormat.STREAM_JSON &&
+                    options.controlService
+                      ? options.controlService.permission.getToolCallUpdateCallback()
+                      : undefined;
+
                   const isAgentTool = requestInfo.name === 'agent';
                   const { handler: outputUpdateHandler } = isAgentTool
                     ? createAgentToolProgressHandler(
@@ -505,7 +526,12 @@ export async function runNonInteractive(
                     config,
                     requestInfo,
                     abortController.signal,
-                    { outputUpdateHandler },
+                    {
+                      outputUpdateHandler,
+                      ...(itemToolCallUpdateCallback && {
+                        onToolCallsUpdate: itemToolCallUpdateCallback,
+                      }),
+                    },
                   );
 
                   if (toolResponse.error) {
@@ -587,9 +613,15 @@ export async function runNonInteractive(
 
           // ─── Terminal hold-back phase ──────────────────────────
           // Wait for running background agents to complete and drain
-          // their notifications before emitting the final result.
+          // their notifications before emitting the final result. If
+          // SIGINT/SIGTERM fires here, abort running background agents
+          // (they use their own AbortControllers) and exit the loop.
 
           while (true) {
+            if (abortController.signal.aborted) {
+              registry.abortAll();
+              break;
+            }
             await drainLocalQueue();
             const running = registry.getRunning();
             if (running.length === 0 && localQueue.length === 0) break;

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -537,11 +537,23 @@ export async function runNonInteractive(
             }
           };
 
-          // Drain all currently queued items.
-          const drainLocalQueue = async () => {
-            while (localQueue.length > 0) {
-              await drainOneItem();
-            }
+          // Single-flight drain: concurrent callers wait for the running
+          // drain. A new drain starts only after the previous one finishes
+          // its queue, which prevents overlapping turns when cron jobs fire
+          // while an earlier queued item is still streaming.
+          let drainPromise: Promise<void> | null = null;
+          const drainLocalQueue = (): Promise<void> => {
+            if (drainPromise) return drainPromise;
+            drainPromise = (async () => {
+              try {
+                while (localQueue.length > 0) {
+                  await drainOneItem();
+                }
+              } finally {
+                drainPromise = null;
+              }
+            })();
+            return drainPromise;
           };
 
           // Start cron scheduler — fires enqueue onto the shared queue.
@@ -552,7 +564,7 @@ export async function runNonInteractive(
           if (scheduler && scheduler.size > 0) {
             await new Promise<void>((resolve) => {
               const checkCronDone = () => {
-                if (scheduler.size === 0) {
+                if (scheduler.size === 0 && !drainPromise) {
                   scheduler.stop();
                   resolve();
                 }

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Config, ToolCallRequestInfo } from '@qwen-code/qwen-code-core';
+import type {
+  BackgroundAgentStatus,
+  Config,
+  ToolCallRequestInfo,
+} from '@qwen-code/qwen-code-core';
 import { isSlashCommand } from './ui/utils/commandUtils.js';
 import type { LoadedSettings } from './config/settings.js';
 import {
@@ -257,18 +261,44 @@ export async function runNonInteractive(
         displayText: string;
         modelText: string;
         sendMessageType: SendMessageType;
+        sdkNotification?: {
+          task_id: string;
+          status: BackgroundAgentStatus;
+          usage?: {
+            total_tokens: number;
+            tool_uses: number;
+            duration_ms: number;
+          };
+        };
       }
       const localQueue: LocalQueueItem[] = [];
       const registry = config.getBackgroundTaskRegistry();
-      registry.setNotificationCallback(
-        (displayText: string, modelText: string) => {
-          localQueue.push({
-            displayText,
-            modelText,
-            sendMessageType: SendMessageType.Notification,
-          });
-        },
-      );
+      registry.setNotificationCallback((displayText, modelText, meta) => {
+        localQueue.push({
+          displayText,
+          modelText,
+          sendMessageType: SendMessageType.Notification,
+          sdkNotification: {
+            task_id: meta.agentId,
+            status: meta.status,
+            usage: meta.stats
+              ? {
+                  total_tokens: meta.stats.totalTokens,
+                  tool_uses: meta.stats.toolUses,
+                  duration_ms: meta.stats.durationMs,
+                }
+              : undefined,
+          },
+        });
+      });
+
+      registry.setRegisterCallback((entry) => {
+        adapter.emitSystemMessage('task_started', {
+          task_id: entry.agentId,
+          description: entry.description,
+          subagent_type: entry.subagentType,
+        });
+      });
 
       let isFirstTurn = true;
       let modelOverride: string | undefined;
@@ -407,11 +437,14 @@ export async function runNonInteractive(
             if (localQueue.length === 0) return;
             const item = localQueue.shift()!;
 
-            // Emit background agent notifications as a user message in the
-            // JSON stream so consumers can distinguish them from model output.
-            // Cron turns are not emitted — preserves existing headless cron output.
             if (item.sendMessageType === SendMessageType.Notification) {
               adapter.emitUserMessage([{ text: item.displayText }]);
+              if (item.sdkNotification) {
+                adapter.emitSystemMessage(
+                  'task_notification',
+                  item.sdkNotification,
+                );
+              }
             }
 
             turnCount++;
@@ -543,7 +576,7 @@ export async function runNonInteractive(
           // ─── Terminal hold-back phase ──────────────────────────
           // Wait for running background agents to complete and drain
           // their notifications before emitting the final result.
-           
+
           while (true) {
             await drainLocalQueue();
             const running = registry.getRunning();
@@ -600,9 +633,10 @@ export async function runNonInteractive(
       });
       handleError(error, config);
     } finally {
-      // Unregister background agent notification callback.
       try {
-        config.getBackgroundTaskRegistry().setNotificationCallback(() => {});
+        const reg = config.getBackgroundTaskRegistry();
+        reg.setNotificationCallback(undefined);
+        reg.setRegisterCallback(undefined);
       } catch {
         // Ignore — registry may not be initialized if we failed early.
       }

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -263,6 +263,7 @@ export async function runNonInteractive(
         sendMessageType: SendMessageType;
         sdkNotification?: {
           task_id: string;
+          tool_use_id?: string;
           status: BackgroundAgentStatus;
           usage?: {
             total_tokens: number;
@@ -280,6 +281,7 @@ export async function runNonInteractive(
           sendMessageType: SendMessageType.Notification,
           sdkNotification: {
             task_id: meta.agentId,
+            tool_use_id: meta.toolUseId,
             status: meta.status,
             usage: meta.stats
               ? {
@@ -295,6 +297,7 @@ export async function runNonInteractive(
       registry.setRegisterCallback((entry) => {
         adapter.emitSystemMessage('task_started', {
           task_id: entry.agentId,
+          tool_use_id: entry.toolUseId,
           description: entry.description,
           subagent_type: entry.subagentType,
         });

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -570,19 +570,29 @@ export async function runNonInteractive(
           // drain. A new drain starts only after the previous one finishes
           // its queue, which prevents overlapping turns when cron jobs fire
           // while an earlier queued item is still streaming.
+          //
+          // The null-clearing is attached via `.finally()` on the outer
+          // promise rather than inside the async body. When the queue is
+          // empty the async body runs to completion synchronously (no
+          // awaits) — an inner `finally { drainPromise = null }` would
+          // therefore fire BEFORE the outer `drainPromise = p` assignment,
+          // leaving drainPromise stuck holding a resolved Promise forever
+          // and making every future call return immediately without ever
+          // draining. Clearing via `p.finally()` schedules the null as a
+          // microtask that runs after the outer assignment.
           let drainPromise: Promise<void> | null = null;
           const drainLocalQueue = (): Promise<void> => {
             if (drainPromise) return drainPromise;
-            drainPromise = (async () => {
-              try {
-                while (localQueue.length > 0) {
-                  await drainOneItem();
-                }
-              } finally {
-                drainPromise = null;
+            const p = (async () => {
+              while (localQueue.length > 0) {
+                await drainOneItem();
               }
             })();
-            return drainPromise;
+            drainPromise = p;
+            void p.finally(() => {
+              if (drainPromise === p) drainPromise = null;
+            });
+            return p;
           };
 
           // Start cron scheduler — fires enqueue onto the shared queue.

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -601,7 +601,7 @@ export async function runNonInteractive(
             : config.getCronScheduler();
 
           if (scheduler && scheduler.size > 0) {
-            await new Promise<void>((resolve) => {
+            await new Promise<void>((resolve, reject) => {
               // Resolve on SIGINT/SIGTERM too — recurring cron jobs never
               // drop scheduler.size to 0 on their own, so without this the
               // hold-back loop below is unreachable after an abort.
@@ -625,6 +625,16 @@ export async function runNonInteractive(
                 }
               };
 
+              // Propagate drain failures. Without this, a rejected
+              // drainLocalQueue() (e.g. a text-mode API error surfacing
+              // out of drainOneItem) would be swallowed by `void` and
+              // checkCronDone would never fire — hanging the run.
+              const onDrainError = (err: unknown) => {
+                abortController.signal.removeEventListener('abort', onAbort);
+                scheduler.stop();
+                reject(err);
+              };
+
               scheduler.start((job: { prompt: string }) => {
                 const label = job.prompt.slice(0, 40);
                 localQueue.push({
@@ -632,7 +642,7 @@ export async function runNonInteractive(
                   modelText: job.prompt,
                   sendMessageType: SendMessageType.Cron,
                 });
-                void drainLocalQueue().then(checkCronDone);
+                drainLocalQueue().then(checkCronDone, onDrainError);
               });
 
               // Check immediately in case jobs were already deleted
@@ -644,12 +654,15 @@ export async function runNonInteractive(
           // Wait for running background agents to complete and drain
           // their notifications before emitting the final result. If
           // SIGINT/SIGTERM fires here, abort running background agents
-          // (they use their own AbortControllers) and exit the loop.
+          // (they use their own AbortControllers) and route through
+          // handleCancellationError so the run exits non-zero — falling
+          // through to the success emitResult below would silently
+          // convert cancellation into a successful completion.
 
           while (true) {
             if (abortController.signal.aborted) {
               registry.abortAll();
-              break;
+              handleCancellationError(config);
             }
             await drainLocalQueue();
             const running = registry.getRunning();

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -544,13 +544,15 @@ export const useGeminiStream = (
       if (typeof query === 'string') {
         const trimmedQuery = query.trim();
 
-        // Notification messages (e.g. background agent completions) are
-        // pre-processed by the notification drain loop which already
-        // added the display item to history. Just pass the model text
-        // through to the API.
-        if (submitType === SendMessageType.Notification) {
+        // Notification and cron messages are pre-processed by the unified
+        // notification drain loop which already added the display item
+        // to history. Just pass the model text through to the API.
+        if (
+          submitType === SendMessageType.Notification ||
+          submitType === SendMessageType.Cron
+        ) {
           onDebugMessage(
-            `Received notification (${trimmedQuery.length} chars)`,
+            `Received ${submitType} (${trimmedQuery.length} chars)`,
           );
           return { queryToSend: trimmedQuery, shouldProceed: true };
         }
@@ -1862,17 +1864,29 @@ export const useGeminiStream = (
     storage,
   ]);
 
-  // ─── Cron scheduler integration ─────────────────────────
-  const cronQueueRef = useRef<string[]>([]);
-  const [cronTrigger, setCronTrigger] = useState(0);
+  // ─── Unified notification queue (cron + background agents) ──────
+  const notificationQueueRef = useRef<
+    Array<{
+      displayText: string;
+      modelText: string;
+      sendMessageType: SendMessageType;
+    }>
+  >([]);
+  const [notificationTrigger, setNotificationTrigger] = useState(0);
 
-  // Start the scheduler on mount, stop on unmount
+  // Start the cron scheduler on mount, stop on unmount.
+  // Cron fires enqueue onto the shared notification queue.
   useEffect(() => {
     if (!config.isCronEnabled()) return;
     const scheduler = config.getCronScheduler();
     scheduler.start((job: { prompt: string }) => {
-      cronQueueRef.current.push(job.prompt);
-      setCronTrigger((n) => n + 1);
+      const label = job.prompt.slice(0, 40);
+      notificationQueueRef.current.push({
+        displayText: `Cron: ${label}`,
+        modelText: job.prompt,
+        sendMessageType: SendMessageType.Cron,
+      });
+      setNotificationTrigger((n) => n + 1);
     });
     return () => {
       const summary = scheduler.getExitSummary();
@@ -1883,28 +1897,16 @@ export const useGeminiStream = (
     };
   }, [config]);
 
-  // When idle, drain the cron queue one prompt at a time
-  useEffect(() => {
-    if (
-      streamingState === StreamingState.Idle &&
-      cronQueueRef.current.length > 0
-    ) {
-      const prompt = cronQueueRef.current.shift()!;
-      submitQuery(prompt, SendMessageType.Cron);
-    }
-  }, [streamingState, submitQuery, cronTrigger]);
-
-  // ─── Background agent notification queue ───────────────────
-  const notificationQueueRef = useRef<
-    Array<{ displayText: string; modelText: string }>
-  >([]);
-  const [notificationTrigger, setNotificationTrigger] = useState(0);
-
+  // Register background agent notification callback onto the shared queue.
   useEffect(() => {
     const registry = config.getBackgroundTaskRegistry();
     registry.setNotificationCallback(
       (displayText: string, modelText: string) => {
-        notificationQueueRef.current.push({ displayText, modelText });
+        notificationQueueRef.current.push({
+          displayText,
+          modelText,
+          sendMessageType: SendMessageType.Notification,
+        });
         setNotificationTrigger((n) => n + 1);
       },
     );
@@ -1913,7 +1915,7 @@ export const useGeminiStream = (
     };
   }, [config]);
 
-  // When idle, drain the notification queue one item at a time
+  // When idle, drain the unified queue one item at a time.
   useEffect(() => {
     if (
       streamingState === StreamingState.Idle &&
@@ -1924,7 +1926,7 @@ export const useGeminiStream = (
         { type: 'notification' as const, text: item.displayText },
         Date.now(),
       );
-      submitQuery(item.modelText, SendMessageType.Notification, undefined, {
+      submitQuery(item.modelText, item.sendMessageType, undefined, {
         notificationDisplayText: item.displayText,
       });
     }

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -606,10 +606,15 @@ export const useGeminiStream = (
 
         localQueryToSendToGemini = trimmedQuery;
 
-        addItem(
-          { type: MessageType.USER, text: trimmedQuery },
-          userMessageTimestamp,
-        );
+        // Cron prompts are already rendered as a `● Cron: …` notification by
+        // the queue drain, so skip the user-message history item to avoid
+        // a duplicate `> …` line. Preprocessing (@/slash/shell) still runs.
+        if (submitType !== SendMessageType.Cron) {
+          addItem(
+            { type: MessageType.USER, text: trimmedQuery },
+            userMessageTimestamp,
+          );
+        }
 
         // Handle @-commands (which might involve tool calls)
         if (isAtCommand(trimmedQuery)) {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1900,18 +1900,16 @@ export const useGeminiStream = (
   // Register background agent notification callback onto the shared queue.
   useEffect(() => {
     const registry = config.getBackgroundTaskRegistry();
-    registry.setNotificationCallback(
-      (displayText: string, modelText: string) => {
-        notificationQueueRef.current.push({
-          displayText,
-          modelText,
-          sendMessageType: SendMessageType.Notification,
-        });
-        setNotificationTrigger((n) => n + 1);
-      },
-    );
+    registry.setNotificationCallback((displayText, modelText) => {
+      notificationQueueRef.current.push({
+        displayText,
+        modelText,
+        sendMessageType: SendMessageType.Notification,
+      });
+      setNotificationTrigger((n) => n + 1);
+    });
     return () => {
-      registry.setNotificationCallback(() => {});
+      registry.setNotificationCallback(undefined);
     };
   }, [config]);
 

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -544,15 +544,14 @@ export const useGeminiStream = (
       if (typeof query === 'string') {
         const trimmedQuery = query.trim();
 
-        // Notification and cron messages are pre-processed by the unified
-        // notification drain loop which already added the display item
-        // to history. Just pass the model text through to the API.
-        if (
-          submitType === SendMessageType.Notification ||
-          submitType === SendMessageType.Cron
-        ) {
+        // Notification messages (e.g. background agent completions) are
+        // pre-processed by the notification drain loop which already
+        // added the display item to history. Just pass the model text
+        // through to the API. Cron prompts still go through the normal
+        // slash/@-command/shell preprocessing path below.
+        if (submitType === SendMessageType.Notification) {
           onDebugMessage(
-            `Received ${submitType} (${trimmedQuery.length} chars)`,
+            `Received notification (${trimmedQuery.length} chars)`,
           );
           return { queryToSend: trimmedQuery, shouldProceed: true };
         }

--- a/packages/cli/src/ui/utils/resumeHistoryUtils.ts
+++ b/packages/cli/src/ui/utils/resumeHistoryUtils.ts
@@ -256,15 +256,19 @@ function convertToHistoryItems(
     }
     switch (record.type) {
       case 'user': {
-        // Restore notification items (background agent completions)
-        if (record.subtype === 'notification') {
+        // Restore notification items (background agent completions and cron fires)
+        if (record.subtype === 'notification' || record.subtype === 'cron') {
           const payload = record.systemPayload as
             | { displayText?: string }
             | undefined;
+          const fallback =
+            record.subtype === 'cron'
+              ? 'Cron job fired'
+              : 'Background agent completed';
           const text =
             payload?.displayText ||
             extractTextFromParts(record.message?.parts as Part[]) ||
-            'Background agent completed';
+            fallback;
           items.push({ type: 'notification', text });
           break;
         }

--- a/packages/core/src/agents/background-tasks.test.ts
+++ b/packages/core/src/agents/background-tasks.test.ts
@@ -229,4 +229,44 @@ describe('BackgroundTaskRegistry', () => {
     registry.complete('test-1', 'done');
     expect(registry.get('test-1')!.status).toBe('completed');
   });
+
+  it('propagates toolUseId through XML and notification meta', () => {
+    const callback = vi.fn();
+    registry.setNotificationCallback(callback);
+
+    registry.register({
+      agentId: 'test-1',
+      description: 'test agent',
+      status: 'running',
+      startTime: Date.now(),
+      abortController: new AbortController(),
+      toolUseId: 'call-abc-123',
+    });
+
+    registry.complete('test-1', 'done');
+
+    expect(callback).toHaveBeenCalledOnce();
+    const [, modelText, meta] = callback.mock.calls[0];
+    expect(modelText).toContain('<tool-use-id>call-abc-123</tool-use-id>');
+    expect(meta.toolUseId).toBe('call-abc-123');
+  });
+
+  it('omits tool-use-id XML tag when toolUseId is absent', () => {
+    const callback = vi.fn();
+    registry.setNotificationCallback(callback);
+
+    registry.register({
+      agentId: 'test-1',
+      description: 'test agent',
+      status: 'running',
+      startTime: Date.now(),
+      abortController: new AbortController(),
+    });
+
+    registry.complete('test-1', 'done');
+
+    const [, modelText, meta] = callback.mock.calls[0];
+    expect(modelText).not.toContain('<tool-use-id>');
+    expect(meta.toolUseId).toBeUndefined();
+  });
 });

--- a/packages/core/src/agents/background-tasks.test.ts
+++ b/packages/core/src/agents/background-tasks.test.ts
@@ -193,8 +193,11 @@ describe('BackgroundTaskRegistry', () => {
 
     // Status should remain 'cancelled', not flip to 'completed'
     expect(registry.get('test-1')!.status).toBe('cancelled');
-    // No notification should have been sent
-    expect(callback).not.toHaveBeenCalled();
+    // Exactly one notification, emitted by cancel() itself — the late
+    // complete() must be no-op'd by the running-status guard.
+    expect(callback).toHaveBeenCalledTimes(1);
+    const [, modelText] = callback.mock.calls[0];
+    expect(modelText).toContain('<status>cancelled</status>');
   });
 
   it('fail is a no-op after cancellation (state race guard)', () => {
@@ -213,7 +216,9 @@ describe('BackgroundTaskRegistry', () => {
     registry.fail('test-1', 'late error');
 
     expect(registry.get('test-1')!.status).toBe('cancelled');
-    expect(callback).not.toHaveBeenCalled();
+    expect(callback).toHaveBeenCalledTimes(1);
+    const [, modelText] = callback.mock.calls[0];
+    expect(modelText).toContain('<status>cancelled</status>');
   });
 
   it('does not send notification without callback', () => {
@@ -268,5 +273,29 @@ describe('BackgroundTaskRegistry', () => {
     const [, modelText, meta] = callback.mock.calls[0];
     expect(modelText).not.toContain('<tool-use-id>');
     expect(meta.toolUseId).toBeUndefined();
+  });
+
+  it('escapes XML metacharacters in interpolated fields', () => {
+    const callback = vi.fn();
+    registry.setNotificationCallback(callback);
+
+    registry.register({
+      agentId: 'test-1',
+      description: 'summarize </result> & </task-notification>',
+      status: 'running',
+      startTime: Date.now(),
+      abortController: new AbortController(),
+    });
+
+    registry.complete('test-1', 'here is <b>bold</b> & </task-notification>');
+
+    const [, modelText] = callback.mock.calls[0];
+    // No injected closing tags — subagent text is escaped so the
+    // parent envelope stays a single task-notification element.
+    expect(modelText.match(/<\/task-notification>/g)!.length).toBe(1);
+    expect(modelText).toContain('&lt;/result&gt;');
+    expect(modelText).toContain('&lt;/task-notification&gt;');
+    expect(modelText).toContain('&lt;b&gt;bold&lt;/b&gt;');
+    expect(modelText).toContain('&amp;');
   });
 });

--- a/packages/core/src/agents/background-tasks.ts
+++ b/packages/core/src/agents/background-tasks.ts
@@ -17,12 +17,19 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 const debugLogger = createDebugLogger('BACKGROUND_TASKS');
 
 const MAX_DESCRIPTION_LENGTH = 40;
+const MAX_RESULT_LENGTH = 2000;
 
 export type BackgroundAgentStatus =
   | 'running'
   | 'completed'
   | 'failed'
   | 'cancelled';
+
+export interface AgentCompletionStats {
+  totalTokens: number;
+  toolUses: number;
+  durationMs: number;
+}
 
 export interface BackgroundAgentEntry {
   agentId: string;
@@ -35,16 +42,27 @@ export interface BackgroundAgentEntry {
   error?: string;
   abortController: AbortController;
   name?: string;
+  stats?: AgentCompletionStats;
+}
+
+export interface NotificationMeta {
+  agentId: string;
+  status: BackgroundAgentStatus;
+  stats?: AgentCompletionStats;
 }
 
 export type BackgroundNotificationCallback = (
   displayText: string,
   modelText: string,
+  meta: NotificationMeta,
 ) => void;
+
+export type BackgroundRegisterCallback = (entry: BackgroundAgentEntry) => void;
 
 export class BackgroundTaskRegistry {
   private readonly agents = new Map<string, BackgroundAgentEntry>();
   private notificationCallback?: BackgroundNotificationCallback;
+  private registerCallback?: BackgroundRegisterCallback;
 
   /**
    * Register a new background agent.
@@ -52,6 +70,14 @@ export class BackgroundTaskRegistry {
   register(entry: BackgroundAgentEntry): void {
     this.agents.set(entry.agentId, entry);
     debugLogger.info(`Registered background agent: ${entry.agentId}`);
+
+    if (this.registerCallback) {
+      try {
+        this.registerCallback(entry);
+      } catch (error) {
+        debugLogger.error('Failed to emit register callback:', error);
+      }
+    }
   }
 
   /**
@@ -59,13 +85,18 @@ export class BackgroundTaskRegistry {
    * No-op if the agent is not in 'running' state (guards against race
    * with concurrent cancellation).
    */
-  complete(agentId: string, result: string): void {
+  complete(
+    agentId: string,
+    result: string,
+    stats?: AgentCompletionStats,
+  ): void {
     const entry = this.agents.get(agentId);
     if (!entry || entry.status !== 'running') return;
 
     entry.status = 'completed';
     entry.endTime = Date.now();
     entry.result = result;
+    entry.stats = stats;
     debugLogger.info(`Background agent completed: ${agentId}`);
 
     this.emitNotification(entry);
@@ -76,13 +107,14 @@ export class BackgroundTaskRegistry {
    * No-op if the agent is not in 'running' state (guards against race
    * with concurrent cancellation).
    */
-  fail(agentId: string, error: string): void {
+  fail(agentId: string, error: string, stats?: AgentCompletionStats): void {
     const entry = this.agents.get(agentId);
     if (!entry || entry.status !== 'running') return;
 
     entry.status = 'failed';
     entry.endTime = Date.now();
     entry.error = error;
+    entry.stats = stats;
     debugLogger.info(`Background agent failed: ${agentId}`);
 
     this.emitNotification(entry);
@@ -133,8 +165,18 @@ export class BackgroundTaskRegistry {
    * Set the callback that delivers completion notifications to the CLI.
    * Called by AppContainer during initialization.
    */
-  setNotificationCallback(cb: BackgroundNotificationCallback): void {
+  setNotificationCallback(
+    cb: BackgroundNotificationCallback | undefined,
+  ): void {
     this.notificationCallback = cb;
+  }
+
+  /**
+   * Set the callback fired when a new background agent is registered.
+   * Used by the CLI to emit task_started SDK events.
+   */
+  setRegisterCallback(cb: BackgroundRegisterCallback | undefined): void {
+    this.registerCallback = cb;
   }
 
   /**
@@ -151,17 +193,7 @@ export class BackgroundTaskRegistry {
     debugLogger.info('Aborted all background agents');
   }
 
-  private emitNotification(entry: BackgroundAgentEntry): void {
-    if (!this.notificationCallback) return;
-
-    const statusText =
-      entry.status === 'completed'
-        ? 'completed'
-        : entry.status === 'failed'
-          ? `failed`
-          : 'was cancelled';
-
-    // Build the label: "Explore: list ts files..." (truncated)
+  private buildDisplayLabel(entry: BackgroundAgentEntry): string {
     // Strip the subagent type prefix if the description already starts with it
     // to avoid duplication like "Explore: Explore: list ts files".
     let rawDesc = entry.description;
@@ -175,24 +207,57 @@ export class BackgroundTaskRegistry {
       rawDesc.length > MAX_DESCRIPTION_LENGTH
         ? rawDesc.slice(0, MAX_DESCRIPTION_LENGTH) + '...'
         : rawDesc;
-    const label = entry.subagentType ? `${entry.subagentType}: ${desc}` : desc;
+    return entry.subagentType ? `${entry.subagentType}: ${desc}` : desc;
+  }
 
-    // Short display line shown in the UI
+  private emitNotification(entry: BackgroundAgentEntry): void {
+    if (!this.notificationCallback) return;
+
+    const statusText =
+      entry.status === 'completed'
+        ? 'completed'
+        : entry.status === 'failed'
+          ? 'failed'
+          : 'was cancelled';
+
+    const label = this.buildDisplayLabel(entry);
     const displayLine = `Background agent "${label}" ${statusText}.`;
 
-    // Full model-facing text (includes result/error for the LLM to act on)
-    const modelLines: string[] = [
-      `Background agent "${entry.description}" (${entry.agentId}) ${statusText}.`,
+    const xmlParts: string[] = [
+      '<task-notification>',
+      `<task-id>${entry.agentId}</task-id>`,
+      `<status>${entry.status}</status>`,
+      `<summary>Agent "${entry.description}" ${statusText}.</summary>`,
     ];
     if (entry.result) {
-      modelLines.push('', entry.result);
+      const truncated =
+        entry.result.length > MAX_RESULT_LENGTH
+          ? entry.result.slice(0, MAX_RESULT_LENGTH) + '\n[truncated]'
+          : entry.result;
+      xmlParts.push(`<result>${truncated}</result>`);
     }
     if (entry.error) {
-      modelLines.push('', `Error: ${entry.error}`);
+      xmlParts.push(`<result>Error: ${entry.error}</result>`);
     }
+    if (entry.stats) {
+      xmlParts.push(
+        '<usage>',
+        `<total_tokens>${entry.stats.totalTokens}</total_tokens>`,
+        `<tool_uses>${entry.stats.toolUses}</tool_uses>`,
+        `<duration_ms>${entry.stats.durationMs}</duration_ms>`,
+        '</usage>',
+      );
+    }
+    xmlParts.push('</task-notification>');
+
+    const meta: NotificationMeta = {
+      agentId: entry.agentId,
+      status: entry.status,
+      stats: entry.stats,
+    };
 
     try {
-      this.notificationCallback(displayLine, modelLines.join('\n'));
+      this.notificationCallback(displayLine, xmlParts.join('\n'), meta);
     } catch (error) {
       debugLogger.error('Failed to emit background notification:', error);
     }

--- a/packages/core/src/agents/background-tasks.ts
+++ b/packages/core/src/agents/background-tasks.ts
@@ -19,6 +19,19 @@ const debugLogger = createDebugLogger('BACKGROUND_TASKS');
 const MAX_DESCRIPTION_LENGTH = 40;
 const MAX_RESULT_LENGTH = 2000;
 
+// Escape text so it is safe to interpolate into an XML element body.
+// Subagent-produced strings (description, result, error) can contain `<`,
+// `>`, or literal `</task-notification>` — without escaping, a subagent
+// summarizing HTML or another agent's notification could close the
+// envelope early and forge sibling tags (e.g. a faked <status>) that the
+// parent model would treat as trusted metadata.
+function escapeXml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
 export type BackgroundAgentStatus =
   | 'running'
   | 'completed'
@@ -133,6 +146,12 @@ export class BackgroundTaskRegistry {
     entry.status = 'cancelled';
     entry.endTime = Date.now();
     debugLogger.info(`Background agent cancelled: ${agentId}`);
+
+    // Emit the terminal notification here — the fire-and-forget
+    // complete()/fail() path is guarded by `status !== 'running'` and
+    // will no-op, so without this the SDK contract breaks: consumers
+    // saw task_started but never receive a matching task_notification.
+    this.emitNotification(entry);
   }
 
   /**
@@ -190,6 +209,10 @@ export class BackgroundTaskRegistry {
         entry.abortController.abort();
         entry.status = 'cancelled';
         entry.endTime = Date.now();
+        // Same reasoning as cancel(): emit the terminal notification
+        // here, because the fire-and-forget complete()/fail() will
+        // be no-op'd by the running-status guard.
+        this.emitNotification(entry);
       }
     }
     debugLogger.info('Aborted all background agents');
@@ -225,26 +248,30 @@ export class BackgroundTaskRegistry {
     const label = this.buildDisplayLabel(entry);
     const displayLine = `Background agent "${label}" ${statusText}.`;
 
+    // Truncate before escaping so we don't slice through an escape
+    // sequence (e.g. mid-`&amp;`) and emit malformed XML.
+    const rawResult = entry.result
+      ? entry.result.length > MAX_RESULT_LENGTH
+        ? entry.result.slice(0, MAX_RESULT_LENGTH) + '\n[truncated]'
+        : entry.result
+      : undefined;
+
     const xmlParts: string[] = [
       '<task-notification>',
-      `<task-id>${entry.agentId}</task-id>`,
+      `<task-id>${escapeXml(entry.agentId)}</task-id>`,
     ];
     if (entry.toolUseId) {
-      xmlParts.push(`<tool-use-id>${entry.toolUseId}</tool-use-id>`);
+      xmlParts.push(`<tool-use-id>${escapeXml(entry.toolUseId)}</tool-use-id>`);
     }
     xmlParts.push(
-      `<status>${entry.status}</status>`,
-      `<summary>Agent "${entry.description}" ${statusText}.</summary>`,
+      `<status>${escapeXml(entry.status)}</status>`,
+      `<summary>Agent "${escapeXml(entry.description)}" ${statusText}.</summary>`,
     );
-    if (entry.result) {
-      const truncated =
-        entry.result.length > MAX_RESULT_LENGTH
-          ? entry.result.slice(0, MAX_RESULT_LENGTH) + '\n[truncated]'
-          : entry.result;
-      xmlParts.push(`<result>${truncated}</result>`);
+    if (rawResult) {
+      xmlParts.push(`<result>${escapeXml(rawResult)}</result>`);
     }
     if (entry.error) {
-      xmlParts.push(`<result>Error: ${entry.error}</result>`);
+      xmlParts.push(`<result>Error: ${escapeXml(entry.error)}</result>`);
     }
     if (entry.stats) {
       xmlParts.push(

--- a/packages/core/src/agents/background-tasks.ts
+++ b/packages/core/src/agents/background-tasks.ts
@@ -43,12 +43,14 @@ export interface BackgroundAgentEntry {
   abortController: AbortController;
   name?: string;
   stats?: AgentCompletionStats;
+  toolUseId?: string;
 }
 
 export interface NotificationMeta {
   agentId: string;
   status: BackgroundAgentStatus;
   stats?: AgentCompletionStats;
+  toolUseId?: string;
 }
 
 export type BackgroundNotificationCallback = (
@@ -226,9 +228,14 @@ export class BackgroundTaskRegistry {
     const xmlParts: string[] = [
       '<task-notification>',
       `<task-id>${entry.agentId}</task-id>`,
+    ];
+    if (entry.toolUseId) {
+      xmlParts.push(`<tool-use-id>${entry.toolUseId}</tool-use-id>`);
+    }
+    xmlParts.push(
       `<status>${entry.status}</status>`,
       `<summary>Agent "${entry.description}" ${statusText}.</summary>`,
-    ];
+    );
     if (entry.result) {
       const truncated =
         entry.result.length > MAX_RESULT_LENGTH
@@ -254,6 +261,7 @@ export class BackgroundTaskRegistry {
       agentId: entry.agentId,
       status: entry.status,
       stats: entry.stats,
+      toolUseId: entry.toolUseId,
     };
 
     try {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -675,8 +675,14 @@ export class GeminiClient {
           });
       }
 
-      // record user message for session management
-      this.config.getChatRecordingService()?.recordUserMessage(request);
+      // record user/cron message for session management
+      if (messageType === SendMessageType.Cron) {
+        this.config
+          .getChatRecordingService()
+          ?.recordCronPrompt(request, options?.notificationDisplayText);
+      } else {
+        this.config.getChatRecordingService()?.recordUserMessage(request);
+      }
 
       // Idle cleanup: clear stale thinking blocks after idle period.
       // Latch: once triggered, never revert — prevents oscillation.

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -610,6 +610,7 @@ export class CoreToolScheduler {
       const invocationOrError = this.buildInvocation(
         call.tool,
         args as Record<string, unknown>,
+        targetCallId,
       );
       if (invocationOrError instanceof Error) {
         const response = createErrorResponse(
@@ -646,9 +647,17 @@ export class CoreToolScheduler {
   private buildInvocation(
     tool: AnyDeclarativeTool,
     args: object,
+    callId?: string,
   ): AnyToolInvocation | Error {
     try {
-      return tool.build(structuredClone(args));
+      const invocation = tool.build(structuredClone(args));
+      if (callId) {
+        const maybeAware = invocation as { setCallId?: (id: string) => void };
+        if (typeof maybeAware.setCallId === 'function') {
+          maybeAware.setCallId(callId);
+        }
+      }
+      return invocation;
     } catch (e) {
       if (e instanceof Error) {
         return e;
@@ -827,6 +836,7 @@ export class CoreToolScheduler {
         const invocationOrError = this.buildInvocation(
           toolInstance,
           reqInfo.args,
+          reqInfo.callId,
         );
         if (invocationOrError instanceof Error) {
           const error = reqInfo.wasOutputTruncated

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -58,7 +58,8 @@ export interface ChatRecord {
     | 'slash_command'
     | 'ui_telemetry'
     | 'at_command'
-    | 'notification';
+    | 'notification'
+    | 'cron';
   /** Working directory at time of message */
   cwd: string;
   /** CLI version for compatibility tracking */
@@ -301,15 +302,32 @@ export class ChatRecordingService {
   }
 
   /**
+   * Records a cron-fired prompt.
+   * Stored as a user-role message with subtype 'cron' so the UI
+   * restores it as a notification item instead of a user turn.
+   */
+  recordCronPrompt(message: PartListUnion, displayText?: string): void {
+    this.recordNotificationLike(message, 'cron', displayText);
+  }
+
+  /**
    * Records a background agent notification.
-   * Stored as a user-role message (so the API history includes it on resume)
-   * with subtype 'notification' (so the UI can restore it as an info item).
+   * Stored as a user-role message with subtype 'notification' so the
+   * UI restores it as an info item, not a user turn.
    */
   recordNotification(message: PartListUnion, displayText?: string): void {
+    this.recordNotificationLike(message, 'notification', displayText);
+  }
+
+  private recordNotificationLike(
+    message: PartListUnion,
+    subtype: 'notification' | 'cron',
+    displayText?: string,
+  ): void {
     try {
       const record: ChatRecord = {
         ...this.createBaseRecord('user'),
-        subtype: 'notification',
+        subtype,
         message: createUserContent(message),
         systemPayload: displayText
           ? ({ displayText } as NotificationRecordPayload)
@@ -317,7 +335,7 @@ export class ChatRecordingService {
       };
       this.appendRecord(record);
     } catch (error) {
-      debugLogger.error('Error saving notification:', error);
+      debugLogger.error(`Error saving ${subtype} record:`, error);
     }
   }
 

--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -1546,6 +1546,26 @@ describe('AgentTool', () => {
       expect(llmText).toContain('Background agent launched');
       expect(mockRegistry.register).toHaveBeenCalled();
     });
+
+    it('forwards the scheduler-provided callId as toolUseId on the registry entry', async () => {
+      const params: AgentParams = {
+        description: 'Start monitor',
+        prompt: 'Watch for changes',
+        subagent_type: 'monitor',
+      };
+
+      const invocation = (
+        agentTool as AgentToolWithProtectedMethods
+      ).createInvocation(params);
+      (invocation as unknown as { setCallId: (id: string) => void }).setCallId(
+        'call-xyz-789',
+      );
+      await invocation.execute();
+
+      expect(mockRegistry.register).toHaveBeenCalledWith(
+        expect.objectContaining({ toolUseId: 'call-xyz-789' }),
+      );
+    });
   });
 });
 

--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -1439,12 +1439,12 @@ describe('AgentTool', () => {
       };
 
       vi.mocked(config.getApprovalMode).mockReturnValue(ApprovalMode.DEFAULT);
-      (config as Record<string, unknown>).isInteractive = vi
+      (config as unknown as Record<string, unknown>)['isInteractive'] = vi
         .fn()
         .mockReturnValue(true);
-      (config as Record<string, unknown>).getBackgroundTaskRegistry = vi
-        .fn()
-        .mockReturnValue(mockRegistry);
+      (config as unknown as Record<string, unknown>)[
+        'getBackgroundTaskRegistry'
+      ] = vi.fn().mockReturnValue(mockRegistry);
 
       vi.mocked(mockSubagentManager.loadSubagent).mockResolvedValue(bgSubagent);
       vi.mocked(mockSubagentManager.createAgentHeadless).mockResolvedValue(
@@ -1526,7 +1526,7 @@ describe('AgentTool', () => {
       expect(mockRegistry.register).not.toHaveBeenCalled();
     });
 
-    it('should reject background when non-interactive, even with background: true config', async () => {
+    it('should allow background in non-interactive mode (headless support)', async () => {
       vi.mocked(
         config.isInteractive as ReturnType<typeof vi.fn>,
       ).mockReturnValue(false);
@@ -1543,9 +1543,8 @@ describe('AgentTool', () => {
       const result = await invocation.execute();
 
       const llmText = partToString(result.llmContent);
-      expect(llmText).toContain('not supported in non-interactive mode');
-      const display = result.returnDisplay as AgentResultDisplay;
-      expect(display.status).toBe('failed');
+      expect(llmText).toContain('Background agent launched');
+      expect(mockRegistry.register).toHaveBeenCalled();
     });
   });
 });

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -660,10 +660,12 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
     const generationConfig = geminiClient?.getChat().getGenerationConfig();
     if (generationConfig?.systemInstruction) {
       // Inline FunctionDeclaration[] from the parent — passed verbatim
-      // including `agent` itself so the fork's tool-name set matches the
-      // parent's. prepareTools bypasses the exclusion filter for inline
-      // decls; `isInForkExecution()` (ALS-based) is the sole
-      // recursive-fork block at runtime.
+      // (including `agent` and cron tools) so the fork's system prompt,
+      // tools, and history exactly match the parent's and share its
+      // DashScope cache prefix. A fork is a context-sharing extension of
+      // the parent, not an isolated subagent, so the general subagent
+      // exclusion list does not apply. Recursive forks are blocked by the
+      // ALS-based `isInForkExecution()` guard.
       const parentToolDecls: FunctionDeclaration[] =
         (
           generationConfig.tools as Array<{
@@ -1003,15 +1005,26 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         // we set shouldAvoidPermissionPrompts so the tool scheduler
         // auto-denies 'ask' decisions — matching claw-code's approach.
         // PermissionRequest hooks still run and can override the denial.
+        // Base on agentConfig so the resolved approval mode override (e.g.
+        // subagent-level `approvalMode: auto-edit`) is preserved.
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const bgConfig = Object.create(this.config) as any;
+        const bgConfig = Object.create(agentConfig) as any;
         bgConfig.getShouldAvoidPermissionPrompts = () => true;
 
-        // Create a dedicated subagent that uses the bg-specific config.
-        const bgSubagent = await this.subagentManager.createAgentHeadless(
-          subagentConfig,
-          bgConfig as Config,
-        );
+        // Rebuild the subagent against bgConfig. For forks, go through
+        // createForkSubagent so the parent's rendered system prompt and
+        // inherited history are carried over; otherwise the background fork
+        // degrades to a plain FORK_AGENT without context.
+        let bgSubagent: AgentHeadless;
+        if (isFork) {
+          const fork = await this.createForkSubagent(bgConfig as Config);
+          bgSubagent = fork.subagent;
+        } else {
+          bgSubagent = await this.subagentManager.createAgentHeadless(
+            subagentConfig,
+            bgConfig as Config,
+          );
+        }
 
         const getCompletionStats = () => {
           const summary = bgSubagent.getExecutionSummary();

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -1013,6 +1013,15 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
           bgConfig as Config,
         );
 
+        const getCompletionStats = () => {
+          const summary = bgSubagent.getExecutionSummary();
+          return {
+            totalTokens: summary.totalTokens,
+            toolUses: summary.totalToolCalls,
+            durationMs: summary.totalDurationMs,
+          };
+        };
+
         // Fire-and-forget: start the subagent without blocking the parent.
         void (async () => {
           try {
@@ -1036,13 +1045,17 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
               }
             }
 
-            registry.complete(hookOpts.agentId, bgSubagent.getFinalText());
+            registry.complete(
+              hookOpts.agentId,
+              bgSubagent.getFinalText(),
+              getCompletionStats(),
+            );
           } catch (error) {
             const errorMsg =
               error instanceof Error ? error.message : String(error);
             debugLogger.error(`[Agent] Background agent failed: ${errorMsg}`);
 
-            registry.fail(hookOpts.agentId, errorMsg);
+            registry.fail(hookOpts.agentId, errorMsg, getCompletionStats());
           }
         })();
 

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -963,23 +963,6 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         subagentConfig.background === true;
 
       if (shouldRunInBackground) {
-        // Background agents are not supported in non-interactive mode
-        if (!this.config.isInteractive()) {
-          return {
-            llmContent:
-              'Background agents are not supported in non-interactive mode. Retry without run_in_background.',
-            returnDisplay: {
-              type: 'task_execution' as const,
-              subagentName: this.params.subagent_type || 'unknown',
-              taskDescription: this.params.description,
-              taskPrompt: this.params.prompt,
-              status: 'failed' as const,
-              terminateReason:
-                'Background agents are not supported in non-interactive mode',
-            },
-          };
-        }
-
         // Fire SubagentStart hook before background launch
         const hookSystem = this.config.getHookSystem();
         if (hookSystem) {

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -1000,17 +1000,6 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         // survive ESC cancellation of the parent's current turn.
         const bgAbortController = new AbortController();
 
-        const registry = this.config.getBackgroundTaskRegistry();
-        registry.register({
-          agentId: hookOpts.agentId,
-          description: this.params.description,
-          subagentType: subagentConfig.name,
-          status: 'running',
-          startTime: Date.now(),
-          abortController: bgAbortController,
-          toolUseId: this.callId,
-        });
-
         // Background agents can't show interactive permission prompts
         // (no UI). Instead of YOLO (which would auto-approve everything),
         // we set shouldAvoidPermissionPrompts so the tool scheduler
@@ -1026,6 +1015,12 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         // createForkSubagent so the parent's rendered system prompt and
         // inherited history are carried over; otherwise the background fork
         // degrades to a plain FORK_AGENT without context.
+        //
+        // Register in the background task registry only AFTER init
+        // succeeds. If construction throws (e.g. invalid agent config or
+        // model setup), registering first would leave a phantom 'running'
+        // entry that the non-interactive hold-back loop would wait on
+        // forever.
         let bgSubagent: AgentHeadless;
         if (isFork) {
           const fork = await this.createForkSubagent(bgConfig as Config);
@@ -1036,6 +1031,17 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
             bgConfig as Config,
           );
         }
+
+        const registry = this.config.getBackgroundTaskRegistry();
+        registry.register({
+          agentId: hookOpts.agentId,
+          description: this.params.description,
+          subagentType: subagentConfig.name,
+          status: 'running',
+          startTime: Date.now(),
+          abortController: bgAbortController,
+          toolUseId: this.callId,
+        });
 
         const getCompletionStats = () => {
           const summary = bgSubagent.getExecutionSummary();

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -391,6 +391,7 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
   readonly eventEmitter: AgentEventEmitter = new AgentEventEmitter();
   private currentDisplay: AgentResultDisplay | null = null;
   private currentToolCalls: AgentResultDisplay['toolCalls'] = [];
+  private callId?: string;
 
   constructor(
     private readonly config: Config,
@@ -398,6 +399,15 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
     params: AgentParams,
   ) {
     super(params);
+  }
+
+  /**
+   * Invoked by the tool scheduler after `build` to link this invocation
+   * back to the model's original tool-use request. Used so background
+   * agents carry the tool-use id through to completion notifications.
+   */
+  setCallId(callId: string): void {
+    this.callId = callId;
   }
 
   /**
@@ -998,6 +1008,7 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
           status: 'running',
           startTime: Date.now(),
           abortController: bgAbortController,
+          toolUseId: this.callId,
         });
 
         // Background agents can't show interactive permission prompts


### PR DESCRIPTION
## TLDR

Second PR in the background-subagent stack. The base PR (#3076) added the `run_in_background` parameter and interactive notification delivery. This PR takes three next steps:

1. **Unifies cron and background notifications** into a single typed queue so they render consistently in the UI and drain through the same loop.
2. **Extends background agents to headless mode.** Headless runs now hold the process open until background agents finish, drain their notifications as additional turns, and exit cleanly on SIGINT/SIGTERM.
3. **Emits structured SDK events** (`task_started`, `task_notification`) on the JSON output stream so programmatic consumers can track background agents without parsing display text.

Also includes a round of review-driven fixes for the base feature's permission handling, cancellation, error propagation, and a subtle assignment-order race that made the headless notification drain silently stall.

## Screenshots / Video Demo

N/A — this is a headless/SDK-facing change plus a UI consistency fix. The observable differences:

- Interactive: cron fires now render as a single `● Cron: <label>` notification line, matching background agent notifications, instead of `● Cron: …` followed by a duplicate `> …` user-message line.
- Headless: a run that launches a background agent now waits for the agent to finish (and for the parent to respond to the resulting notification) before exiting, and the JSON stream carries `system/task_started` and `system/task_notification` events alongside the existing user message.

## Dive Deeper

### Why unify cron and background notifications

The base PR built a dedicated notification queue for background agents while cron stayed on its own separate queue. Two queues meant two drain loops, two idle-detection paths, two places where rendering logic had to stay in sync, and two places where bugs had to be fixed. The unified queue carries a typed discriminator so producers stay distinct but consumers share one pipeline. The consistent `● <label>` rendering is a direct consequence.

### Why headless deserves full support

Background agents are most useful to headless / SDK consumers: a script that spawns a long-running agent and polls or streams its progress is the exact scenario the feature was built for. The original implementation rejected `run_in_background` in non-interactive mode because the notification delivery loop only existed in the interactive path. That gap is now closed: headless runs have a cron-and-notification drain loop and a terminal hold-back phase that waits for running background agents before emitting the final result. SIGINT/SIGTERM cleanly aborts any in-flight agents rather than pinning the process until they complete on their own.

### Why SDK events in addition to user messages

The notification already arrives as a user-role message carrying the display line. That's fine for conversational use but awkward for SDK consumers who want to know when an agent started, when it finished, what its status was, and what resources it used — without parsing free-form text. The new `task_started` and `task_notification` system events expose that data as a structured payload with `task_id`, `status`, and `usage` fields. Agent output still lands in the user message for conversational history; the structured event is additive.

### Bug fixes rolled into this PR

Review and E2E testing surfaced several correctness issues that needed to land alongside the new surface area:

- Background agents were losing the parent's resolved approval mode — the foreground path uses a config override so that trusted folders or agent-level `approvalMode` settings apply correctly; the background path originally bypassed that and fell back to the raw session config.
- Non-interactive cron drains could race. Concurrent cron fires started overlapping drain loops, which in turn let the final-result emission fire while a cron turn was still streaming. The drain is now single-flight, and the cron-wait check won't resolve while a drain is active.
- Queued-turn tool execution was dropping the stream-json approval update callback. In that input mode, permission-gated tools invoked by a notification follow-up would hang waiting for approvals that never reached the SDK.
- Queued-turn API errors were being silently formatted as assistant text. Text-mode failures now surface as non-zero exit codes, matching the main turn loop.
- Interactive cron prompts lost `@`/slash/shell preprocessing. The unification refactor accidentally short-circuited cron alongside plain notifications. Only notifications skip preprocessing; cron goes through the normal prompt path.
- Cron prompts rendered twice (`● Cron:` plus a `>` user message) once preprocessing was restored. The user-message history item is now suppressed for cron specifically, so preprocessing runs but rendering stays single.
- SIGINT during the cron wait phase was ignored. Recurring cron jobs never drop the scheduler size to zero, so the previous abort path was unreachable. An abort listener now resolves the cron promise so the hold-back loop can run.
- The notification drain silently stalled in headless mode. A JavaScript assignment-order race in the single-flight drain wrapper left the drain reference stuck on a resolved promise forever, so callbacks that pushed notifications onto the queue never got processed. The fix moves the reference-clearing into a microtask that runs after the outer assignment.

### Design-level decisions worth noting

- Forks keep the full parent tool list. The fork path intentionally passes the parent's tool declarations verbatim (including `agent` and cron tools) so the fork shares the parent's DashScope cache prefix exactly. Forks are context-sharing extensions, not isolated subagents — the general subagent exclusion list doesn't apply. Recursive forks are still blocked by the ALS-based guard.
- Background agents inherit the resolved approval mode. If a trusted folder escalates the parent from `default` to `auto-edit`, the background agent sees `auto-edit` too. `auto-edit`'s auto-approval still only applies to edit-like confirmation types; anything else (notably shell) hits the background-specific deny-by-default, which is the only path that makes sense when there is no UI to prompt.
- Background forks use the fork construction path. The base PR's background branch constructed a plain headless agent even when the tool call was an implicit fork, which threw away the parent-context fork setup. Background forks now go through the fork construction path too.

## Reviewer Test Plan

The most impactful behaviors to verify manually:

1. **Interactive cron rendering.** With `QWEN_CODE_ENABLE_CRON=1`, ask the model to schedule a one-minute cron and wait for a fire. The fire should appear as a single `● Cron: <label>` line, followed by the model's response. No duplicate user-prompt line above it.
2. **Interactive mixed producers.** Schedule a cron, then launch a background agent before the first cron fire. Both producers should deliver `●`-prefixed notifications in FIFO order, each triggering its own model turn.
3. **Cron `@file` / slash preprocessing.** Schedule a cron whose prompt uses `@<path>`; when it fires, verify the file contents are expanded into the prompt exactly as they would be for a typed user message.
4. **Headless background agent happy path.** In `--output-format json`, ask the model to launch a background agent and say `LAUNCHED`. The process should exit 0 after the agent completes; the stream should contain `system/task_started`, the drain's user message, `system/task_notification` with the structured payload, and the drain-turn assistant response before the final `result/success`.
5. **Headless failed / graceful-failure background agent.** Same shape, but with a prompt that forces the subagent to handle a missing path. The `task_notification` payload's status should reflect reality (typically `completed` because the subagent handles the error gracefully).
6. **Headless SIGTERM during cron.** With a recurring cron plus a background agent, send SIGTERM. The process should exit cleanly within a couple of seconds rather than pinning until SIGKILL.
7. **Interactive background agent permissions.** From a default-mode session in a trusted folder, launch a background agent that only needs shell access. Shell confirmations should be auto-denied (no UI available); the notification should reflect that. In the same session, an edit-type tool should succeed because the resolved approval mode is auto-edit.

Unit suite:

- `cd packages/cli && npx vitest run src/nonInteractiveCli.test.ts src/ui/hooks/useGeminiStream.test.tsx`
- `cd packages/core && npx vitest run src/agents/background-tasks.test.ts src/tools/agent/agent.test.ts`

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Stacks on #3076.