### PR TITLE
fix(sdk-java): pass custom env to CLI process

### DIFF
--- a/packages/sdk-java/qwencode/src/main/java/com/alibaba/qwen/code/cli/transport/process/ProcessTransport.java
+++ b/packages/sdk-java/qwencode/src/main/java/com/alibaba/qwen/code/cli/transport/process/ProcessTransport.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.lang.ProcessBuilder.Redirect;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -102,6 +103,13 @@ public class ProcessTransport implements Transport {
                 .redirectError(Redirect.PIPE)
                 .redirectErrorStream(false)
                 .directory(new File(transportOptionsAdapter.getCwd()));
+
+        Map<String, String> env = transportOptionsAdapter.getHandledTransportOptions().getEnv();
+        if (env != null) {
+            Map<String, String> processEnv = processBuilder.environment();
+            processEnv.clear();
+            processEnv.putAll(env);
+        }
 
         process = processBuilder.start();
         processInput = new BufferedWriter(new OutputStreamWriter(process.getOutputStream()));

--- a/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/transport/process/ProcessTransportTest.java
+++ b/packages/sdk-java/qwencode/src/test/java/com/alibaba/qwen/code/cli/transport/process/ProcessTransportTest.java
@@ -1,6 +1,10 @@
 package com.alibaba.qwen.code.cli.transport.process;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
@@ -16,18 +20,41 @@ import com.alibaba.qwen.code.cli.transport.Transport;
 import com.alibaba.qwen.code.cli.transport.TransportOptions;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ProcessTransportTest {
 
     private static final Logger logger = LoggerFactory.getLogger(ProcessTransportTest.class);
+    private static final String CUSTOM_ENV_NAME = "QWEN_SDK_TEST_ENV";
+    private static final String CUSTOM_ENV_VALUE = "from-set-env";
+
+    @TempDir
+    Path tempDir;
 
     @Test
     void shouldStartAndCloseSuccessfully() throws IOException {
         TransportOptions transportOptions = new TransportOptions();
         Transport transport = new ProcessTransport(transportOptions);
         transport.close();
+    }
+
+    @Test
+    void shouldPassCustomEnvToProcess() throws IOException {
+        Path executable = createEnvPrinter();
+        TransportOptions transportOptions = new TransportOptions()
+                .setPathToQwenExecutable(executable.toString())
+                .setEnv(Collections.singletonMap(CUSTOM_ENV_NAME, CUSTOM_ENV_VALUE));
+
+        ProcessTransport transport = new ProcessTransport(transportOptions);
+        try {
+            assertEquals(CUSTOM_ENV_VALUE, transport.processOutput.readLine());
+        } finally {
+            transport.close();
+        }
     }
 
     @Test
@@ -82,6 +109,17 @@ class ProcessTransportTest {
         transport.inputWaitForOneLine(CLIControlRequest.create(new CLIControlInitializeRequest()).toString());
         transport.inputWaitForMultiLine(new SDKUserMessage().setContent("您好").toString(),
                 line -> "result".equals(JSON.parseObject(line).getString("type")));
+    }
+
+    private Path createEnvPrinter() throws IOException {
+        boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win");
+        Path executable = tempDir.resolve(isWindows ? "print-env.cmd" : "print-env.sh");
+        String script = isWindows
+                ? "@echo off\r\necho %" + CUSTOM_ENV_NAME + "%\r\n"
+                : "#!/bin/sh\nprintf '%s\\n' \"$" + CUSTOM_ENV_NAME + "\"\n";
+        Files.write(executable, script.getBytes(StandardCharsets.UTF_8));
+        executable.toFile().setExecutable(true);
+        return executable;
     }
 
 }


### PR DESCRIPTION
## TLDR

Fixes #3536.

Apply `TransportOptions.setEnv(...)` to the Java SDK `ProcessBuilder` before starting the Qwen Code CLI subprocess. The adapter already merges `System.getenv()` with the caller-provided env map, but the merged map was never wired into the child process.

## Screenshots / Video Demo

Terminal evidence:

Before this change, the focused regression failed because the child process printed an empty value:

```console
expected: <from-set-env> but was: <>
```

After this change:

```console
mvn -Dtest=ProcessTransportTest#shouldPassCustomEnvToProcess test
# BUILD SUCCESS; Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

## Dive Deeper

`TransportOptionsAdapter#addDefaultTransportOptions()` already builds the intended subprocess environment by starting from `System.getenv()` and overlaying `TransportOptions.getEnv()`.

`ProcessTransport#start()` now copies that handled env map into `processBuilder.environment()` before `start()`, so Java SDK callers can pass values such as proxy, sandbox, model, or other runtime configuration variables to the CLI process as documented.

## Reviewer Test Plan

1. From `packages/sdk-java/qwencode`, run `mvn -Dtest=ProcessTransportTest#shouldPassCustomEnvToProcess test`.
2. Confirm the new test creates a temporary executable, passes `QWEN_SDK_TEST_ENV` through `TransportOptions.setEnv(...)`, and reads the value from the child process output.
3. Inspect `ProcessTransport#start()` and confirm the handled env map is applied before `processBuilder.start()`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

Java SDK validation run on macOS:

```console
mvn -Dtest=ProcessTransportTest#shouldPassCustomEnvToProcess test
mvn -DskipTests test
mvn checkstyle:check
git diff --check
```

All passed. I did not run `npm run preflight`; this patch is limited to the Maven-based Java SDK package, and the existing package test file includes live-CLI tests that can depend on local auth/provider state.

## Linked issues / bugs

Fixes #3536
