### PR TITLE
feat(mcp): add OSC 52 copy hotkey for OAuth authorization URL

### DIFF
--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1083,6 +1083,12 @@ export default {
     'Press Enter to start authentication, Esc to go back',
   'Authenticating... Please complete the login in your browser.':
     'Authenticating... Please complete the login in your browser.',
+  'Press c to copy the authorization URL to your clipboard.':
+    'Press c to copy the authorization URL to your clipboard.',
+  'Copy request sent to your terminal. If paste is empty, copy the URL above manually.':
+    'Copy request sent to your terminal. If paste is empty, copy the URL above manually.',
+  'Cannot write to terminal — copy the URL above manually.':
+    'Cannot write to terminal — copy the URL above manually.',
   'Press Enter or Esc to go back': 'Press Enter or Esc to go back',
 
   // MCP Tool List

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1023,6 +1023,12 @@ export default {
     '按 Enter 开始认证，Esc 返回',
   'Authenticating... Please complete the login in your browser.':
     '认证中... 请在浏览器中完成登录。',
+  'Press c to copy the authorization URL to your clipboard.':
+    '按 c 复制授权 URL 到剪贴板。',
+  'Copy request sent to your terminal. If paste is empty, copy the URL above manually.':
+    '已向终端发送复制请求；若粘贴为空，请手动复制上方 URL。',
+  'Cannot write to terminal — copy the URL above manually.':
+    '无法写入终端，请手动复制上方 URL。',
   'Press Enter or Esc to go back': '按 Enter 或 Esc 返回',
 
   // MCP Server Detail

--- a/packages/cli/src/ui/components/mcp/steps/AuthenticateStep.tsx
+++ b/packages/cli/src/ui/components/mcp/steps/AuthenticateStep.tsx
@@ -22,6 +22,47 @@ import { appEvents, AppEvent } from '../../../../utils/events.js';
 type AuthState = 'idle' | 'authenticating' | 'success' | 'error';
 
 const AUTO_BACK_DELAY_MS = 2000;
+const COPY_FEEDBACK_MS = 2000;
+
+/**
+ * Wrap an OSC sequence for terminal multiplexers so the host terminal
+ * receives it. tmux requires a DCS passthrough with inner ESCs doubled;
+ * GNU screen uses a plain DCS envelope.
+ */
+function wrapForMultiplexer(osc: string): string {
+  if (process.env['TMUX']) {
+    return `\x1bPtmux;${osc.split('\x1b').join('\x1b\x1b')}\x1b\\`;
+  }
+  if (process.env['STY']) {
+    return `\x1bP${osc}\x1b\\`;
+  }
+  return osc;
+}
+
+/**
+ * Copy a string to the user's clipboard using the OSC 52 terminal escape
+ * sequence. Works through SSH and most web terminals (iTerm2, Windows
+ * Terminal, xterm.js-based emulators) without spawning a subprocess.
+ * Returns true if the sequence was written to a TTY; false otherwise.
+ * A return of true does not guarantee the terminal accepted the write —
+ * some terminals disable OSC 52 by default.
+ */
+function copyToClipboardViaOsc52(text: string): boolean {
+  const base64 = Buffer.from(text, 'utf8').toString('base64');
+  const seq = wrapForMultiplexer(`\x1b]52;c;${base64}\x07`);
+  const stream = process.stderr.isTTY
+    ? process.stderr
+    : process.stdout.isTTY
+      ? process.stdout
+      : null;
+  if (!stream) return false;
+  try {
+    stream.write(seq);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 export const AuthenticateStep: React.FC<AuthenticateStepProps> = ({
   server,
@@ -31,6 +72,10 @@ export const AuthenticateStep: React.FC<AuthenticateStepProps> = ({
   const [authState, setAuthState] = useState<AuthState>('idle');
   const [messages, setMessages] = useState<string[]>([]);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [authUrl, setAuthUrl] = useState<string | null>(null);
+  const [copyState, setCopyState] = useState<
+    { status: 'idle' } | { status: 'copied' | 'unsupported'; nonce: number }
+  >({ status: 'idle' });
   const isRunning = useRef(false);
 
   const runAuthentication = useCallback(async () => {
@@ -40,15 +85,6 @@ export const AuthenticateStep: React.FC<AuthenticateStepProps> = ({
     setAuthState('authenticating');
     setMessages([]);
     setErrorMessage(null);
-
-    // Listen for OAuth display messages - supports both plain strings and
-    // structured i18n messages ({ key, params }) emitted by the core layer.
-    const displayListener = (message: OAuthDisplayPayload) => {
-      const text =
-        typeof message === 'string' ? message : t(message.key, message.params);
-      setMessages((prev) => [...prev, text]);
-    };
-    appEvents.on(AppEvent.OauthDisplayMessage, displayListener);
 
     try {
       setMessages([
@@ -117,9 +153,29 @@ export const AuthenticateStep: React.FC<AuthenticateStepProps> = ({
       setAuthState('error');
     } finally {
       isRunning.current = false;
-      appEvents.removeListener(AppEvent.OauthDisplayMessage, displayListener);
     }
   }, [server, config]);
+
+  // Subscribe to OAuth events for the lifetime of this component. Keeping
+  // the subscription tied to mount/unmount (rather than to runAuthentication's
+  // async flow) ensures listeners are released immediately on unmount even if
+  // the authentication promise is still pending.
+  useEffect(() => {
+    const displayListener = (message: OAuthDisplayPayload) => {
+      const text =
+        typeof message === 'string' ? message : t(message.key, message.params);
+      setMessages((prev) => [...prev, text]);
+    };
+    const authUrlListener = (url: string) => {
+      setAuthUrl(url);
+    };
+    appEvents.on(AppEvent.OauthDisplayMessage, displayListener);
+    appEvents.on(AppEvent.OauthAuthUrl, authUrlListener);
+    return () => {
+      appEvents.removeListener(AppEvent.OauthDisplayMessage, displayListener);
+      appEvents.removeListener(AppEvent.OauthAuthUrl, authUrlListener);
+    };
+  }, []);
 
   useEffect(() => {
     runAuthentication();
@@ -139,10 +195,35 @@ export const AuthenticateStep: React.FC<AuthenticateStepProps> = ({
     (key) => {
       if (key.name === 'escape') {
         onBack();
+        return;
+      }
+      if (
+        key.name === 'c' &&
+        !key.ctrl &&
+        !key.meta &&
+        !key.paste &&
+        authUrl &&
+        authState === 'authenticating'
+      ) {
+        const ok = copyToClipboardViaOsc52(authUrl);
+        setCopyState({
+          status: ok ? 'copied' : 'unsupported',
+          nonce: Date.now(),
+        });
       }
     },
     { isActive: true },
   );
+
+  useEffect(() => {
+    if (copyState.status === 'idle') return;
+    const timer = setTimeout(
+      () => setCopyState({ status: 'idle' }),
+      COPY_FEEDBACK_MS,
+    );
+    return () => clearTimeout(timer);
+    // Depend on the nonce so repeated presses reset the timer.
+  }, [copyState]);
 
   if (!server) {
     return (
@@ -180,10 +261,30 @@ export const AuthenticateStep: React.FC<AuthenticateStepProps> = ({
       )}
 
       {/* Action hints */}
-      <Box>
+      <Box flexDirection="column">
         {authState === 'authenticating' && (
           <Text color={theme.text.secondary}>
             {t('Authenticating... Please complete the login in your browser.')}
+          </Text>
+        )}
+        {authState === 'authenticating' && authUrl && (
+          <Text
+            bold={copyState.status === 'idle'}
+            color={
+              copyState.status === 'copied'
+                ? theme.status.success
+                : copyState.status === 'unsupported'
+                  ? theme.status.warning
+                  : theme.text.accent
+            }
+          >
+            {copyState.status === 'copied'
+              ? t(
+                  'Copy request sent to your terminal. If paste is empty, copy the URL above manually.',
+                )
+              : copyState.status === 'unsupported'
+                ? t('Cannot write to terminal — copy the URL above manually.')
+                : t('Press c to copy the authorization URL to your clipboard.')}
           </Text>
         )}
         {authState === 'success' && (

--- a/packages/cli/src/utils/events.ts
+++ b/packages/cli/src/utils/events.ts
@@ -10,6 +10,7 @@ export enum AppEvent {
   OpenDebugConsole = 'open-debug-console',
   LogError = 'log-error',
   OauthDisplayMessage = 'oauth-display-message',
+  OauthAuthUrl = 'oauth-auth-url',
 }
 
 export const appEvents = new EventEmitter();

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -158,7 +158,11 @@ export * from './lsp/types.js';
 // MCP (Model Context Protocol)
 // ============================================================================
 
-export { MCPOAuthProvider } from './mcp/oauth-provider.js';
+export {
+  MCPOAuthProvider,
+  OAUTH_AUTH_URL_EVENT,
+  OAUTH_DISPLAY_MESSAGE_EVENT,
+} from './mcp/oauth-provider.js';
 export type {
   MCPOAuthConfig,
   OAuthDisplayMessage,

--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -21,6 +21,7 @@ import {
 } from './constants.js';
 
 export const OAUTH_DISPLAY_MESSAGE_EVENT = 'oauth-display-message' as const;
+export const OAUTH_AUTH_URL_EVENT = 'oauth-auth-url' as const;
 
 /**
  * Structured display message for i18n support.
@@ -818,6 +819,9 @@ export class MCPOAuthProvider {
     displayMessage({
       key: 'Make sure to copy the COMPLETE URL - it may wrap across multiple lines.',
     });
+    if (events) {
+      events.emit(OAUTH_AUTH_URL_EVENT, authUrl.toString());
+    }
 
     // Start callback server
     const callbackPromise = this.startCallbackServer(pkceParams.state);


### PR DESCRIPTION
## Summary

Fixes #3337.

When MCP OAuth falls back to the "copy this URL into your browser" path (browser can't auto-open, e.g. remote/SSH/web terminal), long URLs wrap across lines inside the bordered dialog and get tangled with `│` border characters on selection. The user has to paste into another buffer and manually strip borders and newlines before it's usable.

This PR adds a **`c` hotkey** on the authentication step that pushes the full URL to the user's local clipboard via an **OSC 52 terminal escape sequence** — no subprocess, no platform shims.

## How it works

- The core `MCPOAuthProvider` emits a new `OAUTH_AUTH_URL_EVENT` carrying the full URL alongside the existing display messages.
- `AuthenticateStep` subscribes, stores the URL in state, and binds `c` while authentication is in progress. Modifier / paste keys (`ctrl`, `meta`, `paste`) are filtered so `Ctrl+C`, bracketed paste, etc. don't misfire.
- `copyToClipboardViaOsc52` base64-encodes the URL and writes `\x1b]52;c;<base64>\x07` to `stderr` when it's a TTY, falls back to `stdout`, and wraps the sequence in DCS passthrough when `$TMUX` / `$STY` is set so multiplexed sessions still deliver to the host terminal.
- Feedback is honest — three states with short auto-revert:
  - **copied**: `Copy request sent to your terminal. If paste is empty, copy the URL above manually.`
  - **unsupported** (non-TTY): `Cannot write to terminal — copy the URL above manually.`
  - **idle**: `Press c to copy the authorization URL to your clipboard.`
- Repeated presses reset the feedback timer via a nonce on the state object.

The original "copy/paste the URL manually" hint is preserved verbatim, so users on terminals that don't support OSC 52 (or where the sequence is silently ignored) aren't regressed — they still see the URL and the manual-copy guidance.

## Terminal support

OSC 52 is implemented by iTerm2, Windows Terminal, kitty, Alacritty, WezTerm, GNOME Terminal (recent), modern xterm, tmux (with `set-clipboard on`), GNU screen, and xterm.js-based web terminals with `@xterm/addon-clipboard`. Where unsupported, the sequence is harmlessly ignored.

## Test plan

- [x] `npm run typecheck` — workspace-wide clean
- [x] `npx vitest run packages/core/src/mcp/oauth-provider.test.ts` — 22/22 pass
- [x] `npx eslint --max-warnings 0` on touched files — clean
- [x] Manual: trigger MCP OAuth against a server whose URL is long enough to wrap; press `c`; paste in browser — URL is intact.
- [ ] Manual: same flow inside tmux (`set -g set-clipboard on`) — clipboard is updated on the host terminal.
- [ ] Manual: same flow over SSH to a remote host into iTerm2 — clipboard lands locally.
- [ ] Manual: pipe stderr to a file (`qwen 2>/tmp/err`) — hint flips to `Cannot write to terminal — copy the URL above manually.`