### PR TITLE
fix(cli): promote resubmitted history prompt to most recent

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -14,7 +14,7 @@ import {
   type Mock,
 } from 'vitest';
 import { render, cleanup } from 'ink-testing-library';
-import { AppContainer } from './AppContainer.js';
+import { AppContainer, dedupeNewestFirst } from './AppContainer.js';
 import {
   type Config,
   makeFakeConfig,
@@ -1403,5 +1403,30 @@ describe('AppContainer State Management', () => {
       capturedUIActions.closeModelDialog();
       expect(mockCloseModelDialog).toHaveBeenCalled();
     });
+  });
+});
+
+describe('dedupeNewestFirst', () => {
+  it('returns empty array for empty input', () => {
+    expect(dedupeNewestFirst([])).toEqual([]);
+  });
+
+  it('preserves order when there are no duplicates', () => {
+    expect(dedupeNewestFirst(['a', 'b', 'c'])).toEqual(['a', 'b', 'c']);
+  });
+
+  it('removes consecutive duplicates', () => {
+    expect(dedupeNewestFirst(['a', 'a', 'b'])).toEqual(['a', 'b']);
+  });
+
+  it('removes non-consecutive duplicates keeping the first (newest) occurrence', () => {
+    expect(
+      dedupeNewestFirst([
+        'first prompt',
+        'third prompt',
+        'second prompt',
+        'first prompt',
+      ]),
+    ).toEqual(['first prompt', 'third prompt', 'second prompt']);
   });
 });

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -154,6 +154,20 @@ function isToolExecuting(pendingHistoryItems: HistoryItemWithoutId[]) {
   });
 }
 
+// Exported for tests. Given a newest-first list of messages, return a list
+// with duplicates removed, keeping the first (newest) occurrence of each.
+export function dedupeNewestFirst(messages: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const msg of messages) {
+    if (!seen.has(msg)) {
+      seen.add(msg);
+      result.push(msg);
+    }
+  }
+  return result;
+}
+
 interface AppContainerProps {
   config: Config;
   settings: LoadedSettings;
@@ -451,20 +465,15 @@ export const AppContainer = (props: AppContainerProps) => {
         )
         .map((item) => item.text)
         .reverse();
+      // Current-session messages are already newest-first; combining with past
+      // messages gives a newest-first list. dedupeNewestFirst keeps the first
+      // (newest) occurrence so resubmitting an old prompt promotes it to
+      // "most recent" rather than leaving a stale copy at an older position.
       const combinedMessages = [
         ...currentSessionUserMessages,
         ...pastMessagesRaw,
       ];
-      const deduplicatedMessages: string[] = [];
-      if (combinedMessages.length > 0) {
-        deduplicatedMessages.push(combinedMessages[0]);
-        for (let i = 1; i < combinedMessages.length; i++) {
-          if (combinedMessages[i] !== combinedMessages[i - 1]) {
-            deduplicatedMessages.push(combinedMessages[i]);
-          }
-        }
-      }
-      setUserMessages(deduplicatedMessages.reverse());
+      setUserMessages(dedupeNewestFirst(combinedMessages).reverse());
     };
     fetchUserMessages();
   }, [historyManager.history, logger]);

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -169,6 +169,7 @@ describe('InputPrompt', () => {
       navigateUp: vi.fn(),
       navigateDown: vi.fn(),
       handleSubmit: vi.fn(),
+      resetHistoryNav: vi.fn(),
     };
     mockedUseInputHistory.mockReturnValue(mockInputHistory);
 
@@ -738,6 +739,25 @@ describe('InputPrompt', () => {
     await wait();
 
     expect(props.onSubmit).toHaveBeenCalledWith('/clear');
+    unmount();
+  });
+
+  it('should reset history navigation after submitting on Enter', async () => {
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: false,
+      isPerfectMatch: false,
+    });
+    props.buffer.setText('a prompt from history');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\r');
+    await wait();
+
+    expect(props.onSubmit).toHaveBeenCalledWith('a prompt from history');
+    expect(mockInputHistory.resetHistoryNav).toHaveBeenCalled();
     unmount();
   });
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -273,6 +273,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     [],
   );
 
+  // Ref to inputHistory.resetHistoryNav, populated after useInputHistory runs.
+  // Needed because handleSubmitAndClear is passed into useInputHistory as
+  // onSubmit, so we can't reference inputHistory directly here without a cycle.
+  const resetHistoryNavRef = useRef<() => void>(() => {});
+
   const handleSubmitAndClear = useCallback(
     (submittedValue: string) => {
       // Expand any large paste placeholders to their full content before submitting
@@ -309,6 +314,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       // if onSubmit triggers a re-render while the buffer still holds the old value.
       buffer.setText('');
       onSubmit(finalValue);
+
+      // Reset history navigation so the next Up-arrow starts from the newest
+      // entry rather than advancing from whatever index the user picked.
+      resetHistoryNavRef.current();
 
       // Dismiss follow-up suggestion after submit
       followup.dismiss();
@@ -352,6 +361,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     currentQuery: buffer.text,
     onChange: customSetTextAndResetCompletionSignal,
   });
+
+  resetHistoryNavRef.current = inputHistory.resetHistoryNav;
 
   // When an arena session starts (agents appear), reset history position so
   // that pressing down-arrow immediately focuses the agent tab bar instead


### PR DESCRIPTION
## TLDR

When a user navigates up through their prompt history with the arrow keys and presses Enter on an older entry, the submitted prompt should move to the most recent position — so the next Up arrow surfaces it first. Today it doesn't: the entry stays wherever it was in the list, and in many cases a stale copy also remains at its old position. This PR fixes both problems so history follows an intuitive most-recently-used ordering.

## Screenshots / Video Demo

N/A — behavior change, best validated interactively. See the Reviewer Test Plan below.

## Dive Deeper

Two distinct bugs interact to produce the reported behavior:

**1. History navigation index isn't reset on submit.** When the user uses the arrow keys to walk up into an older prompt and then hits Enter, the submit handler never clears the in-memory navigation position. On the very next Up press, navigation advances from that stale index rather than starting fresh from the newest entry, which in turn lands the user on an older (and now duplicate) entry and then blocks further Up presses until they press Down enough times to reset.

**2. History deduplication only collapses *consecutive* duplicates.** After a session appends a new entry, the combined (current-session + past-session) list is deduped by skipping adjacent repeats only. When the user resubmits a prompt that already existed elsewhere in history, the original occurrence is preserved — so the same text ends up appearing in two positions and Up-arrow navigation eventually surfaces the old copy again.

The fix addresses both:

- On submit, explicitly reset the history-navigation index so the next Up press starts from the newest entry.
- Dedupe the combined history by keeping only the first (newest) occurrence of each string, so resubmitting an older prompt promotes it to "most recent" and removes its stale copy.

The second change is effectively a small semantic shift from "collapse adjacent repeats" to "unique entries, newest wins" — which matches how most shells and editors treat input history.

## Reviewer Test Plan

1. Start a session in a directory with some existing prompt history (or submit 3–4 unique prompts first so there is history to navigate).
2. Press Up arrow repeatedly to land on an older prompt — ideally the oldest one.
3. Press Enter to submit it. Wait for the model response.
4. Press Up arrow once — the just-submitted prompt should be first (most recent).
5. Continue pressing Up — the entry should appear exactly once; the other unique prompts should follow in order. No duplicate of the submitted prompt should reappear at the tail.
6. Regression check: without submitting anything, press Up/Down arrows to walk through history. Behavior should be identical to before this change (navigation still scrolls through all unique entries, Down restores the original query).
7. Regression check: submit a brand-new prompt that was not already in history. Up arrow afterwards should show it first.

## Testing Matrix

|          | :apple: | :window: | :penguin: |
| -------- | ------- | -------- | --------- |
| npm run  | :question: | :question: | :white_check_mark: |
| npx      | :question: | :question: | :question: |
| Docker   | :question: | :question: | :question: |
| Podman   | :question: | -        | -         |
| Seatbelt | :question: | -        | -         |

## Linked issues / bugs

N/A — reported by a user, no existing GitHub issue.