### PR TITLE
fix(core): match DeepSeek provider by model name for sglang/vllm (#3613)

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/deepseek.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/deepseek.test.ts
@@ -49,15 +49,40 @@ describe('DeepSeekOpenAICompatibleProvider', () => {
       expect(result).toBe(true);
     });
 
-    it('returns false for non deepseek baseUrl', () => {
+    it('returns false when neither baseUrl nor model match deepseek', () => {
       const config = {
         ...mockContentGeneratorConfig,
         baseUrl: 'https://api.example.com/v1',
+        model: 'gpt-4o',
       } as ContentGeneratorConfig;
 
       const result =
         DeepSeekOpenAICompatibleProvider.isDeepSeekProvider(config);
       expect(result).toBe(false);
+    });
+
+    it('returns true for deepseek model on a non-deepseek baseUrl (e.g. sglang) — issue #3613', () => {
+      const config = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://my-sglang.example.com:8000/v1',
+        model: 'deepseek-v4-pro',
+      } as ContentGeneratorConfig;
+
+      const result =
+        DeepSeekOpenAICompatibleProvider.isDeepSeekProvider(config);
+      expect(result).toBe(true);
+    });
+
+    it('matches model name case-insensitively', () => {
+      const config = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://my-vllm.example.com/v1',
+        model: 'DeepSeek-R1',
+      } as ContentGeneratorConfig;
+
+      const result =
+        DeepSeekOpenAICompatibleProvider.isDeepSeekProvider(config);
+      expect(result).toBe(true);
     });
   });
 

--- a/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
@@ -22,8 +22,17 @@ export class DeepSeekOpenAICompatibleProvider extends DefaultOpenAICompatiblePro
     contentGeneratorConfig: ContentGeneratorConfig,
   ): boolean {
     const baseUrl = contentGeneratorConfig.baseUrl ?? '';
+    if (baseUrl.toLowerCase().includes('api.deepseek.com')) {
+      return true;
+    }
 
-    return baseUrl.toLowerCase().includes('api.deepseek.com');
+    // DeepSeek models served behind any OpenAI-compatible endpoint (sglang,
+    // vllm, ollama, etc.) share the same content-format constraint that the
+    // official api.deepseek.com endpoint has. Detect them by model name so
+    // the buildRequest flattening below kicks in.
+    // See https://github.com/QwenLM/qwen-code/issues/3613
+    const model = contentGeneratorConfig.model ?? '';
+    return model.toLowerCase().includes('deepseek');
   }
 
   /**


### PR DESCRIPTION
## Summary

Some OpenAI-compatible servers (notably **sglang's deepseek-v4 jinja template**) crash on the array form of message content even when it carries a single text block — see #3613, with `TypeError: sequence item 0: expected str instance, list found` at `encoding_dsv4.py:336`.

`DeepSeekOpenAICompatibleProvider.buildRequest` already flattens content arrays into joined strings, but `isDeepSeekProvider` only matched on the official `api.deepseek.com` baseUrl. DeepSeek models served behind sglang / vllm / ollama / etc. bypass the workaround and hit the bug.

Extend the matcher to also detect by **model name** (case-insensitive substring `deepseek`), so any OpenAI-compatible endpoint serving a DeepSeek model picks up the existing flattening.

Fixes #3613

## Changes

- `provider/deepseek.ts:21-35`: `isDeepSeekProvider` now returns true if either baseUrl includes `api.deepseek.com` OR model name contains `deepseek`.
- `provider/deepseek.test.ts`: 1 existing case adjusted (so the spread default model `deepseek-chat` doesn't accidentally satisfy the new rule when verifying baseUrl-negative); 2 new cases for the sglang scenario and case-insensitive matching.

## Test plan

- [x] `provider/deepseek.test.ts`: 9/9 pass
- [x] `packages/core`: 6070/6072 pass (2 skipped, unrelated)
- [x] `tsc --noEmit`: clean
- [x] `eslint`: clean
- [ ] Manual verification against a sglang `--tool-call-parser deepseekv4` server (issue reporter)