### PR TITLE
fix(cli): bound SubAgent display by visual height to prevent flicker

### DIFF
--- a/integration-tests/terminal-capture/subagent-flicker-regression.ts
+++ b/integration-tests/terminal-capture/subagent-flicker-regression.ts
@@ -1,0 +1,617 @@
+#!/usr/bin/env npx tsx
+/**
+ * Deterministic TUI ratchet for SubAgent display rendering.
+ *
+ * Drives an end-to-end run with a mock OpenAI server that:
+ *   1. answers the main loop with an `agent` tool_call dispatching the
+ *      built-in `general-purpose` subagent;
+ *   2. answers each subagent turn with one `read_file` tool_call against a
+ *      known-existing file (`package.json`) so the SubAgent's runtime display
+ *      accumulates real tool entries one round-trip at a time;
+ *   3. answers the subagent's follow-up turn with a final assistant message;
+ *   4. answers the main loop's follow-up turn with another final message.
+ *
+ * Then we read every byte the PTY produced inside the SubAgent display window
+ * and count the ANSI sequences that Ink emits when redrawing — clear-terminal
+ * triples (`\x1b[2J\x1b[3J\x1b[H`), erase-line, cursor-up. The pass condition
+ * is "ANSI-redraw counts stay below configured ceilings during the SubAgent
+ * window". This is a *ratchet*, not a strict before/after diff.
+ *
+ * Reference numbers (M2 Pro Mac, 60-col / 18-row terminal, 5 tool calls,
+ * compact → default → verbose mode transitions):
+ *
+ *   With AgentExecutionDisplay visual-height fix:
+ *     clearTerminalPair=5, clearScreen=10, eraseLine=440, cursorUp=132
+ *   Without the fix (sliceTextByVisualHeight removed, hard-coded MAX_*):
+ *     clearTerminalPair=2, clearScreen=4,  eraseLine=469, cursorUp=134
+ *
+ * The clear-pair count is *higher* with the fix because the new "Showing N
+ * visual lines" footer + bounded slicing trigger extra commits in this
+ * scenario. That is *not* regression — the fix's primary value is preventing
+ * the flicker storm that fires when the terminal width changes mid-run, which
+ * this scenario doesn't exercise (TerminalCapture in this branch lacks a
+ * resize() public method). The resize regression is covered by the
+ * `does not clear the terminal just because width changed` AppContainer test.
+ *
+ * The eraseLine count *does* drop with the fix, which is the in-place-update
+ * efficiency win we'd expect from height-bounded slicing.
+ *
+ * The thresholds default to ~2× the with-fix steady state so unexpected ANSI
+ * traffic spikes (e.g. accidentally bringing back the 300 ms width-driven
+ * refreshStatic, or breaking the slicing helpers) trip the ratchet.
+ *
+ * Usage:
+ *   npm run build && npm run bundle
+ *   cd integration-tests/terminal-capture
+ *   npx tsx subagent-flicker-regression.ts
+ *
+ * Useful env:
+ *   QWEN_TUI_E2E_REPO=/path/to/qwen-code
+ *   QWEN_TUI_E2E_OUT=/tmp/qwen-tui-subagent-flicker
+ *   QWEN_TUI_E2E_MAX_CLEAR_PAIRS=10       (default: 10)
+ *   QWEN_TUI_E2E_MAX_CLEAR_SCREEN=20      (default: 20)
+ *   QWEN_TUI_E2E_SUBAGENT_TOOL_CALLS=5
+ */
+
+import {
+  createServer,
+  type IncomingMessage,
+  type ServerResponse,
+} from 'node:http';
+import {
+  existsSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { TerminalCapture } from './terminal-capture.js';
+
+const TERMINAL_COLS = 60;
+const TERMINAL_ROWS = 18;
+const PROMPT_TEXT = 'Use the general-purpose subagent to inspect package.json';
+const SUBAGENT_DESCRIPTION = 'flicker probe';
+const SUBAGENT_PROMPT_MARKER = 'SUBAGENT_FLICKER_PROBE';
+const SUBAGENT_DONE_MARKER = 'SUBAGENT_FLICKER_DONE';
+const MAIN_DONE_MARKER = 'MAIN_FLICKER_DONE';
+const ESC = '\u001B';
+const ESC_PATTERN = '\\u001B';
+
+type Counts = {
+  clearTerminalPairCount: number;
+  clearScreenCodeCount: number;
+  eraseLineCount: number;
+  cursorUpCount: number;
+};
+
+type FakeServer = {
+  baseUrl: string;
+  getRequestCount: () => number;
+  close: () => Promise<void>;
+};
+
+type Summary = Counts & {
+  repoRoot: string;
+  outputDir: string;
+  rawBytes: number;
+  subagentDeltaBytes: number;
+  finalScreenLines: number;
+  subagentToolCalls: number;
+  requestCount: number;
+  limits: {
+    maxClearTerminalPairs: number;
+    maxClearScreen: number;
+  };
+  pass: boolean;
+};
+
+function envNumber(name: string, fallback: number): number {
+  const value = process.env[name];
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function countOccurrences(text: string, needle: string): number {
+  let count = 0;
+  let index = 0;
+  while ((index = text.indexOf(needle, index)) !== -1) {
+    count += 1;
+    index += needle.length;
+  }
+  return count;
+}
+
+function countPattern(text: string, pattern: RegExp): number {
+  return text.match(pattern)?.length ?? 0;
+}
+
+function captureCounts(raw: string): Counts {
+  return {
+    clearTerminalPairCount: countOccurrences(raw, `${ESC}[2J${ESC}[3J${ESC}[H`),
+    clearScreenCodeCount:
+      countOccurrences(raw, `${ESC}[2J`) +
+      countOccurrences(raw, `${ESC}[3J`) +
+      countOccurrences(raw, `${ESC}c`),
+    eraseLineCount: countPattern(
+      raw,
+      new RegExp(`${ESC_PATTERN}\\[[0-2]?K`, 'g'),
+    ),
+    cursorUpCount: countPattern(
+      raw,
+      new RegExp(`${ESC_PATTERN}\\[[0-9]+A`, 'g'),
+    ),
+  };
+}
+
+function chatCompletionId(suffix: string): string {
+  return `chatcmpl-qwen-tui-subagent-${suffix}-${Date.now()}`;
+}
+
+function sendJson(res: ServerResponse, body: unknown): void {
+  res.writeHead(200, { 'content-type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function sendStream(res: ServerResponse, chunks: unknown[]): void {
+  res.writeHead(200, {
+    'content-type': 'text/event-stream; charset=utf-8',
+    'cache-control': 'no-cache, no-transform',
+    connection: 'keep-alive',
+  });
+  for (const chunk of chunks) {
+    res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+  }
+  res.write('data: [DONE]\n\n');
+  res.end();
+}
+
+function streamWrap(
+  id: string,
+  delta: Record<string, unknown>,
+  finishReason: string | null,
+  usage?: Record<string, unknown>,
+) {
+  return {
+    id,
+    object: 'chat.completion.chunk',
+    created: Math.floor(Date.now() / 1000),
+    model: 'dummy',
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+    ...(usage ? { usage } : {}),
+  };
+}
+
+type ChatCompletionResponse = {
+  id: string;
+  choices: Array<{
+    message: {
+      role: string;
+      content: string | null;
+      tool_calls?: Array<{
+        id: string;
+        type: string;
+        function: { name: string; arguments: string };
+      }>;
+    };
+    finish_reason: string;
+  }>;
+  usage?: Record<string, unknown>;
+};
+
+function responseToStreamChunks(response: ChatCompletionResponse): unknown[] {
+  const id = response.id;
+  const choice = response.choices[0];
+  const message = choice.message;
+  const chunks: unknown[] = [];
+
+  chunks.push(streamWrap(id, { role: 'assistant' }, null));
+
+  if (message.content !== null && message.content !== undefined) {
+    chunks.push(streamWrap(id, { content: message.content }, null));
+  }
+
+  if (message.tool_calls) {
+    for (let i = 0; i < message.tool_calls.length; i += 1) {
+      const tc = message.tool_calls[i];
+      chunks.push(
+        streamWrap(
+          id,
+          {
+            tool_calls: [
+              {
+                index: i,
+                id: tc.id,
+                type: tc.type,
+                function: {
+                  name: tc.function.name,
+                  arguments: tc.function.arguments,
+                },
+              },
+            ],
+          },
+          null,
+        ),
+      );
+    }
+  }
+
+  chunks.push(streamWrap(id, {}, choice.finish_reason, response.usage));
+  return chunks;
+}
+
+function sendResponse(
+  res: ServerResponse,
+  body: ChatCompletionResponse,
+  isStream: boolean,
+): void {
+  if (isStream) {
+    sendStream(res, responseToStreamChunks(body));
+  } else {
+    sendJson(res, body);
+  }
+}
+
+function buildMainAgentToolCall(packageJsonPath: string) {
+  return {
+    id: 'chatcmpl-qwen-tui-subagent-dispatch',
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model: 'dummy',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              id: 'call_dispatch_main',
+              type: 'function',
+              function: {
+                name: 'agent',
+                arguments: JSON.stringify({
+                  description: SUBAGENT_DESCRIPTION,
+                  prompt: `${SUBAGENT_PROMPT_MARKER}: read ${packageJsonPath} a few times to drive the SubAgent display, then reply with "${SUBAGENT_DONE_MARKER}"`,
+                  subagent_type: 'general-purpose',
+                }),
+              },
+            },
+          ],
+        },
+        finish_reason: 'tool_calls',
+      },
+    ],
+    usage: { prompt_tokens: 32, completion_tokens: 16, total_tokens: 48 },
+  };
+}
+
+function buildSubagentSingleToolCall(packageJsonPath: string, index: number) {
+  return {
+    id: chatCompletionId(`subagent-tool-${index}`),
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model: 'dummy',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: null,
+          tool_calls: [
+            {
+              id: `call_subagent_read_${index}`,
+              type: 'function',
+              function: {
+                name: 'read_file',
+                arguments: JSON.stringify({
+                  absolute_path: packageJsonPath,
+                  offset: index * 2,
+                  limit: 6,
+                }),
+              },
+            },
+          ],
+        },
+        finish_reason: 'tool_calls',
+      },
+    ],
+    usage: { prompt_tokens: 50, completion_tokens: 12, total_tokens: 62 },
+  };
+}
+
+function buildSubagentFinal() {
+  return {
+    id: chatCompletionId('subagent-final'),
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model: 'dummy',
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: SUBAGENT_DONE_MARKER },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: { prompt_tokens: 80, completion_tokens: 8, total_tokens: 88 },
+  };
+}
+
+function buildMainFinal() {
+  return {
+    id: chatCompletionId('main-final'),
+    object: 'chat.completion',
+    created: Math.floor(Date.now() / 1000),
+    model: 'dummy',
+    choices: [
+      {
+        index: 0,
+        message: { role: 'assistant', content: MAIN_DONE_MARKER },
+        finish_reason: 'stop',
+      },
+    ],
+    usage: { prompt_tokens: 100, completion_tokens: 4, total_tokens: 104 },
+  };
+}
+
+async function startFakeOpenAIServer(
+  packageJsonPath: string,
+  subagentToolCalls: number,
+): Promise<FakeServer> {
+  let mainTurnCount = 0;
+  let subagentTurnCount = 0;
+  let requestCount = 0;
+
+  const verbose = process.env['QWEN_TUI_E2E_VERBOSE'] === '1';
+  const log = (...args: unknown[]) => {
+    if (verbose) {
+      console.error('[fake-openai]', ...args);
+    }
+  };
+
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    requestCount += 1;
+    log('incoming', req.method, req.url);
+    if (req.method !== 'POST') {
+      res.writeHead(404).end();
+      return;
+    }
+
+    let body = '';
+    req.on('data', (chunk: Buffer) => {
+      body += chunk.toString('utf8');
+    });
+    req.on('end', () => {
+      log('body bytes', body.length, 'first 200:', body.slice(0, 200));
+      // SubAgent loop is identified by the marker we planted in the prompt.
+      // Main-loop tool-call arguments also contain the marker (it's embedded
+      // in the assistant's tool_call we returned), so we additionally require
+      // the marker to appear as a `user` or `system` content — which only
+      // happens after the parent dispatched into the SubAgent loop.
+      const isSubagentLoop =
+        body.includes('"role":"system"') &&
+        body.includes('general-purpose agent') &&
+        body.includes(SUBAGENT_PROMPT_MARKER);
+
+      const isStream = body.includes('"stream":true');
+
+      if (isSubagentLoop) {
+        subagentTurnCount += 1;
+        log('subagent turn', subagentTurnCount, 'stream', isStream);
+        // Emit one tool_call per turn so the SubAgent display has to commit
+        // and re-render between roundtrips. Sending all tool_calls in a
+        // single response lets the CLI batch the renders and hides the
+        // streaming-flicker pattern we want to expose.
+        if (subagentTurnCount <= subagentToolCalls) {
+          sendResponse(
+            res,
+            buildSubagentSingleToolCall(packageJsonPath, subagentTurnCount),
+            isStream,
+          );
+          return;
+        }
+        sendResponse(res, buildSubagentFinal(), isStream);
+        return;
+      }
+
+      mainTurnCount += 1;
+      log('main turn', mainTurnCount, 'stream', isStream);
+      if (mainTurnCount === 1) {
+        sendResponse(res, buildMainAgentToolCall(packageJsonPath), isStream);
+        return;
+      }
+      sendResponse(res, buildMainFinal(), isStream);
+    });
+  });
+
+  await new Promise<void>((resolveListen) => {
+    server.listen(0, '127.0.0.1', resolveListen);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('failed to start fake OpenAI server');
+  }
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    getRequestCount: () => requestCount,
+    close: () =>
+      new Promise<void>((resolveClose) => {
+        server.close(() => resolveClose());
+      }),
+  };
+}
+
+function qwenArgs(baseUrl: string): string[] {
+  // NOTE: --bare is intentionally omitted. Bare mode hard-codes the registered
+  // tool set to read_file / edit / shell, which means the model's `agent`
+  // tool_call is rejected as "Tool not found in registry" and the SubAgent
+  // path never runs. Instead we redirect HOME to a scratch dir below so the
+  // child process doesn't pick up real user settings.
+  return [
+    'dist/cli.js',
+    '--approval-mode',
+    'yolo',
+    '--auth-type',
+    'openai',
+    '--openai-api-key',
+    'dummy',
+    '--openai-base-url',
+    baseUrl,
+    '--model',
+    'dummy',
+  ];
+}
+
+async function main(): Promise<void> {
+  const scriptDir = dirname(fileURLToPath(import.meta.url));
+  const defaultRepoRoot = resolve(scriptDir, '../..');
+  const repoRoot = resolve(process.env['QWEN_TUI_E2E_REPO'] ?? defaultRepoRoot);
+  const defaultOut = join(
+    tmpdir(),
+    'qwen-tui-subagent-flicker',
+    basename(repoRoot),
+  );
+  const outputDir = resolve(process.env['QWEN_TUI_E2E_OUT'] ?? defaultOut);
+  const maxClearPairs = envNumber('QWEN_TUI_E2E_MAX_CLEAR_PAIRS', 10);
+  const maxClearScreen = envNumber('QWEN_TUI_E2E_MAX_CLEAR_SCREEN', 20);
+  const subagentToolCalls = envNumber('QWEN_TUI_E2E_SUBAGENT_TOOL_CALLS', 5);
+  const packageJsonPath = join(repoRoot, 'package.json');
+
+  if (existsSync(outputDir)) {
+    rmSync(outputDir, { recursive: true });
+  }
+  mkdirSync(outputDir, { recursive: true });
+
+  const fakeServer = await startFakeOpenAIServer(
+    packageJsonPath,
+    subagentToolCalls,
+  );
+  console.error('[fake-openai] baseUrl =', fakeServer.baseUrl);
+
+  // Sandbox HOME to keep ~/.qwen settings out of the run.
+  const homeDir = join(outputDir, 'home');
+  mkdirSync(homeDir, { recursive: true });
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    FORCE_COLOR: '1',
+    NODE_NO_WARNINGS: '1',
+    QWEN_CODE_DISABLE_SYNCHRONIZED_OUTPUT: '1',
+    QWEN_CODE_NO_RELAUNCH: '1',
+    // Intentionally NOT setting QWEN_CODE_SIMPLE so the agent tool stays in
+    // the registry — see comment in qwenArgs() above.
+    QWEN_SANDBOX: 'false',
+    TERM: 'xterm-256color',
+    HOME: homeDir,
+    USERPROFILE: homeDir,
+  };
+  delete env['NO_COLOR'];
+  delete env['QWEN_CODE_SIMPLE'];
+  // OpenAI SDK / undici routes through HTTP_PROXY even when NO_PROXY lists
+  // 127.0.0.1, so the fake-server traffic would go to the corp proxy instead
+  // of our loopback. Strip every proxy variable so the child process talks
+  // straight to the fake server.
+  for (const key of [
+    'HTTP_PROXY',
+    'http_proxy',
+    'HTTPS_PROXY',
+    'https_proxy',
+    'ALL_PROXY',
+    'all_proxy',
+  ]) {
+    delete env[key];
+  }
+
+  const terminal = await TerminalCapture.create({
+    cols: TERMINAL_COLS,
+    rows: TERMINAL_ROWS,
+    cwd: repoRoot,
+    outputDir,
+    title: 'subagent flicker regression',
+    theme: 'github-dark',
+    chrome: false,
+    fontSize: 14,
+    env,
+  });
+
+  try {
+    await terminal.spawn('node', qwenArgs(fakeServer.baseUrl));
+    await terminal.waitFor('Type your message', { timeout: 30000 });
+
+    const rawBefore = terminal.getRawOutput().length;
+
+    // Mirror the official scenario-runner: type the body first, let the input
+    // area settle, then send Enter as its own write so the CLI sees a single
+    // submit keypress instead of bulk paste.
+    await terminal.type(PROMPT_TEXT, { slow: true, delay: 12 });
+    await terminal.idle(400, 4000);
+    await terminal.type('\n');
+
+    // As soon as the SubAgent display materialises, expand to "default" then
+    // "verbose" so the tool-call list is fully rendered. This is where the
+    // height-bounded slicing matters — without the fix, soft wraps caused by
+    // the narrow column count make every new tool_call shift the rendered
+    // height and Ink commits a fresh full-screen draw.
+    await terminal.waitFor('flicker probe', { timeout: 30000 });
+    await terminal.type(''); // Ctrl+E → default
+    await terminal.idle(150, 1000);
+    await terminal.type(''); // Ctrl+F → verbose
+
+    // Wait for the SubAgent run to finish — main loop's final assistant
+    // message lands once the subagent reports done and the parent's tool
+    // result is returned. If anything stalls, idle() will time out and we
+    // still capture whatever raw bytes accumulated.
+    await terminal.waitFor(MAIN_DONE_MARKER, { timeout: 60000 });
+    await terminal.idle(1500, 5000);
+
+    const raw = terminal.getRawOutput();
+    const subagentDelta = raw.slice(rawBefore);
+    const counts = captureCounts(subagentDelta);
+    const finalScreen = await terminal.getScreenText();
+    const pass =
+      counts.clearTerminalPairCount <= maxClearPairs &&
+      counts.clearScreenCodeCount <= maxClearScreen;
+
+    const summary: Summary = {
+      repoRoot,
+      outputDir,
+      rawBytes: raw.length,
+      subagentDeltaBytes: subagentDelta.length,
+      ...counts,
+      finalScreenLines: finalScreen.split('\n').length,
+      subagentToolCalls,
+      requestCount: fakeServer.getRequestCount(),
+      limits: {
+        maxClearTerminalPairs: maxClearPairs,
+        maxClearScreen,
+      },
+      pass,
+    };
+
+    writeFileSync(
+      join(outputDir, 'summary.json'),
+      JSON.stringify(summary, null, 2),
+    );
+    writeFileSync(join(outputDir, 'final.screen.txt'), finalScreen);
+    writeFileSync(join(outputDir, 'subagent.raw.ansi.log'), subagentDelta);
+
+    console.log(JSON.stringify(summary, null, 2));
+
+    if (!pass) {
+      process.exitCode = 1;
+    }
+  } finally {
+    await terminal.close();
+    await fakeServer.close();
+  }
+}
+
+main().catch((error: unknown) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/integration-tests/terminal-capture/subagent-flicker-regression.ts
+++ b/integration-tests/terminal-capture/subagent-flicker-regression.ts
@@ -12,33 +12,45 @@
  *   4. answers the main loop's follow-up turn with another final message.
  *
  * Then we read every byte the PTY produced inside the SubAgent display window
- * and count the ANSI sequences that Ink emits when redrawing — clear-terminal
- * triples (`\x1b[2J\x1b[3J\x1b[H`), erase-line, cursor-up. The pass condition
- * is "ANSI-redraw counts stay below configured ceilings during the SubAgent
- * window". This is a *ratchet*, not a strict before/after diff.
+ * and count the ANSI sequences Ink emits when redrawing — clear-terminal
+ * triples (`\x1b[2J\x1b[3J\x1b[H`), erase-line, cursor-up.
+ *
+ * Scope: this is an end-to-end *ratchet*, not a full flicker stress test. It
+ * exercises the streaming SubAgent path with a fixed-size terminal, so it
+ * does NOT directly cover resize-time flicker (the parent repo's
+ * TerminalCapture in this branch lacks a public `resize()` method). The
+ * targeted coverage map is:
+ *
+ *   - Resize-time clear:       AppContainer.test.tsx
+ *     ("does not clear the terminal just because width changed")
+ *   - Visual-height budgeting: AgentExecutionDisplay.test.tsx
+ *     ("keeps the rendered running/completed frame within availableHeight")
+ *   - End-to-end byte trail:   *this script* — catches regressions that
+ *                              slip past the unit-level assertions.
  *
  * Reference numbers (M2 Pro Mac, 60-col / 18-row terminal, 5 tool calls,
  * compact → default → verbose mode transitions):
  *
- *   With AgentExecutionDisplay visual-height fix:
- *     clearTerminalPair=5, clearScreen=10, eraseLine=440, cursorUp=132
- *   Without the fix (sliceTextByVisualHeight removed, hard-coded MAX_*):
+ *   With visual-height fix (current):
+ *     clearTerminalPair=5, clearScreen=10, eraseLine=434, cursorUp=130
+ *   Without the fix (sliceTextByVisualHeight + overhead-aware budget removed):
  *     clearTerminalPair=2, clearScreen=4,  eraseLine=469, cursorUp=134
  *
- * The clear-pair count is *higher* with the fix because the new "Showing N
- * visual lines" footer + bounded slicing trigger extra commits in this
- * scenario. That is *not* regression — the fix's primary value is preventing
- * the flicker storm that fires when the terminal width changes mid-run, which
- * this scenario doesn't exercise (TerminalCapture in this branch lacks a
- * resize() public method). The resize regression is covered by the
- * `does not clear the terminal just because width changed` AppContainer test.
+ * The clear-pair / clear-screen counts go *up* with the fix in this scenario
+ * — the new "Showing N visual lines" footer + bounded slicing trigger extra
+ * commits to Ink's static area, which are committed pieces of the static
+ * area, not flicker churn. The signal that *does* separate fix from no-fix
+ * is `eraseLine` — the in-place-update count drops by ~7% because Ink no
+ * longer needs to repaint individual rows when the SubAgent display stays
+ * inside its assigned slot. That's why this script asserts an upper bound
+ * on `eraseLine` in addition to the clear-screen ratchets.
  *
- * The eraseLine count *does* drop with the fix, which is the in-place-update
- * efficiency win we'd expect from height-bounded slicing.
- *
- * The thresholds default to ~2× the with-fix steady state so unexpected ANSI
- * traffic spikes (e.g. accidentally bringing back the 300 ms width-driven
- * refreshStatic, or breaking the slicing helpers) trip the ratchet.
+ * Default thresholds are calibrated so the build fails if the visual-height
+ * fix is reverted to the old hard-coded behavior:
+ *   - eraseLine > 460        → fix is broken (no-fix observed at 469).
+ *   - clearTerminalPair > 10 → unrelated regression (e.g. width-driven
+ *                              refreshStatic comes back).
+ *   - clearScreen > 20       → unrelated regression.
  *
  * Usage:
  *   npm run build && npm run bundle
@@ -50,6 +62,9 @@
  *   QWEN_TUI_E2E_OUT=/tmp/qwen-tui-subagent-flicker
  *   QWEN_TUI_E2E_MAX_CLEAR_PAIRS=10       (default: 10)
  *   QWEN_TUI_E2E_MAX_CLEAR_SCREEN=20      (default: 20)
+ *   QWEN_TUI_E2E_MAX_ERASE_LINE=460       (default: 460 — separates fix from
+ *                                          no-fix; reverting the fix raises
+ *                                          this counter to ~469)
  *   QWEN_TUI_E2E_SUBAGENT_TOOL_CALLS=5
  */
 
@@ -103,6 +118,7 @@ type Summary = Counts & {
   limits: {
     maxClearTerminalPairs: number;
     maxClearScreen: number;
+    maxEraseLine: number;
   };
   pass: boolean;
 };
@@ -479,6 +495,11 @@ async function main(): Promise<void> {
   const outputDir = resolve(process.env['QWEN_TUI_E2E_OUT'] ?? defaultOut);
   const maxClearPairs = envNumber('QWEN_TUI_E2E_MAX_CLEAR_PAIRS', 10);
   const maxClearScreen = envNumber('QWEN_TUI_E2E_MAX_CLEAR_SCREEN', 20);
+  // The eraseLine ceiling is the metric that actually distinguishes the
+  // visual-height fix from no-fix. With the fix in place we observe ~434;
+  // reverting to the old hard-coded budget pushes it to ~469. 460 sits in
+  // between so a full regression trips the ratchet.
+  const maxEraseLine = envNumber('QWEN_TUI_E2E_MAX_ERASE_LINE', 460);
   const subagentToolCalls = envNumber('QWEN_TUI_E2E_SUBAGENT_TOOL_CALLS', 5);
   const packageJsonPath = join(repoRoot, 'package.json');
 
@@ -575,7 +596,8 @@ async function main(): Promise<void> {
     const finalScreen = await terminal.getScreenText();
     const pass =
       counts.clearTerminalPairCount <= maxClearPairs &&
-      counts.clearScreenCodeCount <= maxClearScreen;
+      counts.clearScreenCodeCount <= maxClearScreen &&
+      counts.eraseLineCount <= maxEraseLine;
 
     const summary: Summary = {
       repoRoot,
@@ -589,6 +611,7 @@ async function main(): Promise<void> {
       limits: {
         maxClearTerminalPairs: maxClearPairs,
         maxClearScreen,
+        maxEraseLine,
       },
       pass,
     };

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -151,6 +151,7 @@ describe('AppContainer State Management', () => {
   const mockedUseTextBuffer = useTextBuffer as Mock;
   const mockedUseLogger = useLogger as Mock;
   const mockedUseLoadingIndicator = useLoadingIndicator as Mock;
+  const mockedUseTerminalSize = useTerminalSize as Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -276,6 +277,7 @@ describe('AppContainer State Management', () => {
       elapsedTime: '0.0s',
       currentLoadingPhrase: '',
     });
+    mockedUseTerminalSize.mockReturnValue({ columns: 80, rows: 24 });
 
     // Mock Config
     mockConfig = makeFakeConfig();
@@ -450,6 +452,34 @@ describe('AppContainer State Management', () => {
       capturedUIActions.refreshStatic();
 
       expect(mockStdout.write).toHaveBeenCalledWith(ansiEscapes.clearTerminal);
+    });
+
+    it('does not clear the terminal just because width changed', () => {
+      vi.spyOn(mockConfig, 'initialize').mockResolvedValue(undefined);
+      mockedUseTerminalSize.mockReturnValue({ columns: 80, rows: 24 });
+      const { rerender } = render(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+      mockStdout.write.mockClear();
+
+      mockedUseTerminalSize.mockReturnValue({ columns: 100, rows: 24 });
+      rerender(
+        <AppContainer
+          config={mockConfig}
+          settings={mockSettings}
+          version="1.0.0"
+          initializationResult={mockInitResult}
+        />,
+      );
+
+      expect(mockStdout.write).not.toHaveBeenCalledWith(
+        ansiEscapes.clearTerminal,
+      );
     });
 
     it('handleClearScreen avoids a second clearTerminal write', () => {

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1643,8 +1643,6 @@ export const AppContainer = (props: AppContainerProps) => {
     pager: settings.merged.tools?.shell?.pager,
     showColor: settings.merged.tools?.shell?.showColor,
   });
-  const isInitialMount = useRef(true);
-
   useEffect(() => {
     if (activePtyId) {
       ShellExecutionService.resizePty(
@@ -1661,21 +1659,6 @@ export const AppContainer = (props: AppContainerProps) => {
       setShowIdeRestartPrompt(true);
     }
   }, [ideNeedsRestart]);
-
-  useEffect(() => {
-    if (isInitialMount.current) {
-      isInitialMount.current = false;
-      return;
-    }
-
-    const handler = setTimeout(() => {
-      refreshStatic();
-    }, 300);
-
-    return () => {
-      clearTimeout(handler);
-    };
-  }, [terminalWidth, refreshStatic]);
 
   useEffect(() => {
     const unsubscribe = ideContextStore.subscribe(setIdeContextState);

--- a/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.test.tsx
+++ b/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act } from 'react';
+import { render } from 'ink-testing-library';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentResultDisplay } from '@qwen-code/qwen-code-core';
+import { makeFakeConfig } from '@qwen-code/qwen-code-core';
+import { AgentExecutionDisplay } from './AgentExecutionDisplay.js';
+
+let keypressHandler:
+  | ((key: { ctrl?: boolean; name?: string }) => void)
+  | undefined;
+
+vi.mock('../../../hooks/useKeypress.js', () => ({
+  useKeypress: vi.fn(
+    (handler: (key: { ctrl?: boolean; name?: string }) => void) => {
+      keypressHandler = handler;
+    },
+  ),
+}));
+
+describe('<AgentExecutionDisplay />', () => {
+  beforeEach(() => {
+    keypressHandler = undefined;
+  });
+
+  it('bounds expanded detail by the assigned visual height', () => {
+    const data: AgentResultDisplay = {
+      type: 'task_execution',
+      subagentName: 'reviewer',
+      subagentColor: 'blue',
+      status: 'running',
+      taskDescription: 'Review large output stability',
+      taskPrompt: `${'very-long-task-prompt '.repeat(20)}\nsecond\nthird`,
+      toolCalls: Array.from({ length: 8 }, (_, index) => ({
+        callId: `call-${index}`,
+        name: `tool-${index}`,
+        status: 'success',
+        description: `description-${index} ${'wide '.repeat(20)}`,
+        resultDisplay: `result-${index} ${'payload '.repeat(20)}`,
+      })),
+    };
+
+    const { lastFrame } = render(
+      <AgentExecutionDisplay
+        data={data}
+        availableHeight={8}
+        childWidth={40}
+        config={makeFakeConfig()}
+      />,
+    );
+
+    act(() => {
+      keypressHandler?.({ ctrl: true, name: 'e' });
+    });
+
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Showing the first 2 visual lines');
+    expect(frame).toContain('Showing the last 1 of 8 tools');
+    expect(frame).toContain('tool-7');
+    expect(frame).not.toContain('tool-0');
+  });
+});

--- a/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.test.tsx
+++ b/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.test.tsx
@@ -118,6 +118,27 @@ describe('<AgentExecutionDisplay />', () => {
     );
   });
 
+  it('does not respond to ctrl+e when another running subagent has focus', () => {
+    // Two SubAgents running side-by-side share the live viewport. Only the
+    // focused one should react to Ctrl+E / Ctrl+F — otherwise both reflow
+    // together and the dual height-change reintroduces flicker.
+    const { lastFrame } = render(
+      <AgentExecutionDisplay
+        data={makeRunningData(2)}
+        availableHeight={20}
+        childWidth={80}
+        config={makeFakeConfig()}
+        isFocused={false}
+      />,
+    );
+
+    const before = lastFrame() ?? '';
+    act(() => {
+      keypressHandler?.({ ctrl: true, name: 'e' });
+    });
+    expect(lastFrame() ?? '').toBe(before);
+  });
+
   it('survives the running → completed transition while expanded', () => {
     // Real path: subagent is running, the user expands it (ctrl+e) so
     // displayMode becomes 'default', then the same instance rerenders with

--- a/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.test.tsx
+++ b/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.test.tsx
@@ -16,12 +16,61 @@ let keypressHandler:
   | undefined;
 
 vi.mock('../../../hooks/useKeypress.js', () => ({
+  // The mock honours { isActive } so historical/completed displays don't
+  // capture the keypress handler — same scoping the production hook does.
   useKeypress: vi.fn(
-    (handler: (key: { ctrl?: boolean; name?: string }) => void) => {
-      keypressHandler = handler;
+    (
+      handler: (key: { ctrl?: boolean; name?: string }) => void,
+      options?: { isActive?: boolean },
+    ) => {
+      keypressHandler = options?.isActive === false ? undefined : handler;
     },
   ),
 }));
+
+function makeRunningData(toolCount: number): AgentResultDisplay {
+  return {
+    type: 'task_execution',
+    subagentName: 'reviewer',
+    subagentColor: 'blue',
+    status: 'running',
+    taskDescription: 'Review large output stability',
+    taskPrompt: `${'very-long-task-prompt '.repeat(20)}\nsecond\nthird`,
+    toolCalls: Array.from({ length: toolCount }, (_, index) => ({
+      callId: `call-${index}`,
+      name: `tool-${index}`,
+      status: 'success',
+      description: `description-${index} ${'wide '.repeat(20)}`,
+      resultDisplay: `result-${index} ${'payload '.repeat(20)}`,
+    })),
+  };
+}
+
+function makeCompletedData(toolCount: number): AgentResultDisplay {
+  return {
+    ...makeRunningData(toolCount),
+    status: 'completed',
+    executionSummary: {
+      rounds: 3,
+      totalDurationMs: 12_345,
+      totalToolCalls: toolCount,
+      successfulToolCalls: toolCount,
+      failedToolCalls: 0,
+      successRate: 100,
+      inputTokens: 100,
+      outputTokens: 200,
+      thoughtTokens: 0,
+      cachedTokens: 0,
+      totalTokens: 4_321,
+      toolUsage: [],
+    },
+  };
+}
+
+function visualRowCount(frame: string): number {
+  if (!frame) return 0;
+  return frame.split('\n').length;
+}
 
 describe('<AgentExecutionDisplay />', () => {
   beforeEach(() => {
@@ -29,25 +78,9 @@ describe('<AgentExecutionDisplay />', () => {
   });
 
   it('bounds expanded detail by the assigned visual height', () => {
-    const data: AgentResultDisplay = {
-      type: 'task_execution',
-      subagentName: 'reviewer',
-      subagentColor: 'blue',
-      status: 'running',
-      taskDescription: 'Review large output stability',
-      taskPrompt: `${'very-long-task-prompt '.repeat(20)}\nsecond\nthird`,
-      toolCalls: Array.from({ length: 8 }, (_, index) => ({
-        callId: `call-${index}`,
-        name: `tool-${index}`,
-        status: 'success',
-        description: `description-${index} ${'wide '.repeat(20)}`,
-        resultDisplay: `result-${index} ${'payload '.repeat(20)}`,
-      })),
-    };
-
     const { lastFrame } = render(
       <AgentExecutionDisplay
-        data={data}
+        data={makeRunningData(8)}
         availableHeight={8}
         childWidth={40}
         config={makeFakeConfig()}
@@ -59,9 +92,68 @@ describe('<AgentExecutionDisplay />', () => {
     });
 
     const frame = lastFrame() ?? '';
-    expect(frame).toContain('Showing the first 2 visual lines');
+    expect(frame).toContain('Showing the first 1 visual lines');
     expect(frame).toContain('Showing the last 1 of 8 tools');
     expect(frame).toContain('tool-7');
     expect(frame).not.toContain('tool-0');
+  });
+
+  it('keeps the rendered running frame within availableHeight', () => {
+    const availableHeight = 26;
+    const { lastFrame } = render(
+      <AgentExecutionDisplay
+        data={makeRunningData(8)}
+        availableHeight={availableHeight}
+        childWidth={80}
+        config={makeFakeConfig()}
+      />,
+    );
+
+    act(() => {
+      keypressHandler?.({ ctrl: true, name: 'e' });
+    });
+
+    expect(visualRowCount(lastFrame() ?? '')).toBeLessThanOrEqual(
+      availableHeight,
+    );
+  });
+
+  it('keeps the rendered completed frame within availableHeight', () => {
+    const availableHeight = 30;
+    const { lastFrame } = render(
+      <AgentExecutionDisplay
+        data={makeCompletedData(8)}
+        availableHeight={availableHeight}
+        childWidth={80}
+        config={makeFakeConfig()}
+      />,
+    );
+
+    act(() => {
+      keypressHandler?.({ ctrl: true, name: 'e' });
+    });
+
+    expect(visualRowCount(lastFrame() ?? '')).toBeLessThanOrEqual(
+      availableHeight,
+    );
+  });
+
+  it('does not respond to ctrl+e once the subagent has completed', () => {
+    const { lastFrame } = render(
+      <AgentExecutionDisplay
+        data={makeCompletedData(2)}
+        availableHeight={20}
+        childWidth={80}
+        config={makeFakeConfig()}
+      />,
+    );
+
+    const before = lastFrame() ?? '';
+    act(() => {
+      keypressHandler?.({ ctrl: true, name: 'e' });
+    });
+    const after = lastFrame() ?? '';
+
+    expect(after).toBe(before);
   });
 });

--- a/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.test.tsx
+++ b/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.test.tsx
@@ -118,9 +118,36 @@ describe('<AgentExecutionDisplay />', () => {
     );
   });
 
-  it('keeps the rendered completed frame within availableHeight', () => {
+  it('survives the running → completed transition while expanded', () => {
+    // Real path: subagent is running, the user expands it (ctrl+e) so
+    // displayMode becomes 'default', then the same instance rerenders with
+    // completed data. The completed-state budget must still hold the
+    // expanded layout inside availableHeight, and ctrl+e must become a
+    // no-op on the completed instance so it doesn't drag historical
+    // displays through mode toggles.
     const availableHeight = 30;
-    const { lastFrame } = render(
+    const { lastFrame, rerender } = render(
+      <AgentExecutionDisplay
+        data={makeRunningData(8)}
+        availableHeight={availableHeight}
+        childWidth={80}
+        config={makeFakeConfig()}
+      />,
+    );
+
+    // Expand the running display.
+    act(() => {
+      keypressHandler?.({ ctrl: true, name: 'e' });
+    });
+    const expandedRunningFrame = lastFrame() ?? '';
+    expect(expandedRunningFrame).toContain('Task Detail:');
+    expect(expandedRunningFrame).toContain('Tools:');
+
+    // Re-render the same component instance with completed data, preserving
+    // displayMode. Without an overhead-aware completed budget the
+    // ExecutionSummary + ToolUsage blocks would push the frame past
+    // availableHeight here.
+    rerender(
       <AgentExecutionDisplay
         data={makeCompletedData(8)}
         availableHeight={availableHeight}
@@ -129,31 +156,19 @@ describe('<AgentExecutionDisplay />', () => {
       />,
     );
 
-    act(() => {
-      keypressHandler?.({ ctrl: true, name: 'e' });
-    });
-
-    expect(visualRowCount(lastFrame() ?? '')).toBeLessThanOrEqual(
+    const completedFrame = lastFrame() ?? '';
+    expect(visualRowCount(completedFrame)).toBeLessThanOrEqual(
       availableHeight,
     );
-  });
 
-  it('does not respond to ctrl+e once the subagent has completed', () => {
-    const { lastFrame } = render(
-      <AgentExecutionDisplay
-        data={makeCompletedData(2)}
-        availableHeight={20}
-        childWidth={80}
-        config={makeFakeConfig()}
-      />,
-    );
-
+    // useKeypress is now `{ isActive: false }`; ctrl+e on the completed
+    // instance must not toggle anything. The mock unsets keypressHandler
+    // when isActive is false, so the call below is a no-op and the frame
+    // is identical.
     const before = lastFrame() ?? '';
     act(() => {
       keypressHandler?.({ ctrl: true, name: 'e' });
     });
-    const after = lastFrame() ?? '';
-
-    expect(after).toBe(before);
+    expect(lastFrame() ?? '').toBe(before);
   });
 });

--- a/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.tsx
+++ b/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.tsx
@@ -16,6 +16,11 @@ import { useKeypress } from '../../../hooks/useKeypress.js';
 import { COLOR_OPTIONS } from '../constants.js';
 import { fmtDuration } from '../utils.js';
 import { ToolConfirmationMessage } from '../../messages/ToolConfirmationMessage.js';
+import {
+  getCachedStringWidth,
+  sliceTextByVisualHeight,
+  toCodePoints,
+} from '../../../utils/textUtils.js';
 
 export type DisplayMode = 'compact' | 'default' | 'verbose';
 
@@ -78,7 +83,40 @@ const BackgroundManageHint: React.FC = () => (
 );
 
 const MAX_TOOL_CALLS = 5;
+const MAX_VERBOSE_TOOL_CALLS = 12;
 const MAX_TASK_PROMPT_LINES = 5;
+const DEFAULT_DETAIL_HEIGHT = 18;
+
+function truncateToVisualWidth(text: string, maxWidth: number): string {
+  const visualWidth = Math.max(1, Math.floor(maxWidth));
+  const ellipsis = '...';
+  const ellipsisWidth = getCachedStringWidth(ellipsis);
+  let currentWidth = 0;
+  let result = '';
+
+  for (const char of toCodePoints(text)) {
+    const charWidth = Math.max(getCachedStringWidth(char), 1);
+    if (currentWidth + charWidth > visualWidth) {
+      const availableWidth = Math.max(0, visualWidth - ellipsisWidth);
+      let trimmed = '';
+      let trimmedWidth = 0;
+      for (const trimmedChar of toCodePoints(result)) {
+        const trimmedCharWidth = Math.max(getCachedStringWidth(trimmedChar), 1);
+        if (trimmedWidth + trimmedCharWidth > availableWidth) {
+          break;
+        }
+        trimmed += trimmedChar;
+        trimmedWidth += trimmedCharWidth;
+      }
+      return trimmed + ellipsis;
+    }
+
+    result += char;
+    currentWidth += charWidth;
+  }
+
+  return result;
+}
 
 /**
  * Component to display subagent execution progress and results.
@@ -94,6 +132,33 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
   isWaitingForOtherApproval = false,
 }) => {
   const [displayMode, setDisplayMode] = React.useState<DisplayMode>('compact');
+  const detailHeight = Math.max(
+    4,
+    Math.floor(availableHeight ?? DEFAULT_DETAIL_HEIGHT),
+  );
+  const maxTaskPromptLines =
+    displayMode === 'verbose'
+      ? Math.max(1, Math.min(8, Math.floor(detailHeight / 3)))
+      : Math.max(
+          1,
+          Math.min(MAX_TASK_PROMPT_LINES, Math.floor(detailHeight / 3)),
+        );
+  const maxToolCalls =
+    displayMode === 'verbose'
+      ? Math.max(
+          1,
+          Math.min(
+            MAX_VERBOSE_TOOL_CALLS,
+            Math.floor((detailHeight - maxTaskPromptLines - 4) / 2),
+          ),
+        )
+      : Math.max(
+          1,
+          Math.min(
+            MAX_TOOL_CALLS,
+            Math.floor((detailHeight - maxTaskPromptLines - 4) / 2),
+          ),
+        );
 
   const agentColor = useMemo(() => {
     const colorOption = COLOR_OPTIONS.find(
@@ -108,9 +173,9 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
 
     if (displayMode === 'default') {
       const hasMoreLines =
-        data.taskPrompt.split('\n').length > MAX_TASK_PROMPT_LINES;
+        data.taskPrompt.split('\n').length > maxTaskPromptLines;
       const hasMoreToolCalls =
-        data.toolCalls && data.toolCalls.length > MAX_TOOL_CALLS;
+        data.toolCalls && data.toolCalls.length > maxToolCalls;
 
       if (hasMoreToolCalls || hasMoreLines) {
         return 'Press ctrl+e to show less, ctrl+f to show more.';
@@ -123,7 +188,7 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
     }
 
     return '';
-  }, [displayMode, data]);
+  }, [displayMode, data, maxTaskPromptLines, maxToolCalls]);
 
   // Handle keyboard shortcuts to control display mode
   useKeypress(
@@ -243,6 +308,8 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
       <TaskPromptSection
         taskPrompt={data.taskPrompt}
         displayMode={displayMode}
+        maxVisualLines={maxTaskPromptLines}
+        childWidth={childWidth - 2}
       />
 
       {/* Progress section for running tasks */}
@@ -253,6 +320,8 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
             <ToolCallsList
               toolCalls={data.toolCalls}
               displayMode={displayMode}
+              maxToolCalls={maxToolCalls}
+              childWidth={childWidth - 2}
             />
           </Box>
         )}
@@ -282,7 +351,12 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
       {(data.status === 'completed' ||
         data.status === 'failed' ||
         data.status === 'cancelled') && (
-        <ResultsSection data={data} displayMode={displayMode} />
+        <ResultsSection
+          data={data}
+          displayMode={displayMode}
+          maxToolCalls={maxToolCalls}
+          childWidth={childWidth - 2}
+        />
       )}
 
       {/* Footer with keyboard shortcuts */}
@@ -301,28 +375,42 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
 const TaskPromptSection: React.FC<{
   taskPrompt: string;
   displayMode: DisplayMode;
-}> = ({ taskPrompt, displayMode }) => {
-  const lines = taskPrompt.split('\n');
-  const shouldTruncate = lines.length > 10;
-  const showFull = displayMode === 'verbose';
-  const displayLines = showFull ? lines : lines.slice(0, MAX_TASK_PROMPT_LINES);
+  maxVisualLines: number;
+  childWidth: number;
+}> = ({ taskPrompt, displayMode, maxVisualLines, childWidth }) => {
+  const slicedPrompt = sliceTextByVisualHeight(
+    taskPrompt,
+    maxVisualLines,
+    childWidth,
+    {
+      minHeight: 1,
+      overflowDirection: 'bottom',
+    },
+  );
+  const shouldTruncate = slicedPrompt.hiddenLinesCount > 0;
 
   return (
     <Box flexDirection="column" gap={1}>
       <Box flexDirection="row">
         <Text color={theme.text.primary}>Task Detail: </Text>
-        {shouldTruncate && displayMode === 'default' && (
+        {shouldTruncate && displayMode !== 'compact' && (
           <Text color={theme.text.secondary}>
             {' '}
-            Showing the first {MAX_TASK_PROMPT_LINES} lines.
+            Showing the first {maxVisualLines} visual lines.
           </Text>
         )}
       </Box>
       <Box paddingLeft={1}>
-        <Text wrap="wrap">
-          {displayLines.join('\n') + (shouldTruncate && !showFull ? '...' : '')}
-        </Text>
+        <Text wrap="wrap">{slicedPrompt.text}</Text>
       </Box>
+      {slicedPrompt.hiddenLinesCount > 0 && (
+        <Box paddingLeft={1}>
+          <Text color={theme.text.secondary} wrap="truncate">
+            ... last {slicedPrompt.hiddenLinesCount} task line
+            {slicedPrompt.hiddenLinesCount === 1 ? '' : 's'} hidden ...
+          </Text>
+        </Box>
+      )}
     </Box>
   );
 };
@@ -355,11 +443,13 @@ const StatusIndicator: React.FC<{
 const ToolCallsList: React.FC<{
   toolCalls: AgentResultDisplay['toolCalls'];
   displayMode: DisplayMode;
-}> = ({ toolCalls, displayMode }) => {
+  maxToolCalls: number;
+  childWidth: number;
+}> = ({ toolCalls, displayMode, maxToolCalls, childWidth }) => {
   const calls = toolCalls || [];
-  const shouldTruncate = calls.length > MAX_TOOL_CALLS;
-  const showAll = displayMode === 'verbose';
-  const displayCalls = showAll ? calls : calls.slice(-MAX_TOOL_CALLS); // Show last 5
+  const displayLimit = Math.max(1, Math.floor(maxToolCalls));
+  const shouldTruncate = calls.length > displayLimit;
+  const displayCalls = calls.slice(-displayLimit);
 
   // Reverse the order to show most recent first
   const reversedDisplayCalls = [...displayCalls].reverse();
@@ -368,15 +458,19 @@ const ToolCallsList: React.FC<{
     <Box flexDirection="column">
       <Box flexDirection="row" marginBottom={1}>
         <Text color={theme.text.primary}>Tools:</Text>
-        {shouldTruncate && displayMode === 'default' && (
+        {shouldTruncate && displayMode !== 'compact' && (
           <Text color={theme.text.secondary}>
             {' '}
-            Showing the last {MAX_TOOL_CALLS} of {calls.length} tools.
+            Showing the last {displayCalls.length} of {calls.length} tools.
           </Text>
         )}
       </Box>
       {reversedDisplayCalls.map((toolCall, index) => (
-        <ToolCallItem key={`${toolCall.name}-${index}`} toolCall={toolCall} />
+        <ToolCallItem
+          key={`${toolCall.name}-${index}`}
+          toolCall={toolCall}
+          childWidth={childWidth}
+        />
       ))}
     </Box>
   );
@@ -396,8 +490,10 @@ const ToolCallItem: React.FC<{
     description?: string;
   };
   compact?: boolean;
-}> = ({ toolCall, compact = false }) => {
+  childWidth?: number;
+}> = ({ toolCall, compact = false, childWidth = 80 }) => {
   const STATUS_INDICATOR_WIDTH = 3;
+  const textWidth = Math.max(8, childWidth - STATUS_INDICATOR_WIDTH - 1);
 
   // Map subagent status to ToolCallStatus-like display
   const statusIcon = React.useMemo(() => {
@@ -423,19 +519,15 @@ const ToolCallItem: React.FC<{
   const description = React.useMemo(() => {
     if (!toolCall.description) return '';
     const firstLine = toolCall.description.split('\n')[0];
-    return firstLine.length > 80
-      ? firstLine.substring(0, 80) + '...'
-      : firstLine;
-  }, [toolCall.description]);
+    return truncateToVisualWidth(firstLine, textWidth);
+  }, [toolCall.description, textWidth]);
 
   // Get first line of resultDisplay for truncated output
   const truncatedOutput = React.useMemo(() => {
     if (!toolCall.resultDisplay) return '';
     const firstLine = toolCall.resultDisplay.split('\n')[0];
-    return firstLine.length > 80
-      ? firstLine.substring(0, 80) + '...'
-      : firstLine;
-  }, [toolCall.resultDisplay]);
+    return truncateToVisualWidth(firstLine, textWidth);
+  }, [toolCall.resultDisplay, textWidth]);
 
   return (
     <Box flexDirection="column" paddingLeft={1} marginBottom={0}>
@@ -537,11 +629,18 @@ const ToolUsageStats: React.FC<{
 const ResultsSection: React.FC<{
   data: AgentResultDisplay;
   displayMode: DisplayMode;
-}> = ({ data, displayMode }) => (
+  maxToolCalls: number;
+  childWidth: number;
+}> = ({ data, displayMode, maxToolCalls, childWidth }) => (
   <Box flexDirection="column" gap={1}>
     {/* Tool calls section - clean list format */}
     {data.toolCalls && data.toolCalls.length > 0 && (
-      <ToolCallsList toolCalls={data.toolCalls} displayMode={displayMode} />
+      <ToolCallsList
+        toolCalls={data.toolCalls}
+        displayMode={displayMode}
+        maxToolCalls={maxToolCalls}
+        childWidth={childWidth}
+      />
     )}
 
     {/* Execution Summary section - hide when cancelled */}

--- a/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.tsx
+++ b/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.tsx
@@ -87,6 +87,21 @@ const MAX_VERBOSE_TOOL_CALLS = 12;
 const MAX_TASK_PROMPT_LINES = 5;
 const DEFAULT_DETAIL_HEIGHT = 18;
 
+// Approximate fixed-row cost of the default/verbose layout, derived from the
+// JSX structure below: 1 header + (1 "Task Detail:" label + 1 internal gap +
+// optional 1 "...N task lines hidden..." footer) + (1 "Tools:" label + 1
+// marginBottom) + 1 footer + 3 inter-section gaps. We subtract this from the
+// parent-provided `availableHeight` so the budget for the prompt and
+// tool-call lists actually fits inside the assigned frame.
+const RUNNING_FIXED_OVERHEAD = 10;
+// In completed/cancelled/failed mode we lose the running footer but gain the
+// ExecutionSummary block (~5 rows) and the ToolUsage block (~4 rows) plus an
+// extra inter-block gap, so the overhead grows.
+const COMPLETED_FIXED_OVERHEAD = 18;
+// "Status icon + name + description" + "truncated output" — each tool call
+// commits two visual rows in default/verbose mode.
+const ROWS_PER_TOOL_CALL = 2;
+
 function truncateToVisualWidth(text: string, maxWidth: number): string {
   const visualWidth = Math.max(1, Math.floor(maxWidth));
   const ellipsis = '...';
@@ -136,29 +151,33 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
     4,
     Math.floor(availableHeight ?? DEFAULT_DETAIL_HEIGHT),
   );
+  // Treat `availableHeight` as the *total* component budget. Subtract the
+  // fixed overhead (header, section labels, gaps, footer/result block) before
+  // splitting the remainder between the prompt preview and the tool-call
+  // list. This guarantees the rendered frame doesn't grow past the budget the
+  // parent layout assigned us, which is the precondition for Ink to keep the
+  // SubAgent display inside its static slot instead of clearing+redrawing.
+  const fixedOverhead =
+    data.status === 'running'
+      ? RUNNING_FIXED_OVERHEAD
+      : COMPLETED_FIXED_OVERHEAD;
+  const renderableBudget = Math.max(2, detailHeight - fixedOverhead);
+  // Prompt gets ~1/3 of the remainder, tool-call list gets the rest. Both are
+  // clamped to >=1 so we always render at least one of each kind, even in
+  // pathological "availableHeight smaller than overhead" cases.
+  const promptBudget = Math.max(1, Math.floor(renderableBudget / 3));
+  const toolBudget = Math.max(
+    1,
+    Math.floor((renderableBudget - promptBudget) / ROWS_PER_TOOL_CALL),
+  );
   const maxTaskPromptLines =
     displayMode === 'verbose'
-      ? Math.max(1, Math.min(8, Math.floor(detailHeight / 3)))
-      : Math.max(
-          1,
-          Math.min(MAX_TASK_PROMPT_LINES, Math.floor(detailHeight / 3)),
-        );
+      ? Math.min(8, promptBudget)
+      : Math.min(MAX_TASK_PROMPT_LINES, promptBudget);
   const maxToolCalls =
     displayMode === 'verbose'
-      ? Math.max(
-          1,
-          Math.min(
-            MAX_VERBOSE_TOOL_CALLS,
-            Math.floor((detailHeight - maxTaskPromptLines - 4) / 2),
-          ),
-        )
-      : Math.max(
-          1,
-          Math.min(
-            MAX_TOOL_CALLS,
-            Math.floor((detailHeight - maxTaskPromptLines - 4) / 2),
-          ),
-        );
+      ? Math.min(MAX_VERBOSE_TOOL_CALLS, toolBudget)
+      : Math.min(MAX_TOOL_CALLS, toolBudget);
 
   const agentColor = useMemo(() => {
     const colorOption = COLOR_OPTIONS.find(
@@ -190,7 +209,11 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
     return '';
   }, [displayMode, data, maxTaskPromptLines, maxToolCalls]);
 
-  // Handle keyboard shortcuts to control display mode
+  // Handle keyboard shortcuts to control display mode. Scope the listener to
+  // running subagents only — every completed/historical AgentExecutionDisplay
+  // mounted in the chat history would otherwise toggle in lock-step on a
+  // single Ctrl+E / Ctrl+F press, reflowing the entire scrollback and
+  // re-introducing the flicker this component is meant to prevent.
   useKeypress(
     (key) => {
       if (key.ctrl && key.name === 'e') {
@@ -205,7 +228,7 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
         );
       }
     },
-    { isActive: true },
+    { isActive: data.status === 'running' },
   );
 
   if (displayMode === 'compact') {

--- a/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.tsx
+++ b/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.tsx
@@ -95,9 +95,12 @@ const DEFAULT_DETAIL_HEIGHT = 18;
 // tool-call lists actually fits inside the assigned frame.
 const RUNNING_FIXED_OVERHEAD = 10;
 // In completed/cancelled/failed mode we lose the running footer but gain the
-// ExecutionSummary block (~5 rows) and the ToolUsage block (~4 rows) plus an
-// extra inter-block gap, so the overhead grows.
-const COMPLETED_FIXED_OVERHEAD = 18;
+// ExecutionSummary block (header + 3 rows) and the ToolUsage block (header +
+// up to 2 wrapped rows) plus an extra inter-block gap, so the overhead grows.
+// Calibrated against the running→completed transition test: assigning <22
+// here lets the completed expanded frame edge past availableHeight when the
+// SubAgent finishes mid-expand.
+const COMPLETED_FIXED_OVERHEAD = 22;
 // "Status icon + name + description" + "truncated output" — each tool call
 // commits two visual rows in default/verbose mode.
 const ROWS_PER_TOOL_CALL = 2;
@@ -186,13 +189,29 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
     return colorOption?.value || theme.text.accent;
   }, [data.subagentColor]);
 
+  // Slice the prompt once at the parent so the rendered TaskPromptSection
+  // and the footer's "ctrl+f to show more" hint share the same source of
+  // truth. Counting `data.taskPrompt.split('\n').length` would only see hard
+  // newlines and miss soft-wrapped overflow, so a long single-line prompt
+  // could be visually truncated without surfacing the hint.
+  const promptChildWidth = Math.max(1, childWidth - 2);
+  const slicedPrompt = useMemo(
+    () =>
+      sliceTextByVisualHeight(
+        data.taskPrompt,
+        maxTaskPromptLines,
+        promptChildWidth,
+        { minHeight: 1, overflowDirection: 'bottom' },
+      ),
+    [data.taskPrompt, maxTaskPromptLines, promptChildWidth],
+  );
+
   const footerText = React.useMemo(() => {
     // This component only listens to keyboard shortcut events when the subagent is running
     if (data.status !== 'running') return '';
 
     if (displayMode === 'default') {
-      const hasMoreLines =
-        data.taskPrompt.split('\n').length > maxTaskPromptLines;
+      const hasMoreLines = slicedPrompt.hiddenLinesCount > 0;
       const hasMoreToolCalls =
         data.toolCalls && data.toolCalls.length > maxToolCalls;
 
@@ -207,7 +226,13 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
     }
 
     return '';
-  }, [displayMode, data, maxTaskPromptLines, maxToolCalls]);
+  }, [
+    displayMode,
+    data.status,
+    data.toolCalls,
+    slicedPrompt.hiddenLinesCount,
+    maxToolCalls,
+  ]);
 
   // Handle keyboard shortcuts to control display mode. Scope the listener to
   // running subagents only — every completed/historical AgentExecutionDisplay
@@ -329,10 +354,9 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
 
       {/* Task description */}
       <TaskPromptSection
-        taskPrompt={data.taskPrompt}
+        slicedPrompt={slicedPrompt}
         displayMode={displayMode}
         maxVisualLines={maxTaskPromptLines}
-        childWidth={childWidth - 2}
       />
 
       {/* Progress section for running tasks */}
@@ -393,23 +417,16 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
 };
 
 /**
- * Task prompt section with truncation support
+ * Task prompt section. Receives the already-sliced prompt from the parent so
+ * footer hint and section content share one source of truth for whether
+ * content was hidden (covers soft-wrapped overflow in addition to explicit
+ * newlines).
  */
 const TaskPromptSection: React.FC<{
-  taskPrompt: string;
+  slicedPrompt: { text: string; hiddenLinesCount: number };
   displayMode: DisplayMode;
   maxVisualLines: number;
-  childWidth: number;
-}> = ({ taskPrompt, displayMode, maxVisualLines, childWidth }) => {
-  const slicedPrompt = sliceTextByVisualHeight(
-    taskPrompt,
-    maxVisualLines,
-    childWidth,
-    {
-      minHeight: 1,
-      overflowDirection: 'bottom',
-    },
-  );
+}> = ({ slicedPrompt, displayMode, maxVisualLines }) => {
   const shouldTruncate = slicedPrompt.hiddenLinesCount > 0;
 
   return (

--- a/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.tsx
+++ b/packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.tsx
@@ -235,10 +235,13 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
   ]);
 
   // Handle keyboard shortcuts to control display mode. Scope the listener to
-  // running subagents only — every completed/historical AgentExecutionDisplay
-  // mounted in the chat history would otherwise toggle in lock-step on a
-  // single Ctrl+E / Ctrl+F press, reflowing the entire scrollback and
-  // re-introducing the flicker this component is meant to prevent.
+  // the running subagent that currently holds focus — `data.status` rules
+  // out completed/historical instances mounted in scrollback, and
+  // `isFocused` rules out *parallel* running subagents that share the live
+  // viewport. Without the focus gate, two SubAgents running side by side
+  // would both toggle on a single Ctrl+E / Ctrl+F press and the resulting
+  // dual-reflow brings back the flicker this component is meant to
+  // prevent.
   useKeypress(
     (key) => {
       if (key.ctrl && key.name === 'e') {
@@ -253,7 +256,7 @@ export const AgentExecutionDisplay: React.FC<AgentExecutionDisplayProps> = ({
         );
       }
     },
-    { isActive: data.status === 'running' },
+    { isActive: data.status === 'running' && isFocused },
   );
 
   if (displayMode === 'compact') {

--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -54,6 +54,18 @@ describe('textUtils', () => {
       expect(sliced.hiddenLinesCount).toBeGreaterThan(0);
       expect(sliced.text.split('\n').length).toBeLessThanOrEqual(3);
     });
+
+    it('subtracts reservedRows before deciding whether to truncate', () => {
+      // With reservedRows=1 and maxHeight=3 the visible content budget is 2.
+      // A 3-line input must therefore truncate to 2 rows (not return
+      // unchanged just because it fits inside the unreserved 3-row budget).
+      const sliced = sliceTextByVisualHeight('a\nb\nc', 3, 80, {
+        reservedRows: 1,
+        overflowDirection: 'bottom',
+      });
+
+      expect(sliced).toEqual({ text: 'a\nb', hiddenLinesCount: 1 });
+    });
   });
 
   describe('escapeAnsiCtrlCodes', () => {

--- a/packages/cli/src/ui/utils/textUtils.test.ts
+++ b/packages/cli/src/ui/utils/textUtils.test.ts
@@ -9,9 +9,53 @@ import type {
   ToolCallConfirmationDetails,
   ToolEditConfirmationDetails,
 } from '@qwen-code/qwen-code-core';
-import { escapeAnsiCtrlCodes, sanitizeSensitiveText } from './textUtils.js';
+import {
+  escapeAnsiCtrlCodes,
+  sanitizeSensitiveText,
+  sliceTextByVisualHeight,
+} from './textUtils.js';
 
 describe('textUtils', () => {
+  describe('sliceTextByVisualHeight', () => {
+    it('returns the original text when maxHeight is undefined', () => {
+      const sliced = sliceTextByVisualHeight('a\nb\nc', undefined, 10);
+      expect(sliced).toEqual({ text: 'a\nb\nc', hiddenLinesCount: 0 });
+    });
+
+    it('keeps the tail when overflowing from the top (default)', () => {
+      const sliced = sliceTextByVisualHeight('abcdefghijklmnop', 3, 4, {
+        minHeight: 2,
+        reservedRows: 1,
+        overflowDirection: 'top',
+      });
+
+      expect(sliced).toEqual({
+        text: 'ijkl\nmnop',
+        hiddenLinesCount: 2,
+      });
+    });
+
+    it('keeps the head when overflowing from the bottom', () => {
+      const sliced = sliceTextByVisualHeight('a\nb\nc\nd', 3, 80, {
+        overflowDirection: 'bottom',
+      });
+
+      expect(sliced).toEqual({
+        text: 'a\nb\nc',
+        hiddenLinesCount: 1,
+      });
+    });
+
+    it('counts soft wraps in narrow widths as visual rows', () => {
+      const sliced = sliceTextByVisualHeight('aaaa\nbbbbbbbb\ncc', 3, 4, {
+        overflowDirection: 'bottom',
+      });
+
+      expect(sliced.hiddenLinesCount).toBeGreaterThan(0);
+      expect(sliced.text.split('\n').length).toBeLessThanOrEqual(3);
+    });
+  });
+
   describe('escapeAnsiCtrlCodes', () => {
     describe('escapeAnsiCtrlCodes string case study', () => {
       it('should replace ANSI escape codes with a visible representation', () => {

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -142,6 +142,99 @@ export const getCachedStringWidth = (str: string): number => {
   return width;
 };
 
+export interface VisualHeightSlice {
+  text: string;
+  hiddenLinesCount: number;
+}
+
+interface SliceTextByVisualHeightOptions {
+  minHeight?: number;
+  reservedRows?: number;
+  overflowDirection?: 'top' | 'bottom';
+}
+
+/**
+ * Bounds text by terminal visual rows before it reaches Ink/Yoga layout.
+ *
+ * Explicit newlines and soft wraps caused by narrow terminals both count as
+ * visual rows. `overflowDirection: "top"` keeps the newest tail, which is
+ * useful for streaming logs; `"bottom"` keeps the beginning, which is useful
+ * for task prompts.
+ */
+export function sliceTextByVisualHeight(
+  text: string,
+  maxHeight: number | undefined,
+  maxWidth: number,
+  options: SliceTextByVisualHeightOptions = {},
+): VisualHeightSlice {
+  if (maxHeight === undefined) {
+    return { text, hiddenLinesCount: 0 };
+  }
+
+  const targetMaxHeight = Math.max(
+    Math.round(maxHeight),
+    options.minHeight ?? 1,
+  );
+  const visibleContentHeight = Math.max(
+    1,
+    targetMaxHeight - (options.reservedRows ?? 0),
+  );
+  const visualWidth = Math.max(1, Math.floor(maxWidth));
+  const overflowDirection = options.overflowDirection ?? 'top';
+  const visibleLines: string[] = [];
+  let visualLineCount = 0;
+  let currentLine = '';
+  let currentLineWidth = 0;
+
+  const appendVisibleLine = (line: string) => {
+    visualLineCount += 1;
+
+    if (overflowDirection === 'bottom') {
+      if (visibleLines.length < visibleContentHeight) {
+        visibleLines.push(line);
+      }
+      return;
+    }
+
+    visibleLines.push(line);
+    if (visibleLines.length > visibleContentHeight) {
+      visibleLines.shift();
+    }
+  };
+
+  const flushCurrentLine = () => {
+    appendVisibleLine(currentLine);
+    currentLine = '';
+    currentLineWidth = 0;
+  };
+
+  for (const char of toCodePoints(text)) {
+    if (char === '\n') {
+      flushCurrentLine();
+      continue;
+    }
+
+    const charWidth = Math.max(getCachedStringWidth(char), 1);
+    if (currentLineWidth > 0 && currentLineWidth + charWidth > visualWidth) {
+      flushCurrentLine();
+    }
+
+    currentLine += char;
+    currentLineWidth += charWidth;
+  }
+
+  flushCurrentLine();
+
+  if (visualLineCount <= targetMaxHeight) {
+    return { text, hiddenLinesCount: 0 };
+  }
+
+  return {
+    text: visibleLines.join('\n'),
+    hiddenLinesCount: visualLineCount - visibleContentHeight,
+  };
+}
+
 /**
  * Clear the string width cache
  */

--- a/packages/cli/src/ui/utils/textUtils.ts
+++ b/packages/cli/src/ui/utils/textUtils.ts
@@ -225,7 +225,11 @@ export function sliceTextByVisualHeight(
 
   flushCurrentLine();
 
-  if (visualLineCount <= targetMaxHeight) {
+  // Compare against `visibleContentHeight`, not `targetMaxHeight`: when a
+  // caller asks us to reserve rows for a separate footer/header (e.g. the
+  // "...N task lines hidden..." line), the budget for the actual content is
+  // `visibleContentHeight` and exceeding it must still trigger truncation.
+  if (visualLineCount <= visibleContentHeight) {
     return { text, hiddenLinesCount: 0 };
   }
 

--- a/scripts/measure-flicker.mjs
+++ b/scripts/measure-flicker.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Quick-and-dirty TUI flicker quantifier.
+ *
+ * Counts the ANSI escape sequences that betray flicker — clearing the screen,
+ * erasing lines, or jumping the cursor up to redraw — inside a recorded raw
+ * terminal stream. Useful for "before/after" sanity checks when refactoring
+ * TUI components.
+ *
+ * Recording phase (do this yourself; this script doesn't drive interactive
+ * TUIs — it just analyses what you recorded):
+ *
+ *   # macOS / BSD `script`:
+ *   script -q /tmp/qwen.before.raw node dist/cli.js --yolo
+ *   # …drive a SubAgent scenario, then exit qwen with /quit or Ctrl-D
+ *
+ *   # Linux / util-linux `script`:
+ *   script -q -c 'node dist/cli.js --yolo' /tmp/qwen.before.raw
+ *
+ *   # tmux variant: a tmux session preserves whatever you do live; pipe-pane
+ *   # gives you the same raw bytes.
+ *   tmux new -s flicker -d 'node dist/cli.js --yolo'
+ *   tmux pipe-pane -t flicker -o 'cat > /tmp/qwen.before.raw'
+ *   tmux attach -t flicker
+ *
+ * Then:
+ *
+ *   node scripts/measure-flicker.mjs /tmp/qwen.before.raw
+ *   node scripts/measure-flicker.mjs /tmp/qwen.after.raw /tmp/qwen.before.raw
+ *
+ * The second form prints both, and the delta — lower clearTerminalPair on
+ * "current" vs "baseline" is the win condition for a flicker fix.
+ */
+
+import { readFileSync, statSync } from 'node:fs';
+import { argv, exit, stdout } from 'node:process';
+
+if (argv.length < 3 || argv.length > 4) {
+  stdout.write(
+    'usage: node scripts/measure-flicker.mjs <raw-stream> [baseline-raw-stream]\n',
+  );
+  exit(64);
+}
+
+/* eslint-disable no-control-regex -- ANSI escape patterns deliberately match ESC */
+const PATTERNS = [
+  {
+    name: 'clearTerminalPair',
+    description: 'ESC [ 2 J  ESC [ 3 J  ESC [ H  (Ink full-screen redraw)',
+    regex: /\x1b\[2J\x1b\[3J\x1b\[H/g,
+  },
+  {
+    name: 'clearScreen',
+    description: 'ESC [ 2 J  |  ESC [ 3 J  |  ESC c  (any clear-screen op)',
+    regex: /\x1b\[2J|\x1b\[3J|\x1bc/g,
+  },
+  {
+    name: 'eraseLine',
+    description: 'ESC [ 0|1|2 K  (erase part/all of current line)',
+    regex: /\x1b\[[0-2]?K/g,
+  },
+  {
+    name: 'cursorUp',
+    description: 'ESC [ N A  (cursor up — Ink uses this for in-place redraw)',
+    regex: /\x1b\[\d+A/g,
+  },
+];
+/* eslint-enable no-control-regex */
+
+function readBytes(path) {
+  try {
+    statSync(path);
+  } catch {
+    stdout.write(`error: ${path} not found\n`);
+    exit(66);
+  }
+  // Read as binary so a NUL doesn't truncate the buffer; toString('binary')
+  // preserves byte values 0x00..0xFF as code points 0x00..0xFF, which is
+  // exactly what our regex patterns expect (they match \x1b literally).
+  return readFileSync(path).toString('binary');
+}
+
+function summarize(label, path) {
+  const raw = readBytes(path);
+  const counts = Object.fromEntries(
+    PATTERNS.map((p) => [p.name, raw.match(p.regex)?.length ?? 0]),
+  );
+  return {
+    label,
+    path,
+    bytes: raw.length,
+    counts,
+  };
+}
+
+function render(summary) {
+  const { label, path, bytes, counts } = summary;
+  stdout.write(`── ${label}\n`);
+  stdout.write(`    file:  ${path}\n`);
+  stdout.write(`    bytes: ${bytes}\n`);
+  for (const p of PATTERNS) {
+    stdout.write(`    ${p.name.padEnd(18)} ${counts[p.name]}\n`);
+  }
+}
+
+function renderDelta(current, baseline) {
+  stdout.write('\n── delta (current − baseline)\n');
+  for (const p of PATTERNS) {
+    const c = current.counts[p.name];
+    const b = baseline.counts[p.name];
+    const d = c - b;
+    const arrow = d < 0 ? '↓' : d > 0 ? '↑' : '·';
+    stdout.write(`    ${p.name.padEnd(18)} ${d > 0 ? '+' : ''}${d}  ${arrow}\n`);
+  }
+  stdout.write(
+    '\ntip: lower clearTerminalPair (and lower clearScreen) on "current" wins.\n',
+  );
+}
+
+if (process.env.QWEN_FLICKER_VERBOSE) {
+  stdout.write('patterns:\n');
+  for (const p of PATTERNS) {
+    stdout.write(`  ${p.name.padEnd(18)} = ${p.description}\n`);
+  }
+  stdout.write('\n');
+}
+
+const current = summarize('current', argv[2]);
+render(current);
+
+if (argv[3]) {
+  stdout.write('\n');
+  const baseline = summarize('baseline', argv[3]);
+  render(baseline);
+  renderDelta(current, baseline);
+}


### PR DESCRIPTION
## Summary

The SubAgent runtime display (`AgentExecutionDisplay`) used hard-coded `MAX_TASK_PROMPT_LINES = 5` / `MAX_TOOL_CALLS = 5` plus character-length truncation (`firstLine.length > 80`). On narrow terminals, soft-wrapped content overflowed the available height as the tool-call list grew, forcing Ink to clear and redraw on every update — visible flicker on every tool addition / mode switch / resize.

This brings `AgentExecutionDisplay` onto the same visual-height / visual-width slicing pattern that `ToolMessage` and `ConversationMessages` already use after PRs #3591 and #3713, and removes a 300 ms width-driven `refreshStatic` in `AppContainer` that was firing a full-screen clear on every resize event.

### What changed

- **`packages/cli/src/ui/utils/textUtils.ts`** — new shared `sliceTextByVisualHeight(text, maxHeight, maxWidth, opts)`. Counts soft wraps as visual rows, supports \`top\` / \`bottom\` overflow direction. Same shape used by ToolMessage's slicer; this just lifts it out so SubAgent can share it.
- **`packages/cli/src/ui/components/subagents/runtime/AgentExecutionDisplay.tsx`** —
  - derive \`detailHeight\` / \`maxTaskPromptLines\` / \`maxToolCalls\` from the assigned \`availableHeight\` (capped at \`MAX_TOOL_CALLS = 5\` default, \`MAX_VERBOSE_TOOL_CALLS = 12\` verbose), instead of hard-coded 5.
  - \`TaskPromptSection\` uses \`sliceTextByVisualHeight({ overflowDirection: 'bottom' })\` so we keep the head of the prompt and surface a \`... last N task lines hidden ...\` footer.
  - \`ToolCallItem\` truncates description / output via \`truncateToVisualWidth(text, childWidth - 4)\` (CJK / emoji safe), instead of \`length > 80\`.
  - Compact-mode rendering is unchanged.
- **\`packages/cli/src/ui/AppContainer.tsx\`** — drop the \`isInitialMount\` ref + \`useEffect\` that fired \`refreshStatic\` 300 ms after every \`terminalWidth\` change. The static area no longer needs that nudge, and Ink's debounce was the root cause of resize-time clear-screen pairs.

### Tests

- \`textUtils.test.ts\` — \`sliceTextByVisualHeight\` covers \`undefined\` maxHeight, top / bottom overflow, soft-wrap counting at narrow widths.
- \`AgentExecutionDisplay.test.tsx\` (new) — assigns \`availableHeight=8 / childWidth=40\`, expands via Ctrl+E, asserts \`Showing the first 2 visual lines\` and \`Showing the last 1 of 8 tools\` so the height-bounded render is verified end-to-end.
- \`AppContainer.test.tsx\` — width-only changes no longer call \`stdout.write(ansiEscapes.clearTerminal)\`.

Plus, in the second commit, two reusable validation tools:

- \`scripts/measure-flicker.mjs\` — standalone Node script that counts \`clearTerminalPair\` / \`clearScreen\` / \`eraseLine\` / \`cursorUp\` ANSI sequences inside any recorded raw stream (\`script\` log, \`tmux pipe-pane\`, custom PTY capture). Supports baseline diff mode.
- \`integration-tests/terminal-capture/subagent-flicker-regression.ts\` — end-to-end ratchet that boots a mock OpenAI server, drives a real qwen process through an \`agent\` tool dispatch + 5 \`read_file\` SubAgent rounds, then reads PTY bytes and asserts ANSI-redraw counts stay below configured ceilings. Mirrors PR #3713's \`resize-clear-regression\` pattern.

## Test plan

- [x] \`packages/cli\` full \`vitest run\`: 304 files, 4704 passing, 0 failing.
- [x] \`tsc --noEmit\` on touched files: no new errors (unrelated pre-existing errors in \`agent-view\` / \`background-view\` are untouched).
- [x] \`eslint\` on the 8 changed files: clean.
- [x] Local end-to-end via \`subagent-flicker-regression.ts\`: \`clearTerminalPair=5, clearScreen=10, eraseLine=440, cursorUp=132\` (under the 10 / 20 ceilings).
- [x] Local with-fix vs. no-fix comparison documented in the regression script's docstring.