### PR TITLE
ci: skip unnecessary release and SDK checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ env:
 jobs:
   classify_pr:
     name: 'Classify PR'
+    if: "${{ github.event_name == 'pull_request' }}"
     runs-on: 'ubuntu-latest'
+    continue-on-error: true
     outputs:
       skip_ci: '${{ steps.release_sync.outputs.skip_ci }}'
     steps:
@@ -55,13 +57,27 @@ jobs:
           PR_TITLE: "${{ github.event_name == 'pull_request' && github.event.pull_request.title || '' }}"
           RELEASE_SYNC_HEAD_PREFIX: "${{ vars.RELEASE_SYNC_HEAD_PREFIX || 'release/' }}"
           RELEASE_SYNC_TITLE_PREFIX: "${{ vars.RELEASE_SYNC_TITLE_PREFIX || 'chore(release):' }}"
+          RELEASE_SYNC_ACTOR: "${{ vars.RELEASE_SYNC_ACTOR || 'qwen-code-ci-bot' }}"
         run: |-
           skip_ci=false
+          repo_match=false
+          actor_match=false
+          head_match=false
+          title_match=false
+          [[ "${HEAD_REPO}" == "${GITHUB_REPOSITORY}" ]] && repo_match=true
+          [[ "${GITHUB_ACTOR}" == "${RELEASE_SYNC_ACTOR}" ]] && actor_match=true
+          [[ "${HEAD_REF}" == "${RELEASE_SYNC_HEAD_PREFIX}"* ]] && head_match=true
+          [[ "${PR_TITLE}" == "${RELEASE_SYNC_TITLE_PREFIX}"* ]] && title_match=true
+
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" &&
-                "${HEAD_REPO}" == "${GITHUB_REPOSITORY}" &&
-                "${HEAD_REF}" == "${RELEASE_SYNC_HEAD_PREFIX}"* &&
-                "${PR_TITLE}" == "${RELEASE_SYNC_TITLE_PREFIX}"* ]]; then
+                "${repo_match}" == "true" &&
+                "${actor_match}" == "true" &&
+                "${head_match}" == "true" &&
+                "${title_match}" == "true" ]]; then
             skip_ci=true
+            echo "Release sync PR detected: actor=${GITHUB_ACTOR}, head_ref=${HEAD_REF}, title=${PR_TITLE}"
+          else
+            echo "Not a release sync PR: event=${GITHUB_EVENT_NAME}, actor=${GITHUB_ACTOR}, expected_actor=${RELEASE_SYNC_ACTOR}, repo_match=${repo_match}, head_match=${head_match}, title_match=${title_match}"
           fi
 
           echo "skip_ci=${skip_ci}" >> "${GITHUB_OUTPUT}"
@@ -70,7 +86,7 @@ jobs:
   lint:
     name: 'Lint'
     needs: 'classify_pr'
-    if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
+    if: "${{ always() && needs.classify_pr.outputs.skip_ci != 'true' }}"
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
@@ -135,7 +151,7 @@ jobs:
   test:
     name: 'Test (${{ matrix.os }}, Node ${{ matrix.node-version }})'
     needs: 'classify_pr'
-    if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
+    if: "${{ always() && needs.classify_pr.outputs.skip_ci != 'true' }}"
     runs-on: '${{ matrix.os }}'
     permissions:
       contents: 'read'
@@ -256,7 +272,7 @@ jobs:
   codeql:
     name: 'CodeQL'
     needs: 'classify_pr'
-    if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
+    if: "${{ always() && needs.classify_pr.outputs.skip_ci != 'true' }}"
     runs-on: 'ubuntu-latest'
     permissions:
       actions: 'read'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,37 @@ env:
   YAMLLINT_VERSION: '1.35.1'
 
 jobs:
+  classify_pr:
+    name: 'Classify PR'
+    runs-on: 'ubuntu-latest'
+    outputs:
+      skip_ci: '${{ steps.release_sync.outputs.skip_ci }}'
+    steps:
+      - name: 'Detect release version-sync PR'
+        id: 'release_sync'
+        env:
+          # Repository variables can override these defaults if release naming changes.
+          HEAD_REPO: '${{ github.event.pull_request.head.repo.full_name }}'
+          HEAD_REF: '${{ github.head_ref }}'
+          PR_TITLE: '${{ github.event.pull_request.title }}'
+          RELEASE_SYNC_HEAD_PREFIX: "${{ vars.RELEASE_SYNC_HEAD_PREFIX || 'release/' }}"
+          RELEASE_SYNC_TITLE_PREFIX: "${{ vars.RELEASE_SYNC_TITLE_PREFIX || 'chore(release):' }}"
+        run: |-
+          skip_ci=false
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" &&
+                "${HEAD_REPO}" == "${GITHUB_REPOSITORY}" &&
+                "${HEAD_REF}" == "${RELEASE_SYNC_HEAD_PREFIX}"* &&
+                "${PR_TITLE}" == "${RELEASE_SYNC_TITLE_PREFIX}"* ]]; then
+            skip_ci=true
+          fi
+
+          echo "skip_ci=${skip_ci}" >> "${GITHUB_OUTPUT}"
+          echo "skip_ci=${skip_ci}"
+
   lint:
     name: 'Lint'
+    needs: 'classify_pr'
+    if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
@@ -105,6 +134,8 @@ jobs:
   #
   test:
     name: 'Test (${{ matrix.os }}, Node ${{ matrix.node-version }})'
+    needs: 'classify_pr'
+    if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
     runs-on: '${{ matrix.os }}'
     permissions:
       contents: 'read'
@@ -180,9 +211,16 @@ jobs:
   post_coverage_comment:
     name: 'Post Coverage Comment'
     runs-on: 'ubuntu-latest'
-    needs: 'test'
+    needs:
+      - 'classify_pr'
+      - 'test'
     if: |-
-      ${{ always() && github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name == github.repository) }}
+      ${{
+        always() &&
+        needs.classify_pr.outputs.skip_ci != 'true' &&
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      }}
     continue-on-error: true
     permissions:
       contents: 'read' # For checkout
@@ -217,6 +255,8 @@ jobs:
 
   codeql:
     name: 'CodeQL'
+    needs: 'classify_pr'
+    if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
     runs-on: 'ubuntu-latest'
     permissions:
       actions: 'read'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,8 @@ jobs:
       - name: 'Detect release version-sync PR'
         id: 'release_sync'
         env:
-          # Repository variables can override these defaults if release naming changes.
+          # Repository variables can override these defaults if release naming
+          # or the CI bot account changes.
           HEAD_REPO: "${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || '' }}"
           HEAD_REF: "${{ github.event_name == 'pull_request' && github.head_ref || '' }}"
           PR_TITLE: "${{ github.event_name == 'pull_request' && github.event.pull_request.title || '' }}"
@@ -86,7 +87,7 @@ jobs:
   lint:
     name: 'Lint'
     needs: 'classify_pr'
-    if: "${{ always() && needs.classify_pr.outputs.skip_ci != 'true' }}"
+    if: "${{ !cancelled() && needs.classify_pr.outputs.skip_ci != 'true' }}"
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
@@ -151,7 +152,7 @@ jobs:
   test:
     name: 'Test (${{ matrix.os }}, Node ${{ matrix.node-version }})'
     needs: 'classify_pr'
-    if: "${{ always() && needs.classify_pr.outputs.skip_ci != 'true' }}"
+    if: "${{ !cancelled() && needs.classify_pr.outputs.skip_ci != 'true' }}"
     runs-on: '${{ matrix.os }}'
     permissions:
       contents: 'read'
@@ -272,7 +273,7 @@ jobs:
   codeql:
     name: 'CodeQL'
     needs: 'classify_pr'
-    if: "${{ always() && needs.classify_pr.outputs.skip_ci != 'true' }}"
+    if: "${{ !cancelled() && needs.classify_pr.outputs.skip_ci != 'true' }}"
     runs-on: 'ubuntu-latest'
     permissions:
       actions: 'read'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,9 @@ jobs:
         id: 'release_sync'
         env:
           # Repository variables can override these defaults if release naming changes.
-          HEAD_REPO: '${{ github.event.pull_request.head.repo.full_name }}'
-          HEAD_REF: '${{ github.head_ref }}'
-          PR_TITLE: '${{ github.event.pull_request.title }}'
+          HEAD_REPO: "${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || '' }}"
+          HEAD_REF: "${{ github.event_name == 'pull_request' && github.head_ref || '' }}"
+          PR_TITLE: "${{ github.event_name == 'pull_request' && github.event.pull_request.title || '' }}"
           RELEASE_SYNC_HEAD_PREFIX: "${{ vars.RELEASE_SYNC_HEAD_PREFIX || 'release/' }}"
           RELEASE_SYNC_TITLE_PREFIX: "${{ vars.RELEASE_SYNC_TITLE_PREFIX || 'chore(release):' }}"
         run: |-

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -28,7 +28,8 @@ jobs:
       - name: 'Detect release version-sync PR'
         id: 'release_sync'
         env:
-          # Repository variables can override these defaults if release naming changes.
+          # Repository variables can override these defaults if release naming
+          # or the CI bot account changes.
           HEAD_REPO: "${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || '' }}"
           HEAD_REF: "${{ github.event_name == 'pull_request' && github.head_ref || '' }}"
           PR_TITLE: "${{ github.event_name == 'pull_request' && github.event.pull_request.title || '' }}"
@@ -63,7 +64,7 @@ jobs:
   sdk-python:
     name: 'SDK Python (${{ matrix.python-version }})'
     needs: 'classify_pr'
-    if: "${{ always() && needs.classify_pr.outputs.skip_ci != 'true' }}"
+    if: "${{ !cancelled() && needs.classify_pr.outputs.skip_ci != 'true' }}"
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -27,9 +27,9 @@ jobs:
         id: 'release_sync'
         env:
           # Repository variables can override these defaults if release naming changes.
-          HEAD_REPO: '${{ github.event.pull_request.head.repo.full_name }}'
-          HEAD_REF: '${{ github.head_ref }}'
-          PR_TITLE: '${{ github.event.pull_request.title }}'
+          HEAD_REPO: "${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name || '' }}"
+          HEAD_REF: "${{ github.event_name == 'pull_request' && github.head_ref || '' }}"
+          PR_TITLE: "${{ github.event_name == 'pull_request' && github.event.pull_request.title || '' }}"
           RELEASE_SYNC_HEAD_PREFIX: "${{ vars.RELEASE_SYNC_HEAD_PREFIX || 'release/' }}"
           RELEASE_SYNC_TITLE_PREFIX: "${{ vars.RELEASE_SYNC_TITLE_PREFIX || 'chore(release):' }}"
         run: |-

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -7,28 +7,47 @@ on:
       - 'release/**'
     paths:
       - 'packages/sdk-python/**'
-      - 'docs/developers/sdk-python.md'
-      - 'docs/developers/_meta.ts'
-      - 'README.md'
-      - 'package.json'
       - '.github/workflows/sdk-python.yml'
-      - '.github/workflows/release-sdk-python.yml'
   push:
     branches:
       - 'main'
       - 'release/**'
     paths:
       - 'packages/sdk-python/**'
-      - 'docs/developers/sdk-python.md'
-      - 'docs/developers/_meta.ts'
-      - 'README.md'
-      - 'package.json'
       - '.github/workflows/sdk-python.yml'
-      - '.github/workflows/release-sdk-python.yml'
 
 jobs:
+  classify_pr:
+    name: 'Classify PR'
+    runs-on: 'ubuntu-latest'
+    outputs:
+      skip_ci: '${{ steps.release_sync.outputs.skip_ci }}'
+    steps:
+      - name: 'Detect release version-sync PR'
+        id: 'release_sync'
+        env:
+          # Repository variables can override these defaults if release naming changes.
+          HEAD_REPO: '${{ github.event.pull_request.head.repo.full_name }}'
+          HEAD_REF: '${{ github.head_ref }}'
+          PR_TITLE: '${{ github.event.pull_request.title }}'
+          RELEASE_SYNC_HEAD_PREFIX: "${{ vars.RELEASE_SYNC_HEAD_PREFIX || 'release/' }}"
+          RELEASE_SYNC_TITLE_PREFIX: "${{ vars.RELEASE_SYNC_TITLE_PREFIX || 'chore(release):' }}"
+        run: |-
+          skip_ci=false
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" &&
+                "${HEAD_REPO}" == "${GITHUB_REPOSITORY}" &&
+                "${HEAD_REF}" == "${RELEASE_SYNC_HEAD_PREFIX}"* &&
+                "${PR_TITLE}" == "${RELEASE_SYNC_TITLE_PREFIX}"* ]]; then
+            skip_ci=true
+          fi
+
+          echo "skip_ci=${skip_ci}" >> "${GITHUB_OUTPUT}"
+          echo "skip_ci=${skip_ci}"
+
   sdk-python:
     name: 'SDK Python (${{ matrix.python-version }})'
+    needs: 'classify_pr'
+    if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false

--- a/.github/workflows/sdk-python.yml
+++ b/.github/workflows/sdk-python.yml
@@ -19,7 +19,9 @@ on:
 jobs:
   classify_pr:
     name: 'Classify PR'
+    if: "${{ github.event_name == 'pull_request' }}"
     runs-on: 'ubuntu-latest'
+    continue-on-error: true
     outputs:
       skip_ci: '${{ steps.release_sync.outputs.skip_ci }}'
     steps:
@@ -32,13 +34,27 @@ jobs:
           PR_TITLE: "${{ github.event_name == 'pull_request' && github.event.pull_request.title || '' }}"
           RELEASE_SYNC_HEAD_PREFIX: "${{ vars.RELEASE_SYNC_HEAD_PREFIX || 'release/' }}"
           RELEASE_SYNC_TITLE_PREFIX: "${{ vars.RELEASE_SYNC_TITLE_PREFIX || 'chore(release):' }}"
+          RELEASE_SYNC_ACTOR: "${{ vars.RELEASE_SYNC_ACTOR || 'qwen-code-ci-bot' }}"
         run: |-
           skip_ci=false
+          repo_match=false
+          actor_match=false
+          head_match=false
+          title_match=false
+          [[ "${HEAD_REPO}" == "${GITHUB_REPOSITORY}" ]] && repo_match=true
+          [[ "${GITHUB_ACTOR}" == "${RELEASE_SYNC_ACTOR}" ]] && actor_match=true
+          [[ "${HEAD_REF}" == "${RELEASE_SYNC_HEAD_PREFIX}"* ]] && head_match=true
+          [[ "${PR_TITLE}" == "${RELEASE_SYNC_TITLE_PREFIX}"* ]] && title_match=true
+
           if [[ "${GITHUB_EVENT_NAME}" == "pull_request" &&
-                "${HEAD_REPO}" == "${GITHUB_REPOSITORY}" &&
-                "${HEAD_REF}" == "${RELEASE_SYNC_HEAD_PREFIX}"* &&
-                "${PR_TITLE}" == "${RELEASE_SYNC_TITLE_PREFIX}"* ]]; then
+                "${repo_match}" == "true" &&
+                "${actor_match}" == "true" &&
+                "${head_match}" == "true" &&
+                "${title_match}" == "true" ]]; then
             skip_ci=true
+            echo "Release sync PR detected: actor=${GITHUB_ACTOR}, head_ref=${HEAD_REF}, title=${PR_TITLE}"
+          else
+            echo "Not a release sync PR: event=${GITHUB_EVENT_NAME}, actor=${GITHUB_ACTOR}, expected_actor=${RELEASE_SYNC_ACTOR}, repo_match=${repo_match}, head_match=${head_match}, title_match=${title_match}"
           fi
 
           echo "skip_ci=${skip_ci}" >> "${GITHUB_OUTPUT}"
@@ -47,7 +63,7 @@ jobs:
   sdk-python:
     name: 'SDK Python (${{ matrix.python-version }})'
     needs: 'classify_pr'
-    if: "${{ needs.classify_pr.outputs.skip_ci != 'true' }}"
+    if: "${{ always() && needs.classify_pr.outputs.skip_ci != 'true' }}"
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- What changed: narrow the `SDK Python` workflow paths so it only runs for Python SDK changes or edits to the workflow itself, and add a centralized `Classify PR` gate that skips CI jobs for same-repository release/version-sync PRs.
- Why it changed: ordinary CLI/Core/README/package.json PRs do not need the Python SDK matrix, and generated release version-sync PRs only merge already-published version files back to `main`, so they do not need duplicate PR CI.
- Reviewer focus: confirm the release/version-sync skip decision is centralized in `Classify PR`, remains limited to same-repository PRs, and can be adjusted through `RELEASE_SYNC_HEAD_PREFIX` / `RELEASE_SYNC_TITLE_PREFIX` repository variables if release naming changes.

## Validation

- Commands run:
  ```bash
  python3 - <<'PY'
  import yaml
  for path in ['.github/workflows/ci.yml', '.github/workflows/sdk-python.yml']:
      with open(path, 'r', encoding='utf-8') as f:
          yaml.safe_load(f)
      print(f'{path}: ok')
  PY

  node scripts/lint.js --actionlint
  git diff --check
  npx prettier --check .github/workflows/ci.yml .github/workflows/sdk-python.yml
  ```
- Prompts / inputs used: evaluated ordinary PRs, Python SDK PRs, and same-repository release/version-sync PR GitHub Actions trigger scenarios.
- Expected result: workflow YAML parses, actionlint passes, ordinary PRs are not affected by the skip gate, release/version-sync detection is managed in one job, and `SDK Python` no longer runs when a PR does not touch Python SDK-related workflow scope.
- Observed result: YAML parse, actionlint, Prettier check, and whitespace check all passed locally.
- Quickest reviewer verification path:
  1. Check the `paths` filters in `.github/workflows/sdk-python.yml`.
  2. Check the `Classify PR` job in each workflow.
  3. Confirm downstream jobs only depend on `needs.classify_pr.outputs.skip_ci != 'true'`.
  4. Confirm the release/version-sync detector still requires a same-repository PR, a release branch prefix, and a release title prefix.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.): local validation commands exited successfully; the diff only changes two workflow files.

## Scope / Risk

- Main risk or tradeoff: release/version-sync PR checks will be skipped for the targeted jobs; this is intentional to avoid duplicate CI.
- Not covered / not validated: no live GitHub Actions run was triggered manually, and the full Node test/build suite was not run because this is workflow configuration only.
- Breaking changes / migration notes: none.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | N/A | N/A | N/A |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Ran workflow YAML parsing, actionlint, Prettier, and whitespace checks locally on macOS. Windows and Linux were not run locally; GitHub Actions will parse the same workflow files remotely.

## Linked Issues / Bugs

Related follow-up to #3950.