### PR TITLE
fix(cli): auto-submit on number key press in AskUserQuestionDialog

### DIFF
--- a/packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx
+++ b/packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx
@@ -286,6 +286,40 @@ describe('<AskUserQuestionDialog />', () => {
 
   describe('multiple questions', () => {
     it.skipIf(process.platform === 'win32')(
+      'does not auto-submit when pressing number key on Submit tab',
+      async () => {
+        const onConfirm = vi.fn();
+        const details = createConfirmationDetails({
+          questions: [
+            createSingleQuestion({ header: 'Q1' }),
+            createSingleQuestion({ header: 'Q2' }),
+          ],
+        });
+
+        const { stdin, unmount } = renderWithProviders(
+          <AskUserQuestionDialog
+            confirmationDetails={details}
+            onConfirm={onConfirm}
+          />,
+        );
+        await wait();
+
+        // Navigate to Submit tab
+        stdin.write('\u001B[C'); // Right
+        await wait();
+        stdin.write('\u001B[C'); // Right
+        await wait();
+
+        // Press '1' on Submit tab — should only highlight, not submit
+        stdin.write('1');
+        await wait();
+
+        expect(onConfirm).not.toHaveBeenCalled();
+        unmount();
+      },
+    );
+
+    it.skipIf(process.platform === 'win32')(
       'shows unanswered questions as (not answered) in Submit tab',
       async () => {
         const onConfirm = vi.fn();

--- a/packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx
+++ b/packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx
@@ -173,6 +173,50 @@ describe('<AskUserQuestionDialog />', () => {
       );
       unmount();
     });
+    it('auto-submits when pressing a number key for a predefined option', async () => {
+      const onConfirm = vi.fn();
+      const details = createConfirmationDetails();
+
+      const { stdin, unmount } = renderWithProviders(
+        <AskUserQuestionDialog
+          confirmationDetails={details}
+          onConfirm={onConfirm}
+        />,
+      );
+      await wait();
+
+      // Press '2' to select the second option (Blue) — should auto-submit
+      stdin.write('2');
+      await wait();
+
+      expect(onConfirm).toHaveBeenCalledWith(
+        ToolConfirmationOutcome.ProceedOnce,
+        { answers: { 0: 'Blue' } },
+      );
+      unmount();
+    });
+
+    it('does not auto-submit when pressing number key for "Other" custom input', async () => {
+      const onConfirm = vi.fn();
+      const details = createConfirmationDetails();
+
+      const { stdin, unmount } = renderWithProviders(
+        <AskUserQuestionDialog
+          confirmationDetails={details}
+          onConfirm={onConfirm}
+        />,
+      );
+      await wait();
+
+      // Press '4' to select the "Other" option (index 3, after 3 predefined options)
+      stdin.write('4');
+      await wait();
+
+      // Should NOT auto-submit — just highlight "Other" for text input
+      expect(onConfirm).not.toHaveBeenCalled();
+      unmount();
+    });
+
     it('cancels with Escape', async () => {
       const onConfirm = vi.fn();
       const details = createConfirmationDetails();
@@ -194,6 +238,28 @@ describe('<AskUserQuestionDialog />', () => {
   });
 
   describe('multi-select interaction', () => {
+    it('does not auto-submit when pressing number key in multi-select mode', async () => {
+      const onConfirm = vi.fn();
+      const details = createConfirmationDetails({
+        questions: [createSingleQuestion({ multiSelect: true })],
+      });
+
+      const { stdin, unmount } = renderWithProviders(
+        <AskUserQuestionDialog
+          confirmationDetails={details}
+          onConfirm={onConfirm}
+        />,
+      );
+      await wait();
+
+      // Press '2' — should only move highlight, not submit
+      stdin.write('2');
+      await wait();
+
+      expect(onConfirm).not.toHaveBeenCalled();
+      unmount();
+    });
+
     it('toggles options with Space', async () => {
       const onConfirm = vi.fn();
       const details = createConfirmationDetails({

--- a/packages/cli/src/ui/components/messages/AskUserQuestionDialog.tsx
+++ b/packages/cli/src/ui/components/messages/AskUserQuestionDialog.tsx
@@ -102,6 +102,22 @@ export const AskUserQuestionDialog: React.FC<AskUserQuestionDialogProps> = ({
     await onConfirm(ToolConfirmationOutcome.ProceedOnce, { answers });
   };
 
+  // Select a value for the current question, then submit (single question) or advance to the next tab (multi-question).
+  const selectAndAdvance = (value: string) => {
+    setSelectedOptions((prev) => ({ ...prev, [currentQuestionIndex]: value }));
+
+    if (!hasMultipleQuestions) {
+      void onConfirm(ToolConfirmationOutcome.ProceedOnce, {
+        answers: { [currentQuestionIndex]: value },
+      });
+    } else if (currentQuestionIndex < totalTabs - 1) {
+      setTimeout(() => {
+        setCurrentQuestionIndex((prev) => Math.min(prev + 1, totalTabs - 1));
+        setSelectedIndex(0);
+      }, 150);
+    }
+  };
+
   const handleMultiSelectSubmit = () => {
     if (!currentQuestion) return;
     const selections = [...(multiSelectedOptions[currentQuestionIndex] ?? [])];
@@ -111,22 +127,7 @@ export const AskUserQuestionDialog: React.FC<AskUserQuestionDialogProps> = ({
     }
     if (selections.length === 0) return;
 
-    const value = selections.join(', ');
-    const updated = { ...selectedOptions, [currentQuestionIndex]: value };
-    setSelectedOptions(updated);
-
-    if (!hasMultipleQuestions) {
-      void onConfirm(ToolConfirmationOutcome.ProceedOnce, {
-        answers: { [currentQuestionIndex]: value },
-      });
-    } else {
-      if (currentQuestionIndex < totalTabs - 1) {
-        setTimeout(() => {
-          setCurrentQuestionIndex((prev) => Math.min(prev + 1, totalTabs - 1));
-          setSelectedIndex(0);
-        }, 150);
-      }
-    }
+    selectAndAdvance(selections.join(', '));
   };
 
   const handleCustomInputSubmit = () => {
@@ -143,37 +144,13 @@ export const AskUserQuestionDialog: React.FC<AskUserQuestionDialogProps> = ({
     }
 
     if (!trimmedValue) return;
-
-    const updated = {
-      ...selectedOptions,
-      [currentQuestionIndex]: trimmedValue,
-    };
-    setSelectedOptions(updated);
-
-    // If single question, submit immediately
-    if (!hasMultipleQuestions) {
-      void onConfirm(ToolConfirmationOutcome.ProceedOnce, {
-        answers: {
-          [currentQuestionIndex]: trimmedValue,
-        },
-      });
-    } else {
-      // Auto-advance to next tab
-      if (currentQuestionIndex < totalTabs - 1) {
-        setTimeout(() => {
-          setCurrentQuestionIndex((prev) => Math.min(prev + 1, totalTabs - 1));
-          setSelectedIndex(0);
-        }, 150);
-      }
-    }
+    selectAndAdvance(trimmedValue);
   };
 
   // Handle navigation and selection
   useKeypress(
     (key) => {
-      if (!isFocused) return;
-
-      // When custom input is focused, still allow up/down navigation, tab switch and escape
+      // When custom input is focused, still allow up/down navigation and escape
       if (isCustomInputSelected) {
         if (key.name === 'up') {
           setSelectedIndex(Math.max(0, selectedIndex - 1));
@@ -221,7 +198,21 @@ export const AskUserQuestionDialog: React.FC<AskUserQuestionDialogProps> = ({
       // Number key selection
       const numKey = parseInt(input || '', 10);
       if (!isNaN(numKey) && numKey >= 1 && numKey <= totalOptions) {
-        setSelectedIndex(numKey - 1);
+        const targetIndex = numKey - 1;
+        setSelectedIndex(targetIndex);
+
+        // For single-select, auto-submit when selecting a predefined option (not "Other")
+        if (
+          !isMultiSelect &&
+          !isSubmitTab &&
+          currentQuestion &&
+          targetIndex < currentQuestion.options.length
+        ) {
+          const option = currentQuestion.options[targetIndex];
+          if (option) {
+            selectAndAdvance(option.label);
+          }
+        }
         return;
       }
 
@@ -272,28 +263,7 @@ export const AskUserQuestionDialog: React.FC<AskUserQuestionDialogProps> = ({
         if (currentQuestion && selectedIndex < currentQuestion.options.length) {
           const option = currentQuestion.options[selectedIndex];
           if (option) {
-            const updated = {
-              ...selectedOptions,
-              [currentQuestionIndex]: option.label,
-            };
-            setSelectedOptions(updated);
-
-            // If single question, submit immediately
-            if (!hasMultipleQuestions) {
-              void onConfirm(ToolConfirmationOutcome.ProceedOnce, {
-                answers: { [currentQuestionIndex]: option.label },
-              });
-            } else {
-              // Auto-advance to next tab after selection
-              if (currentQuestionIndex < totalTabs - 1) {
-                setTimeout(() => {
-                  setCurrentQuestionIndex((prev) =>
-                    Math.min(prev + 1, totalTabs - 1),
-                  );
-                  setSelectedIndex(0);
-                }, 150);
-              }
-            }
+            selectAndAdvance(option.label);
           }
         }
         return;


### PR DESCRIPTION
## Summary

Fixes #500

- Number keys in `AskUserQuestionDialog` only moved the highlight cursor without submitting, while the standard tool approval dialog (`useSelectionList`) auto-submits. Users pressed a number, saw the option highlight, and assumed it was selected — but the system was still waiting for Enter.
- For **single-select predefined options**, pressing a number key now auto-submits immediately, matching the behavior of `RadioButtonSelect`. Multi-select and "Other" custom input remain highlight-only.
- Extracted a shared `selectAndAdvance` helper to deduplicate the select-and-submit/advance logic across 4 code paths (number key, Enter, multi-select submit, custom input submit).
- Removed redundant `if (!isFocused) return` guard (already handled by `useKeypress`'s `isActive` parameter).

## Test plan

- [x] Added test: single-select auto-submits on number key press
- [x] Added test: "Other" custom input does NOT auto-submit on number key press
- [x] Added test: multi-select does NOT auto-submit on number key press
- [x] All 14 existing + new tests pass

##人工验证
本地编译：
```shell
  npm run build --workspace=packages/cli
```
运行：
```shell
  node packages/cli/dist/index.js
```
输入问题：
```
 Do not answer directly. You MUST call the AskUserQuestion tool with this question: "Which caching strategy?" with options: ["Redis", "Local
  memory", "No cache"]. Do NOT skip the tool call.
```

  当选项弹出后：
  - 按对应 "Other" 的数字键 → 应只高亮，不提交
  - 上下箭头 → 移动光标，不提交
  - Enter → 确认当前高亮项
  - 按数字键 1/2/3 → 应立即提交，不需要按 Enter(视频最终按的1)


详情参考录屏：

https://github.com/user-attachments/assets/225ae9f6-6e9c-481e-8132-908cc690f178



🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Qwen-Coder <qwen-coder@alibabacloud.com>