### PR TITLE
feat(core): add reactive compression on context overflow

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -11,7 +11,7 @@ import type {
   GenerateContentResponse,
 } from '@google/genai';
 import { ApiError } from '@google/genai';
-import type { ContentGenerator } from '../core/contentGenerator.js';
+import { AuthType, type ContentGenerator } from '../core/contentGenerator.js';
 import {
   GeminiChat,
   InvalidStreamError,
@@ -1311,6 +1311,93 @@ describe('GeminiChat', async () => {
               'answer after compact',
         ),
       ).toBe(true);
+    });
+
+    it('uses the parsed context limit when reactive overflow lacks an actual token count', async () => {
+      const compressedHistory: Content[] = [
+        { role: 'user', parts: [{ text: 'summary' }] },
+        { role: 'model', parts: [{ text: 'ack' }] },
+      ];
+      const compressSpy = vi
+        .spyOn(ChatCompressionService.prototype, 'compress')
+        .mockResolvedValueOnce({
+          newHistory: null,
+          info: {
+            originalTokenCount: 0,
+            newTokenCount: 0,
+            compressionStatus: CompressionStatus.NOOP,
+          },
+        })
+        .mockResolvedValueOnce({
+          newHistory: compressedHistory,
+          info: {
+            originalTokenCount: 128_000,
+            newTokenCount: 40_000,
+            compressionStatus: CompressionStatus.COMPRESSED,
+          },
+        });
+      vi.mocked(mockContentGenerator.generateContentStream)
+        .mockRejectedValueOnce(
+          new Error("This model's maximum context length is 128000 tokens."),
+        )
+        .mockResolvedValueOnce(makeStreamResponse('answer after compact'));
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'latest' },
+        'prompt-id-reactive-limit-only',
+      );
+      for await (const _ of stream) {
+        /* consume */
+      }
+
+      expect(compressSpy).toHaveBeenCalledTimes(2);
+      expect(compressSpy.mock.calls[1][1].originalTokenCount).toBe(128_000);
+    });
+
+    it('uses the configured context window when reactive overflow has no token counts', async () => {
+      vi.mocked(mockConfig.getContentGeneratorConfig).mockReturnValue({
+        authType: AuthType.USE_GEMINI,
+        model: 'test-model',
+        contextWindowSize: 262_144,
+      });
+      const compressedHistory: Content[] = [
+        { role: 'user', parts: [{ text: 'summary' }] },
+        { role: 'model', parts: [{ text: 'ack' }] },
+      ];
+      const compressSpy = vi
+        .spyOn(ChatCompressionService.prototype, 'compress')
+        .mockResolvedValueOnce({
+          newHistory: null,
+          info: {
+            originalTokenCount: 0,
+            newTokenCount: 0,
+            compressionStatus: CompressionStatus.NOOP,
+          },
+        })
+        .mockResolvedValueOnce({
+          newHistory: compressedHistory,
+          info: {
+            originalTokenCount: 262_144,
+            newTokenCount: 40_000,
+            compressionStatus: CompressionStatus.COMPRESSED,
+          },
+        });
+      vi.mocked(mockContentGenerator.generateContentStream)
+        .mockRejectedValueOnce(new Error('context_length_exceeded'))
+        .mockResolvedValueOnce(makeStreamResponse('answer after compact'));
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'latest' },
+        'prompt-id-reactive-window-fallback',
+      );
+      for await (const _ of stream) {
+        /* consume */
+      }
+
+      expect(compressSpy).toHaveBeenCalledTimes(2);
+      expect(compressSpy.mock.calls[1][1].originalTokenCount).toBe(262_144);
     });
 
     it('does not attempt reactive compression more than once per send', async () => {

--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1243,6 +1243,295 @@ describe('GeminiChat', async () => {
         false,
       );
     });
+
+    it('reactively compresses and retries once after a context overflow error', async () => {
+      const compressedHistory: Content[] = [
+        { role: 'user', parts: [{ text: 'summary' }] },
+        { role: 'model', parts: [{ text: 'ack' }] },
+        { role: 'user', parts: [{ text: 'latest' }] },
+      ];
+      const expectedRequestContents = structuredClone(compressedHistory);
+      const compressSpy = vi
+        .spyOn(ChatCompressionService.prototype, 'compress')
+        .mockResolvedValueOnce({
+          newHistory: null,
+          info: {
+            originalTokenCount: 0,
+            newTokenCount: 0,
+            compressionStatus: CompressionStatus.NOOP,
+          },
+        })
+        .mockResolvedValueOnce({
+          newHistory: compressedHistory,
+          info: {
+            originalTokenCount: 135_000,
+            newTokenCount: 40_000,
+            compressionStatus: CompressionStatus.COMPRESSED,
+          },
+        });
+      vi.mocked(mockContentGenerator.generateContentStream)
+        .mockRejectedValueOnce(
+          new Error(
+            "This model's maximum context length is 128000 tokens. However, your messages resulted in 135000 tokens.",
+          ),
+        )
+        .mockResolvedValueOnce(makeStreamResponse('answer after compact'));
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'latest' },
+        'prompt-id-reactive-compact',
+      );
+
+      const events: StreamEvent[] = [];
+      for await (const event of stream) {
+        events.push(event);
+      }
+
+      expect(compressSpy).toHaveBeenCalledTimes(2);
+      expect(compressSpy.mock.calls[1][1].force).toBe(true);
+      expect(compressSpy.mock.calls[1][1].trigger).toBe('auto');
+      expect(compressSpy.mock.calls[1][1].originalTokenCount).toBe(135_000);
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        2,
+      );
+
+      const secondRequest = vi.mocked(
+        mockContentGenerator.generateContentStream,
+      ).mock.calls[1]![0];
+      expect(secondRequest.contents).toEqual(expectedRequestContents);
+      expect(events[0]?.type).toBe(StreamEventType.COMPRESSED);
+      expect(events[1]?.type).toBe(StreamEventType.RETRY);
+      expect(events[1]).not.toHaveProperty('retryInfo');
+      expect(
+        events.some(
+          (event) =>
+            event.type === StreamEventType.CHUNK &&
+            event.value.candidates?.[0]?.content?.parts?.[0]?.text ===
+              'answer after compact',
+        ),
+      ).toBe(true);
+    });
+
+    it('does not attempt reactive compression more than once per send', async () => {
+      const compressedHistory: Content[] = [
+        { role: 'user', parts: [{ text: 'summary' }] },
+        { role: 'model', parts: [{ text: 'ack' }] },
+      ];
+      const secondOverflow = new Error(
+        'prompt is too long: 140000 tokens > 128000 maximum',
+      );
+      const compressSpy = vi
+        .spyOn(ChatCompressionService.prototype, 'compress')
+        .mockResolvedValueOnce({
+          newHistory: null,
+          info: {
+            originalTokenCount: 0,
+            newTokenCount: 0,
+            compressionStatus: CompressionStatus.NOOP,
+          },
+        })
+        .mockResolvedValueOnce({
+          newHistory: compressedHistory,
+          info: {
+            originalTokenCount: 135_000,
+            newTokenCount: 40_000,
+            compressionStatus: CompressionStatus.COMPRESSED,
+          },
+        });
+      vi.mocked(mockContentGenerator.generateContentStream)
+        .mockRejectedValueOnce(
+          new Error('prompt is too long: 135000 tokens > 128000 maximum'),
+        )
+        .mockRejectedValueOnce(secondOverflow);
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'latest' },
+        'prompt-id-reactive-once',
+      );
+
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            /* consume */
+          }
+        })(),
+      ).rejects.toThrow(secondOverflow);
+
+      expect(compressSpy).toHaveBeenCalledTimes(2);
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        2,
+      );
+    });
+
+    it('does not emit a duplicate RETRY after reactive compression follows another retry', async () => {
+      vi.useFakeTimers();
+      try {
+        const compressedHistory: Content[] = [
+          { role: 'user', parts: [{ text: 'summary' }] },
+          { role: 'model', parts: [{ text: 'ack' }] },
+          { role: 'user', parts: [{ text: 'latest' }] },
+        ];
+        vi.spyOn(ChatCompressionService.prototype, 'compress')
+          .mockResolvedValueOnce({
+            newHistory: null,
+            info: {
+              originalTokenCount: 0,
+              newTokenCount: 0,
+              compressionStatus: CompressionStatus.NOOP,
+            },
+          })
+          .mockResolvedValueOnce({
+            newHistory: compressedHistory,
+            info: {
+              originalTokenCount: 135_000,
+              newTokenCount: 40_000,
+              compressionStatus: CompressionStatus.COMPRESSED,
+            },
+          });
+        vi.mocked(mockContentGenerator.generateContentStream)
+          .mockResolvedValueOnce(
+            (async function* () {
+              yield {
+                candidates: [{ content: { parts: [{ text: '' }] } }],
+              } as unknown as GenerateContentResponse;
+            })(),
+          )
+          .mockRejectedValueOnce(
+            new Error('prompt is too long: 135000 tokens > 128000 maximum'),
+          )
+          .mockResolvedValueOnce(makeStreamResponse('answer after compact'));
+
+        const stream = await chat.sendMessageStream(
+          'test-model',
+          { message: 'latest' },
+          'prompt-id-reactive-after-invalid-stream',
+        );
+        const events = await collectStreamWithFakeTimers(stream);
+        const eventTypes = events.map((event) => event.type);
+        const compressedIndex = eventTypes.indexOf(StreamEventType.COMPRESSED);
+
+        expect(compressedIndex).toBeGreaterThanOrEqual(0);
+        expect(eventTypes.slice(compressedIndex)).toEqual([
+          StreamEventType.COMPRESSED,
+          StreamEventType.RETRY,
+          StreamEventType.CHUNK,
+        ]);
+        expect(
+          mockContentGenerator.generateContentStream,
+        ).toHaveBeenCalledTimes(3);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('surfaces the original context overflow when reactive compression is a NOOP', async () => {
+      const overflow = new Error(
+        'prompt is too long: 135000 tokens > 128000 maximum',
+      );
+      const compressSpy = vi
+        .spyOn(ChatCompressionService.prototype, 'compress')
+        .mockResolvedValueOnce({
+          newHistory: null,
+          info: {
+            originalTokenCount: 0,
+            newTokenCount: 0,
+            compressionStatus: CompressionStatus.NOOP,
+          },
+        })
+        .mockResolvedValueOnce({
+          newHistory: null,
+          info: {
+            originalTokenCount: 135_000,
+            newTokenCount: 135_000,
+            compressionStatus: CompressionStatus.NOOP,
+          },
+        });
+      vi.mocked(mockContentGenerator.generateContentStream).mockRejectedValue(
+        overflow,
+      );
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'latest' },
+        'prompt-id-reactive-noop',
+      );
+
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            /* consume */
+          }
+        })(),
+      ).rejects.toThrow(overflow);
+
+      expect(compressSpy).toHaveBeenCalledTimes(2);
+      expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
+        1,
+      );
+    });
+
+    it('releases the send-lock when reactive compression throws', async () => {
+      const overflow = new Error(
+        'prompt is too long: 135000 tokens > 128000 maximum',
+      );
+      const compressSpy = vi
+        .spyOn(ChatCompressionService.prototype, 'compress')
+        .mockResolvedValueOnce({
+          newHistory: null,
+          info: {
+            originalTokenCount: 0,
+            newTokenCount: 0,
+            compressionStatus: CompressionStatus.NOOP,
+          },
+        })
+        .mockRejectedValueOnce(new Error('compression failed'))
+        .mockResolvedValueOnce({
+          newHistory: null,
+          info: {
+            originalTokenCount: 0,
+            newTokenCount: 0,
+            compressionStatus: CompressionStatus.NOOP,
+          },
+        });
+      vi.mocked(mockContentGenerator.generateContentStream)
+        .mockRejectedValueOnce(overflow)
+        .mockResolvedValueOnce(makeStreamResponse('next request ok'));
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'latest' },
+        'prompt-id-reactive-throws',
+      );
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            /* consume */
+          }
+        })(),
+      ).rejects.toThrow(overflow);
+
+      const nextStream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'next' },
+        'prompt-id-after-reactive-throws',
+      );
+      const events: StreamEvent[] = [];
+      for await (const event of nextStream) {
+        events.push(event);
+      }
+
+      expect(compressSpy).toHaveBeenCalledTimes(3);
+      expect(
+        events.some(
+          (event) =>
+            event.type === StreamEventType.CHUNK &&
+            event.value.candidates?.[0]?.content?.parts?.[0]?.text ===
+              'next request ok',
+        ),
+      ).toBe(true);
+    });
   });
 
   describe('addHistory', () => {

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -18,7 +18,7 @@ import type {
 } from '@google/genai';
 import { createUserContent, FinishReason } from '@google/genai';
 import { retryWithBackoff, isUnattendedMode } from '../utils/retry.js';
-import { getErrorStatus } from '../utils/errors.js';
+import { getErrorStatus, isAbortError } from '../utils/errors.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { parseAndFormatApiError } from '../utils/errorParsing.js';
 import { isRateLimitError, type RetryInfo } from '../utils/rateLimit.js';
@@ -31,13 +31,17 @@ import {
   logContentRetryFailure,
 } from '../telemetry/loggers.js';
 import { type ChatRecordingService } from '../services/chatRecordingService.js';
-import { ChatCompressionService } from '../services/chatCompressionService.js';
+import {
+  ChatCompressionService,
+  type CompactTrigger,
+} from '../services/chatCompressionService.js';
 import {
   ContentRetryEvent,
   ContentRetryFailureEvent,
 } from '../telemetry/types.js';
 import type { UiTelemetryService } from '../telemetry/uiTelemetry.js';
 import { type ChatCompressionInfo, CompressionStatus } from './turn.js';
+import { getContextLengthExceededInfo } from '../utils/contextLengthError.js';
 
 const debugLogger = createDebugLogger('QWEN_CODE_CHAT');
 
@@ -74,6 +78,11 @@ interface ContentRetryOptions {
   maxAttempts: number;
   /** The base delay in milliseconds for linear backoff. */
   initialDelayMs: number;
+}
+
+interface TryCompressOptions {
+  originalTokenCountOverride?: number;
+  trigger?: CompactTrigger;
 }
 
 const INVALID_CONTENT_RETRY_OPTIONS: ContentRetryOptions = {
@@ -381,6 +390,7 @@ export class GeminiChat {
     model: string,
     force = false,
     signal?: AbortSignal,
+    options?: TryCompressOptions,
   ): Promise<ChatCompressionInfo> {
     const service = new ChatCompressionService();
     const { newHistory, info } = await service.compress(this, {
@@ -389,7 +399,9 @@ export class GeminiChat {
       model,
       config: this.config,
       hasFailedCompressionAttempt: this.hasFailedCompressionAttempt,
-      originalTokenCount: this.lastPromptTokenCount,
+      originalTokenCount:
+        options?.originalTokenCountOverride ?? this.lastPromptTokenCount,
+      trigger: options?.trigger,
       signal,
     });
 
@@ -495,7 +507,7 @@ export class GeminiChat {
 
     // Add user content to history ONCE before any attempts.
     this.history.push(userContent);
-    const requestContents = this.getHistory(true);
+    let requestContents = this.getHistory(true);
 
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
@@ -518,6 +530,8 @@ export class GeminiChat {
         let lastError: unknown = new Error('Request failed after all retries.');
         let rateLimitRetryCount = 0;
         let invalidStreamRetryCount = 0;
+        let reactiveCompressionAttempted = false;
+        let suppressNextRetryEvent = false;
 
         // Read per-config overrides; fall back to built-in defaults.
         const cgConfig = self.config.getContentGeneratorConfig();
@@ -542,7 +556,9 @@ export class GeminiChat {
           attempt++
         ) {
           try {
-            if (
+            if (suppressNextRetryEvent) {
+              suppressNextRetryEvent = false;
+            } else if (
               attempt > 0 ||
               rateLimitRetryCount > 0 ||
               invalidStreamRetryCount > 0
@@ -602,6 +618,67 @@ export class GeminiChat {
               attempt--;
               await delayPromise;
               continue;
+            }
+
+            const contextOverflow = getContextLengthExceededInfo(error);
+            if (contextOverflow.isExceeded) {
+              if (!reactiveCompressionAttempted) {
+                reactiveCompressionAttempted = true;
+                debugLogger.warn(
+                  'Context length exceeded; attempting reactive compression.',
+                );
+                try {
+                  const reactiveInfo = await self.tryCompress(
+                    prompt_id,
+                    model,
+                    true,
+                    params.config?.abortSignal,
+                    {
+                      originalTokenCountOverride: contextOverflow.actualTokens,
+                      trigger: 'auto',
+                    },
+                  );
+
+                  if (
+                    reactiveInfo.compressionStatus ===
+                    CompressionStatus.COMPRESSED
+                  ) {
+                    requestContents = self.getHistory(true);
+                    debugLogger.info(
+                      `Reactive compression succeeded: ` +
+                        `${reactiveInfo.originalTokenCount} -> ` +
+                        `${reactiveInfo.newTokenCount} tokens.`,
+                    );
+                    yield {
+                      type: StreamEventType.COMPRESSED,
+                      info: reactiveInfo,
+                    };
+                    yield { type: StreamEventType.RETRY };
+                    suppressNextRetryEvent = true;
+                    // Do not count reactive compression against the content
+                    // validation retry budget.
+                    attempt--;
+                    continue;
+                  }
+
+                  debugLogger.warn(
+                    `Reactive compression did not recover context overflow: ` +
+                      `status=${reactiveInfo.compressionStatus}.`,
+                  );
+                } catch (compressionError) {
+                  if (
+                    params.config?.abortSignal?.aborted ||
+                    isAbortError(compressionError)
+                  ) {
+                    throw compressionError;
+                  }
+                  debugLogger.warn(
+                    'Reactive compression failed.',
+                    compressionError,
+                  );
+                }
+              }
+              break;
             }
 
             // Transient stream anomalies (NO_FINISH_REASON / NO_RESPONSE_TEXT):

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -23,7 +23,11 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 import { parseAndFormatApiError } from '../utils/errorParsing.js';
 import { isRateLimitError, type RetryInfo } from '../utils/rateLimit.js';
 import type { Config } from '../config/config.js';
-import { ESCALATED_MAX_TOKENS, tokenLimit } from './tokenLimits.js';
+import {
+  DEFAULT_TOKEN_LIMIT,
+  ESCALATED_MAX_TOKENS,
+  tokenLimit,
+} from './tokenLimits.js';
 import { hasCycleInSchema } from '../tools/tools.js';
 import type { StructuredError } from './turn.js';
 import {
@@ -624,6 +628,11 @@ export class GeminiChat {
             if (contextOverflow.isExceeded) {
               if (!reactiveCompressionAttempted) {
                 reactiveCompressionAttempted = true;
+                const reactiveOriginalTokenCount =
+                  contextOverflow.actualTokens ??
+                  contextOverflow.limitTokens ??
+                  self.config.getContentGeneratorConfig()?.contextWindowSize ??
+                  DEFAULT_TOKEN_LIMIT;
                 debugLogger.warn(
                   'Context length exceeded; attempting reactive compression.',
                 );
@@ -634,7 +643,7 @@ export class GeminiChat {
                     true,
                     params.config?.abortSignal,
                     {
-                      originalTokenCountOverride: contextOverflow.actualTokens,
+                      originalTokenCountOverride: reactiveOriginalTokenCount,
                       trigger: 'auto',
                     },
                   );
@@ -677,6 +686,11 @@ export class GeminiChat {
                     compressionError,
                   );
                 }
+              } else {
+                debugLogger.warn(
+                  'Reactive compression already attempted; ' +
+                    'propagating the context overflow error to caller.',
+                );
               }
               break;
             }

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -49,6 +49,8 @@ export const MIN_COMPRESSION_FRACTION = 0.05;
  */
 export const TOOL_ROUND_RETAIN_COUNT = 2;
 
+export type CompactTrigger = 'manual' | 'auto';
+
 const hasFunctionCall = (content: Content | undefined): boolean =>
   !!content?.parts?.some((part) => !!part.functionCall);
 
@@ -162,6 +164,12 @@ export interface CompressOptions {
    * the service does not read or write any global telemetry.
    */
   originalTokenCount: number;
+  /**
+   * Hook trigger to report for this compression. `force=true` bypasses the
+   * threshold gate but does not always mean the user manually requested
+   * compaction; reactive overflow recovery is forced but still automatic.
+   */
+  trigger?: CompactTrigger;
   signal?: AbortSignal;
 }
 
@@ -177,8 +185,10 @@ export class ChatCompressionService {
       config,
       hasFailedCompressionAttempt,
       originalTokenCount,
+      trigger,
       signal,
     } = opts;
+    const compactTrigger = trigger ?? (force ? 'manual' : 'auto');
     const threshold =
       config.getChatCompression()?.contextPercentageThreshold ??
       COMPRESSION_TOKEN_THRESHOLD;
@@ -229,9 +239,12 @@ export class ChatCompressionService {
     // Fire PreCompact hook before compression begins
     const hookSystem = config.getHookSystem();
     if (hookSystem) {
-      const trigger = force ? PreCompactTrigger.Manual : PreCompactTrigger.Auto;
+      const preCompactTrigger =
+        compactTrigger === 'manual'
+          ? PreCompactTrigger.Manual
+          : PreCompactTrigger.Auto;
       try {
-        await hookSystem.firePreCompactEvent(trigger, '', signal);
+        await hookSystem.firePreCompactEvent(preCompactTrigger, '', signal);
       } catch (err) {
         config.getDebugLogger().warn(`PreCompact hook failed: ${err}`);
       }
@@ -456,9 +469,10 @@ export class ChatCompressionService {
 
       // Fire PostCompact event after successful compression
       try {
-        const postCompactTrigger = force
-          ? PostCompactTrigger.Manual
-          : PostCompactTrigger.Auto;
+        const postCompactTrigger =
+          compactTrigger === 'manual'
+            ? PostCompactTrigger.Manual
+            : PostCompactTrigger.Auto;
         await config
           .getHookSystem()
           ?.firePostCompactEvent(postCompactTrigger, summary, signal);

--- a/packages/core/src/utils/contextLengthError.test.ts
+++ b/packages/core/src/utils/contextLengthError.test.ts
@@ -61,6 +61,16 @@ describe('contextLengthError', () => {
     expect(info.limitTokens).toBe(128000);
   });
 
+  it('parses maximum context length limits without actual token counts', () => {
+    const info = getContextLengthExceededInfo(
+      new Error("This model's maximum context length is 128000 tokens."),
+    );
+
+    expect(info.isExceeded).toBe(true);
+    expect(info.actualTokens).toBeUndefined();
+    expect(info.limitTokens).toBe(128000);
+  });
+
   it('extracts nested JSON error messages from strings', () => {
     const info = getContextLengthExceededInfo(
       new Error(
@@ -84,5 +94,26 @@ describe('contextLengthError', () => {
 
     expect(info.isExceeded).toBe(true);
     expect(info.message).toContain('Input token length is too long');
+  });
+
+  it('does not match object keys as context overflow text', () => {
+    const info = getContextLengthExceededInfo({
+      context: 'request body',
+      detail: 'tokens are available',
+      status: 'exceeded',
+    });
+
+    expect(info.isExceeded).toBe(false);
+    expect(info.message).not.toContain('context');
+    expect(info.message).toContain('tokens are available');
+  });
+
+  it('does not match broad token wording across separate fragments', () => {
+    const info = getContextLengthExceededInfo({
+      message: 'context window check',
+      detail: 'tokens exceeded by policy wording',
+    });
+
+    expect(info.isExceeded).toBe(false);
   });
 });

--- a/packages/core/src/utils/contextLengthError.test.ts
+++ b/packages/core/src/utils/contextLengthError.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  getContextLengthExceededInfo,
+  isContextLengthExceededError,
+} from './contextLengthError.js';
+
+describe('contextLengthError', () => {
+  it.each([
+    "This model's maximum context length is 128000 tokens. However, your messages resulted in 135000 tokens.",
+    'context_length_exceeded',
+    'prompt is too long: 137500 tokens > 135000 maximum',
+    'Range of input length should be [1, 30000]',
+    'Input token length is too long',
+    'The input token count (127234) exceeds the maximum number of tokens allowed (100000).',
+    '{"error":{"code":"context_length_exceeded","message":"too many tokens in prompt"}}',
+  ])('matches context overflow: %s', (message) => {
+    expect(isContextLengthExceededError(new Error(message))).toBe(true);
+  });
+
+  it.each([
+    'rate limit exceeded',
+    'Throttling: TPM(1/1)',
+    'connection timeout',
+    'finishReason: MAX_TOKENS',
+    'max_tokens',
+    'Request failed: maximum schema depth exceeded',
+    'Request contains an invalid argument',
+    'context deadline exceeded',
+    'deadline exceeded',
+    'Request timeout after 60s. Try reducing input length or increasing timeout in config.',
+    'connection timed out while waiting for response',
+  ])('does not match unrelated errors: %s', (message) => {
+    expect(isContextLengthExceededError(new Error(message))).toBe(false);
+  });
+
+  it('parses prompt-too-long actual and limit token counts', () => {
+    const info = getContextLengthExceededInfo(
+      new Error('prompt is too long: 137500 tokens > 135000 maximum'),
+    );
+
+    expect(info.isExceeded).toBe(true);
+    expect(info.actualTokens).toBe(137500);
+    expect(info.limitTokens).toBe(135000);
+  });
+
+  it('parses OpenAI-style maximum context length token counts', () => {
+    const info = getContextLengthExceededInfo(
+      new Error(
+        "This model's maximum context length is 128000 tokens. However, your messages resulted in 135000 tokens.",
+      ),
+    );
+
+    expect(info.isExceeded).toBe(true);
+    expect(info.actualTokens).toBe(135000);
+    expect(info.limitTokens).toBe(128000);
+  });
+
+  it('extracts nested JSON error messages from strings', () => {
+    const info = getContextLengthExceededInfo(
+      new Error(
+        'HTTP 400 {"error":{"code":"context_length_exceeded","message":"prompt is too long: 137500 tokens > 135000 maximum"}}',
+      ),
+    );
+
+    expect(info.isExceeded).toBe(true);
+    expect(info.actualTokens).toBe(137500);
+    expect(info.limitTokens).toBe(135000);
+  });
+
+  it('extracts nested error object messages', () => {
+    const info = getContextLengthExceededInfo({
+      status: 400,
+      error: {
+        code: 'BadRequest',
+        message: 'Input token length is too long',
+      },
+    });
+
+    expect(info.isExceeded).toBe(true);
+    expect(info.message).toContain('Input token length is too long');
+  });
+});

--- a/packages/core/src/utils/contextLengthError.ts
+++ b/packages/core/src/utils/contextLengthError.ts
@@ -1,0 +1,175 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface ContextLengthExceededInfo {
+  isExceeded: boolean;
+  message: string;
+  actualTokens?: number;
+  limitTokens?: number;
+}
+
+const MAX_COLLECT_DEPTH = 4;
+
+const TIMEOUT_PATTERNS = [
+  /\bcontext deadline exceeded\b/i,
+  /\bdeadline exceeded\b/i,
+  /\b(?:request|connection|read|context)\s+timed out\b/i,
+  /\b(?:request|connection|read|context)\s+timeout\b/i,
+  /\b(?:timeout|timed out)\s+(?:after|while|during)\b/i,
+];
+
+const CONTEXT_LENGTH_PATTERNS = [
+  /\bcontext[_\s-]?length[_\s-]?exceeded\b/i,
+  /\bmaximum context length\b/i,
+  /\bprompt\s+(?:is\s+)?too long\b/i,
+  /\binput\s+(?:token\s+)?(?:count\s+|length\s+)?(?:is\s+)?too long\b/i,
+  /\brange of input length should be\b/i,
+  /\btoo many tokens\b/i,
+  /\btokens?\s*>\s*[\d,]+\s*(?:maximum|max|limit)\b/i,
+  /\b(?:input|prompt|messages?|context)\b[\s\S]{0,120}\btokens?\b[\s\S]{0,120}\bexceed(?:s|ed|ing)?\b/i,
+];
+
+function parseInteger(value: string): number {
+  return Number.parseInt(value.replace(/,/g, ''), 10);
+}
+
+function parseTokenCounts(text: string): {
+  actualTokens?: number;
+  limitTokens?: number;
+} {
+  const greaterThanMatch = text.match(/(\d[\d,]*)\s*tokens?\s*>\s*(\d[\d,]*)/i);
+  if (greaterThanMatch) {
+    return {
+      actualTokens: parseInteger(greaterThanMatch[1]!),
+      limitTokens: parseInteger(greaterThanMatch[2]!),
+    };
+  }
+
+  const openAiMatch = text.match(
+    /maximum context length is\s*(\d[\d,]*)\s*tokens?[\s\S]*?(?:resulted in|requested|used)\s*(\d[\d,]*)\s*tokens?/i,
+  );
+  if (openAiMatch) {
+    return {
+      actualTokens: parseInteger(openAiMatch[2]!),
+      limitTokens: parseInteger(openAiMatch[1]!),
+    };
+  }
+
+  const inputExceedsMatch = text.match(
+    /input\s+token\s+(?:count|length)[^\d]*(\d[\d,]*)[\s\S]*?exceed(?:s|ed)?[\s\S]*?(?:maximum|limit)[^\d]*(\d[\d,]*)/i,
+  );
+  if (inputExceedsMatch) {
+    return {
+      actualTokens: parseInteger(inputExceedsMatch[1]!),
+      limitTokens: parseInteger(inputExceedsMatch[2]!),
+    };
+  }
+
+  return {};
+}
+
+function tryParseEmbeddedJson(text: string): unknown | undefined {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+    try {
+      return JSON.parse(trimmed) as unknown;
+    } catch {
+      // Fall through to embedded-object parsing.
+    }
+  }
+
+  const start = text.indexOf('{');
+  const end = text.lastIndexOf('}');
+  if (start === -1 || end <= start) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(text.slice(start, end + 1)) as unknown;
+  } catch {
+    return undefined;
+  }
+}
+
+function collectStrings(
+  value: unknown,
+  seen: Set<object>,
+  depth = 0,
+): string[] {
+  if (depth > MAX_COLLECT_DEPTH || value === null || value === undefined) {
+    return [];
+  }
+
+  if (typeof value === 'string') {
+    const parsed = tryParseEmbeddedJson(value);
+    if (parsed === undefined) {
+      return [value];
+    }
+    return [value, ...collectStrings(parsed, seen, depth + 1)];
+  }
+
+  if (typeof value === 'number' || typeof value === 'boolean') {
+    return [String(value)];
+  }
+
+  if (typeof value !== 'object') {
+    return [];
+  }
+
+  if (seen.has(value)) {
+    return [];
+  }
+  seen.add(value);
+
+  const strings: string[] = [];
+  if (value instanceof Error) {
+    strings.push(value.name, value.message);
+    strings.push(...collectStrings(value.cause, seen, depth + 1));
+  }
+
+  for (const [key, nested] of Object.entries(value)) {
+    strings.push(key);
+    strings.push(...collectStrings(nested, seen, depth + 1));
+  }
+
+  return strings;
+}
+
+function uniqueNonEmpty(values: string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) {
+      continue;
+    }
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+export function getContextLengthExceededInfo(
+  error: unknown,
+): ContextLengthExceededInfo {
+  const fragments = uniqueNonEmpty(collectStrings(error, new Set<object>()));
+  const message = fragments.join('\n');
+  const isTimeout = TIMEOUT_PATTERNS.some((pattern) => pattern.test(message));
+  const isExceeded =
+    !isTimeout &&
+    CONTEXT_LENGTH_PATTERNS.some((pattern) => pattern.test(message));
+  const counts = isExceeded ? parseTokenCounts(message) : {};
+
+  return {
+    isExceeded,
+    message,
+    ...counts,
+  };
+}
+
+export function isContextLengthExceededError(error: unknown): boolean {
+  return getContextLengthExceededInfo(error).isExceeded;
+}

--- a/packages/core/src/utils/contextLengthError.ts
+++ b/packages/core/src/utils/contextLengthError.ts
@@ -29,7 +29,7 @@ const CONTEXT_LENGTH_PATTERNS = [
   /\brange of input length should be\b/i,
   /\btoo many tokens\b/i,
   /\btokens?\s*>\s*[\d,]+\s*(?:maximum|max|limit)\b/i,
-  /\b(?:input|prompt|messages?|context)\b[\s\S]{0,120}\btokens?\b[\s\S]{0,120}\bexceed(?:s|ed|ing)?\b/i,
+  /\b(?:input|prompt|messages?|context)\b[^\n]{0,120}\btokens?\b[^\n]{0,120}\bexceed(?:s|ed|ing)?\b/i,
 ];
 
 function parseInteger(value: string): number {
@@ -55,6 +55,15 @@ function parseTokenCounts(text: string): {
     return {
       actualTokens: parseInteger(openAiMatch[2]!),
       limitTokens: parseInteger(openAiMatch[1]!),
+    };
+  }
+
+  const maxContextLimitMatch = text.match(
+    /maximum context length is\s*(\d[\d,]*)\s*tokens?/i,
+  );
+  if (maxContextLimitMatch) {
+    return {
+      limitTokens: parseInteger(maxContextLimitMatch[1]!),
     };
   }
 
@@ -130,8 +139,7 @@ function collectStrings(
     strings.push(...collectStrings(value.cause, seen, depth + 1));
   }
 
-  for (const [key, nested] of Object.entries(value)) {
-    strings.push(key);
+  for (const [, nested] of Object.entries(value)) {
     strings.push(...collectStrings(nested, seen, depth + 1));
   }
 
@@ -160,7 +168,9 @@ export function getContextLengthExceededInfo(
   const isTimeout = TIMEOUT_PATTERNS.some((pattern) => pattern.test(message));
   const isExceeded =
     !isTimeout &&
-    CONTEXT_LENGTH_PATTERNS.some((pattern) => pattern.test(message));
+    fragments.some((fragment) =>
+      CONTEXT_LENGTH_PATTERNS.some((pattern) => pattern.test(fragment)),
+    );
   const counts = isExceeded ? parseTokenCounts(message) : {};
 
   return {


### PR DESCRIPTION
## Summary

- What changed: Added a recovery path that recognizes provider context-window overflow errors, compresses the current conversation, and retries the failed turn once with the compressed context.
- Why it changed: Sudden prompt growth or provider-side context limits can still reject a request even when proactive compression did not run first. This keeps long sessions recoverable instead of failing immediately.
- Reviewer focus: Please check the error classification boundaries, the single-retry guard, and the interaction with existing retry and compression behavior.

## Validation

- Automated commands run in local tmux session `reactive-compression-verify-211430`:
  ```bash
  cd packages/core && npx vitest run src/utils/contextLengthError.test.ts src/core/geminiChat.test.ts
  cd packages/core && npm run typecheck
  npm run build && npm run typecheck
  ```
- Automated test inputs: Unit tests cover OpenAI-style maximum-context errors, `context_length_exceeded`, prompt-too-long token-count errors, DashScope input-length errors, timeout/deadline negatives, compression success, compression NOOP, compression exceptions, repeated overflow after retry, and avoiding duplicate retry events after reactive compression.
- Automated observed result: Focused tests passed: 84 tests across the classifier and chat retry suites. Core typecheck passed. Root build and workspace typecheck passed.
- Quickest reviewer verification path:
  ```bash
  cd packages/core && npx vitest run src/utils/contextLengthError.test.ts src/core/geminiChat.test.ts
  ```

### Interactive tmux verification

- Goal: Verify the user-visible reactive compression path in the interactive CLI, including provider overflow detection, compression, one retry, and final streamed output.
- Setup: Started a local mock OpenAI-compatible server in tmux. The server returns `context_length_exceeded` for the first streaming chat completion, returns a non-stream compression/utility summary for non-stream requests, then returns a streamed assistant answer for the retried request.
- CLI command:
  ```bash
  npm run dev -- --auth-type openai --model mock-model --openai-api-key dummy --openai-base-url http://127.0.0.1:8788/v1
  ```
- User input sent in the interactive CLI:
  ```text
  please answer OK
  ```
- Expected server sequence:
  ```text
  1. Optional non-stream utility request from startup/background work.
  2. First stream request returns context_length_exceeded.
  3. Non-stream compression request returns compressed summary.
  4. Second stream request returns final assistant output.
  ```
- Observed server sequence:
  ```text
  streamCalls=1 -> returning context_length_exceeded
  nonStreamCalls=2 -> returning compression/utility summary
  streamCalls=2 -> returning final streamed answer
  ```
- Expected CLI output: A compression notice is shown, then the original user turn completes after the automatic retry.
- Observed CLI output:
  ```text
  IMPORTANT: This conversation approached the input token limit for mock-model.
  A compressed context will be sent for future messages (compressed from: 135000 to 47000 tokens).

  OK after reactive compression
  ```
- Key server log excerpt:
  ```text
  reactive-test: mock OpenAI server listening on 8788
  {"event":"request","calls":2,"streamCalls":1,"nonStreamCalls":1,"stream":true,"messageCount":4}
  reactive-test: returning context_length_exceeded
  {"event":"request","calls":3,"streamCalls":1,"nonStreamCalls":2,"stream":false,"messageCount":4}
  reactive-test: returning compression/utility summary
  {"event":"request","calls":4,"streamCalls":2,"nonStreamCalls":2,"stream":true,"messageCount":4}
  reactive-test: returning final streamed answer
  ```
- Key CLI transcript excerpt:
  ```text
  > please answer OK

  IMPORTANT: This conversation approached the input token limit for
  mock-model. A compressed context will be sent for future messages
  (compressed from: 135000 to 47000 tokens).

  OK after reactive compression
  ```

## 人工验证
qwen-code截图
<img width="1479" height="736" alt="image" src="https://github.com/user-attachments/assets/25d1ea03-9403-43d2-865b-f7479db6aa82" />
server截图
<img width="1504" height="364" alt="image" src="https://github.com/user-attachments/assets/e916fa46-7a39-43e9-8c72-8b1079bedcc7" />


## Scope / Risk

- Main risk or tradeoff: Error text matching is provider-dependent, so the classifier intentionally prefers known context-window wording and excludes timeout/deadline wording to avoid mutating history for transport failures.
- Not covered / not validated: No live provider E2E was run against an actual oversized request; the interactive run used a local OpenAI-compatible mock server.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | N/A | ⚠️  |
| Podman   | ⚠️  | N/A | ⚠️  |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Validated on macOS in this worktree. Windows, Linux, Docker, Podman, and Seatbelt were not run locally.

## Linked Issues / Bugs

- None.
