### PR TITLE
fix(core): recover from `}{` glued records on session JSONL load (#3606)

### DIFF
--- a/packages/core/src/utils/jsonl-utils.test.ts
+++ b/packages/core/src/utils/jsonl-utils.test.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  _recoverObjectsFromLine,
+  _resetEnsuredDirsCacheForTest,
+  read,
+  readLines,
+} from './jsonl-utils.js';
+
+let tmpRoot: string;
+
+beforeAll(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'jsonl-utils-test-'));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+afterEach(() => {
+  _resetEnsuredDirsCacheForTest();
+});
+
+function tmpFile(content: string): string {
+  const p = path.join(
+    tmpRoot,
+    `t-${Math.random().toString(36).slice(2)}.jsonl`,
+  );
+  fs.writeFileSync(p, content, 'utf8');
+  return p;
+}
+
+describe('_recoverObjectsFromLine', () => {
+  it('returns single object for a well-formed JSON line', () => {
+    expect(_recoverObjectsFromLine<{ a: number }>('{"a":1}')).toEqual([
+      { a: 1 },
+    ]);
+  });
+
+  it('splits two concatenated objects with no separator', () => {
+    expect(
+      _recoverObjectsFromLine<{ a: number } | { b: number }>('{"a":1}{"b":2}'),
+    ).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+
+  it('does not split on `}{` that appears inside a string value', () => {
+    const line = '{"text":"close-then-open: }{ here"}';
+    expect(_recoverObjectsFromLine<{ text: string }>(line)).toEqual([
+      { text: 'close-then-open: }{ here' },
+    ]);
+  });
+
+  it('handles escaped quotes inside strings', () => {
+    const line = '{"q":"he said \\"hi\\"","n":1}{"q":"x"}';
+    expect(_recoverObjectsFromLine<{ q: string; n?: number }>(line)).toEqual([
+      { q: 'he said "hi"', n: 1 },
+      { q: 'x' },
+    ]);
+  });
+
+  it('recovers objects around an unbalanced fragment', () => {
+    // Middle `{"oops":}` fails JSON.parse, surrounding objects still parse.
+    expect(
+      _recoverObjectsFromLine<{ a?: number; b?: number }>(
+        '{"a":1}{"oops":}{"b":2}',
+      ),
+    ).toEqual([{ a: 1 }, { b: 2 }]);
+  });
+
+  it('returns empty array when nothing balanced can be parsed', () => {
+    expect(_recoverObjectsFromLine('not json at all')).toEqual([]);
+    expect(_recoverObjectsFromLine('{"unterminated":')).toEqual([]);
+  });
+});
+
+describe('read() / readLines() with malformed lines', () => {
+  it('reads a clean file unchanged', async () => {
+    const file = tmpFile('{"a":1}\n{"a":2}\n{"a":3}\n');
+    expect(await read<{ a: number }>(file)).toEqual([
+      { a: 1 },
+      { a: 2 },
+      { a: 3 },
+    ]);
+  });
+
+  it('recovers concatenated records without losing later lines', async () => {
+    // The #3606 corruption shape: two records glued onto one physical line,
+    // with valid records before and after.
+    const file = tmpFile(
+      '{"uuid":"a","i":1}\n{"uuid":"b","i":2}{"uuid":"c","i":3}\n{"uuid":"d","i":4}\n',
+    );
+    const out = await read<{ uuid: string; i: number }>(file);
+    expect(out.map((r) => r.uuid)).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('skips a fully-garbage line and keeps reading', async () => {
+    const file = tmpFile('{"a":1}\nnot-json-at-all\n{"a":3}\n');
+    expect(await read<{ a: number }>(file)).toEqual([{ a: 1 }, { a: 3 }]);
+  });
+
+  it('returns [] for a missing file', async () => {
+    expect(await read(path.join(tmpRoot, 'does-not-exist.jsonl'))).toEqual([]);
+  });
+
+  it('readLines respects the limit when objects come from recovery', async () => {
+    // Two clean lines, then a glued pair. Asking for 3 should yield 3.
+    const file = tmpFile('{"i":1}\n{"i":2}\n{"i":3}{"i":4}\n{"i":5}\n');
+    expect((await readLines<{ i: number }>(file, 3)).map((r) => r.i)).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it('readLines recovers when the malformed line is within the first N', async () => {
+    const file = tmpFile('{"i":1}{"i":2}\n{"i":3}\n');
+    expect((await readLines<{ i: number }>(file, 5)).map((r) => r.i)).toEqual([
+      1, 2, 3,
+    ]);
+  });
+
+  it('skips blank lines', async () => {
+    const file = tmpFile('{"a":1}\n\n{"a":2}\n');
+    expect(await read<{ a: number }>(file)).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+});

--- a/packages/core/src/utils/jsonl-utils.ts
+++ b/packages/core/src/utils/jsonl-utils.ts
@@ -45,6 +45,89 @@ function getFileLock(filePath: string): Mutex {
 }
 
 /**
+ * Recovers parsed objects from a single physical line that may contain one
+ * or more concatenated top-level JSON objects (i.e. a missing newline
+ * separator left two records glued together as `}{`). Walks the line with a
+ * brace-depth counter that respects string boundaries and `\` escapes, then
+ * tries `JSON.parse` on each balanced top-level fragment. Fragments that
+ * still fail to parse are skipped silently — the caller decides whether to
+ * warn.
+ *
+ * **Limitation**: only top-level `{...}` records are recovered. A glued line
+ * whose records are top-level arrays (`[...][...]`) will not split. All
+ * existing JSONL writers in this codebase produce object records, so this
+ * matches the actual corruption shape — extend if that ever changes.
+ *
+ * Exported for unit tests; not part of the module's stable surface.
+ */
+export function _recoverObjectsFromLine<T = unknown>(line: string): T[] {
+  const out: T[] = [];
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+  let start = -1;
+  for (let i = 0; i < line.length; i++) {
+    const c = line[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (inString) {
+      if (c === '\\') escape = true;
+      else if (c === '"') inString = false;
+      continue;
+    }
+    if (c === '"') {
+      inString = true;
+      continue;
+    }
+    if (c === '{') {
+      if (depth === 0) start = i;
+      depth++;
+    } else if (c === '}') {
+      depth--;
+      if (depth === 0 && start >= 0) {
+        const fragment = line.slice(start, i + 1);
+        try {
+          out.push(JSON.parse(fragment) as T);
+        } catch {
+          // Skip un-parseable fragment; caller may still recover others.
+        }
+        start = -1;
+      } else if (depth < 0) {
+        // Unbalanced close brace — reset and keep scanning for the next
+        // well-formed object rather than giving up on the whole line.
+        depth = 0;
+        start = -1;
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Parses a single physical JSONL line tolerantly. Returns the parsed objects:
+ * one if the line is well-formed, multiple if it is `}{`-glued from an
+ * interrupted append (the #3606 corruption shape), zero if nothing can be
+ * recovered. Mirrors the silent skip in `countSessionMessages`.
+ */
+function parseLineTolerant<T>(line: string, filePath: string): T[] {
+  try {
+    return [JSON.parse(line) as T];
+  } catch {
+    const fragments = _recoverObjectsFromLine<T>(line);
+    if (fragments.length === 0) {
+      debugLogger.warn(`Failed to parse line in ${filePath}`);
+    } else {
+      debugLogger.warn(
+        `Recovered ${fragments.length} record(s) from malformed line in ${filePath}`,
+      );
+    }
+    return fragments;
+  }
+}
+
+/**
  * Reads the first N lines from a JSONL file efficiently.
  * Returns an array of parsed objects.
  */
@@ -63,8 +146,10 @@ export async function readLines<T = unknown>(
     for await (const line of rl) {
       if (results.length >= count) break;
       const trimmed = line.trim();
-      if (trimmed.length > 0) {
-        results.push(JSON.parse(trimmed) as T);
+      if (trimmed.length === 0) continue;
+      for (const obj of parseLineTolerant<T>(trimmed, filePath)) {
+        if (results.length >= count) break;
+        results.push(obj);
       }
     }
 
@@ -95,8 +180,9 @@ export async function read<T = unknown>(filePath: string): Promise<T[]> {
     const results: T[] = [];
     for await (const line of rl) {
       const trimmed = line.trim();
-      if (trimmed.length > 0) {
-        results.push(JSON.parse(trimmed) as T);
+      if (trimmed.length === 0) continue;
+      for (const obj of parseLineTolerant<T>(trimmed, filePath)) {
+        results.push(obj);
       }
     }
 


### PR DESCRIPTION
## Summary

- **What changed:** `jsonl.read()` and `jsonl.readLines()` now tolerate per-line parse errors and recover concatenated records (`}{` glued onto a single physical line) via a brace-depth scanner that respects string boundaries and `\` escapes. New helper `_recoverObjectsFromLine()` does the splitting; `parseLineTolerant()` routes per-line failures through it.
- **Why it changed:** Fixes #3606. A single corrupted line (two records glued without a newline separator — caused by an interrupted append losing its trailing `\n`) made `JSON.parse` throw, so `read()` returned `[]` and `loadSession()` returned `undefined` ("No saved session found"). Worse, simply skipping the bad line orphans every subsequent record via `parentUuid` chain breakage in `reconstructHistory`, so recovery — not just tolerance — is required to actually restore the session.
- **Reviewer focus:**
  1. `_recoverObjectsFromLine` correctness — string/escape handling, depth `< 0` reset, and the documented limitation (top-level objects only)
  2. `parseLineTolerant` 0-vs-N branch in `debugLogger.warn` (no false "Recovered 0" noise)
  3. No write-side change — read-side recovery is sufficient and avoids accumulating empty separator lines on every resume

## Validation

- **Commands run:**

  ```bash
  # Full unit suite for the touched code paths
  npx vitest run \
    packages/core/src/utils/jsonl-utils.test.ts \
    packages/core/src/services/chatRecordingService.test.ts \
    packages/core/src/services/sessionService.test.ts \
    packages/core/src/services/sessionService.rename.test.ts \
    packages/core/src/services/chatRecordingService.customTitle.test.ts \
    packages/core/src/services/chatRecordingService.autoTitle.test.ts

  # Type + lint
  npx tsc --noEmit -p packages/core
  npx eslint packages/core/src/utils/jsonl-utils.ts \
              packages/core/src/utils/jsonl-utils.test.ts

  # End-to-end against the JSONL attached to #3606
  npx tsx <<'EOF'
  const { SessionService } = await import(
    './packages/core/src/services/sessionService.ts'
  );
  const svc = new SessionService('/path/to/project');
  const loaded = await svc.loadSession('5b0c6411-5f63-4457-a33f-f4d3af300dd5');
  console.log('messages:', loaded?.conversation.messages.length);
  EOF
  ```

- **Inputs used:** the JSONL file megapro17 attached to #3606 (`5b0c6411-...jsonl`), 480 lines, 1 malformed line at line 63 of the form `{record_A}}}{record_B}` (an `api_response` ui_telemetry record glued to a `user` message record across a 5-minute session-restart gap).

- **Expected result:**
  - Unit suite green (existing + 13 new cases)
  - `loadSession` returns 481 records (480 lines, line 63 yields 2)
  - All UUIDs unique
  - The line-64 record's `parentUuid = ce2f0622...` resolves (recovered from the second half of line 63), so `reconstructHistory` walks the full chain with no orphans

- **Observed result:**

  ```text
  Test Files  6 passed (6)
       Tests  98 passed (98)
  
  --- end-to-end loadSession against #3606 attachment ---
  Sessions visible to picker: ... (target listed; messageCount: 144)
  loadSession result:
    messages reconstructed: 481
    lastCompletedUuid: 4702d357-1eca-42ab-bb67-21d7683f5e2d
    Glued pair recovered: true true (3ff76a26 + ce2f0622)
    Post-corruption record present: true (63eefedc — line 64)
  ```

- **Quickest reviewer verification path:**
  1. Download the JSONL from megapro17's comment on #3606
  2. Place under any `<runtime>/projects/<sanitized-cwd>/chats/<id>.jsonl` (rewrite `records[0].cwd` to your project root so `getProjectHash` matches)
  3. `npm start -- --resume 5b0c6411-5f63-4457-a33f-f4d3af300dd5`
  4. Before this PR: "No saved session found". After: full session loads, 481 messages reconstructed; stderr/debug log shows `Recovered 2 record(s) from malformed line in ...`

- **Evidence — before/after on the real attachment:**

  | Metric                                | Before fix | After fix |
  | ------------------------------------- | ---------: | --------: |
  | `read()` returns                       |     `[]`   | 481 records |
  | `loadSession()` returns                | `undefined` | full conversation |
  | `reconstructHistory()` linear messages |          0 | 481 |
  | Glued line halves recovered            | 0 / 2      | 2 / 2 |
  | Orphaned records via parentUuid break  |        417 | 0 |

## Scope / Risk

- **Main risk / tradeoff:**
  - Scanner only recognizes top-level `{...}` records, not `[...]` arrays (documented in the helper's JSDoc). All existing JSONL writers in this codebase emit object records, so this matches the only corruption shape we observe in the wild — but a future writer that emits arrays would not benefit from the recovery path.
  - On a parse failure, the scanner attempts recovery by walking the line; on a deliberately-crafted huge single line this is O(n) but unbounded by the upstream `readline` buffer. In practice session JSONL is small (megapro17's worst case: 162 KB single record, < 5 ms scan).
- **Not covered / not validated:**
  - No fix on the write side. The trailing-newline loss that triggered #3606 is OS/process-level (Windows console close, abnormal exit, antivirus interception of un-`fsync`'d page cache) — out of scope to repair preemptively. Read-side recovery is enough to keep `loadSession` correct even if the same corruption recurs, and avoids accumulating extra empty lines on every resume.
  - Not exercised on Windows or Linux locally — see matrix below.
- **Breaking changes / migration notes:** None. `read()` / `readLines()` signatures and return types are unchanged; behavior change is purely additive (was throwing → now recovers + logs).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- macOS (🍏): unit suite + end-to-end `loadSession` against the #3606 attachment, both via `npm run` and direct `npx tsx`. ✅
- Windows (🪟) / Linux (🐧): not exercised locally. The change is pure JS string scanning + a `try/catch` around `JSON.parse`; no platform-specific syscalls or path handling. The original write-side `\n`-loss that produced the bug is reportedly Windows-specific, but the read-side recovery is platform-agnostic.
- Docker / Podman / Seatbelt: not applicable — change is in `packages/core` JSONL utilities, no sandbox or container surface.

## Linked Issues / Bugs

Closes #3606
