### PR TITLE
fix(lsp): expose status and startup diagnostics

### DIFF
--- a/docs/users/features/lsp.md
+++ b/docs/users/features/lsp.md
@@ -396,6 +396,17 @@ LSP: enabled, no servers configured
 LSP: enabled, status unavailable
 ```
 
+For per-server details, run `/lsp`:
+
+```text
+**LSP Server Status**
+
+| Server | Command | Languages | Status |
+|--------|---------|-----------|--------|
+| clangd | `clangd` | c, cpp | READY |
+| pyright | `pyright-langserver` | python | FAILED - startup failed |
+```
+
 Common error messages to look for:
 
 ```text
@@ -456,12 +467,16 @@ Start Qwen Code with LSP and debug mode enabled:
 qwen --experimental-lsp --debug
 ```
 
-Then run `/status` for a short summary, or inspect the debug log:
+Then run `/status` for a short summary, `/lsp` for per-server status, or inspect the debug log:
 
 ```bash
+# Default runtime directory
 rg "LSP|Native LSP|<server-name>" ~/.qwen/debug/latest
 # Or:
 grep -E "LSP|Native LSP|<server-name>" ~/.qwen/debug/latest
+
+# If QWEN_RUNTIME_DIR is configured
+rg "LSP|Native LSP|<server-name>" "$QWEN_RUNTIME_DIR/debug/latest"
 ```
 
 LSP uses Qwen Code's normal `--debug` mode; there is no separate LSP debug flag.

--- a/docs/users/features/lsp.md
+++ b/docs/users/features/lsp.md
@@ -344,7 +344,7 @@ You can override trust requirements for specific servers in their configuration:
 2. **Check if the server is installed**: Run the command manually (e.g. `clangd --version`) to verify
 3. **Check the command**: The server binary must be in your system `PATH`, or specified as an absolute path (e.g. `/opt/llvm/bin/clangd`). Relative paths that escape the workspace are blocked
 4. **Check workspace trust**: The workspace must be trusted for LSP (use `/trust`)
-5. **Check logs**: Look for `[LSP]` entries in the debug log (see Debugging section below)
+5. **Check logs**: Start Qwen Code with `--debug`, then search for LSP-related entries in the debug log (see Debugging section below)
 6. **Check the process**: Run `ps aux | grep <server-name>` to verify the server process is running
 
 ### Slow Performance
@@ -361,19 +361,67 @@ You can override trust requirements for specific servers in their configuration:
 
 ### Debugging
 
-LSP debug logs are automatically written to session log files in `~/.qwen/debug/`. To check LSP-related entries:
+LSP does not have a separate debug flag. Use Qwen Code's normal debug mode together with the LSP feature flag:
 
 ```bash
-# View the latest session log
-grep '\[LSP\]' ~/.qwen/debug/latest
-
-# Common error messages to look for:
-#   "command path is unsafe"  → relative path escapes workspace, use absolute path or add to PATH
-#   "command not found"       → server binary not installed or not in PATH
-#   "requires trusted workspace" → run /trust first
+qwen --experimental-lsp --debug
 ```
 
-You can also verify the server process is running:
+Debug logs are written to the session debug log directory. To check LSP-related entries:
+
+```bash
+# Default runtime directory
+rg "LSP|Native LSP|clangd|connection closed" ~/.qwen/debug/latest
+# Or, without ripgrep:
+grep -E "LSP|Native LSP|clangd|connection closed" ~/.qwen/debug/latest
+
+# If QWEN_RUNTIME_DIR is configured
+rg "LSP|Native LSP|clangd|connection closed" "$QWEN_RUNTIME_DIR/debug/latest"
+```
+
+Useful entries include:
+
+- `[LSP] ...`: Logs emitted by the native LSP service and server manager.
+- `[CONFIG] Native LSP status after discovery: ...`: LSP server configuration discovered for the session.
+- `[CONFIG] Native LSP status after startup: ...`: Server startup result, including ready/failed counts.
+- `[STATUS] LSP status snapshot for /status: ...`: Status snapshot printed when running `/status` in debug mode.
+
+You can also run `/status` in the CLI to see a short LSP summary:
+
+```text
+LSP: disabled
+LSP: enabled, 1/1 ready
+LSP: enabled, 0/1 ready (1 failed)
+LSP: enabled, no servers configured
+LSP: enabled, status unavailable
+```
+
+Common error messages to look for:
+
+```text
+command path is unsafe        -> relative path escapes workspace, use absolute path or add to PATH
+command not found             -> server binary not installed or not in PATH
+requires trusted workspace    -> run /trust first
+LSP connection closed         -> server started but exited or closed stdio before replying to initialize
+```
+
+For clangd startup failures, verify the server directly from the project root:
+
+```bash
+clangd --version
+clangd --check=/path/to/file.cpp --log=verbose
+```
+
+C/C++ projects should usually provide a `compile_commands.json` or `compile_flags.txt`. If the compile database is in a build directory, pass it to clangd:
+
+```json
+{
+  "cpp": {
+    "command": "clangd",
+    "args": ["--background-index", "--compile-commands-dir=build"]
+  }
+}
+```
 
 ```bash
 ps aux | grep clangd   # or typescript-language-server, jdtls, etc.
@@ -402,7 +450,21 @@ qwen --experimental-lsp
 
 ### Q: How do I know which language servers are running?
 
-Check the debug log for `[LSP]` entries (`grep '\[LSP\]' ~/.qwen/debug/latest`), or verify the process directly with `ps aux | grep <server-name>`.
+Start Qwen Code with LSP and debug mode enabled:
+
+```bash
+qwen --experimental-lsp --debug
+```
+
+Then run `/status` for a short summary, or inspect the debug log:
+
+```bash
+rg "LSP|Native LSP|<server-name>" ~/.qwen/debug/latest
+# Or:
+grep -E "LSP|Native LSP|<server-name>" ~/.qwen/debug/latest
+```
+
+LSP uses Qwen Code's normal `--debug` mode; there is no separate LSP debug flag.
 
 ### Q: Can I use multiple language servers for the same file type?
 

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -53,6 +53,22 @@ const createNativeLspServiceInstance = () => ({
   workspaceDiagnostics: vi.fn().mockResolvedValue([]),
   codeActions: vi.fn().mockResolvedValue([]),
   applyWorkspaceEdit: vi.fn().mockResolvedValue(false),
+  getStatusSnapshot: vi.fn().mockReturnValue({
+    enabled: true,
+    configuredServers: 1,
+    readyServers: 1,
+    failedServers: 0,
+    inProgressServers: 0,
+    notStartedServers: 0,
+    servers: [
+      {
+        name: 'typescript',
+        status: 'READY',
+        languages: ['typescript'],
+        transport: 'stdio',
+      },
+    ],
+  }),
 });
 
 vi.mock('./trustedFolders.js', () => ({
@@ -1065,6 +1081,28 @@ describe('loadCliConfig', () => {
     expect(lspInstance).toBeDefined();
     expect(lspInstance?.discoverAndPrepare).toHaveBeenCalledTimes(1);
     expect(lspInstance?.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('should collect LSP status snapshots during debug-mode startup', async () => {
+    process.argv = ['node', 'script.js', '--experimental-lsp', '--debug'];
+    const argv = await parseArguments();
+    const settings: Settings = {};
+
+    await loadCliConfig(settings, argv);
+
+    const lspInstance = getLastLspInstance();
+    expect(lspInstance?.getStatusSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not collect LSP status snapshots during normal startup', async () => {
+    process.argv = ['node', 'script.js', '--experimental-lsp'];
+    const argv = await parseArguments();
+    const settings: Settings = {};
+
+    await loadCliConfig(settings, argv);
+
+    const lspInstance = getLastLspInstance();
+    expect(lspInstance?.getStatusSnapshot).not.toHaveBeenCalled();
   });
 
   describe('Proxy configuration', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1800,10 +1800,26 @@ export async function loadCliConfig(
       );
 
       await lspService.discoverAndPrepare();
+      if (config.getDebugMode()) {
+        debugLogger.debug(
+          'Native LSP status after discovery:',
+          lspService.getStatusSnapshot(),
+        );
+      }
       await lspService.start();
+      if (config.getDebugMode()) {
+        debugLogger.debug(
+          'Native LSP status after startup:',
+          lspService.getStatusSnapshot(),
+        );
+      }
       lspClient = new NativeLspClient(lspService);
       config.setLspClient(lspClient);
+      config.setLspInitializationError(undefined);
     } catch (err) {
+      config.setLspInitializationError(
+        err instanceof Error ? err : String(err),
+      );
       debugLogger.warn('Failed to initialize native LSP service:', err);
     }
   }

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1815,11 +1815,21 @@ export async function loadCliConfig(
       }
       lspClient = new NativeLspClient(lspService);
       config.setLspClient(lspClient);
-      config.setLspInitializationError(undefined);
+      try {
+        config.setLspInitializationError(undefined);
+      } catch {
+        debugLogger.warn(
+          'Failed to clear LSP initialization error after initialization',
+        );
+      }
     } catch (err) {
-      config.setLspInitializationError(
-        err instanceof Error ? err : String(err),
-      );
+      try {
+        config.setLspInitializationError(
+          err instanceof Error ? err : String(err),
+        );
+      } catch {
+        debugLogger.warn('LSP init error occurred after initialization:', err);
+      }
       debugLogger.warn('Failed to initialize native LSP service:', err);
     }
   }

--- a/packages/cli/src/services/BuiltinCommandLoader.test.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.test.ts
@@ -125,6 +125,7 @@ describe('BuiltinCommandLoader', () => {
       getUseModelRouter: () => false,
       getDisableAllHooks: vi.fn().mockReturnValue(false),
       getManagedAutoMemoryEnabled: vi.fn().mockReturnValue(true),
+      isLspEnabled: vi.fn().mockReturnValue(false),
     } as unknown as Config;
 
     restoreCommandMock.mockReturnValue({

--- a/packages/cli/src/services/BuiltinCommandLoader.test.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.test.ts
@@ -211,6 +211,22 @@ describe('BuiltinCommandLoader', () => {
     expect(modelCmd?.name).toBe('model');
   });
 
+  it('should include lsp command only when LSP is enabled', async () => {
+    const disabledLoader = new BuiltinCommandLoader(mockConfig);
+    const disabledCommands = await disabledLoader.loadCommands(
+      new AbortController().signal,
+    );
+    expect(disabledCommands.find((c) => c.name === 'lsp')).toBeUndefined();
+
+    (mockConfig.isLspEnabled as Mock).mockReturnValue(true);
+    const enabledLoader = new BuiltinCommandLoader(mockConfig);
+    const enabledCommands = await enabledLoader.loadCommands(
+      new AbortController().signal,
+    );
+
+    expect(enabledCommands.find((c) => c.name === 'lsp')).toBeDefined();
+  });
+
   it('should still load all other commands when ideCommand() throws', async () => {
     // Simulate ideCommand() failure (e.g., platform-specific process detection fails)
     const { ideCommand: ideCommandMock } = await import(

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -62,6 +62,7 @@ import { vimCommand } from '../ui/commands/vimCommand.js';
 import { setupGithubCommand } from '../ui/commands/setupGithubCommand.js';
 import { insightCommand } from '../ui/commands/insightCommand.js';
 import { statuslineCommand } from '../ui/commands/statuslineCommand.js';
+import { lspCommand } from '../ui/commands/lspCommand.js';
 
 const builtinDebugLogger = createDebugLogger('BUILTIN_COMMAND_LOADER');
 
@@ -149,6 +150,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       terminalSetupCommand,
       insightCommand,
       statuslineCommand,
+      ...(this.config?.isLspEnabled() ? [lspCommand] : []),
     ];
 
     return allDefinitions

--- a/packages/cli/src/ui/commands/aboutCommand.test.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.test.ts
@@ -340,5 +340,37 @@ describe('aboutCommand', () => {
       expect(result.content).toContain('abc1234');
       expect(result.content).toContain('vscode');
     });
+
+    it('should include LSP status when available', async () => {
+      if (!aboutCommand.action) throw new Error('No action');
+
+      vi.mocked(systemInfoUtils.getExtendedSystemInfo).mockResolvedValue({
+        cliVersion: 'test-version',
+        osPlatform: 'test-os',
+        osArch: 'x64',
+        osRelease: '22.0.0',
+        nodeVersion: 'v20.0.0',
+        npmVersion: '10.0.0',
+        sandboxEnv: 'no sandbox',
+        modelVersion: 'test-model',
+        selectedAuthType: 'test-auth',
+        ideClient: '',
+        sessionId: 'sess-1',
+        memoryUsage: '100 MB',
+        baseUrl: undefined,
+        lspStatus: 'enabled, 1/1 ready',
+      });
+
+      const nonInteractiveContext = createMockCommandContext({
+        executionMode: 'non_interactive',
+      } as unknown as Partial<CommandContext>);
+
+      const result = (await aboutCommand.action(nonInteractiveContext, '')) as {
+        type: string;
+        content: string;
+      };
+
+      expect(result.content).toContain('LSP: enabled, 1/1 ready');
+    });
   });
 });

--- a/packages/cli/src/ui/commands/aboutCommand.ts
+++ b/packages/cli/src/ui/commands/aboutCommand.ts
@@ -34,6 +34,7 @@ export const aboutCommand: SlashCommand = {
           ? [`Git commit: ${systemInfo.gitCommit}`]
           : []),
         ...(systemInfo.ideClient ? [`IDE: ${systemInfo.ideClient}`] : []),
+        ...(systemInfo.lspStatus ? [`LSP: ${systemInfo.lspStatus}`] : []),
       ];
       return {
         type: 'message' as const,

--- a/packages/cli/src/ui/commands/lspCommand.test.ts
+++ b/packages/cli/src/ui/commands/lspCommand.test.ts
@@ -1,0 +1,209 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { LspClient } from '@qwen-code/qwen-code-core';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { MessageType } from '../types.js';
+import { lspCommand } from './lspCommand.js';
+
+const createConfig = ({
+  enabled = true,
+  client,
+}: {
+  enabled?: boolean;
+  client?: Partial<LspClient>;
+}) => ({
+  isLspEnabled: vi.fn().mockReturnValue(enabled),
+  getLspClient: vi.fn().mockReturnValue(client),
+});
+
+describe('lspCommand', () => {
+  it('returns an error when config is unavailable in non-interactive mode', async () => {
+    if (!lspCommand.action) {
+      throw new Error('lspCommand must have an action');
+    }
+    const context = createMockCommandContext({
+      executionMode: 'non_interactive',
+      services: { config: null },
+    });
+
+    const result = await lspCommand.action(context, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Config not available.',
+    });
+    expect(context.ui.addItem).not.toHaveBeenCalled();
+  });
+
+  it('returns disabled guidance in non-interactive mode', async () => {
+    if (!lspCommand.action) {
+      throw new Error('lspCommand must have an action');
+    }
+    const context = createMockCommandContext({
+      executionMode: 'non_interactive',
+      services: {
+        config: createConfig({ enabled: false }) as unknown as never,
+      },
+    });
+
+    const result = await lspCommand.action(context, '');
+
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'info',
+      content: expect.stringContaining('--experimental-lsp'),
+    });
+    expect(context.ui.addItem).not.toHaveBeenCalled();
+  });
+
+  it('returns guidance when LSP is enabled but no client is connected', async () => {
+    if (!lspCommand.action) {
+      throw new Error('lspCommand must have an action');
+    }
+    const context = createMockCommandContext({
+      executionMode: 'non_interactive',
+      services: {
+        config: createConfig({ client: undefined }) as unknown as never,
+      },
+    });
+
+    const result = await lspCommand.action(context, '');
+
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'info',
+      content: expect.stringContaining('QWEN_RUNTIME_DIR'),
+    });
+    expect(context.ui.addItem).not.toHaveBeenCalled();
+  });
+
+  it('handles clients that do not expose server status', async () => {
+    if (!lspCommand.action) {
+      throw new Error('lspCommand must have an action');
+    }
+    const context = createMockCommandContext({
+      executionMode: 'non_interactive',
+      services: {
+        config: createConfig({ client: {} }) as unknown as never,
+      },
+    });
+
+    const result = await lspCommand.action(context, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'LSP is enabled, but server status is unavailable.',
+    });
+    expect(context.ui.addItem).not.toHaveBeenCalled();
+  });
+
+  it('reports when no LSP servers are configured', async () => {
+    if (!lspCommand.action) {
+      throw new Error('lspCommand must have an action');
+    }
+    const context = createMockCommandContext({
+      executionMode: 'non_interactive',
+      services: {
+        config: createConfig({
+          client: { getServerStatus: vi.fn().mockReturnValue([]) },
+        }) as unknown as never,
+      },
+    });
+
+    const result = await lspCommand.action(context, '');
+
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'info',
+      content: expect.stringContaining('No LSP servers configured'),
+    });
+    expect(context.ui.addItem).not.toHaveBeenCalled();
+  });
+
+  it('renders mixed server status without emoji in non-interactive mode', async () => {
+    if (!lspCommand.action) {
+      throw new Error('lspCommand must have an action');
+    }
+    const context = createMockCommandContext({
+      executionMode: 'non_interactive',
+      services: {
+        config: createConfig({
+          client: {
+            getServerStatus: vi.fn().mockReturnValue([
+              {
+                name: 'clangd',
+                status: 'READY',
+                command: 'clangd',
+                languages: ['c', 'cpp'],
+              },
+              {
+                name: 'pyright',
+                status: 'FAILED',
+                command: 'pyright-langserver',
+                languages: ['python'],
+                error: 'startup failed',
+              },
+            ]),
+          },
+        }) as unknown as never,
+      },
+    });
+
+    const result = await lspCommand.action(context, '');
+
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'info',
+      content: expect.stringContaining('**LSP Server Status**'),
+    });
+    if (!result || result.type !== 'message') {
+      throw new Error('Expected message result');
+    }
+    expect(result.content).toContain('| clangd | `clangd` | c, cpp | READY |');
+    expect(result.content).toContain(
+      '| pyright | `pyright-langserver` | python | FAILED - startup failed |',
+    );
+    expect(result.content).not.toMatch(/[✅⏳❌⚪❓]/u);
+    expect(context.ui.addItem).not.toHaveBeenCalled();
+  });
+
+  it('adds the rendered status to history in interactive mode', async () => {
+    if (!lspCommand.action) {
+      throw new Error('lspCommand must have an action');
+    }
+    const context = createMockCommandContext({
+      services: {
+        config: createConfig({
+          client: {
+            getServerStatus: vi.fn().mockReturnValue([
+              {
+                name: 'clangd',
+                status: 'READY',
+                command: 'clangd',
+                languages: ['cpp'],
+              },
+            ]),
+          },
+        }) as unknown as never,
+      },
+    });
+
+    const result = await lspCommand.action(context, '');
+
+    expect(result).toBeUndefined();
+    expect(context.ui.addItem).toHaveBeenCalledWith(
+      {
+        type: MessageType.INFO,
+        text: expect.stringContaining('| clangd | `clangd` | cpp | READY |'),
+      },
+      expect.any(Number),
+    );
+  });
+});

--- a/packages/cli/src/ui/commands/lspCommand.ts
+++ b/packages/cli/src/ui/commands/lspCommand.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  type CommandContext,
+  type SlashCommand,
+  CommandKind,
+} from './types.js';
+import { MessageType } from '../types.js';
+import { t } from '../../i18n/index.js';
+
+/**
+ * Format LSP server status with an icon.
+ */
+function statusIcon(status: string): string {
+  switch (status) {
+    case 'READY':
+      return '✅';
+    case 'IN_PROGRESS':
+      return '⏳';
+    case 'FAILED':
+      return '❌';
+    case 'NOT_STARTED':
+      return '⚪';
+    default:
+      return '❓';
+  }
+}
+
+export const lspCommand: SlashCommand = {
+  name: 'lsp',
+  get description() {
+    return t('Show LSP server status. Usage: /lsp [status]');
+  },
+  kind: CommandKind.BUILT_IN,
+  supportedModes: ['interactive', 'non_interactive'] as const,
+  action: async (context: CommandContext, _args?: string): Promise<void> => {
+    const config = context.services.config;
+
+    if (!config) {
+      context.ui.addItem(
+        { type: MessageType.ERROR, text: t('Config not available.') },
+        Date.now(),
+      );
+      return;
+    }
+
+    if (!config.isLspEnabled()) {
+      context.ui.addItem(
+        {
+          type: MessageType.INFO,
+          text: t(
+            'LSP is not enabled. Start Qwen Code with `--experimental-lsp` to enable LSP support.',
+          ),
+        },
+        Date.now(),
+      );
+      return;
+    }
+
+    const client = config.getLspClient();
+    if (!client) {
+      context.ui.addItem(
+        {
+          type: MessageType.INFO,
+          text: t(
+            "LSP is enabled but no client is connected. Check debug logs: `grep '[LSP]' ~/.qwen/debug/latest`",
+          ),
+        },
+        Date.now(),
+      );
+      return;
+    }
+
+    // Get server status via the client
+    const servers = client.getServerStatus();
+
+    if (servers.length === 0) {
+      context.ui.addItem(
+        {
+          type: MessageType.INFO,
+          text: t(
+            'No LSP servers configured. Add a `.lsp.json` file to your project root. See `/help` for details.',
+          ),
+        },
+        Date.now(),
+      );
+      return;
+    }
+
+    // Build status table
+    const lines: string[] = ['**LSP Server Status**', ''];
+    lines.push('| Server | Command | Languages | Status |');
+    lines.push('|--------|---------|-----------|--------|');
+
+    for (const server of servers) {
+      const icon = statusIcon(server.status);
+      const cmd = server.command ?? '(n/a)';
+      const langs = server.languages.join(', ') || '(auto)';
+      const statusText = server.error
+        ? `${icon} ${server.status} — ${server.error}`
+        : `${icon} ${server.status}`;
+      lines.push(`| ${server.name} | \`${cmd}\` | ${langs} | ${statusText} |`);
+    }
+
+    context.ui.addItem(
+      { type: MessageType.INFO, text: lines.join('\n') },
+      Date.now(),
+    );
+  },
+};

--- a/packages/cli/src/ui/commands/lspCommand.ts
+++ b/packages/cli/src/ui/commands/lspCommand.ts
@@ -6,28 +6,33 @@
 
 import {
   type CommandContext,
+  type MessageActionReturn,
   type SlashCommand,
   CommandKind,
 } from './types.js';
 import { MessageType } from '../types.js';
 import { t } from '../../i18n/index.js';
 
-/**
- * Format LSP server status with an icon.
- */
-function statusIcon(status: string): string {
-  switch (status) {
-    case 'READY':
-      return '✅';
-    case 'IN_PROGRESS':
-      return '⏳';
-    case 'FAILED':
-      return '❌';
-    case 'NOT_STARTED':
-      return '⚪';
-    default:
-      return '❓';
+function emitMessage(
+  context: CommandContext,
+  messageType: 'info' | 'error',
+  content: string,
+): MessageActionReturn | void {
+  if (context.executionMode !== 'interactive') {
+    return {
+      type: 'message',
+      messageType,
+      content,
+    };
   }
+
+  context.ui.addItem(
+    {
+      type: messageType === 'error' ? MessageType.ERROR : MessageType.INFO,
+      text: content,
+    },
+    Date.now(),
+  );
 }
 
 export const lspCommand: SlashCommand = {
@@ -37,78 +42,70 @@ export const lspCommand: SlashCommand = {
   },
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive', 'non_interactive'] as const,
-  action: async (context: CommandContext, _args?: string): Promise<void> => {
+  action: async (
+    context: CommandContext,
+    _args?: string,
+  ): Promise<MessageActionReturn | void> => {
     const config = context.services.config;
 
     if (!config) {
-      context.ui.addItem(
-        { type: MessageType.ERROR, text: t('Config not available.') },
-        Date.now(),
-      );
-      return;
+      return emitMessage(context, 'error', t('Config not available.'));
     }
 
     if (!config.isLspEnabled()) {
-      context.ui.addItem(
-        {
-          type: MessageType.INFO,
-          text: t(
-            'LSP is not enabled. Start Qwen Code with `--experimental-lsp` to enable LSP support.',
-          ),
-        },
-        Date.now(),
+      return emitMessage(
+        context,
+        'info',
+        t(
+          'LSP is not enabled. Start Qwen Code with `--experimental-lsp` to enable LSP support.',
+        ),
       );
-      return;
     }
 
     const client = config.getLspClient();
     if (!client) {
-      context.ui.addItem(
-        {
-          type: MessageType.INFO,
-          text: t(
-            "LSP is enabled but no client is connected. Check debug logs: `grep '[LSP]' ~/.qwen/debug/latest`",
-          ),
-        },
-        Date.now(),
+      return emitMessage(
+        context,
+        'info',
+        t(
+          'LSP is enabled but no client is connected. Check debug logs under `${QWEN_RUNTIME_DIR:-~/.qwen}/debug/` or see the LSP troubleshooting docs.',
+        ),
       );
-      return;
     }
 
-    // Get server status via the client
+    if (!client.getServerStatus) {
+      return emitMessage(
+        context,
+        'info',
+        t('LSP is enabled, but server status is unavailable.'),
+      );
+    }
+
     const servers = client.getServerStatus();
 
     if (servers.length === 0) {
-      context.ui.addItem(
-        {
-          type: MessageType.INFO,
-          text: t(
-            'No LSP servers configured. Add a `.lsp.json` file to your project root. See `/help` for details.',
-          ),
-        },
-        Date.now(),
+      return emitMessage(
+        context,
+        'info',
+        t(
+          'No LSP servers configured. Add a `.lsp.json` file to your project root. See `/help` for details.',
+        ),
       );
-      return;
     }
 
-    // Build status table
     const lines: string[] = ['**LSP Server Status**', ''];
     lines.push('| Server | Command | Languages | Status |');
     lines.push('|--------|---------|-----------|--------|');
 
     for (const server of servers) {
-      const icon = statusIcon(server.status);
       const cmd = server.command ?? '(n/a)';
       const langs = server.languages.join(', ') || '(auto)';
       const statusText = server.error
-        ? `${icon} ${server.status} — ${server.error}`
-        : `${icon} ${server.status}`;
+        ? `${server.status} - ${server.error}`
+        : server.status;
       lines.push(`| ${server.name} | \`${cmd}\` | ${langs} | ${statusText} |`);
     }
 
-    context.ui.addItem(
-      { type: MessageType.INFO, text: lines.join('\n') },
-      Date.now(),
-    );
+    return emitMessage(context, 'info', lines.join('\n'));
   },
 };

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -163,6 +163,7 @@ export type HistoryItemAbout = HistoryItemBase & {
     memoryUsage: string;
     baseUrl?: string;
     gitCommit?: string;
+    lspStatus?: string;
   };
 };
 
@@ -627,6 +628,7 @@ export type Message =
         memoryUsage: string;
         baseUrl?: string;
         gitCommit?: string;
+        lspStatus?: string;
       };
       content?: string; // Optional content, not really used for ABOUT
     }

--- a/packages/cli/src/utils/systemInfo.test.ts
+++ b/packages/cli/src/utils/systemInfo.test.ts
@@ -333,5 +333,68 @@ describe('systemInfo', () => {
 
       expect(extendedInfo.baseUrl).toBeUndefined();
     });
+
+    it('should include formatted LSP status when config exposes it', async () => {
+      vi.mocked(IdeClient.getInstance).mockResolvedValue({
+        getDetectedIdeDisplayName: vi.fn().mockReturnValue(''),
+      } as unknown as IdeClient);
+      const getLspStatusSnapshot = vi.fn().mockReturnValue({
+        enabled: true,
+        configuredServers: 2,
+        readyServers: 1,
+        failedServers: 1,
+        inProgressServers: 0,
+        notStartedServers: 0,
+        servers: [
+          {
+            name: 'clangd',
+            status: 'READY',
+            languages: ['cpp'],
+            transport: 'stdio',
+          },
+          {
+            name: 'pyright',
+            status: 'FAILED',
+            languages: ['python'],
+            transport: 'stdio',
+            error: 'startup failed',
+          },
+        ],
+      });
+      mockContext.services.config = {
+        ...(mockContext.services.config ?? {}),
+        getLspStatusSnapshot,
+        getDebugMode: vi.fn().mockReturnValue(false),
+      } as unknown as CommandContext['services']['config'];
+
+      const extendedInfo = await getExtendedSystemInfo(mockContext);
+
+      expect(getLspStatusSnapshot).toHaveBeenCalledTimes(1);
+      expect(extendedInfo.lspStatus).toBe('enabled, 1/2 ready (1 failed)');
+    });
+
+    it('should report unavailable LSP status distinctly', async () => {
+      vi.mocked(IdeClient.getInstance).mockResolvedValue({
+        getDetectedIdeDisplayName: vi.fn().mockReturnValue(''),
+      } as unknown as IdeClient);
+      mockContext.services.config = {
+        ...(mockContext.services.config ?? {}),
+        getLspStatusSnapshot: vi.fn().mockReturnValue({
+          enabled: true,
+          configuredServers: 0,
+          readyServers: 0,
+          failedServers: 0,
+          inProgressServers: 0,
+          notStartedServers: 0,
+          servers: [],
+          statusUnavailable: true,
+        }),
+        getDebugMode: vi.fn().mockReturnValue(false),
+      } as unknown as CommandContext['services']['config'];
+
+      const extendedInfo = await getExtendedSystemInfo(mockContext);
+
+      expect(extendedInfo.lspStatus).toBe('enabled, status unavailable');
+    });
   });
 });

--- a/packages/cli/src/utils/systemInfo.test.ts
+++ b/packages/cli/src/utils/systemInfo.test.ts
@@ -396,5 +396,94 @@ describe('systemInfo', () => {
 
       expect(extendedInfo.lspStatus).toBe('enabled, status unavailable');
     });
+
+    it('should omit LSP status when the status snapshot throws', async () => {
+      vi.mocked(IdeClient.getInstance).mockResolvedValue({
+        getDetectedIdeDisplayName: vi.fn().mockReturnValue(''),
+      } as unknown as IdeClient);
+      mockContext.services.config = {
+        ...(mockContext.services.config ?? {}),
+        getLspStatusSnapshot: vi.fn(() => {
+          throw new Error('snapshot failed');
+        }),
+        getDebugMode: vi.fn().mockReturnValue(false),
+      } as unknown as CommandContext['services']['config'];
+
+      const extendedInfo = await getExtendedSystemInfo(mockContext);
+
+      expect(extendedInfo.lspStatus).toBeUndefined();
+    });
+
+    it.each([
+      [
+        'disabled',
+        {
+          enabled: false,
+          configuredServers: 0,
+          readyServers: 0,
+          failedServers: 0,
+          inProgressServers: 0,
+          notStartedServers: 0,
+          servers: [],
+        },
+        'disabled',
+      ],
+      [
+        'initialization failed',
+        {
+          enabled: true,
+          configuredServers: 0,
+          readyServers: 0,
+          failedServers: 0,
+          inProgressServers: 0,
+          notStartedServers: 0,
+          servers: [],
+          initializationError: 'discovery failed',
+        },
+        'enabled, initialization failed: discovery failed',
+      ],
+      [
+        'no servers configured',
+        {
+          enabled: true,
+          configuredServers: 0,
+          readyServers: 0,
+          failedServers: 0,
+          inProgressServers: 0,
+          notStartedServers: 0,
+          servers: [],
+        },
+        'enabled, no servers configured',
+      ],
+      [
+        'starting and not-started servers',
+        {
+          enabled: true,
+          configuredServers: 3,
+          readyServers: 1,
+          failedServers: 0,
+          inProgressServers: 1,
+          notStartedServers: 1,
+          servers: [],
+        },
+        'enabled, 1/3 ready (1 starting, 1 not started)',
+      ],
+    ])(
+      'should format LSP status when %s',
+      async (_name, snapshot, expected) => {
+        vi.mocked(IdeClient.getInstance).mockResolvedValue({
+          getDetectedIdeDisplayName: vi.fn().mockReturnValue(''),
+        } as unknown as IdeClient);
+        mockContext.services.config = {
+          ...(mockContext.services.config ?? {}),
+          getLspStatusSnapshot: vi.fn().mockReturnValue(snapshot),
+          getDebugMode: vi.fn().mockReturnValue(false),
+        } as unknown as CommandContext['services']['config'];
+
+        const extendedInfo = await getExtendedSystemInfo(mockContext);
+
+        expect(extendedInfo.lspStatus).toBe(expected);
+      },
+    );
   });
 });

--- a/packages/cli/src/utils/systemInfo.ts
+++ b/packages/cli/src/utils/systemInfo.ts
@@ -9,9 +9,16 @@ import os from 'node:os';
 import { execSync } from 'node:child_process';
 import type { CommandContext } from '../ui/commands/types.js';
 import { getCliVersion } from './version.js';
-import { IdeClient, AuthType } from '@qwen-code/qwen-code-core';
+import {
+  IdeClient,
+  AuthType,
+  createDebugLogger,
+  type LspStatusSnapshot,
+} from '@qwen-code/qwen-code-core';
 import { formatMemoryUsage } from '../ui/utils/formatters.js';
 import { GIT_COMMIT_INFO } from '../generated/git-commit.js';
+
+const debugLogger = createDebugLogger('STATUS');
 
 /**
  * System information interface containing all system-related details
@@ -42,6 +49,7 @@ export interface ExtendedSystemInfo extends SystemInfo {
   gitCommit?: string;
   proxy?: string;
   fastModel?: string;
+  lspStatus?: string;
 }
 
 /**
@@ -185,6 +193,7 @@ export async function getExtendedSystemInfo(
 
   // Get fast model from settings
   const fastModel = context.services.settings?.merged?.fastModel || undefined;
+  const lspStatus = getLspStatus(context);
 
   return {
     ...baseInfo,
@@ -194,5 +203,50 @@ export async function getExtendedSystemInfo(
     apiKeyEnvKey,
     gitCommit,
     fastModel,
+    lspStatus,
   };
+}
+
+function getLspStatus(context: CommandContext): string | undefined {
+  const snapshot = context.services.config?.getLspStatusSnapshot?.();
+  if (!snapshot) {
+    return undefined;
+  }
+
+  if (context.services.config?.getDebugMode?.()) {
+    debugLogger.debug('LSP status snapshot for /status:', snapshot);
+  }
+
+  return formatLspStatusSnapshot(snapshot);
+}
+
+function formatLspStatusSnapshot(snapshot: LspStatusSnapshot): string {
+  if (!snapshot.enabled) {
+    return 'disabled';
+  }
+
+  if (snapshot.initializationError) {
+    return `enabled, initialization failed: ${snapshot.initializationError}`;
+  }
+
+  if (snapshot.statusUnavailable) {
+    return 'enabled, status unavailable';
+  }
+
+  if (snapshot.configuredServers === 0) {
+    return 'enabled, no servers configured';
+  }
+
+  const details = [
+    snapshot.failedServers > 0 ? `${snapshot.failedServers} failed` : '',
+    snapshot.inProgressServers > 0
+      ? `${snapshot.inProgressServers} starting`
+      : '',
+    snapshot.notStartedServers > 0
+      ? `${snapshot.notStartedServers} not started`
+      : '',
+  ].filter(Boolean);
+
+  const detailText = details.length > 0 ? ` (${details.join(', ')})` : '';
+  return `enabled, ${snapshot.readyServers}/${snapshot.configuredServers} ready${detailText}`;
 }

--- a/packages/cli/src/utils/systemInfo.ts
+++ b/packages/cli/src/utils/systemInfo.ts
@@ -208,16 +208,26 @@ export async function getExtendedSystemInfo(
 }
 
 function getLspStatus(context: CommandContext): string | undefined {
-  const snapshot = context.services.config?.getLspStatusSnapshot?.();
-  if (!snapshot) {
+  try {
+    const snapshot = context.services.config?.getLspStatusSnapshot?.();
+    if (!snapshot) {
+      return undefined;
+    }
+
+    if (context.services.config?.getDebugMode?.()) {
+      debugLogger.debug('LSP status snapshot for /status:', snapshot);
+    }
+
+    return formatLspStatusSnapshot(snapshot);
+  } catch (error) {
+    if (context.services.config?.getDebugMode?.()) {
+      debugLogger.debug(
+        'Unable to read LSP status snapshot for /status:',
+        error,
+      );
+    }
     return undefined;
   }
-
-  if (context.services.config?.getDebugMode?.()) {
-    debugLogger.debug('LSP status snapshot for /status:', snapshot);
-  }
-
-  return formatLspStatusSnapshot(snapshot);
 }
 
 function formatLspStatusSnapshot(snapshot: LspStatusSnapshot): string {

--- a/packages/cli/src/utils/systemInfoFields.test.ts
+++ b/packages/cli/src/utils/systemInfoFields.test.ts
@@ -21,6 +21,7 @@ describe('getAboutSystemInfoFields', () => {
       modelVersion: 'test-model',
       selectedAuthType: 'test-auth',
       ideClient: 'test-ide',
+      lspStatus: 'enabled, 1/1 ready',
       sessionId: 'test-session-id',
       memoryUsage: '100 MB',
       baseUrl: undefined,
@@ -35,6 +36,7 @@ describe('getAboutSystemInfoFields', () => {
       'Qwen Code',
       'Runtime',
       'IDE Client',
+      'LSP',
       'OS',
       'Auth',
       'Model',
@@ -49,6 +51,9 @@ describe('getAboutSystemInfoFields', () => {
       labels.indexOf('Sandbox'),
     );
     expect(labels.indexOf('Session ID')).toBeLessThan(labels.indexOf('Proxy'));
+
+    const lspField = fields.find((f) => f.label === 'LSP');
+    expect(lspField?.value).toBe('enabled, 1/1 ready');
 
     const proxyField = fields.find((f) => f.label === 'Proxy');
     expect(proxyField?.value).toBe('http://***:***@localhost:7890/');

--- a/packages/cli/src/utils/systemInfoFields.ts
+++ b/packages/cli/src/utils/systemInfoFields.ts
@@ -30,6 +30,7 @@ export function getSystemInfoFields(
   addField(fields, t('Qwen Code'), formatCliVersion(info));
   addField(fields, t('Runtime'), formatRuntime(info));
   addField(fields, t('IDE Client'), info.ideClient);
+  addField(fields, 'LSP', info.lspStatus ?? '');
   addField(fields, t('OS'), formatOs(info));
   addField(fields, t('Auth'), formatAuth(info));
   addField(fields, t('Base URL'), formatBaseUrl(info));

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -407,6 +407,69 @@ describe('Server Config (config.ts)', () => {
     });
   });
 
+  it('should expose LSP status from the configured client', () => {
+    const getStatusSnapshot = vi.fn().mockReturnValue({
+      enabled: true,
+      configuredServers: 1,
+      readyServers: 1,
+      failedServers: 0,
+      inProgressServers: 0,
+      notStartedServers: 0,
+      servers: [
+        {
+          name: 'clangd',
+          status: 'READY',
+          languages: ['cpp'],
+          transport: 'stdio',
+        },
+      ],
+    });
+    const config = new Config({
+      ...baseParams,
+      lsp: { enabled: true },
+      lspClient: {
+        getStatusSnapshot,
+      } as unknown as ConfigParameters['lspClient'],
+    });
+
+    expect(config.getLspStatusSnapshot()).toEqual({
+      enabled: true,
+      configuredServers: 1,
+      readyServers: 1,
+      failedServers: 0,
+      inProgressServers: 0,
+      notStartedServers: 0,
+      servers: [
+        {
+          name: 'clangd',
+          status: 'READY',
+          languages: ['cpp'],
+          transport: 'stdio',
+        },
+      ],
+    });
+    expect(getStatusSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it('should report unavailable LSP status when client lacks a status snapshot API', () => {
+    const config = new Config({
+      ...baseParams,
+      lsp: { enabled: true },
+      lspClient: {} as unknown as ConfigParameters['lspClient'],
+    });
+
+    expect(config.getLspStatusSnapshot()).toEqual({
+      enabled: true,
+      configuredServers: 0,
+      readyServers: 0,
+      failedServers: 0,
+      inProgressServers: 0,
+      notStartedServers: 0,
+      servers: [],
+      statusUnavailable: true,
+    });
+  });
+
   describe('initialize', () => {
     it('should throw an error if checkpointing is enabled and GitService fails', async () => {
       const gitError = new Error('Git is not installed');

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -470,6 +470,50 @@ describe('Server Config (config.ts)', () => {
     });
   });
 
+  it('should merge initialization errors into the client LSP status snapshot', () => {
+    const config = new Config({
+      ...baseParams,
+      lsp: { enabled: true },
+      lspClient: {
+        getStatusSnapshot: vi.fn().mockReturnValue({
+          enabled: true,
+          configuredServers: 1,
+          readyServers: 0,
+          failedServers: 1,
+          inProgressServers: 0,
+          notStartedServers: 0,
+          servers: [],
+          initializationError: 'client failed',
+        }),
+      } as unknown as ConfigParameters['lspClient'],
+    });
+
+    config.setLspInitializationError('discovery failed');
+
+    expect(config.getLspStatusSnapshot()).toMatchObject({
+      enabled: true,
+      initializationError: 'discovery failed',
+    });
+  });
+
+  it('should report an initialization error when LSP is enabled without a client', () => {
+    const config = new Config({
+      ...baseParams,
+      lsp: { enabled: true },
+    });
+
+    expect(config.getLspStatusSnapshot()).toEqual({
+      enabled: true,
+      configuredServers: 0,
+      readyServers: 0,
+      failedServers: 0,
+      inProgressServers: 0,
+      notStartedServers: 0,
+      servers: [],
+      initializationError: 'LSP client is not initialized',
+    });
+  });
+
   describe('initialize', () => {
     it('should throw an error if checkpointing is enabled and GitService fails', async () => {
       const gitError = new Error('Git is not installed');

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -60,7 +60,7 @@ import { canUseRipgrep } from '../utils/ripgrepUtils.js';
 import { recordStartupEvent } from '../utils/startupEventSink.js';
 import { ToolRegistry, type ToolFactory } from '../tools/tool-registry.js';
 import { ToolNames } from '../tools/tool-names.js';
-import type { LspClient } from '../lsp/types.js';
+import type { LspClient, LspStatusSnapshot } from '../lsp/types.js';
 
 // Other modules
 import { ideContextStore } from '../ide/ideContext.js';
@@ -726,6 +726,7 @@ export class Config {
   private mcpServers: Record<string, MCPServerConfig> | undefined;
   private readonly lspEnabled: boolean;
   private lspClient?: LspClient;
+  private lspInitializationError?: string;
   private readonly allowedMcpServers?: string[];
   private excludedMcpServers?: string[];
   private sessionSubagents: SubagentConfig[];
@@ -2297,6 +2298,50 @@ export class Config {
     return this.lspClient;
   }
 
+  getLspStatusSnapshot(): LspStatusSnapshot {
+    if (!this.isLspEnabled()) {
+      return this.createLspStatusSnapshot(false);
+    }
+
+    const clientSnapshot = this.lspClient?.getStatusSnapshot?.();
+    if (clientSnapshot) {
+      return {
+        ...clientSnapshot,
+        enabled: true,
+        initializationError:
+          this.lspInitializationError ?? clientSnapshot.initializationError,
+      };
+    }
+
+    if (this.lspClient) {
+      return {
+        ...this.createLspStatusSnapshot(true),
+        statusUnavailable: true,
+      };
+    }
+
+    return this.createLspStatusSnapshot(
+      true,
+      this.lspInitializationError ?? 'LSP client is not initialized',
+    );
+  }
+
+  private createLspStatusSnapshot(
+    enabled: boolean,
+    initializationError?: string,
+  ): LspStatusSnapshot {
+    return {
+      enabled,
+      configuredServers: 0,
+      readyServers: 0,
+      failedServers: 0,
+      inProgressServers: 0,
+      notStartedServers: 0,
+      servers: [],
+      ...(initializationError ? { initializationError } : {}),
+    };
+  }
+
   /**
    * Allows wiring an LSP client after Config construction but before initialize().
    */
@@ -2305,6 +2350,14 @@ export class Config {
       throw new Error('Cannot set LSP client after initialization');
     }
     this.lspClient = client;
+  }
+
+  setLspInitializationError(error: Error | string | undefined): void {
+    if (this.initialized) {
+      throw new Error('Cannot set LSP status after initialization');
+    }
+    this.lspInitializationError =
+      error instanceof Error ? error.message : error;
   }
 
   getSessionSubagents(): SubagentConfig[] {

--- a/packages/core/src/lsp/LspConnectionFactory.test.ts
+++ b/packages/core/src/lsp/LspConnectionFactory.test.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { LspConnectionFactory } from './LspConnectionFactory.js';
+
+describe('LspConnectionFactory', () => {
+  it('captures stderr and exit code when stdio server closes during initialize', async () => {
+    const connection = await LspConnectionFactory.createStdioConnection(
+      process.execPath,
+      [
+        '-e',
+        'process.stderr.write("clangd failed before initialize\\n"); process.exit(7);',
+      ],
+    );
+
+    await expect(connection.connection.initialize({})).rejects.toThrow(
+      'LSP connection closed',
+    );
+
+    if (!connection.processDiagnostics) {
+      throw new Error('Expected process diagnostics for stdio connection');
+    }
+    const diagnostics = connection.processDiagnostics;
+
+    expect(diagnostics.stderrTail).toContain('clangd failed before initialize');
+    expect(diagnostics.exitCode).toBe(7);
+    expect(diagnostics.exitSignal).toBeNull();
+  });
+});

--- a/packages/core/src/lsp/LspConnectionFactory.test.ts
+++ b/packages/core/src/lsp/LspConnectionFactory.test.ts
@@ -30,4 +30,26 @@ describe('LspConnectionFactory', () => {
     expect(diagnostics.exitCode).toBe(7);
     expect(diagnostics.exitSignal).toBeNull();
   });
+
+  it('preserves UTF-8 characters split across stderr chunks', async () => {
+    const connection = await LspConnectionFactory.createStdioConnection(
+      process.execPath,
+      [
+        '-e',
+        [
+          'process.stderr.write(Buffer.from([0xe2]));',
+          'setTimeout(() => {',
+          'process.stderr.write(Buffer.from([0x98, 0x83, 0x0a]));',
+          'process.exit(7);',
+          '}, 10);',
+        ].join(''),
+      ],
+    );
+
+    await expect(connection.connection.initialize({})).rejects.toThrow(
+      'LSP connection closed',
+    );
+
+    expect(connection.processDiagnostics?.stderrTail).toContain('☃');
+  });
 });

--- a/packages/core/src/lsp/LspConnectionFactory.ts
+++ b/packages/core/src/lsp/LspConnectionFactory.ts
@@ -7,10 +7,19 @@
 import * as cp from 'node:child_process';
 import * as net from 'node:net';
 import { DEFAULT_LSP_REQUEST_TIMEOUT_MS } from './constants.js';
-import type { JsonRpcMessage } from './types.js';
+import type { JsonRpcMessage, LspProcessDiagnostics } from './types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 
 const debugLogger = createDebugLogger('LSP');
+const MAX_STDERR_TAIL_BYTES = 8192;
+
+function trimTail(value: string, maxBytes: number): string {
+  const buffer = Buffer.from(value, 'utf8');
+  if (buffer.byteLength <= maxBytes) {
+    return value;
+  }
+  return buffer.subarray(buffer.byteLength - maxBytes).toString('utf8');
+}
 
 interface PendingRequest {
   resolve: (value: unknown) => void;
@@ -236,6 +245,7 @@ class JsonRpcConnection {
 interface LspConnection {
   connection: JsonRpcConnection;
   process?: cp.ChildProcess;
+  processDiagnostics?: LspProcessDiagnostics;
   socket?: net.Socket;
 }
 
@@ -260,6 +270,9 @@ export class LspConnectionFactory {
         stdio: 'pipe',
         ...options,
       };
+      const processDiagnostics: LspProcessDiagnostics = {
+        stderrTail: '',
+      };
       const processInstance = cp.spawn(command, args, spawnOptions);
 
       const timeoutId = setTimeout(() => {
@@ -282,18 +295,36 @@ export class LspConnectionFactory {
           return;
         }
 
+        processInstance.stderr?.on('data', (chunk: Buffer) => {
+          processDiagnostics.stderrTail = trimTail(
+            processDiagnostics.stderrTail + chunk.toString('utf8'),
+            MAX_STDERR_TAIL_BYTES,
+          );
+        });
+
         const connection = new JsonRpcConnection(
           (payload) => processInstance.stdin?.write(payload),
           () => processInstance.stdin?.end(),
         );
 
         connection.listen(processInstance.stdout);
-        processInstance.once('exit', () => connection.end());
-        processInstance.once('close', () => connection.end());
+        const recordProcessExit = (
+          code: number | null,
+          signal: NodeJS.Signals | null,
+        ) => {
+          processDiagnostics.exitCode = code;
+          processDiagnostics.exitSignal = signal;
+        };
+        processInstance.once('exit', recordProcessExit);
+        processInstance.once('close', (code, signal) => {
+          recordProcessExit(code, signal);
+          connection.end();
+        });
 
         resolve({
           connection,
           process: processInstance,
+          processDiagnostics,
         });
       });
     });

--- a/packages/core/src/lsp/LspConnectionFactory.ts
+++ b/packages/core/src/lsp/LspConnectionFactory.ts
@@ -309,6 +309,9 @@ export class LspConnectionFactory {
             MAX_STDERR_TAIL_BYTES,
           );
         });
+        processInstance.stderr?.on('error', (err) => {
+          debugLogger.warn(`LSP stderr stream error for ${command}:`, err);
+        });
 
         const connection = new JsonRpcConnection(
           (payload) => processInstance.stdin?.write(payload),

--- a/packages/core/src/lsp/LspConnectionFactory.ts
+++ b/packages/core/src/lsp/LspConnectionFactory.ts
@@ -6,6 +6,7 @@
 
 import * as cp from 'node:child_process';
 import * as net from 'node:net';
+import { StringDecoder } from 'node:string_decoder';
 import { DEFAULT_LSP_REQUEST_TIMEOUT_MS } from './constants.js';
 import type { JsonRpcMessage, LspProcessDiagnostics } from './types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
@@ -295,9 +296,16 @@ export class LspConnectionFactory {
           return;
         }
 
+        const stderrDecoder = new StringDecoder('utf8');
         processInstance.stderr?.on('data', (chunk: Buffer) => {
           processDiagnostics.stderrTail = trimTail(
-            processDiagnostics.stderrTail + chunk.toString('utf8'),
+            processDiagnostics.stderrTail + stderrDecoder.write(chunk),
+            MAX_STDERR_TAIL_BYTES,
+          );
+        });
+        processInstance.stderr?.on('end', () => {
+          processDiagnostics.stderrTail = trimTail(
+            processDiagnostics.stderrTail + stderrDecoder.end(),
             MAX_STDERR_TAIL_BYTES,
           );
         });

--- a/packages/core/src/lsp/LspServerManager.test.ts
+++ b/packages/core/src/lsp/LspServerManager.test.ts
@@ -5,11 +5,33 @@
  */
 
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import type { Config as CoreConfig } from '../config/config.js';
 import type { FileDiscoveryService } from '../services/fileDiscoveryService.js';
 import type { WorkspaceContext } from '../utils/workspaceContext.js';
 import { LspServerManager } from './LspServerManager.js';
+import type { LspConnectionResult, LspServerConfig } from './types.js';
+
+const debugLoggerMock = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock('../utils/debugLogger.js', () => ({
+  createDebugLogger: vi.fn(() => debugLoggerMock),
+}));
+
+const serverConfig: LspServerConfig = {
+  name: 'clangd',
+  languages: ['cpp'],
+  command: 'clangd',
+  args: [],
+  transport: 'stdio',
+  rootUri: 'file:///workspace',
+  workspaceFolder: '/workspace',
+};
 
 type PathSafeManager = {
   isPathSafe(command: string, workspacePath: string, cwd?: string): boolean;
@@ -90,5 +112,71 @@ describe('LspServerManager', () => {
         manager.isPathSafe('tools/clangd', workspaceRoot, workspaceRoot),
       ).toBe(true);
     });
+  });
+
+  it('logs process diagnostics when startup fails after connection creation', async () => {
+    const manager = new LspServerManager(
+      {
+        isTrustedFolder: vi.fn().mockReturnValue(true),
+      } as unknown as CoreConfig,
+      {} as WorkspaceContext,
+      {} as FileDiscoveryService,
+      {
+        requireTrustedWorkspace: false,
+        workspaceRoot: '/workspace',
+      },
+    );
+    const processDiagnostics = {
+      stderrTail: 'clangd: unknown argument\n',
+      exitCode: 7,
+      exitSignal: null,
+    };
+    vi.spyOn(
+      manager as unknown as {
+        checkWorkspaceTrust: () => Promise<boolean>;
+      },
+      'checkWorkspaceTrust',
+    ).mockResolvedValue(true);
+    vi.spyOn(
+      manager as unknown as {
+        commandExists: () => Promise<boolean>;
+      },
+      'commandExists',
+    ).mockResolvedValue(true);
+    vi.spyOn(
+      manager as unknown as {
+        isPathSafe: () => boolean;
+      },
+      'isPathSafe',
+    ).mockReturnValue(true);
+    vi.spyOn(
+      manager as unknown as {
+        createLspConnection: (
+          config: LspServerConfig,
+        ) => Promise<LspConnectionResult>;
+      },
+      'createLspConnection',
+    ).mockResolvedValue({
+      connection: {},
+      processDiagnostics,
+    } as unknown as LspConnectionResult);
+    vi.spyOn(
+      manager as unknown as {
+        initializeLspServer: () => Promise<void>;
+      },
+      'initializeLspServer',
+    ).mockRejectedValue(new Error('initialize failed'));
+
+    manager.setServerConfigs([serverConfig]);
+    await manager.startAll();
+
+    expect(debugLoggerMock.error).toHaveBeenCalledWith(
+      'LSP server clangd process diagnostics:',
+      processDiagnostics,
+    );
+    expect(debugLoggerMock.error).toHaveBeenCalledWith(
+      'LSP server clangd failed to start:',
+      expect.any(Error),
+    );
   });
 });

--- a/packages/core/src/lsp/LspServerManager.ts
+++ b/packages/core/src/lsp/LspServerManager.ts
@@ -265,6 +265,7 @@ export class LspServerManager {
       const connection = await this.createLspConnection(handle.config);
       handle.connection = connection.connection;
       handle.process = connection.process;
+      handle.processDiagnostics = connection.processDiagnostics;
 
       // Initialize LSP server
       await this.initializeLspServer(connection, handle.config);
@@ -275,6 +276,12 @@ export class LspServerManager {
     } catch (error) {
       handle.status = 'FAILED';
       handle.error = error as Error;
+      if (handle.processDiagnostics) {
+        debugLogger.error(
+          `LSP server ${name} process diagnostics:`,
+          handle.processDiagnostics,
+        );
+      }
       debugLogger.error(`LSP server ${name} failed to start:`, error);
     }
   }
@@ -299,6 +306,7 @@ export class LspServerManager {
     }
     handle.connection = undefined;
     handle.process = undefined;
+    handle.processDiagnostics = undefined;
     handle.status = 'NOT_STARTED';
     handle.warmedUp = false;
     handle.restartAttempts = 0;
@@ -368,6 +376,7 @@ export class LspServerManager {
     }
     handle.connection = undefined;
     handle.process = undefined;
+    handle.processDiagnostics = undefined;
     handle.status = 'NOT_STARTED';
     handle.error = undefined;
     handle.warmedUp = false;
@@ -442,6 +451,7 @@ export class LspServerManager {
       return {
         connection: lspConnection.connection,
         process: lspConnection.process as ChildProcess,
+        processDiagnostics: lspConnection.processDiagnostics,
         shutdown: async () => {
           await lspConnection.connection.shutdown();
         },

--- a/packages/core/src/lsp/NativeLspClient.test.ts
+++ b/packages/core/src/lsp/NativeLspClient.test.ts
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { NativeLspClient } from './NativeLspClient.js';
+import type { NativeLspService } from './NativeLspService.js';
+import type { LspServerHandle } from './types.js';
+
+const createHandle = (overrides: Partial<LspServerHandle>): LspServerHandle =>
+  ({
+    config: {
+      name: 'clangd',
+      languages: ['cpp'],
+      command: 'clangd',
+      args: [],
+      transport: 'stdio',
+      rootUri: 'file:///workspace',
+      workspaceFolder: '/workspace',
+    },
+    status: 'READY',
+    ...overrides,
+  }) as LspServerHandle;
+
+describe('NativeLspClient', () => {
+  it('returns status details from the current server handles', () => {
+    const service = {
+      getStatus: vi.fn().mockReturnValue(
+        new Map([
+          ['clangd', 'FAILED'],
+          ['stale-server', 'READY'],
+        ]),
+      ),
+      getServerHandles: vi.fn().mockReturnValue(
+        new Map([
+          [
+            'clangd',
+            createHandle({
+              status: 'READY',
+              config: {
+                name: 'clangd',
+                languages: ['c', 'cpp'],
+                command: 'clangd',
+                args: ['--background-index'],
+                transport: 'stdio',
+                rootUri: 'file:///workspace',
+                workspaceFolder: '/workspace',
+              },
+            }),
+          ],
+        ]),
+      ),
+    } as unknown as NativeLspService;
+
+    const client = new NativeLspClient(service);
+
+    expect(client.getServerStatus()).toEqual([
+      {
+        name: 'clangd',
+        status: 'READY',
+        command: 'clangd',
+        languages: ['c', 'cpp'],
+      },
+    ]);
+    expect(service.getStatus).not.toHaveBeenCalled();
+  });
+
+  it('stringifies non-Error startup failures', () => {
+    const service = {
+      getServerHandles: vi.fn().mockReturnValue(
+        new Map([
+          [
+            'pyright',
+            createHandle({
+              status: 'FAILED',
+              config: {
+                name: 'pyright',
+                languages: ['python'],
+                command: 'pyright-langserver',
+                args: ['--stdio'],
+                transport: 'stdio',
+                rootUri: 'file:///workspace',
+                workspaceFolder: '/workspace',
+              },
+              error: 'startup failed' as unknown as Error,
+            }),
+          ],
+        ]),
+      ),
+    } as unknown as NativeLspService;
+
+    const client = new NativeLspClient(service);
+
+    expect(client.getServerStatus()).toEqual([
+      {
+        name: 'pyright',
+        status: 'FAILED',
+        command: 'pyright-langserver',
+        languages: ['python'],
+        error: 'startup failed',
+      },
+    ]);
+  });
+});

--- a/packages/core/src/lsp/NativeLspClient.ts
+++ b/packages/core/src/lsp/NativeLspClient.ts
@@ -28,6 +28,7 @@ import type {
   LspReference,
   LspSymbolInformation,
   LspWorkspaceEdit,
+  LspServerStatusInfo,
 } from './types.js';
 
 import type { NativeLspService } from './NativeLspService.js';
@@ -50,6 +51,28 @@ export class NativeLspClient implements LspClient {
    * @param service - The NativeLspService instance to delegate calls to
    */
   constructor(private readonly service: NativeLspService) {}
+
+  /**
+   * Get the status of all configured LSP servers.
+   */
+  getServerStatus(): LspServerStatusInfo[] {
+    const statusMap = this.service.getStatus();
+    const handles = this.service.getServerHandles();
+    const result: LspServerStatusInfo[] = [];
+
+    for (const [name, status] of statusMap) {
+      const handle = handles.get(name);
+      result.push({
+        name,
+        status,
+        command: handle?.config.command,
+        languages: handle?.config.languages ?? [],
+        error: handle?.error?.message,
+      });
+    }
+
+    return result;
+  }
 
   /**
    * Search for symbols across the workspace.

--- a/packages/core/src/lsp/NativeLspClient.ts
+++ b/packages/core/src/lsp/NativeLspClient.ts
@@ -26,6 +26,7 @@ import type {
   LspLocation,
   LspRange,
   LspReference,
+  LspStatusSnapshot,
   LspSymbolInformation,
   LspWorkspaceEdit,
   LspServerStatusInfo,
@@ -278,5 +279,12 @@ export class NativeLspClient implements LspClient {
     serverName?: string,
   ): Promise<boolean> {
     return this.service.applyWorkspaceEdit(edit, serverName);
+  }
+
+  /**
+   * Get a point-in-time status snapshot for UI and debug logging.
+   */
+  getStatusSnapshot(): LspStatusSnapshot {
+    return this.service.getStatusSnapshot();
   }
 }

--- a/packages/core/src/lsp/NativeLspClient.ts
+++ b/packages/core/src/lsp/NativeLspClient.ts
@@ -34,6 +34,13 @@ import type {
 
 import type { NativeLspService } from './NativeLspService.js';
 
+function getErrorMessage(error: unknown): string | undefined {
+  if (error === undefined || error === null) {
+    return undefined;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
 /**
  * Adapter class that implements LspClient by delegating to NativeLspService.
  *
@@ -57,18 +64,17 @@ export class NativeLspClient implements LspClient {
    * Get the status of all configured LSP servers.
    */
   getServerStatus(): LspServerStatusInfo[] {
-    const statusMap = this.service.getStatus();
     const handles = this.service.getServerHandles();
     const result: LspServerStatusInfo[] = [];
 
-    for (const [name, status] of statusMap) {
-      const handle = handles.get(name);
+    for (const [name, handle] of handles) {
+      const error = getErrorMessage(handle.error);
       result.push({
         name,
-        status,
-        command: handle?.config.command,
-        languages: handle?.config.languages ?? [],
-        error: handle?.error?.message,
+        status: handle.status,
+        command: handle.config.command,
+        languages: handle.config.languages ?? [],
+        ...(error !== undefined ? { error } : {}),
       });
     }
 

--- a/packages/core/src/lsp/NativeLspService.test.ts
+++ b/packages/core/src/lsp/NativeLspService.test.ts
@@ -144,6 +144,96 @@ describe('NativeLspService', () => {
     expect(status).toBeDefined();
   });
 
+  test('should expose a detailed status snapshot for configured servers', () => {
+    const serverManager = {
+      getHandles: () =>
+        new Map([
+          [
+            'clangd',
+            {
+              config: {
+                name: 'clangd',
+                languages: ['c', 'cpp'],
+                command: 'clangd',
+                args: ['--background-index'],
+                transport: 'stdio',
+                rootUri: 'file:///test/workspace',
+                workspaceFolder: '/test/workspace',
+              },
+              status: 'READY',
+              process: { pid: 12345 },
+              warmedUp: true,
+              restartAttempts: 1,
+              processDiagnostics: {
+                stderrTail: 'clangd: unknown argument\n',
+                exitCode: 7,
+                exitSignal: null,
+              },
+            },
+          ],
+          [
+            'pyright',
+            {
+              config: {
+                name: 'pyright',
+                languages: ['python'],
+                command: 'pyright-langserver',
+                args: ['--stdio'],
+                transport: 'stdio',
+                rootUri: 'file:///test/workspace',
+                workspaceFolder: '/test/workspace',
+              },
+              status: 'FAILED',
+              error: new Error('startup failed'),
+            },
+          ],
+        ]),
+    };
+
+    (lspService as unknown as { serverManager: unknown }).serverManager =
+      serverManager;
+
+    const snapshot = lspService.getStatusSnapshot();
+
+    expect(snapshot).toEqual({
+      enabled: true,
+      configuredServers: 2,
+      readyServers: 1,
+      failedServers: 1,
+      inProgressServers: 0,
+      notStartedServers: 0,
+      servers: [
+        {
+          name: 'clangd',
+          status: 'READY',
+          languages: ['c', 'cpp'],
+          transport: 'stdio',
+          command: 'clangd',
+          args: ['--background-index'],
+          rootUri: 'file:///test/workspace',
+          workspaceFolder: '/test/workspace',
+          pid: 12345,
+          warmedUp: true,
+          restartAttempts: 1,
+          stderrTail: 'clangd: unknown argument\n',
+          exitCode: 7,
+          exitSignal: null,
+        },
+        {
+          name: 'pyright',
+          status: 'FAILED',
+          languages: ['python'],
+          transport: 'stdio',
+          command: 'pyright-langserver',
+          args: ['--stdio'],
+          rootUri: 'file:///test/workspace',
+          workspaceFolder: '/test/workspace',
+          error: 'startup failed',
+        },
+      ],
+    });
+  });
+
   test('should open document before hover requests', async () => {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lsp-test-'));
     const filePath = path.join(tempDir, 'main.cpp');

--- a/packages/core/src/lsp/NativeLspService.ts
+++ b/packages/core/src/lsp/NativeLspService.ts
@@ -172,6 +172,13 @@ export class NativeLspService {
   }
 
   /**
+   * Get all server handles for status reporting.
+   */
+  getServerHandles(): ReadonlyMap<string, LspServerHandle> {
+    return this.serverManager.getHandles();
+  }
+
+  /**
    * Get ready server handles filtered by optional server name.
    * Each handle is guaranteed to have a valid connection.
    *

--- a/packages/core/src/lsp/NativeLspService.ts
+++ b/packages/core/src/lsp/NativeLspService.ts
@@ -39,6 +39,7 @@ import type {
   LspConnectionInterface,
   LspServerHandle,
   LspServerStatus,
+  LspStatusSnapshot,
   NativeLspServiceOptions,
 } from './types.js';
 import * as path from 'path';
@@ -176,6 +177,68 @@ export class NativeLspService {
    */
   getServerHandles(): ReadonlyMap<string, LspServerHandle> {
     return this.serverManager.getHandles();
+  }
+
+  /**
+   * Get detailed LSP server status for UI and debug logging.
+   */
+  getStatusSnapshot(): LspStatusSnapshot {
+    const servers = Array.from(this.serverManager.getHandles().entries()).map(
+      ([name, handle]) => {
+        const error =
+          handle.error instanceof Error
+            ? handle.error.message
+            : handle.error
+              ? String(handle.error)
+              : undefined;
+
+        return {
+          name,
+          status: handle.status,
+          languages: handle.config.languages,
+          transport: handle.config.transport,
+          ...(handle.config.command ? { command: handle.config.command } : {}),
+          ...(handle.config.args ? { args: handle.config.args } : {}),
+          ...(handle.config.rootUri ? { rootUri: handle.config.rootUri } : {}),
+          ...(handle.config.workspaceFolder
+            ? { workspaceFolder: handle.config.workspaceFolder }
+            : {}),
+          ...(handle.process?.pid ? { pid: handle.process.pid } : {}),
+          ...(handle.warmedUp !== undefined
+            ? { warmedUp: handle.warmedUp }
+            : {}),
+          ...(handle.restartAttempts !== undefined
+            ? { restartAttempts: handle.restartAttempts }
+            : {}),
+          ...(handle.processDiagnostics?.stderrTail
+            ? { stderrTail: handle.processDiagnostics.stderrTail }
+            : {}),
+          ...(handle.processDiagnostics?.exitCode !== undefined
+            ? { exitCode: handle.processDiagnostics.exitCode }
+            : {}),
+          ...(handle.processDiagnostics?.exitSignal !== undefined
+            ? { exitSignal: handle.processDiagnostics.exitSignal }
+            : {}),
+          ...(error ? { error } : {}),
+        };
+      },
+    );
+
+    return {
+      enabled: true,
+      configuredServers: servers.length,
+      readyServers: servers.filter((server) => server.status === 'READY')
+        .length,
+      failedServers: servers.filter((server) => server.status === 'FAILED')
+        .length,
+      inProgressServers: servers.filter(
+        (server) => server.status === 'IN_PROGRESS',
+      ).length,
+      notStartedServers: servers.filter(
+        (server) => server.status === 'NOT_STARTED',
+      ).length,
+      servers,
+    };
   }
 
   /**

--- a/packages/core/src/lsp/types.ts
+++ b/packages/core/src/lsp/types.ts
@@ -246,7 +246,20 @@ export interface LspCodeActionContext {
   triggerKind?: 'invoked' | 'automatic';
 }
 
+export interface LspServerStatusInfo {
+  name: string;
+  status: LspServerStatus;
+  command?: string;
+  languages: string[];
+  error?: string;
+}
+
 export interface LspClient {
+  /**
+   * Get the status of all configured LSP servers.
+   */
+  getServerStatus(): LspServerStatusInfo[];
+
   /**
    * Search for symbols across the workspace.
    */

--- a/packages/core/src/lsp/types.ts
+++ b/packages/core/src/lsp/types.ts
@@ -371,6 +371,11 @@ export interface LspClient {
     edit: LspWorkspaceEdit,
     serverName?: string,
   ): Promise<boolean>;
+
+  /**
+   * Get a point-in-time snapshot of LSP server connection status.
+   */
+  getStatusSnapshot?(): LspStatusSnapshot;
 }
 
 // ============================================================================
@@ -486,6 +491,78 @@ export type LspServerStatus =
   | 'FAILED';
 
 /**
+ * Detailed status for one configured LSP server.
+ */
+export interface LspServerStatusDetail {
+  /** Server name */
+  name: string;
+  /** Current server status */
+  status: LspServerStatus;
+  /** Languages handled by this server */
+  languages: string[];
+  /** Transport used to connect to the server */
+  transport: LspServerConfig['transport'];
+  /** Command used to start the server, when applicable */
+  command?: string;
+  /** Command arguments, when applicable */
+  args?: string[];
+  /** Root URI used during initialization */
+  rootUri?: string;
+  /** Workspace folder used during initialization */
+  workspaceFolder?: string;
+  /** Process id for stdio servers, when available */
+  pid?: number;
+  /** Whether the server has completed warm-up */
+  warmedUp?: boolean;
+  /** Number of restart attempts already used */
+  restartAttempts?: number;
+  /** Last error message, when failed */
+  error?: string;
+  /** Recent stderr output from the server process, when available */
+  stderrTail?: string;
+  /** Exit code from the server process, when available */
+  exitCode?: number | null;
+  /** Exit signal from the server process, when available */
+  exitSignal?: string | null;
+}
+
+/**
+ * Point-in-time LSP connection status exposed to UI and debug logs.
+ */
+export interface LspStatusSnapshot {
+  /** Whether LSP is enabled for this Config */
+  enabled: boolean;
+  /** Number of configured servers */
+  configuredServers: number;
+  /** Number of ready servers */
+  readyServers: number;
+  /** Number of failed servers */
+  failedServers: number;
+  /** Number of servers currently starting */
+  inProgressServers: number;
+  /** Number of servers not started yet */
+  notStartedServers: number;
+  /** Detailed per-server status */
+  servers: LspServerStatusDetail[];
+  /** Initialization error captured before client creation */
+  initializationError?: string;
+  /** Status could not be read from the active LSP client */
+  statusUnavailable?: boolean;
+}
+
+/**
+ * Process-level diagnostics captured from a spawned LSP server.
+ */
+export interface LspProcessDiagnostics {
+  /** Recent stderr output from the server process */
+  stderrTail: string;
+  /** Exit code from the server process, when available */
+  exitCode?: number | null;
+  /** Exit signal from the server process, when available */
+  exitSignal?: string | null;
+}
+
+/**
  * Handle for managing an LSP server instance.
  */
 export interface LspServerHandle {
@@ -505,6 +582,8 @@ export interface LspServerHandle {
   stopRequested?: boolean;
   /** Number of restart attempts */
   restartAttempts?: number;
+  /** Process-level diagnostics from the server */
+  processDiagnostics?: LspProcessDiagnostics;
   /** Lock to prevent concurrent startup attempts */
   startingPromise?: Promise<void>;
 }
@@ -527,6 +606,8 @@ export interface LspConnectionResult {
   connection: LspConnectionInterface;
   /** Server process (for stdio transport) */
   process?: ChildProcess;
+  /** Process-level diagnostics from the server */
+  processDiagnostics?: LspProcessDiagnostics;
   /** Shutdown the connection gracefully */
   shutdown: () => Promise<void>;
   /** Force exit the connection */

--- a/packages/core/src/lsp/types.ts
+++ b/packages/core/src/lsp/types.ts
@@ -258,7 +258,7 @@ export interface LspClient {
   /**
    * Get the status of all configured LSP servers.
    */
-  getServerStatus(): LspServerStatusInfo[];
+  getServerStatus?(): LspServerStatusInfo[];
 
   /**
    * Search for symbols across the workspace.


### PR DESCRIPTION
## Summary

This PR is no longer blocked on #3615: that PR has merged, and this branch has been rebased onto `main` after resolving the earlier conflicts.

Changes in this PR:

- Add `/lsp` for per-server LSP status, including non-interactive output support.
- Expose an LSP status snapshot through config and `/status`, including ready/failed/starting/not-started counts.
- Capture stdio LSP process diagnostics for startup failures, including recent stderr output and exit code/signal.
- Preserve UTF-8 stderr diagnostics when multi-byte characters are split across chunks.
- Add debug log entries for native LSP discovery/startup and `/status` snapshots when `--debug` is enabled.
- Update the LSP troubleshooting docs for `--debug`, `/status`, `/lsp`, `QWEN_RUNTIME_DIR`, and connection-closed diagnostics.
- Add focused regression coverage for the command, client status adapter, config snapshots, system info formatting, connection diagnostics, and server-manager diagnostics logging.

## Test Plan

Local verification on the rebased branch:

- `npm run lint`
- `npm run build`
- `npm run typecheck`
- `npm run bundle`
- `git diff --check`
- `cd packages/core && npx vitest run src/lsp/LspConnectionFactory.test.ts src/lsp/LspServerManager.test.ts src/lsp/NativeLspClient.test.ts src/lsp/NativeLspService.test.ts src/config/config.test.ts`
- `cd packages/cli && npx vitest run src/ui/commands/lspCommand.test.ts src/services/BuiltinCommandLoader.test.ts src/utils/systemInfo.test.ts src/utils/systemInfoFields.test.ts src/ui/commands/aboutCommand.test.ts src/config/config.test.ts`

Reviewer test plan:

- Start Qwen Code with `--experimental-lsp --debug` in a project with a `.lsp.json` file.
- Run `/status` and verify the short LSP summary is present.
- Run `/lsp` and verify each configured server shows command, languages, and status.
- Check the debug log under `${QWEN_RUNTIME_DIR:-~/.qwen}/debug/` for discovery/startup snapshots and startup failure diagnostics.