### PR TITLE
fix(core): handle shell line continuations in command splitting

### DIFF
--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -442,6 +442,20 @@ describe('getCommandRoots', () => {
     expect(result).toEqual(['grep']);
   });
 
+  it('should treat escaped newlines in chained commands as line continuations', async () => {
+    const result = getCommandRoots(
+      'cd project && \\\ngit add file.php && \\\ngit commit -m "feat"',
+    );
+    expect(result).toEqual(['cd', 'git', 'git']);
+  });
+
+  it('should treat escaped Windows newlines in chained commands as line continuations', async () => {
+    const result = getCommandRoots(
+      'cd project && \\\r\ngit add file.php && \\\r\ngit commit -m "feat"',
+    );
+    expect(result).toEqual(['cd', 'git', 'git']);
+  });
+
   it('should filter out empty segments from consecutive newlines', async () => {
     const result = getCommandRoots('ls\n\ngrep foo');
     expect(result).toEqual(['ls', 'grep']);

--- a/packages/core/src/utils/shell-utils.test.ts
+++ b/packages/core/src/utils/shell-utils.test.ts
@@ -449,11 +449,9 @@ describe('getCommandRoots', () => {
     expect(result).toEqual(['cd', 'git', 'git']);
   });
 
-  it('should treat escaped Windows newlines in chained commands as line continuations', async () => {
-    const result = getCommandRoots(
-      'cd project && \\\r\ngit add file.php && \\\r\ngit commit -m "feat"',
-    );
-    expect(result).toEqual(['cd', 'git', 'git']);
+  it('should not treat escaped CRLF as a line continuation', async () => {
+    const result = getCommandRoots('echo SAFE \\\r\nrm -rf /');
+    expect(result).toEqual(['echo', 'rm']);
   });
 
   it('should filter out empty segments from consecutive newlines', async () => {

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -224,6 +224,21 @@ export function splitCommands(command: string): string[] {
     const char = command[i];
     const nextChar = command[i + 1];
 
+    if (
+      !inSingleQuotes &&
+      char === '\\' &&
+      nextChar === '\r' &&
+      command[i + 2] === '\n'
+    ) {
+      i += 3;
+      continue;
+    }
+
+    if (!inSingleQuotes && char === '\\' && nextChar === '\n') {
+      i += 2;
+      continue;
+    }
+
     if (char === '\\' && i < command.length - 1) {
       currentCommand += char + command[i + 1];
       i += 2;

--- a/packages/core/src/utils/shell-utils.ts
+++ b/packages/core/src/utils/shell-utils.ts
@@ -224,16 +224,6 @@ export function splitCommands(command: string): string[] {
     const char = command[i];
     const nextChar = command[i + 1];
 
-    if (
-      !inSingleQuotes &&
-      char === '\\' &&
-      nextChar === '\r' &&
-      command[i + 2] === '\n'
-    ) {
-      i += 3;
-      continue;
-    }
-
     if (!inSingleQuotes && char === '\\' && nextChar === '\n') {
       i += 2;
       continue;


### PR DESCRIPTION
Fixes #3158

## Summary
- Treat shell line continuations (`\` followed by LF) as removed while splitting compound shell commands.
- Keep normal LF/CRLF newlines as command separators, including `\` followed by CRLF, so permission parsing still sees the next command.
- Add regression coverage for multiline chained LF continuations and for the escaped-CRLF safety case.

## Root Cause
`splitCommands()` handled generic backslash escapes before newline and operator splitting. For a command like `cd project && \` followed by LF and `git add`, the segment after `&&` still began with a backslash-newline pair, so command root extraction could resolve to an empty command.

The original PR also treated `\` followed by CRLF as a continuation, but bash does not: the backslash escapes only the carriage return and the following newline still separates commands. The follow-up commit removes that CRLF special case.

## Validation
- `npm run test --workspace=@qwen-code/qwen-code-core -- src/utils/shell-utils.test.ts -t "CRLF|line continuation"`
- `npm run test --workspace=@qwen-code/qwen-code-core -- src/utils/shell-utils.test.ts`
- `npm run lint --workspace=@qwen-code/qwen-code-core`
- `npm run typecheck --workspace=@qwen-code/qwen-code-core`
