### PR TITLE
fix(core): route countSessionMessages through parseLineTolerant

### DIFF
--- a/packages/core/src/services/sessionService.corruption.test.ts
+++ b/packages/core/src/services/sessionService.corruption.test.ts
@@ -173,4 +173,60 @@ describe('SessionService.readLastRecordUuid (corruption recovery)', () => {
     // function must not surface the payload's nested uuid.
     expect(svc.readLastRecordUuid(file)).not.toBe('fake-from-payload');
   });
+
+  it('returns the final complete record uuid when a giant partial precedes it in the tail', () => {
+    // Positive twin of the partial-tail test above: after a giant line
+    // whose head is past the tail window, append one normal complete
+    // record. The partial first segment must be discarded, but the
+    // complete record after the in-window `\n` must be recovered. Pins
+    // the desired behaviour — the bare-negative assertion above would
+    // still pass if the function silently skipped every line in the
+    // window and returned `null`.
+    const filler = new Array(80000).fill(0).join(',');
+    const giantLine =
+      `{"uuid":"too-early-to-see","filler":[${filler}],` +
+      `"trojan":{"uuid":"fake-from-payload"}}`;
+    const finalRecord = JSON.stringify(recordFor('actual-last', 'user', null));
+    const file = writeJsonl(
+      'big-tail-then-final.jsonl',
+      `${giantLine}\n${finalRecord}\n`,
+    );
+
+    expect(svc.readLastRecordUuid(file)).toBe('actual-last');
+  });
+
+  it('returns the only record when the tail window starts exactly on a newline boundary', () => {
+    // Boundary case: file is `prev\n<final>\n` where `final\n` is
+    // exactly TAIL_READ_SIZE bytes, so the tail read covers `final\n`
+    // and `readStart - 1` lands on the separating `\n`. The first
+    // split segment is a complete record — not a partial fragment.
+    // An unconditional `lines.shift()` drops the only readable uuid
+    // and `renameSession` writes `custom_title.parentUuid` as `null`,
+    // truncating history on resume. The fix peeks the byte before
+    // `readStart` to distinguish boundary-aligned from mid-line reads.
+    const TAIL_READ_SIZE = 64 * 1024;
+    // Build `final` so that `final + '\n'` is exactly TAIL_READ_SIZE.
+    // `recordFor` produces a stable JSON shape; pad it via an extra
+    // `filler` field tuned so the stringified record + 1 (for the
+    // trailing newline we'll join with) hits the target length.
+    const baseFinal = recordFor('boundary-final', 'user', null);
+    const baseFinalLen = Buffer.byteLength(JSON.stringify(baseFinal), 'utf8');
+    // The added field looks like `,"filler":"x...x"` — fixed overhead
+    // (everything except the x-run) is 12 bytes: ` , " f i l l e r " : " " ` .
+    const fillerLen = TAIL_READ_SIZE - 1 - baseFinalLen - 12;
+    expect(fillerLen).toBeGreaterThan(0);
+    const finalRecord = JSON.stringify({
+      ...baseFinal,
+      filler: 'x'.repeat(fillerLen),
+    });
+    expect(Buffer.byteLength(finalRecord + '\n', 'utf8')).toBe(TAIL_READ_SIZE);
+
+    const prevRecord = JSON.stringify(recordFor('older', 'user', null));
+    const file = writeJsonl(
+      'tail-aligned.jsonl',
+      `${prevRecord}\n${finalRecord}\n`,
+    );
+
+    expect(svc.readLastRecordUuid(file)).toBe('boundary-final');
+  });
 });

--- a/packages/core/src/services/sessionService.corruption.test.ts
+++ b/packages/core/src/services/sessionService.corruption.test.ts
@@ -1,0 +1,151 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Integration tests for SessionService corruption-recovery paths.
+ *
+ * Lives in its own file (no module-level `vi.mock`) because both
+ * `countSessionMessages` and `readLastRecordUuid` walk real bytes from disk
+ * via `fs.createReadStream` / `fs.readSync`, and need the real
+ * `jsonl.parseLineTolerant` to exercise the `}{`-glued recovery path
+ * introduced for #3606. The unit-test file (sessionService.test.ts) mocks
+ * jsonl-utils wholesale, so corruption shapes can't be exercised there.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { SessionService } from './sessionService.js';
+import type { ChatRecord } from './chatRecordingService.js';
+
+let tmpRoot: string;
+
+beforeAll(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'session-svc-corruption-'));
+});
+
+afterAll(() => {
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function recordFor(
+  uuid: string,
+  type: 'user' | 'assistant',
+  parentUuid: string | null,
+): ChatRecord {
+  return {
+    uuid,
+    parentUuid,
+    sessionId: '550e8400-e29b-41d4-a716-446655440000',
+    timestamp: '2024-01-01T00:00:00Z',
+    type,
+    message: {
+      role: type === 'user' ? 'user' : 'model',
+      parts: [{ text: 'x' }],
+    },
+    cwd: '/tmp/x',
+    version: '1.0.0',
+    gitBranch: 'main',
+  };
+}
+
+function writeJsonl(name: string, content: string): string {
+  const p = path.join(tmpRoot, name);
+  fs.writeFileSync(p, content, 'utf8');
+  return p;
+}
+
+describe('SessionService.countSessionMessages (corruption recovery)', () => {
+  // The method is private; cast is the cheapest way to test the unit
+  // without exposing it on the public surface.
+  type Privates = {
+    countSessionMessages: (filePath: string) => Promise<number>;
+  };
+  let svc: Privates;
+
+  beforeEach(() => {
+    svc = new SessionService('/tmp/x') as unknown as Privates;
+  });
+
+  it('counts both records of a `}{`-glued physical line', async () => {
+    // The exact #3606 corruption shape: two well-formed objects glued onto
+    // one line because the writer was interrupted between `JSON.stringify`
+    // and the trailing `\n`.
+    const r1 = JSON.stringify(recordFor('u1', 'user', null));
+    const r2 = JSON.stringify(recordFor('u2', 'assistant', 'u1'));
+    const r3 = JSON.stringify(recordFor('u3', 'user', 'u2'));
+    const file = writeJsonl('glued.jsonl', `${r1}${r2}\n${r3}\n`);
+
+    expect(await svc.countSessionMessages(file)).toBe(3);
+  });
+
+  it('does not zero out the count when a line is valid JSON but not an object', async () => {
+    // Old `JSON.parse + catch { continue }` would skip a bare `null` line
+    // because `null.type` threw. After the parseLineTolerant refactor, a
+    // missing object-filter would propagate that TypeError to the outer
+    // catch and zero the whole count — regression guard.
+    const r1 = JSON.stringify(recordFor('u1', 'user', null));
+    const r2 = JSON.stringify(recordFor('u2', 'assistant', 'u1'));
+    const file = writeJsonl('scalar-line.jsonl', `${r1}\nnull\n${r2}\n`);
+
+    expect(await svc.countSessionMessages(file)).toBe(2);
+  });
+
+  it('deduplicates uuids across recovered fragments', async () => {
+    // Same uuid appearing twice (e.g. record was re-emitted during recovery)
+    // must still count as one logical message.
+    const r1 = JSON.stringify(recordFor('u1', 'user', null));
+    const file = writeJsonl('dup.jsonl', `${r1}${r1}\n`);
+
+    expect(await svc.countSessionMessages(file)).toBe(1);
+  });
+
+  it('returns 0 for a missing file', async () => {
+    expect(
+      await svc.countSessionMessages(path.join(tmpRoot, 'nope.jsonl')),
+    ).toBe(0);
+  });
+});
+
+describe('SessionService.readLastRecordUuid (corruption recovery)', () => {
+  type Privates = {
+    readLastRecordUuid: (filePath: string) => string | null;
+  };
+  let svc: Privates;
+
+  beforeEach(() => {
+    svc = new SessionService('/tmp/x') as unknown as Privates;
+  });
+
+  it('returns the latest record uuid from a `}{`-glued tail line', () => {
+    // Critical case: renameSession passes this uuid as the parentUuid of the
+    // synthetic title record. If the tail line is glued and we silently drop
+    // it (old behaviour), parentUuid points at an earlier record and
+    // reconstructHistory truncates the chain on resume.
+    const r1 = JSON.stringify(recordFor('u1', 'user', null));
+    const r2 = JSON.stringify(recordFor('u2', 'assistant', 'u1'));
+    const file = writeJsonl('glued-tail.jsonl', `${r1}${r2}\n`);
+
+    expect(svc.readLastRecordUuid(file)).toBe('u2');
+  });
+
+  it('walks past a malformed tail line and returns the previous valid uuid', () => {
+    const r1 = JSON.stringify(recordFor('u1', 'user', null));
+    const file = writeJsonl('garbage-tail.jsonl', `${r1}\nnot-json-at-all\n`);
+
+    expect(svc.readLastRecordUuid(file)).toBe('u1');
+  });
+
+  it('returns null for a file with no recoverable records', () => {
+    const file = writeJsonl('no-records.jsonl', 'not-json\nstill-not-json\n');
+    expect(svc.readLastRecordUuid(file)).toBeNull();
+  });
+
+  it('returns null for a missing file', () => {
+    expect(svc.readLastRecordUuid(path.join(tmpRoot, 'nope.jsonl'))).toBeNull();
+  });
+});

--- a/packages/core/src/services/sessionService.corruption.test.ts
+++ b/packages/core/src/services/sessionService.corruption.test.ts
@@ -148,4 +148,29 @@ describe('SessionService.readLastRecordUuid (corruption recovery)', () => {
   it('returns null for a missing file', () => {
     expect(svc.readLastRecordUuid(path.join(tmpRoot, 'nope.jsonl'))).toBeNull();
   });
+
+  it('does not extract a uuid from a payload object inside a partial-tail fragment', () => {
+    // When the last record exceeds TAIL_READ_SIZE (64 KiB), the tail buffer
+    // starts mid-record. Without the boundary guard, _recoverObjectsFromLine
+    // walks the partial fragment with depth starting at 0, finds a balanced
+    // inner `{ "uuid": "fake" }` object inside the record's payload, and
+    // surfaces "fake" as if it were the last top-level uuid. renameSession
+    // would then anchor custom_title.parentUuid at payload data and
+    // reconstructHistory would truncate the chain on resume.
+    //
+    // Filler is a long array of zeros (no quote characters) so the parser's
+    // inString state stays aligned even when entering mid-fragment, ensuring
+    // the trojan is reachable. ~80k entries → ~160 KB, comfortably above
+    // TAIL_READ_SIZE.
+    const filler = new Array(80000).fill(0).join(',');
+    const giantLine =
+      `{"uuid":"real-last","filler":[${filler}],` +
+      `"trojan":{"uuid":"fake-from-payload"}}`;
+    const file = writeJsonl('big-tail.jsonl', `${giantLine}\n`);
+
+    // We cannot recover "real-last" — it lies before the tail window. The
+    // critical assertion is the absence of the false-positive recovery: the
+    // function must not surface the payload's nested uuid.
+    expect(svc.readLastRecordUuid(file)).not.toBe('fake-from-payload');
+  });
 });

--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -60,9 +60,13 @@ describe('SessionService', () => {
       .spyOn(fs, 'unlinkSync')
       .mockImplementation(() => undefined);
 
-    // Mock jsonl-utils
+    // Mock jsonl-utils. `parseLineTolerant` defaults to a no-op so any code
+    // path that streams lines through it (e.g. countSessionMessages,
+    // readLastRecordUuid) does not crash on the auto-mocked `undefined`
+    // return; tests that need recovery semantics override this explicitly.
     vi.mocked(jsonl.read).mockResolvedValue([]);
     vi.mocked(jsonl.readLines).mockResolvedValue([]);
+    vi.mocked(jsonl.parseLineTolerant).mockReturnValue([]);
   });
 
   afterEach(() => {

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -310,6 +310,10 @@ export class SessionService {
   /**
    * Counts unique message UUIDs in a session file.
    * This gives the number of logical messages in the session.
+   *
+   * Streams the file and routes each physical line through
+   * `jsonl.parseLineTolerant` so a `}{`-glued line (#3606 corruption shape)
+   * still contributes both records, instead of being silently dropped.
    */
   private async countSessionMessages(filePath: string): Promise<number> {
     const uniqueUuids = new Set<string>();
@@ -323,14 +327,13 @@ export class SessionService {
       for await (const line of rl) {
         const trimmed = line.trim();
         if (!trimmed) continue;
-        try {
-          const record = JSON.parse(trimmed) as ChatRecord;
+        for (const record of jsonl.parseLineTolerant<ChatRecord>(
+          trimmed,
+          filePath,
+        )) {
           if (record.type === 'user' || record.type === 'assistant') {
             uniqueUuids.add(record.uuid);
           }
-        } catch {
-          // Ignore malformed lines
-          continue;
         }
       }
 

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -253,9 +253,23 @@ export class SessionService {
 
       const fd = fs.openSync(filePath, 'r');
       let buffer: Buffer;
+      let firstSegmentIsPartial = false;
       try {
         buffer = Buffer.alloc(readLength);
         fs.readSync(fd, buffer, 0, readLength, readStart);
+
+        // The first split segment is partial only when the tail window
+        // truly starts in the middle of a JSONL record. If the byte right
+        // before `readStart` is `\n`, the window started on a record
+        // boundary and the first segment is a complete line — the
+        // 64-KiB-aligned case where `prev\n<exactly-64KiB-record>\n`
+        // would otherwise drop the only readable record. Peek that byte
+        // before deciding to shift.
+        if (readStart > 0) {
+          const peek = Buffer.alloc(1);
+          fs.readSync(fd, peek, 0, 1, readStart - 1);
+          firstSegmentIsPartial = peek[0] !== 0x0a; // 0x0a = '\n'
+        }
       } finally {
         fs.closeSync(fd);
       }
@@ -263,14 +277,14 @@ export class SessionService {
       const tail = buffer.toString('utf-8');
       const lines = tail.split('\n');
 
-      // When tail-reading from mid-file, the first split segment is a partial
-      // fragment of a record that started before our window. Running tolerant
-      // recovery on it can surface a balanced inner `{ "uuid": ... }` object
-      // from inside the record's payload as if it were a top-level uuid —
-      // `renameSession` would then anchor `custom_title.parentUuid` at payload
-      // data and break the parent chain. Discard that first segment; complete
-      // physical lines after the first `\n` are safe to recover.
-      if (readStart > 0) {
+      // Discard the first segment ONLY when it's a true partial fragment.
+      // Running tolerant recovery on a partial would surface a balanced
+      // inner `{ "uuid": ... }` object from inside the record's payload as
+      // if it were a top-level uuid — `renameSession` would then anchor
+      // `custom_title.parentUuid` at payload data and break the parent
+      // chain. Complete physical lines (including a boundary-aligned
+      // first segment) are safe to recover.
+      if (firstSegmentIsPartial) {
         lines.shift();
       }
 

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -237,6 +237,12 @@ export class SessionService {
   /**
    * Reads the UUID of the last record in a session JSONL file.
    * Uses a tail-read strategy for efficiency.
+   *
+   * Each physical line is routed through `jsonl.parseLineTolerant` so a
+   * `}{`-glued tail line (#3606 corruption shape) still yields its records
+   * instead of being silently skipped — otherwise `renameSession` would set
+   * `custom_title.parentUuid` to a stale uuid and `reconstructHistory` would
+   * truncate the chain on resume.
    */
   private readLastRecordUuid(filePath: string): string | null {
     try {
@@ -257,17 +263,17 @@ export class SessionService {
       const tail = buffer.toString('utf-8');
       const lines = tail.split('\n');
 
-      // Walk backwards to find the last valid record
+      // Walk physical lines bottom-up; on each line walk recovered records
+      // bottom-up too, so a `}{`-glued tail returns the *latest* record.
       for (let i = lines.length - 1; i >= 0; i--) {
         const trimmed = lines[i].trim();
         if (!trimmed) continue;
-        try {
-          const record = JSON.parse(trimmed) as ChatRecord;
-          if (record.uuid) {
+        const records = jsonl.parseLineTolerant<ChatRecord>(trimmed, filePath);
+        for (let j = records.length - 1; j >= 0; j--) {
+          const record = records[j];
+          if (record?.uuid) {
             return record.uuid;
           }
-        } catch {
-          continue;
         }
       }
 

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -263,6 +263,17 @@ export class SessionService {
       const tail = buffer.toString('utf-8');
       const lines = tail.split('\n');
 
+      // When tail-reading from mid-file, the first split segment is a partial
+      // fragment of a record that started before our window. Running tolerant
+      // recovery on it can surface a balanced inner `{ "uuid": ... }` object
+      // from inside the record's payload as if it were a top-level uuid —
+      // `renameSession` would then anchor `custom_title.parentUuid` at payload
+      // data and break the parent chain. Discard that first segment; complete
+      // physical lines after the first `\n` are safe to recover.
+      if (readStart > 0) {
+        lines.shift();
+      }
+
       // Walk physical lines bottom-up; on each line walk recovered records
       // bottom-up too, so a `}{`-glued tail returns the *latest* record.
       for (let i = lines.length - 1; i >= 0; i--) {
@@ -271,7 +282,7 @@ export class SessionService {
         const records = jsonl.parseLineTolerant<ChatRecord>(trimmed, filePath);
         for (let j = records.length - 1; j >= 0; j--) {
           const record = records[j];
-          if (record?.uuid) {
+          if (record.uuid) {
             return record.uuid;
           }
         }

--- a/packages/core/src/utils/jsonl-utils.test.ts
+++ b/packages/core/src/utils/jsonl-utils.test.ts
@@ -11,6 +11,7 @@ import path from 'node:path';
 import {
   _recoverObjectsFromLine,
   _resetEnsuredDirsCacheForTest,
+  parseLineTolerant,
   read,
   readLines,
 } from './jsonl-utils.js';
@@ -78,6 +79,27 @@ describe('_recoverObjectsFromLine', () => {
   it('returns empty array when nothing balanced can be parsed', () => {
     expect(_recoverObjectsFromLine('not json at all')).toEqual([]);
     expect(_recoverObjectsFromLine('{"unterminated":')).toEqual([]);
+  });
+});
+
+describe('parseLineTolerant', () => {
+  it('returns the parsed object for a well-formed line', () => {
+    expect(parseLineTolerant<{ a: number }>('{"a":1}', '/tmp/x.jsonl')).toEqual(
+      [{ a: 1 }],
+    );
+  });
+
+  it('recovers both records from a `}{`-glued line', () => {
+    expect(
+      parseLineTolerant<{ uuid: string }>(
+        '{"uuid":"a"}{"uuid":"b"}',
+        '/tmp/x.jsonl',
+      ),
+    ).toEqual([{ uuid: 'a' }, { uuid: 'b' }]);
+  });
+
+  it('returns [] when nothing balanced can be recovered', () => {
+    expect(parseLineTolerant('not-json', '/tmp/x.jsonl')).toEqual([]);
   });
 });
 

--- a/packages/core/src/utils/jsonl-utils.test.ts
+++ b/packages/core/src/utils/jsonl-utils.test.ts
@@ -110,6 +110,14 @@ describe('parseLineTolerant', () => {
     expect(parseLineTolerant('42', '/tmp/x.jsonl')).toEqual([]);
     expect(parseLineTolerant('"a string"', '/tmp/x.jsonl')).toEqual([]);
   });
+
+  it('filters bare JSON arrays (typeof [] === "object" trap)', () => {
+    // Docstring promises only objects flow through. Arrays would otherwise
+    // slip past the `typeof === 'object'` check and force callers to add
+    // their own `Array.isArray` guards before `record.type`.
+    expect(parseLineTolerant('[1,2,3]', '/tmp/x.jsonl')).toEqual([]);
+    expect(parseLineTolerant('[]', '/tmp/x.jsonl')).toEqual([]);
+  });
 });
 
 describe('read() / readLines() with malformed lines', () => {
@@ -159,5 +167,18 @@ describe('read() / readLines() with malformed lines', () => {
   it('skips blank lines', async () => {
     const file = tmpFile('{"a":1}\n\n{"a":2}\n');
     expect(await read<{ a: number }>(file)).toEqual([{ a: 1 }, { a: 2 }]);
+  });
+
+  it('drops scalar / array lines so callers do not see non-object records', async () => {
+    // Locks in the broader semantic change beyond #3681 Item 1: read() and
+    // readLines() now silently skip well-formed JSON that is not an object.
+    // Pre-#3692 these would have round-tripped through `JSON.parse(line)`
+    // and surfaced as `null` / `42` / `"s"` / `[1,2]` array elements.
+    const file = tmpFile('{"a":1}\nnull\n42\n"a string"\n[1,2,3]\n{"a":2}\n');
+    expect(await read<{ a: number }>(file)).toEqual([{ a: 1 }, { a: 2 }]);
+    expect(await readLines<{ a: number }>(file, 10)).toEqual([
+      { a: 1 },
+      { a: 2 },
+    ]);
   });
 });

--- a/packages/core/src/utils/jsonl-utils.test.ts
+++ b/packages/core/src/utils/jsonl-utils.test.ts
@@ -101,6 +101,15 @@ describe('parseLineTolerant', () => {
   it('returns [] when nothing balanced can be recovered', () => {
     expect(parseLineTolerant('not-json', '/tmp/x.jsonl')).toEqual([]);
   });
+
+  it('filters non-object JSON values (e.g. bare `null`) instead of forwarding them', () => {
+    // Without the filter, callers that do `record.type` would crash on the
+    // returned scalar; integration sites then propagate to outer catches and
+    // zero out whole counts.
+    expect(parseLineTolerant('null', '/tmp/x.jsonl')).toEqual([]);
+    expect(parseLineTolerant('42', '/tmp/x.jsonl')).toEqual([]);
+    expect(parseLineTolerant('"a string"', '/tmp/x.jsonl')).toEqual([]);
+  });
 });
 
 describe('read() / readLines() with malformed lines', () => {

--- a/packages/core/src/utils/jsonl-utils.ts
+++ b/packages/core/src/utils/jsonl-utils.ts
@@ -109,9 +109,10 @@ export function _recoverObjectsFromLine<T = unknown>(line: string): T[] {
  * Parses a single physical JSONL line tolerantly. Returns the parsed objects:
  * one if the line is well-formed, multiple if it is `}{`-glued from an
  * interrupted append (the #3606 corruption shape), zero if nothing can be
- * recovered. Mirrors the silent skip in `countSessionMessages`.
+ * recovered. Use this from any streaming reader that walks JSONL line-by-line
+ * and wants the same recovery semantics as `read()` / `readLines()`.
  */
-function parseLineTolerant<T>(line: string, filePath: string): T[] {
+export function parseLineTolerant<T>(line: string, filePath: string): T[] {
   try {
     return [JSON.parse(line) as T];
   } catch {

--- a/packages/core/src/utils/jsonl-utils.ts
+++ b/packages/core/src/utils/jsonl-utils.ts
@@ -112,14 +112,19 @@ export function _recoverObjectsFromLine<T = unknown>(line: string): T[] {
  * recovered. Use this from any streaming reader that walks JSONL line-by-line
  * and wants the same recovery semantics as `read()` / `readLines()`.
  *
- * Non-object JSON values (e.g. a bare `null` or `42` line) are filtered out:
- * JSONL records in this codebase are always objects, and forwarding scalars
- * would trip property accesses in callers (`record.type`, `record.uuid`).
+ * Non-object JSON values (e.g. a bare `null`, `42`, or `[1,2,3]` line) are
+ * filtered out: JSONL records in this codebase are always objects, and
+ * forwarding scalars or arrays would trip property accesses in callers
+ * (`record.type`, `record.uuid`).
  */
 export function parseLineTolerant<T>(line: string, filePath: string): T[] {
   try {
     const parsed = JSON.parse(line);
-    if (parsed !== null && typeof parsed === 'object') {
+    if (
+      parsed !== null &&
+      typeof parsed === 'object' &&
+      !Array.isArray(parsed)
+    ) {
       return [parsed as T];
     }
     debugLogger.warn(`Skipping non-object JSONL value in ${filePath}`);

--- a/packages/core/src/utils/jsonl-utils.ts
+++ b/packages/core/src/utils/jsonl-utils.ts
@@ -106,15 +106,24 @@ export function _recoverObjectsFromLine<T = unknown>(line: string): T[] {
 }
 
 /**
- * Parses a single physical JSONL line tolerantly. Returns the parsed objects:
+ * Parses a single physical JSONL line tolerantly. Returns the parsed records:
  * one if the line is well-formed, multiple if it is `}{`-glued from an
  * interrupted append (the #3606 corruption shape), zero if nothing can be
  * recovered. Use this from any streaming reader that walks JSONL line-by-line
  * and wants the same recovery semantics as `read()` / `readLines()`.
+ *
+ * Non-object JSON values (e.g. a bare `null` or `42` line) are filtered out:
+ * JSONL records in this codebase are always objects, and forwarding scalars
+ * would trip property accesses in callers (`record.type`, `record.uuid`).
  */
 export function parseLineTolerant<T>(line: string, filePath: string): T[] {
   try {
-    return [JSON.parse(line) as T];
+    const parsed = JSON.parse(line);
+    if (parsed !== null && typeof parsed === 'object') {
+      return [parsed as T];
+    }
+    debugLogger.warn(`Skipping non-object JSONL value in ${filePath}`);
+    return [];
   } catch {
     const fragments = _recoverObjectsFromLine<T>(line);
     if (fragments.length === 0) {


### PR DESCRIPTION
## Summary

Fixes Item 1 from #3681. `SessionService.countSessionMessages` had its own readline loop that silently dropped any line failing `JSON.parse` — including the `}{`-glued lines that #3606's read-side recovery now handles. Result: a corrupted session's `listSessions` count was lower than the record count seen on resume.

## What changes

- **Export `parseLineTolerant`** from `packages/core/src/utils/jsonl-utils.ts` — previously private to `read()` / `readLines()`. Docstring updated to describe it as the streaming-reader entry point.
- **`countSessionMessages`** now routes each physical line through `jsonl.parseLineTolerant<ChatRecord>(...)` and iterates the recovered records, instead of doing inline `JSON.parse` + silent `catch { continue }`. The `user`/`assistant` filter and uuid-set semantics are unchanged.
- **3 unit tests** for the newly exported `parseLineTolerant` (well-formed line / `}{`-glued recovery / unrecoverable input).

## Why streaming, not `jsonl.read()` + dedupe

The issue's second suggestion was to call `jsonl.read()` and dedupe by uuid. Rejected because `countSessionMessages` is on the `listSessions` hot path (default page size 20) and active sessions can hold thousands of records — full-loading every file just to count uuids is wasteful. Keeping the streaming readline loop preserves the original O(uuid-set) memory profile.

## What this PR does NOT do

Item 2 from #3681 — write-side durability (`writeLine` / `writeLineSync` lack `fsync` / atomic-rename) — is intentionally deferred per the issue's own guidance ("Open for discussion — no immediate action required unless reports of corruption persist").

## Test plan

- [x] `npx vitest run packages/core/src/utils/jsonl-utils.test.ts packages/core/src/services/sessionService.test.ts` — 46/46 passing
- [x] `npx tsc --noEmit` in `packages/core` — clean
- [x] Lint + prettier passed via pre-commit hook

Refs #3681