### PR TITLE
test(integration): match new cron notification format in interactive tests

### DIFF
--- a/integration-tests/interactive/cron-interactive.test.ts
+++ b/integration-tests/interactive/cron-interactive.test.ts
@@ -55,15 +55,15 @@ function makeEnv(): NodeJS.ProcessEnv {
     );
 
     await session.waitForScreen(
-      (scr) => scr.split('\n').some((l) => l.trim() === '> PONG7742'),
-      'cron-injected prompt "> PONG7742"',
+      (scr) => scr.includes('Cron: PONG7742'),
+      'cron notification "Cron: PONG7742"',
       90_000,
     );
 
     await session.idle(5000);
     const finalScreen = await session.screen();
     const afterPrompt = finalScreen.slice(
-      finalScreen.lastIndexOf('> PONG7742'),
+      finalScreen.lastIndexOf('Cron: PONG7742'),
     );
     expect(afterPrompt).toContain('✦');
   });
@@ -79,8 +79,8 @@ function makeEnv(): NodeJS.ProcessEnv {
     );
 
     await session.waitForScreen(
-      (scr) => scr.split('\n').some((l) => l.trim() === '> CRONTICK99'),
-      'first cron fire "> CRONTICK99"',
+      (scr) => scr.includes('Cron: CRONTICK99'),
+      'first cron fire "Cron: CRONTICK99"',
       90_000,
     );
 


### PR DESCRIPTION
## TLDR

The `interactive/cron-interactive.test.ts` tests have been failing in CI since the distinct cron message type landed. They waited for the cron-injected prompt to appear as a legacy `> PONG7742` / `> CRONTICK99` user-message line, but cron prompts are now rendered only as `● Cron: …` notifications (the `> …` line is intentionally suppressed to avoid duplicates). The tests timed out after 90s waiting for a line that no longer exists. This PR updates the two affected predicates to match the current rendering.

## Screenshots / Video Demo

N/A — test-only change, no user-facing behavior.

## Dive Deeper

The shift happened when `SendMessageType.Cron` was introduced: the user-message history item is now skipped for cron submits, and the cron fire is surfaced via the unified notification queue as `Cron: <label>`. The render comment in `useGeminiStream.ts` calls this out explicitly. The third test in the file (`error during cron turn does not kill the loop`) already used substring matching on a model-emitted token, so it kept passing — only the two predicates that asserted on the legacy `> …` line needed updating.

## Reviewer Test Plan

- Build and bundle (`npm run build && npm run bundle`).
- Run `cd integration-tests && QWEN_SANDBOX=false npx vitest run interactive/cron-interactive.test.ts` with OpenAI-compatible env vars set.
- Expect all 3 tests to pass in roughly 90 seconds.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ✅  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

N/A