### PR TITLE
ci(deps): bump docker/* actions to Node 24 majors (silences GitHub Node 20 deprecation warning)

### DIFF
--- a/.github/workflows/build-and-publish-image.yml
+++ b/.github/workflows/build-and-publish-image.yml
@@ -67,14 +67,14 @@ jobs:
           echo "GitHub ref: ${{ github.ref }}"
 
       - name: 'Set up QEMU'
-        uses: 'docker/setup-qemu-action@v3' # ratchet:exclude
+        uses: 'docker/setup-qemu-action@v4' # ratchet:exclude
 
       - name: 'Set up Docker Buildx'
-        uses: 'docker/setup-buildx-action@v3' # ratchet:exclude
+        uses: 'docker/setup-buildx-action@v4' # ratchet:exclude
 
       - name: 'Extract metadata (tags, labels) for Docker'
         id: 'meta'
-        uses: 'docker/metadata-action@v5' # ratchet:exclude
+        uses: 'docker/metadata-action@v6' # ratchet:exclude
         with:
           images: '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}'
           tags: |
@@ -89,7 +89,7 @@ jobs:
       - name: 'Log in to the Container registry'
         if: |-
           ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true') }}
-        uses: 'docker/login-action@v3' # ratchet:exclude
+        uses: 'docker/login-action@v4' # ratchet:exclude
         with:
           registry: '${{ env.REGISTRY }}'
           username: '${{ github.actor }}'
@@ -97,7 +97,7 @@ jobs:
 
       - name: 'Build and push Docker image'
         id: 'build-and-push'
-        uses: 'docker/build-push-action@v6' # ratchet:exclude
+        uses: 'docker/build-push-action@v7' # ratchet:exclude
         with:
           context: '.'
           platforms: 'linux/amd64,linux/arm64'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -58,7 +58,7 @@ jobs:
       - name: 'Set up Docker'
         if: |-
           ${{ matrix.sandbox == 'sandbox:docker' }}
-        uses: 'docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435' # ratchet:docker/setup-buildx-action@v3
+        uses: 'docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd' # ratchet:docker/setup-buildx-action@v4
 
       - name: 'Set up Podman'
         if: |-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,7 +266,7 @@ jobs:
           npm ci --no-audit --progress=false
 
       - name: 'Set up Docker'
-        uses: 'docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435' # ratchet:docker/setup-buildx-action@v3
+        uses: 'docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd' # ratchet:docker/setup-buildx-action@v4
 
       - name: 'Build Sandbox'
         env:


### PR DESCRIPTION
## Summary

GitHub Actions deprecates the Node 20 runtime for actions. Release / e2e / image-build runs currently emit:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: \`docker/setup-buildx-action\`...

Each \`docker/*\` action shipped a "Node 24 as default runtime" major that silences this:

| action | from | to | release |
|---|---|---|---|
| \`docker/setup-buildx-action\` | v3 | **v4** | 2026-03-05 |
| \`docker/setup-qemu-action\`  | v3 | **v4** | — |
| \`docker/metadata-action\`    | v5 | **v6** | — |
| \`docker/login-action\`        | v3 | **v4** | — |
| \`docker/build-push-action\`  | v6 | **v7** | — |

## Compatibility

None of our usages touch the deprecated inputs/outputs removed in these majors:
- \`release.yml\` / \`e2e.yml\` call \`setup-buildx-action\` with **no \`with:\` block** at all
- \`build-and-publish-image.yml\` only passes the universally-supported inputs (\`images\` / \`tags\` / \`registry\` / \`username\` / \`password\` / \`context\` / \`platforms\` / \`push\` / \`labels\` / \`build-args\`)
- The internal ESM refactor inside each action is transparent to consumers

\`actions/runner\` v2.327.1+ (required for Node 24) has been the default on GitHub-hosted runners since 2026-03, so no infra bump is required.

## Pin format

- Ratchet-pinned references (\`release.yml\`, \`e2e.yml\`) get the v4.0.0 commit SHA \`4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd\` + updated comment tag.
- Manual \`# ratchet:exclude\` pins in \`build-and-publish-image.yml\` get plain version-string bumps per existing convention.

## Test plan

- [x] \`grep -rn "docker/" .github/workflows/\` → all five actions now reference their new major
- [ ] CI runs cleanly on this PR (Lint + per-OS Test pass — these workflows don't trigger here, but no syntactic regression introduced)
- [ ] Manual: trigger \`Release\` workflow on a test tag and confirm the deprecation warning is gone

🤖 Generated with [Qwen Code](https://qwen.ai/qwencode)