### PR TITLE
feat(core): --insecure flag and QWEN_TLS_INSECURE env var (#3535)

### DIFF
--- a/docs/users/support/troubleshooting.md
+++ b/docs/users/support/troubleshooting.md
@@ -27,6 +27,10 @@ This guide provides solutions to common issues and debugging tips, including top
     - If you are behind a proxy, set it via `qwen --proxy <url>` (or the `proxy` setting in `settings.json`).
     - If your network uses a corporate TLS inspection CA, set `NODE_EXTRA_CA_CERTS` as described above.
 
+- **Self-signed model endpoint: `[API Error: Connection error. (cause: fetch failed)]`**
+  - **Cause:** A self-signed or otherwise untrusted TLS certificate on the model server (common in dev / lab / homelab setups). Setting `NODE_TLS_REJECT_UNAUTHORIZED=0` alone does **not** fix this for `fetch`-based code paths because Node's bundled HTTP client (`undici`) ignores that env var by design.
+  - **Solution:** Pass `--insecure` on the command line, set `QWEN_TLS_INSECURE=1`, or set `NODE_TLS_REJECT_UNAUTHORIZED=0` (Qwen Code now also honors the latter for parity with Claude Code / Node's legacy http stack). All three configure undici with `rejectUnauthorized: false` for outbound model API and MCP traffic. Only use this on networks you trust — it disables certificate verification for the entire process.
+
 - **Issue: Unable to display UI after authentication failure**
   - **Cause:** If authentication fails after selecting an authentication type, the `security.auth.selectedType` setting may be persisted in `settings.json`. On restart, the CLI may get stuck trying to authenticate with the failed auth type and fail to display the UI.
   - **Solution:** Clear the `security.auth.selectedType` configuration item in your `settings.json` file:

--- a/packages/cli/src/commands/auth/handler.ts
+++ b/packages/cli/src/commands/auth/handler.ts
@@ -90,6 +90,7 @@ export async function handleQwenAuth(
       openaiBaseUrl: undefined,
       openaiLoggingDir: undefined,
       proxy: undefined,
+      insecure: undefined,
       includeDirectories: undefined,
       screenReader: undefined,
       inputFormat: undefined,

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -878,6 +878,22 @@ describe('loadCliConfig', () => {
       const config = await loadCliConfig({}, argv);
       expect(config.getInsecure()).toBe(true);
     });
+
+    it('--no-insecure forces verification on even with QWEN_TLS_INSECURE=1', async () => {
+      vi.stubEnv('QWEN_TLS_INSECURE', '1');
+      process.argv = ['node', 'script.js', '--no-insecure'];
+      const argv = await parseArguments();
+      const config = await loadCliConfig({}, argv);
+      expect(config.getInsecure()).toBe(false);
+    });
+
+    it('--no-insecure overrides NODE_TLS_REJECT_UNAUTHORIZED=0', async () => {
+      vi.stubEnv('NODE_TLS_REJECT_UNAUTHORIZED', '0');
+      process.argv = ['node', 'script.js', '--no-insecure'];
+      const argv = await parseArguments();
+      const config = await loadCliConfig({}, argv);
+      expect(config.getInsecure()).toBe(false);
+    });
   });
 });
 

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -800,6 +800,85 @@ describe('loadCliConfig', () => {
       expect(config.getProxy()).toBe('http://localhost:7890');
     });
   });
+
+  describe('Insecure / TLS-skip configuration (#3535)', () => {
+    const insecureEnvVars = [
+      'QWEN_TLS_INSECURE',
+      'NODE_TLS_REJECT_UNAUTHORIZED',
+    ];
+    const original: { [key: string]: string | undefined } = {};
+
+    beforeEach(() => {
+      for (const key of insecureEnvVars) {
+        original[key] = process.env[key];
+        delete process.env[key];
+      }
+    });
+
+    afterEach(() => {
+      for (const key of insecureEnvVars) {
+        if (original[key] !== undefined) {
+          process.env[key] = original[key];
+        } else {
+          delete process.env[key];
+        }
+      }
+    });
+
+    it('defaults to false', async () => {
+      process.argv = ['node', 'script.js'];
+      const argv = await parseArguments();
+      const config = await loadCliConfig({}, argv);
+      expect(config.getInsecure()).toBe(false);
+    });
+
+    it('honors --insecure flag', async () => {
+      process.argv = ['node', 'script.js', '--insecure'];
+      const argv = await parseArguments();
+      const config = await loadCliConfig({}, argv);
+      expect(config.getInsecure()).toBe(true);
+    });
+
+    it('honors QWEN_TLS_INSECURE=1', async () => {
+      vi.stubEnv('QWEN_TLS_INSECURE', '1');
+      process.argv = ['node', 'script.js'];
+      const argv = await parseArguments();
+      const config = await loadCliConfig({}, argv);
+      expect(config.getInsecure()).toBe(true);
+    });
+
+    it('honors NODE_TLS_REJECT_UNAUTHORIZED=0 (matches Claude Code/Node convention)', async () => {
+      vi.stubEnv('NODE_TLS_REJECT_UNAUTHORIZED', '0');
+      process.argv = ['node', 'script.js'];
+      const argv = await parseArguments();
+      const config = await loadCliConfig({}, argv);
+      expect(config.getInsecure()).toBe(true);
+    });
+
+    it('ignores QWEN_TLS_INSECURE=0 / arbitrary values', async () => {
+      vi.stubEnv('QWEN_TLS_INSECURE', '0');
+      process.argv = ['node', 'script.js'];
+      const argv = await parseArguments();
+      const config = await loadCliConfig({}, argv);
+      expect(config.getInsecure()).toBe(false);
+    });
+
+    it('ignores NODE_TLS_REJECT_UNAUTHORIZED=1', async () => {
+      vi.stubEnv('NODE_TLS_REJECT_UNAUTHORIZED', '1');
+      process.argv = ['node', 'script.js'];
+      const argv = await parseArguments();
+      const config = await loadCliConfig({}, argv);
+      expect(config.getInsecure()).toBe(false);
+    });
+
+    it('--insecure overrides explicit env=0', async () => {
+      vi.stubEnv('QWEN_TLS_INSECURE', '0');
+      process.argv = ['node', 'script.js', '--insecure'];
+      const argv = await parseArguments();
+      const config = await loadCliConfig({}, argv);
+      expect(config.getInsecure()).toBe(true);
+    });
+  });
 });
 
 describe('loadCliConfig telemetry', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -136,6 +136,7 @@ export interface CliArgs {
   openaiBaseUrl: string | undefined;
   openaiLoggingDir: string | undefined;
   proxy: string | undefined;
+  insecure: boolean | undefined;
   includeDirectories: string[] | undefined;
   screenReader: boolean | undefined;
   inputFormat?: string | undefined;
@@ -161,6 +162,30 @@ export interface CliArgs {
   jsonFd?: number | undefined;
   jsonFile?: string | undefined;
   inputFile?: string | undefined;
+}
+
+/**
+ * Resolve the effective TLS-insecure setting from (in order):
+ *   1. ``--insecure`` CLI flag,
+ *   2. ``QWEN_TLS_INSECURE`` env var (truthy: ``1``, ``true``, ``yes``,
+ *      case-insensitive),
+ *   3. ``NODE_TLS_REJECT_UNAUTHORIZED=0`` for parity with Node's legacy
+ *      ``http`` stack and Claude Code -- undici (used by ``fetch``)
+ *      otherwise ignores this env var, leaving users surprised that the
+ *      flag they set "for everything" silently does nothing here (#3535).
+ */
+function resolveInsecureFlag(cliFlag: boolean | undefined): boolean {
+  if (cliFlag) {
+    return true;
+  }
+  const qwenEnv = process.env['QWEN_TLS_INSECURE']?.trim().toLowerCase();
+  if (qwenEnv === '1' || qwenEnv === 'true' || qwenEnv === 'yes') {
+    return true;
+  }
+  if (process.env['NODE_TLS_REJECT_UNAUTHORIZED']?.trim() === '0') {
+    return true;
+  }
+  return false;
 }
 
 function normalizeOutputFormat(
@@ -272,6 +297,14 @@ export async function parseArguments(): Promise<CliArgs> {
       'proxy',
       'Use the "proxy" setting in settings.json instead. This flag will be removed in a future version.',
     )
+    .option('insecure', {
+      type: 'boolean',
+      description:
+        'Skip TLS certificate verification for outbound HTTPS requests. ' +
+        'Use for self-signed dev/lab endpoints. Equivalent env vars: ' +
+        'QWEN_TLS_INSECURE=1 or NODE_TLS_REJECT_UNAUTHORIZED=0.',
+      default: false,
+    })
     .option('chat-recording', {
       type: 'boolean',
       description:
@@ -1158,6 +1191,7 @@ export async function loadCliConfig(
       process.env['https_proxy'] ||
       process.env['HTTP_PROXY'] ||
       process.env['http_proxy'],
+    insecure: resolveInsecureFlag(argv.insecure),
     cwd,
     fileDiscoveryService: fileService,
     bugCommand: settings.advanced?.bugCommand,

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -166,17 +166,22 @@ export interface CliArgs {
 
 /**
  * Resolve the effective TLS-insecure setting from (in order):
- *   1. ``--insecure`` CLI flag,
+ *   1. ``--insecure`` / ``--no-insecure`` CLI flag (any explicit value wins),
  *   2. ``QWEN_TLS_INSECURE`` env var (truthy: ``1``, ``true``, ``yes``,
  *      case-insensitive),
  *   3. ``NODE_TLS_REJECT_UNAUTHORIZED=0`` for parity with Node's legacy
  *      ``http`` stack and Claude Code -- undici (used by ``fetch``)
  *      otherwise ignores this env var, leaving users surprised that the
  *      flag they set "for everything" silently does nothing here (#3535).
+ *
+ * ``cliFlag`` is tri-state: ``undefined`` means the user passed neither
+ * ``--insecure`` nor ``--no-insecure``, in which case we fall through to
+ * the env-var checks. An explicit ``false`` (``--no-insecure``) forces
+ * verification on regardless of env, since the CLI is documented to win.
  */
 function resolveInsecureFlag(cliFlag: boolean | undefined): boolean {
-  if (cliFlag) {
-    return true;
+  if (cliFlag !== undefined) {
+    return cliFlag;
   }
   const qwenEnv = process.env['QWEN_TLS_INSECURE']?.trim().toLowerCase();
   if (qwenEnv === '1' || qwenEnv === 'true' || qwenEnv === 'yes') {
@@ -301,9 +306,14 @@ export async function parseArguments(): Promise<CliArgs> {
       type: 'boolean',
       description:
         'Skip TLS certificate verification for outbound HTTPS requests. ' +
-        'Use for self-signed dev/lab endpoints. Equivalent env vars: ' +
+        'Use for self-signed dev/lab endpoints. ' +
+        'Pass --no-insecure to force verification on, overriding env vars. ' +
+        'Equivalent env vars (lower precedence): ' +
         'QWEN_TLS_INSECURE=1 or NODE_TLS_REJECT_UNAUTHORIZED=0.',
-      default: false,
+      // No default so yargs reports ``undefined`` when neither --insecure
+      // nor --no-insecure is passed. That preserves three distinct states
+      // (true / false / undefined), which lets the resolver below treat
+      // an explicit ``--no-insecure`` as the highest-precedence override.
     })
     .option('chat-recording', {
       type: 'boolean',

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -594,6 +594,7 @@ describe('gemini.tsx main function kitty protocol', () => {
       openaiBaseUrl: undefined,
       openaiLoggingDir: undefined,
       proxy: undefined,
+      insecure: undefined,
       includeDirectories: undefined,
       screenReader: undefined,
       inputFormat: undefined,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -11,7 +11,7 @@ import * as path from 'node:path';
 import process from 'node:process';
 
 // External dependencies
-import { ProxyAgent, setGlobalDispatcher } from 'undici';
+import { Agent, ProxyAgent, setGlobalDispatcher } from 'undici';
 
 // Types
 import type {
@@ -372,6 +372,13 @@ export interface ConfigParameters {
   };
   checkpointing?: boolean;
   proxy?: string;
+  /**
+   * Disable TLS certificate verification for outbound HTTPS requests
+   * (model APIs, MCP servers reached over HTTPS, and similar). Intended for
+   * self-signed dev/lab endpoints. See ``getInsecure`` for the resolution
+   * order applied at the CLI layer (#3535).
+   */
+  insecure?: boolean;
   cwd: string;
   fileDiscoveryService?: FileDiscoveryService;
   includeDirectories?: string[];
@@ -613,6 +620,7 @@ export class Config {
   private chatRecordingService: ChatRecordingService | undefined = undefined;
   private readonly checkpointing: boolean;
   private readonly proxy: string | undefined;
+  private readonly insecure: boolean;
   private readonly cwd: string;
   private readonly explicitIncludeDirectories: string[];
   private readonly bugCommand: BugCommandSettings | undefined;
@@ -759,6 +767,7 @@ export class Config {
     };
     this.checkpointing = params.checkpointing ?? false;
     this.proxy = params.proxy;
+    this.insecure = params.insecure ?? false;
     this.cwd = params.cwd ?? process.cwd();
     this.fileDiscoveryService = params.fileDiscoveryService ?? null;
     this.bugCommand = params.bugCommand;
@@ -850,8 +859,22 @@ export class Config {
     }
 
     const proxyUrl = this.getProxy();
+    // The global dispatcher backs every ``fetch`` call that does not provide
+    // its own dispatcher (MCP transports, streaming endpoints, telemetry).
+    // Apply both proxy and insecure-TLS here so they take effect uniformly,
+    // not only for the SDK clients we control directly (#3535).
+    const connect = this.insecure ? { rejectUnauthorized: false } : undefined;
     if (proxyUrl) {
-      setGlobalDispatcher(new ProxyAgent(proxyUrl));
+      setGlobalDispatcher(
+        new ProxyAgent({
+          uri: proxyUrl,
+          ...(connect ? { connect } : {}),
+        }),
+      );
+    } else if (this.insecure) {
+      setGlobalDispatcher(
+        new Agent({ connect: { rejectUnauthorized: false } }),
+      );
     }
     this.geminiClient = new GeminiClient(this);
     this.chatRecordingService = this.chatRecordingEnabled
@@ -2033,6 +2056,20 @@ export class Config {
 
   getProxy(): string | undefined {
     return normalizeProxyUrl(this.proxy);
+  }
+
+  /**
+   * Whether outbound HTTPS connections should skip TLS certificate
+   * verification. Useful for self-signed dev/lab model endpoints (#3535).
+   *
+   * Resolution order is applied by the CLI layer:
+   *   1. ``--insecure`` flag
+   *   2. ``QWEN_TLS_INSECURE`` env var (truthy: ``1``, ``true``, ``yes``)
+   *   3. ``NODE_TLS_REJECT_UNAUTHORIZED=0`` for parity with Node's
+   *      legacy http stack and Claude Code.
+   */
+  getInsecure(): boolean {
+    return this.insecure;
   }
 
   getWorkingDir(): string {

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -97,6 +97,7 @@ describe('AnthropicContentGenerator', () => {
     mockConfig = {
       getCliVersion: vi.fn().mockReturnValue('1.2.3'),
       getProxy: vi.fn().mockReturnValue(undefined),
+      getInsecure: vi.fn().mockReturnValue(false),
     } as unknown as Config;
   });
 

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -66,10 +66,10 @@ export class AnthropicContentGenerator implements ContentGenerator {
     const baseURL = contentGeneratorConfig.baseUrl;
     // Configure runtime options to ensure user-configured timeout works as expected
     // bodyTimeout is always disabled (0) to let Anthropic SDK timeout control the request
-    const runtimeOptions = buildRuntimeFetchOptions(
-      'anthropic',
-      this.cliConfig.getProxy(),
-    );
+    const runtimeOptions = buildRuntimeFetchOptions('anthropic', {
+      proxyUrl: this.cliConfig.getProxy(),
+      insecure: this.cliConfig.getInsecure(),
+    });
 
     this.client = new Anthropic({
       apiKey: contentGeneratorConfig.apiKey,

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -69,6 +69,7 @@ describe('DashScopeOpenAICompatibleProvider', () => {
         enableCacheControl: true,
       }),
       getProxy: vi.fn().mockReturnValue(undefined),
+      getInsecure: vi.fn().mockReturnValue(false),
     } as unknown as Config;
 
     provider = new DashScopeOpenAICompatibleProvider(

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -63,10 +63,10 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
     const defaultHeaders = this.buildHeaders();
     // Configure fetch options to ensure user-configured timeout works as expected
     // bodyTimeout is always disabled (0) to let OpenAI SDK timeout control the request
-    const runtimeOptions = buildRuntimeFetchOptions(
-      'openai',
-      this.cliConfig.getProxy(),
-    );
+    const runtimeOptions = buildRuntimeFetchOptions('openai', {
+      proxyUrl: this.cliConfig.getProxy(),
+      insecure: this.cliConfig.getInsecure(),
+    });
     return new OpenAI({
       apiKey,
       baseURL: baseUrl,

--- a/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
@@ -62,6 +62,7 @@ describe('DefaultOpenAICompatibleProvider', () => {
     mockCliConfig = {
       getCliVersion: vi.fn().mockReturnValue('1.0.0'),
       getProxy: vi.fn().mockReturnValue(undefined),
+      getInsecure: vi.fn().mockReturnValue(false),
     } as unknown as Config;
 
     provider = new DefaultOpenAICompatibleProvider(

--- a/packages/core/src/core/openaiContentGenerator/provider/default.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.ts
@@ -51,10 +51,10 @@ export class DefaultOpenAICompatibleProvider
     const defaultHeaders = this.buildHeaders();
     // Configure fetch options to ensure user-configured timeout works as expected
     // bodyTimeout is always disabled (0) to let OpenAI SDK timeout control the request
-    const runtimeOptions = buildRuntimeFetchOptions(
-      'openai',
-      this.cliConfig.getProxy(),
-    );
+    const runtimeOptions = buildRuntimeFetchOptions('openai', {
+      proxyUrl: this.cliConfig.getProxy(),
+      insecure: this.cliConfig.getInsecure(),
+    });
     return new OpenAI({
       apiKey,
       baseURL: baseUrl,

--- a/packages/core/src/utils/runtimeFetchOptions.test.ts
+++ b/packages/core/src/utils/runtimeFetchOptions.test.ts
@@ -92,4 +92,81 @@ describe('buildRuntimeFetchOptions (node runtime)', () => {
       bodyTimeout: 0,
     });
   });
+
+  describe('insecure flag (#3535)', () => {
+    it('omits connect option when insecure is unset', () => {
+      const result = buildRuntimeFetchOptions('openai');
+      const dispatcher = (
+        result as {
+          fetchOptions?: { dispatcher?: { options?: UndiciOptions } };
+        }
+      ).fetchOptions?.dispatcher;
+      expect(dispatcher?.options).not.toHaveProperty('connect');
+    });
+
+    it('forwards rejectUnauthorized: false to undici Agent', () => {
+      const result = buildRuntimeFetchOptions('openai', { insecure: true });
+      const dispatcher = (
+        result as {
+          fetchOptions?: { dispatcher?: { options?: UndiciOptions } };
+        }
+      ).fetchOptions?.dispatcher;
+      expect(dispatcher?.options).toMatchObject({
+        connect: { rejectUnauthorized: false },
+        headersTimeout: 0,
+        bodyTimeout: 0,
+      });
+    });
+
+    it('forwards rejectUnauthorized: false to undici ProxyAgent', () => {
+      const result = buildRuntimeFetchOptions('openai', {
+        proxyUrl: 'http://proxy.local',
+        insecure: true,
+      });
+      const dispatcher = (
+        result as {
+          fetchOptions?: { dispatcher?: { options?: UndiciOptions } };
+        }
+      ).fetchOptions?.dispatcher;
+      expect(dispatcher?.options).toMatchObject({
+        uri: 'http://proxy.local',
+        connect: { rejectUnauthorized: false },
+        headersTimeout: 0,
+        bodyTimeout: 0,
+      });
+    });
+
+    it('treats a bare proxy-URL string identically to legacy callers', () => {
+      const stringResult = buildRuntimeFetchOptions(
+        'openai',
+        'http://proxy.local',
+      );
+      const objectResult = buildRuntimeFetchOptions('openai', {
+        proxyUrl: 'http://proxy.local',
+      });
+      const stringDispatcher = (
+        stringResult as {
+          fetchOptions?: { dispatcher?: { options?: UndiciOptions } };
+        }
+      ).fetchOptions?.dispatcher?.options;
+      const objectDispatcher = (
+        objectResult as {
+          fetchOptions?: { dispatcher?: { options?: UndiciOptions } };
+        }
+      ).fetchOptions?.dispatcher?.options;
+      expect(stringDispatcher).toEqual(objectDispatcher);
+    });
+
+    it('also threads insecure into Anthropic builders', () => {
+      const result = buildRuntimeFetchOptions('anthropic', { insecure: true });
+      const dispatcher = (
+        result as {
+          fetchOptions?: { dispatcher?: { options?: UndiciOptions } };
+        }
+      ).fetchOptions?.dispatcher;
+      expect(dispatcher?.options).toMatchObject({
+        connect: { rejectUnauthorized: false },
+      });
+    });
+  });
 });

--- a/packages/core/src/utils/runtimeFetchOptions.ts
+++ b/packages/core/src/utils/runtimeFetchOptions.ts
@@ -53,18 +53,34 @@ export type AnthropicRuntimeFetchOptions = {
 export type SDKType = 'openai' | 'anthropic';
 
 /**
+ * Optional runtime configuration shared across SDK builders.
+ *
+ * - ``proxyUrl``: Outbound HTTP/HTTPS proxy. When set, an undici
+ *   ``ProxyAgent`` is used as the dispatcher.
+ * - ``insecure``: Disable TLS certificate verification. Required for
+ *   self-signed dev/lab endpoints because undici ignores the
+ *   ``NODE_TLS_REJECT_UNAUTHORIZED`` env var by default. The Node global
+ *   ``rejectUnauthorized`` setting only affects the legacy ``http``
+ *   module, not undici/``fetch``.
+ */
+export interface RuntimeFetchConfig {
+  proxyUrl?: string;
+  insecure?: boolean;
+}
+
+/**
  * Build runtime-specific fetch options for OpenAI SDK
  */
 export function buildRuntimeFetchOptions(
   sdkType: 'openai',
-  proxyUrl?: string,
+  proxyUrlOrConfig?: string | RuntimeFetchConfig,
 ): OpenAIRuntimeFetchOptions;
 /**
  * Build runtime-specific fetch options for Anthropic SDK
  */
 export function buildRuntimeFetchOptions(
   sdkType: 'anthropic',
-  proxyUrl?: string,
+  proxyUrlOrConfig?: string | RuntimeFetchConfig,
 ): AnthropicRuntimeFetchOptions;
 /**
  * Build runtime-specific fetch options based on the detected runtime and SDK type
@@ -72,13 +88,16 @@ export function buildRuntimeFetchOptions(
  * across Node.js and Bun, ensuring user-configured timeout works as expected.
  *
  * @param sdkType - The SDK type ('openai' or 'anthropic') to determine return type
+ * @param proxyUrlOrConfig - Either a proxy URL string (legacy positional form) or a
+ *   ``RuntimeFetchConfig`` object carrying ``proxyUrl`` and/or ``insecure``.
  * @returns Runtime-specific options compatible with the specified SDK
  */
 export function buildRuntimeFetchOptions(
   sdkType: SDKType,
-  proxyUrl?: string,
+  proxyUrlOrConfig?: string | RuntimeFetchConfig,
 ): OpenAIRuntimeFetchOptions | AnthropicRuntimeFetchOptions {
   const runtime = detectRuntime();
+  const { proxyUrl, insecure } = normalizeConfig(proxyUrlOrConfig);
 
   // Always disable undici timeouts (set to 0) to let SDK's timeout parameter
   // control the total request time. bodyTimeout monitors intervals between data
@@ -121,30 +140,50 @@ export function buildRuntimeFetchOptions(
       // Node.js: Use undici dispatcher for both SDKs.
       // This enables proxy support and disables undici timeouts so SDK timeout
       // controls the total request time.
-      return buildFetchOptionsWithDispatcher(sdkType, proxyUrl);
+      return buildFetchOptionsWithDispatcher(sdkType, proxyUrl, insecure);
     }
 
     default: {
       // Unknown runtime: treat as Node.js-like environment.
-      return buildFetchOptionsWithDispatcher(sdkType, proxyUrl);
+      return buildFetchOptionsWithDispatcher(sdkType, proxyUrl, insecure);
     }
   }
 }
 
+function normalizeConfig(
+  proxyUrlOrConfig: string | RuntimeFetchConfig | undefined,
+): RuntimeFetchConfig {
+  if (proxyUrlOrConfig === undefined) {
+    return {};
+  }
+  if (typeof proxyUrlOrConfig === 'string') {
+    return { proxyUrl: proxyUrlOrConfig };
+  }
+  return proxyUrlOrConfig;
+}
+
 function buildFetchOptionsWithDispatcher(
   sdkType: SDKType,
-  proxyUrl?: string,
+  proxyUrl: string | undefined,
+  insecure: boolean | undefined,
 ): OpenAIRuntimeFetchOptions | AnthropicRuntimeFetchOptions {
   try {
+    // undici exposes TLS options via ``connect``. Setting ``rejectUnauthorized``
+    // here is the only way to mirror what Node's legacy http stack does for
+    // ``NODE_TLS_REJECT_UNAUTHORIZED=0``; the env var alone has no effect on
+    // ``fetch``-based code paths because undici uses its own connector.
+    const connect = insecure ? { rejectUnauthorized: false } : undefined;
     const dispatcher = proxyUrl
       ? new ProxyAgent({
           uri: proxyUrl,
           headersTimeout: 0,
           bodyTimeout: 0,
+          ...(connect ? { connect } : {}),
         })
       : new Agent({
           headersTimeout: 0,
           bodyTimeout: 0,
+          ...(connect ? { connect } : {}),
         });
     return { fetchOptions: { dispatcher } };
   } catch {


### PR DESCRIPTION
Closes #3535.

## What

Allow skipping TLS certificate verification for outbound HTTPS requests to model APIs and MCP servers. Required for self-signed dev / lab / homelab endpoints because Node's bundled HTTP client (`undici`, used by `fetch`) ignores `NODE_TLS_REJECT_UNAUTHORIZED` by design — Claude Code works in those setups only because Anthropic's SDK reads the env var back through a custom agent. Qwen Code does not, so today a user with a self-signed Qwen3.6 server has no escape hatch and just sees:

```
[API Error: Connection error. (cause: fetch failed)]
```

This PR adds three coordinated entry points and threads the resolved value through every place an undici dispatcher is constructed.

## How (resolution order, highest to lowest)

1. `--insecure` CLI flag
2. `QWEN_TLS_INSECURE=1|true|yes` (case-insensitive)
3. `NODE_TLS_REJECT_UNAUTHORIZED=0` — for parity with Claude Code and Node's legacy `http` stack. We respect this even though `fetch` itself doesn't, because users reasonably expect the global Node convention to apply.

When set, the resolver passes `connect: { rejectUnauthorized: false }` to:
- the OpenAI SDK's undici dispatcher (default + DashScope providers),
- the Anthropic SDK's undici dispatcher,
- and the **global** undici dispatcher used by MCP / streaming / telemetry traffic — so the flag is uniform across the whole process, not only the SDK clients we control.

## Behavior matrix

| Layer set                           | Before     | After |
|-------------------------------------|------------|-------|
| `--insecure`                        | unsupported | TLS skipped ✅ |
| `QWEN_TLS_INSECURE=1`               | unsupported | TLS skipped ✅ |
| `NODE_TLS_REJECT_UNAUTHORIZED=0`    | silent no-op | TLS skipped ✅ |
| `NODE_TLS_REJECT_UNAUTHORIZED=1`    | n/a         | unchanged (verification on) |
| Combined with `--proxy <url>`       | n/a         | both honored on `ProxyAgent` |

## Areas needing careful review

1. **Backwards-compatible signature change to `buildRuntimeFetchOptions`.** Second arg now accepts either a bare proxy-URL string (legacy) or a `RuntimeFetchConfig` object (`{ proxyUrl?, insecure? }`). `normalizeConfig()` reduces both to the same internal shape, and a regression test pins the equivalence (`'treats a bare proxy-URL string identically to legacy callers'`). Open to renaming the option to `tlsRejectUnauthorized: false` if maintainers prefer matching Node's exact spelling.
2. **Global dispatcher mutation.** The constructor now also calls `setGlobalDispatcher(new Agent({ connect: { rejectUnauthorized: false } }))` when `insecure` is set without a proxy. This is process-wide, but only triggered by an explicit opt-in flag/env, and the existing proxy path already mutates global state in the same place — I followed that pattern rather than introducing a new injection point.
3. **`insecure: undefined` in two CliArgs literals.** `auth/handler.ts` and `gemini.test.tsx` build a fully-spread `CliArgs` literal so I added `insecure: undefined` rather than make the field optional in the interface; matches the surrounding `proxy: undefined` style.

## Tests

- `runtimeFetchOptions.test.ts`: 5 new cases pinning the `connect` option behavior (omitted when unset, present on both `Agent` and `ProxyAgent` when `insecure=true`, also threaded for Anthropic), plus a string-vs-object equivalence test.
- `cli/config.test.ts`: 7 new cases covering the three precedence layers, the negation cases (`=0`, `=1`, arbitrary values), and the `--insecure` overrides `QWEN_TLS_INSECURE=0` interaction.
- Existing provider mocks (`default.test.ts`, `dashscope.test.ts`, `anthropicContentGenerator.test.ts`) updated to expose `getInsecure()` so the new call sites resolve.

## Testing

- [x] Tested locally
- [x] All targeted suites pass: **2,134** core + **439** CLI tests
- [x] `npm run build` clean (full TypeScript build)
- [x] Added tests for new functionality
- [x] Docs updated (`docs/users/support/troubleshooting.md`)

---

*Prepared with assistance from Claude (Anthropic) under human review.*