### PR TITLE
feat(dashscope): support DASHSCOPE_PROXY_BASE_URL for prompt cache via API gateway

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/constants.ts
+++ b/packages/core/src/core/openaiContentGenerator/constants.ts
@@ -6,3 +6,4 @@ export const DEFAULT_DASHSCOPE_BASE_URL =
   'https://dashscope.aliyuncs.com/compatible-mode/v1';
 export const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com/v1';
 export const DEFAULT_OPEN_ROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+export const DASHSCOPE_PROXY_BASE_URL = process.env['DASHSCOPE_PROXY_BASE_URL'];

--- a/packages/core/src/core/openaiContentGenerator/constants.ts
+++ b/packages/core/src/core/openaiContentGenerator/constants.ts
@@ -6,9 +6,4 @@ export const DEFAULT_DASHSCOPE_BASE_URL =
   'https://dashscope.aliyuncs.com/compatible-mode/v1';
 export const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com/v1';
 export const DEFAULT_OPEN_ROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
-// Consider exporting a getter function for SDK use:
 export const DASHSCOPE_PROXY_BASE_URL = process.env['DASHSCOPE_PROXY_BASE_URL'];
-// Or a function:
-export function getDashScopeProxyBaseUrl(): string | undefined {
-  return process.env['DASHSCOPE_PROXY_BASE_URL'];
-}

--- a/packages/core/src/core/openaiContentGenerator/constants.ts
+++ b/packages/core/src/core/openaiContentGenerator/constants.ts
@@ -6,4 +6,9 @@ export const DEFAULT_DASHSCOPE_BASE_URL =
   'https://dashscope.aliyuncs.com/compatible-mode/v1';
 export const DEFAULT_DEEPSEEK_BASE_URL = 'https://api.deepseek.com/v1';
 export const DEFAULT_OPEN_ROUTER_BASE_URL = 'https://openrouter.ai/api/v1';
+// Consider exporting a getter function for SDK use:
 export const DASHSCOPE_PROXY_BASE_URL = process.env['DASHSCOPE_PROXY_BASE_URL'];
+// Or a function:
+export function getDashScopeProxyBaseUrl(): string | undefined {
+  return process.env['DASHSCOPE_PROXY_BASE_URL'];
+}

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -22,6 +22,16 @@ import { DEFAULT_TIMEOUT, DEFAULT_MAX_RETRIES } from '../constants.js';
 import { buildRuntimeFetchOptions } from '../../../utils/runtimeFetchOptions.js';
 import type { OpenAIRuntimeFetchOptions } from '../../../utils/runtimeFetchOptions.js';
 
+const mockDebugLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+}));
+vi.mock('../../../utils/debugLogger.js', () => ({
+  createDebugLogger: vi.fn(() => mockDebugLogger),
+}));
+
 // Mock OpenAI
 vi.mock('openai', () => ({
   default: vi.fn().mockImplementation((config) => ({
@@ -217,6 +227,28 @@ describe('DashScopeOpenAICompatibleProvider', () => {
       const result =
         DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
       expect(result).toBe(false);
+    });
+
+    it('should debug log when baseUrl does not match DASHSCOPE_PROXY_BASE_URL', () => {
+      vi.stubEnv(
+        'DASHSCOPE_PROXY_BASE_URL',
+        'https://your-proxy.com/dashscope',
+      );
+
+      const config = {
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://other-proxy.com/dashscope',
+      } as ContentGeneratorConfig;
+
+      const result =
+        DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
+
+      expect(result).toBe(false);
+      expect(mockDebugLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "DASHSCOPE_PROXY_BASE_URL is configured as 'https://your-proxy.com/dashscope'",
+        ),
+      );
     });
 
     it('should return true when baseUrl matches DASHSCOPE_PROXY_BASE_URL with trailing slash', () => {

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -69,6 +69,7 @@ describe('DashScopeOpenAICompatibleProvider', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
     const mockedBuildRuntimeFetchOptions =
       buildRuntimeFetchOptions as unknown as MockedFunction<
         (sdkType: 'openai', proxyUrl?: string) => OpenAIRuntimeFetchOptions
@@ -236,7 +237,7 @@ describe('DashScopeOpenAICompatibleProvider', () => {
       expect(result).toBe(false);
       expect(mockDebugLogger.debug).toHaveBeenCalledWith(
         expect.stringContaining(
-          "DASHSCOPE_PROXY_BASE_URL is configured as 'https://your-proxy.com/dashscope'",
+          'DASHSCOPE_PROXY_BASE_URL is configured but the request baseUrl does not match',
         ),
       );
     });

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -38,6 +38,20 @@ vi.mock('../../../utils/runtimeFetchOptions.js', () => ({
   buildRuntimeFetchOptions: vi.fn(),
 }));
 
+// Mock DASHSCOPE_PROXY_BASE_URL so tests can control its value
+vi.mock('../constants.js', () => ({
+  DEFAULT_TIMEOUT: 120000,
+  DEFAULT_MAX_RETRIES: 3,
+  DEFAULT_OPENAI_BASE_URL: 'https://api.openai.com/v1',
+  DEFAULT_DASHSCOPE_BASE_URL:
+    'https://dashscope.aliyuncs.com/compatible-mode/v1',
+  DEFAULT_DEEPSEEK_BASE_URL: 'https://api.deepseek.com/v1',
+  DEFAULT_OPEN_ROUTER_BASE_URL: 'https://openrouter.ai/api/v1',
+  get DASHSCOPE_PROXY_BASE_URL() {
+    return process.env['DASHSCOPE_PROXY_BASE_URL'];
+  },
+}));
+
 describe('DashScopeOpenAICompatibleProvider', () => {
   let provider: DashScopeOpenAICompatibleProvider;
   let mockContentGeneratorConfig: ContentGeneratorConfig;
@@ -161,6 +175,57 @@ describe('DashScopeOpenAICompatibleProvider', () => {
         );
         expect(result).toBe(false);
       });
+    });
+
+    it('should return true when baseUrl matches DASHSCOPE_PROXY_BASE_URL', () => {
+      const originalEnv = process.env['DASHSCOPE_PROXY_BASE_URL'];
+      process.env['DASHSCOPE_PROXY_BASE_URL'] =
+        'https://your-proxy.com/dashscope';
+
+      const config = {
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://your-proxy.com/dashscope',
+      } as ContentGeneratorConfig;
+
+      const result =
+        DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
+      expect(result).toBe(true);
+
+      process.env['DASHSCOPE_PROXY_BASE_URL'] = originalEnv;
+    });
+
+    it('should return false when baseUrl does not match DASHSCOPE_PROXY_BASE_URL', () => {
+      const originalEnv = process.env['DASHSCOPE_PROXY_BASE_URL'];
+      process.env['DASHSCOPE_PROXY_BASE_URL'] =
+        'https://your-proxy.com/dashscope';
+
+      const config = {
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://other-proxy.com/dashscope',
+      } as ContentGeneratorConfig;
+
+      const result =
+        DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
+      expect(result).toBe(false);
+
+      process.env['DASHSCOPE_PROXY_BASE_URL'] = originalEnv;
+    });
+
+    it('should return true when baseUrl matches DASHSCOPE_PROXY_BASE_URL with trailing slash', () => {
+      const originalEnv = process.env['DASHSCOPE_PROXY_BASE_URL'];
+      process.env['DASHSCOPE_PROXY_BASE_URL'] =
+        'https://your-proxy.com/dashscope';
+
+      const config = {
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://your-proxy.com/dashscope/',
+      } as ContentGeneratorConfig;
+
+      const result =
+        DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
+      expect(result).toBe(true);
+
+      process.env['DASHSCOPE_PROXY_BASE_URL'] = originalEnv;
     });
   });
 

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -178,9 +178,10 @@ describe('DashScopeOpenAICompatibleProvider', () => {
     });
 
     it('should return true when baseUrl matches DASHSCOPE_PROXY_BASE_URL', () => {
-      const originalEnv = process.env['DASHSCOPE_PROXY_BASE_URL'];
-      process.env['DASHSCOPE_PROXY_BASE_URL'] =
-        'https://your-proxy.com/dashscope';
+      vi.stubEnv(
+        'DASHSCOPE_PROXY_BASE_URL',
+        'https://your-proxy.com/dashscope',
+      );
 
       const config = {
         authType: AuthType.USE_OPENAI,
@@ -190,14 +191,13 @@ describe('DashScopeOpenAICompatibleProvider', () => {
       const result =
         DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
       expect(result).toBe(true);
-
-      process.env['DASHSCOPE_PROXY_BASE_URL'] = originalEnv;
     });
 
     it('should return false when baseUrl does not match DASHSCOPE_PROXY_BASE_URL', () => {
-      const originalEnv = process.env['DASHSCOPE_PROXY_BASE_URL'];
-      process.env['DASHSCOPE_PROXY_BASE_URL'] =
-        'https://your-proxy.com/dashscope';
+      vi.stubEnv(
+        'DASHSCOPE_PROXY_BASE_URL',
+        'https://your-proxy.com/dashscope',
+      );
 
       const config = {
         authType: AuthType.USE_OPENAI,
@@ -207,14 +207,13 @@ describe('DashScopeOpenAICompatibleProvider', () => {
       const result =
         DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
       expect(result).toBe(false);
-
-      process.env['DASHSCOPE_PROXY_BASE_URL'] = originalEnv;
     });
 
     it('should return true when baseUrl matches DASHSCOPE_PROXY_BASE_URL with trailing slash', () => {
-      const originalEnv = process.env['DASHSCOPE_PROXY_BASE_URL'];
-      process.env['DASHSCOPE_PROXY_BASE_URL'] =
-        'https://your-proxy.com/dashscope';
+      vi.stubEnv(
+        'DASHSCOPE_PROXY_BASE_URL',
+        'https://your-proxy.com/dashscope',
+      );
 
       const config = {
         authType: AuthType.USE_OPENAI,
@@ -224,8 +223,6 @@ describe('DashScopeOpenAICompatibleProvider', () => {
       const result =
         DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
       expect(result).toBe(true);
-
-      process.env['DASHSCOPE_PROXY_BASE_URL'] = originalEnv;
     });
   });
 

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -38,6 +38,16 @@ vi.mock('../../../utils/runtimeFetchOptions.js', () => ({
   buildRuntimeFetchOptions: vi.fn(),
 }));
 
+vi.mock('../constants.js', async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    get DASHSCOPE_PROXY_BASE_URL() {
+      return process.env['DASHSCOPE_PROXY_BASE_URL'];
+    },
+  };
+});
+
 // Mock DASHSCOPE_PROXY_BASE_URL so tests can control its value
 vi.mock('../constants.js', () => ({
   DEFAULT_TIMEOUT: 120000,

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -48,16 +48,6 @@ vi.mock('../../../utils/runtimeFetchOptions.js', () => ({
   buildRuntimeFetchOptions: vi.fn(),
 }));
 
-vi.mock('../constants.js', async (importOriginal) => {
-  const actual = await importOriginal();
-  return {
-    ...actual,
-    get DASHSCOPE_PROXY_BASE_URL() {
-      return process.env['DASHSCOPE_PROXY_BASE_URL'];
-    },
-  };
-});
-
 // Mock DASHSCOPE_PROXY_BASE_URL so tests can control its value
 vi.mock('../constants.js', () => ({
   DEFAULT_TIMEOUT: 120000,

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -48,7 +48,8 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
       : DASHSCOPE_PROXY_BASE_URL;
 
     const isProxyConfigured = Boolean(
-      normalizedProxyUrl && normalizedBaseUrl === normalizedProxyUrl,
+      normalizedProxyUrl &&
+        normalizedBaseUrl.toLowerCase() === normalizedProxyUrl.toLowerCase(),
     );
 
     return isDashscopeOrigin || isProxyConfigured;

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -40,7 +40,7 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
 
     // Matches: dashscope.aliyuncs.com, *.dashscope.aliyuncs.com, or *.dashscope-intl.aliyuncs.com
     const isDashscopeOrigin =
-      /([\w-]+\.)?dashscope(-intl)?\.aliyuncs\.com/i.test(baseUrl);
+      /([\w-]+\.)?dashscope(-intl)?\.aliyuncs\.com/i.test(normalizedBaseUrl);
 
     // Check if proxy is configured and matches
     const normalizedProxyUrl = DASHSCOPE_PROXY_BASE_URL?.endsWith('/')

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -16,6 +16,7 @@ import type {
   ChatCompletionToolWithCache,
 } from './types.js';
 import { buildRuntimeFetchOptions } from '../../../utils/runtimeFetchOptions.js';
+import { createDebugLogger } from '../../../utils/debugLogger.js';
 import { DefaultOpenAICompatibleProvider } from './default.js';
 
 export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatibleProvider {
@@ -51,6 +52,12 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
       normalizedProxyUrl &&
         normalizedBaseUrl.toLowerCase() === normalizedProxyUrl.toLowerCase(),
     );
+
+    if (normalizedProxyUrl && !isDashscopeOrigin && !isProxyConfigured) {
+      createDebugLogger('DashScopeOpenAICompatibleProvider').debug(
+        `DASHSCOPE_PROXY_BASE_URL is configured as '${normalizedProxyUrl}', but the request baseUrl '${normalizedBaseUrl}' does not match. DashScope headers/cache control will be skipped.`,
+      );
+    }
 
     return isDashscopeOrigin || isProxyConfigured;
   }

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -19,6 +19,8 @@ import { buildRuntimeFetchOptions } from '../../../utils/runtimeFetchOptions.js'
 import { createDebugLogger } from '../../../utils/debugLogger.js';
 import { DefaultOpenAICompatibleProvider } from './default.js';
 
+const debugLogger = createDebugLogger('DashScopeOpenAICompatibleProvider');
+
 export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatibleProvider {
   constructor(
     contentGeneratorConfig: ContentGeneratorConfig,
@@ -53,7 +55,6 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
         normalizedBaseUrl.toLowerCase() === normalizedProxyUrl.toLowerCase(),
     );
 
-    const debugLogger = createDebugLogger('DashScopeOpenAICompatibleProvider');
     if (normalizedProxyUrl && !isDashscopeOrigin && !isProxyMatch) {
       debugLogger.debug(
         `DASHSCOPE_PROXY_BASE_URL is configured but the request baseUrl does not match. DashScope headers/cache control will be skipped.`,

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_TIMEOUT,
   DEFAULT_MAX_RETRIES,
   DEFAULT_DASHSCOPE_BASE_URL,
+  DASHSCOPE_PROXY_BASE_URL,
 } from '../constants.js';
 import type {
   DashScopeRequestMetadata,
@@ -33,8 +34,21 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
     if (authType === AuthType.QWEN_OAUTH) return true;
     if (!baseUrl) return true;
 
+    const normalizedBaseUrl = baseUrl.endsWith('/')
+      ? baseUrl.slice(0, -1)
+      : baseUrl;
+
     // Matches: dashscope.aliyuncs.com, *.dashscope.aliyuncs.com, or *.dashscope-intl.aliyuncs.com
-    return /([\w-]+\.)?dashscope(-intl)?\.aliyuncs\.com/i.test(baseUrl);
+    const isDashscopeOrigin =
+      /([\w-]+\.)?dashscope(-intl)?\.aliyuncs\.com/i.test(baseUrl);
+
+    // Check if proxy is configured and matches
+    const isProxyConfigured = Boolean(
+      DASHSCOPE_PROXY_BASE_URL &&
+        normalizedBaseUrl === DASHSCOPE_PROXY_BASE_URL,
+    );
+
+    return isDashscopeOrigin || isProxyConfigured;
   }
 
   override buildHeaders(): Record<string, string | undefined> {

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -48,23 +48,19 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
       ? DASHSCOPE_PROXY_BASE_URL.slice(0, -1)
       : DASHSCOPE_PROXY_BASE_URL;
 
-const isProxyMatch = Boolean(
-  normalizedProxyUrl &&
-    normalizedBaseUrl.toLowerCase() === normalizedProxyUrl.toLowerCase(),
-);
-// ...
-return isDashscopeOrigin || isProxyMatch;
+    const isProxyMatch = Boolean(
       normalizedProxyUrl &&
         normalizedBaseUrl.toLowerCase() === normalizedProxyUrl.toLowerCase(),
     );
 
-    if (normalizedProxyUrl && !isDashscopeOrigin && !isProxyConfigured) {
-      createDebugLogger('DashScopeOpenAICompatibleProvider').debug(
-        `DASHSCOPE_PROXY_BASE_URL is configured as '${normalizedProxyUrl}', but the request baseUrl '${normalizedBaseUrl}' does not match. DashScope headers/cache control will be skipped.`,
+    const debugLogger = createDebugLogger('DashScopeOpenAICompatibleProvider');
+    if (normalizedProxyUrl && !isDashscopeOrigin && !isProxyMatch) {
+      debugLogger.debug(
+        `DASHSCOPE_PROXY_BASE_URL is configured but the request baseUrl does not match. DashScope headers/cache control will be skipped.`,
       );
     }
 
-    return isDashscopeOrigin || isProxyConfigured;
+    return isDashscopeOrigin || isProxyMatch;
   }
 
   override buildHeaders(): Record<string, string | undefined> {

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -43,9 +43,12 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
       /([\w-]+\.)?dashscope(-intl)?\.aliyuncs\.com/i.test(baseUrl);
 
     // Check if proxy is configured and matches
+    const normalizedProxyUrl = DASHSCOPE_PROXY_BASE_URL?.endsWith('/')
+      ? DASHSCOPE_PROXY_BASE_URL.slice(0, -1)
+      : DASHSCOPE_PROXY_BASE_URL;
+
     const isProxyConfigured = Boolean(
-      DASHSCOPE_PROXY_BASE_URL &&
-        normalizedBaseUrl === DASHSCOPE_PROXY_BASE_URL,
+      normalizedProxyUrl && normalizedBaseUrl === normalizedProxyUrl,
     );
 
     return isDashscopeOrigin || isProxyConfigured;

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -48,7 +48,12 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
       ? DASHSCOPE_PROXY_BASE_URL.slice(0, -1)
       : DASHSCOPE_PROXY_BASE_URL;
 
-    const isProxyConfigured = Boolean(
+const isProxyMatch = Boolean(
+  normalizedProxyUrl &&
+    normalizedBaseUrl.toLowerCase() === normalizedProxyUrl.toLowerCase(),
+);
+// ...
+return isDashscopeOrigin || isProxyMatch;
       normalizedProxyUrl &&
         normalizedBaseUrl.toLowerCase() === normalizedProxyUrl.toLowerCase(),
     );


### PR DESCRIPTION
## Summary
- Add `DASHSCOPE_PROXY_BASE_URL` environment variable to identify API Gateway proxy URLs
- Modify `isDashScopeProvider()` to detect proxy URL and enable DashScope prompt caching when baseUrl matches the env var
- Add tests for proxy URL matching scenarios (matching, non-matching, trailing slash)

## Test plan
- [x] All 43 tests in dashscope.test.ts pass
- [x] Verify prompt caching works with your proxy URL by setting `DASHSCOPE_PROXY_BASE_URL=https://your-proxy.com/dashscope`
