### PR TITLE
fix(telemetry): suppress async resource attribute warning on startup

### DIFF
--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -136,6 +136,9 @@ describe('Telemetry SDK', () => {
       compression: 'gzip',
     });
     expect(NodeSDK.prototype.start).toHaveBeenCalled();
+    expect(NodeSDK).toHaveBeenCalledWith(
+      expect.objectContaining({ autoDetectResources: false }),
+    );
   });
 
   it('should use HTTP exporters with signal-specific paths when protocol is http', () => {

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -160,6 +160,9 @@ describe('Telemetry SDK', () => {
       url: 'http://localhost:4318/v1/metrics',
     });
     expect(NodeSDK.prototype.start).toHaveBeenCalled();
+    expect(NodeSDK).toHaveBeenCalledWith(
+      expect.objectContaining({ autoDetectResources: false }),
+    );
   });
 
   it('should parse gRPC endpoint correctly', () => {
@@ -295,6 +298,9 @@ describe('Telemetry SDK', () => {
     expect(OTLPLogExporterHttp).not.toHaveBeenCalled();
     expect(OTLPMetricExporterHttp).not.toHaveBeenCalled();
     expect(NodeSDK.prototype.start).toHaveBeenCalled();
+    expect(NodeSDK).toHaveBeenCalledWith(
+      expect.objectContaining({ autoDetectResources: false }),
+    );
   });
 
   it('should not register async process shutdown handlers', () => {

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -246,7 +246,8 @@ export function initializeTelemetry(config: Config): void {
   sdk = new NodeSDK({
     resource,
     // Disable async host/process/env resource detectors: they leave attributes
-    // pending and trigger an OTel diag.error before the first span is exported.
+    // pending and trigger an OTel diag.error on any resource attribute read
+    // before the detectors settle (e.g. during HttpInstrumentation span creation).
     autoDetectResources: false,
     spanProcessors: spanExporter ? [new BatchSpanProcessor(spanExporter)] : [],
     logRecordProcessors: logExporter

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -245,6 +245,8 @@ export function initializeTelemetry(config: Config): void {
 
   sdk = new NodeSDK({
     resource,
+    // Disable async host/process/env resource detectors: they leave attributes
+    // pending and trigger an OTel diag.error before the first span is exported.
     autoDetectResources: false,
     spanProcessors: spanExporter ? [new BatchSpanProcessor(spanExporter)] : [],
     logRecordProcessors: logExporter

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -245,6 +245,7 @@ export function initializeTelemetry(config: Config): void {
 
   sdk = new NodeSDK({
     resource,
+    autoDetectResources: false,
     spanProcessors: spanExporter ? [new BatchSpanProcessor(spanExporter)] : [],
     logRecordProcessors: logExporter
       ? [new BatchLogRecordProcessor(logExporter)]


### PR DESCRIPTION
## Summary

- Adds `autoDetectResources: false` to the `NodeSDK` constructor in `packages/core/src/telemetry/sdk.ts`
- Eliminates the `"Accessing resource attributes before async attributes settled"` warning that was printing to the terminal UI on every startup when telemetry was enabled

## Root cause

`NodeSDK` by default runs three async resource detectors (`envDetector`, `processDetector`, `hostDetector`). `start()` is synchronous and does not await these detectors settling. The first HTTP span exported (e.g. from `HttpInstrumentation`) reads `resource.attributes` while `asyncAttributesPending` is still `true`, triggering an OTel `diag.error()` that is visible in the terminal because `DiagConsoleLogger` is set at `WARN` level (ERROR > WARN).

## Why this fix is safe

All resource attributes we actually care about (`service.name`, `service.version`, `session.id`) are already provided synchronously via `resourceFromAttributes()` before the SDK starts. The auto-detected attributes (`host.name`, `process.pid`, `process.runtime.*`) are not used by any current exporter or dashboard configuration.

## Test plan

- [ ] Run `qwen` with telemetry enabled; confirm the warning no longer appears in the terminal
- [ ] Existing telemetry unit tests pass (`vitest run packages/core/src/telemetry`)

## 人工验证
改动前：
<img width="1231" height="340" alt="image" src="https://github.com/user-attachments/assets/9de398e6-ebb6-45cb-a75f-3a184e58c6c0" />
改动后：
<img width="1251" height="407" alt="image" src="https://github.com/user-attachments/assets/9489ae39-977a-4588-8400-af52d98893c2" />


Closes part of #3731

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)