### PR TITLE
ci(e2e): cancel stale main E2E runs

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,6 +7,12 @@ on:
       - 'feat/e2e/**'
   merge_group:
 
+concurrency:
+  group: |-
+    ${{ github.workflow }}-${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'main' || github.run_id }}
+  cancel-in-progress: |-
+    ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+
 jobs:
   e2e-test-linux:
     name: 'E2E Test (Linux) - ${{ matrix.sandbox }}'


### PR DESCRIPTION
## Summary

- What changed: Added workflow-level concurrency to the E2E workflow.
- Why it changed: Consecutive pushes to `main` currently run all E2E jobs concurrently, even when an older run has already been superseded by a newer main commit.
- Reviewer focus: Please check the concurrency expression: only `push` events on `refs/heads/main` share the fixed group and cancel older in-progress runs. `feat/e2e/**` and `merge_group` runs use a unique `run_id` group and are not canceled by this change.

## Validation

- Commands run:
  ```bash
  npx prettier --check .github/workflows/e2e.yml
  ruby -e 'require "yaml"; YAML.load_file(".github/workflows/e2e.yml"); puts "yaml-ok"'
  git diff --check
  GOBIN="$(mktemp -d /tmp/actionlint-bin.XXXXXX)" go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
  /tmp/actionlint-bin.*/actionlint .github/workflows/e2e.yml
  ```
- Prompts / inputs used: N/A
- Expected result: Workflow syntax remains valid; future main pushes cancel older in-progress E2E workflow runs, while branch and merge queue E2E runs remain independent.
- Observed result: Prettier, YAML parsing, whitespace check, and actionlint passed locally.
- Quickest reviewer verification path: Inspect the concurrency block in `.github/workflows/e2e.yml` and verify a follow-up main push cancels the previous main E2E run after merge.
- Evidence: Recent main E2E runs for `576bd8e0` and `cb7059f` were both in progress concurrently before this change.

## Scope / Risk

- Main risk or tradeoff: Older main E2E runs may be canceled before completion when a newer main commit arrives; this is intentional because the newer run supersedes the older one.
- Not covered / not validated: Exact cancellation behavior can only be observed after this workflow change is merged and two main pushes occur.
- Breaking changes / migration notes: N/A

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | N/A | N/A | N/A |
| npx      | ✅  | N/A | N/A |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Workflow-only change; local validation focused on YAML formatting and GitHub Actions syntax.

## Linked Issues / Bugs

