### PR TITLE
fix(core): use empty string instead of null for reasoning-only assistant content

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -867,6 +867,111 @@ describe('OpenAIContentConverter', () => {
         content: '',
       });
     });
+
+    describe('assistant message with reasoning-only content (issue #3421)', () => {
+      /**
+       * Regression tests for https://github.com/QwenLM/qwen-code/issues/3421
+       *
+       * When a model (e.g. Ollama qwen3.5:9b) returns a response that contains
+       * reasoning content but an empty text body, the converted assistant message
+       * must use content: "" instead of content: null.
+       * Some OpenAI-compatible providers reject content: null with HTTP 400 when
+       * reasoning_content is also present.
+       */
+      it('should use empty string instead of null for content when assistant has only reasoning parts', () => {
+        const request: GenerateContentParameters = {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Think about this.' }] },
+            {
+              // Assistant turn that only produced a thought, no visible text
+              role: 'model',
+              parts: [{ text: 'I reasoned about it.', thought: true }],
+            },
+            { role: 'user', parts: [{ text: 'What did you conclude?' }] },
+          ],
+        };
+
+        const messages = converter.convertGeminiRequestToOpenAI(request);
+
+        const assistantMsg = messages.find((m) => m.role === 'assistant');
+        expect(assistantMsg).toBeDefined();
+        // Must NOT be null – Ollama and other providers reject null content
+        // when reasoning_content is present (HTTP 400).
+        expect((assistantMsg as { content: unknown }).content).toBe('');
+        // reasoning_content should still be preserved
+        expect(
+          (assistantMsg as { reasoning_content?: string }).reasoning_content,
+        ).toBe('I reasoned about it.');
+      });
+
+      it('should keep content null when assistant has only tool_calls and no reasoning', () => {
+        const request: GenerateContentParameters = {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Call the tool.' }] },
+            {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    id: 'call_1',
+                    name: 'some_tool',
+                    args: {},
+                  },
+                },
+              ],
+            },
+            {
+              role: 'user',
+              parts: [
+                {
+                  functionResponse: {
+                    id: 'call_1',
+                    name: 'some_tool',
+                    response: { output: 'done' },
+                  },
+                },
+              ],
+            },
+          ],
+        };
+
+        const messages = converter.convertGeminiRequestToOpenAI(request);
+
+        const assistantMsg = messages.find((m) => m.role === 'assistant');
+        expect(assistantMsg).toBeDefined();
+        // Tool-call-only messages follow the OpenAI spec: content should be null
+        expect((assistantMsg as { content: unknown }).content).toBeNull();
+      });
+
+      it('should use actual text content when assistant has both reasoning and text', () => {
+        const request: GenerateContentParameters = {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Explain.' }] },
+            {
+              role: 'model',
+              parts: [
+                { text: 'My hidden reasoning.', thought: true },
+                { text: 'Here is my answer.' },
+              ],
+            },
+          ],
+        };
+
+        const messages = converter.convertGeminiRequestToOpenAI(request);
+
+        const assistantMsg = messages.find((m) => m.role === 'assistant');
+        expect(assistantMsg).toBeDefined();
+        expect((assistantMsg as { content: unknown }).content).toBe(
+          'Here is my answer.',
+        );
+        expect(
+          (assistantMsg as { reasoning_content?: string }).reasoning_content,
+        ).toBe('My hidden reasoning.');
+      });
+    });
   });
 
   describe('MCP multi-part tool results (issue #1520)', () => {

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -502,7 +502,12 @@ export class OpenAIContentConverter {
         .join('');
       const assistantMessage: ExtendedChatCompletionAssistantMessageParam = {
         role: 'assistant',
-        content: assistantTextContent || null,
+        // When there is reasoning content but no text, use "" instead of null.
+        // Some OpenAI-compatible providers (e.g. Ollama) reject content: null
+        // when reasoning_content is present, returning HTTP 400.
+        // For tool-call-only messages we keep null to stay spec-compliant.
+        content:
+          assistantTextContent || (reasoningParts.length > 0 ? '' : null),
       };
 
       if (toolCalls.length > 0) {


### PR DESCRIPTION
## TLDR

When a model (e.g. Ollama + qwen3.5:9b) returns a streaming response that contains `reasoning`/`thinking` content but an empty text body, the assistant message in the conversation history was serialised with `content: null`. On the next turn this `null` is sent verbatim to the provider, and Ollama (and other OpenAI-compatible servers) reject the request with **HTTP 400 – invalid message content type: `<nil>`**, making the session unrecoverable without a restart.

## Screenshots / Video Demo

N/A — no user-facing change. The fix prevents an HTTP 400 error from being thrown mid-session, so the session continues working transparently.

## Dive Deeper

### Root cause

In `processContent()` ([converter.ts](packages/core/src/core/openaiContentGenerator/converter.ts)), when converting a Gemini `Content` object back to an OpenAI assistant message:

```typescript
content: assistantTextContent || null,
// "" || null = null  ← sent to Ollama → HTTP 400
```

If the model produced only a thought part (no visible text), `assistantTextContent` is `""` and the expression evaluates to `null`. The message is then:

```json
{ "role": "assistant", "content": null, "reasoning_content": "Done…" }
```

Ollama rejects this because it does not accept `content: null` when other fields like `reasoning_content` are present.

### Why resume works but live sessions don't

On resume, `buildApiHistoryFromConversation()` calls `stripThoughtsFromContent()`, which drops the entire assistant `Content` node that only contained thought parts. So the bad message is silently excluded and the request succeeds. This guard is absent for in-flight conversation history.

### Fix

```typescript
content: assistantTextContent || (reasoningParts.length > 0 ? '' : null),
```

- **reasoning-only** messages → `content: ""` (accepted by Ollama)  
- **tool-call-only** messages (no reasoning) → `content: null` (OpenAI spec-compliant)  
- **normal text** messages → unchanged

## Reviewer Test Plan

1. Use an Ollama-compatible backend (e.g. `ollama serve` with `qwen3.5:9b` or any model that emits `reasoning` tokens).
2. Configure Qwen Code to use `http://localhost:11434/v1` with that model.
3. Have a multi-turn conversation where the model's reasoning step produces no visible text (this happens intermittently with smaller models).
4. Without the fix the session hangs with _API Error: 400 invalid message content type: `<nil>`_; with the fix the session continues normally.

## Testing Matrix

|          | ��  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | -   | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3421