### PR TITLE
fix(cli): disable Kitty keyboard protocol on SIGINT to prevent garbled 9;5u output

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -675,6 +675,7 @@ describe('startInteractiveUI', () => {
 
   vi.mock('./ui/utils/kittyProtocolDetector.js', () => ({
     detectAndEnableKittyProtocol: vi.fn(() => Promise.resolve(true)),
+    disableKittyProtocol: vi.fn(),
   }));
 
   vi.mock('./ui/utils/updateCheck.js', () => ({

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -46,7 +46,10 @@ import { VimModeProvider } from './ui/contexts/VimModeContext.js';
 import { AgentViewProvider } from './ui/contexts/AgentViewContext.js';
 import { useKittyKeyboardProtocol } from './ui/hooks/useKittyKeyboardProtocol.js';
 import { themeManager, AUTO_THEME_NAME } from './ui/themes/theme-manager.js';
-import { detectAndEnableKittyProtocol } from './ui/utils/kittyProtocolDetector.js';
+import {
+  detectAndEnableKittyProtocol,
+  disableKittyProtocol,
+} from './ui/utils/kittyProtocolDetector.js';
 import { checkForUpdates } from './ui/utils/updateCheck.js';
 import {
   cleanupCheckpoints,
@@ -289,6 +292,10 @@ export async function startInteractiveUI(
   registerCleanup(async () => {
     remoteInputWatcher?.shutdown();
     await dualOutputBridge?.shutdown();
+    // Explicitly disable the Kitty keyboard protocol before unmounting Ink so
+    // that the disable escape sequence is written while stdout is still fully
+    // operational, preventing garbled terminal output after the app exits.
+    disableKittyProtocol();
     instance.unmount();
     restoreTerminalRedrawOptimizer();
   });

--- a/packages/cli/src/ui/utils/kittyProtocolDetector.ts
+++ b/packages/cli/src/ui/utils/kittyProtocolDetector.ts
@@ -86,9 +86,11 @@ export async function detectAndEnableKittyProtocol(): Promise<boolean> {
           protocolSupported = true;
           protocolEnabled = true;
 
-          // Set up cleanup on exit
+          // Set up cleanup on exit (exit covers process.exit() calls,
+          // SIGTERM/SIGINT cover signal-based terminations).
           process.on('exit', disableProtocol);
           process.on('SIGTERM', disableProtocol);
+          process.on('SIGINT', disableProtocol);
         }
 
         detectionComplete = true;
@@ -114,6 +116,15 @@ function disableProtocol() {
     process.stdout.write('\x1b[<u');
     protocolEnabled = false;
   }
+}
+
+/**
+ * Explicitly disables the Kitty keyboard protocol. Should be called during
+ * application cleanup before process.exit() to ensure the terminal is restored
+ * even if the 'exit' event handler does not fire in time (e.g. on SIGKILL).
+ */
+export function disableKittyProtocol(): void {
+  disableProtocol();
 }
 
 export function isKittyProtocolEnabled(): boolean {


### PR DESCRIPTION
## TLDR

Fixes a bug ([#3528](https://github.com/QwenLM/qwen-code/issues/3528)) where exiting the CLI in a Kitty-capable terminal (iTerm2, Kitty, WezTerm) leaves the terminal in Kitty keyboard protocol mode. Subsequent Ctrl+C presses in the shell output garbled text like `9;5u9;5u9;5u`.

The root cause is that `kittyProtocolDetector.ts` registered cleanup on `'exit'` and `'SIGTERM'` but **omitted `SIGINT`**. Any termination via SIGINT skipped the `ESC[<u` disable sequence entirely.

## Screenshots / Video Demo

Before fix (GLOBAL v0.15.0, unpatched — SIGINT path):
```
[GLOBAL v0.15.0] Kitty enabled. Sending SIGINT to PID=18987
[GLOBAL v0.15.0] After SIGINT: kittyDisabled=false
[GLOBAL v0.15.0] BUG: Kitty NOT disabled -> garbled 9;5u after exit
```

After fix (patched — SIGINT path):
```
[PATCHED local] Kitty enabled. Sending SIGINT to PID=19037
[PATCHED local] After SIGINT: kittyDisabled=true
[PATCHED local] OK: Kitty disabled by SIGINT handler -> terminal properly restored
```

## Dive Deeper

### How the bug manifests

When a Kitty-capable terminal is in use, the CLI sends `ESC[>1u` at startup to enable the Kitty keyboard protocol. In this mode the terminal encodes Ctrl+C as `ESC[99;5u` instead of the traditional `0x03`.

On a normal double-Ctrl+C exit the CLI calls `runExitCleanup()` which goes through Node.js's `process.exit()`, which fires the `'exit'` event, which calls `disableProtocol()` and writes `ESC[<u` — the terminal is restored. ✅

However when the process is terminated via **SIGINT** (e.g. `kill -INT <pid>`, a process manager, or certain shell integrations), Node.js delivers SIGINT, the process exits, but the `'exit'` event **may not reliably emit the ESC[<u** because the original code registered no `SIGINT` handler at all — the process just dies. The terminal stays in Kitty mode. Now in the shell, pressing Ctrl+C sends `ESC[99;5u`; the shell echoes the unrecognised suffix `9;5u` as literal text.

### Changes

**`packages/cli/src/ui/utils/kittyProtocolDetector.ts`**
- Add `process.on('SIGINT', disableProtocol)` alongside the existing `'exit'` and `'SIGTERM'` handlers so that SIGINT-based terminations also restore the terminal.
- Export a new `disableKittyProtocol()` function to allow explicit call sites.

**`packages/cli/src/gemini.tsx`**
- Call `disableKittyProtocol()` in the `registerCleanup` callback **before** `instance.unmount()`. This ensures the disable escape sequence is written while stdout is still fully operational, regardless of exit path (defensive belt-and-suspenders over the signal handlers).

## Reviewer Test Plan

### Automated E2E (recommended, no Kitty terminal required)

The test script uses `@lydell/node-pty` to simulate a Kitty-capable terminal by injecting the protocol detection responses, then sends SIGINT to the child process and checks whether `ESC[<u` was emitted before the process died.

```bash
cd /path/to/qwen-code

# Test against globally installed qwen (should show BUG)
node scripts/test-sigint-kitty.mjs

# Build the fix and re-run (should show OK)
npm run build && npm run bundle
node scripts/test-sigint-kitty.mjs
```

Expected output after fix:
```
=== SIGINT test: does SIGINT disable Kitty protocol? ===

[GLOBAL v0.15.0 (unpatched)] Kitty enabled. Sending SIGINT to PID=...
[GLOBAL v0.15.0 (unpatched)] After SIGINT: kittyDisabled=false
[GLOBAL v0.15.0 (unpatched)] BUG: Kitty NOT disabled -> garbled 9;5u after exit

[PATCHED local (with fix)] Kitty enabled. Sending SIGINT to PID=...
[PATCHED local (with fix)] After SIGINT: kittyDisabled=true
[PATCHED local (with fix)] OK: Kitty disabled by SIGINT handler -> terminal properly restored
```

### Manual verification (requires iTerm2 ≥ 3.5, Kitty, or WezTerm)

**Reproducing the bug (unpatched `qwen`):**

1. Open iTerm2 (or another Kitty-protocol terminal).
2. Run `qwen` and wait for the interactive prompt.
3. From a second terminal, send SIGINT: `kill -INT $(pgrep -f 'cli.js' | head -1)`
4. Back in the first terminal, press Ctrl+C a few times.
5. **Expected (bug):** you see `9;5u9;5u9;5u` echoed after each keypress.

**Verifying the fix:**

1. Build the patched bundle: `npm run build && npm run bundle`
2. Run `node dist/cli.js` and wait for the interactive prompt.
3. From a second terminal: `kill -INT $(pgrep -f 'cli.js' | head -1)`
4. Back in the first terminal, press Ctrl+C a few times.
5. **Expected (fixed):** terminal behaves normally, no `9;5u` output.

**Manual test result (macOS arm64, iTerm2 3.5.10):**
- ✅ Bug reproduced on unpatched `qwen` v0.15.0
- ✅ No garbled output after applying this fix

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

Fixes #3528