### PR TITLE
feat(core): add Monitor(...) permission namespace

### DIFF
--- a/packages/core/src/permissions/permission-manager.test.ts
+++ b/packages/core/src/permissions/permission-manager.test.ts
@@ -137,10 +137,22 @@ describe('parseRule', () => {
     expect(r.toolName).toBe('run_shell_command');
   });
 
+  it('parses Monitor alias', async () => {
+    const r = parseRule('Monitor');
+    expect(r.toolName).toBe('monitor');
+  });
+
   it('parses a shell tool with a specifier', async () => {
     const r = parseRule('Bash(git *)');
     expect(r.toolName).toBe('run_shell_command');
     expect(r.specifier).toBe('git *');
+    expect(r.specifierKind).toBe('command');
+  });
+
+  it('parses Monitor with command specifier', async () => {
+    const r = parseRule('Monitor(tail -f *)');
+    expect(r.toolName).toBe('monitor');
+    expect(r.specifier).toBe('tail -f *');
     expect(r.specifierKind).toBe('command');
   });
 
@@ -645,6 +657,28 @@ describe('matchesRule', () => {
     expect(matchesRule(rule, 'run_shell_command', 'echo hello')).toBe(false);
   });
 
+  // Monitor command specifier
+  it('Monitor rule matches monitor invocations with command specifier', async () => {
+    const rule = parseRule('Monitor(tail -f *)');
+    expect(matchesRule(rule, 'monitor')).toBe(false); // no command
+    expect(matchesRule(rule, 'monitor', 'tail -f /var/log/app.log')).toBe(true);
+    expect(matchesRule(rule, 'monitor', 'echo hello')).toBe(false);
+  });
+
+  it('Monitor rule does not match run_shell_command', async () => {
+    const rule = parseRule('Monitor(tail -f *)');
+    expect(
+      matchesRule(rule, 'run_shell_command', 'tail -f /var/log/app.log'),
+    ).toBe(false);
+  });
+
+  it('Bash rule does not match monitor', async () => {
+    const rule = parseRule('Bash(tail -f *)');
+    expect(matchesRule(rule, 'monitor', 'tail -f /var/log/app.log')).toBe(
+      false,
+    );
+  });
+
   it('matchesRule checks individual simple commands (compound splitting is at PM level)', async () => {
     const rule = parseRule('Bash(git *)');
     // matchesRule receives a simple command (already split by PM)
@@ -930,6 +964,81 @@ describe('PermissionManager', () => {
       expect(await pm.isCommandAllowed('rm -rf /')).toBe('deny');
       // 'ls' is readonly, resolves to 'allow' when no rule matches
       expect(await pm.isCommandAllowed('ls')).toBe('allow');
+    });
+  });
+
+  describe('monitor command-level evaluation', () => {
+    it('Monitor(...) allow rule matches monitor invocations', async () => {
+      const pm2 = new PermissionManager(
+        makeConfig({
+          permissionsAllow: ['Monitor(tail -f *)'],
+        }),
+      );
+      pm2.initialize();
+      expect(
+        await pm2.evaluate({
+          toolName: 'monitor',
+          command: 'tail -f /var/log/app.log',
+        }),
+      ).toBe('allow');
+    });
+
+    it('Monitor(...) deny rule blocks monitor invocations', async () => {
+      const pm2 = new PermissionManager(
+        makeConfig({
+          permissionsDeny: ['Monitor(rm *)'],
+        }),
+      );
+      pm2.initialize();
+      expect(
+        await pm2.evaluate({
+          toolName: 'monitor',
+          command: 'rm -rf /',
+        }),
+      ).toBe('deny');
+    });
+
+    it('Monitor approval does NOT allow run_shell_command', async () => {
+      const pm2 = new PermissionManager(
+        makeConfig({
+          permissionsAllow: ['Monitor(npm *)'],
+        }),
+      );
+      pm2.initialize();
+      // Same command via shell tool should NOT be allowed by Monitor rule
+      expect(
+        await pm2.evaluate({
+          toolName: 'run_shell_command',
+          command: 'npm install',
+        }),
+      ).not.toBe('allow');
+    });
+
+    it('Bash approval does NOT allow monitor', async () => {
+      const pm2 = new PermissionManager(
+        makeConfig({
+          permissionsAllow: ['Bash(npm *)'],
+        }),
+      );
+      pm2.initialize();
+      // Same command via monitor tool should NOT be allowed by Bash rule
+      expect(
+        await pm2.evaluate({
+          toolName: 'monitor',
+          command: 'npm install',
+        }),
+      ).not.toBe('allow');
+    });
+
+    it('resolves default to allow for readonly monitor commands', async () => {
+      const pm2 = new PermissionManager(makeConfig({}));
+      pm2.initialize();
+      expect(
+        await pm2.evaluate({
+          toolName: 'monitor',
+          command: 'echo hello',
+        }),
+      ).toBe('allow');
     });
   });
 
@@ -1691,6 +1800,19 @@ describe('buildPermissionRules', () => {
       const rules = buildPermissionRules({ toolName: 'run_shell_command' });
       expect(rules).toEqual(['Bash']);
     });
+
+    it('generates Monitor rule with command specifier', async () => {
+      const rules = buildPermissionRules({
+        toolName: 'monitor',
+        command: 'tail -f /var/log/app.log',
+      });
+      expect(rules).toEqual(['Monitor(tail -f /var/log/app.log)']);
+    });
+
+    it('falls back to bare Monitor display name when no command', async () => {
+      const rules = buildPermissionRules({ toolName: 'monitor' });
+      expect(rules).toEqual(['Monitor']);
+    });
   });
 
   describe('literal-specifier tools', () => {
@@ -1741,6 +1863,10 @@ describe('buildHumanReadableRuleLabel', () => {
     expect(buildHumanReadableRuleLabel(['Bash'])).toBe('run commands');
   });
 
+  it('converts bare Monitor rule to "monitor commands"', () => {
+    expect(buildHumanReadableRuleLabel(['Monitor'])).toBe('monitor commands');
+  });
+
   it('converts Read with absolute path specifier', () => {
     const label = buildHumanReadableRuleLabel(['Read(//Users/mochi/.qwen/**)']);
     expect(label).toBe('read files in /Users/mochi/.qwen/');
@@ -1759,6 +1885,11 @@ describe('buildHumanReadableRuleLabel', () => {
   it('converts Bash with command specifier', () => {
     const label = buildHumanReadableRuleLabel(['Bash(git *)']);
     expect(label).toBe("run 'git *' commands");
+  });
+
+  it('converts Monitor with command specifier', () => {
+    const label = buildHumanReadableRuleLabel(['Monitor(tail -f *)']);
+    expect(label).toBe("monitor 'tail -f *' commands");
   });
 
   it('converts WebFetch with domain specifier', () => {

--- a/packages/core/src/permissions/permission-manager.ts
+++ b/packages/core/src/permissions/permission-manager.ts
@@ -30,6 +30,13 @@ import type {
 const debugLogger = createDebugLogger('PERMISSIONS');
 
 /**
+ * Tools that spawn shell commands and share the same permission evaluation
+ * semantics: compound-command splitting, AST read-only analysis, and
+ * virtual file/network operation matching.
+ */
+const SHELL_LIKE_TOOLS = new Set(['run_shell_command', 'monitor']);
+
+/**
  * Numeric priority for each PermissionDecision.
  * Higher number = more restrictive. Used to combine decisions by taking
  * the most restrictive result across base rules + virtual shell operations.
@@ -178,7 +185,7 @@ export class PermissionManager {
     // a concrete permission (deny/ask/allow) based on the command's readonly status.
     if (
       decision === 'default' &&
-      toolName === 'run_shell_command' &&
+      SHELL_LIKE_TOOLS.has(toolName) &&
       command !== undefined
     ) {
       return this.resolveDefaultPermission(command);
@@ -256,7 +263,7 @@ export class PermissionManager {
     // must never downgrade an explicit 'allow' decision from a Bash rule.
     // Example: `git status` has no file ops; an allow rule for `Bash(git *)`
     // should return 'allow', not be downgraded to 'default'.
-    if (toolName === 'run_shell_command' && command !== undefined) {
+    if (SHELL_LIKE_TOOLS.has(toolName) && command !== undefined) {
       const cwd = pathCtx?.cwd ?? process.cwd();
       const virtualDecision = this.evaluateShellVirtualOps(
         extractShellOperations(command, cwd),
@@ -546,7 +553,7 @@ export class PermissionManager {
   hasRelevantRules(ctx: PermissionCheckContext): boolean {
     const { toolName, command, filePath, domain, specifier } = ctx;
 
-    if (ctx.toolName === 'run_shell_command' && command !== undefined) {
+    if (SHELL_LIKE_TOOLS.has(ctx.toolName) && command !== undefined) {
       const subCommands = splitCompoundCommand(command);
       if (subCommands.length > 1) {
         return subCommands.some((subCmd) =>
@@ -587,7 +594,7 @@ export class PermissionManager {
     // extracted from the command has a relevant rule. This ensures the PM is
     // consulted (and the confirmation dialog shown) when Read/Edit/etc. rules
     // would match equivalent shell commands.
-    if (ctx.toolName === 'run_shell_command' && ctx.command !== undefined) {
+    if (SHELL_LIKE_TOOLS.has(ctx.toolName) && ctx.command !== undefined) {
       const cwd = pathCtx?.cwd ?? process.cwd();
       const ops = extractShellOperations(ctx.command, cwd);
       if (
@@ -622,7 +629,7 @@ export class PermissionManager {
   hasMatchingAskRule(ctx: PermissionCheckContext): boolean {
     const { toolName, command, filePath, domain, specifier } = ctx;
 
-    if (ctx.toolName === 'run_shell_command' && command !== undefined) {
+    if (SHELL_LIKE_TOOLS.has(ctx.toolName) && command !== undefined) {
       const subCommands = splitCompoundCommand(command);
       if (subCommands.length > 1) {
         return subCommands.some((subCmd) =>
@@ -654,7 +661,7 @@ export class PermissionManager {
       return true;
     }
 
-    if (ctx.toolName === 'run_shell_command' && ctx.command !== undefined) {
+    if (SHELL_LIKE_TOOLS.has(ctx.toolName) && ctx.command !== undefined) {
       const cwd = pathCtx?.cwd ?? process.cwd();
       const ops = extractShellOperations(ctx.command, cwd);
       return ops.some((op) => {

--- a/packages/core/src/permissions/rule-parser.ts
+++ b/packages/core/src/permissions/rule-parser.ts
@@ -118,6 +118,11 @@ export const TOOL_NAME_ALIASES: Readonly<Record<string, string>> = {
   Lsp: 'lsp',
   LspTool: 'lsp',
 
+  // Monitor tool
+  monitor: 'monitor',
+  Monitor: 'monitor',
+  MonitorTool: 'monitor',
+
   // Legacy edit tool name
   replace: 'edit',
 };
@@ -125,7 +130,7 @@ export const TOOL_NAME_ALIASES: Readonly<Record<string, string>> = {
 /**
  * Shell tool canonical names.
  */
-const SHELL_TOOL_NAMES = new Set(['run_shell_command']);
+const SHELL_TOOL_NAMES = new Set(['run_shell_command', 'monitor']);
 
 /**
  * File-reading tools — "Read" rules apply to all of these (best-effort).
@@ -305,6 +310,8 @@ const CANONICAL_TO_RULE_DISPLAY: Readonly<Record<string, string>> = {
   write_file: 'Edit',
   // Shell
   run_shell_command: 'Bash',
+  // Monitor
+  monitor: 'Monitor',
   // Web
   web_fetch: 'WebFetch',
   // Agent / Skill
@@ -419,6 +426,7 @@ const DISPLAY_NAME_TO_VERB: Readonly<Record<string, string>> = {
   Read: 'read files',
   Edit: 'edit files',
   Bash: 'run commands',
+  Monitor: 'monitor commands',
   WebFetch: 'fetch from',
   Agent: 'use agent',
   Skill: 'use skill',
@@ -494,9 +502,13 @@ export function buildHumanReadableRuleLabel(rules: string[]): string {
         parts.push(`${verb} in ${cleanPath}`);
         break;
       }
-      case 'command':
-        parts.push(`run '${specifier}' commands`);
+      case 'command': {
+        const cmdVerb = DISPLAY_NAME_TO_VERB[displayName] ?? 'run';
+        // Extract just the verb word (e.g. "run commands" → "run", "monitor commands" → "monitor")
+        const verbWord = cmdVerb.split(' ')[0]!;
+        parts.push(`${verbWord} '${specifier}' commands`);
         break;
+      }
       case 'domain':
         parts.push(`${verb} ${specifier}`);
         break;

--- a/packages/core/src/tools/monitor.test.ts
+++ b/packages/core/src/tools/monitor.test.ts
@@ -151,7 +151,7 @@ describe('MonitorTool', () => {
       };
 
       expect(details.type).toBe('exec');
-      expect(details.permissionRules).toEqual(['Bash(tail -f *)']);
+      expect(details.permissionRules).toEqual(['Monitor(tail -f *)']);
     });
 
     it('does not consult Bash permission rules for monitor commands', async () => {
@@ -183,8 +183,8 @@ describe('MonitorTool', () => {
       expect(pm.isCommandAllowed).not.toHaveBeenCalled();
       // Both subcommands remain in confirmation scope
       expect(details.permissionRules).toEqual([
-        'Bash(git add *)',
-        'Bash(git commit *)',
+        'Monitor(git add *)',
+        'Monitor(git commit *)',
       ]);
     });
 
@@ -201,7 +201,9 @@ describe('MonitorTool', () => {
         permissionRules?: string[];
       };
 
-      expect(details.permissionRules).toEqual(['Bash(python -c "print(1)")']);
+      expect(details.permissionRules).toEqual([
+        'Monitor(python -c "print(1)")',
+      ]);
     });
   });
 

--- a/packages/core/src/tools/monitor.ts
+++ b/packages/core/src/tools/monitor.ts
@@ -139,10 +139,12 @@ class MonitorToolInvocation extends BaseToolInvocation<
         const rules = await extractCommandRules(sub);
         allRules.push(...rules);
       }
-      permissionRules = [...new Set(allRules)].map((rule) => `Bash(${rule})`);
+      permissionRules = [...new Set(allRules)].map(
+        (rule) => `Monitor(${rule})`,
+      );
     } catch (e) {
       debugLogger.warn('Failed to extract monitor command rules:', e);
-      permissionRules = [`Bash(${command})`];
+      permissionRules = [`Monitor(${command})`];
     }
 
     return {


### PR DESCRIPTION
## Summary

- Introduce a dedicated `Monitor(...)` permission namespace so monitor and shell tools have **independent permission boundaries**
- Previously monitor emitted `Bash(...)` rules, causing "Always Allow" to fail for future monitor invocations while unintentionally granting `run_shell_command` permission
- Add `SHELL_LIKE_TOOLS` set in `permission-manager.ts` so all shell-like evaluation paths (AST analysis, virtual ops, compound splitting) handle both `run_shell_command` and `monitor`

Follow-up to #3684 (review threads 8/10/11).

## Changes

| File | What |
|---|---|
| `rule-parser.ts` | Add `Monitor` alias → `'monitor'`, `SHELL_TOOL_NAMES`, `CANONICAL_TO_RULE_DISPLAY`, `DISPLAY_NAME_TO_VERB` |
| `permission-manager.ts` | Extract `SHELL_LIKE_TOOLS` set, use in `evaluate()`, `evaluateSingle()`, `hasRelevantRules()`, `hasMatchingAskRule()` |
| `monitor.ts` | Emit `Monitor(...)` instead of `Bash(...)` in `permissionRules` |
| `permission-manager.test.ts` | Add `parseRule`, `matchesRule`, cross-tool isolation regression, `buildPermissionRules`, `buildHumanReadableRuleLabel` tests for Monitor |
| `monitor.test.ts` | Update expected `Bash(...)` → `Monitor(...)` |

## Test plan

- [x] `npx vitest run src/permissions/permission-manager.test.ts` — 206 passed
- [x] `npx vitest run src/tools/monitor.test.ts` — 29 passed  
- [x] `npm run typecheck` — clean across all workspaces
- [x] Regression: `Monitor(npm *)` does NOT allow `run_shell_command` with `npm install`
- [x] Regression: `Bash(npm *)` does NOT allow `monitor` with `npm install`

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)