### PR TITLE
fix(core): prevent auto-memory recall from blocking main request

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1880,6 +1880,39 @@ hello
       vi.mocked(mockConfig.getManagedAutoMemoryEnabled).mockReturnValue(true);
     });
 
+    it('should proceed normally when recall rejects', async () => {
+      // Simulate a recall that throws — the .catch() handler should swallow
+      // the error and the main request should complete without memory content
+      mockMemoryManager.recall.mockRejectedValue(new Error('recall failed'));
+
+      const mockStream = (async function* () {
+        yield { type: 'content', value: 'Hello' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      const mockChat: Partial<GeminiChat> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'Quick question' }],
+        new AbortController().signal,
+        'prompt-id-recall-fail',
+      );
+      for await (const _ of stream) {
+        // consume stream
+      }
+
+      // The main request should have been called without any memory content
+      expect(mockTurnRunFn).toHaveBeenCalledWith(
+        'test-model',
+        ['Quick question'],
+        expect.any(AbortSignal),
+      );
+    });
+
     it('should run managed auto-memory extraction after a completed user query', async () => {
       mockMemoryManager.scheduleExtract.mockResolvedValue({
         touchedTopics: ['user'],

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1749,6 +1749,100 @@ hello
       );
     });
 
+    it('should not block the main request when auto-memory recall is slow', async () => {
+      // Simulate a recall that takes longer than the 2.5s deadline
+      mockMemoryManager.recall.mockReturnValue(
+        new Promise((resolve) =>
+          setTimeout(
+            () =>
+              resolve({
+                prompt: '## Relevant memory\n\nSlow memory result.',
+                selectedDocs: [],
+                strategy: 'model',
+              }),
+            10_000,
+          ),
+        ),
+      );
+
+      const mockStream = (async function* () {
+        yield { type: 'content', value: 'Hello' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      const mockChat: Partial<GeminiChat> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        stripThoughtsFromHistory: vi.fn(),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      vi.useFakeTimers();
+      try {
+        const streamPromise = (async () => {
+          const stream = client.sendMessageStream(
+            [{ text: 'Quick question' }],
+            new AbortController().signal,
+            'prompt-id-slow-memory',
+          );
+          for await (const _ of stream) {
+            // consume stream
+          }
+        })();
+
+        // Advance past the 2.5s deadline — the main request should proceed
+        await vi.advanceTimersByTimeAsync(3_000);
+        await streamPromise;
+
+        // The main request should have been called without the slow memory
+        expect(mockTurnRunFn).toHaveBeenCalledWith(
+          'test-model',
+          expect.not.arrayContaining([
+            expect.stringContaining('Slow memory result'),
+          ]),
+          expect.any(AbortSignal),
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('should include auto-memory prompt when recall completes within deadline', async () => {
+      // Simulate a fast recall that completes well within the deadline
+      mockMemoryManager.recall.mockResolvedValue({
+        prompt: '## Relevant memory\n\nFast memory result.',
+        selectedDocs: [],
+        strategy: 'heuristic',
+      });
+
+      const mockStream = (async function* () {
+        yield { type: 'content', value: 'Hello' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      const mockChat: Partial<GeminiChat> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+        stripThoughtsFromHistory: vi.fn(),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'Quick question' }],
+        new AbortController().signal,
+        'prompt-id-fast-memory',
+      );
+      for await (const _ of stream) {
+        // consume stream
+      }
+
+      expect(mockTurnRunFn).toHaveBeenCalledWith(
+        'test-model',
+        expect.arrayContaining(['## Relevant memory\n\nFast memory result.']),
+        expect.any(AbortSignal),
+      );
+    });
+
     it('should run managed auto-memory extraction after a completed user query', async () => {
       mockMemoryManager.scheduleExtract.mockResolvedValue({
         touchedTopics: ['user'],

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -2200,6 +2200,89 @@ Other open files:
       expect(mockTurnRunFn).toHaveBeenCalledTimes(MAX_SESSION_TURNS);
     });
 
+    it('should abort the pending recall when MaxSessionTurns is hit', async () => {
+      vi.spyOn(client['config'], 'getMaxSessionTurns').mockReturnValue(1);
+      client['sessionTurnCount'] = 1; // already at limit; next call exceeds it
+
+      const abortHandler = vi.fn();
+      mockMemoryManager.recall.mockImplementation((_root, _query, opts) => {
+        opts.abortSignal?.addEventListener('abort', abortHandler);
+        return new Promise(() => {}); // never resolves
+      });
+
+      const mockStream = (async function* () {
+        yield { type: 'content', value: 'Hello' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      const mockChat: Partial<GeminiChat> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'over the limit' }],
+        new AbortController().signal,
+        'prompt-id-over-limit',
+      );
+      const events = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      expect(events).toEqual([{ type: GeminiEventType.MaxSessionTurns }]);
+      expect(abortHandler).toHaveBeenCalledTimes(1);
+    });
+
+    it('should abort the pending recall when SessionTokenLimitExceeded', async () => {
+      // Use a very low token limit so the (uncompressed) history exceeds it
+      vi.spyOn(client['config'], 'getSessionTokenLimit').mockReturnValue(1);
+
+      // Force token count to be above the limit
+      vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(
+        9999,
+      );
+
+      const abortHandler = vi.fn();
+      mockMemoryManager.recall.mockImplementation((_root, _query, opts) => {
+        opts.abortSignal?.addEventListener('abort', abortHandler);
+        return new Promise(() => {}); // never resolves
+      });
+
+      const mockStream = (async function* () {
+        yield { type: 'content', value: 'Hello' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      const mockChat: Partial<GeminiChat> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'token limit test' }],
+        new AbortController().signal,
+        'prompt-id-token-limit',
+      );
+      const events = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      expect(events).toEqual([
+        {
+          type: GeminiEventType.SessionTokenLimitExceeded,
+          value: expect.objectContaining({
+            currentTokens: 9999,
+            limit: 1,
+          }),
+        },
+      ]);
+      expect(abortHandler).toHaveBeenCalledTimes(1);
+    });
+
     it('should respect MAX_TURNS limit even when turns parameter is set to a large value', async () => {
       // This test verifies that the infinite loop protection works even when
       // someone tries to bypass it by calling with a very large turns value

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1773,7 +1773,6 @@ hello
       const mockChat: Partial<GeminiChat> = {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
-        stripThoughtsFromHistory: vi.fn(),
       };
       client['chat'] = mockChat as GeminiChat;
 
@@ -1823,7 +1822,6 @@ hello
       const mockChat: Partial<GeminiChat> = {
         addHistory: vi.fn(),
         getHistory: vi.fn().mockReturnValue([]),
-        stripThoughtsFromHistory: vi.fn(),
       };
       client['chat'] = mockChat as GeminiChat;
 

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1841,6 +1841,45 @@ hello
       );
     });
 
+    it('should proceed without auto-memory when managed auto-memory is disabled', async () => {
+      // When getManagedAutoMemoryEnabled returns false, no recall is initiated
+      // and sendMessageStream completes without memory content
+      vi.mocked(mockConfig.getManagedAutoMemoryEnabled).mockReturnValue(false);
+
+      const mockStream = (async function* () {
+        yield { type: 'content', value: 'Hello' };
+      })();
+      mockTurnRunFn.mockReturnValue(mockStream);
+
+      const mockChat: Partial<GeminiChat> = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue([]),
+      };
+      client['chat'] = mockChat as GeminiChat;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'Quick question' }],
+        new AbortController().signal,
+        'prompt-id-no-memory',
+      );
+      for await (const _ of stream) {
+        // consume stream
+      }
+
+      // recall should never have been called
+      expect(mockMemoryManager.recall).not.toHaveBeenCalled();
+
+      // The main request should have been called without any memory content
+      expect(mockTurnRunFn).toHaveBeenCalledWith(
+        'test-model',
+        ['Quick question'],
+        expect.any(AbortSignal),
+      );
+
+      // Restore default
+      vi.mocked(mockConfig.getManagedAutoMemoryEnabled).mockReturnValue(true);
+    });
+
     it('should run managed auto-memory extraction after a completed user query', async () => {
       mockMemoryManager.scheduleExtract.mockResolvedValue({
         touchedTopics: ['user'],

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -321,6 +321,12 @@ export class GeminiClient {
     debugLogger.debug('[FILE_READ_CACHE] clear after resetChat');
     this.config.getFileReadCache().clear();
     this.perModelGeneratorCache.clear();
+    // Abort any in-flight auto-memory recall so the stale controller
+    // does not leak into the next session.
+    if (this.pendingRecallAbortController) {
+      this.pendingRecallAbortController.abort();
+      this.pendingRecallAbortController = undefined;
+    }
     await this.startChat();
   }
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -150,8 +150,11 @@ async function resolveAutoMemoryWithDeadline(
   let timer: ReturnType<typeof setTimeout>;
   const deadline = new Promise<RelevantAutoMemoryPromptResult>((resolve) => {
     timer = setTimeout(() => {
-      onDeadline();
-      resolve(EMPTY_RELEVANT_AUTO_MEMORY_RESULT);
+      try {
+        onDeadline();
+      } finally {
+        resolve(EMPTY_RELEVANT_AUTO_MEMORY_RESULT);
+      }
     }, 2_500);
   });
 
@@ -171,7 +174,7 @@ export class GeminiClient {
   private lastPromptId: string | undefined = undefined;
   private lastSentIdeContext: IdeContext | undefined;
   private forceFullIdeContext = true;
-  private _pendingRecallAbortController: AbortController | undefined;
+  private pendingRecallAbortController: AbortController | undefined;
 
   /**
    * Cache of per-model ContentGenerators keyed by model ID.
@@ -759,7 +762,7 @@ export class GeminiClient {
             );
             return EMPTY_RELEVANT_AUTO_MEMORY_RESULT;
           });
-        this._pendingRecallAbortController = recallAbortController;
+        this.pendingRecallAbortController = recallAbortController;
       }
 
       // record user/cron message for session management
@@ -807,6 +810,8 @@ export class GeminiClient {
         this.config.getMaxSessionTurns() > 0 &&
         this.sessionTurnCount > this.config.getMaxSessionTurns()
       ) {
+        this.pendingRecallAbortController?.abort();
+        this.pendingRecallAbortController = undefined;
         yield { type: GeminiEventType.MaxSessionTurns };
         return new Turn(this.getChat(), prompt_id);
       }
@@ -815,6 +820,8 @@ export class GeminiClient {
     // Ensure turns never exceeds MAX_TURNS to prevent infinite loops
     const boundedTurns = Math.min(turns, MAX_TURNS);
     if (!boundedTurns) {
+      this.pendingRecallAbortController?.abort();
+      this.pendingRecallAbortController = undefined;
       return new Turn(this.getChat(), prompt_id);
     }
 
@@ -830,6 +837,8 @@ export class GeminiClient {
     if (sessionTokenLimit > 0) {
       const lastPromptTokenCount = uiTelemetryService.getLastPromptTokenCount();
       if (lastPromptTokenCount > sessionTokenLimit) {
+        this.pendingRecallAbortController?.abort();
+        this.pendingRecallAbortController = undefined;
         yield {
           type: GeminiEventType.SessionTokenLimitExceeded,
           value: {
@@ -880,6 +889,8 @@ export class GeminiClient {
           `Arena control signal received: ${controlSignal.type} - ${controlSignal.reason}`,
         );
         await arenaAgentClient.reportCancelled();
+        this.pendingRecallAbortController?.abort();
+        this.pendingRecallAbortController = undefined;
         return new Turn(this.getChat(), prompt_id);
       }
     }
@@ -896,8 +907,8 @@ export class GeminiClient {
       messageType === SendMessageType.Cron
     ) {
       const systemReminders = [];
-      const recallAbortController = this._pendingRecallAbortController;
-      this._pendingRecallAbortController = undefined;
+      const recallAbortController = this.pendingRecallAbortController;
+      this.pendingRecallAbortController = undefined;
       const relevantAutoMemory = await resolveAutoMemoryWithDeadline(
         relevantAutoMemoryPromise,
         () => recallAbortController?.abort(),

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -748,7 +748,7 @@ export class GeminiClient {
     ) {
       if (this.config.getManagedAutoMemoryEnabled()) {
         const recallAbortController = new AbortController();
-        relevantAutoMemoryPromise = this.config
+        const rawRecallPromise = this.config
           .getMemoryManager()
           .recall(this.config.getProjectRoot(), partToString(request), {
             config: this.config,
@@ -763,6 +763,13 @@ export class GeminiClient {
             return EMPTY_RELEVANT_AUTO_MEMORY_RESULT;
           });
         this.pendingRecallAbortController = recallAbortController;
+        // Race the recall against the deadline at initiation time so the 2.5s
+        // budget is not consumed by intermediate work (microcompact, compression,
+        // token checks, IDE context) between initiation and consumption.
+        relevantAutoMemoryPromise = resolveAutoMemoryWithDeadline(
+          rawRecallPromise,
+          () => recallAbortController.abort(),
+        );
       }
 
       // record user/cron message for session management
@@ -907,12 +914,12 @@ export class GeminiClient {
       messageType === SendMessageType.Cron
     ) {
       const systemReminders = [];
-      const recallAbortController = this.pendingRecallAbortController;
+      // The recall promise was already raced against the 2.5s deadline at
+      // initiation time; this await just collects the result.
       this.pendingRecallAbortController = undefined;
-      const relevantAutoMemory = await resolveAutoMemoryWithDeadline(
-        relevantAutoMemoryPromise,
-        () => recallAbortController?.abort(),
-      );
+      const relevantAutoMemory = relevantAutoMemoryPromise
+        ? await relevantAutoMemoryPromise
+        : EMPTY_RELEVANT_AUTO_MEMORY_RESULT;
       const relevantAutoMemoryPrompt = relevantAutoMemory.prompt;
 
       if (relevantAutoMemoryPrompt) {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -147,7 +147,7 @@ async function resolveAutoMemoryWithDeadline(
     return EMPTY_RELEVANT_AUTO_MEMORY_RESULT;
   }
 
-  let timer: ReturnType<typeof setTimeout>;
+  let timer: ReturnType<typeof setTimeout> | undefined;
   const deadline = new Promise<RelevantAutoMemoryPromptResult>((resolve) => {
     timer = setTimeout(() => {
       try {
@@ -161,7 +161,9 @@ async function resolveAutoMemoryWithDeadline(
   try {
     return await Promise.race([promise, deadline]);
   } finally {
-    clearTimeout(timer!);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+    }
   }
 }
 
@@ -762,10 +764,17 @@ export class GeminiClient {
             abortSignal: recallAbortController.signal,
           })
           .catch((error: unknown) => {
-            debugLogger.warn(
-              'Managed auto-memory recall prefetch failed.',
-              error,
-            );
+            if (error instanceof DOMException && error.name === 'AbortError') {
+              debugLogger.debug(
+                'Auto-memory recall aborted by deadline.',
+                error,
+              );
+            } else {
+              debugLogger.warn(
+                'Managed auto-memory recall prefetch failed.',
+                error,
+              );
+            }
             return EMPTY_RELEVANT_AUTO_MEMORY_RESULT;
           });
         this.pendingRecallAbortController = recallAbortController;

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -130,6 +130,29 @@ const EMPTY_RELEVANT_AUTO_MEMORY_RESULT: RelevantAutoMemoryPromptResult = {
   strategy: 'none',
 };
 
+/**
+ * Resolve the auto-memory recall promise with a hard deadline.
+ * If the recall (model-driven selection + heuristic fallback) does not complete
+ * within the deadline, return an empty result so the main request is not delayed.
+ *
+ * The deadline is set slightly above the model-driven selector's own
+ * AbortSignal.timeout (2s) to give the heuristic fallback time to complete,
+ * but low enough that the user does not perceive a delay on every turn.
+ */
+async function resolveAutoMemoryWithDeadline(
+  promise: Promise<RelevantAutoMemoryPromptResult> | undefined,
+): Promise<RelevantAutoMemoryPromptResult> {
+  if (!promise) {
+    return EMPTY_RELEVANT_AUTO_MEMORY_RESULT;
+  }
+
+  const deadline = new Promise<RelevantAutoMemoryPromptResult>((resolve) => {
+    setTimeout(() => resolve(EMPTY_RELEVANT_AUTO_MEMORY_RESULT), 2_500);
+  });
+
+  return Promise.race([promise, deadline]);
+}
+
 export class GeminiClient {
   private chat?: GeminiChat;
   private sessionTurnCount = 0;
@@ -860,9 +883,9 @@ export class GeminiClient {
       messageType === SendMessageType.Cron
     ) {
       const systemReminders = [];
-      const relevantAutoMemory = relevantAutoMemoryPromise
-        ? await relevantAutoMemoryPromise
-        : EMPTY_RELEVANT_AUTO_MEMORY_RESULT;
+      const relevantAutoMemory = await resolveAutoMemoryWithDeadline(
+        relevantAutoMemoryPromise,
+      );
       const relevantAutoMemoryPrompt = relevantAutoMemory.prompt;
 
       if (relevantAutoMemoryPrompt) {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -141,16 +141,25 @@ const EMPTY_RELEVANT_AUTO_MEMORY_RESULT: RelevantAutoMemoryPromptResult = {
  */
 async function resolveAutoMemoryWithDeadline(
   promise: Promise<RelevantAutoMemoryPromptResult> | undefined,
+  onDeadline: () => void,
 ): Promise<RelevantAutoMemoryPromptResult> {
   if (!promise) {
     return EMPTY_RELEVANT_AUTO_MEMORY_RESULT;
   }
 
+  let timer: ReturnType<typeof setTimeout>;
   const deadline = new Promise<RelevantAutoMemoryPromptResult>((resolve) => {
-    setTimeout(() => resolve(EMPTY_RELEVANT_AUTO_MEMORY_RESULT), 2_500);
+    timer = setTimeout(() => {
+      onDeadline();
+      resolve(EMPTY_RELEVANT_AUTO_MEMORY_RESULT);
+    }, 2_500);
   });
 
-  return Promise.race([promise, deadline]);
+  try {
+    return await Promise.race([promise, deadline]);
+  } finally {
+    clearTimeout(timer!);
+  }
 }
 
 export class GeminiClient {
@@ -162,6 +171,7 @@ export class GeminiClient {
   private lastPromptId: string | undefined = undefined;
   private lastSentIdeContext: IdeContext | undefined;
   private forceFullIdeContext = true;
+  private _pendingRecallAbortController: AbortController | undefined;
 
   /**
    * Cache of per-model ContentGenerators keyed by model ID.
@@ -734,11 +744,13 @@ export class GeminiClient {
       messageType === SendMessageType.Cron
     ) {
       if (this.config.getManagedAutoMemoryEnabled()) {
+        const recallAbortController = new AbortController();
         relevantAutoMemoryPromise = this.config
           .getMemoryManager()
           .recall(this.config.getProjectRoot(), partToString(request), {
             config: this.config,
             excludedFilePaths: this.surfacedRelevantAutoMemoryPaths,
+            abortSignal: recallAbortController.signal,
           })
           .catch((error: unknown) => {
             debugLogger.warn(
@@ -747,6 +759,7 @@ export class GeminiClient {
             );
             return EMPTY_RELEVANT_AUTO_MEMORY_RESULT;
           });
+        this._pendingRecallAbortController = recallAbortController;
       }
 
       // record user/cron message for session management
@@ -883,8 +896,11 @@ export class GeminiClient {
       messageType === SendMessageType.Cron
     ) {
       const systemReminders = [];
+      const recallAbortController = this._pendingRecallAbortController;
+      this._pendingRecallAbortController = undefined;
       const relevantAutoMemory = await resolveAutoMemoryWithDeadline(
         relevantAutoMemoryPromise,
+        () => recallAbortController?.abort(),
       );
       const relevantAutoMemoryPrompt = relevantAutoMemory.prompt;
 

--- a/packages/core/src/memory/recall.ts
+++ b/packages/core/src/memory/recall.ts
@@ -219,10 +219,18 @@ export async function resolveRelevantAutoMemoryPromptForQuery(
         strategy,
       };
     } catch (error) {
-      debugLogger.warn(
-        'Model-driven auto-memory recall failed; falling back to heuristic selection.',
-        error,
-      );
+      // Distinguish deadline-triggered cancellation from real model errors
+      // so oncall debugging is not misled by the fallback log.
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        debugLogger.debug(
+          'Model-driven auto-memory recall cancelled by deadline; heuristic result discarded.',
+        );
+      } else {
+        debugLogger.warn(
+          'Model-driven auto-memory recall failed; falling back to heuristic selection.',
+          error,
+        );
+      }
     }
   }
 

--- a/packages/core/src/memory/recall.ts
+++ b/packages/core/src/memory/recall.ts
@@ -234,6 +234,16 @@ export async function resolveRelevantAutoMemoryPromptForQuery(
     }
   }
 
+  // If the caller's abort signal is already set (e.g. deadline fired), skip the
+  // heuristic fallback — the result would be discarded anyway.
+  if (options.abortSignal?.aborted) {
+    return {
+      prompt: '',
+      selectedDocs: [],
+      strategy: 'none',
+    };
+  }
+
   const selectedDocs = selectRelevantAutoMemoryDocuments(query, docs, limit);
   const strategy: RelevantAutoMemoryPromptResult['strategy'] =
     selectedDocs.length > 0 ? 'heuristic' : 'none';

--- a/packages/core/src/memory/recall.ts
+++ b/packages/core/src/memory/recall.ts
@@ -131,6 +131,8 @@ export interface ResolveRelevantAutoMemoryPromptOptions {
   excludedFilePaths?: Iterable<string>;
   limit?: number;
   recentTools?: readonly string[];
+  /** When provided and aborted, suppresses logMemoryRecall telemetry for discarded results. */
+  abortSignal?: AbortSignal;
 }
 
 export interface RelevantAutoMemoryPromptResult {
@@ -168,7 +170,7 @@ export async function resolveRelevantAutoMemoryPromptForQuery(
   const limit = options.limit ?? MAX_RELEVANT_DOCS;
 
   if (query.trim().length === 0 || docs.length === 0 || limit <= 0) {
-    if (options.config) {
+    if (options.config && !options.abortSignal?.aborted) {
       logMemoryRecall(
         options.config,
         new MemoryRecallEvent({
@@ -198,16 +200,18 @@ export async function resolveRelevantAutoMemoryPromptForQuery(
       );
       const strategy: RelevantAutoMemoryPromptResult['strategy'] =
         selectedDocs.length > 0 ? 'model' : 'none';
-      logMemoryRecall(
-        options.config,
-        new MemoryRecallEvent({
-          query_length: query.length,
-          docs_scanned: docs.length,
-          docs_selected: selectedDocs.length,
-          strategy,
-          duration_ms: Date.now() - t0,
-        }),
-      );
+      if (!options.abortSignal?.aborted) {
+        logMemoryRecall(
+          options.config,
+          new MemoryRecallEvent({
+            query_length: query.length,
+            docs_scanned: docs.length,
+            docs_selected: selectedDocs.length,
+            strategy,
+            duration_ms: Date.now() - t0,
+          }),
+        );
+      }
       return {
         prompt: buildRelevantAutoMemoryPrompt(selectedDocs),
         selectedDocs,
@@ -224,7 +228,7 @@ export async function resolveRelevantAutoMemoryPromptForQuery(
   const selectedDocs = selectRelevantAutoMemoryDocuments(query, docs, limit);
   const strategy: RelevantAutoMemoryPromptResult['strategy'] =
     selectedDocs.length > 0 ? 'heuristic' : 'none';
-  if (options.config) {
+  if (options.config && !options.abortSignal?.aborted) {
     logMemoryRecall(
       options.config,
       new MemoryRecallEvent({

--- a/packages/core/src/memory/recall.ts
+++ b/packages/core/src/memory/recall.ts
@@ -197,6 +197,7 @@ export async function resolveRelevantAutoMemoryPromptForQuery(
         docs,
         limit,
         options.recentTools ?? [],
+        options.abortSignal,
       );
       const strategy: RelevantAutoMemoryPromptResult['strategy'] =
         selectedDocs.length > 0 ? 'model' : 'none';

--- a/packages/core/src/memory/relevanceSelector.test.ts
+++ b/packages/core/src/memory/relevanceSelector.test.ts
@@ -76,6 +76,56 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
     expect(runSideQuery).not.toHaveBeenCalled();
   });
 
+  it('forwards caller abort signal to runSideQuery combined with timeout', async () => {
+    vi.mocked(runSideQuery).mockResolvedValue({
+      selected_memories: ['user.md'],
+    });
+
+    const callerSignal = new AbortController().signal;
+    await selectRelevantAutoMemoryDocumentsByModel(
+      mockConfig,
+      'check preferences',
+      docs,
+      2,
+      [],
+      callerSignal,
+    );
+
+    expect(runSideQuery).toHaveBeenCalledWith(
+      mockConfig,
+      expect.objectContaining({
+        abortSignal: expect.any(AbortSignal),
+      }),
+    );
+
+    // Verify the abort signal is a combined signal (AbortSignal.any)
+    const callArgs = vi.mocked(runSideQuery).mock.calls[0][1];
+    const passedSignal = callArgs.abortSignal;
+    // When callerAbortSignal is provided, it should be an AbortSignal from AbortSignal.any
+    // which is still an AbortSignal instance
+    expect(passedSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it('uses timeout-only abort signal when no caller signal provided', async () => {
+    vi.mocked(runSideQuery).mockResolvedValue({
+      selected_memories: [],
+    });
+
+    await selectRelevantAutoMemoryDocumentsByModel(
+      mockConfig,
+      'check preferences',
+      docs,
+      2,
+    );
+
+    expect(runSideQuery).toHaveBeenCalledWith(
+      mockConfig,
+      expect.objectContaining({
+        abortSignal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
   it('throws when selector returns unknown relative paths', async () => {
     vi.mocked(runSideQuery).mockImplementation(async (_config, options) => {
       const error = options.validate?.({

--- a/packages/core/src/memory/relevanceSelector.test.ts
+++ b/packages/core/src/memory/relevanceSelector.test.ts
@@ -5,7 +5,6 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-// eslint-disable-next-line import/no-internal-modules -- Test must mock the exact side-query module path used by relevanceSelector.
 import { runSideQuery } from '../utils/sideQuery.js';
 import type { ScannedAutoMemoryDocument } from './scan.js';
 import { selectRelevantAutoMemoryDocumentsByModel } from './relevanceSelector.js';

--- a/packages/core/src/memory/relevanceSelector.test.ts
+++ b/packages/core/src/memory/relevanceSelector.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { Config } from '../config/config.js';
+// eslint-disable-next-line import/no-internal-modules -- Test must mock the exact side-query module path used by relevanceSelector.
 import { runSideQuery } from '../utils/sideQuery.js';
 import type { ScannedAutoMemoryDocument } from './scan.js';
 import { selectRelevantAutoMemoryDocumentsByModel } from './relevanceSelector.js';
@@ -38,7 +38,9 @@ const docs: ScannedAutoMemoryDocument[] = [
 ];
 
 describe('selectRelevantAutoMemoryDocumentsByModel', () => {
-  const mockConfig = {} as Config;
+  const mockConfig = {} as Parameters<
+    typeof selectRelevantAutoMemoryDocumentsByModel
+  >[0];
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -77,33 +79,32 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
   });
 
   it('forwards caller abort signal to runSideQuery combined with timeout', async () => {
-    vi.mocked(runSideQuery).mockResolvedValue({
-      selected_memories: ['user.md'],
+    const callerController = new AbortController();
+    let capturedSignal: AbortSignal | undefined;
+
+    vi.mocked(runSideQuery).mockImplementation(async (_config, opts) => {
+      capturedSignal = opts.abortSignal;
+      return { selected_memories: [] };
     });
 
-    const callerSignal = new AbortController().signal;
     await selectRelevantAutoMemoryDocumentsByModel(
       mockConfig,
       'check preferences',
       docs,
       2,
       [],
-      callerSignal,
+      callerController.signal,
     );
 
-    expect(runSideQuery).toHaveBeenCalledWith(
-      mockConfig,
-      expect.objectContaining({
-        abortSignal: expect.any(AbortSignal),
-      }),
-    );
+    expect(runSideQuery).toHaveBeenCalledTimes(1);
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal!.aborted).toBe(false);
 
-    // Verify the abort signal is a combined signal (AbortSignal.any)
-    const callArgs = vi.mocked(runSideQuery).mock.calls[0][1];
-    const passedSignal = callArgs.abortSignal;
-    // When callerAbortSignal is provided, it should be an AbortSignal from AbortSignal.any
-    // which is still an AbortSignal instance
-    expect(passedSignal).toBeInstanceOf(AbortSignal);
+    callerController.abort();
+
+    await vi.waitFor(() => {
+      expect(capturedSignal!.aborted).toBe(true);
+    });
   });
 
   it('uses timeout-only abort signal when no caller signal provided', async () => {

--- a/packages/core/src/memory/relevanceSelector.ts
+++ b/packages/core/src/memory/relevanceSelector.ts
@@ -58,6 +58,7 @@ export async function selectRelevantAutoMemoryDocumentsByModel(
   docs: ScannedAutoMemoryDocument[],
   limit: number,
   recentTools: readonly string[] = [],
+  callerAbortSignal?: AbortSignal,
 ): Promise<ScannedAutoMemoryDocument[]> {
   if (docs.length === 0 || limit <= 0 || query.trim().length === 0) {
     return [];
@@ -90,7 +91,9 @@ export async function selectRelevantAutoMemoryDocumentsByModel(
     purpose: 'auto-memory-recall',
     contents,
     schema: RESPONSE_SCHEMA,
-    abortSignal: AbortSignal.timeout(2_000),
+    abortSignal: callerAbortSignal
+      ? AbortSignal.any([AbortSignal.timeout(2_000), callerAbortSignal])
+      : AbortSignal.timeout(2_000),
     systemInstruction: SELECT_MEMORIES_SYSTEM_PROMPT,
     config: {
       temperature: 0,

--- a/packages/core/src/memory/relevanceSelector.ts
+++ b/packages/core/src/memory/relevanceSelector.ts
@@ -90,7 +90,7 @@ export async function selectRelevantAutoMemoryDocumentsByModel(
     purpose: 'auto-memory-recall',
     contents,
     schema: RESPONSE_SCHEMA,
-    abortSignal: AbortSignal.timeout(5_000),
+    abortSignal: AbortSignal.timeout(2_000),
     systemInstruction: SELECT_MEMORIES_SYSTEM_PROMPT,
     config: {
       temperature: 0,


### PR DESCRIPTION
## Summary

Fixes #3759. The auto-memory recall side-query had a 5s AbortSignal.timeout that fired on every turn. Since the main request path awaited the full recall promise (including timeout + heuristic fallback), every user turn was delayed by ~5s.

## Changes

### Core fix
- **client.ts**: Add `resolveAutoMemoryWithDeadline()` that races the recall promise against a 2.5s deadline. If recall hasn't completed by then, proceed with an empty result so the main request is never blocked.
- **relevanceSelector.ts**: Reduce model-driven selector timeout from 5s to 2s. The selector is a simple ranking task that should complete quickly; 2s is still generous. When a caller abort signal is provided, combine both via `AbortSignal.any([AbortSignal.timeout(2_000), callerAbortSignal])` so the deadline propagates to the model API call.

### Abort lifecycle
- **client.ts**: Store the `AbortController` as `pendingRecallAbortController` instance field. The 2.5s deadline calls `abort()` on it, which propagates through `recall()` → `selectRelevantAutoMemoryDocumentsByModel` → `runSideQuery`, cancelling the in-flight LLM call.
- **client.ts**: All 4 early-return paths (MaxSessionTurns, boundedTurns=0, SessionTokenLimitExceeded, Arena control signal) now abort and clear `pendingRecallAbortController` before returning, preventing background recall from running after the user-facing turn has already completed.
- **client.ts**: `resetChat()` aborts and clears `pendingRecallAbortController` so a stale in-flight recall does not leak into the next session.
- **recall.ts**: When the model-driven selector is aborted by the deadline, the catch block distinguishes `AbortError` (logs at debug) from real model errors (logs at warn), keeping the warn channel meaningful for oncall debugging.
- **recall.ts**: Heuristic fallback is gated on `!abortSignal.aborted` so discarded results after the deadline don't produce output.

### Race-at-initiation trade-off
The recall promise is raced against the deadline at **initiation time** (when `recall()` is called), not at consumption time (when the result is awaited). This gives a consistent 2.5s recall budget regardless of how much intermediate work (microcompact, compression, token checks, IDE context) happens between initiation and consumption. The trade-off is that the recall no longer overlaps with that intermediate work — the total turn latency is slightly higher in the fast-recall case, but the worst-case latency is bounded.

### Telemetry
- **recall.ts**: `logMemoryRecall` is gated on `!abortSignal.aborted` at all 3 call sites, so discarded results don't inflate recall-success metrics.

## Validation

- `npm run build` — 0 errors
- `npx vitest run packages/core/src/core/client.test.ts` — 78 tests pass
- `npx vitest run packages/core/src/memory/` — 10 tests pass
- Pre-commit hooks (prettier + eslint) pass

## Risk

Low. The change only affects the auto-memory recall path. When recall is fast (the common case), behavior is unchanged. When recall is slow, the main request proceeds without memory context instead of waiting. The abort cleanup on early-return paths and `resetChat()` prevents resource leaks.