### PR TITLE
ci(release): skip CI on the version-bump squash commit on main

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -321,7 +321,7 @@ jobs:
           if git diff --staged --quiet; then
             echo "No version changes to commit"
           else
-            git commit -m "chore(release): sdk-typescript ${RELEASE_TAG} [skip ci]"
+            git commit -m "chore(release): sdk-typescript ${RELEASE_TAG}"
           fi
           echo "Pushing release branch to remote..."
           git push --set-upstream origin "${BRANCH_NAME}" --follow-tags
@@ -411,6 +411,7 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ secrets.CI_BOT_PAT }}'
           PR_URL: '${{ steps.pr.outputs.PR_URL }}'
+          RELEASE_TAG: '${{ steps.version.outputs.RELEASE_TAG }}'
         run: |-
           set -euo pipefail
           # Keep [skip ci] on the squash commit that lands on main. The release

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -413,7 +413,15 @@ jobs:
           PR_URL: '${{ steps.pr.outputs.PR_URL }}'
         run: |-
           set -euo pipefail
-          gh pr merge "${PR_URL}" --squash --auto --delete-branch
+          # Keep [skip ci] on the squash commit that lands on main. The release
+          # PR title also includes it for visibility, but --subject makes the
+          # post-merge CI-skip behavior explicit instead of depending on gh's
+          # default squash subject.
+          gh pr merge "${PR_URL}" \
+            --squash \
+            --auto \
+            --delete-branch \
+            --subject "chore(release): sdk-typescript ${RELEASE_TAG} [skip ci]"
 
       - name: 'Create Issue on Failure'
         if: |-

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -321,7 +321,7 @@ jobs:
           if git diff --staged --quiet; then
             echo "No version changes to commit"
           else
-            git commit -m "chore(release): sdk-typescript ${RELEASE_TAG}"
+            git commit -m "chore(release): sdk-typescript ${RELEASE_TAG} [skip ci]"
           fi
           echo "Pushing release branch to remote..."
           git push --set-upstream origin "${BRANCH_NAME}" --follow-tags
@@ -399,7 +399,7 @@ jobs:
             pr_url="$(gh pr create \
               --base main \
               --head "${RELEASE_BRANCH}" \
-              --title "chore(release): sdk-typescript ${RELEASE_TAG}" \
+              --title "chore(release): sdk-typescript ${RELEASE_TAG} [skip ci]" \
               --body "Automated release PR for sdk-typescript ${RELEASE_TAG}.")"
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,7 +367,7 @@ jobs:
           if git diff --staged --quiet; then
             echo "No version changes to commit"
           else
-            git commit -m "chore(release): ${RELEASE_TAG}"
+            git commit -m "chore(release): ${RELEASE_TAG} [skip ci]"
           fi
           if [[ "${IS_DRY_RUN}" == "false" ]]; then
             echo "Pushing release branch to remote..."
@@ -435,7 +435,7 @@ jobs:
             pr_url="$(gh pr create \
               --base main \
               --head "${RELEASE_BRANCH}" \
-              --title "chore(release): ${RELEASE_TAG}" \
+              --title "chore(release): ${RELEASE_TAG} [skip ci]" \
               --body "Automated release PR for ${RELEASE_TAG}. Syncs package.json versions on main.")"
           fi
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,7 +367,7 @@ jobs:
           if git diff --staged --quiet; then
             echo "No version changes to commit"
           else
-            git commit -m "chore(release): ${RELEASE_TAG} [skip ci]"
+            git commit -m "chore(release): ${RELEASE_TAG}"
           fi
           if [[ "${IS_DRY_RUN}" == "false" ]]; then
             echo "Pushing release branch to remote..."
@@ -447,6 +447,7 @@ jobs:
         env:
           GITHUB_TOKEN: '${{ secrets.CI_BOT_PAT }}'
           PR_URL: '${{ steps.pr.outputs.PR_URL }}'
+          RELEASE_TAG: '${{ needs.prepare.outputs.release_tag }}'
         run: |-
           set -euo pipefail
           # Keep [skip ci] on the squash commit that lands on main. The release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,7 +449,15 @@ jobs:
           PR_URL: '${{ steps.pr.outputs.PR_URL }}'
         run: |-
           set -euo pipefail
-          gh pr merge "${PR_URL}" --squash --auto --delete-branch
+          # Keep [skip ci] on the squash commit that lands on main. The release
+          # PR title also includes it for visibility, but --subject makes the
+          # post-merge CI-skip behavior explicit instead of depending on gh's
+          # default squash subject.
+          gh pr merge "${PR_URL}" \
+            --squash \
+            --auto \
+            --delete-branch \
+            --subject "chore(release): ${RELEASE_TAG} [skip ci]"
 
   notify_failure:
     name: 'Notify Release Failure'


### PR DESCRIPTION
## Summary

- **What changed**: Set `[skip ci]` as the squash subject (via `gh pr merge --subject`) when the auto-generated release PR auto-merges into `main`, so the squashed commit landing on `main` does not re-run CI.
- **Why it changed**: Release PRs like #3907 only bump `package.json` / `package-lock.json` versions but currently re-run the full check matrix on the post-merge `main` push, on top of the validation that `release.yml` already runs (`quality` + `integration_*` jobs).
- **Reviewer focus**:
  - `release.yml` and `release-sdk.yml` `Enable auto-merge for release PR` step now explicitly passes `--subject "...[skip ci]"`, instead of relying on `gh pr merge`'s default of using the PR title.
  - Both auto-merge steps export `RELEASE_TAG` in their `env:` block — without that, `set -euo pipefail` would crash on `${RELEASE_TAG}` being unbound.
  - The release-branch commit message is intentionally **not** marked `[skip ci]`, so `gh release create --target "${RELEASE_BRANCH}"` does not silently suppress tag-push workflows like `build-and-publish-image.yml`.

## Behavior matrix (after this PR)

| Step | Triggering commit / event | CI behavior |
| --- | --- | --- |
| Push release branch | release-branch tip (no `[skip ci]`) | `ci.yml` + `sdk-python.yml` run once |
| Open release PR | PR head = release-branch tip (no `[skip ci]`) | `ci.yml` + `sdk-python.yml` run once |
| Tag the release (`gh release create --target ${RELEASE_BRANCH}`) | tag points at release-branch tip | `build-and-publish-image.yml` runs as usual |
| Auto-merge squashes into `main` | squash commit subject contains `[skip ci]` | `ci.yml`, `e2e.yml`, `sdk-python.yml` skip |

The PR-time CI run is duplicative with `release.yml`'s `quality` / `integration_*` jobs but harmless, and stripping it would require job-level `if:` filters in `ci.yml` / `sdk-python.yml` — out of scope for this PR.

## Validation

- **Commands run**:
  ```bash
  git diff --stat origin/main...HEAD
  # .github/workflows/release-sdk.yml | 11 ++++++++++-
  # .github/workflows/release.yml     | 11 ++++++++++-

  # Verify YAML still parses
  python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); yaml.safe_load(open('.github/workflows/release-sdk.yml'))"
  ```
- **Expected result**: On the next non-dry-run release, the squash commit on `main` carries `[skip ci]` and `ci.yml` does not re-run on `main`. The tag-push event still triggers `build-and-publish-image.yml`. `Enable auto-merge` no longer fails on `RELEASE_TAG: unbound variable`.
- **Observed result**: Not yet exercised against a real release run; dry-run skips the auto-merge step.
- **Quickest reviewer verification path**:
  1. Confirm `--subject` is passed in `release.yml:457-461` and `release-sdk.yml:421-425`.
  2. Confirm both `Enable auto-merge` steps export `RELEASE_TAG` in `env:`.
  3. Confirm the release-branch commit message in `release.yml:370` and `release-sdk.yml:324` does **not** contain `[skip ci]`.
- **Evidence**: PR #3907 ran the full check matrix on the post-merge `main` push despite only changing version strings.

## Scope / Risk

- **Main risk or tradeoff**: If `main` later adopts strict required status checks, `[skip ci]` on the squash commit would prevent those required checks from running and `gh pr merge --auto` would stall. Branch protection currently has `required_status_checks: null`, verified before this change; revisit if that ever changes.
- **Not covered / not validated**: No live release was triggered. The `Enable auto-merge` step is gated off in dry-run / nightly / preview paths, so the original `RELEASE_TAG: unbound variable` crash would only have manifested in a real production release.
- **Breaking changes / migration notes**: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | N/A | N/A | N/A |
| npx      | N/A | N/A | N/A |

Workflow YAML change with no runtime / platform component — testing matrix not applicable.

## Linked Issues / Bugs

None.
