### PR TITLE
feat(cli): set OS process title to encode session identity

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -46,6 +46,7 @@ import { VimModeProvider } from './ui/contexts/VimModeContext.js';
 import { AgentViewProvider } from './ui/contexts/AgentViewContext.js';
 import { BackgroundTaskViewProvider } from './ui/contexts/BackgroundTaskViewContext.js';
 import { useKittyKeyboardProtocol } from './ui/hooks/useKittyKeyboardProtocol.js';
+import { setSessionProcessTitle } from './utils/processTitle.js';
 import { themeManager, AUTO_THEME_NAME } from './ui/themes/theme-manager.js';
 import {
   detectAndEnableKittyProtocol,
@@ -173,6 +174,7 @@ export async function startInteractiveUI(
 ) {
   const version = await getCliVersion();
   setWindowTitle(basename(workspaceRoot), settings);
+  setSessionProcessTitle(config.getSessionId(), config.getTargetDir());
   const restoreTerminalRedrawOptimizer =
     process.stdout.isTTY && !config.getScreenReader()
       ? installTerminalRedrawOptimizer(process.stdout)

--- a/packages/cli/src/utils/processTitle.test.ts
+++ b/packages/cli/src/utils/processTitle.test.ts
@@ -1,0 +1,183 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  composeSessionProcessTitle,
+  setSessionProcessTitle,
+  shortSessionId,
+  shouldSetProcessTitle,
+} from './processTitle.js';
+
+describe('shortSessionId', () => {
+  it('strips dashes and truncates to 8 chars', () => {
+    expect(shortSessionId('12345678-aaaa-bbbb-cccc-dddddddddddd')).toBe(
+      '12345678',
+    );
+  });
+
+  it('passes through short ids unchanged', () => {
+    expect(shortSessionId('abc')).toBe('abc');
+  });
+
+  it('falls back to the original id when stripping leaves nothing', () => {
+    expect(shortSessionId('---')).toBe('---');
+  });
+});
+
+describe('composeSessionProcessTitle', () => {
+  it('renders base + session + cwd in the documented format', () => {
+    const title = composeSessionProcessTitle(
+      '12345678-aaaa-bbbb-cccc-dddddddddddd',
+      '/home/user/projects/my-project',
+    );
+    expect(title).toBe('qwen-code session=12345678 cwd=my-project');
+  });
+
+  it('omits cwd when no work_dir is provided', () => {
+    const title = composeSessionProcessTitle(
+      '12345678-aaaa-bbbb-cccc-dddddddddddd',
+    );
+    expect(title).toBe('qwen-code session=12345678');
+  });
+
+  it('honors a custom base name', () => {
+    const title = composeSessionProcessTitle('deadbeefcafebabe', undefined, {
+      baseName: 'qwen-code-bg',
+    });
+    expect(title).toBe('qwen-code-bg session=deadbeef');
+  });
+
+  it('normalizes a trailing path separator', () => {
+    const title = composeSessionProcessTitle(
+      'abcdef0123456789',
+      '/home/user/projects/my-project/',
+    );
+    expect(title).toContain('cwd=my-project');
+  });
+
+  it('replaces spaces in the cwd basename with underscores', () => {
+    const title = composeSessionProcessTitle(
+      '12345678-aaaa-bbbb-cccc-dddddddddddd',
+      '/home/John Doe/my project',
+    );
+    expect(title).toBe('qwen-code session=12345678 cwd=my_project');
+  });
+
+  it('replaces "=" in the cwd basename with underscores', () => {
+    const title = composeSessionProcessTitle(
+      '12345678-aaaa-bbbb-cccc-dddddddddddd',
+      '/srv/key=value',
+    );
+    expect(title).toBe('qwen-code session=12345678 cwd=key_value');
+  });
+
+  it('preserves non-ASCII path components', () => {
+    const title = composeSessionProcessTitle(
+      '12345678-aaaa-bbbb-cccc-dddddddddddd',
+      // Forward-slash form so the assertion holds on both Win and POSIX.
+      '/项目/我的-app',
+    );
+    expect(title).toBe('qwen-code session=12345678 cwd=我的-app');
+  });
+
+  it('split-on-whitespace yields exactly 3 tokens even with spaces in cwd', () => {
+    const title = composeSessionProcessTitle(
+      '12345678-aaaa-bbbb-cccc-dddddddddddd',
+      '/x/a b c d',
+    );
+    expect(title.split(/\s+/)).toEqual([
+      'qwen-code',
+      'session=12345678',
+      'cwd=a_b_c_d',
+    ]);
+  });
+
+  it('sanitizes whitespace and "=" inside the session id token', () => {
+    const title = composeSessionProcessTitle('my id=1', '/tmp/proj');
+    expect(title.split(/\s+/)).toEqual([
+      'qwen-code',
+      'session=my_id_1',
+      'cwd=proj',
+    ]);
+  });
+
+  it('omits the cwd token when work_dir is empty string', () => {
+    const title = composeSessionProcessTitle(
+      '12345678-aaaa-bbbb-cccc-dddddddddddd',
+      '',
+    );
+    expect(title).toBe('qwen-code session=12345678');
+  });
+});
+
+describe('shouldSetProcessTitle', () => {
+  it('skips Windows', () => {
+    expect(shouldSetProcessTitle('win32')).toBe(false);
+  });
+
+  it.each(['linux', 'darwin', 'freebsd', 'openbsd'] as NodeJS.Platform[])(
+    'sets on %s',
+    (platform) => {
+      expect(shouldSetProcessTitle(platform)).toBe(true);
+    },
+  );
+});
+
+describe('setSessionProcessTitle', () => {
+  it('dispatches the composed title to the apply sink on POSIX-like platforms', () => {
+    const captured: string[] = [];
+    const result = setSessionProcessTitle(
+      '12345678-aaaa-bbbb-cccc-dddddddddddd',
+      '/tmp/proj',
+      {
+        platform: 'linux',
+        apply: (t) => captured.push(t),
+      },
+    );
+    expect(result).toBe('qwen-code session=12345678 cwd=proj');
+    expect(captured).toEqual(['qwen-code session=12345678 cwd=proj']);
+  });
+
+  it('no-ops and returns null on Windows', () => {
+    const captured: string[] = [];
+    const result = setSessionProcessTitle(
+      '12345678-aaaa-bbbb-cccc-dddddddddddd',
+      '/tmp/proj',
+      {
+        platform: 'win32',
+        apply: (t) => captured.push(t),
+      },
+    );
+    expect(result).toBeNull();
+    expect(captured).toEqual([]);
+  });
+
+  it('swallows errors raised by the apply sink', () => {
+    expect(() =>
+      setSessionProcessTitle(
+        '12345678-aaaa-bbbb-cccc-dddddddddddd',
+        '/tmp/proj',
+        {
+          platform: 'linux',
+          apply: () => {
+            throw new Error('seccomp says no');
+          },
+        },
+      ),
+    ).not.toThrow();
+  });
+
+  it('honors custom baseName via options', () => {
+    const captured: string[] = [];
+    setSessionProcessTitle('abcdef00', '/x/proj', {
+      platform: 'linux',
+      baseName: 'qwen-code-acp',
+      apply: (t) => captured.push(t),
+    });
+    expect(captured).toEqual(['qwen-code-acp session=abcdef00 cwd=proj']);
+  });
+});

--- a/packages/cli/src/utils/processTitle.ts
+++ b/packages/cli/src/utils/processTitle.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { basename, normalize } from 'node:path';
+
+/**
+ * Maximum length of the short session id rendered in the process title.
+ * Eight hex chars is plenty for visual disambiguation while keeping
+ * process titles compact (Windows Task Manager and macOS `ps` both
+ * truncate aggressively).
+ */
+const SHORT_SESSION_ID_LEN = 8;
+
+/**
+ * Default base name embedded in the process title.
+ */
+export const DEFAULT_PROCESS_TITLE_BASE = 'qwen-code';
+
+/**
+ * Return a short, display-friendly version of a session id.
+ *
+ * Strips dashes (uuid-style) and truncates to {@link SHORT_SESSION_ID_LEN}
+ * characters so the resulting tag fits comfortably in process titles.
+ *
+ * Falls back to the original id if stripping dashes leaves nothing
+ * (e.g. a synthetic id of all dashes), so a non-empty input always
+ * produces a non-empty output.
+ */
+export function shortSessionId(sessionId: string): string {
+  const compact = sessionId.replace(/-/g, '');
+  return compact.slice(0, SHORT_SESSION_ID_LEN) || sessionId;
+}
+
+/**
+ * Make `value` safe to embed in a `key=value` process-title token.
+ *
+ * Whitespace and `=` would break naive split-on-whitespace parsing by
+ * external observers, so both are replaced with `_`. All other Unicode,
+ * including non-ASCII path components, is preserved verbatim.
+ */
+function sanitizeProctitleToken(value: string): string {
+  let out = '';
+  for (const ch of value) {
+    if (ch === '=' || /\s/u.test(ch)) {
+      out += '_';
+    } else {
+      out += ch;
+    }
+  }
+  return out;
+}
+
+export interface ComposeSessionProcessTitleOptions {
+  /** Base name embedded in the title. Defaults to `qwen-code`. */
+  baseName?: string;
+}
+
+/**
+ * Compose an OS process title that encodes the live session identity.
+ *
+ * Format: `"<base> session=<short-id>[ cwd=<basename>]"`.
+ *
+ * External tools (terminal multiplexers, tab managers, IDE integrations)
+ * can read this from `ps` / Task Manager and reliably map a running
+ * process to its session — even when the session was created without an
+ * explicit `--resume` flag, which is the common case.
+ *
+ * The `key=value` token form is intentional: it parses with simple
+ * splits and avoids ambiguity if user-facing branding changes. To keep
+ * that contract intact, whitespace and `=` inside the cwd basename and
+ * session id are replaced with `_` via {@link sanitizeProctitleToken};
+ * otherwise a repository under, say, `.../John Doe/` would yield
+ * `cwd=John Doe` and break naive token parsing.
+ */
+export function composeSessionProcessTitle(
+  sessionId: string,
+  workDir?: string | null,
+  options: ComposeSessionProcessTitleOptions = {},
+): string {
+  const { baseName = DEFAULT_PROCESS_TITLE_BASE } = options;
+  const parts: string[] = [
+    baseName,
+    `session=${sanitizeProctitleToken(shortSessionId(sessionId))}`,
+  ];
+  if (workDir != null && workDir !== '') {
+    const cwdBasename = basename(normalize(String(workDir)));
+    if (cwdBasename) {
+      parts.push(`cwd=${sanitizeProctitleToken(cwdBasename)}`);
+    }
+  }
+  return parts.join(' ');
+}
+
+/**
+ * Predicate: is this platform one where setting `process.title` is
+ * actually visible in the process table (and only there)?
+ *
+ * On Linux/macOS Node rewrites the argv buffer, so `process.title` is
+ * visible to `ps`/`top` and is the right knob.
+ *
+ * On Windows, Node sets the **console window title** (the same surface
+ * as the OSC `\x1b]2;…\x07` escape), which conflicts with qwen-code's
+ * existing OSC writers in `gemini.tsx` and `AppContainer.tsx`. We
+ * therefore skip Windows here; runtime identity for Windows users would
+ * need a different mechanism (e.g. ETW, named pipe) which is out of
+ * scope.
+ */
+export function shouldSetProcessTitle(
+  platform: NodeJS.Platform = process.platform,
+): boolean {
+  return platform !== 'win32';
+}
+
+export interface SetSessionProcessTitleOptions
+  extends ComposeSessionProcessTitleOptions {
+  /**
+   * Override the platform check. Useful in tests; production callers
+   * should let it default to `process.platform`.
+   */
+  platform?: NodeJS.Platform;
+  /**
+   * Sink that actually applies the title. Defaults to assigning
+   * `process.title`. Tests inject a captured-string sink instead of
+   * mutating the live process.
+   */
+  apply?: (title: string) => void;
+}
+
+/**
+ * Set the OS process title to encode the live session identity.
+ *
+ * No-op on Windows (see {@link shouldSetProcessTitle}). Errors from the
+ * underlying assignment are swallowed: the title is a best-effort
+ * observability hint, not a correctness contract, so a hostile
+ * environment (e.g. seccomp-restricted container) must never crash
+ * qwen-code over it.
+ *
+ * Returns the title string that was applied, or `null` if this platform
+ * does not set a process title.
+ */
+export function setSessionProcessTitle(
+  sessionId: string,
+  workDir?: string | null,
+  options: SetSessionProcessTitleOptions = {},
+): string | null {
+  const { platform, apply, ...composeOptions } = options;
+  if (!shouldSetProcessTitle(platform)) {
+    return null;
+  }
+  const title = composeSessionProcessTitle(sessionId, workDir, composeOptions);
+  try {
+    if (apply) {
+      apply(title);
+    } else {
+      process.title = title;
+    }
+  } catch {
+    // Best-effort only. Some sandboxes refuse to mutate argv or the
+    // console title; that is fine, we just lose the observability hint.
+  }
+  return title;
+}


### PR DESCRIPTION
## What

Set the OS process title on POSIX-like platforms when starting the interactive UI, in the form:

```
qwen-code session=<short-id> cwd=<basename>
```

session= carries the first 8 chars of the live session id; cwd= carries the basename of the working directory. Whitespace and `=` inside either token are replaced with `_` so the title remains parseable with naive whitespace splits.

## Why

External tools — terminal multiplexers, tab managers, IDE integrations, operators triaging a shared box — need to map a running PID back to its qwen-code session. Today they cannot: `ps -ef` shows generic `node …`. Setting `process.title` makes the mapping trivial without requiring users to launch with `--resume`.

This mirrors the proctitle helpers in [kimi-cli PR #2082](https://github.com/MoonshotAI/kimi-cli/pull/2082).

## Scope

**In scope (this PR):**
- New helper `packages/cli/src/utils/processTitle.ts`
- One call site in `startInteractiveUI()` next to the existing `setWindowTitle()`
- Vitest coverage (22 cases)

**Out of scope (intentionally):**
- `runtime.json` sidecar from kimi #2082 (part 1)
- Dynamic OSC tab title updates from kimi #2083

## Windows behavior

No-op. Node maps `process.title` to the **console window title** on Windows, which would race with the existing OSC `\x1b]2;…\x07` writers in `gemini.tsx` and `AppContainer.tsx`. A future Windows-specific runtime-identity mechanism (named pipe, ETW) can be added without touching this code path.

## Tests

```
npx vitest run src/utils/processTitle.test.ts
# 22 passed (22)
```

Covers: short session id derivation, format composition with/without cwd, custom base name, trailing-separator normalization, whitespace + `=` sanitization, Unicode preservation in cwd, dispatch to apply sink on POSIX, no-op on Windows, error swallowing.

## Manual verification

On Linux/macOS, after `qwen` starts:
```
$ ps -o pid,comm,args -C node | grep qwen-code
12345 node    qwen-code session=a1b2c3d4 cwd=my-project
```