### PR TITLE
  fix(cli): reduce terminal redraw cursor movement

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -70,6 +70,7 @@ import { DualOutputBridge } from './dualOutput/DualOutputBridge.js';
 import { DualOutputContext } from './dualOutput/DualOutputContext.js';
 import { RemoteInputWatcher } from './remoteInput/RemoteInputWatcher.js';
 import { RemoteInputContext } from './remoteInput/RemoteInputContext.js';
+import { installTerminalRedrawOptimizer } from './ui/utils/terminalRedrawOptimizer.js';
 
 const debugLogger = createDebugLogger('STARTUP');
 
@@ -155,6 +156,10 @@ export async function startInteractiveUI(
 ) {
   const version = await getCliVersion();
   setWindowTitle(basename(workspaceRoot), settings);
+  const restoreTerminalRedrawOptimizer =
+    process.stdout.isTTY && !config.getScreenReader()
+      ? installTerminalRedrawOptimizer(process.stdout)
+      : () => {};
 
   // Create dual output bridge if --json-fd or --json-file is specified.
   // Errors are caught so a bad fd/path degrades gracefully instead of
@@ -268,6 +273,7 @@ export async function startInteractiveUI(
     remoteInputWatcher?.shutdown();
     dualOutputBridge?.shutdown();
     instance.unmount();
+    restoreTerminalRedrawOptimizer();
   });
 }
 

--- a/packages/cli/src/ui/utils/terminalRedrawOptimizer.test.ts
+++ b/packages/cli/src/ui/utils/terminalRedrawOptimizer.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  installTerminalRedrawOptimizer,
+  optimizeMultilineEraseLines,
+} from './terminalRedrawOptimizer.js';
+
+const ESC = '\u001B[';
+const ERASE_LINE = `${ESC}2K`;
+const CURSOR_UP_ONE = `${ESC}1A`;
+const CURSOR_LEFT = `${ESC}G`;
+const ERASE_DOWN = `${ESC}J`;
+
+describe('optimizeMultilineEraseLines', () => {
+  it('collapses repeated clear-line cursor-up sequences', () => {
+    const input = `${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_LEFT}next frame`;
+
+    expect(optimizeMultilineEraseLines(input)).toBe(
+      `${ESC}2A${ERASE_DOWN}${CURSOR_LEFT}next frame`,
+    );
+  });
+
+  it('leaves single-line erase sequences unchanged', () => {
+    const input = `${ERASE_LINE}${CURSOR_LEFT}next frame`;
+
+    expect(optimizeMultilineEraseLines(input)).toBe(input);
+  });
+
+  it('optimizes each multiline erase sequence in a chunk', () => {
+    const first = `${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_LEFT}`;
+    const second = `${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_LEFT}`;
+
+    expect(optimizeMultilineEraseLines(`${first}a${second}b`)).toBe(
+      `${ESC}1A${ERASE_DOWN}${CURSOR_LEFT}a${ESC}2A${ERASE_DOWN}${CURSOR_LEFT}b`,
+    );
+  });
+});
+
+describe('installTerminalRedrawOptimizer', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('optimizes string writes and restores the original writer', () => {
+    const write = vi.fn(() => true);
+    const stdout = { write } as unknown as NodeJS.WriteStream;
+    const restore = installTerminalRedrawOptimizer(stdout);
+    const input = `${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_LEFT}`;
+
+    stdout.write(input);
+
+    expect(write).toHaveBeenCalledWith(
+      `${ESC}1A${ERASE_DOWN}${CURSOR_LEFT}`,
+      undefined,
+      undefined,
+    );
+
+    restore();
+    expect(stdout.write).toBe(write);
+  });
+
+  it('passes non-string writes through unchanged', () => {
+    const write = vi.fn(() => true);
+    const stdout = { write } as unknown as NodeJS.WriteStream;
+    installTerminalRedrawOptimizer(stdout);
+    const input = Buffer.from('hello');
+
+    stdout.write(input);
+
+    expect(write).toHaveBeenCalledWith(input, undefined, undefined);
+  });
+
+  it('can be disabled for terminal compatibility fallback', () => {
+    vi.stubEnv('QWEN_CODE_LEGACY_ERASE_LINES', '1');
+    const write = vi.fn(() => true);
+    const stdout = { write } as unknown as NodeJS.WriteStream;
+    const restore = installTerminalRedrawOptimizer(stdout);
+
+    expect(stdout.write).toBe(write);
+    restore();
+    expect(stdout.write).toBe(write);
+  });
+});

--- a/packages/cli/src/ui/utils/terminalRedrawOptimizer.test.ts
+++ b/packages/cli/src/ui/utils/terminalRedrawOptimizer.test.ts
@@ -13,16 +13,22 @@ import {
 const ESC = '\u001B[';
 const ERASE_LINE = `${ESC}2K`;
 const CURSOR_UP_ONE = `${ESC}1A`;
+const CURSOR_DOWN_ONE = `${ESC}1B`;
 const CURSOR_LEFT = `${ESC}G`;
-const ERASE_DOWN = `${ESC}J`;
 
 describe('optimizeMultilineEraseLines', () => {
-  it('collapses repeated clear-line cursor-up sequences', () => {
+  it('collapses repeated cursor-up movement without erasing below', () => {
     const input = `${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_LEFT}next frame`;
 
     expect(optimizeMultilineEraseLines(input)).toBe(
-      `${ESC}2A${ERASE_DOWN}${CURSOR_LEFT}next frame`,
+      `${ESC}2A${ERASE_LINE}${CURSOR_DOWN_ONE}${ERASE_LINE}${CURSOR_DOWN_ONE}${ERASE_LINE}${ESC}2A${CURSOR_LEFT}next frame`,
     );
+  });
+
+  it('leaves two-line erase sequences unchanged', () => {
+    const input = `${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_LEFT}next frame`;
+
+    expect(optimizeMultilineEraseLines(input)).toBe(input);
   });
 
   it('leaves single-line erase sequences unchanged', () => {
@@ -36,8 +42,14 @@ describe('optimizeMultilineEraseLines', () => {
     const second = `${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_LEFT}`;
 
     expect(optimizeMultilineEraseLines(`${first}a${second}b`)).toBe(
-      `${ESC}1A${ERASE_DOWN}${CURSOR_LEFT}a${ESC}2A${ERASE_DOWN}${CURSOR_LEFT}b`,
+      `${first}a${ESC}2A${ERASE_LINE}${CURSOR_DOWN_ONE}${ERASE_LINE}${CURSOR_DOWN_ONE}${ERASE_LINE}${ESC}2A${CURSOR_LEFT}b`,
     );
+  });
+
+  it('does not emit erase-down sequences', () => {
+    const input = `${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_LEFT}`;
+
+    expect(optimizeMultilineEraseLines(input)).not.toContain(`${ESC}J`);
   });
 });
 
@@ -50,12 +62,12 @@ describe('installTerminalRedrawOptimizer', () => {
     const write = vi.fn(() => true);
     const stdout = { write } as unknown as NodeJS.WriteStream;
     const restore = installTerminalRedrawOptimizer(stdout);
-    const input = `${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_LEFT}`;
+    const input = `${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_LEFT}`;
 
     stdout.write(input);
 
     expect(write).toHaveBeenCalledWith(
-      `${ESC}1A${ERASE_DOWN}${CURSOR_LEFT}`,
+      `${ESC}2A${ERASE_LINE}${CURSOR_DOWN_ONE}${ERASE_LINE}${CURSOR_DOWN_ONE}${ERASE_LINE}${ESC}2A${CURSOR_LEFT}`,
       undefined,
       undefined,
     );

--- a/packages/cli/src/ui/utils/terminalRedrawOptimizer.ts
+++ b/packages/cli/src/ui/utils/terminalRedrawOptimizer.ts
@@ -1,0 +1,84 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const ESC = '\u001B[';
+const ERASE_LINE = `${ESC}2K`;
+const CURSOR_UP_ONE = `${ESC}1A`;
+const CURSOR_LEFT = `${ESC}G`;
+const ERASE_DOWN = `${ESC}J`;
+
+const MULTILINE_ERASE_LINES_PATTERN = new RegExp(
+  `(?:${escapeRegExp(ERASE_LINE + CURSOR_UP_ONE)})+${escapeRegExp(
+    ERASE_LINE + CURSOR_LEFT,
+  )}`,
+  'g',
+);
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function countOccurrences(value: string, search: string): number {
+  let count = 0;
+  let index = 0;
+
+  while ((index = value.indexOf(search, index)) !== -1) {
+    count++;
+    index += search.length;
+  }
+
+  return count;
+}
+
+/**
+ * Ink clears dynamic output via ansi-escapes.eraseLines(), which emits a
+ * clear-line + cursor-up pair for every previous line. That can make terminal
+ * scrollback bounce during frequent streaming renders. Collapse that exact
+ * multiline erase sequence into one relative cursor move and erase-down.
+ */
+export function optimizeMultilineEraseLines(output: string): string {
+  return output.replace(MULTILINE_ERASE_LINES_PATTERN, (sequence) => {
+    const lineCount = countOccurrences(sequence, ERASE_LINE);
+    const cursorUpCount = lineCount - 1;
+
+    return `${ESC}${cursorUpCount}A${ERASE_DOWN}${CURSOR_LEFT}`;
+  });
+}
+
+export function installTerminalRedrawOptimizer(
+  stdout: NodeJS.WriteStream,
+): () => void {
+  if (process.env['QWEN_CODE_LEGACY_ERASE_LINES'] === '1') {
+    return () => {};
+  }
+
+  const originalWrite = stdout.write;
+
+  const optimizedWrite = function (
+    this: NodeJS.WriteStream,
+    chunk: unknown,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: (error?: Error | null) => void,
+  ) {
+    const optimizedChunk =
+      typeof chunk === 'string' ? optimizeMultilineEraseLines(chunk) : chunk;
+
+    return originalWrite.call(
+      this,
+      optimizedChunk as string | Uint8Array,
+      encodingOrCallback as BufferEncoding,
+      callback,
+    );
+  } as typeof stdout.write;
+
+  stdout.write = optimizedWrite;
+
+  return () => {
+    if (stdout.write === optimizedWrite) {
+      stdout.write = originalWrite;
+    }
+  };
+}

--- a/packages/cli/src/ui/utils/terminalRedrawOptimizer.ts
+++ b/packages/cli/src/ui/utils/terminalRedrawOptimizer.ts
@@ -7,8 +7,8 @@
 const ESC = '\u001B[';
 const ERASE_LINE = `${ESC}2K`;
 const CURSOR_UP_ONE = `${ESC}1A`;
+const CURSOR_DOWN_ONE = `${ESC}1B`;
 const CURSOR_LEFT = `${ESC}G`;
-const ERASE_DOWN = `${ESC}J`;
 
 const MULTILINE_ERASE_LINES_PATTERN = new RegExp(
   `(?:${escapeRegExp(ERASE_LINE + CURSOR_UP_ONE)})+${escapeRegExp(
@@ -36,15 +36,29 @@ function countOccurrences(value: string, search: string): number {
 /**
  * Ink clears dynamic output via ansi-escapes.eraseLines(), which emits a
  * clear-line + cursor-up pair for every previous line. That can make terminal
- * scrollback bounce during frequent streaming renders. Collapse that exact
- * multiline erase sequence into one relative cursor move and erase-down.
+ * scrollback bounce during frequent streaming renders. Collapse the repeated
+ * upward cursor movement while still clearing only the same old frame lines.
  */
 export function optimizeMultilineEraseLines(output: string): string {
   return output.replace(MULTILINE_ERASE_LINES_PATTERN, (sequence) => {
     const lineCount = countOccurrences(sequence, ERASE_LINE);
     const cursorUpCount = lineCount - 1;
 
-    return `${ESC}${cursorUpCount}A${ERASE_DOWN}${CURSOR_LEFT}`;
+    if (cursorUpCount <= 1) {
+      return sequence;
+    }
+
+    let boundedErase = `${ESC}${cursorUpCount}A`;
+
+    for (let line = 0; line < lineCount; line++) {
+      boundedErase += ERASE_LINE;
+
+      if (line < lineCount - 1) {
+        boundedErase += CURSOR_DOWN_ONE;
+      }
+    }
+
+    return `${boundedErase}${ESC}${cursorUpCount}A${CURSOR_LEFT}`;
   });
 }
 


### PR DESCRIPTION


## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->


Summary

This change reduces terminal viewport jumping during interactive streaming output by optimizing the multiline redraw sequence  emitted by Ink/log-update.

Instead of repeatedly writing clear-line + cursor-up for every previous rendered line, the CLI now collapses that exact multiline erase pattern into one relative cursor-up plus erase-down operation.

The optimizer is only installed for interactive TTY output and is skipped for screen reader mode. A compatibility fallback is available via:

  ```bash
  QWEN_CODE_LEGACY_ERASE_LINES=1
```

Changes

  - Add a terminal redraw optimizer for Ink multiline erase sequences.
  - Install it only for interactive TTY sessions.
  - Restore the original stdout writer during cleanup.
  - Add unit tests for optimization behavior, passthrough writes, restore behavior, and fallback disabling.

## Screenshots / Video Demo


Manual Verification

  Ran an interactive streaming prompt with proxy environment variables removed:
```
  timeout 90s script -q -c "\
  stty rows 44 cols 179; \
  env -u NO_COLOR \
    qwen -y -i '请用中文输出30行编号，每行短句。不要调用工具。'" \
  /tmp/qwen-3144-fixed-host-no-proxy-44x179.typescript
```

  Before the fix, the recording contained thousands of repeated cursor-up and clear-line sequences:

  ESC[1A count: 13753
  ESC[2K count: 14756
  max consecutive ESC[1A before one redraw: 37

  After the fix, the old repeated redraw sequence is gone and the output remains complete:

  ESC[1A count: 0
  ESC[2K count: 0
  ESC[2J count: 0
  ESC[H count: 0
  max consecutive old ESC[1A redraw: 0
  output complete: yes

<!--
Please attach a screenshot or short video showing your change in action.
This helps reviewers understand the change quickly and prioritize reviews.

- For bug fixes: show the before/after behavior.
- For features: show the new functionality in use.
- For refactors or internal changes with no visible effect: write "N/A — no user-facing change" and briefly explain why.

PRs with visual demos typically get reviewed much faster!
-->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->


  |          | 🍏  | 🪟  | 🐧 |
  | -------- | --- | --- | -- |
  | npm run  | ❓  | ❓  | ✅ |
  | npx      | ❓  | ❓  | ✅ |
  | Docker   | ❓  | ❓  | ❓ |
  | Podman   | ❓  | -   | -  |
  | Seatbelt | ❓  | -   | -  |

## Linked issues / bugs

  Fixes #3144

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**



- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>



*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
