### PR TITLE
fix(core): skip incompatible OpenAI dispatcher on Node 26

### DIFF
--- a/packages/core/src/utils/runtimeFetchOptions.test.ts
+++ b/packages/core/src/utils/runtimeFetchOptions.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterAll } from 'vitest';
 import {
   buildRuntimeFetchOptions,
   getOrCreateSharedDispatcher,
@@ -12,6 +12,35 @@ import {
 } from './runtimeFetchOptions.js';
 
 type UndiciOptions = Record<string, unknown>;
+const originalUndiciVersionDescriptor = Object.getOwnPropertyDescriptor(
+  process.versions,
+  'undici',
+);
+
+function stubNativeUndiciVersion(version: string | undefined): void {
+  if (version === undefined) {
+    delete (process.versions as Record<string, string | undefined>)['undici'];
+    return;
+  }
+
+  Object.defineProperty(process.versions, 'undici', {
+    value: version,
+    configurable: true,
+  });
+}
+
+function restoreNativeUndiciVersion(): void {
+  if (originalUndiciVersionDescriptor) {
+    Object.defineProperty(
+      process.versions,
+      'undici',
+      originalUndiciVersionDescriptor,
+    );
+    return;
+  }
+
+  delete (process.versions as Record<string, string | undefined>)['undici'];
+}
 
 vi.mock('undici', () => {
   class MockAgent {
@@ -37,7 +66,13 @@ vi.mock('undici', () => {
 describe('buildRuntimeFetchOptions (node runtime)', () => {
   beforeEach(() => {
     resetDispatcherCache();
+    stubNativeUndiciVersion('7.24.4');
   });
+
+  afterAll(() => {
+    restoreNativeUndiciVersion();
+  });
+
   it('disables undici timeouts for Agent in OpenAI options', () => {
     const result = buildRuntimeFetchOptions('openai');
 
@@ -69,6 +104,41 @@ describe('buildRuntimeFetchOptions (node runtime)', () => {
     });
   });
 
+  it('uses native fetch for OpenAI without proxy when Node ships undici v8', () => {
+    stubNativeUndiciVersion('8.0.2');
+
+    const result = buildRuntimeFetchOptions('openai');
+
+    expect(result).toBeUndefined();
+  });
+
+  it('returns dispatcher for OpenAI when undici version is absent', () => {
+    stubNativeUndiciVersion(undefined);
+
+    const result = buildRuntimeFetchOptions('openai');
+
+    expect(result).toBeDefined();
+    expect(result && 'fetchOptions' in result).toBe(true);
+  });
+
+  it('keeps proxy dispatcher for OpenAI when Node ships undici v8 and proxy is set', () => {
+    stubNativeUndiciVersion('8.0.2');
+
+    const result = buildRuntimeFetchOptions('openai', 'http://proxy.local');
+
+    expect(result).toBeDefined();
+    expect(result && 'fetchOptions' in result).toBe(true);
+
+    const dispatcher = (
+      result as { fetchOptions?: { dispatcher?: { options?: UndiciOptions } } }
+    ).fetchOptions?.dispatcher;
+    expect(dispatcher?.options).toMatchObject({
+      uri: 'http://proxy.local',
+      headersTimeout: 0,
+      bodyTimeout: 0,
+    });
+  });
+
   it('returns fetchOptions with dispatcher for Anthropic without proxy', () => {
     const result = buildRuntimeFetchOptions('anthropic');
 
@@ -82,6 +152,15 @@ describe('buildRuntimeFetchOptions (node runtime)', () => {
       headersTimeout: 0,
       bodyTimeout: 0,
     });
+  });
+
+  it('returns dispatcher for Anthropic when Node ships undici v8', () => {
+    stubNativeUndiciVersion('8.0.2');
+
+    const result = buildRuntimeFetchOptions('anthropic');
+
+    expect(result).toBeDefined();
+    expect(result && 'fetchOptions' in result).toBe(true);
   });
 
   it('returns fetchOptions with ProxyAgent for Anthropic with proxy', () => {

--- a/packages/core/src/utils/runtimeFetchOptions.ts
+++ b/packages/core/src/utils/runtimeFetchOptions.ts
@@ -5,6 +5,9 @@
  */
 
 import { Agent, ProxyAgent, type Dispatcher } from 'undici';
+import { createDebugLogger } from './debugLogger.js';
+
+const debugLogger = createDebugLogger('RUNTIME_FETCH_OPTIONS');
 
 /**
  * JavaScript runtime type
@@ -180,10 +183,33 @@ function buildFetchOptionsWithDispatcher(
   sdkType: SDKType,
   proxyUrl?: string,
 ): OpenAIRuntimeFetchOptions | AnthropicRuntimeFetchOptions {
+  // Node 26 native fetch uses undici v8, which is incompatible with dispatchers
+  // created by the bundled undici v6 package when passed through the OpenAI SDK.
+  if (sdkType === 'openai' && !proxyUrl && hasNativeUndiciV8OrNewer()) {
+    debugLogger.debug(
+      `buildFetchOptionsWithDispatcher: using native fetch for undici v${process.versions?.['undici']}`,
+    );
+    return undefined;
+  }
+
   try {
     const dispatcher = getOrCreateSharedDispatcher(proxyUrl);
     return { fetchOptions: { dispatcher } };
   } catch {
     return sdkType === 'openai' ? undefined : {};
   }
+}
+
+function hasNativeUndiciV8OrNewer(): boolean {
+  if (typeof process === 'undefined') {
+    return false;
+  }
+
+  const undiciVersion = process.versions?.['undici'];
+  if (!undiciVersion) {
+    return false;
+  }
+
+  const major = Number.parseInt(undiciVersion.split('.')[0] ?? '', 10);
+  return !Number.isNaN(major) && major >= 8;
 }


### PR DESCRIPTION
Fixes #4035

## Summary
- Avoid passing qwen-code's bundled undici dispatcher to the OpenAI SDK when Node native fetch is backed by undici v8 and no proxy is configured.
- Preserve ProxyAgent behavior when a proxy is configured.
- Preserve Anthropic behavior and existing OpenAI dispatcher behavior on native undici v7 and older runtimes.

## Root Cause
Node 26 native fetch uses undici v8, while qwen-code bundles undici v6. Passing a dispatcher created by bundled undici v6 through the OpenAI SDK can fail when native fetch validates/uses that dispatcher, which surfaces as `Connection error. (cause: fetch failed)` for DashScope-intl/OpenAI-compatible requests.

## Validation
- `npm run test --workspace=packages/core -- src/utils/runtimeFetchOptions.test.ts -t "undici v8"`
- `npm run test --workspace=packages/core -- src/utils/runtimeFetchOptions.test.ts`
- `npm run test --workspace=packages/core -- src/utils/runtimeFetchOptions.test.ts src/core/openaiContentGenerator/provider/dashscope.test.ts src/core/openaiContentGenerator/provider/default.test.ts`
- `npx eslint packages/core/src/utils/runtimeFetchOptions.ts packages/core/src/utils/runtimeFetchOptions.test.ts`
- `npx prettier --check packages/core/src/utils/runtimeFetchOptions.ts packages/core/src/utils/runtimeFetchOptions.test.ts`
- `npm run typecheck --workspace=packages/core`
