### PR TITLE
feat(cli): add Idealab as third-party provider

### DIFF
--- a/packages/cli/src/auth/allProviders.ts
+++ b/packages/cli/src/auth/allProviders.ts
@@ -18,6 +18,7 @@ import { openRouterProvider } from './providers/oauth/openrouter.js';
 import { deepseekProvider } from './providers/thirdParty/deepseek.js';
 import { minimaxProvider } from './providers/thirdParty/minimax.js';
 import { zaiProvider } from './providers/thirdParty/zai.js';
+import { idealabProvider } from './providers/thirdParty/idealab.js';
 import { customProvider } from './providers/custom/customProvider.js';
 
 // Re-export all providers
@@ -29,6 +30,7 @@ export {
   deepseekProvider,
   minimaxProvider,
   zaiProvider,
+  idealabProvider,
   customProvider,
 };
 export {
@@ -49,6 +51,7 @@ export const ALL_PROVIDERS: readonly ProviderConfig[] = [
   deepseekProvider,
   minimaxProvider,
   zaiProvider,
+  idealabProvider,
   customProvider,
 ];
 

--- a/packages/cli/src/auth/providers/thirdParty/idealab.test.ts
+++ b/packages/cli/src/auth/providers/thirdParty/idealab.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { AuthType } from '@qwen-code/qwen-code-core';
+import { idealabProvider, buildInstallPlan } from '../../allProviders.js';
+
+describe('idealabProvider', () => {
+  it('has correct provider config', () => {
+    expect(idealabProvider).toMatchObject({
+      id: 'idealab',
+      label: 'Idealab API Key',
+      protocol: AuthType.USE_OPENAI,
+      baseUrl: 'https://idealab.alibaba-inc.com/api/openai/v1',
+      envKey: 'IDEALAB_API_KEY',
+      uiGroup: 'third-party',
+    });
+  });
+
+  it('creates an install plan with per-model metadata for known IDs', () => {
+    const plan = buildInstallPlan(idealabProvider, {
+      baseUrl: 'https://idealab.alibaba-inc.com/api/openai/v1',
+      apiKey: 'sk-idealab',
+      modelIds: ['Qwen3.6-Plus-DogFooding', 'bailian/deepseek-v4-pro'],
+    });
+
+    const models = plan.modelProviders?.[0]?.models;
+    expect(models).toHaveLength(2);
+    expect(models?.[0]).toMatchObject({
+      id: 'Qwen3.6-Plus-DogFooding',
+      name: '[Idealab] Qwen3.6-Plus-DogFooding',
+      generationConfig: { contextWindowSize: 1000000 },
+    });
+    expect(models?.[1]).toMatchObject({
+      id: 'bailian/deepseek-v4-pro',
+      name: '[Idealab] bailian/deepseek-v4-pro',
+      generationConfig: { contextWindowSize: 1000000 },
+    });
+  });
+
+  it('falls back gracefully for unknown model IDs', () => {
+    const plan = buildInstallPlan(idealabProvider, {
+      baseUrl: 'https://idealab.alibaba-inc.com/api/openai/v1',
+      apiKey: 'sk-idealab',
+      modelIds: ['Qwen3.6-Plus-DogFooding', 'some-new-model'],
+    });
+
+    const models = plan.modelProviders?.[0]?.models;
+    expect(models).toHaveLength(2);
+    expect(models?.[0]).toMatchObject({
+      id: 'Qwen3.6-Plus-DogFooding',
+      name: '[Idealab] Qwen3.6-Plus-DogFooding',
+    });
+    expect(models?.[1]).toMatchObject({
+      id: 'some-new-model',
+      name: '[Idealab] some-new-model',
+    });
+    expect(models?.[1]?.generationConfig).toBeUndefined();
+  });
+
+  it('includes all four predefined models', () => {
+    expect(idealabProvider.models).toHaveLength(4);
+    expect(idealabProvider.models?.map((m) => m.id)).toEqual([
+      'Qwen3.6-Plus-DogFooding',
+      'bailian/deepseek-v4-pro',
+      'bailian/deepseek-v4-flash',
+      'bailian/kimi-k2.6',
+    ]);
+  });
+});

--- a/packages/cli/src/auth/providers/thirdParty/idealab.ts
+++ b/packages/cli/src/auth/providers/thirdParty/idealab.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AuthType } from '@qwen-code/qwen-code-core';
+import type { ProviderConfig } from '../../providerConfig.js';
+
+export const idealabProvider: ProviderConfig = {
+  id: 'idealab',
+  label: 'Idealab API Key',
+  description:
+    'Alibaba internal LLM service (Qwen3.6-Plus-DogFooding, DeepSeek V4, Kimi K2.6)',
+  protocol: AuthType.USE_OPENAI,
+  baseUrl: 'https://idealab.alibaba-inc.com/api/openai/v1',
+  envKey: 'IDEALAB_API_KEY',
+  authMethod: 'input',
+  models: [
+    {
+      id: 'Qwen3.6-Plus-DogFooding',
+      contextWindowSize: 1000000,
+      enableThinking: true,
+      modalities: { image: true, video: true },
+    },
+    {
+      id: 'bailian/deepseek-v4-pro',
+      contextWindowSize: 1000000,
+      enableThinking: true,
+      modalities: { image: true, video: true },
+    },
+    {
+      id: 'bailian/deepseek-v4-flash',
+      contextWindowSize: 1000000,
+      enableThinking: true,
+      modalities: { image: true, video: true },
+    },
+    {
+      id: 'bailian/kimi-k2.6',
+      contextWindowSize: 262144,
+      enableThinking: true,
+      modalities: { image: true, video: true },
+    },
+  ],
+  modelsEditable: true,
+  modelNamePrefix: 'Idealab',
+  uiGroup: 'third-party',
+};


### PR DESCRIPTION
## Summary

- **What changed:** Added Idealab as a built-in third-party provider in the auth flow. Idealab is Alibaba's internal LLM service, placed alongside DeepSeek, MiniMax, and Z.AI in the third-party group.
- **Why it changed:** Alibaba internal users can use Idealab for free. Making it a first-class built-in provider lowers the barrier to entry and avoids manual Custom Provider setup.
- **Reviewer focus:**
  - Provider config correctness (`idealab.ts`)
  - Registration in `allProviders.ts`
  - Test coverage for install plans and model metadata

<img width="1746" height="1072" alt="image" src="https://github.com/user-attachments/assets/594d8df0-2637-4b8d-96ff-0bafa7725195" />

## Validation

- Commands run:
  ```bash
  cd packages/cli && npx vitest run src/auth/providers/thirdParty/idealab.test.ts
  npm run build && npm run typecheck
  ```
- Expected result: All 4 tests pass, build and typecheck succeed.
- Observed result: ✓ All passed with no errors.
- Quickest reviewer verification path:
  ```bash
  cd packages/cli && npx vitest run src/auth/providers/thirdParty/idealab.test.ts
  ```

### E2E Test (tmux real-user)

Full `/auth` → Third-party → Idealab flow tested end-to-end via tmux real-user testing. Result: **✅ PASS**.

| Step | Screen observation |
|---|---|
| /auth menu | Idealab listed under Third-party Providers with correct description |
| Step 1/2 API Key | "Idealab API Key · Step 1/2 · API Key" |
| Step 2/2 Model IDs | All 4 model IDs shown as examples |
| Auth complete | "Successfully configured Idealab API Key" |
| /model list | 4 `[Idealab]` models appear with correct prefix, protocol, and metadata |

Model detail panel confirms for `Qwen3.6-Plus-DogFooding`:
- Modality: text · image · video
- Context Window: 1,000,000 tokens
- Base URL: https://idealab.alibaba-inc.com/api/openai/v1
- API Key: IDEALAB_API_KEY

E2E logs: `tmp/idealab-auth-tmux-20260508-171256/`

## Scope / Risk

- **Main risk:** Low — this is a pure addition of a new provider definition; no existing behavior is altered.
- **Not covered:** End-to-end Idealab API connectivity (requires internal network).
- **Breaking changes:** None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | N/A | N/A |
| npx      | N/A | N/A | N/A |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes: Unit tests and E2E real-user test verified on macOS.

## Linked Issues

Closes #3953

---

<details>
<summary>中文说明</summary>

## 概述

- **变更内容：** 在认证流程中新增 Idealab 作为内置的第三方提供商。Idealab 是阿里内部的 LLM 服务，与 DeepSeek、MiniMax、Z.AI 并列在 third-party 分组中。
- **变更原因：** 阿里内部用户可免费使用 Idealab。将其作为内置提供商可降低使用门槛，避免手动配置 Custom Provider。
- **审查重点：**
  - Provider 配置正确性（`idealab.ts`）
  - `allProviders.ts` 中的注册
  - 安装计划和模型元数据的测试覆盖

## 验证

- 运行命令：
  ```bash
  cd packages/cli && npx vitest run src/auth/providers/thirdParty/idealab.test.ts
  npm run build && npm run typecheck
  ```
- 预期结果：4 条测试全部通过，build 和 typecheck 均成功。
- 实际结果：✓ 全部通过，无报错。

### E2E 测试（tmux 真实用户）

完整的 `/auth` → Third-party → Idealab 流程已通过 tmux 真实用户测试端到端验证。结果：**✅ PASS**。

| 步骤 | 屏幕观察 |
|---|---|
| /auth 菜单 | Idealab 在 Third-party Providers 中列出，描述正确 |
| Step 1/2 API Key | 显示 "Idealab API Key · Step 1/2 · API Key" |
| Step 2/2 Model IDs | 4 个模型 ID 全部作为示例显示 |
| 认证完成 | "Successfully configured Idealab API Key" |
| /model 列表 | 4 个 `[Idealab]` 模型正确显示，前缀、协议和元数据正确 |

模型详情面板确认 `Qwen3.6-Plus-DogFooding`：
- 模态：text · image · video
- 上下文窗口：1,000,000 tokens
- Base URL：https://idealab.alibaba-inc.com/api/openai/v1
- API Key：IDEALAB_API_KEY

E2E 日志：`tmp/idealab-auth-tmux-20260508-171256/`

## 范围 / 风险

- **主要风险：** 低 — 纯粹新增 provider 定义，不影响现有行为。
- **未覆盖：** Idealab API 端到端连接测试（需要内网环境）。
- **破坏性变更：** 无。

## 关联 Issue

Closes #3953

</details>