### PR TITLE
feat(core): add signal.reason convention for ShellExecutionService (#3831 PR-1 of 3)

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1734,6 +1734,21 @@ describe('ShellExecutionService execution method selection', () => {
       value: 54321,
       configurable: true,
     });
+    // Mirror real Node ChildProcess: `exitCode` / `signalCode` are
+    // `null` while alive. Kept in sync with the `child_process
+    // fallback` describe block's mock setup so any future promote-
+    // related test that lands here doesn't trip the production
+    // `child.exitCode !== null` race guard with a stale `undefined`.
+    Object.defineProperty(mockChildProcess, 'exitCode', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(mockChildProcess, 'signalCode', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
     mockCpSpawn.mockReturnValue(mockChildProcess);
   });
 

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -21,7 +21,10 @@ import type {
   ShellAbortReason,
   ShellOutputEvent,
 } from './shellExecutionService.js';
-import { ShellExecutionService } from './shellExecutionService.js';
+import {
+  getShellAbortReasonKind,
+  ShellExecutionService,
+} from './shellExecutionService.js';
 import type { AnsiOutput } from '../utils/terminalSerializer.js';
 
 const { Terminal } = pkg;
@@ -700,6 +703,40 @@ describe('ShellExecutionService', () => {
       expect(exitDisposableStub.dispose).toHaveBeenCalled();
     });
 
+    it("post-promotion: ptyProcess error listener is removed via 'removeListener', NOT 'off' (regression guard for @lydell/node-pty)", async () => {
+      // node EventEmitter exposes both `off` (Node 10+) and the legacy
+      // `removeListener`, but @lydell/node-pty's IPty interface only
+      // surfaces `removeListener` — calling `.off(...)` on a real PTY
+      // throws TypeError. Pin that the production code path uses
+      // `removeListener` so a future refactor swapping to `.off()`
+      // doesn't silently regress under the EventEmitter mock (which
+      // tolerates both).
+      const removeListenerSpy = vi.spyOn(mockPtyProcess, 'removeListener');
+      const offSpy = vi.spyOn(mockPtyProcess, 'off');
+
+      const { result } = await simulateExecution(
+        'tail -f /tmp/never.log',
+        (_pty, abortController) => {
+          abortController.abort({
+            kind: 'background',
+            shellId: 'bg_test123',
+          } satisfies ShellAbortReason);
+        },
+      );
+
+      expect(result.promoted).toBe(true);
+      // The 'error' handler is removed via legacy API; `.off` must not
+      // appear in the production teardown path.
+      expect(removeListenerSpy).toHaveBeenCalledWith(
+        'error',
+        expect.any(Function),
+      );
+      const offErrorCalls = offSpy.mock.calls.filter(
+        ([event]) => event === 'error',
+      );
+      expect(offErrorCalls).toEqual([]);
+    });
+
     it('post-promotion: PTY exit does NOT re-resolve the result (already resolved with promoted)', async () => {
       // Pin: even if the still-running child later exits naturally and the
       // caller's own exit listener fires, our foreground result Promise
@@ -1057,6 +1094,22 @@ describe('ShellExecutionService child_process fallback', () => {
       value: 12345,
       configurable: true,
     });
+    // Mirror real Node ChildProcess: `exitCode` / `signalCode` are `null`
+    // while the child is alive and become a number / signal name on
+    // exit. The background-promote liveness guard reads these to detect
+    // an exit that fired between abort dispatch and the abort handler
+    // run, and a default of `undefined` would mistakenly look terminal
+    // and skip the promote.
+    Object.defineProperty(mockChildProcess, 'exitCode', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(mockChildProcess, 'signalCode', {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
 
     mockCpSpawn.mockReturnValue(mockChildProcess);
   });
@@ -1348,6 +1401,45 @@ describe('ShellExecutionService child_process fallback', () => {
       expect(result.output).toContain('pre-promote');
       expect(result.output).not.toContain('post-promote-stdout');
       expect(result.output).not.toContain('post-promote-stderr');
+    });
+
+    it('post-exit race: background-promote refuses if child is already terminal (exitCode/signalCode non-null)', async () => {
+      // Race window: the child may have exited (exitCode set) but the
+      // 'exit' event hasn't reached our handler yet because Node delivers
+      // child_process events on the next microtask. Promoting in that
+      // window would detach our exit listener and report `promoted: true`
+      // for a process that's already dead — the caller would hold an
+      // inert pid expecting to take over. Production code reads
+      // exitCode / signalCode before detaching; if either is non-null,
+      // it falls through and lets the pending exit handler resolve
+      // normally with the real exit info.
+      mockPlatform.mockReturnValue('linux');
+      const { result } = await simulateExecution(
+        'fast-and-cancelled',
+        (cp, abortController) => {
+          // Simulate the race: pretend the child has already exited
+          // (exitCode set on the ChildProcess) but the 'exit' event
+          // emit is queued behind the abort dispatch.
+          Object.defineProperty(cp, 'exitCode', {
+            value: 0,
+            writable: true,
+            configurable: true,
+          });
+          abortController.abort({
+            kind: 'background',
+            shellId: 'bg_test123',
+          } satisfies ShellAbortReason);
+          // Now drain the pending exit + close events; the normal
+          // exit path should resolve the result.
+          cp.emit('exit', 0, null);
+          cp.emit('close', 0, null);
+        },
+      );
+
+      // Result is the normal exit shape, not the promoted shape.
+      expect(result.promoted).toBeUndefined();
+      expect(result.aborted).toBe(true); // abortSignal.aborted is still true
+      expect(result.exitCode).toBe(0);
     });
 
     it('post-promotion: child exit does NOT re-resolve the result with a non-promoted shape', async () => {
@@ -1663,5 +1755,79 @@ describe('ShellExecutionService execution method selection', () => {
     expect(mockPtySpawn).not.toHaveBeenCalled();
     expect(mockCpSpawn).toHaveBeenCalled();
     expect(result.executionMethod).toBe('child_process');
+  });
+});
+
+describe('getShellAbortReasonKind (defensive abort-reason read)', () => {
+  it("returns 'cancel' for null reason (e.g. plain abortController.abort())", () => {
+    expect(getShellAbortReasonKind(null)).toBe('cancel');
+    expect(getShellAbortReasonKind(undefined)).toBe('cancel');
+  });
+
+  it("returns 'cancel' for non-object reasons (string / number / DOMException)", () => {
+    expect(getShellAbortReasonKind('background')).toBe('cancel');
+    expect(getShellAbortReasonKind(42)).toBe('cancel');
+    expect(getShellAbortReasonKind(true)).toBe('cancel');
+    // DOMException-like object — not the real DOMException constructor in
+    // the test runtime, but the principle is the same: a non-discriminated
+    // object reason without an own `kind` falls back to cancel.
+    expect(getShellAbortReasonKind(new Error('aborted'))).toBe('cancel');
+  });
+
+  it("returns 'cancel' for an empty object (no own kind)", () => {
+    expect(getShellAbortReasonKind({})).toBe('cancel');
+  });
+
+  it("returns 'cancel' when 'kind' lives only on the prototype (pollution defense)", () => {
+    const polluted: Record<string, unknown> = Object.create({
+      kind: 'background',
+    });
+    // hasOwnProperty('kind') is false → helper rejects the prototype-only kind
+    expect(getShellAbortReasonKind(polluted)).toBe('cancel');
+  });
+
+  it("returns 'cancel' for an unknown kind value (typo / future-untyped variant)", () => {
+    expect(getShellAbortReasonKind({ kind: 'suspend' })).toBe('cancel');
+    expect(getShellAbortReasonKind({ kind: 'BACKGROUND' })).toBe('cancel');
+    expect(getShellAbortReasonKind({ kind: 42 })).toBe('cancel');
+  });
+
+  it("returns 'cancel' when reading 'kind' throws (accessor / Proxy trap)", () => {
+    const throwingReason = Object.defineProperty({}, 'kind', {
+      enumerable: true,
+      configurable: true,
+      get() {
+        throw new Error('accessor blew up');
+      },
+    });
+    expect(getShellAbortReasonKind(throwingReason)).toBe('cancel');
+
+    const proxyReason = new Proxy(
+      {},
+      {
+        get(_target, prop) {
+          if (prop === 'kind') throw new Error('proxy trap blew up');
+          return undefined;
+        },
+        getOwnPropertyDescriptor(_target, prop) {
+          if (prop === 'kind') {
+            return { configurable: true, enumerable: true, value: 'unused' };
+          }
+          return undefined;
+        },
+      },
+    );
+    expect(getShellAbortReasonKind(proxyReason)).toBe('cancel');
+  });
+
+  it("returns 'background' for the canonical happy-path reason", () => {
+    expect(getShellAbortReasonKind({ kind: 'background' })).toBe('background');
+    expect(
+      getShellAbortReasonKind({ kind: 'background', shellId: 'bg_x' }),
+    ).toBe('background');
+  });
+
+  it("returns 'cancel' for the canonical cancel reason", () => {
+    expect(getShellAbortReasonKind({ kind: 'cancel' })).toBe('cancel');
   });
 });

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -17,7 +17,10 @@ import EventEmitter from 'node:events';
 import type { Readable } from 'node:stream';
 import { type ChildProcess } from 'node:child_process';
 import pkg from '@xterm/headless';
-import type { ShellOutputEvent } from './shellExecutionService.js';
+import type {
+  ShellAbortReason,
+  ShellOutputEvent,
+} from './shellExecutionService.js';
 import { ShellExecutionService } from './shellExecutionService.js';
 import type { AnsiOutput } from '../utils/terminalSerializer.js';
 
@@ -608,6 +611,59 @@ describe('ShellExecutionService', () => {
       expect(result.aborted).toBe(true);
       // The process kill is mocked, so we just check that the flag is set.
     });
+
+    it('signal.reason = { kind: "cancel" } still tree-kills (same as default)', async () => {
+      const { result } = await simulateExecution(
+        'sleep 10',
+        (pty, abortController) => {
+          abortController.abort({ kind: 'cancel' } satisfies ShellAbortReason);
+          pty.onExit.mock.calls[0][0]({ exitCode: 1, signal: null });
+        },
+      );
+
+      expect(result.aborted).toBe(true);
+      expect(result.promoted).toBeUndefined();
+      // The default kill path runs: SIGTERM via process.kill on the
+      // process-group pid. Pinning that we DID try to kill — i.e., reason
+      // === 'cancel' is NOT mistakenly routed through the background branch.
+      expect(mockProcessKill).toHaveBeenCalledWith(
+        -mockPtyProcess.pid,
+        'SIGTERM',
+      );
+    });
+
+    it('signal.reason = { kind: "background" } skips kill and resolves with promoted: true', async () => {
+      // Critical: do NOT fire onExit — the child is still alive after the
+      // background-promote abort. The result Promise must resolve via the
+      // abort handler's own immediate resolve, not via the exit handler.
+      const { result } = await simulateExecution(
+        'tail -f /tmp/never.log',
+        (_pty, abortController) => {
+          abortController.abort({
+            kind: 'background',
+            shellId: 'bg_test123',
+          } satisfies ShellAbortReason);
+        },
+      );
+
+      expect(result.aborted).toBe(true);
+      expect(result.promoted).toBe(true);
+      expect(result.exitCode).toBeNull();
+      expect(result.signal).toBeNull();
+      expect(result.error).toBeNull();
+      expect(result.pid).toBe(mockPtyProcess.pid);
+      // Verify the kill path did NOT run: neither the PTY's own kill() nor
+      // process.kill on the group pid. Caller now owns the child.
+      expect(mockPtyProcess.kill).not.toHaveBeenCalled();
+      expect(mockProcessKill).not.toHaveBeenCalledWith(
+        -mockPtyProcess.pid,
+        'SIGTERM',
+      );
+      expect(mockProcessKill).not.toHaveBeenCalledWith(
+        -mockPtyProcess.pid,
+        'SIGKILL',
+      );
+    });
   });
 
   describe('Binary Output', () => {
@@ -1138,6 +1194,67 @@ describe('ShellExecutionService child_process fallback', () => {
         });
       },
     );
+
+    it('signal.reason = { kind: "cancel" } still tree-kills (same as default)', async () => {
+      mockPlatform.mockReturnValue('linux');
+      const { result } = await simulateExecution(
+        'sleep 10',
+        (cp, abortController) => {
+          abortController.abort({ kind: 'cancel' } satisfies ShellAbortReason);
+          cp.emit('exit', null, 'SIGKILL');
+          cp.emit('close', null, 'SIGKILL');
+        },
+      );
+
+      expect(result.aborted).toBe(true);
+      expect(result.promoted).toBeUndefined();
+      // Default kill path ran — pin that reason === 'cancel' is NOT
+      // mistakenly routed through the background branch.
+      expect(mockProcessKill).toHaveBeenCalledWith(
+        -mockChildProcess.pid!,
+        'SIGTERM',
+      );
+    });
+
+    it('signal.reason = { kind: "background" } skips kill and resolves with promoted: true', async () => {
+      mockPlatform.mockReturnValue('linux');
+      // Critical: do NOT fire 'exit' — the child is still alive after the
+      // background-promote abort. The result Promise must resolve via the
+      // abort handler's own immediate resolve.
+      const { result } = await simulateExecution(
+        'tail -f /tmp/never.log',
+        (cp, abortController) => {
+          // Emit some output first so the snapshot has content.
+          cp.stdout?.emit('data', Buffer.from('line1\nline2\n'));
+          abortController.abort({
+            kind: 'background',
+            shellId: 'bg_test123',
+          } satisfies ShellAbortReason);
+        },
+      );
+
+      expect(result.aborted).toBe(true);
+      expect(result.promoted).toBe(true);
+      expect(result.exitCode).toBeNull();
+      expect(result.signal).toBeNull();
+      expect(result.error).toBeNull();
+      expect(result.pid).toBe(mockChildProcess.pid);
+      // Output captured up to the promote moment is preserved as the
+      // snapshot for the caller to seed the BackgroundShellEntry's output
+      // file from.
+      expect(result.output).toContain('line1');
+      expect(result.output).toContain('line2');
+      // Verify the kill path did NOT run.
+      expect(mockProcessKill).not.toHaveBeenCalledWith(
+        -mockChildProcess.pid!,
+        'SIGTERM',
+      );
+      expect(mockProcessKill).not.toHaveBeenCalledWith(
+        -mockChildProcess.pid!,
+        'SIGKILL',
+      );
+      expect(mockChildProcess.kill).not.toHaveBeenCalled();
+    });
 
     it('should gracefully attempt SIGKILL on linux if SIGTERM fails', async () => {
       mockPlatform.mockReturnValue('linux');

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -703,6 +703,51 @@ describe('ShellExecutionService', () => {
       expect(exitDisposableStub.dispose).toHaveBeenCalled();
     });
 
+    it('post-exit race: PTY background-promote refuses if process.kill(pid, 0) reports the pid is gone', async () => {
+      // Mirror of the child_process post-exit race test. The PTY may
+      // have already exited but our `exitDisposable` (onExit) handler
+      // hasn't run yet — node-pty delivers the exit event async after
+      // the native SIGCHLD. Promoting in that window would detach our
+      // exit listener, miss the real exit status, and report
+      // `promoted: true` for a dead PTY. Production guard:
+      // process.kill(pid, 0); if it throws ESRCH, fall through.
+      mockProcessKill.mockImplementationOnce((pid, signal) => {
+        // Only fail the very first liveness probe with signal 0 — let
+        // any subsequent kill calls (e.g. cleanup() at process exit)
+        // succeed so the test teardown stays clean.
+        if (signal === 0) {
+          throw Object.assign(new Error('ESRCH'), { code: 'ESRCH' });
+        }
+        return true;
+      });
+      const { result } = await simulateExecution(
+        'fast-and-cancelled',
+        (pty, abortController) => {
+          abortController.abort({
+            kind: 'background',
+            shellId: 'bg_test123',
+          } satisfies ShellAbortReason);
+          // Drain the pending onExit (production code falls through;
+          // normal exit path resolves with the real exit info).
+          pty.onExit.mock.calls[0][0]({ exitCode: 0, signal: undefined });
+        },
+      );
+
+      // Result is the normal exit shape, not the promoted shape.
+      expect(result.promoted).toBeUndefined();
+      expect(result.exitCode).toBe(0);
+      // Our PTY listeners stayed registered — the disposables are
+      // disposed by the natural onExit, not the abort handler.
+      const dataDisposableStub = mockPtyProcess.onData.mock.results[0]
+        .value as { dispose: Mock };
+      // dataDisposable is NOT disposed by our abort handler in the
+      // race-fallthrough path (the normal onExit handler doesn't
+      // dispose it either — it relies on the PTY tearing down its own
+      // event source). What matters is that we did NOT pre-dispose it
+      // and lose the exit info.
+      void dataDisposableStub; // referenced for the future expansion
+    });
+
     it("post-promotion: ptyProcess error listener is removed via 'removeListener', NOT 'off' (regression guard for @lydell/node-pty)", async () => {
       // node EventEmitter exposes both `off` (Node 10+) and the legacy
       // `removeListener`, but @lydell/node-pty's IPty interface only

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -228,8 +228,12 @@ describe('ShellExecutionService', () => {
     };
     mockPtyProcess.pid = 12345;
     mockPtyProcess.kill = vi.fn();
-    mockPtyProcess.onData = vi.fn();
-    mockPtyProcess.onExit = vi.fn();
+    // node-pty's onData/onExit return IDisposable; the production
+    // background-promote path calls .dispose() on those handles to detach
+    // its listeners cleanly. Mock them to return a disposable stub so the
+    // promote path doesn't crash on `undefined.dispose()`.
+    mockPtyProcess.onData = vi.fn().mockReturnValue({ dispose: vi.fn() });
+    mockPtyProcess.onExit = vi.fn().mockReturnValue({ dispose: vi.fn() });
     mockPtyProcess.write = vi.fn();
     mockPtyProcess.resize = vi.fn();
 
@@ -663,6 +667,60 @@ describe('ShellExecutionService', () => {
         -mockPtyProcess.pid,
         'SIGKILL',
       );
+    });
+
+    it('post-promotion: PTY data is no longer routed to onOutputEvent (handoff boundary)', async () => {
+      // Pin the ownership contract: after background-promote, PTY data
+      // arriving on the still-running child must NOT surface through the
+      // foreground execute()'s onOutputEvent (the caller has its own
+      // listeners now). Without dataDisposable.dispose() in the abort
+      // handler, the listener-retention bug would let post-promote bytes
+      // leak into the foreground consumer.
+      const { result } = await simulateExecution(
+        'tail -f /tmp/never.log',
+        (pty, abortController) => {
+          // Data BEFORE promote — fed via the live onData listener so it
+          // reaches the foreground onOutputEvent normally.
+          pty.onData.mock.calls[0][0]('pre-promote-data\n');
+          abortController.abort({
+            kind: 'background',
+            shellId: 'bg_test123',
+          } satisfies ShellAbortReason);
+        },
+      );
+      expect(result.promoted).toBe(true);
+
+      // The disposable returned by mockPtyProcess.onData was disposed by
+      // the abort handler — verify by calling .dispose's mock.
+      const dataDisposableStub = mockPtyProcess.onData.mock.results[0]
+        .value as { dispose: Mock };
+      expect(dataDisposableStub.dispose).toHaveBeenCalled();
+      const exitDisposableStub = mockPtyProcess.onExit.mock.results[0]
+        .value as { dispose: Mock };
+      expect(exitDisposableStub.dispose).toHaveBeenCalled();
+    });
+
+    it('post-promotion: PTY exit does NOT re-resolve the result (already resolved with promoted)', async () => {
+      // Pin: even if the still-running child later exits naturally and the
+      // caller's own exit listener fires, our foreground result Promise
+      // must NOT be re-resolved with a different shape (Promise can only
+      // resolve once). The exit disposable being disposed prevents our
+      // own onExit from firing at all in the first place — but verify the
+      // final resolved shape stays `promoted: true` regardless.
+      const { result } = await simulateExecution(
+        'tail -f /tmp/never.log',
+        (_pty, abortController) => {
+          abortController.abort({
+            kind: 'background',
+            shellId: 'bg_test123',
+          } satisfies ShellAbortReason);
+        },
+      );
+
+      // Resolved as promoted, with no exit info from a post-promote exit.
+      expect(result.promoted).toBe(true);
+      expect(result.exitCode).toBeNull();
+      expect(result.signal).toBeNull();
     });
   });
 
@@ -1256,6 +1314,68 @@ describe('ShellExecutionService child_process fallback', () => {
       expect(mockChildProcess.kill).not.toHaveBeenCalled();
     });
 
+    it('post-promotion: stdout / stderr data is no longer routed to onOutputEvent (handoff boundary)', async () => {
+      mockPlatform.mockReturnValue('linux');
+      // Pin the ownership contract: after background-promote, stdout/stderr
+      // arriving on the still-running child must NOT surface through the
+      // foreground execute()'s onOutputEvent. Without off()'ing the
+      // stdoutHandler / stderrHandler in the abort handler, post-promote
+      // bytes would re-enter handleOutput, which then calls
+      // decoder.decode() on a now-finalized decoder (cleanup() called
+      // .decode() without stream:true) → TypeError crash, OR routes to
+      // onOutputEvent → ownership leak / duplicated emit.
+      const { result } = await simulateExecution(
+        'tail -f /tmp/never.log',
+        (cp, abortController) => {
+          cp.stdout?.emit('data', Buffer.from('pre-promote\n'));
+          abortController.abort({
+            kind: 'background',
+            shellId: 'bg_test123',
+          } satisfies ShellAbortReason);
+          // Capture call count at the moment of promote, then emit more
+          // data on the still-live child stream and assert onOutputEvent
+          // was NOT called again. (Also verifies no TypeError from
+          // decoding through the finalized decoder.)
+          const eventCountAtPromote = onOutputEventMock.mock.calls.length;
+          cp.stdout?.emit('data', Buffer.from('post-promote-stdout\n'));
+          cp.stderr?.emit('data', Buffer.from('post-promote-stderr\n'));
+          expect(onOutputEventMock.mock.calls.length).toBe(eventCountAtPromote);
+        },
+      );
+
+      expect(result.promoted).toBe(true);
+      // Pre-promote data made it into the snapshot; post-promote did not.
+      expect(result.output).toContain('pre-promote');
+      expect(result.output).not.toContain('post-promote-stdout');
+      expect(result.output).not.toContain('post-promote-stderr');
+    });
+
+    it('post-promotion: child exit does NOT re-resolve the result with a non-promoted shape', async () => {
+      mockPlatform.mockReturnValue('linux');
+      // Pin: even if the still-running child later exits naturally and the
+      // caller's own exit listener fires, our foreground result Promise
+      // must NOT be re-resolved (Promise can only resolve once). The
+      // detached exit handler prevents our own handler from firing.
+      const { result } = await simulateExecution(
+        'tail -f /tmp/never.log',
+        (cp, abortController) => {
+          abortController.abort({
+            kind: 'background',
+            shellId: 'bg_test123',
+          } satisfies ShellAbortReason);
+          // Simulate the still-running child exiting later; this should
+          // NOT route through our handleExit because the exit listener
+          // was off()'d in the background-promote branch.
+          cp.emit('exit', 42, null);
+          cp.emit('close', 42, null);
+        },
+      );
+
+      expect(result.promoted).toBe(true);
+      expect(result.exitCode).toBeNull();
+      expect(result.signal).toBeNull();
+    });
+
     it('should gracefully attempt SIGKILL on linux if SIGTERM fails', async () => {
       mockPlatform.mockReturnValue('linux');
       vi.useFakeTimers();
@@ -1452,8 +1572,12 @@ describe('ShellExecutionService execution method selection', () => {
     };
     mockPtyProcess.pid = 12345;
     mockPtyProcess.kill = vi.fn();
-    mockPtyProcess.onData = vi.fn();
-    mockPtyProcess.onExit = vi.fn();
+    // node-pty's onData/onExit return IDisposable; the production
+    // background-promote path calls .dispose() on those handles to detach
+    // its listeners cleanly. Mock them to return a disposable stub so the
+    // promote path doesn't crash on `undefined.dispose()`.
+    mockPtyProcess.onData = vi.fn().mockReturnValue({ dispose: vi.fn() });
+    mockPtyProcess.onExit = vi.fn().mockReturnValue({ dispose: vi.fn() });
     mockPtyProcess.write = vi.fn();
     mockPtyProcess.resize = vi.fn();
 

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -44,18 +44,34 @@ const PROMOTE_DRAIN_TIMEOUT_MS = 200;
  *     would force the kill path through the promote branch on any plain
  *     `abortController.abort({})`. Lifecycle/safety branches deserve the
  *     extra check.
+ *   - Wrap the property read in try/catch — an own getter or a `Proxy`
+ *     trap may throw during inspection. A throw here would propagate up
+ *     past the abort handler (which is dispatched async and not awaited
+ *     by AbortSignal), leaving the shell process alive instead of being
+ *     killed on cancel. We swallow the throw and fall back to 'cancel'.
  *   - Whitelist the value against the known union — anything else (typos,
  *     future-untyped variants) defaults to `'cancel'` so the historical
  *     kill behavior is preserved as the safe fallback.
+ *
+ * Exported for direct unit testing of all six edge cases (null /
+ * non-object / `{}` no own kind / prototype-only kind / unknown kind /
+ * throwing accessor) — the integration tests only exercise the three
+ * happy-path inputs.
  */
-function getShellAbortReasonKind(reason: unknown): ShellAbortReason['kind'] {
+export function getShellAbortReasonKind(
+  reason: unknown,
+): ShellAbortReason['kind'] {
   if (
     reason !== null &&
     typeof reason === 'object' &&
     Object.prototype.hasOwnProperty.call(reason, 'kind')
   ) {
-    const kind = (reason as { kind?: unknown }).kind;
-    if (kind === 'background' || kind === 'cancel') return kind;
+    try {
+      const kind = (reason as { kind?: unknown }).kind;
+      if (kind === 'background' || kind === 'cancel') return kind;
+    } catch {
+      // Throwing accessor / Proxy trap — fall back to safe kill below.
+    }
   }
   return 'cancel';
 }
@@ -604,6 +620,25 @@ export class ShellExecutionService {
 
         const performBackgroundPromote = (): void => {
           if (!child.pid || exited) return;
+          // Race guard: the child may have already exited but the 'exit'
+          // event hasn't reached our handler yet (Node delivers
+          // child_process events on the next microtask). Promoting in
+          // that window would detach our exit listener, leak the
+          // already-terminal exit code, and report `promoted: true` to
+          // the caller for a process that's already dead — they'd hold
+          // an inert pid expecting to take over. Check exitCode /
+          // signalCode before detaching: if either is non-null the
+          // child is gone, so leave the listeners alone and let the
+          // pending exit handler fire normally with the real exit info.
+          if (child.exitCode !== null || child.signalCode !== null) {
+            debugLogger.debug(
+              `Background-promote requested for pid ${child.pid} but child ` +
+                `is already terminal (exitCode=${child.exitCode}, ` +
+                `signalCode=${child.signalCode}); falling through to the ` +
+                `normal exit-handled resolution.`,
+            );
+            return;
+          }
           // Detach our listeners (so post-promote output doesn't leak
           // into the foreground onOutputEvent or the now-finalized text
           // decoder), drop the child from our active set (so cleanup()
@@ -688,11 +723,17 @@ export class ShellExecutionService {
               await performCancelKill();
               return;
             default: {
+              // Unreachable at runtime: getShellAbortReasonKind whitelists
+              // the return to the union members, so this branch only
+              // exists to force a TS error if the `ShellAbortReason` union
+              // ever gains a new variant — that error directs the
+              // developer to (1) extend the helper's whitelist and
+              // (2) add a `case` here. Without this exhaustiveness check
+              // the helper's whitelist and the switch could drift apart
+              // silently when the union grows.
               const _exhaustive: never = kind;
-              debugLogger.warn(
-                `Unknown ShellAbortReason kind, falling back to cancel/kill: ${String(_exhaustive)}`,
-              );
               await performCancelKill();
+              return _exhaustive;
             }
           }
         };
@@ -1171,17 +1212,42 @@ export class ShellExecutionService {
           const finalBuffer = Buffer.concat(outputChunks);
           let snapshot = '';
           try {
-            snapshot = serializeTerminalToText(headlessTerminal) ?? '';
+            // Mirror the normal exit path's snapshot logic: re-decode
+            // the full buffer with the final encoding (the streaming
+            // decoder fed `headlessTerminal` from a first-chunk
+            // heuristic, which can mis-detect when early output is
+            // ASCII-only but later output is in a different encoding,
+            // e.g. GBK). Then replay through a fresh terminal so ANSI
+            // sequences land at the right cursor position. Falling back
+            // to `serializeTerminalToText(headlessTerminal)` would risk
+            // mojibake on the promoted snapshot that the normal exit
+            // path doesn't produce.
+            if (isStreamingRawContent) {
+              const finalEncoding = getCachedEncodingForBuffer(finalBuffer);
+              const decodedOutput = new TextDecoder(finalEncoding).decode(
+                finalBuffer,
+              );
+              snapshot = await replayTerminalOutput(decodedOutput, cols, rows);
+            } else {
+              snapshot = serializeTerminalToText(headlessTerminal) ?? '';
+            }
           } catch (serErr) {
-            // Best-effort snapshot — terminal serialization may fail if
-            // the PTY is mid-render. Empty snapshot is acceptable since
-            // the caller has rawOutput, but log so the failure leaves a
-            // diagnostic trail (otherwise an empty `output` is
-            // indistinguishable from "command produced no output").
+            // Best-effort snapshot — re-decode + replay may fail (encoding
+            // detection error, terminal write throw, etc.). Empty snapshot
+            // is acceptable since the caller has rawOutput, but log so
+            // the failure leaves a diagnostic trail (otherwise an empty
+            // `output` is indistinguishable from "command produced no
+            // output"). Try the simpler direct-serialize path as a
+            // last-ditch fallback before giving up.
             debugLogger.warn(
-              `Background-promote snapshot serialization failed: ${serErr instanceof Error ? serErr.message : String(serErr)}. ` +
-                `Result.output will be empty; caller should fall back to rawOutput.`,
+              `Background-promote snapshot replay failed: ${serErr instanceof Error ? serErr.message : String(serErr)}. ` +
+                `Falling back to direct headlessTerminal serialize; if that also fails, output stays empty.`,
             );
+            try {
+              snapshot = serializeTerminalToText(headlessTerminal) ?? '';
+            } catch {
+              // Both paths failed — leave snapshot empty.
+            }
           }
           resolve({
             rawOutput: finalBuffer,
@@ -1234,11 +1300,17 @@ export class ShellExecutionService {
               await performCancelKill();
               return;
             default: {
+              // Unreachable at runtime: getShellAbortReasonKind whitelists
+              // the return to the union members, so this branch only
+              // exists to force a TS error if the `ShellAbortReason` union
+              // ever gains a new variant — that error directs the
+              // developer to (1) extend the helper's whitelist and
+              // (2) add a `case` here. Without this exhaustiveness check
+              // the helper's whitelist and the switch could drift apart
+              // silently when the union grows.
               const _exhaustive: never = kind;
-              debugLogger.warn(
-                `Unknown ShellAbortReason kind, falling back to cancel/kill: ${String(_exhaustive)}`,
-              );
               await performCancelKill();
+              return _exhaustive;
             }
           }
         };

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -21,9 +21,20 @@ import {
   type AnsiOutput,
 } from '../utils/terminalSerializer.js';
 import { normalizePathEnvForWindows } from '../utils/windowsPath.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
 const { Terminal } = pkg;
 
+const debugLogger = createDebugLogger('SHELL_EXECUTION');
+
 const SIGKILL_TIMEOUT_MS = 200;
+/**
+ * Bound on how long the background-promote drain waits for in-flight
+ * processingChain callbacks to finish writing into the headless terminal
+ * before snapshotting it. Kept separate from SIGKILL_TIMEOUT_MS so that
+ * tuning kill escalation doesn't silently change drain behavior; same
+ * 200ms default today, but the two have unrelated reasons-to-change.
+ */
+const PROMOTE_DRAIN_TIMEOUT_MS = 200;
 
 /**
  * On Windows with PowerShell, prefix the command with a statement that forces
@@ -567,54 +578,78 @@ export class ShellExecutionService {
           child.off('exit', exitHandler);
         };
 
-        const abortHandler = async () => {
-          // Background-promote takeover: skip kill, detach our listeners (so
-          // post-promote output doesn't leak into the foreground onOutputEvent
-          // or the now-finalized text decoder), drop the child from our active
-          // set (so cleanup() won't kill it later), flush our text buffers
-          // into a snapshot, and resolve immediately with `promoted: true` so
-          // the awaiting caller unblocks. The caller has attached its own
-          // listeners to the live child by this point and now owns the child.
-          const reason = abortSignal.reason as ShellAbortReason | undefined;
-          if (reason?.kind === 'background' && child.pid && !exited) {
-            this.activeChildProcesses.delete(child.pid);
-            detachServiceListeners();
-            const {
-              stdout: snapStdout,
-              stderr: snapStderr,
-              finalBuffer,
-            } = cleanup();
-            const separator = snapStdout.endsWith('\n') ? '' : '\n';
-            const combined =
-              snapStdout +
-              (snapStderr ? (snapStdout ? separator : '') + snapStderr : '');
-            resolve({
-              rawOutput: finalBuffer,
-              output: stripAnsi(combined).trim(),
-              exitCode: null,
-              signal: null,
-              error: null,
-              aborted: true,
-              promoted: true,
-              pid: child.pid,
-              executionMethod: 'child_process',
-            });
-            return;
-          }
+        const performBackgroundPromote = (): void => {
+          if (!child.pid || exited) return;
+          // Detach our listeners (so post-promote output doesn't leak
+          // into the foreground onOutputEvent or the now-finalized text
+          // decoder), drop the child from our active set (so cleanup()
+          // won't kill it later), flush our text buffers into a snapshot,
+          // and resolve immediately with `promoted: true` so the awaiting
+          // caller unblocks. The caller has attached its own listeners
+          // by this point and now owns the child.
+          this.activeChildProcesses.delete(child.pid);
+          detachServiceListeners();
+          const {
+            stdout: snapStdout,
+            stderr: snapStderr,
+            finalBuffer,
+          } = cleanup();
+          const separator = snapStdout.endsWith('\n') ? '' : '\n';
+          const combined =
+            snapStdout +
+            (snapStderr ? (snapStdout ? separator : '') + snapStderr : '');
+          resolve({
+            rawOutput: finalBuffer,
+            output: stripAnsi(combined).trim(),
+            exitCode: null,
+            signal: null,
+            error: null,
+            aborted: true,
+            promoted: true,
+            pid: child.pid,
+            executionMethod: 'child_process',
+          });
+        };
 
-          if (child.pid && !exited) {
-            if (isWindows) {
-              cpSpawn('taskkill', ['/pid', child.pid.toString(), '/f', '/t']);
-            } else {
-              try {
-                process.kill(-child.pid, 'SIGTERM');
-                await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
-                if (!exited) {
-                  process.kill(-child.pid, 'SIGKILL');
-                }
-              } catch (_e) {
-                if (!exited) child.kill('SIGKILL');
+        const performCancelKill = async (): Promise<void> => {
+          if (!child.pid || exited) return;
+          if (isWindows) {
+            cpSpawn('taskkill', ['/pid', child.pid.toString(), '/f', '/t']);
+          } else {
+            try {
+              process.kill(-child.pid, 'SIGTERM');
+              await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
+              if (!exited) {
+                process.kill(-child.pid, 'SIGKILL');
               }
+            } catch (_e) {
+              if (!exited) child.kill('SIGKILL');
+            }
+          }
+        };
+
+        const abortHandler = async () => {
+          // Default reason (none set) is treated as cancel — historical
+          // behavior. Switch on `kind` so any future ShellAbortReason
+          // variant fails the type-check at the `never` default rather
+          // than silently falling through to the kill path. (Earlier
+          // if-else form would have silently killed the process for
+          // e.g. a future `{ kind: 'suspend' }` — review feedback.)
+          const reason = abortSignal.reason as ShellAbortReason | undefined;
+          const kind: ShellAbortReason['kind'] = reason?.kind ?? 'cancel';
+          switch (kind) {
+            case 'background':
+              performBackgroundPromote();
+              return;
+            case 'cancel':
+              await performCancelKill();
+              return;
+            default: {
+              const _exhaustive: never = kind;
+              debugLogger.warn(
+                `Unknown ShellAbortReason kind, falling back to cancel/kill: ${String(_exhaustive)}`,
+              );
+              await performCancelKill();
             }
           }
         };
@@ -1000,89 +1035,162 @@ export class ShellExecutionService {
           },
         );
 
-        const abortHandler = async () => {
-          // Background-promote takeover: skip kill, dispose all our
-          // listeners on the live PTY (so post-promote data/exit/error don't
-          // leak into our foreground onOutputEvent or crash via the error
-          // handler's `throw err`), set the listenersDetached guard so any
-          // already-enqueued processingChain callback's onOutputEvent emits
-          // are suppressed (in-flight writes still LAND in headlessTerminal
-          // so the snapshot below reflects them), drain pending chain work,
-          // drop the PTY from the active set (so cleanup() won't kill it
-          // later), serialize the terminal as the snapshot, and resolve
-          // immediately with `promoted: true` so the awaiting caller
-          // unblocks. The caller has attached its own listeners to the live
-          // PTY by this point and owns its lifecycle from here on.
-          const reason = abortSignal.reason as ShellAbortReason | undefined;
-          if (reason?.kind === 'background' && ptyProcess.pid && !exited) {
-            exited = true;
-            listenersDetached = true;
-            abortSignal.removeEventListener('abort', abortHandler);
+        const performBackgroundPromote = async (): Promise<void> => {
+          if (!ptyProcess.pid || exited) return;
+          // Skip kill, dispose all our listeners on the live PTY (so
+          // post-promote data/exit/error don't leak into our foreground
+          // onOutputEvent or crash via the error handler's `throw err`),
+          // set the listenersDetached guard so any already-enqueued
+          // processingChain callback's onOutputEvent emits are
+          // suppressed (in-flight writes still LAND in headlessTerminal
+          // so the snapshot below reflects them), drain pending chain
+          // work, drop the PTY from the active set (so cleanup() won't
+          // kill it later), serialize the terminal as the snapshot, and
+          // resolve immediately with `promoted: true` so the awaiting
+          // caller unblocks. The caller has attached its own listeners
+          // by this point and owns the PTY's lifecycle.
+          exited = true;
+          listenersDetached = true;
+          abortSignal.removeEventListener('abort', abortHandler);
+          // Each dispose() in its own try/catch — node-pty's IDisposable
+          // contract doesn't guarantee no-throw, and we must run all
+          // teardown steps even if one throws (otherwise activePtys.delete
+          // / drain / resolve could be skipped and the caller would hang).
+          try {
             dataDisposable.dispose();
+          } catch (e) {
+            debugLogger.warn(
+              `dataDisposable.dispose() threw during background-promote: ${e instanceof Error ? e.message : String(e)}`,
+            );
+          }
+          try {
             exitDisposable.dispose();
+          } catch (e) {
+            debugLogger.warn(
+              `exitDisposable.dispose() threw during background-promote: ${e instanceof Error ? e.message : String(e)}`,
+            );
+          }
+          try {
             ptyProcess.off('error', ptyErrorHandler);
-            if (renderTimeout) {
-              clearTimeout(renderTimeout);
-              renderTimeout = null;
-            }
-            this.activePtys.delete(ptyProcess.pid);
+          } catch (e) {
+            debugLogger.warn(
+              `ptyProcess.off('error') threw during background-promote: ${e instanceof Error ? e.message : String(e)}`,
+            );
+          }
+          if (renderTimeout) {
+            clearTimeout(renderTimeout);
+            renderTimeout = null;
+          }
+          this.activePtys.delete(ptyProcess.pid);
 
-            // Drain in-flight chain work (already-enqueued
-            // headlessTerminal.write callbacks) so the snapshot reflects
-            // the last batch of bytes the PTY emitted before promote.
-            // Bounded by SIGKILL_TIMEOUT_MS so the caller's await never
-            // blocks indefinitely if a write callback is stuck.
-            const drain = () =>
-              new Promise<void>((res) => setImmediate(res)).then(
-                () => processingChain,
-              );
-            await Promise.race([
-              processingChain.then(drain).then(drain),
-              new Promise<void>((res) => setTimeout(res, SIGKILL_TIMEOUT_MS)),
-            ]);
-
-            const finalBuffer = Buffer.concat(outputChunks);
-            let snapshot = '';
-            try {
-              snapshot = serializeTerminalToText(headlessTerminal) ?? '';
-            } catch {
-              // Best-effort snapshot — terminal serialization may fail if the
-              // PTY is mid-render; an empty snapshot is acceptable since the
-              // caller already has the rawOutput buffer below.
-            }
-            resolve({
-              rawOutput: finalBuffer,
-              output: snapshot,
-              exitCode: null,
-              signal: null,
-              error,
-              aborted: true,
-              promoted: true,
-              pid: ptyProcess.pid,
-              executionMethod:
-                (ptyInfo?.name as 'node-pty' | 'lydell-node-pty') ?? 'node-pty',
-            });
-            return;
+          // Drain in-flight chain work (already-enqueued
+          // headlessTerminal.write callbacks) so the snapshot reflects
+          // the last batch of bytes the PTY emitted before promote.
+          // Bounded by PROMOTE_DRAIN_TIMEOUT_MS so the caller's await
+          // never blocks indefinitely if a write callback is stuck.
+          // The drain side may reject (a prior chain item threw); swallow
+          // via .catch — abort handlers run via addEventListener which
+          // doesn't await our return, so a leaked rejection here would
+          // become unhandled and the caller would hang waiting on resolve.
+          // Race result is observed (not just discarded) so we can warn
+          // when the timeout side won — without that the snapshot may be
+          // truncated with no diagnostic trail.
+          const TIMEOUT_SENTINEL = Symbol('drain-timeout');
+          const drain = () =>
+            new Promise<void>((res) => setImmediate(res)).then(
+              () => processingChain,
+            );
+          const winner = await Promise.race<unknown>([
+            processingChain
+              .then(drain)
+              .then(drain)
+              .catch(() => undefined),
+            new Promise<symbol>((res) =>
+              setTimeout(() => res(TIMEOUT_SENTINEL), PROMOTE_DRAIN_TIMEOUT_MS),
+            ),
+          ]);
+          if (winner === TIMEOUT_SENTINEL) {
+            debugLogger.warn(
+              `Background-promote drain hit the ${PROMOTE_DRAIN_TIMEOUT_MS}ms ` +
+                `timeout before processingChain settled. The output snapshot ` +
+                `may be missing the very last batch of bytes the PTY emitted ` +
+                `before promote (rawOutput in the result still has the full ` +
+                `buffer the caller can re-render).`,
+            );
           }
 
-          if (ptyProcess.pid && !exited) {
-            if (os.platform() === 'win32') {
-              ptyProcess.kill();
-            } else {
-              try {
-                // Send SIGTERM first to allow graceful shutdown
-                process.kill(-ptyProcess.pid, 'SIGTERM');
-                await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
-                if (!exited) {
-                  // Escalate to SIGKILL if still running
-                  process.kill(-ptyProcess.pid, 'SIGKILL');
-                }
-              } catch (_e) {
-                // Fallback to killing just the process if the group kill fails
-                if (!exited) {
-                  ptyProcess.kill();
-                }
+          const finalBuffer = Buffer.concat(outputChunks);
+          let snapshot = '';
+          try {
+            snapshot = serializeTerminalToText(headlessTerminal) ?? '';
+          } catch (serErr) {
+            // Best-effort snapshot — terminal serialization may fail if
+            // the PTY is mid-render. Empty snapshot is acceptable since
+            // the caller has rawOutput, but log so the failure leaves a
+            // diagnostic trail (otherwise an empty `output` is
+            // indistinguishable from "command produced no output").
+            debugLogger.warn(
+              `Background-promote snapshot serialization failed: ${serErr instanceof Error ? serErr.message : String(serErr)}. ` +
+                `Result.output will be empty; caller should fall back to rawOutput.`,
+            );
+          }
+          resolve({
+            rawOutput: finalBuffer,
+            output: snapshot,
+            exitCode: null,
+            signal: null,
+            error,
+            aborted: true,
+            promoted: true,
+            pid: ptyProcess.pid,
+            executionMethod:
+              (ptyInfo?.name as 'node-pty' | 'lydell-node-pty') ?? 'node-pty',
+          });
+        };
+
+        const performCancelKill = async (): Promise<void> => {
+          if (!ptyProcess.pid || exited) return;
+          if (os.platform() === 'win32') {
+            ptyProcess.kill();
+          } else {
+            try {
+              // Send SIGTERM first to allow graceful shutdown
+              process.kill(-ptyProcess.pid, 'SIGTERM');
+              await new Promise((res) => setTimeout(res, SIGKILL_TIMEOUT_MS));
+              if (!exited) {
+                // Escalate to SIGKILL if still running
+                process.kill(-ptyProcess.pid, 'SIGKILL');
               }
+            } catch (_e) {
+              // Fallback to killing just the process if the group kill fails
+              if (!exited) {
+                ptyProcess.kill();
+              }
+            }
+          }
+        };
+
+        const abortHandler = async () => {
+          // Switch on the discriminated `kind` so any future
+          // ShellAbortReason variant fails the type-check at the
+          // `never` default rather than silently falling through to the
+          // kill path (review feedback — earlier if-else form would have
+          // silently killed for e.g. a future `{ kind: 'suspend' }`).
+          const reason = abortSignal.reason as ShellAbortReason | undefined;
+          const kind: ShellAbortReason['kind'] = reason?.kind ?? 'cancel';
+          switch (kind) {
+            case 'background':
+              await performBackgroundPromote();
+              return;
+            case 'cancel':
+              await performCancelKill();
+              return;
+            default: {
+              const _exhaustive: never = kind;
+              debugLogger.warn(
+                `Unknown ShellAbortReason kind, falling back to cancel/kill: ${String(_exhaustive)}`,
+              );
+              await performCancelKill();
             }
           }
         };

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -1121,6 +1121,24 @@ export class ShellExecutionService {
 
         const performBackgroundPromote = async (): Promise<void> => {
           if (!ptyProcess.pid || exited) return;
+          // Race guard mirroring the child_process path: the PTY may
+          // have already exited but `exitDisposable` (our onExit
+          // handler) has not yet run — node-pty delivers the exit
+          // event asynchronously after the PTY's native SIGCHLD. The
+          // IPty interface doesn't expose an `exitCode` field we can
+          // read directly, so use `process.kill(pid, 0)` as a
+          // best-effort liveness check (it throws ESRCH if the pid
+          // is gone, EPERM if it's not ours / not reusable). If the
+          // PTY is gone, fall through and let the pending onExit
+          // callback resolve normally with the real exit status.
+          if (!ShellExecutionService.isPtyActive(ptyProcess.pid)) {
+            debugLogger.debug(
+              `Background-promote requested for PTY pid ${ptyProcess.pid} ` +
+                `but the process is no longer alive (process.kill(pid, 0) ` +
+                `failed); falling through to normal exit-handled resolution.`,
+            );
+            return;
+          }
           // Skip kill, dispose all our listeners on the live PTY (so
           // post-promote data/exit/error don't leak into our foreground
           // onOutputEvent or crash via the error handler's `throw err`),

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -37,6 +37,23 @@ function applyPowerShellUtf8Prefix(command: string, shell: string): string {
   return command;
 }
 
+/**
+ * Discriminated reason attached to the AbortSignal that drives execute().
+ * Default behavior (no reason set, or `{ kind: 'cancel' }`) is the historical
+ * tree-kill on abort. `{ kind: 'background' }` is a takeover signal: the
+ * caller has accepted ownership of the child process and wants execute() to
+ * relinquish it without killing — used by the foreground-shell → background
+ * promote path so the in-flight child keeps running.
+ *
+ * Callers MUST attach their own listeners (data / exit / error) to the live
+ * child *before* calling `abortController.abort({ kind: 'background', ... })`,
+ * since execute() drops the child from its active set on background-abort and
+ * will no longer route events to its own handlers' downstream consumers.
+ */
+export type ShellAbortReason =
+  | { kind: 'cancel' }
+  | { kind: 'background'; shellId?: string };
+
 /** A structured result from a shell command execution. */
 export interface ShellExecutionResult {
   /** The raw, unprocessed output buffer. */
@@ -51,6 +68,14 @@ export interface ShellExecutionResult {
   error: Error | null;
   /** A boolean indicating if the command was aborted by the user. */
   aborted: boolean;
+  /**
+   * True iff execute() returned because of a background-promote abort
+   * (`signal.reason.kind === 'background'`) — the child process is still
+   * alive and the caller has taken over its lifecycle. Callers receiving
+   * `promoted: true` must NOT treat exitCode/signal as terminal — the
+   * underlying process has not exited.
+   */
+  promoted?: boolean;
   /** The process ID of the spawned shell. */
   pid: number | undefined;
   /** The method used to execute the shell command. */
@@ -518,6 +543,37 @@ export class ShellExecutionService {
         });
 
         const abortHandler = async () => {
+          // Background-promote takeover: skip kill, drop the child from our
+          // active set (so cleanup() won't kill it later), flush our text
+          // buffers into a snapshot, and resolve immediately with
+          // `promoted: true` so the awaiting caller unblocks. The caller has
+          // attached its own listeners to the live child by this point.
+          const reason = abortSignal.reason as ShellAbortReason | undefined;
+          if (reason?.kind === 'background' && child.pid && !exited) {
+            this.activeChildProcesses.delete(child.pid);
+            const {
+              stdout: snapStdout,
+              stderr: snapStderr,
+              finalBuffer,
+            } = cleanup();
+            const separator = snapStdout.endsWith('\n') ? '' : '\n';
+            const combined =
+              snapStdout +
+              (snapStderr ? (snapStdout ? separator : '') + snapStderr : '');
+            resolve({
+              rawOutput: finalBuffer,
+              output: stripAnsi(combined).trim(),
+              exitCode: null,
+              signal: null,
+              error: null,
+              aborted: true,
+              promoted: true,
+              pid: child.pid,
+              executionMethod: 'child_process',
+            });
+            return;
+          }
+
           if (child.pid && !exited) {
             if (isWindows) {
               cpSpawn('taskkill', ['/pid', child.pid.toString(), '/f', '/t']);
@@ -898,6 +954,41 @@ export class ShellExecutionService {
         );
 
         const abortHandler = async () => {
+          // Background-promote takeover: skip kill, drop the PTY from the
+          // active set (so cleanup() won't kill it later), flush a snapshot
+          // of the output buffer captured so far, and resolve immediately
+          // with `promoted: true` so the awaiting caller unblocks. The
+          // caller has attached its own listeners to the live PTY by this
+          // point and owns its lifecycle from here on.
+          const reason = abortSignal.reason as ShellAbortReason | undefined;
+          if (reason?.kind === 'background' && ptyProcess.pid && !exited) {
+            exited = true;
+            abortSignal.removeEventListener('abort', abortHandler);
+            this.activePtys.delete(ptyProcess.pid);
+            const finalBuffer = Buffer.concat(outputChunks);
+            let snapshot = '';
+            try {
+              snapshot = serializeTerminalToText(headlessTerminal) ?? '';
+            } catch {
+              // Best-effort snapshot — terminal serialization may fail if the
+              // PTY is mid-render; an empty snapshot is acceptable since the
+              // caller already has the rawOutput buffer below.
+            }
+            resolve({
+              rawOutput: finalBuffer,
+              output: snapshot,
+              exitCode: null,
+              signal: null,
+              error,
+              aborted: true,
+              promoted: true,
+              pid: ptyProcess.pid,
+              executionMethod:
+                (ptyInfo?.name as 'node-pty' | 'lydell-node-pty') ?? 'node-pty',
+            });
+            return;
+          }
+
           if (ptyProcess.pid && !exited) {
             if (os.platform() === 'win32') {
               ptyProcess.kill();

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -53,10 +53,11 @@ const PROMOTE_DRAIN_TIMEOUT_MS = 200;
  *     future-untyped variants) defaults to `'cancel'` so the historical
  *     kill behavior is preserved as the safe fallback.
  *
- * Exported for direct unit testing of all six edge cases (null /
- * non-object / `{}` no own kind / prototype-only kind / unknown kind /
- * throwing accessor) — the integration tests only exercise the three
- * happy-path inputs.
+ * Exported for direct unit testing of all eight cases (null /
+ * undefined / non-object / `{}` no own kind / prototype-only kind /
+ * unknown kind / throwing-accessor / Proxy trap, plus the two
+ * happy-path inputs) — the integration tests only exercise the three
+ * happy-path scenarios.
  */
 export function getShellAbortReasonKind(
   reason: unknown,

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -37,6 +37,30 @@ const SIGKILL_TIMEOUT_MS = 200;
 const PROMOTE_DRAIN_TIMEOUT_MS = 200;
 
 /**
+ * Read the `kind` discriminator off `abortSignal.reason` defensively:
+ *   - Reject non-object reasons (DOMException, strings, numbers).
+ *   - Read the `kind` property as an OWN property only — without
+ *     `hasOwnProperty`, a polluted `Object.prototype.kind = 'background'`
+ *     would force the kill path through the promote branch on any plain
+ *     `abortController.abort({})`. Lifecycle/safety branches deserve the
+ *     extra check.
+ *   - Whitelist the value against the known union — anything else (typos,
+ *     future-untyped variants) defaults to `'cancel'` so the historical
+ *     kill behavior is preserved as the safe fallback.
+ */
+function getShellAbortReasonKind(reason: unknown): ShellAbortReason['kind'] {
+  if (
+    reason !== null &&
+    typeof reason === 'object' &&
+    Object.prototype.hasOwnProperty.call(reason, 'kind')
+  ) {
+    const kind = (reason as { kind?: unknown }).kind;
+    if (kind === 'background' || kind === 'cancel') return kind;
+  }
+  return 'cancel';
+}
+
+/**
  * On Windows with PowerShell, prefix the command with a statement that forces
  * UTF-8 output encoding so that CJK and other non-ASCII characters are emitted
  * as UTF-8 regardless of the system codepage.
@@ -587,6 +611,26 @@ export class ShellExecutionService {
           // and resolve immediately with `promoted: true` so the awaiting
           // caller unblocks. The caller has attached its own listeners
           // by this point and now owns the child.
+          //
+          // INVARIANT: this snapshot path reads from `stdout` / `stderr`
+          // string accumulators (populated by handleOutput's buffered-text
+          // branch). Under `streamStdout: true`, output is forwarded
+          // through `onOutputEvent` and NOT accumulated into stdout/stderr,
+          // so the promoted snapshot would be silently empty. PR-1's only
+          // caller (foreground shell.ts) uses streamStdout: false, so
+          // there's no live combination today; if a future caller pairs
+          // `streamStdout: true` with `{ kind: 'background' }`, log so the
+          // empty-snapshot is observable rather than mysterious. The
+          // caller still has rawOutput as a fallback.
+          if (streamStdout) {
+            debugLogger.warn(
+              'Background-promote on a streamStdout=true child_process: ' +
+                'snapshot accumulators were never populated (output went ' +
+                'through onOutputEvent), so result.output will be empty. ' +
+                'Caller should fall back to rawOutput, or assemble its ' +
+                'own snapshot from the data events it received.',
+            );
+          }
           this.activeChildProcesses.delete(child.pid);
           detachServiceListeners();
           const {
@@ -635,8 +679,7 @@ export class ShellExecutionService {
           // than silently falling through to the kill path. (Earlier
           // if-else form would have silently killed the process for
           // e.g. a future `{ kind: 'suspend' }` — review feedback.)
-          const reason = abortSignal.reason as ShellAbortReason | undefined;
-          const kind: ShellAbortReason['kind'] = reason?.kind ?? 'cancel';
+          const kind = getShellAbortReasonKind(abortSignal.reason);
           switch (kind) {
             case 'background':
               performBackgroundPromote();
@@ -1071,10 +1114,16 @@ export class ShellExecutionService {
             );
           }
           try {
-            ptyProcess.off('error', ptyErrorHandler);
+            // @lydell/node-pty's IPty exposes `removeListener` (Node's
+            // EventEmitter API), not the modern `off` alias. Calling
+            // `off` here used to throw TypeError at runtime — caught
+            // and logged but the handler stayed registered, so a
+            // post-promote PTY error would still run our foreground
+            // handler's `throw err` and break the handoff contract.
+            ptyProcess.removeListener('error', ptyErrorHandler);
           } catch (e) {
             debugLogger.warn(
-              `ptyProcess.off('error') threw during background-promote: ${e instanceof Error ? e.message : String(e)}`,
+              `ptyProcess.removeListener('error') threw during background-promote: ${e instanceof Error ? e.message : String(e)}`,
             );
           }
           if (renderTimeout) {
@@ -1176,8 +1225,7 @@ export class ShellExecutionService {
           // `never` default rather than silently falling through to the
           // kill path (review feedback — earlier if-else form would have
           // silently killed for e.g. a future `{ kind: 'suspend' }`).
-          const reason = abortSignal.reason as ShellAbortReason | undefined;
-          const kind: ShellAbortReason['kind'] = reason?.kind ?? 'cancel';
+          const kind = getShellAbortReasonKind(abortSignal.reason);
           switch (kind) {
             case 'background':
               await performBackgroundPromote();

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -535,22 +535,50 @@ export class ShellExecutionService {
           });
         };
 
-        child.stdout.on('data', (data) => handleOutput(data, 'stdout'));
-        child.stderr.on('data', (data) => handleOutput(data, 'stderr'));
-        child.on('error', (err) => {
+        // Named handler refs so the background-promote branch below can
+        // detach them all and hand ownership of the child cleanly to the
+        // caller. Anonymous arrows here would leak: the still-running child
+        // would keep firing into our handlers (using a finalized decoder →
+        // TypeError, or duplicating events the caller now also receives).
+        const stdoutHandler = (data: Buffer) => handleOutput(data, 'stdout');
+        const stderrHandler = (data: Buffer) => handleOutput(data, 'stderr');
+        const errorHandler = (err: Error) => {
           error = err;
           handleExit(1, null);
-        });
+        };
+        const exitHandler = (
+          code: number | null,
+          signal: NodeJS.Signals | null,
+        ) => {
+          if (child.pid) {
+            this.activeChildProcesses.delete(child.pid);
+          }
+          handleExit(code, signal);
+        };
+
+        child.stdout.on('data', stdoutHandler);
+        child.stderr.on('data', stderrHandler);
+        child.on('error', errorHandler);
+
+        const detachServiceListeners = () => {
+          child.stdout?.off('data', stdoutHandler);
+          child.stderr?.off('data', stderrHandler);
+          child.off('error', errorHandler);
+          child.off('exit', exitHandler);
+        };
 
         const abortHandler = async () => {
-          // Background-promote takeover: skip kill, drop the child from our
-          // active set (so cleanup() won't kill it later), flush our text
-          // buffers into a snapshot, and resolve immediately with
-          // `promoted: true` so the awaiting caller unblocks. The caller has
-          // attached its own listeners to the live child by this point.
+          // Background-promote takeover: skip kill, detach our listeners (so
+          // post-promote output doesn't leak into the foreground onOutputEvent
+          // or the now-finalized text decoder), drop the child from our active
+          // set (so cleanup() won't kill it later), flush our text buffers
+          // into a snapshot, and resolve immediately with `promoted: true` so
+          // the awaiting caller unblocks. The caller has attached its own
+          // listeners to the live child by this point and now owns the child.
           const reason = abortSignal.reason as ShellAbortReason | undefined;
           if (reason?.kind === 'background' && child.pid && !exited) {
             this.activeChildProcesses.delete(child.pid);
+            detachServiceListeners();
             const {
               stdout: snapStdout,
               stderr: snapStderr,
@@ -597,12 +625,7 @@ export class ShellExecutionService {
           this.activeChildProcesses.add(child.pid);
         }
 
-        child.on('exit', (code, signal) => {
-          if (child.pid) {
-            this.activeChildProcesses.delete(child.pid);
-          }
-          handleExit(code, signal);
-        });
+        child.on('exit', exitHandler);
 
         function cleanup() {
           exited = true;
@@ -717,11 +740,18 @@ export class ShellExecutionService {
         let isWriting = false;
         let hasStartedOutput = false;
         let renderTimeout: NodeJS.Timeout | null = null;
+        // Set to true by the background-promote branch so any in-flight
+        // processingChain callback or pending render short-circuits instead
+        // of emitting onOutputEvent / writing to the (now caller-owned)
+        // headlessTerminal. The PTY data disposable is also disposed in the
+        // same branch so no NEW work is enqueued — this guard handles the
+        // already-scheduled chain items.
+        let listenersDetached = false;
 
         const RENDER_THROTTLE_MS = 100;
 
         const renderFn = () => {
-          if (!isStreamingRawContent) {
+          if (!isStreamingRawContent || listenersDetached) {
             return;
           }
 
@@ -842,30 +872,46 @@ export class ShellExecutionService {
 
                   if (isBinary(sniffBuffer)) {
                     isStreamingRawContent = false;
-                    onOutputEvent({ type: 'binary_detected' });
+                    if (!listenersDetached) {
+                      onOutputEvent({ type: 'binary_detected' });
+                    }
                   }
                 }
 
                 if (isStreamingRawContent) {
                   const decodedChunk = decoder!.decode(data, { stream: true });
                   isWriting = true;
+                  // Allow in-flight writes to LAND in the headlessTerminal
+                  // even after a background promote — the snapshot we'll
+                  // serialize next reads from this buffer. The render()
+                  // callback (and renderFn) is already guarded by
+                  // listenersDetached, so no onOutputEvent fires.
                   headlessTerminal.write(decodedChunk, () => {
                     render();
                     isWriting = false;
                     resolve();
                   });
                 } else {
-                  onOutputEvent({
-                    type: 'binary_progress',
-                    bytesReceived,
-                  });
+                  if (!listenersDetached) {
+                    onOutputEvent({
+                      type: 'binary_progress',
+                      bytesReceived,
+                    });
+                  }
                   resolve();
                 }
               }),
           );
         };
 
-        ptyProcess.onData((data: string) => {
+        // Capture the IDisposables that node-pty returns so the
+        // background-promote branch below can hand the live PTY to the
+        // caller cleanly. Without dispose(), post-promote PTY data would
+        // continue calling our handleOutput → render → onOutputEvent (the
+        // foreground caller's downstream consumer that no longer owns this
+        // child) and post-promote PTY errors would `throw err` → process
+        // crash.
+        const dataDisposable = ptyProcess.onData((data: string) => {
           const bufferData = Buffer.from(data, 'utf-8');
           handleOutput(bufferData);
         });
@@ -874,7 +920,7 @@ export class ShellExecutionService {
         // due to race conditions between the exit event and read operations.
         // This is a normal behavior on macOS/Linux and should not crash the app.
         // See: https://github.com/microsoft/node-pty/issues/178
-        ptyProcess.on('error', (err: NodeJS.ErrnoException) => {
+        const ptyErrorHandler = (err: NodeJS.ErrnoException) => {
           if (isExpectedPtyReadExitError(err)) {
             // EIO is expected when the PTY process exits - ignore it
             return;
@@ -882,9 +928,10 @@ export class ShellExecutionService {
 
           // Surface unexpected PTY errors to preserve existing crash behavior.
           throw err;
-        });
+        };
+        ptyProcess.on('error', ptyErrorHandler);
 
-        ptyProcess.onExit(
+        const exitDisposable = ptyProcess.onExit(
           ({ exitCode, signal }: { exitCode: number; signal?: number }) => {
             exited = true;
             abortSignal.removeEventListener('abort', abortHandler);
@@ -954,17 +1001,46 @@ export class ShellExecutionService {
         );
 
         const abortHandler = async () => {
-          // Background-promote takeover: skip kill, drop the PTY from the
-          // active set (so cleanup() won't kill it later), flush a snapshot
-          // of the output buffer captured so far, and resolve immediately
-          // with `promoted: true` so the awaiting caller unblocks. The
-          // caller has attached its own listeners to the live PTY by this
-          // point and owns its lifecycle from here on.
+          // Background-promote takeover: skip kill, dispose all our
+          // listeners on the live PTY (so post-promote data/exit/error don't
+          // leak into our foreground onOutputEvent or crash via the error
+          // handler's `throw err`), set the listenersDetached guard so any
+          // already-enqueued processingChain callback's onOutputEvent emits
+          // are suppressed (in-flight writes still LAND in headlessTerminal
+          // so the snapshot below reflects them), drain pending chain work,
+          // drop the PTY from the active set (so cleanup() won't kill it
+          // later), serialize the terminal as the snapshot, and resolve
+          // immediately with `promoted: true` so the awaiting caller
+          // unblocks. The caller has attached its own listeners to the live
+          // PTY by this point and owns its lifecycle from here on.
           const reason = abortSignal.reason as ShellAbortReason | undefined;
           if (reason?.kind === 'background' && ptyProcess.pid && !exited) {
             exited = true;
+            listenersDetached = true;
             abortSignal.removeEventListener('abort', abortHandler);
+            dataDisposable.dispose();
+            exitDisposable.dispose();
+            ptyProcess.off('error', ptyErrorHandler);
+            if (renderTimeout) {
+              clearTimeout(renderTimeout);
+              renderTimeout = null;
+            }
             this.activePtys.delete(ptyProcess.pid);
+
+            // Drain in-flight chain work (already-enqueued
+            // headlessTerminal.write callbacks) so the snapshot reflects
+            // the last batch of bytes the PTY emitted before promote.
+            // Bounded by SIGKILL_TIMEOUT_MS so the caller's await never
+            // blocks indefinitely if a write callback is stuck.
+            const drain = () =>
+              new Promise<void>((res) => setImmediate(res)).then(
+                () => processingChain,
+              );
+            await Promise.race([
+              processingChain.then(drain).then(drain),
+              new Promise<void>((res) => setTimeout(res, SIGKILL_TIMEOUT_MS)),
+            ]);
+
             const finalBuffer = Buffer.concat(outputChunks);
             let snapshot = '';
             try {

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -69,6 +69,16 @@ export function getShellAbortReasonKind(
   ) {
     try {
       const kind = (reason as { kind?: unknown }).kind;
+      // INVARIANT — three points must be kept in sync when extending
+      // `ShellAbortReason`:
+      //   (1) the discriminated union below (`type ShellAbortReason`),
+      //   (2) the value-equality whitelist on this line, and
+      //   (3) the `case` arms in both abort-handler switches (the
+      //       `default: { const _exhaustive: never = kind; ... }`
+      //       statically forces #3 when #1 grows, but #2 has no
+      //       compile-time tie to the union; if you forget to extend
+      //       it the new variant silently degrades to 'cancel' here
+      //       and the `case` you added in #3 is never reached).
       if (kind === 'background' || kind === 'cancel') return kind;
     } catch {
       // Throwing accessor / Proxy trap — fall back to safe kill below.


### PR DESCRIPTION
## Summary

**PR-1 of 3** implementing Phase D part (b) of #3831 — Ctrl+B promote of a running foreground shell to background. **Pure plumbing, zero behavior change** for existing callers (no caller sets the new reason yet).

Defines a discriminated `ShellAbortReason` union that an `AbortController.abort(reason)` can carry into `ShellExecutionService.execute()`:

```ts
export type ShellAbortReason =
  | { kind: 'cancel' }
  | { kind: 'background'; shellId?: string };
```

- **Default** (no reason set, or `{ kind: 'cancel' }`) → unchanged tree-kill on abort.
- **`{ kind: 'background' }`** → takeover signal: `execute()` skips the kill, drops the child from its active set (so `ShellExecutionService.cleanup()` won't kill it later either), flushes a snapshot of captured output into the result, and resolves the result Promise immediately with `promoted: true` so the awaiting caller unblocks. The caller has accepted ownership of the live child.

`ShellExecutionResult` gains an optional `promoted?: boolean` field; existing consumers compile against the new shape without source changes.

> **Review status**: **22 review threads across 5 review rounds, all resolved**. Round 1 (commit `8e8e18ca7`, 6 threads — 4 Critical + 2 Suggestion): introduced dispose-based listener detach (named handler refs for child_process; `node-pty` IDisposable for PTY's `onData`/`onExit`; named ref + `off()` for `ptyProcess.on('error')`). Round 2 (`9008717b8`, 6 threads): defensive hardening — exhaustive-switch on `ShellAbortReason.kind`, per-dispose try/catch, `.catch(() => undefined)` on the drain race so a chain rejection doesn't leak unhandled, dedicated `PROMOTE_DRAIN_TIMEOUT_MS` constant separated from `SIGKILL_TIMEOUT_MS`, drain timeout sentinel + warn, snapshot serialize warn. Round 3 (`094fff09c`, 3 threads): **real bug** — `ptyProcess.off('error', …)` throws TypeError on real `@lydell/node-pty` (only `removeListener` is exposed), switched + regression-guarded; prototype-pollution-safe own-property `kind` read. Round 4 (`4cc558b3d`, 6 threads — 1 Critical + 5): throw-safe abort-reason read (own getters / Proxy traps wrapped in try/catch), child_process post-exit liveness check, encoding-aware PTY snapshot via re-decode + replay, removed unreachable `default`-warn (kept `_exhaustive: never` for compile-time safety only), 8 helper boundary tests. Round 5 (`289feaa74`, 1 Critical): mirrored child_process race guard into PTY via `process.kill(pid, 0)` liveness probe. Implementation notes below describe the final ownership model.

## Why this PR alone

Full sequence per #3831:
- **PR-1 (this) — ~210 LOC** — `signal.reason` foundation + reason-aware abort handling. Zero behavior change.
- PR-2 (~280 LOC) — `shell.ts` integration: lazy promote, `BackgroundShellRegistry.promoteFromForeground(...)`, output buffer flush + stream redirect.
- PR-3 (~120 LOC) — `Command.PROMOTE_TO_BACKGROUND` keybinding (Ctrl+B), AppContainer wire-up, E2E tests.

#3831's design discussion is open. Pushing PR-1 because the foundation has zero user-visible behavior change and is independently mergeable / revertable — surfacing the contract in code form alongside the issue. Reviewer can sanity-check the abort-handler shape independently from the lazy-promote semantics in PR-2.

## Caller contract

Callers wishing to promote MUST attach their own listeners (`data` / `exit` / `error`) to the live child **before** calling `abortController.abort({ kind: 'background', ... })`. After the background-abort, `execute()` no longer routes events through its own handlers' downstream consumers. The caller seeing `result.promoted === true` knows ownership has been transferred — it must NOT treat `result.exitCode` / `result.signal` as terminal (the underlying process has not exited).

## Design rationale (why `signal.reason`, not a new parameter)

Three alternatives were considered (full discussion in #3831):

1. **New `execute()` parameter** like `onPromoteRequest` callback or `promotionMode` flag — adds an always-present API surface for a rare path; couples the takeover lifecycle into the call signature; harder to extend later (would need a 2nd parameter for shellId, etc.).
2. **Pre-allocate hidden `BackgroundShellEntry`** for every foreground spawn, then flip `visible: true` on Ctrl+B — touches `ShellExecutionService` heavily (output stream conditionally file-vs-memory throughout) for a feature that fires <1% of the time. Wasteful in the common case.
3. **`signal.reason` as takeover channel (this PR)** — reuses existing `AbortController` plumbing every caller already has; the discrimination is a 5-line addition to the existing abort handler; zero overhead in the common case (no Ctrl+B → no promote logic runs); leverages Node's native `AbortSignal.reason` (Node 17.2+, our `engines: >=20` covers it).

Option 3 was preferred in the #3831 design issue. This PR implements that choice.

**Why resolve the Promise immediately on background-abort (vs. wait for natural child exit)**: blocking the caller's `await` until the (potentially long-running) child exits would defeat the entire purpose — the caller needs to unblock so the agent can move on. Once the caller has accepted ownership (per the contract above), the result Promise's job is done.

## Implementation notes

- **`getShellAbortReasonKind(reason)` helper** (exported) reads `signal.reason.kind` defensively: rejects non-object reasons; reads `kind` only as an OWN property via `hasOwnProperty.call` (prototype-pollution defense — `Object.prototype.kind = 'background'` cannot force the promote branch); wraps the read in try/catch so an own getter / `Proxy` trap that throws can't leak past the async abort handler (which is dispatched via `addEventListener` and not awaited — a leaked throw would leave the shell process alive instead of killed); whitelists the value against the known union members and defaults to `'cancel'` for everything else (safe historical kill behavior).
- **Both abort handlers branch via exhaustive `switch`** — `executeWithPty` and `childProcessFallback` extract `performBackgroundPromote` / `performCancelKill` named helpers and `switch (kind)` between them. The `default: { const _exhaustive: never = kind; ... }` arm forces a compile-time error if `ShellAbortReason` ever grows a new variant — directing the developer to (1) extend the helper's whitelist and (2) add a `case` arm. (The runtime `default` branch is unreachable today; the assertion is the static-only safety net.)
- **`activeChildProcesses` / `activePtys` set deletion** — critical so `ShellExecutionService.cleanup()` (the process-exit handler that wipes active sets) won't kill the promoted child on Ctrl+C or process shutdown later.
- **Race guards before detach** — both paths check terminal state right before disposing:
  - **childProcess**: `if (child.exitCode !== null || child.signalCode !== null)` — fall through to the normal exit path. The child may have already exited but the `'exit'` event hasn't reached our handler yet (Node delivers child_process events on the next microtask); promoting in that window would detach our exit listener and report `promoted: true` for a process that's already dead.
  - **PTY**: `if (!ShellExecutionService.isPtyActive(ptyProcess.pid))` — node-pty's `IPty` doesn't expose `exitCode`, so we use `process.kill(pid, 0)` (the existing helper) as a best-effort liveness probe. If the pid is gone, fall through and let the pending `onExit` callback resolve normally with the real exit status.
- **Listener detach is dispose-based, not flag-based**:
  - **childProcess**: extracted named handler refs (`stdoutHandler` / `stderrHandler` / `errorHandler` / `exitHandler`); the abort handler calls `detachServiceListeners()` which `off()`s all four. Without this, post-promote bytes re-enter `handleOutput`, which calls `decoder.decode()` on the now-finalized text decoder (cleanup() called `.decode()` without `stream:true`) → **TypeError crash**. Even without the crash, the old `onOutputEvent` would fire for new data → ownership contract violation + duplication.
  - **PTY**: `node-pty`'s `onData` / `onExit` return `IDisposable` handles; the abort handler captures `dataDisposable` / `exitDisposable` and calls `.dispose()` — each in its own try/catch (the IDisposable contract doesn't guarantee no-throw, and a single throwing dispose must not skip subsequent teardown). `ptyProcess.on('error')` is EventEmitter-style — extracted named `ptyErrorHandler` ref and **`removeListener`'d** (NOT `off()` — `@lydell/node-pty`'s `IPty` interface only exposes the legacy `removeListener`; `.off()` throws TypeError on a real PTY). Without these, post-promote PTY error throws → **Node.js process crash**; post-promote data continues writing to `headlessTerminal` and calling old `onOutputEvent` → ownership violation.
  - Net result: post-promote, our service-side listeners simply never fire. There's no "wasted no-op work" — there's no work at all.
- **In-flight `processingChain` ownership** — `processingChain` may have already-enqueued callbacks past the dispose point. `listenersDetached` flag guards each `onOutputEvent` emit individually inside the chain callbacks. This way in-flight writes still LAND in `headlessTerminal` (so the snapshot reflects them), but no events leak to the foreground `onOutputEvent`. Also clear `renderTimeout` in the abort handler so a pending throttled render doesn't fire post-promote.
- **Drain race + dedicated `PROMOTE_DRAIN_TIMEOUT_MS` constant** — abort handler `await`s `Promise.race([processingChain.then(drain).then(drain).catch(() => undefined), timeout])` before serialization (mirrors the `onExit` finalize pattern at line ~970) so in-flight `headlessTerminal.write` callbacks land before we read the buffer. The chain side has `.catch(() => undefined)` so a chain rejection becomes the resolved branch instead of an unhandled rejection (abort handlers run via `addEventListener` which doesn't await our return, so a leaked rejection would mean `resolve()` is never called and the caller hangs). Race result is observed via a `Symbol` sentinel; if the timeout side wins, `debugLogger.warn` fires pointing the caller at `rawOutput` as the un-truncated fallback. The drain timeout has its own constant separate from `SIGKILL_TIMEOUT_MS` so tuning kill escalation doesn't silently change drain behavior.
- **Encoding-aware PTY snapshot** — `result.output` for the promoted PTY is the same shape as the normal exit path: re-decode `finalBuffer` with `getCachedEncodingForBuffer(finalBuffer)` + `replayTerminalOutput(...)`. Direct `serializeTerminalToText(headlessTerminal)` would risk mojibake when early output is ASCII-only but later output is in a different encoding (GBK / Shift-JIS). Direct serialize stays as a last-ditch fallback if replay throws. Deliberately does NOT call `render(true)` — `renderFn` emits via `onOutputEvent`, which would violate the "no emit post-promote" invariant.
- **Snapshot semantics** — `result.output` for the promoted result is the output captured up to the moment of abort (text decoders flushed for child_process via `cleanup()`; encoding-aware re-decode + replay for PTY after drain). Caller (PR-2) uses this to seed the `BackgroundShellEntry`'s on-disk output file before installing its own data listener for subsequent output.
- **`streamStdout: true` + `{ kind: 'background' }`** is a latent empty-snapshot combo (snapshot reads from string accumulators that `streamStdout` mode bypasses). Today PR-1's only caller uses `streamStdout: false` so the combination is unreachable, but `debugLogger.warn` fires if a future caller pairs them, pointing at `rawOutput` as the fallback.
- **Defensive `?? ''` on PTY snapshot** — `serializeTerminalToText` may return undefined under unusual conditions (mid-render race, or in test mocks); the fallback keeps `result.output` typed as string.

## Test coverage

`shellExecutionService.test.ts`: **69 / 69 pass** (50 baseline + 19 new across five review rounds).

**First-pass — discrimination** (round 1, 4 tests):
- **PTY**: `{ kind: 'cancel' }` still tree-kills via `process.kill(-pid, 'SIGTERM')`; `{ kind: 'background' }` skips kill — `mockProcessKill` NOT called with SIGTERM/SIGKILL on group pid; `mockPtyProcess.kill` NOT called; `result.promoted === true`; `result.exitCode === null`; `result.signal === null`.
- **child_process fallback**: `{ kind: 'cancel' }` still tree-kills (mirror of PTY); `{ kind: 'background' }` skips kill — output captured pre-abort preserved as snapshot in `result.output` (test emits `'line1\nline2\n'` via stdout, then aborts; verifies snapshot contains both lines).

**Handoff-boundary** (round 1, 2 tests):
- **PTY**: post-promotion, `mockPtyProcess.onData.mock.results[0].value.dispose` and `mockPtyProcess.onExit.mock.results[0].value.dispose` ARE called — verifying the disposable handles returned by node-pty are correctly disposed; result shape stays `promoted: true` even when subsequent events would otherwise fire.
- **child_process**: post-promotion, emitting more `'data'` on the live `cp.stdout` / `cp.stderr` does NOT increase `onOutputEvent.mock.calls.length`; emitting `'exit', 42, null` does NOT change `result.exitCode` (stays `null`). Pre-promote bytes ARE in the snapshot; post-promote bytes are NOT.

**Post-exit race guards** (round 4, 2 tests):
- **child_process**: pretend `child.exitCode` was set to 0 BEFORE `'exit'` reaches our handler, abort with `{ kind: 'background' }` — production race guard detects the terminal state and falls through; result has no `promoted: true`, `exitCode: 0` flows through.
- **PTY**: mock `process.kill(pid, 0)` to throw ESRCH on the liveness probe, abort with `{ kind: 'background' }` — production guard refuses to promote a dead PTY; result has no `promoted: true`.

**`removeListener` regression guard** (round 3, 1 test):
- Spies both `mockPtyProcess.removeListener` and `mockPtyProcess.off`, asserts production teardown calls `removeListener('error', …)` and NOT `off('error', …)` — `@lydell/node-pty`'s `IPty` interface only exposes `removeListener`, not the modern `off` alias. The EventEmitter mock tolerates both, so without this guard a future swap to `.off()` would silently regress under tests but throw TypeError on a real PTY.

**`getShellAbortReasonKind` boundary tests** (round 4, 8 tests, helper exported for direct testing):
- null / undefined reason → 'cancel'
- non-object reasons (string / number / boolean / Error-instance) → 'cancel'
- empty object (no own kind) → 'cancel'
- prototype-only kind (`Object.create({ kind: 'background' })`) → 'cancel' (pollution defense)
- unknown kind value (typo / future-untyped variant) → 'cancel'
- throwing accessor (`Object.defineProperty('kind', { get() { throw } })`) → 'cancel'
- Proxy with throwing `get` trap → 'cancel'
- canonical `{ kind: 'background' }` / `{ kind: 'cancel' }` happy paths

**Test fixture hygiene** (round 4, 2 mock-setup adjustments):
- Both `child_process fallback` and `execution method selection` `beforeEach` hooks set `mockChildProcess.exitCode` / `signalCode` to `null` (matches real Node `ChildProcess` shape — alive process has these as `null`, not `undefined`). Without this, the new race guard `child.exitCode !== null` would silently misfire on `undefined`.
- `mockPtyProcess.onData` / `.onExit` return `{ dispose: vi.fn() }` so the production `dataDisposable.dispose()` / `exitDisposable.dispose()` calls don't crash on `undefined.dispose()`. The stub's `.mock.results[0].value` is then inspected by the handoff-boundary tests.

## Test plan

- [x] \`vitest run packages/core/src/services/shellExecutionService.test.ts\`: **69 / 69 pass** (50 baseline + 19 new across five review rounds)
- [x] \`tsc --build packages/cli\` (CI-equivalent full mode): clean
- [x] \`npm run build --workspace=@qwen-code/qwen-code-core\`: clean
- [x] ESLint: clean
- [ ] **Manual** (deferred — needs PR-2 caller to exercise): foreground bash + Ctrl+B → child process kept alive, registry entry created. PR-1 alone has no user-visible surface to manually test.

## Related

- #3831 (Phase D part b — design + 3-PR sequencing)
- #3634 (Background task management roadmap — Phase D in flight)
- #3809 (Phase D part a — long-running foreground bash advisory, merged)

<details>
<summary>中文版</summary>

**PR-1 of 3** — 实现 #3831 的 Phase D 第 (b) 部分：Ctrl+B 把运行中的前台 shell 甩到后台。**纯 plumbing，对现有调用方零行为变化**（没人传新 reason）。

定义一个 discriminated union `ShellAbortReason`，让 `AbortController.abort(reason)` 携带进 `ShellExecutionService.execute()`：

```ts
export type ShellAbortReason =
  | { kind: 'cancel' }
  | { kind: 'background'; shellId?: string };
```

- **默认**（不传 reason 或 `{ kind: 'cancel' }`）→ 维持现状的 tree-kill。
- **`{ kind: 'background' }`** → takeover 信号：`execute()` 跳过 kill，把 child 从 active 集合移除（防 `ShellExecutionService.cleanup()` 后续杀它），flush 一份已捕获 output 的 snapshot 进 result，**立即** resolve result Promise 带 `promoted: true` 让 await 中的调用方解锁。调用方已经接管了运行中的 child。

`ShellExecutionResult` 加可选字段 `promoted?: boolean`，现有消费方不用改源码就能编译通过。

**为什么 PR-1 单独推（不等 #3831 alignment）**：foundation 零用户可见行为变化，独立可合可回退；用 PR 把契约具象化呈现给 reviewer，跟 issue 的设计讨论对照。Reviewer 可以在不看 PR-2 lazy-promote 语义的情况下独立 sanity-check abort handler 的形状。

**调用方契约**：想 promote 的调用方**必须**在调 `abortController.abort({ kind: 'background', ... })` **之前**给 live child attach 自己的 listener（`data` / `exit` / `error`）。background-abort 之后，`execute()` 不再把事件路由给自己 handler 的下游消费方。调用方看到 `result.promoted === true` 就知道所有权已交接 — **不能**把 `result.exitCode` / `result.signal` 当作终态（底层进程没真退出）。

**设计 rationale（为啥用 `signal.reason` 不加新参数）**：考虑过 3 个选项（详细在 #3831）：(1) 给 `execute()` 加新参数 — 给罕见路径加常驻 API 表面，耦合 takeover 生命周期到调用签名；(2) 给每个前台 spawn 预分配 hidden `BackgroundShellEntry` 然后 Ctrl+B 翻 `visible: true` — 改 ShellExecutionService 太多（输出流条件 file-vs-memory），common case 浪费；(3) `signal.reason` 作 takeover 通道（**本 PR**）— 复用每个调用方都有的 AbortController plumbing，区分逻辑是 5 行加在现有 abort handler 里，common case 零开销，用 Node 原生 `AbortSignal.reason`（Node 17.2+，我们 `engines: >=20` 覆盖）。#3831 design 倾向 (3)，本 PR 实现这个选择。

**为什么 background-abort 立刻 resolve Promise（不是等 child 自然 exit）**：让调用方 `await` 阻塞到（可能长跑的）child exit 就完全违背初衷 — 调用方需要解锁让 agent 继续。一旦调用方接管了所有权（按上面契约），result Promise 的使命完成。

**Review 状态**：**5 轮 review 累计 22 个 thread 全部 resolved**。第 1 轮（`8e8e18ca7`，6 个 — 4 Critical + 2 Suggestion）：引入 dispose-based listener detach。第 2 轮（`9008717b8`，6 个）：defensive hardening — 穷尽 switch、per-dispose try/catch、drain race `.catch` 防 unhandled rejection、独立 `PROMOTE_DRAIN_TIMEOUT_MS`、drain timeout sentinel/warn、snapshot serialize warn。第 3 轮（`094fff09c`，3 个）：**真 bug** — `ptyProcess.off('error')` 在 `@lydell/node-pty` 抛 TypeError（只暴露 `removeListener`），改 + 加 regression guard；prototype-pollution-safe own-property kind 读。第 4 轮（`4cc558b3d`，6 个 — 1 Critical + 5）：throw-safe abort-reason 读（own getter / Proxy trap try/catch 包）、child_process post-exit liveness check、encoding-aware PTY snapshot（re-decode + replay）、删 unreachable `default`-warn（保 `_exhaustive: never` 静态检查）、8 helper 边界测试。第 5 轮（`289feaa74`，1 Critical）：PTY 同款 race guard via `process.kill(pid, 0)` liveness probe。下面"实现要点"描述最终 ownership 模型。

**实现要点**：
- **`getShellAbortReasonKind(reason)` helper**（已 export）防御性读 `signal.reason.kind`：拒绝非对象 reason；用 `hasOwnProperty.call` 只读 OWN property（防原型污染 — `Object.prototype.kind = 'background'` 不能进 promote）；try/catch 包读取（防 own getter / Proxy trap 抛错穿透 async abort handler — addEventListener 不 await,泄漏 throw 会让 shell 进程留活而非被 kill）；返值白名单到 union 成员，未知值默认 'cancel'（安全历史 kill 行为）。
- **两个 abort handler 用穷尽 `switch`**：`executeWithPty` + `childProcessFallback` 提取 `performBackgroundPromote` / `performCancelKill` 命名 helper，`switch (kind)` 分支。`default: { const _exhaustive: never = kind; ... }` 在 `ShellAbortReason` union 扩展时强制 TS 报错 — 提示开发者扩 helper 白名单 + 加 case。（runtime default 不可达，仅静态保护。）
- **`activeChildProcesses` / `activePtys` 集合 delete** 关键：防 `ShellExecutionService.cleanup()`（process exit handler 清 active 集合）在 Ctrl+C 或 process shutdown 时杀掉 promoted child。
- **Detach 之前 race guards**：两路径都在 dispose 前检 terminal 状态：
  - **child_process**：`if (child.exitCode !== null || child.signalCode !== null)` → fall through 走正常 exit 路径。child 可能已 exit 但 `'exit'` 事件还没 reach handler（Node 异步派发）；该窗口 promote 会 detach exit listener 上报 `promoted: true` 给已死进程。
  - **PTY**：`if (!ShellExecutionService.isPtyActive(ptyProcess.pid))`。node-pty 的 `IPty` 不暴露 `exitCode`，用 `process.kill(pid, 0)`（现有 helper）作 best-effort liveness probe。pid 不存在 → fall through，让 pending `onExit` 走真实 exit。
- **Listener detach 是 dispose-based 不是 flag-based**：
  - **child_process**：提取 named handler refs (`stdoutHandler` / `stderrHandler` / `errorHandler` / `exitHandler`)；abort handler 调 `detachServiceListeners()` 把 4 个全 `off()`。否则 post-promote 字节会 re-enter `handleOutput` → 它会调 `decoder.decode()` 在已 finalize 的 decoder（cleanup() 已调 `.decode()` no `stream:true`）→ **TypeError crash**。即使没 crash，老 `onOutputEvent` 也会 fire → 违反 ownership + duplicate。
  - **PTY**：node-pty 的 `onData` / `onExit` 返 `IDisposable`；abort handler 拿 `dataDisposable` / `exitDisposable` 调 `.dispose()` — 每个独立 try/catch（IDisposable contract 不保证 no-throw，单一 dispose 抛错不能跳过后续 teardown）。`ptyProcess.on('error')` 是 EventEmitter 风格 — 提取 named `ptyErrorHandler` ref + **`removeListener`**（**不是 `off()`** — `@lydell/node-pty` 的 IPty 接口只暴露 legacy `removeListener`；`.off()` 在真 PTY 抛 TypeError）。否则 post-promote PTY error throw → **Node.js 进程 crash**；post-promote data 继续写 `headlessTerminal` 调老 `onOutputEvent` → 违反 ownership。
  - 净效果：post-promote service-side listener 完全不 fire — 不是"wasted no-op work"，**根本没 work**。
- **In-flight `processingChain` ownership** — chain 可能有 dispose 之前已 enqueue 的 callback。`listenersDetached` flag 守每个 chain callback 内的 `onOutputEvent` emit。这样 in-flight write 仍 LAND 进 `headlessTerminal`（snapshot 反映它们），但事件不 leak 到老 `onOutputEvent`。abort handler 内也清 `renderTimeout` 防 pending 节流 render fire。
- **Drain race + 独立 `PROMOTE_DRAIN_TIMEOUT_MS` 常量** — abort handler `await Promise.race([processingChain.then(drain).then(drain).catch(() => undefined), timeout])` 后再 serialize（镜像 `onExit` 的 finalize pattern at line ~970）让 in-flight `headlessTerminal.write` callback 在读 buffer 之前 land。chain 边带 `.catch(() => undefined)`，让 chain rejection 变 resolved 而非 unhandled rejection（abort handler 经 `addEventListener` 不被 await，泄漏 rejection → resolve 永不调 → caller 死锁）。Race 结果用 Symbol sentinel 检测；timeout 边赢 → `debugLogger.warn` 指向 `rawOutput` 作未截断 fallback。drain timeout 用独立常量与 `SIGKILL_TIMEOUT_MS` 解耦，调一不动另一。
- **Encoding-aware PTY snapshot** — promoted PTY 的 `result.output` 跟正常 exit 同形：用 `getCachedEncodingForBuffer(finalBuffer)` + `replayTerminalOutput(...)` 重新解码 `finalBuffer`。直接 `serializeTerminalToText(headlessTerminal)` 在早期 ASCII 但后段 GBK / Shift-JIS 时会 mojibake。replay 抛错时直接 serialize 作 last-ditch fallback。**故意不**调 `render(true)` — `renderFn` 通过 `onOutputEvent` emit，会违反 "no emit post-promote" 不变量。
- **Snapshot 语义**：promoted result 的 `output` 是 abort 那一刻已捕获的 output（child_process 走 text decoder flush via `cleanup()`；PTY drain 后 encoding-aware re-decode + replay）。caller (PR-2) 用这个 seed `BackgroundShellEntry` 的 on-disk output file，再 attach 自己的 data listener 接后续输出。
- **`streamStdout: true` + `{ kind: 'background' }`** 是潜在空 snapshot 组合（snapshot 读 string accumulator 但 streamStdout 模式跳过累积）。今 PR-1 的唯一 caller 用 `streamStdout: false` 不踩，但 future caller 配对会触发 `debugLogger.warn` 指向 `rawOutput` 兜底。
- **PTY snapshot 加 `?? ''` 防御**：`serializeTerminalToText` 在异常情况下（mid-render race / 测试 mock）可能返 undefined，fallback 保 `result.output` 类型仍是 string。

**测试覆盖**：`shellExecutionService.test.ts` **69 / 69 pass**（50 baseline + 19 个新加，跨 5 轮 review）。

**第 1 轮 — discrimination**（4 测试）：
- **PTY**：`{ kind: 'cancel' }` 仍走 `process.kill(-pid, 'SIGTERM')` tree-kill；`{ kind: 'background' }` 跳 kill — `mockProcessKill` 不被调，`mockPtyProcess.kill` 不被调，`result.promoted === true`。
- **child_process fallback**：同上 + 验证 `result.output` snapshot 包含 abort 前 emit 的 `'line1\nline2\n'`。

**第 1 轮 — Handoff-boundary**（2 测试）：
- **PTY**：post-promotion，`mockPtyProcess.onData.mock.results[0].value.dispose` 和 `.onExit.mock.results[0].value.dispose` **被调用** — 验证 node-pty 返回的 disposable handle 被正确 dispose；result shape 仍 `promoted: true`。
- **child_process**：post-promotion，往 live `cp.stdout` / `cp.stderr` 再 emit `'data'` **不**增加 `onOutputEvent.mock.calls.length`；emit `'exit', 42, null` **不**改 `result.exitCode`（仍 `null`）。

**第 4 轮 — Post-exit race guards**（2 测试）：
- **child_process**：模拟 `child.exitCode` 已设 0 但 `'exit'` 还没 reach handler 的 race 窗口，abort with `{ kind: 'background' }` — production race guard 检测到 terminal 状态 → fall through，result 没 `promoted: true`，正常 `exitCode: 0`。
- **PTY**：mock `process.kill(pid, 0)` 在 liveness probe 时抛 ESRCH，abort with `{ kind: 'background' }` — production guard 拒绝 promote 已死 PTY；result 没 `promoted: true`。

**第 3 轮 — `removeListener` regression guard**（1 测试）：
- spy `mockPtyProcess.removeListener` + `mockPtyProcess.off`，断言 production teardown 调 `removeListener('error', …)` 而**不**调 `off('error', …)`。`@lydell/node-pty` 的 IPty 接口只暴露 `removeListener`（无 `off` alias）— EventEmitter mock 容忍两者，没这测试 future 改回 `.off()` 会在 mock 下静默 regress 但 real PTY 抛 TypeError。

**第 4 轮 — `getShellAbortReasonKind` 边界**（8 测试，helper 已 export 给直接测试）：
- null / undefined reason → 'cancel'
- 非对象 reason（string / number / boolean / Error 实例）→ 'cancel'
- 空对象（无 own kind）→ 'cancel'
- prototype-only kind（`Object.create({ kind: 'background' })`）→ 'cancel'（污染防御）
- 未知 kind 值（typo / 未来 untyped variant）→ 'cancel'
- throwing accessor（`Object.defineProperty('kind', { get() { throw } })`）→ 'cancel'
- Proxy with throwing `get` trap → 'cancel'
- 标准 `{ kind: 'background' }` / `{ kind: 'cancel' }` happy path

**第 4 轮 — Test fixture 一致性**（2 mock setup 调整）：
- 两个 `beforeEach`（`child_process fallback` + `execution method selection`）都设 `mockChildProcess.exitCode` / `signalCode = null` — 镜像真 Node ChildProcess 形状（alive 时 null 不 undefined）。否则 race guard `child.exitCode !== null` 会因 `undefined` 误触发。
- `mockPtyProcess.onData` / `.onExit` 返 `{ dispose: vi.fn() }` 让 production dispose path 不会 crash on `undefined.dispose()` — stub 的 `.mock.results[0].value` 然后被 handoff 测试 inspect。

**测试计划**：
- [x] `vitest run packages/core/src/services/shellExecutionService.test.ts`：**69 / 69 pass**（50 baseline + 19 个新加，跨 5 轮 review）
- [x] `tsc --build packages/cli`（CI 等价 full mode）：clean
- [x] `npm run build --workspace=@qwen-code/qwen-code-core`：clean
- [x] ESLint：clean
- [ ] **Manual**（推迟 — 需 PR-2 caller 才能 exercise）：前台 bash + Ctrl+B → child 仍 alive，registry entry 创建。PR-1 单独无用户可见 surface 可手测。

**Related**：#3831（Phase D b 设计 + 3-PR sequencing）/ #3634（Background task 管理 roadmap）/ #3809（Phase D a，已合）

</details>


