### PR TITLE
fix(cli): stop slash completion render loop

### DIFF
--- a/packages/cli/src/ui/hooks/useResumeCommand.ts
+++ b/packages/cli/src/ui/hooks/useResumeCommand.ts
@@ -62,9 +62,11 @@ export function useResumeCommand(
   const { config, historyManager, startNewSession, setSessionName, remount } =
     options ?? {};
 
+  const hasHistoryManager = !!historyManager;
+  const { clearItems, loadHistory } = historyManager || {};
   const handleResume = useCallback(
     async (sessionId: string) => {
-      if (!config || !historyManager || !startNewSession) {
+      if (!config || !hasHistoryManager || !startNewSession) {
         return;
       }
 
@@ -88,8 +90,8 @@ export function useResumeCommand(
 
       // Reset UI history.
       const uiHistoryItems = buildResumedHistoryItems(sessionData, config);
-      historyManager.clearItems();
-      historyManager.loadHistory(uiHistoryItems);
+      clearItems?.();
+      loadHistory?.(uiHistoryItems);
 
       // Update session history core.
       config.startNewSession(sessionId, sessionData);
@@ -114,7 +116,9 @@ export function useResumeCommand(
     [
       closeResumeDialog,
       config,
-      historyManager,
+      hasHistoryManager,
+      clearItems,
+      loadHistory,
       startNewSession,
       setSessionName,
       remount,


### PR DESCRIPTION
## TLDR

Stabilize the `useResumeCommand()` callback dependencies so slash-command argument completion no longer re-runs on every render. This fixes the interactive CLI crash where typing `/model ` could get stuck on "Loading suggestions..." and repeatedly throw `Maximum update depth exceeded`.

## Screenshots / Video Demo

N/A — no permanent UI change. This PR fixes an interactive re-render loop in slash-command completion.

## Dive Deeper

### User-visible behavior

In the interactive CLI, typing a slash command that enters argument completion mode could trigger an infinite render loop. A concrete reproduction was:

1. Type `/model`
2. Type a trailing space
3. Observe the suggestions area stay on `Loading suggestions...`
4. The app repeatedly logs `Maximum update depth exceeded`

This was easiest to hit when the command's `completion()` returned `null` or an empty array, because the completion flow kept re-running while also writing completion state back into React.

### Root cause

The loop was not caused by `modelCommand` itself. The actual instability came from `useResumeCommand()`.

`useResumeCommand()` memoized `handleResume()` with the entire `historyManager` object in its dependency list. `useHistory()` returns a fresh object each render, even though its methods are individually stable. That meant:

- `handleResume()` got recreated every render
- `slashCommandActions` in `AppContainer` changed every render because it depends on `handleResume`
- `commandContext` in `slashCommandProcessor` changed every render because it depends on `actions`
- `useSlashCompletion()` treats `commandContext` as an effect dependency, so argument completion re-fired every render
- the completion effect kept setting loading/suggestion state, producing a render-feedback loop

So `/model ` merely exposed the bug because it enters slash argument completion and its `completion()` path was invoked over and over.

### Fix

This PR removes the unstable object dependency from `useResumeCommand()`:

- derive `hasHistoryManager` as a boolean guard
- destructure `clearItems` and `loadHistory` from `historyManager`
- depend on those stable callbacks instead of the whole `historyManager` object
- use optional calls when resetting and loading history

This keeps `handleResume()` referentially stable across normal renders, which in turn keeps `slashCommandActions`, `commandContext`, and slash completion stable.

## Reviewer Test Plan

1. Start the interactive CLI.
2. Type `/model` and then a space.
3. Confirm the app does **not** enter a render loop.
4. Confirm the UI does **not** spam `Maximum update depth exceeded`.
5. Confirm the suggestions area exits loading normally when no suggestions are returned.
6. Sanity check `/resume` still works and restores prior session history.

Good extra cases:

- `/model --`
- `/model --fast `
- any other slash command with argument completion that can return no results

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Related to the interactive slash-command completion render loop triggered by `/model ` when command argument completion returned no suggestions.
