### PR TITLE
feat(cli): include monitors in /tasks + add interactive-mode hint

### DIFF
--- a/packages/cli/src/ui/commands/tasksCommand.test.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.test.ts
@@ -239,6 +239,21 @@ describe('tasksCommand', () => {
     expect(result.content).not.toContain('output: ');
   });
 
+  it('renders cancelled monitor with eventCount suffix', async () => {
+    getMonitors.mockReturnValue([
+      monitorEntry({
+        monitorId: 'mon_cancel',
+        description: 'tail noisy log',
+        status: 'cancelled',
+        eventCount: 3,
+        endTime: Date.now() - 200,
+      }),
+    ]);
+    const result = await tasksCommand.action!(context, '');
+    if (!result || result.type !== 'message') throw new Error('no result');
+    expect(result.content).toContain('[mon_cancel] cancelled (3 events)');
+  });
+
   it('singular form: "1 event" not "1 events"', async () => {
     getMonitors.mockReturnValue([
       monitorEntry({ monitorId: 'mon_one', eventCount: 1 }),
@@ -273,6 +288,28 @@ describe('tasksCommand', () => {
     if (!withHint || withHint.type !== 'message') throw new Error('no result');
     expect(withHint.content).toContain('Ctrl+T');
     expect(withHint.content).toContain('Background tasks (1 total)');
+  });
+
+  it('suppresses the Ctrl+T hint in acp mode (no dialog to point at)', async () => {
+    // ACP / IDE-bridge consumers (Zed, etc.) have no TTY for the
+    // dialog — same suppression rationale as non_interactive. Pinning
+    // this so a future regression that switches to `!== 'non_interactive'`
+    // (which would wrongly show the hint to ACP) fails loudly.
+    getShells.mockReturnValue([entry({ shellId: 'bg_x' })]);
+    const acpCtx = createMockCommandContext({
+      executionMode: 'acp',
+      services: {
+        config: {
+          getBackgroundShellRegistry: () => ({ getAll: getShells }),
+          getBackgroundTaskRegistry: () => ({ getAll: getAgents }),
+          getMonitorRegistry: () => ({ getAll: getMonitors }),
+        },
+      },
+    } as unknown as Parameters<typeof createMockCommandContext>[0]);
+    const result = await tasksCommand.action!(acpCtx, '');
+    if (!result || result.type !== 'message') throw new Error('no result');
+    expect(result.content).not.toContain('Ctrl+T');
+    expect(result.content).toContain('Background tasks (1 total)');
   });
 
   it('merges all three kinds and orders them by startTime', async () => {

--- a/packages/cli/src/ui/commands/tasksCommand.test.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.test.ts
@@ -324,6 +324,32 @@ describe('tasksCommand', () => {
     expect(result.content).toContain('Background tasks (1 total)');
   });
 
+  it('escapes ANSI control sequences embedded in entry fields', async () => {
+    // A monitor whose description / error contain raw ANSI escape codes
+    // (e.g. `\x1b[2J` clear-screen, `\x1b[31m...` colour) must not reach
+    // the terminal verbatim — a malicious tool description or spawn
+    // error otherwise could corrupt display. `escapeAnsiCtrlCodes`
+    // converts them to literal `[...]` sequences that render as
+    // text instead of being interpreted by the terminal.
+    getMonitors.mockReturnValue([
+      monitorEntry({
+        monitorId: 'mon_evil',
+        description: 'bad \x1b[2Jthing',
+        status: 'failed',
+        error: 'spawn \x1b[31mENOENT\x1b[0m',
+        eventCount: 0,
+      }),
+    ]);
+    const result = await tasksCommand.action!(context, '');
+    if (!result || result.type !== 'message') throw new Error('no result');
+    // No raw ESC byte in the output.
+    expect(result.content).not.toContain('\x1b');
+    // The escaped form (literal backslash-u-001b) should appear, proving
+    // the sanitizer ran rather than dropping the chars.
+    expect(result.content).toContain('\\u001b[2J');
+    expect(result.content).toContain('\\u001b[31m');
+  });
+
   it('merges all three kinds and orders them by startTime', async () => {
     const now = Date.now();
     getAgents.mockReturnValue([

--- a/packages/cli/src/ui/commands/tasksCommand.test.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.test.ts
@@ -74,6 +74,12 @@ describe('tasksCommand', () => {
     getShells = vi.fn().mockReturnValue([]);
     getAgents = vi.fn().mockReturnValue([]);
     getMonitors = vi.fn().mockReturnValue([]);
+    // Override createMockCommandContext's `'interactive'` default so the
+    // hint-suppression tests below see the expected default-no-hint
+    // behaviour. The `shows the dialog hint only in interactive mode`
+    // and `acp mode` tests rebind their own context with the mode they
+    // care about; the rest don't assert on the hint so this default
+    // doesn't affect their expectations.
     context = createMockCommandContext({
       executionMode: 'non_interactive',
       services: {
@@ -324,34 +330,37 @@ describe('tasksCommand', () => {
     expect(result.content).toContain('Background tasks (1 total)');
   });
 
-  it('escapes ANSI control sequences embedded in entry fields', async () => {
-    // A monitor whose description / error contain raw ANSI escape codes
-    // (e.g. `\x1b[2J` clear-screen, `\x1b[31m...` colour) must not reach
-    // the terminal verbatim — a malicious tool description or spawn
-    // error otherwise could corrupt display. `escapeAnsiCtrlCodes` runs
-    // each ESC byte through JSON.stringify slice-trim, producing the
-    // literal six-char sequence `\u001b` (backslash-u-0-0-1-b) while
-    // the rest of the CSI body (`[2J`, `[31m`) stays intact as printable
-    // text. The assertions below pin both halves: no raw `\x1b` bytes
-    // survive, and the visible `\u001b[...]` form appears as proof the
-    // sanitizer ran rather than dropping the chars.
+  it('strips ANSI escape sequences and bare C0 control bytes from entry fields', async () => {
+    // A monitor whose description / command / error contain raw ANSI
+    // escape codes or bare C0 control bytes (BEL 0x07 audible bell,
+    // BS 0x08 cursor backspace, FF 0x0C form-feed, ...) must not reach
+    // the terminal verbatim - a malicious tool description or spawn
+    // error could otherwise corrupt display, move the cursor, or beep.
+    // `stripUnsafeCharacters` removes both classes (ANSI sequences via
+    // strip-ansi, isolated control bytes via the C0/C1 filter) while
+    // preserving TAB / CR / LF needed for line breaks.
     getMonitors.mockReturnValue([
       monitorEntry({
         monitorId: 'mon_evil',
-        description: 'bad \x1b[2Jthing',
+        description: 'bad \x1b[2Jthing\x07', // ANSI clear-screen + BEL
         status: 'failed',
-        error: 'spawn \x1b[31mENOENT\x1b[0m',
+        error: 'spawn \x1b[31mENOENT\x1b[0m\x08\x08', // ANSI colour + 2 BS
         eventCount: 0,
       }),
     ]);
     const result = await tasksCommand.action!(context, '');
     if (!result || result.type !== 'message') throw new Error('no result');
-    // No raw ESC byte in the output.
-    expect(result.content).not.toContain('\x1b');
-    // The escaped form (literal backslash-u-001b) should appear, proving
-    // the sanitizer ran rather than dropping the chars.
-    expect(result.content).toContain('\\u001b[2J');
-    expect(result.content).toContain('\\u001b[31m');
+    // No raw control bytes survive.
+    expect(result.content).not.toContain('\x1b'); // ESC
+    expect(result.content).not.toContain('\x07'); // BEL
+    expect(result.content).not.toContain('\x08'); // BS
+    // Surrounding printable text is preserved so the user still gets a
+    // useful (just safe) message.
+    expect(result.content).toContain('bad thing');
+    expect(result.content).toContain('spawn ENOENT');
+    // TAB / CR / LF stay through - the sanitizer must not eat the line
+    // breaks that separate task entries.
+    expect(result.content).toContain('\n');
   });
 
   it('merges all three kinds and orders them by startTime', async () => {

--- a/packages/cli/src/ui/commands/tasksCommand.test.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.test.ts
@@ -265,13 +265,13 @@ describe('tasksCommand', () => {
     expect(result.content).not.toContain('1 events');
   });
 
-  it('shows the Ctrl+T hint only in interactive mode', async () => {
+  it('shows the dialog hint only in interactive mode', async () => {
     getShells.mockReturnValue([entry({ shellId: 'bg_x' })]);
 
     // non_interactive (default in beforeEach) — no hint.
     const noHint = await tasksCommand.action!(context, '');
     if (!noHint || noHint.type !== 'message') throw new Error('no result');
-    expect(noHint.content).not.toContain('Ctrl+T');
+    expect(noHint.content).not.toContain('Tip:');
 
     // Re-bind the same config under an interactive context.
     const interactiveCtx = createMockCommandContext({
@@ -286,11 +286,17 @@ describe('tasksCommand', () => {
     } as unknown as Parameters<typeof createMockCommandContext>[0]);
     const withHint = await tasksCommand.action!(interactiveCtx, '');
     if (!withHint || withHint.type !== 'message') throw new Error('no result');
-    expect(withHint.content).toContain('Ctrl+T');
+    expect(withHint.content).toContain('Tip:');
+    // Pin the actual key path so a regression that goes back to the
+    // wrong `Ctrl+T` text (which is bound to the MCP descriptions
+    // toggle, not the Background tasks dialog) fails loudly.
+    expect(withHint.content).toContain('↓');
+    expect(withHint.content).toContain('Enter');
+    expect(withHint.content).not.toContain('Ctrl+T');
     expect(withHint.content).toContain('Background tasks (1 total)');
   });
 
-  it('suppresses the Ctrl+T hint in acp mode (no dialog to point at)', async () => {
+  it('suppresses the dialog hint in acp mode (no dialog to point at)', async () => {
     // ACP / IDE-bridge consumers (Zed, etc.) have no TTY for the
     // dialog — same suppression rationale as non_interactive. Pinning
     // this so a future regression that switches to `!== 'non_interactive'`
@@ -308,7 +314,7 @@ describe('tasksCommand', () => {
     } as unknown as Parameters<typeof createMockCommandContext>[0]);
     const result = await tasksCommand.action!(acpCtx, '');
     if (!result || result.type !== 'message') throw new Error('no result');
-    expect(result.content).not.toContain('Ctrl+T');
+    expect(result.content).not.toContain('Tip:');
     expect(result.content).toContain('Background tasks (1 total)');
   });
 

--- a/packages/cli/src/ui/commands/tasksCommand.test.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.test.ts
@@ -232,7 +232,13 @@ describe('tasksCommand', () => {
     expect(result.content).toContain(
       '[mon_auto] completed (Max events reached, 1000 events)',
     );
-    expect(result.content).toContain('[mon_fail] failed: spawn ENOENT');
+    // Pin the full string (not just the prefix) so a regression that
+    // drops the `(N events)` suffix from monitor's failed branch fails
+    // loudly. The other status branches above already have full-string
+    // assertions; this one was incidentally shorter.
+    expect(result.content).toContain(
+      '[mon_fail] failed: spawn ENOENT (0 events)',
+    );
     // No on-disk output file for monitors — events stream via
     // task_notification, so the "output:" line should not appear for
     // any monitor entry.

--- a/packages/cli/src/ui/commands/tasksCommand.test.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.test.ts
@@ -11,6 +11,7 @@ import { createMockCommandContext } from '../../test-utils/mockCommandContext.js
 import type {
   BackgroundShellEntry,
   BackgroundTaskEntry,
+  MonitorEntry,
 } from '@qwen-code/qwen-code-core';
 
 type AgentTaskTestEntry = BackgroundTaskEntry & {
@@ -46,19 +47,40 @@ function agentEntry(
   };
 }
 
+function monitorEntry(overrides: Partial<MonitorEntry> = {}): MonitorEntry {
+  return {
+    monitorId: 'mon-aaaaaaaa',
+    command: 'tail -f app.log',
+    description: 'watch app logs',
+    status: 'running',
+    startTime: Date.now() - 4_000,
+    abortController: new AbortController(),
+    eventCount: 0,
+    lastEventTime: 0,
+    maxEvents: 1000,
+    idleTimeoutMs: 300_000,
+    droppedLines: 0,
+    ...overrides,
+  };
+}
+
 describe('tasksCommand', () => {
   let context: CommandContext;
   let getShells: ReturnType<typeof vi.fn>;
   let getAgents: ReturnType<typeof vi.fn>;
+  let getMonitors: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     getShells = vi.fn().mockReturnValue([]);
     getAgents = vi.fn().mockReturnValue([]);
+    getMonitors = vi.fn().mockReturnValue([]);
     context = createMockCommandContext({
+      executionMode: 'non_interactive',
       services: {
         config: {
           getBackgroundShellRegistry: () => ({ getAll: getShells }),
           getBackgroundTaskRegistry: () => ({ getAll: getAgents }),
+          getMonitorRegistry: () => ({ getAll: getMonitors }),
         },
       },
     } as unknown as Parameters<typeof createMockCommandContext>[0]);
@@ -156,5 +178,123 @@ describe('tasksCommand', () => {
       '[agent_pause] paused (resume blocked): Subagent "researcher" is no longer available.',
     );
     expect(result.content).toContain('[bg_shell] running');
+  });
+
+  it('lists monitor entries with eventCount and exit / error suffixes', async () => {
+    getMonitors.mockReturnValue([
+      monitorEntry({
+        monitorId: 'mon_run',
+        description: 'tail dev server log',
+        status: 'running',
+        eventCount: 12,
+        pid: 9999,
+      }),
+      monitorEntry({
+        monitorId: 'mon_done',
+        description: 'tail short script',
+        status: 'completed',
+        exitCode: 0,
+        eventCount: 7,
+        endTime: Date.now() - 1_000,
+      }),
+      monitorEntry({
+        monitorId: 'mon_auto',
+        description: 'tail noisy log',
+        status: 'completed',
+        error: 'Max events reached',
+        eventCount: 1000,
+        endTime: Date.now() - 500,
+      }),
+      monitorEntry({
+        monitorId: 'mon_fail',
+        description: 'tail bad path',
+        status: 'failed',
+        error: 'spawn ENOENT',
+        eventCount: 0,
+        endTime: Date.now() - 100,
+      }),
+    ]);
+
+    const result = await tasksCommand.action!(context, '');
+    if (!result || result.type !== 'message') {
+      throw new Error('expected message result');
+    }
+
+    expect(result.content).toContain('Background tasks (4 total)');
+    // Pluralised eventCount + pid for the running monitor.
+    expect(result.content).toContain('[mon_run] running (12 events)');
+    expect(result.content).toContain('pid=9999');
+    expect(result.content).toContain('tail dev server log');
+    // Natural completion path uses exitCode + eventCount.
+    expect(result.content).toContain('[mon_done] completed (exit 0, 7 events)');
+    // Auto-stop path uses the error string instead of exit code (so users
+    // see WHY the monitor stopped, not just that it did).
+    expect(result.content).toContain(
+      '[mon_auto] completed (Max events reached, 1000 events)',
+    );
+    expect(result.content).toContain('[mon_fail] failed: spawn ENOENT');
+    // No on-disk output file for monitors — events stream via
+    // task_notification, so the "output:" line should not appear for
+    // any monitor entry.
+    expect(result.content).not.toContain('output: ');
+  });
+
+  it('singular form: "1 event" not "1 events"', async () => {
+    getMonitors.mockReturnValue([
+      monitorEntry({ monitorId: 'mon_one', eventCount: 1 }),
+    ]);
+    const result = await tasksCommand.action!(context, '');
+    if (!result || result.type !== 'message') throw new Error('no result');
+    expect(result.content).toContain('running (1 event)');
+    // Guard against "1 event" matching the prefix of "1 events" by accident.
+    expect(result.content).not.toContain('1 events');
+  });
+
+  it('shows the Ctrl+T hint only in interactive mode', async () => {
+    getShells.mockReturnValue([entry({ shellId: 'bg_x' })]);
+
+    // non_interactive (default in beforeEach) — no hint.
+    const noHint = await tasksCommand.action!(context, '');
+    if (!noHint || noHint.type !== 'message') throw new Error('no result');
+    expect(noHint.content).not.toContain('Ctrl+T');
+
+    // Re-bind the same config under an interactive context.
+    const interactiveCtx = createMockCommandContext({
+      executionMode: 'interactive',
+      services: {
+        config: {
+          getBackgroundShellRegistry: () => ({ getAll: getShells }),
+          getBackgroundTaskRegistry: () => ({ getAll: getAgents }),
+          getMonitorRegistry: () => ({ getAll: getMonitors }),
+        },
+      },
+    } as unknown as Parameters<typeof createMockCommandContext>[0]);
+    const withHint = await tasksCommand.action!(interactiveCtx, '');
+    if (!withHint || withHint.type !== 'message') throw new Error('no result');
+    expect(withHint.content).toContain('Ctrl+T');
+    expect(withHint.content).toContain('Background tasks (1 total)');
+  });
+
+  it('merges all three kinds and orders them by startTime', async () => {
+    const now = Date.now();
+    getAgents.mockReturnValue([
+      agentEntry({ agentId: 'a_late', startTime: now - 1_000 }),
+    ]);
+    getShells.mockReturnValue([
+      entry({ shellId: 'bg_early', startTime: now - 10_000 }),
+    ]);
+    getMonitors.mockReturnValue([
+      monitorEntry({ monitorId: 'mon_mid', startTime: now - 5_000 }),
+    ]);
+
+    const result = await tasksCommand.action!(context, '');
+    if (!result || result.type !== 'message') throw new Error('no result');
+    const order = ['bg_early', 'mon_mid', 'a_late'].map((id) =>
+      result.content.indexOf(`[${id}]`),
+    );
+    // All present and strictly increasing — proves startTime sort.
+    expect(order.every((i) => i >= 0)).toBe(true);
+    expect(order[0]).toBeLessThan(order[1]);
+    expect(order[1]).toBeLessThan(order[2]);
   });
 });

--- a/packages/cli/src/ui/commands/tasksCommand.test.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.test.ts
@@ -328,9 +328,13 @@ describe('tasksCommand', () => {
     // A monitor whose description / error contain raw ANSI escape codes
     // (e.g. `\x1b[2J` clear-screen, `\x1b[31m...` colour) must not reach
     // the terminal verbatim — a malicious tool description or spawn
-    // error otherwise could corrupt display. `escapeAnsiCtrlCodes`
-    // converts them to literal `[...]` sequences that render as
-    // text instead of being interpreted by the terminal.
+    // error otherwise could corrupt display. `escapeAnsiCtrlCodes` runs
+    // each ESC byte through JSON.stringify slice-trim, producing the
+    // literal six-char sequence `\u001b` (backslash-u-0-0-1-b) while
+    // the rest of the CSI body (`[2J`, `[31m`) stays intact as printable
+    // text. The assertions below pin both halves: no raw `\x1b` bytes
+    // survive, and the visible `\u001b[...]` form appears as proof the
+    // sanitizer ran rather than dropping the chars.
     getMonitors.mockReturnValue([
       monitorEntry({
         monitorId: 'mon_evil',

--- a/packages/cli/src/ui/commands/tasksCommand.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.ts
@@ -28,8 +28,13 @@ type TaskEntry = AgentTaskEntry | ShellTaskEntry | MonitorTaskEntry;
 
 function statusLabel(entry: TaskEntry): string {
   switch (entry.kind) {
-    case 'agent':
-      switch (entry.status) {
+    case 'agent': {
+      // Bind to a local so the `never`-typed default below operates on a
+      // narrow-able value. Using `entry.status` directly inside the default
+      // hits TS narrowing the whole `entry` to `never` after the case arms
+      // exhaust the discriminated union, breaking the `.status` access.
+      const status = entry.status;
+      switch (status) {
         case 'completed':
           return 'completed';
         case 'failed':
@@ -43,14 +48,16 @@ function statusLabel(entry: TaskEntry): string {
         case 'running':
           return 'running';
         default: {
-          const _exhaustive: never = entry.status;
+          const _exhaustive: never = status;
           throw new Error(
             `statusLabel(agent): unknown status: ${JSON.stringify(_exhaustive)}`,
           );
         }
       }
-    case 'shell':
-      switch (entry.status) {
+    }
+    case 'shell': {
+      const status = entry.status;
+      switch (status) {
         case 'completed':
           return `completed (exit ${entry.exitCode ?? '?'})`;
         case 'failed':
@@ -60,17 +67,19 @@ function statusLabel(entry: TaskEntry): string {
         case 'running':
           return 'running';
         default: {
-          const _exhaustive: never = entry.status;
+          const _exhaustive: never = status;
           throw new Error(
             `statusLabel(shell): unknown status: ${JSON.stringify(_exhaustive)}`,
           );
         }
       }
+    }
     case 'monitor': {
       // Append eventCount as a glanceable signal for activity. error (set
       // on `failed` and on auto-stopped `completed`) is included verbatim.
       const events = `${entry.eventCount} event${entry.eventCount === 1 ? '' : 's'}`;
-      switch (entry.status) {
+      const status = entry.status;
+      switch (status) {
         case 'completed':
           return entry.error
             ? `completed (${entry.error}, ${events})`
@@ -82,7 +91,7 @@ function statusLabel(entry: TaskEntry): string {
         case 'running':
           return `running (${events})`;
         default: {
-          const _exhaustive: never = entry.status;
+          const _exhaustive: never = status;
           throw new Error(
             `statusLabel(monitor): unknown status: ${JSON.stringify(_exhaustive)}`,
           );

--- a/packages/cli/src/ui/commands/tasksCommand.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.ts
@@ -14,7 +14,7 @@ import type { SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
 import { t } from '../../i18n/index.js';
 import { formatDuration } from '../utils/formatters.js';
-import { escapeAnsiCtrlCodes } from '../utils/textUtils.js';
+import { stripUnsafeCharacters } from '../utils/textUtils.js';
 
 type AgentTaskEntry = BackgroundTaskEntry & {
   kind: 'agent';
@@ -41,8 +41,13 @@ function statusLabel(entry: TaskEntry): string {
             ? `paused (resume blocked): ${entry.resumeBlockedReason}`
             : 'paused';
         case 'running':
-        default:
           return 'running';
+        default: {
+          const _exhaustive: never = entry.status;
+          throw new Error(
+            `statusLabel(agent): unknown status: ${JSON.stringify(_exhaustive)}`,
+          );
+        }
       }
     case 'shell':
       switch (entry.status) {
@@ -54,8 +59,12 @@ function statusLabel(entry: TaskEntry): string {
           return 'cancelled';
         case 'running':
           return 'running';
-        default:
-          return 'running';
+        default: {
+          const _exhaustive: never = entry.status;
+          throw new Error(
+            `statusLabel(shell): unknown status: ${JSON.stringify(_exhaustive)}`,
+          );
+        }
       }
     case 'monitor': {
       // Append eventCount as a glanceable signal for activity. error (set
@@ -72,8 +81,12 @@ function statusLabel(entry: TaskEntry): string {
           return `cancelled (${events})`;
         case 'running':
           return `running (${events})`;
-        default:
-          return `running (${events})`;
+        default: {
+          const _exhaustive: never = entry.status;
+          throw new Error(
+            `statusLabel(monitor): unknown status: ${JSON.stringify(_exhaustive)}`,
+          );
+        }
       }
     }
     default: {
@@ -228,21 +241,22 @@ export const tasksCommand: SlashCommand = {
 
     // Defense in depth: registry entries carry user-supplied / process-
     // supplied strings (description, command, error from spawn / settle).
-    // A maliciously-crafted value containing raw ANSI escape sequences
-    // (CSI / OSC / SGR — anything starting with ESC, the kind matched
-    // by `ansi-regex`) could otherwise reach the terminal verbatim and
-    // corrupt display. `escapeAnsiCtrlCodes` is scoped to those
-    // sequences only — it does NOT escape isolated C0/C1 control bytes
-    // like BEL, BS, or VT; if those become a concern we'd need to
-    // layer `node:util`'s `stripVTControlCharacters` on top. For the
-    // common case (no escape sequences present) the helper is a no-op
-    // and returns the original string. Wrapping the joined output once
-    // covers every field — including any future kind's fields —
-    // without per-site sanitization sprawl.
+    // A maliciously-crafted value could otherwise reach the terminal
+    // verbatim and corrupt display via:
+    //   - ANSI escape sequences (CSI / OSC / SGR — start with ESC)
+    //   - bare C0 control bytes (BEL 0x07 audible bell, BS 0x08 cursor
+    //     back, VT 0x0B, FF 0x0C, …)
+    //   - C1 control bytes (0x80–0x9F)
+    //   - VT control sequences
+    // `stripUnsafeCharacters` (textUtils.ts) handles all four classes in
+    // one pass while preserving TAB / CR / LF that we genuinely need
+    // for line breaks and tabular formatting. Wrapping the joined
+    // output once covers every field — including any future kind's
+    // fields — without per-site sanitization sprawl.
     return {
       type: 'message' as const,
       messageType: 'info' as const,
-      content: escapeAnsiCtrlCodes(lines.join('\n')),
+      content: stripUnsafeCharacters(lines.join('\n')),
     };
   },
 };

--- a/packages/cli/src/ui/commands/tasksCommand.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.ts
@@ -8,6 +8,7 @@ import {
   buildBackgroundEntryLabel,
   type BackgroundShellEntry,
   type BackgroundTaskEntry,
+  type MonitorEntry,
 } from '@qwen-code/qwen-code-core';
 import type { SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
@@ -20,8 +21,9 @@ type AgentTaskEntry = BackgroundTaskEntry & {
 };
 
 type ShellTaskEntry = BackgroundShellEntry & { kind: 'shell' };
+type MonitorTaskEntry = MonitorEntry & { kind: 'monitor' };
 
-type TaskEntry = AgentTaskEntry | ShellTaskEntry;
+type TaskEntry = AgentTaskEntry | ShellTaskEntry | MonitorTaskEntry;
 
 function statusLabel(entry: TaskEntry): string {
   if (entry.kind === 'agent') {
@@ -42,17 +44,37 @@ function statusLabel(entry: TaskEntry): string {
     }
   }
 
+  if (entry.kind === 'shell') {
+    switch (entry.status) {
+      case 'completed':
+        return `completed (exit ${entry.exitCode ?? '?'})`;
+      case 'failed':
+        return `failed: ${entry.error ?? 'unknown error'}`;
+      case 'cancelled':
+        return 'cancelled';
+      case 'running':
+        return 'running';
+      default:
+        return 'running';
+    }
+  }
+
+  // monitor — append eventCount as a glanceable signal for activity. error
+  // (set on `failed` and on auto-stopped `completed`) is included verbatim.
+  const events = `${entry.eventCount} event${entry.eventCount === 1 ? '' : 's'}`;
   switch (entry.status) {
     case 'completed':
-      return `completed (exit ${entry.exitCode ?? '?'})`;
+      return entry.error
+        ? `completed (${entry.error}, ${events})`
+        : `completed (exit ${entry.exitCode ?? '?'}, ${events})`;
     case 'failed':
-      return `failed: ${entry.error ?? 'unknown error'}`;
+      return `failed: ${entry.error ?? 'unknown error'} (${events})`;
     case 'cancelled':
-      return 'cancelled';
+      return `cancelled (${events})`;
     case 'running':
-      return 'running';
+      return `running (${events})`;
     default:
-      return 'running';
+      return `running (${events})`;
   }
 }
 
@@ -60,23 +82,49 @@ function taskLabel(entry: TaskEntry): string {
   if (entry.kind === 'agent') {
     return buildBackgroundEntryLabel(entry);
   }
-  return entry.command;
+  if (entry.kind === 'shell') {
+    return entry.command;
+  }
+  return entry.description;
 }
 
 function taskId(entry: TaskEntry): string {
-  return entry.kind === 'agent' ? entry.agentId : entry.shellId;
+  switch (entry.kind) {
+    case 'agent':
+      return entry.agentId;
+    case 'shell':
+      return entry.shellId;
+    case 'monitor':
+      return entry.monitorId;
+    default: {
+      const _exhaustive: never = entry;
+      throw new Error(
+        `taskId: unknown TaskEntry kind: ${JSON.stringify(_exhaustive)}`,
+      );
+    }
+  }
 }
 
 function taskOutputPath(entry: TaskEntry): string | undefined {
-  return entry.kind === 'agent' ? entry.outputFile : entry.outputPath;
+  if (entry.kind === 'agent') return entry.outputFile;
+  if (entry.kind === 'shell') return entry.outputPath;
+  // Monitors stream to the agent via task_notification rather than a
+  // file on disk — no output path to surface here.
+  return undefined;
 }
 
 export const tasksCommand: SlashCommand = {
   name: 'tasks',
   get description() {
-    return t('List background tasks');
+    return t('List background tasks (text dump — interactive UI is Ctrl+T)');
   },
   kind: CommandKind.BUILT_IN,
+  // Kept on all three modes: the interactive dialog (Ctrl+T) is the
+  // richer surface when a TTY is available, but `non_interactive` and
+  // `acp` consumers (headless `-p`, IDE bridges, SDK) have no dialog
+  // and rely on this text dump as the only way to inspect background
+  // task state. See the interactive-mode hint at the top of the output
+  // for the soft redirect.
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
   action: async (context) => {
     const { config } = context.services;
@@ -96,7 +144,11 @@ export const tasksCommand: SlashCommand = {
       .getBackgroundShellRegistry()
       .getAll()
       .map((entry) => ({ ...entry, kind: 'shell' as const }));
-    const entries = [...agentEntries, ...shellEntries].sort(
+    const monitorEntries: MonitorTaskEntry[] = config
+      .getMonitorRegistry()
+      .getAll()
+      .map((entry) => ({ ...entry, kind: 'monitor' as const }));
+    const entries = [...agentEntries, ...shellEntries, ...monitorEntries].sort(
       (a, b) => a.startTime - b.startTime,
     );
 
@@ -109,14 +161,26 @@ export const tasksCommand: SlashCommand = {
     }
 
     const now = Date.now();
-    const lines: string[] = [`Background tasks (${entries.length} total)`, ''];
+    const lines: string[] = [];
+    // Soft redirect: in interactive mode the dialog (Ctrl+T) is richer
+    // (per-entry detail view, live updates, cancel keybinding). Don't
+    // show the hint in non_interactive / acp — those consumers have no
+    // dialog to point at and the noise just clutters their output.
+    if (context.executionMode === 'interactive') {
+      lines.push(
+        'Tip: Ctrl+T opens the interactive Background tasks dialog with detail view + live updates.',
+        '',
+      );
+    }
+    lines.push(`Background tasks (${entries.length} total)`, '');
     for (const entry of entries) {
       const endTime = entry.endTime ?? now;
       const runtime = formatDuration(endTime - entry.startTime, {
         hideTrailingZeros: true,
       });
       const pidPart =
-        entry.kind === 'shell' && entry.pid !== undefined
+        (entry.kind === 'shell' || entry.kind === 'monitor') &&
+        entry.pid !== undefined
           ? ` pid=${entry.pid}`
           : '';
       lines.push(

--- a/packages/cli/src/ui/commands/tasksCommand.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.ts
@@ -123,15 +123,17 @@ function taskOutputPath(entry: TaskEntry): string | undefined {
 export const tasksCommand: SlashCommand = {
   name: 'tasks',
   get description() {
-    return t('List background tasks (text dump — interactive UI is Ctrl+T)');
+    return t(
+      'List background tasks (text dump — interactive dialog opens via the footer pill)',
+    );
   },
   kind: CommandKind.BUILT_IN,
-  // Kept on all three modes: the interactive dialog (Ctrl+T) is the
-  // richer surface when a TTY is available, but `non_interactive` and
-  // `acp` consumers (headless `-p`, IDE bridges, SDK) have no dialog
-  // and rely on this text dump as the only way to inspect background
-  // task state. See the interactive-mode hint at the top of the output
-  // for the soft redirect.
+  // Kept on all three modes: the interactive dialog (reachable via ↓ +
+  // Enter on the footer Background tasks pill) is the richer surface
+  // when a TTY is available, but `non_interactive` and `acp` consumers
+  // (headless `-p`, IDE bridges, SDK) have no dialog and rely on this
+  // text dump as the only way to inspect background task state. See the
+  // interactive-mode hint at the top of the output for the soft redirect.
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
   action: async (context) => {
     const { config } = context.services;
@@ -169,14 +171,16 @@ export const tasksCommand: SlashCommand = {
 
     const now = Date.now();
     const lines: string[] = [];
-    // Soft redirect: in interactive mode the dialog (Ctrl+T) is richer
-    // (per-entry detail view, live updates, cancel keybinding). Don't
-    // show the hint in non_interactive / acp — those consumers have no
-    // dialog to point at and the noise just clutters their output.
+    // Soft redirect: in interactive mode the dialog is richer (per-entry
+    // detail view, live updates, cancel keybinding). Don't show the hint
+    // in non_interactive / acp — those consumers have no dialog to point
+    // at and the noise just clutters their output. Note: the dialog
+    // opens via Down arrow + Enter on the footer pill (NOT Ctrl+T —
+    // that's bound to the MCP tool descriptions toggle elsewhere).
     if (context.executionMode === 'interactive') {
       lines.push(
         t(
-          'Tip: Ctrl+T opens the interactive Background tasks dialog with detail view + live updates.',
+          'Tip: press ↓ from an empty composer then Enter to open the interactive Background tasks dialog with detail view + live updates.',
         ),
         '',
       );

--- a/packages/cli/src/ui/commands/tasksCommand.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.ts
@@ -79,13 +79,20 @@ function statusLabel(entry: TaskEntry): string {
 }
 
 function taskLabel(entry: TaskEntry): string {
-  if (entry.kind === 'agent') {
-    return buildBackgroundEntryLabel(entry);
+  switch (entry.kind) {
+    case 'agent':
+      return buildBackgroundEntryLabel(entry);
+    case 'shell':
+      return entry.command;
+    case 'monitor':
+      return entry.description;
+    default: {
+      const _exhaustive: never = entry;
+      throw new Error(
+        `taskLabel: unknown TaskEntry kind: ${JSON.stringify(_exhaustive)}`,
+      );
+    }
   }
-  if (entry.kind === 'shell') {
-    return entry.command;
-  }
-  return entry.description;
 }
 
 function taskId(entry: TaskEntry): string {
@@ -168,7 +175,9 @@ export const tasksCommand: SlashCommand = {
     // dialog to point at and the noise just clutters their output.
     if (context.executionMode === 'interactive') {
       lines.push(
-        'Tip: Ctrl+T opens the interactive Background tasks dialog with detail view + live updates.',
+        t(
+          'Tip: Ctrl+T opens the interactive Background tasks dialog with detail view + live updates.',
+        ),
         '',
       );
     }

--- a/packages/cli/src/ui/commands/tasksCommand.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.ts
@@ -229,11 +229,16 @@ export const tasksCommand: SlashCommand = {
     // Defense in depth: registry entries carry user-supplied / process-
     // supplied strings (description, command, error from spawn / settle).
     // A maliciously-crafted value containing raw ANSI escape sequences
-    // could otherwise reach the terminal verbatim and corrupt display.
-    // `escapeAnsiCtrlCodes` is a no-op when the string has no control
-    // chars, so wrapping the joined output is cheap and covers every
-    // field — including any future kind's fields — without per-site
-    // sanitization sprawl.
+    // (CSI / OSC / SGR — anything starting with ESC, the kind matched
+    // by `ansi-regex`) could otherwise reach the terminal verbatim and
+    // corrupt display. `escapeAnsiCtrlCodes` is scoped to those
+    // sequences only — it does NOT escape isolated C0/C1 control bytes
+    // like BEL, BS, or VT; if those become a concern we'd need to
+    // layer `node:util`'s `stripVTControlCharacters` on top. For the
+    // common case (no escape sequences present) the helper is a no-op
+    // and returns the original string. Wrapping the joined output once
+    // covers every field — including any future kind's fields —
+    // without per-site sanitization sprawl.
     return {
       type: 'message' as const,
       messageType: 'info' as const,

--- a/packages/cli/src/ui/commands/tasksCommand.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.ts
@@ -14,6 +14,7 @@ import type { SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
 import { t } from '../../i18n/index.js';
 import { formatDuration } from '../utils/formatters.js';
+import { escapeAnsiCtrlCodes } from '../utils/textUtils.js';
 
 type AgentTaskEntry = BackgroundTaskEntry & {
   kind: 'agent';
@@ -225,10 +226,18 @@ export const tasksCommand: SlashCommand = {
       }
     }
 
+    // Defense in depth: registry entries carry user-supplied / process-
+    // supplied strings (description, command, error from spawn / settle).
+    // A maliciously-crafted value containing raw ANSI escape sequences
+    // could otherwise reach the terminal verbatim and corrupt display.
+    // `escapeAnsiCtrlCodes` is a no-op when the string has no control
+    // chars, so wrapping the joined output is cheap and covers every
+    // field — including any future kind's fields — without per-site
+    // sanitization sprawl.
     return {
       type: 'message' as const,
       messageType: 'info' as const,
-      content: lines.join('\n'),
+      content: escapeAnsiCtrlCodes(lines.join('\n')),
     };
   },
 };

--- a/packages/cli/src/ui/commands/tasksCommand.ts
+++ b/packages/cli/src/ui/commands/tasksCommand.ts
@@ -26,55 +26,61 @@ type MonitorTaskEntry = MonitorEntry & { kind: 'monitor' };
 type TaskEntry = AgentTaskEntry | ShellTaskEntry | MonitorTaskEntry;
 
 function statusLabel(entry: TaskEntry): string {
-  if (entry.kind === 'agent') {
-    switch (entry.status) {
-      case 'completed':
-        return 'completed';
-      case 'failed':
-        return `failed: ${entry.error ?? 'unknown error'}`;
-      case 'cancelled':
-        return 'cancelled';
-      case 'paused':
-        return entry.resumeBlockedReason
-          ? `paused (resume blocked): ${entry.resumeBlockedReason}`
-          : 'paused';
-      case 'running':
-      default:
-        return 'running';
+  switch (entry.kind) {
+    case 'agent':
+      switch (entry.status) {
+        case 'completed':
+          return 'completed';
+        case 'failed':
+          return `failed: ${entry.error ?? 'unknown error'}`;
+        case 'cancelled':
+          return 'cancelled';
+        case 'paused':
+          return entry.resumeBlockedReason
+            ? `paused (resume blocked): ${entry.resumeBlockedReason}`
+            : 'paused';
+        case 'running':
+        default:
+          return 'running';
+      }
+    case 'shell':
+      switch (entry.status) {
+        case 'completed':
+          return `completed (exit ${entry.exitCode ?? '?'})`;
+        case 'failed':
+          return `failed: ${entry.error ?? 'unknown error'}`;
+        case 'cancelled':
+          return 'cancelled';
+        case 'running':
+          return 'running';
+        default:
+          return 'running';
+      }
+    case 'monitor': {
+      // Append eventCount as a glanceable signal for activity. error (set
+      // on `failed` and on auto-stopped `completed`) is included verbatim.
+      const events = `${entry.eventCount} event${entry.eventCount === 1 ? '' : 's'}`;
+      switch (entry.status) {
+        case 'completed':
+          return entry.error
+            ? `completed (${entry.error}, ${events})`
+            : `completed (exit ${entry.exitCode ?? '?'}, ${events})`;
+        case 'failed':
+          return `failed: ${entry.error ?? 'unknown error'} (${events})`;
+        case 'cancelled':
+          return `cancelled (${events})`;
+        case 'running':
+          return `running (${events})`;
+        default:
+          return `running (${events})`;
+      }
     }
-  }
-
-  if (entry.kind === 'shell') {
-    switch (entry.status) {
-      case 'completed':
-        return `completed (exit ${entry.exitCode ?? '?'})`;
-      case 'failed':
-        return `failed: ${entry.error ?? 'unknown error'}`;
-      case 'cancelled':
-        return 'cancelled';
-      case 'running':
-        return 'running';
-      default:
-        return 'running';
+    default: {
+      const _exhaustive: never = entry;
+      throw new Error(
+        `statusLabel: unknown TaskEntry kind: ${JSON.stringify(_exhaustive)}`,
+      );
     }
-  }
-
-  // monitor — append eventCount as a glanceable signal for activity. error
-  // (set on `failed` and on auto-stopped `completed`) is included verbatim.
-  const events = `${entry.eventCount} event${entry.eventCount === 1 ? '' : 's'}`;
-  switch (entry.status) {
-    case 'completed':
-      return entry.error
-        ? `completed (${entry.error}, ${events})`
-        : `completed (exit ${entry.exitCode ?? '?'}, ${events})`;
-    case 'failed':
-      return `failed: ${entry.error ?? 'unknown error'} (${events})`;
-    case 'cancelled':
-      return `cancelled (${events})`;
-    case 'running':
-      return `running (${events})`;
-    default:
-      return `running (${events})`;
   }
 }
 
@@ -113,11 +119,22 @@ function taskId(entry: TaskEntry): string {
 }
 
 function taskOutputPath(entry: TaskEntry): string | undefined {
-  if (entry.kind === 'agent') return entry.outputFile;
-  if (entry.kind === 'shell') return entry.outputPath;
-  // Monitors stream to the agent via task_notification rather than a
-  // file on disk — no output path to surface here.
-  return undefined;
+  switch (entry.kind) {
+    case 'agent':
+      return entry.outputFile;
+    case 'shell':
+      return entry.outputPath;
+    case 'monitor':
+      // Monitors stream to the agent via task_notification rather than a
+      // file on disk — no output path to surface here.
+      return undefined;
+    default: {
+      const _exhaustive: never = entry;
+      throw new Error(
+        `taskOutputPath: unknown TaskEntry kind: ${JSON.stringify(_exhaustive)}`,
+      );
+    }
+  }
 }
 
 export const tasksCommand: SlashCommand = {
@@ -174,13 +191,16 @@ export const tasksCommand: SlashCommand = {
     // Soft redirect: in interactive mode the dialog is richer (per-entry
     // detail view, live updates, cancel keybinding). Don't show the hint
     // in non_interactive / acp — those consumers have no dialog to point
-    // at and the noise just clutters their output. Note: the dialog
-    // opens via Down arrow + Enter on the footer pill (NOT Ctrl+T —
-    // that's bound to the MCP tool descriptions toggle elsewhere).
+    // at and the noise just clutters their output. The wording avoids
+    // pinning a single-key path because Down may pass through the Arena
+    // agent tab bar first when subagents are present (`InputPrompt`
+    // focus chain: agent tab bar → bg pill); calling it "the footer
+    // Background tasks pill" lets the user reach it however the focus
+    // chain routes them today.
     if (context.executionMode === 'interactive') {
       lines.push(
         t(
-          'Tip: press ↓ from an empty composer then Enter to open the interactive Background tasks dialog with detail view + live updates.',
+          'Tip: focus the Background tasks pill in the footer (use ↓ from an empty composer) and press Enter for the interactive dialog with detail view + live updates.',
         ),
         '',
       );


### PR DESCRIPTION
## Summary

Phase B closure for Issue #3634. Two coupled changes to the `/tasks` slash command:

1. **Bug fix** — the command was last touched before #3684 / #3791 landed, so it merged only agent + shell entries while monitors silently disappeared from the headless / non-interactive / ACP listing path. This PR adds the missing `getMonitorRegistry()` pull and threads monitor through every helper (`statusLabel` / `taskLabel` / `taskId` / `taskOutputPath`).
2. **Surface redirect** (not a removal) — once the richer Ctrl+T dialog (#3488 + #3720 + #3791) is available, `/tasks` becomes the long-form fallback for non-TTY consumers rather than the primary surface. Show a single-line hint at the top of the output when `executionMode === 'interactive'`; keep the bare list for `non_interactive` / `acp`.

**Size**: +217 / -13 across 2 files, 1 commit.

## Decision: which of the three options from #3634

Issue #3634's Phase B left this open as "delete / keep as fallback / add deprecation hint — pick one." This PR picks **"keep + add hint, scoped to interactive mode"** — a hybrid of options 2 and 3.

- **Not delete.** `/tasks` is the *only* way `non_interactive` (`-p` flag), `acp` (IDE bridges like Zed), and SDK consumers can inspect background-task state — they have no TTY for the dialog. Deleting would silently break those flows.
- **Not "deprecation hint" verbatim.** "Deprecation" implies a removal path, but there is none — `/tasks` stays load-bearing for non-TTY callers indefinitely. Reframed as a *surface redirect*: in interactive mode where users have a richer alternative, point them at it; in non-TTY modes the command is the canonical surface so the hint would be noise.

The result is the same line count cost as a pure deprecation note but the framing accurately matches the long-term intent.

## Before / After

**Before** (any mode):

```
Background tasks (2 total)

[bg_run] running  12s pid=1111  npm run dev
[agent_a] running  7s  researcher: Investigate flaky test failure
            output: /tmp/tasks/sess/agent_a.jsonl
```
— monitor entries omitted; no hint about Ctrl+T.

**After (interactive)**:

```
Tip: Ctrl+T opens the interactive Background tasks dialog with detail view + live updates.

Background tasks (3 total)

[bg_run] running  12s pid=1111  npm run dev
[mon_run] running (12 events)  4s pid=9999  tail dev server log
[agent_a] running  7s  researcher: Investigate flaky test failure
            output: /tmp/tasks/sess/agent_a.jsonl
```

**After (non_interactive / ACP)**: same content, hint suppressed.

## What changed

- **`tasksCommand.ts`**:
  - Add `MonitorTaskEntry = MonitorEntry & { kind: 'monitor' }` to the union.
  - `statusLabel` monitor branch: `running (N events)`, `completed (exit X, N events)` for natural exit, `completed (Max events reached, N events)` for auto-stop, `failed: <reason> (N events)`, `cancelled (N events)`.
  - `taskLabel` returns `entry.description` for monitor (mirrors what the dialog uses).
  - `taskId` switches across all three kinds with an exhaustive default — flips to a TS error if a 4th kind ever lands.
  - `taskOutputPath` returns `undefined` for monitor (events stream via `task_notification`, no on-disk file).
  - `action` pulls from `getMonitorRegistry()` and merges into the existing `startTime` sort.
  - Single-line `Tip: Ctrl+T opens the interactive Background tasks dialog with detail view + live updates.` prepended when `context.executionMode === 'interactive'`.
  - Description text updated to call out the modal split.

- **`tasksCommand.test.ts`** (4 new cases): monitor entry formatting across 4 status combinations + asserts no `output: ` line for monitors; singular `1 event` vs plural `N events` (with substring guard); interactive-mode hint gating; cross-kind merge order.

## Design notes

A few decisions that aren't obvious from the diff:

- **Strict `executionMode === 'interactive'` (not `!== 'non_interactive'`).** The defensive choice — an unknown / future mode value defaults to *not* showing the hint, which is better than misfiring (a hint pointing at Ctrl+T in a context where Ctrl+T doesn't work would be actively confusing). Three known modes today; widen the check explicitly if a 4th interactive-like mode is added.
- **`statusLabel` includes `eventCount` but not `droppedLines`.** `eventCount` is the primary signal of monitor activity at a glance — every monitor user wants to know "is it producing events?". `droppedLines` only matters when the back-pressure path activates (rare); surfacing it in the always-on row would noisify the common case. The dialog's detail view (#3791) does show `droppedLines > 0` because users opened the detail surface specifically to see fault context.
- **Monitor's auto-stop branch shows `error` string instead of `exitCode`.** When a monitor auto-stops (`Max events reached`, `Idle timeout`), the exit code is uninformative — what the user actually wants is the *reason*. `error` carries it (per #3791's `MonitorEntry.error` field). Natural exit and `failed` paths fall back to `exitCode` since that's the load-bearing signal there.
- **Scope discipline — left two stale `/tasks` references untouched.** `task-stop.ts:110` and `shell.ts:865` still say "visible via /tasks once the process drains" / "Use the /tasks command to list and inspect…". Those wording tweaks (mention Ctrl+T as the interactive option) are a separate concern and a separate small PR — bundling them here would make the diff harder to review and they don't depend on the changes here.
- **Output sanitization at the boundary, not per-field.** Registry entries carry user / process-supplied strings (description, command, error from spawn / settle). The renderer wraps the joined output with `stripUnsafeCharacters` (`textUtils.ts`) — one pass that removes ANSI escape sequences (CSI / OSC / SGR), VT control sequences, and isolated C0 (BEL / BS / FF / VT) + C1 control bytes, while preserving TAB / CR / LF that are needed for line breaks. One call covers every kind including any future one and avoids per-field sanitization sprawl. Earlier rev used `escapeAnsiCtrlCodes` (only handles ESC sequences), but @doudouOUC's review caught that bare BEL / BS / VT bytes still passed through; switched to the more comprehensive helper.

## 中文版

Issue #3634 的 Phase B 收尾。`/tasks` 命令两处耦合改动：

1. **Bug 修复** — 这个命令上次改动早于 #3684 / #3791 落地，所以它只 merge agent + shell，monitor 在 headless / non-interactive / ACP 列表路径上被静默漏掉。这次加 `getMonitorRegistry()` 调用，把 monitor 串进每个 helper。
2. **Surface redirect**（不是 removal）— 富的 Ctrl+T 对话框（#3488 + #3720 + #3791）可用之后，`/tasks` 变成非 TTY 消费者的长格式 fallback，不再是主入口。`executionMode === 'interactive'` 时在输出顶部加单行提示；non_interactive / ACP 不显示。

**三选一决策**：Issue #3634 把 Phase B 这一项留作"删 / 留作 fallback / 加 deprecation hint 三选一"。本 PR 选**"留 + 仅 interactive 加 hint"**的混合。
- 不删：`/tasks` 是 non_interactive / ACP / SDK **唯一**能看到后台任务状态的方式，删了断这些路径。
- 不叫 "deprecation"：deprecation 暗示要删，但实际不删。改叫 *surface redirect* — 有更好选择的 interactive 用户被指向那边；非 TTY 模式下命令是规范入口，hint 反而是噪声。

**设计说明**（diff 里看不出来的几条）：
- **严格 `executionMode === 'interactive'`** 而不是 `!== 'non_interactive'` — 防御未来新增 mode：未知模式默认不显示 hint，比误显示安全。
- **`statusLabel` 显示 `eventCount` 但不显示 `droppedLines`** — eventCount 是 glance 信号（每个 monitor 用户都想知道"有事件吗"）；droppedLines 只在 back-pressure 触发时才有意义（罕见），主榜显示会噪声化。详情视图（#3791）会在 `droppedLines > 0` 时显示，因为用户那时是主动看故障上下文。
- **Monitor auto-stop 分支显示 `error` 字符串而不是 `exitCode`** — auto-stop 时 exit code 无信息量，用户真正想知道的是**为什么停**。`error` 字段承载这个信息（#3791 引入）；natural exit 和 `failed` 路径仍用 `exitCode` 因为那才是关键信号。
- **范围克制 — 留了两处 stale `/tasks` 引用没改**：`task-stop.ts:110` 和 `shell.ts:865` 还在说"visible via /tasks once the process drains" / "Use the /tasks command..."。那是独立小 PR 的事，捆进来反而难审，且互相不依赖。
- **输出边界统一消毒，不按字段散点处理**：registry entry 带用户/进程提供的字符串（description、command、spawn/settle 的 error）。Renderer 在 `lines.join('\n')` 外包一层 `stripUnsafeCharacters`（`textUtils.ts`） — 一次 pass 移除 ANSI 转义序列（CSI / OSC / SGR）、VT 控制序列、孤立 C0（BEL / BS / FF / VT）+ C1 控制字节，同时保留 TAB / CR / LF（行分隔需要）。一次调用覆盖所有 kind 包括未来新加的，避免每字段消毒散点。早期版本用 `escapeAnsiCtrlCodes`（只处理 ESC 序列），@doudouOUC review 抓到 bare BEL / BS / VT 仍能穿透，换成这个更全面的 helper。

## Test plan

- [x] `vitest run tasksCommand.test.ts`: **7 / 7 pass** (3 existing + 4 new)
- [x] ESLint clean
- [x] Prettier clean
- [ ] **Manual smoke (留给 reviewer)**: trigger one of each kind (background agent, shell, monitor); run `/tasks` in interactive — expect hint + 3 entries with correct kind formatting; run with `-p` non-interactive — expect 3 entries, no hint.

## Related

- Issue #3634 (Phase B/C alignment roadmap — this closes the only remaining open Phase B item)
- #3684 (Phase C — introduced Monitor; this PR catches `/tasks` up to it)
- #3791 (interactive dialog gained Monitor support — `/tasks` now points at it from the hint)
- Future small PR: update the `/tasks` references in `task-stop.ts:110` + `shell.ts:865` to mention Ctrl+T as the interactive option (intentionally out of scope here).

