### PR TITLE
fix(core): treat ask_user_question multiSelect as optional

### DIFF
--- a/packages/core/src/tools/askUserQuestion.test.ts
+++ b/packages/core/src/tools/askUserQuestion.test.ts
@@ -98,6 +98,43 @@ describe('AskUserQuestionTool', () => {
       const result = tool.validateToolParams(params);
       expect(result).toContain('between 2 and 4 options');
     });
+
+    it('should accept params with multiSelect omitted', () => {
+      const params = {
+        questions: [
+          {
+            question: 'Pick a framework?',
+            header: 'Framework',
+            options: [
+              { label: 'React', description: 'A JavaScript library' },
+              { label: 'Vue', description: 'Progressive framework' },
+            ],
+          },
+        ],
+      };
+
+      expect(tool.validateToolParams(params)).toBeNull();
+      expect(() => tool.build(params)).not.toThrow();
+    });
+
+    it('should reject params where multiSelect is not a boolean', () => {
+      const params = {
+        questions: [
+          {
+            question: 'Pick a framework?',
+            header: 'Framework',
+            options: [
+              { label: 'React', description: 'A JavaScript library' },
+              { label: 'Vue', description: 'Progressive framework' },
+            ],
+            multiSelect: 'yes' as unknown as boolean,
+          },
+        ],
+      };
+
+      const result = tool.validateToolParams(params);
+      expect(result).toBe('Question 1: "multiSelect" must be a boolean.');
+    });
   });
 
   describe('getDefaultPermission and getConfirmationDetails', () => {

--- a/packages/core/src/tools/askUserQuestion.ts
+++ b/packages/core/src/tools/askUserQuestion.ts
@@ -33,7 +33,7 @@ export interface Question {
   question: string;
   header: string;
   options: QuestionOption[];
-  multiSelect: boolean;
+  multiSelect?: boolean;
 }
 
 export interface AskUserQuestionParams {
@@ -113,7 +113,7 @@ const askUserQuestionToolSchemaData: FunctionDeclaration = {
               type: 'boolean',
             },
           },
-          required: ['question', 'header', 'options', 'multiSelect'],
+          required: ['question', 'header', 'options'],
           additionalProperties: false,
         },
       },
@@ -345,7 +345,10 @@ export class AskUserQuestionTool extends BaseDeclarativeTool<
         }
       }
 
-      if (typeof question.multiSelect !== 'boolean') {
+      if (
+        question.multiSelect !== undefined &&
+        typeof question.multiSelect !== 'boolean'
+      ) {
         return `Question ${i + 1}: "multiSelect" must be a boolean.`;
       }
     }

--- a/packages/core/src/tools/tools.ts
+++ b/packages/core/src/tools/tools.ts
@@ -697,7 +697,7 @@ export interface ToolAskUserQuestionConfirmationDetails {
       label: string;
       description: string;
     }>;
-    multiSelect: boolean;
+    multiSelect?: boolean;
   }>;
   metadata?: {
     source?: string;


### PR DESCRIPTION
## Summary

- **What changed**: `ask_user_question` now accepts tool calls where the model omits `multiSelect` for a question. Calls that include the field with a non-boolean value are still rejected with the original error.
- **Why it changed**: the field's schema declared `default: false` (signalling "optional, falls back to false"), but the same schema also listed it in `required`, and the validator hard-rejected anything that wasn't a boolean. Frontier models read the default annotation and reasonably omitted the field; they then hit `Question 1: "multiSelect" must be a boolean.` and got stuck looping on the same malformed call. This made the tool effectively unusable in some sessions and was the bug reported in #3218.
- **Reviewer focus**: confirm the input shape is now self-consistent (optional in the schema, optional in the type, only validated when present), and that existing UI consumers — which already coalesce a missing value to `false` — keep rendering the dialog correctly.

## Validation

**Before:** the user saw `Question 1: "multiSelect" must be a boolean.` instead of a question dialog whenever the model's tool call omitted `multiSelect`, and the model usually retried the same malformed call (per the screenshot in #3218).

**After:** the same call renders the question dialog. The user picks an option and the conversation continues normally.

Verified end-to-end against a mock model server returning three payload shapes — `multiSelect` omitted, explicit `false`, and a non-boolean string. The first two reach the dialog; the third still surfaces the validator error so genuinely malformed input is still caught. Unit tests for the affected core and CLI surfaces all pass.

## Scope / Risk

- **Main risk or tradeoff**: the input type for a question now declares `multiSelect` as optional. Any downstream code that read it as a guaranteed boolean would have to handle `undefined`. Both rendering call sites already coalesce a missing value to `false`, and a typecheck of `core`, `cli`, and `webui` passes after the change.
- **Not covered / not validated**: the ACP `rawInput` payload — which forwards the model's raw arguments to the IDE companion — has always carried whatever the model actually sent. That's unchanged here; the runtime consumers of that payload already defend against a missing field.
- **Breaking changes / migration notes**: none. The change is strictly more permissive at the validation layer, the type change widens an existing field, and the on-the-wire schema becomes a closer match to what the model already sends.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Verified locally on macOS. Windows and Linux were not exercised; the change is pure TypeScript with no platform-specific logic, so behavior should be identical, but I have not confirmed that.

## Linked Issues / Bugs

Fixes #3218