### PR TITLE
fix(ci): preserve preview version overrides

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The version to release (e.g., v0.1.11). Required for manual patch releases.'
+        description: 'The version to release (e.g., v0.1.11 or v0.1.11-preview.0). Required for manual patch releases.'
         required: false
         type: 'string'
       ref:
@@ -31,7 +31,7 @@ on:
         type: 'boolean'
         default: false
       create_preview_release:
-        description: 'Auto apply the preview release tag, input version is ignored.'
+        description: 'Create a preview release. If version is X.Y.Z-preview.N, use it as-is. If version is X.Y.Z, derive X.Y.Z-preview.0.'
         required: false
         type: 'boolean'
         default: false
@@ -114,6 +114,17 @@ jobs:
             VERSION_ARGS+=(--type=nightly)
           elif [[ "${IS_PREVIEW}" == "true" ]]; then
             VERSION_ARGS+=(--type=preview)
+            if [[ -n "${MANUAL_VERSION}" ]]; then
+              MANUAL_CLEAN="${MANUAL_VERSION#v}"
+              if [[ "${MANUAL_CLEAN}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview\.[0-9]+$ ]]; then
+                VERSION_ARGS+=("--preview_version_override=${MANUAL_CLEAN}")
+              elif [[ "${MANUAL_CLEAN}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                VERSION_ARGS+=("--preview_version_override=${MANUAL_CLEAN}-preview.0")
+              else
+                echo "::error::For preview releases, version must be X.Y.Z or X.Y.Z-preview.N; got ${MANUAL_VERSION}"
+                exit 1
+              fi
+            fi
           else
             VERSION_ARGS+=(--type=stable)
             if [[ -n "${MANUAL_VERSION}" ]]; then

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -114,9 +114,6 @@ jobs:
             VERSION_ARGS+=(--type=nightly)
           elif [[ "${IS_PREVIEW}" == "true" ]]; then
             VERSION_ARGS+=(--type=preview)
-            if [[ -n "${MANUAL_VERSION}" ]]; then
-              VERSION_ARGS+=("--preview_version_override=${MANUAL_VERSION}")
-            fi
           else
             VERSION_ARGS+=(--type=stable)
             if [[ -n "${MANUAL_VERSION}" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,9 +114,6 @@ jobs:
             VERSION_ARGS+=(--type=nightly)
           elif [[ "${IS_PREVIEW}" == "true" ]]; then
             VERSION_ARGS+=(--type=preview)
-            if [[ -n "${MANUAL_VERSION}" ]]; then
-              VERSION_ARGS+=("--preview_version_override=${MANUAL_VERSION}")
-            fi
           else
             VERSION_ARGS+=(--type=stable)
             if [[ -n "${MANUAL_VERSION}" ]]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'The version to release (e.g., v0.1.11). Required for manual patch releases.'
+        description: 'The version to release (e.g., v0.1.11 or v0.1.11-preview.0). Required for manual patch releases.'
         required: false
         type: 'string'
       ref:
@@ -28,7 +28,7 @@ on:
         type: 'boolean'
         default: false
       create_preview_release:
-        description: 'Auto apply the preview release tag, input version is ignored.'
+        description: 'Create a preview release. If version is X.Y.Z-preview.N, use it as-is. If version is X.Y.Z, derive X.Y.Z-preview.0.'
         required: false
         type: 'boolean'
         default: false
@@ -114,6 +114,17 @@ jobs:
             VERSION_ARGS+=(--type=nightly)
           elif [[ "${IS_PREVIEW}" == "true" ]]; then
             VERSION_ARGS+=(--type=preview)
+            if [[ -n "${MANUAL_VERSION}" ]]; then
+              MANUAL_CLEAN="${MANUAL_VERSION#v}"
+              if [[ "${MANUAL_CLEAN}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview\.[0-9]+$ ]]; then
+                VERSION_ARGS+=("--preview_version_override=${MANUAL_CLEAN}")
+              elif [[ "${MANUAL_CLEAN}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                VERSION_ARGS+=("--preview_version_override=${MANUAL_CLEAN}-preview.0")
+              else
+                echo "::error::For preview releases, version must be X.Y.Z or X.Y.Z-preview.N; got ${MANUAL_VERSION}"
+                exit 1
+              fi
+            fi
           else
             VERSION_ARGS+=(--type=stable)
             if [[ -n "${MANUAL_VERSION}" ]]; then


### PR DESCRIPTION
## Summary

- What changed:
  - Preserve manual preview version overrides in the CLI and SDK release workflows.
  - Accept either `X.Y.Z-preview.N` directly or auto-derive `X.Y.Z-preview.0` from a stable-style `X.Y.Z` / `vX.Y.Z` input.
  - Fail early with a clearer workflow error for any other preview version format.
- Why it changed:
  - Issue `#3686` happened because a preview release was triggered with `v0.1.7`, which the downstream script correctly rejected as not being in preview format.
  - The previous PR version removed the manual override path entirely, but reviewers want to keep it for controlled re-runs and pinned preview suffixes.
- Reviewer focus:
  - Confirm preview releases still support explicit preview overrides and now handle stable-style manual input predictably.

## Validation

- Commands run:
  ```bash
  gh run view 25032972161 --repo QwenLM/qwen-code --log-failed
  bash -lc 'MANUAL_VERSION=v0.1.7; MANUAL_CLEAN="${MANUAL_VERSION#v}"; if [[ "${MANUAL_CLEAN}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview\.[0-9]+$ ]]; then echo preview:$MANUAL_CLEAN; elif [[ "${MANUAL_CLEAN}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then echo stable:${MANUAL_CLEAN}-preview.0; else echo invalid; fi'
  bash -lc 'MANUAL_VERSION=v0.1.7-preview.3; MANUAL_CLEAN="${MANUAL_VERSION#v}"; if [[ "${MANUAL_CLEAN}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview\.[0-9]+$ ]]; then echo preview:$MANUAL_CLEAN; elif [[ "${MANUAL_CLEAN}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then echo stable:${MANUAL_CLEAN}-preview.0; else echo invalid; fi'
  bash -lc 'MANUAL_VERSION=v0.1.7-beta.1; MANUAL_CLEAN="${MANUAL_VERSION#v}"; if [[ "${MANUAL_CLEAN}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-preview\.[0-9]+$ ]]; then echo preview:$MANUAL_CLEAN; elif [[ "${MANUAL_CLEAN}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then echo stable:${MANUAL_CLEAN}-preview.0; else echo invalid; fi'
  node packages/sdk-typescript/scripts/get-release-version.js --type=preview --preview_version_override=0.1.7-preview.0
  npm run typecheck
  ```
- Prompts / inputs used:
  - Investigated failed SDK preview release run `25032972161` tied to issue `#3686`.
- Expected result:
  - Preview releases should continue to honor manual preview overrides, while also handling stable-style manual inputs like `v0.1.7` without crashing deep in the version script.
- Observed result:
  - The failed run passed `--preview_version_override=v0.1.7` and crashed with `Invalid preview_version_override: 0.1.7. Must be in X.Y.Z-preview.N format.`
  - After this change, `v0.1.7` maps to `0.1.7-preview.0`, valid preview overrides are preserved, and invalid formats fail immediately with a clearer message.
- Quickest reviewer verification path:
  - Inspect the `Get the version` step in `.github/workflows/release.yml` and `.github/workflows/release-sdk.yml`.
  - Confirm preview mode now:
    - passes through `X.Y.Z-preview.N`
    - converts `X.Y.Z` to `X.Y.Z-preview.0`
    - errors out clearly for any other format
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  - `gh run view 25032972161 --repo QwenLM/qwen-code --log-failed` shows the original failure on `v0.1.7`.
  - Local shell validation shows:
    - `v0.1.7` → `0.1.7-preview.0`
    - `v0.1.7-preview.3` remains `0.1.7-preview.3`
    - `v0.1.7-beta.1` is rejected
  - `node packages/sdk-typescript/scripts/get-release-version.js --type=preview --preview_version_override=0.1.7-preview.0` succeeds and increments when the target version already exists.

## Scope / Risk

- Main risk or tradeoff:
  - The release workflows now encode preview-version input normalization logic in shell instead of relying solely on the downstream script.
- Not covered / not validated:
  - I did not run the full publish workflows end-to-end.
- Breaking changes / migration notes:
  - None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ⚠️  | ✅  |
| npx      | N/A | N/A | N/A |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- `npm run typecheck` was run locally in this environment.
- Workflow behavior was validated with the failed run log, the new shell normalization branch logic, and the underlying SDK version script.

## Linked Issues / Bugs

Fixes #3686
