### PR TITLE
fix(core): replay DeepSeek reasoning_content on all assistant turns

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/deepseek.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/deepseek.test.ts
@@ -180,9 +180,9 @@ describe('DeepSeekOpenAICompatibleProvider', () => {
     });
 
     // https://github.com/QwenLM/qwen-code/issues/3695 — DeepSeek's thinking
-    // mode rejects subsequent requests when a prior tool-calling assistant
-    // turn omits reasoning_content, even if the model itself returned no
-    // reasoning text. The provider must always send the field.
+    // mode rejects subsequent requests when any prior assistant turn omits
+    // reasoning_content, even if the model itself returned no reasoning text.
+    // The provider must always send the field.
     it('injects empty reasoning_content on tool-calling assistant turns missing it', () => {
       const originalRequest: OpenAI.Chat.ChatCompletionCreateParams = {
         model: 'deepseek-v4-flash',
@@ -245,7 +245,7 @@ describe('DeepSeekOpenAICompatibleProvider', () => {
       expect(assistant.reasoning_content).toBe('Let me glob first.');
     });
 
-    it('does not add reasoning_content to assistant turns without tool_calls', () => {
+    it('injects empty reasoning_content on assistant turns without tool_calls', () => {
       const originalRequest: OpenAI.Chat.ChatCompletionCreateParams = {
         model: 'deepseek-v4-flash',
         messages: [
@@ -259,7 +259,7 @@ describe('DeepSeekOpenAICompatibleProvider', () => {
       const assistant = result.messages?.[1] as {
         reasoning_content?: string;
       };
-      expect(assistant.reasoning_content).toBeUndefined();
+      expect(assistant.reasoning_content).toBe('');
     });
   });
 

--- a/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/deepseek.ts
@@ -108,17 +108,14 @@ function flattenContentParts(
 }
 
 // DeepSeek's thinking mode requires reasoning_content to be replayed on every
-// prior assistant turn that carried tool_calls. The model may legitimately
-// return a tool round without reasoning text, so the field can be missing
-// when we rebuild the request. Send an empty string in that case so the API
-// contract is satisfied. https://github.com/QwenLM/qwen-code/issues/3695
+// prior assistant turn, including ones without tool_calls. The model may
+// legitimately return a turn without reasoning text, so the field can be
+// missing when we rebuild the request. Send an empty string in that case so
+// the API contract is satisfied. https://github.com/QwenLM/qwen-code/issues/3695
 function ensureReasoningContentOnToolCalls(
   message: OpenAI.Chat.ChatCompletionMessageParam,
 ): OpenAI.Chat.ChatCompletionMessageParam {
   if (message.role !== 'assistant') {
-    return message;
-  }
-  if (!Array.isArray(message.tool_calls) || message.tool_calls.length === 0) {
     return message;
   }
   const extended = message as ExtendedChatCompletionAssistantMessageParam;


### PR DESCRIPTION
## Summary

- **What changed**: Extend the DeepSeek `reasoning_content` normalization to **all** prior assistant turns, not just ones with `tool_calls`.
- **Why it changed**: #3729 (the prior fix) only stamped `reasoning_content` on tool-calling assistant turns. Live testing against `api.deepseek.com` shows the API also rejects follow-up requests when an assistant turn **without** `tool_calls` is missing `reasoning_content` — same HTTP 400 (`The reasoning_content in the thinking mode must be passed back to the API`), just from a different turn. The guard was too narrow.
- **Reviewer focus**: that the empty-string fallback now applies on every assistant turn (not only tool-calling ones), and existing `reasoning_content` is still preserved.

## Validation

**Before**(A series of failed requests)
<img width="1348" height="1084" alt="image" src="https://github.com/user-attachments/assets/e5673a23-e9c7-4cb9-b500-a311b10993b1" />
<img width="1408" height="690" alt="image" src="https://github.com/user-attachments/assets/dfcf47af-e78d-4118-9786-2b25222010e7" />

**After**(Request succeed)
<img width="1306" height="450" alt="image" src="https://github.com/user-attachments/assets/09bc0593-ff75-4846-86e6-11eb42109c36" />

**Proof of response with tool_calls but no reason_content**
<img width="1350" height="1076" alt="image" src="https://github.com/user-attachments/assets/573b7902-c247-4744-b2a4-d3bc78d2ac1f" />

## Scope / Risk

- Main risk: an empty string is now stamped on every assistant turn that lacks `reasoning_content`. The previous PR (#3729) already validated the empty-string approach against the live DeepSeek endpoint for tool-calling turns; this change extends the same fallback to non-tool-calling turns.
- Not covered: session resume / compression replay paths.
- Breaking changes / migration: none. Provider-scoped to DeepSeek.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Verified on macOS via unit tests + typecheck. Pure provider-side normalization, no platform-dependent code paths.

## Linked Issues / Bugs

Relates to #3695, #3729