### PR TITLE
fix(test): update rewind E2E Test 1 assertion after isRealUserTurn fix

### DIFF
--- a/scripts/test-rewind-e2e.sh
+++ b/scripts/test-rewind-e2e.sh
@@ -299,13 +299,12 @@ test_rewind_command() {
   send_keys y
   wait_for "Conversation rewound" || return 1
 
-  # After rewind: the input should be pre-populated with the selected turn's
-  # text ("say exactly GAMMA3..."). The GAMMA3 *response* turn should be gone
-  # from the conversation, but the text appears in the input bar — which is
-  # the correct pre-population behavior.
-  # Verify pre-population: the input bar should contain GAMMA3 text
-  assert_screen "say exactly GAMMA3" || return 1
-  # Verify the earlier turns (ALPHA1, BETA2) are still in conversation
+  # After rewind: pressing Up once from the initial selection (GAMMA3, the last
+  # real user turn) lands on BETA2. Rewind targets BETA2, so its text gets
+  # pre-populated into the input bar. Slash commands like /rewind are excluded
+  # from the turn list by isRealUserTurn().
+  assert_screen "say exactly BETA2" || return 1
+  # Verify the earlier turn (ALPHA1) is still in conversation
   assert_scrollback "ALPHA1" || return 1
 }
 


### PR DESCRIPTION
## Summary
- Fix stale assertion in `scripts/test-rewind-e2e.sh` Test 1 that was passing only because of the off-by-one bug that `isRealUserTurn()` later fixed
- After the fix, `/rewind` is excluded from the user turn list, so pressing Up once from the initial selection (GAMMA3) lands on BETA2 — update the assertion from `GAMMA3` to `BETA2`

Ref: https://github.com/QwenLM/qwen-code/pull/3441#issuecomment-4319798259

## Test plan
- [x] Run `scripts/test-rewind-e2e.sh` and verify all 5 tests pass

### E2E test output
```
=== Rewind Feature E2E Tests (tmux) ===

[PASS] Test 1: /rewind command flow
[PASS] Test 2: Double-ESC opens selector
[PASS] Test 3: ESC during streaming cancels (no rewind)
[PASS] Test 4: /rewind with no prior conversation
[PASS] Test 5: After rewind, model ignores removed turns

=== Results ===
Passed: 5
Failed: 0
All 5 tests passed.
```

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)