### PR TITLE
feat(telemetry) suppress OpenTelemetry diagnostics from UI

### DIFF
--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -24,6 +24,11 @@ import { TelemetryTarget } from './index.js';
 
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { promises as fs } from 'node:fs';
+import {
+  resetDebugLoggingState,
+  setDebugLogSession,
+} from '../utils/debugLogger.js';
 
 vi.mock('@opentelemetry/exporter-trace-otlp-grpc');
 vi.mock('@opentelemetry/exporter-logs-otlp-grpc');
@@ -141,6 +146,77 @@ describe('Telemetry SDK', () => {
     expect(NodeSDK).toHaveBeenCalledWith(
       expect.objectContaining({ autoDetectResources: false }),
     );
+  });
+
+  it('should route OpenTelemetry diagnostics to debug log instead of console output', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+    const consoleWarnSpy = vi
+      .spyOn(console, 'warn')
+      .mockImplementation(() => {});
+    const mkdirSpy = vi.spyOn(fs, 'mkdir').mockResolvedValue(undefined);
+    const appendFileSpy = vi
+      .spyOn(fs, 'appendFile')
+      .mockResolvedValue(undefined);
+    const unlinkSpy = vi.spyOn(fs, 'unlink').mockResolvedValue(undefined);
+    const symlinkSpy = vi.spyOn(fs, 'symlink').mockResolvedValue(undefined);
+    const previousDebugLogFileEnv = process.env['QWEN_DEBUG_LOG_FILE'];
+    try {
+      process.env['QWEN_DEBUG_LOG_FILE'] = '1';
+      setDebugLogSession({ getSessionId: () => 'otel-diag-test-session' });
+
+      diag.error(
+        JSON.stringify({
+          message:
+            'Error: PeriodicExportingMetricReader: metrics export failed (error Error: connect ECONNREFUSED)',
+        }),
+      );
+
+      diag.error('A different OpenTelemetry diagnostic');
+      diag.warn('An OpenTelemetry warning');
+
+      await vi.waitFor(() => {
+        expect(appendFileSpy).toHaveBeenCalledTimes(3);
+      });
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(consoleWarnSpy).not.toHaveBeenCalled();
+      expect(mkdirSpy).toHaveBeenCalled();
+      expect(appendFileSpy).toHaveBeenCalledWith(
+        expect.stringContaining('otel-diag-test-session'),
+        expect.stringContaining(
+          '[ERROR] [OTEL] {"message":"Error: PeriodicExportingMetricReader: metrics export failed (error Error: connect ECONNREFUSED)"}',
+        ),
+        'utf8',
+      );
+      expect(appendFileSpy).toHaveBeenCalledWith(
+        expect.stringContaining('otel-diag-test-session'),
+        expect.stringContaining(
+          '[ERROR] [OTEL] A different OpenTelemetry diagnostic',
+        ),
+        'utf8',
+      );
+      expect(appendFileSpy).toHaveBeenCalledWith(
+        expect.stringContaining('otel-diag-test-session'),
+        expect.stringContaining('[WARN] [OTEL] An OpenTelemetry warning'),
+        'utf8',
+      );
+    } finally {
+      consoleErrorSpy.mockRestore();
+      consoleWarnSpy.mockRestore();
+      mkdirSpy.mockRestore();
+      appendFileSpy.mockRestore();
+      unlinkSpy.mockRestore();
+      symlinkSpy.mockRestore();
+      setDebugLogSession(null);
+      resetDebugLoggingState();
+      if (previousDebugLogFileEnv === undefined) {
+        delete process.env['QWEN_DEBUG_LOG_FILE'];
+      } else {
+        process.env['QWEN_DEBUG_LOG_FILE'] = previousDebugLogFileEnv;
+      }
+    }
   });
 
   it('should use HTTP exporters with signal-specific paths when protocol is http', () => {

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DiagConsoleLogger, DiagLogLevel, diag } from '@opentelemetry/api';
+import { DiagLogLevel, diag } from '@opentelemetry/api';
+import type { DiagLogger } from '@opentelemetry/api';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-grpc';
 import { OTLPMetricExporter } from '@opentelemetry/exporter-metrics-otlp-grpc';
@@ -30,8 +31,21 @@ import {
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { LogToSpanProcessor } from './log-to-span-processor.js';
 
-// For troubleshooting, set the log level to DiagLogLevel.DEBUG
-diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.WARN);
+function createTelemetryDiagLogger(): DiagLogger {
+  const debugLogger = createDebugLogger('OTEL');
+  return {
+    error: (message, ...args) => debugLogger.error(message, ...args),
+    warn: (message, ...args) => debugLogger.warn(message, ...args),
+    info: (message, ...args) => debugLogger.info(message, ...args),
+    debug: (message, ...args) => debugLogger.debug(message, ...args),
+    verbose: (message, ...args) => debugLogger.debug(message, ...args),
+  };
+}
+
+// For troubleshooting, set the log level to DiagLogLevel.DEBUG.
+// OTel SDK diagnostics must not write to console because console output can be
+// surfaced in user-visible UI. Keep diagnostics in the debug log instead.
+diag.setLogger(createTelemetryDiagLogger(), DiagLogLevel.WARN);
 
 /**
  * Standard OTLP HTTP signal-specific paths per the OpenTelemetry specification.


### PR DESCRIPTION
## Summary

- What changed: OpenTelemetry SDK diagnostics are routed to the existing debug log path instead of console output.
- Why it changed: exporter connection failures and other SDK diagnostics can be surfaced in user-visible UI when they go through console.
- Reviewer focus: confirm diagnostics remain available for troubleshooting without polluting the UI surface.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/telemetry/sdk.test.ts
  npm run build && npm run typecheck
  ```
- Prompts / inputs used: Simulated OpenTelemetry error and warning diagnostics in the regression test.
- Expected result: OpenTelemetry diagnostics do not write to console output, while telemetry startup and exporter configuration behavior remains intact.
- Observed result: The targeted telemetry SDK test file passed with 24 tests, then repository build and typecheck completed successfully.
- Quickest reviewer verification path: run the telemetry SDK test file and inspect that the console spies are not called for OpenTelemetry diagnostics.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.): `src/telemetry/sdk.test.ts (24 tests)` passed; `npm run build && npm run typecheck` exited successfully. Build emitted only the existing Browserslist data age warning.

## Scope / Risk

- Main risk or tradeoff: OpenTelemetry SDK diagnostics no longer appear on stderr/console by default; troubleshooting should use the debug log.
- Not covered / not validated: No manual VS Code/webview screenshot was captured because the regression is covered at the console-output boundary.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | N/A | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Validated locally on macOS with `npx vitest`, `npm run build`, and `npm run typecheck`.
- Windows, Linux, Docker, Podman, and Seatbelt were not run for this narrow logger-routing change.

## 人工验证
日志有metrics相关日志，而UI没有了
<img width="1685" height="151" alt="image" src="https://github.com/user-attachments/assets/9670aabf-8701-41a9-85f5-82a545576718" />


## Linked Issues / Bugs

- Part of #3731 (Runtime safety P0: restrict console/debug exporters in structured-output or non-interactive modes)