### PR TITLE
feat(telemetry): unify span creation paths for hierarchical trace tree

### DIFF
--- a/docs/design/workflow-tracing-gaps.md
+++ b/docs/design/workflow-tracing-gaps.md
@@ -1,0 +1,376 @@
+# Workflow 级 Span 粒度不足分析 (P1)
+
+> 基于 2026-05-13 对 qwen-code origin/main 的复核
+
+## 现状
+
+qwen-code 已具备 tracing 基础设施：
+
+| 组件          | 位置                                             | 说明                                                     |
+| ------------- | ------------------------------------------------ | -------------------------------------------------------- |
+| Span 类型定义 | `packages/core/src/telemetry/session-tracing.ts` | `interaction`、`llm_request`、`tool`、`tool.execution`   |
+| Tracer 工具   | `packages/core/src/telemetry/tracer.ts`          | session root context、`withSpan`、`startSpanWithContext` |
+| 交互入口      | `packages/core/src/core/client.ts`               | 顶层交互显式启动 `interaction` span                      |
+| 生命周期管理  | —                                                | AsyncLocalStorage + WeakRef + TTL cleanup                |
+
+当前 runtime 中稳定接入的主要是两类 generic spans：
+
+- `api.generateContent` / `api.generateContentStream`
+- `tool.<toolName>`
+
+**结论：已进入"有 tracing 主干"阶段，但尚未把 agent workflow 的阶段边界完整编码进 trace 树。**
+
+### 对比：claude-code 已实现的 span 类型
+
+参考 `claude-code/src/utils/telemetry/sessionTracing.ts` (line 49)：
+
+- `interaction`
+- `llm_request`
+- `tool`
+- `tool.blocked_on_user`
+- `tool.execution`
+- `hook`
+
+## 缺失项
+
+| 缺失 span / 机制                           | 影响                                            |
+| ------------------------------------------ | ----------------------------------------------- |
+| `permission_wait` / `blocked_on_user` span | 无法区分审批等待 vs 工具执行耗时                |
+| `hook` span                                | hook 耗时被折叠进 tool span，定位边界不清       |
+| `subagent` root span                       | subagent 内部 llm/tool 调用无法形成 trace 子树  |
+| `tool.execution` 真实接线                  | helper 已定义但主链路未调用                     |
+| 稳定的 parent-child wiring                 | spans 多为 session root 下的 sibling 而非层级树 |
+
+## 逐项分析
+
+### 1. 用户审批等待不在 trace 中
+
+工具调用等待审批时，状态迁移路径为 `awaiting_approval` → `scheduled` → 执行。
+
+- "等待用户确认"只是状态迁移，不是 trace 节点
+- trace 上看不到审批等待耗时
+- 工具慢时无法区分是"卡在等用户"还是"工具本身执行慢"
+
+### 2. Hook 有事件记录但没有独立 span
+
+Pre/Post hook 执行后产出 `HookCallEvent`，走 `logHookCall()`，但不建立独立 OTel span。
+
+- hook 变慢时表现为外层 tool span 变慢
+- hook 失败时表现为 "tool 失败"
+- trace 无法回答"时间花在 hook 还是 tool.execution 上"
+
+### 3. Subagent 是 log/metric 而非 trace subtree
+
+subagent 启动/完成时记录 `SubagentExecutionEvent` 并进入 log/metric，但没有形成显式 span 子树。
+
+- 能统计"哪个 subagent 跑过"
+- 不能顺着 trace 看"这个 subagent 触发了哪些 llm/tool 调用"
+- 并发 subagent 场景下因果链不清
+
+### 4. tool.execution helper 已定义但未接入主链路
+
+`session-tracing.ts` 中已有 `startToolExecutionSpan()` / `endToolExecutionSpan()`，但非测试代码中未见调用点。
+
+当前实际 trace 树：
+
+```
+session-root
+  interaction
+    api.generateContent
+    tool.Bash
+  subagent_execution        (log/metric)
+  hook_call                 (event/QwenLogger)
+```
+
+理想 trace 树：
+
+```
+interaction
+  llm_request
+    tool
+      tool.blocked_on_user
+      hook(pre)
+      tool.execution
+      hook(post)
+  subagent
+    interaction
+      llm_request
+        tool
+```
+
+### 5. Parent-child wiring 不够稳定
+
+interaction span 已存在，但很多运行中的 spans 挂在 session root 下作为 sibling，而不是 interaction 的子节点。
+
+- 调用树偏平
+- 节点间因果关系不直观
+- 从一个用户轮次追到内部 llm/tool/hook/subagent 的体验不连续
+
+## 影响
+
+- traces 有基础价值，但不足以支撑 workflow 级排障
+- 无法直接回答"这轮慢在等用户、hook，还是 tool 真执行"
+- 无法把 subagent 运行过程还原为可阅读的 trace 子树
+- hook 问题被折叠进 tool span，定位边界不清
+- 在 Jaeger / Tempo / ARMS 上的树比 claude-code 更平、更难读
+
+---
+
+## claude-code 方案复用分析
+
+> 基于 2026-05-13 对 claude-code 源码的深度对比
+
+### claude-code 的 tracing 架构
+
+claude-code 在 `src/utils/telemetry/sessionTracing.ts` 中实现了一个**统一的、基于双 ALS 的 span 管理系统**：
+
+```
+                    interactionContext (ALS)          toolContext (ALS)
+                          │                                │
+                          ▼                                ▼
+              ┌─────────────────────┐           ┌─────────────────────┐
+              │  interaction span   │           │    tool span        │
+              │  (session root)     │           │  (child of intxn)   │
+              └─────────────────────┘           └─────────────────────┘
+                   ▲ parent of                       ▲ parent of
+                   │                                 │
+           ┌───────┴───────┐              ┌──────────┼──────────┐
+           │               │              │          │          │
+      llm_request      tool          blocked    execution    hook
+                                     _on_user
+```
+
+**核心机制：**
+
+| 机制        | 实现                                                                                                                                                                                      |
+| ----------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 双 ALS      | `interactionContext` 存当前 interaction span；`toolContext` 存当前 tool span                                                                                                              |
+| parent 解析 | 每种 span 类型硬编码从哪个 ALS 取 parent：`llm_request`/`tool` 取 `interactionContext`；`blocked_on_user`/`execution`/`hook` 取 `toolContext`；`hook` 有 fallback 到 `interactionContext` |
+| 生命周期    | enterWith 注入 → span 运行 → enterWith(undefined) 清除                                                                                                                                    |
+| 查找 span   | 非 ALS 存储的 span（如 blocked_on_user）通过 `activeSpans` Map 按 `span.type` 反查                                                                                                        |
+| 内存管理    | ALS 持有的 span 用 WeakRef；非 ALS 持有的 span 用 strongRef 防 GC；TTL 30min 自动清理                                                                                                     |
+
+**claude-code tool span 完整生命周期** (`toolExecution.ts`):
+
+```
+startToolSpan(name, attrs)                    // → toolContext.enterWith(spanCtx)
+  startToolBlockedOnUserSpan()                // → parent = toolContext.getStore()
+    [permission resolution / user prompt]
+  endToolBlockedOnUserSpan(decision, source)
+  startToolExecutionSpan()                    // → parent = toolContext.getStore()
+    [tool.call()]
+  endToolExecutionSpan({ success })
+endToolSpan(result)                           // → toolContext.enterWith(undefined)
+```
+
+**claude-code hook span** (`hooks.ts`):
+
+```
+startHookSpan(event, name, count, defs)       // → parent = toolContext ?? interactionContext
+  [parallel hook execution]
+endHookSpan(span, { success, blocking, ... })
+```
+
+### qwen-code 现有架构 vs claude-code
+
+#### 根本差异：两套断裂的 span 创建路径
+
+这是 qwen-code 当前最关键的架构问题：
+
+| 层                 | 文件                 | 用法                                                                                        | parent 解析                                               |
+| ------------------ | -------------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| session-tracing 层 | `session-tracing.ts` | `startInteractionSpan` / `startLLMRequestSpan` / `startToolSpan` / `startToolExecutionSpan` | 显式从 `interactionContext` ALS 取 parent                 |
+| tracer 层          | `tracer.ts`          | `withSpan` / `startSpanWithContext`                                                         | 从 `context.active()` 取 parent，fallback 到 session root |
+
+**runtime 实际调用情况：**
+
+- `startInteractionSpan` → **已接入** (`client.ts` line 956)，写入 `interactionContext` ALS
+- `startLLMRequestSpan` / `endLLMRequestSpan` → **未接入**，runtime 用的是 `withSpan('api.generateContent', ...)` (在 `loggingContentGenerator.ts`)
+- `startToolSpan` / `endToolSpan` → **未接入**，runtime 用的是 `withSpan('tool.${name}', ...)` (在 `coreToolScheduler.ts`)
+- `startToolExecutionSpan` / `endToolExecutionSpan` → **未接入**
+
+**后果：**
+
+`withSpan` 的 `getParentContext()` 先检查 `context.active()`（OTel 原生 context），找不到活跃 span 时回退到 session root context。它**完全不读取 `interactionContext` ALS**。
+
+因此 interaction span 和 LLM/tool spans 变成了 session root 下的**平级 sibling**，而不是 parent-child 树：
+
+```
+session-root
+  ├── interaction         (来自 session-tracing, 写入了 interactionContext ALS)
+  ├── api.generateContent (来自 withSpan, 不读 interactionContext → 挂到 session root)
+  ├── tool.Bash           (来自 withSpan, 同上)
+  └── tool.Read           (来自 withSpan, 同上)
+```
+
+**而 claude-code 中，只有一套 span 创建路径（sessionTracing.ts），所有 span 都走同一套 ALS → OTel context 转换逻辑，所以树是完整的。**
+
+#### 逐项复用评估
+
+##### 1. 双 ALS + 显式 parent 解析 — 可复用，是核心修复
+
+| 维度         | claude-code                                           | qwen-code                                    |
+| ------------ | ----------------------------------------------------- | -------------------------------------------- |
+| ALS 数量     | 2 (`interactionContext` + `toolContext`)              | 1 (`interactionContext`，无 `toolContext`)   |
+| parent 解析  | 每种 span 类型显式指定从哪个 ALS 取 parent            | `withSpan` 统一走 `context.active()`         |
+| context 注入 | `trace.setSpan(otelContext.active(), parentCtx.span)` | `withSpan` 内部由 `startActiveSpan` 隐式注入 |
+
+**复用方案：**
+
+qwen-code 的 `session-tracing.ts` 已经实现了与 claude-code **几乎相同的 parent 解析模式**：
+
+```typescript
+// qwen-code session-tracing.ts (已有但未用)
+export function startLLMRequestSpan(model, promptId): Span {
+  const parentCtx = interactionContext.getStore();
+  const ctx = parentCtx
+    ? trace.setSpan(otelContext.active(), parentCtx.span)
+    : otelContext.active();
+  // ...
+}
+```
+
+这段代码与 claude-code 的 `startLLMRequestSpan` 逻辑**完全一致**。
+
+**核心修复路径：废弃 runtime 中的 `withSpan('api.*')` / `withSpan('tool.*')` 调用，改为调用 session-tracing 的 typed helpers。** 不需要重写 session-tracing 层——它的 API 已经就绪。
+
+需要新增的只有：
+
+- 增加 `toolContext` ALS（仿 claude-code）
+- 增加 `blocked_on_user` 和 `hook` span 类型及 helper 函数
+
+##### 2. tool.blocked_on_user — 需要适配审批流差异
+
+| 维度          | claude-code                                | qwen-code                                                                  |
+| ------------- | ------------------------------------------ | -------------------------------------------------------------------------- |
+| 审批位置      | 在 `toolExecution.ts` 内，tool span 内部   | 在 `coreToolScheduler._schedule()` 内，tool span 之前                      |
+| 审批模式      | 同步等待 `resolveHookPermissionDecision()` | 状态机驱动：`validating` → `awaiting_approval` → `scheduled` → `executing` |
+| span 覆盖范围 | tool span 包含 blocked + execution         | tool span(`withSpan`) 只包含 execution（从 `executeSingleToolCall` 开始）  |
+
+**关键差异：** qwen-code 的 `executeSingleToolCall` 入口检查 `toolCall.status !== 'scheduled'` 才继续——也就是说调用到这里时审批已经完成。Tool span 的 `withSpan` 包不住审批等待。
+
+**适配方案（两种）：**
+
+**方案 A — 前移 tool span 起点（推荐）：**
+
+将 `startToolSpan` 调用从 `executeSingleToolCall` 移到 `_schedule` 中审批检查之前，使 tool span 覆盖完整生命周期。在进入 `awaiting_approval` 状态时 `startToolBlockedOnUserSpan`，在审批完成（`scheduled`）时 `endToolBlockedOnUserSpan`。
+
+```
+_schedule():
+  startToolSpan(name)                         // ← 新增
+    startToolBlockedOnUserSpan()              // ← 新增，进入 awaiting_approval 时
+      [状态机等待]
+    endToolBlockedOnUserSpan(decision)        // ← 新增，进入 scheduled 时
+executeSingleToolCall():
+    startToolExecutionSpan()                  // ← 接入已有 helper
+      [hook + execute]
+    endToolExecutionSpan()
+  endToolSpan()                               // ← 需要在 finally 中
+```
+
+**方案 B — 保持 tool span 位置不变，单独追踪审批：**
+
+在 `_schedule` 中独立创建 `approval_wait` span（不作为 tool 的 child），挂到 interaction 下。好处是改动更小，坏处是与 claude-code 模型不一致、trace 树可读性差。
+
+**建议采用方案 A**，因为：
+
+- 与 claude-code 的 trace 树结构一致
+- trace 上一个 tool 节点就能看到"等了多久 + 执行了多久"
+- 状态机驱动的特性只影响 span start/end 的触发时机，不影响 parent-child 建模
+
+##### 3. hook span — 可直接复用
+
+| 维度          | claude-code                         | qwen-code                                                            |
+| ------------- | ----------------------------------- | -------------------------------------------------------------------- |
+| hook 执行入口 | `executeHooks()` in `hooks.ts`      | `firePreToolUseHook`/`firePostToolUseHook` via `hookEventHandler.ts` |
+| 现有记录方式  | OTel span + Perfetto span           | `HookCallEvent` → `QwenLogger` (无 OTel)                             |
+| parent        | `toolContext ?? interactionContext` | —                                                                    |
+
+**复用方案：**
+
+1. 在 `session-tracing.ts` 新增 `startHookSpan` / `endHookSpan`（parent = `toolContext ?? interactionContext`，与 claude-code 一致）
+2. 在 `coreToolScheduler.ts` 的 `executeSingleToolCall` 中，pre/post hook 调用前后分别 start/end hook span
+3. 保留现有 `logHookCall` 事件记录（两套并行，不互斥）
+
+改动量低，不影响现有 hook 逻辑。
+
+##### 4. tool.execution — 已有 helper，只需接线
+
+qwen-code 的 `startToolExecutionSpan(parentToolSpan)` / `endToolExecutionSpan(span, metadata)` 已经完整实现，只需在 `executeSingleToolCall` 中调用：
+
+```typescript
+// coreToolScheduler.ts executeSingleToolCall 内部
+const toolSpan = startToolSpan(toolName, attrs);
+// ... hook pre ...
+const execSpan = startToolExecutionSpan(toolSpan);
+try {
+  // ... invocation.execute() ...
+  endToolExecutionSpan(execSpan, { success: true });
+} catch (e) {
+  endToolExecutionSpan(execSpan, { success: false, error: e.message });
+}
+// ... hook post ...
+endToolSpan(toolSpan);
+```
+
+注意：qwen-code 的 `startToolExecutionSpan` 接收显式 `parentToolSpan` 参数，而 claude-code 的是从 `toolContext` ALS 隐式获取。这不影响功能，只是风格差异。如果引入 `toolContext` ALS，可以统一改为隐式获取。
+
+##### 5. subagent trace tree — 双方都不完整，不建议直接复用
+
+| 维度            | claude-code                                                             | qwen-code                                            |
+| --------------- | ----------------------------------------------------------------------- | ---------------------------------------------------- |
+| OTel trace 传播 | **无** — subagent 的 interaction 是新 root                              | **无** — subagent 无显式 trace 传播                  |
+| 身份关联        | Perfetto metadata（agent process/thread）+ `teammateContextStorage` ALS | `subagentNameContext` ALS + `SubagentExecutionEvent` |
+| 并发隔离        | OTel ALS 有泄漏风险（`enterWith` 是进程级，并发 subagent 会互覆盖）     | 同样的风险                                           |
+
+claude-code 在 subagent OTel tracing 上**自己也没解决好**：
+
+- `interactionContext.enterWith()` 是进程级的，并发 subagent 会覆盖彼此的 ALS 值
+- 真正的 agent 层级树只存在于 Perfetto（一个 Anthropic 内部 feature-flagged 的系统），不在 OTel 中
+
+**建议：**
+
+- 短期：沿用 qwen-code 现有的 `subagentNameContext` + 事件日志方案
+- 中期：在 subagent 启动时创建一个 `subagent` span（parent = 当前 toolContext），并用 `context.with()` 而非 `enterWith()` 来隔离并发 subagent 的 OTel context
+- 这是需要独立设计的工作项，不建议直接照搬 claude-code
+
+##### 6. LLM request span — 路径明确
+
+qwen-code 当前在 `loggingContentGenerator.ts` 中用 `withSpan('api.generateContent', ...)` 和 `startSpanWithContext('api.generateContentStream', ...)`。
+
+改为调用 `startLLMRequestSpan` / `endLLMRequestSpan`（session-tracing 层已有实现）即可。streaming 场景需要注意：
+
+- `startLLMRequestSpan` 返回 `Span` 对象
+- 需要手动传入 `endLLMRequestSpan(span, metadata)` 终结
+- 这与 `startSpanWithContext` 的手动管理模式兼容
+
+### 复用总结
+
+| 改造项                                                                    | 可复用程度                            | 改动量                                        | 优先级 |
+| ------------------------------------------------------------------------- | ------------------------------------- | --------------------------------------------- | ------ |
+| 统一 span 创建路径（废弃 runtime `withSpan`，用 session-tracing helpers） | **核心修复** — 解决 parent-child 断裂 | 中（~5 个调用点）                             | P0     |
+| 新增 `toolContext` ALS                                                    | 直接照搬 claude-code 模式             | 低（session-tracing.ts 内部）                 | P0     |
+| tool.blocked_on_user span                                                 | 方案 A 需适配状态机                   | 中（\_schedule + executeSingleToolCall 协调） | P1     |
+| tool.execution 接线                                                       | helper 已有，只需调用                 | 低（executeSingleToolCall 内 3 行）           | P1     |
+| hook span                                                                 | 新增 helper + 调用点                  | 低                                            | P1     |
+| LLM request span 切换                                                     | 替换 withSpan 为 typed helper         | 低（2 个调用点）                              | P1     |
+| subagent trace tree                                                       | **不建议直接复用** — 需独立设计       | 高                                            | P2     |
+
+### 推荐实施顺序
+
+```
+Phase 1 — 修复 trace 树结构 (P0)
+├── 1a. session-tracing.ts 新增 toolContext ALS + blocked_on_user / hook span helpers
+├── 1b. loggingContentGenerator.ts: withSpan → startLLMRequestSpan/endLLMRequestSpan
+└── 1c. coreToolScheduler.ts: withSpan → startToolSpan/endToolSpan
+
+Phase 2 — 补齐 workflow span (P1)
+├── 2a. coreToolScheduler._schedule: blocked_on_user span 接入
+├── 2b. coreToolScheduler.executeSingleToolCall: tool.execution span 接入
+└── 2c. hook pre/post 调用处: hook span 接入
+
+Phase 3 — Subagent trace tree (P2)
+├── 3a. 设计 context.with() 隔离方案（替代 enterWith）
+├── 3b. subagent 启动时创建 subagent root span
+└── 3c. 并发 subagent 场景验证
+```

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -15,7 +15,6 @@ import {
 } from 'vitest';
 
 import type { Content, GenerateContentResponse, Part } from '@google/genai';
-import { SpanStatusCode } from '@opentelemetry/api';
 import { GeminiClient, SendMessageType } from './client.js';
 import { findCompressSplitPoint } from '../services/chatCompressionService.js';
 import {
@@ -167,29 +166,9 @@ const mockUiTelemetryService = vi.hoisted(() => ({
   reset: vi.fn(),
   addEvent: vi.fn(),
 }));
-const clientSpanCalls = vi.hoisted(
-  (): Array<{
-    name: string;
-    attributes: Record<string, string | number | boolean>;
-    statuses: Array<{ code: number; message?: string }>;
-  }> => [],
-);
-const mockWithSpan = vi.hoisted(() => vi.fn());
-
 vi.mock('../telemetry/tracer.js', () => ({
   API_CALL_ABORTED_SPAN_STATUS_MESSAGE: 'API call aborted',
   API_CALL_FAILED_SPAN_STATUS_MESSAGE: 'API call failed',
-  safeSetStatus: (
-    span: { setStatus: (status: { code: number; message?: string }) => void },
-    status: { code: number; message?: string },
-  ) => {
-    try {
-      span.setStatus(status);
-    } catch {
-      // Match production best-effort telemetry behavior.
-    }
-  },
-  withSpan: mockWithSpan,
 }));
 
 vi.mock('../telemetry/index.js', async (importOriginal) => {
@@ -356,32 +335,6 @@ describe('Gemini Client (client.ts)', () => {
   };
   beforeEach(async () => {
     vi.resetAllMocks();
-    clientSpanCalls.length = 0;
-    mockWithSpan.mockImplementation(
-      async (
-        name: string,
-        attributes: Record<string, string | number | boolean>,
-        fn: (span: {
-          setStatus: ReturnType<typeof vi.fn>;
-          setAttribute: ReturnType<typeof vi.fn>;
-          end: ReturnType<typeof vi.fn>;
-        }) => Promise<unknown>,
-      ) => {
-        const spanCall = {
-          name,
-          attributes,
-          statuses: [] as Array<{ code: number; message?: string }>,
-        };
-        clientSpanCalls.push(spanCall);
-        return fn({
-          setStatus: vi.fn((status: { code: number; message?: string }) => {
-            spanCall.statuses.push(status);
-          }),
-          setAttribute: vi.fn(),
-          end: vi.fn(),
-        });
-      },
-    );
     vi.mocked(uiTelemetryService.setLastPromptTokenCount).mockClear();
 
     // Default: createContentGenerator rejects (simulates test env without auth).
@@ -4494,15 +4447,6 @@ Other open files:
         }),
         'btw-prompt-id',
       );
-      expect(clientSpanCalls.at(-1)).toEqual(
-        expect.objectContaining({
-          name: 'client.generateContent',
-          attributes: {
-            model: DEFAULT_QWEN_FLASH_MODEL,
-            prompt_id: 'btw-prompt-id',
-          },
-        }),
-      );
     });
 
     it('should prefer an explicit prompt id override over the current context', async () => {
@@ -4529,15 +4473,6 @@ Other open files:
           contents,
         }),
         'override-prompt-id',
-      );
-      expect(clientSpanCalls.at(-1)).toEqual(
-        expect.objectContaining({
-          name: 'client.generateContent',
-          attributes: {
-            model: DEFAULT_QWEN_FLASH_MODEL,
-            prompt_id: 'override-prompt-id',
-          },
-        }),
       );
     });
 
@@ -4642,7 +4577,7 @@ Other open files:
       );
     });
 
-    it('sets a generic span status when content generation fails', async () => {
+    it('propagates error when content generation fails', async () => {
       const contents = [{ role: 'user', parts: [{ text: 'hello' }] }];
       const abortSignal = new AbortController().signal;
       mockGenerateContentFn.mockRejectedValueOnce(
@@ -4657,15 +4592,9 @@ Other open files:
           DEFAULT_QWEN_FLASH_MODEL,
         ),
       ).rejects.toThrow('raw upstream 500 with sensitive details');
-
-      const spanCall = clientSpanCalls.at(-1);
-      expect(spanCall?.statuses).toEqual([
-        { code: SpanStatusCode.ERROR, message: 'API call failed' },
-      ]);
-      expect(JSON.stringify(spanCall?.statuses)).not.toContain('raw upstream');
     });
 
-    it('sets a generic aborted span status when content generation is aborted', async () => {
+    it('propagates error when content generation is aborted', async () => {
       const contents = [{ role: 'user', parts: [{ text: 'hello' }] }];
       const abortController = new AbortController();
       abortController.abort();
@@ -4681,12 +4610,6 @@ Other open files:
           DEFAULT_QWEN_FLASH_MODEL,
         ),
       ).rejects.toThrow('raw abort reason with sensitive details');
-
-      const spanCall = clientSpanCalls.at(-1);
-      expect(spanCall?.statuses).toEqual([
-        { code: SpanStatusCode.ERROR, message: 'API call aborted' },
-      ]);
-      expect(JSON.stringify(spanCall?.statuses)).not.toContain('raw abort');
     });
 
     // Note: there is currently no "fallback mode" model routing; the model used

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -12,7 +12,6 @@ import type {
   PartListUnion,
   Tool,
 } from '@google/genai';
-import { SpanStatusCode } from '@opentelemetry/api';
 
 // Config
 import { ApprovalMode, type Config } from '../config/config.js';
@@ -105,12 +104,6 @@ import { createHookOutput, SessionStartSource } from '../hooks/types.js';
 import { ideContextStore } from '../ide/ideContext.js';
 import { type File, type IdeContext } from '../ide/types.js';
 import { PermissionMode, type StopHookOutput } from '../hooks/types.js';
-import {
-  API_CALL_ABORTED_SPAN_STATUS_MESSAGE,
-  API_CALL_FAILED_SPAN_STATUS_MESSAGE,
-  safeSetStatus,
-  withSpan,
-} from '../telemetry/tracer.js';
 
 const MAX_TURNS = 100;
 
@@ -1684,91 +1677,73 @@ export class GeminiClient {
     const promptId =
       promptIdOverride ?? promptIdContext.getStore() ?? this.lastPromptId!;
 
-    return withSpan(
-      'client.generateContent',
-      { model, prompt_id: promptId },
-      async (span) => {
-        let currentAttemptModel: string = model;
+    let currentAttemptModel: string = model;
 
-        try {
-          const userMemory = this.config.getUserMemory();
-          const finalSystemInstruction = generationConfig.systemInstruction
-            ? getCustomSystemPrompt(
-                generationConfig.systemInstruction,
-                userMemory,
-              )
-            : this.getMainSessionSystemInstruction();
+    try {
+      const userMemory = this.config.getUserMemory();
+      const finalSystemInstruction = generationConfig.systemInstruction
+        ? getCustomSystemPrompt(generationConfig.systemInstruction, userMemory)
+        : this.getMainSessionSystemInstruction();
 
-          const requestConfig: GenerateContentConfig = {
-            abortSignal,
-            ...generationConfig,
-            systemInstruction: finalSystemInstruction,
-          };
+      const requestConfig: GenerateContentConfig = {
+        abortSignal,
+        ...generationConfig,
+        systemInstruction: finalSystemInstruction,
+      };
 
-          // When the requested model differs from the main model (e.g. fast model
-          // side queries for session recap / title / summary), resolve the target
-          // model's own ContentGeneratorConfig so that per-model settings like
-          // extra_body, samplingParams, and reasoning are not inherited from the
-          // main model's config. The retry authType is resolved alongside so that
-          // provider-specific checks (e.g. QWEN_OAUTH quota detection) reference
-          // the target model's provider.
-          const {
-            contentGenerator,
-            retryAuthType,
+      // When the requested model differs from the main model (e.g. fast model
+      // side queries for session recap / title / summary), resolve the target
+      // model's own ContentGeneratorConfig so that per-model settings like
+      // extra_body, samplingParams, and reasoning are not inherited from the
+      // main model's config. The retry authType is resolved alongside so that
+      // provider-specific checks (e.g. QWEN_OAUTH quota detection) reference
+      // the target model's provider.
+      const {
+        contentGenerator,
+        retryAuthType,
+        model: requestModel,
+      } = await this.config.getBaseLlmClient().resolveForModel(model);
+
+      const apiCall = () => {
+        currentAttemptModel = requestModel;
+
+        return contentGenerator.generateContent(
+          {
             model: requestModel,
-          } = await this.config.getBaseLlmClient().resolveForModel(model);
-
-          const apiCall = () => {
-            currentAttemptModel = requestModel;
-
-            return contentGenerator.generateContent(
-              {
-                model: requestModel,
-                config: requestConfig,
-                contents,
-              },
-              promptId,
-            );
-          };
-          const result = await retryWithBackoff(apiCall, {
-            authType: retryAuthType,
-            persistentMode: isUnattendedMode(),
-            signal: abortSignal,
-            heartbeatFn: (info) => {
-              process.stderr.write(
-                `[qwen-code] Waiting for API capacity... attempt ${info.attempt}, retry in ${Math.ceil(info.remainingMs / 1000)}s\n`,
-              );
-            },
-          });
-          return result;
-        } catch (error: unknown) {
-          if (abortSignal.aborted) {
-            safeSetStatus(span, {
-              code: SpanStatusCode.ERROR,
-              message: API_CALL_ABORTED_SPAN_STATUS_MESSAGE,
-            });
-            throw error;
-          }
-
-          safeSetStatus(span, {
-            code: SpanStatusCode.ERROR,
-            message: API_CALL_FAILED_SPAN_STATUS_MESSAGE,
-          });
-          await reportError(
-            error,
-            `Error generating content via API with model ${currentAttemptModel}.`,
-            {
-              requestContents: contents,
-              requestConfig: generationConfig,
-            },
-            'generateContent-api',
+            config: requestConfig,
+            contents,
+          },
+          promptId,
+        );
+      };
+      const result = await retryWithBackoff(apiCall, {
+        authType: retryAuthType,
+        persistentMode: isUnattendedMode(),
+        signal: abortSignal,
+        heartbeatFn: (info) => {
+          process.stderr.write(
+            `[qwen-code] Waiting for API capacity... attempt ${info.attempt}, retry in ${Math.ceil(info.remainingMs / 1000)}s\n`,
           );
-          throw new Error(
-            `Failed to generate content with model ${currentAttemptModel}: ${getErrorMessage(error)}`,
-          );
-        }
-      },
-    );
+        },
+      });
+      return result;
+    } catch (error: unknown) {
+      if (abortSignal.aborted) {
+        throw error;
+      }
+      await reportError(
+        error,
+        `Error generating content via API with model ${currentAttemptModel}.`,
+        {
+          requestContents: contents,
+          requestConfig: generationConfig,
+        },
+        'generateContent-api',
+      );
+      throw new Error(
+        `Failed to generate content with model ${currentAttemptModel}: ${getErrorMessage(error)}`,
+      );
+    }
   }
 
   /**

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -128,45 +128,47 @@ vi.mock('../telemetry/index.js', async (importOriginal) => {
   return {
     ...actual,
     startToolSpan: vi.fn(
-    (name: string, attrs?: Record<string, string | number | boolean>) =>
-      createMockToolSpan(`tool.${name}`, { tool_name: name, ...attrs }),
-  ),
-  endToolSpan: vi.fn(
-    (
-      span: ReturnType<typeof createMockToolSpan>,
-      metadata?: { success?: boolean; error?: string },
-    ) => {
-      try {
-        if (metadata) {
-          if (metadata.success !== false) {
-            span.setStatus({ code: 1 });
-          } else {
-            span.setStatus({
-              code: 2,
-              message: metadata.error ?? 'tool error',
-            });
+      (name: string, attrs?: Record<string, string | number | boolean>) =>
+        createMockToolSpan(`tool.${name}`, { tool_name: name, ...attrs }),
+    ),
+    endToolSpan: vi.fn(
+      (
+        span: ReturnType<typeof createMockToolSpan>,
+        metadata?: { success?: boolean; error?: string },
+      ) => {
+        try {
+          if (metadata) {
+            if (metadata.success !== false) {
+              span.setStatus({ code: 1 });
+            } else {
+              span.setStatus({
+                code: 2,
+                message: metadata.error ?? 'tool error',
+              });
+            }
           }
+          span.end();
+        } catch {
+          // best-effort
         }
-        span.end();
-      } catch {
-        // best-effort
-      }
-    },
-  ),
-  runInToolSpanContext: vi.fn(<T>(_span: unknown, fn: () => T): T => fn()),
-  startToolExecutionSpan: vi.fn(() => createMockToolSpan('tool.execution', {})),
-  endToolExecutionSpan: vi.fn(
-    (
-      span: ReturnType<typeof createMockToolSpan>,
-      _metadata?: { success?: boolean; error?: string },
-    ) => {
-      try {
-        span.end();
-      } catch {
-        // best-effort
-      }
-    },
-  ),
+      },
+    ),
+    runInToolSpanContext: vi.fn(<T>(_span: unknown, fn: () => T): T => fn()),
+    startToolExecutionSpan: vi.fn(() =>
+      createMockToolSpan('tool.execution', {}),
+    ),
+    endToolExecutionSpan: vi.fn(
+      (
+        span: ReturnType<typeof createMockToolSpan>,
+        _metadata?: { success?: boolean; error?: string },
+      ) => {
+        try {
+          span.end();
+        } catch {
+          // best-effort
+        }
+      },
+    ),
   };
 });
 
@@ -2970,7 +2972,9 @@ describe('CoreToolScheduler telemetry spans', () => {
   });
 
   function getLastToolSpan(): ToolSpanRecord {
-    const spanRecord = toolSpanRecords.at(-1);
+    const spanRecord = toolSpanRecords.findLast(
+      (r) => r.name.startsWith('tool.') && r.name !== 'tool.execution',
+    );
     if (!spanRecord) {
       throw new Error('tool span was not created');
     }

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -3389,6 +3389,52 @@ describe('CoreToolScheduler telemetry spans', () => {
     expect(spanRecord.ended).toBe(true);
   });
 
+  // tool span `success` boolean attribute — must always be present so
+  // observability backends can filter failures with the same query they
+  // use for llm_request spans (which carry `success` unconditionally).
+
+  it('tool span: success=true attribute on success', async () => {
+    const { spanRecord, completedCalls } = await runSingleTool();
+    expect(completedCalls[0].status).toBe('success');
+    expect(spanRecord.spanAttributes).toHaveProperty('success', true);
+  });
+
+  it('tool span: success=false attribute on ToolResult.error', async () => {
+    const { spanRecord, completedCalls } = await runSingleTool({
+      execute: vi.fn().mockResolvedValue({
+        llmContent: 'failed',
+        returnDisplay: 'failed',
+        error: {
+          message: 'tool failed',
+          type: ToolErrorType.EXECUTION_FAILED,
+        },
+      }),
+    });
+    expect(completedCalls[0].status).toBe('error');
+    expect(spanRecord.spanAttributes).toHaveProperty('success', false);
+  });
+
+  it('tool span: success=false attribute on thrown invocation exception', async () => {
+    const { spanRecord, completedCalls } = await runSingleTool({
+      execute: vi.fn().mockRejectedValue(new Error('boom')),
+    });
+    expect(completedCalls[0].status).toBe('error');
+    expect(spanRecord.spanAttributes).toHaveProperty('success', false);
+  });
+
+  it('tool span: success=false attribute on cancellation', async () => {
+    const abortController = new AbortController();
+    const { spanRecord, completedCalls } = await runSingleTool({
+      abortController,
+      execute: vi.fn().mockImplementation(async () => {
+        abortController.abort();
+        return { llmContent: 'cancelled', returnDisplay: 'cancelled' };
+      }),
+    });
+    expect(completedCalls[0].status).toBe('cancelled');
+    expect(spanRecord.spanAttributes).toHaveProperty('success', false);
+  });
+
   // tool.execution sub-span lifecycle assertions —
   // ensure the sub-span is started/ended on every meaningful path so that
   // future regressions (e.g. dropping the sub-span call or mis-marking a

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -3379,6 +3379,60 @@ describe('CoreToolScheduler telemetry spans', () => {
     expect(spanRecord.spanAttributes).not.toHaveProperty('tool.failure_kind');
     expect(spanRecord.ended).toBe(true);
   });
+
+  // tool.execution sub-span lifecycle assertions —
+  // ensure the sub-span is started/ended on every meaningful path so that
+  // future regressions (e.g. dropping the sub-span call or mis-marking a
+  // failed result as success) fail loudly.
+
+  function getExecutionSpan(): ToolSpanRecord | undefined {
+    return toolSpanRecords.find((r) => r.name === 'tool.execution');
+  }
+
+  it('execution sub-span: started and ended (success: true) on success', async () => {
+    await runSingleTool();
+    const exec = getExecutionSpan();
+    expect(exec).toBeDefined();
+    expect(exec!.ended).toBe(true);
+  });
+
+  it('execution sub-span: ended (success: false) when ToolResult.error is set', async () => {
+    await runSingleTool({
+      execute: vi.fn().mockResolvedValue({
+        llmContent: 'failed',
+        returnDisplay: 'failed',
+        error: {
+          message: 'tool failed',
+          type: ToolErrorType.EXECUTION_FAILED,
+        },
+      }),
+    });
+    const exec = getExecutionSpan();
+    expect(exec).toBeDefined();
+    expect(exec!.ended).toBe(true);
+  });
+
+  it('execution sub-span: ended on thrown invocation exception', async () => {
+    await runSingleTool({
+      execute: vi.fn().mockRejectedValue(new Error('boom')),
+    });
+    const exec = getExecutionSpan();
+    expect(exec).toBeDefined();
+    expect(exec!.ended).toBe(true);
+  });
+
+  it('execution sub-span: NOT created when pre-hook denies execution', async () => {
+    const messageBus = {
+      request: vi.fn().mockResolvedValueOnce({
+        type: MessageBusType.HOOK_EXECUTION_RESPONSE,
+        correlationId: 'pre-hook',
+        success: true,
+        output: { decision: 'block', reason: 'denied' },
+      }),
+    };
+    await runSingleTool({ messageBus, disableHooks: false });
+    expect(getExecutionSpan()).toBeUndefined();
+  });
 });
 
 // Integration tests for the fire* functions

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -133,24 +133,17 @@ vi.mock('../telemetry/index.js', async (importOriginal) => {
     ),
     endToolSpan: vi.fn(
       (
-        span: ReturnType<typeof createMockToolSpan>,
+        span: ToolSpanRecord & ReturnType<typeof createMockToolSpan>,
         metadata?: { success?: boolean; error?: string },
       ) => {
-        try {
-          if (metadata) {
-            if (metadata.success !== false) {
-              span.setStatus({ code: 1 });
-            } else {
-              span.setStatus({
-                code: 2,
-                message: metadata.error ?? 'tool error',
-              });
-            }
-          }
-          span.end();
-        } catch {
-          // best-effort
+        if (metadata) {
+          const status =
+            metadata.success !== false
+              ? { code: 1 }
+              : { code: 2, message: metadata.error ?? 'tool error' };
+          span.statusCalls.push(status);
         }
+        span.ended = true;
       },
     ),
     runInToolSpanContext: vi.fn(<T>(_span: unknown, fn: () => T): T => fn()),

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -3451,6 +3451,23 @@ describe('CoreToolScheduler telemetry spans', () => {
     await runSingleTool({ messageBus, disableHooks: false });
     expect(getExecutionSpan()).toBeUndefined();
   });
+
+  it('execution sub-span: uses cancelled-by-user error when invocation throws after abort', async () => {
+    const abortController = new AbortController();
+    await runSingleTool({
+      abortController,
+      execute: vi.fn().mockImplementation(async () => {
+        abortController.abort();
+        throw new Error('aborted');
+      }),
+    });
+    const exec = getExecutionSpan();
+    expect(exec).toBeDefined();
+    expect(exec!.endMetadata?.success).toBe(false);
+    // Operators filtering exec spans for errors should NOT see cancellation
+    // messages here — only real exception messages.
+    expect(exec!.endMetadata?.error).toBe('Tool execution cancelled by user');
+  });
 });
 
 // Integration tests for the fire* functions

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -79,62 +79,88 @@ vi.mock('../telemetry/tracer.js', () => ({
       // Match production best-effort telemetry behavior.
     }
   },
-  withSpan: vi.fn(
-    async (
-      name: string,
-      attributes: Record<string, string | number | boolean>,
-      fn: (span: {
-        setStatus: (status: { code: number; message?: string }) => void;
-        setAttribute: (key: string, value: string | number | boolean) => void;
-        end: () => void;
-      }) => Promise<unknown>,
-      options?: { autoOkOnSuccess?: boolean },
-    ) => {
-      const autoOkOnSuccess = options?.autoOkOnSuccess ?? true;
-      const record: ToolSpanRecord = {
-        name,
-        attributes,
-        statusCalls: [],
-        spanAttributes: {},
-        ended: false,
-      };
-      toolSpanRecords.push(record);
-      let statusSet = false;
-      const span = {
-        setStatus(status: { code: number; message?: string }) {
-          statusSet = true;
-          if (shouldThrowToolSpanSetStatus.value) {
-            throw new Error('setStatus failed');
-          }
-          record.statusCalls.push(status);
-        },
-        setAttribute(key: string, value: string | number | boolean) {
-          if (shouldThrowToolSpanSetAttribute.value) {
-            throw new Error('setAttribute failed');
-          }
-          record.spanAttributes[key] = value;
-        },
-        end() {
-          record.ended = true;
-        },
-      };
+}));
 
+function createMockToolSpan(
+  name: string,
+  attributes: Record<string, string | number | boolean>,
+): ToolSpanRecord & {
+  setStatus: (status: { code: number; message?: string }) => void;
+  setAttribute: (key: string, value: string | number | boolean) => void;
+  setAttributes: (attrs: Record<string, string | number | boolean>) => void;
+  end: () => void;
+  spanContext: () => { spanId: string; traceId: string; traceFlags: number };
+} {
+  const record: ToolSpanRecord = {
+    name,
+    attributes,
+    statusCalls: [],
+    spanAttributes: {},
+    ended: false,
+  };
+  toolSpanRecords.push(record);
+  const spanId = Math.random().toString(16).slice(2, 18).padEnd(16, '0');
+  return Object.assign(record, {
+    setStatus(status: { code: number; message?: string }) {
+      if (shouldThrowToolSpanSetStatus.value) {
+        throw new Error('setStatus failed');
+      }
+      record.statusCalls.push(status);
+    },
+    setAttribute(key: string, value: string | number | boolean) {
+      if (shouldThrowToolSpanSetAttribute.value) {
+        throw new Error('setAttribute failed');
+      }
+      record.spanAttributes[key] = value;
+    },
+    setAttributes(attrs: Record<string, string | number | boolean>) {
+      Object.assign(record.spanAttributes, attrs);
+    },
+    end() {
+      record.ended = true;
+    },
+    spanContext: () => ({ spanId, traceId: '0'.repeat(32), traceFlags: 0 }),
+  });
+}
+
+vi.mock('../telemetry/index.js', () => ({
+  startToolSpan: vi.fn(
+    (name: string, attrs?: Record<string, string | number | boolean>) =>
+      createMockToolSpan(`tool.${name}`, { tool_name: name, ...attrs }),
+  ),
+  endToolSpan: vi.fn(
+    (
+      span: ReturnType<typeof createMockToolSpan>,
+      metadata?: { success?: boolean; error?: string },
+    ) => {
       try {
-        const result = await fn(span);
-        if (autoOkOnSuccess && !statusSet) {
-          record.statusCalls.push({ code: 1 });
+        if (metadata) {
+          if (metadata.success !== false) {
+            span.setStatus({ code: 1 });
+          } else {
+            span.setStatus({
+              code: 2,
+              message: metadata.error ?? 'tool error',
+            });
+          }
         }
-        return result;
-      } catch (error) {
-        if (!statusSet) {
-          record.statusCalls.push({
-            code: 2,
-            message: error instanceof Error ? error.message : String(error),
-          });
-        }
-        throw error;
-      } finally {
-        record.ended = true;
+        span.end();
+      } catch {
+        // best-effort
+      }
+    },
+  ),
+  runInToolSpanContext: vi.fn(<T>(_span: unknown, fn: () => T): T => fn()),
+  startToolExecutionSpan: vi.fn(() => createMockToolSpan('tool.execution', {})),
+  endToolExecutionSpan: vi.fn(
+    (
+      span: ReturnType<typeof createMockToolSpan>,
+      _metadata?: { success?: boolean; error?: string },
+    ) => {
+      try {
+        span.end();
+      } catch {
+        // best-effort
       }
     },
   ),
@@ -3275,7 +3301,7 @@ describe('CoreToolScheduler telemetry spans', () => {
     );
   });
 
-  it('leaves cancellation spans with no explicit status (autoOkOnSuccess: false)', async () => {
+  it('marks cancellation spans with UNSET status', async () => {
     const abortController = new AbortController();
     const { spanRecord, completedCalls } = await runSingleTool({
       abortController,
@@ -3289,9 +3315,7 @@ describe('CoreToolScheduler telemetry spans', () => {
     });
 
     expect(completedCalls[0].status).toBe('cancelled');
-    // autoOkOnSuccess: false prevents withSpan from auto-setting OK;
-    // setToolSpanCancelled only sets the failure_kind attribute, not a status.
-    expect(spanRecord.statusCalls).toEqual([]);
+    expect(spanRecord.statusCalls).toEqual([{ code: SpanStatusCode.UNSET }]);
     expect(spanRecord.spanAttributes['tool.failure_kind']).toBe('cancelled');
     expect(spanRecord.ended).toBe(true);
   });
@@ -3311,9 +3335,9 @@ describe('CoreToolScheduler telemetry spans', () => {
     });
 
     expect(completedCalls[0].status).toBe('cancelled');
-    // No status set — autoOkOnSuccess: false, and setToolSpanCancelled
-    // only sets the attribute (which fails here, caught internally).
-    expect(spanRecord.statusCalls).toEqual([]);
+    // setAttribute throws, but safeSetStatus still attempts setStatus.
+    // Since throwSpanSetAttribute only affects setAttribute, setStatus succeeds.
+    expect(spanRecord.statusCalls).toEqual([{ code: SpanStatusCode.UNSET }]);
     expect(spanRecord.spanAttributes).not.toHaveProperty('tool.failure_kind');
     expect(spanRecord.ended).toBe(true);
   });
@@ -3333,9 +3357,8 @@ describe('CoreToolScheduler telemetry spans', () => {
     });
 
     expect(completedCalls[0].status).toBe('cancelled');
-    // setToolSpanCancelled no longer calls setStatus, so throwSpanSetStatus
-    // only affects the safeSetStatus(span, OK) in the success path (not hit).
-    // With autoOkOnSuccess: false, withSpan does not attempt setStatus either.
+    // setToolSpanCancelled calls safeSetStatus which catches the throw.
+    // Status call is attempted but swallowed by safeSetStatus.
     expect(spanRecord.statusCalls).toEqual([]);
     expect(spanRecord.spanAttributes['tool.failure_kind']).toBe('cancelled');
     expect(spanRecord.ended).toBe(true);
@@ -3352,7 +3375,7 @@ describe('CoreToolScheduler telemetry spans', () => {
     expect(spanRecord.ended).toBe(true);
   });
 
-  it('leaves successful tool calls to be marked OK by withSpan', async () => {
+  it('marks successful tool calls with OK status via endToolSpan', async () => {
     const { spanRecord, completedCalls } = await runSingleTool();
 
     expect(completedCalls[0].status).toBe('success');

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -123,47 +123,42 @@ function createMockToolSpan(
   });
 }
 
-vi.mock('../telemetry/index.js', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    startToolSpan: vi.fn(
-      (name: string, attrs?: Record<string, string | number | boolean>) =>
-        createMockToolSpan(`tool.${name}`, { tool_name: name, ...attrs }),
-    ),
-    endToolSpan: vi.fn(
-      (
-        span: ToolSpanRecord & ReturnType<typeof createMockToolSpan>,
-        metadata?: { success?: boolean; error?: string },
-      ) => {
-        if (metadata) {
-          const status =
-            metadata.success !== false
-              ? { code: 1 }
-              : { code: 2, message: metadata.error ?? 'tool error' };
-          span.statusCalls.push(status);
-        }
-        span.ended = true;
-      },
-    ),
-    runInToolSpanContext: vi.fn(<T>(_span: unknown, fn: () => T): T => fn()),
-    startToolExecutionSpan: vi.fn(() =>
-      createMockToolSpan('tool.execution', {}),
-    ),
-    endToolExecutionSpan: vi.fn(
-      (
-        span: ReturnType<typeof createMockToolSpan>,
-        _metadata?: { success?: boolean; error?: string },
-      ) => {
-        try {
-          span.end();
-        } catch {
-          // best-effort
-        }
-      },
-    ),
-  };
-});
+vi.mock('../telemetry/session-tracing.js', () => ({
+  startToolSpan: vi.fn(
+    (name: string, attrs?: Record<string, string | number | boolean>) =>
+      createMockToolSpan(`tool.${name}`, { tool_name: name, ...attrs }),
+  ),
+  endToolSpan: vi.fn(
+    (
+      span: ToolSpanRecord & ReturnType<typeof createMockToolSpan>,
+      metadata?: { success?: boolean; error?: string },
+    ) => {
+      if (metadata) {
+        const status =
+          metadata.success !== false
+            ? { code: 1 }
+            : { code: 2, message: metadata.error ?? 'tool error' };
+        span.statusCalls.push(status);
+      }
+      span.ended = true;
+    },
+  ),
+  runInToolSpanContext: vi.fn(<T>(_span: unknown, fn: () => T): T => fn()),
+  startToolExecutionSpan: vi.fn(() => createMockToolSpan('tool.execution', {})),
+  endToolExecutionSpan: vi.fn(
+    (
+      span: ReturnType<typeof createMockToolSpan>,
+      _metadata?: { success?: boolean; error?: string },
+    ) => {
+      span.ended = true;
+    },
+  ),
+  startInteractionSpan: vi.fn(),
+  endInteractionSpan: vi.fn(),
+  startLLMRequestSpan: vi.fn(),
+  endLLMRequestSpan: vi.fn(),
+  clearSessionTracingForTesting: vi.fn(),
+}));
 
 vi.mock('fs/promises', () => ({
   writeFile: vi.fn(),

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -123,8 +123,11 @@ function createMockToolSpan(
   });
 }
 
-vi.mock('../telemetry/index.js', () => ({
-  startToolSpan: vi.fn(
+vi.mock('../telemetry/index.js', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    startToolSpan: vi.fn(
     (name: string, attrs?: Record<string, string | number | boolean>) =>
       createMockToolSpan(`tool.${name}`, { tool_name: name, ...attrs }),
   ),
@@ -164,7 +167,8 @@ vi.mock('../telemetry/index.js', () => ({
       }
     },
   ),
-}));
+  };
+});
 
 vi.mock('fs/promises', () => ({
   writeFile: vi.fn(),

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -62,6 +62,11 @@ type ToolSpanRecord = {
   statusCalls: Array<{ code: number; message?: string }>;
   spanAttributes: Record<string, string | number | boolean>;
   ended: boolean;
+  /**
+   * Metadata passed to endToolSpan / endToolExecutionSpan — captured so
+   * tests can assert success/error values are forwarded correctly.
+   */
+  endMetadata?: { success?: boolean; error?: string };
 };
 
 const toolSpanRecords = vi.hoisted((): ToolSpanRecord[] => []);
@@ -134,6 +139,7 @@ vi.mock('../telemetry/session-tracing.js', () => ({
       metadata?: { success?: boolean; error?: string },
     ) => {
       if (metadata) {
+        span.endMetadata = metadata;
         const status =
           metadata.success !== false
             ? { code: 1 }
@@ -147,9 +153,12 @@ vi.mock('../telemetry/session-tracing.js', () => ({
   startToolExecutionSpan: vi.fn(() => createMockToolSpan('tool.execution', {})),
   endToolExecutionSpan: vi.fn(
     (
-      span: ReturnType<typeof createMockToolSpan>,
-      _metadata?: { success?: boolean; error?: string },
+      span: ToolSpanRecord & ReturnType<typeof createMockToolSpan>,
+      metadata?: { success?: boolean; error?: string },
     ) => {
+      if (metadata) {
+        span.endMetadata = metadata;
+      }
       span.ended = true;
     },
   ),
@@ -3394,6 +3403,7 @@ describe('CoreToolScheduler telemetry spans', () => {
     const exec = getExecutionSpan();
     expect(exec).toBeDefined();
     expect(exec!.ended).toBe(true);
+    expect(exec!.endMetadata).toEqual({ success: true });
   });
 
   it('execution sub-span: ended (success: false) when ToolResult.error is set', async () => {
@@ -3410,15 +3420,23 @@ describe('CoreToolScheduler telemetry spans', () => {
     const exec = getExecutionSpan();
     expect(exec).toBeDefined();
     expect(exec!.ended).toBe(true);
+    expect(exec!.endMetadata).toEqual({ success: false });
   });
 
-  it('execution sub-span: ended on thrown invocation exception', async () => {
+  it('execution sub-span: ended (success: false) with sanitized error on thrown invocation exception', async () => {
     await runSingleTool({
       execute: vi.fn().mockRejectedValue(new Error('boom')),
     });
     const exec = getExecutionSpan();
     expect(exec).toBeDefined();
     expect(exec!.ended).toBe(true);
+    expect(exec!.endMetadata?.success).toBe(false);
+    // The execution span error message is the sanitized constant
+    // (TOOL_SPAN_STATUS_TOOL_EXCEPTION = 'Tool execution failed with exception'),
+    // not the raw 'boom'.
+    expect(exec!.endMetadata?.error).toBe(
+      'Tool execution failed with exception',
+    );
   });
 
   it('execution sub-span: NOT created when pre-hook denies execution', async () => {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -75,8 +75,15 @@ import levenshtein from 'fast-levenshtein';
 import { getPlanModeSystemReminder } from './prompts.js';
 import { ShellToolInvocation } from '../tools/shell.js';
 import { IdeClient } from '../ide/ide-client.js';
-import { safeSetStatus, withSpan } from '../telemetry/tracer.js';
+import { safeSetStatus } from '../telemetry/tracer.js';
 import { SpanStatusCode, type Span } from '@opentelemetry/api';
+import {
+  startToolSpan,
+  endToolSpan,
+  runInToolSpanContext,
+  startToolExecutionSpan,
+  endToolExecutionSpan,
+} from '../telemetry/index.js';
 
 const TOOL_FAILURE_KIND_ATTRIBUTE = 'tool.failure_kind';
 const TOOL_FAILURE_KIND_PRE_HOOK_BLOCKED = 'pre_hook_blocked';
@@ -131,9 +138,9 @@ function setToolSpanCancelled(span: Span): void {
   } catch {
     // OTel errors must not block the cancellation status update.
   }
-  // No explicit span status — cancellation is neither OK nor ERROR.
-  // The caller uses withSpan({ autoOkOnSuccess: false }) so withSpan
-  // will not auto-set OK, and the span ends with the default UNSET status.
+  safeSetStatus(span, {
+    code: SpanStatusCode.UNSET,
+  });
 }
 
 async function safelyFirePostToolUseFailureHook(
@@ -1852,424 +1859,440 @@ export class CoreToolScheduler {
     const scheduledCall = toolCall;
     const { callId, name: toolName } = scheduledCall.request;
 
-    return withSpan(
-      `tool.${toolName}`,
-      { tool_name: toolName, call_id: callId },
-      async (span: Span) => {
-        const invocation = scheduledCall.invocation;
-        const toolInput = scheduledCall.request.args as Record<string, unknown>;
+    const toolSpan = startToolSpan(toolName, {
+      tool_name: toolName,
+      call_id: callId,
+    });
+    try {
+      await runInToolSpanContext(toolSpan, () =>
+        this._executeToolCallBody(scheduledCall, signal, toolSpan),
+      );
+    } finally {
+      const tc = this.toolCalls.find((c) => c.request.callId === callId);
+      if (tc?.status === 'success') {
+        endToolSpan(toolSpan, { success: true });
+      } else {
+        endToolSpan(toolSpan);
+      }
+    }
+  }
 
-        // Normalize shell-escaped path params so hooks operate on actual filesystem
-        // paths, matching the normalization done in tool validation.
-        for (const key of PATH_ARG_KEYS) {
-          if (typeof toolInput[key] === 'string') {
-            toolInput[key] = unescapePath(String(toolInput[key]).trim());
+  private async _executeToolCallBody(
+    scheduledCall: ScheduledToolCall,
+    signal: AbortSignal,
+    span: Span,
+  ): Promise<void> {
+    const { callId, name: toolName } = scheduledCall.request;
+    const invocation = scheduledCall.invocation;
+    const toolInput = scheduledCall.request.args as Record<string, unknown>;
+
+    // Normalize shell-escaped path params so hooks operate on actual filesystem
+    // paths, matching the normalization done in tool validation.
+    for (const key of PATH_ARG_KEYS) {
+      if (typeof toolInput[key] === 'string') {
+        toolInput[key] = unescapePath(String(toolInput[key]).trim());
+      }
+    }
+
+    // Generate unique tool_use_id for hook tracking
+    const toolUseId = generateToolUseId();
+
+    // Get MessageBus for hook execution
+    const messageBus = this.config.getMessageBus() as
+      | MessageBus
+      | undefined;
+    const hooksEnabled = !this.config.getDisableAllHooks();
+
+    // PreToolUse Hook
+    if (hooksEnabled && messageBus) {
+      // Convert ApprovalMode to permission_mode string for hooks
+      const permissionMode = this.config.getApprovalMode();
+      const preHookResult = await firePreToolUseHook(
+        messageBus,
+        toolName,
+        toolInput,
+        toolUseId,
+        permissionMode,
+      );
+
+      if (!preHookResult.shouldProceed) {
+        // Hook blocked the execution
+        const blockMessage =
+          preHookResult.blockReason || 'Tool execution blocked by hook';
+        const errorResponse = createErrorResponse(
+          scheduledCall.request,
+          new Error(blockMessage),
+          ToolErrorType.EXECUTION_DENIED,
+        );
+        this.setStatusInternal(callId, 'error', errorResponse);
+        setToolSpanFailure(
+          span,
+          TOOL_FAILURE_KIND_PRE_HOOK_BLOCKED,
+          TOOL_SPAN_STATUS_PRE_HOOK_BLOCKED,
+        );
+        return;
+      }
+    }
+
+    this.setStatusInternal(callId, 'executing');
+
+    const liveOutputCallback = scheduledCall.tool.canUpdateOutput
+      ? (outputChunk: ToolResultDisplay) => {
+          if (this.outputUpdateHandler) {
+            this.outputUpdateHandler(callId, outputChunk);
           }
+          this.toolCalls = this.toolCalls.map((tc) =>
+            tc.request.callId === callId && tc.status === 'executing'
+              ? { ...tc, liveOutput: outputChunk }
+              : tc,
+          );
+          this.notifyToolCallsUpdate();
         }
+      : undefined;
 
-        // Generate unique tool_use_id for hook tracking
-        const toolUseId = generateToolUseId();
+    const shellExecutionConfig = this.config.getShellExecutionConfig();
 
-        // Get MessageBus for hook execution
-        const messageBus = this.config.getMessageBus() as
-          | MessageBus
-          | undefined;
-        const hooksEnabled = !this.config.getDisableAllHooks();
+    // TODO: Refactor to remove special casing for ShellToolInvocation.
+    // Introduce a generic callbacks object for the execute method to handle
+    // things like `onPid` and `onLiveOutput`. This will make the scheduler
+    // agnostic to the invocation type.
+    let promise: Promise<ToolResult>;
+    if (invocation instanceof ShellToolInvocation) {
+      const setPidCallback = (pid: number) => {
+        this.toolCalls = this.toolCalls.map((tc) =>
+          tc.request.callId === callId && tc.status === 'executing'
+            ? { ...tc, pid }
+            : tc,
+        );
+        this.notifyToolCallsUpdate();
+      };
+      // Stash the promote AbortController on the executing tool call so
+      // a UI surface (Ctrl+B keybind) can find the foreground shell's
+      // promote trigger by callId.
+      const setPromoteAbortControllerCallback = (ac: AbortController) => {
+        this.toolCalls = this.toolCalls.map((tc) =>
+          tc.request.callId === callId && tc.status === 'executing'
+            ? { ...tc, promoteAbortController: ac }
+            : tc,
+        );
+        this.notifyToolCallsUpdate();
+      };
+      promise = invocation.execute(
+        signal,
+        liveOutputCallback,
+        shellExecutionConfig,
+        setPidCallback,
+        setPromoteAbortControllerCallback,
+      );
+    } else {
+      promise = invocation.execute(
+        signal,
+        liveOutputCallback,
+        shellExecutionConfig,
+      );
+    }
 
-        // PreToolUse Hook
+    const execSpan = startToolExecutionSpan();
+    try {
+      const toolResult: ToolResult = await promise;
+      endToolExecutionSpan(execSpan, {
+        success: toolResult.error === undefined,
+      });
+      if (signal.aborted) {
+        // PostToolUseFailure Hook
         if (hooksEnabled && messageBus) {
-          // Convert ApprovalMode to permission_mode string for hooks
+          const failureHookResult = await safelyFirePostToolUseFailureHook(
+            messageBus,
+            toolUseId,
+            toolName,
+            toolInput,
+            'User cancelled tool execution.',
+            true,
+            this.config.getApprovalMode(),
+          );
+
+          // Append additional context from hook if provided
+          let cancelMessage = 'User cancelled tool execution.';
+          if (failureHookResult.additionalContext) {
+            cancelMessage += `\n\n${failureHookResult.additionalContext}`;
+          }
+          this.setStatusInternal(callId, 'cancelled', cancelMessage);
+        } else {
+          this.setStatusInternal(
+            callId,
+            'cancelled',
+            'User cancelled tool execution.',
+          );
+        }
+        setToolSpanCancelled(span);
+        return; // Both code paths should return here
+      }
+
+      if (toolResult.error === undefined) {
+        let content = toolResult.llmContent;
+        const contentLength =
+          typeof content === 'string' ? content.length : undefined;
+
+        // PostToolUse Hook
+        if (hooksEnabled && messageBus) {
+          const toolResponse = {
+            llmContent: content,
+            returnDisplay: toolResult.returnDisplay,
+          };
           const permissionMode = this.config.getApprovalMode();
-          const preHookResult = await firePreToolUseHook(
+          const postHookResult = await firePostToolUseHook(
             messageBus,
             toolName,
             toolInput,
+            toolResponse,
             toolUseId,
             permissionMode,
           );
 
-          if (!preHookResult.shouldProceed) {
-            // Hook blocked the execution
-            const blockMessage =
-              preHookResult.blockReason || 'Tool execution blocked by hook';
+          // Append additional context from hook if provided
+          if (postHookResult.additionalContext) {
+            content = appendAdditionalContext(
+              content,
+              postHookResult.additionalContext,
+            );
+          }
+
+          // Check if hook requested to stop execution
+          if (postHookResult.shouldStop) {
+            const stopMessage =
+              postHookResult.stopReason || 'Execution stopped by hook';
             const errorResponse = createErrorResponse(
               scheduledCall.request,
-              new Error(blockMessage),
+              new Error(stopMessage),
               ToolErrorType.EXECUTION_DENIED,
             );
             this.setStatusInternal(callId, 'error', errorResponse);
             setToolSpanFailure(
               span,
-              TOOL_FAILURE_KIND_PRE_HOOK_BLOCKED,
-              TOOL_SPAN_STATUS_PRE_HOOK_BLOCKED,
+              TOOL_FAILURE_KIND_POST_HOOK_STOPPED,
+              TOOL_SPAN_STATUS_POST_HOOK_STOPPED,
             );
             return;
           }
         }
 
-        this.setStatusInternal(callId, 'executing');
+        // Collect filesystem paths the tool just touched. Different tools
+        // use different parameter names: `file_path` (read/edit/write),
+        // `path` (ls, glob), `filePath` (grep, lsp), and `paths`
+        // (ripGrep array form). Conditional rules and skill activation
+        // both key off the same path set, so inspect the union — and
+        // gate the inspection on a tool-name allowlist (see
+        // FS_PATH_TOOL_NAMES) so MCP / non-FS tools that reuse those
+        // parameter names with different semantics never enter the
+        // activation pipeline.
+        const inputPaths = extractToolFilePaths(toolName, toolInput);
+        const resultPaths =
+          isFilesystemPathTool(toolName) &&
+          Array.isArray(toolResult.resultFilePaths)
+            ? toolResult.resultFilePaths
+            : [];
+        const candidatePaths = Array.from(
+          new Set([
+            ...inputPaths.map((p) => unescapePath(p)),
+            ...resultPaths,
+          ]),
+        );
 
-        const liveOutputCallback = scheduledCall.tool.canUpdateOutput
-          ? (outputChunk: ToolResultDisplay) => {
-              if (this.outputUpdateHandler) {
-                this.outputUpdateHandler(callId, outputChunk);
-              }
-              this.toolCalls = this.toolCalls.map((tc) =>
-                tc.request.callId === callId && tc.status === 'executing'
-                  ? { ...tc, liveOutput: outputChunk }
-                  : tc,
-              );
-              this.notifyToolCallsUpdate();
-            }
-          : undefined;
+        if (candidatePaths.length > 0) {
+          const rulesRegistry = this.config.getConditionalRulesRegistry();
+          const skillManager = this.config.getSkillManager();
 
-        const shellExecutionConfig = this.config.getShellExecutionConfig();
+          // Collect every reminder block produced by this tool call, then
+          // emit them as a single `<system-reminder>` envelope at the end.
+          // The previous version emitted one envelope per matching rule
+          // PLUS one for skill activation — a multi-path tool could
+          // produce N+1 envelopes, diluting the model's attention. One
+          // wrapper / one append also lets us share the breakout-prevention
+          // sanitization step (closing-tag scrub) in one place.
+          const reminderBlocks: string[] = [];
 
-        // TODO: Refactor to remove special casing for ShellToolInvocation.
-        // Introduce a generic callbacks object for the execute method to handle
-        // things like `onPid` and `onLiveOutput`. This will make the scheduler
-        // agnostic to the invocation type.
-        let promise: Promise<ToolResult>;
-        if (invocation instanceof ShellToolInvocation) {
-          const setPidCallback = (pid: number) => {
-            this.toolCalls = this.toolCalls.map((tc) =>
-              tc.request.callId === callId && tc.status === 'executing'
-                ? { ...tc, pid }
-                : tc,
-            );
-            this.notifyToolCallsUpdate();
-          };
-          // Stash the promote AbortController on the executing tool call so
-          // a UI surface (Ctrl+B keybind) can find the foreground shell's
-          // promote trigger by callId.
-          const setPromoteAbortControllerCallback = (ac: AbortController) => {
-            this.toolCalls = this.toolCalls.map((tc) =>
-              tc.request.callId === callId && tc.status === 'executing'
-                ? { ...tc, promoteAbortController: ac }
-                : tc,
-            );
-            this.notifyToolCallsUpdate();
-          };
-          promise = invocation.execute(
-            signal,
-            liveOutputCallback,
-            shellExecutionConfig,
-            setPidCallback,
-            setPromoteAbortControllerCallback,
-          );
-        } else {
-          promise = invocation.execute(
-            signal,
-            liveOutputCallback,
-            shellExecutionConfig,
-          );
-        }
-
-        try {
-          const toolResult: ToolResult = await promise;
-          if (signal.aborted) {
-            // PostToolUseFailure Hook
-            if (hooksEnabled && messageBus) {
-              const failureHookResult = await safelyFirePostToolUseFailureHook(
-                messageBus,
-                toolUseId,
-                toolName,
-                toolInput,
-                'User cancelled tool execution.',
-                true,
-                this.config.getApprovalMode(),
-              );
-
-              // Append additional context from hook if provided
-              let cancelMessage = 'User cancelled tool execution.';
-              if (failureHookResult.additionalContext) {
-                cancelMessage += `\n\n${failureHookResult.additionalContext}`;
-              }
-              this.setStatusInternal(callId, 'cancelled', cancelMessage);
-            } else {
-              this.setStatusInternal(
-                callId,
-                'cancelled',
-                'User cancelled tool execution.',
-              );
-            }
-            setToolSpanCancelled(span);
-            return; // Both code paths should return here
+          for (const candidatePath of candidatePaths) {
+            // Inject conditional rules at most once per session per rule
+            // file. The registry tracks dedup internally.
+            const rulesCtx = rulesRegistry?.matchAndConsume(candidatePath);
+            if (rulesCtx) reminderBlocks.push(rulesCtx);
           }
 
-          if (toolResult.error === undefined) {
-            let content = toolResult.llmContent;
-            const contentLength =
-              typeof content === 'string' ? content.length : undefined;
-
-            // PostToolUse Hook
-            if (hooksEnabled && messageBus) {
-              const toolResponse = {
-                llmContent: content,
-                returnDisplay: toolResult.returnDisplay,
-              };
-              const permissionMode = this.config.getApprovalMode();
-              const postHookResult = await firePostToolUseHook(
-                messageBus,
-                toolName,
-                toolInput,
-                toolResponse,
-                toolUseId,
-                permissionMode,
-              );
-
-              // Append additional context from hook if provided
-              if (postHookResult.additionalContext) {
-                content = appendAdditionalContext(
-                  content,
-                  postHookResult.additionalContext,
-                );
-              }
-
-              // Check if hook requested to stop execution
-              if (postHookResult.shouldStop) {
-                const stopMessage =
-                  postHookResult.stopReason || 'Execution stopped by hook';
-                const errorResponse = createErrorResponse(
-                  scheduledCall.request,
-                  new Error(stopMessage),
-                  ToolErrorType.EXECUTION_DENIED,
-                );
-                this.setStatusInternal(callId, 'error', errorResponse);
-                setToolSpanFailure(
-                  span,
-                  TOOL_FAILURE_KIND_POST_HOOK_STOPPED,
-                  TOOL_SPAN_STATUS_POST_HOOK_STOPPED,
-                );
-                return;
-              }
-            }
-
-            // Collect filesystem paths the tool just touched. Different tools
-            // use different parameter names: `file_path` (read/edit/write),
-            // `path` (ls, glob), `filePath` (grep, lsp), and `paths`
-            // (ripGrep array form). Conditional rules and skill activation
-            // both key off the same path set, so inspect the union — and
-            // gate the inspection on a tool-name allowlist (see
-            // FS_PATH_TOOL_NAMES) so MCP / non-FS tools that reuse those
-            // parameter names with different semantics never enter the
-            // activation pipeline.
-            const inputPaths = extractToolFilePaths(toolName, toolInput);
-            const resultPaths =
-              isFilesystemPathTool(toolName) &&
-              Array.isArray(toolResult.resultFilePaths)
-                ? toolResult.resultFilePaths
-                : [];
-            const candidatePaths = Array.from(
-              new Set([
-                ...inputPaths.map((p) => unescapePath(p)),
-                ...resultPaths,
-              ]),
+          // Skill activation runs in a single batch over all candidate
+          // paths so `notifyChangeListeners` (and therefore
+          // `SkillTool.refreshSkills` / `geminiClient.setTools()`) fires
+          // exactly once for this tool call, regardless of how many
+          // paths produced new activations. The await is load-bearing:
+          // matchAndActivateByPaths only resolves after the listener
+          // chain settles, so the activation reminder we append below
+          // never lands in a turn where <available_skills> is still
+          // stale.
+          const activatedSkills =
+            await skillManager?.matchAndActivateByPaths(candidatePaths);
+          if (activatedSkills && activatedSkills.length > 0) {
+            // Subagents share the parent's SkillManager but may have a
+            // restricted toolsList that excludes SkillTool entirely.
+            // Telling such a context "skill X is now available via the
+            // Skill tool" is misleading — the subagent can't invoke it
+            // and would waste a turn trying. Gate the reminder on
+            // whether the active tool registry actually exposes
+            // SkillTool to the model.
+            const hasSkillTool = !!this.toolRegistry.getTool(
+              ToolNames.SKILL,
             );
-
-            if (candidatePaths.length > 0) {
-              const rulesRegistry = this.config.getConditionalRulesRegistry();
-              const skillManager = this.config.getSkillManager();
-
-              // Collect every reminder block produced by this tool call, then
-              // emit them as a single `<system-reminder>` envelope at the end.
-              // The previous version emitted one envelope per matching rule
-              // PLUS one for skill activation — a multi-path tool could
-              // produce N+1 envelopes, diluting the model's attention. One
-              // wrapper / one append also lets us share the breakout-prevention
-              // sanitization step (escapeSystemReminderTags) in one place.
-              const reminderBlocks: string[] = [];
-
-              for (const candidatePath of candidatePaths) {
-                // Inject conditional rules at most once per session per rule
-                // file. The registry tracks dedup internally.
-                const rulesCtx = rulesRegistry?.matchAndConsume(candidatePath);
-                if (rulesCtx) reminderBlocks.push(rulesCtx);
-              }
-
-              // Skill activation runs in a single batch over all candidate
-              // paths so `notifyChangeListeners` (and therefore
-              // `SkillTool.refreshSkills` / `geminiClient.setTools()`) fires
-              // exactly once for this tool call, regardless of how many
-              // paths produced new activations. The await is load-bearing:
-              // matchAndActivateByPaths only resolves after the listener
-              // chain settles, so the activation reminder we append below
-              // never lands in a turn where <available_skills> is still
-              // stale.
-              const activatedSkills =
-                await skillManager?.matchAndActivateByPaths(candidatePaths);
-              if (activatedSkills && activatedSkills.length > 0) {
-                // Subagents share the parent's SkillManager but may have a
-                // restricted toolsList that excludes SkillTool entirely.
-                // Telling such a context "skill X is now available via the
-                // Skill tool" is misleading — the subagent can't invoke it
-                // and would waste a turn trying. Gate the reminder on
-                // whether the active tool registry actually exposes
-                // SkillTool to the model.
-                const hasSkillTool = !!this.toolRegistry.getTool(
-                  ToolNames.SKILL,
-                );
-                if (hasSkillTool) {
-                  // Escape skill names defensively: validateSkillName already
-                  // excludes `<>&` for parsed file-based skills, but
-                  // extension skills (extension.skills array) bypass that
-                  // validator. A crafted extension name would otherwise
-                  // close the <system-reminder> envelope early.
-                  const names = activatedSkills.map(escapeXml).join(', ');
-                  reminderBlocks.push(
-                    `The following skill(s) are now available via the Skill tool based on the file you just accessed: ${names}. Use them if relevant to the task.`,
-                  );
-                }
-              }
-
-              if (reminderBlocks.length > 0) {
-                // Final tag scrub on the joined body — defense in depth
-                // against rules whose markdown body contains a
-                // `<system-reminder>` open/close sequence (literal or
-                // obfuscated with whitespace / zero-width / control
-                // chars). Full XML escaping would mangle code blocks in
-                // rule bodies; the shared targeted scrub keeps markdown
-                // readable while neutralizing envelope-breakout
-                // attempts. Mirrors the IDE-context scrub via the same
-                // `escapeSystemReminderTags` helper.
-                const body = escapeSystemReminderTags(
-                  reminderBlocks.join('\n\n'),
-                );
-                content = appendAdditionalContext(
-                  content,
-                  `<system-reminder>\n${body}\n</system-reminder>`,
-                );
-              }
+            if (hasSkillTool) {
+              // Escape skill names defensively: validateSkillName already
+              // excludes `<>&` for parsed file-based skills, but
+              // extension skills (extension.skills array) bypass that
+              // validator. A crafted extension name would otherwise
+              // close the <system-reminder> envelope early.
+              const names = activatedSkills.map(escapeXml).join(', ');
+              reminderBlocks.push(
+                `The following skill(s) are now available via the Skill tool based on the file you just accessed: ${names}. Use them if relevant to the task.`,
+              );
             }
+          }
 
-            const response = convertToFunctionResponse(
-              toolName,
-              callId,
+          if (reminderBlocks.length > 0) {
+            const body = escapeSystemReminderTags(
+              reminderBlocks.join('\n\n'),
+            );
+            content = appendAdditionalContext(
               content,
-            );
-            const successResponse: ToolCallResponseInfo = {
-              callId,
-              responseParts: response,
-              resultDisplay: toolResult.returnDisplay,
-              error: undefined,
-              errorType: undefined,
-              contentLength,
-              // Propagate modelOverride from skill tools. Use `in` to distinguish
-              // "skill returned undefined (inherit)" from "non-skill tool (no field)".
-              ...('modelOverride' in toolResult
-                ? { modelOverride: toolResult.modelOverride }
-                : {}),
-            };
-            this.setStatusInternal(callId, 'success', successResponse);
-            safeSetStatus(span, { code: SpanStatusCode.OK });
-          } else {
-            // It is a failure
-            // PostToolUseFailure Hook
-            let errorMessage = toolResult.error.message;
-            if (hooksEnabled && messageBus) {
-              const failureHookResult = await safelyFirePostToolUseFailureHook(
-                messageBus,
-                toolUseId,
-                toolName,
-                toolInput,
-                toolResult.error.message,
-                false,
-                this.config.getApprovalMode(),
-              );
-
-              // Append additional context from hook if provided
-              if (failureHookResult.additionalContext) {
-                errorMessage += `\n\n${failureHookResult.additionalContext}`;
-              }
-            }
-
-            const error = new Error(errorMessage);
-            const errorResponse = createErrorResponse(
-              scheduledCall.request,
-              error,
-              toolResult.error.type,
-            );
-            this.setStatusInternal(callId, 'error', errorResponse);
-            setToolSpanFailure(
-              span,
-              TOOL_FAILURE_KIND_TOOL_ERROR,
-              TOOL_SPAN_STATUS_TOOL_ERROR,
-            );
-          }
-        } catch (executionError: unknown) {
-          const errorMessage =
-            executionError instanceof Error
-              ? executionError.message
-              : String(executionError);
-
-          if (signal.aborted) {
-            // PostToolUseFailure Hook (user interrupt)
-            if (hooksEnabled && messageBus) {
-              const failureHookResult = await safelyFirePostToolUseFailureHook(
-                messageBus,
-                toolUseId,
-                toolName,
-                toolInput,
-                'User cancelled tool execution.',
-                true,
-                this.config.getApprovalMode(),
-              );
-
-              // Append additional context from hook if provided
-              let cancelMessage = 'User cancelled tool execution.';
-              if (failureHookResult.additionalContext) {
-                cancelMessage += `\n\n${failureHookResult.additionalContext}`;
-              }
-              this.setStatusInternal(callId, 'cancelled', cancelMessage);
-            } else {
-              this.setStatusInternal(
-                callId,
-                'cancelled',
-                'User cancelled tool execution.',
-              );
-            }
-            setToolSpanCancelled(span);
-            return;
-          } else {
-            // PostToolUseFailure Hook
-            let exceptionErrorMessage = errorMessage;
-            if (hooksEnabled && messageBus) {
-              const failureHookResult = await safelyFirePostToolUseFailureHook(
-                messageBus,
-                toolUseId,
-                toolName,
-                toolInput,
-                errorMessage,
-                false,
-                this.config.getApprovalMode(),
-              );
-
-              // Append additional context from hook if provided
-              if (failureHookResult.additionalContext) {
-                exceptionErrorMessage += `\n\n${failureHookResult.additionalContext}`;
-              }
-            }
-            this.setStatusInternal(
-              callId,
-              'error',
-              createErrorResponse(
-                scheduledCall.request,
-                executionError instanceof Error
-                  ? new Error(exceptionErrorMessage)
-                  : new Error(String(executionError)),
-                ToolErrorType.UNHANDLED_EXCEPTION,
-              ),
-            );
-            setToolSpanFailure(
-              span,
-              TOOL_FAILURE_KIND_TOOL_EXCEPTION,
-              TOOL_SPAN_STATUS_TOOL_EXCEPTION,
+              `<system-reminder>\n${body}\n</system-reminder>`,
             );
           }
         }
-      },
-      { autoOkOnSuccess: false },
-    );
+
+        const response = convertToFunctionResponse(
+          toolName,
+          callId,
+          content,
+        );
+        const successResponse: ToolCallResponseInfo = {
+          callId,
+          responseParts: response,
+          resultDisplay: toolResult.returnDisplay,
+          error: undefined,
+          errorType: undefined,
+          contentLength,
+          // Propagate modelOverride from skill tools. Use `in` to distinguish
+          // "skill returned undefined (inherit)" from "non-skill tool (no field)".
+          ...('modelOverride' in toolResult
+            ? { modelOverride: toolResult.modelOverride }
+            : {}),
+        };
+        this.setStatusInternal(callId, 'success', successResponse);
+        safeSetStatus(span, { code: SpanStatusCode.OK });
+      } else {
+        // It is a failure
+        // PostToolUseFailure Hook
+        let errorMessage = toolResult.error.message;
+        if (hooksEnabled && messageBus) {
+          const failureHookResult = await safelyFirePostToolUseFailureHook(
+            messageBus,
+            toolUseId,
+            toolName,
+            toolInput,
+            toolResult.error.message,
+            false,
+            this.config.getApprovalMode(),
+          );
+
+          // Append additional context from hook if provided
+          if (failureHookResult.additionalContext) {
+            errorMessage += `\n\n${failureHookResult.additionalContext}`;
+          }
+        }
+
+        const error = new Error(errorMessage);
+        const errorResponse = createErrorResponse(
+          scheduledCall.request,
+          error,
+          toolResult.error.type,
+        );
+        this.setStatusInternal(callId, 'error', errorResponse);
+        setToolSpanFailure(
+          span,
+          TOOL_FAILURE_KIND_TOOL_ERROR,
+          TOOL_SPAN_STATUS_TOOL_ERROR,
+        );
+      }
+    } catch (executionError: unknown) {
+      const errorMessage =
+        executionError instanceof Error
+          ? executionError.message
+          : String(executionError);
+      endToolExecutionSpan(execSpan, {
+        success: false,
+        error: errorMessage,
+      });
+
+      if (signal.aborted) {
+        // PostToolUseFailure Hook (user interrupt)
+        if (hooksEnabled && messageBus) {
+          const failureHookResult = await safelyFirePostToolUseFailureHook(
+            messageBus,
+            toolUseId,
+            toolName,
+            toolInput,
+            'User cancelled tool execution.',
+            true,
+            this.config.getApprovalMode(),
+          );
+
+          // Append additional context from hook if provided
+          let cancelMessage = 'User cancelled tool execution.';
+          if (failureHookResult.additionalContext) {
+            cancelMessage += `\n\n${failureHookResult.additionalContext}`;
+          }
+          this.setStatusInternal(callId, 'cancelled', cancelMessage);
+        } else {
+          this.setStatusInternal(
+            callId,
+            'cancelled',
+            'User cancelled tool execution.',
+          );
+        }
+        setToolSpanCancelled(span);
+        return;
+      } else {
+        // PostToolUseFailure Hook
+        let exceptionErrorMessage = errorMessage;
+        if (hooksEnabled && messageBus) {
+          const failureHookResult = await safelyFirePostToolUseFailureHook(
+            messageBus,
+            toolUseId,
+            toolName,
+            toolInput,
+            errorMessage,
+            false,
+            this.config.getApprovalMode(),
+          );
+
+          // Append additional context from hook if provided
+          if (failureHookResult.additionalContext) {
+            exceptionErrorMessage += `\n\n${failureHookResult.additionalContext}`;
+          }
+        }
+        this.setStatusInternal(
+          callId,
+          'error',
+          createErrorResponse(
+            scheduledCall.request,
+            executionError instanceof Error
+              ? new Error(exceptionErrorMessage)
+              : new Error(String(executionError)),
+            ToolErrorType.UNHANDLED_EXCEPTION,
+          ),
+        );
+        setToolSpanFailure(
+          span,
+          TOOL_FAILURE_KIND_TOOL_EXCEPTION,
+          TOOL_SPAN_STATUS_TOOL_EXCEPTION,
+        );
+      }
+    }
   }
 
   private async checkAndNotifyCompletion(): Promise<void> {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1898,9 +1898,7 @@ export class CoreToolScheduler {
     const toolUseId = generateToolUseId();
 
     // Get MessageBus for hook execution
-    const messageBus = this.config.getMessageBus() as
-      | MessageBus
-      | undefined;
+    const messageBus = this.config.getMessageBus() as MessageBus | undefined;
     const hooksEnabled = !this.config.getDisableAllHooks();
 
     // PreToolUse Hook
@@ -2092,10 +2090,7 @@ export class CoreToolScheduler {
             ? toolResult.resultFilePaths
             : [];
         const candidatePaths = Array.from(
-          new Set([
-            ...inputPaths.map((p) => unescapePath(p)),
-            ...resultPaths,
-          ]),
+          new Set([...inputPaths.map((p) => unescapePath(p)), ...resultPaths]),
         );
 
         if (candidatePaths.length > 0) {
@@ -2137,9 +2132,7 @@ export class CoreToolScheduler {
             // and would waste a turn trying. Gate the reminder on
             // whether the active tool registry actually exposes
             // SkillTool to the model.
-            const hasSkillTool = !!this.toolRegistry.getTool(
-              ToolNames.SKILL,
-            );
+            const hasSkillTool = !!this.toolRegistry.getTool(ToolNames.SKILL);
             if (hasSkillTool) {
               // Escape skill names defensively: validateSkillName already
               // excludes `<>&` for parsed file-based skills, but
@@ -2164,11 +2157,7 @@ export class CoreToolScheduler {
           }
         }
 
-        const response = convertToFunctionResponse(
-          toolName,
-          callId,
-          content,
-        );
+        const response = convertToFunctionResponse(toolName, callId, content);
         const successResponse: ToolCallResponseInfo = {
           callId,
           responseParts: response,
@@ -2225,7 +2214,7 @@ export class CoreToolScheduler {
           : String(executionError);
       endToolExecutionSpan(execSpan, {
         success: false,
-        error: errorMessage,
+        error: TOOL_SPAN_STATUS_TOOL_EXCEPTION,
       });
 
       if (signal.aborted) {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -96,6 +96,7 @@ const TOOL_SPAN_STATUS_PRE_HOOK_BLOCKED = 'Tool execution blocked by hook';
 const TOOL_SPAN_STATUS_POST_HOOK_STOPPED = 'Tool execution stopped by hook';
 const TOOL_SPAN_STATUS_TOOL_ERROR = 'Tool execution failed';
 const TOOL_SPAN_STATUS_TOOL_EXCEPTION = 'Tool execution failed with exception';
+const TOOL_SPAN_STATUS_TOOL_CANCELLED = 'Tool execution cancelled by user';
 
 const TRUNCATION_PARAM_GUIDANCE =
   'Note: Your previous response was truncated due to max_tokens limit, ' +
@@ -2217,9 +2218,15 @@ export class CoreToolScheduler {
         executionError instanceof Error
           ? executionError.message
           : String(executionError);
+      // Distinguish user cancellation from real tool exceptions on the
+      // execution sub-span so trace backends filtering for errors do not
+      // see false positives. Both are still success: false; only the
+      // sanitized error message differs.
       endToolExecutionSpan(execSpan, {
         success: false,
-        error: TOOL_SPAN_STATUS_TOOL_EXCEPTION,
+        error: signal.aborted
+          ? TOOL_SPAN_STATUS_TOOL_CANCELLED
+          : TOOL_SPAN_STATUS_TOOL_EXCEPTION,
       });
 
       if (signal.aborted) {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1949,6 +1949,15 @@ export class CoreToolScheduler {
     // Introduce a generic callbacks object for the execute method to handle
     // things like `onPid` and `onLiveOutput`. This will make the scheduler
     // agnostic to the invocation type.
+    //
+    // Start the execution sub-span BEFORE invocation.execute() so its
+    // synchronous setup (shell command preprocessing, child_process.spawn,
+    // etc.) is bracketed by the span. We don't manually activate the span
+    // as OTel context here because the surrounding tool span is already
+    // active via runInToolSpanContext, and tool implementations don't
+    // currently emit nested OTel spans of their own — the span boundary
+    // is purely for timing/attribution.
+    const execSpan = startToolExecutionSpan();
     let promise: Promise<ToolResult>;
     if (invocation instanceof ShellToolInvocation) {
       const setPidCallback = (pid: number) => {
@@ -1985,7 +1994,6 @@ export class CoreToolScheduler {
       );
     }
 
-    const execSpan = startToolExecutionSpan();
     try {
       const toolResult: ToolResult = await promise;
       endToolExecutionSpan(execSpan, {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -124,6 +124,10 @@ function setToolSpanFailure(
 ): void {
   try {
     span.setAttribute(TOOL_FAILURE_KIND_ATTRIBUTE, failureKind);
+    // Always write `success: false` so trace backends can filter tool
+    // failures with the same query they use for llm_request spans —
+    // mirrors the unconditional `success` attribute on llm_request.
+    span.setAttribute('success', false);
   } catch {
     // OTel errors must not block the failure status update.
   }
@@ -136,6 +140,7 @@ function setToolSpanFailure(
 function setToolSpanCancelled(span: Span): void {
   try {
     span.setAttribute(TOOL_FAILURE_KIND_ATTRIBUTE, TOOL_FAILURE_KIND_CANCELLED);
+    span.setAttribute('success', false);
   } catch {
     // OTel errors must not block the cancellation status update.
   }
@@ -2179,6 +2184,14 @@ export class CoreToolScheduler {
         };
         this.setStatusInternal(callId, 'success', successResponse);
         safeSetStatus(span, { code: SpanStatusCode.OK });
+        // Mirrors setToolSpanFailure/setToolSpanCancelled — every tool span
+        // ends with an explicit `success` attribute so backends can filter
+        // failures the same way they filter llm_request failures.
+        try {
+          span.setAttribute('success', true);
+        } catch {
+          // OTel errors must not block API behavior.
+        }
       } else {
         // It is a failure
         // PostToolUseFailure Hook

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1868,12 +1868,7 @@ export class CoreToolScheduler {
         this._executeToolCallBody(scheduledCall, signal, toolSpan),
       );
     } finally {
-      const tc = this.toolCalls.find((c) => c.request.callId === callId);
-      if (tc?.status === 'success') {
-        endToolSpan(toolSpan, { success: true });
-      } else {
-        endToolSpan(toolSpan);
-      }
+      endToolSpan(toolSpan);
     }
   }
 
@@ -2170,6 +2165,7 @@ export class CoreToolScheduler {
             : {}),
         };
         this.setStatusInternal(callId, 'success', successResponse);
+        safeSetStatus(span, { code: SpanStatusCode.OK });
       } else {
         // It is a failure
         // PostToolUseFailure Hook

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -2147,9 +2147,7 @@ export class CoreToolScheduler {
           }
 
           if (reminderBlocks.length > 0) {
-            const body = escapeSystemReminderTags(
-              reminderBlocks.join('\n\n'),
-            );
+            const body = escapeSystemReminderTags(reminderBlocks.join('\n\n'));
             content = appendAdditionalContext(
               content,
               `<system-reminder>\n${body}\n</system-reminder>`,
@@ -2172,7 +2170,6 @@ export class CoreToolScheduler {
             : {}),
         };
         this.setStatusInternal(callId, 'success', successResponse);
-        safeSetStatus(span, { code: SpanStatusCode.OK });
       } else {
         // It is a failure
         // PostToolUseFailure Hook

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1958,43 +1958,47 @@ export class CoreToolScheduler {
     // currently emit nested OTel spans of their own — the span boundary
     // is purely for timing/attribution.
     const execSpan = startToolExecutionSpan();
-    let promise: Promise<ToolResult>;
-    if (invocation instanceof ShellToolInvocation) {
-      const setPidCallback = (pid: number) => {
-        this.toolCalls = this.toolCalls.map((tc) =>
-          tc.request.callId === callId && tc.status === 'executing'
-            ? { ...tc, pid }
-            : tc,
-        );
-        this.notifyToolCallsUpdate();
-      };
-      // Stash the promote AbortController on the executing tool call so
-      // a UI surface (Ctrl+B keybind) can find the foreground shell's
-      // promote trigger by callId.
-      const setPromoteAbortControllerCallback = (ac: AbortController) => {
-        this.toolCalls = this.toolCalls.map((tc) =>
-          tc.request.callId === callId && tc.status === 'executing'
-            ? { ...tc, promoteAbortController: ac }
-            : tc,
-        );
-        this.notifyToolCallsUpdate();
-      };
-      promise = invocation.execute(
-        signal,
-        liveOutputCallback,
-        shellExecutionConfig,
-        setPidCallback,
-        setPromoteAbortControllerCallback,
-      );
-    } else {
-      promise = invocation.execute(
-        signal,
-        liveOutputCallback,
-        shellExecutionConfig,
-      );
-    }
-
+    // try wraps both invocation.execute() and the await so synchronous
+    // throws (e.g. shell setup failure) flow into the same catch as async
+    // rejections — otherwise execSpan leaks unended and failure hooks
+    // are skipped.
     try {
+      let promise: Promise<ToolResult>;
+      if (invocation instanceof ShellToolInvocation) {
+        const setPidCallback = (pid: number) => {
+          this.toolCalls = this.toolCalls.map((tc) =>
+            tc.request.callId === callId && tc.status === 'executing'
+              ? { ...tc, pid }
+              : tc,
+          );
+          this.notifyToolCallsUpdate();
+        };
+        // Stash the promote AbortController on the executing tool call so
+        // a UI surface (Ctrl+B keybind) can find the foreground shell's
+        // promote trigger by callId.
+        const setPromoteAbortControllerCallback = (ac: AbortController) => {
+          this.toolCalls = this.toolCalls.map((tc) =>
+            tc.request.callId === callId && tc.status === 'executing'
+              ? { ...tc, promoteAbortController: ac }
+              : tc,
+          );
+          this.notifyToolCallsUpdate();
+        };
+        promise = invocation.execute(
+          signal,
+          liveOutputCallback,
+          shellExecutionConfig,
+          setPidCallback,
+          setPromoteAbortControllerCallback,
+        );
+      } else {
+        promise = invocation.execute(
+          signal,
+          liveOutputCallback,
+          shellExecutionConfig,
+        );
+      }
+
       const toolResult: ToolResult = await promise;
       endToolExecutionSpan(execSpan, {
         success: toolResult.error === undefined,

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
@@ -95,7 +95,11 @@ vi.mock('@opentelemetry/api', async (importOriginal) => {
   };
 });
 
-vi.mock('../../telemetry/tracer.js', () => {
+vi.mock('../../telemetry/tracer.js', () => ({
+    API_CALL_FAILED_SPAN_STATUS_MESSAGE: 'API call failed',
+  }));
+
+vi.mock('../../telemetry/index.js', () => {
   function createSpan(
     name: string,
     attributes: Record<string, string | number | boolean>,
@@ -116,6 +120,7 @@ vi.mock('../../telemetry/tracer.js', () => {
         record.statuses.push(status);
       },
       setAttribute: vi.fn(),
+      setAttributes: vi.fn(),
       end() {
         record.ended = true;
       },
@@ -127,77 +132,35 @@ vi.mock('../../telemetry/tracer.js', () => {
     };
   }
 
-  function runWithActive<T>(label: string, fn: () => T): T {
-    const previous = activeOtelContext.current;
-    activeOtelContext.current = label;
-    try {
-      const result = fn();
-      if (result instanceof Promise) {
-        return result.finally(() => {
-          activeOtelContext.current = previous;
-        }) as T;
-      }
-      activeOtelContext.current = previous;
-      return result;
-    } catch (error) {
-      activeOtelContext.current = previous;
-      throw error;
-    }
-  }
-
   return {
-    API_CALL_FAILED_SPAN_STATUS_MESSAGE: 'API call failed',
-    safeSetStatus: (
-      span: { setStatus: (status: { code: number; message?: string }) => void },
-      status: { code: number; message?: string },
-    ) => {
-      try {
-        span.setStatus(status);
-      } catch {
-        // Match production best-effort telemetry behavior.
-      }
-    },
-    withSpan: vi.fn(
-      async (
-        name: string,
-        attributes: Record<string, string | number | boolean>,
-        fn: (span: ReturnType<typeof createSpan>) => Promise<unknown>,
+    startLLMRequestSpan: vi.fn((model: string, promptId: string) =>
+      createSpan('qwen-code.llm_request', {
+        'qwen-code.model': model,
+        'qwen-code.prompt_id': promptId,
+      }),
+    ),
+    endLLMRequestSpan: vi.fn(
+      (
+        span: ReturnType<typeof createSpan>,
+        metadata?: {
+          success: boolean;
+          inputTokens?: number;
+          outputTokens?: number;
+          durationMs?: number;
+          error?: string;
+        },
       ) => {
-        const span = createSpan(name, attributes);
-        let statusSet = false;
-        const wrappedSpan = {
-          ...span,
-          setStatus(status: { code: number; message?: string }) {
-            statusSet = true;
-            return span.setStatus(status);
-          },
-        };
-        try {
-          const result = await fn(wrappedSpan);
-          if (!statusSet) {
-            span.setStatus({ code: 1 });
-          }
-          return result;
-        } catch (error) {
-          if (!statusSet) {
+        if (metadata) {
+          if (metadata.success) {
+            span.setStatus({ code: 1 }); // OK
+          } else {
             span.setStatus({
               code: 2,
-              message: error instanceof Error ? error.message : String(error),
-            });
+              message: metadata.error ?? 'unknown error',
+            }); // ERROR
           }
-          throw error;
-        } finally {
-          span.end();
         }
-      },
-    ),
-    startSpanWithContext: vi.fn(
-      (name: string, attributes: Record<string, string | number | boolean>) => {
-        const span = createSpan(name, attributes);
-        return {
-          span,
-          runInContext: <T>(fn: () => T): T => runWithActive(name, fn),
-        };
+        span.end();
       },
     ),
   };
@@ -290,20 +253,20 @@ const createResponse = (
 
 const getStreamSpanRecord = () => {
   const spanRecord = loggingSpanRecords.find(
-    (record) => record.name === 'api.generateContentStream',
+    (record) => record.name === 'qwen-code.llm_request',
   );
   if (!spanRecord) {
-    throw new Error('api.generateContentStream span was not created');
+    throw new Error('qwen-code.llm_request span was not created');
   }
   return spanRecord;
 };
 
 const getGenerateContentSpanRecord = () => {
   const spanRecord = loggingSpanRecords.find(
-    (record) => record.name === 'api.generateContent',
+    (record) => record.name === 'qwen-code.llm_request',
   );
   if (!spanRecord) {
-    throw new Error('api.generateContent span was not created');
+    throw new Error('qwen-code.llm_request span was not created');
   }
   return spanRecord;
 };
@@ -790,7 +753,7 @@ describe('LoggingContentGenerator', () => {
   });
 
   it('preserves stream success when the OK status update fails', async () => {
-    loggingSpanNamesWithSetStatusFailure.add('api.generateContentStream');
+    loggingSpanNamesWithSetStatusFailure.add('qwen-code.llm_request');
     const response = createResponse('resp-status', 'model-stream', [
       { text: 'ok' },
     ]);
@@ -858,7 +821,7 @@ describe('LoggingContentGenerator', () => {
       // Consume stream to trigger cleanup.
     }
 
-    expect(activeContextDuringWrappedCall).toBe('api.generateContentStream');
+    expect(activeContextDuringWrappedCall).toBe('qwen-code.llm_request');
   });
 
   it('logs stream setup errors before leaving the stream span context', async () => {
@@ -889,7 +852,7 @@ describe('LoggingContentGenerator', () => {
     ).rejects.toThrow('setup-fail');
 
     expect(logApiError).toHaveBeenCalledTimes(1);
-    expect(activeContextDuringApiError).toBe('api.generateContentStream');
+    expect(activeContextDuringApiError).toBe('qwen-code.llm_request');
     expect(spanEndedDuringApiError).toBe(false);
 
     const spanRecord = getStreamSpanRecord();
@@ -1002,7 +965,7 @@ describe('LoggingContentGenerator', () => {
   });
 
   it('preserves stream errors when the error status update fails', async () => {
-    loggingSpanNamesWithSetStatusFailure.add('api.generateContentStream');
+    loggingSpanNamesWithSetStatusFailure.add('qwen-code.llm_request');
     const response1 = createResponse('resp-1', 'model-stream', [
       { text: 'partial' },
     ]);

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
@@ -96,8 +96,8 @@ vi.mock('@opentelemetry/api', async (importOriginal) => {
 });
 
 vi.mock('../../telemetry/tracer.js', () => ({
-    API_CALL_FAILED_SPAN_STATUS_MESSAGE: 'API call failed',
-  }));
+  API_CALL_FAILED_SPAN_STATUS_MESSAGE: 'API call failed',
+}));
 
 vi.mock('../../telemetry/index.js', () => {
   function createSpan(
@@ -135,8 +135,8 @@ vi.mock('../../telemetry/index.js', () => {
   return {
     startLLMRequestSpan: vi.fn((model: string, promptId: string) =>
       createSpan('qwen-code.llm_request', {
-        'qwen-code.model': model,
-        'qwen-code.prompt_id': promptId,
+        model,
+        prompt_id: promptId,
       }),
     ),
     endLLMRequestSpan: vi.fn(
@@ -150,17 +150,22 @@ vi.mock('../../telemetry/index.js', () => {
           error?: string;
         },
       ) => {
-        if (metadata) {
-          if (metadata.success) {
-            span.setStatus({ code: 1 }); // OK
-          } else {
-            span.setStatus({
-              code: 2,
-              message: metadata.error ?? 'unknown error',
-            }); // ERROR
+        try {
+          if (metadata) {
+            if (metadata.success) {
+              span.setStatus({ code: 1 }); // OK
+            } else {
+              span.setStatus({
+                code: 2,
+                message: metadata.error ?? 'unknown error',
+              }); // ERROR
+            }
           }
+          span.end();
+        } catch {
+          // Match production best-effort behavior.
+          span.end();
         }
-        span.end();
       },
     ),
   };

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
@@ -106,7 +106,10 @@ vi.mock('../../telemetry/index.js', () => {
   ) {
     const record = {
       name,
-      attributes,
+      attributes: { ...attributes } as Record<
+        string,
+        string | number | boolean
+      >,
       statuses: [] as Array<{ code: number; message?: string }>,
       ended: false,
     };
@@ -119,8 +122,12 @@ vi.mock('../../telemetry/index.js', () => {
         }
         record.statuses.push(status);
       },
-      setAttribute: vi.fn(),
-      setAttributes: vi.fn(),
+      setAttribute(key: string, value: string | number | boolean) {
+        record.attributes[key] = value;
+      },
+      setAttributes(attrs: Record<string, string | number | boolean>) {
+        Object.assign(record.attributes, attrs);
+      },
       end() {
         record.ended = true;
       },
@@ -429,12 +436,67 @@ describe('LoggingContentGenerator', () => {
     await generator.generateContent(request, 'prompt-span');
 
     const spanRecord = getGenerateContentSpanRecord();
-    expect(spanRecord.attributes).toEqual({
+    expect(spanRecord.attributes).toMatchObject({
       model: 'test-model',
       prompt_id: 'prompt-span',
+      'llm_request.stream': false,
     });
     expect(spanRecord.statuses).toEqual([{ code: SpanStatusCode.OK }]);
     expect(spanRecord.ended).toBe(true);
+  });
+
+  it('marks non-stream LLM span with llm_request.stream=false', async () => {
+    const wrapped = createWrappedGenerator(
+      vi
+        .fn()
+        .mockResolvedValue(
+          createResponse('resp', 'test-model', [{ text: 'ok' }]),
+        ),
+      vi.fn(),
+    );
+    const generator = new LoggingContentGenerator(wrapped, createConfig(), {
+      model: 'test-model',
+      authType: AuthType.USE_OPENAI,
+      enableOpenAILogging: false,
+    });
+    const request = {
+      model: 'test-model',
+      contents: 'Hello',
+    } as unknown as GenerateContentParameters;
+
+    await generator.generateContent(request, 'prompt-stream-attr');
+
+    const spanRecord = getGenerateContentSpanRecord();
+    expect(spanRecord.attributes['llm_request.stream']).toBe(false);
+  });
+
+  it('marks streaming LLM span with llm_request.stream=true', async () => {
+    const streamFn = vi.fn().mockResolvedValue(
+      (async function* () {
+        yield createResponse('resp-1', 'test-model', [{ text: 'ok' }]);
+      })(),
+    );
+    const wrapped = createWrappedGenerator(vi.fn(), streamFn);
+    const generator = new LoggingContentGenerator(wrapped, createConfig(), {
+      model: 'test-model',
+      authType: AuthType.USE_OPENAI,
+      enableOpenAILogging: false,
+    });
+    const request = {
+      model: 'test-model',
+      contents: 'Hello',
+    } as unknown as GenerateContentParameters;
+
+    const stream = await generator.generateContentStream(
+      request,
+      'prompt-stream-attr',
+    );
+    for await (const _ of stream) {
+      // consume
+    }
+
+    const spanRecord = getStreamSpanRecord();
+    expect(spanRecord.attributes['llm_request.stream']).toBe(true);
   });
 
   it('preserves non-stream success when response and OpenAI logging fail', async () => {

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts
@@ -32,6 +32,17 @@ const loggingSpanRecords = vi.hoisted(
     attributes: Record<string, string | number | boolean>;
     statuses: Array<{ code: number; message?: string }>;
     ended: boolean;
+    /**
+     * Metadata passed to endLLMRequestSpan — captured so tests can assert
+     * that token counts, durationMs, success, error are forwarded correctly.
+     */
+    endMetadata?: {
+      success?: boolean;
+      inputTokens?: number;
+      outputTokens?: number;
+      durationMs?: number;
+      error?: string;
+    };
   }> => [],
 );
 const loggingSpanNamesWithSetStatusFailure = vi.hoisted(
@@ -157,6 +168,14 @@ vi.mock('../../telemetry/index.js', () => {
           error?: string;
         },
       ) => {
+        // Capture metadata on the matching span record so tests can assert
+        // token counts, durationMs, success, error are forwarded correctly.
+        const record = loggingSpanRecords.find(
+          (r) => r.name === span.__spanName && r.endMetadata === undefined,
+        );
+        if (record) {
+          record.endMetadata = metadata;
+        }
         try {
           if (metadata) {
             if (metadata.success) {
@@ -497,6 +516,99 @@ describe('LoggingContentGenerator', () => {
 
     const spanRecord = getStreamSpanRecord();
     expect(spanRecord.attributes['llm_request.stream']).toBe(true);
+  });
+
+  it('forwards token counts and duration to endLLMRequestSpan on non-stream success', async () => {
+    const wrapped = createWrappedGenerator(
+      vi.fn().mockResolvedValue(
+        createResponse('resp', 'test-model', [{ text: 'ok' }], {
+          promptTokenCount: 42,
+          candidatesTokenCount: 17,
+          totalTokenCount: 59,
+        }),
+      ),
+      vi.fn(),
+    );
+    const generator = new LoggingContentGenerator(wrapped, createConfig(), {
+      model: 'test-model',
+      authType: AuthType.USE_OPENAI,
+      enableOpenAILogging: false,
+    });
+    const request = {
+      model: 'test-model',
+      contents: 'Hello',
+    } as unknown as GenerateContentParameters;
+
+    await generator.generateContent(request, 'prompt-meta');
+
+    const spanRecord = getGenerateContentSpanRecord();
+    expect(spanRecord.endMetadata).toMatchObject({
+      success: true,
+      inputTokens: 42,
+      outputTokens: 17,
+    });
+    expect(spanRecord.endMetadata!.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('forwards error metadata to endLLMRequestSpan on non-stream failure', async () => {
+    const wrapped = createWrappedGenerator(
+      vi.fn().mockRejectedValue(new Error('upstream-down')),
+      vi.fn(),
+    );
+    const generator = new LoggingContentGenerator(wrapped, createConfig(), {
+      model: 'test-model',
+      authType: AuthType.USE_OPENAI,
+      enableOpenAILogging: false,
+    });
+    const request = {
+      model: 'test-model',
+      contents: 'Hello',
+    } as unknown as GenerateContentParameters;
+
+    await expect(
+      generator.generateContent(request, 'prompt-err'),
+    ).rejects.toThrow('upstream-down');
+
+    const spanRecord = getGenerateContentSpanRecord();
+    expect(spanRecord.endMetadata).toMatchObject({
+      success: false,
+      error: 'API call failed',
+    });
+  });
+
+  it('forwards final lastUsageMetadata to endLLMRequestSpan on stream success', async () => {
+    const streamFn = vi.fn().mockResolvedValue(
+      (async function* () {
+        yield createResponse('r1', 'test-model', [{ text: 'a' }]);
+        yield createResponse('r2', 'test-model', [{ text: 'b' }], {
+          promptTokenCount: 100,
+          candidatesTokenCount: 50,
+          totalTokenCount: 150,
+        });
+      })(),
+    );
+    const wrapped = createWrappedGenerator(vi.fn(), streamFn);
+    const generator = new LoggingContentGenerator(wrapped, createConfig(), {
+      model: 'test-model',
+      authType: AuthType.USE_OPENAI,
+      enableOpenAILogging: false,
+    });
+    const request = {
+      model: 'test-model',
+      contents: 'Hello',
+    } as unknown as GenerateContentParameters;
+
+    const stream = await generator.generateContentStream(request, 'prompt-tok');
+    for await (const _ of stream) {
+      // consume
+    }
+
+    const spanRecord = getStreamSpanRecord();
+    expect(spanRecord.endMetadata).toMatchObject({
+      success: true,
+      inputTokens: 100,
+      outputTokens: 50,
+    });
   });
 
   it('preserves non-stream success when response and OpenAI logging fail', async () => {

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -405,6 +405,11 @@ export class LoggingContentGenerator implements ContentGenerator {
     let firstModelVersion = '';
     let lastUsageMetadata: GenerateContentResponseUsageMetadata | undefined;
     let errorOccurred = false;
+    // Tracks whether the idle timeout fired and ended the span. If so,
+    // a resumed-after-timeout consumer must not call endLLMRequestSpan
+    // again (the helper would no-op, but more importantly we skip the
+    // redundant work and avoid resetting the timer further).
+    let spanEndedByTimeout = false;
 
     // Helper to run code within the span context during iteration.
     // This ensures debug log lines emitted during stream processing
@@ -420,6 +425,7 @@ export class LoggingContentGenerator implements ContentGenerator {
     let spanEndTimeout: ReturnType<typeof setTimeout> | undefined;
     const resetSpanTimeout = span
       ? () => {
+          if (spanEndedByTimeout) return;
           if (spanEndTimeout !== undefined) clearTimeout(spanEndTimeout);
           spanEndTimeout = setTimeout(() => {
             try {
@@ -432,6 +438,7 @@ export class LoggingContentGenerator implements ContentGenerator {
               durationMs: Date.now() - startTime,
               error: 'Stream span timed out (idle)',
             });
+            spanEndedByTimeout = true;
           }, STREAM_IDLE_TIMEOUT_MS);
           spanEndTimeout.unref();
         }
@@ -509,7 +516,11 @@ export class LoggingContentGenerator implements ContentGenerator {
       if (spanEndTimeout !== undefined) {
         clearTimeout(spanEndTimeout);
       }
-      if (span) {
+      // If the idle timeout already ended the span, skip the redundant
+      // endLLMRequestSpan call. The helper itself would no-op due to its
+      // own ended guard, but we want to avoid pretending the final token
+      // counts were recorded — they weren't, the span is the timeout one.
+      if (span && !spanEndedByTimeout) {
         endLLMRequestSpan(span, {
           success: !errorOccurred,
           inputTokens: lastUsageMetadata?.promptTokenCount,

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -204,6 +204,11 @@ export class LoggingContentGenerator implements ContentGenerator {
     userPromptId: string,
   ): Promise<GenerateContentResponse> {
     const llmSpan = startLLMRequestSpan(req.model, userPromptId);
+    try {
+      llmSpan.setAttribute('llm_request.stream', false);
+    } catch {
+      /* best-effort */
+    }
     const startTime = Date.now();
     const isInternal = isInternalPromptId(userPromptId);
     const session = this.startCaptureSession();
@@ -274,6 +279,11 @@ export class LoggingContentGenerator implements ContentGenerator {
     userPromptId: string,
   ): Promise<AsyncGenerator<GenerateContentResponse>> {
     const llmSpan = startLLMRequestSpan(req.model, userPromptId);
+    try {
+      llmSpan.setAttribute('llm_request.stream', true);
+    } catch {
+      /* best-effort */
+    }
 
     // Capture the span context so the stream wrapper can activate it
     // during iteration — not just during generator creation.

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -53,7 +53,10 @@ import {
   startLLMRequestSpan,
   endLLMRequestSpan,
 } from '../../telemetry/index.js';
-import { API_CALL_FAILED_SPAN_STATUS_MESSAGE } from '../../telemetry/tracer.js';
+import {
+  API_CALL_ABORTED_SPAN_STATUS_MESSAGE,
+  API_CALL_FAILED_SPAN_STATUS_MESSAGE,
+} from '../../telemetry/tracer.js';
 
 const debugLogger = createDebugLogger('LOGGING_CONTENT_GENERATOR');
 
@@ -262,6 +265,19 @@ export class LoggingContentGenerator implements ContentGenerator {
       return response;
     } catch (error) {
       const durationMs = Date.now() - startTime;
+      // End the span BEFORE the (potentially-throwing) logging block, so a
+      // logging-side rejection cannot prevent span finalization. Mirrors the
+      // streaming path order. Use abort-specific status message when the
+      // caller's abortSignal fired, so trace backends can distinguish user
+      // cancellations from real upstream failures.
+      const aborted = req.config?.abortSignal?.aborted ?? false;
+      endLLMRequestSpan(llmSpan, {
+        success: false,
+        durationMs,
+        error: aborted
+          ? API_CALL_ABORTED_SPAN_STATUS_MESSAGE
+          : API_CALL_FAILED_SPAN_STATUS_MESSAGE,
+      });
       await context.with(spanContext, async () => {
         this.safelyLogApiError('', durationMs, error, req.model, userPromptId);
         try {
@@ -274,11 +290,6 @@ export class LoggingContentGenerator implements ContentGenerator {
         } catch (loggingError) {
           debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
         }
-      });
-      endLLMRequestSpan(llmSpan, {
-        success: false,
-        durationMs,
-        error: API_CALL_FAILED_SPAN_STATUS_MESSAGE,
       });
       throw error;
     }
@@ -322,10 +333,13 @@ export class LoggingContentGenerator implements ContentGenerator {
       context.with(spanContext, () =>
         this.safelyLogApiError('', durationMs, error, req.model, userPromptId),
       );
+      const aborted = req.config?.abortSignal?.aborted ?? false;
       endLLMRequestSpan(llmSpan, {
         success: false,
         durationMs,
-        error: API_CALL_FAILED_SPAN_STATUS_MESSAGE,
+        error: aborted
+          ? API_CALL_ABORTED_SPAN_STATUS_MESSAGE
+          : API_CALL_FAILED_SPAN_STATUS_MESSAGE,
       });
       try {
         await this.safelyLogOpenAIInteraction(
@@ -358,6 +372,7 @@ export class LoggingContentGenerator implements ContentGenerator {
         resolvedRequest,
         llmSpan,
         spanContext,
+        req.config?.abortSignal,
       ),
     );
   }
@@ -392,6 +407,7 @@ export class LoggingContentGenerator implements ContentGenerator {
     openaiRequest?: OpenAI.Chat.ChatCompletionCreateParams,
     span?: Span,
     spanContext?: Context,
+    abortSignal?: AbortSignal,
   ): AsyncGenerator<GenerateContentResponse> {
     const isInternal = isInternalPromptId(userPromptId);
     // Skip collecting full responses for internal prompts to avoid memory
@@ -521,13 +537,16 @@ export class LoggingContentGenerator implements ContentGenerator {
       // own ended guard, but we want to avoid pretending the final token
       // counts were recorded — they weren't, the span is the timeout one.
       if (span && !spanEndedByTimeout) {
+        const aborted = abortSignal?.aborted ?? false;
         endLLMRequestSpan(span, {
           success: !errorOccurred,
           inputTokens: lastUsageMetadata?.promptTokenCount,
           outputTokens: lastUsageMetadata?.candidatesTokenCount,
           durationMs: Date.now() - startTime,
           error: errorOccurred
-            ? API_CALL_FAILED_SPAN_STATUS_MESSAGE
+            ? aborted
+              ? API_CALL_ABORTED_SPAN_STATUS_MESSAGE
+              : API_CALL_FAILED_SPAN_STATUS_MESSAGE
             : undefined,
         });
       }

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -20,13 +20,7 @@ import {
   type FinishReason,
 } from '@google/genai';
 import type OpenAI from 'openai';
-import {
-  SpanStatusCode,
-  context,
-  trace,
-  type Context,
-  type Span,
-} from '@opentelemetry/api';
+import { context, trace, type Context, type Span } from '@opentelemetry/api';
 import {
   ApiRequestEvent,
   ApiResponseEvent,
@@ -56,11 +50,10 @@ import {
   getErrorType,
 } from '../../utils/errors.js';
 import {
-  API_CALL_FAILED_SPAN_STATUS_MESSAGE,
-  safeSetStatus,
-  startSpanWithContext,
-  withSpan,
-} from '../../telemetry/tracer.js';
+  startLLMRequestSpan,
+  endLLMRequestSpan,
+} from '../../telemetry/index.js';
+import { API_CALL_FAILED_SPAN_STATUS_MESSAGE } from '../../telemetry/tracer.js';
 
 const debugLogger = createDebugLogger('LOGGING_CONTENT_GENERATOR');
 
@@ -210,88 +203,81 @@ export class LoggingContentGenerator implements ContentGenerator {
     req: GenerateContentParameters,
     userPromptId: string,
   ): Promise<GenerateContentResponse> {
-    return withSpan(
-      'api.generateContent',
-      { model: req.model, prompt_id: userPromptId },
-      async (span) => {
-        const startTime = Date.now();
-        const isInternal = isInternalPromptId(userPromptId);
-        const session = this.startCaptureSession();
-        try {
-          if (!isInternal) {
-            this.logApiRequest(
-              this.toContents(req.contents),
-              req.model,
-              userPromptId,
-            );
-          }
-          const response = await session.wrap(() =>
-            this.wrapped.generateContent(req, userPromptId),
-          );
-          const durationMs = Date.now() - startTime;
-          const responseText = isInternal
-            ? undefined
-            : this.extractResponseText(response);
-          this.safelyLogApiResponse(
-            response.responseId ?? '',
-            durationMs,
-            response.modelVersion || req.model,
-            userPromptId,
-            response.usageMetadata,
-            responseText,
-          );
-          try {
-            await this.safelyLogOpenAIInteraction(
-              await session.resolve(req),
-              response,
-              undefined,
-              userPromptId,
-            );
-          } catch (loggingError) {
-            debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
-          }
-          return response;
-        } catch (error) {
-          const durationMs = Date.now() - startTime;
-          this.safelyLogApiError(
-            '',
-            durationMs,
-            error,
-            req.model,
-            userPromptId,
-          );
-          try {
-            await this.safelyLogOpenAIInteraction(
-              await session.resolve(req),
-              undefined,
-              error,
-              userPromptId,
-            );
-          } catch (loggingError) {
-            debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
-          }
-          safeSetStatus(span, {
-            code: SpanStatusCode.ERROR,
-            message: API_CALL_FAILED_SPAN_STATUS_MESSAGE,
-          });
-          throw error;
-        }
-      },
-    );
+    const llmSpan = startLLMRequestSpan(req.model, userPromptId);
+    const startTime = Date.now();
+    const isInternal = isInternalPromptId(userPromptId);
+    const session = this.startCaptureSession();
+    try {
+      if (!isInternal) {
+        this.logApiRequest(
+          this.toContents(req.contents),
+          req.model,
+          userPromptId,
+        );
+      }
+      const response = await session.wrap(() =>
+        this.wrapped.generateContent(req, userPromptId),
+      );
+      const durationMs = Date.now() - startTime;
+      const responseText = isInternal
+        ? undefined
+        : this.extractResponseText(response);
+      this.safelyLogApiResponse(
+        response.responseId ?? '',
+        durationMs,
+        response.modelVersion || req.model,
+        userPromptId,
+        response.usageMetadata,
+        responseText,
+      );
+      try {
+        await this.safelyLogOpenAIInteraction(
+          await session.resolve(req),
+          response,
+          undefined,
+          userPromptId,
+        );
+      } catch (loggingError) {
+        debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
+      }
+      endLLMRequestSpan(llmSpan, {
+        success: true,
+        inputTokens: response.usageMetadata?.promptTokenCount,
+        outputTokens: response.usageMetadata?.candidatesTokenCount,
+        durationMs,
+      });
+      return response;
+    } catch (error) {
+      const durationMs = Date.now() - startTime;
+      this.safelyLogApiError('', durationMs, error, req.model, userPromptId);
+      try {
+        await this.safelyLogOpenAIInteraction(
+          await session.resolve(req),
+          undefined,
+          error,
+          userPromptId,
+        );
+      } catch (loggingError) {
+        debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
+      }
+      endLLMRequestSpan(llmSpan, {
+        success: false,
+        durationMs,
+        error: API_CALL_FAILED_SPAN_STATUS_MESSAGE,
+      });
+      throw error;
+    }
   }
 
   async generateContentStream(
     req: GenerateContentParameters,
     userPromptId: string,
   ): Promise<AsyncGenerator<GenerateContentResponse>> {
-    const { span, runInContext } = startSpanWithContext(
-      'api.generateContentStream',
-      { model: req.model, prompt_id: userPromptId },
-    );
+    const llmSpan = startLLMRequestSpan(req.model, userPromptId);
 
     // Capture the span context so the stream wrapper can activate it
     // during iteration — not just during generator creation.
-    const spanContext = trace.setSpan(context.active(), span);
+    const spanContext = trace.setSpan(context.active(), llmSpan);
 
     const startTime = Date.now();
     const isInternal = isInternalPromptId(userPromptId);
@@ -299,7 +285,7 @@ export class LoggingContentGenerator implements ContentGenerator {
 
     let stream: AsyncGenerator<GenerateContentResponse>;
     try {
-      stream = await runInContext(async () => {
+      stream = await context.with(spanContext, async () => {
         if (!isInternal) {
           this.logApiRequest(
             this.toContents(req.contents),
@@ -312,19 +298,15 @@ export class LoggingContentGenerator implements ContentGenerator {
         );
       });
     } catch (error) {
-      safeSetStatus(span, {
-        code: SpanStatusCode.ERROR,
-        message: API_CALL_FAILED_SPAN_STATUS_MESSAGE,
-      });
       const durationMs = Date.now() - startTime;
-      runInContext(() =>
+      context.with(spanContext, () =>
         this.safelyLogApiError('', durationMs, error, req.model, userPromptId),
       );
-      try {
-        span.end();
-      } catch {
-        // OTel errors must not mask the original API error
-      }
+      endLLMRequestSpan(llmSpan, {
+        success: false,
+        durationMs,
+        error: API_CALL_FAILED_SPAN_STATUS_MESSAGE,
+      });
       try {
         await this.safelyLogOpenAIInteraction(
           await session.resolve(req),
@@ -347,14 +329,14 @@ export class LoggingContentGenerator implements ContentGenerator {
       }
     }
 
-    return runInContext(() =>
+    return context.with(spanContext, () =>
       this.loggingStreamWrapper(
         stream,
         startTime,
         userPromptId,
         req.model,
         resolvedRequest,
-        span,
+        llmSpan,
         spanContext,
       ),
     );
@@ -402,8 +384,7 @@ export class LoggingContentGenerator implements ContentGenerator {
     let firstResponseId = '';
     let firstModelVersion = '';
     let lastUsageMetadata: GenerateContentResponseUsageMetadata | undefined;
-    let terminalStatusAttempted = false;
-    let spanEnded = false;
+    let errorOccurred = false;
 
     // Helper to run code within the span context during iteration.
     // This ensures debug log lines emitted during stream processing
@@ -419,20 +400,18 @@ export class LoggingContentGenerator implements ContentGenerator {
     let spanEndTimeout: ReturnType<typeof setTimeout> | undefined;
     const resetSpanTimeout = span
       ? () => {
-          if (spanEnded) return;
           if (spanEndTimeout !== undefined) clearTimeout(spanEndTimeout);
           spanEndTimeout = setTimeout(() => {
             try {
-              safeSetStatus(span, {
-                code: SpanStatusCode.ERROR,
-                message: 'Stream span timed out (idle)',
-              });
-              spanEnded = true;
               span.setAttribute('stream.timed_out', true);
-              span.end();
             } catch {
               // OTel errors must not interrupt the consumer.
             }
+            endLLMRequestSpan(span, {
+              success: false,
+              durationMs: Date.now() - startTime,
+              error: 'Stream span timed out (idle)',
+            });
           }, STREAM_IDLE_TIMEOUT_MS);
           spanEndTimeout.unref();
         }
@@ -485,11 +464,8 @@ export class LoggingContentGenerator implements ContentGenerator {
           userPromptId,
         ),
       );
-      terminalStatusAttempted = true;
-      if (span) {
-        safeSetStatus(span, { code: SpanStatusCode.OK });
-      }
     } catch (error) {
+      errorOccurred = true;
       const durationMs = Date.now() - startTime;
       runInSpan(() =>
         this.safelyLogApiError(
@@ -508,29 +484,21 @@ export class LoggingContentGenerator implements ContentGenerator {
           userPromptId,
         ),
       );
-      terminalStatusAttempted = true;
-      if (span) {
-        safeSetStatus(span, {
-          code: SpanStatusCode.ERROR,
-          message: API_CALL_FAILED_SPAN_STATUS_MESSAGE,
-        });
-      }
       throw error;
     } finally {
       if (spanEndTimeout !== undefined) {
         clearTimeout(spanEndTimeout);
       }
-      if (!spanEnded) {
-        if (!terminalStatusAttempted) {
-          if (span) {
-            safeSetStatus(span, { code: SpanStatusCode.OK });
-          }
-        }
-        try {
-          span?.end();
-        } catch {
-          // OTel errors must not mask the original API error
-        }
+      if (span) {
+        endLLMRequestSpan(span, {
+          success: !errorOccurred,
+          inputTokens: lastUsageMetadata?.promptTokenCount,
+          outputTokens: lastUsageMetadata?.candidatesTokenCount,
+          durationMs: Date.now() - startTime,
+          error: errorOccurred
+            ? API_CALL_FAILED_SPAN_STATUS_MESSAGE
+            : undefined,
+        });
       }
     }
   }

--- a/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
+++ b/packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts
@@ -209,62 +209,72 @@ export class LoggingContentGenerator implements ContentGenerator {
     } catch {
       /* best-effort */
     }
+    // Capture span context so the API call and logging activate it via
+    // context.with(). Without this, nested OTel spans (HTTP instrumentation,
+    // log-bridge spans) parent to session root instead of llm_request.
+    const spanContext = trace.setSpan(context.active(), llmSpan);
+
     const startTime = Date.now();
     const isInternal = isInternalPromptId(userPromptId);
     const session = this.startCaptureSession();
     try {
-      if (!isInternal) {
-        this.logApiRequest(
-          this.toContents(req.contents),
-          req.model,
-          userPromptId,
+      const response = await context.with(spanContext, async () => {
+        if (!isInternal) {
+          this.logApiRequest(
+            this.toContents(req.contents),
+            req.model,
+            userPromptId,
+          );
+        }
+        const result = await session.wrap(() =>
+          this.wrapped.generateContent(req, userPromptId),
         );
-      }
-      const response = await session.wrap(() =>
-        this.wrapped.generateContent(req, userPromptId),
-      );
-      const durationMs = Date.now() - startTime;
-      const responseText = isInternal
-        ? undefined
-        : this.extractResponseText(response);
-      this.safelyLogApiResponse(
-        response.responseId ?? '',
-        durationMs,
-        response.modelVersion || req.model,
-        userPromptId,
-        response.usageMetadata,
-        responseText,
-      );
-      try {
-        await this.safelyLogOpenAIInteraction(
-          await session.resolve(req),
-          response,
-          undefined,
+        const durationMs = Date.now() - startTime;
+        const responseText = isInternal
+          ? undefined
+          : this.extractResponseText(result);
+        this.safelyLogApiResponse(
+          result.responseId ?? '',
+          durationMs,
+          result.modelVersion || req.model,
           userPromptId,
+          result.usageMetadata,
+          responseText,
         );
-      } catch (loggingError) {
-        debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
-      }
+        try {
+          await this.safelyLogOpenAIInteraction(
+            await session.resolve(req),
+            result,
+            undefined,
+            userPromptId,
+          );
+        } catch (loggingError) {
+          debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
+        }
+        return result;
+      });
       endLLMRequestSpan(llmSpan, {
         success: true,
         inputTokens: response.usageMetadata?.promptTokenCount,
         outputTokens: response.usageMetadata?.candidatesTokenCount,
-        durationMs,
+        durationMs: Date.now() - startTime,
       });
       return response;
     } catch (error) {
       const durationMs = Date.now() - startTime;
-      this.safelyLogApiError('', durationMs, error, req.model, userPromptId);
-      try {
-        await this.safelyLogOpenAIInteraction(
-          await session.resolve(req),
-          undefined,
-          error,
-          userPromptId,
-        );
-      } catch (loggingError) {
-        debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
-      }
+      await context.with(spanContext, async () => {
+        this.safelyLogApiError('', durationMs, error, req.model, userPromptId);
+        try {
+          await this.safelyLogOpenAIInteraction(
+            await session.resolve(req),
+            undefined,
+            error,
+            userPromptId,
+          );
+        } catch (loggingError) {
+          debugLogger.warn('Failed to log OpenAI interaction:', loggingError);
+        }
+      });
       endLLMRequestSpan(llmSpan, {
         success: false,
         durationMs,

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -143,6 +143,7 @@ export {
   endLLMRequestSpan,
   startToolSpan,
   endToolSpan,
+  runInToolSpanContext,
   startToolExecutionSpan,
   endToolExecutionSpan,
   clearSessionTracingForTesting,

--- a/packages/core/src/telemetry/session-tracing.test.ts
+++ b/packages/core/src/telemetry/session-tracing.test.ts
@@ -95,6 +95,7 @@ vi.mock('@opentelemetry/api', async () => {
     },
     context: {
       active: () => ({}),
+      with: <T>(_ctx: unknown, fn: () => T): T => fn(),
     },
   };
 });

--- a/packages/core/src/telemetry/session-tracing.test.ts
+++ b/packages/core/src/telemetry/session-tracing.test.ts
@@ -107,6 +107,7 @@ import {
   endLLMRequestSpan,
   startToolSpan,
   endToolSpan,
+  runInToolSpanContext,
   startToolExecutionSpan,
   endToolExecutionSpan,
   clearSessionTracingForTesting,
@@ -348,11 +349,11 @@ describe('session-tracing', () => {
       expect(mockSpans[0]!.statuses[0]!.message).toBe('command failed');
     });
 
-    it('defaults to OK when success is undefined', () => {
+    it('does not set status when no metadata is passed', () => {
       const span = startToolSpan('Read');
       endToolSpan(span);
 
-      expect(mockSpans[0]!.statuses[0]!.code).toBe(SpanStatusCode.OK);
+      expect(mockSpans[0]!.statuses).toHaveLength(0);
     });
 
     it('concurrent tool spans are isolated', () => {
@@ -388,12 +389,17 @@ describe('session-tracing', () => {
   });
 
   describe('tool execution sub-spans', () => {
-    it('creates a tool execution span as child of tool span', () => {
+    it('creates a tool execution span as child of tool span via runInToolSpanContext', () => {
       const toolSpan = startToolSpan('Bash');
-      const execSpan = startToolExecutionSpan(toolSpan);
+
+      let execSpan!: ReturnType<typeof startToolExecutionSpan>;
+      runInToolSpanContext(toolSpan, () => {
+        execSpan = startToolExecutionSpan();
+      });
 
       expect(mockSpans).toHaveLength(2);
       expect(mockSpans[1]!.name).toBe('qwen-code.tool.execution');
+      expect(mockSpans[1]!.parentContext).toBeDefined();
 
       endToolExecutionSpan(execSpan, { success: true });
       endToolSpan(toolSpan, { success: true });
@@ -403,10 +409,72 @@ describe('session-tracing', () => {
 
     it('returns NOOP span when SDK is not initialized', () => {
       mockState.sdkInitialized = false;
-      const toolSpan = startToolSpan('Bash');
-      const execSpan = startToolExecutionSpan(toolSpan);
+      const _toolSpan = startToolSpan('Bash');
+      const execSpan = startToolExecutionSpan();
 
       expect(execSpan.spanContext().traceId).toBe('0'.repeat(32));
+    });
+
+    it('falls back gracefully when no tool span is active', () => {
+      const execSpan = startToolExecutionSpan();
+
+      expect(mockSpans).toHaveLength(1);
+      expect(mockSpans[0]!.name).toBe('qwen-code.tool.execution');
+
+      endToolExecutionSpan(execSpan, { success: true });
+      expect(mockSpans[0]!.ended).toBe(true);
+    });
+  });
+
+  describe('toolContext ALS lifecycle', () => {
+    it('runInToolSpanContext scopes toolContext via run(), not enterWith', () => {
+      const toolSpan = startToolSpan('Bash');
+
+      let execSpanInsideContext: ReturnType<typeof startToolExecutionSpan>;
+
+      runInToolSpanContext(toolSpan, () => {
+        execSpanInsideContext = startToolExecutionSpan();
+      });
+      const execSpanOutsideContext = startToolExecutionSpan();
+
+      // Inside context: should have parent
+      const insideRecord = mockSpans.find(
+        (s) =>
+          s.name === 'qwen-code.tool.execution' &&
+          (s.parentContext as Record<string, unknown>)?.__parentSpan,
+      );
+      expect(insideRecord).toBeDefined();
+
+      // Outside context: should NOT have tool parent
+      const outsideRecord = mockSpans.filter(
+        (s) => s.name === 'qwen-code.tool.execution',
+      );
+      expect(outsideRecord).toHaveLength(2);
+      const noParent = outsideRecord.find(
+        (s) => !(s.parentContext as Record<string, unknown>)?.__parentSpan,
+      );
+      expect(noParent).toBeDefined();
+
+      endToolExecutionSpan(execSpanInsideContext!, { success: true });
+      endToolExecutionSpan(execSpanOutsideContext!, { success: true });
+      endToolSpan(toolSpan, { success: true });
+    });
+
+    it('endToolSpan without metadata preserves pre-set status', () => {
+      const toolSpan = startToolSpan('Bash');
+      // Simulate setToolSpanFailure calling setStatus directly
+      (
+        toolSpan as unknown as MockSpanRecord & {
+          setStatus: (s: { code: number; message?: string }) => void;
+        }
+      ).setStatus({ code: SpanStatusCode.ERROR, message: 'hook blocked' });
+
+      endToolSpan(toolSpan);
+
+      // endToolSpan should NOT have added another status
+      const toolRecord = mockSpans.find((s) => s.name === 'qwen-code.tool');
+      expect(toolRecord!.statuses).toHaveLength(1);
+      expect(toolRecord!.statuses[0]!.code).toBe(SpanStatusCode.ERROR);
     });
   });
 

--- a/packages/core/src/telemetry/session-tracing.test.ts
+++ b/packages/core/src/telemetry/session-tracing.test.ts
@@ -9,6 +9,10 @@ import { SpanStatusCode } from '@opentelemetry/api';
 
 const mockState = vi.hoisted(() => ({
   sdkInitialized: true,
+  // Toggles to force span.setAttributes/setStatus to throw — exercises the
+  // try/catch hardening in end*Span helpers (span.end() must still run).
+  throwOnSetAttributes: false,
+  throwOnSetStatus: false,
 }));
 
 vi.mock('./sdk.js', () => ({
@@ -61,10 +65,16 @@ vi.mock('@opentelemetry/api', async () => {
         traceFlags: 0,
       }),
       setAttributes: (attrs: Record<string, unknown>) => {
+        if (mockState.throwOnSetAttributes) {
+          throw new Error('setAttributes failed');
+        }
         record.setAttributesCalls.push(attrs);
         Object.assign(record.attributes, attrs);
       },
       setStatus: (status: { code: number; message?: string }) => {
+        if (mockState.throwOnSetStatus) {
+          throw new Error('setStatus failed');
+        }
         record.statuses.push(status);
       },
       end: () => {
@@ -131,6 +141,8 @@ describe('session-tracing', () => {
     clearSessionTracingForTesting();
     mockSpans.length = 0;
     mockState.sdkInitialized = true;
+    mockState.throwOnSetAttributes = false;
+    mockState.throwOnSetStatus = false;
   });
 
   afterEach(() => {
@@ -499,6 +511,61 @@ describe('session-tracing', () => {
 
       // Sequence should be reset to 1
       expect(mockSpans[0]!.attributes['interaction.sequence']).toBe(1);
+    });
+  });
+
+  describe('OTel error resilience — span.end() must run on attribute/status failure', () => {
+    it('endLLMRequestSpan: end() runs and activeSpans is cleared when setStatus throws', () => {
+      const span = startLLMRequestSpan('test-model', 'prompt-x');
+      const record = mockSpans.find((s) => s.name === 'qwen-code.llm_request')!;
+
+      mockState.throwOnSetStatus = true;
+      endLLMRequestSpan(span, { success: true });
+
+      expect(record.ended).toBe(true);
+      // Idempotency: a second call must short-circuit (spanCtx removed from activeSpans).
+      mockState.throwOnSetStatus = false;
+      endLLMRequestSpan(span, { success: true });
+      expect(record.statuses).toHaveLength(0); // no recovery status added
+    });
+
+    it('endLLMRequestSpan: end() runs when setAttributes throws', () => {
+      const span = startLLMRequestSpan('test-model', 'prompt-x');
+      const record = mockSpans.find((s) => s.name === 'qwen-code.llm_request')!;
+
+      mockState.throwOnSetAttributes = true;
+      endLLMRequestSpan(span, { success: true });
+
+      expect(record.ended).toBe(true);
+    });
+
+    it('endToolSpan: end() runs when setStatus throws', () => {
+      const span = startToolSpan('Bash');
+      const record = mockSpans.find((s) => s.name === 'qwen-code.tool')!;
+
+      mockState.throwOnSetStatus = true;
+      endToolSpan(span, { success: true });
+
+      expect(record.ended).toBe(true);
+    });
+
+    it('endToolExecutionSpan: end() runs when setAttributes throws', () => {
+      const toolSpan = startToolSpan('Bash');
+      let execSpan!: ReturnType<typeof startToolExecutionSpan>;
+      runInToolSpanContext(toolSpan, () => {
+        execSpan = startToolExecutionSpan();
+      });
+      const execRecord = mockSpans.find(
+        (s) => s.name === 'qwen-code.tool.execution',
+      )!;
+
+      mockState.throwOnSetAttributes = true;
+      endToolExecutionSpan(execSpan, { success: true });
+
+      expect(execRecord.ended).toBe(true);
+
+      mockState.throwOnSetAttributes = false;
+      endToolSpan(toolSpan, { success: true });
     });
   });
 });

--- a/packages/core/src/telemetry/session-tracing.test.ts
+++ b/packages/core/src/telemetry/session-tracing.test.ts
@@ -409,7 +409,7 @@ describe('session-tracing', () => {
 
     it('returns NOOP span when SDK is not initialized', () => {
       mockState.sdkInitialized = false;
-      const _toolSpan = startToolSpan('Bash');
+      startToolSpan('Bash');
       const execSpan = startToolExecutionSpan();
 
       expect(execSpan.spanContext().traceId).toBe('0'.repeat(32));
@@ -441,7 +441,7 @@ describe('session-tracing', () => {
       const insideRecord = mockSpans.find(
         (s) =>
           s.name === 'qwen-code.tool.execution' &&
-          (s.parentContext as Record<string, unknown>)?.__parentSpan,
+          (s.parentContext as Record<string, unknown>)?.['__parentSpan'],
       );
       expect(insideRecord).toBeDefined();
 
@@ -451,7 +451,7 @@ describe('session-tracing', () => {
       );
       expect(outsideRecord).toHaveLength(2);
       const noParent = outsideRecord.find(
-        (s) => !(s.parentContext as Record<string, unknown>)?.__parentSpan,
+        (s) => !(s.parentContext as Record<string, unknown>)?.['__parentSpan'],
       );
       expect(noParent).toBeDefined();
 

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -62,6 +62,9 @@ interface SpanContext {
     | 'llm_request'
     | 'tool'
     | 'tool.execution'
+    // Phase 2 forward-declarations (no start*/end* helpers wired yet —
+    // see docs/design/workflow-tracing-gaps.md). Listed here so Phase 2
+    // can add helpers without touching this type.
     | 'tool.blocked_on_user'
     | 'hook';
 }
@@ -453,13 +456,18 @@ export function endToolExecutionSpan(
 
     spanCtx.span.setAttributes(endAttributes);
 
-    if (metadata?.success !== false) {
-      spanCtx.span.setStatus({ code: SpanStatusCode.OK });
-    } else {
-      spanCtx.span.setStatus({
-        code: SpanStatusCode.ERROR,
-        message: metadata?.error ?? 'tool execution error',
-      });
+    // No-metadata-no-status: matches endToolSpan. Callers that pre-set
+    // status (e.g. via setToolSpanCancelled) and then call this without
+    // metadata get their pre-set status preserved.
+    if (metadata) {
+      if (metadata.success !== false) {
+        spanCtx.span.setStatus({ code: SpanStatusCode.OK });
+      } else {
+        spanCtx.span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: metadata.error ?? 'tool execution error',
+        });
+      }
     }
   } catch (error) {
     debugLogger.warn(

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -53,7 +53,13 @@ interface SpanContext {
   startTime: number;
   attributes: Record<string, string | number | boolean>;
   ended?: boolean;
-  type: 'interaction' | 'llm_request' | 'tool' | 'tool.execution';
+  type:
+    | 'interaction'
+    | 'llm_request'
+    | 'tool'
+    | 'tool.execution'
+    | 'tool.blocked_on_user'
+    | 'hook';
 }
 
 const NOOP_SPAN = trace.wrapSpanContext({
@@ -63,6 +69,7 @@ const NOOP_SPAN = trace.wrapSpanContext({
 });
 
 const interactionContext = new AsyncLocalStorage<SpanContext | undefined>();
+const toolContext = new AsyncLocalStorage<SpanContext | undefined>();
 
 const activeSpans = new Map<string, WeakRef<SpanContext>>();
 const strongSpans = new Map<string, SpanContext>();
@@ -222,30 +229,34 @@ export function endLLMRequestSpan(
 
   spanCtx.ended = true;
 
-  const duration = metadata?.durationMs ?? Date.now() - spanCtx.startTime;
-  const endAttributes: Attributes = { duration_ms: duration };
+  try {
+    const duration = metadata?.durationMs ?? Date.now() - spanCtx.startTime;
+    const endAttributes: Attributes = { duration_ms: duration };
 
-  if (metadata) {
-    if (metadata.inputTokens !== undefined)
-      endAttributes['input_tokens'] = metadata.inputTokens;
-    if (metadata.outputTokens !== undefined)
-      endAttributes['output_tokens'] = metadata.outputTokens;
-    endAttributes['success'] = metadata.success;
-    if (metadata.error !== undefined) endAttributes['error'] = metadata.error;
+    if (metadata) {
+      if (metadata.inputTokens !== undefined)
+        endAttributes['input_tokens'] = metadata.inputTokens;
+      if (metadata.outputTokens !== undefined)
+        endAttributes['output_tokens'] = metadata.outputTokens;
+      endAttributes['success'] = metadata.success;
+      if (metadata.error !== undefined) endAttributes['error'] = metadata.error;
+    }
+
+    span.setAttributes(endAttributes);
+
+    if (metadata === undefined || metadata.success) {
+      span.setStatus({ code: SpanStatusCode.OK });
+    } else {
+      span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: metadata.error ?? 'unknown error',
+      });
+    }
+
+    span.end();
+  } catch {
+    // OTel errors must not affect API behavior.
   }
-
-  span.setAttributes(endAttributes);
-
-  if (metadata === undefined || metadata.success) {
-    span.setStatus({ code: SpanStatusCode.OK });
-  } else {
-    span.setStatus({
-      code: SpanStatusCode.ERROR,
-      message: metadata.error ?? 'unknown error',
-    });
-  }
-
-  span.end();
   activeSpans.delete(spanId);
   strongSpans.delete(spanId);
 }
@@ -289,6 +300,18 @@ export function startToolSpan(
   return span;
 }
 
+/**
+ * Runs a callback within the tool span's AsyncLocalStorage context.
+ * Use this instead of enterWith() to scope the context to a single
+ * async call tree — safe for concurrent tool calls.
+ */
+export function runInToolSpanContext<T>(span: Span, fn: () => T): T {
+  const spanId = getSpanId(span);
+  const spanCtx = activeSpans.get(spanId)?.deref();
+  if (!spanCtx) return fn();
+  return toolContext.run(spanCtx, fn);
+}
+
 export function endToolSpan(span: Span, metadata?: ToolSpanMetadata): void {
   const spanId = getSpanId(span);
   const spanCtx = activeSpans.get(spanId)?.deref();
@@ -296,39 +319,48 @@ export function endToolSpan(span: Span, metadata?: ToolSpanMetadata): void {
 
   spanCtx.ended = true;
 
-  const duration = Date.now() - spanCtx.startTime;
-  const endAttributes: Attributes = { duration_ms: duration };
+  try {
+    const duration = Date.now() - spanCtx.startTime;
+    const endAttributes: Attributes = { duration_ms: duration };
 
-  if (metadata) {
-    if (metadata.success !== undefined)
-      endAttributes['success'] = metadata.success;
-    if (metadata.error !== undefined) endAttributes['error'] = metadata.error;
+    if (metadata) {
+      if (metadata.success !== undefined)
+        endAttributes['success'] = metadata.success;
+      if (metadata.error !== undefined) endAttributes['error'] = metadata.error;
+    }
+
+    spanCtx.span.setAttributes(endAttributes);
+
+    if (metadata) {
+      if (metadata.success !== false) {
+        spanCtx.span.setStatus({ code: SpanStatusCode.OK });
+      } else {
+        spanCtx.span.setStatus({
+          code: SpanStatusCode.ERROR,
+          message: metadata.error ?? 'tool error',
+        });
+      }
+    }
+
+    spanCtx.span.end();
+  } catch {
+    // OTel errors must not affect tool scheduling.
   }
-
-  spanCtx.span.setAttributes(endAttributes);
-
-  if (metadata?.success !== false) {
-    spanCtx.span.setStatus({ code: SpanStatusCode.OK });
-  } else {
-    spanCtx.span.setStatus({
-      code: SpanStatusCode.ERROR,
-      message: metadata?.error ?? 'tool error',
-    });
-  }
-
-  spanCtx.span.end();
   activeSpans.delete(spanId);
   strongSpans.delete(spanId);
 }
 
 // --- Tool Execution Sub-Spans ---
 
-export function startToolExecutionSpan(parentToolSpan: Span): Span {
+export function startToolExecutionSpan(): Span {
   if (!isTelemetrySdkInitialized()) {
     return NOOP_SPAN;
   }
 
-  const ctx = trace.setSpan(otelContext.active(), parentToolSpan);
+  const parentCtx = toolContext.getStore();
+  const ctx = parentCtx
+    ? trace.setSpan(otelContext.active(), parentCtx.span)
+    : otelContext.active();
 
   const span = getTracer().startSpan(
     SPAN_TOOL_EXECUTION,
@@ -362,27 +394,31 @@ export function endToolExecutionSpan(
 
   spanCtx.ended = true;
 
-  const duration = Date.now() - spanCtx.startTime;
-  const endAttributes: Attributes = { duration_ms: duration };
+  try {
+    const duration = Date.now() - spanCtx.startTime;
+    const endAttributes: Attributes = { duration_ms: duration };
 
-  if (metadata) {
-    if (metadata.success !== undefined)
-      endAttributes['success'] = metadata.success;
-    if (metadata.error !== undefined) endAttributes['error'] = metadata.error;
+    if (metadata) {
+      if (metadata.success !== undefined)
+        endAttributes['success'] = metadata.success;
+      if (metadata.error !== undefined) endAttributes['error'] = metadata.error;
+    }
+
+    spanCtx.span.setAttributes(endAttributes);
+
+    if (metadata?.success !== false) {
+      spanCtx.span.setStatus({ code: SpanStatusCode.OK });
+    } else {
+      spanCtx.span.setStatus({
+        code: SpanStatusCode.ERROR,
+        message: metadata?.error ?? 'tool execution error',
+      });
+    }
+
+    spanCtx.span.end();
+  } catch {
+    // OTel errors must not affect tool scheduling.
   }
-
-  spanCtx.span.setAttributes(endAttributes);
-
-  if (metadata?.success !== false) {
-    spanCtx.span.setStatus({ code: SpanStatusCode.OK });
-  } else {
-    spanCtx.span.setStatus({
-      code: SpanStatusCode.ERROR,
-      message: metadata?.error ?? 'tool execution error',
-    });
-  }
-
-  spanCtx.span.end();
   activeSpans.delete(spanId);
   strongSpans.delete(spanId);
 }
@@ -393,6 +429,7 @@ export function clearSessionTracingForTesting(): void {
   activeSpans.clear();
   strongSpans.clear();
   interactionContext.enterWith(undefined);
+  toolContext.enterWith(undefined);
   interactionSequence = 0;
   lastInteractionCtx = undefined;
 }

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -22,6 +22,9 @@ import {
   SPAN_TOOL_EXECUTION,
 } from './constants.js';
 import { isTelemetrySdkInitialized } from './sdk.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
+
+const debugLogger = createDebugLogger('SESSION_TRACING');
 
 type InteractionStatus = 'ok' | 'error' | 'cancelled';
 
@@ -254,8 +257,10 @@ export function endLLMRequestSpan(
     }
 
     span.end();
-  } catch {
-    // OTel errors must not affect API behavior.
+  } catch (error) {
+    debugLogger.warn(
+      `Failed to end LLM request span: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
   activeSpans.delete(spanId);
   strongSpans.delete(spanId);
@@ -312,6 +317,12 @@ export function runInToolSpanContext<T>(span: Span, fn: () => T): T {
   return toolContext.run(spanCtx, fn);
 }
 
+/**
+ * When metadata is omitted, span status is NOT set — callers on failure paths
+ * must pre-set status via setToolSpanFailure/setToolSpanCancelled before calling
+ * this. This asymmetry with endLLMRequestSpan (which defaults to OK) is intentional:
+ * tool spans have multiple failure modes that set status before endToolSpan runs.
+ */
 export function endToolSpan(span: Span, metadata?: ToolSpanMetadata): void {
   const spanId = getSpanId(span);
   const spanCtx = activeSpans.get(spanId)?.deref();
@@ -343,8 +354,10 @@ export function endToolSpan(span: Span, metadata?: ToolSpanMetadata): void {
     }
 
     spanCtx.span.end();
-  } catch {
-    // OTel errors must not affect tool scheduling.
+  } catch (error) {
+    debugLogger.warn(
+      `Failed to end tool span: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
   activeSpans.delete(spanId);
   strongSpans.delete(spanId);
@@ -358,6 +371,11 @@ export function startToolExecutionSpan(): Span {
   }
 
   const parentCtx = toolContext.getStore();
+  if (!parentCtx) {
+    debugLogger.warn(
+      'startToolExecutionSpan called outside runInToolSpanContext — span will not be parented to tool span',
+    );
+  }
   const ctx = parentCtx
     ? trace.setSpan(otelContext.active(), parentCtx.span)
     : otelContext.active();
@@ -416,8 +434,10 @@ export function endToolExecutionSpan(
     }
 
     spanCtx.span.end();
-  } catch {
-    // OTel errors must not affect tool scheduling.
+  } catch (error) {
+    debugLogger.warn(
+      `Failed to end tool execution span: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
   activeSpans.delete(spanId);
   strongSpans.delete(spanId);

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -237,6 +237,11 @@ export function endLLMRequestSpan(
 
   spanCtx.ended = true;
 
+  // Use spanCtx.span for mutations to stay consistent with endToolSpan/
+  // endToolExecutionSpan. (It's the same object as the passed `span`
+  // since we just looked it up by spanId — but matching the lookup
+  // pattern across helpers prevents subtle drift if the lookup ever
+  // gains caching/normalization.)
   try {
     const duration = metadata?.durationMs ?? Date.now() - spanCtx.startTime;
     const endAttributes: Attributes = { duration_ms: duration };
@@ -250,12 +255,12 @@ export function endLLMRequestSpan(
       if (metadata.error !== undefined) endAttributes['error'] = metadata.error;
     }
 
-    span.setAttributes(endAttributes);
+    spanCtx.span.setAttributes(endAttributes);
 
     if (metadata === undefined || metadata.success) {
-      span.setStatus({ code: SpanStatusCode.OK });
+      spanCtx.span.setStatus({ code: SpanStatusCode.OK });
     } else {
-      span.setStatus({
+      spanCtx.span.setStatus({
         code: SpanStatusCode.ERROR,
         message: metadata.error ?? 'unknown error',
       });
@@ -268,7 +273,7 @@ export function endLLMRequestSpan(
   // span.end() must run even if attribute/status updates threw,
   // otherwise the span leaks (never exported, never cleared from activeSpans).
   try {
-    span.end();
+    spanCtx.span.end();
   } catch (error) {
     debugLogger.warn(
       `Failed to end LLM request span: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -22,6 +22,7 @@ import {
   SPAN_TOOL_EXECUTION,
 } from './constants.js';
 import { isTelemetrySdkInitialized } from './sdk.js';
+import { getSessionContext } from './session-context.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 
 const debugLogger = createDebugLogger('SESSION_TRACING');
@@ -193,9 +194,13 @@ export function startLLMRequestSpan(model: string, promptId: string): Span {
   }
 
   const parentCtx = interactionContext.getStore();
+  // Fall back to session root context (deterministic traceId from sessionId)
+  // for side-query LLM calls (auto-title, recap, etc.) that run outside an
+  // interaction. Without this, those spans start a fresh trace and lose
+  // correlation with the session.
   const ctx = parentCtx
     ? trace.setSpan(otelContext.active(), parentCtx.span)
-    : otelContext.active();
+    : (getSessionContext() ?? otelContext.active());
 
   const attributes: Attributes = {
     'qwen-code.model': model,
@@ -284,9 +289,10 @@ export function startToolSpan(
   }
 
   const parentCtx = interactionContext.getStore();
+  // Same session-root fallback as startLLMRequestSpan.
   const ctx = parentCtx
     ? trace.setSpan(otelContext.active(), parentCtx.span)
-    : otelContext.active();
+    : (getSessionContext() ?? otelContext.active());
 
   const attributes: Attributes = {
     'tool.name': toolName,
@@ -396,7 +402,7 @@ export function startToolExecutionSpan(): Span {
   }
   const ctx = parentCtx
     ? trace.setSpan(otelContext.active(), parentCtx.span)
-    : otelContext.active();
+    : (getSessionContext() ?? otelContext.active());
 
   const span = getTracer().startSpan(
     SPAN_TOOL_EXECUTION,

--- a/packages/core/src/telemetry/session-tracing.ts
+++ b/packages/core/src/telemetry/session-tracing.ts
@@ -255,7 +255,14 @@ export function endLLMRequestSpan(
         message: metadata.error ?? 'unknown error',
       });
     }
-
+  } catch (error) {
+    debugLogger.warn(
+      `Failed to update LLM request span attributes/status: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  // span.end() must run even if attribute/status updates threw,
+  // otherwise the span leaks (never exported, never cleared from activeSpans).
+  try {
     span.end();
   } catch (error) {
     debugLogger.warn(
@@ -306,15 +313,20 @@ export function startToolSpan(
 }
 
 /**
- * Runs a callback within the tool span's AsyncLocalStorage context.
- * Use this instead of enterWith() to scope the context to a single
- * async call tree — safe for concurrent tool calls.
+ * Runs a callback within the tool span's AsyncLocalStorage context AND
+ * OpenTelemetry context. Use this instead of enterWith() to scope the
+ * context to a single async call tree — safe for concurrent tool calls.
+ *
+ * Setting the OTel context ensures any nested OTel spans/logs emitted
+ * during the callback (HTTP instrumentation, hooks, log-bridge spans)
+ * inherit the tool span as parent.
  */
 export function runInToolSpanContext<T>(span: Span, fn: () => T): T {
   const spanId = getSpanId(span);
   const spanCtx = activeSpans.get(spanId)?.deref();
   if (!spanCtx) return fn();
-  return toolContext.run(spanCtx, fn);
+  const otelCtxWithSpan = trace.setSpan(otelContext.active(), span);
+  return toolContext.run(spanCtx, () => otelContext.with(otelCtxWithSpan, fn));
 }
 
 /**
@@ -352,7 +364,13 @@ export function endToolSpan(span: Span, metadata?: ToolSpanMetadata): void {
         });
       }
     }
-
+  } catch (error) {
+    debugLogger.warn(
+      `Failed to update tool span attributes/status: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  // span.end() must run even if attribute/status updates threw.
+  try {
     spanCtx.span.end();
   } catch (error) {
     debugLogger.warn(
@@ -432,7 +450,13 @@ export function endToolExecutionSpan(
         message: metadata?.error ?? 'tool execution error',
       });
     }
-
+  } catch (error) {
+    debugLogger.warn(
+      `Failed to update tool execution span attributes/status: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  // span.end() must run even if attribute/status updates threw.
+  try {
     spanCtx.span.end();
   } catch (error) {
     debugLogger.warn(


### PR DESCRIPTION
## Summary

Replaces disconnected `withSpan`/`startSpanWithContext` calls in runtime with session-tracing typed helpers, fixing the trace tree so LLM and tool spans become **children** of the interaction span instead of siblings under the session root.

**Before** (flat — all spans are siblings):
```
session-root
  interaction
  api.generateContent
  tool.Bash
  tool.Read
```

**After** (hierarchical — proper parent-child):
```
interaction
  llm_request
  tool
    tool.execution
  tool
    tool.execution
  llm_request
```

### Key changes

- **`session-tracing.ts`**: Add `toolContext` ALS with `runInToolSpanContext()` for concurrent-safe tool span scoping (uses `AsyncLocalStorage.run`, not `enterWith`); change `startToolExecutionSpan` to read parent from `toolContext`; fix `endToolSpan` to not override pre-set status when metadata is omitted (documented via JSDoc); add `debugLogger.warn` in all `end*Span` catch blocks for OTel error visibility; warn when `startToolExecutionSpan` called outside `runInToolSpanContext`
- **`loggingContentGenerator.ts`**: Wire `startLLMRequestSpan`/`endLLMRequestSpan` for both streaming and non-streaming paths, replacing `withSpan`/`startSpanWithContext`; integrate upstream `spanEndTimeout` idle mechanism with `endLLMRequestSpan` idempotency; add `llm_request.stream` attribute to distinguish streaming vs non-streaming
- **`coreToolScheduler.ts`**: Wire `startToolSpan`/`endToolSpan` + `startToolExecutionSpan`/`endToolExecutionSpan` with `try/finally` lifecycle; extract `_executeToolCallBody` for clean span scoping; sanitize error in `endToolExecutionSpan` (use constant instead of raw message); set OK status in success path via `safeSetStatus`
- **`client.ts`**: Remove redundant `withSpan('client.generateContent')` wrapper (LLM span now created in loggingContentGenerator); preserve abort error propagation
- **Tests**: Update mocks for new span APIs; mock `session-tracing.js` directly for reliable interception; add `toolContext` ALS scoping tests
- **Design doc**: Add `docs/design/workflow-tracing-gaps.md` with full gap analysis and Phase 1-3 roadmap

### Part of #3731 (P3 Deeper observability — Phase 1)

Phase 1 focuses on unifying span creation paths. Phase 2 (blocked_on_user + hook spans) and Phase 3 (subagent trace tree) tracked in the parent issue.

> **Note**: #4097 adds detailed span attributes on top of these spans. After this PR merges, #4097 needs a rebase to target the new span variables (`llmSpan`, `toolSpan`) and `_executeToolCallBody` structure.

### Phase 1.5 follow-ups → #4212

Non-blocking polish items from late review rounds (parent fallback order, exec span on abort-as-result, mock missing constant, idle timeout vs API log inconsistency) are tracked in #4212 — none of these affect the trace tree this PR fixes.

## Test plan

- [x] `npx vitest run packages/core/src/telemetry/session-tracing.test.ts` — 23 tests pass
- [x] `npx vitest run packages/core/src/core/coreToolScheduler.test.ts` — 119 tests pass
- [x] `npx vitest run packages/core/src/core/loggingContentGenerator/loggingContentGenerator.test.ts` — 32 tests pass
- [x] `npx vitest run packages/core/src/core/client.test.ts` — 104 tests pass
- [x] `npx tsc --noEmit` — zero new type errors
- [x] ESLint + Prettier pass (pre-commit hooks)
- [x] CI Lint pass
- [ ] CI Tests (pending latest push)
- [x] E2E trace verification (see below)

## E2E trace verification

```bash
rm -f /tmp/spans-test.jsonl
QWEN_TELEMETRY_ENABLED=1 \
QWEN_TELEMETRY_OUTFILE=/tmp/spans-test.jsonl \
node packages/cli/dist/index.js --prompt "what is 2+2" --max-session-turns 1
```

Verify parent-child relationships:
```bash
cat /tmp/spans-test.jsonl | jq -s '[.[] | select(.name != null and .name != "") | {
  name, spanId: ._spanContext.spanId[0:12],
  parentSpanId: (.parentSpanContext.spanId // "ROOT")[0:12],
  status: .status.code,
  stream: .attributes["llm_request.stream"],
  tool: .attributes["tool.name"]
}]'
```

**Actual output:**

```json
[
  {"name":"qwen-code.llm_request","spanId":"a11e955e775f","parentSpanId":"1a88a402e766","status":2,"stream":false,"tool":null},
  {"name":"qwen-code.llm_request","spanId":"b52fc1e4267d","parentSpanId":"1a88a402e766","status":1,"stream":true,"tool":null},
  {"name":"qwen-code.interaction","spanId":"1a88a402e766","parentSpanId":"ROOT","status":1,"stream":null,"tool":null},
  {"name":"qwen-code.llm_request","spanId":"e46925657044","parentSpanId":"1a88a402e766","status":1,"stream":true,"tool":null},
  {"name":"qwen-code.tool.execution","spanId":"31c2ee6fb1f5","parentSpanId":"4709050c8523","status":1,"stream":null,"tool":null},
  {"name":"qwen-code.tool","spanId":"4709050c8523","parentSpanId":"1a88a402e766","status":1,"stream":null,"tool":"read_file"},
  {"name":"qwen-code.tool.execution","spanId":"7df917fb02cd","parentSpanId":"0ccbfe610d63","status":1,"stream":null,"tool":null},
  {"name":"qwen-code.tool","spanId":"0ccbfe610d63","parentSpanId":"1a88a402e766","status":1,"stream":null,"tool":"read_file"},
  {"name":"qwen-code.llm_request","spanId":"4c3ae4665b69","parentSpanId":"1a88a402e766","status":1,"stream":true,"tool":null}
]
```

**Expected trace tree (confirmed):**

```
qwen-code.interaction (1a88) — ROOT
  ├── qwen-code.llm_request (a11e) — parent=1a88 ✅ stream=false
  ├── qwen-code.llm_request (b52f) — parent=1a88 ✅ stream=true
  ├── qwen-code.llm_request (e469) — parent=1a88 ✅ stream=true
  ├── qwen-code.tool (4709) — parent=1a88 ✅ tool=read_file
  │   └── qwen-code.tool.execution (31c2) — parent=4709 ✅
  ├── qwen-code.tool (0ccb) — parent=1a88 ✅ tool=read_file
  │   └── qwen-code.tool.execution (7df9) — parent=0ccb ✅
  └── qwen-code.llm_request (4c3a) — parent=1a88 ✅ stream=true
```

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)
