### PR TITLE
fix(ci): add merge-back PR for stable releases in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,6 +304,8 @@ jobs:
       contents: 'write'
       packages: 'write'
       id-token: 'write'
+      pull-requests: 'write'
+      issues: 'write'
 
     steps:
       - name: 'Checkout'
@@ -408,6 +410,38 @@ jobs:
             --notes-start-tag "${PREVIOUS_RELEASE_TAG}" \
             --generate-notes \
             ${PRERELEASE_FLAG}
+
+      - name: 'Create PR to merge release branch into main'
+        if: |-
+          ${{ needs.prepare.outputs.is_dry_run == 'false' && needs.prepare.outputs.is_nightly == 'false' && needs.prepare.outputs.is_preview == 'false' }}
+        id: 'pr'
+        env:
+          GITHUB_TOKEN: '${{ secrets.CI_BOT_PAT }}'
+          RELEASE_BRANCH: '${{ steps.release_branch.outputs.BRANCH_NAME }}'
+          RELEASE_TAG: '${{ needs.prepare.outputs.release_tag }}'
+        run: |-
+          set -euo pipefail
+
+          pr_url="$(gh pr list --head "${RELEASE_BRANCH}" --base main --json url --jq '.[0].url')"
+          if [[ -z "${pr_url}" ]]; then
+            pr_url="$(gh pr create \
+              --base main \
+              --head "${RELEASE_BRANCH}" \
+              --title "chore(release): ${RELEASE_TAG}" \
+              --body "Automated release PR for ${RELEASE_TAG}. Syncs package.json versions on main.")"
+          fi
+
+          echo "PR_URL=${pr_url}" >> "${GITHUB_OUTPUT}"
+
+      - name: 'Enable auto-merge for release PR'
+        if: |-
+          ${{ needs.prepare.outputs.is_dry_run == 'false' && needs.prepare.outputs.is_nightly == 'false' && needs.prepare.outputs.is_preview == 'false' }}
+        env:
+          GITHUB_TOKEN: '${{ secrets.CI_BOT_PAT }}'
+          PR_URL: '${{ steps.pr.outputs.PR_URL }}'
+        run: |-
+          set -euo pipefail
+          gh pr merge "${PR_URL}" --squash --auto --delete-branch
 
   notify_failure:
     name: 'Notify Release Failure'


### PR DESCRIPTION
## Summary

- What changed: After a stable/patch CLI release succeeds, two new steps in the `publish` job automatically create a merge-back PR (using `CI_BOT_PAT`) and enable auto-merge to sync the release branch version bump back to `main`.
- Why it changed: The release workflow creates a dedicated `release/*` branch and bumps `package.json` there, but never merges the bump back to `main`. This causes nightly versions (derived from `package.json` on `main`) to fall behind stable releases (e.g. nightly `0.15.3-*` < stable `0.15.5`).
- Reviewer focus: Whether the two new steps' conditions (stable/patch only, excluding nightly/preview/dry-run) and `CI_BOT_PAT` usage are consistent with the existing `release-sdk.yml` implementation (lines 378–408).

## Validation

- Commands run:
  ```bash
  python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); print('OK')"
  ```
- Prompts / inputs used: Compared against `release-sdk.yml` lines 378–408 (existing merge-back implementation).
- Expected result: After a stable/patch release, CI automatically creates a merge-back PR; once approved, it auto-merges back to `main`.
- Observed result: YAML syntax validation passed; logic matches the SDK release workflow's production-verified implementation.
- Quickest reviewer verification path:
  1. Diff `release-sdk.yml` lines 378–408 against the two new steps in this PR.
  2. Confirm conditions exclude nightly/preview/dry-run.
  3. Verify end-to-end on the next stable release (with dry-run first).
- Evidence: The same pattern in `release-sdk.yml` has been running in production (e.g. PR #3688 was auto-created by ci-bot and auto-merged after approval).

## Scope / Risk

- Main risk or tradeoff: If the release branch conflicts with `main`, auto-merge will fail and require manual resolution. This matches the existing SDK release behavior.
- Not covered / not validated: Not yet end-to-end tested in an actual stable release (needs next release to confirm).
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | N/A | N/A | N/A |
| npx      | N/A | N/A | N/A |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:
- This change only affects CI workflow configuration, not CLI runtime behavior. No platform testing needed.

## Linked Issues / Bugs

Resolves #3756