### PR TITLE
fix(core): inject thinking blocks for DeepSeek anthropic-compatible provider

### DIFF
--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -494,6 +494,139 @@ describe('AnthropicContentGenerator', () => {
     });
   });
 
+  // https://github.com/QwenLM/qwen-code/issues/3786 — DeepSeek's
+  // anthropic-compatible API rejects subsequent requests when any prior
+  // assistant turn omits a thinking block while thinking mode is on.
+  describe('DeepSeek anthropic-compatible provider', () => {
+    it('injects empty thinking blocks on prior assistant turns when baseUrl points to api.deepseek.com', async () => {
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl.mockResolvedValue({
+        id: 'msg-1',
+        model: 'deepseek-v4-pro',
+        content: [{ type: 'text', text: 'ok' }],
+      });
+
+      const generator = new AnthropicContentGenerator(
+        {
+          model: 'deepseek-v4-pro',
+          apiKey: 'test-key',
+          baseUrl: 'https://api.deepseek.com/anthropic',
+          timeout: 10_000,
+          maxRetries: 2,
+          samplingParams: { max_tokens: 500 },
+          schemaCompliance: 'auto',
+        },
+        mockConfig,
+      );
+
+      await generator.generateContent({
+        model: 'models/ignored',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          { role: 'model', parts: [{ text: 'Hello!' }] },
+          { role: 'user', parts: [{ text: 'How are you?' }] },
+        ],
+      } as unknown as GenerateContentParameters);
+
+      const [anthropicRequest] =
+        anthropicState.lastCreateArgs as AnthropicCreateArgs;
+      const messages = (anthropicRequest as { messages: unknown[] }).messages;
+
+      // Assistant turn should now have an empty thinking block prepended.
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: '', signature: '' },
+          { type: 'text', text: 'Hello!' },
+        ],
+      });
+    });
+
+    it('detects deepseek by model name even when baseUrl is different', async () => {
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl.mockResolvedValue({
+        id: 'msg-1',
+        model: 'deepseek-v4-pro',
+        content: [{ type: 'text', text: 'ok' }],
+      });
+
+      const generator = new AnthropicContentGenerator(
+        {
+          model: 'deepseek-v4-pro',
+          apiKey: 'test-key',
+          baseUrl: 'https://my-proxy.example.com/anthropic',
+          timeout: 10_000,
+          maxRetries: 2,
+          samplingParams: { max_tokens: 500 },
+          schemaCompliance: 'auto',
+        },
+        mockConfig,
+      );
+
+      await generator.generateContent({
+        model: 'models/ignored',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          { role: 'model', parts: [{ text: 'Hello!' }] },
+          { role: 'user', parts: [{ text: 'How are you?' }] },
+        ],
+      } as unknown as GenerateContentParameters);
+
+      const [anthropicRequest] =
+        anthropicState.lastCreateArgs as AnthropicCreateArgs;
+      const messages = (anthropicRequest as { messages: unknown[] }).messages;
+
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: '', signature: '' },
+          { type: 'text', text: 'Hello!' },
+        ],
+      });
+    });
+
+    it('does not inject empty thinking blocks for non-deepseek providers', async () => {
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl.mockResolvedValue({
+        id: 'msg-1',
+        model: 'claude-test',
+        content: [{ type: 'text', text: 'ok' }],
+      });
+
+      const generator = new AnthropicContentGenerator(
+        {
+          model: 'claude-test',
+          apiKey: 'test-key',
+          baseUrl: 'https://api.anthropic.com',
+          timeout: 10_000,
+          maxRetries: 2,
+          samplingParams: { max_tokens: 500 },
+          schemaCompliance: 'auto',
+        },
+        mockConfig,
+      );
+
+      await generator.generateContent({
+        model: 'models/ignored',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          { role: 'model', parts: [{ text: 'Hello!' }] },
+          { role: 'user', parts: [{ text: 'How are you?' }] },
+        ],
+      } as unknown as GenerateContentParameters);
+
+      const [anthropicRequest] =
+        anthropicState.lastCreateArgs as AnthropicCreateArgs;
+      const messages = (anthropicRequest as { messages: unknown[] }).messages;
+
+      // No thinking block injected for non-deepseek providers.
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello!' }],
+      });
+    });
+  });
+
   describe('countTokens', () => {
     it('counts tokens using the request tokenizer', async () => {
       const { AnthropicContentGenerator } = await importGenerator();

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -495,8 +495,9 @@ describe('AnthropicContentGenerator', () => {
   });
 
   // https://github.com/QwenLM/qwen-code/issues/3786 — DeepSeek's
-  // anthropic-compatible API rejects subsequent requests when any prior
-  // assistant turn omits a thinking block while thinking mode is on.
+  // anthropic-compatible API rejects requests in thinking mode when a prior
+  // assistant turn carrying `tool_use` omits a thinking block. Plain-text
+  // assistant turns without thinking are accepted unchanged.
   describe('DeepSeek anthropic-compatible provider', () => {
     // Helper: tool-use assistant turn missing thinking — the only shape that
     // actually triggers DeepSeek's HTTP 400.

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -625,6 +625,142 @@ describe('AnthropicContentGenerator', () => {
         content: [{ type: 'text', text: 'Hello!' }],
       });
     });
+
+    it('does not match spoofed hostnames like api.deepseek.com.evil.com', async () => {
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl.mockResolvedValue({
+        id: 'msg-1',
+        model: 'claude-test',
+        content: [{ type: 'text', text: 'ok' }],
+      });
+
+      const generator = new AnthropicContentGenerator(
+        {
+          model: 'claude-test',
+          apiKey: 'test-key',
+          baseUrl: 'https://api.deepseek.com.evil.com/anthropic',
+          timeout: 10_000,
+          maxRetries: 2,
+          samplingParams: { max_tokens: 500 },
+          schemaCompliance: 'auto',
+        },
+        mockConfig,
+      );
+
+      await generator.generateContent({
+        model: 'models/ignored',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          { role: 'model', parts: [{ text: 'Hello!' }] },
+          { role: 'user', parts: [{ text: 'How are you?' }] },
+        ],
+      } as unknown as GenerateContentParameters);
+
+      const [anthropicRequest] =
+        anthropicState.lastCreateArgs as AnthropicCreateArgs;
+      const messages = (anthropicRequest as { messages: unknown[] }).messages;
+
+      // Hostname differs from api.deepseek.com — must not inject.
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello!' }],
+      });
+    });
+
+    it('does not inject when reasoning is explicitly disabled', async () => {
+      // Even on a confirmed-DeepSeek provider, if the request omits the
+      // top-level `thinking` parameter (because reasoning=false), shipping
+      // synthetic thinking blocks would be a protocol violation.
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl.mockResolvedValue({
+        id: 'msg-1',
+        model: 'deepseek-v4-pro',
+        content: [{ type: 'text', text: 'ok' }],
+      });
+
+      const generator = new AnthropicContentGenerator(
+        {
+          model: 'deepseek-v4-pro',
+          apiKey: 'test-key',
+          baseUrl: 'https://api.deepseek.com/anthropic',
+          timeout: 10_000,
+          maxRetries: 2,
+          samplingParams: { max_tokens: 500 },
+          schemaCompliance: 'auto',
+          reasoning: false,
+        },
+        mockConfig,
+      );
+
+      await generator.generateContent({
+        model: 'models/ignored',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          { role: 'model', parts: [{ text: 'Hello!' }] },
+          { role: 'user', parts: [{ text: 'How are you?' }] },
+        ],
+      } as unknown as GenerateContentParameters);
+
+      const [anthropicRequest] =
+        anthropicState.lastCreateArgs as AnthropicCreateArgs;
+      const messages = (anthropicRequest as { messages: unknown[] }).messages;
+
+      // No `thinking` field in the request body, no injected blocks either.
+      expect(anthropicRequest).toEqual(
+        expect.not.objectContaining({ thinking: expect.anything() }),
+      );
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello!' }],
+      });
+    });
+
+    it('does not inject when request sets thinkingConfig.includeThoughts=false', async () => {
+      // Same concern as above but for the per-request override used by
+      // suggestionGenerator / forkedAgent / ArenaManager.
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl.mockResolvedValue({
+        id: 'msg-1',
+        model: 'deepseek-v4-pro',
+        content: [{ type: 'text', text: 'ok' }],
+      });
+
+      const generator = new AnthropicContentGenerator(
+        {
+          model: 'deepseek-v4-pro',
+          apiKey: 'test-key',
+          baseUrl: 'https://api.deepseek.com/anthropic',
+          timeout: 10_000,
+          maxRetries: 2,
+          samplingParams: { max_tokens: 500 },
+          schemaCompliance: 'auto',
+          reasoning: { effort: 'medium' },
+        },
+        mockConfig,
+      );
+
+      await generator.generateContent({
+        model: 'models/ignored',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          { role: 'model', parts: [{ text: 'Hello!' }] },
+          { role: 'user', parts: [{ text: 'How are you?' }] },
+        ],
+        config: { thinkingConfig: { includeThoughts: false } },
+      } as unknown as GenerateContentParameters);
+
+      const [anthropicRequest] =
+        anthropicState.lastCreateArgs as AnthropicCreateArgs;
+      const messages = (anthropicRequest as { messages: unknown[] }).messages;
+
+      expect(anthropicRequest).toEqual(
+        expect.not.objectContaining({ thinking: expect.anything() }),
+      );
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello!' }],
+      });
+    });
   });
 
   describe('countTokens', () => {

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -271,6 +271,39 @@ describe('AnthropicContentGenerator', () => {
       );
       expect(headers['anthropic-beta']).toBeUndefined();
     });
+
+    it('also sends the computed beta header on streaming requests', async () => {
+      // generateContentStream() goes through a separate code path from
+      // generateContent(); make sure the per-request header attaches there
+      // too so streaming Anthropic/DeepSeek requests stay consistent.
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl.mockResolvedValue(
+        (async function* () {
+          yield { type: 'message_stop' };
+        })(),
+      );
+
+      const generator = new AnthropicContentGenerator(
+        { ...baseConfig, reasoning: { effort: 'medium' } },
+        mockConfig,
+      );
+      const stream = await generator.generateContentStream({
+        model: 'models/ignored',
+        contents: 'Hi',
+      } as unknown as GenerateContentParameters);
+      // Drain the stream so create() has been called.
+      for await (const _chunk of stream) {
+        void _chunk;
+      }
+
+      const [, options] = anthropicState.lastCreateArgs as AnthropicCreateArgs;
+      const headers = ((options as { headers?: Record<string, string> })
+        ?.headers || {}) as Record<string, string>;
+      expect(headers['anthropic-beta']).toContain(
+        'interleaved-thinking-2025-05-14',
+      );
+      expect(headers['anthropic-beta']).toContain('effort-2025-11-24');
+    });
   });
 
   describe('generateContent', () => {

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -272,6 +272,50 @@ describe('AnthropicContentGenerator', () => {
       expect(headers['anthropic-beta']).toBeUndefined();
     });
 
+    it('keeps customHeaders + User-Agent in defaultHeaders while sending computed anthropic-beta per-request', async () => {
+      // The per-request override must NOT replace existing defaultHeaders
+      // (User-Agent and unrelated customHeaders entries) — it should only
+      // contribute the computed `anthropic-beta` flags. Defends against a
+      // future regression where headers might be set via a path that wipes
+      // out the constructor-time defaults.
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl.mockResolvedValue({
+        id: 'msg-1',
+        model: 'claude-test',
+        content: [{ type: 'text', text: 'ok' }],
+      });
+      const generator = new AnthropicContentGenerator(
+        {
+          ...baseConfig,
+          reasoning: { effort: 'medium' },
+          customHeaders: { 'X-Custom': 'v1' },
+        },
+        mockConfig,
+      );
+      await generator.generateContent({
+        model: 'models/ignored',
+        contents: 'Hi',
+      } as unknown as GenerateContentParameters);
+
+      // defaultHeaders carries User-Agent and customHeaders (not beta).
+      const defaultHeaders = (anthropicState.constructorOptions?.[
+        'defaultHeaders'
+      ] || {}) as Record<string, string>;
+      expect(defaultHeaders['User-Agent']).toContain('QwenCode/1.2.3');
+      expect(defaultHeaders['X-Custom']).toBe('v1');
+      expect(defaultHeaders['anthropic-beta']).toBeUndefined();
+
+      // Per-request headers carry only the computed beta flags.
+      const [, options] = anthropicState.lastCreateArgs as AnthropicCreateArgs;
+      const reqHeaders = ((options as { headers?: Record<string, string> })
+        ?.headers || {}) as Record<string, string>;
+      expect(reqHeaders['User-Agent']).toBeUndefined();
+      expect(reqHeaders['X-Custom']).toBeUndefined();
+      expect(reqHeaders['anthropic-beta']).toContain(
+        'interleaved-thinking-2025-05-14',
+      );
+    });
+
     it('also sends the computed beta header on streaming requests', async () => {
       // generateContentStream() goes through a separate code path from
       // generateContent(); make sure the per-request header attaches there

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -498,7 +498,29 @@ describe('AnthropicContentGenerator', () => {
   // anthropic-compatible API rejects subsequent requests when any prior
   // assistant turn omits a thinking block while thinking mode is on.
   describe('DeepSeek anthropic-compatible provider', () => {
-    it('injects empty thinking blocks on prior assistant turns when baseUrl points to api.deepseek.com', async () => {
+    // Helper: tool-use assistant turn missing thinking — the only shape that
+    // actually triggers DeepSeek's HTTP 400.
+    const toolUseConversation = [
+      { role: 'user' as const, parts: [{ text: 'Run tool' }] },
+      {
+        role: 'model' as const,
+        parts: [{ functionCall: { id: 't1', name: 'tool', args: {} } }],
+      },
+      {
+        role: 'user' as const,
+        parts: [
+          {
+            functionResponse: {
+              id: 't1',
+              name: 'tool',
+              response: { output: 'ok' },
+            },
+          },
+        ],
+      },
+    ];
+
+    it('injects empty thinking blocks on tool-use assistant turns when baseUrl is api.deepseek.com', async () => {
       const { AnthropicContentGenerator } = await importGenerator();
       anthropicState.createImpl.mockResolvedValue({
         id: 'msg-1',
@@ -521,23 +543,18 @@ describe('AnthropicContentGenerator', () => {
 
       await generator.generateContent({
         model: 'models/ignored',
-        contents: [
-          { role: 'user', parts: [{ text: 'Hi' }] },
-          { role: 'model', parts: [{ text: 'Hello!' }] },
-          { role: 'user', parts: [{ text: 'How are you?' }] },
-        ],
+        contents: toolUseConversation,
       } as unknown as GenerateContentParameters);
 
       const [anthropicRequest] =
         anthropicState.lastCreateArgs as AnthropicCreateArgs;
       const messages = (anthropicRequest as { messages: unknown[] }).messages;
 
-      // Assistant turn should now have an empty thinking block prepended.
       expect(messages[1]).toEqual({
         role: 'assistant',
         content: [
           { type: 'thinking', thinking: '', signature: '' },
-          { type: 'text', text: 'Hello!' },
+          { type: 'tool_use', id: 't1', name: 'tool', input: {} },
         ],
       });
     });
@@ -565,11 +582,7 @@ describe('AnthropicContentGenerator', () => {
 
       await generator.generateContent({
         model: 'models/ignored',
-        contents: [
-          { role: 'user', parts: [{ text: 'Hi' }] },
-          { role: 'model', parts: [{ text: 'Hello!' }] },
-          { role: 'user', parts: [{ text: 'How are you?' }] },
-        ],
+        contents: toolUseConversation,
       } as unknown as GenerateContentParameters);
 
       const [anthropicRequest] =
@@ -580,10 +593,54 @@ describe('AnthropicContentGenerator', () => {
         role: 'assistant',
         content: [
           { type: 'thinking', thinking: '', signature: '' },
-          { type: 'text', text: 'Hello!' },
+          { type: 'tool_use', id: 't1', name: 'tool', input: {} },
         ],
       });
     });
+
+    it('matches regional DeepSeek subdomains (e.g. us.api.deepseek.com)', async () => {
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl.mockResolvedValue({
+        id: 'msg-1',
+        model: 'unrelated-model',
+        content: [{ type: 'text', text: 'ok' }],
+      });
+
+      const generator = new AnthropicContentGenerator(
+        {
+          model: 'unrelated-model',
+          apiKey: 'test-key',
+          baseUrl: 'https://us.api.deepseek.com/anthropic',
+          timeout: 10_000,
+          maxRetries: 2,
+          samplingParams: { max_tokens: 500 },
+          schemaCompliance: 'auto',
+        },
+        mockConfig,
+      );
+
+      await generator.generateContent({
+        model: 'models/ignored',
+        contents: toolUseConversation,
+      } as unknown as GenerateContentParameters);
+
+      const [anthropicRequest] =
+        anthropicState.lastCreateArgs as AnthropicCreateArgs;
+      const messages = (anthropicRequest as { messages: unknown[] }).messages;
+
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: '', signature: '' },
+          { type: 'tool_use', id: 't1', name: 'tool', input: {} },
+        ],
+      });
+    });
+
+    const toolOnlyAssistant = {
+      role: 'assistant',
+      content: [{ type: 'tool_use', id: 't1', name: 'tool', input: {} }],
+    };
 
     it('does not inject empty thinking blocks for non-deepseek providers', async () => {
       const { AnthropicContentGenerator } = await importGenerator();
@@ -608,22 +665,15 @@ describe('AnthropicContentGenerator', () => {
 
       await generator.generateContent({
         model: 'models/ignored',
-        contents: [
-          { role: 'user', parts: [{ text: 'Hi' }] },
-          { role: 'model', parts: [{ text: 'Hello!' }] },
-          { role: 'user', parts: [{ text: 'How are you?' }] },
-        ],
+        contents: toolUseConversation,
       } as unknown as GenerateContentParameters);
 
       const [anthropicRequest] =
         anthropicState.lastCreateArgs as AnthropicCreateArgs;
       const messages = (anthropicRequest as { messages: unknown[] }).messages;
 
-      // No thinking block injected for non-deepseek providers.
-      expect(messages[1]).toEqual({
-        role: 'assistant',
-        content: [{ type: 'text', text: 'Hello!' }],
-      });
+      // Non-deepseek provider: even tool_use turns get no injection.
+      expect(messages[1]).toEqual(toolOnlyAssistant);
     });
 
     it('does not match spoofed hostnames like api.deepseek.com.evil.com', async () => {
@@ -649,28 +699,23 @@ describe('AnthropicContentGenerator', () => {
 
       await generator.generateContent({
         model: 'models/ignored',
-        contents: [
-          { role: 'user', parts: [{ text: 'Hi' }] },
-          { role: 'model', parts: [{ text: 'Hello!' }] },
-          { role: 'user', parts: [{ text: 'How are you?' }] },
-        ],
+        contents: toolUseConversation,
       } as unknown as GenerateContentParameters);
 
       const [anthropicRequest] =
         anthropicState.lastCreateArgs as AnthropicCreateArgs;
       const messages = (anthropicRequest as { messages: unknown[] }).messages;
 
-      // Hostname differs from api.deepseek.com — must not inject.
-      expect(messages[1]).toEqual({
-        role: 'assistant',
-        content: [{ type: 'text', text: 'Hello!' }],
-      });
+      // Hostname differs from api.deepseek.com — must not inject even on
+      // tool_use turns.
+      expect(messages[1]).toEqual(toolOnlyAssistant);
     });
 
     it('does not inject when reasoning is explicitly disabled', async () => {
-      // Even on a confirmed-DeepSeek provider, if the request omits the
-      // top-level `thinking` parameter (because reasoning=false), shipping
-      // synthetic thinking blocks would be a protocol violation.
+      // Even on a confirmed-DeepSeek provider with a tool-use turn, if the
+      // request omits the top-level `thinking` parameter (because
+      // reasoning=false), shipping synthetic thinking blocks would be a
+      // protocol violation.
       const { AnthropicContentGenerator } = await importGenerator();
       anthropicState.createImpl.mockResolvedValue({
         id: 'msg-1',
@@ -694,25 +739,17 @@ describe('AnthropicContentGenerator', () => {
 
       await generator.generateContent({
         model: 'models/ignored',
-        contents: [
-          { role: 'user', parts: [{ text: 'Hi' }] },
-          { role: 'model', parts: [{ text: 'Hello!' }] },
-          { role: 'user', parts: [{ text: 'How are you?' }] },
-        ],
+        contents: toolUseConversation,
       } as unknown as GenerateContentParameters);
 
       const [anthropicRequest] =
         anthropicState.lastCreateArgs as AnthropicCreateArgs;
       const messages = (anthropicRequest as { messages: unknown[] }).messages;
 
-      // No `thinking` field in the request body, no injected blocks either.
       expect(anthropicRequest).toEqual(
         expect.not.objectContaining({ thinking: expect.anything() }),
       );
-      expect(messages[1]).toEqual({
-        role: 'assistant',
-        content: [{ type: 'text', text: 'Hello!' }],
-      });
+      expect(messages[1]).toEqual(toolOnlyAssistant);
     });
 
     it('does not inject when request sets thinkingConfig.includeThoughts=false', async () => {
@@ -741,11 +778,7 @@ describe('AnthropicContentGenerator', () => {
 
       await generator.generateContent({
         model: 'models/ignored',
-        contents: [
-          { role: 'user', parts: [{ text: 'Hi' }] },
-          { role: 'model', parts: [{ text: 'Hello!' }] },
-          { role: 'user', parts: [{ text: 'How are you?' }] },
-        ],
+        contents: toolUseConversation,
         config: { thinkingConfig: { includeThoughts: false } },
       } as unknown as GenerateContentParameters);
 
@@ -756,10 +789,7 @@ describe('AnthropicContentGenerator', () => {
       expect(anthropicRequest).toEqual(
         expect.not.objectContaining({ thinking: expect.anything() }),
       );
-      expect(messages[1]).toEqual({
-        role: 'assistant',
-        content: [{ type: 'text', text: 'Hello!' }],
-      });
+      expect(messages[1]).toEqual(toolOnlyAssistant);
     });
   });
 

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -218,6 +218,49 @@ describe('AnthropicContentGenerator', () => {
       expect(headers['anthropic-beta']).toBeUndefined();
     });
 
+    it('merges user-supplied customHeaders[anthropic-beta] with computed flags (no overwrite)', async () => {
+      // Users configure additional Anthropic beta flags via customHeaders.
+      // The per-request override must add to that list, not replace it.
+      const headers = await callOnce({
+        ...baseConfig,
+        reasoning: { effort: 'medium' },
+        customHeaders: { 'anthropic-beta': 'experimental-x,experimental-y' },
+      });
+      const beta = headers['anthropic-beta'] ?? '';
+      expect(beta.split(',')).toEqual(
+        expect.arrayContaining([
+          'experimental-x',
+          'experimental-y',
+          'interleaved-thinking-2025-05-14',
+          'effort-2025-11-24',
+        ]),
+      );
+    });
+
+    it('passes user-supplied customHeaders[anthropic-beta] through even when no thinking/effort is enabled', async () => {
+      const headers = await callOnce({
+        ...baseConfig,
+        reasoning: false,
+        customHeaders: { 'anthropic-beta': 'experimental-x' },
+      });
+      expect(headers['anthropic-beta']).toBe('experimental-x');
+    });
+
+    it('dedupes beta flags so duplicates from customHeaders are not repeated', async () => {
+      const headers = await callOnce({
+        ...baseConfig,
+        reasoning: { effort: 'medium' },
+        customHeaders: {
+          'anthropic-beta': 'interleaved-thinking-2025-05-14',
+        },
+      });
+      const beta = headers['anthropic-beta'] ?? '';
+      const occurrences = beta
+        .split(',')
+        .filter((f) => f.trim() === 'interleaved-thinking-2025-05-14');
+      expect(occurrences).toHaveLength(1);
+    });
+
     it('omits beta header when per-request thinkingConfig.includeThoughts=false', async () => {
       // Even though the global reasoning config sets effort, the per-request
       // opt-out drops both `thinking` and `output_config` from the body — and

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -246,6 +246,34 @@ describe('AnthropicContentGenerator', () => {
       expect(headers['anthropic-beta']).toBe('experimental-x');
     });
 
+    it('does not leak customHeaders[anthropic-beta] (any casing) into defaultHeaders', async () => {
+      // The per-request path owns anthropic-beta. If we also copied a
+      // mixed-case `Anthropic-Beta` from customHeaders into defaultHeaders,
+      // the wire request would carry two physical headers for the same
+      // logical name — one mixed-case (verbatim from defaultHeaders) and one
+      // lowercase (from the per-request override). SDK behavior on duplicate
+      // headers with different casings is undefined.
+      const { AnthropicContentGenerator } = await importGenerator();
+      void new AnthropicContentGenerator(
+        {
+          ...baseConfig,
+          customHeaders: {
+            'Anthropic-Beta': 'user-flag',
+            'X-Other': 'kept',
+          },
+        },
+        mockConfig,
+      );
+      const defaultHeaders = (anthropicState.constructorOptions?.[
+        'defaultHeaders'
+      ] || {}) as Record<string, string>;
+      expect(defaultHeaders['Anthropic-Beta']).toBeUndefined();
+      expect(defaultHeaders['anthropic-beta']).toBeUndefined();
+      expect(defaultHeaders['ANTHROPIC-BETA']).toBeUndefined();
+      // Unrelated customHeaders are still passed through.
+      expect(defaultHeaders['X-Other']).toBe('kept');
+    });
+
     it('honors customHeaders[anthropic-beta] under mixed-case keys (Anthropic-Beta / ANTHROPIC-BETA)', async () => {
       // HTTP header names are case-insensitive; Anthropic SDK lower-cases
       // headers when merging. Make sure our merge logic also matches

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -148,71 +148,86 @@ describe('AnthropicContentGenerator', () => {
 
     const headers = (anthropicState.constructorOptions?.['defaultHeaders'] ||
       {}) as Record<string, string>;
+    // Beta headers moved out of defaultHeaders — see PR #3788 review feedback.
+    // Only User-Agent and customHeaders remain at construction time.
     expect(headers['User-Agent']).toContain('QwenCode/1.2.3');
-    expect(headers['anthropic-beta']).toContain('effort-2025-11-24');
     expect(headers['X-Custom']).toBe('1');
-  });
-
-  it('adds the effort beta header when reasoning.effort is set', async () => {
-    const { AnthropicContentGenerator } = await importGenerator();
-    void new AnthropicContentGenerator(
-      {
-        model: 'claude-test',
-        apiKey: 'test-key',
-        baseUrl: 'https://example.invalid',
-        timeout: 10_000,
-        maxRetries: 2,
-        samplingParams: {},
-        schemaCompliance: 'auto',
-        reasoning: { effort: 'medium' },
-      },
-      mockConfig,
-    );
-
-    const headers = (anthropicState.constructorOptions?.['defaultHeaders'] ||
-      {}) as Record<string, string>;
-    expect(headers['anthropic-beta']).toContain('effort-2025-11-24');
-  });
-
-  it('does not add the effort beta header when reasoning.effort is not set', async () => {
-    const { AnthropicContentGenerator } = await importGenerator();
-    void new AnthropicContentGenerator(
-      {
-        model: 'claude-test',
-        apiKey: 'test-key',
-        baseUrl: 'https://example.invalid',
-        timeout: 10_000,
-        maxRetries: 2,
-        samplingParams: {},
-        schemaCompliance: 'auto',
-      },
-      mockConfig,
-    );
-
-    const headers = (anthropicState.constructorOptions?.['defaultHeaders'] ||
-      {}) as Record<string, string>;
-    expect(headers['anthropic-beta']).not.toContain('effort-2025-11-24');
-  });
-
-  it('omits the anthropic beta header when reasoning is disabled', async () => {
-    const { AnthropicContentGenerator } = await importGenerator();
-    void new AnthropicContentGenerator(
-      {
-        model: 'claude-test',
-        apiKey: 'test-key',
-        baseUrl: 'https://example.invalid',
-        timeout: 10_000,
-        maxRetries: 2,
-        samplingParams: {},
-        schemaCompliance: 'auto',
-        reasoning: false,
-      },
-      mockConfig,
-    );
-
-    const headers = (anthropicState.constructorOptions?.['defaultHeaders'] ||
-      {}) as Record<string, string>;
     expect(headers['anthropic-beta']).toBeUndefined();
+  });
+
+  // Per-request header behavior moved into the generateContent describe
+  // block below — see "anthropic-beta header" cases.
+
+  // Per-request anthropic-beta is computed from the actual fields present
+  // in the request body (rather than the constructor-time reasoning config),
+  // so the wire shape stays consistent when a per-request opt-out drops
+  // `thinking` / `output_config`. See PR #3788 review feedback.
+  describe('per-request anthropic-beta header', () => {
+    const baseConfig: ContentGeneratorConfig = {
+      model: 'claude-test',
+      apiKey: 'test-key',
+      baseUrl: 'https://example.invalid',
+      timeout: 10_000,
+      maxRetries: 2,
+      samplingParams: { max_tokens: 100 },
+      schemaCompliance: 'auto',
+    };
+
+    async function callOnce(
+      config: ContentGeneratorConfig,
+      requestConfig?: object,
+    ) {
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl.mockResolvedValue({
+        id: 'msg-1',
+        model: 'claude-test',
+        content: [{ type: 'text', text: 'ok' }],
+      });
+      const generator = new AnthropicContentGenerator(config, mockConfig);
+      await generator.generateContent({
+        model: 'models/ignored',
+        contents: 'Hi',
+        ...(requestConfig ? { config: requestConfig } : {}),
+      } as unknown as GenerateContentParameters);
+      const [, options] = anthropicState.lastCreateArgs as AnthropicCreateArgs;
+      return ((options as { headers?: Record<string, string> })?.headers ||
+        {}) as Record<string, string>;
+    }
+
+    it('sends interleaved-thinking + effort beta when both are present in the body', async () => {
+      const headers = await callOnce({
+        ...baseConfig,
+        reasoning: { effort: 'medium' },
+      });
+      expect(headers['anthropic-beta']).toContain(
+        'interleaved-thinking-2025-05-14',
+      );
+      expect(headers['anthropic-beta']).toContain('effort-2025-11-24');
+    });
+
+    it('sends only interleaved-thinking when effort is not set', async () => {
+      const headers = await callOnce({
+        ...baseConfig,
+        // No reasoning config: thinking defaults to enabled, no effort.
+      });
+      expect(headers['anthropic-beta']).toBe('interleaved-thinking-2025-05-14');
+    });
+
+    it('omits beta header when reasoning is disabled (no thinking, no effort)', async () => {
+      const headers = await callOnce({ ...baseConfig, reasoning: false });
+      expect(headers['anthropic-beta']).toBeUndefined();
+    });
+
+    it('omits beta header when per-request thinkingConfig.includeThoughts=false', async () => {
+      // Even though the global reasoning config sets effort, the per-request
+      // opt-out drops both `thinking` and `output_config` from the body — and
+      // the beta header must follow.
+      const headers = await callOnce(
+        { ...baseConfig, reasoning: { effort: 'medium' } },
+        { thinkingConfig: { includeThoughts: false } },
+      );
+      expect(headers['anthropic-beta']).toBeUndefined();
+    });
   });
 
   describe('generateContent', () => {

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -863,7 +863,10 @@ describe('AnthropicContentGenerator', () => {
 
     it('does not inject when request sets thinkingConfig.includeThoughts=false', async () => {
       // Same concern as above but for the per-request override used by
-      // suggestionGenerator / forkedAgent / ArenaManager.
+      // suggestionGenerator / forkedAgent / ArenaManager. Both the top-level
+      // `thinking` field AND the reasoning-shaped `output_config` must be
+      // suppressed — leaving either behind reintroduces the protocol
+      // mismatch this gate is designed to avoid.
       const { AnthropicContentGenerator } = await importGenerator();
       anthropicState.createImpl.mockResolvedValue({
         id: 'msg-1',
@@ -897,6 +900,9 @@ describe('AnthropicContentGenerator', () => {
 
       expect(anthropicRequest).toEqual(
         expect.not.objectContaining({ thinking: expect.anything() }),
+      );
+      expect(anthropicRequest).toEqual(
+        expect.not.objectContaining({ output_config: expect.anything() }),
       );
       expect(messages[1]).toEqual(toolOnlyAssistant);
     });

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -246,6 +246,32 @@ describe('AnthropicContentGenerator', () => {
       expect(headers['anthropic-beta']).toBe('experimental-x');
     });
 
+    it('honors customHeaders[anthropic-beta] under mixed-case keys (Anthropic-Beta / ANTHROPIC-BETA)', async () => {
+      // HTTP header names are case-insensitive; Anthropic SDK lower-cases
+      // headers when merging. Make sure our merge logic also matches
+      // case-insensitively so the user-configured beta flag isn't silently
+      // overwritten by the per-request value.
+      const headersUpper = await callOnce({
+        ...baseConfig,
+        reasoning: { effort: 'medium' },
+        customHeaders: { 'ANTHROPIC-BETA': 'experimental-x' },
+      });
+      expect(headersUpper['anthropic-beta']).toContain('experimental-x');
+      expect(headersUpper['anthropic-beta']).toContain(
+        'interleaved-thinking-2025-05-14',
+      );
+
+      const headersTitle = await callOnce({
+        ...baseConfig,
+        reasoning: { effort: 'medium' },
+        customHeaders: { 'Anthropic-Beta': 'experimental-y' },
+      });
+      expect(headersTitle['anthropic-beta']).toContain('experimental-y');
+      expect(headersTitle['anthropic-beta']).toContain(
+        'interleaved-thinking-2025-05-14',
+      );
+    });
+
     it('dedupes beta flags so duplicates from customHeaders are not repeated', async () => {
       const headers = await callOnce({
         ...baseConfig,

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -753,6 +753,114 @@ describe('AnthropicContentGenerator', () => {
       expect(messages[1]).toEqual(toolOnlyAssistant);
     });
 
+    it('strips real thought parts from assistant history when reasoning is disabled', async () => {
+      // suggestionGenerator / forkedAgent path: the top-level `thinking`
+      // parameter is dropped, but the session history may still carry
+      // `thought: true` parts that the converter would otherwise replay as
+      // thinking blocks — same protocol mismatch the gate is meant to avoid.
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl.mockResolvedValue({
+        id: 'msg-1',
+        model: 'deepseek-v4-pro',
+        content: [{ type: 'text', text: 'ok' }],
+      });
+
+      const generator = new AnthropicContentGenerator(
+        {
+          model: 'deepseek-v4-pro',
+          apiKey: 'test-key',
+          baseUrl: 'https://api.deepseek.com/anthropic',
+          timeout: 10_000,
+          maxRetries: 2,
+          samplingParams: { max_tokens: 500 },
+          schemaCompliance: 'auto',
+          reasoning: false,
+        },
+        mockConfig,
+      );
+
+      await generator.generateContent({
+        model: 'models/ignored',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          {
+            role: 'model',
+            parts: [
+              { text: 'real reasoning', thought: true, thoughtSignature: 's1' },
+              { text: 'Hello!' },
+            ],
+          },
+          { role: 'user', parts: [{ text: 'Bye' }] },
+        ],
+      } as unknown as GenerateContentParameters);
+
+      const [anthropicRequest] =
+        anthropicState.lastCreateArgs as AnthropicCreateArgs;
+      const messages = (anthropicRequest as { messages: unknown[] }).messages;
+
+      expect(anthropicRequest).toEqual(
+        expect.not.objectContaining({ thinking: expect.anything() }),
+      );
+      // Existing thinking block dropped — no protocol mismatch.
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello!' }],
+      });
+    });
+
+    it('reflects runtime model changes (no stale provider cache)', async () => {
+      // Config.setModel() mutates contentGeneratorConfig.model in place. A
+      // generator constructed against a non-DeepSeek model must start
+      // injecting thinking blocks once the model is switched to DeepSeek
+      // without re-creating the generator.
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl.mockResolvedValue({
+        id: 'msg-1',
+        model: 'claude-test',
+        content: [{ type: 'text', text: 'ok' }],
+      });
+
+      const config: ContentGeneratorConfig = {
+        model: 'claude-test',
+        apiKey: 'test-key',
+        baseUrl: 'https://example.invalid',
+        timeout: 10_000,
+        maxRetries: 2,
+        samplingParams: { max_tokens: 500 },
+        schemaCompliance: 'auto',
+      };
+
+      const generator = new AnthropicContentGenerator(config, mockConfig);
+
+      // Initial model isn't DeepSeek — no injection.
+      await generator.generateContent({
+        model: 'models/ignored',
+        contents: toolUseConversation,
+      } as unknown as GenerateContentParameters);
+      let [req] = anthropicState.lastCreateArgs as AnthropicCreateArgs;
+      expect(
+        (req as { messages: unknown[] }).messages[1] as { content: unknown },
+      ).toEqual(toolOnlyAssistant);
+
+      // Hot-update the model in place, mimicking Config.setModel().
+      config.model = 'deepseek-chat';
+
+      await generator.generateContent({
+        model: 'models/ignored',
+        contents: toolUseConversation,
+      } as unknown as GenerateContentParameters);
+      [req] = anthropicState.lastCreateArgs as AnthropicCreateArgs;
+      expect(
+        (req as { messages: unknown[] }).messages[1] as { content: unknown },
+      ).toEqual({
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: '', signature: '' },
+          { type: 'tool_use', id: 't1', name: 'tool', input: {} },
+        ],
+      });
+    });
+
     it('does not inject when request sets thinkingConfig.includeThoughts=false', async () => {
       // Same concern as above but for the per-request override used by
       // suggestionGenerator / forkedAgent / ArenaManager.

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -39,6 +39,23 @@ import {
 
 const debugLogger = createDebugLogger('ANTHROPIC');
 
+/**
+ * DeepSeek's anthropic-compatible API rejects requests in thinking mode that
+ * omit a thinking block on prior assistant turns. Detect by base URL or model
+ * name so the converter can inject empty thinking blocks where missing.
+ * https://github.com/QwenLM/qwen-code/issues/3786
+ */
+function isDeepSeekAnthropicProvider(
+  contentGeneratorConfig: ContentGeneratorConfig,
+): boolean {
+  const baseUrl = (contentGeneratorConfig.baseUrl ?? '').toLowerCase();
+  if (baseUrl.includes('api.deepseek.com')) {
+    return true;
+  }
+  const model = (contentGeneratorConfig.model ?? '').toLowerCase();
+  return model.includes('deepseek');
+}
+
 type StreamingBlockState = {
   type: string;
   id?: string;
@@ -84,6 +101,7 @@ export class AnthropicContentGenerator implements ContentGenerator {
       contentGeneratorConfig.model,
       contentGeneratorConfig.schemaCompliance,
       contentGeneratorConfig.enableCacheControl,
+      isDeepSeekAnthropicProvider(contentGeneratorConfig),
     );
   }
 

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -41,16 +41,26 @@ const debugLogger = createDebugLogger('ANTHROPIC');
 
 /**
  * DeepSeek's anthropic-compatible API rejects requests in thinking mode that
- * omit a thinking block on prior assistant turns. Detect by base URL or model
- * name so the converter can inject empty thinking blocks where missing.
- * https://github.com/QwenLM/qwen-code/issues/3786
+ * omit a thinking block on prior assistant turns. Detect by base URL hostname
+ * or model name so the converter can inject empty thinking blocks where
+ * missing. https://github.com/QwenLM/qwen-code/issues/3786
  */
 function isDeepSeekAnthropicProvider(
   contentGeneratorConfig: ContentGeneratorConfig,
 ): boolean {
-  const baseUrl = (contentGeneratorConfig.baseUrl ?? '').toLowerCase();
-  if (baseUrl.includes('api.deepseek.com')) {
-    return true;
+  const baseUrl = contentGeneratorConfig.baseUrl ?? '';
+  if (baseUrl) {
+    try {
+      const hostname = new URL(baseUrl).hostname.toLowerCase();
+      if (
+        hostname === 'api.deepseek.com' ||
+        hostname.endsWith('.api.deepseek.com')
+      ) {
+        return true;
+      }
+    } catch {
+      // Invalid URL — fall through to model-name detection.
+    }
   }
   const model = (contentGeneratorConfig.model ?? '').toLowerCase();
   return model.includes('deepseek');
@@ -74,6 +84,7 @@ type MessageCreateParamsWithThinking = MessageCreateParamsNonStreaming & {
 export class AnthropicContentGenerator implements ContentGenerator {
   private client: Anthropic;
   private converter: AnthropicContentConverter;
+  private readonly isDeepSeekProvider: boolean;
 
   constructor(
     private contentGeneratorConfig: ContentGeneratorConfig,
@@ -101,7 +112,9 @@ export class AnthropicContentGenerator implements ContentGenerator {
       contentGeneratorConfig.model,
       contentGeneratorConfig.schemaCompliance,
       contentGeneratorConfig.enableCacheControl,
-      isDeepSeekAnthropicProvider(contentGeneratorConfig),
+    );
+    this.isDeepSeekProvider = isDeepSeekAnthropicProvider(
+      contentGeneratorConfig,
     );
   }
 
@@ -204,16 +217,26 @@ export class AnthropicContentGenerator implements ContentGenerator {
   private async buildRequest(
     request: GenerateContentParameters,
   ): Promise<MessageCreateParamsWithThinking> {
-    const { system, messages } =
-      this.converter.convertGeminiRequestToAnthropic(request);
+    const sampling = this.buildSamplingParameters(request);
+    const thinking = this.buildThinkingConfig(request);
+    const outputConfig = this.buildOutputConfig();
+
+    // Only ask the converter to inject empty thinking blocks when both the
+    // provider needs them AND this request actually enables thinking mode.
+    // Otherwise we'd ship thinking blocks without the top-level `thinking`
+    // parameter — a protocol violation that DeepSeek rejects with a different
+    // 400. Matters for code paths that pass `includeThoughts: false`
+    // (suggestionGenerator / ArenaManager / forkedAgent).
+    const ensureAssistantThinking = this.isDeepSeekProvider && !!thinking;
+
+    const { system, messages } = this.converter.convertGeminiRequestToAnthropic(
+      request,
+      { ensureAssistantThinking },
+    );
 
     const tools = request.config?.tools
       ? await this.converter.convertGeminiToolsToAnthropic(request.config.tools)
       : undefined;
-
-    const sampling = this.buildSamplingParameters(request);
-    const thinking = this.buildThinkingConfig(request);
-    const outputConfig = this.buildOutputConfig();
 
     return {
       model: this.contentGeneratorConfig.model,

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -208,20 +208,17 @@ export class AnthropicContentGenerator implements ContentGenerator {
    *
    * User-supplied `customHeaders['anthropic-beta']` flags are merged in (and
    * deduped) so the per-request override doesn't wipe out the existing
-   * customHeaders escape hatch for unrelated beta features.
+   * customHeaders escape hatch for unrelated beta features. The lookup is
+   * case-insensitive — HTTP header names are case-insensitive by spec, so a
+   * user-configured `Anthropic-Beta` or `ANTHROPIC-BETA` is honored too.
    */
   private buildPerRequestHeaders(
     anthropicRequest: MessageCreateParamsWithThinking,
   ): Record<string, string> | undefined {
     const betas: string[] = [];
 
-    const userBeta =
-      this.contentGeneratorConfig.customHeaders?.['anthropic-beta'];
-    if (typeof userBeta === 'string' && userBeta) {
-      for (const flag of userBeta.split(',')) {
-        const trimmed = flag.trim();
-        if (trimmed) betas.push(trimmed);
-      }
+    for (const flag of this.collectCustomBetaFlags()) {
+      betas.push(flag);
     }
 
     if (anthropicRequest.thinking) {
@@ -234,6 +231,28 @@ export class AnthropicContentGenerator implements ContentGenerator {
     if (betas.length === 0) return undefined;
     const unique = Array.from(new Set(betas));
     return { 'anthropic-beta': unique.join(',') };
+  }
+
+  /**
+   * Read every customHeaders entry whose key (case-insensitively) is
+   * `anthropic-beta` and yield the comma-separated flags from each. Multiple
+   * matching entries are concatenated; later ones may produce duplicates
+   * which the caller dedupes.
+   */
+  private collectCustomBetaFlags(): string[] {
+    const customHeaders = this.contentGeneratorConfig.customHeaders;
+    if (!customHeaders) return [];
+
+    const flags: string[] = [];
+    for (const [key, value] of Object.entries(customHeaders)) {
+      if (key.toLowerCase() !== 'anthropic-beta') continue;
+      if (typeof value !== 'string' || !value) continue;
+      for (const flag of value.split(',')) {
+        const trimmed = flag.trim();
+        if (trimmed) flags.push(trimmed);
+      }
+    }
+    return flags;
   }
 
   private async buildRequest(

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -120,8 +120,10 @@ export class AnthropicContentGenerator implements ContentGenerator {
     request: GenerateContentParameters,
   ): Promise<GenerateContentResponse> {
     const anthropicRequest = await this.buildRequest(request);
+    const headers = this.buildPerRequestHeaders(anthropicRequest);
     const response = (await this.client.messages.create(anthropicRequest, {
       signal: request.config?.abortSignal,
+      ...(headers ? { headers } : {}),
     })) as Message;
 
     return this.converter.convertAnthropicResponseToGemini(response);
@@ -131,6 +133,7 @@ export class AnthropicContentGenerator implements ContentGenerator {
     request: GenerateContentParameters,
   ): Promise<AsyncGenerator<GenerateContentResponse>> {
     const anthropicRequest = await this.buildRequest(request);
+    const headers = this.buildPerRequestHeaders(anthropicRequest);
     const streamingRequest: MessageCreateParamsStreaming & {
       thinking?: { type: 'enabled'; budget_tokens: number };
     } = {
@@ -142,6 +145,7 @@ export class AnthropicContentGenerator implements ContentGenerator {
       streamingRequest as MessageCreateParamsStreaming,
       {
         signal: request.config?.abortSignal,
+        ...(headers ? { headers } : {}),
       },
     )) as AsyncIterable<RawMessageStreamEvent>;
 
@@ -184,32 +188,35 @@ export class AnthropicContentGenerator implements ContentGenerator {
   }
 
   private buildHeaders(): Record<string, string> {
+    // Beta headers are computed per-request in buildPerRequestHeaders so they
+    // stay in sync with what the request body actually carries — see #3788
+    // review feedback. Constructor headers carry only User-Agent and any
+    // user-supplied custom headers.
     const version = this.cliConfig.getCliVersion() || 'unknown';
     const userAgent = `QwenCode/${version} (${process.platform}; ${process.arch})`;
     const { customHeaders } = this.contentGeneratorConfig;
 
-    const betas: string[] = [];
-    const reasoning = this.contentGeneratorConfig.reasoning;
+    const headers: Record<string, string> = { 'User-Agent': userAgent };
+    return customHeaders ? { ...headers, ...customHeaders } : headers;
+  }
 
-    // Interleaved thinking is used when we send the `thinking` field.
-    if (reasoning !== false) {
+  /**
+   * Compute `anthropic-beta` from the actual fields present in the request
+   * body. Keeps the header consistent with the body even when a per-request
+   * `thinkingConfig.includeThoughts: false` opt-out drops `thinking` /
+   * `output_config` after the constructor has already run.
+   */
+  private buildPerRequestHeaders(
+    anthropicRequest: MessageCreateParamsWithThinking,
+  ): Record<string, string> | undefined {
+    const betas: string[] = [];
+    if (anthropicRequest.thinking) {
       betas.push('interleaved-thinking-2025-05-14');
     }
-
-    // Effort (beta) is enabled when reasoning.effort is set.
-    if (reasoning !== false && reasoning?.effort !== undefined) {
+    if (anthropicRequest.output_config) {
       betas.push('effort-2025-11-24');
     }
-
-    const headers: Record<string, string> = {
-      'User-Agent': userAgent,
-    };
-
-    if (betas.length) {
-      headers['anthropic-beta'] = betas.join(',');
-    }
-
-    return customHeaders ? { ...headers, ...customHeaders } : headers;
+    return betas.length > 0 ? { 'anthropic-beta': betas.join(',') } : undefined;
   }
 
   private async buildRequest(

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -86,7 +86,6 @@ type MessageCreateParamsWithThinking = MessageCreateParamsNonStreaming & {
 export class AnthropicContentGenerator implements ContentGenerator {
   private client: Anthropic;
   private converter: AnthropicContentConverter;
-  private readonly isDeepSeekProvider: boolean;
 
   constructor(
     private contentGeneratorConfig: ContentGeneratorConfig,
@@ -114,9 +113,6 @@ export class AnthropicContentGenerator implements ContentGenerator {
       contentGeneratorConfig.model,
       contentGeneratorConfig.schemaCompliance,
       contentGeneratorConfig.enableCacheControl,
-    );
-    this.isDeepSeekProvider = isDeepSeekAnthropicProvider(
-      contentGeneratorConfig,
     );
   }
 
@@ -223,17 +219,28 @@ export class AnthropicContentGenerator implements ContentGenerator {
     const thinking = this.buildThinkingConfig(request);
     const outputConfig = this.buildOutputConfig();
 
-    // Only ask the converter to inject empty thinking blocks when both the
-    // provider needs them AND this request actually enables thinking mode.
-    // Otherwise we'd ship thinking blocks without the top-level `thinking`
-    // parameter — a protocol violation that DeepSeek rejects with a different
-    // 400. Matters for code paths that pass `includeThoughts: false`
-    // (suggestionGenerator / ArenaManager / forkedAgent).
-    const ensureAssistantThinking = this.isDeepSeekProvider && !!thinking;
+    // Compute per-request: `Config.setModel()` mutates contentGeneratorConfig
+    // in place, so a constructor-time cache could go stale on a runtime
+    // model switch. The detector is cheap (URL parse + string compare).
+    const isDeepSeek = isDeepSeekAnthropicProvider(this.contentGeneratorConfig);
+
+    // On DeepSeek the converter must keep history aligned with the top-level
+    // `thinking` parameter to avoid HTTP 400:
+    //   - thinking on  → inject empty thinking on tool_use turns missing one
+    //                    (issue #3786 trigger)
+    //   - thinking off → strip pre-existing thinking blocks from assistant
+    //                    history so a request without `thinking` config
+    //                    doesn't ship stray thinking blocks. Matters for
+    //                    code paths that pass `includeThoughts: false`
+    //                    against a session whose history already contains
+    //                    `thought: true` parts (suggestionGenerator /
+    //                    ArenaManager / forkedAgent).
+    const ensureAssistantThinking = isDeepSeek && !!thinking;
+    const stripAssistantThinking = isDeepSeek && !thinking;
 
     const { system, messages } = this.converter.convertGeminiRequestToAnthropic(
       request,
-      { ensureAssistantThinking },
+      { ensureAssistantThinking, stripAssistantThinking },
     );
 
     const tools = request.config?.tools

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -205,18 +205,35 @@ export class AnthropicContentGenerator implements ContentGenerator {
    * body. Keeps the header consistent with the body even when a per-request
    * `thinkingConfig.includeThoughts: false` opt-out drops `thinking` /
    * `output_config` after the constructor has already run.
+   *
+   * User-supplied `customHeaders['anthropic-beta']` flags are merged in (and
+   * deduped) so the per-request override doesn't wipe out the existing
+   * customHeaders escape hatch for unrelated beta features.
    */
   private buildPerRequestHeaders(
     anthropicRequest: MessageCreateParamsWithThinking,
   ): Record<string, string> | undefined {
     const betas: string[] = [];
+
+    const userBeta =
+      this.contentGeneratorConfig.customHeaders?.['anthropic-beta'];
+    if (typeof userBeta === 'string' && userBeta) {
+      for (const flag of userBeta.split(',')) {
+        const trimmed = flag.trim();
+        if (trimmed) betas.push(trimmed);
+      }
+    }
+
     if (anthropicRequest.thinking) {
       betas.push('interleaved-thinking-2025-05-14');
     }
     if (anthropicRequest.output_config) {
       betas.push('effort-2025-11-24');
     }
-    return betas.length > 0 ? { 'anthropic-beta': betas.join(',') } : undefined;
+
+    if (betas.length === 0) return undefined;
+    const unique = Array.from(new Set(betas));
+    return { 'anthropic-beta': unique.join(',') };
   }
 
   private async buildRequest(

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -217,7 +217,7 @@ export class AnthropicContentGenerator implements ContentGenerator {
   ): Promise<MessageCreateParamsWithThinking> {
     const sampling = this.buildSamplingParameters(request);
     const thinking = this.buildThinkingConfig(request);
-    const outputConfig = this.buildOutputConfig();
+    const outputConfig = this.buildOutputConfig(request);
 
     // Compute per-request: `Config.setModel()` mutates contentGeneratorConfig
     // in place, so a constructor-time cache could go stale on a runtime
@@ -235,12 +235,12 @@ export class AnthropicContentGenerator implements ContentGenerator {
     //                    against a session whose history already contains
     //                    `thought: true` parts (suggestionGenerator /
     //                    ArenaManager / forkedAgent).
-    const ensureAssistantThinking = isDeepSeek && !!thinking;
+    const ensureThinkingOnToolUseTurns = isDeepSeek && !!thinking;
     const stripAssistantThinking = isDeepSeek && !thinking;
 
     const { system, messages } = this.converter.convertGeminiRequestToAnthropic(
       request,
-      { ensureAssistantThinking, stripAssistantThinking },
+      { ensureThinkingOnToolUseTurns, stripAssistantThinking },
     );
 
     const tools = request.config?.tools
@@ -341,9 +341,16 @@ export class AnthropicContentGenerator implements ContentGenerator {
     };
   }
 
-  private buildOutputConfig():
-    | { effort: 'low' | 'medium' | 'high' }
-    | undefined {
+  private buildOutputConfig(
+    request: GenerateContentParameters,
+  ): { effort: 'low' | 'medium' | 'high' } | undefined {
+    // Honor per-request opt-out so side queries (suggestionGenerator,
+    // ArenaManager, forkedAgent) don't leak a reasoning-shaped output_config
+    // alongside an absent top-level `thinking` parameter.
+    if (request.config?.thinkingConfig?.includeThoughts === false) {
+      return undefined;
+    }
+
     const reasoning = this.contentGeneratorConfig.reasoning;
     if (reasoning === false || reasoning === undefined) {
       return undefined;

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -40,10 +40,12 @@ import {
 const debugLogger = createDebugLogger('ANTHROPIC');
 
 /**
- * DeepSeek's anthropic-compatible API rejects requests in thinking mode that
- * omit a thinking block on prior assistant turns. Detect by base URL hostname
- * or model name so the converter can inject empty thinking blocks where
- * missing. https://github.com/QwenLM/qwen-code/issues/3786
+ * DeepSeek's anthropic-compatible API rejects requests in thinking mode when
+ * a prior assistant turn carrying `tool_use` omits a thinking block.
+ * Plain-text assistant turns without thinking are accepted unchanged. Detect
+ * the provider by base URL hostname or model name so the converter can inject
+ * empty thinking blocks on the affected turns.
+ * https://github.com/QwenLM/qwen-code/issues/3786
  */
 function isDeepSeekAnthropicProvider(
   contentGeneratorConfig: ContentGeneratorConfig,

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -191,13 +191,22 @@ export class AnthropicContentGenerator implements ContentGenerator {
     // Beta headers are computed per-request in buildPerRequestHeaders so they
     // stay in sync with what the request body actually carries — see #3788
     // review feedback. Constructor headers carry only User-Agent and any
-    // user-supplied custom headers.
+    // user-supplied custom headers EXCEPT anthropic-beta (any casing): the
+    // per-request path owns that header, and copying it into defaultHeaders
+    // would cause two physical headers on the wire (one mixed-case, one
+    // lowercase) when the per-request override fires.
     const version = this.cliConfig.getCliVersion() || 'unknown';
     const userAgent = `QwenCode/${version} (${process.platform}; ${process.arch})`;
     const { customHeaders } = this.contentGeneratorConfig;
 
     const headers: Record<string, string> = { 'User-Agent': userAgent };
-    return customHeaders ? { ...headers, ...customHeaders } : headers;
+    if (customHeaders) {
+      for (const [key, value] of Object.entries(customHeaders)) {
+        if (key.toLowerCase() === 'anthropic-beta') continue;
+        headers[key] = value;
+      }
+    }
+    return headers;
   }
 
   /**

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -259,12 +259,19 @@ export class AnthropicContentGenerator implements ContentGenerator {
     //                    against a session whose history already contains
     //                    `thought: true` parts (suggestionGenerator /
     //                    ArenaManager / forkedAgent).
-    const ensureThinkingOnToolUseTurns = isDeepSeek && !!thinking;
+    const deepseekThinkingOn = isDeepSeek && !!thinking;
     const stripAssistantThinking = isDeepSeek && !thinking;
 
     const { system, messages } = this.converter.convertGeminiRequestToAnthropic(
       request,
-      { ensureThinkingOnToolUseTurns, stripAssistantThinking },
+      {
+        // Both run together: normalization fills missing signatures so the
+        // injection pass treats those blocks as already-present, and the
+        // injection adds a synthetic block on tool_use turns lacking one.
+        normalizeAssistantThinkingSignature: deepseekThinkingOn,
+        injectThinkingOnToolUseTurns: deepseekThinkingOn,
+        stripAssistantThinking,
+      },
     );
 
     const tools = request.config?.tools

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -919,12 +919,13 @@ describe('AnthropicContentConverter', () => {
       ]);
     });
 
-    it('replaces a non-compliant thinking block (no signature field) with a synthetic one', () => {
+    it('normalizes a non-compliant thinking block (no signature field) on a tool-use turn', () => {
       // A part `{ text: '', thought: true }` (e.g. round-tripped from a
       // `redacted_thinking` response that lost its `data` field via the
       // Gemini Part representation) converts to a thinking block without a
-      // `signature` field. That shape is not spec-compliant, so the injector
-      // drops it and prepends a synthetic block with `signature: ''`.
+      // `signature` field. The cleanup adds an empty signature in place;
+      // because the normalized block now satisfies the requirement, Step 2
+      // does not prepend a synthetic.
       const { messages } = converter.convertGeminiRequestToAnthropic(
         {
           model: 'models/test',
@@ -988,11 +989,14 @@ describe('AnthropicContentConverter', () => {
       });
     });
 
-    it('drops non-compliant thinking blocks from plain-text assistant turns even when no tool_use is present', () => {
-      // A `redacted_thinking` round-tripped through Gemini-Part comes back as
-      // `{ type: 'thinking', thinking: '' }` with no signature. On a
-      // plain-text turn there is nothing to inject (no tool_use), but the
-      // bad block is still non-compliant and should be cleaned up.
+    it('normalizes non-compliant thinking blocks (adds empty signature) on plain-text turns', () => {
+      // A part `{ thought: true, text: '...' }` (the normal shape from
+      // OpenAI/Gemini/agent-runtime where users may switch providers
+      // mid-session, or a `redacted_thinking` round-tripped through Gemini-
+      // Part) converts to `{ type: 'thinking', thinking: '...' }` without
+      // signature. The cleanup adds an empty signature in place to make the
+      // block spec-compliant while preserving the original thinking text.
+      // No synthetic is prepended on a plain-text turn (no tool_use).
       const { messages } = converter.convertGeminiRequestToAnthropic(
         {
           model: 'models/test',
@@ -1000,18 +1004,26 @@ describe('AnthropicContentConverter', () => {
             { role: 'user', parts: [{ text: 'Hi' }] },
             {
               role: 'model',
-              parts: [{ text: '', thought: true }, { text: 'Hello!' }],
+              parts: [
+                { text: 'cross-provider thoughts', thought: true },
+                { text: 'Hello!' },
+              ],
             },
           ],
         },
         enableThinking,
       );
 
-      // Bad thinking block dropped; remaining text passes through. No
-      // synthetic prepended because the turn has no tool_use.
       expect(messages[1]).toEqual({
         role: 'assistant',
-        content: [{ type: 'text', text: 'Hello!' }],
+        content: [
+          {
+            type: 'thinking',
+            thinking: 'cross-provider thoughts',
+            signature: '',
+          },
+          { type: 'text', text: 'Hello!' },
+        ],
       });
     });
 

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -654,7 +654,10 @@ describe('AnthropicContentConverter', () => {
   describe('ensureAssistantThinking', () => {
     const enableThinking = { ensureAssistantThinking: true };
 
-    it('injects an empty thinking block on assistant turns missing one', () => {
+    it('does not inject on plain-text assistant turns (DeepSeek tolerates them)', () => {
+      // Verified against api.deepseek.com/anthropic: plain-text assistant
+      // turns without thinking are accepted. Avoid bloating replay history
+      // with synthetic blocks the API does not require.
       const { messages } = converter.convertGeminiRequestToAnthropic(
         {
           model: 'models/test',
@@ -666,21 +669,10 @@ describe('AnthropicContentConverter', () => {
         enableThinking,
       );
 
-      expect(messages).toEqual([
-        {
-          role: 'user',
-          content: [
-            { type: 'text', text: 'Hi', cache_control: { type: 'ephemeral' } },
-          ],
-        },
-        {
-          role: 'assistant',
-          content: [
-            { type: 'thinking', thinking: '', signature: '' },
-            { type: 'text', text: 'Hello!' },
-          ],
-        },
-      ]);
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello!' }],
+      });
     });
 
     it('injects an empty thinking block on tool-calling assistant turns missing one', () => {
@@ -720,12 +712,12 @@ describe('AnthropicContentConverter', () => {
       });
     });
 
-    it('preserves existing thinking blocks on assistant turns', () => {
+    it('preserves existing thinking blocks on tool-use assistant turns', () => {
       const { messages } = converter.convertGeminiRequestToAnthropic(
         {
           model: 'models/test',
           contents: [
-            { role: 'user', parts: [{ text: 'Hi' }] },
+            { role: 'user', parts: [{ text: 'Run tool' }] },
             {
               role: 'model',
               parts: [
@@ -734,7 +726,7 @@ describe('AnthropicContentConverter', () => {
                   thought: true,
                   thoughtSignature: 'sig',
                 },
-                { text: 'Hello!' },
+                { functionCall: { id: 't1', name: 'tool', args: {} } },
               ],
             },
           ],
@@ -746,7 +738,7 @@ describe('AnthropicContentConverter', () => {
         role: 'assistant',
         content: [
           { type: 'thinking', thinking: 'Let me think', signature: 'sig' },
-          { type: 'text', text: 'Hello!' },
+          { type: 'tool_use', id: 't1', name: 'tool', input: {} },
         ],
       });
     });
@@ -785,16 +777,23 @@ describe('AnthropicContentConverter', () => {
       });
     });
 
-    it('injects thinking blocks on every prior assistant turn in a multi-turn history', () => {
+    it('injects thinking blocks on every tool-using assistant turn in a multi-turn history', () => {
+      const toolUse = (id: string) => ({
+        functionCall: { id, name: 'tool', args: {} },
+      });
+      const toolResult = (id: string) => ({
+        functionResponse: { id, name: 'tool', response: { output: 'ok' } },
+      });
+
       const { messages } = converter.convertGeminiRequestToAnthropic(
         {
           model: 'models/test',
           contents: [
             { role: 'user', parts: [{ text: 'Q1' }] },
-            { role: 'model', parts: [{ text: 'A1' }] },
-            { role: 'user', parts: [{ text: 'Q2' }] },
-            { role: 'model', parts: [{ text: 'A2' }] },
-            { role: 'user', parts: [{ text: 'Q3' }] },
+            { role: 'model', parts: [toolUse('t1')] },
+            { role: 'user', parts: [toolResult('t1')] },
+            { role: 'model', parts: [toolUse('t2')] },
+            { role: 'user', parts: [toolResult('t2')] },
           ],
         },
         enableThinking,
@@ -814,7 +813,7 @@ describe('AnthropicContentConverter', () => {
       });
     });
 
-    it('does not inject a duplicate thinking block when one already exists (even without signature)', () => {
+    it('does not inject a duplicate thinking block when one already exists on a tool-use turn', () => {
       // A part `{ text: '', thought: true }` (e.g. from a redacted_thinking
       // response or a turn whose thinking stream had no content) converts to
       // a `{ type: 'thinking', thinking: '' }` block without a signature. The
@@ -823,10 +822,13 @@ describe('AnthropicContentConverter', () => {
         {
           model: 'models/test',
           contents: [
-            { role: 'user', parts: [{ text: 'Hi' }] },
+            { role: 'user', parts: [{ text: 'Run tool' }] },
             {
               role: 'model',
-              parts: [{ text: '', thought: true }, { text: 'Hello!' }],
+              parts: [
+                { text: '', thought: true },
+                { functionCall: { id: 't1', name: 'tool', args: {} } },
+              ],
             },
           ],
         },
@@ -837,7 +839,7 @@ describe('AnthropicContentConverter', () => {
         role: 'assistant',
         content: [
           { type: 'thinking', thinking: '' },
-          { type: 'text', text: 'Hello!' },
+          { type: 'tool_use', id: 't1', name: 'tool', input: {} },
         ],
       });
     });

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -647,6 +647,185 @@ describe('AnthropicContentConverter', () => {
     });
   });
 
+  // https://github.com/QwenLM/qwen-code/issues/3786 — DeepSeek's
+  // anthropic-compatible API rejects subsequent requests when any prior
+  // assistant turn omits a thinking block while thinking mode is on. The
+  // converter must inject empty thinking blocks when missing.
+  describe('ensureAssistantThinking', () => {
+    let deepseekConverter: AnthropicContentConverter;
+
+    beforeEach(() => {
+      deepseekConverter = new AnthropicContentConverter(
+        'deepseek-v4-pro',
+        'auto',
+        false,
+        true,
+      );
+    });
+
+    it('injects an empty thinking block on assistant turns missing one', () => {
+      const { messages } = deepseekConverter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          { role: 'model', parts: [{ text: 'Hello!' }] },
+        ],
+      });
+
+      expect(messages).toEqual([
+        { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+        {
+          role: 'assistant',
+          content: [
+            { type: 'thinking', thinking: '', signature: '' },
+            { type: 'text', text: 'Hello!' },
+          ],
+        },
+      ]);
+    });
+
+    it('injects an empty thinking block on tool-calling assistant turns missing one', () => {
+      const { messages } = deepseekConverter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'List files' }] },
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call-1',
+                  name: 'glob',
+                  args: { pattern: '**/*.md' },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: '', signature: '' },
+          {
+            type: 'tool_use',
+            id: 'call-1',
+            name: 'glob',
+            input: { pattern: '**/*.md' },
+          },
+        ],
+      });
+    });
+
+    it('preserves existing thinking blocks on assistant turns', () => {
+      const { messages } = deepseekConverter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          {
+            role: 'model',
+            parts: [
+              { text: 'Let me think', thought: true, thoughtSignature: 'sig' },
+              { text: 'Hello!' },
+            ],
+          },
+        ],
+      });
+
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'Let me think', signature: 'sig' },
+          { type: 'text', text: 'Hello!' },
+        ],
+      });
+    });
+
+    it('does not modify user messages', () => {
+      const { messages } = deepseekConverter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [{ role: 'user', parts: [{ text: 'Hi' }] }],
+      });
+
+      expect(messages).toEqual([
+        { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+      ]);
+    });
+
+    it('does nothing when option is disabled (default)', () => {
+      const defaultConverter = new AnthropicContentConverter(
+        'deepseek-v4-pro',
+        'auto',
+        false,
+      );
+
+      const { messages } = defaultConverter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          { role: 'model', parts: [{ text: 'Hello!' }] },
+        ],
+      });
+
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello!' }],
+      });
+    });
+
+    it('injects thinking blocks on every prior assistant turn in a multi-turn history', () => {
+      const { messages } = deepseekConverter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'Q1' }] },
+          { role: 'model', parts: [{ text: 'A1' }] },
+          { role: 'user', parts: [{ text: 'Q2' }] },
+          { role: 'model', parts: [{ text: 'A2' }] },
+          { role: 'user', parts: [{ text: 'Q3' }] },
+        ],
+      });
+
+      expect(messages[1]).toMatchObject({ role: 'assistant' });
+      expect(messages[3]).toMatchObject({ role: 'assistant' });
+      expect((messages[1] as { content: unknown[] }).content[0]).toEqual({
+        type: 'thinking',
+        thinking: '',
+        signature: '',
+      });
+      expect((messages[3] as { content: unknown[] }).content[0]).toEqual({
+        type: 'thinking',
+        thinking: '',
+        signature: '',
+      });
+    });
+
+    it('treats existing redacted_thinking blocks as satisfying the requirement', () => {
+      // redacted_thinking blocks come back from the response converter as
+      // { text: '', thought: true } (no thoughtSignature). When converted to
+      // Anthropic format they become { type: 'thinking', thinking: '' }, which
+      // already counts as a thinking block — so we should not prepend another.
+      const { messages } = deepseekConverter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'Hi' }] },
+          {
+            role: 'model',
+            parts: [{ text: '', thought: true }, { text: 'Hello!' }],
+          },
+        ],
+      });
+
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: '' },
+          { type: 'text', text: 'Hello!' },
+        ],
+      });
+    });
+  });
+
   describe('convertGeminiToolsToAnthropic', () => {
     it('converts Tool.functionDeclarations to Anthropic tools and runs schema conversion', async () => {
       const tools = [

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -653,8 +653,8 @@ describe('AnthropicContentConverter', () => {
   // assistant turns without thinking are accepted unchanged, so the converter
   // injects an empty thinking block only on tool-use turns when the caller
   // opts in.
-  describe('ensureAssistantThinking', () => {
-    const enableThinking = { ensureAssistantThinking: true };
+  describe('ensureThinkingOnToolUseTurns', () => {
+    const enableThinking = { ensureThinkingOnToolUseTurns: true };
 
     it('does not inject on plain-text assistant turns (DeepSeek tolerates them)', () => {
       // Verified against api.deepseek.com/anthropic: plain-text assistant
@@ -895,11 +895,12 @@ describe('AnthropicContentConverter', () => {
       });
     });
 
-    it('does not inject a duplicate thinking block when one already exists on a tool-use turn', () => {
-      // A part `{ text: '', thought: true }` (e.g. from a redacted_thinking
-      // response or a turn whose thinking stream had no content) converts to
-      // a `{ type: 'thinking', thinking: '' }` block without a signature. The
-      // injector should leave it alone rather than prepend a second one.
+    it('replaces a non-compliant thinking block (no signature field) with a synthetic one', () => {
+      // A part `{ text: '', thought: true }` (e.g. round-tripped from a
+      // `redacted_thinking` response that lost its `data` field via the
+      // Gemini Part representation) converts to a thinking block without a
+      // `signature` field. That shape is not spec-compliant, so the injector
+      // drops it and prepends a synthetic block with `signature: ''`.
       const { messages } = converter.convertGeminiRequestToAnthropic(
         {
           model: 'models/test',
@@ -920,8 +921,75 @@ describe('AnthropicContentConverter', () => {
       expect(messages[1]).toEqual({
         role: 'assistant',
         content: [
-          { type: 'thinking', thinking: '' },
+          { type: 'thinking', thinking: '', signature: '' },
           { type: 'tool_use', id: 't1', name: 'tool', input: {} },
+        ],
+      });
+    });
+
+    it('preserves an existing compliant thinking block on a tool-use turn', () => {
+      // A thinking block with a real `signature` field is fully compliant —
+      // the injector must not duplicate it.
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Run tool' }] },
+            {
+              role: 'model',
+              parts: [
+                {
+                  text: 'real thinking',
+                  thought: true,
+                  thoughtSignature: 'real-sig',
+                },
+                { functionCall: { id: 't1', name: 'tool', args: {} } },
+              ],
+            },
+          ],
+        },
+        enableThinking,
+      );
+
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [
+          {
+            type: 'thinking',
+            thinking: 'real thinking',
+            signature: 'real-sig',
+          },
+          { type: 'tool_use', id: 't1', name: 'tool', input: {} },
+        ],
+      });
+    });
+
+    it('injects on mixed text+tool_use assistant turns missing thinking', () => {
+      // Common shape: model says something, then calls a tool. With no
+      // thinking, this is still a tool-use turn that needs the synthetic.
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Look this up' }] },
+            {
+              role: 'model',
+              parts: [
+                { text: 'Let me check that' },
+                { functionCall: { id: 't1', name: 'lookup', args: {} } },
+              ],
+            },
+          ],
+        },
+        enableThinking,
+      );
+
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: '', signature: '' },
+          { type: 'text', text: 'Let me check that' },
+          { type: 'tool_use', id: 't1', name: 'lookup', input: {} },
         ],
       });
     });

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -653,7 +653,7 @@ describe('AnthropicContentConverter', () => {
   // assistant turns without thinking are accepted unchanged, so the converter
   // injects an empty thinking block only on tool-use turns when the caller
   // opts in.
-  describe('thinking-mode injection + normalization (DeepSeek thinking on)', () => {
+  describe('DeepSeek thinking-mode normalization, injection, and stripping', () => {
     // The two options paired together replicate the DeepSeek "thinking on"
     // behavior wired in AnthropicContentGenerator.buildRequest.
     const enableThinking = {
@@ -898,6 +898,26 @@ describe('AnthropicContentConverter', () => {
         role: 'assistant',
         content: [{ type: 'tool_use', id: 't1', name: 'tool', input: {} }],
       });
+    });
+
+    it('strips redacted_thinking blocks too when stripAssistantThinking is set', () => {
+      // The strip path must cover both `thinking` and `redacted_thinking`.
+      // processContent doesn't synthesize redacted_thinking from Gemini parts,
+      // so reach into the private helper directly with a constructed message.
+      const messages = [
+        {
+          role: 'assistant' as const,
+          content: [
+            { type: 'redacted_thinking', data: 'opaque' },
+            { type: 'text', text: 'Hello!' },
+            { type: 'thinking', thinking: 'reasoning', signature: 'sig' },
+          ],
+        },
+      ];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (converter as any).stripThinkingFromAssistantMessages(messages);
+
+      expect(messages[0].content).toEqual([{ type: 'text', text: 'Hello!' }]);
     });
 
     it('treats a redacted_thinking block as already-satisfying (no synthetic injection)', () => {

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -815,6 +815,50 @@ describe('AnthropicContentConverter', () => {
       });
     });
 
+    it('strips thinking blocks from assistant turns when stripAssistantThinking is set', () => {
+      // suggestionGenerator / forkedAgent path: history has real thought
+      // parts but the side-query disables thinking. The converter must drop
+      // those blocks so the outgoing request matches the absent top-level
+      // `thinking` config.
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Hi' }] },
+            {
+              role: 'model',
+              parts: [
+                {
+                  text: 'reasoning',
+                  thought: true,
+                  thoughtSignature: 'sig',
+                },
+                { text: 'Hello!' },
+              ],
+            },
+            {
+              role: 'model',
+              parts: [
+                { text: 'more reasoning', thought: true },
+                { functionCall: { id: 't1', name: 'tool', args: {} } },
+              ],
+            },
+          ],
+        },
+        { stripAssistantThinking: true },
+      );
+
+      // Both assistant turns have their thinking blocks removed.
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello!' }],
+      });
+      expect(messages[2]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'tool_use', id: 't1', name: 'tool', input: {} }],
+      });
+    });
+
     it('does not inject a duplicate thinking block when one already exists on a tool-use turn', () => {
       // A part `{ text: '', thought: true }` (e.g. from a redacted_thinking
       // response or a turn whose thinking stream had no content) converts to

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -895,6 +895,30 @@ describe('AnthropicContentConverter', () => {
       });
     });
 
+    it('treats a redacted_thinking block as already-satisfying (no synthetic injection)', () => {
+      // redacted_thinking has no `signature` field by spec — its `data` is
+      // the opaque token. Distinct from a non-compliant `thinking` block
+      // missing its required signature. The injector must leave redacted
+      // turns alone. processContent doesn't synthesize redacted_thinking
+      // from Gemini parts, so reach into the private helper directly.
+      const messages = [
+        {
+          role: 'assistant' as const,
+          content: [
+            { type: 'redacted_thinking', data: 'opaque' },
+            { type: 'tool_use', id: 't1', name: 'tool', input: {} },
+          ],
+        },
+      ];
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (converter as any).applyEmptyThinkingToToolUseTurns(messages);
+
+      expect(messages[0].content).toEqual([
+        { type: 'redacted_thinking', data: 'opaque' },
+        { type: 'tool_use', id: 't1', name: 'tool', input: {} },
+      ]);
+    });
+
     it('replaces a non-compliant thinking block (no signature field) with a synthetic one', () => {
       // A part `{ text: '', thought: true }` (e.g. round-tripped from a
       // `redacted_thinking` response that lost its `data` field via the

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -653,8 +653,13 @@ describe('AnthropicContentConverter', () => {
   // assistant turns without thinking are accepted unchanged, so the converter
   // injects an empty thinking block only on tool-use turns when the caller
   // opts in.
-  describe('ensureThinkingOnToolUseTurns', () => {
-    const enableThinking = { ensureThinkingOnToolUseTurns: true };
+  describe('thinking-mode injection + normalization (DeepSeek thinking on)', () => {
+    // The two options paired together replicate the DeepSeek "thinking on"
+    // behavior wired in AnthropicContentGenerator.buildRequest.
+    const enableThinking = {
+      normalizeAssistantThinkingSignature: true,
+      injectThinkingOnToolUseTurns: true,
+    };
 
     it('does not inject on plain-text assistant turns (DeepSeek tolerates them)', () => {
       // Verified against api.deepseek.com/anthropic: plain-text assistant
@@ -911,7 +916,7 @@ describe('AnthropicContentConverter', () => {
         },
       ];
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (converter as any).applyEmptyThinkingToToolUseTurns(messages);
+      (converter as any).injectEmptyThinkingOnToolUseTurns(messages);
 
       expect(messages[0].content).toEqual([
         { type: 'redacted_thinking', data: 'opaque' },

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -815,6 +815,42 @@ describe('AnthropicContentConverter', () => {
       });
     });
 
+    it('preserves thinking-only assistant turns rather than emit empty content (Anthropic rejects content: [])', () => {
+      // A turn whose only blocks are thinking/redacted_thinking can occur
+      // when a previous round was cut off by max_tokens before any text or
+      // tool_use was emitted. Stripping unconditionally would leave
+      // `content: []`, which Anthropic API rejects, and dropping the message
+      // would break user/assistant alternation. Keep the original blocks
+      // instead — DeepSeek empirically tolerates the residual mismatch.
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Hi' }] },
+            {
+              role: 'model',
+              parts: [
+                {
+                  text: 'pondering',
+                  thought: true,
+                  thoughtSignature: 'sig',
+                },
+              ],
+            },
+            { role: 'user', parts: [{ text: 'Continue' }] },
+          ],
+        },
+        { stripAssistantThinking: true },
+      );
+
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [
+          { type: 'thinking', thinking: 'pondering', signature: 'sig' },
+        ],
+      });
+    });
+
     it('strips thinking blocks from assistant turns when stripAssistantThinking is set', () => {
       // suggestionGenerator / forkedAgent path: history has real thought
       // parts but the side-query disables thinking. The converter must drop

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -648,9 +648,11 @@ describe('AnthropicContentConverter', () => {
   });
 
   // https://github.com/QwenLM/qwen-code/issues/3786 — DeepSeek's
-  // anthropic-compatible API rejects subsequent requests when any prior
-  // assistant turn omits a thinking block while thinking mode is on. The
-  // converter must inject empty thinking blocks when the caller asks.
+  // anthropic-compatible API rejects requests in thinking mode when a prior
+  // assistant turn carrying `tool_use` omits a thinking block. Plain-text
+  // assistant turns without thinking are accepted unchanged, so the converter
+  // injects an empty thinking block only on tool-use turns when the caller
+  // opts in.
   describe('ensureAssistantThinking', () => {
     const enableThinking = { ensureAssistantThinking: true };
 

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -650,30 +650,29 @@ describe('AnthropicContentConverter', () => {
   // https://github.com/QwenLM/qwen-code/issues/3786 — DeepSeek's
   // anthropic-compatible API rejects subsequent requests when any prior
   // assistant turn omits a thinking block while thinking mode is on. The
-  // converter must inject empty thinking blocks when missing.
+  // converter must inject empty thinking blocks when the caller asks.
   describe('ensureAssistantThinking', () => {
-    let deepseekConverter: AnthropicContentConverter;
-
-    beforeEach(() => {
-      deepseekConverter = new AnthropicContentConverter(
-        'deepseek-v4-pro',
-        'auto',
-        false,
-        true,
-      );
-    });
+    const enableThinking = { ensureAssistantThinking: true };
 
     it('injects an empty thinking block on assistant turns missing one', () => {
-      const { messages } = deepseekConverter.convertGeminiRequestToAnthropic({
-        model: 'models/test',
-        contents: [
-          { role: 'user', parts: [{ text: 'Hi' }] },
-          { role: 'model', parts: [{ text: 'Hello!' }] },
-        ],
-      });
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Hi' }] },
+            { role: 'model', parts: [{ text: 'Hello!' }] },
+          ],
+        },
+        enableThinking,
+      );
 
       expect(messages).toEqual([
-        { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Hi', cache_control: { type: 'ephemeral' } },
+          ],
+        },
         {
           role: 'assistant',
           content: [
@@ -685,24 +684,27 @@ describe('AnthropicContentConverter', () => {
     });
 
     it('injects an empty thinking block on tool-calling assistant turns missing one', () => {
-      const { messages } = deepseekConverter.convertGeminiRequestToAnthropic({
-        model: 'models/test',
-        contents: [
-          { role: 'user', parts: [{ text: 'List files' }] },
-          {
-            role: 'model',
-            parts: [
-              {
-                functionCall: {
-                  id: 'call-1',
-                  name: 'glob',
-                  args: { pattern: '**/*.md' },
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'List files' }] },
+            {
+              role: 'model',
+              parts: [
+                {
+                  functionCall: {
+                    id: 'call-1',
+                    name: 'glob',
+                    args: { pattern: '**/*.md' },
+                  },
                 },
-              },
-            ],
-          },
-        ],
-      });
+              ],
+            },
+          ],
+        },
+        enableThinking,
+      );
 
       expect(messages[1]).toEqual({
         role: 'assistant',
@@ -719,19 +721,26 @@ describe('AnthropicContentConverter', () => {
     });
 
     it('preserves existing thinking blocks on assistant turns', () => {
-      const { messages } = deepseekConverter.convertGeminiRequestToAnthropic({
-        model: 'models/test',
-        contents: [
-          { role: 'user', parts: [{ text: 'Hi' }] },
-          {
-            role: 'model',
-            parts: [
-              { text: 'Let me think', thought: true, thoughtSignature: 'sig' },
-              { text: 'Hello!' },
-            ],
-          },
-        ],
-      });
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Hi' }] },
+            {
+              role: 'model',
+              parts: [
+                {
+                  text: 'Let me think',
+                  thought: true,
+                  thoughtSignature: 'sig',
+                },
+                { text: 'Hello!' },
+              ],
+            },
+          ],
+        },
+        enableThinking,
+      );
 
       expect(messages[1]).toEqual({
         role: 'assistant',
@@ -743,24 +752,26 @@ describe('AnthropicContentConverter', () => {
     });
 
     it('does not modify user messages', () => {
-      const { messages } = deepseekConverter.convertGeminiRequestToAnthropic({
-        model: 'models/test',
-        contents: [{ role: 'user', parts: [{ text: 'Hi' }] }],
-      });
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [{ role: 'user', parts: [{ text: 'Hi' }] }],
+        },
+        enableThinking,
+      );
 
       expect(messages).toEqual([
-        { role: 'user', content: [{ type: 'text', text: 'Hi' }] },
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Hi', cache_control: { type: 'ephemeral' } },
+          ],
+        },
       ]);
     });
 
     it('does nothing when option is disabled (default)', () => {
-      const defaultConverter = new AnthropicContentConverter(
-        'deepseek-v4-pro',
-        'auto',
-        false,
-      );
-
-      const { messages } = defaultConverter.convertGeminiRequestToAnthropic({
+      const { messages } = converter.convertGeminiRequestToAnthropic({
         model: 'models/test',
         contents: [
           { role: 'user', parts: [{ text: 'Hi' }] },
@@ -775,16 +786,19 @@ describe('AnthropicContentConverter', () => {
     });
 
     it('injects thinking blocks on every prior assistant turn in a multi-turn history', () => {
-      const { messages } = deepseekConverter.convertGeminiRequestToAnthropic({
-        model: 'models/test',
-        contents: [
-          { role: 'user', parts: [{ text: 'Q1' }] },
-          { role: 'model', parts: [{ text: 'A1' }] },
-          { role: 'user', parts: [{ text: 'Q2' }] },
-          { role: 'model', parts: [{ text: 'A2' }] },
-          { role: 'user', parts: [{ text: 'Q3' }] },
-        ],
-      });
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Q1' }] },
+            { role: 'model', parts: [{ text: 'A1' }] },
+            { role: 'user', parts: [{ text: 'Q2' }] },
+            { role: 'model', parts: [{ text: 'A2' }] },
+            { role: 'user', parts: [{ text: 'Q3' }] },
+          ],
+        },
+        enableThinking,
+      );
 
       expect(messages[1]).toMatchObject({ role: 'assistant' });
       expect(messages[3]).toMatchObject({ role: 'assistant' });
@@ -800,21 +814,24 @@ describe('AnthropicContentConverter', () => {
       });
     });
 
-    it('treats existing redacted_thinking blocks as satisfying the requirement', () => {
-      // redacted_thinking blocks come back from the response converter as
-      // { text: '', thought: true } (no thoughtSignature). When converted to
-      // Anthropic format they become { type: 'thinking', thinking: '' }, which
-      // already counts as a thinking block — so we should not prepend another.
-      const { messages } = deepseekConverter.convertGeminiRequestToAnthropic({
-        model: 'models/test',
-        contents: [
-          { role: 'user', parts: [{ text: 'Hi' }] },
-          {
-            role: 'model',
-            parts: [{ text: '', thought: true }, { text: 'Hello!' }],
-          },
-        ],
-      });
+    it('does not inject a duplicate thinking block when one already exists (even without signature)', () => {
+      // A part `{ text: '', thought: true }` (e.g. from a redacted_thinking
+      // response or a turn whose thinking stream had no content) converts to
+      // a `{ type: 'thinking', thinking: '' }` block without a signature. The
+      // injector should leave it alone rather than prepend a second one.
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Hi' }] },
+            {
+              role: 'model',
+              parts: [{ text: '', thought: true }, { text: 'Hello!' }],
+            },
+          ],
+        },
+        enableThinking,
+      );
 
       expect(messages[1]).toEqual({
         role: 'assistant',

--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -964,6 +964,33 @@ describe('AnthropicContentConverter', () => {
       });
     });
 
+    it('drops non-compliant thinking blocks from plain-text assistant turns even when no tool_use is present', () => {
+      // A `redacted_thinking` round-tripped through Gemini-Part comes back as
+      // `{ type: 'thinking', thinking: '' }` with no signature. On a
+      // plain-text turn there is nothing to inject (no tool_use), but the
+      // bad block is still non-compliant and should be cleaned up.
+      const { messages } = converter.convertGeminiRequestToAnthropic(
+        {
+          model: 'models/test',
+          contents: [
+            { role: 'user', parts: [{ text: 'Hi' }] },
+            {
+              role: 'model',
+              parts: [{ text: '', thought: true }, { text: 'Hello!' }],
+            },
+          ],
+        },
+        enableThinking,
+      );
+
+      // Bad thinking block dropped; remaining text passes through. No
+      // synthetic prepended because the turn has no tool_use.
+      expect(messages[1]).toEqual({
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Hello!' }],
+      });
+    });
+
     it('injects on mixed text+tool_use assistant turns missing thinking', () => {
       // Common shape: model says something, then calls a tool. With no
       // thinking, this is still a tool-use turn that needs the synthetic.

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -577,6 +577,15 @@ export class AnthropicContentConverter {
    * Used by DeepSeek when thinking mode is off but session history still
    * has `thought: true` parts — keeps the request body in sync with the
    * absent top-level `thinking` config.
+   *
+   * If stripping would leave an assistant message with no content blocks
+   * (a thinking-only turn, e.g. one cut off by max_tokens before any text
+   * or tool_use was emitted), we keep the original blocks. An empty
+   * `content: []` is rejected by the Anthropic API, and dropping the
+   * message would break the required user/assistant alternation. DeepSeek
+   * empirically tolerates the residual `thinking-block + no-thinking-config`
+   * shape (verified against api.deepseek.com/anthropic), so leaving it as
+   * an unaltered passthrough is the safer fallback.
    */
   private stripThinkingFromAssistantMessages(
     messages: AnthropicMessageParam[],
@@ -589,6 +598,7 @@ export class AnthropicContentConverter {
         const t = (block as { type?: string }).type;
         return t !== 'thinking' && t !== 'redacted_thinking';
       });
+      if (filtered.length === 0) continue;
       if (filtered.length !== message.content.length) {
         message.content = filtered;
       }

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -48,9 +48,12 @@ export interface ConvertGeminiRequestToAnthropicOptions {
    * follow-up requests fail with HTTP 400 ("The content[].thinking in the
    * thinking mode must be passed back to the API.").
    *
-   * Pair with `normalizeAssistantThinkingSignature` so that signature-less
-   * blocks are seen as missing (and therefore replaced by the synthetic with
-   * a valid signature) rather than as already-satisfying.
+   * Pair with `normalizeAssistantThinkingSignature` so that any
+   * signature-less `thinking` block already present is normalized (filled
+   * with `signature: ''`) before this pass runs. After normalization the
+   * block has a valid `signature` and is treated as already-satisfying, so
+   * no synthetic block is prepended and the original thinking text is
+   * preserved on the wire.
    *
    * Must be gated on the same per-request condition that emits the
    * top-level `thinking` config so disabled-thinking requests don't ship
@@ -678,8 +681,9 @@ export class AnthropicContentConverter {
    * to avoid bloating replay history with synthetic blocks for turns the
    * API already accepts.
    *
-   * Should be paired with `fillMissingThinkingSignatures` so that
-   * round-tripped non-compliant `thinking` blocks aren't mistaken for
+   * Should be paired with `fillMissingThinkingSignatures` running first
+   * so that signature-less `thinking` blocks become compliant in place
+   * (preserving their original text), and this pass then sees them as
    * already-satisfying. https://github.com/QwenLM/qwen-code/issues/3786
    */
   private injectEmptyThinkingOnToolUseTurns(

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -643,16 +643,43 @@ export class AnthropicContentConverter {
             ? message.content
             : [];
 
-      // Step 1: Drop non-compliant thinking blocks (no `signature` field) on
-      // every assistant turn, not just tool-use ones. Plain-text turns can
-      // carry these too — e.g. when `redacted_thinking` round-trips through
-      // the Gemini Part representation, losing its `data` payload along the
-      // way. Empirically DeepSeek tolerates the residual shape, but
-      // normalizing keeps the wire message spec-correct.
-      const cleanedBlocks = blocks.filter((block) => {
+      // Step 1: Normalize non-compliant `thinking` blocks (missing the
+      // required `signature` field) by setting `signature: ''` in place. This
+      // shape commonly arrives from other generators (OpenAI/Gemini/agent-
+      // runtime emit `{ thought: true }` parts with no signature) when users
+      // switch providers mid-session, or from `redacted_thinking` blocks that
+      // lost their `data` field through the Gemini-Part round trip. Adding an
+      // empty signature preserves the original thinking text instead of
+      // dropping the block — DeepSeek currently accepts empty signatures, so
+      // this keeps the wire shape spec-compliant without losing history.
+      let modified = false;
+      const normalizedBlocks = blocks.map((block) => {
         const b = block as { type?: string; signature?: unknown };
-        return !(b.type === 'thinking' && typeof b.signature !== 'string');
+        if (b.type === 'thinking' && typeof b.signature !== 'string') {
+          modified = true;
+          return {
+            ...(block as object),
+            signature: '',
+          } as unknown as AnthropicContentBlockParam;
+        }
+        return block;
       });
+      if (modified) {
+        message.content = normalizedBlocks;
+      }
+
+      // Step 2: On tool-use turns still lacking any thinking block, prepend
+      // a synthetic empty one (the issue #3786 trigger).
+      const hasToolUse = normalizedBlocks.some(
+        (block) => (block as { type?: string }).type === 'tool_use',
+      );
+      if (!hasToolUse) continue;
+
+      const hasThinking = normalizedBlocks.some((block) => {
+        const t = (block as { type?: string }).type;
+        return t === 'thinking' || t === 'redacted_thinking';
+      });
+      if (hasThinking) continue;
 
       // DeepSeek currently accepts an empty `signature` for synthetic
       // thinking blocks. The `signature` field is an opaque token in the
@@ -664,34 +691,7 @@ export class AnthropicContentConverter {
         thinking: '',
         signature: '',
       } as unknown as AnthropicContentBlockParam;
-
-      // If cleanup would leave `content: []` (Anthropic API rejects) — i.e.
-      // the whole turn was non-compliant thinking blocks — replace with a
-      // synthetic empty thinking block so the message stays non-empty AND
-      // spec-compliant.
-      if (cleanedBlocks.length === 0) {
-        message.content = [emptyThinking];
-        continue;
-      }
-      if (cleanedBlocks.length !== blocks.length) {
-        message.content = cleanedBlocks;
-      }
-
-      // Step 2: On tool-use turns missing a compliant thinking block,
-      // prepend an empty synthetic. This is the issue #3786 trigger.
-      const hasToolUse = cleanedBlocks.some(
-        (block) => (block as { type?: string }).type === 'tool_use',
-      );
-      if (!hasToolUse) continue;
-
-      const hasCompliantThinking = cleanedBlocks.some((block) => {
-        const t = (block as { type?: string }).type;
-        // Any thinking block remaining here passed Step 1's signature check.
-        return t === 'thinking' || t === 'redacted_thinking';
-      });
-      if (hasCompliantThinking) continue;
-
-      message.content = [emptyThinking, ...cleanedBlocks];
+      message.content = [emptyThinking, ...normalizedBlocks];
     }
   }
 

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -33,13 +33,16 @@ type AnthropicContentBlockParam = Anthropic.ContentBlockParam;
 
 export interface ConvertGeminiRequestToAnthropicOptions {
   /**
-   * Inject an empty thinking block on tool-use assistant turns missing one.
-   * Required by DeepSeek's anthropic-compatible API when thinking mode is
-   * enabled. Must be gated on the same per-request condition that emits the
-   * top-level `thinking` config so disabled-thinking requests don't ship
-   * stray thinking blocks. https://github.com/QwenLM/qwen-code/issues/3786
+   * On assistant turns containing `tool_use` but lacking a compliant thinking
+   * block (i.e. a `thinking` block with a `signature` field, or a
+   * `redacted_thinking` block), prepend a synthetic empty thinking block and
+   * drop any non-compliant `thinking` block already present. Required by
+   * DeepSeek's anthropic-compatible API when thinking mode is enabled.
+   * Must be gated on the same per-request condition that emits the top-level
+   * `thinking` config so disabled-thinking requests don't ship stray
+   * thinking blocks. https://github.com/QwenLM/qwen-code/issues/3786
    */
-  ensureAssistantThinking?: boolean;
+  ensureThinkingOnToolUseTurns?: boolean;
   /**
    * Strip thinking and redacted_thinking blocks from assistant messages.
    * Used to keep DeepSeek requests consistent when thinking mode is off but
@@ -82,8 +85,8 @@ export class AnthropicContentConverter {
     if (options.stripAssistantThinking) {
       this.stripThinkingFromAssistantMessages(messages);
     }
-    if (options.ensureAssistantThinking) {
-      this.applyEmptyThinkingToAssistantMessages(messages);
+    if (options.ensureThinkingOnToolUseTurns) {
+      this.applyEmptyThinkingToToolUseTurns(messages);
     }
 
     // Add cache_control to enable prompt caching (if enabled)
@@ -617,9 +620,17 @@ export class AnthropicContentConverter {
    * trigger is specific to tool_use turns — plain-text assistant turns
    * without thinking are accepted unchanged. We mirror that boundary here to
    * avoid bloating replay history with synthetic blocks for turns the API
-   * already accepts. https://github.com/QwenLM/qwen-code/issues/3786
+   * already accepts.
+   *
+   * Edge case: a `thinking` block round-tripped through Gemini Part format
+   * may come back without its `signature` field (e.g. when the upstream
+   * block was `redacted_thinking`, whose `data` field doesn't survive the
+   * `{ thought: true }` representation). Such blocks are not spec-compliant,
+   * so we drop them here and let the synthetic injection take over rather
+   * than treat them as already-satisfying the requirement.
+   * https://github.com/QwenLM/qwen-code/issues/3786
    */
-  private applyEmptyThinkingToAssistantMessages(
+  private applyEmptyThinkingToToolUseTurns(
     messages: AnthropicMessageParam[],
   ): void {
     for (const message of messages) {
@@ -637,12 +648,22 @@ export class AnthropicContentConverter {
       );
       if (!hasToolUse) continue;
 
-      const hasThinking = blocks.some(
-        (block) =>
-          (block as { type?: string }).type === 'thinking' ||
-          (block as { type?: string }).type === 'redacted_thinking',
-      );
-      if (hasThinking) continue;
+      // A redacted_thinking block satisfies the requirement on its own.
+      // A thinking block satisfies it only when it carries a signature
+      // field — otherwise it's a non-compliant artefact of the Gemini-Part
+      // round trip and should be dropped before we inject our synthetic.
+      const hasCompliantThinking = blocks.some((block) => {
+        const b = block as { type?: string; signature?: unknown };
+        if (b.type === 'redacted_thinking') return true;
+        if (b.type === 'thinking') return typeof b.signature === 'string';
+        return false;
+      });
+      if (hasCompliantThinking) continue;
+
+      const cleanedBlocks = blocks.filter((block) => {
+        const b = block as { type?: string; signature?: unknown };
+        return !(b.type === 'thinking' && typeof b.signature !== 'string');
+      });
 
       // DeepSeek currently accepts an empty `signature` for synthetic
       // thinking blocks. The `signature` field is an opaque token in the
@@ -654,7 +675,7 @@ export class AnthropicContentConverter {
         thinking: '',
         signature: '',
       } as unknown as AnthropicContentBlockParam;
-      message.content = [emptyThinking, ...blocks];
+      message.content = [emptyThinking, ...cleanedBlocks];
     }
   }
 

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -35,15 +35,18 @@ export class AnthropicContentConverter {
   private model: string;
   private schemaCompliance: SchemaComplianceMode;
   private enableCacheControl: boolean;
+  private ensureAssistantThinking: boolean;
 
   constructor(
     model: string,
     schemaCompliance: SchemaComplianceMode = 'auto',
     enableCacheControl: boolean = true,
+    ensureAssistantThinking: boolean = false,
   ) {
     this.model = model;
     this.schemaCompliance = schemaCompliance;
     this.enableCacheControl = enableCacheControl;
+    this.ensureAssistantThinking = ensureAssistantThinking;
   }
 
   convertGeminiRequestToAnthropic(request: GenerateContentParameters): {
@@ -57,6 +60,10 @@ export class AnthropicContentConverter {
     );
 
     this.processContents(request.contents, messages);
+
+    if (this.ensureAssistantThinking) {
+      this.applyEmptyThinkingToAssistantMessages(messages);
+    }
 
     // Add cache_control to enable prompt caching (if enabled)
     const system = this.enableCacheControl
@@ -542,6 +549,44 @@ export class AnthropicContentConverter {
         cache_control: { type: 'ephemeral' },
       },
     ];
+  }
+
+  /**
+   * DeepSeek's anthropic-compatible API rejects follow-up requests when any
+   * prior assistant turn omits a thinking block while thinking mode is on,
+   * returning HTTP 400 ("The content[].thinking in the thinking mode must be
+   * passed back to the API."). The model can legitimately return a turn
+   * without thinking content, so inject an empty thinking block whenever one
+   * is missing. https://github.com/QwenLM/qwen-code/issues/3786
+   */
+  private applyEmptyThinkingToAssistantMessages(
+    messages: AnthropicMessageParam[],
+  ): void {
+    for (const message of messages) {
+      if (message.role !== 'assistant') continue;
+
+      const blocks: AnthropicContentBlockParam[] =
+        typeof message.content === 'string'
+          ? [{ type: 'text', text: message.content }]
+          : Array.isArray(message.content)
+            ? message.content
+            : [];
+
+      const hasThinking = blocks.some(
+        (block) =>
+          (block as { type?: string }).type === 'thinking' ||
+          (block as { type?: string }).type === 'redacted_thinking',
+      );
+
+      if (!hasThinking) {
+        const emptyThinking = {
+          type: 'thinking',
+          thinking: '',
+          signature: '',
+        } as unknown as AnthropicContentBlockParam;
+        message.content = [emptyThinking, ...blocks];
+      }
+    }
   }
 
   /**

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -33,13 +33,20 @@ type AnthropicContentBlockParam = Anthropic.ContentBlockParam;
 
 export interface ConvertGeminiRequestToAnthropicOptions {
   /**
-   * Inject an empty thinking block on assistant turns missing one. Required by
-   * DeepSeek's anthropic-compatible API when thinking mode is enabled — must
-   * be gated on the same per-request condition that sends the top-level
-   * `thinking` config so disabled-thinking requests don't ship stray thinking
-   * blocks. https://github.com/QwenLM/qwen-code/issues/3786
+   * Inject an empty thinking block on tool-use assistant turns missing one.
+   * Required by DeepSeek's anthropic-compatible API when thinking mode is
+   * enabled. Must be gated on the same per-request condition that emits the
+   * top-level `thinking` config so disabled-thinking requests don't ship
+   * stray thinking blocks. https://github.com/QwenLM/qwen-code/issues/3786
    */
   ensureAssistantThinking?: boolean;
+  /**
+   * Strip thinking and redacted_thinking blocks from assistant messages.
+   * Used to keep DeepSeek requests consistent when thinking mode is off but
+   * session history still carries `thought: true` parts (e.g. side-queries
+   * spawned with `thinkingConfig.includeThoughts: false`).
+   */
+  stripAssistantThinking?: boolean;
 }
 
 export class AnthropicContentConverter {
@@ -72,6 +79,9 @@ export class AnthropicContentConverter {
 
     this.processContents(request.contents, messages);
 
+    if (options.stripAssistantThinking) {
+      this.stripThinkingFromAssistantMessages(messages);
+    }
     if (options.ensureAssistantThinking) {
       this.applyEmptyThinkingToAssistantMessages(messages);
     }
@@ -560,6 +570,29 @@ export class AnthropicContentConverter {
         cache_control: { type: 'ephemeral' },
       },
     ];
+  }
+
+  /**
+   * Remove thinking and redacted_thinking blocks from assistant messages.
+   * Used by DeepSeek when thinking mode is off but session history still
+   * has `thought: true` parts — keeps the request body in sync with the
+   * absent top-level `thinking` config.
+   */
+  private stripThinkingFromAssistantMessages(
+    messages: AnthropicMessageParam[],
+  ): void {
+    for (const message of messages) {
+      if (message.role !== 'assistant') continue;
+      if (!Array.isArray(message.content)) continue;
+
+      const filtered = message.content.filter((block) => {
+        const t = (block as { type?: string }).type;
+        return t !== 'thinking' && t !== 'redacted_thinking';
+      });
+      if (filtered.length !== message.content.length) {
+        message.content = filtered;
+      }
+    }
   }
 
   /**

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -643,27 +643,37 @@ export class AnthropicContentConverter {
             ? message.content
             : [];
 
-      const hasToolUse = blocks.some(
-        (block) => (block as { type?: string }).type === 'tool_use',
-      );
-      if (!hasToolUse) continue;
-
-      // A redacted_thinking block satisfies the requirement on its own.
-      // A thinking block satisfies it only when it carries a signature
-      // field — otherwise it's a non-compliant artefact of the Gemini-Part
-      // round trip and should be dropped before we inject our synthetic.
-      const hasCompliantThinking = blocks.some((block) => {
-        const b = block as { type?: string; signature?: unknown };
-        if (b.type === 'redacted_thinking') return true;
-        if (b.type === 'thinking') return typeof b.signature === 'string';
-        return false;
-      });
-      if (hasCompliantThinking) continue;
-
+      // Step 1: Drop non-compliant thinking blocks (no `signature` field) on
+      // every assistant turn, not just tool-use ones. Plain-text turns can
+      // carry these too — e.g. when `redacted_thinking` round-trips through
+      // the Gemini Part representation, losing its `data` payload along the
+      // way. Empirically DeepSeek tolerates the residual shape, but
+      // normalizing keeps the wire message spec-correct.
       const cleanedBlocks = blocks.filter((block) => {
         const b = block as { type?: string; signature?: unknown };
         return !(b.type === 'thinking' && typeof b.signature !== 'string');
       });
+
+      // Avoid emitting `content: []` (Anthropic API rejects). If cleanup
+      // would empty the message, leave the original blocks in place.
+      if (cleanedBlocks.length === 0) continue;
+      if (cleanedBlocks.length !== blocks.length) {
+        message.content = cleanedBlocks;
+      }
+
+      // Step 2: On tool-use turns missing a compliant thinking block,
+      // prepend an empty synthetic. This is the issue #3786 trigger.
+      const hasToolUse = cleanedBlocks.some(
+        (block) => (block as { type?: string }).type === 'tool_use',
+      );
+      if (!hasToolUse) continue;
+
+      const hasCompliantThinking = cleanedBlocks.some((block) => {
+        const t = (block as { type?: string }).type;
+        // Any thinking block remaining here passed Step 1's signature check.
+        return t === 'thinking' || t === 'redacted_thinking';
+      });
+      if (hasCompliantThinking) continue;
 
       // DeepSeek currently accepts an empty `signature` for synthetic
       // thinking blocks. The `signature` field is an opaque token in the

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -654,9 +654,25 @@ export class AnthropicContentConverter {
         return !(b.type === 'thinking' && typeof b.signature !== 'string');
       });
 
-      // Avoid emitting `content: []` (Anthropic API rejects). If cleanup
-      // would empty the message, leave the original blocks in place.
-      if (cleanedBlocks.length === 0) continue;
+      // DeepSeek currently accepts an empty `signature` for synthetic
+      // thinking blocks. The `signature` field is an opaque token in the
+      // Anthropic spec, so this is a workaround — if DeepSeek tightens
+      // validation in the future, we may need to switch to
+      // `redacted_thinking` or another approach.
+      const emptyThinking = {
+        type: 'thinking',
+        thinking: '',
+        signature: '',
+      } as unknown as AnthropicContentBlockParam;
+
+      // If cleanup would leave `content: []` (Anthropic API rejects) — i.e.
+      // the whole turn was non-compliant thinking blocks — replace with a
+      // synthetic empty thinking block so the message stays non-empty AND
+      // spec-compliant.
+      if (cleanedBlocks.length === 0) {
+        message.content = [emptyThinking];
+        continue;
+      }
       if (cleanedBlocks.length !== blocks.length) {
         message.content = cleanedBlocks;
       }
@@ -675,16 +691,6 @@ export class AnthropicContentConverter {
       });
       if (hasCompliantThinking) continue;
 
-      // DeepSeek currently accepts an empty `signature` for synthetic
-      // thinking blocks. The `signature` field is an opaque token in the
-      // Anthropic spec, so this is a workaround — if DeepSeek tightens
-      // validation in the future, we may need to switch to
-      // `redacted_thinking` or another approach.
-      const emptyThinking = {
-        type: 'thinking',
-        thinking: '',
-        signature: '',
-      } as unknown as AnthropicContentBlockParam;
       message.content = [emptyThinking, ...cleanedBlocks];
     }
   }

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -33,14 +33,14 @@ type AnthropicContentBlockParam = Anthropic.ContentBlockParam;
 
 export interface ConvertGeminiRequestToAnthropicOptions {
   /**
-   * On assistant turns containing `tool_use` but lacking a compliant thinking
-   * block (i.e. a `thinking` block with a `signature` field, or a
-   * `redacted_thinking` block), prepend a synthetic empty thinking block and
-   * drop any non-compliant `thinking` block already present. Required by
-   * DeepSeek's anthropic-compatible API when thinking mode is enabled.
-   * Must be gated on the same per-request condition that emits the top-level
-   * `thinking` config so disabled-thinking requests don't ship stray
-   * thinking blocks. https://github.com/QwenLM/qwen-code/issues/3786
+   * On every assistant turn, normalize any `thinking` block that lacks the
+   * required `signature` field by filling it with `signature: ''` (preserving
+   * the original `thinking` text). On assistant turns containing `tool_use`
+   * with no thinking block at all, prepend a synthetic empty thinking block.
+   * Required by DeepSeek's anthropic-compatible API when thinking mode is
+   * enabled. Must be gated on the same per-request condition that emits the
+   * top-level `thinking` config so disabled-thinking requests don't ship
+   * stray thinking blocks. https://github.com/QwenLM/qwen-code/issues/3786
    */
   ensureThinkingOnToolUseTurns?: boolean;
   /**
@@ -625,9 +625,11 @@ export class AnthropicContentConverter {
    * Edge case: a `thinking` block round-tripped through Gemini Part format
    * may come back without its `signature` field (e.g. when the upstream
    * block was `redacted_thinking`, whose `data` field doesn't survive the
-   * `{ thought: true }` representation). Such blocks are not spec-compliant,
-   * so we drop them here and let the synthetic injection take over rather
-   * than treat them as already-satisfying the requirement.
+   * `{ thought: true }` representation, or when the conversation history
+   * was recorded by a non-Anthropic generator that only sets
+   * `thought: true`). Such blocks are not spec-compliant, so we normalize
+   * them in place by filling in `signature: ''` — preserving the original
+   * thinking text rather than discarding it.
    * https://github.com/QwenLM/qwen-code/issues/3786
    */
   private applyEmptyThinkingToToolUseTurns(

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -33,16 +33,30 @@ type AnthropicContentBlockParam = Anthropic.ContentBlockParam;
 
 export interface ConvertGeminiRequestToAnthropicOptions {
   /**
-   * On every assistant turn, normalize any `thinking` block that lacks the
-   * required `signature` field by filling it with `signature: ''` (preserving
-   * the original `thinking` text). On assistant turns containing `tool_use`
-   * with no thinking block at all, prepend a synthetic empty thinking block.
-   * Required by DeepSeek's anthropic-compatible API when thinking mode is
-   * enabled. Must be gated on the same per-request condition that emits the
+   * On every assistant turn, fill in `signature: ''` on any `thinking` block
+   * that lacks the required `signature` field. Preserves the original
+   * `thinking` text. Common case: cross-provider history where non-Anthropic
+   * generators (OpenAI / Gemini / agent-runtime) only set `thought: true`,
+   * or `redacted_thinking` blocks that lost their `data` field through the
+   * Gemini-Part round trip.
+   */
+  normalizeAssistantThinkingSignature?: boolean;
+  /**
+   * On assistant turns containing `tool_use` but lacking any thinking block,
+   * prepend a synthetic empty thinking block. Required by DeepSeek's
+   * anthropic-compatible API when thinking mode is enabled — without this,
+   * follow-up requests fail with HTTP 400 ("The content[].thinking in the
+   * thinking mode must be passed back to the API.").
+   *
+   * Pair with `normalizeAssistantThinkingSignature` so that signature-less
+   * blocks are seen as missing (and therefore replaced by the synthetic with
+   * a valid signature) rather than as already-satisfying.
+   *
+   * Must be gated on the same per-request condition that emits the
    * top-level `thinking` config so disabled-thinking requests don't ship
    * stray thinking blocks. https://github.com/QwenLM/qwen-code/issues/3786
    */
-  ensureThinkingOnToolUseTurns?: boolean;
+  injectThinkingOnToolUseTurns?: boolean;
   /**
    * Strip thinking and redacted_thinking blocks from assistant messages.
    * Used to keep DeepSeek requests consistent when thinking mode is off but
@@ -85,8 +99,13 @@ export class AnthropicContentConverter {
     if (options.stripAssistantThinking) {
       this.stripThinkingFromAssistantMessages(messages);
     }
-    if (options.ensureThinkingOnToolUseTurns) {
-      this.applyEmptyThinkingToToolUseTurns(messages);
+    // Normalization runs before injection so non-compliant blocks are seen
+    // as already-present (and not duplicated) by the injection pass.
+    if (options.normalizeAssistantThinkingSignature) {
+      this.fillMissingThinkingSignatures(messages);
+    }
+    if (options.injectThinkingOnToolUseTurns) {
+      this.injectEmptyThinkingOnToolUseTurns(messages);
     }
 
     // Add cache_control to enable prompt caching (if enabled)
@@ -609,53 +628,26 @@ export class AnthropicContentConverter {
   }
 
   /**
-   * DeepSeek's anthropic-compatible API rejects follow-up requests when an
-   * assistant turn carrying `tool_use` omits a thinking block while thinking
-   * mode is on, returning HTTP 400 ("The content[].thinking in the thinking
-   * mode must be passed back to the API."). The model can legitimately
-   * return a tool round without thinking content, so inject an empty thinking
-   * block when one is missing.
+   * Fill in `signature: ''` on every assistant `thinking` block that lacks
+   * a `signature` field. Preserves the original thinking text. Common cases:
    *
-   * Live verification against api.deepseek.com/anthropic confirmed the
-   * trigger is specific to tool_use turns — plain-text assistant turns
-   * without thinking are accepted unchanged. We mirror that boundary here to
-   * avoid bloating replay history with synthetic blocks for turns the API
-   * already accepts.
+   * - Cross-provider history where the upstream generator (OpenAI / Gemini /
+   *   agent-runtime) only set `thought: true` without a signature.
+   * - `redacted_thinking` blocks whose `data` field didn't survive the
+   *   round-trip through Gemini Part format.
    *
-   * Edge case: a `thinking` block round-tripped through Gemini Part format
-   * may come back without its `signature` field (e.g. when the upstream
-   * block was `redacted_thinking`, whose `data` field doesn't survive the
-   * `{ thought: true }` representation, or when the conversation history
-   * was recorded by a non-Anthropic generator that only sets
-   * `thought: true`). Such blocks are not spec-compliant, so we normalize
-   * them in place by filling in `signature: ''` — preserving the original
-   * thinking text rather than discarding it.
-   * https://github.com/QwenLM/qwen-code/issues/3786
+   * DeepSeek empirically accepts empty signatures, so this keeps the wire
+   * shape spec-compliant without discarding any preserved thinking text.
    */
-  private applyEmptyThinkingToToolUseTurns(
+  private fillMissingThinkingSignatures(
     messages: AnthropicMessageParam[],
   ): void {
     for (const message of messages) {
       if (message.role !== 'assistant') continue;
+      if (!Array.isArray(message.content)) continue;
 
-      const blocks: AnthropicContentBlockParam[] =
-        typeof message.content === 'string'
-          ? [{ type: 'text', text: message.content }]
-          : Array.isArray(message.content)
-            ? message.content
-            : [];
-
-      // Step 1: Normalize non-compliant `thinking` blocks (missing the
-      // required `signature` field) by setting `signature: ''` in place. This
-      // shape commonly arrives from other generators (OpenAI/Gemini/agent-
-      // runtime emit `{ thought: true }` parts with no signature) when users
-      // switch providers mid-session, or from `redacted_thinking` blocks that
-      // lost their `data` field through the Gemini-Part round trip. Adding an
-      // empty signature preserves the original thinking text instead of
-      // dropping the block — DeepSeek currently accepts empty signatures, so
-      // this keeps the wire shape spec-compliant without losing history.
       let modified = false;
-      const normalizedBlocks = blocks.map((block) => {
+      const normalized = message.content.map((block) => {
         const b = block as { type?: string; signature?: unknown };
         if (b.type === 'thinking' && typeof b.signature !== 'string') {
           modified = true;
@@ -667,17 +659,44 @@ export class AnthropicContentConverter {
         return block;
       });
       if (modified) {
-        message.content = normalizedBlocks;
+        message.content = normalized;
       }
+    }
+  }
 
-      // Step 2: On tool-use turns still lacking any thinking block, prepend
-      // a synthetic empty one (the issue #3786 trigger).
-      const hasToolUse = normalizedBlocks.some(
+  /**
+   * DeepSeek's anthropic-compatible API rejects follow-up requests when an
+   * assistant turn carrying `tool_use` omits a thinking block while thinking
+   * mode is on, returning HTTP 400 ("The content[].thinking in the thinking
+   * mode must be passed back to the API."). The model can legitimately
+   * return a tool round without thinking content, so prepend a synthetic
+   * empty thinking block when one is missing.
+   *
+   * Live verification against api.deepseek.com/anthropic confirmed the
+   * trigger is specific to tool_use turns — plain-text assistant turns
+   * without thinking are accepted unchanged. We mirror that boundary here
+   * to avoid bloating replay history with synthetic blocks for turns the
+   * API already accepts.
+   *
+   * Should be paired with `fillMissingThinkingSignatures` so that
+   * round-tripped non-compliant `thinking` blocks aren't mistaken for
+   * already-satisfying. https://github.com/QwenLM/qwen-code/issues/3786
+   */
+  private injectEmptyThinkingOnToolUseTurns(
+    messages: AnthropicMessageParam[],
+  ): void {
+    for (const message of messages) {
+      if (message.role !== 'assistant') continue;
+      if (!Array.isArray(message.content)) continue;
+
+      const blocks = message.content;
+
+      const hasToolUse = blocks.some(
         (block) => (block as { type?: string }).type === 'tool_use',
       );
       if (!hasToolUse) continue;
 
-      const hasThinking = normalizedBlocks.some((block) => {
+      const hasThinking = blocks.some((block) => {
         const t = (block as { type?: string }).type;
         return t === 'thinking' || t === 'redacted_thinking';
       });
@@ -693,7 +712,7 @@ export class AnthropicContentConverter {
         thinking: '',
         signature: '',
       } as unknown as AnthropicContentBlockParam;
-      message.content = [emptyThinking, ...normalizedBlocks];
+      message.content = [emptyThinking, ...blocks];
     }
   }
 

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -563,12 +563,18 @@ export class AnthropicContentConverter {
   }
 
   /**
-   * DeepSeek's anthropic-compatible API rejects follow-up requests when any
-   * prior assistant turn omits a thinking block while thinking mode is on,
-   * returning HTTP 400 ("The content[].thinking in the thinking mode must be
-   * passed back to the API."). The model can legitimately return a turn
-   * without thinking content, so inject an empty thinking block whenever one
-   * is missing. https://github.com/QwenLM/qwen-code/issues/3786
+   * DeepSeek's anthropic-compatible API rejects follow-up requests when an
+   * assistant turn carrying `tool_use` omits a thinking block while thinking
+   * mode is on, returning HTTP 400 ("The content[].thinking in the thinking
+   * mode must be passed back to the API."). The model can legitimately
+   * return a tool round without thinking content, so inject an empty thinking
+   * block when one is missing.
+   *
+   * Live verification against api.deepseek.com/anthropic confirmed the
+   * trigger is specific to tool_use turns — plain-text assistant turns
+   * without thinking are accepted unchanged. We mirror that boundary here to
+   * avoid bloating replay history with synthetic blocks for turns the API
+   * already accepts. https://github.com/QwenLM/qwen-code/issues/3786
    */
   private applyEmptyThinkingToAssistantMessages(
     messages: AnthropicMessageParam[],
@@ -583,25 +589,29 @@ export class AnthropicContentConverter {
             ? message.content
             : [];
 
+      const hasToolUse = blocks.some(
+        (block) => (block as { type?: string }).type === 'tool_use',
+      );
+      if (!hasToolUse) continue;
+
       const hasThinking = blocks.some(
         (block) =>
           (block as { type?: string }).type === 'thinking' ||
           (block as { type?: string }).type === 'redacted_thinking',
       );
+      if (hasThinking) continue;
 
-      if (!hasThinking) {
-        // DeepSeek currently accepts an empty `signature` for synthetic
-        // thinking blocks. The `signature` field is an opaque token in the
-        // Anthropic spec, so this is a workaround — if DeepSeek tightens
-        // validation in the future, we may need to switch to
-        // `redacted_thinking` or another approach.
-        const emptyThinking = {
-          type: 'thinking',
-          thinking: '',
-          signature: '',
-        } as unknown as AnthropicContentBlockParam;
-        message.content = [emptyThinking, ...blocks];
-      }
+      // DeepSeek currently accepts an empty `signature` for synthetic
+      // thinking blocks. The `signature` field is an opaque token in the
+      // Anthropic spec, so this is a workaround — if DeepSeek tightens
+      // validation in the future, we may need to switch to
+      // `redacted_thinking` or another approach.
+      const emptyThinking = {
+        type: 'thinking',
+        thinking: '',
+        signature: '',
+      } as unknown as AnthropicContentBlockParam;
+      message.content = [emptyThinking, ...blocks];
     }
   }
 

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -31,25 +31,36 @@ type AnthropicToolParam = Anthropic.Tool & {
 };
 type AnthropicContentBlockParam = Anthropic.ContentBlockParam;
 
+export interface ConvertGeminiRequestToAnthropicOptions {
+  /**
+   * Inject an empty thinking block on assistant turns missing one. Required by
+   * DeepSeek's anthropic-compatible API when thinking mode is enabled — must
+   * be gated on the same per-request condition that sends the top-level
+   * `thinking` config so disabled-thinking requests don't ship stray thinking
+   * blocks. https://github.com/QwenLM/qwen-code/issues/3786
+   */
+  ensureAssistantThinking?: boolean;
+}
+
 export class AnthropicContentConverter {
   private model: string;
   private schemaCompliance: SchemaComplianceMode;
   private enableCacheControl: boolean;
-  private ensureAssistantThinking: boolean;
 
   constructor(
     model: string,
     schemaCompliance: SchemaComplianceMode = 'auto',
     enableCacheControl: boolean = true,
-    ensureAssistantThinking: boolean = false,
   ) {
     this.model = model;
     this.schemaCompliance = schemaCompliance;
     this.enableCacheControl = enableCacheControl;
-    this.ensureAssistantThinking = ensureAssistantThinking;
   }
 
-  convertGeminiRequestToAnthropic(request: GenerateContentParameters): {
+  convertGeminiRequestToAnthropic(
+    request: GenerateContentParameters,
+    options: ConvertGeminiRequestToAnthropicOptions = {},
+  ): {
     system?: Anthropic.TextBlockParam[] | string;
     messages: AnthropicMessageParam[];
   } {
@@ -61,7 +72,7 @@ export class AnthropicContentConverter {
 
     this.processContents(request.contents, messages);
 
-    if (this.ensureAssistantThinking) {
+    if (options.ensureAssistantThinking) {
       this.applyEmptyThinkingToAssistantMessages(messages);
     }
 
@@ -579,6 +590,11 @@ export class AnthropicContentConverter {
       );
 
       if (!hasThinking) {
+        // DeepSeek currently accepts an empty `signature` for synthetic
+        // thinking blocks. The `signature` field is an opaque token in the
+        // Anthropic spec, so this is a workaround — if DeepSeek tightens
+        // validation in the future, we may need to switch to
+        // `redacted_thinking` or another approach.
         const emptyThinking = {
           type: 'thinking',
           thinking: '',


### PR DESCRIPTION
## Summary

Closes #3786.

DeepSeek's anthropic-compatible endpoint (`https://api.deepseek.com/anthropic`) rejects follow-up requests with HTTP 400 when an assistant turn carrying `tool_use` is missing a `thinking` block:

```
The content[].thinking in the thinking mode must be passed back to the API.
```

The model can legitimately return a tool round without thinking text, so qwen-code stored no thought parts and rebuilt the next request with no `thinking` block, tripping the API's check.

This mirrors the existing OpenAI-side fix (#3729, #3747) at the request boundary. Three coordinated converter behaviors keep DeepSeek requests internally consistent:

1. **When thinking mode is on** (`thinking` config present): two passes run together.
   - `normalizeAssistantThinkingSignature` fills in `signature: ''` on every assistant `thinking` block that lacks the required `signature` field, *preserving the original thinking text in place*. Common case: cross-provider history where non-Anthropic generators (OpenAI / Gemini / agent-runtime) only set `thought: true`, or `redacted_thinking` blocks that lost their `data` field through the Gemini-Part round trip.
   - `injectThinkingOnToolUseTurns` then prepends a synthetic empty thinking block on assistant turns containing `tool_use` but lacking any thinking block. Live verification showed only tool-use turns trigger DeepSeek's 400 — plain-text assistant turns are accepted unchanged, so injection is scoped to that case to avoid bloating replay history. Because normalization ran first, any pre-existing `thinking` block is now compliant and the injector treats it as already-satisfying (no synthetic prepended).

2. **When thinking mode is off** (e.g. `suggestionGenerator` / `forkedAgent` / `ArenaManager` paths that pass `thinkingConfig.includeThoughts: false`): strip pre-existing thinking and redacted_thinking blocks from assistant messages so the request body matches the absent top-level `thinking` config. The same per-request opt-out also drops `output_config.effort` so reasoning-shaped fields don't leak into thinking-off side queries. Thinking-only assistant turns (rare, e.g. max_tokens cutoff) are left untouched to avoid emitting `content: []`, which Anthropic API rejects.

3. **Provider detection** runs per request (DeepSeek by hostname or model name) so a runtime `/model` switch via `Config.setModel()` doesn't see a stale provider flag. The `anthropic-beta` header is also computed per-request from the actual fields in the request body, with user-supplied `customHeaders['anthropic-beta']` (case-insensitive lookup) merged in and deduped.

### Detection scope

Detection matches `api.deepseek.com` (and subdomains like `us.api.deepseek.com`) by hostname, or any model name containing `deepseek`. The model-name path is consistent with the OpenAI-side `DeepSeekOpenAICompatibleProvider.isDeepSeekProvider` and intentionally covers self-hosted DeepSeek deployments (sglang/vllm) that may sit behind generic anthropic-compatible endpoints. Side effect: a model named e.g. `my-deepseek-clone` on a non-DeepSeek host also enables the workaround. Trade-off accepted because false positives are harmless on lenient providers, while a stricter prefix check would silently break the self-hosted DeepSeek scenarios the OpenAI path already supports.

## Verification

Reproduced and verified directly against the live `api.deepseek.com/anthropic` endpoint:

| Scenario | Before fix | After fix |
|---|---|---|
| `assistant: [tool_use]` (no thinking) | ❌ 400 — exact issue error | ✓ 200 |
| `assistant: [thinking, tool_use]` | ✓ 200 | ✓ 200 |
| `assistant: [text]` (no tool_use) | ✓ 200 | ✓ 200 |
| `assistant: [thinking-no-signature, tool_use]` | ✓ 200 (lenient) | ✓ 200 (now normalized in place — text preserved) |
| thinking-off + history with thinking blocks | ✓ 200 (lenient) | ✓ 200 (now internally consistent) |

## Test plan

- [x] `npm test` — all core tests pass (74 anthropic-side tests covering normalization on every assistant turn, injection on tool_use turns, stripping when thinking-off, runtime model switch, hostname detection variants including subdomains and spoof rejection, gating, edge cases like thinking-only turns and mixed text+tool_use, customHeaders coexistence and case-insensitive merge, streaming-path beta headers)
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean
- [x] Live API verification against `api.deepseek.com/anthropic` (issue reproduced pre-fix, gone post-fix; signature-less and signature-empty thinking blocks both currently accepted by DeepSeek)
