### PR TITLE
fix(core): address @tanzhenxin's PR-1 review notes (post-merge follow-up to #3842)

### DIFF
--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -1918,22 +1918,21 @@ describe('getShellAbortReasonKind (defensive abort-reason read)', () => {
     expect(getShellAbortReasonKind(proxyReason)).toBe('cancel');
   });
 
-  it("returns 'cancel' when the `getOwnPropertyDescriptor` Proxy trap throws (regression for @tanzhenxin's PR-1 review note)", () => {
+  it("returns 'cancel' when the `getOwnPropertyDescriptor` Proxy trap throws", () => {
     // `Object.prototype.hasOwnProperty.call(reason, 'kind')` triggers
     // the `[[GetOwnProperty]]` Proxy trap. A Proxy whose
     // `getOwnPropertyDescriptor` handler throws (separate from the
     // `get` trap covered by the test above) used to propagate past
     // the helper because `hasOwnProperty.call` was outside the try.
     // Now the helper wraps both the descriptor probe and the property
-    // read, so this also falls back to 'cancel'.
+    // read, so this also falls back to 'cancel'. (No `get` handler on
+    // the proxy: `hasOwnProperty.call` throws before the helper ever
+    // tries to read `kind`.)
     const throwingDescriptorProxy = new Proxy(
       {},
       {
         getOwnPropertyDescriptor() {
           throw new Error('getOwnPropertyDescriptor blew up');
-        },
-        get() {
-          return undefined;
         },
       },
     );

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -679,33 +679,55 @@ describe('ShellExecutionService', () => {
       // listeners now). Without dataDisposable.dispose() in the abort
       // handler, the listener-retention bug would let post-promote bytes
       // leak into the foreground consumer.
+      //
+      // Implementation note: PTY's handleOutput is async (`processingChain`
+      // queues microtasks for headlessTerminal.write callbacks), unlike
+      // child_process's sync handleOutput. Sync `expect` immediately
+      // after emit-then-abort would only see the call count BEFORE chain
+      // items run — both pre and post would read 0 and the assertion
+      // would tautologically pass without exercising the
+      // `listenersDetached` guard. We drive the test using the
+      // `simulateExecution` helper, which awaits `handle.result` — by
+      // the time the result resolves, the abort handler has run its
+      // drain (so all queued chain items have settled) and we can read
+      // the final emit count.
+      const dataCallbackHolder: { current: (data: string) => void } = {
+        current: () => {},
+      };
       const { result } = await simulateExecution(
         'tail -f /tmp/never.log',
-        (pty, abortController) => {
-          // Data BEFORE promote — fed via the live onData listener so it
+        (pty, ac) => {
+          // Pre-promote data — fed via the live onData listener so it
           // reaches the foreground onOutputEvent normally.
-          const dataCallback = pty.onData.mock.calls[0][0];
-          dataCallback('pre-promote-data\n');
-          abortController.abort({
+          dataCallbackHolder.current = pty.onData.mock.calls[0][0];
+          dataCallbackHolder.current('pre-promote-data\n');
+          ac.abort({
             kind: 'background',
             shellId: 'bg_test123',
           } satisfies ShellAbortReason);
-          // Mirror the child_process equivalent test: emit data AFTER
-          // abort and assert onOutputEventMock call count does NOT
-          // increase. The mock disposable doesn't actually detach the
-          // callback (it's a vi.fn() stub), so invoking dataCallback
-          // directly here exercises the production-side
-          // `listenersDetached` guard inside handleOutput's chain
-          // callback. Without that guard, the foreground onOutputEvent
-          // would fire for post-promote bytes — exactly the leak the
-          // PR-1 review (round 4 by @tanzhenxin) flagged this test
-          // didn't actually verify.
-          const eventCountAtPromote = onOutputEventMock.mock.calls.length;
-          dataCallback('post-promote-data\n');
-          expect(onOutputEventMock.mock.calls.length).toBe(eventCountAtPromote);
         },
       );
       expect(result.promoted).toBe(true);
+      // Snapshot the count after promote settled — pre-promote chain
+      // item ran AFTER abort set listenersDetached=true (chain items
+      // queue at handleOutput time but only execute when their .then
+      // microtask runs), so even pre-promote emits may have been
+      // suppressed. We don't assert on the exact pre count; we just
+      // capture it as a baseline for the post-promote assertion below.
+      const eventCountAfterSettle = onOutputEventMock.mock.calls.length;
+      // Suppress the post-promote-emit unhandled rejection (mock chain
+      // items don't await; if production-side state has been torn
+      // down, the inner promise might reject — fine for this test).
+      // Drive the data callback again after promote: production-side
+      // dataDisposable was disposed (mock stub does not actually detach
+      // the callback, but production's listenersDetached guard inside
+      // chain callbacks suppresses onOutputEvent emits regardless).
+      dataCallbackHolder.current('post-promote-data\n');
+      // Wait one macrotask + a microtask flush to let any chain items
+      // queued by the post-promote dataCallback fully settle.
+      await new Promise((res) => setImmediate(res));
+      await new Promise((res) => setImmediate(res));
+      expect(onOutputEventMock.mock.calls.length).toBe(eventCountAfterSettle);
 
       // The disposable returned by mockPtyProcess.onData was disposed by
       // the abort handler — verify by calling .dispose's mock.

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -691,16 +691,12 @@ describe('ShellExecutionService', () => {
       // the time the result resolves, the abort handler has run its
       // drain (so all queued chain items have settled) and we can read
       // the final emit count.
-      const dataCallbackHolder: { current: (data: string) => void } = {
-        current: () => {},
-      };
       const { result } = await simulateExecution(
         'tail -f /tmp/never.log',
         (pty, ac) => {
           // Pre-promote data — fed via the live onData listener so it
           // reaches the foreground onOutputEvent normally.
-          dataCallbackHolder.current = pty.onData.mock.calls[0][0];
-          dataCallbackHolder.current('pre-promote-data\n');
+          pty.onData.mock.calls[0][0]('pre-promote-data\n');
           ac.abort({
             kind: 'background',
             shellId: 'bg_test123',
@@ -721,14 +717,14 @@ describe('ShellExecutionService', () => {
       // assertion.
       const eventCountAfterSettle = onOutputEventMock.mock.calls.length;
       expect(eventCountAfterSettle).toBe(0);
-      // Suppress the post-promote-emit unhandled rejection (mock chain
-      // items don't await; if production-side state has been torn
-      // down, the inner promise might reject — fine for this test).
       // Drive the data callback again after promote: production-side
-      // dataDisposable was disposed (mock stub does not actually detach
-      // the callback, but production's listenersDetached guard inside
-      // chain callbacks suppresses onOutputEvent emits regardless).
-      dataCallbackHolder.current('post-promote-data\n');
+      // dataDisposable was disposed, but the mock stub doesn't actually
+      // detach the callback (the disposable returned by `vi.fn()` is a
+      // no-op). Re-invoking via `mock.calls[0][0]` exercises the
+      // production-side `listenersDetached` guard inside the chain
+      // callback, which is the real backstop against post-promote
+      // bytes leaking to the foreground onOutputEvent.
+      mockPtyProcess.onData.mock.calls[0][0]('post-promote-data\n');
       // Wait one macrotask + a microtask flush to let any chain items
       // queued by the post-promote dataCallback fully settle.
       await new Promise((res) => setImmediate(res));

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -684,11 +684,25 @@ describe('ShellExecutionService', () => {
         (pty, abortController) => {
           // Data BEFORE promote — fed via the live onData listener so it
           // reaches the foreground onOutputEvent normally.
-          pty.onData.mock.calls[0][0]('pre-promote-data\n');
+          const dataCallback = pty.onData.mock.calls[0][0];
+          dataCallback('pre-promote-data\n');
           abortController.abort({
             kind: 'background',
             shellId: 'bg_test123',
           } satisfies ShellAbortReason);
+          // Mirror the child_process equivalent test: emit data AFTER
+          // abort and assert onOutputEventMock call count does NOT
+          // increase. The mock disposable doesn't actually detach the
+          // callback (it's a vi.fn() stub), so invoking dataCallback
+          // directly here exercises the production-side
+          // `listenersDetached` guard inside handleOutput's chain
+          // callback. Without that guard, the foreground onOutputEvent
+          // would fire for post-promote bytes — exactly the leak the
+          // PR-1 review (round 4 by @tanzhenxin) flagged this test
+          // didn't actually verify.
+          const eventCountAtPromote = onOutputEventMock.mock.calls.length;
+          dataCallback('post-promote-data\n');
+          expect(onOutputEventMock.mock.calls.length).toBe(eventCountAtPromote);
         },
       );
       expect(result.promoted).toBe(true);
@@ -1878,6 +1892,28 @@ describe('getShellAbortReasonKind (defensive abort-reason read)', () => {
       },
     );
     expect(getShellAbortReasonKind(proxyReason)).toBe('cancel');
+  });
+
+  it("returns 'cancel' when the `getOwnPropertyDescriptor` Proxy trap throws (regression for @tanzhenxin's PR-1 review note)", () => {
+    // `Object.prototype.hasOwnProperty.call(reason, 'kind')` triggers
+    // the `[[GetOwnProperty]]` Proxy trap. A Proxy whose
+    // `getOwnPropertyDescriptor` handler throws (separate from the
+    // `get` trap covered by the test above) used to propagate past
+    // the helper because `hasOwnProperty.call` was outside the try.
+    // Now the helper wraps both the descriptor probe and the property
+    // read, so this also falls back to 'cancel'.
+    const throwingDescriptorProxy = new Proxy(
+      {},
+      {
+        getOwnPropertyDescriptor() {
+          throw new Error('getOwnPropertyDescriptor blew up');
+        },
+        get() {
+          return undefined;
+        },
+      },
+    );
+    expect(getShellAbortReasonKind(throwingDescriptorProxy)).toBe('cancel');
   });
 
   it("returns 'background' for the canonical happy-path reason", () => {

--- a/packages/core/src/services/shellExecutionService.test.ts
+++ b/packages/core/src/services/shellExecutionService.test.ts
@@ -708,13 +708,19 @@ describe('ShellExecutionService', () => {
         },
       );
       expect(result.promoted).toBe(true);
-      // Snapshot the count after promote settled — pre-promote chain
-      // item ran AFTER abort set listenersDetached=true (chain items
-      // queue at handleOutput time but only execute when their .then
-      // microtask runs), so even pre-promote emits may have been
-      // suppressed. We don't assert on the exact pre count; we just
-      // capture it as a baseline for the post-promote assertion below.
+      // Snapshot the count after promote settled. Pre-promote chain
+      // item ran AFTER abort set `listenersDetached = true` (chain
+      // items queue at handleOutput time but only execute when their
+      // .then microtask runs, which is after the sync abort dispatch
+      // that set the flag), so the pre-promote emit was already
+      // suppressed by the guard. Asserting `0` here pins both halves
+      // of the contract — pre-promote AND post-promote bytes are both
+      // suppressed once `listenersDetached` is set. Without the guard,
+      // pre-promote's render path would emit a `'data'` event into
+      // `onOutputEventMock` and this would be `>= 1`, failing the
+      // assertion.
       const eventCountAfterSettle = onOutputEventMock.mock.calls.length;
+      expect(eventCountAfterSettle).toBe(0);
       // Suppress the post-promote-emit unhandled rejection (mock chain
       // items don't await; if production-side state has been torn
       // down, the inner promise might reject — fine for this test).

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -64,13 +64,12 @@ export function getShellAbortReasonKind(
 ): ShellAbortReason['kind'] {
   if (reason !== null && typeof reason === 'object') {
     try {
-      // Both `hasOwnProperty.call` AND the `kind` read are inside the try:
-      // `hasOwnProperty.call` triggers the `[[GetOwnProperty]]` Proxy trap
-      // (`getOwnPropertyDescriptor` handler), so a Proxy whose
-      // `getOwnPropertyDescriptor` throws — separate from a throwing
-      // `get` trap — would otherwise propagate past the helper. (Caught
-      // by @tanzhenxin in the PR-1 review; my own audit only covered
-      // `get` trap throws.)
+      // Both `hasOwnProperty.call` AND the `kind` read are inside the
+      // try: `hasOwnProperty.call` triggers the `[[GetOwnProperty]]`
+      // Proxy trap (`getOwnPropertyDescriptor` handler), so a Proxy
+      // whose `getOwnPropertyDescriptor` throws — separate from a
+      // throwing `get` trap — would otherwise propagate past the
+      // helper.
       if (Object.prototype.hasOwnProperty.call(reason, 'kind')) {
         const kind = (reason as { kind?: unknown }).kind;
         // INVARIANT — three points must be kept in sync when extending

--- a/packages/core/src/services/shellExecutionService.ts
+++ b/packages/core/src/services/shellExecutionService.ts
@@ -62,26 +62,32 @@ const PROMOTE_DRAIN_TIMEOUT_MS = 200;
 export function getShellAbortReasonKind(
   reason: unknown,
 ): ShellAbortReason['kind'] {
-  if (
-    reason !== null &&
-    typeof reason === 'object' &&
-    Object.prototype.hasOwnProperty.call(reason, 'kind')
-  ) {
+  if (reason !== null && typeof reason === 'object') {
     try {
-      const kind = (reason as { kind?: unknown }).kind;
-      // INVARIANT — three points must be kept in sync when extending
-      // `ShellAbortReason`:
-      //   (1) the discriminated union below (`type ShellAbortReason`),
-      //   (2) the value-equality whitelist on this line, and
-      //   (3) the `case` arms in both abort-handler switches (the
-      //       `default: { const _exhaustive: never = kind; ... }`
-      //       statically forces #3 when #1 grows, but #2 has no
-      //       compile-time tie to the union; if you forget to extend
-      //       it the new variant silently degrades to 'cancel' here
-      //       and the `case` you added in #3 is never reached).
-      if (kind === 'background' || kind === 'cancel') return kind;
+      // Both `hasOwnProperty.call` AND the `kind` read are inside the try:
+      // `hasOwnProperty.call` triggers the `[[GetOwnProperty]]` Proxy trap
+      // (`getOwnPropertyDescriptor` handler), so a Proxy whose
+      // `getOwnPropertyDescriptor` throws — separate from a throwing
+      // `get` trap — would otherwise propagate past the helper. (Caught
+      // by @tanzhenxin in the PR-1 review; my own audit only covered
+      // `get` trap throws.)
+      if (Object.prototype.hasOwnProperty.call(reason, 'kind')) {
+        const kind = (reason as { kind?: unknown }).kind;
+        // INVARIANT — three points must be kept in sync when extending
+        // `ShellAbortReason`:
+        //   (1) the discriminated union below (`type ShellAbortReason`),
+        //   (2) the value-equality whitelist on this line, and
+        //   (3) the `case` arms in both abort-handler switches (the
+        //       `default: { const _exhaustive: never = kind; ... }`
+        //       statically forces #3 when #1 grows, but #2 has no
+        //       compile-time tie to the union; if you forget to extend
+        //       it the new variant silently degrades to 'cancel' here
+        //       and the `case` you added in #3 is never reached).
+        if (kind === 'background' || kind === 'cancel') return kind;
+      }
     } catch {
-      // Throwing accessor / Proxy trap — fall back to safe kill below.
+      // Throwing accessor / Proxy trap (either `get` or
+      // `getOwnPropertyDescriptor`) — fall back to safe kill below.
     }
   }
   return 'cancel';


### PR DESCRIPTION
Fast-follow on the PR-1 of #3831 (merged at #3842). @tanzhenxin's approving review left three non-blocking notes; this PR addresses two of them. Note 1 stays for PR-2.

## Fixed

### Note 2 (real bug) — \`getShellAbortReasonKind\` Proxy-trap leak

> The \`hasOwnProperty.call\` on the reason runs outside the \`try\`. A Proxy with a throwing \`getOwnPropertyDescriptor\` trap would propagate past the helper. Probably worth moving the check inside the try.

Confirmed: \`Object.prototype.hasOwnProperty.call(reason, 'kind')\` triggers the \`[[GetOwnProperty]]\` Proxy trap. A Proxy whose \`getOwnPropertyDescriptor\` handler throws would propagate up past the helper, then through the abort handler's \`switch\` on \`kind\`, then out of the (async) abort listener. \`addEventListener\` doesn't await the listener's returned Promise, so a leaked throw would silently leave the shell process alive instead of being killed on cancel.

Wrapped both the descriptor probe and the value read inside the same try block. Added a regression test that uses a Proxy whose \`getOwnPropertyDescriptor\` throws — mirror of the existing throwing-\`get\` Proxy test.

My multi-round self-audit before merge covered 6 attack vectors but missed this one — only \`get\` trap throws were considered. Worth noting publicly in case anyone else iterates here.

### Note 3 (test parity) — PTY handoff-boundary assertion

> Asserts \`dispose\` was called, but doesn't emit data after the abort to verify the foreground handler actually stops firing — the child_process equivalent does. Worth mirroring when convenient.

Mirrored. The PTY post-promotion test now re-invokes the production \`onData\` callback (via \`mockPtyProcess.onData.mock.calls[0][0]\`) AFTER the background abort, then awaits two \`setImmediate\` cycles to let any chain microtask fully settle, and asserts \`onOutputEventMock.mock.calls.length === 0\` both pre and post — the strict \`=== 0\` baseline pin guarantees the assertion fails if a future refactor lets the pre-promote chain item emit before \`listenersDetached\` is set, not just if pre and post counts diverge. Exercises the production \`listenersDetached\` guard inside the chain callback, which the bare \`dispose-was-called\` check didn't.

(PTY's \`handleOutput\` is async via \`processingChain\` — child_process's equivalent is sync, so the mirror needed extra microtask flush + an explicit \`=== 0\` baseline rather than just asserting the count didn't change between two synchronous reads.)

## Deferred to PR-2

### Note 1 — \`aborted\` + \`promoted\` shape

> Both promote branches resolve with \`aborted: true, promoted: true\`. The existing \`tools/shell.ts\` consumer checks \`aborted\` first and emits \"cancelled\" copy. PR-2 callers will need to branch on \`promoted\` before \`aborted\`. Might be cleaner to set \`aborted: false\` when \`promoted: true\` so existing branches just work.

This is a contract simplification that affects PR-2's branching logic. Doing it here would change the result shape AGAIN before PR-2 lands, and PR-2 may want to weigh \`aborted: false\` vs an explicit \`if (result.promoted)\` check upstream of the cancel/timeout copy. Tracked as **design question 7 in #3831** — PR-2 will resolve this along with the caller-side branching logic.

## Test plan

- [x] \`vitest run packages/core/src/services/shellExecutionService.test.ts\`: **70 / 70 pass** (69 baseline + 1 new for the throwing-\`getOwnPropertyDescriptor\` case)
- [x] \`tsc --build packages/cli\` (CI-equivalent full mode): clean
- [x] ESLint: clean
- [ ] **Manual** (deferred — same as PR-1, no user-visible surface in this fast-follow): real \`@lydell/node-pty\` handoff exercised by PR-2.

## Related

- #3842 (PR-1 of #3831, merged) — reviewer notes addressed here
- #3831 (Phase D part b — design + 3-PR sequencing)
- #3634 (Background task management roadmap)

cc @tanzhenxin

