### PR TITLE
fix(cli): let /btw use live conversation context

### DIFF
--- a/packages/cli/src/ui/commands/btwCommand.test.ts
+++ b/packages/cli/src/ui/commands/btwCommand.test.ts
@@ -52,6 +52,12 @@ describe('btwCommand', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetCacheSafeParams.mockReturnValue({
+      generationConfig: {},
+      history: [],
+      model: 'test-model',
+      version: 1,
+    });
     mockContext = createMockCommandContext({
       services: {
         config: createConfig(),
@@ -153,6 +159,107 @@ describe('btwCommand', () => {
         expect.objectContaining({
           cacheSafeParams: expect.objectContaining({ model: 'test-model' }),
           userMessage: expect.stringContaining('my question'),
+        }),
+      );
+    });
+
+    it('should fall back to live Gemini client context when no saved cache params exist', async () => {
+      mockGetCacheSafeParams.mockReturnValue(null);
+      mockRunForkedAgent.mockResolvedValue({
+        text: 'answer',
+        usage: { inputTokens: 5, outputTokens: 2, cacheHitTokens: 0 },
+      });
+
+      const geminiClient = {
+        getHistory: vi
+          .fn()
+          .mockReturnValue([
+            { role: 'user', parts: [{ text: '杭州天气如何？' }] },
+          ]),
+        getChat: vi.fn().mockReturnValue({
+          getGenerationConfig: vi.fn().mockReturnValue({
+            systemInstruction: 'You are helpful',
+            tools: [],
+          }),
+        }),
+      };
+
+      const liveContext = createMockCommandContext({
+        services: {
+          config: createConfig({
+            getGeminiClient: () => geminiClient,
+          }),
+        },
+      });
+
+      await btwCommand.action!(liveContext, 'how ?');
+      await flushPromises();
+
+      expect(mockRunForkedAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cacheSafeParams: expect.objectContaining({
+            generationConfig: expect.objectContaining({
+              systemInstruction: 'You are helpful',
+            }),
+            history: [{ role: 'user', parts: [{ text: '杭州天气如何？' }] }],
+            model: 'test-model',
+          }),
+          userMessage: expect.stringContaining('how ?'),
+        }),
+      );
+    });
+
+    it('should prefer live Gemini client history over a stale saved cache snapshot', async () => {
+      mockGetCacheSafeParams.mockReturnValue({
+        generationConfig: {
+          systemInstruction: 'stale system prompt',
+          tools: [],
+        },
+        history: [{ role: 'user', parts: [{ text: '旧问题' }] }],
+        model: 'stale-model',
+        version: 99,
+      });
+      mockRunForkedAgent.mockResolvedValue({
+        text: 'answer',
+        usage: { inputTokens: 5, outputTokens: 2, cacheHitTokens: 0 },
+      });
+
+      const geminiClient = {
+        getHistory: vi.fn().mockReturnValue([
+          { role: 'user', parts: [{ text: '杭州天气如何？' }] },
+          { role: 'user', parts: [{ text: '请顺便解释一下湿度怎么看' }] },
+        ]),
+        getChat: vi.fn().mockReturnValue({
+          getGenerationConfig: vi.fn().mockReturnValue({
+            systemInstruction: 'live system prompt',
+            tools: [],
+          }),
+        }),
+      };
+
+      const liveContext = createMockCommandContext({
+        services: {
+          config: createConfig({
+            getGeminiClient: () => geminiClient,
+          }),
+        },
+      });
+
+      await btwCommand.action!(liveContext, 'how ?');
+      await flushPromises();
+
+      expect(mockRunForkedAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          cacheSafeParams: expect.objectContaining({
+            generationConfig: expect.objectContaining({
+              systemInstruction: 'live system prompt',
+            }),
+            history: [
+              { role: 'user', parts: [{ text: '杭州天气如何？' }] },
+              { role: 'user', parts: [{ text: '请顺便解释一下湿度怎么看' }] },
+            ],
+            model: 'test-model',
+          }),
         }),
       );
     });

--- a/packages/cli/src/ui/commands/btwCommand.ts
+++ b/packages/cli/src/ui/commands/btwCommand.ts
@@ -47,6 +47,44 @@ function buildBtwPrompt(question: string): string {
   ].join('\n');
 }
 
+function getBtwCacheSafeParams(
+  context: CommandContext,
+): ReturnType<typeof getCacheSafeParams> {
+  const geminiClient = context.services.config?.getGeminiClient();
+  if (
+    geminiClient &&
+    typeof geminiClient === 'object' &&
+    typeof geminiClient.getChat === 'function' &&
+    typeof geminiClient.getHistory === 'function'
+  ) {
+    const chat = geminiClient.getChat();
+    if (
+      chat &&
+      typeof chat === 'object' &&
+      typeof chat.getGenerationConfig === 'function'
+    ) {
+      const generationConfig = chat.getGenerationConfig();
+      if (generationConfig) {
+        const fullHistory = geminiClient.getHistory(true);
+        const maxHistoryEntries = 40;
+        const history =
+          fullHistory.length > maxHistoryEntries
+            ? fullHistory.slice(-maxHistoryEntries)
+            : fullHistory;
+
+        return {
+          generationConfig,
+          history,
+          model: context.services.config?.getModel() ?? '',
+          version: 0,
+        };
+      }
+    }
+  }
+
+  return getCacheSafeParams();
+}
+
 /**
  * Run a side question using runForkedAgent (cache path).
  *
@@ -63,7 +101,7 @@ async function askBtw(
   const { config } = context.services;
   if (!config) throw new Error('Config not loaded');
 
-  const cacheSafeParams = getCacheSafeParams();
+  const cacheSafeParams = getBtwCacheSafeParams(context);
   if (!cacheSafeParams)
     throw new Error(t('No conversation context available for /btw'));
 


### PR DESCRIPTION
## TLDR

Fix `/btw` so it can use the live conversation context while the main request is still in progress, instead of failing with `No conversation context available for /btw` when no saved cache snapshot exists yet.

## Screenshots / Video Demo

<img width="1994" height="1430" alt="image" src="https://github.com/user-attachments/assets/bcf1b37f-c330-415d-988a-e1ecf3911586" />

this is a CLI interaction fix for side-question context handling. The behavior is best validated with the reviewer test plan below.

## Dive Deeper

Before this change, `/btw` only read `getCacheSafeParams()`. That snapshot is saved after a main turn finishes, so `/btw` could fail in two common cases:

- the first main request was still running
- the current main request had newer live history than the last saved snapshot

This PR adds a small fallback in `btwCommand`:

- prefer the live `GeminiClient` generation config and history when available
- fall back to the saved cache snapshot only when the live client context is unavailable

That keeps `/btw` aligned with the current session state and avoids using stale context when the main conversation has already advanced.

It also adds regression coverage for both cases:

- no saved cache params yet, but live client context exists
- a stale saved snapshot exists, but live client history is newer and should win

## Reviewer Test Plan

1. Run `npm run start`
2. Submit a normal prompt, for example `杭州天气如何？`
3. While the main answer is still streaming, run `/btw how?`
4. Confirm `/btw` answers instead of showing `Failed to answer btw question: No conversation context available for /btw`
5. Repeat with a second main prompt and trigger `/btw` while that second prompt is still in progress
6. Confirm `/btw` reflects the current conversation context rather than an older completed turn

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

Verified locally with:

- `npm exec --workspace=packages/cli vitest -- --run src/ui/commands/btwCommand.test.ts`
- `npm run build`

## Linked issues / bugs

No dedicated issue yet.

This bug is separate from #3334, which only addressed dismissing the `/btw` UI on `/clear`.
