### PR TITLE
  test(core): update scheduler registry mock

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -3919,16 +3919,22 @@ describe('CoreToolScheduler validation retry loop detection', () => {
 
   function createSchedulerWithTool(tool: StrictStringTool) {
     const mockToolRegistry = {
-      getTool: () => tool,
+      ensureTool: async (name: string) =>
+        name === StrictStringTool.Name ? tool : undefined,
+      getTool: (name: string) =>
+        name === StrictStringTool.Name ? tool : undefined,
       getFunctionDeclarations: () => [],
       tools: new Map(),
       discovery: {},
       registerTool: () => {},
-      getToolByName: () => tool,
-      getToolByDisplayName: () => tool,
+      getToolByName: (name: string) =>
+        name === StrictStringTool.Name ? tool : undefined,
+      getToolByDisplayName: (name: string) =>
+        name === 'StrictStringTool' ? tool : undefined,
       getTools: () => [],
       discoverTools: async () => {},
       getAllTools: () => [],
+      getAllToolNames: () => [StrictStringTool.Name],
       getToolsByServer: () => [],
     } as unknown as ToolRegistry;
 


### PR DESCRIPTION

## TLDR

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

  Updates the `CoreToolScheduler` retry-loop test mock to match the current `ToolRegistry` interface.

  The scheduler now calls `ensureTool()` when resolving tools and `getAllToolNames()` when building unknown-tool suggestions. The affected
  tests still used an older hand-written mock, which caused CI failures with:

## Screenshots / Video Demo

<!--
Please attach a screenshot or short video showing your change in action.
This helps reviewers understand the change quickly and prioritize reviews.

- For bug fixes: show the before/after behavior.
- For features: show the new functionality in use.
- For refactors or internal changes with no visible effect: write "N/A — no user-facing change" and briefly explain why.

PRs with visual demos typically get reviewed much faster!
-->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

  |          | 🍏  | 🪟  | 🐧  |
  | -------- | --- | --- | --- |
  | npm run  | ❓  | ❓  | ✅  |
  | npx      | ❓  | ❓  | ✅  |
  | Docker   | ❓  | ❓  | ❓  |
  | Podman   | ❓  | -   | -   |
  | Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

https://github.com/QwenLM/qwen-code/actions/runs/24596356586/job/71927119595?pr=3394

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
