### PR TITLE
chore(core): runtime.json sidecar follow-ups (round 2)

### DIFF
--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -225,7 +225,7 @@ export async function startInteractiveUI(
   // starting up.
   try {
     const sessionId = config.getSessionId();
-    const runtimeStatusPath = config.storage.getRuntimeStatusPath(sessionId);
+    const runtimeStatusPath = config.getRuntimeStatusPath(sessionId);
     await writeRuntimeStatus(runtimeStatusPath, {
       sessionId,
       workDir: config.getTargetDir(),

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1525,6 +1525,15 @@ export class Config {
   }
 
   /**
+   * Path to the runtime.json sidecar for `sessionId` (or the current
+   * session if omitted). Thin pass-through to `Storage` so callers
+   * outside `core` don't reach into `config.storage` directly.
+   */
+  getRuntimeStatusPath(sessionId: string = this.sessionId): string {
+    return this.storage.getRuntimeStatusPath(sessionId);
+  }
+
+  /**
    * Returns the resumed session data if this session was resumed from a previous one.
    */
   getResumedSessionData(): ResumedSessionData | undefined {

--- a/packages/core/src/config/storage.ts
+++ b/packages/core/src/config/storage.ts
@@ -249,8 +249,16 @@ export class Storage {
    * `<projectDir>/chats/<sessionId>.runtime.json` so external observers
    * (terminal multiplexers, IDE integrations, status daemons) can scan
    * the same directory used for chat history to find live sessions.
+   *
+   * `sessionId` is normally a `randomUUID()`, but `--resume <id>` and
+   * `Config.startNewSession(sessionId)` accept user-supplied strings.
+   * Defense-in-depth: reject anything that could escape the `chats/`
+   * directory (path separators, `..`, NUL, leading dot) before joining.
    */
   getRuntimeStatusPath(sessionId: string): string {
+    if (!isSafeSessionId(sessionId)) {
+      throw new Error(`unsafe sessionId for runtime status path: ${sessionId}`);
+    }
     return path.join(
       this.getProjectDir(),
       'chats',
@@ -291,4 +299,18 @@ export class Storage {
   getHistoryFilePath(): string {
     return path.join(this.getProjectTempDir(), 'shell_history');
   }
+}
+
+// Path-component safety for ids that we use as filename stems.
+// Accept the same shape `randomUUID()` produces (hex + hyphens) plus the
+// underscore for hand-rolled ids, and reject anything that contains a
+// path separator, traversal, NUL, or a leading dot/space. Conservative
+// by design: legitimate consumers won't trip it.
+function isSafeSessionId(sessionId: string): boolean {
+  if (typeof sessionId !== 'string') return false;
+  if (sessionId.length === 0 || sessionId.length > 128) return false;
+  if (!/^[A-Za-z0-9._-]+$/.test(sessionId)) return false;
+  if (sessionId.includes('..')) return false;
+  if (sessionId.startsWith('.')) return false;
+  return true;
 }

--- a/packages/core/src/utils/runtimeStatus.config.test.ts
+++ b/packages/core/src/utils/runtimeStatus.config.test.ts
@@ -157,4 +157,30 @@ describe('Storage.getRuntimeStatusPath', () => {
     expect(p.endsWith(path.join('chats', 'abc-123.runtime.json'))).toBe(true);
     expect(p.startsWith(storage.getProjectDir())).toBe(true);
   });
+
+  it('accepts the randomUUID shape', () => {
+    const storage = new Storage(tmpDir);
+    expect(() =>
+      storage.getRuntimeStatusPath('aaaaaaaa-1111-2222-3333-aaaaaaaaaaaa'),
+    ).not.toThrow();
+  });
+
+  // Defense-in-depth: --resume <id> and Config.startNewSession(id) accept
+  // user-supplied strings. These would resolve outside chats/ via
+  // path.join, so reject them at the boundary.
+  it.each([
+    ['empty string', ''],
+    ['parent traversal', '../foo'],
+    ['nested parent traversal', 'a/../b'],
+    ['forward slash', 'foo/bar'],
+    ['backslash', 'foo\\bar'],
+    ['leading dot', '.hidden'],
+    ['NUL byte', 'foo\0bar'],
+    ['whitespace', 'foo bar'],
+  ])('rejects %s', (_label, sessionId) => {
+    const storage = new Storage(tmpDir);
+    expect(() => storage.getRuntimeStatusPath(sessionId)).toThrow(
+      /unsafe sessionId/,
+    );
+  });
 });

--- a/packages/core/src/utils/runtimeStatus.ts
+++ b/packages/core/src/utils/runtimeStatus.ts
@@ -30,8 +30,12 @@
  *   (e.g. a hypothetical future mode-switch). Not currently invoked.
  *
  * The file is written atomically (tmp-file + rename) and contains a
- * small, stable schema. External consumers should treat unknown fields
- * as forward-compatible additions.
+ * small, stable schema. Within a given `schema_version` external
+ * consumers should ignore unknown fields so future producers can add
+ * new keys without breaking older readers. A bump of `schema_version`
+ * is itself a breaking change — the reader rejects mismatches outright
+ * rather than guessing forward compatibility — so the version is bumped
+ * only when a field's meaning or required-set actually changes.
  */
 
 import * as crypto from 'node:crypto';


### PR DESCRIPTION
## Summary

Picks up three of the items left as **Out of scope** in #4030, all from the original #3714 review. No runtime behavior change.

1. **Sanitize `sessionId` in `Storage.getRuntimeStatusPath`** *(was #6 of the original 9 review items — `storage.ts:241`)*. `--resume <id>` and `Config.startNewSession(id)` accept user-supplied strings, so values like `../foo` or `a/b` would resolve outside `chats/` via `path.join`. Reject anything that isn't `[A-Za-z0-9._-]{1..128}`, plus reject `..` substrings, leading dot, NUL, whitespace, and empty. The two on-path callers (`gemini.tsx` startup, `Config.startNewSession`'s IIFE) already swallow exceptions, so a throw is safe.
2. **Add `Config.getRuntimeStatusPath()` pass-through** *(was the encapsulation note on `gemini.tsx:185`)*. `gemini.tsx` was reaching into `config.storage` directly, which leaks the `Storage` internal across the package boundary. Route through `Config` so a future `Storage` refactor surfaces at compile time.
3. **Clarify the module-header forward-compat wording** *(was the doc/code-disagreement note on `runtimeStatus.ts:27`)*. The original *“treat unknown fields as forward-compatible additions”* read as if `schema_version` itself were forward-compatible, which contradicts the strict-equality check in `readRuntimeStatus`. Reworded to scope forward-compat to unknown fields **within** a `schema_version`, and to state that a bump is a breaking change.

## Tests

```
$ npx vitest run src/utils/runtimeStatus.test.ts src/utils/runtimeStatus.config.test.ts
 ✓ src/utils/runtimeStatus.test.ts        (19 tests)
 ✓ src/utils/runtimeStatus.config.test.ts (13 tests)   ← +9
 Test Files  2 passed (2)
      Tests  32 passed (32)
```

Eight new cases in `Storage.getRuntimeStatusPath` cover the rejection set (empty, `../foo`, `a/../b`, `foo/bar`, `foo\\bar`, `.hidden`, NUL, whitespace), plus one positive case for the `randomUUID` shape.

`config.test.ts` 132/132 still pass. Workspace `typecheck` is clean for the touched packages (the two pre-existing errors in `renameCommand.ts` / `summaryCommand.ts` are unrelated and reproduce on clean `main`).

## Test plan

- [x] `runtimeStatus.test.ts` — 19/19 unchanged
- [x] `runtimeStatus.config.test.ts` — 13/13 (added 9)
- [x] `config.test.ts` — 132/132 unchanged
- [x] `core` typecheck clean
- [x] `cli` typecheck clean for `gemini.tsx`

## Out of scope (still)

Two items from #3714 review remain unhandled and are deliberately not in this PR:

- **`renameWithRetry` de-duplication against `atomicFileWrite.ts`.** Cross-module refactor — better as its own PR where the consolidation can be reviewed independently of the sidecar code path.
- **Fire-and-forget IIFE serialization in `Config.startNewSession`.** Final on-disk state is correct after any rapid `/clear` burst (the last `rename` wins and external consumers PID-liveness-check anyway). Adding a promise-chain mutex would buy nothing observable.