### PR TITLE
feat(tools): keep ask_user_question always-visible to surface clarification UX

### DIFF
--- a/packages/core/src/tools/askUserQuestion.test.ts
+++ b/packages/core/src/tools/askUserQuestion.test.ts
@@ -27,6 +27,15 @@ describe('AskUserQuestionTool', () => {
     tool = new AskUserQuestionTool(mockConfig);
   });
 
+  describe('tool registration flags', () => {
+    it('is not deferred — must remain visible in the initial tool list', () => {
+      // shouldDefer=true would hide the schema behind ToolSearch and force the
+      // model to discover the tool by name before using it. The model then
+      // tends to skip the structured clarification UX and ask in plain prose.
+      expect(tool.shouldDefer).toBe(false);
+    });
+  });
+
   describe('validateToolParams', () => {
     it('should accept valid params with single question', () => {
       const params = {

--- a/packages/core/src/tools/askUserQuestion.ts
+++ b/packages/core/src/tools/askUserQuestion.ts
@@ -281,9 +281,7 @@ export class AskUserQuestionTool extends BaseDeclarativeTool<
       >,
       true, // isOutputMarkdown
       false, // canUpdateOutput
-      true, // shouldDefer — rarely needed; loaded on demand via ToolSearch
-      false, // alwaysLoad
-      'ask question user input clarify choose',
+      false, // shouldDefer — kept always-visible so the model reaches for the structured clarification UX instead of asking in plain prose
     );
   }
 


### PR DESCRIPTION
## Summary

- What changed: `ask_user_question` is no longer deferred behind `ToolSearch` — its schema lives in the initial tool list sent to the model every turn.
- Why it changed: When deferred, the model rarely went through `tool_search` discovery before invoking it, and instead asked clarifying questions in plain prose. That loses the structured multiple-choice UX the tool exists to provide.
- Reviewer focus: A unit-test guard pins `shouldDefer === false` so future refactors can't silently regress this. Other deferred tools (`cron_create`, `cron_list`, `lsp`, …) are unchanged. The deferred-tool reveal flow itself is untouched.

## Validation

- Prompts / inputs used: see "E2E test report" comment below — covers tool-list inspection (via `--openai-logging`), an ambiguous prompt to verify the model now reaches for `ask_user_question` directly, a trivial prompt to verify it doesn't over-invoke, and a regression check that the `ToolSearch` reveal flow still works for `cron_list`.
- Expected result: `ask_user_question` appears in the initial tool declarations; the model invokes it directly for ambiguous prompts; other deferred tools stay deferred.
- Observed result: matches expectation across all seven test cases.
- Quickest reviewer verification path:
  ```bash
  node /path/to/qwen-code/dist/cli.js "say hello" --approval-mode yolo --output-format json --openai-logging --openai-logging-dir /tmp/logs >/dev/null 2>&1
  jq '[.request.tools[].function.name] | index("ask_user_question")' "$(ls -1t /tmp/logs/*.json | tail -1)"
  # Expect a non-null integer (was null on origin/main).
  ```
- Evidence: see the E2E test report posted as a separate PR comment.

## Scope / Risk

- Main risk or tradeoff: full schema for `ask_user_question` is now sent every API request. The schema is moderate-sized; the cost is bounded and the UX gain (avoided rework from missed clarifications) is the trade we want.
- Not covered / not validated: behaviour with the `--exclude-tools ask_user_question` flag is unchanged in spirit (the registry filter still applies before the new always-loaded flag matters). Token-budget instrumentation hasn't been re-baselined.
- Breaking changes / migration notes: none. The tool was always registered; this only changes whether its schema appears in the initial declaration list.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Verified locally on macOS via `npm run build && npm run typecheck && npm run bundle` plus E2E runs against `node dist/cli.js`. No platform-specific code paths touched.