### PR TITLE
fix(core): drop disabled MCP server from health status registry

### DIFF
--- a/packages/cli/src/ui/hooks/useMCPHealth.ts
+++ b/packages/cli/src/ui/hooks/useMCPHealth.ts
@@ -38,10 +38,15 @@ export function useMCPHealth(): MCPHealthSnapshot {
   );
 
   useEffect(() => {
-    const listener = (name: string, status: MCPServerStatus) => {
+    const listener = (name: string, status: MCPServerStatus | undefined) => {
       setServers((prev) => {
         const next = new Map(prev);
-        next.set(name, status);
+        if (status === undefined) {
+          // Server was removed from the registry (e.g. disabled via /mcp).
+          next.delete(name);
+        } else {
+          next.set(name, status);
+        }
         return next;
       });
     };

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -12,6 +12,7 @@ import {
   MCPDiscoveryState,
   MCPServerStatus,
   populateMcpServerCommand,
+  removeMCPServerStatus,
 } from './mcp-client.js';
 import type { SendSdkMcpMessage } from './mcp-client.js';
 import { getErrorMessage } from '../utils/errors.js';
@@ -515,6 +516,10 @@ export class McpClientManager {
 
     // Remove tools for this server from registry
     this.toolRegistry.removeMcpToolsByServer(serverName);
+
+    // The server has been removed from configuration, so drop it from the
+    // global status registry too — the health pill should no longer count it.
+    removeMCPServerStatus(serverName);
 
     this.eventEmitter?.emit('mcp-client-update', this.clients);
   }

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -555,6 +555,48 @@ describe('mcp-client', () => {
       removeMCPStatusChangeListener(listener);
       expect(listener).not.toHaveBeenCalled();
     });
+
+    it('a stale status update from an in-flight connect cannot resurrect a removed server', async () => {
+      // Race scenario from PR review: `disableMcpServer` removes the entry,
+      // but `McpClient.connect()`'s catch block could still fire afterwards
+      // and call `updateStatus(DISCONNECTED)`. The `isDisconnecting` guard
+      // inside `McpClient.updateStatus` must prevent that resurrection.
+      const mockedClient = {
+        connect: vi.fn().mockRejectedValue(new Error('connect failed')),
+        registerCapabilities: vi.fn(),
+        setRequestHandler: vi.fn(),
+        close: vi.fn(),
+      };
+      vi.mocked(ClientLib.Client).mockReturnValue(
+        mockedClient as unknown as ClientLib.Client,
+      );
+      vi.spyOn(SdkClientStdioLib, 'StdioClientTransport').mockReturnValue({
+        close: vi.fn(),
+      } as unknown as SdkClientStdioLib.StdioClientTransport);
+
+      const client = new McpClient(
+        'racy-server',
+        { command: 'test-command' },
+        {} as ToolRegistry,
+        {} as PromptRegistry,
+        {} as WorkspaceContext,
+        false,
+      );
+
+      // Kick off connect() but don't await it; it will reject and run its
+      // catch block which calls updateStatus(DISCONNECTED).
+      const connectPromise = client.connect();
+
+      // Simulate the disable path running before connect's catch fires.
+      await client.disconnect();
+      removeMCPServerStatus('racy-server');
+
+      // Now let the rejected connect propagate.
+      await expect(connectPromise).rejects.toThrow('connect failed');
+
+      // The entry must remain absent — no resurrection.
+      expect(getAllMCPServerStatuses().has('racy-server')).toBe(false);
+    });
   });
 
   describe('hasNetworkTransport', () => {

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -15,11 +15,18 @@ import { GoogleCredentialProvider } from '../mcp/google-auth-provider.js';
 import type { PromptRegistry } from '../prompts/prompt-registry.js';
 import type { WorkspaceContext } from '../utils/workspaceContext.js';
 import {
+  addMCPStatusChangeListener,
   createTransport,
+  getAllMCPServerStatuses,
+  getMCPServerStatus,
   hasNetworkTransport,
   isEnabled,
+  MCPServerStatus,
   McpClient,
   populateMcpServerCommand,
+  removeMCPServerStatus,
+  removeMCPStatusChangeListener,
+  updateMCPServerStatus,
 } from './mcp-client.js';
 import type { ToolRegistry } from './tool-registry.js';
 
@@ -498,6 +505,55 @@ describe('mcp-client', () => {
       expect(isEnabled(namelessFuncDecl, serverName, mcpServerConfig)).toBe(
         false,
       );
+    });
+  });
+
+  describe('removeMCPServerStatus', () => {
+    afterEach(() => {
+      // Clean up any state left in the module-level registry between tests.
+      for (const name of getAllMCPServerStatuses().keys()) {
+        removeMCPServerStatus(name);
+      }
+    });
+
+    it('removes the entry from the global status map', () => {
+      updateMCPServerStatus('srv-a', MCPServerStatus.DISCONNECTED);
+      expect(getAllMCPServerStatuses().has('srv-a')).toBe(true);
+
+      removeMCPServerStatus('srv-a');
+
+      expect(getAllMCPServerStatuses().has('srv-a')).toBe(false);
+      // getMCPServerStatus falls back to DISCONNECTED for unknown servers,
+      // but the snapshot map should no longer include the entry.
+      expect(getMCPServerStatus('srv-a')).toBe(MCPServerStatus.DISCONNECTED);
+    });
+
+    it('notifies listeners with undefined to signal removal', () => {
+      const events: Array<[string, MCPServerStatus | undefined]> = [];
+      const listener = (name: string, status: MCPServerStatus | undefined) => {
+        events.push([name, status]);
+      };
+      addMCPStatusChangeListener(listener);
+
+      updateMCPServerStatus('srv-b', MCPServerStatus.CONNECTED);
+      removeMCPServerStatus('srv-b');
+
+      removeMCPStatusChangeListener(listener);
+
+      expect(events).toEqual([
+        ['srv-b', MCPServerStatus.CONNECTED],
+        ['srv-b', undefined],
+      ]);
+    });
+
+    it('is a no-op (no listener fired) when the server is not tracked', () => {
+      const listener = vi.fn();
+      addMCPStatusChangeListener(listener);
+
+      removeMCPServerStatus('never-registered');
+
+      removeMCPStatusChangeListener(listener);
+      expect(listener).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -266,11 +266,14 @@ let mcpDiscoveryState: MCPDiscoveryState = MCPDiscoveryState.NOT_STARTED;
 export const mcpServerRequiresOAuth: Map<string, boolean> = new Map();
 
 /**
- * Event listeners for MCP server status changes
+ * Event listeners for MCP server status changes.
+ * `status` is `undefined` when the server has been removed from the registry
+ * (e.g. disabled via `/mcp`), so consumers can drop it from their snapshots
+ * rather than continue to count it as `DISCONNECTED`.
  */
 type StatusChangeListener = (
   serverName: string,
-  status: MCPServerStatus,
+  status: MCPServerStatus | undefined,
 ) => void;
 const statusChangeListeners: StatusChangeListener[] = [];
 
@@ -306,6 +309,21 @@ export function updateMCPServerStatus(
   // Notify all listeners
   for (const listener of statusChangeListeners) {
     listener(serverName, status);
+  }
+}
+
+/**
+ * Remove an MCP server from the status registry and notify listeners.
+ * Used when a server is disabled or removed from configuration so it no
+ * longer shows up in the Footer's MCP health pill as offline.
+ */
+export function removeMCPServerStatus(serverName: string): void {
+  if (!serverStatuses.has(serverName)) {
+    return;
+  }
+  serverStatuses.delete(serverName);
+  for (const listener of statusChangeListeners) {
+    listener(serverName, undefined);
   }
 }
 

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -224,6 +224,14 @@ export class McpClient {
 
   private updateStatus(status: MCPServerStatus): void {
     this.status = status;
+    // Once disconnect has begun, don't propagate further status changes to
+    // the global registry. An in-flight `connect()` whose catch block fires
+    // after `disableMcpServer` has already removed the entry would otherwise
+    // silently resurrect the server and the Footer's MCP health pill would
+    // continue to count it as offline.
+    if (this.isDisconnecting) {
+      return;
+    }
     updateMCPServerStatus(this.serverName, status);
   }
 
@@ -306,8 +314,10 @@ export function updateMCPServerStatus(
   status: MCPServerStatus,
 ): void {
   serverStatuses.set(serverName, status);
-  // Notify all listeners
-  for (const listener of statusChangeListeners) {
+  // Snapshot the listener list so a listener that detaches itself (or
+  // attaches a new one) during dispatch doesn't mutate the array we're
+  // iterating.
+  for (const listener of [...statusChangeListeners]) {
     listener(serverName, status);
   }
 }
@@ -322,7 +332,7 @@ export function removeMCPServerStatus(serverName: string): void {
     return;
   }
   serverStatuses.delete(serverName);
-  for (const listener of statusChangeListeners) {
+  for (const listener of [...statusChangeListeners]) {
     listener(serverName, undefined);
   }
 }

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -544,6 +544,24 @@ describe('ToolRegistry', () => {
       }
     });
 
+    it('still removes the registry entry when disconnect throws', async () => {
+      updateMCPServerStatus('flaky-server', MCPServerStatus.DISCONNECTED);
+      vi.spyOn(config, 'getExcludedMcpServers').mockReturnValue([]);
+      vi.spyOn(config, 'setExcludedMcpServers').mockImplementation(() => {});
+      vi.spyOn(
+        McpClientManager.prototype,
+        'disconnectServer',
+      ).mockRejectedValue(new Error('boom'));
+
+      await expect(
+        toolRegistry.disableMcpServer('flaky-server'),
+      ).rejects.toThrow('boom');
+
+      // Even though disconnect threw, the global status entry must be cleared
+      // so the health pill stops counting the server.
+      expect(getAllMCPServerStatuses().has('flaky-server')).toBe(false);
+    });
+
     it('removes the server from the global status registry so the health pill stops counting it', async () => {
       // Simulate an MCP server that connected and then dropped — the global
       // registry would carry a DISCONNECTED entry for it.

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -18,6 +18,12 @@ import fs from 'node:fs';
 import { MockTool } from '../test-utils/mock-tool.js';
 
 import { McpClientManager } from './mcp-client-manager.js';
+import {
+  getAllMCPServerStatuses,
+  MCPServerStatus,
+  removeMCPServerStatus,
+  updateMCPServerStatus,
+} from './mcp-client.js';
 import { ToolErrorType } from './tool-error.js';
 
 vi.mock('node:fs');
@@ -528,6 +534,38 @@ describe('ToolRegistry', () => {
 
       // The good tool should still have been loaded despite the failure.
       expect(await toolRegistry.ensureTool('good-tool')).toBe(goodTool);
+    });
+  });
+
+  describe('disableMcpServer', () => {
+    afterEach(() => {
+      for (const name of getAllMCPServerStatuses().keys()) {
+        removeMCPServerStatus(name);
+      }
+    });
+
+    it('removes the server from the global status registry so the health pill stops counting it', async () => {
+      // Simulate an MCP server that connected and then dropped — the global
+      // registry would carry a DISCONNECTED entry for it.
+      updateMCPServerStatus('flaky-server', MCPServerStatus.DISCONNECTED);
+      expect(getAllMCPServerStatuses().has('flaky-server')).toBe(true);
+
+      const setExcludedSpy = vi
+        .spyOn(config, 'setExcludedMcpServers')
+        .mockImplementation(() => {});
+      vi.spyOn(config, 'getExcludedMcpServers').mockReturnValue([]);
+      // disableMcpServer delegates the actual transport teardown to the
+      // McpClientManager — stub it out so we can isolate the status-registry
+      // behavior.
+      vi.spyOn(
+        McpClientManager.prototype,
+        'disconnectServer',
+      ).mockResolvedValue(undefined);
+
+      await toolRegistry.disableMcpServer('flaky-server');
+
+      expect(getAllMCPServerStatuses().has('flaky-server')).toBe(false);
+      expect(setExcludedSpy).toHaveBeenCalledWith(['flaky-server']);
     });
   });
 

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -585,6 +585,36 @@ describe('ToolRegistry', () => {
       expect(getAllMCPServerStatuses().has('flaky-server')).toBe(false);
       expect(setExcludedSpy).toHaveBeenCalledWith(['flaky-server']);
     });
+
+    it('updates the exclusion list before dropping the status entry', async () => {
+      // Order matters: doctorChecks classifies a server as "disabled" only
+      // when it appears in the exclusion list. If the status entry is
+      // dropped before the exclusion list is updated, there's a window
+      // where the server is reported as a connectivity failure instead of
+      // an intentional disable.
+      updateMCPServerStatus('flaky-server', MCPServerStatus.DISCONNECTED);
+      vi.spyOn(config, 'getExcludedMcpServers').mockReturnValue([]);
+      vi.spyOn(
+        McpClientManager.prototype,
+        'disconnectServer',
+      ).mockResolvedValue(undefined);
+
+      const callOrder: string[] = [];
+      vi.spyOn(config, 'setExcludedMcpServers').mockImplementation(() => {
+        callOrder.push(
+          `setExcludedMcpServers:hasStatus=${getAllMCPServerStatuses().has(
+            'flaky-server',
+          )}`,
+        );
+      });
+
+      await toolRegistry.disableMcpServer('flaky-server');
+
+      // When setExcludedMcpServers ran, the status entry must still be
+      // present — i.e. the exclusion list is updated first.
+      expect(callOrder).toEqual(['setExcludedMcpServers:hasStatus=true']);
+      expect(getAllMCPServerStatuses().has('flaky-server')).toBe(false);
+    });
   });
 
   describe('stop', () => {

--- a/packages/core/src/tools/tool-registry.test.ts
+++ b/packages/core/src/tools/tool-registry.test.ts
@@ -544,10 +544,12 @@ describe('ToolRegistry', () => {
       }
     });
 
-    it('still removes the registry entry when disconnect throws', async () => {
+    it('still removes the registry entry and updates the exclusion list when disconnect throws', async () => {
       updateMCPServerStatus('flaky-server', MCPServerStatus.DISCONNECTED);
       vi.spyOn(config, 'getExcludedMcpServers').mockReturnValue([]);
-      vi.spyOn(config, 'setExcludedMcpServers').mockImplementation(() => {});
+      const setExcludedSpy = vi
+        .spyOn(config, 'setExcludedMcpServers')
+        .mockImplementation(() => {});
       vi.spyOn(
         McpClientManager.prototype,
         'disconnectServer',
@@ -558,7 +560,30 @@ describe('ToolRegistry', () => {
       ).rejects.toThrow('boom');
 
       // Even though disconnect threw, the global status entry must be cleared
-      // so the health pill stops counting the server.
+      // so the health pill stops counting the server, and the exclusion list
+      // must still be updated so the server doesn't reappear on next discovery.
+      expect(getAllMCPServerStatuses().has('flaky-server')).toBe(false);
+      expect(setExcludedSpy).toHaveBeenCalledWith(['flaky-server']);
+    });
+
+    it('still removes the registry entry when the exclusion-list update throws', async () => {
+      // Defensive: if a future config implementation makes setExcludedMcpServers
+      // throw, the status registry must still be cleaned up — otherwise the
+      // health pill would keep a stale entry forever.
+      updateMCPServerStatus('flaky-server', MCPServerStatus.DISCONNECTED);
+      vi.spyOn(config, 'getExcludedMcpServers').mockReturnValue([]);
+      vi.spyOn(config, 'setExcludedMcpServers').mockImplementation(() => {
+        throw new Error('config write failed');
+      });
+      vi.spyOn(
+        McpClientManager.prototype,
+        'disconnectServer',
+      ).mockResolvedValue(undefined);
+
+      await expect(
+        toolRegistry.disableMcpServer('flaky-server'),
+      ).rejects.toThrow('config write failed');
+
       expect(getAllMCPServerStatuses().has('flaky-server')).toBe(false);
     });
 

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -355,17 +355,22 @@ export class ToolRegistry {
       // Disconnect the MCP client
       await this.mcpClientManager.disconnectServer(serverName);
     } finally {
-      // Always drop the server from the global status registry — even if
-      // disconnect throws — so the Footer's MCP health pill stops counting
-      // it as "offline". Disabling is intentional, not a connectivity
-      // failure, and a leftover entry would resurrect the bug from #3895.
+      // Update the exclusion list before dropping the status entry, so a
+      // server is already marked as disabled by the time it disappears
+      // from the registry. Otherwise there's a (currently synchronous,
+      // but easy to widen) window where doctorChecks would observe a
+      // missing status (falling back to DISCONNECTED) while
+      // isMcpServerDisabled still returns false, mis-reporting an
+      // intentional disable as a connectivity failure.
+      const currentExcluded = this.config.getExcludedMcpServers() || [];
+      if (!currentExcluded.includes(serverName)) {
+        this.config.setExcludedMcpServers([...currentExcluded, serverName]);
+      }
+      // Then drop the server from the global status registry — even if
+      // disconnect throws — so the Footer's MCP health pill stops
+      // counting it as "offline". A leftover entry would resurrect the
+      // bug from #3895.
       removeMCPServerStatus(serverName);
-    }
-
-    // Update config's exclusion list
-    const currentExcluded = this.config.getExcludedMcpServers() || [];
-    if (!currentExcluded.includes(serverName)) {
-      this.config.setExcludedMcpServers([...currentExcluded, serverName]);
     }
   }
 

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -355,22 +355,25 @@ export class ToolRegistry {
       // Disconnect the MCP client
       await this.mcpClientManager.disconnectServer(serverName);
     } finally {
-      // Update the exclusion list before dropping the status entry, so a
-      // server is already marked as disabled by the time it disappears
-      // from the registry. Otherwise there's a (currently synchronous,
-      // but easy to widen) window where doctorChecks would observe a
-      // missing status (falling back to DISCONNECTED) while
-      // isMcpServerDisabled still returns false, mis-reporting an
-      // intentional disable as a connectivity failure.
-      const currentExcluded = this.config.getExcludedMcpServers() || [];
-      if (!currentExcluded.includes(serverName)) {
-        this.config.setExcludedMcpServers([...currentExcluded, serverName]);
+      try {
+        // Update the exclusion list before dropping the status entry,
+        // so a server is already marked as disabled by the time it
+        // disappears from the registry. Otherwise there's a (currently
+        // synchronous, but easy to widen) window where doctorChecks
+        // would observe a missing status (falling back to DISCONNECTED)
+        // while isMcpServerDisabled still returns false, mis-reporting
+        // an intentional disable as a connectivity failure.
+        const currentExcluded = this.config.getExcludedMcpServers() || [];
+        if (!currentExcluded.includes(serverName)) {
+          this.config.setExcludedMcpServers([...currentExcluded, serverName]);
+        }
+      } finally {
+        // Always drop the server from the global status registry — even
+        // if disconnect or the exclusion-list update throws — so the
+        // Footer's MCP health pill stops counting it as "offline". A
+        // leftover entry would resurrect the bug from #3895.
+        removeMCPServerStatus(serverName);
       }
-      // Then drop the server from the global status registry — even if
-      // disconnect throws — so the Footer's MCP health pill stops
-      // counting it as "offline". A leftover entry would resurrect the
-      // bug from #3895.
-      removeMCPServerStatus(serverName);
     }
   }
 

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -351,13 +351,16 @@ export class ToolRegistry {
     // Remove prompts
     this.config.getPromptRegistry().removePromptsByServer(serverName);
 
-    // Disconnect the MCP client
-    await this.mcpClientManager.disconnectServer(serverName);
-
-    // Drop the server from the global status registry so the Footer's
-    // MCP health pill doesn't keep counting it as "offline" — disabling
-    // is intentional, not a connectivity failure.
-    removeMCPServerStatus(serverName);
+    try {
+      // Disconnect the MCP client
+      await this.mcpClientManager.disconnectServer(serverName);
+    } finally {
+      // Always drop the server from the global status registry — even if
+      // disconnect throws — so the Footer's MCP health pill stops counting
+      // it as "offline". Disabling is intentional, not a connectivity
+      // failure, and a leftover entry would resurrect the bug from #3895.
+      removeMCPServerStatus(serverName);
+    }
 
     // Update config's exclusion list
     const currentExcluded = this.config.getExcludedMcpServers() || [];

--- a/packages/core/src/tools/tool-registry.ts
+++ b/packages/core/src/tools/tool-registry.ts
@@ -16,6 +16,7 @@ import type { Config } from '../config/config.js';
 import { spawn } from 'node:child_process';
 import { StringDecoder } from 'node:string_decoder';
 import type { SendSdkMcpMessage } from './mcp-client.js';
+import { removeMCPServerStatus } from './mcp-client.js';
 import { McpClientManager } from './mcp-client-manager.js';
 import { DiscoveredMCPTool } from './mcp-tool.js';
 import { parse } from 'shell-quote';
@@ -352,6 +353,11 @@ export class ToolRegistry {
 
     // Disconnect the MCP client
     await this.mcpClientManager.disconnectServer(serverName);
+
+    // Drop the server from the global status registry so the Footer's
+    // MCP health pill doesn't keep counting it as "offline" — disabling
+    // is intentional, not a connectivity failure.
+    removeMCPServerStatus(serverName);
 
     // Update config's exclusion list
     const currentExcluded = this.config.getExcludedMcpServers() || [];


### PR DESCRIPTION
## Summary

- Fixes #3895 — after disabling an MCP server via `/mcp`, the Footer's MCP health pill kept showing "1 MCP offline" because `serverStatuses` in `mcp-client.ts` only added entries, never removed them.
- Adds `removeMCPServerStatus(serverName)` and calls it from `ToolRegistry.disableMcpServer` so the server drops out of the health snapshot. `disconnectServer` (used for transient reconnects — OAuth, health-check retries) keeps the entry as before.
- `useMCPHealth` listener now treats an `undefined` status as a removal signal and deletes the local entry.

## Test plan

- [x] `vitest run` for `packages/core/src/tools/mcp-client.test.ts` — added 3 cases for `removeMCPServerStatus` (removes from map, notifies listeners with `undefined`, no-op when untracked).
- [x] `vitest run` for `packages/core/src/tools/tool-registry.test.ts` — added a case verifying `disableMcpServer` clears the registry entry and updates the exclusion list.
- [x] `vitest run` for `packages/cli/src/ui/components/mcp/MCPHealthPill.test.tsx` and `packages/core/src/tools/mcp-client-manager.test.ts` — no regressions.
- [x] ESLint clean on all touched files.
- [x] Manual repro: configure an MCP server, drop it externally so pill shows "1 MCP offline", `/mcp` disable → pill clears.