### PR TITLE
fix(memory): use project transcript path for dream

### DIFF
--- a/packages/cli/src/ui/commands/dreamCommand.test.ts
+++ b/packages/cli/src/ui/commands/dreamCommand.test.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { Storage } from '@qwen-code/qwen-code-core';
+import { dreamCommand } from './dreamCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+
+describe('dreamCommand', () => {
+  it('submits a consolidation prompt with the project-scoped transcript directory', async () => {
+    const projectRoot = path.join('tmp', 'dream-project');
+    const buildConsolidationPrompt = vi.fn().mockReturnValue('dream prompt');
+    const writeDreamManualRun = vi.fn();
+    const context = createMockCommandContext({
+      services: {
+        config: {
+          getProjectRoot: vi.fn().mockReturnValue(projectRoot),
+          getMemoryManager: vi.fn().mockReturnValue({
+            buildConsolidationPrompt,
+            writeDreamManualRun,
+          }),
+          getSessionId: vi.fn().mockReturnValue('session-1'),
+        },
+      },
+    });
+
+    const result = await dreamCommand.action?.(context, '');
+    const expectedTranscriptDir = path.join(
+      new Storage(projectRoot).getProjectDir(),
+      'chats',
+    );
+
+    expect(result).toEqual({
+      type: 'submit_prompt',
+      content: 'dream prompt',
+      onComplete: expect.any(Function),
+    });
+    expect(buildConsolidationPrompt).toHaveBeenCalledWith(
+      expect.any(String),
+      expectedTranscriptDir,
+    );
+    expect(expectedTranscriptDir).not.toContain(
+      `${path.sep}.qwen${path.sep}tmp${path.sep}`,
+    );
+  });
+});

--- a/packages/cli/src/ui/commands/dreamCommand.ts
+++ b/packages/cli/src/ui/commands/dreamCommand.ts
@@ -4,11 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  getAutoMemoryRoot,
-  getProjectHash,
-  QWEN_DIR,
-} from '@qwen-code/qwen-code-core';
+import * as path from 'node:path';
+import { getAutoMemoryRoot, Storage } from '@qwen-code/qwen-code-core';
 import { t } from '../../i18n/index.js';
 import type { SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
@@ -31,8 +28,10 @@ export const dreamCommand: SlashCommand = {
 
     const projectRoot = config.getProjectRoot();
     const memoryRoot = getAutoMemoryRoot(projectRoot);
-    const projectHash = getProjectHash(projectRoot);
-    const transcriptDir = `${QWEN_DIR}/tmp/${projectHash}/chats`;
+    const transcriptDir = path.join(
+      new Storage(projectRoot).getProjectDir(),
+      'chats',
+    );
 
     const prompt = config
       .getMemoryManager()

--- a/packages/core/src/memory/dreamAgentPlanner.test.ts
+++ b/packages/core/src/memory/dreamAgentPlanner.test.ts
@@ -9,9 +9,13 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Config } from '../config/config.js';
+import { Storage } from '../config/storage.js';
 import type { ForkedAgentResult } from '../utils/forkedAgent.js';
 import { runForkedAgent } from '../utils/forkedAgent.js';
-import { planManagedAutoMemoryDreamByAgent } from './dreamAgentPlanner.js';
+import {
+  getTranscriptDir,
+  planManagedAutoMemoryDreamByAgent,
+} from './dreamAgentPlanner.js';
 import { ensureAutoMemoryScaffold } from './store.js';
 
 vi.mock('../utils/forkedAgent.js', () => ({
@@ -38,12 +42,28 @@ describe('dreamAgentPlanner', () => {
   });
 
   afterEach(async () => {
+    Storage.setRuntimeBaseDir(null);
     await fs.rm(tempDir, {
       recursive: true,
       force: true,
       maxRetries: 3,
       retryDelay: 10,
     });
+  });
+
+  it('returns project-scoped session transcript directory', () => {
+    const runtimeDir = path.join(tempDir, 'runtime');
+    Storage.setRuntimeBaseDir(runtimeDir);
+
+    expect(getTranscriptDir(projectRoot)).toBe(
+      path.join(new Storage(projectRoot).getProjectDir(), 'chats'),
+    );
+    expect(getTranscriptDir(projectRoot)).toContain(
+      path.join(runtimeDir, 'projects'),
+    );
+    expect(getTranscriptDir(projectRoot)).not.toContain(
+      `${path.sep}.qwen${path.sep}tmp${path.sep}`,
+    );
   });
 
   it('returns the forked agent result', async () => {

--- a/packages/core/src/memory/dreamAgentPlanner.test.ts
+++ b/packages/core/src/memory/dreamAgentPlanner.test.ts
@@ -12,6 +12,7 @@ import type { Config } from '../config/config.js';
 import { Storage } from '../config/storage.js';
 import type { ForkedAgentResult } from '../utils/forkedAgent.js';
 import { runForkedAgent } from '../utils/forkedAgent.js';
+import { escapeShellArg, getShellConfiguration } from '../utils/shell-utils.js';
 import {
   buildConsolidationTaskPrompt,
   getTranscriptDir,
@@ -75,16 +76,20 @@ describe('dreamAgentPlanner', () => {
       '-tmp-project',
       'chats',
     );
+    const quotedTranscriptDir = escapeShellArg(
+      `${transcriptDir}${path.sep}`,
+      getShellConfiguration().shell,
+    );
     const prompt = buildConsolidationTaskPrompt(
       path.join(tempDir, 'memory'),
       transcriptDir,
     );
 
     expect(prompt).toContain(
-      `grep -rn "<narrow term>" '${transcriptDir}/' --include="*.jsonl" | tail -50`,
+      `grep -rn "<narrow term>" ${quotedTranscriptDir} --include="*.jsonl" | tail -50`,
     );
     expect(prompt).not.toContain(
-      `grep -rn "<narrow term>" ${transcriptDir}/ --include="*.jsonl" | tail -50`,
+      `grep -rn "<narrow term>" ${transcriptDir}${path.sep} --include="*.jsonl" | tail -50`,
     );
   });
 

--- a/packages/core/src/memory/dreamAgentPlanner.test.ts
+++ b/packages/core/src/memory/dreamAgentPlanner.test.ts
@@ -13,6 +13,7 @@ import { Storage } from '../config/storage.js';
 import type { ForkedAgentResult } from '../utils/forkedAgent.js';
 import { runForkedAgent } from '../utils/forkedAgent.js';
 import {
+  buildConsolidationTaskPrompt,
   getTranscriptDir,
   planManagedAutoMemoryDreamByAgent,
 } from './dreamAgentPlanner.js';
@@ -63,6 +64,27 @@ describe('dreamAgentPlanner', () => {
     );
     expect(getTranscriptDir(projectRoot)).not.toContain(
       `${path.sep}.qwen${path.sep}tmp${path.sep}`,
+    );
+  });
+
+  it('shell-quotes the transcript directory in the grep example', () => {
+    const transcriptDir = path.join(
+      tempDir,
+      'runtime dir; touch BAD',
+      'projects',
+      '-tmp-project',
+      'chats',
+    );
+    const prompt = buildConsolidationTaskPrompt(
+      path.join(tempDir, 'memory'),
+      transcriptDir,
+    );
+
+    expect(prompt).toContain(
+      `grep -rn "<narrow term>" '${transcriptDir}/' --include="*.jsonl" | tail -50`,
+    );
+    expect(prompt).not.toContain(
+      `grep -rn "<narrow term>" ${transcriptDir}/ --include="*.jsonl" | tail -50`,
     );
   });
 

--- a/packages/core/src/memory/dreamAgentPlanner.ts
+++ b/packages/core/src/memory/dreamAgentPlanner.ts
@@ -23,7 +23,11 @@ import type {
   PermissionDecision,
 } from '../permissions/types.js';
 import { isShellCommandReadOnlyAST } from '../utils/shellAstParser.js';
-import { stripShellWrapper } from '../utils/shell-utils.js';
+import {
+  escapeShellArg,
+  getShellConfiguration,
+  stripShellWrapper,
+} from '../utils/shell-utils.js';
 
 const MAX_TURNS = 8;
 const MAX_TIME_MINUTES = 5;
@@ -165,10 +169,17 @@ export function getTranscriptDir(projectRoot: string): string {
   return path.join(new Storage(projectRoot).getProjectDir(), 'chats');
 }
 
+function quoteShellPathWithTrailingSeparator(dirPath: string): string {
+  return escapeShellArg(`${dirPath}${path.sep}`, getShellConfiguration().shell);
+}
+
 export function buildConsolidationTaskPrompt(
   memoryRoot: string,
   transcriptDir: string,
 ): string {
+  const quotedTranscriptDir =
+    quoteShellPathWithTrailingSeparator(transcriptDir);
+
   return [
     `Memory directory: \`${memoryRoot}\``,
     'This directory already exists — write to it directly with the write_file tool (do not run mkdir or check for its existence).',
@@ -187,7 +198,7 @@ export function buildConsolidationTaskPrompt(
     '',
     '1. Existing memories that drifted — facts that contradict something you now know from current memory files',
     '2. Transcript search — if you need specific context, grep session transcripts for narrow terms:',
-    `   \`grep -rn "<narrow term>" ${transcriptDir}/ --include="*.jsonl" | tail -50\``,
+    `   \`grep -rn "<narrow term>" ${quotedTranscriptDir} --include="*.jsonl" | tail -50\``,
     '',
     "Don't exhaustively read transcripts. Look only for things you already suspect matter.",
     '',

--- a/packages/core/src/memory/dreamAgentPlanner.ts
+++ b/packages/core/src/memory/dreamAgentPlanner.ts
@@ -9,7 +9,8 @@ import {
   runForkedAgent,
   type ForkedAgentResult,
 } from '../utils/forkedAgent.js';
-import { getProjectHash, QWEN_DIR } from '../utils/paths.js';
+import * as path from 'node:path';
+import { Storage } from '../config/storage.js';
 import {
   AUTO_MEMORY_INDEX_FILENAME,
   getAutoMemoryRoot,
@@ -160,9 +161,8 @@ Rules:
 - Keep the MEMORY.md index concise: one line per file in the format \`- [Title](relative/path.md) — one-line hook\`.
 - If nothing needs consolidation, do nothing and say so.`;
 
-function getTranscriptDir(projectRoot: string): string {
-  const projectHash = getProjectHash(projectRoot);
-  return `${QWEN_DIR}/tmp/${projectHash}/chats`;
+export function getTranscriptDir(projectRoot: string): string {
+  return path.join(new Storage(projectRoot).getProjectDir(), 'chats');
 }
 
 export function buildConsolidationTaskPrompt(


### PR DESCRIPTION
<!--
Help reviewers verify this PR quickly.

Maintainers prioritize PRs that include clear proof of work.
If a PR does not include enough validation detail to reproduce and verify the change efficiently, review may be delayed.
-->

## Summary

- What changed: Updated `/dream` transcript lookup instructions to use the project-scoped session transcript directory used by chat recording/session storage, and added regression coverage for both the CLI command and core dream planner.
- Why it changed: `/dream` previously pointed memory consolidation at `.qwen/tmp/<hash>/chats`, which no longer contains session transcripts, so transcript search could miss recent conversation history.
- Reviewer focus: Confirm the transcript path now follows `Storage.getProjectDir()/chats` consistently for manual `/dream` and managed auto-memory dream planning.

## Validation

<!--
Be concrete. Do not write only "tested locally".
Include the exact commands, prompts, outputs, logs, screenshots, or videos that prove the change was actually run and observed.

For user-visible changes, bug fixes, CLI / TUI behavior changes, or interaction changes, include key screenshots or a short video.
When possible, show before/after behavior.

If helpful, use the `e2e-testing` skill to gather stronger end-to-end validation evidence.
-->

- Commands run:
  ```bash
  npx vitest run src/ui/commands/dreamCommand.test.ts
  npx vitest run src/memory/dreamAgentPlanner.test.ts
  npm run build && npm run bundle
  npm run typecheck
  npm run lint
  ```
- Prompts / inputs used: Submitted `/dream` in an isolated interactive TUI session using `node /Users/mochi/code/fix-issue-qwen-code/dist/cli.js --auth-type openai --approval-mode yolo --openai-logging --openai-logging-dir "$tmpdir/logs"` with dummy OpenAI endpoint settings.
- Expected result: The `/dream` consolidation prompt should point transcript search at the actual project-scoped `projects/<project-id>/chats/*.jsonl` location.
- Observed result: Verification captured a prompt containing `Session transcripts: /Users/mochi/.qwen/projects/-private-tmp-qwen-3599-verify-lf9cto-work/chats`, and that directory contained the active session JSONL file.
- Quickest reviewer verification path: Run the two focused vitest commands above, then inspect `/dream` prompt generation to confirm it uses `Storage.getProjectDir()/chats` rather than `.qwen/tmp/<hash>/chats`.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.): `test-engineer` reproduced the bug against the installed CLI and verified this branch with `node dist/cli.js`; the issue artifact records `Status: REPRODUCED` and `Status: VERIFIED_FIXED` in `.qwen/issues/issue-3599.md`.

## Scope / Risk

- Main risk or tradeoff: The transcript directory now follows runtime storage configuration through `Storage.getProjectDir()`, so behavior depends on the same runtime base directory resolution used by session recording.
- Not covered / not validated: Windows and Linux were not run locally.
- Breaking changes / migration notes: None.

## Testing Matrix

<!--
Use:
- ✅ tested
- ⚠️ not tested
- N/A
If anything is ⚠️, explain why briefly below.
-->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- macOS validation covered focused `npx vitest`, `npm run build && npm run bundle`, `npm run typecheck`, `npm run lint`, and an interactive `/dream` E2E verification.
- Windows, Linux, Docker, Podman, and Seatbelt were not tested locally.

## Linked Issues / Bugs

Related discussion: #3599

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)
