### PR TITLE
fix(core): tag subagent OpenAI JSON logs

### DIFF
--- a/packages/core/src/utils/openaiLogger.test.ts
+++ b/packages/core/src/utils/openaiLogger.test.ts
@@ -195,6 +195,52 @@ describe('OpenAILogger', () => {
       );
     });
 
+    it('should include a subagent suffix without the session id', async () => {
+      const logger = new OpenAILogger(testTempDir);
+      await logger.initialize();
+
+      const request = {
+        model: 'claude-opus-4-7',
+        messages: [{ role: 'user', content: 'test' }],
+      };
+      const response = { id: 'test-id', choices: [] };
+
+      const logPath = await logger.logInteraction(
+        request,
+        response,
+        undefined,
+        'e097d32b-82d6-422a-afa6-f6184565a8ab#Explore-g2tss0#7',
+      );
+
+      const basename = path.basename(logPath);
+      expect(basename).toMatch(
+        /openai-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z-[a-f0-9]{8}-subagent-Explore-g2tss0\.json/,
+      );
+      expect(basename).not.toContain('e097d32b');
+    });
+
+    it('should not include a suffix for main-session prompt ids', async () => {
+      const logger = new OpenAILogger(testTempDir);
+      await logger.initialize();
+
+      const request = {
+        model: 'claude-opus-4-7',
+        messages: [{ role: 'user', content: 'test' }],
+      };
+      const response = { id: 'test-id', choices: [] };
+
+      const logPath = await logger.logInteraction(
+        request,
+        response,
+        undefined,
+        'e097d32b-82d6-422a-afa6-f6184565a8ab########0',
+      );
+
+      expect(path.basename(logPath)).toMatch(
+        /openai-\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.\d{3}Z-[a-f0-9]{8}\.json/,
+      );
+    });
+
     it('should write correct log data structure', async () => {
       const logger = new OpenAILogger(testTempDir);
       await logger.initialize();

--- a/packages/core/src/utils/openaiLogger.ts
+++ b/packages/core/src/utils/openaiLogger.ts
@@ -13,14 +13,36 @@ import { isInternalPromptId } from './internalPromptIds.js';
 
 const debugLogger = createDebugLogger('OPENAI_LOGGER');
 
-function sanitizePromptIdForFilename(
-  promptId: string | undefined,
+function sanitizeDiagnosticSuffix(
+  suffix: string | undefined,
 ): string | undefined {
-  if (!promptId || !isInternalPromptId(promptId)) return undefined;
-  const sanitized = promptId
+  if (!suffix) return undefined;
+  const sanitized = suffix
     .replace(/[^a-zA-Z0-9._-]+/g, '-')
     .replace(/^-+|-+$/g, '');
   return sanitized || undefined;
+}
+
+function extractSubagentSuffix(promptId: string): string | undefined {
+  const parts = promptId.split('#');
+  if (parts.length !== 3) return undefined;
+
+  const [, subagentId, turn] = parts;
+  if (!subagentId || !turn || !/^\d+$/.test(turn)) {
+    return undefined;
+  }
+
+  return `subagent-${subagentId}`;
+}
+
+function promptIdSuffixForFilename(
+  promptId: string | undefined,
+): string | undefined {
+  if (!promptId) return undefined;
+  if (isInternalPromptId(promptId)) {
+    return sanitizeDiagnosticSuffix(promptId);
+  }
+  return sanitizeDiagnosticSuffix(extractSubagentSuffix(promptId));
 }
 
 /**
@@ -75,8 +97,8 @@ export class OpenAILogger {
    * @param request The request sent to OpenAI
    * @param response The response received from OpenAI
    * @param error Optional error if the request failed
-   * @param promptId Optional prompt id; internal prompt ids are appended to
-   *                 the filename after timestamp and id.
+   * @param promptId Optional prompt id; internal and subagent prompt ids are
+   *                 appended to the filename after timestamp and id.
    * @returns The file path where the log was written
    */
   async logInteraction(
@@ -91,7 +113,7 @@ export class OpenAILogger {
 
     const timestamp = new Date().toISOString().replace(/:/g, '-');
     const id = uuidv4().slice(0, 8);
-    const promptIdSuffix = sanitizePromptIdForFilename(promptId);
+    const promptIdSuffix = promptIdSuffixForFilename(promptId);
     const filename = promptIdSuffix
       ? `openai-${timestamp}-${id}-${promptIdSuffix}.json`
       : `openai-${timestamp}-${id}.json`;


### PR DESCRIPTION
## Summary

- What changed: OpenAI JSON request/response file logging now appends a sanitized subagent suffix for subagent prompt ids when explicit OpenAI file logging is enabled. Side-query suffixes from #4081 remain unchanged, and main-session prompt ids remain untagged so the filename set separates main calls, side queries, and subagent turns without exposing the session id.
- Why it changed: https://github.com/QwenLM/qwen-code/pull/4081 made internal `side-query:*` calls visible in the explicit diagnostic sink, but Anthropic agent sidechain calls use prompt ids shaped like `<session>#<subagent>#<round>`. Those calls were recorded as plain `openai-*.json` files, making subagent traffic hard to distinguish from the main agent even though telemetry already attributes them separately.
- Reviewer focus: Please verify that explicit OpenAI JSON file logging keeps side-query suffixes, adds `subagent-*` suffixes for subagent prompt ids, leaves main-session prompt ids untagged, and does not write the full session id into filenames.

## Validation

- Commands run: `cd packages/core && npx vitest run src/utils/openaiLogger.test.ts src/core/loggingContentGenerator/loggingContentGenerator.test.ts`; `npm run build && npm run typecheck`; `npm run bundle`; `git diff --check`
- Prompts / inputs used: Interactive TUI E2E with `node dist/cli.js --approval-mode yolo --openai-logging --openai-logging-dir /tmp/qwen-rename-auto-logs-1778642240-fast`, a setup prompt (`For an end-to-end logging test, reply with exactly: ready for rename auto.`), and `/rename --auto` under a temporary `QWEN_HOME` with `fastModel` set to `claude-opus-4-7`.
- Expected result: Explicit OpenAI JSON logging distinguishes main agent calls, `side-query:*` calls, and subagent calls by filename suffix while preserving timestamp-first chronological sorting.
- Observed result: Focused logging tests passed, build passed, typecheck passed, bundle passed, diff whitespace checks passed, and the E2E log directory contained plain main-agent files, `side-query-session-title` files, and a `subagent-managed-auto-memory-extractor-*` file.
- Quickest reviewer verification path: Run the focused Vitest command above and inspect the new OpenAI JSON filename assertions for subagent prompt ids and main-session prompt ids.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.): Focused tests reported 2 files passed and 66 tests passed. E2E wrote `/tmp/qwen-rename-auto-logs-1778642240-fast/openai-2026-05-13T03-17-39.632Z-74bf403a-side-query-session-title.json`, `/tmp/qwen-rename-auto-logs-1778642240-fast/openai-2026-05-13T03-17-49.579Z-dc490e0d-side-query-session-title.json`, and `/tmp/qwen-rename-auto-logs-1778642240-fast/openai-2026-05-13T03-17-43.225Z-ac6a1ab1-subagent-managed-auto-memory-extractor-d31oyk.json`.

## Scope / Risk

- Main risk or tradeoff: Subagent prompt identity is now visible in explicit OpenAI diagnostic log filenames, though the full session id is intentionally omitted.
- Not covered / not validated: No Windows or Linux validation; this is covered locally on macOS with focused unit tests plus an interactive Anthropic TUI logging run.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Validated locally on macOS only.

## Linked Issues / Bugs

- Follow-up to: https://github.com/QwenLM/qwen-code/pull/4081
- Related: https://github.com/QwenLM/qwen-code/pull/2872
