### PR TITLE
ci(issue-followup-bot): render bot comment newlines correctly

### DIFF
--- a/.github/workflows/qwen-issue-followup-bot.yml
+++ b/.github/workflows/qwen-issue-followup-bot.yml
@@ -232,7 +232,26 @@ jobs:
               require_write_enabled "$@"
               validate_issue_comment_args "$@"
               reject_if_arg_contains_secret "$@"
-              exec "${real_gh}" "$@"
+              # Some models emit a literal `\n` (backslash + n) inside the
+              # --body argument; bash double-quoted strings do not interpret
+              # it, so the rendered comment collapses onto one line. Rewrite
+              # the body just before exec so multi-paragraph follow-ups
+              # render correctly on GitHub.
+              normalized_args=()
+              expect_body=0
+              for arg in "$@"; do
+                if (( expect_body )); then
+                  arg="${arg//\\n/$'\n'}"
+                  expect_body=0
+                elif [[ "${arg}" == '--body' ]]; then
+                  expect_body=1
+                elif [[ "${arg}" == --body=* ]]; then
+                  arg="--body=${arg#--body=}"
+                  arg="${arg//\\n/$'\n'}"
+                fi
+                normalized_args+=("${arg}")
+              done
+              exec "${real_gh}" "${normalized_args[@]}"
               ;;
             'issue edit')
               require_write_enabled "$@"
@@ -408,6 +427,15 @@ jobs:
             - Use `gh issue comment <number> --repo "${{ github.repository }}" --body "..."`
               to create comments. The runner blocks comment editing, comment
               deletion, body files, and comments containing known secret values.
+            - The `--body` value must contain real newline characters between
+              paragraphs and list items. Bash double-quoted strings do not
+              interpret `\n`, so writing the literal two characters `\` and
+              `n` collapses the comment onto a single line on GitHub. Either
+              break the argument across multiple lines, for example
+              `--body "<!-- qwen-issue-bot:related -->`, then a blank line,
+              then `This appears related to ...`, then ``- #1234 - ...``,
+              all inside the same double-quoted argument; or use ANSI-C
+              quoting like `--body $'<!-- qwen-issue-bot:related -->\n\nThis appears ...\n\n- #1234 - ...'`.
             - Do not update existing comments through `gh api`; skip issues with
               an existing marker comment unless a human explicitly re-runs this
               workflow for that issue.


### PR DESCRIPTION
## Summary

- What changed: prompt + safe-gh shim hardening so the issue follow-up bot's marker comments preserve real newlines.
- Why it changed: the agent occasionally emits a literal `\n` (two characters: `\` + `n`) inside the `--body` argument. Bash double-quoted strings do not interpret that escape, so the literal sequence reaches GitHub and the comment collapses onto one line — see [comment on #3914](https://github.com/QwenLM/qwen-code/issues/3914#issuecomment-4396808119).
- Reviewer focus: (1) the new bullet under `Execution Guidance` in the prompt, (2) the body-normalization loop in the `'issue comment')` branch of the safe-gh shim, between `reject_if_arg_contains_secret` and `exec`.

## Validation

- Commands run:
  ```bash
  # 1. Reproduce the bad rendering on the production comment
  gh api repos/QwenLM/qwen-code/issues/comments/4396808119 --jq '.body' | od -c | head -3
  # → bytes 0x5c 0x6e ("\n") instead of 0x0a (real newline)

  # 2. Apply the same normalization the shim now applies
  body='<!-- qwen-issue-bot:related -->\n\nThis appears related.\n\n- #2787 - ...\n- #3050 - ...'
  printf '%s' "${body//\\n/$'\n'}" | od -c | head -4
  # → real newlines between paragraphs and list items

  # 3. YAML still parses
  python3 -c "import yaml; yaml.safe_load(open('.github/workflows/qwen-issue-followup-bot.yml'))"
  ```
- Expected result: literal `\n` inside `--body` is converted to a real newline before `exec`, for both `--body "..."` and `--body=...` forms.
- Observed result: matches expected; non-`--body` arguments pass through untouched.
- Quickest reviewer verification path: read the diff, then run the local bash snippet above against any string containing `\n`.
- Evidence: byte dumps above; the comment on #3914 is the production artifact this PR targets.

## Scope / Risk

- Main risk or tradeoff: the shim now rewrites literal `\n` inside `--body` unconditionally. This is intentional — the bot only posts templated marker comments and never needs to embed a literal `\n` token in published prose. If a future use case ever needs to keep a literal `\n` (e.g., quoting source code), it can be wrapped in a fenced code block where GitHub already preserves the original bytes.
- Not covered / not validated: no end-to-end run against the real Qwen Code action — the workflow only fires on issue events / schedule / dispatch in CI. The shim change is exercised by the local bash simulation above.
- Breaking changes / migration notes: none. Comments that already contained real newlines are unaffected (the substitution targets the two-character sequence `\n`, not real newlines).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | N/A | N/A | N/A |
| npx      | N/A | N/A | N/A |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- This PR only changes `.github/workflows/qwen-issue-followup-bot.yml`. The workflow runs on `ubuntu-latest`; there is no platform matrix to exercise.

## Linked Issues / Bugs

- Symptom in production: https://github.com/QwenLM/qwen-code/issues/3914#issuecomment-4396808119 (comment artifact, not the underlying connection-error issue itself).