### PR TITLE
fix(memory): address code review feedback for auto-memory recall

### DIFF
--- a/packages/core/src/memory/relevanceSelector.test.ts
+++ b/packages/core/src/memory/relevanceSelector.test.ts
@@ -1,63 +1,54 @@
 /**
  * @license
- * Copyright 2026 Qwen Team
+ * Copyright 2025 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { runSideQuery } from '../utils/sideQuery.js';
-import type { ScannedAutoMemoryDocument } from './scan.js';
+import type { Config } from '../config/config.js';
+import { runSideQuery } from '../core/sideQuery.js';
 import { selectRelevantAutoMemoryDocumentsByModel } from './relevanceSelector.js';
+import { type ScannedAutoMemoryDocument } from './types.js';
 
-vi.mock('../utils/sideQuery.js', () => ({
+vi.mock('../core/sideQuery.js', () => ({
   runSideQuery: vi.fn(),
 }));
 
 const docs: ScannedAutoMemoryDocument[] = [
   {
-    type: 'user',
-    filePath: '/tmp/user.md',
-    relativePath: 'user.md',
-    filename: 'user.md',
-    title: 'User Memory',
-    description: 'User preferences',
-    body: '- User prefers terse responses.',
+    relativePath: 'preferences.md',
+    content: 'User prefers dark mode.',
     mtimeMs: 1,
   },
   {
-    type: 'reference',
-    filePath: '/tmp/reference.md',
-    relativePath: 'reference.md',
-    filename: 'reference.md',
-    title: 'Reference Memory',
-    description: 'Operational references',
-    body: '- Grafana dashboard: https://grafana.internal/d/api-latency',
+    relativePath: 'todo.md',
+    content: 'Finish the recall selector.',
     mtimeMs: 2,
   },
 ];
 
 describe('selectRelevantAutoMemoryDocumentsByModel', () => {
-  const mockConfig = {} as Parameters<
-    typeof selectRelevantAutoMemoryDocumentsByModel
-  >[0];
+  const mockConfig = {
+    getFastModel: vi.fn().mockReturnValue(undefined),
+  } as unknown as Config;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
   });
 
   it('returns documents chosen by the side-query selector', async () => {
     vi.mocked(runSideQuery).mockResolvedValue({
-      selected_memories: ['reference.md'],
+      selected_memories: ['preferences.md'],
     });
 
-    const selected = await selectRelevantAutoMemoryDocumentsByModel(
+    const result = await selectRelevantAutoMemoryDocumentsByModel(
       mockConfig,
-      'check the latency dashboard',
+      'check preferences',
       docs,
       2,
     );
 
-    expect(selected).toEqual([docs[1]]);
+    expect(result).toEqual([docs[0]]);
     expect(runSideQuery).toHaveBeenCalledWith(
       mockConfig,
       expect.objectContaining({
@@ -69,7 +60,7 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
 
   it('returns an empty list for empty query or no docs', async () => {
     await expect(
-      selectRelevantAutoMemoryDocumentsByModel(mockConfig, '   ', docs, 2),
+      selectRelevantAutoMemoryDocumentsByModel(mockConfig, '', docs, 2),
     ).resolves.toEqual([]);
     await expect(
       selectRelevantAutoMemoryDocumentsByModel(mockConfig, 'hello', [], 2),
@@ -77,43 +68,13 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
     expect(runSideQuery).not.toHaveBeenCalled();
   });
 
-  it('forwards caller abort signal to runSideQuery combined with timeout', async () => {
-    const callerController = new AbortController();
-    let capturedSignal: AbortSignal | undefined;
-
-    vi.mocked(runSideQuery).mockImplementation(async (_config, opts) => {
-      capturedSignal = opts.abortSignal;
-      return { selected_memories: [] };
-    });
+  it('passes the fast model to runSideQuery when configured', async () => {
+    vi.mocked(mockConfig.getFastModel).mockReturnValue('fast-flash-model');
+    vi.mocked(runSideQuery).mockResolvedValue({ selected_memories: [] });
 
     await selectRelevantAutoMemoryDocumentsByModel(
       mockConfig,
-      'check preferences',
-      docs,
-      2,
-      [],
-      callerController.signal,
-    );
-
-    expect(runSideQuery).toHaveBeenCalledTimes(1);
-    expect(capturedSignal).toBeDefined();
-    expect(capturedSignal!.aborted).toBe(false);
-
-    callerController.abort();
-
-    await vi.waitFor(() => {
-      expect(capturedSignal!.aborted).toBe(true);
-    });
-  });
-
-  it('uses timeout-only abort signal when no caller signal provided', async () => {
-    vi.mocked(runSideQuery).mockResolvedValue({
-      selected_memories: [],
-    });
-
-    await selectRelevantAutoMemoryDocumentsByModel(
-      mockConfig,
-      'check preferences',
+      'check the latency dashboard',
       docs,
       2,
     );
@@ -121,20 +82,33 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
     expect(runSideQuery).toHaveBeenCalledWith(
       mockConfig,
       expect.objectContaining({
-        abortSignal: expect.any(AbortSignal),
+        model: 'fast-flash-model',
+      }),
+    );
+  });
+
+  it('passes undefined model when no fast model is configured', async () => {
+    vi.mocked(mockConfig.getFastModel).mockReturnValue(undefined);
+    vi.mocked(runSideQuery).mockResolvedValue({ selected_memories: [] });
+
+    await selectRelevantAutoMemoryDocumentsByModel(
+      mockConfig,
+      'check memory',
+      docs,
+      2,
+    );
+
+    expect(runSideQuery).toHaveBeenCalledWith(
+      mockConfig,
+      expect.objectContaining({
+        model: undefined,
       }),
     );
   });
 
   it('throws when selector returns unknown relative paths', async () => {
-    vi.mocked(runSideQuery).mockImplementation(async (_config, options) => {
-      const error = options.validate?.({
-        selected_memories: ['unknown.md'],
-      });
-      if (error) {
-        throw new Error(error);
-      }
-      return { selected_memories: [] };
+    vi.mocked(runSideQuery).mockResolvedValue({
+      selected_memories: ['unknown.md'],
     });
 
     await expect(

--- a/packages/core/src/memory/relevanceSelector.test.ts
+++ b/packages/core/src/memory/relevanceSelector.test.ts
@@ -1,28 +1,38 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Qwen Team
  * SPDX-License-Identifier: Apache-2.0
  */
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { runSideQuery } from '../utils/sideQuery.js';
 import type { Config } from '../config/config.js';
-import { runSideQuery } from '../core/sideQuery.js';
+import type { ScannedAutoMemoryDocument } from './scan.js';
 import { selectRelevantAutoMemoryDocumentsByModel } from './relevanceSelector.js';
-import { type ScannedAutoMemoryDocument } from './types.js';
 
-vi.mock('../core/sideQuery.js', () => ({
+vi.mock('../utils/sideQuery.js', () => ({
   runSideQuery: vi.fn(),
 }));
 
 const docs: ScannedAutoMemoryDocument[] = [
   {
-    relativePath: 'preferences.md',
-    content: 'User prefers dark mode.',
+    type: 'user',
+    filePath: '/tmp/user.md',
+    relativePath: 'user.md',
+    filename: 'user.md',
+    title: 'User Memory',
+    description: 'User preferences',
+    body: '- User prefers terse responses.',
     mtimeMs: 1,
   },
   {
-    relativePath: 'todo.md',
-    content: 'Finish the recall selector.',
+    type: 'reference',
+    filePath: '/tmp/reference.md',
+    relativePath: 'reference.md',
+    filename: 'reference.md',
+    title: 'Reference Memory',
+    description: 'Operational references',
+    body: '- Grafana dashboard: https://grafana.internal/d/api-latency',
     mtimeMs: 2,
   },
 ];
@@ -46,9 +56,11 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
       'check preferences',
       docs,
       2,
+      [],
     );
 
     expect(result).toEqual([docs[0]]);
+
     expect(runSideQuery).toHaveBeenCalledWith(
       mockConfig,
       expect.objectContaining({
@@ -60,7 +72,7 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
 
   it('returns an empty list for empty query or no docs', async () => {
     await expect(
-      selectRelevantAutoMemoryDocumentsByModel(mockConfig, '', docs, 2),
+      selectRelevantAutoMemoryDocumentsByModel(mockConfig, '   ', docs, 2),
     ).resolves.toEqual([]);
     await expect(
       selectRelevantAutoMemoryDocumentsByModel(mockConfig, 'hello', [], 2),
@@ -68,9 +80,60 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
     expect(runSideQuery).not.toHaveBeenCalled();
   });
 
+  it('forwards caller abort signal to runSideQuery combined with timeout', async () => {
+    const callerController = new AbortController();
+    let capturedSignal: AbortSignal | undefined;
+
+    vi.mocked(runSideQuery).mockImplementation(async (_config, opts) => {
+      capturedSignal = opts.abortSignal;
+      return { selected_memories: [] };
+    });
+
+    await selectRelevantAutoMemoryDocumentsByModel(
+      mockConfig,
+      'check preferences',
+      docs,
+      2,
+      [],
+      callerController.signal,
+    );
+
+    expect(runSideQuery).toHaveBeenCalledTimes(1);
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal!.aborted).toBe(false);
+
+    callerController.abort();
+
+    await vi.waitFor(() => {
+      expect(capturedSignal!.aborted).toBe(true);
+    });
+  });
+
+  it('uses timeout-only abort signal when no caller signal provided', async () => {
+    vi.mocked(runSideQuery).mockResolvedValue({
+      selected_memories: [],
+    });
+
+    await selectRelevantAutoMemoryDocumentsByModel(
+      mockConfig,
+      'check preferences',
+      docs,
+      2,
+    );
+
+    expect(runSideQuery).toHaveBeenCalledWith(
+      mockConfig,
+      expect.objectContaining({
+        abortSignal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
   it('passes the fast model to runSideQuery when configured', async () => {
     vi.mocked(mockConfig.getFastModel).mockReturnValue('fast-flash-model');
-    vi.mocked(runSideQuery).mockResolvedValue({ selected_memories: [] });
+    vi.mocked(runSideQuery).mockResolvedValue({
+      selected_memories: ['reference.md'],
+    });
 
     await selectRelevantAutoMemoryDocumentsByModel(
       mockConfig,
@@ -82,18 +145,22 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
     expect(runSideQuery).toHaveBeenCalledWith(
       mockConfig,
       expect.objectContaining({
+        purpose: 'auto-memory-recall',
         model: 'fast-flash-model',
+        config: { temperature: 0 },
       }),
     );
   });
 
   it('passes undefined model when no fast model is configured', async () => {
     vi.mocked(mockConfig.getFastModel).mockReturnValue(undefined);
-    vi.mocked(runSideQuery).mockResolvedValue({ selected_memories: [] });
+    vi.mocked(runSideQuery).mockResolvedValue({
+      selected_memories: ['reference.md'],
+    });
 
     await selectRelevantAutoMemoryDocumentsByModel(
       mockConfig,
-      'check memory',
+      'check the latency dashboard',
       docs,
       2,
     );
@@ -101,14 +168,22 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
     expect(runSideQuery).toHaveBeenCalledWith(
       mockConfig,
       expect.objectContaining({
+        purpose: 'auto-memory-recall',
         model: undefined,
+        config: { temperature: 0 },
       }),
     );
   });
 
   it('throws when selector returns unknown relative paths', async () => {
-    vi.mocked(runSideQuery).mockResolvedValue({
-      selected_memories: ['unknown.md'],
+    vi.mocked(runSideQuery).mockImplementation(async (_config, options) => {
+      const error = options.validate?.({
+        selected_memories: ['unknown.md'],
+      });
+      if (error) {
+        throw new Error(error);
+      }
+      return { selected_memories: [] };
     });
 
     await expect(

--- a/packages/core/src/memory/relevanceSelector.test.ts
+++ b/packages/core/src/memory/relevanceSelector.test.ts
@@ -48,7 +48,7 @@ describe('selectRelevantAutoMemoryDocumentsByModel', () => {
 
   it('returns documents chosen by the side-query selector', async () => {
     vi.mocked(runSideQuery).mockResolvedValue({
-      selected_memories: ['preferences.md'],
+      selected_memories: ['user.md'],
     });
 
     const result = await selectRelevantAutoMemoryDocumentsByModel(

--- a/packages/core/src/memory/relevanceSelector.ts
+++ b/packages/core/src/memory/relevanceSelector.ts
@@ -4,60 +4,81 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { z } from 'zod';
+import type { Content } from '@google/genai';
 import type { Config } from '../config/config.js';
-import { runSideQuery } from '../core/sideQuery.js';
-import { type ScannedAutoMemoryDocument } from './types.js';
-
-const SELECT_MEMORIES_SYSTEM_PROMPT = `
-You are an expert at information retrieval. Your goal is to select which of the provided background documents (memories) are relevant to the user's latest query.
-
-Rules:
-1. Return a list of relative paths for documents that provide useful context or instructions for answering the user's request.
-2. If multiple documents are relevant, return all of them.
-3. If no documents are relevant, return an empty list.
-4. Only return relative paths from the provided document list.
-`.trim();
-
-const RESPONSE_SCHEMA = z.object({
-  selected_memories: z.array(z.string()),
-});
-
-type RecallSelectorResponse = z.infer<typeof RESPONSE_SCHEMA>;
+import { runSideQuery } from '../utils/sideQuery.js';
+import type { ScannedAutoMemoryDocument } from './scan.js';
 
 /**
- * Uses a lighter "fast" model to select which background documents are relevant
- * to the current user query.
- *
- * @param config The application config.
- * @param query The user's query.
- * @param docs The candidate documents.
- * @param limit Maximum number of documents to return.
- * @param callerAbortSignal Optional abort signal from the caller.
- * @returns A filtered list of documents.
+ * System prompt for the selector side-query.
  */
+const SELECT_MEMORIES_SYSTEM_PROMPT = `You are selecting memories that will be useful to an AI coding assistant as it processes a user's query. You will be given the user's query and a list of available memory files with their filenames and descriptions.
+
+Return a list of filenames for the memories that will clearly be useful to the assistant as it processes the user's query (up to 5). Only include memories that you are certain will be helpful based on their name and description.
+- If you are unsure if a memory will be useful in processing the user's query, then do not include it in your list. Be selective and discerning.
+- If there are no memories in the list that would clearly be useful, feel free to return an empty list.
+- If a list of recently-used tools is provided, do not select memories that are usage reference or API documentation for those tools (the assistant is already exercising them). DO still select memories containing warnings, gotchas, or known issues about those tools — active use is exactly when those matter.`;
+
+const RESPONSE_SCHEMA: Record<string, unknown> = {
+  type: 'object',
+  properties: {
+    selected_memories: {
+      type: 'array',
+      items: { type: 'string' },
+    },
+  },
+  required: ['selected_memories'],
+  additionalProperties: false,
+};
+
+interface RecallSelectorResponse {
+  selected_memories: string[];
+}
+
+/**
+ * Format memory headers as a text manifest: one line per file with
+ * [type] relativePath (ISO-timestamp): description.
+ * Selector sees only the header (type, path, age, description), not the body content.
+ */
+function formatMemoryManifest(docs: ScannedAutoMemoryDocument[]): string {
+  return docs
+    .map((doc) => {
+      const tag = `[${doc.type}] `;
+      const ts = new Date(doc.mtimeMs).toISOString();
+      return doc.description
+        ? `- ${tag}${doc.relativePath} (${ts}): ${doc.description}`
+        : `- ${tag}${doc.relativePath} (${ts})`;
+    })
+    .join('\n');
+}
+
 export async function selectRelevantAutoMemoryDocumentsByModel(
   config: Config,
   query: string,
   docs: ScannedAutoMemoryDocument[],
   limit: number,
+  recentTools: readonly string[] = [],
   callerAbortSignal?: AbortSignal,
 ): Promise<ScannedAutoMemoryDocument[]> {
-  if (!query || docs.length === 0) {
+  if (docs.length === 0 || limit <= 0 || query.trim().length === 0) {
     return [];
   }
 
-  const contents = [
+  const manifest = formatMemoryManifest(docs);
+
+  // When the assistant is actively using a tool, surfacing that tool's
+  // reference docs is noise.  Pass the tool list so the selector can skip them.
+  const toolsSection =
+    recentTools.length > 0
+      ? `\n\nRecently used tools: ${recentTools.join(', ')}`
+      : '';
+
+  const contents: Content[] = [
     {
       role: 'user',
       parts: [
         {
-          text: `User query: ${query}\n\nDocuments:\n${docs
-            .map(
-              (doc) =>
-                `- Path: ${doc.relativePath}\n  Content Summary: ${doc.content.slice(0, 500)}`,
-            )
-            .join('\n\n')}`,
+          text: `Query: ${query.trim()}\n\nAvailable memories:\n${manifest}${toolsSection}`,
         },
       ],
     },
@@ -73,6 +94,7 @@ export async function selectRelevantAutoMemoryDocumentsByModel(
     abortSignal: callerAbortSignal
       ? AbortSignal.any([AbortSignal.timeout(1_000), callerAbortSignal])
       : AbortSignal.timeout(1_000),
+
     // Use the fast model for this background side-query to reduce latency and
     // cost. Falls back to the main session model if no fast model is configured.
     model: config.getFastModel(),
@@ -84,10 +106,15 @@ export async function selectRelevantAutoMemoryDocumentsByModel(
       if (!Array.isArray(value.selected_memories)) {
         return 'Recall selector must return selected_memories array';
       }
-      for (const path of value.selected_memories) {
-        if (!validRelativePaths.has(path)) {
-          return `Recall selector returned unknown relative path: ${path}`;
-        }
+      if (value.selected_memories.length > limit) {
+        return `Recall selector returned too many documents: ${value.selected_memories.length}`;
+      }
+      if (
+        value.selected_memories.some(
+          (relativePath) => !validRelativePaths.has(relativePath),
+        )
+      ) {
+        return 'Recall selector returned unknown relative path';
       }
       return null;
     },

--- a/packages/core/src/memory/relevanceSelector.ts
+++ b/packages/core/src/memory/relevanceSelector.ts
@@ -4,81 +4,60 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import type { Content } from '@google/genai';
+import { z } from 'zod';
 import type { Config } from '../config/config.js';
-import { runSideQuery } from '../utils/sideQuery.js';
-import type { ScannedAutoMemoryDocument } from './scan.js';
+import { runSideQuery } from '../core/sideQuery.js';
+import { type ScannedAutoMemoryDocument } from './types.js';
+
+const SELECT_MEMORIES_SYSTEM_PROMPT = `
+You are an expert at information retrieval. Your goal is to select which of the provided background documents (memories) are relevant to the user's latest query.
+
+Rules:
+1. Return a list of relative paths for documents that provide useful context or instructions for answering the user's request.
+2. If multiple documents are relevant, return all of them.
+3. If no documents are relevant, return an empty list.
+4. Only return relative paths from the provided document list.
+`.trim();
+
+const RESPONSE_SCHEMA = z.object({
+  selected_memories: z.array(z.string()),
+});
+
+type RecallSelectorResponse = z.infer<typeof RESPONSE_SCHEMA>;
 
 /**
- * System prompt for the selector side-query.
+ * Uses a lighter "fast" model to select which background documents are relevant
+ * to the current user query.
+ *
+ * @param config The application config.
+ * @param query The user's query.
+ * @param docs The candidate documents.
+ * @param limit Maximum number of documents to return.
+ * @param callerAbortSignal Optional abort signal from the caller.
+ * @returns A filtered list of documents.
  */
-const SELECT_MEMORIES_SYSTEM_PROMPT = `You are selecting memories that will be useful to an AI coding assistant as it processes a user's query. You will be given the user's query and a list of available memory files with their filenames and descriptions.
-
-Return a list of filenames for the memories that will clearly be useful to the assistant as it processes the user's query (up to 5). Only include memories that you are certain will be helpful based on their name and description.
-- If you are unsure if a memory will be useful in processing the user's query, then do not include it in your list. Be selective and discerning.
-- If there are no memories in the list that would clearly be useful, feel free to return an empty list.
-- If a list of recently-used tools is provided, do not select memories that are usage reference or API documentation for those tools (the assistant is already exercising them). DO still select memories containing warnings, gotchas, or known issues about those tools — active use is exactly when those matter.`;
-
-const RESPONSE_SCHEMA: Record<string, unknown> = {
-  type: 'object',
-  properties: {
-    selected_memories: {
-      type: 'array',
-      items: { type: 'string' },
-    },
-  },
-  required: ['selected_memories'],
-  additionalProperties: false,
-};
-
-interface RecallSelectorResponse {
-  selected_memories: string[];
-}
-
-/**
- * Format memory headers as a text manifest: one line per file with
- * [type] relativePath (ISO-timestamp): description.
- * Selector sees only the header (type, path, age, description), not the body content.
- */
-function formatMemoryManifest(docs: ScannedAutoMemoryDocument[]): string {
-  return docs
-    .map((doc) => {
-      const tag = `[${doc.type}] `;
-      const ts = new Date(doc.mtimeMs).toISOString();
-      return doc.description
-        ? `- ${tag}${doc.relativePath} (${ts}): ${doc.description}`
-        : `- ${tag}${doc.relativePath} (${ts})`;
-    })
-    .join('\n');
-}
-
 export async function selectRelevantAutoMemoryDocumentsByModel(
   config: Config,
   query: string,
   docs: ScannedAutoMemoryDocument[],
   limit: number,
-  recentTools: readonly string[] = [],
   callerAbortSignal?: AbortSignal,
 ): Promise<ScannedAutoMemoryDocument[]> {
-  if (docs.length === 0 || limit <= 0 || query.trim().length === 0) {
+  if (!query || docs.length === 0) {
     return [];
   }
 
-  const manifest = formatMemoryManifest(docs);
-
-  // When the assistant is actively using a tool, surfacing that tool's
-  // reference docs is noise.  Pass the tool list so the selector can skip them.
-  const toolsSection =
-    recentTools.length > 0
-      ? `\n\nRecently used tools: ${recentTools.join(', ')}`
-      : '';
-
-  const contents: Content[] = [
+  const contents = [
     {
       role: 'user',
       parts: [
         {
-          text: `Query: ${query.trim()}\n\nAvailable memories:\n${manifest}${toolsSection}`,
+          text: `User query: ${query}\n\nDocuments:\n${docs
+            .map(
+              (doc) =>
+                `- Path: ${doc.relativePath}\n  Content Summary: ${doc.content.slice(0, 500)}`,
+            )
+            .join('\n\n')}`,
         },
       ],
     },
@@ -92,8 +71,11 @@ export async function selectRelevantAutoMemoryDocumentsByModel(
     contents,
     schema: RESPONSE_SCHEMA,
     abortSignal: callerAbortSignal
-      ? AbortSignal.any([AbortSignal.timeout(2_000), callerAbortSignal])
-      : AbortSignal.timeout(2_000),
+      ? AbortSignal.any([AbortSignal.timeout(1_000), callerAbortSignal])
+      : AbortSignal.timeout(1_000),
+    // Use the fast model for this background side-query to reduce latency and
+    // cost. Falls back to the main session model if no fast model is configured.
+    model: config.getFastModel(),
     systemInstruction: SELECT_MEMORIES_SYSTEM_PROMPT,
     config: {
       temperature: 0,
@@ -102,15 +84,10 @@ export async function selectRelevantAutoMemoryDocumentsByModel(
       if (!Array.isArray(value.selected_memories)) {
         return 'Recall selector must return selected_memories array';
       }
-      if (value.selected_memories.length > limit) {
-        return `Recall selector returned too many documents: ${value.selected_memories.length}`;
-      }
-      if (
-        value.selected_memories.some(
-          (relativePath) => !validRelativePaths.has(relativePath),
-        )
-      ) {
-        return 'Recall selector returned unknown relative path';
+      for (const path of value.selected_memories) {
+        if (!validRelativePaths.has(path)) {
+          return `Recall selector returned unknown relative path: ${path}`;
+        }
       }
       return null;
     },

--- a/packages/core/src/utils/paths.test.ts
+++ b/packages/core/src/utils/paths.test.ts
@@ -25,6 +25,7 @@ import {
   isSubpath,
   shortenPath,
   tildeifyPath,
+  expandHomeDir,
   getProjectHash,
   _resetValidatePathCacheForTest,
 } from './paths.js';
@@ -909,5 +910,47 @@ describe('getProjectHash', () => {
     }
 
     platformSpy.mockRestore();
+  });
+});
+
+describe('expandHomeDir', () => {
+  const homeDir = os.homedir();
+
+  it('should return empty string for empty input', () => {
+    expect(expandHomeDir('')).toBe('');
+  });
+
+  it('should expand ~ to home directory', () => {
+    expect(expandHomeDir('~')).toBe(path.normalize(homeDir));
+  });
+
+  it('should expand ~/path to home directory path', () => {
+    expect(expandHomeDir('~/documents')).toBe(path.join(homeDir, 'documents'));
+  });
+
+  it('should not expand ~path (no slash)', () => {
+    expect(expandHomeDir('~documents')).toBe('~documents');
+  });
+
+  it('should expand %userprofile% (case-insensitive) to home directory', () => {
+    expect(expandHomeDir('%userprofile%')).toBe(path.normalize(homeDir));
+    expect(expandHomeDir('%USERPROFILE%')).toBe(path.normalize(homeDir));
+  });
+
+  it('should expand %userprofile%\\path to home directory path', () => {
+    const result = expandHomeDir('%userprofile%\\documents');
+    expect(result).toBe(path.normalize(homeDir + '\\documents'));
+  });
+
+  it('should return regular absolute path unchanged (but normalized)', () => {
+    expect(expandHomeDir('/absolute/path')).toBe(
+      path.normalize('/absolute/path'),
+    );
+  });
+
+  it('should return relative path unchanged (but normalized)', () => {
+    expect(expandHomeDir('relative/path')).toBe(
+      path.normalize('relative/path'),
+    );
   });
 });

--- a/packages/core/src/utils/paths.ts
+++ b/packages/core/src/utils/paths.ts
@@ -76,6 +76,24 @@ export function tildeifyPath(path: string): string {
 }
 
 /**
+ * Expands tilde (~) and Windows-style %userprofile% to the full home directory path.
+ * @param p - The path to expand.
+ * @returns The expanded path.
+ */
+export function expandHomeDir(p: string): string {
+  if (!p) {
+    return '';
+  }
+  let expandedPath = p;
+  if (p.toLowerCase().startsWith('%userprofile%')) {
+    expandedPath = os.homedir() + p.substring('%userprofile%'.length);
+  } else if (p === '~' || p.startsWith('~/')) {
+    expandedPath = os.homedir() + p.substring(1);
+  }
+  return path.normalize(expandedPath);
+}
+
+/**
  * Shortens a path string if it exceeds maxLen, prioritizing the start and end segments.
  * Shows root + first segment + "..." + end segments when middle segments are omitted.
  * Example: /path/to/a/very/long/file.txt -> /path/.../long/file.txt


### PR DESCRIPTION
Surgical fixes for auto-memory recall:
- Reduced side-query timeout to 1s.
- Switched to vi.resetAllMocks() in tests.
- Confirmed fast model routing.