### PR TITLE
fix(core): inject reasoning_content on DeepSeek tool-call replays

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -37,7 +37,7 @@ interface ExtendedCompletionUsage extends OpenAI.CompletionUsage {
   cached_tokens?: number;
 }
 
-interface ExtendedChatCompletionAssistantMessageParam
+export interface ExtendedChatCompletionAssistantMessageParam
   extends OpenAI.Chat.ChatCompletionAssistantMessageParam {
   reasoning_content?: string | null;
 }

--- a/packages/core/src/core/openaiContentGenerator/provider/deepseek.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/deepseek.test.ts
@@ -178,6 +178,89 @@ describe('DeepSeekOpenAICompatibleProvider', () => {
         content: 'Hello \n\n[Unsupported content type: image_url]',
       });
     });
+
+    // https://github.com/QwenLM/qwen-code/issues/3695 — DeepSeek's thinking
+    // mode rejects subsequent requests when a prior tool-calling assistant
+    // turn omits reasoning_content, even if the model itself returned no
+    // reasoning text. The provider must always send the field.
+    it('injects empty reasoning_content on tool-calling assistant turns missing it', () => {
+      const originalRequest: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'deepseek-v4-flash',
+        messages: [
+          { role: 'user', content: 'list markdown files' },
+          {
+            role: 'assistant',
+            content: null,
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function',
+                function: { name: 'glob', arguments: '{"pattern":"**/*.md"}' },
+              },
+            ],
+          },
+          {
+            role: 'tool',
+            tool_call_id: 'call_1',
+            content: 'Found 2 matching file(s)',
+          },
+        ],
+      };
+
+      const result = provider.buildRequest(originalRequest, userPromptId);
+
+      const assistant = result.messages?.[1] as {
+        role: string;
+        reasoning_content?: string;
+      };
+      expect(assistant.role).toBe('assistant');
+      expect(assistant.reasoning_content).toBe('');
+    });
+
+    it('preserves existing reasoning_content on tool-calling assistant turns', () => {
+      const originalRequest = {
+        model: 'deepseek-v4-flash',
+        messages: [
+          { role: 'user' as const, content: 'list markdown files' },
+          {
+            role: 'assistant' as const,
+            content: null,
+            reasoning_content: 'Let me glob first.',
+            tool_calls: [
+              {
+                id: 'call_1',
+                type: 'function' as const,
+                function: { name: 'glob', arguments: '{"pattern":"**/*.md"}' },
+              },
+            ],
+          },
+        ],
+      } as unknown as OpenAI.Chat.ChatCompletionCreateParams;
+
+      const result = provider.buildRequest(originalRequest, userPromptId);
+
+      const assistant = result.messages?.[1] as {
+        reasoning_content?: string;
+      };
+      expect(assistant.reasoning_content).toBe('Let me glob first.');
+    });
+
+    it('does not add reasoning_content to assistant turns without tool_calls', () => {
+      const originalRequest: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'deepseek-v4-flash',
+        messages: [
+          { role: 'user', content: 'hi' },
+          { role: 'assistant', content: 'hello' },
+        ],
+      };
+
+      const result = provider.buildRequest(originalRequest, userPromptId);
+
+      const assistant = result.messages?.[1] as {
+        reasoning_content?: string;
+      };
+      expect(assistant.reasoning_content).toBeUndefined();
+    });
   });
 
   describe('getDefaultGenerationConfig', () => {

--- a/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
@@ -7,6 +7,7 @@
 import type OpenAI from 'openai';
 import type { Config } from '../../../config/config.js';
 import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+import type { ExtendedChatCompletionAssistantMessageParam } from '../converter.js';
 import { DefaultOpenAICompatibleProvider } from './default.js';
 import type { GenerateContentConfig } from '@google/genai';
 
@@ -50,40 +51,8 @@ export class DeepSeekOpenAICompatibleProvider extends DefaultOpenAICompatiblePro
     }
 
     const messages = baseRequest.messages.map((message) => {
-      if (!('content' in message)) {
-        return message;
-      }
-
-      const { content } = message;
-
-      if (
-        typeof content === 'string' ||
-        content === null ||
-        content === undefined
-      ) {
-        return message;
-      }
-
-      if (!Array.isArray(content)) {
-        return message;
-      }
-
-      const text = content
-        .map((part) => {
-          if (typeof part === 'string') {
-            return part;
-          }
-          if (part.type === 'text') {
-            return part.text ?? '';
-          }
-          return `[Unsupported content type: ${part.type}]`;
-        })
-        .join('\n\n');
-
-      return {
-        ...message,
-        content: text,
-      } as OpenAI.Chat.ChatCompletionMessageParam;
+      const flattened = flattenContentParts(message);
+      return ensureReasoningContentOnToolCalls(flattened);
     });
 
     return {
@@ -97,4 +66,70 @@ export class DeepSeekOpenAICompatibleProvider extends DefaultOpenAICompatiblePro
       temperature: 0,
     };
   }
+}
+
+function flattenContentParts(
+  message: OpenAI.Chat.ChatCompletionMessageParam,
+): OpenAI.Chat.ChatCompletionMessageParam {
+  if (!('content' in message)) {
+    return message;
+  }
+
+  const { content } = message;
+
+  if (
+    typeof content === 'string' ||
+    content === null ||
+    content === undefined
+  ) {
+    return message;
+  }
+
+  if (!Array.isArray(content)) {
+    return message;
+  }
+
+  const text = content
+    .map((part) => {
+      if (typeof part === 'string') {
+        return part;
+      }
+      if (part.type === 'text') {
+        return part.text ?? '';
+      }
+      return `[Unsupported content type: ${part.type}]`;
+    })
+    .join('\n\n');
+
+  return {
+    ...message,
+    content: text,
+  } as OpenAI.Chat.ChatCompletionMessageParam;
+}
+
+// DeepSeek's thinking mode requires reasoning_content to be replayed on every
+// prior assistant turn that carried tool_calls. The model may legitimately
+// return a tool round without reasoning text, so the field can be missing
+// when we rebuild the request. Send an empty string in that case so the API
+// contract is satisfied. https://github.com/QwenLM/qwen-code/issues/3695
+function ensureReasoningContentOnToolCalls(
+  message: OpenAI.Chat.ChatCompletionMessageParam,
+): OpenAI.Chat.ChatCompletionMessageParam {
+  if (message.role !== 'assistant') {
+    return message;
+  }
+  if (!Array.isArray(message.tool_calls) || message.tool_calls.length === 0) {
+    return message;
+  }
+  const extended = message as ExtendedChatCompletionAssistantMessageParam;
+  if (
+    typeof extended.reasoning_content === 'string' &&
+    extended.reasoning_content.length > 0
+  ) {
+    return message;
+  }
+  return {
+    ...extended,
+    reasoning_content: '',
+  } as OpenAI.Chat.ChatCompletionMessageParam;
 }


### PR DESCRIPTION
## Summary

- **Root cause**: DeepSeek's API endpoint sometimes returns a tool-calls response with **no `reasoning_content`** (e.g. when the model decided not to reason for that round). When qwen-code replays the conversation on the next turn, that assistant message goes back without `reasoning_content` — and DeepSeek's thinking mode then rejects the request with HTTP 400 ("The reasoning_content in the thinking mode must be passed back to the API"). DeepSeek emits a shape that, on round-trip, it then refuses to accept.
- **Fix**: in the DeepSeek provider, normalize outgoing assistant messages so any turn carrying `tool_calls` always has `reasoning_content` set. When the model emitted no reasoning text, we send back an **empty string** (`""`). Other providers are untouched.
- **Reviewer focus**: that the injection only fires for assistant messages with non-empty `tool_calls`, only on the DeepSeek provider, and never overwrites existing reasoning content.

## Validation

Reproduced the bug end-to-end using a small local mock server that emulates DeepSeek's contract: it returns a tool-calls response with no `reasoning_content`, then on the next turn fails the request if `reasoning_content` is missing on the prior assistant message — which is the exact rule DeepSeek enforces.

- **Before the fix**: the run errors with the exact 400 from the issue.
- **After the fix**: the run completes cleanly. The follow-up request now carries `reasoning_content: ""` on the tool-calling assistant message, satisfying the API.
- **Cross-check against the real DeepSeek API**: openclaw ships the same workaround (inject empty `reasoning_content` on tool-calling turns) against the live endpoint — https://github.com/openclaw/openclaw/commit/678ed5d512 — confirming the empty-string approach is accepted in production.
- **Unit tests**: 3 new tests cover the three branches of the new helper (inject when missing, preserve when present, skip when no `tool_calls`). 12/12 pass; full converter suite (73 tests) and `npm run typecheck` clean.

A separate comment below describes the mock-server reproduction commands and full test summary if a reviewer wants to run it locally.

## Scope / Risk

- Main risk: the fix sends `""` when no reasoning text was produced. Corroborated by openclaw's production fix; no source-only test can fully prove live-API acceptance, but the precedent removes most of that uncertainty.
- Not exercised: multi-tool-call rounds (3+ sequential tools), session resume / compression replay paths.
- Breaking changes / migration: none. Provider-scoped to DeepSeek (matches `api.deepseek.com` base URL or any model name containing "deepseek").

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Verified on macOS via mock-server reproduction + unit tests + typecheck. Pure provider-side normalization, no platform-dependent code paths.

## Linked Issues / Bugs

Fixes #3695
Fixes #3619
Relates to #3724