### PR TITLE
fix(ci): use squash merge for SDK release auto-merge

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -405,7 +405,7 @@ jobs:
           PR_URL: '${{ steps.pr.outputs.PR_URL }}'
         run: |-
           set -euo pipefail
-          gh pr merge "${PR_URL}" --merge --auto --delete-branch
+          gh pr merge "${PR_URL}" --squash --auto --delete-branch
 
       - name: 'Create Issue on Failure'
         if: |-


### PR DESCRIPTION
## Summary

The Release SDK workflow's `Enable auto-merge for release PR` step calls `gh pr merge --merge --auto`, but the repo only allows squash merges:

```
gh repo view QwenLM/qwen-code --json mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed
{"mergeCommitAllowed":false,"rebaseMergeAllowed":false,"squashMergeAllowed":true}
```

So the step always exits 1, and every release run goes red even when publish, tag, and release-PR creation all succeed. Just hit this on v0.1.7 (run [25036315088](https://github.com/QwenLM/qwen-code/actions/runs/25036315088)) — `@qwen-code/sdk@0.1.7` shipped to `latest` fine, but the workflow failed at this step and PR #3688 was left needing manual merge.

Switching to `--squash --auto` matches the allowed methods and lets the release workflow finish green end-to-end.

## Test plan

- [ ] Next stable SDK release run completes without the `Enable auto-merge for release PR` step failing
- [ ] The release PR gets auto-merged via squash and its branch is deleted (the `--delete-branch` flag is preserved)