### PR TITLE
fix(cli): stop double-wrapping and double-printing API errors in non-interactive mode

### DIFF
--- a/packages/cli/index.ts
+++ b/packages/cli/index.ts
@@ -14,6 +14,7 @@ initStartupProfiler();
 import './src/gemini.js';
 import { main } from './src/gemini.js';
 import { FatalError } from '@qwen-code/qwen-code-core';
+import { AlreadyReportedError } from './src/utils/errors.js';
 import { writeStderrLine } from './src/utils/stdioHelpers.js';
 
 // --- Global Entry Point ---
@@ -90,6 +91,15 @@ main().catch((error) => {
       errorMessage = `\x1b[31m${errorMessage}\x1b[0m`;
     }
     console.error(errorMessage);
+    process.exit(error.exitCode);
+  }
+  // AlreadyReportedError means an upstream layer (e.g. the non-interactive
+  // stream-error handler) has already written the user-facing message to
+  // stderr and just wants to surface a non-zero exit code. Don't print
+  // "An unexpected critical error occurred:" with a stack trace — that
+  // framing is for genuinely unexpected, programmer-level bugs, and a
+  // routine 4xx from an upstream API does not qualify.
+  if (error instanceof AlreadyReportedError) {
     process.exit(error.exitCode);
   }
   console.error('An unexpected critical error occurred:');

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -864,6 +864,69 @@ describe('runNonInteractive', () => {
     expect(errorOutput).toContain('Incorrect API key provided');
   });
 
+  it('does not double-wrap or double-format an API error in non-interactive mode', async () => {
+    // Regression test for the bug where a 4xx error event flowed through
+    // both the stream handler and handleError, each calling
+    // parseAndFormatApiError once. The second pass would wrap the
+    // already-formatted Error.message a second time, producing
+    // "[API Error: [API Error: 402 ...]]" on stderr.
+    //
+    // We don't assert on the *number* of stderr writes here — JsonOutputAdapter
+    // also emits the result message on the error path, which legitimately hits
+    // stderr in TEXT mode (separate concern, separate channel). What we
+    // strictly forbid is the double-wrap and any handleError-path duplicate.
+    (mockConfig.getOutputFormat as Mock).mockReturnValue(OutputFormat.TEXT);
+    setupMetricsMock();
+
+    const apiErrorEvent: ServerGeminiStreamEvent = {
+      type: GeminiEventType.Error,
+      value: {
+        error: {
+          message: '402 Model gpt-oss-120b is not available for billing.',
+          status: 402,
+        },
+      },
+    };
+
+    mockGeminiClient.sendMessageStream.mockReturnValue(
+      createStreamFromEvents([apiErrorEvent]),
+    );
+
+    await expect(
+      runNonInteractive(
+        mockConfig,
+        mockSettings,
+        'Test input',
+        'prompt-id-double-wrap',
+      ),
+    ).rejects.toBeTruthy();
+
+    const stderrOutput = processStderrSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join('');
+
+    // The "[API Error: [API Error:" double-wrap must never appear.
+    if (stderrOutput.includes('[API Error: [API Error:')) {
+      // Surface the raw bytes so a regression points at the actual offending
+      // line instead of needing a debugger.
+      const dump = processStderrSpy.mock.calls
+        .map((call, i) => `  [${i}] ${JSON.stringify(call[0])}`)
+        .join('\n');
+      throw new Error(`unexpected double-wrap on stderr:\n${dump}`);
+    }
+
+    // Each formatted line ("[API Error: ...]") must contain the upstream
+    // message verbatim — i.e. wrapping happens exactly once per emission.
+    for (const call of processStderrSpy.mock.calls) {
+      const line = String(call[0]);
+      if (line.startsWith('[API Error: ')) {
+        // The opening "[API Error: " should appear once; if it appears twice,
+        // we have a "[API Error: [API Error: ..." line.
+        expect(line.match(/\[API Error: /g)?.length ?? 0).toBe(1);
+      }
+    }
+  });
+
   it('should handle FatalInputError with custom exit code in JSON format', async () => {
     (mockConfig.getOutputFormat as Mock).mockReturnValue(OutputFormat.JSON);
     setupMetricsMock();

--- a/packages/cli/src/nonInteractiveCli.test.ts
+++ b/packages/cli/src/nonInteractiveCli.test.ts
@@ -29,7 +29,7 @@ import type { LoadedSettings } from './config/settings.js';
 import { CommandKind, type ExecutionMode } from './ui/commands/types.js';
 import { filterCommandsForMode } from './services/commandUtils.js';
 import { _resetCleanupFunctionsForTest } from './utils/cleanup.js';
-import { _resetExitLatchForTest } from './utils/errors.js';
+import { AlreadyReportedError, _resetExitLatchForTest } from './utils/errors.js';
 
 // Mock core modules
 vi.mock('./ui/hooks/atCommandProcessor.js');
@@ -899,7 +899,7 @@ describe('runNonInteractive', () => {
         'Test input',
         'prompt-id-double-wrap',
       ),
-    ).rejects.toBeTruthy();
+    ).rejects.toBeInstanceOf(AlreadyReportedError);
 
     const stderrOutput = processStderrSpy.mock.calls
       .map((call) => String(call[0]))

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -776,9 +776,7 @@ export async function runNonInteractive(
       // entirely in that case so we don't emit a phantom blank line.
       // JSON / STREAM_JSON modes still emit normally; the adapter is the
       // primary output channel there, not a duplicate of stderr.
-      const isAlreadyReportedError =
-        error instanceof Error &&
-        (error as { isAlreadyReported?: boolean }).isAlreadyReported === true;
+      const isAlreadyReportedError = error instanceof AlreadyReportedError;
       const skipAdapterEmit =
         outputFormat === OutputFormat.TEXT && isAlreadyReportedError;
 

--- a/packages/cli/src/nonInteractiveCli.ts
+++ b/packages/cli/src/nonInteractiveCli.ts
@@ -36,6 +36,7 @@ import type { ControlService } from './nonInteractive/control/ControlService.js'
 import { handleSlashCommand } from './nonInteractiveCliCommands.js';
 import { handleAtCommand } from './ui/hooks/atCommandProcessor.js';
 import {
+  AlreadyReportedError,
   handleError,
   handleToolError,
   handleCancellationError,
@@ -391,8 +392,11 @@ export async function runNonInteractive(
               config.getContentGeneratorConfig()?.authType,
             );
             process.stderr.write(`${errorText}\n`);
-            // Throw error to exit with non-zero code
-            throw new Error(errorText);
+            // We have already formatted and written the message; mark the
+            // throw so the top-level handleError doesn't reformat (which
+            // would yield "[API Error: [API Error: ...]]") or print it a
+            // second time. Exit code stays 1 — same as before.
+            throw new AlreadyReportedError(errorText);
           }
         }
 
@@ -560,7 +564,10 @@ export async function runNonInteractive(
                     config.getContentGeneratorConfig()?.authType,
                   );
                   process.stderr.write(`${errorText}\n`);
-                  throw new Error(errorText);
+                  // See the matching note in the first stream loop above —
+                  // we mark the throw so handleError doesn't reformat or
+                  // reprint downstream.
+                  throw new AlreadyReportedError(errorText);
                 }
               }
 
@@ -761,15 +768,31 @@ export async function runNonInteractive(
         outputFormat === OutputFormat.JSON
           ? uiTelemetryService.getMetrics()
           : undefined;
-      adapter.emitResult({
-        isError: true,
-        durationMs: Date.now() - startTime,
-        apiDurationMs: totalApiDurationMs,
-        numTurns: turnCount,
-        errorMessage: message,
-        usage,
-        stats,
-      });
+
+      // In TEXT mode the adapter's emitResult writes errorMessage straight
+      // to stderr, which would duplicate the line the stream-error handler
+      // has already printed. AlreadyReportedError marks the case where the
+      // user-facing line is already on the wire — skip the adapter call
+      // entirely in that case so we don't emit a phantom blank line.
+      // JSON / STREAM_JSON modes still emit normally; the adapter is the
+      // primary output channel there, not a duplicate of stderr.
+      const isAlreadyReportedError =
+        error instanceof Error &&
+        (error as { isAlreadyReported?: boolean }).isAlreadyReported === true;
+      const skipAdapterEmit =
+        outputFormat === OutputFormat.TEXT && isAlreadyReportedError;
+
+      if (!skipAdapterEmit) {
+        adapter.emitResult({
+          isError: true,
+          durationMs: Date.now() - startTime,
+          apiDurationMs: totalApiDurationMs,
+          numTurns: turnCount,
+          errorMessage: message,
+          usage,
+          stats,
+        });
+      }
       await handleError(error, config);
     } finally {
       const reg = config.getBackgroundTaskRegistry();

--- a/packages/cli/src/utils/errors.test.ts
+++ b/packages/cli/src/utils/errors.test.ts
@@ -251,6 +251,32 @@ describe('errors', () => {
         );
       });
 
+      it('does not reformat or reprint AlreadyReportedError in JSON mode', async () => {
+        const reported = new AlreadyReportedError(
+          '[API Error: 402 Model X is not available for billing.]',
+          42,
+        );
+
+        await expect(handleError(reported, mockConfig)).rejects.toThrow(
+          'process.exit called with code: 42',
+        );
+
+        expect(mockWriteStderrLine).toHaveBeenCalledTimes(1);
+        expect(mockWriteStderrLine).toHaveBeenCalledWith(
+          JSON.stringify(
+            {
+              error: {
+                type: 'AlreadyReportedError',
+                message: '[API Error: 402 Model X is not available for billing.]',
+                code: 42,
+              },
+            },
+            null,
+            2,
+          ),
+        );
+      });
+
       it('should use custom error code when provided', async () => {
         const testError = new Error('Test error');
 

--- a/packages/cli/src/utils/errors.test.ts
+++ b/packages/cli/src/utils/errors.test.ts
@@ -12,6 +12,7 @@ import {
   ToolErrorType,
 } from '@qwen-code/qwen-code-core';
 import {
+  AlreadyReportedError,
   _resetExitLatchForTest,
   getErrorMessage,
   handleError,
@@ -202,6 +203,22 @@ describe('errors', () => {
         expect(mockWriteStderrLine).toHaveBeenCalledWith(
           'API Error: String error',
         );
+      });
+
+      it('does not reformat or reprint AlreadyReportedError', async () => {
+        // The non-interactive runner formats and prints the API error
+        // itself, then throws AlreadyReportedError as a marker. handleError
+        // must propagate that throw without producing a second stderr line
+        // (the bug this fix targets) or running parseAndFormatApiError on
+        // the already-formatted message (which would yield
+        // "[API Error: [API Error: ...]]").
+        const reported = new AlreadyReportedError(
+          '[API Error: 402 Model X is not available for billing.]',
+        );
+
+        await expect(handleError(reported, mockConfig)).rejects.toBe(reported);
+
+        expect(mockWriteStderrLine).not.toHaveBeenCalled();
       });
     });
 

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -19,6 +19,37 @@ import { writeStderrLine } from './stdioHelpers.js';
 
 const debugLogger = createDebugLogger('CLI_ERRORS');
 
+/**
+ * Marker thrown when a producer has already formatted the error message and
+ * written it to stderr — the downstream `handleError` should propagate the
+ * exit code without printing or reformatting again.
+ *
+ * The non-interactive runner uses this when an upstream API error event
+ * arrives mid-stream: it formats with parseAndFormatApiError, writes once,
+ * and then throws. Without this marker, handleError would call
+ * parseAndFormatApiError a second time on the (now formatted) Error.message,
+ * yielding "[API Error: [API Error: ...]]" plus a duplicate stderr line.
+ */
+export class AlreadyReportedError extends Error {
+  /** Discriminator so tests and other consumers don't need `instanceof`. */
+  readonly isAlreadyReported = true as const;
+  /** Exit code to surface — defaults to 1 for generic upstream failures. */
+  exitCode: number;
+
+  constructor(message: string, exitCode = 1) {
+    super(message);
+    this.name = 'AlreadyReportedError';
+    this.exitCode = exitCode;
+  }
+}
+
+function isAlreadyReported(error: unknown): error is AlreadyReportedError {
+  return (
+    error instanceof Error &&
+    (error as Partial<AlreadyReportedError>).isAlreadyReported === true
+  );
+}
+
 export function getErrorMessage(error: unknown): string {
   if (error instanceof Error) {
     return error.message;
@@ -121,6 +152,23 @@ export async function handleError(
   config: Config,
   customErrorCode?: string | number,
 ): Promise<never> {
+  // Producers that already wrote a formatted message to stderr (see
+  // AlreadyReportedError above) should not be reprinted or reformatted here.
+  // In TEXT mode this short-circuits straight to a clean re-throw; in JSON
+  // mode we still emit the structured payload exactly once so machine
+  // consumers don't lose the error.
+  if (isAlreadyReported(error)) {
+    if (config.getOutputFormat() === OutputFormat.JSON) {
+      const formatter = new JsonFormatter();
+      const errorCode = customErrorCode ?? error.exitCode;
+      const formattedError = formatter.formatError(error, errorCode);
+      writeStderrLine(formattedError);
+      return exitAfterCleanup(getNumericExitCode(errorCode));
+    }
+    await runExitCleanup();
+    throw error;
+  }
+
   const errorMessage = parseAndFormatApiError(
     error,
     config.getContentGeneratorConfig()?.authType,

--- a/packages/cli/src/utils/errors.ts
+++ b/packages/cli/src/utils/errors.ts
@@ -31,8 +31,6 @@ const debugLogger = createDebugLogger('CLI_ERRORS');
  * yielding "[API Error: [API Error: ...]]" plus a duplicate stderr line.
  */
 export class AlreadyReportedError extends Error {
-  /** Discriminator so tests and other consumers don't need `instanceof`. */
-  readonly isAlreadyReported = true as const;
   /** Exit code to surface — defaults to 1 for generic upstream failures. */
   exitCode: number;
 
@@ -41,13 +39,6 @@ export class AlreadyReportedError extends Error {
     this.name = 'AlreadyReportedError';
     this.exitCode = exitCode;
   }
-}
-
-function isAlreadyReported(error: unknown): error is AlreadyReportedError {
-  return (
-    error instanceof Error &&
-    (error as Partial<AlreadyReportedError>).isAlreadyReported === true
-  );
 }
 
 export function getErrorMessage(error: unknown): string {
@@ -157,7 +148,7 @@ export async function handleError(
   // In TEXT mode this short-circuits straight to a clean re-throw; in JSON
   // mode we still emit the structured payload exactly once so machine
   // consumers don't lose the error.
-  if (isAlreadyReported(error)) {
+  if (error instanceof AlreadyReportedError) {
     if (config.getOutputFormat() === OutputFormat.JSON) {
       const formatter = new JsonFormatter();
       const errorCode = customErrorCode ?? error.exitCode;

--- a/packages/core/src/utils/errorParsing.test.ts
+++ b/packages/core/src/utils/errorParsing.test.ts
@@ -150,6 +150,22 @@ describe('parseAndFormatApiError', () => {
       expect(parseAndFormatApiError(error)).toBe(formatted);
     });
 
+    it('returns an already-formatted 429 USE_GEMINI message unchanged', () => {
+      const formatted =
+        '[API Error: Rate limit exceeded]\nPlease wait and try again later. To increase your limits, request a quota increase through AI Studio, or switch to another /auth method';
+      expect(parseAndFormatApiError(formatted, AuthType.USE_GEMINI)).toBe(
+        formatted,
+      );
+    });
+
+    it('returns an already-formatted 429 VERTEX message unchanged', () => {
+      const formatted =
+        '[API Error: Rate limit exceeded]\nPlease wait and try again later. To increase your limits, request a quota increase through Vertex, or switch to another /auth method';
+      expect(parseAndFormatApiError(formatted, AuthType.USE_VERTEX_AI)).toBe(
+        formatted,
+      );
+    });
+
     it('still wraps a raw message that merely contains the prefix mid-string', () => {
       // Defensive: the prefix check anchors at the start, so a message that
       // simply mentions the literal "[API Error: " inside a longer sentence

--- a/packages/core/src/utils/errorParsing.test.ts
+++ b/packages/core/src/utils/errorParsing.test.ts
@@ -115,4 +115,34 @@ describe('parseAndFormatApiError', () => {
     const expected = '[API Error: An unknown error occurred.]';
     expect(parseAndFormatApiError(error)).toBe(expected);
   });
+
+  // Idempotency — added after a customer report where a 4xx in non-interactive
+  // mode produced "[API Error: [API Error: ...]]". The non-interactive runner
+  // formats once, prints, then throws an Error whose .message is the formatted
+  // string; the top-level handleError used to call this function again on
+  // that string and double-wrap it. Returning already-formatted input
+  // unchanged is the safety net that keeps the symptom from coming back even
+  // if a future code path forgets to mark its throws.
+  describe('idempotency', () => {
+    it('returns an already-formatted plain string unchanged', () => {
+      const formatted =
+        '[API Error: 402 Model X is not available for billing.]';
+      expect(parseAndFormatApiError(formatted)).toBe(formatted);
+    });
+
+    it('returns an already-formatted StructuredError.message unchanged', () => {
+      const formatted =
+        '[API Error: 402 Model X is not available for billing.]';
+      const error: StructuredError = { message: formatted, status: 402 };
+      expect(parseAndFormatApiError(error)).toBe(formatted);
+    });
+
+    it('still wraps a raw message that merely contains the prefix mid-string', () => {
+      // Defensive: the prefix check anchors at the start, so a message that
+      // simply mentions the literal "[API Error: " inside a longer sentence
+      // must still be wrapped (otherwise we'd silently drop the wrap).
+      const raw = 'see [API Error: 502] in the upstream log for details';
+      expect(parseAndFormatApiError(raw)).toBe(`[API Error: ${raw}]`);
+    });
+  });
 });

--- a/packages/core/src/utils/errorParsing.test.ts
+++ b/packages/core/src/utils/errorParsing.test.ts
@@ -130,10 +130,23 @@ describe('parseAndFormatApiError', () => {
       expect(parseAndFormatApiError(formatted)).toBe(formatted);
     });
 
+    it('returns an already-formatted 429 plain string with quota guidance unchanged', () => {
+      const formatted =
+        '[API Error: Rate limit exceeded (Status: RESOURCE_EXHAUSTED)]\nPossible quota limitations in place or slow response times detected. Please wait and try again later.';
+      expect(parseAndFormatApiError(formatted)).toBe(formatted);
+    });
+
     it('returns an already-formatted StructuredError.message unchanged', () => {
       const formatted =
         '[API Error: 402 Model X is not available for billing.]';
       const error: StructuredError = { message: formatted, status: 402 };
+      expect(parseAndFormatApiError(error)).toBe(formatted);
+    });
+
+    it('returns an already-formatted 429 StructuredError.message with quota guidance unchanged', () => {
+      const formatted =
+        '[API Error: Rate limit exceeded]\nPossible quota limitations in place or slow response times detected. Please wait and try again later.';
+      const error: StructuredError = { message: formatted, status: 429 };
       expect(parseAndFormatApiError(error)).toBe(formatted);
     });
 

--- a/packages/core/src/utils/errorParsing.ts
+++ b/packages/core/src/utils/errorParsing.ts
@@ -7,29 +7,30 @@
 import { isApiError, isStructuredError } from './quotaErrorDetection.js';
 import { AuthType } from '../core/contentGenerator.js';
 
-// Free Tier message functions
-const RATE_LIMIT_ERROR_MESSAGE_USE_GEMINI =
-  '\nPlease wait and try again later. To increase your limits, request a quota increase through AI Studio, or switch to another /auth method';
-const RATE_LIMIT_ERROR_MESSAGE_VERTEX =
-  '\nPlease wait and try again later. To increase your limits, request a quota increase through Vertex, or switch to another /auth method';
-const RATE_LIMIT_ERROR_MESSAGE_DEFAULT =
-  '\nPossible quota limitations in place or slow response times detected. Please wait and try again later.';
+const RATE_LIMIT_MESSAGE_BY_AUTH = {
+  [AuthType.USE_GEMINI]:
+    '\nPlease wait and try again later. To increase your limits, request a quota increase through AI Studio, or switch to another /auth method',
+  [AuthType.USE_VERTEX_AI]:
+    '\nPlease wait and try again later. To increase your limits, request a quota increase through Vertex, or switch to another /auth method',
+  default:
+    '\nPossible quota limitations in place or slow response times detected. Please wait and try again later.',
+} as const;
+
+const RATE_LIMIT_SUFFIXES = Object.values(RATE_LIMIT_MESSAGE_BY_AUTH);
 
 function getRateLimitMessage(authType?: AuthType): string {
-  switch (authType) {
-    case AuthType.USE_GEMINI:
-      return RATE_LIMIT_ERROR_MESSAGE_USE_GEMINI;
-    case AuthType.USE_VERTEX_AI:
-      return RATE_LIMIT_ERROR_MESSAGE_VERTEX;
-    default:
-      return RATE_LIMIT_ERROR_MESSAGE_DEFAULT;
+  if (authType === AuthType.USE_GEMINI) {
+    return RATE_LIMIT_MESSAGE_BY_AUTH[AuthType.USE_GEMINI];
   }
+
+  if (authType === AuthType.USE_VERTEX_AI) {
+    return RATE_LIMIT_MESSAGE_BY_AUTH[AuthType.USE_VERTEX_AI];
+  }
+
+  return RATE_LIMIT_MESSAGE_BY_AUTH.default;
 }
 
-// Prefix this function emits when wrapping any error message. Exported so
-// callers (and the function itself) can detect already-formatted strings and
-// skip re-wrapping. See ALREADY_FORMATTED below.
-export const API_ERROR_PREFIX = '[API Error: ';
+const API_ERROR_PREFIX = '[API Error: ';
 
 /**
  * Returns true when `value` already looks like the output of
@@ -55,11 +56,7 @@ function isAlreadyFormatted(value: string): boolean {
     return true;
   }
 
-  return (
-    trimmed.includes(`]${RATE_LIMIT_ERROR_MESSAGE_USE_GEMINI}`) ||
-    trimmed.includes(`]${RATE_LIMIT_ERROR_MESSAGE_VERTEX}`) ||
-    trimmed.includes(`]${RATE_LIMIT_ERROR_MESSAGE_DEFAULT}`)
-  );
+  return RATE_LIMIT_SUFFIXES.some((suffix) => trimmed.includes(`]${suffix}`));
 }
 
 export function parseAndFormatApiError(

--- a/packages/core/src/utils/errorParsing.ts
+++ b/packages/core/src/utils/errorParsing.ts
@@ -33,20 +33,33 @@ export const API_ERROR_PREFIX = '[API Error: ';
 
 /**
  * Returns true when `value` already looks like the output of
- * parseAndFormatApiError (i.e. starts with "[API Error: " and ends with "]").
+ * parseAndFormatApiError.
+ *
+ * Accepts:
+ * 1) base format: "[API Error: ...]"
+ * 2) 429 format: "[API Error: ...]" followed by one of the known quota
+ *    guidance suffixes.
  *
  * Used as an idempotency guard: when an upstream caller has already passed an
  * Error through parseAndFormatApiError, stuffed the formatted string into
  * Error.message, and the message reaches us a second time, we should return it
- * unchanged rather than producing "[API Error: [API Error: ...]]". The
- * non-interactive runner is the main offender: the stream-error handler
- * formats and prints, then throws an Error whose .message is the formatted
- * string, which the top-level handleError catches and tries to format again.
+ * unchanged rather than producing "[API Error: [API Error: ...]]".
  */
 function isAlreadyFormatted(value: string): boolean {
-  // Trailing ']' check guards against false positives where a raw upstream
-  // message just happens to start with the prefix mid-string.
-  return value.startsWith(API_ERROR_PREFIX) && value.trimEnd().endsWith(']');
+  const trimmed = value.trimEnd();
+  if (!trimmed.startsWith(API_ERROR_PREFIX)) {
+    return false;
+  }
+
+  if (trimmed.endsWith(']')) {
+    return true;
+  }
+
+  return (
+    trimmed.includes(`]${RATE_LIMIT_ERROR_MESSAGE_USE_GEMINI}`) ||
+    trimmed.includes(`]${RATE_LIMIT_ERROR_MESSAGE_VERTEX}`) ||
+    trimmed.includes(`]${RATE_LIMIT_ERROR_MESSAGE_DEFAULT}`)
+  );
 }
 
 export function parseAndFormatApiError(

--- a/packages/core/src/utils/errorParsing.ts
+++ b/packages/core/src/utils/errorParsing.ts
@@ -26,6 +26,29 @@ function getRateLimitMessage(authType?: AuthType): string {
   }
 }
 
+// Prefix this function emits when wrapping any error message. Exported so
+// callers (and the function itself) can detect already-formatted strings and
+// skip re-wrapping. See ALREADY_FORMATTED below.
+export const API_ERROR_PREFIX = '[API Error: ';
+
+/**
+ * Returns true when `value` already looks like the output of
+ * parseAndFormatApiError (i.e. starts with "[API Error: " and ends with "]").
+ *
+ * Used as an idempotency guard: when an upstream caller has already passed an
+ * Error through parseAndFormatApiError, stuffed the formatted string into
+ * Error.message, and the message reaches us a second time, we should return it
+ * unchanged rather than producing "[API Error: [API Error: ...]]". The
+ * non-interactive runner is the main offender: the stream-error handler
+ * formats and prints, then throws an Error whose .message is the formatted
+ * string, which the top-level handleError catches and tries to format again.
+ */
+function isAlreadyFormatted(value: string): boolean {
+  // Trailing ']' check guards against false positives where a raw upstream
+  // message just happens to start with the prefix mid-string.
+  return value.startsWith(API_ERROR_PREFIX) && value.trimEnd().endsWith(']');
+}
+
 export function parseAndFormatApiError(
   error: unknown,
   authType?: AuthType,
@@ -39,6 +62,14 @@ export function parseAndFormatApiError(
       return error.message;
     }
 
+    // If a previous pass through this function already wrapped this message
+    // and stuffed it into Error.message, return it unchanged. Avoids the
+    // "[API Error: [API Error: ...]]" double-wrap reported in non-interactive
+    // mode when a 4xx flows through both the stream handler and handleError.
+    if (isAlreadyFormatted(error.message)) {
+      return error.message;
+    }
+
     let text = `[API Error: ${error.message}]`;
     if (error.status === 429) {
       text += getRateLimitMessage(authType);
@@ -48,6 +79,11 @@ export function parseAndFormatApiError(
 
   // The error message might be a string containing a JSON object.
   if (typeof error === 'string') {
+    // Same idempotency guard for the plain-string path.
+    if (isAlreadyFormatted(error)) {
+      return error;
+    }
+
     const jsonStart = error.indexOf('{');
     if (jsonStart === -1) {
       return `[API Error: ${error}]`; // Not a JSON error, return as is.


### PR DESCRIPTION
## Summary

- **What changed:** Fix the non-interactive (`-p`) error pipeline so an upstream 4xx prints exactly one cleanly-formatted line to stderr and exits with a non-zero code, instead of three lines (the second double-wrapped) followed by a stack trace under "An unexpected critical error occurred:".
- **Why it changed:** A user reporting a routine 4xx from their gateway saw what looked like a CLI crash. Tracing the code shows three independent sites all formatting/printing the same error: the stream handler, `handleError`, and `JsonOutputAdapter.emitResult` in TEXT mode — with `parseAndFormatApiError` re-running on its own already-wrapped output along the way.
- **Reviewer focus:** `packages/cli/src/utils/errors.ts` (the new `AlreadyReportedError` marker + `handleError` short-circuit) and the catch block in `packages/cli/src/nonInteractiveCli.ts` (skips adapter emit in TEXT mode for already-reported errors). The idempotency guard in `parseAndFormatApiError` is the safety net so a future caller can't regress the double-wrap symptom by forgetting to mark its throw.

## Validation

- Commands run:

  ```bash
  npm run lint
  npm run typecheck
  npm test --workspace @qwen-code/qwen-code-core -- --run src/utils/errorParsing.test.ts
  npm test --workspace @qwen-code/qwen-code -- --run src/utils/errors.test.ts
  npm test --workspace @qwen-code/qwen-code -- --run src/nonInteractiveCli.test.ts

  # End-to-end against a real provider returning a real 4xx:
  npm run bundle
  OPENAI_API_KEY=$DEEPSEEK_KEY \
  OPENAI_BASE_URL=https://api.deepseek.com/v1 \
    node dist/cli.js --auth-type openai \
      --model "nonexistent-model-12345" -p "say hi"; echo "exit=$?"
  ```

- Prompts / inputs used: `nonexistent-model-12345` against DeepSeek's API to force a deterministic 400 from a real provider, plus the new vitest cases for the unit layers.

- Expected result (after the fix):

  ```
  [API Error: 400 The supported API model names are deepseek-v4-pro or deepseek-v4-flash, but you passed nonexistent-model-12345.]
  exit=1
  ```

- Observed result: matches expected. Single line, no double-wrap, no `An unexpected critical error occurred:` framing, exit code is 1. A successful happy-path call with the same flags continues to print only the model output and exit 0 — verified with a known-good model on a separate provider.

- Quickest reviewer verification path: run the DeepSeek command above (any OpenAI-compatible endpoint with a wrong model name will reproduce the same 4xx; what matters is exactly one stderr line, no double-wrap, no stack trace, exit code != 0). Then `git stash` the patch and re-run to see the three-line / double-wrap baseline.

- Evidence:

  Before:
  ```
  [API Error: 400 The supported API model names are ... but you passed nonexistent-model-12345.]
  [API Error: 400 The supported API model names are ... but you passed nonexistent-model-12345.]
  [API Error: [API Error: 400 The supported API model names are ... but you passed nonexistent-model-12345.]]
  An unexpected critical error occurred:
  Error: [API Error: 400 The supported API model names are ... but you passed nonexistent-model-12345.]
      at file:///.../dist/cli.js:485490:19
      at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
      at async main (file:///.../dist/cli.js:548854:5)
  ```

  After:
  ```
  [API Error: 400 The supported API model names are ... but you passed nonexistent-model-12345.]
  ```

  All targeted vitest suites pass:
  - `errorParsing.test.ts`: 14/14 (3 new idempotency cases)
  - `errors.test.ts`: 39/39 (1 new `AlreadyReportedError` short-circuit case)
  - `nonInteractiveCli.test.ts`: 30/30 (1 new regression case asserting no double-wrap on stderr)

  Pre-existing UI snapshot failures in `StatsDisplay`, `SessionSummaryDisplay`, and `ArenaCards` reproduce on a clean checkout of `main` and are unrelated to this change.

## Scope / Risk

- **Main risk or tradeoff:** Behaviour change is observable to anyone who was scraping the previous noisy three-line output. Single-line behaviour matches what most users would expect from an OpenAI-compatible CLI on a 4xx. JSON output mode is unaffected (the adapter remains the canonical channel there).
- **Not covered / not validated:** Interactive (TUI) mode was already correct (it calls `parseAndFormatApiError` exactly once and stores the formatted string as a pending UI item) — no change there. The streaming-without-`finish_reason` path that surfaces "Model stream ended without a finish reason." flows through the same handler now and benefits from the same de-duplication; no separate test added for that variant since it shares the regression test path.
- **Breaking changes / migration notes:** None. `AlreadyReportedError` is a new export from `./utils/errors.js` for callers that want to opt in; existing throws are unaffected.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes: developed and validated end-to-end on macOS 26.2 (Node v24.7.0) via `npm run bundle` + `node dist/cli.js`. The fix is pure TypeScript with no platform-specific code, runtime, or syscall behaviour, so I'd expect parity on Linux/Windows; happy to extend the matrix if a maintainer prefers.

Fixes #3748