### PR TITLE
  fix(core): remove abort listener during cleanup

### DIFF
--- a/packages/core/src/hooks/combinedAbortSignal.test.ts
+++ b/packages/core/src/hooks/combinedAbortSignal.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { createCombinedAbortSignal } from './combinedAbortSignal.js';
 
 describe('createCombinedAbortSignal', () => {
@@ -57,6 +57,26 @@ describe('createCombinedAbortSignal', () => {
 
     // Wait longer than timeout - should not abort because timer was cleared
     await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(signal.aborted).toBe(false);
+  });
+
+  it('should remove external abort listener on cleanup', () => {
+    const externalController = new AbortController();
+    const removeListenerSpy = vi.spyOn(
+      externalController.signal,
+      'removeEventListener',
+    );
+    const { signal, cleanup } = createCombinedAbortSignal(
+      externalController.signal,
+    );
+
+    cleanup();
+    externalController.abort();
+
+    expect(removeListenerSpy).toHaveBeenCalledWith(
+      'abort',
+      expect.any(Function),
+    );
     expect(signal.aborted).toBe(false);
   });
 

--- a/packages/core/src/hooks/combinedAbortSignal.ts
+++ b/packages/core/src/hooks/combinedAbortSignal.ts
@@ -30,11 +30,12 @@ export function createCombinedAbortSignal(
   }
 
   // Listen to external signal
+  let abortHandler: (() => void) | undefined;
   if (externalSignal) {
     if (externalSignal.aborted) {
       controller.abort();
     } else {
-      const abortHandler = () => {
+      abortHandler = () => {
         controller.abort();
       };
       externalSignal.addEventListener('abort', abortHandler, { once: true });
@@ -45,6 +46,10 @@ export function createCombinedAbortSignal(
     if (timeoutId !== undefined) {
       clearTimeout(timeoutId);
       timeoutId = undefined;
+    }
+    if (externalSignal && abortHandler) {
+      externalSignal.removeEventListener('abort', abortHandler);
+      abortHandler = undefined;
     }
   };
 


### PR DESCRIPTION

## TLDR

  ### Problem

 Repeated calls to `createCombinedAbortSignal()` with the same external `AbortSignal` registered one `abort` listener per call. The existing cleanup only cleared the timeout, so the external signal listeners remained attached.

  After enough repeated calls, Node could emit:

  ```
  MaxListenersExceededWarning: Possible EventTarget memory leak detected. 11 abort listeners added to [AbortSignal]. MaxListeners is 10.
```

  #### Summary

  - Remove the external `AbortSignal` listener when `createCombinedAbortSignal()` cleanup is called.
  - Add regression coverage for listener cleanup behavior.


<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->

## Screenshots / Video Demo

<!--
Please attach a screenshot or short video showing your change in action.
This helps reviewers understand the change quickly and prioritize reviews.

- For bug fixes: show the before/after behavior.
- For features: show the new functionality in use.
- For refactors or internal changes with no visible effect: write "N/A — no user-facing change" and briefly explain why.

PRs with visual demos typically get reviewed much faster!
-->

## Dive Deeper

<!-- more thoughts and in-depth discussion here -->

## Reviewer Test Plan

<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | Pass  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!--
Link to any related issues or bugs.

**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**

- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

*Example: `Resolves #123`*

**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**

*Example: `This PR makes progress on #456` or `Related to #789`*
-->
