### PR TITLE
docs(github): tighten PR template validation guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,54 +1,73 @@
-## TLDR
-
-<!-- Add a brief description of what this pull request changes and why and any important things for reviewers to look at -->
-
-## Screenshots / Video Demo
-
 <!--
-Please attach a screenshot or short video showing your change in action.
-This helps reviewers understand the change quickly and prioritize reviews.
+Help reviewers verify this PR quickly.
 
-- For bug fixes: show the before/after behavior.
-- For features: show the new functionality in use.
-- For refactors or internal changes with no visible effect: write "N/A — no user-facing change" and briefly explain why.
-
-PRs with visual demos typically get reviewed much faster!
+Maintainers prioritize PRs that include clear proof of work.
+If a PR does not include enough validation detail to reproduce and verify the change efficiently, review may be delayed.
 -->
 
-## Dive Deeper
+## Summary
 
-<!-- more thoughts and in-depth discussion here -->
+- What changed:
+- Why it changed:
+- Reviewer focus:
 
-## Reviewer Test Plan
+## Validation
 
-<!-- when a person reviews your code they should ideally be pulling and running that code. How would they validate your change works and if relevant what are some good classes of example prompts and ways they can exercise your changes -->
+<!--
+Be concrete. Do not write only "tested locally".
+Include the exact commands, prompts, outputs, logs, screenshots, or videos that prove the change was actually run and observed.
+
+For user-visible changes, bug fixes, CLI / TUI behavior changes, or interaction changes, include key screenshots or a short video.
+When possible, show before/after behavior.
+
+If helpful, use the `e2e-testing` skill to gather stronger end-to-end validation evidence.
+-->
+
+- Commands run:
+  ```bash
+  # paste commands here
+  ```
+- Prompts / inputs used:
+- Expected result:
+- Observed result:
+- Quickest reviewer verification path:
+- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
+
+## Scope / Risk
+
+- Main risk or tradeoff:
+- Not covered / not validated:
+- Breaking changes / migration notes:
 
 ## Testing Matrix
 
-<!-- Before submitting please validate your changes on as many of these options as possible -->
+<!--
+Use:
+- ✅ tested
+- ⚠️ not tested
+- N/A
+If anything is ⚠️, explain why briefly below.
+-->
 
 |          | 🍏  | 🪟  | 🐧  |
 | -------- | --- | --- | --- |
-| npm run  | ❓  | ❓  | ❓  |
-| npx      | ❓  | ❓  | ❓  |
-| Docker   | ❓  | ❓  | ❓  |
-| Podman   | ❓  | -   | -   |
-| Seatbelt | ❓  | -   | -   |
+| npm run  | ⚠️  | ⚠️  | ⚠️  |
+| npx      | ⚠️  | ⚠️  | ⚠️  |
+| Docker   | ⚠️  | ⚠️  | ⚠️  |
+| Podman   | ⚠️  | N/A | N/A |
+| Seatbelt | ⚠️  | N/A | N/A |
 
-## Linked issues / bugs
+Testing matrix notes:
+
+-
+
+## Linked Issues / Bugs
 
 <!--
-Link to any related issues or bugs.
-
-**If this PR fully resolves the issue, use one of the following keywords to automatically close the issue when this PR is merged:**
-
+If this PR fully resolves an issue, use one of:
 - Closes #<issue_number>
 - Fixes #<issue_number>
 - Resolves #<issue_number>
 
-*Example: `Resolves #123`*
-
-**If this PR is only related to an issue or is a partial fix, simply reference the issue number without a keyword:**
-
-*Example: `This PR makes progress on #456` or `Related to #789`*
+Otherwise reference related issues without a closing keyword.
 -->


### PR DESCRIPTION
## Summary

- What changed: Rewrote the PR template to be shorter, more structured, and more evidence-driven. It now centers on `Summary`, `Validation`, `Scope / Risk`, and `Testing Matrix`, and removes overlapping free-form sections.
- Why it changed: In an AI-coding-heavy workflow, maintainer time is the scarce resource. The old template allowed too much vague prose and did not clearly require proof of work. This update makes contributors show concrete validation evidence and gives reviewers a faster path to trust or reject a PR.
- Reviewer focus: Check whether the new template is opinionated enough to reduce low-signal PRs without becoming too heavy for good contributors.

## Validation

- Commands run:
  ```bash
  git diff main...HEAD -- .github/pull_request_template.md
  ```
- Prompts / inputs used:
  - Iteratively refined the template around these goals:
    - reduce maintainer review time
    - increase trust via proof of work
    - require concrete validation evidence instead of vague claims
    - encourage screenshots / video / before-after evidence for visible changes
- Expected result:
  - The new template should be easier to fill out well, harder to fill out with empty AI-generated prose, and clearer about what maintainers need in order to review quickly.
- Observed result:
  - The template is now materially shorter and more direct.
  - `Validation` absorbs the old reviewer-runbook intent and asks for commands, prompts/inputs, expected vs observed result, quickest reviewer verification path, and evidence.
  - The template explicitly says review may be delayed if validation detail is missing.
  - The template explicitly asks for screenshots / short video and before/after evidence where relevant.
- Quickest reviewer verification path:
  1. Open `.github/pull_request_template.md` in the PR diff.
  2. Compare old vs new structure.
  3. Check that the new version reduces overlap and pushes contributors toward concrete evidence instead of free-form description.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  - Main evidence is the diff itself in `.github/pull_request_template.md`.
  - No screenshot/video attached because this PR changes repository documentation/workflow rather than product behavior.
  - Before/after is visible directly in the PR diff.

## Scope / Risk

- Main risk or tradeoff:
  - The template is intentionally more opinionated. It may slightly increase authoring friction for very small PRs, but the tradeoff is better reviewer efficiency and stronger trust signals.
- Not covered / not validated:
  - This PR does not validate community adoption quality yet; that will only be visible after contributors start using the new template.
  - No automation was added to enforce completeness; this change relies on template guidance and maintainer expectations.
- Breaking changes / migration notes:
  - N/A. This only changes the PR description template.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | N/A | N/A | N/A |
| npx      | N/A | N/A | N/A |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:
- N/A for this docs/process-only change.

## Linked Issues / Bugs

- N/A
