### PR TITLE
chore: Add bilingual requirement to create-issue command

### DIFF
--- a/.qwen/commands/qc/create-issue.md
+++ b/.qwen/commands/qc/create-issue.md
@@ -35,6 +35,16 @@ The user provides a brief description of a feature request or bug report:
   - Bug report: follow @.github/ISSUE_TEMPLATE/bug_report.yml
 - Write from the user's perspective, not as an implementation spec
 - Keep the language clear and concise, AVOID internal implementation details
+- **Bilingual requirement**: The issue body must be in both English and Chinese
+  - English content comes first at the top
+  - Chinese translation goes at the end, wrapped in a `<details>` collapsible tag:
+    ```markdown
+    <details>
+    <summary>中文</summary>
+    (Chinese translation here)
+    </details>
+    ```
+  - The issue title stays in English only — do NOT translate the title
 
 4.  **Review with user**
 


### PR DESCRIPTION
### What this PR does

Updates the `/qc:create-issue` slash command to require bilingual (English + Chinese) issue bodies.

The new rule added to the "Draft the issue" step:

- English content comes first at the top
- Chinese translation is placed at the end, wrapped in a `<details>` collapsible tag
- The issue title stays in English only — no translation

This ensures future issues created via the command follow a consistent bilingual format, making them accessible to both international and Chinese-speaking contributors.

### Reviewer test plan

- Run `/qc:create-issue` with any feature or bug description
- Verify the drafted issue body contains English first, followed by Chinese inside a `<details>` tag
- Verify the issue title is in English only

---

<details>
<summary>中文</summary>

### 这个 PR 做了什么

更新 `/qc:create-issue` 斜杠命令，增加中英双语要求。

在"起草 Issue"步骤中新增规则：

- 英文内容放在最前面
- 中文翻译放在末尾，用 `<details>` 折叠标签包裹
- Issue 标题保持英文，不翻译

这确保以后通过该命令创建的 Issue 都遵循一致的双语格式，方便国际和中文贡献者阅读。

### 评审测试计划

- 用任意功能或 Bug 描述运行 `/qc:create-issue`
- 检查起草的 Issue body：英文在前，中文在 `<details>` 折叠标签内
- 检查 Issue 标题为纯英文

</details>