### PR TITLE
ci: reduce PR test matrix runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,13 +50,13 @@ jobs:
           ref: '${{ github.event.inputs.branch_ref || github.ref }}'
           fetch-depth: 0
 
-      - name: 'Set up Node.js'
+      - name: 'Set up Node.js 22.x'
         uses: 'actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020' # ratchet:actions/setup-node@v4.4.0
         with:
-          node-version-file: '.nvmrc'
+          node-version: '22.x'
           cache: 'npm'
 
-      - name: 'Install dependencies'
+      - name: 'Install dependencies and run prepare'
         run: 'npm ci'
 
       - name: 'Check lockfile'
@@ -86,9 +86,6 @@ jobs:
       - name: 'Run i18n check'
         run: 'npm run check-i18n'
 
-      - name: 'Build CLI package'
-        run: 'npm run build --workspace=packages/cli'
-
       - name: 'Generate settings schema'
         run: 'npm run generate:settings-schema'
 
@@ -107,10 +104,8 @@ jobs:
   # Test: Node
   #
   test:
-    name: 'Test'
+    name: 'Test (${{ matrix.os }}, Node ${{ matrix.node-version }})'
     runs-on: '${{ matrix.os }}'
-    needs:
-      - 'lint'
     permissions:
       contents: 'read'
       checks: 'write'
@@ -118,14 +113,16 @@ jobs:
     strategy:
       fail-fast: false # So we can see all test failures
       matrix:
-        os:
-          - 'macos-latest'
-          - 'ubuntu-latest'
-          - 'windows-latest'
-        node-version:
-          - '20.x'
-          - '22.x'
-          - '24.x'
+        include:
+          - os: 'macos-latest'
+            node-version: '22.x'
+            upload-coverage: 'false'
+          - os: 'ubuntu-latest'
+            node-version: '22.x'
+            upload-coverage: 'true'
+          - os: 'windows-latest'
+            node-version: '22.x'
+            upload-coverage: 'false'
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8' # ratchet:actions/checkout@v5
@@ -149,10 +146,6 @@ jobs:
         run: |-
           npm ci --prefer-offline --no-audit --progress=false
 
-      - name: 'Build project'
-        run: |-
-          npm run build
-
       - name: 'Run tests and generate reports'
         env:
           NO_COLOR: true
@@ -163,7 +156,7 @@ jobs:
           ${{ always() && (github.event.pull_request.head.repo.full_name == github.repository) }}
         uses: 'dorny/test-reporter@dc3a92680fcc15842eef52e8c4606ea7ce6bd3f3' # ratchet:dorny/test-reporter@v2
         with:
-          name: 'Test Results (Node ${{ matrix.node-version }})'
+          name: 'Test Results (${{ matrix.os }}, Node ${{ matrix.node-version }})'
           path: 'packages/*/junit.xml'
           reporter: 'java-junit'
           fail-on-error: 'false'
@@ -178,7 +171,7 @@ jobs:
 
       - name: 'Upload coverage reports'
         if: |-
-          ${{ always() }}
+          ${{ always() && matrix.upload-coverage == 'true' }}
         uses: 'actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02' # ratchet:actions/upload-artifact@v4
         with:
           name: 'coverage-reports-${{ matrix.node-version }}-${{ matrix.os }}'


### PR DESCRIPTION
## Summary

- What changed: Reduced the `Qwen Code CI` test matrix to 3 representative jobs: Ubuntu, macOS, and Windows on Node 22. The test job no longer waits for `lint`, coverage artifact upload is limited to the Ubuntu Node 22 job, and duplicate explicit build steps after `npm ci` were removed because root `prepare` already runs the build during install.
- Why it changed: CI currently amplifies runner queue time and repeats build work after dependency installation, which slows iteration and increases Actions usage. The meeting direction was to keep the three OS images but stop matrix-testing Node versions, using Node 22 as the stable test runtime.
- Reviewer focus: Please check the simplified GitHub Actions matrix and the build flow: `npm ci` still runs the existing root `prepare`, so separate `Build CLI package` / `Build project` steps are no longer needed.

## Validation

- Commands run:
  ```bash
  npm ci --prefer-offline --no-audit --progress=false
  npm run generate:settings-schema
  node scripts/lint.js --actionlint
  /tmp/qwen-yamllint-venv/bin/yamllint --format github .github/workflows/ci.yml
  npx prettier --check .github/workflows/ci.yml
  git diff --check
  ```
- Prompts / inputs used: N/A, workflow-only CI behavior change.
- Expected result: CI workflow syntax remains valid; `npm ci` runs the existing root `prepare` build, the follow-up schema generation still works, and CI test jobs use a Node 22-only cross-platform matrix.
- Observed result: `npm ci --prefer-offline --no-audit --progress=false` completed successfully in a temporary clean worktree and ran root `prepare` (`husky && npm run build && npm run bundle`). `npm run generate:settings-schema` exited successfully and left the tracked settings schema unchanged. actionlint, yamllint, Prettier, and diff whitespace checks passed locally.
- Quickest reviewer verification path: Review `.github/workflows/ci.yml` matrix generation and run the workflow on this draft PR to compare the generated job set and build steps with the previous 9-job matrix.
- Evidence: The clean-worktree validation confirmed that `npm ci` prepares the build artifacts before the lint schema check. The actual wall-clock improvement should be confirmed from this PR's GitHub Actions run.

## Scope / Risk

- Main risk or tradeoff: CI no longer runs Node 20 or Node 24 in this workflow. It keeps OS coverage across Ubuntu, macOS, and Windows on Node 22.
- Not covered / not validated: Full `npm run test:ci`, Windows runner behavior, and the GitHub-hosted Actions wall-clock improvement are left to the PR CI run itself.
- Breaking changes / migration notes: None expected. Default `npm prepare` behavior is unchanged; this PR removes CI build steps that duplicated that prepare build.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ⚠️  | ⚠️  |
| npx      | N/A | N/A | ✅  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Local validation was run on macOS from a temporary clean worktree.
- The meaningful verification for this change is the generated GitHub Actions job set and runtime on the draft PR.

## Linked Issues / Bugs

Resolves #3943