### PR TITLE
fix(cli,core): live-phase panel-ownership filter + post-delete statusChange emit

### DIFF
--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -656,6 +656,94 @@ describe('<ToolGroupMessage />', () => {
       expect(lastFrame() ?? '').not.toContain('MockSubagent[task-completed]');
     });
 
+    it('live phase (non-compact): running subagent tool entry is hidden — panel owns the row', () => {
+      // Without this filter the user sees the same subagent twice —
+      // once as the parent tool group's `task` row, once as the
+      // `LiveAgentPanel` row beneath the composer. Hide the inline
+      // entry while `isPending=true` so the panel is the single
+      // source of truth for in-flight subagents.
+      const { lastFrame } = renderWithProviders(
+        <ToolGroupMessage
+          {...baseProps}
+          toolCalls={[subagentCall('running')]}
+          isPending={true}
+        />,
+      );
+      // Pure-subagent group with everything panel-owned → entire
+      // group is hidden so an empty bordered container doesn't
+      // float above the panel.
+      expect(lastFrame() ?? '').toBe('');
+    });
+
+    it('live phase (non-compact): mixed group still renders sibling tools', () => {
+      // Only the subagent entry is hidden in live phase — sibling
+      // tools (Read / Edit / Bash) keep rendering normally so the
+      // parent's tool stream stays continuous.
+      const sibling = createToolCall({
+        callId: 'read-1',
+        name: 'read_file',
+        description: 'read config.yaml',
+        status: ToolCallStatus.Success,
+      });
+      const { lastFrame } = renderWithProviders(
+        <ToolGroupMessage
+          {...baseProps}
+          toolCalls={[subagentCall('running'), sibling]}
+          isPending={true}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      // Sibling shown.
+      expect(frame).toContain('read_file');
+      // Subagent hidden — panel owns the live row.
+      expect(frame).not.toContain('MockSubagent[task-running]');
+    });
+
+    it('live phase (non-compact): subagent with pending approval still renders', () => {
+      // The focus-routed approval banner / queued marker is the
+      // only inline surface that lets users answer the prompt
+      // without opening the dialog, so the entry must NOT be
+      // hidden when the subagent is awaiting confirmation.
+      const pending = createToolCall({
+        callId: 'task-pending',
+        name: 'task',
+        description: 'Delegate task to subagent',
+        status: ToolCallStatus.Executing,
+        resultDisplay: {
+          type: 'task_execution',
+          subagentName: 'researcher',
+          taskDescription: 'investigate the change',
+          taskPrompt: 'investigate',
+          status: 'running',
+          pendingConfirmation: { type: 'info', title: 't', prompt: 'p' },
+        } as AgentResultDisplay,
+      });
+      const { lastFrame } = renderWithProviders(
+        <ToolGroupMessage
+          {...baseProps}
+          toolCalls={[pending]}
+          isPending={true}
+        />,
+      );
+      // Subagent entry rendered (banner / marker fires inside
+      // ToolMessage); panel sits below as ambient progress.
+      expect(lastFrame() ?? '').toContain('MockSubagent[task-pending]');
+    });
+
+    it('committed phase (non-compact): subagent tool entry comes back for the audit trail', () => {
+      // Once the parent turn commits the panel evicts the row and
+      // the inline entry returns so SubagentScrollbackSummary lands
+      // inside the parent's tool group as a permanent record.
+      const { lastFrame } = renderWithProviders(
+        <ToolGroupMessage
+          {...baseProps}
+          toolCalls={[subagentCall('completed')]}
+          isPending={false}
+        />,
+      );
+      expect(lastFrame() ?? '').toContain('MockSubagent[task-completed]');
+    });
+
     it('compact mode: committed group with failed subagent forces expand', () => {
       // Same as the completed case — the scrollback summary needs to
       // land for failed / cancelled foreground subagents too so the

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -647,11 +647,18 @@ describe('<ToolGroupMessage />', () => {
       expect(lastFrame() ?? '').not.toContain('MockSubagent[task-running]');
     });
 
-    it('compact mode: live group with completed subagent stays compact', () => {
-      // The subagent terminated mid-turn but the parent is still
-      // running. Panel shows the synthesized / terminal row; the
-      // group should NOT yet expand to render the scrollback summary
-      // (that happens when the parent commits, isPending=false).
+    it('compact mode: live group with completed subagent force-expands so the summary bridges the panel-snapshot drop', () => {
+      // The subagent terminated mid-turn while the parent is still
+      // running. After #3921 swapped the order in
+      // `unregisterForeground` (delete-then-emit), the panel snapshot
+      // has already evicted the row by the time we render — so if the
+      // group stayed compact, the user would see NOTHING for the run
+      // until the parent commits. Force-expand here so
+      // `SubagentScrollbackSummary` lands inline immediately and
+      // bridges the gap. Mirrors `SubagentExecutionRenderer`'s
+      // ungated terminal-summary path and
+      // `mergeCompactToolGroups.isForceExpandGroup`'s no-isPending-gate
+      // committed-history rule.
       const { lastFrame } = renderCompact(
         <ToolGroupMessage
           {...baseProps}
@@ -659,7 +666,7 @@ describe('<ToolGroupMessage />', () => {
           isPending={true}
         />,
       );
-      expect(lastFrame() ?? '').not.toContain('MockSubagent[task-completed]');
+      expect(lastFrame() ?? '').toContain('MockSubagent[task-completed]');
     });
 
     it('live phase (non-compact): running subagent tool entry is hidden — panel owns the row', () => {
@@ -802,6 +809,33 @@ describe('<ToolGroupMessage />', () => {
         />,
       );
       expect(lastFrame() ?? '').toContain('MockSubagent[task-failed]');
+    });
+
+    it('compact mode: live mixed group with terminal subagent + sibling force-expands and renders both', () => {
+      // Terminal subagent (drops from the panel snapshot the moment
+      // it finishes) + sibling tool, in live + compact. The group
+      // must force-expand so `SubagentScrollbackSummary` lands inline
+      // for the subagent, while the sibling continues to render
+      // through the normal ToolMessage path. Without this, the
+      // sibling alone would have appeared in `CompactToolGroupDisplay`
+      // and the subagent's outcome would have stayed invisible until
+      // parent commit.
+      const sibling = createToolCall({
+        callId: 'edit-1',
+        name: 'edit_file',
+        description: 'apply diff to handler.ts',
+        status: ToolCallStatus.Success,
+      });
+      const { lastFrame } = renderCompact(
+        <ToolGroupMessage
+          {...baseProps}
+          toolCalls={[subagentCall('completed'), sibling]}
+          isPending={true}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('MockSubagent[task-completed]');
+      expect(frame).toContain('MockTool[edit-1]');
     });
 
     it('compact mode: live mixed group filters panel-owned subagent out of count + active tool', () => {

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -30,6 +30,7 @@ vi.mock('./ToolMessage.js', () => ({
     emphasis,
     resultDisplay,
     isFocused,
+    forceShowResult,
   }: {
     callId: string;
     name: string;
@@ -38,6 +39,7 @@ vi.mock('./ToolMessage.js', () => ({
     emphasis: string;
     resultDisplay?: unknown;
     isFocused?: boolean;
+    forceShowResult?: boolean;
   }) {
     // Use the same constants as the real component
     const statusSymbolMap: Record<ToolCallStatus, string> = {
@@ -54,9 +56,13 @@ vi.mock('./ToolMessage.js', () => ({
       typeof resultDisplay === 'object' &&
       (resultDisplay as { type?: string }).type === 'task_execution'
     ) {
+      // `forceShowResult` is the gate that lets `SubagentScrollbackSummary`
+      // render in compact mode — surfaced in the mock so tests can
+      // assert it was passed for terminal subagent tools.
       return (
         <Text>
-          MockSubagent[{callId}]: focused={String(isFocused)}
+          MockSubagent[{callId}]: focused={String(isFocused)} force=
+          {String(Boolean(forceShowResult))}
         </Text>
       );
     }
@@ -730,6 +736,27 @@ describe('<ToolGroupMessage />', () => {
       expect(lastFrame() ?? '').toContain('MockSubagent[task-pending]');
     });
 
+    it('live phase (non-compact): TERMINAL subagent renders inline (panel snapshot already dropped)', () => {
+      // Post-#3921 swap-order, `unregisterForeground` removes the
+      // foreground entry from the panel snapshot the moment the
+      // subagent finishes. If the inline path also stayed hidden in
+      // the live phase, the user would see nothing for the run
+      // until the parent commits — `SubagentScrollbackSummary` has
+      // to bridge that gap. Live-phase hide applies only to
+      // running / paused / background entries.
+      const { lastFrame } = renderWithProviders(
+        <ToolGroupMessage
+          {...baseProps}
+          toolCalls={[subagentCall('completed')]}
+          isPending={true}
+        />,
+      );
+      // Terminal entry rendered → MockSubagent sentinel from the
+      // ToolMessage mock; if the entry were still hidden the frame
+      // would be empty.
+      expect(lastFrame() ?? '').toContain('MockSubagent[task-completed]');
+    });
+
     it('committed phase (non-compact): subagent tool entry comes back for the audit trail', () => {
       // Once the parent turn commits the panel evicts the row and
       // the inline entry returns so SubagentScrollbackSummary lands
@@ -742,6 +769,25 @@ describe('<ToolGroupMessage />', () => {
         />,
       );
       expect(lastFrame() ?? '').toContain('MockSubagent[task-completed]');
+    });
+
+    it('terminal subagent tool receives forceShowResult so the summary renders in compact mode', () => {
+      // Force-expanding the group is necessary but not sufficient —
+      // `ToolMessage`'s own compact-mode gate
+      // (`!compactMode || forceShowResult`) would otherwise drop the
+      // result block, so the inner SubagentScrollbackSummary never
+      // gets a chance to render. ToolGroupMessage must propagate
+      // `forceShowResult=true` for terminal subagent tools.
+      const { lastFrame } = renderCompact(
+        <ToolGroupMessage
+          {...baseProps}
+          toolCalls={[subagentCall('completed')]}
+          isPending={false}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      expect(frame).toContain('MockSubagent[task-completed]');
+      expect(frame).toContain('force=true');
     });
 
     it('compact mode: committed group with failed subagent forces expand', () => {

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -18,6 +18,7 @@ import type {
 } from '@qwen-code/qwen-code-core';
 import { TOOL_STATUS } from '../../constants.js';
 import { ConfigContext } from '../../contexts/ConfigContext.js';
+import { CompactModeProvider } from '../../contexts/CompactModeContext.js';
 
 // Mock child components to isolate ToolGroupMessage behavior
 vi.mock('./ToolMessage.js', () => ({
@@ -564,6 +565,109 @@ describe('<ToolGroupMessage />', () => {
       );
       // Should only show confirmation for the first tool
       expect(lastFrame()).toMatchSnapshot();
+    });
+  });
+
+  describe('Compact mode + terminal subagent expansion', () => {
+    // Helper that wraps the group with `compactMode: true` so the
+    // `showCompact` branch is exercised. Verifies the safety net that
+    // forces the group to expand when it carries a committed terminal
+    // subagent — without it, `CompactToolGroupDisplay` would skip the
+    // ToolMessage path and `SubagentScrollbackSummary` would never
+    // surface in scrollback. The committed-summary handoff promised
+    // by the LiveAgentPanel design depends on this.
+    const renderCompact = (component: React.ReactElement, compactMode = true) =>
+      render(
+        <ConfigContext.Provider value={mockConfig}>
+          <CompactModeProvider value={{ compactMode }}>
+            {component}
+          </CompactModeProvider>
+        </ConfigContext.Provider>,
+      );
+
+    const subagentCall = (
+      status: 'running' | 'completed' | 'failed' | 'cancelled',
+    ): IndividualToolCallDisplay =>
+      createToolCall({
+        callId: `task-${status}`,
+        name: 'task',
+        description: 'Delegate task to subagent',
+        status:
+          status === 'running'
+            ? ToolCallStatus.Executing
+            : status === 'completed'
+              ? ToolCallStatus.Success
+              : ToolCallStatus.Error,
+        resultDisplay: {
+          type: 'task_execution',
+          subagentName: 'researcher',
+          taskDescription: 'investigate the change',
+          taskPrompt: 'investigate',
+          status,
+        } as AgentResultDisplay,
+      });
+
+    it('compact mode: committed group with completed subagent forces expand', () => {
+      // isPending=false (committed) + completed subagent → expand,
+      // routing through ToolMessage so the scrollback summary lands
+      // in the persistent record.
+      const { lastFrame } = renderCompact(
+        <ToolGroupMessage
+          {...baseProps}
+          toolCalls={[subagentCall('completed')]}
+          isPending={false}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      // The MockToolMessage's `MockSubagent[task-completed]` sentinel
+      // proves we routed through the expanded path; absence would
+      // mean CompactToolGroupDisplay swallowed the call.
+      expect(frame).toContain('MockSubagent[task-completed]');
+    });
+
+    it('compact mode: live group with running subagent stays compact', () => {
+      // isPending=true (live) → panel below the composer owns the
+      // row; staying compact keeps scrollback quiet until the parent
+      // turn commits.
+      const { lastFrame } = renderCompact(
+        <ToolGroupMessage
+          {...baseProps}
+          toolCalls={[subagentCall('running')]}
+          isPending={true}
+        />,
+      );
+      // Compact path renders the group header / count, NOT the
+      // expanded MockToolMessage sentinel.
+      expect(lastFrame() ?? '').not.toContain('MockSubagent[task-running]');
+    });
+
+    it('compact mode: live group with completed subagent stays compact', () => {
+      // The subagent terminated mid-turn but the parent is still
+      // running. Panel shows the synthesized / terminal row; the
+      // group should NOT yet expand to render the scrollback summary
+      // (that happens when the parent commits, isPending=false).
+      const { lastFrame } = renderCompact(
+        <ToolGroupMessage
+          {...baseProps}
+          toolCalls={[subagentCall('completed')]}
+          isPending={true}
+        />,
+      );
+      expect(lastFrame() ?? '').not.toContain('MockSubagent[task-completed]');
+    });
+
+    it('compact mode: committed group with failed subagent forces expand', () => {
+      // Same as the completed case — the scrollback summary needs to
+      // land for failed / cancelled foreground subagents too so the
+      // user has a permanent record of the run's outcome.
+      const { lastFrame } = renderCompact(
+        <ToolGroupMessage
+          {...baseProps}
+          toolCalls={[subagentCall('failed')]}
+          isPending={false}
+        />,
+      );
+      expect(lastFrame() ?? '').toContain('MockSubagent[task-failed]');
     });
   });
 });

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -803,5 +803,41 @@ describe('<ToolGroupMessage />', () => {
       );
       expect(lastFrame() ?? '').toContain('MockSubagent[task-failed]');
     });
+
+    it('compact mode: live mixed group filters panel-owned subagent out of count + active tool', () => {
+      // Regression: in compact mode, the per-tool live-phase filter
+      // used to live inside the expanded `.map()`, which `showCompact`
+      // returned BEFORE. So a mixed live group (running subagent +
+      // sibling tool) sent the unfiltered list to
+      // `CompactToolGroupDisplay`, where the running subagent could
+      // (a) inflate the count to N (`× N` suffix), and (b) win
+      // `getActiveTool` (Executing beats sibling's Success / Pending),
+      // overriding the header with the subagent's name. The fix
+      // derives `inlineToolCalls` ONCE before any compact decision so
+      // both the count and the active-tool selection see only what
+      // will actually render inline.
+      const sibling = createToolCall({
+        callId: 'read-1',
+        name: 'read_file',
+        description: 'read config.yaml',
+        status: ToolCallStatus.Success,
+      });
+      const { lastFrame } = renderCompact(
+        <ToolGroupMessage
+          {...baseProps}
+          toolCalls={[subagentCall('running'), sibling]}
+          isPending={true}
+        />,
+      );
+      const frame = lastFrame() ?? '';
+      // Sibling is the only inline survivor → wins active-tool, count
+      // collapses to 1 (no `× N` suffix).
+      expect(frame).toContain('read_file');
+      expect(frame).not.toMatch(/× 2/);
+      // Sibling description should appear; subagent description
+      // should not.
+      expect(frame).toContain('read config.yaml');
+      expect(frame).not.toContain('Delegate task to subagent');
+    });
   });
 });

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -44,13 +44,7 @@ function isRunningAgent(
 
 /**
  * Predicate: tool entry whose `resultDisplay` is an `AgentResultDisplay`
- * (i.e. a `task_execution` subagent invocation). Used by the group
- * body to:
- *   - hide such entries during the live phase (LiveAgentPanel owns
- *     the row, so leaving them inline duplicates the display)
- *   - force-expand a committed compact group containing one with a
- *     terminal status, so SubagentScrollbackSummary lands in the
- *     persistent record
+ * (i.e. a `task_execution` subagent invocation), regardless of status.
  */
 function isSubagentToolEntry(tool: IndividualToolCallDisplay): boolean {
   const rd = tool.resultDisplay;
@@ -59,6 +53,36 @@ function isSubagentToolEntry(tool: IndividualToolCallDisplay): boolean {
     rd !== null &&
     'type' in rd &&
     (rd as AgentResultDisplay).type === 'task_execution'
+  );
+}
+
+/**
+ * Predicate: subagent tool entry whose live UI is owned by
+ * `LiveAgentPanel`. Only running / paused / background entries
+ * should be hidden during the live phase — terminal entries (the
+ * subagent already finished while the parent turn is still
+ * running) are NOT panel-owned: the panel snapshot drops them on
+ * `unregisterForeground`'s post-delete emit, so the inline path
+ * needs to render `SubagentScrollbackSummary` immediately so the
+ * user keeps a record of the run instead of seeing nothing.
+ */
+function isPanelOwnedSubagentTool(tool: IndividualToolCallDisplay): boolean {
+  if (!isSubagentToolEntry(tool)) return false;
+  const status = (tool.resultDisplay as AgentResultDisplay).status;
+  return status === 'running' || status === 'paused' || status === 'background';
+}
+
+/**
+ * Predicate: tool entry whose subagent has reached a terminal state
+ * (`completed` / `failed` / `cancelled`). Used to force-expand the
+ * group + force the inner ToolMessage to render its result block in
+ * compact mode, so `SubagentScrollbackSummary` actually lands.
+ */
+function isTerminalSubagentTool(tool: IndividualToolCallDisplay): boolean {
+  if (!isSubagentToolEntry(tool)) return false;
+  const status = (tool.resultDisplay as AgentResultDisplay).status;
+  return (
+    status === 'completed' || status === 'failed' || status === 'cancelled'
   );
 }
 
@@ -207,17 +231,21 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
     focusedSubagentCallId ?? runningSubagentCallId;
 
   // Decide whether the entire group is panel-owned during the live
-  // phase: a pure-task_execution batch with no pending approval has
-  // nothing inline left to render once the subagent rows themselves
-  // are filtered out (LiveAgentPanel handles them). Hide the whole
-  // group so the bordered container / compact summary line don't
-  // float above the panel as a duplicate.
+  // phase: a pure-running-subagent batch with no pending approval
+  // has nothing inline left to render once the subagent rows
+  // themselves are filtered out (LiveAgentPanel handles them).
+  // Hide the whole group so the bordered container / compact
+  // summary line don't float above the panel as a duplicate.
+  // Terminal subagents (completed / failed / cancelled) are NOT
+  // panel-owned — `unregisterForeground`'s post-delete emit drops
+  // them from the panel snapshot, so the inline path must render
+  // their `SubagentScrollbackSummary` instead.
   const allEntriesPanelOwned =
     isPending &&
     toolCalls.length > 0 &&
     toolCalls.every(
       (tool) =>
-        isSubagentToolEntry(tool) &&
+        isPanelOwnedSubagentTool(tool) &&
         !isAgentWithPendingConfirmation(tool.resultDisplay),
     );
   if (allEntriesPanelOwned) {
@@ -236,14 +264,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   // because the panel below the composer is still showing the row.
   const hasSubagentPendingConfirmation = subagentsAwaitingApproval.length > 0;
   const hasCommittedTerminalSubagent =
-    !isPending &&
-    toolCalls.some(
-      (t) =>
-        isSubagentToolEntry(t) &&
-        ((t.resultDisplay as AgentResultDisplay).status === 'completed' ||
-          (t.resultDisplay as AgentResultDisplay).status === 'failed' ||
-          (t.resultDisplay as AgentResultDisplay).status === 'cancelled'),
-    );
+    !isPending && toolCalls.some(isTerminalSubagentTool);
   const showCompact =
     compactMode &&
     !hasConfirmingTool &&
@@ -366,17 +387,19 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
           );
         })()}
       {toolCalls.map((tool) => {
-        // Live phase: hide subagent (`task_execution`) tool entries
-        // unless the subagent is awaiting user approval. The inline
-        // banner / queued marker is the only way the user can answer
-        // the approval prompt without opening the dialog, so those
-        // entries always render. Other subagent entries are hidden
-        // because LiveAgentPanel below the composer paints them; the
-        // entry returns once the parent turn commits and carries the
-        // SubagentScrollbackSummary as the persistent audit trail.
+        // Live phase: hide ONLY panel-owned subagent entries (running /
+        // paused / background) so LiveAgentPanel below the composer
+        // is the single source of truth for in-flight subagents.
+        // Terminal subagents (completed / failed / cancelled) ARE
+        // rendered inline immediately so `SubagentScrollbackSummary`
+        // lands the moment the subagent finishes — `unregisterForeground`
+        // already dropped the panel row, leaving inline as the only
+        // place the user can see the run's outcome until commit.
+        // Pending-approval entries also pass through so the inline
+        // banner / queued marker can answer the prompt.
         if (
           isPending &&
-          isSubagentToolEntry(tool) &&
+          isPanelOwnedSubagentTool(tool) &&
           !isAgentWithPendingConfirmation(tool.resultDisplay)
         ) {
           return null;
@@ -415,7 +438,15 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
                   isUserInitiated ||
                   tool.status === ToolCallStatus.Confirming ||
                   tool.status === ToolCallStatus.Error ||
-                  isAgentWithPendingConfirmation(tool.resultDisplay)
+                  isAgentWithPendingConfirmation(tool.resultDisplay) ||
+                  // Terminal subagents need their result block to render
+                  // even in compact mode — that's where
+                  // `SubagentScrollbackSummary` lands. ToolMessage's
+                  // compact-mode gate
+                  // (`!compactMode || forceShowResult ? renderer : 'none'`)
+                  // would otherwise drop the result block, leaving the
+                  // committed audit trail empty for compact-mode users.
+                  isTerminalSubagentTool(tool)
                 }
                 isFocused={isSubagentFocused}
                 isPending={isPending}

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -51,9 +51,14 @@ interface ToolGroupMessageProps {
   /**
    * True when this tool group is being rendered live (in
    * `pendingHistoryItems`). False once it commits to Ink's `<Static>`.
-   * Currently consumed by upstream callers but not by the group body
-   * itself — the subagent renderer used to gate its live frame on
-   * this; that gating moved to LiveAgentPanel + BackgroundTasksDialog.
+   *
+   * Read by the group body to (1) force-expand a compact group when
+   * it has just committed AND carries a terminal subagent, so
+   * `SubagentScrollbackSummary` lands in the persistent record, and
+   * (2) forward to `ToolMessage` so the same renderer can decide
+   * whether to emit the inline summary or stay panel-only. Live
+   * progress / drill-down for running subagents themselves still
+   * happens via `LiveAgentPanel` + `BackgroundTasksDialog`.
    */
   isPending?: boolean;
   activeShellPtyId?: number | null;

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -58,18 +58,23 @@ function isSubagentToolEntry(tool: IndividualToolCallDisplay): boolean {
 
 /**
  * Predicate: subagent tool entry whose live UI is owned by
- * `LiveAgentPanel`. Only running / paused / background entries
- * should be hidden during the live phase — terminal entries (the
- * subagent already finished while the parent turn is still
- * running) are NOT panel-owned: the panel snapshot drops them on
+ * `LiveAgentPanel`. Only running / background entries should be
+ * hidden during the live phase — terminal entries (the subagent
+ * already finished while the parent turn is still running) are NOT
+ * panel-owned: the panel snapshot drops them on
  * `unregisterForeground`'s post-delete emit, so the inline path
  * needs to render `SubagentScrollbackSummary` immediately so the
  * user keeps a record of the run instead of seeing nothing.
+ *
+ * Note: `AgentResultDisplay.status` does NOT carry `'paused'` — that
+ * status lives on the registry-side `BackgroundTaskStatus` and is
+ * surfaced through the panel directly, never through a tool-result
+ * `task_execution` payload. So this predicate has no `paused` arm.
  */
 function isPanelOwnedSubagentTool(tool: IndividualToolCallDisplay): boolean {
   if (!isSubagentToolEntry(tool)) return false;
   const status = (tool.resultDisplay as AgentResultDisplay).status;
-  return status === 'running' || status === 'paused' || status === 'background';
+  return status === 'running' || status === 'background';
 }
 
 /**

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -78,10 +78,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   availableTerminalHeight,
   contentWidth,
   isFocused = true,
-  // `isPending` stays on the props interface for upstream compat
-  // (HistoryItemDisplay et al. forward it) but the group body no
-  // longer reads it. Skip the destructure so TS catches accidental
-  // re-introductions of dead state.
+  isPending = false,
   activeShellPtyId,
   embeddedShellFocused,
   memoryWriteCount,
@@ -327,6 +324,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
                   isAgentWithPendingConfirmation(tool.resultDisplay)
                 }
                 isFocused={isSubagentFocused}
+                isPending={isPending}
               />
             </Box>
             {tool.status === ToolCallStatus.Confirming &&

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -164,15 +164,35 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
 
   // Compact mode: entire group → single line summary
   // Force-expand when: user must interact (Confirming or subagent pending
-  // confirmation), tool errored, shell is focused, or user-initiated
+  // confirmation), tool errored, shell is focused, or user-initiated.
+  // Also force-expand when this group has just committed and contains
+  // a terminal subagent — `CompactToolGroupDisplay` doesn't know about
+  // `task_execution` results, so the compact path would skip
+  // `SubagentScrollbackSummary` and the user would lose the persistent
+  // record promised by the LiveAgentPanel → committed-summary handoff.
+  // Stay compact while the parent turn is still live (`isPending`),
+  // because the panel below the composer is still showing the row.
   const hasSubagentPendingConfirmation = subagentsAwaitingApproval.length > 0;
+  const hasCommittedTerminalSubagent =
+    !isPending &&
+    toolCalls.some((t) => {
+      const display = t.resultDisplay;
+      if (!display || typeof display !== 'object') return false;
+      if (!('type' in display) || display.type !== 'task_execution')
+        return false;
+      const status = (display as { status?: string }).status;
+      return (
+        status === 'completed' || status === 'failed' || status === 'cancelled'
+      );
+    });
   const showCompact =
     compactMode &&
     !hasConfirmingTool &&
     !hasSubagentPendingConfirmation &&
     !hasErrorTool &&
     !isEmbeddedShellFocused &&
-    !isUserInitiated;
+    !isUserInitiated &&
+    !hasCommittedTerminalSubagent;
 
   if (showCompact) {
     return (

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -280,16 +280,22 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   // Compact mode: entire group → single line summary
   // Force-expand when: user must interact (Confirming or subagent pending
   // confirmation), tool errored, shell is focused, or user-initiated.
-  // Also force-expand when this group has just committed and contains
-  // a terminal subagent — `CompactToolGroupDisplay` doesn't know about
-  // `task_execution` results, so the compact path would skip
-  // `SubagentScrollbackSummary` and the user would lose the persistent
-  // record promised by the LiveAgentPanel → committed-summary handoff.
-  // Stay compact while the parent turn is still live (`isPending`),
-  // because the panel below the composer is still showing the row.
+  // Also force-expand when this group carries a terminal subagent —
+  // `CompactToolGroupDisplay` doesn't know about `task_execution`
+  // results, so the compact path would skip `SubagentScrollbackSummary`
+  // entirely. Applies in BOTH live and committed phases:
+  //   - committed phase: the summary is the persistent audit trail.
+  //   - live phase: `unregisterForeground`'s post-delete emit has
+  //     already evicted the panel snapshot row by the time a foreground
+  //     subagent reaches a terminal status, so the inline summary is
+  //     the only surface that carries the run's outcome until the
+  //     parent commits. Mirrors the renderer-side decision in
+  //     `SubagentExecutionRenderer` (terminal summary fires regardless
+  //     of `isPending`) and the preprocessor in
+  //     `mergeCompactToolGroups.isForceExpandGroup` (no `isPending`
+  //     gate either).
   const hasSubagentPendingConfirmation = subagentsAwaitingApproval.length > 0;
-  const hasCommittedTerminalSubagent =
-    !isPending && inlineToolCalls.some(isTerminalSubagentTool);
+  const hasTerminalSubagent = inlineToolCalls.some(isTerminalSubagentTool);
   const showCompact =
     compactMode &&
     !hasConfirmingTool &&
@@ -297,7 +303,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
     !hasErrorTool &&
     !isEmbeddedShellFocused &&
     !isUserInitiated &&
-    !hasCommittedTerminalSubagent;
+    !hasTerminalSubagent;
 
   if (showCompact) {
     return (

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -42,6 +42,23 @@ function isRunningAgent(
   );
 }
 
+/**
+ * Tool entry whose live (`isPending=true`) display would duplicate
+ * the LiveAgentPanel row. Used to hide the inline tool-group entry
+ * during the live phase so the panel is the single source of truth;
+ * once the parent turn commits (`isPending=false`) the entry returns,
+ * carrying the SubagentScrollbackSummary as its persistent record.
+ */
+function isLiveSubagentTool(tool: IndividualToolCallDisplay): boolean {
+  const rd = tool.resultDisplay;
+  return (
+    typeof rd === 'object' &&
+    rd !== null &&
+    'type' in rd &&
+    (rd as AgentResultDisplay).type === 'task_execution'
+  );
+}
+
 interface ToolGroupMessageProps {
   groupId: number;
   toolCalls: IndividualToolCallDisplay[];
@@ -209,6 +226,24 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
     );
   }
 
+  // Live phase: if every tool in the group is a panel-owned subagent
+  // call (no pending approval to gate on), skip the entire group
+  // container — otherwise the bordered Box would render empty under
+  // the panel. Once the parent turn commits the call sites stop
+  // passing `isPending=true` and the group reappears with the
+  // committed audit trail.
+  const allEntriesPanelOwned =
+    isPending &&
+    toolCalls.length > 0 &&
+    toolCalls.every(
+      (tool) =>
+        isLiveSubagentTool(tool) &&
+        !isAgentWithPendingConfirmation(tool.resultDisplay),
+    );
+  if (allEntriesPanelOwned) {
+    return null;
+  }
+
   // Full expanded view
   const hasPending = !toolCalls.every(
     (t) => t.status === ToolCallStatus.Success,
@@ -312,6 +347,26 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
           );
         })()}
       {toolCalls.map((tool) => {
+        // Live phase: hide subagent (`task_execution`) tool entries
+        // entirely so LiveAgentPanel below the composer is the single
+        // source of truth for in-flight subagents. Otherwise the
+        // user sees the same agent twice — once as the parent tool
+        // group's row, once as the panel row. Once the parent turn
+        // commits (`isPending=false`) the row reappears so the
+        // SubagentScrollbackSummary lands inside the parent's tool
+        // group and the audit trail stays intact.
+        //
+        // EXCEPT when the subagent has a pending approval: the
+        // ToolMessage path renders the focus-routed banner / queued
+        // marker, which is the only way the user can answer the
+        // prompt without opening the dialog.
+        if (
+          isPending &&
+          isLiveSubagentTool(tool) &&
+          !isAgentWithPendingConfirmation(tool.resultDisplay)
+        ) {
+          return null;
+        }
         const isConfirming = toolAwaitingApproval?.callId === tool.callId;
         // A subagent's inline approval prompt should only receive keyboard
         // focus when (1) there is no direct tool-level confirmation active

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -102,23 +102,27 @@ interface ToolGroupMessageProps {
    * `pendingHistoryItems`). False once it commits to Ink's `<Static>`.
    *
    * Read by the group body to:
-   *   1. Hide the entire group when every tool entry is a panel-owned
-   *      subagent (`task_execution` without pending approval) — the
-   *      LiveAgentPanel below the composer is the single source of
-   *      truth for in-flight subagents. Group reappears once the parent
-   *      turn commits with the SubagentScrollbackSummary as the
-   *      persistent audit trail.
+   *   1. Build `inlineToolCalls` — drop panel-owned subagent entries
+   *      (running / background `task_execution` without pending
+   *      approval) so LiveAgentPanel below the composer is the single
+   *      source of truth for in-flight subagents. Mixed groups still
+   *      render their non-subagent siblings; pure-panel-owned groups
+   *      collapse to nothing and the whole bordered container is
+   *      hidden. Terminal subagents (completed / failed / cancelled)
+   *      pass through because `unregisterForeground`'s post-delete
+   *      emit already drops them from the panel snapshot, and the
+   *      inline path must render `SubagentScrollbackSummary`
+   *      immediately so the user keeps a record of the run.
    *   2. Force-expand a compact group when committed AND carrying a
    *      terminal subagent, so `SubagentScrollbackSummary` actually
    *      lands in the persistent record (CompactToolGroupDisplay is
    *      otherwise unaware of `task_execution` results).
-   *   3. Filter individual subagent entries out of the inline list
-   *      during the live phase — same panel-ownership rule as #1, but
-   *      applies per-tool when the group is mixed (subagent + sibling
-   *      tools), so siblings keep rendering normally.
-   *   4. Forward to `ToolMessage` so the same renderer can decide
-   *      whether to emit the inline scrollback summary or stay
-   *      panel-only.
+   *   3. Forward to `ToolMessage` for parity with sibling renderers
+   *      and possible future gating; the prop is currently inert at
+   *      that layer (the live-phase filter at #1 already prevents
+   *      panel-owned entries from reaching the renderer, and the
+   *      terminal scrollback summary fires in BOTH live and committed
+   *      phases to bridge `unregisterForeground` → parent commit).
    */
   isPending?: boolean;
   activeShellPtyId?: number | null;
@@ -189,6 +193,26 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
     [toolCalls],
   );
 
+  // Live-phase panel-ownership filter applied ONCE so every downstream
+  // decision (compact summary, sizing, render map) sees the same list.
+  // Without this, mixed live groups (running subagent + sibling tool)
+  // could leak the panel-owned subagent into `CompactToolGroupDisplay`'s
+  // count / active-tool selection, reintroducing the duplicate UI the
+  // LiveAgentPanel hand-off was designed to prevent. Pending-approval
+  // subagents pass through (the inline banner / queued marker is the
+  // only surface that lets users answer the prompt).
+  const inlineToolCalls = useMemo(
+    () =>
+      isPending
+        ? toolCalls.filter(
+            (tool) =>
+              !isPanelOwnedSubagentTool(tool) ||
+              isAgentWithPendingConfirmation(tool.resultDisplay),
+          )
+        : toolCalls,
+    [isPending, toolCalls],
+  );
+
   // Determine which subagent tools currently have a pending confirmation.
   // Must be called unconditionally (Rules of Hooks) — before any early return.
   const subagentsAwaitingApproval = useMemo(
@@ -221,11 +245,11 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   // the fallback is now mostly inert; it stays here so a future
   // re-introduction of inline keyboard surfaces has a focus target.
   // Note: during the live phase running subagent entries are filtered
-  // out of the rendered map (`isPending && isSubagentToolEntry &&
-  // !pending`), so this id can point at a hidden tool. That's harmless
-  // — `isSubagentFocused` is only read inside the map iteration which
-  // already returned `null` for the hidden entry, so no focus prop
-  // ever reaches a missing DOM node.
+  // out of `inlineToolCalls` (LiveAgentPanel owns those rows), so this
+  // id can point at a tool that won't be rendered. That's harmless —
+  // `isSubagentFocused` is only consumed inside the `inlineToolCalls`
+  // map iteration; the hidden entry is never iterated, so no focus
+  // prop ever reaches a missing DOM node.
   const runningSubagentCallId = useMemo(
     () =>
       toolCalls.find((tc) => isRunningAgent(tc.resultDisplay))?.callId ?? null,
@@ -235,25 +259,21 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   const keyboardFocusedSubagentCallId =
     focusedSubagentCallId ?? runningSubagentCallId;
 
-  // Decide whether the entire group is panel-owned during the live
-  // phase: a pure-running-subagent batch with no pending approval
-  // has nothing inline left to render once the subagent rows
-  // themselves are filtered out (LiveAgentPanel handles them).
-  // Hide the whole group so the bordered container / compact
-  // summary line don't float above the panel as a duplicate.
-  // Terminal subagents (completed / failed / cancelled) are NOT
-  // panel-owned — `unregisterForeground`'s post-delete emit drops
-  // them from the panel snapshot, so the inline path must render
-  // their `SubagentScrollbackSummary` instead.
-  const allEntriesPanelOwned =
-    isPending &&
-    toolCalls.length > 0 &&
-    toolCalls.every(
-      (tool) =>
-        isPanelOwnedSubagentTool(tool) &&
-        !isAgentWithPendingConfirmation(tool.resultDisplay),
-    );
-  if (allEntriesPanelOwned) {
+  // Hide the entire group when the live-phase filter leaves nothing
+  // inline to render — i.e. a pure-running-subagent batch with no
+  // pending approval. LiveAgentPanel below the composer is the
+  // single source of truth for those rows; an empty bordered
+  // container floating above the panel would just be a duplicate
+  // chrome line. Terminal subagents (completed / failed / cancelled)
+  // pass through `inlineToolCalls` because `unregisterForeground`'s
+  // post-delete emit already dropped them from the panel snapshot,
+  // and the inline path must render `SubagentScrollbackSummary`
+  // immediately so the user keeps a record of the run.
+  // (Gate on `isPending` so a degenerate empty `toolCalls=[]` in the
+  // committed phase still falls through to the legacy empty-border
+  // snapshot — the suppression is specifically about live-phase
+  // panel ownership, not about hiding empty inputs in general.)
+  if (isPending && inlineToolCalls.length === 0) {
     return null;
   }
 
@@ -269,7 +289,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   // because the panel below the composer is still showing the row.
   const hasSubagentPendingConfirmation = subagentsAwaitingApproval.length > 0;
   const hasCommittedTerminalSubagent =
-    !isPending && toolCalls.some(isTerminalSubagentTool);
+    !isPending && inlineToolCalls.some(isTerminalSubagentTool);
   const showCompact =
     compactMode &&
     !hasConfirmingTool &&
@@ -282,7 +302,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   if (showCompact) {
     return (
       <CompactToolGroupDisplay
-        toolCalls={toolCalls}
+        toolCalls={inlineToolCalls}
         contentWidth={contentWidth}
         compactLabel={compactLabel}
       />
@@ -290,10 +310,10 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   }
 
   // Full expanded view
-  const hasPending = !toolCalls.every(
+  const hasPending = !inlineToolCalls.every(
     (t) => t.status === ToolCallStatus.Success,
   );
-  const isShellCommand = toolCalls.some(
+  const isShellCommand = inlineToolCalls.some(
     (t) => t.name === SHELL_COMMAND_NAME || t.name === SHELL_NAME,
   );
   const borderColor =
@@ -308,12 +328,13 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   const innerWidth = contentWidth - 4;
 
   let countToolCallsWithResults = 0;
-  for (const tool of toolCalls) {
+  for (const tool of inlineToolCalls) {
     if (tool.resultDisplay !== undefined && tool.resultDisplay !== '') {
       countToolCallsWithResults++;
     }
   }
-  const countOneLineToolCalls = toolCalls.length - countToolCallsWithResults;
+  const countOneLineToolCalls =
+    inlineToolCalls.length - countToolCallsWithResults;
   const availableTerminalHeightPerToolMessage = availableTerminalHeight
     ? Math.max(
         Math.floor(
@@ -391,24 +412,12 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
             </Box>
           );
         })()}
-      {toolCalls.map((tool) => {
-        // Live phase: hide ONLY panel-owned subagent entries (running /
-        // paused / background) so LiveAgentPanel below the composer
-        // is the single source of truth for in-flight subagents.
-        // Terminal subagents (completed / failed / cancelled) ARE
-        // rendered inline immediately so `SubagentScrollbackSummary`
-        // lands the moment the subagent finishes — `unregisterForeground`
-        // already dropped the panel row, leaving inline as the only
-        // place the user can see the run's outcome until commit.
-        // Pending-approval entries also pass through so the inline
-        // banner / queued marker can answer the prompt.
-        if (
-          isPending &&
-          isPanelOwnedSubagentTool(tool) &&
-          !isAgentWithPendingConfirmation(tool.resultDisplay)
-        ) {
-          return null;
-        }
+      {inlineToolCalls.map((tool) => {
+        // `inlineToolCalls` already excludes panel-owned subagent
+        // entries during the live phase (LiveAgentPanel owns those
+        // rows). Terminal subagents and pending-approval subagents
+        // pass through the filter and render inline so the
+        // scrollback summary / approval banner lands.
         const isConfirming = toolAwaitingApproval?.callId === tool.callId;
         // A subagent's inline approval prompt should only receive keyboard
         // focus when (1) there is no direct tool-level confirmation active

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -43,13 +43,16 @@ function isRunningAgent(
 }
 
 /**
- * Tool entry whose live (`isPending=true`) display would duplicate
- * the LiveAgentPanel row. Used to hide the inline tool-group entry
- * during the live phase so the panel is the single source of truth;
- * once the parent turn commits (`isPending=false`) the entry returns,
- * carrying the SubagentScrollbackSummary as its persistent record.
+ * Predicate: tool entry whose `resultDisplay` is an `AgentResultDisplay`
+ * (i.e. a `task_execution` subagent invocation). Used by the group
+ * body to:
+ *   - hide such entries during the live phase (LiveAgentPanel owns
+ *     the row, so leaving them inline duplicates the display)
+ *   - force-expand a committed compact group containing one with a
+ *     terminal status, so SubagentScrollbackSummary lands in the
+ *     persistent record
  */
-function isLiveSubagentTool(tool: IndividualToolCallDisplay): boolean {
+function isSubagentToolEntry(tool: IndividualToolCallDisplay): boolean {
   const rd = tool.resultDisplay;
   return (
     typeof rd === 'object' &&
@@ -69,13 +72,24 @@ interface ToolGroupMessageProps {
    * True when this tool group is being rendered live (in
    * `pendingHistoryItems`). False once it commits to Ink's `<Static>`.
    *
-   * Read by the group body to (1) force-expand a compact group when
-   * it has just committed AND carries a terminal subagent, so
-   * `SubagentScrollbackSummary` lands in the persistent record, and
-   * (2) forward to `ToolMessage` so the same renderer can decide
-   * whether to emit the inline summary or stay panel-only. Live
-   * progress / drill-down for running subagents themselves still
-   * happens via `LiveAgentPanel` + `BackgroundTasksDialog`.
+   * Read by the group body to:
+   *   1. Hide the entire group when every tool entry is a panel-owned
+   *      subagent (`task_execution` without pending approval) — the
+   *      LiveAgentPanel below the composer is the single source of
+   *      truth for in-flight subagents. Group reappears once the parent
+   *      turn commits with the SubagentScrollbackSummary as the
+   *      persistent audit trail.
+   *   2. Force-expand a compact group when committed AND carrying a
+   *      terminal subagent, so `SubagentScrollbackSummary` actually
+   *      lands in the persistent record (CompactToolGroupDisplay is
+   *      otherwise unaware of `task_execution` results).
+   *   3. Filter individual subagent entries out of the inline list
+   *      during the live phase — same panel-ownership rule as #1, but
+   *      applies per-tool when the group is mixed (subagent + sibling
+   *      tools), so siblings keep rendering normally.
+   *   4. Forward to `ToolMessage` so the same renderer can decide
+   *      whether to emit the inline scrollback summary or stay
+   *      panel-only.
    */
   isPending?: boolean;
   activeShellPtyId?: number | null;
@@ -172,9 +186,17 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
 
   const focusedSubagentCallId = focusedSubagentRef.current;
   // When no subagent has a pending confirmation, fall back to the *first*
-  // running subagent for Ctrl+E/Ctrl+F shortcut focus. "First" (array order)
-  // is the oldest — the one most likely to have accumulated tool calls and
-  // display the "+N more (ctrl+e to expand)" hint.
+  // running subagent for keyboard focus. "First" (array order) is the
+  // oldest — the one most likely to be the focal subagent. The legacy
+  // Ctrl+E / Ctrl+F display shortcuts retired with the inline frame, so
+  // the fallback is now mostly inert; it stays here so a future
+  // re-introduction of inline keyboard surfaces has a focus target.
+  // Note: during the live phase running subagent entries are filtered
+  // out of the rendered map (`isPending && isSubagentToolEntry &&
+  // !pending`), so this id can point at a hidden tool. That's harmless
+  // — `isSubagentFocused` is only read inside the map iteration which
+  // already returned `null` for the hidden entry, so no focus prop
+  // ever reaches a missing DOM node.
   const runningSubagentCallId = useMemo(
     () =>
       toolCalls.find((tc) => isRunningAgent(tc.resultDisplay))?.callId ?? null,
@@ -183,6 +205,24 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   // Pending confirmation takes strict priority over running fallback.
   const keyboardFocusedSubagentCallId =
     focusedSubagentCallId ?? runningSubagentCallId;
+
+  // Decide whether the entire group is panel-owned during the live
+  // phase: a pure-task_execution batch with no pending approval has
+  // nothing inline left to render once the subagent rows themselves
+  // are filtered out (LiveAgentPanel handles them). Hide the whole
+  // group so the bordered container / compact summary line don't
+  // float above the panel as a duplicate.
+  const allEntriesPanelOwned =
+    isPending &&
+    toolCalls.length > 0 &&
+    toolCalls.every(
+      (tool) =>
+        isSubagentToolEntry(tool) &&
+        !isAgentWithPendingConfirmation(tool.resultDisplay),
+    );
+  if (allEntriesPanelOwned) {
+    return null;
+  }
 
   // Compact mode: entire group → single line summary
   // Force-expand when: user must interact (Confirming or subagent pending
@@ -197,16 +237,13 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
   const hasSubagentPendingConfirmation = subagentsAwaitingApproval.length > 0;
   const hasCommittedTerminalSubagent =
     !isPending &&
-    toolCalls.some((t) => {
-      const display = t.resultDisplay;
-      if (!display || typeof display !== 'object') return false;
-      if (!('type' in display) || display.type !== 'task_execution')
-        return false;
-      const status = (display as { status?: string }).status;
-      return (
-        status === 'completed' || status === 'failed' || status === 'cancelled'
-      );
-    });
+    toolCalls.some(
+      (t) =>
+        isSubagentToolEntry(t) &&
+        ((t.resultDisplay as AgentResultDisplay).status === 'completed' ||
+          (t.resultDisplay as AgentResultDisplay).status === 'failed' ||
+          (t.resultDisplay as AgentResultDisplay).status === 'cancelled'),
+    );
   const showCompact =
     compactMode &&
     !hasConfirmingTool &&
@@ -224,24 +261,6 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
         compactLabel={compactLabel}
       />
     );
-  }
-
-  // Live phase: if every tool in the group is a panel-owned subagent
-  // call (no pending approval to gate on), skip the entire group
-  // container — otherwise the bordered Box would render empty under
-  // the panel. Once the parent turn commits the call sites stop
-  // passing `isPending=true` and the group reappears with the
-  // committed audit trail.
-  const allEntriesPanelOwned =
-    isPending &&
-    toolCalls.length > 0 &&
-    toolCalls.every(
-      (tool) =>
-        isLiveSubagentTool(tool) &&
-        !isAgentWithPendingConfirmation(tool.resultDisplay),
-    );
-  if (allEntriesPanelOwned) {
-    return null;
   }
 
   // Full expanded view
@@ -348,21 +367,16 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
         })()}
       {toolCalls.map((tool) => {
         // Live phase: hide subagent (`task_execution`) tool entries
-        // entirely so LiveAgentPanel below the composer is the single
-        // source of truth for in-flight subagents. Otherwise the
-        // user sees the same agent twice — once as the parent tool
-        // group's row, once as the panel row. Once the parent turn
-        // commits (`isPending=false`) the row reappears so the
-        // SubagentScrollbackSummary lands inside the parent's tool
-        // group and the audit trail stays intact.
-        //
-        // EXCEPT when the subagent has a pending approval: the
-        // ToolMessage path renders the focus-routed banner / queued
-        // marker, which is the only way the user can answer the
-        // prompt without opening the dialog.
+        // unless the subagent is awaiting user approval. The inline
+        // banner / queued marker is the only way the user can answer
+        // the approval prompt without opening the dialog, so those
+        // entries always render. Other subagent entries are hidden
+        // because LiveAgentPanel below the composer paints them; the
+        // entry returns once the parent turn commits and carries the
+        // SubagentScrollbackSummary as the persistent audit trail.
         if (
           isPending &&
-          isLiveSubagentTool(tool) &&
+          isSubagentToolEntry(tool) &&
           !isAgentWithPendingConfirmation(tool.resultDisplay)
         ) {
           return null;

--- a/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
@@ -387,13 +387,16 @@ describe('<ToolMessage />', () => {
       expect(output).not.toContain('MockApprovalPrompt');
     });
 
-    it('live (`isPending`) terminal subagent → no scrollback summary (panel owns the row)', () => {
-      // While the parent turn is still in `pendingHistoryItems`,
-      // LiveAgentPanel below the composer renders the synthesized /
-      // terminal row — emitting the summary here too would duplicate
-      // it visually. The summary fires only when the tool message
-      // commits to <Static> (`isPending=false`), guaranteeing exactly
-      // one inline copy in the eventual scrollback record.
+    it('live (`isPending`) terminal subagent → renders summary inline (panel snapshot already dropped)', () => {
+      // After `unregisterForeground`'s post-delete emit (#3921 swap-
+      // order), the panel snapshot drops the foreground entry as soon
+      // as the subagent finishes — even while the parent turn is
+      // still in `pendingHistoryItems`. If the inline summary were
+      // also gated on `!isPending`, a foreground subagent that
+      // finishes mid-turn would simply disappear from screen until
+      // commit. Render the summary in BOTH live and committed phases;
+      // the live-phase filter in `ToolGroupMessage` already keeps
+      // running entries from reaching this renderer.
       const { lastFrame } = renderWithContext(
         <ToolMessage
           {...buildProps({
@@ -409,9 +412,8 @@ describe('<ToolMessage />', () => {
         StreamingState.Responding,
       );
       const output = lastFrame() ?? '';
-      // No inline summary — the panel renders this row instead.
-      expect(output).not.toContain('✔');
-      expect(output).not.toContain('Just finished mid-turn');
+      expect(output).toContain('✔');
+      expect(output).toContain('Just finished mid-turn');
     });
 
     it('failed subagent → renders summary with terminate reason', () => {

--- a/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
@@ -317,6 +317,7 @@ describe('<ToolMessage />', () => {
         terminateReason?: string;
       };
       isFocused?: boolean;
+      isPending?: boolean;
     }): ToolMessageProps => {
       const resultDisplay = {
         type: 'task_execution' as const,
@@ -331,6 +332,7 @@ describe('<ToolMessage />', () => {
         callId: 'gated-task-call',
         forceShowResult: true, // mirror ToolGroupMessage's forceShowResult
         isFocused: overrides.isFocused,
+        isPending: overrides.isPending,
       };
     };
 
@@ -355,7 +357,7 @@ describe('<ToolMessage />', () => {
       expect(output).not.toContain('Queued approval:');
     });
 
-    it('completed subagent → renders a one-line scrollback summary', () => {
+    it('committed (`!isPending`) terminal subagent → renders a one-line scrollback summary', () => {
       // The verbose 15-row inline frame is retired (it caused
       // scrollback flicker), but the conversation history needs to
       // keep a permanent record after the panel's 8s window expires
@@ -370,6 +372,7 @@ describe('<ToolMessage />', () => {
               taskPrompt: 'Already done',
               status: 'completed',
             },
+            isPending: false,
           })}
         />,
         StreamingState.Idle,
@@ -382,6 +385,33 @@ describe('<ToolMessage />', () => {
       // No approval prompt — completed subagents don't sit on the
       // focus lock.
       expect(output).not.toContain('MockApprovalPrompt');
+    });
+
+    it('live (`isPending`) terminal subagent → no scrollback summary (panel owns the row)', () => {
+      // While the parent turn is still in `pendingHistoryItems`,
+      // LiveAgentPanel below the composer renders the synthesized /
+      // terminal row — emitting the summary here too would duplicate
+      // it visually. The summary fires only when the tool message
+      // commits to <Static> (`isPending=false`), guaranteeing exactly
+      // one inline copy in the eventual scrollback record.
+      const { lastFrame } = renderWithContext(
+        <ToolMessage
+          {...buildProps({
+            data: {
+              subagentName: 'live-terminal',
+              taskDescription: 'Just finished mid-turn',
+              taskPrompt: 'Mid-turn',
+              status: 'completed',
+            },
+            isPending: true,
+          })}
+        />,
+        StreamingState.Responding,
+      );
+      const output = lastFrame() ?? '';
+      // No inline summary — the panel renders this row instead.
+      expect(output).not.toContain('✔');
+      expect(output).not.toContain('Just finished mid-turn');
     });
 
     it('failed subagent → renders summary with terminate reason', () => {

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -262,6 +262,14 @@ const PlanResultRenderer: React.FC<{
  *   single-line scrollback summary so the conversation history retains
  *   a permanent record after the panel's 8s window expires and the
  *   dialog closes. Format: `<icon> <type>: <description> · N tools · Xs · Yk tokens`.
+ *
+ * The committed-phase summary is gated on `!isPending` — without the
+ * gate the summary would also paint into `pendingHistoryItems`
+ * (the live area) the moment a subagent terminates, duplicating the
+ * row LiveAgentPanel already renders synthesized below the composer.
+ * `isPending=true` means we're still in the live area; `isPending=false`
+ * means the item has committed to `<Static>` and the summary is the
+ * one and only place the user can find this run after the panel evicts.
  */
 const SubagentExecutionRenderer: React.FC<{
   data: AgentResultDisplay;
@@ -269,7 +277,15 @@ const SubagentExecutionRenderer: React.FC<{
   childWidth: number;
   config: Config;
   isFocused?: boolean;
-}> = ({ data, availableHeight, childWidth, config, isFocused }) => {
+  isPending?: boolean;
+}> = ({
+  data,
+  availableHeight,
+  childWidth,
+  config,
+  isFocused,
+  isPending = false,
+}) => {
   if (data.pendingConfirmation && isFocused) {
     const agentLabel = data.subagentName || 'agent';
     return (
@@ -308,10 +324,14 @@ const SubagentExecutionRenderer: React.FC<{
   // 8s visibility window expires (LiveAgentPanel evicts terminal rows;
   // BackgroundTasksDialog only retains them while open). Skip
   // `running` / `background` since the panel + dialog cover those.
+  // ALSO skip while `isPending` — the live area is already painted by
+  // the panel, so emitting the summary into `pendingHistoryItems` would
+  // duplicate the row visually until the parent turn commits.
   if (
-    data.status === 'completed' ||
-    data.status === 'failed' ||
-    data.status === 'cancelled'
+    !isPending &&
+    (data.status === 'completed' ||
+      data.status === 'failed' ||
+      data.status === 'cancelled')
   ) {
     return <SubagentScrollbackSummary data={data} />;
   }
@@ -478,6 +498,15 @@ export interface ToolMessageProps extends IndividualToolCallDisplay {
    * sibling subagents render a dim "Queued approval" marker instead.
    */
   isFocused?: boolean;
+  /**
+   * True while the tool message is rendered inside `pendingHistoryItems`
+   * (live area), false once committed to `<Static>`. Used by the
+   * subagent renderer to gate the scrollback summary so the live area
+   * stays panel-only — without this gate the summary would duplicate
+   * the synthesized row LiveAgentPanel already renders below the
+   * composer the moment a subagent terminates.
+   */
+  isPending?: boolean;
 }
 
 export const ToolMessage: React.FC<ToolMessageProps> = ({
@@ -495,6 +524,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
   config,
   forceShowResult,
   isFocused,
+  isPending,
   executionStartTime,
 }) => {
   const settings = useSettings();
@@ -649,6 +679,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
                 childWidth={innerWidth}
                 config={config}
                 isFocused={isFocused}
+                isPending={isPending}
               />
             )}
             {effectiveDisplayRenderer.type === 'diff' && (

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -522,12 +522,13 @@ export interface ToolMessageProps extends IndividualToolCallDisplay {
   /**
    * True while the tool message is rendered inside `pendingHistoryItems`
    * (live area), false (or omitted — undefined is treated as false)
-   * once committed to `<Static>`. Live-area renderers MUST pass
-   * `true` explicitly; committed renderers can omit it. Used by the
-   * subagent renderer to gate the scrollback summary so the live
-   * area stays panel-only — without this gate the summary would
-   * duplicate the synthesized row LiveAgentPanel already renders
-   * below the composer the moment a subagent terminates.
+   * once committed to `<Static>`. Forwarded for parity with sibling
+   * renderers and possible future gating; currently inert inside this
+   * component. The live-phase filter for panel-owned subagent entries
+   * lives in `ToolGroupMessage` (the only call site), and the terminal
+   * `SubagentScrollbackSummary` fires regardless of `isPending` so the
+   * inline path can bridge the gap between `unregisterForeground`'s
+   * post-delete panel-snapshot drop and the parent turn committing.
    */
   isPending?: boolean;
 }

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -256,24 +256,27 @@ const PlanResultRenderer: React.FC<{
  *
  * The verbose inline frame has been retired. Three surfaces remain:
  *
- * - **Live phase (running)**: nothing inline — `LiveAgentPanel` (the
- *   always-on bottom roster) and `BackgroundTasksDialog` (Down-arrow
- *   detail view) own progress reporting.
- * - **Approval prompt (focus-locked)**: full inline approval banner so
- *   the user can answer without context-switching into the dialog;
+ * - **Running**: nothing inline — `LiveAgentPanel` (the always-on
+ *   bottom roster) and `BackgroundTasksDialog` (Down-arrow detail
+ *   view) own progress reporting. `ToolGroupMessage` filters
+ *   running task entries out of the live phase entirely so the
+ *   group container doesn't even attempt to render this renderer.
+ * - **Approval prompt (focus-locked)**: full inline approval banner
+ *   so the user can answer without context-switching into the dialog;
  *   sibling subagents render a queued marker.
- * - **Committed phase (terminal — completed / failed / cancelled)**: a
- *   single-line scrollback summary so the conversation history retains
- *   a permanent record after the panel's 8s window expires and the
- *   dialog closes. Format: `<icon> <type>: <description> · N tools · Xs · Yk tokens`.
+ * - **Terminal (completed / failed / cancelled)**: a single-line
+ *   scrollback summary so the conversation history retains a
+ *   permanent record after the panel evicts. Fires regardless of
+ *   `isPending` — `unregisterForeground`'s post-delete emit drops
+ *   the panel snapshot row immediately, so the inline summary is
+ *   the only surface that bridges the moment a foreground subagent
+ *   finishes mid-parent-turn until the parent commits.
+ *   Format: `<icon> <type>: <description> · N tools · Xs · Yk tokens`.
  *
- * The committed-phase summary is gated on `!isPending` — without the
- * gate the summary would also paint into `pendingHistoryItems`
- * (the live area) the moment a subagent terminates, duplicating the
- * row LiveAgentPanel already renders synthesized below the composer.
- * `isPending=true` means we're still in the live area; `isPending=false`
- * means the item has committed to `<Static>` and the summary is the
- * one and only place the user can find this run after the panel evicts.
+ * `isPending` is no longer used as a render gate here; the live-phase
+ * filter in `ToolGroupMessage` handles the running case before this
+ * renderer is reached. The prop is kept on the signature for future
+ * needs and parity with sibling renderers.
  */
 const SubagentExecutionRenderer: React.FC<{
   data: AgentResultDisplay;
@@ -282,16 +285,17 @@ const SubagentExecutionRenderer: React.FC<{
   config: Config;
   isFocused?: boolean;
   isPending?: boolean;
-}> = ({
-  data,
-  availableHeight,
-  childWidth,
-  config,
-  isFocused,
-  isPending = false,
-}) => {
+  // `isPending` stays on the prop signature for parity with sibling
+  // renderers and possible future gating, but isn't read here — the
+  // live-phase filter in `ToolGroupMessage` already keeps running
+  // entries from reaching this renderer (so the terminal-summary path
+  // is the only thing left to gate, and it should fire in both phases).
+}> = ({ data, availableHeight, childWidth, config, isFocused }) => {
   if (data.pendingConfirmation && isFocused) {
-    const agentLabel = data.subagentName || 'agent';
+    // `subagentName` is user-authored / model-chosen and may carry
+    // ANSI control sequences; escape before rendering into Ink Text
+    // (matches LiveAgentPanel + SubagentScrollbackSummary).
+    const agentLabel = escapeAnsiCtrlCodes(data.subagentName || 'agent');
     return (
       <Box flexDirection="column" paddingLeft={1}>
         <Box>
@@ -313,7 +317,10 @@ const SubagentExecutionRenderer: React.FC<{
     );
   }
   if (data.pendingConfirmation) {
-    const agentLabel = data.subagentName || 'agent';
+    // `subagentName` is user-authored / model-chosen and may carry
+    // ANSI control sequences; escape before rendering into Ink Text
+    // (matches LiveAgentPanel + SubagentScrollbackSummary).
+    const agentLabel = escapeAnsiCtrlCodes(data.subagentName || 'agent');
     return (
       <Box paddingLeft={1}>
         <Text color={theme.text.secondary} dimColor>
@@ -324,18 +331,18 @@ const SubagentExecutionRenderer: React.FC<{
     );
   }
   // Terminal phase: render a single-line scrollback summary so the
-  // conversation history keeps a permanent record after the panel's
-  // 8s visibility window expires (LiveAgentPanel evicts terminal rows;
-  // BackgroundTasksDialog only retains them while open). Skip
-  // `running` / `background` since the panel + dialog cover those.
-  // ALSO skip while `isPending` — the live area is already painted by
-  // the panel, so emitting the summary into `pendingHistoryItems` would
-  // duplicate the row visually until the parent turn commits.
+  // conversation history keeps a permanent record. Fires in BOTH
+  // live and committed phases — `unregisterForeground`'s post-delete
+  // emit drops the panel snapshot row immediately, so without an
+  // inline render here a foreground subagent that finishes
+  // mid-parent-turn would simply disappear from screen until commit.
+  // No duplication risk because the panel never re-resurrects a
+  // dropped foreground entry. Skip `running` / `background` since the
+  // panel + dialog cover those.
   if (
-    !isPending &&
-    (data.status === 'completed' ||
-      data.status === 'failed' ||
-      data.status === 'cancelled')
+    data.status === 'completed' ||
+    data.status === 'failed' ||
+    data.status === 'cancelled'
   ) {
     return <SubagentScrollbackSummary data={data} />;
   }

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -33,7 +33,11 @@ import { theme } from '../../semantic-colors.js';
 import { useSettings } from '../../contexts/SettingsContext.js';
 import type { LoadedSettings } from '../../../config/settings.js';
 import { useCompactMode } from '../../contexts/CompactModeContext.js';
-import { getCachedStringWidth, toCodePoints } from '../../utils/textUtils.js';
+import {
+  escapeAnsiCtrlCodes,
+  getCachedStringWidth,
+  toCodePoints,
+} from '../../utils/textUtils.js';
 
 import {
   ToolStatusIndicator,
@@ -376,18 +380,28 @@ const SubagentScrollbackSummary: React.FC<{
   if (stats?.totalTokens && stats.totalTokens > 0) {
     parts.push(`${formatTokenCount(stats.totalTokens)} tokens`);
   }
+  // Sanitize every user/LLM-controlled string before it reaches Ink.
+  // `subagentName` is subagent config (user-authored or model-chosen),
+  // `taskDescription` is LLM-generated, `terminateReason` is whatever
+  // the agent emitted on failure. All can carry terminal control
+  // sequences that would otherwise bleed through Ink's `<Text>` and
+  // corrupt scrollback chrome — same threat model as the panel rows
+  // and HistoryItemDisplay's user-facing content.
   const tail = parts.length > 0 ? ` · ${parts.join(' · ')}` : '';
-  const typePrefix = data.subagentName ? `${data.subagentName}: ` : '';
+  const typePrefix = data.subagentName
+    ? `${escapeAnsiCtrlCodes(data.subagentName)}: `
+    : '';
+  const safeDescription = escapeAnsiCtrlCodes(data.taskDescription ?? '');
   const reason =
     data.status !== 'completed' && data.terminateReason
-      ? ` · ${data.terminateReason}`
+      ? ` · ${escapeAnsiCtrlCodes(data.terminateReason)}`
       : '';
   return (
     <Box paddingLeft={1}>
       <Text wrap="truncate-end">
         <Text color={color}>{`${glyph} `}</Text>
         <Text bold>{typePrefix}</Text>
-        <Text color={theme.text.secondary}>{data.taskDescription}</Text>
+        <Text color={theme.text.secondary}>{safeDescription}</Text>
         <Text color={theme.text.secondary}>{tail}</Text>
         <Text color={theme.text.secondary}>{reason}</Text>
       </Text>

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -500,11 +500,13 @@ export interface ToolMessageProps extends IndividualToolCallDisplay {
   isFocused?: boolean;
   /**
    * True while the tool message is rendered inside `pendingHistoryItems`
-   * (live area), false once committed to `<Static>`. Used by the
-   * subagent renderer to gate the scrollback summary so the live area
-   * stays panel-only — without this gate the summary would duplicate
-   * the synthesized row LiveAgentPanel already renders below the
-   * composer the moment a subagent terminates.
+   * (live area), false (or omitted — undefined is treated as false)
+   * once committed to `<Static>`. Live-area renderers MUST pass
+   * `true` explicitly; committed renderers can omit it. Used by the
+   * subagent renderer to gate the scrollback summary so the live
+   * area stays panel-only — without this gate the summary would
+   * duplicate the synthesized row LiveAgentPanel already renders
+   * below the composer the moment a subagent terminates.
    */
   isPending?: boolean;
 }

--- a/packages/cli/src/ui/utils/mergeCompactToolGroups.test.ts
+++ b/packages/cli/src/ui/utils/mergeCompactToolGroups.test.ts
@@ -203,6 +203,48 @@ describe('mergeCompactToolGroups', () => {
     // Group 2 with subagent pending confirmation stays separate
   });
 
+  it.each([
+    ['completed', 'completed'],
+    ['failed', 'failed'],
+    ['cancelled', 'cancelled'],
+  ] as const)(
+    'does NOT merge tool_group with terminal subagent (%s)',
+    (_label, status) => {
+      // Terminal task_execution groups must not be absorbed: their
+      // SubagentScrollbackSummary lands inline as the persistent
+      // record of the run's outcome, and the compact path can't
+      // surface it. Mirrors `hasCommittedTerminalSubagent` in
+      // `ToolGroupMessage.showCompact`.
+      const subagentResult = {
+        type: 'task_execution',
+        subagentName: 'test-agent',
+        taskDescription: 'test task',
+        status,
+      };
+      const items: HistoryItem[] = [
+        createToolGroup(1, [createTool('c1', 'Shell', ToolCallStatus.Success)]),
+        createToolGroup(2, [
+          createTool(
+            'c2',
+            'Agent',
+            status === 'failed' ? ToolCallStatus.Error : ToolCallStatus.Success,
+            subagentResult,
+          ),
+        ]),
+        createToolGroup(3, [createTool('c3', 'Shell', ToolCallStatus.Success)]),
+      ];
+      const merged = mergeCompactToolGroups(items);
+      // Three separate groups: terminal subagent stays its own batch
+      // so SubagentScrollbackSummary renders as a standalone entry.
+      expect(merged.length).toBe(3);
+      const ids = merged
+        .filter(isToolGroup)
+        .map((g) => g.id)
+        .sort();
+      expect(ids).toEqual([1, 2, 3]);
+    },
+  );
+
   it('does NOT merge focused executing shell', () => {
     const items: HistoryItem[] = [
       createToolGroup(1, [createTool('c1', 'Shell', ToolCallStatus.Success)]),

--- a/packages/cli/src/ui/utils/mergeCompactToolGroups.test.ts
+++ b/packages/cli/src/ui/utils/mergeCompactToolGroups.test.ts
@@ -213,7 +213,7 @@ describe('mergeCompactToolGroups', () => {
       // Terminal task_execution groups must not be absorbed: their
       // SubagentScrollbackSummary lands inline as the persistent
       // record of the run's outcome, and the compact path can't
-      // surface it. Mirrors `hasCommittedTerminalSubagent` in
+      // surface it. Mirrors `hasTerminalSubagent` in
       // `ToolGroupMessage.showCompact`.
       const subagentResult = {
         type: 'task_execution',

--- a/packages/cli/src/ui/utils/mergeCompactToolGroups.ts
+++ b/packages/cli/src/ui/utils/mergeCompactToolGroups.ts
@@ -75,7 +75,7 @@ export function isForceExpandGroup(
   // run's outcome (LiveAgentPanel evicts terminal rows after its
   // visibility window). If the group merged into a compact batch,
   // the summary would never render and the user would lose the
-  // committed audit trail. Mirrors the `hasCommittedTerminalSubagent`
+  // committed audit trail. Mirrors the `hasTerminalSubagent`
   // predicate in `ToolGroupMessage.showCompact`.
   if (
     tools.some((t) => {

--- a/packages/cli/src/ui/utils/mergeCompactToolGroups.ts
+++ b/packages/cli/src/ui/utils/mergeCompactToolGroups.ts
@@ -70,6 +70,33 @@ export function isForceExpandGroup(
     return true;
   }
 
+  // Terminal subagent tool calls must show — the inline
+  // `SubagentScrollbackSummary` is the persistent record of the
+  // run's outcome (LiveAgentPanel evicts terminal rows after its
+  // visibility window). If the group merged into a compact batch,
+  // the summary would never render and the user would lose the
+  // committed audit trail. Mirrors the `hasCommittedTerminalSubagent`
+  // predicate in `ToolGroupMessage.showCompact`.
+  if (
+    tools.some((t) => {
+      const rd = t.resultDisplay;
+      if (
+        !rd ||
+        typeof rd !== 'object' ||
+        !('type' in rd) ||
+        (rd as { type?: string }).type !== 'task_execution'
+      ) {
+        return false;
+      }
+      const status = (rd as { status?: string }).status;
+      return (
+        status === 'completed' || status === 'failed' || status === 'cancelled'
+      );
+    })
+  ) {
+    return true;
+  }
+
   // Active focused shell must be visible
   if (
     embeddedShellFocused &&

--- a/packages/core/src/agents/background-tasks.test.ts
+++ b/packages/core/src/agents/background-tasks.test.ts
@@ -999,7 +999,7 @@ describe('BackgroundTaskRegistry', () => {
       }
     });
 
-    it('unregisterForeground removes the entry and emits a status change', () => {
+    it('unregisterForeground removes the entry and emits status change twice (pre + post delete)', () => {
       const onStatusChange = vi.fn();
       registry.setStatusChangeCallback(onStatusChange);
 
@@ -1016,7 +1016,56 @@ describe('BackgroundTaskRegistry', () => {
       registry.unregisterForeground('fg-5');
 
       expect(registry.get('fg-5')).toBeUndefined();
-      expect(onStatusChange).toHaveBeenCalledTimes(1);
+      // Two emits: the pre-delete one matches the
+      // complete/fail/cancel/finalize ordering so callbacks that
+      // re-read `registry.get(agentId)` see the entry; the post-delete
+      // one lets snapshot-based views (`useBackgroundTaskView` calling
+      // `registry.getAll()`) observe the entry-less state without
+      // needing per-tick reconciliation. Both fire synchronously, so
+      // React batches the resulting setState calls into one re-render.
+      expect(onStatusChange).toHaveBeenCalledTimes(2);
+    });
+
+    it('unregisterForeground post-delete emit observes registry-less state', () => {
+      // The second emit is the contract that lets snapshot consumers
+      // (e.g. BackgroundTasksDialog list mode) drop ghost rows for
+      // foreground subagents that just unregistered. Without it the
+      // snapshot would freeze at the pre-delete entry-as-running state
+      // until the next unrelated transition.
+      registry.register({
+        agentId: 'fg-post-delete',
+        description: 'sync agent',
+        flavor: 'foreground',
+        status: 'running',
+        startTime: Date.now(),
+        abortController: new AbortController(),
+      });
+
+      const observations: Array<{
+        getAtCallback: BackgroundTaskEntry | undefined;
+        getAllCount: number;
+      }> = [];
+      registry.setStatusChangeCallback((entry) => {
+        if (entry?.agentId !== 'fg-post-delete') return;
+        observations.push({
+          getAtCallback: registry.get('fg-post-delete'),
+          getAllCount: registry
+            .getAll()
+            .filter((e) => e.agentId === 'fg-post-delete').length,
+        });
+      });
+
+      registry.unregisterForeground('fg-post-delete');
+
+      expect(observations).toHaveLength(2);
+      // First emit (pre-delete): entry still in the registry.
+      expect(observations[0].getAtCallback?.agentId).toBe('fg-post-delete');
+      expect(observations[0].getAllCount).toBe(1);
+      // Second emit (post-delete): entry gone. This is what
+      // `useBackgroundTaskView.refresh()` sees, so its merged
+      // entries no longer include the agent.
+      expect(observations[1].getAtCallback).toBeUndefined();
+      expect(observations[1].getAllCount).toBe(0);
     });
 
     it('unregisterForeground throws if asked to remove a background entry', () => {
@@ -1078,10 +1127,15 @@ describe('BackgroundTaskRegistry', () => {
       expect(onRegister.mock.calls[0]![0].agentId).toBe('bg-fires-register-cb');
     });
 
-    it('unregisterForeground emits status change before removing the entry', () => {
-      // Mirrors the ordering used by complete/fail/cancel/finalize so a
-      // statusChange callback that re-reads `registry.get(agentId)` from
-      // inside the callback sees the entry across every terminal path.
+    it('unregisterForeground first emit sees entry; later emits see registry-less state', () => {
+      // The first emit mirrors the ordering used by
+      // complete/fail/cancel/finalize so a statusChange callback that
+      // re-reads `registry.get(agentId)` from inside the callback sees
+      // the entry across every terminal path. The second emit (added
+      // for snapshot consumers like `useBackgroundTaskView`) sees the
+      // registry-less state — both paths are documented + tested
+      // separately so a future refactor that collapsed the two emits
+      // would surface here.
       registry.register({
         agentId: 'fg-unregister-order',
         description: 'sync agent',
@@ -1091,17 +1145,21 @@ describe('BackgroundTaskRegistry', () => {
         abortController: new AbortController(),
       });
 
-      let observedFromCallback: BackgroundTaskEntry | undefined;
+      const observed: Array<BackgroundTaskEntry | undefined> = [];
       registry.setStatusChangeCallback((entry) => {
         if (entry?.agentId === 'fg-unregister-order') {
-          observedFromCallback = registry.get(entry.agentId);
+          observed.push(registry.get(entry.agentId));
         }
       });
 
       registry.unregisterForeground('fg-unregister-order');
 
-      expect(observedFromCallback).toBeDefined();
-      expect(observedFromCallback!.agentId).toBe('fg-unregister-order');
+      expect(observed).toHaveLength(2);
+      // First emit: pre-delete, callback sees the entry.
+      expect(observed[0]).toBeDefined();
+      expect(observed[0]!.agentId).toBe('fg-unregister-order');
+      // Second emit: post-delete, callback sees the registry-less state.
+      expect(observed[1]).toBeUndefined();
       expect(registry.get('fg-unregister-order')).toBeUndefined();
     });
 

--- a/packages/core/src/agents/background-tasks.test.ts
+++ b/packages/core/src/agents/background-tasks.test.ts
@@ -999,7 +999,7 @@ describe('BackgroundTaskRegistry', () => {
       }
     });
 
-    it('unregisterForeground removes the entry and emits status change twice (pre + post delete)', () => {
+    it('unregisterForeground emits status change twice with removed flag on second emit', () => {
       const onStatusChange = vi.fn();
       registry.setStatusChangeCallback(onStatusChange);
 
@@ -1016,14 +1016,25 @@ describe('BackgroundTaskRegistry', () => {
       registry.unregisterForeground('fg-5');
 
       expect(registry.get('fg-5')).toBeUndefined();
-      // Two emits: the pre-delete one matches the
-      // complete/fail/cancel/finalize ordering so callbacks that
-      // re-read `registry.get(agentId)` see the entry; the post-delete
-      // one lets snapshot-based views (`useBackgroundTaskView` calling
-      // `registry.getAll()`) observe the entry-less state without
-      // needing per-tick reconciliation. Both fire synchronously, so
-      // React batches the resulting setState calls into one re-render.
+      // Two emits: the first omits `removed` (entry still present in
+      // the registry — matches complete/fail/cancel/finalize); the
+      // second sets `removed: true` (entry gone). Snapshot-style
+      // consumers can ignore the first; consumers that key off the
+      // entry's last live state can ignore the second. Both fire
+      // synchronously so a typical React-based consumer's setState
+      // calls collapse to a single re-render.
       expect(onStatusChange).toHaveBeenCalledTimes(2);
+      // First call: pre-delete, no context flag (context arg is
+      // undefined since `emitStatusChange(entry)` doesn't pass one).
+      expect(onStatusChange.mock.calls[0][0]).toMatchObject({
+        agentId: 'fg-5',
+      });
+      expect(onStatusChange.mock.calls[0][1]).toBeUndefined();
+      // Second call: post-delete, `removed: true` flag set.
+      expect(onStatusChange.mock.calls[1][0]).toMatchObject({
+        agentId: 'fg-5',
+      });
+      expect(onStatusChange.mock.calls[1][1]).toEqual({ removed: true });
     });
 
     it('unregisterForeground post-delete emit observes registry-less state', () => {
@@ -1042,12 +1053,14 @@ describe('BackgroundTaskRegistry', () => {
       });
 
       const observations: Array<{
+        removed: boolean;
         getAtCallback: BackgroundTaskEntry | undefined;
         getAllCount: number;
       }> = [];
-      registry.setStatusChangeCallback((entry) => {
+      registry.setStatusChangeCallback((entry, context) => {
         if (entry?.agentId !== 'fg-post-delete') return;
         observations.push({
+          removed: context?.removed ?? false,
           getAtCallback: registry.get('fg-post-delete'),
           getAllCount: registry
             .getAll()
@@ -1058,12 +1071,15 @@ describe('BackgroundTaskRegistry', () => {
       registry.unregisterForeground('fg-post-delete');
 
       expect(observations).toHaveLength(2);
-      // First emit (pre-delete): entry still in the registry.
+      // First emit (pre-delete): entry still in the registry, no
+      // `removed` flag → callbacks that re-read see the entry.
+      expect(observations[0].removed).toBe(false);
       expect(observations[0].getAtCallback?.agentId).toBe('fg-post-delete');
       expect(observations[0].getAllCount).toBe(1);
-      // Second emit (post-delete): entry gone. This is what
-      // `useBackgroundTaskView.refresh()` sees, so its merged
-      // entries no longer include the agent.
+      // Second emit (post-delete): `removed: true` flag, entry gone.
+      // This is what `useBackgroundTaskView.refresh()` sees, so its
+      // merged entries no longer include the agent.
+      expect(observations[1].removed).toBe(true);
       expect(observations[1].getAtCallback).toBeUndefined();
       expect(observations[1].getAllCount).toBe(0);
     });
@@ -1135,7 +1151,9 @@ describe('BackgroundTaskRegistry', () => {
       // for snapshot consumers like `useBackgroundTaskView`) sees the
       // registry-less state — both paths are documented + tested
       // separately so a future refactor that collapsed the two emits
-      // would surface here.
+      // would surface here. Consumers that need to distinguish the
+      // two emits without re-querying the registry can read
+      // `context.removed`.
       registry.register({
         agentId: 'fg-unregister-order',
         description: 'sync agent',
@@ -1145,21 +1163,30 @@ describe('BackgroundTaskRegistry', () => {
         abortController: new AbortController(),
       });
 
-      const observed: Array<BackgroundTaskEntry | undefined> = [];
-      registry.setStatusChangeCallback((entry) => {
+      const observed: Array<{
+        live: BackgroundTaskEntry | undefined;
+        removed: boolean;
+      }> = [];
+      registry.setStatusChangeCallback((entry, context) => {
         if (entry?.agentId === 'fg-unregister-order') {
-          observed.push(registry.get(entry.agentId));
+          observed.push({
+            live: registry.get(entry.agentId),
+            removed: context?.removed ?? false,
+          });
         }
       });
 
       registry.unregisterForeground('fg-unregister-order');
 
       expect(observed).toHaveLength(2);
-      // First emit: pre-delete, callback sees the entry.
-      expect(observed[0]).toBeDefined();
-      expect(observed[0]!.agentId).toBe('fg-unregister-order');
-      // Second emit: post-delete, callback sees the registry-less state.
-      expect(observed[1]).toBeUndefined();
+      // First emit: pre-delete, callback sees the entry, `removed` absent.
+      expect(observed[0].live).toBeDefined();
+      expect(observed[0].live!.agentId).toBe('fg-unregister-order');
+      expect(observed[0].removed).toBe(false);
+      // Second emit: post-delete, callback sees the registry-less
+      // state, `removed: true` flag set.
+      expect(observed[1].live).toBeUndefined();
+      expect(observed[1].removed).toBe(true);
       expect(registry.get('fg-unregister-order')).toBeUndefined();
     });
 

--- a/packages/core/src/agents/background-tasks.ts
+++ b/packages/core/src/agents/background-tasks.ts
@@ -275,11 +275,22 @@ export class BackgroundTaskRegistry {
           `Background entries must terminate via complete/fail/finalizeCancelled.`,
       );
     }
-    // Emit before delete so any future BackgroundStatusChangeCallback that
-    // re-reads `registry.get(agentId)` from inside the callback sees the
-    // entry, matching the ordering used by complete/fail/cancel/finalize.
+    // Emit BEFORE delete so callbacks that re-read `registry.get(agentId)`
+    // from inside see the entry — matches the ordering used by
+    // complete/fail/cancel/finalize. This is the "agent reached its
+    // last live state" signal.
     this.emitStatusChange(entry);
     this.agents.delete(agentId);
+    // Emit AGAIN after delete so views that re-snapshot the registry
+    // on statusChange (e.g. `useBackgroundTaskView.refresh()` calling
+    // `registry.getAll()`) see the entry-less state and stop showing
+    // a stale "running" row. Without this second emit the snapshot
+    // freezes at the pre-delete state until the next unrelated
+    // statusChange event, leaving ghost rows in `BackgroundTasksDialog`
+    // list mode and forcing each consumer to re-implement registry
+    // re-pull. The two emits are batched by React's setState batching,
+    // so consumers only re-render once.
+    this.emitStatusChange(entry);
     debugLogger.info(`Unregistered foreground agent: ${agentId}`);
   }
 

--- a/packages/core/src/agents/background-tasks.ts
+++ b/packages/core/src/agents/background-tasks.ts
@@ -188,13 +188,26 @@ interface BackgroundTaskCancelOptions {
 }
 
 /**
- * Fires on entry status transitions — register, complete, fail, cancel.
- * Intentionally does NOT fire on `appendActivity` so consumers that only
- * care about the pill / roster (Footer, AppContainer) don't re-render
- * on every tool call a background agent makes.
+ * Fires on entry status transitions — register, complete, fail, cancel,
+ * unregister. Intentionally does NOT fire on `appendActivity` so
+ * consumers that only care about the roster don't re-render on every
+ * tool call a background agent makes.
+ *
+ * `entry` reflects the registry's view at the moment of emission.
+ * `unregisterForeground` fires twice for a single logical removal:
+ *   - first emit: `removed === false` (or absent), entry still in the
+ *     registry. Mirrors the complete/fail/cancel/finalize ordering so
+ *     callbacks that re-read `registry.get(entry.agentId)` from inside
+ *     the callback see the entry across every terminal path.
+ *   - second emit: `removed === true`, the registry has already
+ *     deleted the entry. Snapshot-style consumers (those that
+ *     re-pull `getAll()` from inside the callback) need this signal
+ *     to drop the row; consumers that only care about the entry's
+ *     last live state can ignore it.
  */
 export type BackgroundStatusChangeCallback = (
   entry?: BackgroundTaskEntry,
+  context?: { removed?: boolean },
 ) => void;
 
 /** Fires on `appendActivity` — scoped to detail-view consumers. */
@@ -278,19 +291,19 @@ export class BackgroundTaskRegistry {
     // Emit BEFORE delete so callbacks that re-read `registry.get(agentId)`
     // from inside see the entry — matches the ordering used by
     // complete/fail/cancel/finalize. This is the "agent reached its
-    // last live state" signal.
+    // last live state" signal; the entry is still present in the
+    // registry, so `removed` is omitted (treated as false).
     this.emitStatusChange(entry);
     this.agents.delete(agentId);
-    // Emit AGAIN after delete so views that re-snapshot the registry
-    // on statusChange (e.g. `useBackgroundTaskView.refresh()` calling
-    // `registry.getAll()`) see the entry-less state and stop showing
-    // a stale "running" row. Without this second emit the snapshot
+    // Emit AGAIN after delete with `removed: true` so snapshot-style
+    // consumers — those that re-pull `getAll()` from inside the
+    // callback — see the entry-less state and stop surfacing the
+    // row. Consumers that only care about the entry's last live
+    // state can ignore the second emit (or check `context.removed`
+    // and skip duplicate work). Without this signal a snapshot
     // freezes at the pre-delete state until the next unrelated
-    // statusChange event, leaving ghost rows in `BackgroundTasksDialog`
-    // list mode and forcing each consumer to re-implement registry
-    // re-pull. The two emits are batched by React's setState batching,
-    // so consumers only re-render once.
-    this.emitStatusChange(entry);
+    // status transition.
+    this.emitStatusChange(entry, { removed: true });
     debugLogger.info(`Unregistered foreground agent: ${agentId}`);
   }
 
@@ -627,10 +640,13 @@ export class BackgroundTaskRegistry {
     }
   }
 
-  private emitStatusChange(entry?: BackgroundTaskEntry): void {
+  private emitStatusChange(
+    entry?: BackgroundTaskEntry,
+    context?: { removed?: boolean },
+  ): void {
     if (!this.statusChangeCallback) return;
     try {
-      this.statusChangeCallback(entry);
+      this.statusChangeCallback(entry, context);
     } catch (error) {
       debugLogger.error('Failed to emit background status change:', error);
     }

--- a/packages/core/src/agents/background-tasks.ts
+++ b/packages/core/src/agents/background-tasks.ts
@@ -188,19 +188,25 @@ interface BackgroundTaskCancelOptions {
 }
 
 /**
- * Fires on entry status transitions — register, complete, fail, cancel,
- * unregister. Intentionally does NOT fire on `appendActivity` so
- * consumers that only care about the roster don't re-render on every
- * tool call a background agent makes.
+ * Fires on entry status transitions: `register`, `complete`, `fail`,
+ * `cancel`, `finalizeCancelled`, `finalizeCancellationIfPending`,
+ * `abandon`, `unregisterForeground`, and `reset`. Intentionally does
+ * NOT fire on `appendActivity` so consumers that only care about the
+ * roster don't re-render on every tool call a background agent makes.
  *
- * Ordering relative to the registry mutation:
- *   - register / complete / fail / cancel / finalize: emit AFTER the
- *     Map mutation but with the entry still present, so a callback
- *     that re-reads `registry.get(entry.agentId)` sees the entry.
- *   - unregisterForeground: deletes BEFORE emitting so snapshot-style
- *     consumers (those that re-pull `getAll()` from inside the
- *     callback) drop the row. The `entry` arg still carries the
- *     agent's last live state for log / display consumers.
+ * Ordering relative to the registry mutation falls into two camps:
+ *   - **Keeps the entry around** (`register` / `complete` / `fail` /
+ *     `cancel` / `finalizeCancelled` /
+ *     `finalizeCancellationIfPending` / `abandon`): emit while the
+ *     entry is still in the Map (the status field has been mutated
+ *     in place to its terminal value), so a callback that re-reads
+ *     `registry.get(entry.agentId)` sees the entry. Snapshot-style
+ *     consumers calling `getAll()` see the new status too.
+ *   - **Removes the entry** (`unregisterForeground`, `reset`):
+ *     deletes from the Map BEFORE emitting so snapshot-style
+ *     consumers drop the row. The `entry` arg carries the agent's
+ *     last live state for log / display consumers; `registry.get`
+ *     and `getAll` already reflect the deletion.
  */
 export type BackgroundStatusChangeCallback = (
   entry?: BackgroundTaskEntry,


### PR DESCRIPTION
Two follow-ups deferred from #3909, both flagged during review and tracked in that PR's `AUQHn` / `AUQGc` Copilot threads.

## #1 — Live-phase panel-ownership filter

`SubagentExecutionRenderer` started rendering `SubagentScrollbackSummary` "whenever the subagent reaches a terminal status" after the verbose inline frame was retired. Since `isPending` was also removed from `ToolMessageProps` in the same PR, panel-owned subagent rows (running / background) leaked through `ToolGroupMessage` into the live area, duplicating the row `LiveAgentPanel` already paints below the composer.

The fix is a per-tool ownership filter, not a render-time gate on the summary itself. `ToolGroupMessage.tsx` derives `inlineToolCalls` once before any compact decision: in the live phase (`isPending=true`) it drops panel-owned subagent entries (`running` / `background` `task_execution` without pending approval); in the committed phase the filter is a no-op. Pending-approval subagents pass through (the inline banner / queued marker is the only surface that lets users answer the prompt). Terminal subagents (`completed` / `failed` / `cancelled`) also pass through — `unregisterForeground`'s post-delete emit (#2 below) drops them from the panel snapshot the moment they finish, and the inline `SubagentScrollbackSummary` is the only surface that bridges the gap between snapshot-drop and parent-turn commit.

The filter is applied ONCE so every downstream decision (compact summary count + active-tool selection, sizing math, render map) sees the same list. Without that consolidation, mixed live groups (running subagent + sibling tool) leaked the panel-owned subagent into `CompactToolGroupDisplay` and reintroduced the duplicate UI the hand-off was designed to prevent.

`isPending?: boolean` stays on `ToolMessageProps` / `ToolGroupMessageProps`. `ToolGroupMessage` reads it for the filter; it does NOT gate the force-expand path — the terminal-subagent force-expand fires in BOTH live and committed phases so the summary lands in compact mode regardless of which side of commit the run terminated on (mirrors `SubagentExecutionRenderer`'s ungated terminal path and `mergeCompactToolGroups.isForceExpandGroup`'s no-isPending-gate preprocessing rule). The flag is forwarded through to `ToolMessage` for parity, but is currently inert at that layer — `SubagentExecutionRenderer` doesn't gate on it.

**Before:** running subagent finishes mid-turn → both `LiveAgentPanel` (synthesized row) AND `SubagentExecutionRenderer` (`✔ name: desc · stats`) try to render in the live area; in compact mixed groups the subagent could even win `CompactToolGroupDisplay`'s active-tool slot and override the header with `task × N`. In compact mode, terminal foreground subagents finishing mid-turn produced NOTHING inline until parent commit (the bridge promise from the design intent went unfulfilled).

**After:** running / background subagents are panel-only in the live phase; terminal subagents render their inline `SubagentScrollbackSummary` immediately in BOTH compact and non-compact modes, so the user keeps a record of the run from the moment it finishes; on commit the filter becomes a no-op and every terminal subagent's summary lands in scrollback as the persistent audit trail. Mixed compact groups now reflect only the inline-visible siblings.

## #2 — Swap order in `unregisterForeground` (delete-then-emit)

`useBackgroundTaskView`'s shared snapshot only refreshes on `statusChange`, and `unregisterForeground` previously fired BEFORE `agents.delete()`. The snapshot froze with the agent as `"running"` while `registry.get()` returned undefined. Concrete UX bug:

```
1. foreground subagent finishes
2. unregisterForeground fires statusChange (entry still in registry)
3. useBackgroundTaskView refresh → snapshot has the entry as running
4. agents.delete() → entry gone from registry
5. NO further statusChange → snapshot stays frozen
6. user opens BackgroundTasksDialog (↓) → list mode shows a "running" row
7. user presses x → registry.cancel(agentId) is a no-op (registry empty)
```

Result: dialog list shows a ghost row with cancel hints that don't work, while `LiveAgentPanel` already correctly synthesizes the row as a neutral terminal (because it has its own per-tick registry re-pull for activity refresh).

Fix at the source — **swap the order so `agents.delete()` runs BEFORE `emitStatusChange()`** (unique to `unregisterForeground`; complete / fail / cancel / finalize keep their existing emit-then-keep ordering since their entries stay in the registry as terminal). The status-change callback's `getAll()` now sees the post-delete state, snapshot consumers drop the row immediately, no per-consumer reconciliation needed.

> **Note:** an earlier version of this PR took a different approach — emit twice, with an explicit `context: { removed: boolean }` flag distinguishing pre-delete from post-delete. The merge with `main` (#3921) brought in the simpler single-emit / swap-order fix; this branch adopted that and reverted the additional API surface. The `BackgroundStatusChangeCallback` signature is unchanged (still `(entry?: BackgroundTaskEntry) => void`).

This also makes `LiveAgentPanel`'s synthesis path defense-in-depth — under normal operation the snapshot updates after the single post-delete emit, the agent leaves `entries`, and the panel renders no row. The synthesis still triggers in the rare case where a snapshot lands between the delete and the emit, but that's a sub-render race, not a sustained ghost.

## Test plan

```bash
npm run typecheck --workspace=packages/cli
npm run typecheck --workspace=packages/core
npx vitest run --no-coverage \
  packages/core/src/agents/background-tasks.test.ts \
  packages/cli/src/ui/components/background-view \
  packages/cli/src/ui/components/messages/ToolMessage.test.tsx \
  packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx \
  packages/cli/src/ui/utils/mergeCompactToolGroups.test.ts \
  packages/cli/src/ui/hooks/useBackgroundTaskView.test.ts
```

**Manual:**

- [ ] Invoke a foreground subagent (Task tool). Confirm:
  - Panel shows the row while running (○).
  - When it finishes mid-turn: panel evicts the row (post-delete emit), inline `SubagentScrollbackSummary` lands immediately so the run stays visible.
  - On parent commit: that same summary stays as the persistent record.
- [ ] Same flow but in compact mode with a sibling tool in the batch — compact header reflects the sibling alone (no `task × N` overriding the header). When the subagent finishes, the group force-expands inline so the summary lands without waiting for parent commit.
- [ ] Open BackgroundTasksDialog (↓) **right after** a foreground subagent finishes. Confirm: no ghost "running" row; the agent is gone from the list.

**Coverage delta:**

- `live (isPending) terminal subagent → renders summary inline` — locks the bridge between panel-snapshot drop and parent commit (ToolMessage.test.tsx).
- `compact mode: live mixed group filters panel-owned subagent out of count + active tool` — locks the once-derived `inlineToolCalls` consolidation (ToolGroupMessage.test.tsx).
- `compact mode: live group with completed subagent force-expands so the summary bridges the panel-snapshot drop` — locks the in-compact bridge for terminal subagents (ToolGroupMessage.test.tsx).
- `compact mode: live mixed group with terminal subagent + sibling force-expands and renders both` — covers the bridge inside mixed groups (ToolGroupMessage.test.tsx).
- `unregisterForeground emits status change after removing the entry` — confirms the swapped ordering and asserts `registry.get()` / `getAll()` both reflect the post-delete state inside the callback (background-tasks.test.ts; aligned with #3921).
- 4 compact-mode cases on `ToolGroupMessage.test.tsx` — committed-completed expands; live-running stays compact (group hidden when pure-panel-owned); live-completed force-expands (bridges); committed-failed expands.

194 passing tests across core + cli (background-tasks + background-view + ToolMessage + ToolGroupMessage + mergeCompactToolGroups + useBackgroundTaskView).


## Test results (local, 2026-05-08)

| Check | Command | Result |
|---|---|---|
| typecheck | `npm run typecheck` | ✅ exit 0 — cli / core / sdk / webui |
| lint (PR-touched files) | `npx eslint <7 files> --max-warnings 0` | ✅ exit 0, zero warnings |
| core tests | `npm run test -w @qwen-code/qwen-code-core` | ✅ 268 files, 6988 passed, 5 skipped |
| cli tests | `npm run test -w @qwen-code/qwen-code` | ✅ 322 files, 5163 passed, 7 skipped |

PR-touched test files (all passing):

- `core/src/agents/background-tasks.test.ts` — 52 tests
- `cli/src/ui/components/messages/ToolMessage.test.tsx` — 35 tests
- `cli/src/ui/components/messages/ToolGroupMessage.test.tsx` — 31 tests
- `cli/src/ui/utils/mergeCompactToolGroups.test.ts` — 27 tests

> Note: cli logs include a stray `Cannot find module '/app/cli.js'` from a child-process relaunch path (sandbox image expects the bundled binary at `/app/cli.js`). Pre-existing environmental noise, unrelated to this PR — vitest absorbs it and the runner exits 0.
