### PR TITLE
fix(cli): persist directory add entries

### DIFF
--- a/packages/cli/src/ui/commands/directoryCommand.test.tsx
+++ b/packages/cli/src/ui/commands/directoryCommand.test.tsx
@@ -9,6 +9,7 @@ import { directoryCommand, expandHomeDir } from './directoryCommand.js';
 import type { Config, WorkspaceContext } from '@qwen-code/qwen-code-core';
 import type { CommandContext } from './types.js';
 import { MessageType } from '../types.js';
+import { SettingScope } from '../../config/settings.js';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
@@ -55,6 +56,10 @@ describe('directoryCommand', () => {
         config: mockConfig,
         settings: {
           merged: {},
+          workspace: {
+            settings: {},
+          },
+          setValue: vi.fn(),
         },
       },
       ui: {
@@ -104,6 +109,39 @@ describe('directoryCommand', () => {
           text: `Successfully added directories:\n- ${newPath}`,
         }),
         expect.any(Number),
+      );
+    });
+
+    it('should persist added directories to workspace settings', async () => {
+      const existingPath = path.normalize('/home/user/existing-project');
+      const newPath = path.normalize('/home/user/new-project');
+      mockContext.services.settings.workspace.settings = {
+        context: { includeDirectories: [existingPath] },
+      };
+
+      if (!addCommand?.action) throw new Error('No action');
+      await addCommand.action(mockContext, newPath);
+
+      expect(mockContext.services.settings.setValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'context.includeDirectories',
+        [existingPath, newPath],
+      );
+    });
+
+    it('should not duplicate existing workspace settings when persisting', async () => {
+      const existingPath = path.normalize('/home/user/existing-project');
+      mockContext.services.settings.workspace.settings = {
+        context: { includeDirectories: [existingPath] },
+      };
+
+      if (!addCommand?.action) throw new Error('No action');
+      await addCommand.action(mockContext, existingPath);
+
+      expect(mockContext.services.settings.setValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'context.includeDirectories',
+        [existingPath],
       );
     });
 

--- a/packages/cli/src/ui/commands/directoryCommand.test.tsx
+++ b/packages/cli/src/ui/commands/directoryCommand.test.tsx
@@ -63,6 +63,7 @@ describe('directoryCommand', () => {
           merged: {},
           workspace: {
             settings: {},
+            originalSettings: {},
           },
           setValue: vi.fn(),
         },
@@ -123,6 +124,9 @@ describe('directoryCommand', () => {
       mockContext.services.settings.workspace.settings = {
         context: { includeDirectories: [existingPath] },
       };
+      mockContext.services.settings.workspace.originalSettings = {
+        context: { includeDirectories: [existingPath] },
+      };
 
       if (!addCommand?.action) throw new Error('No action');
       await addCommand.action(mockContext, newPath);
@@ -137,6 +141,9 @@ describe('directoryCommand', () => {
     it('should not duplicate existing workspace settings when persisting', async () => {
       const existingPath = path.normalize('/home/user/existing-project');
       mockContext.services.settings.workspace.settings = {
+        context: { includeDirectories: [existingPath] },
+      };
+      mockContext.services.settings.workspace.originalSettings = {
         context: { includeDirectories: [existingPath] },
       };
 
@@ -166,6 +173,52 @@ describe('directoryCommand', () => {
           text: `Successfully added directories:\n- ${skippedPath}`,
         }),
         expect.any(Number),
+      );
+    });
+
+    it('should show already-added directories without an empty success message', async () => {
+      const existingPath = path.normalize('/home/user/project1');
+
+      if (!addCommand?.action) throw new Error('No action');
+      await addCommand.action(mockContext, existingPath);
+
+      expect(mockContext.services.settings.setValue).not.toHaveBeenCalled();
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: `Directories already in workspace:\n- ${existingPath}`,
+        }),
+        expect.any(Number),
+      );
+      expect(mockContext.ui.addItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: 'Successfully added QWEN.md files from the following directories if there are:\n- ',
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('should preserve env-var-form include directories when persisting', async () => {
+      const originalExistingPath = '$HOME/existing-project';
+      const resolvedExistingPath = path.normalize(
+        '/home/user/existing-project',
+      );
+      const newPath = path.normalize('/home/user/new-project');
+      mockContext.services.settings.workspace.settings = {
+        context: { includeDirectories: [resolvedExistingPath] },
+      };
+      mockContext.services.settings.workspace.originalSettings = {
+        context: { includeDirectories: [originalExistingPath] },
+      };
+
+      if (!addCommand?.action) throw new Error('No action');
+      await addCommand.action(mockContext, newPath);
+
+      expect(mockContext.services.settings.setValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'context.includeDirectories',
+        [originalExistingPath, newPath],
       );
     });
 

--- a/packages/cli/src/ui/commands/directoryCommand.test.tsx
+++ b/packages/cli/src/ui/commands/directoryCommand.test.tsx
@@ -17,6 +17,7 @@ describe('directoryCommand', () => {
   let mockContext: CommandContext;
   let mockConfig: Config;
   let mockWorkspaceContext: WorkspaceContext;
+  let mockWorkspaceDirectories: string[];
   const addCommand = directoryCommand.subCommands?.find(
     (c) => c.name === 'add',
   );
@@ -25,14 +26,18 @@ describe('directoryCommand', () => {
   );
 
   beforeEach(() => {
+    mockWorkspaceDirectories = [
+      path.normalize('/home/user/project1'),
+      path.normalize('/home/user/project2'),
+    ];
     mockWorkspaceContext = {
-      addDirectory: vi.fn(),
-      getDirectories: vi
-        .fn()
-        .mockReturnValue([
-          path.normalize('/home/user/project1'),
-          path.normalize('/home/user/project2'),
-        ]),
+      addDirectory: vi.fn((directory: string) => {
+        const normalizedDirectory = path.normalize(directory);
+        if (!mockWorkspaceDirectories.includes(normalizedDirectory)) {
+          mockWorkspaceDirectories.push(normalizedDirectory);
+        }
+      }),
+      getDirectories: vi.fn(() => [...mockWorkspaceDirectories]),
     } as unknown as WorkspaceContext;
 
     mockConfig = {
@@ -145,6 +150,49 @@ describe('directoryCommand', () => {
       );
     });
 
+    it('should not persist directories skipped by the workspace context', async () => {
+      const skippedPath = path.normalize('/home/user/missing-project');
+      vi.mocked(mockWorkspaceContext.addDirectory).mockImplementation(
+        () => undefined,
+      );
+
+      if (!addCommand?.action) throw new Error('No action');
+      await addCommand.action(mockContext, skippedPath);
+
+      expect(mockContext.services.settings.setValue).not.toHaveBeenCalled();
+      expect(mockContext.ui.addItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: `Successfully added directories:\n- ${skippedPath}`,
+        }),
+        expect.any(Number),
+      );
+    });
+
+    it('should persist the directory path accepted by the workspace context', async () => {
+      const inputPath = 'linked-project';
+      const acceptedPath = path.normalize('/home/user/real-project');
+      vi.mocked(mockWorkspaceContext.addDirectory).mockImplementation(() => {
+        mockWorkspaceDirectories.push(acceptedPath);
+      });
+
+      if (!addCommand?.action) throw new Error('No action');
+      await addCommand.action(mockContext, inputPath);
+
+      expect(mockContext.services.settings.setValue).toHaveBeenCalledWith(
+        SettingScope.Workspace,
+        'context.includeDirectories',
+        [acceptedPath],
+      );
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: MessageType.INFO,
+          text: `Successfully added directories:\n- ${acceptedPath}`,
+        }),
+        expect.any(Number),
+      );
+    });
+
     it('should call addDirectory for each path and show a success message for multiple paths', async () => {
       const newPath1 = path.normalize('/home/user/new-project1');
       const newPath2 = path.normalize('/home/user/new-project2');
@@ -186,6 +234,9 @@ describe('directoryCommand', () => {
         (p: string) => {
           if (p === invalidPath) {
             throw error;
+          }
+          if (!mockWorkspaceDirectories.includes(p)) {
+            mockWorkspaceDirectories.push(p);
           }
         },
       );

--- a/packages/cli/src/ui/commands/directoryCommand.tsx
+++ b/packages/cli/src/ui/commands/directoryCommand.tsx
@@ -15,6 +15,7 @@ import {
   ConditionalRulesRegistry,
 } from '@qwen-code/qwen-code-core';
 import { t } from '../../i18n/index.js';
+import { SettingScope } from '../../config/settings.js';
 
 export function expandHomeDir(p: string): string {
   if (!p) {
@@ -90,7 +91,7 @@ export const directoryCommand: SlashCommand = {
       action: async (context: CommandContext, args: string) => {
         const {
           ui: { addItem },
-          services: { config },
+          services: { config, settings },
         } = context;
         const [...rest] = args.split(' ');
 
@@ -136,9 +137,10 @@ export const directoryCommand: SlashCommand = {
         const errors: string[] = [];
 
         for (const pathToAdd of pathsToAdd) {
+          const directory = expandHomeDir(pathToAdd.trim());
           try {
-            workspaceContext.addDirectory(expandHomeDir(pathToAdd.trim()));
-            added.push(pathToAdd.trim());
+            workspaceContext.addDirectory(directory);
+            added.push(directory);
           } catch (e) {
             const error = e as Error;
             errors.push(
@@ -150,15 +152,33 @@ export const directoryCommand: SlashCommand = {
           }
         }
 
+        if (added.length > 0) {
+          try {
+            const existingIncludeDirectories =
+              settings.workspace.settings.context?.includeDirectories ?? [];
+            const includeDirectories = Array.from(
+              new Set([...existingIncludeDirectories, ...added]),
+            );
+            settings.setValue(
+              SettingScope.Workspace,
+              'context.includeDirectories',
+              includeDirectories,
+            );
+          } catch (error) {
+            errors.push(
+              t('Error saving directories to workspace settings: {{error}}', {
+                error: (error as Error).message,
+              }),
+            );
+          }
+        }
+
         try {
           if (config.shouldLoadMemoryFromIncludeDirectories()) {
             const { memoryContent, fileCount, conditionalRules, projectRoot } =
               await loadServerHierarchicalMemory(
                 config.getWorkingDir(),
-                [
-                  ...config.getWorkspaceContext().getDirectories(),
-                  ...pathsToAdd,
-                ],
+                [...config.getWorkspaceContext().getDirectories(), ...added],
                 config.getFileService(),
                 config.getExtensionContextFilePaths(),
                 config.getFolderTrust(),

--- a/packages/cli/src/ui/commands/directoryCommand.tsx
+++ b/packages/cli/src/ui/commands/directoryCommand.tsx
@@ -138,9 +138,15 @@ export const directoryCommand: SlashCommand = {
 
         for (const pathToAdd of pathsToAdd) {
           const directory = expandHomeDir(pathToAdd.trim());
+          const directoriesBeforeAdd = new Set(
+            workspaceContext.getDirectories(),
+          );
           try {
             workspaceContext.addDirectory(directory);
-            added.push(directory);
+            const acceptedDirectories = workspaceContext
+              .getDirectories()
+              .filter((dir) => !directoriesBeforeAdd.has(dir));
+            added.push(...acceptedDirectories);
           } catch (e) {
             const error = e as Error;
             errors.push(

--- a/packages/cli/src/ui/commands/directoryCommand.tsx
+++ b/packages/cli/src/ui/commands/directoryCommand.tsx
@@ -30,6 +30,30 @@ export function expandHomeDir(p: string): string {
   return path.normalize(expandedPath);
 }
 
+function findExistingWorkspaceDirectory(
+  directory: string,
+  existingDirectories: Set<string>,
+): string | undefined {
+  if (existingDirectories.has(directory)) {
+    return directory;
+  }
+
+  try {
+    const absolutePath = path.isAbsolute(directory)
+      ? directory
+      : path.resolve(directory);
+    const resolvedDirectory = fs.realpathSync(absolutePath);
+    if (existingDirectories.has(resolvedDirectory)) {
+      return resolvedDirectory;
+    }
+  } catch {
+    // WorkspaceContext also skips unreadable paths; only report paths that
+    // resolve to an existing workspace directory as already present.
+  }
+
+  return undefined;
+}
+
 /**
  * Returns directory path completions for the given partial argument.
  * Supports comma-separated paths by completing only the last segment.
@@ -134,6 +158,7 @@ export const directoryCommand: SlashCommand = {
         }
 
         const added: string[] = [];
+        const alreadyAdded: string[] = [];
         const errors: string[] = [];
 
         for (const pathToAdd of pathsToAdd) {
@@ -146,7 +171,17 @@ export const directoryCommand: SlashCommand = {
             const acceptedDirectories = workspaceContext
               .getDirectories()
               .filter((dir) => !directoriesBeforeAdd.has(dir));
-            added.push(...acceptedDirectories);
+            if (acceptedDirectories.length > 0) {
+              added.push(...acceptedDirectories);
+            } else {
+              const existingDirectory = findExistingWorkspaceDirectory(
+                directory,
+                directoriesBeforeAdd,
+              );
+              if (existingDirectory) {
+                alreadyAdded.push(existingDirectory);
+              }
+            }
           } catch (e) {
             const error = e as Error;
             errors.push(
@@ -161,7 +196,8 @@ export const directoryCommand: SlashCommand = {
         if (added.length > 0) {
           try {
             const existingIncludeDirectories =
-              settings.workspace.settings.context?.includeDirectories ?? [];
+              settings.workspace.originalSettings.context?.includeDirectories ??
+              [];
             const includeDirectories = Array.from(
               new Set([...existingIncludeDirectories, ...added]),
             );
@@ -179,10 +215,15 @@ export const directoryCommand: SlashCommand = {
           }
         }
 
-        try {
-          if (config.shouldLoadMemoryFromIncludeDirectories()) {
-            const { memoryContent, fileCount, conditionalRules, projectRoot } =
-              await loadServerHierarchicalMemory(
+        if (added.length > 0) {
+          try {
+            if (config.shouldLoadMemoryFromIncludeDirectories()) {
+              const {
+                memoryContent,
+                fileCount,
+                conditionalRules,
+                projectRoot,
+              } = await loadServerHierarchicalMemory(
                 config.getWorkingDir(),
                 [...config.getWorkspaceContext().getDirectories(), ...added],
                 config.getFileService(),
@@ -192,31 +233,32 @@ export const directoryCommand: SlashCommand = {
                   'tree', // Use setting or default to 'tree'
                 config.getContextRuleExcludes(),
               );
-            config.setUserMemory(memoryContent);
-            config.setGeminiMdFileCount(fileCount);
-            config.setConditionalRulesRegistry(
-              new ConditionalRulesRegistry(conditionalRules, projectRoot),
+              config.setUserMemory(memoryContent);
+              config.setGeminiMdFileCount(fileCount);
+              config.setConditionalRulesRegistry(
+                new ConditionalRulesRegistry(conditionalRules, projectRoot),
+              );
+              context.ui.setGeminiMdFileCount(fileCount);
+            }
+            addItem(
+              {
+                type: MessageType.INFO,
+                text: t(
+                  'Successfully added QWEN.md files from the following directories if there are:\n- {{directories}}',
+                  {
+                    directories: added.join('\n- '),
+                  },
+                ),
+              },
+              Date.now(),
             );
-            context.ui.setGeminiMdFileCount(fileCount);
+          } catch (error) {
+            errors.push(
+              t('Error refreshing memory: {{error}}', {
+                error: (error as Error).message,
+              }),
+            );
           }
-          addItem(
-            {
-              type: MessageType.INFO,
-              text: t(
-                'Successfully added QWEN.md files from the following directories if there are:\n- {{directories}}',
-                {
-                  directories: added.join('\n- '),
-                },
-              ),
-            },
-            Date.now(),
-          );
-        } catch (error) {
-          errors.push(
-            t('Error refreshing memory: {{error}}', {
-              error: (error as Error).message,
-            }),
-          );
         }
 
         if (added.length > 0) {
@@ -229,6 +271,19 @@ export const directoryCommand: SlashCommand = {
               type: MessageType.INFO,
               text: t('Successfully added directories:\n- {{directories}}', {
                 directories: added.join('\n- '),
+              }),
+            },
+            Date.now(),
+          );
+        }
+
+        if (alreadyAdded.length > 0) {
+          const directories = Array.from(new Set(alreadyAdded));
+          addItem(
+            {
+              type: MessageType.INFO,
+              text: t('Directories already in workspace:\n- {{directories}}', {
+                directories: directories.join('\n- '),
               }),
             },
             Date.now(),


### PR DESCRIPTION
## Summary

- What changed: `/directory add` now persists successfully added directories to the workspace `context.includeDirectories` setting, while preserving existing entries and avoiding duplicates.
- Why it changed: added directories were only applied to the in-memory workspace context, so they disappeared after restart instead of being written to `.qwen/settings.json`.
- Reviewer focus: please check that workspace-scoped settings remain the right persistence target for `/directory add`.

## Validation

- Commands run:
  ```bash
  npm ci --ignore-scripts
  cd packages/cli && npx vitest run src/ui/commands/directoryCommand.test.tsx
  npm run build
  npm run typecheck --workspace=packages/cli
  npx prettier --check packages/cli/src/ui/commands/directoryCommand.tsx packages/cli/src/ui/commands/directoryCommand.test.tsx
  git diff --check
  ```
- Prompts / inputs used: N/A; covered with the focused command unit tests.
- Expected result: adding a directory writes the normalized path to workspace `context.includeDirectories`, keeps existing entries, and does not duplicate paths.
- Observed result: focused Vitest test passed with 9 tests; build, CLI typecheck, Prettier, and diff check passed.
- Quickest reviewer verification path: `cd packages/cli && npx vitest run src/ui/commands/directoryCommand.test.tsx`.
- Evidence: the regression tests assert the `settings.setValue(SettingScope.Workspace, 'context.includeDirectories', ...)` calls for new and duplicate directories.

## Scope / Risk

- Main risk or tradeoff: failed settings writes are now surfaced as command errors after the directory has already been added to the in-memory context.
- Not covered / not validated: manual TUI/E2E run was not performed in this environment.
- Breaking changes / migration notes: none.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ⚠️  | ✅  |
| npx      | ⚠️  | ⚠️  | ✅  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Validated on Linux with `npm ci --ignore-scripts`, `npm run build`, `npm run typecheck --workspace=packages/cli`, focused Vitest, Prettier, and `git diff --check`.
- Docker/Podman/Seatbelt and macOS/Windows runs were not available in this environment.

## Linked Issues / Bugs

Fixes #3746
