### PR TITLE
chore: bump version to 0.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "workspaces": [
         "packages/*",
         "packages/channels/base",
@@ -16860,7 +16860,7 @@
     },
     "packages/channels/base": {
       "name": "@qwen-code/channel-base",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1"
       },
@@ -16870,7 +16870,7 @@
     },
     "packages/channels/dingtalk": {
       "name": "@qwen-code/channel-dingtalk",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base",
         "dingtalk-stream-sdk-nodejs": "^2.0.4"
@@ -16881,7 +16881,7 @@
     },
     "packages/channels/plugin-example": {
       "name": "@qwen-code/channel-plugin-example",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base",
         "ws": "^8.18.0"
@@ -16895,7 +16895,7 @@
     },
     "packages/channels/telegram": {
       "name": "@qwen-code/channel-telegram",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base",
         "grammy": "^1.41.1",
@@ -16908,7 +16908,7 @@
     },
     "packages/channels/weixin": {
       "name": "@qwen-code/channel-weixin",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base"
       },
@@ -16918,7 +16918,7 @@
     },
     "packages/cli": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
         "@google/genai": "1.30.0",
@@ -17577,7 +17577,7 @@
     },
     "packages/core": {
       "name": "@qwen-code/qwen-code-core",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.36.1",
@@ -21021,7 +21021,7 @@
     },
     "packages/vscode-ide-companion": {
       "name": "qwen-code-vscode-ide-companion",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "LICENSE",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
@@ -21268,7 +21268,7 @@
     },
     "packages/web-templates": {
       "name": "@qwen-code/web-templates",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "devDependencies": {
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
@@ -21796,7 +21796,7 @@
     },
     "packages/webui": {
       "name": "@qwen-code/webui",
-      "version": "0.15.0",
+      "version": "0.15.1",
       "license": "MIT",
       "dependencies": {
         "markdown-it": "^14.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "engines": {
     "node": ">=20.0.0"
   },
@@ -18,7 +18,7 @@
     "url": "git+https://github.com/QwenLM/qwen-code.git"
   },
   "config": {
-    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.15.0"
+    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.15.1"
   },
   "scripts": {
     "start": "cross-env node scripts/start.js",

--- a/packages/channels/base/package.json
+++ b/packages/channels/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-base",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Base channel infrastructure for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/dingtalk/package.json
+++ b/packages/channels/dingtalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-dingtalk",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "DingTalk channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/plugin-example/package.json
+++ b/packages/channels/plugin-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-plugin-example",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/telegram/package.json
+++ b/packages/channels/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-telegram",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Telegram channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/weixin/package.json
+++ b/packages/channels/weixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-weixin",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "WeChat (Weixin) channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Qwen Code",
   "repository": {
     "type": "git",
@@ -33,7 +33,7 @@
     "dist"
   ],
   "config": {
-    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.15.0"
+    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.15.1"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.14.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code-core",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Qwen Code Core",
   "repository": {
     "type": "git",

--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -2,7 +2,7 @@
   "name": "qwen-code-vscode-ide-companion",
   "displayName": "Qwen Code Companion",
   "description": "Enable Qwen Code with direct access to your VS Code workspace.",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "publisher": "qwenlm",
   "icon": "assets/icon.png",
   "repository": {

--- a/packages/web-templates/package.json
+++ b/packages/web-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/web-templates",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Web templates bundled as embeddable JS/CSS strings",
   "repository": {
     "type": "git",

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/webui",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Shared UI components for Qwen Code packages",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## TLDR

Bump version from 0.15.0 to 0.15.1 across all packages and update sandbox image reference.

## Screenshots / Video Demo

<!--
Please attach a screenshot or short video showing your change in action.
This helps reviewers understand the change quickly and prioritize reviews.

- For bug fixes: show the before/after behavior.
- For features: show the new functionality in use.
- For refactors or internal changes with no visible effect: write "N/A — no user-facing change" and briefly explain why.

PRs with visual demos typically get reviewed much faster!
-->

## Dive Deeper

This is a version bump patch update affecting:
- Root package.json and package-lock.json
- All package.json files across packages (channels, cli, core, vscode-ide-companion, web-templates, webui, plugin-example)
- Sandbox container image reference updated to v0.15.1

## Reviewer Test Plan

Standard version bump - no functional changes. Verify:
- All package.json files show version 0.15.1
- package-lock.json is consistent
- Sandbox image reference is updated

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

No linked issues

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)