### PR TITLE
feat(cli): add OAuth configuration flags to `mcp add`

### DIFF
--- a/docs/developers/tools/mcp-server.md
+++ b/docs/developers/tools/mcp-server.md
@@ -158,16 +158,28 @@ When connecting to an OAuth-enabled server:
 
 #### Browser Redirect Requirements
 
-**Important:** OAuth authentication requires that your local machine can:
+**Important:** OAuth authentication requires that the redirect URI is accessible:
 
-- Open a web browser for authentication
-- Receive redirects on `http://localhost:7777/oauth/callback`
+- **Default behavior**: Redirects to `http://localhost:7777/oauth/callback` (works for local setups)
+- **Custom redirect URI**: Use `--oauth-redirect-uri` or configure `redirectUri` in settings.json to specify a different URL
 
-This feature will not work in:
+For **remote/cloud server deployments** (e.g., web terminals, SSH sessions, cloud IDEs):
+
+- The default `localhost` redirect will NOT work
+- You MUST configure a custom `redirectUri` pointing to a publicly accessible URL
+- The user's browser must be able to reach this URL and redirect back to the server
+
+Example for remote servers:
+
+```bash
+qwen mcp add --transport sse remote-server https://api.example.com/sse/ \
+  --oauth-redirect-uri https://your-remote-server.example.com/oauth/callback
+```
+
+OAuth will not work in:
 
 - Headless environments without browser access
-- Remote SSH sessions without X11 forwarding
-- Containerized environments without browser support
+- Environments where the configured `redirectUri` is unreachable from the user's browser
 
 #### Managing OAuth Authentication
 
@@ -192,7 +204,7 @@ Use the `/mcp auth` command to manage OAuth authentication:
 - **`authorizationUrl`** (string): OAuth authorization endpoint (auto-discovered if omitted)
 - **`tokenUrl`** (string): OAuth token endpoint (auto-discovered if omitted)
 - **`scopes`** (string[]): Required OAuth scopes
-- **`redirectUri`** (string): Custom redirect URI (defaults to `http://localhost:7777/oauth/callback`)
+- **`redirectUri`** (string): Custom redirect URI. **Critical for remote deployments**: Defaults to `http://localhost:7777/oauth/callback`. When running Qwen Code on remote/cloud servers, set this to a publicly accessible URL (e.g., `https://your-server.com/oauth/callback`). Can be configured via `qwen mcp add --oauth-redirect-uri` or directly in settings.json.
 - **`tokenParamName`** (string): Query parameter name for tokens in SSE URLs
 - **`audiences`** (string[]): Audiences the token is valid for
 
@@ -788,6 +800,12 @@ qwen mcp add [options] <name> <commandOrUrl> [args...]
 - `--description`: Set the description for the server.
 - `--include-tools`: A comma-separated list of tools to include.
 - `--exclude-tools`: A comma-separated list of tools to exclude.
+- `--oauth-client-id`: OAuth client ID for MCP server authentication.
+- `--oauth-client-secret`: OAuth client secret for MCP server authentication.
+- `--oauth-redirect-uri`: OAuth redirect URI (e.g., `https://your-server.com/oauth/callback`). Defaults to `http://localhost:7777/oauth/callback` for local setups. **Important for remote deployments**: When running Qwen Code on remote/cloud servers, set this to a publicly accessible URL.
+- `--oauth-authorization-url`: OAuth authorization URL.
+- `--oauth-token-url`: OAuth token URL.
+- `--oauth-scopes`: OAuth scopes (comma-separated).
 
 #### Adding an stdio server
 
@@ -832,6 +850,13 @@ qwen mcp add --transport sse sse-server https://api.example.com/sse/
 
 # Example: Adding an SSE server with an authentication header
 qwen mcp add --transport sse secure-sse https://api.example.com/sse/ --header "Authorization: Bearer abc123"
+
+# Example: Adding an OAuth-enabled SSE server
+qwen mcp add --transport sse oauth-server https://api.example.com/sse/ \
+  --oauth-client-id your-client-id \
+  --oauth-redirect-uri https://your-server.com/oauth/callback \
+  --oauth-authorization-url https://provider.example.com/authorize \
+  --oauth-token-url https://provider.example.com/token
 ```
 
 ### Managing Servers (`qwen mcp`)

--- a/docs/users/features/mcp.md
+++ b/docs/users/features/mcp.md
@@ -153,6 +153,84 @@ qwen mcp add --transport sse sseServer http://localhost:8080/sse --timeout 30000
 
 - **Server trust** (`trust: true`): bypasses confirmation prompts for that server (use sparingly).
 
+### OAuth authentication
+
+Qwen Code supports OAuth 2.0 authentication for MCP servers. This is useful when accessing remote servers that require authentication.
+
+#### Basic usage
+
+When you add an MCP server with OAuth credentials, Qwen Code will automatically handle the authentication flow:
+
+```bash
+qwen mcp add --transport sse oauth-server https://api.example.com/sse/ \
+  --oauth-client-id your-client-id \
+  --oauth-redirect-uri https://your-server.com/oauth/callback \
+  --oauth-authorization-url https://provider.example.com/authorize \
+  --oauth-token-url https://provider.example.com/token
+```
+
+#### Important: Redirect URI configuration
+
+The OAuth flow requires a redirect URI where the authorization provider sends the authentication code.
+
+- **Local development**: By default, Qwen Code uses `http://localhost:7777/oauth/callback`. This works when running Qwen Code on your local machine with a local browser.
+
+- **Remote/cloud deployments**: When running Qwen Code on remote servers, cloud IDEs, or web terminals, the default `localhost` redirect will NOT work. You MUST configure `--oauth-redirect-uri` to point to a publicly accessible URL that can receive the OAuth callback.
+
+Example for remote servers:
+
+```bash
+qwen mcp add --transport sse remote-server https://api.example.com/sse/ \
+  --oauth-redirect-uri https://your-remote-server.example.com/oauth/callback
+```
+
+#### Manual configuration via settings.json
+
+You can also configure OAuth by editing `settings.json` directly:
+
+```json
+{
+  "mcpServers": {
+    "oauthServer": {
+      "url": "https://api.example.com/sse/",
+      "oauth": {
+        "enabled": true,
+        "clientId": "your-client-id",
+        "clientSecret": "your-client-secret",
+        "authorizationUrl": "https://provider.example.com/authorize",
+        "tokenUrl": "https://provider.example.com/token",
+        "redirectUri": "https://your-server.com/oauth/callback",
+        "scopes": ["read", "write"]
+      }
+    }
+  }
+}
+```
+
+OAuth configuration properties:
+
+| Property           | Description                                                                                                           |
+| ------------------ | --------------------------------------------------------------------------------------------------------------------- |
+| `enabled`          | Enable OAuth for this server (boolean)                                                                                |
+| `clientId`         | OAuth client identifier (string, optional with dynamic registration)                                                  |
+| `clientSecret`     | OAuth client secret (string, optional for public clients)                                                             |
+| `authorizationUrl` | OAuth authorization endpoint (string, auto-discovered if omitted)                                                     |
+| `tokenUrl`         | OAuth token endpoint (string, auto-discovered if omitted)                                                             |
+| `scopes`           | Required OAuth scopes (array of strings)                                                                              |
+| `redirectUri`      | Custom redirect URI (string). **Critical for remote deployments**. Defaults to `http://localhost:7777/oauth/callback` |
+| `tokenParamName`   | Query parameter name for tokens in SSE URLs (string)                                                                  |
+| `audiences`        | Audiences the token is valid for (array of strings)                                                                   |
+
+#### Token management
+
+OAuth tokens are automatically:
+
+- **Stored securely** in `~/.qwen/mcp-oauth-tokens.json`
+- **Refreshed** when expired (if refresh tokens are available)
+- **Validated** before each connection attempt
+
+Use the `/mcp auth` command within Qwen Code to manage OAuth authentication interactively.
+
 ### Tool filtering (allow/deny tools per server)
 
 Use `includeTools` / `excludeTools` to restrict tools exposed by a server (from Qwen Code’s perspective).
@@ -259,20 +337,25 @@ You can always configure MCP servers by manually editing `settings.json`, but th
 qwen mcp add [options] <name> <commandOrUrl> [args...]
 ```
 
-| Argument/Option     | Description                                                         | Default            | Example                                   |
-| ------------------- | ------------------------------------------------------------------- | ------------------ | ----------------------------------------- |
-| `<name>`            | A unique name for the server.                                       | —                  | `example-server`                          |
-| `<commandOrUrl>`    | The command to execute (for `stdio`) or the URL (for `http`/`sse`). | —                  | `/usr/bin/python` or `http://localhost:8` |
-| `[args...]`         | Optional arguments for a `stdio` command.                           | —                  | `--port 5000`                             |
-| `-s`, `--scope`     | Configuration scope (user or project).                              | `project`          | `-s user`                                 |
-| `-t`, `--transport` | Transport type (`stdio`, `sse`, `http`).                            | `stdio`            | `-t sse`                                  |
-| `-e`, `--env`       | Set environment variables.                                          | —                  | `-e KEY=value`                            |
-| `-H`, `--header`    | Set HTTP headers for SSE and HTTP transports.                       | —                  | `-H "X-Api-Key: abc123"`                  |
-| `--timeout`         | Set connection timeout in milliseconds.                             | —                  | `--timeout 30000`                         |
-| `--trust`           | Trust the server (bypass all tool call confirmation prompts).       | — (`false`)        | `--trust`                                 |
-| `--description`     | Set the description for the server.                                 | —                  | `--description "Local tools"`             |
-| `--include-tools`   | A comma-separated list of tools to include.                         | all tools included | `--include-tools mytool,othertool`        |
-| `--exclude-tools`   | A comma-separated list of tools to exclude.                         | none               | `--exclude-tools mytool`                  |
+| Argument/Option             | Description                                                         | Default                                | Example                                                            |
+| --------------------------- | ------------------------------------------------------------------- | -------------------------------------- | ------------------------------------------------------------------ |
+| `<name>`                    | A unique name for the server.                                       | —                                      | `example-server`                                                   |
+| `<commandOrUrl>`            | The command to execute (for `stdio`) or the URL (for `http`/`sse`). | —                                      | `/usr/bin/python` or `http://localhost:8`                          |
+| `[args...]`                 | Optional arguments for a `stdio` command.                           | —                                      | `--port 5000`                                                      |
+| `-s`, `--scope`             | Configuration scope (user or project).                              | `project`                              | `-s user`                                                          |
+| `-t`, `--transport`         | Transport type (`stdio`, `sse`, `http`).                            | `stdio`                                | `-t sse`                                                           |
+| `-e`, `--env`               | Set environment variables.                                          | —                                      | `-e KEY=value`                                                     |
+| `-H`, `--header`            | Set HTTP headers for SSE and HTTP transports.                       | —                                      | `-H "X-Api-Key: abc123"`                                           |
+| `--timeout`                 | Set connection timeout in milliseconds.                             | —                                      | `--timeout 30000`                                                  |
+| `--trust`                   | Trust the server (bypass all tool call confirmation prompts).       | — (`false`)                            | `--trust`                                                          |
+| `--description`             | Set the description for the server.                                 | —                                      | `--description "Local tools"`                                      |
+| `--include-tools`           | A comma-separated list of tools to include.                         | all tools included                     | `--include-tools mytool,othertool`                                 |
+| `--exclude-tools`           | A comma-separated list of tools to exclude.                         | none                                   | `--exclude-tools mytool`                                           |
+| `--oauth-client-id`         | OAuth client ID for MCP server authentication.                      | —                                      | `--oauth-client-id your-client-id`                                 |
+| `--oauth-redirect-uri`      | OAuth redirect URI for authentication callback.                     | `http://localhost:7777/oauth/callback` | `--oauth-redirect-uri https://your-server.com/oauth/callback`      |
+| `--oauth-authorization-url` | OAuth authorization URL.                                            | —                                      | `--oauth-authorization-url https://provider.example.com/authorize` |
+| `--oauth-token-url`         | OAuth token URL.                                                    | —                                      | `--oauth-token-url https://provider.example.com/token`             |
+| `--oauth-scopes`            | OAuth scopes (comma-separated).                                     | —                                      | `--oauth-scopes scope1,scope2`                                     |
 
 #### Removing a server (`qwen mcp remove`)
 

--- a/docs/users/features/mcp.md
+++ b/docs/users/features/mcp.md
@@ -352,10 +352,13 @@ qwen mcp add [options] <name> <commandOrUrl> [args...]
 | `--include-tools`           | A comma-separated list of tools to include.                         | all tools included                     | `--include-tools mytool,othertool`                                 |
 | `--exclude-tools`           | A comma-separated list of tools to exclude.                         | none                                   | `--exclude-tools mytool`                                           |
 | `--oauth-client-id`         | OAuth client ID for MCP server authentication.                      | —                                      | `--oauth-client-id your-client-id`                                 |
+| `--oauth-client-secret`     | OAuth client secret for MCP server authentication.                  | —                                      | `--oauth-client-secret your-client-secret`                         |
 | `--oauth-redirect-uri`      | OAuth redirect URI for authentication callback.                     | `http://localhost:7777/oauth/callback` | `--oauth-redirect-uri https://your-server.com/oauth/callback`      |
 | `--oauth-authorization-url` | OAuth authorization URL.                                            | —                                      | `--oauth-authorization-url https://provider.example.com/authorize` |
 | `--oauth-token-url`         | OAuth token URL.                                                    | —                                      | `--oauth-token-url https://provider.example.com/token`             |
 | `--oauth-scopes`            | OAuth scopes (comma-separated).                                     | —                                      | `--oauth-scopes scope1,scope2`                                     |
+
+> `--oauth-*` flags apply only to `--transport sse` and `--transport http`. Combining them with `--transport stdio` is rejected.
 
 #### Removing a server (`qwen mcp remove`)
 

--- a/packages/cli/src/commands/mcp/add.test.ts
+++ b/packages/cli/src/commands/mcp/add.test.ts
@@ -5,8 +5,10 @@
  */
 
 import yargs from 'yargs';
+import type { Argv } from 'yargs';
 import { addCommand } from './add.js';
 import { loadSettings, SettingScope } from '../../config/settings.js';
+import type { Mock } from 'vitest';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockWriteStdoutLine = vi.hoisted(() => vi.fn());
@@ -45,11 +47,11 @@ vi.mock('../../config/settings.js', async () => {
   };
 });
 
-const mockedLoadSettings = loadSettings as vi.Mock;
+const mockedLoadSettings = loadSettings as Mock;
 
 describe('mcp add command', () => {
-  let parser: yargs.Argv;
-  let mockSetValue: vi.Mock;
+  let parser: Argv;
+  let mockSetValue: Mock;
 
   beforeEach(() => {
     vi.resetAllMocks();
@@ -443,7 +445,7 @@ describe('mcp add command', () => {
         .spyOn(process, 'exit')
         .mockImplementation((() => {
           throw new Error('process.exit called');
-        }) as (code?: number) => never);
+        }) as typeof process.exit);
 
       await expect(
         parser.parseAsync(

--- a/packages/cli/src/commands/mcp/add.test.ts
+++ b/packages/cli/src/commands/mcp/add.test.ts
@@ -437,5 +437,47 @@ describe('mcp add command', () => {
         }),
       );
     });
+
+    it('should reject OAuth options when transport is stdio', async () => {
+      const mockProcessExit = vi
+        .spyOn(process, 'exit')
+        .mockImplementation((() => {
+          throw new Error('process.exit called');
+        }) as (code?: number) => never);
+
+      await expect(
+        parser.parseAsync(
+          'add stdio-server /usr/bin/my-server --transport stdio ' +
+            '--oauth-client-id id',
+        ),
+      ).rejects.toThrow('process.exit called');
+
+      expect(mockWriteStderrLine).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'OAuth options (--oauth-*) are only supported with --transport sse or --transport http.',
+        ),
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+      expect(mockSetValue).not.toHaveBeenCalled();
+    });
+
+    it('should split comma-separated scopes and trim whitespace', async () => {
+      await parser.parseAsync(
+        'add oauth-server https://example.com/mcp --transport http ' +
+          '--oauth-scopes "read, write , admin"',
+      );
+
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'mcpServers',
+        expect.objectContaining({
+          'oauth-server': expect.objectContaining({
+            oauth: expect.objectContaining({
+              scopes: ['read', 'write', 'admin'],
+            }),
+          }),
+        }),
+      );
+    });
   });
 });

--- a/packages/cli/src/commands/mcp/add.test.ts
+++ b/packages/cli/src/commands/mcp/add.test.ts
@@ -368,4 +368,74 @@ describe('mcp add command', () => {
       );
     });
   });
+
+  describe('OAuth configuration', () => {
+    it('should add OAuth config when OAuth options are provided', async () => {
+      await parser.parseAsync(
+        'add oauth-server https://example.com/mcp --transport http ' +
+          '--oauth-client-id test-client-id ' +
+          '--oauth-client-secret test-client-secret ' +
+          '--oauth-redirect-uri https://example.com/oauth/callback ' +
+          '--oauth-authorization-url https://provider.example.com/authorize ' +
+          '--oauth-token-url https://provider.example.com/token ' +
+          '--oauth-scopes read,write',
+      );
+
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'mcpServers',
+        expect.objectContaining({
+          'oauth-server': expect.objectContaining({
+            httpUrl: 'https://example.com/mcp',
+            oauth: {
+              enabled: true,
+              clientId: 'test-client-id',
+              clientSecret: 'test-client-secret',
+              redirectUri: 'https://example.com/oauth/callback',
+              authorizationUrl: 'https://provider.example.com/authorize',
+              tokenUrl: 'https://provider.example.com/token',
+              scopes: ['read', 'write'],
+            },
+          }),
+        }),
+      );
+    });
+
+    it('should add OAuth config with only redirect URI', async () => {
+      await parser.parseAsync(
+        'add oauth-server https://example.com/mcp --transport sse ' +
+          '--oauth-redirect-uri https://example.com/oauth/callback',
+      );
+
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'mcpServers',
+        expect.objectContaining({
+          'oauth-server': expect.objectContaining({
+            url: 'https://example.com/mcp',
+            oauth: {
+              enabled: true,
+              redirectUri: 'https://example.com/oauth/callback',
+            },
+          }),
+        }),
+      );
+    });
+
+    it('should not include oauth field when no OAuth options are provided', async () => {
+      await parser.parseAsync(
+        'add my-server https://example.com/mcp --transport http',
+      );
+
+      expect(mockSetValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'mcpServers',
+        expect.objectContaining({
+          'my-server': expect.objectContaining({
+            httpUrl: 'https://example.com/mcp',
+          }),
+        }),
+      );
+    });
+  });
 });

--- a/packages/cli/src/commands/mcp/add.ts
+++ b/packages/cli/src/commands/mcp/add.ts
@@ -8,7 +8,10 @@
 import type { CommandModule } from 'yargs';
 import { loadSettings, SettingScope } from '../../config/settings.js';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
-import type { MCPServerConfig } from '@qwen-code/qwen-code-core';
+import type {
+  MCPServerConfig,
+  MCPOAuthConfig,
+} from '@qwen-code/qwen-code-core';
 
 async function addMcpServer(
   name: string,
@@ -24,6 +27,12 @@ async function addMcpServer(
     description?: string;
     includeTools?: string[];
     excludeTools?: string[];
+    oauthClientId?: string;
+    oauthClientSecret?: string;
+    oauthRedirectUri?: string;
+    oauthAuthorizationUrl?: string;
+    oauthTokenUrl?: string;
+    oauthScopes?: string[];
   },
 ) {
   const {
@@ -36,6 +45,12 @@ async function addMcpServer(
     description,
     includeTools,
     excludeTools,
+    oauthClientId,
+    oauthClientSecret,
+    oauthRedirectUri,
+    oauthAuthorizationUrl,
+    oauthTokenUrl,
+    oauthScopes,
   } = options;
 
   const settings = loadSettings(process.cwd());
@@ -52,6 +67,26 @@ async function addMcpServer(
     scope === 'user' ? SettingScope.User : SettingScope.Workspace;
 
   let newServer: Partial<MCPServerConfig> = {};
+
+  // Build OAuth config if any OAuth options are provided
+  const oauthConfig: MCPOAuthConfig = {};
+  if (oauthClientId) oauthConfig.clientId = oauthClientId;
+  if (oauthClientSecret) oauthConfig.clientSecret = oauthClientSecret;
+  if (oauthRedirectUri) oauthConfig.redirectUri = oauthRedirectUri;
+  if (oauthAuthorizationUrl)
+    oauthConfig.authorizationUrl = oauthAuthorizationUrl;
+  if (oauthTokenUrl) oauthConfig.tokenUrl = oauthTokenUrl;
+  if (oauthScopes && oauthScopes.length > 0) {
+    // Split comma-separated scopes
+    oauthConfig.scopes = oauthScopes
+      .flatMap((s) => s.split(','))
+      .filter(Boolean);
+  }
+
+  const hasOAuth = Object.keys(oauthConfig).length > 0;
+  if (hasOAuth) {
+    oauthConfig.enabled = true;
+  }
 
   const headers = header?.reduce(
     (acc, curr) => {
@@ -75,6 +110,7 @@ async function addMcpServer(
         description,
         includeTools,
         excludeTools,
+        oauth: hasOAuth ? oauthConfig : undefined,
       };
       break;
     case 'http':
@@ -86,6 +122,7 @@ async function addMcpServer(
         description,
         includeTools,
         excludeTools,
+        oauth: hasOAuth ? oauthConfig : undefined,
       };
       break;
     case 'stdio':
@@ -108,6 +145,7 @@ async function addMcpServer(
         description,
         includeTools,
         excludeTools,
+        oauth: hasOAuth ? oauthConfig : undefined,
       };
       break;
   }
@@ -207,6 +245,32 @@ export const addCommand: CommandModule = {
         type: 'array',
         string: true,
       })
+      .option('oauth-client-id', {
+        describe: 'OAuth client ID for MCP server authentication',
+        type: 'string',
+      })
+      .option('oauth-client-secret', {
+        describe: 'OAuth client secret for MCP server authentication',
+        type: 'string',
+      })
+      .option('oauth-redirect-uri', {
+        describe:
+          'OAuth redirect URI (e.g., https://your-server.com/oauth/callback). Defaults to localhost for local setups.',
+        type: 'string',
+      })
+      .option('oauth-authorization-url', {
+        describe: 'OAuth authorization URL',
+        type: 'string',
+      })
+      .option('oauth-token-url', {
+        describe: 'OAuth token URL',
+        type: 'string',
+      })
+      .option('oauth-scopes', {
+        describe: 'OAuth scopes (comma-separated)',
+        type: 'array',
+        string: true,
+      })
       .middleware((argv) => {
         // Handle -- separator args as server args if present
         if (argv['--']) {
@@ -243,6 +307,14 @@ export const addCommand: CommandModule = {
         description: argv['description'] as string | undefined,
         includeTools: argv['includeTools'] as string[] | undefined,
         excludeTools: argv['excludeTools'] as string[] | undefined,
+        oauthClientId: argv['oauthClientId'] as string | undefined,
+        oauthClientSecret: argv['oauthClientSecret'] as string | undefined,
+        oauthRedirectUri: argv['oauthRedirectUri'] as string | undefined,
+        oauthAuthorizationUrl: argv['oauthAuthorizationUrl'] as
+          | string
+          | undefined,
+        oauthTokenUrl: argv['oauthTokenUrl'] as string | undefined,
+        oauthScopes: argv['oauthScopes'] as string[] | undefined,
       },
     );
   },

--- a/packages/cli/src/commands/mcp/add.ts
+++ b/packages/cli/src/commands/mcp/add.ts
@@ -68,25 +68,42 @@ async function addMcpServer(
 
   let newServer: Partial<MCPServerConfig> = {};
 
-  // Build OAuth config if any OAuth options are provided
-  const oauthConfig: MCPOAuthConfig = {};
-  if (oauthClientId) oauthConfig.clientId = oauthClientId;
-  if (oauthClientSecret) oauthConfig.clientSecret = oauthClientSecret;
-  if (oauthRedirectUri) oauthConfig.redirectUri = oauthRedirectUri;
-  if (oauthAuthorizationUrl)
-    oauthConfig.authorizationUrl = oauthAuthorizationUrl;
-  if (oauthTokenUrl) oauthConfig.tokenUrl = oauthTokenUrl;
-  if (oauthScopes && oauthScopes.length > 0) {
-    // Split comma-separated scopes
-    oauthConfig.scopes = oauthScopes
-      .flatMap((s) => s.split(','))
-      .filter(Boolean);
+  const scopes = oauthScopes
+    ?.flatMap((s) => s.split(','))
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const hasOAuth = Boolean(
+    oauthClientId ||
+      oauthClientSecret ||
+      oauthRedirectUri ||
+      oauthAuthorizationUrl ||
+      oauthTokenUrl ||
+      (scopes && scopes.length > 0),
+  );
+
+  // OAuth only applies to remote HTTP/SSE transports. Reject mixing with stdio
+  // so users don't silently persist unused configuration.
+  if (hasOAuth && transport === 'stdio') {
+    writeStderrLine(
+      'Error: OAuth options (--oauth-*) are only supported with --transport sse or --transport http.',
+    );
+    process.exit(1);
   }
 
-  const hasOAuth = Object.keys(oauthConfig).length > 0;
-  if (hasOAuth) {
-    oauthConfig.enabled = true;
-  }
+  const oauthConfig: MCPOAuthConfig | undefined = hasOAuth
+    ? {
+        enabled: true,
+        ...(oauthClientId && { clientId: oauthClientId }),
+        ...(oauthClientSecret && { clientSecret: oauthClientSecret }),
+        ...(oauthRedirectUri && { redirectUri: oauthRedirectUri }),
+        ...(oauthAuthorizationUrl && {
+          authorizationUrl: oauthAuthorizationUrl,
+        }),
+        ...(oauthTokenUrl && { tokenUrl: oauthTokenUrl }),
+        ...(scopes && scopes.length > 0 && { scopes }),
+      }
+    : undefined;
 
   const headers = header?.reduce(
     (acc, curr) => {
@@ -110,7 +127,7 @@ async function addMcpServer(
         description,
         includeTools,
         excludeTools,
-        oauth: hasOAuth ? oauthConfig : undefined,
+        oauth: oauthConfig,
       };
       break;
     case 'http':
@@ -122,7 +139,7 @@ async function addMcpServer(
         description,
         includeTools,
         excludeTools,
-        oauth: hasOAuth ? oauthConfig : undefined,
+        oauth: oauthConfig,
       };
       break;
     case 'stdio':
@@ -145,7 +162,6 @@ async function addMcpServer(
         description,
         includeTools,
         excludeTools,
-        oauth: hasOAuth ? oauthConfig : undefined,
       };
       break;
   }


### PR DESCRIPTION
## Summary

Fixes #3336

Adds a full set of `--oauth-*` flags to `qwen mcp add` so users can configure OAuth 2.0 for remote MCP servers from the command line. The main motivator is `--oauth-redirect-uri`: the OAuth flow previously hardcoded `http://localhost:7777/oauth/callback`, which breaks for remote/cloud deployments (web terminals, SSH sessions, cloud IDEs) where the user's browser can't reach the server's localhost.

### Changes

- Add the following flags to `qwen mcp add` (applies to `--transport sse` and `--transport http`):
  - `--oauth-client-id`
  - `--oauth-client-secret`
  - `--oauth-redirect-uri`
  - `--oauth-authorization-url`
  - `--oauth-token-url`
  - `--oauth-scopes` (comma-separated, trimmed)
- Reject `--oauth-*` flags when `--transport stdio` is used, so unused config isn't silently persisted.
- Only emit an `oauth` block in settings when at least one OAuth flag is provided; omit it entirely otherwise.
- Document `auth.redirectUri` and the new CLI flags in both the developer (`docs/developers/tools/mcp-server.md`) and user-facing (`docs/users/features/mcp.md`) MCP docs, with guidance and examples for remote deployments.
- Add unit tests in `packages/cli/src/commands/mcp/add.test.ts` covering: full OAuth config, redirect-URI-only, no-OAuth, stdio rejection, and scope splitting/trimming.

### Example

```bash
qwen mcp add --transport sse remote-server https://api.example.com/sse/ \
  --oauth-client-id your-client-id \
  --oauth-redirect-uri https://your-server.com/oauth/callback \
  --oauth-authorization-url https://provider.example.com/authorize \
  --oauth-token-url https://provider.example.com/token
```

### Testing

- New and existing unit tests pass
- TypeScript compilation succeeds
- Build completes successfully