### PR TITLE
fix(core): accept partial reads in prior-read enforcement

### DIFF
--- a/packages/core/src/tools/edit.test.ts
+++ b/packages/core/src/tools/edit.test.ts
@@ -1013,31 +1013,35 @@ describe('EditTool', () => {
 
       expect(result.error?.type).toBe(ToolErrorType.EDIT_REQUIRES_PRIOR_READ);
       expect(result.error?.message).toMatch(
-        /has not been fully read in this session/,
+        /has not been read in this session/,
       );
       // File must remain untouched.
       expect(fs.readFileSync(filePath, 'utf8')).toBe('untouched content');
     });
 
-    it('rejects an edit when the previous read was ranged (offset/limit)', async () => {
-      // A model that only Read part of a file has not seen the bytes
-      // a free-form old_string would touch. Treat this the same as
-      // "no prior read".
+    it('allows an edit after a ranged (offset/limit) read', async () => {
+      // A partial read still counts as a prior read: requiring the
+      // model to re-read multi-thousand-line files just to change one
+      // line is wasteful, and the existing `0 occurrences` failure
+      // mode catches the case the full-read requirement was meant to
+      // defend against (a fabricated old_string that misses the
+      // actual bytes). This matches Claude Code's `readFileState`
+      // contract, which also accepts partial reads.
       fs.writeFileSync(filePath, 'line a\nline b\nline c\n', 'utf8');
       const stats = fs.statSync(filePath);
-      // Record as a ranged read: lastReadWasFull = false.
       fileReadCache.recordRead(filePath, stats, {
         full: false,
         cacheable: true,
       });
+      (mockConfig.getApprovalMode as Mock).mockReturnValueOnce(
+        ApprovalMode.AUTO_EDIT,
+      );
 
       const result = await tool
         .build({ file_path: filePath, old_string: 'line a', new_string: 'X' })
         .execute(abortSignal);
-      expect(result.error?.type).toBe(ToolErrorType.EDIT_REQUIRES_PRIOR_READ);
-      expect(fs.readFileSync(filePath, 'utf8')).toBe(
-        'line a\nline b\nline c\n',
-      );
+      expect(result.error).toBeUndefined();
+      expect(fs.readFileSync(filePath, 'utf8')).toBe('X\nline b\nline c\n');
     });
 
     it('rejects an edit when the previous read was non-cacheable (binary / pdf / image)', async () => {
@@ -1161,7 +1165,7 @@ describe('EditTool', () => {
       });
       await expect(
         invocation.getConfirmationDetails(abortSignal),
-      ).rejects.toThrow(/has not been fully read in this session/);
+      ).rejects.toThrow(/has not been read in this session/);
     });
 
     it('rejects an edit when the file has been modified since the last read', async () => {
@@ -1239,13 +1243,15 @@ describe('EditTool', () => {
       expect(fs.readFileSync(newPath, 'utf8')).toBe('second content\n');
     });
 
-    it('allows Edit after Write→partial-Read (sticky-on-true preserves write-author rights)', async () => {
-      // Reproduction for the maintainer-review regression: pre-fix,
-      // a partial read recorded `lastReadWasFull = false` and
-      // clobbered the `true` that recordWrite had stamped at
-      // create time, so this Edit would then be rejected with
-      // EDIT_REQUIRES_PRIOR_READ even though the model had
-      // authored the file's full content.
+    it('allows Edit after Write→partial-Read', async () => {
+      // The Write authors the bytes (recordWrite seeds the cache), and
+      // a follow-up partial Read at the same fingerprint must not
+      // disqualify the next Edit. After dropping the `lastReadWasFull`
+      // requirement from prior-read enforcement, this is just the
+      // generic "partial read counts" path; pre-fix it failed for a
+      // different reason (the partial read overwrote the full-read
+      // flag recordWrite had stamped, and enforcement still required
+      // that flag).
       const newPath = path.join(rootDir, 'write-then-partial-read.txt');
       (mockConfig.getApprovalMode as Mock).mockReturnValue(
         ApprovalMode.AUTO_EDIT,

--- a/packages/core/src/tools/priorReadEnforcement.ts
+++ b/packages/core/src/tools/priorReadEnforcement.ts
@@ -82,9 +82,22 @@ export type PriorReadVerb = 'editing' | 'overwriting';
  *    drift, not a "the file genuinely never existed" disappearance
  *    race. The default (`expectExisting: false`) is the pre-read
  *    behaviour: ENOENT means "go ahead and create".
+ *  - `requireFullRead`: when true, a partial read (offset / limit /
+ *    pages) of an existing file does NOT satisfy enforcement — only
+ *    a full read does. EditTool can rely on its `old_string` matching
+ *    as a content-derived guard against editing bytes the model never
+ *    saw, so a partial read is acceptable there. WriteFileTool's
+ *    overwrite path replaces the entire file and has no equivalent
+ *    guard: a model that has only seen a slice would necessarily
+ *    hallucinate the rest of the bytes it overwrites (the data-loss
+ *    scenario in issue #2499). Pass `true` from WriteFileTool's
+ *    enforcement call sites; leave unset / `false` for EditTool.
+ *    The flag has no effect when the file does not yet exist
+ *    (ENOENT → `ok: true` for new-file creation regardless).
  */
 export interface CheckPriorReadOptions {
   expectExisting?: boolean;
+  requireFullRead?: boolean;
 }
 
 /**
@@ -92,12 +105,23 @@ export interface CheckPriorReadOptions {
  * `filePath` based on the session FileReadCache.
  *
  * Approval requires more than `cache.check === 'fresh'`: the recorded
- * read must also have been (a) stamped with `lastReadAt`,
- * (b) `lastReadWasFull` (no offset / limit / pages), and
- * (c) `lastReadCacheable` (i.e. plain text, not binary / image /
- * audio / video / PDF / notebook). Otherwise the model has only seen
- * a slice or a structured proxy of the file, not the bytes a
- * prospective edit would mutate.
+ * read must also have been (a) stamped with `lastReadAt` and
+ * (b) `lastReadCacheable` (i.e. plain text, not binary / image /
+ * audio / video / PDF / notebook — those return a structured payload
+ * the Edit / WriteFile tools cannot mutate as text).
+ *
+ * Partial vs full read policy depends on `options.requireFullRead`:
+ *  - default (`requireFullRead !== true`, i.e. EditTool): a partial
+ *    read (offset / limit / pages) counts. The `0 occurrences`
+ *    failure mode in `calculateEdit` already catches a fabricated
+ *    `old_string` that misses the actual bytes, so requiring a full
+ *    read on top of that is over-defence at a real context cost.
+ *  - `requireFullRead: true` (WriteFileTool overwrite): partial reads
+ *    do NOT count. Overwriting replaces the entire file with no
+ *    content-derived guard, so the model must have seen all current
+ *    bytes — issue #2499 (LLM hallucinates content of an unread
+ *    file and clobbers user changes) is exactly the partial-read-
+ *    then-WriteFile case.
  *
  * Stat policy: `ENOENT` means the path disappeared between the
  * caller's `fileExists` check and now — a disappearance race that is
@@ -109,11 +133,11 @@ export interface CheckPriorReadOptions {
  *
  * Note on `recordWrite` interaction: when a tool *creates* a file via
  * Edit (`old_string === ''`) or WriteFile (new path), the FileReadCache
- * `recordWrite` call seeds `lastReadAt` / `lastReadWasFull` /
- * `lastReadCacheable` on the brand-new entry, so a subsequent edit on
- * that same file passes here without an intervening explicit Read.
- * The model authored those bytes; for the purposes of prior-read
- * enforcement that counts as having seen them.
+ * `recordWrite` call seeds `lastReadAt` / `lastReadCacheable` on the
+ * brand-new entry, so a subsequent edit on that same file passes here
+ * without an intervening explicit Read. The model authored those bytes;
+ * for the purposes of prior-read enforcement that counts as having
+ * seen them.
  */
 export async function checkPriorRead(
   cache: FileReadCache,
@@ -212,8 +236,8 @@ export async function checkPriorRead(
   if (
     status.state === 'fresh' &&
     status.entry.lastReadAt !== undefined &&
-    status.entry.lastReadWasFull &&
-    status.entry.lastReadCacheable
+    status.entry.lastReadCacheable &&
+    (!options.requireFullRead || status.entry.lastReadWasFull)
   ) {
     return { ok: true };
   }
@@ -231,14 +255,13 @@ export async function checkPriorRead(
     };
   }
   // Differentiate "fresh but the recorded read was non-cacheable"
-  // (binary / image / audio / video / PDF / notebook) from "no /
-  // partial read at all". Telling the model to "re-read with read_file"
-  // for a binary file would loop forever because that read would
-  // also leave `lastReadCacheable === false`.
+  // (binary / image / audio / video / PDF / notebook) from "never
+  // read at all". Telling the model to "re-read with read_file" for
+  // a binary file would loop forever because that read would also
+  // leave `lastReadCacheable === false`.
   if (
     status.state === 'fresh' &&
     status.entry.lastReadAt !== undefined &&
-    status.entry.lastReadWasFull &&
     !status.entry.lastReadCacheable
   ) {
     // Both raw and displayMessage use the bare verb (`edit` /
@@ -263,13 +286,48 @@ export async function checkPriorRead(
       displayMessage: `non-text payload; cannot ${verbBare} via this tool.`,
     };
   }
-  // unknown OR fresh-but-partial: require a fresh full text read.
-  const raw =
-    `File ${filePath} has not been fully read in this session. ` +
-    `Use the ${ToolNames.READ_FILE} tool first (without offset / limit ` +
-    `/ pages) to load the entire current text content before ${verb} it.`;
+  // fresh + cacheable + partial, but caller demands a full read
+  // (WriteFile overwrites). The model has seen *some* of this file's
+  // current bytes, but not all of them — and the operation is about
+  // to replace every byte. Without this branch a partial-read-then-
+  // WriteFile would silently destroy content the model never saw,
+  // re-introducing the issue #2499 data-loss scenario.
+  if (
+    status.state === 'fresh' &&
+    status.entry.lastReadAt !== undefined &&
+    status.entry.lastReadCacheable &&
+    options.requireFullRead &&
+    !status.entry.lastReadWasFull
+  ) {
+    const raw =
+      `File ${filePath} has only been partially read in this session ` +
+      `(prior read used offset / limit / pages). ${verb === 'overwriting' ? 'Overwriting' : 'This operation'} ` +
+      `replaces the entire file, so the model must have seen all current ` +
+      `bytes first — not just the slice it has read. Re-read with the ` +
+      `${ToolNames.READ_FILE} tool without offset / limit / pages, then ` +
+      `retry ${verb} it.`;
+    return {
+      ok: false,
+      type: ToolErrorType.EDIT_REQUIRES_PRIOR_READ,
+      rawMessage: raw,
+      displayMessage: `partial read; full ${ToolNames.READ_FILE} required before ${verb} this file.`,
+    };
+  }
+  // unknown: the model has never read this file in this session.
+  const verbBare = verb === 'editing' ? 'edit' : 'overwrite';
   const verbDisplay =
     verb === 'editing' ? 'editing this file' : 'overwriting this file';
+  const raw = options.requireFullRead
+    ? `File ${filePath} has not been read in this session. ` +
+      `${verb === 'overwriting' ? 'Overwriting' : 'This operation'} replaces ` +
+      `the entire file, so the model must have seen all current bytes ` +
+      `first. Use the ${ToolNames.READ_FILE} tool without offset / limit ` +
+      `/ pages to load the full content before ${verb} it.`
+    : `File ${filePath} has not been read in this session. ` +
+      `Use the ${ToolNames.READ_FILE} tool first to load the current ` +
+      `content (a partial read with offset / limit is fine — you only ` +
+      `need to have seen the bytes you intend to ${verbBare}) before ` +
+      `${verb} it.`;
   return {
     ok: false,
     type: ToolErrorType.EDIT_REQUIRES_PRIOR_READ,

--- a/packages/core/src/tools/write-file.test.ts
+++ b/packages/core/src/tools/write-file.test.ts
@@ -843,7 +843,7 @@ describe('WriteFileTool', () => {
 
       expect(result.error?.type).toBe(ToolErrorType.EDIT_REQUIRES_PRIOR_READ);
       expect(result.error?.message).toMatch(
-        /has not been fully read in this session/,
+        /has not been read in this session/,
       );
       // File must remain at its pre-call content, and the tool must
       // not have slurped the existing bytes into memory before
@@ -856,6 +856,13 @@ describe('WriteFileTool', () => {
     });
 
     it('rejects a write when the previous read was ranged (offset/limit)', async () => {
+      // WriteFile diverges from EditTool here: a partial read counts
+      // for in-place edits (Edit's `old_string` matching is the
+      // content-derived guard against editing bytes the model never
+      // saw), but WriteFile replaces the whole file and has no
+      // equivalent guard — a slice-only read followed by an
+      // overwrite would necessarily hallucinate the rest of the
+      // bytes, which is the issue #2499 data-loss scenario.
       const filePath = path.join(rootDir, 'enforce-ranged.txt');
       fs.writeFileSync(filePath, 'unchanged', 'utf-8');
       const stats = fs.statSync(filePath);
@@ -868,6 +875,11 @@ describe('WriteFileTool', () => {
         .build({ file_path: filePath, content: 'clobber' })
         .execute(abortSignal);
       expect(result.error?.type).toBe(ToolErrorType.EDIT_REQUIRES_PRIOR_READ);
+      // Error message should explain why partial reads are not enough
+      // for overwrites, not just say "has not been read".
+      expect(result.error?.message).toMatch(
+        /only been partially read|replaces the entire file/,
+      );
       expect(fs.readFileSync(filePath, 'utf-8')).toBe('unchanged');
 
       fs.unlinkSync(filePath);
@@ -938,7 +950,7 @@ describe('WriteFileTool', () => {
       });
       await expect(
         invocation.getConfirmationDetails(abortSignal),
-      ).rejects.toThrow(/has not been fully read in this session/);
+      ).rejects.toThrow(/has not been read in this session/);
 
       fs.unlinkSync(filePath);
     });

--- a/packages/core/src/tools/write-file.ts
+++ b/packages/core/src/tools/write-file.ts
@@ -139,6 +139,11 @@ class WriteFileToolInvocation extends BaseToolInvocation<
         this.config.getFileReadCache(),
         this.params.file_path,
         'overwriting',
+        // WriteFile replaces the entire file: a partial read is not
+        // enough evidence. Edit's `old_string` matching covers the
+        // "fabricated content" case for in-place edits, but there is
+        // no equivalent guard on the overwrite path.
+        { requireFullRead: true },
       );
       if (!decision.ok) {
         // Surface the structured ToolErrorType through scheduler.
@@ -183,7 +188,7 @@ class WriteFileToolInvocation extends BaseToolInvocation<
         this.config.getFileReadCache(),
         this.params.file_path,
         'overwriting',
-        { expectExisting: true },
+        { expectExisting: true, requireFullRead: true },
       );
       if (!postDecision.ok) {
         debugLogger.warn('post-read TOCTOU rejection (confirmation)', {
@@ -257,6 +262,7 @@ class WriteFileToolInvocation extends BaseToolInvocation<
         this.config.getFileReadCache(),
         file_path,
         'overwriting',
+        { requireFullRead: true },
       );
       if (!decision.ok) {
         return {
@@ -320,7 +326,7 @@ class WriteFileToolInvocation extends BaseToolInvocation<
         this.config.getFileReadCache(),
         file_path,
         'overwriting',
-        { expectExisting: true },
+        { expectExisting: true, requireFullRead: true },
       );
       if (!postDecision.ok) {
         debugLogger.warn('post-read TOCTOU rejection (execute)', {
@@ -388,7 +394,12 @@ class WriteFileToolInvocation extends BaseToolInvocation<
         // file from stale bytes. For new-file creation
         // (`fileExists === false`), ENOENT is the expected pre-write
         // state (ok:true → writeTextFile creates).
-        { expectExisting: fileExists },
+        //
+        // `requireFullRead: true` only matters when stat succeeds
+        // (file currently exists). On the new-file path the helper
+        // returns ok:true via ENOENT before consulting this flag, so
+        // creation is still exempt regardless.
+        { expectExisting: fileExists, requireFullRead: true },
       );
       if (!writeDecision.ok) {
         debugLogger.warn('pre-write TOCTOU rejection', {


### PR DESCRIPTION
## Motivation

PR #3774 introduced a `lastReadWasFull` requirement to `checkPriorRead`: in addition to a fresh, cacheable cache entry, the most recent read had to have consumed the entire file (no `offset` / `limit` / `pages`). That over-constrains the in-place edit case. For a multi-thousand-line file where the edit only touches a single line, the model is forced to re-read the whole file even when the bytes the edit touches are already in its context from `read_file(offset, limit)`.

But — as a code review of the first revision of this PR pointed out — `Edit` and `WriteFile` are not symmetric:

- `Edit` requires `old_string` to match the file's current bytes; a fabricated string that misses what is actually on disk is caught by the `0 occurrences found` failure mode in `calculateEdit`. So a partial read is acceptable for in-place edits.
- `WriteFile` overwrites the entire file. There is no equivalent content-derived guard. A model that has only seen a slice via `read_file(offset, limit)` followed by a `WriteFile` would necessarily hallucinate the rest of the bytes — which is **issue #2499** verbatim (the data-loss scenario PR #3774 was opened to address).

This PR splits the policy along that line.

## Change

`checkPriorRead` gains a `requireFullRead?: boolean` option (`CheckPriorReadOptions`). When `true`, a `fresh + cacheable + partial` cache entry is rejected; only a full read clears enforcement.

| Tool | Pre-existing file | Behaviour |
|---|---|---|
| `EditTool` | not read → reject; partial → **accept**; full → accept; mtime drift → reject | `requireFullRead` not set (default `false`) |
| `WriteFileTool` overwrite | not read → reject; partial → **reject**; full → accept; mtime drift → reject | passes `requireFullRead: true` from all 5 call sites |
| Either | new-file creation | exempt (ENOENT → `ok: true` before `requireFullRead` is consulted) |
| Either | `fileReadCacheDisabled === true` | enforcement bypassed (escape hatch from PR #3774, unchanged) |
| Either | non-text payload (binary / image / PDF / notebook) | reject via dedicated binary branch with "use a different mechanism" guidance |

A new dedicated rejection branch handles `fresh + cacheable + partial + requireFullRead` so the model gets a clear *"only been partially read … overwriting replaces the entire file"* message rather than the generic *"has not been read"*. The `unknown` branch's wording also varies by `requireFullRead` so the read instruction matches the operation's actual requirement.

## Comparison with Claude Code

Claude Code's `readFileState` enforcement (spec `03_tools.md:484, 532`) treats partial and full reads identically for both Edit and WriteFile. This PR is **stricter on the WriteFile path** (full read required) and **identical on the Edit path** (partial OK). The asymmetric stance reflects the asymmetric guards: Claude Code's `Write` tool ships with the same risk surface, but issue #2499 in this repo is empirical evidence that the partial-read-then-overwrite hallucination case is real on at least some model populations, so the additional WriteFile constraint is justified here.

## Risk

- The same `(mtime, size)` fingerprint risk PR #3774's "Known unmitigated" section flagged remains: a writer that produces an identical-length payload in the same mtime tick can pass `cache.check === fresh`. Unchanged by this PR; mitigation deferred to a follow-up content-hash on the read pipeline.
- The pre-write stat → write race window is unchanged (closing it needs atomic write or post-write recheck — also deferred).
- Partial-read-then-Edit is now allowed against bytes the model has not literally seen. The `0 occurrences` floor catches fabricated `old_string`s, but a fabrication that *coincidentally matches* a region outside the partial-read window would still go through. The single-occurrence-or-`replace_all` requirement narrows but does not close this. Operators who want strict full-read protection on Edit too can set `fileReadCacheDisabled: true`.

## Test plan

- [x] `npx vitest run src/tools/edit.test.ts src/tools/write-file.test.ts src/tools/read-file.test.ts src/services/fileReadCache.test.ts` — **198 / 198 pass**
- [x] `tsc --noEmit -p packages/core/tsconfig.json` — clean
- [x] Edit: ranged-read test (`edit.test.ts:1022`) inverted from "rejects" to "allows after ranged read" with passing assertion on resulting bytes
- [x] WriteFile: ranged-read test (`write-file.test.ts:858`) restored to "rejects" with assertion on the new "partially read / replaces the entire file" message
- [x] Three error-message regex matchers updated from `/fully read/` to `/read/`
- [x] `Write→partial-Read→Edit` regression test description updated; behaviour unchanged

## Notes for reviewers

- The error message in the unknown-entry branch now varies by `requireFullRead` so a model reading the message gets the read instruction matching the operation it just attempted (full read for overwrite, partial-OK hint for edit).
- `lastReadWasFull` is still consulted by `read-file.ts` for the `file_unchanged` fast-path (decides whether a follow-up no-args Read can return a `file_unchanged` placeholder). Unchanged and unrelated to enforcement.
- `FileReadCache.recordRead`'s sticky-on-true behaviour for matching fingerprints remains in place; with this PR it serves the `file_unchanged` fast-path *and* keeps the WriteFile-overwrite path passing once a full read has been recorded against the current bytes.

## Commits

- `afc1b917` — first pass: drop `lastReadWasFull` for both Edit and WriteFile
- `503fc0b0` — review fix: re-introduce full-read requirement for WriteFile only, via `requireFullRead` option