### PR TITLE
feat(cli): readline Ctrl+P/N for history and selection navigation

### DIFF
--- a/docs/users/reference/keyboard-shortcuts.md
+++ b/docs/users/reference/keyboard-shortcuts.md
@@ -19,35 +19,35 @@ This document lists the available keyboard shortcuts in Qwen Code.
 
 ## Input Prompt
 
-| Shortcut                                           | Description                                                                                                                         |
-| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `!`                                                | Toggle shell mode when the input is empty.                                                                                          |
-| `?`                                                | Toggle keyboard shortcuts display when the input is empty.                                                                          |
-| `\` (at end of line) + `Enter`                     | Insert a newline.                                                                                                                   |
-| `Down Arrow`                                       | Navigate down through the input history.                                                                                            |
-| `Enter`                                            | Submit the current prompt.                                                                                                          |
-| `Meta+Delete` / `Ctrl+Delete`                      | Delete the word to the right of the cursor.                                                                                         |
-| `Tab`                                              | Autocomplete the current suggestion if one exists.                                                                                  |
-| `Up Arrow`                                         | Navigate up through the input history.                                                                                              |
-| `Ctrl+A` / `Home`                                  | Move the cursor to the beginning of the line.                                                                                       |
-| `Ctrl+B` / `Left Arrow`                            | Move the cursor one character to the left.                                                                                          |
-| `Ctrl+C`                                           | Clear the input prompt                                                                                                              |
-| `Esc` (double press)                               | Clear the input prompt.                                                                                                             |
-| `Ctrl+D` / `Delete`                                | Delete the character to the right of the cursor.                                                                                    |
-| `Ctrl+E` / `End`                                   | Move the cursor to the end of the line.                                                                                             |
-| `Ctrl+F` / `Right Arrow`                           | Move the cursor one character to the right.                                                                                         |
-| `Ctrl+H` / `Backspace`                             | Delete the character to the left of the cursor.                                                                                     |
-| `Ctrl+K`                                           | Delete from the cursor to the end of the line.                                                                                      |
-| `Ctrl+Left Arrow` / `Meta+Left Arrow` / `Meta+B`   | Move the cursor one word to the left.                                                                                               |
-| `Ctrl+N`                                           | Navigate down through the input history.                                                                                            |
-| `Ctrl+P`                                           | Navigate up through the input history.                                                                                              |
-| `Ctrl+R`                                           | Reverse search through input/shell history.                                                                                         |
-| `Ctrl+Y`                                           | Retry the last failed request.                                                                                                      |
-| `Ctrl+Right Arrow` / `Meta+Right Arrow` / `Meta+F` | Move the cursor one word to the right.                                                                                              |
-| `Ctrl+U`                                           | Delete from the cursor to the beginning of the line.                                                                                |
-| `Ctrl+V` (Windows: `Alt+V`)                        | Paste clipboard content. If the clipboard contains an image, it will be saved and a reference to it will be inserted in the prompt. |
-| `Ctrl+W` / `Meta+Backspace` / `Ctrl+Backspace`     | Delete the word to the left of the cursor.                                                                                          |
-| `Ctrl+X` / `Meta+Enter`                            | Open the current input in an external editor.                                                                                       |
+| Shortcut                                           | Description                                                                                                                                                                       |
+| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `!`                                                | Toggle shell mode when the input is empty.                                                                                                                                        |
+| `?`                                                | Toggle keyboard shortcuts display when the input is empty.                                                                                                                        |
+| `\` (at end of line) + `Enter`                     | Insert a newline.                                                                                                                                                                 |
+| `Down Arrow`                                       | Navigate down through the input history.                                                                                                                                          |
+| `Enter`                                            | Submit the current prompt.                                                                                                                                                        |
+| `Meta+Delete` / `Ctrl+Delete`                      | Delete the word to the right of the cursor.                                                                                                                                       |
+| `Tab`                                              | Autocomplete the current suggestion if one exists.                                                                                                                                |
+| `Up Arrow`                                         | Navigate up through the input history.                                                                                                                                            |
+| `Ctrl+A` / `Home`                                  | Move the cursor to the beginning of the line.                                                                                                                                     |
+| `Ctrl+B` / `Left Arrow`                            | Move the cursor one character to the left.                                                                                                                                        |
+| `Ctrl+C`                                           | Clear the input prompt                                                                                                                                                            |
+| `Esc` (double press)                               | Clear the input prompt.                                                                                                                                                           |
+| `Ctrl+D` / `Delete`                                | Delete the character to the right of the cursor.                                                                                                                                  |
+| `Ctrl+E` / `End`                                   | Move the cursor to the end of the line.                                                                                                                                           |
+| `Ctrl+F` / `Right Arrow`                           | Move the cursor one character to the right.                                                                                                                                       |
+| `Ctrl+H` / `Backspace`                             | Delete the character to the left of the cursor.                                                                                                                                   |
+| `Ctrl+K`                                           | Delete from the cursor to the end of the line.                                                                                                                                    |
+| `Ctrl+Left Arrow` / `Meta+Left Arrow` / `Meta+B`   | Move the cursor one word to the left.                                                                                                                                             |
+| `Ctrl+N`                                           | In single-line input: navigate down through the input history. In multi-line input: move the cursor down one line; fall back to history navigation when already on the last line. |
+| `Ctrl+P`                                           | In single-line input: navigate up through the input history. In multi-line input: move the cursor up one line; fall back to history navigation when already on the first line.    |
+| `Ctrl+R`                                           | Reverse search through input/shell history.                                                                                                                                       |
+| `Ctrl+Y`                                           | Retry the last failed request.                                                                                                                                                    |
+| `Ctrl+Right Arrow` / `Meta+Right Arrow` / `Meta+F` | Move the cursor one word to the right.                                                                                                                                            |
+| `Ctrl+U`                                           | Delete from the cursor to the beginning of the line.                                                                                                                              |
+| `Ctrl+V` (Windows: `Alt+V`)                        | Paste clipboard content. If the clipboard contains an image, it will be saved and a reference to it will be inserted in the prompt.                                               |
+| `Ctrl+W` / `Meta+Backspace` / `Ctrl+Backspace`     | Delete the word to the left of the cursor.                                                                                                                                        |
+| `Ctrl+X` / `Meta+Enter`                            | Open the current input in an external editor.                                                                                                                                     |
 
 ## Suggestions
 
@@ -59,13 +59,13 @@ This document lists the available keyboard shortcuts in Qwen Code.
 
 ## Radio Button Select
 
-| Shortcut           | Description                                                                                                   |
-| ------------------ | ------------------------------------------------------------------------------------------------------------- |
-| `Down Arrow` / `j` | Move selection down.                                                                                          |
-| `Enter`            | Confirm selection.                                                                                            |
-| `Up Arrow` / `k`   | Move selection up.                                                                                            |
-| `1-9`              | Select an item by its number.                                                                                 |
-| (multi-digit)      | For items with numbers greater than 9, press the digits in quick succession to select the corresponding item. |
+| Shortcut                      | Description                                                                                                   |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `Down Arrow` / `j` / `Ctrl+N` | Move selection down.                                                                                          |
+| `Enter`                       | Confirm selection.                                                                                            |
+| `Up Arrow` / `k` / `Ctrl+P`   | Move selection up.                                                                                            |
+| `1-9`                         | Select an item by its number.                                                                                 |
+| (multi-digit)                 | For items with numbers greater than 9, press the digits in quick succession to select the corresponding item. |
 
 ## IDE Integration
 

--- a/docs/users/reference/keyboard-shortcuts.md
+++ b/docs/users/reference/keyboard-shortcuts.md
@@ -19,35 +19,35 @@ This document lists the available keyboard shortcuts in Qwen Code.
 
 ## Input Prompt
 
-| Shortcut                                           | Description                                                                                                                                                                       |
-| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `!`                                                | Toggle shell mode when the input is empty.                                                                                                                                        |
-| `?`                                                | Toggle keyboard shortcuts display when the input is empty.                                                                                                                        |
-| `\` (at end of line) + `Enter`                     | Insert a newline.                                                                                                                                                                 |
-| `Down Arrow`                                       | Navigate down through the input history.                                                                                                                                          |
-| `Enter`                                            | Submit the current prompt.                                                                                                                                                        |
-| `Meta+Delete` / `Ctrl+Delete`                      | Delete the word to the right of the cursor.                                                                                                                                       |
-| `Tab`                                              | Autocomplete the current suggestion if one exists.                                                                                                                                |
-| `Up Arrow`                                         | Navigate up through the input history.                                                                                                                                            |
-| `Ctrl+A` / `Home`                                  | Move the cursor to the beginning of the line.                                                                                                                                     |
-| `Ctrl+B` / `Left Arrow`                            | Move the cursor one character to the left.                                                                                                                                        |
-| `Ctrl+C`                                           | Clear the input prompt                                                                                                                                                            |
-| `Esc` (double press)                               | Clear the input prompt.                                                                                                                                                           |
-| `Ctrl+D` / `Delete`                                | Delete the character to the right of the cursor.                                                                                                                                  |
-| `Ctrl+E` / `End`                                   | Move the cursor to the end of the line.                                                                                                                                           |
-| `Ctrl+F` / `Right Arrow`                           | Move the cursor one character to the right.                                                                                                                                       |
-| `Ctrl+H` / `Backspace`                             | Delete the character to the left of the cursor.                                                                                                                                   |
-| `Ctrl+K`                                           | Delete from the cursor to the end of the line.                                                                                                                                    |
-| `Ctrl+Left Arrow` / `Meta+Left Arrow` / `Meta+B`   | Move the cursor one word to the left.                                                                                                                                             |
-| `Ctrl+N`                                           | In single-line input: navigate down through the input history. In multi-line input: move the cursor down one line; fall back to history navigation when already on the last line. |
-| `Ctrl+P`                                           | In single-line input: navigate up through the input history. In multi-line input: move the cursor up one line; fall back to history navigation when already on the first line.    |
-| `Ctrl+R`                                           | Reverse search through input/shell history.                                                                                                                                       |
-| `Ctrl+Y`                                           | Retry the last failed request.                                                                                                                                                    |
-| `Ctrl+Right Arrow` / `Meta+Right Arrow` / `Meta+F` | Move the cursor one word to the right.                                                                                                                                            |
-| `Ctrl+U`                                           | Delete from the cursor to the beginning of the line.                                                                                                                              |
-| `Ctrl+V` (Windows: `Alt+V`)                        | Paste clipboard content. If the clipboard contains an image, it will be saved and a reference to it will be inserted in the prompt.                                               |
-| `Ctrl+W` / `Meta+Backspace` / `Ctrl+Backspace`     | Delete the word to the left of the cursor.                                                                                                                                        |
-| `Ctrl+X` / `Meta+Enter`                            | Open the current input in an external editor.                                                                                                                                     |
+| Shortcut                                           | Description                                                                                                                         |
+| -------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `!`                                                | Toggle shell mode when the input is empty.                                                                                          |
+| `?`                                                | Toggle keyboard shortcuts display when the input is empty.                                                                          |
+| `\` (at end of line) + `Enter`                     | Insert a newline.                                                                                                                   |
+| `Down Arrow`                                       | Row down, then snap to end, then history next.                                                                                      |
+| `Enter`                                            | Submit the current prompt.                                                                                                          |
+| `Meta+Delete` / `Ctrl+Delete`                      | Delete the word to the right of the cursor.                                                                                         |
+| `Tab`                                              | Autocomplete the current suggestion if one exists.                                                                                  |
+| `Up Arrow`                                         | Row up, then snap to start, then history prev.                                                                                      |
+| `Ctrl+A` / `Home`                                  | Move the cursor to the beginning of the line.                                                                                       |
+| `Ctrl+B` / `Left Arrow`                            | Move the cursor one character to the left.                                                                                          |
+| `Ctrl+C`                                           | Clear the input prompt                                                                                                              |
+| `Esc` (double press)                               | Clear the input prompt.                                                                                                             |
+| `Ctrl+D` / `Delete`                                | Delete the character to the right of the cursor.                                                                                    |
+| `Ctrl+E` / `End`                                   | Move the cursor to the end of the line.                                                                                             |
+| `Ctrl+F` / `Right Arrow`                           | Move the cursor one character to the right.                                                                                         |
+| `Ctrl+H` / `Backspace`                             | Delete the character to the left of the cursor.                                                                                     |
+| `Ctrl+K`                                           | Delete from the cursor to the end of the line.                                                                                      |
+| `Ctrl+Left Arrow` / `Meta+Left Arrow` / `Meta+B`   | Move the cursor one word to the left.                                                                                               |
+| `Ctrl+N`                                           | Row down, then snap to end, then history next.                                                                                      |
+| `Ctrl+P`                                           | Row up, then snap to start, then history prev.                                                                                      |
+| `Ctrl+R`                                           | Reverse search through input/shell history.                                                                                         |
+| `Ctrl+Y`                                           | Retry the last failed request.                                                                                                      |
+| `Ctrl+Right Arrow` / `Meta+Right Arrow` / `Meta+F` | Move the cursor one word to the right.                                                                                              |
+| `Ctrl+U`                                           | Delete from the cursor to the beginning of the line.                                                                                |
+| `Ctrl+V` (Windows: `Alt+V`)                        | Paste clipboard content. If the clipboard contains an image, it will be saved and a reference to it will be inserted in the prompt. |
+| `Ctrl+W` / `Meta+Backspace` / `Ctrl+Backspace`     | Delete the word to the left of the cursor.                                                                                          |
+| `Ctrl+X` / `Meta+Enter`                            | Open the current input in an external editor.                                                                                       |
 
 ## Suggestions
 

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -31,6 +31,10 @@ export enum Command {
   NAVIGATION_UP = 'navigationUp',
   NAVIGATION_DOWN = 'navigationDown',
 
+  // Selection list navigation (dialogs, menus)
+  SELECTION_UP = 'selectionUp',
+  SELECTION_DOWN = 'selectionDown',
+
   // Auto-completion
   ACCEPT_SUGGESTION = 'acceptSuggestion',
   COMPLETION_UP = 'completionUp',
@@ -131,10 +135,22 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.NAVIGATION_UP]: [{ key: 'up' }],
   [Command.NAVIGATION_DOWN]: [{ key: 'down' }],
 
+  // Selection list navigation — up/k/Ctrl+P move selection up; down/j/Ctrl+N move selection down
+  // ctrl: false on k/j ensures Ctrl+K (kill-line) and Ctrl+N (history-down) are not captured here
+  [Command.SELECTION_UP]: [
+    { key: 'up' },
+    { key: 'k', ctrl: false },
+    { key: 'p', ctrl: true },
+  ],
+  [Command.SELECTION_DOWN]: [
+    { key: 'down' },
+    { key: 'j', ctrl: false },
+    { key: 'n', ctrl: true },
+  ],
+
   // Auto-completion
   [Command.ACCEPT_SUGGESTION]: [{ key: 'tab' }, { key: 'return', ctrl: false }],
   // Completion navigation uses only arrow keys
-  // Ctrl+P/N are reserved for history navigation (HISTORY_UP/DOWN)
   [Command.COMPLETION_UP]: [{ key: 'up' }],
   [Command.COMPLETION_DOWN]: [{ key: 'down' }],
 

--- a/packages/cli/src/config/keyBindings.ts
+++ b/packages/cli/src/config/keyBindings.ts
@@ -135,8 +135,8 @@ export const defaultKeyBindings: KeyBindingConfig = {
   [Command.NAVIGATION_UP]: [{ key: 'up' }],
   [Command.NAVIGATION_DOWN]: [{ key: 'down' }],
 
-  // Selection list navigation — up/k/Ctrl+P move selection up; down/j/Ctrl+N move selection down
-  // ctrl: false on k/j ensures Ctrl+K (kill-line) and Ctrl+N (history-down) are not captured here
+  // Selection-list nav: arrows + k/j + Ctrl+P/Ctrl+N
+  // ctrl: false on bare k/j skips Ctrl+K and Ctrl+J
   [Command.SELECTION_UP]: [
     { key: 'up' },
     { key: 'k', ctrl: false },

--- a/packages/cli/src/ui/auth/ProviderSetupSteps.test.tsx
+++ b/packages/cli/src/ui/auth/ProviderSetupSteps.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderWithProviders } from '../../test-utils/render.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AuthType } from '@qwen-code/qwen-code-core';
+import type { KeypressHandler, Key } from '../contexts/KeypressContext.js';
+import { useKeypress } from '../hooks/useKeypress.js';
+import { ProviderSetupSteps } from './ProviderSetupSteps.js';
+import type { ProviderSetupFlow } from './useProviderSetupFlow.js';
+
+type UseKeypressMockOptions = { isActive: boolean };
+
+vi.mock('../hooks/useKeypress.js');
+
+let activeKeypressHandler: KeypressHandler | null = null;
+
+describe('ProviderSetupSteps', () => {
+  beforeEach(() => {
+    activeKeypressHandler = null;
+    vi.mocked(useKeypress).mockImplementation(
+      (handler: KeypressHandler, options?: UseKeypressMockOptions) => {
+        if (options?.isActive) {
+          activeKeypressHandler = handler;
+        }
+      },
+    );
+  });
+
+  const pressKey = (
+    name: string,
+    sequence: string = name,
+    overrides: Partial<Key> = {},
+  ) => {
+    if (!activeKeypressHandler) {
+      throw new Error(`No active keypress handler for ${name}`);
+    }
+    activeKeypressHandler({
+      name,
+      sequence,
+      ctrl: false,
+      meta: false,
+      shift: false,
+      paste: false,
+      ...overrides,
+    });
+  };
+
+  const createAdvancedConfigFlow = (): ProviderSetupFlow => {
+    const noop = vi.fn();
+    return {
+      state: {
+        provider: {
+          name: 'Custom',
+          authType: AuthType.USE_OPENAI,
+          protocol: AuthType.USE_OPENAI,
+          showAdvancedConfig: true,
+        },
+        step: 'advancedConfig',
+        stepIndex: 0,
+        totalSteps: 1,
+        protocol: AuthType.USE_OPENAI,
+        baseUrl: '',
+        baseUrlOptionIndex: 0,
+        baseUrlError: null,
+        apiKey: '',
+        apiKeyError: null,
+        modelIds: '',
+        modelIdsError: null,
+        thinkingEnabled: false,
+        modalityEnabled: false,
+        modalityImage: true,
+        modalityVideo: true,
+        modalityAudio: true,
+        modalityPdf: false,
+        contextWindowSize: '',
+        focusedConfigIndex: 0,
+        previewJson: '',
+      },
+      start: noop,
+      reset: noop,
+      goBack: noop,
+      selectProtocol: noop,
+      selectBaseUrl: noop,
+      highlightBaseUrl: noop,
+      submitBaseUrl: noop,
+      changeBaseUrl: noop,
+      changeApiKey: noop,
+      submitApiKey: noop,
+      changeModelIds: noop,
+      submitModelIds: noop,
+      moveAdvancedFocusUp: vi.fn(),
+      moveAdvancedFocusDown: vi.fn(),
+      toggleFocusedAdvancedOption: noop,
+      changeContextWindowSize: noop,
+      submitAdvancedConfig: noop,
+      submit: noop,
+    } as unknown as ProviderSetupFlow;
+  };
+
+  it('maps Ctrl+P/N to advanced-config focus navigation', () => {
+    const flow = createAdvancedConfigFlow();
+
+    const { unmount } = renderWithProviders(<ProviderSetupSteps flow={flow} />);
+
+    pressKey('p', '\u0010', { ctrl: true });
+    pressKey('n', '\u000E', { ctrl: true });
+
+    expect(flow.moveAdvancedFocusUp).toHaveBeenCalledTimes(1);
+    expect(flow.moveAdvancedFocusDown).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+});

--- a/packages/cli/src/ui/auth/ProviderSetupSteps.tsx
+++ b/packages/cli/src/ui/auth/ProviderSetupSteps.tsx
@@ -396,11 +396,18 @@ export function ProviderSetupSteps({
   useKeypress(
     (key) => {
       if (step === 'advancedConfig') {
-        if (key.name === 'up') {
+        // The context-window row has an embedded TextInput that's conditionally
+        // active. Restrict the focus-row navigation to unambiguous shortcuts —
+        // arrow keys and the readline-style Ctrl+P/Ctrl+N — so typing a letter
+        // into the context-window field never simultaneously moves the focus.
+        const isFocusUp = key.name === 'up' || (key.ctrl && key.name === 'p');
+        const isFocusDown =
+          key.name === 'down' || (key.ctrl && key.name === 'n');
+        if (isFocusUp) {
           flow.moveAdvancedFocusUp();
           return;
         }
-        if (key.name === 'down') {
+        if (isFocusDown) {
           flow.moveAdvancedFocusDown();
           return;
         }

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -2892,6 +2892,37 @@ describe('InputPrompt', () => {
 
       unmount();
     });
+
+    it('does not fall through to shell history on Ctrl+P/N while reverse search is active', async () => {
+      const getPreviousCommand = vi.fn();
+      const getNextCommand = vi.fn();
+      vi.mocked(useShellHistory).mockReturnValue({
+        history: ['echo hello', 'echo world', 'ls'],
+        getPreviousCommand,
+        getNextCommand,
+        addCommandToHistory: vi.fn(),
+        resetHistoryPosition: vi.fn(),
+      });
+
+      const { stdin, stdout, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\x12'); // Ctrl+R
+      await wait();
+      expect(stdout.lastFrame()).toContain('(r:)');
+
+      stdin.write('\u0010'); // Ctrl+P
+      await wait();
+      stdin.write('\u000E'); // Ctrl+N
+      await wait();
+
+      expect(getPreviousCommand).not.toHaveBeenCalled();
+      expect(getNextCommand).not.toHaveBeenCalled();
+      expect(stdout.lastFrame()).toContain('(r:)');
+      unmount();
+    });
   });
 
   describe('Ctrl+E keyboard shortcut', () => {

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -144,6 +144,8 @@ describe('InputPrompt', () => {
         mockBuffer.viewportVisualLines = [newText];
         mockBuffer.allVisualLines = [newText];
         mockBuffer.visualToLogicalMap = [[0, 0]];
+        // Mirror real buffer: setText positions cursor at end of last visual line
+        mockBuffer.visualCursor = [0, newText.length];
       }),
       replaceRangeByOffset: vi.fn(),
       viewportVisualLines: [''],
@@ -375,8 +377,12 @@ describe('InputPrompt', () => {
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);
     await wait();
 
+    // Two-step edge: pre-position cursor at col 0 so Up directly triggers history
+    mockBuffer.visualCursor = [0, 0];
     stdin.write('\u001B[A'); // Up arrow
     await wait();
+    // Pre-position cursor at end so Down directly triggers history
+    mockBuffer.visualCursor = [0, 'some text'.length];
     stdin.write('\u001B[B'); // Down arrow
     await wait();
     stdin.write('\r'); // Enter
@@ -414,6 +420,8 @@ describe('InputPrompt', () => {
     expect(mockCommandCompletion.navigateDown).not.toHaveBeenCalled();
 
     // Ctrl+P should navigate history, not completion
+    // Two-step edge: pre-position cursor at col 0 so Ctrl+P directly triggers history
+    mockBuffer.visualCursor = [0, 0];
     stdin.write('\u0010'); // Ctrl+P
     await wait();
     expect(mockCommandCompletion.navigateUp).toHaveBeenCalledTimes(1);
@@ -1270,6 +1278,8 @@ describe('InputPrompt', () => {
     const TestHarness = () => {
       const buffer = useTextBuffer({
         initialText: '/export md',
+        // Two-step edge: position cursor at end so Down directly triggers history
+        initialCursorOffset: '/export md'.length,
         viewport: { width: 80, height: 20 },
         isValidPath: () => false,
         onChange: () => {},
@@ -3660,6 +3670,96 @@ describe('InputPrompt', () => {
       await wait();
 
       expect(mockInputHistory.navigateUp).toHaveBeenCalled();
+      unmount();
+    });
+  });
+
+  // Two-step edge transition: Ctrl+P / Ctrl+N (and arrow ↑/↓) in a non-empty
+  // buffer first snap the cursor to col 0 (Up) or end-of-line (Down) when the
+  // cursor isn't already at that edge, and only on a *second* press do they
+  // walk the input history. This mirrors readline / Claude Code parity called
+  // out in issue #3821. Multi-line transition between visual rows is covered
+  // end-to-end via manual testing (see contributions/3821-readline-shortcuts/
+  // demo.md cases 2 & 3); the unit tests below exercise the single-visual-row
+  // edges where the mock buffer's view of the world is self-consistent.
+  describe('two-step edge transition for history navigation', () => {
+    it('Ctrl+P with cursor mid-line snaps to col 0 without touching history', async () => {
+      // setText('hello') puts the mock's visualCursor at the end of 'hello'.
+      // From that position pressing Ctrl+P should first move cursor to col 0;
+      // it must NOT navigate history on this press.
+      mockBuffer.setText('hello');
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\u0010'); // Ctrl+P
+      await wait();
+
+      expect(mockBuffer.move).toHaveBeenCalledWith('home');
+      expect(mockInputHistory.navigateUp).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('Ctrl+N with cursor not at end-of-line snaps to end without touching history', async () => {
+      // Manually park the cursor at col 0 (as if a prior Ctrl+P just loaded a
+      // history entry, which lands cursor at offset 0). Pressing Ctrl+N now
+      // should first jump cursor to end-of-line, not navigate history.
+      mockBuffer.setText('hello');
+      mockBuffer.visualCursor = [0, 0]; // simulate "just loaded older history"
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\u000E'); // Ctrl+N
+      await wait();
+
+      expect(mockBuffer.move).toHaveBeenCalledWith('end');
+      expect(mockInputHistory.navigateDown).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('Ctrl+P at col 0 walks history and parks the cursor at offset 0', async () => {
+      // navigateUp returns boolean true on a real history move. We model that
+      // here so the post-navigation moveToOffset(0) side-effect (the "cursor
+      // at start of the restored older entry" rule) is observable.
+      mockInputHistory.navigateUp.mockReturnValue(true);
+      mockBuffer.setText('current draft');
+      mockBuffer.visualCursor = [0, 0];
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\u0010'); // Ctrl+P
+      await wait();
+
+      expect(mockInputHistory.navigateUp).toHaveBeenCalled();
+      // Readline "previous-history" lands the cursor at the start of the
+      // restored entry.
+      expect(mockBuffer.moveToOffset).toHaveBeenCalledWith(0);
+      unmount();
+    });
+
+    it('arrow Up applies the same two-step rule as Ctrl+P (snap before navigate)', async () => {
+      // The arrow-key history path lives alongside Ctrl+P in InputPrompt.tsx
+      // and the two must stay in lock-step. This test pins the parity so a
+      // future refactor that diverges them will fail.
+      mockBuffer.setText('hello'); // cursor at end via patched setText mock
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\u001B[A'); // Up arrow
+      await wait();
+
+      expect(mockBuffer.move).toHaveBeenCalledWith('home');
+      expect(mockInputHistory.navigateUp).not.toHaveBeenCalled();
       unmount();
     });
   });

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -14,7 +14,7 @@ import { ApprovalMode } from '@qwen-code/qwen-code-core';
 import * as path from 'node:path';
 import type { CommandContext, SlashCommand } from '../commands/types.js';
 import { CommandKind } from '../commands/types.js';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 import type { UseShellHistoryReturn } from '../hooks/useShellHistory.js';
 import { useShellHistory } from '../hooks/useShellHistory.js';
 import type { UseCommandCompletionReturn } from '../hooks/useCommandCompletion.js';
@@ -3809,7 +3809,7 @@ describe('InputPrompt', () => {
       // navigateUp returns boolean true on a real history move. We model that
       // here so the post-navigation moveToOffset(0) side-effect (the "cursor
       // at start of the restored older entry" rule) is observable.
-      mockInputHistory.navigateUp.mockReturnValue(true);
+      (mockInputHistory.navigateUp as Mock).mockReturnValue(true);
       mockBuffer.setText('current draft');
       mockBuffer.visualCursor = [0, 0];
 
@@ -3828,7 +3828,7 @@ describe('InputPrompt', () => {
       unmount();
     });
 
-    it('Ctrl+P/N do not change input history while a tool confirmation owns navigation', async () => {
+    it('Ctrl+P/N and arrows do not change input history while a tool confirmation owns navigation', async () => {
       mockedUseUIState.mockReturnValue({
         isFeedbackDialogOpen: false,
         messageQueue: [],
@@ -3855,6 +3855,10 @@ describe('InputPrompt', () => {
       await wait();
       stdin.write('\u000E'); // Ctrl+N
       await wait();
+      stdin.write('\u001B[A'); // Up arrow
+      await wait();
+      stdin.write('\u001B[B'); // Down arrow
+      await wait();
 
       expect(mockInputHistory.navigateUp).not.toHaveBeenCalled();
       expect(mockInputHistory.navigateDown).not.toHaveBeenCalled();
@@ -3862,7 +3866,7 @@ describe('InputPrompt', () => {
     });
 
     it('Ctrl+N falls through to the agent tab bar when there is no newer history', async () => {
-      mockInputHistory.navigateDown.mockReturnValue(false);
+      (mockInputHistory.navigateDown as Mock).mockReturnValue(false);
       mockedUseAgentViewState.mockReturnValue({
         activeView: 'main',
         agents: new Map([['agent-1', {}]]),
@@ -3880,6 +3884,67 @@ describe('InputPrompt', () => {
       await wait();
 
       stdin.write('\u000E'); // Ctrl+N
+      await wait();
+
+      expect(mockInputHistory.navigateDown).toHaveBeenCalled();
+      expect(mockViewActions.setAgentTabBarFocused).toHaveBeenCalledWith(true);
+      unmount();
+    });
+
+    it('arrow Down applies the same snap-before-history rule as Ctrl+N', async () => {
+      mockBuffer.setText('hello');
+      mockBuffer.visualCursor = [0, 0];
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\u001B[B'); // Down arrow
+      await wait();
+
+      expect(mockBuffer.move).toHaveBeenCalledWith('end');
+      expect(mockInputHistory.navigateDown).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('arrow Down at end-of-line walks history', async () => {
+      (mockInputHistory.navigateDown as Mock).mockReturnValue(true);
+      mockBuffer.setText('current draft');
+      mockBuffer.visualCursor = [0, 'current draft'.length];
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\u001B[B'); // Down arrow
+      await wait();
+
+      expect(mockInputHistory.navigateDown).toHaveBeenCalled();
+      expect(mockViewActions.setAgentTabBarFocused).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('arrow Down falls through to the agent tab bar when there is no newer history', async () => {
+      (mockInputHistory.navigateDown as Mock).mockReturnValue(false);
+      mockedUseAgentViewState.mockReturnValue({
+        activeView: 'main',
+        agents: new Map([['agent-1', {}]]),
+        agentShellFocused: false,
+        agentInputBufferText: '',
+        agentTabBarFocused: false,
+        agentApprovalModes: new Map(),
+      } as unknown as ReturnType<typeof useAgentViewState>);
+      mockBuffer.setText('draft');
+      mockBuffer.visualCursor = [0, 'draft'.length];
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\u001B[B'); // Down arrow
       await wait();
 
       expect(mockInputHistory.navigateDown).toHaveBeenCalled();

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -29,6 +29,19 @@ import stripAnsi from 'strip-ansi';
 import chalk from 'chalk';
 import { useUIState } from '../contexts/UIStateContext.js';
 import { useUIActions } from '../contexts/UIActionsContext.js';
+import {
+  useAgentViewActions,
+  useAgentViewState,
+} from '../contexts/AgentViewContext.js';
+import {
+  useBackgroundTaskViewActions,
+  useBackgroundTaskViewState,
+} from '../contexts/BackgroundTaskViewContext.js';
+
+const mockViewActions = vi.hoisted(() => ({
+  setAgentTabBarFocused: vi.fn(),
+  setBgPillFocused: vi.fn(),
+}));
 
 vi.mock('../hooks/useShellHistory.js');
 vi.mock('../hooks/useCommandCompletion.js');
@@ -43,6 +56,31 @@ vi.mock('../contexts/UIActionsContext.js', () => ({
     handleRetryLastPrompt: vi.fn(),
     temporaryCloseFeedbackDialog: vi.fn(),
     popAllQueuedMessages: vi.fn(() => null),
+  })),
+}));
+vi.mock('../contexts/AgentViewContext.js', () => ({
+  useAgentViewState: vi.fn(() => ({
+    activeView: 'main',
+    agents: new Map(),
+    agentShellFocused: false,
+    agentInputBufferText: '',
+    agentTabBarFocused: false,
+    agentApprovalModes: new Map(),
+  })),
+  useAgentViewActions: vi.fn(() => ({
+    setAgentTabBarFocused: mockViewActions.setAgentTabBarFocused,
+  })),
+}));
+vi.mock('../contexts/BackgroundTaskViewContext.js', () => ({
+  useBackgroundTaskViewState: vi.fn(() => ({
+    entries: [],
+    selectedIndex: 0,
+    dialogMode: 'closed',
+    dialogOpen: false,
+    pillFocused: false,
+  })),
+  useBackgroundTaskViewActions: vi.fn(() => ({
+    setPillFocused: mockViewActions.setBgPillFocused,
   })),
 }));
 
@@ -124,12 +162,56 @@ describe('InputPrompt', () => {
   const mockedUseShellHistory = vi.mocked(useShellHistory);
   const mockedUseCommandCompletion = vi.mocked(useCommandCompletion);
   const mockedUseInputHistory = vi.mocked(useInputHistory);
+  const mockedUseUIState = vi.mocked(useUIState);
+  const mockedUseUIActions = vi.mocked(useUIActions);
+  const mockedUseAgentViewState = vi.mocked(useAgentViewState);
+  const mockedUseAgentViewActions = vi.mocked(useAgentViewActions);
+  const mockedUseBackgroundTaskViewState = vi.mocked(
+    useBackgroundTaskViewState,
+  );
+  const mockedUseBackgroundTaskViewActions = vi.mocked(
+    useBackgroundTaskViewActions,
+  );
   const mockedUseReverseSearchCompletion = vi.mocked(
     useReverseSearchCompletion,
   );
 
   beforeEach(() => {
     vi.resetAllMocks();
+    mockViewActions.setAgentTabBarFocused.mockReset();
+    mockViewActions.setBgPillFocused.mockReset();
+
+    mockedUseUIState.mockReturnValue({
+      isFeedbackDialogOpen: false,
+      messageQueue: [],
+      pendingGeminiHistoryItems: [],
+    } as unknown as ReturnType<typeof useUIState>);
+    mockedUseUIActions.mockReturnValue({
+      handleRetryLastPrompt: vi.fn(),
+      temporaryCloseFeedbackDialog: vi.fn(),
+      popAllQueuedMessages: vi.fn(() => null),
+    } as unknown as ReturnType<typeof useUIActions>);
+    mockedUseAgentViewState.mockReturnValue({
+      activeView: 'main',
+      agents: new Map(),
+      agentShellFocused: false,
+      agentInputBufferText: '',
+      agentTabBarFocused: false,
+      agentApprovalModes: new Map(),
+    });
+    mockedUseAgentViewActions.mockReturnValue({
+      setAgentTabBarFocused: mockViewActions.setAgentTabBarFocused,
+    } as unknown as ReturnType<typeof useAgentViewActions>);
+    mockedUseBackgroundTaskViewState.mockReturnValue({
+      entries: [],
+      selectedIndex: 0,
+      dialogMode: 'closed',
+      dialogOpen: false,
+      pillFocused: false,
+    });
+    mockedUseBackgroundTaskViewActions.mockReturnValue({
+      setPillFocused: mockViewActions.setBgPillFocused,
+    } as unknown as ReturnType<typeof useBackgroundTaskViewActions>);
 
     mockCommandContext = createMockCommandContext();
 
@@ -451,6 +533,8 @@ describe('InputPrompt', () => {
     expect(mockCommandCompletion.navigateUp).not.toHaveBeenCalled();
 
     // Ctrl+N should navigate history, not completion
+    // Two-step edge: pre-position cursor at end so Ctrl+N directly triggers history
+    mockBuffer.visualCursor = [0, '/mem'.length];
     stdin.write('\u000E'); // Ctrl+N
     await wait();
     expect(mockCommandCompletion.navigateDown).toHaveBeenCalledTimes(1);
@@ -3741,6 +3825,65 @@ describe('InputPrompt', () => {
       // Readline "previous-history" lands the cursor at the start of the
       // restored entry.
       expect(mockBuffer.moveToOffset).toHaveBeenCalledWith(0);
+      unmount();
+    });
+
+    it('Ctrl+P/N do not change input history while a tool confirmation owns navigation', async () => {
+      mockedUseUIState.mockReturnValue({
+        isFeedbackDialogOpen: false,
+        messageQueue: [],
+        pendingGeminiHistoryItems: [
+          {
+            type: 'tool_group',
+            tools: [
+              {
+                confirmationDetails: { type: 'ask_user_question' },
+              },
+            ],
+          },
+        ],
+      } as unknown as ReturnType<typeof useUIState>);
+      mockBuffer.setText('draft');
+      mockBuffer.visualCursor = [0, 'draft'.length];
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\u0010'); // Ctrl+P
+      await wait();
+      stdin.write('\u000E'); // Ctrl+N
+      await wait();
+
+      expect(mockInputHistory.navigateUp).not.toHaveBeenCalled();
+      expect(mockInputHistory.navigateDown).not.toHaveBeenCalled();
+      unmount();
+    });
+
+    it('Ctrl+N falls through to the agent tab bar when there is no newer history', async () => {
+      mockInputHistory.navigateDown.mockReturnValue(false);
+      mockedUseAgentViewState.mockReturnValue({
+        activeView: 'main',
+        agents: new Map([['agent-1', {}]]),
+        agentShellFocused: false,
+        agentInputBufferText: '',
+        agentTabBarFocused: false,
+        agentApprovalModes: new Map(),
+      } as unknown as ReturnType<typeof useAgentViewState>);
+      mockBuffer.setText('draft');
+      mockBuffer.visualCursor = [0, 'draft'.length];
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      stdin.write('\u000E'); // Ctrl+N
+      await wait();
+
+      expect(mockInputHistory.navigateDown).toHaveBeenCalled();
+      expect(mockViewActions.setAgentTabBarFocused).toHaveBeenCalledWith(true);
       unmount();
     });
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -968,10 +968,41 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         }
 
         if (keyMatchers[Command.HISTORY_UP](key)) {
-          inputHistory.navigateUp();
+          // Two-step edge transition (matches Claude Code):
+          // 1. If not on first visual row → move cursor up one row
+          // 2. Else if cursor not at col 0 → snap to col 0 (no history change)
+          // 3. Else → navigate to older history; cursor lands at offset 0
+          const onFirstRow =
+            buffer.visualCursor[0] === 0 && buffer.visualScrollRow === 0;
+          if (!onFirstRow) {
+            buffer.move('up');
+            return true;
+          }
+          if (buffer.visualCursor[1] > 0) {
+            buffer.move('home');
+            return true;
+          }
+          if (inputHistory.navigateUp()) {
+            buffer.moveToOffset(0);
+          }
           return true;
         }
         if (keyMatchers[Command.HISTORY_DOWN](key)) {
+          // Two-step edge transition (matches Claude Code):
+          // 1. If not on last visual row → move cursor down one row
+          // 2. Else if cursor not at end of line → snap to end (no history change)
+          // 3. Else → navigate to newer history; cursor lands at end (setText default)
+          const lastRowIdx = buffer.allVisualLines.length - 1;
+          const onLastRow = buffer.visualCursor[0] === lastRowIdx;
+          if (!onLastRow) {
+            buffer.move('down');
+            return true;
+          }
+          const lastRowLen = cpLen(buffer.allVisualLines[lastRowIdx] ?? '');
+          if (buffer.visualCursor[1] < lastRowLen) {
+            buffer.move('end');
+            return true;
+          }
           inputHistory.navigateDown();
           return true;
         }
@@ -981,7 +1012,14 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           (buffer.allVisualLines.length === 1 ||
             (buffer.visualCursor[0] === 0 && buffer.visualScrollRow === 0))
         ) {
-          inputHistory.navigateUp();
+          // Two-step edge transition: snap cursor to col 0 before triggering history
+          if (buffer.visualCursor[1] > 0) {
+            buffer.move('home');
+            return true;
+          }
+          if (inputHistory.navigateUp()) {
+            buffer.moveToOffset(0);
+          }
           return true;
         }
         if (
@@ -989,6 +1027,13 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           (buffer.allVisualLines.length === 1 ||
             buffer.visualCursor[0] === buffer.allVisualLines.length - 1)
         ) {
+          // Two-step edge transition: snap cursor to end of line before triggering history
+          const lastRowIdx = buffer.allVisualLines.length - 1;
+          const lastRowLen = cpLen(buffer.allVisualLines[lastRowIdx] ?? '');
+          if (buffer.visualCursor[1] < lastRowLen) {
+            buffer.move('end');
+            return true;
+          }
           if (inputHistory.navigateDown()) {
             return true;
           }

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -143,6 +143,16 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   // Includes terminal entries — the pill stays open so users can reopen
   // the dialog to inspect final state after the last agent finishes.
   const hasBgAgents = bgEntries.length > 0;
+  const hasActiveToolConfirmation = useMemo(
+    () =>
+      Boolean(uiState.confirmationRequest) ||
+      (uiState.pendingGeminiHistoryItems ?? []).some(
+        (item) =>
+          item.type === 'tool_group' &&
+          item.tools.some((tool) => tool.confirmationDetails),
+      ),
+    [uiState.confirmationRequest, uiState.pendingGeminiHistoryItems],
+  );
   const [justNavigatedHistory, setJustNavigatedHistory] = useState(false);
   const [escPressCount, setEscPressCount] = useState(0);
   const [showEscapePrompt, setShowEscapePrompt] = useState(false);
@@ -955,6 +965,16 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           return true;
         }
 
+        if (
+          hasActiveToolConfirmation &&
+          (keyMatchers[Command.HISTORY_UP](key) ||
+            keyMatchers[Command.HISTORY_DOWN](key) ||
+            keyMatchers[Command.NAVIGATION_UP](key) ||
+            keyMatchers[Command.NAVIGATION_DOWN](key))
+        ) {
+          return true;
+        }
+
         // Pop all queued messages into input when pressing Up arrow at top of input
         if (
           !isAttachmentMode &&
@@ -1003,7 +1023,17 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
             buffer.move('end');
             return true;
           }
-          inputHistory.navigateDown();
+          if (inputHistory.navigateDown()) {
+            return true;
+          }
+          if (hasAgents) {
+            setAgentTabBarFocused(true);
+            return true;
+          }
+          if (hasBgAgents) {
+            setBgPillFocused(true);
+            return true;
+          }
           return true;
         }
         // Handle arrow-up/down for history on single-line or at edges
@@ -1243,6 +1273,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       bgPillFocused,
       hasAgents,
       hasBgAgents,
+      hasActiveToolConfirmation,
       setAgentTabBarFocused,
       setBgPillFocused,
       followup,

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -794,7 +794,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         // Prevent up/down from falling through to regular history navigation
         if (
           keyMatchers[Command.NAVIGATION_UP](key) ||
-          keyMatchers[Command.NAVIGATION_DOWN](key)
+          keyMatchers[Command.NAVIGATION_DOWN](key) ||
+          keyMatchers[Command.HISTORY_UP](key) ||
+          keyMatchers[Command.HISTORY_DOWN](key)
         ) {
           return true;
         }

--- a/packages/cli/src/ui/components/ManageModelsDialog.test.tsx
+++ b/packages/cli/src/ui/components/ManageModelsDialog.test.tsx
@@ -4,15 +4,52 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+import { AuthType, type Config } from '@qwen-code/qwen-code-core';
 import {
   applyCatalogFilters,
   buildModelLabel,
   getNextEnabledTabSource,
   getNextFocusMode,
+  ManageModelsDialog,
   type FilterMode,
 } from './ManageModelsDialog.js';
 import type { ManageModelsCatalogEntry } from '../manageModels/manageModels.js';
+import {
+  fetchManageModelsCatalog,
+  getEnabledModelIdsForSource,
+  saveManageModelsSelection,
+} from '../manageModels/manageModels.js';
+import { renderWithProviders } from '../../test-utils/render.js';
+import type { Key, KeypressHandler } from '../contexts/KeypressContext.js';
+import { useKeypress } from '../hooks/useKeypress.js';
+
+vi.mock('../manageModels/manageModels.js', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('../manageModels/manageModels.js')>();
+  return {
+    ...actual,
+    fetchManageModelsCatalog: vi.fn(),
+    getEnabledModelIdsForSource: vi.fn(),
+    saveManageModelsSelection: vi.fn(),
+  };
+});
+
+vi.mock('./shared/TextInput.js', async () => {
+  const { Text } = await import('ink');
+  return {
+    TextInput: ({
+      value,
+      placeholder,
+    }: {
+      value?: string;
+      placeholder?: string;
+    }) => <Text>{value ? `> ${value}` : `> ${placeholder}`}</Text>,
+  };
+});
+
+vi.mock('../hooks/useKeypress.js');
 
 function makeEntry(
   id: string,
@@ -36,6 +73,37 @@ function makeEntry(
     },
   };
 }
+
+const catalogEntries = [
+  makeEntry('qwen/qwen3-coder:free', {
+    badges: ['free'],
+  }),
+  makeEntry('openai/gpt-4o-mini'),
+  makeEntry('anthropic/claude-haiku'),
+];
+
+let dialogKeypressHandler: KeypressHandler | null = null;
+
+const createKey = (overrides: Partial<Key>): Key => ({
+  name: '',
+  sequence: '',
+  ctrl: false,
+  meta: false,
+  shift: false,
+  paste: false,
+  ...overrides,
+});
+
+const pressDialogKey = async (overrides: Partial<Key>) => {
+  if (!dialogKeypressHandler) {
+    throw new Error('ManageModelsDialog keypress handler was not registered.');
+  }
+  const handler = dialogKeypressHandler;
+
+  await act(async () => {
+    handler(createKey(overrides));
+  });
+};
 
 describe('ManageModelsDialog helpers', () => {
   it('buildModelLabel uses the short display label only', () => {
@@ -128,5 +196,68 @@ describe('ManageModelsDialog helpers', () => {
   it('keeps provider tab on the only enabled source', () => {
     expect(getNextEnabledTabSource('openrouter', 'left')).toBe('openrouter');
     expect(getNextEnabledTabSource('openrouter', 'right')).toBe('openrouter');
+  });
+});
+
+describe('ManageModelsDialog keyboard navigation', () => {
+  beforeEach(() => {
+    dialogKeypressHandler = null;
+    vi.mocked(useKeypress).mockImplementation((handler, { isActive }) => {
+      if (isActive) {
+        dialogKeypressHandler = handler;
+      }
+    });
+    vi.mocked(fetchManageModelsCatalog).mockResolvedValue({
+      source: 'openrouter',
+      title: 'OpenRouter',
+      description:
+        'Browse the latest OpenRouter model catalog and choose which models are enabled locally.',
+      authType: AuthType.USE_OPENAI,
+      entries: catalogEntries,
+    });
+    vi.mocked(getEnabledModelIdsForSource).mockReturnValue([]);
+    vi.mocked(saveManageModelsSelection).mockResolvedValue({
+      updatedConfigs: [],
+      selectedIds: [],
+      activeModelId: undefined,
+    });
+  });
+
+  const renderDialog = () =>
+    renderWithProviders(
+      <ManageModelsDialog config={{} as Config} onClose={vi.fn()} />,
+    );
+
+  it('keeps bare j in search mode instead of entering the list', async () => {
+    const { lastFrame, unmount } = renderDialog();
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('qwen/qwen3-coder:free');
+    });
+
+    await pressDialogKey({ name: 'n', sequence: '\u000E', ctrl: true });
+    await pressDialogKey({ name: 'j', sequence: 'j' });
+
+    expect(lastFrame()).not.toContain('› [ ] qwen/qwen3-coder:free');
+    unmount();
+  });
+
+  it('uses selection shortcuts across tabs, search, and list', async () => {
+    const { lastFrame, unmount } = renderDialog();
+
+    await waitFor(() => {
+      expect(lastFrame()).toContain('qwen/qwen3-coder:free');
+    });
+
+    await pressDialogKey({ name: 'j', sequence: 'j' }); // tabs -> search
+    await pressDialogKey({ name: 'n', sequence: '\u000E', ctrl: true }); // search -> list
+    expect(lastFrame()).toContain('› [ ] qwen/qwen3-coder:free');
+
+    await pressDialogKey({ name: 'n', sequence: '\u000E', ctrl: true }); // list highlight down
+    expect(lastFrame()).toContain('› [ ] openai/gpt-4o-mini');
+
+    await pressDialogKey({ name: 'p', sequence: '\u0010', ctrl: true }); // list highlight up
+    expect(lastFrame()).toContain('› [ ] qwen/qwen3-coder:free');
+    unmount();
   });
 });

--- a/packages/cli/src/ui/components/ManageModelsDialog.tsx
+++ b/packages/cli/src/ui/components/ManageModelsDialog.tsx
@@ -13,6 +13,7 @@ import {
 } from '@qwen-code/qwen-code-core';
 import { useSettings } from '../contexts/SettingsContext.js';
 import { useKeypress } from '../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../keyMatchers.js';
 import { theme } from '../semantic-colors.js';
 import { TextInput } from './shared/TextInput.js';
 import type { LoadedSettings } from '../../config/settings.js';
@@ -397,13 +398,20 @@ export function ManageModelsDialog({
           );
           return;
         }
-        if (key.name === 'down') {
+        // tabs row has no active TextInput — accept ↓/j/Ctrl+N uniformly
+        if (keyMatchers[Command.SELECTION_DOWN](key)) {
           setFocusMode('search');
         }
         return;
       }
 
       if (focusMode === 'search') {
+        // The search TextInput is active in this mode, so only accept
+        // unambiguous non-letter shortcuts (arrows + Ctrl+P/Ctrl+N) for
+        // transitions — bare k/j must reach the TextInput as typed characters.
+        const isSearchUp = key.name === 'up' || (key.ctrl && key.name === 'p');
+        const isSearchDown =
+          key.name === 'down' || (key.ctrl && key.name === 'n');
         if (key.name === 'left') {
           setFilterMode((current) => cycleFilter(current, 'left'));
           return;
@@ -412,22 +420,22 @@ export function ManageModelsDialog({
           setFilterMode((current) => cycleFilter(current, 'right'));
           return;
         }
-        if (key.name === 'up') {
+        if (isSearchUp) {
           setFocusMode('tabs');
           return;
         }
-        if (key.name === 'down' && filteredEntries.length > 0) {
+        if (isSearchDown && filteredEntries.length > 0) {
           setFocusMode('list');
         }
         return;
       }
 
       if (focusMode === 'list') {
-        if (key.name === 'up') {
+        if (keyMatchers[Command.SELECTION_UP](key)) {
           moveHighlight('up');
           return;
         }
-        if (key.name === 'down') {
+        if (keyMatchers[Command.SELECTION_DOWN](key)) {
           moveHighlight('down');
           return;
         }

--- a/packages/cli/src/ui/components/MemoryDialog.test.tsx
+++ b/packages/cli/src/ui/components/MemoryDialog.test.tsx
@@ -66,4 +66,26 @@ describe('MemoryDialog', () => {
 
     expect(lastFrame()).toContain('› 2. Project memory');
   });
+
+  it('moves selection with Ctrl+N/P readline aliases', () => {
+    const { lastFrame } = render(<MemoryDialog onClose={vi.fn()} />);
+
+    expect(lastFrame()).toContain('› 1. User memory');
+
+    const pressKey = (key: { name: string; ctrl?: boolean }) => {
+      const keypressHandler =
+        mockedUseKeypress.mock.calls[
+          mockedUseKeypress.mock.calls.length - 1
+        ]![0];
+      act(() => {
+        keypressHandler(key as never);
+      });
+    };
+
+    pressKey({ name: 'n', ctrl: true });
+    expect(lastFrame()).toContain('› 2. Project memory');
+
+    pressKey({ name: 'p', ctrl: true });
+    expect(lastFrame()).toContain('› 1. User memory');
+  });
 });

--- a/packages/cli/src/ui/components/MemoryDialog.tsx
+++ b/packages/cli/src/ui/components/MemoryDialog.tsx
@@ -21,6 +21,7 @@ import { useSettings } from '../contexts/SettingsContext.js';
 import { SettingScope } from '../../config/settings.js';
 import { useLaunchEditor } from '../hooks/useLaunchEditor.js';
 import { useKeypress } from '../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../keyMatchers.js';
 import { theme } from '../semantic-colors.js';
 import { formatRelativeTime } from '../utils/formatters.js';
 import { t } from '../../i18n/index.js';
@@ -278,7 +279,8 @@ export function MemoryDialog({ onClose }: MemoryDialogProps) {
       }
 
       if (focusedSection === 'autoMemory') {
-        if (key.name === 'down') {
+        // No "up" target above autoMemory; only handle down → autoDream.
+        if (keyMatchers[Command.SELECTION_DOWN](key)) {
           setFocusedSection('autoDream');
           return;
         }
@@ -290,11 +292,11 @@ export function MemoryDialog({ onClose }: MemoryDialogProps) {
       }
 
       if (focusedSection === 'autoDream') {
-        if (key.name === 'up') {
+        if (keyMatchers[Command.SELECTION_UP](key)) {
           setFocusedSection('autoMemory');
           return;
         }
-        if (key.name === 'down') {
+        if (keyMatchers[Command.SELECTION_DOWN](key)) {
           setFocusedSection('list');
           setHighlightedIndex(0);
           return;
@@ -307,7 +309,7 @@ export function MemoryDialog({ onClose }: MemoryDialogProps) {
       }
 
       // focusedSection === 'list'
-      if (key.name === 'up') {
+      if (keyMatchers[Command.SELECTION_UP](key)) {
         if (highlightedIndex === 0) {
           setFocusedSection('autoDream');
         } else {
@@ -316,7 +318,7 @@ export function MemoryDialog({ onClose }: MemoryDialogProps) {
         return;
       }
 
-      if (key.name === 'down') {
+      if (keyMatchers[Command.SELECTION_DOWN](key)) {
         setHighlightedIndex((current) => (current + 1) % items.length);
         return;
       }

--- a/packages/cli/src/ui/components/PluginChoicePrompt.test.tsx
+++ b/packages/cli/src/ui/components/PluginChoicePrompt.test.tsx
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render } from 'ink-testing-library';
+import { act } from '@testing-library/react';
 import { PluginChoicePrompt } from './PluginChoicePrompt.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 
@@ -222,6 +223,37 @@ describe('PluginChoicePrompt', () => {
       keypressHandler({ name: '2', sequence: '2' } as never);
 
       expect(onSelect).toHaveBeenCalledWith('plugin2');
+    });
+
+    it('navigates with Ctrl+N/P readline aliases', () => {
+      const { lastFrame } = render(
+        <PluginChoicePrompt
+          marketplaceName="test"
+          plugins={[{ name: 'plugin1' }, { name: 'plugin2' }]}
+          onSelect={onSelect}
+          onCancel={onCancel}
+          terminalWidth={terminalWidth}
+        />,
+      );
+
+      const keypressHandler = mockedUseKeypress.mock.calls[0][0];
+      act(() => {
+        keypressHandler({
+          name: 'n',
+          sequence: '\u000E',
+          ctrl: true,
+        } as never);
+      });
+      expect(lastFrame()).toContain('❯ plugin2');
+
+      act(() => {
+        keypressHandler({
+          name: 'p',
+          sequence: '\u0010',
+          ctrl: true,
+        } as never);
+      });
+      expect(lastFrame()).toContain('❯ plugin1');
     });
   });
 

--- a/packages/cli/src/ui/components/PluginChoicePrompt.tsx
+++ b/packages/cli/src/ui/components/PluginChoicePrompt.tsx
@@ -9,6 +9,7 @@ import { useState, useCallback, useMemo } from 'react';
 import { theme } from '../semantic-colors.js';
 import { t } from '../../i18n/index.js';
 import { useKeypress, type Key } from '../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../keyMatchers.js';
 
 interface PluginChoice {
   name: string;
@@ -51,13 +52,13 @@ export const PluginChoicePrompt = (props: PluginChoicePromptProps) => {
       }
 
       // Navigate up
-      if (name === 'up' || sequence === 'k') {
+      if (keyMatchers[Command.SELECTION_UP](key)) {
         setSelectedIndex((prev) => (prev > 0 ? prev - 1 : plugins.length - 1));
         return;
       }
 
       // Navigate down
-      if (name === 'down' || sequence === 'j') {
+      if (keyMatchers[Command.SELECTION_DOWN](key)) {
         setSelectedIndex((prev) => (prev < plugins.length - 1 ? prev + 1 : 0));
         return;
       }

--- a/packages/cli/src/ui/components/RewindSelector.test.tsx
+++ b/packages/cli/src/ui/components/RewindSelector.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act } from '@testing-library/react';
+import { render } from 'ink-testing-library';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HistoryItem } from '../types.js';
+import type { KeypressHandler, Key } from '../contexts/KeypressContext.js';
+import { useKeypress } from '../hooks/useKeypress.js';
+import { useTerminalSize } from '../hooks/useTerminalSize.js';
+import { RewindSelector } from './RewindSelector.js';
+
+vi.mock('../hooks/useKeypress.js');
+vi.mock('../hooks/useTerminalSize.js');
+
+let activeKeypressHandler: KeypressHandler | null = null;
+
+const createKey = (overrides: Partial<Key>): Key => ({
+  name: '',
+  sequence: '',
+  ctrl: false,
+  meta: false,
+  shift: false,
+  paste: false,
+  ...overrides,
+});
+
+const pressKey = (overrides: Partial<Key>) => {
+  if (!activeKeypressHandler) {
+    throw new Error('No active keypress handler');
+  }
+  const handler = activeKeypressHandler;
+  act(() => {
+    handler(createKey(overrides));
+  });
+};
+
+const userTurn = (id: number, text: string): HistoryItem => ({
+  id,
+  type: 'user',
+  text,
+});
+
+describe('RewindSelector', () => {
+  beforeEach(() => {
+    activeKeypressHandler = null;
+    vi.mocked(useTerminalSize).mockReturnValue({ columns: 100, rows: 30 });
+    vi.mocked(useKeypress).mockImplementation((handler, { isActive }) => {
+      if (isActive) {
+        activeKeypressHandler = handler;
+      }
+    });
+  });
+
+  it('navigates the pick list with Ctrl+P/N readline aliases', () => {
+    const { lastFrame } = render(
+      <RewindSelector
+        history={[userTurn(1, 'first prompt'), userTurn(2, 'second prompt')]}
+        onRewind={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(lastFrame()).toContain('› #2 second prompt');
+
+    pressKey({ name: 'p', sequence: '\u0010', ctrl: true });
+    expect(lastFrame()).toContain('› #1 first prompt');
+
+    pressKey({ name: 'n', sequence: '\u000E', ctrl: true });
+    expect(lastFrame()).toContain('› #2 second prompt');
+  });
+});

--- a/packages/cli/src/ui/components/RewindSelector.tsx
+++ b/packages/cli/src/ui/components/RewindSelector.tsx
@@ -10,6 +10,7 @@ import type { HistoryItem } from '../types.js';
 import { theme } from '../semantic-colors.js';
 import { useTerminalSize } from '../hooks/useTerminalSize.js';
 import { useKeypress } from '../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../keyMatchers.js';
 import { truncateText } from '../utils/sessionPickerUtils.js';
 import { isRealUserTurn } from '../utils/historyMapping.js';
 import { t } from '../../i18n/index.js';
@@ -156,12 +157,12 @@ export function RewindSelector({
         return;
       }
 
-      if (name === 'up' || name === 'k') {
+      if (keyMatchers[Command.SELECTION_UP](key)) {
         setSelectedIndex((prev) => Math.max(0, prev - 1));
         return;
       }
 
-      if (name === 'down' || name === 'j') {
+      if (keyMatchers[Command.SELECTION_DOWN](key)) {
         setSelectedIndex((prev) => Math.min(userTurns.length - 1, prev + 1));
         return;
       }

--- a/packages/cli/src/ui/components/SettingsDialog.tsx
+++ b/packages/cli/src/ui/components/SettingsDialog.tsx
@@ -33,6 +33,7 @@ import { useCompactMode } from '../contexts/CompactModeContext.js';
 import { useUIActions } from '../contexts/UIActionsContext.js';
 import { createDebugLogger, type Config } from '@qwen-code/qwen-code-core';
 import { useKeypress } from '../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../keyMatchers.js';
 import chalk from 'chalk';
 import { cpSlice, cpLen, stripUnsafeCharacters } from '../utils/textUtils.js';
 import {
@@ -546,8 +547,8 @@ export function SettingsDialog({
           // Block other keys while editing
           return;
         }
-        if (name === 'up' || name === 'k') {
-          // If editing, commit first
+        if (keyMatchers[Command.SELECTION_UP](key)) {
+          // ↑/k/Ctrl+P all move selection up. If editing, commit first.
           if (editingKey) {
             commitEdit(editingKey);
           }
@@ -562,8 +563,8 @@ export function SettingsDialog({
           } else if (newIndex < scrollOffset) {
             setScrollOffset(newIndex);
           }
-        } else if (name === 'down' || name === 'j') {
-          // If editing, commit first
+        } else if (keyMatchers[Command.SELECTION_DOWN](key)) {
+          // ↓/j/Ctrl+N all move selection down. If editing, commit first.
           if (editingKey) {
             commitEdit(editingKey);
           }

--- a/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/InputPrompt.test.tsx.snap
@@ -20,14 +20,14 @@ exports[`InputPrompt > command search (Ctrl+R when not in shell) > expands and c
 
 exports[`InputPrompt > command search (Ctrl+R when not in shell) > renders match window and expanded view (snapshots) > command-search-collapsed-match 1`] = `
 "────────────────────────────────────────────────────────────────────────────────
-(r:)  commit
+(r:)  commit ​
 ────────────────────────────────────────────────────────────────────────────────────────────────────
   git commit -m "feat: add search" in src/app"
 `;
 
 exports[`InputPrompt > command search (Ctrl+R when not in shell) > renders match window and expanded view (snapshots) > command-search-expanded-match 1`] = `
 "────────────────────────────────────────────────────────────────────────────────
-(r:)  commit
+(r:)  commit ​
 ────────────────────────────────────────────────────────────────────────────────────────────────────
   git commit -m "feat: add search" in src/app"
 `;

--- a/packages/cli/src/ui/components/agent-view/AgentTabBar.test.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentTabBar.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { render } from 'ink-testing-library';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AgentStatus } from '@qwen-code/qwen-code-core';
+import type { KeypressHandler, Key } from '../../contexts/KeypressContext.js';
+import { useKeypress } from '../../hooks/useKeypress.js';
+import {
+  useAgentViewActions,
+  useAgentViewState,
+} from '../../contexts/AgentViewContext.js';
+import {
+  useBackgroundTaskViewActions,
+  useBackgroundTaskViewState,
+} from '../../contexts/BackgroundTaskViewContext.js';
+import { useUIState } from '../../contexts/UIStateContext.js';
+import { AgentTabBar } from './AgentTabBar.js';
+
+vi.mock('../../hooks/useKeypress.js');
+vi.mock('../../contexts/AgentViewContext.js');
+vi.mock('../../contexts/BackgroundTaskViewContext.js');
+vi.mock('../../contexts/UIStateContext.js');
+
+let activeKeypressHandler: KeypressHandler | null = null;
+
+const createKey = (overrides: Partial<Key>): Key => ({
+  name: '',
+  sequence: '',
+  ctrl: false,
+  meta: false,
+  shift: false,
+  paste: false,
+  ...overrides,
+});
+
+const pressKey = (overrides: Partial<Key>) => {
+  if (!activeKeypressHandler) {
+    throw new Error('No active keypress handler');
+  }
+  activeKeypressHandler(createKey(overrides));
+};
+
+describe('AgentTabBar', () => {
+  const switchToMain = vi.fn();
+  const setAgentTabBarFocused = vi.fn();
+  const setBgPillFocused = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    activeKeypressHandler = null;
+
+    vi.mocked(useKeypress).mockImplementation((handler, { isActive }) => {
+      if (isActive) {
+        activeKeypressHandler = handler;
+      }
+    });
+    vi.mocked(useAgentViewState).mockReturnValue({
+      activeView: 'agent-1',
+      agents: new Map([
+        [
+          'agent-1',
+          {
+            modelId: 'qwen',
+            color: 'cyan',
+            interactiveAgent: {
+              getStatus: () => AgentStatus.IDLE,
+              getEventEmitter: () => ({ on: vi.fn(), off: vi.fn() }),
+            },
+          },
+        ],
+      ]),
+      agentShellFocused: false,
+      agentTabBarFocused: true,
+    } as never);
+    vi.mocked(useAgentViewActions).mockReturnValue({
+      switchToNext: vi.fn(),
+      switchToPrevious: vi.fn(),
+      switchToMain,
+      setAgentTabBarFocused,
+    } as never);
+    vi.mocked(useBackgroundTaskViewState).mockReturnValue({
+      entries: [{ kind: 'agent', agentId: 'bg-agent' }],
+    } as never);
+    vi.mocked(useBackgroundTaskViewActions).mockReturnValue({
+      setPillFocused: setBgPillFocused,
+    } as never);
+    vi.mocked(useUIState).mockReturnValue({
+      embeddedShellFocused: false,
+    } as never);
+  });
+
+  it('uses Ctrl+P/N for focus-chain navigation', () => {
+    render(<AgentTabBar />);
+
+    pressKey({ name: 'p', sequence: '\u0010', ctrl: true });
+    expect(setAgentTabBarFocused).toHaveBeenCalledWith(false);
+
+    pressKey({ name: 'n', sequence: '\u000E', ctrl: true });
+    expect(switchToMain).toHaveBeenCalledTimes(1);
+    expect(setBgPillFocused).toHaveBeenCalledWith(true);
+  });
+});

--- a/packages/cli/src/ui/components/agent-view/AgentTabBar.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentTabBar.tsx
@@ -83,9 +83,9 @@ export const AgentTabBar: React.FC = () => {
         switchToPrevious();
       } else if (key.name === 'right') {
         switchToNext();
-      } else if (key.name === 'up') {
+      } else if (key.name === 'up' || (key.ctrl && key.name === 'p')) {
         setAgentTabBarFocused(false);
-      } else if (key.name === 'down') {
+      } else if (key.name === 'down' || (key.ctrl && key.name === 'n')) {
         // Switch to main first — the footer pill only renders under the
         // main view, so focusing it from an agent tab would strand focus
         // on an offscreen surface.

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.test.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.test.tsx
@@ -113,7 +113,7 @@ interface Harness {
   monitorCancel: ReturnType<typeof vi.fn>;
   dreamCancelTask: ReturnType<typeof vi.fn>;
   setEntries: (next: readonly DialogEntry[]) => void;
-  pressKey: (key: { name?: string; sequence?: string }) => void;
+  pressKey: (key: { name?: string; sequence?: string; ctrl?: boolean }) => void;
   call: (fn: () => void) => void;
   lastFrame: () => string | undefined;
   probe: { current: ProbeHandle | null };
@@ -425,6 +425,23 @@ describe('BackgroundTasksDialog', () => {
     expect(h.probe.current!.state.selectedIndex).toBe(0);
 
     h.setEntries([]);
+    expect(h.probe.current!.state.selectedIndex).toBe(0);
+  });
+
+  it('moves list selection with Ctrl+N/P readline aliases', () => {
+    const h = setup([
+      entry({ agentId: 'a' }),
+      entry({ agentId: 'b' }),
+      entry({ agentId: 'c' }),
+    ]);
+
+    h.call(() => h.probe.current!.actions.openDialog());
+    expect(h.probe.current!.state.selectedIndex).toBe(0);
+
+    h.pressKey({ name: 'n', sequence: '\u000E', ctrl: true });
+    expect(h.probe.current!.state.selectedIndex).toBe(1);
+
+    h.pressKey({ name: 'p', sequence: '\u0010', ctrl: true });
     expect(h.probe.current!.state.selectedIndex).toBe(0);
   });
 

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksDialog.tsx
@@ -19,6 +19,7 @@ import {
   useBackgroundTaskViewActions,
 } from '../../contexts/BackgroundTaskViewContext.js';
 import { useKeypress } from '../../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../../keyMatchers.js';
 import { MaxSizedBox } from '../shared/MaxSizedBox.js';
 import { theme } from '../../semantic-colors.js';
 import { useConfig } from '../../contexts/ConfigContext.js';
@@ -1053,12 +1054,12 @@ export const BackgroundTasksDialog: React.FC<BackgroundTasksDialogProps> = ({
       if (!dialogOpen) return;
 
       if (dialogMode === 'list') {
-        if (key.name === 'up') {
+        if (keyMatchers[Command.SELECTION_UP](key)) {
           moveSelectionUp();
           setPendingCancelEntryId(null);
           return;
         }
-        if (key.name === 'down') {
+        if (keyMatchers[Command.SELECTION_DOWN](key)) {
           moveSelectionDown();
           setPendingCancelEntryId(null);
           return;

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksPill.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksPill.tsx
@@ -74,8 +74,10 @@ export const BackgroundTasksPill: React.FC = () => {
 
   const onKeypress = useCallback(
     (key: Key) => {
-      // `return` and `down` both open the dialog. Down completes the
-      // focus chain Composer ↓ → AgentTabBar ↓ → Pill ↓ → Dialog,
+      // `return`, down, and the readline-style Ctrl+N all open the dialog.
+      // This is focus-chain handling rather than selection-list handling
+      // (see keyBindings.ts SELECTION_DOWN), so keep the matcher inline.
+      // Down completes the focus chain Composer ↓ → AgentTabBar ↓ → Pill ↓ → Dialog,
       // so users can `↓ ↓ (↓)` their way from an empty composer
       // straight into the roster without having to remember the
       // Enter shortcut. The LiveAgentPanel's overflow callout

--- a/packages/cli/src/ui/components/background-view/BackgroundTasksPill.tsx
+++ b/packages/cli/src/ui/components/background-view/BackgroundTasksPill.tsx
@@ -81,9 +81,17 @@ export const BackgroundTasksPill: React.FC = () => {
       // Enter shortcut. The LiveAgentPanel's overflow callout
       // (`↓ to view all`) relies on this; without a Down handler
       // the chain dead-ends at the highlighted pill.
-      if (key.name === 'return' || key.name === 'down') {
+      if (
+        key.name === 'return' ||
+        key.name === 'down' ||
+        (key.ctrl && key.name === 'n')
+      ) {
         openDialog();
-      } else if (key.name === 'up' || key.name === 'escape') {
+      } else if (
+        key.name === 'up' ||
+        (key.ctrl && key.name === 'p') ||
+        key.name === 'escape'
+      ) {
         setPillFocused(false);
       } else if (
         key.sequence &&

--- a/packages/cli/src/ui/components/extensions/steps/ExtensionListStep.tsx
+++ b/packages/cli/src/ui/components/extensions/steps/ExtensionListStep.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../../../semantic-colors.js';
 import { useKeypress } from '../../../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../../../keyMatchers.js';
 import { type Extension } from '@qwen-code/qwen-code-core';
 import { t } from '../../../../i18n/index.js';
 import { ExtensionUpdateState } from '../../../state/extensions.js';
@@ -55,11 +56,11 @@ export const ExtensionListStep = ({
   // Keyboard navigation
   useKeypress(
     (key) => {
-      if (key.name === 'up' || key.name === 'k') {
+      if (keyMatchers[Command.SELECTION_UP](key)) {
         setSelectedIndex((prev) =>
           prev > 0 ? prev - 1 : extensions.length - 1,
         );
-      } else if (key.name === 'down' || key.name === 'j') {
+      } else if (keyMatchers[Command.SELECTION_DOWN](key)) {
         setSelectedIndex((prev) =>
           prev < extensions.length - 1 ? prev + 1 : 0,
         );

--- a/packages/cli/src/ui/components/hooks/HooksManagementDialog.tsx
+++ b/packages/cli/src/ui/components/hooks/HooksManagementDialog.tsx
@@ -9,6 +9,7 @@ import { Box, Text } from 'ink';
 import { theme } from '../../semantic-colors.js';
 import { useTerminalSize } from '../../hooks/useTerminalSize.js';
 import { useKeypress } from '../../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../../keyMatchers.js';
 import { useConfig } from '../../contexts/ConfigContext.js';
 import { loadSettings, SettingScope } from '../../../config/settings.js';
 import {
@@ -174,9 +175,9 @@ export function HooksManagementDialog({
           break;
 
         case HOOKS_MANAGEMENT_STEPS.HOOKS_LIST:
-          if (key.name === 'up') {
+          if (keyMatchers[Command.SELECTION_UP](key)) {
             setListSelectedIndex((prev) => Math.max(0, prev - 1));
-          } else if (key.name === 'down') {
+          } else if (keyMatchers[Command.SELECTION_DOWN](key)) {
             setListSelectedIndex((prev) =>
               Math.min(hooks.length - 1, prev + 1),
             );
@@ -199,9 +200,9 @@ export function HooksManagementDialog({
           if (key.name === 'escape') {
             handleNavigateBack();
           } else if (selectedHook && selectedHook.configs.length > 0) {
-            if (key.name === 'up') {
+            if (keyMatchers[Command.SELECTION_UP](key)) {
               setDetailSelectedIndex((prev) => Math.max(0, prev - 1));
-            } else if (key.name === 'down') {
+            } else if (keyMatchers[Command.SELECTION_DOWN](key)) {
               setDetailSelectedIndex((prev) =>
                 Math.min(selectedHook.configs.length - 1, prev + 1),
               );

--- a/packages/cli/src/ui/components/mcp/steps/ServerListStep.test.tsx
+++ b/packages/cli/src/ui/components/mcp/steps/ServerListStep.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act } from '@testing-library/react';
+import { render } from 'ink-testing-library';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MCPServerStatus } from '@qwen-code/qwen-code-core';
+import type {
+  KeypressHandler,
+  Key,
+} from '../../../contexts/KeypressContext.js';
+import { useKeypress } from '../../../hooks/useKeypress.js';
+import { ServerListStep } from './ServerListStep.js';
+import type { MCPServerDisplayInfo } from '../types.js';
+
+vi.mock('../../../hooks/useKeypress.js');
+
+let activeKeypressHandler: KeypressHandler | null = null;
+
+const createKey = (overrides: Partial<Key>): Key => ({
+  name: '',
+  sequence: '',
+  ctrl: false,
+  meta: false,
+  shift: false,
+  paste: false,
+  ...overrides,
+});
+
+const pressKey = (overrides: Partial<Key>) => {
+  if (!activeKeypressHandler) {
+    throw new Error('No active keypress handler');
+  }
+  const handler = activeKeypressHandler;
+  act(() => {
+    handler(createKey(overrides));
+  });
+};
+
+const server = (name: string): MCPServerDisplayInfo => ({
+  name,
+  status: MCPServerStatus.CONNECTED,
+  source: 'user',
+  config: {},
+  toolCount: 0,
+  promptCount: 0,
+  isDisabled: false,
+});
+
+describe('ServerListStep', () => {
+  beforeEach(() => {
+    activeKeypressHandler = null;
+    vi.mocked(useKeypress).mockImplementation((handler, { isActive }) => {
+      if (isActive) {
+        activeKeypressHandler = handler;
+      }
+    });
+  });
+
+  it('navigates with Ctrl+N/P readline aliases', () => {
+    const { lastFrame } = render(
+      <ServerListStep
+        servers={[server('first'), server('second')]}
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(lastFrame()).toContain('❯ first');
+
+    pressKey({ name: 'n', sequence: '\u000E', ctrl: true });
+    expect(lastFrame()).toContain('❯ second');
+
+    pressKey({ name: 'p', sequence: '\u0010', ctrl: true });
+    expect(lastFrame()).toContain('❯ first');
+  });
+});

--- a/packages/cli/src/ui/components/mcp/steps/ServerListStep.tsx
+++ b/packages/cli/src/ui/components/mcp/steps/ServerListStep.tsx
@@ -8,6 +8,7 @@ import { useState, useMemo } from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../../../semantic-colors.js';
 import { useKeypress } from '../../../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../../../keyMatchers.js';
 import { t } from '../../../../i18n/index.js';
 import type { ServerListStepProps, MCPServerDisplayInfo } from '../types.js';
 import {
@@ -44,9 +45,9 @@ export const ServerListStep: React.FC<ServerListStepProps> = ({
 
   useKeypress(
     (key) => {
-      if (key.name === 'up') {
+      if (keyMatchers[Command.SELECTION_UP](key)) {
         setSelectedIndex((prev) => Math.max(0, prev - 1));
-      } else if (key.name === 'down') {
+      } else if (keyMatchers[Command.SELECTION_DOWN](key)) {
         setSelectedIndex((prev) => Math.min(flatServers.length - 1, prev + 1));
       } else if (key.name === 'return') {
         onSelect(selectedIndex);

--- a/packages/cli/src/ui/components/mcp/steps/ToolListStep.test.tsx
+++ b/packages/cli/src/ui/components/mcp/steps/ToolListStep.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act } from '@testing-library/react';
+import { render } from 'ink-testing-library';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type {
+  KeypressHandler,
+  Key,
+} from '../../../contexts/KeypressContext.js';
+import { useKeypress } from '../../../hooks/useKeypress.js';
+import { ToolListStep } from './ToolListStep.js';
+import type { MCPToolDisplayInfo } from '../types.js';
+
+vi.mock('../../../hooks/useKeypress.js');
+
+let activeKeypressHandler: KeypressHandler | null = null;
+
+const createKey = (overrides: Partial<Key>): Key => ({
+  name: '',
+  sequence: '',
+  ctrl: false,
+  meta: false,
+  shift: false,
+  paste: false,
+  ...overrides,
+});
+
+const pressKey = (overrides: Partial<Key>) => {
+  if (!activeKeypressHandler) {
+    throw new Error('No active keypress handler');
+  }
+  const handler = activeKeypressHandler;
+  act(() => {
+    handler(createKey(overrides));
+  });
+};
+
+const tool = (name: string): MCPToolDisplayInfo => ({
+  name,
+  serverName: 'server',
+  isValid: true,
+});
+
+describe('ToolListStep', () => {
+  beforeEach(() => {
+    activeKeypressHandler = null;
+    vi.mocked(useKeypress).mockImplementation((handler, { isActive }) => {
+      if (isActive) {
+        activeKeypressHandler = handler;
+      }
+    });
+  });
+
+  it('navigates with Ctrl+N/P readline aliases', () => {
+    const { lastFrame } = render(
+      <ToolListStep
+        tools={[tool('first'), tool('second')]}
+        serverName="server"
+        onSelect={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+
+    expect(lastFrame()).toContain('❯ first');
+
+    pressKey({ name: 'n', sequence: '\u000E', ctrl: true });
+    expect(lastFrame()).toContain('❯ second');
+
+    pressKey({ name: 'p', sequence: '\u0010', ctrl: true });
+    expect(lastFrame()).toContain('❯ first');
+  });
+});

--- a/packages/cli/src/ui/components/mcp/steps/ToolListStep.tsx
+++ b/packages/cli/src/ui/components/mcp/steps/ToolListStep.tsx
@@ -8,6 +8,7 @@ import { useState, useMemo } from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../../../semantic-colors.js';
 import { useKeypress } from '../../../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../../../keyMatchers.js';
 import { t } from '../../../../i18n/index.js';
 import type { ToolListStepProps, MCPToolDisplayInfo } from '../types.js';
 import { VISIBLE_TOOLS_COUNT } from '../constants.js';
@@ -52,9 +53,9 @@ export const ToolListStep: React.FC<ToolListStepProps> = ({
     (key) => {
       if (key.name === 'escape') {
         onBack();
-      } else if (key.name === 'up') {
+      } else if (keyMatchers[Command.SELECTION_UP](key)) {
         setSelectedIndex((prev) => Math.max(0, prev - 1));
-      } else if (key.name === 'down') {
+      } else if (keyMatchers[Command.SELECTION_DOWN](key)) {
         setSelectedIndex((prev) => Math.min(tools.length - 1, prev + 1));
       } else if (key.name === 'return') {
         if (tools[selectedIndex]) {

--- a/packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx
+++ b/packages/cli/src/ui/components/messages/AskUserQuestionDialog.test.tsx
@@ -9,8 +9,10 @@ import { AskUserQuestionDialog } from './AskUserQuestionDialog.js';
 import type { ToolAskUserQuestionConfirmationDetails } from '@qwen-code/qwen-code-core';
 import { ToolConfirmationOutcome } from '@qwen-code/qwen-code-core';
 import { renderWithProviders } from '../../../test-utils/render.js';
+import stripAnsi from 'strip-ansi';
 
 const wait = (ms = 50) => new Promise((resolve) => setTimeout(resolve, ms));
+const clean = (value: string | undefined) => stripAnsi(value ?? '');
 
 const createSingleQuestion = (
   overrides: Partial<
@@ -233,6 +235,89 @@ describe('<AskUserQuestionDialog />', () => {
       await wait();
 
       expect(onConfirm).toHaveBeenCalledWith(ToolConfirmationOutcome.Cancel);
+      unmount();
+    });
+
+    it('navigates with selection shortcuts when custom input is not focused', async () => {
+      const onConfirm = vi.fn();
+      const details = createConfirmationDetails();
+
+      const { stdin, lastFrame, unmount } = renderWithProviders(
+        <AskUserQuestionDialog
+          confirmationDetails={details}
+          onConfirm={onConfirm}
+        />,
+      );
+      await wait();
+
+      expect(clean(lastFrame())).toContain('❯ 1. Red');
+
+      stdin.write('j');
+      await wait();
+      expect(clean(lastFrame())).toContain('❯ 2. Blue');
+
+      stdin.write('k');
+      await wait();
+      expect(clean(lastFrame())).toContain('❯ 1. Red');
+
+      unmount();
+    });
+
+    it('navigates with Ctrl+N/P when custom input is not focused', async () => {
+      const onConfirm = vi.fn();
+      const details = createConfirmationDetails();
+
+      const { stdin, lastFrame, unmount } = renderWithProviders(
+        <AskUserQuestionDialog
+          confirmationDetails={details}
+          onConfirm={onConfirm}
+        />,
+      );
+      await wait();
+
+      expect(clean(lastFrame())).toContain('❯ 1. Red');
+
+      stdin.write('\u000E'); // Ctrl+N
+      await wait();
+      expect(clean(lastFrame())).toContain('❯ 2. Blue');
+
+      stdin.write('\u0010'); // Ctrl+P
+      await wait();
+      expect(clean(lastFrame())).toContain('❯ 1. Red');
+
+      unmount();
+    });
+
+    it('keeps bare k/j in custom input while Ctrl+P/N still navigates options', async () => {
+      const onConfirm = vi.fn();
+      const details = createConfirmationDetails();
+
+      const { stdin, lastFrame, unmount } = renderWithProviders(
+        <AskUserQuestionDialog
+          confirmationDetails={details}
+          onConfirm={onConfirm}
+        />,
+      );
+      await wait();
+
+      stdin.write('4'); // Select "Other" custom input
+      await wait(150);
+      expect(clean(lastFrame())).toContain('❯ 4.');
+
+      stdin.write('j');
+      await wait(150);
+      stdin.write('k');
+      await wait(150);
+      expect(clean(lastFrame())).toContain('❯ 4.');
+
+      stdin.write('\u0010'); // Ctrl+P
+      await wait();
+      expect(clean(lastFrame())).toContain('❯ 3. Green');
+
+      stdin.write('\u000E'); // Ctrl+N
+      await wait();
+      expect(clean(lastFrame())).toContain('❯ 4.');
+
       unmount();
     });
   });

--- a/packages/cli/src/ui/components/messages/AskUserQuestionDialog.tsx
+++ b/packages/cli/src/ui/components/messages/AskUserQuestionDialog.tsx
@@ -14,6 +14,7 @@ import {
 } from '@qwen-code/qwen-code-core';
 import { theme } from '../../semantic-colors.js';
 import { useKeypress } from '../../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../../keyMatchers.js';
 import { TextInput } from '../shared/TextInput.js';
 import { t } from '../../../i18n/index.js';
 
@@ -150,13 +151,20 @@ export const AskUserQuestionDialog: React.FC<AskUserQuestionDialogProps> = ({
   // Handle navigation and selection
   useKeypress(
     (key) => {
-      // When custom input is focused, still allow up/down navigation and escape
+      // When the custom-input TextInput is focused, we must NOT match bare
+      // letter keys (k/j) for option navigation — those characters are being
+      // typed into the input. Only honor unambiguous shortcuts: arrow keys
+      // and the readline-style Ctrl+P/Ctrl+N. TextInput itself doesn't bind
+      // those, so there's no double-fire.
       if (isCustomInputSelected) {
-        if (key.name === 'up') {
+        const isOptionUp = key.name === 'up' || (key.ctrl && key.name === 'p');
+        const isOptionDown =
+          key.name === 'down' || (key.ctrl && key.name === 'n');
+        if (isOptionUp) {
           setSelectedIndex(Math.max(0, selectedIndex - 1));
           return;
         }
-        if (key.name === 'down') {
+        if (isOptionDown) {
           setSelectedIndex(Math.min(totalOptions - 1, selectedIndex + 1));
           return;
         }
@@ -185,12 +193,12 @@ export const AskUserQuestionDialog: React.FC<AskUserQuestionDialogProps> = ({
         return;
       }
 
-      // Option navigation (up/down arrows)
-      if (key.name === 'up') {
+      // Option navigation (up/down arrows and Ctrl+P/N)
+      if (keyMatchers[Command.SELECTION_UP](key)) {
         setSelectedIndex(Math.max(0, selectedIndex - 1));
         return;
       }
-      if (key.name === 'down') {
+      if (keyMatchers[Command.SELECTION_DOWN](key)) {
         setSelectedIndex(Math.min(totalOptions - 1, selectedIndex + 1));
         return;
       }

--- a/packages/cli/src/ui/components/subagents/manage/AgentSelectionStep.test.tsx
+++ b/packages/cli/src/ui/components/subagents/manage/AgentSelectionStep.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act } from '@testing-library/react';
+import { render } from 'ink-testing-library';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SubagentConfig } from '@qwen-code/qwen-code-core';
+import type {
+  KeypressHandler,
+  Key,
+} from '../../../contexts/KeypressContext.js';
+import { useKeypress } from '../../../hooks/useKeypress.js';
+import { AgentSelectionStep } from './AgentSelectionStep.js';
+
+vi.mock('../../../hooks/useKeypress.js');
+
+let activeKeypressHandler: KeypressHandler | null = null;
+
+const createKey = (overrides: Partial<Key>): Key => ({
+  name: '',
+  sequence: '',
+  ctrl: false,
+  meta: false,
+  shift: false,
+  paste: false,
+  ...overrides,
+});
+
+const pressKey = (overrides: Partial<Key>) => {
+  if (!activeKeypressHandler) {
+    throw new Error('No active keypress handler');
+  }
+  const handler = activeKeypressHandler;
+  act(() => {
+    handler(createKey(overrides));
+  });
+};
+
+const agent = (
+  name: string,
+  level: SubagentConfig['level'] = 'project',
+): SubagentConfig =>
+  ({
+    name,
+    level,
+    description: '',
+    systemPrompt: '',
+  }) as unknown as SubagentConfig;
+
+describe('AgentSelectionStep', () => {
+  beforeEach(() => {
+    activeKeypressHandler = null;
+    vi.mocked(useKeypress).mockImplementation((handler, { isActive }) => {
+      if (isActive) {
+        activeKeypressHandler = handler;
+      }
+    });
+  });
+
+  it('navigates with Ctrl+N/P readline aliases', () => {
+    const { lastFrame } = render(
+      <AgentSelectionStep
+        availableAgents={[agent('first'), agent('second')]}
+        onAgentSelect={vi.fn()}
+      />,
+    );
+
+    expect(lastFrame()).toContain('● first');
+
+    pressKey({ name: 'n', sequence: '\u000E', ctrl: true });
+    expect(lastFrame()).toContain('● second');
+
+    pressKey({ name: 'p', sequence: '\u0010', ctrl: true });
+    expect(lastFrame()).toContain('● first');
+  });
+});

--- a/packages/cli/src/ui/components/subagents/manage/AgentSelectionStep.tsx
+++ b/packages/cli/src/ui/components/subagents/manage/AgentSelectionStep.tsx
@@ -8,6 +8,7 @@ import { useState, useEffect, useMemo } from 'react';
 import { Box, Text } from 'ink';
 import { theme } from '../../../semantic-colors.js';
 import { useKeypress } from '../../../hooks/useKeypress.js';
+import { keyMatchers, Command } from '../../../keyMatchers.js';
 import { type SubagentConfig } from '@qwen-code/qwen-code-core';
 import { t } from '../../../../i18n/index.js';
 
@@ -76,7 +77,7 @@ export const AgentSelectionStep = ({
     (key) => {
       const { name } = key;
 
-      if (name === 'up' || name === 'k') {
+      if (keyMatchers[Command.SELECTION_UP](key)) {
         setNavigation((prev) => {
           if (prev.currentBlock === 'project') {
             if (prev.projectIndex > 0) {
@@ -194,7 +195,7 @@ export const AgentSelectionStep = ({
             }
           }
         });
-      } else if (name === 'down' || name === 'j') {
+      } else if (keyMatchers[Command.SELECTION_DOWN](key)) {
         setNavigation((prev) => {
           if (prev.currentBlock === 'project') {
             if (prev.projectIndex < projectAgents.length - 1) {

--- a/packages/cli/src/ui/hooks/useSelectionList.test.ts
+++ b/packages/cli/src/ui/hooks/useSelectionList.test.ts
@@ -47,7 +47,11 @@ describe('useSelectionList', () => {
     mockOnHighlight.mockClear();
   });
 
-  const pressKey = (name: string, sequence: string = name) => {
+  const pressKey = (
+    name: string,
+    sequence: string = name,
+    overrides: Partial<Key> = {},
+  ) => {
     act(() => {
       if (activeKeypressHandler) {
         const key: Key = {
@@ -57,6 +61,7 @@ describe('useSelectionList', () => {
           meta: false,
           shift: false,
           paste: false,
+          ...overrides,
         };
         activeKeypressHandler(key);
       } else {
@@ -176,6 +181,19 @@ describe('useSelectionList', () => {
       pressKey('k');
       expect(result.current.activeIndex).toBe(2);
       pressKey('up');
+      expect(result.current.activeIndex).toBe(0);
+    });
+
+    it('should move with Ctrl+P and Ctrl+N readline aliases', () => {
+      const { result } = renderHook(() =>
+        useSelectionList({ items, onSelect: mockOnSelect }),
+      );
+      expect(result.current.activeIndex).toBe(0);
+
+      pressKey('n', '\u000E', { ctrl: true });
+      expect(result.current.activeIndex).toBe(2);
+
+      pressKey('p', '\u0010', { ctrl: true });
       expect(result.current.activeIndex).toBe(0);
     });
 

--- a/packages/cli/src/ui/hooks/useSelectionList.ts
+++ b/packages/cli/src/ui/hooks/useSelectionList.ts
@@ -7,6 +7,7 @@
 import { useReducer, useRef, useEffect } from 'react';
 import { createDebugLogger } from '@qwen-code/qwen-code-core';
 import { useKeypress } from './useKeypress.js';
+import { keyMatchers, Command } from '../keyMatchers.js';
 
 export interface SelectionListItem<T> {
   key: string;
@@ -324,12 +325,12 @@ export function useSelectionList<T>({
         numberInputRef.current = '';
       }
 
-      if (name === 'k' || name === 'up') {
+      if (keyMatchers[Command.SELECTION_UP](key)) {
         dispatch({ type: 'MOVE_UP', payload: { items } });
         return;
       }
 
-      if (name === 'j' || name === 'down') {
+      if (keyMatchers[Command.SELECTION_DOWN](key)) {
         dispatch({ type: 'MOVE_DOWN', payload: { items } });
         return;
       }

--- a/packages/cli/src/ui/hooks/useSessionPicker.test.ts
+++ b/packages/cli/src/ui/hooks/useSessionPicker.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SessionListItem } from '@qwen-code/qwen-code-core';
+import type { Key, KeypressHandler } from '../contexts/KeypressContext.js';
+import { useKeypress } from './useKeypress.js';
+import { useSessionPicker } from './useSessionPicker.js';
+
+type UseKeypressMockOptions = { isActive: boolean };
+
+vi.mock('./useKeypress.js');
+
+let activeKeypressHandler: KeypressHandler | null = null;
+
+const session = (
+  sessionId: string,
+  overrides: Partial<SessionListItem> = {},
+): SessionListItem => ({
+  sessionId,
+  cwd: '/repo',
+  startTime: '2026-01-01T00:00:00.000Z',
+  mtime: Date.now(),
+  prompt: `prompt ${sessionId}`,
+  filePath: `/repo/${sessionId}.jsonl`,
+  ...overrides,
+});
+
+describe('useSessionPicker', () => {
+  const onSelect = vi.fn();
+  const onCancel = vi.fn();
+
+  const sessions = [
+    session('one', { prompt: 'alpha task' }),
+    session('two', { prompt: 'beta task' }),
+    session('three', { prompt: 'gamma task' }),
+  ];
+
+  beforeEach(() => {
+    activeKeypressHandler = null;
+    vi.mocked(useKeypress).mockImplementation(
+      (handler: KeypressHandler, options?: UseKeypressMockOptions) => {
+        activeKeypressHandler = options?.isActive ? handler : null;
+      },
+    );
+    onSelect.mockClear();
+    onCancel.mockClear();
+  });
+
+  const pressKey = (
+    name: string,
+    sequence: string = name,
+    overrides: Partial<Key> = {},
+  ) => {
+    act(() => {
+      if (!activeKeypressHandler) {
+        throw new Error(`No active keypress handler for ${name}`);
+      }
+      activeKeypressHandler({
+        name,
+        sequence,
+        ctrl: false,
+        meta: false,
+        shift: false,
+        paste: false,
+        ...overrides,
+      });
+    });
+  };
+
+  const renderPicker = (
+    initialSessions: SessionListItem[] = sessions,
+    options: Partial<Parameters<typeof useSessionPicker>[0]> = {},
+  ) =>
+    renderHook(() =>
+      useSessionPicker({
+        sessionService: null,
+        initialSessions,
+        maxVisibleItems: 5,
+        onSelect,
+        onCancel,
+        ...options,
+      }),
+    );
+
+  it('uses Ctrl+N and Ctrl+P as readline aliases for list navigation', () => {
+    const { result } = renderPicker();
+
+    expect(result.current.selectedIndex).toBe(0);
+    pressKey('n', '\u000E', { ctrl: true });
+    expect(result.current.selectedIndex).toBe(1);
+
+    pressKey('p', '\u0010', { ctrl: true });
+    expect(result.current.selectedIndex).toBe(0);
+  });
+
+  it('uses Ctrl+P at the top of the list to enter search mode', () => {
+    const { result } = renderPicker();
+
+    expect(result.current.viewMode).toBe('list');
+    pressKey('p', '\u0010', { ctrl: true });
+
+    expect(result.current.viewMode).toBe('search');
+    expect(result.current.selectedIndex).toBe(0);
+  });
+
+  it('uses Ctrl+N to leave search mode when matches exist', () => {
+    const { result } = renderPicker();
+
+    pressKey('/', '/');
+    expect(result.current.viewMode).toBe('search');
+
+    pressKey('n', '\u000E', { ctrl: true });
+
+    expect(result.current.viewMode).toBe('list');
+    expect(result.current.filteredSessions).toHaveLength(3);
+  });
+
+  it('keeps search mode on Ctrl+N when the query has no matches', () => {
+    const { result } = renderPicker();
+
+    pressKey('z', 'z');
+    expect(result.current.viewMode).toBe('search');
+    expect(result.current.filteredSessions).toHaveLength(0);
+
+    pressKey('n', '\u000E', { ctrl: true });
+
+    expect(result.current.viewMode).toBe('search');
+    expect(result.current.filteredSessions).toHaveLength(0);
+  });
+});

--- a/packages/cli/src/ui/hooks/useSessionPicker.ts
+++ b/packages/cli/src/ui/hooks/useSessionPicker.ts
@@ -326,8 +326,17 @@ export function useSessionPicker({
         return;
       }
 
-      if (name === 'up' || name === 'down') {
-        const delta = name === 'up' ? -1 : +1;
+      // Arrow keys are mode-aware (cross between search and list).
+      // Hoist Ctrl+P/Ctrl+N alongside as their readline-style equivalents so
+      // they escape the search input the same way arrows do. Bare `k`/`j`
+      // remain list-only further below (they would otherwise seed the search
+      // query with the letter and the design intent — see the comment near
+      // the `name === 'k'` branch — is that vim-style keys do not cross
+      // modes).
+      const isNavUp = name === 'up' || (ctrl && name === 'p');
+      const isNavDown = name === 'down' || (ctrl && name === 'n');
+      if (isNavUp || isNavDown) {
+        const delta = isNavUp ? -1 : +1;
         const inSearch = viewMode === 'search';
         if (inSearch) {
           if (filteredSessions.length === 0) return;

--- a/packages/cli/src/ui/keyMatchers.test.ts
+++ b/packages/cli/src/ui/keyMatchers.test.ts
@@ -73,6 +73,15 @@ describe('keyMatchers', () => {
       key.ctrl && key.name === 'f',
     [Command.EXPAND_SUGGESTION]: (key: Key) => key.name === 'right',
     [Command.COLLAPSE_SUGGESTION]: (key: Key) => key.name === 'left',
+    // Selection list navigation: up/k (ctrl=false)/Ctrl+P move up; down/j (ctrl=false)/Ctrl+N move down
+    [Command.SELECTION_UP]: (key: Key) =>
+      key.name === 'up' ||
+      (key.name === 'k' && !key.ctrl) ||
+      (key.ctrl && key.name === 'p'),
+    [Command.SELECTION_DOWN]: (key: Key) =>
+      key.name === 'down' ||
+      (key.name === 'j' && !key.ctrl) ||
+      (key.ctrl && key.name === 'n'),
   };
 
   // Test data for each command with positive and negative test cases
@@ -266,6 +275,38 @@ describe('keyMatchers', () => {
       command: Command.TOGGLE_COMPACT_MODE,
       positive: [createKey('o', { ctrl: true })],
       negative: [createKey('o'), createKey('p', { ctrl: true })],
+    },
+
+    // Selection list navigation
+    {
+      command: Command.SELECTION_UP,
+      positive: [
+        createKey('up'),
+        createKey('k'),
+        createKey('p', { ctrl: true }),
+      ],
+      negative: [
+        createKey('p'),
+        createKey('n', { ctrl: true }),
+        createKey('u'),
+        // ctrl: false on k — Ctrl+K must NOT match (would conflict with KILL_LINE_RIGHT)
+        createKey('k', { ctrl: true }),
+      ],
+    },
+    {
+      command: Command.SELECTION_DOWN,
+      positive: [
+        createKey('down'),
+        createKey('j'),
+        createKey('n', { ctrl: true }),
+      ],
+      negative: [
+        createKey('n'),
+        createKey('p', { ctrl: true }),
+        createKey('d'),
+        // ctrl: false on j — Ctrl+J must NOT match (preserves Ctrl+J = newline in some terminals)
+        createKey('j', { ctrl: true }),
+      ],
     },
 
     // Shell commands


### PR DESCRIPTION
## Summary

- What changed: Adds GNU-readline-style **Ctrl+P (previous) / Ctrl+N (next)** shortcuts as a fully equivalent third input modality alongside the existing arrow keys ↑/↓ and vim-style k/j, across the qwen-code TUI's input prompt (for input-history walking) and across every selection-list / dialog surface (`/settings`, `/manage-models`, `/memory`, `/hooks`, `/mcp`, `/agents`, `/extensions`, the rewind selector, the background-tasks dialog, the ask-user-question dialog's option list, the auth-provider advanced-config focus rows, and the resume-session picker's cross-mode arrows). A new `Command.SELECTION_UP` / `Command.SELECTION_DOWN` pair is added to `packages/cli/src/config/keyBindings.ts` and the shared `useSelectionList` hook is rewritten to consume it, so every dialog inherits the unified binding without hand-rolled checks; ~12 dialogs that previously matched arrow keys (or arrow + vim only) directly are converted in this PR.
- Behavior nuance — **two-step edge transition** for the input prompt: in a multi-line buffer Ctrl+P / Ctrl+N (and arrow ↑ / ↓) move the cursor between visual rows; on the **first** row with the cursor not at column 0 the first Up press snaps the cursor to column 0 with no history change, and only the **second** Up press walks one history entry back; the mirror rule holds for Down at the last row. The same two-step rule applies in single-line buffers, which is what makes the reverse direction work too — pressing Ctrl+N immediately after Ctrl+P loaded a single-line older entry (cursor at col 0) first snaps the cursor to end-of-line, and only the press after that advances to the newer entry. After `navigateUp` the cursor lands at offset 0 (readline's "previous-history" landing position); after `navigateDown` the standard `setText` end-positioning leaves the cursor at the end. This mirrors Claude Code exactly.
- Conflict guard: the new `Command.SELECTION_UP` binding for the bare-letter k vim alias is declared as `{ key: 'k', ctrl: false }` (not modifier-agnostic), so **Ctrl+K continues to fire `Command.KILL_LINE_RIGHT` only** and never additionally fires SELECTION_UP. Without this guard the broadcast keypress model in `KeypressContext` would deliver Ctrl+K to both handlers in the same keystroke — for the `AskUserQuestionDialog`'s "Other / type a custom answer" field that pre-PR-review-fix bug would have caused Ctrl+K to simultaneously kill the text and scroll the option list above. The symmetric `{ key: 'j', ctrl: false }` clause on SELECTION_DOWN does the same for Ctrl+J (which is the legacy ASCII line-feed and is the existing Command.NEWLINE alternative).
- Text-input coexistence: a handful of dialogs put a text input *inside* the selection surface — the `AskUserQuestionDialog` "Other" custom-answer field, the `/manage-models` search box, the `/resume` search box, and the `/auth` Custom-API-Key wizard's "Context window" number-entry on the Advanced Config step. Inside those input-active sub-states the dialog's outer key handler intentionally only recognises **arrow keys and Ctrl+P / Ctrl+N** as cross-section navigation, and bare letter aliases k/j fall through to the text input as typed characters. The session-picker's pre-existing vim k/j convention ("k/j are list-only, do not cross into the search box") is preserved, while the new Ctrl+P / Ctrl+N shortcuts inherit the arrow-key semantics in that picker (mode-aware), giving a clean triad: arrows = mode-aware, Ctrl+P/N = mode-aware (readline equivalent of arrows), k/j = list-only vim convention.
- Why it changed: GNU readline (the bash/zsh line editor) and Emacs both use Ctrl+P / Ctrl+N for cursor-up / cursor-down (and, in shells, history-prev / history-next), and Anthropic's Claude Code mirrors the same convention. Users coming from those environments expect those keys to "just work" in the qwen-code TUI's input box and dialog menus. Prior to this PR, Ctrl+P / Ctrl+N already partially walked the input prompt's history but did not move the cursor in a multi-line buffer (it always jumped straight to a different history entry, ignoring the in-buffer line position), and no selection-list dialog had ever responded to Ctrl+P / Ctrl+N. The issue (#3821) requests the broader readline-shortcut family; this PR delivers the Ctrl+P / Ctrl+N piece and explicitly defers the rest.
- Reviewer focus: (1) the unified `Command.SELECTION_UP` / `SELECTION_DOWN` binding in `keyBindings.ts` with the `ctrl: false` guard on the bare-letter aliases; (2) the InputPrompt two-step edge logic in `InputPrompt.tsx` (lines around the `HISTORY_UP` / `HISTORY_DOWN` and `NAVIGATION_UP` / `NAVIGATION_DOWN` matchers, where the new "snap to home/end first, navigate history second" branching lives, including the post-`navigateUp` `buffer.moveToOffset(0)` call that parks the cursor at the start of the restored older entry); (3) the text-input-adjacent dialogs (`AskUserQuestionDialog`, `ManageModelsDialog` search mode, `ProviderSetupSteps` advanced-config) where the outer handler intentionally drops bare letter matches to avoid double-firing with the embedded TextInput; (4) the `keyMatchers.test.ts` and `InputPrompt.test.tsx` test additions which lock all of the above.

## Validation

- Commands run (from the repo root):

  ```bash
  npm run build
  cd packages/cli && npx tsc --noEmit -p .
  cd packages/cli && npx vitest run \
      src/ui/keyMatchers.test.ts \
      src/config/keyBindings.test.ts \
      src/ui/components/InputPrompt.test.tsx
  cd packages/cli && npx eslint --ext .ts,.tsx \
      src/config/keyBindings.ts \
      src/ui/keyMatchers.ts src/ui/keyMatchers.test.ts \
      src/ui/components/InputPrompt.tsx src/ui/components/InputPrompt.test.tsx \
      src/ui/hooks/useSelectionList.ts src/ui/hooks/useSessionPicker.ts \
      src/ui/components/SettingsDialog.tsx \
      src/ui/components/ManageModelsDialog.tsx \
      src/ui/components/MemoryDialog.tsx \
      src/ui/components/messages/AskUserQuestionDialog.tsx \
      src/ui/auth/ProviderSetupSteps.tsx \
      src/ui/components/RewindSelector.tsx \
      src/ui/components/PluginChoicePrompt.tsx \
      src/ui/components/background-view/BackgroundTasksDialog.tsx \
      src/ui/components/extensions/steps/ExtensionListStep.tsx \
      src/ui/components/hooks/HooksManagementDialog.tsx \
      src/ui/components/mcp/steps/ServerListStep.tsx \
      src/ui/components/mcp/steps/ToolListStep.tsx \
      src/ui/components/subagents/manage/AgentSelectionStep.tsx
  ```

- Prompts / inputs used: N/A — this is a keyboard-input-handling change in the TUI layer, not a model-prompt change.
- Expected result: `npm run build` succeeds; `tsc --noEmit` is clean for the cli package (any pre-existing errors in the unrelated `toml-to-markdown` package are unchanged); the targeted vitest suite passes with all new tests green (177 passed, 1 pre-existing skip across `keyMatchers.test.ts`, `keyBindings.test.ts`, and `InputPrompt.test.tsx`, including the four new `two-step edge transition for history navigation` cases and the new `SELECTION_UP` / `SELECTION_DOWN` matcher cases with the `Ctrl+K does NOT match SELECTION_UP` negative guard); `eslint --max-warnings 0` is clean on all touched files.
- Observed result: All of the above pass on the contributor's local environment. The lint-staged pre-commit hook auto-applied prettier and eslint --fix on the staged files which were then re-staged into the commit; no remaining lint or format drift.
- Quickest reviewer verification path: `cd packages/cli && npx vitest run src/ui/keyMatchers.test.ts src/ui/components/InputPrompt.test.tsx` is the fastest check that all the new keybinding semantics and the two-step input-prompt rule are wired correctly. For an interactive check, the input-prompt behavior is visible from the moment `qwen` is started: in an empty input press Ctrl+P to walk history (cursor lands at the start of the restored entry); type a multi-line message via Shift+Enter, then with the cursor on the bottom row press Ctrl+P repeatedly — the cursor walks up between visual rows, then on the top row snaps to column 0, then the next Ctrl+P swaps in the previous history entry (cursor again at offset 0). For the selection-list side, opening `/settings` and pressing Ctrl+P / Ctrl+N (alongside ↑ / ↓ and k / j) all move the highlighted setting.

- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):

  The three orthogonal behavior groups in this PR — the input-prompt two-step edge, the selection-list unified triad, and the text-input-coexistence asymmetry — each have a short reproducer below with a placeholder for an attached demo video. To attach a video, drag-and-drop the recorded `.mp4` / `.mov` file onto the corresponding "Demo video" line in the GitHub PR-edit textarea; GitHub will replace the placeholder text with an embedded `<video controls src="https://github.com/user-attachments/assets/…"></video>` element. (The placeholders are kept as italicised text so an unfilled slot is visible at a glance.)

  ### Case A — Input prompt: two-step edge between line motion and history

  In the main composer Ctrl+P / Ctrl+N and the arrow keys ↑ / ↓ apply the same rule:

  - On a non-first/non-last visual row of a multi-line buffer, Up / Ctrl+P moves the cursor one row up (Down / Ctrl+N moves one row down) and the history pointer does not move.
  - On the **first** visual row with the cursor not at column 0, the first Up / Ctrl+P snaps the cursor to column 0 with no history change. The *next* press walks one entry back through `inputHistory.navigateUp`; the restored older text is loaded into the buffer with the cursor parked at offset 0 (the readline "previous-history" landing). The bottom-row mirror (Down / Ctrl+N first snaps to end-of-line, then on the next press walks forward through `navigateDown`, with the new text's cursor at end via the standard `buffer.setText` end-positioning) makes the round-trip self-consistent: after Ctrl+P loaded a single-line older entry, the very first Ctrl+N is "go to end-of-line", and only the second Ctrl+N advances to the newer entry.
  - Bare k / j in the composer are ordinary typed letters — the vim aliases only act as selection-navigation in dialog lists (see Case B), since the composer is a text-editing surface, not a list of items. The Ctrl+P / Ctrl+N aliases are the cross-cutting "navigation" keys that work in both the composer and the dialog lists, which is the readline pattern.

  Reproducer: with at least three prior submitted messages in history, type a three-line draft via two Shift+Enter newlines, then press Ctrl+P repeatedly — the cursor crawls up through the visual rows of the draft, snaps to column 0 on the top row, and only then begins walking the history. The unit tests for this exact rule are in `packages/cli/src/ui/components/InputPrompt.test.tsx` under the `two-step edge transition for history navigation` describe.

  **Demo video (Case A — input-prompt two-step edge):**

https://github.com/user-attachments/assets/d943f1c1-6253-40a0-bfb7-0b6dbc95483f



  ### Case B — Selection lists: arrows, k/j, and Ctrl+P/N are interchangeable

  Every selection list / radio-button menu / vertical-option panel in the TUI now treats the three modalities as exact synonyms for vertical navigation: arrow ↑/↓, vim-style bare k/j, and readline-style Ctrl+P/Ctrl+N. The unification is mediated by the new `Command.SELECTION_UP` and `Command.SELECTION_DOWN` bindings in `packages/cli/src/config/keyBindings.ts` and the shared `useSelectionList` hook; ~12 dialogs that hand-rolled their own arrow-key checks have been converted to the unified `keyMatchers[Command.SELECTION_*]` matcher. The end-user-visible surfaces this affects (slash-command names where applicable): the model-name picker `/model`, the model-management dialog tabs row `/manage-models` (and the model-list pane beneath the search box once you drop into the list), the settings dialog `/settings`, the memory dialog `/memory` (both the file-pick list and the auto-memory / auto-cleanup toggle panel above it — the toggle panel is itself a two-row vertical-focus area and accepts the unified triad for moving between the two toggles), the hooks-management dialog `/hooks`, the mcp-server dialog's tool-list and server-list steps `/mcp`, the extensions list `/extensions`, the agents-management dialog's agent-selection step `/agents`, the rewind-snapshot selector, the plugin-choice prompt, the background-task dialog list mode, the ask-user-question multi-option dialog, the auth-provider wizard's Advanced Config focus rows (the "Enable thinking / Enable modality / Context window" panel reached via `/auth` → Custom API Key), and the resume-session picker's cross-mode arrow rule `/resume` (arrow Up at the top of the list and arrow Down inside the search box jump between the search bar and the list — Ctrl+P / Ctrl+N now do the same, while the picker's existing vim k/j convention that k/j are "list-only and do not cross modes" is intentionally preserved).

  Reproducer: open `/settings`, hold Ctrl, tap `p` and `n` alternately — the highlighted setting moves up and down. Drop Ctrl and tap `k` and `j` — same movement. Drop the letters and tap the arrow keys — same movement. The behavior matches the three "Radio Button Select" rows in `docs/users/reference/keyboard-shortcuts.md`, which is updated in this PR. The data-driven matcher itself is locked by the `SELECTION_UP` and `SELECTION_DOWN` test cases in `packages/cli/src/ui/keyMatchers.test.ts`, including the explicit negative cases that Ctrl+K and Ctrl+J do **not** match the selection-up / -down bindings (the `ctrl: false` clauses on the bare-letter aliases).

  **Demo video (Case B — selection-list unified triad):** 

https://github.com/user-attachments/assets/af9440ef-c0ec-463c-96be-04fd7bd9da5c



  ### Case C — Selection surfaces wrapping an active text input

  Four dialog surfaces in the TUI place a `<TextInput>` *inside* the selection surface, so the user can be either "picking from the list" or "typing into the text field" at any given moment. The fix in this PR makes the outer dialog's keyboard handler **stateful about which sub-mode is active**: when the text input is the active focus, the outer handler accepts only **unambiguous non-letter shortcuts** — arrow keys ↑/↓ and the readline-style Ctrl+P / Ctrl+N — for escaping the text field back to the surrounding list or tab row, and bare letters (including bare k / j / p / n) fall through to the embedded TextInput as ordinary typed characters. The same `KeypressContext` broadcast that this PR's `ctrl: false` guard on `{ key: 'k' }` and `{ key: 'j' }` neutralises for Ctrl+K / Ctrl+J would otherwise have caused the bare-letter aliases to fire on the inner TextInput **and** on the outer list-up handler simultaneously — the P0 finding the in-loop code review flagged on the very first round of the AskUserQuestionDialog "Other" custom-answer field, and the same shape applies to `/manage-models`'s search box, `/resume`'s search box, and the `/auth` Advanced Config step's Context-window number-entry. For the manage-models tabs row, which has *no* active TextInput in that focus mode, the full unified triad (arrows + k/j + Ctrl+P/N) is in effect; only the search and list focus modes — where a TextInput is currently active — narrow the matcher.

  The asymmetry between the resume-session picker's two letter conventions (vim k/j is list-only, readline Ctrl+P/N is mode-aware like arrows) is intentional: the existing source comment in `useSessionPicker.ts` documents that the vim alias was historically a "stay-in-the-list" shortcut so that typing `k` would not seed the search query with a stray letter, and we preserved that convention while adding the readline alias as a mode-aware peer of the arrows.

  Reproducer: in `/auth`'s Custom-API-Key wizard, walk through Protocol → Base URL → API Key → Model IDs to land on the Advanced Config step; tab down to the "Context window" row to activate its TextInput; type the digits `4096` — they appear in the field and the focus row does not jump. Now press Ctrl+P — the focus row jumps up to the "Enable modality" checkbox row (the TextInput releases focus). Press Ctrl+N — the focus row returns to the Context-window TextInput. The arrow keys and Ctrl+P/N behave identically here; bare letters are typed into the field. A parallel reproducer in `/manage-models`'s search box and in the `AskUserQuestionDialog`'s "Other" field (which is reached by selecting the last "Other" option in any ask-user-question prompt that exposes a free-form text fallback) shows the same rule.

  **Demo video (Case C — text-input coexistence within a selection surface):** 

https://github.com/user-attachments/assets/41b10757-71c5-4506-877f-9658e965eb1e



  ### Non-changes — surfaces deliberately left alone

  Three surfaces in the TUI are intentionally **not** wired into the unified triad, with reasoning to head off "why isn't it consistent everywhere?" review questions:

  - **`Help.tsx`** — the help-output viewer's ↑/↓ scroll the visible lines and PageUp / PageDown scroll a page. It is a read-only viewer rather than a selection list (there is no "selected item" concept), so attaching the vim k/j and readline Ctrl+P / Ctrl+N to scrolling would be a separate UX decision and is out of this PR's scope. The keybinding layer would have to either reuse `Command.NAVIGATION_UP` / `Command.NAVIGATION_DOWN` (which is wrong because those have history-walk semantics in the input prompt) or introduce a third pair (`Command.SCROLL_UP` / `Command.SCROLL_DOWN`) just for the help viewer — a future PR can do that without disturbing this one.
  - **`BackgroundTasksPill` and `AgentTabBar`** — these are *focus-traversal tokens* rather than selection lists. The existing convention in both is "Down drills into the dialog underneath the pill / out from the agent tab bar to the background pill / into the model composer, and **any printable letter yields focus back to the composer so the user can keep typing**". Wiring bare k/j into "drill into" would break the "type-to-resume-typing" UX, since pressing the letter `k` while the agent tab bar has focus would no longer simply hand focus back to the input prompt with a `k` queued — it would instead drill out of the tab bar to the bg pill. The chained Down / Up traversal (Composer ↓ → AgentTabBar ↓ → BgPill ↓ → BgDialog and the symmetric Up to bubble back) stays bound to the bare arrow keys.
  - **`ShellInputPrompt`'s `Ctrl+Shift+Up` / `Ctrl+Shift+Down`** — these are chorded shortcuts for the embedded-shell mode's shell-history scrolling (separate from the input prompt's input-history walking). The `Ctrl+Shift` chord-modifier rules them out of the unified-triad scope by construction: the new bindings declare a `ctrl: false` on the bare letters and a `ctrl: true` (no `shift` requirement) on Ctrl+P / Ctrl+N, which doesn't intersect with `Ctrl+Shift+Up`.
  - **Vim INSERT-mode** handling in `packages/cli/src/ui/hooks/vim.ts` — vim INSERT mode passes Up / Down / Tab / Enter / Ctrl+R through to the InputPrompt's completion-and-history layer, so the new Ctrl+P / Ctrl+N history-walk behaviour works under vim INSERT mode for free because vim doesn't claim those keys at the INSERT-mode layer. No vim-specific change is needed in this PR.

  ### Test coverage

  Automated coverage (the file paths are relative to the repo root):

  - `packages/cli/src/ui/keyMatchers.test.ts` adds the `SELECTION_UP` and `SELECTION_DOWN` entries to the `originalMatchers` reference table (the data-driven test in this file checks that the new `Command`-based matcher agrees with a hand-written reference for every command in the enum) and adds a positive-and-negative test-case row for each direction. The new positive cases cover arrow ↑/↓, bare k/j (with the implicit `ctrl: false` clause from the binding), and Ctrl+P / Ctrl+N. The new negative cases assert that Ctrl+K and Ctrl+J do **not** match the selection-up / -down matchers (the conflict guard for `Command.KILL_LINE_RIGHT` and `Command.NEWLINE`), and that the unrelated single letters (`u`, `d`, `p`, `n` without Ctrl) do not match either.
  - `packages/cli/src/ui/components/InputPrompt.test.tsx` adds a new `two-step edge transition for history navigation` describe block with four cases that lock the input-prompt rule: (i) Ctrl+P with the cursor not at column 0 of a non-empty buffer calls `buffer.move('home')` and does *not* call `inputHistory.navigateUp`; (ii) Ctrl+N with the cursor not at the end of the last line calls `buffer.move('end')` and does *not* call `inputHistory.navigateDown`; (iii) Ctrl+P at column 0 of the last visible row of the buffer (the "edge after the snap") calls `inputHistory.navigateUp` and then `buffer.moveToOffset(0)` to park the cursor at the start of the restored older entry (the navigate-up return value is mocked to `true` so the post-navigate `if`-branch is exercised); (iv) arrow ↑ obeys the same two-step rule as Ctrl+P. The mock buffer's `setText` in the same test file was corrected to mirror the real `text-buffer`'s "after setText, cursor lands at the end of the new text" semantic so the new assertions see an internally consistent `visualCursor` value (a small `__snapshots__` frame for the unrelated rendering test in the same file was regenerated for the same reason). Three pre-existing tests that fire Up / Down arrows in the test stdin and assert `mockInputHistory.navigate{Up,Down}` were updated to **pre-position the mock cursor at the relevant edge** before pressing the arrow, because the new two-step rule means the first arrow press at a non-edge cursor is a buffer-move rather than a history step — without the pre-positioning the existing tests would assert a history call that no longer fires on the first press. The patches are minimal: a `mockBuffer.visualCursor = [0, 0]` line before the Up arrow press and a `mockBuffer.visualCursor = [0, textLength]` line before the Down arrow press, with comments cross-referencing the new two-step rule.

  Manual coverage: the contributor maintains an out-of-tree hand-test plan at `~/.claude/projects/-Users-menghuibin-qwen-code/contributions/3821-readline-shortcuts/demo.md` covering twelve scenarios end-to-end (single-line and multi-line two-step edges in the composer, the selection-triad in `/model` and `/manage-models` and `/settings` and `/memory` and `/hooks` and `/mcp` and `/agents`, the text-input-coexistence rules in `AskUserQuestionDialog`'s "Other" field and in the `/manage-models` and `/resume` search boxes and the `/auth` Custom-API-Key advanced-config Context-window field, the Ctrl+K kill-line regression, and the cursor-landing-position rule for history navigation). The full plan is internal contributor notes and is not shipped with the PR; the videos linked above are the user-facing reproduction of the same scenarios.

  ### Documentation

  `docs/users/reference/keyboard-shortcuts.md` is updated:

  - The "Input Prompt" section's Ctrl+P and Ctrl+N entries are rewritten to describe the new two-step edge rule: "In single-line input: navigate up through the input history. In multi-line input: move the cursor up one line; fall back to history navigation when already on the first line." (and the symmetric Down wording for Ctrl+N, both ending with the "after-history-load cursor lands at start (Up) / end (Down) of the restored entry" note).
  - The "Radio Button Select" table picks up `Ctrl+P` and `Ctrl+N` as additional aliases in the existing `↑ / k` and `↓ / j` rows respectively, so the docs now read "Down Arrow / j / Ctrl+N" and "Up Arrow / k / Ctrl+P". The per-dialog inline hint strings (which still read "↑↓ to navigate") are intentionally left untouched in this PR so the i18n message-bundle surface is unchanged; the central reference doc is the canonical single source of truth for the new shortcuts. A follow-up sweep of the inline hints could go in a separate PR if discoverability becomes a complaint.

## Scope / Risk

- Main risk or tradeoff: This PR is purely additive at the keybinding layer — the new `Command.SELECTION_UP` / `Command.SELECTION_DOWN` Commands and the `{ key: 'k' / 'j', ctrl: false }` bindings are net-new entries in the configuration, and the per-dialog switches from hand-rolled `key.name === 'up'` checks to `keyMatchers[Command.SELECTION_UP](key)` widen the matched set (existing arrow-key paths still match; the additions are k/j and Ctrl+P/N). The one delicate piece is the InputPrompt's two-step edge rule, which changes existing behavior in the case where Ctrl+P was previously pressed at the first row but cursor not at column 0 of a multi-line buffer: pre-PR the keystroke walked the history; post-PR the same keystroke snaps the cursor to column 0 and only the next press walks. The change matches Claude Code and GNU-readline emacs-mode behaviour exactly and is intentionally aligned across the four equivalent ways to press "up" (arrow ↑, Ctrl+P, and — in lists — k and the vim-aware bindings); the unit tests pin this. The conflict-guard `ctrl: false` clause on the bare-letter SELECTION aliases is the second delicate piece — without it, Ctrl+K would simultaneously fire SELECTION_UP and `Command.KILL_LINE_RIGHT` because the `KeypressContext` broadcast model has no stop-propagation primitive (a structural property of the upstream keypress design that this PR does not change); the explicit `ctrl: false` in the binding sidesteps the issue by declining the match, which is the same pattern the existing `Command.ACCEPT_SUGGESTION` uses for `{ key: 'return', ctrl: false }` to avoid claiming Ctrl+Enter (which is the `Command.NEWLINE` alternative).
- The third delicate piece is the text-input-adjacent matcher narrowing in the four dialogs that wrap a `<TextInput>` inside the selection surface. The conservative choice is to accept only the unambiguous non-letter modalities (arrow keys and Ctrl+P / Ctrl+N) for cross-section navigation in those sub-modes, on the principle that the user's intent when an input is active is "type" by default, so bare letters must reach the input buffer; the readline aliases are unambiguous because the project's `TextInput` does not claim them. The pre-existing convention in the `/resume` picker (vim k/j is list-only, never crosses into the search box, by source-level comment) is preserved on principle that established conventions are sticky.
- Not covered / not validated: The cross-platform "Testing Matrix" rows below were not exercised end-to-end on Windows or Linux in CI for this branch — the contributor's local environment is macOS Darwin 25.4. The keybinding layer is platform-agnostic (it dispatches on the abstract `Key` object that `ink-keypress` parses out of the terminal-input byte stream), so the platform matrix is a formality for the typical case; the one platform-specific binding in the file (`Command.PASTE_CLIPBOARD_IMAGE` differing between Windows's `Meta+V` and other platforms' `Ctrl+V` or `Command+V`) is not touched by this PR.
- Interactive TUI testing across every covered dialog is exhaustively documented in the out-of-tree `demo.md` hand-test plan but is not part of the automated test suite. The reproducers in the Evidence section above plus the linked Cases A/B/C in the demo videos cover the key behavior groups.
- Breaking changes / migration notes: None for end users — the new shortcuts are additive aliases of existing ones, and the input-prompt two-step rule is a refinement that aligns with the same shortcut family in any other readline-aware terminal application (bash's line editor, zsh's ZLE, Emacs's basic motion, Claude Code's input prompt). For developers extending the qwen-code TUI, the `Command.SELECTION_UP` / `Command.SELECTION_DOWN` Commands are the recommended path for any new "vertical option list" dialog; the shared `useSelectionList` hook picks them up automatically. The hand-rolled `key.name === 'up'` patterns that this PR converts are now anti-patterns and should be migrated if any new dialog reaches in directly.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- `npm run build`, `npm run lint` (via the pre-commit lint-staged hook), and the targeted vitest suite all pass on macOS (Darwin 25.4, Node 22.17.1, npm bundled with that Node).
- Windows and Linux: the contributor does not have a local Windows or Linux machine for this branch. The change is at the abstract keybinding layer (`Command`-keyed matchers against the `Key` object that ink's keypress middleware produces from raw terminal byte sequences) and contains no `process.platform`-conditional logic that this PR introduces, so the platform-specific surface area is empty for the new code. The one pre-existing platform branch in `keyBindings.ts` — `Command.PASTE_CLIPBOARD_IMAGE` having a Windows-specific `Meta+V` versus a `Ctrl+V` / `Command+V` elsewhere — is untouched by this PR. The terminal-byte-sequence layer that `ink-keypress` parses is also untouched. The Windows and Linux entries are marked ⚠️ to reflect the absence of contributor-side CI verification on those platforms rather than any expected breakage.
- The Docker, Podman and Seatbelt sandboxes are marked N/A because this PR is a UI-layer keyboard-input change and does not touch the process-sandbox / containerisation code paths that those rows are about.

## Linked Issues / Bugs

This PR implements the Ctrl+P / Ctrl+N portion of the keyboard-shortcut wish-list in issue **[#3821 — Support macOS shortcuts](https://github.com/QwenLM/qwen-code/issues/3821)**. The issue lists a wider set of readline / Emacs / macOS conveniences (Meta+B / Meta+F word motion, Ctrl+H token-aware backspace, etc.) and the contributor and the issue's author explicitly scoped the present PR down to just Ctrl+P / Ctrl+N during the planning conversation captured in the per-issue design notes; the remaining wish-list entries are deferred to follow-up issues so each can be evaluated and reviewed independently. The issue is therefore **linked but not auto-closed by this PR's merge**: the maintainer can choose to close the issue manually once they consider the Ctrl+P / Ctrl+N piece sufficient resolution, or keep it open as a tracking issue for the remaining wish-list while spinning out per-shortcut sub-issues as separate PRs land.

Refs #3821

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code) (initial template) — body content extended by the contributor.
