### PR TITLE
feat(skills): reload slash commands when SkillManager fires change event

### DIFF
--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -1070,6 +1070,63 @@ describe('useSlashCommandProcessor', () => {
         skillManagerSpy.mockRestore();
       }
     });
+
+    it('should register SkillManager listener after config initialization', async () => {
+      const removeListener = vi.fn();
+      const addChangeListener = vi.fn().mockReturnValue(removeListener);
+      const fakeSkillManager = { addChangeListener };
+      let initializedForConfig = false;
+      const skillManagerSpy = vi
+        .spyOn(mockConfig, 'getSkillManager')
+        .mockImplementation(() =>
+          initializedForConfig
+            ? (fakeSkillManager as unknown as ReturnType<
+                typeof mockConfig.getSkillManager
+              >)
+            : null,
+        );
+
+      try {
+        mockBuiltinLoadCommands.mockResolvedValue([]);
+        mockFileLoadCommands.mockResolvedValue([]);
+        mockMcpLoadCommands.mockResolvedValue([]);
+
+        const { rerender, unmount } = renderHook(
+          ({ isConfigInitialized }) => {
+            initializedForConfig = isConfigInitialized;
+            return useSlashCommandProcessor(
+              mockConfig,
+              mockSettings,
+              mockAddItem,
+              mockClearItems,
+              mockLoadHistory,
+              vi.fn(),
+              vi.fn(),
+              false,
+              vi.fn(),
+              { current: true },
+              vi.fn(),
+              createMockActions(),
+              new Map(),
+              isConfigInitialized,
+              null,
+            );
+          },
+          { initialProps: { isConfigInitialized: false } },
+        );
+
+        expect(addChangeListener).not.toHaveBeenCalled();
+
+        rerender({ isConfigInitialized: true });
+
+        await waitFor(() => expect(addChangeListener).toHaveBeenCalledTimes(1));
+
+        unmount();
+        expect(removeListener).toHaveBeenCalledTimes(1);
+      } finally {
+        skillManagerSpy.mockRestore();
+      }
+    });
   });
 
   describe('Slash Command Logging', () => {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -1007,6 +1007,69 @@ describe('useSlashCommandProcessor', () => {
 
       expect(abortSpy).toHaveBeenCalledTimes(1);
     });
+
+    it('should reload commands when SkillManager fires a change event', async () => {
+      const removeListener = vi.fn();
+      const addChangeListener = vi.fn().mockReturnValue(removeListener);
+      const fakeSkillManager = { addChangeListener };
+      const skillManagerSpy = vi
+        .spyOn(mockConfig, 'getSkillManager')
+        .mockReturnValue(
+          fakeSkillManager as unknown as ReturnType<
+            typeof mockConfig.getSkillManager
+          >,
+        );
+
+      try {
+        mockBuiltinLoadCommands.mockResolvedValue([]);
+        mockFileLoadCommands.mockResolvedValue([]);
+        mockMcpLoadCommands.mockResolvedValue([]);
+
+        const { unmount } = renderHook(() =>
+          useSlashCommandProcessor(
+            mockConfig,
+            mockSettings,
+            mockAddItem,
+            mockClearItems,
+            mockLoadHistory,
+            vi.fn(),
+            vi.fn(),
+            false,
+            vi.fn(),
+            { current: true },
+            vi.fn(),
+            createMockActions(),
+            new Map(),
+            true,
+            null,
+          ),
+        );
+
+        await waitFor(() => expect(addChangeListener).toHaveBeenCalledTimes(1));
+        // Initial CommandService.create() pass: BuiltinCommandLoader is
+        // constructed once. Firing the SkillManager listener bumps the
+        // reloadTrigger and the loader effect re-runs, constructing the
+        // builtin loader a second time — that is the observable signal
+        // that a reload happened.
+        await waitFor(() =>
+          expect(BuiltinCommandLoader).toHaveBeenCalledTimes(1),
+        );
+
+        const listener = addChangeListener.mock.calls[0][0] as () => void;
+        await act(async () => {
+          listener();
+        });
+
+        await waitFor(() =>
+          expect(BuiltinCommandLoader).toHaveBeenCalledTimes(2),
+        );
+
+        unmount();
+        expect(removeListener).toHaveBeenCalledTimes(1);
+      } finally {
+        skillManagerSpy.mockRestore();
+      }
+    });
   });
 
   describe('Slash Command Logging', () => {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.test.ts
@@ -1127,6 +1127,73 @@ describe('useSlashCommandProcessor', () => {
         skillManagerSpy.mockRestore();
       }
     });
+
+    it('should not publish model-invocable commands from an aborted reload', async () => {
+      const staleCommand = createTestCommand({
+        name: 'stale',
+        modelInvocable: true,
+      });
+      const freshCommand = createTestCommand({
+        name: 'fresh',
+        modelInvocable: true,
+      });
+      let resolveStaleLoad!: (commands: SlashCommand[]) => void;
+
+      mockBuiltinLoadCommands
+        .mockImplementationOnce(
+          () =>
+            new Promise<SlashCommand[]>((resolve) => {
+              resolveStaleLoad = resolve;
+            }),
+        )
+        .mockResolvedValueOnce([freshCommand]);
+      mockFileLoadCommands.mockResolvedValue([]);
+      mockMcpLoadCommands.mockResolvedValue([]);
+
+      const { rerender } = renderHook(
+        ({ isConfigInitialized }) =>
+          useSlashCommandProcessor(
+            mockConfig,
+            mockSettings,
+            mockAddItem,
+            mockClearItems,
+            mockLoadHistory,
+            vi.fn(),
+            vi.fn(),
+            false,
+            vi.fn(),
+            { current: true },
+            vi.fn(),
+            createMockActions(),
+            new Map(),
+            isConfigInitialized,
+            null,
+          ),
+        { initialProps: { isConfigInitialized: false } },
+      );
+
+      rerender({ isConfigInitialized: true });
+
+      await waitFor(() =>
+        expect(
+          mockConfig
+            .getModelInvocableCommandsProvider?.()?.()
+            .map((c) => c.name),
+        ).toEqual(['fresh']),
+      );
+
+      await act(async () => {
+        resolveStaleLoad([staleCommand]);
+      });
+
+      await waitFor(() =>
+        expect(
+          mockConfig
+            .getModelInvocableCommandsProvider?.()?.()
+            .map((c) => c.name),
+        ).toEqual(['fresh']),
+      );
+    });
   });
 
   describe('Slash Command Logging', () => {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -357,6 +357,23 @@ export const useSlashCommandProcessor = (
     };
   }, [config, reloadCommands]);
 
+  // SkillManager already rebuilds its own cache and notifies SkillTool
+  // (which re-runs `setTools()` so `<available_skills>` is fresh). The
+  // slash-command list is a separate consumer: SkillCommandLoader reads
+  // `listSkills()` once during CommandService.create(), so without this
+  // bridge a newly added SKILL.md never produces a `/<skill-name>` entry
+  // until restart. Bumping reloadTrigger re-runs the loader effect below
+  // and CommandService picks up the fresh skill list.
+  useEffect(() => {
+    const skillManager = config?.getSkillManager();
+    if (!skillManager) {
+      return;
+    }
+    return skillManager.addChangeListener(() => {
+      reloadCommands();
+    });
+  }, [config, reloadCommands]);
+
   useEffect(() => {
     const controller = new AbortController();
     const load = async () => {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -365,6 +365,9 @@ export const useSlashCommandProcessor = (
   // until restart. Bumping reloadTrigger re-runs the loader effect below
   // and CommandService picks up the fresh skill list.
   useEffect(() => {
+    if (!isConfigInitialized) {
+      return;
+    }
     const skillManager = config?.getSkillManager();
     if (!skillManager) {
       return;
@@ -372,7 +375,7 @@ export const useSlashCommandProcessor = (
     return skillManager.addChangeListener(() => {
       reloadCommands();
     });
-  }, [config, reloadCommands]);
+  }, [config, isConfigInitialized, reloadCommands]);
 
   useEffect(() => {
     const controller = new AbortController();

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -394,6 +394,10 @@ export const useSlashCommandProcessor = (
           controller.signal,
           disabled.length > 0 ? new Set(disabled) : undefined,
         );
+        // Avoid overwriting newer results from a subsequent effect run
+        if (controller.signal.aborted) {
+          return;
+        }
         // Register model-invocable commands provider so SkillTool can include
         // bundled skills, file commands, and MCP prompts in its description.
         if (config) {
@@ -441,10 +445,7 @@ export const useSlashCommandProcessor = (
             },
           );
         }
-        // Avoid overwriting newer results from a subsequent effect run
-        if (!controller.signal.aborted) {
-          setCommands(commandService.getCommandsForMode('interactive'));
-        }
+        setCommands(commandService.getCommandsForMode('interactive'));
       } catch (error) {
         debugLogger.error('Failed to load slash commands:', error);
       }


### PR DESCRIPTION
## Summary

- What changed: Subscribe `slashCommandProcessor` to `SkillManager.addChangeListener`. When skill files change (chokidar watcher → `SkillManager.refreshCache()` → `notifyChangeListeners`), the slash-command list now rebuilds via the existing `reloadCommands()` path, so `/<skill-name>` entries appear/disappear without restart.
- Why it changed: Today the watcher already refreshes `<available_skills>` (via `SkillTool.refreshSkills` → `setTools()`), but `SkillCommandLoader.loadCommands()` only runs once during `CommandService.create()`. Adding or editing a `SKILL.md` would update the model-facing tool description but leave the slash-command list stale until restart. Tracked in #3696 sub-task 2.
- Reviewer focus: The new `useEffect` in `slashCommandProcessor.ts` (mirrors the existing `IdeClient.addStatusChangeListener` pattern). `SkillManager.notifyChangeListeners` already provides per-listener 30s timeout and `Promise.allSettled` isolation, so no extra defensive code at the call site.

## Validation

- Commands run:
  ```bash
  npx vitest run --no-coverage \
    packages/cli/src/ui/hooks/slashCommandProcessor.test.ts \
    packages/cli/src/services/SkillCommandLoader.test.ts \
    packages/cli/src/services/BundledSkillLoader.test.ts \
    packages/cli/src/ui/commands/languageCommand.test.ts \
    packages/cli/src/ui/commands/extensionsCommand.test.ts \
    packages/cli/src/config/config.test.ts \
    packages/core/src/skills/skill-manager.test.ts \
    packages/core/src/skills/skill-load.test.ts \
    packages/core/src/skills/skill-activation.test.ts \
    packages/core/src/skills/symlinkScope.test.ts \
    packages/core/src/tools/skill.test.ts \
    packages/core/src/extension/extensionManager.test.ts \
    packages/core/src/core/coreToolScheduler.test.ts \
    packages/core/src/config/config.test.ts
  (cd packages/cli && npx tsc --noEmit)
  (cd packages/cli && npx eslint src/ui/hooks/slashCommandProcessor.ts src/ui/hooks/slashCommandProcessor.test.ts)
  ```
- Prompts / inputs used: New unit test mocks `getSkillManager().addChangeListener`, fires the registered listener, and asserts that `BuiltinCommandLoader` is constructed a second time (i.e. `CommandService.create()` re-ran). Unmount triggers the cleanup returned by `addChangeListener`.
- Expected result: All 14 listed test files pass; the new case exercises the hot-reload wiring; tsc and eslint clean.
- Observed result: 14 files / 746 cases passed (2 pre-existing skips); `tsc --noEmit` clean; `eslint` clean on changed files.
- Quickest reviewer verification path:
  1. `npx vitest run packages/cli/src/ui/hooks/slashCommandProcessor.test.ts` — the new case `should reload commands when SkillManager fires a change event` covers the wiring.
  2. Manual: in a running session, create `.qwen/skills/foo/SKILL.md` (frontmatter with `name: foo`, `description: test`, plus a body). `/foo` should appear in the slash-command list without restart.
- Evidence: `Test Files 14 passed | Tests 746 passed (2 skipped)` from the vitest runs above.

## Scope / Risk

- Main risk or tradeoff: A skill change now triggers a `CommandService.create()` rebuild on top of the existing `SkillTool.refreshSkills` + `setTools()`. Both run in parallel via `Promise.allSettled` inside `notifyChangeListeners`, and `SkillManager.scheduleRefresh()` already debounces watcher events at 150 ms, so a burst of file changes still yields one rebuild.
- Not covered / not validated: No CI integration test exercises the full chokidar → CommandService rebuild loop end-to-end; the manual path above is the recommended spot-check.
- Breaking changes / migration notes: None. Additive listener wiring; existing `IdeClient`-driven reload path is untouched.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- macOS (`npm run`-equivalent vitest/tsc/eslint) verified locally; other platforms not exercised in this iteration.

## Linked Issues / Bugs

Progress on #3696 (sub-task 2 of 6: Skill hot-reload improvements — propagate skill cache changes to dependent slash commands).
