### PR TITLE
doc[sdk-python] Expand Python SDK usage documentation

### DIFF
--- a/docs/developers/sdk-python.md
+++ b/docs/developers/sdk-python.md
@@ -215,7 +215,7 @@ async def can_use_tool(tool_name, tool_input, context):
     if tool_name in {"read_file", "list_directory"}:
         return {"behavior": "allow", "updatedInput": tool_input}
 
-    if tool_name == "write_file" and tool_input.get("path", "").endswith(".md"):
+    if tool_name == "write_file" and tool_input.get("file_path", "").endswith(".md"):
         return {"behavior": "allow", "updatedInput": tool_input}
 
     return {
@@ -266,7 +266,7 @@ async def prompts():
         "session_id": SESSION_ID,
         "message": {
             "role": "user",
-            "content": "Convert that summary into three bullets.",
+            "content": "Also list the test files.",
         },
         "parent_tool_use_id": None,
     }
@@ -294,6 +294,11 @@ async def main():
 
 asyncio.run(main())
 ```
+
+All messages in the async iterable must be known upfront. The SDK sends them
+sequentially to the CLI but cannot feed a prior response back into the generator.
+If you need conversational turn-taking, manage each turn as a separate `query()`
+call.
 
 ## Runtime Controls
 
@@ -338,23 +343,52 @@ underlying process, and `get_session_id()` to persist a session id for later.
 ## Session Resume
 
 ```python
-from qwen_code_sdk import query
+import asyncio
 
-known = query(
-    "Continue from this session.",
-    {
-        "path_to_qwen_executable": "qwen",
-        "resume": "123e4567-e89b-12d3-a456-426614174000",
-    },
-)
+from qwen_code_sdk import is_sdk_result_message, query
 
-latest = query(
-    "Continue the latest session.",
-    {
-        "path_to_qwen_executable": "qwen",
-        "continue_session": True,
-    },
-)
+
+async def main():
+    # Resume a known session by its id.
+    known = query(
+        "Continue from this session.",
+        {
+            "path_to_qwen_executable": "qwen",
+            "resume": "123e4567-e89b-12d3-a456-426614174000",
+        },
+    )
+
+    async for message in known:
+        if is_sdk_result_message(message):
+            print(message.get("result", ""))
+
+
+asyncio.run(main())
+```
+
+To continue the latest session instead:
+
+```python
+import asyncio
+
+from qwen_code_sdk import is_sdk_result_message, query
+
+
+async def main():
+    latest = query(
+        "Continue the latest session.",
+        {
+            "path_to_qwen_executable": "qwen",
+            "continue_session": True,
+        },
+    )
+
+    async for message in latest:
+        if is_sdk_result_message(message):
+            print(message.get("result", ""))
+
+
+asyncio.run(main())
 ```
 
 `resume` is useful when your application stores session ids. `continue_session`

--- a/docs/developers/sdk-python.md
+++ b/docs/developers/sdk-python.md
@@ -48,12 +48,15 @@ from qwen_code_sdk import (
 
 
 def extract_text(message):
-    content = message["message"].get("content", [])
-    return "".join(
+    content = message.get("message", {}).get("content", [])
+    if not isinstance(content, list):
+        return repr(content)
+    texts = [
         block.get("text", "")
         for block in content
         if isinstance(block, dict) and block.get("type") == "text"
-    )
+    ]
+    return "".join(texts) if texts else "[no text content]"
 
 
 def print_result(message):
@@ -65,23 +68,26 @@ def print_result(message):
 
 
 async def main() -> None:
-    result = query(
+    async with query(
         "Explain the repository structure.",
         {
             "cwd": "/path/to/project",
             "path_to_qwen_executable": "qwen",
         },
-    )
-
-    async for message in result:
-        if is_sdk_assistant_message(message):
-            print(extract_text(message))
-        elif is_sdk_result_message(message):
-            print_result(message)
+    ) as result:
+        async for message in result:
+            if is_sdk_assistant_message(message):
+                print(extract_text(message))
+            elif is_sdk_result_message(message):
+                print_result(message)
 
 
 asyncio.run(main())
 ```
+
+`asyncio.run()` is appropriate for standalone scripts. If your application
+already runs an event loop, such as Jupyter, FastAPI, or pytest-asyncio, call
+`await main()` instead.
 
 ## Sync Usage
 
@@ -133,28 +139,28 @@ with query_sync(
 
 ### `QueryOptions`
 
-| Option                     | Type / values                                              | Description                                                |
-| -------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------- |
-| `cwd`                      | `str`                                                      | Working directory for the CLI process.                     |
-| `model`                    | `str`                                                      | Model override for this SDK session.                       |
-| `path_to_qwen_executable`  | `str`                                                      | `qwen`, an explicit binary path, or a `.js` CLI bundle.    |
-| `permission_mode`          | `default`, `plan`, `auto-edit`, `yolo`                     | Tool execution approval mode.                              |
-| `can_use_tool`             | async callback                                             | Custom permission callback for tool requests.              |
-| `env`                      | `dict[str, str]`                                           | Extra environment variables passed to the CLI process.     |
-| `system_prompt`            | `str`                                                      | Override the system prompt.                                |
-| `append_system_prompt`     | `str`                                                      | Append extra instructions to the system prompt.            |
-| `debug`                    | `bool`                                                     | Forward CLI stderr to stderr when no `stderr` hook exists. |
-| `max_session_turns`        | `int`                                                      | Maximum turns before the CLI ends the session.             |
-| `core_tools`               | `list[str]`                                                | Restrict the available tool set.                           |
-| `exclude_tools`            | `list[str]`                                                | Exclude matching tools.                                    |
-| `allowed_tools`            | `list[str]`                                                | Allow matching tools without callback approval.            |
-| `auth_type`                | `openai`, `anthropic`, `qwen-oauth`, `gemini`, `vertex-ai` | Authentication mode passed to the CLI.                     |
-| `include_partial_messages` | `bool`                                                     | Emit partial assistant stream events.                      |
-| `resume`                   | UUID string                                                | Resume a known session id.                                 |
-| `continue_session`         | `bool`                                                     | Continue the latest CLI session.                           |
-| `session_id`               | UUID string                                                | Start or correlate a session with a known id.              |
-| `timeout`                  | mapping                                                    | Timeouts in seconds.                                       |
-| `stderr`                   | callable                                                   | Receives CLI stderr lines.                                 |
+| Option                     | Type / values                                              | Description                                                                                                     |
+| -------------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `cwd`                      | `str`                                                      | Working directory for the CLI process.                                                                          |
+| `model`                    | `str`                                                      | Model override for this SDK session.                                                                            |
+| `path_to_qwen_executable`  | `str`                                                      | `qwen`, an explicit binary path, or a `.js` CLI bundle.                                                         |
+| `permission_mode`          | `default`, `plan`, `auto-edit`, `yolo`                     | Tool execution approval mode. `yolo` auto-approves all tools; use it only in trusted or sandboxed environments. |
+| `can_use_tool`             | async callback                                             | Custom permission callback for tool requests.                                                                   |
+| `env`                      | `dict[str, str]`                                           | Extra environment variables passed to the CLI process.                                                          |
+| `system_prompt`            | `str`                                                      | Override the system prompt.                                                                                     |
+| `append_system_prompt`     | `str`                                                      | Append extra instructions to the system prompt.                                                                 |
+| `debug`                    | `bool`                                                     | Forward CLI stderr to stderr when no `stderr` hook exists.                                                      |
+| `max_session_turns`        | `int`                                                      | Maximum turns before the CLI ends the session.                                                                  |
+| `core_tools`               | `list[str]`                                                | Restrict the available tool set.                                                                                |
+| `exclude_tools`            | `list[str]`                                                | Exclude matching tools.                                                                                         |
+| `allowed_tools`            | `list[str]`                                                | Allow matching tools without callback approval.                                                                 |
+| `auth_type`                | `openai`, `anthropic`, `qwen-oauth`, `gemini`, `vertex-ai` | Authentication mode passed to the CLI.                                                                          |
+| `include_partial_messages` | `bool`                                                     | Emit partial assistant stream events.                                                                           |
+| `resume`                   | UUID string                                                | Resume a known session id.                                                                                      |
+| `continue_session`         | `bool`                                                     | Continue the latest CLI session.                                                                                |
+| `session_id`               | UUID string                                                | Start or correlate a session with a known id.                                                                   |
+| `timeout`                  | mapping                                                    | Timeouts in seconds.                                                                                            |
+| `stderr`                   | callable                                                   | Receives CLI stderr lines.                                                                                      |
 
 Use only one of `resume`, `continue_session`, or `session_id` in a request. The
 SDK raises `ValidationError` if these session options are combined.
@@ -166,31 +172,27 @@ Unsupported in v1:
 ### Common Configuration
 
 ```python
-result = query(
-    "Summarize the recent changes.",
-    {
-        "cwd": "/path/to/project",
-        "path_to_qwen_executable": "qwen",
-        "model": "qwen-plus",
-        "permission_mode": "plan",
-        "max_session_turns": 1,
-        "env": {
-            "OPENAI_API_KEY": "...",
-            "OPENAI_BASE_URL": "...",
-            "OPENAI_MODEL": "qwen-plus",
-        },
-        "timeout": {
-            "control_request": 60,
-            "can_use_tool": 60,
-            "stream_close": 60,
-        },
+options = {
+    "cwd": "/path/to/project",
+    "path_to_qwen_executable": "qwen",
+    "model": "qwen-plus",
+    "permission_mode": "plan",
+    "max_session_turns": 1,
+    "env": {
+        "OPENAI_MODEL": "qwen-plus",
     },
-)
+    "timeout": {
+        "control_request": 60,
+        "can_use_tool": 60,
+        "stream_close": 60,
+    },
+}
 ```
 
 Timeout values are seconds. `env` is merged on top of the parent process
 environment, so you only need to pass variables that should differ for this SDK
-session.
+session. Set secrets such as `OPENAI_API_KEY` in the parent environment or a
+secrets manager rather than hardcoding them in source.
 
 ## Permission Handling
 
@@ -209,15 +211,39 @@ Example:
 
 ```python
 import asyncio
+from pathlib import Path
 
 from qwen_code_sdk import is_sdk_result_message, query
 
+PROJECT_ROOT = Path("/path/to/project").resolve()
+
+
+def project_path(tool_name, tool_input):
+    key = "path" if tool_name == "list_directory" else "file_path"
+    raw_path = tool_input.get(key)
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+
+    resolved = (PROJECT_ROOT / raw_path).resolve()
+    try:
+        resolved.relative_to(PROJECT_ROOT)
+    except ValueError:
+        return None
+    return resolved
+
 
 async def can_use_tool(tool_name, tool_input, context):
-    if tool_name in {"read_file", "list_directory"}:
-        return {"behavior": "allow", "updatedInput": tool_input}
+    if tool_name in {"read_file", "list_directory", "write_file"}:
+        resolved = project_path(tool_name, tool_input)
+        if resolved is None:
+            return {
+                "behavior": "deny",
+                "message": "Only project-local paths are allowed",
+            }
 
-    if tool_name == "write_file" and tool_input.get("file_path", "").endswith(".md"):
+        if tool_name == "write_file" and resolved.suffix != ".md":
+            return {"behavior": "deny", "message": "Only .md files can be written"}
+
         return {"behavior": "allow", "updatedInput": tool_input}
 
     return {
@@ -227,22 +253,21 @@ async def can_use_tool(tool_name, tool_input, context):
 
 
 async def main():
-    result = query(
+    async with query(
         "Update README.md with a short summary.",
         {
-            "cwd": "/path/to/project",
+            "cwd": str(PROJECT_ROOT),
             "path_to_qwen_executable": "qwen",
             "can_use_tool": can_use_tool,
         },
-    )
-
-    async for message in result:
-        if is_sdk_result_message(message):
-            if message.get("is_error"):
-                error = message.get("error") or {}
-                print(f"Error: {error.get('message', 'Unknown error')}")
-            else:
-                print(message.get("result", ""))
+    ) as result:
+        async for message in result:
+            if is_sdk_result_message(message):
+                if message.get("is_error"):
+                    error = message.get("error") or {}
+                    print(f"Error: {error.get('message', 'Unknown error')}")
+                else:
+                    print(message.get("result", ""))
 
 
 asyncio.run(main())
@@ -288,22 +313,21 @@ async def prompts():
 
 
 async def main():
-    result = query(
+    async with query(
         prompts(),
         {
             "cwd": "/path/to/project",
             "path_to_qwen_executable": "qwen",
             "session_id": SESSION_ID,
         },
-    )
-
-    async for message in result:
-        if is_sdk_result_message(message):
-            if message.get("is_error"):
-                error = message.get("error") or {}
-                print(f"Error: {error.get('message', 'Unknown error')}")
-            else:
-                print(message.get("result", ""))
+    ) as result:
+        async for message in result:
+            if is_sdk_result_message(message):
+                if message.get("is_error"):
+                    error = message.get("error") or {}
+                    print(f"Error: {error.get('message', 'Unknown error')}")
+                else:
+                    print(message.get("result", ""))
 
 
 asyncio.run(main())
@@ -325,27 +349,26 @@ from qwen_code_sdk import is_sdk_result_message, query
 
 
 async def main():
-    result = query(
+    async with query(
         "Inspect this repository and explain the test layout.",
         {
             "cwd": "/path/to/project",
             "path_to_qwen_executable": "qwen",
         },
-    )
+    ) as result:
+        commands = await result.supported_commands()
+        print(commands)
 
-    commands = await result.supported_commands()
-    print(commands)
+        await result.set_permission_mode("plan")
+        await result.set_model("qwen-plus")
 
-    await result.set_permission_mode("plan")
-    await result.set_model("qwen-plus")
-
-    async for message in result:
-        if is_sdk_result_message(message):
-            if message.get("is_error"):
-                error = message.get("error") or {}
-                print(f"Error: {error.get('message', 'Unknown error')}")
-            else:
-                print(message.get("result", ""))
+        async for message in result:
+            if is_sdk_result_message(message):
+                if message.get("is_error"):
+                    error = message.get("error") or {}
+                    print(f"Error: {error.get('message', 'Unknown error')}")
+                else:
+                    print(message.get("result", ""))
 
 
 asyncio.run(main())
@@ -364,21 +387,20 @@ from qwen_code_sdk import is_sdk_result_message, query
 
 async def main():
     # Resume a known session by its id.
-    known = query(
+    async with query(
         "Continue from this session.",
         {
             "path_to_qwen_executable": "qwen",
             "resume": "123e4567-e89b-12d3-a456-426614174000",
         },
-    )
-
-    async for message in known:
-        if is_sdk_result_message(message):
-            if message.get("is_error"):
-                error = message.get("error") or {}
-                print(f"Error: {error.get('message', 'Unknown error')}")
-            else:
-                print(message.get("result", ""))
+    ) as known:
+        async for message in known:
+            if is_sdk_result_message(message):
+                if message.get("is_error"):
+                    error = message.get("error") or {}
+                    print(f"Error: {error.get('message', 'Unknown error')}")
+                else:
+                    print(message.get("result", ""))
 
 
 asyncio.run(main())
@@ -393,21 +415,20 @@ from qwen_code_sdk import is_sdk_result_message, query
 
 
 async def main():
-    latest = query(
+    async with query(
         "Continue the latest session.",
         {
             "path_to_qwen_executable": "qwen",
             "continue_session": True,
         },
-    )
-
-    async for message in latest:
-        if is_sdk_result_message(message):
-            if message.get("is_error"):
-                error = message.get("error") or {}
-                print(f"Error: {error.get('message', 'Unknown error')}")
-            else:
-                print(message.get("result", ""))
+    ) as latest:
+        async for message in latest:
+            if is_sdk_result_message(message):
+                if message.get("is_error"):
+                    error = message.get("error") or {}
+                    print(f"Error: {error.get('message', 'Unknown error')}")
+                else:
+                    print(message.get("result", ""))
 
 
 asyncio.run(main())
@@ -425,12 +446,22 @@ delegates the selection of the latest session to the CLI.
 - `AbortError`: control request or session was cancelled
 
 ```python
-from qwen_code_sdk import ProcessExitError, ValidationError, query_sync
+from qwen_code_sdk import (
+    ProcessExitError,
+    ValidationError,
+    is_sdk_result_message,
+    query_sync,
+)
 
 try:
     with query_sync("Say hello", {"path_to_qwen_executable": "qwen"}) as result:
         for message in result:
-            print(message)
+            if is_sdk_result_message(message):
+                if message.get("is_error"):
+                    error = message.get("error") or {}
+                    print(f"Error: {error.get('message', 'Unknown error')}")
+                else:
+                    print(message.get("result", ""))
 except ValidationError as exc:
     print(f"Invalid SDK options: {exc}")
 except ProcessExitError as exc:

--- a/docs/developers/sdk-python.md
+++ b/docs/developers/sdk-python.md
@@ -21,14 +21,47 @@ testable.
 pip install qwen-code-sdk
 ```
 
+For preview releases:
+
+```bash
+pip install --pre qwen-code-sdk
+```
+
 If `qwen` is not on `PATH`, pass `path_to_qwen_executable` explicitly.
+
+Before writing SDK code, make sure the CLI works in the same shell:
+
+```bash
+qwen --version
+```
 
 ## Quick Start
 
 ```python
 import asyncio
 
-from qwen_code_sdk import is_sdk_result_message, query
+from qwen_code_sdk import (
+    is_sdk_assistant_message,
+    is_sdk_result_message,
+    query,
+)
+
+
+def extract_text(message):
+    content = message["message"].get("content", [])
+    return "".join(
+        block.get("text", "")
+        for block in content
+        if isinstance(block, dict) and block.get("type") == "text"
+    )
+
+
+def print_result(message):
+    if message.get("is_error"):
+        error = message.get("error") or {}
+        print(f"Error: {error.get('message', 'Unknown error')}")
+        return
+    print(message.get("result", ""))
 
 
 async def main() -> None:
@@ -41,11 +74,37 @@ async def main() -> None:
     )
 
     async for message in result:
-        if is_sdk_result_message(message):
-            print(message["result"])
+        if is_sdk_assistant_message(message):
+            print(extract_text(message))
+        elif is_sdk_result_message(message):
+            print_result(message)
 
 
 asyncio.run(main())
+```
+
+## Sync Usage
+
+Use `query_sync` when your host application is not async:
+
+```python
+from qwen_code_sdk import is_sdk_result_message, query_sync
+
+
+with query_sync(
+    "Summarize this repository in one paragraph.",
+    {
+        "cwd": "/path/to/project",
+        "path_to_qwen_executable": "qwen",
+    },
+) as result:
+    for message in result:
+        if is_sdk_result_message(message):
+            if message.get("is_error"):
+                error = message.get("error") or {}
+                print(f"Error: {error.get('message', 'Unknown error')}")
+            else:
+                print(message.get("result", ""))
 ```
 
 ## API Surface
@@ -74,35 +133,64 @@ asyncio.run(main())
 
 ### `QueryOptions`
 
-Supported options in v1:
+| Option                     | Type / values                                              | Description                                                |
+| -------------------------- | ---------------------------------------------------------- | ---------------------------------------------------------- |
+| `cwd`                      | `str`                                                      | Working directory for the CLI process.                     |
+| `model`                    | `str`                                                      | Model override for this SDK session.                       |
+| `path_to_qwen_executable`  | `str`                                                      | `qwen`, an explicit binary path, or a `.js` CLI bundle.    |
+| `permission_mode`          | `default`, `plan`, `auto-edit`, `yolo`                     | Tool execution approval mode.                              |
+| `can_use_tool`             | async callback                                             | Custom permission callback for tool requests.              |
+| `env`                      | `dict[str, str]`                                           | Extra environment variables passed to the CLI process.     |
+| `system_prompt`            | `str`                                                      | Override the system prompt.                                |
+| `append_system_prompt`     | `str`                                                      | Append extra instructions to the system prompt.            |
+| `debug`                    | `bool`                                                     | Forward CLI stderr to stderr when no `stderr` hook exists. |
+| `max_session_turns`        | `int`                                                      | Maximum turns before the CLI ends the session.             |
+| `core_tools`               | `list[str]`                                                | Restrict the available tool set.                           |
+| `exclude_tools`            | `list[str]`                                                | Exclude matching tools.                                    |
+| `allowed_tools`            | `list[str]`                                                | Allow matching tools without callback approval.            |
+| `auth_type`                | `openai`, `anthropic`, `qwen-oauth`, `gemini`, `vertex-ai` | Authentication mode passed to the CLI.                     |
+| `include_partial_messages` | `bool`                                                     | Emit partial assistant stream events.                      |
+| `resume`                   | UUID string                                                | Resume a known session id.                                 |
+| `continue_session`         | `bool`                                                     | Continue the latest CLI session.                           |
+| `session_id`               | UUID string                                                | Start or correlate a session with a known id.              |
+| `timeout`                  | mapping                                                    | Timeouts in seconds.                                       |
+| `stderr`                   | callable                                                   | Receives CLI stderr lines.                                 |
 
-- `cwd`
-- `model`
-- `path_to_qwen_executable`
-- `permission_mode`
-- `can_use_tool`
-- `env`
-- `system_prompt`
-- `append_system_prompt`
-- `debug`
-- `max_session_turns`
-- `core_tools`
-- `exclude_tools`
-- `allowed_tools`
-- `auth_type`
-- `include_partial_messages`
-- `resume`
-- `continue_session`
-- `session_id`
-- `timeout`
+Use only one of `resume`, `continue_session`, or `session_id` in a request. The
+SDK raises `ValidationError` if these session options are combined.
+
+Unsupported in v1:
+
 - `mcp_servers`
-- `stderr`
 
-Session argument priority is fixed as:
+### Common Configuration
 
-1. `resume`
-2. `continue_session`
-3. `session_id`
+```python
+result = query(
+    "Summarize the recent changes.",
+    {
+        "cwd": "/path/to/project",
+        "path_to_qwen_executable": "qwen",
+        "model": "qwen-plus",
+        "permission_mode": "plan",
+        "max_session_turns": 1,
+        "env": {
+            "OPENAI_API_KEY": "...",
+            "OPENAI_BASE_URL": "...",
+            "OPENAI_MODEL": "qwen-plus",
+        },
+        "timeout": {
+            "control_request": 60,
+            "can_use_tool": 60,
+            "stream_close": 60,
+        },
+    },
+)
+```
+
+Timeout values are seconds. `env` is merged on top of the parent process
+environment, so you only need to pass variables that should differ for this SDK
+session.
 
 ## Permission Handling
 
@@ -110,12 +198,167 @@ When the CLI emits a `can_use_tool` control request, the SDK routes it through
 `can_use_tool(tool_name, tool_input, context)`.
 
 - Default behavior: deny
-- Default timeout: 60 seconds
+- Default timeout: 60 seconds, configurable with `timeout.can_use_tool`
 - Timeout fallback: deny
 - Callback exceptions: converted to deny with an error message
 - Callback context: `cancel_event`, `suggestions`, and `blocked_path`
 - Callback contract: `can_use_tool` must be async with 3 positional arguments;
   `stderr` must accept 1 positional string argument
+
+Example:
+
+```python
+from qwen_code_sdk import query
+
+
+async def can_use_tool(tool_name, tool_input, context):
+    if tool_name in {"read_file", "list_directory"}:
+        return {"behavior": "allow", "updatedInput": tool_input}
+
+    if tool_name == "write_file" and tool_input.get("path", "").endswith(".md"):
+        return {"behavior": "allow", "updatedInput": tool_input}
+
+    return {
+        "behavior": "deny",
+        "message": f"{tool_name} is not allowed by this application",
+    }
+
+
+result = query(
+    "Update README.md with a short summary.",
+    {
+        "cwd": "/path/to/project",
+        "path_to_qwen_executable": "qwen",
+        "can_use_tool": can_use_tool,
+    },
+)
+```
+
+If you do not pass `can_use_tool`, the SDK denies permission requests by
+default.
+
+## Multi-Turn Sessions
+
+For multi-turn sessions, pass an async iterable of `SDKUserMessage` objects:
+
+```python
+import asyncio
+
+from qwen_code_sdk import SDKUserMessage, is_sdk_result_message, query
+
+SESSION_ID = "123e4567-e89b-12d3-a456-426614174000"
+
+
+async def prompts():
+    first: SDKUserMessage = {
+        "type": "user",
+        "session_id": SESSION_ID,
+        "message": {
+            "role": "user",
+            "content": "Create a concise project summary.",
+        },
+        "parent_tool_use_id": None,
+    }
+    yield first
+
+    second: SDKUserMessage = {
+        "type": "user",
+        "session_id": SESSION_ID,
+        "message": {
+            "role": "user",
+            "content": "Convert that summary into three bullets.",
+        },
+        "parent_tool_use_id": None,
+    }
+    yield second
+
+
+async def main():
+    result = query(
+        prompts(),
+        {
+            "cwd": "/path/to/project",
+            "path_to_qwen_executable": "qwen",
+            "session_id": SESSION_ID,
+        },
+    )
+
+    async for message in result:
+        if is_sdk_result_message(message):
+            if message.get("is_error"):
+                error = message.get("error") or {}
+                print(f"Error: {error.get('message', 'Unknown error')}")
+            else:
+                print(message.get("result", ""))
+
+
+asyncio.run(main())
+```
+
+## Runtime Controls
+
+The returned `Query` object can control the running CLI process:
+
+```python
+import asyncio
+
+from qwen_code_sdk import is_sdk_result_message, query
+
+
+async def main():
+    result = query(
+        "Inspect this repository and explain the test layout.",
+        {
+            "cwd": "/path/to/project",
+            "path_to_qwen_executable": "qwen",
+        },
+    )
+
+    commands = await result.supported_commands()
+    print(commands)
+
+    await result.set_permission_mode("plan")
+    await result.set_model("qwen-plus")
+
+    async for message in result:
+        if is_sdk_result_message(message):
+            if message.get("is_error"):
+                error = message.get("error") or {}
+                print(f"Error: {error.get('message', 'Unknown error')}")
+            else:
+                print(message.get("result", ""))
+
+
+asyncio.run(main())
+```
+
+Use `interrupt()` to cancel the current operation, `close()` to clean up the
+underlying process, and `get_session_id()` to persist a session id for later.
+
+## Session Resume
+
+```python
+from qwen_code_sdk import query
+
+known = query(
+    "Continue from this session.",
+    {
+        "path_to_qwen_executable": "qwen",
+        "resume": "123e4567-e89b-12d3-a456-426614174000",
+    },
+)
+
+latest = query(
+    "Continue the latest session.",
+    {
+        "path_to_qwen_executable": "qwen",
+        "continue_session": True,
+    },
+)
+```
+
+`resume` is useful when your application stores session ids. `continue_session`
+delegates the selection of the latest session to the CLI.
 
 ## Error Model
 
@@ -124,6 +367,19 @@ When the CLI emits a `can_use_tool` control request, the SDK routes it through
   timed out
 - `ProcessExitError`: CLI exited non-zero
 - `AbortError`: control request or session was cancelled
+
+```python
+from qwen_code_sdk import ProcessExitError, ValidationError, query_sync
+
+try:
+    with query_sync("Say hello", {"path_to_qwen_executable": "qwen"}) as result:
+        for message in result:
+            print(message)
+except ValidationError as exc:
+    print(f"Invalid SDK options: {exc}")
+except ProcessExitError as exc:
+    print(f"qwen exited with {exc.exit_code}: {exc}")
+```
 
 ## Troubleshooting
 

--- a/docs/developers/sdk-python.md
+++ b/docs/developers/sdk-python.md
@@ -208,7 +208,9 @@ When the CLI emits a `can_use_tool` control request, the SDK routes it through
 Example:
 
 ```python
-from qwen_code_sdk import query
+import asyncio
+
+from qwen_code_sdk import is_sdk_result_message, query
 
 
 async def can_use_tool(tool_name, tool_input, context):
@@ -224,14 +226,26 @@ async def can_use_tool(tool_name, tool_input, context):
     }
 
 
-result = query(
-    "Update README.md with a short summary.",
-    {
-        "cwd": "/path/to/project",
-        "path_to_qwen_executable": "qwen",
-        "can_use_tool": can_use_tool,
-    },
-)
+async def main():
+    result = query(
+        "Update README.md with a short summary.",
+        {
+            "cwd": "/path/to/project",
+            "path_to_qwen_executable": "qwen",
+            "can_use_tool": can_use_tool,
+        },
+    )
+
+    async for message in result:
+        if is_sdk_result_message(message):
+            if message.get("is_error"):
+                error = message.get("error") or {}
+                print(f"Error: {error.get('message', 'Unknown error')}")
+            else:
+                print(message.get("result", ""))
+
+
+asyncio.run(main())
 ```
 
 If you do not pass `can_use_tool`, the SDK denies permission requests by
@@ -360,7 +374,11 @@ async def main():
 
     async for message in known:
         if is_sdk_result_message(message):
-            print(message.get("result", ""))
+            if message.get("is_error"):
+                error = message.get("error") or {}
+                print(f"Error: {error.get('message', 'Unknown error')}")
+            else:
+                print(message.get("result", ""))
 
 
 asyncio.run(main())
@@ -385,7 +403,11 @@ async def main():
 
     async for message in latest:
         if is_sdk_result_message(message):
-            print(message.get("result", ""))
+            if message.get("is_error"):
+                error = message.get("error") or {}
+                print(f"Error: {error.get('message', 'Unknown error')}")
+            else:
+                print(message.get("result", ""))
 
 
 asyncio.run(main())

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -209,7 +209,9 @@ call.
 ## Permission Callback
 
 ```python
-from qwen_code_sdk import query
+import asyncio
+
+from qwen_code_sdk import is_sdk_result_message, query
 
 
 async def can_use_tool(tool_name, tool_input, context):
@@ -225,14 +227,26 @@ async def can_use_tool(tool_name, tool_input, context):
     }
 
 
-result = query(
-    "Update README.md with a one paragraph summary.",
-    {
-        "cwd": "/path/to/project",
-        "path_to_qwen_executable": "qwen",
-        "can_use_tool": can_use_tool,
-    },
-)
+async def main():
+    result = query(
+        "Update README.md with a one paragraph summary.",
+        {
+            "cwd": "/path/to/project",
+            "path_to_qwen_executable": "qwen",
+            "can_use_tool": can_use_tool,
+        },
+    )
+
+    async for message in result:
+        if is_sdk_result_message(message):
+            if message.get("is_error"):
+                error = message.get("error") or {}
+                print(f"Error: {error.get('message', 'Unknown error')}")
+            else:
+                print(message.get("result", ""))
+
+
+asyncio.run(main())
 ```
 
 The callback defaults to deny. If it does not return within
@@ -299,7 +313,11 @@ async def main():
 
     async for message in result:
         if is_sdk_result_message(message):
-            print(message.get("result", ""))
+            if message.get("is_error"):
+                error = message.get("error") or {}
+                print(f"Error: {error.get('message', 'Unknown error')}")
+            else:
+                print(message.get("result", ""))
 
 
 asyncio.run(main())
@@ -324,7 +342,11 @@ async def main():
 
     async for message in latest:
         if is_sdk_result_message(message):
-            print(message.get("result", ""))
+            if message.get("is_error"):
+                error = message.get("error") or {}
+                print(f"Error: {error.get('message', 'Unknown error')}")
+            else:
+                print(message.get("result", ""))
 
 
 asyncio.run(main())

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -173,7 +173,7 @@ async def prompts():
     second: SDKUserMessage = {
         "type": "user",
         "session_id": SESSION_ID,
-        "message": {"role": "user", "content": "Now turn it into three bullets."},
+        "message": {"role": "user", "content": "Also list the test files."},
         "parent_tool_use_id": None,
     }
     yield second
@@ -201,6 +201,11 @@ async def main():
 asyncio.run(main())
 ```
 
+All messages in the async iterable must be known upfront. The SDK sends them
+sequentially to the CLI but cannot feed a prior response back into the generator.
+If you need conversational turn-taking, manage each turn as a separate `query()`
+call.
+
 ## Permission Callback
 
 ```python
@@ -211,7 +216,7 @@ async def can_use_tool(tool_name, tool_input, context):
     if tool_name in {"read_file", "list_directory"}:
         return {"behavior": "allow", "updatedInput": tool_input}
 
-    if tool_name == "write_file" and tool_input.get("path", "").endswith(".md"):
+    if tool_name == "write_file" and tool_input.get("file_path", "").endswith(".md"):
         return {"behavior": "allow", "updatedInput": tool_input}
 
     return {
@@ -277,25 +282,52 @@ the underlying process.
 ## Resuming Sessions
 
 ```python
-from qwen_code_sdk import query
+import asyncio
 
-# Resume a known session.
-result = query(
-    "Continue from the previous state.",
-    {
-        "path_to_qwen_executable": "qwen",
-        "resume": "123e4567-e89b-12d3-a456-426614174000",
-    },
-)
+from qwen_code_sdk import is_sdk_result_message, query
 
-# Or ask the CLI to continue its latest session.
-latest = query(
-    "Continue the last session.",
-    {
-        "path_to_qwen_executable": "qwen",
-        "continue_session": True,
-    },
-)
+
+async def main():
+    # Resume a known session.
+    result = query(
+        "Continue from the previous state.",
+        {
+            "path_to_qwen_executable": "qwen",
+            "resume": "123e4567-e89b-12d3-a456-426614174000",
+        },
+    )
+
+    async for message in result:
+        if is_sdk_result_message(message):
+            print(message.get("result", ""))
+
+
+asyncio.run(main())
+```
+
+To continue the latest session instead:
+
+```python
+import asyncio
+
+from qwen_code_sdk import is_sdk_result_message, query
+
+
+async def main():
+    latest = query(
+        "Continue the last session.",
+        {
+            "path_to_qwen_executable": "qwen",
+            "continue_session": True,
+        },
+    )
+
+    async for message in latest:
+        if is_sdk_result_message(message):
+            print(message.get("result", ""))
+
+
+asyncio.run(main())
 ```
 
 Use only one of `resume`, `continue_session`, or `session_id` in a request. The

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -9,6 +9,12 @@ Experimental Python SDK for programmatic access to Qwen Code through the
 pip install qwen-code-sdk
 ```
 
+For preview releases, enable pre-release resolution:
+
+```bash
+pip install --pre qwen-code-sdk
+```
+
 ## Requirements
 
 - Python `>=3.10`
@@ -17,12 +23,39 @@ pip install qwen-code-sdk
 You can also point the SDK at an explicit CLI binary or script with
 `path_to_qwen_executable`.
 
+Before using the SDK, verify that the CLI works in the same environment:
+
+```bash
+qwen --version
+```
+
 ## Quick Start
 
 ```python
 import asyncio
 
-from qwen_code_sdk import is_sdk_result_message, query
+from qwen_code_sdk import (
+    is_sdk_assistant_message,
+    is_sdk_result_message,
+    query,
+)
+
+
+def text_from_message(message):
+    content = message["message"].get("content", [])
+    return "".join(
+        block.get("text", "")
+        for block in content
+        if isinstance(block, dict) and block.get("type") == "text"
+    )
+
+
+def print_result(message):
+    if message.get("is_error"):
+        error = message.get("error") or {}
+        print(f"Error: {error.get('message', 'Unknown error')}")
+        return
+    print(message.get("result", ""))
 
 
 async def main() -> None:
@@ -35,8 +68,10 @@ async def main() -> None:
     )
 
     async for message in result:
-        if is_sdk_result_message(message):
-            print(message["result"])
+        if is_sdk_assistant_message(message):
+            print(text_from_message(message))
+        elif is_sdk_result_message(message):
+            print_result(message)
 
 
 asyncio.run(main())
@@ -45,17 +80,23 @@ asyncio.run(main())
 ## Sync API
 
 ```python
-from qwen_code_sdk import query_sync
+from qwen_code_sdk import is_sdk_result_message, query_sync
 
 
 with query_sync(
     "Say hello",
     {
+        "cwd": "/path/to/project",
         "path_to_qwen_executable": "qwen",
     },
 ) as result:
     for message in result:
-        print(message)
+        if is_sdk_result_message(message):
+            if message.get("is_error"):
+                error = message.get("error") or {}
+                print(f"Error: {error.get('message', 'Unknown error')}")
+            else:
+                print(message.get("result", ""))
 ```
 
 ## Main APIs
@@ -68,6 +109,98 @@ with query_sync(
 `prompt` accepts either a single `str` or an `AsyncIterable[SDKUserMessage]`
 for multi-turn sessions.
 
+## Common Options
+
+```python
+result = query(
+    "Summarize this project.",
+    {
+        "cwd": "/path/to/project",
+        "path_to_qwen_executable": "qwen",
+        "model": "qwen-plus",
+        "permission_mode": "plan",
+        "max_session_turns": 1,
+        "env": {
+            "OPENAI_API_KEY": "...",
+            "OPENAI_BASE_URL": "...",
+            "OPENAI_MODEL": "qwen-plus",
+        },
+        "timeout": {
+            "control_request": 60,
+            "can_use_tool": 60,
+            "stream_close": 60,
+        },
+    },
+)
+```
+
+Common fields:
+
+- `cwd`: working directory used by the CLI
+- `path_to_qwen_executable`: `qwen`, an absolute binary path, or a `.js` CLI
+  bundle
+- `model`: model override for this session
+- `permission_mode`: one of `default`, `plan`, `auto-edit`, or `yolo`
+- `env`: extra environment variables passed to the CLI process
+- `system_prompt` / `append_system_prompt`: override or extend the system
+  prompt
+- `core_tools`, `exclude_tools`, `allowed_tools`: constrain tool availability
+- `timeout`: seconds for control requests, permission callbacks, and stream
+  close waits
+
+## Multi-Turn Sessions
+
+For multi-turn use cases, pass an async iterable of `SDKUserMessage` objects.
+Use a stable UUID for `session_id` when you want to correlate messages:
+
+```python
+import asyncio
+
+from qwen_code_sdk import SDKUserMessage, is_sdk_result_message, query
+
+SESSION_ID = "123e4567-e89b-12d3-a456-426614174000"
+
+
+async def prompts():
+    first: SDKUserMessage = {
+        "type": "user",
+        "session_id": SESSION_ID,
+        "message": {"role": "user", "content": "Create a short project summary."},
+        "parent_tool_use_id": None,
+    }
+    yield first
+
+    second: SDKUserMessage = {
+        "type": "user",
+        "session_id": SESSION_ID,
+        "message": {"role": "user", "content": "Now turn it into three bullets."},
+        "parent_tool_use_id": None,
+    }
+    yield second
+
+
+async def main():
+    result = query(
+        prompts(),
+        {
+            "cwd": "/path/to/project",
+            "path_to_qwen_executable": "qwen",
+            "session_id": SESSION_ID,
+        },
+    )
+
+    async for message in result:
+        if is_sdk_result_message(message):
+            if message.get("is_error"):
+                error = message.get("error") or {}
+                print(f"Error: {error.get('message', 'Unknown error')}")
+            else:
+                print(message.get("result", ""))
+
+
+asyncio.run(main())
+```
+
 ## Permission Callback
 
 ```python
@@ -75,34 +208,118 @@ from qwen_code_sdk import query
 
 
 async def can_use_tool(tool_name, tool_input, context):
-    if tool_name == "write_file":
-        return {"behavior": "deny", "message": "Writes disabled in this app"}
-    return {"behavior": "allow", "updatedInput": tool_input}
+    if tool_name in {"read_file", "list_directory"}:
+        return {"behavior": "allow", "updatedInput": tool_input}
+
+    if tool_name == "write_file" and tool_input.get("path", "").endswith(".md"):
+        return {"behavior": "allow", "updatedInput": tool_input}
+
+    return {
+        "behavior": "deny",
+        "message": f"{tool_name} is not allowed by this application",
+    }
 
 
 result = query(
-    "Create hello.txt",
+    "Update README.md with a one paragraph summary.",
     {
+        "cwd": "/path/to/project",
         "path_to_qwen_executable": "qwen",
         "can_use_tool": can_use_tool,
     },
 )
 ```
 
-The callback defaults to deny. If it does not return within 60 seconds, the SDK
-auto-denies the tool request.
+The callback defaults to deny. If it does not return within
+`timeout.can_use_tool` seconds, the SDK auto-denies the tool request. The
+default timeout is 60 seconds.
 
 The `context` argument includes `cancel_event`, `suggestions`, and
 `blocked_path` when the CLI provides a path-specific permission target.
 `can_use_tool` must be an `async def` callback accepting
 `(tool_name, tool_input, context)`. `stderr` must accept a single `str`.
 
-## Errors
+## Runtime Controls
+
+Control methods can be called while a session is active:
+
+```python
+import asyncio
+
+from qwen_code_sdk import query
+
+
+async def main():
+    result = query(
+        "Inspect this project and wait for my next instruction.",
+        {
+            "cwd": "/path/to/project",
+            "path_to_qwen_executable": "qwen",
+        },
+    )
+
+    commands = await result.supported_commands()
+    print(commands)
+
+    await result.set_permission_mode("plan")
+    await result.set_model("qwen-plus")
+
+    async for message in result:
+        print(message["type"])
+
+
+asyncio.run(main())
+```
+
+Use `interrupt()` to cancel the current CLI operation and `close()` to clean up
+the underlying process.
+
+## Resuming Sessions
+
+```python
+from qwen_code_sdk import query
+
+# Resume a known session.
+result = query(
+    "Continue from the previous state.",
+    {
+        "path_to_qwen_executable": "qwen",
+        "resume": "123e4567-e89b-12d3-a456-426614174000",
+    },
+)
+
+# Or ask the CLI to continue its latest session.
+latest = query(
+    "Continue the last session.",
+    {
+        "path_to_qwen_executable": "qwen",
+        "continue_session": True,
+    },
+)
+```
+
+Use only one of `resume`, `continue_session`, or `session_id` in a request. The
+SDK raises `ValidationError` if these session options are combined.
+
+## Error Handling
 
 - `ValidationError`: invalid query options or malformed session identifiers
 - `ControlRequestTimeoutError`: CLI control operation exceeded timeout
 - `ProcessExitError`: `qwen` exited with a non-zero code
 - `AbortError`: query or control request was cancelled
+
+```python
+from qwen_code_sdk import ProcessExitError, ValidationError, query_sync
+
+try:
+    with query_sync("Say hello", {"path_to_qwen_executable": "qwen"}) as result:
+        for message in result:
+            print(message)
+except ValidationError as exc:
+    print(f"Invalid SDK options: {exc}")
+except ProcessExitError as exc:
+    print(f"qwen exited with {exc.exit_code}: {exc}")
+```
 
 ## Current Scope
 

--- a/packages/sdk-python/README.md
+++ b/packages/sdk-python/README.md
@@ -42,12 +42,15 @@ from qwen_code_sdk import (
 
 
 def text_from_message(message):
-    content = message["message"].get("content", [])
-    return "".join(
+    content = message.get("message", {}).get("content", [])
+    if not isinstance(content, list):
+        return repr(content)
+    texts = [
         block.get("text", "")
         for block in content
         if isinstance(block, dict) and block.get("type") == "text"
-    )
+    ]
+    return "".join(texts) if texts else "[no text content]"
 
 
 def print_result(message):
@@ -59,23 +62,26 @@ def print_result(message):
 
 
 async def main() -> None:
-    result = query(
+    async with query(
         "List the top-level packages in this repository.",
         {
             "cwd": "/path/to/project",
             "path_to_qwen_executable": "qwen",
         },
-    )
-
-    async for message in result:
-        if is_sdk_assistant_message(message):
-            print(text_from_message(message))
-        elif is_sdk_result_message(message):
-            print_result(message)
+    ) as result:
+        async for message in result:
+            if is_sdk_assistant_message(message):
+                print(text_from_message(message))
+            elif is_sdk_result_message(message):
+                print_result(message)
 
 
 asyncio.run(main())
 ```
+
+`asyncio.run()` is appropriate for standalone scripts. If your application
+already runs an event loop, such as Jupyter, FastAPI, or pytest-asyncio, call
+`await main()` instead.
 
 ## Sync API
 
@@ -112,26 +118,21 @@ for multi-turn sessions.
 ## Common Options
 
 ```python
-result = query(
-    "Summarize this project.",
-    {
-        "cwd": "/path/to/project",
-        "path_to_qwen_executable": "qwen",
-        "model": "qwen-plus",
-        "permission_mode": "plan",
-        "max_session_turns": 1,
-        "env": {
-            "OPENAI_API_KEY": "...",
-            "OPENAI_BASE_URL": "...",
-            "OPENAI_MODEL": "qwen-plus",
-        },
-        "timeout": {
-            "control_request": 60,
-            "can_use_tool": 60,
-            "stream_close": 60,
-        },
+options = {
+    "cwd": "/path/to/project",
+    "path_to_qwen_executable": "qwen",
+    "model": "qwen-plus",
+    "permission_mode": "plan",
+    "max_session_turns": 1,
+    "env": {
+        "OPENAI_MODEL": "qwen-plus",
     },
-)
+    "timeout": {
+        "control_request": 60,
+        "can_use_tool": 60,
+        "stream_close": 60,
+    },
+}
 ```
 
 Common fields:
@@ -140,13 +141,18 @@ Common fields:
 - `path_to_qwen_executable`: `qwen`, an absolute binary path, or a `.js` CLI
   bundle
 - `model`: model override for this session
-- `permission_mode`: one of `default`, `plan`, `auto-edit`, or `yolo`
+- `permission_mode`: one of `default`, `plan`, `auto-edit`, or `yolo`; `yolo`
+  auto-approves all tools, so use it only in trusted or sandboxed environments
 - `env`: extra environment variables passed to the CLI process
 - `system_prompt` / `append_system_prompt`: override or extend the system
   prompt
 - `core_tools`, `exclude_tools`, `allowed_tools`: constrain tool availability
 - `timeout`: seconds for control requests, permission callbacks, and stream
   close waits
+
+`env` is merged on top of the parent process environment. Set secrets such as
+`OPENAI_API_KEY` in the parent environment or a secrets manager rather than
+hardcoding them in source.
 
 ## Multi-Turn Sessions
 
@@ -180,22 +186,21 @@ async def prompts():
 
 
 async def main():
-    result = query(
+    async with query(
         prompts(),
         {
             "cwd": "/path/to/project",
             "path_to_qwen_executable": "qwen",
             "session_id": SESSION_ID,
         },
-    )
-
-    async for message in result:
-        if is_sdk_result_message(message):
-            if message.get("is_error"):
-                error = message.get("error") or {}
-                print(f"Error: {error.get('message', 'Unknown error')}")
-            else:
-                print(message.get("result", ""))
+    ) as result:
+        async for message in result:
+            if is_sdk_result_message(message):
+                if message.get("is_error"):
+                    error = message.get("error") or {}
+                    print(f"Error: {error.get('message', 'Unknown error')}")
+                else:
+                    print(message.get("result", ""))
 
 
 asyncio.run(main())
@@ -210,15 +215,39 @@ call.
 
 ```python
 import asyncio
+from pathlib import Path
 
 from qwen_code_sdk import is_sdk_result_message, query
 
+PROJECT_ROOT = Path("/path/to/project").resolve()
+
+
+def project_path(tool_name, tool_input):
+    key = "path" if tool_name == "list_directory" else "file_path"
+    raw_path = tool_input.get(key)
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+
+    resolved = (PROJECT_ROOT / raw_path).resolve()
+    try:
+        resolved.relative_to(PROJECT_ROOT)
+    except ValueError:
+        return None
+    return resolved
+
 
 async def can_use_tool(tool_name, tool_input, context):
-    if tool_name in {"read_file", "list_directory"}:
-        return {"behavior": "allow", "updatedInput": tool_input}
+    if tool_name in {"read_file", "list_directory", "write_file"}:
+        resolved = project_path(tool_name, tool_input)
+        if resolved is None:
+            return {
+                "behavior": "deny",
+                "message": "Only project-local paths are allowed",
+            }
 
-    if tool_name == "write_file" and tool_input.get("file_path", "").endswith(".md"):
+        if tool_name == "write_file" and resolved.suffix != ".md":
+            return {"behavior": "deny", "message": "Only .md files can be written"}
+
         return {"behavior": "allow", "updatedInput": tool_input}
 
     return {
@@ -228,22 +257,21 @@ async def can_use_tool(tool_name, tool_input, context):
 
 
 async def main():
-    result = query(
+    async with query(
         "Update README.md with a one paragraph summary.",
         {
-            "cwd": "/path/to/project",
+            "cwd": str(PROJECT_ROOT),
             "path_to_qwen_executable": "qwen",
             "can_use_tool": can_use_tool,
         },
-    )
-
-    async for message in result:
-        if is_sdk_result_message(message):
-            if message.get("is_error"):
-                error = message.get("error") or {}
-                print(f"Error: {error.get('message', 'Unknown error')}")
-            else:
-                print(message.get("result", ""))
+    ) as result:
+        async for message in result:
+            if is_sdk_result_message(message):
+                if message.get("is_error"):
+                    error = message.get("error") or {}
+                    print(f"Error: {error.get('message', 'Unknown error')}")
+                else:
+                    print(message.get("result", ""))
 
 
 asyncio.run(main())
@@ -265,26 +293,30 @@ Control methods can be called while a session is active:
 ```python
 import asyncio
 
-from qwen_code_sdk import query
+from qwen_code_sdk import is_sdk_result_message, query
 
 
 async def main():
-    result = query(
+    async with query(
         "Inspect this project and wait for my next instruction.",
         {
             "cwd": "/path/to/project",
             "path_to_qwen_executable": "qwen",
         },
-    )
+    ) as result:
+        commands = await result.supported_commands()
+        print(commands)
 
-    commands = await result.supported_commands()
-    print(commands)
+        await result.set_permission_mode("plan")
+        await result.set_model("qwen-plus")
 
-    await result.set_permission_mode("plan")
-    await result.set_model("qwen-plus")
-
-    async for message in result:
-        print(message["type"])
+        async for message in result:
+            if is_sdk_result_message(message):
+                if message.get("is_error"):
+                    error = message.get("error") or {}
+                    print(f"Error: {error.get('message', 'Unknown error')}")
+                else:
+                    print(message.get("result", ""))
 
 
 asyncio.run(main())
@@ -303,21 +335,20 @@ from qwen_code_sdk import is_sdk_result_message, query
 
 async def main():
     # Resume a known session.
-    result = query(
+    async with query(
         "Continue from the previous state.",
         {
             "path_to_qwen_executable": "qwen",
             "resume": "123e4567-e89b-12d3-a456-426614174000",
         },
-    )
-
-    async for message in result:
-        if is_sdk_result_message(message):
-            if message.get("is_error"):
-                error = message.get("error") or {}
-                print(f"Error: {error.get('message', 'Unknown error')}")
-            else:
-                print(message.get("result", ""))
+    ) as result:
+        async for message in result:
+            if is_sdk_result_message(message):
+                if message.get("is_error"):
+                    error = message.get("error") or {}
+                    print(f"Error: {error.get('message', 'Unknown error')}")
+                else:
+                    print(message.get("result", ""))
 
 
 asyncio.run(main())
@@ -332,21 +363,20 @@ from qwen_code_sdk import is_sdk_result_message, query
 
 
 async def main():
-    latest = query(
+    async with query(
         "Continue the last session.",
         {
             "path_to_qwen_executable": "qwen",
             "continue_session": True,
         },
-    )
-
-    async for message in latest:
-        if is_sdk_result_message(message):
-            if message.get("is_error"):
-                error = message.get("error") or {}
-                print(f"Error: {error.get('message', 'Unknown error')}")
-            else:
-                print(message.get("result", ""))
+    ) as latest:
+        async for message in latest:
+            if is_sdk_result_message(message):
+                if message.get("is_error"):
+                    error = message.get("error") or {}
+                    print(f"Error: {error.get('message', 'Unknown error')}")
+                else:
+                    print(message.get("result", ""))
 
 
 asyncio.run(main())
@@ -363,12 +393,22 @@ SDK raises `ValidationError` if these session options are combined.
 - `AbortError`: query or control request was cancelled
 
 ```python
-from qwen_code_sdk import ProcessExitError, ValidationError, query_sync
+from qwen_code_sdk import (
+    ProcessExitError,
+    ValidationError,
+    is_sdk_result_message,
+    query_sync,
+)
 
 try:
     with query_sync("Say hello", {"path_to_qwen_executable": "qwen"}) as result:
         for message in result:
-            print(message)
+            if is_sdk_result_message(message):
+                if message.get("is_error"):
+                    error = message.get("error") or {}
+                    print(f"Error: {error.get('message', 'Unknown error')}")
+                else:
+                    print(message.get("result", ""))
 except ValidationError as exc:
     print(f"Invalid SDK options: {exc}")
 except ProcessExitError as exc:


### PR DESCRIPTION
## Summary

- What changed: Expanded the Python SDK README and developer documentation with copyable usage examples for installation, async queries, sync queries, common options, multi-turn sessions, permission callbacks, runtime controls, session resume, and error handling.
- Why it changed: Users need documentation that shows how to use the Python SDK directly after installing the package, without relying on separate verification scripts.
- Reviewer focus: Please check whether the examples are clear, accurate for the current Python SDK API, and appropriately scoped for the alpha release.

## Validation

- Commands run:
  ```bash
  npx prettier --check packages/sdk-python/README.md docs/developers/sdk-python.md
  /tmp/qwen-sdk-py311.igmI6u/venv/bin/python -m ruff check --config packages/sdk-python/pyproject.toml packages/sdk-python
  /tmp/qwen-sdk-py311.igmI6u/venv/bin/python -m mypy --config-file packages/sdk-python/pyproject.toml packages/sdk-python/src
  /tmp/qwen-sdk-py311.igmI6u/venv/bin/python -m pytest -c packages/sdk-python/pyproject.toml packages/sdk-python/tests -q
  ```
- Prompts / inputs used: N/A, documentation-only change.
- Expected result: Markdown formatting passes and the existing Python SDK checks remain green.
- Observed result: Prettier passed, Ruff passed, Mypy passed, and Pytest reported `58 passed`.
- Quickest reviewer verification path: Read the Python SDK README or developer docs and confirm the examples match the public API names.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.): Local command output showed all checks passing.

## Scope / Risk

- Main risk or tradeoff: Documentation examples can drift from runtime behavior; the examples were aligned with the existing SDK types and validation rules.
- Not covered / not validated: Full docs site rendering was not run locally.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | N/A | N/A | N/A |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Documentation formatting and Python SDK checks were run locally on macOS. Windows and Linux were not run locally.

## Linked Issues / Bugs

None.