### PR TITLE
feat(cli): add OSC terminal notifications for iTerm2, Kitty, Ghostty and cmux

### DIFF
--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -411,15 +411,25 @@ const SETTINGS_SCHEMA = {
           'or set a specific language.',
         showInDialog: true,
       },
-      terminalBell: {
-        type: 'boolean',
-        label: 'Terminal Bell Notification',
+      notifications: {
+        type: 'enum',
+        label: 'Notifications',
         category: 'General',
         requiresRestart: false,
-        default: true,
+        default: 'auto',
         description:
-          'Play terminal bell sound when response completes or needs approval.',
+          'Terminal notification channel when agent finishes or needs attention. ' +
+          '"auto" detects your terminal (iTerm2/Kitty/Ghostty → native notification, others → bell). ' +
+          'Or choose a specific channel.',
         showInDialog: true,
+        options: [
+          { value: 'auto', label: 'Auto-detect' },
+          { value: 'iterm2', label: 'iTerm2' },
+          { value: 'kitty', label: 'Kitty' },
+          { value: 'ghostty', label: 'Ghostty' },
+          { value: 'terminal_bell', label: 'Terminal Bell' },
+          { value: 'notifications_disabled', label: 'Disabled' },
+        ],
       },
       chatRecording: {
         type: 'boolean',

--- a/packages/cli/src/services/notificationService.ts
+++ b/packages/cli/src/services/notificationService.ts
@@ -1,0 +1,110 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Notification routing service.
+ *
+ * Routes notifications to the appropriate terminal channel based on
+ * user configuration (`notifications` setting) and auto-detected
+ * terminal type.
+ *
+ * Channel priority in `auto` mode:
+ *   iTerm.app → OSC 9 (native notification)
+ *   kitty     → OSC 99 (desktop notification protocol)
+ *   ghostty   → OSC 777 (notify)
+ *   others    → terminal bell fallback
+ *
+ * Reference: Claude Code's `src/services/notifier.ts`
+ */
+
+import { createDebugLogger } from '@qwen-code/qwen-code-core';
+import type { TerminalNotification } from '../ui/hooks/useTerminalNotification.js';
+import { detectTerminal, generateKittyId } from '../utils/osc.js';
+
+const debugLogger = createDebugLogger('NOTIFICATION_SERVICE');
+
+export type NotificationChannel =
+  | 'auto'
+  | 'iterm2'
+  | 'kitty'
+  | 'ghostty'
+  | 'terminal_bell'
+  | 'notifications_disabled';
+
+export interface NotificationOptions {
+  message: string;
+  title?: string;
+}
+
+const DEFAULT_TITLE = 'Qwen Code';
+
+/**
+ * Send a notification through the configured channel.
+ *
+ * @returns The channel method that was actually used, or 'disabled'/'none'.
+ */
+export function sendNotification(
+  opts: NotificationOptions,
+  terminal: TerminalNotification,
+  channel: NotificationChannel,
+): string {
+  const title = opts.title ?? DEFAULT_TITLE;
+
+  try {
+    switch (channel) {
+      case 'auto':
+        return sendAuto(opts, terminal);
+      case 'iterm2':
+        terminal.notifyITerm2({ ...opts, title });
+        return 'iterm2';
+      case 'kitty':
+        terminal.notifyKitty({ ...opts, title, id: generateKittyId() });
+        return 'kitty';
+      case 'ghostty':
+        terminal.notifyGhostty({ ...opts, title });
+        return 'ghostty';
+      case 'terminal_bell':
+        terminal.notifyBell();
+        return 'terminal_bell';
+      case 'notifications_disabled':
+        return 'disabled';
+      default:
+        return 'none';
+    }
+  } catch (error) {
+    debugLogger.warn('Failed to send notification:', error);
+    return 'error';
+  }
+}
+
+function sendAuto(
+  opts: NotificationOptions,
+  terminal: TerminalNotification,
+): string {
+  const title = opts.title ?? DEFAULT_TITLE;
+  const terminalType = detectTerminal();
+
+  switch (terminalType) {
+    case 'iTerm.app':
+      terminal.notifyITerm2({ ...opts, title });
+      return 'iterm2';
+    case 'kitty':
+      terminal.notifyKitty({ ...opts, title, id: generateKittyId() });
+      return 'kitty';
+    case 'ghostty':
+      terminal.notifyGhostty({ ...opts, title });
+      return 'ghostty';
+    case 'Apple_Terminal':
+      // Apple Terminal doesn't support OSC notifications;
+      // fall through to bell
+      terminal.notifyBell();
+      return 'terminal_bell';
+    default:
+      // Unknown terminal — bell is the safest fallback
+      terminal.notifyBell();
+      return 'terminal_bell';
+  }
+}

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -131,6 +131,11 @@ import { useMcpDialog } from './hooks/useMcpDialog.js';
 import { useHooksDialog } from './hooks/useHooksDialog.js';
 import { useMemoryDialog } from './hooks/useMemoryDialog.js';
 import { useAttentionNotifications } from './hooks/useAttentionNotifications.js';
+import {
+  TerminalWriteProvider,
+  buildTerminalNotification,
+} from './hooks/useTerminalNotification.js';
+import { useTabStatus } from './hooks/useTabStatus.js';
 import { useContextualTips } from './hooks/useContextualTips.js';
 import { getTipHistory } from '../services/tips/index.js';
 import { useRemoteInput } from '../remoteInput/RemoteInputContext.js';
@@ -293,6 +298,20 @@ export const AppContainer = (props: AppContainerProps) => {
   const { columns: terminalWidth, rows: terminalHeight } = useTerminalSize();
   const { stdin, setRawMode } = useStdin();
   const { stdout } = useStdout();
+
+  // Raw write function for terminal escape sequences (bypasses Ink)
+  const writeRaw = useCallback(
+    (data: string) => {
+      stdout?.write(data);
+    },
+    [stdout],
+  );
+
+  // Terminal notification helpers (constructed directly, not via context)
+  const terminal = useMemo(
+    () => buildTerminalNotification(writeRaw),
+    [writeRaw],
+  );
 
   // Additional hooks moved from App.tsx
   const { stats: sessionStats, startNewSession } = useSessionStats();
@@ -1198,6 +1217,9 @@ export const AppContainer = (props: AppContainerProps) => {
   // Terminal tab progress bar (OSC 9;4) for iTerm2/Ghostty
   useTerminalProgress(streamingState, isToolExecuting(pendingHistoryItems));
 
+  // Terminal tab status indicator (OSC 21337) for cmux sidebar
+  useTabStatus(streamingState, writeRaw);
+
   cancelHandlerRef.current = useCallback(() => {
     const pendingHistoryItems = [
       ...pendingSlashCommandHistoryItems,
@@ -1685,6 +1707,7 @@ export const AppContainer = (props: AppContainerProps) => {
     elapsedTime,
     settings,
     config,
+    terminal,
   });
 
   // Dialog close functionality
@@ -2418,23 +2441,25 @@ export const AppContainer = (props: AppContainerProps) => {
   );
 
   return (
-    <UIStateContext.Provider value={uiState}>
-      <UIActionsContext.Provider value={uiActions}>
-        <ConfigContext.Provider value={config}>
-          <AppContext.Provider
-            value={{
-              version: props.version,
-              startupWarnings: props.startupWarnings || [],
-            }}
-          >
-            <CompactModeProvider value={compactModeValue}>
-              <ShellFocusContext.Provider value={isFocused}>
-                <App />
-              </ShellFocusContext.Provider>
-            </CompactModeProvider>
-          </AppContext.Provider>
-        </ConfigContext.Provider>
-      </UIActionsContext.Provider>
-    </UIStateContext.Provider>
+    <TerminalWriteProvider value={writeRaw}>
+      <UIStateContext.Provider value={uiState}>
+        <UIActionsContext.Provider value={uiActions}>
+          <ConfigContext.Provider value={config}>
+            <AppContext.Provider
+              value={{
+                version: props.version,
+                startupWarnings: props.startupWarnings || [],
+              }}
+            >
+              <CompactModeProvider value={compactModeValue}>
+                <ShellFocusContext.Provider value={isFocused}>
+                  <App />
+                </ShellFocusContext.Provider>
+              </CompactModeProvider>
+            </AppContext.Provider>
+          </ConfigContext.Provider>
+        </UIActionsContext.Provider>
+      </UIStateContext.Provider>
+    </TerminalWriteProvider>
   );
 };

--- a/packages/cli/src/ui/hooks/useAttentionNotifications.test.ts
+++ b/packages/cli/src/ui/hooks/useAttentionNotifications.test.ts
@@ -8,19 +8,31 @@ import { renderHook } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { StreamingState } from '../types.js';
 import {
-  AttentionNotificationReason,
-  notifyTerminalAttention,
-} from '../../utils/attentionNotification.js';
-import {
   LONG_TASK_NOTIFICATION_THRESHOLD_SECONDS,
   useAttentionNotifications,
 } from './useAttentionNotifications.js';
 import type { LoadedSettings } from '../../config/settings.js';
+import type { TerminalNotification } from './useTerminalNotification.js';
+
+vi.mock('../../services/notificationService.js', () => ({
+  sendNotification: vi.fn(),
+}));
+
+const { sendNotification: mockedSendNotification } = await import(
+  '../../services/notificationService.js'
+);
+
+const mockTerminal: TerminalNotification = {
+  notifyITerm2: vi.fn(),
+  notifyKitty: vi.fn(),
+  notifyGhostty: vi.fn(),
+  notifyBell: vi.fn(),
+};
 
 const mockSettings: LoadedSettings = {
   merged: {
     general: {
-      terminalBell: true,
+      notifications: 'auto',
     },
   },
 } as LoadedSettings;
@@ -28,24 +40,14 @@ const mockSettings: LoadedSettings = {
 const mockSettingsDisabled: LoadedSettings = {
   merged: {
     general: {
-      terminalBell: false,
+      notifications: 'notifications_disabled',
     },
   },
 } as LoadedSettings;
 
-vi.mock('../../utils/attentionNotification.js', () => ({
-  notifyTerminalAttention: vi.fn(),
-  AttentionNotificationReason: {
-    ToolApproval: 'tool_approval',
-    LongTaskComplete: 'long_task_complete',
-  },
-}));
-
-const mockedNotify = vi.mocked(notifyTerminalAttention);
-
 describe('useAttentionNotifications', () => {
   beforeEach(() => {
-    mockedNotify.mockReset();
+    vi.mocked(mockedSendNotification).mockReset();
   });
 
   const render = (
@@ -58,6 +60,7 @@ describe('useAttentionNotifications', () => {
           streamingState: StreamingState.Idle,
           elapsedTime: 0,
           settings: mockSettings,
+          terminal: mockTerminal,
           ...props,
         },
       },
@@ -72,13 +75,11 @@ describe('useAttentionNotifications', () => {
         streamingState: StreamingState.WaitingForConfirmation,
         elapsedTime: 0,
         settings: mockSettings,
+        terminal: mockTerminal,
       },
     });
 
-    expect(mockedNotify).toHaveBeenCalledWith(
-      AttentionNotificationReason.ToolApproval,
-      { enabled: true },
-    );
+    expect(mockedSendNotification).toHaveBeenCalledTimes(1);
   });
 
   it('notifies when focus is lost after entering approval wait state', () => {
@@ -93,10 +94,11 @@ describe('useAttentionNotifications', () => {
         streamingState: StreamingState.WaitingForConfirmation,
         elapsedTime: 0,
         settings: mockSettings,
+        terminal: mockTerminal,
       },
     });
 
-    expect(mockedNotify).toHaveBeenCalledTimes(1);
+    expect(mockedSendNotification).toHaveBeenCalledTimes(1);
   });
 
   it('sends a notification when a long task finishes while unfocused', () => {
@@ -108,6 +110,7 @@ describe('useAttentionNotifications', () => {
         streamingState: StreamingState.Responding,
         elapsedTime: LONG_TASK_NOTIFICATION_THRESHOLD_SECONDS + 5,
         settings: mockSettings,
+        terminal: mockTerminal,
       },
     });
 
@@ -117,13 +120,11 @@ describe('useAttentionNotifications', () => {
         streamingState: StreamingState.Idle,
         elapsedTime: 0,
         settings: mockSettings,
+        terminal: mockTerminal,
       },
     });
 
-    expect(mockedNotify).toHaveBeenCalledWith(
-      AttentionNotificationReason.LongTaskComplete,
-      { enabled: true },
-    );
+    expect(mockedSendNotification).toHaveBeenCalledTimes(1);
   });
 
   it('does not notify about long tasks when the CLI is focused', () => {
@@ -135,6 +136,7 @@ describe('useAttentionNotifications', () => {
         streamingState: StreamingState.Responding,
         elapsedTime: LONG_TASK_NOTIFICATION_THRESHOLD_SECONDS + 2,
         settings: mockSettings,
+        terminal: mockTerminal,
       },
     });
 
@@ -144,13 +146,11 @@ describe('useAttentionNotifications', () => {
         streamingState: StreamingState.Idle,
         elapsedTime: 0,
         settings: mockSettings,
+        terminal: mockTerminal,
       },
     });
 
-    expect(mockedNotify).not.toHaveBeenCalledWith(
-      AttentionNotificationReason.LongTaskComplete,
-      expect.anything(),
-    );
+    expect(mockedSendNotification).not.toHaveBeenCalled();
   });
 
   it('does not treat short responses as long tasks', () => {
@@ -162,6 +162,7 @@ describe('useAttentionNotifications', () => {
         streamingState: StreamingState.Responding,
         elapsedTime: 5,
         settings: mockSettings,
+        terminal: mockTerminal,
       },
     });
 
@@ -171,13 +172,14 @@ describe('useAttentionNotifications', () => {
         streamingState: StreamingState.Idle,
         elapsedTime: 0,
         settings: mockSettings,
+        terminal: mockTerminal,
       },
     });
 
-    expect(mockedNotify).not.toHaveBeenCalled();
+    expect(mockedSendNotification).not.toHaveBeenCalled();
   });
 
-  it('does not notify when terminalBell setting is disabled', () => {
+  it('does not notify when notifications are disabled', () => {
     const { rerender } = render({
       settings: mockSettingsDisabled,
     });
@@ -188,12 +190,10 @@ describe('useAttentionNotifications', () => {
         streamingState: StreamingState.WaitingForConfirmation,
         elapsedTime: 0,
         settings: mockSettingsDisabled,
+        terminal: mockTerminal,
       },
     });
 
-    expect(mockedNotify).toHaveBeenCalledWith(
-      AttentionNotificationReason.ToolApproval,
-      { enabled: false },
-    );
+    expect(mockedSendNotification).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/ui/hooks/useAttentionNotifications.ts
+++ b/packages/cli/src/ui/hooks/useAttentionNotifications.ts
@@ -6,18 +6,22 @@
 
 import { useEffect, useRef } from 'react';
 import { StreamingState } from '../types.js';
-import {
-  notifyTerminalAttention,
-  AttentionNotificationReason,
-} from '../../utils/attentionNotification.js';
 import type { LoadedSettings } from '../../config/settings.js';
 import type { Config } from '@qwen-code/qwen-code-core';
 import {
   fireNotificationHook,
   NotificationType,
 } from '@qwen-code/qwen-code-core';
+import type { TerminalNotification } from './useTerminalNotification.js';
+import {
+  sendNotification,
+  type NotificationChannel,
+} from '../../services/notificationService.js';
 
 export const LONG_TASK_NOTIFICATION_THRESHOLD_SECONDS = 20;
+
+const NOTIFICATION_TITLE = 'Qwen Code';
+const NOTIFICATION_MESSAGE = 'Qwen Code is waiting for your input';
 
 interface UseAttentionNotificationsOptions {
   isFocused: boolean;
@@ -25,6 +29,7 @@ interface UseAttentionNotificationsOptions {
   elapsedTime: number;
   settings: LoadedSettings;
   config?: Config;
+  terminal: TerminalNotification;
 }
 
 export const useAttentionNotifications = ({
@@ -33,8 +38,12 @@ export const useAttentionNotifications = ({
   elapsedTime,
   settings,
   config,
+  terminal,
 }: UseAttentionNotificationsOptions) => {
-  const terminalBellEnabled = settings?.merged?.general?.terminalBell ?? true;
+  const notificationChannel: NotificationChannel =
+    (settings?.merged?.general?.notifications as NotificationChannel) ?? 'auto';
+  const isDisabled = notificationChannel === 'notifications_disabled';
+
   const awaitingNotificationSentRef = useRef(false);
   const respondingElapsedRef = useRef(0);
   const idleNotificationSentRef = useRef(false);
@@ -43,23 +52,25 @@ export const useAttentionNotifications = ({
     if (
       streamingState === StreamingState.WaitingForConfirmation &&
       !isFocused &&
-      !awaitingNotificationSentRef.current
+      !awaitingNotificationSentRef.current &&
+      !isDisabled
     ) {
-      notifyTerminalAttention(AttentionNotificationReason.ToolApproval, {
-        enabled: terminalBellEnabled,
-      });
+      sendNotification(
+        { message: NOTIFICATION_MESSAGE, title: NOTIFICATION_TITLE },
+        terminal,
+        notificationChannel,
+      );
       awaitingNotificationSentRef.current = true;
     }
 
     if (streamingState !== StreamingState.WaitingForConfirmation || isFocused) {
       awaitingNotificationSentRef.current = false;
     }
-  }, [isFocused, streamingState, terminalBellEnabled]);
+  }, [isFocused, streamingState, notificationChannel, isDisabled, terminal]);
 
   useEffect(() => {
     if (streamingState === StreamingState.Responding) {
       respondingElapsedRef.current = elapsedTime;
-      // Reset idle notification flag when responding
       idleNotificationSentRef.current = false;
       return;
     }
@@ -68,12 +79,13 @@ export const useAttentionNotifications = ({
       const wasLongTask =
         respondingElapsedRef.current >=
         LONG_TASK_NOTIFICATION_THRESHOLD_SECONDS;
-      if (wasLongTask && !isFocused) {
-        notifyTerminalAttention(AttentionNotificationReason.LongTaskComplete, {
-          enabled: terminalBellEnabled,
-        });
+      if (wasLongTask && !isFocused && !isDisabled) {
+        sendNotification(
+          { message: NOTIFICATION_MESSAGE, title: NOTIFICATION_TITLE },
+          terminal,
+          notificationChannel,
+        );
       }
-      // Reset tracking for next task
       respondingElapsedRef.current = 0;
 
       // Fire idle_prompt notification hook when entering idle state
@@ -83,12 +95,11 @@ export const useAttentionNotifications = ({
         if (hooksEnabled && messageBus) {
           fireNotificationHook(
             messageBus,
-            'Qwen Code is waiting for your input',
+            NOTIFICATION_MESSAGE,
             NotificationType.IdlePrompt,
             'Waiting for input',
           ).catch(() => {
             // Silently ignore errors - fireNotificationHook has internal error handling
-            // and notification hooks should not block the idle flow
           });
         }
         idleNotificationSentRef.current = true;
@@ -96,7 +107,14 @@ export const useAttentionNotifications = ({
       return;
     }
 
-    // Reset idle notification flag when in WaitingForConfirmation state
     idleNotificationSentRef.current = false;
-  }, [streamingState, elapsedTime, isFocused, terminalBellEnabled, config]);
+  }, [
+    streamingState,
+    elapsedTime,
+    isFocused,
+    notificationChannel,
+    isDisabled,
+    config,
+    terminal,
+  ]);
 };

--- a/packages/cli/src/ui/hooks/useTabStatus.ts
+++ b/packages/cli/src/ui/hooks/useTabStatus.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * React hook that emits OSC 21337 tab-status sequences to set the
+ * colored indicator dot in cmux's sidebar, based on streaming state.
+ *
+ * States:
+ * - 🟢 Green (idle)   — waiting for user input
+ * - 🟠 Orange (busy)  — processing / streaming
+ * - 🔵 Blue (waiting) — waiting for user confirmation (tool approval)
+ *
+ * The indicator is cleared on process exit so the tab doesn't stay
+ * colored after qwen terminates.
+ */
+
+import { useEffect, useCallback } from 'react';
+import { StreamingState } from '../types.js';
+import {
+  tabStatus,
+  CLEAR_TAB_STATUS,
+  TAB_COLORS,
+  wrapForMultiplexer,
+} from '../../utils/osc.js';
+
+type WriteRaw = ((data: string) => void) | null;
+
+export function useTabStatus(
+  streamingState: StreamingState,
+  writeRaw: WriteRaw,
+): void {
+  const writeStatus = useCallback(
+    (seq: string) => {
+      writeRaw?.(wrapForMultiplexer(seq));
+    },
+    [writeRaw],
+  );
+
+  useEffect(() => {
+    if (!writeRaw) return;
+
+    switch (streamingState) {
+      case StreamingState.Idle:
+        writeStatus(tabStatus({ indicator: TAB_COLORS.IDLE, status: 'idle' }));
+        break;
+      case StreamingState.Responding:
+        writeStatus(tabStatus({ indicator: TAB_COLORS.BUSY, status: 'busy' }));
+        break;
+      case StreamingState.WaitingForConfirmation:
+        writeStatus(
+          tabStatus({
+            indicator: TAB_COLORS.WAITING,
+            status: 'waiting',
+          }),
+        );
+        break;
+      default:
+        break;
+    }
+  }, [streamingState, writeStatus, writeRaw]);
+
+  // Clear on process exit
+  useEffect(() => {
+    if (!writeRaw) return;
+    const clearOnExit = () => {
+      writeRaw(wrapForMultiplexer(CLEAR_TAB_STATUS));
+    };
+    process.on('exit', clearOnExit);
+    return () => {
+      process.removeListener('exit', clearOnExit);
+    };
+  }, [writeRaw]);
+}

--- a/packages/cli/src/ui/hooks/useTerminalNotification.ts
+++ b/packages/cli/src/ui/hooks/useTerminalNotification.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * React hook and context for writing raw escape sequences to the terminal,
+ * bypassing Ink's stdout interception.
+ *
+ * Provides per-protocol notification helpers (iTerm2 / Kitty / Ghostty / Bell)
+ * and terminal progress reporting.
+ *
+ * Reference: Claude Code's `src/ink/useTerminalNotification.ts`
+ */
+
+import { createContext, useCallback, useContext, useMemo } from 'react';
+import {
+  BEL,
+  wrapForMultiplexer,
+  oscITerm2Notify,
+  oscKittyNotify,
+  oscGhosttyNotify,
+} from '../../utils/osc.js';
+
+// ── TerminalWriteContext ────────────────────────────────────────────
+
+type WriteRaw = (data: string) => void;
+
+export const TerminalWriteContext = createContext<WriteRaw | null>(null);
+
+export const TerminalWriteProvider = TerminalWriteContext.Provider;
+
+// ── Hook interface ──────────────────────────────────────────────────
+
+export interface TerminalNotification {
+  notifyITerm2: (opts: { message: string; title?: string }) => void;
+  notifyKitty: (opts: { message: string; title: string; id: number }) => void;
+  notifyGhostty: (opts: { message: string; title: string }) => void;
+  notifyBell: () => void;
+}
+
+// ── Factory (no React context needed) ──────────────────────────────
+
+/**
+ * Build a TerminalNotification object from a raw write function.
+ * Useful when the caller already has stdout.write and does not need
+ * (or cannot use) TerminalWriteContext (e.g. in AppContainer's body
+ * before the provider is mounted in the JSX tree).
+ */
+export function buildTerminalNotification(
+  writeRaw: WriteRaw,
+): TerminalNotification {
+  return {
+    notifyITerm2({ message, title }) {
+      writeRaw(wrapForMultiplexer(oscITerm2Notify(title ?? '', message)));
+    },
+    notifyKitty({ message, title, id }) {
+      for (const seq of oscKittyNotify(title, message, id)) {
+        writeRaw(wrapForMultiplexer(seq));
+      }
+    },
+    notifyGhostty({ message, title }) {
+      writeRaw(wrapForMultiplexer(oscGhosttyNotify(title, message)));
+    },
+    notifyBell() {
+      // Raw BEL — inside tmux this triggers tmux's bell-action (window flag).
+      // Wrapping would make it opaque DCS payload and lose that fallback.
+      writeRaw(BEL);
+    },
+  };
+}
+
+// ── Hook ────────────────────────────────────────────────────────────
+
+export function useTerminalNotification(): TerminalNotification {
+  const writeRaw = useContext(TerminalWriteContext);
+  if (!writeRaw) {
+    throw new Error(
+      'useTerminalNotification must be used within TerminalWriteProvider',
+    );
+  }
+
+  const notifyITerm2 = useCallback(
+    ({ message, title }: { message: string; title?: string }) => {
+      writeRaw(wrapForMultiplexer(oscITerm2Notify(title ?? '', message)));
+    },
+    [writeRaw],
+  );
+
+  const notifyKitty = useCallback(
+    ({
+      message,
+      title,
+      id,
+    }: {
+      message: string;
+      title: string;
+      id: number;
+    }) => {
+      for (const seq of oscKittyNotify(title, message, id)) {
+        writeRaw(wrapForMultiplexer(seq));
+      }
+    },
+    [writeRaw],
+  );
+
+  const notifyGhostty = useCallback(
+    ({ message, title }: { message: string; title: string }) => {
+      writeRaw(wrapForMultiplexer(oscGhosttyNotify(title, message)));
+    },
+    [writeRaw],
+  );
+
+  const notifyBell = useCallback(() => {
+    writeRaw(BEL);
+  }, [writeRaw]);
+
+  return useMemo(
+    () => ({ notifyITerm2, notifyKitty, notifyGhostty, notifyBell }),
+    [notifyITerm2, notifyKitty, notifyGhostty, notifyBell],
+  );
+}

--- a/packages/cli/src/ui/hooks/useTerminalProgress.ts
+++ b/packages/cli/src/ui/hooks/useTerminalProgress.ts
@@ -7,6 +7,12 @@
 import { useEffect, useCallback } from 'react';
 import { useStdout } from 'ink';
 import { StreamingState } from '../types.js';
+import {
+  OSC,
+  BEL,
+  wrapForMultiplexer,
+  detectTerminal,
+} from '../../utils/osc.js';
 
 /**
  * OSC 9;4 progress sequences for terminal tab/title bar progress.
@@ -15,24 +21,6 @@ import { StreamingState } from '../types.js';
  * @see https://iterm2.com/documentation-escape-codes.html
  * @see https://learn.microsoft.com/en-us/windows/terminal/tutorials/progress-bar-sequences
  */
-const OSC = '\x1b]';
-const BEL = '\x07';
-
-/**
- * Wrap an OSC sequence for tmux/screen passthrough.
- * tmux requires DCS escape: \ePtmux;\e<seq>\e\\
- * screen requires DCS escape: \eP<seq>\e\\
- */
-function wrapForMultiplexer(seq: string): string {
-  if (process.env['TMUX']) {
-    return `\x1bPtmux;\x1b${seq}\x1b\\`;
-  }
-  if (process.env['STY']) {
-    return `\x1bP${seq}\x1b\\`;
-  }
-  return seq;
-}
-
 const PROGRESS_CLEAR = wrapForMultiplexer(`${OSC}9;4;0;${BEL}`);
 const PROGRESS_INDETERMINATE = wrapForMultiplexer(`${OSC}9;4;3;;${BEL}`);
 
@@ -40,7 +28,7 @@ function isProgressBarSupported(): boolean {
   // Don't emit escape sequences when stdout is not a TTY (CI, piped output,
   // redirected to log files, etc.)
   if (!process.stdout?.isTTY) return false;
-  const term = process.env['TERM_PROGRAM'];
+  const term = detectTerminal();
   if (term === 'iTerm.app') return true;
   if (term === 'ghostty') return true;
   if (process.env['ConEmuPID']) return true;

--- a/packages/cli/src/utils/osc.ts
+++ b/packages/cli/src/utils/osc.ts
@@ -1,0 +1,199 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * OSC (Operating System Command) escape sequence utilities for terminal
+ * notifications, tab status indicators, and multiplexer passthrough.
+ *
+ * Reference: Claude Code's `src/ink/termio/osc.ts`
+ */
+
+// ── Escape sequence primitives ──────────────────────────────────────
+
+export const ESC = '\x1b';
+export const BEL = '\x07';
+/** String Terminator — used by Kitty instead of BEL */
+export const ST = ESC + '\\';
+const OSC_PREFIX = ESC + ']';
+const SEP = ';';
+
+// ── OSC type codes ──────────────────────────────────────────────────
+
+export const OSC = {
+  /** iTerm2 notification / progress */
+  ITERM2: 9,
+  /** Kitty desktop notification protocol */
+  KITTY: 99,
+  /** Ghostty / cmux notification */
+  GHOSTTY: 777,
+  /** cmux tab status (indicator dot + status text) */
+  TAB_STATUS: 21337,
+} as const;
+
+// ── Terminal type detection ─────────────────────────────────────────
+
+export type TerminalType =
+  | 'iTerm.app'
+  | 'kitty'
+  | 'ghostty'
+  | 'Apple_Terminal'
+  | 'unknown';
+
+/**
+ * Detect the current terminal emulator from environment variables.
+ */
+export function detectTerminal(): TerminalType {
+  const term = process.env['TERM_PROGRAM'];
+  switch (term) {
+    case 'iTerm.app':
+      return 'iTerm.app';
+    case 'kitty':
+      return 'kitty';
+    case 'ghostty':
+      return 'ghostty';
+    case 'Apple_Terminal':
+      return 'Apple_Terminal';
+    default:
+      return 'unknown';
+  }
+}
+
+// ── Core OSC builders ───────────────────────────────────────────────
+
+/**
+ * Build an OSC escape sequence from parts.
+ * Uses ST terminator for Kitty (which doesn't support BEL in OSC),
+ * and BEL for all other terminals.
+ */
+export function osc(...parts: Array<string | number>): string {
+  const terminator = detectTerminal() === 'kitty' ? ST : BEL;
+  return `${OSC_PREFIX}${parts.join(SEP)}${terminator}`;
+}
+
+/**
+ * Wrap an OSC sequence for tmux / screen passthrough.
+ *
+ * - tmux: DCS `\ePtmux;\e<seq>\e\\` with ESC doubling inside
+ * - screen: DCS `\eP<seq>\e\\`
+ *
+ * BEL should NOT be wrapped — raw BEL triggers tmux's bell-action,
+ * whereas a wrapped BEL becomes an opaque DCS payload and is ignored.
+ */
+export function wrapForMultiplexer(sequence: string): string {
+  if (process.env['TMUX']) {
+    // tmux requires all ESC bytes inside the payload to be doubled
+    const escaped = sequence.replaceAll('\x1b', '\x1b\x1b');
+    return `\x1bPtmux;${escaped}\x1b\\`;
+  }
+  if (process.env['STY']) {
+    return `\x1bP${sequence}\x1b\\`;
+  }
+  return sequence;
+}
+
+// ── Notification helpers ────────────────────────────────────────────
+
+/**
+ * iTerm2 notification via OSC 9.
+ * Format: `\e]9;\n\n<title>:\n<message>\a`
+ */
+export function oscITerm2Notify(title: string, message: string): string {
+  const displayString = title ? `${title}:\n${message}` : message;
+  return osc(OSC.ITERM2, `\n\n${displayString}`);
+}
+
+/**
+ * Kitty desktop notification via OSC 99 (three-step protocol).
+ * Returns an array of sequences that must be written in order.
+ *
+ * @see https://sw.kovidgoyal.net/kitty/desktop-notifications/
+ */
+export function oscKittyNotify(
+  title: string,
+  message: string,
+  id: number,
+): string[] {
+  return [
+    osc(OSC.KITTY, `i=${id}:d=0:p=title`, title),
+    osc(OSC.KITTY, `i=${id}:p=body`, message),
+    osc(OSC.KITTY, `i=${id}:d=1:a=focus`, ''),
+  ];
+}
+
+/**
+ * Ghostty / cmux notification via OSC 777.
+ * Format: `\e]777;notify;<title>;<message>\a`
+ */
+export function oscGhosttyNotify(title: string, message: string): string {
+  return osc(OSC.GHOSTTY, 'notify', title, message);
+}
+
+// ── Tab Status (OSC 21337) ──────────────────────────────────────────
+
+export interface Color {
+  r: number;
+  g: number;
+  b: number;
+}
+
+export interface TabStatusFields {
+  indicator?: Color | null;
+  status?: string | null;
+  statusColor?: Color | null;
+}
+
+function colorToHex(c: Color): string {
+  return `#${[c.r, c.g, c.b].map((n) => n.toString(16).padStart(2, '0')).join('')}`;
+}
+
+/**
+ * Build an OSC 21337 tab status sequence for cmux.
+ * Supports indicator dot color, status text, and status text color.
+ */
+export function tabStatus(fields: TabStatusFields): string {
+  const parts: string[] = [];
+  if ('indicator' in fields) {
+    parts.push(
+      `indicator=${fields.indicator ? colorToHex(fields.indicator) : ''}`,
+    );
+  }
+  if ('status' in fields) {
+    parts.push(
+      `status=${fields.status?.replaceAll('\\', '\\\\').replaceAll(';', '\\;') ?? ''}`,
+    );
+  }
+  if ('statusColor' in fields) {
+    parts.push(
+      `status-color=${fields.statusColor ? colorToHex(fields.statusColor) : ''}`,
+    );
+  }
+  return osc(OSC.TAB_STATUS, parts.join(';'));
+}
+
+/** Clear all tab status fields */
+export const CLEAR_TAB_STATUS = tabStatus({
+  indicator: null,
+  status: null,
+  statusColor: null,
+});
+
+// ── Pre-defined tab status colors ───────────────────────────────────
+
+export const TAB_COLORS = {
+  /** Green — idle / ready for input */
+  IDLE: { r: 0x28, g: 0xa7, b: 0x45 } as Color,
+  /** Orange — busy / processing */
+  BUSY: { r: 0xf5, g: 0x9e, b: 0x0b } as Color,
+  /** Blue — waiting for user confirmation */
+  WAITING: { r: 0x3b, g: 0x82, b: 0xf6 } as Color,
+} as const;
+
+/**
+ * Generate a random Kitty notification ID.
+ */
+export function generateKittyId(): number {
+  return Math.floor(Math.random() * 10000);
+}

--- a/packages/cli/src/utils/settingsUtils.ts
+++ b/packages/cli/src/utils/settingsUtils.ts
@@ -291,7 +291,7 @@ const SETTINGS_DIALOG_ORDER: readonly string[] = [
   'ide.enabled',
   'ui.showLineNumbers',
   'ui.hideTips',
-  'general.terminalBell',
+  'general.notifications',
   'ui.enableWelcomeBack',
 
   // Git Behavior

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -101,10 +101,17 @@
           "type": "string",
           "default": "auto"
         },
-        "terminalBell": {
-          "description": "Play terminal bell sound when response completes or needs approval.",
-          "type": "boolean",
-          "default": true
+        "notifications": {
+          "description": "Terminal notification channel when agent finishes or needs attention. \"auto\" detects your terminal (iTerm2/Kitty/Ghostty → native notification, others → bell). Or choose a specific channel. Options: auto, iterm2, kitty, ghostty, terminal_bell, notifications_disabled",
+          "enum": [
+            "auto",
+            "iterm2",
+            "kitty",
+            "ghostty",
+            "terminal_bell",
+            "notifications_disabled"
+          ],
+          "default": "auto"
         },
         "chatRecording": {
           "description": "Enable saving chat history to disk. Disabling this will also prevent --continue and --resume from working.",


### PR DESCRIPTION
## Summary

Closes #2528

Adds native terminal notification support via OSC escape sequences, replacing the simple bell-only approach with protocol-aware routing that works across iTerm2, Kitty, Ghostty, and cmux.

### What changed

- **`packages/cli/src/utils/osc.ts`** (new): Foundation layer with OSC sequence builders for iTerm2 (OSC 9), Kitty (OSC 99), Ghostty (OSC 777), and cmux tab status (OSC 21337). Includes tmux/screen DCS passthrough wrapping and terminal detection.

- **`packages/cli/src/ui/hooks/useTerminalNotification.ts`** (new): React hook + context for writing raw escape sequences to the terminal bypassing Ink's stdout interception. Provides per-protocol notification helpers and a `buildTerminalNotification()` factory for use outside React context.

- **`packages/cli/src/ui/hooks/useTabStatus.ts`** (new): Hook that emits colored indicator dots in cmux's sidebar — green (idle), orange (busy), blue (waiting for confirmation).

- **`packages/cli/src/services/notificationService.ts`** (new): Notification routing service that auto-detects the terminal emulator or honors the user's explicit channel preference.

- **`packages/cli/src/config/settingsSchema.ts`**: Upgraded `terminalBell: boolean` → `notifications` enum with options: `auto`, `iterm2`, `kitty`, `ghostty`, `terminal_bell`, `notifications_disabled`. Shows in the settings dialog.

- **`packages/cli/src/ui/hooks/useAttentionNotifications.ts`**: Refactored to use the new `notificationService` and accept a `TerminalNotification` object.

- **`packages/cli/src/ui/hooks/useTerminalProgress.ts`**: Consolidated to reuse shared `osc.ts` utilities instead of duplicating OSC/BEL constants locally.

- **`packages/cli/src/ui/AppContainer.tsx`**: Wired up `TerminalWriteProvider`, `useTabStatus`, and the new notification flow.

### How it works

```
User sets notifications: "auto" (default)
  → notificationService.sendAuto() detects TERM_PROGRAM
  → Routes to appropriate OSC protocol
  → tmux/screen: auto-wrapped in DCS passthrough
```

### Supported terminals

| Terminal | Protocol | Notifications | Tab Status |
|----------|----------|:---:|:---:|
| iTerm2 | OSC 9 | ✅ | - |
| Kitty | OSC 99 | ✅ | - |
| Ghostty | OSC 777 | ✅ | - |
| cmux | OSC 21337 | - | ✅ |
| tmux/screen | DCS wrap | ✅ (passthrough) | - |
| Other | BEL | ✅ (fallback) | - |

## Test plan

- [ ] `npm run preflight` passes (typecheck, lint, build, all tests)
- [ ] Verify in iTerm2: tool approval and long-task completion trigger native notifications
- [ ] Verify in Kitty: notifications appear with title and body
- [ ] Verify in Ghostty: desktop notifications triggered
- [ ] Verify settings dialog shows notification channel dropdown
- [ ] Verify `notifications: "notifications_disabled"` suppresses all notifications
- [ ] Verify cmux tab status dots change color with streaming state
- [ ] Verify tmux passthrough: notifications reach the outer terminal