### PR TITLE
fix(telemetry): address PR #3847 review follow-ups for trace correlation

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -88,7 +88,9 @@ vi.mock('../telemetry/tracer.js', () => ({
         setAttribute: (key: string, value: string | number | boolean) => void;
         end: () => void;
       }) => Promise<unknown>,
+      options?: { autoOkOnSuccess?: boolean },
     ) => {
+      const autoOkOnSuccess = options?.autoOkOnSuccess ?? true;
       const record: ToolSpanRecord = {
         name,
         attributes,
@@ -119,7 +121,7 @@ vi.mock('../telemetry/tracer.js', () => ({
 
       try {
         const result = await fn(span);
-        if (!statusSet) {
+        if (autoOkOnSuccess && !statusSet) {
           record.statusCalls.push({ code: 1 });
         }
         return result;
@@ -3273,7 +3275,7 @@ describe('CoreToolScheduler telemetry spans', () => {
     );
   });
 
-  it('marks cancellation as UNSET with a failure kind and no auto-OK', async () => {
+  it('leaves cancellation spans with no explicit status (autoOkOnSuccess: false)', async () => {
     const abortController = new AbortController();
     const { spanRecord, completedCalls } = await runSingleTool({
       abortController,
@@ -3287,12 +3289,14 @@ describe('CoreToolScheduler telemetry spans', () => {
     });
 
     expect(completedCalls[0].status).toBe('cancelled');
-    expect(spanRecord.statusCalls).toEqual([{ code: SpanStatusCode.UNSET }]);
+    // autoOkOnSuccess: false prevents withSpan from auto-setting OK;
+    // setToolSpanCancelled only sets the failure_kind attribute, not a status.
+    expect(spanRecord.statusCalls).toEqual([]);
     expect(spanRecord.spanAttributes['tool.failure_kind']).toBe('cancelled');
     expect(spanRecord.ended).toBe(true);
   });
 
-  it('sets cancellation status when span attribute recording fails', async () => {
+  it('sets cancellation attribute even when span attribute recording fails', async () => {
     const abortController = new AbortController();
     const { spanRecord, completedCalls } = await runSingleTool({
       abortController,
@@ -3307,7 +3311,9 @@ describe('CoreToolScheduler telemetry spans', () => {
     });
 
     expect(completedCalls[0].status).toBe('cancelled');
-    expect(spanRecord.statusCalls).toEqual([{ code: SpanStatusCode.UNSET }]);
+    // No status set — autoOkOnSuccess: false, and setToolSpanCancelled
+    // only sets the attribute (which fails here, caught internally).
+    expect(spanRecord.statusCalls).toEqual([]);
     expect(spanRecord.spanAttributes).not.toHaveProperty('tool.failure_kind');
     expect(spanRecord.ended).toBe(true);
   });
@@ -3327,6 +3333,9 @@ describe('CoreToolScheduler telemetry spans', () => {
     });
 
     expect(completedCalls[0].status).toBe('cancelled');
+    // setToolSpanCancelled no longer calls setStatus, so throwSpanSetStatus
+    // only affects the safeSetStatus(span, OK) in the success path (not hit).
+    // With autoOkOnSuccess: false, withSpan does not attempt setStatus either.
     expect(spanRecord.statusCalls).toEqual([]);
     expect(spanRecord.spanAttributes['tool.failure_kind']).toBe('cancelled');
     expect(spanRecord.ended).toBe(true);

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -3341,6 +3341,17 @@ describe('CoreToolScheduler telemetry spans', () => {
     expect(spanRecord.ended).toBe(true);
   });
 
+  it('does not crash when safeSetStatus throws on the success path', async () => {
+    const { spanRecord, completedCalls } = await runSingleTool({
+      throwSpanSetStatus: true,
+    });
+
+    expect(completedCalls[0].status).toBe('success');
+    expect(spanRecord.statusCalls).toEqual([]);
+    expect(spanRecord.spanAttributes).not.toHaveProperty('tool.failure_kind');
+    expect(spanRecord.ended).toBe(true);
+  });
+
   it('leaves successful tool calls to be marked OK by withSpan', async () => {
     const { spanRecord, completedCalls } = await runSingleTool();
 

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -131,9 +131,9 @@ function setToolSpanCancelled(span: Span): void {
   } catch {
     // OTel errors must not block the cancellation status update.
   }
-  safeSetStatus(span, {
-    code: SpanStatusCode.UNSET,
-  });
+  // No explicit span status — cancellation is neither OK nor ERROR.
+  // The caller uses withSpan({ autoOkOnSuccess: false }) so withSpan
+  // will not auto-set OK, and the span ends with the default UNSET status.
 }
 
 async function safelyFirePostToolUseFailureHook(
@@ -1993,7 +1993,6 @@ export class CoreToolScheduler {
                 'User cancelled tool execution.',
               );
             }
-            // Load-bearing: prevents withSpan from auto-setting OK on normal return
             setToolSpanCancelled(span);
             return; // Both code paths should return here
           }
@@ -2160,6 +2159,7 @@ export class CoreToolScheduler {
                 : {}),
             };
             this.setStatusInternal(callId, 'success', successResponse);
+            safeSetStatus(span, { code: SpanStatusCode.OK });
           } else {
             // It is a failure
             // PostToolUseFailure Hook
@@ -2226,7 +2226,6 @@ export class CoreToolScheduler {
                 'User cancelled tool execution.',
               );
             }
-            // Load-bearing: prevents withSpan from auto-setting OK on normal return
             setToolSpanCancelled(span);
             return;
           } else {
@@ -2267,6 +2266,7 @@ export class CoreToolScheduler {
           }
         }
       },
+      { autoOkOnSuccess: false },
     );
   }
 

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -415,20 +415,44 @@ export class LoggingContentGenerator implements ContentGenerator {
     const runInSpan = <T>(fn: () => T): T =>
       spanContext ? context.with(spanContext, fn) : fn();
 
+    // Defensive timeout: if the consumer abandons the generator without
+    // calling .return() (e.g. drops the reference), the span would never
+    // end. Close it after a bounded duration so it doesn't leak forever.
+    const STREAM_SPAN_MAX_MS = 5 * 60_000; // 5 minutes
+    let spanEndTimeout: ReturnType<typeof setTimeout> | undefined;
+    if (span) {
+      spanEndTimeout = setTimeout(() => {
+        try {
+          safeSetStatus(span, {
+            code: SpanStatusCode.ERROR,
+            message: 'Stream span timed out',
+          });
+          span.end();
+        } catch {
+          // OTel errors must not interrupt the consumer.
+        }
+      }, STREAM_SPAN_MAX_MS);
+      spanEndTimeout.unref();
+    }
+
     try {
       for await (const response of stream) {
-        if (!firstResponseId && response.responseId) {
-          firstResponseId = response.responseId;
-        }
-        if (!firstModelVersion && response.modelVersion) {
-          firstModelVersion = response.modelVersion;
-        }
-        if (!isInternal) {
-          responses.push(response);
-        }
-        if (response.usageMetadata) {
-          lastUsageMetadata = response.usageMetadata;
-        }
+        // Run chunk processing inside the span context so any debug logs
+        // emitted during iteration see the stream span as active.
+        runInSpan(() => {
+          if (!firstResponseId && response.responseId) {
+            firstResponseId = response.responseId;
+          }
+          if (!firstModelVersion && response.modelVersion) {
+            firstModelVersion = response.modelVersion;
+          }
+          if (!isInternal) {
+            responses.push(response);
+          }
+          if (response.usageMetadata) {
+            lastUsageMetadata = response.usageMetadata;
+          }
+        });
         yield response;
       }
       // Only log successful API response if no error occurred
@@ -480,6 +504,9 @@ export class LoggingContentGenerator implements ContentGenerator {
       }
       throw error;
     } finally {
+      if (spanEndTimeout !== undefined) {
+        clearTimeout(spanEndTimeout);
+      }
       if (!terminalStatusAttempted) {
         if (span) {
           safeSetStatus(span, { code: SpanStatusCode.OK });

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -424,6 +424,7 @@ export class LoggingContentGenerator implements ContentGenerator {
     let spanEndTimeout: ReturnType<typeof setTimeout> | undefined;
     const resetSpanTimeout = span
       ? () => {
+          if (spanEnded) return;
           if (spanEndTimeout !== undefined) clearTimeout(spanEndTimeout);
           spanEndTimeout = setTimeout(() => {
             try {

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -428,13 +428,13 @@ export class LoggingContentGenerator implements ContentGenerator {
           if (spanEndTimeout !== undefined) clearTimeout(spanEndTimeout);
           spanEndTimeout = setTimeout(() => {
             try {
-              span.setAttribute('stream.timed_out', true);
               safeSetStatus(span, {
                 code: SpanStatusCode.ERROR,
                 message: 'Stream span timed out (idle)',
               });
-              span.end();
               spanEnded = true;
+              span.setAttribute('stream.timed_out', true);
+              span.end();
             } catch {
               // OTel errors must not interrupt the consumer.
             }

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -432,8 +432,8 @@ export class LoggingContentGenerator implements ContentGenerator {
                 code: SpanStatusCode.ERROR,
                 message: 'Stream span timed out (idle)',
               });
-              spanEnded = true;
               span.end();
+              spanEnded = true;
             } catch {
               // OTel errors must not interrupt the consumer.
             }
@@ -463,6 +463,10 @@ export class LoggingContentGenerator implements ContentGenerator {
         });
         resetSpanTimeout?.();
         yield response;
+      }
+      if (spanEndTimeout !== undefined) {
+        clearTimeout(spanEndTimeout);
+        spanEndTimeout = undefined;
       }
       // Only log successful API response if no error occurred
       const durationMs = Date.now() - startTime;

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -416,26 +416,31 @@ export class LoggingContentGenerator implements ContentGenerator {
     const runInSpan = <T>(fn: () => T): T =>
       spanContext ? context.with(spanContext, fn) : fn();
 
-    // Defensive timeout: if the consumer abandons the generator without
-    // calling .return() (e.g. drops the reference), the span would never
-    // end. Close it after a bounded duration so it doesn't leak forever.
-    const STREAM_SPAN_MAX_MS = 5 * 60_000; // 5 minutes
+    // Idle timeout: if no chunks arrive for this duration the consumer has
+    // likely abandoned the generator without calling .return(). Close the
+    // span so it doesn't leak forever.  The timer resets on every chunk,
+    // so legitimately long-running streams are never affected.
+    const STREAM_IDLE_TIMEOUT_MS = 5 * 60_000; // 5 minutes
     let spanEndTimeout: ReturnType<typeof setTimeout> | undefined;
-    if (span) {
-      spanEndTimeout = setTimeout(() => {
-        try {
-          safeSetStatus(span, {
-            code: SpanStatusCode.ERROR,
-            message: 'Stream span timed out',
-          });
-          spanEnded = true;
-          span.end();
-        } catch {
-          // OTel errors must not interrupt the consumer.
+    const resetSpanTimeout = span
+      ? () => {
+          if (spanEndTimeout !== undefined) clearTimeout(spanEndTimeout);
+          spanEndTimeout = setTimeout(() => {
+            try {
+              safeSetStatus(span, {
+                code: SpanStatusCode.ERROR,
+                message: 'Stream span timed out (idle)',
+              });
+              spanEnded = true;
+              span.end();
+            } catch {
+              // OTel errors must not interrupt the consumer.
+            }
+          }, STREAM_IDLE_TIMEOUT_MS);
+          spanEndTimeout.unref();
         }
-      }, STREAM_SPAN_MAX_MS);
-      spanEndTimeout.unref();
-    }
+      : undefined;
+    resetSpanTimeout?.();
 
     try {
       for await (const response of stream) {
@@ -455,6 +460,7 @@ export class LoggingContentGenerator implements ContentGenerator {
             lastUsageMetadata = response.usageMetadata;
           }
         });
+        resetSpanTimeout?.();
         yield response;
       }
       // Only log successful API response if no error occurred

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -408,6 +408,7 @@ export class LoggingContentGenerator implements ContentGenerator {
     let firstModelVersion = '';
     let lastUsageMetadata: GenerateContentResponseUsageMetadata | undefined;
     let terminalStatusAttempted = false;
+    let spanEnded = false;
 
     // Helper to run code within the span context during iteration.
     // This ensures debug log lines emitted during stream processing
@@ -427,6 +428,7 @@ export class LoggingContentGenerator implements ContentGenerator {
             code: SpanStatusCode.ERROR,
             message: 'Stream span timed out',
           });
+          spanEnded = true;
           span.end();
         } catch {
           // OTel errors must not interrupt the consumer.
@@ -507,15 +509,17 @@ export class LoggingContentGenerator implements ContentGenerator {
       if (spanEndTimeout !== undefined) {
         clearTimeout(spanEndTimeout);
       }
-      if (!terminalStatusAttempted) {
-        if (span) {
-          safeSetStatus(span, { code: SpanStatusCode.OK });
+      if (!spanEnded) {
+        if (!terminalStatusAttempted) {
+          if (span) {
+            safeSetStatus(span, { code: SpanStatusCode.OK });
+          }
         }
-      }
-      try {
-        span?.end();
-      } catch {
-        // OTel errors must not mask the original API error
+        try {
+          span?.end();
+        } catch {
+          // OTel errors must not mask the original API error
+        }
       }
     }
   }

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -428,6 +428,7 @@ export class LoggingContentGenerator implements ContentGenerator {
           if (spanEndTimeout !== undefined) clearTimeout(spanEndTimeout);
           spanEndTimeout = setTimeout(() => {
             try {
+              span.setAttribute('stream.timed_out', true);
               safeSetStatus(span, {
                 code: SpanStatusCode.ERROR,
                 message: 'Stream span timed out (idle)',
@@ -445,22 +446,18 @@ export class LoggingContentGenerator implements ContentGenerator {
 
     try {
       for await (const response of stream) {
-        // Run chunk processing inside the span context so any debug logs
-        // emitted during iteration see the stream span as active.
-        runInSpan(() => {
-          if (!firstResponseId && response.responseId) {
-            firstResponseId = response.responseId;
-          }
-          if (!firstModelVersion && response.modelVersion) {
-            firstModelVersion = response.modelVersion;
-          }
-          if (!isInternal) {
-            responses.push(response);
-          }
-          if (response.usageMetadata) {
-            lastUsageMetadata = response.usageMetadata;
-          }
-        });
+        if (!firstResponseId && response.responseId) {
+          firstResponseId = response.responseId;
+        }
+        if (!firstModelVersion && response.modelVersion) {
+          firstModelVersion = response.modelVersion;
+        }
+        if (!isInternal) {
+          responses.push(response);
+        }
+        if (response.usageMetadata) {
+          lastUsageMetadata = response.usageMetadata;
+        }
         resetSpanTimeout?.();
         yield response;
       }

--- a/packages/core/src/telemetry/log-to-span-processor.test.ts
+++ b/packages/core/src/telemetry/log-to-span-processor.test.ts
@@ -16,6 +16,12 @@ import { LogToSpanProcessor } from './log-to-span-processor.js';
 import type { ReadableLogRecord } from '@opentelemetry/sdk-logs';
 import type { SpanExporter } from '@opentelemetry/sdk-trace-base';
 
+let mockCurrentSessionId: string | undefined = undefined;
+
+vi.mock('./session-context.js', () => ({
+  getCurrentSessionId: () => mockCurrentSessionId,
+}));
+
 interface ExportedSpan {
   name: string;
   kind: number;
@@ -34,6 +40,7 @@ describe('LogToSpanProcessor', () => {
 
   beforeEach(() => {
     exportedSpans = [];
+    mockCurrentSessionId = undefined;
     mockExporter = {
       export: vi.fn((spans, cb) => {
         exportedSpans.push(...spans);
@@ -707,5 +714,41 @@ describe('LogToSpanProcessor', () => {
     await processor.shutdown();
 
     expect(mockExporter.shutdown).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to getCurrentSessionId when log record has no session.id', async () => {
+    mockCurrentSessionId = 'session-from-context';
+    const logRecord = {
+      body: 'event without session attr',
+      hrTime: [1000, 0] as [number, number],
+      attributes: {},
+    } as unknown as ReadableLogRecord;
+
+    processor.onEmit(logRecord);
+    await processor.forceFlush();
+
+    // The traceId should be derived from the fallback session ID,
+    // not a random one.
+    const { deriveTraceId } = await import('./trace-id-utils.js');
+    expect(exportedSpans[0].spanContext().traceId).toBe(
+      deriveTraceId('session-from-context'),
+    );
+  });
+
+  it('prefers log record session.id over getCurrentSessionId', async () => {
+    mockCurrentSessionId = 'stale-session';
+    const logRecord = {
+      body: 'event with session attr',
+      hrTime: [1000, 0] as [number, number],
+      attributes: { 'session.id': 'fresh-session' },
+    } as unknown as ReadableLogRecord;
+
+    processor.onEmit(logRecord);
+    await processor.forceFlush();
+
+    const { deriveTraceId } = await import('./trace-id-utils.js');
+    expect(exportedSpans[0].spanContext().traceId).toBe(
+      deriveTraceId('fresh-session'),
+    );
   });
 });

--- a/packages/core/src/telemetry/log-to-span-processor.ts
+++ b/packages/core/src/telemetry/log-to-span-processor.ts
@@ -161,6 +161,7 @@ export class LogToSpanProcessor implements LogRecordProcessor {
     // getCurrentSessionId() when the log record has no session.id attribute
     // (e.g. after a session change via /clear or /resume).
     const parentSpanContext = getValidParentSpanContext(logRecord.spanContext);
+    // || (not ??) so empty-string session.id also falls through to the fallback
     const sessionId =
       logRecord.attributes?.['session.id'] || getCurrentSessionId();
     let traceId: string;

--- a/packages/core/src/telemetry/log-to-span-processor.ts
+++ b/packages/core/src/telemetry/log-to-span-processor.ts
@@ -162,7 +162,7 @@ export class LogToSpanProcessor implements LogRecordProcessor {
     // (e.g. after a session change via /clear or /resume).
     const parentSpanContext = getValidParentSpanContext(logRecord.spanContext);
     const sessionId =
-      logRecord.attributes?.['session.id'] ?? getCurrentSessionId();
+      logRecord.attributes?.['session.id'] || getCurrentSessionId();
     let traceId: string;
     if (parentSpanContext) {
       traceId = parentSpanContext.traceId;

--- a/packages/core/src/telemetry/log-to-span-processor.ts
+++ b/packages/core/src/telemetry/log-to-span-processor.ts
@@ -158,8 +158,8 @@ export class LogToSpanProcessor implements LogRecordProcessor {
     // Prefer a real active span context when OTel logs provide one, preserving
     // direct parentage. Otherwise derive traceId from session.id so all events
     // in one session appear under a single trace.  Fall back to
-    // getCurrentSessionId() when the OTel Resource session.id is stale after
-    // a session change (/clear, /resume).
+    // getCurrentSessionId() when the log record has no session.id attribute
+    // (e.g. after a session change via /clear or /resume).
     const parentSpanContext = getValidParentSpanContext(logRecord.spanContext);
     const sessionId =
       logRecord.attributes?.['session.id'] ?? getCurrentSessionId();

--- a/packages/core/src/telemetry/log-to-span-processor.ts
+++ b/packages/core/src/telemetry/log-to-span-processor.ts
@@ -28,6 +28,7 @@ import {
   randomHexString,
   randomSpanId,
 } from './trace-id-utils.js';
+import { getCurrentSessionId } from './session-context.js';
 
 const EXPORT_TIMEOUT_MS = 30_000;
 const DEFAULT_MAX_BUFFER_SIZE = 10_000;
@@ -156,9 +157,12 @@ export class LogToSpanProcessor implements LogRecordProcessor {
 
     // Prefer a real active span context when OTel logs provide one, preserving
     // direct parentage. Otherwise derive traceId from session.id so all events
-    // in one session appear under a single trace.
+    // in one session appear under a single trace.  Fall back to
+    // getCurrentSessionId() when the OTel Resource session.id is stale after
+    // a session change (/clear, /resume).
     const parentSpanContext = getValidParentSpanContext(logRecord.spanContext);
-    const sessionId = logRecord.attributes?.['session.id'];
+    const sessionId =
+      logRecord.attributes?.['session.id'] ?? getCurrentSessionId();
     let traceId: string;
     if (parentSpanContext) {
       traceId = parentSpanContext.traceId;

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -569,9 +569,10 @@ describe('refreshSessionContext', () => {
     refreshSessionContext('new-session-id');
 
     expect(createSessionRootContext).toHaveBeenCalledWith('new-session-id');
-    expect(setSessionContext).toHaveBeenCalledWith({
-      __sessionId: 'new-session-id',
-    });
+    expect(setSessionContext).toHaveBeenCalledWith(
+      { __sessionId: 'new-session-id' },
+      'new-session-id',
+    );
   });
 
   it('should be a no-op when telemetry is not initialized', () => {

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -289,10 +289,8 @@ export function initializeTelemetry(config: Config): void {
     sdk.start();
     debugLogger.debug('OpenTelemetry SDK started successfully.');
     telemetryInitialized = true;
-    setSessionContext(
-      createSessionRootContext(config.getSessionId()),
-      config.getSessionId(),
-    );
+    const sessionId = config.getSessionId();
+    setSessionContext(createSessionRootContext(sessionId), sessionId);
     initializeMetrics(config);
   } catch (error) {
     debugLogger.error('Error starting OpenTelemetry SDK:', error);

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -289,7 +289,10 @@ export function initializeTelemetry(config: Config): void {
     sdk.start();
     debugLogger.debug('OpenTelemetry SDK started successfully.');
     telemetryInitialized = true;
-    setSessionContext(createSessionRootContext(config.getSessionId()));
+    setSessionContext(
+      createSessionRootContext(config.getSessionId()),
+      config.getSessionId(),
+    );
     initializeMetrics(config);
   } catch (error) {
     debugLogger.error('Error starting OpenTelemetry SDK:', error);
@@ -304,7 +307,7 @@ export function initializeTelemetry(config: Config): void {
 export function refreshSessionContext(sessionId: string): void {
   if (!telemetryInitialized) return;
   try {
-    setSessionContext(createSessionRootContext(sessionId));
+    setSessionContext(createSessionRootContext(sessionId), sessionId);
   } catch (error) {
     createDebugLogger('OTEL').warn('Failed to refresh session context:', error);
   }

--- a/packages/core/src/telemetry/session-context.test.ts
+++ b/packages/core/src/telemetry/session-context.test.ts
@@ -6,7 +6,11 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 import { ROOT_CONTEXT, createContextKey } from '@opentelemetry/api';
-import { getSessionContext, setSessionContext } from './session-context.js';
+import {
+  getSessionContext,
+  setSessionContext,
+  getCurrentSessionId,
+} from './session-context.js';
 
 describe('session-context', () => {
   afterEach(() => {
@@ -40,5 +44,38 @@ describe('session-context', () => {
     setSessionContext(undefined);
 
     expect(getSessionContext()).toBeUndefined();
+  });
+});
+
+describe('getCurrentSessionId', () => {
+  afterEach(() => {
+    setSessionContext(undefined);
+  });
+
+  it('returns undefined when no session has been set', () => {
+    expect(getCurrentSessionId()).toBeUndefined();
+  });
+
+  it('returns the session ID passed to setSessionContext', () => {
+    const key = createContextKey('sid-test-key');
+    setSessionContext(ROOT_CONTEXT.setValue(key, 'ctx'), 'session-abc');
+
+    expect(getCurrentSessionId()).toBe('session-abc');
+  });
+
+  it('updates when setSessionContext is called with a new session ID', () => {
+    const key = createContextKey('sid-update-key');
+    setSessionContext(ROOT_CONTEXT.setValue(key, 'first'), 'session-1');
+    setSessionContext(ROOT_CONTEXT.setValue(key, 'second'), 'session-2');
+
+    expect(getCurrentSessionId()).toBe('session-2');
+  });
+
+  it('clears when setSessionContext is called without a session ID', () => {
+    const key = createContextKey('sid-clear-key');
+    setSessionContext(ROOT_CONTEXT.setValue(key, 'ctx'), 'session-xyz');
+    setSessionContext(undefined);
+
+    expect(getCurrentSessionId()).toBeUndefined();
   });
 });

--- a/packages/core/src/telemetry/session-context.ts
+++ b/packages/core/src/telemetry/session-context.ts
@@ -7,11 +7,25 @@
 import type { Context } from '@opentelemetry/api';
 
 let sessionRootContext: Context | undefined;
+let currentSessionId: string | undefined;
 
-export function setSessionContext(ctx: Context | undefined): void {
+export function setSessionContext(
+  ctx: Context | undefined,
+  sessionId?: string,
+): void {
   sessionRootContext = ctx;
+  currentSessionId = sessionId;
 }
 
 export function getSessionContext(): Context | undefined {
   return sessionRootContext;
+}
+
+/**
+ * Returns the most recent session ID passed to setSessionContext.
+ * Used by LogToSpanProcessor to derive the correct traceId even when
+ * the OTel Resource session.id attribute is stale after a session change.
+ */
+export function getCurrentSessionId(): string | undefined {
+  return currentSessionId;
 }

--- a/packages/core/src/telemetry/session-context.ts
+++ b/packages/core/src/telemetry/session-context.ts
@@ -23,8 +23,8 @@ export function getSessionContext(): Context | undefined {
 
 /**
  * Returns the most recent session ID passed to setSessionContext.
- * Used by LogToSpanProcessor to derive the correct traceId even when
- * the OTel Resource session.id attribute is stale after a session change.
+ * Used by LogToSpanProcessor as a fallback to derive the correct traceId
+ * when a log record has no session.id attribute (e.g. after /clear or /resume).
  */
 export function getCurrentSessionId(): string | undefined {
   return currentSessionId;

--- a/packages/core/src/telemetry/tracer.test.ts
+++ b/packages/core/src/telemetry/tracer.test.ts
@@ -439,6 +439,20 @@ describe('createSessionRootContext', () => {
     }
   });
 
+  it('uses TraceFlags.SAMPLED for parentbased_traceidratio (parent flag gates children)', () => {
+    const original = process.env['OTEL_TRACES_SAMPLER'];
+    process.env['OTEL_TRACES_SAMPLER'] = 'parentbased_traceidratio';
+    try {
+      const ctx = createSessionRootContext('session-pb-ratio') as unknown as {
+        traceFlags: number;
+      };
+      expect(ctx.traceFlags).toBe(TraceFlags.SAMPLED);
+    } finally {
+      if (original !== undefined) process.env['OTEL_TRACES_SAMPLER'] = original;
+      else delete process.env['OTEL_TRACES_SAMPLER'];
+    }
+  });
+
   it('generates a valid 16-char hex spanId', () => {
     const ctx = createSessionRootContext('session-123') as unknown as {
       spanId: string;

--- a/packages/core/src/telemetry/tracer.test.ts
+++ b/packages/core/src/telemetry/tracer.test.ts
@@ -303,6 +303,70 @@ describe('withSpan', () => {
 
     expect(spans[0].attributes).toEqual({ tool_name: 'read', call_id: '123' });
   });
+
+  describe('autoOkOnSuccess option', () => {
+    it('does not auto-set OK when autoOkOnSuccess is false and callback resolves', async () => {
+      await withSpan('test.no-auto-ok', {}, async () => 42, {
+        autoOkOnSuccess: false,
+      });
+
+      expect(spans).toHaveLength(1);
+      expect(spans[0].statuses).toEqual([]);
+      expect(spans[0].ended).toBe(true);
+    });
+
+    it('still sets ERROR when callback throws and autoOkOnSuccess is false', async () => {
+      await expect(
+        withSpan(
+          'test.throw-no-auto',
+          {},
+          async () => {
+            throw new Error('fail');
+          },
+          { autoOkOnSuccess: false },
+        ),
+      ).rejects.toThrow('fail');
+
+      expect(spans).toHaveLength(1);
+      expect(spans[0].statuses).toEqual([
+        { code: SpanStatusCode.ERROR, message: 'Operation failed' },
+      ]);
+    });
+
+    it('preserves caller-set ERROR with autoOkOnSuccess false', async () => {
+      await withSpan(
+        'test.error-no-auto',
+        {},
+        async (span) => {
+          span.setStatus({
+            code: SpanStatusCode.ERROR,
+            message: 'hook denied',
+          });
+        },
+        { autoOkOnSuccess: false },
+      );
+
+      expect(spans).toHaveLength(1);
+      expect(spans[0].statuses).toEqual([
+        { code: SpanStatusCode.ERROR, message: 'hook denied' },
+      ]);
+    });
+
+    it('allows caller to set OK explicitly with autoOkOnSuccess false', async () => {
+      await withSpan(
+        'test.explicit-ok',
+        {},
+        async (span) => {
+          span.setStatus({ code: SpanStatusCode.OK });
+          return 'done';
+        },
+        { autoOkOnSuccess: false },
+      );
+
+      expect(spans).toHaveLength(1);
+      expect(spans[0].statuses).toEqual([{ code: SpanStatusCode.OK }]);
+    });
+  });
 });
 
 describe('startSpanWithContext', () => {
@@ -333,11 +397,46 @@ describe('createSessionRootContext', () => {
     expect(ctx.traceId).toBe(deriveTraceId('session-123'));
   });
 
-  it('uses TraceFlags.SAMPLED so children are recorded by default', () => {
-    const ctx = createSessionRootContext('session-123') as unknown as {
-      traceFlags: number;
-    };
-    expect(ctx.traceFlags).toBe(TraceFlags.SAMPLED);
+  it('uses TraceFlags.SAMPLED by default (no OTEL_TRACES_SAMPLER)', () => {
+    const original = process.env['OTEL_TRACES_SAMPLER'];
+    delete process.env['OTEL_TRACES_SAMPLER'];
+    try {
+      const ctx = createSessionRootContext('session-123') as unknown as {
+        traceFlags: number;
+      };
+      expect(ctx.traceFlags).toBe(TraceFlags.SAMPLED);
+    } finally {
+      if (original !== undefined) process.env['OTEL_TRACES_SAMPLER'] = original;
+      else delete process.env['OTEL_TRACES_SAMPLER'];
+    }
+  });
+
+  it('uses TraceFlags.NONE when a custom sampler is configured', () => {
+    const original = process.env['OTEL_TRACES_SAMPLER'];
+    process.env['OTEL_TRACES_SAMPLER'] = 'traceidratio';
+    try {
+      const ctx = createSessionRootContext('session-456') as unknown as {
+        traceFlags: number;
+      };
+      expect(ctx.traceFlags).toBe(TraceFlags.NONE);
+    } finally {
+      if (original !== undefined) process.env['OTEL_TRACES_SAMPLER'] = original;
+      else delete process.env['OTEL_TRACES_SAMPLER'];
+    }
+  });
+
+  it('uses TraceFlags.SAMPLED when OTEL_TRACES_SAMPLER=parentbased_always_on', () => {
+    const original = process.env['OTEL_TRACES_SAMPLER'];
+    process.env['OTEL_TRACES_SAMPLER'] = 'parentbased_always_on';
+    try {
+      const ctx = createSessionRootContext('session-789') as unknown as {
+        traceFlags: number;
+      };
+      expect(ctx.traceFlags).toBe(TraceFlags.SAMPLED);
+    } finally {
+      if (original !== undefined) process.env['OTEL_TRACES_SAMPLER'] = original;
+      else delete process.env['OTEL_TRACES_SAMPLER'];
+    }
   });
 
   it('generates a valid 16-char hex spanId', () => {

--- a/packages/core/src/telemetry/tracer.test.ts
+++ b/packages/core/src/telemetry/tracer.test.ts
@@ -425,6 +425,34 @@ describe('createSessionRootContext', () => {
     }
   });
 
+  it('uses TraceFlags.SAMPLED when OTEL_TRACES_SAMPLER=always_on', () => {
+    const original = process.env['OTEL_TRACES_SAMPLER'];
+    process.env['OTEL_TRACES_SAMPLER'] = 'always_on';
+    try {
+      const ctx = createSessionRootContext('session-ao') as unknown as {
+        traceFlags: number;
+      };
+      expect(ctx.traceFlags).toBe(TraceFlags.SAMPLED);
+    } finally {
+      if (original !== undefined) process.env['OTEL_TRACES_SAMPLER'] = original;
+      else delete process.env['OTEL_TRACES_SAMPLER'];
+    }
+  });
+
+  it('uses TraceFlags.NONE when OTEL_TRACES_SAMPLER=always_off', () => {
+    const original = process.env['OTEL_TRACES_SAMPLER'];
+    process.env['OTEL_TRACES_SAMPLER'] = 'always_off';
+    try {
+      const ctx = createSessionRootContext('session-aoff') as unknown as {
+        traceFlags: number;
+      };
+      expect(ctx.traceFlags).toBe(TraceFlags.NONE);
+    } finally {
+      if (original !== undefined) process.env['OTEL_TRACES_SAMPLER'] = original;
+      else delete process.env['OTEL_TRACES_SAMPLER'];
+    }
+  });
+
   it('uses TraceFlags.SAMPLED when OTEL_TRACES_SAMPLER=parentbased_always_on', () => {
     const original = process.env['OTEL_TRACES_SAMPLER'];
     process.env['OTEL_TRACES_SAMPLER'] = 'parentbased_always_on';

--- a/packages/core/src/telemetry/tracer.test.ts
+++ b/packages/core/src/telemetry/tracer.test.ts
@@ -439,6 +439,20 @@ describe('createSessionRootContext', () => {
     }
   });
 
+  it('uses TraceFlags.NONE when OTEL_TRACES_SAMPLER=parentbased_always_off', () => {
+    const original = process.env['OTEL_TRACES_SAMPLER'];
+    process.env['OTEL_TRACES_SAMPLER'] = 'parentbased_always_off';
+    try {
+      const ctx = createSessionRootContext('session-off') as unknown as {
+        traceFlags: number;
+      };
+      expect(ctx.traceFlags).toBe(TraceFlags.NONE);
+    } finally {
+      if (original !== undefined) process.env['OTEL_TRACES_SAMPLER'] = original;
+      else delete process.env['OTEL_TRACES_SAMPLER'];
+    }
+  });
+
   it('uses TraceFlags.SAMPLED for parentbased_traceidratio (parent flag gates children)', () => {
     const original = process.env['OTEL_TRACES_SAMPLER'];
     process.env['OTEL_TRACES_SAMPLER'] = 'parentbased_traceidratio';

--- a/packages/core/src/telemetry/tracer.ts
+++ b/packages/core/src/telemetry/tracer.ts
@@ -214,18 +214,20 @@ export function startSpanWithContext(
 /**
  * Determine whether the synthetic session root should force the SAMPLED flag.
  *
- * With the default `parentbased_always_on` sampler, children of an unsampled
- * parent are not recorded, so the root must carry SAMPLED for traces to
- * appear. When a custom sampler is configured (e.g. `traceidratio:0.01`),
- * forcing SAMPLED would bypass that sampler, making it effectively a no-op.
- * In that case we use NONE so the sampler evaluates each span independently.
+ * parentbased_* samplers delegate to localParentNotSampled (default AlwaysOff)
+ * when the parent carries TraceFlags.NONE. Since our synthetic root is the
+ * parent of all session spans, it MUST carry SAMPLED for any parentbased_*
+ * sampler — otherwise zero traces are exported.
+ *
+ * For non-parentbased samplers (e.g. `traceidratio`, `always_off`), each span
+ * is evaluated independently regardless of parent flags, so we use NONE to
+ * let the sampler decide.
  */
 function shouldForceSampled(): boolean {
   const sampler =
     process.env['OTEL_TRACES_SAMPLER']?.trim().toLowerCase() ?? '';
-  return (
-    !sampler || sampler === 'parentbased_always_on' || sampler === 'always_on'
-  );
+  if (!sampler || sampler.startsWith('parentbased_')) return true;
+  return sampler === 'always_on';
 }
 
 /**

--- a/packages/core/src/telemetry/tracer.ts
+++ b/packages/core/src/telemetry/tracer.ts
@@ -221,7 +221,8 @@ export function startSpanWithContext(
  * In that case we use NONE so the sampler evaluates each span independently.
  */
 function shouldForceSampled(): boolean {
-  const sampler = process.env['OTEL_TRACES_SAMPLER']?.toLowerCase() ?? '';
+  const sampler =
+    process.env['OTEL_TRACES_SAMPLER']?.trim().toLowerCase() ?? '';
   return (
     !sampler || sampler === 'parentbased_always_on' || sampler === 'always_on'
   );

--- a/packages/core/src/telemetry/tracer.ts
+++ b/packages/core/src/telemetry/tracer.ts
@@ -216,17 +216,25 @@ export function startSpanWithContext(
  *
  * parentbased_* samplers delegate to localParentNotSampled (default AlwaysOff)
  * when the parent carries TraceFlags.NONE. Since our synthetic root is the
- * parent of all session spans, it MUST carry SAMPLED for any parentbased_*
- * sampler — otherwise zero traces are exported.
+ * parent of all session spans, it MUST carry SAMPLED for most parentbased_*
+ * samplers — otherwise zero traces are exported.
+ *
+ * Exception: `parentbased_always_off` explicitly wants no sampling. Forcing
+ * SAMPLED would cause ParentBasedSampler to delegate to localParentSampled
+ * (default AlwaysOn), sampling everything — the opposite of the user's intent.
  *
  * For non-parentbased samplers (e.g. `traceidratio`, `always_off`), each span
  * is evaluated independently regardless of parent flags, so we use NONE to
- * let the sampler decide.
+ * let the sampler decide. `always_on` is the exception — it ignores parent
+ * flags, so SAMPLED is harmless and keeps the decision matrix explicit.
  */
 function shouldForceSampled(): boolean {
   const sampler =
     process.env['OTEL_TRACES_SAMPLER']?.trim().toLowerCase() ?? '';
-  if (!sampler || sampler.startsWith('parentbased_')) return true;
+  if (!sampler || sampler.startsWith('parentbased_')) {
+    if (sampler.includes('always_off')) return false;
+    return true;
+  }
   return sampler === 'always_on';
 }
 

--- a/packages/core/src/telemetry/tracer.ts
+++ b/packages/core/src/telemetry/tracer.ts
@@ -109,21 +109,38 @@ function wrapSpanWithStatusTracking(span: Span): {
 }
 
 /**
+ * Options for {@link withSpan}.
+ */
+export interface WithSpanOptions {
+  /**
+   * When true (default), withSpan automatically sets OK status if the
+   * callback resolves without having set a status. When false, the caller
+   * is responsible for setting a terminal status in every code path.
+   * Use false when the callback handles multiple outcomes (success, error,
+   * cancellation) and each path sets its own status.
+   */
+  autoOkOnSuccess?: boolean;
+}
+
+/**
  * Run an async function within a new OTel span.
  * The span inherits the session root traceId when no parent span is active.
  * When the OTel SDK is not initialized, the tracer is a noop.
  *
  * If the callback sets a status explicitly (e.g. ERROR on a handled failure),
  * withSpan will not overwrite it. Only when no status has been set and the
- * callback resolves without throwing will the span be marked OK. If the
- * callback throws before setting status, the span is marked ERROR with a
- * generic message so raw exception text is not exported to OTel backends.
+ * callback resolves without throwing will the span be marked OK (unless
+ * autoOkOnSuccess is false). If the callback throws before setting status,
+ * the span is marked ERROR with a generic message so raw exception text is
+ * not exported to OTel backends.
  */
 export async function withSpan<T>(
   name: string,
   attributes: Record<string, string | number | boolean>,
   fn: (span: Span) => Promise<T>,
+  options?: WithSpanOptions,
 ): Promise<T> {
+  const autoOkOnSuccess = options?.autoOkOnSuccess ?? true;
   const parentCtx = getParentContext();
   return tracer.startActiveSpan(
     name,
@@ -133,7 +150,7 @@ export async function withSpan<T>(
       const { wrappedSpan, wasStatusSet } = wrapSpanWithStatusTracking(span);
       try {
         const result = await fn(wrappedSpan);
-        if (!wasStatusSet()) {
+        if (autoOkOnSuccess && !wasStatusSet()) {
           safeSetStatus(span, { code: SpanStatusCode.OK });
         }
         return result;
@@ -195,6 +212,22 @@ export function startSpanWithContext(
 }
 
 /**
+ * Determine whether the synthetic session root should force the SAMPLED flag.
+ *
+ * With the default `parentbased_always_on` sampler, children of an unsampled
+ * parent are not recorded, so the root must carry SAMPLED for traces to
+ * appear. When a custom sampler is configured (e.g. `traceidratio:0.01`),
+ * forcing SAMPLED would bypass that sampler, making it effectively a no-op.
+ * In that case we use NONE so the sampler evaluates each span independently.
+ */
+function shouldForceSampled(): boolean {
+  const sampler = process.env['OTEL_TRACES_SAMPLER']?.toLowerCase() ?? '';
+  return (
+    !sampler || sampler === 'parentbased_always_on' || sampler === 'always_on'
+  );
+}
+
+/**
  * Create a root context with a deterministic traceId derived from sessionId.
  * All spans created within this context will share the same traceId,
  * consistent with LogToSpanProcessor.
@@ -205,7 +238,7 @@ export function createSessionRootContext(sessionId: string): Context {
   const rootSpan = trace.wrapSpanContext({
     traceId,
     spanId,
-    traceFlags: TraceFlags.SAMPLED,
+    traceFlags: shouldForceSampled() ? TraceFlags.SAMPLED : TraceFlags.NONE,
     isRemote: false,
   });
   return trace.setSpan(ROOT_CONTEXT, rootSpan);

--- a/packages/core/src/telemetry/tracer.ts
+++ b/packages/core/src/telemetry/tracer.ts
@@ -214,10 +214,20 @@ export function startSpanWithContext(
 /**
  * Determine whether the synthetic session root should force the SAMPLED flag.
  *
+ * This function reads `OTEL_TRACES_SAMPLER` to infer the sampler type.
+ * If a sampler is configured programmatically (e.g. via NodeSDK constructor)
+ * without setting the env var, this heuristic will not detect it.
+ *
  * parentbased_* samplers delegate to localParentNotSampled (default AlwaysOff)
  * when the parent carries TraceFlags.NONE. Since our synthetic root is the
  * parent of all session spans, it MUST carry SAMPLED for most parentbased_*
  * samplers — otherwise zero traces are exported.
+ *
+ * Note: `parentbased_traceidratio` users expect probabilistic sampling, but
+ * because our synthetic root is always present with SAMPLED, the ratio sampler
+ * (only consulted for parentless root spans) is never invoked — they
+ * effectively get 100% sampling. This is intentional: the alternative
+ * (TraceFlags.NONE) would produce zero traces.
  *
  * Exception: `parentbased_always_off` explicitly wants no sampling. Forcing
  * SAMPLED would cause ParentBasedSampler to delegate to localParentSampled

--- a/packages/core/src/utils/debugLogger.test.ts
+++ b/packages/core/src/utils/debugLogger.test.ts
@@ -207,7 +207,7 @@ describe('debugLogger', () => {
 
     it('uses the session root span context for fallback trace context', async () => {
       const sessionRootContext = { root: true } as unknown as Context;
-      setSessionContext(sessionRootContext);
+      setSessionContext(sessionRootContext, 'test-session');
       vi.mocked(trace.getSpan).mockImplementation((ctx) =>
         ctx === sessionRootContext
           ? ({


### PR DESCRIPTION
## Summary

Addresses unresolved review feedback from PR #3847 (feat(telemetry): inject traceId/spanId into debug log files for OTel correlation):

- **TraceFlags.SAMPLED hardcoding**: `createSessionRootContext` now reads `OTEL_TRACES_SAMPLER` env var — most `parentbased_*` samplers get `SAMPLED` (parent flag gates children via `localParentNotSampled`), `parentbased_always_off` gets `NONE` to respect user intent, non-parentbased samplers (e.g. `traceidratio`) get `NONE` so the sampler evaluates each span independently
- **OTel Resource session.id missing after session change**: Added `getCurrentSessionId()` to `session-context.ts`; `LogToSpanProcessor.onEmit` falls back to it when the log record has no `session.id` attribute (e.g. after a session change via `/clear` or `/resume`). Uses `||` (not `??`) so empty-string `session.id` also triggers fallback
- **Consumer-side stream logs outside span context**: Post-loop logging calls wrapped in `runInSpan()` so debug logs emitted during stream processing see the stream span as active. Chunk field-assignment block left unwrapped (no log emission)
- **`setStatus(UNSET)` hack**: Added `autoOkOnSuccess` option to `withSpan`; tool execution span uses `autoOkOnSuccess: false` so callers explicitly set status in each path — eliminates the load-bearing `setStatus(UNSET)` pattern
- **Abandoned generator span leak**: Added defensive idle timeout on stream spans — timer resets on each chunk, so only truly abandoned generators (no chunks for 5 minutes) trigger span cleanup. Timeout fires `stream.timed_out=true` attribute + ERROR status. Includes multi-layer guards: `spanEnded` flag (set before `span.end()`), zombie timer prevention (`if (spanEnded) return`), immediate `clearTimeout` after for-await loop exit

## Verification

```
$ npx vitest run <7 test files>

 ✓ src/utils/debugLogger.test.ts (22 tests) 12ms
 ✓ src/telemetry/tracer.test.ts (32 tests) 6ms
 ✓ src/telemetry/session-context.test.ts (7 tests) 1ms
 ✓ src/telemetry/log-to-span-processor.test.ts (32 tests) 7ms
 ✓ src/core/loggingContentGenerator/loggingContentGenerator.test.ts (30 tests) 12ms
 ✓ src/telemetry/sdk.test.ts (27 tests) 85ms
 ✓ src/core/coreToolScheduler.test.ts (112 tests) 754ms

 Test Files  7 passed (7)
      Tests  262 passed (262)

$ npx tsc --noEmit -p packages/core/tsconfig.json
# No errors in changed files (pre-existing @google/genai module errors only)
```

## Test plan

- [x] `tracer.test.ts`: 32 tests (autoOkOnSuccess, sampler-aware trace flags for `parentbased_always_on/off`, `parentbased_traceidratio`, `always_on`, `always_off`, `traceidratio`)
- [x] `session-context.test.ts`: 7 tests (getCurrentSessionId)
- [x] `log-to-span-processor.test.ts`: 32 tests (session fallback with `getCurrentSessionId`)
- [x] `coreToolScheduler.test.ts`: 112 tests (cancellation status, success path resilience when `safeSetStatus` throws)
- [x] `loggingContentGenerator.test.ts`: 30 tests
- [x] `sdk.test.ts`: 27 tests (setSessionContext two-arg signature)
- [x] `debugLogger.test.ts`: 22 tests
- [x] `tsc --noEmit` — no new type errors
- [x] ESLint 0 warnings on changed files

### Manual smoke test (requires OTel collector)

If a local OTel collector (e.g. Jaeger) is available:

| Scenario | Env var | Expected |
|---|---|---|
| Default (no env var) | — | All spans share session traceId, `TraceFlags.SAMPLED` |
| `parentbased_always_on` | `OTEL_TRACES_SAMPLER=parentbased_always_on` | 100% traces exported |
| `parentbased_always_off` | `OTEL_TRACES_SAMPLER=parentbased_always_off` | Zero traces exported |
| `parentbased_traceidratio` | `OTEL_TRACES_SAMPLER=parentbased_traceidratio` | 100% traces (synthetic root forces SAMPLED) |
| `always_off` | `OTEL_TRACES_SAMPLER=always_off` | Zero traces exported |
| `/clear` then new conversation | — | New traceId, logs still correlate |
| Tool cancellation | — | Span ends with no status (not OK, not ERROR) |
| Stream timeout (set `STREAM_IDLE_TIMEOUT_MS` to 5s) | — | Span has `stream.timed_out=true` + ERROR |

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)