### PR TITLE
feat(web-templates): add light theme and toggle to /export HTML

### DIFF
--- a/packages/web-templates/src/export-html/src/components/ThemeToggle.tsx
+++ b/packages/web-templates/src/export-html/src/components/ThemeToggle.tsx
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { ExportTheme } from './useExportTheme.js';
+
+export type ThemeToggleProps = {
+  theme: ExportTheme;
+  onToggle: () => void;
+};
+
+const SunIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2" />
+    <path d="M12 20v2" />
+    <path d="m4.93 4.93 1.41 1.41" />
+    <path d="m17.66 17.66 1.41 1.41" />
+    <path d="M2 12h2" />
+    <path d="M20 12h2" />
+    <path d="m6.34 17.66-1.41 1.41" />
+    <path d="m19.07 4.93-1.41 1.41" />
+  </svg>
+);
+
+const MoonIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M12 3a6 6 0 0 0 9 9 9 9 0 1 1-9-9Z" />
+  </svg>
+);
+
+export const ThemeToggle = ({ theme, onToggle }: ThemeToggleProps) => {
+  const isLight = theme === 'light';
+  const nextThemeLabel = isLight
+    ? 'Switch to dark theme'
+    : 'Switch to light theme';
+  return (
+    <button
+      type="button"
+      className="theme-toggle"
+      aria-label={nextThemeLabel}
+      aria-pressed={isLight}
+      title={nextThemeLabel}
+      onClick={onToggle}
+    >
+      {isLight ? <MoonIcon /> : <SunIcon />}
+    </button>
+  );
+};

--- a/packages/web-templates/src/export-html/src/components/useExportTheme.ts
+++ b/packages/web-templates/src/export-html/src/components/useExportTheme.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// React is loaded as a UMD bundle via the CDN <script> tag in index.html
+// (see __REACT_UMD_VERSION__ replacement). All code in this package consumes
+// React/JSX through `window.React` + the `react/jsx-runtime` shim, instead
+// of ESM imports.
+const React = window.React;
+const { useCallback, useEffect, useState } = React;
+
+export type ExportTheme = 'light' | 'dark';
+
+// IMPORTANT: keep this string in sync with the inline FOUC bootstrap script
+// in `index.html` — both reads must agree on the same key for theme
+// persistence to work without an initial flash.
+export const EXPORT_THEME_STORAGE_KEY = 'qwen-export-theme';
+
+const isExportTheme = (value: unknown): value is ExportTheme =>
+  value === 'light' || value === 'dark';
+
+const readInitialTheme = (): ExportTheme => {
+  try {
+    const stored = window.localStorage.getItem(EXPORT_THEME_STORAGE_KEY);
+    if (isExportTheme(stored)) {
+      return stored;
+    }
+  } catch {
+    // localStorage may be unavailable (private mode, file:// sandbox).
+  }
+  return 'dark';
+};
+
+const applyThemeToDocument = (theme: ExportTheme) => {
+  const root = document.documentElement;
+  root.classList.toggle('light', theme === 'light');
+  root.classList.toggle('dark', theme === 'dark');
+};
+
+export type UseExportThemeResult = {
+  theme: ExportTheme;
+  toggleTheme: () => void;
+};
+
+export const useExportTheme = (): UseExportThemeResult => {
+  const [theme, setTheme] = useState<ExportTheme>(readInitialTheme);
+
+  useEffect(() => {
+    applyThemeToDocument(theme);
+    try {
+      window.localStorage.setItem(EXPORT_THEME_STORAGE_KEY, theme);
+    } catch {
+      // Persisting is best-effort; ignore failures.
+    }
+  }, [theme]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  }, []);
+
+  return { theme, toggleTheme };
+};

--- a/packages/web-templates/src/export-html/src/index.html
+++ b/packages/web-templates/src/export-html/src/index.html
@@ -37,6 +37,26 @@
       href="https://unpkg.com/@qwen-code/webui@__WEBUI_VERSION__/dist/styles.css"
     />
     <title>Qwen Code Chat Export</title>
+    <script>
+      // Pre-hydrate FOUC guard: must run before <style> below applies layout.
+      // The storage key 'qwen-export-theme' is duplicated here verbatim and
+      // MUST stay in sync with EXPORT_THEME_STORAGE_KEY in
+      // src/components/useExportTheme.ts.
+      (function () {
+        try {
+          var stored = window.localStorage.getItem('qwen-export-theme');
+          var theme = stored === 'light' || stored === 'dark' ? stored : 'dark';
+          var root = document.documentElement;
+          // Toggle-style writes mirror the React hook's effect, so the two
+          // code paths converge on identical class state.
+          root.classList.toggle('light', theme === 'light');
+          root.classList.toggle('dark', theme === 'dark');
+        } catch (e) {
+          // localStorage may be unavailable (private mode, file:// sandbox);
+          // the static class="dark" attribute on <html> remains the default.
+        }
+      })();
+    </script>
     <style>
       @font-face {
         font-family: "Press Start 2P";

--- a/packages/web-templates/src/export-html/src/main.tsx
+++ b/packages/web-templates/src/export-html/src/main.tsx
@@ -3,6 +3,8 @@ import logoSvg from './favicon.svg';
 import { TempFileModal } from './components/TempFileModal.js';
 import { usePlatformContext } from './components/hooks.js';
 import { MetadataSidebar } from './components/MetadataSidebar.js';
+import { ThemeToggle } from './components/ThemeToggle.js';
+import { useExportTheme } from './components/useExportTheme.js';
 import { parseChatData, isChatViewerMessage } from './components/utils.js';
 
 declare global {
@@ -50,6 +52,7 @@ const App = () => {
     .filter((record) => record.type !== 'system');
   const metadata = chatData.metadata;
   const { platformContext, modalState, closeModal } = usePlatformContext();
+  const { theme, toggleTheme } = useExportTheme();
 
   return (
     <div className="page-wrapper">
@@ -66,11 +69,14 @@ const App = () => {
             </div>
           </div>
         </div>
+        <div className="header-right">
+          <ThemeToggle theme={theme} onToggle={toggleTheme} />
+        </div>
       </header>
       <div className="content-wrapper">
         <div className="chat-container">
           <PlatformProvider value={platformContext}>
-            <ChatViewer messages={messages} autoScroll={false} theme="dark" />
+            <ChatViewer messages={messages} autoScroll={false} theme={theme} />
           </PlatformProvider>
         </div>
         {metadata && <MetadataSidebar metadata={metadata} />}

--- a/packages/web-templates/src/export-html/src/styles.css
+++ b/packages/web-templates/src/export-html/src/styles.css
@@ -5,6 +5,49 @@
   --text-secondary: #a1a1aa;
   --border-color: #3f3f46;
   --accent-color: #3b82f6;
+  --header-bg: rgba(24, 24, 27, 0.95);
+  --scrollbar-thumb-hover: #52525b;
+}
+
+:root.light {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f3f4f6;
+  --text-primary: #1f2937;
+  --text-secondary: #6b7280;
+  --border-color: #e5e7eb;
+  --accent-color: #2563eb;
+  --header-bg: rgba(249, 250, 251, 0.95);
+  --scrollbar-thumb-hover: #d1d5db;
+
+  /*
+   * Mirror webui's light-theme overrides so ChatViewer follows the toggle.
+   * These values track @qwen-code/webui's variables.css `:root.auto-theme`
+   * block. When upgrading the webui dependency, diff that block and sync
+   * any new `--app-*` keys here so light mode keeps parity with dark.
+   */
+  --app-primary-foreground: #1f2937;
+  --app-secondary-foreground: #6b7280;
+  --app-background: #ffffff;
+  --app-primary-background: #ffffff;
+  --app-background-secondary: #f3f4f6;
+  --app-background-tertiary: #e5e7eb;
+  --app-foreground: #1f2937;
+  --app-foreground-secondary: #6b7280;
+  --app-foreground-muted: #9ca3af;
+  --app-border: #e5e7eb;
+  --app-primary-border-color: #e5e7eb;
+  --app-input-background: #ffffff;
+  --app-input-border: #d1d5db;
+  --app-input-placeholder-foreground: #9ca3af;
+  --app-ghost-button-hover-background: rgba(0, 0, 0, 0.05);
+  --app-header-background: #f9fafb;
+  --app-list-hover-background: rgba(0, 0, 0, 0.05);
+  --app-list-active-background: #3b82f6;
+  --app-menu-background: #ffffff;
+  --app-menu-border: #e5e7eb;
+  --app-menu-foreground: #1f2937;
+  --app-tool-background: #ffffff;
+  --app-code-background: #f3f4f6;
 }
 
 body {
@@ -30,7 +73,7 @@ body {
   width: 100%;
   padding: 16px 24px;
   border-bottom: 1px solid var(--border-color);
-  background-color: rgba(24, 24, 27, 0.95);
+  background-color: var(--header-bg);
   backdrop-filter: blur(8px);
   position: sticky;
   top: 0;
@@ -45,6 +88,44 @@ body {
   display: flex;
   align-items: center;
   gap: 12px;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.theme-toggle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+}
+
+.theme-toggle:hover {
+  background-color: var(--bg-secondary);
+  color: var(--text-primary);
+}
+
+.theme-toggle:focus-visible {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+.theme-toggle:active {
+  transform: scale(0.95);
 }
 
 .logo-icon {
@@ -141,7 +222,7 @@ body {
 }
 
 .meta-label {
-  color: #71717a;
+  color: var(--text-secondary);
 }
 
 ::-webkit-scrollbar {
@@ -160,7 +241,7 @@ body {
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #52525b;
+  background: var(--scrollbar-thumb-hover);
 }
 
 @media (max-width: 768px) {
@@ -171,14 +252,6 @@ body {
 
   .header {
     padding: 12px 16px;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 12px;
-  }
-
-  .header-left {
-    width: 100%;
-    justify-content: space-between;
   }
 
   .meta {
@@ -256,7 +329,7 @@ body {
 
 .metadata-item-empty {
   font-size: 12px;
-  color: #71717a;
+  color: var(--text-secondary);
   margin: 0;
   padding: 4px 0;
 }
@@ -270,7 +343,7 @@ body {
 
 .metadata-content .metadata-label {
   font-size: 10px;
-  color: #71717a;
+  color: var(--text-secondary);
 }
 
 .metadata-content .metadata-value {

--- a/packages/web-templates/src/export-html/src/styles.css
+++ b/packages/web-templates/src/export-html/src/styles.css
@@ -21,9 +21,15 @@
 
   /*
    * Mirror webui's light-theme overrides so ChatViewer follows the toggle.
-   * These values track @qwen-code/webui's variables.css `:root.auto-theme`
-   * block. When upgrading the webui dependency, diff that block and sync
-   * any new `--app-*` keys here so light mode keeps parity with dark.
+   * The first group tracks @qwen-code/webui's variables.css `:root.auto-theme`
+   * block. The second group covers `--app-*` tokens that the auto-theme block
+   * does NOT override but ChatViewer / MarkdownRenderer / CollapsibleFileContent
+   * still read — without these, light-mode exports leak dark surfaces (e.g.
+   * markdown table headers, collapsible file blocks).
+   *
+   * When upgrading the webui dependency, diff its `:root` defaults plus the
+   * `:root.auto-theme` block and sync any new `--app-*` keys here so light
+   * mode keeps parity with dark.
    */
   --app-primary-foreground: #1f2937;
   --app-secondary-foreground: #6b7280;
@@ -48,6 +54,14 @@
   --app-menu-foreground: #1f2937;
   --app-tool-background: #ffffff;
   --app-code-background: #f3f4f6;
+  --app-secondary-background: #f3f4f6;
+  --app-input-secondary-background: #f3f4f6;
+  --app-input-foreground: #1f2937;
+  --app-button-background: #e5e7eb;
+  --app-button-secondary-background: #f3f4f6;
+  --app-button-foreground: #1f2937;
+  --app-transparent-inner-border: rgba(0, 0, 0, 0.1);
+  --app-warning-foreground: #b45309;
 }
 
 body {


### PR DESCRIPTION
## Summary

- What changed: Added light theme support and a toggle button to the /export HTML report page header
- Why it changed: The /export HTML report previously rendered only in dark mode; users requested the ability to switch themes
- Reviewer focus: Verify theme toggle works correctly, persists preference, and maintains backward compatibility with default dark mode

## Validation

- Commands run:
  ```bash
  npm run build && npm run bundle
  ```
- Prompts / inputs used: Various export scenarios including default dark mode, two-way toggle, persistence checks, localStorage edge cases, mobile layout, and ChatViewer parity
- Expected result: Theme toggle appears in header, switches between light/dark, persists selection in localStorage, defaults to dark
- Observed result: All 6 manual test cases passed successfully
- Quickest reviewer verification path: Build the project, run an export, toggle the theme button, refresh page to verify persistence
- Evidence: Manual testing across default dark, two-way toggle, persistence + no FOUC, localStorage poisoning, mobile layout, ChatViewer parity

Web Dark Theme
<img width="3186" height="1652" alt="webDark" src="https://github.com/user-attachments/assets/3af44fb2-1256-4c2d-9124-de6360acc7d0" />

Web Light Theme
<img width="3024" height="1654" alt="webLight" src="https://github.com/user-attachments/assets/e9d34241-50a6-4a18-b598-1a761d99f1eb" />

Mobile Dark Theme
<img width="814" height="1466" alt="mobileDark" src="https://github.com/user-attachments/assets/8ad76d8f-7beb-42b4-806b-bed3a5f293cf" />

Mobile Light Theme
<img width="3024" height="1654" alt="webLight" src="https://github.com/user-attachments/assets/126b35af-f1f9-4266-83e0-d66f0a477c98" />


## Scope / Risk

- Main risk or tradeoff: localStorage access wrapped in try/catch to handle private mode and file:// URLs gracefully
- Not covered / not validated: Automated unit tests deferred (web-templates and webui lack vitest setup); will be added in follow-up PR with test infrastructure
- Breaking changes / migration notes: None — default remains dark to preserve backward compatibility

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:
- Manual validation performed across 6 export theme scenarios; automated tests pending test infrastructure setup

## Linked Issues / Bugs

Closes #3678

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)