### PR TITLE
fix(core): create temp dir before saving truncated shell output

### DIFF
--- a/packages/core/src/utils/truncation.test.ts
+++ b/packages/core/src/utils/truncation.test.ts
@@ -13,11 +13,13 @@ vi.mock('node:fs/promises');
 
 describe('truncateAndSaveToFile', () => {
   const mockWriteFile = vi.mocked(fs.writeFile);
+  const mockMkdir = vi.mocked(fs.mkdir);
   const THRESHOLD = 40_000;
   const TRUNCATE_LINES = 1000;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockMkdir.mockResolvedValue(undefined);
   });
 
   it('should return content unchanged if below both threshold and line limit', async () => {
@@ -35,6 +37,7 @@ describe('truncateAndSaveToFile', () => {
 
     expect(result).toEqual({ content });
     expect(mockWriteFile).not.toHaveBeenCalled();
+    expect(mockMkdir).not.toHaveBeenCalled();
   });
 
   it('should truncate when line limit exceeded even if under character threshold', async () => {
@@ -59,6 +62,9 @@ describe('truncateAndSaveToFile', () => {
     expect(result.outputFile).toBe(
       path.join(projectTempDir, `${fileName}.output`),
     );
+    expect(mockMkdir).toHaveBeenCalledWith(projectTempDir, {
+      recursive: true,
+    });
 
     const head = Math.floor(TRUNCATE_LINES / 5);
     const beginning = lines.slice(0, head);
@@ -133,6 +139,9 @@ describe('truncateAndSaveToFile', () => {
     expect(result.outputFile).toBe(
       path.join(projectTempDir, `${fileName}.output`),
     );
+    expect(mockMkdir).toHaveBeenCalledWith(projectTempDir, {
+      recursive: true,
+    });
     expect(mockWriteFile).toHaveBeenCalledWith(
       path.join(projectTempDir, `${fileName}.output`),
       content,

--- a/packages/core/src/utils/truncation.ts
+++ b/packages/core/src/utils/truncation.ts
@@ -85,6 +85,7 @@ export async function truncateAndSaveToFile(
   const safeFileName = `${path.basename(fileName)}.output`;
   const outputFile = path.join(projectTempDir, safeFileName);
   try {
+    await fs.mkdir(projectTempDir, { recursive: true });
     await fs.writeFile(outputFile, content);
 
     return {


### PR DESCRIPTION
## Summary

- What changed: The shell output truncation path now ensures project runtime temp storage exists before saving the full output file.
- Why it changed: Fresh ACP sessions can encounter large shell output before any project temp storage has been initialized, which prevents the full-output file from being written and leaves oversized output untruncated.
- Reviewer focus: Confirm the fix preserves the existing behavior that truncation only replaces model-facing content when the full output is successfully saved.

## Validation

- Commands run:
  npx vitest run src/utils/truncation.test.ts from packages/core
  npm run build
  npm run typecheck
- Prompts / inputs used: Unit test coverage exercises oversized output that needs to be saved before truncation can report a full-output path.
- Expected result: Oversized output creates project temp storage before saving the complete output file, then returns truncated output with the saved file path.
- Observed result: The focused truncation test passed, and repository build and typecheck completed successfully.
- Quickest reviewer verification path: Run npx vitest run src/utils/truncation.test.ts from packages/core.
- Evidence: Local command output reported 10 passing tests for src/utils/truncation.test.ts. Build and typecheck exited successfully.

## Scope / Risk

- Main risk or tradeoff: Low. The change only creates the already-selected project temp directory immediately before writing the full saved output.
- Not covered / not validated: End-to-end ACP reproduction was not run locally.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | tested | not tested | not tested |
| npx      | tested | not tested | not tested |
| Docker   | not tested | not tested | not tested |
| Podman   | not tested | N/A | N/A |
| Seatbelt | not tested | N/A | N/A |

Testing matrix notes:

- Validation was local on macOS only.

## Linked Issues / Bugs

Fixes #3874