### PR TITLE
test(sdk): align tool-control E2E with prior-read enforcement

### DIFF
--- a/integration-tests/sdk-typescript/tool-control.test.ts
+++ b/integration-tests/sdk-typescript/tool-control.test.ts
@@ -1121,8 +1121,9 @@ describe('Tool Control Parameters (E2E)', () => {
     it(
       'should apply updatedInput from canUseTool callback',
       async () => {
-        await helper.createFile('test.txt', 'original');
-
+        // Don't pre-create test.txt: prior-read enforcement requires
+        // existing files to have been read via read_file first, but
+        // this test restricts coreTools to write_file only.
         let capturedInput: Record<string, unknown> = {};
 
         const q = query({
@@ -1171,8 +1172,9 @@ describe('Tool Control Parameters (E2E)', () => {
     it(
       'canUseTool should not be called for allowedTools even if it would modify input',
       async () => {
-        await helper.createFile('test.txt', 'original');
-
+        // Don't pre-create test.txt: prior-read enforcement requires
+        // existing files to have been read via read_file first, but
+        // this test restricts coreTools to write_file only.
         let canUseToolCalled = false;
 
         const q = query({
@@ -1433,7 +1435,10 @@ describe('Tool Control Parameters (E2E)', () => {
             session_id: crypto.randomUUID(),
             message: {
               role: 'user',
-              content: 'Write "modified" to test.txt.',
+              // Read-first instruction satisfies prior-read enforcement
+              // so the deny path is exercised by canUseTool, not by the
+              // write tool's pre-write guard.
+              content: 'Read test.txt and then write "modified" to it.',
             },
             parent_tool_use_id: null,
           };
@@ -1447,14 +1452,16 @@ describe('Tool Control Parameters (E2E)', () => {
             cwd: testDir,
             permissionMode: 'default',
             coreTools: ['read_file', 'write_file'],
-            canUseTool: async (toolName) => {
+            canUseTool: async (toolName, input) => {
               if (toolName === 'write_file') {
                 return {
                   behavior: 'deny',
                   message: 'Write operations are not allowed',
                 };
               }
-              return { behavior: 'allow', updatedInput: {} };
+              // Pass-through: empty `updatedInput` would erase
+              // file_path and break the read_file call.
+              return { behavior: 'allow', updatedInput: input };
             },
             debug: false,
           },

--- a/integration-tests/sdk-typescript/tool-control.test.ts
+++ b/integration-tests/sdk-typescript/tool-control.test.ts
@@ -1477,6 +1477,15 @@ describe('Tool Control Parameters (E2E)', () => {
             }
           }
 
+          // Make the read-first dependency explicit: if the model
+          // skipped read_file, prior-read enforcement would surface
+          // EDIT_REQUIRES_PRIOR_READ instead of the canUseTool deny
+          // message we are asserting on below — fail fast with a
+          // clear signal instead of a confusing toContain mismatch.
+          const toolCalls = findToolCalls(messages);
+          const toolNames = toolCalls.map((tc) => tc.toolUse.name);
+          expect(toolNames).toContain('read_file');
+
           // write_file should have been attempted but stream was closed
           const writeFileResults = findToolResults(messages, 'write_file');
           expect(writeFileResults.length).toBeGreaterThan(0);
@@ -1540,9 +1549,12 @@ describe('Tool Control Parameters (E2E)', () => {
             cwd: testDir,
             permissionMode: 'default',
             coreTools: ['read_file', 'write_file'],
-            canUseTool: async (toolName) => {
+            canUseTool: async (toolName, input) => {
               canUseToolCalls.push(toolName);
-              return { behavior: 'allow', updatedInput: {} };
+              // Pass-through: empty `updatedInput` would erase
+              // file_path on the SDK→CLI boundary
+              // (permissionController.ts:444 truthy-replaces args).
+              return { behavior: 'allow', updatedInput: input };
             },
             debug: false,
           },


### PR DESCRIPTION
## Summary

Three tests in `integration-tests/sdk-typescript/tool-control.test.ts` broke deterministically after #3774 landed (prior-read enforcement before Edit / WriteFile mutates a file). Same pattern in each: `helper.createFile` seeds `test.txt`, then the prompt asks the model to write to it directly. The new guard rejects the write before `canUseTool` fires with `File X has not been fully read in this session...`.

The smoking gun — test 3 expected `[Operation Cancelled] Reason: Write operations are not allowed` (from `canUseTool` deny) but received the prior-read error instead.

Both Linux and macOS jobs hit the same 3 failures, retry x2, on every E2E run since #3774 merged on 2026-05-06.

## Changes

- `should apply updatedInput from canUseTool callback` and `canUseTool should not be called for allowedTools even if it would modify input`: drop the seed file. `write_file` then takes the new-file path, which the enforcement exempts (`fileExists === false`). Both tests' assertions still hold (`capturedInput` populated / `canUseToolCalled === false` / final content matches).

- `should deny tool when canUseTool returns deny with asyncGenerator prompt`: keep the seed (the assertion requires unchanged content), change prompt to `Read test.txt and then write "modified" to it.`. This matches the read-first pattern already used by 27 passing tests in the same file (line 57, 145, 1361). Also fix a latent bug — `canUseTool` returned `updatedInput: {}` for non-write tools, which would erase `file_path` on the now-required `read_file` call. The SDK's `result.updatedInput ?? toolInput` fallback (Query.ts:478) only catches nullish, not empty objects. Pass `input` through instead.

No production code changes — test-side alignment only. The #3774 enforcement contract stays intact.

## Test plan

- [ ] CI E2E (Linux + macOS) green on the 3 previously-failing tests
- [ ] No regression in the 27 other tests in the same file

<details>
<summary>中文</summary>

## 概要

`tool-control.test.ts` 里 3 个用例在 #3774（prior-read enforcement）合入后确定性挂掉。三个用例同样套路：`helper.createFile` 预存 `test.txt`，然后提示模型直接 `Write X to test.txt`。新加的强制现在在 `canUseTool` 之前就把 write 拦下，错误信息是 `File X has not been fully read in this session...`。

冒烟枪是用例 3——它期望 `[Operation Cancelled] Reason: Write operations are not allowed`（来自 `canUseTool` 的 deny），实际拿到 prior-read 错误。

Linux + macOS 两个 job 同样 3 个用例，retry x2 仍然挂，2026-05-06 #3774 合并后每一次 E2E 都红。

## 修改

- `should apply updatedInput from canUseTool callback` 和 `canUseTool should not be called for allowedTools...`：移除前置 seed 文件。`write_file` 走 new-file 路径，`fileExists === false` 时 enforcement 豁免。两个用例断言（`capturedInput` 有值 / `canUseToolCalled === false` / 最终文件内容）都成立。

- `should deny tool when canUseTool returns deny with asyncGenerator prompt`：保留 seed（断言要求文件内容不变），prompt 改成 `Read test.txt and then write "modified" to it.`。同 file 27 个过的用例（line 57、145、1361）已在用这个 read-first 模式。顺手修了个 latent bug——`canUseTool` 对非 write 工具返回 `updatedInput: {}`，会把 `read_file` 的 `file_path` 抹空。SDK 的 `result.updatedInput ?? toolInput` 兜底（Query.ts:478）只接 nullish，不接空对象。改成透传 `input`。

不动生产代码，只在测试侧对齐 #3774 的契约。

</details>