### PR TITLE
feat(vscode): add native context menu copy actions for webview chat

### DIFF
--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -125,6 +125,18 @@
       {
         "command": "qwen-code.showLogs",
         "title": "Qwen Code: Show Logs"
+      },
+      {
+        "command": "qwen-code.copyMessage",
+        "title": "%qwen-code.copyMessage.title%"
+      },
+      {
+        "command": "qwen-code.copyAllMessages",
+        "title": "%qwen-code.copyAllMessages.title%"
+      },
+      {
+        "command": "qwen-code.copyLastReply",
+        "title": "%qwen-code.copyLastReply.title%"
       }
     ],
     "menus": {
@@ -140,6 +152,35 @@
         {
           "command": "qwen-code.login",
           "when": "false"
+        },
+        {
+          "command": "qwen-code.copyMessage",
+          "when": "false"
+        },
+        {
+          "command": "qwen-code.copyAllMessages",
+          "when": "false"
+        },
+        {
+          "command": "qwen-code.copyLastReply",
+          "when": "false"
+        }
+      ],
+      "webview/context": [
+        {
+          "command": "qwen-code.copyMessage",
+          "when": "webviewSection == 'chat-messages'",
+          "group": "9_cutcopypaste@1"
+        },
+        {
+          "command": "qwen-code.copyAllMessages",
+          "when": "webviewSection == 'chat-messages'",
+          "group": "9_cutcopypaste@2"
+        },
+        {
+          "command": "qwen-code.copyLastReply",
+          "when": "webviewSection == 'chat-messages'",
+          "group": "9_cutcopypaste@3"
         }
       ],
       "editor/title": [

--- a/packages/vscode-ide-companion/package.nls.json
+++ b/packages/vscode-ide-companion/package.nls.json
@@ -1,0 +1,5 @@
+{
+  "qwen-code.copyMessage.title": "Copy Message",
+  "qwen-code.copyAllMessages.title": "Copy All Messages",
+  "qwen-code.copyLastReply.title": "Copy Last Reply"
+}

--- a/packages/vscode-ide-companion/package.nls.zh-cn.json
+++ b/packages/vscode-ide-companion/package.nls.zh-cn.json
@@ -1,0 +1,5 @@
+{
+  "qwen-code.copyMessage.title": "复制消息",
+  "qwen-code.copyAllMessages.title": "复制全部消息",
+  "qwen-code.copyLastReply.title": "复制最后回复"
+}

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -213,6 +213,26 @@ export async function activate(context: vscode.ExtensionContext) {
     supportsSecondarySidebar,
   );
 
+  // Register copy commands for webview context menu
+  // Only send to the first provider with an active webview (the one the user right-clicked)
+  const sendCopyToActive = (action: string) => {
+    for (const provider of chatProviderRegistry?.getPermissionAwareProviders() ??
+      []) {
+      if (provider.sendCopyCommand(action)) break;
+    }
+  };
+  context.subscriptions.push(
+    vscode.commands.registerCommand('qwen-code.copyMessage', () =>
+      sendCopyToActive('copyMessage'),
+    ),
+    vscode.commands.registerCommand('qwen-code.copyAllMessages', () =>
+      sendCopyToActive('copyAllMessages'),
+    ),
+    vscode.commands.registerCommand('qwen-code.copyLastReply', () =>
+      sendCopyToActive('copyLastReply'),
+    ),
+  );
+
   context.subscriptions.push(
     vscode.workspace.onDidCloseTextDocument((doc) => {
       if (doc.uri.scheme === DIFF_SCHEME) {

--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -812,6 +812,144 @@ export const App: React.FC = () => {
 
   console.log('[App] Rendering messages:', allMessages);
 
+  // Format a tool call's content for clipboard copy
+  const formatToolCallForCopy = useCallback((tc: ToolCallData): string => {
+    const parts: string[] = [];
+    if (tc.content) {
+      for (const c of tc.content) {
+        if (c.type === 'content' && c.content?.text) {
+          parts.push(c.content.text);
+        } else if (c.type === 'diff') {
+          const filePath = c.path || '';
+          if (c.oldText) {
+            // Edit: unified diff format
+            const oldLines = c.oldText
+              .split('\n')
+              .map((l) => `-${l}`)
+              .join('\n');
+            const newLines = (c.newText || '')
+              .split('\n')
+              .map((l) => `+${l}`)
+              .join('\n');
+            parts.push(
+              `\`\`\`diff\n--- ${filePath}\n+++ ${filePath}\n${oldLines}\n${newLines}\n\`\`\``,
+            );
+          } else {
+            // Write: show new content in code block
+            parts.push(`${filePath}:\n\`\`\`\n${c.newText || ''}\n\`\`\``);
+          }
+        }
+      }
+    }
+    return parts.join('\n\n');
+  }, []);
+
+  // Track the right-click target so we can identify which message was clicked
+  const contextMenuTargetRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    const trackTarget = (e: MouseEvent) => {
+      contextMenuTargetRef.current = e.target as HTMLElement;
+    };
+    document.addEventListener('contextmenu', trackTarget, true);
+    return () => document.removeEventListener('contextmenu', trackTarget, true);
+  }, []);
+
+  // Stamp data-msg-idx on each rendered message element after render.
+  // renderMessages() returns exactly allMessages.length elements as the first N children of the container.
+  useLayoutEffect(() => {
+    const container = messagesContainerRef.current;
+    if (!container) return;
+    const children = container.children;
+    const count = Math.min(children.length, allMessages.length);
+    for (let i = 0; i < count; i++) {
+      (children[i] as HTMLElement).setAttribute('data-msg-idx', String(i));
+    }
+  }, [allMessages]);
+
+  // Copy text via the extension host's clipboard API (more reliable than navigator.clipboard in webview)
+  const copyToClipboard = useCallback(
+    (text: string) => {
+      vscode.postMessage({ type: 'copyToClipboard', data: { text } });
+    },
+    [vscode],
+  );
+
+  // Handle copy commands from VSCode native context menu
+  useEffect(() => {
+    const handler = (event: MessageEvent) => {
+      const message = event.data;
+      if (message?.type !== 'copyCommand') return;
+
+      const { action } = message.data as { action: string };
+
+      if (action === 'copyMessage') {
+        const target = contextMenuTargetRef.current;
+        if (target) {
+          const msgEl = target.closest('[data-msg-idx]') as HTMLElement | null;
+          if (msgEl) {
+            const idx = parseInt(
+              msgEl.getAttribute('data-msg-idx') || '-1',
+              10,
+            );
+            if (idx >= 0 && idx < allMessages.length) {
+              const item = allMessages[idx];
+              if (item.type === 'message') {
+                const msg = item.data as TextMessage;
+                copyToClipboard(msg.content || '');
+              } else if (
+                item.type === 'completed-tool-call' ||
+                item.type === 'in-progress-tool-call'
+              ) {
+                copyToClipboard(
+                  formatToolCallForCopy(item.data as ToolCallData),
+                );
+              }
+            }
+          }
+        }
+      } else if (action === 'copyAllMessages') {
+        const parts: string[] = [];
+        for (const item of allMessages) {
+          if (item.type === 'message') {
+            const msg = item.data as TextMessage;
+            if (msg.role === 'user') {
+              parts.push(`**User:** ${msg.content || ''}`);
+            } else if (msg.role === 'thinking') {
+              parts.push(`**Thinking:** ${msg.content || ''}`);
+            } else {
+              parts.push(`**Qwen Code:** ${msg.content || ''}`);
+            }
+          } else if (
+            item.type === 'completed-tool-call' ||
+            item.type === 'in-progress-tool-call'
+          ) {
+            const text = formatToolCallForCopy(item.data as ToolCallData);
+            if (text) {
+              parts.push(
+                `**[Tool: ${(item.data as ToolCallData).kind}]**\n\n${text}`,
+              );
+            }
+          }
+        }
+        copyToClipboard(parts.join('\n\n---\n\n'));
+      } else if (action === 'copyLastReply') {
+        for (let i = allMessages.length - 1; i >= 0; i--) {
+          const item = allMessages[i];
+          if (item.type === 'message') {
+            const msg = item.data as TextMessage;
+            if (msg.role === 'assistant') {
+              copyToClipboard(msg.content || '');
+              return;
+            }
+          }
+        }
+      }
+    };
+
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, [allMessages, copyToClipboard, formatToolCallForCopy]);
+
   // Render all messages and tool calls
   const renderMessages = useCallback<() => React.ReactNode>(() => {
     let imageIndex = 0;
@@ -943,6 +1081,9 @@ export const App: React.FC = () => {
       <div
         ref={messagesContainerRef}
         className="chat-messages messages-container flex-1 overflow-y-auto overflow-x-hidden pt-5 pr-5 pl-5 pb-[140px] flex flex-col relative min-w-0 focus:outline-none [&::-webkit-scrollbar]:w-2 [&::-webkit-scrollbar-track]:bg-transparent [&::-webkit-scrollbar-thumb]:bg-white/20 [&::-webkit-scrollbar-thumb]:rounded-sm [&::-webkit-scrollbar-thumb]:hover:bg-white/30 [&>*]:flex [&>*]:gap-0 [&>*]:items-start [&>*]:text-left [&>*]:py-2 [&>*:not(:last-child)]:pb-[8px] [&>*]:flex-col [&>*]:relative [&>*]:animate-[fadeIn_0.2s_ease-in]"
+        data-vscode-context={
+          hasContent ? '{"webviewSection": "chat-messages"}' : undefined
+        }
       >
         {!hasContent && !isLoading ? (
           isAuthenticated === false ? (

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
@@ -498,6 +498,11 @@ export class WebViewProvider {
           this.handleWebviewReady();
           return;
         }
+        if (message.type === 'copyToClipboard') {
+          const { text } = message.data as { text: string };
+          await vscode.env.clipboard.writeText(text);
+          return;
+        }
         if (message.type === 'resolveImagePaths') {
           this.handleResolveImagePaths(message.data, webview);
           return;
@@ -655,6 +660,11 @@ export class WebViewProvider {
         }
         if (message.type === 'webviewReady') {
           this.handleWebviewReady();
+          return;
+        }
+        if (message.type === 'copyToClipboard') {
+          const { text } = message.data as { text: string };
+          await vscode.env.clipboard.writeText(text);
           return;
         }
         if (message.type === 'resolveImagePaths') {
@@ -1309,6 +1319,17 @@ export class WebViewProvider {
   }
 
   /**
+   * Send a copy command to the webview (triggered by native context menu).
+   * The webview resolves the content and posts back a 'copyToClipboard' message.
+   */
+  sendCopyCommand(action: string): boolean {
+    const webview = this.getActiveWebview();
+    if (!webview) return false;
+    webview.postMessage({ type: 'copyCommand', data: { action } });
+    return true;
+  }
+
+  /**
    * Send message to WebView
    */
   private sendMessageToWebView(message: unknown): void {
@@ -1492,6 +1513,11 @@ export class WebViewProvider {
         }
         if (message.type === 'webviewReady') {
           this.handleWebviewReady();
+          return;
+        }
+        if (message.type === 'copyToClipboard') {
+          const { text } = message.data as { text: string };
+          await vscode.env.clipboard.writeText(text);
           return;
         }
         if (message.type === 'resolveImagePaths') {


### PR DESCRIPTION
## TLDR

Add three right-click context menu items to the chat message area using VSCode's native webview/context API:
- **Copy Message**: copies the right-clicked message's raw markdown content
- **Copy All Messages**: copies the full conversation in markdown format
- **Copy Last Reply**: copies the last assistant response

This improves usability by allowing users to quickly copy specific messages without manual text selection.

## Screenshots / Video Demo

<!--
Please attach a screenshot or short video showing your change in action.
This helps reviewers understand the change quickly and prioritize reviews.

- For bug fixes: show the before/after behavior.
- For features: show the new functionality in use.
- For refactors or internal changes with no visible effect: write "N/A — no user-facing change" and briefly explain why.

PRs with visual demos typically get reviewed much faster!
-->

## Dive Deeper

### Implementation details:
- Commands registered in `package.json` with `webview/context` menu entries
- Clipboard writes go through extension host (`vscode.env.clipboard`) for reliability in webview sandbox
- Message identification via `data-msg-idx` stamped after render
- Tool-call outputs supported including diff format (git diff style)
- i18n support via `package.nls.json` (English) and `package.nls.zh-cn.json`
- Menu only shown in message area (not input box or empty state)

## Reviewer Test Plan

1. Open the VSCode extension with the webview chat
2. Send a message and wait for a response
3. Right-click on any message in the chat area
4. Verify the three context menu items appear: "Copy Message", "Copy All Messages", "Copy Last Reply"
5. Test each option:
   - **Copy Message**: Should copy only the clicked message's content
   - **Copy All Messages**: Should copy the entire conversation in markdown format
   - **Copy Last Reply**: Should copy only the last assistant response
6. Paste into a text editor to verify the copied content
7. Test with tool-call outputs (including diff format) to ensure they are properly included

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Resolves #3052

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)
