### PR TITLE
fix(core): improve stream rate-limit retry handling

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1541,6 +1541,97 @@ describe('GeminiChat', async () => {
       }
     });
 
+    it('should increase delay across repeated streamed rate-limit errors', async () => {
+      vi.useFakeTimers();
+
+      try {
+        const firstError = new StreamContentError(
+          'id:1\nevent:error\n:HTTP_STATUS/429\ndata:{"request_id":"req-1","code":"Throttling.AllocationQuota","message":"Allocated quota exceeded"}',
+        );
+        const secondError = new StreamContentError(
+          'id:2\nevent:error\n:HTTP_STATUS/429\ndata:{"request_id":"req-2","code":"Throttling.AllocationQuota","message":"Allocated quota exceeded"}',
+        );
+
+        vi.mocked(mockContentGenerator.generateContentStream)
+          .mockResolvedValueOnce(
+            (async function* () {
+              throw firstError;
+
+              yield {} as GenerateContentResponse;
+            })(),
+          )
+          .mockResolvedValueOnce(
+            (async function* () {
+              throw secondError;
+
+              yield {} as GenerateContentResponse;
+            })(),
+          )
+          .mockResolvedValueOnce(
+            (async function* () {
+              yield {
+                candidates: [
+                  {
+                    content: { parts: [{ text: 'Recovered after backoff' }] },
+                    finishReason: 'STOP',
+                  },
+                ],
+              } as unknown as GenerateContentResponse;
+            })(),
+          );
+
+        const stream = await chat.sendMessageStream(
+          'test-model',
+          { message: 'test' },
+          'prompt-id-streamed-rate-limit-backoff',
+        );
+
+        const iterator = stream[Symbol.asyncIterator]();
+        const retryInfos: Array<
+          NonNullable<
+            Extract<StreamEvent, { type: StreamEventType.RETRY }>['retryInfo']
+          >
+        > = [];
+
+        const first = await iterator.next();
+        expect(first.value.type).toBe(StreamEventType.RETRY);
+        retryInfos.push(first.value.retryInfo!);
+
+        let nextPromise = iterator.next();
+        await vi.advanceTimersByTimeAsync(60_000);
+        await nextPromise;
+
+        const second = await iterator.next();
+        expect(second.value.type).toBe(StreamEventType.RETRY);
+        retryInfos.push(second.value.retryInfo!);
+
+        nextPromise = iterator.next();
+        await vi.advanceTimersByTimeAsync(120_000);
+        await nextPromise;
+
+        const events: StreamEvent[] = [];
+        for (;;) {
+          const next = await iterator.next();
+          if (next.done) break;
+          events.push(next.value);
+        }
+
+        expect(retryInfos.map((info) => info.delayMs)).toEqual([
+          60_000, 120_000,
+        ]);
+        expect(
+          events.some(
+            (e) =>
+              e.type === StreamEventType.CHUNK &&
+              e.value.candidates?.[0]?.content?.parts?.[0]?.text ===
+                'Recovered after backoff',
+          ),
+        ).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     describe('API error retry behavior', () => {
       beforeEach(() => {
         // Use a more direct mock for retry testing

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1225,7 +1225,7 @@ describe('GeminiChat', async () => {
       }
     });
 
-    it('should retry on TPM throttling StreamContentError with fixed delay', async () => {
+    it('should retry on TPM throttling StreamContentError with initial delay', async () => {
       vi.useFakeTimers();
 
       try {
@@ -1296,6 +1296,81 @@ describe('GeminiChat', async () => {
           ),
         ).toBe(true);
         expect(mockLogContentRetry).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should use Retry-After delay for streamed rate-limit errors', async () => {
+      vi.useFakeTimers();
+
+      try {
+        const retryAfterError = Object.assign(
+          new StreamContentError(
+            '{"error":{"code":"429","message":"Throttling: TPM(1/1)"}}',
+          ),
+          {
+            status: 429,
+            headers: { 'retry-after': '180' },
+          },
+        );
+
+        vi.mocked(mockContentGenerator.generateContentStream)
+          .mockResolvedValueOnce(
+            (async function* () {
+              throw retryAfterError;
+
+              yield {} as GenerateContentResponse;
+            })(),
+          )
+          .mockResolvedValueOnce(
+            (async function* () {
+              yield {
+                candidates: [
+                  {
+                    content: {
+                      parts: [{ text: 'Success after Retry-After' }],
+                    },
+                    finishReason: 'STOP',
+                  },
+                ],
+              } as unknown as GenerateContentResponse;
+            })(),
+          );
+
+        const stream = await chat.sendMessageStream(
+          'test-model',
+          { message: 'test' },
+          'prompt-id-retry-after',
+        );
+
+        const iterator = stream[Symbol.asyncIterator]();
+        const first = await iterator.next();
+        expect(first.value.type).toBe(StreamEventType.RETRY);
+        expect(first.value.retryInfo?.delayMs).toBe(180_000);
+
+        const secondPromise = iterator.next();
+        await vi.advanceTimersByTimeAsync(180_000);
+        await secondPromise;
+
+        const events: StreamEvent[] = [];
+        for (;;) {
+          const next = await iterator.next();
+          if (next.done) break;
+          events.push(next.value);
+        }
+
+        expect(
+          mockContentGenerator.generateContentStream,
+        ).toHaveBeenCalledTimes(2);
+        expect(
+          events.some(
+            (e) =>
+              e.type === StreamEventType.CHUNK &&
+              e.value.candidates?.[0]?.content?.parts?.[0]?.text ===
+                'Success after Retry-After',
+          ),
+        ).toBe(true);
       } finally {
         vi.useRealTimers();
       }

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -21,7 +21,12 @@ import { retryWithBackoff, isUnattendedMode } from '../utils/retry.js';
 import { getErrorStatus } from '../utils/errors.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { parseAndFormatApiError } from '../utils/errorParsing.js';
-import { isRateLimitError, type RetryInfo } from '../utils/rateLimit.js';
+import {
+  getRateLimitErrorDetails,
+  getRateLimitRetryDelayMs,
+  isRateLimitError,
+  type RetryInfo,
+} from '../utils/rateLimit.js';
 import type { Config } from '../config/config.js';
 import { ESCALATED_MAX_TOKENS, tokenLimit } from './tokenLimits.js';
 import { hasCycleInSchema } from '../tools/tools.js';
@@ -102,12 +107,14 @@ const OUTPUT_RECOVERY_MESSAGE =
 
 /**
  * Options for retrying on rate-limit throttling errors returned as stream content.
- * Fixed 60s delay matches the DashScope per-minute quota window.
+ * Starts at 60s to match DashScope's per-minute quota window, then backs off
+ * across repeated stream-side throttling errors.
  * 10 retries aligns with Claude Code's retry behavior.
  */
 const RATE_LIMIT_RETRY_OPTIONS = {
   maxRetries: 10,
-  delayMs: 60000,
+  initialDelayMs: 60000,
+  maxDelayMs: 5 * 60 * 1000,
 };
 
 /**
@@ -431,14 +438,22 @@ export class GeminiChat {
             const isRateLimit = isRateLimitError(error, extraRetryErrorCodes);
             if (isRateLimit && rateLimitRetryCount < maxRateLimitRetries) {
               rateLimitRetryCount++;
-              const delayMs = RATE_LIMIT_RETRY_OPTIONS.delayMs;
+              const delayMs = getRateLimitRetryDelayMs(
+                rateLimitRetryCount,
+                RATE_LIMIT_RETRY_OPTIONS,
+              );
               const message = parseAndFormatApiError(
                 error instanceof Error ? error.message : String(error),
               );
-              debugLogger.warn(
-                `Rate limit throttling detected (retry ${rateLimitRetryCount}/${maxRateLimitRetries}). ` +
-                  `Waiting ${delayMs / 1000}s before retrying...`,
-              );
+              const details = getRateLimitErrorDetails(error);
+              debugLogger.warn('Rate limit retry scheduled', {
+                retryPath: 'stream',
+                retryDecision: 'retry',
+                attempt: rateLimitRetryCount,
+                maxRetries: maxRateLimitRetries,
+                retryDelayMs: delayMs,
+                ...details,
+              });
               const { promise: delayPromise, skip } = delay(
                 delayMs,
                 params.config?.abortSignal,
@@ -457,6 +472,15 @@ export class GeminiChat {
               attempt--;
               await delayPromise;
               continue;
+            }
+            if (isRateLimit) {
+              debugLogger.warn('Rate limit retry exhausted', {
+                retryPath: 'stream',
+                retryDecision: 'exhausted',
+                attempts: rateLimitRetryCount,
+                maxRetries: maxRateLimitRetries,
+                ...getRateLimitErrorDetails(error),
+              });
             }
 
             // Transient stream anomalies (NO_FINISH_REASON / NO_RESPONSE_TEXT):

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -438,10 +438,10 @@ export class GeminiChat {
             const isRateLimit = isRateLimitError(error, extraRetryErrorCodes);
             if (isRateLimit && rateLimitRetryCount < maxRateLimitRetries) {
               rateLimitRetryCount++;
-              const delayMs = getRateLimitRetryDelayMs(
-                rateLimitRetryCount,
-                RATE_LIMIT_RETRY_OPTIONS,
-              );
+              const delayMs = getRateLimitRetryDelayMs(rateLimitRetryCount, {
+                ...RATE_LIMIT_RETRY_OPTIONS,
+                error,
+              });
               const message = parseAndFormatApiError(
                 error instanceof Error ? error.message : String(error),
               );

--- a/packages/core/src/utils/rateLimit.test.ts
+++ b/packages/core/src/utils/rateLimit.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
   getRateLimitErrorDetails,
   getRateLimitRetryDelayMs,
@@ -195,6 +195,19 @@ describe('rate-limit retry diagnostics', () => {
     });
   });
 
+  it('should extract request id from top-level nested JSON error messages', () => {
+    const error = new Error(
+      '{"request_id":"req-123","error":{"code":"429","message":"Throttling: TPM limit reached"}}',
+    );
+
+    expect(getRateLimitErrorDetails(error)).toEqual({
+      providerCode: '429',
+      providerMessage: 'Throttling: TPM limit reached',
+      requestId: 'req-123',
+      transport: 'unknown',
+    });
+  });
+
   it('should increase retry delay by attempt and cap at the maximum', () => {
     expect(
       getRateLimitRetryDelayMs(0, {
@@ -284,10 +297,116 @@ describe('rate-limit retry diagnostics', () => {
     ).toBe(180_000);
   });
 
+  it('should read Retry-After from Headers-like objects', () => {
+    const error = Object.assign(new Error('Too many requests'), {
+      status: 429,
+      headers: {
+        get: (name: string) => (name === 'retry-after' ? '180' : null),
+      },
+    });
+
+    expect(
+      getRateLimitRetryDelayMs(1, {
+        initialDelayMs: 60_000,
+        maxDelayMs: 300_000,
+        error,
+      }),
+    ).toBe(180_000);
+  });
+
+  it('should read Retry-After headers case-insensitively', () => {
+    const error = Object.assign(new Error('Too many requests'), {
+      status: 429,
+      headers: { 'Retry-After': '180' },
+    });
+
+    expect(
+      getRateLimitRetryDelayMs(1, {
+        initialDelayMs: 60_000,
+        maxDelayMs: 300_000,
+        error,
+      }),
+    ).toBe(180_000);
+  });
+
+  it('should read HTTP-date Retry-After values', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));
+
+    try {
+      const error = Object.assign(new Error('Too many requests'), {
+        status: 429,
+        headers: { 'retry-after': 'Thu, 01 Jan 2026 00:03:00 GMT' },
+      });
+
+      expect(
+        getRateLimitRetryDelayMs(1, {
+          initialDelayMs: 60_000,
+          maxDelayMs: 300_000,
+          error,
+        }),
+      ).toBe(180_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should ignore past HTTP-date Retry-After values', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:03:00.000Z'));
+
+    try {
+      const error = Object.assign(new Error('Too many requests'), {
+        status: 429,
+        headers: { 'retry-after': 'Thu, 01 Jan 2026 00:00:00 GMT' },
+      });
+
+      expect(
+        getRateLimitRetryDelayMs(1, {
+          initialDelayMs: 60_000,
+          maxDelayMs: 300_000,
+          error,
+        }),
+      ).toBe(60_000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('should ignore malformed Retry-After values', () => {
+    const error = Object.assign(new Error('Too many requests'), {
+      status: 429,
+      headers: { 'retry-after': 'not a retry-after value' },
+    });
+
+    expect(
+      getRateLimitRetryDelayMs(1, {
+        initialDelayMs: 60_000,
+        maxDelayMs: 300_000,
+        error,
+      }),
+    ).toBe(60_000);
+  });
+
   it('should ignore null direct headers', () => {
     const error = Object.assign(new Error('Too many requests'), {
       status: 429,
       headers: null,
+    });
+
+    expect(
+      getRateLimitRetryDelayMs(1, {
+        initialDelayMs: 60_000,
+        maxDelayMs: 300_000,
+        error,
+      }),
+    ).toBe(60_000);
+  });
+
+  it('should ignore undefined direct headers', () => {
+    const error = Object.assign(new Error('Too many requests'), {
+      status: 429,
+      headers: undefined,
     });
 
     expect(
@@ -304,6 +423,23 @@ describe('rate-limit retry diagnostics', () => {
       status: 429,
       response: {
         headers: null,
+      },
+    });
+
+    expect(
+      getRateLimitRetryDelayMs(1, {
+        initialDelayMs: 60_000,
+        maxDelayMs: 300_000,
+        error,
+      }),
+    ).toBe(60_000);
+  });
+
+  it('should ignore undefined response headers', () => {
+    const error = Object.assign(new Error('Too many requests'), {
+      status: 429,
+      response: {
+        headers: undefined,
       },
     });
 

--- a/packages/core/src/utils/rateLimit.test.ts
+++ b/packages/core/src/utils/rateLimit.test.ts
@@ -283,4 +283,36 @@ describe('rate-limit retry diagnostics', () => {
       }),
     ).toBe(180_000);
   });
+
+  it('should ignore null direct headers', () => {
+    const error = Object.assign(new Error('Too many requests'), {
+      status: 429,
+      headers: null,
+    });
+
+    expect(
+      getRateLimitRetryDelayMs(1, {
+        initialDelayMs: 60_000,
+        maxDelayMs: 300_000,
+        error,
+      }),
+    ).toBe(60_000);
+  });
+
+  it('should ignore null response headers', () => {
+    const error = Object.assign(new Error('Too many requests'), {
+      status: 429,
+      response: {
+        headers: null,
+      },
+    });
+
+    expect(
+      getRateLimitRetryDelayMs(1, {
+        initialDelayMs: 60_000,
+        maxDelayMs: 300_000,
+        error,
+      }),
+    ).toBe(60_000);
+  });
 });

--- a/packages/core/src/utils/rateLimit.test.ts
+++ b/packages/core/src/utils/rateLimit.test.ts
@@ -212,4 +212,49 @@ describe('rate-limit retry diagnostics', () => {
       }),
     ).toBe(300_000);
   });
+
+  it('should use Retry-After as a minimum delay when it is longer than exponential backoff', () => {
+    const error = Object.assign(new Error('Too many requests'), {
+      status: 429,
+      headers: { 'retry-after': '180' },
+    });
+
+    expect(
+      getRateLimitRetryDelayMs(1, {
+        initialDelayMs: 60_000,
+        maxDelayMs: 300_000,
+        error,
+      }),
+    ).toBe(180_000);
+  });
+
+  it('should keep exponential backoff when Retry-After is shorter', () => {
+    const error = Object.assign(new Error('Too many requests'), {
+      status: 429,
+      headers: { 'retry-after': '30' },
+    });
+
+    expect(
+      getRateLimitRetryDelayMs(2, {
+        initialDelayMs: 60_000,
+        maxDelayMs: 300_000,
+        error,
+      }),
+    ).toBe(120_000);
+  });
+
+  it('should cap long Retry-After values at the maximum delay', () => {
+    const error = Object.assign(new Error('Too many requests'), {
+      status: 429,
+      headers: { 'retry-after': '600' },
+    });
+
+    expect(
+      getRateLimitRetryDelayMs(1, {
+        initialDelayMs: 60_000,
+        maxDelayMs: 300_000,
+        error,
+      }),
+    ).toBe(300_000);
+  });
 });

--- a/packages/core/src/utils/rateLimit.test.ts
+++ b/packages/core/src/utils/rateLimit.test.ts
@@ -157,6 +157,15 @@ describe('rate-limit retry diagnostics', () => {
     });
   });
 
+  it('should ignore non-object SSE JSON payloads in diagnostics', () => {
+    const error = new Error('id:1\nevent:error\n:HTTP_STATUS/429\ndata:null');
+
+    expect(getRateLimitErrorDetails(error)).toEqual({
+      statusCode: 429,
+      transport: 'sse',
+    });
+  });
+
   it('should extract structured details from HTTP-shaped rate-limit errors', () => {
     const error = Object.assign(new Error('Too many requests'), {
       status: 429,

--- a/packages/core/src/utils/rateLimit.test.ts
+++ b/packages/core/src/utils/rateLimit.test.ts
@@ -257,4 +257,21 @@ describe('rate-limit retry diagnostics', () => {
       }),
     ).toBe(300_000);
   });
+
+  it('should read Retry-After from response headers', () => {
+    const error = Object.assign(new Error('Too many requests'), {
+      status: 429,
+      response: {
+        headers: { 'retry-after': '180' },
+      },
+    });
+
+    expect(
+      getRateLimitRetryDelayMs(1, {
+        initialDelayMs: 60_000,
+        maxDelayMs: 300_000,
+        error,
+      }),
+    ).toBe(180_000);
+  });
 });

--- a/packages/core/src/utils/rateLimit.test.ts
+++ b/packages/core/src/utils/rateLimit.test.ts
@@ -5,7 +5,11 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isRateLimitError } from './rateLimit.js';
+import {
+  getRateLimitErrorDetails,
+  getRateLimitRetryDelayMs,
+  isRateLimitError,
+} from './rateLimit.js';
 import type { StructuredError } from '../core/turn.js';
 import type { HttpError } from './retry.js';
 
@@ -135,5 +139,77 @@ describe('isRateLimitError — return shape', () => {
       'id:1\nevent:error\n:HTTP_STATUS/429\ndata:{"request_id":"70acdc21-a546-489a-b5d6-650df970a4ef","code":"Throttling.AllocationQuota","message":"Allocated quota exceeded, please increase your quota limit."}',
     );
     expect(isRateLimitError(error)).toBe(true);
+  });
+});
+
+describe('rate-limit retry diagnostics', () => {
+  it('should extract structured details from SSE-embedded rate-limit errors', () => {
+    const error = new Error(
+      'id:1\nevent:error\n:HTTP_STATUS/429\ndata:{"request_id":"70acdc21-a546-489a-b5d6-650df970a4ef","code":"Throttling.AllocationQuota","message":"Allocated quota exceeded"}',
+    );
+
+    expect(getRateLimitErrorDetails(error)).toEqual({
+      statusCode: 429,
+      providerCode: 'Throttling.AllocationQuota',
+      providerMessage: 'Allocated quota exceeded',
+      requestId: '70acdc21-a546-489a-b5d6-650df970a4ef',
+      transport: 'sse',
+    });
+  });
+
+  it('should extract structured details from HTTP-shaped rate-limit errors', () => {
+    const error = Object.assign(new Error('Too many requests'), {
+      status: 429,
+      error: {
+        code: 'rate_limit_exceeded',
+        message: 'Rate limit exceeded',
+      },
+    });
+
+    expect(getRateLimitErrorDetails(error)).toEqual({
+      statusCode: 429,
+      providerCode: 'rate_limit_exceeded',
+      providerMessage: 'Rate limit exceeded',
+      transport: 'http',
+    });
+  });
+
+  it('should extract nested JSON provider details from error messages', () => {
+    const error = new Error(
+      '{"error":{"code":"429","message":"Throttling: TPM limit reached"}}',
+    );
+
+    expect(getRateLimitErrorDetails(error)).toEqual({
+      providerCode: '429',
+      providerMessage: 'Throttling: TPM limit reached',
+      transport: 'unknown',
+    });
+  });
+
+  it('should increase retry delay by attempt and cap at the maximum', () => {
+    expect(
+      getRateLimitRetryDelayMs(0, {
+        initialDelayMs: 60_000,
+        maxDelayMs: 300_000,
+      }),
+    ).toBe(60_000);
+    expect(
+      getRateLimitRetryDelayMs(1, {
+        initialDelayMs: 60_000,
+        maxDelayMs: 300_000,
+      }),
+    ).toBe(60_000);
+    expect(
+      getRateLimitRetryDelayMs(2, {
+        initialDelayMs: 60_000,
+        maxDelayMs: 300_000,
+      }),
+    ).toBe(120_000);
+    expect(
+      getRateLimitRetryDelayMs(10, {
+        initialDelayMs: 60_000,
+        maxDelayMs: 300_000,
+      }),
+    ).toBe(300_000);
   });
 });

--- a/packages/core/src/utils/rateLimit.ts
+++ b/packages/core/src/utils/rateLimit.ts
@@ -38,6 +38,7 @@ export interface RateLimitErrorDetails {
 export interface RateLimitRetryDelayOptions {
   initialDelayMs: number;
   maxDelayMs: number;
+  error?: unknown;
 }
 
 /**
@@ -58,6 +59,10 @@ export function isRateLimitError(
   return false;
 }
 
+/**
+ * Extracts structured diagnostic fields from known HTTP and SSE rate-limit
+ * error shapes without changing retryability decisions.
+ */
 export function getRateLimitErrorDetails(
   error: unknown,
 ): RateLimitErrorDetails {
@@ -86,6 +91,13 @@ export function getRateLimitErrorDetails(
   };
 }
 
+/**
+ * Calculates the stream-side rate-limit retry delay.
+ *
+ * Retry-After is treated as a provider-supplied minimum wait, but the final
+ * delay is still capped by maxDelayMs so an interactive session cannot be
+ * parked indefinitely by an oversized header.
+ */
 export function getRateLimitRetryDelayMs(
   attempt: number,
   options: RateLimitRetryDelayOptions,
@@ -93,7 +105,12 @@ export function getRateLimitRetryDelayMs(
   const normalizedAttempt = Math.max(1, attempt);
   const exponentialDelayMs =
     options.initialDelayMs * Math.pow(2, normalizedAttempt - 1);
-  return Math.min(exponentialDelayMs, options.maxDelayMs);
+  const retryAfterMs = getRetryAfterDelayMs(options.error);
+  const delayMs =
+    retryAfterMs === null
+      ? exponentialDelayMs
+      : Math.max(exponentialDelayMs, retryAfterMs);
+  return Math.min(delayMs, options.maxDelayMs);
 }
 
 /**
@@ -223,6 +240,8 @@ function getJsonPayloads(error: unknown): unknown[] {
     }
   }
 
+  if (payloads.length > 0) return payloads;
+
   const jsonStart = message.indexOf('{');
   const jsonEnd = message.lastIndexOf('}');
   if (jsonStart !== -1 && jsonEnd > jsonStart) {
@@ -242,4 +261,46 @@ function getRawErrorMessage(error: unknown): string | null {
   if (error instanceof Error) return error.message;
   if (typeof error === 'string') return error;
   return null;
+}
+
+function getRetryAfterDelayMs(error: unknown): number | null {
+  const value = getHeaderValue(error, 'retry-after');
+  if (value === null) return null;
+
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) {
+    return seconds * 1000;
+  }
+
+  const retryAtMs = Date.parse(value);
+  if (!Number.isFinite(retryAtMs)) return null;
+
+  const delayMs = retryAtMs - Date.now();
+  return delayMs > 0 ? delayMs : 0;
+}
+
+function getHeaderValue(error: unknown, headerName: string): string | null {
+  if (!hasHeaders(error)) return null;
+
+  const { headers } = error;
+  if (typeof headers.get === 'function') {
+    const value = headers.get(headerName);
+    return typeof value === 'string' ? value : null;
+  }
+
+  if (typeof headers !== 'object' || headers === null) return null;
+
+  const lowerHeaderName = headerName.toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() !== lowerHeaderName) continue;
+    return typeof value === 'string' ? value : null;
+  }
+
+  return null;
+}
+
+function hasHeaders(error: unknown): error is {
+  headers: { get?: (name: string) => unknown } | Record<string, unknown>;
+} {
+  return typeof error === 'object' && error !== null && 'headers' in error;
 }

--- a/packages/core/src/utils/rateLimit.ts
+++ b/packages/core/src/utils/rateLimit.ts
@@ -185,14 +185,16 @@ function getProviderErrorPayload(error: unknown): ProviderErrorPayload | null {
       request_id?: unknown;
       requestId?: unknown;
     };
-    const nested = (payload as { error?: unknown }).error as
-      | {
-          code?: unknown;
-          message?: unknown;
-          request_id?: unknown;
-          requestId?: unknown;
-        }
-      | undefined;
+    const nestedError = (payload as { error?: unknown }).error;
+    const nested =
+      typeof nestedError === 'object' && nestedError !== null
+        ? (nestedError as {
+            code?: unknown;
+            message?: unknown;
+            request_id?: unknown;
+            requestId?: unknown;
+          })
+        : undefined;
     const source = nested ?? direct;
     const code =
       typeof source.code === 'string' || typeof source.code === 'number'
@@ -205,7 +207,11 @@ function getProviderErrorPayload(error: unknown): ProviderErrorPayload | null {
         ? source.request_id
         : typeof source.requestId === 'string'
           ? source.requestId
-          : undefined;
+          : typeof direct.request_id === 'string'
+            ? direct.request_id
+            : typeof direct.requestId === 'string'
+              ? direct.requestId
+              : undefined;
 
     if (
       code !== undefined ||
@@ -318,7 +324,7 @@ function hasHeaders(error: unknown): error is {
     typeof error === 'object' &&
     error !== null &&
     'headers' in error &&
-    error.headers !== null
+    error.headers != null
   );
 }
 
@@ -334,6 +340,6 @@ function hasResponseHeaders(error: unknown): error is {
     typeof error.response === 'object' &&
     error.response !== null &&
     'headers' in error.response &&
-    error.response.headers !== null
+    error.response.headers != null
   );
 }

--- a/packages/core/src/utils/rateLimit.ts
+++ b/packages/core/src/utils/rateLimit.ts
@@ -264,7 +264,9 @@ function getRawErrorMessage(error: unknown): string | null {
 }
 
 function getRetryAfterDelayMs(error: unknown): number | null {
-  const value = getHeaderValue(error, 'retry-after');
+  const value =
+    getHeaderValue(error, 'retry-after') ??
+    getResponseHeaderValue(error, 'retry-after');
   if (value === null) return null;
 
   const seconds = Number(value);
@@ -299,8 +301,31 @@ function getHeaderValue(error: unknown, headerName: string): string | null {
   return null;
 }
 
+function getResponseHeaderValue(
+  error: unknown,
+  headerName: string,
+): string | null {
+  if (!hasResponseHeaders(error)) return null;
+  return getHeaderValue(error.response, headerName);
+}
+
 function hasHeaders(error: unknown): error is {
   headers: { get?: (name: string) => unknown } | Record<string, unknown>;
 } {
   return typeof error === 'object' && error !== null && 'headers' in error;
+}
+
+function hasResponseHeaders(error: unknown): error is {
+  response: {
+    headers: { get?: (name: string) => unknown } | Record<string, unknown>;
+  };
+} {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'response' in error &&
+    typeof error.response === 'object' &&
+    error.response !== null &&
+    'headers' in error.response
+  );
 }

--- a/packages/core/src/utils/rateLimit.ts
+++ b/packages/core/src/utils/rateLimit.ts
@@ -314,7 +314,12 @@ function getResponseHeaderValue(
 function hasHeaders(error: unknown): error is {
   headers: { get?: (name: string) => unknown } | Record<string, unknown>;
 } {
-  return typeof error === 'object' && error !== null && 'headers' in error;
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'headers' in error &&
+    error.headers !== null
+  );
 }
 
 function hasResponseHeaders(error: unknown): error is {
@@ -328,6 +333,7 @@ function hasResponseHeaders(error: unknown): error is {
     'response' in error &&
     typeof error.response === 'object' &&
     error.response !== null &&
-    'headers' in error.response
+    'headers' in error.response &&
+    error.response.headers !== null
   );
 }

--- a/packages/core/src/utils/rateLimit.ts
+++ b/packages/core/src/utils/rateLimit.ts
@@ -27,6 +27,19 @@ export interface RetryInfo {
   skipDelay: () => void;
 }
 
+export interface RateLimitErrorDetails {
+  statusCode?: number;
+  providerCode?: string;
+  providerMessage?: string;
+  requestId?: string;
+  transport: 'http' | 'sse' | 'unknown';
+}
+
+export interface RateLimitRetryDelayOptions {
+  initialDelayMs: number;
+  maxDelayMs: number;
+}
+
 /**
  * Detects rate-limit / throttling errors and returns retry info.
  *
@@ -43,6 +56,44 @@ export function isRateLimitError(
   if (RATE_LIMIT_ERROR_CODES.has(code)) return true;
   if (extraCodes && extraCodes.includes(code)) return true;
   return false;
+}
+
+export function getRateLimitErrorDetails(
+  error: unknown,
+): RateLimitErrorDetails {
+  const statusCode = getErrorStatus(error);
+  const payload = getProviderErrorPayload(error);
+  const message = getRawErrorMessage(error);
+  const transport =
+    message?.includes('event:error') || message?.includes('HTTP_STATUS/')
+      ? 'sse'
+      : statusCode !== undefined
+        ? 'http'
+        : 'unknown';
+
+  return {
+    ...(statusCode !== undefined ? { statusCode } : {}),
+    ...(payload?.code !== undefined
+      ? { providerCode: String(payload.code) }
+      : {}),
+    ...(payload?.message !== undefined
+      ? { providerMessage: payload.message }
+      : {}),
+    ...(payload?.requestId !== undefined
+      ? { requestId: payload.requestId }
+      : {}),
+    transport,
+  };
+}
+
+export function getRateLimitRetryDelayMs(
+  attempt: number,
+  options: RateLimitRetryDelayOptions,
+): number {
+  const normalizedAttempt = Math.max(1, attempt);
+  const exponentialDelayMs =
+    options.initialDelayMs * Math.pow(2, normalizedAttempt - 1);
+  return Math.min(exponentialDelayMs, options.maxDelayMs);
 }
 
 /**
@@ -99,4 +150,96 @@ function getErrorCode(error: unknown): number | null {
   // `Throttling.AllocationQuota` where the SDK never surfaces a real HTTP
   // status because the stream opened with 200 OK).
   return getErrorStatus(error) ?? null;
+}
+
+interface ProviderErrorPayload {
+  code?: string | number;
+  message?: string;
+  requestId?: string;
+}
+
+function getProviderErrorPayload(error: unknown): ProviderErrorPayload | null {
+  for (const payload of getJsonPayloads(error)) {
+    const direct = payload as {
+      code?: unknown;
+      message?: unknown;
+      request_id?: unknown;
+      requestId?: unknown;
+    };
+    const nested = (payload as { error?: unknown }).error as
+      | {
+          code?: unknown;
+          message?: unknown;
+          request_id?: unknown;
+          requestId?: unknown;
+        }
+      | undefined;
+    const source = nested ?? direct;
+    const code =
+      typeof source.code === 'string' || typeof source.code === 'number'
+        ? source.code
+        : undefined;
+    const message =
+      typeof source.message === 'string' ? source.message : undefined;
+    const requestId =
+      typeof source.request_id === 'string'
+        ? source.request_id
+        : typeof source.requestId === 'string'
+          ? source.requestId
+          : undefined;
+
+    if (
+      code !== undefined ||
+      message !== undefined ||
+      requestId !== undefined
+    ) {
+      return { code, message, requestId };
+    }
+  }
+
+  if (isApiError(error)) {
+    return {
+      code: error.error.code,
+      message: error.error.message,
+    };
+  }
+
+  return null;
+}
+
+function getJsonPayloads(error: unknown): unknown[] {
+  const message = getRawErrorMessage(error);
+  if (!message) return [];
+
+  const payloads: unknown[] = [];
+  for (const line of message.split(/\r?\n/)) {
+    if (!line.startsWith('data:')) continue;
+    const data = line.slice('data:'.length).trim();
+    if (!data || data === '[DONE]') continue;
+    try {
+      payloads.push(JSON.parse(data) as unknown);
+    } catch {
+      /* ignore invalid SSE data */
+    }
+  }
+
+  const jsonStart = message.indexOf('{');
+  const jsonEnd = message.lastIndexOf('}');
+  if (jsonStart !== -1 && jsonEnd > jsonStart) {
+    try {
+      payloads.push(
+        JSON.parse(message.slice(jsonStart, jsonEnd + 1)) as unknown,
+      );
+    } catch {
+      /* ignore non-JSON message fragments */
+    }
+  }
+
+  return payloads;
+}
+
+function getRawErrorMessage(error: unknown): string | null {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  return null;
 }

--- a/packages/core/src/utils/rateLimit.ts
+++ b/packages/core/src/utils/rateLimit.ts
@@ -177,6 +177,8 @@ interface ProviderErrorPayload {
 
 function getProviderErrorPayload(error: unknown): ProviderErrorPayload | null {
   for (const payload of getJsonPayloads(error)) {
+    if (typeof payload !== 'object' || payload === null) continue;
+
     const direct = payload as {
       code?: unknown;
       message?: unknown;


### PR DESCRIPTION
## Summary

- What changed:
  - Add structured rate-limit diagnostics for stream-side retry failures, including transport type, HTTP status, provider error code/message, request id, retry decision, attempt, max retries, and retry delay.
  - Change SSE-side rate-limit retry from a fixed 60s wait to exponential backoff capped at 5 minutes.
  - Honor `Retry-After` for stream-side 429 retries as a provider minimum while still capping the final delay at 5 minutes.
  - Support both `error.headers` and `error.response.headers` Retry-After shapes.
  - Add regression coverage for DashScope-style SSE `HTTP_STATUS/429` errors, stream retry delay behavior, capped `Retry-After`, response-header Retry-After handling, HTTP-date parsing, malformed headers, and defensive diagnostic parsing.
- Why it changed:
  - Issue #3004 shows that provider-side throttling can surface after the stream has already started, so the existing HTTP request creation retry path is not enough.
  - The old stream retry path used a fixed delay and did not log enough structured context to diagnose whether an error was HTTP, SSE, retryable, or exhausted.
- Reviewer focus:
  - Whether the stream-side retry delay semantics are appropriate for interactive use.
  - Whether the structured debug fields are useful without being too noisy.
  - Whether this PR stays scoped to PR 1 of the retry improvement plan, leaving broader retry policy unification and provider-specific fallback to follow-up PRs.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/utils/rateLimit.test.ts src/core/geminiChat.test.ts
  npm -w packages/core run typecheck
  npm -w packages/core run lint
  npm run build
  ```
- Prompts / inputs used:
  - Unit tests use DashScope-style streamed SSE errors such as `event:error`, `:HTTP_STATUS/429`, and `data:{"request_id":"...","code":"Throttling.AllocationQuota",...}`.
  - Unit tests also cover `Retry-After` from direct headers, response headers, Headers-like objects, case-insensitive header keys, HTTP-date values, malformed values, and null/undefined header shapes.
- Expected result:
  - Repeated stream-side 429 errors should yield increasing retry delays instead of repeated fixed 60s waits.
  - `Retry-After` should be treated as a minimum wait but must not bypass the 5-minute cap.
  - Debug logs should include enough structured fields to tell which retry path and provider error were involved.
- Observed result:
  - Targeted tests passed: `Test Files 2 passed (2), Tests 83 passed (83)`.
  - `npm -w packages/core run typecheck` passed.
  - `npm -w packages/core run lint` passed.
  - `npm run build` passed. Existing warnings remain in `packages/vscode-ide-companion` lint output and stale Browserslist data; no build errors.
- Quickest reviewer verification path:
  ```bash
  cd packages/core && npx vitest run src/utils/rateLimit.test.ts src/core/geminiChat.test.ts
  ```

## Scope / Risk

- Main risk or tradeoff:
  - This makes repeated stream-side throttling wait longer than before. The cap remains 5 minutes, and the user can still skip the retry delay from the retry UI.
- Not covered / not validated:
  - This PR does not unify the HTTP request creation retry path with the SSE stream retry path; that is planned for a follow-up PR.
  - This PR does not implement provider-specific fail-fast behavior for quota-exhausted cases such as `Throttling.AllocationQuota`; that belongs to the later error-classification/provider-specific PR.
  - The pre-existing `InvalidStreamError` dead-code cleanup noted by Copilot is intentionally left for a separate cleanup issue or PR.
  - No live provider E2E was run because the behavior is covered with deterministic stream error fixtures.
- Breaking changes / migration notes:
  - None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Tested locally on macOS with targeted `npx vitest`, `npm run build`, package typecheck, and package lint.
- Windows and Linux were not tested locally.

## Linked Issues / Bugs

Related to #3004.

