### PR TITLE
[codex] Persist ACP model selection

### DIFF
--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -402,10 +402,13 @@ class QwenAgent implements Agent {
         break;
       }
       case 'model': {
-        await this.unstable_setSessionModel({
-          sessionId,
-          modelId: value as string,
-        });
+        await session.setModel(
+          {
+            sessionId,
+            modelId: value as string,
+          },
+          { persistDefault: false },
+        );
         break;
       }
       default:

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -12,6 +12,7 @@ import { Session } from './Session.js';
 import type { Config, GeminiChat } from '@qwen-code/qwen-code-core';
 import { ApprovalMode, AuthType } from '@qwen-code/qwen-code-core';
 import * as core from '@qwen-code/qwen-code-core';
+import { SettingScope } from '../../config/settings.js';
 import type {
   AgentSideConnection,
   PromptRequest,
@@ -158,7 +159,11 @@ describe('Session', () => {
 
     mockSettings = {
       merged: {},
-    } as LoadedSettings;
+      isTrusted: false,
+      user: { settings: {} },
+      workspace: { settings: {} },
+      setValue: vi.fn(),
+    } as unknown as LoadedSettings;
 
     getAvailableCommandsSpy = vi.mocked(nonInteractiveCliCommands)
       .getAvailableCommands as unknown as ReturnType<typeof vi.fn>;
@@ -216,6 +221,16 @@ describe('Session', () => {
         'qwen3-coder-plus',
         undefined,
       );
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'model.name',
+        'qwen3-coder-plus',
+      );
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'security.auth.selectedType',
+        AuthType.USE_OPENAI,
+      );
     });
 
     it('rejects empty/whitespace model IDs', async () => {
@@ -227,6 +242,24 @@ describe('Session', () => {
       ).rejects.toThrow('Invalid params');
 
       expect(mockConfig.switchModel).not.toHaveBeenCalled();
+      expect(mockSettings.setValue).not.toHaveBeenCalled();
+    });
+
+    it('can switch the session model without persisting a new default', async () => {
+      await session.setModel(
+        {
+          sessionId: 'test-session-id',
+          modelId: `qwen3-coder-flash(${AuthType.USE_OPENAI})`,
+        },
+        { persistDefault: false },
+      );
+
+      expect(mockConfig.switchModel).toHaveBeenCalledWith(
+        AuthType.USE_OPENAI,
+        'qwen3-coder-flash',
+        undefined,
+      );
+      expect(mockSettings.setValue).not.toHaveBeenCalled();
     });
 
     it('propagates errors from config.switchModel', async () => {
@@ -239,6 +272,7 @@ describe('Session', () => {
           modelId: `invalid-model(${AuthType.USE_OPENAI})`,
         }),
       ).rejects.toThrow('Invalid model');
+      expect(mockSettings.setValue).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -88,6 +88,7 @@ import { isSlashCommand } from '../../ui/utils/commandUtils.js';
 import { CommandKind } from '../../ui/commands/types.js';
 import { parseAcpModelOption } from '../../utils/acpModelUtils.js';
 import { classifyApiError } from '../../ui/hooks/useGeminiStream.js';
+import { getPersistScopeForModelSelection } from '../../config/modelProvidersScope.js';
 
 // Import modular session components
 import type {
@@ -1337,6 +1338,7 @@ export class Session implements SessionContext {
    */
   async setModel(
     params: SetSessionModelRequest,
+    options: { persistDefault?: boolean } = {},
   ): Promise<SetSessionModelResponse | void> {
     const rawModelId = params.modelId.trim();
 
@@ -1363,6 +1365,16 @@ export class Session implements SessionContext {
         ? { requireCachedCredentials: true }
         : undefined,
     );
+
+    if (options.persistDefault ?? true) {
+      const persistScope = getPersistScopeForModelSelection(this.settings);
+      this.settings.setValue(persistScope, 'model.name', parsed.modelId);
+      this.settings.setValue(
+        persistScope,
+        'security.auth.selectedType',
+        selectedAuthType,
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

Persist ACP `session/set_model` selections as the default CLI model, matching the behavior users expect from interactive model switching.

`session/set_config_option` with `configId: "model"` remains session-scoped and does not persist a new default. This preserves temporary model changes used by ACP clients while allowing explicit model switches from clients like the VS Code extension to update future sessions.

## Validation

- `npm run build`
- `cd packages/cli && npx vitest run src/acp-integration/session/Session.test.ts`
- `npm run typecheck --workspace=packages/cli`

<img width="1886" height="476" alt="image" src="https://github.com/user-attachments/assets/bf204283-04bd-47be-8a07-88cb234494a7" />
