### PR TITLE
fix(cli): preserve description in subject-bearing thought chunks

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -2734,6 +2734,51 @@ describe('useGeminiStream', () => {
       });
     });
 
+    it('should render descriptions from subject-bearing thought chunks', async () => {
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Thought,
+            value: {
+              subject: 'Evaluating installation approach',
+              description: 'The',
+            },
+          };
+          yield {
+            type: ServerGeminiEventType.Thought,
+            value: {
+              subject: '',
+              description: ' user mentioned globally installed qwen,',
+            },
+          };
+          yield {
+            type: ServerGeminiEventType.Finished,
+            value: { reason: 'STOP', usageMetadata: undefined },
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('Streamed thought');
+      });
+
+      await waitFor(() => {
+        expect(mockAddItem).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'gemini_thought',
+            text: 'The user mentioned globally installed qwen,',
+          }),
+          expect.any(Number),
+        );
+      });
+      expect(result.current.thought).toEqual({
+        subject: 'Evaluating installation approach',
+        description: 'The user mentioned globally installed qwen,',
+      });
+    });
+
     it('should show a retry countdown and update pending history over time', async () => {
       vi.useFakeTimers();
       try {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1285,9 +1285,12 @@ export const useGeminiStream = (
           dualOutput?.processEvent(event);
           switch (event.type) {
             case ServerGeminiEventType.Thought:
-              // If the thought has a subject, it's a discrete status update rather than
-              // a streamed textual thought, so we update the thought state directly.
-              if (event.value.subject) {
+              // Subject-only chunks are discrete status updates for the
+              // loading indicator and render immediately. Anything carrying
+              // streamed text (with or without a subject) goes through the
+              // throttled buffer so it batches with adjacent reasoning
+              // chunks; the flush merger preserves the subject.
+              if (event.value.subject && !event.value.description) {
                 flushBufferedStreamEvents();
                 setThought(event.value);
               } else {


### PR DESCRIPTION
## Summary

- **What changed:** When a streamed reasoning chunk arrived with both a parsed subject (from `**Title**`) and a description (body text after `\n\n` in the same chunk), the Thought event handler routed only to `setThought` and discarded the description. As a result, the first body word that happened to share a chunk with the closing `**` was silently dropped from the persistent reasoning display. The handler now treats subject-only chunks as discrete loading-indicator updates and routes everything carrying streamed text through the throttled buffer; the existing flush merger preserves the subject.
- **Why it changed:** Some OpenAI-compatible providers emit reasoning batched as `**Subject**\n\nFirstWord ...` in a single SSE delta. With the previous logic the user saw "FirstWord" missing in the rendered reasoning text — a confusing silent loss with no error.
- **Reviewer focus:** `packages/cli/src/ui/hooks/useGeminiStream.ts` Thought-event branch (now 4 lines smaller). The flush merger at `useGeminiStream.ts:1255-1260` already does `subject: queuedThought.value.subject || mergedThought.subject`, so subjects survive batching unchanged.

## Validation

- **User-visible bug:** Using an OpenAI-compatible reasoning provider, the model streams reasoning that follows the `**Heading**\n\nBody…` convention (e.g. `**Evaluating installation approach**\n\nThe user mentioned globally installed qwen,`). When a stream delta from the provider happens to carry both the closing `**` and the first body token in the same SSE chunk, the first word after `\n\n` is silently missing from the rendered reasoning text. The loss is invisible — no error, no warning — and it depends on how aggressively the upstream batches deltas, so the same prompt may render correctly one run and drop a word the next.
- **Expected result:** The full reasoning body renders, including the first word right after the heading.
- **Observed result (before fix):**
  ```
  ✦ user mentioned globally installed qwen, and is asking about the bug.
  ```
- **Observed result (after fix):**
  ```
  ✦ The user mentioned globally installed qwen, and is asking about the bug.
  ```
- **Quickest reviewer verification path:** Point qwen at the `gpt-5.5` model (which streams reasoning in the `**Heading**\n\nBody…` shape) and send any prompt that elicits a non-trivial reasoning trace. Inspect the rendered reasoning block: the first word after the heading should be present.

## Scope / Risk

- **Main risk or tradeoff:** Subject+description chunks now wait up to `STREAM_UPDATE_THROTTLE_MS` before rendering, the same delay every other reasoning chunk already has. Subject-only chunks (the discrete status updates) still render synchronously, so the loading-indicator responsiveness is unchanged.
- **Not covered / not validated:** A separate pre-existing trim issue in `parseThought` (`packages/core/src/utils/thoughtUtils.ts:50-53`) eats the trailing space when a delta ends with `**Subject**\n\nThe ` and the next delta begins with `user ` (no leading space), squashing to `Theuser`. Real BPE tokenizers used by Qwen / OpenAI emit leading-space tokens, so this edge does not arise in practice; it warrants a separate ticket if it ever does.
- **Breaking changes / migration notes:** None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Verified on macOS. No platform-specific code paths are touched, so other platforms should behave identically.

## Linked Issues / Bugs

- None — bug surfaced during local testing against an OpenAI-compatible reasoning provider.