### PR TITLE
fix(anthropic): allow cache_control on tool_result blocks

### DIFF
--- a/packages/core/src/core/anthropicContentGenerator/converter.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.test.ts
@@ -221,6 +221,7 @@ describe('AnthropicContentConverter', () => {
               type: 'tool_result',
               tool_use_id: 'call-1',
               content: 'ok',
+              cache_control: { type: 'ephemeral' },
             },
           ],
         },
@@ -253,6 +254,7 @@ describe('AnthropicContentConverter', () => {
             type: 'tool_result',
             tool_use_id: 'call-1',
             content: 'boom',
+            cache_control: { type: 'ephemeral' },
           },
         ],
       });
@@ -286,6 +288,7 @@ describe('AnthropicContentConverter', () => {
             type: 'tool_result',
             tool_use_id: 'call-1',
             content: '',
+            cache_control: { type: 'ephemeral' },
           },
         ],
       });
@@ -336,6 +339,7 @@ describe('AnthropicContentConverter', () => {
                   },
                 },
               ],
+              cache_control: { type: 'ephemeral' },
             },
           ],
         },
@@ -434,6 +438,7 @@ describe('AnthropicContentConverter', () => {
                   },
                 },
               ],
+              cache_control: { type: 'ephemeral' },
             },
           ],
         },
@@ -485,6 +490,7 @@ describe('AnthropicContentConverter', () => {
                   },
                 },
               ],
+              cache_control: { type: 'ephemeral' },
             },
           ],
         },
@@ -536,6 +542,7 @@ describe('AnthropicContentConverter', () => {
                   },
                 },
               ],
+              cache_control: { type: 'ephemeral' },
             },
           ],
         },
@@ -665,6 +672,7 @@ describe('AnthropicContentConverter', () => {
                 },
               },
             ],
+            cache_control: { type: 'ephemeral' },
           },
         ],
       });
@@ -1386,6 +1394,47 @@ describe('AnthropicContentConverter', () => {
           content: [{ type: 'text', text: 'Hello' }],
         },
       ]);
+    });
+
+    it('marks the last user message with cache_control when its last block is tool_result', () => {
+      // Regression: in agentic loops the last user message is typically a
+      // tool_result, not a text block. An earlier guard required the last
+      // block to be text, which silently dropped the per-turn cache
+      // breakpoint from turn 2 onward and collapsed the cacheable region
+      // back to system+tools. Anthropic docs explicitly list tool_result
+      // as a cacheable block type in messages.content.
+      const { messages } = converter.convertGeminiRequestToAnthropic({
+        model: 'models/test',
+        contents: [
+          { role: 'user', parts: [{ text: 'do the thing' }] },
+          {
+            role: 'model',
+            parts: [{ functionCall: { id: 'c1', name: 't', args: {} } }],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'c1',
+                  name: 't',
+                  response: { output: 'done' },
+                },
+              },
+            ],
+          },
+        ],
+      });
+
+      const lastUser = messages[messages.length - 1];
+      expect(lastUser.role).toBe('user');
+      const content = Array.isArray(lastUser.content) ? lastUser.content : [];
+      const lastBlock = content[content.length - 1] as {
+        type: string;
+        cache_control?: { type: string };
+      };
+      expect(lastBlock.type).toBe('tool_result');
+      expect(lastBlock.cache_control).toEqual({ type: 'ephemeral' });
     });
 
     it('does not add cache_control to tools when disabled', async () => {

--- a/packages/core/src/core/anthropicContentGenerator/converter.ts
+++ b/packages/core/src/core/anthropicContentGenerator/converter.ts
@@ -807,7 +807,14 @@ export class AnthropicContentConverter {
    * `scope: 'global'` instead.
    */
   private addCacheControlToMessages(messages: Anthropic.MessageParam[]): void {
-    // Find the last user message to add cache_control
+    // Find the last user message to add cache_control. The Anthropic docs
+    // (https://docs.claude.com/en/docs/build-with-claude/prompt-caching)
+    // explicitly list both `text` and `tool_result` blocks as cacheable in
+    // `messages.content`. In agentic loops the last user message after
+    // turn 1 is typically a tool_result-only message, so accepting both
+    // types keeps the per-turn breakpoint moving forward as the
+    // conversation grows (otherwise the cacheable region collapses back
+    // to system+tools and turn-over-turn history never gets cached).
     for (let i = messages.length - 1; i >= 0; i--) {
       const msg = messages[i];
       if (msg.role === 'user') {
@@ -817,19 +824,18 @@ export class AnthropicContentConverter {
 
         if (content.length > 0) {
           const lastContent = content[content.length - 1];
-          // Only add cache_control if the last block is a non-empty text block
-          if (
-            typeof lastContent === 'object' &&
-            'type' in lastContent &&
-            lastContent.type === 'text' &&
-            'text' in lastContent &&
-            lastContent.text
-          ) {
-            lastContent.cache_control = {
-              type: 'ephemeral',
-            };
+          if (typeof lastContent === 'object' && 'type' in lastContent) {
+            const type = lastContent.type;
+            // Empty text blocks cannot be cached (per Anthropic docs).
+            const isEmptyText =
+              type === 'text' &&
+              (!('text' in lastContent) || !lastContent.text);
+            if ((type === 'text' || type === 'tool_result') && !isEmptyText) {
+              lastContent.cache_control = {
+                type: 'ephemeral',
+              };
+            }
           }
-          // If last block is not text or is empty, don't add cache_control
           msg.content = content;
         }
         break;


### PR DESCRIPTION
## Summary

- What changed: `addCacheControlToMessages` now attaches the per-turn cache breakpoint to the last user message's last block whether that block is `text` *or* `tool_result`. Previously only `text` blocks qualified.
- Why it changed: In agentic loops the last user message after turn 1 is typically a `tool_result`. The old guard silently dropped the per-turn breakpoint, collapsing the cacheable region back to system+tools (~32k) and never caching conversation history. The Anthropic docs ([prompt caching](https://docs.claude.com/en/docs/build-with-claude/prompt-caching)) explicitly list `tool_result` as a cacheable block type in `messages.content`.
- Reviewer focus: [converter.ts:809-844](https://github.com/QwenLM/qwen-code/blob/fix/anthropic-cache-tool-result/packages/core/src/core/anthropicContentGenerator/converter.ts#L809) — the relaxed guard and the empty-text exclusion. The empty-text skip is preserved per docs.

## Validation

- Commands run:
  ```bash
  npm install
  cd packages/core && npx vitest run src/core/anthropicContentGenerator/
  npm run typecheck
  npm run build
  ```
- Prompts / inputs used: same multi-turn `gh`-driven prompt against `claude-opus-4-7` (via IDEALAB → Bedrock/Vertex) and `deepseek-v4-pro` (api.deepseek.com/anthropic), both under `--auth-type anthropic`. Raw token trace captured pre- and post-fix.
- Expected result: `cache_creation_input_tokens` grows turn-over-turn once the conversation history starts flowing into the cacheable region.
- Observed result: For Anthropic-protocol providers the cacheable prefix now extends through the tool_result history. On same-backend Bedrock transitions, `cache_read` grew from ~32k (system+tools only, pre-fix) to 43k → 47k → 51k as conversation history accumulated. Detailed E2E numbers in the comment below.
- Quickest reviewer verification path: 110/110 anthropic-adapter unit tests pass, including a new regression test that asserts a `tool_result`-last user message gets `cache_control` attached.
- Evidence: full per-call trace and aggregate amortization numbers posted as a comment on this PR.

## Scope / Risk

- Main risk or tradeoff: Adds a `cache_control: { type: 'ephemeral' }` attribute to `tool_result` content blocks emitted by the converter. This is explicitly documented by Anthropic as supported. Providers that ignore `cache_control` (DeepSeek's auto-caching) are unaffected; providers that honor it (real Anthropic / Bedrock / Vertex) now amortize history.
- Not covered / not validated: direct `api.anthropic.com` was not exercised in E2E (no key in this environment). The behavior is symmetric to the existing system/tool markers, both of which DO ship to api.anthropic.com today.
- Breaking changes / migration notes: none. Cache writes for `tool_result` blocks are billable at 1.25× per Anthropic's pricing, but the same blocks were already in the request body as fresh input tokens — net cost on the first turn is roughly even, and reads on subsequent turns are 0.1× (≈10× cheaper) so any multi-turn workload comes out ahead.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- macOS: unit tests, typecheck, build, headless E2E against two Anthropic-protocol providers (12 API calls each).
- Other platforms: not validated; change is pure conversion logic in the request-builder with no platform surface.

## Linked Issues / Bugs

None.