### PR TITLE
fix(cli): memoize useHistory() return to avoid unnecessary re-renders

### DIFF
--- a/packages/cli/src/ui/hooks/useHistoryManager.ts
+++ b/packages/cli/src/ui/hooks/useHistoryManager.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useMemo } from 'react';
 import type { HistoryItem } from '../types.js';
 
 // Type for the updater function passed to updateHistoryItem
@@ -101,11 +101,14 @@ export function useHistory(): UseHistoryManagerReturn {
     messageIdCounterRef.current = 0;
   }, []);
 
-  return {
-    history,
-    addItem,
-    updateItem,
-    clearItems,
-    loadHistory,
-  };
+  return useMemo(
+    () => ({
+      history,
+      addItem,
+      updateItem,
+      clearItems,
+      loadHistory,
+    }),
+    [history, addItem, updateItem, clearItems, loadHistory],
+  );
 }


### PR DESCRIPTION
# Backport: gemini-cli#10820 — memoize useHistory() return

## Motivation

Originated from [QwenLM/qwen-code#3530](https://github.com/QwenLM/qwen-code/issues/3530): on 0.15.0, typing `/model ` repeatedly throws `Maximum update depth exceeded`.

While investigating, we found that upstream Gemini CLI had already fixed the same instability at the hook boundary ~6 months earlier. This repo missed the fix because the `Sync upstream Gemini-CLI v0.8.2 (#838)` synced against a v0.8.2 tag cut from a commit that did not include it. This change backports it.

## Upstream PR Reference

[google-gemini/gemini-cli#10820](https://github.com/google-gemini/gemini-cli/pull/10820) — `Fix hooks to avoid unnecessary re-renders`

- commit `cd354aebe`
- author Tommaso Sciortino (scidomino)
- merged on 2025-10-09

> ## TLDR
>
> These hooks were not properly memoized and it was causing unnecessary re-renders.
>
> ## Dive Deeper
>
> Normally, this is not a super big deal but I spotted it while investigating #10517
>
> ## Reviewer Test Plan
>
> Basic smoke test is sufficient. This is a pure refactor.
>
> ## Linked issues / bugs
>
> Contributes to #10517