### PR TITLE
fix(dashscope): use URL hostname check instead of regex to avoid ReDoS (CodeQL)

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -188,6 +188,39 @@ describe('DashScopeOpenAICompatibleProvider', () => {
       });
     });
 
+    it('should return false when the dashscope domain only appears in the URL path', () => {
+      const config = {
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://evil.example.com/dashscope.aliyuncs.com/v1',
+      } as ContentGeneratorConfig;
+
+      const result =
+        DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for a domain that only ends with dashscope.aliyuncs.com as a suffix without a dot', () => {
+      const config = {
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'https://notdashscope.aliyuncs.com/v1',
+      } as ContentGeneratorConfig;
+
+      const result =
+        DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
+      expect(result).toBe(false);
+    });
+
+    it('should return false for an unparseable baseUrl', () => {
+      const config = {
+        authType: AuthType.USE_OPENAI,
+        baseUrl: 'not a url',
+      } as ContentGeneratorConfig;
+
+      const result =
+        DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
+      expect(result).toBe(false);
+    });
+
     it('should return true when baseUrl matches DASHSCOPE_PROXY_BASE_URL', () => {
       vi.stubEnv(
         'DASHSCOPE_PROXY_BASE_URL',

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -41,9 +41,24 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
       ? baseUrl.slice(0, -1)
       : baseUrl;
 
-    // Matches: dashscope.aliyuncs.com, *.dashscope.aliyuncs.com, or *.dashscope-intl.aliyuncs.com
+    // Parse the URL and check hostname instead of regex to avoid ReDoS on
+    // attacker-controlled baseUrl and to reject path-only matches like
+    // https://evil.example/dashscope.aliyuncs.com/...
+    let hostname: string | null = null;
+    try {
+      hostname = new URL(normalizedBaseUrl).hostname.toLowerCase();
+    } catch {
+      hostname = null;
+    }
+
+    // Matches: dashscope.aliyuncs.com, *.dashscope.aliyuncs.com,
+    // dashscope-intl.aliyuncs.com, or *.dashscope-intl.aliyuncs.com
     const isDashscopeOrigin =
-      /([\w-]+\.)?dashscope(-intl)?\.aliyuncs\.com/i.test(normalizedBaseUrl);
+      hostname !== null &&
+      (hostname === 'dashscope.aliyuncs.com' ||
+        hostname === 'dashscope-intl.aliyuncs.com' ||
+        hostname.endsWith('.dashscope.aliyuncs.com') ||
+        hostname.endsWith('.dashscope-intl.aliyuncs.com'));
 
     // Check if proxy is configured and matches
     const normalizedProxyUrl = DASHSCOPE_PROXY_BASE_URL?.endsWith('/')


### PR DESCRIPTION
## Summary

Fixes the CodeQL high-severity alert ([js/polynomial-redos](https://codeql.github.com/codeql-query-help/javascript/js-polynomial-redos/)) that landed on `main` with #3991.

The alert pointed at `packages/core/src/core/openaiContentGenerator/provider/dashscope.ts:44`:

\`\`\`ts
const isDashscopeOrigin =
  /([\w-]+\.)?dashscope(-intl)?\.aliyuncs\.com/i.test(normalizedBaseUrl);
\`\`\`

Two problems with this regex against the user-controlled \`baseUrl\`:

1. **ReDoS surface.** \`[\w-]+\` is a polynomial-backtracking quantifier; combined with the dotted suffix it can take quadratic time on inputs with many \`-\` characters. \`baseUrl\` reaches this check unsanitized (env var, settings, CLI flag).
2. **Too permissive.** The pattern is unanchored and the input is the whole URL (scheme + host + path), so an unrelated host with the dashscope domain in its path — e.g. \`https://evil.example/dashscope.aliyuncs.com/...\` — also matches and is treated as a trusted DashScope origin, which causes the client to send the DashScope auth/cache headers + session metadata to a third-party server.

## Fix

Parse \`baseUrl\` with the \`URL\` constructor and compare the hostname instead. No regex, no ReDoS surface, and strictly tighter:

\`\`\`ts
let hostname: string | null = null;
try {
  hostname = new URL(normalizedBaseUrl).hostname.toLowerCase();
} catch {
  hostname = null;
}

const isDashscopeOrigin =
  hostname !== null &&
  (hostname === 'dashscope.aliyuncs.com' ||
    hostname === 'dashscope-intl.aliyuncs.com' ||
    hostname.endsWith('.dashscope.aliyuncs.com') ||
    hostname.endsWith('.dashscope-intl.aliyuncs.com'));
\`\`\`

All five existing matching cases (\`dashscope.aliyuncs.com\`, \`dashscope-intl.aliyuncs.com\`, \`coding.dashscope.aliyuncs.com\`, \`coding-intl.dashscope-intl.aliyuncs.com\`, plus the QWEN_OAUTH / no-baseUrl shortcut) keep passing.

Added three regression tests for the previously-permissive behavior:
- domain appearing only in URL path → false
- \`notdashscope.aliyuncs.com\` (suffix without dot boundary) → false
- unparseable baseUrl → false

## Test plan
- [x] \`vitest run packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts\` — 47/47 passing (44 existing + 3 new)
- [x] \`eslint\` on changed files — clean
- [x] \`tsc --noEmit\` on \`packages/core\` — clean
- [ ] CodeQL CI on this PR shows the alert resolved