### PR TITLE
fix(core): parse MiniMax think tags in OpenAI responses

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -1143,6 +1143,176 @@ describe('OpenAIContentConverter', () => {
       );
     });
 
+    it('should extract leading MiniMax <think> tags into thought parts for non-streaming responses', () => {
+      const minimaxConverter = new OpenAIContentConverter('MiniMax-M2.5');
+      const response = minimaxConverter.convertOpenAIResponseToGemini({
+        object: 'chat.completion',
+        id: 'chatcmpl-minimax-think',
+        created: 123,
+        model: 'MiniMax-M2.5',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: '<think>chain-of-thought</think>\n\nfinal answer',
+            },
+            finish_reason: 'stop',
+            logprobs: null,
+          },
+        ],
+      } as unknown as OpenAI.Chat.ChatCompletion);
+
+      const parts = response.candidates?.[0]?.content?.parts;
+      expect(parts?.[0]).toEqual(
+        expect.objectContaining({ thought: true, text: 'chain-of-thought' }),
+      );
+      expect(parts?.[1]).toEqual(
+        expect.objectContaining({ text: '\n\nfinal answer' }),
+      );
+    });
+
+    it('should extract MiniMax <think> tags that appear after visible text', () => {
+      const minimaxConverter = new OpenAIContentConverter('MiniMax-M2.5');
+      const response = minimaxConverter.convertOpenAIResponseToGemini({
+        object: 'chat.completion',
+        id: 'chatcmpl-minimax-inline-think',
+        created: 123,
+        model: 'MiniMax-M2.5',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: 'preface <think>chain-of-thought</think>final answer',
+            },
+            finish_reason: 'stop',
+            logprobs: null,
+          },
+        ],
+      } as unknown as OpenAI.Chat.ChatCompletion);
+
+      const parts = response.candidates?.[0]?.content?.parts;
+      expect(parts?.[0]).toEqual(expect.objectContaining({ text: 'preface ' }));
+      expect(parts?.[1]).toEqual(
+        expect.objectContaining({ thought: true, text: 'chain-of-thought' }),
+      );
+      expect(parts?.[2]).toEqual(
+        expect.objectContaining({ text: 'final answer' }),
+      );
+    });
+
+    it('should leave non-MiniMax <think> tags in visible text', () => {
+      const response = converter.convertOpenAIResponseToGemini({
+        object: 'chat.completion',
+        id: 'chatcmpl-generic-think',
+        created: 123,
+        model: 'gpt-test',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content: '<think>chain-of-thought</think>final answer',
+            },
+            finish_reason: 'stop',
+            logprobs: null,
+          },
+        ],
+      } as unknown as OpenAI.Chat.ChatCompletion);
+
+      const parts = response.candidates?.[0]?.content?.parts;
+      expect(parts).toEqual([
+        expect.objectContaining({
+          text: '<think>chain-of-thought</think>final answer',
+        }),
+      ]);
+    });
+
+    it('should preserve earlier MiniMax thought parts when a later <think> block is unterminated', () => {
+      const minimaxConverter = new OpenAIContentConverter('MiniMax-M2.5');
+      const response = minimaxConverter.convertOpenAIResponseToGemini({
+        object: 'chat.completion',
+        id: 'chatcmpl-minimax-partial-think',
+        created: 123,
+        model: 'MiniMax-M2.5',
+        choices: [
+          {
+            index: 0,
+            message: {
+              role: 'assistant',
+              content:
+                'preface <think>chain-of-thought</think>tail <think>unterminated',
+            },
+            finish_reason: 'stop',
+            logprobs: null,
+          },
+        ],
+      } as unknown as OpenAI.Chat.ChatCompletion);
+
+      const parts = response.candidates?.[0]?.content?.parts;
+      expect(parts?.[0]).toEqual(expect.objectContaining({ text: 'preface ' }));
+      expect(parts?.[1]).toEqual(
+        expect.objectContaining({ thought: true, text: 'chain-of-thought' }),
+      );
+      expect(parts?.[2]).toEqual(expect.objectContaining({ text: 'tail ' }));
+      expect(parts?.[3]).toEqual(
+        expect.objectContaining({ text: '<think>unterminated' }),
+      );
+    });
+
+    it('should extract streaming MiniMax <think> tags into thought parts', () => {
+      const minimaxConverter = new OpenAIContentConverter('MiniMax-M2.5');
+      minimaxConverter.resetStreamingToolCalls();
+
+      const firstChunk = minimaxConverter.convertOpenAIChunkToGemini({
+        object: 'chat.completion.chunk',
+        id: 'chunk-minimax-think-1',
+        created: 456,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: '<think>chain-',
+            },
+            finish_reason: null,
+            logprobs: null,
+          },
+        ],
+        model: 'MiniMax-M2.5',
+      } as unknown as OpenAI.Chat.ChatCompletionChunk);
+
+      const secondChunk = minimaxConverter.convertOpenAIChunkToGemini({
+        object: 'chat.completion.chunk',
+        id: 'chunk-minimax-think-2',
+        created: 457,
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: 'of-thought</think>\n\nfinal answer',
+            },
+            finish_reason: 'stop',
+            logprobs: null,
+          },
+        ],
+        model: 'MiniMax-M2.5',
+      } as unknown as OpenAI.Chat.ChatCompletionChunk);
+
+      const firstParts = firstChunk.candidates?.[0]?.content?.parts;
+      const secondParts = secondChunk.candidates?.[0]?.content?.parts;
+
+      expect(firstParts?.[0]).toEqual(
+        expect.objectContaining({ thought: true, text: 'chain-' }),
+      );
+      expect(secondParts?.[0]).toEqual(
+        expect.objectContaining({ thought: true, text: 'of-thought' }),
+      );
+      expect(secondParts?.[1]).toEqual(
+        expect.objectContaining({ text: '\n\nfinal answer' }),
+      );
+    });
+
     it('should not throw when streaming chunk has no delta', () => {
       const chunk = converter.convertOpenAIChunkToGemini({
         object: 'chat.completion.chunk',

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -29,6 +29,8 @@ import {
 } from '../../utils/schemaConverter.js';
 
 const debugLogger = createDebugLogger('CONVERTER');
+const THINK_OPEN_TAG = '<think>';
+const THINK_CLOSE_TAG = '</think>';
 
 /**
  * Extended usage type that supports both OpenAI standard format and alternative formats
@@ -99,6 +101,8 @@ export class OpenAIContentConverter {
   private modalities: InputModalities;
   private streamingToolCallParser: StreamingToolCallParser =
     new StreamingToolCallParser();
+  private streamingThinkBuffer = '';
+  private streamingInsideThinkTag = false;
 
   constructor(
     model: string,
@@ -132,6 +136,115 @@ export class OpenAIContentConverter {
    */
   resetStreamingToolCalls(): void {
     this.streamingToolCallParser.reset();
+    this.streamingThinkBuffer = '';
+    this.streamingInsideThinkTag = false;
+  }
+
+  private isMiniMaxModel(): boolean {
+    return /^minimax-/i.test(this.model);
+  }
+
+  private splitMiniMaxThinkParts(content: string): Part[] {
+    if (!this.isMiniMaxModel()) {
+      return [{ text: content }];
+    }
+
+    const parts: Part[] = [];
+    let cursor = 0;
+    let matchedThinkBlock = false;
+
+    while (cursor < content.length) {
+      const openIndex = content.indexOf(THINK_OPEN_TAG, cursor);
+      if (openIndex === -1) {
+        const visibleText = content.slice(cursor);
+        if (visibleText) {
+          parts.push({ text: visibleText });
+        }
+        break;
+      }
+
+      const visibleText = content.slice(cursor, openIndex);
+      if (visibleText) {
+        parts.push({ text: visibleText });
+      }
+
+      const closeIndex = content.indexOf(
+        THINK_CLOSE_TAG,
+        openIndex + THINK_OPEN_TAG.length,
+      );
+      if (closeIndex === -1) {
+        const trailingText = content.slice(openIndex);
+        if (trailingText) {
+          parts.push({ text: trailingText });
+        }
+        break;
+      }
+
+      matchedThinkBlock = true;
+
+      const thoughtText = content.slice(
+        openIndex + THINK_OPEN_TAG.length,
+        closeIndex,
+      );
+      if (thoughtText) {
+        parts.push({ text: thoughtText, thought: true });
+      }
+
+      cursor = closeIndex + THINK_CLOSE_TAG.length;
+    }
+
+    return matchedThinkBlock ? parts : [{ text: content }];
+  }
+
+  private extractMiniMaxStreamingParts(fragment: string): Part[] {
+    if (!this.isMiniMaxModel() || fragment === '') {
+      return fragment ? [{ text: fragment }] : [];
+    }
+
+    let buffer = this.streamingThinkBuffer + fragment;
+    this.streamingThinkBuffer = '';
+    const parts: Part[] = [];
+
+    while (buffer) {
+      const targetTag = this.streamingInsideThinkTag
+        ? THINK_CLOSE_TAG
+        : THINK_OPEN_TAG;
+      const tagIndex = buffer.indexOf(targetTag);
+
+      if (tagIndex === -1) {
+        const suffixLength = this.getTrailingTagPrefixLength(buffer, targetTag);
+        const text = buffer.slice(0, buffer.length - suffixLength);
+        if (text) {
+          parts.push(
+            this.streamingInsideThinkTag ? { text, thought: true } : { text },
+          );
+        }
+        this.streamingThinkBuffer = buffer.slice(buffer.length - suffixLength);
+        return parts;
+      }
+
+      const text = buffer.slice(0, tagIndex);
+      if (text) {
+        parts.push(
+          this.streamingInsideThinkTag ? { text, thought: true } : { text },
+        );
+      }
+
+      buffer = buffer.slice(tagIndex + targetTag.length);
+      this.streamingInsideThinkTag = !this.streamingInsideThinkTag;
+    }
+
+    return parts;
+  }
+
+  private getTrailingTagPrefixLength(text: string, tag: string): number {
+    const maxLength = Math.min(text.length, tag.length - 1);
+    for (let length = maxLength; length > 0; length -= 1) {
+      if (text.endsWith(tag.slice(0, length))) {
+        return length;
+      }
+    }
+    return 0;
   }
 
   /**
@@ -827,7 +940,6 @@ export class OpenAIContentConverter {
     if (choice) {
       const parts: Part[] = [];
 
-      // Handle reasoning content (thoughts)
       const reasoningText =
         (choice.message as ExtendedCompletionMessage).reasoning_content ??
         (choice.message as ExtendedCompletionMessage).reasoning;
@@ -837,7 +949,11 @@ export class OpenAIContentConverter {
 
       // Handle text content
       if (choice.message.content) {
-        parts.push({ text: choice.message.content });
+        if (!reasoningText && typeof choice.message.content === 'string') {
+          parts.push(...this.splitMiniMaxThinkParts(choice.message.content));
+        } else {
+          parts.push({ text: choice.message.content });
+        }
       }
 
       // Handle tool calls
@@ -947,7 +1063,13 @@ export class OpenAIContentConverter {
       // Handle text content
       if (choice.delta?.content) {
         if (typeof choice.delta.content === 'string') {
-          parts.push({ text: choice.delta.content });
+          if (reasoningText) {
+            parts.push({ text: choice.delta.content });
+          } else {
+            parts.push(
+              ...this.extractMiniMaxStreamingParts(choice.delta.content),
+            );
+          }
         }
       }
 


### PR DESCRIPTION
## TLDR

Parse MiniMax OpenAI-compatible `<think>...</think>` content into thought parts in the OpenAI-to-Gemini converter so the tags no longer leak into visible assistant output.

## Screenshots / Video Demo

See issue #3387 for before screenshots.

After this change, the converter emits MiniMax `<think>` content as thought parts and preserves the visible suffix exactly, including newline formatting. The behavior is covered by focused regression tests for:
- non-streaming responses
- streaming chunk boundaries
- visible text before a `<think>` block
- unterminated trailing `<think>` blocks

## Dive Deeper

MiniMax's OpenAI-compatible surface can return reasoning inline inside `message.content` / `delta.content` using `<think>...</think>` tags instead of the structured `reasoning_content` / `reasoning` fields that the converter already understands.

This patch keeps the scope narrow:
- only MiniMax models are affected
- structured reasoning fields still take precedence
- non-MiniMax models keep literal `<think>` text unchanged
- unmatched trailing `<think>` content falls back to visible text instead of dropping already-parsed parts

## Reviewer Test Plan

1. Run `cd packages/core && npx vitest run --coverage.enabled=false src/core/openaiContentGenerator/converter.test.ts`
2. Inspect the added MiniMax cases in `src/core/openaiContentGenerator/converter.test.ts`
3. Confirm that MiniMax-tagged content is split into thought + visible parts, while `gpt-test` keeps literal `<think>` text unchanged

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

## Linked issues / bugs

Closes #3387
