### PR TITLE
feat(cli): attach remote-control to current TUI

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -521,6 +521,52 @@ describe('parseArguments', () => {
     expect(argv.includePartialMessages).toBe(true);
   });
 
+  it('should parse remote-control TUI attach flags', async () => {
+    process.argv = [
+      'node',
+      'script.js',
+      '--remote-control',
+      '--remote-control-host',
+      '127.0.0.1',
+      '--remote-control-port',
+      '0',
+      '--remote-control-token-ttl',
+      '60',
+    ];
+
+    const argv = await parseArguments();
+
+    expect(argv.remoteControl).toBe(true);
+    expect(argv.remoteControlHost).toBe('127.0.0.1');
+    expect(argv.remoteControlPort).toBe(0);
+    expect(argv.remoteControlTokenTtl).toBe(60);
+  });
+
+  it('should reject remote-control attach in non-interactive prompt mode', async () => {
+    process.argv = [
+      'node',
+      'script.js',
+      '--remote-control',
+      '--prompt',
+      'hello',
+    ];
+
+    const mockExit = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+    mockWriteStderrLine.mockClear();
+
+    await expect(parseArguments()).rejects.toThrow('process.exit called');
+
+    expect(mockWriteStderrLine).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '--remote-control attaches to the interactive TUI',
+      ),
+    );
+
+    mockExit.mockRestore();
+  });
+
   it('should allow --approval-mode without --yolo', async () => {
     process.argv = ['node', 'script.js', '--approval-mode', 'auto-edit'];
     const argv = await parseArguments();
@@ -705,6 +751,31 @@ describe('loadCliConfig', () => {
     expect(lspInstance).toBeDefined();
     expect(lspInstance?.discoverAndPrepare).toHaveBeenCalledTimes(1);
     expect(lspInstance?.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('should pass remote-control attach config into core config', async () => {
+    process.argv = [
+      'node',
+      'script.js',
+      '--remote-control',
+      '--remote-control-port',
+      '0',
+      '--remote-control-token-ttl',
+      '90',
+    ];
+    const argv = await parseArguments();
+    const settings: Settings = {};
+
+    const config = await loadCliConfig(settings, argv);
+
+    expect(config.getRemoteControlConfig()).toEqual({
+      enabled: true,
+      host: undefined,
+      port: 0,
+      allowLan: false,
+      noUi: false,
+      tokenTtlSeconds: 90,
+    });
   });
 
   describe('Proxy configuration', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -166,6 +166,12 @@ export interface CliArgs {
   jsonFd?: number | undefined;
   jsonFile?: string | undefined;
   inputFile?: string | undefined;
+  remoteControl?: boolean | undefined;
+  remoteControlHost?: string | undefined;
+  remoteControlPort?: number | undefined;
+  remoteControlAllowLan?: boolean | undefined;
+  remoteControlNoUi?: boolean | undefined;
+  remoteControlTokenTtl?: number | undefined;
 }
 
 function normalizeOutputFormat(
@@ -477,6 +483,38 @@ export async function parseArguments(): Promise<CliArgs> {
             'File path for receiving remote input commands (bidirectional sync). ' +
             'An external process writes JSONL commands; the TUI watches and processes them.',
         })
+        .option('remote-control', {
+          type: 'boolean',
+          description:
+            'Attach a browser/mobile remote-control server to the current interactive TUI session.',
+        })
+        .option('remote-control-host', {
+          type: 'string',
+          description:
+            'Host interface for --remote-control. Defaults to 127.0.0.1.',
+        })
+        .option('remote-control-port', {
+          type: 'number',
+          description:
+            'Port for --remote-control. Defaults to 7373; use 0 for a random free port.',
+        })
+        .option('remote-control-allow-lan', {
+          type: 'boolean',
+          default: false,
+          description:
+            'Allow --remote-control to bind to non-loopback interfaces.',
+        })
+        .option('remote-control-no-ui', {
+          type: 'boolean',
+          default: false,
+          description:
+            'Disable the built-in browser UI for --remote-control and serve only the API.',
+        })
+        .option('remote-control-token-ttl', {
+          type: 'number',
+          description:
+            'Pairing token TTL for --remote-control in seconds. Defaults to 300.',
+        })
         .option('continue', {
           alias: 'c',
           type: 'boolean',
@@ -603,6 +641,20 @@ export async function parseArguments(): Promise<CliArgs> {
           // --resume accepts either a session UUID or a custom title
           if (argv['jsonFd'] != null && argv['jsonFile'] != null) {
             return '--json-fd and --json-file are mutually exclusive. Use one or the other.';
+          }
+          if (
+            argv['remoteControl'] &&
+            (argv['prompt'] ||
+              (hasPositionalQuery && !argv['promptInteractive']))
+          ) {
+            return '--remote-control attaches to the interactive TUI and cannot be combined with non-interactive prompt mode.';
+          }
+          if (
+            argv['remoteControl'] &&
+            (argv['inputFormat'] === 'stream-json' ||
+              argv['outputFormat'] === OutputFormat.STREAM_JSON)
+          ) {
+            return '--remote-control attaches to the interactive TUI and cannot be combined with stream-json mode.';
           }
           return true;
         }),
@@ -1322,6 +1374,16 @@ export async function loadCliConfig(
     jsonFd: argv.jsonFd,
     jsonFile: argv.jsonFile ?? settings.dualOutput?.jsonFile,
     inputFile: argv.inputFile ?? settings.dualOutput?.inputFile,
+    remoteControl: argv.remoteControl
+      ? {
+          enabled: true,
+          host: argv.remoteControlHost,
+          port: argv.remoteControlPort,
+          allowLan: argv.remoteControlAllowLan,
+          noUi: argv.remoteControlNoUi,
+          tokenTtlSeconds: argv.remoteControlTokenTtl,
+        }
+      : undefined,
     // Precedence: explicit CLI flag > settings file > default(true).
     // NOTE: do NOT set a yargs default for `chat-recording`, otherwise argv will
     // always be true and the settings file can never disable recording.

--- a/packages/cli/src/dualOutput/DualOutputContext.tsx
+++ b/packages/cli/src/dualOutput/DualOutputContext.tsx
@@ -5,14 +5,43 @@
  */
 
 import { createContext, useContext } from 'react';
-import type { DualOutputBridge } from './DualOutputBridge.js';
+import type {
+  ServerGeminiStreamEvent,
+  ToolCallRequestInfo,
+  ToolCallResponseInfo,
+} from '@qwen-code/qwen-code-core';
+import type { Part } from '@google/genai';
+
+export interface DualOutputBridgeLike {
+  readonly isConnected: boolean;
+  processEvent(event: ServerGeminiStreamEvent): void;
+  startAssistantMessage(): void;
+  finalizeAssistantMessage(): void;
+  emitUserMessage(parts: Part[]): void;
+  emitToolResult(
+    request: ToolCallRequestInfo,
+    response: ToolCallResponseInfo,
+  ): void;
+  emitPermissionRequest(
+    requestId: string,
+    toolName: string,
+    toolUseId: string,
+    input: unknown,
+    blockedPath?: string | null,
+  ): void;
+  emitControlResponse(requestId: string, allowed: boolean): void;
+  emitControlError(requestId: string, message: string): void;
+  emitSystemMessage(subtype: string, data?: unknown): void;
+}
 
 /**
  * React context for the dual output bridge.
  * Provides access to the sidecar JSON event emitter throughout the
  * interactive UI component tree.
  */
-export const DualOutputContext = createContext<DualOutputBridge | null>(null);
+export const DualOutputContext = createContext<DualOutputBridgeLike | null>(
+  null,
+);
 
 /**
  * Hook to access the dual output bridge from any component or hook
@@ -20,6 +49,6 @@ export const DualOutputContext = createContext<DualOutputBridge | null>(null);
  *
  * Returns null when dual output is not enabled (no --json-fd or --json-file).
  */
-export function useDualOutput(): DualOutputBridge | null {
+export function useDualOutput(): DualOutputBridgeLike | null {
   return useContext(DualOutputContext);
 }

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -86,6 +86,12 @@ import { DualOutputBridge } from './dualOutput/DualOutputBridge.js';
 import { DualOutputContext } from './dualOutput/DualOutputContext.js';
 import { RemoteInputWatcher } from './remoteInput/RemoteInputWatcher.js';
 import { RemoteInputContext } from './remoteInput/RemoteInputContext.js';
+import {
+  MutableDualOutputBridge,
+  MutableRemoteInputController,
+  TuiRemoteControlManager,
+} from './remoteControl/TuiRemoteControlManager.js';
+import type { RemoteControlServerInfo } from './remoteControl/RemoteControlServer.js';
 import { installTerminalRedrawOptimizer } from './ui/utils/terminalRedrawOptimizer.js';
 import { installSynchronizedOutput } from './ui/utils/synchronizedOutput.js';
 
@@ -206,6 +212,29 @@ function installInteractiveSignalHandlers(wasRaw: boolean): () => void {
   };
 }
 
+function writeRemoteControlStartupInfo(
+  info: RemoteControlServerInfo,
+  allowLan: boolean,
+): void {
+  writeStderrLine('[Remote Control] Attached to current TUI session');
+  writeStderrLine(`[Remote Control] URL: ${info.url}`);
+  if (info.lanUrls.length > 0) {
+    writeStderrLine('[Remote Control] LAN URLs:');
+    for (const url of info.lanUrls) {
+      writeStderrLine(`[Remote Control]   ${url}`);
+    }
+  }
+  writeStderrLine(`[Remote Control] Pairing token: ${info.pairingToken}`);
+  writeStderrLine(
+    `[Remote Control] Pairing token expires at: ${info.pairingExpiresAt}`,
+  );
+  if (allowLan) {
+    writeStderrLine(
+      '[Remote Control] LAN mode is enabled. Only share the pairing token with trusted devices on this network.',
+    );
+  }
+}
+
 export async function startInteractiveUI(
   config: Config,
   settings: LoadedSettings,
@@ -267,6 +296,44 @@ export async function startInteractiveUI(
     }
   }
 
+  const dualOutputProvider = new MutableDualOutputBridge();
+  if (dualOutputBridge) {
+    dualOutputProvider.addBridge(dualOutputBridge);
+  }
+  const remoteInputProvider = new MutableRemoteInputController();
+  if (remoteInputWatcher) {
+    remoteInputProvider.addController(remoteInputWatcher);
+  }
+  const remoteControlManager = new TuiRemoteControlManager(config, {
+    version,
+    dualOutput: dualOutputProvider,
+    remoteInput: remoteInputProvider,
+  });
+  const remoteControlConfig = config.getRemoteControlConfig?.();
+  if (remoteControlConfig?.enabled) {
+    try {
+      const result = await remoteControlManager.start({
+        host:
+          remoteControlConfig.host ??
+          (remoteControlConfig.allowLan ? '0.0.0.0' : undefined),
+        port: remoteControlConfig.port,
+        allowLan: remoteControlConfig.allowLan,
+        noUi: remoteControlConfig.noUi,
+        tokenTtlMs:
+          Math.max(1, remoteControlConfig.tokenTtlSeconds ?? 300) * 1000,
+      });
+      writeRemoteControlStartupInfo(
+        result.info,
+        remoteControlConfig.allowLan ?? false,
+      );
+    } catch (err) {
+      debugLogger.error('Failed to initialize TUI remote-control bridge:', err);
+      writeStderrLine(
+        `Warning: remote control disabled — ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
   // Drain the early-captured input exactly once, before any React rendering.
   // Must be outside any component/effect so StrictMode's mount/cleanup/remount
   // always reads from the same stable prop rather than the (now empty) module buffer.
@@ -277,8 +344,8 @@ export async function startInteractiveUI(
     const kittyProtocolStatus = useKittyKeyboardProtocol();
     const nodeMajorVersion = parseInt(process.versions.node.split('.')[0], 10);
     return (
-      <RemoteInputContext.Provider value={remoteInputWatcher}>
-        <DualOutputContext.Provider value={dualOutputBridge}>
+      <RemoteInputContext.Provider value={remoteInputProvider}>
+        <DualOutputContext.Provider value={dualOutputProvider}>
           <SettingsContext.Provider value={settings}>
             <KeypressProvider
               kittyProtocolEnabled={kittyProtocolStatus.enabled}
@@ -301,6 +368,7 @@ export async function startInteractiveUI(
                         startupWarnings={startupWarnings}
                         version={version}
                         initializationResult={initializationResult}
+                        remoteControl={remoteControlManager}
                       />
                     </BackgroundTaskViewProvider>
                   </AgentViewProvider>
@@ -341,6 +409,7 @@ export async function startInteractiveUI(
   }
 
   registerCleanup(async () => {
+    await remoteControlManager.shutdown();
     remoteInputWatcher?.shutdown();
     await dualOutputBridge?.shutdown();
     // Explicitly disable the Kitty keyboard protocol before unmounting Ink so

--- a/packages/cli/src/remoteControl/RemoteControlServer.ts
+++ b/packages/cli/src/remoteControl/RemoteControlServer.ts
@@ -12,6 +12,7 @@ import type { PermissionMode } from '../nonInteractive/types.js';
 import { PairingManager } from './PairingManager.js';
 import {
   SessionRegistry,
+  type RemoteControlSessionRegistry,
   type SessionRegistryOptions,
 } from './SessionRegistry.js';
 import { APP_JS, INDEX_HTML, STYLES_CSS } from './staticAssets.js';
@@ -26,6 +27,7 @@ import {
   makeEnvelope,
   parseRemoteEnvelope,
   requireStringField,
+  type RemoteCapabilities,
   type RemoteEnvelope,
   type RemoteHistoryPayload,
   type RemoteSessionCreatePayload,
@@ -49,8 +51,9 @@ export interface RemoteControlServerOptions {
   cliEntryPath: string;
   defaultModel?: string;
   defaultPermissionMode?: PermissionMode;
-  registry?: SessionRegistry;
+  registry?: RemoteControlSessionRegistry;
   registryOptions?: Partial<SessionRegistryOptions>;
+  capabilities?: Partial<RemoteCapabilities>;
 }
 
 export interface RemoteControlServerInfo {
@@ -91,7 +94,7 @@ export class RemoteControlServer {
       | 'tokenTtlMs'
     >;
   private readonly pairing = new PairingManager();
-  private readonly registry: SessionRegistry;
+  private readonly registry: RemoteControlSessionRegistry;
   private readonly clients = new Map<WebSocket, ClientState>();
   private readonly authFailures = new Map<string, number[]>();
   private server: http.Server | null = null;
@@ -115,6 +118,7 @@ export class RemoteControlServer {
       defaultPermissionMode: options.defaultPermissionMode,
       registry: options.registry,
       registryOptions: options.registryOptions,
+      capabilities: options.capabilities,
     };
     this.assertHostAllowed();
     this.registry =
@@ -350,10 +354,10 @@ export class RemoteControlServer {
     const issued = isClientToken ? null : this.pairing.issueClientToken();
     this.send(ws, 'auth/result', {
       ok: true,
-      capabilities: buildCapabilities(),
       clientToken: issued?.token,
       clientTokenExpiresAt: issued?.expiresAt,
       sessions: this.registry.listSessions(),
+      capabilities: buildCapabilities(this.options.capabilities),
     });
   }
 

--- a/packages/cli/src/remoteControl/SessionRegistry.ts
+++ b/packages/cli/src/remoteControl/SessionRegistry.ts
@@ -54,9 +54,34 @@ interface RemoteSessionRecord {
   runner: RemoteSessionRunnerLike;
 }
 
-type SessionEventListener = (sessionId: string, event: RemoteEvent) => void;
+export type SessionEventListener = (
+  sessionId: string,
+  event: RemoteEvent,
+) => void;
 
-export class SessionRegistry {
+export interface RemoteControlSessionRegistry {
+  subscribe(listener: SessionEventListener): () => void;
+  createSession(payload?: RemoteSessionCreatePayload): RemoteSessionSnapshot;
+  listSessions(): RemoteSessionSnapshot[];
+  getSession(sessionId: string): RemoteSessionSnapshot;
+  replay(
+    sessionId: string,
+    since?: number,
+  ): {
+    events: RemoteEvent[];
+    truncated: boolean;
+  };
+  submit(sessionId: string, text: string): void;
+  respondToTool(sessionId: string, payload: RemoteToolResponsePayload): void;
+  interrupt(sessionId: string): string;
+  setModel(sessionId: string, model: string): string;
+  setPermissionMode(sessionId: string, mode: PermissionMode): string;
+  getContextUsage(sessionId: string, showDetails?: boolean): string;
+  closeSession(sessionId: string): void;
+  closeAll(): void;
+}
+
+export class SessionRegistry implements RemoteControlSessionRegistry {
   private readonly sessions = new Map<string, RemoteSessionRecord>();
   private readonly listeners = new Set<SessionEventListener>();
   private readonly options: SessionRegistryOptions;

--- a/packages/cli/src/remoteControl/TuiRemoteBridge.ts
+++ b/packages/cli/src/remoteControl/TuiRemoteBridge.ts
@@ -1,0 +1,215 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { Config } from '@qwen-code/qwen-code-core';
+import { createDebugLogger } from '@qwen-code/qwen-code-core';
+import { DualOutputBridge } from '../dualOutput/DualOutputBridge.js';
+import type { DualOutputBridgeLike } from '../dualOutput/DualOutputContext.js';
+import { RemoteInputWatcher } from '../remoteInput/RemoteInputWatcher.js';
+import type { RemoteInputController } from '../remoteInput/RemoteInputContext.js';
+import type { PermissionMode } from '../nonInteractive/types.js';
+import { RemoteControlServer } from './RemoteControlServer.js';
+import type { RemoteControlServerInfo } from './RemoteControlServer.js';
+import { TuiSessionRegistry } from './TuiSessionRegistry.js';
+
+const debugLogger = createDebugLogger('TUI_REMOTE_CONTROL');
+
+export interface TuiRemoteBridgeOptions {
+  host?: string;
+  port?: number;
+  allowLan?: boolean;
+  noUi?: boolean;
+  tokenTtlMs?: number;
+  version?: string;
+}
+
+export class CompositeDualOutputBridge implements DualOutputBridgeLike {
+  constructor(private readonly bridges: DualOutputBridgeLike[]) {}
+
+  get isConnected(): boolean {
+    return this.bridges.some((bridge) => bridge.isConnected);
+  }
+
+  processEvent(...args: Parameters<DualOutputBridgeLike['processEvent']>) {
+    this.forEachConnected((bridge) => bridge.processEvent(...args));
+  }
+
+  startAssistantMessage(
+    ...args: Parameters<DualOutputBridgeLike['startAssistantMessage']>
+  ) {
+    this.forEachConnected((bridge) => bridge.startAssistantMessage(...args));
+  }
+
+  finalizeAssistantMessage(
+    ...args: Parameters<DualOutputBridgeLike['finalizeAssistantMessage']>
+  ) {
+    this.forEachConnected((bridge) => bridge.finalizeAssistantMessage(...args));
+  }
+
+  emitUserMessage(
+    ...args: Parameters<DualOutputBridgeLike['emitUserMessage']>
+  ) {
+    this.forEachConnected((bridge) => bridge.emitUserMessage(...args));
+  }
+
+  emitToolResult(...args: Parameters<DualOutputBridgeLike['emitToolResult']>) {
+    this.forEachConnected((bridge) => bridge.emitToolResult(...args));
+  }
+
+  emitPermissionRequest(
+    ...args: Parameters<DualOutputBridgeLike['emitPermissionRequest']>
+  ) {
+    this.forEachConnected((bridge) => bridge.emitPermissionRequest(...args));
+  }
+
+  emitControlResponse(
+    ...args: Parameters<DualOutputBridgeLike['emitControlResponse']>
+  ) {
+    this.forEachConnected((bridge) => bridge.emitControlResponse(...args));
+  }
+
+  emitControlError(
+    ...args: Parameters<DualOutputBridgeLike['emitControlError']>
+  ) {
+    this.forEachConnected((bridge) => bridge.emitControlError(...args));
+  }
+
+  emitSystemMessage(
+    ...args: Parameters<DualOutputBridgeLike['emitSystemMessage']>
+  ) {
+    this.forEachConnected((bridge) => bridge.emitSystemMessage(...args));
+  }
+
+  private forEachConnected(fn: (bridge: DualOutputBridgeLike) => void): void {
+    for (const bridge of this.bridges) {
+      if (bridge.isConnected) {
+        fn(bridge);
+      }
+    }
+  }
+}
+
+export class CompositeRemoteInputController implements RemoteInputController {
+  constructor(private readonly controllers: RemoteInputController[]) {}
+
+  setSubmitFn(...args: Parameters<RemoteInputController['setSubmitFn']>) {
+    for (const controller of this.controllers) {
+      controller.setSubmitFn(...args);
+    }
+  }
+
+  setConfirmationHandler(
+    ...args: Parameters<RemoteInputController['setConfirmationHandler']>
+  ) {
+    for (const controller of this.controllers) {
+      controller.setConfirmationHandler(...args);
+    }
+  }
+
+  setControlHandler(
+    ...args: Parameters<RemoteInputController['setControlHandler']>
+  ) {
+    for (const controller of this.controllers) {
+      controller.setControlHandler(...args);
+    }
+  }
+
+  notifyIdle(...args: Parameters<RemoteInputController['notifyIdle']>) {
+    for (const controller of this.controllers) {
+      controller.notifyIdle(...args);
+    }
+  }
+}
+
+export class TuiRemoteBridge {
+  private readonly tmpDir: string;
+  private readonly inputFilePath: string;
+  private readonly outputFilePath: string;
+  private readonly registry: TuiSessionRegistry;
+  private readonly dualOutputBridge: DualOutputBridge;
+  private readonly remoteInputWatcher: RemoteInputWatcher;
+  private readonly server: RemoteControlServer;
+  private started = false;
+
+  constructor(config: Config, options: TuiRemoteBridgeOptions = {}) {
+    this.tmpDir = mkdtempSync(path.join(os.tmpdir(), 'qwen-remote-control-'));
+    this.inputFilePath = path.join(this.tmpDir, 'input.jsonl');
+    this.outputFilePath = path.join(this.tmpDir, 'output.jsonl');
+    writeFileSync(this.inputFilePath, '', 'utf-8');
+    writeFileSync(this.outputFilePath, '', 'utf-8');
+
+    this.registry = new TuiSessionRegistry({
+      sessionId: config.getSessionId(),
+      cwd: config.getTargetDir(),
+      model: config.getModel(),
+      permissionMode: String(config.getApprovalMode()) as PermissionMode,
+      inputFilePath: this.inputFilePath,
+      outputFilePath: this.outputFilePath,
+    });
+    this.dualOutputBridge = new DualOutputBridge(
+      config,
+      { filePath: this.outputFilePath },
+      { version: options.version },
+    );
+    this.remoteInputWatcher = new RemoteInputWatcher(this.inputFilePath);
+    this.server = new RemoteControlServer({
+      host: options.host,
+      port: options.port,
+      allowLan: options.allowLan,
+      noUi: options.noUi,
+      tokenTtlMs: options.tokenTtlMs,
+      cwd: config.getTargetDir(),
+      cliEntryPath: findCliEntryPath(),
+      defaultModel: config.getModel(),
+      defaultPermissionMode: String(config.getApprovalMode()) as PermissionMode,
+      registry: this.registry,
+      capabilities: {
+        canCreateWorkerSession: false,
+        canAttachCurrentTui: true,
+      },
+    });
+  }
+
+  async start(): Promise<RemoteControlServerInfo> {
+    if (this.started) {
+      return this.server.getInfo();
+    }
+    const info = await this.server.start();
+    await this.registry.checkForOutput();
+    this.started = true;
+    return info;
+  }
+
+  getDualOutputBridge(): DualOutputBridgeLike {
+    return this.dualOutputBridge;
+  }
+
+  getRemoteInputController(): RemoteInputController {
+    return this.remoteInputWatcher;
+  }
+
+  async shutdown(): Promise<void> {
+    try {
+      await this.dualOutputBridge.shutdown();
+      await this.registry.checkForOutput();
+      await this.server.stop();
+    } catch (error) {
+      debugLogger.debug('TUI remote-control shutdown error:', error);
+    } finally {
+      this.remoteInputWatcher.shutdown();
+      this.registry.shutdown();
+      rmSync(this.tmpDir, { recursive: true, force: true });
+    }
+  }
+}
+
+function findCliEntryPath(): string {
+  const mainModule = process.argv[1];
+  return mainModule ? path.resolve(mainModule) : process.cwd();
+}

--- a/packages/cli/src/remoteControl/TuiRemoteControlManager.test.ts
+++ b/packages/cli/src/remoteControl/TuiRemoteControlManager.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { DualOutputBridgeLike } from '../dualOutput/DualOutputContext.js';
+import type { RemoteInputController } from '../remoteInput/RemoteInputContext.js';
+import {
+  MutableDualOutputBridge,
+  MutableRemoteInputController,
+} from './TuiRemoteControlManager.js';
+
+function createDualOutputBridge(
+  overrides: Partial<DualOutputBridgeLike> = {},
+): DualOutputBridgeLike {
+  return {
+    isConnected: true,
+    processEvent: vi.fn(),
+    startAssistantMessage: vi.fn(),
+    finalizeAssistantMessage: vi.fn(),
+    emitUserMessage: vi.fn(),
+    emitToolResult: vi.fn(),
+    emitPermissionRequest: vi.fn(),
+    emitControlResponse: vi.fn(),
+    emitControlError: vi.fn(),
+    emitSystemMessage: vi.fn(),
+    ...overrides,
+  };
+}
+
+function createRemoteInputController(): RemoteInputController {
+  return {
+    setSubmitFn: vi.fn(),
+    setConfirmationHandler: vi.fn(),
+    setControlHandler: vi.fn(),
+    notifyIdle: vi.fn(),
+  };
+}
+
+describe('MutableDualOutputBridge', () => {
+  it('fans events out to connected bridges and supports removal', () => {
+    const mutable = new MutableDualOutputBridge();
+    const connected = createDualOutputBridge();
+    const disconnected = createDualOutputBridge({ isConnected: false });
+
+    const removeConnected = mutable.addBridge(connected);
+    mutable.addBridge(disconnected);
+    mutable.startAssistantMessage();
+
+    expect(connected.startAssistantMessage).toHaveBeenCalled();
+    expect(disconnected.startAssistantMessage).not.toHaveBeenCalled();
+    expect(mutable.isConnected).toBe(true);
+
+    removeConnected();
+    expect(mutable.isConnected).toBe(false);
+  });
+});
+
+describe('MutableRemoteInputController', () => {
+  it('applies existing handlers to controllers added later', () => {
+    const mutable = new MutableRemoteInputController();
+    const submit = vi.fn();
+    const confirmation = vi.fn();
+    const control = vi.fn();
+    mutable.setSubmitFn(submit);
+    mutable.setConfirmationHandler(confirmation);
+    mutable.setControlHandler(control);
+
+    const controller = createRemoteInputController();
+    mutable.addController(controller);
+
+    expect(controller.setSubmitFn).toHaveBeenCalledWith(submit);
+    expect(controller.setConfirmationHandler).toHaveBeenCalledWith(
+      confirmation,
+    );
+    expect(controller.setControlHandler).toHaveBeenCalledWith(control);
+  });
+
+  it('fans notifyIdle out to all controllers', () => {
+    const mutable = new MutableRemoteInputController();
+    const first = createRemoteInputController();
+    const second = createRemoteInputController();
+    mutable.addController(first);
+    mutable.addController(second);
+
+    mutable.notifyIdle();
+
+    expect(first.notifyIdle).toHaveBeenCalled();
+    expect(second.notifyIdle).toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/remoteControl/TuiRemoteControlManager.ts
+++ b/packages/cli/src/remoteControl/TuiRemoteControlManager.ts
@@ -1,0 +1,244 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '@qwen-code/qwen-code-core';
+import type { DualOutputBridgeLike } from '../dualOutput/DualOutputContext.js';
+import type {
+  ConfirmationHandler,
+  ControlHandler,
+  SubmitFn,
+} from '../remoteInput/RemoteInputWatcher.js';
+import type { RemoteInputController } from '../remoteInput/RemoteInputContext.js';
+import { TuiRemoteBridge } from './TuiRemoteBridge.js';
+import type { RemoteControlServerInfo } from './RemoteControlServer.js';
+
+export class MutableDualOutputBridge implements DualOutputBridgeLike {
+  private readonly bridges = new Set<DualOutputBridgeLike>();
+
+  get isConnected(): boolean {
+    return [...this.bridges].some((bridge) => bridge.isConnected);
+  }
+
+  addBridge(bridge: DualOutputBridgeLike): () => void {
+    this.bridges.add(bridge);
+    return () => {
+      this.bridges.delete(bridge);
+    };
+  }
+
+  processEvent(...args: Parameters<DualOutputBridgeLike['processEvent']>) {
+    this.forEachConnected((bridge) => bridge.processEvent(...args));
+  }
+
+  startAssistantMessage(
+    ...args: Parameters<DualOutputBridgeLike['startAssistantMessage']>
+  ) {
+    this.forEachConnected((bridge) => bridge.startAssistantMessage(...args));
+  }
+
+  finalizeAssistantMessage(
+    ...args: Parameters<DualOutputBridgeLike['finalizeAssistantMessage']>
+  ) {
+    this.forEachConnected((bridge) => bridge.finalizeAssistantMessage(...args));
+  }
+
+  emitUserMessage(
+    ...args: Parameters<DualOutputBridgeLike['emitUserMessage']>
+  ) {
+    this.forEachConnected((bridge) => bridge.emitUserMessage(...args));
+  }
+
+  emitToolResult(...args: Parameters<DualOutputBridgeLike['emitToolResult']>) {
+    this.forEachConnected((bridge) => bridge.emitToolResult(...args));
+  }
+
+  emitPermissionRequest(
+    ...args: Parameters<DualOutputBridgeLike['emitPermissionRequest']>
+  ) {
+    this.forEachConnected((bridge) => bridge.emitPermissionRequest(...args));
+  }
+
+  emitControlResponse(
+    ...args: Parameters<DualOutputBridgeLike['emitControlResponse']>
+  ) {
+    this.forEachConnected((bridge) => bridge.emitControlResponse(...args));
+  }
+
+  emitControlError(
+    ...args: Parameters<DualOutputBridgeLike['emitControlError']>
+  ) {
+    this.forEachConnected((bridge) => bridge.emitControlError(...args));
+  }
+
+  emitSystemMessage(
+    ...args: Parameters<DualOutputBridgeLike['emitSystemMessage']>
+  ) {
+    this.forEachConnected((bridge) => bridge.emitSystemMessage(...args));
+  }
+
+  private forEachConnected(fn: (bridge: DualOutputBridgeLike) => void): void {
+    for (const bridge of this.bridges) {
+      if (bridge.isConnected) {
+        fn(bridge);
+      }
+    }
+  }
+}
+
+export class MutableRemoteInputController implements RemoteInputController {
+  private readonly controllers = new Set<RemoteInputController>();
+  private submitFn: SubmitFn | null = null;
+  private confirmationHandler: ConfirmationHandler | null = null;
+  private controlHandler: ControlHandler | null = null;
+
+  addController(controller: RemoteInputController): () => void {
+    this.controllers.add(controller);
+    if (this.submitFn) {
+      controller.setSubmitFn(this.submitFn);
+    }
+    if (this.confirmationHandler) {
+      controller.setConfirmationHandler(this.confirmationHandler);
+    }
+    if (this.controlHandler) {
+      controller.setControlHandler(this.controlHandler);
+    }
+    return () => {
+      this.controllers.delete(controller);
+      controller.setConfirmationHandler(() => {});
+      controller.setControlHandler(() => {});
+    };
+  }
+
+  setSubmitFn(fn: SubmitFn): void {
+    this.submitFn = fn;
+    for (const controller of this.controllers) {
+      controller.setSubmitFn(fn);
+    }
+  }
+
+  setConfirmationHandler(fn: ConfirmationHandler): void {
+    this.confirmationHandler = fn;
+    for (const controller of this.controllers) {
+      controller.setConfirmationHandler(fn);
+    }
+  }
+
+  setControlHandler(fn: ControlHandler): void {
+    this.controlHandler = fn;
+    for (const controller of this.controllers) {
+      controller.setControlHandler(fn);
+    }
+  }
+
+  notifyIdle(): void {
+    for (const controller of this.controllers) {
+      controller.notifyIdle();
+    }
+  }
+}
+
+export interface TuiRemoteControlStartOptions {
+  host?: string;
+  port?: number;
+  allowLan?: boolean;
+  noUi?: boolean;
+  tokenTtlMs?: number;
+}
+
+export interface TuiRemoteControlStartResult {
+  info: RemoteControlServerInfo;
+  alreadyStarted: boolean;
+}
+
+export interface TuiRemoteControlStatus {
+  running: boolean;
+  info?: RemoteControlServerInfo;
+}
+
+export class TuiRemoteControlManager {
+  private bridge: TuiRemoteBridge | null = null;
+  private info: RemoteControlServerInfo | null = null;
+  private removeDualOutputBridge: (() => void) | null = null;
+  private removeRemoteInputController: (() => void) | null = null;
+
+  constructor(
+    private readonly config: Config,
+    private readonly options: {
+      version?: string;
+      dualOutput: MutableDualOutputBridge;
+      remoteInput: MutableRemoteInputController;
+    },
+  ) {}
+
+  async start(
+    startOptions: TuiRemoteControlStartOptions = {},
+  ): Promise<TuiRemoteControlStartResult> {
+    if (this.bridge && this.info) {
+      return {
+        info: this.info,
+        alreadyStarted: true,
+      };
+    }
+
+    const bridge = new TuiRemoteBridge(this.config, {
+      host: startOptions.host,
+      port: startOptions.port,
+      allowLan: startOptions.allowLan,
+      noUi: startOptions.noUi,
+      tokenTtlMs: startOptions.tokenTtlMs,
+      version: this.options.version,
+    });
+
+    try {
+      const info = await bridge.start();
+      this.removeDualOutputBridge = this.options.dualOutput.addBridge(
+        bridge.getDualOutputBridge(),
+      );
+      this.removeRemoteInputController = this.options.remoteInput.addController(
+        bridge.getRemoteInputController(),
+      );
+      this.bridge = bridge;
+      this.info = info;
+      return {
+        info,
+        alreadyStarted: false,
+      };
+    } catch (error) {
+      await bridge.shutdown();
+      throw error;
+    }
+  }
+
+  getStatus(): TuiRemoteControlStatus {
+    return this.info
+      ? {
+          running: true,
+          info: this.info,
+        }
+      : {
+          running: false,
+        };
+  }
+
+  async stop(): Promise<boolean> {
+    if (!this.bridge) {
+      return false;
+    }
+    const bridge = this.bridge;
+    this.bridge = null;
+    this.info = null;
+    this.removeDualOutputBridge?.();
+    this.removeDualOutputBridge = null;
+    this.removeRemoteInputController?.();
+    this.removeRemoteInputController = null;
+    await bridge.shutdown();
+    return true;
+  }
+
+  async shutdown(): Promise<void> {
+    await this.stop();
+  }
+}

--- a/packages/cli/src/remoteControl/TuiSessionRegistry.test.ts
+++ b/packages/cli/src/remoteControl/TuiSessionRegistry.test.ts
@@ -1,0 +1,154 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { TuiSessionRegistry } from './TuiSessionRegistry.js';
+
+describe('TuiSessionRegistry', () => {
+  let tmpDir: string;
+  let inputFile: string;
+  let outputFile: string;
+  let registry: TuiSessionRegistry | null = null;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-tui-registry-'));
+    inputFile = path.join(tmpDir, 'input.jsonl');
+    outputFile = path.join(tmpDir, 'output.jsonl');
+    fs.writeFileSync(inputFile, '');
+    fs.writeFileSync(outputFile, '');
+  });
+
+  afterEach(() => {
+    registry?.shutdown();
+    registry = null;
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('exposes the current TUI as a single attachable session', () => {
+    registry = new TuiSessionRegistry({
+      sessionId: 'session-1',
+      cwd: tmpDir,
+      model: 'qwen3-coder',
+      permissionMode: 'default',
+      inputFilePath: inputFile,
+      outputFilePath: outputFile,
+    });
+
+    expect(registry.listSessions()).toMatchObject([
+      {
+        id: 'session-1',
+        cwd: tmpDir,
+        model: 'qwen3-coder',
+        permissionMode: 'default',
+        mode: 'tui',
+      },
+    ]);
+    expect(registry.createSession({ mode: 'tui' }).id).toBe('session-1');
+    expect(() => registry?.createSession({ mode: 'worker' })).toThrow(
+      'Unsupported remote session mode',
+    );
+  });
+
+  it('writes remote commands into the TUI input file', () => {
+    registry = new TuiSessionRegistry({
+      sessionId: 'session-1',
+      cwd: tmpDir,
+      inputFilePath: inputFile,
+      outputFilePath: outputFile,
+    });
+
+    registry.submit('session-1', 'hello');
+    registry.respondToTool('session-1', {
+      requestId: 'req-1',
+      behavior: 'deny',
+    });
+    registry.interrupt('session-1');
+    registry.setModel('session-1', 'qwen3-coder');
+    registry.setPermissionMode('session-1', 'auto-edit');
+
+    const lines = fs
+      .readFileSync(inputFile, 'utf-8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    expect(lines[0]).toEqual({ type: 'submit', text: 'hello' });
+    expect(lines[1]).toEqual({
+      type: 'confirmation_response',
+      request_id: 'req-1',
+      allowed: false,
+    });
+    expect(lines[2]?.['type']).toBe('interrupt');
+    expect(lines[3]).toMatchObject({
+      type: 'set_model',
+      model: 'qwen3-coder',
+    });
+    expect(lines[4]).toMatchObject({
+      type: 'set_permission_mode',
+      mode: 'auto-edit',
+    });
+  });
+
+  it('maps dual-output lines into remote-control events and session state', async () => {
+    registry = new TuiSessionRegistry({
+      sessionId: 'session-1',
+      cwd: tmpDir,
+      inputFilePath: inputFile,
+      outputFilePath: outputFile,
+    });
+    const listener = vi.fn();
+    registry.subscribe(listener);
+
+    fs.appendFileSync(
+      outputFile,
+      JSON.stringify({
+        type: 'control_request',
+        request_id: 'req-1',
+        request: {
+          subtype: 'can_use_tool',
+          tool_name: 'read_file',
+          tool_use_id: 'tool-1',
+          input: { path: 'README.md' },
+        },
+      }) +
+        '\n' +
+        JSON.stringify({ type: 'result', subtype: 'success' }) +
+        '\n',
+    );
+
+    await registry.checkForOutput();
+    const replay = registry.replay('session-1');
+    expect(replay.events.map((event) => event.type)).toContain(
+      'control/request',
+    );
+    expect(registry.getSession('session-1').state).toBe('idle');
+    expect(listener).toHaveBeenCalled();
+  });
+
+  it('buffers incomplete dual-output lines until the newline arrives', async () => {
+    registry = new TuiSessionRegistry({
+      sessionId: 'session-1',
+      cwd: tmpDir,
+      inputFilePath: inputFile,
+      outputFilePath: outputFile,
+    });
+
+    fs.appendFileSync(outputFile, '{"type":"result"');
+    await registry.checkForOutput();
+    expect(registry.replay('session-1').events).not.toContainEqual(
+      expect.objectContaining({ type: 'event/append' }),
+    );
+
+    fs.appendFileSync(outputFile, ',"subtype":"success"}\n');
+    await registry.checkForOutput();
+    expect(registry.replay('session-1').events).toContainEqual(
+      expect.objectContaining({ type: 'event/append' }),
+    );
+  });
+});

--- a/packages/cli/src/remoteControl/TuiSessionRegistry.ts
+++ b/packages/cli/src/remoteControl/TuiSessionRegistry.ts
@@ -1,0 +1,387 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  appendFileSync,
+  createReadStream,
+  statSync,
+  unwatchFile,
+  watchFile,
+} from 'node:fs';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import type { PermissionMode } from '../nonInteractive/types.js';
+import { EventLog } from './EventLog.js';
+import {
+  isRecord,
+  type RemoteEvent,
+  type RemoteSessionCreatePayload,
+  type RemoteSessionSnapshot,
+  type RemoteSessionState,
+  type RemoteToolResponsePayload,
+} from './protocol.js';
+import type {
+  RemoteControlSessionRegistry,
+  SessionEventListener,
+} from './SessionRegistry.js';
+
+export interface TuiSessionRegistryOptions {
+  sessionId: string;
+  cwd: string;
+  model?: string;
+  permissionMode?: PermissionMode;
+  inputFilePath: string;
+  outputFilePath: string;
+  pollIntervalMs?: number;
+}
+
+export class TuiSessionRegistry implements RemoteControlSessionRegistry {
+  private readonly log = new EventLog();
+  private readonly listeners = new Set<SessionEventListener>();
+  private readonly inputFilePath: string;
+  private readonly outputFilePath: string;
+  private readonly pollIntervalMs: number;
+  private snapshot: RemoteSessionSnapshot;
+  private bytesRead = 0;
+  private pendingOutput = '';
+  private reading = false;
+  private active = true;
+
+  constructor(options: TuiSessionRegistryOptions) {
+    const now = new Date().toISOString();
+    this.inputFilePath = options.inputFilePath;
+    this.outputFilePath = options.outputFilePath;
+    this.pollIntervalMs = options.pollIntervalMs ?? 250;
+    this.snapshot = {
+      id: options.sessionId,
+      cwd: options.cwd,
+      model: options.model,
+      permissionMode: options.permissionMode,
+      mode: 'tui',
+      state: 'starting',
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.append('session/state', this.getSession(options.sessionId));
+    this.startWatchingOutput();
+  }
+
+  subscribe(listener: SessionEventListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  createSession(
+    payload: RemoteSessionCreatePayload = {},
+  ): RemoteSessionSnapshot {
+    if (payload.mode && payload.mode !== 'tui') {
+      throw new Error(`Unsupported remote session mode: ${payload.mode}`);
+    }
+    if (payload.cwd && path.resolve(payload.cwd) !== path.resolve(this.cwd)) {
+      throw new Error('Attached TUI sessions cannot change working directory');
+    }
+    if (payload.name) {
+      this.snapshot = {
+        ...this.snapshot,
+        name: payload.name,
+      };
+      this.touch();
+    }
+    if (payload.model) {
+      this.setModel(this.snapshot.id, payload.model);
+    }
+    if (payload.permissionMode) {
+      this.setPermissionMode(this.snapshot.id, payload.permissionMode);
+    }
+    this.setState('idle');
+    return this.getSession(this.snapshot.id);
+  }
+
+  listSessions(): RemoteSessionSnapshot[] {
+    return [this.getSession(this.snapshot.id)];
+  }
+
+  getSession(sessionId: string): RemoteSessionSnapshot {
+    this.assertSession(sessionId);
+    return { ...this.snapshot };
+  }
+
+  replay(
+    sessionId: string,
+    since?: number,
+  ): {
+    events: RemoteEvent[];
+    truncated: boolean;
+  } {
+    this.assertSession(sessionId);
+    return this.log.replay(since);
+  }
+
+  submit(sessionId: string, text: string): void {
+    this.assertSession(sessionId);
+    if (!text.trim()) {
+      throw new Error('Prompt text is required');
+    }
+    this.writeInputCommand({ type: 'submit', text });
+    this.setState('working');
+    this.append('event/append', { type: 'remote_user_submit', text });
+  }
+
+  respondToTool(sessionId: string, payload: RemoteToolResponsePayload): void {
+    this.assertSession(sessionId);
+    this.writeInputCommand({
+      type: 'confirmation_response',
+      request_id: payload.requestId,
+      allowed: payload.behavior === 'allow',
+    });
+    this.setState('working');
+  }
+
+  interrupt(sessionId: string): string {
+    this.assertSession(sessionId);
+    const requestId = randomUUID();
+    this.writeInputCommand({ type: 'interrupt', request_id: requestId });
+    this.setState('interrupted');
+    return requestId;
+  }
+
+  setModel(sessionId: string, model: string): string {
+    this.assertSession(sessionId);
+    if (!model.trim()) {
+      throw new Error('Model is required');
+    }
+    const requestId = randomUUID();
+    this.snapshot = { ...this.snapshot, model };
+    this.touch();
+    this.writeInputCommand({ type: 'set_model', request_id: requestId, model });
+    this.append('session/state', this.getSession(sessionId));
+    return requestId;
+  }
+
+  setPermissionMode(sessionId: string, mode: PermissionMode): string {
+    this.assertSession(sessionId);
+    const requestId = randomUUID();
+    this.snapshot = { ...this.snapshot, permissionMode: mode };
+    this.touch();
+    this.writeInputCommand({
+      type: 'set_permission_mode',
+      request_id: requestId,
+      mode,
+    });
+    this.append('session/state', this.getSession(sessionId));
+    return requestId;
+  }
+
+  getContextUsage(sessionId: string, _showDetails: boolean = false): string {
+    this.assertSession(sessionId);
+    const requestId = randomUUID();
+    this.append('control/response', {
+      type: 'control_response',
+      response: {
+        subtype: 'error',
+        request_id: requestId,
+        error: 'Context usage is not available for attached TUI sessions yet.',
+      },
+    });
+    return requestId;
+  }
+
+  closeSession(sessionId: string): void {
+    this.assertSession(sessionId);
+    this.append('event/append', {
+      type: 'remote_session_close_ignored',
+      message: 'Attached TUI sessions are detached, not terminated.',
+    });
+  }
+
+  closeAll(): void {
+    // The remote server must not terminate the current interactive terminal.
+  }
+
+  shutdown(): void {
+    this.active = false;
+    unwatchFile(this.outputFilePath);
+  }
+
+  checkForOutput(): Promise<void> {
+    return this.readNewOutput();
+  }
+
+  private get cwd(): string {
+    return this.snapshot.cwd;
+  }
+
+  private startWatchingOutput(): void {
+    try {
+      this.bytesRead = statSync(this.outputFilePath).size;
+    } catch {
+      this.bytesRead = 0;
+    }
+
+    watchFile(this.outputFilePath, { interval: this.pollIntervalMs }, () => {
+      if (!this.active) return;
+      void this.readNewOutput();
+    });
+  }
+
+  private readNewOutput(): Promise<void> {
+    if (!this.active || this.reading) return Promise.resolve();
+
+    let currentSize: number;
+    try {
+      currentSize = statSync(this.outputFilePath).size;
+    } catch {
+      return Promise.resolve();
+    }
+
+    if (currentSize < this.bytesRead) {
+      this.bytesRead = 0;
+    }
+    if (currentSize <= this.bytesRead) {
+      return Promise.resolve();
+    }
+
+    this.reading = true;
+    const chunks: string[] = [];
+    const stream = createReadStream(this.outputFilePath, {
+      start: this.bytesRead,
+      end: currentSize - 1,
+      encoding: 'utf-8',
+    });
+
+    return new Promise<void>((resolve) => {
+      stream.on('data', (chunk) => {
+        chunks.push(String(chunk));
+      });
+      stream.on('error', (error) => {
+        this.append('error', { message: error.message });
+        this.reading = false;
+        resolve();
+      });
+      stream.on('end', () => {
+        const text = this.pendingOutput + chunks.join('');
+        const lines = text.split(/\r?\n/);
+        this.pendingOutput = lines.pop() ?? '';
+        for (const line of lines) {
+          this.handleOutputLine(line);
+        }
+        this.bytesRead = currentSize;
+        this.reading = false;
+        resolve();
+      });
+    });
+  }
+
+  private handleOutputLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    try {
+      this.handleOutputMessage(JSON.parse(trimmed));
+    } catch (error) {
+      this.append('error', {
+        message:
+          error instanceof Error
+            ? error.message
+            : `Failed to parse TUI output line: ${trimmed}`,
+      });
+    }
+  }
+
+  private handleOutputMessage(message: unknown): void {
+    if (!isRecord(message)) {
+      this.append('event/append', message);
+      return;
+    }
+
+    if (message['type'] === 'control_request') {
+      const request = message as Record<string, unknown>;
+      const body = isRecord(request['request']) ? request['request'] : {};
+      if (body['subtype'] === 'can_use_tool') {
+        this.setState('waiting_for_approval');
+      }
+      this.append('control/request', request);
+      return;
+    }
+
+    if (message['type'] === 'control_response') {
+      this.append('control/response', message);
+      return;
+    }
+
+    if (message['type'] === 'system' && message['subtype'] === 'session_end') {
+      this.setState('closed');
+      this.append('event/append', message);
+      return;
+    }
+
+    if (
+      message['type'] === 'system' &&
+      message['subtype'] === 'session_start'
+    ) {
+      this.setState('idle');
+      this.append('event/append', message);
+      return;
+    }
+
+    if (
+      message['type'] === 'user' ||
+      message['type'] === 'assistant' ||
+      message['type'] === 'stream_event' ||
+      message['type'] === 'system'
+    ) {
+      this.setState('working');
+    }
+
+    if (message['type'] === 'result') {
+      this.setState('idle');
+    }
+
+    this.append('event/append', message);
+  }
+
+  private setState(state: RemoteSessionState, lastError?: string): void {
+    const previousState = this.snapshot.state;
+    this.snapshot = {
+      ...this.snapshot,
+      state,
+      updatedAt: new Date().toISOString(),
+      ...(lastError && { lastError }),
+    };
+    if (previousState !== state || lastError) {
+      this.append('session/state', this.getSession(this.snapshot.id));
+    }
+  }
+
+  private touch(): void {
+    this.snapshot = {
+      ...this.snapshot,
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  private append<TPayload>(
+    type: string,
+    payload: TPayload,
+  ): RemoteEvent<TPayload> {
+    const event = this.log.append(this.snapshot.id, type, payload);
+    for (const listener of this.listeners) {
+      listener(this.snapshot.id, event);
+    }
+    return event;
+  }
+
+  private writeInputCommand(command: Record<string, unknown>): void {
+    appendFileSync(this.inputFilePath, `${JSON.stringify(command)}\n`, {
+      encoding: 'utf-8',
+    });
+  }
+
+  private assertSession(sessionId: string): void {
+    if (sessionId !== this.snapshot.id) {
+      throw new Error(`Unknown remote session: ${sessionId}`);
+    }
+  }
+}

--- a/packages/cli/src/remoteControl/index.ts
+++ b/packages/cli/src/remoteControl/index.ts
@@ -7,6 +7,13 @@
 export { RemoteControlServer } from './RemoteControlServer.js';
 export { SessionRegistry } from './SessionRegistry.js';
 export { RemoteSessionRunner } from './RemoteSessionRunner.js';
+export { TuiRemoteBridge } from './TuiRemoteBridge.js';
+export {
+  MutableDualOutputBridge,
+  MutableRemoteInputController,
+  TuiRemoteControlManager,
+} from './TuiRemoteControlManager.js';
+export { TuiSessionRegistry } from './TuiSessionRegistry.js';
 export { EventLog } from './EventLog.js';
 export { PairingManager } from './PairingManager.js';
 export * from './protocol.js';

--- a/packages/cli/src/remoteControl/protocol.ts
+++ b/packages/cli/src/remoteControl/protocol.ts
@@ -18,7 +18,7 @@ export const DEFAULT_MAX_PAYLOAD_BYTES = 1024 * 1024;
 export const DEFAULT_MAX_CLIENTS = 5;
 export const DEFAULT_EVENT_LOG_LIMIT = 1000;
 
-export type RemoteSessionMode = 'worker';
+export type RemoteSessionMode = 'worker' | 'tui';
 
 export type RemoteSessionState =
   | 'starting'
@@ -104,17 +104,19 @@ export type RemoteChildMessage =
   | Record<string, unknown>;
 
 export interface RemoteCapabilities {
-  canCreateWorkerSession: true;
-  canAttachCurrentTui: false;
-  canStreamEvents: true;
-  canReplayHistory: true;
-  canApproveTools: true;
-  canInterrupt: true;
-  canSetModel: true;
-  canSetPermissionMode: true;
+  canCreateWorkerSession: boolean;
+  canAttachCurrentTui: boolean;
+  canStreamEvents: boolean;
+  canReplayHistory: boolean;
+  canApproveTools: boolean;
+  canInterrupt: boolean;
+  canSetModel: boolean;
+  canSetPermissionMode: boolean;
 }
 
-export function buildCapabilities(): RemoteCapabilities {
+export function buildCapabilities(
+  overrides: Partial<RemoteCapabilities> = {},
+): RemoteCapabilities {
   return {
     canCreateWorkerSession: true,
     canAttachCurrentTui: false,
@@ -124,6 +126,7 @@ export function buildCapabilities(): RemoteCapabilities {
     canInterrupt: true,
     canSetModel: true,
     canSetPermissionMode: true,
+    ...overrides,
   };
 }
 

--- a/packages/cli/src/remoteControl/staticAssets.ts
+++ b/packages/cli/src/remoteControl/staticAssets.ts
@@ -221,6 +221,7 @@ export const APP_JS = `const protocolVersion = 1;
 let socket;
 let clientToken = localStorage.getItem('qwenRemoteClientToken') || '';
 let activeSessionId = null;
+let capabilities = {};
 let authenticated = false;
 let authTimer = null;
 const sessions = new Map();
@@ -314,6 +315,15 @@ function renderSessions() {
   }
 }
 
+function applyCapabilities() {
+  const canCreateWorkerSession = capabilities.canCreateWorkerSession !== false;
+  for (const id of ['session-name', 'cwd', 'model', 'permission-mode']) {
+    document.getElementById(id).disabled = !canCreateWorkerSession;
+  }
+  const create = document.getElementById('create');
+  create.textContent = canCreateWorkerSession ? 'New session' : 'Attach current TUI';
+}
+
 function handleApproval(message) {
   const wrapper = document.createElement('div');
   wrapper.className = 'entry approval';
@@ -342,8 +352,14 @@ function handleMessage(envelope) {
       localStorage.setItem('qwenRemoteClientToken', clientToken);
       tokenInput.value = clientToken;
     }
+    capabilities = envelope.payload.capabilities || {};
+    applyCapabilities();
     setStatus('Connected');
     for (const session of envelope.payload.sessions || []) sessions.set(session.id, session);
+    if (!activeSessionId && capabilities.canAttachCurrentTui && sessions.size === 1) {
+      activeSessionId = sessions.values().next().value.id;
+      send('session/attach', { since: 0 }, activeSessionId);
+    }
     renderSessions();
     return;
   }
@@ -416,6 +432,16 @@ document.getElementById('connect').addEventListener('click', () => {
 });
 
 document.getElementById('create').addEventListener('click', () => {
+  if (capabilities.canCreateWorkerSession === false) {
+    const first = sessions.values().next().value;
+    if (first) {
+      activeSessionId = first.id;
+      log.replaceChildren();
+      send('session/attach', { since: 0 }, activeSessionId);
+      renderSessions();
+    }
+    return;
+  }
   send('session/create', {
     name: document.getElementById('session-name').value.trim() || undefined,
     cwd: document.getElementById('cwd').value.trim() || undefined,

--- a/packages/cli/src/remoteInput/RemoteInputContext.tsx
+++ b/packages/cli/src/remoteInput/RemoteInputContext.tsx
@@ -5,9 +5,20 @@
  */
 
 import { createContext, useContext } from 'react';
-import type { RemoteInputWatcher } from './RemoteInputWatcher.js';
+import type {
+  ConfirmationHandler,
+  ControlHandler,
+  SubmitFn,
+} from './RemoteInputWatcher.js';
 
-export const RemoteInputContext = createContext<RemoteInputWatcher | null>(
+export interface RemoteInputController {
+  setSubmitFn(fn: SubmitFn): void;
+  setConfirmationHandler(fn: ConfirmationHandler): void;
+  setControlHandler(fn: ControlHandler): void;
+  notifyIdle(): void;
+}
+
+export const RemoteInputContext = createContext<RemoteInputController | null>(
   null,
 );
 export const useRemoteInput = () => useContext(RemoteInputContext);

--- a/packages/cli/src/remoteInput/RemoteInputWatcher.test.ts
+++ b/packages/cli/src/remoteInput/RemoteInputWatcher.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { ApprovalMode } from '@qwen-code/qwen-code-core';
 import { RemoteInputWatcher } from './RemoteInputWatcher.js';
 
 describe('RemoteInputWatcher', () => {
@@ -67,6 +68,36 @@ describe('RemoteInputWatcher', () => {
     expect(handler).toHaveBeenCalledWith('req-7', true);
   });
 
+  it('dispatches control commands immediately', async () => {
+    watcher = new RemoteInputWatcher(inputFile);
+    const handler = vi.fn();
+    watcher.setControlHandler(handler);
+
+    fs.appendFileSync(
+      inputFile,
+      JSON.stringify({ type: 'interrupt' }) +
+        '\n' +
+        JSON.stringify({
+          type: 'set_permission_mode',
+          mode: ApprovalMode.AUTO_EDIT,
+        }) +
+        '\n' +
+        JSON.stringify({ type: 'set_model', model: 'qwen3-coder' }) +
+        '\n',
+    );
+
+    await watcher.checkForNewInput();
+    expect(handler).toHaveBeenNthCalledWith(1, { type: 'interrupt' });
+    expect(handler).toHaveBeenNthCalledWith(2, {
+      type: 'set_permission_mode',
+      mode: ApprovalMode.AUTO_EDIT,
+    });
+    expect(handler).toHaveBeenNthCalledWith(3, {
+      type: 'set_model',
+      model: 'qwen3-coder',
+    });
+  });
+
   it('retries queued submits when the TUI signals it has become idle', async () => {
     watcher = new RemoteInputWatcher(inputFile);
 
@@ -112,6 +143,22 @@ describe('RemoteInputWatcher', () => {
 
     await watcher.checkForNewInput();
     expect(submitted).toEqual(['after-bad-line']);
+  });
+
+  it('buffers incomplete JSONL commands until a newline arrives', async () => {
+    watcher = new RemoteInputWatcher(inputFile);
+    const submitted: string[] = [];
+    watcher.setSubmitFn((text) => {
+      submitted.push(text);
+    });
+
+    fs.appendFileSync(inputFile, '{"type":"submit"');
+    await watcher.checkForNewInput();
+    expect(submitted).toEqual([]);
+
+    fs.appendFileSync(inputFile, ',"text":"after-newline"}\n');
+    await watcher.checkForNewInput();
+    expect(submitted).toEqual(['after-newline']);
   });
 
   it('stops watching after shutdown', async () => {

--- a/packages/cli/src/remoteInput/RemoteInputWatcher.ts
+++ b/packages/cli/src/remoteInput/RemoteInputWatcher.ts
@@ -5,8 +5,8 @@
  */
 
 import { createReadStream, watchFile, unwatchFile, statSync } from 'node:fs';
-import { createInterface } from 'node:readline';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
+import type { ApprovalMode } from '@qwen-code/qwen-code-core';
 
 const debugLogger = createDebugLogger('REMOTE_INPUT');
 
@@ -21,7 +21,10 @@ const debugLogger = createDebugLogger('REMOTE_INPUT');
  */
 export type RemoteInputCommand =
   | { type: 'submit'; text: string }
-  | { type: 'confirmation_response'; request_id: string; allowed: boolean };
+  | { type: 'confirmation_response'; request_id: string; allowed: boolean }
+  | { type: 'interrupt' }
+  | { type: 'set_permission_mode'; mode: ApprovalMode }
+  | { type: 'set_model'; model: string };
 
 /**
  * Callback invoked when a `confirmation_response` command is read.
@@ -36,6 +39,13 @@ export type SubmitFn = (
   query: string,
 ) => Promise<boolean | void> | boolean | void;
 
+export type ControlHandler = (
+  command: Extract<
+    RemoteInputCommand,
+    { type: 'interrupt' | 'set_permission_mode' | 'set_model' }
+  >,
+) => Promise<void> | void;
+
 /**
  * Watches a JSONL file for remote input commands and calls the registered
  * submit function when new commands arrive.
@@ -47,10 +57,12 @@ export type SubmitFn = (
 export class RemoteInputWatcher {
   private submitFn: SubmitFn | null = null;
   private confirmationHandler: ConfirmationHandler | null = null;
+  private controlHandler: ControlHandler | null = null;
   private queue: Array<Extract<RemoteInputCommand, { type: 'submit' }>> = [];
   private processing = false;
   private active = true;
   private bytesRead = 0;
+  private pendingInput = '';
   private reading = false;
   private filePath: string;
   private retryTimer: ReturnType<typeof setTimeout> | null = null;
@@ -78,6 +90,10 @@ export class RemoteInputWatcher {
    */
   setConfirmationHandler(fn: ConfirmationHandler): void {
     this.confirmationHandler = fn;
+  }
+
+  setControlHandler(fn: ControlHandler): void {
+    this.controlHandler = fn;
   }
 
   /**
@@ -128,62 +144,96 @@ export class RemoteInputWatcher {
       return Promise.resolve();
     }
 
+    if (currentSize < this.bytesRead) {
+      this.bytesRead = 0;
+      this.pendingInput = '';
+    }
+
     if (currentSize <= this.bytesRead) return Promise.resolve();
 
     this.reading = true;
+    const chunks: string[] = [];
     const stream = createReadStream(this.filePath, {
       start: this.bytesRead,
+      end: currentSize - 1,
       encoding: 'utf-8',
-    });
-    const rl = createInterface({ input: stream, crlfDelay: Infinity });
-
-    rl.on('line', (line) => {
-      const trimmed = line.trim();
-      if (!trimmed) return;
-      try {
-        const cmd = JSON.parse(trimmed);
-        // confirmation_response is dispatched immediately rather than queued:
-        // a pending tool call is blocking and the response must reach
-        // onConfirm without waiting for any earlier `submit` to finish.
-        if (
-          cmd &&
-          cmd.type === 'confirmation_response' &&
-          typeof cmd.request_id === 'string' &&
-          typeof cmd.allowed === 'boolean'
-        ) {
-          debugLogger.debug(
-            `RemoteInput: confirmation_response for ${cmd.request_id} (allowed=${cmd.allowed})`,
-          );
-          this.confirmationHandler?.(cmd.request_id, cmd.allowed);
-        } else if (
-          cmd &&
-          cmd.type === 'submit' &&
-          typeof cmd.text === 'string'
-        ) {
-          debugLogger.debug(
-            `RemoteInput: queued command: ${cmd.text.slice(0, 50)}...`,
-          );
-          this.queue.push(
-            cmd as Extract<RemoteInputCommand, { type: 'submit' }>,
-          );
-        } else {
-          debugLogger.warn(
-            `RemoteInput: unknown command type: ${String(cmd?.type)}`,
-          );
-        }
-      } catch (_err) {
-        debugLogger.warn(`RemoteInput: failed to parse line: ${trimmed}`);
-      }
     });
 
     return new Promise<void>((resolve) => {
-      rl.on('close', () => {
+      stream.on('data', (chunk) => {
+        chunks.push(String(chunk));
+      });
+      stream.on('error', (error) => {
+        debugLogger.warn(`RemoteInput: failed to read input: ${error.message}`);
+        this.reading = false;
+        resolve();
+      });
+      stream.on('end', () => {
+        const text = this.pendingInput + chunks.join('');
+        const lines = text.split(/\r?\n/);
+        this.pendingInput = lines.pop() ?? '';
+        for (const line of lines) {
+          this.handleLine(line);
+        }
         this.bytesRead = currentSize;
         this.reading = false;
         this.processQueue();
         resolve();
       });
     });
+  }
+
+  private handleLine(line: string): void {
+    const trimmed = line.trim();
+    if (!trimmed) return;
+    try {
+      const cmd = JSON.parse(trimmed);
+      // confirmation_response is dispatched immediately rather than queued:
+      // a pending tool call is blocking and the response must reach
+      // onConfirm without waiting for any earlier `submit` to finish.
+      if (
+        cmd &&
+        cmd.type === 'confirmation_response' &&
+        typeof cmd.request_id === 'string' &&
+        typeof cmd.allowed === 'boolean'
+      ) {
+        debugLogger.debug(
+          `RemoteInput: confirmation_response for ${cmd.request_id} (allowed=${cmd.allowed})`,
+        );
+        this.confirmationHandler?.(cmd.request_id, cmd.allowed);
+      } else if (cmd && cmd.type === 'submit' && typeof cmd.text === 'string') {
+        debugLogger.debug(
+          `RemoteInput: queued command: ${cmd.text.slice(0, 50)}...`,
+        );
+        this.queue.push(cmd as Extract<RemoteInputCommand, { type: 'submit' }>);
+      } else if (cmd && cmd.type === 'interrupt') {
+        this.controlHandler?.({ type: 'interrupt' });
+      } else if (
+        cmd &&
+        cmd.type === 'set_permission_mode' &&
+        typeof cmd.mode === 'string'
+      ) {
+        this.controlHandler?.({
+          type: 'set_permission_mode',
+          mode: cmd.mode as ApprovalMode,
+        });
+      } else if (
+        cmd &&
+        cmd.type === 'set_model' &&
+        typeof cmd.model === 'string'
+      ) {
+        this.controlHandler?.({
+          type: 'set_model',
+          model: cmd.model,
+        });
+      } else {
+        debugLogger.warn(
+          `RemoteInput: unknown command type: ${String(cmd?.type)}`,
+        );
+      }
+    } catch (_err) {
+      debugLogger.warn(`RemoteInput: failed to parse line: ${trimmed}`);
+    }
   }
 
   private async processQueue(): Promise<void> {

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -44,6 +44,7 @@ import { permissionsCommand } from '../ui/commands/permissionsCommand.js';
 import { trustCommand } from '../ui/commands/trustCommand.js';
 import { quitCommand } from '../ui/commands/quitCommand.js';
 import { recapCommand } from '../ui/commands/recapCommand.js';
+import { remoteControlCommand } from '../ui/commands/remoteControlCommand.js';
 import { renameCommand } from '../ui/commands/renameCommand.js';
 import { restoreCommand } from '../ui/commands/restoreCommand.js';
 import { resumeCommand } from '../ui/commands/resumeCommand.js';
@@ -128,6 +129,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       ...(this.config?.getFolderTrust() ? [trustCommand] : []),
       quitCommand,
       recapCommand,
+      remoteControlCommand,
       renameCommand,
       restoreCommand(this.config),
       resumeCommand,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -164,6 +164,7 @@ import {
   requestConsentInteractive,
   requestConsentOrFail,
 } from '../commands/extensions/consent.js';
+import type { RemoteControlCommandService } from './commands/types.js';
 
 const CTRL_EXIT_PROMPT_DURATION_MS = 1000;
 const debugLogger = createDebugLogger('APP_CONTAINER');
@@ -236,6 +237,7 @@ interface AppContainerProps {
   startupWarnings?: string[];
   version: string;
   initializationResult: InitializationResult;
+  remoteControl?: RemoteControlCommandService;
 }
 
 /**
@@ -251,7 +253,7 @@ const SHELL_WIDTH_FRACTION = 0.89;
 const SHELL_HEIGHT_PADDING = 10;
 
 export const AppContainer = (props: AppContainerProps) => {
-  const { settings, config, initializationResult } = props;
+  const { settings, config, initializationResult, remoteControl } = props;
   const historyManager = useHistory();
   useMemoryMonitor(historyManager);
   const [debugMessage, setDebugMessage] = useState<string>('');
@@ -826,6 +828,7 @@ export const AppContainer = (props: AppContainerProps) => {
     isConfigInitialized,
     logger,
     setSessionName,
+    remoteControl,
   );
 
   // onDebugMessage should log to debug logfile, not update footer debugMessage
@@ -1015,8 +1018,13 @@ export const AppContainer = (props: AppContainerProps) => {
   const remoteInput = useRemoteInput();
   useEffect(() => {
     if (!remoteInput) return;
-    remoteInput.setSubmitFn((text: string) => submitQuery(text));
-  }, [remoteInput, submitQuery]);
+    remoteInput.setSubmitFn((text: string) => {
+      if (streamingState !== StreamingState.Idle) {
+        return false;
+      }
+      return submitQuery(text);
+    });
+  }, [remoteInput, streamingState, submitQuery]);
 
   // Notify remote input watcher when TUI becomes idle so it can
   // retry queued commands that were deferred while TUI was busy.
@@ -1083,6 +1091,63 @@ export const AppContainer = (props: AppContainerProps) => {
   pendingToolCallsRef.current = pendingToolCalls;
   const dualOutputRef = useRef(dualOutput);
   dualOutputRef.current = dualOutput;
+
+  useEffect(() => {
+    if (!remoteInput) return;
+    remoteInput.setControlHandler(async (command) => {
+      try {
+        if (command.type === 'interrupt') {
+          cancelOngoingRequest?.();
+          return;
+        }
+        if (command.type === 'set_permission_mode') {
+          config.setApprovalMode(command.mode);
+          await handleApprovalModeChange(command.mode);
+          historyManager.addItem(
+            {
+              type: MessageType.INFO,
+              text: `Remote control switched permission mode to ${command.mode}.`,
+            },
+            Date.now(),
+          );
+          return;
+        }
+        if (command.type === 'set_model') {
+          await config.setModel(command.model, { reason: 'remote_control' });
+          historyManager.addItem(
+            {
+              type: MessageType.INFO,
+              text: `Remote control switched model to ${command.model}.`,
+            },
+            Date.now(),
+          );
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        historyManager.addItem(
+          {
+            type: MessageType.ERROR,
+            text: `Remote control command failed: ${message}`,
+          },
+          Date.now(),
+        );
+        dualOutputRef.current?.emitSystemMessage('remote_control_error', {
+          command: command.type,
+          message,
+        });
+      }
+    });
+
+    return () => {
+      remoteInput.setControlHandler(() => {});
+    };
+  }, [
+    cancelOngoingRequest,
+    config,
+    handleApprovalModeChange,
+    historyManager,
+    remoteInput,
+  ]);
 
   // Route confirmation_response commands written to --input-file back into
   // the tool's onConfirm handler. Registered once (deps: [remoteInput]) to

--- a/packages/cli/src/ui/commands/remoteControlCommand.test.ts
+++ b/packages/cli/src/ui/commands/remoteControlCommand.test.ts
@@ -1,0 +1,128 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import { remoteControlCommand } from './remoteControlCommand.js';
+
+const serverInfo = {
+  url: 'http://127.0.0.1:7373',
+  wsUrl: 'ws://127.0.0.1:7373/ws',
+  lanUrls: ['http://192.168.1.23:7373'],
+  lanWsUrls: ['ws://192.168.1.23:7373/ws'],
+  pairingToken: 'pair-token',
+  pairingExpiresAt: '2026-05-08T12:00:00.000Z',
+};
+
+describe('remoteControlCommand', () => {
+  it('starts current TUI remote control', async () => {
+    const remoteControl = {
+      start: vi.fn().mockResolvedValue({
+        info: serverInfo,
+        alreadyStarted: false,
+      }),
+      stop: vi.fn(),
+      getStatus: vi.fn(),
+    };
+    const context = createMockCommandContext({
+      services: { remoteControl },
+    });
+
+    const result = await remoteControlCommand.action!(context, '');
+
+    expect(remoteControl.start).toHaveBeenCalledWith({});
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'info',
+    });
+    expect(result?.type === 'message' ? result.content : '').toContain(
+      'Remote control attached to the current TUI session.',
+    );
+    expect(result?.type === 'message' ? result.content : '').toContain(
+      'Pairing token: pair-token',
+    );
+  });
+
+  it('uses 0.0.0.0 when LAN mode is requested without an explicit host', async () => {
+    const remoteControl = {
+      start: vi.fn().mockResolvedValue({
+        info: serverInfo,
+        alreadyStarted: false,
+      }),
+      stop: vi.fn(),
+      getStatus: vi.fn(),
+    };
+    const context = createMockCommandContext({
+      services: { remoteControl },
+    });
+
+    await remoteControlCommand.action!(
+      context,
+      'start --allow-lan --port 0 --token-ttl 60 --no-ui',
+    );
+
+    expect(remoteControl.start).toHaveBeenCalledWith({
+      allowLan: true,
+      host: '0.0.0.0',
+      noUi: true,
+      port: 0,
+      tokenTtlMs: 60_000,
+    });
+  });
+
+  it('reports status without starting a new server', async () => {
+    const remoteControl = {
+      start: vi.fn(),
+      stop: vi.fn(),
+      getStatus: vi.fn().mockReturnValue({
+        running: true,
+        info: serverInfo,
+      }),
+    };
+    const context = createMockCommandContext({
+      services: { remoteControl },
+    });
+
+    const result = await remoteControlCommand.action!(context, 'status');
+
+    expect(remoteControl.start).not.toHaveBeenCalled();
+    expect(result?.type === 'message' ? result.content : '').toContain(
+      'Remote control is running.',
+    );
+  });
+
+  it('stops a running remote-control bridge', async () => {
+    const remoteControl = {
+      start: vi.fn(),
+      stop: vi.fn().mockResolvedValue(true),
+      getStatus: vi.fn(),
+    };
+    const context = createMockCommandContext({
+      services: { remoteControl },
+    });
+
+    const result = await remoteControlCommand.action!(context, 'stop');
+
+    expect(remoteControl.stop).toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Remote control stopped for the current TUI session.',
+    });
+  });
+
+  it('returns an error when the runtime service is unavailable', async () => {
+    const context = createMockCommandContext();
+
+    const result = await remoteControlCommand.action!(context, '');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Remote control service is not available.',
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/remoteControlCommand.ts
+++ b/packages/cli/src/ui/commands/remoteControlCommand.ts
@@ -1,0 +1,246 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DEFAULT_REMOTE_CONTROL_PORT } from '../../remoteControl/protocol.js';
+import { t } from '../../i18n/index.js';
+import {
+  CommandKind,
+  type MessageActionReturn,
+  type RemoteControlCommandServerInfo,
+  type RemoteControlCommandStartOptions,
+  type SlashCommand,
+} from './types.js';
+
+interface ParsedRemoteControlArgs {
+  action: 'start' | 'status' | 'stop' | 'help';
+  options: RemoteControlCommandStartOptions;
+  explicitHost: boolean;
+  error?: string;
+}
+
+const USAGE = [
+  'Usage:',
+  '  /remote-control',
+  '  /remote-control --allow-lan [--port <port>]',
+  '  /remote-control --host <host> [--port <port>]',
+  '  /remote-control start [--allow-lan] [--port <port>]',
+  '  /remote-control status',
+  '  /remote-control stop',
+  '',
+  'Options:',
+  '  --host <host>          Host interface to bind. Defaults to 127.0.0.1.',
+  `  --port <port>          Port to listen on. Defaults to ${DEFAULT_REMOTE_CONTROL_PORT}; use 0 for a random free port.`,
+  '  --allow-lan            Bind to 0.0.0.0 when --host is omitted and allow LAN access.',
+  '  --no-ui                Serve only the remote-control API.',
+  '  --token-ttl <seconds>  Pairing token TTL. Defaults to 300 seconds.',
+].join('\n');
+
+export const remoteControlCommand: SlashCommand = {
+  name: 'remote-control',
+  altNames: ['rc'],
+  argumentHint: '[status|stop] [--host <host>] [--port <port>] [--allow-lan]',
+  get description() {
+    return t('Start or inspect browser/mobile remote control for this TUI.');
+  },
+  kind: CommandKind.BUILT_IN,
+  supportedModes: ['interactive'] as const,
+  action: async (context, args): Promise<MessageActionReturn> => {
+    if (context.executionMode !== 'interactive') {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: t(
+          '/remote-control is only available in interactive TUI mode.',
+        ),
+      };
+    }
+
+    const remoteControl = context.services.remoteControl;
+    if (!remoteControl) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: t('Remote control service is not available.'),
+      };
+    }
+
+    const parsed = parseRemoteControlArgs(args);
+    if (parsed.error) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: parsed.error,
+      };
+    }
+    if (parsed.action === 'help') {
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: USAGE,
+      };
+    }
+    if (parsed.action === 'status') {
+      const status = remoteControl.getStatus();
+      return {
+        type: 'message',
+        messageType: 'info',
+        content:
+          status.running && status.info
+            ? formatRemoteControlInfo(status.info, {
+                title: 'Remote control is running.',
+                reusedToken: true,
+              })
+            : 'Remote control is not running. Run `/remote-control` to start it.',
+      };
+    }
+    if (parsed.action === 'stop') {
+      const stopped = await remoteControl.stop();
+      return {
+        type: 'message',
+        messageType: 'info',
+        content: stopped
+          ? 'Remote control stopped for the current TUI session.'
+          : 'Remote control is not running.',
+      };
+    }
+
+    const options = {
+      ...parsed.options,
+      host:
+        parsed.options.allowLan && !parsed.explicitHost
+          ? '0.0.0.0'
+          : parsed.options.host,
+    };
+    const result = await remoteControl.start(options);
+    return {
+      type: 'message',
+      messageType: 'info',
+      content: formatRemoteControlInfo(result.info, {
+        title: result.alreadyStarted
+          ? 'Remote control is already running for the current TUI session.'
+          : 'Remote control attached to the current TUI session.',
+        reusedToken: result.alreadyStarted,
+      }),
+    };
+  },
+};
+
+function parseRemoteControlArgs(raw: string): ParsedRemoteControlArgs {
+  const tokens = raw.trim() ? raw.trim().split(/\s+/) : [];
+  const parsed: ParsedRemoteControlArgs = {
+    action: 'start',
+    options: {},
+    explicitHost: false,
+  };
+
+  for (let index = 0; index < tokens.length; index++) {
+    const token = tokens[index]!;
+    if (index === 0 && !token.startsWith('--')) {
+      if (token === 'start' || token === 'status' || token === 'stop') {
+        parsed.action = token;
+        continue;
+      }
+      if (token === 'help') {
+        parsed.action = 'help';
+        continue;
+      }
+      return {
+        ...parsed,
+        error: `Unknown /remote-control action: ${token}\n\n${USAGE}`,
+      };
+    }
+
+    if (token === '--help' || token === '-h') {
+      parsed.action = 'help';
+      continue;
+    }
+    if (token === '--allow-lan') {
+      parsed.options.allowLan = true;
+      continue;
+    }
+    if (token === '--no-ui') {
+      parsed.options.noUi = true;
+      continue;
+    }
+    if (token === '--host') {
+      const value = tokens[++index];
+      if (!value) {
+        return {
+          ...parsed,
+          error: '--host requires a value.',
+        };
+      }
+      parsed.options.host = value;
+      parsed.explicitHost = true;
+      continue;
+    }
+    if (token === '--port') {
+      const value = tokens[++index];
+      const port = parseIntegerFlag('--port', value);
+      if (typeof port === 'string') {
+        return {
+          ...parsed,
+          error: port,
+        };
+      }
+      parsed.options.port = port;
+      continue;
+    }
+    if (token === '--token-ttl') {
+      const value = tokens[++index];
+      const tokenTtlSeconds = parseIntegerFlag('--token-ttl', value);
+      if (typeof tokenTtlSeconds === 'string') {
+        return {
+          ...parsed,
+          error: tokenTtlSeconds,
+        };
+      }
+      parsed.options.tokenTtlMs = Math.max(1, tokenTtlSeconds) * 1000;
+      continue;
+    }
+
+    return {
+      ...parsed,
+      error: `Unknown /remote-control option: ${token}\n\n${USAGE}`,
+    };
+  }
+
+  return parsed;
+}
+
+function parseIntegerFlag(
+  flag: string,
+  value: string | undefined,
+): number | string {
+  if (!value) {
+    return `${flag} requires a value.`;
+  }
+  const numberValue = Number(value);
+  if (!Number.isInteger(numberValue) || numberValue < 0) {
+    return `${flag} must be a non-negative integer.`;
+  }
+  return numberValue;
+}
+
+function formatRemoteControlInfo(
+  info: RemoteControlCommandServerInfo,
+  options: { title: string; reusedToken: boolean },
+): string {
+  const lines = [options.title, `URL: ${info.url}`, `WebSocket: ${info.wsUrl}`];
+  if (info.lanUrls.length > 0) {
+    lines.push('LAN URLs:', ...info.lanUrls.map((url) => `  ${url}`));
+  }
+  lines.push(
+    `Pairing token: ${info.pairingToken}`,
+    `Pairing token expires at: ${info.pairingExpiresAt}`,
+  );
+  if (options.reusedToken) {
+    lines.push(
+      'Note: the pairing token is one-time. If it was already used, run `/remote-control stop` and then `/remote-control` to generate a fresh token.',
+    );
+  }
+  return lines.join('\n');
+}

--- a/packages/cli/src/ui/commands/types.ts
+++ b/packages/cli/src/ui/commands/types.ts
@@ -26,6 +26,41 @@ import type {
   ExtensionUpdateStatus,
 } from '../state/extensions.js';
 
+export interface RemoteControlCommandServerInfo {
+  url: string;
+  wsUrl: string;
+  lanUrls: string[];
+  lanWsUrls: string[];
+  pairingToken: string;
+  pairingExpiresAt: string;
+}
+
+export interface RemoteControlCommandStartOptions {
+  host?: string;
+  port?: number;
+  allowLan?: boolean;
+  noUi?: boolean;
+  tokenTtlMs?: number;
+}
+
+export interface RemoteControlCommandStartResult {
+  info: RemoteControlCommandServerInfo;
+  alreadyStarted: boolean;
+}
+
+export interface RemoteControlCommandStatus {
+  running: boolean;
+  info?: RemoteControlCommandServerInfo;
+}
+
+export interface RemoteControlCommandService {
+  start(
+    options?: RemoteControlCommandStartOptions,
+  ): Promise<RemoteControlCommandStartResult>;
+  stop(): Promise<boolean>;
+  getStatus(): RemoteControlCommandStatus;
+}
+
 // Grouped dependencies for clarity and easier mocking
 export interface CommandContext {
   /**
@@ -52,6 +87,7 @@ export interface CommandContext {
     settings: LoadedSettings;
     git: GitService | undefined;
     logger: Logger | null;
+    remoteControl?: RemoteControlCommandService;
   };
   // UI state and history management
   ui: {

--- a/packages/cli/src/ui/hooks/slashCommandProcessor.ts
+++ b/packages/cli/src/ui/hooks/slashCommandProcessor.ts
@@ -128,6 +128,7 @@ export const useSlashCommandProcessor = (
   isConfigInitialized: boolean,
   logger: Logger | null,
   setSessionName?: (name: string | null) => void,
+  remoteControl?: CommandContext['services']['remoteControl'],
 ) => {
   const { stats: sessionStats, startNewSession } = useSessionStats();
   const [commands, setCommands] = useState<readonly SlashCommand[]>([]);
@@ -273,6 +274,7 @@ export const useSlashCommandProcessor = (
         settings,
         git: gitService,
         logger,
+        remoteControl,
       },
       ui: {
         addItem,
@@ -313,6 +315,7 @@ export const useSlashCommandProcessor = (
       settings,
       gitService,
       logger,
+      remoteControl,
       loadHistory,
       addItem,
       clearItems,

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -464,6 +464,11 @@ export interface ConfigParameters {
    * watches it to process messages as if the user typed them.
    */
   inputFile?: string;
+  /**
+   * Attach a browser/mobile remote-control server to the current interactive
+   * TUI session.
+   */
+  remoteControl?: RemoteControlConfig;
   /** Model providers configuration grouped by authType */
   modelProvidersConfig?: ModelProvidersConfig;
   /** Multi-agent collaboration settings (Arena, Team, Swarm) */
@@ -519,6 +524,15 @@ export interface ConfigParameters {
     ruleType: 'allow' | 'ask' | 'deny',
     rule: string,
   ) => Promise<void>;
+}
+
+export interface RemoteControlConfig {
+  enabled?: boolean;
+  host?: string;
+  port?: number;
+  allowLan?: boolean;
+  noUi?: boolean;
+  tokenTtlSeconds?: number;
 }
 
 function normalizeConfigOutputFormat(
@@ -699,6 +713,7 @@ export class Config {
   private readonly jsonFd: number | undefined;
   private readonly jsonFile: string | undefined;
   private readonly inputFile: string | undefined;
+  private readonly remoteControl: RemoteControlConfig | undefined;
   private readonly defaultFileEncoding: FileEncodingType | undefined;
   private readonly enableManagedAutoMemory: boolean;
   private readonly enableManagedAutoDream: boolean;
@@ -855,6 +870,7 @@ export class Config {
     this.jsonFd = params.jsonFd;
     this.jsonFile = params.jsonFile;
     this.inputFile = params.inputFile;
+    this.remoteControl = params.remoteControl;
     this.defaultFileEncoding = params.defaultFileEncoding;
     this.storage = new Storage(this.targetDir);
     this.inputFormat = params.inputFormat ?? InputFormat.TEXT;
@@ -2412,6 +2428,10 @@ export class Config {
    */
   getInputFile(): string | undefined {
     return this.inputFile;
+  }
+
+  getRemoteControlConfig(): RemoteControlConfig | undefined {
+    return this.remoteControl;
   }
 
   /**


### PR DESCRIPTION
## Summary

This is PR 3 of the 3-PR stacked remote-control implementation. It is stacked on #3930, which is stacked on #3929.

Stack split:
1. **Foundation (#3929)**: design doc plus stream-json interrupt/session lifecycle fixes.
2. **Worker server (#3930)**: standalone `qwen remote-control` worker server and mobile/browser protocol.
3. **Current TUI attach (this PR, #3931)**: `qwen --remote-control` and `/remote-control` attach the live Ink TUI to the same remote-control server without spawning a child session.

This PR reuses the existing dual-output and remote-input primitives for current-session control. It adds `TuiRemoteBridge`, `TuiRemoteControlManager`, a single-session TUI registry, dynamic dual-output/input providers, composite dual-output/input contexts, remote control command handling in the TUI, CLI attach flags, `/remote-control` slash command support, LAN URL printing for attach mode, and partial-line buffering for remote-input/dual-output JSONL.

## Mobile/current TUI behavior

- The mobile/browser client can attach to the current TUI session and replay recent structured events.
- `/remote-control`, `/remote-control start`, `/remote-control status`, and `/remote-control stop` are available inside the TUI.
- `/remote-control --allow-lan` and `qwen --remote-control --remote-control-allow-lan` bind to `0.0.0.0` when no explicit host is provided, so phones on the same trusted LAN can connect.
- Remote prompt submit is queued through RemoteInputWatcher and respects TUI busy/idle state.
- Tool approval is mirrored through dual-output `control_request`/`control_response`; either local TUI or remote UI can resolve first.
- Remote interrupt, model switch, and permission-mode switch are routed into the current TUI.
- Remote session close does not terminate the local terminal; it only detaches/acknowledges safely.

## Validation

- `cd packages/cli && npm run typecheck`
- `cd packages/cli && npx vitest run src/config/config.test.ts src/remoteControl/EventLog.test.ts src/remoteControl/PairingManager.test.ts src/remoteControl/RemoteSessionRunner.test.ts src/remoteControl/RemoteControlServer.test.ts src/remoteControl/TuiSessionRegistry.test.ts src/remoteControl/TuiRemoteControlManager.test.ts src/remoteInput/RemoteInputWatcher.test.ts src/ui/commands/remoteControlCommand.test.ts src/services/BuiltinCommandLoader.test.ts src/nonInteractive/control/ControlDispatcher.test.ts src/nonInteractive/session.test.ts`
- `cd packages/cli && npx eslint src/gemini.tsx src/remoteControl/TuiRemoteControlManager.ts src/remoteControl/TuiRemoteControlManager.test.ts src/remoteControl/TuiSessionRegistry.ts src/remoteControl/index.ts src/services/BuiltinCommandLoader.ts src/ui/AppContainer.tsx src/ui/commands/remoteControlCommand.ts src/ui/commands/remoteControlCommand.test.ts src/ui/commands/types.ts src/ui/hooks/slashCommandProcessor.ts --max-warnings 0`
- `npm run build`
- `git diff --check feat/remote-control-worker...feat/remote-control-tui-attach`