### PR TITLE
feat(telemetry): add hierarchical session tracing spans

### DIFF
--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1243,10 +1243,9 @@ export class GeminiClient {
           }
           this.lastApiCompletionTimestamp = Date.now();
           if (isTopLevelInteraction) {
+            // Sanitize: do not pass raw API error messages to span status
             const errMsg =
-              event.value instanceof Error
-                ? event.value.message
-                : 'unknown error';
+              event.value instanceof Error ? '[API error]' : 'unknown error';
             endInteractionSpan('error', { errorMessage: errMsg });
           }
           return turn;
@@ -1420,7 +1419,7 @@ export class GeminiClient {
             nextRequest,
             signal,
             prompt_id,
-            options,
+            { ...options, type: SendMessageType.Hook },
             boundedTurns - 1,
           );
           if (isTopLevelInteraction)

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -934,508 +934,524 @@ export class GeminiClient {
       });
     }
 
-    if (
-      messageType === SendMessageType.UserQuery ||
-      messageType === SendMessageType.Cron
-    ) {
-      if (this.config.getManagedAutoMemoryEnabled()) {
-        const recallAbortController = new AbortController();
-        const rawRecallPromise = this.config
-          .getMemoryManager()
-          .recall(this.config.getProjectRoot(), partToString(request), {
-            config: this.config,
-            excludedFilePaths: this.surfacedRelevantAutoMemoryPaths,
-            abortSignal: recallAbortController.signal,
-          })
-          .catch((error: unknown) => {
-            if (error instanceof DOMException && error.name === 'AbortError') {
-              debugLogger.debug(
-                'Auto-memory recall aborted by deadline.',
-                error,
-              );
-            } else {
-              debugLogger.warn(
-                'Managed auto-memory recall prefetch failed.',
-                error,
-              );
-            }
-            return EMPTY_RELEVANT_AUTO_MEMORY_RESULT;
-          });
-        this.pendingRecallAbortController = recallAbortController;
-        // Race the recall against the deadline at initiation time so the 2.5s
-        // budget is not consumed by intermediate work (microcompact, compression,
-        // token checks, IDE context) between initiation and consumption.
-        relevantAutoMemoryPromise = resolveAutoMemoryWithDeadline(
-          rawRecallPromise,
-          () => recallAbortController.abort(),
+    try {
+      if (
+        messageType === SendMessageType.UserQuery ||
+        messageType === SendMessageType.Cron
+      ) {
+        if (this.config.getManagedAutoMemoryEnabled()) {
+          const recallAbortController = new AbortController();
+          const rawRecallPromise = this.config
+            .getMemoryManager()
+            .recall(this.config.getProjectRoot(), partToString(request), {
+              config: this.config,
+              excludedFilePaths: this.surfacedRelevantAutoMemoryPaths,
+              abortSignal: recallAbortController.signal,
+            })
+            .catch((error: unknown) => {
+              if (
+                error instanceof DOMException &&
+                error.name === 'AbortError'
+              ) {
+                debugLogger.debug(
+                  'Auto-memory recall aborted by deadline.',
+                  error,
+                );
+              } else {
+                debugLogger.warn(
+                  'Managed auto-memory recall prefetch failed.',
+                  error,
+                );
+              }
+              return EMPTY_RELEVANT_AUTO_MEMORY_RESULT;
+            });
+          this.pendingRecallAbortController = recallAbortController;
+          // Race the recall against the deadline at initiation time so the 2.5s
+          // budget is not consumed by intermediate work (microcompact, compression,
+          // token checks, IDE context) between initiation and consumption.
+          relevantAutoMemoryPromise = resolveAutoMemoryWithDeadline(
+            rawRecallPromise,
+            () => recallAbortController.abort(),
+          );
+        }
+
+        // Track prompt count for commit attribution. Only the user typing a
+        // fresh prompt should bump the counter — `ToolResult` (tool-call
+        // continuation), `Retry`, `Hook`, `Cron`, and `Notification` are all
+        // model-driven or background-driven re-entries of the same logical
+        // turn. Counting them inflates the "N-shotted" label in the PR
+        // attribution trailer (one user message becomes "10-shotted" when it
+        // triggered ten tool calls).
+        const attributionService = CommitAttributionService.getInstance();
+        if (messageType === SendMessageType.UserQuery) {
+          attributionService.incrementPromptCount();
+        }
+
+        // record user/cron message for session management
+        if (messageType === SendMessageType.Cron) {
+          this.config
+            .getChatRecordingService()
+            ?.recordCronPrompt(request, options?.notificationDisplayText);
+        } else {
+          this.config.getChatRecordingService()?.recordUserMessage(request);
+        }
+
+        // Idle cleanup: clear old tool results when idle > threshold.
+        // Runs on user and cron messages (not tool result submissions or
+        // retries/hooks) so that model latency during a tool-call loop
+        // doesn't count as user idle time.
+        const mcResult = microcompactHistory(
+          this.getChat().getHistory(),
+          this.lastApiCompletionTimestamp,
+          this.config.getClearContextOnIdle(),
         );
+        if (mcResult.meta) {
+          this.getChat().setHistory(mcResult.history);
+          // Microcompaction replaces old compactable tool outputs
+          // (including read_file) with a placeholder, but the
+          // FileReadCache still records the prior full Reads as "seen in
+          // this conversation". A follow-up Read of an unchanged file
+          // would then return the file_unchanged placeholder pointing at
+          // bytes the model can no longer retrieve from history. Drop the
+          // cache so post-microcompaction Reads re-emit the bytes,
+          // mirroring the post-compaction clear in tryCompressChat.
+          debugLogger.debug('[FILE_READ_CACHE] clear after microcompaction');
+          this.config.getFileReadCache().clear();
+          const m = mcResult.meta;
+          debugLogger.debug(
+            `[TIME-BASED MC] gap ${m.gapMinutes}min > ${m.thresholdMinutes}min, ` +
+              `cleared ${m.toolsCleared} tool results (~${m.tokensSaved} tokens), ` +
+              `kept last ${m.toolsKept}`,
+          );
+        }
       }
 
-      // Track prompt count for commit attribution. Only the user typing a
-      // fresh prompt should bump the counter — `ToolResult` (tool-call
-      // continuation), `Retry`, `Hook`, `Cron`, and `Notification` are all
-      // model-driven or background-driven re-entries of the same logical
-      // turn. Counting them inflates the "N-shotted" label in the PR
-      // attribution trailer (one user message becomes "10-shotted" when it
-      // triggered ten tool calls).
-      const attributionService = CommitAttributionService.getInstance();
-      if (messageType === SendMessageType.UserQuery) {
-        attributionService.incrementPromptCount();
-      }
-
-      // record user/cron message for session management
-      if (messageType === SendMessageType.Cron) {
+      if (messageType !== SendMessageType.Retry) {
+        // Snapshot on every non-retry turn. ToolResult turns run right after
+        // tool execution, so their snapshot captures edits that a prior
+        // UserQuery turn scheduled. Without this, a resumed session only sees
+        // the UserQuery-time snapshot (empty) and loses tool-driven edits.
         this.config
           .getChatRecordingService()
-          ?.recordCronPrompt(request, options?.notificationDisplayText);
-      } else {
-        this.config.getChatRecordingService()?.recordUserMessage(request);
-      }
+          ?.recordAttributionSnapshot(
+            CommitAttributionService.getInstance().toSnapshot(),
+          );
 
-      // Idle cleanup: clear old tool results when idle > threshold.
-      // Runs on user and cron messages (not tool result submissions or
-      // retries/hooks) so that model latency during a tool-call loop
-      // doesn't count as user idle time.
-      const mcResult = microcompactHistory(
-        this.getChat().getHistory(),
-        this.lastApiCompletionTimestamp,
-        this.config.getClearContextOnIdle(),
-      );
-      if (mcResult.meta) {
-        this.getChat().setHistory(mcResult.history);
-        // Microcompaction replaces old compactable tool outputs
-        // (including read_file) with a placeholder, but the
-        // FileReadCache still records the prior full Reads as "seen in
-        // this conversation". A follow-up Read of an unchanged file
-        // would then return the file_unchanged placeholder pointing at
-        // bytes the model can no longer retrieve from history. Drop the
-        // cache so post-microcompaction Reads re-emit the bytes,
-        // mirroring the post-compaction clear in tryCompressChat.
-        debugLogger.debug('[FILE_READ_CACHE] clear after microcompaction');
-        this.config.getFileReadCache().clear();
-        const m = mcResult.meta;
-        debugLogger.debug(
-          `[TIME-BASED MC] gap ${m.gapMinutes}min > ${m.thresholdMinutes}min, ` +
-            `cleared ${m.toolsCleared} tool results (~${m.tokensSaved} tokens), ` +
-            `kept last ${m.toolsKept}`,
-        );
-      }
-    }
+        this.sessionTurnCount++;
 
-    if (messageType !== SendMessageType.Retry) {
-      // Snapshot on every non-retry turn. ToolResult turns run right after
-      // tool execution, so their snapshot captures edits that a prior
-      // UserQuery turn scheduled. Without this, a resumed session only sees
-      // the UserQuery-time snapshot (empty) and loses tool-driven edits.
-      this.config
-        .getChatRecordingService()
-        ?.recordAttributionSnapshot(
-          CommitAttributionService.getInstance().toSnapshot(),
-        );
-
-      this.sessionTurnCount++;
-
-      if (
-        this.config.getMaxSessionTurns() > 0 &&
-        this.sessionTurnCount > this.config.getMaxSessionTurns()
-      ) {
-        this.pendingRecallAbortController?.abort();
-        this.pendingRecallAbortController = undefined;
-        yield { type: GeminiEventType.MaxSessionTurns };
-        if (isTopLevelInteraction)
-          endInteractionSpan('error', {
-            errorMessage: 'max session turns exceeded',
-          });
-        return new Turn(this.getChat(), prompt_id);
-      }
-    }
-
-    // Ensure turns never exceeds MAX_TURNS to prevent infinite loops
-    const boundedTurns = Math.min(turns, MAX_TURNS);
-    if (!boundedTurns) {
-      this.pendingRecallAbortController?.abort();
-      this.pendingRecallAbortController = undefined;
-      if (isTopLevelInteraction)
-        endInteractionSpan('error', { errorMessage: 'max turns exhausted' });
-      return new Turn(this.getChat(), prompt_id);
-    }
-
-    // Auto-compaction happens inside GeminiChat.sendMessageStream and surfaces
-    // via the `compressed → ChatCompressed` bridge in turn.ts. Manual /compress
-    // still calls tryCompressChat directly for the full reset (env refresh +
-    // forceFullIdeContext flip).
-    const sessionTokenLimit = this.config.getSessionTokenLimit();
-    if (sessionTokenLimit > 0) {
-      const lastPromptTokenCount = uiTelemetryService.getLastPromptTokenCount();
-      if (lastPromptTokenCount > sessionTokenLimit) {
-        this.pendingRecallAbortController?.abort();
-        this.pendingRecallAbortController = undefined;
-        yield {
-          type: GeminiEventType.SessionTokenLimitExceeded,
-          value: {
-            currentTokens: lastPromptTokenCount,
-            limit: sessionTokenLimit,
-            message:
-              `Session token limit exceeded: ${lastPromptTokenCount} tokens > ${sessionTokenLimit} limit. ` +
-              'Please start a new session or increase the sessionTokenLimit in your settings.json.',
-          },
-        };
-        if (isTopLevelInteraction)
-          endInteractionSpan('error', {
-            errorMessage: 'session token limit exceeded',
-          });
-        return new Turn(this.getChat(), prompt_id);
-      }
-    }
-
-    // Prevent context updates from being sent while a tool call is
-    // waiting for a response. The Qwen API requires that a functionResponse
-    // part from the user immediately follows a functionCall part from the model
-    // in the conversation history . The IDE context is not discarded; it will
-    // be included in the next regular message sent to the model.
-    const history = this.getHistory();
-    const lastMessage =
-      history.length > 0 ? history[history.length - 1] : undefined;
-    const hasPendingToolCall =
-      !!lastMessage &&
-      lastMessage.role === 'model' &&
-      (lastMessage.parts?.some((p) => 'functionCall' in p) || false);
-
-    if (this.config.getIdeMode() && !hasPendingToolCall) {
-      const { contextParts, newIdeContext } = this.getIdeContextParts(
-        this.forceFullIdeContext || history.length === 0,
-      );
-      if (contextParts.length > 0) {
-        this.getChat().addHistory({
-          role: 'user',
-          parts: [{ text: contextParts.join('\n') }],
-        });
-      }
-      this.lastSentIdeContext = newIdeContext;
-      this.forceFullIdeContext = false;
-    }
-
-    // Check for arena control signal before starting a new turn
-    const arenaAgentClient = this.config.getArenaAgentClient();
-    if (arenaAgentClient) {
-      const controlSignal = await arenaAgentClient.checkControlSignal();
-      if (controlSignal) {
-        debugLogger.info(
-          `Arena control signal received: ${controlSignal.type} - ${controlSignal.reason}`,
-        );
-        await arenaAgentClient.reportCancelled();
-        this.pendingRecallAbortController?.abort();
-        this.pendingRecallAbortController = undefined;
-        if (isTopLevelInteraction) endInteractionSpan('cancelled');
-        return new Turn(this.getChat(), prompt_id);
-      }
-    }
-
-    const turn = new Turn(this.getChat(), prompt_id);
-
-    // Determine the model to use for this turn
-    const model = options?.modelOverride ?? this.config.getModel();
-
-    // append system reminders to the request
-    let requestToSent = await flatMapTextParts(request, async (text) => [text]);
-    if (
-      messageType === SendMessageType.UserQuery ||
-      messageType === SendMessageType.Cron
-    ) {
-      const systemReminders = [];
-      // The recall promise was already raced against the 2.5s deadline at
-      // initiation time; this await just collects the result.
-      this.pendingRecallAbortController = undefined;
-      const relevantAutoMemory = relevantAutoMemoryPromise
-        ? await relevantAutoMemoryPromise
-        : EMPTY_RELEVANT_AUTO_MEMORY_RESULT;
-      const relevantAutoMemoryPrompt = relevantAutoMemory.prompt;
-
-      if (relevantAutoMemoryPrompt) {
-        systemReminders.push(relevantAutoMemoryPrompt);
-        for (const doc of relevantAutoMemory.selectedDocs) {
-          this.surfacedRelevantAutoMemoryPaths.add(doc.filePath);
+        if (
+          this.config.getMaxSessionTurns() > 0 &&
+          this.sessionTurnCount > this.config.getMaxSessionTurns()
+        ) {
+          this.pendingRecallAbortController?.abort();
+          this.pendingRecallAbortController = undefined;
+          yield { type: GeminiEventType.MaxSessionTurns };
+          if (isTopLevelInteraction)
+            endInteractionSpan('error', {
+              errorMessage: 'max session turns exceeded',
+            });
+          return new Turn(this.getChat(), prompt_id);
         }
       }
 
-      // add subagent system reminder if there are subagents
-      const hasAgentTool = await this.config
-        .getToolRegistry()
-        .ensureTool(ToolNames.AGENT);
-      const subagents = (await this.config.getSubagentManager().listSubagents())
-        .filter((subagent) => subagent.level !== 'builtin')
-        .map((subagent) => subagent.name);
-
-      if (hasAgentTool && subagents.length > 0) {
-        systemReminders.push(getSubagentSystemReminder(subagents));
+      // Ensure turns never exceeds MAX_TURNS to prevent infinite loops
+      const boundedTurns = Math.min(turns, MAX_TURNS);
+      if (!boundedTurns) {
+        this.pendingRecallAbortController?.abort();
+        this.pendingRecallAbortController = undefined;
+        if (isTopLevelInteraction)
+          endInteractionSpan('error', { errorMessage: 'max turns exhausted' });
+        return new Turn(this.getChat(), prompt_id);
       }
 
-      // add plan mode system reminder if approval mode is plan
-      if (this.config.getApprovalMode() === ApprovalMode.PLAN) {
-        systemReminders.push(
-          getPlanModeSystemReminder(this.config.getSdkMode()),
-        );
-      }
-
-      // add arena system reminder if an arena session is active
-      const arenaManager = this.config.getArenaManager();
-      if (arenaManager) {
-        try {
-          const sessionDir = arenaManager.getArenaSessionDir();
-          const configPath = `${sessionDir}/config.json`;
-          systemReminders.push(getArenaSystemReminder(configPath));
-        } catch {
-          // Arena config not yet initialized — skip
-        }
-      }
-
-      requestToSent = [...systemReminders, ...requestToSent];
-    }
-
-    const resultStream = turn.run(model, requestToSent, signal);
-    for await (const event of resultStream) {
-      if (!this.config.getSkipLoopDetection()) {
-        if (this.loopDetector.addAndCheck(event)) {
-          const loopType = this.loopDetector.getLastLoopType();
+      // Auto-compaction happens inside GeminiChat.sendMessageStream and surfaces
+      // via the `compressed → ChatCompressed` bridge in turn.ts. Manual /compress
+      // still calls tryCompressChat directly for the full reset (env refresh +
+      // forceFullIdeContext flip).
+      const sessionTokenLimit = this.config.getSessionTokenLimit();
+      if (sessionTokenLimit > 0) {
+        const lastPromptTokenCount =
+          uiTelemetryService.getLastPromptTokenCount();
+        if (lastPromptTokenCount > sessionTokenLimit) {
+          this.pendingRecallAbortController?.abort();
+          this.pendingRecallAbortController = undefined;
           yield {
-            type: GeminiEventType.LoopDetected,
-            ...(loopType && { value: { loopType } }),
+            type: GeminiEventType.SessionTokenLimitExceeded,
+            value: {
+              currentTokens: lastPromptTokenCount,
+              limit: sessionTokenLimit,
+              message:
+                `Session token limit exceeded: ${lastPromptTokenCount} tokens > ${sessionTokenLimit} limit. ` +
+                'Please start a new session or increase the sessionTokenLimit in your settings.json.',
+            },
           };
+          if (isTopLevelInteraction)
+            endInteractionSpan('error', {
+              errorMessage: 'session token limit exceeded',
+            });
+          return new Turn(this.getChat(), prompt_id);
+        }
+      }
+
+      // Prevent context updates from being sent while a tool call is
+      // waiting for a response. The Qwen API requires that a functionResponse
+      // part from the user immediately follows a functionCall part from the model
+      // in the conversation history . The IDE context is not discarded; it will
+      // be included in the next regular message sent to the model.
+      const history = this.getHistory();
+      const lastMessage =
+        history.length > 0 ? history[history.length - 1] : undefined;
+      const hasPendingToolCall =
+        !!lastMessage &&
+        lastMessage.role === 'model' &&
+        (lastMessage.parts?.some((p) => 'functionCall' in p) || false);
+
+      if (this.config.getIdeMode() && !hasPendingToolCall) {
+        const { contextParts, newIdeContext } = this.getIdeContextParts(
+          this.forceFullIdeContext || history.length === 0,
+        );
+        if (contextParts.length > 0) {
+          this.getChat().addHistory({
+            role: 'user',
+            parts: [{ text: contextParts.join('\n') }],
+          });
+        }
+        this.lastSentIdeContext = newIdeContext;
+        this.forceFullIdeContext = false;
+      }
+
+      // Check for arena control signal before starting a new turn
+      const arenaAgentClient = this.config.getArenaAgentClient();
+      if (arenaAgentClient) {
+        const controlSignal = await arenaAgentClient.checkControlSignal();
+        if (controlSignal) {
+          debugLogger.info(
+            `Arena control signal received: ${controlSignal.type} - ${controlSignal.reason}`,
+          );
+          await arenaAgentClient.reportCancelled();
+          this.pendingRecallAbortController?.abort();
+          this.pendingRecallAbortController = undefined;
+          if (isTopLevelInteraction) endInteractionSpan('cancelled');
+          return new Turn(this.getChat(), prompt_id);
+        }
+      }
+
+      const turn = new Turn(this.getChat(), prompt_id);
+
+      // Determine the model to use for this turn
+      const model = options?.modelOverride ?? this.config.getModel();
+
+      // append system reminders to the request
+      let requestToSent = await flatMapTextParts(request, async (text) => [
+        text,
+      ]);
+      if (
+        messageType === SendMessageType.UserQuery ||
+        messageType === SendMessageType.Cron
+      ) {
+        const systemReminders = [];
+        // The recall promise was already raced against the 2.5s deadline at
+        // initiation time; this await just collects the result.
+        this.pendingRecallAbortController = undefined;
+        const relevantAutoMemory = relevantAutoMemoryPromise
+          ? await relevantAutoMemoryPromise
+          : EMPTY_RELEVANT_AUTO_MEMORY_RESULT;
+        const relevantAutoMemoryPrompt = relevantAutoMemory.prompt;
+
+        if (relevantAutoMemoryPrompt) {
+          systemReminders.push(relevantAutoMemoryPrompt);
+          for (const doc of relevantAutoMemory.selectedDocs) {
+            this.surfacedRelevantAutoMemoryPaths.add(doc.filePath);
+          }
+        }
+
+        // add subagent system reminder if there are subagents
+        const hasAgentTool = await this.config
+          .getToolRegistry()
+          .ensureTool(ToolNames.AGENT);
+        const subagents = (
+          await this.config.getSubagentManager().listSubagents()
+        )
+          .filter((subagent) => subagent.level !== 'builtin')
+          .map((subagent) => subagent.name);
+
+        if (hasAgentTool && subagents.length > 0) {
+          systemReminders.push(getSubagentSystemReminder(subagents));
+        }
+
+        // add plan mode system reminder if approval mode is plan
+        if (this.config.getApprovalMode() === ApprovalMode.PLAN) {
+          systemReminders.push(
+            getPlanModeSystemReminder(this.config.getSdkMode()),
+          );
+        }
+
+        // add arena system reminder if an arena session is active
+        const arenaManager = this.config.getArenaManager();
+        if (arenaManager) {
+          try {
+            const sessionDir = arenaManager.getArenaSessionDir();
+            const configPath = `${sessionDir}/config.json`;
+            systemReminders.push(getArenaSystemReminder(configPath));
+          } catch {
+            // Arena config not yet initialized — skip
+          }
+        }
+
+        requestToSent = [...systemReminders, ...requestToSent];
+      }
+
+      const resultStream = turn.run(model, requestToSent, signal);
+      for await (const event of resultStream) {
+        if (!this.config.getSkipLoopDetection()) {
+          if (this.loopDetector.addAndCheck(event)) {
+            const loopType = this.loopDetector.getLastLoopType();
+            yield {
+              type: GeminiEventType.LoopDetected,
+              ...(loopType && { value: { loopType } }),
+            };
+            if (arenaAgentClient) {
+              await arenaAgentClient.reportError('Loop detected');
+            }
+            this.lastApiCompletionTimestamp = Date.now();
+            if (isTopLevelInteraction)
+              endInteractionSpan('error', { errorMessage: 'loop detected' });
+            return turn;
+          }
+        }
+        // Update arena status on Finished events — stats are derived
+        // automatically from uiTelemetryService by the reporter.
+        if (arenaAgentClient && event.type === GeminiEventType.Finished) {
+          await arenaAgentClient.updateStatus();
+        }
+
+        // Re-send a full IDE context blob on the next regular message — auto
+        // compaction inside chat.sendMessageStream may have summarized away
+        // the previous IDE-context turn.
+        if (event.type === GeminiEventType.ChatCompressed) {
+          this.forceFullIdeContext = true;
+        }
+
+        yield event;
+        if (event.type === GeminiEventType.Error) {
           if (arenaAgentClient) {
-            await arenaAgentClient.reportError('Loop detected');
+            const errorMsg =
+              event.value instanceof Error
+                ? event.value.message
+                : 'Unknown error';
+            await arenaAgentClient.reportError(errorMsg);
           }
           this.lastApiCompletionTimestamp = Date.now();
-          if (isTopLevelInteraction)
-            endInteractionSpan('error', { errorMessage: 'loop detected' });
+          if (isTopLevelInteraction) {
+            const errMsg =
+              event.value instanceof Error
+                ? event.value.message
+                : 'unknown error';
+            endInteractionSpan('error', { errorMessage: errMsg });
+          }
           return turn;
         }
       }
-      // Update arena status on Finished events — stats are derived
-      // automatically from uiTelemetryService by the reporter.
-      if (arenaAgentClient && event.type === GeminiEventType.Finished) {
-        await arenaAgentClient.updateStatus();
-      }
 
-      // Re-send a full IDE context blob on the next regular message — auto
-      // compaction inside chat.sendMessageStream may have summarized away
-      // the previous IDE-context turn.
-      if (event.type === GeminiEventType.ChatCompressed) {
-        this.forceFullIdeContext = true;
-      }
+      // Track API completion time for thinking block idle cleanup
+      this.lastApiCompletionTimestamp = Date.now();
 
-      yield event;
-      if (event.type === GeminiEventType.Error) {
-        if (arenaAgentClient) {
-          const errorMsg =
-            event.value instanceof Error
-              ? event.value.message
-              : 'Unknown error';
-          await arenaAgentClient.reportError(errorMsg);
-        }
-        this.lastApiCompletionTimestamp = Date.now();
-        if (isTopLevelInteraction) {
-          const errMsg =
-            event.value instanceof Error
-              ? event.value.message
-              : 'unknown error';
-          endInteractionSpan('error', { errorMessage: errMsg });
-        }
-        return turn;
-      }
-    }
-
-    // Track API completion time for thinking block idle cleanup
-    this.lastApiCompletionTimestamp = Date.now();
-
-    // Fire Stop hook through MessageBus (only if hooks are enabled and registered)
-    // This must be done before any early returns to ensure hooks are always triggered
-    if (
-      hooksEnabled &&
-      messageBus &&
-      !turn.pendingToolCalls.length &&
-      signal &&
-      !signal.aborted &&
-      this.config.hasHooksForEvent('Stop')
-    ) {
-      // Get response text from the chat history
-      const history = this.getHistory();
-      const lastModelMessage = history
-        .filter((msg) => msg.role === 'model')
-        .pop();
-      const responseText =
-        lastModelMessage?.parts
-          ?.filter((p): p is { text: string } => 'text' in p)
-          .map((p) => p.text)
-          .join('') || '[no response text]';
-
-      const response = await messageBus.request<
-        HookExecutionRequest,
-        HookExecutionResponse
-      >(
-        {
-          type: MessageBusType.HOOK_EXECUTION_REQUEST,
-          eventName: 'Stop',
-          input: {
-            stop_hook_active: true,
-            last_assistant_message: responseText,
-          },
-          signal,
-        },
-        MessageBusType.HOOK_EXECUTION_RESPONSE,
-      );
-
-      // Check if aborted after hook execution
-      if (signal.aborted) {
-        if (isTopLevelInteraction) endInteractionSpan('cancelled');
-        return turn;
-      }
-
-      const hookOutput = response.output
-        ? createHookOutput('Stop', response.output)
-        : undefined;
-
-      const stopOutput = hookOutput as StopHookOutput | undefined;
-
-      // This should happen regardless of the hook's decision
-      if (stopOutput?.systemMessage) {
-        yield {
-          type: GeminiEventType.HookSystemMessage,
-          value: stopOutput.systemMessage,
-        };
-      }
-
-      // For Stop hooks, blocking/stop execution should force continuation
+      // Fire Stop hook through MessageBus (only if hooks are enabled and registered)
+      // This must be done before any early returns to ensure hooks are always triggered
       if (
-        stopOutput?.isBlockingDecision() ||
-        stopOutput?.shouldStopExecution()
+        hooksEnabled &&
+        messageBus &&
+        !turn.pendingToolCalls.length &&
+        signal &&
+        !signal.aborted &&
+        this.config.hasHooksForEvent('Stop')
       ) {
-        // Check if aborted before continuing
+        // Get response text from the chat history
+        const history = this.getHistory();
+        const lastModelMessage = history
+          .filter((msg) => msg.role === 'model')
+          .pop();
+        const responseText =
+          lastModelMessage?.parts
+            ?.filter((p): p is { text: string } => 'text' in p)
+            .map((p) => p.text)
+            .join('') || '[no response text]';
+
+        const response = await messageBus.request<
+          HookExecutionRequest,
+          HookExecutionResponse
+        >(
+          {
+            type: MessageBusType.HOOK_EXECUTION_REQUEST,
+            eventName: 'Stop',
+            input: {
+              stop_hook_active: true,
+              last_assistant_message: responseText,
+            },
+            signal,
+          },
+          MessageBusType.HOOK_EXECUTION_RESPONSE,
+        );
+
+        // Check if aborted after hook execution
         if (signal.aborted) {
           if (isTopLevelInteraction) endInteractionSpan('cancelled');
           return turn;
         }
 
-        const continueReason = stopOutput.getEffectiveReason();
+        const hookOutput = response.output
+          ? createHookOutput('Stop', response.output)
+          : undefined;
 
-        // Track stop hook iterations
-        const currentIterationCount =
-          (options?.stopHookState?.iterationCount ?? 0) + 1;
-        const currentReasons = [
-          ...(options?.stopHookState?.reasons ?? []),
-          continueReason,
-        ];
+        const stopOutput = hookOutput as StopHookOutput | undefined;
 
-        // Emit StopHookLoop event for iterations after the first one.
-        // The first iteration (currentIterationCount === 1) is the initial request,
-        // so there's no prior stop hook execution to report. We only emit this event
-        // when stop hooks have been executed multiple times (loop detected).
-        if (currentIterationCount > 1) {
+        // This should happen regardless of the hook's decision
+        if (stopOutput?.systemMessage) {
           yield {
-            type: GeminiEventType.StopHookLoop,
-            value: {
-              iterationCount: currentIterationCount,
-              reasons: currentReasons,
-              stopHookCount: response.stopHookCount ?? 1,
-            },
+            type: GeminiEventType.HookSystemMessage,
+            value: stopOutput.systemMessage,
           };
         }
 
-        const continueRequest = [{ text: continueReason }];
-        const hookTurn = yield* this.sendMessageStream(
-          continueRequest,
+        // For Stop hooks, blocking/stop execution should force continuation
+        if (
+          stopOutput?.isBlockingDecision() ||
+          stopOutput?.shouldStopExecution()
+        ) {
+          // Check if aborted before continuing
+          if (signal.aborted) {
+            if (isTopLevelInteraction) endInteractionSpan('cancelled');
+            return turn;
+          }
+
+          const continueReason = stopOutput.getEffectiveReason();
+
+          // Track stop hook iterations
+          const currentIterationCount =
+            (options?.stopHookState?.iterationCount ?? 0) + 1;
+          const currentReasons = [
+            ...(options?.stopHookState?.reasons ?? []),
+            continueReason,
+          ];
+
+          // Emit StopHookLoop event for iterations after the first one.
+          // The first iteration (currentIterationCount === 1) is the initial request,
+          // so there's no prior stop hook execution to report. We only emit this event
+          // when stop hooks have been executed multiple times (loop detected).
+          if (currentIterationCount > 1) {
+            yield {
+              type: GeminiEventType.StopHookLoop,
+              value: {
+                iterationCount: currentIterationCount,
+                reasons: currentReasons,
+                stopHookCount: response.stopHookCount ?? 1,
+              },
+            };
+          }
+
+          const continueRequest = [{ text: continueReason }];
+          const hookTurn = yield* this.sendMessageStream(
+            continueRequest,
+            signal,
+            prompt_id,
+            {
+              type: SendMessageType.Hook,
+              modelOverride: options?.modelOverride,
+              stopHookState: {
+                iterationCount: currentIterationCount,
+                reasons: currentReasons,
+              },
+            },
+            boundedTurns - 1,
+          );
+          if (isTopLevelInteraction)
+            endInteractionSpan(signal.aborted ? 'cancelled' : 'ok');
+          return hookTurn;
+        }
+      }
+
+      if (!turn.pendingToolCalls.length && signal && !signal.aborted) {
+        // Save cache-safe params here — before any early return — so that
+        // background extract/dream agents calling getCacheSafeParams() always
+        // see the current turn's history regardless of which path exits below.
+        try {
+          const chat = this.getChat();
+          const fullHistory = chat.getHistory(true);
+          const maxHistoryForCache = 40;
+          const cachedHistory =
+            fullHistory.length > maxHistoryForCache
+              ? fullHistory.slice(-maxHistoryForCache)
+              : fullHistory;
+          saveCacheSafeParams(
+            chat.getGenerationConfig(),
+            cachedHistory,
+            this.config.getModel(),
+          );
+        } catch {
+          // Best-effort — don't block the main flow
+        }
+
+        if (this.config.getSkipNextSpeakerCheck()) {
+          this.runManagedAutoMemoryBackgroundTasks(messageType);
+          if (arenaAgentClient) {
+            await arenaAgentClient.reportCompleted();
+          }
+          if (isTopLevelInteraction) endInteractionSpan('ok');
+          return turn;
+        }
+
+        const nextSpeakerCheck = await checkNextSpeaker(
+          this.getChat(),
+          this.config,
           signal,
           prompt_id,
-          {
-            type: SendMessageType.Hook,
-            modelOverride: options?.modelOverride,
-            stopHookState: {
-              iterationCount: currentIterationCount,
-              reasons: currentReasons,
-            },
-          },
-          boundedTurns - 1,
         );
-        if (isTopLevelInteraction)
-          endInteractionSpan(signal.aborted ? 'cancelled' : 'ok');
-        return hookTurn;
-      }
-    }
-
-    if (!turn.pendingToolCalls.length && signal && !signal.aborted) {
-      // Save cache-safe params here — before any early return — so that
-      // background extract/dream agents calling getCacheSafeParams() always
-      // see the current turn's history regardless of which path exits below.
-      try {
-        const chat = this.getChat();
-        const fullHistory = chat.getHistory(true);
-        const maxHistoryForCache = 40;
-        const cachedHistory =
-          fullHistory.length > maxHistoryForCache
-            ? fullHistory.slice(-maxHistoryForCache)
-            : fullHistory;
-        saveCacheSafeParams(
-          chat.getGenerationConfig(),
-          cachedHistory,
-          this.config.getModel(),
+        logNextSpeakerCheck(
+          this.config,
+          new NextSpeakerCheckEvent(
+            prompt_id,
+            turn.finishReason?.toString() || '',
+            nextSpeakerCheck?.next_speaker || '',
+          ),
         );
-      } catch {
-        // Best-effort — don't block the main flow
-      }
+        if (nextSpeakerCheck?.next_speaker === 'model') {
+          const nextRequest = [{ text: 'Please continue.' }];
+          const continueTurn = yield* this.sendMessageStream(
+            nextRequest,
+            signal,
+            prompt_id,
+            options,
+            boundedTurns - 1,
+          );
+          if (isTopLevelInteraction)
+            endInteractionSpan(signal.aborted ? 'cancelled' : 'ok');
+          return continueTurn;
+        }
 
-      if (this.config.getSkipNextSpeakerCheck()) {
         this.runManagedAutoMemoryBackgroundTasks(messageType);
+
         if (arenaAgentClient) {
+          // No continuation needed — agent completed its task
           await arenaAgentClient.reportCompleted();
         }
-        if (isTopLevelInteraction) endInteractionSpan('ok');
-        return turn;
       }
 
-      const nextSpeakerCheck = await checkNextSpeaker(
-        this.getChat(),
-        this.config,
-        signal,
-        prompt_id,
-      );
-      logNextSpeakerCheck(
-        this.config,
-        new NextSpeakerCheckEvent(
-          prompt_id,
-          turn.finishReason?.toString() || '',
-          nextSpeakerCheck?.next_speaker || '',
-        ),
-      );
-      if (nextSpeakerCheck?.next_speaker === 'model') {
-        const nextRequest = [{ text: 'Please continue.' }];
-        const continueTurn = yield* this.sendMessageStream(
-          nextRequest,
-          signal,
-          prompt_id,
-          options,
-          boundedTurns - 1,
-        );
-        if (isTopLevelInteraction)
-          endInteractionSpan(signal.aborted ? 'cancelled' : 'ok');
-        return continueTurn;
+      // Report cancelled to arena when user cancelled mid-stream
+      if (signal?.aborted && arenaAgentClient) {
+        await arenaAgentClient.reportCancelled();
       }
 
-      this.runManagedAutoMemoryBackgroundTasks(messageType);
-
-      if (arenaAgentClient) {
-        // No continuation needed — agent completed its task
-        await arenaAgentClient.reportCompleted();
+      if (isTopLevelInteraction) {
+        endInteractionSpan(signal?.aborted ? 'cancelled' : 'ok');
+      }
+      return turn;
+    } finally {
+      if (isTopLevelInteraction) {
+        endInteractionSpan(signal?.aborted ? 'cancelled' : 'error', {
+          errorMessage: 'unexpected exit',
+        });
       }
     }
-
-    // Report cancelled to arena when user cancelled mid-stream
-    if (signal?.aborted && arenaAgentClient) {
-      await arenaAgentClient.reportCancelled();
-    }
-
-    if (isTopLevelInteraction) {
-      endInteractionSpan(signal?.aborted ? 'cancelled' : 'ok');
-    }
-    return turn;
   }
 
   async generateContent(

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -60,6 +60,8 @@ import { ToolNames } from '../tools/tool-names.js';
 import {
   NextSpeakerCheckEvent,
   logNextSpeakerCheck,
+  startInteractionSpan,
+  endInteractionSpan,
 } from '../telemetry/index.js';
 import { uiTelemetryService } from '../telemetry/uiTelemetry.js';
 
@@ -918,13 +920,18 @@ export class GeminiClient {
     // Notifications start a fresh Turn with a new prompt_id, so the loop
     // detector must reset — otherwise a prior turn's count can trip
     // LoopDetected early on the notification turn.
-    if (
+    const isTopLevelInteraction =
       messageType === SendMessageType.UserQuery ||
       messageType === SendMessageType.Cron ||
-      messageType === SendMessageType.Notification
-    ) {
+      messageType === SendMessageType.Notification;
+    if (isTopLevelInteraction) {
       this.loopDetector.reset(prompt_id);
       this.lastPromptId = prompt_id;
+      startInteractionSpan(this.config, {
+        promptId: prompt_id,
+        model: options?.modelOverride ?? this.config.getModel(),
+        messageType,
+      });
     }
 
     if (
@@ -1035,6 +1042,10 @@ export class GeminiClient {
         this.pendingRecallAbortController?.abort();
         this.pendingRecallAbortController = undefined;
         yield { type: GeminiEventType.MaxSessionTurns };
+        if (isTopLevelInteraction)
+          endInteractionSpan('error', {
+            errorMessage: 'max session turns exceeded',
+          });
         return new Turn(this.getChat(), prompt_id);
       }
     }
@@ -1044,6 +1055,8 @@ export class GeminiClient {
     if (!boundedTurns) {
       this.pendingRecallAbortController?.abort();
       this.pendingRecallAbortController = undefined;
+      if (isTopLevelInteraction)
+        endInteractionSpan('error', { errorMessage: 'max turns exhausted' });
       return new Turn(this.getChat(), prompt_id);
     }
 
@@ -1067,6 +1080,10 @@ export class GeminiClient {
               'Please start a new session or increase the sessionTokenLimit in your settings.json.',
           },
         };
+        if (isTopLevelInteraction)
+          endInteractionSpan('error', {
+            errorMessage: 'session token limit exceeded',
+          });
         return new Turn(this.getChat(), prompt_id);
       }
     }
@@ -1109,6 +1126,7 @@ export class GeminiClient {
         await arenaAgentClient.reportCancelled();
         this.pendingRecallAbortController?.abort();
         this.pendingRecallAbortController = undefined;
+        if (isTopLevelInteraction) endInteractionSpan('cancelled');
         return new Turn(this.getChat(), prompt_id);
       }
     }
@@ -1187,6 +1205,8 @@ export class GeminiClient {
             await arenaAgentClient.reportError('Loop detected');
           }
           this.lastApiCompletionTimestamp = Date.now();
+          if (isTopLevelInteraction)
+            endInteractionSpan('error', { errorMessage: 'loop detected' });
           return turn;
         }
       }
@@ -1213,6 +1233,13 @@ export class GeminiClient {
           await arenaAgentClient.reportError(errorMsg);
         }
         this.lastApiCompletionTimestamp = Date.now();
+        if (isTopLevelInteraction) {
+          const errMsg =
+            event.value instanceof Error
+              ? event.value.message
+              : 'unknown error';
+          endInteractionSpan('error', { errorMessage: errMsg });
+        }
         return turn;
       }
     }
@@ -1259,6 +1286,7 @@ export class GeminiClient {
 
       // Check if aborted after hook execution
       if (signal.aborted) {
+        if (isTopLevelInteraction) endInteractionSpan('cancelled');
         return turn;
       }
 
@@ -1283,6 +1311,7 @@ export class GeminiClient {
       ) {
         // Check if aborted before continuing
         if (signal.aborted) {
+          if (isTopLevelInteraction) endInteractionSpan('cancelled');
           return turn;
         }
 
@@ -1312,7 +1341,7 @@ export class GeminiClient {
         }
 
         const continueRequest = [{ text: continueReason }];
-        return yield* this.sendMessageStream(
+        const hookTurn = yield* this.sendMessageStream(
           continueRequest,
           signal,
           prompt_id,
@@ -1326,6 +1355,9 @@ export class GeminiClient {
           },
           boundedTurns - 1,
         );
+        if (isTopLevelInteraction)
+          endInteractionSpan(signal.aborted ? 'cancelled' : 'ok');
+        return hookTurn;
       }
     }
 
@@ -1352,10 +1384,10 @@ export class GeminiClient {
 
       if (this.config.getSkipNextSpeakerCheck()) {
         this.runManagedAutoMemoryBackgroundTasks(messageType);
-        // Report completed before returning — agent has no more work to do
         if (arenaAgentClient) {
           await arenaAgentClient.reportCompleted();
         }
+        if (isTopLevelInteraction) endInteractionSpan('ok');
         return turn;
       }
 
@@ -1375,15 +1407,16 @@ export class GeminiClient {
       );
       if (nextSpeakerCheck?.next_speaker === 'model') {
         const nextRequest = [{ text: 'Please continue.' }];
-        // This recursive call's events will be yielded out, and the final
-        // turn object from the recursive call will be returned.
-        return yield* this.sendMessageStream(
+        const continueTurn = yield* this.sendMessageStream(
           nextRequest,
           signal,
           prompt_id,
           options,
           boundedTurns - 1,
         );
+        if (isTopLevelInteraction)
+          endInteractionSpan(signal.aborted ? 'cancelled' : 'ok');
+        return continueTurn;
       }
 
       this.runManagedAutoMemoryBackgroundTasks(messageType);
@@ -1399,6 +1432,9 @@ export class GeminiClient {
       await arenaAgentClient.reportCancelled();
     }
 
+    if (isTopLevelInteraction) {
+      endInteractionSpan(signal?.aborted ? 'cancelled' : 'ok');
+    }
     return turn;
   }
 

--- a/packages/core/src/telemetry/constants.ts
+++ b/packages/core/src/telemetry/constants.ts
@@ -58,3 +58,9 @@ export const EVENT_PERFORMANCE_REGRESSION = 'qwen-code.performance.regression';
 export const EVENT_MEMORY_EXTRACT = 'qwen-code.memory.extract';
 export const EVENT_MEMORY_DREAM = 'qwen-code.memory.dream';
 export const EVENT_MEMORY_RECALL = 'qwen-code.memory.recall';
+
+// Session Tracing Span Names
+export const SPAN_INTERACTION = 'qwen-code.interaction';
+export const SPAN_LLM_REQUEST = 'qwen-code.llm_request';
+export const SPAN_TOOL = 'qwen-code.tool';
+export const SPAN_TOOL_EXECUTION = 'qwen-code.tool.execution';

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -136,3 +136,20 @@ export {
 } from './metrics.js';
 export { QwenLogger } from './qwen-logger/qwen-logger.js';
 export { sanitizeHookName } from './sanitize.js';
+export {
+  startInteractionSpan,
+  endInteractionSpan,
+  startLLMRequestSpan,
+  endLLMRequestSpan,
+  startToolSpan,
+  endToolSpan,
+  startToolExecutionSpan,
+  endToolExecutionSpan,
+  clearSessionTracingForTesting,
+} from './session-tracing.js';
+export type {
+  StartInteractionOptions,
+  EndInteractionOptions,
+  LLMRequestMetadata,
+  ToolSpanMetadata,
+} from './session-tracing.js';

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -32,6 +32,7 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 import { LogToSpanProcessor } from './log-to-span-processor.js';
 import { createSessionRootContext } from './tracer.js';
 import { setSessionContext } from './session-context.js';
+import { endInteractionSpan } from './session-tracing.js';
 
 function createTelemetryDiagLogger(): DiagLogger {
   const debugLogger = createDebugLogger('OTEL');
@@ -317,6 +318,7 @@ export async function shutdownTelemetry(): Promise<void> {
   if (!telemetryInitialized || !sdk) {
     return;
   }
+  endInteractionSpan('cancelled');
   const currentSdk = sdk;
   const debugLogger = createDebugLogger('OTEL');
   telemetryShutdownPromise = (async () => {

--- a/packages/core/src/telemetry/session-tracing.test.ts
+++ b/packages/core/src/telemetry/session-tracing.test.ts
@@ -1,0 +1,427 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SpanStatusCode } from '@opentelemetry/api';
+
+const mockState = vi.hoisted(() => ({
+  sdkInitialized: true,
+}));
+
+vi.mock('./sdk.js', () => ({
+  isTelemetrySdkInitialized: () => mockState.sdkInitialized,
+}));
+
+interface MockSpanRecord {
+  name: string;
+  kind: number;
+  attributes: Record<string, unknown>;
+  setAttributesCalls: Array<Record<string, unknown>>;
+  statuses: Array<{ code: number; message?: string }>;
+  ended: boolean;
+  parentContext?: unknown;
+}
+
+const mockSpans: MockSpanRecord[] = [];
+
+vi.mock('@opentelemetry/api', async () => {
+  const actual =
+    await vi.importActual<typeof import('@opentelemetry/api')>(
+      '@opentelemetry/api',
+    );
+
+  function createMockSpan(
+    name: string,
+    opts?: { kind?: number; attributes?: Record<string, unknown> },
+    parentCtx?: unknown,
+  ): MockSpanRecord & {
+    spanContext: () => { spanId: string; traceId: string; traceFlags: number };
+    setAttributes: (attrs: Record<string, unknown>) => void;
+    setStatus: (status: { code: number; message?: string }) => void;
+    end: () => void;
+  } {
+    const record: MockSpanRecord = {
+      name,
+      kind: opts?.kind ?? 0,
+      attributes: { ...(opts?.attributes ?? {}) },
+      setAttributesCalls: [],
+      statuses: [],
+      ended: false,
+      parentContext: parentCtx,
+    };
+    mockSpans.push(record);
+    const spanId = Math.random().toString(16).slice(2, 18).padEnd(16, '0');
+    return Object.assign(record, {
+      spanContext: () => ({
+        spanId,
+        traceId: '0'.repeat(32),
+        traceFlags: 0,
+      }),
+      setAttributes: (attrs: Record<string, unknown>) => {
+        record.setAttributesCalls.push(attrs);
+        Object.assign(record.attributes, attrs);
+      },
+      setStatus: (status: { code: number; message?: string }) => {
+        record.statuses.push(status);
+      },
+      end: () => {
+        record.ended = true;
+      },
+    });
+  }
+
+  const mockTracer = {
+    startSpan: (
+      name: string,
+      opts?: { kind?: number; attributes?: Record<string, unknown> },
+      parentCtx?: unknown,
+    ) => createMockSpan(name, opts, parentCtx),
+  };
+
+  return {
+    ...actual,
+    SpanKind: actual.SpanKind,
+    SpanStatusCode: actual.SpanStatusCode,
+    trace: {
+      getTracer: () => mockTracer,
+      setSpan: (ctx: unknown, _span: unknown) => ({
+        ...(ctx as object),
+        __parentSpan: _span,
+      }),
+      wrapSpanContext: actual.trace.wrapSpanContext,
+    },
+    context: {
+      active: () => ({}),
+    },
+  };
+});
+
+import type { Config } from '../config/config.js';
+import {
+  startInteractionSpan,
+  endInteractionSpan,
+  startLLMRequestSpan,
+  endLLMRequestSpan,
+  startToolSpan,
+  endToolSpan,
+  startToolExecutionSpan,
+  endToolExecutionSpan,
+  clearSessionTracingForTesting,
+} from './session-tracing.js';
+
+function createMockConfig(
+  overrides: Partial<{
+    sessionId: string;
+    approvalMode: string;
+  }> = {},
+): Config {
+  return {
+    getSessionId: () => overrides.sessionId ?? 'test-session-id',
+    getApprovalMode: () => overrides.approvalMode ?? 'suggest',
+  } as unknown as Config;
+}
+
+describe('session-tracing', () => {
+  beforeEach(() => {
+    clearSessionTracingForTesting();
+    mockSpans.length = 0;
+    mockState.sdkInitialized = true;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('interaction spans', () => {
+    it('starts and ends an interaction span with ok status', () => {
+      const config = createMockConfig();
+      startInteractionSpan(config, {
+        promptId: 'prompt-1',
+        model: 'test-model',
+        messageType: 'userQuery',
+      });
+
+      expect(mockSpans).toHaveLength(1);
+      expect(mockSpans[0]!.name).toBe('qwen-code.interaction');
+      expect(mockSpans[0]!.attributes['session.id']).toBe('test-session-id');
+      expect(mockSpans[0]!.attributes['qwen-code.prompt_id']).toBe('prompt-1');
+      expect(mockSpans[0]!.attributes['qwen-code.model']).toBe('test-model');
+
+      endInteractionSpan('ok');
+
+      expect(mockSpans[0]!.ended).toBe(true);
+      expect(mockSpans[0]!.statuses).toHaveLength(1);
+      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.OK);
+    });
+
+    it('ends interaction span with error status', () => {
+      const config = createMockConfig();
+      startInteractionSpan(config, {
+        promptId: 'prompt-2',
+        model: 'test-model',
+        messageType: 'userQuery',
+      });
+
+      endInteractionSpan('error', { errorMessage: 'something went wrong' });
+
+      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.ERROR);
+      expect(mockSpans[0]!.statuses[0]!.message).toBe('something went wrong');
+    });
+
+    it('ends interaction span with cancelled status', () => {
+      const config = createMockConfig();
+      startInteractionSpan(config, {
+        promptId: 'prompt-3',
+        model: 'test-model',
+        messageType: 'userQuery',
+      });
+
+      endInteractionSpan('cancelled');
+
+      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.ERROR);
+      expect(mockSpans[0]!.statuses[0]!.message).toBe('cancelled');
+    });
+
+    it('is idempotent — ending twice does not double-end', () => {
+      const config = createMockConfig();
+      startInteractionSpan(config, {
+        promptId: 'prompt-4',
+        model: 'test-model',
+        messageType: 'userQuery',
+      });
+
+      endInteractionSpan('ok');
+      endInteractionSpan('error');
+
+      expect(mockSpans[0]!.statuses).toHaveLength(1);
+    });
+
+    it('no-ops when SDK is not initialized', () => {
+      mockState.sdkInitialized = false;
+      const config = createMockConfig();
+      startInteractionSpan(config, {
+        promptId: 'prompt-5',
+        model: 'test-model',
+        messageType: 'userQuery',
+      });
+
+      expect(mockSpans).toHaveLength(0);
+
+      // endInteractionSpan should be safe to call
+      endInteractionSpan('ok');
+    });
+
+    it('increments interaction sequence', () => {
+      const config = createMockConfig();
+      startInteractionSpan(config, {
+        promptId: 'prompt-a',
+        model: 'test-model',
+        messageType: 'userQuery',
+      });
+      endInteractionSpan('ok');
+
+      startInteractionSpan(config, {
+        promptId: 'prompt-b',
+        model: 'test-model',
+        messageType: 'userQuery',
+      });
+
+      expect(mockSpans[1]!.attributes['interaction.sequence']).toBe(2);
+    });
+
+    it('records duration_ms and turn_status on end', () => {
+      const config = createMockConfig();
+      startInteractionSpan(config, {
+        promptId: 'prompt-dur',
+        model: 'test-model',
+        messageType: 'userQuery',
+      });
+
+      endInteractionSpan('ok');
+
+      const setAttrs = mockSpans[0]!.setAttributesCalls[0]!;
+      expect(setAttrs).toHaveProperty('interaction.duration_ms');
+      expect(setAttrs['qwen-code.turn_status']).toBe('ok');
+    });
+  });
+
+  describe('LLM request spans', () => {
+    it('creates and ends an LLM request span', () => {
+      const span = startLLMRequestSpan('test-model', 'prompt-llm');
+
+      expect(mockSpans).toHaveLength(1);
+      expect(mockSpans[0]!.name).toBe('qwen-code.llm_request');
+      expect(mockSpans[0]!.attributes['qwen-code.model']).toBe('test-model');
+
+      endLLMRequestSpan(span, {
+        success: true,
+        inputTokens: 100,
+        outputTokens: 50,
+        durationMs: 500,
+      });
+
+      expect(mockSpans[0]!.ended).toBe(true);
+      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.OK);
+    });
+
+    it('records error status on failure', () => {
+      const span = startLLMRequestSpan('test-model', 'prompt-err');
+
+      endLLMRequestSpan(span, {
+        success: false,
+        error: 'rate limited',
+      });
+
+      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.ERROR);
+      expect(mockSpans[0]!.statuses[0]!.message).toBe('rate limited');
+    });
+
+    it('parents under interaction span when one is active', () => {
+      const config = createMockConfig();
+      startInteractionSpan(config, {
+        promptId: 'p',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+
+      const span = startLLMRequestSpan('m', 'p');
+      endLLMRequestSpan(span, { success: true });
+      endInteractionSpan('ok');
+
+      // The LLM span should have a parent context
+      const llmSpan = mockSpans.find((s) => s.name === 'qwen-code.llm_request');
+      expect(llmSpan?.parentContext).toBeDefined();
+      expect(llmSpan?.attributes['llm_request.context']).toBe('interaction');
+    });
+
+    it('marks standalone when no interaction is active', () => {
+      const span = startLLMRequestSpan('m', 'p');
+      endLLMRequestSpan(span, { success: true });
+
+      expect(mockSpans[0]!.attributes['llm_request.context']).toBe(
+        'standalone',
+      );
+    });
+
+    it('returns NOOP span when SDK is not initialized', () => {
+      mockState.sdkInitialized = false;
+      const span = startLLMRequestSpan('m', 'p');
+      expect(span.spanContext().traceId).toBe('0'.repeat(32));
+      expect(span.spanContext().spanId).toBe('0'.repeat(16));
+
+      // endLLMRequestSpan with noop should be safe
+      endLLMRequestSpan(span, { success: true });
+    });
+  });
+
+  describe('tool spans', () => {
+    it('creates and ends a tool span', () => {
+      const span = startToolSpan('ReadFile', { 'tool.call_id': 'call-1' });
+
+      expect(mockSpans).toHaveLength(1);
+      expect(mockSpans[0]!.name).toBe('qwen-code.tool');
+      expect(mockSpans[0]!.attributes['tool.name']).toBe('ReadFile');
+      expect(mockSpans[0]!.attributes['tool.call_id']).toBe('call-1');
+
+      endToolSpan(span, { success: true });
+
+      expect(mockSpans[0]!.ended).toBe(true);
+      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.OK);
+    });
+
+    it('records error on tool failure', () => {
+      const span = startToolSpan('Bash');
+      endToolSpan(span, { success: false, error: 'command failed' });
+
+      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.ERROR);
+      expect(mockSpans[0]!.statuses[0]!.message).toBe('command failed');
+    });
+
+    it('defaults to OK when success is undefined', () => {
+      const span = startToolSpan('Read');
+      endToolSpan(span);
+
+      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.OK);
+    });
+
+    it('concurrent tool spans are isolated', () => {
+      const config = createMockConfig();
+      startInteractionSpan(config, {
+        promptId: 'p',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+
+      const span1 = startToolSpan('Read', { 'tool.call_id': 'c1' });
+      const span2 = startToolSpan('Bash', { 'tool.call_id': 'c2' });
+
+      // End span2 first (out of order)
+      endToolSpan(span2, { success: true });
+      endToolSpan(span1, { success: false, error: 'timeout' });
+
+      // Find tool spans
+      const toolSpans = mockSpans.filter((s) => s.name === 'qwen-code.tool');
+      expect(toolSpans).toHaveLength(2);
+
+      const readSpan = toolSpans.find(
+        (s) => s.attributes['tool.name'] === 'Read',
+      );
+      const bashSpan = toolSpans.find(
+        (s) => s.attributes['tool.name'] === 'Bash',
+      );
+
+      expect(bashSpan?.statuses[0]?.code).toBe(SpanStatusCode.OK);
+      expect(readSpan?.statuses[0]?.code).toBe(SpanStatusCode.ERROR);
+      expect(readSpan?.statuses[0]?.message).toBe('timeout');
+    });
+  });
+
+  describe('tool execution sub-spans', () => {
+    it('creates a tool execution span as child of tool span', () => {
+      const toolSpan = startToolSpan('Bash');
+      const execSpan = startToolExecutionSpan(toolSpan);
+
+      expect(mockSpans).toHaveLength(2);
+      expect(mockSpans[1]!.name).toBe('qwen-code.tool.execution');
+
+      endToolExecutionSpan(execSpan, { success: true });
+      endToolSpan(toolSpan, { success: true });
+
+      expect(mockSpans[1]!.ended).toBe(true);
+    });
+
+    it('returns NOOP span when SDK is not initialized', () => {
+      mockState.sdkInitialized = false;
+      const toolSpan = startToolSpan('Bash');
+      const execSpan = startToolExecutionSpan(toolSpan);
+
+      expect(execSpan.spanContext().traceId).toBe('0'.repeat(32));
+    });
+  });
+
+  describe('clearSessionTracingForTesting', () => {
+    it('resets state so new interactions start fresh', () => {
+      const config = createMockConfig();
+      startInteractionSpan(config, {
+        promptId: 'p',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+
+      clearSessionTracingForTesting();
+      mockSpans.length = 0;
+
+      startInteractionSpan(config, {
+        promptId: 'p2',
+        model: 'm',
+        messageType: 'userQuery',
+      });
+
+      // Sequence should be reset to 1
+      expect(mockSpans[0]!.attributes['interaction.sequence']).toBe(1);
+    });
+  });
+});

--- a/packages/core/src/telemetry/session-tracing.test.ts
+++ b/packages/core/src/telemetry/session-tracing.test.ts
@@ -171,7 +171,7 @@ describe('session-tracing', () => {
       expect(mockSpans[0]!.statuses[0]!.message).toBe('something went wrong');
     });
 
-    it('ends interaction span with cancelled status', () => {
+    it('ends interaction span with cancelled status as OK', () => {
       const config = createMockConfig();
       startInteractionSpan(config, {
         promptId: 'prompt-3',
@@ -181,8 +181,7 @@ describe('session-tracing', () => {
 
       endInteractionSpan('cancelled');
 
-      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.ERROR);
-      expect(mockSpans[0]!.statuses[0]!.message).toBe('cancelled');
+      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.OK);
     });
 
     it('is idempotent — ending twice does not double-end', () => {
@@ -304,6 +303,15 @@ describe('session-tracing', () => {
       expect(mockSpans[0]!.attributes['llm_request.context']).toBe(
         'standalone',
       );
+    });
+
+    it('treats missing metadata as OK status', () => {
+      const span = startLLMRequestSpan('test-model', 'prompt-no-meta');
+
+      endLLMRequestSpan(span);
+
+      expect(mockSpans[0]!.ended).toBe(true);
+      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.OK);
     });
 
     it('returns NOOP span when SDK is not initialized', () => {

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -68,6 +68,7 @@ const activeSpans = new Map<string, WeakRef<SpanContext>>();
 const strongSpans = new Map<string, SpanContext>();
 
 let interactionSequence = 0;
+let lastInteractionCtx: SpanContext | undefined;
 let cleanupIntervalStarted = false;
 const SPAN_TTL_MS = 30 * 60 * 1000;
 
@@ -82,7 +83,10 @@ function ensureCleanupInterval(): void {
         activeSpans.delete(spanId);
         strongSpans.delete(spanId);
       } else if (ctx.startTime < cutoff) {
-        if (!ctx.ended) ctx.span.end();
+        if (!ctx.ended) {
+          ctx.ended = true;
+          ctx.span.end();
+        }
         activeSpans.delete(spanId);
         strongSpans.delete(spanId);
       }
@@ -134,6 +138,8 @@ export function startInteractionSpan(
     type: 'interaction',
   };
   activeSpans.set(spanId, new WeakRef(spanContextObj));
+  strongSpans.set(spanId, spanContextObj);
+  lastInteractionCtx = spanContextObj;
   interactionContext.enterWith(spanContextObj);
 }
 
@@ -141,10 +147,11 @@ export function endInteractionSpan(
   status: InteractionStatus,
   metadata?: EndInteractionOptions,
 ): void {
-  const spanCtx = interactionContext.getStore();
+  const spanCtx = interactionContext.getStore() ?? lastInteractionCtx;
   if (!spanCtx || spanCtx.ended) return;
 
   spanCtx.ended = true;
+  lastInteractionCtx = undefined;
 
   const duration = Date.now() - spanCtx.startTime;
   spanCtx.span.setAttributes({
@@ -152,17 +159,19 @@ export function endInteractionSpan(
     'qwen-code.turn_status': status,
   });
 
-  if (status === 'ok') {
-    spanCtx.span.setStatus({ code: SpanStatusCode.OK });
-  } else {
+  if (status === 'error') {
     spanCtx.span.setStatus({
       code: SpanStatusCode.ERROR,
-      message: metadata?.errorMessage ?? status,
+      message: metadata?.errorMessage ?? 'unknown error',
     });
+  } else {
+    spanCtx.span.setStatus({ code: SpanStatusCode.OK });
   }
 
   spanCtx.span.end();
-  activeSpans.delete(getSpanId(spanCtx.span));
+  const spanId = getSpanId(spanCtx.span);
+  activeSpans.delete(spanId);
+  strongSpans.delete(spanId);
   interactionContext.enterWith(undefined);
 }
 
@@ -227,12 +236,12 @@ export function endLLMRequestSpan(
 
   span.setAttributes(endAttributes);
 
-  if (metadata?.success) {
+  if (metadata === undefined || metadata.success) {
     span.setStatus({ code: SpanStatusCode.OK });
   } else {
     span.setStatus({
       code: SpanStatusCode.ERROR,
-      message: metadata?.error ?? 'unknown error',
+      message: metadata.error ?? 'unknown error',
     });
   }
 
@@ -375,4 +384,5 @@ export function clearSessionTracingForTesting(): void {
   strongSpans.clear();
   interactionContext.enterWith(undefined);
   interactionSequence = 0;
+  lastInteractionCtx = undefined;
 }

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -1,0 +1,378 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+import {
+  context as otelContext,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+  type Attributes,
+  type Span,
+} from '@opentelemetry/api';
+import type { Config } from '../config/config.js';
+import {
+  SERVICE_NAME,
+  SPAN_INTERACTION,
+  SPAN_LLM_REQUEST,
+  SPAN_TOOL,
+  SPAN_TOOL_EXECUTION,
+} from './constants.js';
+import { isTelemetrySdkInitialized } from './sdk.js';
+
+type InteractionStatus = 'ok' | 'error' | 'cancelled';
+
+export interface StartInteractionOptions {
+  promptId: string;
+  model: string;
+  messageType: string;
+}
+
+export interface EndInteractionOptions {
+  errorMessage?: string;
+}
+
+export interface LLMRequestMetadata {
+  inputTokens?: number;
+  outputTokens?: number;
+  success: boolean;
+  durationMs?: number;
+  error?: string;
+}
+
+export interface ToolSpanMetadata {
+  success?: boolean;
+  error?: string;
+}
+
+interface SpanContext {
+  span: Span;
+  startTime: number;
+  attributes: Record<string, string | number | boolean>;
+  ended?: boolean;
+  type: 'interaction' | 'llm_request' | 'tool' | 'tool.execution';
+}
+
+const NOOP_SPAN = trace.wrapSpanContext({
+  traceId: '0'.repeat(32),
+  spanId: '0'.repeat(16),
+  traceFlags: 0,
+});
+
+const interactionContext = new AsyncLocalStorage<SpanContext | undefined>();
+
+const activeSpans = new Map<string, WeakRef<SpanContext>>();
+const strongSpans = new Map<string, SpanContext>();
+
+let interactionSequence = 0;
+let cleanupIntervalStarted = false;
+const SPAN_TTL_MS = 30 * 60 * 1000;
+
+function ensureCleanupInterval(): void {
+  if (cleanupIntervalStarted) return;
+  cleanupIntervalStarted = true;
+  const interval = setInterval(() => {
+    const cutoff = Date.now() - SPAN_TTL_MS;
+    for (const [spanId, weakRef] of activeSpans) {
+      const ctx = weakRef.deref();
+      if (ctx === undefined) {
+        activeSpans.delete(spanId);
+        strongSpans.delete(spanId);
+      } else if (ctx.startTime < cutoff) {
+        if (!ctx.ended) ctx.span.end();
+        activeSpans.delete(spanId);
+        strongSpans.delete(spanId);
+      }
+    }
+  }, 60_000);
+  if (typeof interval.unref === 'function') {
+    interval.unref();
+  }
+}
+
+function getSpanId(span: Span): string {
+  return span.spanContext().spanId || '';
+}
+
+function getTracer() {
+  return trace.getTracer(SERVICE_NAME, '1.0.0');
+}
+
+// --- Interaction Spans ---
+
+export function startInteractionSpan(
+  config: Config,
+  options: StartInteractionOptions,
+): void {
+  if (!isTelemetrySdkInitialized()) return;
+
+  ensureCleanupInterval();
+  interactionSequence++;
+
+  const attributes: Attributes = {
+    'session.id': config.getSessionId(),
+    'qwen-code.prompt_id': options.promptId,
+    'qwen-code.message_type': options.messageType,
+    'qwen-code.model': options.model,
+    'qwen-code.approval_mode': config.getApprovalMode(),
+    'interaction.sequence': interactionSequence,
+  };
+
+  const span = getTracer().startSpan(SPAN_INTERACTION, {
+    kind: SpanKind.INTERNAL,
+    attributes,
+  });
+
+  const spanId = getSpanId(span);
+  const spanContextObj: SpanContext = {
+    span,
+    startTime: Date.now(),
+    attributes: attributes as Record<string, string | number | boolean>,
+    type: 'interaction',
+  };
+  activeSpans.set(spanId, new WeakRef(spanContextObj));
+  interactionContext.enterWith(spanContextObj);
+}
+
+export function endInteractionSpan(
+  status: InteractionStatus,
+  metadata?: EndInteractionOptions,
+): void {
+  const spanCtx = interactionContext.getStore();
+  if (!spanCtx || spanCtx.ended) return;
+
+  spanCtx.ended = true;
+
+  const duration = Date.now() - spanCtx.startTime;
+  spanCtx.span.setAttributes({
+    'interaction.duration_ms': duration,
+    'qwen-code.turn_status': status,
+  });
+
+  if (status === 'ok') {
+    spanCtx.span.setStatus({ code: SpanStatusCode.OK });
+  } else {
+    spanCtx.span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: metadata?.errorMessage ?? status,
+    });
+  }
+
+  spanCtx.span.end();
+  activeSpans.delete(getSpanId(spanCtx.span));
+  interactionContext.enterWith(undefined);
+}
+
+// --- LLM Request Spans ---
+
+export function startLLMRequestSpan(model: string, promptId: string): Span {
+  if (!isTelemetrySdkInitialized()) {
+    return NOOP_SPAN;
+  }
+
+  const parentCtx = interactionContext.getStore();
+  const ctx = parentCtx
+    ? trace.setSpan(otelContext.active(), parentCtx.span)
+    : otelContext.active();
+
+  const attributes: Attributes = {
+    'qwen-code.model': model,
+    'qwen-code.prompt_id': promptId,
+    'llm_request.context': parentCtx ? 'interaction' : 'standalone',
+  };
+
+  const span = getTracer().startSpan(
+    SPAN_LLM_REQUEST,
+    { kind: SpanKind.INTERNAL, attributes },
+    ctx,
+  );
+
+  const spanId = getSpanId(span);
+  const spanContextObj: SpanContext = {
+    span,
+    startTime: Date.now(),
+    attributes: attributes as Record<string, string | number | boolean>,
+    type: 'llm_request',
+  };
+  activeSpans.set(spanId, new WeakRef(spanContextObj));
+  strongSpans.set(spanId, spanContextObj);
+
+  return span;
+}
+
+export function endLLMRequestSpan(
+  span: Span,
+  metadata?: LLMRequestMetadata,
+): void {
+  const spanId = getSpanId(span);
+  const spanCtx = activeSpans.get(spanId)?.deref();
+  if (!spanCtx || spanCtx.ended) return;
+
+  spanCtx.ended = true;
+
+  const duration = metadata?.durationMs ?? Date.now() - spanCtx.startTime;
+  const endAttributes: Attributes = { duration_ms: duration };
+
+  if (metadata) {
+    if (metadata.inputTokens !== undefined)
+      endAttributes['input_tokens'] = metadata.inputTokens;
+    if (metadata.outputTokens !== undefined)
+      endAttributes['output_tokens'] = metadata.outputTokens;
+    endAttributes['success'] = metadata.success;
+    if (metadata.error !== undefined) endAttributes['error'] = metadata.error;
+  }
+
+  span.setAttributes(endAttributes);
+
+  if (metadata?.success) {
+    span.setStatus({ code: SpanStatusCode.OK });
+  } else {
+    span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: metadata?.error ?? 'unknown error',
+    });
+  }
+
+  span.end();
+  activeSpans.delete(spanId);
+  strongSpans.delete(spanId);
+}
+
+// --- Tool Spans ---
+
+export function startToolSpan(
+  toolName: string,
+  attrs?: Record<string, string | number | boolean>,
+): Span {
+  if (!isTelemetrySdkInitialized()) {
+    return NOOP_SPAN;
+  }
+
+  const parentCtx = interactionContext.getStore();
+  const ctx = parentCtx
+    ? trace.setSpan(otelContext.active(), parentCtx.span)
+    : otelContext.active();
+
+  const attributes: Attributes = {
+    'tool.name': toolName,
+    ...attrs,
+  };
+
+  const span = getTracer().startSpan(
+    SPAN_TOOL,
+    { kind: SpanKind.INTERNAL, attributes },
+    ctx,
+  );
+
+  const spanId = getSpanId(span);
+  const spanContextObj: SpanContext = {
+    span,
+    startTime: Date.now(),
+    attributes: attributes as Record<string, string | number | boolean>,
+    type: 'tool',
+  };
+  activeSpans.set(spanId, new WeakRef(spanContextObj));
+  strongSpans.set(spanId, spanContextObj);
+
+  return span;
+}
+
+export function endToolSpan(span: Span, metadata?: ToolSpanMetadata): void {
+  const spanId = getSpanId(span);
+  const spanCtx = activeSpans.get(spanId)?.deref();
+  if (!spanCtx || spanCtx.ended) return;
+
+  spanCtx.ended = true;
+
+  const duration = Date.now() - spanCtx.startTime;
+  const endAttributes: Attributes = { duration_ms: duration };
+
+  if (metadata) {
+    if (metadata.success !== undefined)
+      endAttributes['success'] = metadata.success;
+    if (metadata.error !== undefined) endAttributes['error'] = metadata.error;
+  }
+
+  spanCtx.span.setAttributes(endAttributes);
+
+  if (metadata?.success !== false) {
+    spanCtx.span.setStatus({ code: SpanStatusCode.OK });
+  } else {
+    spanCtx.span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: metadata?.error ?? 'tool error',
+    });
+  }
+
+  spanCtx.span.end();
+  activeSpans.delete(spanId);
+  strongSpans.delete(spanId);
+}
+
+// --- Tool Execution Sub-Spans ---
+
+export function startToolExecutionSpan(parentToolSpan: Span): Span {
+  if (!isTelemetrySdkInitialized()) {
+    return NOOP_SPAN;
+  }
+
+  const ctx = trace.setSpan(otelContext.active(), parentToolSpan);
+
+  const span = getTracer().startSpan(
+    SPAN_TOOL_EXECUTION,
+    { kind: SpanKind.INTERNAL },
+    ctx,
+  );
+
+  const spanId = getSpanId(span);
+  const spanContextObj: SpanContext = {
+    span,
+    startTime: Date.now(),
+    attributes: {},
+    type: 'tool.execution',
+  };
+  activeSpans.set(spanId, new WeakRef(spanContextObj));
+  strongSpans.set(spanId, spanContextObj);
+
+  return span;
+}
+
+export function endToolExecutionSpan(
+  span: Span,
+  metadata?: {
+    success?: boolean;
+    error?: string;
+  },
+): void {
+  const spanId = getSpanId(span);
+  const spanCtx = activeSpans.get(spanId)?.deref();
+  if (!spanCtx || spanCtx.ended) return;
+
+  spanCtx.ended = true;
+
+  const duration = Date.now() - spanCtx.startTime;
+  const endAttributes: Attributes = { duration_ms: duration };
+
+  if (metadata) {
+    if (metadata.success !== undefined)
+      endAttributes['success'] = metadata.success;
+    if (metadata.error !== undefined) endAttributes['error'] = metadata.error;
+  }
+
+  spanCtx.span.setAttributes(endAttributes);
+  spanCtx.span.end();
+  activeSpans.delete(spanId);
+  strongSpans.delete(spanId);
+}
+
+// --- Testing Utilities ---
+
+export function clearSessionTracingForTesting(): void {
+  activeSpans.clear();
+  strongSpans.clear();
+  interactionContext.enterWith(undefined);
+  interactionSequence = 0;
+}

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -372,6 +372,16 @@ export function endToolExecutionSpan(
   }
 
   spanCtx.span.setAttributes(endAttributes);
+
+  if (metadata?.success !== false) {
+    spanCtx.span.setStatus({ code: SpanStatusCode.OK });
+  } else {
+    spanCtx.span.setStatus({
+      code: SpanStatusCode.ERROR,
+      message: metadata?.error ?? 'tool execution error',
+    });
+  }
+
   spanCtx.span.end();
   activeSpans.delete(spanId);
   strongSpans.delete(spanId);


### PR DESCRIPTION
## Summary

Add OpenTelemetry hierarchical session tracing with interaction-level spans that wrap the full `sendMessageStream` lifecycle.

- **New `session-tracing.ts` module** — concurrent-safe span management using explicit span references (no shared ALS for tool/LLM spans), `WeakRef` + `strongRefs` + 30-min TTL cleanup, `NOOP_SPAN` sentinel when SDK is uninitialized
- **Interaction spans in `client.ts`** — started for UserQuery/Cron/Notification message types, properly ended at all exit points (ok/error/cancelled), including recursive yield* paths, with try/finally safety net for uncaught exceptions
- **Shutdown safety net in `sdk.ts`** — ends active interaction span before SDK shutdown to prevent orphan spans on Ctrl+C
- **Span hierarchy constants** — `SPAN_INTERACTION`, `SPAN_LLM_REQUEST`, `SPAN_TOOL`, `SPAN_TOOL_EXECUTION` in constants.ts
- **Full re-exports** from telemetry barrel file

### Review fixes (second commit)

- TTL cleanup sets `ctx.ended = true` before `span.end()` to prevent double-end
- Interaction spans stored in `strongSpans` for GC-safe TTL cleanup
- `cancelled` status uses `SpanStatusCode.OK` per codebase convention (`log-to-span-processor.ts`) — `qwen-code.turn_status` attribute provides classification
- `endLLMRequestSpan` treats missing metadata as OK, not ERROR
- Module-level `lastInteractionCtx` fallback ensures `shutdownTelemetry()` can end the active span even outside ALS context
- `sendMessageStream` body wrapped in try/finally — idempotent safety net for span cleanup on uncaught exceptions

> Note: Tool and LLM request span APIs are exported but not yet wired into callsites — upstream already has comprehensive tool/LLM instrumentation via `tracer.ts`/`withSpan`/`startSpanWithContext`. These APIs are available for future use or alternative instrumentation paths.

## Test plan

- [x] 20 unit tests covering interaction lifecycle, LLM spans (including missing-metadata-as-OK), tool spans, concurrent isolation, noop behavior, and cleanup
- [x] TypeScript type check passes
- [x] ESLint + Prettier pass (pre-commit hooks)
- [x] SDK test suite (26 tests) still passes with new import

## 人工验证
```
# 在另一个终端执行：
  cd /Users/jinye.djy/.codex/worktrees/81a7/qwen-code
  QWEN_TELEMETRY_OUTFILE=/tmp/spans.json node packages/cli/dist/index.js

  进去后随便问一句话，等回复完后输入 /exit 退出
```

<img width="1653" height="356" alt="image" src="https://github.com/user-attachments/assets/b9668af2-b615-4d25-8c8d-f18e2710597c" />

```
然后：

  # 查看 interaction span
  cat /tmp/spans.json | jq 'select(.name == "qwen-code.interaction")'

  应该能看到包含 session.id、qwen-code.turn_status、interaction.duration_ms 等属性的 span。
```
符合预期
<img width="1340" height="931" alt="image" src="https://github.com/user-attachments/assets/15e95e61-2446-4cb0-a5a4-1095a5009288" />


🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)


---

> **📝 描述准确性更新（2026-05-31，作者自查）**
>
> 注明：当前仅 interaction span 接线，startLLMRequestSpan/startToolSpan 等已导出但暂未使用；concurrent-safe 仅适用顺序路径（模块全局 ctx 非并发安全）。
