### PR TITLE
fix(core): clear FileReadCache on every history rewrite path

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -457,6 +457,78 @@ describe('Gemini Client (client.ts)', () => {
       expect(newHistory.length).toBe(initialHistory.length);
       expect(JSON.stringify(newHistory)).not.toContain('some old message');
     });
+
+    it('clears the FileReadCache so post-reset Reads re-emit content', async () => {
+      const cacheClear = vi.fn();
+      vi.mocked(mockConfig.getFileReadCache).mockReturnValue({
+        clear: cacheClear,
+      } as unknown as ReturnType<Config['getFileReadCache']>);
+
+      await client.resetChat();
+
+      expect(cacheClear).toHaveBeenCalled();
+    });
+  });
+
+  describe('history mutation invalidates FileReadCache', () => {
+    it('setHistory clears the cache', () => {
+      const cacheClear = vi.fn();
+      vi.mocked(mockConfig.getFileReadCache).mockReturnValue({
+        clear: cacheClear,
+      } as unknown as ReturnType<Config['getFileReadCache']>);
+      client['chat'] = {
+        setHistory: vi.fn(),
+      } as unknown as GeminiChat;
+
+      client.setHistory([{ role: 'user', parts: [{ text: 'replaced' }] }]);
+
+      expect(cacheClear).toHaveBeenCalled();
+    });
+
+    it('truncateHistory clears the cache', () => {
+      const cacheClear = vi.fn();
+      vi.mocked(mockConfig.getFileReadCache).mockReturnValue({
+        clear: cacheClear,
+      } as unknown as ReturnType<Config['getFileReadCache']>);
+      client['chat'] = {
+        truncateHistory: vi.fn(),
+      } as unknown as GeminiChat;
+
+      client.truncateHistory(2);
+
+      expect(cacheClear).toHaveBeenCalled();
+    });
+
+    it('retry strips orphaned trailing user entries and clears the cache', async () => {
+      const cacheClear = vi.fn();
+      vi.mocked(mockConfig.getFileReadCache).mockReturnValue({
+        clear: cacheClear,
+      } as unknown as ReturnType<Config['getFileReadCache']>);
+      const stripOrphanedUserEntriesFromHistory = vi.fn();
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        stripOrphanedUserEntriesFromHistory,
+      } as unknown as GeminiChat;
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: GeminiEventType.Content, value: 'response' };
+        })(),
+      );
+
+      const stream = client.sendMessageStream(
+        [{ text: 'retry' }],
+        new AbortController().signal,
+        'prompt-retry-1',
+        { type: SendMessageType.Retry },
+      );
+      for await (const _ of stream) {
+        /* drain */
+      }
+
+      expect(stripOrphanedUserEntriesFromHistory).toHaveBeenCalled();
+      expect(cacheClear).toHaveBeenCalled();
+    });
   });
 
   describe('thinking block idle cleanup and latch', () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -479,32 +479,56 @@ describe('Gemini Client (client.ts)', () => {
       expect(cacheClear).toHaveBeenCalled();
     });
 
-    it('truncateHistory clears the cache when entries are actually removed', () => {
-      const cacheClear = mockFileReadCacheClear();
-      client['chat'] = {
-        getHistoryLength: vi.fn().mockReturnValue(3),
+    /**
+     * Test helper: mock a GeminiChat whose history length goes from
+     * `before` to `after` across truncateHistory(). The first
+     * getHistoryLength() call (pre-truncate) returns `before`; the
+     * second (post-truncate) returns `after`.
+     */
+    function mockChatWithLengths(before: number, after: number): GeminiChat {
+      return {
+        getHistoryLength: vi
+          .fn()
+          .mockReturnValueOnce(before)
+          .mockReturnValueOnce(after),
         truncateHistory: vi.fn(),
       } as unknown as GeminiChat;
+    }
+
+    it('truncateHistory clears the cache when entries are actually removed', () => {
+      const cacheClear = mockFileReadCacheClear();
+      client['chat'] = mockChatWithLengths(3, 2);
 
       client.truncateHistory(2);
 
       expect(cacheClear).toHaveBeenCalled();
     });
 
-    it('truncateHistory does NOT clear the cache when keepCount >= history length (no-op)', () => {
+    it('truncateHistory does NOT clear the cache when nothing was removed (keepCount >= history length)', () => {
       const cacheClear = mockFileReadCacheClear();
-      client['chat'] = {
-        getHistoryLength: vi.fn().mockReturnValue(2),
-        truncateHistory: vi.fn(),
-      } as unknown as GeminiChat;
 
-      // keepCount equals history length — nothing dropped, cache stays valid.
+      // keepCount equals history length — nothing dropped.
+      client['chat'] = mockChatWithLengths(2, 2);
       client.truncateHistory(2);
       expect(cacheClear).not.toHaveBeenCalled();
 
       // keepCount exceeds history length — also a no-op.
+      client['chat'] = mockChatWithLengths(2, 2);
       client.truncateHistory(99);
       expect(cacheClear).not.toHaveBeenCalled();
+    });
+
+    it('truncateHistory clears the cache when a non-finite keepCount empties history (NaN regression)', () => {
+      // slice(0, NaN) returns [], but `NaN < prevLen` evaluates to
+      // false. Comparing the actual post-truncate length closes that
+      // hole — without this guard the cache would survive a history
+      // wipe and the file_unchanged placeholder bug returns.
+      const cacheClear = mockFileReadCacheClear();
+      client['chat'] = mockChatWithLengths(3, 0);
+
+      client.truncateHistory(NaN);
+
+      expect(cacheClear).toHaveBeenCalled();
     });
 
     it('truncateHistory uses O(1) getHistoryLength, not getHistory (avoids structuredClone)', () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -459,10 +459,7 @@ describe('Gemini Client (client.ts)', () => {
     });
 
     it('clears the FileReadCache so post-reset Reads re-emit content', async () => {
-      const cacheClear = vi.fn();
-      vi.mocked(mockConfig.getFileReadCache).mockReturnValue({
-        clear: cacheClear,
-      } as unknown as ReturnType<Config['getFileReadCache']>);
+      const cacheClear = mockFileReadCacheClear();
 
       await client.resetChat();
 
@@ -472,10 +469,7 @@ describe('Gemini Client (client.ts)', () => {
 
   describe('history mutation invalidates FileReadCache', () => {
     it('setHistory clears the cache', () => {
-      const cacheClear = vi.fn();
-      vi.mocked(mockConfig.getFileReadCache).mockReturnValue({
-        clear: cacheClear,
-      } as unknown as ReturnType<Config['getFileReadCache']>);
+      const cacheClear = mockFileReadCacheClear();
       client['chat'] = {
         setHistory: vi.fn(),
       } as unknown as GeminiChat;
@@ -485,12 +479,14 @@ describe('Gemini Client (client.ts)', () => {
       expect(cacheClear).toHaveBeenCalled();
     });
 
-    it('truncateHistory clears the cache', () => {
-      const cacheClear = vi.fn();
-      vi.mocked(mockConfig.getFileReadCache).mockReturnValue({
-        clear: cacheClear,
-      } as unknown as ReturnType<Config['getFileReadCache']>);
+    it('truncateHistory clears the cache when entries are actually removed', () => {
+      const cacheClear = mockFileReadCacheClear();
       client['chat'] = {
+        getHistory: vi.fn().mockReturnValue([
+          { role: 'user', parts: [{ text: 'a' }] },
+          { role: 'model', parts: [{ text: 'b' }] },
+          { role: 'user', parts: [{ text: 'c' }] },
+        ]),
         truncateHistory: vi.fn(),
       } as unknown as GeminiChat;
 
@@ -499,11 +495,27 @@ describe('Gemini Client (client.ts)', () => {
       expect(cacheClear).toHaveBeenCalled();
     });
 
+    it('truncateHistory does NOT clear the cache when keepCount >= history length (no-op)', () => {
+      const cacheClear = mockFileReadCacheClear();
+      client['chat'] = {
+        getHistory: vi.fn().mockReturnValue([
+          { role: 'user', parts: [{ text: 'a' }] },
+          { role: 'model', parts: [{ text: 'b' }] },
+        ]),
+        truncateHistory: vi.fn(),
+      } as unknown as GeminiChat;
+
+      // keepCount equals history length — nothing dropped, cache stays valid.
+      client.truncateHistory(2);
+      expect(cacheClear).not.toHaveBeenCalled();
+
+      // keepCount exceeds history length — also a no-op.
+      client.truncateHistory(99);
+      expect(cacheClear).not.toHaveBeenCalled();
+    });
+
     it('retry strips orphaned trailing user entries and clears the cache', async () => {
-      const cacheClear = vi.fn();
-      vi.mocked(mockConfig.getFileReadCache).mockReturnValue({
-        clear: cacheClear,
-      } as unknown as ReturnType<Config['getFileReadCache']>);
+      const cacheClear = mockFileReadCacheClear();
       const stripOrphanedUserEntriesFromHistory = vi.fn();
       client['chat'] = {
         addHistory: vi.fn(),
@@ -530,6 +542,19 @@ describe('Gemini Client (client.ts)', () => {
       expect(cacheClear).toHaveBeenCalled();
     });
   });
+
+  /**
+   * Test helper: replace mockConfig.getFileReadCache to return a stub
+   * whose clear() is a fresh spy. Returned spy lets tests assert on
+   * whether a code path invalidated the cache.
+   */
+  function mockFileReadCacheClear(): ReturnType<typeof vi.fn> {
+    const clearMock = vi.fn();
+    vi.mocked(mockConfig.getFileReadCache).mockReturnValue({
+      clear: clearMock,
+    } as unknown as ReturnType<Config['getFileReadCache']>);
+    return clearMock;
+  }
 
   describe('thinking block idle cleanup and latch', () => {
     let mockChat: Partial<GeminiChat>;
@@ -621,10 +646,7 @@ describe('Gemini Client (client.ts)', () => {
       // toolResultsNumToKeep = 5. Six read_file results + a 90-minute
       // idle gap means the oldest one gets cleared, so the if-meta
       // branch in sendMessageStream fires and must invalidate the cache.
-      const cacheClear = vi.fn();
-      vi.mocked(mockConfig.getFileReadCache).mockReturnValue({
-        clear: cacheClear,
-      } as unknown as ReturnType<Config['getFileReadCache']>);
+      const cacheClear = mockFileReadCacheClear();
 
       const history = makeReadFileResponses(6);
       const setHistory = vi.fn();
@@ -650,10 +672,7 @@ describe('Gemini Client (client.ts)', () => {
     });
 
     it('does not clear the cache when the idle gap is below the threshold', async () => {
-      const cacheClear = vi.fn();
-      vi.mocked(mockConfig.getFileReadCache).mockReturnValue({
-        clear: cacheClear,
-      } as unknown as ReturnType<Config['getFileReadCache']>);
+      const cacheClear = mockFileReadCacheClear();
 
       const history = makeReadFileResponses(6);
       client['chat'] = {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -506,6 +506,106 @@ describe('Gemini Client (client.ts)', () => {
     });
   });
 
+  describe('microcompaction FileReadCache invalidation', () => {
+    function makeReadFileResponses(count: number): Content[] {
+      const out: Content[] = [];
+      for (let i = 0; i < count; i++) {
+        out.push({
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                name: 'read_file',
+                args: { file_path: `/x/${i}.ts` },
+              },
+            },
+          ],
+        });
+        out.push({
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                name: 'read_file',
+                response: { output: `content of ${i}` },
+              },
+            },
+          ],
+        });
+      }
+      return out;
+    }
+
+    beforeEach(() => {
+      mockTurnRunFn.mockReturnValue(
+        (async function* () {
+          yield { type: GeminiEventType.Content, value: 'response' };
+        })(),
+      );
+    });
+
+    it('clears the cache after microcompaction strips old read_file results', async () => {
+      // Default test fixture: toolResultsThresholdMinutes = 60,
+      // toolResultsNumToKeep = 5. Six read_file results + a 90-minute
+      // idle gap means the oldest one gets cleared, so the if-meta
+      // branch in sendMessageStream fires and must invalidate the cache.
+      const cacheClear = vi.fn();
+      vi.mocked(mockConfig.getFileReadCache).mockReturnValue({
+        clear: cacheClear,
+      } as unknown as ReturnType<Config['getFileReadCache']>);
+
+      const history = makeReadFileResponses(6);
+      const setHistory = vi.fn();
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue(history),
+        setHistory,
+      } as unknown as GeminiChat;
+      client['lastApiCompletionTimestamp'] = Date.now() - 90 * 60_000;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'hi' }],
+        new AbortController().signal,
+        'prompt-mc-clear-1',
+        { type: SendMessageType.UserQuery },
+      );
+      for await (const _ of stream) {
+        /* drain */
+      }
+
+      expect(setHistory).toHaveBeenCalled();
+      expect(cacheClear).toHaveBeenCalled();
+    });
+
+    it('does not clear the cache when the idle gap is below the threshold', async () => {
+      const cacheClear = vi.fn();
+      vi.mocked(mockConfig.getFileReadCache).mockReturnValue({
+        clear: cacheClear,
+      } as unknown as ReturnType<Config['getFileReadCache']>);
+
+      const history = makeReadFileResponses(6);
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue(history),
+        setHistory: vi.fn(),
+      } as unknown as GeminiChat;
+      // Recent activity — microcompaction must not fire.
+      client['lastApiCompletionTimestamp'] = Date.now() - 30 * 1000;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'hi' }],
+        new AbortController().signal,
+        'prompt-mc-clear-2',
+        { type: SendMessageType.UserQuery },
+      );
+      for await (const _ of stream) {
+        /* drain */
+      }
+
+      expect(cacheClear).not.toHaveBeenCalled();
+    });
+  });
+
   describe('tryCompressChat', () => {
     const mockGetHistory = vi.fn();
 

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -482,11 +482,7 @@ describe('Gemini Client (client.ts)', () => {
     it('truncateHistory clears the cache when entries are actually removed', () => {
       const cacheClear = mockFileReadCacheClear();
       client['chat'] = {
-        getHistory: vi.fn().mockReturnValue([
-          { role: 'user', parts: [{ text: 'a' }] },
-          { role: 'model', parts: [{ text: 'b' }] },
-          { role: 'user', parts: [{ text: 'c' }] },
-        ]),
+        getHistoryLength: vi.fn().mockReturnValue(3),
         truncateHistory: vi.fn(),
       } as unknown as GeminiChat;
 
@@ -498,10 +494,7 @@ describe('Gemini Client (client.ts)', () => {
     it('truncateHistory does NOT clear the cache when keepCount >= history length (no-op)', () => {
       const cacheClear = mockFileReadCacheClear();
       client['chat'] = {
-        getHistory: vi.fn().mockReturnValue([
-          { role: 'user', parts: [{ text: 'a' }] },
-          { role: 'model', parts: [{ text: 'b' }] },
-        ]),
+        getHistoryLength: vi.fn().mockReturnValue(2),
         truncateHistory: vi.fn(),
       } as unknown as GeminiChat;
 
@@ -512,6 +505,22 @@ describe('Gemini Client (client.ts)', () => {
       // keepCount exceeds history length — also a no-op.
       client.truncateHistory(99);
       expect(cacheClear).not.toHaveBeenCalled();
+    });
+
+    it('truncateHistory uses O(1) getHistoryLength, not getHistory (avoids structuredClone)', () => {
+      mockFileReadCacheClear();
+      const getHistoryLength = vi.fn().mockReturnValue(5);
+      const getHistory = vi.fn();
+      client['chat'] = {
+        getHistoryLength,
+        getHistory,
+        truncateHistory: vi.fn(),
+      } as unknown as GeminiChat;
+
+      client.truncateHistory(3);
+
+      expect(getHistoryLength).toHaveBeenCalled();
+      expect(getHistory).not.toHaveBeenCalled();
     });
 
     it('retry strips orphaned trailing user entries and clears the cache', async () => {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -206,15 +206,31 @@ export class GeminiClient {
 
   private stripOrphanedUserEntriesFromHistory() {
     this.getChat().stripOrphanedUserEntriesFromHistory();
+    // Stripped trailing user entries can include read_file
+    // functionResponses from a failed-then-retried request. The
+    // FileReadCache would still record those reads, so the retry's
+    // re-issued Read could hit the file_unchanged placeholder while
+    // the model has nothing to fall back on. Clear to be safe.
+    this.config.getFileReadCache().clear();
   }
 
   setHistory(history: Content[]) {
     this.getChat().setHistory(history);
+    // Replacing history wholesale drops any prior read_file tool
+    // results the FileReadCache still believes the model has seen.
+    // Without clearing, a follow-up Read of an unchanged file would
+    // return the file_unchanged placeholder for bytes that no longer
+    // exist in the new history.
+    this.config.getFileReadCache().clear();
     this.forceFullIdeContext = true;
   }
 
   truncateHistory(keepCount: number) {
     this.getChat().truncateHistory(keepCount);
+    // Truncation can drop prior read_file results past keepCount while
+    // the FileReadCache still records those reads — same staleness
+    // risk as setHistory. Clear to force re-emission.
+    this.config.getFileReadCache().clear();
     this.forceFullIdeContext = true;
   }
 
@@ -233,6 +249,11 @@ export class GeminiClient {
   async resetChat(): Promise<void> {
     this.surfacedRelevantAutoMemoryPaths.clear();
     this.lastApiCompletionTimestamp = null;
+    // startChat() rewrites the chat to its initial state. Any prior
+    // read_file tool results the FileReadCache still tracks are no
+    // longer in history, so a follow-up Read would serve a placeholder
+    // pointing at content the model can no longer retrieve.
+    this.config.getFileReadCache().clear();
     await this.startChat();
   }
 
@@ -694,8 +715,8 @@ export class GeminiClient {
       );
       if (mcResult.meta) {
         this.getChat().setHistory(mcResult.history);
-        // Microcompaction replaces old read_file / shell / glob / grep /
-        // edit / write_file tool outputs with a placeholder, but the
+        // Microcompaction replaces old compactable tool outputs
+        // (including read_file) with a placeholder, but the
         // FileReadCache still records the prior full Reads as "seen in
         // this conversation". A follow-up Read of an unchanged file
         // would then return the file_unchanged placeholder pointing at

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -230,14 +230,19 @@ export class GeminiClient {
   }
 
   truncateHistory(keepCount: number) {
+    const prevLen = this.getChat().getHistory().length;
     this.getChat().truncateHistory(keepCount);
     // Truncation can drop prior read_file results past keepCount while
     // the FileReadCache still records those reads — same staleness
-    // risk as setHistory. Clear to force re-emission.
-    debugLogger.debug(
-      `[FILE_READ_CACHE] clear after truncateHistory(keep=${keepCount})`,
-    );
-    this.config.getFileReadCache().clear();
+    // risk as setHistory. Only clear when entries were actually
+    // removed; a no-op truncate (keepCount >= prevLen) leaves the
+    // cache valid against the unchanged history.
+    if (keepCount < prevLen) {
+      debugLogger.debug(
+        `[FILE_READ_CACHE] clear after truncateHistory(keep=${keepCount}, prev=${prevLen})`,
+      );
+      this.config.getFileReadCache().clear();
+    }
     this.forceFullIdeContext = true;
   }
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -230,7 +230,10 @@ export class GeminiClient {
   }
 
   truncateHistory(keepCount: number) {
-    const prevLen = this.getChat().getHistory().length;
+    // Use the O(1) length getter rather than getHistory() — the latter
+    // structuredClone's the entire history just to read .length, which
+    // gets expensive in long-running sessions.
+    const prevLen = this.getChat().getHistoryLength();
     this.getChat().truncateHistory(keepCount);
     // Truncation can drop prior read_file results past keepCount while
     // the FileReadCache still records those reads — same staleness

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -694,6 +694,15 @@ export class GeminiClient {
       );
       if (mcResult.meta) {
         this.getChat().setHistory(mcResult.history);
+        // Microcompaction replaces old read_file / shell / glob / grep /
+        // edit / write_file tool outputs with a placeholder, but the
+        // FileReadCache still records the prior full Reads as "seen in
+        // this conversation". A follow-up Read of an unchanged file
+        // would then return the file_unchanged placeholder pointing at
+        // bytes the model can no longer retrieve from history. Drop the
+        // cache so post-microcompaction Reads re-emit the bytes,
+        // mirroring the post-compaction clear in tryCompressChat.
+        this.config.getFileReadCache().clear();
         const m = mcResult.meta;
         debugLogger.debug(
           `[TIME-BASED MC] gap ${m.gapMinutes}min > ${m.thresholdMinutes}min, ` +

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -235,14 +235,15 @@ export class GeminiClient {
     // gets expensive in long-running sessions.
     const prevLen = this.getChat().getHistoryLength();
     this.getChat().truncateHistory(keepCount);
-    // Truncation can drop prior read_file results past keepCount while
-    // the FileReadCache still records those reads — same staleness
-    // risk as setHistory. Only clear when entries were actually
-    // removed; a no-op truncate (keepCount >= prevLen) leaves the
-    // cache valid against the unchanged history.
-    if (keepCount < prevLen) {
+    // Decide whether to invalidate based on the *actual* post-truncate
+    // length, not on the keepCount argument. Comparing keepCount alone
+    // misses pathological inputs (e.g. NaN: slice(0, NaN) returns [],
+    // emptying history, but `NaN < prevLen` is false and would skip
+    // the clear, reintroducing the file_unchanged placeholder bug).
+    const newLen = this.getChat().getHistoryLength();
+    if (newLen < prevLen) {
       debugLogger.debug(
-        `[FILE_READ_CACHE] clear after truncateHistory(keep=${keepCount}, prev=${prevLen})`,
+        `[FILE_READ_CACHE] clear after truncateHistory(keep=${keepCount}, prev=${prevLen}, new=${newLen})`,
       );
       this.config.getFileReadCache().clear();
     }

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -211,6 +211,9 @@ export class GeminiClient {
     // FileReadCache would still record those reads, so the retry's
     // re-issued Read could hit the file_unchanged placeholder while
     // the model has nothing to fall back on. Clear to be safe.
+    debugLogger.debug(
+      '[FILE_READ_CACHE] clear after stripOrphanedUserEntriesFromHistory',
+    );
     this.config.getFileReadCache().clear();
   }
 
@@ -221,6 +224,7 @@ export class GeminiClient {
     // Without clearing, a follow-up Read of an unchanged file would
     // return the file_unchanged placeholder for bytes that no longer
     // exist in the new history.
+    debugLogger.debug('[FILE_READ_CACHE] clear after setHistory');
     this.config.getFileReadCache().clear();
     this.forceFullIdeContext = true;
   }
@@ -230,6 +234,9 @@ export class GeminiClient {
     // Truncation can drop prior read_file results past keepCount while
     // the FileReadCache still records those reads — same staleness
     // risk as setHistory. Clear to force re-emission.
+    debugLogger.debug(
+      `[FILE_READ_CACHE] clear after truncateHistory(keep=${keepCount})`,
+    );
     this.config.getFileReadCache().clear();
     this.forceFullIdeContext = true;
   }
@@ -253,6 +260,7 @@ export class GeminiClient {
     // read_file tool results the FileReadCache still tracks are no
     // longer in history, so a follow-up Read would serve a placeholder
     // pointing at content the model can no longer retrieve.
+    debugLogger.debug('[FILE_READ_CACHE] clear after resetChat');
     this.config.getFileReadCache().clear();
     await this.startChat();
   }
@@ -723,6 +731,7 @@ export class GeminiClient {
         // bytes the model can no longer retrieve from history. Drop the
         // cache so post-microcompaction Reads re-emit the bytes,
         // mirroring the post-compaction clear in tryCompressChat.
+        debugLogger.debug('[FILE_READ_CACHE] clear after microcompaction');
         this.config.getFileReadCache().clear();
         const m = mcResult.meta;
         debugLogger.debug(
@@ -1196,6 +1205,7 @@ export class GeminiClient {
         // placeholder pointing at content the model can no longer
         // retrieve from its own context. Clear the cache so post-
         // compaction Reads re-emit the bytes.
+        debugLogger.debug('[FILE_READ_CACHE] clear after tryCompressChat');
         this.config.getFileReadCache().clear();
         uiTelemetryService.setLastPromptTokenCount(info.newTokenCount);
         this.forceFullIdeContext = true;

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1049,6 +1049,25 @@ describe('GeminiChat', async () => {
     });
   });
 
+  describe('getHistoryLength', () => {
+    it('returns 0 for an empty history', () => {
+      expect(chat.getHistoryLength()).toBe(0);
+    });
+
+    it('reflects entries added via addHistory', () => {
+      chat.addHistory({ role: 'user', parts: [{ text: 'a' }] });
+      chat.addHistory({ role: 'model', parts: [{ text: 'b' }] });
+      expect(chat.getHistoryLength()).toBe(2);
+    });
+
+    it('matches getHistory().length without paying the structuredClone cost', () => {
+      chat.addHistory({ role: 'user', parts: [{ text: 'a' }] });
+      chat.addHistory({ role: 'model', parts: [{ text: 'b' }] });
+      chat.addHistory({ role: 'user', parts: [{ text: 'c' }] });
+      expect(chat.getHistoryLength()).toBe(chat.getHistory().length);
+    });
+  });
+
   describe('sendMessageStream with retries', () => {
     it('should retry on invalid content, succeed, and report metrics', async () => {
       vi.useFakeTimers();

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -771,6 +771,15 @@ export class GeminiChat {
   }
 
   /**
+   * Returns the number of entries in the raw chat history. O(1) and
+   * does not clone — use this when you only need the count and would
+   * otherwise pay the {@link getHistory} `structuredClone` cost.
+   */
+  getHistoryLength(): number {
+    return this.history.length;
+  }
+
+  /**
    * Clears the chat history.
    */
   clearHistory(): void {

--- a/packages/core/src/services/fileReadCache.integration.test.ts
+++ b/packages/core/src/services/fileReadCache.integration.test.ts
@@ -72,14 +72,10 @@ describe('FileReadCache integration: read after history rewrite', () => {
     const tool = new ReadFileTool(config);
 
     // STEP 1 — first real Read populates the cache.
-    const inv1 = (
-      tool as unknown as {
-        createInvocation: (p: { file_path: string }) => {
-          execute(s: AbortSignal): Promise<{ llmContent: unknown }>;
-        };
-      }
-    ).createInvocation({ file_path: filePath });
-    const r1 = await inv1.execute(new AbortController().signal);
+    const r1 = await tool.buildAndExecute(
+      { file_path: filePath },
+      new AbortController().signal,
+    );
     expect(typeof r1.llmContent).toBe('string');
     expect(r1.llmContent as string).toContain('export function hello');
     expect(cache.size()).toBe(1);
@@ -133,14 +129,10 @@ describe('FileReadCache integration: read after history rewrite', () => {
 
     // STEP 4 — pre-fix code path: cache is NOT cleared after microcompact.
     // User reads foo.ts again. File on disk is unchanged.
-    const inv2 = (
-      tool as unknown as {
-        createInvocation: (p: { file_path: string }) => {
-          execute(s: AbortSignal): Promise<{ llmContent: unknown }>;
-        };
-      }
-    ).createInvocation({ file_path: filePath });
-    const r2 = await inv2.execute(new AbortController().signal);
+    const r2 = await tool.buildAndExecute(
+      { file_path: filePath },
+      new AbortController().signal,
+    );
 
     // THE BUG: returned content is the placeholder, NOT the real file.
     expect(r2.llmContent as string).toContain(
@@ -167,27 +159,19 @@ describe('FileReadCache integration: read after history rewrite', () => {
     const config = makeConfig(tmpDir, cache);
     const tool = new ReadFileTool(config);
 
-    const inv1 = (
-      tool as unknown as {
-        createInvocation: (p: { file_path: string }) => {
-          execute(s: AbortSignal): Promise<{ llmContent: unknown }>;
-        };
-      }
-    ).createInvocation({ file_path: filePath });
-    const r1 = await inv1.execute(new AbortController().signal);
+    const r1 = await tool.buildAndExecute(
+      { file_path: filePath },
+      new AbortController().signal,
+    );
     expect(r1.llmContent as string).toContain('export function hello');
 
     // The fix.
     cache.clear();
 
-    const inv2 = (
-      tool as unknown as {
-        createInvocation: (p: { file_path: string }) => {
-          execute(s: AbortSignal): Promise<{ llmContent: unknown }>;
-        };
-      }
-    ).createInvocation({ file_path: filePath });
-    const r2 = await inv2.execute(new AbortController().signal);
+    const r2 = await tool.buildAndExecute(
+      { file_path: filePath },
+      new AbortController().signal,
+    );
 
     expect(r2.llmContent as string).toContain('export function hello');
     expect(r2.llmContent as string).not.toContain(
@@ -208,15 +192,10 @@ describe('FileReadCache integration: read after history rewrite', () => {
     fs.writeFileSync(otherPath, 'unrelated\n');
 
     // Read foo.ts (target file).
-    await (
-      tool as unknown as {
-        createInvocation: (p: { file_path: string }) => {
-          execute(s: AbortSignal): Promise<{ llmContent: unknown }>;
-        };
-      }
-    )
-      .createInvocation({ file_path: filePath })
-      .execute(new AbortController().signal);
+    await tool.buildAndExecute(
+      { file_path: filePath },
+      new AbortController().signal,
+    );
 
     // Build history: 1 foo.ts read, then 1 other.ts read (kept).
     const fooContent = fs.readFileSync(filePath, 'utf-8');
@@ -283,15 +262,10 @@ describe('FileReadCache integration: read after history rewrite', () => {
     );
 
     // Now Read foo.ts again — pre-fix, cache returns placeholder.
-    const r = await (
-      tool as unknown as {
-        createInvocation: (p: { file_path: string }) => {
-          execute(s: AbortSignal): Promise<{ llmContent: unknown }>;
-        };
-      }
-    )
-      .createInvocation({ file_path: filePath })
-      .execute(new AbortController().signal);
+    const r = await tool.buildAndExecute(
+      { file_path: filePath },
+      new AbortController().signal,
+    );
 
     expect(r.llmContent as string).toContain(
       'unchanged since last read in this session',

--- a/packages/core/src/services/fileReadCache.integration.test.ts
+++ b/packages/core/src/services/fileReadCache.integration.test.ts
@@ -1,0 +1,304 @@
+/**
+ * Integration tests for the FileReadCache short-circuit. Real
+ * filesystem, real ReadFileTool, real microcompactHistory — verify
+ * that the placeholder fast-path stays correct under history rewrites.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { Content } from '@google/genai';
+
+import { FileReadCache } from './fileReadCache.js';
+import { ReadFileTool } from '../tools/read-file.js';
+import { microcompactHistory } from './microcompaction/microcompact.js';
+import { StandardFileSystemService } from './fileSystemService.js';
+
+function makeConfig(targetDir: string, cache: FileReadCache, disabled = false) {
+  const explicit: Record<string, unknown> = {
+    getTargetDir: () => targetDir,
+    getProjectRoot: () => targetDir,
+    getWorkspaceContext: () => ({
+      isPathWithinWorkspace: () => true,
+    }),
+    storage: {
+      getProjectTempDir: () => path.join(targetDir, '.tmp'),
+      getProjectDir: () => path.join(targetDir, '.proj'),
+      getUserSkillsDirs: () => [],
+    },
+    getFileReadCache: () => cache,
+    getFileReadCacheDisabled: () => disabled,
+    getFileService: () => ({ shouldQwenIgnoreFile: () => false }),
+    getFileFilteringOptions: () => ({}),
+    getDebugMode: () => false,
+    getFileSystemService: () => new StandardFileSystemService(),
+    getContentGeneratorConfig: () => ({ modalities: {} }),
+    getModel: () => 'test-model',
+    getTruncateToolOutputLines: () => 2000,
+    getTruncateToolOutputThreshold: () => 4_000_000,
+    getUsageStatisticsEnabled: () => false,
+  };
+  return new Proxy(explicit, {
+    get(target, prop) {
+      if (prop in target)
+        return (target as Record<string | symbol, unknown>)[prop];
+      // Default: any unknown getter returns undefined-yielding fn.
+      return () => undefined;
+    },
+  }) as never;
+}
+
+describe('FileReadCache integration: read after history rewrite', () => {
+  let tmpDir: string;
+  let filePath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'repro-3805-'));
+    filePath = path.join(tmpDir, 'foo.ts');
+    fs.writeFileSync(
+      filePath,
+      'export function hello() {\n  return "world";\n}\n'.repeat(10),
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns the file_unchanged placeholder on a follow-up Read after microcompact, exposing why the cache must be cleared on history rewrite', async () => {
+    const cache = new FileReadCache();
+    const config = makeConfig(tmpDir, cache);
+    const tool = new ReadFileTool(config);
+
+    // STEP 1 — first real Read populates the cache.
+    const inv1 = (
+      tool as unknown as {
+        createInvocation: (p: { file_path: string }) => {
+          execute(s: AbortSignal): Promise<{ llmContent: unknown }>;
+        };
+      }
+    ).createInvocation({ file_path: filePath });
+    const r1 = await inv1.execute(new AbortController().signal);
+    expect(typeof r1.llmContent).toBe('string');
+    expect(r1.llmContent as string).toContain('export function hello');
+    expect(cache.size()).toBe(1);
+
+    // STEP 2 — build a conversation history mirroring real flow:
+    // 6 prior read_file functionResponses with the foo.ts content.
+    // microcompact's keepRecent=1 will clear the oldest 5.
+    const history: Content[] = [];
+    for (let i = 0; i < 6; i++) {
+      history.push({
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              name: 'read_file',
+              args: { file_path: filePath },
+            },
+          },
+        ],
+      });
+      history.push({
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'read_file',
+              response: { output: r1.llmContent as string },
+            },
+          },
+        ],
+      });
+    }
+
+    // STEP 3 — microcompact fires (>60min idle).
+    const mcResult = microcompactHistory(history, Date.now() - 90 * 60_000, {
+      toolResultsThresholdMinutes: 60,
+      toolResultsNumToKeep: 1,
+    });
+    expect(mcResult.meta).toBeDefined();
+    expect(mcResult.meta!.toolsCleared).toBe(5);
+
+    // Confirm: most foo.ts content has been wiped from history.
+    const fooContentEntries = mcResult.history.filter((c) =>
+      c.parts?.some((p) => {
+        const out = p.functionResponse?.response?.['output'];
+        return typeof out === 'string' && out.includes('export function hello');
+      }),
+    );
+    // Only 1 fresh entry remains; the other 5 are placeholders.
+    expect(fooContentEntries).toHaveLength(1);
+
+    // STEP 4 — pre-fix code path: cache is NOT cleared after microcompact.
+    // User reads foo.ts again. File on disk is unchanged.
+    const inv2 = (
+      tool as unknown as {
+        createInvocation: (p: { file_path: string }) => {
+          execute(s: AbortSignal): Promise<{ llmContent: unknown }>;
+        };
+      }
+    ).createInvocation({ file_path: filePath });
+    const r2 = await inv2.execute(new AbortController().signal);
+
+    // THE BUG: returned content is the placeholder, NOT the real file.
+    expect(r2.llmContent as string).toContain(
+      'unchanged since last read in this session',
+    );
+    expect(r2.llmContent as string).not.toContain('export function hello');
+
+    // The model now has:
+    //   - history: 5 entries are [Old tool result content cleared],
+    //              1 entry has real content (the most-recent kept one)
+    //   - fresh tool response: a placeholder pointing at "earlier in
+    //     this conversation" — which is partly true (1 entry remains)
+    //     but if the LLM trusted the placeholder and discarded the
+    //     last surviving entry, the bytes are unrecoverable.
+    //
+    // In a longer chain (e.g. 20 reads, keep 1, microcompact clears
+    // 19), the surviving entry might not even be foo.ts — it would be
+    // whatever was read most recently. Then the placeholder points at
+    // ZERO bytes the model can find.
+  });
+
+  it('after cache.clear(), a follow-up Read of the same unchanged file re-emits the real bytes', async () => {
+    const cache = new FileReadCache();
+    const config = makeConfig(tmpDir, cache);
+    const tool = new ReadFileTool(config);
+
+    const inv1 = (
+      tool as unknown as {
+        createInvocation: (p: { file_path: string }) => {
+          execute(s: AbortSignal): Promise<{ llmContent: unknown }>;
+        };
+      }
+    ).createInvocation({ file_path: filePath });
+    const r1 = await inv1.execute(new AbortController().signal);
+    expect(r1.llmContent as string).toContain('export function hello');
+
+    // The fix.
+    cache.clear();
+
+    const inv2 = (
+      tool as unknown as {
+        createInvocation: (p: { file_path: string }) => {
+          execute(s: AbortSignal): Promise<{ llmContent: unknown }>;
+        };
+      }
+    ).createInvocation({ file_path: filePath });
+    const r2 = await inv2.execute(new AbortController().signal);
+
+    expect(r2.llmContent as string).toContain('export function hello');
+    expect(r2.llmContent as string).not.toContain(
+      'unchanged since last read in this session',
+    );
+  });
+
+  it('worst case: when microcompact removes every prior read of a file, the placeholder leaves zero recoverable bytes for the model', async () => {
+    // This is the worst-case version: many reads, microcompact clears
+    // everything, the surviving entry is a different file. The placeholder
+    // then points the model at content that no longer exists anywhere
+    // in its reachable context.
+    const cache = new FileReadCache();
+    const config = makeConfig(tmpDir, cache);
+    const tool = new ReadFileTool(config);
+
+    const otherPath = path.join(tmpDir, 'other.ts');
+    fs.writeFileSync(otherPath, 'unrelated\n');
+
+    // Read foo.ts (target file).
+    await (
+      tool as unknown as {
+        createInvocation: (p: { file_path: string }) => {
+          execute(s: AbortSignal): Promise<{ llmContent: unknown }>;
+        };
+      }
+    )
+      .createInvocation({ file_path: filePath })
+      .execute(new AbortController().signal);
+
+    // Build history: 1 foo.ts read, then 1 other.ts read (kept).
+    const fooContent = fs.readFileSync(filePath, 'utf-8');
+    const history: Content[] = [
+      {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              name: 'read_file',
+              args: { file_path: filePath },
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'read_file',
+              response: { output: fooContent },
+            },
+          },
+        ],
+      },
+      {
+        role: 'model',
+        parts: [
+          {
+            functionCall: {
+              name: 'read_file',
+              args: { file_path: otherPath },
+            },
+          },
+        ],
+      },
+      {
+        role: 'user',
+        parts: [
+          {
+            functionResponse: {
+              name: 'read_file',
+              response: { output: 'unrelated\n' },
+            },
+          },
+        ],
+      },
+    ];
+
+    const mc = microcompactHistory(history, Date.now() - 90 * 60_000, {
+      toolResultsThresholdMinutes: 60,
+      toolResultsNumToKeep: 1,
+    });
+    expect(mc.meta!.toolsCleared).toBe(1);
+
+    // foo.ts content is gone from history; only other.ts remains.
+    const surviving = mc.history
+      .flatMap((c) => c.parts ?? [])
+      .map((p) => p.functionResponse?.response?.['output'])
+      .filter((o): o is string => typeof o === 'string');
+    expect(surviving.some((o) => o.includes('export function hello'))).toBe(
+      false,
+    );
+
+    // Now Read foo.ts again — pre-fix, cache returns placeholder.
+    const r = await (
+      tool as unknown as {
+        createInvocation: (p: { file_path: string }) => {
+          execute(s: AbortSignal): Promise<{ llmContent: unknown }>;
+        };
+      }
+    )
+      .createInvocation({ file_path: filePath })
+      .execute(new AbortController().signal);
+
+    expect(r.llmContent as string).toContain(
+      'unchanged since last read in this session',
+    );
+    // Total foo.ts content reachable to the model:
+    //   history → 0 bytes
+    //   fresh tool result → placeholder, 0 bytes
+    // The model literally cannot recover the file contents.
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #3805 — "read tool returns no content in long-running sessions."

The `FileReadCache` (#3717) short-circuits repeated full Reads of an unchanged file by returning a `file_unchanged` placeholder that points the model at the *prior tool result in conversation history*. This optimization is correct only as long as that prior tool result is still in history. Anything that rewrites history without invalidating the cache produces a Read that succeeds at the tool layer but delivers no usable content to the model.

#3717 wired the invalidation into two paths (`tryCompressChat`, `startNewSession`) but missed five others. After a multi-round audit:

| Path | Trigger | Was clearing? |
|---|---|---|
| `tryCompressChat` | auto compaction | yes |
| `Config.startNewSession` | /clear, session resume | yes |
| `microcompactHistory` call site | idle cleanup (>= 60min) | no -> yes |
| `GeminiClient.setHistory` | /restore, /load_history | no -> yes |
| `GeminiClient.truncateHistory` | rewind | no -> yes |
| `GeminiClient.resetChat` | public API | no -> yes |
| `stripOrphanedUserEntriesFromHistory` | retry path | no -> yes |

Each fix is a single `getFileReadCache().clear()` at the call site (matching the pre-existing pattern), with a focused regression test in `client.test.ts`.

---

## Proof the bug is real

`fileReadCache.integration.test.ts` runs the **real** `ReadFileTool` against a **real** on-disk file, calls the **real** `microcompactHistory`, and uses the **real** `FileReadCache` — no mocks. The first test deliberately omits the cache clear (i.e. reproduces the pre-fix code path) and asserts the failure:

```ts
// STEP 1 — first Read populates the cache and emits real bytes.
const r1 = await tool.createInvocation({ file_path: filePath })
                    .execute(signal);
expect(r1.llmContent).toContain('export function hello');  // ✓

// STEP 2 — build a 6-entry history of read_file results, then run
//          microcompactHistory (idle 90min, keepRecent=1).
const mc = microcompactHistory(history, Date.now() - 90 * 60_000, {
  toolResultsThresholdMinutes: 60,
  toolResultsNumToKeep: 1,
});
expect(mc.meta.toolsCleared).toBe(5);  // ✓ — 5 entries replaced with placeholder

// STEP 3 — pre-fix path: cache is NOT cleared. Read foo.ts again.
const r2 = await tool.createInvocation({ file_path: filePath })
                    .execute(signal);

// THE BUG: the tool returns the placeholder, not the file content.
expect(r2.llmContent).toContain('unchanged since last read in this session');  // ✓
expect(r2.llmContent).not.toContain('export function hello');                  // ✓
```

The test passes — meaning **without the fix, a follow-up Read of an unchanged file after microcompact really does return the placeholder while history no longer holds the bytes**. This is the exact failure mode in the issue.

A worst-case test (`toolsCleared = 19, kept = 1, surviving entry is a different file`) further shows the model is left with **zero recoverable bytes anywhere in its reachable context**.

## Proof the fix works

Same setup, with `cache.clear()` between the two reads:

```ts
const r1 = await tool.createInvocation({ file_path: filePath }).execute(signal);
expect(r1.llmContent).toContain('export function hello');  // ✓

cache.clear();  // the fix

const r2 = await tool.createInvocation({ file_path: filePath }).execute(signal);
expect(r2.llmContent).toContain('export function hello');                       // ✓ — real bytes
expect(r2.llmContent).not.toContain('unchanged since last read in this session'); // ✓
```

After the fix, the second Read re-emits the real file content instead of the placeholder.

---

## Test output

```
✓ FileReadCache integration: read after history rewrite
  ✓ returns the file_unchanged placeholder on a follow-up Read after microcompact,
    exposing why the cache must be cleared on history rewrite (6ms)
  ✓ after cache.clear(), a follow-up Read of the same unchanged file re-emits
    the real bytes (1ms)
  ✓ worst case: when microcompact removes every prior read of a file, the
    placeholder leaves zero recoverable bytes for the model (1ms)

Test Files  1 passed (1)
     Tests  3 passed (3)
```

## Reverse-tested

Every new `clear()` in `client.ts` was temporarily commented out and the matching unit test in `client.test.ts` was confirmed to fail. So each `clear()` is exercised by — and required by — the test suite.

## Verification

- `npm run test --workspace packages/core`: 6610 tests pass (6607 prior + 3 new integration)
- `tsc --noEmit`: clean
- `eslint`: clean

## Notes

- The user's second comment ("Edit tool errors with filenames containing spaces") is a separate report and not addressed here. Edit uses `path.resolve` / `fs` APIs that handle spaces correctly; that report needs a concrete repro before it can be triaged.