### PR TITLE
fix(cli): gate synchronized terminal output

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -85,6 +85,7 @@ import { DualOutputContext } from './dualOutput/DualOutputContext.js';
 import { RemoteInputWatcher } from './remoteInput/RemoteInputWatcher.js';
 import { RemoteInputContext } from './remoteInput/RemoteInputContext.js';
 import { installTerminalRedrawOptimizer } from './ui/utils/terminalRedrawOptimizer.js';
+import { installSynchronizedOutput } from './ui/utils/synchronizedOutput.js';
 
 const debugLogger = createDebugLogger('STARTUP');
 
@@ -173,6 +174,10 @@ export async function startInteractiveUI(
   const restoreTerminalRedrawOptimizer =
     process.stdout.isTTY && !config.getScreenReader()
       ? installTerminalRedrawOptimizer(process.stdout)
+      : () => {};
+  const restoreSynchronizedOutput =
+    process.stdout.isTTY && !config.getScreenReader()
+      ? installSynchronizedOutput(process.stdout)
       : () => {};
 
   // Create dual output bridge if --json-fd or --json-file is specified.
@@ -297,6 +302,7 @@ export async function startInteractiveUI(
     // operational, preventing garbled terminal output after the app exits.
     disableKittyProtocol();
     instance.unmount();
+    restoreSynchronizedOutput();
     restoreTerminalRedrawOptimizer();
   });
 }

--- a/packages/cli/src/ui/utils/synchronizedOutput.test.ts
+++ b/packages/cli/src/ui/utils/synchronizedOutput.test.ts
@@ -1,0 +1,191 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  BEGIN_SYNCHRONIZED_UPDATE,
+  END_SYNCHRONIZED_UPDATE,
+  getSynchronizedOutputStatsSnapshot,
+  installSynchronizedOutput,
+  resetSynchronizedOutputStats,
+  terminalSupportsSynchronizedOutput,
+} from './synchronizedOutput.js';
+import { installTerminalRedrawOptimizer } from './terminalRedrawOptimizer.js';
+
+const ESC = '\u001B[';
+const ERASE_LINE = `${ESC}2K`;
+const CURSOR_UP_ONE = `${ESC}1A`;
+const CURSOR_DOWN_ONE = `${ESC}1B`;
+const CURSOR_LEFT = `${ESC}G`;
+
+function createStdout(write: NodeJS.WriteStream['write']): NodeJS.WriteStream {
+  return {
+    isTTY: true,
+    write,
+  } as NodeJS.WriteStream;
+}
+
+describe('terminalSupportsSynchronizedOutput', () => {
+  it.each([
+    [{ TERM_PROGRAM: 'WezTerm' }, true],
+    [{ TERM_PROGRAM: 'iTerm.app' }, true],
+    [{ TERM: 'xterm-kitty' }, true],
+    [{ KITTY_WINDOW_ID: '1' }, true],
+    [{ TERM_PROGRAM: 'Apple_Terminal' }, false],
+    [{ TERM_PROGRAM: 'JetBrains-JediTerm' }, false],
+    [{ TERM_PROGRAM: 'WezTerm', TMUX: '/tmp/tmux' }, false],
+    [{ TERM_PROGRAM: 'WezTerm', SSH_TTY: '/dev/pts/1' }, false],
+    [{ TERM_PROGRAM: 'WezTerm', SSH_CLIENT: '127.0.0.1 1 2' }, false],
+    [{ TERM_PROGRAM: 'WezTerm', QWEN_CODE_SYNCHRONIZED_OUTPUT: '0' }, false],
+    [
+      {
+        TERM_PROGRAM: 'WezTerm',
+        QWEN_CODE_DISABLE_SYNCHRONIZED_OUTPUT: '1',
+        QWEN_CODE_FORCE_SYNCHRONIZED_OUTPUT: '1',
+      },
+      false,
+    ],
+    [
+      {
+        TERM_PROGRAM: 'Apple_Terminal',
+        QWEN_CODE_FORCE_SYNCHRONIZED_OUTPUT: '1',
+      },
+      true,
+    ],
+  ])('detects support for %j', (env, expected) => {
+    expect(terminalSupportsSynchronizedOutput(env)).toBe(expected);
+  });
+});
+
+describe('installSynchronizedOutput', () => {
+  afterEach(() => {
+    resetSynchronizedOutputStats();
+  });
+
+  it('does not install for non-TTY stdout', () => {
+    const write = vi.fn(() => true) as NodeJS.WriteStream['write'];
+    const stdout = {
+      isTTY: false,
+      write,
+    } as NodeJS.WriteStream;
+
+    const restore = installSynchronizedOutput(stdout, {
+      TERM_PROGRAM: 'WezTerm',
+    });
+
+    expect(stdout.write).toBe(write);
+    restore();
+  });
+
+  it('wraps one synchronous write burst in balanced BSU and ESU markers', async () => {
+    const writes: string[] = [];
+    const write = vi.fn((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === 'string' ? chunk : chunk.toString());
+      return true;
+    }) as NodeJS.WriteStream['write'];
+    const stdout = createStdout(write);
+
+    const restore = installSynchronizedOutput(stdout, {
+      TERM_PROGRAM: 'WezTerm',
+    });
+
+    stdout.write('frame-a');
+    stdout.write(Buffer.from('frame-b'));
+    await Promise.resolve();
+
+    expect(writes).toEqual([
+      BEGIN_SYNCHRONIZED_UPDATE,
+      'frame-a',
+      'frame-b',
+      END_SYNCHRONIZED_UPDATE,
+    ]);
+    expect(getSynchronizedOutputStatsSnapshot()).toEqual({
+      synchronizedOutputFrameCount: 1,
+      synchronizedOutputBeginCount: 1,
+      synchronizedOutputEndCount: 1,
+    });
+
+    restore();
+    expect(stdout.write).toBe(write);
+  });
+
+  it('preserves write return values and callbacks', async () => {
+    const callback = vi.fn();
+    const write = vi.fn(
+      (
+        _chunk: string | Uint8Array,
+        encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+      ) => {
+        if (typeof encodingOrCallback === 'function') {
+          encodingOrCallback();
+        }
+        return false;
+      },
+    ) as NodeJS.WriteStream['write'];
+    const stdout = createStdout(write);
+
+    const restore = installSynchronizedOutput(stdout, {
+      TERM_PROGRAM: 'iTerm.app',
+    });
+
+    const result = stdout.write('payload', callback);
+    await Promise.resolve();
+
+    expect(result).toBe(false);
+    expect(callback).toHaveBeenCalledTimes(1);
+    restore();
+  });
+
+  it('composes after terminal redraw optimization without losing erase optimization', async () => {
+    const writes: string[] = [];
+    const write = vi.fn((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === 'string' ? chunk : chunk.toString());
+      return true;
+    }) as NodeJS.WriteStream['write'];
+    const stdout = createStdout(write);
+    const restoreRedrawOptimizer = installTerminalRedrawOptimizer(stdout);
+    const restoreSynchronizedOutput = installSynchronizedOutput(stdout, {
+      TERM_PROGRAM: 'WezTerm',
+    });
+
+    stdout.write(
+      `${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_UP_ONE}${ERASE_LINE}${CURSOR_LEFT}`,
+    );
+    await Promise.resolve();
+
+    expect(writes).toEqual([
+      BEGIN_SYNCHRONIZED_UPDATE,
+      `${ESC}2A${ERASE_LINE}${CURSOR_DOWN_ONE}${ERASE_LINE}${CURSOR_DOWN_ONE}${ERASE_LINE}${ESC}2A${CURSOR_LEFT}`,
+      END_SYNCHRONIZED_UPDATE,
+    ]);
+
+    restoreSynchronizedOutput();
+    restoreRedrawOptimizer();
+    expect(stdout.write).toBe(write);
+  });
+
+  it('closes an open frame before restore', () => {
+    const writes: string[] = [];
+    const write = vi.fn((chunk: string | Uint8Array) => {
+      writes.push(typeof chunk === 'string' ? chunk : chunk.toString());
+      return true;
+    }) as NodeJS.WriteStream['write'];
+    const stdout = createStdout(write);
+    const restore = installSynchronizedOutput(stdout, {
+      TERM_PROGRAM: 'WezTerm',
+    });
+
+    stdout.write('payload');
+    restore();
+
+    expect(writes).toEqual([
+      BEGIN_SYNCHRONIZED_UPDATE,
+      'payload',
+      END_SYNCHRONIZED_UPDATE,
+    ]);
+    expect(stdout.write).toBe(write);
+  });
+});

--- a/packages/cli/src/ui/utils/synchronizedOutput.ts
+++ b/packages/cli/src/ui/utils/synchronizedOutput.ts
@@ -1,0 +1,131 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const BEGIN_SYNCHRONIZED_UPDATE = '\u001B[?2026h';
+export const END_SYNCHRONIZED_UPDATE = '\u001B[?2026l';
+
+export interface SynchronizedOutputStatsSnapshot {
+  synchronizedOutputFrameCount: number;
+  synchronizedOutputBeginCount: number;
+  synchronizedOutputEndCount: number;
+}
+
+const synchronizedOutputStats: SynchronizedOutputStatsSnapshot = {
+  synchronizedOutputFrameCount: 0,
+  synchronizedOutputBeginCount: 0,
+  synchronizedOutputEndCount: 0,
+};
+
+let installed = false;
+
+export function getSynchronizedOutputStatsSnapshot(): SynchronizedOutputStatsSnapshot {
+  return { ...synchronizedOutputStats };
+}
+
+export function resetSynchronizedOutputStats(): void {
+  synchronizedOutputStats.synchronizedOutputFrameCount = 0;
+  synchronizedOutputStats.synchronizedOutputBeginCount = 0;
+  synchronizedOutputStats.synchronizedOutputEndCount = 0;
+}
+
+export function terminalSupportsSynchronizedOutput(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  if (
+    env['QWEN_CODE_DISABLE_SYNCHRONIZED_OUTPUT'] === '1' ||
+    env['QWEN_CODE_SYNCHRONIZED_OUTPUT'] === '0'
+  ) {
+    return false;
+  }
+
+  if (
+    env['QWEN_CODE_FORCE_SYNCHRONIZED_OUTPUT'] === '1' ||
+    env['QWEN_CODE_SYNCHRONIZED_OUTPUT'] === '1'
+  ) {
+    return true;
+  }
+
+  if (env['TMUX'] || env['SSH_TTY'] || env['SSH_CLIENT']) {
+    return false;
+  }
+
+  const termProgram = env['TERM_PROGRAM'];
+  if (termProgram === 'WezTerm' || termProgram === 'iTerm.app') {
+    return true;
+  }
+
+  const term = env['TERM'];
+  return Boolean(env['KITTY_WINDOW_ID'] || term?.includes('kitty'));
+}
+
+export function installSynchronizedOutput(
+  stdout: NodeJS.WriteStream = process.stdout,
+  env: NodeJS.ProcessEnv = process.env,
+): () => void {
+  if (installed || !stdout.isTTY || !terminalSupportsSynchronizedOutput(env)) {
+    return () => {};
+  }
+
+  const originalWrite = stdout.write;
+  let inFrame = false;
+
+  const writeControlSequence = (sequence: string) => {
+    originalWrite.call(stdout, sequence);
+  };
+
+  const endFrame = () => {
+    if (!inFrame) {
+      return;
+    }
+
+    inFrame = false;
+    synchronizedOutputStats.synchronizedOutputEndCount += 1;
+    writeControlSequence(END_SYNCHRONIZED_UPDATE);
+  };
+
+  const patchedWrite = function (
+    this: NodeJS.WriteStream,
+    chunk: unknown,
+    encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
+    callback?: (error?: Error | null) => void,
+  ) {
+    if (!inFrame) {
+      inFrame = true;
+      synchronizedOutputStats.synchronizedOutputFrameCount += 1;
+      synchronizedOutputStats.synchronizedOutputBeginCount += 1;
+      writeControlSequence(BEGIN_SYNCHRONIZED_UPDATE);
+      queueMicrotask(endFrame);
+    }
+
+    return originalWrite.call(
+      this,
+      chunk as string | Uint8Array,
+      encodingOrCallback as BufferEncoding,
+      callback,
+    );
+  } as typeof stdout.write;
+
+  const exitHandler = () => {
+    try {
+      endFrame();
+    } catch {
+      // stdout may already be closed during process shutdown.
+    }
+  };
+
+  stdout.write = patchedWrite;
+  installed = true;
+  process.once('exit', exitHandler);
+
+  return () => {
+    if (stdout.write === patchedWrite) {
+      endFrame();
+      stdout.write = originalWrite;
+    }
+    process.removeListener('exit', exitHandler);
+    installed = false;
+  };
+}


### PR DESCRIPTION
## Summary

This is PR4 in the TUI flicker/stability series and is intentionally stacked on #3587 (`codex/pr3-narrow-shell-viewport`). It should stay last in the stack because it touches terminal protocol behavior and stdout monkeypatch ordering.

It adds a conservative DECSET 2026 synchronized-output wrapper for supported terminals so a burst of Ink frame writes can be bracketed by BSU/ESU. Unknown terminals, tmux, SSH, JetBrains, non-TTY output, and screen reader mode stay on the existing path by default.

## Changes

- Add `synchronizedOutput` utility with DECSET 2026 BSU/ESU frame bracketing.
- Enable only for known supported terminals by default: WezTerm, iTerm2, and kitty.
- Keep tmux / SSH / JetBrains / unknown terminals disabled unless explicitly forced.
- Add env rollback controls:
  - `QWEN_CODE_DISABLE_SYNCHRONIZED_OUTPUT=1`
  - `QWEN_CODE_SYNCHRONIZED_OUTPUT=0`
- Add explicit force controls for manual validation:
  - `QWEN_CODE_FORCE_SYNCHRONIZED_OUTPUT=1`
  - `QWEN_CODE_SYNCHRONIZED_OUTPUT=1`
- Preserve stdout.write return value, callback, Buffer, and encoding behavior.
- Install after `terminalRedrawOptimizer` and restore before it so the monkeypatch stack unwinds cleanly.
- Expose BSU/ESU balance counters for verification.

## Issue Class

Targets the PR4 issue class from the TUI plan:

- Residual frame tearing / intermediate frames after PR1-PR3 application-level fixes.
- Terminal-family-specific flicker where synchronized output is supported.
- Safe fallback and rollback for unsupported terminals.

## Verification

After rebasing on the updated PR2/PR3 stack:

- `git diff --check`
- `cd packages/cli && npx vitest run src/ui/hooks/useGeminiStream.test.tsx src/ui/components/messages/ToolMessage.test.tsx src/ui/utils/terminalRedrawOptimizer.test.ts src/ui/utils/synchronizedOutput.test.ts`
- `cd packages/core && npx vitest run src/utils/terminalSerializer.test.ts src/services/shellExecutionService.test.ts`
- `npm run typecheck --workspace=packages/cli`
- `npm run typecheck --workspace=packages/core`
- `npm run lint --workspace=packages/cli`
- `npm run lint --workspace=packages/core`

## Manual Matrix

Before merge, please manually verify:

- WezTerm
- kitty
- iTerm2
- JetBrains terminal: should not regress by default
- tmux / SSH: should not enable by default
- screen reader mode: should not install protocol wrapper

## Effect Comparison

Before screenshot/video:

> TODO: attach supported-terminal frame tearing before this PR.

After screenshot/video:

> TODO: attach the same scenario after this PR.
