### PR TITLE
fix(vscode-companion): fill slash commands into input on Enter instead of auto-submitting

### DIFF
--- a/packages/channels/base/src/AcpBridge.ts
+++ b/packages/channels/base/src/AcpBridge.ts
@@ -23,6 +23,7 @@ export interface AcpBridgeOptions {
 export interface AvailableCommand {
   name: string;
   description: string;
+  input?: { hint: string } | null;
 }
 
 export interface ToolCallEvent {

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -241,7 +241,36 @@ describe('Session', () => {
             {
               name: 'init',
               description: 'Initialize project context',
-              input: null,
+              input: { hint: '[path]' },
+            },
+          ],
+        },
+      });
+    });
+
+    it('sets input for built-in commands with subCommands', async () => {
+      getAvailableCommandsSpy.mockResolvedValueOnce([
+        {
+          name: 'export',
+          description: 'Export conversation history',
+          kind: 'built-in',
+          subCommands: [
+            { name: 'md', description: 'Export as markdown', kind: 'built-in' },
+          ],
+        },
+      ]);
+
+      await session.sendAvailableCommandsUpdate();
+
+      expect(mockClient.sessionUpdate).toHaveBeenCalledWith({
+        sessionId: 'test-session-id',
+        update: {
+          sessionUpdate: 'available_commands_update',
+          availableCommands: [
+            {
+              name: 'export',
+              description: 'Export conversation history',
+              input: { hint: '' },
             },
           ],
         },

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -221,6 +221,7 @@ describe('Session', () => {
         {
           name: 'init',
           description: 'Initialize project context',
+          kind: 'built-in',
         },
       ]);
 
@@ -251,6 +252,7 @@ describe('Session', () => {
         {
           name: 'init',
           description: 'Initialize project context',
+          kind: 'built-in',
         },
       ]);
       mockConfig.getSkillManager = vi.fn().mockReturnValue({

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -81,6 +81,7 @@ import {
   type NonInteractiveSlashCommandResult,
 } from '../../nonInteractiveCliCommands.js';
 import { isSlashCommand } from '../../ui/utils/commandUtils.js';
+import { CommandKind } from '../../ui/commands/types.js';
 import { parseAcpModelOption } from '../../utils/acpModelUtils.js';
 import { classifyApiError } from '../../ui/hooks/useGeminiStream.js';
 
@@ -976,12 +977,19 @@ export class Session implements SessionContext {
         'acp',
       );
 
-      // Convert SlashCommand[] to AvailableCommand[] format for ACP protocol
+      // Convert SlashCommand[] to AvailableCommand[] format for ACP protocol.
+      // Commands that accept arguments (skills, commands with completion) get
+      // input: { hint } so the client can let users type arguments before
+      // submitting.  Built-in commands without completion get input: null so the
+      // client auto-submits them immediately on selection.
       const availableCommands: AvailableCommand[] = slashCommands.map(
         (cmd) => ({
           name: cmd.name,
           description: cmd.description,
-          input: null,
+          input:
+            cmd.kind !== CommandKind.BUILT_IN || cmd.completion != null
+              ? { hint: cmd.argumentHint ?? '' }
+              : null,
         }),
       );
 

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -978,20 +978,27 @@ export class Session implements SessionContext {
       );
 
       // Convert SlashCommand[] to AvailableCommand[] format for ACP protocol.
-      // Commands that accept arguments (skills, commands with completion) get
-      // input: { hint } so the client can let users type arguments before
-      // submitting.  Built-in commands without completion get input: null so the
-      // client auto-submits them immediately on selection.
-      const availableCommands: AvailableCommand[] = slashCommands.map(
-        (cmd) => ({
+      // Commands that accept arguments get input: { hint } so the client can
+      // let users type arguments before submitting.  Commands with no argument
+      // support get input: null so the client auto-submits them on selection.
+      //
+      // A command is considered to accept arguments when any of:
+      //   - it is not a BUILT_IN command (skills, file commands, etc.)
+      //   - it has a completion function
+      //   - it declares an argumentHint
+      //   - it has subCommands
+      const availableCommands: AvailableCommand[] = slashCommands.map((cmd) => {
+        const acceptsInput =
+          cmd.kind !== CommandKind.BUILT_IN ||
+          cmd.completion != null ||
+          cmd.argumentHint != null ||
+          (cmd.subCommands != null && cmd.subCommands.length > 0);
+        return {
           name: cmd.name,
           description: cmd.description,
-          input:
-            cmd.kind !== CommandKind.BUILT_IN || cmd.completion != null
-              ? { hint: cmd.argumentHint ?? '' }
-              : null,
-        }),
-      );
+          input: acceptsInput ? { hint: cmd.argumentHint ?? '' } : null,
+        };
+      });
 
       let availableSkills: string[] | undefined;
       try {

--- a/packages/cli/src/ui/commands/bugCommand.ts
+++ b/packages/cli/src/ui/commands/bugCommand.ts
@@ -21,6 +21,7 @@ export const bugCommand: SlashCommand = {
     return t('submit a bug report');
   },
   kind: CommandKind.BUILT_IN,
+  argumentHint: '<description>',
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
   action: async (context: CommandContext, args?: string): Promise<void> => {
     const bugDescription = (args || '').trim();

--- a/packages/vscode-ide-companion/src/webview/App.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.test.tsx
@@ -34,6 +34,20 @@ const secondarySkillItem: CompletionItem = {
   value: 'skills code-review',
 };
 
+const commitCommandItem: CompletionItem = {
+  id: 'commit',
+  label: '/commit',
+  type: 'command',
+  value: 'commit',
+};
+
+const clearCommandItem: CompletionItem = {
+  id: 'clear',
+  label: '/clear',
+  type: 'command',
+  value: 'clear',
+};
+
 vi.mock('./hooks/useVSCode.js', () => ({
   useVSCode: () => ({
     postMessage: mockPostMessage,
@@ -101,7 +115,11 @@ vi.mock('./hooks/useWebViewMessages.js', async () => {
     }: {
       setIsAuthenticated: (value: boolean) => void;
       setAvailableCommands: (
-        value: Array<{ name: string; description?: string }>,
+        value: Array<{
+          name: string;
+          description: string;
+          input?: { hint: string } | null;
+        }>,
       ) => void;
       setAvailableSkills: (value: string[]) => void;
     }) => {
@@ -114,7 +132,21 @@ vi.mock('./hooks/useWebViewMessages.js', async () => {
         initializedRef.current = true;
         setIsAuthenticated(true);
         setAvailableCommands([
-          { name: 'skills', description: 'List available skills' },
+          {
+            name: 'skills',
+            description: 'List available skills',
+            input: null,
+          },
+          {
+            name: 'commit',
+            description: 'Commit current changes',
+            input: { hint: '' },
+          },
+          {
+            name: 'clear',
+            description: 'Clear the chat',
+            input: null,
+          },
         ]);
         setAvailableSkills(['code-review']);
       }, [setAvailableCommands, setAvailableSkills, setIsAuthenticated]);
@@ -143,7 +175,12 @@ vi.mock('./hooks/useCompletionTrigger.js', () => ({
     isOpen: true,
     triggerChar: '/',
     query: 'skills ',
-    items: [slashSkillsItem, secondarySkillItem],
+    items: [
+      slashSkillsItem,
+      secondarySkillItem,
+      commitCommandItem,
+      clearCommandItem,
+    ],
     closeCompletion: mockCloseCompletion,
     openCompletion: mockOpenCompletion,
     refreshCompletion: vi.fn(),
@@ -216,6 +253,15 @@ vi.mock('./components/layout/InputForm.js', () => ({
       </button>
       <button onClick={() => onCompletionFill?.(secondarySkillItem)}>
         select-skill-tab
+      </button>
+      <button onClick={() => onCompletionSelect(commitCommandItem)}>
+        select-commit-enter
+      </button>
+      <button onClick={() => onCompletionSelect(clearCommandItem)}>
+        select-clear-enter
+      </button>
+      <button onClick={() => onCompletionFill?.(clearCommandItem)}>
+        select-clear-tab
       </button>
     </div>
   ),
@@ -409,5 +455,51 @@ describe('App /skills secondary picker', () => {
     expect(getRenderedInputText(rendered.container)).toBe(
       '/skills code-review ',
     );
+  });
+
+  it('fills slash commands that declare input when pressing Enter', async () => {
+    const rendered = renderApp();
+    root = rendered.root;
+    container = rendered.container;
+
+    await act(async () => {});
+    setInputSelection(rendered.container, '/');
+
+    clickButton(rendered.container, 'select-commit-enter');
+
+    expect(mockPostMessage).not.toHaveBeenCalled();
+    expect(getRenderedInputText(rendered.container)).toBe('/commit ');
+    expect(mockCloseCompletion).toHaveBeenCalled();
+  });
+
+  it('auto-submits slash commands without input when pressing Enter', async () => {
+    const rendered = renderApp();
+    root = rendered.root;
+    container = rendered.container;
+
+    await act(async () => {});
+    setInputSelection(rendered.container, '/');
+
+    clickButton(rendered.container, 'select-clear-enter');
+
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      type: 'sendMessage',
+      data: { text: '/clear' },
+    });
+    expect(mockCloseCompletion).toHaveBeenCalled();
+  });
+
+  it('fills slash commands without input when pressing Tab', async () => {
+    const rendered = renderApp();
+    root = rendered.root;
+    container = rendered.container;
+
+    await act(async () => {});
+    setInputSelection(rendered.container, '/');
+
+    clickButton(rendered.container, 'select-clear-tab');
+
+    expect(mockPostMessage).not.toHaveBeenCalled();
+    expect(getRenderedInputText(rendered.container)).toBe('/clear ');
   });
 });

--- a/packages/vscode-ide-companion/src/webview/App.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.test.tsx
@@ -221,6 +221,7 @@ vi.mock('@qwen-code/webui', () => ({
   EmptyState: () => null,
   ChatHeader: () => null,
   SessionSelector: () => null,
+  stripZeroWidthSpaces: (text: string) => text.replace(/\u200B/g, ''),
 }));
 
 vi.mock('./components/layout/InputForm.js', () => ({

--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -796,32 +796,29 @@ export const App: React.FC = () => {
           }
         };
 
-        if (itemId === 'auth') {
+        // Client-side commands that trigger extension actions directly
+        // instead of being sent to the agent as messages.
+        const clientActions: Record<string, () => void> = {
+          auth: () => vscode.postMessage({ type: 'auth', data: {} }),
+          account: () =>
+            vscode.postMessage({ type: 'getAccountInfo', data: {} }),
+          model: () => setShowModelSelector(true),
+        };
+
+        const clientAction = clientActions[itemId];
+        if (clientAction) {
           clearTriggerText();
-          vscode.postMessage({ type: 'auth', data: {} });
+          clientAction();
           closeCompletion();
           return;
         }
 
-        if (itemId === 'account') {
-          clearTriggerText();
-          vscode.postMessage({ type: 'getAccountInfo', data: {} });
-          closeCompletion();
-          return;
-        }
-
-        if (itemId === 'model') {
-          clearTriggerText();
-          setShowModelSelector(true);
-          closeCompletion();
-          return;
-        }
-
-        // Handle server-provided slash commands by sending them as messages.
-        // Skip when fillOnly (Tab) — let the generic insertion path fill the
-        // command text so the user can keep typing arguments.
-        // Special case: /skills always uses fill behavior (Enter = Tab) to
-        // allow the secondary skill picker to appear.
+        // For server-provided slash commands, decide based on the `input`
+        // field: commands without input (input == null) auto-submit
+        // immediately; commands that accept input fall through to the generic
+        // insertion path so users can type arguments before submitting.
+        // Special case: /skills always uses fill behavior to allow the
+        // secondary skill picker to appear.
         const serverCmd = availableCommands.find((c) => c.name === itemId);
         const isSkillsCmd = shouldOpenSkillsSecondaryPicker(
           item,
@@ -829,19 +826,19 @@ export const App: React.FC = () => {
         );
         if (
           serverCmd &&
-          !fillOnly &&
           !isSkillsCmd &&
           !isExpandableSlashCommand(serverCmd.name)
         ) {
-          // Clear the trigger text since we're sending the command
-          clearTriggerText();
-          // Send the slash command as a user message
-          vscode.postMessage({
-            type: 'sendMessage',
-            data: { text: `/${serverCmd.name}` },
-          });
-          closeCompletion();
-          return;
+          if (!serverCmd.input && !fillOnly) {
+            clearTriggerText();
+            vscode.postMessage({
+              type: 'sendMessage',
+              data: { text: `/${serverCmd.name}` },
+            });
+            closeCompletion();
+            return;
+          }
+          // Command accepts input — fall through to fill the input box.
         }
 
         // Handle secondary skill selection — send `/skills <name>` with

--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -23,6 +23,7 @@ import {
   useMessageSubmit,
 } from './hooks/useMessageSubmit.js';
 import type { PermissionOption, PermissionToolCall } from '@qwen-code/webui';
+import { stripZeroWidthSpaces } from '@qwen-code/webui';
 import type { TextMessage } from './hooks/message/useMessageHandling.js';
 import type { ToolCallData } from './components/messages/toolcalls/ToolCall.js';
 import { ToolCall } from './components/messages/toolcalls/ToolCall.js';
@@ -872,12 +873,16 @@ export const App: React.FC = () => {
         return;
       }
 
-      // Current text and cursor
-      const text = inputElement.textContent || '';
+      // Current text and cursor — strip U+200B height placeholder so it
+      // does not contaminate the inserted completion text.
+      const rawText = inputElement.textContent || '';
+      const text = stripZeroWidthSpaces(rawText);
       const range = selection.getRangeAt(0);
 
-      // Compute total text offset for contentEditable
-      let cursorPos = text.length;
+      // Compute total text offset for contentEditable.  The DOM offsets
+      // are based on rawText (which may contain U+200B), so we compute the
+      // raw cursor position first and then adjust for stripped characters.
+      let rawCursorPos = rawText.length;
       if (range.startContainer === inputElement) {
         const childIndex = range.startOffset;
         let offset = 0;
@@ -888,7 +893,7 @@ export const App: React.FC = () => {
         ) {
           offset += inputElement.childNodes[i].textContent?.length || 0;
         }
-        cursorPos = offset || text.length;
+        rawCursorPos = offset || rawText.length;
       } else if (range.startContainer.nodeType === Node.TEXT_NODE) {
         const walker = document.createTreeWalker(
           inputElement,
@@ -907,8 +912,14 @@ export const App: React.FC = () => {
           offset += node.textContent?.length || 0;
           node = walker.nextNode();
         }
-        cursorPos = found ? offset : text.length;
+        rawCursorPos = found ? offset : rawText.length;
       }
+      // Adjust cursor to match the stripped text by subtracting
+      // zero-width characters that appeared before the cursor.
+      const zeroWidthBeforeCursor = (
+        rawText.substring(0, rawCursorPos).match(/\u200B/g) || []
+      ).length;
+      const cursorPos = Math.max(0, rawCursorPos - zeroWidthBeforeCursor);
 
       // Replace from trigger to cursor with selected value
       const textBeforeCursor = text.substring(0, cursorPos);

--- a/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useMessageSubmit.ts
@@ -101,8 +101,11 @@ export const useMessageSubmit = ({
         return;
       }
 
-      // Handle /login command - show inline loading while extension authenticates
-      if (textToSend.trim() === '/login') {
+      // Handle /auth (and its legacy alias /login) — trigger interactive
+      // auth flow directly in the extension instead of sending the command
+      // to the agent.
+      const trimmedInput = textToSend.trim();
+      if (trimmedInput === '/auth' || trimmedInput === '/login') {
         setInputText('');
         if (inputFieldRef.current) {
           inputFieldRef.current.textContent = ZERO_WIDTH_SPACE;
@@ -112,7 +115,6 @@ export const useMessageSubmit = ({
           type: 'auth',
           data: {},
         });
-        // Show a friendly loading message in the chat while authenticating
         try {
           messageHandling.setWaitingForResponse('Authenticating Qwen Code...');
         } catch (_err) {

--- a/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.test.tsx
@@ -248,6 +248,24 @@ describe('useWebViewMessages', () => {
     expect(rendered.clearWaitingForResponse).toHaveBeenCalled();
   });
 
+  it('clears waiting state when authCancelled is received', () => {
+    const rendered = renderHookHarness();
+    root = rendered.root;
+    container = rendered.container;
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: {
+            type: 'authCancelled',
+          },
+        }),
+      );
+    });
+
+    expect(rendered.clearWaitingForResponse).toHaveBeenCalled();
+  });
+
   it('stores the latest insight report path when the ready event arrives', () => {
     const rendered = renderHookHarness();
     root = rendered.root;

--- a/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
+++ b/packages/vscode-ide-companion/src/webview/hooks/useWebViewMessages.ts
@@ -521,6 +521,13 @@ export const useWebViewMessages = ({
           break;
         }
 
+        case 'authCancelled': {
+          // User dismissed the auth picker — clear loading state so the
+          // input is not left disabled.
+          handlers.messageHandling.clearWaitingForResponse();
+          break;
+        }
+
         case 'authState': {
           const state = (
             message?.data as { authenticated?: boolean | null } | undefined

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
@@ -1109,7 +1109,7 @@ export class WebViewProvider {
 
   /**
    * Initialize agent connection and session
-   * Can be called from show() or via /login command
+   * Can be called from show() or via /auth command
    */
   async initializeAgentConnection(options?: {
     autoAuthenticate?: boolean;


### PR DESCRIPTION
## TLDR

- What changed: Slash commands that accept arguments (skills, custom commands) now fill into the input box when selected via Enter from the completion menu, instead of being sent immediately. No-arg built-in commands (`/clear`, `/doctor`, etc.) still auto-submit.
- Why it changed: The previous behavior made custom commands with arguments unusable from the completion menu — the command was sent before users could type anything.
- Reviewer focus: The `input` field propagation from `Session.ts` → webview `App.tsx`, and the `clientActions` refactor.

## Screenshots / Video Demo

> TODO: Add before/after recording showing completion menu behavior for skill commands vs built-in commands.

## Dive Deeper

**Protocol-level change.** `Session.ts` now populates the ACP `AvailableCommand.input` field based on the command definition: commands with `kind !== BUILT_IN` or a `completion` function get `input: { hint }`, signaling they accept arguments. Built-in commands without completion get `input: null`.

**Webview selection logic.** `App.tsx` uses the `input` field to decide behavior on Enter:
- `input` is falsy + Enter → auto-submit (no-arg commands like `/clear`)
- `input` is truthy + Enter → fill into input box (skills, commands with completion)
- Tab → always fills, unchanged
- Client-side commands (`/auth`, `/account`, `/model`) → immediate action via `clientActions` map, unchanged

**Also fixed:**
- `useMessageSubmit.ts`: `/login` → `/auth` + `/login` (legacy alias preserved)
- `useWebViewMessages.ts`: added `authCancelled` handler to clear waiting state when auth picker is dismissed
- `WebViewProvider.ts`: stale `/login` comment updated to `/auth`

## Reviewer Test Plan

1. `npm run build && npm run bundle`
2. Open the VSCode Companion extension
3. Type `/` to open the completion menu
4. **Enter on a no-arg command** (e.g. `/clear`): should execute immediately
5. **Enter on a skill** (e.g. `/commit`): should fill `/commit ` into input, cursor at end, user can type args then press Enter
6. **Tab on any command**: should always fill without submitting
7. **Select `/model`**: should open model selector immediately
8. **Select `/export`**: should fill and expand subcommand completion
9. **Type `/auth` manually and press Enter**: should trigger auth flow
10. **Cancel auth picker after triggering**: input should not be stuck in loading state

**Unit tests:**
```bash
npx vitest run packages/vscode-ide-companion/src/webview/
# 21 files, 106 tests — all pass
```

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | -   | -   |
| Seatbelt | ⚠️  | -   | -   |

Testing matrix notes:
- Build + unit tests verified on macOS. Manual VSCode interaction testing pending.

## Linked issues / bugs

Resolves #1990