### PR TITLE
fix(cli): replace clearTerminal with targeted repaint on resize

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -367,6 +367,7 @@ export const AppContainer = (props: AppContainerProps) => {
 
   // Terminal and layout hooks
   const { columns: terminalWidth, rows: terminalHeight } = useTerminalSize();
+  const previousTerminalWidthRef = useRef(terminalWidth);
   const { stdin, setRawMode } = useStdin();
   const { stdout } = useStdout();
 
@@ -560,6 +561,13 @@ export const AppContainer = (props: AppContainerProps) => {
 
   const refreshStatic = useCallback(() => {
     stdout.write(ansiEscapes.clearTerminal);
+    remountStaticHistory();
+  }, [remountStaticHistory, stdout]);
+
+  // Targeted repaint for resize events: move cursor to top-left and erase
+  // downward instead of a full clearTerminal, avoiding the full-screen flash.
+  const repaintStaticViewport = useCallback(() => {
+    stdout.write(`${ansiEscapes.cursorTo(0, 0)}${ansiEscapes.eraseDown}`);
     remountStaticHistory();
   }, [remountStaticHistory, stdout]);
 
@@ -1746,6 +1754,14 @@ export const AppContainer = (props: AppContainerProps) => {
       );
     }
   }, [terminalWidth, availableTerminalHeight, activePtyId]);
+
+  useEffect(() => {
+    if (previousTerminalWidthRef.current === terminalWidth) {
+      return;
+    }
+    previousTerminalWidthRef.current = terminalWidth;
+    repaintStaticViewport();
+  }, [terminalWidth, repaintStaticViewport]);
 
   useEffect(() => {
     if (ideNeedsRestart) {


### PR DESCRIPTION
## Problem

When the terminal is resized, `refreshStatic()` writes `ESC[2J ESC[3J ESC[H]` (full-screen clear) to repaint the static history. This causes a visible full-screen flash on every width change.

Root cause: `AppContainer.tsx` uses `clearTerminal` for all static repaints, including resize events that only need to shift the cursor, not blank the entire screen.

## Fix

Add a separate `repaintStaticViewport()` callback that uses `cursorTo(0, 0) + eraseDown` — a targeted repaint that moves the cursor to the top-left and erases only downward, instead of clearing the whole screen.

Hook it to terminal width changes via a `previousTerminalWidthRef` guard:
- Only fires when column count actually changes (not on height-only resizes)
- `refreshStatic()` (full clear) is preserved for explicit repaints: model switches, `/clear`, IDE trust changes, etc.

## Related

Part of the flicker reduction effort tracked in #3663. Orthogonal to the virtual viewport (#3941) — this fixes the legacy `<Static>` path which remains active when `ui.useTerminalBuffer` is false.

## Test plan

- [ ] Resize terminal width while a long conversation is displayed — no full-screen flash
- [ ] Switch model via `/model` — full repaint still occurs (correct)
- [ ] Run `/clear` — full repaint still occurs (correct)
- [ ] `npx vitest run` in `packages/cli` — existing tests pass

🤖 Generated with [Qwen Code](https://qwen.ai/qwencode)