### PR TITLE
fix(cli): stabilize sticky todo redraws

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -58,7 +58,13 @@ import {
   type WaitingToolCall,
 } from '@qwen-code/qwen-code-core';
 import { buildResumedHistoryItems } from './utils/resumeHistoryUtils.js';
-import { getStickyTodos } from './utils/todoSnapshot.js';
+import {
+  getStickyTodos,
+  getStickyTodoMaxVisibleItems,
+  getStickyTodosLayoutKey,
+  getStickyTodosRenderKey,
+} from './utils/todoSnapshot.js';
+import type { TodoItem } from './components/TodoDisplay.js';
 import { validateAuthMethod } from '../config/auth.js';
 import { loadHierarchicalGeminiMemory } from '../config/config.js';
 import process from 'node:process';
@@ -158,6 +164,20 @@ function isToolExecuting(pendingHistoryItems: HistoryItemWithoutId[]) {
     }
     return false;
   });
+}
+
+function useStableStickyTodos(todos: TodoItem[] | null): TodoItem[] | null {
+  const renderKey = getStickyTodosRenderKey(todos);
+  const stableTodosRef = useRef<{
+    renderKey: string;
+    todos: TodoItem[] | null;
+  } | null>(null);
+
+  if (stableTodosRef.current?.renderKey !== renderKey) {
+    stableTodosRef.current = { renderKey, todos };
+  }
+
+  return stableTodosRef.current.todos;
 }
 
 // Exported for tests. Given a newest-first list of messages, return a list
@@ -1230,10 +1250,11 @@ export const AppContainer = (props: AppContainerProps) => {
     () => [...pendingSlashCommandHistoryItems, ...pendingGeminiHistoryItems],
     [pendingSlashCommandHistoryItems, pendingGeminiHistoryItems],
   );
-  const stickyTodos = useMemo(
+  const rawStickyTodos = useMemo(
     () => getStickyTodos(historyManager.history, pendingHistoryItems),
     [historyManager.history, pendingHistoryItems],
   );
+  const stickyTodos = useStableStickyTodos(rawStickyTodos);
 
   // Terminal tab progress bar (OSC 9;4) for iTerm2/Ghostty
   useTerminalProgress(streamingState, isToolExecuting(pendingHistoryItems));
@@ -1573,24 +1594,39 @@ export const AppContainer = (props: AppContainerProps) => {
     !dialogsVisible &&
     !isFeedbackDialogOpen &&
     streamingState !== StreamingState.WaitingForConfirmation;
+  const stickyTodoWidth = Math.min(mainAreaWidth, 64);
+  const stickyTodoMaxVisibleItems =
+    getStickyTodoMaxVisibleItems(terminalHeight);
+  const stickyTodosLayoutKey = shouldShowStickyTodos
+    ? getStickyTodosLayoutKey(
+        stickyTodos,
+        stickyTodoWidth,
+        stickyTodoMaxVisibleItems,
+      )
+    : 'hidden';
   const [controlsHeight, setControlsHeight] = useState(0);
 
   useLayoutEffect(() => {
     if (!mainControlsRef.current) {
-      setControlsHeight(0);
+      setControlsHeight((previousHeight) =>
+        previousHeight === 0 ? previousHeight : 0,
+      );
       return;
     }
 
     const fullFooterMeasurement = measureElement(mainControlsRef.current);
-    setControlsHeight(fullFooterMeasurement.height);
+    setControlsHeight((previousHeight) =>
+      previousHeight === fullFooterMeasurement.height
+        ? previousHeight
+        : fullFooterMeasurement.height,
+    );
   }, [
     buffer,
     terminalWidth,
     terminalHeight,
     btwItem,
     dialogsVisible,
-    shouldShowStickyTodos,
-    stickyTodos,
+    stickyTodosLayoutKey,
   ]);
 
   // agentViewState is declared earlier (before handleFinalSubmit) so it

--- a/packages/cli/src/ui/components/StickyTodoList.test.tsx
+++ b/packages/cli/src/ui/components/StickyTodoList.test.tsx
@@ -54,4 +54,23 @@ describe('StickyTodoList', () => {
       output.indexOf('Summarize results'),
     );
   });
+
+  it('limits visible items and shows an overflow summary', () => {
+    const todos: TodoItem[] = Array.from({ length: 7 }, (_, index) => ({
+      id: `todo-${index + 1}`,
+      content: `Task ${index + 1}`,
+      status: 'pending',
+    }));
+
+    const { lastFrame } = render(
+      <StickyTodoList todos={todos} width={60} maxVisibleItems={5} />,
+    );
+    const output = lastFrame() ?? '';
+
+    expect(output).toContain('Task 1');
+    expect(output).toContain('Task 5');
+    expect(output).not.toContain('Task 6');
+    expect(output).not.toContain('Task 7');
+    expect(output).toContain('... and 2 more');
+  });
 });

--- a/packages/cli/src/ui/components/StickyTodoList.tsx
+++ b/packages/cli/src/ui/components/StickyTodoList.tsx
@@ -5,17 +5,22 @@
  */
 
 import type React from 'react';
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { Box, Text } from 'ink';
 import { t } from '../../i18n/index.js';
 import { Colors } from '../colors.js';
 import { theme } from '../semantic-colors.js';
-import { getOrderedStickyTodos } from '../utils/todoSnapshot.js';
+import {
+  getOrderedStickyTodos,
+  STICKY_TODO_MAX_VISIBLE_ITEMS,
+  getStickyTodosRenderKey,
+} from '../utils/todoSnapshot.js';
 import type { TodoItem } from './TodoDisplay.js';
 
 interface StickyTodoListProps {
   todos: TodoItem[];
   width: number;
+  maxVisibleItems?: number;
 }
 
 const STATUS_ICONS = {
@@ -24,9 +29,10 @@ const STATUS_ICONS = {
   completed: '●',
 } as const;
 
-export const StickyTodoList: React.FC<StickyTodoListProps> = ({
+const StickyTodoListComponent: React.FC<StickyTodoListProps> = ({
   todos,
   width,
+  maxVisibleItems = STICKY_TODO_MAX_VISIBLE_ITEMS,
 }) => {
   const orderedTodos = useMemo(() => getOrderedStickyTodos(todos), [todos]);
   const todoNumberById = useMemo(
@@ -34,6 +40,9 @@ export const StickyTodoList: React.FC<StickyTodoListProps> = ({
       new Map(todos.map((todo, index) => [todo.id, `${index + 1}.`] as const)),
     [todos],
   );
+
+  const visibleTodos = orderedTodos.slice(0, maxVisibleItems);
+  const overflowCount = orderedTodos.length - maxVisibleItems;
 
   if (todos.length === 0) {
     return null;
@@ -53,7 +62,7 @@ export const StickyTodoList: React.FC<StickyTodoListProps> = ({
       <Text color={theme.text.secondary} bold>
         {t('Current tasks')}
       </Text>
-      {orderedTodos.map((todo, index) => {
+      {visibleTodos.map((todo, index) => {
         const todoNumber = todoNumberById.get(todo.id) ?? `${index + 1}.`;
         const itemColor =
           todo.status === 'in_progress'
@@ -72,7 +81,7 @@ export const StickyTodoList: React.FC<StickyTodoListProps> = ({
               <Text
                 color={itemColor}
                 strikethrough={todo.status === 'completed'}
-                wrap="wrap"
+                wrap="truncate-end"
               >
                 {todo.content}
               </Text>
@@ -80,6 +89,20 @@ export const StickyTodoList: React.FC<StickyTodoListProps> = ({
           </Box>
         );
       })}
+      {overflowCount > 0 && (
+        <Text color={theme.text.secondary}>
+          {t('... and {{count}} more', { count: String(overflowCount) })}
+        </Text>
+      )}
     </Box>
   );
 };
+
+export const StickyTodoList = memo(
+  StickyTodoListComponent,
+  (previousProps, nextProps) =>
+    previousProps.width === nextProps.width &&
+    previousProps.maxVisibleItems === nextProps.maxVisibleItems &&
+    getStickyTodosRenderKey(previousProps.todos) ===
+      getStickyTodosRenderKey(nextProps.todos),
+);

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.test.tsx
@@ -151,6 +151,22 @@ describe('DefaultAppLayout', () => {
     expect(output).toContain('Composer');
   });
 
+  it('renders sticky todo list while responding', () => {
+    mockedUseAgentViewState.mockReturnValue({
+      activeView: 'main',
+      agents: new Map(),
+    });
+
+    const { lastFrame } = renderLayout({
+      ...baseUIState,
+      streamingState: StreamingState.Responding,
+    });
+
+    const output = lastFrame() ?? '';
+    expect(output).toContain('StickyTodoList');
+    expect(output).toContain('Composer');
+  });
+
   it('does not render sticky todo list when feedback dialog is open', () => {
     mockedUseAgentViewState.mockReturnValue({
       activeView: 'main',

--- a/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/DefaultAppLayout.tsx
@@ -21,6 +21,7 @@ import { useUIActions } from '../contexts/UIActionsContext.js';
 import { useAgentViewState } from '../contexts/AgentViewContext.js';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
 import { StreamingState } from '../types.js';
+import { getStickyTodoMaxVisibleItems } from '../utils/todoSnapshot.js';
 
 export const DefaultAppLayout: React.FC = () => {
   const uiState = useUIState();
@@ -30,6 +31,9 @@ export const DefaultAppLayout: React.FC = () => {
   const hasAgents = agents.size > 0;
   const isAgentTab = activeView !== 'main' && agents.has(activeView);
   const stickyTodoWidth = Math.min(uiState.mainAreaWidth, 64);
+  const stickyTodoMaxVisibleItems = getStickyTodoMaxVisibleItems(
+    uiState.terminalHeight,
+  );
   const shouldShowStickyTodos =
     uiState.stickyTodos !== null &&
     !uiState.dialogsVisible &&
@@ -81,6 +85,7 @@ export const DefaultAppLayout: React.FC = () => {
                   <StickyTodoList
                     todos={uiState.stickyTodos!}
                     width={stickyTodoWidth}
+                    maxVisibleItems={stickyTodoMaxVisibleItems}
                   />
                 )}
                 {uiState.btwItem && (

--- a/packages/cli/src/ui/layouts/ScreenReaderAppLayout.test.tsx
+++ b/packages/cli/src/ui/layouts/ScreenReaderAppLayout.test.tsx
@@ -110,6 +110,17 @@ describe('ScreenReaderAppLayout', () => {
     expect(output).toContain('Composer');
   });
 
+  it('renders sticky todo list while responding', () => {
+    const { lastFrame } = renderLayout({
+      ...baseUIState,
+      streamingState: StreamingState.Responding,
+    });
+
+    const output = lastFrame() ?? '';
+    expect(output).toContain('StickyTodoList');
+    expect(output).toContain('Composer');
+  });
+
   it('does not render sticky todo list when feedback dialog is open', () => {
     const { lastFrame } = renderLayout({
       ...baseUIState,

--- a/packages/cli/src/ui/layouts/ScreenReaderAppLayout.tsx
+++ b/packages/cli/src/ui/layouts/ScreenReaderAppLayout.tsx
@@ -16,10 +16,14 @@ import { StickyTodoList } from '../components/StickyTodoList.js';
 import { BtwMessage } from '../components/messages/BtwMessage.js';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { StreamingState } from '../types.js';
+import { getStickyTodoMaxVisibleItems } from '../utils/todoSnapshot.js';
 
 export const ScreenReaderAppLayout: React.FC = () => {
   const uiState = useUIState();
   const stickyTodoWidth = Math.min(uiState.mainAreaWidth, 64);
+  const stickyTodoMaxVisibleItems = getStickyTodoMaxVisibleItems(
+    uiState.terminalHeight,
+  );
   const shouldShowStickyTodos =
     uiState.stickyTodos !== null &&
     !uiState.dialogsVisible &&
@@ -47,6 +51,7 @@ export const ScreenReaderAppLayout: React.FC = () => {
             <StickyTodoList
               todos={uiState.stickyTodos!}
               width={stickyTodoWidth}
+              maxVisibleItems={stickyTodoMaxVisibleItems}
             />
           )}
           {uiState.btwItem && (

--- a/packages/cli/src/ui/utils/todoSnapshot.test.ts
+++ b/packages/cli/src/ui/utils/todoSnapshot.test.ts
@@ -5,9 +5,15 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { ToolNames } from '@qwen-code/qwen-code-core';
 import type { HistoryItem, HistoryItemWithoutId } from '../types.js';
 import { ToolCallStatus } from '../types.js';
-import { getStickyTodos } from './todoSnapshot.js';
+import {
+  getStickyTodos,
+  getStickyTodoMaxVisibleItems,
+  getStickyTodosLayoutKey,
+  getStickyTodosRenderKey,
+} from './todoSnapshot.js';
 
 function makeTodoToolGroup(
   content: string,
@@ -118,22 +124,20 @@ describe('getStickyTodos', () => {
     ]);
   });
 
-  it('prefers pending todo snapshots over history', () => {
+  it('returns null when pending TodoWrite result is visible (avoids duplicate rendering)', () => {
+    // This is the key fix for issue #3638:
+    // When a TodoWrite tool has a result in the pending area,
+    // the sticky panel should be hidden to avoid duplicate rendering
+    // and layout reflows that cause flickering.
     const history = [makeTodoToolGroup('history task', 1)] as HistoryItem[];
     const pendingHistoryItems = [
       makeTodoToolGroup('pending task'),
     ] as HistoryItemWithoutId[];
 
-    expect(getStickyTodos(history, pendingHistoryItems)).toEqual([
-      {
-        id: 'todo-pending task',
-        content: 'pending task',
-        status: 'pending',
-      },
-    ]);
+    expect(getStickyTodos(history, pendingHistoryItems)).toBeNull();
   });
 
-  it('returns null when the latest todo snapshot clears the list', () => {
+  it('returns null when pending TodoWrite result clears the list', () => {
     const history = [makeTodoToolGroup('history task', 1)] as HistoryItem[];
     const pendingHistoryItems = [
       makeEmptyTodoToolGroup(),
@@ -164,36 +168,118 @@ describe('getStickyTodos', () => {
     expect(getStickyTodos(history, [])).toBeNull();
   });
 
-  it('keeps showing a fully completed pending snapshot until the turn finishes', () => {
-    const history = [
-      makeTodoToolGroup('older history task', 1),
-    ] as HistoryItem[];
+  it('shows history snapshot when pending has non-TodoWrite tool', () => {
+    // When pending items don't contain a TodoWrite result,
+    // we should show the history snapshot in the sticky panel.
+    const history = [makeTodoToolGroup('history task', 1)] as HistoryItem[];
     const pendingHistoryItems = [
-      makeCustomTodoToolGroup([
-        {
-          id: 'todo-1',
-          content: 'Run tests',
-          status: 'completed',
-        },
-        {
-          id: 'todo-2',
-          content: 'Summarize results',
-          status: 'completed',
-        },
-      ]),
+      {
+        type: 'tool_group' as const,
+        tools: [
+          {
+            callId: 'read-file-1',
+            name: ToolNames.READ_FILE,
+            description: 'Read a file',
+            resultDisplay: 'File content here',
+            status: ToolCallStatus.Success,
+            confirmationDetails: undefined,
+          },
+        ],
+      },
     ] as HistoryItemWithoutId[];
 
     expect(getStickyTodos(history, pendingHistoryItems)).toEqual([
       {
-        id: 'todo-1',
-        content: 'Run tests',
-        status: 'completed',
-      },
-      {
-        id: 'todo-2',
-        content: 'Summarize results',
-        status: 'completed',
+        id: 'todo-history task',
+        content: 'history task',
+        status: 'pending',
       },
     ]);
+  });
+
+  it('shows history snapshot when pending TodoWrite is executing without result', () => {
+    // When TodoWrite is still executing (no result yet),
+    // we should hide the sticky panel to prepare for the result.
+    const history = [makeTodoToolGroup('history task', 1)] as HistoryItem[];
+    const pendingHistoryItems = [
+      {
+        type: 'tool_group' as const,
+        tools: [
+          {
+            callId: 'todo-executing',
+            name: ToolNames.TODO_WRITE,
+            description: 'Update todos',
+            resultDisplay: undefined, // No result yet
+            status: ToolCallStatus.Executing,
+            confirmationDetails: undefined,
+          },
+        ],
+      },
+    ] as HistoryItemWithoutId[];
+
+    // Should show history snapshot when TodoWrite is executing but no result yet
+    expect(getStickyTodos(history, pendingHistoryItems)).toEqual([
+      {
+        id: 'todo-history task',
+        content: 'history task',
+        status: 'pending',
+      },
+    ]);
+  });
+});
+
+describe('sticky todo render keys', () => {
+  it('keeps the layout key stable for status-only updates', () => {
+    const pendingTodos = [
+      {
+        id: 'todo-1',
+        content: 'Run focused tests',
+        status: 'pending' as const,
+      },
+    ];
+    const inProgressTodos = [
+      {
+        id: 'todo-1',
+        content: 'Run focused tests',
+        status: 'in_progress' as const,
+      },
+    ];
+
+    expect(getStickyTodosLayoutKey(pendingTodos, 64, 5)).toBe(
+      getStickyTodosLayoutKey(inProgressTodos, 64, 5),
+    );
+    expect(getStickyTodosRenderKey(pendingTodos)).not.toBe(
+      getStickyTodosRenderKey(inProgressTodos),
+    );
+  });
+
+  it('changes the layout key when wrapping-sensitive inputs change', () => {
+    const todos = [
+      {
+        id: 'todo-1',
+        content: 'Run focused tests',
+        status: 'pending' as const,
+      },
+    ];
+
+    expect(getStickyTodosLayoutKey(todos, 64, 5)).not.toBe(
+      getStickyTodosLayoutKey(todos, 40, 5),
+    );
+    expect(getStickyTodosLayoutKey(todos, 64, 5)).not.toBe(
+      getStickyTodosLayoutKey(
+        [{ ...todos[0], content: 'Run focused tests and build' }],
+        64,
+        5,
+      ),
+    );
+    expect(getStickyTodosLayoutKey(todos, 64, 5)).not.toBe(
+      getStickyTodosLayoutKey(todos, 64, 2),
+    );
+  });
+
+  it('derives a bounded sticky todo item count from terminal height', () => {
+    expect(getStickyTodoMaxVisibleItems(4)).toBe(1);
+    expect(getStickyTodoMaxVisibleItems(12)).toBe(3);
+    expect(getStickyTodoMaxVisibleItems(40)).toBe(5);
   });
 });

--- a/packages/cli/src/ui/utils/todoSnapshot.ts
+++ b/packages/cli/src/ui/utils/todoSnapshot.ts
@@ -18,6 +18,8 @@ const STICKY_TODO_STATUS_PRIORITY: Record<TodoItem['status'], number> = {
   pending: 1,
   completed: 2,
 };
+export const STICKY_TODO_MAX_VISIBLE_ITEMS = 5;
+const STICKY_TODO_HEIGHT_RATIO = 4;
 
 function extractTodosFromResultDisplay(
   resultDisplay: unknown,
@@ -83,9 +85,12 @@ export function getStickyTodos(
   history: readonly HistoryItem[],
   pendingHistoryItems: readonly HistoryItemWithoutId[],
 ): TodoItem[] | null {
+  // Hide sticky panel when pending TodoWrite result is visible inline.
+  // This avoids duplicate rendering and prevents layout reflows that cause
+  // flickering on Windows PowerShell and other terminals.
   const pendingSnapshot = findLatestTodoSnapshot(pendingHistoryItems);
   if (pendingSnapshot !== undefined) {
-    return pendingSnapshot;
+    return null;
   }
 
   const historySnapshot = findLatestTodoSnapshot(history);
@@ -106,4 +111,42 @@ export function getOrderedStickyTodos(todos: readonly TodoItem[]): TodoItem[] {
         left.index - right.index,
     )
     .map(({ todo }) => todo);
+}
+
+export function getStickyTodosRenderKey(
+  todos: readonly TodoItem[] | null,
+): string {
+  if (!todos) {
+    return 'null';
+  }
+
+  return JSON.stringify(
+    todos.map((todo) => [todo.id, todo.content, todo.status]),
+  );
+}
+
+export function getStickyTodosLayoutKey(
+  todos: readonly TodoItem[] | null,
+  width: number,
+  maxVisibleItems: number,
+): string {
+  if (!todos) {
+    return 'null';
+  }
+
+  return JSON.stringify({
+    width,
+    maxVisibleItems,
+    todos: todos.map((todo) => [todo.id, todo.content]),
+  });
+}
+
+export function getStickyTodoMaxVisibleItems(terminalHeight: number): number {
+  return Math.max(
+    1,
+    Math.min(
+      STICKY_TODO_MAX_VISIBLE_ITEMS,
+      Math.floor(terminalHeight / STICKY_TODO_HEIGHT_RATIO),
+    ),
+  );
 }


### PR DESCRIPTION
## Summary

- What changed: Stabilizes the sticky `Current tasks` panel during streaming updates without removing the feature.
- Why it changed: #3638 reports severe terminal flicker when the sticky todo panel is visible while the model streams and updates todos, especially with long todo lists or small terminals.
- Reviewer focus: Please review the sticky todo visibility rules, the compact rendering behavior, and the footer-height measurement dependencies. Requested reviewers: @wenshao and @shenyankm.

## Root Cause

The flicker is caused by a feedback loop between sticky todo rendering and Ink's dynamic redraw area:

1. The sticky `Current tasks` panel is rendered in the bottom controls area.
2. While the model is streaming, `TodoWrite` updates and pending history items can update frequently.
3. The inline `TodoWrite` result can still be visible while the sticky panel renders the same todo snapshot again.
4. Long todo items were allowed to wrap across multiple lines, and long todo lists rendered all items.
5. The sticky panel height feeds into `mainControlsRef` measurement, which affects `controlsHeight` and then `availableTerminalHeight`.
6. During streaming, repeated layout changes cause more terminal lines to be erased and redrawn, which appears as visible flicker in terminals such as Windows PowerShell and can also be observed on macOS terminals.

## Solution

This PR reduces the bottom-area layout churn while keeping the sticky todo feature:

- Hides the sticky panel while a pending inline `TodoWrite` result is still visible, avoiding duplicate todo rendering in the same frame.
- Caps the number of visible sticky todo items based on terminal height, with an upper bound of 5 items.
- Truncates long sticky todo item text to one line instead of allowing multi-line wrapping.
- Shows an overflow summary such as `... and N more` when the todo list is longer than the compact panel.
- Adds a memoized `StickyTodoList` render path keyed by semantic todo content instead of array identity.
- Splits sticky todo keys into:
  - render key: `id + content + status`, for visible content updates;
  - layout key: `width + maxVisibleItems + id + content`, for changes that can affect panel height or wrapping.
- Uses the layout key in `AppContainer`'s footer-height measurement dependency list so status-only updates do not unnecessarily trigger `measureElement()` and `availableTerminalHeight` recalculation.

## Validation

- Commands run:
  ```bash
  cd packages/cli
  npx vitest run src/ui/utils/todoSnapshot.test.ts src/ui/layouts/DefaultAppLayout.test.tsx src/ui/layouts/ScreenReaderAppLayout.test.tsx src/ui/components/StickyTodoList.test.tsx
  npx vitest run src/ui/AppContainer.test.tsx
  npm run lint

  cd ../..
  npm run typecheck
  npm run build
  node scripts/check-build-status.js
  git diff --check origin/main...HEAD
  ```

- Test results:
  - `todoSnapshot`, `DefaultAppLayout`, `ScreenReaderAppLayout`, `StickyTodoList`: 4 test files passed, 22 tests passed.
  - `AppContainer`: 1 test file passed, 50 tests passed.
  - `packages/cli` lint: passed.
  - `npm run typecheck`: passed.
  - `npm run build`: passed with existing `vscode-ide-companion` lint warnings only: 9 warnings, 0 errors.
  - `node scripts/check-build-status.js`: `Build is up-to-date.`
  - `git diff --check origin/main...HEAD`: passed.

- Prompts / inputs used:
  - Manual local validation used prompts that force `todo_write`, long todo lists, and streaming analysis responses so the sticky panel remains active while output is updating.

- Expected result:
  - The sticky todo panel should remain useful, but it should not duplicate the inline pending `TodoWrite` result.
  - Long todo lists should stay compact.
  - Long todo text should not increase panel height through wrapping.
  - Status-only todo updates should update display state without forcing footer-height remeasurement.

- Observed result:
  - Local testing showed the sticky todo flicker is noticeably improved.
  - Automated tests confirm the new visibility, compact rendering, and layout-key behavior.

- Quickest reviewer verification path:
  ```bash
  cd packages/cli
  npx vitest run src/ui/utils/todoSnapshot.test.ts src/ui/components/StickyTodoList.test.tsx src/ui/layouts/DefaultAppLayout.test.tsx src/ui/layouts/ScreenReaderAppLayout.test.tsx src/ui/AppContainer.test.tsx
  ```

## Scope / Risk

- Main risk or tradeoff: While a pending inline `TodoWrite` result is visible, the sticky panel is hidden to avoid rendering the same todo list twice. The user still sees the todo list inline during that period; the sticky panel returns once the inline pending result is no longer the active pending display.
- Not covered / not validated: I did not capture a Windows PowerShell screen recording in this run. The fix is validated by tests and local manual behavior, but terminal visual flicker still benefits from reviewer visual confirmation on Windows.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- macOS was covered through local `npm run` and `npx vitest` commands.
- Windows visual behavior is based on the root cause reported in #3638 and should be reviewer-verified with a real terminal session.
- Container/sandbox-specific modes were not exercised because this change is limited to CLI TUI rendering and layout behavior.

## Linked Issues / Bugs

Refs #3638
