### PR TITLE
fix(cli): guard gradient rendering without colors

### DIFF
--- a/packages/cli/src/ui/components/Header.test.tsx
+++ b/packages/cli/src/ui/components/Header.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { render } from 'ink-testing-library';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Header, AuthDisplayType } from './Header.js';
 import * as useTerminalSize from '../hooks/useTerminalSize.js';
 
@@ -20,8 +20,19 @@ const defaultProps = {
 };
 
 describe('<Header />', () => {
+  const originalNoColor = process.env['NO_COLOR'];
+
   beforeEach(() => {
+    delete process.env['NO_COLOR'];
     useTerminalSizeMock.mockReturnValue({ columns: 120, rows: 24 });
+  });
+
+  afterEach(() => {
+    if (originalNoColor === undefined) {
+      delete process.env['NO_COLOR'];
+    } else {
+      process.env['NO_COLOR'] = originalNoColor;
+    }
   });
 
   it('renders the ASCII logo on wide terminal', () => {
@@ -80,5 +91,13 @@ describe('<Header />', () => {
     const { lastFrame } = render(<Header {...defaultProps} />);
     expect(lastFrame()).toContain('┌');
     expect(lastFrame()).toContain('┐');
+  });
+
+  it('renders plain text when NO_COLOR disables gradient colors', () => {
+    process.env['NO_COLOR'] = '1';
+
+    const { lastFrame } = render(<Header {...defaultProps} />);
+
+    expect(lastFrame()).toContain('██╔═══██╗');
   });
 });

--- a/packages/cli/src/ui/components/Header.tsx
+++ b/packages/cli/src/ui/components/Header.tsx
@@ -12,6 +12,7 @@ import { theme } from '../semantic-colors.js';
 import { shortAsciiLogo } from './AsciiArt.js';
 import { getAsciiArtWidth, getCachedStringWidth } from '../utils/textUtils.js';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
+import { getRenderableGradientColors } from '../utils/gradientUtils.js';
 
 /**
  * Auth display type for the Header component.
@@ -98,12 +99,11 @@ export const Header: React.FC<HeaderProps> = ({
         ? shortenedPath.slice(0, maxPathLength)
         : shortenedPath;
 
-  // Use theme gradient colors if available, otherwise use text colors (excluding primary)
-  const gradientColors = theme.ui.gradient || [
+  const gradientColors = getRenderableGradientColors(theme.ui.gradient, [
     theme.text.secondary,
     theme.text.link,
     theme.text.accent,
-  ];
+  ]);
 
   return (
     <Box
@@ -116,9 +116,13 @@ export const Header: React.FC<HeaderProps> = ({
       {showLogo && (
         <>
           <Box flexShrink={0}>
-            <Gradient colors={gradientColors}>
+            {gradientColors ? (
+              <Gradient colors={gradientColors}>
+                <Text>{displayLogo}</Text>
+              </Gradient>
+            ) : (
               <Text>{displayLogo}</Text>
-            </Gradient>
+            )}
           </Box>
           {/* Fixed gap between logo and info panel */}
           <Box width={logoGap} />

--- a/packages/cli/src/ui/components/StatsDisplay.test.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { render } from 'ink-testing-library';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { StatsDisplay } from './StatsDisplay.js';
 import * as SessionContext from '../contexts/SessionContext.js';
 import type {
@@ -14,6 +14,7 @@ import type {
   SessionMetrics,
 } from '../contexts/SessionContext.js';
 import { MAIN_SOURCE } from '@qwen-code/qwen-code-core';
+import { DEFAULT_THEME, themeManager } from '../themes/theme-manager.js';
 
 // Wraps a core metrics object as a ModelMetrics with a single `main` source
 // bucket, matching the shape produced by processing an API call with no
@@ -33,6 +34,21 @@ vi.mock('../contexts/SessionContext.js', async (importOriginal) => {
 });
 
 const useSessionStatsMock = vi.mocked(SessionContext.useSessionStats);
+const originalNoColor = process.env['NO_COLOR'];
+
+beforeEach(() => {
+  delete process.env['NO_COLOR'];
+});
+
+afterEach(() => {
+  if (originalNoColor === undefined) {
+    delete process.env['NO_COLOR'];
+  } else {
+    process.env['NO_COLOR'] = originalNoColor;
+  }
+  themeManager.loadCustomThemes({});
+  themeManager.setActiveTheme(DEFAULT_THEME.name);
+});
 
 const renderWithMockedStats = (metrics: SessionMetrics) => {
   useSessionStatsMock.mockReturnValue({
@@ -557,6 +573,36 @@ describe('<StatsDisplay />', () => {
       expect(output).toContain('Agent powering down. Goodbye!');
       expect(output).not.toContain('Session Stats');
       expect(output).toMatchSnapshot();
+    });
+
+    it('renders a custom title as plain text when the theme has too few gradient colors', () => {
+      themeManager.loadCustomThemes({
+        OneColorGradient: {
+          name: 'OneColorGradient',
+          type: 'custom',
+          ui: { gradient: ['red'] },
+        },
+      });
+      themeManager.setActiveTheme('OneColorGradient');
+      useSessionStatsMock.mockReturnValue({
+        stats: {
+          sessionId: 'test-session-id',
+          sessionStartTime: new Date(),
+          metrics: zeroMetrics,
+          lastPromptTokenCount: 0,
+          promptCount: 5,
+        },
+
+        getPromptCount: () => 5,
+        startNewPrompt: vi.fn(),
+      });
+
+      const { lastFrame } = render(
+        <StatsDisplay duration="1s" title="Agent powering down. Goodbye!" />,
+      );
+      const output = lastFrame();
+      expect(output).toContain('Agent powering down. Goodbye!');
+      expect(output).not.toContain('Invalid number of stops');
     });
   });
 });

--- a/packages/cli/src/ui/components/StatsDisplay.tsx
+++ b/packages/cli/src/ui/components/StatsDisplay.tsx
@@ -18,6 +18,7 @@ import {
   USER_AGREEMENT_RATE_HIGH,
   USER_AGREEMENT_RATE_MEDIUM,
 } from '../utils/displayUtils.js';
+import { getRenderableGradientColors } from '../utils/gradientUtils.js';
 import { computeSessionStats } from '../utils/computeStats.js';
 import { flattenModelsBySource } from '../utils/modelsBySource.js';
 import { t } from '../../i18n/index.js';
@@ -194,8 +195,9 @@ export const StatsDisplay: React.FC<StatsDisplayProps> = ({
 
   const renderTitle = () => {
     if (title) {
-      return theme.ui.gradient && theme.ui.gradient.length > 0 ? (
-        <Gradient colors={theme.ui.gradient}>
+      const gradientColors = getRenderableGradientColors(theme.ui.gradient);
+      return gradientColors ? (
+        <Gradient colors={gradientColors}>
           <Text bold color={theme.text.primary}>
             {title}
           </Text>

--- a/packages/cli/src/ui/utils/gradientUtils.ts
+++ b/packages/cli/src/ui/utils/gradientUtils.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export function getRenderableGradientColors(
+  ...candidates: Array<string[] | undefined>
+): string[] | undefined {
+  return candidates.find(
+    (colors): colors is string[] =>
+      Array.isArray(colors) &&
+      colors.length >= 2 &&
+      colors.every(
+        (color) => typeof color === 'string' && color.trim().length > 0,
+      ),
+  );
+}


### PR DESCRIPTION
## Summary

- What changed:
  - Added `getRenderableGradientColors` so `ink-gradient` only receives gradients with at least two non-empty color stops.
  - Updated `Header` to fall back to plain text rendering when `NO_COLOR=1` or the active theme has no renderable gradient.
  - Updated `StatsDisplay` to avoid the same crash for one-color or otherwise invalid gradients.
  - Added regression coverage for wide-terminal Header rendering with `NO_COLOR=1` and StatsDisplay title rendering with a one-color custom gradient.

- Why it changed:
  - `NoColorTheme` provides `ui.gradient: []`.
  - Empty arrays are truthy in JavaScript, so the previous `theme.ui.gradient || fallback` logic passed `[]` to `<Gradient>`.
  - `ink-gradient` / `gradient-string` requires at least two color stops and throws `Invalid number of stops (< 2)` otherwise.

- Reviewer focus:
  - Whether the gradient validation is conservative enough.
  - Whether the plain text fallbacks in `Header` and `StatsDisplay` match `NO_COLOR` behavior.

## Validation

- Commands run:
  ```bash
  cd packages/cli && npx vitest run src/ui/components/Header.test.tsx src/ui/components/StatsDisplay.test.tsx
  npm run typecheck
  npm run lint
  npm run build && npm run bundle
  NO_COLOR=1 node dist/cli.js --sandbox=false --approval-mode=default
  ```

- Prompts / inputs used:
  - Launched the CLI in a 180x40 `tmux` terminal:
    ```bash
    NO_COLOR=1 node dist/cli.js --sandbox=false --approval-mode=default
    ```

- Expected result:
  - The CLI starts normally with `NO_COLOR=1` in a wide terminal that renders the ASCII logo.
  - `Invalid number of stops (< 2)` is not shown.

- Observed result:
  - `Header.test.tsx` and `StatsDisplay.test.tsx` passed: 27 tests total.
  - `typecheck` passed.
  - `lint` passed.
  - `build && bundle` passed.
  - The 180-column `tmux` smoke test rendered the CLI with the plain-text logo and prompt, with no `ERROR` or `Invalid number of stops` output.

- Quickest reviewer verification path:
  ```bash
  cd packages/cli && npx vitest run src/ui/components/Header.test.tsx src/ui/components/StatsDisplay.test.tsx
  npm run build && npm run bundle
  NO_COLOR=1 node dist/cli.js --sandbox=false --approval-mode=default
  ```

- Evidence:
  - Before the fix, the new regression tests reproduced `Invalid number of stops (< 2)`.
  - After the fix, the same tests pass and the wide-terminal `tmux` smoke test renders normally.

## Scope / Risk

- Main risk or tradeoff:
  - This only changes the gradient rendering boundary. When no valid gradient exists, the UI renders plain text instead of attempting a gradient.
- Not covered / not validated:
  - Manual interactive TUI verification was not performed on Windows or Linux.
- Breaking changes / migration notes:
  - N/A

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Verified on macOS with `npm run lint`, `npm run typecheck`, and `npm run build && npm run bundle`.
- Verified on macOS with a wide-terminal `NO_COLOR=1` smoke test using `node dist/cli.js`.
- Windows, Linux, Docker, Podman, and Seatbelt were not manually validated because this fix is limited to guarding gradient arguments before React/Ink rendering.

## Linked Issues / Bugs

Fixes #3639
