### PR TITLE
fix(cli): inject plan/subagent/arena system reminders in ACP (#1151)

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -1066,5 +1066,107 @@ describe('Session', () => {
         });
       });
     });
+
+    describe('system reminders', () => {
+      // Captures the `message` parts fed into chat.sendMessageStream on the
+      // first turn so individual tests can assert what the model saw.
+      const captureFirstTurnMessage = () => {
+        const capture: { parts: Array<{ text?: string }> } = { parts: [] };
+        (mockChat.sendMessageStream as ReturnType<typeof vi.fn>) = vi
+          .fn()
+          .mockImplementation(async (_model, req) => {
+            capture.parts = req.message ?? [];
+            return createEmptyStream();
+          });
+        return capture;
+      };
+
+      const stubEmptySubagents = () => {
+        (mockConfig as unknown as Record<string, unknown>)[
+          'getSubagentManager'
+        ] = vi.fn().mockReturnValue({
+          listSubagents: vi.fn().mockResolvedValue([]),
+        });
+        // ensureTool is called on the result of getToolRegistry(); add it.
+        (
+          mockToolRegistry as unknown as { ensureTool: () => Promise<boolean> }
+        ).ensureTool = vi.fn().mockResolvedValue(true);
+      };
+
+      it('prepends plan-mode reminder when approval mode is PLAN (#1151)', async () => {
+        stubEmptySubagents();
+        mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.PLAN);
+        const capture = captureFirstTurnMessage();
+
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text', text: 'research this' }],
+        });
+
+        const reminderPart = capture.parts.find(
+          (p) => p.text && p.text.includes('Plan mode is active'),
+        );
+        expect(reminderPart).toBeTruthy();
+        expect(reminderPart!.text).toContain('exit_plan_mode');
+        // Reminder comes before the user text, matching client.ts ordering.
+        const reminderIdx = capture.parts.indexOf(reminderPart!);
+        const userIdx = capture.parts.findIndex(
+          (p) => p.text === 'research this',
+        );
+        expect(reminderIdx).toBeLessThan(userIdx);
+      });
+
+      it('does not prepend plan-mode reminder in default approval mode', async () => {
+        stubEmptySubagents();
+        mockConfig.getApprovalMode = vi
+          .fn()
+          .mockReturnValue(ApprovalMode.DEFAULT);
+        const capture = captureFirstTurnMessage();
+
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text', text: 'hi' }],
+        });
+
+        const hasPlanReminder = capture.parts.some(
+          (p) => p.text && p.text.includes('Plan mode is active'),
+        );
+        expect(hasPlanReminder).toBe(false);
+      });
+
+      it('prepends subagent reminder when user-level subagents exist', async () => {
+        (mockConfig as unknown as Record<string, unknown>)[
+          'getSubagentManager'
+        ] = vi.fn().mockReturnValue({
+          listSubagents: vi.fn().mockResolvedValue([
+            { name: 'researcher', level: 'user' },
+            { name: 'planner', level: 'project' },
+            // builtin entries are filtered out, matching client.ts:853.
+            { name: 'builtin-helper', level: 'builtin' },
+          ]),
+        });
+        (
+          mockToolRegistry as unknown as { ensureTool: () => Promise<boolean> }
+        ).ensureTool = vi.fn().mockResolvedValue(true);
+        mockConfig.getApprovalMode = vi
+          .fn()
+          .mockReturnValue(ApprovalMode.DEFAULT);
+        const capture = captureFirstTurnMessage();
+
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text', text: 'hi' }],
+        });
+
+        const reminder = capture.parts.find(
+          (p) =>
+            p.text &&
+            p.text.includes('researcher') &&
+            p.text.includes('planner'),
+        );
+        expect(reminder).toBeTruthy();
+        expect(reminder!.text).not.toContain('builtin-helper');
+      });
+    });
   });
 });

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -149,9 +149,7 @@ describe('Session', () => {
     mockConfig = undefined as unknown as Config;
     mockClient = undefined as unknown as AgentSideConnection;
     mockSettings = undefined as unknown as LoadedSettings;
-    mockToolRegistry = undefined as unknown as {
-      getTool: ReturnType<typeof vi.fn>;
-    };
+    mockToolRegistry = undefined as unknown as typeof mockToolRegistry;
     vi.restoreAllMocks();
     vi.clearAllTimers();
   });

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -56,7 +56,10 @@ describe('Session', () => {
   let currentAuthType: AuthType;
   let switchModelSpy: ReturnType<typeof vi.fn>;
   let getAvailableCommandsSpy: ReturnType<typeof vi.fn>;
-  let mockToolRegistry: { getTool: ReturnType<typeof vi.fn> };
+  let mockToolRegistry: {
+    getTool: ReturnType<typeof vi.fn>;
+    ensureTool: ReturnType<typeof vi.fn>;
+  };
   beforeEach(() => {
     currentModel = 'qwen3-code-plus';
     currentAuthType = AuthType.USE_OPENAI;
@@ -73,7 +76,13 @@ describe('Session', () => {
       getHistory: vi.fn().mockReturnValue([]),
     } as unknown as GeminiChat;
 
-    mockToolRegistry = { getTool: vi.fn() };
+    mockToolRegistry = {
+      getTool: vi.fn(),
+      // #executePrompt → #buildInitialSystemReminders calls
+      // getToolRegistry().ensureTool(ToolNames.AGENT) on every session.prompt(),
+      // so the default mock must provide it (#1151 / #3479).
+      ensureTool: vi.fn().mockResolvedValue(true),
+    };
     const fileService = { shouldGitIgnoreFile: vi.fn().mockReturnValue(false) };
 
     mockConfig = {
@@ -91,6 +100,12 @@ describe('Session', () => {
         recordToolResult: vi.fn(),
       }),
       getToolRegistry: vi.fn().mockReturnValue(mockToolRegistry),
+      // #buildInitialSystemReminders iterates listSubagents() on every
+      // session.prompt(). Default to an empty list so tests that don't
+      // exercise subagent reminders don't need to stub it (#1151 / #3479).
+      getSubagentManager: vi.fn().mockReturnValue({
+        listSubagents: vi.fn().mockResolvedValue([]),
+      }),
       getFileService: vi.fn().mockReturnValue(fileService),
       getFileFilteringRespectGitIgnore: vi.fn().mockReturnValue(true),
       getEnableRecursiveFileSearch: vi.fn().mockReturnValue(false),

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -87,6 +87,10 @@ describe('Session', () => {
 
     mockConfig = {
       setApprovalMode: vi.fn(),
+      // #buildInitialSystemReminders branches on ApprovalMode.PLAN on every
+      // session.prompt(), so the default must be defined. Individual tests
+      // that care override via `mockConfig.getApprovalMode = vi.fn()...`.
+      getApprovalMode: vi.fn().mockReturnValue(ApprovalMode.DEFAULT),
       switchModel: switchModelSpy,
       getModel: vi.fn().mockImplementation(() => currentModel),
       getSessionId: vi.fn().mockReturnValue('test-session-id'),

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -50,6 +50,9 @@ import {
   createHookOutput,
   generateToolUseId,
   MessageBusType,
+  getPlanModeSystemReminder,
+  getSubagentSystemReminder,
+  getArenaSystemReminder,
 } from '@qwen-code/qwen-code-core';
 
 import { RequestError } from '@agentclientprotocol/sdk';
@@ -398,6 +401,16 @@ export class Session implements SessionContext {
           if (additionalContext) {
             parts = [...parts, { text: additionalContext }];
           }
+        }
+
+        // Prepend session-level system reminders (plan mode / subagent /
+        // arena) so the model sees them, matching the behaviour of
+        // `GeminiClient.sendMessageStream` in the CLI/TUI path. Without this,
+        // plan mode in ACP has no effect because the model never learns it
+        // should avoid edits (#1151).
+        const systemReminders = await this.#buildInitialSystemReminders();
+        if (systemReminders.length > 0) {
+          parts = [...systemReminders, ...parts];
         }
 
         let nextMessage: Content | null = { role: 'user', parts };
@@ -872,9 +885,12 @@ export class Session implements SessionContext {
             _meta: { source: 'cron' },
           });
 
+          // Prepend session-level system reminders (same rationale as the
+          // user-query path in #executePrompt).
+          const cronReminders = await this.#buildInitialSystemReminders();
           let nextMessage: Content | null = {
             role: 'user',
-            parts: [{ text: prompt }],
+            parts: [...cronReminders, { text: prompt }],
           };
 
           while (nextMessage !== null) {
@@ -1088,6 +1104,51 @@ export class Session implements SessionContext {
     };
 
     await this.sendUpdate(update);
+  }
+
+  /**
+   * Assemble the per-turn system reminders the model needs to see at the
+   * start of a user query or cron fire. Mirrors the subagent/plan/arena
+   * branches in `GeminiClient.sendMessageStream` (`client.ts:848-878`) —
+   * the ACP path bypasses that code, so without this helper plan mode is
+   * silently inert (#1151) and subagent/arena sessions lose context.
+   *
+   * Scope note: the `relevantAutoMemory` reminder is intentionally NOT
+   * included here. Managed auto-memory requires a prefetch pipeline that
+   * lives in `GeminiClient`, and porting it into the ACP path is tracked
+   * separately as part of the broader middleware-alignment work.
+   */
+  async #buildInitialSystemReminders(): Promise<Part[]> {
+    const reminders: Part[] = [];
+
+    const hasAgentTool = await this.config
+      .getToolRegistry()
+      .ensureTool(ToolNames.AGENT);
+    const subagents = (await this.config.getSubagentManager().listSubagents())
+      .filter((subagent) => subagent.level !== 'builtin')
+      .map((subagent) => subagent.name);
+    if (hasAgentTool && subagents.length > 0) {
+      reminders.push({ text: getSubagentSystemReminder(subagents) });
+    }
+
+    if (this.config.getApprovalMode() === ApprovalMode.PLAN) {
+      reminders.push({
+        text: getPlanModeSystemReminder(this.config.getSdkMode?.()),
+      });
+    }
+
+    const arenaManager = this.config.getArenaManager?.();
+    if (arenaManager) {
+      try {
+        const sessionDir = arenaManager.getArenaSessionDir();
+        const configPath = `${sessionDir}/config.json`;
+        reminders.push({ text: getArenaSystemReminder(configPath) });
+      } catch {
+        // Arena config not yet initialized — skip (matches client.ts).
+      }
+    }
+
+    return reminders;
   }
 
   private async runTool(


### PR DESCRIPTION
## Summary

Closes #1151.

The ACP Session sends user messages via `chat.sendMessageStream()` directly, bypassing `GeminiClient.sendMessageStream()` where the CLI/TUI path injects its per-turn system reminders (`client.ts:848-878`). Consequences:

- **Plan mode is silently inert in ACP** (#1151): the model never sees the reminder telling it to avoid edits and call `exit_plan_mode`, so it tries to run edit tools; the plan-mode block-check in `Session.runTool` catches them only as a fallback, producing a confusing UX.
- **User-level subagents registered in the workspace are invisible to the model** for the same reason.
- **Arena sessions started via ACP lose session-dir context.**

### Changes

- New helper `Session.#buildInitialSystemReminders` mirrors the subagent / plan / arena branches from `client.ts:848-878`.
- Prepend the reminders to the initial user-query message in `#executePrompt`, and to the cron-fired prompt in `#executeCronPrompt`.
- Scope note: the `relevantAutoMemory` reminder is intentionally **not** included here. Managed auto-memory requires the prefetch pipeline that lives in `GeminiClient`, which will be handled as part of broader middleware alignment (see notes below).

### Why not switch ACP to `GeminiClient.sendMessageStream` outright

That would be the structurally correct fix for all ACP/TUI parity gaps, but it requires:
- Deleting the hand-rolled `UserPromptSubmit` + `Stop` hook loops in `Session.ts` (otherwise they would double-fire).
- Writing an event-type adapter (`ServerGeminiStreamEvent` → the raw `StreamEvent` shape ACP currently consumes).
- Handling `SendMessageType.Retry / Cron / Notification` branch semantics.

That's a much larger refactor. This PR is the minimal fix for #1151; the structural work is tracked separately in a follow-up issue (opening after this PR).

## Relationship to #3108

#3108 claims a broader hook-alignment gap. On HEAD the hook wiring is already complete:

| Hook | Status in Session.ts |
|------|---|
| `UserPromptSubmit` | ✅ L359 |
| `Stop` / `StopFailure` | ✅ L534 / L467 |
| `PreToolUse` / `PostToolUse` / `PostToolUseFailure` | ✅ inside `runTool` |
| `PermissionRequest` / `Notification` | ✅ |

The remaining divergence is **non-hook middleware** (system reminders, IDE context, loop detection, auto-memory recall, arena control-signal). This PR covers the system-reminder slice; the rest is tracked by the follow-up.

## Test plan

- [x] `Session.test.ts > prompt > system reminders`: plan-mode on vs default, plus non-builtin subagent filtering. Captures the first-turn message fed into `chat.sendMessageStream` and asserts reminder presence + ordering.
- [x] Typecheck: no new errors in `acp-integration/` after rebuilding `packages/core`.
- [ ] Manual smoke in Zed: `qwen --experimental-acp --approval-mode plan`, ask for a code change, verify the model responds with a plan via `exit_plan_mode` instead of trying to use `edit`.
- [ ] CI green.