### PR TITLE
revert(vscode-ide-companion): undo #3450 split-stream timestamp sharing

### DIFF
--- a/packages/vscode-ide-companion/src/webview/hooks/message/useMessageHandling.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/hooks/message/useMessageHandling.test.tsx
@@ -8,7 +8,7 @@
 
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useMessageHandling, type TextMessage } from './useMessageHandling.js';
 
 type MessageHandlingApi = ReturnType<typeof useMessageHandling>;
@@ -41,6 +41,26 @@ function renderHookHarness() {
   };
 }
 
+/**
+ * The webview merges text messages and tool calls and sorts them by
+ * `timestamp` for rendering. Two known bugs push that sort in opposite
+ * directions:
+ *
+ *   - Tool-call interleave: a tool call that arrives between two assistant
+ *     segments of the same turn must sort strictly between them. This
+ *     requires seg1.ts < toolCall.ts < seg2.ts.
+ *
+ *   - #3273 (user question appears above the previous assistant answer):
+ *     a user message belonging to a later turn must sort after every
+ *     segment / tool call of the previous turn, even if the later segment
+ *     was created after the user message was added. This requires all
+ *     segments of turn N to be strictly less than any message/tool call
+ *     from turn N+1.
+ *
+ * A single timestamp strategy cannot satisfy both simultaneously without a
+ * monotonic-sequence layer. These tests pin the current behaviour of the
+ * hook so we can wire a proper fix in next.
+ */
 describe('useMessageHandling', () => {
   let root: Root | null = null;
   let container: HTMLDivElement | null = null;
@@ -52,6 +72,7 @@ describe('useMessageHandling', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     if (root) {
       act(() => {
         root?.unmount();
@@ -64,7 +85,10 @@ describe('useMessageHandling', () => {
     }
   });
 
-  it('keeps the original stream timestamp when a tool call splits one assistant reply into multiple segments', () => {
+  it('assigns the second assistant segment a newer timestamp so a tool call can sort between the two segments', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+
     const rendered = renderHookHarness();
     root = rendered.root;
     container = rendered.container;
@@ -74,15 +98,20 @@ describe('useMessageHandling', () => {
     });
 
     act(() => {
-      rendered.api.appendStreamChunk('before tool call');
+      rendered.api.appendStreamChunk('seg1');
     });
 
+    // Tool call arrives and triggers a segment break.
+    vi.setSystemTime(2_000);
+    const toolCallTimestamp = Date.now();
     act(() => {
       rendered.api.breakAssistantSegment();
     });
 
+    // Next chunk lands after the tool call.
+    vi.setSystemTime(3_000);
     act(() => {
-      rendered.api.appendStreamChunk('after tool call');
+      rendered.api.appendStreamChunk('seg2');
     });
 
     const assistantMessages = rendered.api.messages.filter(
@@ -90,8 +119,68 @@ describe('useMessageHandling', () => {
     );
 
     expect(assistantMessages).toHaveLength(2);
-    expect(assistantMessages.map((message) => message.timestamp)).toEqual([
-      1_000, 1_000,
-    ]);
+    expect(assistantMessages[0].timestamp).toBeLessThan(toolCallTimestamp);
+    expect(assistantMessages[1].timestamp).toBeGreaterThan(toolCallTimestamp);
   });
+
+  it.fails(
+    'keeps every assistant segment of a turn before a user message that was sent between segments (#3273)',
+    () => {
+      // Reproduces the race that #3273 describes: React batching (or any
+      // other delay) causes the second segment's placeholder to materialize
+      // AFTER the next user message has already been pushed into the list.
+      // Because the placeholder uses Date.now() at materialization time, it
+      // receives a timestamp greater than the new user message, and the
+      // user bubble ends up sandwiched between the two assistant segments
+      // once the list is sorted.
+      vi.useFakeTimers();
+      vi.setSystemTime(1_000);
+
+      const rendered = renderHookHarness();
+      root = rendered.root;
+      container = rendered.container;
+
+      act(() => {
+        rendered.api.startStreaming(1_000);
+      });
+
+      act(() => {
+        rendered.api.appendStreamChunk('seg1');
+      });
+
+      vi.setSystemTime(2_000);
+      act(() => {
+        rendered.api.breakAssistantSegment();
+      });
+
+      // The user types and sends their next question before the delayed
+      // second-segment chunk is flushed.
+      vi.setSystemTime(3_000);
+      act(() => {
+        rendered.api.addMessage({
+          role: 'user',
+          content: 'next question',
+          timestamp: Date.now(),
+        });
+      });
+
+      // Second-segment chunk finally runs.
+      vi.setSystemTime(4_000);
+      act(() => {
+        rendered.api.appendStreamChunk('seg2');
+      });
+
+      const sorted = [...rendered.api.messages].sort(
+        (a, b) => a.timestamp - b.timestamp,
+      );
+      const roles = sorted.map((m) => m.role);
+      const userIdx = roles.indexOf('user');
+      const lastAssistantIdx = roles.lastIndexOf('assistant');
+
+      // Expected (and currently violated) invariant: the user message marks
+      // the start of a new turn, so every assistant segment of the previous
+      // turn must come before it.
+      expect(lastAssistantIdx).toBeLessThan(userIdx);
+    },
+  );
 });

--- a/packages/vscode-ide-companion/src/webview/hooks/message/useMessageHandling.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/message/useMessageHandling.ts
@@ -35,8 +35,6 @@ export const useMessageHandling = () => {
   const streamingMessageIndexRef = useRef<number | null>(null);
   // Track the index of the current aggregated thinking message
   const thinkingMessageIndexRef = useRef<number | null>(null);
-  // Preserve one stable timestamp for all message segments in the same turn.
-  const currentStreamTimestampRef = useRef<number | null>(null);
 
   /**
    * Add message
@@ -56,9 +54,6 @@ export const useMessageHandling = () => {
    * Start streaming response
    */
   const startStreaming = useCallback((timestamp?: number) => {
-    const resolvedTimestamp =
-      typeof timestamp === 'number' ? timestamp : Date.now();
-    currentStreamTimestampRef.current = resolvedTimestamp;
     // Create an assistant placeholder message immediately so tool calls won't jump before it
     setMessages((prev) => {
       // Record index of the placeholder to update on chunks
@@ -68,8 +63,8 @@ export const useMessageHandling = () => {
         {
           role: 'assistant',
           content: '',
-          // Use one stable turn timestamp so later split segments sort correctly.
-          timestamp: resolvedTimestamp,
+          // Use provided timestamp (from extension) to keep ordering stable
+          timestamp: typeof timestamp === 'number' ? timestamp : Date.now(),
         },
       ];
     });
@@ -94,11 +89,7 @@ export const useMessageHandling = () => {
         if (idx === null) {
           idx = next.length;
           streamingMessageIndexRef.current = idx;
-          next.push({
-            role: 'assistant',
-            content: '',
-            timestamp: currentStreamTimestampRef.current ?? Date.now(),
-          });
+          next.push({ role: 'assistant', content: '', timestamp: Date.now() });
         }
 
         if (idx < 0 || idx >= next.length) {
@@ -131,7 +122,6 @@ export const useMessageHandling = () => {
     setIsStreaming(false);
     streamingMessageIndexRef.current = null;
     thinkingMessageIndexRef.current = null;
-    currentStreamTimestampRef.current = null;
   }, []);
 
   /**
@@ -183,7 +173,7 @@ export const useMessageHandling = () => {
             assistantIdx >= 0 &&
             assistantIdx < next.length
               ? next[assistantIdx].timestamp
-              : (currentStreamTimestampRef.current ?? Date.now());
+              : Date.now();
           next.push({
             role: 'thinking',
             content: '',


### PR DESCRIPTION
## TLDR

Roll back #3450 byte-for-byte on `useMessageHandling.ts`. #3450 tried to fix #3273 (a later user message sorting between two segments of the previous assistant turn) by pinning every split segment to the same turn-start timestamp, but that strategy conflicts with the tool-call timeline: tool calls carry their own arrival timestamp (strictly greater than the turn-start timestamp), so after #3450 every tool call sorts **after** both assistant segments instead of between them. The resulting "tool call jumped to the end" symptom is what users are currently reporting. Revert unblocks that regression; two focused tests pin the two conflicting invariants so the next fix has a clear target.

## Dive Deeper

The webview (`App.tsx`) merges text messages (`useMessageHandling.messages`) and tool-call cards (`useToolCalls` map) into a single array and sorts by `timestamp` for rendering. Three producers write into that sort key:

1. **Assistant seg1** — created by `startStreaming(T_stream)` using the extension-side `Date.now()` that rides on the `streamStart` message.
2. **Tool call** — created by `useToolCalls.resolveTimestamp`, which takes the ACP `_meta.timestamp` when present, otherwise the webview's `Date.now()` at event-arrival time. Always ≥ `T_stream`.
3. **Assistant seg2** (the one created after a `breakAssistantSegment()`) — before #3450, created with the webview's `Date.now()` at chunk-arrival time; after #3450, re-uses `T_stream`.

**#3273** — under React batching on Linux, `Date.now()` inside the `setMessages` reducer of `appendStreamChunk` can be evaluated later than the next-turn user message was pushed. That produces `seg2.ts > nextUser.ts`, and the sort wedges the new user bubble between seg1 and seg2.

**#3450** — reused `T_stream` for seg2 so `seg1.ts == seg2.ts`; since the next user message's timestamp is always > `T_stream`, it can no longer slip between segments. This closed #3273 but locked every seg2 at `T_stream`, which is less than any tool call in the same turn — so tool-call cards are now appended at the bottom of the turn instead of between the two segments.

The two invariants are genuinely opposed under a single-timestamp sort:

| Invariant needed for… | Constraint |
|---|---|
| Tool-call interleave (today's bug) | `seg1.ts < toolCall.ts < seg2.ts` |
| #3273 (yesterday's bug) | `all segs of turn N < any event of turn N+1` |

Satisfying both requires a monotonic sequence number shared across producers (messages, tool calls, plan cards), not just smarter timestamps. That is out of scope for this revert — the goal here is to restore the more-visible tool-call ordering and pin the invariants down in tests so the next PR can be judged against both at once.

This PR touches exactly two files:

- `useMessageHandling.ts` — identical to `cfe142e9a^` (byte-for-byte).
- `useMessageHandling.test.tsx` — rewritten with two focused cases (see Reviewer Test Plan).

## Reviewer Test Plan

1. In `packages/vscode-ide-companion`, run `npm run build`.
2. `npx vitest run src/webview/hooks` — all 5 test files / 10 cases green, including the two new ones in `useMessageHandling.test.tsx`:
   - `assigns the second assistant segment a newer timestamp so a tool call can sort between the two segments` — a normal `it`, passes today.
   - `keeps every assistant segment of a turn before a user message that was sent between segments (#3273)` — marked `it.fails` and documents the known regression; will flip to a plain `it` once the monotonic-sequence fix lands.
3. Open the VS Code companion and send a prompt that emits tool calls mid-reply (e.g. "read file X and summarize"). Confirm the tool-call cards now render between the two assistant text segments instead of being appended after them.
4. Optional stress: send a follow-up user question quickly after a tool-heavy turn; #3273 may reappear until the proper fix lands — this is the expected trade-off documented by the `it.fails` test.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | -   | -   | -   |
| Podman   | -   | -   | -   |
| Seatbelt | -   | -   | -   |

## Linked issues / bugs

Reverts #3450. Re-opens #3273 as a known regression pinned by the `it.fails` test; the next PR should close it together with the tool-call interleave invariant.