### PR TITLE
fix(core): set DeepSeek V4 context to 1M and output to 384K

### DIFF
--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -172,6 +172,11 @@ describe('tokenLimit', () => {
   });
 
   describe('DeepSeek', () => {
+    it('should return 1M for DeepSeek V4 models', () => {
+      expect(tokenLimit('deepseek-v4-flash')).toBe(1000000);
+      expect(tokenLimit('deepseek-v4-pro')).toBe(1000000);
+    });
+
     it('should return 128K for DeepSeek models', () => {
       expect(tokenLimit('deepseek-r1')).toBe(131072);
       expect(tokenLimit('deepseek-v3')).toBe(131072);
@@ -296,6 +301,8 @@ describe('tokenLimit with output type', () => {
 
   describe('other output limits', () => {
     it('should return correct output limits for DeepSeek', () => {
+      expect(tokenLimit('deepseek-v4-flash', 'output')).toBe(384000);
+      expect(tokenLimit('deepseek-v4-pro', 'output')).toBe(384000);
       expect(tokenLimit('deepseek-reasoner', 'output')).toBe(65536);
       expect(tokenLimit('deepseek-r1', 'output')).toBe(65536);
       expect(tokenLimit('deepseek-r1-0528', 'output')).toBe(65536);

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -32,6 +32,7 @@ const LIMITS = {
   '200k': 200_000, // vendor-declared decimal, used by OpenAI, Anthropic, etc.
   '256k': 262_144,
   '272k': 272_000, // vendor-declared decimal, GPT-5.x input (400K total - 128K output)
+  '384k': 384_000, // vendor-declared decimal, DeepSeek V4 max output
   '400k': 400_000, // vendor-declared decimal, used by OpenAI GPT-5.x
   '512k': 524_288,
   '1m': 1_000_000,
@@ -125,6 +126,7 @@ const PATTERNS: Array<[RegExp, TokenCount]> = [
   // -------------------
   // DeepSeek
   // -------------------
+  [/^deepseek-v4/, LIMITS['1m']], // DeepSeek V4 (flash, pro): 1M
   [/^deepseek/, LIMITS['128k']],
 
   // -------------------
@@ -176,6 +178,7 @@ const OUTPUT_PATTERNS: Array<[RegExp, TokenCount]> = [
   [/^qwen/, LIMITS['32k']], // Qwen fallback (VL, turbo, plus, etc.): 8K
 
   // DeepSeek
+  [/^deepseek-v4/, LIMITS['384k']], // DeepSeek V4 (flash, pro): 384K
   [/^deepseek-reasoner/, LIMITS['64k']],
   [/^deepseek-r1/, LIMITS['64k']],
   [/^deepseek-chat/, LIMITS['8k']],


### PR DESCRIPTION
## Summary

- What changed: DeepSeek V4 models (flash, pro) now report a 1M context window and 384K max output, matching the vendor's published limits.
- Why it changed: The catch-all DeepSeek rule was capping V4 at 128K input and 8K–64K output, so `/context` and output token escalation under-reported the available capacity. A dedicated V4 rule takes precedence over the generic DeepSeek fallback. Older DeepSeek models (R1, V3, chat, reasoner) keep their existing limits.
- Reviewer focus: that the new V4 rule is matched ahead of the generic DeepSeek fallback for both input and output, and that the existing DeepSeek R1/V3/chat/reasoner cases are unchanged.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/core/tokenLimits.test.ts
  npm run typecheck
  ```
- Prompts / inputs used: unit tests for `deepseek-v4-flash`, `deepseek-v4-pro`, plus existing DeepSeek R1/V3/chat assertions retained.
- Expected result: V4 models resolve to 1,000,000 input / 384,000 output; older DeepSeek models still resolve to 131,072 input with their prior output limits; full typecheck clean.
- Observed result: 55 token-limit tests pass; full repo typecheck passes.
- Quickest reviewer verification path: configure a custom OpenAI-compatible provider with model id `deepseek-v4-flash` and run `/context detail` — the context window header should now read `1.0M tokens` instead of `131.1k tokens`.
- Evidence: test run output `Tests 55 passed (55)`.

## Scope / Risk

- Main risk or tradeoff: the V4 rule is keyed off the `deepseek-v4` prefix after normalization. A bare `deepseek-v4` (no `-flash` / `-pro` suffix) gets the trailing `-v4` stripped by the existing version-suffix normalizer and falls through to the generic DeepSeek 128K rule. The vendor's published model ids always carry a suffix, so this only affects synthetic names.
- Not covered / not validated: no live API call against DeepSeek V4 — limits are taken from the vendor docs cited in the linked issue.
- Breaking changes / migration notes: none. Users who already override the limit via `model.generationConfig.contextWindowSize` keep that override; the change only affects the default when nothing is configured.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Pure data change in token-limit tables; behavior is identical across platforms. Verified on macOS via unit tests and typecheck.

## Linked Issues / Bugs

Fixes #3679