### PR TITLE
feat(core): wire background shells into the task_stop tool

### DIFF
--- a/packages/core/src/services/backgroundShellRegistry.test.ts
+++ b/packages/core/src/services/backgroundShellRegistry.test.ts
@@ -101,6 +101,38 @@ describe('BackgroundShellRegistry', () => {
     });
   });
 
+  describe('requestCancel', () => {
+    it('aborts the signal but leaves status running and endTime undefined', () => {
+      const reg = new BackgroundShellRegistry();
+      const ac = new AbortController();
+      reg.register(makeEntry({ shellId: 'a', abortController: ac }));
+
+      reg.requestCancel('a');
+
+      const e = reg.get('a')!;
+      expect(e.status).toBe('running');
+      expect(e.endTime).toBeUndefined();
+      expect(ac.signal.aborted).toBe(true);
+    });
+
+    it('is a no-op on a terminal entry', () => {
+      const reg = new BackgroundShellRegistry();
+      const ac = new AbortController();
+      reg.register(makeEntry({ shellId: 'a', abortController: ac }));
+      reg.complete('a', 0, 1500);
+
+      reg.requestCancel('a');
+
+      expect(reg.get('a')!.status).toBe('completed');
+      expect(ac.signal.aborted).toBe(false);
+    });
+
+    it('is a no-op for unknown id', () => {
+      const reg = new BackgroundShellRegistry();
+      expect(() => reg.requestCancel('missing')).not.toThrow();
+    });
+  });
+
   describe('abortAll', () => {
     it('cancels every running entry and leaves terminal entries alone', () => {
       const reg = new BackgroundShellRegistry();

--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -93,6 +93,29 @@ export class BackgroundShellRegistry {
   }
 
   /**
+   * Request cancellation without marking the entry terminal.
+   *
+   * Triggers the entry's AbortController so the spawn handler can tear the
+   * process down, but leaves `status='running'` until the settle path
+   * observes the abort and records the real exit moment + outcome via
+   * `complete()` / `fail()` / `cancel()`. This keeps the registry honest:
+   * a cancelled shell only shows its terminal `endTime` once the process
+   * has actually drained, and a cancel-vs-exit race can't permanently hide
+   * a real completed/failed result.
+   *
+   * Used by the `task_stop` tool path; the immediate-mark `cancel()` above
+   * is reserved for `abortAll()` / shutdown, where the CLI process is
+   * tearing down anyway and there is no settle handler to wait for.
+   *
+   * Idempotent: no-op on entries that aren't `running`.
+   */
+  requestCancel(shellId: string): void {
+    const entry = this.entries.get(shellId);
+    if (!entry || entry.status !== 'running') return;
+    entry.abortController.abort();
+  }
+
+  /**
    * Cancel every still-running entry. Called on session/Config shutdown so
    * background shells don't outlive the CLI process and leak orphaned
    * children. Symmetric with `BackgroundTaskRegistry.abortAll()` for the

--- a/packages/core/src/tools/task-stop.test.ts
+++ b/packages/core/src/tools/task-stop.test.ts
@@ -7,18 +7,22 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { TaskStopTool } from './task-stop.js';
 import { BackgroundTaskRegistry } from '../agents/background-tasks.js';
+import { BackgroundShellRegistry } from '../services/backgroundShellRegistry.js';
 import type { Config } from '../config/config.js';
 import { ToolErrorType } from './tool-error.js';
 
 describe('TaskStopTool', () => {
   let registry: BackgroundTaskRegistry;
+  let shellRegistry: BackgroundShellRegistry;
   let config: Config;
   let tool: TaskStopTool;
 
   beforeEach(() => {
     registry = new BackgroundTaskRegistry();
+    shellRegistry = new BackgroundShellRegistry();
     config = {
       getBackgroundTaskRegistry: () => registry,
+      getBackgroundShellRegistry: () => shellRegistry,
     } as unknown as Config;
     tool = new TaskStopTool(config);
   });
@@ -90,5 +94,87 @@ describe('TaskStopTool', () => {
 
     expect(result.llmContent).toContain('Search for auth code');
     expect(result.returnDisplay).toContain('Search for auth code');
+  });
+
+  describe('background shell support', () => {
+    it('cancels a running background shell', async () => {
+      const ac = new AbortController();
+      shellRegistry.register({
+        shellId: 'bg_a1b2c3d4',
+        command: 'npm run dev',
+        cwd: '/work',
+        status: 'running',
+        startTime: Date.now(),
+        outputPath: '/tmp/bg-out/shell-bg_a1b2c3d4.output',
+        abortController: ac,
+      });
+
+      const result = await tool.validateBuildAndExecute(
+        { task_id: 'bg_a1b2c3d4' },
+        new AbortController().signal,
+      );
+
+      expect(result.error).toBeUndefined();
+      expect(result.llmContent).toContain('background shell "bg_a1b2c3d4"');
+      expect(result.llmContent).toContain('npm run dev');
+      expect(result.llmContent).toContain('/tmp/bg-out/shell-bg_a1b2c3d4.output');
+      expect(shellRegistry.get('bg_a1b2c3d4')!.status).toBe('cancelled');
+      expect(ac.signal.aborted).toBe(true);
+    });
+
+    it('returns NOT_RUNNING when the shell already exited', async () => {
+      shellRegistry.register({
+        shellId: 'bg_done',
+        command: 'true',
+        cwd: '/work',
+        status: 'running',
+        startTime: Date.now() - 1000,
+        outputPath: '/tmp/bg-out/shell-bg_done.output',
+        abortController: new AbortController(),
+      });
+      shellRegistry.complete('bg_done', 0, Date.now());
+
+      const result = await tool.validateBuildAndExecute(
+        { task_id: 'bg_done' },
+        new AbortController().signal,
+      );
+
+      expect(result.error?.type).toBe(ToolErrorType.TASK_STOP_NOT_RUNNING);
+      expect(result.llmContent).toContain('Background shell "bg_done"');
+      expect(result.llmContent).toContain('completed');
+    });
+
+    it('prefers an agent over a shell when both have the same id (defensive)', async () => {
+      // IDs cannot collide in practice (different naming schemes), but the
+      // tool's lookup order should still be deterministic if they ever do.
+      const agentAc = new AbortController();
+      const shellAc = new AbortController();
+      registry.register({
+        agentId: 'shared-id',
+        description: 'agent',
+        status: 'running',
+        startTime: Date.now(),
+        abortController: agentAc,
+      });
+      shellRegistry.register({
+        shellId: 'shared-id',
+        command: 'shell-cmd',
+        cwd: '/work',
+        status: 'running',
+        startTime: Date.now(),
+        outputPath: '/tmp/x.out',
+        abortController: shellAc,
+      });
+
+      const result = await tool.validateBuildAndExecute(
+        { task_id: 'shared-id' },
+        new AbortController().signal,
+      );
+
+      expect(result.llmContent).toContain('background agent');
+      expect(agentAc.signal.aborted).toBe(true);
+      expect(shellAc.signal.aborted).toBe(false);
+      expect(shellRegistry.get('shared-id')!.status).toBe('running');
+    });
   });
 });

--- a/packages/core/src/tools/task-stop.test.ts
+++ b/packages/core/src/tools/task-stop.test.ts
@@ -118,7 +118,12 @@ describe('TaskStopTool', () => {
       expect(result.llmContent).toContain('background shell "bg_a1b2c3d4"');
       expect(result.llmContent).toContain('npm run dev');
       expect(result.llmContent).toContain('/tmp/bg-out/shell-bg_a1b2c3d4.output');
-      expect(shellRegistry.get('bg_a1b2c3d4')!.status).toBe('cancelled');
+      // task_stop only requests cancellation — the entry stays `running`
+      // until the spawn handler observes the abort and settles the entry
+      // with the real exit moment. Without this guarantee, /tasks would
+      // report a terminal-but-still-draining shell.
+      expect(shellRegistry.get('bg_a1b2c3d4')!.status).toBe('running');
+      expect(shellRegistry.get('bg_a1b2c3d4')!.endTime).toBeUndefined();
       expect(ac.signal.aborted).toBe(true);
     });
 

--- a/packages/core/src/tools/task-stop.ts
+++ b/packages/core/src/tools/task-stop.ts
@@ -40,43 +40,76 @@ class TaskStopInvocation extends BaseToolInvocation<
   }
 
   async execute(_signal: AbortSignal): Promise<ToolResult> {
-    const registry = this.config.getBackgroundTaskRegistry();
-    const entry = registry.get(this.params.task_id);
+    const taskId = this.params.task_id;
 
-    if (!entry) {
+    // Subagent registry first (Phase A control plane). Agent IDs follow the
+    // pattern `<subagentName>-<suffix>`, so they cannot collide with shell
+    // IDs (which are `bg_<8 hex chars>` from the background shell pool).
+    const agentRegistry = this.config.getBackgroundTaskRegistry();
+    const agentEntry = agentRegistry.get(taskId);
+    if (agentEntry) {
+      if (agentEntry.status !== 'running') {
+        return notRunningError('agent', taskId, agentEntry.status);
+      }
+      agentRegistry.cancel(taskId);
+      // The terminal task-notification is emitted by the agent's own handler
+      // (via registry.complete/fail) rather than cancel(), so the parent
+      // model still receives the agent's real partial/final result — not just
+      // a bare "cancelled" message — once the reasoning loop unwinds.
+      const desc = agentEntry.description;
       return {
-        llmContent: `Error: No background task found with ID "${this.params.task_id}".`,
-        returnDisplay: 'Task not found.',
-        error: {
-          message: `Task not found: ${this.params.task_id}`,
-          type: ToolErrorType.TASK_STOP_NOT_FOUND,
-        },
+        llmContent:
+          `Cancellation requested for background agent "${taskId}". ` +
+          `A final task-notification carrying the agent's last result will ` +
+          `follow.\nDescription: ${desc}`,
+        returnDisplay: `Cancelled: ${desc}`,
       };
     }
 
-    if (entry.status !== 'running') {
+    // Background shell registry (Phase B). Settles asynchronously when the
+    // child process exits in response to the AbortController; the registry
+    // entry's terminal state (`cancelled`) and final exit code/output stay
+    // observable via `/tasks` and the on-disk output file.
+    const shellRegistry = this.config.getBackgroundShellRegistry();
+    const shellEntry = shellRegistry.get(taskId);
+    if (shellEntry) {
+      if (shellEntry.status !== 'running') {
+        return notRunningError('shell', taskId, shellEntry.status);
+      }
+      shellRegistry.cancel(taskId, Date.now());
       return {
-        llmContent: `Error: Background task "${this.params.task_id}" is not running (status: ${entry.status}).`,
-        returnDisplay: `Task not running (${entry.status}).`,
-        error: {
-          message: `Task is ${entry.status}: ${this.params.task_id}`,
-          type: ToolErrorType.TASK_STOP_NOT_RUNNING,
-        },
+        llmContent:
+          `Cancellation requested for background shell "${taskId}". ` +
+          `Final status will be visible via /tasks; captured output remains ` +
+          `at ${shellEntry.outputPath}.\nCommand: ${shellEntry.command}`,
+        returnDisplay: `Cancelled shell: ${shellEntry.command}`,
       };
     }
 
-    registry.cancel(this.params.task_id);
-
-    // The terminal task-notification is emitted by the task's own handler
-    // (via registry.complete/fail) rather than cancel(), so the parent model
-    // still receives the task's real partial/final result — not just a bare
-    // "cancelled" message — once the reasoning loop unwinds.
-    const desc = entry.description;
     return {
-      llmContent: `Cancellation requested for background task "${this.params.task_id}". A final task-notification carrying the task's last result will follow.\nDescription: ${desc}`,
-      returnDisplay: `Cancelled: ${desc}`,
+      llmContent: `Error: No background task found with ID "${taskId}".`,
+      returnDisplay: 'Task not found.',
+      error: {
+        message: `Task not found: ${taskId}`,
+        type: ToolErrorType.TASK_STOP_NOT_FOUND,
+      },
     };
   }
+}
+
+function notRunningError(
+  kind: 'agent' | 'shell',
+  taskId: string,
+  status: string,
+): ToolResult {
+  return {
+    llmContent: `Error: Background ${kind} "${taskId}" is not running (status: ${status}).`,
+    returnDisplay: `Task not running (${status}).`,
+    error: {
+      message: `${kind} is ${status}: ${taskId}`,
+      type: ToolErrorType.TASK_STOP_NOT_RUNNING,
+    },
+  };
 }
 
 export class TaskStopTool extends BaseDeclarativeTool<

--- a/packages/core/src/tools/task-stop.ts
+++ b/packages/core/src/tools/task-stop.ts
@@ -76,12 +76,17 @@ class TaskStopInvocation extends BaseToolInvocation<
       if (shellEntry.status !== 'running') {
         return notRunningError('shell', taskId, shellEntry.status);
       }
-      shellRegistry.cancel(taskId, Date.now());
+      // requestCancel triggers the AbortController only — the registry's
+      // settle path records the real terminal status + endTime once the
+      // process actually drains. Calling cancel(id, Date.now()) here would
+      // mark the entry terminal immediately and lose the real exit info.
+      shellRegistry.requestCancel(taskId);
       return {
         llmContent:
           `Cancellation requested for background shell "${taskId}". ` +
-          `Final status will be visible via /tasks; captured output remains ` +
-          `at ${shellEntry.outputPath}.\nCommand: ${shellEntry.command}`,
+          `Final status will be visible via /tasks once the process drains; ` +
+          `captured output remains at ${shellEntry.outputPath}.\n` +
+          `Command: ${shellEntry.command}`,
         returnDisplay: `Cancelled shell: ${shellEntry.command}`,
       };
     }


### PR DESCRIPTION
## Summary

Phase B follow-up #1 from #3634, unblocked by #3471 (control plane) merging in. The model can now cancel a managed background shell with the **same `task_stop` tool** it uses for subagents — no more falling back to `kill <pid>` via `BashTool`.

## Why

#3642 landed `BackgroundShellRegistry` with its own `AbortController` as the cancellation source of truth, but `task_stop` only knew about the subagent registry. To stop a `bg_xxx` shell the model had to spawn another bash and call `kill`, which is awkward, leaks a foreground bash, and bypasses the registry's lifecycle hooks. @tanzhenxin called this out as the obvious post-merge follow-up in his #3642 review (no blockers, follow-up).

## Before / After (model-facing)

The shell ID `bg_a1b2c3d4` came from `Bash(npm run dev, is_background: true)`'s response.

**Before**:
```
> task_stop("bg_a1b2c3d4")
Error: No background task found with ID "bg_a1b2c3d4".

> Bash("kill 54321", is_background: false)   # workaround: spawn another bash
(returns exit 0; entry stays "running" in /tasks; output file still open)
```

**After**:
```
> task_stop("bg_a1b2c3d4")
Cancellation requested for background shell "bg_a1b2c3d4". Final status will
be visible via /tasks; captured output remains at
<projectTempDir>/background-shells/<sessionId>/shell-bg_a1b2c3d4.output.
Command: npm run dev
```

Subagents see no behavior change — same lookup, same description, same final task-notification semantics.

## What changes

- **`task_stop` lookup**: subagent registry first (existing behavior), then `BackgroundShellRegistry` as a fallback. Agent IDs follow `<subagentName>-<suffix>` and shell IDs follow `bg_<8 hex chars>`, so the two namespaces cannot collide in practice. A defensive test pins agent-wins-over-shell determinism in case they ever do.
- **Cancellation path**: shell cancel resolves through the entry's own `AbortController` (which `BackgroundShellRegistry.cancel` triggers), then the child-process exit handler settles the registry to `cancelled`. The on-disk output file is preserved for inspection via `/tasks` or a direct `Read` — message wording explicitly tells the agent where to find it.
- **Error type reuse**: `TASK_STOP_NOT_FOUND` / `TASK_STOP_NOT_RUNNING` (both already kind-agnostic from #3471's review) cover both registries; only the human-facing message changes wording (`background agent` vs `background shell`).

No behavior change for subagents.

## What this PR doesn't do

- Footer pill / dialog integration with shell entries — that's Phase B follow-up #2 (separate PR, in progress on `feat/shell-in-dialog`).
- `/tasks` slash-command deprecation — gated on follow-up #2 landing.

## Test plan

- [x] 3 new tests in `task-stop.test.ts`: cancel-shell happy path, `NOT_RUNNING` for exited shell, agent-precedence-on-id-collision.
- [x] All 7 `task-stop` tests pass.
- [x] No regressions in `background-tasks.test.ts` or `backgroundShellRegistry.test.ts`.
- [x] Lint + typecheck + core build clean.

Related: #3634 (roadmap), #3642 (Phase B), #3471 (Phase A control plane).

<details>
<summary>中文版</summary>

## Summary

来自 #3634 的 Phase B follow-up #1，在 #3471（control plane）合入后解锁。模型现在可以用**和取消 subagent 同一个 `task_stop` 工具**取消受管的 background shell — 不再需要通过 `BashTool` 跑 `kill <pid>`。

## 为什么

#3642 落地了 `BackgroundShellRegistry`，自己的 `AbortController` 作为 cancellation 单一源，但 `task_stop` 只认识 subagent registry。要停一个 `bg_xxx` shell 时模型必须再 spawn 一个 bash 调 `kill` —— 很别扭、泄漏一个前台 bash、绕过 registry 的 lifecycle hook。@tanzhenxin 在 #3642 review 里把这个标为明显的 post-merge follow-up（不阻塞，follow-up 处理）。

## Before / After（模型视角）

shell ID `bg_a1b2c3d4` 来自之前 `Bash(npm run dev, is_background: true)` 的返回。

**Before**：
```
> task_stop("bg_a1b2c3d4")
Error: No background task found with ID "bg_a1b2c3d4".

> Bash("kill 54321", is_background: false)   # workaround：再 spawn 一个 bash
(返回 exit 0；entry 在 /tasks 里仍是 "running"；输出文件仍打开)
```

**After**：
```
> task_stop("bg_a1b2c3d4")
Cancellation requested for background shell "bg_a1b2c3d4". Final status will
be visible via /tasks; captured output remains at
<projectTempDir>/background-shells/<sessionId>/shell-bg_a1b2c3d4.output.
Command: npm run dev
```

subagent 行为完全不变 — 同样的 lookup、同样的 description、同样的最终 task-notification 语义。

## 改动

- **`task_stop` 查找顺序**：subagent registry 优先（保留原行为），再 fallback 到 `BackgroundShellRegistry`。agent ID 是 `<subagentName>-<suffix>` 格式，shell ID 是 `bg_<8 个 hex>`，两个命名空间实践中不可能撞。一个 defensive test 钉住"撞了就 agent 优先"的确定性行为。
- **取消路径**：shell cancel 走 entry 自己的 `AbortController`（被 `BackgroundShellRegistry.cancel` 触发），然后子进程 exit handler 把 registry 状态 settle 成 `cancelled`。磁盘上的输出文件保留，可通过 `/tasks` 或直接 `Read` 查看 —— 返回消息明确告诉 agent 文件位置。
- **错误类型复用**：`TASK_STOP_NOT_FOUND` / `TASK_STOP_NOT_RUNNING`（在 #3471 review 时已经改成 kind-agnostic）覆盖两个 registry；只是人类可读消息按 kind 区分（`background agent` vs `background shell`）。

subagent 行为零变化。

## 本 PR 不做的

- Footer pill / dialog 集成 shell entries —— 是 Phase B follow-up #2（独立 PR，进行中：分支 `feat/shell-in-dialog`）。
- `/tasks` slash command 的 deprecate —— 卡 follow-up #2 合入。

## 测试

- [x] `task-stop.test.ts` 加 3 个新测试：cancel-shell happy path、对已退出 shell 返回 `NOT_RUNNING`、ID 撞车时 agent 优先。
- [x] 7 个 `task-stop` 测试全过。
- [x] `background-tasks.test.ts` 和 `backgroundShellRegistry.test.ts` 无 regression。
- [x] Lint + typecheck + core build 全绿。

相关：#3634（roadmap）、#3642（Phase B）、#3471（Phase A 控制面）。

</details>
