### PR TITLE
fix(ci): use squash auto-merge for sdk release pr

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -405,7 +405,7 @@ jobs:
           PR_URL: '${{ steps.pr.outputs.PR_URL }}'
         run: |-
           set -euo pipefail
-          gh pr merge "${PR_URL}" --merge --auto --delete-branch
+          gh pr merge "${PR_URL}" --squash --auto --delete-branch
 
       - name: 'Create Issue on Failure'
         if: |-


### PR DESCRIPTION
## Summary

- What changed:
  - Update the SDK release workflow to enable PR auto-merge with `--squash` instead of `--merge`.
- Why it changed:
  - The repository currently disallows merge commits, so `gh pr merge --merge --auto` fails even when the release build, publish, and PR creation steps succeed.
- Reviewer focus:
  - Confirm the release workflow now uses a merge method that matches the repository merge policy.

## Validation

- Commands run:
  ```bash
  npm run build
  npm run typecheck
  gh repo view QwenLM/qwen-code --json mergeCommitAllowed,rebaseMergeAllowed,squashMergeAllowed,viewerDefaultMergeMethod
  gh run view 25036315088 --repo QwenLM/qwen-code --log-failed
  ```
- Prompts / inputs used:
  - Investigated failed GitHub Actions run `25036315088` and release PR `#3688`.
- Expected result:
  - The SDK release workflow should be able to enable auto-merge for the release PR without failing on repository merge policy checks.
- Observed result:
  - The failed run used `gh pr merge "${PR_URL}" --merge --auto --delete-branch` and GitHub rejected it because merge commits are not allowed on this repository.
  - The repository currently allows squash merge only.
- Quickest reviewer verification path:
  - Inspect the `Enable auto-merge for release PR` step in `.github/workflows/release-sdk.yml` and confirm it now uses `--squash --auto`.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  - `gh run view 25036315088 --repo QwenLM/qwen-code --log-failed` returned: `GraphQL: Merge method merge commits are not allowed on this repository`.
  - `gh repo view QwenLM/qwen-code --json ...` returned `mergeCommitAllowed: false`, `rebaseMergeAllowed: false`, `squashMergeAllowed: true`, `viewerDefaultMergeMethod: SQUASH`.

## Scope / Risk

- Main risk or tradeoff:
  - This changes the merge method for automated SDK release PRs from merge commit to squash.
- Not covered / not validated:
  - I did not rerun the full release workflow end-to-end because it publishes packages and creates releases.
- Breaking changes / migration notes:
  - None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ⚠️  | ✅  |
| npx      | N/A | N/A | N/A |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- `npm run build` and `npm run typecheck` were run locally in this environment.
- The release workflow behavior was validated by inspecting the failed GitHub Actions run rather than re-running a publish workflow.

## Linked Issues / Bugs

Fixes #3689
