### PR TITLE
docs(design): banner customization design (#3005)

### DIFF
--- a/docs/design/customize-banner-area/customize-banner-area.md
+++ b/docs/design/customize-banner-area/customize-banner-area.md
@@ -1,0 +1,590 @@
+# Customize Banner Area Design
+
+> Allow users to replace the QWEN ASCII art, replace the brand title, and
+> hide the banner entirely — without letting them suppress the operational
+> data (version, auth, model, working directory) that makes Qwen Code
+> debuggable and trustworthy.
+
+## Overview
+
+The Qwen Code CLI prints a banner at startup containing a QWEN ASCII logo
+and a bordered info panel. Several real-world use cases want some control
+over this surface:
+
+- **White-label / third-party brand integration**: enterprises and teams
+  embedding Qwen Code into their own products want to display their brand
+  identity rather than the default "Qwen Code".
+- **Personalization**: individuals want to match the terminal banner to a
+  team standard or their own taste.
+- **Multi-tenant / multi-instance distinction**: in shared environments,
+  different teams want a quick visual signal of which instance they are
+  in.
+
+The design stance is simple: **brand chrome is replaceable; operational
+data is not**. Customization should let users put their own branding on
+top, not let them silence the information that makes a session
+debuggable. That stance drives every "what can change vs. what is locked"
+decision in the rest of this document.
+
+This is tracked by [issue #3005](https://github.com/QwenLM/qwen-code/issues/3005).
+
+## Banner region taxonomy
+
+Today the banner is rendered by `Header` (mounted from `AppHeader`) and
+breaks into the following regions:
+
+```
+  marginX=2                                                           marginX=2
+  │                                                                          │
+  ▼                                                                          ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                                                                             │
+│   ┌──── Logo Column ─────┐  gap=2  ┌──── Info Panel (bordered) ──────────┐  │
+│   │                      │         │                                     │  │
+│   │  ███ QWEN ASCII ███  │         │  ① Title:   >_ Qwen Code (vX.Y.Z)   │  │
+│   │  ███   ART ART  ███  │         │                                     │  │
+│   │  ███ QWEN ASCII ███  │         │  ② Status:  Qwen OAuth | qwen-coder │  │
+│   │                      │         │  ③ Path:    ~/projects/example      │  │
+│   └──────── A ───────────┘         └──────────────── B ──────────────────┘  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+                              region: AppHeader
+                          │ Tips component renders below (governed by ui.hideTips) │
+```
+
+The two top-level boxes are:
+
+- **A. Logo column** — a single ASCII art block with a gradient. Sourced
+  today from `shortAsciiLogo` in
+  `packages/cli/src/ui/components/AsciiArt.ts`.
+- **B. Info panel** — a bordered box containing three lines:
+  - **B①** Title: `>_ Qwen Code (vX.Y.Z)` — brand text + version suffix.
+  - **B②** Status: `<auth display type> | <model> ( /model to change)`.
+  - **B③** Path: a tildeified, shortened working directory.
+
+The whole thing is wrapped by `<AppHeader>`, which already gates the
+banner on `showBanner = !config.getScreenReader()` (screen-reader mode
+falls back to plain output).
+
+## Customization rules — what can change, what is locked
+
+| Region | Today's source | Customization category | Rationale |
+| --- | --- | --- | --- |
+| **A. Logo column** | `shortAsciiLogo` (`AsciiArt.ts`) | **Replaceable + auto-hideable** | Pure brand surface. White-label needs full control over the visual. The existing "auto-hide on narrow terminals" fallback is preserved. |
+| **B①. Title — brand text** (`>_ Qwen Code`) | Hard-coded in `Header.tsx` | **Replaceable** | Brand surface. The leading `>_` glyph is part of the existing brand; if a user wants it gone, they simply omit it from `customBannerTitle`. |
+| **B①. Title — version suffix** (`(vX.Y.Z)`) | `version` prop | **Locked** | Critical for bug reports. Hiding it makes "what version are you on?" answerable only via `--version`, which is a real cost in support workflows. We trade a small white-label loss for support tractability. |
+| **B②. Status line** (auth + model) | `formattedAuthType`, `model` props | **Locked** | Operational and security signal. Users must always see which credential is in use and which model will spend their tokens. Suppressing it is a footgun even for white-label scenarios. |
+| **B③. Path line** (working directory) | `workingDirectory` prop | **Locked** | Operational. "Which directory am I in?" is a constant question; the banner is its canonical answer. |
+| **Whole banner** (A + B) | `<Header>` mount in `AppHeader.tsx` | **Hideable** | A single `ui.hideBanner: true` skips both regions — same shape as the existing screen-reader gate. `<Tips>` continues to be governed independently by `ui.hideTips`. |
+
+The matrix translates to three settings, no more:
+
+| Setting | Default | Effect | Region affected |
+| --- | --- | --- | --- |
+| `ui.hideBanner` | `false` | Hides the entire banner (regions A + B). | A + B |
+| `ui.customBannerTitle` | unset | Replaces the brand text in B①. The version suffix is still appended. Trimmed; an empty string means "use default". | B① brand text |
+| `ui.customAsciiArt` | unset | Replaces region A. Three accepted shapes (see below). Falls back to default on any error. | A |
+
+What is **not** offered, by design:
+
+- No setting hides only the version suffix.
+- No setting hides only the auth/model line.
+- No setting hides only the path line.
+- No setting changes the gradient colors of the logo (theme owns that).
+- No setting reorders or restructures the info panel.
+
+If the implementation later needs to expose any of those, they should be
+new fields with their own justification — not derived from the three
+fields above.
+
+## User configuration guide — how to modify
+
+All three settings live under `ui` in `settings.json`. Both user-level
+(`~/.qwen/settings.json`) and workspace-level (`.qwen/settings.json` in
+the project root) are supported with the standard merge precedence
+(workspace overrides user, system overrides workspace).
+
+### Hide the banner entirely
+
+```jsonc
+{
+  "ui": {
+    "hideBanner": true
+  }
+}
+```
+
+The startup output skips both the logo column and the info panel. Tips
+still render unless `ui.hideTips` is also `true`.
+
+### Replace the brand title
+
+```jsonc
+{
+  "ui": {
+    "customBannerTitle": "Acme CLI"
+  }
+}
+```
+
+Renders as `Acme CLI (vX.Y.Z)` in the info panel. The `>_` glyph is
+removed when a custom title is set; if you want it back, include it
+yourself: `"customBannerTitle": ">_ Acme CLI"`.
+
+### Replace the ASCII art — inline string
+
+```jsonc
+{
+  "ui": {
+    "customAsciiArt": "  ___  _    _  ____ \n / _ \\| |  / |/ _\\\n| |_| | |__| | __/\n \\___/|____|_|___|"
+  }
+}
+```
+
+Use `\n` to embed newlines inside the JSON string. The art is rendered
+with the active gradient theme just like the default logo.
+
+> **Don't have ASCII art handy?** Use any external generator and paste
+> the result. The simplest path is `figlet`:
+> `npx figlet -f "ANSI Shadow" "xxxCode" > brand.txt` and then point
+> `customAsciiArt: { "path": "./brand.txt" }` at it. The CLI does not
+> render text-to-art at runtime — see the *Out of scope* section for
+> why.
+
+### Replace the ASCII art — external file
+
+```jsonc
+{
+  "ui": {
+    "customAsciiArt": { "path": "./brand.txt" }
+  }
+}
+```
+
+Avoids JSON-escaping a multi-line string. Path resolution rules:
+
+- **Workspace settings**: relative paths resolve against the workspace
+  `.qwen/` directory.
+- **User settings**: relative paths resolve against `~/.qwen/`.
+- Absolute paths are used as-is.
+- The file is read **once at startup**, sanitized, and cached. Editing
+  the file mid-session does not re-render the banner — restart the CLI.
+
+### Replace the ASCII art — width-aware
+
+```jsonc
+{
+  "ui": {
+    "customAsciiArt": {
+      "small": "  ACME\n  ----",
+      "large": { "path": "./brand-wide.txt" }
+    }
+  }
+}
+```
+
+`large` is preferred when the terminal is wide enough; otherwise `small`
+is used; otherwise the logo column is hidden (the existing two-column
+fallback). Either tier may be a string or `{ path }`. Either tier may be
+omitted: a missing tier simply falls through to the next step.
+
+### Combine all three
+
+```jsonc
+{
+  "ui": {
+    "hideBanner": false,
+    "customBannerTitle": "Acme CLI",
+    "customAsciiArt": {
+      "small": "  ACME\n  ----",
+      "large": { "path": "./brand-wide.txt" }
+    }
+  }
+}
+```
+
+### How to verify your change
+
+1. Save `settings.json` and start a fresh `qwen` session — banner
+   resolution runs once at startup.
+2. Resize the terminal to confirm `small` / `large` tiers swap as
+   expected, and that the logo column disappears at very narrow widths.
+3. If something does not appear as expected, look at
+   `~/.qwen/debug/<sessionId>.txt` (the symlink `latest.txt` points to
+   the current session) and grep for `[BANNER]` — every soft failure
+   logs a warn line with the underlying reason.
+
+## Resolution pipeline
+
+```
+   settings.json                              packages/cli/src/ui/components/
+   ─────────────                              ──────────────────────────────
+   {                                          AppHeader.tsx
+     "ui": {                                    │
+       "hideBanner": false,                     │  showBanner =
+       "customBannerTitle": "Acme",             │      !screenReader
+       "customAsciiArt": …                      │   && !ui.hideBanner
+     }                                          │
+   }                                            ▼
+        │                              <Header
+        ▼                                customAsciiArt={resolved}
+   loadSettings()                        customBannerTitle="Acme"
+   merge user / workspace                version=… model=… authType=…
+        │                                workingDirectory=… />
+        ▼                                          │
+   resolveCustomBanner(merged, paths)              ▼
+   ┌─────────────────────────┐         packages/cli/src/ui/components/
+   │ 1. normalize to         │         Header.tsx
+   │    { small, large }     │           │
+   │ 2. resolve each tier:   │           │  pick tier by
+   │    string → as-is       │           │    availableTerminalWidth
+   │    {path} → fs.read     │           │
+   │      O_NOFOLLOW         │           ▼
+   │      ≤ 64 KB            │         render Logo Column
+   │ 3. sanitize:            │         render Info Panel:
+   │    stripControlSeqs     │           Title  = customBannerTitle
+   │    ≤ 200 lines × 200    │                 ?? '>_ Qwen Code'
+   │    cols                 │           Status = locked
+   │ 4. memoize by source    │           Path   = locked
+   └─────────────────────────┘
+```
+
+The five-step resolution algorithm runs once when settings are loaded
+and again only on settings reload events:
+
+1. **Normalize**. A bare `string` or `{ path }` becomes
+   `{ small: x, large: x }`. A `{ small, large }` object passes through.
+2. **Resolve each tier**. For each `AsciiArtSource`:
+   - If it is a string, use it as-is.
+   - If it is `{ path }`, read the file synchronously with `O_NOFOLLOW`
+     defense (Windows: plain read-only — the constant is not exposed),
+     capped at 64 KB. Relative paths resolve against the *owning
+     settings file's directory* — workspace settings against the
+     workspace `.qwen/`, user settings against `~/.qwen/`. Read failure
+     logs `[BANNER]` warn and falls back to default for that tier.
+3. **Sanitize**. Pass each resolved string through
+   `stripTerminalControlSequences` (shared with the session-title
+   feature), trim trailing whitespace, then cap at 200 lines × 200
+   columns. Anything beyond the cap is truncated and a `[BANNER]` warn
+   is logged.
+4. **Render-time tier selection**. In `Header.tsx`, given the resolved
+   `small` and `large`, evaluate the existing width budget
+   (`availableTerminalWidth ≥ logoWidth + logoGap + minInfoPanelWidth`):
+   - Prefer `large` if it fits.
+   - Else fall back to `small` if it fits.
+   - Else hide the logo column entirely (the existing
+     `showLogo = false` branch). The info panel still renders.
+5. **Fallback**. If both tiers end up empty or invalid, render
+   `shortAsciiLogo` as if no customization had been set. The CLI must
+   never crash on a banner config error.
+
+Pseudocode for tier selection:
+
+```ts
+function pickTier(
+  small: string | undefined,
+  large: string | undefined,
+  availableWidth: number,
+  logoGap: number,
+  minInfoPanelWidth: number,
+): string | undefined {
+  for (const candidate of [large, small]) {
+    if (!candidate) continue;
+    const w = getAsciiArtWidth(candidate);
+    if (availableWidth >= w + logoGap + minInfoPanelWidth) {
+      return candidate;
+    }
+  }
+  return undefined; // logo column hidden
+}
+```
+
+## Settings schema additions
+
+Three new properties are appended to the `ui` object in
+`packages/cli/src/config/settingsSchema.ts`, immediately after
+`shellOutputMaxLines` (around line 720):
+
+```ts
+hideBanner: {
+  type: 'boolean',
+  label: 'Hide Banner',
+  category: 'UI',
+  requiresRestart: false,
+  default: false,
+  description: 'Hide the startup ASCII banner and info panel.',
+  showInDialog: true,
+},
+customBannerTitle: {
+  type: 'string',
+  label: 'Custom Banner Title',
+  category: 'UI',
+  requiresRestart: false,
+  default: '' as string,
+  description:
+    'Replace the default ">_ Qwen Code" title shown in the banner info panel. The version suffix is always appended.',
+  showInDialog: false,
+},
+customAsciiArt: {
+  type: 'object',
+  label: 'Custom ASCII Art',
+  category: 'UI',
+  requiresRestart: false,
+  default: undefined,
+  description:
+    'Replace the default QWEN ASCII art. Accepts an inline string, {"path": "..."}, or {"small": ..., "large": ...} for width-aware selection.',
+  showInDialog: false,
+},
+```
+
+`hideBanner` mirrors the existing `hideTips` pattern (`showInDialog:
+true`). The two free-form fields stay out of the in-app settings dialog
+because a multi-line ASCII editor in the TUI dialog is its own project;
+power users edit `settings.json` directly.
+
+## Wiring changes
+
+The implementation touch points are small. Each is described below with
+the file and line range from the current `main`.
+
+`packages/cli/src/ui/components/AppHeader.tsx:53` — extend `showBanner`:
+
+```ts
+const showBanner =
+  !config.getScreenReader() && !settings.merged.ui?.hideBanner;
+```
+
+`packages/cli/src/ui/components/AppHeader.tsx:64-71` — pass the resolved
+banner into `<Header>`:
+
+```tsx
+<Header
+  version={version}
+  authDisplayType={authDisplayType}
+  model={model}
+  workingDirectory={targetDir}
+  customAsciiArt={resolvedCustomAsciiArt /* { small?, large? } */}
+  customBannerTitle={resolvedCustomBannerTitle /* string | undefined */}
+/>
+```
+
+`packages/cli/src/ui/components/Header.tsx:28-34` — extend `HeaderProps`:
+
+```ts
+interface HeaderProps {
+  customAsciiArt?: { small?: string; large?: string };
+  customBannerTitle?: string;
+  version: string;
+  authDisplayType?: AuthDisplayType;
+  model: string;
+  workingDirectory: string;
+}
+```
+
+`packages/cli/src/ui/components/Header.tsx:45-46` — pick the tier before
+computing `logoWidth`, with the existing default as the floor:
+
+```ts
+const tier = pickTier(
+  customAsciiArt?.small,
+  customAsciiArt?.large,
+  availableTerminalWidth,
+  logoGap,
+  minInfoPanelWidth,
+);
+const displayLogo = tier ?? shortAsciiLogo;
+```
+
+`packages/cli/src/ui/components/Header.tsx:144` — render the title from
+the prop:
+
+```tsx
+<Text bold color={theme.text.accent}>
+  {customBannerTitle && customBannerTitle.trim()
+    ? customBannerTitle
+    : '>_ Qwen Code'}
+</Text>
+```
+
+**New file**: `packages/cli/src/ui/utils/customBanner.ts` — the resolver.
+Exports:
+
+```ts
+export interface ResolvedBanner {
+  asciiArt: { small?: string; large?: string };
+  title?: string;
+}
+
+export function resolveCustomBanner(
+  settings: LoadedSettings,
+  paths: { userDir: string; workspaceDir?: string },
+): ResolvedBanner;
+```
+
+The resolver does the normalization, file reads, sanitization, and
+caching described in the resolution pipeline above. It is called once
+during CLI startup and re-run on settings hot-reload events.
+
+## Alternative approaches considered
+
+Five shapes of this feature were considered. They are listed here so
+future contributors understand the design space and can revisit the
+choice if the constraints change.
+
+### Option 1 — Three flat settings (RECOMMENDED, matches the issue)
+
+```jsonc
+{
+  "ui": {
+    "customAsciiArt": "...",        // string | {path} | {small,large}
+    "customBannerTitle": "Acme CLI",
+    "hideBanner": false
+  }
+}
+```
+
+- **Effect**: minimal user-facing surface; exactly what the issue asks
+  for.
+- **Pros**: zero learning curve; trivially documented; consistent with
+  existing flat `ui.*` properties (`hideTips`, `customWittyPhrases`,
+  etc.).
+- **Cons**: three top-level keys that conceptually belong together
+  aren't grouped; future banner-only knobs (gradient, subtitle) would
+  add more siblings to `ui` instead of nesting cleanly.
+
+### Option 2 — Nested `ui.banner` namespace
+
+```jsonc
+{
+  "ui": {
+    "banner": {
+      "hide": false,
+      "title": "Acme CLI",
+      "asciiArt": { "path": "./brand.txt" }
+    }
+  }
+}
+```
+
+- **Effect**: same capabilities as Option 1, organized by feature.
+- **Pros**: clean namespace for future banner-only knobs; easier
+  discovery via `/settings`.
+- **Cons**: diverges from the issue's exact wording; existing UI
+  settings are mostly flat (only `ui.accessibility` and `ui.statusLine`
+  nest), so consistency is mixed; adds one nesting level for users to
+  remember.
+
+### Option 3 — Banner profile presets + slot overrides
+
+```jsonc
+{
+  "ui": {
+    "bannerProfile": "minimal" | "default" | "branded" | "hidden",
+    "banner": { /* slot overrides for 'branded' */ }
+  }
+}
+```
+
+- **Effect**: users pick from named presets; advanced users override
+  slots inside a chosen profile.
+- **Pros**: nice onboarding UX; presets ship with the CLI.
+- **Cons**: significant complexity; presets are a maintenance
+  commitment; the issue asks for raw customization, not curation.
+
+### Option 4 — Whole-banner override (single string template)
+
+```jsonc
+{
+  "ui": {
+    "bannerTemplate": "{{logo}}\n>_ {{title}} ({{version}})\n{{auth}} | {{model}}\n{{path}}"
+  }
+}
+```
+
+- **Effect**: single freeform template with locked variables filled in.
+- **Pros**: maximum flexibility for non-standard layouts.
+- **Cons**: re-implements layout in user-space; loses Ink's two-column
+  resilience to terminal width; very easy to write a template that
+  breaks on narrow terminals; large blast radius for a small feature.
+
+### Option 5 — Plugin / hook API
+
+Expose a banner-renderer hook through the extensions system.
+
+- **Effect**: code-level customization; extensions can render anything.
+- **Pros**: maximum power; lets enterprises ship a sealed branding
+  plugin.
+- **Cons**: large API surface; needs security review for arbitrary
+  terminal rendering; massively over-scoped for the issue.
+
+### Recommendation
+
+**Option 1** is recommended. It satisfies the issue verbatim, slots into
+the existing `ui.*` style, and avoids forcing a nested-namespace
+decision before we know what other banner-only knobs would actually
+look like. If future siblings start accumulating, migrating to Option 2
+is additive — `ui.banner.title` and `ui.customBannerTitle` can coexist
+during a deprecation window.
+
+## Security & failure handling
+
+The custom banner content is rendered verbatim in the terminal AND, in
+the path-form, read from disk. Both surfaces are attack-reachable if a
+hostile or compromised settings file is loaded. The same threat model
+that drives the session-title feature applies here.
+
+| Concern | Guard |
+| --- | --- |
+| ANSI / OSC-8 / CSI injection in art or title | `stripTerminalControlSequences` (shared with session-title) before render and before any cache write. |
+| Oversize file freezes startup | 64 KB hard cap on file reads. |
+| Pathological art freezes layout | 200 lines × 200 cols cap on each resolved string. Excess is truncated; a `[BANNER]` warn is logged. |
+| Symlink redirect on the path form | `O_NOFOLLOW` on file reads (Windows: plain read-only; constant not exposed). |
+| Missing or unreadable file | Catch, log `[BANNER]` warn, fall back to default. Never throw into the UI. |
+| Title with newlines or excess length | Strip newlines, cap at 80 characters. |
+| Race on settings reload | Resolution is memoized by source (path or string hash). Reloads invalidate cache for changed sources only. |
+
+Failure mode summary: every soft failure ends in `shortAsciiLogo` (or
+the locked default title) plus a debug-log warn. Hard failures
+(thrown errors) are not allowed in any branch of the resolver.
+
+## Out of scope
+
+These were considered and deliberately deferred. Each can be a separate
+follow-up if user demand surfaces.
+
+| Item | Why not |
+| --- | --- |
+| Text-to-ASCII rendering (`{ text: "xxxCode" }` form) | Considered and rejected for v1. Adding this would require either a `figlet` runtime dependency (~2–3 MB unpacked once a usable set of fonts is included) or a vendored single-font renderer (~200 lines + a `.flf` font file we'd own). Both options bring ongoing surface area: font selection, font-license tracking, "my font doesn't render right on terminal X" issues, and CJK / wide-character handling. The driving use case for this feature (white-label / multi-tenant) almost always has a designer producing intentional ASCII art, not relying on a default figlet font. Users who want one-line generation can already get it with `npx figlet "xxxCode" > brand.txt` + `customAsciiArt: { "path": "./brand.txt" }` — same outcome, no added dependency, no support burden inside Qwen Code. If demand surfaces later this form is purely additive: extend `AsciiArtSource` to `string \| {path} \| {text, font?}` without breaking any existing config. |
+| `/banner` slash command for live editing | The settings UI is the canonical edit surface. A live editor for multi-line ASCII art is its own project. |
+| Custom gradient colors / per-line color overrides | Theme owns colors. A separate proposal can extend the theme contract; banner customization should not duplicate that surface. |
+| URL-loaded ASCII art | Network fetch at startup is its own can of worms — failure modes, caching, security review. The file-path form is the lower-risk equivalent. |
+| Animation (spinning logo, marquee title) | Adds rendering load and a11y concerns; nothing in the use cases needs it. |
+| VSCode / Web UI banner parity | Those surfaces don't render the Ink banner today. If they grow a banner, this design is the reference. |
+| Dynamic reload on file change | The resolver runs at startup and on settings reload only. Mid-session art changes are rare enough that "restart to take effect" is the acceptable trade. |
+| Hiding only individual locked regions (version, auth, model, path) | These are operational signals; suppressing them harms support and security posture more than it helps white-label scenarios. |
+
+## Verification plan
+
+For the eventual implementation PR, the following end-to-end checks
+should pass.
+
+1. `~/.qwen/settings.json` with `customBannerTitle: "Acme CLI"` and an
+   inline `customAsciiArt` string → `qwen` shows the new title and art;
+   version suffix still present.
+2. `hideBanner: true` → `qwen` starts with no banner; tips and chat
+   render normally.
+3. `customAsciiArt: { "path": "./brand.txt" }` in a workspace
+   `settings.json`, with `brand.txt` next to it in `.qwen/` → loads
+   from disk on workspace open.
+4. `customAsciiArt: { "small": "...", "large": "..." }` → resize the
+   terminal between wide / medium / narrow; large at wide widths,
+   small at medium widths, logo column hidden at narrow widths, info
+   panel always visible.
+5. Inject `\x1b[31mhostile` into `customBannerTitle` → renders as
+   literal text, not interpreted as red.
+6. Point `path` at a missing file → CLI starts; `[BANNER]` warn
+   appears in `~/.qwen/debug/<sessionId>.txt`; default art renders.
+7. `npm test` and `npm run typecheck` pass for the CLI package; unit
+   tests in `customBanner.test.ts` cover each accepted shape and each
+   failure path (missing file, oversize file, ANSI injection, malformed
+   object).

--- a/docs/design/customize-banner-area/customize-banner-area.zh-CN.md
+++ b/docs/design/customize-banner-area/customize-banner-area.zh-CN.md
@@ -1,0 +1,556 @@
+# Banner 自定义区域设计方案
+
+> 允许用户替换 QWEN ASCII Logo、替换品牌标题、整体隐藏 Banner ——
+> 但不允许抹掉用于排障与可信度的运行时信息（版本号、鉴权方式、模型、
+> 工作目录）。
+
+## 概述
+
+Qwen Code CLI 启动时会在终端顶部打印一个 Banner，包含 QWEN ASCII
+Logo 和一个带边框的信息面板。多种真实场景需要对这一区域进行控制：
+
+- **白标 / 第三方品牌集成**：将 Qwen Code 嵌入企业或团队自有产品时，
+  需要展示自家品牌而非默认的 "Qwen Code"。
+- **个性化**：个人用户希望让终端 Banner 与团队规范或个人审美一致。
+- **多租户 / 多实例区分**：在共享环境下，不同团队希望快速辨认自己
+  正在使用哪个实例。
+
+设计立场十分简单：**品牌外观可替换；运行时信息不可替换**。
+自定义只允许用户把自己的品牌叠在上面，**不允许**屏蔽用于排障的关键
+信息。本文档后续每一处「可改 / 不可改」的判定都来自这一立场。
+
+对应 issue：[#3005](https://github.com/QwenLM/qwen-code/issues/3005)。
+
+## Banner 区域划分
+
+当前 Banner 由 `Header`（由 `AppHeader` 挂载）渲染，整体可拆分如下：
+
+```
+  marginX=2                                                           marginX=2
+  │                                                                          │
+  ▼                                                                          ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                                                                             │
+│   ┌──── Logo 列 ─────────┐  gap=2  ┌──── 信息面板 (带边框) ──────────────┐  │
+│   │                      │         │                                     │  │
+│   │  ███ QWEN ASCII ███  │         │  ① 标题：  >_ Qwen Code (vX.Y.Z)    │  │
+│   │  ███   ART ART  ███  │         │                                     │  │
+│   │  ███ QWEN ASCII ███  │         │  ② 状态：  Qwen OAuth | qwen-coder  │  │
+│   │                      │         │  ③ 路径：  ~/projects/example       │  │
+│   └──────── A ───────────┘         └──────────────── B ──────────────────┘  │
+│                                                                             │
+└─────────────────────────────────────────────────────────────────────────────┘
+                              区域归属：AppHeader
+                          │ Tips 组件渲染在下方（由 ui.hideTips 控制） │
+```
+
+两个顶级区块：
+
+- **A. Logo 列** —— 单块带渐变色的 ASCII art。
+  当前来源：`packages/cli/src/ui/components/AsciiArt.ts` 中的
+  `shortAsciiLogo`。
+- **B. 信息面板** —— 带边框的信息盒，包含三行：
+  - **B①** 标题：`>_ Qwen Code (vX.Y.Z)` —— 品牌文字 + 版本号后缀。
+  - **B②** 状态：`<鉴权显示类型> | <模型> ( /model 切换)`。
+  - **B③** 路径：经过 tildeify 与缩短的工作目录。
+
+外层 `<AppHeader>` 已经基于 `showBanner = !config.getScreenReader()`
+对 Banner 做了屏读模式下的整体隐藏处理（屏读模式下回退为纯文本输出）。
+
+## 自定义规则 —— 哪些可改，哪些被锁定
+
+| 区域 | 当前来源 | 自定义类别 | 锁定/开放原因 |
+| --- | --- | --- | --- |
+| **A. Logo 列** | `shortAsciiLogo` (`AsciiArt.ts`) | **可替换 + 可自动隐藏** | 纯品牌区域。白标场景需要完全控制视觉。窄终端下「自动隐藏 Logo」的现有行为保持不变。 |
+| **B①. 标题文字**（`>_ Qwen Code`） | `Header.tsx` 硬编码 | **可替换** | 品牌区域。开头的 `>_` 字符是现有品牌的一部分；如不需要，用户在 `customBannerTitle` 中省略即可。 |
+| **B①. 版本号后缀**（`(vX.Y.Z)`） | `version` prop | **锁定** | 排障与支持必备。隐藏后只能通过 `--version` 才能回答「你用的什么版本？」，对支持流程是真实成本。我们以小幅白标体验损失换取支持可达性。 |
+| **B②. 状态行**（鉴权 + 模型） | `formattedAuthType`、`model` prop | **锁定** | 运营与安全信号。用户必须看到当前使用的凭据以及实际消耗 token 的模型。任何隐藏/替换都是 footgun，即便在白标场景下也不应允许。 |
+| **B③. 路径行**（工作目录） | `workingDirectory` prop | **锁定** | 运营信息。「我现在在哪个目录？」是高频问题；Banner 是其唯一权威答案。 |
+| **整个 Banner** (A + B) | `AppHeader.tsx` 中 `<Header>` 挂载点 | **可隐藏** | 一个 `ui.hideBanner: true` 同时跳过 A、B 两个区块 —— 形态与现有屏读模式开关一致。`<Tips>` 仍由独立的 `ui.hideTips` 控制。 |
+
+上述矩阵对应三个设置项，仅此而已：
+
+| 设置 | 默认值 | 效果 | 影响区域 |
+| --- | --- | --- | --- |
+| `ui.hideBanner` | `false` | 隐藏整个 Banner（区域 A + B）。 | A + B |
+| `ui.customBannerTitle` | 未设置 | 替换 B① 的品牌文字。版本号后缀照常追加。会被 trim；空字符串 = 使用默认。 | B① 品牌文字 |
+| `ui.customAsciiArt` | 未设置 | 替换区域 A。支持三种数据形态（见下文）。任何错误均回退为默认。 | A |
+
+**有意不提供**的能力：
+
+- 不提供「仅隐藏版本号后缀」的开关。
+- 不提供「仅隐藏鉴权/模型行」的开关。
+- 不提供「仅隐藏路径行」的开关。
+- 不提供 Logo 渐变颜色的修改入口（颜色由 theme 负责）。
+- 不提供调整信息面板顺序或结构的能力。
+
+如果未来确有需求，应作为新字段单独走方案评估，而不是从上述三个字段
+派生出来。
+
+## 用户配置指南 —— 如何修改
+
+三个设置都位于 `settings.json` 的 `ui` 节点下。同时支持用户级
+（`~/.qwen/settings.json`）和工作区级（项目根目录的
+`.qwen/settings.json`），按标准合并优先级生效（workspace 覆盖
+user，system 覆盖 workspace）。
+
+### 整体隐藏 Banner
+
+```jsonc
+{
+  "ui": {
+    "hideBanner": true
+  }
+}
+```
+
+启动输出会跳过 Logo 列和信息面板。除非也设置了 `ui.hideTips`，否则
+Tips 仍会显示。
+
+### 替换品牌标题
+
+```jsonc
+{
+  "ui": {
+    "customBannerTitle": "Acme CLI"
+  }
+}
+```
+
+信息面板将渲染为 `Acme CLI (vX.Y.Z)`。设置自定义标题后默认不再带
+`>_` 字符；如需保留，请自己写进去：
+`"customBannerTitle": ">_ Acme CLI"`。
+
+### 替换 ASCII art —— 内联字符串
+
+```jsonc
+{
+  "ui": {
+    "customAsciiArt": "  ___  _    _  ____ \n / _ \\| |  / |/ _\\\n| |_| | |__| | __/\n \\___/|____|_|___|"
+  }
+}
+```
+
+JSON 字符串中用 `\n` 表示换行。该 ASCII art 会与默认 Logo 一样应用
+当前主题的渐变色。
+
+> **手头没有 ASCII art？** 任何外部生成器都行，把生成结果粘贴
+> 进来即可。最简路径是 `figlet`：
+> `npx figlet -f "ANSI Shadow" "xxxCode" > brand.txt`，然后把
+> `customAsciiArt: { "path": "./brand.txt" }` 指向该文件。CLI **不会**
+> 在运行时把文案渲染成 ASCII art —— 原因见下文「不在本设计范围内」。
+
+### 替换 ASCII art —— 外部文件
+
+```jsonc
+{
+  "ui": {
+    "customAsciiArt": { "path": "./brand.txt" }
+  }
+}
+```
+
+避免在 JSON 中转义大段多行字符串。路径解析规则：
+
+- **工作区级设置**：相对路径相对于 workspace 的 `.qwen/` 目录。
+- **用户级设置**：相对路径相对于 `~/.qwen/`。
+- 绝对路径直接使用。
+- 文件**仅在启动时读取一次**，经过清洗后写入缓存。会话进行中修改
+  文件不会重新渲染 —— 请重启 CLI。
+
+### 替换 ASCII art —— 宽度自适应
+
+```jsonc
+{
+  "ui": {
+    "customAsciiArt": {
+      "small": "  ACME\n  ----",
+      "large": { "path": "./brand-wide.txt" }
+    }
+  }
+}
+```
+
+终端足够宽时优先使用 `large`；否则使用 `small`；再否则隐藏 Logo 列
+（沿用当前的双列回退策略）。`small` 与 `large` 各自既可以是字符串
+也可以是 `{ path }`。任意一档可省略：缺失时直接进入下一档。
+
+### 三项组合
+
+```jsonc
+{
+  "ui": {
+    "hideBanner": false,
+    "customBannerTitle": "Acme CLI",
+    "customAsciiArt": {
+      "small": "  ACME\n  ----",
+      "large": { "path": "./brand-wide.txt" }
+    }
+  }
+}
+```
+
+### 如何验证
+
+1. 保存 `settings.json`，重新启动 `qwen` —— Banner 解析仅在启动时
+   运行一次。
+2. 调整终端宽度，确认 `small` / `large` 切换符合预期，并且在极窄
+   宽度下 Logo 列正确隐藏。
+3. 若结果与预期不符，查看
+   `~/.qwen/debug/<sessionId>.txt`（`latest.txt` 软链指向当前
+   会话），grep `[BANNER]` —— 每一次软失败都会打印一行 warn
+   说明原因。
+
+## 解析流水线
+
+```
+   settings.json                              packages/cli/src/ui/components/
+   ─────────────                              ──────────────────────────────
+   {                                          AppHeader.tsx
+     "ui": {                                    │
+       "hideBanner": false,                     │  showBanner =
+       "customBannerTitle": "Acme",             │      !screenReader
+       "customAsciiArt": …                      │   && !ui.hideBanner
+     }                                          │
+   }                                            ▼
+        │                              <Header
+        ▼                                customAsciiArt={resolved}
+   loadSettings()                        customBannerTitle="Acme"
+   merge user / workspace                version=… model=… authType=…
+        │                                workingDirectory=… />
+        ▼                                          │
+   resolveCustomBanner(merged, paths)              ▼
+   ┌─────────────────────────┐         packages/cli/src/ui/components/
+   │ 1. 归一化为              │         Header.tsx
+   │    { small, large }     │           │
+   │ 2. 解析每一档：          │           │  按 availableTerminalWidth
+   │    string → 直接使用     │           │  挑选档位
+   │    {path} → fs.read     │           │
+   │      O_NOFOLLOW         │           ▼
+   │      ≤ 64 KB            │         渲染 Logo 列
+   │ 3. 清洗：                │         渲染信息面板：
+   │    stripControlSeqs     │           Title  = customBannerTitle
+   │    ≤ 200 行 × 200 列    │                 ?? '>_ Qwen Code'
+   │ 4. 按来源 memoize        │           Status = 锁定
+   └─────────────────────────┘           Path   = 锁定
+```
+
+五步解析算法在加载设置时运行一次，仅在设置热重载事件触发时再次
+运行：
+
+1. **归一化**。裸 `string` 或 `{ path }` 转为
+   `{ small: x, large: x }`。`{ small, large }` 对象原样通过。
+2. **逐档解析**。对每个 `AsciiArtSource`：
+   - 字符串：直接使用。
+   - `{ path }`：同步读取，使用 `O_NOFOLLOW` 防御软链劫持
+     （Windows 退化为普通只读读取 —— 该常量不暴露），
+     上限 64 KB。相对路径相对于*所属设置文件的目录*：workspace
+     设置相对 workspace `.qwen/`，user 设置相对 `~/.qwen/`。
+     读取失败 → `[BANNER]` warn，该档回退默认。
+3. **清洗**。每个解析结果经过 `stripTerminalControlSequences`
+   （与 session-title 共享）处理，trim 尾部空白，截断至 200 行 × 200
+   列。超出部分截断并打印 `[BANNER]` warn。
+4. **渲染期挑档**。在 `Header.tsx` 中，给定解析后的 `small` 与
+   `large`，根据现有宽度预算
+   （`availableTerminalWidth ≥ logoWidth + logoGap + minInfoPanelWidth`）：
+   - 若 `large` 容得下，优先 `large`。
+   - 否则若 `small` 容得下，回退 `small`。
+   - 再否则隐藏 Logo 列（沿用 `showLogo = false` 分支），
+     信息面板继续渲染。
+5. **兜底**。如果两档最终都为空或非法，按未自定义渲染
+   `shortAsciiLogo`。CLI **绝不能**因为 Banner 配置错误而崩溃。
+
+挑档的伪代码：
+
+```ts
+function pickTier(
+  small: string | undefined,
+  large: string | undefined,
+  availableWidth: number,
+  logoGap: number,
+  minInfoPanelWidth: number,
+): string | undefined {
+  for (const candidate of [large, small]) {
+    if (!candidate) continue;
+    const w = getAsciiArtWidth(candidate);
+    if (availableWidth >= w + logoGap + minInfoPanelWidth) {
+      return candidate;
+    }
+  }
+  return undefined; // 隐藏 Logo 列
+}
+```
+
+## Settings schema 新增
+
+在 `packages/cli/src/config/settingsSchema.ts` 的 `ui` 对象中，
+紧接 `shellOutputMaxLines`（约第 720 行）追加三个属性：
+
+```ts
+hideBanner: {
+  type: 'boolean',
+  label: 'Hide Banner',
+  category: 'UI',
+  requiresRestart: false,
+  default: false,
+  description: 'Hide the startup ASCII banner and info panel.',
+  showInDialog: true,
+},
+customBannerTitle: {
+  type: 'string',
+  label: 'Custom Banner Title',
+  category: 'UI',
+  requiresRestart: false,
+  default: '' as string,
+  description:
+    'Replace the default ">_ Qwen Code" title shown in the banner info panel. The version suffix is always appended.',
+  showInDialog: false,
+},
+customAsciiArt: {
+  type: 'object',
+  label: 'Custom ASCII Art',
+  category: 'UI',
+  requiresRestart: false,
+  default: undefined,
+  description:
+    'Replace the default QWEN ASCII art. Accepts an inline string, {"path": "..."}, or {"small": ..., "large": ...} for width-aware selection.',
+  showInDialog: false,
+},
+```
+
+`hideBanner` 沿用现有 `hideTips` 的模式（`showInDialog: true`）；
+两个自由文本字段不进入应用内设置对话框 —— 在 TUI 对话框里做多行
+ASCII 编辑器是另一个项目，高级用户直接编辑 `settings.json` 即可。
+
+## 代码改动点
+
+实施改动很小。下面给出每处的文件与当前 `main` 分支上的行号范围。
+
+`packages/cli/src/ui/components/AppHeader.tsx:53` —— 扩展
+`showBanner`：
+
+```ts
+const showBanner =
+  !config.getScreenReader() && !settings.merged.ui?.hideBanner;
+```
+
+`packages/cli/src/ui/components/AppHeader.tsx:64-71` —— 把解析后的
+Banner 数据传入 `<Header>`：
+
+```tsx
+<Header
+  version={version}
+  authDisplayType={authDisplayType}
+  model={model}
+  workingDirectory={targetDir}
+  customAsciiArt={resolvedCustomAsciiArt /* { small?, large? } */}
+  customBannerTitle={resolvedCustomBannerTitle /* string | undefined */}
+/>
+```
+
+`packages/cli/src/ui/components/Header.tsx:28-34` —— 扩展
+`HeaderProps`：
+
+```ts
+interface HeaderProps {
+  customAsciiArt?: { small?: string; large?: string };
+  customBannerTitle?: string;
+  version: string;
+  authDisplayType?: AuthDisplayType;
+  model: string;
+  workingDirectory: string;
+}
+```
+
+`packages/cli/src/ui/components/Header.tsx:45-46` —— 在计算
+`logoWidth` 之前先挑档，并以现有默认作为兜底：
+
+```ts
+const tier = pickTier(
+  customAsciiArt?.small,
+  customAsciiArt?.large,
+  availableTerminalWidth,
+  logoGap,
+  minInfoPanelWidth,
+);
+const displayLogo = tier ?? shortAsciiLogo;
+```
+
+`packages/cli/src/ui/components/Header.tsx:144` —— 标题从 prop 渲染：
+
+```tsx
+<Text bold color={theme.text.accent}>
+  {customBannerTitle && customBannerTitle.trim()
+    ? customBannerTitle
+    : '>_ Qwen Code'}
+</Text>
+```
+
+**新增文件**：`packages/cli/src/ui/utils/customBanner.ts` —— 解析器。
+对外接口：
+
+```ts
+export interface ResolvedBanner {
+  asciiArt: { small?: string; large?: string };
+  title?: string;
+}
+
+export function resolveCustomBanner(
+  settings: LoadedSettings,
+  paths: { userDir: string; workspaceDir?: string },
+): ResolvedBanner;
+```
+
+解析器负责上述「解析流水线」中描述的归一化、文件读取、清洗与缓存。
+在 CLI 启动时调用一次，并在设置热重载事件中再次调用。
+
+## 备选方案对比
+
+下面给出曾经评估过的 5 种形态，便于后续维护者了解设计空间，必要时
+重新评估。
+
+### 方案 1 —— 三个扁平字段（推荐，与 issue 完全一致）
+
+```jsonc
+{
+  "ui": {
+    "customAsciiArt": "...",        // string | {path} | {small,large}
+    "customBannerTitle": "Acme CLI",
+    "hideBanner": false
+  }
+}
+```
+
+- **效果**：用户面最小，与 issue 描述一一对应。
+- **优点**：零学习成本；文档极易；与现有 `ui.*` 扁平字段一致
+  （`hideTips`、`customWittyPhrases` 等）。
+- **缺点**：三个语义相关的键散落在 `ui` 顶层；未来若新增 banner
+  专属开关（渐变、副标题等）只能继续向 `ui` 加兄弟字段，不能
+  天然分组。
+
+### 方案 2 —— 嵌套 `ui.banner` 命名空间
+
+```jsonc
+{
+  "ui": {
+    "banner": {
+      "hide": false,
+      "title": "Acme CLI",
+      "asciiArt": { "path": "./brand.txt" }
+    }
+  }
+}
+```
+
+- **效果**：能力等同方案 1，按特性聚合。
+- **优点**：未来 banner 专属开关有干净的命名空间；`/settings`
+  发现性更好。
+- **缺点**：与 issue 原文写法不完全一致；现有 UI 设置以扁平为主
+  （仅 `ui.accessibility` 与 `ui.statusLine` 是嵌套的），一致性
+  打折；多了一层让用户记忆。
+
+### 方案 3 —— Banner profile 预设 + slot override
+
+```jsonc
+{
+  "ui": {
+    "bannerProfile": "minimal" | "default" | "branded" | "hidden",
+    "banner": { /* 'branded' 下的 slot 覆盖 */ }
+  }
+}
+```
+
+- **效果**：用户从命名预设挑选；高级用户在所选预设上覆盖具体 slot。
+- **优点**：onboarding 体验更好；预设可由 CLI 自带。
+- **缺点**：复杂度显著上升；预设是长期维护承诺；issue 要求的是
+  开放自定义而非内容策划。
+
+### 方案 4 —— 整体 Banner 模板字符串
+
+```jsonc
+{
+  "ui": {
+    "bannerTemplate": "{{logo}}\n>_ {{title}} ({{version}})\n{{auth}} | {{model}}\n{{path}}"
+  }
+}
+```
+
+- **效果**：单条 freeform 模板，受锁字段做插值。
+- **优点**：非标准布局的灵活度最高。
+- **缺点**：把布局责任推给用户态；Ink 双列对终端宽度的鲁棒性失去；
+  极易写出在窄终端下崩坏的模板；为这点收益打开很大的破坏面。
+
+### 方案 5 —— 插件 / 钩子 API
+
+通过扩展系统暴露一个 banner-renderer 钩子。
+
+- **效果**：代码级自定义；扩展可以渲染任意内容。
+- **优点**：能力上限最高；企业可以打包出整套封装的品牌插件。
+- **缺点**：API 表面巨大；任意终端渲染需要安全评审；对该 issue
+  完全过度设计。
+
+### 推荐结论
+
+**采用方案 1**。它直接满足 issue，契合现有 `ui.*` 风格，且不会在
+我们尚未明确还有哪些 banner 专属开关之前就被命名空间锁死。如果未来
+兄弟字段开始累积，迁移到方案 2 是叠加式的 —— `ui.banner.title` 与
+`ui.customBannerTitle` 可以在弃用窗口期内并存。
+
+## 安全与失败处理
+
+自定义 Banner 内容会**逐字渲染到终端**，并且在 path 形态下还会
+**从磁盘读取**。两条路径在加载到恶意或被篡改的 settings 时都是
+可达的。Session-title 特性所应对的同一类威胁模型在此同样适用。
+
+| 关注点 | 防护手段 |
+| --- | --- |
+| ASCII art 或标题中的 ANSI / OSC-8 / CSI 注入 | 渲染前与缓存写入前调用 `stripTerminalControlSequences`（与 session-title 共享）。 |
+| 超大文件冻结启动 | 文件读取硬上限 64 KB。 |
+| 病态 ASCII art 冻结布局 | 每个解析结果上限 200 行 × 200 列；超出截断 + `[BANNER]` warn。 |
+| 软链劫持 path 形态 | 文件读取使用 `O_NOFOLLOW`（Windows 下退化为只读；常量不暴露）。 |
+| 文件缺失或不可读 | 捕获 → `[BANNER]` warn → 回退默认；绝不抛入 UI。 |
+| 标题包含换行或过长 | 去掉换行，截断到 80 字符。 |
+| 设置热重载竞态 | 解析结果按来源（path 或字符串哈希）做 memoize；reload 仅失效发生变化的来源。 |
+
+失败模式总结：所有软失败最终都会落到 `shortAsciiLogo`（或锁定的
+默认标题）+ 一行调试日志 warn。任何分支都不允许产生硬失败
+（向上抛出异常）。
+
+## 不在本设计范围内
+
+下列项被有意排除。每一项都可以视用户反馈做后续单独提案。
+
+| 项目 | 不做的理由 |
+| --- | --- |
+| 文案转 ASCII art（`{ text: "xxxCode" }` 形态） | v1 评估后**拒绝**。要么引入 `figlet` 运行时依赖（含一套可用字体后约 2–3 MB unpacked），要么自己 vendor 一份单字体渲染器（~200 行代码 + 一份 `.flf` 字体我们自己维护）。两条路都带来长期的维护面：字体选型、字体 license 审计、「我的字体在 X 终端渲染不对」类 issue、CJK / 全角字符处理。本特性的驱动用例（白标 / 多租户）几乎一定有设计师交付成品 ASCII art，不会依赖 figlet 默认字体。希望一行命令生成的用户今天就能 `npx figlet "xxxCode" > brand.txt` + `customAsciiArt: { "path": "./brand.txt" }` —— 等价效果、零新增依赖、零 Qwen Code 内部支持负担。如果未来诉求增多，这一形态是纯叠加：把 `AsciiArtSource` 扩展为 `string \| {path} \| {text, font?}`，不会破坏任何已有配置。 |
+| `/banner` slash 命令在线编辑 | 设置 UI 是规范化的编辑入口；多行 ASCII 在线编辑器是另一个项目。 |
+| 自定义渐变色 / 单行颜色 | 颜色由 theme 拥有。如需扩展应另立提案，Banner 自定义不重复造该面。 |
+| URL 加载 ASCII art | 启动期网络请求自带一堆问题：失败模式、缓存、安全评审。`{path}` 文件加载是低风险等价物。 |
+| 动画（旋转 Logo、跑马灯标题） | 增加渲染负担与无障碍问题；本特性的用例不需要。 |
+| VSCode / Web UI banner 对齐 | 这两个端目前不渲染 Ink Banner。若未来引入，本设计为参考。 |
+| 文件变更的动态 reload | 解析器仅在启动与设置 reload 时运行。会话中途换 art 的需求很少，「重启生效」是可以接受的折中。 |
+| 单独隐藏锁定区域（version / auth / model / path） | 这些是运行时信号；屏蔽它们对支持与安全姿态的损害，远大于白标场景的收益。 |
+
+## 验证计划
+
+后续实施 PR 应通过以下端到端检查：
+
+1. `~/.qwen/settings.json` 设置 `customBannerTitle: "Acme CLI"`
+   与一段内联 `customAsciiArt` → `qwen` 启动后展示新标题与新
+   ASCII art；版本号后缀仍在。
+2. 设置 `hideBanner: true` → `qwen` 启动无 Banner；Tips 与正文
+   照常渲染。
+3. workspace `settings.json` 设置
+   `customAsciiArt: { "path": "./brand.txt" }`，`brand.txt` 与
+   之同处 `.qwen/` 目录 → 打开工作区时从磁盘加载。
+4. `customAsciiArt: { "small": "...", "large": "..." }` →
+   在宽 / 中 / 窄三档下调整终端尺寸；宽时取 large、中时取
+   small、窄时隐藏 Logo 列；信息面板始终可见。
+5. `customBannerTitle` 中注入 `\x1b[31mhostile` → 渲染为
+   字面文本，不会被解释为红色。
+6. `path` 指向不存在的文件 → CLI 正常启动；
+   `~/.qwen/debug/<sessionId>.txt` 出现 `[BANNER]` warn；
+   渲染默认 art。
+7. CLI 包通过 `npm test` 与 `npm run typecheck`；
+   `customBanner.test.ts` 单测覆盖每种数据形态以及每条失败路径
+   （文件缺失、文件超大、ANSI 注入、对象格式不合法）。


### PR DESCRIPTION
## Summary

- Design-only PR for issue #3005 (customize CLI banner area). **No code changes** — implementation will land in a follow-up PR after this design is reviewed and approved.
- Adds `docs/design/customize-banner-area/customize-banner-area.md` (EN) and `customize-banner-area.zh-CN.md` (zh-CN mirror).
- Documents the banner region taxonomy (Logo column / Title / Status / Path), the "brand chrome replaceable, operational data locked" stance, the three proposed settings (`ui.hideBanner`, `ui.customBannerTitle`, `ui.customAsciiArt`), the resolution pipeline, schema additions, wiring touch points, five alternative shapes considered with the recommended pick, security & failure handling, and an explicitly rejected text-to-ASCII rendering form (with rationale).

## Review focus

This PR exists so reviewers can sign off on the design before any code lands. Specifically, please weigh in on:

- The **what's locked / what's replaceable** matrix — is the locked set (version, auth, model, working directory) right for white-label scenarios?
- The **three flat settings** vs. **nested `ui.banner.*`** namespace choice (Option 1 vs. Option 2 in the alternatives section).
- The **`{ small, large }` width-aware tier** — worth the extra surface, or overkill?
- The **rejection of the `{ text }` figlet-style form** — agree with the dependency / maintenance reasoning, or push back?

## Test plan

- [ ] Read `docs/design/customize-banner-area/customize-banner-area.md` end-to-end.
- [ ] Skim `customize-banner-area.zh-CN.md` to confirm content parity (same diagrams, same tables, same code blocks).
- [ ] Sanity-check the file/line references against current `main` (`packages/cli/src/ui/components/Header.tsx`, `AppHeader.tsx`, `AsciiArt.ts`, `packages/cli/src/config/settingsSchema.ts`).
- [ ] Approve / request changes — implementation PR will follow this one and use it as the spec.

🤖 Generated with [Qwen Code](https://qwen.ai/qwencode)