### PR TITLE
feat(cli): Add ability to switch models non-interactively from the cli

### DIFF
--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -1208,7 +1208,7 @@ export default {
   // ============================================================================
   // Ordres - Model
   // ============================================================================
-  'Switch the model for this session (--fast for suggestion model)':
+  'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).':
     'Canviar el model per a aquesta sessió (--fast per al model de suggeriments)',
   'Set a lighter model for prompt suggestions and speculative execution':
     'Establir un model més lleuger per a suggeriments de missatges i execució especulativa',
@@ -1217,6 +1217,8 @@ export default {
   'Authentication type not available.': "Tipus d'autenticació no disponible.",
   'No models available for the current authentication type ({{authType}}).':
     "No hi ha models disponibles per al tipus d'autenticació actual ({{authType}}).",
+  // Needs translation
+  ' (not in model registry)': ' (not in model registry)',
 
   // ============================================================================
   // Ordres - Netejar

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -1031,7 +1031,7 @@ export default {
   // ============================================================================
   // Commands - Model
   // ============================================================================
-  'Switch the model for this session (--fast for suggestion model)':
+  'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).':
     'Modell für diese Sitzung wechseln (--fast für Vorschlagsmodell)',
   'Set a lighter model for prompt suggestions and speculative execution':
     'Leichteres Modell für Eingabevorschläge und spekulative Ausführung festlegen',
@@ -1041,6 +1041,8 @@ export default {
     'Authentifizierungstyp nicht verfügbar.',
   'No models available for the current authentication type ({{authType}}).':
     'Keine Modelle für den aktuellen Authentifizierungstyp ({{authType}}) verfügbar.',
+  // Needs translation
+  ' (not in model registry)': ' (not in model registry)',
 
   // ============================================================================
   // Commands - Clear

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1201,7 +1201,7 @@ export default {
   // Commands - Model
   // ============================================================================
   'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).':
-    'Switch the model for this session (--fast for suggestion model)',
+    'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).',
   'Set a lighter model for prompt suggestions and speculative execution':
     'Set a lighter model for prompt suggestions and speculative execution',
   'Content generator configuration not available.':

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1200,7 +1200,7 @@ export default {
   // ============================================================================
   // Commands - Model
   // ============================================================================
-  'Switch the model for this session (--fast for suggestion model)':
+  'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).':
     'Switch the model for this session (--fast for suggestion model)',
   'Set a lighter model for prompt suggestions and speculative execution':
     'Set a lighter model for prompt suggestions and speculative execution',
@@ -1209,6 +1209,8 @@ export default {
   'Authentication type not available.': 'Authentication type not available.',
   'No models available for the current authentication type ({{authType}}).':
     'No models available for the current authentication type ({{authType}}).',
+  // Needs translation
+  ' (not in model registry)': ' (not in model registry)',
 
   // ============================================================================
   // Commands - Clear

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -1175,7 +1175,7 @@ export default {
   // ============================================================================
   // Commandes - Modèle
   // ============================================================================
-  'Switch the model for this session (--fast for suggestion model)':
+  'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).':
     'Changer le modèle pour cette session (--fast pour le modèle de suggestion)',
   'Set a lighter model for prompt suggestions and speculative execution':
     "Définir un modèle plus léger pour les suggestions d'invite et l'exécution spéculative",
@@ -1185,6 +1185,8 @@ export default {
     "Type d'authentification non disponible.",
   'No models available for the current authentication type ({{authType}}).':
     "Aucun modèle disponible pour le type d'authentification actuel ({{authType}}).",
+  // Needs translation
+  ' (not in model registry)': ' (not in model registry)',
 
   // ============================================================================
   // Commandes - Effacer

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -785,7 +785,7 @@ export default {
   'Failed to generate summary - no text content received from LLM response':
     'サマリーの生成に失敗 - LLMレスポンスからテキストコンテンツを受信できませんでした',
   // Model
-  'Switch the model for this session (--fast for suggestion model)':
+  'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).':
     'このセッションのモデルを切り替え（--fast で提案モデルを設定）',
   'Set a lighter model for prompt suggestions and speculative execution':
     'プロンプト提案と投機的実行用の軽量モデルを設定',
@@ -794,6 +794,8 @@ export default {
   'Authentication type not available.': '認証タイプが利用できません',
   'No models available for the current authentication type ({{authType}}).':
     '現在の認証タイプ({{authType}})で利用可能なモデルはありません',
+  // Needs translation
+  ' (not in model registry)': ' (not in model registry)',
   // Clear
   'Starting a new session, resetting chat, and clearing terminal.':
     '新しいセッションを開始し、チャットをリセットし、ターミナルをクリアしています',

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -1040,7 +1040,7 @@ export default {
   // ============================================================================
   // Commands - Model
   // ============================================================================
-  'Switch the model for this session (--fast for suggestion model)':
+  'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).':
     'Trocar o modelo para esta sessão (--fast para modelo de sugestões)',
   'Set a lighter model for prompt suggestions and speculative execution':
     'Definir modelo mais leve para sugestões de prompt e execução especulativa',
@@ -1049,6 +1049,8 @@ export default {
   'Authentication type not available.': 'Tipo de autenticação não disponível.',
   'No models available for the current authentication type ({{authType}}).':
     'Nenhum modelo disponível para o tipo de autenticação atual ({{authType}}).',
+  // Needs translation
+  ' (not in model registry)': ' (not in model registry)',
 
   // ============================================================================
   // Commands - Clear

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -1039,7 +1039,7 @@ export default {
   // ============================================================================
   // Команды - Модель
   // ============================================================================
-  'Switch the model for this session (--fast for suggestion model)':
+  'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).':
     'Переключение модели для этой сессии (--fast для модели подсказок)',
   'Set a lighter model for prompt suggestions and speculative execution':
     'Установить облегчённую модель для подсказок и спекулятивного выполнения',
@@ -1048,6 +1048,8 @@ export default {
   'Authentication type not available.': 'Тип авторизации недоступен.',
   'No models available for the current authentication type ({{authType}}).':
     'Нет доступных моделей для текущего типа авторизации ({{authType}}).',
+  // Needs translation
+  ' (not in model registry)': ' (not in model registry)',
 
   // ============================================================================
   // Команды - Очистка

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -1027,7 +1027,7 @@ export default {
   'Generating project summary...': '正在生成項目摘要...',
   'Failed to generate summary - no text content received from LLM response':
     '生成摘要失敗 - 未從 LLM 響應中接收到文本內容',
-  'Switch the model for this session (--fast for suggestion model)':
+  'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).':
     '切換此會話的模型（--fast 可設置建議模型）',
   'Set a lighter model for prompt suggestions and speculative execution':
     '設置用於輸入建議和推測執行的輕量模型',
@@ -1035,6 +1035,8 @@ export default {
   'Authentication type not available.': '認證類型不可用',
   'No models available for the current authentication type ({{authType}}).':
     '當前認證類型 ({{authType}}) 沒有可用的模型',
+  // Needs translation
+  ' (not in model registry)': ' (not in model registry)',
   'Starting a new session, resetting chat, and clearing terminal.':
     '正在開始新會話，重置聊天並清屏。',
   'Starting a new session and clearing.': '正在開始新會話並清屏。',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1142,7 +1142,7 @@ export default {
   // ============================================================================
   // Commands - Model
   // ============================================================================
-  'Switch the model for this session (--fast for suggestion model)':
+  'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).':
     '切换此会话的模型（--fast 可设置建议模型）',
   'Set a lighter model for prompt suggestions and speculative execution':
     '设置用于输入建议和推测执行的轻量模型',
@@ -1150,6 +1150,8 @@ export default {
   'Authentication type not available.': '认证类型不可用',
   'No models available for the current authentication type ({{authType}}).':
     '当前认证类型 ({{authType}}) 没有可用的模型',
+  // Needs translation
+  ' (not in model registry)': ' (not in model registry)',
 
   // ============================================================================
   // Commands - Clear

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -34,7 +34,7 @@ describe('modelCommand', () => {
   it('should have the correct name and description', () => {
     expect(modelCommand.name).toBe('model');
     expect(modelCommand.description).toBe(
-      'Switch the model for this session (--fast for suggestion model)',
+      'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).',
     );
   });
 

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -31,7 +31,7 @@ export const modelCommand: SlashCommand = {
   completionPriority: 100,
   get description() {
     return t(
-      'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately). ',
+      'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).',
     );
   },
   kind: CommandKind.BUILT_IN,
@@ -141,12 +141,12 @@ export const modelCommand: SlashCommand = {
             content: t('Settings service not available.'),
           };
         }
+        await config.setModel(modelName);
         settings.setValue(
           getPersistScopeForModelSelection(settings),
           'model.name',
           modelName,
         );
-        await config.setModel(modelName);
 
         if (config.getModelsConfig().hasModel(authType, modelName)) {
           return {
@@ -176,12 +176,12 @@ export const modelCommand: SlashCommand = {
             content: t('Settings service not available.'),
           };
         }
+        await config.setModel(modelName);
         settings.setValue(
           getPersistScopeForModelSelection(settings),
           'model.name',
           modelName,
         );
-        await config.setModel(modelName);
         return {
           type: 'message',
           messageType: 'info',

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -160,7 +160,8 @@ export const modelCommand: SlashCommand = {
           return {
             type: 'message',
             messageType: 'info',
-            content: t('Model') + ': ' + modelName + ' (not in model registry)',
+            content:
+              t('Model') + ': ' + modelName + t(' (not in model registry)'),
           };
         }
       }

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -36,7 +36,7 @@ export const modelCommand: SlashCommand = {
   },
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
-  completion: async (_context, partialArg) => {
+  completion: async (context, partialArg) => {
     if (partialArg && '--fast'.startsWith(partialArg)) {
       return [
         {
@@ -46,11 +46,13 @@ export const modelCommand: SlashCommand = {
           ),
         },
       ];
-    } else {
+    } else if (partialArg.trim()) {
       // Include model IDs matching the partial argument
-      return getAvailableModelIds(_context).filter((id) =>
+      return getAvailableModelIds(context).filter((id) =>
         id.startsWith(partialArg),
       );
+    } else {
+      return null;
     }
   },
   action: async (

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -95,10 +95,7 @@ export const modelCommand: SlashCommand = {
     // Handle modelName argument: immediately switch to the provided model
     if (
       args !== '' &&
-    if (
-      args !== '' &&
-      context.executionMode === 'interactive'
-    ) {
+      !args.startsWith('--fast') &&
       context.executionMode === 'interactive'
     ) {
       // Use first argument only, avoids later syntax confusion and/or use of model names with spaces

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -95,7 +95,10 @@ export const modelCommand: SlashCommand = {
     //Handle modelName argument: immediately switch to the provided model
     if (
       args !== '' &&
-      !args.startsWith('--fast') &&
+    if (
+      args !== '' &&
+      context.executionMode === 'interactive'
+    ) {
       context.executionMode === 'interactive'
     ) {
       // Use first argument only, avoids later syntax confusion and/or use of model names with spaces

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -18,7 +18,9 @@ export const modelCommand: SlashCommand = {
   name: 'model',
   completionPriority: 100,
   get description() {
-    return t('Switch the model for this session (--fast for suggestion model)');
+    return t(
+      'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately). ',
+    );
   },
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -100,7 +100,7 @@ export const modelCommand: SlashCommand = {
     ) {
       //Use first argument only, avoids later synatx confusion and/or use of model names with spaces
       const modelName = args.trim().split(' ')[0];
-      config.setModel(modelName);
+      await config.setModel(modelName);
       return {
         type: 'message',
         messageType: 'info',

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -31,6 +31,8 @@ export const modelCommand: SlashCommand = {
   completionPriority: 100,
   get description() {
     return t(
+      'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).',
+    );
       'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately). ',
     );
   },

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -14,7 +14,7 @@ import { CommandKind } from './types.js';
 import { t } from '../../i18n/index.js';
 import { getPersistScopeForModelSelection } from '../../config/modelProvidersScope.js';
 
-// Get an aray of the available model IDs as strings
+// Get an array of the available model IDs as strings
 function getAvailableModelIds(context: CommandContext) {
   const { services } = context;
   const { config } = services;

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -31,8 +31,6 @@ export const modelCommand: SlashCommand = {
   completionPriority: 100,
   get description() {
     return t(
-      'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).',
-    );
       'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately). ',
     );
   },

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -98,7 +98,7 @@ export const modelCommand: SlashCommand = {
       !args.startsWith('--fast') &&
       context.executionMode === 'interactive'
     ) {
-      //Use first argument only, avoids later synatx confusion and/or use of model names with spaces
+      // Use first argument only, avoids later syntax confusion and/or use of model names with spaces
       if (!settings) {
         return {
           type: 'message',

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -14,6 +14,18 @@ import { CommandKind } from './types.js';
 import { t } from '../../i18n/index.js';
 import { getPersistScopeForModelSelection } from '../../config/modelProvidersScope.js';
 
+// Get an aray of the available model IDs as strings
+function getAvailableModelIds(context: CommandContext) {
+  const { services } = context;
+  const { config } = services;
+  if (!config) {
+    return [];
+  }
+  const availableModels = config.getAvailableModels();
+  // Convert AvailableModel[] to string[] on AvailableModel.id
+  return availableModels.map((model) => model.id);
+}
+
 export const modelCommand: SlashCommand = {
   name: 'model',
   completionPriority: 100,
@@ -34,8 +46,12 @@ export const modelCommand: SlashCommand = {
           ),
         },
       ];
+    } else {
+      // Include model IDs matching the partial argument
+      return getAvailableModelIds(_context).filter((id) =>
+        id.startsWith(partialArg),
+      );
     }
-    return null;
   },
   action: async (
     context: CommandContext,

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -99,7 +99,20 @@ export const modelCommand: SlashCommand = {
       context.executionMode === 'interactive'
     ) {
       //Use first argument only, avoids later synatx confusion and/or use of model names with spaces
+      if (!settings) {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: t('Settings service not available.'),
+        };
+      }
       const modelName = args.trim().split(' ')[0];
+      settings.setValue(
+        getPersistScopeForModelSelection(settings),
+        'model.name',
+        modelName,
+      );
+      await config.setModel(modelName);
       await config.setModel(modelName);
       return {
         type: 'message',

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -93,32 +93,31 @@ export const modelCommand: SlashCommand = {
     }
 
     // Handle modelName argument: immediately switch to the provided model
-    if (
-      args !== '' &&
-      !args.startsWith('--fast') &&
-      context.executionMode === 'interactive'
-    ) {
-      // Use first argument only, avoids later syntax confusion and/or use of model names with spaces
-      if (!settings) {
+    if (args !== '' && context.executionMode === 'interactive') {
+      const modelName = args.trim().split(' ')[0];
+      if (modelName.trim()) {
+        // Use first argument only, avoids later syntax confusion and/or use of model names with spaces
+        // Ignore argument if it is empty, e.g. to avoid confusion with trailing whitespace
+        if (!settings) {
+          return {
+            type: 'message',
+            messageType: 'error',
+            content: t('Settings service not available.'),
+          };
+        }
+        settings.setValue(
+          getPersistScopeForModelSelection(settings),
+          'model.name',
+          modelName,
+        );
+        await config.setModel(modelName);
+        await config.setModel(modelName);
         return {
           type: 'message',
-          messageType: 'error',
-          content: t('Settings service not available.'),
+          messageType: 'info',
+          content: t('Model') + ': ' + modelName,
         };
       }
-      const modelName = args.trim().split(' ')[0];
-      settings.setValue(
-        getPersistScopeForModelSelection(settings),
-        'model.name',
-        modelName,
-      );
-      await config.setModel(modelName);
-      await config.setModel(modelName);
-      return {
-        type: 'message',
-        messageType: 'info',
-        content: t('Model') + ': ' + modelName,
-      };
     }
 
     const contentGeneratorConfig = config.getContentGeneratorConfig();
@@ -141,8 +140,8 @@ export const modelCommand: SlashCommand = {
 
     // Non-interactive/ACP: set model if an arg was provided, otherwise show current model
     if (context.executionMode !== 'interactive') {
-      const modelName = args.trim();
-      if (modelName) {
+      const modelName = args.trim().split(' ')[0];
+      if (modelName.trim()) {
         // /model <model-id> — set the main model
         if (!settings) {
           return {

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -92,7 +92,7 @@ export const modelCommand: SlashCommand = {
       };
     }
 
-    //Handle modelName argument: immediately switch to the provided model
+    // Handle modelName argument: immediately switch to the provided model
     if (
       args !== '' &&
     if (

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -133,7 +133,7 @@ export const modelCommand: SlashCommand = {
     // Handle modelName argument: immediately switch to the provided model
     if (args !== '' && context.executionMode === 'interactive') {
       const modelName = args.trim().split(' ')[0];
-      if (modelName.trim()) {
+      if (modelName) {
         // Use first argument only, avoids later syntax confusion and/or use of model names with spaces
         // Ignore argument if it is empty, e.g. to avoid confusion with trailing whitespace
         if (!settings) {

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -92,6 +92,22 @@ export const modelCommand: SlashCommand = {
       };
     }
 
+    //Handle modelName argument: immediately switch to the provided model
+    if (
+      args !== '' &&
+      !args.startsWith('--fast') &&
+      context.executionMode === 'interactive'
+    ) {
+      //Use first argument only, avoids later synatx confusion and/or use of model names with spaces
+      const modelName = args.trim().split(' ')[0];
+      config.setModel(modelName);
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: t('Model') + ': ' + modelName,
+      };
+    }
+
     const contentGeneratorConfig = config.getContentGeneratorConfig();
     if (!contentGeneratorConfig) {
       return {

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -92,6 +92,24 @@ export const modelCommand: SlashCommand = {
       };
     }
 
+    const contentGeneratorConfig = config.getContentGeneratorConfig();
+    if (!contentGeneratorConfig) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: t('Content generator configuration not available.'),
+      };
+    }
+
+    const authType = contentGeneratorConfig.authType;
+    if (!authType) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: t('Authentication type not available.'),
+      };
+    }
+
     // Handle modelName argument: immediately switch to the provided model
     if (args !== '' && context.executionMode === 'interactive') {
       const modelName = args.trim().split(' ')[0];
@@ -111,31 +129,21 @@ export const modelCommand: SlashCommand = {
           modelName,
         );
         await config.setModel(modelName);
-        await config.setModel(modelName);
-        return {
-          type: 'message',
-          messageType: 'info',
-          content: t('Model') + ': ' + modelName,
-        };
+
+        if (config.getModelsConfig().hasModel(authType, modelName)) {
+          return {
+            type: 'message',
+            messageType: 'info',
+            content: t('Model') + ': ' + modelName,
+          };
+        } else {
+          return {
+            type: 'message',
+            messageType: 'info',
+            content: t('Model') + ': ' + modelName + ' (not in model registry)',
+          };
+        }
       }
-    }
-
-    const contentGeneratorConfig = config.getContentGeneratorConfig();
-    if (!contentGeneratorConfig) {
-      return {
-        type: 'message',
-        messageType: 'error',
-        content: t('Content generator configuration not available.'),
-      };
-    }
-
-    const authType = contentGeneratorConfig.authType;
-    if (!authType) {
-      return {
-        type: 'message',
-        messageType: 'error',
-        content: t('Authentication type not available.'),
-      };
     }
 
     // Non-interactive/ACP: set model if an arg was provided, otherwise show current model

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -49,7 +49,7 @@ export const modelCommand: SlashCommand = {
     } else if (partialArg.trim()) {
       // Include model IDs matching the partial argument
       return getAvailableModelIds(context).filter((id) =>
-        id.startsWith(partialArg),
+        id.startsWith(partialArg.trim()),
       );
     } else {
       return null;


### PR DESCRIPTION
<!--
Help reviewers verify this PR quickly.

Maintainers prioritize PRs that include clear proof of work.
If a PR does not include enough validation detail to reproduce and verify the change efficiently, review may be delayed.
-->

## Summary

- What changed: Added new syntax to the /model command. ```/model```, ```/model --fast```, and ```/model --fast [model-name]``` still function as previously. This PR adds a new syntax ```/model [model-name]``` which allows for immediately switching the active model without using the interactive model selector.
- Why it changed: The primary use case for this is to allow switching between upstream models when those models are available at the configured base url, but not explicitly configured in the config. This behavior is already present when launching with ```qwen --model [model-name]```; the intent of this feature is to replicate this functionality at runtime. This functionality also brings greater parity with the existing functionality of other coding agents.

This is a small PR with no platform-specific or core changes.
This PR contains no AI-generated code.

## Validation

- Commands run:
```bash
- npm run build
- npm run test:scripts
- npm run start
```

All test scripts passed.

Functionality before changes:
<img width="755" height="429" alt="Before" src="https://github.com/user-attachments/assets/9e3dc0b4-6153-4e69-9874-082366915028" />

Functionality after changes:
<img width="740" height="478" alt="After" src="https://github.com/user-attachments/assets/9b67898b-4bbc-4646-91e0-1687ca035150" />

## Scope / Risk

- Main risk or tradeoff: This feature allows the user to try switching to an unavailable model at runtime. This replicates the functionality of the launch argument ```--model``` and is intended.
- Breaking changes / migration notes: This PR changes the behavior of invoking ```/model``` with invalid syntax. Extraneous arguments were previously ignored. Now, the first extraneous argument is interpreted as a model name. Existing correct syntax is unchanged, and the changes explicitly do not take effect in non-interactive mode. This should not break any workflows or orchestration flows, but the change should be noted.

## Linked Issues / Bugs

<!--
If this PR fully resolves an issue, use one of:
- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

Otherwise reference related issues without a closing keyword.
-->

- Closes #3410 