### PR TITLE
feat(cli): searchable /resume picker with focus-aware modes

### DIFF
--- a/packages/cli/src/ui/components/SessionPicker.tsx
+++ b/packages/cli/src/ui/components/SessionPicker.tsx
@@ -163,9 +163,12 @@ export function SessionPicker(props: SessionPickerProps) {
 
   // Calculate box width (marginX={2})
   const boxWidth = width - 4;
-  // Calculate visible items (same heuristic as before)
-  // Reserved space: header (1), footer (1), separators (2), borders (2)
-  const reservedLines = 6;
+  // Calculate visible items.
+  // Reserved space: header (1), search row (1), footer (1), separators (2),
+  // borders (2). The search row is rendered as a thin "Press / to search"
+  // hint in list mode and a live query in search mode — same height in
+  // both, so the visible-item count doesn't shift between modes.
+  const reservedLines = 7;
   // Each item takes 2 lines (prompt + metadata) + 1 line margin between items
   const itemHeight = 3;
   const maxVisibleItems = Math.max(
@@ -234,6 +237,39 @@ export function SessionPicker(props: SessionPickerProps) {
               {t('(branch: {{branch}})', { branch: currentBranch })}
             </Text>
           )}
+          {picker.searchQuery !== '' && (
+            <Text color={theme.text.secondary}>
+              {' '}
+              {t('({{count}} matches)', {
+                count: String(picker.filteredSessions.length),
+              })}
+            </Text>
+          )}
+        </Box>
+
+        {/* Search row — three states share this row at constant height so
+            the visible-item count doesn't shift between them:
+              - search: "Search: <query>▌" (live editing, caret visible)
+              - list + non-empty query: "Filter: <query>" (read-only,
+                no caret — user has stopped typing but the filter sticks)
+              - list + empty query: "Press / to search" hint */}
+        <Box paddingX={1}>
+          {picker.isSearchActive ? (
+            <>
+              <Text color={theme.text.secondary}>{t('Search: ')}</Text>
+              <Text color={theme.text.primary}>
+                {picker.searchQuery}
+                <Text color={theme.text.secondary}>▌</Text>
+              </Text>
+            </>
+          ) : picker.searchQuery !== '' ? (
+            <>
+              <Text color={theme.text.secondary}>{t('Filter: ')}</Text>
+              <Text color={theme.text.primary}>{picker.searchQuery}</Text>
+            </>
+          ) : (
+            <Text color={theme.text.secondary}>{t('Press / to search')}</Text>
+          )}
         </Box>
 
         {/* Separator */}
@@ -252,11 +288,15 @@ export function SessionPicker(props: SessionPickerProps) {
           ) : picker.filteredSessions.length === 0 ? (
             <Box paddingY={1} justifyContent="center">
               <Text color={theme.text.secondary}>
-                {picker.filterByBranch
-                  ? t('No sessions found for branch "{{branch}}"', {
-                      branch: currentBranch ?? '',
+                {picker.searchQuery !== ''
+                  ? t('No sessions match "{{query}}"', {
+                      query: picker.searchQuery,
                     })
-                  : t('No sessions found')}
+                  : picker.filterByBranch
+                    ? t('No sessions found for branch "{{branch}}"', {
+                        branch: currentBranch ?? '',
+                      })
+                    : t('No sessions found')}
               </Text>
             </Box>
           ) : (
@@ -266,7 +306,10 @@ export function SessionPicker(props: SessionPickerProps) {
                 <SessionListItemView
                   key={session.sessionId}
                   session={session}
-                  isSelected={actualIndex === picker.selectedIndex}
+                  isSelected={
+                    !picker.isSearchActive &&
+                    actualIndex === picker.selectedIndex
+                  }
                   isFirst={visibleIndex === 0}
                   isLast={visibleIndex === picker.visibleSessions.length - 1}
                   showScrollUp={picker.showScrollUp}
@@ -288,25 +331,35 @@ export function SessionPicker(props: SessionPickerProps) {
         {/* Footer */}
         <Box paddingX={1}>
           <Box flexDirection="row">
-            {currentBranch && (
+            {picker.isSearchActive ? (
               <Text color={theme.text.secondary}>
-                <Text
-                  bold={picker.filterByBranch}
-                  color={picker.filterByBranch ? theme.text.accent : undefined}
-                >
-                  B
+                {t('Type to search · Enter to commit · Esc to clear')}
+              </Text>
+            ) : (
+              <>
+                {currentBranch && (
+                  <Text color={theme.text.secondary}>
+                    <Text
+                      bold={picker.filterByBranch}
+                      color={
+                        picker.filterByBranch ? theme.text.accent : undefined
+                      }
+                    >
+                      Ctrl+B
+                    </Text>
+                    {t(' to toggle branch · ')}
+                  </Text>
+                )}
+                {enablePreview && (
+                  <Text color={theme.text.secondary}>
+                    {t('Space to preview · ')}
+                  </Text>
+                )}
+                <Text color={theme.text.secondary}>
+                  {t('↑↓ to navigate · Type to search · Esc to cancel')}
                 </Text>
-                {t(' to toggle branch · ')}
-              </Text>
+              </>
             )}
-            {enablePreview && (
-              <Text color={theme.text.secondary}>
-                {t('Space to preview · ')}
-              </Text>
-            )}
-            <Text color={theme.text.secondary}>
-              {t('↑↓ to navigate · Esc to cancel')}
-            </Text>
           </Box>
         </Box>
       </Box>

--- a/packages/cli/src/ui/components/StandaloneSessionPicker.test.tsx
+++ b/packages/cli/src/ui/components/StandaloneSessionPicker.test.tsx
@@ -1236,6 +1236,13 @@ describe('SessionPicker', () => {
       // jumped past the first (highest-relevance) match. Now ↓
       // simply commits the focus transition; selectedIndex stays at
       // 0 (already reset by the query-change effect).
+      //
+      // Inter-key waits are 50ms (not the 30ms used elsewhere): on
+      // Windows runners the keypress → useEffect → render chain
+      // through `/login` + ARROW_DOWN + Enter consistently exceeded
+      // 30ms and dropped the Enter event — the spy never saw the
+      // selection. Tests in this file already use 50ms in similar
+      // multi-step sequences; align with that.
       const sessions = [
         createMockSession({
           sessionId: 'first-match',
@@ -1263,11 +1270,11 @@ describe('SessionPicker', () => {
 
       await wait(100);
       stdin.write('/login');
-      await wait(30);
+      await wait(50);
       stdin.write(ARROW_DOWN); // exit search → first match should be highlighted
-      await wait(30);
+      await wait(50);
       stdin.write('\r'); // Enter from list = select highlighted row
-      await wait(30);
+      await wait(50);
 
       expect(onSelect).toHaveBeenCalledWith('first-match');
     });

--- a/packages/cli/src/ui/components/StandaloneSessionPicker.test.tsx
+++ b/packages/cli/src/ui/components/StandaloneSessionPicker.test.tsx
@@ -26,6 +26,15 @@ vi.mock('@qwen-code/qwen-code-core', async () => {
   };
 });
 
+// Control byte sequences that ink-testing-library's stdin.write delivers as
+// modified key events. Pulled out so the tests don't bury invisible bytes
+// inside string literals.
+const CTRL_B = '';
+const ESC = '';
+const BACKSPACE = '';
+const ARROW_DOWN = '[B';
+const ARROW_UP = '[A';
+
 // Mock terminal size
 const mockTerminalSize = { columns: 80, rows: 24 };
 
@@ -186,7 +195,9 @@ describe('SessionPicker', () => {
   });
 
   describe('Branch Filtering', () => {
-    it('should filter by branch when B is pressed', async () => {
+    it('should filter by branch when Ctrl+B is pressed', async () => {
+      // Bare letter keys ('B', 'b', 'j', 'k', …) are reserved for the
+      // search query buffer. The branch toggle is Ctrl+B exclusively.
       const sessions = [
         createMockSession({
           sessionId: 's1',
@@ -229,8 +240,7 @@ describe('SessionPicker', () => {
       expect(output).toContain('Main branch');
       expect(output).toContain('Feature branch');
 
-      // Press B to filter by branch
-      stdin.write('B');
+      stdin.write(CTRL_B);
       await wait(50);
 
       output = lastFrame();
@@ -278,8 +288,7 @@ describe('SessionPicker', () => {
 
       await wait(100);
 
-      // Press B to filter by branch
-      stdin.write('B');
+      stdin.write(CTRL_B);
       await wait(50);
 
       const output = lastFrame();
@@ -330,52 +339,12 @@ describe('SessionPicker', () => {
       expect(output).toContain('First session');
 
       // Navigate down
-      stdin.write('\u001B[B'); // Down arrow
+      stdin.write(ARROW_DOWN); // Down arrow
       await wait(50);
 
       output = lastFrame();
       // Selection indicator should move
       expect(output).toBeDefined();
-    });
-
-    it('should navigate with vim keys (j/k)', async () => {
-      const sessions = [
-        createMockSession({
-          sessionId: 's1',
-          prompt: 'First',
-          messageCount: 1,
-        }),
-        createMockSession({
-          sessionId: 's2',
-          prompt: 'Second',
-          messageCount: 1,
-        }),
-      ];
-      const mockService = createMockSessionService(sessions);
-      const onSelect = vi.fn();
-      const onCancel = vi.fn();
-
-      const { stdin, unmount } = render(
-        <KeypressProvider kittyProtocolEnabled={false}>
-          <SessionPicker
-            sessionService={mockService as never}
-            onSelect={onSelect}
-            onCancel={onCancel}
-          />
-        </KeypressProvider>,
-      );
-
-      await wait(100);
-
-      // Navigate with j (down)
-      stdin.write('j');
-      await wait(50);
-
-      // Navigate with k (up)
-      stdin.write('k');
-      await wait(50);
-
-      unmount();
     });
 
     it('should select session on Enter', async () => {
@@ -430,11 +399,969 @@ describe('SessionPicker', () => {
       await wait(100);
 
       // Press Escape to cancel
-      stdin.write('\u001B');
+      stdin.write(ESC);
       await wait(50);
 
       expect(onCancel).toHaveBeenCalled();
       expect(onSelect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Search', () => {
+    it('substring filters across customTitle, prompt, and gitBranch', async () => {
+      const sessions = [
+        createMockSession({
+          sessionId: 's1',
+          prompt: 'completely unrelated',
+          customTitle: 'login bug investigation',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 's2',
+          prompt: 'review login flow',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 's3',
+          prompt: 'totally different',
+          gitBranch: 'feature/login-revamp',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 's4',
+          prompt: 'unrelated work',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={vi.fn()}
+            onCancel={vi.fn()}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+
+      // '/' enters search explicitly so the query starts fresh and
+      // shortcut letters in the term (none here) don't get reinterpreted.
+      stdin.write('/login');
+      await wait(50);
+
+      const output = lastFrame() ?? '';
+      // s1 matches via customTitle, s2 via prompt, s3 via gitBranch.
+      expect(output).toContain('login bug investigation');
+      expect(output).toContain('review login flow');
+      expect(output).toContain('feature/login-revamp');
+      // The non-matching session must drop out.
+      expect(output).not.toContain('unrelated work');
+      // The visible search row reflects the active query.
+      expect(output).toContain('Search:');
+    });
+
+    it('typing a non-shortcut char enters search mode implicitly', async () => {
+      // Letters that are not list-mode shortcuts (anything other than j,
+      // k, b, B, ' ', '/') seed the search query directly.
+      const sessions = [
+        createMockSession({
+          sessionId: 'a',
+          prompt: 'deploy review',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 'b',
+          // Picked so it shares no letters with the typed query 'dep'.
+          prompt: 'cluster setup',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={vi.fn()}
+            onCancel={vi.fn()}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      stdin.write('dep');
+      await wait(50);
+
+      const output = lastFrame() ?? '';
+      expect(output).toContain('Search:');
+      expect(output).toContain('deploy review');
+      expect(output).not.toContain('cluster setup');
+    });
+
+    it('list-mode j/k navigate the list', async () => {
+      // vim shortcuts stay live in list mode even though the rest of
+      // the alphabet seeds search.
+      const sessions = [
+        createMockSession({
+          sessionId: 's1',
+          prompt: 'first',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 's2',
+          prompt: 'second',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+      const onSelect = vi.fn();
+
+      const { stdin } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={onSelect}
+            onCancel={vi.fn()}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      stdin.write('j'); // selectedIndex 0 -> 1
+      await wait(30);
+      stdin.write('\r');
+      await wait(50);
+      expect(onSelect).toHaveBeenLastCalledWith('s2');
+
+      stdin.write('k'); // back to 0
+      await wait(30);
+      stdin.write('\r');
+      await wait(50);
+      expect(onSelect).toHaveBeenLastCalledWith('s1');
+    });
+
+    it("'b' seeds search; once searching, 'j' appends to the query", async () => {
+      // Lowercase letters that aren't list-mode shortcuts ('b' here)
+      // implicitly enter search. Once in search mode, j and k lose
+      // their nav meaning and behave as regular query characters so
+      // titles containing 'j' or 'k' can be searched.
+      const sessions = [
+        createMockSession({
+          sessionId: 's1',
+          prompt: 'bjorn config',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 's2',
+          prompt: 'bug investigation',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 's3',
+          prompt: 'unrelated',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={vi.fn()}
+            onCancel={vi.fn()}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      // 'b' implicitly enters search. Both s1 and s2 contain 'b'.
+      stdin.write('b');
+      await wait(30);
+      let output = lastFrame() ?? '';
+      expect(output).toContain('Search:');
+      expect(output).toContain('bjorn config');
+      expect(output).toContain('bug investigation');
+      expect(output).not.toContain('unrelated');
+
+      // 'j' inside search appends to the query → "bj" — only s1 still
+      // matches. If 'j' were still bound to nav we would see the same
+      // 'b'-filtered list (two matches), and selectedIndex would drift
+      // instead of the matches narrowing.
+      stdin.write('j');
+      await wait(50);
+      output = lastFrame() ?? '';
+      expect(output).toContain('bjorn config');
+      expect(output).not.toContain('bug investigation');
+    });
+
+    it('list-mode Space without preview enabled is a no-op', async () => {
+      // When preview is disabled, the Space-as-preview shortcut never
+      // fires; Space is also explicitly skipped from implicit search
+      // entry to keep leading whitespace out of the query.
+      const sessions = [
+        createMockSession({
+          sessionId: 's1',
+          prompt: 'first',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={vi.fn()}
+            onCancel={vi.fn()}
+            // No `enablePreview` here — preview is disabled, so Space is
+            // simply ignored by list mode (the search seed-skip rule
+            // also kicks in to keep leading whitespace out of the query).
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      stdin.write(' ');
+      await wait(50);
+
+      const output = lastFrame() ?? '';
+      expect(output).toContain('Press / to search');
+      expect(output).not.toContain('Search:');
+    });
+
+    it('Backspace edits the query; emptying it returns to list mode', async () => {
+      // Backspace is an edit op that, when it deletes the final char,
+      // also flips back to list mode so the shortcut keymap is
+      // immediately available again. Esc remains the explicit exit.
+      const sessions = [
+        createMockSession({
+          sessionId: 's1',
+          prompt: 'login bug',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 's2',
+          prompt: 'unrelated',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+      const onCancel = vi.fn();
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={vi.fn()}
+            onCancel={onCancel}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+
+      stdin.write('/logim');
+      await wait(30);
+      stdin.write(BACKSPACE);
+      await wait(30);
+      stdin.write('n');
+      await wait(50);
+
+      let output = lastFrame() ?? '';
+      expect(output).toContain('login bug');
+      expect(output).not.toContain('unrelated');
+
+      // First Esc: exit search back to list, do not cancel.
+      stdin.write(ESC);
+      await wait(30);
+      output = lastFrame() ?? '';
+      expect(output).toContain('login bug');
+      expect(output).toContain('unrelated');
+      expect(output).toContain('Press / to search');
+      expect(onCancel).not.toHaveBeenCalled();
+
+      // Second Esc: now actually cancels.
+      stdin.write(ESC);
+      await wait(30);
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it('Backspace in list mode does not spawn a search', async () => {
+      // Regression: Backspace's raw byte (DEL, 0x7F) used to slip past
+      // the printable-char filter and seed an implicit search with the
+      // literal DEL byte, producing a confusing 'No sessions match …'
+      // frame in list mode. List-mode Backspace must be inert.
+      const sessions = [
+        createMockSession({
+          sessionId: 's1',
+          prompt: 'first',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={vi.fn()}
+            onCancel={vi.fn()}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      stdin.write(BACKSPACE);
+      await wait(50);
+
+      const output = lastFrame() ?? '';
+      // Still in list mode — no search frame, no spurious empty match.
+      expect(output).toContain('Press / to search');
+      expect(output).not.toContain('Search:');
+      expect(output).not.toContain('No sessions match');
+      // The session list is still rendered untouched.
+      expect(output).toContain('first');
+    });
+
+    it('search mode suppresses the row highlight', async () => {
+      // The "›" selected-prefix and accent color belong to the row
+      // the user is about to act on. While they're still typing the
+      // query, no row should claim that affordance — the search input
+      // owns focus exclusively until ↑↓/Enter commits to the list.
+      const sessions = [
+        createMockSession({
+          sessionId: 's1',
+          prompt: 'login flow',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 's2',
+          prompt: 'login bug',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={vi.fn()}
+            onCancel={vi.fn()}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      // Sanity: in list mode the first row is highlighted with '› '.
+      let output = lastFrame() ?? '';
+      expect(output).toContain('› ');
+
+      // Enter search; the highlight should disappear.
+      stdin.write('/login');
+      await wait(50);
+      output = lastFrame() ?? '';
+      expect(output).toContain('Search:');
+      expect(output).not.toContain('› ');
+
+      // Commit (↓ or Enter) reinstates the highlight on the list.
+      stdin.write(ARROW_DOWN);
+      await wait(30);
+      output = lastFrame() ?? '';
+      expect(output).toContain('Filter:');
+      expect(output).toContain('› ');
+    });
+
+    it('Enter in search commits the filter; second Enter selects', async () => {
+      // Defensive UX: the user's typing reflex shouldn't accidentally
+      // resume a session. Pressing Enter while still in the search
+      // input commits the filter (drops to list, query preserved)
+      // and onSelect stays unfired. Only a deliberate second Enter
+      // from the list view actually resumes.
+      const sessions = [
+        createMockSession({
+          sessionId: 'first',
+          prompt: 'foo',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 'matching',
+          prompt: 'special-target',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+      const onSelect = vi.fn();
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={onSelect}
+            onCancel={vi.fn()}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      stdin.write('/special');
+      await wait(30);
+
+      // First Enter: search → list, query stays applied, no resume.
+      stdin.write('\r');
+      await wait(30);
+      expect(onSelect).not.toHaveBeenCalled();
+      const afterFirstEnter = lastFrame() ?? '';
+      expect(afterFirstEnter).toContain('Filter:');
+      expect(afterFirstEnter).toContain('special-target');
+
+      // Second Enter from list view selects the highlighted row.
+      stdin.write('\r');
+      await wait(30);
+      expect(onSelect).toHaveBeenCalledWith('matching');
+    });
+
+    it('Enter in search with no matches stays in search', async () => {
+      // Don't drop the user out of the search input on Enter when
+      // there's nothing to commit to — they're mid-typo and need
+      // to keep editing.
+      const sessions = [
+        createMockSession({
+          sessionId: 's1',
+          prompt: 'unrelated',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+      const onSelect = vi.fn();
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={onSelect}
+            onCancel={vi.fn()}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      stdin.write('/zzz'); // matches nothing
+      await wait(30);
+      stdin.write('\r');
+      await wait(30);
+
+      const output = lastFrame() ?? '';
+      expect(output).toContain('Search:');
+      expect(output).toContain('No sessions match');
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it('↑/↓ from search drops to list mode while keeping the filter', async () => {
+      // The post-narrow state: user types to filter, then arrows to
+      // pick a row. Once they navigate, the search frame goes away
+      // (no more caret, switches to "Filter:" indicator) but the
+      // query stays applied so the list remains narrowed and full
+      // list-mode shortcuts work on the highlighted row.
+      const sessions = [
+        createMockSession({
+          sessionId: 'a',
+          prompt: 'login flow review',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 'b',
+          prompt: 'login bug fix',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 'c',
+          prompt: 'unrelated',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={vi.fn()}
+            onCancel={vi.fn()}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      stdin.write('/login');
+      await wait(30);
+
+      let output = lastFrame() ?? '';
+      // In search mode: caret-bearing "Search:" row is visible.
+      expect(output).toContain('Search:');
+
+      stdin.write(ARROW_DOWN);
+      await wait(50);
+
+      output = lastFrame() ?? '';
+      // Now in list mode with filter preserved: the read-only
+      // "Filter:" indicator replaces "Search:", but the list is
+      // still narrowed to the two login matches.
+      expect(output).toContain('Filter:');
+      expect(output).not.toContain('Search:');
+      expect(output).toContain('login flow review');
+      expect(output).toContain('login bug fix');
+      expect(output).not.toContain('unrelated');
+    });
+
+    it('Space → preview works on the highlighted row in filtered-list', async () => {
+      // Once narrowed and out of search, Space should trigger the
+      // preview shortcut just like in the unfiltered list — proves
+      // the action is mode-independent.
+      const sessions = [
+        createMockSession({
+          sessionId: 'a',
+          prompt: 'login flow',
+          messageCount: 2,
+        }),
+        createMockSession({
+          sessionId: 'b',
+          prompt: 'unrelated',
+          messageCount: 2,
+        }),
+      ];
+      const service = createMockSessionService(sessions);
+      service.loadSession.mockResolvedValue({
+        conversation: { messages: [] },
+        filePath: '/x',
+        lastCompletedUuid: null,
+      });
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <ConfigContext.Provider
+            value={
+              {
+                getShouldUseNodePtyShell: () => false,
+                getIdeMode: () => false,
+                isTrustedFolder: () => false,
+              } as unknown as Config
+            }
+          >
+            <SettingsContext.Provider
+              value={
+                {
+                  merged: {},
+                } as unknown as LoadedSettings
+              }
+            >
+              <SessionPicker
+                sessionService={service as never}
+                onSelect={vi.fn()}
+                onCancel={vi.fn()}
+                enablePreview
+              />
+            </SettingsContext.Provider>
+          </ConfigContext.Provider>
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      stdin.write('/login');
+      await wait(30);
+      stdin.write(ARROW_DOWN); // exits search, cursor on filtered first item
+      await wait(30);
+      stdin.write(' '); // Space → preview
+      await wait(150);
+
+      const frame = lastFrame() ?? '';
+      // Preview frame shows session metadata (prompt, message count).
+      expect(frame).toContain('login flow');
+      // The filter row / list view is replaced by the preview, which
+      // does not render the "Search:" or "Filter:" rows.
+      expect(frame).not.toContain('Filter:');
+    });
+
+    it('Ctrl+B toggles branch in filtered-list', async () => {
+      // Branch toggle stays available after narrowing, so users can
+      // refine filter axes without losing their query.
+      const sessions = [
+        createMockSession({
+          sessionId: 'a',
+          gitBranch: 'main',
+          prompt: 'login',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 'b',
+          gitBranch: 'feature',
+          prompt: 'login on feature',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={vi.fn()}
+            onCancel={vi.fn()}
+            currentBranch="main"
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      stdin.write('/login');
+      await wait(30);
+      stdin.write(ARROW_DOWN); // exit search to filtered-list
+      await wait(30);
+
+      // Both still visible (filter='login' matches both).
+      let output = lastFrame() ?? '';
+      expect(output).toContain('login on feature');
+
+      stdin.write(CTRL_B);
+      await wait(50);
+
+      output = lastFrame() ?? '';
+      // Branch filter narrows to main; query still applied.
+      expect(output).toContain('Filter:');
+      expect(output).toContain('login');
+      expect(output).not.toContain('login on feature');
+    });
+
+    it('Esc in filtered-list clears the query first, then cancels', async () => {
+      // Two-stage Esc parity with search mode: pressing Esc once on
+      // the filtered list drops the query (returning the unfiltered
+      // list) while keeping the picker open; a second Esc finally
+      // cancels. Avoids an "I lost my filter AND closed the dialog"
+      // surprise from a single accidental keystroke.
+      const sessions = [
+        createMockSession({
+          sessionId: 'a',
+          prompt: 'login flow',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 'b',
+          prompt: 'unrelated',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+      const onCancel = vi.fn();
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={vi.fn()}
+            onCancel={onCancel}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      stdin.write('/login');
+      await wait(30);
+      stdin.write(ARROW_DOWN); // → filtered-list with q='login'
+      await wait(30);
+
+      let output = lastFrame() ?? '';
+      expect(output).toContain('Filter:');
+
+      // First Esc: drop the filter, stay open.
+      stdin.write(ESC);
+      await wait(30);
+      output = lastFrame() ?? '';
+      expect(output).toContain('Press / to search');
+      expect(output).toContain('login flow');
+      expect(output).toContain('unrelated');
+      expect(onCancel).not.toHaveBeenCalled();
+
+      // Second Esc: actually cancel.
+      stdin.write(ESC);
+      await wait(30);
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    it("'/' from filtered-list preserves the existing query", async () => {
+      // Re-focusing search via '/' must not throw away what the user
+      // already typed — they typically hit '/' when they want to
+      // tweak the filter, not start over. Esc is the explicit clear
+      // gesture (covered by the Backspace/Esc test above).
+      const sessions = [
+        createMockSession({
+          sessionId: 'a',
+          prompt: 'login flow',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 'b',
+          prompt: 'unrelated',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={vi.fn()}
+            onCancel={vi.fn()}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      stdin.write('/login');
+      await wait(30);
+      stdin.write(ARROW_DOWN); // exit to filtered-list
+      await wait(30);
+
+      // Re-press '/' from filtered-list: viewMode flips back to
+      // search but the query stays.
+      stdin.write('/');
+      await wait(30);
+
+      const output = lastFrame() ?? '';
+      expect(output).toContain('Search:');
+      expect(output).toContain('login');
+      // Filter is still applied — non-matches stay filtered out.
+      expect(output).not.toContain('unrelated');
+    });
+
+    it('↑ at top of unfiltered list also wraps into search', async () => {
+      // Same boundary-wrap pattern as the filtered case: a fresh
+      // picker (no query yet) lets the user kick off a search just
+      // by hitting ↑ from the first row, no '/' required.
+      const sessions = [
+        createMockSession({
+          sessionId: 's1',
+          prompt: 'first',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 's2',
+          prompt: 'second',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={vi.fn()}
+            onCancel={vi.fn()}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      // Already at index 0 from the initial render; ↑ wraps into search.
+      stdin.write(ARROW_UP);
+      await wait(50);
+
+      const output = lastFrame() ?? '';
+      expect(output).toContain('Search:');
+      // No query yet, so the list is unfiltered — both rows visible.
+      expect(output).toContain('first');
+      expect(output).toContain('second');
+    });
+
+    it('↑ at top of filtered-list wraps focus back to search', async () => {
+      // fzf-style boundary wrap: the search row is treated as a row
+      // above the list, so pressing ↑ when already on the first
+      // filtered match returns the user to search-mode editing
+      // without needing another '/' keystroke. ↓ at the bottom is
+      // intentionally NOT wrapped — that's the loadMore sentinel.
+      const sessions = [
+        createMockSession({
+          sessionId: 'a',
+          prompt: 'login flow',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 'b',
+          prompt: 'login bug',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={vi.fn()}
+            onCancel={vi.fn()}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      stdin.write('/login');
+      await wait(30);
+
+      // ↓ from search exits to filtered-list at the first match
+      // (selectedIndex was reset to 0 when the query changed, and
+      // ↓ no longer advances past it).
+      stdin.write(ARROW_DOWN);
+      await wait(30);
+      let output = lastFrame() ?? '';
+      expect(output).toContain('Filter:');
+
+      // ↑ at index 0 wraps focus right back into search.
+      stdin.write(ARROW_UP);
+      await wait(30);
+      output = lastFrame() ?? '';
+      expect(output).toContain('Search:');
+      expect(output).not.toContain('Filter:');
+      // Query is preserved so the user is editing the same filter.
+      expect(output).toContain('login');
+    });
+
+    it('↓ from search lands on the first match, not the second', async () => {
+      // Regression: previously ↓ from search did setViewMode('list')
+      // *and* advanced selectedIndex, so the user pressed ↓ once and
+      // jumped past the first (highest-relevance) match. Now ↓
+      // simply commits the focus transition; selectedIndex stays at
+      // 0 (already reset by the query-change effect).
+      const sessions = [
+        createMockSession({
+          sessionId: 'first-match',
+          prompt: 'login flow',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 'second-match',
+          prompt: 'login bug',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+      const onSelect = vi.fn();
+
+      const { stdin } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={onSelect}
+            onCancel={vi.fn()}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      stdin.write('/login');
+      await wait(30);
+      stdin.write(ARROW_DOWN); // exit search → first match should be highlighted
+      await wait(30);
+      stdin.write('\r'); // Enter from list = select highlighted row
+      await wait(30);
+
+      expect(onSelect).toHaveBeenCalledWith('first-match');
+    });
+
+    it('↑/↓ are a no-op in search when the query matches nothing', async () => {
+      // Sentinel for the "phantom mode-switch" glitch: when the
+      // current query has zero matches there is no row to land on,
+      // so ↑/↓ must not silently flip the picker out of search mode.
+      // The user keeps editing the query (or backs up) until the
+      // filter actually finds something.
+      const sessions = [
+        createMockSession({
+          sessionId: 's1',
+          prompt: 'unrelated work',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={vi.fn()}
+            onCancel={vi.fn()}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      // Type a query that matches nothing.
+      stdin.write('/zzznomatch');
+      await wait(50);
+      let output = lastFrame() ?? '';
+      expect(output).toContain('Search:');
+      expect(output).toContain('No sessions match');
+
+      // ↑↓ should not exit search.
+      stdin.write(ARROW_DOWN);
+      await wait(30);
+      output = lastFrame() ?? '';
+      expect(output).toContain('Search:');
+      expect(output).not.toContain('Filter:');
+
+      stdin.write(ARROW_UP);
+      await wait(30);
+      output = lastFrame() ?? '';
+      expect(output).toContain('Search:');
+      expect(output).not.toContain('Filter:');
+    });
+
+    it('typing in filtered-list re-enters search and appends', async () => {
+      // After narrowing → arrow → list, further typing should refine
+      // (append to existing query) rather than start a fresh search.
+      // Prompts use no spaces so the substring "loginbug" / "loginflow"
+      // can match contiguously without colliding with Space-as-preview.
+      const sessions = [
+        createMockSession({
+          sessionId: 'a',
+          prompt: 'loginflow',
+          messageCount: 1,
+        }),
+        createMockSession({
+          sessionId: 'b',
+          prompt: 'loginbug',
+          messageCount: 1,
+        }),
+      ];
+      const mockService = createMockSessionService(sessions);
+
+      const { stdin, lastFrame } = render(
+        <KeypressProvider kittyProtocolEnabled={false}>
+          <SessionPicker
+            sessionService={mockService as never}
+            onSelect={vi.fn()}
+            onCancel={vi.fn()}
+          />
+        </KeypressProvider>,
+      );
+
+      await wait(100);
+      stdin.write('/login');
+      await wait(30);
+      stdin.write(ARROW_DOWN);
+      await wait(30);
+      // Now list-mode + query='login'. Type 'bug' — implicit entry
+      // re-enters search and appends, yielding query='loginbug'.
+      stdin.write('bug');
+      await wait(50);
+
+      const output = lastFrame() ?? '';
+      expect(output).toContain('Search:');
+      expect(output).toContain('loginbug');
+      expect(output).not.toContain('loginflow');
     });
   });
 
@@ -492,6 +1419,8 @@ describe('SessionPicker', () => {
       expect(output).toContain('Resume Session');
       expect(output).toContain('↑↓ to navigate');
       expect(output).toContain('Esc to cancel');
+      // The default footer points the user at typing to start a search.
+      expect(output).toContain('Type to search');
     });
 
     it('should show branch toggle hint when currentBranch is provided', async () => {
@@ -514,8 +1443,8 @@ describe('SessionPicker', () => {
       await wait(100);
 
       const output = lastFrame();
-      expect(output).toContain('B');
-      expect(output).toContain('toggle branch');
+      expect(output).toContain('Ctrl+B');
+      expect(output).toContain('branch');
     });
 
     it('should truncate long prompts', async () => {
@@ -778,7 +1707,7 @@ describe('SessionPicker', () => {
       );
 
       await wait(100);
-      stdin.write(' '); // Space → preview
+      stdin.write(' '); // Space → preview in list mode
       await wait(150);
       const frame = lastFrame() ?? '';
       // Tool group renders with raw function name fallback (no registry).
@@ -852,7 +1781,7 @@ describe('SessionPicker', () => {
       // Space in destructive flows.
       expect(beforeFrame).not.toContain('Space to preview');
 
-      stdin.write(' '); // Space
+      stdin.write(' '); // Space — no-op when preview is disabled
       await wait(150);
       const afterFrame = lastFrame() ?? '';
       // No preview body, still on the list.

--- a/packages/cli/src/ui/hooks/useSessionPicker.ts
+++ b/packages/cli/src/ui/hooks/useSessionPicker.ts
@@ -25,6 +25,10 @@ import {
   type SessionState,
 } from '../utils/sessionPickerUtils.js';
 import { useKeypress } from './useKeypress.js';
+import {
+  isPrintableSearchChar,
+  useSessionSearchInput,
+} from './useSessionSearchInput.js';
 
 export interface UseSessionPickerOptions {
   sessionService: SessionService | null;
@@ -66,9 +70,16 @@ export interface UseSessionPickerResult {
   showScrollUp: boolean;
   showScrollDown: boolean;
   loadMoreSessions: () => Promise<void>;
-  viewMode: 'list' | 'preview';
+  viewMode: 'list' | 'search' | 'preview';
   previewSessionId: string | null;
   exitPreview: () => void;
+  /** Free-text filter applied on top of branch filter. */
+  searchQuery: string;
+  /**
+   * True iff `viewMode === 'search'`. Convenience for UI that conditions
+   * on "the user is currently typing a query".
+   */
+  isSearchActive: boolean;
 }
 
 export function useSessionPicker({
@@ -95,8 +106,10 @@ export function useSessionPicker({
   // For follow mode (non-centered)
   const [followScrollOffset, setFollowScrollOffset] = useState(0);
 
-  // Preview view state.
-  const [viewMode, setViewMode] = useState<'list' | 'preview'>('list');
+  // Picker mode state
+  const [viewMode, setViewMode] = useState<'list' | 'search' | 'preview'>(
+    'list',
+  );
   const [previewSessionId, setPreviewSessionId] = useState<string | null>(null);
 
   const exitPreview = useCallback(() => {
@@ -104,11 +117,27 @@ export function useSessionPicker({
     setPreviewSessionId(null);
   }, []);
 
+  // Search-mode editor — owns the query buffer and handles the
+  // edit-keys (printable chars, Backspace/Delete, Ctrl+U/L, Esc).
+  // The outer hook below dispatches keys to it whenever
+  // `viewMode === 'search'`.
+  const onExitToList = useCallback(() => {
+    setViewMode('list');
+  }, []);
+  const { searchQuery, setSearchQuery, handleSearchKey } =
+    useSessionSearchInput({ onExitToList });
+
   const isLoadingMoreRef = useRef(false);
 
   const filteredSessions = useMemo(
-    () => filterSessions(sessionState.sessions, filterByBranch, currentBranch),
-    [sessionState.sessions, filterByBranch, currentBranch],
+    () =>
+      filterSessions(
+        sessionState.sessions,
+        filterByBranch,
+        currentBranch,
+        searchQuery,
+      ),
+    [sessionState.sessions, filterByBranch, currentBranch, searchQuery],
   );
 
   const scrollOffset = useMemo(() => {
@@ -184,11 +213,11 @@ export function useSessionPicker({
     }
   }, [sessionService, sessionState.hasMore, sessionState.nextCursor]);
 
-  // Reset selection when filter changes
+  // Reset selection when any filter changes (branch toggle or text query).
   useEffect(() => {
     setSelectedIndex(0);
     setFollowScrollOffset(0);
-  }, [filterByBranch]);
+  }, [filterByBranch, searchQuery]);
 
   // Ensure selectedIndex is valid when filtered sessions change
   useEffect(() => {
@@ -228,31 +257,9 @@ export function useSessionPicker({
     sessionState.hasMore,
   ]);
 
-  // Key handling (KeypressContext)
-  useKeypress(
-    (key) => {
-      // Preview owns the keyboard while active; suppress list-mode
-      // handlers so we don't double-handle Escape / Enter / navigation.
-      if (viewMode !== 'list') {
-        return;
-      }
-
-      const { name, sequence, ctrl } = key;
-
-      if (name === 'escape' || (ctrl && name === 'c')) {
-        onCancel();
-        return;
-      }
-
-      if (name === 'return') {
-        const session = filteredSessions[selectedIndex];
-        if (session) {
-          onSelect(session.sessionId);
-        }
-        return;
-      }
-
-      if (name === 'up' || name === 'k') {
+  const moveSelection = useCallback(
+    (delta: -1 | 1) => {
+      if (delta === -1) {
         setSelectedIndex((prev) => {
           const newIndex = Math.max(0, prev - 1);
           if (!centerSelection && newIndex < followScrollOffset) {
@@ -262,29 +269,106 @@ export function useSessionPicker({
         });
         return;
       }
+      if (filteredSessions.length === 0) return;
+      setSelectedIndex((prev) => {
+        const newIndex = Math.min(filteredSessions.length - 1, prev + 1);
+        if (
+          !centerSelection &&
+          newIndex >= followScrollOffset + maxVisibleItems
+        ) {
+          setFollowScrollOffset(newIndex - maxVisibleItems + 1);
+        }
+        if (!centerSelection && newIndex >= filteredSessions.length - 3) {
+          void loadMoreSessions();
+        }
+        return newIndex;
+      });
+    },
+    [
+      centerSelection,
+      filteredSessions.length,
+      followScrollOffset,
+      loadMoreSessions,
+      maxVisibleItems,
+    ],
+  );
 
-      if (name === 'down' || name === 'j') {
-        if (filteredSessions.length === 0) {
+  useKeypress(
+    (key) => {
+      // Preview mode is gated by the `isActive` option below, so this
+      // callback only runs in list/search modes — no inline guard
+      // needed.
+      const { name, sequence, ctrl } = key;
+
+      if (ctrl && name === 'c') {
+        onCancel();
+        return;
+      }
+
+      if (name === 'return') {
+        if (viewMode === 'search') {
+          if (filteredSessions.length === 0) {
+            // Nothing to commit to — keep editing.
+            return;
+          }
+          setViewMode('list');
           return;
         }
+        const session = filteredSessions[selectedIndex];
+        if (session) {
+          onSelect(session.sessionId);
+        }
+        return;
+      }
 
-        setSelectedIndex((prev) => {
-          const newIndex = Math.min(filteredSessions.length - 1, prev + 1);
+      if (name === 'up' || name === 'down') {
+        const delta = name === 'up' ? -1 : +1;
+        const inSearch = viewMode === 'search';
+        if (inSearch) {
+          if (filteredSessions.length === 0) return;
+          setViewMode('list');
+          return;
+        }
+        if (
+          delta === -1 &&
+          filteredSessions.length > 0 &&
+          selectedIndex === 0
+        ) {
+          setViewMode('search');
+          return;
+        }
+        moveSelection(delta);
+        return;
+      }
 
-          if (
-            !centerSelection &&
-            newIndex >= followScrollOffset + maxVisibleItems
-          ) {
-            setFollowScrollOffset(newIndex - maxVisibleItems + 1);
-          }
+      // While the search input is focused it owns the keyboard
+      // exclusively: anything `handleSearchKey` doesn't claim is
+      // intentionally swallowed (e.g. Ctrl+B, '/' typed as a query
+      // char, etc.). The mode-independent shortcuts above (Ctrl+C,
+      // Enter, ↑↓) are the only escape hatches. To make a list-mode
+      // shortcut work in search, hoist it above this delegate the
+      // way Enter / ↑↓ already are.
+      if (viewMode === 'search') {
+        handleSearchKey(key);
+        return;
+      }
 
-          // Follow mode: load more when near the end.
-          if (!centerSelection && newIndex >= filteredSessions.length - 3) {
-            void loadMoreSessions();
-          }
+      // ── list mode ──
+      if (name === 'escape') {
+        if (searchQuery !== '') {
+          setSearchQuery('');
+        } else {
+          onCancel();
+        }
+        return;
+      }
 
-          return newIndex;
-        });
+      if (name === 'k') {
+        moveSelection(-1);
+        return;
+      }
+      if (name === 'j') {
+        moveSelection(+1);
         return;
       }
 
@@ -297,13 +381,30 @@ export function useSessionPicker({
         return;
       }
 
-      if (sequence === 'b' || sequence === 'B') {
+      if (ctrl && (name === 'b' || name === 'B')) {
         if (currentBranch) {
           setFilterByBranch((prev) => !prev);
         }
+        return;
+      }
+
+      if (sequence === '/') {
+        setViewMode('search');
+        return;
+      }
+
+      if (isPrintableSearchChar(key)) {
+        // Skip Space when it would seed a leading-whitespace query —
+        // hits this branch only when enablePreview=false (otherwise
+        // the Space-preview shortcut above already returned).
+        if (sequence === ' ') {
+          return;
+        }
+        setViewMode('search');
+        setSearchQuery((q) => q + sequence);
       }
     },
-    { isActive: isActive && viewMode === 'list' },
+    { isActive: isActive && viewMode !== 'preview' },
   );
 
   return {
@@ -320,5 +421,7 @@ export function useSessionPicker({
     viewMode,
     previewSessionId,
     exitPreview,
+    searchQuery,
+    isSearchActive: viewMode === 'search',
   };
 }

--- a/packages/cli/src/ui/hooks/useSessionPicker.ts
+++ b/packages/cli/src/ui/hooks/useSessionPicker.ts
@@ -259,6 +259,12 @@ export function useSessionPicker({
 
   const moveSelection = useCallback(
     (delta: -1 | 1) => {
+      // Both directions need the same empty-list guard. Without it, the
+      // -1 branch coasts on `Math.max(0, 0-1) === 0` (no crash), but the
+      // asymmetry was a tell that the empty case wasn't being thought
+      // about — share the early-return so a future tweak in either
+      // branch can't drift past length 0.
+      if (filteredSessions.length === 0) return;
       if (delta === -1) {
         setSelectedIndex((prev) => {
           const newIndex = Math.max(0, prev - 1);
@@ -269,7 +275,6 @@ export function useSessionPicker({
         });
         return;
       }
-      if (filteredSessions.length === 0) return;
       setSelectedIndex((prev) => {
         const newIndex = Math.min(filteredSessions.length - 1, prev + 1);
         if (
@@ -363,6 +368,11 @@ export function useSessionPicker({
         return;
       }
 
+      // `j`/`k` are list-mode navigation only — intentionally claimed
+      // BEFORE the implicit-search-seed branch below, so typing `j`
+      // never seeds the query with "j". vim users stay in list mode;
+      // anyone wanting to search for a literal "j..." can press `/`
+      // first to enter search explicitly.
       if (name === 'k') {
         moveSelection(-1);
         return;

--- a/packages/cli/src/ui/hooks/useSessionSearchInput.test.ts
+++ b/packages/cli/src/ui/hooks/useSessionSearchInput.test.ts
@@ -1,0 +1,291 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import {
+  isPrintableSearchChar,
+  useSessionSearchInput,
+} from './useSessionSearchInput.js';
+import type { Key } from './useKeypress.js';
+
+function k(overrides: Partial<Key>): Key {
+  return {
+    name: '',
+    ctrl: false,
+    meta: false,
+    shift: false,
+    paste: false,
+    sequence: '',
+    ...overrides,
+  };
+}
+
+describe('isPrintableSearchChar', () => {
+  it('accepts a single printable ASCII char', () => {
+    expect(isPrintableSearchChar(k({ name: 'a', sequence: 'a' }))).toBe(true);
+  });
+
+  it('accepts SPACE — caller decides whether to seed it', () => {
+    // The picker's outer handler suppresses leading-whitespace queries
+    // separately. The predicate itself only filters by character class.
+    expect(isPrintableSearchChar(k({ name: 'space', sequence: ' ' }))).toBe(
+      true,
+    );
+  });
+
+  it('rejects Ctrl-modified keys', () => {
+    expect(
+      isPrintableSearchChar(k({ name: 'a', sequence: 'a', ctrl: true })),
+    ).toBe(false);
+  });
+
+  it('rejects Meta-modified keys', () => {
+    expect(
+      isPrintableSearchChar(k({ name: 'a', sequence: 'a', meta: true })),
+    ).toBe(false);
+  });
+
+  it('rejects bracketed pastes (multi-line content must never seed a query)', () => {
+    expect(
+      isPrintableSearchChar(k({ name: 'paste', sequence: 'a', paste: true })),
+    ).toBe(false);
+  });
+
+  it('rejects multi-character sequences (e.g. CSI escape sequences)', () => {
+    expect(isPrintableSearchChar(k({ name: 'up', sequence: '[A' }))).toBe(
+      false,
+    );
+  });
+
+  it('rejects empty sequences (synthetic / structural keys)', () => {
+    expect(isPrintableSearchChar(k({ name: 'return', sequence: '' }))).toBe(
+      false,
+    );
+  });
+
+  it('rejects control characters below 0x20 (Tab, Enter, Esc)', () => {
+    expect(isPrintableSearchChar(k({ name: 'tab', sequence: '\t' }))).toBe(
+      false,
+    );
+    expect(isPrintableSearchChar(k({ name: 'return', sequence: '\r' }))).toBe(
+      false,
+    );
+    expect(isPrintableSearchChar(k({ name: 'escape', sequence: '' }))).toBe(
+      false,
+    );
+  });
+
+  it('rejects DEL (0x7F) — Backspace would otherwise slip through', () => {
+    expect(isPrintableSearchChar(k({ name: 'backspace', sequence: '' }))).toBe(
+      false,
+    );
+  });
+});
+
+describe('useSessionSearchInput', () => {
+  // Each keystroke gets its own act() — terminal events arrive in
+  // separate render cycles, and the empty-query effect runs after
+  // each commit. Batching multiple keys into one act() collapses the
+  // intermediate states the effect needs to observe (so a never-saw-
+  // 'a' state can never satisfy the prev-non-empty → empty
+  // transition).
+
+  it('starts with an empty query', () => {
+    const { result } = renderHook(() =>
+      useSessionSearchInput({ onExitToList: vi.fn() }),
+    );
+    expect(result.current.searchQuery).toBe('');
+  });
+
+  it('does not fire onExitToList on initial mount with the default empty query', () => {
+    // Pin the prev-ref guard: the effect must distinguish "started
+    // empty" from "transitioned to empty". Without the guard, every
+    // mount with a default-empty query would falsely call the parent
+    // out of search mode before search ever started.
+    const onExitToList = vi.fn();
+    renderHook(() => useSessionSearchInput({ onExitToList }));
+    expect(onExitToList).not.toHaveBeenCalled();
+  });
+
+  it('appends a printable char to the query', () => {
+    const { result } = renderHook(() =>
+      useSessionSearchInput({ onExitToList: vi.fn() }),
+    );
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'a', sequence: 'a' }));
+    });
+    expect(result.current.searchQuery).toBe('a');
+  });
+
+  it('accumulates printable chars across separate keystrokes', () => {
+    const { result } = renderHook(() =>
+      useSessionSearchInput({ onExitToList: vi.fn() }),
+    );
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'a', sequence: 'a' }));
+    });
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'b', sequence: 'b' }));
+    });
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'c', sequence: 'c' }));
+    });
+    expect(result.current.searchQuery).toBe('abc');
+  });
+
+  it('Backspace pops one char without exiting while query stays non-empty', () => {
+    const onExitToList = vi.fn();
+    const { result } = renderHook(() =>
+      useSessionSearchInput({ onExitToList }),
+    );
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'a', sequence: 'a' }));
+    });
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'b', sequence: 'b' }));
+    });
+    expect(result.current.searchQuery).toBe('ab');
+
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'backspace', sequence: '' }));
+    });
+    expect(result.current.searchQuery).toBe('a');
+    expect(onExitToList).not.toHaveBeenCalled();
+  });
+
+  it('Backspace through the last char clears the query AND exits to list', () => {
+    const onExitToList = vi.fn();
+    const { result } = renderHook(() =>
+      useSessionSearchInput({ onExitToList }),
+    );
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'a', sequence: 'a' }));
+    });
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'backspace', sequence: '' }));
+    });
+    expect(result.current.searchQuery).toBe('');
+    expect(onExitToList).toHaveBeenCalledTimes(1);
+  });
+
+  it('Delete behaves like Backspace (pop + exit on empty)', () => {
+    const onExitToList = vi.fn();
+    const { result } = renderHook(() =>
+      useSessionSearchInput({ onExitToList }),
+    );
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'a', sequence: 'a' }));
+    });
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'delete' }));
+    });
+    expect(result.current.searchQuery).toBe('');
+    expect(onExitToList).toHaveBeenCalledTimes(1);
+  });
+
+  it('Esc clears any current query and exits to list', () => {
+    const onExitToList = vi.fn();
+    const { result } = renderHook(() =>
+      useSessionSearchInput({ onExitToList }),
+    );
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'a', sequence: 'a' }));
+    });
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'b', sequence: 'b' }));
+    });
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'escape', sequence: '' }));
+    });
+    expect(result.current.searchQuery).toBe('');
+    expect(onExitToList).toHaveBeenCalledTimes(1);
+  });
+
+  it('Ctrl+U wipes the query and exits — single-stroke equivalent of full Backspace', () => {
+    const onExitToList = vi.fn();
+    const { result } = renderHook(() =>
+      useSessionSearchInput({ onExitToList }),
+    );
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'a', sequence: 'a' }));
+    });
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'b', sequence: 'b' }));
+    });
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'c', sequence: 'c' }));
+    });
+    act(() => {
+      result.current.handleSearchKey(
+        k({ name: 'u', sequence: '', ctrl: true }),
+      );
+    });
+    expect(result.current.searchQuery).toBe('');
+    expect(onExitToList).toHaveBeenCalledTimes(1);
+  });
+
+  it('Ctrl+L wipes the query and exits (alias of Ctrl+U for muscle-memory parity)', () => {
+    const onExitToList = vi.fn();
+    const { result } = renderHook(() =>
+      useSessionSearchInput({ onExitToList }),
+    );
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'a', sequence: 'a' }));
+    });
+    act(() => {
+      result.current.handleSearchKey(
+        k({ name: 'l', sequence: '', ctrl: true }),
+      );
+    });
+    expect(result.current.searchQuery).toBe('');
+    expect(onExitToList).toHaveBeenCalledTimes(1);
+  });
+
+  it('silently swallows unrecognized keys (search owns the keyboard)', () => {
+    const onExitToList = vi.fn();
+    const { result } = renderHook(() =>
+      useSessionSearchInput({ onExitToList }),
+    );
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'a', sequence: 'a' }));
+    });
+    // Tab, Page-Up, and Ctrl+B all hit search while focused — they
+    // must neither mutate the query nor leak through as exits.
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'tab', sequence: '\t' }));
+    });
+    act(() => {
+      result.current.handleSearchKey(k({ name: 'pageup' }));
+    });
+    act(() => {
+      result.current.handleSearchKey(
+        k({ name: 'b', sequence: '', ctrl: true }),
+      );
+    });
+    expect(result.current.searchQuery).toBe('a');
+    expect(onExitToList).not.toHaveBeenCalled();
+  });
+
+  it("exposes setSearchQuery for the parent's implicit-entry path", () => {
+    // The picker uses this to seed the query when a printable char
+    // arrives in list mode — covered here as a smoke test that the
+    // setter (functional and direct) round-trips through the hook
+    // independently of handleSearchKey.
+    const { result } = renderHook(() =>
+      useSessionSearchInput({ onExitToList: vi.fn() }),
+    );
+    act(() => {
+      result.current.setSearchQuery('seed');
+    });
+    expect(result.current.searchQuery).toBe('seed');
+
+    act(() => {
+      result.current.setSearchQuery((q) => `${q}-more`);
+    });
+    expect(result.current.searchQuery).toBe('seed-more');
+  });
+});

--- a/packages/cli/src/ui/hooks/useSessionSearchInput.ts
+++ b/packages/cli/src/ui/hooks/useSessionSearchInput.ts
@@ -1,0 +1,153 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Owns the search-query state and the editing-key handler used by the
+ * session picker while it's in search mode.
+ *
+ * Scoped intentionally narrow: this hook only knows how to mutate the
+ * query (append a printable char, pop a char, clear) and how to ask
+ * its parent to leave search mode. Mode transitions, navigation
+ * (Enter / ↑ / ↓ / Ctrl+C), list-only shortcuts (Ctrl+B branch
+ * toggle, Space-preview), and the "implicit entry" fallback that
+ * seeds the query from list mode are all the parent's responsibility
+ * — kept out of here so the search editor can be reasoned about as a
+ * small, append-only buffer with a few escape hatches.
+ *
+ * Inspired by claude-code's `useSearchInput` but trimmed to qwen's
+ * current feature set: no cursor movement, no kill ring, no word-wise
+ * editing. Adding those later only requires extending this hook —
+ * the outer picker stays untouched.
+ */
+
+import { useCallback, useState } from 'react';
+import type { Key } from './useKeypress.js';
+
+const DELETION_KEY_NAMES = new Set(['backspace', 'delete']);
+
+/**
+ * True when the key represents a single printable character that
+ * should be appended to the search buffer. Excludes:
+ *   - any modified key (Ctrl/Meta combos handled separately);
+ *   - bracketed pastes (a multi-line paste should never silently
+ *     become a search query);
+ *   - control characters (sequences below 0x20 like Tab/Enter/Esc);
+ *   - DEL (0x7F) — Backspace's sequence byte, otherwise it would
+ *     slip past the printable check and produce a literal DEL
+ *     character in the query.
+ *
+ * Exported because the picker's outer keypress handler reuses this
+ * predicate to recognize the "implicit search entry" gesture (any
+ * printable letter typed in list mode flips into search and seeds
+ * the query). Sharing the definition keeps the two paths in sync.
+ */
+export function isPrintableSearchChar(key: Key): boolean {
+  if (key.ctrl || key.meta || key.paste) return false;
+  if (key.sequence.length !== 1) return false;
+  const code = key.sequence.charCodeAt(0);
+  return code >= 0x20 && code !== 0x7f;
+}
+
+export interface UseSessionSearchInputOptions {
+  /**
+   * Called when the search frame should yield back to list mode —
+   * fires on Esc, Ctrl+U/Ctrl+L, and on a Backspace that empties the
+   * query. The parent typically maps this to `setViewMode('list')`.
+   * This hook has already cleared the query for the Esc/Ctrl+U/L
+   * paths and left it empty for the Backspace path, so the parent
+   * doesn't need to touch the query itself.
+   */
+  onExitToList: () => void;
+}
+
+export interface UseSessionSearchInputResult {
+  /** Current query text. */
+  searchQuery: string;
+  /**
+   * Imperative setter — the parent uses this for "implicit entry"
+   * (typing in list mode seeds the query) without going through
+   * `handleSearchKey`. Functional updaters are supported and
+   * recommended whenever the new value depends on the previous one.
+   */
+  setSearchQuery: React.Dispatch<React.SetStateAction<string>>;
+  /**
+   * Process a key event that arrived while the picker is in search
+   * mode. Always treated as the final handler for that key — the
+   * search input has exclusive ownership of the keyboard while
+   * focused, so anything this function doesn't recognize is
+   * intentionally swallowed by the caller. (Mode-independent
+   * shortcuts that need to fire in search mode — Enter, ↑/↓,
+   * Ctrl+C — are routed by the parent before this delegate.)
+   */
+  handleSearchKey: (key: Key) => void;
+}
+
+export function useSessionSearchInput(
+  options: UseSessionSearchInputOptions,
+): UseSessionSearchInputResult {
+  const { onExitToList } = options;
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const handleSearchKey = useCallback(
+    (key: Key): void => {
+      const { name, sequence, ctrl } = key;
+
+      if (name === 'escape') {
+        // Drop the query and yield to list mode in one Esc.
+        // The list mode's own Esc handler then implements the
+        // second-stage cancel.
+        setSearchQuery('');
+        onExitToList();
+        return;
+      }
+
+      if (DELETION_KEY_NAMES.has(name)) {
+        // Pop one char from the query. Once the query has been
+        // fully erased, fall back to list mode so the shortcut
+        // keymap is immediately available again — typing `/abc`
+        // ⌫⌫⌫⌫ should leave the user exactly where they started,
+        // not stuck in a search frame with an empty query.
+        //
+        // The side effect inside the updater is intentional. The
+        // functional form is required for correctness under batched
+        // Backspaces (each call sees the previous queued value, so
+        // they don't all read the same stale closure). React 18
+        // StrictMode will invoke this updater twice in dev for
+        // purity checks, which means `onExitToList()` may fire
+        // twice — harmless because `setViewMode('list')` is
+        // idempotent. Don't refactor this back into a plain
+        // `setSearchQuery(searchQuery.slice(0, -1))` without
+        // re-deriving the empty-query check from the next state
+        // somehow; the closure read is what's actually unsafe.
+        setSearchQuery((q) => {
+          const next = q.slice(0, -1);
+          if (!next) onExitToList();
+          return next;
+        });
+        return;
+      }
+
+      if (ctrl && (name === 'u' || name === 'l')) {
+        // Wipe the query and exit search — same end state as
+        // backspacing through every char, just one keystroke.
+        setSearchQuery('');
+        onExitToList();
+        return;
+      }
+
+      if (isPrintableSearchChar(key)) {
+        setSearchQuery((q) => q + sequence);
+        return;
+      }
+
+      // Anything else (Ctrl+B, Tab, Page keys, …) is silently
+      // swallowed by the caller — search owns the keyboard.
+    },
+    [onExitToList],
+  );
+
+  return { searchQuery, setSearchQuery, handleSearchKey };
+}

--- a/packages/cli/src/ui/hooks/useSessionSearchInput.ts
+++ b/packages/cli/src/ui/hooks/useSessionSearchInput.ts
@@ -23,7 +23,7 @@
  * the outer picker stays untouched.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Key } from './useKeypress.js';
 
 const DELETION_KEY_NAMES = new Set(['backspace', 'delete']);
@@ -54,11 +54,11 @@ export function isPrintableSearchChar(key: Key): boolean {
 export interface UseSessionSearchInputOptions {
   /**
    * Called when the search frame should yield back to list mode —
-   * fires on Esc, Ctrl+U/Ctrl+L, and on a Backspace that empties the
-   * query. The parent typically maps this to `setViewMode('list')`.
-   * This hook has already cleared the query for the Esc/Ctrl+U/L
-   * paths and left it empty for the Backspace path, so the parent
-   * doesn't need to touch the query itself.
+   * fires after a non-empty → empty query transition (Esc, Ctrl+U/L,
+   * or the last Backspace), via a `useEffect` so the side effect
+   * lives outside the React state updater. The parent typically
+   * maps this to `setViewMode('list')`. The query is already empty
+   * by the time this fires, so the parent doesn't need to touch it.
    */
   onExitToList: () => void;
 }
@@ -91,63 +91,58 @@ export function useSessionSearchInput(
   const { onExitToList } = options;
   const [searchQuery, setSearchQuery] = useState('');
 
-  const handleSearchKey = useCallback(
-    (key: Key): void => {
-      const { name, sequence, ctrl } = key;
+  const handleSearchKey = useCallback((key: Key): void => {
+    const { name, sequence, ctrl } = key;
 
-      if (name === 'escape') {
-        // Drop the query and yield to list mode in one Esc.
-        // The list mode's own Esc handler then implements the
-        // second-stage cancel.
-        setSearchQuery('');
-        onExitToList();
-        return;
-      }
+    if (name === 'escape') {
+      // Drop the query; the empty-query effect below routes the exit.
+      // The list-mode Esc handler then implements the second-stage cancel.
+      setSearchQuery('');
+      return;
+    }
 
-      if (DELETION_KEY_NAMES.has(name)) {
-        // Pop one char from the query. Once the query has been
-        // fully erased, fall back to list mode so the shortcut
-        // keymap is immediately available again — typing `/abc`
-        // ⌫⌫⌫⌫ should leave the user exactly where they started,
-        // not stuck in a search frame with an empty query.
-        //
-        // The side effect inside the updater is intentional. The
-        // functional form is required for correctness under batched
-        // Backspaces (each call sees the previous queued value, so
-        // they don't all read the same stale closure). React 18
-        // StrictMode will invoke this updater twice in dev for
-        // purity checks, which means `onExitToList()` may fire
-        // twice — harmless because `setViewMode('list')` is
-        // idempotent. Don't refactor this back into a plain
-        // `setSearchQuery(searchQuery.slice(0, -1))` without
-        // re-deriving the empty-query check from the next state
-        // somehow; the closure read is what's actually unsafe.
-        setSearchQuery((q) => {
-          const next = q.slice(0, -1);
-          if (!next) onExitToList();
-          return next;
-        });
-        return;
-      }
+    if (DELETION_KEY_NAMES.has(name)) {
+      // Pop one char. Once the query empties out, the effect fires
+      // the exit — typing `/abc` ⌫⌫⌫⌫ leaves the user exactly where
+      // they started instead of stuck in a search frame.
+      //
+      // The functional updater is required for correctness under
+      // batched Backspaces (each call sees the previous queued
+      // value, not the same stale closure). React 18 StrictMode
+      // double-invokes updaters in dev for purity checks, which
+      // is why the side effect lives outside the updater.
+      setSearchQuery((q) => q.slice(0, -1));
+      return;
+    }
 
-      if (ctrl && (name === 'u' || name === 'l')) {
-        // Wipe the query and exit search — same end state as
-        // backspacing through every char, just one keystroke.
-        setSearchQuery('');
-        onExitToList();
-        return;
-      }
+    if (ctrl && (name === 'u' || name === 'l')) {
+      // Wipe the query and let the empty-query effect fire the exit.
+      setSearchQuery('');
+      return;
+    }
 
-      if (isPrintableSearchChar(key)) {
-        setSearchQuery((q) => q + sequence);
-        return;
-      }
+    if (isPrintableSearchChar(key)) {
+      setSearchQuery((q) => q + sequence);
+      return;
+    }
 
-      // Anything else (Ctrl+B, Tab, Page keys, …) is silently
-      // swallowed by the caller — search owns the keyboard.
-    },
-    [onExitToList],
-  );
+    // Anything else (Ctrl+B, Tab, Page keys, …) is silently
+    // swallowed by the caller — search owns the keyboard.
+  }, []);
+
+  // Exit to list mode whenever the query empties out — unifies Esc,
+  // Ctrl+U/L, and the last Backspace through a single side-effect
+  // site. The previous-value ref guards initial mount (where query
+  // starts at ''): we only fire on a non-empty → empty transition.
+  // StrictMode's mount/cleanup/mount dance is a no-op here because
+  // the initial state can never satisfy `prev !== ''`.
+  const prevSearchQueryRef = useRef('');
+  useEffect(() => {
+    if (searchQuery === '' && prevSearchQueryRef.current !== '') {
+      onExitToList();
+    }
+    prevSearchQueryRef.current = searchQuery;
+  }, [searchQuery, onExitToList]);
 
   return { searchQuery, setSearchQuery, handleSearchKey };
 }

--- a/packages/cli/src/ui/utils/sessionPickerUtils.test.ts
+++ b/packages/cli/src/ui/utils/sessionPickerUtils.test.ts
@@ -5,7 +5,21 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { truncateText } from './sessionPickerUtils.js';
+import type { SessionListItem } from '@qwen-code/qwen-code-core';
+import { filterSessions, truncateText } from './sessionPickerUtils.js';
+
+function s(overrides: Partial<SessionListItem>): SessionListItem {
+  return {
+    sessionId: overrides.sessionId ?? 'id',
+    cwd: '/cwd',
+    startTime: '2025-01-01T00:00:00.000Z',
+    mtime: 0,
+    prompt: '',
+    filePath: '/cwd/x.jsonl',
+    messageCount: 1,
+    ...overrides,
+  };
+}
 
 describe('sessionPickerUtils', () => {
   describe('truncateText', () => {
@@ -40,6 +54,43 @@ describe('sessionPickerUtils', () => {
 
     it('returns only the first line even if there are multiple line breaks', () => {
       expect(truncateText('hello\n\nworld', 20)).toBe('hello');
+    });
+  });
+
+  describe('filterSessions', () => {
+    const sessions: SessionListItem[] = [
+      s({ sessionId: 'a', prompt: 'fix login bug', gitBranch: 'main' }),
+      s({ sessionId: 'b', customTitle: 'Add OAuth flow', gitBranch: 'feat' }),
+      s({ sessionId: 'c', prompt: 'random work', gitBranch: 'hotfix/login' }),
+      s({ sessionId: 'd', prompt: 'unrelated', gitBranch: 'main' }),
+    ];
+
+    it('passes everything through when no filter is set', () => {
+      expect(filterSessions(sessions, false)).toEqual(sessions);
+      expect(filterSessions(sessions, false, 'main', '')).toEqual(sessions);
+    });
+
+    it('matches the query against prompt, customTitle, and gitBranch', () => {
+      const result = filterSessions(sessions, false, undefined, 'login');
+      expect(result.map((x) => x.sessionId)).toEqual(['a', 'c']);
+    });
+
+    it('is case-insensitive and trims surrounding whitespace', () => {
+      const result = filterSessions(sessions, false, undefined, '  OAUTH  ');
+      expect(result.map((x) => x.sessionId)).toEqual(['b']);
+    });
+
+    it('composes branch filter and query as AND', () => {
+      // Branch filter narrows to main; query then drops the unrelated row
+      // even though 'unrelated' is on main.
+      const result = filterSessions(sessions, true, 'main', 'login');
+      expect(result.map((x) => x.sessionId)).toEqual(['a']);
+    });
+
+    it('returns empty when the query matches nothing', () => {
+      expect(
+        filterSessions(sessions, false, undefined, 'definitelynotpresent'),
+      ).toEqual([]);
     });
   });
 });

--- a/packages/cli/src/ui/utils/sessionPickerUtils.ts
+++ b/packages/cli/src/ui/utils/sessionPickerUtils.ts
@@ -35,19 +35,49 @@ export function truncateText(text: string, maxWidth: number): string {
 }
 
 /**
- * Filters sessions optionally by branch.
+ * Returns true when the session matches the query as a substring on any of:
+ * customTitle, first prompt, gitBranch.
+ *
+ * Empty queries match everything. The query is expected pre-normalized —
+ * `filterSessions` does the trim+lowercase once before the per-session
+ * loop, so this helper can do straight `includes()` checks per haystack.
+ */
+function matchesQuery(
+  session: SessionListItem,
+  normalizedQuery: string,
+): boolean {
+  if (!normalizedQuery) return true;
+  const haystacks: Array<string | undefined> = [
+    session.customTitle,
+    session.prompt,
+    session.gitBranch,
+  ];
+  for (const h of haystacks) {
+    if (h && h.toLowerCase().includes(normalizedQuery)) return true;
+  }
+  return false;
+}
+
+/**
+ * Filters sessions by branch and/or a free-text query.
+ *
+ * Branch filter and query filter compose (AND): when both are active, a
+ * session must satisfy both. Query is matched case-insensitively against
+ * customTitle, prompt, and gitBranch — branch is included in query matching
+ * so users can type a branch name without first toggling branch-filter.
  */
 export function filterSessions(
   sessions: SessionListItem[],
   filterByBranch: boolean,
   currentBranch?: string,
+  query?: string,
 ): SessionListItem[] {
+  const normalizedQuery = query?.toLowerCase().trim() ?? '';
   return sessions.filter((session) => {
-    // Apply branch filter if enabled
     if (filterByBranch && currentBranch) {
-      return session.gitBranch === currentBranch;
+      if (session.gitBranch !== currentBranch) return false;
     }
-    return true;
+    return matchesQuery(session, normalizedQuery);
   });
 }
 


### PR DESCRIPTION
## Summary

Adds free-text search to the `/resume` session picker. Users can find a session by typing a substring of its title, prompt, or git branch — no more scrolling through dozens of rows. The search input is treated as a focusable surface so the existing list-mode shortcuts (j/k, Space-preview, Ctrl+B branch toggle) keep working in the post-narrow state.

The hook gained a sibling — `useSessionSearchInput` — that owns the query buffer and the editing keys (Backspace/Delete, Ctrl+U/L, Esc, printable chars). The outer picker stays focused on mode dispatch and list state.

<img width="2140" height="942" alt="search" src="https://github.com/user-attachments/assets/fdeb476c-d8b7-4465-9a69-cddb499e171b" />

### State machine

| Mode | Esc | Enter | ↑/↓ | Space | Ctrl+B | / | Letter | Backspace |
|---|---|---|---|---|---|---|---|---|
| list q='' | cancel | select highlighted | nav; ↑@0 wraps to search | preview | toggle branch | → search | → search seed | no-op |
| list q≠'' (post-narrow) | clear q | select | same as above | preview | toggle branch | → search (keeps q) | → search append | no-op |
| search | clear q + → list | commit filter (→ list) | exit search to list (no nav advance) | append | swallow | append | append | pop; empty → list |

### Notable design choices

- **Enter in search commits, doesn't resume.** Guards against accidental session resume while still typing the query. Second Enter from the list view does the actual select.
- **↓ from search lands on the first match.** Earlier draft also advanced the cursor by 1, which made `/login` ↓ skip past the most relevant match.
- **↑ at index 0 wraps back to search** — fzf-style boundary wrap. ↓ at the bottom is left for the lazy-load sentinel.
- **j/k stay in search-as-query.** Only ↑/↓ are mode-independent navigation; j/k are list-only so titles containing those letters can be searched.
- **`/` preserves the existing query** so re-focusing search to refine doesn't wipe what the user typed. Esc is the explicit clear.
- **Search mode owns the keyboard exclusively.** Anything `handleSearchKey` doesn't claim is intentionally swallowed — Ctrl+B, Tab, etc. The mode-independent escape hatches (Enter / ↑↓ / Ctrl+C) are routed before the delegate.

### Backwards compatibility

- Branch toggle moved from bare `B` to **Ctrl+B** so the entire alphabet can seed search. Existing tests updated.
- vim-style `j/k` navigation kept in list mode; only available there now.

## Test plan

- [x] `tsc --noEmit -p packages/cli/tsconfig.json` — clean
- [x] `vitest run` for `StandaloneSessionPicker.test.tsx` (37 cases), `sessionPickerUtils.test.ts` (12 cases), `useResumeCommand.test.ts` (9 cases) — 58/58 pass
- [x] New tests pin the major UX promises:
  - substring filter across customTitle/prompt/gitBranch
  - implicit search entry on a non-shortcut printable
  - list-mode j/k still navigate
  - Backspace empties query → returns to list mode
  - list-mode Backspace doesn't spawn a phantom search (DEL byte excluded from printable)
  - search-mode hides the row highlight
  - Enter in search commits the filter (no resume)
  - ↑ wraps to search at top of both filtered and unfiltered list
  - ↓ from search lands on first match
  - typing in filtered-list re-enters search and appends
  - Esc 2-stage in filtered-list (clear → cancel)
  - `/` from filtered-list preserves the query

Related to #3869 