### PR TITLE
  fix(core): support older Git during repository initialization

### DIFF
--- a/packages/core/src/services/gitInit.ts
+++ b/packages/core/src/services/gitInit.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { SimpleGit } from 'simple-git';
+
+export async function initRepositoryWithMainBranch(
+  git: SimpleGit,
+): Promise<void> {
+  await git.init(false);
+  await git.raw(['symbolic-ref', 'HEAD', 'refs/heads/main']);
+}

--- a/packages/core/src/services/gitService.test.ts
+++ b/packages/core/src/services/gitService.test.ts
@@ -162,12 +162,27 @@ describe('GitService', () => {
       expect(actualConfigContent).toBe(expectedConfigContent);
     });
 
+    it('should use the shadow git config during repository setup', async () => {
+      const service = new GitService(projectRoot, storage);
+      await service.setupShadowGitRepository();
+
+      expect(hoistedMockEnv).toHaveBeenCalledWith({
+        HOME: repoDir,
+        XDG_CONFIG_HOME: repoDir,
+      });
+    });
+
     it('should initialize git repo in historyDir if not already initialized', async () => {
       hoistedMockCheckIsRepo.mockResolvedValue(false);
       const service = new GitService(projectRoot, storage);
       await service.setupShadowGitRepository();
       expect(hoistedMockSimpleGit).toHaveBeenCalledWith(repoDir);
-      expect(hoistedMockInit).toHaveBeenCalled();
+      expect(hoistedMockInit).toHaveBeenCalledWith(false);
+      expect(hoistedMockRaw).toHaveBeenCalledWith([
+        'symbolic-ref',
+        'HEAD',
+        'refs/heads/main',
+      ]);
     });
 
     it('should initialize git repo when root repo check throws', async () => {
@@ -184,6 +199,7 @@ describe('GitService', () => {
       const service = new GitService(projectRoot, storage);
       await service.setupShadowGitRepository();
       expect(hoistedMockInit).not.toHaveBeenCalled();
+      expect(hoistedMockRaw).not.toHaveBeenCalled();
     });
 
     it('should copy .gitignore from projectRoot if it exists', async () => {

--- a/packages/core/src/services/gitService.ts
+++ b/packages/core/src/services/gitService.ts
@@ -11,6 +11,7 @@ import type { SimpleGit } from 'simple-git';
 import { simpleGit, CheckRepoActions } from 'simple-git';
 import type { Storage } from '../config/storage.js';
 import { isNodeError } from '../utils/errors.js';
+import { initRepositoryWithMainBranch } from './gitInit.js';
 
 export class GitService {
   private projectRoot: string;
@@ -57,7 +58,11 @@ export class GitService {
       '[user]\n  name = Qwen Code\n  email = qwen-code@qwen.ai\n[commit]\n  gpgsign = false\n';
     await fs.writeFile(gitConfigPath, gitConfigContent);
 
-    const repo = simpleGit(repoDir);
+    const repo = simpleGit(repoDir).env({
+      // Prevent git from using the user's global git config.
+      HOME: repoDir,
+      XDG_CONFIG_HOME: repoDir,
+    });
     let isRepoDefined = false;
     try {
       isRepoDefined = await repo.checkIsRepo(CheckRepoActions.IS_REPO_ROOT);
@@ -68,10 +73,7 @@ export class GitService {
     }
 
     if (!isRepoDefined) {
-      await repo.init(false, {
-        '--initial-branch': 'main',
-      });
-
+      await initRepositoryWithMainBranch(repo);
       await repo.commit('Initial commit', { '--allow-empty': null });
     }
 

--- a/packages/core/src/services/gitWorktreeService.test.ts
+++ b/packages/core/src/services/gitWorktreeService.test.ts
@@ -135,6 +135,43 @@ describe('GitWorktreeService', () => {
     expect(hoistedMockCheckIsRepo).toHaveBeenNthCalledWith(2);
   });
 
+  it('initializeRepository should initialize a new repo on main', async () => {
+    hoistedMockCheckIsRepo.mockResolvedValue(false);
+    const service = new GitWorktreeService('/repo');
+
+    const result = await service.initializeRepository();
+
+    expect(result).toEqual({ initialized: true });
+    expect(hoistedMockInit).toHaveBeenCalledWith(false);
+    expect(hoistedMockRaw).toHaveBeenCalledWith([
+      'symbolic-ref',
+      'HEAD',
+      'refs/heads/main',
+    ]);
+    expect(hoistedMockAdd).toHaveBeenCalledWith('.');
+    expect(hoistedMockCommit).toHaveBeenCalledWith('Initial commit', {
+      '--allow-empty': null,
+    });
+    expect(hoistedMockInit.mock.invocationCallOrder[0]!).toBeLessThan(
+      hoistedMockRaw.mock.invocationCallOrder[0]!,
+    );
+    expect(hoistedMockRaw.mock.invocationCallOrder[0]!).toBeLessThan(
+      hoistedMockCommit.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it('initializeRepository should not update HEAD for an existing repo', async () => {
+    hoistedMockCheckIsRepo.mockResolvedValue(true);
+    const service = new GitWorktreeService('/repo');
+
+    const result = await service.initializeRepository();
+
+    expect(result).toEqual({ initialized: false });
+    expect(hoistedMockInit).not.toHaveBeenCalled();
+    expect(hoistedMockRaw).not.toHaveBeenCalled();
+    expect(hoistedMockCommit).not.toHaveBeenCalled();
+  });
+
   it('createWorktree should create a sanitized branch and worktree path', async () => {
     const service = new GitWorktreeService('/repo');
 

--- a/packages/core/src/services/gitWorktreeService.ts
+++ b/packages/core/src/services/gitWorktreeService.ts
@@ -12,6 +12,7 @@ import type { SimpleGit } from 'simple-git';
 import { Storage } from '../config/storage.js';
 import { isCommandAvailable } from '../utils/shell-utils.js';
 import { isNodeError } from '../utils/errors.js';
+import { initRepositoryWithMainBranch } from './gitInit.js';
 
 /**
  * Commit message used for the baseline snapshot in worktrees.
@@ -185,7 +186,7 @@ export class GitWorktreeService {
     }
 
     try {
-      await this.git.init(false, { '--initial-branch': 'main' });
+      await initRepositoryWithMainBranch(this.git);
 
       // Create initial commit so we can create worktrees
       await this.git.add('.');


### PR DESCRIPTION


## TLDR

  Checkpointing initializes a shadow Git repository during startup. The current
  implementation uses `git init --initial-branch=main`, which requires Git 2.28 or
  newer. On older Git versions, enabling checkpointing can fail during startup
  before any checkpoint is created.

  This PR replaces that initialization with a more compatible sequence:

  - `git init`
  - `git symbolic-ref HEAD refs/heads/main`

  This preserves the intended `main` initial branch while avoiding the Git 2.28+
  requirement.

  The same helper is used for worktree repository initialization so both code
  paths share the compatible behavior.

  This also ensures shadow repository setup uses its dedicated Git config during
  the initial commit, so checkpoint initialization does not depend on the user's
  global Git identity.

<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Screenshots / Video Demo

<!--
Please attach a screenshot or short video showing your change in action.
This helps reviewers understand the change quickly and prioritize reviews.

- For bug fixes: show the before/after behavior.
- For features: show the new functionality in use.
- For refactors or internal changes with no visible effect: write "N/A — no user-facing change" and briefly explain why.

PRs with visual demos typically get reviewed much faster!
-->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
