### PR TITLE
fix(openai): when samplingParams is set, pass it through verbatim

### DIFF
--- a/packages/core/src/core/contentGenerator.ts
+++ b/packages/core/src/core/contentGenerator.ts
@@ -92,6 +92,9 @@ export type ContentGeneratorConfig = {
     frequency_penalty?: number;
     temperature?: number;
     max_tokens?: number;
+    // Additional provider-specific keys pass through verbatim
+    // (e.g. `max_completion_tokens` for GPT-5 / o-series, `reasoning_effort`).
+    [key: string]: unknown;
   };
   reasoning?:
     | false

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -1475,6 +1475,80 @@ describe('ContentGenerationPipeline', () => {
         }),
       );
     });
+
+    it('should pass arbitrary samplingParams keys through verbatim (e.g. max_completion_tokens for GPT-5)', async () => {
+      // Arrange: user sets a GPT-5 / o-series shape in samplingParams.
+      // None of these are typed fields; all must appear on the wire because
+      // samplingParams is the source of truth.
+      mockContentGeneratorConfig.samplingParams = {
+        max_completion_tokens: 4096,
+        reasoning_effort: 'medium',
+        verbosity: 'low',
+      } as ContentGeneratorConfig['samplingParams'];
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
+        config: { maxOutputTokens: 999 },
+      };
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'test',
+        choices: [{ message: { content: 'r' } }],
+      });
+
+      // Act
+      await pipeline.execute(request, 'prompt-id');
+
+      // Assert: the exact samplingParams keys reach the wire; max_tokens is NOT
+      // synthesized from request.config.maxOutputTokens.
+      const call = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(call).toMatchObject({
+        max_completion_tokens: 4096,
+        reasoning_effort: 'medium',
+        verbosity: 'low',
+      });
+      expect(call).not.toHaveProperty('max_tokens');
+    });
+
+    it('should preserve historical default behavior when samplingParams is absent', async () => {
+      // Arrange: no samplingParams — request.config.maxOutputTokens must still
+      // fall through to max_tokens on the wire (original behavior unchanged).
+      mockContentGeneratorConfig.samplingParams = undefined;
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
+        config: { temperature: 0.5, topP: 0.6, maxOutputTokens: 2048 },
+      };
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'test',
+        choices: [{ message: { content: 'r' } }],
+      });
+
+      // Act
+      await pipeline.execute(request, 'prompt-id');
+
+      // Assert: identical to upstream behavior for existing users
+      expect(mockClient.chat.completions.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          temperature: 0.5,
+          top_p: 0.6,
+          max_tokens: 2048,
+        }),
+        expect.objectContaining({ signal: undefined }),
+      );
+    });
   });
 
   describe('createRequestContext', () => {

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -399,6 +399,14 @@ export class ContentGenerationPipeline {
       return value !== undefined ? { [key]: value } : {};
     };
 
+    // When samplingParams is set, its keys pass through to the wire verbatim.
+    // This lets users target provider-specific parameter names
+    // (e.g. `max_completion_tokens` for GPT-5 / o-series) without a client release.
+    // When absent, the historical default behavior applies.
+    if (configSamplingParams !== undefined) {
+      return { ...configSamplingParams };
+    }
+
     const params: Record<string, unknown> = {
       // Parameters with request fallback but no defaults
       ...addParameterIfDefined('temperature', 'temperature', 'temperature'),

--- a/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
@@ -306,6 +306,46 @@ describe('DefaultOpenAICompatibleProvider', () => {
       expect(result.max_tokens).toBe(8000); // GPT-4 has 16K limit, min(16K, 8K) = 8K
     });
 
+    it('should not inject max_tokens when samplingParams is set without it (e.g. GPT-5 / o-series)', () => {
+      // GPT-5 / o-series on Azure reject max_tokens entirely.
+      // When the user sets samplingParams without max_tokens, honor the opt-out.
+      const cfg = {
+        ...mockContentGeneratorConfig,
+        samplingParams: { max_completion_tokens: 4096 },
+      } as ContentGeneratorConfig;
+      const p = new DefaultOpenAICompatibleProvider(cfg, mockCliConfig);
+
+      const request: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'Hello' }],
+      };
+
+      const result = p.buildRequest(request, 'prompt-id');
+
+      expect(result.max_tokens).toBeUndefined();
+    });
+
+    it('should pass samplingParams.max_tokens through verbatim, bypassing the model cap', () => {
+      // When samplingParams is the source of truth, even max_tokens values that
+      // exceed the known model output limit pass through unchanged —
+      // no automatic capping.
+      const cfg = {
+        ...mockContentGeneratorConfig,
+        samplingParams: { max_tokens: 100000 },
+      } as ContentGeneratorConfig;
+      const p = new DefaultOpenAICompatibleProvider(cfg, mockCliConfig);
+
+      const request: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'gpt-4', // known model, 16K output limit — would normally cap.
+        messages: [{ role: 'user', content: 'Hello' }],
+        max_tokens: 100000,
+      };
+
+      const result = p.buildRequest(request, 'prompt-id');
+
+      expect(result.max_tokens).toBe(100000);
+    });
+
     it('should handle streaming requests', () => {
       const streamingRequest: OpenAI.Chat.ChatCompletionCreateParams = {
         model: 'gpt-4',

--- a/packages/core/src/core/openaiContentGenerator/provider/default.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.ts
@@ -121,6 +121,12 @@ export class DefaultOpenAICompatibleProvider
   protected applyOutputTokenLimit<
     T extends { max_tokens?: number | null; model: string },
   >(request: T): T {
+    // When samplingParams is set, it is the source of truth for the wire shape.
+    // Don't inject a max_tokens default — honor the user's explicit choice.
+    if (this.contentGeneratorConfig.samplingParams !== undefined) {
+      return request;
+    }
+
     const userMaxTokens = request.max_tokens;
 
     // Get model-specific output limit and check if model is known


### PR DESCRIPTION
## What's broken

**Azure GPT-5 / o-series deployments are unusable on the OpenAI-compatible code path**, because the client unconditionally injects `max_tokens` on the wire and these models reject it:

```
Unsupported parameter: 'max_tokens' is not supported with this model.
Use 'max_completion_tokens' instead.
```

No user config can opt out — `max_tokens` is added in two places even when `samplingParams` doesn't mention it:

1. `buildSamplingParameters` (pipeline.ts) — hardcoded via `addParameterIfDefined`.
2. `applyOutputTokenLimit` (provider/default.ts) — downstream default injecting `max_tokens: 8000` when absent.

## Why

Parameter names are a moving target (GPT-5 → `max_completion_tokens`, future reasoning knobs, provider-specific fields). Hardcoding per-model translation locks every new parameter behind a client release and misfires on custom deployment names, proxies, and Azure endpoints. Simpler primitive: let the user own the wire shape.

## The fix

Make `samplingParams` an opt-in, verbatim passthrough:

- `samplingParams` **set** (even to `{}`) → wire carries exactly those keys. Both injection sites early-return.
- `samplingParams` **absent** → existing behavior preserved byte-for-byte.

Also adds `[key: string]: unknown` to the `samplingParams` type so users can pass arbitrary provider-specific keys (`max_completion_tokens`, `reasoning_effort`, `verbosity`, …) without waiting for a client release.

## Test plan

- `pipeline.test.ts` — arbitrary-keys passthrough, no-cap passthrough, original behavior preserved when `samplingParams` absent.
- `provider/default.test.ts` — `applyOutputTokenLimit` skips injection; a user-supplied `max_tokens` passes through verbatim even when it exceeds the known model cap.

All existing tests pass.

## Example

Azure GPT-5 deployment (no longer accepts `max_tokens`, `temperature`, or `top_p`):

```json
{
  "modelProviders": {
    "openai": [{
      "id": "gpt-5",
      "baseUrl": "https://<your-azure>.cognitiveservices.azure.com/openai/v1/",
      "generationConfig": {
        "samplingParams": { "max_completion_tokens": 4096 }
      }
    }]
  }
}
```

Wire request carries exactly `max_completion_tokens: 4096`. `samplingParams: {}` also works — passthrough engaged, nothing sent, deployment defaults apply.
