### PR TITLE
feat(cli): add session-scoped /goal command with judge-driven turn continuation

### DIFF
--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1847,6 +1847,8 @@ export default {
     'Press Ctrl+O to show full tool output',
   'Switch to plan mode or exit plan mode':
     'Switch to plan mode or exit plan mode',
+  'Set a goal — keep working until the condition is met':
+    'Set a goal — keep working until the condition is met',
   'Exited plan mode. Previous approval mode restored.':
     'Exited plan mode. Previous approval mode restored.',
   'Enabled plan mode. The agent will analyze and plan without executing tools.':

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -1416,6 +1416,8 @@ export default {
     '緊湊模式下隱藏工具輸出和思考過程，界面更簡潔（Ctrl+O 切換）。',
   'Press Ctrl+O to show full tool output': '按 Ctrl+O 查看詳細工具調用結果',
   'Switch to plan mode or exit plan mode': '切換到計劃模式或退出計劃模式',
+  'Set a goal — keep working until the condition is met':
+    '設定目標 — 持續工作直到條件滿足',
   'Exited plan mode. Previous approval mode restored.':
     '已退出計劃模式，已恢復之前的審批模式。',
   'Enabled plan mode. The agent will analyze and plan without executing tools.':

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -1605,6 +1605,8 @@ export default {
     '紧凑模式下隐藏工具输出和思考过程，界面更简洁（Ctrl+O 切换）。',
   'Press Ctrl+O to show full tool output': '按 Ctrl+O 查看详细工具调用结果',
   'Switch to plan mode or exit plan mode': '切换到计划模式或退出计划模式',
+  'Set a goal — keep working until the condition is met':
+    '设定目标 — 持续工作直到条件满足',
   'Exited plan mode. Previous approval mode restored.':
     '已退出计划模式，已恢复之前的审批模式。',
   'Enabled plan mode. The agent will analyze and plan without executing tools.':

--- a/packages/cli/src/services/BuiltinCommandLoader.ts
+++ b/packages/cli/src/services/BuiltinCommandLoader.ts
@@ -28,6 +28,7 @@ import { directoryCommand } from '../ui/commands/directoryCommand.js';
 import { editorCommand } from '../ui/commands/editorCommand.js';
 import { exportCommand } from '../ui/commands/exportCommand.js';
 import { extensionsCommand } from '../ui/commands/extensionsCommand.js';
+import { goalCommand } from '../ui/commands/goalCommand.js';
 import { helpCommand } from '../ui/commands/helpCommand.js';
 import { hooksCommand } from '../ui/commands/hooksCommand.js';
 import { ideCommand } from '../ui/commands/ideCommand.js';
@@ -123,6 +124,7 @@ export class BuiltinCommandLoader implements ICommandLoader {
       ...(this.config?.getManagedAutoMemoryEnabled()
         ? [dreamCommand, forgetCommand]
         : []),
+      goalCommand,
       memoryCommand,
       modelCommand,
       manageModelsCommand,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -61,6 +61,7 @@ import {
   ToolNames,
 } from '@qwen-code/qwen-code-core';
 import { buildResumedHistoryItems } from './utils/resumeHistoryUtils.js';
+import { restoreGoalFromHistory } from './utils/restoreGoal.js';
 import {
   getStickyTodos,
   getStickyTodoMaxVisibleItems,
@@ -429,6 +430,13 @@ export const AppContainer = (props: AppContainerProps) => {
           config,
         );
         historyManager.loadHistory(historyItems);
+
+        // Re-arm any `/goal` that was active when the prior session ended.
+        try {
+          restoreGoalFromHistory(historyItems, config);
+        } catch {
+          // Restore is best-effort — never block resume on it.
+        }
 
         const recovered = await config.loadPausedBackgroundAgents(
           config.getSessionId(),

--- a/packages/cli/src/ui/commands/goalCommand.test.ts
+++ b/packages/cli/src/ui/commands/goalCommand.test.ts
@@ -1,0 +1,292 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { goalCommand } from './goalCommand.js';
+import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
+import type { Config } from '@qwen-code/qwen-code-core';
+import {
+  __resetActiveGoalStoreForTests,
+  clearActiveGoal,
+  notifyGoalTerminal,
+} from '@qwen-code/qwen-code-core';
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    getSessionId: vi.fn().mockReturnValue('sess-1'),
+    isTrustedFolder: vi.fn().mockReturnValue(true),
+    getDisableAllHooks: vi.fn().mockReturnValue(false),
+    getHookSystem: vi.fn().mockReturnValue({
+      addFunctionHook: vi.fn().mockReturnValue('hook-1'),
+      removeFunctionHook: vi.fn().mockReturnValue(true),
+    }),
+    ...overrides,
+  } as unknown as Config;
+}
+
+describe('goalCommand', () => {
+  beforeEach(() => __resetActiveGoalStoreForTests());
+  afterEach(() => __resetActiveGoalStoreForTests());
+
+  it('rejects when config is missing', async () => {
+    const ctx = createMockCommandContext();
+    const result = await goalCommand.action!(ctx, 'do x');
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'error',
+    });
+  });
+
+  it('shows status (no goal) for empty args', async () => {
+    const ctx = createMockCommandContext({
+      services: { config: makeConfig() as unknown as Config },
+    });
+    const result = await goalCommand.action!(ctx, '');
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'info',
+    });
+    expect((result as { content: string }).content).toMatch(/no goal set/i);
+  });
+
+  it('blocks /goal in untrusted folder', async () => {
+    const ctx = createMockCommandContext({
+      services: {
+        config: makeConfig({
+          isTrustedFolder: vi.fn().mockReturnValue(false),
+        } as unknown as Partial<Config>),
+      },
+    });
+    const result = await goalCommand.action!(ctx, 'do x');
+    expect(result).toMatchObject({ type: 'message', messageType: 'error' });
+    expect((result as { content: string }).content).toMatch(/trusted/i);
+  });
+
+  it('blocks /goal when hooks are disabled by policy', async () => {
+    const ctx = createMockCommandContext({
+      services: {
+        config: makeConfig({
+          getDisableAllHooks: vi.fn().mockReturnValue(true),
+        } as unknown as Partial<Config>),
+      },
+    });
+    const result = await goalCommand.action!(ctx, 'do x');
+    expect(result).toMatchObject({ type: 'message', messageType: 'error' });
+    expect((result as { content: string }).content).toMatch(/disabled/i);
+  });
+
+  it('rejects oversized conditions', async () => {
+    const ctx = createMockCommandContext({
+      services: { config: makeConfig() as unknown as Config },
+    });
+    const result = await goalCommand.action!(ctx, 'x'.repeat(4001));
+    expect(result).toMatchObject({ type: 'message', messageType: 'error' });
+    expect((result as { content: string }).content).toMatch(/limited/i);
+  });
+
+  it('clears existing goal on clear keyword and emits a cleared card', async () => {
+    const cfg = makeConfig();
+    const ctx = createMockCommandContext({
+      services: { config: cfg as unknown as Config },
+    });
+    await goalCommand.action!(ctx, 'write hello');
+    const before = (ctx.ui.addItem as ReturnType<typeof vi.fn>).mock.calls
+      .length;
+    const result = await goalCommand.action!(ctx, 'clear');
+    expect(result).toBeUndefined();
+    const after = (ctx.ui.addItem as ReturnType<typeof vi.fn>).mock.calls
+      .length;
+    expect(after).toBe(before + 1);
+    const lastItem = (ctx.ui.addItem as ReturnType<typeof vi.fn>).mock.calls[
+      after - 1
+    ][0];
+    expect(lastItem).toMatchObject({
+      type: 'goal_status',
+      kind: 'cleared',
+      condition: 'write hello',
+    });
+  });
+
+  it('returns info when clearing a non-existent goal', async () => {
+    const ctx = createMockCommandContext({
+      services: { config: makeConfig() as unknown as Config },
+    });
+    const result = await goalCommand.action!(ctx, 'cancel');
+    expect(result).toMatchObject({
+      type: 'message',
+      messageType: 'info',
+      content: 'No goal set.',
+    });
+  });
+
+  it('registers the hook and submits an instructional prompt on set', async () => {
+    const ctx = createMockCommandContext({
+      services: { config: makeConfig() as unknown as Config },
+    });
+    const result = await goalCommand.action!(ctx, 'write a hello world script');
+    expect(result).toMatchObject({ type: 'submit_prompt' });
+    const submit = result as { content: Array<{ text: string }> };
+    expect(submit.content[0].text).toMatch(/Stop hook is now active/i);
+    expect(submit.content[0].text).toMatch(/write a hello world script/);
+
+    const setCall = (ctx.ui.addItem as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(setCall).toMatchObject({
+      type: 'goal_status',
+      kind: 'set',
+      condition: 'write a hello world script',
+    });
+  });
+
+  it('shows active goal status when re-invoked with empty args', async () => {
+    const ctx = createMockCommandContext({
+      services: { config: makeConfig() as unknown as Config },
+    });
+    await goalCommand.action!(ctx, 'do x');
+    const result = await goalCommand.action!(ctx, '');
+    expect((result as { content: string }).content).toMatch(
+      /Goal active: do x/,
+    );
+  });
+
+  it('forwards core terminal events into a goal_status history item', async () => {
+    const ctx = createMockCommandContext({
+      services: { config: makeConfig() as unknown as Config },
+    });
+    await goalCommand.action!(ctx, 'do x');
+    const addItem = ctx.ui.addItem as ReturnType<typeof vi.fn>;
+    const beforeCount = addItem.mock.calls.length;
+
+    notifyGoalTerminal('sess-1', {
+      kind: 'achieved',
+      condition: 'do x',
+      iterations: 3,
+      durationMs: 12_345,
+      lastReason: 'quoted evidence from transcript',
+    });
+
+    expect(addItem.mock.calls.length).toBe(beforeCount + 1);
+    const lastItem = addItem.mock.calls.at(-1)![0];
+    expect(lastItem).toMatchObject({
+      type: 'goal_status',
+      kind: 'achieved',
+      condition: 'do x',
+      iterations: 3,
+      durationMs: 12_345,
+      lastReason: 'quoted evidence from transcript',
+    });
+  });
+
+  it('after achievement, empty /goal shows the last completed summary', async () => {
+    const ctx = createMockCommandContext({
+      services: { config: makeConfig() as unknown as Config },
+    });
+    await goalCommand.action!(ctx, 'do x');
+    // Real flow: hook callback clears active goal BEFORE notifying.
+    clearActiveGoal('sess-1');
+    notifyGoalTerminal('sess-1', {
+      kind: 'achieved',
+      condition: 'do x',
+      iterations: 3,
+      durationMs: 24_000,
+      lastReason: 'transcript shows completion',
+    });
+    const result = await goalCommand.action!(ctx, '');
+    const content = (result as { content: string }).content;
+    expect(content).toMatch(/Goal achieved/);
+    expect(content).toMatch(/3 turns/);
+    expect(content).toMatch(/24s/);
+    expect(content).toMatch(/Goal: do x/);
+    // `Last check:` line was dropped from the achieved summary — the judge
+    // reason is informative only during the in-flight loop, not in the
+    // final card.
+    expect(content).not.toMatch(/Last check/);
+    expect(content).not.toMatch(/transcript shows completion/);
+  });
+
+  it('strict claude alignment: `/goal clear` with no active goal does NOT dismiss the achievement summary', async () => {
+    // Claude Code's `woH` bails (`q.length===0 → return null`) when no active
+    // goal exists — it does NOT write a dismissal sentinel and does NOT wipe
+    // the cache. Subsequent empty `/goal` still surfaces the previous
+    // achievement via `findLastTerminalGoal`. We pin this behavior to prevent
+    // accidental divergence; users who want a true "forget" will need a
+    // separate dedicated keyword (out of scope for this alignment).
+    const ctx = createMockCommandContext({
+      services: { config: makeConfig() as unknown as Config },
+    });
+    await goalCommand.action!(ctx, 'do x');
+    clearActiveGoal('sess-1');
+    notifyGoalTerminal('sess-1', {
+      kind: 'achieved',
+      condition: 'do x',
+      iterations: 3,
+      durationMs: 1_000,
+    });
+
+    const addItem = ctx.ui.addItem as ReturnType<typeof vi.fn>;
+    const beforeClearCount = addItem.mock.calls.length;
+
+    // /goal clear with no active goal: pure no-op informational message
+    const clearResult = await goalCommand.action!(ctx, 'clear');
+    expect(clearResult).toMatchObject({
+      type: 'message',
+      messageType: 'info',
+      content: 'No goal set.',
+    });
+    expect(addItem.mock.calls.length).toBe(beforeClearCount);
+
+    // Cache survives — empty /goal still shows the achievement card.
+    const afterClear = await goalCommand.action!(ctx, '');
+    expect((afterClear as { content: string }).content).toMatch(
+      /Goal achieved/,
+    );
+  });
+
+  it('after abort, empty /goal shows the aborted summary', async () => {
+    const ctx = createMockCommandContext({
+      services: { config: makeConfig() as unknown as Config },
+    });
+    await goalCommand.action!(ctx, 'do x');
+    clearActiveGoal('sess-1');
+    notifyGoalTerminal('sess-1', {
+      kind: 'aborted',
+      condition: 'do x',
+      iterations: 50,
+      durationMs: 60_000,
+      systemMessage: 'Goal max iterations reached',
+    });
+    const result = await goalCommand.action!(ctx, '');
+    const content = (result as { content: string }).content;
+    expect(content).toMatch(/Goal aborted/);
+    expect(content).toMatch(/Goal: do x/);
+    // No more `Last check:` line — the `systemMessage`/`lastReason` content
+    // lives on the goal_status history item (see test below) but is dropped
+    // from the empty-/goal summary.
+    expect(content).not.toMatch(/Last check/);
+  });
+
+  it('falls back to systemMessage as lastReason on aborted events', async () => {
+    const ctx = createMockCommandContext({
+      services: { config: makeConfig() as unknown as Config },
+    });
+    await goalCommand.action!(ctx, 'do x');
+    const addItem = ctx.ui.addItem as ReturnType<typeof vi.fn>;
+
+    notifyGoalTerminal('sess-1', {
+      kind: 'aborted',
+      condition: 'do x',
+      iterations: 50,
+      durationMs: 60_000,
+      systemMessage: 'Goal max iterations reached',
+    });
+
+    const lastItem = addItem.mock.calls.at(-1)![0];
+    expect(lastItem).toMatchObject({
+      kind: 'aborted',
+      lastReason: 'Goal max iterations reached',
+    });
+  });
+});

--- a/packages/cli/src/ui/commands/goalCommand.ts
+++ b/packages/cli/src/ui/commands/goalCommand.ts
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  CommandKind,
+  type CommandContext,
+  type MessageActionReturn,
+  type SlashCommand,
+  type SlashCommandActionReturn,
+  type SubmitPromptActionReturn,
+} from './types.js';
+import {
+  getActiveGoal,
+  getLastGoalTerminal,
+  registerGoalHook,
+  setGoalTerminalObserver,
+  unregisterGoalHook,
+  type GoalTerminalEvent,
+} from '@qwen-code/qwen-code-core';
+import { MessageType, type HistoryItemGoalStatus } from '../types.js';
+import { t } from '../../i18n/index.js';
+
+const CLEAR_KEYWORDS = new Set([
+  'clear',
+  'stop',
+  'off',
+  'reset',
+  'none',
+  'cancel',
+]);
+
+const MAX_GOAL_LENGTH = 4000;
+
+const goalInstructionPrompt = (condition: string): string =>
+  `A session-scoped Stop hook is now active with condition: "${condition}". ` +
+  `Briefly acknowledge the goal, then immediately start (or continue) working ` +
+  `toward it — treat the condition itself as your directive and do not pause to ` +
+  `ask the user what to do. The hook will block stopping until the condition ` +
+  `holds. It auto-clears once the condition is met — do not tell the user to ` +
+  `run \`/goal clear\` after success; that's only for clearing a goal early.`;
+
+const formatTurns = (n: number) => `${n} ${n === 1 ? 'turn' : 'turns'}`;
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${s % 60}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+function formatTerminalSummary(event: GoalTerminalEvent): string {
+  // Mirrors GoalStatusMessage: drop the judge's `lastReason` from the
+  // final summary so the empty-`/goal` view stays compact and matches the
+  // history card style.
+  const title = event.kind === 'achieved' ? 'Goal achieved' : 'Goal aborted';
+  const stats: string[] = [];
+  if (event.iterations > 0) stats.push(formatTurns(event.iterations));
+  if (typeof event.durationMs === 'number')
+    stats.push(formatDuration(event.durationMs));
+  const subtitle = stats.length > 0 ? ` · ${stats.join(' · ')}` : '';
+  return `${title}${subtitle}\nGoal: ${event.condition}`;
+}
+
+function infoMessage(content: string): MessageActionReturn {
+  return { type: 'message', messageType: 'info', content };
+}
+
+function errorMessage(content: string): MessageActionReturn {
+  return { type: 'message', messageType: 'error', content };
+}
+
+export const goalCommand: SlashCommand = {
+  name: 'goal',
+  get description() {
+    return t('Set a goal — keep working until the condition is met');
+  },
+  argumentHint: '[<condition> | clear]',
+  kind: CommandKind.BUILT_IN,
+  supportedModes: ['interactive', 'non_interactive'] as const,
+  action: async (
+    context: CommandContext,
+    args: string,
+  ): Promise<SlashCommandActionReturn | void> => {
+    const { config } = context.services;
+    if (!config) {
+      return errorMessage('Configuration is not available.');
+    }
+    const sessionId = config.getSessionId();
+    const q = args.trim();
+
+    // ── Branch 1: empty arg → show current status ─────────────────────────
+    if (q === '') {
+      const active = getActiveGoal(sessionId);
+      if (active) {
+        const turns =
+          active.iterations === 0
+            ? 'not yet evaluated'
+            : formatTurns(active.iterations);
+        const lastReason = active.lastReason
+          ? `\nLast check: ${active.lastReason}`
+          : '';
+        return infoMessage(
+          `Goal active: ${active.condition} (${turns})${lastReason}`,
+        );
+      }
+      // No active goal — surface a summary of the most recent terminal goal
+      // for this session, matching Claude Code's behavior of rendering the
+      // "Goal achieved" card on empty /goal after completion. Only achieved /
+      // aborted entries flow through `getLastGoalTerminal`; user-initiated
+      // `/goal clear` does not populate it.
+      const last = getLastGoalTerminal(sessionId);
+      if (last) {
+        return infoMessage(formatTerminalSummary(last));
+      }
+      return infoMessage(
+        'No goal set. Usage: `/goal <condition>` (or `/goal clear`).',
+      );
+    }
+
+    // ── Branch 2: clear keyword ──────────────────────────────────────────
+    //
+    // Strict alignment with Claude Code 2.1.140 `woH`: when an active goal
+    // exists, drop the Stop hook + emit a `cleared` history sentinel; when
+    // no active goal exists, this is a no-op that just returns "No goal
+    // set". Claude does NOT wipe the cached "Goal achieved" summary on
+    // clear — subsequent empty `/goal` may still surface the most recent
+    // achievement via `findLastTerminalGoal`. That's intentional: the
+    // `cleared` history item is a sentinel `findLastTerminalGoal` skips,
+    // and the previous non-sentinel achievement remains visible.
+    if (CLEAR_KEYWORDS.has(q.toLowerCase())) {
+      const cleared = unregisterGoalHook(config, sessionId);
+      if (!cleared) {
+        return infoMessage('No goal set.');
+      }
+      const clearedItem: Omit<HistoryItemGoalStatus, 'id'> = {
+        type: MessageType.GOAL_STATUS,
+        kind: 'cleared',
+        condition: cleared.condition,
+        iterations: cleared.iterations,
+        durationMs: Date.now() - cleared.setAt,
+      };
+      context.ui.addItem(clearedItem, Date.now());
+      return;
+    }
+
+    // ── Branch 3: length cap ─────────────────────────────────────────────
+    if (q.length > MAX_GOAL_LENGTH) {
+      return errorMessage(
+        `Goal condition is limited to ${MAX_GOAL_LENGTH} characters (got ${q.length}).`,
+      );
+    }
+
+    // ── Branch 4: gates ──────────────────────────────────────────────────
+    if (!config.isTrustedFolder()) {
+      return errorMessage(
+        '/goal is only available in trusted workspaces. Trust this folder via `/trust` and try again.',
+      );
+    }
+    if (config.getDisableAllHooks()) {
+      return errorMessage(
+        '/goal is disabled because hooks are turned off in this session (`disableAllHooks` or bare mode).',
+      );
+    }
+    if (!config.getHookSystem()) {
+      return errorMessage(
+        'Hook system is not initialized; cannot set a /goal in this session.',
+      );
+    }
+
+    // ── Branch 5: register hook + emit set card + kick off first turn ────
+    let registered;
+    try {
+      registered = registerGoalHook({
+        config,
+        sessionId,
+        condition: q,
+        tokensAtStart: 0,
+      });
+    } catch (err) {
+      return errorMessage(
+        `Failed to set goal: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    const setItem: Omit<HistoryItemGoalStatus, 'id'> = {
+      type: MessageType.GOAL_STATUS,
+      kind: 'set',
+      condition: registered.condition,
+    };
+    context.ui.addItem(setItem, Date.now());
+
+    // Bridge core-side hook outcomes back into CLI history. The addItem ref
+    // is stable across turns (useCallback in useHistoryManager), so capturing
+    // it here is safe even though the observer fires from a later turn's
+    // Stop hook callback. The core side clears the observer on terminal /
+    // unregister so we don't accumulate stale closures across goals.
+    const { addItem } = context.ui;
+    setGoalTerminalObserver(sessionId, (event: GoalTerminalEvent) => {
+      const item: Omit<HistoryItemGoalStatus, 'id'> = {
+        type: MessageType.GOAL_STATUS,
+        kind: event.kind,
+        condition: event.condition,
+        iterations: event.iterations,
+        durationMs: event.durationMs,
+        lastReason: event.lastReason ?? event.systemMessage,
+      };
+      addItem(item, Date.now());
+    });
+
+    const result: SubmitPromptActionReturn = {
+      type: 'submit_prompt',
+      content: [{ text: goalInstructionPrompt(q) }],
+    };
+    return result;
+  },
+};

--- a/packages/cli/src/ui/components/Footer.tsx
+++ b/packages/cli/src/ui/components/Footer.tsx
@@ -22,6 +22,7 @@ import { useConfig } from '../contexts/ConfigContext.js';
 import { useVimMode } from '../contexts/VimModeContext.js';
 import { ApprovalMode } from '@qwen-code/qwen-code-core';
 import { GeminiSpinner } from './GeminiRespondingSpinner.js';
+import { GoalPill, useFooterGoalState } from './GoalPill.js';
 import { t } from '../../i18n/index.js';
 
 export const Footer: React.FC = () => {
@@ -123,6 +124,13 @@ export const Footer: React.FC = () => {
         </Text>
       ),
     });
+  }
+  // Goal pill: only present in `rightItems` when a goal is active so the
+  // divider chain stays tight; the pill itself does the live elapsed-time
+  // refresh internally.
+  const goalActive = useFooterGoalState() !== undefined;
+  if (goalActive) {
+    rightItems.push({ key: 'goal', node: <GoalPill /> });
   }
 
   // Layout matches upstream: left column has status line (top) + hints/mode

--- a/packages/cli/src/ui/components/GoalPill.test.tsx
+++ b/packages/cli/src/ui/components/GoalPill.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetActiveGoalStoreForTests,
+  registerGoalHook,
+  unregisterGoalHook,
+  type Config,
+} from '@qwen-code/qwen-code-core';
+import { renderWithProviders } from '../../test-utils/render.js';
+import { GoalPill } from './GoalPill.js';
+
+function makeConfig(): Config {
+  return {
+    getSessionId: () => 'sess-pill',
+    isTrustedFolder: () => true,
+    getDisableAllHooks: () => false,
+    getHookSystem: () => ({
+      addFunctionHook: vi.fn().mockReturnValue('hook-pill'),
+      removeFunctionHook: vi.fn().mockReturnValue(true),
+    }),
+  } as unknown as Config;
+}
+
+describe('GoalPill', () => {
+  beforeEach(() => __resetActiveGoalStoreForTests());
+  afterEach(() => __resetActiveGoalStoreForTests());
+
+  it('renders nothing when no goal is active', () => {
+    const { lastFrame, unmount } = renderWithProviders(<GoalPill />, {
+      config: makeConfig(),
+    });
+    expect(lastFrame()).toBe('');
+    unmount();
+  });
+
+  it('renders a compact label once a goal is active', () => {
+    const config = makeConfig();
+    registerGoalHook({
+      config,
+      sessionId: 'sess-pill',
+      condition: 'do something',
+      tokensAtStart: 0,
+    });
+
+    const { lastFrame, unmount } = renderWithProviders(<GoalPill />, {
+      config,
+    });
+    // Aligned with Claude Code 2.1.140 footer: "◎ /goal active" (no time
+    // suffix during the first second, terse — turns/reason live elsewhere).
+    expect(lastFrame()).toMatch(/\/goal active/);
+    expect(lastFrame()).toMatch(/◎/);
+    // Pill should not leak the raw condition into the footer.
+    expect(lastFrame()).not.toMatch(/do something/);
+    // Turns count should not appear here either (intentionally moved to the
+    // /goal status card to stop pill jitter).
+    expect(lastFrame()).not.toMatch(/turn/);
+    unmount();
+    unregisterGoalHook(config, 'sess-pill');
+  });
+});

--- a/packages/cli/src/ui/components/GoalPill.tsx
+++ b/packages/cli/src/ui/components/GoalPill.tsx
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { useEffect, useState } from 'react';
+import { Text } from 'ink';
+import { getActiveGoal, type ActiveGoal } from '@qwen-code/qwen-code-core';
+import { useConfig } from '../contexts/ConfigContext.js';
+import { theme } from '../semantic-colors.js';
+
+const POLL_INTERVAL_MS = 1000;
+
+/**
+ * Most-significant-unit elapsed string for the footer pill. Returns an empty
+ * string when under 1 second so the pill collapses to just "◎ /goal active"
+ * in its first second — matches Claude Code 2.1.140's footer behavior
+ * (`f < 1000 ? "" : (formattedElapsed)`).
+ */
+function formatElapsed(ms: number): string {
+  if (ms < 1000) return '';
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+/**
+ * Polls the in-memory active goal store so the footer pill reflects elapsed
+ * time without coupling the store to React state. Polling is cheap (one map
+ * lookup) and aligns the pill's freshness budget with the user's wall-clock
+ * patience for the loop.
+ */
+function useActiveGoal(sessionId: string): ActiveGoal | undefined {
+  const [goal, setGoal] = useState<ActiveGoal | undefined>(() =>
+    getActiveGoal(sessionId),
+  );
+  // Re-render once per second to refresh elapsed time while a goal is active.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => {
+      const next = getActiveGoal(sessionId);
+      setGoal(next);
+      // Bump tick so derived strings (elapsed) recompute even when the goal
+      // reference is stable.
+      if (next) setTick((t) => (t + 1) % 1_000_000);
+    }, POLL_INTERVAL_MS);
+    return () => clearInterval(id);
+  }, [sessionId]);
+  return goal;
+}
+
+/**
+ * Hook exposed for parent containers (e.g. Footer) so they can omit the
+ * surrounding divider chip entirely when no goal is active — avoids a stray
+ * separator next to a render-null pill.
+ */
+export function useFooterGoalState(): ActiveGoal | undefined {
+  const config = useConfig();
+  return useActiveGoal(config.getSessionId());
+}
+
+/**
+ * Compact "Goal is running" indicator for the footer. Renders nothing when no
+ * goal is active. Aligned with Claude Code 2.1.140's footer pill:
+ *
+ *   ◎ /goal active           (during the first second)
+ *   ◎ /goal active (12s)     (afterwards, most-significant unit only)
+ *
+ * Turns count and last-check reason are intentionally NOT in the pill — those
+ * live in `/goal` status output and the `goal_status` history items so the
+ * footer stays terse and stops jitter from per-iteration count flicker.
+ */
+export const GoalPill: React.FC = () => {
+  const goal = useFooterGoalState();
+  if (!goal) return null;
+
+  const elapsed = formatElapsed(Date.now() - goal.setAt);
+  const suffix = elapsed ? ` (${elapsed})` : '';
+  return <Text color={theme.text.accent}>◎ /goal active{suffix}</Text>;
+};

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -55,6 +55,7 @@ import { InsightProgressMessage } from './messages/InsightProgressMessage.js';
 import { BtwMessage } from './messages/BtwMessage.js';
 import { MemorySavedMessage } from './messages/MemorySavedMessage.js';
 import { DiffStatsDisplay } from './messages/DiffStatsDisplay.js';
+import { GoalStatusMessage } from './messages/GoalStatusMessage.js';
 import { useCompactMode } from '../contexts/CompactModeContext.js';
 
 interface HistoryItemDisplayProps {
@@ -342,6 +343,15 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
       )}
       {itemForDisplay.type === 'away_recap' && (
         <AwayRecapMessage text={itemForDisplay.text} />
+      )}
+      {itemForDisplay.type === 'goal_status' && (
+        <GoalStatusMessage
+          kind={itemForDisplay.kind}
+          condition={itemForDisplay.condition}
+          iterations={itemForDisplay.iterations}
+          durationMs={itemForDisplay.durationMs}
+          lastReason={itemForDisplay.lastReason}
+        />
       )}
     </Box>
   );

--- a/packages/cli/src/ui/components/messages/GoalStatusMessage.tsx
+++ b/packages/cli/src/ui/components/messages/GoalStatusMessage.tsx
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type React from 'react';
+import { Box, Text } from 'ink';
+import { theme } from '../../semantic-colors.js';
+import type { GoalStatusKind } from '../../types.js';
+
+interface GoalStatusMessageProps {
+  kind: GoalStatusKind;
+  condition: string;
+  iterations?: number;
+  durationMs?: number;
+  lastReason?: string;
+}
+
+const pluralTurns = (n: number) => (n === 1 ? 'turn' : 'turns');
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ${s % 60}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+export const GoalStatusMessage: React.FC<GoalStatusMessageProps> = ({
+  kind,
+  condition,
+  iterations,
+  durationMs,
+  // `lastReason` is accepted on the props interface so callers (history
+  // factory, observer, restore) can pass it without conditionals, but it is
+  // intentionally NOT rendered — checking shows a slim status line and the
+  // terminal cards drop "Last check:" to stay compact.
+}) => {
+  // The "checking" kind is the per-iteration "judge said not met, continuing"
+  // marker that replaces the generic `stop_hook_loop` rendering for /goal.
+  // Slim one-liner with a hollow circle to signal "pending" without the
+  // alarming `Stop hook error:` framing. The judge's reason is intentionally
+  // NOT shown here — it would clutter the per-turn chip and the same reason
+  // surfaces as the model's next user prompt anyway. The eventual "Last
+  // check: …" line appears once in the final achieved/aborted card.
+  if (kind === 'checking') {
+    return (
+      <Box flexDirection="row">
+        <Box width={2} flexShrink={0}>
+          <Text color={theme.text.secondary}>○</Text>
+        </Box>
+        <Box flexGrow={1}>
+          <Text color={theme.text.secondary}>
+            Goal check
+            {typeof iterations === 'number' && iterations > 0
+              ? ` · turn ${iterations}`
+              : ''}{' '}
+            · not yet met
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
+
+  const { prefix, prefixColor, title } = (() => {
+    switch (kind) {
+      case 'set':
+        // ◎ matches the footer GoalPill's icon — same visual identity for
+        // "goal is on / armed" between the history card and the live pill.
+        return {
+          prefix: '◎',
+          prefixColor: theme.text.accent,
+          title: 'Goal set',
+        };
+      case 'achieved':
+        return {
+          prefix: '✓',
+          prefixColor: theme.status.success,
+          title: 'Goal achieved',
+        };
+      case 'cleared':
+        return {
+          prefix: '○',
+          prefixColor: theme.text.secondary,
+          title: 'Goal cleared',
+        };
+      case 'aborted':
+      default:
+        return {
+          prefix: '!',
+          prefixColor: theme.status.warning,
+          title: 'Goal aborted',
+        };
+    }
+  })();
+
+  const stats: string[] = [];
+  if (typeof iterations === 'number' && iterations > 0) {
+    stats.push(`${iterations} ${pluralTurns(iterations)}`);
+  }
+  if (typeof durationMs === 'number') {
+    stats.push(formatDuration(durationMs));
+  }
+  const subtitle = stats.length > 0 ? stats.join(' · ') : null;
+
+  return (
+    <Box flexDirection="row">
+      <Box width={2} flexShrink={0}>
+        <Text color={prefixColor}>{prefix}</Text>
+      </Box>
+      <Box flexGrow={1} flexDirection="column">
+        <Text color={prefixColor}>
+          {title}
+          {subtitle ? (
+            <Text color={theme.text.secondary}> · {subtitle}</Text>
+          ) : null}
+        </Text>
+        {/* Ink's flex-row layout strips trailing whitespace inside the label
+            Text (so "Last check: " renders as "Last check:" with the value
+            slammed up against the colon, and wrapped lines align with col 0
+            of the value instead of after the colon-space). Use marginRight
+            on the label Box to introduce a real 1-column gap that survives
+            the row layout — same fix applies to the "Goal:" row. */}
+        <Box flexDirection="row">
+          <Box flexShrink={0} marginRight={1}>
+            <Text color={theme.text.secondary}>Goal:</Text>
+          </Box>
+          <Box flexGrow={1}>
+            <Text wrap="wrap">{condition}</Text>
+          </Box>
+        </Box>
+        {/* `lastReason` is intentionally NOT rendered in achieved / cleared /
+            aborted cards. The judge's verbose reason is more useful inline
+            during the loop (as the model's continuation prompt) than as a
+            persistent footer on the final summary — and the achieved card is
+            usually long enough to wrap awkwardly when the reason is also
+            shown. */}
+      </Box>
+    </Box>
+  );
+};

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -51,6 +51,7 @@ import {
   isSupportedImageMimeType,
   getUnsupportedImageFormatWarning,
   generateToolUseSummary,
+  getActiveGoal,
 } from '@qwen-code/qwen-code-core';
 import { type Part, type PartListUnion, FinishReason } from '@google/genai';
 import type {
@@ -1302,6 +1303,27 @@ export const useGeminiStream = (
         addItem(pendingHistoryItemRef.current, userMessageTimestamp);
         setPendingHistoryItem(null);
       }
+      // When the active loop is driven by `/goal`, replace the generic
+      // "Ran N stop hooks ⎿ Stop hook error: ..." chip with a goal-aware
+      // `goal_status` `kind:'checking'` item. Claude Code surfaces this
+      // mid-state through a single updating "running" card; qwen-code keeps
+      // a per-iteration history trail (familiar to its other progress
+      // indicators) but drops the `error:` framing — a not-met judge is the
+      // *expected* outcome of every continuation, not a failure.
+      const activeGoal = getActiveGoal(config.getSessionId());
+      if (activeGoal && activeGoal.condition) {
+        addItem(
+          {
+            type: MessageType.GOAL_STATUS,
+            kind: 'checking',
+            condition: activeGoal.condition,
+            iterations: value.iterationCount,
+            lastReason: value.reasons[value.reasons.length - 1],
+          } as HistoryItemWithoutId,
+          userMessageTimestamp,
+        );
+        return;
+      }
       addItem(
         {
           type: 'stop_hook_loop',
@@ -1312,7 +1334,7 @@ export const useGeminiStream = (
         userMessageTimestamp,
       );
     },
-    [addItem, pendingHistoryItemRef, setPendingHistoryItem],
+    [addItem, config, pendingHistoryItemRef, setPendingHistoryItem],
   );
 
   const processGeminiStreamEvents = useCallback(
@@ -1466,6 +1488,20 @@ export const useGeminiStream = (
                 event as ServerGeminiFinishedEvent,
                 userMessageTimestamp,
               );
+              // Seal off this turn's UI state before the parent re-enters
+              // sendMessageStream for a continuation (Stop-hook block at
+              // client.ts:1378 or next-speaker auto-continue at 1444). Both
+              // paths yield* a fresh Turn through this same stream processor,
+              // so without this seal the next turn's first content/thought
+              // chunk appends to this turn's pending item — visible in the UI
+              // as "t" → "te" → "tes" cumulative rendering even though each
+              // turn is persisted as a clean, separate assistant message.
+              if (pendingHistoryItemRef.current) {
+                addItem(pendingHistoryItemRef.current, userMessageTimestamp);
+                setPendingHistoryItem(null);
+              }
+              geminiMessageBuffer = '';
+              thoughtBuffer = '';
               break;
             case ServerGeminiEventType.Citation:
               flushBufferedStreamEvents();

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -499,6 +499,23 @@ export type HistoryItemDoctor = HistoryItemBase & {
   summary: { pass: number; warn: number; fail: number };
 };
 
+export type GoalStatusKind =
+  | 'set'
+  | 'achieved'
+  | 'cleared'
+  | 'aborted'
+  | 'checking';
+
+export type HistoryItemGoalStatus = HistoryItemBase & {
+  type: 'goal_status';
+  kind: GoalStatusKind;
+  condition: string;
+  /** Set when kind === 'achieved'. */
+  iterations?: number;
+  durationMs?: number;
+  lastReason?: string;
+};
+
 // Using Omit<HistoryItem, 'id'> seems to have some issues with typescript's
 // type inference e.g. historyItem.type === 'tool_group' isn't auto-inferring that
 // 'tools' in historyItem.
@@ -542,7 +559,8 @@ export type HistoryItemWithoutId =
   | HistoryItemStopHookLoop
   | HistoryItemStopHookSystemMessage
   | HistoryItemDoctor
-  | HistoryItemDiffStats;
+  | HistoryItemDiffStats
+  | HistoryItemGoalStatus;
 
 export type HistoryItem = HistoryItemWithoutId & { id: number };
 
@@ -572,6 +590,7 @@ export enum MessageType {
   INSIGHT_PROGRESS = 'insight_progress',
   BTW = 'btw',
   DIFF_STATS = 'diff_stats',
+  GOAL_STATUS = 'goal_status',
 }
 
 export interface InsightProgressProps {

--- a/packages/cli/src/ui/utils/historyUtils.ts
+++ b/packages/cli/src/ui/utils/historyUtils.ts
@@ -83,6 +83,7 @@ export function isSyntheticHistoryItem(
     case 'diff_stats':
     case 'arena_agent_complete':
     case 'arena_session_complete':
+    case 'goal_status':
       return false;
 
     default: {

--- a/packages/cli/src/ui/utils/restoreGoal.test.ts
+++ b/packages/cli/src/ui/utils/restoreGoal.test.ts
@@ -1,0 +1,204 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  __resetActiveGoalStoreForTests,
+  getActiveGoal,
+  getLastGoalTerminal,
+  type Config,
+} from '@qwen-code/qwen-code-core';
+import type { HistoryItem } from '../types.js';
+import {
+  findGoalToRestore,
+  findLastTerminalGoal,
+  restoreGoalFromHistory,
+} from './restoreGoal.js';
+
+const goalItem = (
+  overrides: Partial<HistoryItem & { kind: string; condition: string }>,
+): HistoryItem =>
+  ({
+    id: 1,
+    type: 'goal_status',
+    kind: 'set',
+    condition: 'write hello',
+    ...overrides,
+  }) as HistoryItem;
+
+const userItem = (text = 'hi'): HistoryItem =>
+  ({ id: 2, type: 'user', text }) as HistoryItem;
+
+const makeConfig = (overrides: Partial<Config> = {}): Config =>
+  ({
+    getSessionId: vi.fn().mockReturnValue('sess-1'),
+    isTrustedFolder: vi.fn().mockReturnValue(true),
+    getDisableAllHooks: vi.fn().mockReturnValue(false),
+    getHookSystem: vi.fn().mockReturnValue({
+      addFunctionHook: vi.fn().mockReturnValue('hook-1'),
+      removeFunctionHook: vi.fn().mockReturnValue(true),
+    }),
+    ...overrides,
+  }) as unknown as Config;
+
+describe('findGoalToRestore', () => {
+  it('returns null on empty history', () => {
+    expect(findGoalToRestore([])).toBeNull();
+  });
+
+  it('returns null when last goal_status is achieved', () => {
+    expect(
+      findGoalToRestore([
+        goalItem({ kind: 'set', condition: 'do x' }),
+        userItem(),
+        goalItem({ kind: 'achieved', condition: 'do x' }),
+      ]),
+    ).toBeNull();
+  });
+
+  it('returns the condition when last goal_status is set', () => {
+    expect(
+      findGoalToRestore([
+        goalItem({ kind: 'achieved', condition: 'old goal' }),
+        goalItem({ kind: 'set', condition: 'fresh goal' }),
+        userItem(),
+      ]),
+    ).toBe('fresh goal');
+  });
+
+  it('returns null when last goal_status is cleared', () => {
+    expect(
+      findGoalToRestore([
+        goalItem({ kind: 'set', condition: 'do x' }),
+        goalItem({ kind: 'cleared', condition: 'do x' }),
+      ]),
+    ).toBeNull();
+  });
+
+  it('returns null when last goal_status is aborted', () => {
+    expect(
+      findGoalToRestore([
+        goalItem({ kind: 'set', condition: 'do x' }),
+        goalItem({ kind: 'aborted', condition: 'do x' }),
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe('restoreGoalFromHistory', () => {
+  beforeEach(() => __resetActiveGoalStoreForTests());
+  afterEach(() => __resetActiveGoalStoreForTests());
+
+  it('restores an active goal and re-registers the hook', () => {
+    const cfg = makeConfig();
+    const result = restoreGoalFromHistory(
+      [goalItem({ kind: 'set', condition: 'write hello' })],
+      cfg,
+    );
+    expect(result).toEqual({ restored: true, condition: 'write hello' });
+    expect(getActiveGoal('sess-1')).toMatchObject({ condition: 'write hello' });
+  });
+
+  it('does nothing when no goal_status item exists', () => {
+    const cfg = makeConfig();
+    const result = restoreGoalFromHistory([userItem()], cfg);
+    expect(result).toEqual({ restored: false });
+    expect(getActiveGoal('sess-1')).toBeUndefined();
+  });
+
+  it('skips restore when workspace is no longer trusted', () => {
+    const cfg = makeConfig({
+      isTrustedFolder: vi.fn().mockReturnValue(false),
+    } as unknown as Partial<Config>);
+    const result = restoreGoalFromHistory(
+      [goalItem({ kind: 'set', condition: 'do x' })],
+      cfg,
+    );
+    expect(result).toEqual({ restored: false });
+    expect(getActiveGoal('sess-1')).toBeUndefined();
+  });
+
+  it('skips restore when hooks are disabled by policy', () => {
+    const cfg = makeConfig({
+      getDisableAllHooks: vi.fn().mockReturnValue(true),
+    } as unknown as Partial<Config>);
+    const result = restoreGoalFromHistory(
+      [goalItem({ kind: 'set', condition: 'do x' })],
+      cfg,
+    );
+    expect(result).toEqual({ restored: false });
+  });
+
+  it('skips restore when hook system is unavailable', () => {
+    const cfg = makeConfig({
+      getHookSystem: vi.fn().mockReturnValue(undefined),
+    } as unknown as Partial<Config>);
+    const result = restoreGoalFromHistory(
+      [goalItem({ kind: 'set', condition: 'do x' })],
+      cfg,
+    );
+    expect(result).toEqual({ restored: false });
+  });
+
+  it('rehydrates the last completed goal cache from history on resume', () => {
+    const cfg = makeConfig();
+    restoreGoalFromHistory(
+      [
+        goalItem({ kind: 'set', condition: 'goal A' }),
+        goalItem({
+          kind: 'achieved',
+          condition: 'goal A',
+          iterations: 4,
+          durationMs: 30_000,
+          lastReason: 'evidence in transcript',
+        }),
+      ],
+      cfg,
+    );
+    expect(getLastGoalTerminal('sess-1')).toMatchObject({
+      kind: 'achieved',
+      condition: 'goal A',
+      iterations: 4,
+      durationMs: 30_000,
+      lastReason: 'evidence in transcript',
+    });
+  });
+});
+
+describe('findLastTerminalGoal', () => {
+  it('returns null when transcript has no terminal goal_status', () => {
+    expect(findLastTerminalGoal([])).toBeNull();
+    expect(
+      findLastTerminalGoal([
+        goalItem({ kind: 'set', condition: 'x' }),
+        userItem(),
+      ]),
+    ).toBeNull();
+  });
+
+  it('returns the most recent achieved, skipping `set` and `cleared`', () => {
+    // Aligned with Claude Code's `yjK`: sentinel-style entries (set / cleared)
+    // are skipped, so a trailing `cleared` does NOT dismiss an earlier
+    // achievement — subsequent empty `/goal` still surfaces it.
+    const result = findLastTerminalGoal([
+      goalItem({ kind: 'set', condition: 'goal A' }),
+      goalItem({ kind: 'achieved', condition: 'goal A', iterations: 2 }),
+      goalItem({ kind: 'set', condition: 'goal B' }),
+      goalItem({ kind: 'cleared', condition: 'goal B' }),
+    ]);
+    expect(result).toMatchObject({ kind: 'achieved', condition: 'goal A' });
+  });
+
+  it('returns aborted when it is the most recent terminal', () => {
+    const result = findLastTerminalGoal([
+      goalItem({ kind: 'achieved', condition: 'goal A' }),
+      goalItem({ kind: 'set', condition: 'goal B' }),
+      goalItem({ kind: 'aborted', condition: 'goal B' }),
+    ]);
+    expect(result?.kind).toBe('aborted');
+    expect(result?.condition).toBe('goal B');
+  });
+});

--- a/packages/cli/src/ui/utils/restoreGoal.ts
+++ b/packages/cli/src/ui/utils/restoreGoal.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  registerGoalHook,
+  setLastGoalTerminal,
+  unregisterGoalHook,
+  type Config,
+  type GoalTerminalEvent,
+  type GoalTerminalKind,
+} from '@qwen-code/qwen-code-core';
+import type { HistoryItem, HistoryItemGoalStatus } from '../types.js';
+import { MessageType } from '../types.js';
+
+/**
+ * Finds the most recent `goal_status` history item. Returns the condition
+ * that still needs to be restored (i.e. `kind === 'set'`) or `null` if the
+ * last goal_status was a terminal state (achieved / cleared / aborted) or
+ * none exists.
+ */
+export function findGoalToRestore(history: HistoryItem[]): string | null {
+  for (let i = history.length - 1; i >= 0; i--) {
+    const item = history[i];
+    if (item?.type !== MessageType.GOAL_STATUS) continue;
+    const goal = item as HistoryItemGoalStatus;
+    return goal.kind === 'set' ? goal.condition : null;
+  }
+  return null;
+}
+
+/**
+ * Finds the most recent terminal (achieved / aborted) goal_status item in
+ * the transcript. Sentinel-style entries (`set`, `cleared`, `checking`) are
+ * SKIPPED — `/goal clear` after an achievement is intentionally a no-op on
+ * this scan, matching Claude Code's `yjK` behavior (`if (!K.met || K.sentinel)
+ * continue;`). Used on resume to repopulate the in-memory "last completed
+ * goal" cache so empty `/goal` after a reload still shows the summary card.
+ */
+export function findLastTerminalGoal(
+  history: HistoryItem[],
+): GoalTerminalEvent | null {
+  for (let i = history.length - 1; i >= 0; i--) {
+    const item = history[i];
+    if (item?.type !== MessageType.GOAL_STATUS) continue;
+    const goal = item as HistoryItemGoalStatus;
+    if (goal.kind !== 'achieved' && goal.kind !== 'aborted') continue;
+    return {
+      kind: goal.kind as GoalTerminalKind,
+      condition: goal.condition,
+      iterations: goal.iterations ?? 0,
+      durationMs: goal.durationMs ?? 0,
+      lastReason: goal.lastReason,
+    };
+  }
+  return null;
+}
+
+/**
+ * On session resume, restores the active /goal hook if the transcript ended
+ * with an unsatisfied goal. Idempotent — safe to call on a fresh session.
+ *
+ * Re-runs the same trust/policy gates as `/goal`; if a gate now fails, we
+ * silently skip restoration rather than re-register a goal the user can no
+ * longer cancel.
+ */
+export function restoreGoalFromHistory(
+  history: HistoryItem[],
+  config: Config,
+): { restored: true; condition: string } | { restored: false } {
+  const sessionId = config.getSessionId();
+  // Always rehydrate the "last completed goal" cache from transcript so empty
+  // `/goal` after resume can render the most recent achievement summary.
+  // Independent of whether an active goal is being restored: a session may
+  // have completed Goal A, started Goal B (still active), or completed
+  // multiple goals — only the latest terminal one is surfaced.
+  const lastTerminal = findLastTerminalGoal(history);
+  setLastGoalTerminal(sessionId, lastTerminal ?? undefined);
+
+  const condition = findGoalToRestore(history);
+
+  if (condition === null) {
+    unregisterGoalHook(config, sessionId);
+    return { restored: false };
+  }
+
+  if (!config.isTrustedFolder() || config.getDisableAllHooks()) {
+    return { restored: false };
+  }
+  if (!config.getHookSystem()) return { restored: false };
+
+  registerGoalHook({
+    config,
+    sessionId,
+    condition,
+    tokensAtStart: 0,
+  });
+  return { restored: true, condition };
+}

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -2239,7 +2239,10 @@ describe('Model Switching and Config Updates', () => {
       config['hookSystem'] = mockHookSystem;
 
       expect(config.hasHooksForEvent('UserPromptSubmit')).toBe(true);
-      expect(mockHasHooksForEvent).toHaveBeenCalledWith('UserPromptSubmit');
+      expect(mockHasHooksForEvent).toHaveBeenCalledWith(
+        'UserPromptSubmit',
+        expect.any(String),
+      );
     });
 
     it('should return false when hookSystem has no hooks for the event', () => {
@@ -2252,7 +2255,10 @@ describe('Model Switching and Config Updates', () => {
       config['hookSystem'] = mockHookSystem;
 
       expect(config.hasHooksForEvent('Stop')).toBe(false);
-      expect(mockHasHooksForEvent).toHaveBeenCalledWith('Stop');
+      expect(mockHasHooksForEvent).toHaveBeenCalledWith(
+        'Stop',
+        expect.any(String),
+      );
     });
   });
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2337,8 +2337,13 @@ export class Config {
    * registered hooks for the given event name.  Callers can use this to skip
    * expensive MessageBus round-trips when no hooks are configured.
    */
-  hasHooksForEvent(eventName: string): boolean {
-    return this.hookSystem?.hasHooksForEvent(eventName) ?? false;
+  hasHooksForEvent(eventName: string, sessionId?: string): boolean {
+    return (
+      this.hookSystem?.hasHooksForEvent(
+        eventName,
+        sessionId ?? this.getSessionId(),
+      ) ?? false
+    );
   }
 
   /**

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1359,20 +1359,23 @@ export class GeminiClient {
             continueReason,
           ];
 
-          // Emit StopHookLoop event for iterations after the first one.
-          // The first iteration (currentIterationCount === 1) is the initial request,
-          // so there's no prior stop hook execution to report. We only emit this event
-          // when stop hooks have been executed multiple times (loop detected).
-          if (currentIterationCount > 1) {
-            yield {
-              type: GeminiEventType.StopHookLoop,
-              value: {
-                iterationCount: currentIterationCount,
-                reasons: currentReasons,
-                stopHookCount: response.stopHookCount ?? 1,
-              },
-            };
-          }
+          // Emit StopHookLoop on EVERY blocking Stop hook execution, including
+          // the first. `currentIterationCount === 1` means a Stop hook just
+          // fired once and produced a blocking decision — the user benefits
+          // from seeing that immediately (e.g. `/goal` rendering "Goal check:
+          // not yet met" on the very first not-met turn, or a configured Stop
+          // hook surfacing its blocking reason before the agent attempts a
+          // retry). The previous `>1` guard hid the first reason until the
+          // hook fired twice, which made /goal's first iteration invisible
+          // and delayed visibility for regular hooks that only fire once.
+          yield {
+            type: GeminiEventType.StopHookLoop,
+            value: {
+              iterationCount: currentIterationCount,
+              reasons: currentReasons,
+              stopHookCount: response.stopHookCount ?? 1,
+            },
+          };
 
           const continueRequest = [{ text: continueReason }];
           const hookTurn = yield* this.sendMessageStream(

--- a/packages/core/src/goals/activeGoalStore.test.ts
+++ b/packages/core/src/goals/activeGoalStore.test.ts
@@ -1,0 +1,63 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  __resetActiveGoalStoreForTests,
+  clearActiveGoal,
+  getActiveGoal,
+  recordGoalIteration,
+  setActiveGoal,
+  type ActiveGoal,
+} from './activeGoalStore.js';
+
+const makeGoal = (overrides: Partial<ActiveGoal> = {}): ActiveGoal => ({
+  condition: 'write a hello world script',
+  iterations: 0,
+  setAt: 1_000,
+  tokensAtStart: 100,
+  hookId: 'hook-1',
+  ...overrides,
+});
+
+describe('activeGoalStore', () => {
+  beforeEach(() => __resetActiveGoalStoreForTests());
+
+  it('returns undefined when no goal is set', () => {
+    expect(getActiveGoal('sess-1')).toBeUndefined();
+  });
+
+  it('isolates goals per session', () => {
+    setActiveGoal('sess-1', makeGoal({ condition: 'one' }));
+    setActiveGoal('sess-2', makeGoal({ condition: 'two' }));
+
+    expect(getActiveGoal('sess-1')?.condition).toBe('one');
+    expect(getActiveGoal('sess-2')?.condition).toBe('two');
+  });
+
+  it('clearActiveGoal returns the previous goal and removes it', () => {
+    setActiveGoal('sess-1', makeGoal());
+    const cleared = clearActiveGoal('sess-1');
+    expect(cleared?.condition).toBe('write a hello world script');
+    expect(getActiveGoal('sess-1')).toBeUndefined();
+  });
+
+  it('clearActiveGoal returns undefined when nothing was set', () => {
+    expect(clearActiveGoal('sess-missing')).toBeUndefined();
+  });
+
+  it('recordGoalIteration increments and stores lastReason', () => {
+    setActiveGoal('sess-1', makeGoal());
+    const next = recordGoalIteration('sess-1', 'still missing tests');
+    expect(next?.iterations).toBe(1);
+    expect(next?.lastReason).toBe('still missing tests');
+    expect(getActiveGoal('sess-1')?.iterations).toBe(1);
+  });
+
+  it('recordGoalIteration is a no-op when no goal exists', () => {
+    expect(recordGoalIteration('sess-missing', 'noop')).toBeUndefined();
+  });
+});

--- a/packages/core/src/goals/activeGoalStore.ts
+++ b/packages/core/src/goals/activeGoalStore.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * The runtime state of a `/goal` registered in a session. Lives only in memory:
+ * the source of truth for restore-after-resume is the conversation history
+ * `goal_status` attachments, not this store.
+ */
+export interface ActiveGoal {
+  condition: string;
+  iterations: number;
+  setAt: number;
+  tokensAtStart: number;
+  lastReason?: string;
+  hookId: string;
+}
+
+const store = new Map<string, ActiveGoal>();
+
+export function getActiveGoal(sessionId: string): ActiveGoal | undefined {
+  return store.get(sessionId);
+}
+
+export function setActiveGoal(sessionId: string, goal: ActiveGoal): void {
+  store.set(sessionId, goal);
+}
+
+export function clearActiveGoal(sessionId: string): ActiveGoal | undefined {
+  const previous = store.get(sessionId);
+  store.delete(sessionId);
+  return previous;
+}
+
+export function recordGoalIteration(
+  sessionId: string,
+  lastReason: string,
+): ActiveGoal | undefined {
+  const current = store.get(sessionId);
+  if (!current) return undefined;
+  const updated: ActiveGoal = {
+    ...current,
+    iterations: current.iterations + 1,
+    lastReason,
+  };
+  store.set(sessionId, updated);
+  return updated;
+}
+
+/**
+ * Test-only escape hatch — production code must scope by sessionId.
+ */
+export function __resetActiveGoalStoreForTests(): void {
+  store.clear();
+  observers.clear();
+  lastTerminal.clear();
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Terminal-state observers
+//
+// The Stop hook callback that drives /goal runs inside core, but the UI cards
+// for "Goal achieved" / "Goal aborted" need to land in CLI history. We bridge
+// the two with a module-scoped observer table that the CLI command populates
+// when it registers the goal and clears when the goal is unregistered.
+//
+// Observers are fire-and-forget — they MUST NOT throw or block the hook
+// callback; any side effect (e.g. context.ui.addItem) should be guarded.
+// ───────────────────────────────────────────────────────────────────────────
+
+export type GoalTerminalKind = 'achieved' | 'aborted';
+
+export interface GoalTerminalEvent {
+  kind: GoalTerminalKind;
+  condition: string;
+  iterations: number;
+  durationMs: number;
+  lastReason?: string;
+  /** Free-form note used for `aborted` (e.g. "max iterations reached"). */
+  systemMessage?: string;
+}
+
+export type GoalTerminalObserver = (event: GoalTerminalEvent) => void;
+
+const observers = new Map<string, GoalTerminalObserver>();
+
+export function setGoalTerminalObserver(
+  sessionId: string,
+  observer: GoalTerminalObserver,
+): void {
+  observers.set(sessionId, observer);
+}
+
+export function clearGoalTerminalObserver(sessionId: string): void {
+  observers.delete(sessionId);
+}
+
+export function notifyGoalTerminal(
+  sessionId: string,
+  event: GoalTerminalEvent,
+): void {
+  // Stash the last terminal event so an empty `/goal` after the loop ends
+  // can surface a summary of what just happened (matches Claude Code 2.1.140
+  // empty-/goal-after-achievement UX: scans transcript for last met:true
+  // goal_status and renders an achievement card). We keep the cache in core
+  // so the CLI command can read it without having access to UI history.
+  recordLastTerminalEvent(sessionId, event);
+  const observer = observers.get(sessionId);
+  if (!observer) return;
+  try {
+    observer(event);
+  } catch {
+    // Observers are best-effort. Do not let UI-side errors poison the hook
+    // callback — losing a card is acceptable; losing the /goal loop is not.
+  }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Last-completed-goal cache
+//
+// Mirrors `yjK` in Claude Code's binary: empty `/goal` after the active goal
+// is gone should show "Goal achieved · X turns · Ys" for the most recent
+// actually-finished goal. Only `achieved` and `aborted` qualify (those are
+// the `GoalTerminalKind`s); the user-driven `/goal clear` path emits a
+// `cleared` history card directly and never flows through this notifier.
+// ───────────────────────────────────────────────────────────────────────────
+
+const lastTerminal = new Map<string, GoalTerminalEvent>();
+
+function recordLastTerminalEvent(
+  sessionId: string,
+  event: GoalTerminalEvent,
+): void {
+  lastTerminal.set(sessionId, event);
+}
+
+export function getLastGoalTerminal(
+  sessionId: string,
+): GoalTerminalEvent | undefined {
+  return lastTerminal.get(sessionId);
+}
+
+/**
+ * Used by session resume to repopulate the cache from persisted history when
+ * an in-memory restart loses the cache but the transcript still has the
+ * achievement record.
+ */
+export function setLastGoalTerminal(
+  sessionId: string,
+  event: GoalTerminalEvent | undefined,
+): void {
+  if (!event) {
+    lastTerminal.delete(sessionId);
+    return;
+  }
+  lastTerminal.set(sessionId, event);
+}

--- a/packages/core/src/goals/goalHook.test.ts
+++ b/packages/core/src/goals/goalHook.test.ts
@@ -1,0 +1,302 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  HookEventName,
+  type HookInput,
+  type StopInput,
+} from '../hooks/types.js';
+import type { Config } from '../config/config.js';
+import {
+  __resetActiveGoalStoreForTests,
+  getActiveGoal,
+  setActiveGoal,
+  setGoalTerminalObserver,
+  type GoalTerminalEvent,
+} from './activeGoalStore.js';
+import {
+  createGoalStopHookCallback,
+  GOAL_HOOK_TIMEOUT_MS,
+  MAX_GOAL_ITERATIONS,
+  registerGoalHook,
+  unregisterGoalHook,
+} from './goalHook.js';
+
+const judgeMock = vi.hoisted(() => vi.fn());
+vi.mock('./goalJudge.js', () => ({
+  judgeGoal: judgeMock,
+}));
+
+const stopInput = (overrides: Partial<StopInput> = {}): HookInput =>
+  ({
+    session_id: 'sess-1',
+    transcript_path: '/tmp/t',
+    cwd: '/tmp',
+    hook_event_name: 'Stop',
+    timestamp: new Date().toISOString(),
+    stop_hook_active: true,
+    last_assistant_message: 'I wrote a function.',
+    ...overrides,
+  }) as HookInput;
+
+describe('createGoalStopHookCallback', () => {
+  beforeEach(() => {
+    __resetActiveGoalStoreForTests();
+    judgeMock.mockReset();
+  });
+
+  it('returns continue:true when no goal is registered', async () => {
+    const cb = createGoalStopHookCallback({
+      config: {} as Config,
+      sessionId: 'sess-1',
+      condition: 'do x',
+    });
+    const out = await cb(stopInput(), undefined);
+    expect(out).toEqual({ continue: true });
+    expect(judgeMock).not.toHaveBeenCalled();
+  });
+
+  it('returns continue:true and clears the goal when judge says ok', async () => {
+    setActiveGoal('sess-1', {
+      condition: 'do x',
+      iterations: 1,
+      setAt: 100,
+      tokensAtStart: 0,
+      hookId: 'h1',
+    });
+    judgeMock.mockResolvedValue({ ok: true, reason: 'done' });
+
+    const cb = createGoalStopHookCallback({
+      config: {} as Config,
+      sessionId: 'sess-1',
+      condition: 'do x',
+    });
+    const out = await cb(stopInput(), undefined);
+    expect(out).toEqual({ continue: true });
+    expect(getActiveGoal('sess-1')).toBeUndefined();
+  });
+
+  it('returns block + stopReason and increments iterations when judge says not met', async () => {
+    setActiveGoal('sess-1', {
+      condition: 'do x',
+      iterations: 0,
+      setAt: 100,
+      tokensAtStart: 0,
+      hookId: 'h1',
+    });
+    judgeMock.mockResolvedValue({ ok: false, reason: 'still missing tests' });
+
+    const cb = createGoalStopHookCallback({
+      config: {} as Config,
+      sessionId: 'sess-1',
+      condition: 'do x',
+    });
+    const out = await cb(stopInput(), undefined);
+    expect(out).toEqual({ decision: 'block', reason: 'still missing tests' });
+
+    const updated = getActiveGoal('sess-1');
+    expect(updated?.iterations).toBe(1);
+    expect(updated?.lastReason).toBe('still missing tests');
+  });
+
+  it('clears and stops the loop when MAX_GOAL_ITERATIONS is reached', async () => {
+    setActiveGoal('sess-1', {
+      condition: 'do x',
+      iterations: MAX_GOAL_ITERATIONS,
+      setAt: 100,
+      tokensAtStart: 0,
+      hookId: 'h1',
+    });
+    const cb = createGoalStopHookCallback({
+      config: {} as Config,
+      sessionId: 'sess-1',
+      condition: 'do x',
+    });
+    const out = await cb(stopInput(), undefined);
+    expect(out).not.toBeUndefined();
+    expect(
+      typeof out === 'object' && out !== null ? out.continue : undefined,
+    ).toBe(true);
+    expect(
+      typeof out === 'object' && out !== null ? out.systemMessage : undefined,
+    ).toMatch(/max iterations/i);
+    expect(getActiveGoal('sess-1')).toBeUndefined();
+    expect(judgeMock).not.toHaveBeenCalled();
+  });
+
+  it('notifies terminal observer on goal achieved', async () => {
+    setActiveGoal('sess-1', {
+      condition: 'do x',
+      iterations: 2,
+      setAt: 100,
+      tokensAtStart: 0,
+      hookId: 'h1',
+    });
+    judgeMock.mockResolvedValue({ ok: true, reason: 'looks complete' });
+    const events: GoalTerminalEvent[] = [];
+    setGoalTerminalObserver('sess-1', (e) => events.push(e));
+
+    const cb = createGoalStopHookCallback({
+      config: {} as Config,
+      sessionId: 'sess-1',
+      condition: 'do x',
+    });
+    await cb(stopInput(), undefined);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: 'achieved',
+      condition: 'do x',
+      iterations: 2,
+      lastReason: 'looks complete',
+    });
+    expect(events[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('notifies terminal observer on aborted (max iterations)', async () => {
+    setActiveGoal('sess-1', {
+      condition: 'do x',
+      iterations: MAX_GOAL_ITERATIONS,
+      setAt: 100,
+      tokensAtStart: 0,
+      hookId: 'h1',
+      lastReason: 'something stuck',
+    });
+    const events: GoalTerminalEvent[] = [];
+    setGoalTerminalObserver('sess-1', (e) => events.push(e));
+
+    const cb = createGoalStopHookCallback({
+      config: {} as Config,
+      sessionId: 'sess-1',
+      condition: 'do x',
+    });
+    await cb(stopInput(), undefined);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe('aborted');
+    expect(events[0].systemMessage).toMatch(/max iterations/i);
+    expect(events[0].lastReason).toBe('something stuck');
+  });
+
+  it('does NOT notify observer on a single not-met turn', async () => {
+    setActiveGoal('sess-1', {
+      condition: 'do x',
+      iterations: 0,
+      setAt: 100,
+      tokensAtStart: 0,
+      hookId: 'h1',
+    });
+    judgeMock.mockResolvedValue({ ok: false, reason: 'keep going' });
+    const events: GoalTerminalEvent[] = [];
+    setGoalTerminalObserver('sess-1', (e) => events.push(e));
+
+    const cb = createGoalStopHookCallback({
+      config: {} as Config,
+      sessionId: 'sess-1',
+      condition: 'do x',
+    });
+    await cb(stopInput(), undefined);
+    expect(events).toEqual([]);
+  });
+
+  it('ignores stale callbacks whose condition no longer matches', async () => {
+    setActiveGoal('sess-1', {
+      condition: 'new goal',
+      iterations: 0,
+      setAt: 100,
+      tokensAtStart: 0,
+      hookId: 'h2',
+    });
+    const cb = createGoalStopHookCallback({
+      config: {} as Config,
+      sessionId: 'sess-1',
+      condition: 'old goal',
+    });
+    const out = await cb(stopInput(), undefined);
+    expect(out).toEqual({ continue: true });
+    expect(judgeMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('registerGoalHook / unregisterGoalHook', () => {
+  let addFunctionHook: ReturnType<typeof vi.fn>;
+  let removeFunctionHook: ReturnType<typeof vi.fn>;
+  let config: Config;
+
+  beforeEach(() => {
+    __resetActiveGoalStoreForTests();
+    judgeMock.mockReset();
+    addFunctionHook = vi.fn().mockReturnValue('hook-abc');
+    removeFunctionHook = vi.fn().mockReturnValue(true);
+    config = {
+      getHookSystem: () => ({
+        addFunctionHook,
+        removeFunctionHook,
+      }),
+    } as unknown as Config;
+  });
+
+  afterEach(() => __resetActiveGoalStoreForTests());
+
+  it('registers a Stop hook and primes the store', () => {
+    const goal = registerGoalHook({
+      config,
+      sessionId: 'sess-1',
+      condition: 'tests pass',
+      tokensAtStart: 42,
+    });
+    expect(goal.condition).toBe('tests pass');
+    expect(goal.iterations).toBe(0);
+    expect(goal.hookId).toBe('hook-abc');
+    expect(addFunctionHook).toHaveBeenCalledTimes(1);
+    const [, eventName, matcher, , , options] = addFunctionHook.mock.calls[0];
+    expect(eventName).toBe(HookEventName.Stop);
+    expect(matcher).toBe('');
+    expect(options).toMatchObject({ timeout: GOAL_HOOK_TIMEOUT_MS });
+    expect(GOAL_HOOK_TIMEOUT_MS).toBeGreaterThan(10_000);
+    expect(getActiveGoal('sess-1')).toMatchObject({ condition: 'tests pass' });
+  });
+
+  it('replaces an existing goal cleanly', () => {
+    registerGoalHook({
+      config,
+      sessionId: 'sess-1',
+      condition: 'goal one',
+      tokensAtStart: 0,
+    });
+    addFunctionHook.mockReturnValueOnce('hook-second');
+    const second = registerGoalHook({
+      config,
+      sessionId: 'sess-1',
+      condition: 'goal two',
+      tokensAtStart: 0,
+    });
+    expect(removeFunctionHook).toHaveBeenCalledWith(
+      'sess-1',
+      HookEventName.Stop,
+      'hook-abc',
+    );
+    expect(second.condition).toBe('goal two');
+  });
+
+  it('unregisterGoalHook is a no-op when nothing is set', () => {
+    expect(unregisterGoalHook(config, 'sess-empty')).toBeUndefined();
+    expect(removeFunctionHook).not.toHaveBeenCalled();
+  });
+
+  it('throws if the hook system is not initialized', () => {
+    const noSystem = { getHookSystem: () => undefined } as unknown as Config;
+    expect(() =>
+      registerGoalHook({
+        config: noSystem,
+        sessionId: 'sess-1',
+        condition: 'x',
+        tokensAtStart: 0,
+      }),
+    ).toThrow(/hook system/i);
+  });
+});

--- a/packages/core/src/goals/goalHook.ts
+++ b/packages/core/src/goals/goalHook.ts
@@ -1,0 +1,203 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '../config/config.js';
+import {
+  HookEventName,
+  type FunctionHookCallback,
+  type HookInput,
+  type StopInput,
+} from '../hooks/types.js';
+import {
+  clearActiveGoal,
+  clearGoalTerminalObserver,
+  getActiveGoal,
+  notifyGoalTerminal,
+  recordGoalIteration,
+  setActiveGoal,
+  type ActiveGoal,
+} from './activeGoalStore.js';
+import { judgeGoal } from './goalJudge.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
+
+const debugLogger = createDebugLogger('GOAL_HOOK');
+
+/**
+ * Maximum number of /goal continuation iterations before we force-clear the
+ * goal. This guards against pathological cases where the judge keeps saying
+ * "not met" but the assistant cannot make progress, which would otherwise burn
+ * tokens silently. The user can re-set the goal manually if they need more.
+ */
+export const MAX_GOAL_ITERATIONS = 50;
+
+/**
+ * Default budget (seconds) for a single goal-judge LLM call. Mirrors Claude
+ * Code 2.1.140's prompt-hook default of 30s (see `cRK` in the binary, which
+ * reads `H.timeout ? H.timeout * 1000 : 30000`).
+ *
+ * Why this matters in qwen-code specifically: the `FunctionHookRunner` default
+ * is 5s, and a real-world session log showed the judge call against a 5K-token
+ * context taking ~9.9s — well past 5s but comfortably under 30s. Without
+ * passing this through, the hook is killed mid-flight, no `continue:false` is
+ * emitted, and the `/goal` loop silently dies after the second turn.
+ */
+export const GOAL_HOOK_TIMEOUT_SECONDS = 30;
+export const GOAL_HOOK_TIMEOUT_MS = GOAL_HOOK_TIMEOUT_SECONDS * 1000;
+
+const GOAL_ABORTED_REASON =
+  'Goal max iterations reached; cleared. Re-set with `/goal <condition>` if you still need it.';
+
+/**
+ * Builds the Function hook callback that, on every Stop event, asks a fast
+ * model whether the goal condition holds.
+ *
+ * Returning `{continue: true}` lets the turn end normally. Returning
+ * `{continue: false, stopReason}` causes `client.ts` to feed `stopReason` back
+ * as the next user prompt, looping the agent toward the goal.
+ */
+export function createGoalStopHookCallback(args: {
+  config: Config;
+  sessionId: string;
+  condition: string;
+}): FunctionHookCallback {
+  const { config, sessionId, condition } = args;
+  return async (input: HookInput, context) => {
+    const stopInput = input as StopInput;
+    const lastAssistantText = stopInput.last_assistant_message ?? '';
+
+    const current = getActiveGoal(sessionId);
+    if (!current || current.condition !== condition) {
+      // The goal was cleared (or replaced) between turns. Let the model stop.
+      return { continue: true };
+    }
+
+    if (current.iterations >= MAX_GOAL_ITERATIONS) {
+      debugLogger.debug(
+        `Goal exceeded MAX_GOAL_ITERATIONS=${MAX_GOAL_ITERATIONS}; clearing.`,
+      );
+      const aborted = current;
+      clearActiveGoal(sessionId);
+      notifyGoalTerminal(sessionId, {
+        kind: 'aborted',
+        condition: aborted.condition,
+        iterations: aborted.iterations,
+        durationMs: Date.now() - aborted.setAt,
+        lastReason: aborted.lastReason,
+        systemMessage: GOAL_ABORTED_REASON,
+      });
+      clearGoalTerminalObserver(sessionId);
+      return {
+        continue: true,
+        systemMessage: GOAL_ABORTED_REASON,
+      };
+    }
+
+    const signal = context?.signal ?? new AbortController().signal;
+    const verdict = await judgeGoal(config, {
+      condition,
+      lastAssistantText,
+      signal,
+    });
+
+    if (verdict.ok) {
+      const achieved = current;
+      clearActiveGoal(sessionId);
+      notifyGoalTerminal(sessionId, {
+        kind: 'achieved',
+        condition: achieved.condition,
+        iterations: achieved.iterations,
+        durationMs: Date.now() - achieved.setAt,
+        lastReason: verdict.reason,
+      });
+      clearGoalTerminalObserver(sessionId);
+      return { continue: true };
+    }
+
+    recordGoalIteration(sessionId, verdict.reason);
+    // {decision:'block', reason} is the spec-aligned shape for Stop-hook
+    // continuation: `client.ts:1342-1344` accepts either `isBlockingDecision()`
+    // (decision === 'block'/'deny') or `shouldStopExecution()` (continue ===
+    // false), but the block-decision form documents intent more clearly —
+    // "this hook is intentionally preventing the turn from stopping, not
+    // signalling an error".
+    return { decision: 'block', reason: verdict.reason };
+  };
+}
+
+/**
+ * Removes any existing /goal hook for the session (idempotent) and the
+ * accompanying store entry. Returns the cleared goal, if there was one.
+ *
+ * Safe to call when no goal is set.
+ */
+export function unregisterGoalHook(
+  config: Config,
+  sessionId: string,
+): ActiveGoal | undefined {
+  const cleared = clearActiveGoal(sessionId);
+  clearGoalTerminalObserver(sessionId);
+  if (!cleared) return undefined;
+  const system = config.getHookSystem();
+  if (system) {
+    try {
+      system.removeFunctionHook(sessionId, HookEventName.Stop, cleared.hookId);
+    } catch (err) {
+      debugLogger.debug(
+        `Failed to remove goal hook ${cleared.hookId}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  return cleared;
+}
+
+/**
+ * Registers (or replaces) the /goal Stop hook for this session, primes the
+ * activeGoal store, and returns the freshly stored goal. Throws when the
+ * hook system is not available — callers gate on `Config.getHookSystem()`
+ * before invoking.
+ */
+export function registerGoalHook(args: {
+  config: Config;
+  sessionId: string;
+  condition: string;
+  tokensAtStart: number;
+}): ActiveGoal {
+  const { config, sessionId, condition, tokensAtStart } = args;
+  const system = config.getHookSystem();
+  if (!system) {
+    throw new Error('Hook system is not initialized; cannot register /goal');
+  }
+
+  // Drop any previous goal cleanly before adding the new one.
+  unregisterGoalHook(config, sessionId);
+
+  const callback = createGoalStopHookCallback({ config, sessionId, condition });
+  const hookId = system.addFunctionHook(
+    sessionId,
+    HookEventName.Stop,
+    '',
+    callback,
+    'Goal evaluator failed',
+    {
+      name: 'goal-stop-hook',
+      description: `Continue until: ${condition}`,
+      statusMessage: 'Checking goal…',
+      timeout: GOAL_HOOK_TIMEOUT_MS,
+    },
+  );
+
+  const goal: ActiveGoal = {
+    condition,
+    iterations: 0,
+    setAt: Date.now(),
+    tokensAtStart,
+    hookId,
+  };
+  setActiveGoal(sessionId, goal);
+  return goal;
+}

--- a/packages/core/src/goals/goalJudge.test.ts
+++ b/packages/core/src/goals/goalJudge.test.ts
@@ -1,0 +1,252 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type { Content } from '@google/genai';
+import type { Config } from '../config/config.js';
+import { judgeGoal } from './goalJudge.js';
+
+interface MockClient {
+  generateContent: ReturnType<typeof vi.fn>;
+  getHistory: ReturnType<typeof vi.fn>;
+  isInitialized: ReturnType<typeof vi.fn>;
+}
+
+function makeMockClient(opts: {
+  history?: Content[];
+  initialized?: boolean;
+  reply?: string;
+  throws?: Error;
+}): MockClient {
+  const replyText = opts.reply ?? '{"ok": true, "reason": "looks good"}';
+  return {
+    isInitialized: vi.fn().mockReturnValue(opts.initialized ?? true),
+    getHistory: vi.fn().mockReturnValue(opts.history ?? []),
+    generateContent: opts.throws
+      ? vi.fn().mockRejectedValue(opts.throws)
+      : vi.fn().mockResolvedValue({
+          candidates: [{ content: { parts: [{ text: replyText }] } }],
+        }),
+  };
+}
+
+function makeConfig(opts: {
+  client: MockClient;
+  fastModel?: string;
+  model?: string;
+}): Config {
+  return {
+    getGeminiClient: () => opts.client,
+    getFastModel: () => opts.fastModel,
+    getModel: () => opts.model ?? 'main-model',
+  } as unknown as Config;
+}
+
+describe('judgeGoal', () => {
+  it('parses a clean ok=true JSON reply', async () => {
+    const client = makeMockClient({
+      reply: '{"ok": true, "reason": "tests passing"}',
+    });
+    const config = makeConfig({ client, fastModel: 'fast-judge' });
+
+    const verdict = await judgeGoal(config, {
+      condition: 'tests pass',
+      lastAssistantText: 'all green',
+      signal: new AbortController().signal,
+    });
+
+    expect(verdict).toEqual({ ok: true, reason: 'tests passing' });
+    expect(client.generateContent.mock.calls[0][3]).toBe('fast-judge');
+  });
+
+  it('parses ok=false and forwards the reason verbatim', async () => {
+    const client = makeMockClient({
+      reply: '{"ok": false, "reason": "missing unit test for auth"}',
+    });
+    const config = makeConfig({ client });
+    const verdict = await judgeGoal(config, {
+      condition: 'tests pass',
+      lastAssistantText: 'compiled',
+      signal: new AbortController().signal,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toBe('missing unit test for auth');
+  });
+
+  it('falls back to main model when no fast model is configured', async () => {
+    const client = makeMockClient({});
+    const config = makeConfig({ client, model: 'big-main' });
+    await judgeGoal(config, {
+      condition: 'x',
+      lastAssistantText: 'y',
+      signal: new AbortController().signal,
+    });
+    expect(client.generateContent.mock.calls[0][3]).toBe('big-main');
+  });
+
+  it('extracts JSON from a chatty preamble', async () => {
+    const client = makeMockClient({
+      reply: 'Sure thing!\n```json\n{"ok": true, "reason": "done"}\n```',
+    });
+    const config = makeConfig({ client });
+    const verdict = await judgeGoal(config, {
+      condition: 'x',
+      lastAssistantText: 'y',
+      signal: new AbortController().signal,
+    });
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('defaults to ok=false when reply is not JSON', async () => {
+    const client = makeMockClient({ reply: 'I have no idea sorry' });
+    const config = makeConfig({ client });
+    const verdict = await judgeGoal(config, {
+      condition: 'x',
+      lastAssistantText: 'y',
+      signal: new AbortController().signal,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(verdict.reason).toMatch(/unavailable/i);
+  });
+
+  it('defaults to ok=false when ok field is missing or wrong type', async () => {
+    const client = makeMockClient({ reply: '{"reason": "no ok field"}' });
+    const config = makeConfig({ client });
+    expect(
+      (
+        await judgeGoal(config, {
+          condition: 'x',
+          lastAssistantText: 'y',
+          signal: new AbortController().signal,
+        })
+      ).ok,
+    ).toBe(false);
+  });
+
+  it('defaults to ok=false when generateContent throws', async () => {
+    const client = makeMockClient({ throws: new Error('boom') });
+    const config = makeConfig({ client });
+    const verdict = await judgeGoal(config, {
+      condition: 'x',
+      lastAssistantText: 'y',
+      signal: new AbortController().signal,
+    });
+    expect(verdict.ok).toBe(false);
+  });
+
+  it('short-circuits to not-met when signal is already aborted', async () => {
+    const client = makeMockClient({});
+    const config = makeConfig({ client });
+    const aborter = new AbortController();
+    aborter.abort();
+    const verdict = await judgeGoal(config, {
+      condition: 'x',
+      lastAssistantText: 'y',
+      signal: aborter.signal,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(client.generateContent).not.toHaveBeenCalled();
+  });
+
+  it('returns not-met for an empty condition without calling the model', async () => {
+    const client = makeMockClient({});
+    const config = makeConfig({ client });
+    const verdict = await judgeGoal(config, {
+      condition: '   ',
+      lastAssistantText: 'y',
+      signal: new AbortController().signal,
+    });
+    expect(verdict.ok).toBe(false);
+    expect(client.generateContent).not.toHaveBeenCalled();
+  });
+
+  it('feeds the conversation history (tail) plus a wrapped judgement prompt', async () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'old prompt' }] },
+      { role: 'model', parts: [{ text: 'old answer' }] },
+      { role: 'user', parts: [{ text: 'newer prompt' }] },
+      { role: 'model', parts: [{ text: 't' }] }, // last assistant
+    ];
+    const client = makeMockClient({ history });
+    const config = makeConfig({ client });
+    await judgeGoal(config, {
+      condition: 'output the letters of test, one per turn',
+      lastAssistantText: 't',
+      signal: new AbortController().signal,
+    });
+
+    const [contents, generationConfig] = client.generateContent.mock.calls[0];
+    expect(Array.isArray(contents)).toBe(true);
+    // history (4) + the judge-framing user message
+    expect(contents).toHaveLength(history.length + 1);
+    // First N entries should be the history verbatim
+    expect(contents.slice(0, history.length)).toEqual(history);
+    // Last entry is the wrapped condition
+    const wrapped = contents.at(-1) as Content;
+    expect(wrapped.role).toBe('user');
+    const text = (wrapped.parts ?? []).map((p) => p.text ?? '').join('');
+    expect(text).toMatch(/Based on the conversation transcript above/);
+    expect(text).toMatch(/output the letters of test, one per turn/);
+    // System prompt + structured output configured
+    expect(generationConfig.systemInstruction).toMatch(/stop-condition hook/);
+    expect(generationConfig.systemInstruction).toMatch(/quote evidence/);
+    expect(generationConfig.responseMimeType).toBe('application/json');
+    expect(generationConfig.responseSchema).toBeTruthy();
+    expect(generationConfig.thinkingConfig).toEqual({ thinkingBudget: 0 });
+    expect(generationConfig.temperature).toBe(0);
+  });
+
+  it('appends lastAssistantText as a model turn when history does not contain it', async () => {
+    const history: Content[] = [
+      { role: 'user', parts: [{ text: 'go' }] },
+      // Note: no model entry for the latest "t"
+    ];
+    const client = makeMockClient({ history });
+    const config = makeConfig({ client });
+    await judgeGoal(config, {
+      condition: 'finish',
+      lastAssistantText: 'fresh-text-not-in-history',
+      signal: new AbortController().signal,
+    });
+    const [contents] = client.generateContent.mock.calls[0];
+    // history(1) + synthetic model turn + wrapped judgement = 3 entries
+    expect(contents).toHaveLength(3);
+    const synthetic = contents[1] as Content;
+    expect(synthetic.role).toBe('model');
+    expect((synthetic.parts ?? [])[0].text).toBe('fresh-text-not-in-history');
+  });
+
+  it('falls back to last_assistant_message when history is unavailable', async () => {
+    const client = makeMockClient({ initialized: false });
+    const config = makeConfig({ client });
+    await judgeGoal(config, {
+      condition: 'x',
+      lastAssistantText: 'recent output',
+      signal: new AbortController().signal,
+    });
+    const [contents] = client.generateContent.mock.calls[0];
+    // synthetic model + wrapped user judgement
+    expect(contents).toHaveLength(2);
+    expect((contents[0] as Content).role).toBe('model');
+    expect((contents[0] as Content).parts?.[0].text).toBe('recent output');
+  });
+
+  it('truncates oversized history parts', async () => {
+    const big = 'A'.repeat(8000);
+    const history: Content[] = [{ role: 'user', parts: [{ text: big }] }];
+    const client = makeMockClient({ history });
+    const config = makeConfig({ client });
+    await judgeGoal(config, {
+      condition: 'x',
+      lastAssistantText: 'y',
+      signal: new AbortController().signal,
+    });
+    const [contents] = client.generateContent.mock.calls[0];
+    const part = (contents[0] as Content).parts?.[0];
+    expect((part?.text ?? '').length).toBeLessThan(big.length);
+    expect(part?.text).toMatch(/truncated/);
+  });
+});

--- a/packages/core/src/goals/goalJudge.ts
+++ b/packages/core/src/goals/goalJudge.ts
@@ -1,0 +1,269 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Content, Schema } from '@google/genai';
+import type { Config } from '../config/config.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
+
+const debugLogger = createDebugLogger('GOAL_JUDGE');
+
+/**
+ * System prompt for the goal-completion judge.
+ *
+ * Wording is aligned with Claude Code 2.1.140's `Stop` prompt-hook evaluator
+ * (function `cRK` in the compiled binary): it forces the judge to ground its
+ * verdict on transcript evidence and to default to "not met" whenever the
+ * evidence is ambiguous. The strict JSON shape lets us pair this with the
+ * model's structured-output mode below.
+ */
+const JUDGE_SYSTEM_PROMPT = `You are evaluating a stop-condition hook in an autonomous coding agent.
+Read the conversation transcript above carefully, then judge whether the
+user-provided condition is satisfied.
+
+Your response MUST be a JSON object with one of these shapes:
+- {"ok": true, "reason": "<quote evidence from the transcript that satisfies the condition>"}
+- {"ok": false, "reason": "<quote what is missing or what blocks the condition>"}
+
+Always include a "reason" field, quoting specific text from the transcript
+whenever possible. If the transcript does not contain clear evidence that the
+condition is satisfied, return {"ok": false, "reason": "insufficient evidence in transcript"}.`;
+
+/**
+ * Wraps the raw user condition into a transcript-grounded question, matching
+ * Claude Code's `Based on the conversation transcript above...` framing so the
+ * model sees the condition as a binary judgement task, not a new directive.
+ */
+const userJudgementPrompt = (condition: string): string =>
+  `Based on the conversation transcript above, has the following stopping ` +
+  `condition been satisfied? Answer based on transcript evidence only.\n` +
+  `Condition: ${condition}`;
+
+const RESPONSE_SCHEMA: Schema = {
+  // Schema typing in @google/genai uses an enum-like Type, but accepts the
+  // lower-cased literals at runtime for the upstream JSON-schema payload.
+  type: 'OBJECT' as unknown as Schema['type'],
+  properties: {
+    ok: { type: 'BOOLEAN' as unknown as Schema['type'] },
+    reason: { type: 'STRING' as unknown as Schema['type'] },
+  },
+  required: ['ok', 'reason'],
+};
+
+export interface JudgeResult {
+  ok: boolean;
+  reason: string;
+}
+
+const JUDGE_REASON_FALLBACK =
+  'Goal judge unavailable; continue working toward the goal and run `/goal clear` to stop early.';
+const MAX_REASON_LEN = 240;
+
+/**
+ * Max number of trailing conversation messages we feed to the judge. Capping
+ * by message count (rather than tokens) keeps the judge call cheap and avoids
+ * runaway costs on long sessions; the most recent turns are also the most
+ * relevant to "did we just finish the goal?" decisions.
+ */
+const TRANSCRIPT_TAIL_MESSAGES = 24;
+
+/** Per-text-part character cap. Same purpose as the message cap above. */
+const TRANSCRIPT_PART_CHAR_CAP = 4_000;
+
+/**
+ * Calls a small fast model (or the main model if no fast model is configured)
+ * to evaluate whether the goal condition holds after the latest turn.
+ *
+ * Any failure — timeout, non-JSON response, missing fields, aborted signal —
+ * is converted into `{ok:false, reason:<fallback>}` so the /goal loop can keep
+ * running and the user retains control via `/goal clear`. We deliberately fail
+ * "not met" so a flaky judge never short-circuits a real goal.
+ */
+export async function judgeGoal(
+  config: Config,
+  args: {
+    condition: string;
+    lastAssistantText: string;
+    signal: AbortSignal;
+  },
+): Promise<JudgeResult> {
+  const condition = args.condition.trim();
+  if (!condition) return { ok: false, reason: JUDGE_REASON_FALLBACK };
+  if (args.signal.aborted) return { ok: false, reason: JUDGE_REASON_FALLBACK };
+
+  // Feed the conversation transcript (trailing N messages) plus the framed
+  // judgement prompt — Claude Code's design. The hook input's
+  // `last_assistant_message` is appended only when the live history doesn't
+  // yet contain it (e.g. before the model turn is committed to chat).
+  const transcript = collectTranscript(config, args.lastAssistantText);
+  transcript.push({
+    role: 'user',
+    parts: [{ text: userJudgementPrompt(condition) }],
+  });
+
+  const model = config.getFastModel() ?? config.getModel();
+
+  try {
+    const client = config.getGeminiClient();
+    const response = await client.generateContent(
+      transcript,
+      {
+        systemInstruction: JUDGE_SYSTEM_PROMPT,
+        temperature: 0,
+        responseMimeType: 'application/json',
+        responseSchema: RESPONSE_SCHEMA,
+        // Disable extended thinking — the judge is a binary check; thinking
+        // burns latency and tokens for no quality gain. Matches Claude Code's
+        // `thinkingConfig: { type: "disabled" }` for the same call.
+        thinkingConfig: { thinkingBudget: 0 },
+      },
+      args.signal,
+      model,
+    );
+
+    const text = extractText(response);
+    if (!text) {
+      debugLogger.debug(
+        'Goal judge returned empty content; defaulting to not-met',
+      );
+      return { ok: false, reason: JUDGE_REASON_FALLBACK };
+    }
+    const parsed = parseJudgeReply(text);
+    if (!parsed) {
+      debugLogger.debug(
+        `Goal judge reply not parseable as JSON: ${text.slice(0, 200)}`,
+      );
+      return { ok: false, reason: JUDGE_REASON_FALLBACK };
+    }
+    return parsed;
+  } catch (err) {
+    debugLogger.debug(
+      `Goal judge threw: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return { ok: false, reason: JUDGE_REASON_FALLBACK };
+  }
+}
+
+/**
+ * Pulls the trailing slice of the active session's chat history. Failures
+ * fall back to a single synthetic user/assistant pair built from
+ * `lastAssistantText`, so the judge always has *some* evidence to look at.
+ */
+function collectTranscript(
+  config: Config,
+  lastAssistantText: string,
+): Content[] {
+  try {
+    const client = config.getGeminiClient();
+    if (!client.isInitialized()) return fallbackTranscript(lastAssistantText);
+    const full = client.getHistory();
+    const tail = full.slice(-TRANSCRIPT_TAIL_MESSAGES).map(capContent);
+    if (tail.length === 0) return fallbackTranscript(lastAssistantText);
+    // If the live history's last assistant text doesn't include the supplied
+    // `lastAssistantText`, splice it in — the Stop hook can fire before the
+    // chat history commit on some code paths.
+    const lastModelText = lastModelTextOf(tail);
+    const haveLast =
+      lastModelText.includes(lastAssistantText) ||
+      lastAssistantText.trim() === '';
+    if (!haveLast && lastAssistantText.trim()) {
+      tail.push({
+        role: 'model',
+        parts: [{ text: lastAssistantText.slice(0, TRANSCRIPT_PART_CHAR_CAP) }],
+      });
+    }
+    return tail;
+  } catch (err) {
+    debugLogger.debug(
+      `Goal judge transcript fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return fallbackTranscript(lastAssistantText);
+  }
+}
+
+function fallbackTranscript(lastAssistantText: string): Content[] {
+  if (!lastAssistantText.trim()) return [];
+  return [
+    {
+      role: 'model',
+      parts: [{ text: lastAssistantText.slice(0, TRANSCRIPT_PART_CHAR_CAP) }],
+    },
+  ];
+}
+
+function capContent(content: Content): Content {
+  if (!content.parts) return content;
+  return {
+    ...content,
+    parts: content.parts.map((p) => {
+      if (typeof p.text !== 'string') return p;
+      return p.text.length > TRANSCRIPT_PART_CHAR_CAP
+        ? {
+            ...p,
+            text: p.text.slice(0, TRANSCRIPT_PART_CHAR_CAP) + '…[truncated]',
+          }
+        : p;
+    }),
+  };
+}
+
+function lastModelTextOf(transcript: Content[]): string {
+  for (let i = transcript.length - 1; i >= 0; i--) {
+    const c = transcript[i];
+    if (c.role !== 'model') continue;
+    return (c.parts ?? [])
+      .map((p) => (typeof p.text === 'string' ? p.text : ''))
+      .join('');
+  }
+  return '';
+}
+
+function extractText(response: unknown): string {
+  // generateContent returns a GenerateContentResponse; we accept the response
+  // object structurally so judge stays loose-coupled from SDK type churn.
+  const candidates = (response as { candidates?: unknown[] } | null)
+    ?.candidates;
+  if (!Array.isArray(candidates) || candidates.length === 0) return '';
+  const first = candidates[0] as
+    | { content?: { parts?: Array<{ text?: unknown }> } }
+    | undefined;
+  const parts = first?.content?.parts;
+  if (!Array.isArray(parts)) return '';
+  return parts
+    .map((p) => (typeof p?.text === 'string' ? p.text : ''))
+    .join('')
+    .trim();
+}
+
+function parseJudgeReply(text: string): JudgeResult | null {
+  const cleaned = stripCodeFence(text).trim();
+  // Accept the JSON anywhere in the reply: tolerant to chatty preambles when
+  // the model ignores structured-output mode.
+  const start = cleaned.indexOf('{');
+  const end = cleaned.lastIndexOf('}');
+  if (start === -1 || end === -1 || end < start) return null;
+  let payload: unknown;
+  try {
+    payload = JSON.parse(cleaned.slice(start, end + 1));
+  } catch {
+    return null;
+  }
+  if (!payload || typeof payload !== 'object') return null;
+  const ok = (payload as { ok?: unknown }).ok;
+  const reason = (payload as { reason?: unknown }).reason;
+  if (typeof ok !== 'boolean') return null;
+  const reasonText =
+    typeof reason === 'string' && reason.trim()
+      ? reason.trim().slice(0, MAX_REASON_LEN)
+      : ok
+        ? 'Goal condition reported as met.'
+        : JUDGE_REASON_FALLBACK;
+  return { ok, reason: reasonText };
+}
+
+function stripCodeFence(s: string): string {
+  const m = s.match(/^```(?:json)?\s*([\s\S]*?)\s*```$/i);
+  return m ? m[1] : s;
+}

--- a/packages/core/src/goals/goalLoop.integration.test.ts
+++ b/packages/core/src/goals/goalLoop.integration.test.ts
@@ -1,0 +1,200 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Integration test for the /goal Stop hook loop.
+ *
+ * This intentionally does NOT boot `GeminiClient` or the full hook runner.
+ * It exercises the seam that matters for the spec criterion:
+ *
+ *   "after `/goal <condition>`, a normal attempt to stop must be intercepted
+ *   by the same Stop hook loop used by configured hooks, and the goal must
+ *   auto-clear only when the judge says the condition is satisfied."
+ *
+ * Concretely we verify:
+ *   - `registerGoalHook` wires a Function hook into the session's hook system
+ *     under the `Stop` event with an empty matcher (so it matches any Stop).
+ *   - When the hook callback runs and the judge says "not met", the response
+ *     shape is `{continue:false, stopReason}` — which `client.ts:1342`'s
+ *     `isBlockingDecision() || shouldStopExecution()` interprets as a
+ *     continuation request. We assert the contract that hook here, then defer
+ *     to the existing client-level test suite for the recursive call itself.
+ *   - When the judge says "met" on a later iteration, the hook returns
+ *     `{continue:true}`, clears the store, and notifies the terminal observer
+ *     with stats (iterations, durationMs) — exactly what the UI needs.
+ *   - The hook is removed from the session manager once the goal is achieved
+ *     so a subsequent Stop event would not re-trigger the judge.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { HookEventName, HookSystem, type StopInput } from '../hooks/index.js';
+import type { Config } from '../config/config.js';
+import {
+  __resetActiveGoalStoreForTests,
+  getActiveGoal,
+  registerGoalHook,
+  setGoalTerminalObserver,
+  type GoalTerminalEvent,
+} from './index.js';
+
+const judgeMock = vi.hoisted(() => vi.fn());
+vi.mock('./goalJudge.js', () => ({
+  judgeGoal: judgeMock,
+}));
+
+const SESSION = 'sess-loop';
+
+function makeStopInput(lastAssistantText: string): StopInput {
+  return {
+    session_id: SESSION,
+    transcript_path: '/tmp/t.jsonl',
+    cwd: '/tmp',
+    hook_event_name: 'Stop',
+    timestamp: new Date().toISOString(),
+    stop_hook_active: true,
+    last_assistant_message: lastAssistantText,
+  };
+}
+
+function makeConfigWithRealHookSystem(): {
+  config: Config;
+  hookSystem: HookSystem;
+} {
+  // Use the real HookSystem so we exercise the same session-hook plumbing
+  // `client.ts` would hit, but stub out network / settings dependencies that
+  // it pulls from Config during construction.
+  const config = {
+    getAllowedHttpHookUrls: () => [],
+    getSessionId: () => SESSION,
+    isTrustedFolder: () => true,
+    getDisableAllHooks: () => false,
+  } as unknown as Config;
+  const hookSystem = new HookSystem(config);
+  // Patch Config.getHookSystem to return our real system.
+  (config as { getHookSystem: () => HookSystem }).getHookSystem = () =>
+    hookSystem;
+  return { config, hookSystem };
+}
+
+describe('/goal Stop hook integration', () => {
+  beforeEach(() => {
+    __resetActiveGoalStoreForTests();
+    judgeMock.mockReset();
+  });
+  afterEach(() => __resetActiveGoalStoreForTests());
+
+  it('drives a not-met → met loop and emits an achieved terminal event', async () => {
+    const { config, hookSystem } = makeConfigWithRealHookSystem();
+
+    // Sanity: fast-path check sees the session Stop hook AFTER we register it.
+    expect(hookSystem.hasHooksForEvent('Stop', SESSION)).toBe(false);
+    const goal = registerGoalHook({
+      config,
+      sessionId: SESSION,
+      condition: 'write test letter sequence',
+      tokensAtStart: 0,
+    });
+    expect(hookSystem.hasHooksForEvent('Stop', SESSION)).toBe(true);
+
+    const events: GoalTerminalEvent[] = [];
+    setGoalTerminalObserver(SESSION, (e) => events.push(e));
+
+    // Pull the live session hook entry so we can invoke its callback exactly
+    // the way HookEventHandler would. This is the seam we care about.
+    const sessionHook = hookSystem
+      .getSessionHooksManager()
+      .getHooksForEvent(SESSION, HookEventName.Stop)[0];
+    expect(sessionHook).toBeDefined();
+    expect(sessionHook.matcher).toBe('');
+    // Function hook config — sanity check
+    if (sessionHook.config.type !== 'function') {
+      throw new Error(
+        `expected function hook, got ${String(sessionHook.config.type)}`,
+      );
+    }
+    const callback = sessionHook.config.callback;
+    expect(typeof callback).toBe('function');
+
+    // Iteration 1: judge says NOT met → continuation expected.
+    judgeMock.mockResolvedValueOnce({
+      ok: false,
+      reason: 'still missing letters e, s, t',
+    });
+    const out1 = await callback(makeStopInput('t'), undefined);
+    expect(out1).toMatchObject({
+      decision: 'block',
+      reason: 'still missing letters e, s, t',
+    });
+    // Store reflects increment and lastReason.
+    const after1 = getActiveGoal(SESSION);
+    expect(after1?.iterations).toBe(1);
+    expect(after1?.lastReason).toBe('still missing letters e, s, t');
+    // No terminal event yet.
+    expect(events).toEqual([]);
+
+    // Iteration 2: judge says NOT met again → continuation again.
+    judgeMock.mockResolvedValueOnce({
+      ok: false,
+      reason: 'still missing letters s, t',
+    });
+    const out2 = await callback(makeStopInput('te'), undefined);
+    expect(out2).toMatchObject({ decision: 'block' });
+    expect(getActiveGoal(SESSION)?.iterations).toBe(2);
+    expect(events).toEqual([]);
+
+    // Iteration 3: judge says MET → continue:true and observer fires.
+    judgeMock.mockResolvedValueOnce({
+      ok: true,
+      reason: 'transcript contains "test"',
+    });
+    const out3 = await callback(makeStopInput('test'), undefined);
+    expect(out3).toEqual({ continue: true });
+
+    // Store is cleared synchronously.
+    expect(getActiveGoal(SESSION)).toBeUndefined();
+    // Achieved event with correct stats.
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: 'achieved',
+      condition: goal.condition,
+      iterations: 2, // not yet 3 — that update only happens for not-met cases
+      lastReason: 'transcript contains "test"',
+    });
+    expect(events[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('does NOT call the judge after the goal is replaced', async () => {
+    const { config, hookSystem } = makeConfigWithRealHookSystem();
+    registerGoalHook({
+      config,
+      sessionId: SESSION,
+      condition: 'goal A',
+      tokensAtStart: 0,
+    });
+    // First hook's callback — captured before replacement.
+    const firstHook = hookSystem
+      .getSessionHooksManager()
+      .getHooksForEvent(SESSION, HookEventName.Stop)[0];
+    if (firstHook.config.type !== 'function')
+      throw new Error('expected fn hook');
+    const oldCallback = firstHook.config.callback;
+
+    // Replace with goal B; the old hook should be torn down.
+    registerGoalHook({
+      config,
+      sessionId: SESSION,
+      condition: 'goal B',
+      tokensAtStart: 0,
+    });
+    expect(getActiveGoal(SESSION)?.condition).toBe('goal B');
+
+    // The OLD callback runs against the new active goal → it must short-circuit
+    // (condition mismatch → continue:true, judge untouched).
+    const out = await oldCallback(makeStopInput('anything'), undefined);
+    expect(out).toEqual({ continue: true });
+    expect(judgeMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/goals/index.ts
+++ b/packages/core/src/goals/index.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export type {
+  ActiveGoal,
+  GoalTerminalEvent,
+  GoalTerminalKind,
+  GoalTerminalObserver,
+} from './activeGoalStore.js';
+export {
+  getActiveGoal,
+  setActiveGoal,
+  clearActiveGoal,
+  recordGoalIteration,
+  setGoalTerminalObserver,
+  clearGoalTerminalObserver,
+  notifyGoalTerminal,
+  getLastGoalTerminal,
+  setLastGoalTerminal,
+  __resetActiveGoalStoreForTests,
+} from './activeGoalStore.js';
+export {
+  MAX_GOAL_ITERATIONS,
+  GOAL_HOOK_TIMEOUT_MS,
+  GOAL_HOOK_TIMEOUT_SECONDS,
+  createGoalStopHookCallback,
+  registerGoalHook,
+  unregisterGoalHook,
+} from './goalHook.js';
+export { judgeGoal } from './goalJudge.js';
+export type { JudgeResult } from './goalJudge.js';

--- a/packages/core/src/hooks/hookSystem.test.ts
+++ b/packages/core/src/hooks/hookSystem.test.ts
@@ -235,6 +235,24 @@ describe('HookSystem', () => {
         'SessionEnd',
       );
     });
+
+    it('returns true when only a session function hook is registered', () => {
+      vi.mocked(mockHookRegistry.getHooksForEvent).mockReturnValue([]);
+      const sessionId = 'sess-1';
+      hookSystem.addFunctionHook(
+        sessionId,
+        HookEventName.Stop,
+        '',
+        async () => ({ continue: true }),
+        'error',
+      );
+      // Without a sessionId, hasHooksForEvent still finds it across any session.
+      expect(hookSystem.hasHooksForEvent('Stop')).toBe(true);
+      // With the correct sessionId.
+      expect(hookSystem.hasHooksForEvent('Stop', sessionId)).toBe(true);
+      // With a different sessionId.
+      expect(hookSystem.hasHooksForEvent('Stop', 'other-session')).toBe(false);
+    });
   });
 
   describe('fireStopEvent', () => {

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -130,10 +130,10 @@ export class HookSystem {
    * This is a fast-path check to avoid expensive MessageBus round-trips
    * when no hooks are configured for a given event.
    */
-  hasHooksForEvent(eventName: string): boolean {
-    return (
-      this.hookRegistry.getHooksForEvent(eventName as HookEventName).length > 0
-    );
+  hasHooksForEvent(eventName: string, sessionId?: string): boolean {
+    const event = eventName as HookEventName;
+    if (this.hookRegistry.getHooksForEvent(event).length > 0) return true;
+    return this.sessionHooksManager.hasHooksForEvent(event, sessionId);
   }
 
   async fireUserPromptSubmitEvent(

--- a/packages/core/src/hooks/sessionHooksManager.ts
+++ b/packages/core/src/hooks/sessionHooksManager.ts
@@ -242,6 +242,23 @@ export class SessionHooksManager {
   }
 
   /**
+   * Returns true when any session (or just `sessionId`, when provided) has at
+   * least one hook registered for `event`. Used as the fast-path skip check by
+   * the turn engine so it knows to actually fire the event for session-scoped
+   * hooks like `/goal`.
+   */
+  hasHooksForEvent(event: HookEventName, sessionId?: string): boolean {
+    if (sessionId !== undefined) {
+      const storage = this.sessions.get(sessionId);
+      return (storage?.hooks.get(event)?.length ?? 0) > 0;
+    }
+    for (const storage of this.sessions.values()) {
+      if ((storage.hooks.get(event)?.length ?? 0) > 0) return true;
+    }
+    return false;
+  }
+
+  /**
    * Get hooks that match a specific tool/target
    * @param sessionId Session ID
    * @param event Hook event name

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -356,6 +356,12 @@ export { HookSystem, HookRegistry } from './hooks/index.js';
 export type { HookRegistryEntry, SessionHookEntry } from './hooks/index.js';
 export { type StopFailureErrorType } from './hooks/types.js';
 
+// ============================================================================
+// Goals (/goal command runtime)
+// ============================================================================
+
+export * from './goals/index.js';
+
 // Export hook triggers for all hook events
 export {
   fireNotificationHook,


### PR DESCRIPTION
## Summary

- **What changed:** added a built-in `/goal <condition>` slash command that pins a free-form session-scoped objective. While a goal is active, an LLM judge runs at every Stop boundary and either lets the turn end (condition met) or feeds the judge's reason back as the next user prompt so the model keeps working. Auto-clears on success; `/goal clear` cancels early. Same primitive as Anthropic's Claude Code 2.1.140 `/goal`.
- **Why it changed:** implements #4074. Collapses the "user re-prompts 'keep going' 3-6 times per long task" UX into a single `/goal …` action. Built entirely on qwen-code's existing Stop-hook + function-hook plumbing — no new subsystem.
- **Reviewer focus:**
  1. `packages/core/src/goals/` — the new module. `goalJudge.ts` (transcript-grounded judge with structured-output + disabled thinking), `goalHook.ts` (function hook on `Stop`), `activeGoalStore.ts` (per-session state + terminal-observer channel for UI bridging).
  2. `packages/core/src/hooks/hookSystem.ts` + `sessionHooksManager.ts` — `hasHooksForEvent(eventName, sessionId?)` now also counts session-scoped function hooks. Pre-existing latent bug: SDK / programmatic Stop function hooks were silently gated out by the fast-path check in `client.ts`, so they never fired.
  3. `packages/core/src/core/client.ts` (`StopHookLoop` emission) — yields on **every** Stop-hook continuation, not just iter > 1. First not-met turn is now visible.
  4. `packages/cli/src/ui/hooks/useGeminiStream.ts` (`Finished` handler) — commits the pending history item + clears `thoughtBuffer` / `geminiMessageBuffer` at every turn boundary so a Stop-hook continuation doesn't bleed its first chunk into the previous turn's pending UI buffer (the persisted transcript was always clean — this was a stream-buffer issue).
  5. `packages/cli/src/ui/commands/goalCommand.ts` + `restoreGoal.ts` — the command surface, plus resume-time rehydration of the active hook and the last-completed-goal summary cache from transcript.

## Validation

- **Commands run:**
  ```bash
  npx tsc --noEmit -p packages/core              # ✓
  npx tsc --noEmit -p packages/cli               # ✓
  cd packages/core && npx vitest run             # all green (1181 tests, incl. new goals/ suite)
  cd packages/cli  && npx vitest run \
    src/ui/commands/goalCommand.test.ts \
    src/ui/utils/restoreGoal.test.ts \
    src/ui/components/GoalPill.test.tsx \
    src/services/BuiltinCommandLoader.test.ts \
    src/ui/utils/historyUtils.test.ts \
    src/i18n/mustTranslateKeys.test.ts            # 67 tests ✓
  npx eslint <touched-files>                      # clean
  ```
- **Prompts used (end-to-end smoke):**
  ```
  > /goal 输出test，每个对话单独输出一个字母，直到完成
  ◎ Goal set
    Goal: 输出test，每个对话单独输出一个字母，直到完成

  ✦ t
  ○ Goal check · turn 1 · not yet met

  ✦ e
  ○ Goal check · turn 2 · not yet met

  ✦ s
  ○ Goal check · turn 3 · not yet met

  ✦ t
  ✓ Goal achieved · 3 turns · 22s
    Goal: 输出test，每个对话单独输出一个字母，直到完成

  > /goal
  ✓ Goal achieved · 3 turns · 22s
    Goal: 输出test，每个对话单独输出一个字母，直到完成
  ```
- **Expected result:** judge gates each Stop boundary; the model emits letters t / e / s / t across four assistant turns; the goal auto-clears; subsequent empty `/goal` shows the achievement card.
- **Observed result:** matches.
- **Quickest reviewer verification path:**
  1. `cd packages/core && npx vitest run src/goals/`
  2. In an interactive session: `/goal 输出A、B、C，每个对话单独输出一个字母` → three turns each producing one letter + auto-clear.

## Scope / Risk

- **Main risk / tradeoff:** `HookSystem.hasHooksForEvent` now considers session-scoped function hooks. Code that registered a Stop function hook expecting the prior "silently no-ops" behavior would now see its hook actually fire. Realistically that prior behavior was a latent bug; any code that registered a function hook *wanted* it to run. The two affected tests in `config.test.ts` are updated to pin the new `(eventName, sessionId)` signature.
- **`Finished`-event buffer reset:** the new commit-pending + clear-buffers logic in `useGeminiStream` runs on every turn boundary. Verified against the existing `useGeminiStream.test.tsx` suite (91 tests) — no regressions.
- **`StopHookLoop` on first iteration:** removing the `> 1` guard means user-configured Stop hooks now also surface their blocking reason on the first fire. Previously the first not-met was silent, which masked configured hooks too. The UI rendering for non-goal Stop hooks is unchanged (`● Ran N stop hooks ⎿ Stop hook error: …`); only the visibility threshold dropped.
- **Persisting goals across `/resume`:** in scope. `restoreGoalFromHistory` scans the loaded transcript for the most recent `set` (to re-arm the hook) and the most recent `achieved`/`aborted` (to repopulate the summary cache). `/clear`, `/branch`, `/new` continue to wipe goal state via session-id rotation.
- **Subagents:** out of scope. The hook is registered against the main session id on the `Stop` event only; subagents have their own session id and fire `SubagentStop`, so they cannot trigger or interact with an active goal.
- **Breaking changes / migration:** none. New command, new exports, additive optional `sessionId` arg on `HookSystem.hasHooksForEvent` (existing single-arg call sites keep working).

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

macOS arm64 (M-series) interactive run + the unit test suite were exercised locally. The only platform-specific surface added is the Footer pill glyph (`◎`) and the history card glyphs (`○`, `✓`, `!`) — plain Unicode, no platform-specific behavior expected.

## Linked Issues / Bugs

Closes #4074