### PR TITLE
fix(cli): refresh static header on model switch

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -301,10 +301,7 @@ export const AppContainer = (props: AppContainerProps) => {
     [],
   );
 
-  // Helper to determine the current model (polled, since Config has no model-change event).
-  const getCurrentModel = useCallback(() => config.getModel(), [config]);
-
-  const [currentModel, setCurrentModel] = useState(getCurrentModel());
+  const [currentModel, setCurrentModel] = useState(() => config.getModel());
 
   const [isConfigInitialized, setConfigInitialized] = useState(false);
 
@@ -418,21 +415,6 @@ export const AppContainer = (props: AppContainerProps) => {
     return () => handler?.cleanup();
   }, [historyManager.addItem]);
 
-  // Watch for model changes (e.g., user switches model via /model)
-  useEffect(() => {
-    const checkModelChange = () => {
-      const model = getCurrentModel();
-      if (model !== currentModel) {
-        setCurrentModel(model);
-      }
-    };
-
-    checkModelChange();
-    const interval = setInterval(checkModelChange, 1000); // Check every second
-
-    return () => clearInterval(interval);
-  }, [config, currentModel, getCurrentModel]);
-
   // Derive widths for InputPrompt using shared helper
   const { inputWidth, suggestionsWidth } = useMemo(() => {
     const { inputWidth, suggestionsWidth } =
@@ -493,6 +475,23 @@ export const AppContainer = (props: AppContainerProps) => {
     stdout.write(ansiEscapes.clearTerminal);
     remountStaticHistory();
   }, [remountStaticHistory, stdout]);
+
+  // Keep the static header in sync with model changes without polling.
+  // Ink's <Static> output is append-only, so model changes must explicitly
+  // clear and remount the static region to redraw the banner at the top.
+  useEffect(() => {
+    const unsubscribe = config.onModelChange((model) => {
+      setCurrentModel((prev) => {
+        if (prev === model) {
+          return prev;
+        }
+        refreshStatic();
+        return model;
+      });
+    });
+
+    return unsubscribe;
+  }, [config, refreshStatic]);
 
   const {
     isThemeDialogOpen,

--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+import { MainContent } from './MainContent.js';
+import { UIStateContext, type UIState } from '../contexts/UIStateContext.js';
+import {
+  UIActionsContext,
+  type UIActions,
+} from '../contexts/UIActionsContext.js';
+import { AppContext } from '../contexts/AppContext.js';
+import { CompactModeProvider } from '../contexts/CompactModeContext.js';
+import { OverflowProvider } from '../contexts/OverflowContext.js';
+
+const staticPropsSpy = vi.fn();
+const staticItemsSpy = vi.fn();
+const appHeaderSpy = vi.fn();
+
+vi.mock('ink', async () => {
+  const actual = await vi.importActual<typeof import('ink')>('ink');
+
+  return {
+    ...actual,
+    Static: ({
+      children,
+      items,
+      ...props
+    }: React.ComponentProps<typeof actual.Static>) => {
+      staticPropsSpy(props);
+      staticItemsSpy(items);
+      return <>{items.map((item, index) => children(item, index))}</>;
+    },
+  };
+});
+
+vi.mock('./AppHeader.js', () => ({
+  AppHeader: ({ version }: { version: string }) => {
+    appHeaderSpy(version);
+    return <Text>{`APP_HEADER:${version}`}</Text>;
+  },
+}));
+
+vi.mock('./HistoryItemDisplay.js', () => ({
+  HistoryItemDisplay: ({ item }: { item: { id: number } }) => (
+    <Text>{`HISTORY:${item.id}`}</Text>
+  ),
+}));
+
+vi.mock('./ShowMoreLines.js', () => ({
+  ShowMoreLines: () => <Text>SHOW_MORE</Text>,
+}));
+
+vi.mock('./Notifications.js', () => ({
+  Notifications: () => <Text>NOTIFICATIONS</Text>,
+}));
+
+vi.mock('./DebugModeNotification.js', () => ({
+  DebugModeNotification: () => <Text>DEBUG_NOTIFICATION</Text>,
+}));
+
+const createUIState = (overrides: Partial<UIState> = {}): UIState =>
+  ({
+    history: [],
+    historyManager: {} as UIState['historyManager'],
+    isThemeDialogOpen: false,
+    themeError: null,
+    isAuthenticating: false,
+    isConfigInitialized: true,
+    authError: null,
+    isAuthDialogOpen: false,
+    pendingAuthType: undefined,
+    externalAuthState: null,
+    qwenAuthState: {} as UIState['qwenAuthState'],
+    editorError: null,
+    isEditorDialogOpen: false,
+    debugMessage: '',
+    quittingMessages: null,
+    isSettingsDialogOpen: false,
+    isMemoryDialogOpen: false,
+    isModelDialogOpen: false,
+    isFastModelMode: false,
+    isManageModelsDialogOpen: false,
+    isTrustDialogOpen: false,
+    activeArenaDialog: null,
+    isPermissionsDialogOpen: false,
+    isApprovalModeDialogOpen: false,
+    isResumeDialogOpen: false,
+    resumeMatchedSessions: undefined,
+    isDeleteDialogOpen: false,
+    slashCommands: [],
+    pendingSlashCommandHistoryItems: [],
+    commandContext: {} as UIState['commandContext'],
+    shellConfirmationRequest: null,
+    confirmationRequest: null,
+    confirmUpdateExtensionRequests: [],
+    codingPlanUpdateRequest: undefined,
+    settingInputRequests: [],
+    pluginChoiceRequests: [],
+    loopDetectionConfirmationRequest: null,
+    geminiMdFileCount: 0,
+    streamingState: {} as UIState['streamingState'],
+    initError: null,
+    pendingGeminiHistoryItems: [],
+    thought: null,
+    shellModeActive: false,
+    userMessages: [],
+    buffer: {} as UIState['buffer'],
+    inputWidth: 80,
+    suggestionsWidth: 80,
+    isInputActive: true,
+    shouldShowIdePrompt: false,
+    shouldShowCommandMigrationNudge: false,
+    commandMigrationTomlFiles: [],
+    isFolderTrustDialogOpen: false,
+    isTrustedFolder: true,
+    constrainHeight: false,
+    ideContextState: undefined,
+    showToolDescriptions: false,
+    ctrlCPressedOnce: false,
+    ctrlDPressedOnce: false,
+    showEscapePrompt: false,
+    elapsedTime: 0,
+    currentLoadingPhrase: '',
+    historyRemountKey: 1,
+    messageQueue: [],
+    showAutoAcceptIndicator: {} as UIState['showAutoAcceptIndicator'],
+    currentModel: 'gpt-5.5',
+    contextFileNames: [],
+    availableTerminalHeight: undefined,
+    mainAreaWidth: 100,
+    staticAreaMaxItemHeight: 100,
+    staticExtraHeight: 0,
+    dialogsVisible: false,
+    pendingHistoryItems: [],
+    stickyTodos: null,
+    btwItem: null,
+    setBtwItem: vi.fn(),
+    cancelBtw: vi.fn(),
+    nightly: false,
+    branchName: 'main',
+    sessionStats: { lastPromptTokenCount: 0 } as UIState['sessionStats'],
+    terminalWidth: 120,
+    terminalHeight: 40,
+    mainControlsRef: { current: null },
+    currentIDE: null,
+    updateInfo: null,
+    showIdeRestartPrompt: false,
+    ideTrustRestartReason: {} as UIState['ideTrustRestartReason'],
+    isRestarting: false,
+    extensionsUpdateState: new Map(),
+    activePtyId: undefined,
+    embeddedShellFocused: false,
+    showWelcomeBackDialog: false,
+    welcomeBackInfo: null,
+    welcomeBackChoice: null,
+    isSubagentCreateDialogOpen: false,
+    isAgentsManagerDialogOpen: false,
+    isExtensionsManagerDialogOpen: false,
+    isMcpDialogOpen: false,
+    isHooksDialogOpen: false,
+    isFeedbackDialogOpen: false,
+    taskStartTokens: 0,
+    streamingResponseLengthRef: { current: 0 },
+    isReceivingContent: false,
+    sessionName: null,
+    setSessionName: vi.fn(),
+    promptSuggestion: null,
+    dismissPromptSuggestion: vi.fn(),
+    isRewindSelectorOpen: false,
+    rewindEscPending: false,
+    ...overrides,
+  }) as UIState;
+
+const createUIActions = (): UIActions =>
+  ({
+    refreshStatic: vi.fn(),
+  }) as unknown as UIActions;
+
+const renderMainContent = (uiState: UIState) =>
+  render(
+    <AppContext.Provider value={{ version: '1.2.3', startupWarnings: [] }}>
+      <CompactModeProvider value={{ compactMode: false }}>
+        <UIActionsContext.Provider value={createUIActions()}>
+          <UIStateContext.Provider value={uiState}>
+            <OverflowProvider>
+              <MainContent />
+            </OverflowProvider>
+          </UIStateContext.Provider>
+        </UIActionsContext.Provider>
+      </CompactModeProvider>
+    </AppContext.Provider>,
+  );
+
+describe('<MainContent />', () => {
+  it('renders AppHeader inside Static at the top of the static content', () => {
+    staticPropsSpy.mockClear();
+    staticItemsSpy.mockClear();
+    appHeaderSpy.mockClear();
+
+    const { lastFrame, rerender } = renderMainContent(
+      createUIState({ currentModel: 'gpt-5.5', historyRemountKey: 7 }),
+    );
+
+    expect(lastFrame()).toContain('APP_HEADER:1.2.3');
+    expect(lastFrame()).toContain('DEBUG_NOTIFICATION');
+    expect(lastFrame()).toContain('NOTIFICATIONS');
+    expect(staticPropsSpy).toHaveBeenCalled();
+    expect(staticItemsSpy).toHaveBeenLastCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'app-header' }),
+        expect.objectContaining({ key: 'debug-notification' }),
+        expect.objectContaining({ key: 'notifications' }),
+      ]),
+    );
+    expect(staticItemsSpy.mock.calls.at(-1)?.[0]).toHaveLength(3);
+    expect(appHeaderSpy).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <AppContext.Provider value={{ version: '1.2.3', startupWarnings: [] }}>
+        <CompactModeProvider value={{ compactMode: false }}>
+          <UIActionsContext.Provider value={createUIActions()}>
+            <UIStateContext.Provider
+              value={createUIState({
+                currentModel: 'gpt-5.4',
+                historyRemountKey: 7,
+              })}
+            >
+              <OverflowProvider>
+                <MainContent />
+              </OverflowProvider>
+            </UIStateContext.Provider>
+          </UIActionsContext.Provider>
+        </CompactModeProvider>
+      </AppContext.Provider>,
+    );
+
+    expect(staticItemsSpy.mock.calls.at(-1)?.[0]).toHaveLength(3);
+    expect(appHeaderSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -35,6 +35,7 @@ export const MainContent = () => {
     mainAreaWidth,
     staticAreaMaxItemHeight,
     availableTerminalHeight,
+    historyRemountKey,
   } = uiState;
 
   // Merge consecutive tool_groups for compact mode display
@@ -87,7 +88,7 @@ export const MainContent = () => {
   return (
     <>
       <Static
-        key={`${uiState.historyRemountKey}-${uiState.currentModel}`}
+        key={historyRemountKey}
         items={[
           <AppHeader key="app-header" version={version} />,
           <DebugModeNotification key="debug-notification" />,

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -569,6 +569,47 @@ describe('Server Config (config.ts)', () => {
 
       expect(stripSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('should notify model change listeners after switchModel', async () => {
+      const config = new Config(baseParams);
+
+      const mockContentConfig: ContentGeneratorConfig = {
+        authType: AuthType.QWEN_OAUTH,
+        model: 'coder-model',
+        apiKey: 'QWEN_OAUTH_DYNAMIC_TOKEN',
+        baseUrl: DEFAULT_DASHSCOPE_BASE_URL,
+        timeout: 60000,
+        maxRetries: 3,
+      } as ContentGeneratorConfig;
+
+      vi.mocked(resolveContentGeneratorConfigWithSources).mockImplementation(
+        (_config, authType, generationConfig) => ({
+          config: {
+            ...mockContentConfig,
+            authType,
+            model: generationConfig?.model ?? mockContentConfig.model,
+          } as ContentGeneratorConfig,
+          sources: {},
+        }),
+      );
+      vi.mocked(createContentGenerator).mockResolvedValue({
+        generateContent: vi.fn(),
+        generateContentStream: vi.fn(),
+        countTokens: vi.fn(),
+        embedContent: vi.fn(),
+      } as unknown as ContentGenerator);
+
+      await config.refreshAuth(AuthType.QWEN_OAUTH);
+
+      const listener = vi.fn();
+      const unsubscribe = config.onModelChange(listener);
+
+      await config.switchModel(AuthType.QWEN_OAUTH, 'coder-model');
+
+      expect(listener).toHaveBeenCalledWith('coder-model');
+
+      unsubscribe();
+    });
   });
 
   describe('model switching with different credentials (OpenAI)', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -682,6 +682,7 @@ export class Config {
   private hookSystem?: HookSystem;
   private messageBus?: MessageBus;
   private readonly memoryManager: MemoryManager;
+  private readonly modelChangeListeners = new Set<(model: string) => void>();
 
   constructor(params: ConfigParameters) {
     this.sessionId = params.sessionId ?? randomUUID();
@@ -1370,6 +1371,20 @@ export class Config {
     return this.contentGeneratorConfig?.model || this.modelsConfig.getModel();
   }
 
+  onModelChange(listener: (model: string) => void): () => void {
+    this.modelChangeListeners.add(listener);
+    return () => {
+      this.modelChangeListeners.delete(listener);
+    };
+  }
+
+  private notifyModelChangeListeners(): void {
+    const model = this.getModel();
+    for (const listener of this.modelChangeListeners) {
+      listener(model);
+    }
+  }
+
   /**
    * Returns the fast model if one is configured and valid for the current auth type,
    * otherwise returns undefined. Background agents (memory extraction, dream, /btw)
@@ -1406,6 +1421,7 @@ export class Config {
     if (this.contentGeneratorConfig) {
       this.contentGeneratorConfig.model = newModel;
     }
+    this.notifyModelChangeListeners();
   }
 
   /**
@@ -1524,6 +1540,7 @@ export class Config {
     options?: { requireCachedCredentials?: boolean },
   ): Promise<void> {
     await this.modelsConfig.switchModel(authType, modelId, options);
+    this.notifyModelChangeListeners();
   }
 
   getMaxSessionTurns(): number {


### PR DESCRIPTION
## Summary

- What changed:
  - Added a public `Config.onModelChange(...)` subscription API in core.
  - Switched the CLI TUI from polling-based model detection to event-driven header refresh.
  - Kept `AppHeader` inside Ink `<Static>` while removing `currentModel` from the static remount key.
  - Added focused regression coverage for config model-change notifications and static header composition.
- Why it changed:
  - Switching models via `/model` could remount the static region and re-print the banner, causing duplicate header output.
  - Moving the header outside `<Static>` avoided duplication but regressed layout by making the banner stick below chat content.
  - The final fix redraws the static region only when the model actually changes, without polling hacks.
- Reviewer focus:
  - Verify the event-driven `Config` listener flow.
  - Verify the static header remains at the top after model switches and subsequent chat messages.
  - Verify the fix avoids duplicate banner prints.

## Validation

- Commands run:
  ```bash
  npm run lint
  npm run typecheck
  npm run build
  cd packages/core && npx vitest run
  cd packages/cli && npx vitest run
  ```
- Prompts / inputs used:
  - `/model <id>` to switch models in the CLI TUI.
  - Follow-up normal chat input after switching models.
- Expected result:
  - The header updates to the new model without duplicate static output.
  - The banner stays at the top instead of moving below dynamic chat content.
  - No polling loop is needed to detect model changes.
- Observed result:
  - Local verification passed.
  - Full lint, typecheck, build, and complete `packages/core` + `packages/cli` test suites passed.
- Quickest reviewer verification path:
  - Start the CLI locally.
  - Switch models multiple times with `/model`.
  - Send a normal message.
  - Confirm the header updates correctly, stays at the top, and does not duplicate.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  - Automated coverage:
    - `packages/core/src/config/config.test.ts`
    - `packages/cli/src/ui/components/MainContent.test.tsx`
  - Full affected-package suites passed locally:
    - `packages/core`: 6104 passed, 2 skipped
    - `packages/cli`: 4621 passed, 7 skipped

## Scope / Risk

- Main risk or tradeoff:
  - The UI now depends on the new public model-change subscription contract in `Config`; future model mutation paths should continue notifying listeners.
- Not covered / not validated:
  - I did not add an end-to-end tmux artifact in this PR.
  - Cross-platform manual TUI verification was not performed beyond local darwin validation.
- Breaking changes / migration notes:
  - None expected.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Verified locally on darwin only.
- `npm run lint`, `npm run typecheck`, and `npm run build` passed.
- Full `packages/core` and `packages/cli` vitest suites passed.

## Linked Issues / Bugs