### PR TITLE
fix(cli): preserve debug session across sandbox relaunch

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -853,6 +853,21 @@ describe('loadCliConfig', () => {
     expect(config.getIncludePartialMessages()).toBe(true);
   });
 
+  it('should use internal sandbox session ID without treating it as a new session', async () => {
+    const sessionId = '123e4567-e89b-12d3-a456-426614174000';
+    process.argv = ['node', 'script.js', '--sandbox-session-id', sessionId];
+    const sessionExistsSpy = vi.spyOn(
+      ServerConfig.SessionService.prototype,
+      'sessionExists',
+    );
+    const argv = await parseArguments();
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, argv);
+
+    expect(config.getSessionId()).toBe(sessionId);
+    expect(sessionExistsSpy).not.toHaveBeenCalled();
+  });
+
   it('should reset context filenames to defaults when context.fileName is not configured', async () => {
     process.argv = ['node', 'script.js'];
     const argv = await parseArguments();

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -158,6 +158,8 @@ export interface CliArgs {
   resume: string | undefined;
   /** Specify a session ID without session resumption */
   sessionId: string | undefined;
+  /** Internal: preserve the outer session ID when relaunching in a sandbox */
+  sandboxSessionId?: string | undefined;
   maxSessionTurns: number | undefined;
   coreTools: string[] | undefined;
   excludeTools: string[] | undefined;
@@ -802,6 +804,10 @@ export async function parseArguments(): Promise<CliArgs> {
           type: 'string',
           description: 'Specify a session ID for this run.',
         })
+        .option('sandbox-session-id', {
+          type: 'string',
+          hidden: true,
+        })
         .option('max-session-turns', {
           type: 'number',
           description: 'Maximum number of session turns',
@@ -903,10 +909,22 @@ export async function parseArguments(): Promise<CliArgs> {
             return 'Cannot use --session-id with --continue or --resume. Use --session-id to start a new session with a specific ID, or use --continue/--resume to resume an existing session.';
           }
           if (
+            argv['sandboxSessionId'] &&
+            (argv['sessionId'] || argv['continue'] || argv['resume'])
+          ) {
+            return 'Cannot use internal --sandbox-session-id with --session-id, --continue, or --resume.';
+          }
+          if (
             argv['sessionId'] &&
             !isValidSessionId(argv['sessionId'] as string)
           ) {
             return `Invalid --session-id: "${argv['sessionId']}". Must be a valid UUID (e.g., "123e4567-e89b-12d3-a456-426614174000").`;
+          }
+          if (
+            argv['sandboxSessionId'] &&
+            !isValidSessionId(argv['sandboxSessionId'] as string)
+          ) {
+            return `Invalid --sandbox-session-id: "${argv['sandboxSessionId']}". Must be a valid UUID (e.g., "123e4567-e89b-12d3-a456-426614174000").`;
           }
           // --resume accepts either a session UUID or a custom title
           if (argv['jsonFd'] != null && argv['jsonFile'] != null) {
@@ -1505,6 +1523,8 @@ export async function loadCliConfig(
         process.exit(1);
       }
     }
+  } else if (argv.sandboxSessionId) {
+    sessionId = argv.sandboxSessionId;
   } else if (argv['sessionId']) {
     // Use provided session ID without session resumption
     // Check if session ID is already in use

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -307,10 +307,12 @@ describe('gemini.tsx main function', () => {
     );
   });
 
-  it('passes the outer session ID into the sandbox child process', async () => {
+  const runSandboxRelaunch = async (
+    argv: string[],
+    sessionId = '123e4567-e89b-12d3-a456-426614174000',
+  ): Promise<string[]> => {
     const originalArgv = process.argv;
-    process.argv = ['node', 'script.js', '--debug', '-p', 'hello'];
-    const sessionId = '123e4567-e89b-12d3-a456-426614174000';
+    process.argv = argv;
     const processExitSpy = vi
       .spyOn(process, 'exit')
       .mockImplementation((code) => {
@@ -324,6 +326,7 @@ describe('gemini.tsx main function', () => {
     const { loadSandboxConfig } = await import('./config/sandboxConfig.js');
     const { start_sandbox } = await import('./utils/sandbox.js');
 
+    vi.mocked(start_sandbox).mockClear();
     vi.mocked(parseArguments).mockResolvedValue({
       debug: true,
       prompt: 'hello',
@@ -363,69 +366,72 @@ describe('gemini.tsx main function', () => {
     }
 
     expect(start_sandbox).toHaveBeenCalledOnce();
-    const sandboxArgs = vi.mocked(start_sandbox).mock.calls[0][3];
-    expect(sandboxArgs).toContain('--session-id');
-    expect(sandboxArgs).toContain(sessionId);
+    return vi.mocked(start_sandbox).mock.calls[0]![3]!;
+  };
+
+  it('passes the outer session ID into the sandbox child process', async () => {
+    const sessionId = '123e4567-e89b-12d3-a456-426614174000';
+    const sandboxArgs = await runSandboxRelaunch(
+      ['node', 'script.js', '--debug', '-p', 'hello'],
+      sessionId,
+    );
+
+    const idx = sandboxArgs.indexOf('--sandbox-session-id');
+    expect(idx).not.toBe(-1);
+    expect(sandboxArgs[idx + 1]).toBe(sessionId);
+    expect(sandboxArgs).not.toContain('--session-id');
   });
 
   it('does not pass an empty session ID into the sandbox child process', async () => {
-    const originalArgv = process.argv;
-    process.argv = ['node', 'script.js', '--debug', '-p', 'hello'];
-    const processExitSpy = vi
-      .spyOn(process, 'exit')
-      .mockImplementation((code) => {
-        throw new MockProcessExitError(code);
-      });
-
-    const { loadCliConfig, parseArguments } = await import(
-      './config/config.js'
+    const sandboxArgs = await runSandboxRelaunch(
+      ['node', 'script.js', '--debug', '-p', 'hello'],
+      '',
     );
-    const { loadSettings } = await import('./config/settings.js');
-    const { loadSandboxConfig } = await import('./config/sandboxConfig.js');
-    const { start_sandbox } = await import('./utils/sandbox.js');
 
-    vi.mocked(start_sandbox).mockClear();
-    vi.mocked(parseArguments).mockResolvedValue({
-      debug: true,
-      prompt: 'hello',
-      extensions: [],
-    } as unknown as CliArgs);
-    vi.mocked(loadSettings).mockReturnValue({
-      errors: [],
-      merged: {
-        advanced: {},
-        security: { auth: {} },
-        ui: {},
-      },
-      setValue: vi.fn(),
-      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
-      migrationWarnings: [],
-      getUserHooks: () => undefined,
-      getProjectHooks: () => undefined,
-    } as never);
-    vi.mocked(loadSandboxConfig).mockResolvedValue({
-      command: 'sandbox-exec',
-      image: '',
-    });
-    vi.mocked(loadCliConfig).mockResolvedValue({
-      getModelsConfig: () => ({ getCurrentAuthType: () => null }),
-      getSessionId: () => '',
-    } as unknown as Config);
-
-    try {
-      await main();
-    } catch (error) {
-      if (!(error instanceof MockProcessExitError)) {
-        throw error;
-      }
-    } finally {
-      process.argv = originalArgv;
-      processExitSpy.mockRestore();
-    }
-
-    expect(start_sandbox).toHaveBeenCalledOnce();
-    const sandboxArgs = vi.mocked(start_sandbox).mock.calls[0][3];
+    expect(sandboxArgs).not.toContain('--sandbox-session-id');
     expect(sandboxArgs).not.toContain('--session-id');
+  });
+
+  it.each([
+    ['--continue', ['node', 'script.js', '--debug', '--continue']],
+    ['-c', ['node', 'script.js', '--debug', '-c']],
+    ['--resume', ['node', 'script.js', '--debug', '--resume', 'session-id']],
+    ['-r', ['node', 'script.js', '--debug', '-r', 'session-id']],
+    [
+      '--session-id',
+      [
+        'node',
+        'script.js',
+        '--debug',
+        '--session-id',
+        '123e4567-e89b-12d3-a456-426614174999',
+      ],
+    ],
+  ])(
+    'does not inject sandbox session ID when argv contains %s',
+    async (_flag, argv) => {
+      const sandboxArgs = await runSandboxRelaunch(argv);
+
+      expect(sandboxArgs).not.toContain('--sandbox-session-id');
+    },
+  );
+
+  it('inserts the sandbox session ID before the argument separator', async () => {
+    const sessionId = '123e4567-e89b-12d3-a456-426614174000';
+    const sandboxArgs = await runSandboxRelaunch(
+      ['node', 'script.js', '--debug', '--', '--not-a-cli-flag'],
+      sessionId,
+    );
+
+    expect(sandboxArgs).toEqual([
+      'node',
+      'script.js',
+      '--debug',
+      '--sandbox-session-id',
+      sessionId,
+      '--',
+      '--not-a-cli-flag',
+    ]);
   });
 
   it('should log unhandled promise rejections and open debug console on first error', async () => {

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -368,6 +368,66 @@ describe('gemini.tsx main function', () => {
     expect(sandboxArgs).toContain(sessionId);
   });
 
+  it('does not pass an empty session ID into the sandbox child process', async () => {
+    const originalArgv = process.argv;
+    process.argv = ['node', 'script.js', '--debug', '-p', 'hello'];
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code) => {
+        throw new MockProcessExitError(code);
+      });
+
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const { loadSandboxConfig } = await import('./config/sandboxConfig.js');
+    const { start_sandbox } = await import('./utils/sandbox.js');
+
+    vi.mocked(start_sandbox).mockClear();
+    vi.mocked(parseArguments).mockResolvedValue({
+      debug: true,
+      prompt: 'hello',
+      extensions: [],
+    } as unknown as CliArgs);
+    vi.mocked(loadSettings).mockReturnValue({
+      errors: [],
+      merged: {
+        advanced: {},
+        security: { auth: {} },
+        ui: {},
+      },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      migrationWarnings: [],
+      getUserHooks: () => undefined,
+      getProjectHooks: () => undefined,
+    } as never);
+    vi.mocked(loadSandboxConfig).mockResolvedValue({
+      command: 'sandbox-exec',
+      image: '',
+    });
+    vi.mocked(loadCliConfig).mockResolvedValue({
+      getModelsConfig: () => ({ getCurrentAuthType: () => null }),
+      getSessionId: () => '',
+    } as unknown as Config);
+
+    try {
+      await main();
+    } catch (error) {
+      if (!(error instanceof MockProcessExitError)) {
+        throw error;
+      }
+    } finally {
+      process.argv = originalArgv;
+      processExitSpy.mockRestore();
+    }
+
+    expect(start_sandbox).toHaveBeenCalledOnce();
+    const sandboxArgs = vi.mocked(start_sandbox).mock.calls[0][3];
+    expect(sandboxArgs).not.toContain('--session-id');
+  });
+
   it('should log unhandled promise rejections and open debug console on first error', async () => {
     const processExitSpy = vi
       .spyOn(process, 'exit')

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -93,6 +93,7 @@ vi.mock('./utils/stdioHelpers.js', () => ({
 
 vi.mock('./utils/relaunch.js', () => ({
   relaunchAppInChildProcess: vi.fn(),
+  relaunchOnExitCode: vi.fn((fn: () => Promise<number>) => fn()),
 }));
 
 vi.mock('./config/sandboxConfig.js', () => ({
@@ -304,6 +305,67 @@ describe('gemini.tsx main function', () => {
         projectHooks: undefined,
       },
     );
+  });
+
+  it('passes the outer session ID into the sandbox child process', async () => {
+    const originalArgv = process.argv;
+    process.argv = ['node', 'script.js', '--debug', '-p', 'hello'];
+    const sessionId = '123e4567-e89b-12d3-a456-426614174000';
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code) => {
+        throw new MockProcessExitError(code);
+      });
+
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const { loadSandboxConfig } = await import('./config/sandboxConfig.js');
+    const { start_sandbox } = await import('./utils/sandbox.js');
+
+    vi.mocked(parseArguments).mockResolvedValue({
+      debug: true,
+      prompt: 'hello',
+      extensions: [],
+    } as unknown as CliArgs);
+    vi.mocked(loadSettings).mockReturnValue({
+      errors: [],
+      merged: {
+        advanced: {},
+        security: { auth: {} },
+        ui: {},
+      },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      migrationWarnings: [],
+      getUserHooks: () => undefined,
+      getProjectHooks: () => undefined,
+    } as never);
+    vi.mocked(loadSandboxConfig).mockResolvedValue({
+      command: 'sandbox-exec',
+      image: '',
+    });
+    vi.mocked(loadCliConfig).mockResolvedValue({
+      getModelsConfig: () => ({ getCurrentAuthType: () => null }),
+      getSessionId: () => sessionId,
+    } as unknown as Config);
+
+    try {
+      await main();
+    } catch (error) {
+      if (!(error instanceof MockProcessExitError)) {
+        throw error;
+      }
+    } finally {
+      process.argv = originalArgv;
+      processExitSpy.mockRestore();
+    }
+
+    expect(start_sandbox).toHaveBeenCalledOnce();
+    const sandboxArgs = vi.mocked(start_sandbox).mock.calls[0][3];
+    expect(sandboxArgs).toContain('--session-id');
+    expect(sandboxArgs).toContain(sessionId);
   });
 
   it('should log unhandled promise rejections and open debug console on first error', async () => {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -513,7 +513,41 @@ export async function main() {
         return finalArgs;
       };
 
-      const sandboxArgs = injectStdinIntoArgs(process.argv, stdinData);
+      const injectSessionIdIntoArgs = (
+        args: string[],
+        sessionId: string,
+      ): string[] => {
+        const separatorIndex = args.indexOf('--');
+        const cliArgs =
+          separatorIndex < 0 ? args : args.slice(0, separatorIndex);
+        const hasArg = (names: string[]) =>
+          cliArgs.some((arg) =>
+            names.some((name) => arg === name || arg.startsWith(`${name}=`)),
+          );
+        if (
+          hasArg(['--session-id']) ||
+          hasArg(['--continue', '-c']) ||
+          hasArg(['--resume', '-r'])
+        ) {
+          return args;
+        }
+
+        const sessionArgs = ['--session-id', sessionId];
+        if (separatorIndex < 0) {
+          return [...args, ...sessionArgs];
+        }
+
+        return [
+          ...args.slice(0, separatorIndex),
+          ...sessionArgs,
+          ...args.slice(separatorIndex),
+        ];
+      };
+
+      const sandboxArgs = injectSessionIdIntoArgs(
+        injectStdinIntoArgs(process.argv, stdinData),
+        partialConfig.getSessionId(),
+      );
 
       await relaunchOnExitCode(() =>
         start_sandbox(sandboxConfig, memoryArgs, partialConfig, sandboxArgs),

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -544,10 +544,13 @@ export async function main() {
         ];
       };
 
-      const sandboxArgs = injectSessionIdIntoArgs(
-        injectStdinIntoArgs(process.argv, stdinData),
-        partialConfig.getSessionId(),
-      );
+      const sessionId = partialConfig.getSessionId();
+      const sandboxArgs = sessionId
+        ? injectSessionIdIntoArgs(
+            injectStdinIntoArgs(process.argv, stdinData),
+            sessionId,
+          )
+        : injectStdinIntoArgs(process.argv, stdinData);
 
       await relaunchOnExitCode(() =>
         start_sandbox(sandboxConfig, memoryArgs, partialConfig, sandboxArgs),

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -513,7 +513,7 @@ export async function main() {
         return finalArgs;
       };
 
-      const injectSessionIdIntoArgs = (
+      const injectSandboxSessionIdIntoArgs = (
         args: string[],
         sessionId: string,
       ): string[] => {
@@ -525,28 +525,24 @@ export async function main() {
             names.some((name) => arg === name || arg.startsWith(`${name}=`)),
           );
         if (
-          hasArg(['--session-id']) ||
+          hasArg(['--session-id', '--sandbox-session-id']) ||
           hasArg(['--continue', '-c']) ||
           hasArg(['--resume', '-r'])
         ) {
           return args;
         }
 
-        const sessionArgs = ['--session-id', sessionId];
+        const sessionArgs = ['--sandbox-session-id', sessionId];
         if (separatorIndex < 0) {
           return [...args, ...sessionArgs];
         }
 
-        return [
-          ...args.slice(0, separatorIndex),
-          ...sessionArgs,
-          ...args.slice(separatorIndex),
-        ];
+        return [...cliArgs, ...sessionArgs, ...args.slice(separatorIndex)];
       };
 
       const sessionId = partialConfig.getSessionId();
       const sandboxArgs = sessionId
-        ? injectSessionIdIntoArgs(
+        ? injectSandboxSessionIdIntoArgs(
             injectStdinIntoArgs(process.argv, stdinData),
             sessionId,
           )


### PR DESCRIPTION
## Summary

Preserve the outer CLI session ID when relaunching into the sandbox so debug logs created before and after the sandbox hop are written to the same session log.

When sandboxing is enabled, the CLI builds a partial config before relaunching in order to validate auth and prepare sandbox execution. Constructing that partial config also establishes the debug log session. The sandboxed child process then used to create a fresh session unless the user explicitly provided one, so early sandbox/relaunch diagnostics could land in a different debug log from the one shown by the final UI.

This change injects the outer session ID into the sandbox child argv for new sessions, while preserving explicit --session-id, --continue, and --resume flows.

## Verification

- npm run typecheck --workspace=packages/cli
- cd packages/cli && npx vitest run src/gemini.test.tsx
- npm run build --workspace=packages/cli