### PR TITLE
fix(core): sanitize Mistral reasoning content

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/index.ts
+++ b/packages/core/src/core/openaiContentGenerator/index.ts
@@ -13,6 +13,7 @@ import { OpenAIContentGenerator } from './openaiContentGenerator.js';
 import {
   DashScopeOpenAICompatibleProvider,
   DeepSeekOpenAICompatibleProvider,
+  MistralOpenAICompatibleProvider,
   ModelScopeOpenAICompatibleProvider,
   MiniMaxOpenAICompatibleProvider,
   OpenRouterOpenAICompatibleProvider,
@@ -28,6 +29,7 @@ export {
   type OpenAICompatibleProvider,
   DashScopeOpenAICompatibleProvider,
   DeepSeekOpenAICompatibleProvider,
+  MistralOpenAICompatibleProvider,
   MiniMaxOpenAICompatibleProvider,
   OpenRouterOpenAICompatibleProvider,
 } from './provider/index.js';
@@ -93,6 +95,14 @@ export function determineProvider(
   // Check for MiniMax provider
   if (MiniMaxOpenAICompatibleProvider.isMiniMaxProvider(config)) {
     return new MiniMaxOpenAICompatibleProvider(
+      contentGeneratorConfig,
+      cliConfig,
+    );
+  }
+
+  // Check for Mistral provider
+  if (MistralOpenAICompatibleProvider.isMistralProvider(config)) {
+    return new MistralOpenAICompatibleProvider(
       contentGeneratorConfig,
       cliConfig,
     );

--- a/packages/core/src/core/openaiContentGenerator/provider/index.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/index.ts
@@ -1,6 +1,7 @@
 export { ModelScopeOpenAICompatibleProvider } from './modelscope.js';
 export { DashScopeOpenAICompatibleProvider } from './dashscope.js';
 export { DeepSeekOpenAICompatibleProvider } from './deepseek.js';
+export { MistralOpenAICompatibleProvider } from './mistral.js';
 export { OpenRouterOpenAICompatibleProvider } from './openrouter.js';
 export { MiniMaxOpenAICompatibleProvider } from './minimax.js';
 export { DefaultOpenAICompatibleProvider } from './default.js';

--- a/packages/core/src/core/openaiContentGenerator/provider/mistral.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/mistral.test.ts
@@ -1,0 +1,147 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type OpenAI from 'openai';
+import type { Config } from '../../../config/config.js';
+import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+import { determineProvider } from '../index.js';
+import { MistralOpenAICompatibleProvider } from './mistral.js';
+
+describe('MistralOpenAICompatibleProvider', () => {
+  const mockCliConfig = {
+    getCliVersion: vi.fn().mockReturnValue('1.0.0'),
+    getProxy: vi.fn().mockReturnValue(undefined),
+  } as unknown as Config;
+
+  function createConfig(
+    overrides: Partial<ContentGeneratorConfig> = {},
+  ): ContentGeneratorConfig {
+    return {
+      apiKey: 'test-api-key',
+      baseUrl: 'https://api.mistral.ai/v1',
+      model: 'mistral-large-latest',
+      ...overrides,
+    } as ContentGeneratorConfig;
+  }
+
+  describe('isMistralProvider', () => {
+    it('matches the official Mistral OpenAI-compatible API host', () => {
+      expect(
+        MistralOpenAICompatibleProvider.isMistralProvider(createConfig()),
+      ).toBe(true);
+    });
+
+    it('matches Mistral models on self-hosted OpenAI-compatible endpoints', () => {
+      expect(
+        MistralOpenAICompatibleProvider.isMistralProvider(
+          createConfig({
+            baseUrl: 'https://my-vllm.example.com/v1',
+            model: 'Mistral-7B-Instruct-v0.3',
+          }),
+        ),
+      ).toBe(true);
+    });
+
+    it('does not match unrelated hosts and models', () => {
+      expect(
+        MistralOpenAICompatibleProvider.isMistralProvider(
+          createConfig({
+            baseUrl: 'https://api.example.com/v1',
+            model: 'gpt-4o',
+          }),
+        ),
+      ).toBe(false);
+    });
+  });
+
+  it('is selected by the OpenAI-compatible provider factory', () => {
+    const provider = determineProvider(createConfig(), mockCliConfig);
+
+    expect(provider).toBeInstanceOf(MistralOpenAICompatibleProvider);
+  });
+
+  it('is selected by the factory for self-hosted Mistral models', () => {
+    const provider = determineProvider(
+      createConfig({
+        baseUrl: 'https://my-vllm.example.com/v1',
+        model: 'mistralai/Mistral-7B-Instruct-v0.3',
+      }),
+      mockCliConfig,
+    );
+
+    expect(provider).toBeInstanceOf(MistralOpenAICompatibleProvider);
+  });
+
+  it('removes reasoning_content from outbound assistant messages without mutating history', () => {
+    const provider = new MistralOpenAICompatibleProvider(
+      createConfig(),
+      mockCliConfig,
+    );
+    const toolCalls: NonNullable<
+      OpenAI.Chat.ChatCompletionAssistantMessageParam['tool_calls']
+    > = [
+      {
+        id: 'call_1',
+        type: 'function',
+        function: { name: 'glob', arguments: '{"pattern":"*.ts"}' },
+      },
+    ];
+    const assistantMessage = {
+      role: 'assistant',
+      content: 'I found one file.',
+      reasoning_content: 'hidden reasoning from a previous model',
+      tool_calls: toolCalls,
+    } as OpenAI.Chat.ChatCompletionAssistantMessageParam & {
+      reasoning_content: string;
+    };
+    const originalRequest: OpenAI.Chat.ChatCompletionCreateParams = {
+      model: 'mistral-large-latest',
+      messages: [
+        { role: 'user', content: 'Find TypeScript files' },
+        assistantMessage,
+        {
+          role: 'tool',
+          tool_call_id: 'call_1',
+          content: 'Found 1 matching file',
+        },
+      ],
+    };
+
+    const result = provider.buildRequest(originalRequest, 'prompt-123');
+    const outboundAssistant = result.messages?.[1] as unknown as Record<
+      string,
+      unknown
+    >;
+
+    expect(outboundAssistant).not.toHaveProperty('reasoning_content');
+    expect(outboundAssistant['content']).toBe('I found one file.');
+    expect(outboundAssistant['tool_calls']).toBe(toolCalls);
+    expect(
+      (originalRequest.messages[1] as typeof assistantMessage)
+        .reasoning_content,
+    ).toBe('hidden reasoning from a previous model');
+  });
+
+  it('preserves assistant messages that do not contain reasoning_content', () => {
+    const provider = new MistralOpenAICompatibleProvider(
+      createConfig(),
+      mockCliConfig,
+    );
+    const assistantMessage = {
+      role: 'assistant',
+      content: 'No reasoning field here.',
+    } as OpenAI.Chat.ChatCompletionMessageParam;
+    const originalRequest: OpenAI.Chat.ChatCompletionCreateParams = {
+      model: 'mistral-large-latest',
+      messages: [{ role: 'user', content: 'Hello' }, assistantMessage],
+    };
+
+    const result = provider.buildRequest(originalRequest, 'prompt-123');
+
+    expect(result.messages?.[1]).toBe(assistantMessage);
+  });
+});

--- a/packages/core/src/core/openaiContentGenerator/provider/mistral.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/mistral.ts
@@ -1,0 +1,91 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type OpenAI from 'openai';
+import type { Config } from '../../../config/config.js';
+import type { ContentGeneratorConfig } from '../../contentGenerator.js';
+import { DefaultOpenAICompatibleProvider } from './default.js';
+
+export function isMistralHostname(
+  contentGeneratorConfig: ContentGeneratorConfig,
+): boolean {
+  const baseUrl = contentGeneratorConfig.baseUrl ?? '';
+  if (!baseUrl) return false;
+  try {
+    const hostname = new URL(baseUrl).hostname.toLowerCase();
+    return (
+      hostname === 'api.mistral.ai' || hostname.endsWith('.api.mistral.ai')
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isMistralProvider(
+  contentGeneratorConfig: ContentGeneratorConfig,
+): boolean {
+  if (isMistralHostname(contentGeneratorConfig)) return true;
+  const model = contentGeneratorConfig.model ?? '';
+  return model.toLowerCase().includes('mistral');
+}
+
+export class MistralOpenAICompatibleProvider extends DefaultOpenAICompatibleProvider {
+  constructor(
+    contentGeneratorConfig: ContentGeneratorConfig,
+    cliConfig: Config,
+  ) {
+    super(contentGeneratorConfig, cliConfig);
+  }
+
+  static isMistralProvider = isMistralProvider;
+  static isMistralHostname = isMistralHostname;
+
+  override buildRequest(
+    request: OpenAI.Chat.ChatCompletionCreateParams,
+    userPromptId: string,
+  ): OpenAI.Chat.ChatCompletionCreateParams {
+    const baseRequest = super.buildRequest(request, userPromptId);
+    if (!baseRequest.messages?.length) {
+      return baseRequest;
+    }
+
+    let changed = false;
+    const messages = baseRequest.messages.map((message) => {
+      const sanitized = stripReasoningContent(message);
+      if (sanitized !== message) {
+        changed = true;
+      }
+      return sanitized;
+    });
+
+    if (!changed) {
+      return baseRequest;
+    }
+
+    return {
+      ...baseRequest,
+      messages,
+    };
+  }
+}
+
+function stripReasoningContent(
+  message: OpenAI.Chat.ChatCompletionMessageParam,
+): OpenAI.Chat.ChatCompletionMessageParam {
+  if (message.role !== 'assistant') {
+    return message;
+  }
+
+  const record = message as OpenAI.Chat.ChatCompletionMessageParam &
+    Record<string, unknown>;
+  if (!Object.prototype.hasOwnProperty.call(record, 'reasoning_content')) {
+    return message;
+  }
+
+  const sanitized = { ...record };
+  delete sanitized['reasoning_content'];
+  return sanitized as OpenAI.Chat.ChatCompletionMessageParam;
+}


### PR DESCRIPTION
Fixes #3304

## Summary
- Add a Mistral OpenAI-compatible provider selected by the official Mistral host or Mistral model-name fallback.
- Sanitize outbound Mistral chat requests by removing `reasoning_content` from assistant messages before the provider call.
- Preserve shared chat history and the existing OpenAI-compatible request pipeline; the sanitization happens only in `buildRequest()`.

## Root Cause
When users switch from a reasoning model to Mistral in the same session, previous assistant turns can contain `reasoning_content`. Mistral's strict OpenAI-compatible API rejects that non-standard message field, while Qwen Code was forwarding the shared history unchanged.

## Validation
- `npm run test --workspace=packages/core -- src/core/openaiContentGenerator/provider/mistral.test.ts -t reasoning_content`
- `npm run test --workspace=packages/core -- src/core/openaiContentGenerator/provider/mistral.test.ts src/core/openaiContentGenerator/provider/deepseek.test.ts`
- `npm run lint --workspace=packages/core`
- `npm run typecheck --workspace=packages/core`
- `npx prettier --check packages/core/src/core/openaiContentGenerator/provider/mistral.ts packages/core/src/core/openaiContentGenerator/provider/mistral.test.ts packages/core/src/core/openaiContentGenerator/provider/index.ts packages/core/src/core/openaiContentGenerator/index.ts`