### PR TITLE
fix(core): log internal OpenAI JSON requests

### DIFF
--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
@@ -1498,13 +1498,7 @@ describe('LoggingContentGenerator', () => {
         expect.objectContaining({ id: 'openai-response' }),
       );
       expect(openaiError).toBeUndefined();
-      expect(options).toEqual({
-        filenameTag: promptId,
-        metadata: {
-          promptId,
-          internalPrompt: true,
-        },
-      });
+      expect(options).toBe(promptId);
     },
   );
 
@@ -1570,13 +1564,7 @@ describe('LoggingContentGenerator', () => {
         expect.objectContaining({ id: 'openai-response' }),
       );
       expect(openaiError).toBeUndefined();
-      expect(options).toEqual({
-        filenameTag: promptId,
-        metadata: {
-          promptId,
-          internalPrompt: true,
-        },
-      });
+      expect(options).toBe(promptId);
     },
   );
 });

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
@@ -1440,8 +1440,13 @@ describe('LoggingContentGenerator', () => {
     expect(openaiLoggerInstance.logInteraction).toHaveBeenCalledTimes(1);
   });
 
-  it.each(['prompt_suggestion', 'forked_query', 'speculation'])(
-    'skips logApiRequest and OpenAI logging for internal promptId %s (generateContent)',
+  it.each([
+    'prompt_suggestion',
+    'forked_query',
+    'speculation',
+    'side-query:session-title',
+  ])(
+    'skips logApiRequest but writes tagged OpenAI logging for internal promptId %s (generateContent)',
     async (promptId) => {
       const mockResponse = {
         responseId: 'internal-resp',
@@ -1474,17 +1479,42 @@ describe('LoggingContentGenerator', () => {
       expect(logApiResponse).toHaveBeenCalled();
       const [, responseEvent] = vi.mocked(logApiResponse).mock.calls[0];
       expect(responseEvent.response_text).toBeUndefined();
-      // OpenAI logger should be constructed, but no interaction should be logged
+      // OpenAI file logging is explicit diagnostic output, so internal prompts
+      // are written with a tag instead of being dropped.
       expect(OpenAILogger).toHaveBeenCalled();
       const loggerInstance = (
         OpenAILogger as unknown as ReturnType<typeof vi.fn>
       ).mock.results[0]?.value;
-      expect(loggerInstance.logInteraction).not.toHaveBeenCalled();
+      expect(loggerInstance.logInteraction).toHaveBeenCalledTimes(1);
+      const [openaiRequest, openaiResponse, openaiError, options] =
+        loggerInstance.logInteraction.mock.calls[0];
+      expect(openaiRequest).toEqual(
+        expect.objectContaining({
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'converted' }],
+        }),
+      );
+      expect(openaiResponse).toEqual(
+        expect.objectContaining({ id: 'openai-response' }),
+      );
+      expect(openaiError).toBeUndefined();
+      expect(options).toEqual({
+        filenameTag: promptId,
+        metadata: {
+          promptId,
+          internalPrompt: true,
+        },
+      });
     },
   );
 
-  it.each(['prompt_suggestion', 'forked_query', 'speculation'])(
-    'skips logApiRequest and OpenAI logging for internal promptId %s (generateContentStream)',
+  it.each([
+    'prompt_suggestion',
+    'forked_query',
+    'speculation',
+    'side-query:session-title',
+  ])(
+    'skips logApiRequest but writes tagged OpenAI logging for internal promptId %s (generateContentStream)',
     async (promptId) => {
       const mockChunk = {
         responseId: 'stream-resp',
@@ -1527,7 +1557,26 @@ describe('LoggingContentGenerator', () => {
       const loggerInstance = (
         OpenAILogger as unknown as ReturnType<typeof vi.fn>
       ).mock.results[0]?.value;
-      expect(loggerInstance.logInteraction).not.toHaveBeenCalled();
+      expect(loggerInstance.logInteraction).toHaveBeenCalledTimes(1);
+      const [openaiRequest, openaiResponse, openaiError, options] =
+        loggerInstance.logInteraction.mock.calls[0];
+      expect(openaiRequest).toEqual(
+        expect.objectContaining({
+          model: 'test-model',
+          messages: [{ role: 'user', content: 'converted' }],
+        }),
+      );
+      expect(openaiResponse).toEqual(
+        expect.objectContaining({ id: 'openai-response' }),
+      );
+      expect(openaiError).toBeUndefined();
+      expect(options).toEqual({
+        filenameTag: promptId,
+        metadata: {
+          promptId,
+          internalPrompt: true,
+        },
+      });
     },
   );
 });

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -48,10 +48,7 @@ import type {
 import { OpenAIContentConverter } from '../openaiContentGenerator/converter.js';
 import { openaiRequestCaptureContext } from '../openaiContentGenerator/requestCaptureContext.js';
 import type { RequestContext } from '../openaiContentGenerator/types.js';
-import {
-  OpenAILogger,
-  type OpenAILogInteractionOptions,
-} from '../../utils/openaiLogger.js';
+import { OpenAILogger } from '../../utils/openaiLogger.js';
 import { createDebugLogger } from '../../utils/debugLogger.js';
 import {
   getErrorMessage,
@@ -577,7 +574,7 @@ export class LoggingContentGenerator implements ContentGenerator {
         : error
           ? new Error(String(error))
           : undefined,
-      this.buildOpenAILogOptions(promptId),
+      promptId,
     );
   }
 
@@ -592,22 +589,6 @@ export class LoggingContentGenerator implements ContentGenerator {
     } catch (loggingError) {
       debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
     }
-  }
-
-  private buildOpenAILogOptions(
-    promptId: string | undefined,
-  ): OpenAILogInteractionOptions | undefined {
-    if (!isInternalPromptId(promptId)) {
-      return undefined;
-    }
-
-    return {
-      filenameTag: promptId,
-      metadata: {
-        promptId,
-        internalPrompt: true,
-      },
-    };
   }
 
   private convertGeminiResponseToOpenAIForLogging(

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -48,7 +48,10 @@ import type {
 import { OpenAIContentConverter } from '../openaiContentGenerator/converter.js';
 import { openaiRequestCaptureContext } from '../openaiContentGenerator/requestCaptureContext.js';
 import type { RequestContext } from '../openaiContentGenerator/types.js';
-import { OpenAILogger } from '../../utils/openaiLogger.js';
+import {
+  OpenAILogger,
+  type OpenAILogInteractionOptions,
+} from '../../utils/openaiLogger.js';
 import { createDebugLogger } from '../../utils/debugLogger.js';
 import {
   getErrorMessage,
@@ -216,7 +219,7 @@ export class LoggingContentGenerator implements ContentGenerator {
       async (span) => {
         const startTime = Date.now();
         const isInternal = isInternalPromptId(userPromptId);
-        const session = this.startCaptureSession(isInternal);
+        const session = this.startCaptureSession();
         try {
           if (!isInternal) {
             this.logApiRequest(
@@ -240,18 +243,15 @@ export class LoggingContentGenerator implements ContentGenerator {
             response.usageMetadata,
             responseText,
           );
-          if (!isInternal) {
-            try {
-              await this.safelyLogOpenAIInteraction(
-                await session.resolve(req),
-                response,
-              );
-            } catch (loggingError) {
-              debugLogger.warn(
-                'Failed to log OpenAI interaction:',
-                loggingError,
-              );
-            }
+          try {
+            await this.safelyLogOpenAIInteraction(
+              await session.resolve(req),
+              response,
+              undefined,
+              userPromptId,
+            );
+          } catch (loggingError) {
+            debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
           }
           return response;
         } catch (error) {
@@ -263,19 +263,15 @@ export class LoggingContentGenerator implements ContentGenerator {
             req.model,
             userPromptId,
           );
-          if (!isInternal) {
-            try {
-              await this.safelyLogOpenAIInteraction(
-                await session.resolve(req),
-                undefined,
-                error,
-              );
-            } catch (loggingError) {
-              debugLogger.warn(
-                'Failed to log OpenAI interaction:',
-                loggingError,
-              );
-            }
+          try {
+            await this.safelyLogOpenAIInteraction(
+              await session.resolve(req),
+              undefined,
+              error,
+              userPromptId,
+            );
+          } catch (loggingError) {
+            debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
           }
           safeSetStatus(span, {
             code: SpanStatusCode.ERROR,
@@ -302,7 +298,7 @@ export class LoggingContentGenerator implements ContentGenerator {
 
     const startTime = Date.now();
     const isInternal = isInternalPromptId(userPromptId);
-    const session = this.startCaptureSession(isInternal);
+    const session = this.startCaptureSession();
 
     let stream: AsyncGenerator<GenerateContentResponse>;
     try {
@@ -332,22 +328,21 @@ export class LoggingContentGenerator implements ContentGenerator {
       } catch {
         // OTel errors must not mask the original API error
       }
-      if (!isInternal) {
-        try {
-          await this.safelyLogOpenAIInteraction(
-            await session.resolve(req),
-            undefined,
-            error,
-          );
-        } catch (loggingError) {
-          debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
-        }
+      try {
+        await this.safelyLogOpenAIInteraction(
+          await session.resolve(req),
+          undefined,
+          error,
+          userPromptId,
+        );
+      } catch (loggingError) {
+        debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
       }
       throw error;
     }
 
     let resolvedRequest: OpenAI.Chat.ChatCompletionCreateParams | undefined;
-    if (!isInternal) {
+    if (this.openaiLogger) {
       try {
         resolvedRequest = await session.resolve(req);
       } catch (loggingError) {
@@ -368,14 +363,14 @@ export class LoggingContentGenerator implements ContentGenerator {
     );
   }
 
-  private startCaptureSession(isInternal: boolean): {
+  private startCaptureSession(): {
     wrap: <T>(fn: () => Promise<T>) => Promise<T>;
     resolve: (
       req: GenerateContentParameters,
     ) => Promise<OpenAI.Chat.ChatCompletionCreateParams | undefined>;
   } {
     let captured: OpenAI.Chat.ChatCompletionCreateParams | undefined;
-    const skipCapture = isInternal || !this.openaiLogger;
+    const skipCapture = !this.openaiLogger;
     return {
       wrap: <T>(fn: () => Promise<T>): Promise<T> =>
         skipCapture
@@ -384,7 +379,9 @@ export class LoggingContentGenerator implements ContentGenerator {
               captured = built;
             }, fn),
       resolve: async (req) =>
-        captured ?? (await this.buildOpenAIRequestForLogging(req)),
+        this.openaiLogger
+          ? (captured ?? (await this.buildOpenAIRequestForLogging(req)))
+          : undefined,
     };
   }
 
@@ -398,8 +395,9 @@ export class LoggingContentGenerator implements ContentGenerator {
     spanContext?: Context,
   ): AsyncGenerator<GenerateContentResponse> {
     const isInternal = isInternalPromptId(userPromptId);
-    // For internal prompts we only need the last usage metadata (for /stats);
-    // skip collecting full responses to avoid unnecessary memory overhead.
+    // Skip collecting full responses for internal prompts to avoid memory
+    // overhead, unless OpenAI file logging needs them.
+    const shouldCollectResponses = !isInternal || !!this.openaiLogger;
     const responses: GenerateContentResponse[] = [];
 
     // Track first-seen IDs so _logApiResponse/_logApiError have accurate
@@ -423,7 +421,7 @@ export class LoggingContentGenerator implements ContentGenerator {
         if (!firstModelVersion && response.modelVersion) {
           firstModelVersion = response.modelVersion;
         }
-        if (!isInternal) {
+        if (shouldCollectResponses) {
           responses.push(response);
         }
         if (response.usageMetadata) {
@@ -433,9 +431,9 @@ export class LoggingContentGenerator implements ContentGenerator {
       }
       // Only log successful API response if no error occurred
       const durationMs = Date.now() - startTime;
-      const consolidatedResponse = isInternal
-        ? undefined
-        : this.consolidateGeminiResponsesForLogging(responses);
+      const consolidatedResponse = shouldCollectResponses
+        ? this.consolidateGeminiResponsesForLogging(responses)
+        : undefined;
       runInSpan(() =>
         this.safelyLogApiResponse(
           firstResponseId,
@@ -443,14 +441,19 @@ export class LoggingContentGenerator implements ContentGenerator {
           firstModelVersion || model,
           userPromptId,
           lastUsageMetadata,
-          this.extractResponseText(consolidatedResponse),
+          isInternal
+            ? undefined
+            : this.extractResponseText(consolidatedResponse),
         ),
       );
-      if (!isInternal) {
-        await runInSpan(() =>
-          this.safelyLogOpenAIInteraction(openaiRequest, consolidatedResponse),
-        );
-      }
+      await runInSpan(() =>
+        this.safelyLogOpenAIInteraction(
+          openaiRequest,
+          consolidatedResponse,
+          undefined,
+          userPromptId,
+        ),
+      );
       terminalStatusAttempted = true;
       if (span) {
         safeSetStatus(span, { code: SpanStatusCode.OK });
@@ -466,11 +469,14 @@ export class LoggingContentGenerator implements ContentGenerator {
           userPromptId,
         ),
       );
-      if (!isInternal) {
-        await runInSpan(() =>
-          this.safelyLogOpenAIInteraction(openaiRequest, undefined, error),
-        );
-      }
+      await runInSpan(() =>
+        this.safelyLogOpenAIInteraction(
+          openaiRequest,
+          undefined,
+          error,
+          userPromptId,
+        ),
+      );
       terminalStatusAttempted = true;
       if (span) {
         safeSetStatus(span, {
@@ -553,6 +559,7 @@ export class LoggingContentGenerator implements ContentGenerator {
     openaiRequest: OpenAI.Chat.ChatCompletionCreateParams | undefined,
     response?: GenerateContentResponse,
     error?: unknown,
+    promptId?: string,
   ): Promise<void> {
     if (!this.openaiLogger || !openaiRequest) {
       return;
@@ -570,6 +577,7 @@ export class LoggingContentGenerator implements ContentGenerator {
         : error
           ? new Error(String(error))
           : undefined,
+      this.buildOpenAILogOptions(promptId),
     );
   }
 
@@ -577,12 +585,29 @@ export class LoggingContentGenerator implements ContentGenerator {
     openaiRequest: OpenAI.Chat.ChatCompletionCreateParams | undefined,
     response?: GenerateContentResponse,
     error?: unknown,
+    promptId?: string,
   ): Promise<void> {
     try {
-      await this.logOpenAIInteraction(openaiRequest, response, error);
+      await this.logOpenAIInteraction(openaiRequest, response, error, promptId);
     } catch (loggingError) {
       debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
     }
+  }
+
+  private buildOpenAILogOptions(
+    promptId: string | undefined,
+  ): OpenAILogInteractionOptions | undefined {
+    if (!isInternalPromptId(promptId)) {
+      return undefined;
+    }
+
+    return {
+      filenameTag: promptId,
+      metadata: {
+        promptId,
+        internalPrompt: true,
+      },
+    };
   }
 
   private convertGeminiResponseToOpenAIForLogging(

--- a/packages/core/src/utils/internalPromptIds.ts
+++ b/packages/core/src/utils/internalPromptIds.ts
@@ -26,7 +26,7 @@ const SIDE_QUERY_PROMPT_PREFIX = 'side-query:';
 /**
  * Returns true if the prompt_id belongs to an internal background operation
  * whose events should not be recorded to the chatRecordingService,
- * OpenAI logs, or other persistent stores visible in the UI.
+ * telemetry payloads, or other persistent stores visible in the UI.
  */
 export function isInternalPromptId(promptId: string | undefined): boolean {
   if (!promptId) return false;

--- a/packages/core/src/utils/openaiLogger.test.ts
+++ b/packages/core/src/utils/openaiLogger.test.ts
@@ -148,6 +148,40 @@ describe('OpenAILogger', () => {
       expect(fileExists).toBe(true);
     });
 
+    it('should include sanitized filename tag and metadata when provided', async () => {
+      const logger = new OpenAILogger(testTempDir);
+      await logger.initialize();
+
+      const request = {
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'test' }],
+      };
+      const response = { id: 'test-id', choices: [] };
+
+      const logPath = await logger.logInteraction(
+        request,
+        response,
+        undefined,
+        {
+          filenameTag: 'side-query:session-title',
+          metadata: {
+            promptId: 'side-query:session-title',
+            internalPrompt: true,
+          },
+        },
+      );
+
+      expect(path.basename(logPath)).toMatch(
+        /openai-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z-[a-f0-9]{8}-side-query-session-title\.json/,
+      );
+
+      const logContent = JSON.parse(await fs.readFile(logPath, 'utf-8'));
+      expect(logContent.metadata).toEqual({
+        promptId: 'side-query:session-title',
+        internalPrompt: true,
+      });
+    });
+
     it('should write correct log data structure', async () => {
       const logger = new OpenAILogger(testTempDir);
       await logger.initialize();

--- a/packages/core/src/utils/openaiLogger.test.ts
+++ b/packages/core/src/utils/openaiLogger.test.ts
@@ -148,7 +148,7 @@ describe('OpenAILogger', () => {
       expect(fileExists).toBe(true);
     });
 
-    it('should include sanitized filename tag and metadata when provided', async () => {
+    it('should include sanitized internal prompt id suffix when provided', async () => {
       const logger = new OpenAILogger(testTempDir);
       await logger.initialize();
 
@@ -162,13 +162,7 @@ describe('OpenAILogger', () => {
         request,
         response,
         undefined,
-        {
-          filenameTag: 'side-query:session-title',
-          metadata: {
-            promptId: 'side-query:session-title',
-            internalPrompt: true,
-          },
-        },
+        'side-query:session-title',
       );
 
       expect(path.basename(logPath)).toMatch(
@@ -176,10 +170,29 @@ describe('OpenAILogger', () => {
       );
 
       const logContent = JSON.parse(await fs.readFile(logPath, 'utf-8'));
-      expect(logContent.metadata).toEqual({
-        promptId: 'side-query:session-title',
-        internalPrompt: true,
-      });
+      expect(logContent).not.toHaveProperty('metadata');
+    });
+
+    it('should not include a filename suffix for non-internal prompt ids', async () => {
+      const logger = new OpenAILogger(testTempDir);
+      await logger.initialize();
+
+      const request = {
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'test' }],
+      };
+      const response = { id: 'test-id', choices: [] };
+
+      const logPath = await logger.logInteraction(
+        request,
+        response,
+        undefined,
+        'user_query',
+      );
+
+      expect(path.basename(logPath)).toMatch(
+        /openai-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z-[a-f0-9]{8}\.json/,
+      );
     });
 
     it('should write correct log data structure', async () => {

--- a/packages/core/src/utils/openaiLogger.ts
+++ b/packages/core/src/utils/openaiLogger.ts
@@ -12,6 +12,19 @@ import { createDebugLogger } from './debugLogger.js';
 
 const debugLogger = createDebugLogger('OPENAI_LOGGER');
 
+export interface OpenAILogInteractionOptions {
+  filenameTag?: string;
+  metadata?: Record<string, unknown>;
+}
+
+function sanitizeFilenameTag(tag: string | undefined): string | undefined {
+  if (!tag) return undefined;
+  const sanitized = tag
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return sanitized || undefined;
+}
+
 /**
  * Logger specifically for OpenAI API requests and responses
  */
@@ -70,6 +83,7 @@ export class OpenAILogger {
     request: unknown,
     response?: unknown,
     error?: Error,
+    options?: OpenAILogInteractionOptions,
   ): Promise<string> {
     if (!this.initialized) {
       await this.initialize();
@@ -77,11 +91,15 @@ export class OpenAILogger {
 
     const timestamp = new Date().toISOString().replace(/:/g, '-');
     const id = uuidv4().slice(0, 8);
-    const filename = `openai-${timestamp}-${id}.json`;
+    const filenameTag = sanitizeFilenameTag(options?.filenameTag);
+    const filename = filenameTag
+      ? `openai-${timestamp}-${id}-${filenameTag}.json`
+      : `openai-${timestamp}-${id}.json`;
     const filePath = path.join(this.logDir, filename);
 
     const logData = {
       timestamp: new Date().toISOString(),
+      ...(options?.metadata ? { metadata: options.metadata } : {}),
       request,
       response: response || null,
       error: error

--- a/packages/core/src/utils/openaiLogger.ts
+++ b/packages/core/src/utils/openaiLogger.ts
@@ -9,17 +9,15 @@ import { promises as fs } from 'node:fs';
 import { v4 as uuidv4 } from 'uuid';
 import * as os from 'os';
 import { createDebugLogger } from './debugLogger.js';
+import { isInternalPromptId } from './internalPromptIds.js';
 
 const debugLogger = createDebugLogger('OPENAI_LOGGER');
 
-export interface OpenAILogInteractionOptions {
-  filenameTag?: string;
-  metadata?: Record<string, unknown>;
-}
-
-function sanitizeFilenameTag(tag: string | undefined): string | undefined {
-  if (!tag) return undefined;
-  const sanitized = tag
+function sanitizePromptIdForFilename(
+  promptId: string | undefined,
+): string | undefined {
+  if (!promptId || !isInternalPromptId(promptId)) return undefined;
+  const sanitized = promptId
     .replace(/[^a-zA-Z0-9._-]+/g, '-')
     .replace(/^-+|-+$/g, '');
   return sanitized || undefined;
@@ -77,13 +75,15 @@ export class OpenAILogger {
    * @param request The request sent to OpenAI
    * @param response The response received from OpenAI
    * @param error Optional error if the request failed
+   * @param promptId Optional prompt id; internal prompt ids are appended to
+   *                 the filename after timestamp and id.
    * @returns The file path where the log was written
    */
   async logInteraction(
     request: unknown,
     response?: unknown,
     error?: Error,
-    options?: OpenAILogInteractionOptions,
+    promptId?: string,
   ): Promise<string> {
     if (!this.initialized) {
       await this.initialize();
@@ -91,15 +91,14 @@ export class OpenAILogger {
 
     const timestamp = new Date().toISOString().replace(/:/g, '-');
     const id = uuidv4().slice(0, 8);
-    const filenameTag = sanitizeFilenameTag(options?.filenameTag);
-    const filename = filenameTag
-      ? `openai-${timestamp}-${id}-${filenameTag}.json`
+    const promptIdSuffix = sanitizePromptIdForFilename(promptId);
+    const filename = promptIdSuffix
+      ? `openai-${timestamp}-${id}-${promptIdSuffix}.json`
       : `openai-${timestamp}-${id}.json`;
     const filePath = path.join(this.logDir, filename);
 
     const logData = {
       timestamp: new Date().toISOString(),
-      ...(options?.metadata ? { metadata: options.metadata } : {}),
       request,
       response: response || null,
       error: error


### PR DESCRIPTION
## Summary

- What changed: OpenAI JSON request/response file logging now records internal background prompts when explicit OpenAI file logging is enabled. These diagnostic files include a sanitized prompt id suffix in the filename so side queries can be identified while preserving chronological filename sorting.
- Why it changed: https://github.com/QwenLM/qwen-code/pull/2872 correctly filtered internal prompts out of UI-visible recording paths to avoid leaking background activity into chat history and replay surfaces. OpenAI JSON request/response files are a separate explicit troubleshooting sink, not a UI replay source, so dropping side-query traffic makes issues like `/rename --auto` harder to debug without improving UI privacy.
- Reviewer focus: Please verify that UI-facing request logs and internal response text remain suppressed, while OpenAI JSON file logging captures internal prompt request/response/error details only when that file logger is enabled.

## Validation

- Commands run: `cd packages/core && npx vitest run src/utils/openaiLogger.test.ts src/core/loggingContentGenerator/loggingContentGenerator.test.ts`; `npm run build && npm run typecheck`; `git diff --check`
- Prompts / inputs used: N/A
- Expected result: Internal prompts remain filtered from UI-visible logging paths, and explicit OpenAI JSON logging writes tagged internal prompt diagnostics.
- Observed result: Focused logging tests passed, build passed, typecheck passed, and diff whitespace checks passed.
- Quickest reviewer verification path: Run the focused Vitest command above and inspect the updated OpenAI JSON filename assertion for the timestamp/hash/tag order.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.): Focused tests reported 2 files passed and 64 tests passed.

## Scope / Risk

- Main risk or tradeoff: Internal prompt request/response JSON can now be written to explicit OpenAI diagnostic logs when that logging mode is enabled.
- Not covered / not validated: No end-to-end CLI run was added; this change is covered at the logging layer with focused unit tests.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Validated locally on macOS only.

## Linked Issues / Bugs

- Related: https://github.com/QwenLM/qwen-code/pull/2872