### PR TITLE
feat(subagents): use fastModel for Explore subagent

### DIFF
--- a/packages/core/src/subagents/builtin-agents.ts
+++ b/packages/core/src/subagents/builtin-agents.ts
@@ -54,6 +54,7 @@ Notes:
       name: 'Explore',
       description:
         'Fast agent specialized for exploring codebases. Use this when you need to quickly find files by patterns (eg. "src/components/**/*.tsx"), search code for keywords (eg. "API endpoints"), or answer questions about the codebase (eg. "how do API endpoints work?"). When calling this agent, specify the desired thoroughness level: "quick" for basic searches, "medium" for moderate exploration, or "very thorough" for comprehensive analysis across multiple locations and naming conventions.',
+      model: 'fast',
       systemPrompt: `You are a file search specialist agent. You excel at thoroughly navigating and exploring codebases.
 
 === CRITICAL: READ-ONLY MODE - NO FILE MODIFICATIONS ===

--- a/packages/core/src/subagents/model-selection.test.ts
+++ b/packages/core/src/subagents/model-selection.test.ts
@@ -49,4 +49,29 @@ describe('parseSubagentModelSelection', () => {
       inherits: false,
     });
   });
+
+  it('parses the fast keyword', () => {
+    expect(parseSubagentModelSelection('fast')).toEqual({
+      inherits: false,
+      usesFastModel: true,
+    });
+  });
+
+  it('parses the fast keyword with surrounding whitespace', () => {
+    expect(parseSubagentModelSelection('  fast  ')).toEqual({
+      inherits: false,
+      usesFastModel: true,
+    });
+  });
+
+  it('treats model IDs that merely contain "fast" as bare IDs, not the keyword', () => {
+    expect(parseSubagentModelSelection('qwen3-coder-flash')).toEqual({
+      modelId: 'qwen3-coder-flash',
+      inherits: false,
+    });
+    expect(parseSubagentModelSelection('Fast')).toEqual({
+      modelId: 'Fast',
+      inherits: false,
+    });
+  });
 });

--- a/packages/core/src/subagents/model-selection.ts
+++ b/packages/core/src/subagents/model-selection.ts
@@ -10,6 +10,12 @@ export interface ParsedSubagentModelSelection {
   authType?: AuthType;
   modelId?: string;
   inherits: boolean;
+  /**
+   * True when the selector was `fast` — the runtime resolves this to
+   * `Config.getFastModel()` if a valid fast model is configured, and
+   * falls back to inheriting the parent model otherwise.
+   */
+  usesFastModel?: boolean;
 }
 
 const AUTH_TYPES = new Set<AuthType>(Object.values(AuthType));
@@ -19,6 +25,7 @@ const AUTH_TYPES = new Set<AuthType>(Object.values(AuthType));
  *
  * Supported forms:
  * - omitted / inherit -> use parent conversation model
+ * - fast -> use Config.getFastModel() if available, else inherit parent model
  * - modelId -> use parent authType with the provided modelId
  * - authType:modelId -> use explicit authType and modelId
  */
@@ -28,6 +35,10 @@ export function parseSubagentModelSelection(
   const trimmed = model?.trim();
   if (!trimmed || trimmed === 'inherit') {
     return { inherits: true };
+  }
+
+  if (trimmed === 'fast') {
+    return { inherits: false, usesFastModel: true };
   }
 
   const colonIndex = trimmed.indexOf(':');

--- a/packages/core/src/subagents/subagent-manager.test.ts
+++ b/packages/core/src/subagents/subagent-manager.test.ts
@@ -1397,6 +1397,40 @@ System prompt 3`);
         );
         expect(runtimeConfig.modelConfig.model).toBe('gpt-4');
       });
+
+      it('should resolve "fast" to Config.getFastModel() when one is configured', async () => {
+        const fastConfig: SubagentConfig = { ...validConfig, model: 'fast' };
+        vi.spyOn(mockConfig, 'getFastModel').mockReturnValue('fast-model-id');
+
+        const runtimeConfig = await manager.convertToRuntimeConfig(
+          fastConfig,
+          mockConfig,
+        );
+
+        expect(runtimeConfig.modelConfig.model).toBe('fast-model-id');
+      });
+
+      it('should leave modelConfig empty for "fast" when getFastModel returns undefined', async () => {
+        // Mirrors the unset / invalid-for-authType cases — AgentCore then
+        // falls back to runtimeContext.getModel() (the parent model).
+        const fastConfig: SubagentConfig = { ...validConfig, model: 'fast' };
+        vi.spyOn(mockConfig, 'getFastModel').mockReturnValue(undefined);
+
+        const runtimeConfig = await manager.convertToRuntimeConfig(
+          fastConfig,
+          mockConfig,
+        );
+
+        expect(runtimeConfig.modelConfig).toEqual({});
+      });
+
+      it('should leave modelConfig empty for "fast" when no runtimeContext is provided', async () => {
+        const fastConfig: SubagentConfig = { ...validConfig, model: 'fast' };
+
+        const runtimeConfig = await manager.convertToRuntimeConfig(fastConfig);
+
+        expect(runtimeConfig.modelConfig).toEqual({});
+      });
     });
 
     describe('mergeConfigurations', () => {
@@ -1524,6 +1558,35 @@ System prompt 3`);
         expect(runtimeView).toBeDefined();
         expect(runtimeView!.contentGenerator).toBe(fakeGenerator);
         expect(runtimeView!.contentGeneratorConfig.model).toBe('custom-model');
+      });
+
+      it('should build a ContentGenerator with the resolved fastModel when model is "fast"', async () => {
+        const config = { ...agentConfig, model: 'fast' };
+        vi.spyOn(mockConfig, 'getFastModel').mockReturnValue('fast-model-id');
+
+        await manager.createAgentHeadless(config, mockConfig);
+
+        expect(mockCreateContentGenerator).toHaveBeenCalledWith(
+          expect.objectContaining({
+            model: 'fast-model-id',
+            authType: AuthType.USE_OPENAI,
+          }),
+          mockConfig,
+        );
+      });
+
+      it('should NOT build a new ContentGenerator for "fast" when getFastModel returns undefined', async () => {
+        const config = { ...agentConfig, model: 'fast' };
+        vi.spyOn(mockConfig, 'getFastModel').mockReturnValue(undefined);
+
+        await manager.createAgentHeadless(config, mockConfig);
+
+        // Falls back to inheriting the parent — no override, no runtimeView.
+        expect(mockCreateContentGenerator).not.toHaveBeenCalled();
+        const { runtimeView } = destructureAgentHeadlessCall(
+          mockAgentHeadlessCreate.mock.calls[0],
+        );
+        expect(runtimeView).toBeUndefined();
       });
     });
   });

--- a/packages/core/src/subagents/subagent-manager.ts
+++ b/packages/core/src/subagents/subagent-manager.ts
@@ -638,7 +638,10 @@ export class SubagentManager {
     },
   ): Promise<AgentHeadless> {
     try {
-      const runtimeConfig = await this.convertToRuntimeConfig(config);
+      const runtimeConfig = await this.convertToRuntimeConfig(
+        config,
+        runtimeContext,
+      );
       const promptConfig: PromptConfig = {
         ...runtimeConfig.promptConfig,
         ...options?.promptConfigOverrides,
@@ -741,6 +744,20 @@ export class SubagentManager {
       return undefined;
     }
 
+    let resolvedModelId = selection.modelId;
+    if (selection.usesFastModel) {
+      // getFastModel() returns the fastModel id only when it's valid for
+      // the current authType; otherwise undefined. Treat undefined as
+      // inherit so an unset or invalid fastModel silently falls back to
+      // the parent session model — matching every other getFastModel()
+      // call site (ForkedAgent, sessionTitle, etc.).
+      const fast = base.getFastModel();
+      if (!fast) {
+        return undefined;
+      }
+      resolvedModelId = fast;
+    }
+
     const authType =
       selection.authType ?? base.getContentGeneratorConfig().authType;
     const authOverrides = {
@@ -750,7 +767,7 @@ export class SubagentManager {
     const view = await createRuntimeContentGeneratorView(
       base,
       base,
-      selection.modelId,
+      resolvedModelId,
       authOverrides,
     );
 
@@ -770,14 +787,22 @@ export class SubagentManager {
    */
   async convertToRuntimeConfig(
     config: SubagentConfig,
+    runtimeContext?: Config,
   ): Promise<SubagentRuntimeConfig> {
     const promptConfig: PromptConfig = {
       systemPrompt: config.systemPrompt,
     };
 
     const selection = parseSubagentModelSelection(config.model);
+    let resolvedModelId = selection.modelId;
+    if (selection.usesFastModel && runtimeContext) {
+      // Resolve `fast` to the configured fastModel. Undefined here means
+      // either unset or invalid for the current authType — leave modelConfig
+      // empty so the agent inherits the parent model (same as `inherit`).
+      resolvedModelId = runtimeContext.getFastModel();
+    }
     const modelConfig: ModelConfig = {
-      ...(selection.modelId ? { model: selection.modelId } : {}),
+      ...(resolvedModelId ? { model: resolvedModelId } : {}),
     };
 
     const runConfig: RunConfig = {

--- a/packages/core/src/subagents/types.ts
+++ b/packages/core/src/subagents/types.ts
@@ -83,6 +83,8 @@ export interface SubagentConfig {
   /**
    * Optional model selector.
    * - Omitted or 'inherit': use the main conversation model
+   * - 'fast': use Config.getFastModel() under the parent authType when
+   *   configured and valid; silently inherit the parent model otherwise
    * - 'model-id': use the given model with the main conversation authType
    * - 'authType:model-id': use the given authType and model ID
    */


### PR DESCRIPTION
## Summary

- What changed: The built-in `Explore` subagent now uses the configured `fastModel` (e.g. `qwen3-coder-flash`) when one is available, falling back to inheriting the main session model when it isn't.
- Why it changed: Explore's read-only search workload is the canonical "small, frequent, low-stakes" job that a fast model should handle. Other parts of the product (session title, recap, ForkedAgent, memory relevance, etc.) already use `fastModel`; Explore was the missing piece.
- Reviewer focus: the new `fast` keyword in the subagent model selector, and the silent-fallback behavior when `fastModel` is unset or invalid for the current authType.

## Validation

- Commands run:
  ```bash
  # Configure fastModel via /settings, then in any qwen-code session:
  qwen "Use the Agent tool with subagent_type='Explore' to find every file ending in .ts under packages/core/src/subagents."
  ```
- Prompts / inputs used: any prompt that triggers an Explore subagent spawn.
- Expected result: with `fastModel` set, the Explore subagent's API calls go out under the fastModel id; the main session keeps using the main model. With `fastModel` unset or set to an id not available for the current authType, Explore silently falls back to the main model (no error).
- Observed result: matches expected across all five E2E scenarios (see PR comment for the full table).
- Quickest reviewer verification path: set `fastModel` in settings, run `qwen --openai-logging --openai-logging-dir /tmp/logs "Use the Explore subagent to find any .md file"`, then `jq '.request.model' /tmp/logs/*.json` and confirm the Explore-system-prompt call uses fastModel while parent calls use the main model.
- Evidence: full E2E table posted as a comment on this PR.

## Scope / Risk

- Main risk or tradeoff: the new `fast` keyword introduces an asymmetry in subagent model resolution — `fast` silently degrades to inherit, while a bare model id error-surfaces if the provider rejects it. This is intentional (matches every other `getFastModel()` call site in the codebase) and documented in the design doc.
- Not covered / not validated: the `fast` keyword is only wired into Explore in this PR. User-defined subagents can opt in via frontmatter (`model: fast`) but that path hasn't been added to the subagent UI/wizard.
- Breaking changes / migration notes: none. The keyword is additive; agents that don't declare `model: fast` are unchanged.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Validated end-to-end on macOS via the npm-built bundle (`node dist/cli.js`). The change is platform-agnostic — pure TypeScript model-selection logic with no filesystem or OS-specific code paths.

## Linked Issues / Bugs

None.