### PR TITLE
feat(core): hint to background long-running foreground bash commands

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -866,6 +866,150 @@ describe('ShellTool', () => {
         expect(result.llmContent).toContain('Command was cancelled');
         expect(result.llmContent).not.toContain('foreground command ran for');
       });
+
+      it('omits the hint on the timeout path (combinedSignal aborted, signal not)', async () => {
+        // The plain `aborted: true` resolution above exercises the user-
+        // cancel branch (`combinedSignal.aborted && signal.aborted`).
+        // The TIMEOUT branch (`combinedSignal.aborted && !signal.aborted`)
+        // needs an `AbortSignal.any` mock that returns an already-aborted
+        // combined signal — same pattern as `should handle timeout vs
+        // user cancellation correctly` further down. Pinning the timeout
+        // branch separately so a future regression that flips the
+        // suppression check (e.g. `!result.aborted` → `!combinedSignal.aborted`)
+        // would fail loudly on this case.
+        const userAbort = new AbortController();
+        const mockTimeoutSignal = {
+          aborted: false,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        } as unknown as AbortSignal;
+        const mockCombinedSignal = {
+          aborted: true,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+        } as unknown as AbortSignal;
+        const originalAbortSignal = globalThis.AbortSignal;
+        vi.stubGlobal('AbortSignal', {
+          ...originalAbortSignal,
+          timeout: vi.fn().mockReturnValue(mockTimeoutSignal),
+          any: vi.fn().mockReturnValue(mockCombinedSignal),
+        });
+
+        const invocation = shellTool.build({
+          command: 'tail -f /tmp/never.log',
+          is_background: false,
+          timeout: 60_000,
+        });
+        const promise = invocation.execute(userAbort.signal);
+        await vi.advanceTimersByTimeAsync(60_000);
+        resolveShellExecution({
+          output: 'partial',
+          exitCode: null,
+          aborted: true,
+        });
+        const result = await promise;
+        vi.stubGlobal('AbortSignal', originalAbortSignal);
+
+        expect(result.llmContent).toContain('Command timed out after 60000ms');
+        expect(result.llmContent).not.toContain('foreground command ran for');
+      });
+
+      it('omits the hint when the process was killed by an external signal (SIGTERM / OOM / etc.)', async () => {
+        // External signals (`result.signal != null`) with `aborted: false`:
+        // `shellExecutionService` only sets `aborted` when the AbortSignal
+        // we passed was triggered, so SIGTERM from container shutdown,
+        // k8s eviction, OOM killer, or a sibling reaping the process group
+        // falls through to the non-aborted branch. The advisory shouldn't
+        // fire there either — the process didn't run to its conclusion,
+        // so "next time, background it" doesn't apply.
+        const invocation = shellTool.build({
+          command: 'tail -f /tmp/never.log',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal);
+        await vi.advanceTimersByTimeAsync(75_000);
+        // SIGTERM = 15; ShellExecutionResult stores the numeric signal
+        // code (see `signal: number | null` in shellExecutionService.ts
+        // and the `os.constants.signals[signal]` lookup at the spawn
+        // settle path).
+        resolveShellExecution({
+          output: '',
+          exitCode: null,
+          signal: 15,
+          aborted: false,
+        });
+        const result = await promise;
+        // Falls through to the normal result formatter (non-aborted).
+        expect(result.llmContent).toContain('Signal: 15');
+        expect(result.llmContent).not.toContain('foreground command ran for');
+      });
+
+      it('off-by-one: omits the hint at threshold − 1ms', async () => {
+        // Pin the boundary so a regression that flips `>=` to `>` would
+        // fail loudly. Pairs with the existing 60_000ms-exactly test
+        // (which fires) — these two together pin the boundary tightly.
+        const invocation = shellTool.build({
+          command: 'echo hi',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal);
+        await vi.advanceTimersByTimeAsync(59_999);
+        resolveShellExecution({ output: 'hi', exitCode: 0 });
+        const result = await promise;
+        expect(result.llmContent).not.toContain('foreground command ran for');
+      });
+
+      it('appends the hint AFTER truncation (so it survives `truncateToolOutput`)', async () => {
+        // `truncateToolOutput` wraps over-budget output in a "Truncated
+        // part of the output:" envelope. If the hint were appended
+        // inside that envelope (i.e. before truncation), the LLM might
+        // read the advisory as part of the command's own output. Pin
+        // the post-truncation insertion order: the hint must appear
+        // outside the truncation marker.
+        //
+        // Mock `truncateToolOutput` directly rather than driving real
+        // truncation — the real path needs `fs.writeFile` to actually
+        // succeed (the catch fallback returns no `outputFile`, so the
+        // shell.ts replacement branch never fires). Mocking here pins
+        // ordering, which is all this test cares about.
+        const truncationModule = await import('../utils/truncation.js');
+        const spy = vi
+          .spyOn(truncationModule, 'truncateToolOutput')
+          .mockResolvedValue({
+            content: 'Tool output was too large and has been truncated.\n[mocked truncated body]',
+            outputFile: '/tmp/qwen-temp/shell_mocked.output',
+          });
+
+        const invocation = shellTool.build({
+          command: 'long-output-cmd',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal);
+        await vi.advanceTimersByTimeAsync(60_000);
+        resolveShellExecution({ output: 'A'.repeat(500), exitCode: 0 });
+        const result = await promise;
+        spy.mockRestore();
+
+        const content = result.llmContent as string;
+        // Hint present.
+        expect(content).toContain('foreground command ran for 60s');
+        // Truncation envelope present (proves the truncation branch
+        // actually ran in shell.ts — `outputFile` was set so the
+        // replacement happened).
+        expect(content).toContain(
+          'Tool output was too large and has been truncated.',
+        );
+        // Hint comes AFTER the truncation marker — pins the
+        // post-truncation insertion order so a regression that moves
+        // the append back inside the non-aborted llmContent builder
+        // (where it'd get wrapped by the truncation envelope on long
+        // output) would fail loudly.
+        const truncIdx = content.indexOf(
+          'Tool output was too large and has been truncated.',
+        );
+        const hintIdx = content.indexOf('foreground command ran for');
+        expect(hintIdx).toBeGreaterThan(truncIdx);
+      });
     });
 
     describe('addCoAuthorToGitCommit', () => {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -794,8 +794,17 @@ describe('ShellTool', () => {
       // on user-cancel / timeout / external signal (their own
       // messaging is enough), and never fire on the background path
       // (returns before the threshold by construction).
+      //
+      // Faking BOTH `Date` and `performance` here — shell.ts uses
+      // `performance.now()` (monotonic, NTP-resilient) for the
+      // long-run elapsed measurement, so without faking performance
+      // the elapsed would always read as "near zero" under
+      // `advanceTimersByTimeAsync` and the hint tests would never
+      // fire. Date stays faked so that `lastUpdateTime = Date.now()`
+      // (streaming throttle) and other Date-based callers in the
+      // execute path also stay deterministic.
       beforeEach(() => {
-        vi.useFakeTimers({ toFake: ['Date'] });
+        vi.useFakeTimers({ toFake: ['Date', 'performance'] });
       });
       afterEach(() => {
         vi.useRealTimers();
@@ -1064,12 +1073,34 @@ describe('ShellTool', () => {
         expect(result.llmContent).toContain('foreground command ran for 305s');
       });
 
-      it('debug-mode TUI mirror is re-synced after the hint append', async () => {
-        // Pin the debug-mode re-sync introduced to avoid the agent
-        // suddenly suggesting `is_background: true` with no visible
-        // trigger in the TUI. All other tests in this describe run
-        // under the default `getDebugMode → false`; this one flips it
-        // to true and asserts the hint is in `returnDisplay` too.
+      it('hint appears in non-debug returnDisplay (user TUI)', async () => {
+        // The hint is useful to the user too — they're the one waiting
+        // for long commands. Pin that the non-debug TUI gets the hint
+        // appended (terse form: result.output + hint, separated by
+        // blank line). Default `getDebugMode → false`.
+        const invocation = shellTool.build({
+          command: 'pytest -q',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal);
+        await vi.advanceTimersByTimeAsync(60_000);
+        resolveShellExecution({ output: 'all green', exitCode: 0 });
+        const result = await promise;
+        // Both surfaces have the hint.
+        expect(result.llmContent).toContain('foreground command ran for 60s');
+        expect(result.returnDisplay).toContain(
+          'foreground command ran for 60s',
+        );
+        // Original output preserved (not replaced by hint).
+        expect(result.returnDisplay).toContain('all green');
+      });
+
+      it('hint also appears in debug-mode returnDisplay (mirrors LLM view)', async () => {
+        // Same hint visibility but through the debug-mode mirror code
+        // path. Both branches now use append-style re-sync (preserving
+        // any prior content like the truncation marker), so the
+        // assertion is the same — but exercising both flips guards
+        // the branch from regressing independently.
         const debugMock = mockConfig as unknown as { getDebugMode: Mock };
         debugMock.getDebugMode.mockReturnValue(true);
         try {
@@ -1082,10 +1113,38 @@ describe('ShellTool', () => {
           resolveShellExecution({ output: 'all green', exitCode: 0 });
           const result = await promise;
           expect(result.llmContent).toContain('foreground command ran for 60s');
-          expect(result.returnDisplay).toContain('foreground command ran for 60s');
+          expect(result.returnDisplay).toContain(
+            'foreground command ran for 60s',
+          );
         } finally {
           debugMock.getDebugMode.mockReturnValue(false);
         }
+      });
+
+      it('hint survives the error path (appended to error.message)', async () => {
+        // `coreToolScheduler` builds the model-facing functionResponse
+        // from `error.message` (NOT llmContent) when toolResult.error
+        // is set. So if a long command fails, the hint we appended to
+        // llmContent would be silently dropped before reaching the
+        // agent. Pin that the hint also lives in error.message.
+        const invocation = shellTool.build({
+          command: 'flaky.sh',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal);
+        await vi.advanceTimersByTimeAsync(75_000);
+        resolveShellExecution({
+          output: '',
+          exitCode: 1,
+          error: new Error('spawn ENOENT'),
+        });
+        const result = await promise;
+        // The hint must appear in the error.message path so the LLM
+        // sees it via the scheduler's error branch.
+        expect(result.error?.message).toContain('spawn ENOENT');
+        expect(result.error?.message).toContain(
+          'foreground command ran for 75s',
+        );
       });
     });
 

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -785,6 +785,89 @@ describe('ShellTool', () => {
       });
     });
 
+    describe('long-running foreground hint', () => {
+      // Phase D part (a) — auto-bg advisory. Threshold currently 60_000ms;
+      // tests use vi fake timers to drive the wall-clock past it without
+      // actually sleeping. Hint must fire on success AND error completions
+      // (advice is the same), suppress on user-cancel / timeout (their own
+      // messaging is enough), and never fire on the background path
+      // (returns before the threshold by construction).
+      beforeEach(() => {
+        vi.useFakeTimers({ toFake: ['Date'] });
+      });
+      afterEach(() => {
+        vi.useRealTimers();
+      });
+
+      it('appends the long-run hint when a foreground command runs ≥ 60s', async () => {
+        const invocation = shellTool.build({
+          command: 'pytest -q',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal);
+        // Advance the wall-clock past the 60s threshold.
+        await vi.advanceTimersByTimeAsync(60_000);
+        resolveShellExecution({ output: 'all green', exitCode: 0 });
+        const result = await promise;
+        expect(result.llmContent).toContain('this foreground command ran for 60s');
+        expect(result.llmContent).toContain('is_background: true');
+        expect(result.llmContent).toContain('/tasks');
+      });
+
+      it('omits the hint when a foreground command finishes under threshold', async () => {
+        const invocation = shellTool.build({
+          command: 'echo hi',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal);
+        await vi.advanceTimersByTimeAsync(5_000);
+        resolveShellExecution({ output: 'hi', exitCode: 0 });
+        const result = await promise;
+        expect(result.llmContent).not.toContain('foreground command ran for');
+        expect(result.llmContent).not.toContain('is_background: true');
+      });
+
+      it('appends the hint when a long-running foreground command exits with error', async () => {
+        // Non-aborted but failed completions still benefit — the agent
+        // got blocked for >60s on something that errored, "next time
+        // background it" is exactly the right advice.
+        const invocation = shellTool.build({
+          command: 'flaky.sh',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal);
+        await vi.advanceTimersByTimeAsync(75_000);
+        resolveShellExecution({
+          output: '',
+          exitCode: 1,
+          error: new Error('exit 1'),
+        });
+        const result = await promise;
+        expect(result.llmContent).toContain('Exit Code: 1');
+        expect(result.llmContent).toContain('this foreground command ran for 75s');
+      });
+
+      it('omits the hint on aborted commands (timeout / user-cancel paths surface their own messaging)', async () => {
+        // `tail -f` (not `sleep N`) so the sleep-interception validator
+        // doesn't reject the command at build-time before we even reach
+        // the long-run hint logic.
+        const invocation = shellTool.build({
+          command: 'tail -f /tmp/never.log',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal);
+        await vi.advanceTimersByTimeAsync(120_000);
+        resolveShellExecution({
+          output: '',
+          exitCode: null,
+          aborted: true,
+        });
+        const result = await promise;
+        expect(result.llmContent).toContain('Command was cancelled');
+        expect(result.llmContent).not.toContain('foreground command ran for');
+      });
+    });
+
     describe('addCoAuthorToGitCommit', () => {
       it('should add co-author to git commit with double quotes', async () => {
         const command = 'git commit -m "Initial commit"';

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -838,10 +838,14 @@ describe('ShellTool', () => {
         expect(result.llmContent).not.toContain('is_background: true');
       });
 
-      it('appends the hint when a long-running foreground command exits with error', async () => {
-        // Non-aborted but failed completions still benefit — the agent
-        // got blocked for >60s on something that errored, "next time
-        // background it" is exactly the right advice.
+      it('appends the hint when a long-running foreground command exits non-zero', async () => {
+        // Non-zero exit (without spawn error) is the common "command
+        // ran but failed" shape. `ShellExecutionResult.error` is
+        // reserved for spawn/setup failures (see the doc on the field
+        // in shellExecutionService.ts) — exit-code-N completions leave
+        // `error: null` and `exitCode: N`. The agent still got blocked
+        // for >60s on something that errored; "next time background
+        // it" is exactly the right advice for either failure shape.
         const invocation = shellTool.build({
           command: 'flaky.sh',
           is_background: false,
@@ -851,7 +855,7 @@ describe('ShellTool', () => {
         resolveShellExecution({
           output: '',
           exitCode: 1,
-          error: new Error('exit 1'),
+          error: null, // realistic shape: non-zero exit, no spawn error
         });
         const result = await promise;
         expect(result.llmContent).toContain('Exit Code: 1');
@@ -1146,24 +1150,41 @@ describe('ShellTool', () => {
       it('hint survives the error path (appended to error.message)', async () => {
         // `coreToolScheduler` builds the model-facing functionResponse
         // from `error.message` (NOT llmContent) when toolResult.error
-        // is set. So if a long command fails, the hint we appended to
-        // llmContent would be silently dropped before reaching the
-        // agent. Pin that the hint also lives in error.message.
+        // is set. So if a long command fails AND hits the spawn-error
+        // path, the hint we appended to llmContent would be silently
+        // dropped before reaching the agent. Pin that the hint also
+        // lives in error.message.
+        //
+        // Note on realism: `ShellExecutionResult.error` is reserved for
+        // spawn / setup failures (per the field's doc comment in
+        // shellExecutionService.ts) — non-zero exits leave it null.
+        // Real spawn failures (ENOENT, permission denied) typically
+        // resolve in <1s, so the long-elapsed + spawn-error combination
+        // tested here is rare in practice. The test still pins the
+        // CODE PATH because slow spawn paths exist (PTY init dragging,
+        // remote-fs exec syscalls, security scanners interposing) and
+        // a future regression that drops the error-path hint
+        // preservation would silently break those edge cases.
+        const slowSpawnError = new Error(
+          'PTY initialization failed after 75s',
+        );
         const invocation = shellTool.build({
-          command: 'flaky.sh',
+          command: 'cmd-that-fails-to-spawn',
           is_background: false,
         });
         const promise = invocation.execute(mockAbortSignal);
         await vi.advanceTimersByTimeAsync(75_000);
         resolveShellExecution({
           output: '',
-          exitCode: 1,
-          error: new Error('spawn ENOENT'),
+          exitCode: null, // spawn never produced an exit code
+          error: slowSpawnError,
         });
         const result = await promise;
         // The hint must appear in the error.message path so the LLM
         // sees it via the scheduler's error branch.
-        expect(result.error?.message).toContain('spawn ENOENT');
+        expect(result.error?.message).toContain(
+          'PTY initialization failed after 75s',
+        );
         expect(result.error?.message).toContain(
           'foreground command ran for 75s',
         );
@@ -1173,7 +1194,9 @@ describe('ShellTool', () => {
         // error body and the appended advisory. Without the divider,
         // pattern-matching on error messages would absorb the ~400-
         // char advisory into the matched body.
-        expect(result.error?.message).toMatch(/spawn ENOENT\n\n---\n/);
+        expect(result.error?.message).toMatch(
+          /PTY initialization failed after 75s\n\n---\n/,
+        );
       });
     });
 

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -820,9 +820,36 @@ describe('ShellTool', () => {
         await vi.advanceTimersByTimeAsync(60_000);
         resolveShellExecution({ output: 'all green', exitCode: 0 });
         const result = await promise;
-        expect(result.llmContent).toContain('this foreground command ran for 60s');
+        expect(result.llmContent).toContain(
+          'this foreground command ran for 60s',
+        );
         expect(result.llmContent).toContain('is_background: true');
         expect(result.llmContent).toContain('/tasks');
+      });
+
+      it('appends the hint when a successful foreground command with empty output runs ≥ 60s', async () => {
+        // Empty-output success: write-only commands (e.g. `tar czf …`,
+        // `cp -r large-dir/`, `dd if=…`) frequently produce no stdout
+        // and exit 0. The non-debug `returnDisplayMessage` build leaves
+        // the message as `''` in this branch (output empty, exitCode 0,
+        // no abort/signal/error), so the hint append is the only thing
+        // that ever populates the user-facing TUI line. Pin both that
+        // the hint reaches the LLM AND that it surfaces in the user's
+        // returnDisplay even when the command produced nothing else to
+        // show — the user is the one who waited 60s, they should see
+        // the same advisory the agent does.
+        const invocation = shellTool.build({
+          command: 'write-to-disk.sh',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal);
+        await vi.advanceTimersByTimeAsync(65_000);
+        resolveShellExecution({ output: '', exitCode: 0 });
+        const result = await promise;
+        expect(result.llmContent).toContain('foreground command ran for 65s');
+        expect(result.returnDisplay).toContain(
+          'foreground command ran for 65s',
+        );
       });
 
       it('omits the hint when a foreground command finishes under threshold', async () => {
@@ -859,7 +886,9 @@ describe('ShellTool', () => {
         });
         const result = await promise;
         expect(result.llmContent).toContain('Exit Code: 1');
-        expect(result.llmContent).toContain('this foreground command ran for 75s');
+        expect(result.llmContent).toContain(
+          'this foreground command ran for 75s',
+        );
       });
 
       it('omits the hint on aborted commands (timeout / user-cancel paths surface their own messaging)', async () => {
@@ -1165,9 +1194,7 @@ describe('ShellTool', () => {
         // remote-fs exec syscalls, security scanners interposing) and
         // a future regression that drops the error-path hint
         // preservation would silently break those edge cases.
-        const slowSpawnError = new Error(
-          'PTY initialization failed after 75s',
-        );
+        const slowSpawnError = new Error('PTY initialization failed after 75s');
         const invocation = shellTool.build({
           command: 'cmd-that-fails-to-spawn',
           is_background: false,
@@ -1197,6 +1224,29 @@ describe('ShellTool', () => {
         expect(result.error?.message).toMatch(
           /PTY initialization failed after 75s\n\n---\n/,
         );
+      });
+
+      it('never appends the long-run hint on background commands', async () => {
+        // Background path returns immediately with `Background shell
+        // started.` and a different result shape — by construction the
+        // hint logic only lives in `executeForeground`, so this can't
+        // fail today. Defensive pin: a future refactor that hoists the
+        // long-run advisory into a shared post-execute path would
+        // accidentally tag every background launch with a "ran for 0s,
+        // consider is_background: true" suggestion (nonsense — it's
+        // already backgrounded). This test fails loudly on that
+        // regression.
+        const invocation = shellTool.build({
+          command: 'pytest -q',
+          is_background: true,
+        });
+        const result = await invocation.execute(mockAbortSignal);
+        expect(result.llmContent).toContain('Background shell started');
+        expect(result.llmContent).not.toContain('foreground command ran for');
+        // The hint text contains the literal `is_background: true` —
+        // the background path's own llmContent doesn't, so this guards
+        // against the hint leaking in via a shared code path.
+        expect(result.llmContent).not.toContain('is_background: true');
       });
     });
 

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -786,10 +786,12 @@ describe('ShellTool', () => {
     });
 
     describe('long-running foreground hint', () => {
-      // Phase D part (a) — auto-bg advisory. Threshold currently 60_000ms;
-      // tests use vi fake timers to drive the wall-clock past it without
-      // actually sleeping. Hint must fire on success AND error completions
-      // (advice is the same), suppress on user-cancel / timeout (their own
+      // Auto-bg advisory. Threshold = effectiveTimeout / 2 — for the
+      // default 120s timeout that's 60_000ms, which the tests below
+      // assume. Tests use vi fake timers to drive the wall-clock past
+      // the threshold without actually sleeping. Hint must fire on
+      // success AND error completions (advice is the same), suppress
+      // on user-cancel / timeout / external signal (their own
       // messaging is enough), and never fire on the background path
       // (returns before the threshold by construction).
       beforeEach(() => {
@@ -895,23 +897,30 @@ describe('ShellTool', () => {
           any: vi.fn().mockReturnValue(mockCombinedSignal),
         });
 
-        const invocation = shellTool.build({
-          command: 'tail -f /tmp/never.log',
-          is_background: false,
-          timeout: 60_000,
-        });
-        const promise = invocation.execute(userAbort.signal);
-        await vi.advanceTimersByTimeAsync(60_000);
-        resolveShellExecution({
-          output: 'partial',
-          exitCode: null,
-          aborted: true,
-        });
-        const result = await promise;
-        vi.stubGlobal('AbortSignal', originalAbortSignal);
+        try {
+          const invocation = shellTool.build({
+            command: 'tail -f /tmp/never.log',
+            is_background: false,
+            timeout: 60_000,
+          });
+          const promise = invocation.execute(userAbort.signal);
+          await vi.advanceTimersByTimeAsync(60_000);
+          resolveShellExecution({
+            output: 'partial',
+            exitCode: null,
+            aborted: true,
+          });
+          const result = await promise;
 
-        expect(result.llmContent).toContain('Command timed out after 60000ms');
-        expect(result.llmContent).not.toContain('foreground command ran for');
+          expect(result.llmContent).toContain(
+            'Command timed out after 60000ms',
+          );
+          expect(result.llmContent).not.toContain('foreground command ran for');
+        } finally {
+          // Restore even if assertions throw, otherwise globalThis.AbortSignal
+          // stays patched and cascades into unrelated subsequent tests.
+          vi.stubGlobal('AbortSignal', originalAbortSignal);
+        }
       });
 
       it('omits the hint when the process was killed by an external signal (SIGTERM / OOM / etc.)', async () => {
@@ -976,39 +985,65 @@ describe('ShellTool', () => {
         const spy = vi
           .spyOn(truncationModule, 'truncateToolOutput')
           .mockResolvedValue({
-            content: 'Tool output was too large and has been truncated.\n[mocked truncated body]',
+            content:
+              'Tool output was too large and has been truncated.\n[mocked truncated body]',
             outputFile: '/tmp/qwen-temp/shell_mocked.output',
           });
 
+        try {
+          const invocation = shellTool.build({
+            command: 'long-output-cmd',
+            is_background: false,
+          });
+          const promise = invocation.execute(mockAbortSignal);
+          await vi.advanceTimersByTimeAsync(60_000);
+          resolveShellExecution({ output: 'A'.repeat(500), exitCode: 0 });
+          const result = await promise;
+
+          const content = result.llmContent as string;
+          // Hint present.
+          expect(content).toContain('foreground command ran for 60s');
+          // Truncation envelope present (proves the truncation branch
+          // actually ran in shell.ts — `outputFile` was set so the
+          // replacement happened).
+          expect(content).toContain(
+            'Tool output was too large and has been truncated.',
+          );
+          // Hint comes AFTER the truncation marker — pins the
+          // post-truncation insertion order so a regression that
+          // moves the append back inside the non-aborted llmContent
+          // builder (where it'd get wrapped by the truncation
+          // envelope on long output) would fail loudly.
+          const truncIdx = content.indexOf(
+            'Tool output was too large and has been truncated.',
+          );
+          const hintIdx = content.indexOf('foreground command ran for');
+          expect(hintIdx).toBeGreaterThan(truncIdx);
+        } finally {
+          // Restore even if assertions throw — otherwise the
+          // truncateToolOutput spy leaks into subsequent tests.
+          spy.mockRestore();
+        }
+      });
+
+      it('threshold scales with the user-supplied timeout (not the default)', async () => {
+        // User explicitly sets timeout: 600_000 (10 min) because they
+        // expect a long command. Threshold is half that, so a 100s
+        // run should NOT trigger the advisory — the user already told
+        // us this command is allowed to run long. Pins the per-
+        // invocation coupling so a regression that goes back to the
+        // fixed `LONG_RUNNING_FOREGROUND_THRESHOLD_MS` constant
+        // would fail this test.
         const invocation = shellTool.build({
-          command: 'long-output-cmd',
+          command: 'pytest --slow',
           is_background: false,
+          timeout: 600_000,
         });
         const promise = invocation.execute(mockAbortSignal);
-        await vi.advanceTimersByTimeAsync(60_000);
-        resolveShellExecution({ output: 'A'.repeat(500), exitCode: 0 });
+        await vi.advanceTimersByTimeAsync(100_000); // 100s, well under threshold (300s)
+        resolveShellExecution({ output: 'all green', exitCode: 0 });
         const result = await promise;
-        spy.mockRestore();
-
-        const content = result.llmContent as string;
-        // Hint present.
-        expect(content).toContain('foreground command ran for 60s');
-        // Truncation envelope present (proves the truncation branch
-        // actually ran in shell.ts — `outputFile` was set so the
-        // replacement happened).
-        expect(content).toContain(
-          'Tool output was too large and has been truncated.',
-        );
-        // Hint comes AFTER the truncation marker — pins the
-        // post-truncation insertion order so a regression that moves
-        // the append back inside the non-aborted llmContent builder
-        // (where it'd get wrapped by the truncation envelope on long
-        // output) would fail loudly.
-        const truncIdx = content.indexOf(
-          'Tool output was too large and has been truncated.',
-        );
-        const hintIdx = content.indexOf('foreground command ran for');
-        expect(hintIdx).toBeGreaterThan(truncIdx);
+        expect(result.llmContent).not.toContain('foreground command ran for');
       });
     });
 

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -1167,6 +1167,13 @@ describe('ShellTool', () => {
         expect(result.error?.message).toContain(
           'foreground command ran for 75s',
         );
+        // `\n---\n` divider so downstream consumers
+        // (firePostToolUseFailureHook, telemetry grouping, SIEM, hook
+        // parsers) have an unambiguous boundary between the original
+        // error body and the appended advisory. Without the divider,
+        // pattern-matching on error messages would absorb the ~400-
+        // char advisory into the matched body.
+        expect(result.error?.message).toMatch(/spawn ENOENT\n\n---\n/);
       });
     });
 

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -1121,6 +1121,28 @@ describe('ShellTool', () => {
         }
       });
 
+      it('honors the MIN_LONG_RUN_THRESHOLD_MS floor for pathological tiny timeouts', async () => {
+        // `longRunThresholdFor(1)` would otherwise be `Math.floor(0.5) = 0`,
+        // making `elapsedMs >= 0` true on every invocation and emitting
+        // a "ran for 0s" advisory. The floor at MIN_LONG_RUN_THRESHOLD_MS
+        // (1000ms) keeps the threshold sensible. This test pins it: a
+        // 500ms run with `timeout: 1` finishes BELOW the floor and must
+        // NOT trigger the hint. (The result is mocked with `aborted: false`
+        // since we're isolating the threshold logic from the abort path —
+        // a regression that strips the `Math.max(...)` guard would fire
+        // the hint here while the real-world abort path stays intact.)
+        const invocation = shellTool.build({
+          command: 'echo done',
+          is_background: false,
+          timeout: 1,
+        });
+        const promise = invocation.execute(mockAbortSignal);
+        await vi.advanceTimersByTimeAsync(500);
+        resolveShellExecution({ output: 'done', exitCode: 0 });
+        const result = await promise;
+        expect(result.llmContent).not.toContain('foreground command ran for');
+      });
+
       it('hint survives the error path (appended to error.message)', async () => {
         // `coreToolScheduler` builds the model-facing functionResponse
         // from `error.message` (NOT llmContent) when toolResult.error

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -1045,6 +1045,48 @@ describe('ShellTool', () => {
         const result = await promise;
         expect(result.llmContent).not.toContain('foreground command ran for');
       });
+
+      it('threshold-scaling positive case: hint DOES fire at the scaled threshold', async () => {
+        // Pair with the negative test above. If `longRunThresholdFor`
+        // regressed to a fixed 60s, the negative test would still pass
+        // (no hint at 100s under default threshold either) but THIS
+        // one would also fire incorrectly at 100s — pinning both ends
+        // catches the failure mode.
+        const invocation = shellTool.build({
+          command: 'pytest --slow',
+          is_background: false,
+          timeout: 600_000,
+        });
+        const promise = invocation.execute(mockAbortSignal);
+        await vi.advanceTimersByTimeAsync(305_000); // past 300s scaled threshold
+        resolveShellExecution({ output: 'all green', exitCode: 0 });
+        const result = await promise;
+        expect(result.llmContent).toContain('foreground command ran for 305s');
+      });
+
+      it('debug-mode TUI mirror is re-synced after the hint append', async () => {
+        // Pin the debug-mode re-sync introduced to avoid the agent
+        // suddenly suggesting `is_background: true` with no visible
+        // trigger in the TUI. All other tests in this describe run
+        // under the default `getDebugMode → false`; this one flips it
+        // to true and asserts the hint is in `returnDisplay` too.
+        const debugMock = mockConfig as unknown as { getDebugMode: Mock };
+        debugMock.getDebugMode.mockReturnValue(true);
+        try {
+          const invocation = shellTool.build({
+            command: 'pytest -q',
+            is_background: false,
+          });
+          const promise = invocation.execute(mockAbortSignal);
+          await vi.advanceTimersByTimeAsync(60_000);
+          resolveShellExecution({ output: 'all green', exitCode: 0 });
+          const result = await promise;
+          expect(result.llmContent).toContain('foreground command ran for 60s');
+          expect(result.returnDisplay).toContain('foreground command ran for 60s');
+        } finally {
+          debugMock.getDebugMode.mockReturnValue(false);
+        }
+      });
     });
 
     describe('addCoAuthorToGitCommit', () => {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -50,6 +50,35 @@ const debugLogger = createDebugLogger('SHELL');
 
 export const OUTPUT_UPDATE_INTERVAL_MS = 1000;
 const DEFAULT_FOREGROUND_TIMEOUT_MS = 120000;
+/**
+ * Wall-clock duration above which a foreground bash command earns a
+ * "consider re-running with is_background: true" advisory in the LLM-
+ * facing tool result. Half the default 120s timeout — long enough that
+ * normal `npm install` / `pytest` runs don't trigger it, short enough
+ * that a hung-but-still-streaming process surfaces the suggestion before
+ * it gets killed by the timeout. Hint is advisory, not corrective: the
+ * command's own result is unchanged.
+ */
+const LONG_RUNNING_FOREGROUND_THRESHOLD_MS = 60000;
+
+/**
+ * Format the long-run advisory appended to long foreground commands.
+ * Exported so tests and any future consumer (e.g. an alternative
+ * renderer) can render the same text without duplicating the threshold
+ * logic.
+ */
+export function buildLongRunningForegroundHint(elapsedMs: number): string {
+  const seconds = Math.round(elapsedMs / 1000);
+  return (
+    `Note: this foreground command ran for ${seconds}s. ` +
+    `For long-running processes (build watchers, dev servers, soak ` +
+    `tests, polling loops), prefer re-running with ` +
+    `\`is_background: true\` so the agent isn't blocked while the ` +
+    `command runs. The output stays inspectable via /tasks (text), the ` +
+    `interactive Background tasks dialog (footer pill + Enter), and ` +
+    `the on-disk output file.`
+  );
+}
 
 /**
  * Detect standalone or leading `sleep N` patterns that should use Monitor
@@ -554,6 +583,12 @@ export class ShellToolInvocation extends BaseToolInvocation<
     let totalLines = 0;
     let totalBytes = 0;
 
+    // Bracket the spawn → settle wall-clock so the result builder below
+    // can decide whether to append the long-run advisory. Mirrors the
+    // background path's `entry.startTime` capture (line ~781) and is the
+    // only added side state for the foreground long-run hint feature.
+    const executionStartTime = Date.now();
+
     const { result: resultPromise, pid } = await ShellExecutionService.execute(
       commandToExecute,
       cwd,
@@ -664,6 +699,18 @@ export class ShellToolInvocation extends BaseToolInvocation<
         `Signal: ${result.signal ?? '(none)'}`,
         `Process Group PGID: ${result.pid ?? '(none)'}`,
       ].join('\n');
+
+      // Long-run advisory: only on the non-aborted branch. Timeout /
+      // user-cancel paths (the `if (result.aborted)` arm above) already
+      // surface the duration via their own message and benefit nothing
+      // from a "should have been background" reminder — the agent
+      // already knows the command didn't complete. Fires for both
+      // successful and error completions because the advice is the same
+      // ("next time, background it") in both cases.
+      const elapsedMs = Date.now() - executionStartTime;
+      if (elapsedMs >= LONG_RUNNING_FOREGROUND_THRESHOLD_MS) {
+        llmContent += `\n\n${buildLongRunningForegroundHint(elapsedMs)}`;
+      }
     }
 
     let returnDisplayMessage = '';

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -58,8 +58,17 @@ const DEFAULT_FOREGROUND_TIMEOUT_MS = 120000;
 // not at 60s. The 1/2 ratio is chosen so the hint surfaces well before
 // the timeout would hard-kill, but late enough that normal foreground
 // commands (under the 120s default) don't trigger it before ~60s.
+//
+// Floor of 1000ms guards the pathological `timeout: 0` / `timeout: 1`
+// edge: without a floor, `Math.floor(0 / 2)` is 0, so `elapsedMs >= 0`
+// would fire on every invocation showing "ran for 0s" — the hint would
+// surface before the command had a chance to fail by timing out.
+const MIN_LONG_RUN_THRESHOLD_MS = 1000;
 function longRunThresholdFor(effectiveTimeoutMs: number): number {
-  return Math.floor(effectiveTimeoutMs / 2);
+  return Math.max(
+    MIN_LONG_RUN_THRESHOLD_MS,
+    Math.floor(effectiveTimeoutMs / 2),
+  );
 }
 
 /**
@@ -78,13 +87,16 @@ export function buildLongRunningForegroundHint(elapsedMs: number): string {
   const seconds = Math.round(elapsedMs / 1000);
   return (
     `Note: this foreground command ran for ${seconds}s. ` +
-    `For long-running processes (build watchers, dev servers, soak ` +
-    `tests, polling loops), prefer re-running with ` +
-    `\`is_background: true\` so the agent isn't blocked while the ` +
-    `command runs. The output stays inspectable via /tasks (text, any ` +
-    `mode) or the on-disk output file; in interactive mode the ` +
-    `Background tasks dialog also has a per-entry detail view + live ` +
-    `updates.`
+    `Next time you run a similar long-running process (build watchers, ` +
+    `dev servers, soak tests, polling loops), pass \`is_background: true\` ` +
+    `so the agent isn't blocked while the command runs. ` +
+    `(This is forward-looking guidance for FUTURE invocations — do NOT ` +
+    `re-run the command that just completed; for stateful operations ` +
+    `like deploys, migrations, or git push, that would cause double ` +
+    `side effects.) The output of background runs stays inspectable ` +
+    `via /tasks (text, any mode) or the on-disk output file; in ` +
+    `interactive mode the Background tasks dialog also has a per-entry ` +
+    `detail view + live updates.`
   );
 }
 
@@ -595,7 +607,14 @@ export class ShellToolInvocation extends BaseToolInvocation<
     // can decide whether to append the long-run advisory. Mirrors the
     // `entry.startTime` capture in the background-shell path. Only added
     // side state for the foreground long-run hint feature.
-    const executionStartTime = Date.now();
+    //
+    // `performance.now()` (monotonic high-res, ms-precision) instead of
+    // `Date.now()` so NTP corrections / VM clock drift between capture
+    // and read can't make `elapsedMs` go negative (which would silently
+    // skip the hint with no observable failure). Returned origin is
+    // arbitrary but consistent across the two reads — only the
+    // difference matters here.
+    const executionStartTime = performance.now();
 
     const { result: resultPromise, pid } = await ShellExecutionService.execute(
       commandToExecute,
@@ -736,11 +755,21 @@ export class ShellToolInvocation extends BaseToolInvocation<
     //     and isn't representative of the command's actual wait.
     // Fires on both successful and naturally-failed completions since
     // the advice ("next time, background it") is the same in both.
-    const elapsedMs = Date.now() - executionStartTime;
+    const elapsedMs = performance.now() - executionStartTime;
+    const longRunThreshold = longRunThresholdFor(effectiveTimeout);
     const shouldAppendLongRunHint =
       !result.aborted &&
       result.signal === null &&
-      elapsedMs >= longRunThresholdFor(effectiveTimeout);
+      elapsedMs >= longRunThreshold;
+    // Observability: the hint decision is otherwise invisible. If a
+    // user reports "my 65s command didn't get the hint" or "5s command
+    // got the hint", the debug log shows which suppression branch fired
+    // (aborted / signal / under-threshold) plus the actual elapsed and
+    // computed threshold. No PII — just timing + result flags.
+    debugLogger.debug(
+      `long-run hint: elapsed=${Math.round(elapsedMs)}ms threshold=${longRunThreshold}ms ` +
+        `aborted=${result.aborted} signal=${result.signal} → ${shouldAppendLongRunHint ? 'fire' : 'suppress'}`,
+    );
 
     // returnDisplayMessage is rebuilt below. In debug mode it mirrors
     // `llmContent`, but the hint is appended AFTER both the truncation
@@ -800,23 +829,21 @@ export class ShellToolInvocation extends BaseToolInvocation<
     // header (which the LLM might misread as part of the command's own
     // output). The hint is process metadata about the command, not
     // command output, so it belongs outside the truncation envelope.
-    if (shouldAppendLongRunHint) {
+    const longRunHint = shouldAppendLongRunHint
+      ? buildLongRunningForegroundHint(elapsedMs)
+      : null;
+    if (longRunHint) {
       if (typeof llmContent === 'string') {
-        const hint = buildLongRunningForegroundHint(elapsedMs);
-        llmContent += `\n\n${hint}`;
+        llmContent += `\n\n${longRunHint}`;
         // Surface the hint in the user-facing TUI too — the user is
         // the one waiting for long commands and benefits from the
         // same "consider backgrounding next time" cue the agent sees.
-        // Debug mode mirrors the full llmContent (covers both the
-        // truncation block's stale snapshot and the new hint in one
-        // re-sync); non-debug mode appends only the hint to preserve
-        // the terse output-or-status form built above.
-        if (this.config.getDebugMode()) {
-          returnDisplayMessage = llmContent;
-        } else {
-          returnDisplayMessage +=
-            (returnDisplayMessage ? '\n\n' : '') + hint;
-        }
+        // Append (not replace) in BOTH modes so the truncation marker
+        // line ("Output too long and was saved to: ...") and any
+        // pre-existing returnDisplayMessage content (debug snapshot,
+        // status line, command output) are preserved.
+        returnDisplayMessage +=
+          (returnDisplayMessage ? '\n\n' : '') + longRunHint;
       }
       // else: llmContent is a structured `Part[]` / `Part` rather than
       // a plain string. Today shell.ts only emits string llmContent,
@@ -828,10 +855,19 @@ export class ShellToolInvocation extends BaseToolInvocation<
       // someone adds a non-string return path.
     }
 
+    // When `result.error` is set, `coreToolScheduler` builds the
+    // model-facing functionResponse from `error.message`, NOT from
+    // `llmContent` (see `convertToFunctionResponse` and the error
+    // branch in scheduler's success/error split). So for the
+    // long-running command-failed case the hint we appended to
+    // llmContent above would be silently dropped before reaching the
+    // agent. Append the hint to error.message too so the advisory
+    // survives whichever branch the scheduler takes.
     const executionError = result.error
       ? {
           error: {
-            message: result.error.message,
+            message:
+              result.error.message + (longRunHint ? `\n\n${longRunHint}` : ''),
             type: ToolErrorType.SHELL_EXECUTE_ERROR,
           },
         }

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -606,19 +606,6 @@ export class ShellToolInvocation extends BaseToolInvocation<
     let totalLines = 0;
     let totalBytes = 0;
 
-    // Bracket the spawn → settle wall-clock so the result builder below
-    // can decide whether to append the long-run advisory. Mirrors the
-    // `entry.startTime` capture in the background-shell path. Only added
-    // side state for the foreground long-run hint feature.
-    //
-    // `performance.now()` (monotonic high-res, ms-precision) instead of
-    // `Date.now()` so NTP corrections / VM clock drift between capture
-    // and read can't make `elapsedMs` go negative (which would silently
-    // skip the hint with no observable failure). Returned origin is
-    // arbitrary but consistent across the two reads — only the
-    // difference matters here.
-    const executionStartTime = performance.now();
-
     const { result: resultPromise, pid } = await ShellExecutionService.execute(
       commandToExecute,
       cwd,
@@ -689,6 +676,23 @@ export class ShellToolInvocation extends BaseToolInvocation<
     if (pid && setPidCallback) {
       setPidCallback(pid);
     }
+
+    // Bracket the spawn → settle wall-clock so the result builder below
+    // can decide whether to append the long-run advisory. Captured AFTER
+    // `await ShellExecutionService.execute(...)` returns its handle so
+    // pre-spawn setup (PTY dynamic import via `getPty()`, ~50–200ms on
+    // first call) is excluded — the elapsed should reflect the
+    // command's actual runtime, not the tool call's total wall time.
+    // The `pid` set above confirms the process has been spawned by this
+    // point, so subtraction below is true post-spawn-to-settle.
+    //
+    // `performance.now()` (monotonic high-res, ms-precision) instead of
+    // `Date.now()` so NTP corrections / VM clock drift between capture
+    // and read can't make `elapsedMs` go negative (which would silently
+    // skip the hint with no observable failure). Returned origin is
+    // arbitrary but consistent across the two reads — only the
+    // difference matters here.
+    const executionStartTime = performance.now();
 
     const result = await resultPromise;
 

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -50,26 +50,17 @@ const debugLogger = createDebugLogger('SHELL');
 
 export const OUTPUT_UPDATE_INTERVAL_MS = 1000;
 const DEFAULT_FOREGROUND_TIMEOUT_MS = 120000;
-/**
- * Wall-clock duration above which a foreground bash command that
- * **completed naturally** (process exited without abort signal and
- * without external SIGTERM/SIGKILL) earns a "consider re-running with
- * is_background: true" advisory in the LLM-facing tool result.
- *
- * Programmatically coupled to half the foreground timeout so the two
- * stay in sync if either is tuned later — long enough that normal
- * `npm install` / `pytest` runs don't trigger it, short enough that a
- * legitimately-long-but-completing command (e.g. a 90s build) still
- * gets the advisory before approaching the timeout. Note that timeout
- * and external-kill paths intentionally do NOT get the hint (their own
- * result messaging is enough — see suppression at the call site).
- *
- * Hint is advisory, not corrective: the command's own result is
- * unchanged. The advice targets the agent's NEXT decision.
- */
-const LONG_RUNNING_FOREGROUND_THRESHOLD_MS = Math.floor(
-  DEFAULT_FOREGROUND_TIMEOUT_MS / 2,
-);
+
+// Long-run advisory threshold: half the EFFECTIVE foreground timeout
+// (not the default), computed per-invocation by `longRunThresholdFor`.
+// Couples to whichever timeout actually governs THIS command — so a
+// user who sets `timeout: 600_000` (10 min) gets the advisory at 5 min,
+// not at 60s. The 1/2 ratio is chosen so the hint surfaces well before
+// the timeout would hard-kill, but late enough that normal foreground
+// commands (under the 120s default) don't trigger it before ~60s.
+function longRunThresholdFor(effectiveTimeoutMs: number): number {
+  return Math.floor(effectiveTimeoutMs / 2);
+}
 
 /**
  * Format the long-run advisory appended to long foreground commands.
@@ -742,8 +733,16 @@ export class ShellToolInvocation extends BaseToolInvocation<
     const shouldAppendLongRunHint =
       !result.aborted &&
       result.signal == null &&
-      elapsedMs >= LONG_RUNNING_FOREGROUND_THRESHOLD_MS;
+      elapsedMs >= longRunThresholdFor(effectiveTimeout);
 
+    // returnDisplayMessage is rebuilt below. In debug mode it mirrors
+    // `llmContent`, but the hint is appended AFTER both the truncation
+    // block and the returnDisplayMessage build (so debug-mode TUI shows
+    // the same pre-hint content the agent would see if hint were
+    // suppressed). We re-sync the debug branch after the hint append
+    // below so the user actually sees the advisory in the TUI too —
+    // otherwise the agent would suddenly suggest `is_background: true`
+    // with no visible trigger.
     let returnDisplayMessage = '';
     if (this.config.getDebugMode()) {
       returnDisplayMessage = llmContent;
@@ -794,8 +793,25 @@ export class ShellToolInvocation extends BaseToolInvocation<
     // header (which the LLM might misread as part of the command's own
     // output). The hint is process metadata about the command, not
     // command output, so it belongs outside the truncation envelope.
-    if (shouldAppendLongRunHint && typeof llmContent === 'string') {
-      llmContent += `\n\n${buildLongRunningForegroundHint(elapsedMs)}`;
+    if (shouldAppendLongRunHint) {
+      if (typeof llmContent === 'string') {
+        llmContent += `\n\n${buildLongRunningForegroundHint(elapsedMs)}`;
+        // Re-sync debug mode's mirror of llmContent so the TUI shows
+        // the same advisory the agent sees (otherwise the agent would
+        // suddenly suggest `is_background: true` with no visible
+        // trigger in debug mode).
+        if (this.config.getDebugMode()) {
+          returnDisplayMessage = llmContent;
+        }
+      }
+      // else: llmContent is a structured `Part[]` / `Part` rather than
+      // a plain string. Today shell.ts only emits string llmContent,
+      // but the type union allows structured content. If a future
+      // refactor changes that, the hint silently disappears here. We
+      // accept that risk for now — the alternative (encoding the hint
+      // as a Part) would require deciding on a rendering convention,
+      // and structured llmContent isn't on the roadmap. Revisit if
+      // someone adds a non-string return path.
     }
 
     const executionError = result.error

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -726,13 +726,20 @@ export class ShellToolInvocation extends BaseToolInvocation<
     //         `aborted` when the AbortSignal we passed was triggered,
     //         so external signals fall through to the non-aborted
     //         branch — same rationale as timeout.
-    //   - Wall-clock duration ≥ threshold.
+    //   - Wall-clock duration ≥ threshold. Measured spawn → resultPromise
+    //     settle, intentionally BEFORE the post-processing block below
+    //     (truncation I/O, output-file write). The hint reports how long
+    //     the COMMAND blocked the agent, not how long the tool call
+    //     spent including post-processing — that's the number the agent
+    //     should be reasoning about when deciding whether to background
+    //     next time. Truncation time is bounded by the temp-dir backend
+    //     and isn't representative of the command's actual wait.
     // Fires on both successful and naturally-failed completions since
     // the advice ("next time, background it") is the same in both.
     const elapsedMs = Date.now() - executionStartTime;
     const shouldAppendLongRunHint =
       !result.aborted &&
-      result.signal == null &&
+      result.signal === null &&
       elapsedMs >= longRunThresholdFor(effectiveTimeout);
 
     // returnDisplayMessage is rebuilt below. In debug mode it mirrors
@@ -795,13 +802,20 @@ export class ShellToolInvocation extends BaseToolInvocation<
     // command output, so it belongs outside the truncation envelope.
     if (shouldAppendLongRunHint) {
       if (typeof llmContent === 'string') {
-        llmContent += `\n\n${buildLongRunningForegroundHint(elapsedMs)}`;
-        // Re-sync debug mode's mirror of llmContent so the TUI shows
-        // the same advisory the agent sees (otherwise the agent would
-        // suddenly suggest `is_background: true` with no visible
-        // trigger in debug mode).
+        const hint = buildLongRunningForegroundHint(elapsedMs);
+        llmContent += `\n\n${hint}`;
+        // Surface the hint in the user-facing TUI too — the user is
+        // the one waiting for long commands and benefits from the
+        // same "consider backgrounding next time" cue the agent sees.
+        // Debug mode mirrors the full llmContent (covers both the
+        // truncation block's stale snapshot and the new hint in one
+        // re-sync); non-debug mode appends only the hint to preserve
+        // the terse output-or-status form built above.
         if (this.config.getDebugMode()) {
           returnDisplayMessage = llmContent;
+        } else {
+          returnDisplayMessage +=
+            (returnDisplayMessage ? '\n\n' : '') + hint;
         }
       }
       // else: llmContent is a structured `Part[]` / `Part` rather than

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -778,14 +778,20 @@ export class ShellToolInvocation extends BaseToolInvocation<
         `aborted=${result.aborted} signal=${result.signal} → ${shouldAppendLongRunHint ? 'fire' : 'suppress'}`,
     );
 
-    // returnDisplayMessage is rebuilt below. In debug mode it mirrors
-    // `llmContent`, but the hint is appended AFTER both the truncation
-    // block and the returnDisplayMessage build (so debug-mode TUI shows
-    // the same pre-hint content the agent would see if hint were
-    // suppressed). We re-sync the debug branch after the hint append
-    // below so the user actually sees the advisory in the TUI too —
-    // otherwise the agent would suddenly suggest `is_background: true`
-    // with no visible trigger.
+    // returnDisplayMessage build order — chronologically:
+    //   1. Initial value: in debug mode, snapshot of pre-truncation
+    //      `llmContent`; in non-debug mode, terse output-or-status.
+    //   2. Truncation block (below) appends `Output too long and was
+    //      saved to: <path>` if truncation fired (BOTH modes).
+    //   3. Long-run hint append (further below) appends the hint
+    //      itself with append-style re-sync (BOTH modes), so the user
+    //      sees the same advisory the agent does — otherwise the
+    //      agent would suddenly suggest `is_background: true` with no
+    //      visible trigger in the TUI.
+    // The pre-existing debug snapshot is captured here (pre-truncation,
+    // pre-hint); both subsequent steps APPEND to it rather than
+    // replacing, so all information accumulates rather than being lost
+    // when later steps fire.
     let returnDisplayMessage = '';
     if (this.config.getDebugMode()) {
       returnDisplayMessage = llmContent;
@@ -865,11 +871,21 @@ export class ShellToolInvocation extends BaseToolInvocation<
     // When `result.error` is set, `coreToolScheduler` builds the
     // model-facing functionResponse from `error.message`, NOT from
     // `llmContent` (see `convertToFunctionResponse` and the error
-    // branch in scheduler's success/error split). So for the
-    // long-running command-failed case the hint we appended to
-    // llmContent above would be silently dropped before reaching the
-    // agent. Append the hint to error.message too so the advisory
-    // survives whichever branch the scheduler takes.
+    // branch in scheduler's success/error split). So if a long
+    // command hits this path the hint we appended to llmContent above
+    // would be silently dropped before reaching the agent. Append the
+    // hint to error.message too so the advisory survives whichever
+    // branch the scheduler takes.
+    //
+    // Note on reach: `ShellExecutionResult.error` is reserved for
+    // SPAWN / setup failures (per the field's doc comment in
+    // shellExecutionService.ts); non-zero exits leave it null. Real
+    // spawn failures (ENOENT, permission denied) typically resolve in
+    // <1s, so the elapsed >= threshold + spawn-error combination is
+    // rare. The preservation is here for the slow-spawn edge cases
+    // (PTY init dragging, remote-fs exec syscalls, security scanners
+    // interposing) where the rare path could still trigger and the
+    // hint would otherwise vanish.
     //
     // Use a `---` divider line so downstream consumers of
     // `error.message` (firePostToolUseFailureHook, telemetry grouping,

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -59,10 +59,13 @@ const DEFAULT_FOREGROUND_TIMEOUT_MS = 120000;
 // the timeout would hard-kill, but late enough that normal foreground
 // commands (under the 120s default) don't trigger it before ~60s.
 //
-// Floor of 1000ms guards the pathological `timeout: 0` / `timeout: 1`
-// edge: without a floor, `Math.floor(0 / 2)` is 0, so `elapsedMs >= 0`
-// would fire on every invocation showing "ran for 0s" — the hint would
-// surface before the command had a chance to fail by timing out.
+// Floor of 1000ms guards the pathological tiny-positive-timeout edge.
+// `timeout <= 0` is already rejected by `validateToolParamValues` so
+// only positive values reach here, but `timeout: 1` (or any value < 2)
+// would otherwise produce `Math.floor(timeout / 2) = 0` and make
+// `elapsedMs >= 0` fire on every invocation showing "ran for 0s",
+// surfacing the hint before the command had a chance to fail by
+// timing out.
 const MIN_LONG_RUN_THRESHOLD_MS = 1000;
 function longRunThresholdFor(effectiveTimeoutMs: number): number {
   return Math.max(
@@ -863,11 +866,18 @@ export class ShellToolInvocation extends BaseToolInvocation<
     // llmContent above would be silently dropped before reaching the
     // agent. Append the hint to error.message too so the advisory
     // survives whichever branch the scheduler takes.
+    //
+    // Use a `---` divider line so downstream consumers of
+    // `error.message` (firePostToolUseFailureHook, telemetry grouping,
+    // SIEM alerting, hook-side error parsers) have an unambiguous
+    // boundary they can split on rather than getting ~400 chars of
+    // advisory text mixed inline with the original error body.
     const executionError = result.error
       ? {
           error: {
             message:
-              result.error.message + (longRunHint ? `\n\n${longRunHint}` : ''),
+              result.error.message +
+              (longRunHint ? `\n\n---\n${longRunHint}` : ''),
             type: ToolErrorType.SHELL_EXECUTE_ERROR,
           },
         }

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -51,21 +51,37 @@ const debugLogger = createDebugLogger('SHELL');
 export const OUTPUT_UPDATE_INTERVAL_MS = 1000;
 const DEFAULT_FOREGROUND_TIMEOUT_MS = 120000;
 /**
- * Wall-clock duration above which a foreground bash command earns a
- * "consider re-running with is_background: true" advisory in the LLM-
- * facing tool result. Half the default 120s timeout — long enough that
- * normal `npm install` / `pytest` runs don't trigger it, short enough
- * that a hung-but-still-streaming process surfaces the suggestion before
- * it gets killed by the timeout. Hint is advisory, not corrective: the
- * command's own result is unchanged.
+ * Wall-clock duration above which a foreground bash command that
+ * **completed naturally** (process exited without abort signal and
+ * without external SIGTERM/SIGKILL) earns a "consider re-running with
+ * is_background: true" advisory in the LLM-facing tool result.
+ *
+ * Programmatically coupled to half the foreground timeout so the two
+ * stay in sync if either is tuned later — long enough that normal
+ * `npm install` / `pytest` runs don't trigger it, short enough that a
+ * legitimately-long-but-completing command (e.g. a 90s build) still
+ * gets the advisory before approaching the timeout. Note that timeout
+ * and external-kill paths intentionally do NOT get the hint (their own
+ * result messaging is enough — see suppression at the call site).
+ *
+ * Hint is advisory, not corrective: the command's own result is
+ * unchanged. The advice targets the agent's NEXT decision.
  */
-const LONG_RUNNING_FOREGROUND_THRESHOLD_MS = 60000;
+const LONG_RUNNING_FOREGROUND_THRESHOLD_MS = Math.floor(
+  DEFAULT_FOREGROUND_TIMEOUT_MS / 2,
+);
 
 /**
  * Format the long-run advisory appended to long foreground commands.
  * Exported so tests and any future consumer (e.g. an alternative
  * renderer) can render the same text without duplicating the threshold
  * logic.
+ *
+ * Wording deliberately keeps the dialog mention conditional ("when
+ * running interactively") so the LLM doesn't relay misleading guidance
+ * to non-TTY users (`-p` headless / ACP / SDK consumers, where no
+ * dialog or footer pill exists). `/tasks` and the on-disk output file
+ * work in every mode.
  */
 export function buildLongRunningForegroundHint(elapsedMs: number): string {
   const seconds = Math.round(elapsedMs / 1000);
@@ -74,9 +90,10 @@ export function buildLongRunningForegroundHint(elapsedMs: number): string {
     `For long-running processes (build watchers, dev servers, soak ` +
     `tests, polling loops), prefer re-running with ` +
     `\`is_background: true\` so the agent isn't blocked while the ` +
-    `command runs. The output stays inspectable via /tasks (text), the ` +
-    `interactive Background tasks dialog (footer pill + Enter), and ` +
-    `the on-disk output file.`
+    `command runs. The output stays inspectable via /tasks (text, any ` +
+    `mode) or the on-disk output file; in interactive mode the ` +
+    `Background tasks dialog also has a per-entry detail view + live ` +
+    `updates.`
   );
 }
 
@@ -585,8 +602,8 @@ export class ShellToolInvocation extends BaseToolInvocation<
 
     // Bracket the spawn → settle wall-clock so the result builder below
     // can decide whether to append the long-run advisory. Mirrors the
-    // background path's `entry.startTime` capture (line ~781) and is the
-    // only added side state for the foreground long-run hint feature.
+    // `entry.startTime` capture in the background-shell path. Only added
+    // side state for the foreground long-run hint feature.
     const executionStartTime = Date.now();
 
     const { result: resultPromise, pid } = await ShellExecutionService.execute(
@@ -700,18 +717,32 @@ export class ShellToolInvocation extends BaseToolInvocation<
         `Process Group PGID: ${result.pid ?? '(none)'}`,
       ].join('\n');
 
-      // Long-run advisory: only on the non-aborted branch. Timeout /
-      // user-cancel paths (the `if (result.aborted)` arm above) already
-      // surface the duration via their own message and benefit nothing
-      // from a "should have been background" reminder — the agent
-      // already knows the command didn't complete. Fires for both
-      // successful and error completions because the advice is the same
-      // ("next time, background it") in both cases.
-      const elapsedMs = Date.now() - executionStartTime;
-      if (elapsedMs >= LONG_RUNNING_FOREGROUND_THRESHOLD_MS) {
-        llmContent += `\n\n${buildLongRunningForegroundHint(elapsedMs)}`;
-      }
+      // (Long-run advisory append happens AFTER `truncateToolOutput`
+      // below — see the explanation there for why post-truncation.)
     }
+    // Decide whether to emit the long-run advisory. Conditions:
+    //   - Process completed under its own steam (no AbortSignal
+    //     trigger, no external signal). Specifically:
+    //       * Suppressed on aborted (`result.aborted: true`) — covers
+    //         the `if (result.aborted)` arm above (timeout / user-
+    //         cancel). Their own messaging is enough; a "should have
+    //         been background" reminder when the agent already knows
+    //         the command didn't complete is noise.
+    //       * Suppressed on external signal kills (`result.signal !=
+    //         null` with `aborted: false`, e.g. SIGTERM from container
+    //         shutdown, k8s eviction, OOM killer, sibling reaping the
+    //         process group). `shellExecutionService` only sets
+    //         `aborted` when the AbortSignal we passed was triggered,
+    //         so external signals fall through to the non-aborted
+    //         branch — same rationale as timeout.
+    //   - Wall-clock duration ≥ threshold.
+    // Fires on both successful and naturally-failed completions since
+    // the advice ("next time, background it") is the same in both.
+    const elapsedMs = Date.now() - executionStartTime;
+    const shouldAppendLongRunHint =
+      !result.aborted &&
+      result.signal == null &&
+      elapsedMs >= LONG_RUNNING_FOREGROUND_THRESHOLD_MS;
 
     let returnDisplayMessage = '';
     if (this.config.getDebugMode()) {
@@ -756,6 +787,15 @@ export class ShellToolInvocation extends BaseToolInvocation<
           (returnDisplayMessage ? '\n' : '') +
           `Output too long and was saved to: ${truncatedResult.outputFile}`;
       }
+    }
+
+    // Append the long-run advisory AFTER truncation so the hint isn't
+    // wrapped in `truncateToolOutput`'s "Truncated part of the output"
+    // header (which the LLM might misread as part of the command's own
+    // output). The hint is process metadata about the command, not
+    // command output, so it belongs outside the truncation envelope.
+    if (shouldAppendLongRunHint && typeof llmContent === 'string') {
+      llmContent += `\n\n${buildLongRunningForegroundHint(elapsedMs)}`;
     }
 
     const executionError = result.error


### PR DESCRIPTION
## Summary

Phase D part (a) of Issue #3634. When a foreground `shell` tool call runs past a duration threshold and completes (succeeds or errors), the LLM-facing tool result gets an advisory line suggesting `is_background: true` for similar long-running commands next time. The threshold is **half the effective timeout** (per-invocation, not a fixed constant), with a 1000ms floor — so a default-timeout (120s) call gets the advisory at 60s, an explicit `timeout: 600_000` call gets it at 300s, and pathological tiny timeouts (`timeout: 1`) don't surface a "ran for 0s" advisory. The advisory itself explicitly warns against re-running the just-completed command (matters for stateful operations like deploys, migrations, `git push`).

**Why this matters**: today a foreground bash that takes minutes (build watcher, soak test, slow `npm install`, polling loop) blocks the agent indefinitely. The user is already paying for the wait; the agent's next turn could have been running in parallel under `is_background: true`. Sleep interception (#3684) handled the egregious `sleep N` case at *validate* time; this handles the legitimate-but-long case at *result* time.

**Size**: ~5 commits, 2 files (`shell.ts` + `shell.test.ts`), 91 tests after additions. Pure additive — no existing behaviour changed.

## Before / After

**Before** (foreground command that took 90 seconds):
```
Command: npm run build
Directory: (root)
Output: ...build output...
Error: (none)
Exit Code: 0
Signal: (none)
Process Group PGID: 12345
```

**After**:
```
Command: npm run build
Directory: (root)
Output: ...build output...
Error: (none)
Exit Code: 0
Signal: (none)
Process Group PGID: 12345

Note: this foreground command ran for 90s. Next time you run a similar long-running process (build watchers, dev servers, soak tests, polling loops), pass `is_background: true` so the agent isn't blocked while the command runs. (This is forward-looking guidance for FUTURE invocations — do NOT re-run the command that just completed; for stateful operations like deploys, migrations, or git push, that would cause double side effects.) The output of background runs stays inspectable via /tasks (text, any mode) or the on-disk output file; in interactive mode the Background tasks dialog also has a per-entry detail view + live updates.
```

## Design notes

- **Threshold = effective timeout / 2, floored at 1000ms** (per-invocation; was previously a fixed 60s constant). For the default `DEFAULT_FOREGROUND_TIMEOUT_MS = 120s` the threshold is 60s; for an explicit `timeout: 600_000` call it's 5 min — respects the user's signalled expectation that the command will take long. The 1000ms floor guards `timeout: 1` (smallest non-rejected pathological value; `timeout <= 0` is rejected at validate time) so the advisory doesn't fire showing "ran for 0s".
- **Advisory, not corrective.** The command still runs to completion in the foreground for THIS invocation. The advice is for the agent's NEXT decision. Wording explicitly warns against re-running the just-completed command — for stateful operations (DB migrations, deploys, `git push`), retrying would cause double side effects. This guard came out of review (gpt-5.5 flagged the original "prefer re-running" wording as ambiguous).
- **Fires on success AND error completions.** A 90s command that errors is just as much "should have been background" as a 90s command that succeeded — the agent's blocking time was the same. So we append in both branches of the non-aborted result builder.
- **Hint survives the error path** via `error.message`. `coreToolScheduler` builds the model-facing functionResponse from `error.message` (NOT from `llmContent`) when `toolResult.error` is set. So the hint is appended to BOTH `llmContent` AND `error.message` — with a `\n---\n` divider in `error.message` so downstream consumers (`firePostToolUseFailureHook`, telemetry grouping, SIEM, hook parsers) have an unambiguous boundary they can split on instead of getting ~400 chars of advisory mixed inline.
- **Suppressed on aborted (timeout / user-cancel) AND external signal** (`result.signal !== null` with `aborted: false`, e.g. SIGTERM from container shutdown / k8s eviction / OOM killer). Their own messaging is enough; the process didn't run to its conclusion, so "next time, background it" doesn't apply.
- **`performance.now()` instead of `Date.now()`** for the elapsed bracket — monotonic high-res clock, NTP corrections / VM clock drift between capture and read can't make `elapsedMs` go negative and silently skip the hint.
- **Append AFTER `truncateToolOutput`** so the hint isn't wrapped in the "Truncated part of the output:" envelope (which the LLM might misread as part of the command's own output).
- **Re-syncs both debug and non-debug TUI** so the user sees the same advisory the agent does (otherwise the agent would suddenly suggest `is_background: true` with no visible trigger). Append-style re-sync preserves the truncation marker line if both fire together.
- **`debugLogger.debug` at the decision point** logs `elapsed=Nms threshold=Mms aborted=X signal=Y → fire/suppress` so support reports like "my 65s command didn't get the hint" can be diagnosed via DEBUG output.
- **One-call helper**: `buildLongRunningForegroundHint(elapsedMs)` is exported so a future UI surface or telemetry consumer can render the same text without duplicating the threshold-driven logic. Today only the LLM result uses it.

## Why this is foreground-only

Background commands return immediately with a shell ID — they're never blocking the agent for the threshold duration by construction. The hint is meaningful only on the path that actually blocks.

## Test plan

- [x] `vitest run packages/core/src/tools/shell.test.ts`: **91 / 91 pass** (covers threshold scaling positive + negative, threshold floor, debug + non-debug returnDisplay, error.message hint surfacing, aborted / timeout / external-signal suppression, off-by-one boundary, post-truncation insertion)
- [x] `tsc --build packages/cli` (CI-equivalent full mode): clean
- [x] `npm run build --workspace=@qwen-code/qwen-code-core`: clean
- [x] ESLint clean
- [ ] **Manual smoke (留给 reviewer)**: run a foreground bash command that takes 60+ seconds (e.g. `sleep 65 && echo done`)→ verify the advisory line appears in the LLM-facing tool result; run a 5-second command → verify no advisory; run with `timeout: 600_000` for 100s → verify no advisory (scaled threshold).

## 中文版

Issue #3634 Phase D 第 (a) 部分。前台 `shell` 工具调用运行**超过阈值**并完成（成功或出错）后，给 LLM 看的工具结果末尾加一行建议，提示下次用 `is_background: true`。阈值是**有效 timeout 的一半**（按调用计算，不是固定常量），下限 1000ms — 默认 timeout（120s）的调用 60s 触发；显式 `timeout: 600_000` 调用 5 分钟触发；病态小 timeout（`timeout: 1`）不会"跑了 0 秒"误触发。建议文案显式警告**不要重跑刚完成的命令**（DB 迁移、部署、`git push` 等有副作用操作要紧）。

**为什么**：今天前台 bash 跑几分钟（build watcher、长测、慢 `npm install`、轮询循环）会无限阻塞 agent。用户已经在等了；agent 的下一轮其实可以在后台并行跑。Sleep 拦截（#3684）处理了恶劣的 `sleep N` 在 validate 时拒绝；这个处理合理但慢的情况在 result 时建议。

**体量**：~5 commits（含多轮 review 修补），2 个文件，最终 91 测试。

**设计要点**：
- **阈值 = 有效 timeout / 2，下限 1000ms**（按调用算，不是固定常量）。默认 `DEFAULT_FOREGROUND_TIMEOUT_MS=120s` → 阈值 60s；显式 `timeout: 600_000` → 阈值 5 分钟，尊重用户对长命令的预期。下限 1000ms 守 `timeout: 1`（最小未被 validate 拒绝的病态值；`timeout <= 0` 在 validate 阶段已拒），避免"跑 0s"虚警。
- **建议性，不强制**，文案明确**禁止重跑**已完成命令（review 抓到的歧义 — 重跑 stateful 操作会双重副作用）。
- **成功 + 错误路径都触发**。错误路径**通过 `error.message` 单独追加**（`coreToolScheduler` 错误分支用 `error.message` 不用 llmContent），并加 `\n---\n` 分隔符让下游消费者（hook / 遥测 / SIEM / parser）有明确边界。
- **被取消 / 外部信号都不触发**（`result.aborted` 或 `result.signal !== null` 都跳过 — 命令没自己跑完）。
- **`performance.now()`** 不用 `Date.now()`，monotonic 高精度，NTP 校时 / VM 漂移不会让 elapsed 变负静默丢 hint。
- **截断之后**追加（不被 `truncateToolOutput` 的"Truncated part of the output:" 信壳包裹，避免 LLM 误读为命令输出）。
- **debug + 非 debug TUI 都重新同步**（用户能看到跟 agent 一样的提示），append-style 保留 truncation marker。
- **`debugLogger.debug`** 在决策点输出 `elapsed/threshold/aborted/signal/fire-or-suppress`，线上"为啥没出现 hint"问题可调试。
- **导出 helper `buildLongRunningForegroundHint`** — 未来 UI / 遥测复用同样文本。

## Related

- Issue #3634 (Phase B/C/D alignment roadmap — this is Phase D part (a))
- #3684 (sleep interception — same advisory shape, different trigger; this PR catches the legitimate-but-long case that sleep interception lets through by design)
