### PR TITLE
feat(cli): improve export format completion navigation

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -8,7 +8,7 @@ import { renderWithProviders } from '../../test-utils/render.js';
 import { waitFor, act } from '@testing-library/react';
 import type { InputPromptProps } from './InputPrompt.js';
 import { InputPrompt } from './InputPrompt.js';
-import type { TextBuffer } from './shared/text-buffer.js';
+import { useTextBuffer, type TextBuffer } from './shared/text-buffer.js';
 import type { Config } from '@qwen-code/qwen-code-core';
 import { ApprovalMode } from '@qwen-code/qwen-code-core';
 import * as path from 'node:path';
@@ -739,6 +739,171 @@ describe('InputPrompt', () => {
     await wait();
 
     expect(props.onSubmit).toHaveBeenCalledWith('/clear');
+    unmount();
+  });
+
+  it('should submit a perfect match on Enter when suggestions were not navigated', async () => {
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/export');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\r');
+    await wait();
+
+    expect(props.onSubmit).toHaveBeenCalledWith('/export');
+    expect(mockCommandCompletion.handleAutocomplete).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should fill and submit an export format selected with arrow navigation', async () => {
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/export');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\u001B[B');
+    await wait();
+
+    expect(props.buffer.setText).toHaveBeenLastCalledWith('/export md ');
+    expect(mockCommandCompletion.handleAutocomplete).not.toHaveBeenCalled();
+    expect(props.onSubmit).not.toHaveBeenCalled();
+
+    stdin.write('\r');
+    await wait();
+
+    expect(props.onSubmit).toHaveBeenCalledWith('/export md ');
+    unmount();
+  });
+
+  it('should keep cycling export formats after arrow navigation fills input', async () => {
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/export');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\u001B[B');
+    await wait();
+    stdin.write('\u001B[B');
+    await wait();
+
+    expect(props.buffer.setText).toHaveBeenNthCalledWith(2, '/export md ');
+    expect(props.buffer.setText).toHaveBeenNthCalledWith(3, '/export json ');
+    expect(mockInputHistory.navigateDown).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should keep export format suggestions visible after arrow navigation fills input', async () => {
+    const exportSuggestions = [
+      { label: 'html', value: 'html' },
+      { label: 'md', value: 'md' },
+      { label: 'json', value: 'json' },
+      { label: 'jsonl', value: 'jsonl' },
+    ];
+    mockedUseCommandCompletion.mockImplementation((buffer) => {
+      const isExportRoot = buffer.text.trim() === '/export';
+      return {
+        ...mockCommandCompletion,
+        showSuggestions: isExportRoot,
+        suggestions: isExportRoot ? exportSuggestions : [],
+        activeSuggestionIndex: 0,
+        isPerfectMatch: isExportRoot,
+      };
+    });
+    props.slashCommands = [
+      ...mockSlashCommands,
+      {
+        name: 'export',
+        kind: CommandKind.BUILT_IN,
+        description: 'Export session',
+        action: vi.fn(),
+        subCommands: [
+          {
+            name: 'html',
+            kind: CommandKind.BUILT_IN,
+            description: 'Export HTML',
+            action: vi.fn(),
+          },
+          {
+            name: 'md',
+            kind: CommandKind.BUILT_IN,
+            description: 'Export Markdown',
+            action: vi.fn(),
+          },
+          {
+            name: 'json',
+            kind: CommandKind.BUILT_IN,
+            description: 'Export JSON',
+            action: vi.fn(),
+          },
+          {
+            name: 'jsonl',
+            kind: CommandKind.BUILT_IN,
+            description: 'Export JSONL',
+            action: vi.fn(),
+          },
+        ],
+      },
+    ];
+    const TestHarness = () => {
+      const buffer = useTextBuffer({
+        initialText: '/export',
+        viewport: { width: 80, height: 20 },
+        isValidPath: () => false,
+        onChange: () => {},
+      });
+      return <InputPrompt {...props} buffer={buffer} />;
+    };
+
+    const { stdin, lastFrame, unmount } = renderWithProviders(<TestHarness />);
+    await wait();
+
+    stdin.write('\u001B[B');
+    await wait();
+
+    const output = stripAnsi(lastFrame() ?? '');
+    expect(output).toContain('/export md');
+    expect(output).toContain('html');
+    expect(output).toContain('md');
+    expect(output).toContain('json');
+    expect(output).toContain('jsonl');
+    expect(output).toContain('Export Markdown');
     unmount();
   });
 

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -1231,6 +1231,129 @@ describe('InputPrompt', () => {
     unmount();
   });
 
+  it('should trigger export-specific arrow navigation even when completion suggestions are a superset', async () => {
+    // Regression for PR #3701 review (hasExportFormatSuggestions superset
+    // matching): when extra non-export items appear alongside all export
+    // formats, Phase 1 must still route arrow keys to setExportCompletionInput
+    // instead of silently falling through to generic navigateDown.
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+        { label: 'report', value: 'report' }, // extra suggestion
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/export');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\u001B[B]'); // Down
+    await wait();
+
+    expect(props.buffer.setText).toHaveBeenLastCalledWith('/export md');
+    expect(mockCommandCompletion.navigateDown).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should fall through to generic accept when Tab targets a non-export item in the /export superset popup', async () => {
+    // Regression for PR #3701 review: when the active suggestion in the
+    // Phase 1 superset popup is a non-export item, ACCEPT_SUGGESTION must
+    // NOT call setExportCompletionInput — it must fall through to the
+    // generic acceptActiveCompletionSuggestion.
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+        { label: 'report', value: 'report' },
+      ],
+      activeSuggestionIndex: 4, // the non-export item
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/export');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\t'); // Tab (ACCEPT_SUGGESTION)
+    await wait();
+
+    expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(4);
+    // Must NOT write "/export report" to the buffer.
+    expect(props.buffer.setText).not.toHaveBeenCalledWith('/export report');
+    unmount();
+  });
+
+  it('should fall through to generic completion when suggestions are missing an export format', async () => {
+    // Regression for PR #3701 review: when completion suggestions do NOT
+    // include all export formats, hasExportFormatSuggestions must be false
+    // and arrow keys must go through the generic completion.navigateDown
+    // path instead of setExportCompletionInput.
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        // jsonl intentionally missing
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/export');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\u001B[B]'); // Down
+    await wait();
+
+    expect(mockCommandCompletion.navigateDown).toHaveBeenCalled();
+    expect(props.buffer.setText).not.toHaveBeenCalledWith('/export md');
+    expect(props.buffer.setText).not.toHaveBeenCalledWith('/export json');
+    unmount();
+  });
+
+  it('should trigger Phase 1 export popup even when /export has trailing spaces', async () => {
+    // Regression: trailing whitespace after "/export" must be treated the
+    // same as plain "/export" — trim() should normalise the buffer so
+    // hasExportFormatSuggestions activates and the popup triggers.
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/export  '); // trailing spaces
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\u001B[B]'); // Down
+    await wait();
+
+    expect(props.buffer.setText).toHaveBeenLastCalledWith('/export md');
+    expect(mockCommandCompletion.navigateDown).not.toHaveBeenCalled();
+    unmount();
+  });
+
   it('should autocomplete on Enter when user arrow-navigated a perfect-match suggestion list', async () => {
     // Regression for PR #3701 review: the isPerfectMatch + navigated + Enter
     // branch was not covered by tests.

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -1200,8 +1200,8 @@ describe('InputPrompt', () => {
   it('should cycle export format on Down when /export <fmt> was typed manually (not via popup)', async () => {
     // Regression for PR #3701 fifth-round review: users who type
     // "/export md" directly (without going through the Phase-1 popup)
-    // must still get Phase-2 cycling on arrow keys — the ref-seeding
-    // asymmetry previously required arriving via the popup.
+    // must still get Phase-2 cycling on arrow keys, but programmatic
+    // buffer.setText/history restores must not arm the same state.
     mockedUseCommandCompletion.mockReturnValue({
       ...mockCommandCompletion,
       showSuggestions: false, // popup is closed for direct input
@@ -1214,18 +1214,64 @@ describe('InputPrompt', () => {
       activeSuggestionIndex: 0,
       isPerfectMatch: false,
     });
-    // Simulate a user typing "/export md" manually.
-    props.buffer.setText('/export md');
 
-    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    const TestHarness = () => {
+      const buffer = useTextBuffer({
+        initialText: '',
+        viewport: { width: 80, height: 20 },
+        isValidPath: () => false,
+        onChange: () => {},
+      });
+      return <InputPrompt {...props} buffer={buffer} />;
+    };
+
+    const { stdin, lastFrame, unmount } = renderWithProviders(<TestHarness />);
     await wait();
 
-    (props.buffer.setText as ReturnType<typeof vi.fn>).mockClear();
+    stdin.write('/export md');
+    await wait();
+    expect(stripAnsi(lastFrame() ?? '')).toContain('/export md');
 
     // Pressing Down must cycle to the NEXT format (json).
     stdin.write('\u001B[B');
     await wait();
-    expect(props.buffer.setText).toHaveBeenLastCalledWith('/export json');
+    expect(stripAnsi(lastFrame() ?? '')).toContain('/export json');
+    unmount();
+  });
+
+  it('should not arm export cycling from restored history text', async () => {
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: false,
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: false,
+    });
+
+    const TestHarness = () => {
+      const buffer = useTextBuffer({
+        initialText: '/export md',
+        viewport: { width: 80, height: 20 },
+        isValidPath: () => false,
+        onChange: () => {},
+      });
+      return <InputPrompt {...props} buffer={buffer} />;
+    };
+
+    const { stdin, lastFrame, unmount } = renderWithProviders(<TestHarness />);
+    await wait();
+
+    stdin.write('\u001B[B');
+    await wait();
+
+    expect(mockInputHistory.navigateDown).toHaveBeenCalled();
+    expect(stripAnsi(lastFrame() ?? '')).toContain('/export md');
+    expect(stripAnsi(lastFrame() ?? '')).not.toContain('/export json');
     unmount();
   });
 
@@ -2815,6 +2861,66 @@ describe('InputPrompt', () => {
       expect(frame).toContain('(r:)');
       expect(frame).toContain('git commit');
       expect(frame).toContain('git push');
+      unmount();
+    });
+
+    it('shows command search suggestions over active export suggestions', async () => {
+      props.shellModeActive = false;
+      const exportSuggestions = [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+      ];
+
+      mockedUseCommandCompletion.mockImplementation((buffer) => {
+        const isExportRoot = buffer.text.trim() === '/export';
+        return {
+          ...mockCommandCompletion,
+          showSuggestions: isExportRoot,
+          suggestions: isExportRoot ? exportSuggestions : [],
+          activeSuggestionIndex: 0,
+          isPerfectMatch: isExportRoot,
+        };
+      });
+      vi.mocked(useReverseSearchCompletion).mockImplementation(
+        (_buffer, _data, isActive) => ({
+          ...mockReverseSearchCompletion,
+          suggestions: isActive
+            ? [{ label: 'git status', value: 'git status' }]
+            : [],
+          showSuggestions: !!isActive,
+          activeSuggestionIndex: isActive ? 0 : -1,
+        }),
+      );
+
+      const TestHarness = () => {
+        const buffer = useTextBuffer({
+          initialText: '/export',
+          viewport: { width: 80, height: 20 },
+          isValidPath: () => false,
+          onChange: () => {},
+        });
+        return <InputPrompt {...props} buffer={buffer} />;
+      };
+
+      const { stdin, lastFrame, unmount } = renderWithProviders(
+        <TestHarness />,
+      );
+      await wait();
+
+      stdin.write('\u001B[B');
+      await wait();
+      expect(stripAnsi(lastFrame() ?? '')).toContain('/export md');
+      expect(stripAnsi(lastFrame() ?? '')).toContain('jsonl');
+
+      stdin.write('\x12'); // Ctrl+R
+      await wait();
+
+      const frame = stripAnsi(lastFrame() ?? '');
+      expect(frame).toContain('(r:)');
+      expect(frame).toContain('git status');
+      expect(frame).not.toContain('jsonl');
       unmount();
     });
 

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -985,6 +985,10 @@ describe('InputPrompt', () => {
     // User clears buffer and types a different command manually.
     stdin.write('\u0015'); // Ctrl+U: clear line
     await wait();
+    // Pin the intermediate state: Ctrl+U must actually clear the buffer
+    // before we type the new command, so a future useTextBuffer/hook change
+    // can't make this test pass for the wrong reason.
+    expect(stripAnsi(lastFrame() ?? '')).not.toContain('/export');
     stdin.write('/help');
     await wait();
     const afterEditFrame = stripAnsi(lastFrame() ?? '');
@@ -1231,6 +1235,38 @@ describe('InputPrompt', () => {
     unmount();
   });
 
+  it('should cycle export format on Down when /export <fmt> was typed manually (not via popup)', async () => {
+    // Regression for PR #3701 fifth-round review: users who type
+    // "/export md" directly (without going through the Phase-1 popup)
+    // must still get Phase-2 cycling on arrow keys — the ref-seeding
+    // asymmetry previously required arriving via the popup.
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: false, // popup is closed for direct input
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: false,
+    });
+    // Simulate a user typing "/export md" manually.
+    props.buffer.setText('/export md');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    (props.buffer.setText as ReturnType<typeof vi.fn>).mockClear();
+
+    // Pressing Down must cycle to the NEXT format (json).
+    stdin.write('\u001B[B');
+    await wait();
+    expect(props.buffer.setText).toHaveBeenLastCalledWith('/export json');
+    unmount();
+  });
+
   it('should trigger export-specific arrow navigation even when completion suggestions are a superset', async () => {
     // Regression for PR #3701 review (hasExportFormatSuggestions superset
     // matching): when extra non-export items appear alongside all export
@@ -1254,7 +1290,7 @@ describe('InputPrompt', () => {
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
     await wait();
 
-    stdin.write('\u001B[B]'); // Down
+    stdin.write('\u001B[B'); // Down
     await wait();
 
     expect(props.buffer.setText).toHaveBeenLastCalledWith('/export md');
@@ -1316,7 +1352,7 @@ describe('InputPrompt', () => {
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
     await wait();
 
-    stdin.write('\u001B[B]'); // Down
+    stdin.write('\u001B[B'); // Down
     await wait();
 
     expect(mockCommandCompletion.navigateDown).toHaveBeenCalled();
@@ -1346,7 +1382,7 @@ describe('InputPrompt', () => {
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
     await wait();
 
-    stdin.write('\u001B[B]'); // Down
+    stdin.write('\u001B[B'); // Down
     await wait();
 
     expect(props.buffer.setText).toHaveBeenLastCalledWith('/export md');

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -78,6 +78,38 @@ const mockSlashCommands: SlashCommand[] = [
       },
     ],
   },
+  {
+    name: 'export',
+    kind: CommandKind.BUILT_IN,
+    description: 'Export session',
+    action: vi.fn(),
+    subCommands: [
+      {
+        name: 'html',
+        kind: CommandKind.BUILT_IN,
+        description: 'Export HTML',
+        action: vi.fn(),
+      },
+      {
+        name: 'md',
+        kind: CommandKind.BUILT_IN,
+        description: 'Export Markdown',
+        action: vi.fn(),
+      },
+      {
+        name: 'json',
+        kind: CommandKind.BUILT_IN,
+        description: 'Export JSON',
+        action: vi.fn(),
+      },
+      {
+        name: 'jsonl',
+        kind: CommandKind.BUILT_IN,
+        description: 'Export JSONL',
+        action: vi.fn(),
+      },
+    ],
+  },
 ];
 
 describe('InputPrompt', () => {
@@ -846,41 +878,6 @@ describe('InputPrompt', () => {
         isPerfectMatch: isExportRoot,
       };
     });
-    props.slashCommands = [
-      ...mockSlashCommands,
-      {
-        name: 'export',
-        kind: CommandKind.BUILT_IN,
-        description: 'Export session',
-        action: vi.fn(),
-        subCommands: [
-          {
-            name: 'html',
-            kind: CommandKind.BUILT_IN,
-            description: 'Export HTML',
-            action: vi.fn(),
-          },
-          {
-            name: 'md',
-            kind: CommandKind.BUILT_IN,
-            description: 'Export Markdown',
-            action: vi.fn(),
-          },
-          {
-            name: 'json',
-            kind: CommandKind.BUILT_IN,
-            description: 'Export JSON',
-            action: vi.fn(),
-          },
-          {
-            name: 'jsonl',
-            kind: CommandKind.BUILT_IN,
-            description: 'Export JSONL',
-            action: vi.fn(),
-          },
-        ],
-      },
-    ];
     const TestHarness = () => {
       const buffer = useTextBuffer({
         initialText: '/export',
@@ -928,41 +925,6 @@ describe('InputPrompt', () => {
         isPerfectMatch: isExportRoot,
       };
     });
-    props.slashCommands = [
-      ...mockSlashCommands,
-      {
-        name: 'export',
-        kind: CommandKind.BUILT_IN,
-        description: 'Export session',
-        action: vi.fn(),
-        subCommands: [
-          {
-            name: 'html',
-            kind: CommandKind.BUILT_IN,
-            description: 'Export HTML',
-            action: vi.fn(),
-          },
-          {
-            name: 'md',
-            kind: CommandKind.BUILT_IN,
-            description: 'Export Markdown',
-            action: vi.fn(),
-          },
-          {
-            name: 'json',
-            kind: CommandKind.BUILT_IN,
-            description: 'Export JSON',
-            action: vi.fn(),
-          },
-          {
-            name: 'jsonl',
-            kind: CommandKind.BUILT_IN,
-            description: 'Export JSONL',
-            action: vi.fn(),
-          },
-        ],
-      },
-    ];
 
     const TestHarness = () => {
       const buffer = useTextBuffer({
@@ -1421,6 +1383,65 @@ describe('InputPrompt', () => {
     expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
     expect(props.onSubmit).not.toHaveBeenCalled();
     unmount();
+  });
+
+  it('should submit directly on Enter after arrow-navigate + backspace + retype to perfect match', async () => {
+    // Regression for PR #3701 review (issue #5): navigate → backspace
+    // → retype → Enter must submit the raw buffer, not autocomplete.
+    // If the popup persists across backspace+retype and the navigated flag
+    // is not cleared on buffer.text changes, Enter would autocomplete the
+    // first sub-command instead of submitting the perfect match.
+    mockedUseCommandCompletion.mockImplementation((buf) => {
+      const text = buf.text;
+      const isMemory = text === '/memory';
+      return {
+        ...mockCommandCompletion,
+        showSuggestions: true, // popup stays visible throughout
+        suggestions: [
+          { label: 'show', value: 'show' },
+          { label: 'add', value: 'add' },
+          { label: 'refresh', value: 'refresh' },
+        ],
+        activeSuggestionIndex: 0,
+        isPerfectMatch: isMemory,
+      };
+    });
+    props.buffer.setText('/memory');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    // Arrow-navigate so completionSelectionWasNavigatedRef flips to true.
+    stdin.write('\u001B[B');
+    await wait();
+    expect(mockCommandCompletion.navigateDown).toHaveBeenCalled();
+
+    // Simulate backspace to /memor — popup stays visible in this test.
+    // Use unmount + re-render to force useEffect re-evaluation on the
+    // changed buffer.text (direct setText on the mock object doesn't
+    // trigger React state updates, so effects don't fire).
+    props.buffer.setText('/memor');
+    unmount();
+    const { unmount: unmountAfterEdit } = renderWithProviders(
+      <InputPrompt {...props} />,
+    );
+    await wait();
+
+    // Retype: /memor → /memory.
+    props.buffer.setText('/memory');
+    unmountAfterEdit();
+    const { stdin: stdinFinal, unmount: unmountFinal } = renderWithProviders(
+      <InputPrompt {...props} />,
+    );
+    await wait();
+
+    // Enter must submit '/memory', NOT autocomplete 'show'.
+    stdinFinal.write('\r');
+    await wait();
+
+    expect(props.onSubmit).toHaveBeenCalledWith('/memory');
+    expect(mockCommandCompletion.handleAutocomplete).not.toHaveBeenCalled();
+    unmountFinal();
   });
 
   it('should submit directly on Enter for a perfect match without prior arrow navigation', async () => {

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -999,6 +999,149 @@ describe('InputPrompt', () => {
     unmount();
   });
 
+  it('should wrap to jsonl when pressing Up from the /export Phase 1 popup', async () => {
+    // Regression for PR #3701 second-round review: Phase 1 Up-arrow path
+    // (including 0 -> lastIndex wrap) had no test coverage.
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/export');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\u001B[A');
+    await wait();
+
+    expect(props.buffer.setText).toHaveBeenLastCalledWith('/export jsonl');
+    expect(mockCommandCompletion.handleAutocomplete).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should wrap Phase 2 cycling backward when pressing Up repeatedly', async () => {
+    // Regression for PR #3701 second-round review: Phase 2 Up-arrow wrap
+    // logic had no test coverage (existing tests only used Down).
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/export');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    // Phase 1 Down -> /export md (ref=1).
+    stdin.write('\u001B[B');
+    await wait();
+    // Phase 2 Up -> /export html (ref=0).
+    stdin.write('\u001B[A');
+    await wait();
+    // Phase 2 Up wraps from index 0 to last index -> /export jsonl (ref=3).
+    stdin.write('\u001B[A');
+    await wait();
+
+    expect(props.buffer.setText).toHaveBeenNthCalledWith(2, '/export md');
+    expect(props.buffer.setText).toHaveBeenNthCalledWith(3, '/export html');
+    expect(props.buffer.setText).toHaveBeenNthCalledWith(4, '/export jsonl');
+    unmount();
+  });
+
+  it('should seed Phase 2 cycling when Tab accepts a format in the /export popup', async () => {
+    // Regression for PR #3701 second-round review (Suggestion): Tab in the
+    // Phase 1 popup must run the export-specific path so that
+    // exportCompletionSelectionIndexRef is seeded and subsequent arrow/Tab
+    // keys can continue cycling.
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/export');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    // Tab in Phase 1 popup fills /export html and seeds the ref.
+    stdin.write('\t');
+    await wait();
+    expect(props.buffer.setText).toHaveBeenLastCalledWith('/export html');
+    expect(mockCommandCompletion.handleAutocomplete).not.toHaveBeenCalled();
+
+    // Phase 2 Down now cycles forward from the seeded ref.
+    stdin.write('\u001B[B');
+    await wait();
+    expect(props.buffer.setText).toHaveBeenLastCalledWith('/export md');
+
+    // Phase 2 Tab should also cycle (covers isCompletionTabKey branch).
+    stdin.write('\t');
+    await wait();
+    expect(props.buffer.setText).toHaveBeenLastCalledWith('/export json');
+    unmount();
+  });
+
+  it('should not overwrite /export html with extra args when Down is pressed', async () => {
+    // Regression for PR #3701 second-round review (Critical): Phase 2 cycling
+    // guard used startsWith('/export '), which matched inputs like
+    // '/export html --verbose' and silently wiped out the extra arguments.
+    // The strict getExportFormatFromInput guard must let such inputs fall
+    // through without overwriting the buffer.
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/export');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    // Seed Phase 2 state: Down fills /export md and sets ref=1.
+    stdin.write('\u001B[B');
+    await wait();
+    expect(props.buffer.setText).toHaveBeenLastCalledWith('/export md');
+
+    // Simulate the user appending extra arguments to the export input.
+    props.buffer.setText('/export md --verbose');
+    (props.buffer.setText as ReturnType<typeof vi.fn>).mockClear();
+
+    // Pressing Down must NOT replace the buffer with '/export json'.
+    stdin.write('\u001B[B');
+    await wait();
+    expect(props.buffer.setText).not.toHaveBeenCalled();
+    unmount();
+  });
+
   it('should autocomplete on Enter when user arrow-navigated a perfect-match suggestion list', async () => {
     // Regression for PR #3701 review: the isPerfectMatch + navigated + Enter
     // branch was not covered by tests.

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -1142,6 +1142,95 @@ describe('InputPrompt', () => {
     unmount();
   });
 
+  it('should reset export cycling state on Escape so arrows no longer cycle', async () => {
+    // Regression for PR #3701 third-round review (Suggestion): ESC resets
+    // exportCompletionSelectionIndexRef but this path had no test coverage,
+    // so a regression could silently break the reset.
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/export');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    // Phase 1 Down -> /export md (enters Phase 2).
+    stdin.write('\u001B[B');
+    await wait();
+    expect(props.buffer.setText).toHaveBeenLastCalledWith('/export md');
+    (props.buffer.setText as ReturnType<typeof vi.fn>).mockClear();
+
+    // Press Escape — should reset the cycling state.
+    stdin.write('\x1B');
+    await wait();
+
+    // Subsequent Down must NOT overwrite the buffer with an export format.
+    stdin.write('\u001B[B');
+    await wait();
+    expect(props.buffer.setText).not.toHaveBeenCalledWith('/export json');
+    expect(props.buffer.setText).not.toHaveBeenCalledWith('/export html');
+    expect(props.buffer.setText).not.toHaveBeenCalledWith('/export jsonl');
+    expect(props.buffer.setText).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should reset export cycling state on Ctrl+C so new input is not overwritten', async () => {
+    // Regression for PR #3701 third-round review (Suggestion): Ctrl+C resets
+    // exportCompletionSelectionIndexRef but this path had no test coverage,
+    // so the ref could leak into the new input. Verify that after Ctrl+C
+    // the user can type a completely unrelated command without arrow keys
+    // clobbering it with export formats.
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'html', value: 'html' },
+        { label: 'md', value: 'md' },
+        { label: 'json', value: 'json' },
+        { label: 'jsonl', value: 'jsonl' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/export');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    // Phase 1 Down -> /export md (enters Phase 2).
+    stdin.write('\u001B[B');
+    await wait();
+    expect(props.buffer.setText).toHaveBeenLastCalledWith('/export md');
+    (props.buffer.setText as ReturnType<typeof vi.fn>).mockClear();
+
+    // Ctrl+C clears the buffer.
+    stdin.write('\x03');
+    await wait();
+
+    // Set a completely different command into the buffer.
+    props.buffer.setText('/help');
+    (props.buffer.setText as ReturnType<typeof vi.fn>).mockClear();
+
+    // Pressing Down must NOT overwrite '/help' with an export format.
+    stdin.write('\u001B[B');
+    await wait();
+    expect(props.buffer.setText).not.toHaveBeenCalledWith('/export json');
+    expect(props.buffer.setText).not.toHaveBeenCalledWith('/export html');
+    expect(props.buffer.setText).not.toHaveBeenCalledWith('/export jsonl');
+    expect(props.buffer.setText).not.toHaveBeenCalledWith('/export md');
+    expect(props.buffer.setText).not.toHaveBeenCalled();
+    unmount();
+  });
+
   it('should autocomplete on Enter when user arrow-navigated a perfect-match suggestion list', async () => {
     // Regression for PR #3701 review: the isPerfectMatch + navigated + Enter
     // branch was not covered by tests.

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -789,14 +789,14 @@ describe('InputPrompt', () => {
     stdin.write('\u001B[B');
     await wait();
 
-    expect(props.buffer.setText).toHaveBeenLastCalledWith('/export md ');
+    expect(props.buffer.setText).toHaveBeenLastCalledWith('/export md');
     expect(mockCommandCompletion.handleAutocomplete).not.toHaveBeenCalled();
     expect(props.onSubmit).not.toHaveBeenCalled();
 
     stdin.write('\r');
     await wait();
 
-    expect(props.onSubmit).toHaveBeenCalledWith('/export md ');
+    expect(props.onSubmit).toHaveBeenCalledWith('/export md');
     unmount();
   });
 
@@ -823,8 +823,8 @@ describe('InputPrompt', () => {
     stdin.write('\u001B[B');
     await wait();
 
-    expect(props.buffer.setText).toHaveBeenNthCalledWith(2, '/export md ');
-    expect(props.buffer.setText).toHaveBeenNthCalledWith(3, '/export json ');
+    expect(props.buffer.setText).toHaveBeenNthCalledWith(2, '/export md');
+    expect(props.buffer.setText).toHaveBeenNthCalledWith(3, '/export json');
     expect(mockInputHistory.navigateDown).not.toHaveBeenCalled();
     unmount();
   });
@@ -904,6 +904,156 @@ describe('InputPrompt', () => {
     expect(output).toContain('json');
     expect(output).toContain('jsonl');
     expect(output).toContain('Export Markdown');
+    unmount();
+  });
+
+  it('should not clobber manually edited buffer when arrow is pressed after export fill', async () => {
+    // Regression for PR #3701 review: exportCompletionSelectionIndexRef
+    // leaked across buffer edits, so arrow keys would overwrite user-typed
+    // text after the user moved away from an "/export <fmt>" input.
+    mockedUseCommandCompletion.mockImplementation((buffer) => {
+      const isExportRoot = buffer.text.trim() === '/export';
+      return {
+        ...mockCommandCompletion,
+        showSuggestions: isExportRoot,
+        suggestions: isExportRoot
+          ? [
+              { label: 'html', value: 'html' },
+              { label: 'md', value: 'md' },
+              { label: 'json', value: 'json' },
+              { label: 'jsonl', value: 'jsonl' },
+            ]
+          : [],
+        activeSuggestionIndex: 0,
+        isPerfectMatch: isExportRoot,
+      };
+    });
+    props.slashCommands = [
+      ...mockSlashCommands,
+      {
+        name: 'export',
+        kind: CommandKind.BUILT_IN,
+        description: 'Export session',
+        action: vi.fn(),
+        subCommands: [
+          {
+            name: 'html',
+            kind: CommandKind.BUILT_IN,
+            description: 'Export HTML',
+            action: vi.fn(),
+          },
+          {
+            name: 'md',
+            kind: CommandKind.BUILT_IN,
+            description: 'Export Markdown',
+            action: vi.fn(),
+          },
+          {
+            name: 'json',
+            kind: CommandKind.BUILT_IN,
+            description: 'Export JSON',
+            action: vi.fn(),
+          },
+          {
+            name: 'jsonl',
+            kind: CommandKind.BUILT_IN,
+            description: 'Export JSONL',
+            action: vi.fn(),
+          },
+        ],
+      },
+    ];
+
+    const TestHarness = () => {
+      const buffer = useTextBuffer({
+        initialText: '/export',
+        viewport: { width: 80, height: 20 },
+        isValidPath: () => false,
+        onChange: () => {},
+      });
+      return <InputPrompt {...props} buffer={buffer} />;
+    };
+
+    const { stdin, lastFrame, unmount } = renderWithProviders(<TestHarness />);
+    await wait();
+
+    // Phase 1 + 2: Down fills "/export md".
+    stdin.write('\u001B[B');
+    await wait();
+    expect(stripAnsi(lastFrame() ?? '')).toContain('/export md');
+
+    // User clears buffer and types a different command manually.
+    stdin.write('\u0015'); // Ctrl+U: clear line
+    await wait();
+    stdin.write('/help');
+    await wait();
+    const afterEditFrame = stripAnsi(lastFrame() ?? '');
+    expect(afterEditFrame).toContain('/help');
+
+    // Pressing Down now must NOT overwrite "/help" with an export format.
+    stdin.write('\u001B[B');
+    await wait();
+    const afterArrowFrame = stripAnsi(lastFrame() ?? '');
+    expect(afterArrowFrame).toContain('/help');
+    expect(afterArrowFrame).not.toMatch(/\/export\s+(html|md|json|jsonl)/);
+    unmount();
+  });
+
+  it('should autocomplete on Enter when user arrow-navigated a perfect-match suggestion list', async () => {
+    // Regression for PR #3701 review: the isPerfectMatch + navigated + Enter
+    // branch was not covered by tests.
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'show', value: 'show' },
+        { label: 'add', value: 'add' },
+        { label: 'refresh', value: 'refresh' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/memory');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    // Arrow-navigate so completionSelectionWasNavigatedRef flips to true.
+    stdin.write('\u001B[B');
+    await wait();
+    expect(mockCommandCompletion.navigateDown).toHaveBeenCalled();
+
+    // Enter should autocomplete the active suggestion, NOT submit the raw buffer.
+    stdin.write('\r');
+    await wait();
+
+    expect(mockCommandCompletion.handleAutocomplete).toHaveBeenCalledWith(0);
+    expect(props.onSubmit).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('should submit directly on Enter for a perfect match without prior arrow navigation', async () => {
+    // Control: with no arrow navigation, Enter on a perfect match must submit.
+    mockedUseCommandCompletion.mockReturnValue({
+      ...mockCommandCompletion,
+      showSuggestions: true,
+      suggestions: [
+        { label: 'show', value: 'show' },
+        { label: 'add', value: 'add' },
+      ],
+      activeSuggestionIndex: 0,
+      isPerfectMatch: true,
+    });
+    props.buffer.setText('/memory');
+
+    const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
+    await wait();
+
+    stdin.write('\r');
+    await wait();
+
+    expect(props.onSubmit).toHaveBeenCalledWith('/memory');
+    expect(mockCommandCompletion.handleAutocomplete).not.toHaveBeenCalled();
     unmount();
   });
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -7,7 +7,11 @@
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { Box, Text } from 'ink';
-import { SuggestionsDisplay, MAX_WIDTH } from './SuggestionsDisplay.js';
+import {
+  SuggestionsDisplay,
+  MAX_WIDTH,
+  type Suggestion,
+} from './SuggestionsDisplay.js';
 import { theme } from '../semantic-colors.js';
 import { useInputHistory } from '../hooks/useInputHistory.js';
 import type { TextBuffer } from './shared/text-buffer.js';
@@ -65,6 +69,20 @@ export interface Attachment {
 }
 
 const debugLogger = createDebugLogger('INPUT_PROMPT');
+const EXPORT_COMMAND_INPUT = '/export';
+const EXPORT_FORMAT_COMPLETIONS = ['html', 'md', 'json', 'jsonl'] as const;
+type ExportFormatCompletion = (typeof EXPORT_FORMAT_COMPLETIONS)[number];
+
+const getExportFormatFromInput = (
+  input: string,
+): ExportFormatCompletion | null => {
+  const match = input.trim().match(/^\/export\s+(html|md|json|jsonl)$/);
+  const format = match?.[1];
+  return EXPORT_FORMAT_COMPLETIONS.includes(format as ExportFormatCompletion)
+    ? (format as ExportFormatCompletion)
+    : null;
+};
+
 export interface InputPromptProps {
   buffer: TextBuffer;
   onSubmit: (value: string) => void;
@@ -189,6 +207,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   ]);
   const [expandedSuggestionIndex, setExpandedSuggestionIndex] =
     useState<number>(-1);
+  const completionSelectionWasNavigatedRef = useRef(false);
+  const exportCompletionSelectionIndexRef = useRef<number | null>(null);
   const shellHistory = useShellHistory(config.getProjectRoot());
   const shellHistoryData = shellHistory.history;
 
@@ -211,6 +231,26 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     showCursorBeforeText?: boolean;
   } | null>(null);
   midInputGhostTextRef.current = completion.midInputGhostText;
+
+  const exportFormatSuggestions = useMemo<Suggestion[]>(() => {
+    const exportCommand = slashCommands.find(
+      (command) => command.name === EXPORT_COMMAND_INPUT.slice(1),
+    );
+    const subCommandsByName = new Map(
+      exportCommand?.subCommands?.map((command) => [command.name, command]) ??
+        [],
+    );
+
+    return EXPORT_FORMAT_COMPLETIONS.map((format) => {
+      const command = subCommandsByName.get(format);
+      return {
+        label: command?.name ?? format,
+        value: command?.name ?? format,
+        description: command?.description,
+        commandKind: command?.kind,
+      };
+    });
+  }, [slashCommands]);
 
   const reverseSearchCompletion = useReverseSearchCompletion(
     buffer,
@@ -243,6 +283,16 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     reverseSearchCompletion.resetCompletionState;
   const resetCommandSearchCompletionState =
     commandSearchCompletion.resetCompletionState;
+
+  useEffect(() => {
+    if (!completion.showSuggestions) {
+      completionSelectionWasNavigatedRef.current = false;
+    }
+  }, [completion.showSuggestions]);
+
+  useEffect(() => {
+    completionSelectionWasNavigatedRef.current = false;
+  }, [completion.suggestions]);
 
   const showCursor =
     focus && isShellFocused && !isEmbeddedShellFocused && !agentTabBarFocused;
@@ -302,6 +352,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const handleSubmitAndClear = useCallback(
     (submittedValue: string) => {
+      exportCompletionSelectionIndexRef.current = null;
       // Expand any large paste placeholders to their full content before submitting
       let finalValue = submittedValue;
       if (pendingPastes.size > 0) {
@@ -615,6 +666,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       if (keyMatchers[Command.ESCAPE](key)) {
+        exportCompletionSelectionIndexRef.current = null;
         const cancelSearch = (
           setActive: (active: boolean) => void,
           resetCompletion: () => void,
@@ -653,6 +705,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
 
         if (completion.showSuggestions) {
+          completionSelectionWasNavigatedRef.current = false;
           completion.resetCompletionState();
           setExpandedSuggestionIndex(-1);
           resetEscapeState();
@@ -780,8 +833,84 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
       }
 
+      const isCompletionUpKey = keyMatchers[Command.COMPLETION_UP](key);
+      const isCompletionDownKey = keyMatchers[Command.COMPLETION_DOWN](key);
+
+      const setExportCompletionInput = (index: number): boolean => {
+        const format = EXPORT_FORMAT_COMPLETIONS[index];
+        if (!format) {
+          return false;
+        }
+
+        buffer.setText(`${EXPORT_COMMAND_INPUT} ${format} `);
+        exportCompletionSelectionIndexRef.current = index;
+        completionSelectionWasNavigatedRef.current = false;
+        setExpandedSuggestionIndex(-1);
+        return true;
+      };
+
+      const getNextExportCompletionIndex = (
+        currentIndex: number,
+        direction: 'up' | 'down',
+      ) => {
+        const lastIndex = EXPORT_FORMAT_COMPLETIONS.length - 1;
+        if (direction === 'up') {
+          return currentIndex <= 0 ? lastIndex : currentIndex - 1;
+        }
+        return currentIndex >= lastIndex ? 0 : currentIndex + 1;
+      };
+
+      const hasExportFormatSuggestions =
+        buffer.text.trim() === EXPORT_COMMAND_INPUT &&
+        completion.suggestions.length === EXPORT_FORMAT_COMPLETIONS.length &&
+        EXPORT_FORMAT_COMPLETIONS.every(
+          (format, index) => completion.suggestions[index]?.value === format,
+        );
+
+      if (
+        exportCompletionSelectionIndexRef.current !== null &&
+        !key.ctrl &&
+        !key.meta &&
+        !key.paste &&
+        (isCompletionUpKey || isCompletionDownKey)
+      ) {
+        const nextIndex = getNextExportCompletionIndex(
+          exportCompletionSelectionIndexRef.current,
+          isCompletionUpKey ? 'up' : 'down',
+        );
+        setExportCompletionInput(nextIndex);
+        return true;
+      }
+
+      const acceptActiveCompletionSuggestion = () => {
+        if (completion.suggestions.length === 0) {
+          return false;
+        }
+
+        const targetIndex =
+          completion.activeSuggestionIndex === -1
+            ? 0
+            : completion.activeSuggestionIndex;
+        if (targetIndex >= completion.suggestions.length) {
+          return false;
+        }
+
+        completion.handleAutocomplete(targetIndex);
+        completionSelectionWasNavigatedRef.current = false;
+        setExpandedSuggestionIndex(-1);
+        return true;
+      };
+
       // If the command is a perfect match, pressing enter should execute it.
       if (completion.isPerfectMatch && keyMatchers[Command.RETURN](key)) {
+        if (
+          completion.showSuggestions &&
+          completionSelectionWasNavigatedRef.current &&
+          acceptActiveCompletionSuggestion()
+        ) {
+          return true;
+        }
+
         handleSubmitAndClear(buffer.text);
         return true;
       }
@@ -819,29 +948,45 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
       if (completion.showSuggestions) {
         if (completion.suggestions.length > 1) {
-          if (keyMatchers[Command.COMPLETION_UP](key)) {
+          if (isCompletionUpKey) {
+            if (hasExportFormatSuggestions) {
+              const activeIndex =
+                completion.activeSuggestionIndex === -1
+                  ? 0
+                  : completion.activeSuggestionIndex;
+              const nextIndex = getNextExportCompletionIndex(activeIndex, 'up');
+              setExportCompletionInput(nextIndex);
+              return true;
+            }
+
             completion.navigateUp();
+            completionSelectionWasNavigatedRef.current = true;
             setExpandedSuggestionIndex(-1); // Reset expansion when navigating
             return true;
           }
-          if (keyMatchers[Command.COMPLETION_DOWN](key)) {
+          if (isCompletionDownKey) {
+            if (hasExportFormatSuggestions) {
+              const activeIndex =
+                completion.activeSuggestionIndex === -1
+                  ? 0
+                  : completion.activeSuggestionIndex;
+              const nextIndex = getNextExportCompletionIndex(
+                activeIndex,
+                'down',
+              );
+              setExportCompletionInput(nextIndex);
+              return true;
+            }
+
             completion.navigateDown();
+            completionSelectionWasNavigatedRef.current = true;
             setExpandedSuggestionIndex(-1); // Reset expansion when navigating
             return true;
           }
         }
 
         if (keyMatchers[Command.ACCEPT_SUGGESTION](key) && !key.paste) {
-          if (completion.suggestions.length > 0) {
-            const targetIndex =
-              completion.activeSuggestionIndex === -1
-                ? 0 // Default to the first if none is active
-                : completion.activeSuggestionIndex;
-            if (targetIndex < completion.suggestions.length) {
-              completion.handleAutocomplete(targetIndex);
-              setExpandedSuggestionIndex(-1); // Reset expansion after selection
-            }
-          }
+          acceptActiveCompletionSuggestion();
           return true;
         }
       }
@@ -1070,6 +1215,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
       // Ctrl+C with completion active — also reset completion state
       if (keyMatchers[Command.CLEAR_INPUT](key)) {
+        exportCompletionSelectionIndexRef.current = null;
         if (buffer.text.length > 0) {
           resetCompletionState();
         }
@@ -1090,6 +1236,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         followup.dismiss();
         onPromptSuggestionDismiss?.();
       }
+      exportCompletionSelectionIndexRef.current = null;
       return false;
     },
     [
@@ -1255,7 +1402,30 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   };
 
   const activeCompletion = getActiveCompletion();
-  const shouldShowSuggestions = activeCompletion.showSuggestions;
+  const selectedExportFormat = getExportFormatFromInput(buffer.text);
+  const selectedExportFormatIndex =
+    selectedExportFormat === null
+      ? -1
+      : EXPORT_FORMAT_COMPLETIONS.indexOf(selectedExportFormat);
+  const shouldKeepExportFormatSuggestions =
+    !reverseSearchActive &&
+    !commandSearchActive &&
+    exportCompletionSelectionIndexRef.current !== null &&
+    selectedExportFormatIndex !== -1;
+  const displayedSuggestions = shouldKeepExportFormatSuggestions
+    ? exportFormatSuggestions
+    : activeCompletion.suggestions;
+  const displayedActiveSuggestionIndex = shouldKeepExportFormatSuggestions
+    ? selectedExportFormatIndex
+    : activeCompletion.activeSuggestionIndex;
+  const displayedSuggestionsScrollOffset = shouldKeepExportFormatSuggestions
+    ? 0
+    : activeCompletion.visibleStartIndex;
+  const displayedSuggestionsLoading = shouldKeepExportFormatSuggestions
+    ? false
+    : activeCompletion.isLoadingSuggestions;
+  const shouldShowSuggestions =
+    shouldKeepExportFormatSuggestions || activeCompletion.showSuggestions;
 
   // Notify parent about suggestions visibility changes
   useEffect(() => {
@@ -1354,11 +1524,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       {shouldShowSuggestions && (
         <Box marginLeft={2} marginRight={2}>
           <SuggestionsDisplay
-            suggestions={activeCompletion.suggestions}
-            activeIndex={activeCompletion.activeSuggestionIndex}
-            isLoading={activeCompletion.isLoadingSuggestions}
+            suggestions={displayedSuggestions}
+            activeIndex={displayedActiveSuggestionIndex}
+            isLoading={displayedSuggestionsLoading}
             width={suggestionsWidth}
-            scrollOffset={activeCompletion.visibleStartIndex}
+            scrollOffset={displayedSuggestionsScrollOffset}
             userInput={buffer.text}
             mode={
               buffer.text.startsWith('/') &&

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -89,6 +89,27 @@ const getExportFormatFromInput = (
     : null;
 };
 
+/**
+ * Compute the next index for export format cycling (round-robin).
+ * Extracted as a module-level pure function to avoid per-keystroke
+ * closure recreation inside handleInput.
+ */
+const getNextExportCompletionIndex = (
+  formatList: readonly string[],
+  currentIndex: number,
+  direction: 'up' | 'down',
+) => {
+  const total = formatList.length;
+  if (total === 0) {
+    return currentIndex;
+  }
+  const lastIndex = total - 1;
+  if (direction === 'up') {
+    return currentIndex <= 0 ? lastIndex : currentIndex - 1;
+  }
+  return currentIndex >= lastIndex ? 0 : currentIndex + 1;
+};
+
 export interface InputPromptProps {
   buffer: TextBuffer;
   onSubmit: (value: string) => void;
@@ -263,6 +284,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       value: format,
     }));
   }, [slashCommands]);
+
+  // Cache the export format names (keys only) so the cycle logic inside
+  // handleInput does not call .map() on every keystroke.
+  const exportCycleFormats = useMemo(
+    () => exportFormatSuggestions.map((suggestion) => suggestion.value),
+    [exportFormatSuggestions],
+  );
 
   const reverseSearchCompletion = useReverseSearchCompletion(
     buffer,
@@ -860,14 +888,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         !key.meta &&
         !key.paste;
 
-      // Runtime source of truth for the export cycle order — derived from
-      // slashCommands via exportFormatSuggestions. Decoupling from the static
-      // EXPORT_FORMAT_COMPLETIONS constant ensures new /export sub-commands
-      // extend the cycle automatically.
-      const exportCycleFormats = exportFormatSuggestions.map(
-        (suggestion) => suggestion.value,
-      );
-
       const setExportCompletionInput = (index: number): boolean => {
         const format = exportCycleFormats[index];
         if (!format) {
@@ -882,21 +902,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         completionSelectionWasNavigatedRef.current = false;
         setExpandedSuggestionIndex(-1);
         return true;
-      };
-
-      const getNextExportCompletionIndex = (
-        currentIndex: number,
-        direction: 'up' | 'down',
-      ) => {
-        const total = exportCycleFormats.length;
-        if (total === 0) {
-          return currentIndex;
-        }
-        const lastIndex = total - 1;
-        if (direction === 'up') {
-          return currentIndex <= 0 ? lastIndex : currentIndex - 1;
-        }
-        return currentIndex >= lastIndex ? 0 : currentIndex + 1;
       };
 
       // Export-completion cycling is a two-phase state machine:
@@ -934,8 +939,21 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       ) {
         // Tab cycles forward like Down for a natural "next format" feel.
         const direction = isCompletionUpKey ? 'up' : 'down';
+        // Derive the current index from the actual buffer text rather than
+        // trusting exportCompletionSelectionIndexRef, which can go stale
+        // when the user manually edits the buffer (e.g. typing a different
+        // export format).
+        // getExportFormatFromInput null was already ruled out by the guard
+        // above; the fallback to exportCompletionSelectionIndexRef is kept
+        // as belt-and-suspenders in case the guard is ever relaxed.
+        const currentFormat = getExportFormatFromInput(buffer.text);
+        const currentIndex =
+          currentFormat !== null
+            ? exportCycleFormats.indexOf(currentFormat)
+            : exportCompletionSelectionIndexRef.current;
         const nextIndex = getNextExportCompletionIndex(
-          exportCompletionSelectionIndexRef.current,
+          exportCycleFormats,
+          currentIndex,
           direction,
         );
         setExportCompletionInput(nextIndex);
@@ -1014,7 +1032,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                 completion.activeSuggestionIndex === -1
                   ? 0
                   : completion.activeSuggestionIndex;
-              const nextIndex = getNextExportCompletionIndex(activeIndex, 'up');
+              const nextIndex = getNextExportCompletionIndex(
+                exportCycleFormats,
+                activeIndex,
+                'up',
+              );
               setExportCompletionInput(nextIndex);
               return true;
             }
@@ -1031,6 +1053,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
                   ? 0
                   : completion.activeSuggestionIndex;
               const nextIndex = getNextExportCompletionIndex(
+                exportCycleFormats,
                 activeIndex,
                 'down',
               );
@@ -1360,7 +1383,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       setBgPillFocused,
       followup,
       onPromptSuggestionDismiss,
-      exportFormatSuggestions,
+      exportCycleFormats,
     ],
   );
 
@@ -1483,7 +1506,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   const selectedExportFormatIndex =
     selectedExportFormat === null
       ? -1
-      : EXPORT_FORMAT_COMPLETIONS.indexOf(selectedExportFormat);
+      : exportFormatSuggestions.findIndex(
+          (s) => s.value === selectedExportFormat,
+        );
   const shouldKeepExportFormatSuggestions =
     !reverseSearchActive &&
     !commandSearchActive &&

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1134,6 +1134,17 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         followup.dismiss();
         onPromptSuggestionDismiss?.();
       }
+
+      if (
+        !key.ctrl &&
+        !key.meta &&
+        !key.paste &&
+        ((key.sequence && key.sequence.length === 1) ||
+          key.name === 'backspace' ||
+          key.name === 'delete')
+      ) {
+        exportCompletion.markNextTextChangeAsUserInput();
+      }
       // NOTE: the former unconditional
       //   `exportCompletion.reset();`
       // at this fallthrough was removed — the phase-2 buffer-text guard above
@@ -1306,14 +1317,20 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   };
 
   const activeCompletion = getActiveCompletion();
-  const suggestionDisplayProps = exportCompletion.suggestionDisplayProps ?? {
-    suggestions: activeCompletion.suggestions,
-    activeIndex: activeCompletion.activeSuggestionIndex,
-    isLoading: activeCompletion.isLoadingSuggestions,
-    scrollOffset: activeCompletion.visibleStartIndex,
-  };
+  const shouldUseExportSuggestions =
+    !commandSearchActive && !reverseSearchActive;
+  const suggestionDisplayProps =
+    shouldUseExportSuggestions && exportCompletion.suggestionDisplayProps
+      ? exportCompletion.suggestionDisplayProps
+      : {
+          suggestions: activeCompletion.suggestions,
+          activeIndex: activeCompletion.activeSuggestionIndex,
+          isLoading: activeCompletion.isLoadingSuggestions,
+          scrollOffset: activeCompletion.visibleStartIndex,
+        };
   const shouldShowSuggestions =
-    exportCompletion.shouldShowSuggestions || activeCompletion.showSuggestions;
+    (shouldUseExportSuggestions && exportCompletion.shouldShowSuggestions) ||
+    activeCompletion.showSuggestions;
 
   // Notify parent about suggestions visibility changes
   useEffect(() => {

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -70,23 +70,43 @@ export interface Attachment {
 
 const debugLogger = createDebugLogger('INPUT_PROMPT');
 const EXPORT_COMMAND_INPUT = '/export';
+// Static fallback list used only during early renders before slashCommands
+// (which carries the canonical export sub-commands) are wired into the
+// component.  Once the /export command is present in slashCommands,
+// exportFormatSuggestions (useMemo) derives the active format list from
+// slashCommands.subCommands and this constant is no longer referenced.
 const EXPORT_FORMAT_COMPLETIONS = ['html', 'md', 'json', 'jsonl'] as const;
-type ExportFormatCompletion = (typeof EXPORT_FORMAT_COMPLETIONS)[number];
 
-const getExportFormatFromInput = (
+/**
+ * Parse a single export format from an input buffer.
+ *
+ * The valid-format list is passed in so that adding a new "/export <fmt>"
+ * sub-command to slashCommands automatically enables Phase-2 cycling for it,
+ * without requiring a synchronous hard-coded regex update.
+ *
+ * Uses a simple slice-based approach (no regex) for two reasons:
+ *   1. No escaping concerns when format names contain regex metacharacters.
+ *   2. O(1) cost after the cheap startsWith prefix guard.
+ */
+export const getExportFormatFromInput = (
   input: string,
-): ExportFormatCompletion | null => {
+  validFormats: readonly string[],
+): string | null => {
   const trimmed = input.trim();
-  // Cheap prefix guard so this runs O(1) for unrelated input instead of
-  // executing the regex every time handleInput / re-renders call it.
-  if (!trimmed.startsWith(EXPORT_COMMAND_INPUT)) {
+  // Require "/export " (with trailing space) so inputs like
+  // "/exportjson" or "/exporthtml" (no space) are not misidentified.
+  // Pure "/export" (no format) is also excluded by this guard.
+  if (!trimmed.startsWith(EXPORT_COMMAND_INPUT + ' ')) {
     return null;
   }
-  const match = trimmed.match(/^\/export\s+(html|md|json|jsonl)$/);
-  const format = match?.[1];
-  return EXPORT_FORMAT_COMPLETIONS.includes(format as ExportFormatCompletion)
-    ? (format as ExportFormatCompletion)
-    : null;
+  // +1 skips the space between "/export" and the format name.
+  const rest = trimmed.slice(EXPORT_COMMAND_INPUT.length + 1);
+  // Reject inputs with extra arguments (e.g. "/export html --verbose")
+  // so the cycling guard does not silently clobber them.
+  if (!rest || rest.includes(' ')) {
+    return null;
+  }
+  return validFormats.includes(rest) ? rest : null;
 };
 
 /**
@@ -261,9 +281,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   // Derive the canonical export format list from slashCommands so adding a new
   // "/export <fmt>" sub-command does not silently break the arrow/Tab cycle.
-  // EXPORT_FORMAT_COMPLETIONS is kept only as a type-safe whitelist for the
-  // format parser (getExportFormatFromInput); runtime display / cycle order
-  // follows whatever the export command declares.
+  // EXPORT_FORMAT_COMPLETIONS is kept only as a fallback for early renders
+  // before slashCommands are wired up; runtime display, cycling, and format
+  // parsing all follow whatever the export command declares.
   const exportFormatSuggestions = useMemo<Suggestion[]>(() => {
     const exportCommand = slashCommands.find(
       (command) => command.name === EXPORT_COMMAND_INPUT.slice(1),
@@ -915,13 +935,29 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       // The two phases are mutually exclusive. Do NOT widen
       // `hasExportFormatSuggestions` to include the filled-in state — it would
       // short-circuit phase 2 cycling.
+      // Export-specific Phase-1 handling activates when *all* export formats
+      // are present somewhere in the completion suggestions (superset match).
+      // This avoids silently falling through to generic completion when the
+      // suggestion list happens to include extra non-export items alongside
+      // the export format entries.
       const hasExportFormatSuggestions =
         buffer.text.trim() === EXPORT_COMMAND_INPUT &&
         completion.suggestions.length > 0 &&
-        completion.suggestions.length === exportCycleFormats.length &&
-        completion.suggestions.every(
-          (suggestion, index) => suggestion.value === exportCycleFormats[index],
+        exportCycleFormats.length > 0 &&
+        exportCycleFormats.every((format) =>
+          completion.suggestions.some((s) => s.value === format),
         );
+
+      // Derive the active suggestion's corresponding exportCycleFormats index.
+      // Returns -1 when the active suggestion is not an export format, so
+      // callers can decide whether to default or fall through.
+      const getExportIndexForActiveSuggestion = (): number => {
+        const idx = completion.activeSuggestionIndex;
+        if (idx < 0 || idx >= completion.suggestions.length) {
+          return -1;
+        }
+        return exportCycleFormats.indexOf(completion.suggestions[idx].value);
+      };
 
       // Phase-2 cycling guard: require buffer to still look like an
       // "/export <fmt>" input so arrow/Tab keys can't clobber arbitrary text
@@ -929,9 +965,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       // Use the strict format parser rather than `startsWith('/export ')`, so
       // inputs like "/export html --verbose" (with extra arguments) fall
       // through to default handling instead of being overwritten.
+      const parsedFormat = getExportFormatFromInput(
+        buffer.text,
+        exportCycleFormats,
+      );
       if (
         exportCompletionSelectionIndexRef.current !== null &&
-        getExportFormatFromInput(buffer.text) !== null &&
+        parsedFormat !== null &&
         !key.ctrl &&
         !key.meta &&
         !key.paste &&
@@ -942,15 +982,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         // Derive the current index from the actual buffer text rather than
         // trusting exportCompletionSelectionIndexRef, which can go stale
         // when the user manually edits the buffer (e.g. typing a different
-        // export format).
-        // getExportFormatFromInput null was already ruled out by the guard
-        // above; the fallback to exportCompletionSelectionIndexRef is kept
-        // as belt-and-suspenders in case the guard is ever relaxed.
-        const currentFormat = getExportFormatFromInput(buffer.text);
-        const currentIndex =
-          currentFormat !== null
-            ? exportCycleFormats.indexOf(currentFormat)
-            : exportCompletionSelectionIndexRef.current;
+        // export format).  parsedFormat is already non-null from the guard.
+        // This design ensures that editing /export md → /export jsonl + Down
+        // correctly wraps to html rather than advancing from the stale md index.
+        const currentIndex = exportCycleFormats.indexOf(parsedFormat);
         const nextIndex = getNextExportCompletionIndex(
           exportCycleFormats,
           currentIndex,
@@ -1028,17 +1063,20 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         if (completion.suggestions.length > 1) {
           if (isCompletionUpKey) {
             if (hasExportFormatSuggestions) {
-              const activeIndex =
-                completion.activeSuggestionIndex === -1
-                  ? 0
-                  : completion.activeSuggestionIndex;
-              const nextIndex = getNextExportCompletionIndex(
-                exportCycleFormats,
-                activeIndex,
-                'up',
-              );
-              setExportCompletionInput(nextIndex);
-              return true;
+              const currentIndex = getExportIndexForActiveSuggestion();
+              // When the active suggestion is not an export format (e.g. a
+              // superset popup extra item), fall through to generic
+              // completion.navigateUp — consistent with how Tab/Enter
+              // already falls through for non-export items.
+              if (currentIndex !== -1) {
+                const nextIndex = getNextExportCompletionIndex(
+                  exportCycleFormats,
+                  currentIndex,
+                  'up',
+                );
+                setExportCompletionInput(nextIndex);
+                return true;
+              }
             }
 
             completion.navigateUp();
@@ -1048,17 +1086,19 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           }
           if (isCompletionDownKey) {
             if (hasExportFormatSuggestions) {
-              const activeIndex =
-                completion.activeSuggestionIndex === -1
-                  ? 0
-                  : completion.activeSuggestionIndex;
-              const nextIndex = getNextExportCompletionIndex(
-                exportCycleFormats,
-                activeIndex,
-                'down',
-              );
-              setExportCompletionInput(nextIndex);
-              return true;
+              const currentIndex = getExportIndexForActiveSuggestion();
+              // When the active suggestion is not an export format, fall
+              // through to generic completion.navigateDown — consistent with
+              // the Up-arrow and Tab/Enter handlers.
+              if (currentIndex !== -1) {
+                const nextIndex = getNextExportCompletionIndex(
+                  exportCycleFormats,
+                  currentIndex,
+                  'down',
+                );
+                setExportCompletionInput(nextIndex);
+                return true;
+              }
             }
 
             completion.navigateDown();
@@ -1073,12 +1113,14 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             // Mirror Up/Down export-specific handling so Tab/Enter in the
             // Phase-1 popup also seed `exportCompletionSelectionIndexRef`,
             // allowing Phase-2 cycling to continue from the selected format.
-            const activeIndex =
-              completion.activeSuggestionIndex === -1
-                ? 0
-                : completion.activeSuggestionIndex;
-            setExportCompletionInput(activeIndex);
-            return true;
+            // Only route to export-specific accept when the active suggestion
+            // is actually an export format; non-export items fall through to
+            // generic acceptActiveCompletionSuggestion.
+            const exportIndex = getExportIndexForActiveSuggestion();
+            if (exportIndex !== -1) {
+              setExportCompletionInput(exportIndex);
+              return true;
+            }
           }
           acceptActiveCompletionSuggestion();
           return true;
@@ -1502,13 +1544,24 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   };
 
   const activeCompletion = getActiveCompletion();
-  const selectedExportFormat = getExportFormatFromInput(buffer.text);
+  const selectedExportFormat = getExportFormatFromInput(
+    buffer.text,
+    exportCycleFormats,
+  );
   const selectedExportFormatIndex =
     selectedExportFormat === null
       ? -1
       : exportFormatSuggestions.findIndex(
           (s) => s.value === selectedExportFormat,
         );
+  // No defensive useEffect is needed to clear exportCompletionSelectionIndexRef
+  // when buffer.text drifts away from a valid export format —
+  // shouldKeepExportFormatSuggestions already gates on
+  // selectedExportFormatIndex !== -1 (derived from getExportFormatFromInput),
+  // so any edit that makes the buffer no longer look like "/export <fmt>"
+  // automatically hides the persistent suggestion panel.  The Phase-2 cycling
+  // guard in handleInput independently blocks arrow/Tab cycling for
+  // non-export input via the same parsedFormat !== null check.
   const shouldKeepExportFormatSuggestions =
     !reverseSearchActive &&
     !commandSearchActive &&

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -88,7 +88,7 @@ const EXPORT_FORMAT_COMPLETIONS = ['html', 'md', 'json', 'jsonl'] as const;
  *   1. No escaping concerns when format names contain regex metacharacters.
  *   2. O(1) cost after the cheap startsWith prefix guard.
  */
-export const getExportFormatFromInput = (
+const getExportFormatFromInput = (
   input: string,
   validFormats: readonly string[],
 ): string | null => {
@@ -281,9 +281,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   // Derive the canonical export format list from slashCommands so adding a new
   // "/export <fmt>" sub-command does not silently break the arrow/Tab cycle.
-  // EXPORT_FORMAT_COMPLETIONS is kept only as a fallback for early renders
-  // before slashCommands are wired up; runtime display, cycling, and format
-  // parsing all follow whatever the export command declares.
+  // EXPORT_FORMAT_COMPLETIONS is kept only as a static fallback for early
+  // renders before slashCommands are wired up.  All runtime logic (display,
+  // cycling, parsing) follows the dynamic list derived from slashCommands.
+  // IMPORTANT: if a format is removed from the /export command definition
+  // (slashCommands.subCommands), also remove it here — otherwise the
+  // fallback will silently re-introduce it during early renders.
   const exportFormatSuggestions = useMemo<Suggestion[]>(() => {
     const exportCommand = slashCommands.find(
       (command) => command.name === EXPORT_COMMAND_INPUT.slice(1),
@@ -311,6 +314,21 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     () => exportFormatSuggestions.map((suggestion) => suggestion.value),
     [exportFormatSuggestions],
   );
+
+  // Seed exportCompletionSelectionIndexRef when the user manually types
+  // "/export <fmt>" without going through the Phase-1 popup (UX symmetry).
+  // ESC/Ctrl+C/Ctrl+U clear the ref; this effect re-seeds it when the
+  // buffer changes afterward — React only re-runs on buffer.text changes,
+  // so ESC alone (which doesn't change buffer.text) won't cause immediate
+  // re-seeding.  During Phase 1/2, setExportCompletionInput writes the ref
+  // first, so this effect is a no-op (ref.current !== null).
+  useEffect(() => {
+    const fmt = getExportFormatFromInput(buffer.text, exportCycleFormats);
+    if (fmt !== null && exportCompletionSelectionIndexRef.current === null) {
+      exportCompletionSelectionIndexRef.current =
+        exportCycleFormats.indexOf(fmt);
+    }
+  }, [buffer.text, exportCycleFormats]);
 
   const reverseSearchCompletion = useReverseSearchCompletion(
     buffer,
@@ -1347,6 +1365,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           }
         }
         // No placeholder matched — fall through to BaseTextInput's default backspace
+      }
+
+      // Ctrl+U (clear-line) — reset export cycling state so a subsequent
+      // manual typing of "/export <fmt>" doesn't mistakenly show the
+      // persistent suggestion panel as if the user had cycled.
+      if (key.ctrl && key.name === 'u') {
+        exportCompletionSelectionIndexRef.current = null;
       }
 
       // Ctrl+C with completion active — also reset completion state

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -7,11 +7,7 @@
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useState, useRef } from 'react';
 import { Box, Text } from 'ink';
-import {
-  SuggestionsDisplay,
-  MAX_WIDTH,
-  type Suggestion,
-} from './SuggestionsDisplay.js';
+import { SuggestionsDisplay, MAX_WIDTH } from './SuggestionsDisplay.js';
 import { theme } from '../semantic-colors.js';
 import { useInputHistory } from '../hooks/useInputHistory.js';
 import type { TextBuffer } from './shared/text-buffer.js';
@@ -21,6 +17,7 @@ import chalk from 'chalk';
 import { useShellHistory } from '../hooks/useShellHistory.js';
 import { useReverseSearchCompletion } from '../hooks/useReverseSearchCompletion.js';
 import { useCommandCompletion } from '../hooks/useCommandCompletion.js';
+import { useExportCompletion } from '../hooks/useExportCompletion.js';
 import { useFollowupSuggestionsCLI } from '../hooks/useFollowupSuggestions.js';
 import type { Config } from '@qwen-code/qwen-code-core';
 import type { Key } from '../hooks/useKeypress.js';
@@ -69,66 +66,6 @@ export interface Attachment {
 }
 
 const debugLogger = createDebugLogger('INPUT_PROMPT');
-const EXPORT_COMMAND_INPUT = '/export';
-// Static fallback list used only during early renders before slashCommands
-// (which carries the canonical export sub-commands) are wired into the
-// component.  Once the /export command is present in slashCommands,
-// exportFormatSuggestions (useMemo) derives the active format list from
-// slashCommands.subCommands and this constant is no longer referenced.
-const EXPORT_FORMAT_COMPLETIONS = ['html', 'md', 'json', 'jsonl'] as const;
-
-/**
- * Parse a single export format from an input buffer.
- *
- * The valid-format list is passed in so that adding a new "/export <fmt>"
- * sub-command to slashCommands automatically enables Phase-2 cycling for it,
- * without requiring a synchronous hard-coded regex update.
- *
- * Uses a simple slice-based approach (no regex) for two reasons:
- *   1. No escaping concerns when format names contain regex metacharacters.
- *   2. O(1) cost after the cheap startsWith prefix guard.
- */
-const getExportFormatFromInput = (
-  input: string,
-  validFormats: readonly string[],
-): string | null => {
-  const trimmed = input.trim();
-  // Require "/export " (with trailing space) so inputs like
-  // "/exportjson" or "/exporthtml" (no space) are not misidentified.
-  // Pure "/export" (no format) is also excluded by this guard.
-  if (!trimmed.startsWith(EXPORT_COMMAND_INPUT + ' ')) {
-    return null;
-  }
-  // +1 skips the space between "/export" and the format name.
-  const rest = trimmed.slice(EXPORT_COMMAND_INPUT.length + 1);
-  // Reject inputs with extra arguments (e.g. "/export html --verbose")
-  // so the cycling guard does not silently clobber them.
-  if (!rest || rest.includes(' ')) {
-    return null;
-  }
-  return validFormats.includes(rest) ? rest : null;
-};
-
-/**
- * Compute the next index for export format cycling (round-robin).
- * Extracted as a module-level pure function to avoid per-keystroke
- * closure recreation inside handleInput.
- */
-const getNextExportCompletionIndex = (
-  formatList: readonly string[],
-  currentIndex: number,
-  direction: 'up' | 'down',
-) => {
-  const total = formatList.length;
-  if (total === 0) {
-    return currentIndex;
-  }
-  const lastIndex = total - 1;
-  if (direction === 'up') {
-    return currentIndex <= 0 ? lastIndex : currentIndex - 1;
-  }
-  return currentIndex >= lastIndex ? 0 : currentIndex + 1;
-};
 
 export interface InputPromptProps {
   buffer: TextBuffer;
@@ -254,8 +191,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   ]);
   const [expandedSuggestionIndex, setExpandedSuggestionIndex] =
     useState<number>(-1);
-  const completionSelectionWasNavigatedRef = useRef(false);
-  const exportCompletionSelectionIndexRef = useRef<number | null>(null);
+  const exportCompletion = useExportCompletion(buffer, slashCommands);
   const shellHistory = useShellHistory(config.getProjectRoot());
   const shellHistoryData = shellHistory.history;
 
@@ -278,57 +214,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     showCursorBeforeText?: boolean;
   } | null>(null);
   midInputGhostTextRef.current = completion.midInputGhostText;
-
-  // Derive the canonical export format list from slashCommands so adding a new
-  // "/export <fmt>" sub-command does not silently break the arrow/Tab cycle.
-  // EXPORT_FORMAT_COMPLETIONS is kept only as a static fallback for early
-  // renders before slashCommands are wired up.  All runtime logic (display,
-  // cycling, parsing) follows the dynamic list derived from slashCommands.
-  // IMPORTANT: if a format is removed from the /export command definition
-  // (slashCommands.subCommands), also remove it here — otherwise the
-  // fallback will silently re-introduce it during early renders.
-  const exportFormatSuggestions = useMemo<Suggestion[]>(() => {
-    const exportCommand = slashCommands.find(
-      (command) => command.name === EXPORT_COMMAND_INPUT.slice(1),
-    );
-    const subCommands = exportCommand?.subCommands;
-    if (subCommands && subCommands.length > 0) {
-      return subCommands.map((command) => ({
-        label: command.name,
-        value: command.name,
-        description: command.description,
-        commandKind: command.kind,
-      }));
-    }
-    // Fallback when slashCommands are not wired up yet (e.g. early render):
-    // fall back to the static whitelist so the UI still shows sensible options.
-    return EXPORT_FORMAT_COMPLETIONS.map((format) => ({
-      label: format,
-      value: format,
-    }));
-  }, [slashCommands]);
-
-  // Cache the export format names (keys only) so the cycle logic inside
-  // handleInput does not call .map() on every keystroke.
-  const exportCycleFormats = useMemo(
-    () => exportFormatSuggestions.map((suggestion) => suggestion.value),
-    [exportFormatSuggestions],
-  );
-
-  // Seed exportCompletionSelectionIndexRef when the user manually types
-  // "/export <fmt>" without going through the Phase-1 popup (UX symmetry).
-  // ESC/Ctrl+C/Ctrl+U clear the ref; this effect re-seeds it when the
-  // buffer changes afterward — React only re-runs on buffer.text changes,
-  // so ESC alone (which doesn't change buffer.text) won't cause immediate
-  // re-seeding.  During Phase 1/2, setExportCompletionInput writes the ref
-  // first, so this effect is a no-op (ref.current !== null).
-  useEffect(() => {
-    const fmt = getExportFormatFromInput(buffer.text, exportCycleFormats);
-    if (fmt !== null && exportCompletionSelectionIndexRef.current === null) {
-      exportCompletionSelectionIndexRef.current =
-        exportCycleFormats.indexOf(fmt);
-    }
-  }, [buffer.text, exportCycleFormats]);
 
   const reverseSearchCompletion = useReverseSearchCompletion(
     buffer,
@@ -361,21 +246,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     reverseSearchCompletion.resetCompletionState;
   const resetCommandSearchCompletionState =
     commandSearchCompletion.resetCompletionState;
-
-  // Reset the "has navigated" flag on popup visibility changes only.
-  // Depending on `completion.suggestions` (array reference) instead would race
-  // with async suggestion refreshes and clobber the flag between the user's
-  // arrow-key press and Enter, silently turning autocomplete into submit.
-  const prevShowSuggestionsRef = useRef(completion.showSuggestions);
-  useEffect(() => {
-    if (!completion.showSuggestions) {
-      completionSelectionWasNavigatedRef.current = false;
-    } else if (!prevShowSuggestionsRef.current) {
-      // Popup just transitioned from hidden to shown — start clean.
-      completionSelectionWasNavigatedRef.current = false;
-    }
-    prevShowSuggestionsRef.current = completion.showSuggestions;
-  }, [completion.showSuggestions]);
 
   const showCursor =
     focus && isShellFocused && !isEmbeddedShellFocused && !agentTabBarFocused;
@@ -435,7 +305,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const handleSubmitAndClear = useCallback(
     (submittedValue: string) => {
-      exportCompletionSelectionIndexRef.current = null;
+      exportCompletion.reset();
       // Expand any large paste placeholders to their full content before submitting
       let finalValue = submittedValue;
       if (pendingPastes.size > 0) {
@@ -487,6 +357,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       resetReverseSearchCompletionState();
     },
     [
+      exportCompletion,
       onSubmit,
       buffer,
       resetCompletionState,
@@ -749,7 +620,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       if (keyMatchers[Command.ESCAPE](key)) {
-        exportCompletionSelectionIndexRef.current = null;
+        exportCompletion.reset();
         const cancelSearch = (
           setActive: (active: boolean) => void,
           resetCompletion: () => void,
@@ -788,7 +659,6 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
 
         if (completion.showSuggestions) {
-          completionSelectionWasNavigatedRef.current = false;
           completion.resetCompletionState();
           setExpandedSuggestionIndex(-1);
           resetEscapeState();
@@ -916,100 +786,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
       }
 
-      const isCompletionUpKey = keyMatchers[Command.COMPLETION_UP](key);
-      const isCompletionDownKey = keyMatchers[Command.COMPLETION_DOWN](key);
-      // Tab cycling is only relevant in phase 2 (popup closed after fill).
-      const isCompletionTabKey =
-        key.name === 'tab' &&
-        !key.shift &&
-        !key.ctrl &&
-        !key.meta &&
-        !key.paste;
-
-      const setExportCompletionInput = (index: number): boolean => {
-        const format = exportCycleFormats[index];
-        if (!format) {
-          return false;
-        }
-
-        // No trailing space: submitted value stays identical to what a user
-        // would type manually, avoiding implicit coupling with how the slash
-        // parser handles trailing whitespace.
-        buffer.setText(`${EXPORT_COMMAND_INPUT} ${format}`);
-        exportCompletionSelectionIndexRef.current = index;
-        completionSelectionWasNavigatedRef.current = false;
-        setExpandedSuggestionIndex(-1);
-        return true;
-      };
-
-      // Export-completion cycling is a two-phase state machine:
-      //   Phase 1 (one-shot trigger): buffer is exactly "/export" and the
-      //     popup shows the export format options. The popup-handler block
-      //     below detects `hasExportFormatSuggestions` and fills the first
-      //     format.
-      //   Phase 2 (continuous cycling): buffer is "/export <fmt>" and the
-      //     popup is closed; arrow/Tab keys cycle via
-      //     exportCompletionSelectionIndexRef.
-      // The two phases are mutually exclusive. Do NOT widen
-      // `hasExportFormatSuggestions` to include the filled-in state — it would
-      // short-circuit phase 2 cycling.
-      // Export-specific Phase-1 handling activates when *all* export formats
-      // are present somewhere in the completion suggestions (superset match).
-      // This avoids silently falling through to generic completion when the
-      // suggestion list happens to include extra non-export items alongside
-      // the export format entries.
-      const hasExportFormatSuggestions =
-        buffer.text.trim() === EXPORT_COMMAND_INPUT &&
-        completion.suggestions.length > 0 &&
-        exportCycleFormats.length > 0 &&
-        exportCycleFormats.every((format) =>
-          completion.suggestions.some((s) => s.value === format),
-        );
-
-      // Derive the active suggestion's corresponding exportCycleFormats index.
-      // Returns -1 when the active suggestion is not an export format, so
-      // callers can decide whether to default or fall through.
-      const getExportIndexForActiveSuggestion = (): number => {
-        const idx = completion.activeSuggestionIndex;
-        if (idx < 0 || idx >= completion.suggestions.length) {
-          return -1;
-        }
-        return exportCycleFormats.indexOf(completion.suggestions[idx].value);
-      };
-
-      // Phase-2 cycling guard: require buffer to still look like an
-      // "/export <fmt>" input so arrow/Tab keys can't clobber arbitrary text
-      // the user typed after filling a format (e.g. after editing to "/help").
-      // Use the strict format parser rather than `startsWith('/export ')`, so
-      // inputs like "/export html --verbose" (with extra arguments) fall
-      // through to default handling instead of being overwritten.
-      const parsedFormat = getExportFormatFromInput(
-        buffer.text,
-        exportCycleFormats,
-      );
-      if (
-        exportCompletionSelectionIndexRef.current !== null &&
-        parsedFormat !== null &&
-        !key.ctrl &&
-        !key.meta &&
-        !key.paste &&
-        (isCompletionUpKey || isCompletionDownKey || isCompletionTabKey)
-      ) {
-        // Tab cycles forward like Down for a natural "next format" feel.
-        const direction = isCompletionUpKey ? 'up' : 'down';
-        // Derive the current index from the actual buffer text rather than
-        // trusting exportCompletionSelectionIndexRef, which can go stale
-        // when the user manually edits the buffer (e.g. typing a different
-        // export format).  parsedFormat is already non-null from the guard.
-        // This design ensures that editing /export md → /export jsonl + Down
-        // correctly wraps to html rather than advancing from the stale md index.
-        const currentIndex = exportCycleFormats.indexOf(parsedFormat);
-        const nextIndex = getNextExportCompletionIndex(
-          exportCycleFormats,
-          currentIndex,
-          direction,
-        );
-        setExportCompletionInput(nextIndex);
+      // Export-specific arrow/Tab/Enter handling (Phase 1 + Phase 2).
+      if (exportCompletion.handleExportInput(key, completion)) {
         return true;
       }
 
@@ -1027,7 +805,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
 
         completion.handleAutocomplete(targetIndex);
-        completionSelectionWasNavigatedRef.current = false;
+        exportCompletion.navigatedRef.current = false;
         setExpandedSuggestionIndex(-1);
         return true;
       };
@@ -1036,7 +814,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       if (completion.isPerfectMatch && keyMatchers[Command.RETURN](key)) {
         if (
           completion.showSuggestions &&
-          completionSelectionWasNavigatedRef.current &&
+          exportCompletion.navigatedRef.current &&
+          exportCompletion.navigatedTextRef.current === buffer.text &&
           acceptActiveCompletionSuggestion()
         ) {
           return true;
@@ -1079,67 +858,25 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
       if (completion.showSuggestions) {
         if (completion.suggestions.length > 1) {
+          const isCompletionUpKey = keyMatchers[Command.COMPLETION_UP](key);
+          const isCompletionDownKey = keyMatchers[Command.COMPLETION_DOWN](key);
           if (isCompletionUpKey) {
-            if (hasExportFormatSuggestions) {
-              const currentIndex = getExportIndexForActiveSuggestion();
-              // When the active suggestion is not an export format (e.g. a
-              // superset popup extra item), fall through to generic
-              // completion.navigateUp — consistent with how Tab/Enter
-              // already falls through for non-export items.
-              if (currentIndex !== -1) {
-                const nextIndex = getNextExportCompletionIndex(
-                  exportCycleFormats,
-                  currentIndex,
-                  'up',
-                );
-                setExportCompletionInput(nextIndex);
-                return true;
-              }
-            }
-
             completion.navigateUp();
-            completionSelectionWasNavigatedRef.current = true;
-            setExpandedSuggestionIndex(-1); // Reset expansion when navigating
+            exportCompletion.navigatedRef.current = true;
+            exportCompletion.navigatedTextRef.current = buffer.text;
+            setExpandedSuggestionIndex(-1);
             return true;
           }
           if (isCompletionDownKey) {
-            if (hasExportFormatSuggestions) {
-              const currentIndex = getExportIndexForActiveSuggestion();
-              // When the active suggestion is not an export format, fall
-              // through to generic completion.navigateDown — consistent with
-              // the Up-arrow and Tab/Enter handlers.
-              if (currentIndex !== -1) {
-                const nextIndex = getNextExportCompletionIndex(
-                  exportCycleFormats,
-                  currentIndex,
-                  'down',
-                );
-                setExportCompletionInput(nextIndex);
-                return true;
-              }
-            }
-
             completion.navigateDown();
-            completionSelectionWasNavigatedRef.current = true;
-            setExpandedSuggestionIndex(-1); // Reset expansion when navigating
+            exportCompletion.navigatedRef.current = true;
+            exportCompletion.navigatedTextRef.current = buffer.text;
+            setExpandedSuggestionIndex(-1);
             return true;
           }
         }
 
         if (keyMatchers[Command.ACCEPT_SUGGESTION](key) && !key.paste) {
-          if (hasExportFormatSuggestions) {
-            // Mirror Up/Down export-specific handling so Tab/Enter in the
-            // Phase-1 popup also seed `exportCompletionSelectionIndexRef`,
-            // allowing Phase-2 cycling to continue from the selected format.
-            // Only route to export-specific accept when the active suggestion
-            // is actually an export format; non-export items fall through to
-            // generic acceptActiveCompletionSuggestion.
-            const exportIndex = getExportIndexForActiveSuggestion();
-            if (exportIndex !== -1) {
-              setExportCompletionInput(exportIndex);
-              return true;
-            }
-          }
           acceptActiveCompletionSuggestion();
           return true;
         }
@@ -1371,12 +1108,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       // manual typing of "/export <fmt>" doesn't mistakenly show the
       // persistent suggestion panel as if the user had cycled.
       if (key.ctrl && key.name === 'u') {
-        exportCompletionSelectionIndexRef.current = null;
+        exportCompletion.reset();
       }
 
       // Ctrl+C with completion active — also reset completion state
       if (keyMatchers[Command.CLEAR_INPUT](key)) {
-        exportCompletionSelectionIndexRef.current = null;
+        exportCompletion.reset();
         if (buffer.text.length > 0) {
           resetCompletionState();
         }
@@ -1398,7 +1135,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         onPromptSuggestionDismiss?.();
       }
       // NOTE: the former unconditional
-      //   `exportCompletionSelectionIndexRef.current = null;`
+      //   `exportCompletion.reset();`
       // at this fallthrough was removed — the phase-2 buffer-text guard above
       // already prevents stale state from affecting non-/export input, and
       // the blanket reset was wiping selection on cursor-only keys such as
@@ -1450,7 +1187,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       setBgPillFocused,
       followup,
       onPromptSuggestionDismiss,
-      exportCycleFormats,
+      exportCompletion,
     ],
   );
 
@@ -1569,43 +1306,14 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   };
 
   const activeCompletion = getActiveCompletion();
-  const selectedExportFormat = getExportFormatFromInput(
-    buffer.text,
-    exportCycleFormats,
-  );
-  const selectedExportFormatIndex =
-    selectedExportFormat === null
-      ? -1
-      : exportFormatSuggestions.findIndex(
-          (s) => s.value === selectedExportFormat,
-        );
-  // No defensive useEffect is needed to clear exportCompletionSelectionIndexRef
-  // when buffer.text drifts away from a valid export format —
-  // shouldKeepExportFormatSuggestions already gates on
-  // selectedExportFormatIndex !== -1 (derived from getExportFormatFromInput),
-  // so any edit that makes the buffer no longer look like "/export <fmt>"
-  // automatically hides the persistent suggestion panel.  The Phase-2 cycling
-  // guard in handleInput independently blocks arrow/Tab cycling for
-  // non-export input via the same parsedFormat !== null check.
-  const shouldKeepExportFormatSuggestions =
-    !reverseSearchActive &&
-    !commandSearchActive &&
-    exportCompletionSelectionIndexRef.current !== null &&
-    selectedExportFormatIndex !== -1;
-  const displayedSuggestions = shouldKeepExportFormatSuggestions
-    ? exportFormatSuggestions
-    : activeCompletion.suggestions;
-  const displayedActiveSuggestionIndex = shouldKeepExportFormatSuggestions
-    ? selectedExportFormatIndex
-    : activeCompletion.activeSuggestionIndex;
-  const displayedSuggestionsScrollOffset = shouldKeepExportFormatSuggestions
-    ? 0
-    : activeCompletion.visibleStartIndex;
-  const displayedSuggestionsLoading = shouldKeepExportFormatSuggestions
-    ? false
-    : activeCompletion.isLoadingSuggestions;
+  const suggestionDisplayProps = exportCompletion.suggestionDisplayProps ?? {
+    suggestions: activeCompletion.suggestions,
+    activeIndex: activeCompletion.activeSuggestionIndex,
+    isLoading: activeCompletion.isLoadingSuggestions,
+    scrollOffset: activeCompletion.visibleStartIndex,
+  };
   const shouldShowSuggestions =
-    shouldKeepExportFormatSuggestions || activeCompletion.showSuggestions;
+    exportCompletion.shouldShowSuggestions || activeCompletion.showSuggestions;
 
   // Notify parent about suggestions visibility changes
   useEffect(() => {
@@ -1704,11 +1412,11 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       {shouldShowSuggestions && (
         <Box marginLeft={2} marginRight={2}>
           <SuggestionsDisplay
-            suggestions={displayedSuggestions}
-            activeIndex={displayedActiveSuggestionIndex}
-            isLoading={displayedSuggestionsLoading}
+            suggestions={suggestionDisplayProps.suggestions}
+            activeIndex={suggestionDisplayProps.activeIndex}
+            isLoading={suggestionDisplayProps.isLoading}
             width={suggestionsWidth}
-            scrollOffset={displayedSuggestionsScrollOffset}
+            scrollOffset={suggestionDisplayProps.scrollOffset}
             userInput={buffer.text}
             mode={
               buffer.text.startsWith('/') &&

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -921,9 +921,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       // Phase-2 cycling guard: require buffer to still look like an
       // "/export <fmt>" input so arrow/Tab keys can't clobber arbitrary text
       // the user typed after filling a format (e.g. after editing to "/help").
+      // Use the strict format parser rather than `startsWith('/export ')`, so
+      // inputs like "/export html --verbose" (with extra arguments) fall
+      // through to default handling instead of being overwritten.
       if (
         exportCompletionSelectionIndexRef.current !== null &&
-        buffer.text.trim().startsWith(`${EXPORT_COMMAND_INPUT} `) &&
+        getExportFormatFromInput(buffer.text) !== null &&
         !key.ctrl &&
         !key.meta &&
         !key.paste &&
@@ -1043,6 +1046,17 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
 
         if (keyMatchers[Command.ACCEPT_SUGGESTION](key) && !key.paste) {
+          if (hasExportFormatSuggestions) {
+            // Mirror Up/Down export-specific handling so Tab/Enter in the
+            // Phase-1 popup also seed `exportCompletionSelectionIndexRef`,
+            // allowing Phase-2 cycling to continue from the selected format.
+            const activeIndex =
+              completion.activeSuggestionIndex === -1
+                ? 0
+                : completion.activeSuggestionIndex;
+            setExportCompletionInput(activeIndex);
+            return true;
+          }
           acceptActiveCompletionSuggestion();
           return true;
         }

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -76,7 +76,13 @@ type ExportFormatCompletion = (typeof EXPORT_FORMAT_COMPLETIONS)[number];
 const getExportFormatFromInput = (
   input: string,
 ): ExportFormatCompletion | null => {
-  const match = input.trim().match(/^\/export\s+(html|md|json|jsonl)$/);
+  const trimmed = input.trim();
+  // Cheap prefix guard so this runs O(1) for unrelated input instead of
+  // executing the regex every time handleInput / re-renders call it.
+  if (!trimmed.startsWith(EXPORT_COMMAND_INPUT)) {
+    return null;
+  }
+  const match = trimmed.match(/^\/export\s+(html|md|json|jsonl)$/);
   const format = match?.[1];
   return EXPORT_FORMAT_COMPLETIONS.includes(format as ExportFormatCompletion)
     ? (format as ExportFormatCompletion)
@@ -232,24 +238,30 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   } | null>(null);
   midInputGhostTextRef.current = completion.midInputGhostText;
 
+  // Derive the canonical export format list from slashCommands so adding a new
+  // "/export <fmt>" sub-command does not silently break the arrow/Tab cycle.
+  // EXPORT_FORMAT_COMPLETIONS is kept only as a type-safe whitelist for the
+  // format parser (getExportFormatFromInput); runtime display / cycle order
+  // follows whatever the export command declares.
   const exportFormatSuggestions = useMemo<Suggestion[]>(() => {
     const exportCommand = slashCommands.find(
       (command) => command.name === EXPORT_COMMAND_INPUT.slice(1),
     );
-    const subCommandsByName = new Map(
-      exportCommand?.subCommands?.map((command) => [command.name, command]) ??
-        [],
-    );
-
-    return EXPORT_FORMAT_COMPLETIONS.map((format) => {
-      const command = subCommandsByName.get(format);
-      return {
-        label: command?.name ?? format,
-        value: command?.name ?? format,
-        description: command?.description,
-        commandKind: command?.kind,
-      };
-    });
+    const subCommands = exportCommand?.subCommands;
+    if (subCommands && subCommands.length > 0) {
+      return subCommands.map((command) => ({
+        label: command.name,
+        value: command.name,
+        description: command.description,
+        commandKind: command.kind,
+      }));
+    }
+    // Fallback when slashCommands are not wired up yet (e.g. early render):
+    // fall back to the static whitelist so the UI still shows sensible options.
+    return EXPORT_FORMAT_COMPLETIONS.map((format) => ({
+      label: format,
+      value: format,
+    }));
   }, [slashCommands]);
 
   const reverseSearchCompletion = useReverseSearchCompletion(
@@ -284,15 +296,20 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   const resetCommandSearchCompletionState =
     commandSearchCompletion.resetCompletionState;
 
+  // Reset the "has navigated" flag on popup visibility changes only.
+  // Depending on `completion.suggestions` (array reference) instead would race
+  // with async suggestion refreshes and clobber the flag between the user's
+  // arrow-key press and Enter, silently turning autocomplete into submit.
+  const prevShowSuggestionsRef = useRef(completion.showSuggestions);
   useEffect(() => {
     if (!completion.showSuggestions) {
       completionSelectionWasNavigatedRef.current = false;
+    } else if (!prevShowSuggestionsRef.current) {
+      // Popup just transitioned from hidden to shown — start clean.
+      completionSelectionWasNavigatedRef.current = false;
     }
+    prevShowSuggestionsRef.current = completion.showSuggestions;
   }, [completion.showSuggestions]);
-
-  useEffect(() => {
-    completionSelectionWasNavigatedRef.current = false;
-  }, [completion.suggestions]);
 
   const showCursor =
     focus && isShellFocused && !isEmbeddedShellFocused && !agentTabBarFocused;
@@ -835,14 +852,32 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
       const isCompletionUpKey = keyMatchers[Command.COMPLETION_UP](key);
       const isCompletionDownKey = keyMatchers[Command.COMPLETION_DOWN](key);
+      // Tab cycling is only relevant in phase 2 (popup closed after fill).
+      const isCompletionTabKey =
+        key.name === 'tab' &&
+        !key.shift &&
+        !key.ctrl &&
+        !key.meta &&
+        !key.paste;
+
+      // Runtime source of truth for the export cycle order — derived from
+      // slashCommands via exportFormatSuggestions. Decoupling from the static
+      // EXPORT_FORMAT_COMPLETIONS constant ensures new /export sub-commands
+      // extend the cycle automatically.
+      const exportCycleFormats = exportFormatSuggestions.map(
+        (suggestion) => suggestion.value,
+      );
 
       const setExportCompletionInput = (index: number): boolean => {
-        const format = EXPORT_FORMAT_COMPLETIONS[index];
+        const format = exportCycleFormats[index];
         if (!format) {
           return false;
         }
 
-        buffer.setText(`${EXPORT_COMMAND_INPUT} ${format} `);
+        // No trailing space: submitted value stays identical to what a user
+        // would type manually, avoiding implicit coupling with how the slash
+        // parser handles trailing whitespace.
+        buffer.setText(`${EXPORT_COMMAND_INPUT} ${format}`);
         exportCompletionSelectionIndexRef.current = index;
         completionSelectionWasNavigatedRef.current = false;
         setExpandedSuggestionIndex(-1);
@@ -853,30 +888,52 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         currentIndex: number,
         direction: 'up' | 'down',
       ) => {
-        const lastIndex = EXPORT_FORMAT_COMPLETIONS.length - 1;
+        const total = exportCycleFormats.length;
+        if (total === 0) {
+          return currentIndex;
+        }
+        const lastIndex = total - 1;
         if (direction === 'up') {
           return currentIndex <= 0 ? lastIndex : currentIndex - 1;
         }
         return currentIndex >= lastIndex ? 0 : currentIndex + 1;
       };
 
+      // Export-completion cycling is a two-phase state machine:
+      //   Phase 1 (one-shot trigger): buffer is exactly "/export" and the
+      //     popup shows the export format options. The popup-handler block
+      //     below detects `hasExportFormatSuggestions` and fills the first
+      //     format.
+      //   Phase 2 (continuous cycling): buffer is "/export <fmt>" and the
+      //     popup is closed; arrow/Tab keys cycle via
+      //     exportCompletionSelectionIndexRef.
+      // The two phases are mutually exclusive. Do NOT widen
+      // `hasExportFormatSuggestions` to include the filled-in state — it would
+      // short-circuit phase 2 cycling.
       const hasExportFormatSuggestions =
         buffer.text.trim() === EXPORT_COMMAND_INPUT &&
-        completion.suggestions.length === EXPORT_FORMAT_COMPLETIONS.length &&
-        EXPORT_FORMAT_COMPLETIONS.every(
-          (format, index) => completion.suggestions[index]?.value === format,
+        completion.suggestions.length > 0 &&
+        completion.suggestions.length === exportCycleFormats.length &&
+        completion.suggestions.every(
+          (suggestion, index) => suggestion.value === exportCycleFormats[index],
         );
 
+      // Phase-2 cycling guard: require buffer to still look like an
+      // "/export <fmt>" input so arrow/Tab keys can't clobber arbitrary text
+      // the user typed after filling a format (e.g. after editing to "/help").
       if (
         exportCompletionSelectionIndexRef.current !== null &&
+        buffer.text.trim().startsWith(`${EXPORT_COMMAND_INPUT} `) &&
         !key.ctrl &&
         !key.meta &&
         !key.paste &&
-        (isCompletionUpKey || isCompletionDownKey)
+        (isCompletionUpKey || isCompletionDownKey || isCompletionTabKey)
       ) {
+        // Tab cycles forward like Down for a natural "next format" feel.
+        const direction = isCompletionUpKey ? 'up' : 'down';
         const nextIndex = getNextExportCompletionIndex(
           exportCompletionSelectionIndexRef.current,
-          isCompletionUpKey ? 'up' : 'down',
+          direction,
         );
         setExportCompletionInput(nextIndex);
         return true;
@@ -1236,7 +1293,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         followup.dismiss();
         onPromptSuggestionDismiss?.();
       }
-      exportCompletionSelectionIndexRef.current = null;
+      // NOTE: the former unconditional
+      //   `exportCompletionSelectionIndexRef.current = null;`
+      // at this fallthrough was removed — the phase-2 buffer-text guard above
+      // already prevents stale state from affecting non-/export input, and
+      // the blanket reset was wiping selection on cursor-only keys such as
+      // Home / End / Ctrl+A.
       return false;
     },
     [
@@ -1284,6 +1346,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       setBgPillFocused,
       followup,
       onPromptSuggestionDismiss,
+      exportFormatSuggestions,
     ],
   );
 

--- a/packages/cli/src/ui/hooks/useExportCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useExportCompletion.test.ts
@@ -1,0 +1,259 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @vitest-environment jsdom */
+
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { CommandKind, type SlashCommand } from '../commands/types.js';
+import type { TextBuffer } from '../components/shared/text-buffer.js';
+import type { Key } from './useKeypress.js';
+import type { UseCommandCompletionReturn } from './useCommandCompletion.js';
+import {
+  getExportFormatFromInput,
+  getNextExportCompletionIndex,
+  useExportCompletion,
+} from './useExportCompletion.js';
+
+const EXPORT_FORMATS = ['html', 'md', 'json', 'jsonl'] as const;
+
+const exportSlashCommands: readonly SlashCommand[] = [
+  {
+    name: 'export',
+    kind: CommandKind.BUILT_IN,
+    description: 'Export conversation',
+    subCommands: EXPORT_FORMATS.map((name) => ({
+      name,
+      kind: CommandKind.BUILT_IN,
+      description: `Export ${name}`,
+    })),
+  },
+];
+
+function createTextBuffer(initialText: string): TextBuffer {
+  let text = initialText;
+  const buffer = {
+    get text() {
+      return text;
+    },
+    get lines() {
+      return [text];
+    },
+    get cursor() {
+      return [0, text.length] as [number, number];
+    },
+    setText: vi.fn((nextText: string) => {
+      text = nextText;
+    }),
+  };
+
+  return buffer as unknown as TextBuffer;
+}
+
+function createKey(name: string): Key {
+  return {
+    name,
+    ctrl: false,
+    meta: false,
+    shift: false,
+    paste: false,
+    sequence: '',
+  };
+}
+
+function createCompletion(
+  overrides: Partial<UseCommandCompletionReturn> = {},
+): UseCommandCompletionReturn {
+  return {
+    suggestions: EXPORT_FORMATS.map((format) => ({
+      label: format,
+      value: format,
+    })),
+    activeSuggestionIndex: 0,
+    visibleStartIndex: 0,
+    showSuggestions: false,
+    isLoadingSuggestions: false,
+    isPerfectMatch: false,
+    setActiveSuggestionIndex: vi.fn(),
+    setShowSuggestions: vi.fn(),
+    resetCompletionState: vi.fn(),
+    navigateUp: vi.fn(),
+    navigateDown: vi.fn(),
+    handleAutocomplete: vi.fn(),
+    midInputGhostText: null,
+    ...overrides,
+  };
+}
+
+describe('getExportFormatFromInput', () => {
+  it.each([
+    ['', null],
+    ['/export', null],
+    ['/export ', null],
+    ['/export yaml', null],
+    ['/export md extra', null],
+    ['/help md', null],
+    ['/export md', 'md'],
+    ['  /export jsonl  ', 'jsonl'],
+  ])('parses %j as %j', (input, expected) => {
+    expect(getExportFormatFromInput(input, EXPORT_FORMATS)).toBe(expected);
+  });
+
+  it('returns null when there are no valid formats', () => {
+    expect(getExportFormatFromInput('/export md', [])).toBeNull();
+  });
+});
+
+describe('getNextExportCompletionIndex', () => {
+  it('returns the current index for an empty format list', () => {
+    expect(getNextExportCompletionIndex([], 3, 'down')).toBe(3);
+  });
+
+  it('wraps downward at the end of the list', () => {
+    expect(getNextExportCompletionIndex(EXPORT_FORMATS, 3, 'down')).toBe(0);
+  });
+
+  it('wraps upward at the start of the list', () => {
+    expect(getNextExportCompletionIndex(EXPORT_FORMATS, 0, 'up')).toBe(3);
+  });
+
+  it('moves from out-of-range indexes back into the cycle', () => {
+    expect(getNextExportCompletionIndex(EXPORT_FORMATS, -1, 'down')).toBe(0);
+    expect(getNextExportCompletionIndex(EXPORT_FORMATS, 99, 'down')).toBe(0);
+    expect(getNextExportCompletionIndex(EXPORT_FORMATS, -1, 'up')).toBe(3);
+  });
+
+  it('keeps a single-item list on the only index', () => {
+    expect(getNextExportCompletionIndex(['html'], 0, 'down')).toBe(0);
+    expect(getNextExportCompletionIndex(['html'], 0, 'up')).toBe(0);
+  });
+});
+
+describe('useExportCompletion', () => {
+  it('returns null display props outside export cycling', () => {
+    const buffer = createTextBuffer('/export');
+    const { result } = renderHook(() =>
+      useExportCompletion(buffer, exportSlashCommands),
+    );
+
+    expect(result.current.shouldShowSuggestions).toBe(false);
+    expect(result.current.suggestionDisplayProps).toBeNull();
+  });
+
+  it('does not seed cycling state from buffer text alone', () => {
+    const buffer = createTextBuffer('/export md');
+    const completion = createCompletion();
+    const { result } = renderHook(() =>
+      useExportCompletion(buffer, exportSlashCommands),
+    );
+
+    let consumed = true;
+    act(() => {
+      consumed = result.current.handleExportInput(
+        createKey('down'),
+        completion,
+      );
+    });
+
+    expect(consumed).toBe(false);
+    expect(buffer.setText).not.toHaveBeenCalled();
+  });
+
+  it('seeds cycling state after a marked user text edit', () => {
+    const buffer = createTextBuffer('');
+    const completion = createCompletion();
+    const { result, rerender } = renderHook(
+      ({ textBuffer }) => useExportCompletion(textBuffer, exportSlashCommands),
+      { initialProps: { textBuffer: buffer } },
+    );
+
+    act(() => {
+      result.current.markNextTextChangeAsUserInput();
+      buffer.setText('/export md');
+    });
+    rerender({ textBuffer: buffer });
+    vi.mocked(buffer.setText).mockClear();
+
+    let consumed = false;
+    act(() => {
+      consumed = result.current.handleExportInput(
+        createKey('down'),
+        completion,
+      );
+    });
+
+    expect(consumed).toBe(true);
+    expect(buffer.setText).toHaveBeenLastCalledWith('/export json');
+  });
+
+  it('clears refs and cycling state on reset', () => {
+    const buffer = createTextBuffer('/export md');
+    const completion = createCompletion();
+    const { result } = renderHook(() =>
+      useExportCompletion(buffer, exportSlashCommands),
+    );
+
+    act(() => {
+      result.current.navigatedRef.current = true;
+      result.current.navigatedTextRef.current = '/memory';
+      result.current.reset();
+    });
+
+    expect(result.current.navigatedRef.current).toBe(false);
+    expect(result.current.navigatedTextRef.current).toBe('');
+
+    let consumed = true;
+    act(() => {
+      consumed = result.current.handleExportInput(
+        createKey('down'),
+        completion,
+      );
+    });
+
+    expect(consumed).toBe(false);
+    expect(buffer.setText).not.toHaveBeenCalled();
+  });
+
+  it('shows export suggestions after phase-1 cycling updates the buffer', () => {
+    const buffer = createTextBuffer('/export');
+    const completion = createCompletion({
+      showSuggestions: true,
+      isPerfectMatch: true,
+    });
+    const { result, rerender } = renderHook(
+      ({ textBuffer }) => useExportCompletion(textBuffer, exportSlashCommands),
+      { initialProps: { textBuffer: buffer } },
+    );
+
+    act(() => {
+      result.current.handleExportInput(createKey('down'), completion);
+    });
+    rerender({ textBuffer: buffer });
+
+    expect(result.current.shouldShowSuggestions).toBe(true);
+    expect(result.current.suggestionDisplayProps).toMatchObject({
+      activeIndex: 1,
+      isLoading: false,
+      scrollOffset: 0,
+    });
+    expect(
+      result.current.suggestionDisplayProps?.suggestions.map((s) => s.value),
+    ).toEqual(['html', 'md', 'json', 'jsonl']);
+  });
+
+  it('keeps the returned object stable when dependencies do not change', () => {
+    const buffer = createTextBuffer('');
+    const { result, rerender } = renderHook(
+      ({ textBuffer }) => useExportCompletion(textBuffer, exportSlashCommands),
+      { initialProps: { textBuffer: buffer } },
+    );
+    const firstResult = result.current;
+
+    rerender({ textBuffer: buffer });
+
+    expect(result.current).toBe(firstResult);
+  });
+});

--- a/packages/cli/src/ui/hooks/useExportCompletion.ts
+++ b/packages/cli/src/ui/hooks/useExportCompletion.ts
@@ -1,0 +1,309 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import type { TextBuffer } from '../components/shared/text-buffer.js';
+import type { Suggestion } from '../components/SuggestionsDisplay.js';
+import type { SlashCommand } from '../commands/types.js';
+import type { Key } from './useKeypress.js';
+import { keyMatchers, Command } from '../keyMatchers.js';
+import type { UseCommandCompletionReturn } from './useCommandCompletion.js';
+
+const EXPORT_COMMAND_INPUT = '/export';
+
+/**
+ * Parse a single export format from an input buffer.
+ *
+ * The valid-format list is passed in so that adding a new "/export <fmt>"
+ * sub-command to slashCommands automatically enables Phase-2 cycling for it,
+ * without requiring a synchronous hard-coded regex update.
+ *
+ * Uses a simple slice-based approach (no regex) for two reasons:
+ *   1. No escaping concerns when format names contain regex metacharacters.
+ *   2. O(1) cost after the cheap startsWith prefix guard.
+ */
+const getExportFormatFromInput = (
+  input: string,
+  validFormats: readonly string[],
+): string | null => {
+  const trimmed = input.trim();
+  if (!trimmed.startsWith(EXPORT_COMMAND_INPUT + ' ')) {
+    return null;
+  }
+  const rest = trimmed.slice(EXPORT_COMMAND_INPUT.length + 1);
+  if (!rest || rest.includes(' ')) {
+    return null;
+  }
+  return validFormats.includes(rest) ? rest : null;
+};
+
+/**
+ * Compute the next index for export format cycling (round-robin).
+ * Extracted as a module-level pure function to avoid per-keystroke
+ * closure recreation inside handleInput.
+ */
+const getNextExportCompletionIndex = (
+  formatList: readonly string[],
+  currentIndex: number,
+  direction: 'up' | 'down',
+) => {
+  const total = formatList.length;
+  if (total === 0) {
+    return currentIndex;
+  }
+  const lastIndex = total - 1;
+  if (direction === 'up') {
+    return currentIndex <= 0 ? lastIndex : currentIndex - 1;
+  }
+  return currentIndex >= lastIndex ? 0 : currentIndex + 1;
+};
+
+export interface ExportCompletionResult {
+  /** Whether the suggestions panel should be visible (export-specific). */
+  shouldShowSuggestions: boolean;
+  /**
+   * Display props for the SuggestionsDisplay component when export
+   * suggestions are active, or null if the caller should fall back
+   * to the generic completion state.
+   */
+  suggestionDisplayProps: {
+    suggestions: Suggestion[];
+    activeIndex: number;
+    isLoading: boolean;
+    scrollOffset: number;
+  } | null;
+  /**
+   * Handle a keypress for export-specific completion logic.
+   * Returns true if the key was consumed, false if the caller should
+   * fall through to generic completion handling.
+   */
+  handleExportInput: (
+    key: Key,
+    completion: UseCommandCompletionReturn,
+  ) => boolean;
+  /** Reset all export cycling state (call on ESC / Ctrl+C / Ctrl+U / submit). */
+  reset: () => void;
+  /**
+   * Shared "has navigated" flag.  The generic completion path sets this
+   * to true on arrow navigation and the isPerfectMatch + Enter path reads
+   * it.  Owned by this hook so both the export-specific and generic paths
+   * share a single source of truth.
+   */
+  navigatedRef: React.MutableRefObject<boolean>;
+  /**
+   * Buffer text snapshot captured when navigatedRef was last set to true.
+   * Used by the caller to detect stale navigation state when the buffer
+   * has been modified externally (e.g. via setText in tests).
+   */
+  navigatedTextRef: React.MutableRefObject<string>;
+}
+
+export function useExportCompletion(
+  buffer: TextBuffer,
+  slashCommands: readonly SlashCommand[],
+): ExportCompletionResult {
+  const navigatedRef = useRef(false);
+  const navigatedTextRef = useRef('');
+  const cyclingActiveRef = useRef(false);
+
+  // Derive the canonical export format list from slashCommands so adding a
+  // new "/export <fmt>" sub-command automatically enables arrow/Tab cycling.
+  const exportFormatSuggestions = useMemo<Suggestion[]>(() => {
+    const exportCommand = slashCommands.find(
+      (command) => command.name === EXPORT_COMMAND_INPUT.slice(1),
+    );
+    const subCommands = exportCommand?.subCommands;
+    if (subCommands && subCommands.length > 0) {
+      return subCommands.map((command) => ({
+        label: command.name,
+        value: command.name,
+        description: command.description,
+        commandKind: command.kind,
+      }));
+    }
+    return [];
+  }, [slashCommands]);
+
+  // Cache the export format names (keys only) so the cycle logic inside
+  // handleInput does not call .map() on every keystroke.
+  const exportCycleFormats = useMemo(
+    () => exportFormatSuggestions.map((s) => s.value),
+    [exportFormatSuggestions],
+  );
+
+  // Seed cyclingActiveRef when the user manually types "/export <fmt>"
+  // without going through the Phase-1 popup (UX symmetry).
+  useEffect(() => {
+    const fmt = getExportFormatFromInput(buffer.text, exportCycleFormats);
+    if (fmt !== null && !cyclingActiveRef.current) {
+      cyclingActiveRef.current = true;
+    }
+  }, [buffer.text, exportCycleFormats]);
+
+  // Reset navigated flag on every popup visibility transition (true↔false)
+  // and on every buffer text change, to prevent flag stickiness when the
+  // user navigates, then backspaces and retypes the command.
+  useEffect(() => {
+    navigatedRef.current = false;
+    navigatedTextRef.current = '';
+  }, [buffer.text]);
+
+  const reset = useCallback(() => {
+    cyclingActiveRef.current = false;
+    navigatedRef.current = false;
+    navigatedTextRef.current = '';
+  }, []);
+
+  const getExportIndexForActiveSuggestion = useCallback(
+    (completion: UseCommandCompletionReturn): number => {
+      const idx = completion.activeSuggestionIndex;
+      if (idx < 0 || idx >= completion.suggestions.length) {
+        return -1;
+      }
+      return exportCycleFormats.indexOf(completion.suggestions[idx].value);
+    },
+    [exportCycleFormats],
+  );
+
+  const setExportCompletionInput = useCallback(
+    (index: number): boolean => {
+      const format = exportCycleFormats[index];
+      if (!format) return false;
+      buffer.setText(`${EXPORT_COMMAND_INPUT} ${format}`);
+      cyclingActiveRef.current = true;
+      navigatedRef.current = false;
+      return true;
+    },
+    [buffer, exportCycleFormats],
+  );
+
+  const handleExportInput = useCallback(
+    (key: Key, completion: UseCommandCompletionReturn): boolean => {
+      const isCompletionUpKey = keyMatchers[Command.COMPLETION_UP](key);
+      const isCompletionDownKey = keyMatchers[Command.COMPLETION_DOWN](key);
+      const isCompletionTabKey =
+        key.name === 'tab' &&
+        !key.shift &&
+        !key.ctrl &&
+        !key.meta &&
+        !key.paste;
+
+      // ---- Phase 1 detection (popup is showing pure "/export") ----
+      const hasExportFormatSuggestions =
+        buffer.text.trim() === EXPORT_COMMAND_INPUT &&
+        completion.suggestions.length > 0 &&
+        exportCycleFormats.length > 0 &&
+        exportCycleFormats.every((format) =>
+          completion.suggestions.some((s) => s.value === format),
+        );
+
+      // ---- Phase 2 guard ----
+      const parsedFormat = getExportFormatFromInput(
+        buffer.text,
+        exportCycleFormats,
+      );
+
+      // Phase-2 cycling: buffer is "/export <fmt>" and cycling is active.
+      if (
+        cyclingActiveRef.current &&
+        parsedFormat !== null &&
+        !key.ctrl &&
+        !key.meta &&
+        !key.paste &&
+        (isCompletionUpKey || isCompletionDownKey || isCompletionTabKey)
+      ) {
+        const direction = isCompletionUpKey ? 'up' : 'down';
+        const currentIndex = exportCycleFormats.indexOf(parsedFormat);
+        const nextIndex = getNextExportCompletionIndex(
+          exportCycleFormats,
+          currentIndex,
+          direction,
+        );
+        setExportCompletionInput(nextIndex);
+        return true;
+      }
+
+      if (!completion.showSuggestions) {
+        return false;
+      }
+
+      // ---- Phase 1: popup is visible ----
+      if (completion.suggestions.length > 1) {
+        if (isCompletionUpKey || isCompletionDownKey) {
+          if (hasExportFormatSuggestions) {
+            const currentIdx = getExportIndexForActiveSuggestion(completion);
+            if (currentIdx !== -1) {
+              const nextIdx = getNextExportCompletionIndex(
+                exportCycleFormats,
+                currentIdx,
+                isCompletionUpKey ? 'up' : 'down',
+              );
+              setExportCompletionInput(nextIdx);
+              return true;
+            }
+          }
+        }
+      }
+
+      if (keyMatchers[Command.ACCEPT_SUGGESTION](key) && !key.paste) {
+        if (
+          hasExportFormatSuggestions &&
+          !(completion.isPerfectMatch && keyMatchers[Command.RETURN](key))
+        ) {
+          const exportIdx = getExportIndexForActiveSuggestion(completion);
+          if (exportIdx !== -1) {
+            setExportCompletionInput(exportIdx);
+            return true;
+          }
+        }
+      }
+
+      return false;
+    },
+    [
+      buffer,
+      exportCycleFormats,
+      getExportIndexForActiveSuggestion,
+      setExportCompletionInput,
+    ],
+  );
+
+  // ---- Render-time derivations ----
+  const selectedExportFormat = getExportFormatFromInput(
+    buffer.text,
+    exportCycleFormats,
+  );
+  const selectedExportFormatIndex =
+    selectedExportFormat === null
+      ? -1
+      : exportFormatSuggestions.findIndex(
+          (s) => s.value === selectedExportFormat,
+        );
+
+  const shouldShowSuggestions =
+    !cyclingActiveRef.current || selectedExportFormatIndex === -1
+      ? false
+      : true;
+
+  const suggestionDisplayProps: ExportCompletionResult['suggestionDisplayProps'] =
+    shouldShowSuggestions
+      ? {
+          suggestions: exportFormatSuggestions,
+          activeIndex: selectedExportFormatIndex,
+          isLoading: false,
+          scrollOffset: 0,
+        }
+      : null;
+
+  return {
+    shouldShowSuggestions,
+    suggestionDisplayProps,
+    handleExportInput,
+    reset,
+    navigatedRef,
+    navigatedTextRef,
+  };
+}

--- a/packages/cli/src/ui/hooks/useExportCompletion.ts
+++ b/packages/cli/src/ui/hooks/useExportCompletion.ts
@@ -25,7 +25,7 @@ const EXPORT_COMMAND_INPUT = '/export';
  *   1. No escaping concerns when format names contain regex metacharacters.
  *   2. O(1) cost after the cheap startsWith prefix guard.
  */
-const getExportFormatFromInput = (
+export const getExportFormatFromInput = (
   input: string,
   validFormats: readonly string[],
 ): string | null => {
@@ -45,7 +45,7 @@ const getExportFormatFromInput = (
  * Extracted as a module-level pure function to avoid per-keystroke
  * closure recreation inside handleInput.
  */
-const getNextExportCompletionIndex = (
+export const getNextExportCompletionIndex = (
   formatList: readonly string[],
   currentIndex: number,
   direction: 'up' | 'down',
@@ -87,6 +87,11 @@ export interface ExportCompletionResult {
   /** Reset all export cycling state (call on ESC / Ctrl+C / Ctrl+U / submit). */
   reset: () => void;
   /**
+   * Allow the next buffer text change to seed export cycling if it becomes
+   * exactly "/export <fmt>". Call this only for direct user text edits.
+   */
+  markNextTextChangeAsUserInput: () => void;
+  /**
    * Shared "has navigated" flag.  The generic completion path sets this
    * to true on arrow navigation and the isPerfectMatch + Enter path reads
    * it.  Owned by this hook so both the export-specific and generic paths
@@ -108,6 +113,7 @@ export function useExportCompletion(
   const navigatedRef = useRef(false);
   const navigatedTextRef = useRef('');
   const cyclingActiveRef = useRef(false);
+  const nextTextChangeWasUserInputRef = useRef(false);
 
   // Derive the canonical export format list from slashCommands so adding a
   // new "/export <fmt>" sub-command automatically enables arrow/Tab cycling.
@@ -134,13 +140,24 @@ export function useExportCompletion(
     [exportFormatSuggestions],
   );
 
-  // Seed cyclingActiveRef when the user manually types "/export <fmt>"
-  // without going through the Phase-1 popup (UX symmetry).
+  const markNextTextChangeAsUserInput = useCallback(() => {
+    nextTextChangeWasUserInputRef.current = true;
+  }, []);
+
+  // Seed cyclingActiveRef only for text changes that InputPrompt marked as
+  // direct user edits. History navigation and programmatic setText() calls can
+  // also produce "/export <fmt>", but they must not steal the next Up/Down key
+  // from the normal history/navigation handlers.
   useEffect(() => {
     const fmt = getExportFormatFromInput(buffer.text, exportCycleFormats);
-    if (fmt !== null && !cyclingActiveRef.current) {
+    if (
+      nextTextChangeWasUserInputRef.current &&
+      fmt !== null &&
+      !cyclingActiveRef.current
+    ) {
       cyclingActiveRef.current = true;
     }
+    nextTextChangeWasUserInputRef.current = false;
   }, [buffer.text, exportCycleFormats]);
 
   // Reset navigated flag on every popup visibility transition (true↔false)
@@ -153,6 +170,7 @@ export function useExportCompletion(
 
   const reset = useCallback(() => {
     cyclingActiveRef.current = false;
+    nextTextChangeWasUserInputRef.current = false;
     navigatedRef.current = false;
     navigatedTextRef.current = '';
   }, []);
@@ -288,22 +306,37 @@ export function useExportCompletion(
       ? false
       : true;
 
-  const suggestionDisplayProps: ExportCompletionResult['suggestionDisplayProps'] =
-    shouldShowSuggestions
-      ? {
-          suggestions: exportFormatSuggestions,
-          activeIndex: selectedExportFormatIndex,
-          isLoading: false,
-          scrollOffset: 0,
-        }
-      : null;
+  const suggestionDisplayProps = useMemo<
+    ExportCompletionResult['suggestionDisplayProps']
+  >(
+    () =>
+      shouldShowSuggestions
+        ? {
+            suggestions: exportFormatSuggestions,
+            activeIndex: selectedExportFormatIndex,
+            isLoading: false,
+            scrollOffset: 0,
+          }
+        : null,
+    [exportFormatSuggestions, selectedExportFormatIndex, shouldShowSuggestions],
+  );
 
-  return {
-    shouldShowSuggestions,
-    suggestionDisplayProps,
-    handleExportInput,
-    reset,
-    navigatedRef,
-    navigatedTextRef,
-  };
+  return useMemo(
+    () => ({
+      shouldShowSuggestions,
+      suggestionDisplayProps,
+      handleExportInput,
+      reset,
+      markNextTextChangeAsUserInput,
+      navigatedRef,
+      navigatedTextRef,
+    }),
+    [
+      shouldShowSuggestions,
+      suggestionDisplayProps,
+      handleExportInput,
+      reset,
+      markNextTextChangeAsUserInput,
+    ],
+  );
 }


### PR DESCRIPTION
<!--
Help reviewers verify this PR quickly.

Maintainers prioritize PRs that include clear proof of work.
If a PR does not include enough validation detail to reproduce and verify the change efficiently, review may be delayed.
-->

## Summary

- What changed: Improved the interactive `/export` command completion flow so arrow-key navigation can insert and cycle through export formats (`html`, `md`, `json`, `jsonl`) directly in the input. The `isPerfectMatch + navigated + Enter` autocomplete path now applies to all slash commands with sub-commands (e.g., `/memory`, `/agents`), not just `/export`.
- Why it changed: Selecting an export format from the completion UI should be faster and more discoverable for keyboard-driven CLI users.
- Reviewer focus: Please verify the `/export` completion behavior, especially that pressing Enter on plain `/export` still preserves the existing default behavior when the user has not navigated suggestions. Also verify that `/memory` + Down + Enter autocompletes the selected sub-command.

## Validation

- Commands run:
  ```bash
  git diff --check
  cd packages/cli
  npx vitest run src/ui/components/InputPrompt.test.tsx
  cd ../..
  npm run dev
  ```
- Prompts / inputs used:
  - Type `/export`
  - Press Down once
  - Press Down again
  - Press Enter
  - Type `/export`
  - Press Enter without navigating suggestions
- Expected result:
  - `/export` shows `html`, `md`, `json`, and `jsonl` suggestions.
  - Down-arrow fills `/export md`, then `/export json` on the next Down press (no trailing space).
  - Suggestions remain visible while cycling through export formats.
  - Enter submits the selected export command.
  - Enter on plain `/export` without suggestion navigation keeps the existing default behavior.
- Observed result:
  - Windows manual validation with `npm run dev` matched the expected interactive behavior.
  - `InputPrompt.test.tsx` passed: `122 passed, 2 skipped`.
  - `git diff --check` completed with no whitespace errors.
  - The pre-commit hook also completed Prettier and ESLint checks for the staged files.
- Quickest reviewer verification path:
  1. Run `npm run dev`.
  2. Type `/export`.
  3. Press Down to verify the input becomes `/export md`.
  4. Press Down again to verify it cycles to `/export json`.
  5. Press Enter to verify the selected export command is submitted.
  6. Run `cd packages/cli && npx vitest run src/ui/components/InputPrompt.test.tsx`.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  - Before: https://github.com/user-attachments/assets/cf8b7388-cc5b-408c-a004-28c3a2060045
  - After: https://github.com/user-attachments/assets/f24977c7-eefe-438f-9bb8-545f841301c6

## Scope / Risk

- Main risk or tradeoff: This adds `/export`-specific completion handling inside `InputPrompt`, so the main risk is accidentally affecting generic slash-command completion or history navigation.
- The `isPerfectMatch + navigated + Enter` autocomplete path now fires for any slash command with sub-commands, not just `/export`. This is intentional: when the user has navigated suggestions via arrow keys, pressing Enter should autocomplete the selected suggestion rather than submit the raw input. A non-`/export` regression test covers this path.
- Not covered / not validated: Manual CLI validation was only performed on Windows; macOS and Linux manual validation were not performed.
- Breaking changes / migration notes: None. This does not change export formats or export file generation logic.

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | N/A   | Pass    | N/A   |
| npx      | N/A   | Pass    | N/A   |
| Docker   | N/A   | N/A     | N/A   |
| Podman   | N/A   | N/A     | N/A   |
| Seatbelt | N/A   | N/A     | N/A   |

Testing matrix notes:

- Windows `npm run` path was tested manually with `npm run dev`.
- Windows `npx` path was tested with `cd packages/cli && npx vitest run src/ui/components/InputPrompt.test.tsx`.
- Docker, Podman, and Seatbelt are not relevant to this focused interactive CLI completion change.
- macOS and Linux manual validation were not performed.

## Linked Issues / Bugs

Closes #3700
