### PR TITLE
fix(cli): dismiss /btw side-question dialog on /clear

### DIFF
--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -995,6 +995,35 @@ describe('useSlashCommandProcessor', () => {
     });
   });
 
+  describe('UI State Management', () => {
+    it('should dismiss the active /btw item when ui.clear is called', async () => {
+      const result = setupProcessorHook();
+      await waitFor(() => expect(result.current.slashCommands).toBeDefined());
+
+      const activeBtwItem = {
+        type: 'btw' as const,
+        btw: {
+          question: 'What is the difference between let and var?',
+          answer: 'let is block-scoped, var is function-scoped.',
+          isPending: false,
+        },
+      };
+
+      act(() => {
+        result.current.setBtwItem(activeBtwItem);
+      });
+
+      expect(result.current.btwItem).toEqual(activeBtwItem);
+
+      act(() => {
+        result.current.commandContext.ui.clear();
+      });
+
+      expect(mockClearItems).toHaveBeenCalledTimes(1);
+      expect(result.current.btwItem).toBeNull();
+    });
+  });
+
   describe('Slash Command Logging', () => {
     const mockCommandAction = vi.fn().mockResolvedValue({ type: 'handled' });
     const loggingTestCommands: SlashCommand[] = [

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -259,6 +259,7 @@ export const useSlashCommandProcessor = (
       ui: {
         addItem,
         clear: () => {
+          cancelBtw();
           clearItems();
           clearScreen();
           refreshStatic();


### PR DESCRIPTION
## TLDR

Fixes an interactive CLI bug where `/clear` reset the main conversation history but left the bottom `/btw` side-question UI visible. `/clear` now cancels and clears the active `/btw` state so the session is actually reset to a clean slate.

## Screenshots / Video Demo

this is a transient CLI UI state fix. The behavior is easiest to validate directly with the reviewer test plan below.

<img width="2218" height="832" alt="image" src="https://github.com/user-attachments/assets/fc6830a2-beea-4fae-be4d-43dfa6d9c437" />
<img width="2214" height="444" alt="image" src="https://github.com/user-attachments/assets/bb0a206f-1484-4b22-80c5-332d52ab6c48" />


## Dive Deeper

`btwItem` is tracked separately from the main history state. Before this change, `ui.clear()` only called `clearItems()`, `clearScreen()`, and `refreshStatic()`, so an active `/btw` item could survive a clear.

This PR updates `ui.clear()` to call `cancelBtw()` first. That covers both completed and in-flight `/btw` side questions and keeps the UI state consistent with the cleared session.

It also adds a regression test to verify that calling `ui.clear()` dismisses an active `btwItem`.

## Reviewer Test Plan

1. Run `npm run start`
2. Send a normal prompt so the main session is active
3. Run `/btw What is the difference between let and var?`
4. After the `/btw` area appears at the bottom, run `/clear`
5. Confirm the main conversation history is cleared and the `/btw` area disappears immediately
6. Repeat once while `/btw` is still pending and confirm it does not reappear later

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

`npm exec --workspace=packages/cli vitest -- --run src/ui/hooks/slashCommandProcessor.test.ts src/ui/commands/clearCommand.test.ts src/ui/commands/btwCommand.test.ts` passed locally.

`npm run build` currently fails in `packages/vscode-ide-companion` because `esbuild-plugin-wasm` cannot be resolved. That failure is pre-existing and unrelated to this PR.

## Linked issues / bugs

Resolves #3334
