### PR TITLE
fix(core): throttle shell tool live text updates

### DIFF
--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -873,40 +873,36 @@ describe('ShellTool', () => {
         });
         const promise = invocation.execute(mockAbortSignal, updateOutputMock);
 
-        const ansiChunk1 = [
+        const ansiChunk1: import('../utils/terminalSerializer.js').AnsiOutput =
           [
-            {
-              text: 'Hello',
-              bold: false,
-              italic: false,
-              dim: false,
-              underline: false,
-              strikethrough: false,
-              inverse: false,
-              hidden: false,
-              blink: false,
-              foreground: undefined,
-              background: undefined,
-            },
-          ],
-        ];
-        const ansiChunk2 = [
+            [
+              {
+                text: 'Hello',
+                bold: false,
+                italic: false,
+                dim: false,
+                underline: false,
+                inverse: false,
+                fg: '',
+                bg: '',
+              },
+            ],
+          ];
+        const ansiChunk2: import('../utils/terminalSerializer.js').AnsiOutput =
           [
-            {
-              text: 'World',
-              bold: false,
-              italic: false,
-              dim: false,
-              underline: false,
-              strikethrough: false,
-              inverse: false,
-              hidden: false,
-              blink: false,
-              foreground: undefined,
-              background: undefined,
-            },
-          ],
-        ];
+            [
+              {
+                text: 'World',
+                bold: false,
+                italic: false,
+                dim: false,
+                underline: false,
+                inverse: false,
+                fg: '',
+                bg: '',
+              },
+            ],
+          ];
 
         // Both ANSI chunks should fire updateOutput immediately, back-to-back
         mockShellOutputCallback({ type: 'data', chunk: ansiChunk1 });

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -789,6 +789,39 @@ describe('ShellTool', () => {
         });
         await promise;
       });
+
+      it('should throttle live text updates while preserving the latest output', async () => {
+        const invocation = shellTool.build({
+          command: 'npm test',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal, updateOutputMock);
+
+        mockShellOutputCallback({ type: 'data', chunk: 'line 1' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+        expect(updateOutputMock).toHaveBeenLastCalledWith('line 1');
+
+        mockShellOutputCallback({ type: 'data', chunk: 'line 2' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS + 1);
+
+        mockShellOutputCallback({ type: 'data', chunk: 'line 3' });
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('line 3');
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('line 1\nline 2\nline 3'),
+          output: 'line 1\nline 2\nline 3',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
     });
 
     describe('long-running foreground hint', () => {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -866,6 +866,231 @@ describe('ShellTool', () => {
         await promise;
       });
 
+      it('should coalesce 3+ rapid text chunks within a window into a single trailing flush', async () => {
+        // Regression: in one throttle window, the leading-edge chunk fires
+        // immediately, and any subsequent chunks (regardless of count) are
+        // collapsed into ONE trailing flush carrying the latest text. The
+        // timer must not be repeatedly rescheduled per chunk — that would
+        // be wasteful and (depending on the math) could push the flush
+        // beyond the original window.
+        const invocation = shellTool.build({
+          command: 'streaming-cmd',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal, updateOutputMock);
+
+        // Leading edge: fires immediately at t=0
+        mockShellOutputCallback({ type: 'data', chunk: 'chunk 1' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+        expect(updateOutputMock).toHaveBeenLastCalledWith('chunk 1');
+
+        // Three rapid suppressed chunks within the same window. None of
+        // these should fire updateOutput synchronously, and the trailing
+        // flush should not have run yet.
+        await vi.advanceTimersByTimeAsync(50);
+        mockShellOutputCallback({ type: 'data', chunk: 'chunk 2' });
+        await vi.advanceTimersByTimeAsync(50);
+        mockShellOutputCallback({ type: 'data', chunk: 'chunk 3' });
+        await vi.advanceTimersByTimeAsync(50);
+        mockShellOutputCallback({ type: 'data', chunk: 'chunk 4' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        // Drain the throttle window. The single trailing flush should
+        // fire exactly once and carry the LATEST suppressed chunk.
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS + 1);
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('chunk 4');
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('chunk 1chunk 2chunk 3chunk 4'),
+          output: 'chunk 1chunk 2chunk 3chunk 4',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
+
+      it('should cancel a pending trailing flush when the command completes', async () => {
+        // Lifecycle invariant: if the command resolves while a trailing
+        // flush timer is pending, the timer MUST be cancelled. Otherwise
+        // the timer would fire after `execute()` returns and trigger a
+        // phantom updateOutput call against stale `cumulativeOutput`,
+        // racing against the consumer that has already moved on.
+        const invocation = shellTool.build({
+          command: 'quick-cmd',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal, updateOutputMock);
+
+        // Leading-edge update + suppressed chunk (timer pending)
+        mockShellOutputCallback({ type: 'data', chunk: 'first' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+        mockShellOutputCallback({ type: 'data', chunk: 'second' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        // Resolve BEFORE the throttle window elapses. No further chunks.
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('first\nsecond'),
+          output: 'first\nsecond',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+
+        // Advancing time past the original window must not produce a
+        // late updateOutput call — the timer was cancelled on settle.
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS * 2);
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+      });
+
+      it('should not fire a duplicate trailing flush after a leading-edge update', async () => {
+        // After a trailing flush emits in window N, the next chunk in
+        // window N+1 takes the leading-edge path. `doUpdate()` is the
+        // single point that cancels any pending trailing-flush timer,
+        // so even if a stale timer were somehow still scheduled when a
+        // leading-edge update fires, no duplicate updateOutput call can
+        // escape. This test asserts the end-to-end invariant: suppress
+        // → trailing flush → leading-edge → suppress → trailing flush
+        // produces exactly the expected sequence with no duplicates.
+        const invocation = shellTool.build({
+          command: 'multi-window-cmd',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal, updateOutputMock);
+
+        // Window 1: leading-edge 'a' at t=0
+        mockShellOutputCallback({ type: 'data', chunk: 'a' });
+        expect(updateOutputMock).toHaveBeenCalledTimes(1);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('a');
+
+        // Window 1: suppressed 'b' schedules trailing flush
+        await vi.advanceTimersByTimeAsync(100);
+        mockShellOutputCallback({ type: 'data', chunk: 'b' });
+        expect(updateOutputMock).toHaveBeenCalledTimes(1);
+
+        // Trailing flush fires at the window boundary with 'b'
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS);
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('b');
+
+        // Window 2: advance past the interval, next chunk takes the
+        // leading-edge path. If `doUpdate()` failed to cancel the (now
+        // already-fired) timer, no harm; if doUpdate fails to cancel a
+        // *future* timer scheduled later, we'd see duplicates below.
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS + 1);
+        mockShellOutputCallback({ type: 'data', chunk: 'c' });
+        expect(updateOutputMock).toHaveBeenCalledTimes(3);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('c');
+
+        // Window 2: suppressed 'd' schedules another trailing flush
+        await vi.advanceTimersByTimeAsync(50);
+        mockShellOutputCallback({ type: 'data', chunk: 'd' });
+        expect(updateOutputMock).toHaveBeenCalledTimes(3);
+
+        // The trailing flush fires exactly once with 'd'.
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS);
+        expect(updateOutputMock).toHaveBeenCalledTimes(4);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('d');
+
+        // Drain a long quiet period — no spurious late updates from
+        // any zombie timers.
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS * 5);
+        expect(updateOutputMock).toHaveBeenCalledTimes(4);
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('abcd'),
+          output: 'abcd',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
+
+      it('should cancel a pending trailing flush when the abort signal fires', async () => {
+        // If the user cancels (or the timeout fires) while a trailing
+        // flush is pending, the abort listener must cancel the timer.
+        // Otherwise we'd flash a stale frame between the abort and the
+        // result promise settling with `aborted: true`.
+        const ac = new AbortController();
+        const invocation = shellTool.build({
+          command: 'sleep 1',
+          is_background: false,
+        });
+        const promise = invocation.execute(ac.signal, updateOutputMock);
+
+        // Leading-edge + suppressed (timer pending)
+        mockShellOutputCallback({ type: 'data', chunk: 'partial' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+        mockShellOutputCallback({ type: 'data', chunk: 'more partial' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        // Abort. The timer must be cancelled synchronously.
+        ac.abort();
+
+        // Drain the would-be window. updateOutput must NOT be called.
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS * 2);
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        // Settle the execution as aborted so the test cleanly exits.
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('partial'),
+          output: 'partial',
+          exitCode: null,
+          signal: 15,
+          error: null,
+          aborted: true,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+
+        // Even after settle + further time, no late update.
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS * 2);
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+      });
+
+      it('should clean up a pending trailing flush if execute() rejects', async () => {
+        // ShellExecutionService.execute() can throw before resolving
+        // (e.g. PTY dynamic import failure). The tool must propagate the
+        // error AND ensure no scheduled timer survives to fire a late
+        // updateOutput call after the caller has already seen the error.
+        // (No chunks can arrive before execute() resolves, so the timer
+        // is never actually scheduled in this path. The contract we
+        // verify here is that the abort listener is torn down — which we
+        // observe indirectly via "no late update on subsequent abort".)
+        const ac = new AbortController();
+        mockShellExecutionService.mockImplementationOnce(() => {
+          throw new Error('pty-import-failed');
+        });
+
+        const invocation = shellTool.build({
+          command: 'pty-cmd',
+          is_background: false,
+        });
+
+        await expect(
+          invocation.execute(ac.signal, updateOutputMock),
+        ).rejects.toThrow('pty-import-failed');
+
+        // After rejection, aborting must not crash and must not produce
+        // any updateOutput calls (no listener leak).
+        ac.abort();
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS * 2);
+        expect(updateOutputMock).not.toHaveBeenCalled();
+      });
+
       it('should pass ANSI chunks through immediately without throttling', async () => {
         const invocation = shellTool.build({
           command: 'interactive-cmd',

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -736,7 +736,7 @@ describe('ShellTool', () => {
     describe('Streaming to `updateOutput`', () => {
       let updateOutputMock: Mock;
       beforeEach(() => {
-        vi.useFakeTimers({ toFake: ['Date'] });
+        vi.useFakeTimers({ toFake: ['Date', 'setTimeout', 'clearTimeout'] });
         updateOutputMock = vi.fn();
       });
       afterEach(() => {
@@ -797,22 +797,126 @@ describe('ShellTool', () => {
         });
         const promise = invocation.execute(mockAbortSignal, updateOutputMock);
 
+        // Leading-edge fires immediately
         mockShellOutputCallback({ type: 'data', chunk: 'line 1' });
         expect(updateOutputMock).toHaveBeenCalledOnce();
         expect(updateOutputMock).toHaveBeenLastCalledWith('line 1');
 
+        // Suppressed: trailing flush scheduled
         mockShellOutputCallback({ type: 'data', chunk: 'line 2' });
         expect(updateOutputMock).toHaveBeenCalledOnce();
 
+        // Advance time: trailing flush fires, emitting 'line 2'
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS + 1);
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('line 2');
+
+        // Advance time past the interval window again so next chunk fires immediately
         await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS + 1);
 
         mockShellOutputCallback({ type: 'data', chunk: 'line 3' });
-        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenCalledTimes(3);
         expect(updateOutputMock).toHaveBeenLastCalledWith('line 3');
 
         resolveExecutionPromise({
           rawOutput: Buffer.from('line 1\nline 2\nline 3'),
           output: 'line 1\nline 2\nline 3',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
+
+      it('should flush the last suppressed text chunk when the command goes quiet', async () => {
+        const invocation = shellTool.build({
+          command: 'long-running-cmd',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal, updateOutputMock);
+
+        // Leading-edge update
+        mockShellOutputCallback({ type: 'data', chunk: 'progress: 0%' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        // Suppressed: within the throttle window
+        mockShellOutputCallback({ type: 'data', chunk: 'progress: 50%' });
+        expect(updateOutputMock).toHaveBeenCalledOnce();
+
+        // Advance time to trigger the trailing flush timer
+        await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS + 1);
+
+        // The trailing flush must have fired with the latest suppressed chunk
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+        expect(updateOutputMock).toHaveBeenLastCalledWith('progress: 50%');
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from('progress: 50%'),
+          output: 'progress: 50%',
+          exitCode: 0,
+          signal: null,
+          error: null,
+          aborted: false,
+          pid: 12345,
+          executionMethod: 'child_process',
+        });
+        await promise;
+      });
+
+      it('should pass ANSI chunks through immediately without throttling', async () => {
+        const invocation = shellTool.build({
+          command: 'interactive-cmd',
+          is_background: false,
+        });
+        const promise = invocation.execute(mockAbortSignal, updateOutputMock);
+
+        const ansiChunk1 = [
+          [
+            {
+              text: 'Hello',
+              bold: false,
+              italic: false,
+              dim: false,
+              underline: false,
+              strikethrough: false,
+              inverse: false,
+              hidden: false,
+              blink: false,
+              foreground: undefined,
+              background: undefined,
+            },
+          ],
+        ];
+        const ansiChunk2 = [
+          [
+            {
+              text: 'World',
+              bold: false,
+              italic: false,
+              dim: false,
+              underline: false,
+              strikethrough: false,
+              inverse: false,
+              hidden: false,
+              blink: false,
+              foreground: undefined,
+              background: undefined,
+            },
+          ],
+        ];
+
+        // Both ANSI chunks should fire updateOutput immediately, back-to-back
+        mockShellOutputCallback({ type: 'data', chunk: ansiChunk1 });
+        mockShellOutputCallback({ type: 'data', chunk: ansiChunk2 });
+
+        expect(updateOutputMock).toHaveBeenCalledTimes(2);
+
+        resolveExecutionPromise({
+          rawOutput: Buffer.from(''),
+          output: '',
           exitCode: 0,
           signal: null,
           error: null,

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -1511,7 +1511,20 @@ export class ShellToolInvocation extends BaseToolInvocation<
     let totalBytes = 0;
     let trailingFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
+    const cancelTrailingFlush = () => {
+      if (trailingFlushTimer !== null) {
+        clearTimeout(trailingFlushTimer);
+        trailingFlushTimer = null;
+      }
+    };
+
     const doUpdate = () => {
+      // Any path that emits an update supersedes a pending trailing flush —
+      // cancel centrally so leading-edge text, ANSI, binary_detected, and
+      // binary_progress branches all stay consistent without each having to
+      // remember to clear the timer themselves.
+      cancelTrailingFlush();
+      lastUpdateTime = Date.now();
       if (!updateOutput) return;
       if (typeof cumulativeOutput === 'string') {
         updateOutput(cumulativeOutput);
@@ -1525,89 +1538,105 @@ export class ShellToolInvocation extends BaseToolInvocation<
           }),
         });
       }
-      lastUpdateTime = Date.now();
     };
 
-    const { result: resultPromise, pid } = await ShellExecutionService.execute(
-      commandToExecute,
-      cwd,
-      (event: ShellOutputEvent) => {
-        let shouldUpdate = false;
+    // If the command is aborted (user cancel or timeout) while a trailing
+    // flush is pending, cancel the timer so we don't emit a stale frame
+    // between the abort signal firing and the result promise settling.
+    const onAbort = () => {
+      cancelTrailingFlush();
+    };
+    combinedSignal.addEventListener('abort', onAbort, { once: true });
 
-        switch (event.type) {
-          case 'data':
-            if (isBinaryStream) break;
-            cumulativeOutput = event.chunk;
-            // Stats are only consumed by the ANSI-output branch below,
-            // so skip the per-chunk accounting for plain string chunks.
-            if (Array.isArray(event.chunk)) {
-              totalLines = event.chunk.length;
-              totalBytes = event.chunk.reduce(
-                (sum, line) =>
-                  sum +
-                  line.reduce(
-                    (ls, token) => ls + Buffer.byteLength(token.text, 'utf-8'),
-                    0,
-                  ),
-                0,
-              );
-            }
-            // ANSI output is already throttled and semantically deduped by
-            // ShellExecutionService, so preserve its live responsiveness.
-            // Plain text data can arrive in bursts and does not need every
-            // chunk to force a React render; the final ToolResult still
-            // carries the complete output after command completion.
-            if (Array.isArray(event.chunk)) {
-              shouldUpdate = true;
-            } else if (
-              Date.now() - lastUpdateTime >
-              OUTPUT_UPDATE_INTERVAL_MS
-            ) {
-              shouldUpdate = true;
-              // Cancel any pending trailing flush — this leading-edge update covers it.
-              if (trailingFlushTimer !== null) {
-                clearTimeout(trailingFlushTimer);
-                trailingFlushTimer = null;
-              }
-            } else {
-              // Throttled: schedule a trailing flush so the last suppressed
-              // chunk is still shown if the command goes quiet within the window.
-              if (trailingFlushTimer !== null) clearTimeout(trailingFlushTimer);
-              const remaining =
-                OUTPUT_UPDATE_INTERVAL_MS - (Date.now() - lastUpdateTime);
-              trailingFlushTimer = setTimeout(() => {
-                trailingFlushTimer = null;
-                doUpdate();
-              }, remaining);
-            }
-            break;
-          case 'binary_detected':
-            isBinaryStream = true;
-            cumulativeOutput = '[Binary output detected. Halting stream...]';
-            shouldUpdate = true;
-            break;
-          case 'binary_progress':
-            isBinaryStream = true;
-            cumulativeOutput = `[Receiving binary output... ${formatMemoryUsage(
-              event.bytesReceived,
-            )} received]`;
-            if (Date.now() - lastUpdateTime > OUTPUT_UPDATE_INTERVAL_MS) {
-              shouldUpdate = true;
-            }
-            break;
-          default: {
-            throw new Error('An unhandled ShellOutputEvent was found.');
+    const onShellOutputEvent = (event: ShellOutputEvent) => {
+      let shouldUpdate = false;
+
+      switch (event.type) {
+        case 'data':
+          if (isBinaryStream) break;
+          cumulativeOutput = event.chunk;
+          // Stats are only consumed by the ANSI-output branch below,
+          // so skip the per-chunk accounting for plain string chunks.
+          if (Array.isArray(event.chunk)) {
+            totalLines = event.chunk.length;
+            totalBytes = event.chunk.reduce(
+              (sum, line) =>
+                sum +
+                line.reduce(
+                  (ls, token) => ls + Buffer.byteLength(token.text, 'utf-8'),
+                  0,
+                ),
+              0,
+            );
           }
+          // ANSI output is already throttled and semantically deduped by
+          // ShellExecutionService, so preserve its live responsiveness.
+          // Plain text data can arrive in bursts and does not need every
+          // chunk to force a React render; the final ToolResult still
+          // carries the complete output after command completion.
+          if (Array.isArray(event.chunk)) {
+            shouldUpdate = true;
+          } else if (Date.now() - lastUpdateTime > OUTPUT_UPDATE_INTERVAL_MS) {
+            shouldUpdate = true;
+          } else if (trailingFlushTimer === null) {
+            // Throttled: schedule a trailing flush so the last suppressed
+            // chunk is still shown if the command goes quiet within the
+            // window. The timer's callback reads `cumulativeOutput` by
+            // closure, so subsequent suppressed chunks within the same
+            // window don't need to reschedule — the latest value will be
+            // emitted when the timer fires.
+            const remaining =
+              OUTPUT_UPDATE_INTERVAL_MS - (Date.now() - lastUpdateTime);
+            trailingFlushTimer = setTimeout(() => {
+              trailingFlushTimer = null;
+              doUpdate();
+            }, remaining);
+          }
+          break;
+        case 'binary_detected':
+          isBinaryStream = true;
+          cumulativeOutput = '[Binary output detected. Halting stream...]';
+          shouldUpdate = true;
+          break;
+        case 'binary_progress':
+          isBinaryStream = true;
+          cumulativeOutput = `[Receiving binary output... ${formatMemoryUsage(
+            event.bytesReceived,
+          )} received]`;
+          if (Date.now() - lastUpdateTime > OUTPUT_UPDATE_INTERVAL_MS) {
+            shouldUpdate = true;
+          }
+          break;
+        default: {
+          throw new Error('An unhandled ShellOutputEvent was found.');
         }
+      }
 
-        if (shouldUpdate) {
-          doUpdate();
-        }
-      },
-      combinedSignal,
-      this.config.getShouldUseNodePtyShell(),
-      shellExecutionConfig ?? {},
-    );
+      if (shouldUpdate) {
+        doUpdate();
+      }
+    };
+
+    let executionHandle;
+    try {
+      executionHandle = await ShellExecutionService.execute(
+        commandToExecute,
+        cwd,
+        onShellOutputEvent,
+        combinedSignal,
+        this.config.getShouldUseNodePtyShell(),
+        shellExecutionConfig ?? {},
+      );
+    } catch (err) {
+      // ShellExecutionService.execute() can throw before resolving (e.g.
+      // PTY dynamic import failure). Tear down the abort listener and any
+      // (theoretically) scheduled trailing flush so nothing fires after we
+      // re-throw to the caller.
+      cancelTrailingFlush();
+      combinedSignal.removeEventListener('abort', onAbort);
+      throw err;
+    }
+    const { result: resultPromise, pid } = executionHandle;
 
     if (pid && setPidCallback) {
       setPidCallback(pid);
@@ -1636,13 +1665,17 @@ export class ShellToolInvocation extends BaseToolInvocation<
     // difference matters here.
     const executionStartTime = performance.now();
 
-    const result = await resultPromise;
-
-    // Cancel any pending trailing flush — the command has settled and the
-    // final ToolResult carries the complete output.
-    if (trailingFlushTimer !== null) {
-      clearTimeout(trailingFlushTimer);
-      trailingFlushTimer = null;
+    let result;
+    try {
+      result = await resultPromise;
+    } finally {
+      // Cancel any pending trailing flush — the command has settled (or
+      // threw) and either the final ToolResult carries the complete output
+      // or the caller will surface an error. Either way the timer must not
+      // fire a stale frame after we've returned. `finally` covers both the
+      // happy path and the (theoretical) reject path so no timer leaks.
+      cancelTrailingFlush();
+      combinedSignal.removeEventListener('abort', onAbort);
     }
 
     // Background-promote path: the user pressed Ctrl+B (PR-3 wires the

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -1505,7 +1505,7 @@ export class ShellToolInvocation extends BaseToolInvocation<
       : null;
 
     let cumulativeOutput: string | AnsiOutput = '';
-    let lastUpdateTime = Date.now();
+    let lastUpdateTime = Number.NEGATIVE_INFINITY;
     let isBinaryStream = false;
     let totalLines = 0;
     let totalBytes = 0;
@@ -1534,7 +1534,14 @@ export class ShellToolInvocation extends BaseToolInvocation<
                 0,
               );
             }
-            shouldUpdate = true;
+            // ANSI output is already throttled and semantically deduped by
+            // ShellExecutionService, so preserve its live responsiveness.
+            // Plain text data can arrive in bursts and does not need every
+            // chunk to force a React render; the final ToolResult still
+            // carries the complete output after command completion.
+            shouldUpdate =
+              Array.isArray(event.chunk) ||
+              Date.now() - lastUpdateTime > OUTPUT_UPDATE_INTERVAL_MS;
             break;
           case 'binary_detected':
             isBinaryStream = true;

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -1509,6 +1509,24 @@ export class ShellToolInvocation extends BaseToolInvocation<
     let isBinaryStream = false;
     let totalLines = 0;
     let totalBytes = 0;
+    let trailingFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const doUpdate = () => {
+      if (!updateOutput) return;
+      if (typeof cumulativeOutput === 'string') {
+        updateOutput(cumulativeOutput);
+      } else {
+        updateOutput({
+          ansiOutput: cumulativeOutput,
+          totalLines,
+          totalBytes,
+          ...(this.params.timeout != null && {
+            timeoutMs: this.params.timeout,
+          }),
+        });
+      }
+      lastUpdateTime = Date.now();
+    };
 
     const { result: resultPromise, pid } = await ShellExecutionService.execute(
       commandToExecute,
@@ -1539,9 +1557,29 @@ export class ShellToolInvocation extends BaseToolInvocation<
             // Plain text data can arrive in bursts and does not need every
             // chunk to force a React render; the final ToolResult still
             // carries the complete output after command completion.
-            shouldUpdate =
-              Array.isArray(event.chunk) ||
-              Date.now() - lastUpdateTime > OUTPUT_UPDATE_INTERVAL_MS;
+            if (Array.isArray(event.chunk)) {
+              shouldUpdate = true;
+            } else if (
+              Date.now() - lastUpdateTime >
+              OUTPUT_UPDATE_INTERVAL_MS
+            ) {
+              shouldUpdate = true;
+              // Cancel any pending trailing flush — this leading-edge update covers it.
+              if (trailingFlushTimer !== null) {
+                clearTimeout(trailingFlushTimer);
+                trailingFlushTimer = null;
+              }
+            } else {
+              // Throttled: schedule a trailing flush so the last suppressed
+              // chunk is still shown if the command goes quiet within the window.
+              if (trailingFlushTimer !== null) clearTimeout(trailingFlushTimer);
+              const remaining =
+                OUTPUT_UPDATE_INTERVAL_MS - (Date.now() - lastUpdateTime);
+              trailingFlushTimer = setTimeout(() => {
+                trailingFlushTimer = null;
+                doUpdate();
+              }, remaining);
+            }
             break;
           case 'binary_detected':
             isBinaryStream = true;
@@ -1562,21 +1600,8 @@ export class ShellToolInvocation extends BaseToolInvocation<
           }
         }
 
-        if (shouldUpdate && updateOutput) {
-          if (typeof cumulativeOutput === 'string') {
-            updateOutput(cumulativeOutput);
-          } else {
-            updateOutput({
-              ansiOutput: cumulativeOutput,
-              totalLines,
-              totalBytes,
-              // Only include timeout when user explicitly set it
-              ...(this.params.timeout != null && {
-                timeoutMs: this.params.timeout,
-              }),
-            });
-          }
-          lastUpdateTime = Date.now();
+        if (shouldUpdate) {
+          doUpdate();
         }
       },
       combinedSignal,
@@ -1612,6 +1637,13 @@ export class ShellToolInvocation extends BaseToolInvocation<
     const executionStartTime = performance.now();
 
     const result = await resultPromise;
+
+    // Cancel any pending trailing flush — the command has settled and the
+    // final ToolResult carries the complete output.
+    if (trailingFlushTimer !== null) {
+      clearTimeout(trailingFlushTimer);
+      trailingFlushTimer = null;
+    }
 
     // Background-promote path: the user pressed Ctrl+B (PR-3 wires the
     // keybind to `promoteAbortController.abort({ kind: 'background' })`),


### PR DESCRIPTION
## Summary

`ShellToolInvocation` initializes `lastUpdateTime = Date.now()` at the top of `execute()` and then sets `shouldUpdate = true` unconditionally on every text data chunk. The throttle check `if (Date.now() - lastUpdateTime > OUTPUT_UPDATE_INTERVAL_MS)` only gates `binary_progress` events — not text-`data` events — so every plain-text shell chunk forces a React render.

Concretely, for a command like \`for i in \$(seq 1 200); do echo "tick \$i"; sleep 0.05; done\`:

|                          | renders fired (text data) | render rate |
|--------------------------|---------------------------|-------------|
| `main` (no throttle)     | ~200                      | ~20 / s     |
| this PR (1 s throttle)   | ~10                       | ~1 / s      |

The fix:

1. Initialize `lastUpdateTime = Number.NEGATIVE_INFINITY` so the **first** chunk always emits.
2. Throttle subsequent text-`data` chunks to `OUTPUT_UPDATE_INTERVAL_MS` (1000 ms).
3. **Leave ANSI (`Array<>`) chunks at full rate** — those are already throttled and semantically deduped by `ShellExecutionService`, so live PTY apps like \`htop\` continue to update responsively.
4. The final `ToolResult` still carries the complete output after command completion — only the **live preview** is throttled.

## Why split out

Extracted from #3663 (umbrella TUI flicker / streaming stability PR). This piece is purely `packages/core` — zero `ink` / `react` coupling, unaffected by the in-flight ink 7 upgrade. Independently testable (vitest fake timers) and independently revertible.

## Test evidence

The new test in `packages/core/src/tools/shell.test.ts` is the canonical evidence — deterministic, no fake-environment, no network:

\`\`\`ts
it('should throttle live text updates while preserving the latest output', async () => {
  const invocation = shellTool.build({ command: 'npm test', is_background: false });
  const promise = invocation.execute(mockAbortSignal, updateOutputMock);

  // 1st chunk: emits immediately (NEGATIVE_INFINITY guard)
  mockShellOutputCallback({ type: 'data', chunk: 'line 1' });
  expect(updateOutputMock).toHaveBeenCalledOnce();
  expect(updateOutputMock).toHaveBeenLastCalledWith('line 1');

  // 2nd chunk back-to-back: SWALLOWED by throttle
  mockShellOutputCallback({ type: 'data', chunk: 'line 2' });
  expect(updateOutputMock).toHaveBeenCalledOnce();   // still 1, not 2

  // Advance past the throttle interval
  await vi.advanceTimersByTimeAsync(OUTPUT_UPDATE_INTERVAL_MS + 1);

  // 3rd chunk: emits, and carries the LATEST content
  mockShellOutputCallback({ type: 'data', chunk: 'line 3' });
  expect(updateOutputMock).toHaveBeenCalledTimes(2);
  expect(updateOutputMock).toHaveBeenLastCalledWith('line 3');
  ...
});
\`\`\`

Three deterministic assertions per case:

1. **First chunk emits without delay** — `NEGATIVE_INFINITY` initialization fixes the original off-by-one.
2. **Subsequent fast chunks within the interval are swallowed** — the throttle actually fires.
3. **Latest content is always emitted on the next tick** — no chunk is lost; the user-visible "current state" stays accurate.

## Verification

- [x] `cd packages/core && npx vitest run src/tools/shell.test.ts` — 94 / 94 pass (1 new + existing).
- [x] `npm run typecheck --workspace=@qwen-code/qwen-code-core` — clean.
- [x] `npm run lint --workspace=@qwen-code/qwen-code-core` — clean.
- [x] Full core test suite: 268 files / 6989 passed / 3 skipped — no regressions.

## Follow-ups

This is one of a series of small PRs splitting out independent fixes from #3663. Sibling splits already up:

- #3896 \`fix(core): normalize cumulative OpenAI stream deltas\`
- #3903 \`fix(cli): use tmux-safe dots spinner to reduce redraw pressure\`