### PR TITLE
fix(cli): stabilize large tool output rendering

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
@@ -573,6 +573,28 @@ describe('<ToolMessage />', () => {
     expect(output).toContain('line 5000');
   });
 
+  it('pre-slices single-line output by visual width before MaxSizedBox layout', () => {
+    const longSingleLine = Array.from({ length: 1000 }, (_, i) =>
+      String(i % 10),
+    ).join('');
+    const { lastFrame } = renderWithContext(
+      <ToolMessage
+        {...baseProps}
+        name="some-other-tool"
+        contentWidth={20}
+        resultDisplay={longSingleLine}
+        status={ToolCallStatus.Success}
+        availableTerminalHeight={12}
+      />,
+      StreamingState.Idle,
+    );
+    const output = lastFrame()!;
+
+    expect(output).toMatch(/\.\.\. first \d+ lin/);
+    expect(output).not.toContain(longSingleLine);
+    expect(output).toContain(longSingleLine.slice(-10));
+  });
+
   it('does not pre-slice string output that exactly fits available height', () => {
     const exactFitString = Array.from(
       { length: 6 },

--- a/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
@@ -547,6 +547,54 @@ describe('<ToolMessage />', () => {
     expect(output).toContain('line 30');
   });
 
+  it('pre-slices large non-shell string output before MaxSizedBox layout', () => {
+    const longString = Array.from(
+      { length: 5000 },
+      (_, i) => `line ${i + 1}`,
+    ).join('\n');
+    const { lastFrame } = renderWithContext(
+      <ToolMessage
+        {...baseProps}
+        name="some-other-tool"
+        resultDisplay={longString}
+        status={ToolCallStatus.Success}
+        availableTerminalHeight={12}
+      />,
+      StreamingState.Idle,
+    );
+    const output = lastFrame()!;
+
+    expect(output).toContain('... first 4995 lines hidden ...');
+    expect(output).not.toContain('line 4995');
+    expect(output).toContain('line 4996');
+    expect(output).toContain('line 4997');
+    expect(output).toContain('line 4998');
+    expect(output).toContain('line 4999');
+    expect(output).toContain('line 5000');
+  });
+
+  it('does not pre-slice string output that exactly fits available height', () => {
+    const exactFitString = Array.from(
+      { length: 6 },
+      (_, i) => `line ${i + 1}`,
+    ).join('\n');
+    const { lastFrame } = renderWithContext(
+      <ToolMessage
+        {...baseProps}
+        name="some-other-tool"
+        resultDisplay={exactFitString}
+        status={ToolCallStatus.Success}
+        availableTerminalHeight={12}
+      />,
+      StreamingState.Idle,
+    );
+    const output = lastFrame()!;
+
+    expect(output).not.toContain('lines hidden');
+    expect(output).toContain('line 1');
+    expect(output).toContain('line 6');
+  });
+
   it.each([
     ['negative', -1],
     ['fractional', 1.5],

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -12,7 +12,7 @@ import { DiffRenderer } from './DiffRenderer.js';
 import { MarkdownDisplay } from '../../utils/MarkdownDisplay.js';
 import { AnsiOutputText, ShellStatsBar } from '../AnsiOutput.js';
 import type { ShellStatsBarProps } from '../AnsiOutput.js';
-import { MaxSizedBox } from '../shared/MaxSizedBox.js';
+import { MaxSizedBox, MINIMUM_MAX_HEIGHT } from '../shared/MaxSizedBox.js';
 import { TodoDisplay } from '../TodoDisplay.js';
 import type {
   TodoResultDisplay,
@@ -47,6 +47,29 @@ const DEFAULT_SHELL_OUTPUT_MAX_LINES = 5;
 // outputs that will get truncated further MaxSizedBox anyway.
 const MAXIMUM_RESULT_DISPLAY_CHARACTERS = 1000000;
 export type TextEmphasis = 'high' | 'medium' | 'low';
+
+function sliceTextForMaxHeight(
+  text: string,
+  maxHeight: number | undefined,
+): { text: string; hiddenLinesCount: number } {
+  if (maxHeight === undefined) {
+    return { text, hiddenLinesCount: 0 };
+  }
+
+  const targetMaxHeight = Math.max(Math.round(maxHeight), MINIMUM_MAX_HEIGHT);
+  const lines = text.split('\n');
+
+  if (lines.length <= targetMaxHeight) {
+    return { text, hiddenLinesCount: 0 };
+  }
+
+  const visibleContentHeight = targetMaxHeight - 1;
+  const hiddenLinesCount = lines.length - visibleContentHeight;
+  return {
+    text: lines.slice(hiddenLinesCount).join('\n'),
+    hiddenLinesCount,
+  };
+}
 
 type DisplayRendererResult =
   | { type: 'none' }
@@ -234,11 +257,17 @@ const StringResultRenderer: React.FC<{
     );
   }
 
+  const sliced = sliceTextForMaxHeight(displayData, availableHeight);
+
   return (
-    <MaxSizedBox maxHeight={availableHeight} maxWidth={childWidth}>
+    <MaxSizedBox
+      maxHeight={availableHeight}
+      maxWidth={childWidth}
+      additionalHiddenLinesCount={sliced.hiddenLinesCount}
+    >
       <Box>
         <Text wrap="wrap" color={theme.text.primary}>
-          {displayData}
+          {sliced.text}
         </Text>
       </Box>
     </MaxSizedBox>

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -31,6 +31,7 @@ import { theme } from '../../semantic-colors.js';
 import { useSettings } from '../../contexts/SettingsContext.js';
 import type { LoadedSettings } from '../../../config/settings.js';
 import { useCompactMode } from '../../contexts/CompactModeContext.js';
+import { getCachedStringWidth, toCodePoints } from '../../utils/textUtils.js';
 
 import {
   ToolStatusIndicator,
@@ -51,22 +52,58 @@ export type TextEmphasis = 'high' | 'medium' | 'low';
 function sliceTextForMaxHeight(
   text: string,
   maxHeight: number | undefined,
+  maxWidth: number,
 ): { text: string; hiddenLinesCount: number } {
   if (maxHeight === undefined) {
     return { text, hiddenLinesCount: 0 };
   }
 
   const targetMaxHeight = Math.max(Math.round(maxHeight), MINIMUM_MAX_HEIGHT);
-  const lines = text.split('\n');
+  const visibleContentHeight = targetMaxHeight - 1;
+  const visualWidth = Math.max(1, Math.floor(maxWidth));
+  const visibleLines: string[] = [];
+  let visualLineCount = 0;
+  let currentLine = '';
+  let currentLineWidth = 0;
 
-  if (lines.length <= targetMaxHeight) {
+  const appendVisibleLine = (line: string) => {
+    visualLineCount += 1;
+    visibleLines.push(line);
+    if (visibleLines.length > visibleContentHeight) {
+      visibleLines.shift();
+    }
+  };
+
+  const flushCurrentLine = () => {
+    appendVisibleLine(currentLine);
+    currentLine = '';
+    currentLineWidth = 0;
+  };
+
+  for (const char of toCodePoints(text)) {
+    if (char === '\n') {
+      flushCurrentLine();
+      continue;
+    }
+
+    const charWidth = Math.max(getCachedStringWidth(char), 1);
+    if (currentLineWidth > 0 && currentLineWidth + charWidth > visualWidth) {
+      flushCurrentLine();
+    }
+
+    currentLine += char;
+    currentLineWidth += charWidth;
+  }
+
+  flushCurrentLine();
+
+  if (visualLineCount <= targetMaxHeight) {
     return { text, hiddenLinesCount: 0 };
   }
 
-  const visibleContentHeight = targetMaxHeight - 1;
-  const hiddenLinesCount = lines.length - visibleContentHeight;
+  const hiddenLinesCount = visualLineCount - visibleContentHeight;
   return {
-    text: lines.slice(hiddenLinesCount).join('\n'),
+    text: visibleLines.join('\n'),
     hiddenLinesCount,
   };
 }
@@ -257,7 +294,11 @@ const StringResultRenderer: React.FC<{
     );
   }
 
-  const sliced = sliceTextForMaxHeight(displayData, availableHeight);
+  const sliced = sliceTextForMaxHeight(
+    displayData,
+    availableHeight,
+    childWidth,
+  );
 
   return (
     <MaxSizedBox


### PR DESCRIPTION
## Summary

This is PR2 in the TUI flicker/stability series and is intentionally stacked on #3584 (`fix/main-screen-flicker`). After #3584 lands, this PR can be retargeted to `main`.

It addresses large string tool result output that currently enters Ink layout in full and is only clipped later by `MaxSizedBox`. The fix now covers both explicit multi-line output and single-line output that visually wraps heavily, such as minified JSON, base64, or long logs.

## Changes

- Pre-slice string tool result output before rendering it through Ink `Text`.
- Slice by terminal visual height using the available content width, not only by explicit `\n` line count.
- Preserve the existing hidden-lines affordance by passing the pre-sliced hidden visual line count into `MaxSizedBox`.
- Keep exact-fit output unchanged so short or height-fitting tool results do not gain a hidden-lines banner.
- Keep ANSI live shell output, diffs, todo display, plans, and structured renderers on their existing paths.

## Why This Is Separate From PR1

PR1 reduces main-screen redraw pressure and stream-token redraw frequency. This PR handles a separate class of flicker: large completed tool outputs that are too expensive before clipping. Keeping it separate makes the behavior easy to reproduce and verify with focused `ToolMessage` tests.

## Verification

- `git diff --check`
- `cd packages/cli && npx vitest run src/ui/components/messages/ToolMessage.test.tsx`
- `npm run typecheck --workspace=packages/cli`
- `npm run lint --workspace=packages/cli`

## Effect Comparison

Before screenshot/video:

> TODO: attach large tool output rendering before this PR.

After screenshot/video:

> TODO: attach the same scenario after this PR.
