### PR TITLE
fix(review): respect /language output setting for local reviews

### DIFF
--- a/packages/core/src/skills/bundled/review/SKILL.md
+++ b/packages/core/src/skills/bundled/review/SKILL.md
@@ -17,7 +17,7 @@ You are an expert code reviewer. Your job is to review code changes and provide 
 
 **Critical rules (most commonly violated — read these first):**
 
-1. **Match the language of the PR.** If the PR is in English, ALL your output (terminal + PR comments) MUST be in English. If in Chinese, use Chinese. Do NOT switch languages.
+1. **Match the language of the PR.** If the PR is in English, ALL your output (terminal + PR comments) MUST be in English. If in Chinese, use Chinese. Do NOT switch languages. For **local reviews** (no PR), if the system prompt includes an output language preference, use that language; otherwise follow the user's input language.
 2. **Step 9: use Create Review API** with `comments` array for inline comments. Do NOT use `gh api .../pulls/.../comments` to post individual comments. See Step 9 for the JSON format.
 
 **Design philosophy: Silence is better than noise.** Every comment you make should be worth the reader's time. If you're unsure whether something is a problem, DO NOT MENTION IT. Low-quality feedback causes "cry wolf" fatigue — developers stop reading all AI comments and miss real issues.
@@ -528,4 +528,4 @@ These criteria apply to both Step 4 (review agents) and Step 5 (verification age
 - Flag any exposed secrets, credentials, API keys, or tokens in the diff as **Critical**.
 - Silence is better than noise. If you have nothing important to say, say nothing.
 - **Do NOT use `#N` notation** (e.g., `#1`, `#2`) in PR comments or summaries — GitHub auto-links these to issues/PRs. Use `(1)`, `[1]`, or descriptive references instead.
-- **Match the language of the PR.** Write review comments, findings, and summaries in the same language as the PR title/description/code comments. If the PR is in English, write in English. If in Chinese, write in Chinese. Do NOT switch languages.
+- **Match the language of the PR.** Write review comments, findings, and summaries in the same language as the PR title/description/code comments. If the PR is in English, write in English. If in Chinese, write in Chinese. Do NOT switch languages. For **local reviews** (no PR), respect the user's output language preference if set; otherwise follow the user's input language.


### PR DESCRIPTION
## TLDR

The `/review` skill's language rule "match the language of the PR" now falls back to the user's `/language output` preference during local reviews (no PR target). PR review behavior is unchanged.

## Dive Deeper

The `/review` skill enforces a language rule: "Match the language of the PR." This works well for PR reviews — findings may be published as inline comments via `--comment`, so matching the PR's language ensures readability for all collaborators.

However, during **local reviews** (`/review` with no arguments, reviewing uncommitted changes), there is no PR to match. The skill instructions are entirely in English, so the LLM defaults to English output — ignoring any `/language output` preference the user has configured.

This change adds a fallback clause to both the critical rules (line 20) and guidelines (line 531):
- If the system prompt includes an output language preference (set via `/language output`), use that language for local review output
- Otherwise, follow the user's input language

## Reviewer Test Plan

- Set `/language output 中文`, run `/review` (no args, with local changes) → terminal output should be in Chinese
- Set `/language output ru`, run `/review` (no args) → terminal output should be in Russian
- Run `/review 123` (PR review) → behavior unchanged, still matches PR language

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ❓  | ❓  | ❓  |

## Linked issues / bugs

Closes #3594