### PR TITLE
fix(cli): prevent ESC in background tasks dialog from cancelling running request

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -2153,7 +2153,12 @@ export const AppContainer = (props: AppContainerProps) => {
         }
 
         // Input is empty, cancel request immediately (no double-press needed)
-        if (streamingState === StreamingState.Responding) {
+        // Skip when a dialog (background tasks, etc.) is open — ESC should
+        // close the dialog, not cancel the running request.
+        if (
+          streamingState === StreamingState.Responding &&
+          !dialogsVisibleRef.current
+        ) {
           if (escapeTimerRef.current) {
             clearTimeout(escapeTimerRef.current);
             escapeTimerRef.current = null;


### PR DESCRIPTION
## Summary

- What changed: Added `dialogsVisibleRef.current` guard to the ESC → `cancelOngoingRequest` branch in `AppContainer.handleGlobalKeypress`.
- Why it changed: The global ESC handler lacked this guard (already present on the double-ESC rewind branch). When the background tasks dialog was open and the user pressed ESC to close it, the global handler also received the key and cancelled the running model request — because the input buffer was empty (InputPrompt swallows keys while the dialog is open) and `streamingState === Responding`.
- Reviewer focus: The 3-line condition change in `AppContainer.tsx` (line ~2155).

## Validation

- Commands run:
  ```bash
  npm run build && npm run typecheck  # OK
  npm run bundle                       # OK
  ```
- Prompts / inputs used: "用Explore agent帮我找一下项目里有哪些vitest.config文件" via tmux TUI
- Expected result: ESC inside the background tasks dialog should close the dialog only, not cancel the running model request.
- Observed result:
  - **Old version**: ESC inside dialog shows `● Request cancelled.` — request cancelled.
  - **Fixed version**: ESC inside dialog closes the dialog, model response continues and completes normally.
- Quickest reviewer verification path: Run `npm run bundle && node dist/cli.js --approval-mode yolo`, send a message that triggers a foreground agent, press Down to focus the pill → Enter to open dialog → ESC to close. The model response should NOT be cancelled.
- Evidence:

  **Before (old version)** — ESC in dialog cancels the request:
  ```
  ⠙ ... (esc to cancel)
  ● Request cancelled.
  ```

  **After (fixed version)** — ESC in dialog only closes the dialog, model completes:
  ```
  ✦ 项目中共有 11 个 vitest.config.ts 文件...
  (full response, no cancel)
  ```

## Scope / Risk

- Main risk or tradeoff: Minimal — adds a guard that is already used in the same handler for the double-ESC rewind branch. The `dialogsVisibleRef` is already maintained correctly by the `DialogManager` component.
- Not covered / not validated: Other dialogs (auth, model selector) — they should also be protected by the same guard, but the background tasks dialog is the most common case where this bug manifests.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:
- Tested on macOS via tmux TUI with both old and fixed versions.

## Linked Issues / Bugs

No linked issues

---
🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)