### PR TITLE
feat(sdk-python): replace verbatim release notes inheritance with --generate-notes

### DIFF
--- a/.github/workflows/release-sdk-python.yml
+++ b/.github/workflows/release-sdk-python.yml
@@ -406,9 +406,17 @@ jobs:
           NOTES_START_TAG_ARG=""
           GENERATE_NOTES_FLAG="--generate-notes"
           if [[ -n "${PREVIOUS_RELEASE_TAG}" ]]; then
-            # --notes-start-tag replaces the old gh release view fetch;
-            # gh release create handles missing tags with a clear error.
-            NOTES_START_TAG_ARG="--notes-start-tag sdk-python-${PREVIOUS_RELEASE_TAG}"
+            # Verify the previous tag exists in Git before using --notes-start-tag.
+            # If a prior release published to PyPI but failed to create a GitHub
+            # release/tag, the tag won't exist — fall back to static notes to
+            # avoid failing gh release create after PyPI publish.
+            if git rev-parse "sdk-python-${PREVIOUS_RELEASE_TAG}" >/dev/null 2>&1; then
+              NOTES_START_TAG_ARG="--notes-start-tag sdk-python-${PREVIOUS_RELEASE_TAG}"
+            else
+              echo "::warning::Previous tag sdk-python-${PREVIOUS_RELEASE_TAG} not found; skipping --generate-notes."
+              GENERATE_NOTES_FLAG=""
+              echo "See commit history for changes." >> "${NOTES_FILE}"
+            fi
           else
             # PREVIOUS_RELEASE_TAG is only computed for stable releases.
             # For preview/nightly, skip --generate-notes to avoid including non-SDK commits.

--- a/.github/workflows/release-sdk-python.yml
+++ b/.github/workflows/release-sdk-python.yml
@@ -403,14 +403,17 @@ jobs:
             echo ""
           } > "${NOTES_FILE}"
 
-          NOTES_START_TAG_FLAG=""
+          NOTES_START_TAG_ARG=""
           GENERATE_NOTES_FLAG="--generate-notes"
           if [[ -n "${PREVIOUS_RELEASE_TAG}" ]]; then
-            NOTES_START_TAG_FLAG="--notes-start-tag sdk-python-${PREVIOUS_RELEASE_TAG}"
+            # --notes-start-tag replaces the old gh release view fetch;
+            # gh release create handles missing tags with a clear error.
+            NOTES_START_TAG_ARG="--notes-start-tag sdk-python-${PREVIOUS_RELEASE_TAG}"
           else
-            # No prior SDK tag — auto-generated notes would include non-SDK commits.
+            # PREVIOUS_RELEASE_TAG is only computed for stable releases.
+            # For preview/nightly, skip --generate-notes to avoid including non-SDK commits.
             GENERATE_NOTES_FLAG=""
-            echo "Initial release. See commit history for changes." >> "${NOTES_FILE}"
+            echo "See commit history for changes." >> "${NOTES_FILE}"
           fi
 
           gh release create "${TAG_NAME}" \
@@ -418,7 +421,7 @@ jobs:
             --title "SDK Python Release ${RELEASE_TAG}" \
             --notes-file "${NOTES_FILE}" \
             ${GENERATE_NOTES_FLAG} \
-            ${NOTES_START_TAG_FLAG} \
+            ${NOTES_START_TAG_ARG} \
             ${PRERELEASE_FLAG}
 
           rm -f "${NOTES_FILE}"

--- a/.github/workflows/release-sdk-python.yml
+++ b/.github/workflows/release-sdk-python.yml
@@ -373,12 +373,6 @@ jobs:
           set -euo pipefail
           TAG_NAME="sdk-python-${RELEASE_TAG}"
 
-          if [[ "${IS_NIGHTLY}" == "true" || "${IS_PREVIEW}" == "true" ]]; then
-            PRERELEASE_FLAG="--prerelease"
-          else
-            PRERELEASE_FLAG=""
-          fi
-
           if gh release view "${TAG_NAME}" --json tagName >/dev/null 2>&1; then
             echo "::warning::GitHub release ${TAG_NAME} already exists; skipping create."
             exit 0
@@ -403,35 +397,34 @@ jobs:
             echo ""
           } > "${NOTES_FILE}"
 
-          NOTES_START_TAG_ARG=""
-          GENERATE_NOTES_FLAG="--generate-notes"
+          GH_RELEASE_ARGS=()
           if [[ -n "${PREVIOUS_RELEASE_TAG}" ]]; then
             # Verify the previous tag exists in Git before using --notes-start-tag.
             # If a prior release published to PyPI but failed to create a GitHub
             # release/tag, the tag won't exist — fall back to static notes to
             # avoid failing gh release create after PyPI publish.
             if git rev-parse "sdk-python-${PREVIOUS_RELEASE_TAG}" >/dev/null 2>&1; then
-              NOTES_START_TAG_ARG="--notes-start-tag sdk-python-${PREVIOUS_RELEASE_TAG}"
+              GH_RELEASE_ARGS+=(--generate-notes --notes-start-tag "sdk-python-${PREVIOUS_RELEASE_TAG}")
             else
               echo "::warning::Previous tag sdk-python-${PREVIOUS_RELEASE_TAG} not found; skipping --generate-notes."
-              GENERATE_NOTES_FLAG=""
               echo "See commit history for changes." >> "${NOTES_FILE}"
             fi
           else
             # PREVIOUS_RELEASE_TAG is empty for preview/nightly (not computed)
             # and for the very first stable release (no prior stable on PyPI).
             # Skip --generate-notes to avoid including non-SDK commits.
-            GENERATE_NOTES_FLAG=""
             echo "See commit history for changes." >> "${NOTES_FILE}"
+          fi
+
+          if [[ "${IS_NIGHTLY}" == "true" || "${IS_PREVIEW}" == "true" ]]; then
+            GH_RELEASE_ARGS+=(--prerelease)
           fi
 
           gh release create "${TAG_NAME}" \
             --target "${RELEASE_TARGET_SHA}" \
             --title "SDK Python Release ${RELEASE_TAG}" \
             --notes-file "${NOTES_FILE}" \
-            ${GENERATE_NOTES_FLAG} \
-            ${NOTES_START_TAG_ARG} \
-            ${PRERELEASE_FLAG}
+            "${GH_RELEASE_ARGS[@]}"
 
           rm -f "${NOTES_FILE}"
 

--- a/.github/workflows/release-sdk-python.yml
+++ b/.github/workflows/release-sdk-python.yml
@@ -418,8 +418,9 @@ jobs:
               echo "See commit history for changes." >> "${NOTES_FILE}"
             fi
           else
-            # PREVIOUS_RELEASE_TAG is only computed for stable releases.
-            # For preview/nightly, skip --generate-notes to avoid including non-SDK commits.
+            # PREVIOUS_RELEASE_TAG is empty for preview/nightly (not computed)
+            # and for the very first stable release (no prior stable on PyPI).
+            # Skip --generate-notes to avoid including non-SDK commits.
             GENERATE_NOTES_FLAG=""
             echo "See commit history for changes." >> "${NOTES_FILE}"
           fi

--- a/.github/workflows/release-sdk-python.yml
+++ b/.github/workflows/release-sdk-python.yml
@@ -399,14 +399,15 @@ jobs:
 
           GH_RELEASE_ARGS=()
           if [[ -n "${PREVIOUS_RELEASE_TAG}" ]]; then
+            PREVIOUS_TAG_NAME="sdk-python-${PREVIOUS_RELEASE_TAG}"
             # Verify the previous tag exists in Git before using --notes-start-tag.
             # If a prior release published to PyPI but failed to create a GitHub
             # release/tag, the tag won't exist — fall back to static notes to
             # avoid failing gh release create after PyPI publish.
-            if git rev-parse "sdk-python-${PREVIOUS_RELEASE_TAG}" >/dev/null 2>&1; then
-              GH_RELEASE_ARGS+=(--generate-notes --notes-start-tag "sdk-python-${PREVIOUS_RELEASE_TAG}")
+            if git rev-parse "${PREVIOUS_TAG_NAME}" >/dev/null 2>&1; then
+              GH_RELEASE_ARGS+=(--generate-notes --notes-start-tag "${PREVIOUS_TAG_NAME}")
             else
-              echo "::warning::Previous tag sdk-python-${PREVIOUS_RELEASE_TAG} not found; skipping --generate-notes."
+              echo "::warning::Previous tag ${PREVIOUS_TAG_NAME} not found; skipping --generate-notes."
               echo "See commit history for changes." >> "${NOTES_FILE}"
             fi
           else

--- a/.github/workflows/release-sdk-python.yml
+++ b/.github/workflows/release-sdk-python.yml
@@ -403,28 +403,22 @@ jobs:
             echo ""
           } > "${NOTES_FILE}"
 
+          NOTES_START_TAG_FLAG=""
+          GENERATE_NOTES_FLAG="--generate-notes"
           if [[ -n "${PREVIOUS_RELEASE_TAG}" ]]; then
-            PREVIOUS_NOTES=$(gh release view "sdk-python-${PREVIOUS_RELEASE_TAG}" --json body -q '.body' 2>&1) || {
-              ERR_MSG="${PREVIOUS_NOTES}"
-              case "${ERR_MSG}" in
-                *"release not found"*|*"Not Found"*|*"HTTP 404"*)
-                  PREVIOUS_NOTES='See commit history for changes.'
-                  ;;
-                *)
-                  echo "::warning::Failed to fetch previous release notes: ${ERR_MSG}"
-                  PREVIOUS_NOTES='See commit history for changes.'
-                  ;;
-              esac
-            }
-            printf '%s\n' "${PREVIOUS_NOTES}" >> "${NOTES_FILE}"
+            NOTES_START_TAG_FLAG="--notes-start-tag sdk-python-${PREVIOUS_RELEASE_TAG}"
           else
-            echo "See commit history for changes." >> "${NOTES_FILE}"
+            # No prior SDK tag — auto-generated notes would include non-SDK commits.
+            GENERATE_NOTES_FLAG=""
+            echo "Initial release. See commit history for changes." >> "${NOTES_FILE}"
           fi
 
           gh release create "${TAG_NAME}" \
             --target "${RELEASE_TARGET_SHA}" \
             --title "SDK Python Release ${RELEASE_TAG}" \
             --notes-file "${NOTES_FILE}" \
+            ${GENERATE_NOTES_FLAG} \
+            ${NOTES_START_TAG_FLAG} \
             ${PRERELEASE_FLAG}
 
           rm -f "${NOTES_FILE}"


### PR DESCRIPTION
## Summary

- What changed: Replaced verbatim previous-release-body inheritance in the Python SDK release workflow with GitHub's `--generate-notes` + `--notes-start-tag` flags. For first-ever releases (no previous SDK tag), `--generate-notes` is skipped and a static "Initial release" message is used instead.
- Why it changed: The old approach fetched the entire body of the previous release and appended it — but since each body already contained all prior bodies, this created a chain that grew linearly with every stable release, eventually hitting GitHub's 125 KB release body limit.
- Reviewer focus: The conditional logic for first-release vs. subsequent-release paths (lines 406-414), and the `--notes-start-tag` prefix (`sdk-python-`) matching the actual Git tag format.

## Validation

- Commands run:
  ```bash
  npm run build && npm run typecheck  # pass
  npm run lint                        # pass
  python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-sdk-python.yml'))"  # valid YAML
  ```
- Prompts / inputs used: N/A (workflow file change, not runtime code)
- Expected result: YAML parses cleanly, build/typecheck/lint pass
- Observed result: All pass
- Quickest reviewer verification path: Read the diff — the change is a single step in one workflow file. Verify that `--generate-notes` combined with `--notes-file` prepends custom body (per [GitHub docs](https://cli.github.com/manual/gh_release_create)).
- Evidence: Build, typecheck, and lint all pass. YAML validated with Python's yaml.safe_load.

## Scope / Risk

- Main risk or tradeoff: Auto-generated notes depend on GitHub's PR-based changelog format; if no PRs exist between tags, the changelog section will be empty (but the SDK metadata header is always present).
- Not covered / not validated: Live workflow execution (requires actual release trigger). The TypeScript SDK workflow has the same chain inheritance pattern but is intentionally left for a separate issue.
- Breaking changes / migration notes: None. Existing releases are unaffected; only future release note content changes.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | N/A | N/A | N/A |
| npx      | N/A | N/A | N/A |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- This change only affects a GitHub Actions workflow file. It does not alter any runtime code, so platform testing is not applicable.

## Linked Issues / Bugs

Closes #3796

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)