### PR TITLE
fix(core): close bound-tool gap on runForkedAgent's YOLO wrapper

### DIFF
--- a/packages/core/src/utils/forkedAgent.agent.test.ts
+++ b/packages/core/src/utils/forkedAgent.agent.test.ts
@@ -1,0 +1,229 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Config } from '../config/config.js';
+import { Config as ConfigImpl, ApprovalMode } from '../config/config.js';
+import { AgentHeadless } from '../agents/runtime/agent-headless.js';
+import { AgentTerminateMode } from '../agents/runtime/agent-types.js';
+import { runForkedAgent } from './forkedAgent.js';
+import { ToolNames } from '../tools/tool-names.js';
+import { EditTool } from '../tools/edit.js';
+import {
+  hasRebuiltToolRegistry,
+  TOOL_REGISTRY_REBUILT,
+} from '../tools/agent/agent.js';
+
+/**
+ * Regression: `runForkedAgent` (AgentHeadless path) used to produce its
+ * YOLO wrapper via `Object.create(parent) + getApprovalMode = YOLO`,
+ * which left the parent's already-bound `EditTool` / `WriteFileTool` /
+ * `ReadFileTool` reachable through the wrapper's prototype chain. Bound
+ * tools then read `this.config.getApprovalMode()` from the parent
+ * (silently ignoring the YOLO override) and `this.config.getFileReadCache()`
+ * from the parent's cache.
+ *
+ * The fix: route through `createApprovalModeOverride`, which rebuilds
+ * the tool registry on the wrapper so bound tools resolve `this.config`
+ * to the wrapper.
+ */
+describe('runForkedAgent (AgentHeadless path) bound-tool isolation', () => {
+  // Bare mode keeps the registry small (ReadFile / Edit / Shell only) so
+  // the rebuild covers the file tools we actually care about.
+  const baseParams = {
+    cwd: '/tmp',
+    targetDir: '/tmp',
+    debugMode: false,
+    model: 'test-model',
+    usageStatisticsEnabled: false,
+    bareMode: true,
+  };
+
+  // Spy on AgentHeadless.create at the source module rather than mocking
+  // the re-export layer in `agents/index.js` — vitest's module-mock layer
+  // doesn't reliably forward `export *` re-exports through `...actual`,
+  // and stubbing the full surface manually is brittle.
+  function captureAgentHeadlessConfig(): {
+    captured: { config: Config | undefined };
+    restore: () => void;
+  } {
+    const captured: { config: Config | undefined } = { config: undefined };
+    const spy = vi
+      .spyOn(AgentHeadless, 'create')
+      .mockImplementation(
+        async (
+          _name: string,
+          config: Config,
+          ..._rest: unknown[]
+        ): Promise<AgentHeadless> => {
+          captured.config = config;
+          return {
+            execute: vi.fn().mockResolvedValue(undefined),
+            getTerminateMode: vi.fn().mockReturnValue(AgentTerminateMode.GOAL),
+            getFinalText: vi.fn().mockReturnValue('done'),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any;
+        },
+      );
+    return { captured, restore: () => spy.mockRestore() };
+  }
+
+  it('passes a Config with the rebuilt-registry marker and YOLO approval mode to AgentHeadless.create', async () => {
+    const parent = new ConfigImpl(baseParams);
+    const parentRegistry = await parent.createToolRegistry(undefined, {
+      skipDiscovery: true,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (parent as any).toolRegistry = parentRegistry;
+
+    const { captured, restore } = captureAgentHeadlessConfig();
+    try {
+      const result = await runForkedAgent({
+        name: 'test-fork',
+        systemPrompt: 'You are a test fork.',
+        taskPrompt: 'do the task',
+        config: parent,
+      });
+      expect(result.status).toBe('completed');
+    } finally {
+      restore();
+    }
+
+    expect(captured.config).toBeDefined();
+    // The wrapper passed to AgentHeadless must:
+    // 1. Have its own rebuilt registry (Symbol marker propagation)
+    expect(hasRebuiltToolRegistry(captured.config!)).toBe(true);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((captured.config as any)[TOOL_REGISTRY_REBUILT]).toBe(true);
+    // 2. Resolve approval mode to YOLO (the override)
+    expect(captured.config!.getApprovalMode()).toBe(ApprovalMode.YOLO);
+    // 3. Hand out a different ToolRegistry instance from the parent
+    expect(captured.config!.getToolRegistry()).not.toBe(parentRegistry);
+  });
+
+  it('binds EditTool from the wrapper registry to the wrapper Config (not the parent)', async () => {
+    const parent = new ConfigImpl(baseParams);
+    const parentRegistry = await parent.createToolRegistry(undefined, {
+      skipDiscovery: true,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (parent as any).toolRegistry = parentRegistry;
+
+    const { captured, restore } = captureAgentHeadlessConfig();
+    try {
+      await runForkedAgent({
+        name: 'test-fork',
+        systemPrompt: 'You are a test fork.',
+        taskPrompt: 'do the task',
+        config: parent,
+      });
+    } finally {
+      restore();
+    }
+
+    expect(captured.config).toBeDefined();
+    const wrapperRegistry = captured.config!.getToolRegistry();
+    const editTool = await wrapperRegistry.ensureTool(ToolNames.EDIT);
+    expect(editTool).toBeInstanceOf(EditTool);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((editTool as any).config).toBe(captured.config);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const boundConfig = (editTool as any).config as Config;
+    expect(boundConfig.getApprovalMode()).toBe(ApprovalMode.YOLO);
+    expect(boundConfig.getFileReadCache()).toBe(
+      captured.config!.getFileReadCache(),
+    );
+    expect(boundConfig.getFileReadCache()).not.toBe(parent.getFileReadCache());
+  });
+
+  it('preserves an upstream getPermissionManager override (memory-scoped composition)', async () => {
+    // The memory extraction / dream agent path stacks two wrappers:
+    //   parent
+    //     └── scopedConfig (Object.create + getPermissionManager override)
+    //           └── yoloConfig (createApprovalModeOverride, sets registry + marker)
+    // Bound tools must see:
+    //   - approval mode = YOLO (from yoloConfig's own override)
+    //   - permission manager = scopedPm (walks proto past yoloConfig to scopedConfig)
+    const parent = new ConfigImpl(baseParams);
+    const parentRegistry = await parent.createToolRegistry(undefined, {
+      skipDiscovery: true,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (parent as any).toolRegistry = parentRegistry;
+
+    const scopedPm = { id: 'scoped-pm-marker' } as never;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const scopedConfig = Object.create(parent) as any;
+    scopedConfig.getPermissionManager = () => scopedPm;
+
+    const { captured, restore } = captureAgentHeadlessConfig();
+    try {
+      await runForkedAgent({
+        name: 'test-fork',
+        systemPrompt: 'You are a test fork.',
+        taskPrompt: 'do the task',
+        config: scopedConfig as Config,
+      });
+    } finally {
+      restore();
+    }
+
+    expect(captured.config).toBeDefined();
+    const editTool = await captured
+      .config!.getToolRegistry()
+      .ensureTool(ToolNames.EDIT);
+    expect(editTool).toBeInstanceOf(EditTool);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const boundConfig = (editTool as any).config as Config;
+    // YOLO from yoloConfig's own override
+    expect(boundConfig.getApprovalMode()).toBe(ApprovalMode.YOLO);
+    // Scoped PM from scopedConfig (one prototype level up)
+    expect(boundConfig.getPermissionManager?.()).toBe(scopedPm);
+  });
+
+  it('stops the per-fork ToolRegistry after the AgentHeadless body finishes', async () => {
+    const parent = new ConfigImpl(baseParams);
+    const parentRegistry = await parent.createToolRegistry(undefined, {
+      skipDiscovery: true,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (parent as any).toolRegistry = parentRegistry;
+
+    // Wrap parent.createToolRegistry so the registry it returns to
+    // `createApprovalModeOverride` carries a stop spy. The wrapper's
+    // own getToolRegistry is then assigned this same instance.
+    const stopSpy = vi.fn().mockResolvedValue(undefined);
+    const originalCreate = parent.createToolRegistry.bind(parent);
+    vi.spyOn(parent, 'createToolRegistry').mockImplementation(
+      async (...args) => {
+        const reg = await originalCreate(...args);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (reg as any).stop = stopSpy;
+        return reg;
+      },
+    );
+
+    const { restore } = captureAgentHeadlessConfig();
+    try {
+      await runForkedAgent({
+        name: 'test-fork',
+        systemPrompt: 'You are a test fork.',
+        taskPrompt: 'do the task',
+        config: parent,
+      });
+    } finally {
+      restore();
+    }
+
+    // stop() is fire-and-forget inside the runForkedAgent finally —
+    // it is awaited by the runtime via the resolved promise chain, so
+    // by the time `await runForkedAgent` returns the stop call has
+    // already started; flush microtasks for the catch handler.
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/utils/forkedAgent.agent.test.ts
+++ b/packages/core/src/utils/forkedAgent.agent.test.ts
@@ -226,4 +226,104 @@ describe('runForkedAgent (AgentHeadless path) bound-tool isolation', () => {
 
     expect(stopSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('stops the per-fork ToolRegistry even when AgentHeadless.create rejects', async () => {
+    // Failure-path regression: a future refactor could accidentally
+    // move the stop() out of the `finally` and onto the success path
+    // while every other test still passes. This test pins that the
+    // cleanup runs when `AgentHeadless.create` rejects before any
+    // body executes.
+    const parent = new ConfigImpl(baseParams);
+    const parentRegistry = await parent.createToolRegistry(undefined, {
+      skipDiscovery: true,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (parent as any).toolRegistry = parentRegistry;
+
+    const stopSpy = vi.fn().mockResolvedValue(undefined);
+    const originalCreate = parent.createToolRegistry.bind(parent);
+    vi.spyOn(parent, 'createToolRegistry').mockImplementation(
+      async (...args) => {
+        const reg = await originalCreate(...args);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (reg as any).stop = stopSpy;
+        return reg;
+      },
+    );
+
+    const createSpy = vi
+      .spyOn(AgentHeadless, 'create')
+      .mockRejectedValue(new Error('agent-headless-create-blew-up'));
+
+    try {
+      await expect(
+        runForkedAgent({
+          name: 'test-fork',
+          systemPrompt: 'You are a test fork.',
+          taskPrompt: 'do the task',
+          config: parent,
+        }),
+      ).rejects.toThrow('agent-headless-create-blew-up');
+    } finally {
+      createSpy.mockRestore();
+    }
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops the per-fork ToolRegistry even when headless.execute rejects', async () => {
+    // Same shape as the create-rejects test, but for the execute
+    // failure path. Together they pin the lifecycle stop to the
+    // `finally` block rather than any specific success branch.
+    const parent = new ConfigImpl(baseParams);
+    const parentRegistry = await parent.createToolRegistry(undefined, {
+      skipDiscovery: true,
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (parent as any).toolRegistry = parentRegistry;
+
+    const stopSpy = vi.fn().mockResolvedValue(undefined);
+    const originalCreate = parent.createToolRegistry.bind(parent);
+    vi.spyOn(parent, 'createToolRegistry').mockImplementation(
+      async (...args) => {
+        const reg = await originalCreate(...args);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (reg as any).stop = stopSpy;
+        return reg;
+      },
+    );
+
+    const createSpy = vi
+      .spyOn(AgentHeadless, 'create')
+      .mockImplementation(
+        async (..._args: unknown[]): Promise<AgentHeadless> =>
+          ({
+            execute: vi
+              .fn()
+              .mockRejectedValue(new Error('headless-execute-blew-up')),
+            getTerminateMode: vi
+              .fn()
+              .mockReturnValue(AgentTerminateMode.GOAL),
+            getFinalText: vi.fn().mockReturnValue(''),
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          }) as any,
+      );
+
+    try {
+      await expect(
+        runForkedAgent({
+          name: 'test-fork',
+          systemPrompt: 'You are a test fork.',
+          taskPrompt: 'do the task',
+          config: parent,
+        }),
+      ).rejects.toThrow('headless-execute-blew-up');
+    } finally {
+      createSpy.mockRestore();
+    }
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/core/src/utils/forkedAgent.ts
+++ b/packages/core/src/utils/forkedAgent.ts
@@ -31,6 +31,7 @@ import type {
 } from '@google/genai';
 import { ApprovalMode, type Config } from '../config/config.js';
 import { GeminiChat, StreamEventType } from '../core/geminiChat.js';
+import { createApprovalModeOverride } from '../tools/agent/agent.js';
 import {
   AgentHeadless,
   AgentEventEmitter,
@@ -257,17 +258,6 @@ export interface ForkedAgentResult {
 }
 
 /**
- * Returns a shallow clone of config with ApprovalMode forced to YOLO.
- * Background agents must never block on permission prompts — there is
- * no user present to answer them.
- */
-function createYoloConfig(config: Config): Config {
-  const yoloConfig = Object.create(config) as Config;
-  yoloConfig.getApprovalMode = () => ApprovalMode.YOLO;
-  return yoloConfig;
-}
-
-/**
  * Extracts file paths from a tool call's args object.
  * Matches any arg key that contains "path", "file", or "target".
  */
@@ -376,7 +366,23 @@ export async function runForkedAgent(
   }
 
   // ── AgentHeadless path ────────────────────────────────────────────────────
-  const yoloConfig = createYoloConfig(params.config);
+  // `createApprovalModeOverride` rebuilds the tool registry on the YOLO
+  // wrapper Config so core file tools (`EditTool` / `WriteFileTool` /
+  // `ReadFileTool`) resolve `this.config` to the wrapper, not to the
+  // parent. Without that rebuild the YOLO override is silently ignored
+  // on the bound-tool path (parent's pre-bound tool instances keep
+  // reading the parent's approval mode), and the wrapper's own
+  // `FileReadCache` lazy-init is bypassed too.
+  //
+  // Consumers that pre-wrap with `createMemoryScopedAgentConfig`
+  // (memory extraction / dream agent) compose correctly: the YOLO
+  // wrapper's bound tools resolve `this.config.getPermissionManager()`
+  // through the prototype chain to the scoped wrapper's own override,
+  // while `this.config.getApprovalMode()` lands on YOLO.
+  const yoloConfig = await createApprovalModeOverride(
+    params.config,
+    ApprovalMode.YOLO,
+  );
   const filesTouched = new Set<string>();
 
   const emitter = new AgentEventEmitter();
@@ -401,47 +407,58 @@ export async function runForkedAgent(
   const toolConfig: ToolConfig | undefined =
     params.tools !== undefined ? { tools: params.tools } : undefined;
 
-  const headless = await AgentHeadless.create(
-    params.name,
-    yoloConfig,
-    promptConfig,
-    modelConfig,
-    runConfig,
-    toolConfig,
-    emitter,
-  );
+  try {
+    const headless = await AgentHeadless.create(
+      params.name,
+      yoloConfig,
+      promptConfig,
+      modelConfig,
+      runConfig,
+      toolConfig,
+      emitter,
+    );
 
-  const context = new ContextState();
-  context.set('task_prompt', params.taskPrompt);
-  await headless.execute(context, params.abortSignal);
+    const context = new ContextState();
+    context.set('task_prompt', params.taskPrompt);
+    await headless.execute(context, params.abortSignal);
 
-  const terminateReason = headless.getTerminateMode();
-  const finalText = headless.getFinalText() || undefined;
-  const touched = [...filesTouched];
+    const terminateReason = headless.getTerminateMode();
+    const finalText = headless.getFinalText() || undefined;
+    const touched = [...filesTouched];
 
-  if (terminateReason === AgentTerminateMode.CANCELLED) {
+    if (terminateReason === AgentTerminateMode.CANCELLED) {
+      return {
+        status: 'cancelled',
+        terminateReason,
+        finalText,
+        filesTouched: touched,
+      };
+    }
+    if (
+      terminateReason === AgentTerminateMode.ERROR ||
+      terminateReason === AgentTerminateMode.TIMEOUT
+    ) {
+      return {
+        status: 'failed',
+        terminateReason,
+        finalText,
+        filesTouched: touched,
+      };
+    }
     return {
-      status: 'cancelled',
+      status: 'completed',
       terminateReason,
       finalText,
       filesTouched: touched,
     };
+  } finally {
+    // Release the per-fork ToolRegistry so AgentTool / SkillTool
+    // instances dispose their change-listeners on shared
+    // SubagentManager / SkillManager. Same shape as the spawn-path
+    // finallys in `agent.ts` and `background-agent-resume.ts`.
+    void yoloConfig
+      .getToolRegistry()
+      .stop()
+      .catch(() => {});
   }
-  if (
-    terminateReason === AgentTerminateMode.ERROR ||
-    terminateReason === AgentTerminateMode.TIMEOUT
-  ) {
-    return {
-      status: 'failed',
-      terminateReason,
-      finalText,
-      filesTouched: touched,
-    };
-  }
-  return {
-    status: 'completed',
-    terminateReason,
-    finalText,
-    filesTouched: touched,
-  };
 }


### PR DESCRIPTION
## Summary

Follow-up to #3873 review — addresses #3 of the three flagged adjacent Config-wrapper sites.

`runForkedAgent`'s AgentHeadless path built its YOLO override via a local `Object.create(parent) + getApprovalMode = YOLO` helper that did NOT rebuild the tool registry, so the parent's already-bound `EditTool` / `WriteFileTool` / `ReadFileTool` instances kept resolving `this.config` to the parent. Three concrete consequences:

1. **YOLO override silently ignored on the bound-tool path** — bound tools called `this.config.getApprovalMode()` which walked through the wrapper's prototype to the parent, returning the parent's mode rather than YOLO.
2. **Per-fork `FileReadCache` bypassed** — reads/mutations were tracked in the parent's cache.
3. **Memory-extraction stacking is the worst case** — `extractionAgentPlanner` and `dreamAgentPlanner` build a `getPermissionManager`-overriding `scopedConfig`, then hand it to `runForkedAgent` which used to wrap with the broken YOLO helper. Bound tools resolved to the parent, so both overrides — the YOLO mode AND the scoped permission manager — were bypassed.

## Fix

Route through the existing `createApprovalModeOverride` helper (#3873):

```ts
const yoloConfig = await createApprovalModeOverride(
  params.config,
  ApprovalMode.YOLO,
);
```

The helper:
- builds the wrapper via `Object.create(base)`,
- rebuilds the tool registry on the wrapper (so bound tools resolve `this.config` to the wrapper),
- copies discovered tools from the upstream registry (no re-discovery),
- sets the `TOOL_REGISTRY_REBUILT` Symbol marker so wrapper-on-wrapper layers downstream skip redundant rebuilds.

Memory-extraction / dream-agent composition now resolves correctly via prototype walk:

```
parent
  └── scopedConfig         (Object.create + getPermissionManager → scopedPm)
        └── yoloConfig     (createApprovalModeOverride: own R + marker + getApprovalMode → YOLO)
```

Tools bound to `yoloConfig` see `this.config.getApprovalMode() === YOLO` (own), `this.config.getPermissionManager() === scopedPm` (one proto level up), and `this.config.getFileReadCache()` lazy-installs a per-fork cache.

Wraps the AgentHeadless run in try/finally so the per-fork `ToolRegistry` is `stop()`'d after execution — same shape as the spawn finallys in `agent.ts` and `background-agent-resume.ts`. Without this, every `AgentTool` / `SkillTool` the fork's model later instantiates leaks its change-listener on shared `SubagentManager` / `SkillManager`.

## Tests

New `forkedAgent.agent.test.ts` covering:

1. The wrapper passed to `AgentHeadless.create` carries the `TOOL_REGISTRY_REBUILT` Symbol marker, has YOLO approval mode, and exposes a registry distinct from the parent's.
2. `EditTool` from the wrapper registry has `tool.config === wrapper` and reads YOLO + the wrapper's own FileReadCache.
3. **Memory-scoped composition** — wrapping a `getPermissionManager`-overriding `scopedConfig` produces bound tools that see YOLO from the wrapper AND `scopedPm` via prototype walk.
4. `stop()` fires once after the AgentHeadless body finishes.

Uses `vi.spyOn(AgentHeadless, 'create')` rather than module mocking so the real `ContextState` / `AgentEventEmitter` keep working — the re-export layer in `agents/index.js` doesn't reliably forward `export *` re-exports through `...actual`, which made the alternative module-mock approach brittle.

## Test plan

- [x] `npx vitest run packages/core/src` — 269 files / 6992 passed
- [x] `npx eslint` on changed files — clean
- [x] typecheck — clean

## Closes the #3873 follow-up triad

- ✅ #3887 — fg-fork lifecycle stop
- ✅ This PR — runForkedAgent YOLO wrapper
- The two memory planner files (`extractionAgentPlanner.ts` / `dreamAgentPlanner.ts`) need NO changes: their `createMemoryScopedAgentConfig` only adds `getPermissionManager`, and the downstream `runForkedAgent` rebuild handles the bound-tool isolation. The composition is verified by the memory-scoped test.

<details>
<summary>中文</summary>

## 概要

#3873 review 的 #3 follow-up（reviewer 标的三个相邻 wrapper 站点的最后一个）。

`runForkedAgent` 的 AgentHeadless 路径用本地 `Object.create(parent) + getApprovalMode = YOLO` helper 建 YOLO override，没重建 tool registry。Parent 早已绑好的 `EditTool` / `WriteFileTool` / `ReadFileTool` 仍把 `this.config` 解析回 parent。三个具体后果：

1. **YOLO override 在 bound-tool 路径上被静默忽略** —— bound tool 调 `this.config.getApprovalMode()` 走 wrapper 原型链回到 parent，返回的是 parent 的 mode 而不是 YOLO。
2. **per-fork `FileReadCache` 被绕过** —— 读写都记录到 parent 的 cache。
3. **memory-extraction 叠加 wrapper 是最差情况** —— `extractionAgentPlanner` / `dreamAgentPlanner` 先建 `getPermissionManager` override 的 `scopedConfig`，再交给 `runForkedAgent`，老 YOLO helper 套上去后 bound tool 仍解析回 parent，两个 override（YOLO mode + scoped permission manager）**都被绕过**。

## 修法

走 #3873 已有的 `createApprovalModeOverride`：rebuild registry + copy discovered tools + set Symbol marker。

memory-extraction / dream-agent 的组合现在通过原型链正确解析：

```
parent
  └── scopedConfig         (Object.create + getPermissionManager → scopedPm)
        └── yoloConfig     (createApprovalModeOverride: own R + marker + getApprovalMode → YOLO)
```

绑到 `yoloConfig` 的工具看到 `this.config.getApprovalMode() === YOLO`（own）、`this.config.getPermissionManager() === scopedPm`（上溯一层）、`this.config.getFileReadCache()` lazy 装一个 per-fork 的 cache。

AgentHeadless 跑完后用 try/finally 调 `stop()` —— 跟 `agent.ts` / `background-agent-resume.ts` 的 spawn finally 同形。否则 fork 的 model 实例化的 `AgentTool` / `SkillTool` 会在 `SubagentManager` / `SkillManager` 上挂 listener 一直泄漏到 session 结束。

## 测试

新增 `forkedAgent.agent.test.ts` 4 个测试：

1. AgentHeadless.create 收到的 wrapper 有 `TOOL_REGISTRY_REBUILT` symbol 标记 + YOLO approval mode + 独立 registry
2. wrapper registry 出来的 `EditTool` `tool.config === wrapper`，读 YOLO + wrapper 自己的 FileReadCache
3. **memory-scoped 组合** —— 套在 `getPermissionManager` override 的 `scopedConfig` 之上，bound tool 同时看到 YOLO + `scopedPm`
4. AgentHeadless body 跑完后 `stop()` 调一次

用 `vi.spyOn(AgentHeadless, 'create')` 而不是 module mock —— `agents/index.js` 的 `export *` 在 vitest mock 下 `...actual` 不能可靠转发，module mock 太脆。

## 已完整覆盖 #3873 三连 follow-up

- ✅ #3887 —— fg-fork lifecycle stop
- ✅ 本 PR —— runForkedAgent YOLO wrapper
- 两个 memory planner 文件（`extractionAgentPlanner.ts` / `dreamAgentPlanner.ts`）**无需改动**：`createMemoryScopedAgentConfig` 只加 `getPermissionManager`，下游 `runForkedAgent` rebuild 会处理 bound-tool 隔离。组合正确性由 memory-scoped 测试验证。

</details>