### PR TITLE
feat(cli): add tools.toolSearch.enabled setting for prefix-caching models

### DIFF
--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -1310,6 +1310,63 @@ describe('mergeExcludeTools', () => {
     );
     expect(config.getPermissionsDeny()).toHaveLength(2);
   });
+
+  it('should add tool_search to deny list when tools.toolSearch.enabled is false', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      tools: { toolSearch: { enabled: false } },
+    };
+    const config = await loadCliConfig(settings, argv, undefined, []);
+    expect(config.getPermissionsDeny()).toContain('tool_search');
+  });
+
+  it('should auto-disable tool_search for deepseek-v4 models', async () => {
+    process.argv = ['node', 'script.js', '--model', 'deepseek-v4-flash'];
+    const argv = await parseArguments();
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, argv, undefined, []);
+    expect(config.getPermissionsDeny()).toContain('tool_search');
+  });
+
+  it('should auto-disable tool_search for deepseek-v3 models', async () => {
+    process.argv = ['node', 'script.js', '--model', 'deepseek-v3'];
+    const argv = await parseArguments();
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, argv, undefined, []);
+    expect(config.getPermissionsDeny()).toContain('tool_search');
+  });
+
+  it('should auto-disable tool_search for deepseek-chat models with provider prefix', async () => {
+    process.argv = [
+      'node',
+      'script.js',
+      '--model',
+      'openrouter/deepseek/deepseek-chat',
+    ];
+    const argv = await parseArguments();
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, argv, undefined, []);
+    expect(config.getPermissionsDeny()).toContain('tool_search');
+  });
+
+  it('should not auto-disable tool_search for non-deepseek models', async () => {
+    process.argv = ['node', 'script.js', '--model', 'qwen-max'];
+    const argv = await parseArguments();
+    const settings: Settings = {};
+    const config = await loadCliConfig(settings, argv, undefined, []);
+    expect(config.getPermissionsDeny()).not.toContain('tool_search');
+  });
+
+  it('should respect explicit enabled:true override for deepseek models', async () => {
+    process.argv = ['node', 'script.js', '--model', 'deepseek-v4-flash'];
+    const argv = await parseArguments();
+    const settings: Settings = {
+      tools: { toolSearch: { enabled: true } },
+    };
+    const config = await loadCliConfig(settings, argv, undefined, []);
+    expect(config.getPermissionsDeny()).not.toContain('tool_search');
+  });
 });
 
 describe('Approval mode tool exclusion logic', () => {

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1473,16 +1473,20 @@ export async function loadCliConfig(
   const { model: resolvedModel } = resolvedCliConfig;
 
   // Disable ToolSearch when explicitly configured or for models that benefit
-  // from prefix-based KV caching (e.g. DeepSeek V4). When tool_search is in
-  // the deny list, client.ts eagerly reveals all deferred tools so every MCP
-  // tool schema is in the initial declaration list, keeping the prompt prefix
+  // from prefix-based KV caching. DeepSeek models (v3, v4, deepseek-chat)
+  // all use prefix-based disk KV caching with heavily discounted cached
+  // token pricing (up to 1/120 for v4). When tool_search is in the deny
+  // list, client.ts eagerly reveals all deferred tools so every MCP tool
+  // schema is in the initial declaration list, keeping the prompt prefix
   // stable and maximizing cache hit rates.
+  // Note: no `^` anchor — model names may include a provider prefix
+  // (e.g. "openrouter/deepseek/deepseek-v4-flash").
   const toolSearchExplicitlyEnabled = settings.tools?.toolSearch?.enabled;
   const shouldDisableToolSearch =
     toolSearchExplicitlyEnabled === false ||
     (toolSearchExplicitlyEnabled === undefined &&
       resolvedModel !== undefined &&
-      /^deepseek-v4/i.test(resolvedModel));
+      /deepseek-(v3|v4|chat)/i.test(resolvedModel));
   if (shouldDisableToolSearch) {
     if (!mergedDeny.includes('tool_search')) {
       mergedDeny.push('tool_search');

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1472,6 +1472,23 @@ export async function loadCliConfig(
 
   const { model: resolvedModel } = resolvedCliConfig;
 
+  // Disable ToolSearch when explicitly configured or for models that benefit
+  // from prefix-based KV caching (e.g. DeepSeek V4). When tool_search is in
+  // the deny list, client.ts eagerly reveals all deferred tools so every MCP
+  // tool schema is in the initial declaration list, keeping the prompt prefix
+  // stable and maximizing cache hit rates.
+  const toolSearchExplicitlyEnabled = settings.tools?.toolSearch?.enabled;
+  const shouldDisableToolSearch =
+    toolSearchExplicitlyEnabled === false ||
+    (toolSearchExplicitlyEnabled === undefined &&
+      resolvedModel !== undefined &&
+      /^deepseek-v4/i.test(resolvedModel));
+  if (shouldDisableToolSearch) {
+    if (!mergedDeny.includes('tool_search')) {
+      mergedDeny.push('tool_search');
+    }
+  }
+
   const sandboxConfig = await loadSandboxConfig(
     bareMode ? ({} as Settings) : settings,
     argv,

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1461,6 +1461,27 @@ const SETTINGS_SCHEMA = {
           'Sandbox image URI used by Docker/Podman when --sandbox-image and QWEN_SANDBOX_IMAGE are not set.',
         showInDialog: false,
       },
+      toolSearch: {
+        type: 'object',
+        label: 'Tool Search',
+        category: 'Tools',
+        requiresRestart: true,
+        default: {},
+        description: 'Settings for the ToolSearch discovery mechanism.',
+        showInDialog: false,
+        properties: {
+          enabled: {
+            type: 'boolean',
+            label: 'Enable ToolSearch',
+            category: 'Tools',
+            requiresRestart: true,
+            default: true,
+            description:
+              'When enabled, MCP tools are loaded on-demand via ToolSearch to reduce prompt size. Disable this for models that rely on prefix-based KV caching (e.g. DeepSeek) to keep the prompt prefix stable and maximize cache hit rates.',
+            showInDialog: true,
+          },
+        },
+      },
       shell: {
         type: 'object',
         label: 'Shell',

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -643,6 +643,17 @@
           "description": "Sandbox image URI used by Docker/Podman when --sandbox-image and QWEN_SANDBOX_IMAGE are not set.",
           "type": "string"
         },
+        "toolSearch": {
+          "description": "Settings for the ToolSearch discovery mechanism.",
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "description": "When enabled, MCP tools are loaded on-demand via ToolSearch to reduce prompt size. Disable this for models that rely on prefix-based KV caching (e.g. DeepSeek) to keep the prompt prefix stable and maximize cache hit rates.",
+              "type": "boolean",
+              "default": true
+            }
+          }
+        },
         "shell": {
           "description": "Settings for shell execution.",
           "type": "object",


### PR DESCRIPTION
## Summary

- Add `tools.toolSearch.enabled` setting to allow disabling ToolSearch, which restores prompt prefix stability for models with prefix-based KV caching
- Auto-disable ToolSearch for all DeepSeek models with prefix caching (`deepseek-v3`, `deepseek-v4-*`, `deepseek-chat`), unless explicitly overridden
- Supports provider-prefixed model names (e.g. `openrouter/deepseek/deepseek-chat`)
- Reuses existing eager-reveal fallback in `client.ts` — no changes needed to core logic

Closes https://github.com/QwenLM/qwen-code/discussions/4065

## Context

ToolSearch (PR #3589) defers MCP tool loading to reduce prompt size (~15K tokens saved), but breaks prefix-based KV caching for providers like DeepSeek. Users reported:
- Cache hit rate: **97.5% → 81.5%** (-16.4%)
- Daily cost: **$1.05 → $3.30** (+214%)
- Despite processing **46% fewer tokens**

## How it works

```
tools.toolSearch.enabled: false (or auto-detected deepseek-*)
  → tool_search added to deny list
    → PermissionManager.isToolEnabled() returns false
      → ToolSearch not registered in registry
        → client.ts detects getTool('tool_search') === undefined
          → eagerly reveals all deferred tools in initial declaration list
            → stable prompt prefix → cache hits restored
```

## Usage

```json
{
  "tools": {
    "toolSearch": {
      "enabled": false
    }
  }
}
```

For DeepSeek models, no configuration needed — auto-disabled by default. Override with `"enabled": true` if desired.

## Test plan

- [x] `vitest run src/config/settingsSchema.test.ts` — 17 passed
- [x] `vitest run src/config/config.test.ts` — 207 passed (6 new), 2 skipped
- [x] Settings schema regenerated (`settings.schema.json`)

### Manual verification — tool list

Tested with `DeepSeek/deepseek-v4-pro` configured in `~/.qwen/settings.json`:

| Scenario | Model | ToolSearch | Tool list | Expected |
|----------|-------|-----------|-----------|----------|
| Auto-detect | `DeepSeek/deepseek-v4-pro` (default) | Auto-disabled | All tools eagerly loaded (including `monitor`, `task_stop`, `send_message`, `exit_plan_mode`, etc.) | ✅ |
| Non-DeepSeek | `qwen3-coder-plus` (`--model`) | Enabled | Core tools only (deferred tools hidden behind ToolSearch) | ✅ |

### Cache hit rate verification

Real API calls to `DeepSeek/deepseek-v4-pro` via DeepSeek API, 3 independent single-turn sessions each:

**ToolSearch DISABLED (this PR, auto-detect):**
```
Turn 1: input=31673, cached=30976, cache_hit=97.8%
Turn 2: input=31673, cached=30976, cache_hit=97.8%
Turn 3: input=31673, cached=30976, cache_hit=97.8%
```

**ToolSearch ENABLED (override with `enabled: true`):**
```
Turn 1: input=35120, cached=15744, cache_hit=44.8%
Turn 2: input=25876, cached=18688, cache_hit=72.2%
Turn 3: input=35370, cached=34688, cache_hit=98.1%
```

| Metric | ToolSearch Disabled | ToolSearch Enabled | Impact |
|--------|:------------------:|:-----------------:|:------:|
| Avg cache hit | **97.8%** | **71.7%** | **+26.1%** cache hit |
| Cache stability | Consistent (97.8% every turn) | Volatile (44.8% → 98.1%) | Stable vs variable |
| Input tokens | ~31.7K | ~32.1K (avg) | Comparable |

With ToolSearch disabled, cache hit rate is **consistently ~98%** from the first request. With ToolSearch enabled, the first request only hits **44.8%** because the tool declarations vary, and it takes multiple requests for the cache to stabilize.

At DeepSeek V4's 1/120 cache pricing, the 26% cache hit improvement translates to significant cost savings for heavy users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)