### PR TITLE
fix(test): repair stale --json-schema integration assertion

### DIFF
--- a/integration-tests/cli/json-schema.test.ts
+++ b/integration-tests/cli/json-schema.test.ts
@@ -154,13 +154,17 @@ describe('--json-schema headless structured output', () => {
     rig = new TestRig();
     await rig.setup('json-schema-bad-schema');
 
-    // Ajv strict-compile will reject `type: "this-is-not-a-real-type"`.
+    // Root type is `object` so the root-accepts-object precheck passes;
+    // Ajv strict-compile then rejects the unknown nested `type`.
     let thrown: Error | undefined;
     try {
       await rig.run(
         'hi',
         '--json-schema',
-        JSON.stringify({ type: 'this-is-not-a-real-type' }),
+        JSON.stringify({
+          type: 'object',
+          properties: { x: { type: 'this-is-not-a-real-type' } },
+        }),
       );
       expect.fail('expected non-zero exit on invalid schema');
     } catch (e) {


### PR DESCRIPTION
## Summary

- What changed: the integration test `--json-schema headless structured output › fails fast at CLI parse time on invalid JSON Schema` now feeds the CLI a schema whose root accepts objects but whose nested property carries a bogus `type`, so it actually exercises the Ajv strict-compile path it was written to cover.
- Why it changed: the CLI grew an earlier `--json-schema root must accept object-typed values` precheck. That precheck rejects `{type: "this-is-not-a-real-type"}` before Ajv runs, producing a different error string than the assertion expected. The test had been silently passing under the old ordering and started failing once integration tests next ran on the scheduled Release workflow.
- Reviewer focus: confirm the new fixture still represents the "bad schema" scenario the test is meant to cover (Ajv compile-time rejection of an invalid JSON Schema), and that the assertion regex stays meaningful.

## Validation

- Prompts / inputs used: the bundled `dist/cli.js` is invoked with `--json-schema '{"type":"object","properties":{"x":{"type":"this-is-not-a-real-type"}}}'`.
- Expected result: CLI exits non-zero with stderr matching `/--json-schema is not a valid JSON Schema/i`.
- Observed result: test passes in ~1.15s; full repo typecheck is clean.
- Quickest reviewer verification path: pull the branch, run the two commands above.
- Evidence:
  ```
   ✓ cli/json-schema.test.ts (6 tests | 5 skipped) 1154ms
     ✓ --json-schema headless structured output > fails fast at CLI parse time on invalid JSON Schema  1153ms

   Test Files  1 passed (1)
        Tests  1 passed | 5 skipped (6)
  ```

## Scope / Risk

- Main risk or tradeoff: only the targeted assertion was re-run; the other five tests in this file were not exercised because they require live model calls. They are unrelated to the change.
- Not covered / not validated: live-model paths in the same file (happy path, file-loaded schema, plain-text fallback). They are independent of this diff.
- Breaking changes / migration notes: none — test-only change.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ⚠️  | ✅  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Verified on Linux against the bundled CLI; the failing CI runs that prompted this fix were the scheduled Release workflow's "Integration Tests (No Sandbox)" and "Integration Tests (Docker)" jobs, both of which should turn green with this change.

## Linked Issues / Bugs

Fixes the integration-test failure surfaced by the scheduled Release run https://github.com/QwenLM/qwen-code/actions/runs/25705113751.