### PR TITLE
chore(gitignore): add .codex directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ package-lock.json
 .qoder
 .claude
 CLAUDE.md
+.codex
 
 # Qwen Code Configs
 .qwen/*


### PR DESCRIPTION
## Summary

- Add `.codex` directory to `.gitignore` under the Editors section

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)