### PR TITLE
fix(core,cli): stop stripping reasoning on model switch/history load

### DIFF
--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -501,7 +501,7 @@ describe('useSlashCommandProcessor', () => {
       );
     });
 
-    it('should strip thoughts when handling "load_history" action', async () => {
+    it('should preserve thoughts when handling "load_history" action', async () => {
       const mockClient = {
         setHistory: vi.fn(),
         stripThoughtsFromHistory: vi.fn(),
@@ -531,7 +531,7 @@ describe('useSlashCommandProcessor', () => {
       });
 
       expect(mockClient.setHistory).toHaveBeenCalledTimes(1);
-      expect(mockClient.stripThoughtsFromHistory).toHaveBeenCalledWith();
+      expect(mockClient.stripThoughtsFromHistory).not.toHaveBeenCalled();
     });
 
     it('should handle a "quit" action', async () => {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -647,7 +647,6 @@ export const useSlashCommandProcessor = (
                   }
                 case 'load_history': {
                   config?.getGeminiClient()?.setHistory(result.clientHistory);
-                  config?.getGeminiClient()?.stripThoughtsFromHistory();
                   fullCommandContext.ui.clear();
                   result.history.forEach((item, index) => {
                     fullCommandContext.ui.addItem(item, index);

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -531,7 +531,7 @@ describe('Server Config (config.ts)', () => {
       expect(vi.mocked(createContentGenerator)).toHaveBeenCalledTimes(1);
     });
 
-    it('should strip thoughts from history on model switch (#3304)', async () => {
+    it('should preserve thoughts from history on model switch', async () => {
       const config = new Config(baseParams);
 
       const mockContentConfig: ContentGeneratorConfig = {
@@ -567,7 +567,7 @@ describe('Server Config (config.ts)', () => {
 
       await config.switchModel(AuthType.QWEN_OAUTH, 'coder-model');
 
-      expect(stripSpy).toHaveBeenCalledTimes(1);
+      expect(stripSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1423,11 +1423,9 @@ export class Config {
       return;
     }
 
-    // Strip thinking blocks from conversation history on model switch.
-    // reasoning_content is a non-standard field that causes strict
-    // OpenAI-compatible providers to reject requests with 422 errors
-    // when thought parts from a previous model leak into the payload (#3304).
-    this.geminiClient.stripThoughtsFromHistory();
+    // Keep full history (including thought parts) on model switch.
+    // Some OpenAI-compatible reasoning models (e.g. DeepSeek) require
+    // reasoning_content to be preserved across turns.
 
     // Hot update path: only supported for qwen-oauth.
     // For other auth types we always refresh to recreate the ContentGenerator.


### PR DESCRIPTION
## Summary

- What changed:
  - Removed event-driven reasoning stripping in two user flows where history is restored or model context changes.
  - Updated regression expectations to assert reasoning/thought content is preserved in those flows.
- Why it changed:
  - Align with maintainer decision in #3579: strip-on-event was identified as the wrong fix direction and should be removed.
- Reviewer focus:
  - Confirm no thought stripping occurs in the targeted flows.
  - Confirm regression tests now enforce preservation behavior.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/config/config.test.ts
  cd packages/cli && npx vitest run src/ui/hooks/slashCommandProcessor.test.ts
  ```
- Prompts / inputs used:
  - Model-switch flow regression expectation.
  - History-load flow regression expectation.
- Expected result:
  - Targeted tests pass and preserve-reasoning assertions hold.
- Observed result:
  - Both test files passed locally (`98/98`, `39/39`).
- Quickest reviewer verification path:
  - Run the two commands above.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  - Vitest outputs show all targeted tests passing.

## Scope / Risk

- Main risk or tradeoff:
  - Strict provider wire-format compatibility is not handled by history mutation anymore.
- Not covered / not validated:
  - Provider-specific request-boundary sanitization work is not part of this PR.
- Breaking changes / migration notes:
  - None intended.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ✅  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Verified with targeted `npx vitest run` in Linux environment only.

## Linked Issues / Bugs

- Related: #3579
- Related: #3304
- Related: #3619
