### PR TITLE
fix(cli): /clear dismisses active /btw side-question dialog

### DIFF
--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -14,6 +14,7 @@ import type {
 } from '../commands/types.js';
 import { CommandKind } from '../commands/types.js';
 import type { LoadedSettings } from '../../config/settings.js';
+import type { HistoryItemBtw } from '../types.js';
 import { MessageType } from '../types.js';
 import { BuiltinCommandLoader } from '../../services/BuiltinCommandLoader.js';
 import { FileCommandLoader } from '../../services/FileCommandLoader.js';
@@ -1122,6 +1123,55 @@ describe('useSlashCommandProcessor', () => {
         await result.current.handleSlashCommand('/unknown');
       });
       expect(logSlashCommand).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ui.clear and /btw dialog', () => {
+    it('should dismiss an active btw dialog when ui.clear is called', async () => {
+      const result = setupProcessorHook();
+      await waitFor(() => expect(result.current.commandContext).toBeDefined());
+
+      const btwItem: HistoryItemBtw = {
+        type: MessageType.BTW,
+        btw: { question: 'why?', answer: '', isPending: true },
+      };
+
+      act(() => {
+        result.current.commandContext.ui.setBtwItem(btwItem);
+      });
+      await waitFor(() => {
+        expect(result.current.commandContext.ui.btwItem).toEqual(btwItem);
+      });
+
+      act(() => {
+        result.current.commandContext.ui.clear();
+      });
+
+      await waitFor(() => {
+        expect(result.current.commandContext.ui.btwItem).toBeNull();
+      });
+    });
+
+    it('should abort the in-flight btw request when ui.clear is called', async () => {
+      const result = setupProcessorHook();
+      await waitFor(() => expect(result.current.commandContext).toBeDefined());
+
+      const abortController = new AbortController();
+      const abortSpy = vi.spyOn(abortController, 'abort');
+
+      act(() => {
+        result.current.commandContext.ui.btwAbortControllerRef.current =
+          abortController;
+      });
+
+      act(() => {
+        result.current.commandContext.ui.clear();
+      });
+
+      expect(abortSpy).toHaveBeenCalledTimes(1);
+      expect(
+        result.current.commandContext.ui.btwAbortControllerRef.current,
+      ).toBeNull();
     });
   });
 });

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -259,6 +259,7 @@ export const useSlashCommandProcessor = (
       ui: {
         addItem,
         clear: () => {
+          cancelBtw();
           clearItems();
           clearScreen();
           refreshStatic();


### PR DESCRIPTION
## Summary

Fixes #3334 — `/clear` (and its aliases `/reset`, `/new`) now dismiss an active `/btw` side-question dialog.

`/btw` stores its pending-question state in a dedicated `btwItem` slot (via `setBtwItem` in `slashCommandProcessor`) rather than in the history log, so it survives `clearItems()` / `clearScreen()`. The result: after `/clear`, the scrollback is gone but the `btw>` question and answer panel is still pinned to the fixed bottom area until it finishes or the user hits ESC.

## Root cause

`slashCommandProcessor.ts` wires the `CommandContext.ui.clear` callback as:

```ts
clear: () => {
  clearItems();
  clearScreen();
  refreshStatic();
},
```

`cancelBtw()` — which aborts `btwAbortControllerRef.current` and calls `setBtwItem(null)` — is never invoked, so the dedicated btw state leaks across the clear.

## Fix

Call `cancelBtw()` at the top of the `clear` callback. `cancelBtw` is already in the memo dependency array, so no other changes are needed. The call is a no-op when no btw is active.

## Test plan

- [x] Added two regression tests in `slashCommandProcessor.test.ts`:
  - `ui.clear` nulls out an active `btwItem`
  - `ui.clear` aborts the stored `btwAbortControllerRef` and resets it to `null`
- [x] `vitest run src/ui/hooks/slashCommandProcessor.test.ts` — 39 passing (37 existing + 2 new)
- [x] `vitest run src/ui/commands/clearCommand.test.ts src/ui/commands/btwCommand.test.ts` — 25 passing, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)