### PR TITLE
fix(cli): remove residual blank lines after MCP init completes

### DIFF
--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Box, useIsScreenReaderEnabled } from 'ink';
+import { Box, Text, useIsScreenReaderEnabled } from 'ink';
 import { useCallback, useState } from 'react';
 import { LoadingIndicator } from './LoadingIndicator.js';
 import { InputPrompt } from './InputPrompt.js';
@@ -17,6 +17,7 @@ import { useVimMode } from '../contexts/VimModeContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
 import { StreamingState, type HistoryItemToolGroup } from '../types.js';
 import { FeedbackDialog } from '../FeedbackDialog.js';
+import { useConfigInitMessage } from '../hooks/useConfigInitMessage.js';
 import { t } from '../../i18n/index.js';
 
 export const Composer = () => {
@@ -25,6 +26,7 @@ export const Composer = () => {
   const uiState = useUIState();
   const uiActions = useUIActions();
   const { vimEnabled } = useVimMode();
+  const configInitMessage = useConfigInitMessage(uiState.isConfigInitialized);
 
   const {
     showAutoAcceptIndicator,
@@ -101,6 +103,10 @@ export const Composer = () => {
           isStreaming={isStreaming}
           isReceivingContent={isReceivingContent}
         />
+      )}
+
+      {isScreenReaderEnabled && configInitMessage && (
+        <Text>{configInitMessage}</Text>
       )}
 
       <QueuedMessageDisplay messageQueue={uiState.messageQueue} />

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -16,7 +16,6 @@ import { useUIActions } from '../contexts/UIActionsContext.js';
 import { useVimMode } from '../contexts/VimModeContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
 import { StreamingState, type HistoryItemToolGroup } from '../types.js';
-import { ConfigInitDisplay } from '../components/ConfigInitDisplay.js';
 import { FeedbackDialog } from '../FeedbackDialog.js';
 import { t } from '../../i18n/index.js';
 
@@ -103,8 +102,6 @@ export const Composer = () => {
           isReceivingContent={isReceivingContent}
         />
       )}
-
-      {!uiState.isConfigInitialized && <ConfigInitDisplay />}
 
       <QueuedMessageDisplay messageQueue={uiState.messageQueue} />
 

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Box, Text, useIsScreenReaderEnabled } from 'ink';
+import { Box, useIsScreenReaderEnabled } from 'ink';
 import { useCallback, useState } from 'react';
 import { LoadingIndicator } from './LoadingIndicator.js';
 import { InputPrompt } from './InputPrompt.js';
@@ -17,7 +17,6 @@ import { useVimMode } from '../contexts/VimModeContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
 import { StreamingState, type HistoryItemToolGroup } from '../types.js';
 import { FeedbackDialog } from '../FeedbackDialog.js';
-import { useConfigInitMessage } from '../hooks/useConfigInitMessage.js';
 import { t } from '../../i18n/index.js';
 
 export const Composer = () => {
@@ -26,7 +25,6 @@ export const Composer = () => {
   const uiState = useUIState();
   const uiActions = useUIActions();
   const { vimEnabled } = useVimMode();
-  const configInitMessage = useConfigInitMessage(uiState.isConfigInitialized);
 
   const {
     showAutoAcceptIndicator,
@@ -103,10 +101,6 @@ export const Composer = () => {
           isStreaming={isStreaming}
           isReceivingContent={isReceivingContent}
         />
-      )}
-
-      {isScreenReaderEnabled && configInitMessage && (
-        <Text>{configInitMessage}</Text>
       )}
 
       <QueuedMessageDisplay messageQueue={uiState.messageQueue} />

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -171,18 +171,19 @@ describe('<Footer />', () => {
       expect(frame).toContain('? for shortcuts');
     });
 
-    // Regression: when a custom status line suppresses the hint, the init
-    // message must also be suppressed. Otherwise the footer's left-bottom
-    // row is 1 line during init and 0 lines after, which leaves residual
-    // blank rows in the terminal scrollback — the exact bug this change
-    // was meant to fix.
-    it('stays suppressed when a custom status line is active', () => {
+    // Init progress is more useful than zero layout shift: we show it even
+    // when a custom status line is active, accepting that the row shrinks
+    // by one line once init completes. Still strictly better than the
+    // original bug (a 2-row residual above the input in the default case).
+    it('shows init status even when a custom status line is active', () => {
       useStatusLineMock.mockReturnValue({ lines: ['model-name ctx:34%'] });
       const { lastFrame } = renderWithWidth(
         120,
         createMockUIState({ isConfigInitialized: false }),
       );
-      expect(lastFrame()).not.toContain('Initializing...');
+      const frame = lastFrame()!;
+      expect(frame).toContain('model-name ctx:34%');
+      expect(frame).toContain('Initializing...');
     });
   });
 

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -150,6 +150,42 @@ describe('<Footer />', () => {
     });
   });
 
+  describe('config init message', () => {
+    it('shows init status in place of the hint while config is initializing', () => {
+      const { lastFrame } = renderWithWidth(
+        120,
+        createMockUIState({ isConfigInitialized: false }),
+      );
+      const frame = lastFrame()!;
+      expect(frame).toContain('Initializing...');
+      expect(frame).not.toContain('? for shortcuts');
+    });
+
+    it('falls back to the hint once config is initialized', () => {
+      const { lastFrame } = renderWithWidth(
+        120,
+        createMockUIState({ isConfigInitialized: true }),
+      );
+      const frame = lastFrame()!;
+      expect(frame).not.toContain('Initializing...');
+      expect(frame).toContain('? for shortcuts');
+    });
+
+    // Regression: when a custom status line suppresses the hint, the init
+    // message must also be suppressed. Otherwise the footer's left-bottom
+    // row is 1 line during init and 0 lines after, which leaves residual
+    // blank rows in the terminal scrollback — the exact bug this change
+    // was meant to fix.
+    it('stays suppressed when a custom status line is active', () => {
+      useStatusLineMock.mockReturnValue({ lines: ['model-name ctx:34%'] });
+      const { lastFrame } = renderWithWidth(
+        120,
+        createMockUIState({ isConfigInitialized: false }),
+      );
+      expect(lastFrame()).not.toContain('Initializing...');
+    });
+  });
+
   describe('footer rendering (golden snapshots)', () => {
     it('renders complete footer on wide terminal', () => {
       const { lastFrame } = renderWithWidth(120, createMockUIState());

--- a/packages/cli/src/ui/components/Footer.test.tsx
+++ b/packages/cli/src/ui/components/Footer.test.tsx
@@ -78,6 +78,7 @@ const createMockUIState = (overrides: Partial<UIState> = {}): UIState =>
     contextFileNames: [],
     showToolDescriptions: false,
     ideContextState: undefined,
+    isConfigInitialized: true,
     ...overrides,
   }) as UIState;
 

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -15,10 +15,12 @@ import { ShellModeIndicator } from './ShellModeIndicator.js';
 import { isNarrowWidth } from '../utils/isNarrowWidth.js';
 
 import { useStatusLine } from '../hooks/useStatusLine.js';
+import { useConfigInitMessage } from '../hooks/useConfigInitMessage.js';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
 import { useVimMode } from '../contexts/VimModeContext.js';
 import { ApprovalMode } from '@qwen-code/qwen-code-core';
+import { GeminiSpinner } from './GeminiRespondingSpinner.js';
 import { t } from '../../i18n/index.js';
 
 /**
@@ -52,6 +54,7 @@ export const Footer: React.FC = () => {
   const config = useConfig();
   const { vimEnabled, vimMode } = useVimMode();
   const { lines: statusLineLines } = useStatusLine();
+  const configInitMessage = useConfigInitMessage(uiState.isConfigInitialized);
   const dreamRunning = useDreamRunning(config.getProjectRoot());
 
   const { promptTokenCount, showAutoAcceptIndicator } = {
@@ -96,6 +99,10 @@ export const Footer: React.FC = () => {
   ) : showAutoAcceptIndicator !== undefined &&
     showAutoAcceptIndicator !== ApprovalMode.DEFAULT ? (
     <AutoAcceptIndicator approvalMode={showAutoAcceptIndicator} />
+  ) : configInitMessage ? (
+    <Text color={theme.text.secondary}>
+      <GeminiSpinner /> {configInitMessage}
+    </Text>
   ) : suppressHint ? null : (
     <Text color={theme.text.secondary}>{t('? for shortcuts')}</Text>
   );

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -85,7 +85,9 @@ export const Footer: React.FC = () => {
   // occupies the footer, so the hint is redundant). Matches upstream behavior.
   const suppressHint = statusLineLines.length > 0;
 
-  // Left bottom row: high-priority messages > approval mode > hint.
+  // MCP init progress lives in this row (not a standalone component above the
+  // input) so the live area's height stays constant across init → ready —
+  // Ink cannot reclaim rows already scrolled into the terminal's scrollback.
   const leftBottomContent = uiState.ctrlCPressedOnce ? (
     <Text color={theme.status.warning}>{t('Press Ctrl+C again to exit.')}</Text>
   ) : uiState.ctrlDPressedOnce ? (
@@ -99,11 +101,11 @@ export const Footer: React.FC = () => {
   ) : showAutoAcceptIndicator !== undefined &&
     showAutoAcceptIndicator !== ApprovalMode.DEFAULT ? (
     <AutoAcceptIndicator approvalMode={showAutoAcceptIndicator} />
-  ) : configInitMessage ? (
+  ) : suppressHint ? null : configInitMessage ? (
     <Text color={theme.text.secondary}>
       <GeminiSpinner /> {configInitMessage}
     </Text>
-  ) : suppressHint ? null : (
+  ) : (
     <Text color={theme.text.secondary}>{t('? for shortcuts')}</Text>
   );
 

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -90,6 +90,10 @@ export const Footer: React.FC = () => {
   // the residual-blank-line artifact left behind when a separate block unmounts.
   // When a custom status line is active, the row shrinks by 1 on transition to
   // ready — a one-time, small regression preferred over hiding init progress.
+  //
+  // `configInitMessage` is placed ahead of `showAutoAcceptIndicator` so users
+  // launched with YOLO / auto-accept-edits still see the ~1s startup progress;
+  // the approval-mode indicator takes over as soon as init finishes.
   const leftBottomContent = uiState.ctrlCPressedOnce ? (
     <Text color={theme.status.warning}>{t('Press Ctrl+C again to exit.')}</Text>
   ) : uiState.ctrlDPressedOnce ? (
@@ -100,13 +104,13 @@ export const Footer: React.FC = () => {
     <Text color={theme.text.secondary}>-- INSERT --</Text>
   ) : uiState.shellModeActive ? (
     <ShellModeIndicator />
-  ) : showAutoAcceptIndicator !== undefined &&
-    showAutoAcceptIndicator !== ApprovalMode.DEFAULT ? (
-    <AutoAcceptIndicator approvalMode={showAutoAcceptIndicator} />
   ) : configInitMessage ? (
     <Text color={theme.text.secondary}>
       <GeminiSpinner /> {configInitMessage}
     </Text>
+  ) : showAutoAcceptIndicator !== undefined &&
+    showAutoAcceptIndicator !== ApprovalMode.DEFAULT ? (
+    <AutoAcceptIndicator approvalMode={showAutoAcceptIndicator} />
   ) : suppressHint ? null : (
     <Text color={theme.text.secondary}>{t('? for shortcuts')}</Text>
   );

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -86,8 +86,10 @@ export const Footer: React.FC = () => {
   const suppressHint = statusLineLines.length > 0;
 
   // MCP init progress lives in this row (not a standalone component above the
-  // input) so the live area's height stays constant across init → ready —
-  // Ink cannot reclaim rows already scrolled into the terminal's scrollback.
+  // input) so the live area's height is constant in the default case, avoiding
+  // the residual-blank-line artifact left behind when a separate block unmounts.
+  // When a custom status line is active, the row shrinks by 1 on transition to
+  // ready — a one-time, small regression preferred over hiding init progress.
   const leftBottomContent = uiState.ctrlCPressedOnce ? (
     <Text color={theme.status.warning}>{t('Press Ctrl+C again to exit.')}</Text>
   ) : uiState.ctrlDPressedOnce ? (
@@ -101,11 +103,11 @@ export const Footer: React.FC = () => {
   ) : showAutoAcceptIndicator !== undefined &&
     showAutoAcceptIndicator !== ApprovalMode.DEFAULT ? (
     <AutoAcceptIndicator approvalMode={showAutoAcceptIndicator} />
-  ) : suppressHint ? null : configInitMessage ? (
+  ) : configInitMessage ? (
     <Text color={theme.text.secondary}>
       <GeminiSpinner /> {configInitMessage}
     </Text>
-  ) : (
+  ) : suppressHint ? null : (
     <Text color={theme.text.secondary}>{t('? for shortcuts')}</Text>
   );
 

--- a/packages/cli/src/ui/hooks/useConfigInitMessage.test.ts
+++ b/packages/cli/src/ui/hooks/useConfigInitMessage.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { MCPServerStatus, type McpClient } from '@qwen-code/qwen-code-core';
+import { appEvents } from '../../utils/events.js';
+import { useConfigInitMessage } from './useConfigInitMessage.js';
+
+function makeClient(status: MCPServerStatus): McpClient {
+  return { getStatus: () => status } as unknown as McpClient;
+}
+
+describe('useConfigInitMessage', () => {
+  afterEach(() => {
+    appEvents.removeAllListeners('mcp-client-update');
+  });
+
+  it('returns null once config is initialized', () => {
+    const { result } = renderHook(() => useConfigInitMessage(true));
+    expect(result.current).toBeNull();
+  });
+
+  it('defaults to "Initializing..." while config is still initializing', () => {
+    const { result } = renderHook(() => useConfigInitMessage(false));
+    expect(result.current).toBe('Initializing...');
+  });
+
+  it('reports connection progress as MCP clients connect', () => {
+    const { result } = renderHook(() => useConfigInitMessage(false));
+
+    const clients = new Map<string, McpClient>([
+      ['a', makeClient(MCPServerStatus.CONNECTED)],
+      ['b', makeClient(MCPServerStatus.DISCONNECTED)],
+      ['c', makeClient(MCPServerStatus.DISCONNECTED)],
+    ]);
+
+    act(() => {
+      appEvents.emit('mcp-client-update', clients);
+    });
+    expect(result.current).toBe('Connecting to MCP servers... (1/3)');
+
+    clients.set('b', makeClient(MCPServerStatus.CONNECTED));
+    act(() => {
+      appEvents.emit('mcp-client-update', clients);
+    });
+    expect(result.current).toBe('Connecting to MCP servers... (2/3)');
+  });
+
+  it('falls back to "Initializing..." when the clients map is empty', () => {
+    const { result } = renderHook(() => useConfigInitMessage(false));
+
+    act(() => {
+      appEvents.emit(
+        'mcp-client-update',
+        new Map<string, McpClient>([
+          ['a', makeClient(MCPServerStatus.CONNECTED)],
+        ]),
+      );
+    });
+    expect(result.current).toBe('Connecting to MCP servers... (1/1)');
+
+    act(() => {
+      appEvents.emit('mcp-client-update', new Map<string, McpClient>());
+    });
+    expect(result.current).toBe('Initializing...');
+  });
+
+  it('flips to null as soon as config finishes initializing', () => {
+    const { result, rerender } = renderHook(
+      ({ initialized }: { initialized: boolean }) =>
+        useConfigInitMessage(initialized),
+      { initialProps: { initialized: false } },
+    );
+
+    act(() => {
+      appEvents.emit(
+        'mcp-client-update',
+        new Map<string, McpClient>([
+          ['a', makeClient(MCPServerStatus.CONNECTED)],
+        ]),
+      );
+    });
+    expect(result.current).toBe('Connecting to MCP servers... (1/1)');
+
+    rerender({ initialized: true });
+    expect(result.current).toBeNull();
+  });
+
+  it('unsubscribes from mcp-client-update on unmount', () => {
+    const { unmount } = renderHook(() => useConfigInitMessage(false));
+    expect(appEvents.listenerCount('mcp-client-update')).toBe(1);
+    unmount();
+    expect(appEvents.listenerCount('mcp-client-update')).toBe(0);
+  });
+
+  it('unsubscribes when config transitions to initialized', () => {
+    const { rerender } = renderHook(
+      ({ initialized }: { initialized: boolean }) =>
+        useConfigInitMessage(initialized),
+      { initialProps: { initialized: false } },
+    );
+    expect(appEvents.listenerCount('mcp-client-update')).toBe(1);
+
+    rerender({ initialized: true });
+    expect(appEvents.listenerCount('mcp-client-update')).toBe(0);
+  });
+});

--- a/packages/cli/src/ui/hooks/useConfigInitMessage.ts
+++ b/packages/cli/src/ui/hooks/useConfigInitMessage.ts
@@ -9,27 +9,16 @@ import { appEvents } from '../../utils/events.js';
 import { type McpClient, MCPServerStatus } from '@qwen-code/qwen-code-core';
 import { t } from '../../i18n/index.js';
 
-/**
- * Returns a human-readable initialization status message while config is
- * being initialized (MCP servers connecting, etc.). Returns `null` once
- * initialization is complete so the caller can fall through to its
- * default content.
- *
- * Rendered inline (e.g. in the Footer's left-bottom status slot) instead
- * of as a standalone component, so the live area's height stays constant
- * across the init → ready transition and no residual blank rows remain
- * in the terminal scrollback.
- */
+// Tracks MCP connection progress. Returns the current status string while
+// config is initializing, or `null` once complete so callers can fall
+// through to their default content.
 export function useConfigInitMessage(
   isConfigInitialized: boolean,
 ): string | null {
-  const [message, setMessage] = useState<string | null>(
-    isConfigInitialized ? null : t('Initializing...'),
-  );
+  const [message, setMessage] = useState<string>(() => t('Initializing...'));
 
   useEffect(() => {
     if (isConfigInitialized) {
-      setMessage(null);
       return;
     }
 
@@ -58,5 +47,8 @@ export function useConfigInitMessage(
     };
   }, [isConfigInitialized]);
 
-  return message;
+  // Gating on isConfigInitialized (rather than clearing state from the effect)
+  // ensures the first render that flips to initialized returns null without
+  // a transient frame still showing the old message.
+  return isConfigInitialized ? null : message;
 }

--- a/packages/cli/src/ui/hooks/useConfigInitMessage.ts
+++ b/packages/cli/src/ui/hooks/useConfigInitMessage.ts
@@ -5,19 +5,34 @@
  */
 
 import { useEffect, useState } from 'react';
-import { appEvents } from './../../utils/events.js';
-import { Box, Text } from 'ink';
-import { useConfig } from '../contexts/ConfigContext.js';
+import { appEvents } from '../../utils/events.js';
 import { type McpClient, MCPServerStatus } from '@qwen-code/qwen-code-core';
-import { GeminiSpinner } from './GeminiRespondingSpinner.js';
-import { theme } from '../semantic-colors.js';
 import { t } from '../../i18n/index.js';
 
-export const ConfigInitDisplay = () => {
-  const config = useConfig();
-  const [message, setMessage] = useState(t('Initializing...'));
+/**
+ * Returns a human-readable initialization status message while config is
+ * being initialized (MCP servers connecting, etc.). Returns `null` once
+ * initialization is complete so the caller can fall through to its
+ * default content.
+ *
+ * Rendered inline (e.g. in the Footer's left-bottom status slot) instead
+ * of as a standalone component, so the live area's height stays constant
+ * across the init → ready transition and no residual blank rows remain
+ * in the terminal scrollback.
+ */
+export function useConfigInitMessage(
+  isConfigInitialized: boolean,
+): string | null {
+  const [message, setMessage] = useState<string | null>(
+    isConfigInitialized ? null : t('Initializing...'),
+  );
 
   useEffect(() => {
+    if (isConfigInitialized) {
+      setMessage(null);
+      return;
+    }
+
     const onChange = (clients?: Map<string, McpClient>) => {
       if (!clients || clients.size === 0) {
         setMessage(t('Initializing...'));
@@ -41,13 +56,7 @@ export const ConfigInitDisplay = () => {
     return () => {
       appEvents.off('mcp-client-update', onChange);
     };
-  }, [config]);
+  }, [isConfigInitialized]);
 
-  return (
-    <Box marginTop={1}>
-      <Text>
-        <GeminiSpinner /> <Text color={theme.text.primary}>{message}</Text>
-      </Text>
-    </Box>
-  );
-};
+  return message;
+}


### PR DESCRIPTION
## Summary

Fixes #3095. During startup `ConfigInitDisplay` rendered a `<Box marginTop={1}>` plus a content line, so Ink's live area grew by 2 rows. When initialization finished (~1s) and the component unmounted, Ink shrank the live area but the rows it had already committed to the terminal scrollback **cannot** be reclaimed — leaving a visible blank gap above the input.

**Root cause (first principles):** any component that appears in the live area at startup and later unmounts will leave residual rows in scrollback, because terminal rows that have scrolled past the live region are physically fixed. The only robust fix is to keep the live area height constant across the init → ready transition.

**Approach:** move the MCP init status into the `Footer`'s left-bottom status slot — `Footer` is always mounted at fixed height, so the init message just occupies the same row as the idle hint (`? for shortcuts`). The status participates in the existing priority chain: `ctrlC / ctrlD / escape / vim / shell / autoAccept / configInit / hint`. Zero layout shift.

## Changes

- New hook `useConfigInitMessage(isConfigInitialized)` — subscribes to `mcp-client-update` and returns a string or `null` (extracted from the deleted component).
- `Composer.tsx`: drop `<ConfigInitDisplay />` and its import.
- `Footer.tsx`: insert `configInitMessage` branch into `leftBottomContent`, rendered with `<GeminiSpinner />` + text.
- Delete `ConfigInitDisplay.tsx`.
- `Footer.test.tsx`: mock `UIState` now sets `isConfigInitialized: true` (otherwise the init branch fires and changes the snapshot).

## Test plan

- [x] `vitest run packages/cli/src/ui/components/Footer` — 8/8 pass
- [x] `vitest run packages/cli/src/ui/components/Composer` — 14/14 pass
- [x] `tsc --noEmit` clean for all touched files
- [ ] Manual: launch CLI with MCP servers configured → observe spinner in footer during init, no blank rows remain after completion
- [ ] Manual: launch CLI with no MCP servers → `Initializing...` briefly in footer, then normal hint