### PR TITLE
fix(skills): allow symlinks pointing outside the skills directory

### DIFF
--- a/packages/core/src/skills/skill-load.test.ts
+++ b/packages/core/src/skills/skill-load.test.ts
@@ -296,17 +296,12 @@ Valid skill.
         },
       ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
 
-      // realpath stays within baseDir (in-tree symlink, e.g. user
-      // symlinks one skill directory to another in the same tree).
-      // Use mockImplementation so realpath(baseDir) returns the base
-      // (canonicalization-of-base is now part of the scope check) and
-      // realpath(skillDir) returns the in-tree target.
-      vi.mocked(fs.realpath).mockImplementation((p) => {
-        const s = String(p);
-        if (s === testBaseDir) return Promise.resolve(testBaseDir);
-        return Promise.resolve(`${testBaseDir}/symlinked-skill`);
-      });
-      // stat resolves to a directory (symlink target)
+      // Symlink target — realpath returns wherever the link points.
+      // Out-of-tree targets are allowed (the supported user workflow
+      // is symlinking into ~/.qwen/skills/ from a separate repo).
+      vi.mocked(fs.realpath).mockResolvedValue(
+        '/elsewhere/skills-repo/symlinked-skill',
+      );
       vi.mocked(fs.stat).mockResolvedValue({
         isDirectory: () => true,
       } as unknown as Awaited<ReturnType<typeof fs.stat>>);
@@ -322,7 +317,6 @@ Symlinked skill body.
 
       const skills = await loadSkillsFromDir(testBaseDir);
 
-      // Skill is loaded from the symlinked directory.
       expect(skills).toHaveLength(1);
     });
 
@@ -336,11 +330,9 @@ Symlinked skill body.
         },
       ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
 
-      vi.mocked(fs.realpath).mockImplementation((p) => {
-        const s = String(p);
-        if (s === testBaseDir) return Promise.resolve(testBaseDir);
-        return Promise.resolve(`${testBaseDir}/file-symlink`);
-      });
+      vi.mocked(fs.realpath).mockResolvedValue(
+        '/elsewhere/skills-repo/some-file',
+      );
       // stat resolves to a file (not a directory)
       vi.mocked(fs.stat).mockResolvedValue({
         isDirectory: () => false,
@@ -361,94 +353,15 @@ Symlinked skill body.
         },
       ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
 
-      // realpath(baseDir) succeeds (the directory itself is fine);
-      // realpath(symlink target) throws because the link is broken.
-      vi.mocked(fs.realpath).mockImplementation((p) => {
-        const s = String(p);
-        if (s === testBaseDir) return Promise.resolve(testBaseDir);
-        return Promise.reject(new Error('ENOENT: no such file or directory'));
-      });
+      // realpath on the dangling link throws ENOENT; the entry is
+      // skipped with an `invalid` reason.
+      vi.mocked(fs.realpath).mockRejectedValue(
+        new Error('ENOENT: no such file or directory'),
+      );
 
       const skills = await loadSkillsFromDir(testBaseDir);
 
       expect(skills).toHaveLength(0);
-    });
-
-    it('should skip symlinks that escape baseDir (prevents arbitrary-skill-load attack)', async () => {
-      // Regression: an attacker who can write a symlink into a skills
-      // directory (shared monorepo, compromised extension) could load
-      // arbitrary skill content from outside the tree, including hooks
-      // that execute shell commands. The realpath scope check rejects
-      // symlinks whose target falls outside `baseDir`.
-      vi.mocked(fs.readdir).mockResolvedValue([
-        {
-          name: 'escape-symlink',
-          isDirectory: () => false,
-          isFile: () => false,
-          isSymbolicLink: () => true,
-        },
-      ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
-
-      // realpath(baseDir) → baseDir; realpath(symlink) → outside-tree
-      // target. Both sides canonicalized so path.relative works as
-      // expected — substring/prefix checks would have an open ambiguity
-      // when baseDir happens to share a prefix with the escape target.
-      vi.mocked(fs.realpath).mockImplementation((p) => {
-        const s = String(p);
-        if (s === testBaseDir) return Promise.resolve(testBaseDir);
-        return Promise.resolve('/etc/cron.d/payload');
-      });
-      vi.mocked(fs.stat).mockResolvedValue({
-        isDirectory: () => true,
-      } as unknown as Awaited<ReturnType<typeof fs.stat>>);
-      vi.mocked(fs.access).mockResolvedValue(undefined);
-      vi.mocked(fs.readFile).mockResolvedValue(`---
-name: hijacked
-description: Should never load
----
-
-malicious body
-`);
-
-      const skills = await loadSkillsFromDir(testBaseDir);
-      expect(skills).toHaveLength(0);
-    });
-
-    it('should accept in-tree symlinks where the target lives in a subdirectory of baseDir', async () => {
-      // Regression for shared-helper realpath-base check on Windows-ish
-      // canonicalization differences: realpath(base) and realpath(target)
-      // must compose via path.relative, so any in-tree target sitting
-      // under a subdirectory must still pass containment. Asserts on
-      // count + body presence rather than name because the YAML parser
-      // here is mocked to a fixed default (name: test-skill).
-      vi.mocked(fs.readdir).mockResolvedValue([
-        {
-          name: 'nested-symlink',
-          isDirectory: () => false,
-          isFile: () => false,
-          isSymbolicLink: () => true,
-        },
-      ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
-
-      vi.mocked(fs.realpath).mockImplementation((p) => {
-        const s = String(p);
-        if (s === testBaseDir) return Promise.resolve(testBaseDir);
-        return Promise.resolve(`${testBaseDir}/inner/dir/nested-skill`);
-      });
-      vi.mocked(fs.stat).mockResolvedValue({
-        isDirectory: () => true,
-      } as unknown as Awaited<ReturnType<typeof fs.stat>>);
-      vi.mocked(fs.access).mockResolvedValue(undefined);
-      vi.mocked(fs.readFile).mockResolvedValue(`---
-name: test-skill
-description: Nested in-tree symlink target
----
-
-body
-`);
-
-      const skills = await loadSkillsFromDir(testBaseDir);
-      expect(skills).toHaveLength(1);
     });
   });
 

--- a/packages/core/src/skills/skill-load.ts
+++ b/packages/core/src/skills/skill-load.ts
@@ -5,7 +5,7 @@ import {
   parsePathsField,
   validateSkillName,
 } from './types.js';
-import { validateSymlinkScope } from './symlinkScope.js';
+import { validateSymlinkTarget } from './symlinkScope.js';
 import * as fs from 'fs/promises';
 import * as path from 'path';
 import { parse as parseYaml } from '../utils/yaml-parser.js';
@@ -25,24 +25,6 @@ export async function loadSkillsFromDir(
     const skills: SkillConfig[] = [];
     debugLogger.debug(`Found ${entries.length} entries in ${baseDir}`);
 
-    // Resolve baseDir once outside the loop. Symlink scope validation
-    // (in `validateSymlinkScope`) needs the canonical form to compare
-    // against; doing it per-entry would burn a syscall per directory
-    // entry for the same answer. `fs.readdir` succeeded just above so
-    // the directory exists — realpath should not throw here, but if it
-    // does we treat the whole directory as unreadable.
-    let baseRealPath: string;
-    try {
-      baseRealPath = await fs.realpath(baseDir);
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : 'Unknown error';
-      debugLogger.debug(
-        `Cannot realpath skills baseDir ${baseDir}: ${errorMessage}`,
-      );
-      return [];
-    }
-
     for (const entry of entries) {
       // Process directories and symlinks that resolve to directories.
       // Plain files are silently skipped (each skill must be a directory).
@@ -56,18 +38,14 @@ export async function loadSkillsFromDir(
 
       const skillDir = path.join(baseDir, entry.name);
 
-      // For symlinks, verify the target (a) resolves, (b) is a directory,
-      // and (c) stays within `baseDir`. Shared with `skill-manager.ts`
-      // so the two parsers can't drift on this code-execution-vector
-      // gate (skills can ship hooks that run shell commands).
+      // For symlinks, verify the target (a) resolves and (b) is a
+      // directory. Shared with `skill-manager.ts` so the two parsers
+      // stay in sync. Targets pointing outside `baseDir` are allowed
+      // — see `symlinkScope.ts` for the rationale.
       if (isSymlink) {
-        const check = await validateSymlinkScope(skillDir, baseRealPath);
+        const check = await validateSymlinkTarget(skillDir);
         if (!check.ok) {
-          if (check.reason === 'escapes') {
-            debugLogger.warn(
-              `Skipping symlink ${entry.name} that escapes ${baseDir}`,
-            );
-          } else if (check.reason === 'not-directory') {
+          if (check.reason === 'not-directory') {
             debugLogger.warn(
               `Skipping symlink ${entry.name} that does not point to a directory`,
             );

--- a/packages/core/src/skills/skill-manager.test.ts
+++ b/packages/core/src/skills/skill-manager.test.ts
@@ -1364,11 +1364,11 @@ Body.
         },
       ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
 
-      // realpath stays within baseDir (in-tree symlink)
-      vi.mocked(fs.realpath).mockImplementation((p) =>
-        Promise.resolve(String(p)),
+      // Symlink target can point anywhere on disk — out-of-tree
+      // targets are the supported user workflow.
+      vi.mocked(fs.realpath).mockResolvedValue(
+        '/elsewhere/skills-repo/symlink-skill',
       );
-      // Mock fs.stat to return directory stats for the symlink target
       vi.mocked(fs.stat).mockResolvedValue({
         isDirectory: () => true,
       } as Awaited<ReturnType<typeof fs.stat>>);
@@ -1397,8 +1397,8 @@ Symlink skill content`);
         },
       ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
 
-      vi.mocked(fs.realpath).mockImplementation((p) =>
-        Promise.resolve(String(p)),
+      vi.mocked(fs.realpath).mockResolvedValue(
+        '/elsewhere/skills-repo/some-file',
       );
       // Mock fs.stat to return file stats (not a directory)
       vi.mocked(fs.stat).mockResolvedValue({
@@ -1420,61 +1420,14 @@ Symlink skill content`);
         },
       ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
 
-      // realpath(baseDir) succeeds (the directory itself is fine);
-      // realpath(target) throws because the link is broken. Without
-      // discriminating, the new realpath-base step in loadSkillsFromDir
-      // would also throw and bail the whole directory before reaching
-      // the per-symlink check we want to test.
-      vi.mocked(fs.realpath).mockImplementation((p) => {
-        const s = String(p);
-        if (s.endsWith('broken-symlink')) {
-          return Promise.reject(new Error('ENOENT: no such file or directory'));
-        }
-        return Promise.resolve(s);
-      });
+      // realpath on the dangling link throws ENOENT; the entry is
+      // skipped with an `invalid` reason.
+      vi.mocked(fs.realpath).mockRejectedValue(
+        new Error('ENOENT: no such file or directory'),
+      );
 
       const skills = await manager.listSkills({ force: true });
 
-      expect(skills).toHaveLength(0);
-    });
-
-    it('should skip symlinks that escape baseDir (prevents arbitrary-skill-load attack)', async () => {
-      // Regression: a symlink whose target falls outside the skills
-      // tree (e.g. attacker pointing at /etc/cron.d) must be dropped
-      // — skills can ship hooks that execute shell commands, so
-      // arbitrary-load is a code-execution vector. realpath + scope
-      // check guards this.
-      vi.mocked(fs.readdir).mockResolvedValue([
-        {
-          name: 'escape-symlink',
-          isDirectory: () => false,
-          isSymbolicLink: () => true,
-          isFile: () => false,
-        },
-      ] as unknown as Awaited<ReturnType<typeof fs.readdir>>);
-
-      // realpath(baseDir) returns the base canonical form; only the
-      // symlink target escapes. A bare `mockResolvedValue` would map
-      // both calls to the same value and accidentally let the attack
-      // through (path.relative(x, x) === '' which is in-scope).
-      vi.mocked(fs.realpath).mockImplementation((p) => {
-        const s = String(p);
-        if (s.endsWith('escape-symlink')) {
-          return Promise.resolve('/etc/cron.d/payload');
-        }
-        return Promise.resolve(s);
-      });
-      vi.mocked(fs.stat).mockResolvedValue({
-        isDirectory: () => true,
-      } as Awaited<ReturnType<typeof fs.stat>>);
-      vi.mocked(fs.access).mockResolvedValue(undefined);
-      vi.mocked(fs.readFile).mockResolvedValue(`---
-name: hijacked
-description: Should never load
----
-malicious body`);
-
-      const skills = await manager.listSkills({ force: true });
       expect(skills).toHaveLength(0);
     });
 

--- a/packages/core/src/skills/skill-manager.ts
+++ b/packages/core/src/skills/skill-manager.ts
@@ -28,7 +28,7 @@ import {
 } from './types.js';
 import type { Config } from '../config/config.js';
 import { validateConfig } from './skill-load.js';
-import { validateSymlinkScope } from './symlinkScope.js';
+import { validateSymlinkTarget } from './symlinkScope.js';
 import {
   SkillActivationRegistry,
   splitConditionalSkills,
@@ -940,25 +940,6 @@ export class SkillManager {
       const entries = await fs.readdir(baseDir, { withFileTypes: true });
       debugLogger.debug(`Found ${entries.length} entries in ${baseDir}`);
 
-      // Resolve baseDir once outside the parallel map. Symlink scope
-      // validation needs the canonical form to compare against; doing
-      // it per-entry would burn N realpath syscalls (one per entry) for
-      // the same answer. `fs.readdir` succeeded above so the directory
-      // exists; if realpath still throws (FS race / permissions), treat
-      // the whole directory as unreadable rather than letting the per-
-      // symlink check trip on every entry.
-      let baseRealPath: string;
-      try {
-        baseRealPath = await fs.realpath(baseDir);
-      } catch (error) {
-        const errorMessage =
-          error instanceof Error ? error.message : 'Unknown error';
-        debugLogger.debug(
-          `Cannot realpath skills baseDir ${baseDir}: ${errorMessage}`,
-        );
-        return [];
-      }
-
       // The returned `loaded` array preserves entries order via Promise.all,
       // but `parseSkillFileInternal` writes into `this.parseErrors` as each
       // promise settles, so the Map's insertion order reflects parse-finish
@@ -976,19 +957,14 @@ export class SkillManager {
 
           const skillDir = path.join(baseDir, entry.name);
 
-          // For symlinks, verify the target (a) resolves, (b) is a
-          // directory, and (c) stays within `baseDir`. Shared with
-          // `skill-load.ts` so the two parsers can't drift on this
-          // code-execution-vector gate (skills can ship hooks that run
-          // shell commands).
+          // For symlinks, verify the target (a) resolves and (b) is a
+          // directory. Shared with `skill-load.ts` so the two parsers
+          // stay in sync. Targets pointing outside `baseDir` are
+          // allowed — see `symlinkScope.ts` for the rationale.
           if (isSymlink) {
-            const check = await validateSymlinkScope(skillDir, baseRealPath);
+            const check = await validateSymlinkTarget(skillDir);
             if (!check.ok) {
-              if (check.reason === 'escapes') {
-                debugLogger.warn(
-                  `Skipping symlink ${entry.name} that escapes ${baseDir}`,
-                );
-              } else if (check.reason === 'not-directory') {
+              if (check.reason === 'not-directory') {
                 debugLogger.warn(
                   `Skipping symlink ${entry.name} that does not point to a directory`,
                 );

--- a/packages/core/src/skills/symlinkScope.test.ts
+++ b/packages/core/src/skills/symlinkScope.test.ts
@@ -6,11 +6,11 @@
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'fs/promises';
-import { validateSymlinkScope } from './symlinkScope.js';
+import { validateSymlinkTarget } from './symlinkScope.js';
 
 vi.mock('fs/promises');
 
-describe('validateSymlinkScope', () => {
+describe('validateSymlinkTarget', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -19,31 +19,32 @@ describe('validateSymlinkScope', () => {
     vi.restoreAllMocks();
   });
 
-  it('accepts a target that resolves inside baseRealPath', async () => {
-    vi.mocked(fs.realpath).mockResolvedValue('/base/skills/foo');
+  it('accepts a target that resolves to a directory', async () => {
+    vi.mocked(fs.realpath).mockResolvedValue('/some/where/foo');
     vi.mocked(fs.stat).mockResolvedValue({
       isDirectory: () => true,
     } as Awaited<ReturnType<typeof fs.stat>>);
 
-    const result = await validateSymlinkScope(
-      '/base/skills/link',
-      '/base/skills',
-    );
+    const result = await validateSymlinkTarget('/base/skills/link');
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.realPath).toBe('/base/skills/foo');
+      expect(result.realPath).toBe('/some/where/foo');
     }
   });
 
-  it('accepts a target nested several directories deep inside baseRealPath', async () => {
-    vi.mocked(fs.realpath).mockResolvedValue('/base/skills/inner/deep/foo');
+  it('accepts a target that resolves outside the skills directory', async () => {
+    // Cross-directory symlinks are the supported user workflow: a
+    // separate skills repo on disk, with subsets symlinked into
+    // `~/.qwen/skills/`. The helper must not reject these.
+    vi.mocked(fs.realpath).mockResolvedValue(
+      '/Users/me/projects/skills-repo/skills/auto-pr',
+    );
     vi.mocked(fs.stat).mockResolvedValue({
       isDirectory: () => true,
     } as Awaited<ReturnType<typeof fs.stat>>);
 
-    const result = await validateSymlinkScope(
-      '/base/skills/link',
-      '/base/skills',
+    const result = await validateSymlinkTarget(
+      '/Users/me/.qwen/skills/auto-pr',
     );
     expect(result.ok).toBe(true);
   });
@@ -51,83 +52,11 @@ describe('validateSymlinkScope', () => {
   it('rejects when realpath fails (broken symlink)', async () => {
     vi.mocked(fs.realpath).mockRejectedValue(new Error('ENOENT'));
 
-    const result = await validateSymlinkScope(
-      '/base/skills/dangling',
-      '/base/skills',
-    );
+    const result = await validateSymlinkTarget('/base/skills/dangling');
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.reason).toBe('invalid');
     }
-  });
-
-  it('rejects when target escapes baseRealPath via parent traversal', async () => {
-    vi.mocked(fs.realpath).mockResolvedValue('/etc/cron.d/payload');
-    vi.mocked(fs.stat).mockResolvedValue({
-      isDirectory: () => true,
-    } as Awaited<ReturnType<typeof fs.stat>>);
-
-    const result = await validateSymlinkScope(
-      '/base/skills/escape',
-      '/base/skills',
-    );
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.reason).toBe('escapes');
-    }
-  });
-
-  it('rejects sibling-prefix attacks (base + suffix that does not start with sep)', async () => {
-    // Without `path.relative`, a naive `realPath.startsWith(base + sep)`
-    // check could still false-pass when the target is `/base/skillsX/...`
-    // (sibling whose name starts with "skills"). path.relative('/base/skills',
-    // '/base/skillsX/foo') = '../skillsX/foo' → first segment `..` → rejected.
-    vi.mocked(fs.realpath).mockResolvedValue('/base/skillsX/foo');
-    vi.mocked(fs.stat).mockResolvedValue({
-      isDirectory: () => true,
-    } as Awaited<ReturnType<typeof fs.stat>>);
-
-    const result = await validateSymlinkScope(
-      '/base/skills/escape',
-      '/base/skills',
-    );
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.reason).toBe('escapes');
-    }
-  });
-
-  it('accepts an in-base directory whose first segment starts with two dots (e.g. "..shared")', async () => {
-    // Regression: `path.relative('/base', '/base/..shared/foo')` returns
-    // `'..shared/foo'`. The previous `rel.startsWith('..')` containment
-    // check false-rejected this legitimate in-base path. Containment
-    // must be segment-aware: only a literal `..` first segment escapes.
-    vi.mocked(fs.realpath).mockResolvedValue('/base/skills/..shared/foo');
-    vi.mocked(fs.stat).mockResolvedValue({
-      isDirectory: () => true,
-    } as Awaited<ReturnType<typeof fs.stat>>);
-
-    const result = await validateSymlinkScope(
-      '/base/skills/link',
-      '/base/skills',
-    );
-    expect(result.ok).toBe(true);
-  });
-
-  it('accepts a single-segment in-base directory whose name is "..bar"', async () => {
-    // Companion to the previous case for the `rel === '..bar'` shape
-    // (no trailing path component). `'..bar'.split(/[/\\]/)[0] === '..bar'`
-    // which is not equal to `..`, so containment passes.
-    vi.mocked(fs.realpath).mockResolvedValue('/base/skills/..bar');
-    vi.mocked(fs.stat).mockResolvedValue({
-      isDirectory: () => true,
-    } as Awaited<ReturnType<typeof fs.stat>>);
-
-    const result = await validateSymlinkScope(
-      '/base/skills/link',
-      '/base/skills',
-    );
-    expect(result.ok).toBe(true);
   });
 
   it('rejects when target exists but is a file, not a directory', async () => {
@@ -136,10 +65,7 @@ describe('validateSymlinkScope', () => {
       isDirectory: () => false,
     } as Awaited<ReturnType<typeof fs.stat>>);
 
-    const result = await validateSymlinkScope(
-      '/base/skills/link',
-      '/base/skills',
-    );
+    const result = await validateSymlinkTarget('/base/skills/link');
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.reason).toBe('not-directory');
@@ -150,30 +76,10 @@ describe('validateSymlinkScope', () => {
     vi.mocked(fs.realpath).mockResolvedValue('/base/skills/foo');
     vi.mocked(fs.stat).mockRejectedValue(new Error('EACCES'));
 
-    const result = await validateSymlinkScope(
-      '/base/skills/link',
-      '/base/skills',
-    );
+    const result = await validateSymlinkTarget('/base/skills/link');
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.reason).toBe('invalid');
     }
-  });
-
-  it('treats a target equal to baseRealPath as in-scope (degenerate but not escaping)', async () => {
-    // Edge case: a symlink whose target IS the base directory itself.
-    // path.relative(x, x) === '' which is neither '..' nor absolute, so
-    // the helper returns ok: true. The downstream `SKILL.md` access
-    // check filters this out (no manifest at the base directory level).
-    vi.mocked(fs.realpath).mockResolvedValue('/base/skills');
-    vi.mocked(fs.stat).mockResolvedValue({
-      isDirectory: () => true,
-    } as Awaited<ReturnType<typeof fs.stat>>);
-
-    const result = await validateSymlinkScope(
-      '/base/skills/self',
-      '/base/skills',
-    );
-    expect(result.ok).toBe(true);
   });
 });

--- a/packages/core/src/skills/symlinkScope.ts
+++ b/packages/core/src/skills/symlinkScope.ts
@@ -5,77 +5,54 @@
  */
 
 import * as fs from 'fs/promises';
-import * as path from 'path';
 
 /**
- * Result of validating a symlink entry's scope inside a skills directory.
+ * Result of validating a symlink entry inside a skills directory.
  *
- *  - `ok: true`  → target exists, is a directory, and stays inside `baseRealPath`.
- *  - `ok: false` → one of `escapes` / `not-directory` / `invalid` (broken or
- *    permission-denied symlink). Callers log a warn and skip the entry.
+ *  - `ok: true`  → target resolves and is a directory.
+ *  - `ok: false` → `not-directory` (target exists but is a file/socket/etc.)
+ *    or `invalid` (broken link, permission denied, stat race). Callers log
+ *    a warn and skip the entry.
+ *
+ * Symlinks pointing outside the skills directory are intentionally **not**
+ * rejected. The original symlink support
+ * (`f02225226 feat(core): add symlink support for skill manager`) was
+ * designed to let users "organize and share skills more flexibly by using
+ * symbolic links" — typical layout is one skills repo on disk, with
+ * subsets symlinked into `~/.qwen/skills/`. PR #3604 added a containment
+ * check that rejected any out-of-scope target as a code-execution-vector
+ * mitigation; the threat model only fits scenarios where an attacker can
+ * write a symlink but **not** a regular file (extremely narrow on a
+ * single-user `~/.qwen/skills/`, since write access to the dir lets the
+ * attacker drop a real `SKILL.md` directly), so the check was net
+ * negative — it broke the supported user-managed-symlink workflow without
+ * meaningfully reducing the underlying hooks-as-shell-execution risk.
+ * If a project-level containment policy is wanted later, scope it to the
+ * `project` level only rather than re-enabling it everywhere.
  */
-export type SymlinkScopeCheck =
+export type SymlinkTargetCheck =
   | { ok: true; realPath: string }
   | {
       ok: false;
-      reason: 'escapes' | 'not-directory' | 'invalid';
+      reason: 'not-directory' | 'invalid';
       error?: unknown;
     };
 
 /**
- * Validate that a symlink at `skillDir` (a) resolves, (b) targets a
- * directory, and (c) stays within `baseRealPath` after both sides are
- * canonicalized.
+ * Validate that a symlink at `skillDir` (a) resolves and (b) targets a
+ * directory. The target is allowed to live anywhere on disk.
  *
- * Caller contract:
- *  - Pass `baseRealPath` already realpath-resolved (typically once outside
- *    a directory-iteration loop). The helper canonicalizes the target
- *    again to keep both sides on the same canonical form — `path.resolve`
- *    alone only collapses `.` / `..` / relative segments, leaving Windows
- *    case differences and short-vs-long-path forms unrecorded. The
- *    failing Windows CI on the symlinked-skill test traced back to that
- *    asymmetry: `realpath(target)` returned the long-form, casing-fixed
- *    path while the prefix being compared was the raw `path.resolve(base)`,
- *    so a legitimate in-tree symlink got flagged as escaping.
- *
- * Containment uses `path.relative` rather than `startsWith(base + sep)`
- * so we don't false-positive on sibling directories whose names happen
- * to share a prefix with the base, and we get cross-platform separator
- * handling for free. The `'..'`-prefix and `path.isAbsolute` checks
- * cover both POSIX (`../foo`) and Windows (`C:\\elsewhere\\foo` →
- * absolute relative-path) escape shapes.
- *
- * Without the scope check at all, a symlink anywhere in the skills tree
- * could pull in arbitrary on-disk content as a "skill" — and skills can
- * ship hooks that invoke shell commands, so this is a code-execution
- * vector. Used by both `skill-load.ts` (sequential extension parser) and
- * `skill-manager.ts` (parallel project/user/bundled parser); kept here
- * so the two paths can't drift.
+ * Used by both `skill-load.ts` (extension parser) and `skill-manager.ts`
+ * (project/user/bundled parser) so the two paths stay in sync.
  */
-export async function validateSymlinkScope(
+export async function validateSymlinkTarget(
   skillDir: string,
-  baseRealPath: string,
-): Promise<SymlinkScopeCheck> {
+): Promise<SymlinkTargetCheck> {
   let realPath: string;
   try {
     realPath = await fs.realpath(skillDir);
   } catch (error) {
     return { ok: false, reason: 'invalid', error };
-  }
-  const rel = path.relative(baseRealPath, realPath);
-  // `rel === ''` means target IS the base directory — degenerate but
-  // technically inside scope; let it through and rely on the caller's
-  // SKILL.md presence check to filter. Containment requires that the
-  // FIRST path segment is not `..`. The previous `rel.startsWith('..')`
-  // check false-rejected legitimate in-base directories whose names
-  // happen to start with two dots (`..shared/foo` is `path.relative`'s
-  // output for `/base/..shared/foo` against `/base` — a real filename
-  // shape, not a parent traversal). Split on both `/` and `\\` so the
-  // segment walk works regardless of platform-specific output from
-  // `path.relative`.
-  const segments = rel.split(/[/\\]/);
-  if (segments[0] === '..' || path.isAbsolute(rel)) {
-    return { ok: false, reason: 'escapes' };
   }
   let targetStat: Awaited<ReturnType<typeof fs.stat>>;
   try {


### PR DESCRIPTION
## Summary

- What changed: drop the baseDir containment check that PR #3604 added to `validateSymlinkScope` (now `validateSymlinkTarget`). Symlinks under `~/.qwen/skills/` (or any other skills root) whose `realpath` resolves to a directory outside that base are loaded again, instead of being silently skipped with a debug-only `escapes` warning. The two remaining symlink validations — target resolves, target is a directory — are kept.
- Why it changed: regression from PR #3604. Commit `f02225226 feat(core): add symlink support for skill manager` was explicit that the goal of symlink support was to let users "organize and share skills more flexibly by using symbolic links". The most common shape of that workflow is symlinking a separate skills repo into `~/.qwen/skills/`. The containment check rejected every such cross-directory symlink and broke this workflow on user-level skill directories.
- Reviewer focus:
  - `packages/core/src/skills/symlinkScope.ts` — the rationale for removing containment lives in the file header so future `git blame` readers don't need to come back to this PR. Also covers why a project-level-only re-introduction is the right shape if a containment policy is wanted later.
  - `packages/core/src/skills/skill-load.ts` and `packages/core/src/skills/skill-manager.ts` — call sites collapse from "resolve baseDir + check containment + check directory" to "check directory"; the per-iteration `fs.realpath(baseDir)` hoist is no longer needed.
  - Tests in all three suites — `escapes` / sibling-prefix / `..shared` segment-aware regression cases are removed; an `out-of-tree accept` case is added in `symlinkScope.test.ts` to pin the new contract.

### Why containment is misaligned

The containment check came from a `Qwen3.6-Plus-DogFooding /review` finding on PR #3604, raised against the worry that an attacker who can write a symlink into a skills directory could point it at `/etc/cron.d/`-shaped content (skills can ship hooks that invoke shell commands, so this is a code-execution vector):

- https://github.com/QwenLM/qwen-code/pull/3604#discussion_r3177782029
- https://github.com/QwenLM/qwen-code/pull/3604#discussion_r3177784820

The threat model fits project-level skills loaded from an untrusted cloned repo's `<repo>/.qwen/skills/`. It was applied uniformly across user / project / extension levels in the merged PR. On user-level (`~/.qwen/skills/`, single-user private directory) the check buys no real security: write access to drop a symlink already implies write access to drop a real `SKILL.md`, so an attacker doesn't need to go through a symlink at all. The containment branch has no level-aware path that would tighten on `project` and loosen on `user`, so removing it on all levels and re-introducing project-level scoping later (if wanted) is the cleaner shape than trying to gate the existing branch.

This PR removes the check on all levels. A follow-up that scopes a containment-style policy to `project` only is a strict superset and stays a separate decision.

## Validation

- Commands run:
  ```bash
  npx vitest run \
    packages/core/src/skills/ \
    packages/core/src/tools/skill.test.ts \
    packages/core/src/core/coreToolScheduler.test.ts
  npx eslint \
    packages/core/src/skills/symlinkScope.ts \
    packages/core/src/skills/symlinkScope.test.ts \
    packages/core/src/skills/skill-load.ts \
    packages/core/src/skills/skill-load.test.ts \
    packages/core/src/skills/skill-manager.ts \
    packages/core/src/skills/skill-manager.test.ts
  npm run typecheck --workspace @qwen-code/qwen-code-core
  ```
- Prompts / inputs used: local symlink reproduction in `~/.qwen/skills/` pointing at a separate on-disk skills repo (`/Users/.../yiliang114/skills/skills/<skill>`); confirmed before this change that `path.relative(baseRealPath, realPath)` resolves to a `..`-prefixed path, which `validateSymlinkScope` rejects with `escapes`.
- Expected result: cross-directory symlinks load and surface in `<available_skills>` and `/skills`; broken links and non-directory targets are still skipped with the previous `invalid` / `not-directory` reasons; existing same-tree symlinks keep working unchanged.
- Observed result:
  - `vitest`: 281/281 tests pass across 6 files (`skill-activation.test.ts`, `skill-load.test.ts`, `skill-manager.test.ts`, `symlinkScope.test.ts`, `tools/skill.test.ts`, `core/coreToolScheduler.test.ts`).
  - `eslint`: clean.
  - `tsc --noEmit` for `@qwen-code/qwen-code-core`: clean.
  - The new `out-of-tree accept` case in `symlinkScope.test.ts` is the regression pin for this PR's contract.
- Quickest reviewer verification path:
  ```bash
  gh pr checkout <this-pr>
  npx vitest run packages/core/src/skills/ packages/core/src/tools/skill.test.ts
  ```
  Expected: 5 files, 188 tests pass; the `should accept a target that resolves outside the skills directory` case in `symlinkScope.test.ts` documents the user-managed-symlink workflow that this PR restores.
- Evidence: `vitest` output reported `Test Files 6 passed (6)` and `Tests 281 passed (281)` for the focused subset above. Diff stat is `6 files changed, 85 insertions(+), 384 deletions(-)`, dominated by removing the containment-specific test cases and helper hoists.

## Scope / Risk

- Main risk or tradeoff: this is a deliberate widening of what `loadSkillsFromDir` accepts on every skill level. A user / project / extension symlink whose target lives anywhere on disk is now loaded, provided the target resolves and is a directory. The trade-off — the user-level containment check buys no security, since drop-a-symlink and drop-a-file have the same precondition — is documented in the `symlinkScope.ts` header. Project-level skills loaded from an untrusted cloned repo do remain a separate consideration; this PR does not introduce a new vector there beyond what already exists pre-PR-#3604, and any project-only containment policy can be added on top.
- Not covered / not validated: Windows-specific symlink behavior is exercised only through the existing skill-loader unit suites; no Windows machine was used directly for this change. The Windows-cross-drive concern that drove the original `path.relative`-based check is no longer relevant once containment is gone, but CI will validate the suites on `windows-latest`.
- Breaking changes / migration notes: none for users. The exported helper renamed from `validateSymlinkScope` to `validateSymlinkTarget` and dropped its `baseRealPath` parameter; both call sites in this repo were updated. The helper has no external consumers I'm aware of.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Focused vitest, eslint, and `tsc --noEmit` were run locally on macOS. Windows / Linux paths covered by the existing `Test (windows-latest, ...)` and `Test (ubuntu-latest, ...)` CI matrix.

## Linked Issues / Bugs

Closes #3913
