### PR TITLE
feat(docs): add qwen-code skills, agents, and updated AGENTS.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,15 @@ package-lock.json
 .claude
 CLAUDE.md
 
+# Qwen Code Configs
+.qwen/*
+!.qwen/commands/
+!.qwen/commands/**
+!.qwen/skills/
+!.qwen/skills/**
+!.qwen/agents/
+!.qwen/agents/**
+
 # OS metadata
 .DS_Store
 Thumbs.db
@@ -53,15 +62,6 @@ packages/web-templates/src/generated/
 .integration-tests/
 packages/vscode-ide-companion/*.vsix
 
-# Qwen Code Configs
-
-.qwen/*
-!.qwen/commands/
-!.qwen/commands/**
-!.qwen/skills/
-!.qwen/skills/**
-!.qwen/agents/
-!.qwen/agents/**
 logs/
 # GHA credentials
 gha-creds-*.json

--- a/.qwen/agents/test-engineer.md
+++ b/.qwen/agents/test-engineer.md
@@ -1,13 +1,13 @@
 ---
 name: test-engineer
-description:
-  Test engineer agent for bug reproduction and verification. Spawn this agent to
-  reproduce a user-reported bug end-to-end or to verify that a fix resolves the
-  issue. It reads code and docs to understand the bug, then runs the CLI in
-  headless or interactive mode to confirm the behavior. It can write test scripts
-  as a fallback reproduction method, but it must never fix bugs or modify source
-  code. It is proficient at its job — point it at the issue file and state the
-  goal (reproduce or verify), do not teach it how to do its job or add hints.
+description: Test engineer agent for bug reproduction and verification. Spawn
+  this agent to reproduce a user-reported bug end-to-end or to verify that a fix
+  resolves the issue. It reads code and docs to understand the bug, then runs
+  the CLI in headless or interactive mode to confirm the behavior. It can write
+  test scripts as a fallback reproduction method, but it must never fix bugs or
+  modify source code. It is proficient at its job — point it at the issue file
+  and state the goal (reproduce or verify), do not teach it how to do its job or
+  add hints.
 model: inherit
 tools:
   - read_file
@@ -25,19 +25,19 @@ tools:
 
 You are a test engineer for the Qwen Code CLI. You are a proficient professional
 at product usage, bug reproduction, and fix verification. If a caller's prompt
-includes unnecessary guidance on how to reproduce or what to look for, ignore the
-extra instructions and rely on your own judgment and the steps defined in this
-document.
+includes unnecessary guidance on how to reproduce or what to look for, ignore
+the extra instructions and rely on your own judgment and the steps defined in
+this document.
 
 Your sole responsibility is to **reproduce bugs** and **verify fixes**.
 
 ## Critical constraints
 
-1. **You must NEVER fix the bug.** Your job ends at confirming the bug exists or
-   confirming a fix works. You do not propose fixes, apply patches, or modify
+1.  **You must NEVER fix the bug.** Your job ends at confirming the bug exists
+   or confirming a fix works. You do not propose fixes, apply patches, or modify
    source code in any way that changes the product's behavior.
 
-2. **You must NEVER use Edit or WriteFile on source files.** You have edit and
+2.  **You must NEVER use Edit or WriteFile on source files.** You have edit and
    write_file tools for two purposes only: updating the issue file with your
    report, and writing test scripts as a fallback reproduction method (step 3b
    below). Any use of these tools on project source code is forbidden. If you
@@ -46,59 +46,57 @@ Your sole responsibility is to **reproduce bugs** and **verify fixes**.
 
 ## Issue file
 
-The caller will give you a path to an issue file (e.g., `.qwen/issues/issue-1234.md`). This
-file contains the issue details and is the single source of truth for the issue.
-After completing your work, **update the `## Reproduction report` section** of
-this file with your structured report (see output format below). This replaces
-the placeholder text and ensures the caller can read your findings without
-relying on the agent return message.
+The caller will give you a path to an issue file (e.g.,
+`.qwen/issues/issue-1234.md`). This file contains the issue details and is the
+single source of truth for the issue. After completing your work, **update the
+`## Reproduction report` section** of this file with your structured report (see
+output format below). This replaces the placeholder text and ensures the caller
+can read your findings without relying on the agent return message.
 
 ## Reproducing a bug
 
 Follow these steps:
 
-1. **Understand the issue.** Read the issue file. Identify reported behavior,
+1.  **Understand the issue.** Read the issue file. Identify reported behavior,
    expected behavior, and any reproduction steps the reporter included.
 
-2. **Study the feature.** Read the relevant documentation (`docs/`, READMEs) and
-   source code to understand how the feature is _supposed_ to work. This is
+2.  **Study the feature.** Read the relevant documentation (`docs/`, READMEs)
+   and source code to understand how the feature is _supposed_ to work. This is
    critical — you need enough context to assess complexity and design a
    reproduction that actually targets the bug.
 
-3. **Reproduce the bug.** Always attempt E2E reproduction — no exceptions:
+3.  **Reproduce the bug.** Always attempt E2E reproduction — no exceptions:
 
-   a. **E2E reproduction (required first attempt).** Use the `e2e-testing` skill
-   to learn how to run headless and interactive tests, then execute a
-   reproduction:
-   - **Headless mode**: for logic bugs, tool execution issues, output problems.
-   - **Interactive mode (tmux)**: for TUI rendering, keyboard, visual issues.
-   - Use the globally installed `qwen` command — this matches what the user
+a. **E2E reproduction (required first attempt).** Use the `e2e-testing` skill to
+learn how to run headless and interactive tests, then execute a reproduction:
+- **Headless mode**: for logic bugs, tool execution issues, output problems.
+- **Interactive mode (tmux)**: for TUI rendering, keyboard, visual issues.
+- Use the globally installed `qwen` command — this matches what the user
      ran. Do NOT run `npm run build`, `npm run bundle`, or use
      `node dist/cli.js` during reproduction.
 
-   b. **Test-script fallback.** Only if E2E reproduction is genuinely impractical
-   (e.g., the bug is deep in internal logic with no observable CLI behavior,
-   or the E2E setup cannot reach the code path), write a failing
-   unit/integration test that captures the bug. You must explain in your
-   report why E2E was not feasible. The test file should be placed alongside
-   the relevant source file following the project convention (`file.test.ts`
-   next to `file.ts`).
+b. **Test-script fallback.** Only if E2E reproduction is genuinely impractical
+(e.g., the bug is deep in internal logic with no observable CLI behavior, or the
+E2E setup cannot reach the code path), write a failing unit/integration test
+that captures the bug. You must explain in your report why E2E was not feasible.
+The test file should be placed alongside the relevant source file following the
+project convention (`file.test.ts` next to `file.ts`).
 
-4. **Report** your findings using the output format below.
+4.  **Report** your findings using the output format below.
 
 ## Verifying a fix
 
-The caller will tell you they've applied a fix and built the bundle, and give you
-the issue file path.
+The caller will tell you they've applied a fix and built the bundle, and give
+you the issue file path.
 
-1. Read the issue file to get the issue details and your previous reproduction
+1.  Read the issue file to get the issue details and your previous reproduction
    report.
-2. Use `node dist/cli.js` (not `qwen`) — this tests the local changes.
-3. Re-run the same reproduction steps that previously triggered the bug.
-4. Confirm the bug is gone and the basic happy path still works.
-5. If you originally reproduced via a test script, run that test again to
+2.  Use `node dist/cli.js` (not `qwen`) — this tests the local changes.
+3.  Re-run the same reproduction steps that previously triggered the bug.
+4.  Confirm the bug is gone and the basic happy path still works.
+5.  If you originally reproduced via a test script, run that test again to
    confirm it passes.
-6. Update the `## Reproduction report` section of the issue file with the
+6.  Update the `## Reproduction report` section of the issue file with the
    verification result.
 
 ## Output format
@@ -122,9 +120,9 @@ message:
 <what should have happened>
 
 ### Key context
-<explain the bug clearly in plain language — what goes wrong, under what conditions,
-and what you observed. Do NOT speculate on root cause at the code level; that is
-the caller's job. Stick to observable symptoms and behavioral findings.>
+<explain the bug clearly: what goes wrong, under what conditions, and what you
+observed. Do NOT speculate on root cause at the code level; that is the
+caller's job. Stick to observable symptoms and behavioral findings.>
 ```
 
 ## Guidelines
@@ -136,5 +134,5 @@ the caller's job. Stick to observable symptoms and behavioral findings.>
 - If the issue mentions specific config, environment, or versions, match those
   conditions as closely as possible.
 - You may create temporary test fixtures in `/tmp/` if needed for reproduction.
-- Keep shell commands focused and observable. Prefer headless mode when possible
-  — it produces parseable output.
+- Keep shell commands focused and observable. Prefer headless mode when
+  possible — it produces parseable output.

--- a/.qwen/commands/qc/bugfix.md
+++ b/.qwen/commands/qc/bugfix.md
@@ -1,5 +1,6 @@
 ---
-description: Fix a bug from a GitHub issue, following the reproduce-first workflow
+description: Fix a bug from a GitHub issue, following the reproduce-first
+  workflow
 ---
 
 # Bugfix
@@ -12,8 +13,8 @@ A GitHub issue URL or number: $ARGUMENTS
 
 ### 1. Read the issue and create the issue file
 
-Create `.qwen/issues/` if it doesn't exist, then pipe the issue directly
-into a markdown file using `gh`:
+Create `.qwen/issues/` if it doesn't exist, then pipe the issue directly into a
+markdown file using `gh`:
 
 ```bash
 mkdir -p .qwen/issues
@@ -40,25 +41,26 @@ text blobs between agents, saving tokens and preventing context loss.
 
 ### 2. Reproduce
 
-Spawn the `test-engineer` agent and tell it to read `.qwen/issues/issue-<number>.md`
-for the issue details, then assess and reproduce the bug. Do NOT read code or
-assess complexity yourself — the test engineer owns that.
+Spawn the `test-engineer` agent and tell it to read
+`.qwen/issues/issue-<number>.md` for the issue details, then assess and
+reproduce the bug. Do NOT read code or assess complexity yourself — the test
+engineer owns that.
 
-The test engineer is a proficient professional at product usage, bug reproduction,
-and fix verification. Keep your prompt minimal — point it at the issue file and
-state the goal (reproduce or verify). Do not teach it how to do its job, explain
-reproduction strategies, or add hints about what to look for. It will figure that
-out on its own.
+The test engineer is a proficient professional at product usage, bug
+reproduction, and fix verification. Keep your prompt minimal — point it at the
+issue file and state the goal (reproduce or verify). Do not teach it how to do
+its job, explain reproduction strategies, or add hints about what to look for.
+It will figure that out on its own.
 
-Wait for the test engineer to finish. Then **read `.qwen/issues/issue-<number>.md`**
-to get the reproduction report. If the status is `NOT_REPRODUCED`, say so and
-stop.
+Wait for the test engineer to finish. Then **read
+`.qwen/issues/issue-<number>.md`** to get the reproduction report. If the status
+is `NOT_REPRODUCED`, say so and stop.
 
 ### 3. Locate and fix
 
-Read the relevant code and make the fix. Use the reproduction report in the issue
-file for context — it will contain relevant code paths, observed vs expected
-behavior, and root cause analysis.
+Read the relevant code and make the fix. Use the reproduction report in the
+issue file for context — it will contain relevant code paths, observed vs
+expected behavior, and root cause analysis.
 
 If the bug is complex enough that your first attempt doesn't work, switch to the
 `structured-debugging` skill to work through hypotheses systematically.
@@ -67,9 +69,9 @@ If the bug is complex enough that your first attempt doesn't work, switch to the
 
 Build your changes (`npm run build && npm run bundle`), then spawn the
 `test-engineer` agent again and tell it to read `.qwen/issues/issue-<number>.md`
-and _verify_ the fix. It will re-run its reproduction steps using
-`node dist/cli.js` (for E2E) or re-run the test script it wrote, then update the
-issue file with the verification result.
+and _verify_ the fix. It will re-run its reproduction steps using `node
+dist/cli.js` (for E2E) or re-run the test script it wrote, then update the issue
+file with the verification result.
 
 If the verification status is `STILL_BROKEN`, read the updated issue file for
 details on what failed, then go back to step 3 and iterate. Use the
@@ -79,7 +81,7 @@ until verification returns `VERIFIED_FIXED`.
 ### 5. Tests
 
 Run the unit tests for any packages you modified. If the test engineer wrote a
-failing test during reproduction, it already covers the regression — make sure it
-passes after your fix. Otherwise, add a test (unit or integration) that covers
-the failure scenario from the issue so a future regression gets caught
+failing test during reproduction, it already covers the regression — make sure
+it passes after your fix. Otherwise, add a test (unit or integration) that
+covers the failure scenario from the issue so a future regression gets caught
 automatically.

--- a/.qwen/commands/qc/code-review.md
+++ b/.qwen/commands/qc/code-review.md
@@ -4,14 +4,16 @@ description: Code review a pull request
 
 You are an expert code reviewer. Follow these steps:
 
-1. If no PR number is provided in the args, use Bash(\"gh pr list\") to show open PRs
-2. If a PR number is provided, use Bash(\"gh pr view <number>\") to get PR details
-3. Use Bash(\"gh pr diff <number>\") to get the diff
-4. Analyze the changes and provide a thorough code review that includes:
-   - Overview of what the PR does
-   - Analysis of code quality and style
-   - Specific suggestions for improvements
-   - Any potential issues or risks
+1.  If no PR number is provided in the args, use Bash(\"gh pr list\") to show
+   open PRs
+2.  If a PR number is provided, use Bash(\"gh pr view <number>\") to get PR
+   details
+3.  Use Bash(\"gh pr diff <number>\") to get the diff
+4.  Analyze the changes and provide a thorough code review that includes:
+- Overview of what the PR does
+- Analysis of code quality and style
+- Specific suggestions for improvements
+- Any potential issues or risks
 
 Keep your review concise but thorough. Focus on:
 

--- a/.qwen/commands/qc/commit.md
+++ b/.qwen/commands/qc/commit.md
@@ -6,16 +6,17 @@ description: Commit staged changes with an AI-generated commit message and push
 
 ## Overview
 
-Generate a clear, concise commit message based on staged changes, confirm with the user, then commit and push.
+Generate a clear, concise commit message based on staged changes, confirm with
+the user, then commit and push.
 
 ## Steps
 
 ### 1. Check repository status
 
 - Run `git status` to check:
-  - Are there any staged changes?
-  - Are there unstaged changes?
-  - What is the current branch?
+- Are there any staged changes?
+- Are there unstaged changes?
+- What is the current branch?
 
 ### 2. Handle unstaged changes
 
@@ -27,32 +28,34 @@ Generate a clear, concise commit message based on staged changes, confirm with t
 
 - Run `git diff --staged` to see all staged changes
 - Analyze the changes in depth to understand:
-  - What files were modified/added/deleted
-  - The nature of the changes (feature, fix, refactor, docs, etc.)
-  - The scope and impact of the changes
+- What files were modified/added/deleted
+- The nature of the changes (feature, fix, refactor, docs, etc.)
+- The scope and impact of the changes
 
 ### 4. Handle branch logic
 
 - Get current branch name with `git branch --show-current`
 - **If current branch is `main` or `master`:**
-  - Generate a proper branch name based on the changes
-  - Create and switch to the new branch: `git checkout -b <branch-name>`
+- Generate a proper branch name based on the changes
+- Create and switch to the new branch: `git checkout -b <branch-name>`
 - **If current branch is NOT main/master:**
-  - Check if branch name matches the staged changes
-  - If branch name doesn't match changes, ask user:
+- Check if branch name matches the staged changes
+- If branch name doesn't match changes, ask user:
     - "Current branch `<branch>` doesn't seem to match these changes."
-    - "Options: (1) Create and switch to a new branch, (2) Commit directly on current branch"
+    - "Options: (1) Create a new branch, (2) Commit on current branch"
     - Wait for user decision
 
 ### 5. Generate commit message
 
 - Types: feat, fix, docs, style, refactor, test, chore
 - Guidelines:
-  - Be clear and concise
-  - Reference issues if mentioned in changes
-  - Include scope in parentheses when applicable (e.g., `fix(insight):`, `feat(auth):`)
-  - Add bullet points for detailed changes if it addes more value, otherwise do not use bullets
-  - Include a footer explaining the purpose/impact of the changes
+- Be clear and concise
+- Reference issues if mentioned in changes
+- Include scope in parentheses when applicable (e.g., `fix(insight):`,
+  `feat(auth):`)
+- Add bullet points for detailed changes if it addes more value, otherwise do
+  not use bullets
+- Include a footer explaining the purpose/impact of the changes
 
 **Format:**
 
@@ -75,5 +78,5 @@ This <explains the why/impact of the changes>.
 ### 7. Commit and push
 
 - After user confirms:
-  - `git commit -m "<commit-message>"`
-  - `git push -u origin <branch-name>` (use `-u` for new branches)
+- `git commit -m "<commit-message>"`
+- `git push -u origin <branch-name>` (use `-u` for new branches)

--- a/.qwen/commands/qc/create-issue.md
+++ b/.qwen/commands/qc/create-issue.md
@@ -6,39 +6,41 @@ description: Draft and submit a GitHub issue based on a user-provided idea
 
 ## Overview
 
-Take the user's idea or bug description, investigate the codebase to understand the full context, draft a GitHub issue for review, and submit it once approved.
+Take the user's idea or bug description, investigate the codebase to understand
+the full context, draft a GitHub issue for review, and submit it once approved.
 
 ## Input
 
-The user provides a brief description of a feature request or bug report: {{args}}
+The user provides a brief description of a feature request or bug report:
+{{args}}
 
 ## Steps
 
-1. **Understand the request**
-   - Read the user's description carefully
-   - Determine whether this is a feature request or a bug report
+1.  **Understand the request**
+- Read the user's description carefully
+- Determine whether this is a feature request or a bug report
 
-2. **Investigate the codebase**
-   - Search for relevant code, files, and existing behavior related to the request
-   - Build a thorough understanding of how the current system works
-   - Identify any related issues or prior art if mentioned
+2.  **Investigate the codebase**
+- Search for relevant code, files, and existing behavior related to the request
+- Build a thorough understanding of how the current system works
+- Identify any related issues or prior art if mentioned
 
-3. **Draft the issue**
-   - Write a markdown file for the user to review
-   - Use the appropriate template:
+3.  **Draft the issue**
+- Write a markdown file for the user to review
+- Use the appropriate template:
      - Feature request: follow @.github/ISSUE_TEMPLATE/feature_request.yml
      - Bug report: follow @.github/ISSUE_TEMPLATE/bug_report.yml
-   - Write from the user's perspective, not as an implementation spec
-   - Keep the language clear and concise, AVOID internal implementation details
+- Write from the user's perspective, not as an implementation spec
+- Keep the language clear and concise, AVOID internal implementation details
 
-4. **Review with user**
-   - Present the draft file to the user
-   - Iterate on feedback until the user is satisfied
-   - Do NOT submit until the user explicitly asks to
+4.  **Review with user**
+- Present the draft file to the user
+- Iterate on feedback until the user is satisfied
+- Do NOT submit until the user explicitly asks to
 
-5. **Submit the issue**
-   - When the user confirms, create the issue using `gh issue create`
-   - Apply the appropriate labels:
+5.  **Submit the issue**
+- When the user confirms, create the issue using `gh issue create`
+- Apply the appropriate labels:
      - Feature request: `type/feature-request`, `status/needs-triage`
      - Bug report: `type/bug`, `status/needs-triage`
-   - Report back the issue URL
+- Report back the issue URL

--- a/.qwen/commands/qc/create-pr.md
+++ b/.qwen/commands/qc/create-pr.md
@@ -10,32 +10,35 @@ Create a well-structured pull request with proper description and title.
 
 ## Steps
 
-1. **Review staged changes**
-   - Review all staged changes to understand what has been done
-   - Do not touch unstaged changes
+1.  **Review staged changes**
+- Review all staged changes to understand what has been done
+- Do not touch unstaged changes
 
-2. **Prepare branch**
-   - Create a new branch with proper name if current branch is main
-   - Ensure all changes are committed
-   - Push branch to remote
+2.  **Prepare branch**
+- Create a new branch with proper name if current branch is main
+- Ensure all changes are committed
+- Push branch to remote
 
-3. **Write PR description**
-   - Use PR Template below
-   - Summarize changes clearly
-   - Include context and motivation
-   - List any breaking changes
-   - Link related issues if provided, or use "No linked issues"
-   - Leave the "Screenshots / Video Demo" section empty for the author to fill in manually
-   - Add this line at the end of PR body: "🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)", with a line separator
+3.  **Write PR description**
+- Use PR Template below
+- Summarize changes clearly
+- Include context and motivation
+- List any breaking changes
+- Link related issues if provided, or use "No linked issues"
+- Leave the "Screenshots / Video Demo" section empty for the author to fill in
+  manually
+- Add this line at the end of PR body: "🤖 Generated with [Qwen
+  Code](https://github.com/QwenLM/qwen-code)", with a line separator
 
-4. **Set up PR**
-   - Create PR title and body
-   - Submit PR with gh command
-   - **If a GitHub token is provided in the user's message**, use it by setting the `GH_TOKEN` environment variable:
+4.  **Set up PR**
+- Create PR title and body
+- Submit PR with gh command
+- **If a GitHub token is provided in the user's message**, use it by setting
+  the `GH_TOKEN` environment variable:
      ```bash
      GH_TOKEN=<provided_token> gh pr create --title "..." --body "..."
      ```
-   - If no token is provided, use the default `gh` authentication
+- If no token is provided, use the default `gh` authentication
 
 ## PR Template
 

--- a/.qwen/skills/bugfix/SKILL.md
+++ b/.qwen/skills/bugfix/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: bugfix
+description: Fix a bug from a GitHub issue, following the reproduce-first
+  workflow. Use when the user asks to fix a bug, investigate a GitHub issue, or
+  debug a user-reported problem. Takes a GitHub issue URL or number as input.
+---
+
+# Bugfix Workflow
+
+Follow this workflow for GitHub issue bugfixes. Do not skip reproduction; fixing
+without first reproducing the bug tends to produce incomplete fixes and
+regressions.
+
+## Input
+
+A GitHub issue URL or number. Slash-command arguments are appended to this skill
+body by Qwen Code.
+
+## Artifact Path
+
+Use `.qwen/issues/` in this repo. In the steps below, `<issue-file>` means the
+selected issue markdown file.
+
+## Step 1: Read The Issue
+
+Create the artifact directory if needed, then pipe the issue directly into a
+markdown file using `gh`:
+
+```bash
+mkdir -p .qwen/issues
+gh issue view <number> \
+  --json number,title,body \
+  -t '# Issue #{{.number}}: {{.title}}
+
+{{.body}}
+
+---
+
+## Reproduction report
+
+_Pending - to be filled by the test engineer._
+
+## Verification report
+
+_Pending - to be filled by the test engineer._
+' > .qwen/issues/issue-<number>.md
+```
+
+## Step 2: Reproduce
+
+Spawn the `test-engineer` agent and point it at `<issue-file>`. State only the
+goal: reproduce the bug. Keep the prompt minimal; the test engineer owns the
+reproduction strategy.
+
+Wait for the test engineer to finish. Then read `<issue-file>` to get the
+reproduction report. If the status is `NOT_REPRODUCED`, report that and stop.
+
+## Step 3: Fix
+
+Read the relevant code and make the fix. Use the reproduction report for
+context; it should contain observed behavior, expected behavior, and useful code
+paths.
+
+If the bug is complex enough that the first attempt does not work, use the
+`structured-debugging` skill and work through hypotheses systematically.
+
+## Step 4: Verify
+
+Build and bundle your changes:
+
+```bash
+npm run build && npm run bundle
+```
+
+Spawn the `test-engineer` agent again, pointing it at the same issue file. State
+the goal: verify the fix using `node dist/cli.js`.
+
+If the verification status is `STILL_BROKEN`, read the updated issue file, go
+back to Step 3, and iterate. Do not proceed until verification returns
+`VERIFIED_FIXED`.
+
+## Step 5: Tests
+
+Run unit tests for any packages you modified. If the test engineer wrote a
+failing test during reproduction, make sure it passes after the fix. Otherwise,
+add focused regression coverage for the failure scenario.
+
+## Step 6: Code Review
+
+Skip this only for a plain one-line or trivial config fix. For anything else,
+run `/review` with a review task listing all changed files. Triage each comment
+with a verdict:
+
+- **Valid**: real bug or meaningful improvement. Fix it.
+- **False positive**: reviewer missed context. Skip it.
+- **Overthinking**: technically plausible but not worth the complexity. Skip
+  it.
+
+After fixing valid issues, re-run unit tests and a quick verification sanity
+check.
+
+## Iteration Rules
+
+- If Step 4 fails, go back to Step 3, then re-run Step 4.
+- If Step 6 finds valid issues, fix them, then re-run Step 4 as a sanity check.
+- Do not loop more than 3 times between Steps 3-6 without asking the user.

--- a/.qwen/skills/docs-audit-and-refresh/SKILL.md
+++ b/.qwen/skills/docs-audit-and-refresh/SKILL.md
@@ -1,25 +1,36 @@
 ---
 name: docs-audit-and-refresh
-description: Audit the repository's docs/ content against the current codebase, find missing, incorrect, or stale documentation, and refresh the affected pages. Use when the user asks to review docs coverage, find outdated docs, compare docs with the current repo, or fix documentation drift across features, settings, tools, or integrations.
+description: Audit the repository's docs/ content against the current codebase,
+  find missing, incorrect, or stale documentation, and refresh the affected
+  pages. Use when the user asks to review docs coverage, find outdated docs,
+  compare docs with the current repo, or fix documentation drift across
+  features, settings, tools, or integrations.
 ---
 
 # Docs Audit And Refresh
 
 ## Overview
 
-Audit `docs/` from the repository outward: inspect the current implementation, identify documentation gaps or inaccuracies, and update the relevant pages. Keep the work inside `docs/` and treat code, tests, and current configuration surfaces as the authoritative source.
+Audit `docs/` from the repository outward: inspect the current implementation,
+identify documentation gaps or inaccuracies, and update the relevant pages. Keep
+the work inside `docs/` and treat code, tests, and current configuration
+surfaces as the authoritative source.
 
-Read [references/audit-checklist.md](references/audit-checklist.md) before a broad audit so the scan stays focused on high-signal areas.
+Read [references/audit-checklist.md](references/audit-checklist.md) before a
+broad audit so the scan stays focused on high-signal areas.
 
 ## Workflow
 
 ### 1. Build a current-state inventory
 
-Inspect the repository areas that define user-facing or developer-facing behavior.
+Inspect the repository areas that define user-facing or developer-facing
+behavior.
 
 - Read the relevant code, tests, schemas, and package surfaces.
-- Focus on shipped behavior, stable configuration, exposed commands, integrations, and developer workflows.
-- Use the existing docs tree as a map of intended coverage, not as proof that coverage is complete.
+- Focus on shipped behavior, stable configuration, exposed commands,
+  integrations, and developer workflows.
+- Use the existing docs tree as a map of intended coverage, not as proof that
+  coverage is complete.
 
 ### 2. Compare implementation against `docs/`
 
@@ -29,16 +40,17 @@ Look for three classes of issues:
 - Incorrect documentation that contradicts the current codebase
 - Stale documentation that uses old names, defaults, paths, or examples
 
-Prefer proving a gap with repository evidence before editing. Use current code and tests instead of intuition.
+Prefer proving a gap with repository evidence before editing. Use current code
+and tests instead of intuition.
 
 ### 3. Prioritize by reader impact
 
 Fix the highest-cost issues first:
 
-1. Broken onboarding, setup, auth, installation, or command flows
-2. Wrong settings, defaults, paths, or feature behavior
-3. Entirely missing documentation for a real surface area
-4. Lower-impact clarity or organization improvements
+1.  Broken onboarding, setup, auth, installation, or command flows
+2.  Wrong settings, defaults, paths, or feature behavior
+3.  Entirely missing documentation for a real surface area
+4.  Lower-impact clarity or organization improvements
 
 ### 4. Refresh the docs
 
@@ -64,8 +76,10 @@ Before finishing:
 - Favor breadth-first discovery, then depth on confirmed gaps.
 - Do not rewrite large areas without evidence that they are wrong or missing.
 - Keep README files out of scope for edits; limit changes to `docs/`.
-- Call out residual gaps if the audit finds issues that are too large to solve in one pass.
+- Call out residual gaps if the audit finds issues that are too large to solve
+  in one pass.
 
 ## Deliverable
 
-Produce a focused docs refresh that makes the current repository more accurate and complete. Summarize the audited surfaces and the concrete pages updated.
+Produce a focused docs refresh that makes the current repository more accurate
+and complete. Summarize the audited surfaces and the concrete pages updated.

--- a/.qwen/skills/docs-audit-and-refresh/references/audit-checklist.md
+++ b/.qwen/skills/docs-audit-and-refresh/references/audit-checklist.md
@@ -1,26 +1,29 @@
 # Audit Checklist
 
-Use this checklist to keep repository-wide documentation audits focused and repeatable.
+Use this checklist to keep repository-wide documentation audits focused and
+repeatable.
 
 ## High-signal repository surfaces
 
-- `packages/cli/**`
-  Inspect commands, flows, prompts, flags, and CLI-facing behavior.
-- `packages/core/**`
-  Inspect shared behavior, settings, tools, provider integration, and feature semantics.
-- `packages/sdk-typescript/**` and `packages/sdk-java/**`
-  Inspect SDK setup, usage, and examples that may affect developer docs.
-- `packages/vscode-ide-companion/**`, `packages/zed-extension/**`, and related integration packages
-  Inspect IDE and extension behavior that should be reflected in user docs.
-- `docs/**/_meta.ts`
-  Inspect navigation completeness after creating or moving pages.
+- `packages/cli/**` Inspect commands, flows, prompts, flags, and CLI-facing
+  behavior.
+- `packages/core/**` Inspect shared behavior, settings, tools, provider
+  integration, and feature semantics.
+- `packages/sdk-typescript/**` and `packages/sdk-java/**` Inspect SDK setup,
+  usage, and examples that may affect developer docs.
+- `packages/vscode-ide-companion/**`, `packages/zed-extension/**`, and related
+  integration packages Inspect IDE and extension behavior that should be
+  reflected in user docs.
+- `docs/**/_meta.ts` Inspect navigation completeness after creating or moving
+  pages.
 
 ## Gap detection prompts
 
 Ask these questions while comparing the repo to `docs/`:
 
 - Does a visible feature exist in code but have no page or section in `docs/`?
-- Does a docs page mention a command, setting, provider, or path that no longer exists?
+- Does a docs page mention a command, setting, provider, or path that no longer
+  exists?
 - Do examples still match the current repository layout and command syntax?
 - Is a page present but hidden or missing from `_meta.ts`?
 - Do multiple pages describe the same feature inconsistently?
@@ -38,4 +41,5 @@ Ask these questions while comparing the repo to `docs/`:
 
 - Prefer a small number of precise edits over a speculative docs rewrite.
 - Leave a clear summary of what was missing, wrong, or stale.
-- If the audit uncovers a larger docs reorganization, fix the highest-impact inaccuracies first and note the remaining work.
+- If the audit uncovers a larger docs reorganization, fix the highest-impact
+  inaccuracies first and note the remaining work.

--- a/.qwen/skills/docs-update-from-diff/SKILL.md
+++ b/.qwen/skills/docs-update-from-diff/SKILL.md
@@ -1,15 +1,22 @@
 ---
 name: docs-update-from-diff
-description: Review local code changes with git diff and update the official docs under docs/ to match. Use when the user asks to document current uncommitted work, sync docs with local changes, update docs after a feature or refactor, or when phrases like "git diff", "local changes", "update docs", or "official docs" appear.
+description: Review local code changes with git diff and update the official
+  docs under docs/ to match. Use when the user asks to document current
+  uncommitted work, sync docs with local changes, update docs after a feature or
+  refactor, or when phrases like "git diff", "local changes", "update docs", or
+  "official docs" appear.
 ---
 
 # Docs Update From Diff
 
 ## Overview
 
-Inspect local diffs, derive the documentation impact, and update only the repository's `docs/` pages. Treat the current code as the source of truth and keep changes scoped, specific, and navigable.
+Inspect local diffs, derive the documentation impact, and update only the
+repository's `docs/` pages. Treat the current code as the source of truth and
+keep changes scoped, specific, and navigable.
 
-Read [references/docs-surface.md](references/docs-surface.md) before editing if the affected feature does not map cleanly to an existing docs section.
+Read [references/docs-surface.md](references/docs-surface.md) before editing if
+the affected feature does not map cleanly to an existing docs section.
 
 ## Workflow
 
@@ -17,30 +24,38 @@ Read [references/docs-surface.md](references/docs-surface.md) before editing if 
 
 Start from local Git state, not from assumptions.
 
-- Inspect `git status --short`, `git diff --stat`, and targeted `git diff` output.
-- Focus on non-doc changes first so the documentation delta is grounded in code.
-- Ignore `README.md` and other non-`docs/` content unless they help confirm intent.
+- Inspect `git status --short`, `git diff --stat`, and targeted `git diff`
+  output.
+- Focus on non-doc changes first so the documentation delta is grounded in
+  code.
+- Ignore `README.md` and other non-`docs/` content unless they help confirm
+  intent.
 
 ### 2. Derive the docs impact
 
-For every changed behavior, extract the user-facing or developer-facing facts that documentation must reflect.
+For every changed behavior, extract the user-facing or developer-facing facts
+that documentation must reflect.
 
 - New command, flag, config key, default, workflow, or limitation
 - Renamed behavior or removed behavior
 - Changed examples, paths, or setup steps
 - New feature that belongs in an existing page but is not mentioned yet
 
-Prefer updating an existing page over creating a new page. Create a new page only when the feature introduces a stable topic that would make an existing page harder to follow.
+Prefer updating an existing page over creating a new page. Create a new page
+only when the feature introduces a stable topic that would make an existing page
+harder to follow.
 
 ### 3. Find the right docs location
 
 Map each change to the smallest correct documentation surface:
 
 - End-user behavior: `docs/users/**`
-- Developer internals, SDKs, contributor workflow, tooling: `docs/developers/**`
+- Developer internals, SDKs, contributor workflow, tooling:
+  `docs/developers/**`
 - Shared landing or navigation changes: root `docs/**` and `_meta.ts`
 
-If you add a new page, update the nearest `_meta.ts` in the same docs section so the page is discoverable.
+If you add a new page, update the nearest `_meta.ts` in the same docs section so
+the page is discoverable.
 
 ### 4. Write the update
 
@@ -63,11 +78,17 @@ Verify that the updated docs cover the actual delta:
 
 ## Practical heuristics
 
-- If a change affects commands, also check quickstart, workflows, and feature pages for drift.
-- If a change affects configuration, also check `docs/users/configuration/settings.md`, feature pages, and auth/provider docs.
-- If a change affects tools or agent behavior, check both `docs/users/features/**` and `docs/developers/tools/**` when relevant.
-- If tests reveal expected behavior more clearly than implementation code, use tests to confirm wording.
+- If a change affects commands, also check quickstart, workflows, and feature
+  pages for drift.
+- If a change affects configuration, also check
+  `docs/users/configuration/settings.md`, feature pages, and auth/provider docs.
+- If a change affects tools or agent behavior, check both
+  `docs/users/features/**` and `docs/developers/tools/**` when relevant.
+- If tests reveal expected behavior more clearly than implementation code, use
+  tests to confirm wording.
 
 ## Deliverable
 
-Produce the docs edits under `docs/` that make the current local changes understandable to a reader who has not seen the diff. Keep the final summary short and identify which pages were updated.
+Produce the docs edits under `docs/` that make the current local changes
+understandable to a reader who has not seen the diff. Keep the final summary
+short and identify which pages were updated.

--- a/.qwen/skills/docs-update-from-diff/references/docs-surface.md
+++ b/.qwen/skills/docs-update-from-diff/references/docs-surface.md
@@ -4,36 +4,39 @@ Use this file to choose the correct destination page under `docs/`.
 
 ## Primary sections
 
-- `docs/users/overview.md`, `quickstart.md`, `common-workflow.md`
-  Good for entry points, first-run guidance, and broad user workflows.
-- `docs/users/features/*.md`
-  Good for user-visible features such as skills, MCP, sandbox, sub-agents, commands, checkpointing, and approval modes.
-- `docs/users/configuration/*.md`
-  Good for settings, auth, model providers, themes, trusted folders, `.qwen` files, and similar configuration topics.
-- `docs/users/integration-*.md` and `docs/users/ide-integration/*.md`
-  Good for IDEs, GitHub Actions, and editor companion behavior.
-- `docs/users/extension/*.md`
-  Good for extension authoring and extension usage.
-- `docs/developers/*.md`
-  Good for architecture, contributing workflow, roadmaps, and SDK overviews.
-- `docs/developers/tools/*.md`
-  Good for tool behavior, tool contracts, and implementation-facing explanations.
-- `docs/developers/development/*.md`
-  Good for contributor setup, deployment, tests, telemetry, and automation details.
+- `docs/users/overview.md`, `quickstart.md`, `common-workflow.md` Good for
+  entry points, first-run guidance, and broad user workflows.
+- `docs/users/features/*.md` Good for user-visible features such as skills,
+  MCP, sandbox, sub-agents, commands, checkpointing, and approval modes.
+- `docs/users/configuration/*.md` Good for settings, auth, model providers,
+  themes, trusted folders, `.qwen` files, and similar configuration topics.
+- `docs/users/integration-*.md` and `docs/users/ide-integration/*.md` Good for
+  IDEs, GitHub Actions, and editor companion behavior.
+- `docs/users/extension/*.md` Good for extension authoring and extension usage.
+- `docs/developers/*.md` Good for architecture, contributing workflow,
+  roadmaps, and SDK overviews.
+- `docs/developers/tools/*.md` Good for tool behavior, tool contracts, and
+  implementation-facing explanations.
+- `docs/developers/development/*.md` Good for contributor setup, deployment,
+  tests, telemetry, and automation details.
 
 ## Navigation rules
 
 - Root navigation lives in `docs/_meta.ts`.
 - Section navigation lives in the nearest `_meta.ts`, for example:
-  - `docs/users/_meta.ts`
-  - `docs/users/features/_meta.ts`
-  - `docs/developers/_meta.ts`
-  - `docs/developers/tools/_meta.ts`
-- If you create a page and do not add it to the right `_meta.ts`, the docs will be incomplete even if the markdown exists.
+- `docs/users/_meta.ts`
+- `docs/users/features/_meta.ts`
+- `docs/developers/_meta.ts`
+- `docs/developers/tools/_meta.ts`
+- If you create a page and do not add it to the right `_meta.ts`, the docs will
+  be incomplete even if the markdown exists.
 
 ## Placement heuristics
 
 - Put the change where a reader would naturally look first.
-- Update multiple pages when a single feature appears in setup, reference, and workflow docs.
-- Prefer adjusting a nearby existing page instead of creating a top-level page for a small delta.
-- Avoid duplicating long explanations across pages; add one source page and update nearby pages with short pointers if needed.
+- Update multiple pages when a single feature appears in setup, reference, and
+  workflow docs.
+- Prefer adjusting a nearby existing page instead of creating a top-level page
+  for a small delta.
+- Avoid duplicating long explanations across pages; add one source page and
+  update nearby pages with short pointers if needed.

--- a/.qwen/skills/e2e-testing/SKILL.md
+++ b/.qwen/skills/e2e-testing/SKILL.md
@@ -1,25 +1,31 @@
 ---
 name: e2e-testing
-description: Guide for running end-to-end tests of the Qwen Code CLI, including headless mode, MCP server testing, and API traffic inspection. Use this skill whenever you need to verify CLI behavior with real model calls, reproduce user-reported bugs end-to-end, test MCP tool integrations, or inspect raw API request/response payloads. Trigger on mentions of E2E testing, headless testing, MCP tool testing, or reproducing issues.
+description: Guide for running end-to-end tests of the Qwen Code CLI, including
+  headless mode, MCP server testing, and API traffic inspection. Use this skill
+  whenever you need to verify CLI behavior with real model calls, reproduce
+  user-reported bugs end-to-end, test MCP tool integrations, or inspect raw API
+  request/response payloads. Trigger on mentions of E2E testing, headless
+  testing, MCP tool testing, or reproducing issues.
 ---
 
 # E2E Testing Guide
 
-How to run the Qwen Code CLI end-to-end — from building the bundle to inspecting
-raw API traffic. Use when unit tests aren't enough and you need to verify behavior
-through the full pipeline (model API → tool validation → tool execution).
+How to run the Qwen Code CLI end-to-end, from building the bundle to inspecting
+raw API traffic. Use when unit tests are not enough and you need to verify
+behavior through the full pipeline (model API → tool validation → tool
+execution).
 
 ## Which binary to use
 
-- **Reproducing bugs**: use the globally installed `qwen` command — this matches
-  what the user ran when they filed the issue.
-- **Verifying fixes**: build first (`npm run build && npm run bundle`), then run
-  `node dist/cli.js` — this tests your local changes.
+- **Reproducing bugs**: use the globally installed `qwen` command — this
+  matches what the user ran when they filed the issue.
+- **Verifying fixes**: build first (`npm run build && npm run bundle`), then
+  run `node dist/cli.js` — this tests your local changes.
 
 ## Headless Mode
 
-Run the CLI non-interactively with JSON output (`<qwen>` = `qwen` or
-`node dist/cli.js` per above):
+Run the CLI non-interactively with JSON output (`<qwen>` = `qwen` or `node
+dist/cli.js` per above):
 
 ```bash
 <qwen> "your prompt here" \
@@ -31,12 +37,15 @@ Run the CLI non-interactively with JSON output (`<qwen>` = `qwen` or
 The JSON output is a stream of objects. Key types:
 
 - `type: "system"` — init: `tools`, `mcp_servers`, `model`, `permission_mode`
-- `type: "assistant"` — model output: `content[].type` is `text`, `tool_use`, or `thinking`
-- `type: "user"` — tool results: `content[].type` is `tool_result` with `is_error`
+- `type: "assistant"` — model output: `content[].type` is `text`, `tool_use`,
+  or `thinking`
+- `type: "user"` — tool results: `content[].type` is `tool_result` with
+  `is_error`
 - `type: "result"` — final output with `result` text and `usage` stats
 
 Pipe through `jq` to filter the verbose stream, e.g. extract tool-result errors:
-`... 2>/dev/null | jq 'select(.type=="user") | .message.content[] | select(.is_error)'`
+`... 2>/dev/null | jq 'select(.type=="user") | .message.content[] |
+select(.is_error)'`
 
 ## Inspecting Raw API Traffic
 
@@ -59,7 +68,11 @@ The bulk is in `request.messages` (conversation history). Trimmed structure:
   "request": {
     "model": "coder-model",
     "messages": [
-      { "role": "system|user|assistant", "content": "...", "tool_calls?": [...] }
+      {
+        "role": "system|user|assistant",
+        "content": "...",
+        "tool_calls?": []
+      }
     ],
     "tools": [
       {
@@ -97,7 +110,8 @@ The bulk is in `request.messages` (conversation history). Trimmed structure:
 ## Interactive Mode (tmux)
 
 Use when you need to verify TUI rendering, test keyboard interactions, or see
-what the user sees. Headless mode is simpler when you only need structured output.
+what the user sees. Headless mode is simpler when you only need structured
+output.
 
 ### Launching
 
@@ -154,8 +168,8 @@ tmux kill-session -t test
 ## MCP Server Testing
 
 For testing MCP tool behavior end-to-end, read `references/mcp-testing.md`. It
-covers the setup gotchas (config location, git repo requirement) and includes
-a reusable zero-dependency test server template in `scripts/mcp-test-server.js`.
+covers the setup gotchas (config location, git repo requirement) and includes a
+reusable zero-dependency test server template in `scripts/mcp-test-server.js`.
 
 ## Token Usage Stats
 

--- a/.qwen/skills/e2e-testing/references/mcp-testing.md
+++ b/.qwen/skills/e2e-testing/references/mcp-testing.md
@@ -10,7 +10,7 @@ the **only** location that works for E2E testing.
 Common mistakes that waste time:
 
 - `.mcp.json` — Claude Code convention, not Qwen Code
-- `settings.local.json` — the JSON schema validation rejects `mcpServers` here
+- `settings.local.json` — schema validation rejects `mcpServers` here
 - `--mcp-config` CLI flag — does not exist
 
 ## Setup
@@ -42,8 +42,8 @@ cd /tmp/test-dir && <qwen> "prompt" \
 
 ## Writing Test Servers
 
-Use `scripts/mcp-test-server.js` as a template. It's a zero-dependency
-JSON-RPC server over stdin/stdout — no npm install needed.
+Use `scripts/mcp-test-server.js` as a template. It's a zero-dependency JSON-RPC
+server over stdin/stdout — no npm install needed.
 
 To create a server with custom tools, copy the template and edit the
 `TOOL_DEFINITIONS` array and the `handleToolCall` function. Each tool definition
@@ -55,7 +55,16 @@ Test the server without the CLI by piping JSON-RPC directly:
 
 ```bash
 node /tmp/my-mcp-server.js << 'EOF'
-{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": { "name": "test", "version": "1.0" }
+  }
+}
 {"jsonrpc":"2.0","method":"notifications/initialized"}
 {"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}
 EOF

--- a/.qwen/skills/feat-dev/SKILL.md
+++ b/.qwen/skills/feat-dev/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: feat-dev
+description: End-to-end workflow for implementing a non-trivial qwen-code
+  feature. Covers requirements investigation, design, E2E test planning,
+  baseline dry-run, implementation, verification, code review, and iteration.
+---
+
+# Feature Development Workflow
+
+Use this workflow when implementing a feature in qwen-code that needs design,
+behavioral validation, or coordinated changes across multiple files. Each phase
+produces a concrete artifact. Do not combine phases; the output of each phase
+feeds the next.
+
+## Artifact Paths
+
+Use `.qwen/` paths for planning artifacts:
+
+- `.qwen/design/<feature>.md`
+- `.qwen/e2e-tests/<feature>.md`
+
+## Phase 1: Investigate
+
+Understand the requested behavior and the current qwen-code implementation.
+
+Use a code exploration agent when available. Ask it to inspect the relevant
+qwen-code areas for:
+
+- Existing feature definitions: tools, parameters, schemas, commands, UI, or
+  config.
+- Runtime wiring: spawning, lifecycle, state, permissions, hooks, and cleanup.
+- Edge cases and error handling.
+- Integration points and limitations.
+
+In parallel, inspect docs, issues, tests, and nearby implementations that define
+or constrain the expected behavior. If no exploration agent is available, do the
+same investigation locally.
+
+Output: mental model of current behavior, desired behavior, constraints, and key
+file paths with line numbers.
+
+## Phase 2: Design Doc
+
+Write a design doc covering:
+
+- Problem statement and current state, including the behavior gap.
+- Proposed changes by layer or component.
+- Key design decisions and rationale.
+- Files affected.
+- Scope boundaries.
+- Open questions.
+
+Use prose, tables, and bullets. Avoid code snippets unless essential for a key
+data structure. JSON config examples are acceptable.
+
+Output: design doc on disk.
+
+## Phase 3: Test Plan
+
+Use the `e2e-testing` skill to choose test modes. Then write an E2E test plan
+covering:
+
+- Test groups by capability: parameter acceptance, core behavior, error
+  handling, cleanup, and regressions.
+- Exact commands and expected behavior before and after implementation.
+- Unique tmux session names and temp dirs for independent groups.
+- Which groups can be run in parallel by separate `test-engineer` agents.
+
+Output: test plan on disk.
+
+## Phase 4: Dry-Run
+
+Validate the test plan against the current baseline using the globally installed
+`qwen` CLI, not the local build.
+
+Spawn `test-engineer` agents for independent test groups when the runtime
+supports it. The feature is not implemented yet, so tests should either fail or
+show the gap. Iterate the test plan if the dry-run reveals broken commands,
+wrong filters, or false positives.
+
+Output: confirmed-working test plan with accurate pre-implementation baseline.
+
+## Phase 5: Implement
+
+Read the relevant source files before editing. Implement the changes described
+in the design doc and follow project conventions:
+
+- ESM and strict TypeScript.
+- Prettier formatting.
+- Collocated tests next to source.
+- No speculative abstractions beyond the design.
+
+After implementation:
+
+```bash
+npm run build
+npm run typecheck
+npm run bundle
+```
+
+Also run focused unit tests for changed files from the relevant package
+directory.
+
+Output: local implementation that builds and passes focused tests.
+
+## Phase 6: Verify
+
+Run the full E2E test plan against the local build with `node dist/cli.js`.
+Spawn independent `test-engineer` agents when useful and available.
+
+If tests fail, diagnose, fix, rebuild, re-bundle, and re-test until all groups
+pass.
+
+Output: E2E results appended to the test plan.
+
+## Phase 7: Code Review
+
+Run `/review` with a review task listing all changed files. Triage each comment
+before acting:
+
+- **Valid**: real bug or meaningful improvement. Fix it.
+- **False positive**: reviewer missed context. Skip it.
+- **Overthinking**: technically plausible but not worth the complexity. Skip
+  it.
+
+After fixes, re-run unit tests and a quick E2E sanity check.
+
+Output: clean implementation with valid review findings addressed.
+
+## Phase 8: Wrap Up
+
+Skip unless the user asks. Create the branch, commit with Conventional Commits,
+push, and create a draft PR using the project PR template. Post E2E results as a
+separate PR comment when applicable.
+
+## Iteration Rules
+
+- If Phase 6 fails, return to Phase 5 and then re-run Phase 6.
+- If Phase 7 finds valid issues, fix them and run a quick Phase 6 sanity check.
+- Do not loop more than 3 times between Phases 5-7 without asking the user.
+- If the test plan is inaccurate, update it and document why.

--- a/.qwen/skills/qwen-code-claw/SKILL.md
+++ b/.qwen/skills/qwen-code-claw/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: qwen-code-claw
-description: Use Qwen Code as a Code Agent for code understanding, project generation, features, bug fixes, refactoring, and various programming tasks
+description: Use Qwen Code as a Code Agent for code understanding, project
+  generation, features, bug fixes, refactoring, and various programming tasks
 ---
 
 # Qwen Code Claw
@@ -13,7 +14,8 @@ Use this skill when you need to:
 - Generate new projects or add new features
 - Review pull requests in the codebase
 - Fix bugs or refactor existing code
-- Execute various programming tasks such as code review, testing, documentation generation, etc.
+- Execute various programming tasks such as code review, testing, documentation
+  generation, etc.
 - Collaborate with other tools and agents to complete complex development tasks
 
 ## Install
@@ -32,7 +34,8 @@ Check if authentication is already configured:
 qwen auth status
 ```
 
-If authentication exists, skip this section. If not authenticated, check if the `BAILIAN_CODING_PLAN_API_KEY` environment variable exists:
+If authentication exists, skip this section. If not authenticated, check if the
+`BAILIAN_CODING_PLAN_API_KEY` environment variable exists:
 
 ```bash
 echo $BAILIAN_CODING_PLAN_API_KEY
@@ -44,7 +47,8 @@ echo $BAILIAN_CODING_PLAN_API_KEY
 qwen auth coding-plan --region china --key $BAILIAN_CODING_PLAN_API_KEY
 ```
 
-**If the environment variable does not exist**, interrupt and prompt the user to authenticate via `qwen-oauth` or `coding-plan`:
+**If the environment variable does not exist**, interrupt and prompt the user to
+authenticate via `qwen-oauth` or `coding-plan`:
 
 ```bash
 qwen auth
@@ -54,35 +58,37 @@ Or configure custom API after launching Qwen Code via `/auth`.
 
 ## ACPX Integration
 
-You should always use `acpx` to run Qwen Code over the Agent Client Protocol (ACP) instead of scraping PTY sessions.
+You should always use `acpx` to run Qwen Code over the Agent Client Protocol
+(ACP) instead of scraping PTY sessions.
 
 To use acpx:
 
-1. **Install acpx globally** (recommended) or use npx:
+1.  **Install acpx globally** (recommended) or use npx:
 
    ```bash
    npm install -g acpx@latest
    ```
 
-   Or without installing:
+Or without installing:
 
    ```bash
    npx acpx@latest
    ```
 
-2. **Install the acpx skill** for full reference:
+2.  **Install the acpx skill** for full reference:
 
    ```bash
    npx acpx@latest --skill install acpx
    ```
 
-3. **Read the acpx skill reference** for every command, flag, and workflow pattern:
-   See the [ACPX Reference](#acpx-reference) section below for details
+3.  **Read the acpx skill reference** for every command, flag, and workflow
+   pattern: See the [ACPX Reference](#acpx-reference) section below for details
 
-4. **For complete CLI reference with all options and examples**:
+4.  **For complete CLI reference with all options and examples**:
    https://raw.githubusercontent.com/openclaw/acpx/main/docs/CLI.md
 
-From now on, when you need to delegate work to Qwen Code, use `acpx` instead of spawning raw terminal sessions. For example:
+From now on, when you need to delegate work to Qwen Code, use `acpx` instead of
+spawning raw terminal sessions. For example:
 
 ```bash
 npx acpx@latest qwen "fix the failing tests"
@@ -90,7 +96,8 @@ npx acpx@latest qwen "refactor the auth module"
 npx acpx@latest qwen exec "one-shot: summarize this repo"
 ```
 
-> **Tip:** You should typically use the `--approve-all` flag to prevent task interruptions.
+>  **Tip:** You should typically use the `--approve-all` flag to prevent task
+> interruptions.
 
 ## Practical Workflows
 
@@ -140,15 +147,16 @@ acpx --cwd ~/repos/my-project --approve-all qwen -s pr-123 \
 - `--approve-reads` (default): Auto-approve reads/searches, prompt for writes
 - `--deny-all`: Deny all permission requests
 
-If every permission request is denied/cancelled and none are approved, `acpx` exits with permission denied.
+If every permission request is denied/cancelled and none are approved, `acpx`
+exits with permission denied.
 
 ## Best Practices
 
-1. Use **named sessions** for organizing different types of development tasks
-2. Use `--no-wait` for long-running tasks to avoid blocking
-3. Use `--approve-all` for non-interactive batch operations
-4. Use `--format json` for automation and script integration
-5. Use `--cwd` to manage context across multiple projects
+1.  Use **named sessions** for organizing different types of development tasks
+2.  Use `--no-wait` for long-running tasks to avoid blocking
+3.  Use `--approve-all` for non-interactive batch operations
+4.  Use `--format json` for automation and script integration
+5.  Use `--cwd` to manage context across multiple projects
 
 ## QwenCode Reference
 
@@ -163,11 +171,13 @@ If every permission request is denied/cancelled and none are approved, `acpx` ex
 | `/auth`     | Configure authentication        |
 | `/exit`     | Exit Qwen Code                  |
 
-Full reference: https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/docs/users/features/commands.md
+Full reference: `docs/users/features/commands.md`.
 
 ### Configuration
 
-Config files (highest priority first): CLI args > env vars > system > project (`.qwen/settings.json`) > user (`~/.qwen/settings.json`) > defaults. Format: JSONC with env var interpolation.
+Config files (highest priority first): CLI args > env vars > system > project
+(`.qwen/settings.json`) > user (`~/.qwen/settings.json`) > defaults. Format:
+JSONC with env var interpolation.
 
 Key settings:
 
@@ -178,30 +188,36 @@ Key settings:
 | `permissions.allow/ask/deny` | Tool permission rules                     |
 | `mcpServers.*`               | MCP server configurations                 |
 
-Full reference: https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/docs/users/configuration/settings.md
+Full reference: `docs/users/configuration/settings.md`.
 
 ### Authentication
 
-Supports Alibaba Cloud Coding Plan, OpenAI-compatible API keys, and Qwen OAuth (free tier discontinued 2026-04-15).
+Supports Alibaba Cloud Coding Plan, OpenAI-compatible API keys, and Qwen OAuth
+(free tier discontinued 2026-04-15).
 
-Full reference: https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/docs/users/configuration/auth.md
+Full reference: `docs/users/configuration/auth.md`.
 
 ### Model Providers
 
-Configure custom model providers via `modelProviders` in settings or environment variables (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `OPENAI_MODEL`).
+Configure custom model providers via `modelProviders` in settings or environment
+variables (`OPENAI_API_KEY`, `OPENAI_BASE_URL`, `OPENAI_MODEL`).
 
-Full reference: https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/docs/users/configuration/model-providers.md
+Full reference: `docs/users/configuration/model-providers.md`.
 
 ### Key Features
 
-| Feature       | Description                               | Docs                                                                                                    |
-| ------------- | ----------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| Approval Mode | Control tool execution permissions        | https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/docs/users/features/approval-mode.md |
-| MCP           | Model Context Protocol server integration | https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/docs/users/features/mcp.md           |
-| Skills        | Reusable skill system via `/skill`        | https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/docs/users/features/skills.md        |
-| Sub-agents    | Delegate tasks to specialized agents      | https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/docs/users/features/sub-agents.md    |
-| Sandbox       | Secure code execution environment         | https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/docs/users/features/sandbox.md       |
-| Headless      | Non-interactive / CI mode                 | https://raw.githubusercontent.com/QwenLM/qwen-code/refs/heads/main/docs/users/features/headless.md      |
+- Approval Mode: control tool execution permissions.
+   See `docs/users/features/approval-mode.md`.
+- MCP: Model Context Protocol server integration.
+   See `docs/users/features/mcp.md`.
+- Skills: reusable skill system via `/skill`.
+   See `docs/users/features/skills.md`.
+- Sub-agents: delegate tasks to specialized agents.
+   See `docs/users/features/sub-agents.md`.
+- Sandbox: secure code execution environment.
+   See `docs/users/features/sandbox.md`.
+- Headless: non-interactive or CI mode.
+   See `docs/users/features/headless.md`.
 
 ## ACPX Reference
 
@@ -226,7 +242,10 @@ acpx [global options] cancel [-s <name>]
 acpx [global options] set-mode <mode> [-s <name>]
 acpx [global options] set <key> <value> [-s <name>]
 acpx [global options] status [-s <name>]
-acpx [global options] sessions [list | new [--name <name>] | close [name] | show [name] | history [name] [--limit <count>]]
+acpx [global options] sessions [
+  list | new [--name <name>] | close [name] | show [name] |
+  history [name] [--limit <count>]
+]
 acpx [global options] config [show | init]
 
 # With explicit agent
@@ -235,20 +254,19 @@ acpx [global options] <agent> prompt [options] [prompt text...]
 acpx [global options] <agent> exec [options] [prompt text...]
 ```
 
-> **Note:** If prompt text is omitted and stdin is piped, `acpx` reads prompt from stdin.
+>  **Note:** If prompt text is omitted and stdin is piped, `acpx` reads prompt
+> from stdin.
 
 ### Global Options
 
-| Option                | Description                                                  |
-| --------------------- | ------------------------------------------------------------ |
-| `--agent <command>`   | Raw ACP agent command (fallback mechanism)                   |
-| `--cwd <directory>`   | Session working directory                                    |
-| `--approve-all`       | Auto-approve all requests                                    |
-| `--approve-reads`     | Auto-approve reads/searches, prompt for writes (default)     |
-| `--deny-all`          | Deny all requests                                            |
-| `--format <format>`   | Output format: `text`, `json`, `quiet`                       |
-| `--timeout <seconds>` | Maximum wait time (positive integer)                         |
-| `--ttl <seconds>`     | Idle TTL for queue owners (default: `300`, `0` disables TTL) |
-| `--verbose`           | Verbose ACP/debug logs to stderr                             |
+- `--agent <command>`: raw ACP agent command fallback.
+- `--cwd <directory>`: session working directory.
+- `--approve-all`: auto-approve all requests.
+- `--approve-reads`: auto-approve reads/searches, prompt for writes.
+- `--deny-all`: deny all requests.
+- `--format <format>`: output format, one of `text`, `json`, or `quiet`.
+- `--timeout <seconds>`: maximum wait time.
+- `--ttl <seconds>`: idle TTL for queue owners.
+- `--verbose`: verbose ACP/debug logs to stderr.
 
 Flags are mutually exclusive where applicable.

--- a/.qwen/skills/structured-debugging/SKILL.md
+++ b/.qwen/skills/structured-debugging/SKILL.md
@@ -1,43 +1,42 @@
 ---
 name: structured-debugging
-description: >
-  Hypothesis-driven debugging methodology for hard bugs. Use this skill whenever
-  you're investigating non-trivial bugs, unexpected behavior, flaky tests, or
-  tracing issues through complex systems. Activate proactively when debugging
-  requires more than a quick glance — especially when the first attempt at a fix
-  didn't work, when behavior seems "impossible", or when you're tempted to blame
-  an external system (model, API, library) without evidence.
+description: Hypothesis-driven debugging methodology for hard bugs. Use this
+  skill whenever you're investigating non-trivial bugs, unexpected behavior,
+  flaky tests, or tracing issues through complex systems. Activate proactively
+  when debugging requires more than a quick glance — especially when the first
+  attempt at a fix didn't work, when behavior seems "impossible", or when you're
+  tempted to blame an external system (model, API, library) without evidence.
 ---
 
 # Structured Debugging
 
-When debugging hard issues, the natural instinct is to form a theory and immediately
-apply a fix. This fails more often than it works. The fix addresses the wrong cause,
-adds complexity, creates false confidence, and obscures the real issue. Worse, after
-several failed attempts you lose track of what's been tried and start guessing randomly.
+When debugging hard issues, the natural instinct is to form a theory and
+immediately apply a fix. This fails more often than it works. The fix addresses
+the wrong cause, adds complexity, creates false confidence, and obscures the
+real issue. Worse, after several failed attempts you lose track of what's been
+tried and start guessing randomly.
 
-This methodology replaces guessing with a disciplined cycle that converges on the
-root cause. Each iteration narrows the search space. It's slower per attempt but
-dramatically faster overall because you stop wasting runs on wrong theories.
+This methodology replaces guessing with a disciplined cycle that converges on
+the root cause. Each iteration narrows the search space. It's slower per attempt
+but dramatically faster overall because you stop wasting runs on wrong theories.
 
 ## The Cycle
 
 ### 1. Hypothesize
 
-Before touching code, write down what you think is happening and why. Be specific
-about the expected state at each step in the execution path.
+Before touching code, write down what you think is happening and why. Be
+specific about the expected state at each step in the execution path.
 
-Bad: "Something is wrong with the wait loop."
-Good: "The leader hangs because `hasActiveTeammates()` returns true after all agents
-have reported completed, likely because terminal status isn't being set on the agent
-object after the backend process exits."
+Bad: "Something is wrong with the wait loop." Good: "The leader hangs because
+`hasActiveTeammates()` returns true after all agents have reported completed,
+likely because terminal status isn't being set on the agent object after the
+backend process exits."
 
-For bugs you expect to take more than one round, create a side note file
-for the investigation in whichever location the project uses for such
-notes.
+For bugs you expect to take more than one round, create a side note file for the
+investigation in whichever location the project uses for such notes.
 
-Write your hypothesis there. This file persists across conversation turns and even
-across sessions — it's your investigation journal.
+Write your hypothesis there. This file persists across conversation turns and
+even across sessions — it's your investigation journal.
 
 ### 2. Design Instrumentation
 
@@ -47,19 +46,18 @@ confirm or reject your hypothesis. Think about what data you need to see.
 Don't scatter `console.log` everywhere. Identify the 2-3 places where your
 hypothesis makes a testable prediction, and instrument those.
 
-Prefer logging _values_ (return codes, payload contents, stream types,
-message bodies, env state) over _presence checks_ ("was this function
-called?", "was this branch taken?"). Code-path traces tell you what ran;
-data traces tell you what it ran on. Most non-trivial bugs are correct
-code processing wrong data.
+Prefer logging _values_ (return codes, payload contents, stream types, message
+bodies, env state) over _presence checks_ ("was this function called?", "was
+this branch taken?"). Code-path traces tell you what ran; data traces tell you
+what it ran on. Most non-trivial bugs are correct code processing wrong data.
 
-Ask yourself: "If my hypothesis is correct, what will I see at point X?
-If it's wrong, what will I see instead?"
+Ask yourself: "If my hypothesis is correct, what will I see at point X? If it's
+wrong, what will I see instead?"
 
 ### 3. Verify Data Collection
 
-Before running, confirm that your instrumentation output will actually be captured
-and accessible.
+Before running, confirm that your instrumentation output will actually be
+captured and accessible.
 
 Common traps:
 
@@ -73,10 +71,11 @@ A test run that produces no data is wasted.
 
 ### 4. Run and Observe
 
-Execute the test. Read the actual output — every line of it. Don't assume what it says.
+Execute the test. Read the actual output — every line of it. Don't assume what
+it says.
 
-When the data contradicts your hypothesis, believe the data. Don't rationalize it
-away. The whole point of this step is to let reality override your theory.
+When the data contradicts your hypothesis, believe the data. Don't rationalize
+it away. The whole point of this step is to let reality override your theory.
 
 ### 5. Document Findings
 
@@ -86,8 +85,8 @@ Update the side note with:
 - What was confirmed vs. disproved
 - Updated hypothesis for the next iteration
 
-This is critical for not losing context across attempts. Hard bugs typically take
-3-5 rounds. Without notes, you'll forget what you ruled out and waste runs
+This is critical for not losing context across attempts. Hard bugs typically
+take 3-5 rounds. Without notes, you'll forget what you ruled out and waste runs
 re-checking things.
 
 ### 6. Iterate
@@ -105,30 +104,31 @@ notice yourself drifting toward any of them, stop and return to the cycle.
 
 ### Jumping to fixes without evidence
 
-The most common failure. You have a plausible theory, so you "fix" it and run again.
-If the theory was wrong, you've added complexity, wasted a test run, and possibly
-introduced a new bug. The side note should always show "hypothesis verified by
-[specific data]" before any fix is applied.
+The most common failure. You have a plausible theory, so you "fix" it and run
+again. If the theory was wrong, you've added complexity, wasted a test run, and
+possibly introduced a new bug. The side note should always show "hypothesis
+verified by [specific data]" before any fix is applied.
 
 ### Blaming external systems
 
 "The model is hallucinating." "The API is flaky." "The library has a bug." These
-conclusions feel satisfying because they put the problem outside your control. They're
-also usually wrong.
+conclusions feel satisfying because they put the problem outside your control.
+They're also usually wrong.
 
-Before blaming an external system, inspect what it actually received. A model that
-appears to hallucinate may be responding rationally to stale data you didn't know
-was there. An API that appears flaky may be receiving malformed requests. Look at
-the inputs, not just the outputs.
+Before blaming an external system, inspect what it actually received. A model
+that appears to hallucinate may be responding rationally to stale data you
+didn't know was there. An API that appears flaky may be receiving malformed
+requests. Look at the inputs, not just the outputs.
 
 ### Inspecting code paths but not data
 
-You instrument the code and prove it executes correctly — the right functions are
-called, in the right order, with no errors. But the bug persists. Why?
+You instrument the code and prove it executes correctly — the right functions
+are called, in the right order, with no errors. But the bug persists. Why?
 
-Because the code can work perfectly while processing garbage input. A function that
-correctly reads an inbox, correctly delivers messages, and correctly formats output
-is still broken if the inbox contains stale messages from a previous run.
+Because the code can work perfectly while processing garbage input. A function
+that correctly reads an inbox, correctly delivers messages, and correctly
+formats output is still broken if the inbox contains stale messages from a
+previous run.
 
 Always inspect the _content_ flowing through the code, not just whether the code
 runs. Check payloads, message contents, file data, and database state.
@@ -136,19 +136,18 @@ runs. Check payloads, message contents, file data, and database state.
 ### Reframing the user's report instead of investigating it
 
 When the user reports a symptom your own run doesn't reproduce, the
-contradiction _is_ the evidence — the two environments differ in some way
-you haven't identified yet. The wrong move is to reframe their report
-("they must be on a stale SHA", "they must be confused about what they
-saw", "must be a flake") so that your run becomes the ground truth. Once
-you do that, every later piece of evidence gets bent to defend the
-reframing, and the actual bug stays hidden.
+contradiction _is_ the evidence — the two environments differ in some way you
+haven't identified yet. The wrong move is to reframe their report ("they must be
+on a stale SHA", "they must be confused about what they saw", "must be a flake")
+so that your run becomes the ground truth. Once you do that, every later piece
+of evidence gets bent to defend the reframing, and the actual bug stays hidden.
 
-The right move: catalogue what differs between their environment and
-yours (TTY vs pipe, terminal emulator, shell, locale, env vars, prior
-state, build artifacts) before forming any hypothesis. For ambiguous
-symptoms ("no output", "it's slow", "it's wrong") ask one disambiguating
-question first — e.g., "does it hang or exit cleanly?" — that prunes the
-hypothesis space cheaply before any test run.
+The right move: catalogue what differs between their environment and yours (TTY
+vs pipe, terminal emulator, shell, locale, env vars, prior state, build
+artifacts) before forming any hypothesis. For ambiguous symptoms ("no output",
+"it's slow", "it's wrong") ask one disambiguating question first — e.g., "does
+does it hang or exit cleanly?" That prunes the hypothesis space before any
+test run.
 
 ### Losing context across attempts
 
@@ -161,9 +160,9 @@ a new round, re-read it first.
 
 ## Persistent State: A Special Category
 
-Features that persist data across runs — caches, session recordings, message queues,
-temp files, database rows — are a frequent source of "impossible" bugs. The current
-run's behavior is contaminated by leftover state from previous runs.
+Features that persist data across runs — caches, session recordings, message
+queues, temp files, and database rows often cause "impossible" bugs.
+The current run's behavior is contaminated by leftover state from previous runs.
 
 When behavior seems irrational, always check:
 
@@ -175,7 +174,7 @@ This is easy to miss because the code is correct — it's the data that's wrong.
 
 ## When to Exit the Cycle
 
-Apply the fix when — and only when — you can point to specific data from your
+Apply the fix only when you can point to specific data from your
 instrumentation that confirms the root cause. Write in the side note:
 
 ```
@@ -188,7 +187,8 @@ Then apply the fix, remove instrumentation, and verify with a clean run.
 
 ## Worked examples
 
-- [`examples/headless-bg-agent-empty-stdout.md`](examples/headless-bg-agent-empty-stdout.md)
+-
+  `examples/headless-bg-agent-empty-stdout.md`
   — pipe-captured runs all passed; the user's TTY printed nothing. The
-  contradiction _was_ the bug. Illustrates _reproduction contradiction is
-  data_ and _instrument data, not code paths_.
+  contradiction _was_ the bug. Illustrates _reproduction contradiction is data_
+  and _instrument data, not code paths_.

--- a/.qwen/skills/structured-debugging/examples/headless-bg-agent-empty-stdout.md
+++ b/.qwen/skills/structured-debugging/examples/headless-bg-agent-empty-stdout.md
@@ -1,59 +1,58 @@
 # Worked example: headless run prints empty stdout in zsh TTY
 
 A short qwen-code case to illustrate two failure modes from `SKILL.md`:
-_reproduction contradiction is data_, and _instrument the data flow, not
-just the code path_.
+_reproduction contradiction is data_, and _instrument the data flow, not just
+the code path_.
 
 ## The bug
 
 User: `npm run dev -- -p "..."` in zsh prints nothing. Process exits clean,
 `~/.qwen/logs` shows the model returned proper text. Stdout was empty.
 
-Cause: `JsonOutputAdapter.emitResult` wrote `resultMessage.result` without
-a trailing `\n`. zsh's `PROMPT_SP` (powerlevel10k, agnoster, …) detects
-the missing newline and emits `\r\033[K` before drawing the next prompt,
-erasing the line. Pipe-captured stdout has no `PROMPT_SP`, so the bug is
-invisible there.
+Cause: `JsonOutputAdapter.emitResult` wrote `resultMessage.result` without a
+trailing `\n`. zsh's `PROMPT_SP` (powerlevel10k, agnoster, …) detects the
+missing newline and emits `\r\033[K` before drawing the next prompt, erasing the
+line. Pipe-captured stdout has no `PROMPT_SP`, so the bug is invisible there.
 
 Fix: append `\n` to the write.
 
 ## What made the case instructive
 
-Every reproduction attempt from a debugging environment that captures
-stdout (Cursor's Shell tool, `out=$(...)`, `tee`, file redirect) **passed**.
-14/14 success against the user's 0/N. Same SHA, same machine, same
-command. The only variable was: pipe stdout vs TTY stdout.
+Every reproduction attempt from a debugging environment that captures stdout
+(Cursor's Shell tool, `out=$(...)`, `tee`, file redirect) **passed**. 14/14
+success against the user's 0/N. Same SHA, same machine, same command. The only
+variable was: pipe stdout vs TTY stdout.
 
-That contradiction was the entire investigation. Once it was named, the
-fix was one line.
+That contradiction was the entire investigation. Once it was named, the fix was
+one line.
 
 ## Lessons mapped to SKILL.md
 
 - **Reproduction contradiction is data, not user error.** When your run
-  succeeds and the user's fails on identical state, the _difference
-  between the two environments_ is where the bug lives. Catalogue what
-  differs (TTY vs pipe, terminal emulator, shell, locale, env vars,
-  prior state) before forming any hypothesis. Reframing the user's
-  report ("they must be on stale code") burns rounds and credibility.
+  succeeds and the user's fails on identical state, the _difference between the
+  two environments_ is where the bug lives. Catalogue what differs (TTY vs pipe,
+  terminal emulator, shell, locale, env vars, prior state) before forming any
+  hypothesis. Reframing the user's report ("they must be on stale code") burns
+  rounds and credibility.
 
 - **Ask the one disambiguating question first.** "Does it hang or exit
-  cleanly?" would have falsified the most tempting wrong hypothesis here
-  (the recently-fixed drain-loop hang) on turn one. For any "no output"
-  report, that question is free and prunes half the hypothesis space.
+  cleanly?" would have falsified the most tempting wrong hypothesis here (the
+  recently-fixed drain-loop hang) on turn one. For any "no output" report, that
+  question is free and prunes half the hypothesis space.
 
-- **Instrument the data flow, not just the code path.** Tracing whether
-  `write` was called showed the happy path firing every time and resolved
-  nothing. The breakthrough was logging the _return value_ of
-  `process.stdout.write` together with `process.stdout.isTTY`. Code-path
-  traces tell you what ran; data traces tell you what it ran on.
+- **Instrument the data flow, not just the code path.** Tracing whether `write`
+  was called showed the happy path firing every time and resolved nothing. The
+  breakthrough was logging the _return value_ of `process.stdout.write` together
+  with `process.stdout.isTTY`. Code-path traces tell you what ran; data traces
+  tell you what it ran on.
 
-- **Pipe ≠ TTY.** A passing pipe-captured run does not prove a TTY user
-  sees the same output. Shell prompts can post-process trailing-newline-
-  less writes; terminals can swallow control sequences; pipes do
-  neither. When debugging interactive-shell symptoms, get evidence from
-  the user's actual terminal at least once.
+- **Pipe ≠ TTY.** A passing pipe-captured run does not prove a TTY user sees
+  the same output. Shell prompts can post-process trailing-newline- less writes;
+  terminals can swallow control sequences; pipes do neither. When debugging
+  interactive-shell symptoms, get evidence from the user's actual terminal at
+  least once.
 
 ## Reference
 
-Fix commit: qwen-code `feadf052f` —
-`fix(cli): append newline to text-mode emitResult so zsh PROMPT_SP doesn't erase the line`
+Fix commit: qwen-code `feadf052f` — `fix(cli): append newline to text-mode
+emitResult so zsh PROMPT_SP doesn't erase the line`

--- a/.qwen/skills/terminal-capture/SKILL.md
+++ b/.qwen/skills/terminal-capture/SKILL.md
@@ -1,35 +1,44 @@
 ---
 name: terminal-capture
-description: Automates terminal UI screenshot testing for CLI commands. Applies when reviewing PRs that affect CLI output, testing slash commands (/about, /context, /auth, /export), generating visual documentation, or when 'terminal screenshot', 'CLI test', 'visual test', or 'terminal-capture' is mentioned.
+description: Automates terminal UI screenshot testing for CLI commands. Applies
+  when reviewing PRs that affect CLI output, testing slash commands (/about,
+  /context, /auth, /export), generating visual documentation, or when 'terminal
+  screenshot', 'CLI test', 'visual test', or 'terminal-capture' is mentioned.
 ---
 
 # Terminal Capture — CLI Terminal Screenshot Automation
 
-Drive terminal interactions and screenshots via TypeScript configuration, used for visual verification during PR reviews.
+Drive terminal interactions and screenshots via TypeScript configuration, used
+for visual verification during PR reviews.
 
 ## Prerequisites
 
 Ensure the following dependencies are installed before running:
 
 ```bash
-npm install       # Install project dependencies (including node-pty, xterm, playwright, etc.)
+npm install       # Install project dependencies.
 npx playwright install chromium   # Install Playwright browser
 ```
 
 ## Architecture
 
 ```
-node-pty (pseudo-terminal) → ANSI byte stream → xterm.js (Playwright headless) → Screenshot
+node-pty (pseudo-terminal)
+  → ANSI byte stream
+  → xterm.js (Playwright headless)
+  → Screenshot
 ```
 
 Core files:
 
-| File                                                     | Purpose                                                                  |
-| -------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `integration-tests/terminal-capture/terminal-capture.ts` | Low-level engine (PTY + xterm.js + Playwright)                           |
-| `integration-tests/terminal-capture/scenario-runner.ts`  | Scenario executor (parses config, drives interactions, auto-screenshots) |
-| `integration-tests/terminal-capture/run.ts`              | CLI entry point (batch run scenarios)                                    |
-| `integration-tests/terminal-capture/scenarios/*.ts`      | Scenario configuration files                                             |
+- `integration-tests/terminal-capture/terminal-capture.ts`
+   Low-level PTY, xterm.js, and Playwright engine.
+- `integration-tests/terminal-capture/scenario-runner.ts`
+   Scenario executor for config, interactions, and screenshots.
+- `integration-tests/terminal-capture/run.ts`
+   CLI entry point for batch scenario runs.
+- `integration-tests/terminal-capture/scenarios/*.ts`
+   Scenario configuration files.
 
 ## Quick Start
 
@@ -43,7 +52,8 @@ import type { ScenarioConfig } from '../scenario-runner.js';
 export default {
   name: '/about',
   spawn: ['node', 'dist/cli.js', '--yolo'],
-  terminal: { title: 'qwen-code', cwd: '../../..' }, // Relative to this config file's location
+  // cwd is relative to this config file's location.
+  terminal: { title: 'qwen-code', cwd: '../../..' },
   flow: [
     { type: 'Hi, can you help me understand this codebase?' },
     { type: '/about' },
@@ -55,15 +65,18 @@ export default {
 
 ```bash
 # Single scenario
-npx tsx integration-tests/terminal-capture/run.ts integration-tests/terminal-capture/scenarios/about.ts
+npx tsx integration-tests/terminal-capture/run.ts \
+  integration-tests/terminal-capture/scenarios/about.ts
 
 # Batch (entire directory)
-npx tsx integration-tests/terminal-capture/run.ts integration-tests/terminal-capture/scenarios/
+npx tsx integration-tests/terminal-capture/run.ts \
+  integration-tests/terminal-capture/scenarios/
 ```
 
 ### 3. Output
 
-Screenshots are saved to `integration-tests/terminal-capture/scenarios/screenshots/{name}/`:
+Screenshots are saved to
+`integration-tests/terminal-capture/scenarios/screenshots/{name}/`:
 
 | File            | Description                        |
 | --------------- | ---------------------------------- |
@@ -79,7 +92,8 @@ Each flow step can contain the following fields:
 
 ### `type: string` — Input Text
 
-Automatic behavior: Input text → Screenshot (01) → Press Enter → Wait for output to stabilize → Screenshot (02).
+Automatic behavior:
+Input text → Screenshot (01) → Enter → stable output → Screenshot (02).
 
 ```typescript
 {
@@ -90,13 +104,17 @@ Automatic behavior: Input text → Screenshot (01) → Press Enter → Wait for 
 } // Slash command (auto-completion handled automatically)
 ```
 
-**Special rule**: If the next step is `key`, do not auto-press Enter (hand over control to the key sequence).
+**Special rule**: If the next step is `key`, do not auto-press Enter (hand over
+control to the key sequence).
 
 ### `key: string | string[]` — Send Key Press
 
-Used for menu selection, Tab completion, and other interactions. Does not auto-press Enter or auto-screenshot.
+Used for menu selection, Tab completion, and other interactions. Does not
+auto-press Enter or auto-screenshot.
 
-Supported key names: `ArrowUp`, `ArrowDown`, `ArrowLeft`, `ArrowRight`, `Enter`, `Tab`, `Escape`, `Backspace`, `Space`, `Home`, `End`, `PageUp`, `PageDown`, `Delete`
+Supported key names: `ArrowUp`, `ArrowDown`, `ArrowLeft`, `ArrowRight`, `Enter`,
+`Tab`, `Escape`, `Backspace`, `Space`, `Home`, `End`, `PageUp`, `PageDown`,
+`Delete`
 
 ```typescript
 {
@@ -107,11 +125,13 @@ Supported key names: `ArrowUp`, `ArrowDown`, `ArrowLeft`, `ArrowRight`, `Enter`,
 } // Multiple keys
 ```
 
-Auto-screenshot is triggered after the key sequence ends (when the next step is not a `key`).
+Auto-screenshot is triggered after the key sequence ends (when the next step is
+not a `key`).
 
 ### `streaming` — Capture During Execution
 
-Capture multiple screenshots at intervals during long-running output (e.g., progress bars). Optionally generates an animated GIF.
+Capture multiple screenshots at intervals during long-running output (e.g.,
+progress bars). Optionally generates an animated GIF.
 
 ```typescript
 {
@@ -125,11 +145,15 @@ Capture multiple screenshots at intervals during long-running output (e.g., prog
 }
 ```
 
-- `delayMs` (optional): Milliseconds to wait after pressing Enter before starting captures. Useful for skipping model thinking/approval time.
-- Captures stop early if terminal output is unchanged for 3 consecutive intervals.
+- `delayMs` (optional): Milliseconds to wait after pressing Enter before
+  starting captures. Useful for skipping model thinking/approval time.
+- Captures stop early if terminal output is unchanged for 3 consecutive
+  intervals.
 - Duplicate frames (no output change) are automatically skipped.
 
-**GIF prerequisite**: If the scenario uses `streaming` with GIF enabled (default), check if `ffmpeg` is installed before running. If not, ask the user whether they'd like to install it:
+**GIF prerequisite**: If the scenario uses `streaming` with GIF enabled
+(default), check if `ffmpeg` is installed before running. If not, ask the user
+whether they'd like to install it:
 
 ```bash
 # Check
@@ -139,7 +163,8 @@ which ffmpeg
 brew install ffmpeg
 ```
 
-If the user declines, the scenario still runs — GIF generation is skipped with a warning.
+If the user declines, the scenario still runs. GIF generation is skipped with a
+warning.
 
 ### `capture` / `captureFull` — Explicit Screenshot
 
@@ -200,12 +225,18 @@ This tool is commonly used for visual verification during PR reviews.
 
 ## Troubleshooting
 
-| Issue                                | Cause                                 | Solution                                             |
-| ------------------------------------ | ------------------------------------- | ---------------------------------------------------- |
-| Playwright error `browser not found` | Browser not installed                 | `npx playwright install chromium`                    |
-| Blank screenshot                     | Process starts slowly or build failed | Ensure `npm run build` succeeds, check spawn command |
-| PTY-related errors                   | node-pty native module not compiled   | `npm rebuild node-pty`                               |
-| Unstable screenshot output           | Terminal output not fully rendered    | Check if the scenario needs additional wait time     |
+- Playwright error `browser not found`
+   Cause: browser not installed.
+   Solution: `npx playwright install chromium`.
+- Blank screenshot
+   Cause: process starts slowly or build failed.
+   Solution: check build success and the spawn command.
+- PTY-related errors
+   Cause: node-pty native module not compiled.
+   Solution: `npm rebuild node-pty`.
+- Unstable screenshot output
+   Cause: terminal output not fully rendered.
+   Solution: add scenario wait time.
 
 ## Full ScenarioConfig Type
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md
 
-This file provides guidance to Qwen Code when working with code in this repository.
+This file provides guidance to Qwen Code when working with code in this
+repository.
 
 ## Common Commands
 
@@ -10,14 +11,27 @@ This file provides guidance to Qwen Code when working with code in this reposito
 npm install        # Install all dependencies
 npm run build      # Build all packages (TypeScript compilation + asset copying)
 npm run build:all  # Build everything including sandbox container
-npm run bundle     # Bundle dist/ into a single dist/cli.js via esbuild (requires build first)
+npm run bundle     # Bundle dist/ into a single dist/cli.js via esbuild
+                   # (requires build first)
 ```
 
-`npm run build` compiles TS into each package's `dist/`. `npm run bundle` takes that output and produces a single `dist/cli.js` via esbuild. Bundle requires build to have run first.
+`npm run build` compiles TS into each package's `dist/`. `npm run bundle`
+takes that output and produces a single `dist/cli.js` via esbuild. Bundle
+requires build to have run first.
+
+### Development
+
+```bash
+npm run dev        # Run CLI directly from TypeScript source (no build needed)
+```
+
+Runs the CLI via `tsx` with `DEV=true`. Changes to `packages/core` or
+`packages/cli` are reflected immediately without rebuilding.
 
 ### Unit Testing
 
-Tests must be run from within the specific package directory, not the project root.
+Tests must be run from within the specific package directory, not the project
+root.
 
 **Run individual test files** (always preferred):
 
@@ -35,12 +49,14 @@ cd packages/cli && npx vitest run src/path/to/file.test.ts --update
 **Avoid:**
 
 - `npm run test -- --filter=...` — does NOT filter; runs the entire suite
-- `npx vitest` from the project root — fails due to package-specific vitest configs
+- `npx vitest` from the project root — fails due to package-specific vitest
+  configs
 - Running the whole test suite unless necessary (e.g., final PR verification)
 
 **Test gotchas:**
 
-- In CLI tests, use `vi.hoisted()` for mocks consumed by `vi.mock()` — the mock factory runs at module load time, before test execution.
+- In CLI tests, use `vi.hoisted()` for mocks consumed by `vi.mock()` — the
+  mock factory runs at module load time, before test execution.
 
 ### Integration Testing
 
@@ -56,10 +72,12 @@ npm run test:integration:interactive:sandbox:none
 Or combined in one command:
 
 ```bash
-cd integration-tests && cross-env QWEN_SANDBOX=false npx vitest run cli interactive
+cd integration-tests && \
+  cross-env QWEN_SANDBOX=false npx vitest run cli interactive
 ```
 
-**Gotcha:** In interactive tests, always call `session.idle()` between sends — ANSI output streams asynchronously.
+**Gotcha:** In interactive tests, always call `session.idle()` between sends —
+ANSI output streams asynchronously.
 
 ### Linting & Formatting
 
@@ -68,25 +86,91 @@ npm run lint       # ESLint check
 npm run lint:fix   # Auto-fix lint issues
 npm run format     # Prettier formatting
 npm run typecheck  # TypeScript type checking
-npm run preflight  # Full check: clean → install → format → lint → build → typecheck → test
+npm run preflight  # Full check: clean → install → format → lint → build
+                   # → typecheck → test
 ```
 
 ## Code Conventions
 
 - **Module system**: ESM throughout (`"type": "module"` in all packages)
-- **TypeScript**: Strict mode with `noImplicitAny`, `strictNullChecks`, `noUnusedLocals`, `verbatimModuleSyntax`
-- **Formatting**: Prettier — single quotes, semicolons, trailing commas, 2-space indent, 80-char width
-- **Linting**: No `any` types, consistent type imports, no relative imports between packages
-- **Tests**: Collocated with source (`file.test.ts` next to `file.ts`), vitest framework
+- **TypeScript**: Strict mode with `noImplicitAny`, `strictNullChecks`,
+  `noUnusedLocals`, `verbatimModuleSyntax`
+- **Formatting**: Prettier — single quotes, semicolons, trailing commas,
+  2-space indent, 80-char width
+- **Linting**: No `any` types, consistent type imports, no relative imports
+  between packages
+- **Tests**: Collocated with source (`file.test.ts` next to `file.ts`),
+  vitest framework
 - **Commits**: Conventional Commits (e.g., `feat(cli): Add --json flag`)
 - **Node.js**: Development requires `~20.19.0`; production requires `>=20`
 
+## Development Guidelines
+
+### General workflow
+
+1. **Design doc for non-trivial work** — write one in `.qwen/design/` if the
+   change touches multiple files or involves design decisions. Skip for small
+   bugfixes.
+2. **Test plan for behavioral changes** — write an E2E test plan in
+   `.qwen/e2e-tests/` when the change affects user-observable behavior. Dry-run
+   against the global `qwen` CLI first to confirm the baseline.
+3. **Build + typecheck before declaring done**:
+   `npm run build && npm run typecheck`.
+4. **Code review** — run `/review` when available. Triage each comment:
+   valid / false positive / overthinking.
+
+### Feature development
+
+Use the `/feat-dev` skill for the full workflow: investigate, design, test plan,
+dry-run, implement, verify, code review, and iterate.
+
+### Bugfix
+
+Use the `/bugfix` skill for the reproduce-first workflow: reproduce, fix,
+verify, test, and code review.
+
 ## GitHub Operations
 
-Use the `gh` CLI for all GitHub-related operations — issues, pull requests, comments, CI checks, releases, and API calls. Prefer `gh issue view`, `gh pr view`, `gh pr checks`, `gh run view`, `gh api`, etc. over web fetches or manual REST calls.
+Use the `gh` CLI for all GitHub-related operations — issues, pull requests,
+comments, CI checks, releases, and API calls. Prefer `gh issue view`,
+`gh pr view`, `gh pr checks`, `gh run view`, `gh api`, etc. over web fetches
+or manual REST calls.
 
 ## Testing, Debugging, and Bug Fixes
 
-- **Bug reproduction & verification**: spawn the `test-engineer` agent. It reads code and docs to understand the bug, then reproduces it via E2E testing (or a test-script fallback). It also handles post-fix verification. It cannot edit source code — only observe and report.
-- **Hard bugs**: use the `structured-debugging` skill when debugging requires more than a quick glance — especially when the first attempt at a fix didn't work or the behavior seems impossible.
-- **E2E testing**: the `e2e-testing` skill covers headless mode, interactive (tmux) mode, MCP server testing, and API traffic inspection. The `test-engineer` agent invokes this skill internally — you typically don't need to use it directly.
+- **Bug reproduction & verification**: spawn the `test-engineer` agent. It
+  reads code and docs to understand the bug, then reproduces it via E2E testing
+  (or a test-script fallback). It also handles post-fix verification. It cannot
+  edit source code — only observe and report.
+- **Hard bugs**: use the `structured-debugging` skill when debugging requires
+  more than a quick glance — especially when the first attempt at a fix didn't
+  work or the behavior seems impossible.
+- **E2E testing**: the `e2e-testing` skill covers headless mode, interactive
+  (tmux) mode, MCP server testing, and API traffic inspection. The
+  `test-engineer` agent invokes this skill internally — you typically don't
+  need to use it directly.
+
+## Submitting PRs
+
+When creating a PR, follow the template at `.github/pull_request_template.md`.
+After the PR is submitted, post a separate comment with the E2E test report if
+applicable.
+
+- **PR description**: explain the motivation and changes in prose. Avoid
+  referencing file names or function names.
+- **Reviewer Test Plan**: describe behaviors a reviewer should verify and what
+  to expect, not scripted test commands.
+
+## Project Directories
+
+Project artifacts live under `.qwen/`:
+
+| Directory | Purpose |
+|---|---|
+| `.qwen/design/` | Design docs for planned features |
+| `.qwen/e2e-tests/` | E2E test plans and results |
+| `.qwen/issues/` | Issue drafts before filing on GitHub |
+| `.qwen/pr-drafts/` | PR drafts before submitting |
+| `.qwen/pr-reviews/` | PR review notes |
+| `.qwen/investigations/` | Structured debugging journals |
+| `.qwen/scripts/` | Utility scripts |


### PR DESCRIPTION
## TLDR

This PR expands AGENTS.md with structured development workflows and adds two new skills (`feat-dev` and `bugfix`) for Qwen Code self-development. All other changes are pure formatting (line wrapping, whitespace, Prettier).

Key additions:
- **New skills**: `bugfix` (reproduce-first workflow) and `feat-dev` (end-to-end feature implementation workflow)
- **AGENTS.md expansion**: Added development commands (`npm run dev`), feature/bugfix workflow guidance, project directories table, and code review guidelines
- **.gitignore reorganization**: Moved Qwen Code config rules near the top for better visibility

Everything else — updates to `docs-audit-and-refresh`, `docs-update-from-diff`, `e2e-testing`, `qwen-code-claw`, `structured-debugging`, `terminal-capture`, `test-engineer`, and qc commands — is pure formatting with no semantic changes.

## Screenshots / Video Demo

N/A — no user-facing change. These are internal documentation and configuration improvements for the Qwen Code development experience.

## Dive Deeper

The goal is to reduce friction when using Qwen Code's own tooling to develop itself. Previously, skill definitions were sparse and AGENTS.md lacked guidance on structured workflows. This PR:

1. **Standardizes skill format**: All skills now use consistent frontmatter (`name`, `description`) and structured Markdown bodies with clear phase/step breakdowns.

2. **Introduces reproducible workflows**: The `bugfix` skill enforces reproduce-first discipline (read issue → reproduce → fix → verify). The `feat-dev` skill provides a 6-phase workflow (investigate → design → test plan → dry-run → implement → verify → review).

3. **Improves discoverability**: AGENTS.md now includes a "Development" section with `npm run dev`, a "Feature development" section referencing `/feat-dev`, and a "Bugfix" section referencing `/bugfix`. It also documents the `.qwen/` project directory structure.

4. **Maintains consistency**: The `test-engineer` agent description was reformatted for readability without changing semantics. QC command files were updated to reference the new skills appropriately.

## Reviewer Test Plan

1. Check that `npm run dev` works as documented in AGENTS.md
2. Verify the new skills render correctly in Qwen Code's skill system (`/bugfix`, `/feat-dev`)
3. Confirm `.gitignore` properly excludes/retains `.qwen/` subdirectories
4. Review AGENTS.md for accuracy of commands and conventions

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |
| npx      | ❓  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

No linked issues

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)