### PR TITLE
fix(core): stop per-subagent ToolRegistry on foreground-fork path

### DIFF
--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -695,6 +695,55 @@ describe('AgentTool', () => {
         undefined,
       );
     });
+
+    it('stops the per-subagent ToolRegistry after the fork body finishes', async () => {
+      // Regression: foreground-fork fires the body via
+      // `void runInForkContext(...)` and returns a placeholder
+      // synchronously. Without an inner try/finally, the per-subagent
+      // ToolRegistry built by `createApprovalModeOverride` would never
+      // be stopped, and any AgentTool / SkillTool the fork's model
+      // instantiates would leak its change-listener on shared
+      // SubagentManager / SkillManager. Other three spawn paths
+      // (foreground non-fork, background fork, background non-fork)
+      // already stop the registry in their finally blocks.
+      const stopSpy = vi.fn().mockResolvedValue(undefined);
+      const stubReg = {
+        copyDiscoveredToolsFrom: vi.fn(),
+        getAllTools: vi.fn().mockReturnValue([]),
+        getAllToolNames: vi.fn().mockReturnValue([]),
+        stop: stopSpy,
+      };
+      // The override Config built by `createApprovalModeOverride` calls
+      // `createToolRegistry` (returns the override's own registry) and
+      // `getToolRegistry` (during `copyDiscoveredToolsFrom(base...)`).
+      // The override's own getToolRegistry is then assigned to whatever
+      // `createToolRegistry` returned. Wire BOTH config getters so the
+      // post-override `agentConfig.getToolRegistry().stop()` reaches our
+      // spy.
+      vi.mocked(config.getToolRegistry).mockReturnValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        stubReg as any,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      vi.mocked((config as any).createToolRegistry).mockResolvedValue(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        stubReg as any,
+      );
+
+      const params: AgentParams = {
+        description: 'fork task',
+        prompt: 'do the thing',
+      };
+      const invocation = (
+        agentTool as AgentToolWithProtectedMethods
+      ).createInvocation(params);
+      await invocation.execute();
+
+      // Drain the detached fork body so its finally block runs.
+      await vi.runAllTimersAsync();
+
+      expect(stopSpy).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('SubagentStart hook integration', () => {

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -1434,10 +1434,27 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
         // Background fork execution. Run under an AsyncLocalStorage frame so
         // nested `agent` tool calls by the fork's model can be detected.
         // Forks run async (return a placeholder); skip foreground registration.
+        // Wrap the fork body in try/finally so the per-subagent ToolRegistry
+        // is stopped after the fork finishes — the other three spawn paths
+        // (foreground non-fork, background fork, background non-fork) already
+        // do this in their finally blocks. Without it, every AgentTool /
+        // SkillTool the fork's model instantiates from this registry leaks
+        // its change-listener on shared SubagentManager / SkillManager.
         const runFramedFork = () =>
-          runWithAgentContext({ agentId: hookOpts.agentId }, () =>
-            this.runSubagentWithHooks(subagent, contextState, hookOpts),
-          );
+          runWithAgentContext({ agentId: hookOpts.agentId }, async () => {
+            try {
+              await this.runSubagentWithHooks(
+                subagent,
+                contextState,
+                hookOpts,
+              );
+            } finally {
+              void agentConfig
+                .getToolRegistry()
+                .stop()
+                .catch(() => {});
+            }
+          });
         void runInForkContext(runFramedFork);
         return {
           llmContent: [{ text: FORK_PLACEHOLDER_RESULT }],


### PR DESCRIPTION
## Summary

Follow-up to #3873 review. The foreground-fork branch in `agent.ts:execute` fires the fork body via `void runInForkContext(runFramedFork)` and returns a placeholder synchronously, with no try/finally around the fork body. The other three spawn paths added in #3873 (foreground non-fork, background fork, background non-fork) already stop the per-subagent `ToolRegistry` in their finally blocks — this one was missed.

Without it, any `AgentTool` / `SkillTool` the fork's model later instantiates leaks its change-listener on the shared `SubagentManager` / `SkillManager` for the rest of the session. The other three paths' fix already proves the cleanup is safe (`stop()` is fire-and-forget; the disposed tools have only just released their listeners; discovered tools shared from parent are skipped because `DiscoveredTool` / `DiscoveredMCPTool` don't implement `dispose`).

## Change

```ts
const runFramedFork = () =>
  runWithAgentContext({ agentId: hookOpts.agentId }, async () => {
    try {
      await this.runSubagentWithHooks(subagent, contextState, hookOpts);
    } finally {
      void agentConfig.getToolRegistry().stop().catch(() => {});
    }
  });
void runInForkContext(runFramedFork);
```

Same shape as the background `bgBody` finally added in #3873.

## Tests

- New regression test in `agent.test.ts > Fork dispatch (subagent_type omitted) > stops the per-subagent ToolRegistry after the fork body finishes` — drains the detached fork body and asserts the stop spy was invoked exactly once.
- `npx vitest run packages/core/src` → 268 files / 6966 passed.

<details>
<summary>中文</summary>

## 概要

#3873 review follow-up。`agent.ts:execute` 的 foreground-fork 分支用 `void runInForkContext(runFramedFork)` fire-and-forget 启动 fork body，同步 return placeholder，没有 try/finally。#3873 加的其他三条 spawn 路径（fg 非 fork、bg fork、bg 非 fork）都已经在 finally 里 stop per-subagent `ToolRegistry`——这条漏了。

不修的话，fork 的 model 后续实例化的 `AgentTool` / `SkillTool` 在共享 `SubagentManager` / `SkillManager` 上挂的 change-listener 会泄漏到 session 结束。其他三条路径的修复已经证明清理是安全的（`stop()` fire-and-forget；被 dispose 的 tool 此刻刚释放 listener；从 parent 复制过来的 discovered tool 因为 `DiscoveredTool` / `DiscoveredMCPTool` 不实现 `dispose` 会被跳过）。

## 修改

跟 #3873 的 background `bgBody` finally 同形：try { 跑 subagent } finally { 异步 stop registry }。

## 测试

- `agent.test.ts > Fork dispatch ... > stops the per-subagent ToolRegistry after the fork body finishes` —— 等 detached fork body 跑完，断言 stop spy 被调一次。
- `npx vitest run packages/core/src` → 268 文件 / 6966 通过。

</details>