### PR TITLE
fix(core): preserve reasoning_content when merging consecutive assistant messages (#3619)

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -2019,6 +2019,145 @@ describe('OpenAIContentConverter', () => {
       expect(messages).toHaveLength(1);
       expect(messages[0].content).toBe('FirstSecond');
     });
+
+    it('should preserve reasoning_content when merging two consecutive assistant messages (issue #3619)', () => {
+      // Without this merge, the second message's reasoning_content is silently
+      // dropped, causing DeepSeek thinking mode to reject the next request
+      // with HTTP 400. This typically fires when cleanOrphanedToolCalls
+      // removes the tool message between two assistant turns.
+      const request: GenerateContentParameters = {
+        model: 'models/test',
+        contents: [
+          {
+            role: 'model',
+            parts: [
+              { text: 'thinking step 1', thought: true },
+              { text: 'visible 1' },
+            ],
+          },
+          {
+            role: 'model',
+            parts: [
+              { text: 'thinking step 2', thought: true },
+              { text: 'visible 2' },
+            ],
+          },
+        ],
+      };
+
+      const messages = converter.convertGeminiRequestToOpenAI(
+        request,
+        requestContext,
+      );
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe('assistant');
+      expect(messages[0].content).toBe('visible 1visible 2');
+      expect(
+        (messages[0] as { reasoning_content?: string }).reasoning_content,
+      ).toBe('thinking step 1thinking step 2');
+    });
+
+    it('should preserve reasoning_content when only the second assistant has it (regression for #3619)', () => {
+      // This is the highest-value regression: previously the second message's
+      // reasoning_content was silently dropped during merge, leaving the
+      // resulting assistant turn with no reasoning_content at all — exactly
+      // what triggers DeepSeek thinking mode 400.
+      const request: GenerateContentParameters = {
+        model: 'models/test',
+        contents: [
+          {
+            role: 'model',
+            parts: [{ text: 'visible 1' }],
+          },
+          {
+            role: 'model',
+            parts: [
+              { text: 'late thought', thought: true },
+              { text: 'visible 2' },
+            ],
+          },
+        ],
+      };
+
+      const messages = converter.convertGeminiRequestToOpenAI(
+        request,
+        requestContext,
+      );
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('visible 1visible 2');
+      expect(
+        (messages[0] as { reasoning_content?: string }).reasoning_content,
+      ).toBe('late thought');
+    });
+
+    it('should keep reasoning_content from one side when only one assistant has it', () => {
+      const request: GenerateContentParameters = {
+        model: 'models/test',
+        contents: [
+          {
+            role: 'model',
+            parts: [
+              { text: 'only thought', thought: true },
+              { text: 'visible 1' },
+            ],
+          },
+          {
+            role: 'model',
+            parts: [{ text: 'visible 2' }],
+          },
+        ],
+      };
+
+      const messages = converter.convertGeminiRequestToOpenAI(
+        request,
+        requestContext,
+      );
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('visible 1visible 2');
+      expect(
+        (messages[0] as { reasoning_content?: string }).reasoning_content,
+      ).toBe('only thought');
+    });
+
+    it('should preserve reasoning_content across three consecutive assistant messages', () => {
+      const request: GenerateContentParameters = {
+        model: 'models/test',
+        contents: [
+          {
+            role: 'model',
+            parts: [
+              { text: 'r1', thought: true },
+              { text: 't1' },
+            ],
+          },
+          {
+            role: 'model',
+            parts: [{ text: 't2' }],
+          },
+          {
+            role: 'model',
+            parts: [
+              { text: 'r3', thought: true },
+              { text: 't3' },
+            ],
+          },
+        ],
+      };
+
+      const messages = converter.convertGeminiRequestToOpenAI(
+        request,
+        requestContext,
+      );
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('t1t2t3');
+      expect(
+        (messages[0] as { reasoning_content?: string }).reasoning_content,
+      ).toBe('r1r3');
+    });
   });
 });
 

--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -2122,6 +2122,36 @@ describe('OpenAIContentConverter', () => {
       ).toBe('only thought');
     });
 
+    it('should use empty string instead of null for content when merged result has reasoning but no visible text (issue #3499)', () => {
+      // Two reasoning-only assistant turns merge to content='' (Ollama
+      // compatibility), not null. processContent enforces this for single
+      // messages; the merge must keep it intact.
+      const request: GenerateContentParameters = {
+        model: 'models/test',
+        contents: [
+          {
+            role: 'model',
+            parts: [{ text: 'r1', thought: true }],
+          },
+          {
+            role: 'model',
+            parts: [{ text: 'r2', thought: true }],
+          },
+        ],
+      };
+
+      const messages = converter.convertGeminiRequestToOpenAI(
+        request,
+        requestContext,
+      );
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('');
+      expect(
+        (messages[0] as { reasoning_content?: string }).reasoning_content,
+      ).toBe('r1r2');
+    });
+
     it('should preserve reasoning_content across three consecutive assistant messages', () => {
       const request: GenerateContentParameters = {
         model: 'models/test',

--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -2122,6 +2122,55 @@ describe('OpenAIContentConverter', () => {
       ).toBe('only thought');
     });
 
+    it('should preserve reasoning_content through the realistic #3619 trigger pattern (orphaned tool_call between reasoning turns)', () => {
+      // Realistic #3619 trigger: model_1 has reasoning + visible text + an
+      // orphaned tool_call (no matching tool response). cleanOrphanedToolCalls
+      // strips the tool_call but keeps the message because content is
+      // non-empty. That leaves model_1 adjacent to model_2, and the merge
+      // must carry both reasoning blocks across so the next request to
+      // DeepSeek thinking mode keeps reasoning_content populated.
+      const request: GenerateContentParameters = {
+        model: 'models/test',
+        contents: [
+          {
+            role: 'model',
+            parts: [
+              { text: 'plan', thought: true },
+              { text: 'visible 1' },
+              {
+                functionCall: { id: 'call_orphan', name: 'tool_x', args: {} },
+              },
+            ],
+          },
+          {
+            role: 'model',
+            parts: [
+              { text: 'replan', thought: true },
+              { text: 'visible 2' },
+            ],
+          },
+        ],
+      };
+
+      const messages = converter.convertGeminiRequestToOpenAI(
+        request,
+        requestContext,
+      );
+
+      expect(messages).toHaveLength(1);
+      const merged = messages[0] as {
+        role: string;
+        content: string | null;
+        reasoning_content?: string;
+        tool_calls?: unknown[];
+      };
+      expect(merged.role).toBe('assistant');
+      expect(merged.content).toBe('visible 1visible 2');
+      expect(merged.reasoning_content).toBe('planreplan');
+      // The orphaned tool_call was stripped by cleanOrphanedToolCalls.
+      expect(merged.tool_calls).toBeUndefined();
+    });
+
     it('should use empty string instead of null for content when merged result has reasoning but no visible text (issue #3499)', () => {
       // Two reasoning-only assistant turns merge to content='' (Ollama
       // compatibility), not null. processContent enforces this for single

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -1340,13 +1340,18 @@ function mergeConsecutiveAssistantMessages(
           .filter(Boolean)
           .join('');
 
-        // Update the last message with combined data
+        // Update the last message with combined data.
+        // When reasoning_content is present, fall back to "" instead of null
+        // for empty content. Some OpenAI-compatible providers (e.g. Ollama)
+        // reject content: null when reasoning_content is set (issue #3499).
+        // processContent already enforces this rule for single messages; we
+        // mirror it here so the merged result stays compatible.
         (
           lastMessage as OpenAI.Chat.ChatCompletionMessageParam & {
             content: string | OpenAI.Chat.ChatCompletionContentPart[] | null;
             tool_calls?: OpenAI.Chat.ChatCompletionMessageToolCall[];
           }
-        ).content = combinedContent || null;
+        ).content = combinedContent || (combinedReasoning ? '' : null);
         if (combinedToolCalls.length > 0) {
           (
             lastMessage as OpenAI.Chat.ChatCompletionMessageParam & {

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -1321,6 +1321,25 @@ function mergeConsecutiveAssistantMessages(
         // Combine tool calls
         const combinedToolCalls = [...lastToolCalls, ...currentToolCalls];
 
+        // Combine reasoning_content. Without this merge, the second message's
+        // reasoning would be silently dropped, which can cause DeepSeek thinking
+        // mode to reject the next request with HTTP 400 (issue #3619). The
+        // merge typically fires when cleanOrphanedToolCalls removes the tool
+        // message between two assistant turns, leaving them adjacent.
+        const lastReasoning =
+          'reasoning_content' in lastMessage
+            ? ((lastMessage as ExtendedChatCompletionAssistantMessageParam)
+                .reasoning_content ?? '')
+            : '';
+        const currentReasoning =
+          'reasoning_content' in message
+            ? ((message as ExtendedChatCompletionAssistantMessageParam)
+                .reasoning_content ?? '')
+            : '';
+        const combinedReasoning = [lastReasoning, currentReasoning]
+          .filter(Boolean)
+          .join('');
+
         // Update the last message with combined data
         (
           lastMessage as OpenAI.Chat.ChatCompletionMessageParam & {
@@ -1335,6 +1354,11 @@ function mergeConsecutiveAssistantMessages(
               tool_calls?: OpenAI.Chat.ChatCompletionMessageToolCall[];
             }
           ).tool_calls = combinedToolCalls;
+        }
+        if (combinedReasoning) {
+          (
+            lastMessage as ExtendedChatCompletionAssistantMessageParam
+          ).reasoning_content = combinedReasoning;
         }
 
         continue; // Skip adding the current message since it's been merged


### PR DESCRIPTION
## Summary

`mergeConsecutiveAssistantMessages` (in `packages/core/src/core/openaiContentGenerator/converter.ts`) merged `content` and `tool_calls` across two adjacent assistant messages but **silently dropped the second message's `reasoning_content`**. When DeepSeek thinking mode is active, the merged turn that lands in the next request is missing the reasoning DeepSeek expects to round-trip, and the API returns HTTP 400:

> The reasoning_content in the thinking mode must be passed back to the API.

## How the merge gets triggered

Two consecutive `assistant` messages typically appear after `cleanOrphanedToolCalls` removes the tool message that previously sat between them — i.e. when a tool call's matching tool response went missing. The longer a session runs and the more tool calls it makes, the higher the cumulative chance, which matches the user-reported \"chats fine at first, breaks after a while\" symptom in #3619.

## Fix

Mirror the existing `tool_calls` merge: read `reasoning_content` from both sides (defensive `?? ''` for null), concatenate with the same empty separator the text-content merge uses, and write it back only when the combined value is non-empty.

```ts
const lastReasoning = ... ?? '';
const currentReasoning = ... ?? '';
const combinedReasoning = [lastReasoning, currentReasoning].filter(Boolean).join('');
// ...
if (combinedReasoning) {
  (lastMessage as ExtendedChatCompletionAssistantMessageParam).reasoning_content = combinedReasoning;
}
```

## Honest scope note

This is a **speculative fix based on code audit** — the path matches the reported symptom and the dropped-reasoning bug is real, but I have no direct repro from a failing user session. The data flow audit (response → history → next request) preserves `reasoning_content` everywhere except this merge, so this is the most likely remaining culprit. If a user with #3619 still reproduces after this lands, we have a clean signal that the root cause is elsewhere.

Independent of the #3304/#3579 conflict (model-switch strip) — does not require a maintainer policy decision.

Refs #3619 #3579

## Test plan

- [x] `converter.test.ts`: 71/71 pass (4 new regression tests under `mergeConsecutiveAssistantMessages`):
  - both consecutive assistants have `reasoning_content` → both preserved
  - only second has reasoning (the highest-value regression — was completely lost) → preserved
  - only first has reasoning → unchanged behavior preserved
  - 3-way merge with reasoning at positions 1 and 3 → both preserved
- [x] `packages/core`: 6075/6077 pass (2 skipped, unrelated)
- [x] `tsc --noEmit`: clean
- [x] `eslint`: clean
- [ ] Manual verification by a reporter from #3619 against a DeepSeek thinking-mode session