### PR TITLE
fix(memory): route auto-memory recall selector to fast model

### DIFF
--- a/packages/core/src/memory/relevanceSelector.ts
+++ b/packages/core/src/memory/relevanceSelector.ts
@@ -92,9 +92,8 @@ export async function selectRelevantAutoMemoryDocumentsByModel(
     contents,
     schema: RESPONSE_SCHEMA,
     abortSignal: callerAbortSignal
-      ? AbortSignal.any([AbortSignal.timeout(1_000), callerAbortSignal])
-      : AbortSignal.timeout(1_000),
-
+      ? AbortSignal.any([AbortSignal.timeout(2_000), callerAbortSignal])
+      : AbortSignal.timeout(2_000),
     // Use the fast model for this background side-query to reduce latency and
     // cost. Falls back to the main session model if no fast model is configured.
     model: config.getFastModel(),


### PR DESCRIPTION
## Summary

Routes the auto-memory recall relevance selector to use the fast model instead of the primary model. Memory recall is a background side-query that should use the fast/cheaper model to reduce latency and cost.

## Changes
- `packages/core/src/memory/relevanceSelector.ts`: Changed `config.getModel()` to `config.getFastModel() ?? config.getModel()`

## Impact
- Auto-memory recall now uses the fast model when configured
- Falls back to primary model if no fast model is set