### PR TITLE
fix(vscode): mark Qwen OAuth coder-model as Discontinued in model picker

### DIFF
--- a/packages/cli/src/utils/acpModelUtils.ts
+++ b/packages/cli/src/utils/acpModelUtils.ts
@@ -9,6 +9,12 @@ import { z } from 'zod';
 
 /**
  * ACP model IDs are represented as `${modelId}(${authType})` in the ACP protocol.
+ *
+ * NOTE: The VSCode webview side mirrors this encoding contract in
+ * `packages/vscode-ide-companion/src/webview/utils/discontinuedModel.ts` to
+ * detect discontinued Qwen OAuth registry models without changing the wire
+ * format. If the encoding here evolves (new authTypes, runtime prefix changes,
+ * etc.), update that file too.
  */
 export function formatAcpModelId(modelId: string, authType: AuthType): string {
   return `${modelId}(${authType})`;

--- a/packages/vscode-ide-companion/src/webview/components/layout/ModelSelector.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/components/layout/ModelSelector.test.tsx
@@ -217,4 +217,46 @@ describe('ModelSelector — discontinued state (Issue #3745)', () => {
       container.querySelector('[data-testid="model-selector-blocked"]'),
     ).toBeNull();
   });
+
+  it('clears a stale blocked message when navigating with ArrowDown / ArrowUp', () => {
+    const { container } = renderModelSelector({
+      models: [discontinuedModel, otherProviderModel],
+    });
+    const discontinuedRow = container.querySelector(
+      '[data-discontinued="true"]',
+    ) as HTMLElement;
+
+    act(() => {
+      discontinuedRow.click();
+    });
+    expect(
+      container.querySelector('[data-testid="model-selector-blocked"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }),
+      );
+    });
+    expect(
+      container.querySelector('[data-testid="model-selector-blocked"]'),
+    ).toBeNull();
+
+    // Re-trigger the banner, then verify ArrowUp also clears it.
+    act(() => {
+      discontinuedRow.click();
+    });
+    expect(
+      container.querySelector('[data-testid="model-selector-blocked"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowUp', bubbles: true }),
+      );
+    });
+    expect(
+      container.querySelector('[data-testid="model-selector-blocked"]'),
+    ).toBeNull();
+  });
 });

--- a/packages/vscode-ide-companion/src/webview/components/layout/ModelSelector.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/components/layout/ModelSelector.test.tsx
@@ -1,0 +1,220 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** @vitest-environment jsdom */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { ModelInfo } from '@agentclientprotocol/sdk';
+import { ModelSelector } from './ModelSelector.js';
+
+vi.mock('@qwen-code/webui', () => ({
+  PlanCompletedIcon: () => null,
+}));
+
+interface RenderHandle {
+  container: HTMLDivElement;
+  root: Root;
+  onSelectModel: ReturnType<typeof vi.fn>;
+  onClose: ReturnType<typeof vi.fn>;
+}
+
+const handles: RenderHandle[] = [];
+
+beforeEach(() => {
+  (
+    globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+  Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+
+function renderModelSelector(props: {
+  models: ModelInfo[];
+  currentModelId?: string | null;
+  visible?: boolean;
+}): RenderHandle {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const onSelectModel = vi.fn();
+  const onClose = vi.fn();
+
+  act(() => {
+    root.render(
+      <ModelSelector
+        visible={props.visible ?? true}
+        models={props.models}
+        currentModelId={props.currentModelId ?? null}
+        onSelectModel={onSelectModel}
+        onClose={onClose}
+      />,
+    );
+  });
+
+  const handle: RenderHandle = { container, root, onSelectModel, onClose };
+  handles.push(handle);
+  return handle;
+}
+
+afterEach(() => {
+  while (handles.length > 0) {
+    const handle = handles.pop()!;
+    act(() => {
+      handle.root.unmount();
+    });
+    handle.container.remove();
+  }
+});
+
+const discontinuedModel: ModelInfo = {
+  modelId: 'qwen3-coder-plus(qwen-oauth)',
+  name: 'Qwen3 Coder Plus',
+  description: 'Original description should be replaced',
+};
+
+const runtimeOAuthModel: ModelInfo = {
+  modelId: '$runtime|qwen-oauth|qwen3-coder-plus(qwen-oauth)',
+  name: 'Qwen3 Coder Plus (Runtime)',
+};
+
+const otherProviderModel: ModelInfo = {
+  modelId: 'gpt-4(openai)',
+  name: 'GPT-4',
+  description: 'OpenAI flagship',
+};
+
+describe('ModelSelector — discontinued state (Issue #3745)', () => {
+  it('renders the (Discontinued) badge for non-runtime Qwen OAuth models', () => {
+    const { container } = renderModelSelector({
+      models: [discontinuedModel],
+    });
+    const row = container.querySelector('[data-discontinued="true"]');
+    expect(row).not.toBeNull();
+    const badge = container.querySelector('[data-testid="discontinued-badge"]');
+    expect(badge?.textContent).toBe('(Discontinued)');
+    expect(row?.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('replaces description with the migration hint for discontinued models', () => {
+    const { container } = renderModelSelector({
+      models: [discontinuedModel],
+    });
+    expect(container.textContent).toContain(
+      'Discontinued — switch to Coding Plan or API Key',
+    );
+    expect(container.textContent).not.toContain(
+      'Original description should be replaced',
+    );
+  });
+
+  it('does NOT mark a runtime Qwen OAuth snapshot as discontinued', () => {
+    const { container } = renderModelSelector({
+      models: [runtimeOAuthModel],
+    });
+    expect(container.querySelector('[data-discontinued="true"]')).toBeNull();
+    expect(
+      container.querySelector('[data-testid="discontinued-badge"]'),
+    ).toBeNull();
+  });
+
+  it('blocks click selection on a discontinued model and surfaces an inline error', () => {
+    const { container, onSelectModel, onClose } = renderModelSelector({
+      models: [discontinuedModel],
+    });
+    const row = container.querySelector(
+      '[data-discontinued="true"]',
+    ) as HTMLElement;
+    expect(row).not.toBeNull();
+
+    act(() => {
+      row.click();
+    });
+
+    expect(onSelectModel).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+    const blocked = container.querySelector(
+      '[data-testid="model-selector-blocked"]',
+    );
+    expect(blocked?.textContent).toContain(
+      'Qwen OAuth free tier was discontinued on 2026-04-15',
+    );
+  });
+
+  it('allows clicking a non-discontinued model exactly once', () => {
+    const { container, onSelectModel, onClose } = renderModelSelector({
+      models: [otherProviderModel],
+    });
+    const row = container.querySelector('[data-index="0"]') as HTMLElement;
+    act(() => {
+      row.click();
+    });
+    expect(onSelectModel).toHaveBeenCalledTimes(1);
+    expect(onSelectModel).toHaveBeenCalledWith('gpt-4(openai)');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a runtime Qwen OAuth snapshot selectable', () => {
+    const { container, onSelectModel } = renderModelSelector({
+      models: [runtimeOAuthModel],
+    });
+    const row = container.querySelector('[data-index="0"]') as HTMLElement;
+    act(() => {
+      row.click();
+    });
+    expect(onSelectModel).toHaveBeenCalledWith(runtimeOAuthModel.modelId);
+  });
+
+  it('blocks the keyboard Enter path on a discontinued model', () => {
+    const { onSelectModel, onClose } = renderModelSelector({
+      models: [discontinuedModel],
+    });
+
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }),
+      );
+    });
+
+    expect(onSelectModel).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('clears a stale blocked message when hovering another row', () => {
+    const { container } = renderModelSelector({
+      models: [discontinuedModel, otherProviderModel],
+    });
+    const discontinuedRow = container.querySelector(
+      '[data-discontinued="true"]',
+    ) as HTMLElement;
+    const otherRow = container.querySelectorAll(
+      '[data-index]',
+    )[1] as HTMLElement;
+
+    act(() => {
+      discontinuedRow.click();
+    });
+    expect(
+      container.querySelector('[data-testid="model-selector-blocked"]'),
+    ).not.toBeNull();
+
+    // React 19 synthesizes onMouseEnter from `mouseover` with boundary checks.
+    // Dispatching `mouseover` on the target row reliably triggers the React
+    // handler in jsdom; raw `mouseenter` does not bubble through the delegated
+    // listener.
+    act(() => {
+      otherRow.dispatchEvent(
+        new MouseEvent('mouseover', { bubbles: true, relatedTarget: null }),
+      );
+    });
+    expect(
+      container.querySelector('[data-testid="model-selector-blocked"]'),
+    ).toBeNull();
+  });
+});

--- a/packages/vscode-ide-companion/src/webview/components/layout/ModelSelector.tsx
+++ b/packages/vscode-ide-companion/src/webview/components/layout/ModelSelector.tsx
@@ -8,6 +8,10 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import type { FC } from 'react';
 import type { ModelInfo } from '@agentclientprotocol/sdk';
 import { PlanCompletedIcon } from '@qwen-code/webui';
+import {
+  DISCONTINUED_MESSAGES,
+  isDiscontinuedModel,
+} from '../../utils/discontinuedModel.js';
 
 interface ModelSelectorProps {
   visible: boolean;
@@ -27,6 +31,7 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
   const containerRef = useRef<HTMLDivElement>(null);
   const [selected, setSelected] = useState(0);
   const [mounted, setMounted] = useState(false);
+  const [blockedMessage, setBlockedMessage] = useState<string | null>(null);
 
   // Reset selection when models change or when opened
   useEffect(() => {
@@ -37,10 +42,24 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
       );
       setSelected(currentIndex >= 0 ? currentIndex : 0);
       setMounted(true);
+      setBlockedMessage(null);
     } else {
       setMounted(false);
+      setBlockedMessage(null);
     }
   }, [visible, models, currentModelId]);
+
+  const handleModelSelect = useCallback(
+    (modelId: string) => {
+      if (isDiscontinuedModel(modelId)) {
+        setBlockedMessage(DISCONTINUED_MESSAGES.blockedError);
+        return;
+      }
+      onSelectModel(modelId);
+      onClose();
+    },
+    [onSelectModel, onClose],
+  );
 
   // Handle clicking outside to close and keyboard navigation
   useEffect(() => {
@@ -67,16 +86,23 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
           event.preventDefault();
           setSelected((prev) => Math.max(prev - 1, 0));
           break;
-        case 'Enter':
+        case 'Enter': {
           // Prevent form submission AND stop propagation so the input form
           // does not treat this Enter as a message send.
           event.preventDefault();
           event.stopPropagation();
-          if (models[selected]) {
-            onSelectModel(models[selected].modelId);
-            onClose();
+          const target = models[selected];
+          if (!target) {
+            break;
           }
+          if (isDiscontinuedModel(target.modelId)) {
+            setBlockedMessage(DISCONTINUED_MESSAGES.blockedError);
+            break;
+          }
+          onSelectModel(target.modelId);
+          onClose();
           break;
+        }
         case 'Escape':
           event.preventDefault();
           onClose();
@@ -108,14 +134,6 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
     }
   }, [selected]);
 
-  const handleModelSelect = useCallback(
-    (modelId: string) => {
-      onSelectModel(modelId);
-      onClose();
-    },
-    [onSelectModel, onClose],
-  );
-
   if (!visible) {
     return null;
   }
@@ -139,6 +157,24 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
         Select a model
       </div>
 
+      {/* Inline blocked-selection error (cleared on hover or close) */}
+      {blockedMessage && (
+        <div
+          role="alert"
+          data-testid="model-selector-blocked"
+          className="mx-2 mb-1 rounded px-3 py-2 text-[0.85em]"
+          style={{
+            background: 'var(--vscode-inputValidation-warningBackground)',
+            color: 'var(--vscode-inputValidation-warningForeground)',
+            border:
+              '1px solid var(--vscode-inputValidation-warningBorder, transparent)',
+          }}
+        >
+          <span aria-hidden="true">⚠ </span>
+          {blockedMessage}
+        </div>
+      )}
+
       {/* Model list */}
       <div className="flex max-h-[300px] flex-col overflow-y-auto p-[var(--app-list-padding)] pb-2">
         {models.length === 0 ? (
@@ -149,16 +185,31 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
           models.map((model, index) => {
             const isActive = index === selected;
             const isCurrentModel = model.modelId === currentModelId;
+            const discontinued = isDiscontinuedModel(model.modelId);
+            const description = discontinued
+              ? DISCONTINUED_MESSAGES.description
+              : model.description;
             return (
               <div
                 key={model.modelId}
                 data-index={index}
+                data-discontinued={discontinued ? 'true' : undefined}
                 role="menuitem"
+                aria-disabled={discontinued ? 'true' : undefined}
                 onClick={() => handleModelSelect(model.modelId)}
-                onMouseEnter={() => setSelected(index)}
+                onMouseEnter={() => {
+                  setSelected(index);
+                  // Clear stale block message when hovering a different row so
+                  // back-to-back attempts on different discontinued models still
+                  // produce fresh feedback.
+                  setBlockedMessage(null);
+                }}
                 className={[
                   'model-selector-item',
-                  'mx-1 cursor-pointer rounded-[var(--app-list-border-radius)]',
+                  'mx-1 rounded-[var(--app-list-border-radius)]',
+                  discontinued
+                    ? 'cursor-not-allowed opacity-60'
+                    : 'cursor-pointer',
                   'p-[var(--app-list-item-padding)]',
                   isActive ? 'bg-[var(--app-list-active-background)]' : '',
                 ].join(' ')}
@@ -174,10 +225,33 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
                       ].join(' ')}
                     >
                       {model.name}
+                      {discontinued && (
+                        <span
+                          data-testid="discontinued-badge"
+                          className="ml-1.5 text-[0.85em]"
+                          style={{
+                            color:
+                              'var(--vscode-editorWarning-foreground, #cca700)',
+                          }}
+                        >
+                          {DISCONTINUED_MESSAGES.badge}
+                        </span>
+                      )}
                     </span>
-                    {model.description && (
-                      <span className="block truncate text-[0.85em] text-[var(--app-secondary-foreground)] opacity-70">
-                        {model.description}
+                    {description && (
+                      <span
+                        className="block truncate text-[0.85em] text-[var(--app-secondary-foreground)] opacity-70"
+                        style={
+                          discontinued
+                            ? {
+                                color:
+                                  'var(--vscode-editorWarning-foreground, #cca700)',
+                                opacity: 1,
+                              }
+                            : undefined
+                        }
+                      >
+                        {description}
                       </span>
                     )}
                   </div>

--- a/packages/vscode-ide-companion/src/webview/components/layout/ModelSelector.tsx
+++ b/packages/vscode-ide-companion/src/webview/components/layout/ModelSelector.tsx
@@ -81,10 +81,14 @@ export const ModelSelector: FC<ModelSelectorProps> = ({
         case 'ArrowDown':
           event.preventDefault();
           setSelected((prev) => Math.min(prev + 1, models.length - 1));
+          // Clear stale block banner so keyboard navigation gives the same
+          // feedback as mouse hover.
+          setBlockedMessage(null);
           break;
         case 'ArrowUp':
           event.preventDefault();
           setSelected((prev) => Math.max(prev - 1, 0));
+          setBlockedMessage(null);
           break;
         case 'Enter': {
           // Prevent form submission AND stop propagation so the input form

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.test.ts
@@ -23,6 +23,7 @@ vi.mock('vscode', () => ({
   window: {
     showWarningMessage: vi.fn(),
     showErrorMessage: mockShowErrorMessage,
+    showInformationMessage: vi.fn(),
   },
   commands: {
     executeCommand: mockExecuteCommand,
@@ -499,6 +500,94 @@ describe('SessionMessageHandler', () => {
         content:
           'Session exported to HTML: [export (#1).html](file:///workspace/export%20(%231).html)',
       }),
+    });
+  });
+
+  describe('handleSetModel — discontinued model defensive validation (Issue #3745)', () => {
+    it('rejects a non-runtime Qwen OAuth model and surfaces an error', async () => {
+      const setModelFromUi = vi.fn();
+      const agentManager = {
+        isConnected: true,
+        currentSessionId: 'session-1',
+        setModelFromUi,
+      };
+      const sendToWebView = vi.fn();
+      const handler = new SessionMessageHandler(
+        agentManager as never,
+        {} as never,
+        null,
+        sendToWebView,
+      );
+
+      await handler.handle({
+        type: 'setModel',
+        data: { modelId: 'qwen3-coder-plus(qwen-oauth)' },
+      });
+
+      expect(setModelFromUi).not.toHaveBeenCalled();
+      expect(mockShowErrorMessage).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Qwen OAuth free tier was discontinued on 2026-04-15',
+        ),
+      );
+      expect(sendToWebView).toHaveBeenCalledWith({
+        type: 'error',
+        data: expect.objectContaining({
+          message: expect.stringContaining('discontinued'),
+        }),
+      });
+    });
+
+    it('allows a runtime Qwen OAuth snapshot to pass through', async () => {
+      const setModelFromUi = vi.fn().mockResolvedValue(undefined);
+      const agentManager = {
+        isConnected: true,
+        currentSessionId: 'session-1',
+        setModelFromUi,
+      };
+      const sendToWebView = vi.fn();
+      const handler = new SessionMessageHandler(
+        agentManager as never,
+        {} as never,
+        null,
+        sendToWebView,
+      );
+
+      await handler.handle({
+        type: 'setModel',
+        data: {
+          modelId: '$runtime|qwen-oauth|qwen3-coder-plus(qwen-oauth)',
+        },
+      });
+
+      expect(setModelFromUi).toHaveBeenCalledWith(
+        '$runtime|qwen-oauth|qwen3-coder-plus(qwen-oauth)',
+      );
+      expect(mockShowErrorMessage).not.toHaveBeenCalled();
+    });
+
+    it('passes through other-provider models (regression — no false positives)', async () => {
+      const setModelFromUi = vi.fn().mockResolvedValue(undefined);
+      const agentManager = {
+        isConnected: true,
+        currentSessionId: 'session-1',
+        setModelFromUi,
+      };
+      const sendToWebView = vi.fn();
+      const handler = new SessionMessageHandler(
+        agentManager as never,
+        {} as never,
+        null,
+        sendToWebView,
+      );
+
+      await handler.handle({
+        type: 'setModel',
+        data: { modelId: 'gpt-4(openai)' },
+      });
+
+      expect(setModelFromUi).toHaveBeenCalledWith('gpt-4(openai)');
+      expect(mockShowErrorMessage).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
+++ b/packages/vscode-ide-companion/src/webview/handlers/SessionMessageHandler.ts
@@ -21,6 +21,10 @@ import {
   parseExportSlashCommand,
   type SessionExportFormat,
 } from '../../services/sessionExportService.js';
+import {
+  DISCONTINUED_MESSAGES,
+  isDiscontinuedModel,
+} from '../utils/discontinuedModel.js';
 
 function formatExportSuccessMessage(
   formatLabel: string,
@@ -1256,6 +1260,21 @@ export class SessionMessageHandler extends BaseMessageHandler {
       const modelId = data?.modelId;
       if (!modelId) {
         throw new Error('Model ID is required');
+      }
+      // Defensive guard: refuse non-runtime Qwen OAuth models in case the UI
+      // is bypassed (programmatic call, stale webview, restored session).
+      if (isDiscontinuedModel(modelId)) {
+        console.warn(
+          '[SessionMessageHandler] Rejected discontinued model',
+          modelId,
+        );
+        const message = `Failed to switch model: ${DISCONTINUED_MESSAGES.blockedError}`;
+        vscode.window.showErrorMessage(message);
+        this.sendToWebView({
+          type: 'error',
+          data: { message },
+        });
+        return;
       }
       await this.agentManager.setModelFromUi(modelId);
       void vscode.window.showInformationMessage(

--- a/packages/vscode-ide-companion/src/webview/utils/discontinuedModel.test.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/discontinuedModel.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  DISCONTINUED_MESSAGES,
+  isDiscontinuedModel,
+  parseAcpModelId,
+  QWEN_OAUTH_AUTH_TYPE,
+} from './discontinuedModel.js';
+
+describe('parseAcpModelId', () => {
+  it('extracts authType and base model id from a registry entry', () => {
+    expect(parseAcpModelId('qwen3-coder-plus(qwen-oauth)')).toEqual({
+      baseModelId: 'qwen3-coder-plus',
+      authType: 'qwen-oauth',
+      isRuntime: false,
+    });
+  });
+
+  it('marks runtime snapshots and still strips the trailing wrapper', () => {
+    expect(
+      parseAcpModelId('$runtime|qwen-oauth|qwen3-coder-plus(qwen-oauth)'),
+    ).toEqual({
+      baseModelId: '$runtime|qwen-oauth|qwen3-coder-plus',
+      authType: 'qwen-oauth',
+      isRuntime: true,
+    });
+  });
+
+  it('preserves inner parens and only strips the anchored trailing wrapper', () => {
+    expect(parseAcpModelId('foo(bar)(openai)')).toEqual({
+      baseModelId: 'foo(bar)',
+      authType: 'openai',
+      isRuntime: false,
+    });
+  });
+
+  it('returns the raw id when no trailing wrapper is present', () => {
+    expect(parseAcpModelId('plain-model-id')).toEqual({
+      baseModelId: 'plain-model-id',
+      isRuntime: false,
+    });
+  });
+
+  it('trims surrounding whitespace before parsing', () => {
+    expect(parseAcpModelId('  gpt-4(openai)  ')).toEqual({
+      baseModelId: 'gpt-4',
+      authType: 'openai',
+      isRuntime: false,
+    });
+  });
+});
+
+describe('isDiscontinuedModel', () => {
+  it('flags a non-runtime Qwen OAuth registry entry as discontinued', () => {
+    expect(isDiscontinuedModel('qwen3-coder-plus(qwen-oauth)')).toBe(true);
+  });
+
+  it('does NOT flag a runtime Qwen OAuth snapshot as discontinued', () => {
+    expect(
+      isDiscontinuedModel('$runtime|qwen-oauth|qwen3-coder-plus(qwen-oauth)'),
+    ).toBe(false);
+  });
+
+  it('does NOT flag other providers', () => {
+    expect(isDiscontinuedModel('gpt-4(openai)')).toBe(false);
+    expect(isDiscontinuedModel('claude-sonnet-4-6(anthropic)')).toBe(false);
+    expect(isDiscontinuedModel('gemini-2.5-pro(gemini)')).toBe(false);
+  });
+
+  it('returns false for empty / non-string ids', () => {
+    expect(isDiscontinuedModel('')).toBe(false);
+    expect(isDiscontinuedModel(undefined as unknown as string)).toBe(false);
+    expect(isDiscontinuedModel(null as unknown as string)).toBe(false);
+  });
+
+  it('returns false when the wrapper is absent (defensive)', () => {
+    expect(isDiscontinuedModel('qwen3-coder-plus')).toBe(false);
+  });
+});
+
+describe('DISCONTINUED_MESSAGES', () => {
+  it('exposes the three user-facing strings', () => {
+    expect(DISCONTINUED_MESSAGES.badge).toBe('(Discontinued)');
+    expect(DISCONTINUED_MESSAGES.description).toMatch(/Discontinued/);
+    expect(DISCONTINUED_MESSAGES.blockedError).toContain('2026-04-15');
+  });
+});
+
+describe('QWEN_OAUTH_AUTH_TYPE', () => {
+  it('matches the encoded value used by the ACP server', () => {
+    expect(QWEN_OAUTH_AUTH_TYPE).toBe('qwen-oauth');
+  });
+});

--- a/packages/vscode-ide-companion/src/webview/utils/discontinuedModel.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/discontinuedModel.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Discontinued-model detection for the ACP `availableModels` payload.
+ *
+ * The ACP server emits each model id wrapped as `${modelId}(${authType})`,
+ * e.g. `qwen3-coder-plus(qwen-oauth)`. Runtime model snapshots are additionally
+ * prefixed with `$runtime|${authType}|`, so the wrapped form becomes
+ * `$runtime|qwen-oauth|qwen3-coder-plus(qwen-oauth)`.
+ *
+ * This helper mirrors the encoding contract used by the CLI's
+ * `acpModelUtils.ts` and the discontinued check in the CLI's `ModelDialog`.
+ * Keep these two files in sync when the encoding evolves.
+ */
+
+const RUNTIME_PREFIX = '$runtime|';
+
+/** Auth type marker for the (now-discontinued) Qwen OAuth free tier. */
+export const QWEN_OAUTH_AUTH_TYPE = 'qwen-oauth';
+
+/** User-facing strings for the discontinued state (English-only — webview has no i18n runtime). */
+export const DISCONTINUED_MESSAGES = {
+  badge: '(Discontinued)',
+  description: 'Discontinued — switch to Coding Plan or API Key',
+  blockedError:
+    'Qwen OAuth free tier was discontinued on 2026-04-15. Please select a model from another provider or run /auth to switch.',
+} as const;
+
+export interface ParsedAcpModelId {
+  /** Model id with the trailing `(authType)` marker stripped. */
+  baseModelId: string;
+  /** Auth type extracted from the trailing `(authType)` marker, or `undefined` if none. */
+  authType?: string;
+  /** True when the id starts with `$runtime|` (cached-token snapshot). */
+  isRuntime: boolean;
+}
+
+/**
+ * Parse an ACP-formatted model id into its components.
+ *
+ * Returned `baseModelId` may still contain `$runtime|` prefix to preserve the
+ * caller's original snapshot id; only the trailing auth-type wrapper is removed.
+ */
+export function parseAcpModelId(modelId: string): ParsedAcpModelId {
+  const trimmed = modelId.trim();
+  const isRuntime = trimmed.startsWith(RUNTIME_PREFIX);
+
+  // Anchored trailing `(authType)` — only matches the very end so model labels
+  // containing `(...)` mid-string are safe (the encoding always appends
+  // `(authType)` last).
+  const closeIdx = trimmed.lastIndexOf(')');
+  const openIdx = trimmed.lastIndexOf('(');
+  if (openIdx >= 0 && closeIdx === trimmed.length - 1 && openIdx < closeIdx) {
+    const authType = trimmed.slice(openIdx + 1, closeIdx);
+    const baseModelId = trimmed.slice(0, openIdx);
+    return { baseModelId, authType, isRuntime };
+  }
+
+  return { baseModelId: trimmed, isRuntime };
+}
+
+/**
+ * Returns true when the model id refers to a non-runtime Qwen OAuth registry
+ * entry, matching the CLI's discontinued rule.
+ *
+ * Runtime snapshots from existing cached tokens are intentionally excluded so
+ * already-authenticated sessions keep working until the server rejects them.
+ */
+export function isDiscontinuedModel(modelId: string): boolean {
+  if (typeof modelId !== 'string' || modelId.length === 0) {
+    return false;
+  }
+  const parsed = parseAcpModelId(modelId);
+  return parsed.authType === QWEN_OAUTH_AUTH_TYPE && !parsed.isRuntime;
+}


### PR DESCRIPTION
<!--
Help reviewers verify this PR quickly.

Maintainers prioritize PRs that include clear proof of work.
If a PR does not include enough validation detail to reproduce and verify the change efficiently, review may be delayed.
-->

## Summary

- **What changed:** Mirrored CLI ModelDialog's discontinued-model handling in the VS Code extension's ModelSelector — added "(Discontinued)" badge, replaced description with migration hint, blocked click/Enter selection with inline error, and added defensive validation in `SessionMessageHandler.handleSetModel` to reject discontinued model IDs that bypass the UI. Runtime OAuth snapshots are intentionally left selectable (matching CLI behavior where already-cached tokens keep working until the server rejects them).
- **Why it changed:** The VS Code extension was not reflecting the same discontinued-model UX as the CLI, leaving users able to select a model that the backend no longer supports, resulting in confusing errors.
- **Reviewer focus:** Verify the ModelSelector badge/behavior matches CLI ModelDialog, and that `handleSetModel` correctly rejects discontinued IDs while allowing runtime OAuth snapshots through.

## Validation

<!--
Be concrete. Do not write only "tested locally".
Include the exact commands, prompts, outputs, logs, screenshots, or videos that prove the change was actually run and observed.

For user-visible changes, bug fixes, CLI / TUI behavior changes, or interaction changes, include key screenshots or a short video.
When possible, show before/after behavior.

If helpful, use the `e2e-testing` skill to gather stronger end-to-end validation evidence.
-->

- **Commands run:**
  ```bash
  npm run build
  ```
- **Prompts / inputs used:** Model picker interaction with Qwen OAuth coder-model
- **Expected result:** Discontinued model shows "(Discontinued)" badge, description replaced with migration hint, selection blocked with inline error; runtime OAuth snapshots remain selectable.
- **Observed result:** ModelSelector renders discontinued badge and migration hint; clicking or pressing Enter on a discontinued model shows an error toast; `handleSetModel` rejects the model ID if it slips past the UI.
- **Quickest reviewer verification path:** Open VS Code extension → open model picker → locate a discontinued model → verify badge + blocked selection → verify runtime OAuth model remains selectable.
- **Evidence:** 

<img width="2934" height="1816" alt="qwenOauthDiscontinued" src="https://github.com/user-attachments/assets/a85247cf-baff-4655-b9a2-ccd1f7fc12e2" />

<img width="2928" height="1778" alt="qwenOauthDiscontinuedTips" src="https://github.com/user-attachments/assets/c18571ea-42b2-4f82-a7d6-6eb17e4036cc" />


## Scope / Risk

- **Main risk or tradeoff:** Discontinued-model detection relies on the same source-of-truth as CLI; any drift between CLI and extension lists would cause inconsistent UX.
- **Not covered / not validated:** VS Code extension E2E tests on all platforms; manual verification on Windows/Linux not performed.
- **Breaking changes / migration notes:** None. This is a UX-only change; existing sessions using discontinued models are unaffected (matching CLI behavior).

## Testing Matrix

<!--
Use:
- ✅ tested
- ⚠️ not tested
- N/A
If anything is ⚠️, explain why briefly below.
-->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- VS Code extension-specific tests run on macOS; Windows/Linux matrix pending due to environment constraints.

## Linked Issues / Bugs

<!--
If this PR fully resolves an issue, use one of:
- Closes #<issue_number>
- Fixes #<issue_number>
- Resolves #<issue_number>

Otherwise reference related issues without a closing keyword.
-->

Refs #3745

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)
