### PR TITLE
fix(cli): use tmux-safe dots spinner to reduce redraw pressure

### DIFF
--- a/packages/cli/src/ui/components/GeminiRespondingSpinner.test.tsx
+++ b/packages/cli/src/ui/components/GeminiRespondingSpinner.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render } from 'ink-testing-library';
+import { Text } from 'ink';
+import { GeminiSpinner } from './GeminiRespondingSpinner.js';
+
+describe('<GeminiSpinner />', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('uses a low-frequency fixed-width indicator inside tmux', () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-1000/default,12345,0');
+
+    const { lastFrame } = render(<GeminiSpinner />);
+
+    expect(lastFrame()).toContain('.');
+  });
+
+  // Regression: Footer.tsx renders <GeminiSpinner /> inside a <Text> wrapper
+  // ('<Text>...<GeminiSpinner /> {msg}</Text>'). Ink forbids <Box> from being
+  // nested inside <Text>, so the tmux branch must return a <Text>, not a
+  // <Box>-wrapped one — otherwise the CLI throws on startup inside tmux.
+  it('renders without throwing when nested inside a <Text> (Footer context)', () => {
+    vi.stubEnv('TMUX', '/tmp/tmux-1000/default,12345,0');
+
+    expect(() =>
+      render(
+        <Text>
+          <GeminiSpinner /> startup message
+        </Text>,
+      ),
+    ).not.toThrow();
+  });
+});

--- a/packages/cli/src/ui/components/GeminiRespondingSpinner.tsx
+++ b/packages/cli/src/ui/components/GeminiRespondingSpinner.tsx
@@ -5,6 +5,7 @@
  */
 
 import type React from 'react';
+import { useEffect, useState } from 'react';
 import { Text, useIsScreenReaderEnabled } from 'ink';
 import Spinner from 'ink-spinner';
 import type { SpinnerName } from 'cli-spinners';
@@ -15,6 +16,9 @@ import {
   SCREEN_READER_RESPONDING,
 } from '../textConstants.js';
 import { theme } from '../semantic-colors.js';
+
+const TMUX_SPINNER_INTERVAL_MS = 750;
+const TMUX_SPINNER_FRAMES = ['.  ', '.. ', '...'];
 
 interface GeminiRespondingSpinnerProps {
   /**
@@ -57,9 +61,38 @@ export const GeminiSpinner: React.FC<GeminiSpinnerProps> = ({
   altText,
 }) => {
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
-  return isScreenReaderEnabled ? (
-    <Text>{altText}</Text>
-  ) : (
+  const isTmux = Boolean(process.env['TMUX']);
+  const [tmuxFrameIndex, setTmuxFrameIndex] = useState(0);
+
+  useEffect(() => {
+    if (isScreenReaderEnabled || !isTmux) {
+      return;
+    }
+
+    const interval = setInterval(() => {
+      setTmuxFrameIndex((index) => (index + 1) % TMUX_SPINNER_FRAMES.length);
+    }, TMUX_SPINNER_INTERVAL_MS);
+
+    return () => clearInterval(interval);
+  }, [isScreenReaderEnabled, isTmux]);
+
+  if (isScreenReaderEnabled) {
+    return <Text>{altText}</Text>;
+  }
+
+  if (isTmux) {
+    // Note: must NOT wrap in <Box> here — GeminiSpinner is rendered inside a
+    // <Text> in Footer.tsx (`<Text>...<GeminiSpinner /> {msg}</Text>`), and
+    // Ink forbids <Box> nested inside <Text>. The 3-char fixed-width frames
+    // already give us stable layout without an explicit width container.
+    return (
+      <Text color={theme.text.primary}>
+        {TMUX_SPINNER_FRAMES[tmuxFrameIndex]}
+      </Text>
+    );
+  }
+
+  return (
     <Text color={theme.text.primary}>
       <Spinner type={spinnerType} />
     </Text>


### PR DESCRIPTION
## Summary

Inside tmux, `ink-spinner` runs at the cli-spinners default frame rate (~80 ms per frame = ~12.5 frames/s). Each frame is a single-cell rewrite, but the multiplexer's pane buffer churns on every tick — visible on some tmux/terminal combinations as spinner residue, pane-scroll churn, or pane buffer activity that crowds out useful streaming content.

When the `TMUX` environment variable is set, this PR swaps to a fixed-width 750 ms three-frame dots spinner (`'.  '` / `'.. '` / `'...'`):

|                              | spinner frame rate | per-second writes to tmux pane |
|------------------------------|--------------------|--------------------------------|
| `main` (ink-spinner default) | ~80 ms             | ~12.5                          |
| this PR (TMUX branch)        | 750 ms             | ~1.3                           |

That is a ~10× reduction in spinner-driven pane writes during streaming. **Outside tmux the existing `ink-spinner` path is unchanged.**

## Why split out

Extracted from #3663 (umbrella TUI flicker / streaming stability PR). This piece touches a single isolated component (`GeminiRespondingSpinner.tsx` + a small new test), is gated by an env-var branch (`process.env.TMUX`), and uses only common ink primitives (`Text`, `useIsScreenReaderEnabled`) — so it is forward-compatible with the in-flight ink 7 upgrade.

## Bug found and fixed during pre-flight (force-pushed)

The original commit from #3663 returned `<Box width={3}><Text>...</Text></Box>` in the tmux branch. `GeminiSpinner` is rendered inside a `<Text>` in `Footer.tsx:87` (`<Text>...<GeminiSpinner /> {configInitMessage}</Text>`), and Ink forbids `<Box>` nested inside `<Text>` — the CLI threw `<Box> can't be nested inside <Text> component` on every tmux startup that hit the Footer's `configInitMessage` path.

This PR's fix:

1. **Drops the `<Box>` wrapper** in the tmux branch — return plain `<Text>` directly. The 3-char fixed-width frames already give stable layout without an explicit width container.
2. **Drops the unused `Box` import**.
3. **Adds a regression test** that renders `<Text><GeminiSpinner /> ...</Text>` and asserts no throw — directly catches the Footer-context bug that the original PR's isolated-render test missed.

The original umbrella #3663 still carries this bug; this split surfaces and fixes it.

## Issues this addresses

- #3330 (CLOSED as duplicate) — "When performing tasks in the cmux terminal, the output content flashes" — directly maps to spinner redraw pressure inside terminal multiplexers.
- #1778 Part 3 — the umbrella ink-rendering / flicker issue explicitly lists "TMUX Terminal" as a high-flicker environment.
- #2912 (xonline's comment) — "tmux 5-pane setup at 34" ultrawide … causes heavy text duplication". The narrower-window text duplication is addressed by other splits from #3663; this PR specifically addresses the tmux-internal spinner redraw pressure, which is one contributor.

> Note: tmux flicker has multiple contributors (spinner redraw pressure, ink scrollback amplification, narrow-window dup, etc.). This PR addresses **only** the spinner redraw pressure. The other contributors will land via separate follow-up splits.

## Test evidence

`packages/cli/src/ui/components/GeminiRespondingSpinner.test.tsx` — 2 deterministic tests:

\`\`\`ts
it('uses a low-frequency fixed-width indicator inside tmux', () => {
  vi.stubEnv('TMUX', '/tmp/tmux-1000/default,12345,0');
  const { lastFrame } = render(<GeminiSpinner />);
  expect(lastFrame()).toContain('.');
});

// Regression: Footer.tsx renders <GeminiSpinner /> inside a <Text> wrapper.
// Ink forbids <Box> nested inside <Text>, so the tmux branch must return a
// <Text>, not a <Box>-wrapped one — otherwise the CLI throws on startup.
it('renders without throwing when nested inside a <Text> (Footer context)', () => {
  vi.stubEnv('TMUX', '/tmp/tmux-1000/default,12345,0');
  expect(() =>
    render(
      <Text>
        <GeminiSpinner /> startup message
      </Text>,
    ),
  ).not.toThrow();
});
\`\`\`

The first test pins behaviour (tmux env → dots indicator). The second test is the regression test that would fail against the original `<Box>`-wrapped commit and passes after dropping the Box.

## Verification

- [x] `cd packages/cli && npx vitest run src/ui/components/GeminiRespondingSpinner.test.tsx` — 2 / 2 pass.
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean.
- [x] Full cli test suite: 8 pre-existing failures in `src/config/config.integration.test.ts` (vite resolveId / channel-registry — verified to fail identically on un-modified `origin/main`); spinner-touched paths all pass.
- [x] Manual verification inside tmux: CLI starts cleanly, no `<Box>`-in-`<Text>` error, spinner ticks every 750 ms.

## Follow-ups

This is one of a series of small PRs splitting out independent fixes from #3663. Sibling splits already up:

- #3896 \`fix(core): normalize cumulative OpenAI stream deltas\`
- #3902 \`fix(core): throttle shell tool live text updates\`