### PR TITLE
fix(cli): unfreeze Ctrl+O compact-mode toggle on long conversations

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -1856,7 +1856,7 @@ describe('AppContainer State Management', () => {
                   callId: 'c1',
                   name: 'shell',
                   description: 'shell description',
-                  status: 'Success',
+                  status: ToolCallStatus.Success,
                   resultDisplay: undefined,
                   confirmationDetails: undefined,
                 },

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -330,6 +330,7 @@ describe('AppContainer State Management', () => {
           hideWindowTitle: false,
         },
       },
+      setValue: vi.fn(),
     } as unknown as LoadedSettings;
 
     // Mock InitializationResult
@@ -1785,6 +1786,108 @@ describe('AppContainer State Management', () => {
       expect(mockHandleSlashCommand).not.toHaveBeenCalledWith('/quit');
 
       vi.useRealTimers();
+    });
+
+    describe('Ctrl+O compact mode toggle (issue #3899)', () => {
+      const ctrlOKey: Key = {
+        name: 'o',
+        ctrl: true,
+        meta: false,
+        shift: false,
+        paste: false,
+        sequence: '',
+      };
+
+      // The global handler is the one that calls compactToggleHasVisualEffect.
+      // Mirrors the discriminator pattern used by the renderMode test above.
+      const findGlobalKeypressHandler = () =>
+        mockedUseKeypress.mock.calls
+          .map((call) => call[0])
+          .reverse()
+          .find(
+            (handler): handler is (key: Key) => void =>
+              typeof handler === 'function' &&
+              handler.toString().includes('compactToggleHasVisualEffect'),
+          );
+
+      it('skips refreshStatic on Ctrl+O when history has no tool_group/thought items', () => {
+        mockedUseHistory.mockReturnValue({
+          history: [
+            { type: 'user', id: 1, text: 'hi' },
+            { type: 'gemini', id: 2, text: 'hello' },
+          ],
+          addItem: vi.fn(),
+          updateItem: vi.fn(),
+          clearItems: vi.fn(),
+          loadHistory: vi.fn(),
+          truncateToItem: vi.fn(),
+        });
+
+        render(
+          <AppContainer
+            config={mockConfig}
+            settings={mockSettings}
+            version="1.0.0"
+            initializationResult={mockInitResult}
+          />,
+        );
+        mockStdout.write.mockClear();
+
+        const handler = findGlobalKeypressHandler();
+        expect(handler).toBeDefined();
+        handler!(ctrlOKey);
+
+        // refreshStatic writes ansiEscapes.clearTerminal — its absence
+        // proves we took the no-op short-circuit.
+        expect(mockStdout.write).not.toHaveBeenCalledWith(
+          ansiEscapes.clearTerminal,
+        );
+      });
+
+      it('calls refreshStatic on Ctrl+O when history contains a tool_group', () => {
+        mockedUseHistory.mockReturnValue({
+          history: [
+            { type: 'user', id: 1, text: 'run ls' },
+            {
+              type: 'tool_group',
+              id: 2,
+              tools: [
+                {
+                  callId: 'c1',
+                  name: 'shell',
+                  description: 'shell description',
+                  status: 'Success',
+                  resultDisplay: undefined,
+                  confirmationDetails: undefined,
+                },
+              ],
+            },
+          ],
+          addItem: vi.fn(),
+          updateItem: vi.fn(),
+          clearItems: vi.fn(),
+          loadHistory: vi.fn(),
+          truncateToItem: vi.fn(),
+        });
+
+        render(
+          <AppContainer
+            config={mockConfig}
+            settings={mockSettings}
+            version="1.0.0"
+            initializationResult={mockInitResult}
+          />,
+        );
+        mockStdout.write.mockClear();
+
+        const handler = findGlobalKeypressHandler();
+        expect(handler).toBeDefined();
+        handler!(ctrlOKey);
+
+        expect(mockStdout.write).toHaveBeenCalledWith(
+          ansiEscapes.clearTerminal,
+        );
+      });
     });
   });
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -164,6 +164,7 @@ import {
   requestConsentInteractive,
   requestConsentOrFail,
 } from '../commands/extensions/consent.js';
+import { compactToggleHasVisualEffect } from './utils/mergeCompactToolGroups.js';
 
 const CTRL_EXIT_PROMPT_DURATION_MS = 1000;
 const debugLogger = createDebugLogger('APP_CONTAINER');
@@ -2238,7 +2239,15 @@ export const AppContainer = (props: AppContainerProps) => {
         const newValue = !compactMode;
         setCompactMode(newValue);
         void settings.setValue(SettingScope.User, 'ui.compactMode', newValue);
-        refreshStatic();
+        // Skip the expensive clearTerminal + Static remount when no past
+        // item would render differently (no tool_group / gemini_thought*).
+        // Future items pick up the new mode naturally because Static is
+        // append-only. Issue #3899: this unfreezes Ctrl+O for plain-chat
+        // long sessions; tool/thinking-bearing sessions still go through
+        // the (now chunked) full path in MainContent.
+        if (compactToggleHasVisualEffect(historyManager.history)) {
+          refreshStatic();
+        }
       }
     },
     [
@@ -2277,6 +2286,7 @@ export const AppContainer = (props: AppContainerProps) => {
       setRenderMode,
       refreshStatic,
       handleDoubleEscRewind,
+      historyManager,
     ],
   );
 

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -254,6 +254,12 @@ const SHELL_HEIGHT_PADDING = 10;
 export const AppContainer = (props: AppContainerProps) => {
   const { settings, config, initializationResult } = props;
   const historyManager = useHistory();
+  // `useHistory()` returns a fresh memoized object whenever `history` changes,
+  // so depending on `historyManager` directly inside event-handler callbacks
+  // would rebuild them on every message. Mirror history into a ref so
+  // handlers can read the latest snapshot at call time without reactive deps.
+  const historyRef = useRef(historyManager.history);
+  historyRef.current = historyManager.history;
   useMemoryMonitor(historyManager);
   const [debugMessage, setDebugMessage] = useState<string>('');
   const [quittingMessages, setQuittingMessages] = useState<
@@ -2245,7 +2251,7 @@ export const AppContainer = (props: AppContainerProps) => {
         // append-only. Issue #3899: this unfreezes Ctrl+O for plain-chat
         // long sessions; tool/thinking-bearing sessions still go through
         // the (now chunked) full path in MainContent.
-        if (compactToggleHasVisualEffect(historyManager.history)) {
+        if (compactToggleHasVisualEffect(historyRef.current)) {
           refreshStatic();
         }
       }
@@ -2286,7 +2292,6 @@ export const AppContainer = (props: AppContainerProps) => {
       setRenderMode,
       refreshStatic,
       handleDoubleEscRewind,
-      historyManager,
     ],
   );
 

--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -348,6 +348,59 @@ describe('<MainContent />', () => {
     expect(lengthAtLastCall()).toBe(TOTAL);
   });
 
+  it('renders newly finalized item without a disappear frame when gap is within CHUNK_SIZE (issue #3899)', () => {
+    // Regression: when a pending item finalizes, it is removed from
+    // pendingHistoryItems immediately. If replayCount still lags behind
+    // mergedHistory.length by ≤ PROGRESSIVE_REPLAY_CHUNK_SIZE, the item
+    // would be absent from BOTH areas for one render frame. The gap-based
+    // condition must render the full list synchronously in that case.
+    //
+    // Setup: 100 items = exactly the replay threshold, so initialReplayCount
+    // returns 100 (fully shown, no chunking). The component state is stable
+    // at replayCount=100 with no pending effects.
+    staticItemsSpy.mockClear();
+    const history = Array.from({ length: 100 }, (_, i) => ({
+      type: 'user' as const,
+      id: i,
+      text: `msg ${i}`,
+    }));
+
+    const { rerender } = renderMainContent(
+      createUIState({ history, historyRemountKey: 1 }),
+    );
+    // All 100 + 3 prefix items rendered immediately (below/at threshold).
+    expect(staticItemsSpy.mock.calls.at(-1)?.[0]).toHaveLength(103);
+
+    // Simulate a pending item finalizing: history grows by 1, same remount key.
+    // replayCount is 100; new length is 101; gap = 1 ≤ PROGRESSIVE_REPLAY_CHUNK_SIZE (50).
+    staticItemsSpy.mockClear();
+    rerender(
+      <AppContext.Provider value={{ version: '1.2.3', startupWarnings: [] }}>
+        <CompactModeProvider value={{ compactMode: false }}>
+          <UIActionsContext.Provider value={createUIActions()}>
+            <UIStateContext.Provider
+              value={createUIState({
+                history: [
+                  ...history,
+                  { type: 'user' as const, id: 100, text: 'new msg' },
+                ],
+                historyRemountKey: 1,
+              })}
+            >
+              <OverflowProvider>
+                <MainContent />
+              </OverflowProvider>
+            </UIStateContext.Provider>
+          </UIActionsContext.Provider>
+        </CompactModeProvider>
+      </AppContext.Provider>,
+    );
+
+    // The first render after the append must show all 104 items — no frame
+    // where the 101st item disappears (which would register as 103 here).
+    expect(staticItemsSpy.mock.calls[0]?.[0]).toHaveLength(104);
+  });
+
   it('synchronously resets to the first chunk on historyRemountKey change after a full catch-up (Ctrl+O regression, issue #3899)', async () => {
     // Wenshao's review: with the previous useEffect-based reset, the FIRST
     // render after a Ctrl+O-induced historyRemountKey bump would still feed

--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -322,16 +322,29 @@ describe('<MainContent />', () => {
 
     renderMainContent(createUIState({ history }));
 
+    const lengthAtLastCall = () =>
+      staticItemsSpy.mock.calls.at(-1)?.[0].length ?? 0;
+
     // Initial render: only the first chunk (50) plus the 3 prefix items
     // should be in Static — long history must not block the input thread.
-    expect(staticItemsSpy.mock.calls.at(-1)?.[0]).toHaveLength(53);
+    const TOTAL = 203; // 200 history + 3 prefix items
+    expect(lengthAtLastCall()).toBe(53);
+    expect(lengthAtLastCall()).toBeLessThan(TOTAL);
 
-    // Drain setImmediate ticks to let progressive replay catch up.
-    for (let i = 0; i < 10; i++) {
+    // Drain setImmediate ticks. Each iteration must not regress the visible
+    // count (monotonic) and we must reach TOTAL inside the loop budget — a
+    // silent regression that stops advancing will fail the final assert
+    // rather than spuriously time out.
+    let prev = lengthAtLastCall();
+    for (let i = 0; i < 50; i++) {
       await new Promise<void>((resolve) => setImmediate(resolve));
+      const curr = lengthAtLastCall();
+      expect(curr).toBeGreaterThanOrEqual(prev); // never shrinks mid-replay
+      prev = curr;
+      if (curr === TOTAL) break;
     }
 
-    // After catch-up the full history should be present.
-    expect(staticItemsSpy.mock.calls.at(-1)?.[0]).toHaveLength(203);
+    // After catch-up the full history must be present.
+    expect(lengthAtLastCall()).toBe(TOTAL);
   });
 });

--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -297,4 +297,41 @@ describe('<MainContent />', () => {
       ),
     ).toBe(1);
   });
+
+  it('passes the full history to Static in one render when below the progressive replay threshold', () => {
+    staticItemsSpy.mockClear();
+    const history = Array.from({ length: 50 }, (_, i) => ({
+      type: 'user' as const,
+      id: i,
+      text: `msg ${i}`,
+    }));
+
+    renderMainContent(createUIState({ history }));
+
+    // 3 prefix items (header / debug / notifications) + 50 history items
+    expect(staticItemsSpy.mock.calls.at(-1)?.[0]).toHaveLength(53);
+  });
+
+  it('progressively replays Static items when history exceeds the threshold (issue #3899)', async () => {
+    staticItemsSpy.mockClear();
+    const history = Array.from({ length: 200 }, (_, i) => ({
+      type: 'user' as const,
+      id: i,
+      text: `msg ${i}`,
+    }));
+
+    renderMainContent(createUIState({ history }));
+
+    // Initial render: only the first chunk (50) plus the 3 prefix items
+    // should be in Static — long history must not block the input thread.
+    expect(staticItemsSpy.mock.calls.at(-1)?.[0]).toHaveLength(53);
+
+    // Drain setImmediate ticks to let progressive replay catch up.
+    for (let i = 0; i < 10; i++) {
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+
+    // After catch-up the full history should be present.
+    expect(staticItemsSpy.mock.calls.at(-1)?.[0]).toHaveLength(203);
+  });
 });

--- a/packages/cli/src/ui/components/MainContent.test.tsx
+++ b/packages/cli/src/ui/components/MainContent.test.tsx
@@ -347,4 +347,54 @@ describe('<MainContent />', () => {
     // After catch-up the full history must be present.
     expect(lengthAtLastCall()).toBe(TOTAL);
   });
+
+  it('synchronously resets to the first chunk on historyRemountKey change after a full catch-up (Ctrl+O regression, issue #3899)', async () => {
+    // Wenshao's review: with the previous useEffect-based reset, the FIRST
+    // render after a Ctrl+O-induced historyRemountKey bump would still feed
+    // <Static> the full (pre-reset) replayCount, causing the synchronous
+    // remount blocking the input thread that the PR is trying to fix. This
+    // test pins the synchronous-reset behavior.
+    staticItemsSpy.mockClear();
+    const history = Array.from({ length: 200 }, (_, i) => ({
+      type: 'user' as const,
+      id: i,
+      text: `msg ${i}`,
+    }));
+    const TOTAL = 203;
+
+    const { rerender } = renderMainContent(
+      createUIState({ history, historyRemountKey: 1 }),
+    );
+
+    // Drive the chunked replay to completion.
+    for (let i = 0; i < 50; i++) {
+      const len = staticItemsSpy.mock.calls.at(-1)?.[0].length ?? 0;
+      if (len === TOTAL) break;
+      await new Promise<void>((resolve) => setImmediate(resolve));
+    }
+    expect(staticItemsSpy.mock.calls.at(-1)?.[0]).toHaveLength(TOTAL);
+
+    // Re-render with a bumped key — analogous to refreshStatic() firing.
+    // The very next render must immediately drop back to the first chunk;
+    // if reset were deferred to useEffect, <Static> would receive 203 items
+    // first and Ink would do the synchronous full-history layout the PR is
+    // meant to avoid.
+    rerender(
+      <AppContext.Provider value={{ version: '1.2.3', startupWarnings: [] }}>
+        <CompactModeProvider value={{ compactMode: false }}>
+          <UIActionsContext.Provider value={createUIActions()}>
+            <UIStateContext.Provider
+              value={createUIState({ history, historyRemountKey: 2 })}
+            >
+              <OverflowProvider>
+                <MainContent />
+              </OverflowProvider>
+            </UIStateContext.Provider>
+          </UIActionsContext.Provider>
+        </CompactModeProvider>
+      </AppContext.Provider>,
+    );
+
+    expect(staticItemsSpy.mock.calls.at(-1)?.[0]).toHaveLength(53);
+  });
 });

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -67,6 +67,12 @@ function addSourceBlockCounts(
 // gap is large (initial mount of a resumed session, or post-Ctrl+O remount).
 // Below the threshold the slice jumps to full length in one render so normal
 // runtime appends are bit-identical to the previous behavior.
+//
+// TODO(#3899 follow-up): the thresholds below are unbenchmarked. Per-item
+// render cost varies hugely (a one-line user message vs. thousands of lines
+// of tool stdout), so an item-count budget over-yields for tiny items and
+// under-yields for big ones. Consider switching to a *line-budget* per
+// chunk once we have telemetry on actual render times.
 const PROGRESSIVE_REPLAY_THRESHOLD = 100;
 const PROGRESSIVE_REPLAY_CHUNK_SIZE = 50;
 
@@ -319,13 +325,17 @@ export const MainContent = () => {
     return () => clearImmediate(handle);
   }, [replayCount, mergedHistory.length]);
 
-  const visibleHistoryItemsWithSourceCopyOffsets = useMemo(
-    () =>
-      replayCount >= historyItemsWithSourceCopyOffsets.length
-        ? historyItemsWithSourceCopyOffsets
-        : historyItemsWithSourceCopyOffsets.slice(0, replayCount),
-    [historyItemsWithSourceCopyOffsets, replayCount],
-  );
+  // TODO(#3899 follow-up): items at indexes >= replayCount are not yet in
+  // <Static>. If a pending item finalizes at index N during the catch-up
+  // window, it briefly disappears from the screen until replayCount reaches
+  // N. The window is bounded by chunkCount × event-loop tick (~100 ms for
+  // 500 items, ~1 s for 5000). For multi-thousand-item resumes a "tail
+  // buffer" — keep the trailing un-replayed items in the dynamic area until
+  // <Static> catches up — would close this gap.
+  const visibleHistoryItemsWithSourceCopyOffsets =
+    replayCount >= historyItemsWithSourceCopyOffsets.length
+      ? historyItemsWithSourceCopyOffsets
+      : historyItemsWithSourceCopyOffsets.slice(0, replayCount);
 
   return (
     <>

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -291,8 +291,7 @@ export const MainContent = () => {
   // history items currently passed to <Static>. It catches up to
   // mergedHistory.length either in one shot (small lag) or chunk-by-chunk
   // through setImmediate (large lag, e.g., post-Ctrl+O remount of a 500-item
-  // session). The reset effect re-runs only when historyRemountKey changes,
-  // so normal runtime appends never restart the chunked replay.
+  // session).
   //
   // Note: source-copy offsets are computed across the FULL mergedHistory
   // above so each code block keeps its stable copy index even when only a
@@ -303,12 +302,20 @@ export const MainContent = () => {
   const mergedLengthRef = useRef(mergedHistory.length);
   mergedLengthRef.current = mergedHistory.length;
 
-  useEffect(() => {
-    // Intentionally only depends on historyRemountKey — we react to remount
-    // events, not to incremental history growth (handled by the next effect).
-    // mergedLengthRef is a ref so it doesn't need to be in deps.
+  // The reset MUST happen during render (not in an effect): historyRemountKey
+  // also drives the <Static> key below, and Ink remounts Static synchronously
+  // on its first render with the new key. If we reset replayCount in a
+  // useEffect, that first render would already feed the full history to the
+  // new <Static> and we'd hit the freeze the PR is trying to avoid. The
+  // canonical "store previous prop in state" pattern queues a re-render
+  // that discards this one before commit, so <Static> never sees the
+  // stale full slice. Refs alone won't work — they don't trigger a re-render.
+  // See: https://react.dev/reference/react/useState#storing-information-from-previous-renders
+  const [lastRemountKey, setLastRemountKey] = useState(historyRemountKey);
+  if (lastRemountKey !== historyRemountKey) {
+    setLastRemountKey(historyRemountKey);
     setReplayCount(initialReplayCount(mergedLengthRef.current));
-  }, [historyRemountKey]);
+  }
 
   useEffect(() => {
     if (replayCount >= mergedHistory.length) return;

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -332,15 +332,16 @@ export const MainContent = () => {
     return () => clearImmediate(handle);
   }, [replayCount, mergedHistory.length]);
 
-  // TODO(#3899 follow-up): items at indexes >= replayCount are not yet in
-  // <Static>. If a pending item finalizes at index N during the catch-up
-  // window, it briefly disappears from the screen until replayCount reaches
-  // N. The window is bounded by chunkCount × event-loop tick (~100 ms for
-  // 500 items, ~1 s for 5000). For multi-thousand-item resumes a "tail
-  // buffer" — keep the trailing un-replayed items in the dynamic area until
-  // <Static> catches up — would close this gap.
+  // Render the full list when the tail gap is small (≤ CHUNK_SIZE). This
+  // covers the normal append path: a pending item finalizes, replayCount is
+  // already close to the new length, so we skip one useless slice frame.
+  // Without this, a just-finalized item could briefly disappear for one tick
+  // because it is gone from pendingHistoryItems but not yet in the Static
+  // slice. Chunked replay is still used for large remount gaps (Ctrl+O on a
+  // long session) where the gap is >> CHUNK_SIZE.
   const visibleHistoryItemsWithSourceCopyOffsets =
-    replayCount >= historyItemsWithSourceCopyOffsets.length
+    historyItemsWithSourceCopyOffsets.length - replayCount <=
+    PROGRESSIVE_REPLAY_CHUNK_SIZE
       ? historyItemsWithSourceCopyOffsets
       : historyItemsWithSourceCopyOffsets.slice(0, replayCount);
 

--- a/packages/cli/src/ui/components/MainContent.tsx
+++ b/packages/cli/src/ui/components/MainContent.tsx
@@ -5,7 +5,7 @@
  */
 
 import { Box, Static } from 'ink';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { HistoryItem, HistoryItemWithoutId } from '../types.js';
 import { HistoryItemDisplay } from './HistoryItemDisplay.js';
 import { ShowMoreLines } from './ShowMoreLines.js';
@@ -58,6 +58,22 @@ function addSourceBlockCounts(
     offsets.codeBlockLanguageCounts.set(lang, current + count);
   }
   offsets.mathBlockCount += counts.mathBlockCount;
+}
+
+// Issue #3899: Ink's <Static> renders all items synchronously on (re)mount.
+// For long histories that's O(N) blocking work — bad on Ctrl+O which clears
+// the terminal and forces a full remount. To keep input responsive, we
+// progressively grow the slice of history fed to <Static> when the catch-up
+// gap is large (initial mount of a resumed session, or post-Ctrl+O remount).
+// Below the threshold the slice jumps to full length in one render so normal
+// runtime appends are bit-identical to the previous behavior.
+const PROGRESSIVE_REPLAY_THRESHOLD = 100;
+const PROGRESSIVE_REPLAY_CHUNK_SIZE = 50;
+
+function initialReplayCount(length: number): number {
+  return length <= PROGRESSIVE_REPLAY_THRESHOLD
+    ? length
+    : Math.min(PROGRESSIVE_REPLAY_CHUNK_SIZE, length);
 }
 
 export const MainContent = () => {
@@ -265,6 +281,52 @@ export const MainContent = () => {
     });
   }, [pendingHistoryItems, pendingStartSourceCopyOffsets]);
 
+  // Progressive Static replay (issue #3899). `replayCount` is the number of
+  // history items currently passed to <Static>. It catches up to
+  // mergedHistory.length either in one shot (small lag) or chunk-by-chunk
+  // through setImmediate (large lag, e.g., post-Ctrl+O remount of a 500-item
+  // session). The reset effect re-runs only when historyRemountKey changes,
+  // so normal runtime appends never restart the chunked replay.
+  //
+  // Note: source-copy offsets are computed across the FULL mergedHistory
+  // above so each code block keeps its stable copy index even when only a
+  // prefix is visible; we slice the post-offset array here.
+  const [replayCount, setReplayCount] = useState(() =>
+    initialReplayCount(mergedHistory.length),
+  );
+  const mergedLengthRef = useRef(mergedHistory.length);
+  mergedLengthRef.current = mergedHistory.length;
+
+  useEffect(() => {
+    // Intentionally only depends on historyRemountKey — we react to remount
+    // events, not to incremental history growth (handled by the next effect).
+    // mergedLengthRef is a ref so it doesn't need to be in deps.
+    setReplayCount(initialReplayCount(mergedLengthRef.current));
+  }, [historyRemountKey]);
+
+  useEffect(() => {
+    if (replayCount >= mergedHistory.length) return;
+    const remaining = mergedHistory.length - replayCount;
+    if (remaining <= PROGRESSIVE_REPLAY_CHUNK_SIZE) {
+      setReplayCount(mergedHistory.length);
+      return;
+    }
+    const handle = setImmediate(() => {
+      setReplayCount((c) =>
+        Math.min(c + PROGRESSIVE_REPLAY_CHUNK_SIZE, mergedLengthRef.current),
+      );
+    });
+    return () => clearImmediate(handle);
+  }, [replayCount, mergedHistory.length]);
+
+  const visibleHistoryItemsWithSourceCopyOffsets = useMemo(
+    () =>
+      replayCount >= historyItemsWithSourceCopyOffsets.length
+        ? historyItemsWithSourceCopyOffsets
+        : historyItemsWithSourceCopyOffsets.slice(0, replayCount),
+    [historyItemsWithSourceCopyOffsets, replayCount],
+  );
+
   return (
     <>
       {/*
@@ -278,7 +340,7 @@ export const MainContent = () => {
           <AppHeader key="app-header" version={version} />,
           <DebugModeNotification key="debug-notification" />,
           <Notifications key="notifications" />,
-          ...historyItemsWithSourceCopyOffsets.map(
+          ...visibleHistoryItemsWithSourceCopyOffsets.map(
             ({ item: h, sourceCopyIndexOffsets }) => (
               <HistoryItemDisplay
                 terminalWidth={terminalWidth}

--- a/packages/cli/src/ui/utils/mergeCompactToolGroups.test.ts
+++ b/packages/cli/src/ui/utils/mergeCompactToolGroups.test.ts
@@ -5,7 +5,10 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { mergeCompactToolGroups } from './mergeCompactToolGroups.js';
+import {
+  compactToggleHasVisualEffect,
+  mergeCompactToolGroups,
+} from './mergeCompactToolGroups.js';
 import type {
   HistoryItem,
   HistoryItemToolGroup,
@@ -525,5 +528,47 @@ describe('mergeCompactToolGroups', () => {
     expect(merged[2].type).toBe('tool_group');
     expect(merged[3].type).toBe('tool_group');
     expect(merged[4].type).toBe('tool_group');
+  });
+});
+
+describe('compactToggleHasVisualEffect', () => {
+  it('returns false for empty history', () => {
+    expect(compactToggleHasVisualEffect([])).toBe(false);
+  });
+
+  it('returns false for plain user/info/error history (no tools, no thinking)', () => {
+    const history: HistoryItem[] = [
+      { type: 'user', id: 1, text: 'hi' },
+      { type: 'gemini', id: 2, text: 'hello' },
+      { type: 'info', id: 3, text: 'note' },
+      { type: 'error', id: 4, text: 'oops' },
+    ];
+    expect(compactToggleHasVisualEffect(history)).toBe(false);
+  });
+
+  it('returns true when any tool_group is present', () => {
+    const history: HistoryItem[] = [
+      { type: 'user', id: 1, text: 'run' },
+      createToolGroup(2, [
+        createTool('c1', 'shell', ToolCallStatus.Success),
+      ]) as HistoryItem,
+    ];
+    expect(compactToggleHasVisualEffect(history)).toBe(true);
+  });
+
+  it('returns true when any gemini_thought is present', () => {
+    const history: HistoryItem[] = [
+      { type: 'user', id: 1, text: 'q' },
+      { type: 'gemini_thought', id: 2, text: 'thinking…' },
+    ];
+    expect(compactToggleHasVisualEffect(history)).toBe(true);
+  });
+
+  it('returns true when any gemini_thought_content is present', () => {
+    const history: HistoryItem[] = [
+      { type: 'user', id: 1, text: 'q' },
+      { type: 'gemini_thought_content', id: 2, text: 'inner' },
+    ];
+    expect(compactToggleHasVisualEffect(history)).toBe(true);
   });
 });

--- a/packages/cli/src/ui/utils/mergeCompactToolGroups.ts
+++ b/packages/cli/src/ui/utils/mergeCompactToolGroups.ts
@@ -108,10 +108,14 @@ function isHiddenInCompactMode(item: HistoryItem): boolean {
  * Ctrl+O for plain-chat sessions that have neither tool calls nor thinking
  * blocks regardless of conversation length.
  *
- * Conservative: any `tool_group` returns true even if it's force-expanded
- * (force-expand groups render via the same path in both modes, but their
- * adjacent `tool_use_summary` may still render differently — checking the
- * group alone is the cheap upper bound).
+ * Conservative: returns true for any `tool_group`, even though a history of
+ * only force-expanded groups would technically render the same way in both
+ * modes (force-expand groups bypass the compact-rendering path and their
+ * adjacent `tool_use_summary` items are not absorbed). Distinguishing
+ * force-expand from regular groups requires `embeddedShellFocused` and
+ * `activePtyId`, which are not cheaply available at the keypress handler
+ * call site — we accept the false-positive in exchange for keeping this
+ * predicate self-contained and O(N).
  */
 export function compactToggleHasVisualEffect(
   history: readonly HistoryItem[],

--- a/packages/cli/src/ui/utils/mergeCompactToolGroups.ts
+++ b/packages/cli/src/ui/utils/mergeCompactToolGroups.ts
@@ -101,6 +101,34 @@ function isHiddenInCompactMode(item: HistoryItem): boolean {
 }
 
 /**
+ * Cheap O(N) scan: does any item in `history` render differently between
+ * compact and detailed modes? When this returns false, toggling compactMode
+ * is a pixel-identical no-op for already-rendered output, so the caller can
+ * skip the expensive `clearTerminal + Static remount` path. This unfreezes
+ * Ctrl+O for plain-chat sessions that have neither tool calls nor thinking
+ * blocks regardless of conversation length.
+ *
+ * Conservative: any `tool_group` returns true even if it's force-expanded
+ * (force-expand groups render via the same path in both modes, but their
+ * adjacent `tool_use_summary` may still render differently — checking the
+ * group alone is the cheap upper bound).
+ */
+export function compactToggleHasVisualEffect(
+  history: readonly HistoryItem[],
+): boolean {
+  for (const item of history) {
+    if (
+      item.type === 'tool_group' ||
+      item.type === 'gemini_thought' ||
+      item.type === 'gemini_thought_content'
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Merge consecutive tool_group history items for compact mode display.
  *
  * Tool_groups separated only by items hidden in compact mode (`gemini_thought`,


### PR DESCRIPTION
## Summary

Closes #3899.

Pressing Ctrl+O on a long conversation froze the terminal for seconds. The toggle handler called `refreshStatic()`, which `clearTerminal`'d and forced Ink's `<Static>` to remount every history item synchronously on the input thread — `N` items × per-item Ink layout/render blocked the keyboard until the redraw finished.

Two narrow changes preserve current UX:

1. **`compactToggleHasVisualEffect(history)` short-circuit** — `mergeCompactToolGroups.ts` exposes an O(N) scan; the Ctrl+O handler in `AppContainer.tsx` skips `refreshStatic()` entirely when no past item would render differently (history without `tool_group` / `gemini_thought*`). Future items still pick up the new mode via React state — `<Static>` is append-only. Plain-chat sessions no longer freeze on Ctrl+O regardless of length.

2. **Progressive `<Static>` replay** — `MainContent.tsx` feeds `<Static>` a growing slice of `mergedHistory` when the catch-up gap is large. Below 100 items the slice jumps to full length in one render (bit-identical to the previous behavior); above that, it grows in 50-item chunks via `setImmediate` so the event loop yields between batches and the input thread stays responsive during the post-Ctrl+O remount. This also covers the post-resume initial mount path — first paint of a large resumed history no longer blocks.

## Why this approach

UX is unchanged: terminal is still cleared, all history items still render under the new mode after the toggle. We only changed *how* the work is scheduled (yielding between chunks vs. a single synchronous burst) and short-circuit the toggle when it would be a pixel-identical no-op.

Discussion of alternatives (sealed prefix + live tail, true viewport virtualization, ANSI-output caching) was considered but each changes UX or requires an architectural rewrite. This PR is the minimum-change fix consistent with the existing rendering model.

## Test plan

- [x] `compactToggleHasVisualEffect` unit tests cover empty / plain / tool_group / gemini_thought / gemini_thought_content histories.
- [x] `MainContent` tests cover both the below-threshold (full slice in one render) and above-threshold (initial 50-item slice, grows after `setImmediate` ticks) paths.
- [x] Full `packages/cli` vitest suite green (5016 tests).
- [x] `tsc --noEmit` clean.
- [x] `eslint` clean (0 warnings).
- [x] Manual repro: open a session with > 200 turns containing tool calls, press Ctrl+O. Expect responsive input throughout the redraw rather than a multi-second freeze.

the demo video: a long conversation with 500 turns, and then press `ctrl + o` to switch from compact to verbose mode.

https://github.com/user-attachments/assets/d4889f49-2e59-4d1d-9274-8ec8b6df31d1



🤖 Generated with [Qwen Code](https://qwen.ai/qwencode)