### PR TITLE
fix(core): foreground agent entry lingering in status bar after completion

### DIFF
--- a/packages/core/src/agents/background-tasks.test.ts
+++ b/packages/core/src/agents/background-tasks.test.ts
@@ -1078,10 +1078,13 @@ describe('BackgroundTaskRegistry', () => {
       expect(onRegister.mock.calls[0]![0].agentId).toBe('bg-fires-register-cb');
     });
 
-    it('unregisterForeground emits status change before removing the entry', () => {
-      // Mirrors the ordering used by complete/fail/cancel/finalize so a
-      // statusChange callback that re-reads `registry.get(agentId)` from
-      // inside the callback sees the entry across every terminal path.
+    it('unregisterForeground emits status change after removing the entry', () => {
+      // The entry is deleted from the Map before the status-change callback
+      // fires, so a callback that rebuilds its snapshot via getAll() no
+      // longer includes this entry. This ordering prevents the entry from
+      // lingering in React state with status='running' — the bug that
+      // caused "1 local agent" to stay visible after the foreground agent
+      // completed.
       registry.register({
         agentId: 'fg-unregister-order',
         description: 'sync agent',
@@ -1092,16 +1095,20 @@ describe('BackgroundTaskRegistry', () => {
       });
 
       let observedFromCallback: BackgroundTaskEntry | undefined;
+      let snapshotDuringCallback: BackgroundTaskEntry[] = [];
       registry.setStatusChangeCallback((entry) => {
         if (entry?.agentId === 'fg-unregister-order') {
           observedFromCallback = registry.get(entry.agentId);
+          snapshotDuringCallback = registry.getAll();
         }
       });
 
       registry.unregisterForeground('fg-unregister-order');
 
-      expect(observedFromCallback).toBeDefined();
-      expect(observedFromCallback!.agentId).toBe('fg-unregister-order');
+      // The entry has been deleted before the callback fires, so
+      // registry.get() returns undefined and getAll() omits it.
+      expect(observedFromCallback).toBeUndefined();
+      expect(snapshotDuringCallback).toEqual([]);
       expect(registry.get('fg-unregister-order')).toBeUndefined();
     });
 

--- a/packages/core/src/agents/background-tasks.ts
+++ b/packages/core/src/agents/background-tasks.ts
@@ -275,12 +275,14 @@ export class BackgroundTaskRegistry {
           `Background entries must terminate via complete/fail/finalizeCancelled.`,
       );
     }
-    // Emit before delete so any future BackgroundStatusChangeCallback that
-    // re-reads `registry.get(agentId)` from inside the callback sees the
-    // entry, matching the ordering used by complete/fail/cancel/finalize.
-    this.emitStatusChange(entry);
+    // Delete before emitting so the status-change callback (which rebuilds
+    // its snapshot via getAll()) no longer includes this entry. Emitting
+    // before delete caused the entry to linger in React state with
+    // status='running' because the callback's getAll() still saw it, and
+    // no second status-change fired after the deletion.
     this.agents.delete(agentId);
     debugLogger.info(`Unregistered foreground agent: ${agentId}`);
+    this.emitStatusChange(entry);
   }
 
   // See complete() for the cancelled → terminal path rationale.


### PR DESCRIPTION
## Summary

- What changed: Swapped the order of `emitStatusChange` and `agents.delete` in `BackgroundTaskRegistry.unregisterForeground()` — now delete-first, emit-second.
- Why it changed: The old order (emit before delete) caused the React refresh callback (`refresh()` → `getAll()`) to still see the foreground entry in the Map with `status='running'`. After deletion, no second status-change fired, so React state never updated. The entry lingered as "1 local agent" in the footer pill and the timer kept ticking in the dialog.
- Reviewer focus: The single-line swap in `background-tasks.ts` and the updated test assertion in `background-tasks.test.ts`.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/agents/background-tasks.test.ts   # 52 passed
  npm run build && npm run typecheck                                        # OK
  npm run bundle                                                            # OK
  ```
- Prompts / inputs used: "用Explore agent帮我找一下项目里有哪些vitest.config文件" (in both old and fixed versions via tmux TUI)
- Expected result: After the foreground sub-agent completes, the footer pill should not show "1 local agent" and the dialog timer should stop.
- Observed result:
  - **Old version (global qwen v0.15.7)**: Footer shows `YOLO 模式 · 1 local agent` after agent completes. Bug reproduced.
  - **Fixed version (node dist/cli.js)**: Footer shows `YOLO mode` with no "local agent" after agent completes. Bug fixed.
- Quickest reviewer verification path: Run `npm run bundle && node dist/cli.js --approval-mode yolo`, send a message that triggers a foreground agent, observe the footer pill disappears after the agent completes.
- Evidence:

  **Before (old version)** — agent completed but status bar still shows "1 local agent":
  ```
  │ Explore ● Completed │ Execution Summary: 1 tool uses · 22,030 tokens · 11.6s
  YOLO 模式 · 1 local agent
  ```

  **After (fixed version)** — agent completed, status bar clean:
  ```
  │ Explore ● Completed │ Execution Summary: 2 tool uses · 22,386 tokens · 13.3s
  YOLO mode
  ```

## Scope / Risk

- Main risk or tradeoff: The status-change callback now fires after the entry is deleted from the Map. Any callback that calls `registry.get(agentId)` during the event will get `undefined` instead of the entry. The current UI callback (`refreshFromRegistry = () => refresh()`) uses `getAll()` (not `get()`) and is unaffected.
- Not covered / not validated: Background agent completion path (uses `complete()` which keeps the entry in the Map — not affected by this change).
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:
- Tested on macOS (darwin) via tmux TUI with both old and fixed versions.
- Unit tests (52 passed) cover the registry logic; platform-specific behavior is not expected to differ.

## Linked Issues / Bugs

No linked issues

---
🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)