### PR TITLE
fix(vscode-companion): slash command completion not triggering after message submit

### DIFF
--- a/packages/vscode-ide-companion/src/services/sessionExportService.test.ts
+++ b/packages/vscode-ide-companion/src/services/sessionExportService.test.ts
@@ -128,6 +128,15 @@ describe('sessionExportService', () => {
         'Unsupported /export format. Use /export html, /export md, /export json, or /export jsonl.',
       );
     });
+
+    it('strips leading zero-width space placeholder before parsing', () => {
+      expect(parseExportSlashCommand('\u200B/export html')).toBe('html');
+      expect(parseExportSlashCommand('\u200B/export md')).toBe('md');
+    });
+
+    it('returns null for zero-width space only input', () => {
+      expect(parseExportSlashCommand('\u200B')).toBeNull();
+    });
   });
 
   describe('exportSessionToFile', () => {

--- a/packages/vscode-ide-companion/src/services/sessionExportService.ts
+++ b/packages/vscode-ide-companion/src/services/sessionExportService.ts
@@ -23,6 +23,7 @@ import {
   isSessionExportFormat,
   type SessionExportFormat,
 } from '../utils/exportSlashCommand.js';
+import { stripZeroWidthSpaces } from '@qwen-code/webui';
 
 export { EXPORT_SESSION_FORMATS as SESSION_EXPORT_FORMATS };
 export type { SessionExportFormat } from '../utils/exportSlashCommand.js';
@@ -40,7 +41,7 @@ const EXPORT_CONFIG = {
 export function parseExportSlashCommand(
   text: string,
 ): SessionExportFormat | null {
-  const trimmed = text.replace(/\u200B/g, '').trim();
+  const trimmed = stripZeroWidthSpaces(text).trim();
   if (!trimmed.startsWith('/')) {
     return null;
   }

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
@@ -15,6 +15,7 @@ import {
 } from '../utils/imageHandler.js';
 import { isAuthenticationRequiredError } from '../../utils/authErrors.js';
 import { getErrorMessage } from '../../utils/errorMessage.js';
+import { stripZeroWidthSpaces } from '@qwen-code/webui';
 import {
   exportSessionToFile,
   parseExportSlashCommand,
@@ -392,7 +393,7 @@ export class SessionMessageHandler extends BaseMessageHandler {
     // Guard: do not process empty or whitespace-only messages.
     // This prevents ghost user-message bubbles when slash-command completions
     // or model-selector interactions clear the input but still trigger a submit.
-    const trimmedText = text.replace(/\u200B/g, '').trim();
+    const trimmedText = stripZeroWidthSpaces(text).trim();
     const hasAttachments = (attachments?.length ?? 0) > 0;
     if (!trimmedText && !hasAttachments) {
       console.warn('[SessionMessageHandler] Ignoring empty message');

--- a/packages/vscode-ide-companion/src/webview/hooks/useCompletionTrigger.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useCompletionTrigger.ts
@@ -8,6 +8,7 @@ import type { RefObject } from 'react';
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import type { CompletionItem } from '../../types/completionItemTypes.js';
 import { shouldAllowCompletionQuery } from '../utils/slashCommandUtils.js';
+import { stripZeroWidthSpaces } from '@qwen-code/webui';
 
 interface CompletionTriggerState {
   isOpen: boolean;
@@ -243,7 +244,9 @@ export function useCompletionTrigger(
     };
 
     const handleInput = async () => {
-      const text = inputElement.textContent || '';
+      // Strip zero-width space placeholders before processing, consistent
+      // with InputForm's onInput handler that strips them for React state.
+      const text = stripZeroWidthSpaces(inputElement.textContent || '');
       const selection = window.getSelection();
       if (!selection || selection.rangeCount === 0) {
         console.log('[useCompletionTrigger] No selection or rangeCount === 0');
@@ -295,8 +298,12 @@ export function useCompletionTrigger(
 
       // Find trigger character before cursor
       // Use text length if cursorPosition is 0 but we have text (edge case for first character)
-      const effectiveCursorPosition =
-        cursorPosition === 0 && text.length > 0 ? text.length : cursorPosition;
+      // Clamp to text.length because the DOM cursor offset may exceed the
+      // stripped text length (e.g. after removing a leading zero-width space).
+      const effectiveCursorPosition = Math.min(
+        cursorPosition === 0 && text.length > 0 ? text.length : cursorPosition,
+        text.length,
+      );
 
       const textBeforeCursor = text.substring(0, effectiveCursorPosition);
       const lastAtMatch = textBeforeCursor.lastIndexOf('@');
@@ -320,13 +327,8 @@ export function useCompletionTrigger(
       // Check if trigger is at word boundary (start of line or after space)
       if (triggerPos >= 0 && triggerChar) {
         const charBefore = triggerPos > 0 ? text[triggerPos - 1] : ' ';
-        // Include zero-width space (\u200B) as a valid word boundary because
-        // the input field uses it as a height placeholder after clearing
         const isValidTrigger =
-          charBefore === ' ' ||
-          charBefore === '\n' ||
-          charBefore === '\u200B' ||
-          triggerPos === 0;
+          charBefore === ' ' || charBefore === '\n' || triggerPos === 0;
 
         if (isValidTrigger) {
           const query = text.substring(triggerPos + 1, effectiveCursorPosition);

--- a/packages/vscode-ide-companion/src/webview/hooks/useCompletionTrigger.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useCompletionTrigger.ts
@@ -320,8 +320,13 @@ export function useCompletionTrigger(
       // Check if trigger is at word boundary (start of line or after space)
       if (triggerPos >= 0 && triggerChar) {
         const charBefore = triggerPos > 0 ? text[triggerPos - 1] : ' ';
+        // Include zero-width space (\u200B) as a valid word boundary because
+        // the input field uses it as a height placeholder after clearing
         const isValidTrigger =
-          charBefore === ' ' || charBefore === '\n' || triggerPos === 0;
+          charBefore === ' ' ||
+          charBefore === '\n' ||
+          charBefore === '\u200B' ||
+          triggerPos === 0;
 
         if (isValidTrigger) {
           const query = text.substring(triggerPos + 1, effectiveCursorPosition);

--- a/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.test.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ZERO_WIDTH_SPACE, stripZeroWidthSpaces } from '@qwen-code/webui';
+import { shouldSendMessage } from './useMessageSubmit.js';
+
+describe('ZERO_WIDTH_SPACE and stripZeroWidthSpaces', () => {
+  it('ZERO_WIDTH_SPACE is U+200B', () => {
+    expect(ZERO_WIDTH_SPACE).toBe('\u200B');
+    expect(ZERO_WIDTH_SPACE.length).toBe(1);
+  });
+
+  it('strips a single leading zero-width space', () => {
+    expect(stripZeroWidthSpaces('\u200B')).toBe('');
+  });
+
+  it('strips zero-width space before real text', () => {
+    expect(stripZeroWidthSpaces('\u200B/help')).toBe('/help');
+  });
+
+  it('strips multiple zero-width spaces', () => {
+    expect(stripZeroWidthSpaces('\u200Bhello\u200B world\u200B')).toBe(
+      'hello world',
+    );
+  });
+
+  it('returns unchanged text when no zero-width spaces present', () => {
+    expect(stripZeroWidthSpaces('hello world')).toBe('hello world');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(stripZeroWidthSpaces('')).toBe('');
+  });
+
+  it('preserves other whitespace characters', () => {
+    expect(stripZeroWidthSpaces('\u200B \t\n')).toBe(' \t\n');
+  });
+});
+
+describe('shouldSendMessage', () => {
+  const defaults = {
+    isStreaming: false,
+    isWaitingForResponse: false,
+  };
+
+  it('returns false when streaming', () => {
+    expect(
+      shouldSendMessage({ ...defaults, inputText: 'hello', isStreaming: true }),
+    ).toBe(false);
+  });
+
+  it('returns false when waiting for response', () => {
+    expect(
+      shouldSendMessage({
+        ...defaults,
+        inputText: 'hello',
+        isWaitingForResponse: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true for non-empty text', () => {
+    expect(shouldSendMessage({ ...defaults, inputText: 'hello' })).toBe(true);
+  });
+
+  it('returns false for empty text', () => {
+    expect(shouldSendMessage({ ...defaults, inputText: '' })).toBe(false);
+  });
+
+  it('returns false for whitespace-only text', () => {
+    expect(shouldSendMessage({ ...defaults, inputText: '   ' })).toBe(false);
+  });
+
+  it('returns false when input is only a zero-width space placeholder', () => {
+    expect(shouldSendMessage({ ...defaults, inputText: '\u200B' })).toBe(false);
+  });
+
+  it('returns false when input is zero-width space plus whitespace', () => {
+    expect(shouldSendMessage({ ...defaults, inputText: '\u200B   ' })).toBe(
+      false,
+    );
+  });
+
+  it('returns true when input has real text after zero-width space', () => {
+    expect(shouldSendMessage({ ...defaults, inputText: '\u200Bhello' })).toBe(
+      true,
+    );
+  });
+
+  it('returns true when input has only attachments and no text', () => {
+    expect(
+      shouldSendMessage({
+        ...defaults,
+        inputText: '',
+        attachedImages: [{ data: 'base64data', mediaType: 'image/png' }],
+      }),
+    ).toBe(true);
+  });
+
+  it('returns true when input has only attachments and zero-width space', () => {
+    expect(
+      shouldSendMessage({
+        ...defaults,
+        inputText: '\u200B',
+        attachedImages: [{ data: 'base64data', mediaType: 'image/png' }],
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.test.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.test.ts
@@ -96,7 +96,16 @@ describe('shouldSendMessage', () => {
       shouldSendMessage({
         ...defaults,
         inputText: '',
-        attachedImages: [{ data: 'base64data', mediaType: 'image/png' }],
+        attachedImages: [
+          {
+            id: '1',
+            name: 'test.png',
+            type: 'image/png',
+            size: 100,
+            data: 'base64data',
+            timestamp: Date.now(),
+          },
+        ],
       }),
     ).toBe(true);
   });
@@ -106,7 +115,16 @@ describe('shouldSendMessage', () => {
       shouldSendMessage({
         ...defaults,
         inputText: '\u200B',
-        attachedImages: [{ data: 'base64data', mediaType: 'image/png' }],
+        attachedImages: [
+          {
+            id: '1',
+            name: 'test.png',
+            type: 'image/png',
+            size: 100,
+            data: 'base64data',
+            timestamp: Date.now(),
+          },
+        ],
       }),
     ).toBe(true);
   });

--- a/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.ts
@@ -8,6 +8,7 @@ import { useCallback } from 'react';
 import type { VSCodeAPI } from './useVSCode.js';
 import { getRandomLoadingMessage } from '../../constants/loadingMessages.js';
 import type { ImageAttachment } from './useImage.js';
+import { ZERO_WIDTH_SPACE, stripZeroWidthSpaces } from '@qwen-code/webui';
 
 interface UseMessageSubmitProps {
   vscode: VSCodeAPI;
@@ -49,7 +50,7 @@ export const shouldSendMessage = ({
     return false;
   }
 
-  const hasText = inputText.replace(/\u200B/g, '').trim().length > 0;
+  const hasText = stripZeroWidthSpaces(inputText).trim().length > 0;
   const hasAttachments = (attachedImages?.length ?? 0) > 0;
   return hasText || hasAttachments;
 };
@@ -93,7 +94,7 @@ export const useMessageSubmit = ({
       if (textToSend.trim() === '/account') {
         setInputText('');
         if (inputFieldRef.current) {
-          inputFieldRef.current.textContent = '\u200B';
+          inputFieldRef.current.textContent = ZERO_WIDTH_SPACE;
           inputFieldRef.current.setAttribute('data-empty', 'true');
         }
         vscode.postMessage({ type: 'getAccountInfo', data: {} });
@@ -104,9 +105,7 @@ export const useMessageSubmit = ({
       if (textToSend.trim() === '/login') {
         setInputText('');
         if (inputFieldRef.current) {
-          // Use a zero-width space to maintain the height of the contentEditable element
-          inputFieldRef.current.textContent = '\u200B';
-          // Set the data-empty attribute to show the placeholder
+          inputFieldRef.current.textContent = ZERO_WIDTH_SPACE;
           inputFieldRef.current.setAttribute('data-empty', 'true');
         }
         vscode.postMessage({
@@ -194,9 +193,7 @@ export const useMessageSubmit = ({
 
       setInputText('');
       if (inputFieldRef.current) {
-        // Use a zero-width space to maintain the height of the contentEditable element
-        inputFieldRef.current.textContent = '\u200B';
-        // Set the data-empty attribute to show the placeholder
+        inputFieldRef.current.textContent = ZERO_WIDTH_SPACE;
         inputFieldRef.current.setAttribute('data-empty', 'true');
       }
       fileContext.clearFileReferences();

--- a/packages/webui/src/components/layout/InputForm.tsx
+++ b/packages/webui/src/components/layout/InputForm.tsx
@@ -23,6 +23,7 @@ import { ContextIndicator } from './ContextIndicator.js';
 import type { CompletionItem } from '../../types/completion.js';
 import type { ContextUsage } from './ContextIndicator.js';
 import type { FollowupState } from '../../types/followup.js';
+import { stripZeroWidthSpaces } from '../../utils/inputPlaceholder.js';
 
 /**
  * Edit mode display information
@@ -203,7 +204,7 @@ export const InputForm: FC<InputFormProps> = ({
 }) => {
   const composerDisabled = isStreaming || isWaitingForResponse;
   const hasDraftContent =
-    canSubmit ?? inputText.replace(/\u200B/g, '').trim().length > 0;
+    canSubmit ?? stripZeroWidthSpaces(inputText).trim().length > 0;
   const completionItemsResolved = completionItems ?? [];
   const completionActive =
     completionIsOpen &&
@@ -337,14 +338,14 @@ export const InputForm: FC<InputFormProps> = ({
               // Use a data flag so CSS can show placeholder even if the browser
               // inserts an invisible <br> into contentEditable (so :empty no longer matches)
               data-empty={
-                inputText.replace(/\u200B/g, '').trim().length === 0
+                stripZeroWidthSpaces(inputText).trim().length === 0
                   ? 'true'
                   : 'false'
               }
               onInput={(e) => {
                 const target = e.target as HTMLDivElement;
                 // Filter out zero-width space that we use to maintain height
-                const text = target.textContent?.replace(/\u200B/g, '') || '';
+                const text = stripZeroWidthSpaces(target.textContent ?? '');
                 onInputChange(text);
                 // Dismiss follow-up suggestion when user starts typing
                 if (hasFollowup && !inputText && text) {

--- a/packages/webui/src/index.ts
+++ b/packages/webui/src/index.ts
@@ -260,6 +260,10 @@ export type { CompletionItem, CompletionItemType } from './types/completion';
 // Utils
 export { groupSessionsByDate, getTimeAgo } from './utils/sessionGrouping';
 export type { SessionGroup } from './utils/sessionGrouping';
+export {
+  ZERO_WIDTH_SPACE,
+  stripZeroWidthSpaces,
+} from './utils/inputPlaceholder';
 
 // Adapters - for normalizing different data formats
 export {

--- a/packages/webui/src/utils/inputPlaceholder.ts
+++ b/packages/webui/src/utils/inputPlaceholder.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Zero-width space used as a height placeholder in contentEditable inputs.
+ *
+ * After clearing a contentEditable element (e.g. on message submit), setting
+ * its textContent to this character keeps the element at its normal line height
+ * instead of collapsing to zero height. All downstream consumers must strip
+ * this character before treating the text as real user input.
+ */
+export const ZERO_WIDTH_SPACE = '\u200B';
+
+/**
+ * Strip {@link ZERO_WIDTH_SPACE} placeholders from text.
+ *
+ * @param text - raw text that may contain zero-width spaces
+ * @returns text with all zero-width spaces removed
+ */
+export function stripZeroWidthSpaces(text: string): string {
+  return text.replace(/\u200B/g, '');
+}


### PR DESCRIPTION
## Summary

- 修复非首次对话时输入 `/` 不触发斜杠命令补全的问题
- 将散落在多个文件中的 `\u200B` 魔法字符串提取为 `ZERO_WIDTH_SPACE` 常量和 `stripZeroWidthSpaces()` helper

## Root Cause

发送消息后，输入框通过 `textContent = '\u200B'`（零宽空格）清空以维持 contentEditable 高度。当用户再次输入 `/` 时，DOM 内容为 `'\u200B/'`，`useCompletionTrigger` 的词边界检查不认识零宽空格，导致触发器被拒绝。

## Fix

- 在 `useCompletionTrigger` 的 `handleInput` 中用 `stripZeroWidthSpaces()` 在源头清理文本（与 `InputForm` 的 `onInput` 保持一致），并 clamp 光标位置防止偏移
- 提取 `ZERO_WIDTH_SPACE` 常量和 `stripZeroWidthSpaces()` helper 到 `@qwen-code/webui`，替换 `vscode-ide-companion` 和 `webui` 中所有 `\u200B` 魔法字符串引用

## Test plan

- [x] TypeScript 编译通过（webui + vscode-ide-companion）
- [x] 236 个单元测试全部通过，无回归
- [x] npm run build 通过
- [x] npm run bundle 通过
- [x] 在 VSCode 中手动验证：发送消息后输入 `/` 能正常触发补全

Closes #3592