### PR TITLE
fix(insight): Harden insight facet normalization and empty qualitative handling

### DIFF
--- a/packages/cli/src/services/insight/generators/DataProcessor.test.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.test.ts
@@ -375,6 +375,44 @@ describe('DataProcessor', () => {
       });
     });
 
+    it('should ignore malformed count objects when aggregating facets', () => {
+      const facets = [
+        {
+          session_id: 's1',
+          underlying_goal: 'test',
+          goal_categories: null,
+          outcome: null,
+          user_satisfaction_counts: null,
+          Qwen_helpfulness: 'very_helpful',
+          session_type: 'single_task',
+          friction_counts: null,
+          friction_detail: '',
+          primary_success: null,
+          brief_summary: 'Test summary',
+        },
+      ] as unknown as SessionFacets[];
+
+      const result = (
+        dataProcessor as unknown as {
+          aggregateFacetsData(facets: SessionFacets[]): {
+            satisfactionAgg: Record<string, number>;
+            frictionAgg: Record<string, number>;
+            primarySuccessAgg: Record<string, number>;
+            outcomesAgg: Record<string, number>;
+            goalsAgg: Record<string, number>;
+          };
+        }
+      ).aggregateFacetsData(facets);
+
+      expect(result.satisfactionAgg).toEqual({});
+      expect(result.frictionAgg).toEqual({});
+      expect(result.primarySuccessAgg).toEqual({});
+      expect(result.goalsAgg).toEqual({});
+      expect(result.outcomesAgg).toEqual({
+        unclear_from_transcript: 1,
+      });
+    });
+
     it('should aggregate friction counts', () => {
       const facets: SessionFacets[] = [
         {
@@ -629,6 +667,57 @@ describe('DataProcessor', () => {
           schema: expect.any(Object),
         }),
       );
+    });
+
+    it('should normalize malformed LLM facet fields', async () => {
+      mockGenerateJson.mockResolvedValue({
+        underlying_goal: ' Test goal ',
+        goal_categories: null,
+        outcome: null,
+        user_satisfaction_counts: null,
+        Qwen_helpfulness: 'invalid',
+        session_type: null,
+        friction_counts: null,
+        friction_detail: null,
+        primary_success: null,
+        brief_summary: ' Test summary ',
+      });
+
+      const records: ChatRecord[] = [
+        {
+          sessionId: 'test-session',
+          timestamp: new Date().toISOString(),
+          type: 'user',
+          message: {
+            role: 'user',
+            parts: [{ text: 'Help me with code' }],
+          },
+          uuid: '',
+          parentUuid: null,
+          cwd: '',
+          version: '',
+        },
+      ];
+
+      const result = await (
+        dataProcessor as unknown as {
+          analyzeSession(records: ChatRecord[]): Promise<SessionFacets | null>;
+        }
+      ).analyzeSession(records);
+
+      expect(result).toEqual({
+        session_id: 'test-session',
+        underlying_goal: 'Test goal',
+        goal_categories: {},
+        outcome: 'unclear_from_transcript',
+        user_satisfaction_counts: {},
+        Qwen_helpfulness: 'moderately_helpful',
+        session_type: 'single_task',
+        friction_counts: {},
+        friction_detail: '',
+        primary_success: 'none',
+        brief_summary: 'Test summary',
+      });
     });
 
     it('should return null when LLM returns empty result', async () => {
@@ -1214,6 +1303,25 @@ describe('DataProcessor', () => {
       expect(result).toBeUndefined();
     });
 
+    it('should return undefined when all qualitative sections are empty', async () => {
+      mockGenerateJson.mockResolvedValue({});
+
+      const result = await (
+        dataProcessor as unknown as {
+          generateQualitativeInsights(
+            metrics: Omit<InsightData, 'facets' | 'qualitative'>,
+            facets: SessionFacets[],
+          ): Promise<
+            | import('../types/QualitativeInsightTypes.js').QualitativeInsights
+            | undefined
+          >;
+        }
+      ).generateQualitativeInsights(mockMetrics, mockFacets);
+
+      expect(result).toBeUndefined();
+      expect(mockGenerateJson).toHaveBeenCalledTimes(8);
+    });
+
     it('should return full qualitative data when all LLM calls succeed', async () => {
       mockGenerateJson.mockResolvedValue({ intro: 'test', areas: [] });
 
@@ -1309,6 +1417,75 @@ describe('DataProcessor', () => {
       expect(mockGenerateJson).toHaveBeenCalledTimes(1);
       expect(result).toHaveLength(1);
       expect(result[0].session_id).toBe('conversational');
+    });
+
+    it('should normalize cached facets before reusing them', async () => {
+      const conversationalRecords: ChatRecord[] = [
+        {
+          sessionId: 'cached-session',
+          timestamp: '2025-01-15T10:00:00Z',
+          type: 'user',
+          message: { role: 'user', parts: [{ text: 'Hello' }] },
+          uuid: '',
+          parentUuid: null,
+          cwd: '',
+          version: '',
+        },
+        {
+          sessionId: 'cached-session',
+          timestamp: '2025-01-15T10:01:00Z',
+          type: 'assistant',
+          message: { role: 'assistant', parts: [{ text: 'Hi' }] },
+          uuid: '',
+          parentUuid: null,
+          cwd: '',
+          version: '',
+        },
+      ];
+
+      mockedReadJsonlFile.mockResolvedValue(conversationalRecords);
+      mockedFs.readFile.mockResolvedValue(
+        JSON.stringify({
+          underlying_goal: ' Cached goal ',
+          goal_categories: null,
+          outcome: null,
+          user_satisfaction_counts: null,
+          Qwen_helpfulness: 'very_helpful',
+          session_type: 'single_task',
+          friction_counts: null,
+          friction_detail: null,
+          primary_success: null,
+          brief_summary: ' Cached summary ',
+        }),
+      );
+
+      const files = [{ path: '/test/cached-session.jsonl', mtime: 1000 }];
+
+      const result = await (
+        dataProcessor as unknown as {
+          generateFacets(
+            files: Array<{ path: string; mtime: number }>,
+            facetsOutputDir?: string,
+          ): Promise<SessionFacets[]>;
+        }
+      ).generateFacets(files, '/facets');
+
+      expect(mockGenerateJson).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        {
+          session_id: 'cached-session',
+          underlying_goal: 'Cached goal',
+          goal_categories: {},
+          outcome: 'unclear_from_transcript',
+          user_satisfaction_counts: {},
+          Qwen_helpfulness: 'very_helpful',
+          session_type: 'single_task',
+          friction_counts: {},
+          friction_detail: '',
+          primary_success: 'none',
+          brief_summary: 'Cached summary',
+        },
+      ]);
     });
   });
 });

--- a/packages/cli/src/services/insight/generators/DataProcessor.test.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.test.ts
@@ -18,6 +18,7 @@ const mockLogger = vi.hoisted(() => ({
   warn: vi.fn(),
   debug: vi.fn(),
 }));
+const mockRunSideQuery = vi.hoisted(() => vi.fn());
 
 // Mock dependencies
 vi.mock('@qwen-code/qwen-code-core', async () => {
@@ -28,6 +29,7 @@ vi.mock('@qwen-code/qwen-code-core', async () => {
     ...actual,
     read: vi.fn(),
     createDebugLogger: vi.fn(() => mockLogger),
+    runSideQuery: mockRunSideQuery,
   };
 });
 
@@ -55,6 +57,9 @@ describe('DataProcessor', () => {
     vi.clearAllMocks();
 
     mockGenerateJson = vi.fn();
+    mockRunSideQuery.mockImplementation((_config, request) =>
+      mockGenerateJson(request),
+    );
     mockConfig = {
       getBaseLlmClient: vi.fn(() => ({
         generateJson: mockGenerateJson,
@@ -1527,6 +1532,65 @@ describe('DataProcessor', () => {
         expect.stringMatching(/[\\/]facets[\\/]cached-session\.json$/),
         JSON.stringify(result[0], null, 2),
         'utf-8',
+      );
+    });
+
+    it('should reuse normalized cached facets when writeback fails', async () => {
+      const conversationalRecords: ChatRecord[] = [
+        {
+          sessionId: 'cached-session',
+          timestamp: '2025-01-15T10:00:00Z',
+          type: 'user',
+          message: { role: 'user', parts: [{ text: 'Hello' }] },
+          uuid: '',
+          parentUuid: null,
+          cwd: '',
+          version: '',
+        },
+        {
+          sessionId: 'cached-session',
+          timestamp: '2025-01-15T10:01:00Z',
+          type: 'assistant',
+          message: { role: 'assistant', parts: [{ text: 'Hi' }] },
+          uuid: '',
+          parentUuid: null,
+          cwd: '',
+          version: '',
+        },
+      ];
+      const writeError = new Error('disk full');
+
+      mockedReadJsonlFile.mockResolvedValue(conversationalRecords);
+      mockedFs.readFile.mockResolvedValue(
+        JSON.stringify({
+          underlying_goal: 'Cached goal',
+          brief_summary: 'Cached summary',
+        }),
+      );
+      mockedFs.writeFile.mockRejectedValueOnce(writeError);
+
+      const files = [{ path: '/test/cached-session.jsonl', mtime: 1000 }];
+
+      const result = await (
+        dataProcessor as unknown as {
+          generateFacets(
+            files: Array<{ path: string; mtime: number }>,
+            facetsOutputDir?: string,
+          ): Promise<SessionFacets[]>;
+        }
+      ).generateFacets(files, '/facets');
+
+      expect(mockGenerateJson).not.toHaveBeenCalled();
+      expect(result).toEqual([
+        expect.objectContaining({
+          session_id: 'cached-session',
+          underlying_goal: 'Cached goal',
+          brief_summary: 'Cached summary',
+        }),
+      ]);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        'Failed to write back normalized facet for cached-session:',
+        writeError,
       );
     });
   });

--- a/packages/cli/src/services/insight/generators/DataProcessor.test.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.test.ts
@@ -12,6 +12,13 @@ import type {
   SessionFacets,
 } from '../types/StaticInsightTypes.js';
 
+const mockLogger = vi.hoisted(() => ({
+  info: vi.fn(),
+  error: vi.fn(),
+  warn: vi.fn(),
+  debug: vi.fn(),
+}));
+
 // Mock dependencies
 vi.mock('@qwen-code/qwen-code-core', async () => {
   const actual = await vi.importActual<
@@ -20,12 +27,7 @@ vi.mock('@qwen-code/qwen-code-core', async () => {
   return {
     ...actual,
     read: vi.fn(),
-    createDebugLogger: vi.fn(() => ({
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
-    })),
+    createDebugLogger: vi.fn(() => mockLogger),
   };
 });
 
@@ -375,6 +377,38 @@ describe('DataProcessor', () => {
       });
     });
 
+    it('should ignore zero and non-finite count values', () => {
+      const facets = [
+        {
+          session_id: 's1',
+          underlying_goal: 'test',
+          goal_categories: { coding: 0, debugging: Number.NaN, testing: 2 },
+          outcome: 'fully_achieved',
+          user_satisfaction_counts: { satisfied: 0, happy: 1 },
+          Qwen_helpfulness: 'very_helpful',
+          session_type: 'single_task',
+          friction_counts: { slow_response: Number.POSITIVE_INFINITY },
+          friction_detail: '',
+          primary_success: 'none',
+          brief_summary: 'Test summary',
+        },
+      ] as unknown as SessionFacets[];
+
+      const result = (
+        dataProcessor as unknown as {
+          aggregateFacetsData(facets: SessionFacets[]): {
+            satisfactionAgg: Record<string, number>;
+            frictionAgg: Record<string, number>;
+            goalsAgg: Record<string, number>;
+          };
+        }
+      ).aggregateFacetsData(facets);
+
+      expect(result.satisfactionAgg).toEqual({ happy: 1 });
+      expect(result.frictionAgg).toEqual({});
+      expect(result.goalsAgg).toEqual({ testing: 2 });
+    });
+
     it('should ignore malformed count objects when aggregating facets', () => {
       const facets = [
         {
@@ -718,6 +752,9 @@ describe('DataProcessor', () => {
         primary_success: 'none',
         brief_summary: 'Test summary',
       });
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        'Normalized unknown insight enum value "invalid" to fallback "moderately_helpful"',
+      );
     });
 
     it('should return null when LLM returns empty result', async () => {
@@ -1486,6 +1523,11 @@ describe('DataProcessor', () => {
           brief_summary: 'Cached summary',
         },
       ]);
+      expect(mockedFs.writeFile).toHaveBeenCalledWith(
+        '/facets/cached-session.json',
+        JSON.stringify(result[0], null, 2),
+        'utf-8',
+      );
     });
   });
 });

--- a/packages/cli/src/services/insight/generators/DataProcessor.test.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.test.ts
@@ -762,6 +762,57 @@ describe('DataProcessor', () => {
       );
     });
 
+    it('should normalize case-variant LLM facet fields to canonical values', async () => {
+      mockGenerateJson.mockResolvedValue({
+        underlying_goal: 'Test goal',
+        goal_categories: { coding: 1 },
+        outcome: 'FULLY_ACHIEVED',
+        user_satisfaction_counts: null,
+        Qwen_helpfulness: 'Very_Helpful',
+        session_type: 'Multi_Task',
+        friction_counts: null,
+        friction_detail: null,
+        primary_success: null,
+        brief_summary: 'Test summary',
+      });
+
+      const records: ChatRecord[] = [
+        {
+          sessionId: 'test-session',
+          timestamp: new Date().toISOString(),
+          type: 'user',
+          message: {
+            role: 'user',
+            parts: [{ text: 'Help me with code' }],
+          },
+          uuid: '',
+          parentUuid: null,
+          cwd: '',
+          version: '',
+        },
+      ];
+
+      const result = await (
+        dataProcessor as unknown as {
+          analyzeSession(records: ChatRecord[]): Promise<SessionFacets | null>;
+        }
+      ).analyzeSession(records);
+
+      expect(result).toEqual({
+        session_id: 'test-session',
+        underlying_goal: 'Test goal',
+        goal_categories: { coding: 1 },
+        outcome: 'fully_achieved',
+        user_satisfaction_counts: {},
+        Qwen_helpfulness: 'very_helpful',
+        session_type: 'multi_task',
+        friction_counts: {},
+        friction_detail: '',
+        primary_success: 'none',
+        brief_summary: 'Test summary',
+      });
+    });
+
     it('should return null when LLM returns empty result', async () => {
       mockGenerateJson.mockResolvedValue({});
 

--- a/packages/cli/src/services/insight/generators/DataProcessor.test.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.test.ts
@@ -706,7 +706,7 @@ describe('DataProcessor', () => {
     it('should normalize malformed LLM facet fields', async () => {
       mockGenerateJson.mockResolvedValue({
         underlying_goal: ' Test goal ',
-        goal_categories: null,
+        goal_categories: { coding: 1 },
         outcome: null,
         user_satisfaction_counts: null,
         Qwen_helpfulness: 'invalid',
@@ -742,7 +742,7 @@ describe('DataProcessor', () => {
       expect(result).toEqual({
         session_id: 'test-session',
         underlying_goal: 'Test goal',
-        goal_categories: {},
+        goal_categories: { coding: 1 },
         outcome: 'unclear_from_transcript',
         user_satisfaction_counts: {},
         Qwen_helpfulness: 'moderately_helpful',
@@ -1524,7 +1524,7 @@ describe('DataProcessor', () => {
         },
       ]);
       expect(mockedFs.writeFile).toHaveBeenCalledWith(
-        '/facets/cached-session.json',
+        expect.stringMatching(/[\\/]facets[\\/]cached-session\.json$/),
         JSON.stringify(result[0], null, 2),
         'utf-8',
       );

--- a/packages/cli/src/services/insight/generators/DataProcessor.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.ts
@@ -38,6 +38,151 @@ import {
 const logger = createDebugLogger('DataProcessor');
 
 const CONCURRENCY_LIMIT = 4;
+const SESSION_OUTCOMES = [
+  'fully_achieved',
+  'mostly_achieved',
+  'partially_achieved',
+  'not_achieved',
+  'unclear_from_transcript',
+] as const;
+const QWEN_HELPFULNESS_LEVELS = [
+  'unhelpful',
+  'slightly_helpful',
+  'moderately_helpful',
+  'very_helpful',
+  'essential',
+] as const;
+const SESSION_TYPES = [
+  'single_task',
+  'multi_task',
+  'iterative_refinement',
+  'exploration',
+  'quick_question',
+] as const;
+const PRIMARY_SUCCESS_VALUES = [
+  'none',
+  'fast_accurate_search',
+  'correct_code_edits',
+  'good_explanations',
+  'proactive_help',
+  'multi_file_changes',
+  'good_debugging',
+] as const;
+
+function hasMeaningfulInsightValue(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => hasMeaningfulInsightValue(item));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.values(value).some((item) => hasMeaningfulInsightValue(item));
+  }
+
+  return false;
+}
+
+function normalizeInsightText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeInsightCountRecord(value: unknown): Record<string, number> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+
+  return Object.entries(value).reduce<Record<string, number>>(
+    (acc, [key, count]) => {
+      if (typeof count === 'number' && Number.isFinite(count) && count >= 0) {
+        acc[key] = count;
+      }
+      return acc;
+    },
+    {},
+  );
+}
+
+function getInsightCountEntries(value: unknown): Array<[string, number]> {
+  return Object.entries(normalizeInsightCountRecord(value));
+}
+
+function normalizeInsightEnum<T extends string>(
+  value: unknown,
+  allowed: readonly T[],
+  fallback: T,
+): T {
+  return typeof value === 'string' && allowed.some((item) => item === value)
+    ? (value as T)
+    : fallback;
+}
+
+function normalizeSessionFacet(
+  facet: unknown,
+  sessionId: string,
+): SessionFacets | null {
+  if (!facet || typeof facet !== 'object' || Array.isArray(facet)) {
+    return null;
+  }
+
+  const rawFacet = facet as Record<string, unknown>;
+  const normalizedFacet: SessionFacets = {
+    session_id: sessionId,
+    underlying_goal: normalizeInsightText(rawFacet['underlying_goal']),
+    goal_categories: normalizeInsightCountRecord(rawFacet['goal_categories']),
+    outcome: normalizeInsightEnum(
+      rawFacet['outcome'],
+      SESSION_OUTCOMES,
+      'unclear_from_transcript',
+    ),
+    user_satisfaction_counts: normalizeInsightCountRecord(
+      rawFacet['user_satisfaction_counts'],
+    ),
+    Qwen_helpfulness: normalizeInsightEnum(
+      rawFacet['Qwen_helpfulness'],
+      QWEN_HELPFULNESS_LEVELS,
+      'moderately_helpful',
+    ),
+    session_type: normalizeInsightEnum(
+      rawFacet['session_type'],
+      SESSION_TYPES,
+      'single_task',
+    ),
+    friction_counts: normalizeInsightCountRecord(rawFacet['friction_counts']),
+    friction_detail: normalizeInsightText(rawFacet['friction_detail']),
+    primary_success: normalizeInsightEnum(
+      rawFacet['primary_success'],
+      PRIMARY_SUCCESS_VALUES,
+      'none',
+    ),
+    brief_summary: normalizeInsightText(rawFacet['brief_summary']),
+  };
+
+  const meaningfulContent = {
+    underlying_goal: normalizedFacet.underlying_goal,
+    goal_categories: normalizedFacet.goal_categories,
+    outcome:
+      normalizedFacet.outcome === 'unclear_from_transcript'
+        ? ''
+        : normalizedFacet.outcome,
+    user_satisfaction_counts: normalizedFacet.user_satisfaction_counts,
+    friction_counts: normalizedFacet.friction_counts,
+    friction_detail: normalizedFacet.friction_detail,
+    primary_success:
+      normalizedFacet.primary_success === 'none'
+        ? ''
+        : normalizedFacet.primary_success,
+    brief_summary: normalizedFacet.brief_summary,
+  };
+
+  return hasMeaningfulInsightValue(meaningfulContent) ? normalizedFacet : null;
+}
 
 export class DataProcessor {
   constructor(private config: Config) {}
@@ -208,10 +353,17 @@ export class DataProcessor {
         return null;
       }
 
-      return {
-        ...(result as unknown as SessionFacets),
-        session_id: records[0].sessionId,
-      };
+      const sessionId = records[0].sessionId;
+      const normalizedFacet = normalizeSessionFacet(result, sessionId);
+
+      if (!normalizedFacet) {
+        logger.warn(
+          `Ignoring malformed insight facet for session ${sessionId}`,
+        );
+        return null;
+      }
+
+      return normalizedFacet;
     } catch (error) {
       logger.error(
         `Failed to analyze session ${records[0]?.sessionId}:`,
@@ -338,28 +490,38 @@ export class DataProcessor {
 
     facets.forEach((facet) => {
       // Aggregate satisfaction
-      Object.entries(facet.user_satisfaction_counts).forEach(([sat, count]) => {
-        satisfactionAgg[sat] = (satisfactionAgg[sat] || 0) + count;
-      });
+      getInsightCountEntries(facet.user_satisfaction_counts).forEach(
+        ([sat, count]) => {
+          satisfactionAgg[sat] = (satisfactionAgg[sat] || 0) + count;
+        },
+      );
 
       // Aggregate friction
-      Object.entries(facet.friction_counts).forEach(([fric, count]) => {
+      getInsightCountEntries(facet.friction_counts).forEach(([fric, count]) => {
         frictionAgg[fric] = (frictionAgg[fric] || 0) + count;
       });
 
       // Aggregate primary success
-      if (facet.primary_success && facet.primary_success !== 'none') {
-        primarySuccessAgg[facet.primary_success] =
-          (primarySuccessAgg[facet.primary_success] || 0) + 1;
+      const primarySuccess = normalizeInsightEnum(
+        facet.primary_success,
+        PRIMARY_SUCCESS_VALUES,
+        'none',
+      );
+      if (primarySuccess !== 'none') {
+        primarySuccessAgg[primarySuccess] =
+          (primarySuccessAgg[primarySuccess] || 0) + 1;
       }
 
       // Aggregate outcomes
-      if (facet.outcome) {
-        outcomesAgg[facet.outcome] = (outcomesAgg[facet.outcome] || 0) + 1;
-      }
+      const outcome = normalizeInsightEnum(
+        facet.outcome,
+        SESSION_OUTCOMES,
+        'unclear_from_transcript',
+      );
+      outcomesAgg[outcome] = (outcomesAgg[outcome] || 0) + 1;
 
       // Aggregate goals
-      Object.entries(facet.goal_categories).forEach(([goal, count]) => {
+      getInsightCountEntries(facet.goal_categories).forEach(([goal, count]) => {
         goalsAgg[goal] = (goalsAgg[goal] || 0) + count;
       });
     });
@@ -659,7 +821,7 @@ export class DataProcessor {
         ),
       );
 
-      return {
+      const qualitative = {
         impressiveWorkflows,
         projectAreas,
         futureOpportunities,
@@ -669,6 +831,8 @@ export class DataProcessor {
         interactionStyle,
         atAGlance,
       };
+
+      return hasMeaningfulInsightValue(qualitative) ? qualitative : undefined;
     } catch (e) {
       logger.error('Error generating qualitative insights:', e);
       return undefined;
@@ -688,27 +852,38 @@ export class DataProcessor {
 
     facets.forEach((facet) => {
       // Aggregate goals
-      Object.entries(facet.goal_categories).forEach(([goal, count]) => {
+      getInsightCountEntries(facet.goal_categories).forEach(([goal, count]) => {
         goalsAgg[goal] = (goalsAgg[goal] || 0) + count;
       });
 
       // Aggregate outcomes
-      outcomesAgg[facet.outcome] = (outcomesAgg[facet.outcome] || 0) + 1;
+      const outcome = normalizeInsightEnum(
+        facet.outcome,
+        SESSION_OUTCOMES,
+        'unclear_from_transcript',
+      );
+      outcomesAgg[outcome] = (outcomesAgg[outcome] || 0) + 1;
 
       // Aggregate satisfaction
-      Object.entries(facet.user_satisfaction_counts).forEach(([sat, count]) => {
-        satisfactionAgg[sat] = (satisfactionAgg[sat] || 0) + count;
-      });
+      getInsightCountEntries(facet.user_satisfaction_counts).forEach(
+        ([sat, count]) => {
+          satisfactionAgg[sat] = (satisfactionAgg[sat] || 0) + count;
+        },
+      );
 
       // Aggregate friction
-      Object.entries(facet.friction_counts).forEach(([fric, count]) => {
+      getInsightCountEntries(facet.friction_counts).forEach(([fric, count]) => {
         frictionAgg[fric] = (frictionAgg[fric] || 0) + count;
       });
 
       // Aggregate success (primary_success)
-      if (facet.primary_success && facet.primary_success !== 'none') {
-        successAgg[facet.primary_success] =
-          (successAgg[facet.primary_success] || 0) + 1;
+      const primarySuccess = normalizeInsightEnum(
+        facet.primary_success,
+        PRIMARY_SUCCESS_VALUES,
+        'none',
+      );
+      if (primarySuccess !== 'none') {
+        successAgg[primarySuccess] = (successAgg[primarySuccess] || 0) + 1;
       }
     });
 
@@ -736,13 +911,16 @@ export class DataProcessor {
 
     // 2. SESSION SUMMARIES section
     const sessionSummaries = facets
-      .map((f) => `- ${f.brief_summary}`)
+      .map((f) => normalizeInsightText(f.brief_summary))
+      .filter((summary) => summary.length > 0)
+      .map((summary) => `- ${summary}`)
       .join('\n');
 
     // 3. FRICTION DETAILS section
     const frictionDetails = facets
-      .filter((f) => f.friction_detail && f.friction_detail.trim().length > 0)
-      .map((f) => `- ${f.friction_detail}`)
+      .map((f) => normalizeInsightText(f.friction_detail))
+      .filter((detail) => detail.length > 0)
+      .map((detail) => `- ${detail}`)
       .join('\n');
 
     return `DATA:
@@ -1060,6 +1238,16 @@ None captured`;
                   'utf-8',
                 );
                 const existingFacet = JSON.parse(existingData);
+                const normalizedFacet = normalizeSessionFacet(
+                  existingFacet,
+                  sessionId,
+                );
+                if (!normalizedFacet) {
+                  logger.warn(
+                    `Cached insight facet for ${sessionId} is malformed, regenerating.`,
+                  );
+                  throw new Error('Malformed cached insight facet');
+                }
                 completed++;
                 if (onProgress) {
                   const percent = 20 + Math.round((completed / total) * 60);
@@ -1069,7 +1257,7 @@ None captured`;
                     `${completed}/${total}`,
                   );
                 }
-                return existingFacet;
+                return normalizedFacet;
               } catch (readError) {
                 // File doesn't exist or is invalid, proceed to analyze
                 if ((readError as NodeJS.ErrnoException).code !== 'ENOENT') {

--- a/packages/cli/src/services/insight/generators/DataProcessor.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.ts
@@ -125,8 +125,9 @@ function normalizeInsightEnum<T extends string>(
   allowed: readonly T[],
   fallback: T,
 ): T {
-  if (typeof value === 'string' && allowed.some((item) => item === value)) {
-    return value as T;
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (trimmed && allowed.some((item) => item === trimmed)) {
+    return trimmed as T;
   }
 
   logger.debug(

--- a/packages/cli/src/services/insight/generators/DataProcessor.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.ts
@@ -45,6 +45,7 @@ const SESSION_OUTCOMES = [
   'not_achieved',
   'unclear_from_transcript',
 ] as const;
+const OUTCOME_FALLBACK = 'unclear_from_transcript';
 const QWEN_HELPFULNESS_LEVELS = [
   'unhelpful',
   'slightly_helpful',
@@ -68,14 +69,20 @@ const PRIMARY_SUCCESS_VALUES = [
   'multi_file_changes',
   'good_debugging',
 ] as const;
+const PRIMARY_SUCCESS_FALLBACK = 'none';
 
+// Keep in sync with packages/web-templates/src/insight/src/App.tsx.
 function hasMeaningfulInsightValue(value: unknown): boolean {
   if (typeof value === 'string') {
     return value.trim().length > 0;
   }
 
-  if (typeof value === 'number' || typeof value === 'boolean') {
-    return true;
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value !== 0;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
   }
 
   if (Array.isArray(value)) {
@@ -100,7 +107,7 @@ function normalizeInsightCountRecord(value: unknown): Record<string, number> {
 
   return Object.entries(value).reduce<Record<string, number>>(
     (acc, [key, count]) => {
-      if (typeof count === 'number' && Number.isFinite(count) && count >= 0) {
+      if (typeof count === 'number' && Number.isFinite(count) && count > 0) {
         acc[key] = count;
       }
       return acc;
@@ -118,9 +125,14 @@ function normalizeInsightEnum<T extends string>(
   allowed: readonly T[],
   fallback: T,
 ): T {
-  return typeof value === 'string' && allowed.some((item) => item === value)
-    ? (value as T)
-    : fallback;
+  if (typeof value === 'string' && allowed.some((item) => item === value)) {
+    return value as T;
+  }
+
+  logger.debug(
+    `Normalized unknown insight enum value "${String(value)}" to fallback "${fallback}"`,
+  );
+  return fallback;
 }
 
 function normalizeSessionFacet(
@@ -139,7 +151,7 @@ function normalizeSessionFacet(
     outcome: normalizeInsightEnum(
       rawFacet['outcome'],
       SESSION_OUTCOMES,
-      'unclear_from_transcript',
+      OUTCOME_FALLBACK,
     ),
     user_satisfaction_counts: normalizeInsightCountRecord(
       rawFacet['user_satisfaction_counts'],
@@ -159,7 +171,7 @@ function normalizeSessionFacet(
     primary_success: normalizeInsightEnum(
       rawFacet['primary_success'],
       PRIMARY_SUCCESS_VALUES,
-      'none',
+      PRIMARY_SUCCESS_FALLBACK,
     ),
     brief_summary: normalizeInsightText(rawFacet['brief_summary']),
   };
@@ -168,14 +180,14 @@ function normalizeSessionFacet(
     underlying_goal: normalizedFacet.underlying_goal,
     goal_categories: normalizedFacet.goal_categories,
     outcome:
-      normalizedFacet.outcome === 'unclear_from_transcript'
+      normalizedFacet.outcome === OUTCOME_FALLBACK
         ? ''
         : normalizedFacet.outcome,
     user_satisfaction_counts: normalizedFacet.user_satisfaction_counts,
     friction_counts: normalizedFacet.friction_counts,
     friction_detail: normalizedFacet.friction_detail,
     primary_success:
-      normalizedFacet.primary_success === 'none'
+      normalizedFacet.primary_success === PRIMARY_SUCCESS_FALLBACK
         ? ''
         : normalizedFacet.primary_success,
     brief_summary: normalizedFacet.brief_summary,
@@ -505,9 +517,9 @@ export class DataProcessor {
       const primarySuccess = normalizeInsightEnum(
         facet.primary_success,
         PRIMARY_SUCCESS_VALUES,
-        'none',
+        PRIMARY_SUCCESS_FALLBACK,
       );
-      if (primarySuccess !== 'none') {
+      if (primarySuccess !== PRIMARY_SUCCESS_FALLBACK) {
         primarySuccessAgg[primarySuccess] =
           (primarySuccessAgg[primarySuccess] || 0) + 1;
       }
@@ -516,7 +528,7 @@ export class DataProcessor {
       const outcome = normalizeInsightEnum(
         facet.outcome,
         SESSION_OUTCOMES,
-        'unclear_from_transcript',
+        OUTCOME_FALLBACK,
       );
       outcomesAgg[outcome] = (outcomesAgg[outcome] || 0) + 1;
 
@@ -860,7 +872,7 @@ export class DataProcessor {
       const outcome = normalizeInsightEnum(
         facet.outcome,
         SESSION_OUTCOMES,
-        'unclear_from_transcript',
+        OUTCOME_FALLBACK,
       );
       outcomesAgg[outcome] = (outcomesAgg[outcome] || 0) + 1;
 
@@ -880,9 +892,9 @@ export class DataProcessor {
       const primarySuccess = normalizeInsightEnum(
         facet.primary_success,
         PRIMARY_SUCCESS_VALUES,
-        'none',
+        PRIMARY_SUCCESS_FALLBACK,
       );
-      if (primarySuccess !== 'none') {
+      if (primarySuccess !== PRIMARY_SUCCESS_FALLBACK) {
         successAgg[primarySuccess] = (successAgg[primarySuccess] || 0) + 1;
       }
     });
@@ -1248,6 +1260,11 @@ None captured`;
                   );
                   throw new Error('Malformed cached insight facet');
                 }
+                await fs.writeFile(
+                  existingFacetPath,
+                  JSON.stringify(normalizedFacet, null, 2),
+                  'utf-8',
+                );
                 completed++;
                 if (onProgress) {
                   const percent = 20 + Math.round((completed / total) * 60);

--- a/packages/cli/src/services/insight/generators/DataProcessor.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.ts
@@ -1260,11 +1260,21 @@ None captured`;
                   );
                   throw new Error('Malformed cached insight facet');
                 }
-                await fs.writeFile(
-                  existingFacetPath,
-                  JSON.stringify(normalizedFacet, null, 2),
-                  'utf-8',
-                );
+                const normalizedData = JSON.stringify(normalizedFacet, null, 2);
+                if (existingData !== normalizedData) {
+                  try {
+                    await fs.writeFile(
+                      existingFacetPath,
+                      normalizedData,
+                      'utf-8',
+                    );
+                  } catch (writeError) {
+                    logger.warn(
+                      `Failed to write back normalized facet for ${sessionId}:`,
+                      writeError,
+                    );
+                  }
+                }
                 completed++;
                 if (onProgress) {
                   const percent = 20 + Math.round((completed / total) * 60);

--- a/packages/cli/src/services/insight/generators/DataProcessor.ts
+++ b/packages/cli/src/services/insight/generators/DataProcessor.ts
@@ -126,8 +126,11 @@ function normalizeInsightEnum<T extends string>(
   fallback: T,
 ): T {
   const trimmed = typeof value === 'string' ? value.trim() : '';
-  if (trimmed && allowed.some((item) => item === trimmed)) {
-    return trimmed as T;
+  if (trimmed) {
+    const match = allowed.find(
+      (item) => String(item).toLowerCase() === trimmed.toLowerCase(),
+    );
+    if (match) return match;
   }
 
   logger.debug(

--- a/packages/web-templates/src/insight/src/App.tsx
+++ b/packages/web-templates/src/insight/src/App.tsx
@@ -192,6 +192,13 @@ function InsightApp({ data }: { data: InsightData }) {
     navSections.push({ href: '#section-horizon', label: 'On the Horizon' });
   }
 
+  const atAGlanceTargetSections = {
+    wins: showImpressiveWorkflows,
+    friction: showFrictionPoints,
+    features: showFeatures,
+    horizon: showFutureOpportunities,
+  };
+
   return (
     <div>
       {/* Elegant Header */}
@@ -212,7 +219,10 @@ function InsightApp({ data }: { data: InsightData }) {
       </header>
 
       {showAtAGlance && data.qualitative && (
-        <AtAGlance qualitative={data.qualitative} />
+        <AtAGlance
+          qualitative={data.qualitative}
+          targetSections={atAGlanceTargetSections}
+        />
       )}
 
       {navSections.length > 0 && <NavToc sections={navSections} />}

--- a/packages/web-templates/src/insight/src/App.tsx
+++ b/packages/web-templates/src/insight/src/App.tsx
@@ -4,6 +4,7 @@ import { StatsRow } from './Header';
 import {
   AtAGlance,
   NavToc,
+  type NavTocSection,
   ProjectAreas,
   InteractionStyle,
   ImpressiveWorkflows,
@@ -17,6 +18,36 @@ import './styles.css';
 import type { InsightData } from './types';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
+
+function hasMeaningfulValue(value: unknown): boolean {
+  if (typeof value === 'string') {
+    return value.trim().length > 0;
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some((item) => hasMeaningfulValue(item));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.values(value).some((item) => hasMeaningfulValue(item));
+  }
+
+  return false;
+}
+
+function hasRecordEntries(
+  value?: Record<string, number> | Array<[string, number]>,
+): boolean {
+  if (Array.isArray(value)) {
+    return value.length > 0;
+  }
+
+  return !!value && Object.keys(value).length > 0;
+}
 
 // Main App Component
 function InsightApp({ data }: { data: InsightData }) {
@@ -96,6 +127,71 @@ function InsightApp({ data }: { data: InsightData }) {
     dateRangeStr = `${formatDate(minDate)} to ${formatDate(maxDate)}`;
   }
 
+  const showAtAGlance = hasMeaningfulValue(data.qualitative?.atAGlance);
+  const showProjectAreas =
+    !!data.qualitative &&
+    (hasMeaningfulValue(data.qualitative.projectAreas) ||
+      hasRecordEntries(data.topGoals) ||
+      hasRecordEntries(data.topTools));
+  const showInteractionStyle = hasMeaningfulValue(
+    data.qualitative?.interactionStyle,
+  );
+  const showImpressiveWorkflows = hasMeaningfulValue(
+    data.qualitative?.impressiveWorkflows,
+  );
+  const showFrictionPoints = hasMeaningfulValue(
+    data.qualitative?.frictionPoints,
+  );
+  const showFeatures =
+    !!data.qualitative &&
+    hasMeaningfulValue({
+      Qwen_md_additions: data.qualitative.improvements?.Qwen_md_additions,
+      features_to_try: data.qualitative.improvements?.features_to_try,
+    });
+  const showPatterns =
+    !!data.qualitative &&
+    hasMeaningfulValue({
+      usage_patterns: data.qualitative.improvements?.usage_patterns,
+    });
+  const showFutureOpportunities = hasMeaningfulValue(
+    data.qualitative?.futureOpportunities,
+  );
+  const showMemorableMoment = hasMeaningfulValue(
+    data.qualitative?.memorableMoment,
+  );
+
+  const navSections: NavTocSection[] = [];
+  if (showProjectAreas) {
+    navSections.push({ href: '#section-work', label: 'What You Work On' });
+  }
+  if (showInteractionStyle) {
+    navSections.push({
+      href: '#section-usage',
+      label: 'How You Use Qwen Code',
+    });
+  }
+  if (showImpressiveWorkflows) {
+    navSections.push({ href: '#section-wins', label: 'Impressive Things' });
+  }
+  if (showFrictionPoints) {
+    navSections.push({
+      href: '#section-friction',
+      label: 'Where Things Go Wrong',
+    });
+  }
+  if (showFeatures) {
+    navSections.push({ href: '#section-features', label: 'Features to Try' });
+  }
+  if (showPatterns) {
+    navSections.push({
+      href: '#section-patterns',
+      label: 'New Usage Patterns',
+    });
+  }
+  if (showFutureOpportunities) {
+    navSections.push({ href: '#section-horizon', label: 'On the Horizon' });
+  }
+
   return (
     <div>
       {/* Elegant Header */}
@@ -115,49 +211,57 @@ function InsightApp({ data }: { data: InsightData }) {
         </div>
       </header>
 
-      {data.qualitative && (
-        <>
-          <AtAGlance qualitative={data.qualitative} />
-          <NavToc />
-        </>
+      {showAtAGlance && data.qualitative && (
+        <AtAGlance qualitative={data.qualitative} />
       )}
+
+      {navSections.length > 0 && <NavToc sections={navSections} />}
 
       <StatsRow data={data} />
 
-      {data.qualitative && (
-        <>
-          <ProjectAreas
-            qualitative={data.qualitative}
-            topGoals={data.topGoals}
-            topTools={data.topTools}
-          />
-        </>
+      {showProjectAreas && data.qualitative && (
+        <ProjectAreas
+          qualitative={data.qualitative}
+          topGoals={data.topGoals}
+          topTools={data.topTools}
+        />
       )}
 
-      {data.qualitative && (
-        <>
-          <InteractionStyle qualitative={data.qualitative} insights={data} />
-        </>
+      {showInteractionStyle && data.qualitative && (
+        <InteractionStyle qualitative={data.qualitative} insights={data} />
       )}
 
-      {data.qualitative && (
-        <>
-          <ImpressiveWorkflows
-            qualitative={data.qualitative}
-            primarySuccess={data.primarySuccess!}
-            outcomes={data.outcomes!}
-          />
-          <FrictionPoints
-            qualitative={data.qualitative}
-            satisfaction={data.satisfaction}
-            friction={data.friction}
-          />
-          <Improvements qualitative={data.qualitative} />
-          <FutureOpportunities qualitative={data.qualitative} />
-          <MemorableMoment qualitative={data.qualitative} />
-        </>
+      {showImpressiveWorkflows && data.qualitative && (
+        <ImpressiveWorkflows
+          qualitative={data.qualitative}
+          primarySuccess={data.primarySuccess!}
+          outcomes={data.outcomes!}
+        />
       )}
 
+      {showFrictionPoints && data.qualitative && (
+        <FrictionPoints
+          qualitative={data.qualitative}
+          satisfaction={data.satisfaction}
+          friction={data.friction}
+        />
+      )}
+
+      {(showFeatures || showPatterns) && data.qualitative && (
+        <Improvements qualitative={data.qualitative} />
+      )}
+
+      {showFutureOpportunities && data.qualitative && (
+        <FutureOpportunities qualitative={data.qualitative} />
+      )}
+
+      {showMemorableMoment && data.qualitative && (
+        <MemorableMoment qualitative={data.qualitative} />
+      )}
+
+      {/*
+        The share card remains available even if qualitative sections are absent.
+      */}
       <ShareCard data={data} theme={cardTheme} />
     </div>
   );

--- a/packages/web-templates/src/insight/src/App.tsx
+++ b/packages/web-templates/src/insight/src/App.tsx
@@ -19,13 +19,18 @@ import type { InsightData } from './types';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 
+// Keep in sync with packages/cli/src/services/insight/generators/DataProcessor.ts.
 function hasMeaningfulValue(value: unknown): boolean {
   if (typeof value === 'string') {
     return value.trim().length > 0;
   }
 
-  if (typeof value === 'number' || typeof value === 'boolean') {
-    return true;
+  if (typeof value === 'number') {
+    return Number.isFinite(value) && value !== 0;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
   }
 
   if (Array.isArray(value)) {
@@ -43,10 +48,17 @@ function hasRecordEntries(
   value?: Record<string, number> | Array<[string, number]>,
 ): boolean {
   if (Array.isArray(value)) {
-    return value.length > 0;
+    return value.some(([, count]) => Number.isFinite(count) && count !== 0);
   }
 
-  return !!value && Object.keys(value).length > 0;
+  return (
+    !!value &&
+    Object.values(value).some((count) => Number.isFinite(count) && count !== 0)
+  );
+}
+
+function hasMeaningfulArray(value: unknown): boolean {
+  return Array.isArray(value) && value.some((item) => hasMeaningfulValue(item));
 }
 
 // Main App Component
@@ -136,23 +148,21 @@ function InsightApp({ data }: { data: InsightData }) {
   const showInteractionStyle = hasMeaningfulValue(
     data.qualitative?.interactionStyle,
   );
-  const showImpressiveWorkflows = hasMeaningfulValue(
-    data.qualitative?.impressiveWorkflows,
-  );
-  const showFrictionPoints = hasMeaningfulValue(
-    data.qualitative?.frictionPoints,
-  );
+  const showImpressiveWorkflows =
+    hasMeaningfulValue(data.qualitative?.impressiveWorkflows) ||
+    hasRecordEntries(data.primarySuccess) ||
+    hasRecordEntries(data.outcomes);
+  const showFrictionPoints =
+    hasMeaningfulValue(data.qualitative?.frictionPoints) ||
+    hasRecordEntries(data.satisfaction) ||
+    hasRecordEntries(data.friction);
   const showFeatures =
     !!data.qualitative &&
-    hasMeaningfulValue({
-      Qwen_md_additions: data.qualitative.improvements?.Qwen_md_additions,
-      features_to_try: data.qualitative.improvements?.features_to_try,
-    });
+    (hasMeaningfulArray(data.qualitative.improvements?.Qwen_md_additions) ||
+      hasMeaningfulArray(data.qualitative.improvements?.features_to_try));
   const showPatterns =
     !!data.qualitative &&
-    hasMeaningfulValue({
-      usage_patterns: data.qualitative.improvements?.usage_patterns,
-    });
+    hasMeaningfulArray(data.qualitative.improvements?.usage_patterns);
   const showFutureOpportunities = hasMeaningfulValue(
     data.qualitative?.futureOpportunities,
   );
@@ -241,19 +251,19 @@ function InsightApp({ data }: { data: InsightData }) {
         <InteractionStyle qualitative={data.qualitative} insights={data} />
       )}
 
-      {showImpressiveWorkflows && data.qualitative && (
+      {showImpressiveWorkflows && (
         <ImpressiveWorkflows
           qualitative={data.qualitative}
-          primarySuccess={data.primarySuccess!}
-          outcomes={data.outcomes!}
+          primarySuccess={data.primarySuccess ?? {}}
+          outcomes={data.outcomes ?? {}}
         />
       )}
 
-      {showFrictionPoints && data.qualitative && (
+      {showFrictionPoints && (
         <FrictionPoints
           qualitative={data.qualitative}
-          satisfaction={data.satisfaction}
-          friction={data.friction}
+          satisfaction={data.satisfaction ?? {}}
+          friction={data.friction ?? {}}
         />
       )}
 

--- a/packages/web-templates/src/insight/src/App.tsx
+++ b/packages/web-templates/src/insight/src/App.tsx
@@ -149,13 +149,15 @@ function InsightApp({ data }: { data: InsightData }) {
     data.qualitative?.interactionStyle,
   );
   const showImpressiveWorkflows =
-    hasMeaningfulValue(data.qualitative?.impressiveWorkflows) ||
-    hasRecordEntries(data.primarySuccess) ||
-    hasRecordEntries(data.outcomes);
+    !!data.qualitative &&
+    (hasMeaningfulValue(data.qualitative.impressiveWorkflows) ||
+      hasRecordEntries(data.primarySuccess) ||
+      hasRecordEntries(data.outcomes));
   const showFrictionPoints =
-    hasMeaningfulValue(data.qualitative?.frictionPoints) ||
-    hasRecordEntries(data.satisfaction) ||
-    hasRecordEntries(data.friction);
+    !!data.qualitative &&
+    (hasMeaningfulValue(data.qualitative.frictionPoints) ||
+      hasRecordEntries(data.satisfaction) ||
+      hasRecordEntries(data.friction));
   const showFeatures =
     !!data.qualitative &&
     (hasMeaningfulArray(data.qualitative.improvements?.Qwen_md_additions) ||

--- a/packages/web-templates/src/insight/src/Qualitative.tsx
+++ b/packages/web-templates/src/insight/src/Qualitative.tsx
@@ -51,16 +51,21 @@ export function AtAGlance({ qualitative }: { qualitative: QualitativeData }) {
   );
 }
 
-export function NavToc() {
+export interface NavTocSection {
+  href: string;
+  label: string;
+}
+
+export function NavToc({ sections }: { sections: NavTocSection[] }) {
+  if (sections.length === 0) return null;
+
   return (
     <nav className="nav-toc">
-      <a href="#section-work">What You Work On</a>
-      <a href="#section-usage">How You Use Qwen Code</a>
-      <a href="#section-wins">Impressive Things</a>
-      <a href="#section-friction">Where Things Go Wrong</a>
-      <a href="#section-features">Features to Try</a>
-      <a href="#section-patterns">New Usage Patterns</a>
-      <a href="#section-horizon">On the Horizon</a>
+      {sections.map((section) => (
+        <a key={section.href} href={section.href}>
+          {section.label}
+        </a>
+      ))}
     </nav>
   );
 }
@@ -566,81 +571,106 @@ export function Improvements({
   const { improvements } = qualitative;
   if (!improvements) return null;
 
+  const hasFeatureSuggestions =
+    (Array.isArray(improvements.Qwen_md_additions) &&
+      improvements.Qwen_md_additions.length > 0) ||
+    (Array.isArray(improvements.features_to_try) &&
+      improvements.features_to_try.length > 0);
+  const hasUsagePatterns =
+    Array.isArray(improvements.usage_patterns) &&
+    improvements.usage_patterns.length > 0;
+
+  if (!hasFeatureSuggestions && !hasUsagePatterns) return null;
+
   return (
     <>
-      <h2
-        id="section-features"
-        className="text-xl font-semibold text-slate-900 mt-8 mb-4"
-      >
-        Existing Qwen Code Features to Try
-      </h2>
+      {hasFeatureSuggestions && (
+        <>
+          <h2
+            id="section-features"
+            className="text-xl font-semibold text-slate-900 mt-8 mb-4"
+          >
+            Existing Qwen Code Features to Try
+          </h2>
 
-      {/* QWEN.md Additions */}
-      {Array.isArray(improvements.Qwen_md_additions) &&
-        improvements.Qwen_md_additions.length > 0 && (
-          <QwenMdAdditionsSection additions={improvements.Qwen_md_additions} />
-        )}
+          {/* QWEN.md Additions */}
+          {Array.isArray(improvements.Qwen_md_additions) &&
+            improvements.Qwen_md_additions.length > 0 && (
+              <QwenMdAdditionsSection
+                additions={improvements.Qwen_md_additions}
+              />
+            )}
 
-      <p className="text-xs text-slate-500 mb-3">
-        Just copy this into Qwen Code and it&apos;ll set it up for you.
-      </p>
+          <p className="text-xs text-slate-500 mb-3">
+            Just copy this into Qwen Code and it&apos;ll set it up for you.
+          </p>
 
-      {/* Features to Try */}
-      <div className="features-section">
-        {Array.isArray(improvements.features_to_try) &&
-          improvements.features_to_try.map((feat, idx) => (
-            <div key={idx} className="feature-card">
-              <div className="feature-title">{feat.feature}</div>
-              <div className="feature-oneliner">
-                <MarkdownText>{feat.one_liner}</MarkdownText>
-              </div>
-              <div className="feature-why">
-                <strong>Why for you:</strong>{' '}
-                <MarkdownText>{feat.why_for_you}</MarkdownText>
-              </div>
-              <div className="feature-examples">
-                <div className="feature-example">
-                  <div className="example-code-row">
-                    <code className="example-code">{feat.example_code}</code>
-                    <CopyButton text={feat.example_code} />
+          {/* Features to Try */}
+          <div className="features-section">
+            {Array.isArray(improvements.features_to_try) &&
+              improvements.features_to_try.map((feat, idx) => (
+                <div key={idx} className="feature-card">
+                  <div className="feature-title">{feat.feature}</div>
+                  <div className="feature-oneliner">
+                    <MarkdownText>{feat.one_liner}</MarkdownText>
+                  </div>
+                  <div className="feature-why">
+                    <strong>Why for you:</strong>{' '}
+                    <MarkdownText>{feat.why_for_you}</MarkdownText>
+                  </div>
+                  <div className="feature-examples">
+                    <div className="feature-example">
+                      <div className="example-code-row">
+                        <code className="example-code">
+                          {feat.example_code}
+                        </code>
+                        <CopyButton text={feat.example_code} />
+                      </div>
+                    </div>
                   </div>
                 </div>
-              </div>
-            </div>
-          ))}
-      </div>
+              ))}
+          </div>
+        </>
+      )}
 
-      <h2
-        id="section-patterns"
-        className="text-xl font-semibold text-slate-900 mt-8 mb-4"
-      >
-        New Ways to Use Qwen Code
-      </h2>
-      <p className="text-xs text-slate-500 mb-3">
-        Just copy this into Qwen Code and it&apos;ll walk you through it.
-      </p>
+      {hasUsagePatterns && (
+        <>
+          <h2
+            id="section-patterns"
+            className="text-xl font-semibold text-slate-900 mt-8 mb-4"
+          >
+            New Ways to Use Qwen Code
+          </h2>
+          <p className="text-xs text-slate-500 mb-3">
+            Just copy this into Qwen Code and it&apos;ll walk you through it.
+          </p>
 
-      <div className="patterns-section">
-        {Array.isArray(improvements.usage_patterns) &&
-          improvements.usage_patterns.map((pat, idx) => (
-            <div key={idx} className="pattern-card">
-              <div className="pattern-title">{pat.title}</div>
-              <div className="pattern-summary">
-                <MarkdownText>{pat.suggestion}</MarkdownText>
-              </div>
-              <div className="pattern-detail">
-                <MarkdownText>{pat.detail}</MarkdownText>
-              </div>
-              <div className="copyable-prompt-section">
-                <div className="prompt-label">Paste into Qwen Code:</div>
-                <div className="copyable-prompt-row">
-                  <code className="copyable-prompt">{pat.copyable_prompt}</code>
-                  <CopyButton text={pat.copyable_prompt} />
+          <div className="patterns-section">
+            {Array.isArray(improvements.usage_patterns) &&
+              improvements.usage_patterns.map((pat, idx) => (
+                <div key={idx} className="pattern-card">
+                  <div className="pattern-title">{pat.title}</div>
+                  <div className="pattern-summary">
+                    <MarkdownText>{pat.suggestion}</MarkdownText>
+                  </div>
+                  <div className="pattern-detail">
+                    <MarkdownText>{pat.detail}</MarkdownText>
+                  </div>
+                  <div className="copyable-prompt-section">
+                    <div className="prompt-label">Paste into Qwen Code:</div>
+                    <div className="copyable-prompt-row">
+                      <code className="copyable-prompt">
+                        {pat.copyable_prompt}
+                      </code>
+                      <CopyButton text={pat.copyable_prompt} />
+                    </div>
+                  </div>
                 </div>
-              </div>
-            </div>
-          ))}
-      </div>
+              ))}
+          </div>
+        </>
+      )}
     </>
   );
 }

--- a/packages/web-templates/src/insight/src/Qualitative.tsx
+++ b/packages/web-templates/src/insight/src/Qualitative.tsx
@@ -10,7 +10,20 @@ import React from 'react';
 // Qualitative Insight Components
 // -----------------------------------------------------------------------------
 
-export function AtAGlance({ qualitative }: { qualitative: QualitativeData }) {
+export interface AtAGlanceTargetSections {
+  wins: boolean;
+  friction: boolean;
+  features: boolean;
+  horizon: boolean;
+}
+
+export function AtAGlance({
+  qualitative,
+  targetSections,
+}: {
+  qualitative: QualitativeData;
+  targetSections: AtAGlanceTargetSections;
+}) {
   const { atAGlance } = qualitative;
   if (!atAGlance) return null;
 
@@ -21,30 +34,38 @@ export function AtAGlance({ qualitative }: { qualitative: QualitativeData }) {
         <div className="glance-section">
           <strong>What&apos;s working:</strong>{' '}
           <MarkdownText>{atAGlance.whats_working}</MarkdownText>
-          <a href="#section-wins" className="see-more">
-            Impressive Things You Did →
-          </a>
+          {targetSections.wins && (
+            <a href="#section-wins" className="see-more">
+              Impressive Things You Did →
+            </a>
+          )}
         </div>
         <div className="glance-section">
           <strong>What&apos;s hindering you:</strong>{' '}
           <MarkdownText>{atAGlance.whats_hindering}</MarkdownText>
-          <a href="#section-friction" className="see-more">
-            Where Things Go Wrong →
-          </a>
+          {targetSections.friction && (
+            <a href="#section-friction" className="see-more">
+              Where Things Go Wrong →
+            </a>
+          )}
         </div>
         <div className="glance-section">
           <strong>Quick wins to try:</strong>{' '}
           <MarkdownText>{atAGlance.quick_wins}</MarkdownText>
-          <a href="#section-features" className="see-more">
-            Features to Try →
-          </a>
+          {targetSections.features && (
+            <a href="#section-features" className="see-more">
+              Features to Try →
+            </a>
+          )}
         </div>
         <div className="glance-section">
           <strong>Ambitious workflows:</strong>{' '}
           <MarkdownText>{atAGlance.ambitious_workflows}</MarkdownText>
-          <a href="#section-horizon" className="see-more">
-            On the Horizon →
-          </a>
+          {targetSections.horizon && (
+            <a href="#section-horizon" className="see-more">
+              On the Horizon →
+            </a>
+          )}
         </div>
       </div>
     </div>

--- a/packages/web-templates/src/insight/src/Qualitative.tsx
+++ b/packages/web-templates/src/insight/src/Qualitative.tsx
@@ -10,6 +10,10 @@ import React from 'react';
 // Qualitative Insight Components
 // -----------------------------------------------------------------------------
 
+function hasMeaningfulText(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
 export interface AtAGlanceTargetSections {
   wins: boolean;
   friction: boolean;
@@ -27,46 +31,58 @@ export function AtAGlance({
   const { atAGlance } = qualitative;
   if (!atAGlance) return null;
 
+  const sections = [
+    {
+      key: 'wins',
+      label: "What's working:",
+      body: atAGlance.whats_working,
+      href: '#section-wins',
+      link: 'Impressive Things You Did →',
+      showLink: targetSections.wins,
+    },
+    {
+      key: 'friction',
+      label: "What's hindering you:",
+      body: atAGlance.whats_hindering,
+      href: '#section-friction',
+      link: 'Where Things Go Wrong →',
+      showLink: targetSections.friction,
+    },
+    {
+      key: 'features',
+      label: 'Quick wins to try:',
+      body: atAGlance.quick_wins,
+      href: '#section-features',
+      link: 'Features to Try →',
+      showLink: targetSections.features,
+    },
+    {
+      key: 'horizon',
+      label: 'Ambitious workflows:',
+      body: atAGlance.ambitious_workflows,
+      href: '#section-horizon',
+      link: 'On the Horizon →',
+      showLink: targetSections.horizon,
+    },
+  ].filter((section) => hasMeaningfulText(section.body));
+
+  if (sections.length === 0) return null;
+
   return (
     <div className="at-a-glance">
       <div className="glance-title">At a Glance</div>
       <div className="glance-sections">
-        <div className="glance-section">
-          <strong>What&apos;s working:</strong>{' '}
-          <MarkdownText>{atAGlance.whats_working}</MarkdownText>
-          {targetSections.wins && (
-            <a href="#section-wins" className="see-more">
-              Impressive Things You Did →
-            </a>
-          )}
-        </div>
-        <div className="glance-section">
-          <strong>What&apos;s hindering you:</strong>{' '}
-          <MarkdownText>{atAGlance.whats_hindering}</MarkdownText>
-          {targetSections.friction && (
-            <a href="#section-friction" className="see-more">
-              Where Things Go Wrong →
-            </a>
-          )}
-        </div>
-        <div className="glance-section">
-          <strong>Quick wins to try:</strong>{' '}
-          <MarkdownText>{atAGlance.quick_wins}</MarkdownText>
-          {targetSections.features && (
-            <a href="#section-features" className="see-more">
-              Features to Try →
-            </a>
-          )}
-        </div>
-        <div className="glance-section">
-          <strong>Ambitious workflows:</strong>{' '}
-          <MarkdownText>{atAGlance.ambitious_workflows}</MarkdownText>
-          {targetSections.horizon && (
-            <a href="#section-horizon" className="see-more">
-              On the Horizon →
-            </a>
-          )}
-        </div>
+        {sections.map((section) => (
+          <div key={section.key} className="glance-section">
+            <strong>{section.label}</strong>{' '}
+            <MarkdownText>{section.body}</MarkdownText>
+            {section.showLink && (
+              <a href={section.href} className="see-more">
+                {section.link}
+              </a>
+            )}
+          </div>
+        ))}
       </div>
     </div>
   );
@@ -202,12 +218,11 @@ export function ImpressiveWorkflows({
   primarySuccess,
   outcomes,
 }: {
-  qualitative: QualitativeData;
+  qualitative?: QualitativeData;
   primarySuccess: Record<string, number>;
   outcomes: Record<string, number>;
 }) {
-  const { impressiveWorkflows } = qualitative;
-  if (!impressiveWorkflows) return null;
+  const impressiveWorkflows = qualitative?.impressiveWorkflows;
 
   return (
     <>
@@ -217,22 +232,24 @@ export function ImpressiveWorkflows({
       >
         Impressive Things You Did
       </h2>
-      {impressiveWorkflows.intro && (
+      {impressiveWorkflows?.intro && (
         <p className="section-intro">
           <MarkdownText>{impressiveWorkflows.intro}</MarkdownText>
         </p>
       )}
-      <div className="big-wins">
-        {Array.isArray(impressiveWorkflows.impressive_workflows) &&
-          impressiveWorkflows.impressive_workflows.map((win, idx) => (
-            <div key={idx} className="big-win">
-              <div className="big-win-title">{win.title}</div>
-              <div className="big-win-desc">
-                <MarkdownText>{win.description}</MarkdownText>
+      {impressiveWorkflows && (
+        <div className="big-wins">
+          {Array.isArray(impressiveWorkflows.impressive_workflows) &&
+            impressiveWorkflows.impressive_workflows.map((win, idx) => (
+              <div key={idx} className="big-win">
+                <div className="big-win-title">{win.title}</div>
+                <div className="big-win-desc">
+                  <MarkdownText>{win.description}</MarkdownText>
+                </div>
               </div>
-            </div>
-          ))}
-      </div>
+            ))}
+        </div>
+      )}
 
       <div
         style={{
@@ -303,7 +320,9 @@ function HorizontalBarChart({
   if (!data || Object.keys(data).length === 0) return null;
 
   // Filter and sort entries
-  let entries = Object.entries(data);
+  let entries = Object.entries(data).filter(
+    ([, count]) => Number.isFinite(count) && count !== 0,
+  );
   if (allowedKeys) {
     entries = entries.filter(([key]) => allowedKeys.includes(key));
   }
@@ -426,12 +445,11 @@ export function FrictionPoints({
   satisfaction,
   friction,
 }: {
-  qualitative: QualitativeData;
+  qualitative?: QualitativeData;
   satisfaction?: Record<string, number>;
   friction?: Record<string, number>;
 }) {
-  const { frictionPoints } = qualitative;
-  if (!frictionPoints) return null;
+  const frictionPoints = qualitative?.frictionPoints;
 
   return (
     <>
@@ -441,31 +459,33 @@ export function FrictionPoints({
       >
         Where Things Go Wrong
       </h2>
-      {frictionPoints.intro && (
+      {frictionPoints?.intro && (
         <p className="section-intro">
           <MarkdownText>{frictionPoints.intro}</MarkdownText>
         </p>
       )}
-      <div className="friction-categories">
-        {Array.isArray(frictionPoints.categories) &&
-          frictionPoints.categories.map((cat, idx) => (
-            <div key={idx} className="friction-category">
-              <div className="friction-title">{cat.category}</div>
-              <div className="friction-desc">
-                <MarkdownText>{cat.description}</MarkdownText>
+      {frictionPoints && (
+        <div className="friction-categories">
+          {Array.isArray(frictionPoints.categories) &&
+            frictionPoints.categories.map((cat, idx) => (
+              <div key={idx} className="friction-category">
+                <div className="friction-title">{cat.category}</div>
+                <div className="friction-desc">
+                  <MarkdownText>{cat.description}</MarkdownText>
+                </div>
+                {Array.isArray(cat.examples) && cat.examples.length > 0 && (
+                  <ul className="friction-examples">
+                    {cat.examples.map((ex, i) => (
+                      <li key={i}>
+                        <MarkdownText>{ex}</MarkdownText>
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </div>
-              {Array.isArray(cat.examples) && cat.examples.length > 0 && (
-                <ul className="friction-examples">
-                  {cat.examples.map((ex, i) => (
-                    <li key={i}>
-                      <MarkdownText>{ex}</MarkdownText>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-          ))}
-      </div>
+            ))}
+        </div>
+      )}
 
       {/* Facets Data Charts */}
       <div


### PR DESCRIPTION
## TLDR

This PR hardens the insight generation system by adding robust normalization for session facet data and improving handling of empty qualitative sections in the insight report UI.

### Key Changes:
- **DataProcessor.ts**: Added comprehensive normalization functions (, , , ) to handle malformed or incomplete LLM responses gracefully
- **DataProcessor.ts**: Added  helper to filter out empty/invalid qualitative data
- **App.tsx & Qualitative.tsx**: Updated UI components to conditionally render sections only when they contain meaningful data, preventing empty sections from appearing in reports
- **Tests**: Added comprehensive test coverage for malformed facet handling and empty qualitative scenarios

## Screenshots / Video Demo

N/A — internal data handling improvements with no visible UI changes when data is present. When qualitative data is empty, sections are now hidden instead of showing blank areas.

## Dive Deeper

The insight generation pipeline processes session data through LLM analysis to produce both quantitative metrics and qualitative insights. Previously, the system had several vulnerabilities:

1. **Malformed LLM responses**: When the LLM returned null values, unexpected types, or invalid enum values for facet fields, the aggregation logic would fail or produce incorrect results
2. **Empty qualitative data**: When all qualitative sections were empty, the UI would still render section headers and navigation links to nowhere
3. **Cached facet reuse**: Previously cached facets weren't validated when reused, potentially propagating malformed data

This PR addresses these issues by:

1. **Normalization layer**: All facet data is now normalized through type-safe functions that coerce invalid values to sensible defaults (e.g., invalid enum values fall back to defaults, null objects become empty records)

2. **Meaningfulness checks**: The UI now checks if qualitative sections have actual content before rendering them, using a recursive  function that handles strings, numbers, arrays, and objects

3. **Defensive aggregation**: Count record aggregation now safely handles malformed inputs using 

4. **Cached facet validation**: When reusing cached facets from previous runs, they are now normalized before being returned

## Reviewer Test Plan

1. Run the insight generation on a dataset with mixed session types
2. Verify that malformed LLM responses (simulated in tests) are handled gracefully
3. Check that the insight report UI renders correctly with partial or empty qualitative data
4. Run the new test cases: 

 ✓ src/services/insight/generators/DataProcessor.test.ts (42 tests) 68ms

 Test Files  1 passed (1)
      Tests  42 passed (42)
   Start at  18:28:01
   Duration  6.19s (transform 1.17s, setup 22ms, collect 2.32s, tests 68ms, environment 384ms, prepare 98ms)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | -   | -   | -   |
| Seatbelt | ❓  | -   | -   |

*Tested on macOS with npm run build + npm run test*

## Linked issues / bugs

No linked issues

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)