### PR TITLE
fix(cli): handle MinTTY Ctrl+Backspace as delete-previous-word

### DIFF
--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -120,6 +120,14 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.DELETE_WORD_BACKWARD]: [
     { key: 'backspace', ctrl: true },
     { key: 'backspace', command: true },
+    // MinTTY (Git Bash on Windows) emits the byte \x1f (ASCII Unit
+    // Separator, rendered as "^_" by `cat -v`) for Ctrl+Backspace under
+    // its standard Ctrl-modifies-meta-keys convention. The same byte is
+    // the historical Ctrl-mapping of the Unit Separator on traditional
+    // ANSI/VT terminals (Ctrl+_ and Ctrl+/ also emit it), but qwen-code
+    // doesn't bind those keystrokes elsewhere so this entry is additive
+    // and non-conflicting on every platform.
+    { sequence: '\x1f' },
   ],
 
   // Screen control

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -31,7 +31,8 @@ describe('keyMatchers', () => {
     [Command.KILL_LINE_LEFT]: (key: Key) => key.ctrl && key.name === 'u',
     [Command.CLEAR_INPUT]: (key: Key) => key.ctrl && key.name === 'c',
     [Command.DELETE_WORD_BACKWARD]: (key: Key) =>
-      (key.ctrl || key.meta) && key.name === 'backspace',
+      ((key.ctrl || key.meta) && key.name === 'backspace') ||
+      key.sequence === '\x1f',
     [Command.CLEAR_SCREEN]: (key: Key) => key.ctrl && key.name === 'l',
     [Command.HISTORY_UP]: (key: Key) => key.ctrl && key.name === 'p',
     [Command.HISTORY_DOWN]: (key: Key) => key.ctrl && key.name === 'n',
@@ -130,6 +131,10 @@ describe('keyMatchers', () => {
       positive: [
         createKey('backspace', { ctrl: true }),
         createKey('backspace', { meta: true }),
+        // MinTTY (Git Bash on Windows) emits a bare \x1f byte for
+        // Ctrl+Backspace — see the matching comment in keyBindings.ts
+        // on the DELETE_WORD_BACKWARD default-binding array.
+        createKey('', { sequence: '\x1f' }),
       ],
       negative: [createKey('backspace'), createKey('delete', { ctrl: true })],
     },


### PR DESCRIPTION
## Summary

- Fixes `Ctrl+Backspace` on Windows Git Bash / MinTTY by mapping the `\x1f` byte sequence to `DELETE_WORD_BACKWARD`.
- Adds test coverage for the MinTTY sequence in the key matcher suite.

## Validation

- **Commands run:**
  ```bash
  cd packages/cli && npx vitest run src/ui/keyMatchers.test.ts
  ```
- **Expected result:**
  - `Ctrl+Backspace` on MinTTY deletes the previous word.
  - Existing `Ctrl+Backspace` / `Cmd+Backspace` bindings continue to match.
- **Observed result:**
  - 37/37 `keyMatchers` tests pass.

## Scope / Risk

- The fix is intentionally narrow: no keyboard text selection behavior is included in this PR.
- MinTTY reports `Ctrl+Backspace` as `\x1f`, which can also be produced by `Ctrl+_` / `Ctrl+/` on traditional terminals. qwen-code does not currently bind those keystrokes elsewhere, so the added binding is treated as an additive compatibility fix.

## Linked Issues / Bugs

Related to #3926
