### PR TITLE
ci(release): keep skip-ci out of release PR titles

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -399,7 +399,7 @@ jobs:
             pr_url="$(gh pr create \
               --base main \
               --head "${RELEASE_BRANCH}" \
-              --title "chore(release): sdk-typescript ${RELEASE_TAG} [skip ci]" \
+              --title "chore(release): sdk-typescript ${RELEASE_TAG}" \
               --body "Automated release PR for sdk-typescript ${RELEASE_TAG}.")"
           fi
 
@@ -414,10 +414,9 @@ jobs:
           RELEASE_TAG: '${{ steps.version.outputs.RELEASE_TAG }}'
         run: |-
           set -euo pipefail
-          # Keep [skip ci] on the squash commit that lands on main. The release
-          # PR title also includes it for visibility, but --subject makes the
-          # post-merge CI-skip behavior explicit instead of depending on gh's
-          # default squash subject.
+          # Keep [skip ci] only on the squash commit that lands on main. The
+          # release branch commit and PR title intentionally omit it so tag-push
+          # workflows and PR metadata stay unaffected.
           gh pr merge "${PR_URL}" \
             --squash \
             --auto \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,7 +435,7 @@ jobs:
             pr_url="$(gh pr create \
               --base main \
               --head "${RELEASE_BRANCH}" \
-              --title "chore(release): ${RELEASE_TAG} [skip ci]" \
+              --title "chore(release): ${RELEASE_TAG}" \
               --body "Automated release PR for ${RELEASE_TAG}. Syncs package.json versions on main.")"
           fi
 
@@ -450,10 +450,9 @@ jobs:
           RELEASE_TAG: '${{ needs.prepare.outputs.release_tag }}'
         run: |-
           set -euo pipefail
-          # Keep [skip ci] on the squash commit that lands on main. The release
-          # PR title also includes it for visibility, but --subject makes the
-          # post-merge CI-skip behavior explicit instead of depending on gh's
-          # default squash subject.
+          # Keep [skip ci] only on the squash commit that lands on main. The
+          # release branch commit and PR title intentionally omit it so tag-push
+          # workflows and PR metadata stay unaffected.
           gh pr merge "${PR_URL}" \
             --squash \
             --auto \


### PR DESCRIPTION
## Summary

- What changed: remove `[skip ci]` from the auto-generated release PR titles in `release.yml` and `release-sdk.yml`, while keeping `[skip ci]` on the explicit squash merge subject that lands on `main`.
- Why it changed: PR titles are metadata and should not imply they control GitHub Actions skip behavior. The intended skip point is only the main-branch squash commit created by auto-merge.
- Reviewer focus: confirm release branch commits and release PR titles stay clean, while `gh pr merge --subject "... [skip ci]"` still skips the duplicate post-merge main push CI.

## Validation

- Commands run:
  ```bash
  python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml')); yaml.safe_load(open('.github/workflows/release-sdk.yml'))"
  node scripts/lint.js --actionlint
  git diff --check
  rg -n -- "--title .*\\[skip ci\\]|PR title also includes|--subject .*\\[skip ci\\]|release branch commit and PR title" .github/workflows/release.yml .github/workflows/release-sdk.yml
  ```
- Prompts / inputs used: N/A, workflow metadata-only change.
- Expected result: release PR titles no longer include `[skip ci]`; the squash merge subject still includes `[skip ci]` for the main-branch version sync commit.
- Observed result: YAML parsing passed, actionlint passed, whitespace check passed, and grep confirms `[skip ci]` remains only in the squash `--subject` plus the explanatory comments.
- Quickest reviewer verification path:
  1. Check the `gh pr create --title` lines in both release workflows.
  2. Check the `gh pr merge --subject` lines still include `[skip ci]`.
  3. Confirm the nearby comments describe why the marker is intentionally limited to the squash commit.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  ```text
  actionlint: passed
  YAML parse: passed
  git diff --check: passed
  rg: no --title line contains [skip ci]; both --subject lines still do
  ```

## Scope / Risk

- Main risk or tradeoff: the main squash commit still uses `[skip ci]`, so main-push workflows triggered by that version-sync commit remain skipped by design.
- Not covered / not validated: no live release was executed; the change is limited to workflow text and command arguments.
- Breaking changes / migration notes: none.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | N/A | N/A | N/A |
| npx      | N/A | N/A | N/A |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Workflow metadata-only change; no runtime/platform surface.

## Linked Issues / Bugs

Related follow-up to #3912.
