### PR TITLE
fix(cli): warn on ignored provider generation config

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,9 @@ Use the `/model` command at any time to switch between all configured models.
 
 You can also run models locally — no API key or cloud account needed. This is not an authentication method; instead, configure your local model endpoint in `~/.qwen/settings.json` using the `modelProviders` field.
 
+Set `generationConfig.contextWindowSize` inside the matching provider entry
+and adjust it to the context length configured on your local server.
+
 <details>
 <summary>Ollama setup</summary>
 
@@ -368,7 +371,10 @@ You can also run models locally — no API key or cloud account needed. This is 
         "id": "qwen3:32b",
         "name": "Qwen3 32B (Ollama)",
         "baseUrl": "http://localhost:11434/v1",
-        "description": "Qwen3 32B running locally via Ollama"
+        "description": "Qwen3 32B running locally via Ollama",
+        "generationConfig": {
+          "contextWindowSize": 131072
+        }
       }
     ]
   },
@@ -400,7 +406,10 @@ You can also run models locally — no API key or cloud account needed. This is 
         "id": "Qwen/Qwen3-32B",
         "name": "Qwen3 32B (vLLM)",
         "baseUrl": "http://localhost:8000/v1",
-        "description": "Qwen3 32B running locally via vLLM"
+        "description": "Qwen3 32B running locally via vLLM",
+        "generationConfig": {
+          "contextWindowSize": 131072
+        }
       }
     ]
   },

--- a/docs/users/configuration/model-providers.md
+++ b/docs/users/configuration/model-providers.md
@@ -417,6 +417,13 @@ The configuration resolution follows a strict layering model with one crucial ru
    - All fields **not defined** by the provider are set to `undefined` (not inherited from settings)
    - This ensures provider configurations act as a complete, self-contained "sealed package"
 
+   If a model is listed in `modelProviders`, put all model-specific
+   generation settings for that model in the matching provider entry. Top-level
+   `model.generationConfig` values, including `contextWindowSize`,
+   `modalities`, `customHeaders`, and `extra_body`, are ignored for provider
+   models. Configure those fields under
+   `modelProviders[authType][].generationConfig` for them to apply.
+
 2. **When NO modelProvider model is selected** (e.g., using `--model` with a raw model ID, or using CLI/env/settings directly):
    - The resolution falls through to lower layers
    - Fields are populated from CLI → env → settings → defaults

--- a/docs/users/configuration/settings.md
+++ b/docs/users/configuration/settings.md
@@ -196,15 +196,20 @@ To override this behavior, either set `samplingParams.max_tokens` in your settin
 
 Overrides the default context window size for the selected model. Qwen Code determines the context window using built-in defaults based on model name matching, with a constant fallback value. Use this setting when a provider's effective context limit differs from Qwen Code's default. This value defines the model's assumed maximum context capacity, not a per-request token limit.
 
+When the selected model is defined in `modelProviders`, set
+`contextWindowSize` in that provider entry's `generationConfig` instead of the
+top-level `model.generationConfig`. Provider model entries are sealed, so
+top-level generation settings do not fill missing provider fields.
+
 **modalities:**
 
 Overrides the auto-detected input modalities for the selected model. Qwen Code automatically detects supported modalities (image, PDF, audio, video) based on model name pattern matching. Use this setting when the auto-detection is incorrect — for example, to enable `pdf` for a model that supports it but isn't recognized. Format: `{ "image": true, "pdf": true, "audio": true, "video": true }`. Omit a key or set it to `false` for unsupported types.
 
 **customHeaders:**
 
-Allows you to add custom HTTP headers to all API requests. This is useful for request tracing, monitoring, API gateway routing, or when different models require different headers. If `customHeaders` is defined in `modelProviders[].generationConfig.customHeaders`, it will be used directly; otherwise, headers from `model.generationConfig.customHeaders` will be used. No merging occurs between the two levels.
+Allows you to add custom HTTP headers to all API requests. This is useful for request tracing, monitoring, API gateway routing, or when different models require different headers. For provider models, define `customHeaders` in `modelProviders[].generationConfig.customHeaders`. For runtime models without a matching provider entry, define it in `model.generationConfig.customHeaders`. No merging occurs between the two levels.
 
-The `extra_body` field allows you to add custom parameters to the request body sent to the API. This is useful for provider-specific options that are not covered by the standard configuration fields. **Note: This field is only supported for OpenAI-compatible providers (`openai`, `qwen-oauth`). It is ignored for Anthropic and Gemini providers.** If `extra_body` is defined in `modelProviders[].generationConfig.extra_body`, it will be used directly; otherwise, values from `model.generationConfig.extra_body` will be used.
+The `extra_body` field allows you to add custom parameters to the request body sent to the API. This is useful for provider-specific options that are not covered by the standard configuration fields. **Note: This field is only supported for OpenAI-compatible providers (`openai`, `qwen-oauth`). It is ignored for Anthropic and Gemini providers.** For provider models, define `extra_body` in `modelProviders[].generationConfig.extra_body`. For runtime models without a matching provider entry, define it in `model.generationConfig.extra_body`.
 
 **model.openAILoggingDir examples:**
 

--- a/packages/cli/src/utils/modelConfigUtils.test.ts
+++ b/packages/cli/src/utils/modelConfigUtils.test.ts
@@ -662,6 +662,44 @@ describe('modelConfigUtils', () => {
       expect(result.warnings).toEqual([]);
     });
 
+    it('should not warn for unknown top-level generationConfig fields', () => {
+      const argv = {};
+      const modelProvider: ProviderModelConfig = {
+        id: 'provider-model',
+        name: 'Provider Model',
+      };
+      const settings = makeMockSettings({
+        model: {
+          name: 'provider-model',
+          generationConfig: {
+            contextWindwSize: 128000,
+          } as Record<string, unknown>,
+        },
+        modelProviders: {
+          [AuthType.USE_OPENAI]: [modelProvider],
+        },
+      });
+      const selectedAuthType = AuthType.USE_OPENAI;
+
+      vi.mocked(resolveModelConfig).mockReturnValue({
+        config: {
+          model: 'provider-model',
+          apiKey: '',
+          baseUrl: '',
+        },
+        sources: {},
+        warnings: [],
+      });
+
+      const result = resolveCliGenerationConfig({
+        argv,
+        settings,
+        selectedAuthType,
+      });
+
+      expect(result.warnings).toEqual([]);
+    });
+
     it('should append ignored generationConfig warnings to resolver warnings', () => {
       const argv = {};
       const modelProvider: ProviderModelConfig = {

--- a/packages/cli/src/utils/modelConfigUtils.test.ts
+++ b/packages/cli/src/utils/modelConfigUtils.test.ts
@@ -532,6 +532,176 @@ describe('modelConfigUtils', () => {
       expect(result.warnings).toEqual(['Warning 1', 'Warning 2']);
     });
 
+    it('should warn when top-level generationConfig fields are ignored for a provider model', () => {
+      const argv = {};
+      const modelProvider: ProviderModelConfig = {
+        id: 'qwen3.6-27b',
+        name: 'qwen3.6-27b',
+        baseUrl: 'http://localhost:8080/v1',
+        envKey: 'IK_LLAMA_API_KEY',
+      };
+      const settings = makeMockSettings({
+        model: {
+          name: 'qwen3.6-27b',
+          generationConfig: {
+            contextWindowSize: 192000,
+            extra_body: {
+              enable_thinking: true,
+            },
+          } as Record<string, unknown>,
+        },
+        modelProviders: {
+          [AuthType.USE_OPENAI]: [modelProvider],
+        },
+      });
+      const selectedAuthType = AuthType.USE_OPENAI;
+
+      vi.mocked(resolveModelConfig).mockReturnValue({
+        config: {
+          model: 'qwen3.6-27b',
+          apiKey: '',
+          baseUrl: 'http://localhost:8080/v1',
+        },
+        sources: {},
+        warnings: [],
+      });
+
+      const result = resolveCliGenerationConfig({
+        argv,
+        settings,
+        selectedAuthType,
+      });
+
+      expect(result.warnings).toHaveLength(1);
+      expect(result.warnings[0]).toContain(
+        'model.generationConfig.contextWindowSize',
+      );
+      expect(result.warnings[0]).toContain('model.generationConfig.extra_body');
+      expect(result.warnings[0]).toContain(
+        'provider model "qwen3.6-27b" from modelProviders.openai',
+      );
+      expect(result.warnings[0]).toContain(
+        'modelProviders.openai[].generationConfig',
+      );
+    });
+
+    it('should not warn for top-level generationConfig on runtime models', () => {
+      const argv = {};
+      const settings = makeMockSettings({
+        model: {
+          name: 'runtime-model',
+          generationConfig: {
+            contextWindowSize: 192000,
+          } as Record<string, unknown>,
+        },
+        modelProviders: {
+          [AuthType.USE_OPENAI]: [{ id: 'other-model', name: 'Other Model' }],
+        },
+      });
+      const selectedAuthType = AuthType.USE_OPENAI;
+
+      vi.mocked(resolveModelConfig).mockReturnValue({
+        config: {
+          model: 'runtime-model',
+          apiKey: '',
+          baseUrl: '',
+          contextWindowSize: 192000,
+        },
+        sources: {},
+        warnings: [],
+      });
+
+      const result = resolveCliGenerationConfig({
+        argv,
+        settings,
+        selectedAuthType,
+      });
+
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('should not warn for generationConfig fields defined by the provider model', () => {
+      const argv = {};
+      const modelProvider: ProviderModelConfig = {
+        id: 'provider-model',
+        name: 'Provider Model',
+        generationConfig: {
+          contextWindowSize: 192000,
+        },
+      };
+      const settings = makeMockSettings({
+        model: {
+          name: 'provider-model',
+          generationConfig: {
+            contextWindowSize: 128000,
+          } as Record<string, unknown>,
+        },
+        modelProviders: {
+          [AuthType.USE_OPENAI]: [modelProvider],
+        },
+      });
+      const selectedAuthType = AuthType.USE_OPENAI;
+
+      vi.mocked(resolveModelConfig).mockReturnValue({
+        config: {
+          model: 'provider-model',
+          apiKey: '',
+          baseUrl: '',
+          contextWindowSize: 192000,
+        },
+        sources: {},
+        warnings: [],
+      });
+
+      const result = resolveCliGenerationConfig({
+        argv,
+        settings,
+        selectedAuthType,
+      });
+
+      expect(result.warnings).toEqual([]);
+    });
+
+    it('should append ignored generationConfig warnings to resolver warnings', () => {
+      const argv = {};
+      const modelProvider: ProviderModelConfig = {
+        id: 'provider-model',
+        name: 'Provider Model',
+      };
+      const settings = makeMockSettings({
+        model: {
+          name: 'provider-model',
+          generationConfig: {
+            modalities: { image: false },
+          } as Record<string, unknown>,
+        },
+        modelProviders: {
+          [AuthType.USE_OPENAI]: [modelProvider],
+        },
+      });
+      const selectedAuthType = AuthType.USE_OPENAI;
+
+      vi.mocked(resolveModelConfig).mockReturnValue({
+        config: {
+          model: 'provider-model',
+          apiKey: '',
+          baseUrl: '',
+        },
+        sources: {},
+        warnings: ['Resolver warning'],
+      });
+
+      const result = resolveCliGenerationConfig({
+        argv,
+        settings,
+        selectedAuthType,
+      });
+
+      expect(result.warnings).toHaveLength(2);
+      expect(result.warnings[0]).toBe('Resolver warning');
+      expect(result.warnings[1]).toContain('model.generationConfig.modalities');
+    });
+
     it('should use custom env when provided', () => {
       const argv = {};
       const settings = makeMockSettings({

--- a/packages/cli/src/utils/modelConfigUtils.test.ts
+++ b/packages/cli/src/utils/modelConfigUtils.test.ts
@@ -699,7 +699,10 @@ describe('modelConfigUtils', () => {
 
       expect(result.warnings).toHaveLength(2);
       expect(result.warnings[0]).toBe('Resolver warning');
-      expect(result.warnings[1]).toContain('model.generationConfig.modalities');
+      expect(result.warnings[1]).toContain(
+        'model.generationConfig.modalities is ignored',
+      );
+      expect(result.warnings[1]).toContain('Move this field');
     });
 
     it('should use custom env when provided', () => {

--- a/packages/cli/src/utils/modelConfigUtils.ts
+++ b/packages/cli/src/utils/modelConfigUtils.ts
@@ -26,25 +26,6 @@ const AUTH_ENV_MODEL_VARS: Record<AuthType, string[]> = {
   [AuthType.QWEN_OAUTH]: [],
 };
 
-const GENERATION_CONFIG_WARNING_FIELDS = [
-  'samplingParams',
-  'timeout',
-  'maxRetries',
-  'retryErrorCodes',
-  'enableCacheControl',
-  'schemaCompliance',
-  'reasoning',
-  'contextWindowSize',
-  'customHeaders',
-  'extra_body',
-  'modalities',
-  'splitToolMedia',
-] as const satisfies ReadonlyArray<keyof ContentGeneratorConfig>;
-
-function hasOwn(object: object, key: PropertyKey): boolean {
-  return Object.prototype.hasOwnProperty.call(object, key);
-}
-
 function getIgnoredTopLevelGenerationConfigFields(
   settingsGenerationConfig: Partial<ContentGeneratorConfig> | undefined,
   modelProvider: ProviderModelConfig | undefined,
@@ -54,10 +35,8 @@ function getIgnoredTopLevelGenerationConfigFields(
   }
 
   const providerGenerationConfig = modelProvider.generationConfig ?? {};
-  return GENERATION_CONFIG_WARNING_FIELDS.filter(
-    (field) =>
-      hasOwn(settingsGenerationConfig, field) &&
-      !hasOwn(providerGenerationConfig, field),
+  return Object.keys(settingsGenerationConfig).filter(
+    (field) => !Object.hasOwn(providerGenerationConfig, field),
   );
 }
 
@@ -73,14 +52,12 @@ function buildIgnoredTopLevelGenerationConfigWarning(
   const fieldList = ignoredFields
     .map((field) => `model.generationConfig.${field}`)
     .join(', ');
+  const isSingular = ignoredFields.length === 1;
+  const verb = isSingular ? 'is' : 'are';
+  const fieldReference = isSingular ? 'this field' : 'these fields';
+  const pronoun = isSingular ? 'it' : 'them';
 
-  return `Warning: ${fieldList} ${
-    ignoredFields.length === 1 ? 'is' : 'are'
-  } ignored for provider model "${modelProvider.id}" from modelProviders.${authType}. Move ${
-    ignoredFields.length === 1 ? 'this field' : 'these fields'
-  } to modelProviders.${authType}[].generationConfig for that model if you want ${
-    ignoredFields.length === 1 ? 'it' : 'them'
-  } to apply.`;
+  return `Warning: ${fieldList} ${verb} ignored for provider model "${modelProvider.id}" from modelProviders.${authType}. Move ${fieldReference} to modelProviders.${authType}[].generationConfig for that model if you want ${pronoun} to apply.`;
 }
 
 export interface CliGenerationConfigInputs {
@@ -245,6 +222,8 @@ export function resolveCliGenerationConfig(
 
   const resolved = resolveModelConfig(configSources);
 
+  // Provider-backed models are synced again during Config.refreshAuth(), which
+  // reapplies provider defaults after the initial resolver fallback.
   const ignoredGenerationConfigWarning =
     authType && modelProvider
       ? buildIgnoredTopLevelGenerationConfigWarning(

--- a/packages/cli/src/utils/modelConfigUtils.ts
+++ b/packages/cli/src/utils/modelConfigUtils.ts
@@ -26,6 +26,63 @@ const AUTH_ENV_MODEL_VARS: Record<AuthType, string[]> = {
   [AuthType.QWEN_OAUTH]: [],
 };
 
+const GENERATION_CONFIG_WARNING_FIELDS = [
+  'samplingParams',
+  'timeout',
+  'maxRetries',
+  'retryErrorCodes',
+  'enableCacheControl',
+  'schemaCompliance',
+  'reasoning',
+  'contextWindowSize',
+  'customHeaders',
+  'extra_body',
+  'modalities',
+  'splitToolMedia',
+] as const satisfies ReadonlyArray<keyof ContentGeneratorConfig>;
+
+function hasOwn(object: object, key: PropertyKey): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function getIgnoredTopLevelGenerationConfigFields(
+  settingsGenerationConfig: Partial<ContentGeneratorConfig> | undefined,
+  modelProvider: ProviderModelConfig | undefined,
+): string[] {
+  if (!settingsGenerationConfig || !modelProvider) {
+    return [];
+  }
+
+  const providerGenerationConfig = modelProvider.generationConfig ?? {};
+  return GENERATION_CONFIG_WARNING_FIELDS.filter(
+    (field) =>
+      hasOwn(settingsGenerationConfig, field) &&
+      !hasOwn(providerGenerationConfig, field),
+  );
+}
+
+function buildIgnoredTopLevelGenerationConfigWarning(
+  authType: AuthType,
+  modelProvider: ProviderModelConfig,
+  ignoredFields: string[],
+): string | undefined {
+  if (ignoredFields.length === 0) {
+    return undefined;
+  }
+
+  const fieldList = ignoredFields
+    .map((field) => `model.generationConfig.${field}`)
+    .join(', ');
+
+  return `Warning: ${fieldList} ${
+    ignoredFields.length === 1 ? 'is' : 'are'
+  } ignored for provider model "${modelProvider.id}" from modelProviders.${authType}. Move ${
+    ignoredFields.length === 1 ? 'this field' : 'these fields'
+  } to modelProviders.${authType}[].generationConfig for that model if you want ${
+    ignoredFields.length === 1 ? 'it' : 'them'
+  } to apply.`;
+}
+
 export interface CliGenerationConfigInputs {
   argv: {
     model?: string | undefined;
@@ -188,6 +245,20 @@ export function resolveCliGenerationConfig(
 
   const resolved = resolveModelConfig(configSources);
 
+  const ignoredGenerationConfigWarning =
+    authType && modelProvider
+      ? buildIgnoredTopLevelGenerationConfigWarning(
+          authType,
+          modelProvider,
+          getIgnoredTopLevelGenerationConfigFields(
+            settings.model?.generationConfig as
+              | Partial<ContentGeneratorConfig>
+              | undefined,
+            modelProvider,
+          ),
+        )
+      : undefined;
+
   // Resolve OpenAI logging config (CLI-specific, not part of core resolver)
   const enableOpenAILogging =
     (typeof argv.openaiLogging === 'undefined'
@@ -211,6 +282,11 @@ export function resolveCliGenerationConfig(
     baseUrl: resolved.config.baseUrl || '',
     generationConfig,
     sources: resolved.sources,
-    warnings: resolved.warnings,
+    warnings: [
+      ...resolved.warnings,
+      ...(ignoredGenerationConfigWarning
+        ? [ignoredGenerationConfigWarning]
+        : []),
+    ],
   };
 }

--- a/packages/cli/src/utils/modelConfigUtils.ts
+++ b/packages/cli/src/utils/modelConfigUtils.ts
@@ -6,6 +6,7 @@
 
 import {
   AuthType,
+  MODEL_GENERATION_CONFIG_FIELDS,
   type ContentGeneratorConfig,
   type ContentGeneratorConfigSources,
   resolveModelConfig,
@@ -35,8 +36,10 @@ function getIgnoredTopLevelGenerationConfigFields(
   }
 
   const providerGenerationConfig = modelProvider.generationConfig ?? {};
-  return Object.keys(settingsGenerationConfig).filter(
-    (field) => !Object.hasOwn(providerGenerationConfig, field),
+  return MODEL_GENERATION_CONFIG_FIELDS.filter(
+    (field) =>
+      Object.hasOwn(settingsGenerationConfig, field) &&
+      !Object.hasOwn(providerGenerationConfig, field),
   );
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,7 @@ export {
   type ModelsConfigOptions,
   type ModelProvidersConfig,
   type ModelSwitchMetadata,
+  MODEL_GENERATION_CONFIG_FIELDS,
   type OnModelChangeCallback,
   QWEN_OAUTH_MODELS,
   resolveModelConfig,


### PR DESCRIPTION
## Summary

- What changed: Added a startup warning when a selected provider-backed model has top-level generation settings that will not apply, and clarified local model configuration examples.
- Why it changed: Provider-backed models use their provider entry as the effective configuration, so missing provider-level context settings can silently fall back to auto-detected limits.
- Reviewer focus: Please check that the warning is scoped to provider-backed models and does not change model resolution behavior.

## Validation

- Commands run:
  ```bash
  source ~/.nvm/nvm.sh && nvm use 20.19.0 >/dev/null && node --version && npm --version && cd packages/cli && npx vitest run src/utils/modelConfigUtils.test.ts
  source ~/.nvm/nvm.sh && nvm use 20.19.0 >/dev/null && npm run build && npm run typecheck
  source ~/.nvm/nvm.sh && nvm use 20.19.0 >/dev/null && cd packages/cli && npx eslint src/utils/modelConfigUtils.ts src/utils/modelConfigUtils.test.ts
  git diff --check
  ```
- tmux real-user run:
  ```bash
  # Temporary HOME contained a redacted ~/.qwen/settings.json with:
  # - modelProviders.openai[].id = qwen3.6-27b
  # - model.generationConfig.contextWindowSize = 192000
  # - no provider-level generationConfig
  npm run dev -- --approval-mode yolo
  ```
- Prompts / inputs used: Unit tests and tmux both use a local OpenAI-compatible provider model with top-level `model.generationConfig.contextWindowSize` and no matching provider-level value.
- Expected result: The provider-backed case emits a startup warning that points users to the matching provider entry; runtime/raw models do not warn; existing resolver warnings are preserved.
- Observed result: All targeted unit tests passed, build and typecheck completed successfully, ESLint passed for the changed TypeScript files, `git diff --check` reported no whitespace issues, and the tmux TUI run displayed the startup warning. `npm run build` emitted only the existing Browserslist database age warning.
- Quickest reviewer verification path:
  ```bash
  source ~/.nvm/nvm.sh && nvm use 20.19.0 >/dev/null && cd packages/cli && npx vitest run src/utils/modelConfigUtils.test.ts
  ```
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  ```text
  v20.19.0
  10.8.2
  ✓ src/utils/modelConfigUtils.test.ts (45 tests) 34ms
  Test Files  1 passed (1)
  Tests  45 passed (45)

  npm run build && npm run typecheck exited with code 0
  npx eslint src/utils/modelConfigUtils.ts src/utils/modelConfigUtils.test.ts exited with code 0
  git diff --check exited with code 0
  ```
- tmux transcript excerpt:
  ```text
  export NVM_DIR='/Users/jinye.djy/.nvm'
  source "$NVM_DIR/nvm.sh" && nvm use 20.19.0 >/dev/null
  export HOME='.../tmp/provider-generation-config-warning-node20-tmux-20260507-003157/home' IK_LLAMA_API_KEY='dummy-key' NO_BROWSER=1 QWEN_CODE_NO_RELAUNCH=true
  node --version && npm --version
  v20.19.0
  10.8.2
  npm run dev -- --approval-mode yolo

  │ Warning: model.generationConfig.timeout, model.generationConfig.enableCacheControl, model.generationConfig.contextWindowSize, model.generationConfig.extra_body, model.generationConfig.modalities   │
  │ are ignored for provider model "qwen3.6-27b" from modelProviders.openai. Move these fields to modelProviders.openai[].generationConfig for that model if you want them to apply.                     │

  PASS: warning text containing model.generationConfig.contextWindowSize was observed.
  ```
- Local tmux artifacts retained:
  ```text
  tmp/provider-generation-config-warning-node20-tmux-20260507-003157/tmux-readable-full.log
  tmp/provider-generation-config-warning-node20-tmux-20260507-003157/tmux-final-capture.log
  tmp/provider-generation-config-warning-node20-tmux-20260507-003157/report.md
  ```

## Scope / Risk

- Main risk or tradeoff: The warning could be noisy if users intentionally keep unused top-level generation settings while selecting a provider-backed model.
- Not covered / not validated: Windows and Linux TUI rendering were not run locally.
- Breaking changes / migration notes: No behavior change to model resolution. Users should place provider-backed model overrides in the matching provider entry.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Verified locally on macOS with Node.js v20.19.0 and npm 10.8.2.
- Windows and Linux were not run locally.
- Docker, Podman, and Seatbelt are not affected by this config warning and documentation update.

## Linked Issues / Bugs

Related to #3878
