### PR TITLE
feat(cli): wire background shells into combined Background tasks dialog

### DIFF
--- a/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.test.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.test.tsx
@@ -16,11 +16,19 @@ import {
   useBackgroundTaskViewState,
 } from '../../contexts/BackgroundTaskViewContext.js';
 import { ConfigContext } from '../../contexts/ConfigContext.js';
-import { useBackgroundTaskView } from '../../hooks/useBackgroundTaskView.js';
+import {
+  useBackgroundTaskView,
+  type DialogEntry,
+} from '../../hooks/useBackgroundTaskView.js';
 import { useKeypress } from '../../hooks/useKeypress.js';
 
 vi.mock('../../hooks/useBackgroundTaskView.js', () => ({
   useBackgroundTaskView: vi.fn(),
+  // Re-export the helper so Dialog renderers can still resolve it under the
+  // mocked module. Inline impl keeps the test independent of the hook
+  // module while preserving the discriminator-based id contract.
+  entryId: (entry: DialogEntry): string =>
+    entry.kind === 'agent' ? entry.agentId : entry.shellId,
 }));
 
 vi.mock('../../hooks/useKeypress.js', () => ({
@@ -30,33 +38,34 @@ vi.mock('../../hooks/useKeypress.js', () => ({
 const mockedUseBackgroundTaskView = vi.mocked(useBackgroundTaskView);
 const mockedUseKeypress = vi.mocked(useKeypress);
 
-function entry(overrides: Partial<BackgroundTaskEntry>): BackgroundTaskEntry {
+function entry(overrides: Partial<BackgroundTaskEntry> = {}): DialogEntry {
   return {
+    kind: 'agent',
     agentId: 'a',
     description: 'desc',
     status: 'running',
     startTime: 0,
     abortController: new AbortController(),
     ...overrides,
-  };
+  } as DialogEntry;
 }
 
 interface ProbeHandle {
   actions: ReturnType<typeof useBackgroundTaskViewActions>;
   state: ReturnType<typeof useBackgroundTaskViewState>;
-  setEntries: (next: readonly BackgroundTaskEntry[]) => void;
+  setEntries: (next: readonly DialogEntry[]) => void;
 }
 
 interface Harness {
   cancel: ReturnType<typeof vi.fn>;
-  setEntries: (next: readonly BackgroundTaskEntry[]) => void;
+  setEntries: (next: readonly DialogEntry[]) => void;
   pressKey: (key: { name?: string; sequence?: string }) => void;
   call: (fn: () => void) => void;
   lastFrame: () => string | undefined;
   probe: { current: ProbeHandle | null };
 }
 
-function setup(initial: readonly BackgroundTaskEntry[]): Harness {
+function setup(initial: readonly DialogEntry[]): Harness {
   const handlers: Array<(key: { name?: string; sequence?: string }) => void> =
     [];
   mockedUseKeypress.mockImplementation((cb, opts) => {
@@ -94,7 +103,7 @@ function setup(initial: readonly BackgroundTaskEntry[]): Harness {
   function Probe({
     entriesSetter,
   }: {
-    entriesSetter: (e: readonly BackgroundTaskEntry[]) => void;
+    entriesSetter: (e: readonly DialogEntry[]) => void;
   }) {
     handle.current = {
       actions: useBackgroundTaskViewActions(),

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.test.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.test.tsx
@@ -73,10 +73,20 @@ function setup(initial: readonly DialogEntry[]): Harness {
   });
 
   const cancel = vi.fn();
+  // Stub registry that resolves `.get(agentId)` against the current entries
+  // snapshot — the dialog now re-reads agent entries via `.get()` to pick up
+  // live activity/stats mutations the snapshot misses.
+  let currentEntries: readonly DialogEntry[] = initial;
   const config = {
     getBackgroundTaskRegistry: () => ({
       cancel,
       setActivityChangeCallback: vi.fn(),
+      get: (id: string) => {
+        const match = currentEntries.find(
+          (e) => e.kind === 'agent' && e.agentId === id,
+        );
+        return match;
+      },
     }),
   } as unknown as Config;
 
@@ -119,6 +129,7 @@ function setup(initial: readonly DialogEntry[]): Harness {
     cancel,
     setEntries(next) {
       handlers.length = 0;
+      currentEntries = next;
       act(() => handle.current!.setEntries(next));
     },
     pressKey(key) {

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.tsx
@@ -28,6 +28,16 @@ import {
   ToolNames,
   type BackgroundTaskEntry,
 } from '@qwen-code/qwen-code-core';
+import {
+  type DialogEntry,
+  entryId,
+} from '../../hooks/useBackgroundTaskView.js';
+
+// `DialogEntry['status']` widens BackgroundTaskEntry['status'] with the
+// shell status union, but they share the same four values
+// (running / completed / failed / cancelled), so handlers keyed on the
+// agent enum still cover every shell case.
+type EntryStatus = DialogEntry['status'];
 
 // Tool-name → display-name lookup (`run_shell_command` → `Shell`).
 const TOOL_DISPLAY_BY_NAME: Record<string, string> = Object.fromEntries(
@@ -46,7 +56,7 @@ function formatActivityLabel(name: string, description: string | undefined) {
 }
 import { formatDuration, formatTokenCount } from '../../utils/formatters.js';
 
-const STATUS_VERBS: Record<BackgroundTaskEntry['status'], string> = {
+const STATUS_VERBS: Record<EntryStatus, string> = {
   running: 'Running',
   completed: 'Completed',
   failed: 'Failed',
@@ -60,7 +70,7 @@ interface StatusPresentation {
 }
 
 function terminalStatusPresentation(
-  status: BackgroundTaskEntry['status'],
+  status: EntryStatus,
 ): StatusPresentation | null {
   switch (status) {
     case 'completed':
@@ -86,11 +96,18 @@ function terminalStatusPresentation(
   }
 }
 
-function rowLabel(entry: BackgroundTaskEntry): string {
-  return buildBackgroundEntryLabel(entry, { includePrefix: false });
+function rowLabel(entry: DialogEntry): string {
+  if (entry.kind === 'agent') {
+    return buildBackgroundEntryLabel(entry, { includePrefix: false });
+  }
+  // Shell row: `[shell] <command>`. Prefix mirrors the dialog's "section"
+  // visual hint without needing per-kind section headers (which would
+  // complicate the windowing math). The command itself is plain text and
+  // already truncated by the row renderer's MaxSizedBox.
+  return `[shell] ${entry.command}`;
 }
 
-function elapsedFor(entry: BackgroundTaskEntry): string {
+function elapsedFor(entry: { startTime: number; endTime?: number }): string {
   const elapsedMs = Math.max(
     0,
     (entry.endTime ?? Date.now()) - entry.startTime,
@@ -126,7 +143,7 @@ function truncateToWidth(text: string, maxWidth: number): string {
 // ─── List mode ─────────────────────────────────────────────
 
 const ListBody: React.FC<{
-  entries: readonly BackgroundTaskEntry[];
+  entries: readonly DialogEntry[];
   selectedIndex: number;
   maxRows: number;
 }> = ({ entries, selectedIndex, maxRows }) => {
@@ -137,7 +154,7 @@ const ListBody: React.FC<{
     return (
       <Box flexDirection="column">
         <Box paddingX={1}>
-          <Text bold>Local agents</Text>
+          <Text bold>Background tasks</Text>
           <Text color={theme.text.secondary}> (0)</Text>
         </Box>
         <Box paddingX={1}>
@@ -193,7 +210,7 @@ const ListBody: React.FC<{
               ? terminal.labelColor
               : theme.text.primary;
           return (
-            <Box key={entry.agentId} flexDirection="row" paddingX={1}>
+            <Box key={entryId(entry)} flexDirection="row" paddingX={1}>
               <Text color={isSelected ? theme.text.accent : undefined}>
                 {isSelected ? '> ' : '  '}
               </Text>
@@ -216,11 +233,22 @@ const ListBody: React.FC<{
 // ─── Detail mode ───────────────────────────────────────────
 
 const DetailBody: React.FC<{
+  entry: DialogEntry;
+  maxHeight: number;
+  maxWidth: number;
+}> = ({ entry, maxHeight, maxWidth }) =>
+  entry.kind === 'agent' ? (
+    <AgentDetailBody entry={entry} maxHeight={maxHeight} maxWidth={maxWidth} />
+  ) : (
+    <ShellDetailBody entry={entry} maxHeight={maxHeight} maxWidth={maxWidth} />
+  );
+
+const AgentDetailBody: React.FC<{
   entry: BackgroundTaskEntry;
   maxHeight: number;
   maxWidth: number;
 }> = ({ entry, maxHeight, maxWidth }) => {
-  const title = `${entry.subagentType ?? 'Agent'} \u203A ${rowLabel(entry)}`;
+  const title = `${entry.subagentType ?? 'Agent'} \u203A ${buildBackgroundEntryLabel(entry, { includePrefix: false })}`;
 
   const terminal = terminalStatusPresentation(entry.status);
   const dimSubtitleParts: string[] = [elapsedFor(entry)];
@@ -342,6 +370,85 @@ const DetailBody: React.FC<{
   );
 };
 
+const ShellDetailBody: React.FC<{
+  entry: import('@qwen-code/qwen-code-core').BackgroundShellEntry;
+  maxHeight: number;
+  maxWidth: number;
+}> = ({ entry, maxHeight, maxWidth }) => {
+  const title = `Shell \u203A ${entry.command}`;
+
+  const terminal = terminalStatusPresentation(entry.status);
+  const dimSubtitleParts: string[] = [elapsedFor(entry)];
+  if (entry.pid !== undefined) {
+    dimSubtitleParts.push(`pid ${entry.pid}`);
+  }
+  if (entry.status === 'completed' && entry.exitCode !== undefined) {
+    dimSubtitleParts.push(`exit ${entry.exitCode}`);
+  }
+
+  const hasError = entry.status === 'failed' && Boolean(entry.error);
+
+  return (
+    <MaxSizedBox
+      maxHeight={maxHeight}
+      maxWidth={maxWidth}
+      overflowDirection="bottom"
+    >
+      <Box>
+        <Text bold color={theme.text.accent}>
+          {title}
+        </Text>
+      </Box>
+      <Box>
+        {terminal && (
+          <Text color={terminal.color}>
+            {`${terminal.icon} ${STATUS_VERBS[entry.status]} \u00B7 `}
+          </Text>
+        )}
+        <Text color={theme.text.secondary}>
+          {dimSubtitleParts.join(' \u00B7 ')}
+        </Text>
+      </Box>
+
+      <Box />
+      <Box>
+        <Text bold dimColor>
+          Working dir
+        </Text>
+      </Box>
+      <Box>
+        <Text wrap="truncate-end">{entry.cwd}</Text>
+      </Box>
+
+      <Box />
+      <Box>
+        <Text bold dimColor>
+          Output file
+        </Text>
+      </Box>
+      <Box>
+        <Text wrap="truncate-end">{entry.outputPath}</Text>
+      </Box>
+
+      {hasError && (
+        <Fragment>
+          <Box />
+          <Box>
+            <Text bold color={theme.status.error}>
+              Error
+            </Text>
+          </Box>
+          <Box>
+            <Text color={theme.status.error} wrap="wrap">
+              {entry.error}
+            </Text>
+          </Box>
+        </Fragment>
+      )}
+    </MaxSizedBox>
+  );
+};
+
 // ─── Dialog shell ──────────────────────────────────────────
 
 interface BackgroundTasksDialogProps {
@@ -390,17 +497,21 @@ export const BackgroundTasksDialog: React.FC<BackgroundTasksDialogProps> = ({
   // activity updates so the Footer pill and AppContainer don't re-run
   // on every tool call a background agent makes.
   const [, bumpActivity] = useState(0);
-  const selectedAgentId = selectedEntry?.agentId;
+  const selectedEntryId = selectedEntry ? entryId(selectedEntry) : undefined;
+  // Activity callback is agent-only — shells don't emit per-tool events.
+  const selectedAgentIdForActivity =
+    selectedEntry?.kind === 'agent' ? selectedEntry.agentId : undefined;
   useEffect(() => {
-    if (!dialogOpen || dialogMode !== 'detail' || !selectedAgentId) return;
+    if (!dialogOpen || dialogMode !== 'detail' || !selectedAgentIdForActivity)
+      return;
     const registry = config.getBackgroundTaskRegistry();
     const onActivity = (entry: BackgroundTaskEntry) => {
-      if (entry.agentId !== selectedAgentId) return;
+      if (entry.agentId !== selectedAgentIdForActivity) return;
       bumpActivity((n) => n + 1);
     };
     registry.setActivityChangeCallback(onActivity);
     return () => registry.setActivityChangeCallback(undefined);
-  }, [dialogOpen, dialogMode, config, selectedAgentId]);
+  }, [dialogOpen, dialogMode, config, selectedAgentIdForActivity]);
 
   // Wall-clock tick for the running agent's duration. Activity callbacks
   // fire when tools run, but duration needs to advance even when the agent
@@ -410,13 +521,13 @@ export const BackgroundTasksDialog: React.FC<BackgroundTasksDialogProps> = ({
     if (
       !dialogOpen ||
       dialogMode !== 'detail' ||
-      !selectedAgentId ||
+      !selectedEntryId ||
       selectedStatus !== 'running'
     )
       return;
     const id = setInterval(() => bumpActivity((n) => n + 1), 1000);
     return () => clearInterval(id);
-  }, [dialogOpen, dialogMode, selectedAgentId, selectedStatus]);
+  }, [dialogOpen, dialogMode, selectedEntryId, selectedStatus]);
 
   // Auto-fallback to the list view when the selected agent reaches a
   // terminal state while the user is watching it live. We only exit on
@@ -425,8 +536,8 @@ export const BackgroundTasksDialog: React.FC<BackgroundTasksDialogProps> = ({
   // view itself renders terminal state fine, so this is a UX choice
   // (return focus to the running roster) rather than a correctness fix.
   const initialDetailStatusRef = useRef<{
-    agentId: string;
-    status: BackgroundTaskEntry['status'];
+    entryId: string;
+    status: EntryStatus;
   } | null>(null);
   useEffect(() => {
     if (!dialogOpen || dialogMode !== 'detail') {
@@ -437,18 +548,18 @@ export const BackgroundTasksDialog: React.FC<BackgroundTasksDialogProps> = ({
     // drop back to the list so we don't sit on a "No entry to show" screen.
     // Hitting this path now is unlikely — terminal entries stay in the
     // registry — but the entry could disappear if the registry is reset.
-    if (!selectedAgentId) {
+    if (!selectedEntryId) {
       initialDetailStatusRef.current = null;
       exitDetail();
       return;
     }
     const seen = initialDetailStatusRef.current;
-    if (!seen || seen.agentId !== selectedAgentId) {
+    if (!seen || seen.entryId !== selectedEntryId) {
       // First render in detail mode for this entry — remember the status we
       // opened with so we can detect a transition away from 'running' later.
       if (selectedStatus) {
         initialDetailStatusRef.current = {
-          agentId: selectedAgentId,
+          entryId: selectedEntryId,
           status: selectedStatus,
         };
       }
@@ -461,7 +572,7 @@ export const BackgroundTasksDialog: React.FC<BackgroundTasksDialogProps> = ({
     ) {
       exitDetail();
     }
-  }, [dialogOpen, dialogMode, selectedAgentId, selectedStatus, exitDetail]);
+  }, [dialogOpen, dialogMode, selectedEntryId, selectedStatus, exitDetail]);
 
   useKeypress(
     (key) => {

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.tsx
@@ -147,9 +147,9 @@ const ListBody: React.FC<{
   selectedIndex: number;
   maxRows: number;
 }> = ({ entries, selectedIndex, maxRows }) => {
-  // Keep the "Local agents (N)" section header rendered even when the list
-  // is empty, so the overlay doesn't collapse into a single line of
-  // empty-state text when the last agent finishes while the dialog is open.
+  // Keep the "Background tasks (N)" section header rendered even when the
+  // list is empty, so the overlay doesn't collapse into a single line of
+  // empty-state text when the last task finishes while the dialog is open.
   if (entries.length === 0) {
     return (
       <Box flexDirection="column">
@@ -189,7 +189,7 @@ const ListBody: React.FC<{
   return (
     <Box flexDirection="column">
       <Box paddingX={1}>
-        <Text bold>Local agents</Text>
+        <Text bold>Background tasks</Text>
         <Text color={theme.text.secondary}> ({entries.length})</Text>
       </Box>
       <Box flexDirection="column">
@@ -483,20 +483,34 @@ export const BackgroundTasksDialog: React.FC<BackgroundTasksDialogProps> = ({
 
   // List mode row budget: terminal height minus chrome (border 2 + title 1
   // + two marginTops 2 + hint 1) and list header ("N active agents" 1 +
-  // marginTop 1 + "Local agents (N)" 1) = 10.
+  // marginTop 1 + "Background tasks (N)" 1) = 10.
   const listMaxRows = Math.max(3, availableTerminalHeight - 10);
 
-  const selectedEntry = useMemo(
-    () => entries[selectedIndex] ?? null,
-    [entries, selectedIndex],
-  );
+  // Activity tick — bumped whenever the watched agent emits an activity
+  // update, *and* used as a useMemo dep below to refresh the live agent
+  // entry from the registry. The snapshot in useBackgroundTaskView
+  // intentionally only refreshes on `statusChange` (so the footer pill
+  // and AppContainer stay quiet during heavy tool traffic), but the
+  // detail body must see fresh `recentActivities` / `stats` between
+  // those transitions — so we re-read from the registry here.
+  const [activityTick, setActivityTick] = useState(0);
 
-  // Tick up a local counter on each activity callback to force the
-  // detail body to re-render while it's open. The main status
-  // subscription in useBackgroundTaskView intentionally ignores
-  // activity updates so the Footer pill and AppContainer don't re-run
-  // on every tool call a background agent makes.
-  const [, bumpActivity] = useState(0);
+  const selectedEntry = useMemo(() => {
+    const fromSnapshot = entries[selectedIndex] ?? null;
+    if (!fromSnapshot || fromSnapshot.kind !== 'agent') return fromSnapshot;
+    // Re-read the agent from the registry so detail-body fields the
+    // registry mutates between status transitions (recentActivities,
+    // stats) are fresh. The shallow spread inside useBackgroundTaskView
+    // captures `recentActivities` at refresh time, and `appendActivity`
+    // reassigns `entry.recentActivities = next` on the registry object —
+    // so the snapshot's reference is detached after the first activity.
+    const live = config.getBackgroundTaskRegistry().get(fromSnapshot.agentId);
+    return live ? { ...live, kind: 'agent' as const } : fromSnapshot;
+    // activityTick is a dep on purpose: the registry mutation is invisible
+    // to useMemo otherwise and we need to recompute on each activity.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [entries, selectedIndex, config, activityTick]);
+
   const selectedEntryId = selectedEntry ? entryId(selectedEntry) : undefined;
   // Activity callback is agent-only — shells don't emit per-tool events.
   const selectedAgentIdForActivity =
@@ -507,7 +521,7 @@ export const BackgroundTasksDialog: React.FC<BackgroundTasksDialogProps> = ({
     const registry = config.getBackgroundTaskRegistry();
     const onActivity = (entry: BackgroundTaskEntry) => {
       if (entry.agentId !== selectedAgentIdForActivity) return;
-      bumpActivity((n) => n + 1);
+      setActivityTick((n) => n + 1);
     };
     registry.setActivityChangeCallback(onActivity);
     return () => registry.setActivityChangeCallback(undefined);
@@ -525,7 +539,7 @@ export const BackgroundTasksDialog: React.FC<BackgroundTasksDialogProps> = ({
       selectedStatus !== 'running'
     )
       return;
-    const id = setInterval(() => bumpActivity((n) => n + 1), 1000);
+    const id = setInterval(() => setActivityTick((n) => n + 1), 1000);
     return () => clearInterval(id);
   }, [dialogOpen, dialogMode, selectedEntryId, selectedStatus]);
 

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksPill.test.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksPill.test.tsx
@@ -5,57 +5,92 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { BackgroundTaskEntry } from '@qwen-code/qwen-code-core';
+import type { DialogEntry } from '../../hooks/useBackgroundTaskView.js';
 import { getPillLabel } from './BackgroundTasksPill.js';
 
-function entry(overrides: Partial<BackgroundTaskEntry>): BackgroundTaskEntry {
+function agentEntry(overrides: Partial<DialogEntry> = {}): DialogEntry {
   return {
+    kind: 'agent',
     agentId: 'a',
     description: 'desc',
     status: 'running',
     startTime: 0,
     abortController: new AbortController(),
     ...overrides,
-  };
+  } as DialogEntry;
+}
+
+function shellEntry(overrides: Partial<DialogEntry> = {}): DialogEntry {
+  return {
+    kind: 'shell',
+    shellId: 'bg_x',
+    command: 'sleep 60',
+    cwd: '/tmp',
+    status: 'running',
+    startTime: 0,
+    outputPath: '/tmp/x.out',
+    abortController: new AbortController(),
+    ...overrides,
+  } as DialogEntry;
 }
 
 describe('getPillLabel', () => {
   it('uses singular form for one running agent', () => {
-    expect(getPillLabel([entry({ agentId: 'a' })])).toBe('1 local agent');
+    expect(getPillLabel([agentEntry({ agentId: 'a' })])).toBe('1 local agent');
   });
 
   it('uses plural form for multiple running agents', () => {
     expect(
       getPillLabel([
-        entry({ agentId: 'a' }),
-        entry({ agentId: 'b' }),
-        entry({ agentId: 'c' }),
+        agentEntry({ agentId: 'a' }),
+        agentEntry({ agentId: 'b' }),
+        agentEntry({ agentId: 'c' }),
       ]),
     ).toBe('3 local agents');
+  });
+
+  it('uses singular form for one running shell', () => {
+    expect(getPillLabel([shellEntry({ shellId: 'bg_a' })])).toBe('1 shell');
+  });
+
+  it('uses plural form for multiple running shells', () => {
+    expect(
+      getPillLabel([
+        shellEntry({ shellId: 'bg_a' }),
+        shellEntry({ shellId: 'bg_b' }),
+      ]),
+    ).toBe('2 shells');
+  });
+
+  it('groups by kind when both kinds are running, shells first', () => {
+    expect(
+      getPillLabel([
+        agentEntry({ agentId: 'a' }),
+        shellEntry({ shellId: 'bg_a' }),
+        shellEntry({ shellId: 'bg_b' }),
+      ]),
+    ).toBe('2 shells, 1 local agent');
   });
 
   it('counts only running entries when running and terminal mix', () => {
     expect(
       getPillLabel([
-        entry({ agentId: 'a', status: 'running' }),
-        entry({ agentId: 'b', status: 'completed' }),
-        entry({ agentId: 'c', status: 'cancelled' }),
+        agentEntry({ agentId: 'a', status: 'running' }),
+        agentEntry({ agentId: 'b', status: 'completed' }),
+        shellEntry({ shellId: 'bg_a', status: 'cancelled' }),
       ]),
     ).toBe('1 local agent');
   });
 
-  it('uses singular done form for one terminal-only entry', () => {
-    expect(getPillLabel([entry({ agentId: 'a', status: 'completed' })])).toBe(
-      '1 local agent done',
-    );
-  });
-
-  it('uses plural done form when all entries are terminal', () => {
+  it('uses generic done form when all entries are terminal', () => {
+    expect(
+      getPillLabel([agentEntry({ agentId: 'a', status: 'completed' })]),
+    ).toBe('1 task done');
     expect(
       getPillLabel([
-        entry({ agentId: 'a', status: 'completed' }),
-        entry({ agentId: 'b', status: 'failed' }),
+        agentEntry({ agentId: 'a', status: 'completed' }),
+        shellEntry({ shellId: 'bg_a', status: 'failed' }),
       ]),
-    ).toBe('2 local agents done');
+    ).toBe('2 tasks done');
   });
 });

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksPill.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksPill.tsx
@@ -13,21 +13,44 @@ import {
 } from '../../contexts/BackgroundTaskViewContext.js';
 import { useKeypress, type Key } from '../../hooks/useKeypress.js';
 import { theme } from '../../semantic-colors.js';
-import type { BackgroundTaskEntry } from '@qwen-code/qwen-code-core';
+import type { DialogEntry } from '../../hooks/useBackgroundTaskView.js';
+
+const KIND_NAMES = {
+  agent: { singular: 'local agent', plural: 'local agents' },
+  shell: { singular: 'shell', plural: 'shells' },
+} as const;
 
 /**
- * Pill label: counts running entries while any are running; once everything
- * has terminated, switches to a "done" form so the pill still invites
- * reopening the dialog to inspect final state.
+ * Pill label: counts running entries grouped by kind while any are
+ * running ("1 shell, 2 local agents"), and once everything has terminated
+ * switches to a "done" form so the pill still invites reopening the
+ * dialog to inspect final state ("3 done").
  */
-export function getPillLabel(entries: readonly BackgroundTaskEntry[]): string {
-  const running = entries.filter((e) => e.status === 'running').length;
-  if (running > 0) {
-    return running === 1 ? '1 local agent' : `${running} local agents`;
+export function getPillLabel(entries: readonly DialogEntry[]): string {
+  if (entries.length === 0) return '';
+
+  const running = entries.filter((e) => e.status === 'running');
+  if (running.length > 0) {
+    return groupAndFormat(running);
   }
-  return entries.length === 1
-    ? '1 local agent done'
-    : `${entries.length} local agents done`;
+  // All terminal — collapse into a single tally; per-kind detail isn't
+  // useful at this point and would clutter the footer.
+  return entries.length === 1 ? '1 task done' : `${entries.length} tasks done`;
+}
+
+function groupAndFormat(entries: readonly DialogEntry[]): string {
+  const counts = { agent: 0, shell: 0 };
+  for (const e of entries) counts[e.kind]++;
+  const parts: string[] = [];
+  // Order: shell first (matches Claude Code's pill convention), agent second.
+  if (counts.shell > 0) parts.push(formatCount('shell', counts.shell));
+  if (counts.agent > 0) parts.push(formatCount('agent', counts.agent));
+  return parts.join(', ');
+}
+
+function formatCount(kind: keyof typeof KIND_NAMES, n: number): string {
+  const names = KIND_NAMES[kind];
+  return `${n} ${n === 1 ? names.singular : names.plural}`;
 }
 
 export const BackgroundTasksPill: React.FC = () => {

--- a/packages/cli/src/ui/contexts/BackgroundTaskViewContext.tsx
+++ b/packages/cli/src/ui/contexts/BackgroundTaskViewContext.tsx
@@ -19,19 +19,23 @@ import {
   useMemo,
   useState,
 } from 'react';
+import { type Config } from '@qwen-code/qwen-code-core';
 import {
-  type BackgroundTaskEntry,
-  type Config,
-} from '@qwen-code/qwen-code-core';
-import { useBackgroundTaskView } from '../hooks/useBackgroundTaskView.js';
+  type DialogEntry,
+  useBackgroundTaskView,
+} from '../hooks/useBackgroundTaskView.js';
 
 // ─── Types ──────────────────────────────────────────────────
 
 export type BackgroundDialogMode = 'closed' | 'list' | 'detail';
 
 export interface BackgroundTaskViewState {
-  /** Live snapshot of every background agent entry, ordered by startTime. */
-  entries: readonly BackgroundTaskEntry[];
+  /**
+   * Live snapshot of every background entry across both registries
+   * (subagents + managed shells), ordered by `startTime`. Each entry carries
+   * a `kind` discriminator so renderers can dispatch on agent vs shell.
+   */
+  entries: readonly DialogEntry[];
   /** Index into `entries` for the currently focused row (0-based). */
   selectedIndex: number;
   /** `'closed'` when the overlay isn't mounted; otherwise the active mode. */
@@ -166,8 +170,16 @@ export function BackgroundTaskViewProvider({
     if (!config) return;
     const target = entries[selectedIndex];
     if (!target) return;
-    // cancel() is a no-op for non-running entries, so no pre-check here.
-    config.getBackgroundTaskRegistry().cancel(target.agentId);
+    // Both registries' cancel paths are no-ops on non-running entries, so
+    // no pre-check here. Shell cancel goes through requestCancel — it
+    // triggers the AbortController only and lets the spawn's settle path
+    // record the real terminal moment + outcome (mirrors the task_stop
+    // tool path in #3687).
+    if (target.kind === 'agent') {
+      config.getBackgroundTaskRegistry().cancel(target.agentId);
+    } else {
+      config.getBackgroundShellRegistry().requestCancel(target.shellId);
+    }
   }, [config, entries, selectedIndex]);
 
   const state: BackgroundTaskViewState = useMemo(

--- a/packages/cli/src/ui/hooks/useBackgroundTaskView.ts
+++ b/packages/cli/src/ui/hooks/useBackgroundTaskView.ts
@@ -5,11 +5,14 @@
  */
 
 /**
- * useBackgroundTaskView — subscribes to the background task registry's
- * status-change callback and maintains a reactive snapshot of every
- * `BackgroundTaskEntry`, including terminal ones. Surfaces that only
- * care about live work (the footer pill, the composer's Down-arrow
- * route) filter for `running` themselves.
+ * useBackgroundTaskView — subscribes to both registries (background
+ * subagents and background shells) and merges them into a single ordered
+ * snapshot of `DialogEntry`s. Both registries fire `statusChange` on
+ * register too, so a single subscription per registry is enough to keep
+ * the snapshot fresh for new + transitioning entries.
+ *
+ * Surfaces that only care about live work (the footer pill, the
+ * composer's Down-arrow route) filter for `running` themselves.
  *
  * Intentionally ignores activity updates (appendActivity). Tool-call
  * traffic from a running background agent would otherwise churn the
@@ -21,33 +24,63 @@
 import { useState, useEffect } from 'react';
 import {
   type BackgroundTaskEntry,
+  type BackgroundShellEntry,
   type Config,
 } from '@qwen-code/qwen-code-core';
 
+/**
+ * A unified view-model entry the dialog/pill/context render against.
+ * Discriminated by `kind`; agent-shaped fields and shell-shaped fields
+ * are inlined verbatim to keep the renderer code unchanged on the agent
+ * branch (just guarded by `kind === 'agent'`).
+ */
+export type DialogEntry =
+  | (BackgroundTaskEntry & { kind: 'agent' })
+  | (BackgroundShellEntry & { kind: 'shell' });
+
 export interface UseBackgroundTaskViewResult {
-  entries: readonly BackgroundTaskEntry[];
+  entries: readonly DialogEntry[];
+}
+
+/** Stable id of an entry regardless of kind — used as React key + lookup. */
+export function entryId(entry: DialogEntry): string {
+  return entry.kind === 'agent' ? entry.agentId : entry.shellId;
 }
 
 export function useBackgroundTaskView(
   config: Config | null,
 ): UseBackgroundTaskViewResult {
-  const [entries, setEntries] = useState<BackgroundTaskEntry[]>([]);
+  const [entries, setEntries] = useState<DialogEntry[]>([]);
 
   useEffect(() => {
     if (!config) return;
-    const registry = config.getBackgroundTaskRegistry();
+    const agentRegistry = config.getBackgroundTaskRegistry();
+    const shellRegistry = config.getBackgroundShellRegistry();
 
-    // getAll() returns a fresh array in registration (= startTime) order.
-    setEntries(registry.getAll());
-
-    const onStatusChange = () => {
-      setEntries(registry.getAll());
+    const refresh = () => {
+      const agentEntries: DialogEntry[] = agentRegistry
+        .getAll()
+        .map((e) => ({ ...e, kind: 'agent' as const }));
+      const shellEntries: DialogEntry[] = shellRegistry
+        .getAll()
+        .map((e) => ({ ...e, kind: 'shell' as const }));
+      // Merge by startTime so the order matches launch order across both
+      // registries (matters when an agent and a shell are launched
+      // alternately).
+      const merged = [...agentEntries, ...shellEntries].sort(
+        (a, b) => a.startTime - b.startTime,
+      );
+      setEntries(merged);
     };
 
-    registry.setStatusChangeCallback(onStatusChange);
+    refresh();
+
+    agentRegistry.setStatusChangeCallback(refresh);
+    shellRegistry.setStatusChangeCallback(refresh);
 
     return () => {
-      registry.setStatusChangeCallback(undefined);
+      agentRegistry.setStatusChangeCallback(undefined);
+      shellRegistry.setStatusChangeCallback(undefined);
     };
   }, [config]);
 

--- a/packages/core/src/services/backgroundShellRegistry.test.ts
+++ b/packages/core/src/services/backgroundShellRegistry.test.ts
@@ -101,6 +101,85 @@ describe('BackgroundShellRegistry', () => {
     });
   });
 
+  describe('callbacks', () => {
+    it('fires register callback synchronously when an entry is added', () => {
+      const reg = new BackgroundShellRegistry();
+      const seen: string[] = [];
+      reg.setRegisterCallback((entry) => seen.push(entry.shellId));
+
+      reg.register(makeEntry({ shellId: 'a' }));
+      reg.register(makeEntry({ shellId: 'b' }));
+
+      expect(seen).toEqual(['a', 'b']);
+    });
+
+    it('fires statusChange callback on register too (mirrors BackgroundTaskRegistry)', () => {
+      const reg = new BackgroundShellRegistry();
+      const seen: string[] = [];
+      reg.setStatusChangeCallback((e) => seen.push(e.shellId));
+      reg.register(makeEntry({ shellId: 'a' }));
+      reg.register(makeEntry({ shellId: 'b' }));
+      expect(seen).toEqual(['a', 'b']);
+    });
+
+    it('fires statusChange callback on complete / fail / cancel', () => {
+      const reg = new BackgroundShellRegistry();
+      reg.register(makeEntry({ shellId: 'a' }));
+      reg.register(makeEntry({ shellId: 'b' }));
+      reg.register(makeEntry({ shellId: 'c' }));
+      const transitions: Array<{ id: string; status: string }> = [];
+      reg.setStatusChangeCallback((entry) =>
+        transitions.push({ id: entry.shellId, status: entry.status }),
+      );
+
+      reg.complete('a', 0, 1000);
+      reg.fail('b', 'boom', 1100);
+      reg.cancel('c', 1200);
+
+      expect(transitions).toEqual([
+        { id: 'a', status: 'completed' },
+        { id: 'b', status: 'failed' },
+        { id: 'c', status: 'cancelled' },
+      ]);
+    });
+
+    it('does not fire statusChange when a transition is a no-op', () => {
+      const reg = new BackgroundShellRegistry();
+      const transitions: string[] = [];
+      reg.setStatusChangeCallback((e) => transitions.push(e.shellId));
+      reg.register(makeEntry({ shellId: 'a' }));
+      reg.complete('a', 0, 1000);
+      transitions.length = 0;
+
+      reg.complete('a', 0, 2000); // already terminal
+      reg.fail('a', 'late', 2000); // already terminal
+      reg.cancel('a', 2000); // already terminal
+      reg.requestCancel('a'); // already terminal — also no fire
+
+      expect(transitions).toEqual([]);
+    });
+
+    it('keeps the registry usable when a callback throws', () => {
+      const reg = new BackgroundShellRegistry();
+      reg.setRegisterCallback(() => {
+        throw new Error('subscriber blew up');
+      });
+
+      expect(() => reg.register(makeEntry({ shellId: 'a' }))).not.toThrow();
+      expect(reg.get('a')!.status).toBe('running');
+    });
+
+    it('clears subscriber when set to undefined', () => {
+      const reg = new BackgroundShellRegistry();
+      const seen: string[] = [];
+      reg.setRegisterCallback((e) => seen.push(e.shellId));
+      reg.register(makeEntry({ shellId: 'a' }));
+      reg.setRegisterCallback(undefined);
+      reg.register(makeEntry({ shellId: 'b' }));
+      expect(seen).toEqual(['a']);
+    });
+  });
+
   describe('requestCancel', () => {
     it('aborts the signal but leaves status running and endTime undefined', () => {
       const reg = new BackgroundShellRegistry();

--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -17,6 +17,10 @@
  * status.
  */
 
+import { createDebugLogger } from '../utils/debugLogger.js';
+
+const debugLogger = createDebugLogger('BACKGROUND_SHELLS');
+
 export type BackgroundShellStatus =
   | 'running'
   | 'completed'
@@ -47,6 +51,20 @@ export interface BackgroundShellEntry {
   abortController: AbortController;
 }
 
+/** Fires when a new entry is registered. */
+export type BackgroundShellRegisterCallback = (
+  entry: BackgroundShellEntry,
+) => void;
+
+/**
+ * Fires on every status transition (running → terminal). Symmetric with
+ * `BackgroundTaskRegistry.setStatusChangeCallback` so the same UI hook can
+ * subscribe to both registries.
+ */
+export type BackgroundShellStatusChangeCallback = (
+  entry: BackgroundShellEntry,
+) => void;
+
 export class BackgroundShellRegistry {
   // Entries persist for the session lifetime — no automatic eviction of
   // terminal entries. For typical interactive sessions (tens of background
@@ -56,8 +74,39 @@ export class BackgroundShellRegistry {
   // is left as a follow-up alongside output-file rotation.
   private readonly entries = new Map<string, BackgroundShellEntry>();
 
+  private registerCallback: BackgroundShellRegisterCallback | undefined;
+  private statusChangeCallback: BackgroundShellStatusChangeCallback | undefined;
+
+  /**
+   * Subscribe to new-entry events. Called synchronously inside `register()`.
+   * Setting `undefined` clears the existing subscriber. Single-subscriber on
+   * purpose — the UI hook is the only consumer in the codebase, and a list
+   * would invite drift in error-handling.
+   */
+  setRegisterCallback(cb: BackgroundShellRegisterCallback | undefined): void {
+    this.registerCallback = cb;
+  }
+
+  /**
+   * Subscribe to status transitions (running → terminal). Called
+   * synchronously inside `complete()` / `fail()` / `cancel()` after the
+   * entry has been mutated. Same single-subscriber rationale as
+   * `setRegisterCallback`.
+   */
+  setStatusChangeCallback(
+    cb: BackgroundShellStatusChangeCallback | undefined,
+  ): void {
+    this.statusChangeCallback = cb;
+  }
+
   register(entry: BackgroundShellEntry): void {
     this.entries.set(entry.shellId, entry);
+    this.fireRegister(entry);
+    // Mirror BackgroundTaskRegistry: registration is a status transition
+    // (nothing → running) so subscribers that only care about
+    // "what's in the registry now" can subscribe to a single callback
+    // and see new entries the same way they see status changes.
+    this.fireStatusChange(entry);
   }
 
   get(shellId: string): BackgroundShellEntry | undefined {
@@ -74,6 +123,7 @@ export class BackgroundShellRegistry {
     entry.status = 'completed';
     entry.exitCode = exitCode;
     entry.endTime = endTime;
+    this.fireStatusChange(entry);
   }
 
   fail(shellId: string, error: string, endTime: number): void {
@@ -82,6 +132,7 @@ export class BackgroundShellRegistry {
     entry.status = 'failed';
     entry.error = error;
     entry.endTime = endTime;
+    this.fireStatusChange(entry);
   }
 
   cancel(shellId: string, endTime: number): void {
@@ -90,6 +141,28 @@ export class BackgroundShellRegistry {
     entry.status = 'cancelled';
     entry.endTime = endTime;
     entry.abortController.abort();
+    this.fireStatusChange(entry);
+  }
+
+  private fireRegister(entry: BackgroundShellEntry): void {
+    if (!this.registerCallback) return;
+    try {
+      this.registerCallback(entry);
+    } catch (error) {
+      // Subscriber failure must not poison the registry — the spawn path
+      // has already happened. Swallow + continue so the entry remains
+      // observable via `getAll()` / `get()`.
+      debugLogger.error('register callback failed:', error);
+    }
+  }
+
+  private fireStatusChange(entry: BackgroundShellEntry): void {
+    if (!this.statusChangeCallback) return;
+    try {
+      this.statusChangeCallback(entry);
+    } catch (error) {
+      debugLogger.error('statusChange callback failed:', error);
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Phase B follow-up #2 of Issue #3634. Surfaces the managed background-shell pool (#3642) in the same combined Background tasks overlay that already shows local subagents (#3488), so users get one unified view across both task kinds instead of having to remember `/tasks` for shells specifically.

After this change, the pill, the list overlay, the detail overlay, and the cancel keybinding all work uniformly across agents and shells — driven by the same registry-callback subscription pattern that the agent side already uses.

**Size**: +500 / −100 across 8 files, 2 commits.

## Before / After

**Before**

- Pill: `1 local agent` only (shells invisible).
- `Ctrl+T` overlay: agent rows only.
- Shells: only reachable via `/tasks` slash command.
- Cancel keybinding (`x`): agent only.

**After**

- Pill: `2 shells, 1 local agent` while running; `3 tasks done` when all terminal.
- `Ctrl+T` overlay: single `Background tasks` section with both kinds, agents prefixed naturally and shells prefixed `[shell] <command>`.
- Detail view dispatches by kind: agents keep the existing layout; shells show cwd / output file / pid / exit code.
- Cancel keybinding (`x`): goes through `requestCancel()` for shells — only aborts, the spawn settle path records the real terminal state (mirrors `task_stop` in #3687).

## What changed

Commit `314692e7f` — main wiring:

- **`BackgroundShellRegistry`** (core): add `setRegisterCallback` / `setStatusChangeCallback` / `requestCancel(id)`, mirroring `BackgroundTaskRegistry`'s contract. `register()` also fires `statusChange` so subscribers observe the lifecycle start, not just transitions.
- **`useBackgroundTaskView`** (cli): subscribe to both registries, merge entries by `startTime`, attach a `kind` discriminator (`DialogEntry` union: `agent` | `shell`) so renderers can dispatch.
- **`BackgroundTasksPill`**: group running counts by kind ("2 shells, 1 local agent"); when all terminal, collapse to "N task(s) done". Shells listed first (matches Claude Code's pill convention).
- **`BackgroundTasksDialog`**: single `Background tasks` header; ListBody renders shells as `[shell] <command>`; DetailBody dispatches to `AgentDetailBody` (original) or new `ShellDetailBody`.
- **Context `cancelSelected`**: switches by `kind` — agents through `cancel()`, shells through `requestCancel()`.

Commit `08e75f2d8` — review-driven follow-up:

- **`selectedEntry` re-resolves the agent from the registry on each render** (in `BackgroundTasksDialog.tsx` via a `useMemo` whose deps include an `activityTick` counter that the `setActivityChangeCallback` bumps). The shallow-copy in `useBackgroundTaskView` copies `recentActivities` by reference, but `BackgroundTaskRegistry.appendActivity` reassigns `entry.recentActivities = next` on the registry object — so the snapshot's reference detaches after the first activity and the Progress block goes stale. The fix keeps the snapshot as the source of truth for the list (so the pill and AppContainer don't churn on tool traffic), and only the detail body re-reads live.
- **List header rename**: non-empty `ListBody` rendered `Local agents` even though `entries` now contains both kinds. Renamed to `Background tasks` to match the empty-state branch.

## Design notes

The `DialogEntry` shape is `(BackgroundTaskEntry & { kind: 'agent' }) | (BackgroundShellEntry & { kind: 'shell' })` — i.e., the underlying entry's fields are spread inline, then a `kind` discriminator is added. Considered a wrapper shape (`{ kind: 'agent', agent: BackgroundTaskEntry } | { kind: 'shell', shell: BackgroundShellEntry }`) but rejected: every consumer (`rowLabel`, `entryId`, `elapsedFor`, `cancelSelected`, `terminalStatusPresentation`, plus all the renderers) would need to switch from `entry.startTime` to `entry.agent.startTime` etc., and the renames cascade through several files. The spread keeps the renderer code mechanical.

The trade-off is identity loss for nested mutable references like `recentActivities` — addressed surgically in commit `08e75f2d8` via the live re-resolve in `selectedEntry`, scoped to the detail body so the optimization for the pill / AppContainer (no churn on tool traffic) is preserved.

## 中文版

Phase B 后续任务 #2（Issue #3634 跟踪）。把 #3642 引入的后台 shell 池接入 #3488 的组合后台任务面板，统一两种后台任务（agent / shell）的展示与控制，不再需要记 `/tasks`。

**体量**：+500 / −100，8 个文件，2 个 commit。

改动覆盖：

Commit `314692e7f`（主接入）：

- **核心层**：`BackgroundShellRegistry` 加上 `setRegisterCallback` / `setStatusChangeCallback` / `requestCancel(id)`，对齐 `BackgroundTaskRegistry`。`register()` 同时触发 `statusChange`，订阅者能看到生命周期起点。
- **CLI 层**：`useBackgroundTaskView` 同时订阅两个 registry，按 `startTime` 合并，给每条目加 `kind` 判别字段（`DialogEntry` 联合类型）。
- **Pill**：按 kind 分组（如 "2 shells, 1 local agent"），全部终结后折叠为 "N task(s) done"。Shell 放前面（对齐 Claude Code 的 pill 惯例）。
- **Dialog**：单一 "Background tasks" 标题；shell 行展示为 `[shell] <command>`；详情视图按 kind 派发，shell 展示 cwd / 输出文件 / pid / 退出码。
- **取消键**（`x`）：agent 走 `cancel()`，shell 走 `requestCancel()`（只 abort，settle 路径记录真实终态，沿用 #3687 在 `task_stop` 上的策略）。

Commit `08e75f2d8`（review 反馈）：

- **`selectedEntry` 在 detail mode 下从 registry 重新取**（`BackgroundTasksDialog.tsx` 的 `useMemo`，deps 含 `activityTick`，由 `setActivityChangeCallback` 触发刷新）。`useBackgroundTaskView` 里的 shallow-copy 把 `recentActivities` 按引用复制，但 `BackgroundTaskRegistry.appendActivity` 会 `entry.recentActivities = next` 重新赋值 — snapshot 拿到的引用第一次 activity 后就脱节，Progress block 会渲染过期数据。修法保留 snapshot 作为列表来源（pill / AppContainer 不被 tool-call 流冲刷），只让详情视图走 live。
- **List header 重命名**：非空 `ListBody` 还是 `Local agents`，但 `entries` 现在含两种 kind。改成 `Background tasks` 跟 empty-state 对齐。

## 设计说明

`DialogEntry` 是 `(BackgroundTaskEntry & { kind: 'agent' }) | (BackgroundShellEntry & { kind: 'shell' })` — 把底层 entry 的字段 spread 进来后加 `kind` 判别。考虑过 wrapper 形态（`{ kind: 'agent', agent: BackgroundTaskEntry } | ...`），否决：所有消费者（`rowLabel`、`entryId`、`elapsedFor`、`cancelSelected`、`terminalStatusPresentation` + 所有渲染器）都要从 `entry.startTime` 改成 `entry.agent.startTime`，跨多个文件级联改动。Spread 形态让渲染层代码保持机械。

代价是 `recentActivities` 这种嵌套可变引用的 identity 丢失 — 在 `08e75f2d8` 里精准修掉：`selectedEntry` 走 live re-resolve，只针对 detail body，pill / AppContainer 的 "tool-call 不冲刷" 优化保留。

## Test plan

- [x] `vitest run` core: 253 files / 6250 pass + 2 skipped
- [x] `vitest run` cli: 304 files / 4701 pass + 7 skipped (含本 PR 新增 / 修改的：8 个 pill 用例 + 4 个 dialog 用例 + 5 + 3 个 shell-registry 用例)
- [x] ESLint clean
- [x] Prettier clean
- [ ] **Manual smoke (留给 reviewer)**: 通过 background tool 启动一个 shell；pill 显示 count；`Ctrl+T` 打开 dialog；行带 `[shell]` 前缀；Enter 进 shell 详情；`x` 取消；shell drain 后 pill 折叠成 "task done"。

## Related

- Issue #3634 (Phase B alignment roadmap)
- #3488 (combined dialog scaffolding)
- #3642 (shell pool + `/tasks`)
- #3687 (shell `task_stop` integration; same cancel-vs-exit race policy is reused here)

## PR 3720 tmux interactive E2E test report

**Branch:** `feat/shell-in-dialog`  
**Binary tested:** `node dist/cli.js`  
**Build command:** `npm run build && npm run bundle`  
**Result:** Build/bundle passed. Bundle assets copied to `dist/`.

### Environment

- OS: darwin
- Repo: `/Users/wenshao/git/qwen-code-x7`
- Test workspace: `/tmp/qwen-bg-shell-e2e-pr3720`
- tmux session: `qwen-pr3720-bg-shell`
- CLI launch command:

```bash
tmux new-session -d -s qwen-pr3720-bg-shell -x 200 -y 50 \
  'cd /tmp/qwen-bg-shell-e2e-pr3720 && node /Users/wenshao/git/qwen-code-x7/dist/cli.js --approval-mode yolo'
```

### Commands actually run

```bash
npm run build && npm run bundle

rm -rf /tmp/qwen-bg-shell-e2e-pr3720
mkdir -p /tmp/qwen-bg-shell-e2e-pr3720
tmux kill-session -t qwen-pr3720-bg-shell 2>/dev/null || true
tmux new-session -d -s qwen-pr3720-bg-shell -x 200 -y 50 \
  'cd /tmp/qwen-bg-shell-e2e-pr3720 && node /Users/wenshao/git/qwen-code-x7/dist/cli.js --approval-mode yolo'
sleep 5
tmux capture-pane -t qwen-pr3720-bg-shell -p -S -80

tmux send-keys -t qwen-pr3720-bg-shell \
  'Run this exact shell command as a background shell using run_shell_command with is_background=true: bash -lc "for i in 1 2 3 4 5 6 7 8 9 10; do echo PR3720_BG_$i; sleep 2; done". Do not use any other tools.'
sleep 0.5
tmux send-keys -t qwen-pr3720-bg-shell Enter
sleep 8
tmux capture-pane -t qwen-pr3720-bg-shell -p -S -160

tmux send-keys -t qwen-pr3720-bg-shell C-t
sleep 1
tmux capture-pane -t qwen-pr3720-bg-shell -p -S -120

tmux send-keys -t qwen-pr3720-bg-shell Down
sleep 0.5
tmux send-keys -t qwen-pr3720-bg-shell Enter
sleep 1
tmux capture-pane -t qwen-pr3720-bg-shell -p -S -140

tmux send-keys -t qwen-pr3720-bg-shell Enter
sleep 1
tmux capture-pane -t qwen-pr3720-bg-shell -p -S -140

tmux send-keys -t qwen-pr3720-bg-shell x
sleep 1.5
tmux capture-pane -t qwen-pr3720-bg-shell -p -S -140

tmux send-keys -t qwen-pr3720-bg-shell Enter
sleep 0.5
tmux capture-pane -t qwen-pr3720-bg-shell -p -S -120

tmux send-keys -t qwen-pr3720-bg-shell Escape
sleep 0.5
tmux capture-pane -t qwen-pr3720-bg-shell -p -S -80

tmux send-keys -t qwen-pr3720-bg-shell \
  'Run this exact shell command as a background shell using run_shell_command with is_background=true: bash -lc "trap '\''echo PR3720_CANCELLED; exit 130'\'' TERM INT; i=0; while true; do echo PR3720_CANCEL_$i; i=$((i+1)); sleep 2; done". Do not use any other tools.'
sleep 0.5
tmux send-keys -t qwen-pr3720-bg-shell Enter
sleep 6
tmux capture-pane -t qwen-pr3720-bg-shell -p -S -180

tmux send-keys -t qwen-pr3720-bg-shell Down
sleep 0.3
tmux send-keys -t qwen-pr3720-bg-shell Enter
sleep 0.5
tmux capture-pane -t qwen-pr3720-bg-shell -p -S -150

tmux send-keys -t qwen-pr3720-bg-shell Down
sleep 0.3
tmux capture-pane -t qwen-pr3720-bg-shell -p -S -80

tmux send-keys -t qwen-pr3720-bg-shell x
sleep 1
tmux capture-pane -t qwen-pr3720-bg-shell -p -S -90

tmux send-keys -t qwen-pr3720-bg-shell Enter
sleep 0.5
tmux capture-pane -t qwen-pr3720-bg-shell -p -S -90

tmux send-keys -t qwen-pr3720-bg-shell Escape
sleep 0.5
tmux capture-pane -t qwen-pr3720-bg-shell -p -S -60
tmux kill-session -t qwen-pr3720-bg-shell
```

### Observations

#### Build / bundle

PASS

`npm run build && npm run bundle` completed successfully with exit code 0. The build emitted existing lint warnings in the VS Code companion package, but no errors.

#### Background shell appears in footer pill

PASS

After launching a background shell, the footer showed:

```text
YOLO mode (shift + tab to cycle) · 1 shell
```

This confirms the pill counts running shell entries.

#### Background shell appears in combined Background tasks overlay

PASS

Opening the overlay through the footer pill showed:

```text
Background tasks
Background tasks (1)
> [shell] bash -lc "for i in 1 2 3 4 5 6 7 8 9 10; do echo PR3720_BG_$i; sleep 2; done"
```

With two shell entries, the same combined overlay showed:

```text
Background tasks (2)
  [shell] bash -lc "for i in 1 2 3 4 5 6 7 8 9 10; do echo PR3720_BG_$i; sleep 2; done"
> [shell] bash -lc "trap 'echo PR3720_CANCELLED; exit 130' TERM INT; i=0; while true; do echo
  PR3720_CANCEL_$i; i=$((i+1)); sleep 2; done"
```

#### Shell row shows `[shell]` prefix

PASS

Both shell rows in the Background tasks dialog rendered with the `[shell]` prefix.

#### Entering shell detail shows cwd / output / pid / exit code

PASS

While the first shell was running, detail view showed:

```text
Shell › bash -lc "for i in 1 2 3 4 5 6 7 8 9 10; do echo PR3720_BG_$i; sleep 2; done"
19s · pid 58511

Working dir
/private/tmp/qwen-bg-shell-e2e-pr3720

Output file
/Users/wenshao/.qwen/tmp/.../backg…
```

After it finished, reopening detail showed terminal state and exit code:

```text
✔ Completed · 20s · pid 58511 · exit 0
```

This confirms cwd, output file path, pid, and completed exit code are visible.

#### `x` cancels a shell

PASS

A second long-running shell was launched and selected in the Background tasks list. Before cancellation, the dialog hint showed `x stop` for the running selected shell:

```text
↑/↓ select · Enter view · x stop · ←/Esc close
```

After sending `x`, the selected shell stopped. Reopening its detail showed:

```text
✖ Stopped · 12s · pid 58642
```

The list hint also no longer showed `x stop` for that terminal entry.

#### Shell finish collapses pill to task done

PASS

After the first shell completed, closing the dialog showed:

```text
YOLO mode (shift + tab to cycle) · 1 task done
```

After both shell entries were terminal, footer showed:

```text
YOLO mode (shift + tab to cycle) · 2 tasks done
```

This confirms running shell counts collapse to the terminal “task(s) done” form.

#### Ctrl+T opens Background tasks dialog

BLOCKED / NOT VERIFIED

I attempted:

```bash
tmux send-keys -t qwen-pr3720-bg-shell C-t
```

The dialog did not open in the captured tmux frame. I could reliably open the Background tasks dialog via the footer pill route (`Down`, then `Enter`), but could not verify Ctrl+T opening the Background tasks dialog through tmux.

Important caveat: current code/docs still show `Ctrl+T` bound to `TOGGLE_TOOL_DESCRIPTIONS` / MCP tool description toggling, and `tmux send-keys` has known limitations for key-combo verification. Therefore I am marking the Ctrl+T-specific item as blocked/not verified from this tmux run rather than failed.

### Notes

- The model response stream produced intermittent UI text:

```text
✕ [API Error: Model stream ended with empty response text.] (Press Ctrl+Y to retry)
```

This did not block shell registration, overlay rendering, detail inspection, cancellation, or pill-state verification.
- All behavioral checks above were performed against the locally built bundle with `node dist/cli.js`.
- No source files were modified.

### Summary

| Item | Result |
| --- | --- |
| Build and bundle local PR branch | PASS |
| Background shell appears in combined Background tasks overlay | PASS |
| Pill displays running shell count | PASS |
| Shell row displays `[shell]` prefix | PASS |
| Shell detail shows cwd | PASS |
| Shell detail shows output file path | PASS |
| Shell detail shows pid | PASS |
| Completed shell detail shows exit code | PASS |
| `x` stops/cancels running shell | PASS |
| Completed/stopped shells collapse footer pill to `task(s) done` | PASS |
| Ctrl+T opens Background tasks dialog | BLOCKED / NOT VERIFIED via tmux |
