### PR TITLE
fix(channels): expand tilde in channel cwd config

### DIFF
--- a/packages/channels/base/src/index.ts
+++ b/packages/channels/base/src/index.ts
@@ -1,4 +1,4 @@
-export { getGlobalQwenDir } from './paths.js';
+export { getGlobalQwenDir, resolvePath } from './paths.js';
 export { AcpBridge } from './AcpBridge.js';
 export type {
   AcpBridgeOptions,

--- a/packages/channels/base/src/paths.test.ts
+++ b/packages/channels/base/src/paths.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import * as path from 'node:path';
 import * as os from 'node:os';
-import { getGlobalQwenDir } from './paths.js';
+import { getGlobalQwenDir, resolvePath } from './paths.js';
 
 describe('channels/base paths – getGlobalQwenDir', () => {
   const originalEnv = process.env['QWEN_HOME'];
@@ -43,5 +43,28 @@ describe('channels/base paths – getGlobalQwenDir', () => {
   it('treats bare tilde (~) as home directory', () => {
     process.env['QWEN_HOME'] = '~';
     expect(getGlobalQwenDir()).toBe(os.homedir());
+  });
+});
+
+describe('channels/base paths – resolvePath', () => {
+  it('returns absolute paths unchanged', () => {
+    const abs = path.resolve('/tmp/x');
+    expect(resolvePath(abs)).toBe(abs);
+  });
+
+  it('expands bare tilde (~) to home directory', () => {
+    expect(resolvePath('~')).toBe(os.homedir());
+  });
+
+  it('expands POSIX-style tilde (~/x)', () => {
+    expect(resolvePath('~/xomo')).toBe(path.join(os.homedir(), 'xomo'));
+  });
+
+  it('expands Windows-style tilde (~\\x)', () => {
+    expect(resolvePath('~\\xomo')).toBe(path.join(os.homedir(), 'xomo'));
+  });
+
+  it('resolves relative paths against process.cwd', () => {
+    expect(resolvePath('relative/dir')).toBe(path.resolve('relative/dir'));
   });
 });

--- a/packages/channels/base/src/paths.ts
+++ b/packages/channels/base/src/paths.ts
@@ -5,7 +5,7 @@ import * as os from 'node:os';
  * Expands tilde and resolves relative paths to absolute.
  * Mirrors Storage.resolvePath() in packages/core.
  */
-function resolvePath(dir: string): string {
+export function resolvePath(dir: string): string {
   let resolved = dir;
   if (
     resolved === '~' ||

--- a/packages/cli/src/commands/channel/config-utils.test.ts
+++ b/packages/cli/src/commands/channel/config-utils.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import * as path from 'node:path';
+import * as os from 'node:os';
 import { resolveEnvVars, parseChannelConfig } from './config-utils.js';
 
 // Mock the channel-registry so we don't pull in real plugins
@@ -136,5 +138,38 @@ describe('parseChannelConfig', () => {
       customField: 42,
     });
     expect((result as Record<string, unknown>)['customField']).toBe(42);
+  });
+
+  it('expands tilde in cwd (~/x → $HOME/x)', async () => {
+    const result = await parseChannelConfig('bot', {
+      type: 'bare',
+      cwd: '~/xomo',
+    });
+    expect(result.cwd).toBe(path.join(os.homedir(), 'xomo'));
+  });
+
+  it('expands bare tilde (~) in cwd to home directory', async () => {
+    const result = await parseChannelConfig('bot', {
+      type: 'bare',
+      cwd: '~',
+    });
+    expect(result.cwd).toBe(os.homedir());
+  });
+
+  it('resolves relative cwd against process.cwd', async () => {
+    const result = await parseChannelConfig('bot', {
+      type: 'bare',
+      cwd: 'relative/dir',
+    });
+    expect(result.cwd).toBe(path.resolve('relative/dir'));
+  });
+
+  it('leaves absolute cwd unchanged', async () => {
+    const abs = path.resolve('/custom');
+    const result = await parseChannelConfig('bot', {
+      type: 'bare',
+      cwd: abs,
+    });
+    expect(result.cwd).toBe(abs);
   });
 });

--- a/packages/cli/src/commands/channel/config-utils.ts
+++ b/packages/cli/src/commands/channel/config-utils.ts
@@ -1,4 +1,5 @@
 import type { ChannelConfig } from '@qwen-code/channel-base';
+import { resolvePath } from '@qwen-code/channel-base';
 import * as path from 'node:path';
 import { getPlugin, supportedTypes } from './channel-registry.js';
 
@@ -73,7 +74,7 @@ export async function parseChannelConfig(
     allowedUsers: (rawConfig['allowedUsers'] as string[]) || [],
     sessionScope:
       (rawConfig['sessionScope'] as ChannelConfig['sessionScope']) || 'user',
-    cwd: (rawConfig['cwd'] as string) || process.cwd(),
+    cwd: resolvePath((rawConfig['cwd'] as string) || process.cwd()),
     approvalMode: rawConfig['approvalMode'] as string | undefined,
     instructions: rawConfig['instructions'] as string | undefined,
     model: rawConfig['model'] as string | undefined,


### PR DESCRIPTION
## Summary

Fixes #3998 — `qwen channel start <name>` with `cwd: "~/xomo"` in settings.json was failing with a misleading `spawn /usr/bin/node ENOENT`.

**Root cause**: `parseChannelConfig` returned `cwd` verbatim, and it was passed straight to `child_process.spawn({ cwd })` in `AcpBridge.start()`. The kernel couldn't chdir to `~/xomo`, errno bound to the spawn op, and the message looked like the node binary was missing.

**Fix**: expand `~` / `~\` and resolve relative paths to absolute at the parse boundary (`parseChannelConfig`), so every downstream consumer (`AcpBridge.spawn`, `SessionRouter`, `WeixinAdapter`, `ChannelBase`) only ever sees absolute paths. Reuses the existing `resolvePath` helper in `@qwen-code/channel-base` (previously used internally by `getGlobalQwenDir`) — same logic, just exported.

## Changes

- `packages/channels/base/src/paths.ts` — `resolvePath` from private to exported (logic unchanged).
- `packages/channels/base/src/index.ts` — re-export `resolvePath`.
- `packages/cli/src/commands/channel/config-utils.ts` — wrap channel `cwd` with `resolvePath` in `parseChannelConfig`.
- Tests: 5 new cases on `resolvePath` directly (absolute / `~` / `~/x` / `~\x` / relative) + 4 new cases on `parseChannelConfig` cwd handling.

## Supported cwd forms (after fix)

- `~` → home dir
- `~/x`, `~\x` → joined under home dir
- relative paths → resolved against `process.cwd()`
- absolute paths → unchanged

Not in scope: `~user/x` expansion, `$HOME` env var expansion, and the secondary error-UX suggestion in the issue (clearer "cwd does not exist" error). The latter can be a follow-up — this PR keeps the change minimal to the actual ENOENT cause.

## Test plan

- [x] `vitest run packages/channels/base/src/paths.test.ts` — 11/11 pass
- [x] `vitest run packages/cli/src/commands/channel/config-utils.test.ts` — 15/15 pass
- [x] `tsc --noEmit -p packages/cli/tsconfig.json` — clean
- [x] Manual repro: confirmed Node `spawn(node, [...], { cwd: '~/xomo' })` produces the exact `spawn <node-path> ENOENT` error described in the issue, and that `resolvePath('~/xomo')` returns the expanded absolute path.