### PR TITLE
fix(core): coalesce MCP server rediscovery

### DIFF
--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -227,6 +227,80 @@ describe('McpClientManager', () => {
     expect(secondClient.disconnect).toHaveBeenCalledOnce();
   });
 
+  it('should coalesce concurrent discovery for the same server', async () => {
+    let resolveDisconnect!: () => void;
+    const disconnectPromise = new Promise<void>((resolve) => {
+      resolveDisconnect = resolve;
+    });
+    const firstClient = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      discover: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(() => disconnectPromise),
+      getStatus: vi.fn(),
+    };
+    const replacementClients: Array<{
+      connect: ReturnType<typeof vi.fn>;
+      discover: ReturnType<typeof vi.fn>;
+      disconnect: ReturnType<typeof vi.fn>;
+      getStatus: ReturnType<typeof vi.fn>;
+    }> = [];
+
+    vi.mocked(McpClient).mockImplementation(() => {
+      if (
+        replacementClients.length === 0 &&
+        vi.mocked(McpClient).mock.calls.length === 1
+      ) {
+        return firstClient as unknown as McpClient;
+      }
+
+      const replacementClient = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        discover: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn().mockResolvedValue(undefined),
+        getStatus: vi.fn(),
+      };
+      replacementClients.push(replacementClient);
+      return replacementClient as unknown as McpClient;
+    });
+
+    const mockConfig = {
+      isTrustedFolder: () => true,
+      getMcpServers: () => ({ 'test-server': {} }),
+      getMcpServerCommand: () => undefined,
+      getPromptRegistry: () => ({}) as PromptRegistry,
+      getWorkspaceContext: () => ({}) as WorkspaceContext,
+      getDebugMode: () => false,
+    } as unknown as Config;
+    const manager = new McpClientManager(mockConfig, {} as ToolRegistry);
+
+    await manager.discoverMcpToolsForServer(
+      'test-server',
+      {} as unknown as Config,
+    );
+
+    const firstRediscovery = manager.discoverMcpToolsForServer(
+      'test-server',
+      {} as unknown as Config,
+    );
+    await Promise.resolve();
+
+    const secondRediscovery = manager.discoverMcpToolsForServer(
+      'test-server',
+      {} as unknown as Config,
+    );
+    const disconnectCallsBeforeResolve =
+      firstClient.disconnect.mock.calls.length;
+
+    resolveDisconnect();
+    await Promise.all([firstRediscovery, secondRediscovery]);
+
+    expect(disconnectCallsBeforeResolve).toBe(1);
+    expect(vi.mocked(McpClient)).toHaveBeenCalledTimes(2);
+    expect(replacementClients).toHaveLength(1);
+    expect(replacementClients[0].connect).toHaveBeenCalledOnce();
+    expect(replacementClients[0].discover).toHaveBeenCalledOnce();
+  });
+
   it('should no-op when discovering an unknown server', async () => {
     const mockedMcpClient = {
       connect: vi.fn(),

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -246,10 +246,7 @@ describe('McpClientManager', () => {
     }> = [];
 
     vi.mocked(McpClient).mockImplementation(() => {
-      if (
-        replacementClients.length === 0 &&
-        vi.mocked(McpClient).mock.calls.length === 1
-      ) {
+      if (vi.mocked(McpClient).mock.calls.length === 1) {
         return firstClient as unknown as McpClient;
       }
 

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -310,6 +310,131 @@ describe('McpClientManager', () => {
     expect(replacementClients[1].discover).toHaveBeenCalledOnce();
   });
 
+  it('should restore health checks after failed server rediscovery', async () => {
+    vi.useFakeTimers();
+
+    const firstClient = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      discover: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      getStatus: vi.fn(),
+    };
+    const failedClient = {
+      connect: vi.fn().mockRejectedValue(new Error('transient failure')),
+      discover: vi.fn(),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      getStatus: vi.fn(),
+    };
+    vi.mocked(McpClient)
+      .mockReturnValueOnce(firstClient as unknown as McpClient)
+      .mockReturnValueOnce(failedClient as unknown as McpClient);
+
+    const mockConfig = {
+      isTrustedFolder: () => true,
+      getMcpServers: () => ({ 'test-server': {} }),
+      getMcpServerCommand: () => undefined,
+      getPromptRegistry: () => ({}) as PromptRegistry,
+      getWorkspaceContext: () => ({}) as WorkspaceContext,
+      getDebugMode: () => false,
+    } as unknown as Config;
+    const manager = new McpClientManager(
+      mockConfig,
+      {} as ToolRegistry,
+      undefined,
+      undefined,
+      {
+        autoReconnect: true,
+        checkIntervalMs: 10,
+        maxConsecutiveFailures: 1,
+        reconnectDelayMs: 10,
+      },
+    );
+
+    try {
+      await manager.discoverMcpToolsForServer(
+        'test-server',
+        {} as unknown as Config,
+      );
+      expect(
+        (
+          manager as unknown as {
+            healthCheckTimers: Map<string, NodeJS.Timeout>;
+          }
+        ).healthCheckTimers.has('test-server'),
+      ).toBe(true);
+
+      await manager.discoverMcpToolsForServer(
+        'test-server',
+        {} as unknown as Config,
+      );
+
+      expect(failedClient.connect).toHaveBeenCalledOnce();
+      expect(
+        (
+          manager as unknown as {
+            healthCheckTimers: Map<string, NodeJS.Timeout>;
+          }
+        ).healthCheckTimers.has('test-server'),
+      ).toBe(true);
+    } finally {
+      await manager.stop();
+      vi.useRealTimers();
+    }
+  });
+
+  it('should clear in-flight discovery tracking when stopping', async () => {
+    let resolveConnect!: () => void;
+    const connectPromise = new Promise<void>((resolve) => {
+      resolveConnect = resolve;
+    });
+    const mockedMcpClient = {
+      connect: vi.fn(() => connectPromise),
+      discover: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      getStatus: vi.fn(),
+    };
+    vi.mocked(McpClient).mockReturnValue(
+      mockedMcpClient as unknown as McpClient,
+    );
+
+    const mockConfig = {
+      isTrustedFolder: () => true,
+      getMcpServers: () => ({ 'test-server': {} }),
+      getMcpServerCommand: () => undefined,
+      getPromptRegistry: () => ({}) as PromptRegistry,
+      getWorkspaceContext: () => ({}) as WorkspaceContext,
+      getDebugMode: () => false,
+    } as unknown as Config;
+    const manager = new McpClientManager(mockConfig, {} as ToolRegistry);
+
+    const discovery = manager.discoverMcpToolsForServer(
+      'test-server',
+      {} as unknown as Config,
+    );
+    await Promise.resolve();
+
+    expect(
+      (
+        manager as unknown as {
+          serverDiscoveryPromises: Map<string, Promise<void>>;
+        }
+      ).serverDiscoveryPromises.has('test-server'),
+    ).toBe(true);
+
+    await manager.stop();
+
+    expect(
+      (
+        manager as unknown as {
+          serverDiscoveryPromises: Map<string, Promise<void>>;
+        }
+      ).serverDiscoveryPromises.has('test-server'),
+    ).toBe(false);
+
+    resolveConnect();
+    await discovery;
+  });
+
   it('should no-op when discovering an unknown server', async () => {
     const mockedMcpClient = {
       connect: vi.fn(),

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -299,6 +299,18 @@ describe('McpClientManager', () => {
     expect(replacementClients).toHaveLength(1);
     expect(replacementClients[0].connect).toHaveBeenCalledOnce();
     expect(replacementClients[0].discover).toHaveBeenCalledOnce();
+
+    // Verify map was cleaned up: a third call should do real work,
+    // not get coalesced into a stale promise.
+    await manager.discoverMcpToolsForServer(
+      'test-server',
+      {} as unknown as Config,
+    );
+
+    expect(vi.mocked(McpClient)).toHaveBeenCalledTimes(3);
+    expect(replacementClients).toHaveLength(2);
+    expect(replacementClients[1].connect).toHaveBeenCalledOnce();
+    expect(replacementClients[1].discover).toHaveBeenCalledOnce();
   });
 
   it('should no-op when discovering an unknown server', async () => {

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -58,6 +58,7 @@ export class McpClientManager {
   private healthCheckTimers: Map<string, NodeJS.Timeout> = new Map();
   private consecutiveFailures: Map<string, number> = new Map();
   private isReconnecting: Map<string, boolean> = new Map();
+  private serverDiscoveryPromises: Map<string, Promise<void>> = new Map();
 
   constructor(
     config: Config,
@@ -148,6 +149,30 @@ export class McpClientManager {
     serverName: string,
     cliConfig: Config,
   ): Promise<void> {
+    const inProgressDiscovery = this.serverDiscoveryPromises.get(serverName);
+    if (inProgressDiscovery) {
+      await inProgressDiscovery;
+      return;
+    }
+
+    const discoveryPromise = Promise.resolve().then(() =>
+      this.discoverMcpToolsForServerInternal(serverName, cliConfig),
+    );
+    this.serverDiscoveryPromises.set(serverName, discoveryPromise);
+
+    try {
+      await discoveryPromise;
+    } finally {
+      if (this.serverDiscoveryPromises.get(serverName) === discoveryPromise) {
+        this.serverDiscoveryPromises.delete(serverName);
+      }
+    }
+  }
+
+  private async discoverMcpToolsForServerInternal(
+    serverName: string,
+    cliConfig: Config,
+  ): Promise<void> {
     const servers = populateMcpServerCommand(
       this.cliConfig.getMcpServers() || {},
       this.cliConfig.getMcpServerCommand(),
@@ -156,6 +181,8 @@ export class McpClientManager {
     if (!serverConfig) {
       return;
     }
+
+    this.stopHealthCheck(serverName);
 
     // Ensure we don't leak an existing connection for this server.
     const existingClient = this.clients.get(serverName);

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -155,8 +155,9 @@ export class McpClientManager {
       return;
     }
 
-    const discoveryPromise = Promise.resolve().then(() =>
-      this.discoverMcpToolsForServerInternal(serverName, cliConfig),
+    const discoveryPromise = this.discoverMcpToolsForServerInternal(
+      serverName,
+      cliConfig,
     );
     this.serverDiscoveryPromises.set(serverName, discoveryPromise);
 

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -221,8 +221,6 @@ export class McpClientManager {
     try {
       await client.connect();
       await client.discover(cliConfig);
-      // Start health check for this server after successful discovery
-      this.startHealthCheck(serverName);
     } catch (error) {
       // Log the error but don't throw: callers expect best-effort discovery.
       debugLogger.error(
@@ -231,6 +229,7 @@ export class McpClientManager {
         )}`,
       );
     } finally {
+      this.startHealthCheck(serverName);
       this.eventEmitter?.emit('mcp-client-update', this.clients);
     }
   }
@@ -259,6 +258,7 @@ export class McpClientManager {
     this.clients.clear();
     this.consecutiveFailures.clear();
     this.isReconnecting.clear();
+    this.serverDiscoveryPromises.clear();
   }
 
   /**
@@ -281,6 +281,7 @@ export class McpClientManager {
         this.clients.delete(serverName);
         this.consecutiveFailures.delete(serverName);
         this.isReconnecting.delete(serverName);
+        this.serverDiscoveryPromises.delete(serverName);
         this.eventEmitter?.emit('mcp-client-update', this.clients);
       }
     }


### PR DESCRIPTION
## Summary

- What changed: Overlapping MCP server rediscovery requests for the same server now share the in-flight restart instead of starting independent replacement clients; rediscovery also stops the old health-check timer before replacing a server connection.
- Why it changed: Concurrent reconnect/restart paths could each try to replace the same server connection and leave an extra MCP process running without a tracked client.
- Reviewer focus: Please check that same-server rediscovery is coalesced while normal single-server replacement behavior remains unchanged.

## Validation

- Commands run:
  ```bash
  npm ci --ignore-scripts
  cd packages/core && npx vitest run src/tools/mcp-client-manager.test.ts
  cd ../..
  npm run build --workspace=packages/core
  npm run typecheck
  npx prettier --check packages/core/src/tools/mcp-client-manager.ts packages/core/src/tools/mcp-client-manager.test.ts
  npx eslint packages/core/src/tools/mcp-client-manager.ts packages/core/src/tools/mcp-client-manager.test.ts
  git diff --check HEAD~1..HEAD
  ```
- Prompts / inputs used: N/A — internal lifecycle regression coverage.
- Expected result: Concurrent same-server rediscovery should perform one replacement flow and create one replacement client.
- Observed result: The focused core Vitest file passes with 8 tests, including the new concurrent rediscovery regression. Build, typecheck, format, lint, and whitespace checks pass locally.
- Quickest reviewer verification path:
  ```bash
  cd packages/core && npx vitest run src/tools/mcp-client-manager.test.ts
  ```
- Evidence: Before the fix, the new regression failed because two concurrent rediscovery calls both tried to disconnect/replace the same client. After the fix, the regression and existing manager tests pass.

## Scope / Risk

- Main risk or tradeoff: A duplicate concurrent request now waits for the in-flight rediscovery instead of forcing an immediate second restart. This is intended to avoid duplicate MCP processes.
- Not covered / not validated: No full end-to-end subprocess demo; validation is focused on the manager lifecycle behavior.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ⚠️  | ✅  |
| npx      | ⚠️  | ⚠️  | ✅  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Local validation was run on Linux only. Docker/Podman/Seatbelt were not applicable to this internal lifecycle fix.

## Linked Issues / Bugs

Fixes #3817

