### PR TITLE
feat(webui): render markdown in generic and web-fetch tool outputs

### DIFF
--- a/packages/webui/src/components/toolcalls/GenericToolCall.tsx
+++ b/packages/webui/src/components/toolcalls/GenericToolCall.tsx
@@ -29,14 +29,14 @@ const CollapsibleOutput: FC<{ content: string }> = ({ content }) => {
   return (
     <div className="flex flex-col gap-[3px]">
       <div
-        className={`text-[13px] opacity-90 overflow-hidden ${
-          !isExpanded && isLongContent
-            ? `[mask-image:linear-gradient(to_bottom,var(--app-primary-background)_140px,transparent_${COLLAPSED_HEIGHT}px)]`
-            : ''
-        }`}
+        className="text-[13px] opacity-90 overflow-hidden"
         style={
           !isExpanded && isLongContent
-            ? { maxHeight: `${COLLAPSED_HEIGHT}px` }
+            ? {
+                maxHeight: `${COLLAPSED_HEIGHT}px`,
+                maskImage: `linear-gradient(to bottom, var(--app-primary-background) 140px, transparent ${COLLAPSED_HEIGHT}px)`,
+                WebkitMaskImage: `linear-gradient(to bottom, var(--app-primary-background) 140px, transparent ${COLLAPSED_HEIGHT}px)`,
+              }
             : undefined
         }
       >

--- a/packages/webui/src/components/toolcalls/GenericToolCall.tsx
+++ b/packages/webui/src/components/toolcalls/GenericToolCall.tsx
@@ -40,7 +40,7 @@ const CollapsibleOutput: FC<{ content: string }> = ({ content }) => {
             : undefined
         }
       >
-        <MarkdownRenderer content={content} />
+        <MarkdownRenderer content={content} enableFileLinks={false} />
       </div>
       {isLongContent && (
         <div className="flex justify-center border-t border-[var(--app-input-border)] pt-1">

--- a/packages/webui/src/components/toolcalls/GenericToolCall.tsx
+++ b/packages/webui/src/components/toolcalls/GenericToolCall.tsx
@@ -6,7 +6,7 @@
  * Generic tool call component - handles all tool call types as fallback
  */
 
-import type { FC } from 'react';
+import { useState, type FC } from 'react';
 import {
   ToolCallContainer,
   ToolCallCard,
@@ -17,6 +17,45 @@ import {
 } from './shared/index.js';
 import type { BaseToolCallProps } from './shared/index.js';
 import { getToolDisplayLabel } from './labelUtils.js';
+import { MarkdownRenderer } from '../messages/MarkdownRenderer/MarkdownRenderer.js';
+
+const COLLAPSED_HEIGHT = 200;
+const EXPAND_THRESHOLD = 400;
+
+const CollapsibleOutput: FC<{ content: string }> = ({ content }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const isLongContent = content.length > EXPAND_THRESHOLD;
+
+  return (
+    <div className="flex flex-col gap-[3px]">
+      <div
+        className={`text-[13px] opacity-90 overflow-hidden ${
+          !isExpanded && isLongContent
+            ? `[mask-image:linear-gradient(to_bottom,var(--app-primary-background)_140px,transparent_${COLLAPSED_HEIGHT}px)]`
+            : ''
+        }`}
+        style={
+          !isExpanded && isLongContent
+            ? { maxHeight: `${COLLAPSED_HEIGHT}px` }
+            : undefined
+        }
+      >
+        <MarkdownRenderer content={content} />
+      </div>
+      {isLongContent && (
+        <div className="flex justify-center border-t border-[var(--app-input-border)] pt-1">
+          <button
+            type="button"
+            onClick={() => setIsExpanded(!isExpanded)}
+            className="text-[var(--app-secondary-foreground)] text-[0.8em] hover:text-[var(--app-primary-foreground)] cursor-pointer bg-transparent border-none px-2 py-1 rounded hover:bg-[var(--app-input-background)] transition-colors"
+          >
+            {isExpanded ? '▲ Collapse' : '▼ Show more'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
 
 /**
  * Generic tool call component that can display any tool call type
@@ -55,18 +94,13 @@ export const GenericToolCall: FC<BaseToolCallProps> = ({
     const isLong = output.length > 150;
 
     if (isLong) {
-      const truncatedOutput =
-        output.length > 300 ? output.substring(0, 300) + '...' : output;
-
       return (
         <ToolCallCard icon="🔧">
           <ToolCallRow label={displayLabel}>
             <div>{operationText}</div>
           </ToolCallRow>
           <ToolCallRow label="Output">
-            <div className="whitespace-pre-wrap font-mono text-[13px] opacity-90">
-              {truncatedOutput}
-            </div>
+            <CollapsibleOutput content={output} />
           </ToolCallRow>
         </ToolCallCard>
       );

--- a/packages/webui/src/components/toolcalls/WebFetchToolCall.tsx
+++ b/packages/webui/src/components/toolcalls/WebFetchToolCall.tsx
@@ -16,6 +16,7 @@ import {
 } from './shared/index.js';
 import type { BaseToolCallProps } from './shared/index.js';
 import { getToolDisplayLabel } from './labelUtils.js';
+import { MarkdownRenderer } from '../messages/MarkdownRenderer/MarkdownRenderer.js';
 
 type WebVariant = 'fetch' | 'search';
 
@@ -70,7 +71,9 @@ const OutputCard: FC<{
             OUT
           </div>
           <div
-            className={`whitespace-pre-wrap break-words m-0 p-1 overflow-hidden ${
+            className={`break-words m-0 p-1 overflow-hidden ${
+              isError ? 'whitespace-pre-wrap' : ''
+            } ${
               !isExpanded && isLongContent
                 ? `max-h-[${COLLAPSED_HEIGHT}px] [mask-image:linear-gradient(to_bottom,var(--app-primary-background)_80px,transparent_${COLLAPSED_HEIGHT}px)]`
                 : ''
@@ -81,13 +84,15 @@ const OutputCard: FC<{
                 : undefined
             }
           >
-            <pre
-              className={`m-0 overflow-hidden font-mono text-[0.85em] ${
-                isError ? 'text-[#c74e39]' : ''
-              }`}
-            >
-              {content}
-            </pre>
+            {isError ? (
+              <pre className="m-0 overflow-hidden font-mono text-[0.85em] text-[#c74e39]">
+                {content}
+              </pre>
+            ) : (
+              <div className="text-[0.85em]">
+                <MarkdownRenderer content={content} />
+              </div>
+            )}
           </div>
         </div>
 

--- a/packages/webui/src/components/toolcalls/WebFetchToolCall.tsx
+++ b/packages/webui/src/components/toolcalls/WebFetchToolCall.tsx
@@ -73,14 +73,14 @@ const OutputCard: FC<{
           <div
             className={`break-words m-0 p-1 overflow-hidden ${
               isError ? 'whitespace-pre-wrap' : ''
-            } ${
-              !isExpanded && isLongContent
-                ? `max-h-[${COLLAPSED_HEIGHT}px] [mask-image:linear-gradient(to_bottom,var(--app-primary-background)_80px,transparent_${COLLAPSED_HEIGHT}px)]`
-                : ''
             }`}
             style={
               !isExpanded && isLongContent
-                ? { maxHeight: `${COLLAPSED_HEIGHT}px` }
+                ? {
+                    maxHeight: `${COLLAPSED_HEIGHT}px`,
+                    maskImage: `linear-gradient(to bottom, var(--app-primary-background) 80px, transparent ${COLLAPSED_HEIGHT}px)`,
+                    WebkitMaskImage: `linear-gradient(to bottom, var(--app-primary-background) 80px, transparent ${COLLAPSED_HEIGHT}px)`,
+                  }
                 : undefined
             }
           >
@@ -90,7 +90,7 @@ const OutputCard: FC<{
               </pre>
             ) : (
               <div className="text-[0.85em]">
-                <MarkdownRenderer content={content} />
+                <MarkdownRenderer content={content} enableFileLinks={false} />
               </div>
             )}
           </div>


### PR DESCRIPTION
## TLDR

Agent and generic tool call outputs are now rendered as markdown in both the live webui and `/export html` output. Previously these were wrapped in raw `<pre>` blocks, so markdown-formatted content (code blocks, bullet lists, bold, headings) appeared as literal characters — especially noticeable for Agent/subagent responses and web-fetch results. Long `GenericToolCall` output also gets a collapse/expand affordance to keep long outputs readable in the chat timeline.

## Screenshots / Video Demo

<!-- attach before/after screenshots here -->

- **Before**: Agent text response rendered as raw markdown characters (` ``` `, `**`, `#`) inside a monospace `<pre>`.

<img width="1710" height="879" alt="image" src="https://github.com/user-attachments/assets/40da1f89-ecbf-4f79-b261-45bfb0aa041b" />

<img width="1710" height="879" alt="image" src="https://github.com/user-attachments/assets/83ffa9c1-b6b1-4e5e-8aef-60e56e876fdc" />


- **After**: Same text rendered with styled headings, inline code, bullet lists, etc.

<img width="1710" height="879" alt="image" src="https://github.com/user-attachments/assets/6b8fbcc2-32a8-41f3-aa6e-98e74dd28dac" />

<img width="1710" height="879" alt="image" src="https://github.com/user-attachments/assets/26dde37b-0dd9-42bd-96f9-0b3d618d3997" />

## Dive Deeper

**Routing note**: `ExportMessage.toolCall` intentionally omits `rawOutput` (see `packages/cli/src/ui/utils/export/types.ts`). Because `isAgentExecutionToolCall` keys off `rawOutput.type === 'task_execution'`, Agent tool calls in HTML exports fall through to `GenericToolCall`. That means fixing markdown rendering in `GenericToolCall` is what actually resolves the Agent-output case in the exported HTML; `AgentToolCall` itself never displays the textual response (only status/progress).

**Scope**:
- `GenericToolCall` — long-output ("card") path replaces `<div class="whitespace-pre-wrap font-mono">` with `<MarkdownRenderer>`. Removed the old 300-char mid-content truncation (it broke markdown blocks and the new collapse handles length); wrapped the renderer in a collapsible container with `max-h: 200px` + `mask-image` fade and a `▼ Show more` / `▲ Collapse` button when output exceeds 400 chars. Short output (<150 chars) stays as plain inline text — no behavior change.
- `WebFetchToolCall` — the `OUT` card renders markdown via `MarkdownRenderer` for successful output; error text stays in a monospace `<pre>` so stack traces / raw diagnostics don't get mangled. Existing expand/collapse behavior preserved.

**What I deliberately did not touch**:
- `AgentToolCall` (structured status card — no textual response to render).
- Short-output paths in `GenericToolCall` — inline text in `ToolCallContainer` would produce block-level markdown in a single-line context.
- Export pipeline (`collect.ts` / `normalize.ts` / `html.ts`) — the data shape is fine; the bug was purely in how webui renders the tool-call content.

## Reviewer Test Plan

1. `npm install && npm run build`
2. `npm start`, have a session that uses the Task/Agent tool with a response containing markdown (code fences, headings, lists).
3. In the CLI, run `/export html` — the exported file renders under unpkg-hosted webui, so after this is merged and `@qwen-code/webui@latest` is published, the fix applies to fresh exports.
4. For local pre-merge verification without waiting on an npm publish:
   - Build webui locally (`npm run build --workspace=packages/webui`)
   - Temporarily swap the unpkg `<script>` / `<link>` tags in an exported HTML file to point at the local `packages/webui/dist/index.umd.js` + `styles.css`, then open in a browser.
5. Live webui verification:
   - Open the VS Code companion, trigger an Agent call with markdown-rich output — the output block should render as formatted markdown instead of raw characters.
   - Trigger a WebFetch call returning markdown content — rendered inside the `OUT` card.
   - Confirm the collapse button appears only when the generic output exceeds the threshold, and toggles correctly.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Closes #2520
