### PR TITLE
fix(vscode-companion): align package eslint config with root and style cleanup

### DIFF
--- a/packages/vscode-ide-companion/eslint.config.mjs
+++ b/packages/vscode-ide-companion/eslint.config.mjs
@@ -67,7 +67,7 @@ export default [
       ],
 
       curly: 'warn',
-      eqeqeq: 'warn',
+      eqeqeq: ['warn', 'always', { null: 'ignore' }],
       'no-throw-literal': 'warn',
       semi: 'warn',
     },

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -218,7 +218,9 @@ export async function activate(context: vscode.ExtensionContext) {
   const sendCopyToActive = (action: string) => {
     for (const provider of chatProviderRegistry?.getPermissionAwareProviders() ??
       []) {
-      if (provider.sendCopyCommand(action)) break;
+      if (provider.sendCopyCommand(action)) {
+        break;
+      }
     }
   };
   context.subscriptions.push(

--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -176,7 +176,7 @@ const MessageList = React.memo<MessageListProps>(
       }
       // No wrapper div — message components render directly as children
       // of the scroll container, preserving the original CSS layout.
-      if (child === null) {
+      if (child == null) {
         return null;
       }
       mapping.push(index);

--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -176,7 +176,9 @@ const MessageList = React.memo<MessageListProps>(
       }
       // No wrapper div — message components render directly as children
       // of the scroll container, preserving the original CSS layout.
-      if (child == null) return null;
+      if (child === null) {
+        return null;
+      }
       mapping.push(index);
       return <React.Fragment key={`msg-${index}`}>{child}</React.Fragment>;
     });
@@ -212,7 +214,9 @@ function findMessageIndex(
   while (directChild && directChild.parentElement !== container) {
     directChild = directChild.parentElement;
   }
-  if (!directChild) return -1;
+  if (!directChild) {
+    return -1;
+  }
 
   // Find DOM child position among container's children
   const children = container.children;
@@ -1203,7 +1207,9 @@ export const App: React.FC = () => {
   useEffect(() => {
     const handler = (event: MessageEvent) => {
       const message = event.data;
-      if (message?.type !== 'copyCommand') return;
+      if (message?.type !== 'copyCommand') {
+        return;
+      }
 
       const { action } = message.data as { action: string };
 
@@ -1234,7 +1240,9 @@ export const App: React.FC = () => {
               msg.kind === 'image' && msg.imagePath
                 ? `![image](${msg.imagePath})`
                 : (msg.content || '').trim();
-            if (!content) continue;
+            if (!content) {
+              continue;
+            }
             if (msg.role === 'user') {
               parts.push(`**User:** ${content}`);
             } else if (msg.role === 'thinking') {
@@ -1247,7 +1255,9 @@ export const App: React.FC = () => {
             item.type === 'in-progress-tool-call'
           ) {
             const tc = item.data as ToolCallData;
-            if (!shouldShowToolCall(tc.kind)) continue;
+            if (!shouldShowToolCall(tc.kind)) {
+              continue;
+            }
             const text = formatToolCallForCopy(tc, true);
             if (text) {
               parts.push(`**[Tool: ${tc.kind}]**\n\n${text}`);

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
@@ -1737,9 +1737,13 @@ export class WebViewProvider {
    * The webview resolves the content and posts back a 'copyToClipboard' message.
    */
   sendCopyCommand(action: string): boolean {
-    if (WebViewProvider.lastContextMenuProvider !== this) return false;
+    if (WebViewProvider.lastContextMenuProvider !== this) {
+      return false;
+    }
     const webview = this.getActiveWebview();
-    if (!webview) return false;
+    if (!webview) {
+      return false;
+    }
     webview.postMessage({ type: 'copyCommand', data: { action } });
     return true;
   }


### PR DESCRIPTION
## Summary

- Align `packages/vscode-ide-companion` ESLint config with the root TypeScript ESLint setup.
- Keep the reviewer-requested `== null` nullish check behavior.
- Apply targeted style cleanup for the package-level lint warnings.

## Changes

### 1. Package ESLint config alignment (`eslint.config.mjs`)
- `eqeqeq`: changed from `'warn'` to `['warn', 'always', { null: 'ignore' }]` to match the root config. This allows the standard `== null` idiom that catches both `null` and `undefined`.

### 2. Revert incorrect `=== null` change
- The original PR commit changed `child == null` to `child === null` in `App.tsx:179`. This was wrong — `== null` is the defensive idiom needed here since `child` is declared as `let child: React.ReactNode` (initially `undefined`). Using `=== null` would let `undefined` slip through, desyncing `childIndexMap` from the rendered DOM. Reverted back to `== null`.

### 3. Style cleanup - brace additions
- Added braces to single-line `if` statements at 6 sites across `extension.ts`, `WebViewProvider.ts`, and `App.tsx`. These are stylistic improvements under the package-level `curly: 'warn'` rule. Note: these were NOT CI-blocking violations - CI runs from root which uses `curly: ['error', 'multi-line']` and permits single-line if statements.

## Verification

- `cd packages/vscode-ide-companion && npx eslint src --max-warnings 0` - clean, zero errors/warnings
- `npx eslint . --ext .ts,.tsx --max-warnings 0` from root - clean
- Pre-commit hooks (prettier + eslint --fix) passed
