### PR TITLE
fix(core): treat empty 'pages' parameter as unset in ReadFile

### DIFF
--- a/packages/core/src/tools/read-file.test.ts
+++ b/packages/core/src/tools/read-file.test.ts
@@ -480,6 +480,14 @@ describe('ReadFileTool', () => {
       expect(() => tool.build(params)).not.toThrow();
     });
 
+    it('should treat empty pages parameter as unset', () => {
+      const params: ReadFileToolParams = {
+        file_path: path.join(tempRootDir, 'test.txt'),
+        pages: '',
+      };
+      expect(() => tool.build(params)).not.toThrow();
+    });
+
     it('should support offset and limit for text files', async () => {
       const filePath = path.join(tempRootDir, 'paginated.txt');
       const lines = Array.from({ length: 20 }, (_, i) => `Line ${i + 1}`);

--- a/packages/core/src/tools/read-file.ts
+++ b/packages/core/src/tools/read-file.ts
@@ -264,7 +264,7 @@ export class ReadFileTool extends BaseDeclarativeTool<
       return 'Limit must be a positive number';
     }
 
-    if (params.pages !== undefined) {
+    if (params.pages) {
       const parsed = parsePDFPageRange(params.pages);
       if (!parsed) {
         return `Invalid pages parameter: '${params.pages}'. Use formats like '5' or '1-10'.`;


### PR DESCRIPTION
## Summary

- `params.pages !== undefined` let `""` fall through to `parsePDFPageRange('')`, which returns `null` and surfaced `Invalid pages parameter: ''` for every `read_file` call from models that default optional strings to `""`.
- Switch the guard to a truthy check so `""` behaves the same as an omitted field.
- Add a regression test covering `pages: ''`.

Fixes #3558

## Origin and why this slipped through

The `pages` parameter was introduced in #3160 (`feat(core): PDF text extraction fallback and Jupyter notebook parsing`, merged 2026-04-20). That PR added, in `packages/core/src/tools/read-file.ts`:

```ts
if (params.pages !== undefined) {
  const parsed = parsePDFPageRange(params.pages);
  if (!parsed) {
    return `Invalid pages parameter: '${params.pages}'. Use formats like '5' or '1-10'.`;
  }
  ...
}
```

`!== undefined` is the natural guard if you think about the parameter in JS/TS terms — the caller is code and would only pass the field when meaningful. But the caller here is an LLM emitting JSON against a tool schema, and two realities from that side weren't accounted for:

1. **Some models habitually populate every declared string field with `""` rather than omitting optionals.** I reproduced this end-to-end on the released 0.15.0 build across 9 models in `~/.qwen/settings.json`. With a prompt that nudges the model to fill all parameters:

   | Model | Emits `pages: ""`? | Surfaces `Invalid pages parameter`? |
   |---|---|---|
   | claude-sonnet-4-6 | no (omits) | no |
   | bailian/kimi-k2.5 | sends `null` (schema blocks first) | no |
   | qwen3.6-plus-preview | once | no (other error first) |
   | bigmodel/GLM-5 | yes | blocked by `limit: 0` first |
   | glm-4.7 | yes | blocked by `offset: ""` first |
   | **bigmodel/GLM-5.1** | **yes** | **yes** |
   | **gpt-5.4** | **yes** | **yes** |
   | **pai/glm-5** | **yes** | **yes** |
   | **qwen3.6-plus** | **yes** | **yes (3x in one turn)** |

   Even without the explicit "fill all params" nudge, qwen3.6-plus and pai/glm-5 do this under slightly longer conversations — e.g. when `/review` subagents read many diff files in sequence.

2. **The retry-loop detector amplifies, not suppresses, the symptom.** Once the tool returns `Invalid pages parameter: ''`, the model retries with the same call shape (it doesn't introspect the error to drop the field). After a few retries we hit `RETRY LOOP DETECTED`, which is what users actually see — the original validation message is buried underneath.

So the fix is to make the validation tolerant of the common `""` shape rather than ask every consumer (every model, every subagent system prompt) to know that `""` is forbidden for this specific field.

## Test plan

- [x] `npx vitest run packages/core/src/tools/read-file.test.ts` — 38 passed
- [x] New test `should treat empty pages parameter as unset` passes
- [x] Existing invalid/valid/range tests still pass
- [x] E2E reproduction on released 0.15.0 (`qwen -m qwen3.6-plus ...`) confirms the error surface before the fix