### PR TITLE
docs(core): point background-shell + monitor guidance at both /tasks and the dialog

### DIFF
--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -6,9 +6,9 @@
 
 /**
  * Tracks background shell processes spawned via the `shell` tool with
- * `is_background: true`. Each entry holds the metadata the agent, the
- * interactive Background tasks dialog, and the `/tasks` slash command
- * need to query, observe, or terminate a running background shell.
+ * `is_background: true`. Each entry holds the metadata the agent,
+ * `/tasks`, and the interactive Background tasks dialog need to query,
+ * observe, or terminate a running background shell.
  *
  * State machine: register → running → { completed | failed | cancelled }.
  * Transitions out of running are one-shot: complete/fail/cancel become
@@ -28,7 +28,7 @@ export type BackgroundShellStatus =
   | 'cancelled';
 
 export interface BackgroundShellEntry {
-  /** Stable id used by the model, the Background tasks dialog, and `/tasks`. */
+  /** Stable id used by the model, `/tasks`, and the Background tasks dialog. */
   shellId: string;
   /** The user-supplied command, after any pre-processing the tool applies. */
   command: string;

--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -6,8 +6,8 @@
 
 /**
  * Tracks background shell processes spawned via the `shell` tool with
- * `is_background: true`. Each entry holds the metadata the agent,
- * `/tasks`, and the interactive Background tasks dialog need to query,
+ * `is_background: true`. Each entry holds the metadata that the agent,
+ * `/tasks`, and the interactive Background tasks dialog use to query,
  * observe, or terminate a running background shell.
  *
  * State machine: register → running → { completed | failed | cancelled }.

--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -6,9 +6,9 @@
 
 /**
  * Tracks background shell processes spawned via the `shell` tool with
- * `is_background: true`. Each entry holds the metadata the agent and the
- * `/tasks` slash command need to query, observe, or terminate a running
- * background shell.
+ * `is_background: true`. Each entry holds the metadata the agent, the
+ * interactive Background tasks dialog, and the `/tasks` slash command
+ * need to query, observe, or terminate a running background shell.
  *
  * State machine: register → running → { completed | failed | cancelled }.
  * Transitions out of running are one-shot: complete/fail/cancel become
@@ -28,7 +28,7 @@ export type BackgroundShellStatus =
   | 'cancelled';
 
 export interface BackgroundShellEntry {
-  /** Stable id used by the model and the `/tasks` UI. */
+  /** Stable id used by the model, the Background tasks dialog, and `/tasks`. */
   shellId: string;
   /** The user-supplied command, after any pre-processing the tool applies. */
   command: string;

--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -7,8 +7,9 @@
 /**
  * Tracks background shell processes spawned via the `shell` tool with
  * `is_background: true`. Each entry holds the metadata that the agent,
- * `/tasks`, and the interactive Background tasks dialog use to query,
- * observe, or terminate a running background shell.
+ * the `/tasks` slash command, and the interactive Background tasks
+ * dialog use to query, observe, or terminate a running background
+ * shell.
  *
  * State machine: register → running → { completed | failed | cancelled }.
  * Transitions out of running are one-shot: complete/fail/cancel become
@@ -28,7 +29,7 @@ export type BackgroundShellStatus =
   | 'cancelled';
 
 export interface BackgroundShellEntry {
-  /** Stable id used by the model, `/tasks`, and the Background tasks dialog. */
+  /** Stable id used by the model, the `/tasks` slash command, and the Background tasks dialog. */
   shellId: string;
   /** The user-supplied command, after any pre-processing the tool applies. */
   command: string;

--- a/packages/core/src/services/monitorRegistry.ts
+++ b/packages/core/src/services/monitorRegistry.ts
@@ -194,8 +194,8 @@ export class MonitorRegistry {
       );
       // Persist the reason so the dialog's detail view can surface it
       // after the monitor terminates (the chat-history notification is
-      // separate and not visible after reopening the Background tasks
-      // dialog or from `/tasks` listings).
+      // separate and not visible in later Background tasks dialog
+      // reopens or `/tasks` listings).
       entry.error = 'Max events reached';
       this.settle(entry, 'completed');
       entry.abortController.abort();

--- a/packages/core/src/services/monitorRegistry.ts
+++ b/packages/core/src/services/monitorRegistry.ts
@@ -194,8 +194,8 @@ export class MonitorRegistry {
       );
       // Persist the reason so the dialog's detail view can surface it
       // after the monitor terminates (the chat-history notification is
-      // separate and not visible from later Background tasks dialog
-      // reopens or `/tasks` listings).
+      // separate and not visible after reopening the Background tasks
+      // dialog or from `/tasks` listings).
       entry.error = 'Max events reached';
       this.settle(entry, 'completed');
       entry.abortController.abort();

--- a/packages/core/src/services/monitorRegistry.ts
+++ b/packages/core/src/services/monitorRegistry.ts
@@ -194,7 +194,8 @@ export class MonitorRegistry {
       );
       // Persist the reason so the dialog's detail view can surface it
       // after the monitor terminates (the chat-history notification is
-      // separate and not visible from /tasks dialog reopens).
+      // separate and not visible from later Background tasks dialog
+      // reopens or `/tasks` listings).
       entry.error = 'Max events reached';
       this.settle(entry, 'completed');
       entry.abortController.abort();

--- a/packages/core/src/services/monitorRegistry.ts
+++ b/packages/core/src/services/monitorRegistry.ts
@@ -193,9 +193,11 @@ export class MonitorRegistry {
         `Monitor ${monitorId} reached max events (${entry.maxEvents}), stopping`,
       );
       // Persist the reason so the dialog's detail view can surface it
-      // after the monitor terminates (the chat-history notification is
-      // separate and not visible in later Background tasks dialog
-      // reopens or `/tasks` listings).
+      // after the monitor terminates. The chat-history notification is
+      // separate from the registry's persistent state, so reopening the
+      // Background tasks dialog or running `/tasks` later won't surface
+      // it on its own — the persisted `entry.error` is what those
+      // surfaces actually read.
       entry.error = 'Max events reached';
       this.settle(entry, 'completed');
       entry.abortController.abort();

--- a/packages/core/src/tools/monitor.ts
+++ b/packages/core/src/tools/monitor.ts
@@ -593,7 +593,8 @@ class MonitorToolInvocation extends BaseToolInvocation<
         `max_events: ${maxEvents}\n` +
         `idle_timeout: ${idleTimeoutMs}ms\n` +
         `Events will be delivered as notifications. ` +
-        `The monitor auto-stops after ${maxEvents} events or ${idleTimeoutMs}ms of silence.`,
+        `The monitor auto-stops after ${maxEvents} events or ${idleTimeoutMs}ms of silence.\n` +
+        `To inspect: /tasks (text) or the interactive Background tasks dialog (focus the footer Background tasks pill, then Enter — detail view + live updates).`,
       returnDisplay: `Monitor started: ${displayDescription} (${monitorId})`,
     };
   }

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -862,7 +862,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
         `id: ${shellId}\n` +
         pidLine +
         `output file: ${outputPath}\n` +
-        `To inspect: /tasks (text) or the interactive Background tasks dialog (footer pill + Enter — detail view + live updates). Read the output file directly to view the captured output.`,
+        `To inspect: /tasks (text) or the interactive Background tasks dialog (focus the footer Background tasks pill, then Enter — detail view + live updates). Read the output file directly to view the captured output.`,
       returnDisplay: `Background shell ${shellId} started${pid !== undefined ? ` (pid ${pid})` : ''}.`,
     };
   }

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -862,7 +862,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
         `id: ${shellId}\n` +
         pidLine +
         `output file: ${outputPath}\n` +
-        `To inspect: /tasks (text listing, works in any mode) or the interactive Background tasks dialog (focus the footer pill, then Enter — has detail view + live updates). Read the output file directly for raw content.`,
+        `To inspect: /tasks (text) or the interactive Background tasks dialog (footer pill + Enter — detail view + live updates). Read the output file directly for the captured output.`,
       returnDisplay: `Background shell ${shellId} started${pid !== undefined ? ` (pid ${pid})` : ''}.`,
     };
   }

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -862,7 +862,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
         `id: ${shellId}\n` +
         pidLine +
         `output file: ${outputPath}\n` +
-        `Use the /tasks command to list and inspect background shells, or Read the output file directly.`,
+        `To inspect: /tasks (text listing, works in any mode) or the interactive Background tasks dialog (focus the footer pill, then Enter — has detail view + live updates). Read the output file directly for raw content.`,
       returnDisplay: `Background shell ${shellId} started${pid !== undefined ? ` (pid ${pid})` : ''}.`,
     };
   }

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -862,7 +862,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
         `id: ${shellId}\n` +
         pidLine +
         `output file: ${outputPath}\n` +
-        `To inspect: /tasks (text) or the interactive Background tasks dialog (footer pill + Enter — detail view + live updates). Read the output file directly for the captured output.`,
+        `To inspect: /tasks (text) or the interactive Background tasks dialog (footer pill + Enter — detail view + live updates). Read the output file directly to view the captured output.`,
       returnDisplay: `Background shell ${shellId} started${pid !== undefined ? ` (pid ${pid})` : ''}.`,
     };
   }

--- a/packages/core/src/tools/task-stop.test.ts
+++ b/packages/core/src/tools/task-stop.test.ts
@@ -235,7 +235,7 @@ describe('TaskStopTool', () => {
       );
 
       expect(result.error).toBeUndefined();
-      expect(result.llmContent).toContain('monitor "mon_123"');
+      expect(result.llmContent).toContain('Monitor "mon_123" cancelled');
       expect(result.llmContent).toContain('tail -f app.log');
       expect(result.returnDisplay).toContain('watch app log');
       expect(monitorRegistry.get('mon_123')!.status).toBe('cancelled');

--- a/packages/core/src/tools/task-stop.ts
+++ b/packages/core/src/tools/task-stop.ts
@@ -125,7 +125,8 @@ class TaskStopInvocation extends BaseToolInvocation<
       monitorRegistry.cancel(taskId);
       return {
         llmContent:
-          `Cancellation requested for monitor "${taskId}".\n` +
+          `Cancellation requested for monitor "${taskId}". ` +
+          `Final status will be visible via /tasks (text) or the interactive Background tasks dialog (focus the footer Background tasks pill, then Enter) once the process drains.\n` +
           `Command: ${monitorEntry.command}`,
         returnDisplay: `Cancelled monitor: ${monitorEntry.description}`,
       };

--- a/packages/core/src/tools/task-stop.ts
+++ b/packages/core/src/tools/task-stop.ts
@@ -93,7 +93,8 @@ class TaskStopInvocation extends BaseToolInvocation<
     // child process exits in response to the AbortController; the registry
     // entry's terminal state (`cancelled`) and final exit code/output stay
     // observable via `/tasks` (text), the interactive Background tasks
-    // dialog (footer pill + Enter), and the on-disk output file.
+    // dialog (focus the footer Background tasks pill, then Enter), and
+    // the on-disk output file.
     const shellRegistry = this.config.getBackgroundShellRegistry();
     const shellEntry = shellRegistry.get(taskId);
     if (shellEntry) {
@@ -108,7 +109,7 @@ class TaskStopInvocation extends BaseToolInvocation<
       return {
         llmContent:
           `Cancellation requested for background shell "${taskId}". ` +
-          `Final status will be visible via /tasks (text) or the interactive Background tasks dialog (footer pill + Enter) once the process drains; ` +
+          `Final status will be visible via /tasks (text) or the interactive Background tasks dialog (focus the footer Background tasks pill, then Enter) once the process drains; ` +
           `captured output remains at ${shellEntry.outputPath}.\n` +
           `Command: ${shellEntry.command}`,
         returnDisplay: `Cancelled shell: ${shellEntry.command}`,

--- a/packages/core/src/tools/task-stop.ts
+++ b/packages/core/src/tools/task-stop.ts
@@ -92,7 +92,8 @@ class TaskStopInvocation extends BaseToolInvocation<
     // Background shell registry (Phase B). Settles asynchronously when the
     // child process exits in response to the AbortController; the registry
     // entry's terminal state (`cancelled`) and final exit code/output stay
-    // observable via `/tasks` and the on-disk output file.
+    // observable via `/tasks` (text), the interactive Background tasks
+    // dialog (footer pill + Enter), and the on-disk output file.
     const shellRegistry = this.config.getBackgroundShellRegistry();
     const shellEntry = shellRegistry.get(taskId);
     if (shellEntry) {
@@ -107,7 +108,7 @@ class TaskStopInvocation extends BaseToolInvocation<
       return {
         llmContent:
           `Cancellation requested for background shell "${taskId}". ` +
-          `Final status will be visible via /tasks once the process drains; ` +
+          `Final status will be visible via /tasks (text) or the interactive Background tasks dialog (footer pill + Enter) once the process drains; ` +
           `captured output remains at ${shellEntry.outputPath}.\n` +
           `Command: ${shellEntry.command}`,
         returnDisplay: `Cancelled shell: ${shellEntry.command}`,

--- a/packages/core/src/tools/task-stop.ts
+++ b/packages/core/src/tools/task-stop.ts
@@ -125,8 +125,12 @@ class TaskStopInvocation extends BaseToolInvocation<
       monitorRegistry.cancel(taskId);
       return {
         llmContent:
-          `Cancellation requested for monitor "${taskId}". ` +
-          `Final status will be visible via /tasks (text) or the interactive Background tasks dialog (focus the footer Background tasks pill, then Enter) once the process drains.\n` +
+          // Unlike background shells (which settle asynchronously when the
+          // child process exits), `monitorRegistry.cancel()` settles the
+          // entry synchronously — the cancelled state is observable right
+          // now, no drain phrasing.
+          `Monitor "${taskId}" cancelled. ` +
+          `Status is visible via /tasks (text) or the interactive Background tasks dialog (focus the footer Background tasks pill, then Enter).\n` +
           `Command: ${monitorEntry.command}`,
         returnDisplay: `Cancelled monitor: ${monitorEntry.description}`,
       };


### PR DESCRIPTION
## Summary

Follow-up to PR #3801, fulfilling the "separate small PR" commitment in its description. The model-facing strings (`shell.ts` after spawning a background shell, `task-stop.ts` after requesting cancel, plus the parallel monitor strings in `monitor.ts` and `task-stop.ts`) and several related comments referenced only `/tasks` as the inspection path, predating the interactive Background tasks dialog landing at #3488 / #3720 / #3791. Now that the dialog handles all three kinds (agent / shell / monitor), both surfaces should be visible to the LLM so it can suggest the right one based on the user's mode (TTY vs headless / SDK / ACP).

**Size**: +24 / −12 across 6 files. Pure docs / string update — no behavior change.

## Scope

Started as 2 LLM-facing strings (`task-stop.ts:110`, `shell.ts:865` — the original commitment in #3801) plus 4 internal comments / docstrings I caught while running `grep -rn '/tasks' packages/core/src`. After @doudouOUC's review on this PR pointed out the symmetry gap, also extended to:

- `monitor.ts:587-598` — Monitor-started `llmContent` mirrors the same `/tasks` + dialog inspection guidance as `shell.ts:865`.
- `task-stop.ts:121-130` (monitor-cancel branch) — adds final-status guidance, parallel to the shell-cancel branch.
- `task-stop.test.ts` — assertion updated to match the new "Monitor \"...\" cancelled" prefix.

This brings shells and monitors to the same level of LLM awareness about both inspection surfaces.

## Intentionally NOT changed

Two `/tasks` references in the same area are correct as-is:

- **`agent-transcript.ts:52`** — references the *path* `<projectDir>/tasks/<sessionId>/<kind>-<id>.jsonl`, not the slash command. Different concept that happens to share the word.
- **`shell.ts:839`** — the comment already reads `let /tasks (and any future UI) ...`, so it's already framed as one of multiple consumers. No update needed.

## Before / After (final form after review)

### `shell.ts:865` (LLM message after `is_background: true` spawn)

```diff
- `Use the /tasks command to list and inspect background shells, or Read the output file directly.`,
+ `To inspect: /tasks (text) or the interactive Background tasks dialog (focus the footer Background tasks pill, then Enter — detail view + live updates). Read the output file directly to view the captured output.`,
```

### `task-stop.ts:111` (LLM message after `task_stop` on a shell)

```diff
- `Final status will be visible via /tasks once the process drains; ` +
+ `Final status will be visible via /tasks (text) or the interactive Background tasks dialog (focus the footer Background tasks pill, then Enter) once the process drains; ` +
```

### `monitor.ts:597` (LLM message after Monitor tool spawns)

```diff
  `Events will be delivered as notifications. ` +
- `The monitor auto-stops after ${maxEvents} events or ${idleTimeoutMs}ms of silence.`,
+ `The monitor auto-stops after ${maxEvents} events or ${idleTimeoutMs}ms of silence.\n` +
+ `To inspect: /tasks (text) or the interactive Background tasks dialog (focus the footer Background tasks pill, then Enter — detail view + live updates).`,
```

### `task-stop.ts:127` (LLM message after `task_stop` on a monitor)

```diff
- `Cancellation requested for monitor "${taskId}".\n` +
- `Command: ${monitorEntry.command}`,
+ `Monitor "${taskId}" cancelled. ` +
+ `Status is visible via /tasks (text) or the interactive Background tasks dialog (focus the footer Background tasks pill, then Enter).\n` +
+ `Command: ${monitorEntry.command}`,
```

> Drops the "once the process drains" qualifier (which would be inherited from the shell branch by reflex): unlike `requestCancel()` on shells, `monitorRegistry.cancel()` settles synchronously, so the cancelled state is observable when the tool returns. An inline comment in the source documents the difference.

### `task-stop.ts:95` (comment)

```diff
- // observable via `/tasks` and the on-disk output file.
+ // observable via `/tasks` (text), the interactive Background tasks
+ // dialog (focus the footer Background tasks pill, then Enter), and
+ // the on-disk output file.
```

### `monitorRegistry.ts:195-200` (comment — fixes a real misnomer)

```diff
- // Persist the reason so the dialog's detail view can surface it
- // after the monitor terminates (the chat-history notification is
- // separate and not visible from /tasks dialog reopens).
+ // Persist the reason so the dialog's detail view can surface it
+ // after the monitor terminates. The chat-history notification is
+ // separate from the registry's persistent state, so reopening the
+ // Background tasks dialog or running `/tasks` later won't surface
+ // it on its own — the persisted `entry.error` is what those
+ // surfaces actually read.
```

The old wording said `"/tasks dialog"` which conflated two distinct surfaces — `/tasks` is the slash-command text dump, the Background tasks dialog is the interactive overlay. Fixed by naming them separately and tightening the explanation.

### `backgroundShellRegistry.ts:7-12` (module docstring) and `:31` (`shellId` JSDoc)

```diff
- * Each entry holds the metadata the agent and the `/tasks` slash
- * command need to query, observe, or terminate a running background
- * shell.
+ * Each entry holds the metadata that the agent, the `/tasks` slash
+ * command, and the interactive Background tasks dialog use to query,
+ * observe, or terminate a running background shell.

- /** Stable id used by the model and the `/tasks` UI. */
+ /** Stable id used by the model, the `/tasks` slash command, and the Background tasks dialog. */
```

## Design notes

- **LLM messages name BOTH surfaces simultaneously** instead of letting the LLM pick one based on context. The LLM doesn't know whether the user is in a TTY or in headless / SDK / ACP mode, so giving it complete information lets it phrase the suggestion to fit the user.
- **Wording is `focus the footer Background tasks pill, then Enter`** to disambiguate from other footer pills (e.g. status indicators).
- **Drain phrasing dropped for monitors** because `monitorRegistry.cancel()` settles synchronously while shell cancel is async. The shell branch keeps "once the process drains" since that's accurate for shells.

## Self-correction

The original commitment in #3801 said the follow-up should "mention Ctrl+T as the interactive option". That was wrong — `Ctrl+T` is bound to the MCP tool descriptions toggle, not the Background tasks dialog. The actual opener is `↓` from an empty composer to focus the footer Background tasks pill, then `Enter`. This PR uses the correct framing.

## Test plan

- [x] `tsc --build` clean
- [x] ESLint clean
- [x] Affected unit tests pass (78 monitor + task-stop + 51 task-stop + monitorRegistry tests)
- [x] No behavior change — pure docs / string update
- [ ] **Manual smoke (留给 reviewer)**: start a background shell via the agent → verify the LLM-facing tool result mentions both `/tasks` and the dialog; cancel a background shell via `task_stop` → same. Same for `monitor` tool spawn and cancel.

## Related

- Issue #3634 (Phase B/C alignment roadmap)
- #3801 (`/tasks` repositioning — committed to this PR as scope-discipline carve-out, also the source of the now-corrected `Ctrl+T` framing)
- #3488 / #3720 / #3791 (Background tasks dialog landings — what these strings should now reference)
