### PR TITLE
fix(cli): trim blank streaming tails from live preview

### DIFF
--- a/packages/cli/src/ui/utils/MarkdownDisplay.tsx
+++ b/packages/cli/src/ui/utils/MarkdownDisplay.tsx
@@ -173,7 +173,12 @@ const MarkdownDisplayInternal: React.FC<MarkdownDisplayProps> = ({
   if (!text) return <></>;
 
   const renderVisualBlocks = renderMode === 'render';
-  const lines = text.split(/\r?\n/);
+  // Some models stream long runs of trailing newlines after useful content.
+  // Trim them from the live preview so blank rows do not push stable streaming
+  // text into scrollback on every repaint. The committed transcript still
+  // renders the full message via MarkdownDisplay with isPending=false.
+  const displayText = isPending ? text.trimEnd() : text;
+  const lines = displayText.split(/\r?\n/);
   const headerRegex = /^ *(#{1,4}) +(.*)/;
   const codeFenceRegex = /^ *(`{3,}|~{3,}) *([^`]*)$/;
   const ulItemRegex = /^([ \t]*)([-*+]) +(.*)/;


### PR DESCRIPTION
## Problem

Some models stream long runs of trailing newlines after useful content. In the live pending viewport, these blank rows push stable streaming text into scrollback on every repaint tick — making it appear as if content has disappeared from the screen mid-stream.

## Fix

In `MarkdownDisplay`, trim trailing whitespace from the raw text when `isPending=true` before parsing and rendering. The committed transcript still receives the full assistant message (`isPending=false`), so transcript fidelity is preserved.

The change is a one-line `.trimEnd()` applied only to the live pending display path — no impact on completed message rendering.

## Closes

Part of the flicker/scrollback stability work documented in the TUI optimization design.

## Test plan

- [x] `npx vitest run packages/cli/src/ui/utils/MarkdownDisplay.test.tsx` — 101 tests pass

🤖 Generated with [Qwen Code](https://qwen.ai/qwencode)