### PR TITLE
fix(core): preserve shell transcript across narrow wraps

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -33,6 +33,26 @@ const mockIsBinary = vi.hoisted(() => vi.fn());
 const mockPlatform = vi.hoisted(() => vi.fn());
 const mockGetPty = vi.hoisted(() => vi.fn());
 const mockSerializeTerminalToObject = vi.hoisted(() => vi.fn());
+const mockSerializeTerminalToText = vi.hoisted(() =>
+  vi.fn((terminal: pkg.Terminal): string => {
+    const buffer = terminal.buffer.active;
+    const lines: string[] = [];
+
+    for (let i = 0; i < buffer.length; i++) {
+      const line = buffer.getLine(i);
+      const lineContent = line ? line.translateToString(true) : '';
+
+      if (line?.isWrapped && lines.length > 0) {
+        lines[lines.length - 1] += lineContent;
+        continue;
+      }
+
+      lines.push(lineContent);
+    }
+
+    return lines.join('\n').trimEnd();
+  }),
+);
 const mockGetShellConfiguration = vi.hoisted(() =>
   vi.fn().mockReturnValue({
     executable: 'bash',
@@ -74,6 +94,7 @@ vi.mock('../utils/getPty.js', () => ({
 }));
 vi.mock('../utils/terminalSerializer.js', () => ({
   serializeTerminalToObject: mockSerializeTerminalToObject,
+  serializeTerminalToText: mockSerializeTerminalToText,
 }));
 vi.mock('../utils/shell-utils.js', () => ({
   getShellConfiguration: mockGetShellConfiguration,
@@ -363,6 +384,23 @@ describe('ShellExecutionService', () => {
       });
 
       expect(result.output).toBe('Compressing objects: 100% (7/7), done.');
+    });
+
+    it('should not persist narrow terminal soft wraps as transcript newlines', async () => {
+      const { result } = await simulateExecution(
+        'narrow-output',
+        (pty) => {
+          pty.onData.mock.calls[0][0]('abcdefghijklmnopqrstuvwxyz\nshort\n');
+          pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+        },
+        {
+          ...shellExecutionConfig,
+          terminalWidth: 8,
+          terminalHeight: 4,
+        },
+      );
+
+      expect(result.output).toBe('abcdefghijklmnopqrstuvwxyz\nshort');
     });
   });
 

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -143,6 +143,17 @@ const createExpectedAnsiOutput = (text: string | string[]): AnsiOutput => {
   return expected;
 };
 
+const createAnsiToken = (text: string) => ({
+  text,
+  bold: false,
+  italic: false,
+  underline: false,
+  dim: false,
+  inverse: false,
+  fg: '',
+  bg: '',
+});
+
 const setupConflictingPathEnv = () => {
   process.env = {
     ...originalProcessEnv,
@@ -745,6 +756,59 @@ describe('ShellExecutionService', () => {
           chunk: mockAnsiOutput,
         }),
       );
+    });
+
+    it('does not re-emit live output when only soft-wrap segmentation changes', async () => {
+      const coloredShellExecutionConfig = {
+        ...shellExecutionConfig,
+        showColor: true,
+        disableDynamicLineTrimming: true,
+      };
+      const firstWrappedOutput = [
+        [createAnsiToken('abcd')],
+        [createAnsiToken('efgh')],
+      ];
+      const rewrappedOutput = [
+        [createAnsiToken('ab')],
+        [createAnsiToken('cdef')],
+        [createAnsiToken('gh')],
+      ];
+      const logicalOutput = [[createAnsiToken('abcdefgh')]];
+      let rawRenderCount = 0;
+
+      mockSerializeTerminalToObject.mockImplementation(
+        (
+          _terminal,
+          _scrollOffset,
+          options?: { unwrapWrappedLines?: boolean },
+        ) => {
+          if (options?.unwrapWrappedLines) {
+            return logicalOutput;
+          }
+
+          rawRenderCount += 1;
+          return rawRenderCount === 1 ? firstWrappedOutput : rewrappedOutput;
+        },
+      );
+
+      await simulateExecution(
+        'narrow-output',
+        (pty) => {
+          pty.onData.mock.calls[0][0]('abcdefgh');
+          pty.onData.mock.calls[0][0]('\r');
+          pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+        },
+        coloredShellExecutionConfig,
+      );
+
+      const dataEvents = onOutputEventMock.mock.calls.filter(
+        ([event]) => event.type === 'data',
+      );
+      expect(dataEvents).toHaveLength(1);
+      expect(dataEvents[0][0]).toEqual({
+        type: 'data',
+        chunk: firstWrappedOutput,
+      });
     });
 
     it('should call onOutputEvent with AnsiOutput when showColor is false', async () => {

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -167,6 +167,21 @@ const expectNormalizedWindowsPathEnv = (env: NodeJS.ProcessEnv) => {
   expect(env['Path']).toBeUndefined();
 };
 
+const waitForDataEventCount = async (
+  onOutputEventMock: Mock<(event: ShellOutputEvent) => void>,
+  expectedCount: number,
+) => {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const dataEvents = onOutputEventMock.mock.calls.filter(
+      ([event]) => event.type === 'data',
+    );
+    if (dataEvents.length >= expectedCount) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+};
+
 describe('ShellExecutionService', () => {
   let mockPtyProcess: EventEmitter & {
     pid: number;
@@ -833,6 +848,47 @@ describe('ShellExecutionService', () => {
           chunk: expected,
         }),
       );
+    });
+
+    it('does not re-emit default plain live output when only soft-wrap segmentation changes', async () => {
+      const abortController = new AbortController();
+      const handle = await ShellExecutionService.execute(
+        'narrow-output',
+        '/test/dir',
+        onOutputEventMock,
+        abortController.signal,
+        true,
+        {
+          ...shellExecutionConfig,
+          terminalWidth: 4,
+          terminalHeight: 4,
+          showColor: false,
+          disableDynamicLineTrimming: false,
+        },
+      );
+
+      await new Promise((resolve) => process.nextTick(resolve));
+      mockPtyProcess.onData.mock.calls[0][0]('abcdefgh');
+      await waitForDataEventCount(onOutputEventMock, 1);
+
+      ShellExecutionService.resizePty(handle.pid!, 2, 4);
+      mockPtyProcess.onData.mock.calls[0][0]('\r');
+      mockPtyProcess.onExit.mock.calls[0][0]({ exitCode: 0, signal: null });
+      await handle.result;
+
+      const dataEvents = onOutputEventMock.mock.calls.filter(
+        ([event]) => event.type === 'data',
+      );
+      expect(dataEvents).toHaveLength(1);
+      const firstDataEvent = dataEvents[0][0];
+      if (firstDataEvent.type !== 'data') {
+        throw new Error('Expected a shell data event.');
+      }
+      const chunk = firstDataEvent.chunk as AnsiOutput;
+      expect(chunk.map((line) => line[0]?.text).filter(Boolean)).toEqual([
+        'abcd',
+        'efgh',
+      ]);
     });
 
     it('should handle multi-line output correctly when showColor is false', async () => {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -17,6 +17,7 @@ import { getShellConfiguration } from '../utils/shell-utils.js';
 import pkg from '@xterm/headless';
 import {
   serializeTerminalToObject,
+  serializeTerminalToText,
   type AnsiOutput,
 } from '../utils/terminalSerializer.js';
 import { normalizePathEnvForWindows } from '../utils/windowsPath.js';
@@ -135,17 +136,6 @@ const isExpectedPtyExitRaceError = (error: unknown): boolean => {
   );
 };
 
-const getFullBufferText = (terminal: pkg.Terminal): string => {
-  const buffer = terminal.buffer.active;
-  const lines: string[] = [];
-  for (let i = 0; i < buffer.length; i++) {
-    const line = buffer.getLine(i);
-    const lineContent = line ? line.translateToString(true) : '';
-    lines.push(lineContent);
-  }
-  return lines.join('\n').trimEnd();
-};
-
 const replayTerminalOutput = async (
   output: string,
   cols: number,
@@ -163,7 +153,7 @@ const replayTerminalOutput = async (
     replayTerminal.write(output, () => resolve());
   });
 
-  return getFullBufferText(replayTerminal);
+  return serializeTerminalToText(replayTerminal);
 };
 
 interface ProcessCleanupStrategy {
@@ -558,7 +548,7 @@ export class ShellExecutionService {
 
           if (!shellExecutionConfig.disableDynamicLineTrimming) {
             if (!hasStartedOutput) {
-              const bufferText = getFullBufferText(headlessTerminal);
+              const bufferText = serializeTerminalToText(headlessTerminal);
               if (bufferText.trim().length === 0) {
                 return;
               }
@@ -759,11 +749,11 @@ export class ShellExecutionService {
                     rows,
                   );
                 } else {
-                  fullOutput = getFullBufferText(headlessTerminal);
+                  fullOutput = serializeTerminalToText(headlessTerminal);
                 }
               } catch {
                 try {
-                  fullOutput = getFullBufferText(headlessTerminal);
+                  fullOutput = serializeTerminalToText(headlessTerminal);
                 } catch {
                   // Ignore fallback rendering errors and resolve with empty text.
                 }

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -205,6 +205,40 @@ const areAnsiOutputsEqual = (
   });
 };
 
+const createPlainAnsiLine = (text: string) => [
+  {
+    text,
+    bold: false,
+    italic: false,
+    underline: false,
+    dim: false,
+    inverse: false,
+    fg: '',
+    bg: '',
+  },
+];
+
+const serializePlainViewportToAnsiOutput = (
+  terminal: pkg.Terminal,
+  unwrapWrappedLines = false,
+): AnsiOutput => {
+  const buffer = terminal.buffer.active;
+  const lines: AnsiOutput = [];
+
+  for (let y = 0; y < terminal.rows; y++) {
+    const line = buffer.getLine(buffer.viewportY + y);
+    const lineContent = line ? line.translateToString(true) : '';
+
+    if (unwrapWrappedLines && line?.isWrapped && lines.length > 0) {
+      lines[lines.length - 1][0].text += lineContent;
+    } else {
+      lines.push(createPlainAnsiLine(lineContent));
+    }
+  }
+
+  return lines;
+};
+
 interface ProcessCleanupStrategy {
   killPty(pid: number, pty: ActivePty): void;
   killChildProcesses(pids: Set<number>): void;
@@ -615,26 +649,11 @@ export class ShellExecutionService {
               { unwrapWrappedLines: true },
             );
           } else {
-            const buffer = headlessTerminal.buffer.active;
-            const lines: AnsiOutput = [];
-            for (let y = 0; y < headlessTerminal.rows; y++) {
-              const line = buffer.getLine(buffer.viewportY + y);
-              const lineContent = line ? line.translateToString(true) : '';
-              lines.push([
-                {
-                  text: lineContent,
-                  bold: false,
-                  italic: false,
-                  underline: false,
-                  dim: false,
-                  inverse: false,
-                  fg: '',
-                  bg: '',
-                },
-              ]);
-            }
-            newOutput = lines;
-            newOutputComparison = lines;
+            newOutput = serializePlainViewportToAnsiOutput(headlessTerminal);
+            newOutputComparison = serializePlainViewportToAnsiOutput(
+              headlessTerminal,
+              true,
+            );
           }
 
           const trimmedOutput = trimTrailingEmptyAnsiLines(newOutput);

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -156,6 +156,55 @@ const replayTerminalOutput = async (
   return serializeTerminalToText(replayTerminal);
 };
 
+const getLastNonEmptyAnsiLineIndex = (output: AnsiOutput): number => {
+  for (let i = output.length - 1; i >= 0; i--) {
+    const line = output[i];
+    if (
+      line
+        .map((segment) => segment.text)
+        .join('')
+        .trim().length > 0
+    ) {
+      return i;
+    }
+  }
+
+  return -1;
+};
+
+const trimTrailingEmptyAnsiLines = (output: AnsiOutput): AnsiOutput =>
+  output.slice(0, getLastNonEmptyAnsiLineIndex(output) + 1);
+
+const areAnsiOutputsEqual = (
+  left: AnsiOutput | null,
+  right: AnsiOutput,
+): boolean => {
+  if (!left || left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((leftLine, lineIndex) => {
+    const rightLine = right[lineIndex];
+    if (leftLine.length !== rightLine.length) {
+      return false;
+    }
+
+    return leftLine.every((leftToken, tokenIndex) => {
+      const rightToken = rightLine[tokenIndex];
+      return (
+        leftToken.text === rightToken.text &&
+        leftToken.bold === rightToken.bold &&
+        leftToken.italic === rightToken.italic &&
+        leftToken.underline === rightToken.underline &&
+        leftToken.dim === rightToken.dim &&
+        leftToken.inverse === rightToken.inverse &&
+        leftToken.fg === rightToken.fg &&
+        leftToken.bg === rightToken.bg
+      );
+    });
+  });
+};
+
 interface ProcessCleanupStrategy {
   killPty(pid: number, pty: ActivePty): void;
   killChildProcesses(pids: Set<number>): void;
@@ -526,7 +575,7 @@ export class ShellExecutionService {
 
         let processingChain = Promise.resolve();
         let decoder: TextDecoder | null = null;
-        let output: string | AnsiOutput | null = null;
+        let outputComparison: AnsiOutput | null = null;
         const outputChunks: Buffer[] = [];
         const error: Error | null = null;
         let exited = false;
@@ -557,8 +606,14 @@ export class ShellExecutionService {
           }
 
           let newOutput: AnsiOutput;
+          let newOutputComparison: AnsiOutput;
           if (shellExecutionConfig.showColor) {
             newOutput = serializeTerminalToObject(headlessTerminal);
+            newOutputComparison = serializeTerminalToObject(
+              headlessTerminal,
+              0,
+              { unwrapWrappedLines: true },
+            );
           } else {
             const buffer = headlessTerminal.buffer.active;
             const lines: AnsiOutput = [];
@@ -579,31 +634,23 @@ export class ShellExecutionService {
               ]);
             }
             newOutput = lines;
+            newOutputComparison = lines;
           }
 
-          let lastNonEmptyLine = -1;
-          for (let i = newOutput.length - 1; i >= 0; i--) {
-            const line = newOutput[i];
-            if (
-              line
-                .map((segment) => segment.text)
-                .join('')
-                .trim().length > 0
-            ) {
-              lastNonEmptyLine = i;
-              break;
-            }
-          }
-
-          const trimmedOutput = newOutput.slice(0, lastNonEmptyLine + 1);
+          const trimmedOutput = trimTrailingEmptyAnsiLines(newOutput);
+          const trimmedOutputComparison =
+            trimTrailingEmptyAnsiLines(newOutputComparison);
 
           const finalOutput = shellExecutionConfig.disableDynamicLineTrimming
             ? newOutput
             : trimmedOutput;
+          const finalOutputComparison = shellExecutionConfig
+            .disableDynamicLineTrimming
+            ? newOutputComparison
+            : trimmedOutputComparison;
 
-          // Using stringify for a quick deep comparison.
-          if (JSON.stringify(output) !== JSON.stringify(finalOutput)) {
-            output = finalOutput;
+          if (!areAnsiOutputsEqual(outputComparison, finalOutputComparison)) {
+            outputComparison = finalOutputComparison;
             onOutputEvent({
               type: 'data',
               chunk: finalOutput,

--- a/packages/core/src/utils/terminalSerializer.test.ts
+++ b/packages/core/src/utils/terminalSerializer.test.ts
@@ -172,6 +172,28 @@ describe('terminalSerializer', () => {
       expect(result[0][0].bg).toBe('#008000');
       expect(result[0][0].text).toBe('Styled text');
     });
+
+    it('can unwrap soft-wrapped ANSI rows for live output comparison', async () => {
+      const terminal = new Terminal({
+        cols: 8,
+        rows: 4,
+        allowProposedApi: true,
+        scrollback: 100,
+        convertEol: true,
+      });
+
+      await writeToTerminal(terminal, 'abcdefghijkl\nshort\n');
+
+      const result = serializeTerminalToObject(terminal, 0, {
+        unwrapWrappedLines: true,
+      });
+      const visibleText = result
+        .map((line) => line.map((token) => token.text).join('').trimEnd())
+        .filter(Boolean);
+
+      expect(visibleText).toEqual(['abcdefghijkl', 'short']);
+      expect(result[0]).toHaveLength(1);
+    });
   });
 
   describe('serializeTerminalToText', () => {

--- a/packages/core/src/utils/terminalSerializer.test.ts
+++ b/packages/core/src/utils/terminalSerializer.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'vitest';
 import { Terminal } from '@xterm/headless';
 import {
   serializeTerminalToObject,
+  serializeTerminalToText,
   convertColorToHex,
   ColorMode,
 } from './terminalSerializer.js';
@@ -172,6 +173,57 @@ describe('terminalSerializer', () => {
       expect(result[0][0].text).toBe('Styled text');
     });
   });
+
+  describe('serializeTerminalToText', () => {
+    it('unwraps soft-wrapped narrow terminal lines for transcript text', async () => {
+      const terminal = new Terminal({
+        cols: 10,
+        rows: 4,
+        allowProposedApi: true,
+        scrollback: 100,
+        convertEol: true,
+      });
+
+      await writeToTerminal(terminal, 'abcdefghijklmnopqrstuvwxyz\n');
+
+      expect(serializeTerminalToText(terminal)).toBe(
+        'abcdefghijklmnopqrstuvwxyz',
+      );
+    });
+
+    it('keeps explicit newlines while unwrapping visual continuation rows', async () => {
+      const terminal = new Terminal({
+        cols: 8,
+        rows: 4,
+        allowProposedApi: true,
+        scrollback: 100,
+        convertEol: true,
+      });
+
+      await writeToTerminal(terminal, 'abcdefghijkl\nshort\n');
+
+      expect(serializeTerminalToText(terminal)).toBe('abcdefghijkl\nshort');
+    });
+
+    it('does not treat resize reflow as duplicated transcript lines', async () => {
+      const terminal = new Terminal({
+        cols: 12,
+        rows: 4,
+        allowProposedApi: true,
+        scrollback: 100,
+        convertEol: true,
+      });
+
+      await writeToTerminal(terminal, 'abcdefghijklmnopqrstuvwxyz\n123456\n');
+      terminal.resize(6, 4);
+      await writeToTerminal(terminal, 'done\n');
+
+      expect(serializeTerminalToText(terminal)).toBe(
+        'abcdefghijklmnopqrstuvwxyz\n123456\ndone',
+      );
+    });
+  });
+
   describe('convertColorToHex', () => {
     it('should convert RGB color to hex', () => {
       const color = (100 << 16) | (200 << 8) | 50;

--- a/packages/core/src/utils/terminalSerializer.ts
+++ b/packages/core/src/utils/terminalSerializer.ts
@@ -5,6 +5,7 @@
  */
 
 import type { IBufferCell, Terminal } from '@xterm/headless';
+
 export interface AnsiToken {
   text: string;
   bold: boolean;
@@ -18,6 +19,25 @@ export interface AnsiToken {
 
 export type AnsiLine = AnsiToken[];
 export type AnsiOutput = AnsiLine[];
+
+export function serializeTerminalToText(terminal: Terminal): string {
+  const buffer = terminal.buffer.active;
+  const lines: string[] = [];
+
+  for (let i = 0; i < buffer.length; i++) {
+    const line = buffer.getLine(i);
+    const lineContent = line ? line.translateToString(true) : '';
+
+    if (line?.isWrapped && lines.length > 0) {
+      lines[lines.length - 1] += lineContent;
+      continue;
+    }
+
+    lines.push(lineContent);
+  }
+
+  return lines.join('\n').trimEnd();
+}
 
 const enum Attribute {
   inverse = 1,

--- a/packages/core/src/utils/terminalSerializer.ts
+++ b/packages/core/src/utils/terminalSerializer.ts
@@ -20,6 +20,30 @@ export interface AnsiToken {
 export type AnsiLine = AnsiToken[];
 export type AnsiOutput = AnsiLine[];
 
+export interface SerializeTerminalToObjectOptions {
+  unwrapWrappedLines?: boolean;
+}
+
+const canMergeAnsiTokens = (left: AnsiToken, right: AnsiToken): boolean =>
+  left.bold === right.bold &&
+  left.italic === right.italic &&
+  left.underline === right.underline &&
+  left.dim === right.dim &&
+  left.inverse === right.inverse &&
+  left.fg === right.fg &&
+  left.bg === right.bg;
+
+const appendAnsiLineTokens = (target: AnsiLine, source: AnsiLine) => {
+  for (const token of source) {
+    const previous = target[target.length - 1];
+    if (previous && canMergeAnsiTokens(previous, token)) {
+      previous.text += token.text;
+    } else {
+      target.push({ ...token });
+    }
+  }
+};
+
 export function serializeTerminalToText(terminal: Terminal): string {
   const buffer = terminal.buffer.active;
   const lines: string[] = [];
@@ -154,6 +178,7 @@ class Cell {
 export function serializeTerminalToObject(
   terminal: Terminal,
   scrollOffset: number = 0,
+  options: SerializeTerminalToObjectOptions = {},
 ): AnsiOutput {
   const buffer = terminal.buffer.active;
   const defaultFg = '';
@@ -219,7 +244,11 @@ export function serializeTerminalToObject(
       currentLine.push(token);
     }
 
-    result.push(currentLine);
+    if (options.unwrapWrappedLines && line.isWrapped && result.length > 0) {
+      appendAnsiLineTokens(result[result.length - 1], currentLine);
+    } else {
+      result.push(currentLine);
+    }
   }
 
   return result;


### PR DESCRIPTION
## Summary

This is PR3 in the TUI flicker/stability series and is intentionally stacked on #3586 (`codex/pr2-large-output-detail-stability`). After the earlier PRs land, this PR can be retargeted down the stack.

It addresses the narrow-terminal / tmux-pane shell class where xterm visual soft wraps and resize reflow can be mistaken for duplicated output. Final shell transcript text now unwraps xterm continuation rows using `line.isWrapped`, and live shell rendering now suppresses updates whose only change is soft-wrap segmentation of the same logical content.

## Changes

- Add `serializeTerminalToText()` for transcript-oriented xterm serialization.
- Preserve explicit newlines while joining soft-wrapped visual continuation rows.
- Use the transcript serializer for shell final output and startup-empty checks.
- Add an `unwrapWrappedLines` comparison mode to `serializeTerminalToObject()` for live ANSI snapshots.
- Coalesce adjacent ANSI tokens with the same style while unwrapping, so width-only reflow does not create a different comparison shape.
- Replace the live output `JSON.stringify` comparison with semantic ANSI token comparison.
- Suppress re-emitting live shell output when the raw viewport changed only because the same logical line was soft-wrapped differently.
- Apply the same logical comparison to the default `showColor=false` shell path, so the default configuration is covered too.

## Issue Class

Targets the PR3 issue class from the TUI plan:

- Narrow terminals / tmux panes repeatedly showing wrapped output.
- Interactive shell transcript pollution from viewport reflow.
- Separating live viewport display from persisted transcript text.

## Verification

- `git diff --check`
- `cd packages/core && npx vitest run src/utils/terminalSerializer.test.ts src/services/shellExecutionService.test.ts`
- `npm run lint --workspace=packages/core`
- Full-stack verification after rebasing PR4 on this branch:
  - `npm run typecheck --workspace=packages/core`
  - `npm run typecheck --workspace=packages/cli`
  - CLI/core targeted test suites all pass

## Effect Comparison

Before screenshot/video:

> TODO: attach narrow terminal / tmux pane shell output before this PR.

After screenshot/video:

> TODO: attach the same scenario after this PR.
