### PR TITLE
feat(cli): support refreshInterval in statusLine for periodic refresh

### DIFF
--- a/docs/users/features/status-line.md
+++ b/docs/users/features/status-line.md
@@ -60,10 +60,11 @@ Add a `statusLine` object under the `ui` key in `~/.qwen/settings.json`:
 }
 ```
 
-| Field     | Type        | Required | Description                                                                             |
-| --------- | ----------- | -------- | --------------------------------------------------------------------------------------- |
-| `type`    | `"command"` | Yes      | Must be `"command"`                                                                     |
-| `command` | string      | Yes      | Shell command to execute. Receives JSON via stdin, stdout is displayed (up to 2 lines). |
+| Field             | Type        | Required | Description                                                                                                                       |
+| ----------------- | ----------- | -------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `type`            | `"command"` | Yes      | Must be `"command"`                                                                                                               |
+| `command`         | string      | Yes      | Shell command to execute. Receives JSON via stdin, stdout is displayed (up to 2 lines).                                           |
+| `refreshInterval` | number      | No       | Re-run the command every N seconds (minimum 1). Useful for data that changes without an Agent state event (clock, quota, uptime). |
 
 ## JSON input
 
@@ -188,6 +189,24 @@ Output: `my-project (main)`
 
 Output: `+120/-30 lines`
 
+### Live clock and git branch
+
+Use `refreshInterval` when the statusline shows data that changes without an Agent event (e.g. the clock, uptime, or rate-limit counters):
+
+```json
+{
+  "ui": {
+    "statusLine": {
+      "type": "command",
+      "command": "input=$(cat); branch=$(echo \"$input\" | jq -r '.git.branch // \"no-git\"'); echo \"$(date +%H:%M:%S)  ($branch)\"",
+      "refreshInterval": 1
+    }
+  }
+}
+```
+
+Output (refreshed every second): `14:32:07  (main)`
+
 ### Script file for complex commands
 
 For longer commands, save a script file at `~/.qwen/statusline-command.sh`:
@@ -225,7 +244,7 @@ Then reference it in settings:
 
 ## Behavior
 
-- **Update triggers**: The status line updates when the model changes, a new message is sent (token count changes), vim mode is toggled, git branch changes, tool calls complete, or file changes occur. Updates are debounced (300ms).
+- **Update triggers**: The status line updates when the model changes, a new message is sent (token count changes), vim mode is toggled, git branch changes, tool calls complete, or file changes occur. Updates are debounced (300ms). Set `refreshInterval` (seconds) to additionally re-run the command on a timer — useful for data that changes without an Agent event (clock, rate limits, build status).
 - **Timeout**: Commands that take longer than 5 seconds are killed. The status line clears on failure.
 - **Output**: Multi-line output is supported (up to 2 lines; extra lines are discarded). Each line is rendered as a separate row with dimmed colors in the footer's left section. Lines that exceed the available width are truncated.
 - **Hot reload**: Changes to `ui.statusLine` in settings take effect immediately — no restart required.
@@ -238,5 +257,5 @@ Then reference it in settings:
 | ----------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Status line not showing | Config at wrong path   | Must be under `ui.statusLine`, not root-level `statusLine`                                                                                                                                                                                                                                                                                                                                             |
 | Empty output            | Command fails silently | Test manually: `echo '{"session_id":"test","version":"0.14.1","model":{"display_name":"test"},"context_window":{"context_window_size":0,"used_percentage":0,"remaining_percentage":100,"current_usage":0,"total_input_tokens":0,"total_output_tokens":0},"workspace":{"current_dir":"/tmp"},"metrics":{"models":{},"files":{"total_lines_added":0,"total_lines_removed":0}}}' \| sh -c 'your_command'` |
-| Stale data              | No trigger fired       | Send a message or switch models to trigger an update                                                                                                                                                                                                                                                                                                                                                   |
+| Stale data              | No trigger fired       | Send a message or switch models to trigger an update — or set `refreshInterval` to re-run the command on a timer                                                                                                                                                                                                                                                                                       |
 | Command too slow        | Complex script         | Optimize the script or move heavy work to a background cache                                                                                                                                                                                                                                                                                                                                           |

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -471,8 +471,15 @@ const SETTINGS_SCHEMA = {
         label: 'Status Line',
         category: 'UI',
         requiresRestart: false,
-        default: undefined as { type: 'command'; command: string } | undefined,
-        description: 'Custom status line display configuration.',
+        default: undefined as
+          | {
+              type: 'command';
+              command: string;
+              refreshInterval?: number;
+            }
+          | undefined,
+        description:
+          'Custom status line display configuration. Optional `refreshInterval` (seconds, >= 1) re-runs the command on a timer so external data stays fresh.',
         showInDialog: false,
       },
       customThemes: {

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -144,8 +144,15 @@ export const Footer: React.FC = () => {
       paddingX={2}
       gap={isNarrow ? 0 : 1}
     >
-      {/* Left column — status line on top, hints/mode on bottom */}
-      <Box flexDirection="column" flexShrink={isNarrow ? 0 : 1}>
+      {/* Left column — status line on top, hints/mode on bottom.
+          `minWidth={0}` lets the column shrink below its natural content
+          width in narrow terminals; without it, Yoga's `min-width: auto`
+          default keeps the Box at content-width, the child `<Text
+          wrap="truncate">` never truncates, and the terminal wraps the
+          text physically — Ink only erases 1 logical row per frame, so
+          the extra physical rows accumulate above the input prompt each
+          tick (#3383). */}
+      <Box flexDirection="column" flexShrink={isNarrow ? 0 : 1} minWidth={0}>
         {statusLineLines.length > 0 &&
           !uiState.ctrlCPressedOnce &&
           !uiState.ctrlDPressedOnce &&
@@ -158,8 +165,12 @@ export const Footer: React.FC = () => {
       </Box>
 
       {/* Right Section — never compressed, aligns to top so multi-line
-          status lines on the left don't push the indicators to the center. */}
-      <Box flexShrink={0} gap={1} alignItems="flex-start">
+          status lines on the left don't push the indicators to the center.
+          `flexWrap="wrap"` lets the indicators break onto a second row when
+          the terminal is too narrow to fit them all — without it Ink
+          accounts for 1 row but the terminal physically wraps to 2, and the
+          extra physical row ghosts on every re-render (#3383). */}
+      <Box flexShrink={0} flexWrap="wrap" gap={1} alignItems="flex-start">
         {rightItems.map(({ key, node }, index) => (
           <Box key={key} alignItems="center">
             {index > 0 && <Text color={theme.text.secondary}> | </Text>}

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -144,15 +144,8 @@ export const Footer: React.FC = () => {
       paddingX={2}
       gap={isNarrow ? 0 : 1}
     >
-      {/* Left column — status line on top, hints/mode on bottom.
-          `minWidth={0}` lets the column shrink below its natural content
-          width in narrow terminals; without it, Yoga's `min-width: auto`
-          default keeps the Box at content-width, the child `<Text
-          wrap="truncate">` never truncates, and the terminal wraps the
-          text physically — Ink only erases 1 logical row per frame, so
-          the extra physical rows accumulate above the input prompt each
-          tick (#3383). */}
-      <Box flexDirection="column" flexShrink={isNarrow ? 0 : 1} minWidth={0}>
+      {/* Left column — status line on top, hints/mode on bottom */}
+      <Box flexDirection="column" flexShrink={isNarrow ? 0 : 1}>
         {statusLineLines.length > 0 &&
           !uiState.ctrlCPressedOnce &&
           !uiState.ctrlDPressedOnce &&
@@ -165,12 +158,8 @@ export const Footer: React.FC = () => {
       </Box>
 
       {/* Right Section — never compressed, aligns to top so multi-line
-          status lines on the left don't push the indicators to the center.
-          `flexWrap="wrap"` lets the indicators break onto a second row when
-          the terminal is too narrow to fit them all — without it Ink
-          accounts for 1 row but the terminal physically wraps to 2, and the
-          extra physical row ghosts on every re-render (#3383). */}
-      <Box flexShrink={0} flexWrap="wrap" gap={1} alignItems="flex-start">
+          status lines on the left don't push the indicators to the center. */}
+      <Box flexShrink={0} gap={1} alignItems="flex-start">
         {rightItems.map(({ key, node }, index) => (
           <Box key={key} alignItems="center">
             {index > 0 && <Text color={theme.text.secondary}> | </Text>}

--- a/packages/cli/src/ui/hooks/useStatusLine.test.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.test.ts
@@ -782,6 +782,57 @@ describe('useStatusLine', () => {
     });
   });
 
+  // --- Output deduplication (cuts unnecessary Footer re-renders) ---
+
+  describe('output deduplication', () => {
+    it('preserves the same lines array reference when output is unchanged', async () => {
+      setStatusLineConfig({ type: 'command', command: 'echo same' });
+      const { result, rerender } = renderHook(() => useStatusLine());
+
+      await act(async () => {
+        execCallback(null, 'same output\n', '');
+      });
+      const firstRef = result.current.lines;
+      expect(firstRef).toEqual(['same output']);
+
+      // Trigger another exec with identical output (e.g. via state change).
+      mockUIState.currentModel = 'new-model';
+      rerender();
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+      await act(async () => {
+        execCallback(null, 'same output\n', '');
+      });
+
+      // Reference preserved → React can skip the Footer re-render.
+      expect(result.current.lines).toBe(firstRef);
+    });
+
+    it('produces a new reference when output changes', async () => {
+      setStatusLineConfig({ type: 'command', command: 'echo tick' });
+      const { result, rerender } = renderHook(() => useStatusLine());
+
+      await act(async () => {
+        execCallback(null, 'first\n', '');
+      });
+      const firstRef = result.current.lines;
+      expect(firstRef).toEqual(['first']);
+
+      mockUIState.currentModel = 'new-model';
+      rerender();
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+      await act(async () => {
+        execCallback(null, 'second\n', '');
+      });
+
+      expect(result.current.lines).not.toBe(firstRef);
+      expect(result.current.lines).toEqual(['second']);
+    });
+  });
+
   // --- refreshInterval (periodic refresh) ---
 
   describe('refreshInterval', () => {

--- a/packages/cli/src/ui/hooks/useStatusLine.test.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.test.ts
@@ -82,7 +82,9 @@ let stdinErrorHandler: ((err: Error) => void) | undefined;
 let mockKill: ReturnType<typeof vi.fn>;
 
 function setStatusLineConfig(
-  config: { type: string; command: string } | undefined,
+  config:
+    | { type: string; command: string; refreshInterval?: number }
+    | undefined,
 ) {
   mockSettings.merged = config ? { ui: { statusLine: config } } : {};
 }
@@ -777,6 +779,149 @@ describe('useStatusLine', () => {
         execCallback(null, 'recovered\n', '');
       });
       expect(result.current.lines).toEqual(['recovered']);
+    });
+  });
+
+  // --- refreshInterval (periodic refresh) ---
+
+  describe('refreshInterval', () => {
+    it('re-executes the command every N seconds', async () => {
+      setStatusLineConfig({
+        type: 'command',
+        command: 'echo tick',
+        refreshInterval: 2,
+      });
+      renderHook(() => useStatusLine());
+
+      // Mount executes once immediately
+      expect(child_process.exec).toHaveBeenCalledTimes(1);
+
+      // First interval tick after 2s
+      await act(async () => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(child_process.exec).toHaveBeenCalledTimes(2);
+
+      // Second interval tick after another 2s
+      await act(async () => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(child_process.exec).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not start an interval when refreshInterval is omitted', async () => {
+      setStatusLineConfig({ type: 'command', command: 'echo static' });
+      renderHook(() => useStatusLine());
+      expect(child_process.exec).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(60_000);
+      });
+      // Still only the mount exec — no periodic refresh
+      expect(child_process.exec).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects refreshInterval < 1 (no interval scheduled)', async () => {
+      setStatusLineConfig({
+        type: 'command',
+        command: 'echo tick',
+        refreshInterval: 0.5,
+      });
+      renderHook(() => useStatusLine());
+      expect(child_process.exec).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(60_000);
+      });
+      expect(child_process.exec).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects non-finite refreshInterval (no interval scheduled)', async () => {
+      setStatusLineConfig({
+        type: 'command',
+        command: 'echo tick',
+        refreshInterval: Number.POSITIVE_INFINITY,
+      });
+      renderHook(() => useStatusLine());
+      expect(child_process.exec).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        vi.advanceTimersByTime(60_000);
+      });
+      expect(child_process.exec).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the interval when config is removed', async () => {
+      setStatusLineConfig({
+        type: 'command',
+        command: 'echo tick',
+        refreshInterval: 1,
+      });
+      const { rerender } = renderHook(() => useStatusLine());
+      expect(child_process.exec).toHaveBeenCalledTimes(1);
+
+      // Remove the config — the interval should be torn down.
+      setStatusLineConfig(undefined);
+      rerender();
+
+      const callsAfterRemoval = vi.mocked(child_process.exec).mock.calls.length;
+
+      await act(async () => {
+        vi.advanceTimersByTime(10_000);
+      });
+      expect(vi.mocked(child_process.exec).mock.calls.length).toBe(
+        callsAfterRemoval,
+      );
+    });
+
+    it('reschedules when refreshInterval changes', async () => {
+      setStatusLineConfig({
+        type: 'command',
+        command: 'echo tick',
+        refreshInterval: 5,
+      });
+      const { rerender } = renderHook(() => useStatusLine());
+      expect(child_process.exec).toHaveBeenCalledTimes(1);
+
+      // 2s passes — not yet a tick on the 5s schedule.
+      await act(async () => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(child_process.exec).toHaveBeenCalledTimes(1);
+
+      // Swap to a 1s interval — the old 5s timer must be cleared, not kept.
+      setStatusLineConfig({
+        type: 'command',
+        command: 'echo tick',
+        refreshInterval: 1,
+      });
+      rerender();
+
+      // 1s later — fires on the new schedule.
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(child_process.exec).toHaveBeenCalledTimes(2);
+    });
+
+    it('clears the interval on unmount', async () => {
+      setStatusLineConfig({
+        type: 'command',
+        command: 'echo tick',
+        refreshInterval: 1,
+      });
+      const { unmount } = renderHook(() => useStatusLine());
+      expect(child_process.exec).toHaveBeenCalledTimes(1);
+
+      unmount();
+
+      const callsAfterUnmount = vi.mocked(child_process.exec).mock.calls.length;
+      await act(async () => {
+        vi.advanceTimersByTime(10_000);
+      });
+      expect(vi.mocked(child_process.exec).mock.calls.length).toBe(
+        callsAfterUnmount,
+      );
     });
   });
 });

--- a/packages/cli/src/ui/hooks/useStatusLine.test.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.test.ts
@@ -937,14 +937,15 @@ describe('useStatusLine', () => {
     it('skips periodic ticks while a previous exec is still running', async () => {
       // Starvation regression (#3383 review): with refreshInterval < command
       // latency, if every tick called doUpdate() it would kill the in-flight
-      // child and the statusline would never update. The tick must yield
-      // when activeChildRef is non-empty.
+      // child, generation++ would stale the eventual callback, and the user
+      // would never see any output. This test asserts BOTH the guard (exec
+      // call count) AND the user-visible result (rendered lines).
       setStatusLineConfig({
         type: 'command',
         command: 'slow-command',
         refreshInterval: 1,
       });
-      renderHook(() => useStatusLine());
+      const { result } = renderHook(() => useStatusLine());
 
       // Mount exec: child is spawned, callback NOT yet resolved — child is
       // still "running" from the hook's perspective.
@@ -964,10 +965,13 @@ describe('useStatusLine', () => {
       });
       expect(child_process.exec).toHaveBeenCalledTimes(1);
 
-      // First exec finally completes — activeChildRef clears.
+      // First exec finally completes — activeChildRef clears. Without the
+      // guard, generationRef would have bumped 3 times above and the next
+      // line would be ignored as stale, leaving `lines` permanently empty.
       await act(async () => {
         pendingCallback(null, 'done\n', '');
       });
+      expect(result.current.lines).toEqual(['done']);
 
       // Next tick is now free to spawn a new exec.
       await act(async () => {

--- a/packages/cli/src/ui/hooks/useStatusLine.test.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.test.ts
@@ -795,12 +795,19 @@ describe('useStatusLine', () => {
 
       // Mount executes once immediately
       expect(child_process.exec).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        execCallback(null, 'tick 1\n', '');
+      });
 
-      // First interval tick after 2s
+      // First interval tick after 2s — previous exec has completed, so
+      // the tick is free to spawn a new one.
       await act(async () => {
         vi.advanceTimersByTime(2000);
       });
       expect(child_process.exec).toHaveBeenCalledTimes(2);
+      await act(async () => {
+        execCallback(null, 'tick 2\n', '');
+      });
 
       // Second interval tick after another 2s
       await act(async () => {
@@ -882,6 +889,9 @@ describe('useStatusLine', () => {
       });
       const { rerender } = renderHook(() => useStatusLine());
       expect(child_process.exec).toHaveBeenCalledTimes(1);
+      await act(async () => {
+        execCallback(null, 'tick\n', '');
+      });
 
       // 2s passes — not yet a tick on the 5s schedule.
       await act(async () => {
@@ -922,6 +932,48 @@ describe('useStatusLine', () => {
       expect(vi.mocked(child_process.exec).mock.calls.length).toBe(
         callsAfterUnmount,
       );
+    });
+
+    it('skips periodic ticks while a previous exec is still running', async () => {
+      // Starvation regression (#3383 review): with refreshInterval < command
+      // latency, if every tick called doUpdate() it would kill the in-flight
+      // child and the statusline would never update. The tick must yield
+      // when activeChildRef is non-empty.
+      setStatusLineConfig({
+        type: 'command',
+        command: 'slow-command',
+        refreshInterval: 1,
+      });
+      renderHook(() => useStatusLine());
+
+      // Mount exec: child is spawned, callback NOT yet resolved — child is
+      // still "running" from the hook's perspective.
+      expect(child_process.exec).toHaveBeenCalledTimes(1);
+      const pendingCallback = execCallback;
+
+      // Several interval ticks pass while the first exec is in flight.
+      // Each tick must detect the running child and skip doUpdate().
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(child_process.exec).toHaveBeenCalledTimes(1);
+
+      // First exec finally completes — activeChildRef clears.
+      await act(async () => {
+        pendingCallback(null, 'done\n', '');
+      });
+
+      // Next tick is now free to spawn a new exec.
+      await act(async () => {
+        vi.advanceTimersByTime(1000);
+      });
+      expect(child_process.exec).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/cli/src/ui/hooks/useStatusLine.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.ts
@@ -69,6 +69,10 @@ export interface StatusLineCommandInput {
 interface StatusLineConfig {
   type: 'command';
   command: string;
+  // Re-run the command every N seconds so external data (git branch, quota,
+  // clock) stays fresh even when no Agent state changes. Values < 1 are
+  // rejected in getStatusLineConfig to avoid flooding the CLI with execs.
+  refreshInterval?: number;
 }
 
 const debugLog = createDebugLogger('STATUS_LINE');
@@ -93,6 +97,14 @@ function getStatusLineConfig(
       type: 'command',
       command: raw.command,
     };
+    if (
+      'refreshInterval' in raw &&
+      typeof raw.refreshInterval === 'number' &&
+      Number.isFinite(raw.refreshInterval) &&
+      raw.refreshInterval >= 1
+    ) {
+      config.refreshInterval = raw.refreshInterval;
+    }
     return config;
   }
   return undefined;
@@ -133,7 +145,10 @@ function buildMetricsPayload(
  * via stdin.
  *
  * Updates are debounced (300ms) and triggered by state changes (model switch,
- * new messages, vim mode toggle) rather than blind polling.
+ * new messages, vim mode toggle) rather than blind polling. When the config
+ * sets `refreshInterval` (seconds, >= 1), the command is additionally re-run
+ * on a timer so external data (git branch, quota, clock) stays fresh even
+ * when no Agent state has changed.
  */
 export function useStatusLine(): {
   lines: string[];
@@ -145,6 +160,7 @@ export function useStatusLine(): {
 
   const statusLineConfig = getStatusLineConfig(settings);
   const statusLineCommand = statusLineConfig?.command;
+  const refreshInterval = statusLineConfig?.refreshInterval;
 
   const [output, setOutput] = useState<string[]>([]);
 
@@ -388,6 +404,19 @@ export function useStatusLine(): {
     // Cleanup when command is removed is handled by the state-change effect.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [statusLineCommand]);
+
+  // Periodic refresh — re-run the command every `refreshInterval` seconds.
+  // Independent of state-change debounce: doUpdate already kills the prior
+  // child and bumps the generation counter, so overlapping ticks are safe.
+  useEffect(() => {
+    if (!statusLineCommand || !refreshInterval) return;
+    const timer = setInterval(() => {
+      doUpdate();
+    }, refreshInterval * 1000);
+    return () => {
+      clearInterval(timer);
+    };
+  }, [statusLineCommand, refreshInterval, doUpdate]);
 
   // Initial execution + cleanup
   useEffect(() => {

--- a/packages/cli/src/ui/hooks/useStatusLine.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.ts
@@ -300,15 +300,27 @@ export function useStatusLine(): {
         (error, stdout) => {
           if (gen !== generationRef.current) return; // stale
           activeChildRef.current = undefined;
-          if (!error && stdout) {
-            const lines = stdout
-              .replace(/\r?\n$/, '')
-              .split(/\r?\n/)
-              .filter(Boolean);
-            setOutput(lines.slice(0, MAX_STATUS_LINES));
-          } else {
-            setOutput([]);
-          }
+          const nextLines =
+            !error && stdout
+              ? stdout
+                  .replace(/\r?\n$/, '')
+                  .split(/\r?\n/)
+                  .filter(Boolean)
+                  .slice(0, MAX_STATUS_LINES)
+              : [];
+          // Skip the state update if the output is unchanged — avoids a
+          // Footer re-render each periodic tick, which cuts wasted work
+          // and reduces the window for Ink to miscount rows in narrow
+          // terminals when `refreshInterval` runs at 1s (see #3383).
+          setOutput((prev) => {
+            if (
+              prev.length === nextLines.length &&
+              prev.every((v, i) => v === nextLines[i])
+            ) {
+              return prev;
+            }
+            return nextLines;
+          });
         },
       );
     } catch (err) {

--- a/packages/cli/src/ui/hooks/useStatusLine.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.ts
@@ -98,7 +98,6 @@ function getStatusLineConfig(
       command: raw.command,
     };
     if (
-      'refreshInterval' in raw &&
       typeof raw.refreshInterval === 'number' &&
       Number.isFinite(raw.refreshInterval) &&
       raw.refreshInterval >= 1
@@ -406,11 +405,16 @@ export function useStatusLine(): {
   }, [statusLineCommand]);
 
   // Periodic refresh — re-run the command every `refreshInterval` seconds.
-  // Independent of state-change debounce: doUpdate already kills the prior
-  // child and bumps the generation counter, so overlapping ticks are safe.
+  // The tick yields if a previous exec is still running: unlike state-change
+  // triggers (which legitimately need to preempt stale data), the periodic
+  // tick exists only to keep external data fresh, so killing an in-flight
+  // child would starve commands that run longer than `refreshInterval` and
+  // the statusline would never update. The 5s exec timeout still caps the
+  // wait, and state-change triggers still go through `doUpdate` directly.
   useEffect(() => {
     if (!statusLineCommand || !refreshInterval) return;
     const timer = setInterval(() => {
+      if (activeChildRef.current) return;
       doUpdate();
     }, refreshInterval * 1000);
     return () => {

--- a/packages/core/src/subagents/builtin-agents.ts
+++ b/packages/core/src/subagents/builtin-agents.ts
@@ -240,6 +240,15 @@ How to use the statusLine command:
    }
    Make sure to preserve any existing "ui" settings (theme, etc.) when updating.
 
+4. Optionally add a "refreshInterval" field (number of seconds, minimum 1) to re-run
+   the command on a timer. Use this when the statusLine shows data that can change
+   WITHOUT an Agent event — examples:
+     - A clock / uptime / elapsed timer → refreshInterval: 1
+     - Rate-limit or quota counters that tick down → refreshInterval: 5–10
+     - CI / build status polled from a local cache file → refreshInterval: 10–30
+   Do NOT set refreshInterval for commands that only show Agent-driven data
+   (model name, token usage, git branch) — those already refresh on state changes.
+
 Guidelines:
 - The status line supports multi-line output (up to 2 lines) — each line of stdout is rendered as a separate row in the footer
 - Preserve existing settings when updating

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -135,7 +135,7 @@
           "default": "Qwen Dark"
         },
         "statusLine": {
-          "description": "Custom status line display configuration.",
+          "description": "Custom status line display configuration. Optional `refreshInterval` (seconds, >= 1) re-runs the command on a timer so external data stays fresh.",
           "type": "object",
           "additionalProperties": true
         },


### PR DESCRIPTION
## Summary

After #3311 landed multi-line statusline support, the statusline still only re-runs when Agent state changes (token count, model, branch, vim mode, tool calls, file lines). Commands that display **external** data — a clock, rate-limit counters, CI build status, uptime, or anything else not tied to an Agent event — go stale between messages.

This PR adds an optional `ui.statusLine.refreshInterval` field (seconds, minimum 1) that schedules a `setInterval` alongside the existing event-driven updates. Matches the same-named option added by Claude Code v2.1.97.

Configs without `refreshInterval` behave exactly as before — zero behavior change on the default path.

## Design

### Validation (parser-gated, not schema-gated)

The TS settings schema has no runtime validator — unknown JSON keys pass straight through. `getStatusLineConfig` is the gatekeeper and only keeps `refreshInterval` when it is:

- `typeof === 'number'`
- `Number.isFinite(x)` — rejects `Infinity`, `NaN`
- `x >= 1` — rejects 0, negatives, sub-second values

Anything else is silently dropped so the rest of the config still loads.

### Concurrency — asymmetric preemption

`doUpdate` kills any in-flight child and bumps `generationRef` before spawning a new one; the exec callback guard (`if (gen !== generationRef.current) return`) discards stale output. **Two callers treat this machinery differently:**

- **State-change and command-change triggers preempt.** Call `doUpdate` directly / via the 300ms debounce. A model switch or branch change implies the current output is now stale, so killing the in-flight child is the correct choice.
- **Periodic ticks yield.** The interval callback checks `if (activeChildRef.current) return;` and skips when an exec is in flight. Without this yield, a command whose real exec time exceeds `refreshInterval` would be killed and re-spawned on every tick; the eventual callback would always be discarded as stale (gen bumped N times) and `setOutput` would never run — the statusline would stay empty forever. Yielding lets the pending exec complete and surface a result before the next tick fires.

The 5s exec timeout is still the hard ceiling regardless of `refreshInterval`.

### React lifecycle

A new `useEffect` owns the interval. Dependencies: `[statusLineCommand, refreshInterval, doUpdate]` (`doUpdate` is `useCallback([])`-stable, so it doesn't cause re-runs).

- Command removed / `refreshInterval` unset → effect early-returns, no timer scheduled
- `refreshInterval` value changes → cleanup clears old timer, new one scheduled
- Command changes but `refreshInterval` stays → old timer cleared, new one scheduled from 0 (the existing command-change effect still fires the immediate re-exec, so no hidden delay)
- Unmount → cleanup clears the timer

Pattern matches existing interval hooks in this repo (`useMemoryMonitor`, `AppContainer` model-change poller).

## Before / After

**Before** — a clock in the statusline only advances when the user sends a message:

```json
{
  "ui": {
    "statusLine": {
      "type": "command",
      "command": "date +%H:%M:%S"
    }
  }
}
```

Displayed: `14:32:07` — frozen until the next Agent event.

**After** — same config + `refreshInterval: 1` ticks every second:

```json
{
  "ui": {
    "statusLine": {
      "type": "command",
      "command": "date +%H:%M:%S",
      "refreshInterval": 1
    }
  }
}
```

Displayed: `14:32:07` → `14:32:08` → `14:32:09` → …

When the command runs longer than `refreshInterval`, the statusline updates as fast as the command allows (bound by command latency, capped at the 5s exec timeout). It never gets stuck.

## Changes

| File | Purpose |
| --- | --- |
| `packages/cli/src/config/settingsSchema.ts` | Extend `ui.statusLine` default type with optional `refreshInterval?: number`; description explains the semantics |
| `packages/cli/src/ui/hooks/useStatusLine.ts` | Add `refreshInterval?: number` to `StatusLineConfig`; parse + validate in `getStatusLineConfig`; new periodic-refresh `useEffect` with yield-if-busy guard; output deduplication to skip unchanged re-renders |
| `packages/cli/src/ui/hooks/useStatusLine.test.ts` | +10 tests: periodic firing, omitted = no interval, `< 1` rejected, non-finite rejected, config-removal clears interval, reschedule on value change, unmount cleanup, starvation regression (verifies both `exec` call counts AND user-visible `lines` state), output dedup referential equality |
| `docs/users/features/status-line.md` | Config table row, behavior note, troubleshooting entry, new "Live clock and git branch" example |
| `packages/core/src/subagents/builtin-agents.ts` | statusline-setup subagent prompt now teaches when to use `refreshInterval` (clock/quota/CI) and when NOT to (Agent-driven data) |
| `packages/vscode-ide-companion/schemas/settings.schema.json` | Regenerated via `npm run generate:settings-schema` — description now reflects new field |

## Test plan

- [x] `useStatusLine.test.ts` — 52 tests pass (42 existing + 10 new)
- [x] Starvation regression asserts user-visible `lines` state after yielded ticks, not just `exec` call counts
- [x] Output dedup preserves array reference on unchanged output; produces new reference on change
- [x] `settingsSchema.test.ts` — 15 tests pass
- [x] `statuslineCommand.test.ts` — 4 tests pass
- [x] `subagent-manager.test.ts` — 64 tests pass
- [x] Full `packages/cli/src/ui/hooks/` suite — 658 pass / 2 skipped (no regressions)
- [x] TypeScript — zero new errors
- [x] ESLint — clean on all changed files
- [x] JSON schema regenerated; VSCode tooltip picks up the updated description
- [x] Runtime simulation: without the guard, a 2s command + `refreshInterval: 1` leaves `lines = null` forever; with the guard, `lines` updates every 2s (bound by command latency)
- [x] **Manual (tmux pseudo-TTY, 80x25, fresh bundle)**: `{ command: "date +%H:%M:%S", refreshInterval: 1 }` — clock advances one second per second without sending any messages (verified 6 consecutive 1-second snapshots: `10:49:27` → `10:49:28` → `10:49:29` → … → `10:49:33`)
- [x] **Manual (tmux pseudo-TTY, 80x25, fresh bundle)**: `{ command: "sleep 2; date +%H:%M:%S", refreshInterval: 1 }` — statusline updates every ~2–3s (bound by command latency) rather than staying blank; initial snapshot before first exec resolves is empty as expected, then `10:49:51` → `10:49:53` → `10:49:56` → `10:49:59`, proving the yield-if-busy guard allows the 2s exec to complete across 1s ticks
- [x] **Manual (tmux 40x25, narrow, 2-line statusline with progress-bar row, 25s)**: Footer renders stably at same row count across 25 ticks — no ghost-row accumulation, no prompt drift. (This environment does not reproduce the stacking reported in the inline E2E feedback; awaiting reporter's specific terminal + config to isolate — separate investigation.)
