### PR TITLE
perf(core): defer four low-frequency tools to shrink per-request payload

### DIFF
--- a/packages/core/src/tools/monitor.ts
+++ b/packages/core/src/tools/monitor.ts
@@ -677,6 +677,11 @@ export class MonitorTool extends BaseDeclarativeTool<
         required: ['command'],
         additionalProperties: false,
       },
+      true, // isOutputMarkdown
+      false, // canUpdateOutput
+      true, // shouldDefer — long-running streamer, only needed when explicit event streaming is required
+      false, // alwaysLoad
+      'stream output from a long-running shell command',
     );
   }
 

--- a/packages/core/src/tools/send-message.ts
+++ b/packages/core/src/tools/send-message.ts
@@ -129,6 +129,11 @@ export class SendMessageTool extends BaseDeclarativeTool<
         required: ['task_id', 'message'],
         additionalProperties: false,
       },
+      true, // isOutputMarkdown
+      false, // canUpdateOutput
+      true, // shouldDefer — only useful once a background task is running
+      false, // alwaysLoad
+      'send a message to a running background task',
     );
   }
 

--- a/packages/core/src/tools/task-stop.ts
+++ b/packages/core/src/tools/task-stop.ts
@@ -247,6 +247,11 @@ export class TaskStopTool extends BaseDeclarativeTool<
         required: ['task_id'],
         additionalProperties: false,
       },
+      true, // isOutputMarkdown
+      false, // canUpdateOutput
+      true, // shouldDefer — only useful once a background task is running
+      false, // alwaysLoad
+      'kill a running background task',
     );
   }
 

--- a/packages/core/src/tools/web-fetch.ts
+++ b/packages/core/src/tools/web-fetch.ts
@@ -289,6 +289,11 @@ export class WebFetchTool extends BaseDeclarativeTool<
         required: ['url', 'prompt'],
         type: 'object',
       },
+      true, // isOutputMarkdown
+      false, // canUpdateOutput
+      true, // shouldDefer — moderate frequency; upstream defers it and the schema is sizeable
+      false, // alwaysLoad
+      'fetch and extract content from a URL',
     );
   }
 


### PR DESCRIPTION
## Summary

- What changed: Four tools — the long-running shell monitor, background-task message sender, background-task stop, and URL fetcher — now opt into the existing on-demand discovery mechanism instead of shipping their schemas with every request. They appear in the deferred-tools section of the system prompt and the model reaches them through tool search the first time they are needed in a session.
- Why it changed: To reduce the per-request token payload. Each schema is roughly 200–800 tokens, and these four are low-frequency for most sessions. Tracks the same deferral coverage the upstream Claude Code project already applies to the same set of tools. Mechanism-wise nothing new is introduced — the discovery surface, deferred-tools prompt section, reveal-on-fetch path, and eager-reveal fallback all already exist and are exercised today by the cron, plan-mode-exit, ask-user-question, MCP, and LSP tools.
- Reviewer focus: (1) Are these the right four to defer — any of them frequent enough that the one-time discovery round trip would hurt? (2) Do the search hints surface each tool for natural-language keyword queries? (3) Anything that should NOT be deferred that this PR accidentally caught? (None expected — the diff is a 5-arg pass-through on each tool's constructor.)

## Validation

- Prompts / inputs used: \"say hi\" (structural prompt for system-prompt and tool-list inspection); \"Fetch https://example.com and tell me the document title.\" (end-to-end discovery flow); \"Call tool_search with query select:&lt;name&gt;\" for each of the four tools (exact-name discovery); four keyword queries (fetch url, stream shell, background task message, kill task) for hint-based discovery.
- Expected result: The four tools drop out of the initial tool list, appear in the system prompt's deferred-tools section, and remain reachable via the discovery surface. The end-to-end fetch flow routes through discovery before invoking the fetcher. With the discovery surface disabled via the exclude-tools flag, all four fall back to eager-loaded.
- Observed result: Matches expectations on every check. The keyword search ranks the expected tool as the top match for all four hint queries — no hint tuning was needed.
- Quickest reviewer verification path: Build and bundle, then run any prompt with API logging enabled. In the captured request, confirm the four tool names are absent from the tool list and present in the deferred-tools section of the system prompt. Then ask the model to fetch a URL and observe that it calls the discovery tool first.
- Evidence: 166 unit tests pass for the four tools plus tool-registry and tool-search. The full end-to-end matrix (10 sub-tests across system-prompt structure, discovery, end-to-end invocation, and fallback) all pass on the local build. See the E2E test report posted as a separate comment below.

## Scope / Risk

- Main risk or tradeoff: One extra discovery round trip the first time the model wants to use one of these tools in a session. For sessions that never call them (the common case), this is pure savings. The borderline case is the URL fetcher — moderately used — but keyword search consistently surfaces it as the top match for fetch/url queries, so the cost is bounded to one round trip per session.
- Not covered / not validated: The resume-history auto-reveal path is unchanged and is already exercised by its existing code path; not separately re-validated here. The task-tracking tool (TodoWrite) deliberately stays eager-loaded — the runtime injects nudges that depend on it being immediately callable, and deferring it would defeat that mechanism. This is an intentional divergence from upstream's broader Task tool deferral.
- Breaking changes / migration notes: None. Users who exclude the discovery tool entirely (via the exclude-tools flag) continue to see all four in the eager tool list via the existing fallback path.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ⚠️  | ✅  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Metadata-only change in shared TypeScript constructors with no platform-conditional code paths. Linux build + end-to-end matrix covers the behavior; other platforms inherit identical behavior.

## Linked Issues / Bugs

None.