### PR TITLE
fix(core): harden reactive compression follow-ups

### DIFF
--- a/packages/core/src/core/geminiChat.test.ts
+++ b/packages/core/src/core/geminiChat.test.ts
@@ -1087,6 +1087,51 @@ describe('GeminiChat', async () => {
       expect(compressSpy).toHaveBeenCalledTimes(2);
     });
 
+    it('releases the send-lock when setup throws after compression', async () => {
+      const compressSpy = vi
+        .spyOn(ChatCompressionService.prototype, 'compress')
+        .mockResolvedValue({
+          newHistory: null,
+          info: {
+            originalTokenCount: 0,
+            newTokenCount: 0,
+            compressionStatus: CompressionStatus.NOOP,
+          },
+        });
+      vi.spyOn(chat, 'getHistory').mockImplementationOnce(() => {
+        throw new Error('history setup failed');
+      });
+
+      await expect(
+        chat.sendMessageStream(
+          'test-model',
+          { message: 'first' },
+          'prompt-id-setup-deadlock-1',
+        ),
+      ).rejects.toThrow('history setup failed');
+
+      vi.mocked(mockContentGenerator.generateContentStream).mockResolvedValue(
+        makeStreamResponse('second response'),
+      );
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'second' },
+        'prompt-id-setup-deadlock-2',
+      );
+      for await (const _ of stream) {
+        /* consume */
+      }
+
+      expect(compressSpy).toHaveBeenCalledTimes(2);
+      expect(
+        chat
+          .getHistory()
+          .some((content) =>
+            content.parts?.some((part) => part.text === 'first'),
+          ),
+      ).toBe(false);
+    });
+
     it('seeds inherited token count via setLastPromptTokenCount', async () => {
       const subagentChat = new GeminiChat(mockConfig, config, [
         { role: 'user', parts: [{ text: 'inherited' }] },
@@ -1556,6 +1601,69 @@ describe('GeminiChat', async () => {
       expect(compressSpy).toHaveBeenCalledTimes(2);
       expect(mockContentGenerator.generateContentStream).toHaveBeenCalledTimes(
         1,
+      );
+    });
+
+    it('marks failed reactive compression attempts for later auto-compaction', async () => {
+      const overflow = new Error(
+        'prompt is too long: 135000 tokens > 128000 maximum',
+      );
+      const compressSpy = vi
+        .spyOn(ChatCompressionService.prototype, 'compress')
+        .mockResolvedValueOnce({
+          newHistory: null,
+          info: {
+            originalTokenCount: 0,
+            newTokenCount: 0,
+            compressionStatus: CompressionStatus.NOOP,
+          },
+        })
+        .mockResolvedValueOnce({
+          newHistory: null,
+          info: {
+            originalTokenCount: 135_000,
+            newTokenCount: 135_000,
+            compressionStatus:
+              CompressionStatus.COMPRESSION_FAILED_EMPTY_SUMMARY,
+          },
+        })
+        .mockResolvedValueOnce({
+          newHistory: null,
+          info: {
+            originalTokenCount: 0,
+            newTokenCount: 0,
+            compressionStatus: CompressionStatus.NOOP,
+          },
+        });
+      vi.mocked(mockContentGenerator.generateContentStream)
+        .mockRejectedValueOnce(overflow)
+        .mockResolvedValueOnce(makeStreamResponse('next request ok'));
+
+      const stream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'latest' },
+        'prompt-id-reactive-failed-latch',
+      );
+      await expect(
+        (async () => {
+          for await (const _ of stream) {
+            /* consume */
+          }
+        })(),
+      ).rejects.toThrow(overflow);
+
+      const nextStream = await chat.sendMessageStream(
+        'test-model',
+        { message: 'next' },
+        'prompt-id-after-reactive-failed-latch',
+      );
+      for await (const _ of nextStream) {
+        /* consume */
+      }
+
+      expect(compressSpy).toHaveBeenCalledTimes(3);
+      expect(compressSpy.mock.calls[2][1].hasFailedCompressionAttempt).toBe(
+        true,
       );
     });
 

--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -54,6 +54,14 @@ import { getContextLengthExceededInfo } from '../utils/contextLengthError.js';
 
 const debugLogger = createDebugLogger('QWEN_CODE_CHAT');
 
+function isCompressionFailureStatus(status: CompressionStatus): boolean {
+  return (
+    status === CompressionStatus.COMPRESSION_FAILED_INFLATED_TOKEN_COUNT ||
+    status === CompressionStatus.COMPRESSION_FAILED_EMPTY_SUMMARY ||
+    status === CompressionStatus.COMPRESSION_FAILED_TOKEN_COUNT_ERROR
+  );
+}
+
 export enum StreamEventType {
   /** A regular content chunk from the API. */
   CHUNK = 'chunk',
@@ -440,14 +448,7 @@ export class GeminiChat {
       // Re-enable auto-compaction so a forced /compress recovers a chat
       // that an earlier auto-attempt latched off.
       this.hasFailedCompressionAttempt = false;
-    } else if (
-      info.compressionStatus ===
-        CompressionStatus.COMPRESSION_FAILED_INFLATED_TOKEN_COUNT ||
-      info.compressionStatus ===
-        CompressionStatus.COMPRESSION_FAILED_EMPTY_SUMMARY ||
-      info.compressionStatus ===
-        CompressionStatus.COMPRESSION_FAILED_TOKEN_COUNT_ERROR
-    ) {
+    } else if (isCompressionFailureStatus(info.compressionStatus)) {
       // Track failed attempts (only mark as failed if not forced) so we
       // stop spending compression-API calls on a chat that can't shrink.
       if (!force) {
@@ -497,28 +498,34 @@ export class GeminiChat {
     });
     this.sendPromise = streamDonePromise;
 
-    // The send-lock above is held but the generator's `finally` (which
-    // resolves it) has not run yet — if `tryCompress` throws, we must
-    // release the lock here or subsequent sends will block forever at
-    // `await this.sendPromise`.
     let compressionInfo: ChatCompressionInfo;
+    let requestContents: Content[];
+    let userContentAdded = false;
     try {
+      // The send-lock above is held but the generator's `finally` (which
+      // resolves it) has not run yet. Any setup error before returning the
+      // generator must release the lock or subsequent sends will block forever
+      // at `await this.sendPromise`.
       compressionInfo = await this.tryCompress(
         prompt_id,
         model,
         false,
         params.config?.abortSignal,
       );
+
+      const userContent = createUserContent(params.message);
+
+      // Add user content to history ONCE before any attempts.
+      this.history.push(userContent);
+      userContentAdded = true;
+      requestContents = this.getHistory(true);
     } catch (error) {
+      if (userContentAdded) {
+        this.history.pop();
+      }
       streamDoneResolver!();
       throw error;
     }
-
-    const userContent = createUserContent(params.message);
-
-    // Add user content to history ONCE before any attempts.
-    this.history.push(userContent);
-    let requestContents = this.getHistory(true);
 
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const self = this;
@@ -698,6 +705,11 @@ export class GeminiChat {
                     `Reactive compression did not recover context overflow: ` +
                       `status=${reactiveInfo.compressionStatus}.`,
                   );
+                  if (
+                    isCompressionFailureStatus(reactiveInfo.compressionStatus)
+                  ) {
+                    self.hasFailedCompressionAttempt = true;
+                  }
                 } catch (compressionError) {
                   if (
                     params.config?.abortSignal?.aborted ||

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -643,6 +643,56 @@ describe('ChatCompressionService', () => {
     );
   });
 
+  it('passes abort signal to summary generation', async () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'msg1' }] },
+      { role: 'model', parts: [{ text: 'msg2' }] },
+      { role: 'user', parts: [{ text: 'msg3' }] },
+      { role: 'model', parts: [{ text: 'msg4' }] },
+    ];
+    const abortController = new AbortController();
+    vi.mocked(mockChat.getHistory).mockReturnValue(history);
+    vi.mocked(uiTelemetryService.getLastPromptTokenCount).mockReturnValue(100);
+    vi.mocked(tokenLimit).mockReturnValue(1000);
+
+    const mockGenerateContent = vi.fn().mockResolvedValue({
+      candidates: [
+        {
+          content: {
+            parts: [{ text: 'Summary' }],
+          },
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 1100,
+        candidatesTokenCount: 50,
+        totalTokenCount: 1150,
+      },
+    } as unknown as GenerateContentResponse);
+    vi.mocked(mockConfig.getContentGenerator).mockReturnValue({
+      generateContent: mockGenerateContent,
+    } as unknown as ContentGenerator);
+
+    await service.compress(mockChat, {
+      promptId: mockPromptId,
+      force: true,
+      model: mockModel,
+      config: mockConfig,
+      hasFailedCompressionAttempt: false,
+      originalTokenCount: uiTelemetryService.getLastPromptTokenCount(),
+      signal: abortController.signal,
+    });
+
+    expect(mockGenerateContent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          abortSignal: abortController.signal,
+        }),
+      }),
+      mockPromptId,
+    );
+  });
+
   it('should return FAILED if new token count is inflated', async () => {
     const history: Content[] = [
       { role: 'user', parts: [{ text: 'msg1' }] },

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -332,6 +332,7 @@ export class ChatCompressionService {
         ],
         config: {
           systemInstruction: getCompressionPrompt(),
+          ...(signal ? { abortSignal: signal } : {}),
         },
       },
       promptId,


### PR DESCRIPTION
## Summary

- What changed: Hardened the reactive compression follow-up paths after PR #3879 by releasing the send lock for setup failures, latching explicit reactive compression failures for later auto-compaction, and passing abort signals into compression summary generation.
- Why it changed: Review follow-up identified small correctness gaps that could otherwise leave later sends blocked, spend repeated compression calls after a failed reactive recovery, or keep a compression API call running after user cancellation.
- Reviewer focus: Please check that the failed-compression latch only applies to explicit compression failure statuses, not `NOOP`, and that the send-lock cleanup does not change normal streaming behavior.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/core/geminiChat.test.ts src/services/chatCompressionService.test.ts
  cd packages/core && npm run typecheck
  npx prettier --write packages/core/src/core/geminiChat.ts packages/core/src/core/geminiChat.test.ts packages/core/src/services/chatCompressionService.ts packages/core/src/services/chatCompressionService.test.ts
  git diff --check
  ```
- Prompts / inputs used: Unit tests simulate setup failure after compression, reactive context overflow followed by compression failure, and compression with an active `AbortSignal`.
- Expected result: Setup failures release the send lock and roll back the failed user turn; explicit reactive compression failures mark the failed-compression latch for later auto-compaction; compression summary requests carry the abort signal.
- Observed result: Focused tests passed: 117 tests across `geminiChat.test.ts` and `chatCompressionService.test.ts`. Core typecheck passed. Prettier reported the changed files unchanged after formatting. `git diff --check` passed.

### Local verification

- From the repository root, run:
  ```bash
  cd packages/core
  npx vitest run src/core/geminiChat.test.ts src/services/chatCompressionService.test.ts
  npm run typecheck
  ```
- Expected test output:
  ```text
  ✓ src/services/chatCompressionService.test.ts (49 tests)
  ✓ src/core/geminiChat.test.ts (68 tests)

  Test Files  2 passed (2)
       Tests  117 passed (117)
  ```
- Expected typecheck output:
  ```text
  > @qwen-code/qwen-code-core@0.15.9 typecheck
  > tsc --noEmit
  ```
- What this verifies:
  ```text
  1. Setup-stage failures after compression release the send lock and roll back the failed user turn.
  2. Explicit reactive compression failures set the failed-compression latch for later auto-compaction.
  3. Compression summary generateContent requests carry the active AbortSignal.
  ```

- Quickest reviewer verification path:
  ```bash
  cd packages/core && npx vitest run src/core/geminiChat.test.ts src/services/chatCompressionService.test.ts
  ```
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  ```text
  ✓ src/services/chatCompressionService.test.ts (49 tests)
  ✓ src/core/geminiChat.test.ts (68 tests)

  Test Files  2 passed (2)
       Tests  117 passed (117)

  > @qwen-code/qwen-code-core@0.15.9 typecheck
  > tsc --noEmit
  ```

## Scope / Risk

- Main risk or tradeoff: The reactive failure latch is intentionally limited to explicit compression failure statuses, so `NOOP` still keeps the existing forced-compression semantics.
- Not covered / not validated: No new interactive or live-provider E2E was run; this is a focused correctness follow-up covered by unit tests.
- Breaking changes / migration notes: None.

## 人工验证
```
please answer OK

```

预期
```
IMPORTANT: This conversation approached the input token limit for mock-model.
A compressed context will be sent for future messages
(compressed from: 135000 to 47000 tokens).

OK after reactive compression

```

<img width="1252" height="583" alt="image" src="https://github.com/user-attachments/assets/3a9eb6b2-83af-42bd-a84b-7887e721f93c" />

预期：
```
returning context_length_exceeded
returning compression/utility summary
returning final streamed answer

```
<img width="1257" height="294" alt="image" src="https://github.com/user-attachments/assets/50082a39-4198-4d21-887b-724a3a62f341" />


## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Validated on macOS in this worktree. Windows, Linux, Docker, Podman, and Seatbelt were not run locally.

## Linked Issues / Bugs

- Follow-up to #3879.
