### PR TITLE
feat(skills): add /stuck diagnostic skill for frozen sessions

### DIFF
--- a/packages/core/src/skills/bundled-skills.integration.test.ts
+++ b/packages/core/src/skills/bundled-skills.integration.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { parseSkillContent } from './skill-load.js';
+
+// Bundled skills are loaded from disk at runtime by SkillManager. A typo in
+// frontmatter (missing `description`, malformed YAML, broken `---` delimiter,
+// `allowedTools` written as a scalar instead of a list, ...) currently fails
+// only when a user invokes the skill — `skill-manager.ts` swallows the parse
+// error and emits a debug log, so CI stays green. This integration test parses
+// every shipped SKILL.md against the real loader so any frontmatter regression
+// fails CI immediately.
+
+const bundledDir = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'bundled',
+);
+
+const skillNames = fs
+  .readdirSync(bundledDir, { withFileTypes: true })
+  .filter((d) => d.isDirectory())
+  .map((d) => d.name);
+
+describe('bundled SKILL.md files', () => {
+  it('discovers at least one bundled skill', () => {
+    expect(skillNames.length).toBeGreaterThan(0);
+  });
+
+  it.each(skillNames)('%s/SKILL.md parses with required fields', (name) => {
+    const file = path.join(bundledDir, name, 'SKILL.md');
+    const content = fs.readFileSync(file, 'utf8');
+    const cfg = parseSkillContent(content, file);
+
+    expect(cfg.name).toBe(name);
+    expect(cfg.description).toBeTruthy();
+    expect(cfg.body.length).toBeGreaterThan(0);
+    if (cfg.allowedTools !== undefined) {
+      expect(Array.isArray(cfg.allowedTools)).toBe(true);
+    }
+  });
+});

--- a/packages/core/src/skills/bundled/stuck/SKILL.md
+++ b/packages/core/src/skills/bundled/stuck/SKILL.md
@@ -40,16 +40,20 @@ RUNTIME_DIR="${RUNTIME_DIR:-${QWEN_HOME:-$HOME/.qwen}}"
 
 (If `jq` isn't installed, the settings layer is silently skipped — the env-var / default fallback covers the common case.)
 
-**Fast path for targeted diagnosis** — if a digit-only PID argument was given, skip step 1 enumeration but still match the PID to its sidecar so step 3 has the right session ID for log lookup:
+**Fast path for targeted diagnosis** — if a digit-only PID argument was given, skip step 1 enumeration. First validate that the PID is a live current-user Qwen Code process; if not, refuse and stop. Without this check, a same-user non-Qwen PID (e.g., a `node my-other-app.js --api-key=...`) would have its full command line dumped into the report.
 
 ```
-kill -0 <pid> 2>/dev/null \
-  && ps -p <pid> -o pid=,pcpu=,rss=,etime=,state=,comm=,command= -ww \
-  || echo "PID <pid> is not running"
+kill -0 <pid> 2>/dev/null && ps -p <pid> -o command= -ww 2>/dev/null | grep -qE '(qwen|node.*qwen|bun.*qwen)'
+```
+
+If this pipeline returns non-zero (PID dead, owned by another user, or not a Qwen Code process), stop the diagnostic and tell the user "PID `<pid>` is not a current-user Qwen Code session". Otherwise, gather stats and the sidecar mapping, then jump to step 3:
+
+```
+ps -p <pid> -o pid=,pcpu=,rss=,etime=,state=,comm=,command= -ww
 grep -l '"pid"[[:space:]]*:[[:space:]]*<pid>\b' "$RUNTIME_DIR"/projects/*/chats/*.runtime.json 2>/dev/null
 ```
 
-The `grep -l` returns the sidecar file path (if any); the basename (stripped of `.runtime.json`) is the session ID for step 3's debug log read. Then jump to step 3.
+The `grep -l` returns the sidecar file path (if any); the basename (stripped of `.runtime.json`) is the session ID for step 3's debug log read.
 
 Otherwise (no arg, or symptom-only arg), run the general path below:
 

--- a/packages/core/src/skills/bundled/stuck/SKILL.md
+++ b/packages/core/src/skills/bundled/stuck/SKILL.md
@@ -26,19 +26,24 @@ Signs of a stuck session:
 
 ## Argument validation
 
-If the user gave an argument, first check whether it is a positive integer (PID). If it contains shell metacharacters (`$`, `;`, `|`, `&`, `` ` ``, `(`, `)`, `<`, `>`, `*`, `?`, backslash, quote, whitespace, etc.), refuse to proceed and tell the user the argument does not look like a valid PID. Treat free-text symptom descriptions as guidance for the report, not as values to substitute into shell commands.
+If the user gave an argument, treat it as a PID **only if it consists entirely of digits 0-9**. Anything else — letters, whitespace, punctuation — fails the check, in which case treat it as a free-text symptom description (guidance for the report only, never substituted into shell commands). The strict digit-only whitelist is safer than enumerating shell metacharacters.
 
 ## Investigation steps
 
-1. **Enumerate live sessions via the runtime sidecar (preferred, reliable)**:
+1. **Resolve the runtime base directory**, then enumerate live sessions via the runtime sidecar (preferred, reliable):
 
-   Qwen Code writes a `runtime.json` sidecar for each interactive session at `<runtime-base>/projects/<sanitized-cwd>/chats/<sessionId>.runtime.json`. The default `<runtime-base>` is `~/.qwen` (overridable by `QWEN_RUNTIME_DIR`, `QWEN_HOME`, or the `advanced.runtimeOutputDir` setting). Each file contains `{schema_version, pid, session_id, work_dir, hostname, started_at, qwen_version}`. Use this as the authoritative source of `(pid, session_id, work_dir)` mappings:
+   Qwen Code writes a `runtime.json` sidecar for each interactive session at `<runtime-base>/projects/<sanitized-cwd>/chats/<sessionId>.runtime.json`. The base directory is taken from (in priority order): `QWEN_RUNTIME_DIR`, `QWEN_HOME`, the `advanced.runtimeOutputDir` setting, and finally `~/.qwen`. Use the resolved value in every command below — substituting the literal default would silently miss sessions on machines that override it.
 
    ```
-   ls -1 ~/.qwen/projects/*/chats/*.runtime.json 2>/dev/null
+   RUNTIME_DIR="${QWEN_RUNTIME_DIR:-${QWEN_HOME:-$HOME/.qwen}}"
+   ls -1 "$RUNTIME_DIR"/projects/*/chats/*.runtime.json 2>/dev/null
    ```
+
+   (If the user has set `advanced.runtimeOutputDir` in `settings.json`, ask them or read it from settings; otherwise the env-var resolution above is correct.) Each sidecar file contains `{schema_version, pid, session_id, work_dir, hostname, started_at, qwen_version}` — the authoritative source of `(pid, session_id, work_dir)` mappings.
 
    For each file, read it and check whether the recorded `pid` is still alive (`kill -0 <pid>` returns 0). Stale files where the PID is gone mean the session has exited — skip them silently. PID reuse is rare but possible, so when you cross-reference with `ps` in step 2, also skip records whose live PID's command line no longer looks like a Qwen Code process.
+
+   **If no sidecar files are found** (empty output, or the directory does not exist), fall through to step 2 — `ps` is the working fallback.
 
 2. **List Qwen Code processes via `ps`** (macOS/Linux) — used to enrich each live session with CPU/RSS/state/uptime, and to catch sessions that may have started before the sidecar feature existed:
 
@@ -50,15 +55,17 @@ If the user gave an argument, first check whether it is a positive integer (PID)
 
    Note: `ps` reports `rss` in **kilobytes** on both macOS and Linux. Divide by 1024 before comparing to the >=4GB threshold or reporting in MB.
 
+   Note: full command lines may contain credentials passed as CLI args (e.g., `--openai-api-key=sk-…`). Redact such values to `***` before quoting them in the report.
+
 3. **For anything suspicious**, gather more context. Substitute `<pid>` only after the validation in "Argument validation" above (or after taking it from `ps` / sidecar output, which is trusted):
    - Child processes (with state, so a hung `git` / `node` shows up): `pgrep -P <pid>` to get child PIDs, then `ps -p <child_pids> -o pid=,ppid=,pcpu=,state=,etime=,command=` for their state
    - If high CPU: sample again after 1-2s to confirm it's sustained
-   - Check the session's debug log if you can infer the session ID (from the sidecar): `~/.qwen/debug/<session-id>.txt` (the last few hundred lines often show what it was doing before hanging). If `QWEN_RUNTIME_DIR` or `QWEN_HOME` is set, the debug directory is `$QWEN_RUNTIME_DIR/debug/` or `$QWEN_HOME/debug/` instead of the default. Debug logs may contain prompts, file contents, or tokens from other sessions — paste only the lines relevant to the hang, and never quote secrets/API keys you happen to see.
-   - The `~/.qwen/debug/latest` symlink points to the most recent session's log
+   - Check the session's debug log if you can infer the session ID (from the sidecar): `"$RUNTIME_DIR"/debug/<session-id>.txt` using the same `RUNTIME_DIR` resolved in step 1. The last few hundred lines often show what it was doing before hanging. Debug logs may contain prompts, file contents, or tokens from other sessions — paste only the lines relevant to the hang, and never quote secrets/API keys you happen to see.
+   - The `"$RUNTIME_DIR"/debug/latest` symlink points to the most recent session's log
 
 4. **Consider a stack dump** for a truly frozen process (advanced, optional):
-   - macOS: `sample <pid> 3` gives a 3-second native stack sample
-   - Linux: `cat /proc/<pid>/stack` for kernel stack, or `strace -p <pid> -c -f` for syscall profile
+   - macOS: `sample <pid> 3` gives a 3-second native stack sample. Stack frames may include function arguments containing API keys or tokens held in memory — redact such values to `***` before including the dump in the report.
+   - Linux: `cat /proc/<pid>/stack` for kernel stack (read-only, no `ptrace` permissions needed). Avoid `strace -p` for this purpose: it requires `CAP_SYS_PTRACE` (often denied under `kernel.yama.ptrace_scope=1`), and `strace -c` blocks until the target exits — it would hang on the very kind of stuck process you are diagnosing.
    - This is big — only grab it if the process is clearly hung and you want to know _why_
 
 ## Report
@@ -75,6 +82,8 @@ Present a structured diagnostic report directly to the user with these sections:
 - Suggested next step for the user to decide (e.g., "user may consider `kill <pid>` if the session is unresponsive", "likely waiting on I/O — check disk", "accidentally stopped — user can resume with `kill -CONT <pid>`"). Do not execute these actions yourself — present them as options for the user.
 
 **If every session looks healthy**, tell the user directly — no diagnostic dump needed. Mention how many sessions you checked and that none showed signs of being stuck.
+
+**If no sessions are found at all** (zero sidecars and zero matching `ps` rows), say so explicitly: which `RUNTIME_DIR` you searched and that `ps` returned no qwen-related processes for the current user. Suggest the session may have already exited.
 
 ## Notes
 

--- a/packages/core/src/skills/bundled/stuck/SKILL.md
+++ b/packages/core/src/skills/bundled/stuck/SKILL.md
@@ -22,7 +22,7 @@ Signs of a stuck session:
 - **Process state `T` (stopped)** — user probably hit Ctrl+Z by accident.
 - **Process state `Z` (zombie)** — parent isn't reaping.
 - **Very high RSS (>=4GB)** — possible memory leak making the session sluggish.
-- **Stuck child process** — a hung `git`, `node`, or shell subprocess can freeze the parent. Check `pgrep -lP <pid>` for each session.
+- **Stuck child process** — a hung `git`, `node`, or shell subprocess can freeze the parent. Check `pgrep -P <pid>` (then `ps -p` for state — see step 3) for each session.
 
 ## Argument validation
 
@@ -57,7 +57,7 @@ If the user gave an argument, treat it as a PID **only if it consists entirely o
 
    Note: full command lines may contain credentials passed as CLI args (e.g., `--openai-api-key=sk-…`). Redact such values to `***` before quoting them in the report.
 
-3. **For anything suspicious**, gather more context. Substitute `<pid>` only after the validation in "Argument validation" above (or after taking it from `ps` / sidecar output, which is trusted):
+3. **For anything suspicious**, gather more context. If the process state alone explains the problem (`T` = accidentally stopped, `Z` = parent not reaping), skip directly to the report — child / log / stack inspection adds nothing. Otherwise, substitute `<pid>` only after the validation in "Argument validation" above (or after taking it from `ps` / sidecar output, which is trusted):
    - Child processes (with state, so a hung `git` / `node` shows up): `pgrep -P <pid>` to get child PIDs, then `ps -p <child_pids> -o pid=,ppid=,pcpu=,state=,etime=,command=` for their state
    - If high CPU: sample again after 1-2s to confirm it's sustained
    - Check the session's debug log if you can infer the session ID (from the sidecar): `"$RUNTIME_DIR"/debug/<session-id>.txt` using the same `RUNTIME_DIR` resolved in step 1. The last few hundred lines often show what it was doing before hanging. Debug logs may contain prompts, file contents, or tokens from other sessions — paste only the lines relevant to the hang, and never quote secrets/API keys you happen to see.

--- a/packages/core/src/skills/bundled/stuck/SKILL.md
+++ b/packages/core/src/skills/bundled/stuck/SKILL.md
@@ -30,6 +30,16 @@ If the user gave an argument, treat it as a PID **only if it consists entirely o
 
 ## Investigation steps
 
+**Fast path for targeted diagnosis** — if a digit-only PID argument was given, skip steps 1-2 (enumeration). Verify the PID is alive, grab its stats, and jump to step 3:
+
+```
+kill -0 <pid> 2>/dev/null && \
+  ps -p <pid> -o pid=,pcpu=,rss=,etime=,state=,comm=,command= -ww \
+  || echo "PID <pid> is not running"
+```
+
+Otherwise (no arg, or symptom-only arg), run the general path below:
+
 1. **Resolve the runtime base directory**, then enumerate live sessions via the runtime sidecar (preferred, reliable):
 
    Qwen Code writes a `runtime.json` sidecar for each interactive session at `<runtime-base>/projects/<sanitized-cwd>/chats/<sessionId>.runtime.json`. The base directory is taken from (in priority order): `QWEN_RUNTIME_DIR` env var, the `advanced.runtimeOutputDir` setting, `QWEN_HOME` env var, and finally `~/.qwen`. Use the resolved value in every command below — substituting the literal default would silently miss sessions on machines that override it.
@@ -43,7 +53,16 @@ If the user gave an argument, treat it as a PID **only if it consists entirely o
 
    (The `jq` line gracefully degrades — if `jq` isn't installed or `settings.json` doesn't exist, the next line falls back to `QWEN_HOME` or the default.) Each sidecar file contains `{schema_version, pid, session_id, work_dir, hostname, started_at, qwen_version}` — the authoritative source of `(pid, session_id, work_dir)` mappings.
 
-   For each file, read it and check whether the recorded `pid` is still alive (`kill -0 <pid>` returns 0). Stale files where the PID is gone mean the session has exited — skip them silently. PID reuse is rare but possible, so when you cross-reference with `ps` in step 2, also skip records whose live PID's command line no longer looks like a Qwen Code process.
+   Then filter to live PIDs in one pass (avoids reading every stale sidecar individually):
+
+   ```
+   for f in "$RUNTIME_DIR"/projects/*/chats/*.runtime.json; do
+     pid=$(jq -r .pid "$f" 2>/dev/null)
+     [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && echo "$pid $f"
+   done
+   ```
+
+   Only the live `(pid, sidecar-path)` pairs reach the report. PID reuse is rare but possible — when you cross-reference with `ps` in step 2, skip pairs whose live PID's command line no longer looks like a Qwen Code process.
 
    **If no sidecar files are found** (empty output, or the directory does not exist), fall through to step 2 — `ps` is the working fallback.
 
@@ -59,11 +78,11 @@ If the user gave an argument, treat it as a PID **only if it consists entirely o
 
    Note: full command lines may contain credentials passed as CLI args (e.g., `--openai-api-key=sk-…`). Redact such values to `***` before quoting them in the report.
 
-3. **For anything suspicious**, gather more context. If the process state alone explains the problem (`T` = accidentally stopped, `Z` = parent not reaping), skip directly to the report — child / log / stack inspection adds nothing. Otherwise, substitute `<pid>` only after the validation in "Argument validation" above (or after taking it from `ps` / sidecar output, which is trusted):
-   - Child processes (with state, so a hung `git` / `node` shows up): `pgrep -P <pid>` to get child PIDs, then `ps -p <child_pids> -o pid=,ppid=,pcpu=,state=,etime=,command=` for their state
+3. **For anything suspicious**, gather more context. If the process state alone explains the problem (`T` = accidentally stopped, `Z` = parent not reaping), skip directly to the report — child / log / stack inspection adds nothing. Otherwise:
+   - Child processes (with state, so a hung `git` / `node` shows up): `pgrep -P <pid> | xargs -I{} ps -p {} -o pid=,ppid=,pcpu=,state=,etime=,command=`
    - If high CPU: sample again after 1-2s to confirm it's sustained
-   - Check the session's debug log if you can infer the session ID (from the sidecar): `"$RUNTIME_DIR"/debug/<session-id>.txt` using the same `RUNTIME_DIR` resolved in step 1. The last few hundred lines often show what it was doing before hanging. Debug logs may contain prompts, file contents, or tokens from other sessions — paste only the lines relevant to the hang, and never quote secrets/API keys you happen to see.
-   - The `"$RUNTIME_DIR"/debug/latest` symlink points to the most recent session's log
+   - **Network hang** — if CPU is low and state is `S` despite the user reporting "stuck", the most likely cause is a hung HTTPS request to the model API. macOS: `lsof -i -p <pid> 2>/dev/null | head -20`. Linux: `ss -tnp 2>/dev/null | grep "pid=<pid>,"`. A long-lived `ESTABLISHED` connection to a model host (dashscope, openai, anthropic, etc.) with no recent traffic is the smoking gun.
+   - **Debug log** — start with `"$RUNTIME_DIR"/debug/latest` (symlink to the most recent session); if it matches the suspicious PID's session, that's usually the right one. Otherwise infer the session ID from the sidecar and read `"$RUNTIME_DIR"/debug/<session-id>.txt`. Bound the read with `tail -n 200 <path>` — debug logs can be GB-sized. The last few hundred lines typically show what the session was doing before hanging. Debug logs may contain prompts, file contents, or tokens from other sessions — paste only lines relevant to the hang, and never quote secrets/API keys you happen to see.
 
 4. **Consider a stack dump** for a truly frozen process (advanced, optional):
    - macOS: `sample <pid> 3` gives a 3-second native stack sample. Stack frames may include function arguments containing API keys or tokens held in memory — redact such values to `***` before including the dump in the report.

--- a/packages/core/src/skills/bundled/stuck/SKILL.md
+++ b/packages/core/src/skills/bundled/stuck/SKILL.md
@@ -18,30 +18,44 @@ Scan for other Qwen Code processes (excluding the current one — exclude the PI
 Signs of a stuck session:
 
 - **High CPU (>=90%) sustained** — likely an infinite loop. Sample twice, 1-2s apart, to confirm it's not a transient spike.
-- **Process state `D` (uninterruptible sleep)** — often an I/O hang. The `state` column in `ps` output; first character matters (ignore modifiers like `+`, `s`, `<`).
+- **Process state `D` / `U` (uninterruptible sleep)** — often an I/O hang. Linux uses `D`, macOS/BSD uses `U`. The `state` column in `ps` output; first character matters (ignore modifiers like `+`, `s`, `<`).
 - **Process state `T` (stopped)** — user probably hit Ctrl+Z by accident.
 - **Process state `Z` (zombie)** — parent isn't reaping.
 - **Very high RSS (>=4GB)** — possible memory leak making the session sluggish.
 - **Stuck child process** — a hung `git`, `node`, or shell subprocess can freeze the parent. Check `pgrep -lP <pid>` for each session.
 
+## Argument validation
+
+If the user gave an argument, first check whether it is a positive integer (PID). If it contains shell metacharacters (`$`, `;`, `|`, `&`, `` ` ``, `(`, `)`, `<`, `>`, `*`, `?`, backslash, quote, whitespace, etc.), refuse to proceed and tell the user the argument does not look like a valid PID. Treat free-text symptom descriptions as guidance for the report, not as values to substitute into shell commands.
+
 ## Investigation steps
 
-1. **List all Qwen Code processes** (macOS/Linux):
+1. **Enumerate live sessions via the runtime sidecar (preferred, reliable)**:
+
+   Qwen Code writes a `runtime.json` sidecar for each interactive session at `<runtime-base>/projects/<sanitized-cwd>/chats/<sessionId>.runtime.json`. The default `<runtime-base>` is `~/.qwen` (overridable by `QWEN_RUNTIME_DIR` or `QWEN_HOME`). Each file contains `{schema_version, pid, session_id, work_dir, hostname, started_at, qwen_version}`. Use this as the authoritative source of `(pid, session_id, work_dir)` mappings:
 
    ```
-   ps -axo pid=,pcpu=,rss=,etime=,state=,comm=,command= | grep -E '(qwen|node.*qwen|bun.*qwen)' | grep -v grep
+   ls -1 ~/.qwen/projects/*/chats/*.runtime.json 2>/dev/null
    ```
 
-   The `comm` column will be `node` or `bun`, not `qwen`. Filter to rows where the `command` column contains a path related to qwen (e.g., `qwen-code/dist/cli.js`, or a bin symlink ending in `/qwen`).
+   For each file, read it and check whether the recorded `pid` is still alive (`kill -0 <pid>` returns 0). Stale files where the PID is gone mean the session has exited — skip them silently.
 
-2. **For anything suspicious**, gather more context:
+2. **List Qwen Code processes via `ps`** (macOS/Linux) — used to enrich each live session with CPU/RSS/state/uptime, and to catch sessions that may have started before the sidecar feature existed:
+
+   ```
+   ps -axo pid=,pcpu=,rss=,etime=,state=,comm=,command= -ww | grep -E '(qwen|node.*qwen|bun.*qwen)' | grep -v grep
+   ```
+
+   The `-ww` flag disables column truncation — without it, long command paths get cut off and `grep` may miss sessions whose "qwen" path component falls beyond the terminal width. The `comm` column will be `node` or `bun`, not `qwen`. Filter to rows where the `command` column contains a path related to qwen (e.g., `qwen-code/dist/cli.js`, or a bin symlink ending in `/qwen`). Cross-reference with the PIDs from step 1.
+
+3. **For anything suspicious**, gather more context. Substitute `<pid>` only after the validation in "Argument validation" above (or after taking it from `ps` / sidecar output, which is trusted):
    - Child processes: `pgrep -lP <pid>`
    - If high CPU: sample again after 1-2s to confirm it's sustained
    - If a child looks hung (e.g., a git command), note its full command line with `ps -p <child_pid> -o command=`
-   - Check the session's debug log if you can infer the session ID: `~/.qwen/debug/<session-id>.txt` (the last few hundred lines often show what it was doing before hanging). If `QWEN_RUNTIME_DIR` or `QWEN_HOME` is set, the debug directory is `$QWEN_RUNTIME_DIR/debug/` or `$QWEN_HOME/debug/` instead of the default.
+   - Check the session's debug log if you can infer the session ID (from the sidecar): `~/.qwen/debug/<session-id>.txt` (the last few hundred lines often show what it was doing before hanging). If `QWEN_RUNTIME_DIR` or `QWEN_HOME` is set, the debug directory is `$QWEN_RUNTIME_DIR/debug/` or `$QWEN_HOME/debug/` instead of the default.
    - The `~/.qwen/debug/latest` symlink points to the most recent session's log
 
-3. **Consider a stack dump** for a truly frozen process (advanced, optional):
+4. **Consider a stack dump** for a truly frozen process (advanced, optional):
    - macOS: `sample <pid> 3` gives a 3-second native stack sample
    - Linux: `cat /proc/<pid>/stack` for kernel stack, or `strace -p <pid> -c -f` for syscall profile
    - This is big — only grab it if the process is clearly hung and you want to know _why_

--- a/packages/core/src/skills/bundled/stuck/SKILL.md
+++ b/packages/core/src/skills/bundled/stuck/SKILL.md
@@ -2,6 +2,9 @@
 name: stuck
 description: Diagnose frozen, stuck, or slow Qwen Code sessions on this machine. Scans for problematic processes, high CPU/memory usage, hung subprocesses, and debug logs. Use /stuck or /stuck <PID> to focus on a specific process.
 argument-hint: '[PID or symptom]'
+allowedTools:
+  - run_shell_command
+  - read_file
 ---
 
 # /stuck — diagnose frozen/slow Qwen Code sessions
@@ -54,7 +57,7 @@ Present a structured diagnostic report directly to the user with these sections:
 - Your diagnosis of what's likely wrong
 - Relevant debug log tail if you captured it
 - Stack dump output if you captured it
-- Recommended action (e.g., "safe to kill with `kill <pid>`", "waiting on I/O — check disk", "accidentally stopped — resume with `kill -CONT <pid>`")
+- Suggested next step for the user to decide (e.g., "user may consider `kill <pid>` if the session is unresponsive", "likely waiting on I/O — check disk", "accidentally stopped — user can resume with `kill -CONT <pid>`"). Do not execute these actions yourself — present them as options for the user.
 
 **If every session looks healthy**, tell the user directly — no diagnostic dump needed. Mention how many sessions you checked and that none showed signs of being stuck.
 

--- a/packages/core/src/skills/bundled/stuck/SKILL.md
+++ b/packages/core/src/skills/bundled/stuck/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: stuck
+description: Diagnose frozen, stuck, or slow Qwen Code sessions on this machine. Scans for problematic processes, high CPU/memory usage, hung subprocesses, and debug logs. Use /stuck or /stuck <PID> to focus on a specific process.
+argument-hint: '[PID or symptom]'
+---
+
+# /stuck — diagnose frozen/slow Qwen Code sessions
+
+The user thinks another Qwen Code session on this machine is frozen, stuck, or very slow. Investigate and present a diagnostic report.
+
+## What to look for
+
+Scan for other Qwen Code processes (excluding the current one — exclude the PID you see running this prompt). Since Qwen Code is a Node.js CLI (`#!/usr/bin/env node`), the process name (`comm` column) is always `node` (or `bun` if run with Bun). Identify Qwen Code sessions by looking at the `command` column for paths containing "qwen" (e.g., `node /path/to/qwen-code/dist/cli.js` or a symlinked `qwen` script).
+
+Signs of a stuck session:
+
+- **High CPU (>=90%) sustained** — likely an infinite loop. Sample twice, 1-2s apart, to confirm it's not a transient spike.
+- **Process state `D` (uninterruptible sleep)** — often an I/O hang. The `state` column in `ps` output; first character matters (ignore modifiers like `+`, `s`, `<`).
+- **Process state `T` (stopped)** — user probably hit Ctrl+Z by accident.
+- **Process state `Z` (zombie)** — parent isn't reaping.
+- **Very high RSS (>=4GB)** — possible memory leak making the session sluggish.
+- **Stuck child process** — a hung `git`, `node`, or shell subprocess can freeze the parent. Check `pgrep -lP <pid>` for each session.
+
+## Investigation steps
+
+1. **List all Qwen Code processes** (macOS/Linux):
+
+   ```
+   ps -axo pid=,pcpu=,rss=,etime=,state=,comm=,command= | grep -E '(qwen|node.*qwen|bun.*qwen)' | grep -v grep
+   ```
+
+   The `comm` column will be `node` or `bun`, not `qwen`. Filter to rows where the `command` column contains a path related to qwen (e.g., `qwen-code/dist/cli.js`, or a bin symlink ending in `/qwen`).
+
+2. **For anything suspicious**, gather more context:
+   - Child processes: `pgrep -lP <pid>`
+   - If high CPU: sample again after 1-2s to confirm it's sustained
+   - If a child looks hung (e.g., a git command), note its full command line with `ps -p <child_pid> -o command=`
+   - Check the session's debug log if you can infer the session ID: `~/.qwen/debug/<session-id>.txt` (the last few hundred lines often show what it was doing before hanging)
+   - The `~/.qwen/debug/latest` symlink points to the most recent session's log
+
+3. **Consider a stack dump** for a truly frozen process (advanced, optional):
+   - macOS: `sample <pid> 3` gives a 3-second native stack sample
+   - Linux: `cat /proc/<pid>/stack` for kernel stack, or `strace -p <pid> -c -f` for syscall profile
+   - This is big — only grab it if the process is clearly hung and you want to know _why_
+
+## Report
+
+Present a structured diagnostic report directly to the user with these sections:
+
+**For each stuck/slow session found:**
+
+- PID, CPU%, RSS (in MB), process state, uptime, full command line
+- Child processes and their states
+- Your diagnosis of what's likely wrong
+- Relevant debug log tail if you captured it
+- Stack dump output if you captured it
+- Recommended action (e.g., "safe to kill with `kill <pid>`", "waiting on I/O — check disk", "accidentally stopped — resume with `kill -CONT <pid>`")
+
+**If every session looks healthy**, tell the user directly — no diagnostic dump needed. Mention how many sessions you checked and that none showed signs of being stuck.
+
+## Notes
+
+- Don't kill or signal any processes — this is diagnostic only.
+- If the user gave an argument (e.g., a specific PID or symptom), focus there first.

--- a/packages/core/src/skills/bundled/stuck/SKILL.md
+++ b/packages/core/src/skills/bundled/stuck/SKILL.md
@@ -30,41 +30,42 @@ If the user gave an argument, treat it as a PID **only if it consists entirely o
 
 ## Investigation steps
 
-**Fast path for targeted diagnosis** — if a digit-only PID argument was given, skip steps 1-2 (enumeration). Verify the PID is alive, grab its stats, and jump to step 3:
+**Preamble — resolve the runtime base directory.** Required for both paths below (sidecar enumeration in step 1, debug log lookup in step 3, and the PID fast path). The base directory is taken from (in priority order): `QWEN_RUNTIME_DIR` env var, the `advanced.runtimeOutputDir` setting, `QWEN_HOME` env var, and finally `~/.qwen`.
 
 ```
-kill -0 <pid> 2>/dev/null && \
-  ps -p <pid> -o pid=,pcpu=,rss=,etime=,state=,comm=,command= -ww \
-  || echo "PID <pid> is not running"
+RUNTIME_DIR="${QWEN_RUNTIME_DIR:-}"
+[ -z "$RUNTIME_DIR" ] && command -v jq >/dev/null && RUNTIME_DIR=$(jq -r '.advanced.runtimeOutputDir // empty' ~/.qwen/settings.json 2>/dev/null)
+RUNTIME_DIR="${RUNTIME_DIR:-${QWEN_HOME:-$HOME/.qwen}}"
 ```
+
+(If `jq` isn't installed, the settings layer is silently skipped — the env-var / default fallback covers the common case.)
+
+**Fast path for targeted diagnosis** — if a digit-only PID argument was given, skip step 1 enumeration but still match the PID to its sidecar so step 3 has the right session ID for log lookup:
+
+```
+kill -0 <pid> 2>/dev/null \
+  && ps -p <pid> -o pid=,pcpu=,rss=,etime=,state=,comm=,command= -ww \
+  || echo "PID <pid> is not running"
+grep -l '"pid"[[:space:]]*:[[:space:]]*<pid>\b' "$RUNTIME_DIR"/projects/*/chats/*.runtime.json 2>/dev/null
+```
+
+The `grep -l` returns the sidecar file path (if any); the basename (stripped of `.runtime.json`) is the session ID for step 3's debug log read. Then jump to step 3.
 
 Otherwise (no arg, or symptom-only arg), run the general path below:
 
-1. **Resolve the runtime base directory**, then enumerate live sessions via the runtime sidecar (preferred, reliable):
+1. **Enumerate live sessions via the runtime sidecar** (preferred, reliable):
 
-   Qwen Code writes a `runtime.json` sidecar for each interactive session at `<runtime-base>/projects/<sanitized-cwd>/chats/<sessionId>.runtime.json`. The base directory is taken from (in priority order): `QWEN_RUNTIME_DIR` env var, the `advanced.runtimeOutputDir` setting, `QWEN_HOME` env var, and finally `~/.qwen`. Use the resolved value in every command below — substituting the literal default would silently miss sessions on machines that override it.
+   Qwen Code writes a `runtime.json` sidecar for each interactive session at `"$RUNTIME_DIR"/projects/<sanitized-cwd>/chats/<sessionId>.runtime.json`. Each file contains `{schema_version, pid, session_id, work_dir, hostname, started_at, qwen_version}` — the authoritative source of `(pid, session_id, work_dir)` mappings.
 
-   ```
-   RUNTIME_DIR="${QWEN_RUNTIME_DIR:-}"
-   [ -z "$RUNTIME_DIR" ] && RUNTIME_DIR=$(jq -r '.advanced.runtimeOutputDir // empty' ~/.qwen/settings.json 2>/dev/null)
-   RUNTIME_DIR="${RUNTIME_DIR:-${QWEN_HOME:-$HOME/.qwen}}"
-   ls -1 "$RUNTIME_DIR"/projects/*/chats/*.runtime.json 2>/dev/null
-   ```
-
-   (The `jq` line gracefully degrades — if `jq` isn't installed or `settings.json` doesn't exist, the next line falls back to `QWEN_HOME` or the default.) Each sidecar file contains `{schema_version, pid, session_id, work_dir, hostname, started_at, qwen_version}` — the authoritative source of `(pid, session_id, work_dir)` mappings.
-
-   Then filter to live PIDs in one pass (avoids reading every stale sidecar individually):
+   Filter to live `(pid, sidecar-path)` pairs in one shot. Use Node (guaranteed available — qwen-code requires it) instead of `jq` (often missing on default macOS / minimal Linux) so this path doesn't silently degrade:
 
    ```
-   for f in "$RUNTIME_DIR"/projects/*/chats/*.runtime.json; do
-     pid=$(jq -r .pid "$f" 2>/dev/null)
-     [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null && echo "$pid $f"
-   done
+   node -e 'const fs=require("fs"); for (const f of process.argv.slice(1)) { try { const p=JSON.parse(fs.readFileSync(f,"utf8")).pid; if (p) { try { process.kill(p,0); console.log(p+" "+f); } catch {} } } catch {} }' "$RUNTIME_DIR"/projects/*/chats/*.runtime.json 2>/dev/null
    ```
 
-   Only the live `(pid, sidecar-path)` pairs reach the report. PID reuse is rare but possible — when you cross-reference with `ps` in step 2, skip pairs whose live PID's command line no longer looks like a Qwen Code process.
+   PID reuse is rare but possible — when you cross-reference with `ps` in step 2, skip pairs whose live PID's command line no longer looks like a Qwen Code process.
 
-   **If no sidecar files are found** (empty output, or the directory does not exist), fall through to step 2 — `ps` is the working fallback.
+   **If the command emits nothing** (no sidecars, or no live PIDs), fall through to step 2 — `ps` is the working fallback.
 
 2. **List Qwen Code processes via `ps`** (macOS/Linux) — used to enrich each live session with CPU/RSS/state/uptime, and to catch sessions that may have started before the sidecar feature existed:
 

--- a/packages/core/src/skills/bundled/stuck/SKILL.md
+++ b/packages/core/src/skills/bundled/stuck/SKILL.md
@@ -35,7 +35,7 @@ Signs of a stuck session:
    - Child processes: `pgrep -lP <pid>`
    - If high CPU: sample again after 1-2s to confirm it's sustained
    - If a child looks hung (e.g., a git command), note its full command line with `ps -p <child_pid> -o command=`
-   - Check the session's debug log if you can infer the session ID: `~/.qwen/debug/<session-id>.txt` (the last few hundred lines often show what it was doing before hanging)
+   - Check the session's debug log if you can infer the session ID: `~/.qwen/debug/<session-id>.txt` (the last few hundred lines often show what it was doing before hanging). If `QWEN_RUNTIME_DIR` or `QWEN_HOME` is set, the debug directory is `$QWEN_RUNTIME_DIR/debug/` or `$QWEN_HOME/debug/` instead of the default.
    - The `~/.qwen/debug/latest` symlink points to the most recent session's log
 
 3. **Consider a stack dump** for a truly frozen process (advanced, optional):

--- a/packages/core/src/skills/bundled/stuck/SKILL.md
+++ b/packages/core/src/skills/bundled/stuck/SKILL.md
@@ -13,7 +13,7 @@ The user thinks another Qwen Code session on this machine is frozen, stuck, or v
 
 ## What to look for
 
-Scan for other Qwen Code processes (excluding the current one — exclude the PID you see running this prompt). Since Qwen Code is a Node.js CLI (`#!/usr/bin/env node`), the process name (`comm` column) is always `node` (or `bun` if run with Bun). Identify Qwen Code sessions by looking at the `command` column for paths containing "qwen" (e.g., `node /path/to/qwen-code/dist/cli.js` or a symlinked `qwen` script).
+Scan for other Qwen Code processes (excluding the current one — exclude the PID you see running this prompt). Since Qwen Code is a Node.js CLI (`#!/usr/bin/env node`), the process name (`comm` column) is always `node` (or `bun` if run with Bun). Identify Qwen Code sessions by looking at the `command` column for a script path inside a `qwen-code/` directory (matches dev / worktree / install layouts) or a bin invocation ending in `/qwen` (matches the global symlink). Avoid loose `qwen-code` substring matching — it false-positives on unrelated processes that merely pass a qwen-code path as a `--cwd` argument (e.g., plugin brokers).
 
 Signs of a stuck session:
 
@@ -34,7 +34,7 @@ If the user gave an argument, treat it as a PID **only if it consists entirely o
 
 ```
 RUNTIME_DIR="${QWEN_RUNTIME_DIR:-}"
-[ -z "$RUNTIME_DIR" ] && command -v jq >/dev/null && RUNTIME_DIR=$(jq -r '.advanced.runtimeOutputDir // empty' ~/.qwen/settings.json 2>/dev/null)
+[ -z "$RUNTIME_DIR" ] && command -v jq >/dev/null && RUNTIME_DIR=$(jq -r '.advanced.runtimeOutputDir // empty' "${QWEN_HOME:-$HOME/.qwen}/settings.json" 2>/dev/null)
 RUNTIME_DIR="${RUNTIME_DIR:-${QWEN_HOME:-$HOME/.qwen}}"
 ```
 
@@ -43,17 +43,17 @@ RUNTIME_DIR="${RUNTIME_DIR:-${QWEN_HOME:-$HOME/.qwen}}"
 **Fast path for targeted diagnosis** — if a digit-only PID argument was given, skip step 1 enumeration. First validate that the PID is a live current-user Qwen Code process; if not, refuse and stop. Without this check, a same-user non-Qwen PID (e.g., a `node my-other-app.js --api-key=...`) would have its full command line dumped into the report.
 
 ```
-kill -0 <pid> 2>/dev/null && ps -p <pid> -o command= -ww 2>/dev/null | grep -qE '(qwen|node.*qwen|bun.*qwen)'
+kill -0 <pid> 2>/dev/null && ps -p <pid> -o command= -ww 2>/dev/null | grep -qE '(qwen-code/[^ ]*\.(js|ts|mjs|cjs)( |$)|/qwen( |$))'
 ```
 
 If this pipeline returns non-zero (PID dead, owned by another user, or not a Qwen Code process), stop the diagnostic and tell the user "PID `<pid>` is not a current-user Qwen Code session". Otherwise, gather stats and the sidecar mapping, then jump to step 3:
 
 ```
 ps -p <pid> -o pid=,pcpu=,rss=,etime=,state=,comm=,command= -ww
-grep -l '"pid"[[:space:]]*:[[:space:]]*<pid>\b' "$RUNTIME_DIR"/projects/*/chats/*.runtime.json 2>/dev/null
+grep -El '"pid"[[:space:]]*:[[:space:]]*<pid>\b' "$RUNTIME_DIR"/projects/*/chats/*.runtime.json 2>/dev/null
 ```
 
-The `grep -l` returns the sidecar file path (if any); the basename (stripped of `.runtime.json`) is the session ID for step 3's debug log read.
+`-E` is required so `\b` is interpreted as word boundary (BSD `grep` without `-E` treats `\b` as a backspace character, silently returning nothing on macOS). The `-l` flag returns the matching sidecar file path; the basename (stripped of `.runtime.json`) is the session ID for step 3's debug log read. If multiple sidecars match (rare — happens only after PID reuse leaves a stale file), prefer the most recently modified one: `ls -t <matches> | head -n 1`.
 
 Otherwise (no arg, or symptom-only arg), run the general path below:
 
@@ -74,7 +74,7 @@ Otherwise (no arg, or symptom-only arg), run the general path below:
 2. **List Qwen Code processes via `ps`** (macOS/Linux) — used to enrich each live session with CPU/RSS/state/uptime, and to catch sessions that may have started before the sidecar feature existed:
 
    ```
-   ps -xo pid=,pcpu=,rss=,etime=,state=,comm=,command= -u "$(id -u)" -ww | grep -E '(qwen|node.*qwen|bun.*qwen)' | grep -v grep
+   ps -xo pid=,pcpu=,rss=,etime=,state=,comm=,command= -u "$(id -u)" -ww | grep -E '(qwen-code/[^ ]*\.(js|ts|mjs|cjs)( |$)|/qwen( |$))' | grep -v grep
    ```
 
    `-u "$(id -u)"` restricts the scan to the current user — on shared hosts this avoids exposing other users' Qwen process paths/arguments into the chat. `-ww` disables column truncation so long "qwen" paths aren't cut off. The `comm` column will be `node` or `bun`, not `qwen`; filter to rows where the `command` column contains a qwen path (e.g., `qwen-code/dist/cli.js`, or a bin symlink ending in `/qwen`). Cross-reference with the PIDs from step 1.
@@ -86,7 +86,7 @@ Otherwise (no arg, or symptom-only arg), run the general path below:
 3. **For anything suspicious**, gather more context. If the process state alone explains the problem (`T` = accidentally stopped, `Z` = parent not reaping), skip directly to the report — child / log / stack inspection adds nothing. Otherwise:
    - Child processes (with state, so a hung `git` / `node` shows up): `pgrep -P <pid> | xargs -I{} ps -p {} -o pid=,ppid=,pcpu=,state=,etime=,command=`
    - If high CPU: sample again after 1-2s to confirm it's sustained
-   - **Network hang** — if CPU is low and state is `S` despite the user reporting "stuck", the most likely cause is a hung HTTPS request to the model API. macOS: `lsof -i -p <pid> 2>/dev/null | head -20`. Linux: `ss -tnp 2>/dev/null | grep "pid=<pid>,"`. A long-lived `ESTABLISHED` connection to a model host (dashscope, openai, anthropic, etc.) with no recent traffic is the smoking gun.
+   - **Network hang** — if CPU is low and state is `S` despite the user reporting "stuck", the most likely cause is a hung HTTPS request to the model API. macOS: `lsof -nP -i -p <pid> 2>/dev/null | head -20` (the `-nP` flags skip reverse-DNS and port lookups, which can themselves hang). If `lsof` itself feels slow, prefix with `timeout 10` (or `gtimeout 10` on macOS with Homebrew coreutils). Linux: `ss -tnp 2>/dev/null | grep "pid=<pid>,"`. A long-lived `ESTABLISHED` connection to a model host (dashscope, openai, anthropic, etc.) with no recent traffic is the smoking gun.
    - **Debug log** — start with `"$RUNTIME_DIR"/debug/latest` (symlink to the most recent session); if it matches the suspicious PID's session, that's usually the right one. Otherwise infer the session ID from the sidecar and read `"$RUNTIME_DIR"/debug/<session-id>.txt`. Bound the read with `tail -n 200 <path>` — debug logs can be GB-sized. The last few hundred lines typically show what the session was doing before hanging. Debug logs may contain prompts, file contents, or tokens from other sessions — paste only lines relevant to the hang, and never quote secrets/API keys you happen to see.
 
 4. **Consider a stack dump** for a truly frozen process (advanced, optional):

--- a/packages/core/src/skills/bundled/stuck/SKILL.md
+++ b/packages/core/src/skills/bundled/stuck/SKILL.md
@@ -35,6 +35,9 @@ If the user gave an argument, treat it as a PID **only if it consists entirely o
 ```
 RUNTIME_DIR="${QWEN_RUNTIME_DIR:-}"
 [ -z "$RUNTIME_DIR" ] && command -v jq >/dev/null && RUNTIME_DIR=$(jq -r '.advanced.runtimeOutputDir // empty' "${QWEN_HOME:-$HOME/.qwen}/settings.json" 2>/dev/null)
+# `advanced.runtimeOutputDir` may be `~/...` or relative; mirror Storage.resolvePath() before using in globs
+[ -n "$RUNTIME_DIR" ] && RUNTIME_DIR="${RUNTIME_DIR/#\~/$HOME}"
+[ -n "$RUNTIME_DIR" ] && case "$RUNTIME_DIR" in /*) ;; *) RUNTIME_DIR="$(cd "$RUNTIME_DIR" 2>/dev/null && pwd)" || RUNTIME_DIR="" ;; esac
 RUNTIME_DIR="${RUNTIME_DIR:-${QWEN_HOME:-$HOME/.qwen}}"
 ```
 

--- a/packages/core/src/skills/bundled/stuck/SKILL.md
+++ b/packages/core/src/skills/bundled/stuck/SKILL.md
@@ -13,7 +13,7 @@ The user thinks another Qwen Code session on this machine is frozen, stuck, or v
 
 ## What to look for
 
-Scan for other Qwen Code processes (excluding the current one — exclude the PID you see running this prompt). Since Qwen Code is a Node.js CLI (`#!/usr/bin/env node`), the process name (`comm` column) is always `node` (or `bun` if run with Bun). Identify Qwen Code sessions by looking at the `command` column for a script path inside a `qwen-code/` directory (matches dev / worktree / install layouts) or a bin invocation ending in `/qwen` (matches the global symlink). Avoid loose `qwen-code` substring matching — it false-positives on unrelated processes that merely pass a qwen-code path as a `--cwd` argument (e.g., plugin brokers).
+Scan for other Qwen Code processes (excluding the current one — exclude the PID you see running this prompt). Since Qwen Code is a Node.js CLI (`#!/usr/bin/env node`), the process name (`comm` column) is always `node` (or `bun` if run with Bun). Identify Qwen Code sessions by looking at the `command` column for a script path inside a directory whose name starts with `qwen-code` (matches `qwen-code/`, `qwen-code-dev/`, worktree clones, etc.) — anchored to the start of the path or after `/` so unrelated names like `analyze-qwen-code/` don't false-match — or a bin invocation ending in `/qwen` (the global symlink). Avoid loose `qwen-code` substring matching: it false-positives on plugin brokers that merely pass a qwen-code path as `--cwd`.
 
 Signs of a stuck session:
 
@@ -22,6 +22,7 @@ Signs of a stuck session:
 - **Process state `T` (stopped)** — user probably hit Ctrl+Z by accident.
 - **Process state `Z` (zombie)** — parent isn't reaping.
 - **Very high RSS (>=4GB)** — possible memory leak making the session sluggish.
+- **State `S` with low CPU** — the most common hang signature: a hung HTTPS request to the model API. Not a process-level red flag on its own, but combined with the user reporting "stuck", treat it as a strong signal to run the network check in step 3.
 - **Stuck child process** — a hung `git`, `node`, or shell subprocess can freeze the parent. Check `pgrep -P <pid>` (then `ps -p` for state — see step 3) for each session.
 
 ## Argument validation
@@ -43,18 +44,21 @@ RUNTIME_DIR="${RUNTIME_DIR:-${QWEN_HOME:-$HOME/.qwen}}"
 
 (If `jq` isn't installed, the settings layer is silently skipped — the env-var / default fallback covers the common case.)
 
-**Fast path for targeted diagnosis** — if a digit-only PID argument was given, skip step 1 enumeration. First validate that the PID is a live current-user Qwen Code process; if not, refuse and stop. Without this check, a same-user non-Qwen PID (e.g., a `node my-other-app.js --api-key=...`) would have its full command line dumped into the report.
+**Fast path for targeted diagnosis** — if a digit-only PID argument was given, skip step 1 enumeration. Validate that the PID is a live current-user Qwen Code process before dumping any details:
 
 ```
-kill -0 <pid> 2>/dev/null && ps -p <pid> -o command= -ww 2>/dev/null | grep -qE '(qwen-code/[^ ]*\.(js|ts|mjs|cjs)( |$)|/qwen( |$))'
+kill -0 <pid> 2>/dev/null || { echo "PID <pid> is dead, or owned by another user"; exit 0; }
+ps -p <pid> -o command= -ww 2>/dev/null | grep -qE '((^|/)qwen-code[^ /]*/[^ ]*\.(js|ts|mjs|cjs)( |$)|/qwen( |$))' || { echo "PID <pid> is yours but is not a Qwen Code process — refusing to dump details"; exit 0; }
 ```
 
-If this pipeline returns non-zero (PID dead, owned by another user, or not a Qwen Code process), stop the diagnostic and tell the user "PID `<pid>` is not a current-user Qwen Code session". Otherwise, gather stats and the sidecar mapping, then jump to step 3:
+If either guard prints, stop the diagnostic and surface the message verbatim. Otherwise, gather stats and the sidecar mapping, then jump to step 3:
 
 ```
 ps -p <pid> -o pid=,pcpu=,rss=,etime=,state=,comm=,command= -ww
 grep -El '"pid"[[:space:]]*:[[:space:]]*<pid>\b' "$RUNTIME_DIR"/projects/*/chats/*.runtime.json 2>/dev/null
 ```
+
+Note: as in step 2, the `command=` column may include credentials passed as CLI args (e.g., `--openai-api-key=sk-…`). Redact such values to `***` before quoting them in the report.
 
 `-E` is required so `\b` is interpreted as word boundary (BSD `grep` without `-E` treats `\b` as a backspace character, silently returning nothing on macOS). The `-l` flag returns the matching sidecar file path; the basename (stripped of `.runtime.json`) is the session ID for step 3's debug log read. If multiple sidecars match (rare — happens only after PID reuse leaves a stale file), prefer the most recently modified one: `ls -t <matches> | head -n 1`.
 
@@ -77,23 +81,23 @@ Otherwise (no arg, or symptom-only arg), run the general path below:
 2. **List Qwen Code processes via `ps`** (macOS/Linux) — used to enrich each live session with CPU/RSS/state/uptime, and to catch sessions that may have started before the sidecar feature existed:
 
    ```
-   ps -xo pid=,pcpu=,rss=,etime=,state=,comm=,command= -u "$(id -u)" -ww | grep -E '(qwen-code/[^ ]*\.(js|ts|mjs|cjs)( |$)|/qwen( |$))' | grep -v grep
+   ps -xo pid=,pcpu=,rss=,etime=,state=,comm=,command= -u "$(id -u)" -ww | grep -E '((^|/)qwen-code[^ /]*/[^ ]*\.(js|ts|mjs|cjs)( |$)|/qwen( |$))' | grep -v grep
    ```
 
    `-u "$(id -u)"` restricts the scan to the current user — on shared hosts this avoids exposing other users' Qwen process paths/arguments into the chat. `-ww` disables column truncation so long "qwen" paths aren't cut off. The `comm` column will be `node` or `bun`, not `qwen`; filter to rows where the `command` column contains a qwen path (e.g., `qwen-code/dist/cli.js`, or a bin symlink ending in `/qwen`). Cross-reference with the PIDs from step 1.
 
-   Note: `ps` reports `rss` in **kilobytes** on both macOS and Linux. Divide by 1024 before comparing to the >=4GB threshold or reporting in MB.
+   Note: `ps` reports `rss` in **kilobytes** on both macOS and Linux. To report in MB, divide by 1024; to report in GB, divide by 1048576. The 4GB threshold is `4194304` KB — compare the raw `rss` value against that, or compare the GB value against 4. Do not divide once and then compare against 4; that would flag every process >4MB as "very high RSS".
 
    Note: full command lines may contain credentials passed as CLI args (e.g., `--openai-api-key=sk-…`). Redact such values to `***` before quoting them in the report.
 
 3. **For anything suspicious**, gather more context. If the process state alone explains the problem (`T` = accidentally stopped, `Z` = parent not reaping), skip directly to the report — child / log / stack inspection adds nothing. Otherwise:
-   - Child processes (with state, so a hung `git` / `node` shows up): `pgrep -P <pid> | xargs -I{} ps -p {} -o pid=,ppid=,pcpu=,state=,etime=,command=`
+   - Child processes (with state, so a hung `git` / `node` shows up): `CHILDREN=$(pgrep -P <pid> | tr '\n' ',' | sed 's/,$//'); [ -n "$CHILDREN" ] && ps -p "$CHILDREN" -o pid=,ppid=,pcpu=,state=,etime=,command= -ww`. Single `ps` call (avoids forking one per child) and `-ww` so long child command lines aren't truncated.
    - If high CPU: sample again after 1-2s to confirm it's sustained
-   - **Network hang** — if CPU is low and state is `S` despite the user reporting "stuck", the most likely cause is a hung HTTPS request to the model API. macOS: `lsof -nP -i -p <pid> 2>/dev/null | head -20` (the `-nP` flags skip reverse-DNS and port lookups, which can themselves hang). If `lsof` itself feels slow, prefix with `timeout 10` (or `gtimeout 10` on macOS with Homebrew coreutils). Linux: `ss -tnp 2>/dev/null | grep "pid=<pid>,"`. A long-lived `ESTABLISHED` connection to a model host (dashscope, openai, anthropic, etc.) with no recent traffic is the smoking gun.
+   - **Network hang** — if CPU is low and state is `S` despite the user reporting "stuck", the most likely cause is a hung HTTPS request to the model API. macOS: `lsof -nP -i -p <pid> 2>/dev/null | head -20` (the `-nP` flags skip reverse-DNS and port lookups, which can themselves hang). If `lsof` itself feels slow, prefix with `timeout 10` (or `gtimeout 10` on macOS with Homebrew coreutils). Linux: `ss -tnp 2>/dev/null | grep "pid=<pid>,"`. Note that `ss -tnp`'s `-p` requires root or `CAP_NET_ADMIN` — without it, the PID column shows `-` and the grep returns empty. If you see no matches but `ss -t 2>/dev/null` does show ESTABLISHED sockets, fall back to `lsof -nP -i -p <pid>` rather than reporting "no connections". A long-lived `ESTABLISHED` connection to a model host (dashscope, openai, anthropic, etc.) with no recent traffic is the smoking gun.
    - **Debug log** — start with `"$RUNTIME_DIR"/debug/latest` (symlink to the most recent session); if it matches the suspicious PID's session, that's usually the right one. Otherwise infer the session ID from the sidecar and read `"$RUNTIME_DIR"/debug/<session-id>.txt`. Bound the read with `tail -n 200 <path>` — debug logs can be GB-sized. The last few hundred lines typically show what the session was doing before hanging. Debug logs may contain prompts, file contents, or tokens from other sessions — paste only lines relevant to the hang, and never quote secrets/API keys you happen to see.
 
 4. **Consider a stack dump** for a truly frozen process (advanced, optional):
-   - macOS: `sample <pid> 3` gives a 3-second native stack sample. Stack frames may include function arguments containing API keys or tokens held in memory — redact such values to `***` before including the dump in the report.
+   - macOS: `sample <pid> 3` gives a 3-second native stack sample. If `sample` itself seems to hang (the target's Mach task port may be wedged on a kernel-level freeze), wrap it: `timeout 15 sample <pid> 3` (or `gtimeout 15 ...` on Homebrew coreutils). Stack frames may include function arguments containing API keys or tokens held in memory — redact such values to `***` before including the dump in the report.
    - Linux: `cat /proc/<pid>/stack` for kernel stack (read-only, no `ptrace` permissions needed). Avoid `strace -p` for this purpose: it requires `CAP_SYS_PTRACE` (often denied under `kernel.yama.ptrace_scope=1`), and `strace -c` blocks until the target exits — it would hang on the very kind of stuck process you are diagnosing.
    - This is big — only grab it if the process is clearly hung and you want to know _why_
 

--- a/packages/core/src/skills/bundled/stuck/SKILL.md
+++ b/packages/core/src/skills/bundled/stuck/SKILL.md
@@ -32,14 +32,16 @@ If the user gave an argument, treat it as a PID **only if it consists entirely o
 
 1. **Resolve the runtime base directory**, then enumerate live sessions via the runtime sidecar (preferred, reliable):
 
-   Qwen Code writes a `runtime.json` sidecar for each interactive session at `<runtime-base>/projects/<sanitized-cwd>/chats/<sessionId>.runtime.json`. The base directory is taken from (in priority order): `QWEN_RUNTIME_DIR`, `QWEN_HOME`, the `advanced.runtimeOutputDir` setting, and finally `~/.qwen`. Use the resolved value in every command below — substituting the literal default would silently miss sessions on machines that override it.
+   Qwen Code writes a `runtime.json` sidecar for each interactive session at `<runtime-base>/projects/<sanitized-cwd>/chats/<sessionId>.runtime.json`. The base directory is taken from (in priority order): `QWEN_RUNTIME_DIR` env var, the `advanced.runtimeOutputDir` setting, `QWEN_HOME` env var, and finally `~/.qwen`. Use the resolved value in every command below — substituting the literal default would silently miss sessions on machines that override it.
 
    ```
-   RUNTIME_DIR="${QWEN_RUNTIME_DIR:-${QWEN_HOME:-$HOME/.qwen}}"
+   RUNTIME_DIR="${QWEN_RUNTIME_DIR:-}"
+   [ -z "$RUNTIME_DIR" ] && RUNTIME_DIR=$(jq -r '.advanced.runtimeOutputDir // empty' ~/.qwen/settings.json 2>/dev/null)
+   RUNTIME_DIR="${RUNTIME_DIR:-${QWEN_HOME:-$HOME/.qwen}}"
    ls -1 "$RUNTIME_DIR"/projects/*/chats/*.runtime.json 2>/dev/null
    ```
 
-   (If the user has set `advanced.runtimeOutputDir` in `settings.json`, ask them or read it from settings; otherwise the env-var resolution above is correct.) Each sidecar file contains `{schema_version, pid, session_id, work_dir, hostname, started_at, qwen_version}` — the authoritative source of `(pid, session_id, work_dir)` mappings.
+   (The `jq` line gracefully degrades — if `jq` isn't installed or `settings.json` doesn't exist, the next line falls back to `QWEN_HOME` or the default.) Each sidecar file contains `{schema_version, pid, session_id, work_dir, hostname, started_at, qwen_version}` — the authoritative source of `(pid, session_id, work_dir)` mappings.
 
    For each file, read it and check whether the recorded `pid` is still alive (`kill -0 <pid>` returns 0). Stale files where the PID is gone mean the session has exited — skip them silently. PID reuse is rare but possible, so when you cross-reference with `ps` in step 2, also skip records whose live PID's command line no longer looks like a Qwen Code process.
 

--- a/packages/core/src/skills/bundled/stuck/SKILL.md
+++ b/packages/core/src/skills/bundled/stuck/SKILL.md
@@ -32,27 +32,28 @@ If the user gave an argument, first check whether it is a positive integer (PID)
 
 1. **Enumerate live sessions via the runtime sidecar (preferred, reliable)**:
 
-   Qwen Code writes a `runtime.json` sidecar for each interactive session at `<runtime-base>/projects/<sanitized-cwd>/chats/<sessionId>.runtime.json`. The default `<runtime-base>` is `~/.qwen` (overridable by `QWEN_RUNTIME_DIR` or `QWEN_HOME`). Each file contains `{schema_version, pid, session_id, work_dir, hostname, started_at, qwen_version}`. Use this as the authoritative source of `(pid, session_id, work_dir)` mappings:
+   Qwen Code writes a `runtime.json` sidecar for each interactive session at `<runtime-base>/projects/<sanitized-cwd>/chats/<sessionId>.runtime.json`. The default `<runtime-base>` is `~/.qwen` (overridable by `QWEN_RUNTIME_DIR`, `QWEN_HOME`, or the `advanced.runtimeOutputDir` setting). Each file contains `{schema_version, pid, session_id, work_dir, hostname, started_at, qwen_version}`. Use this as the authoritative source of `(pid, session_id, work_dir)` mappings:
 
    ```
    ls -1 ~/.qwen/projects/*/chats/*.runtime.json 2>/dev/null
    ```
 
-   For each file, read it and check whether the recorded `pid` is still alive (`kill -0 <pid>` returns 0). Stale files where the PID is gone mean the session has exited — skip them silently.
+   For each file, read it and check whether the recorded `pid` is still alive (`kill -0 <pid>` returns 0). Stale files where the PID is gone mean the session has exited — skip them silently. PID reuse is rare but possible, so when you cross-reference with `ps` in step 2, also skip records whose live PID's command line no longer looks like a Qwen Code process.
 
 2. **List Qwen Code processes via `ps`** (macOS/Linux) — used to enrich each live session with CPU/RSS/state/uptime, and to catch sessions that may have started before the sidecar feature existed:
 
    ```
-   ps -axo pid=,pcpu=,rss=,etime=,state=,comm=,command= -ww | grep -E '(qwen|node.*qwen|bun.*qwen)' | grep -v grep
+   ps -xo pid=,pcpu=,rss=,etime=,state=,comm=,command= -u "$(id -u)" -ww | grep -E '(qwen|node.*qwen|bun.*qwen)' | grep -v grep
    ```
 
-   The `-ww` flag disables column truncation — without it, long command paths get cut off and `grep` may miss sessions whose "qwen" path component falls beyond the terminal width. The `comm` column will be `node` or `bun`, not `qwen`. Filter to rows where the `command` column contains a path related to qwen (e.g., `qwen-code/dist/cli.js`, or a bin symlink ending in `/qwen`). Cross-reference with the PIDs from step 1.
+   `-u "$(id -u)"` restricts the scan to the current user — on shared hosts this avoids exposing other users' Qwen process paths/arguments into the chat. `-ww` disables column truncation so long "qwen" paths aren't cut off. The `comm` column will be `node` or `bun`, not `qwen`; filter to rows where the `command` column contains a qwen path (e.g., `qwen-code/dist/cli.js`, or a bin symlink ending in `/qwen`). Cross-reference with the PIDs from step 1.
+
+   Note: `ps` reports `rss` in **kilobytes** on both macOS and Linux. Divide by 1024 before comparing to the >=4GB threshold or reporting in MB.
 
 3. **For anything suspicious**, gather more context. Substitute `<pid>` only after the validation in "Argument validation" above (or after taking it from `ps` / sidecar output, which is trusted):
-   - Child processes: `pgrep -lP <pid>`
+   - Child processes (with state, so a hung `git` / `node` shows up): `pgrep -P <pid>` to get child PIDs, then `ps -p <child_pids> -o pid=,ppid=,pcpu=,state=,etime=,command=` for their state
    - If high CPU: sample again after 1-2s to confirm it's sustained
-   - If a child looks hung (e.g., a git command), note its full command line with `ps -p <child_pid> -o command=`
-   - Check the session's debug log if you can infer the session ID (from the sidecar): `~/.qwen/debug/<session-id>.txt` (the last few hundred lines often show what it was doing before hanging). If `QWEN_RUNTIME_DIR` or `QWEN_HOME` is set, the debug directory is `$QWEN_RUNTIME_DIR/debug/` or `$QWEN_HOME/debug/` instead of the default.
+   - Check the session's debug log if you can infer the session ID (from the sidecar): `~/.qwen/debug/<session-id>.txt` (the last few hundred lines often show what it was doing before hanging). If `QWEN_RUNTIME_DIR` or `QWEN_HOME` is set, the debug directory is `$QWEN_RUNTIME_DIR/debug/` or `$QWEN_HOME/debug/` instead of the default. Debug logs may contain prompts, file contents, or tokens from other sessions — paste only the lines relevant to the hang, and never quote secrets/API keys you happen to see.
    - The `~/.qwen/debug/latest` symlink points to the most recent session's log
 
 4. **Consider a stack dump** for a truly frozen process (advanced, optional):


### PR DESCRIPTION
## Summary

- Add a new `/stuck` bundled skill that diagnoses frozen, stuck, or slow Qwen Code sessions
- Scans system processes for high CPU, abnormal states (D/T/Z), excessive memory, and hung subprocesses
- Checks `~/.qwen/debug/` logs and supports macOS `sample` + Linux `/proc/stack` for stack dumps
- Presents a structured diagnostic report directly to the user

Ported from claude-code's internal `/stuck` skill with adaptations:
- Process identification via `command` column path matching (Node.js CLI shows as `node` in `comm`, not `qwen`)
- Debug log path `~/.qwen/debug/` with `latest` symlink support
- Cross-platform stack dump (macOS + Linux)
- Direct terminal output instead of Slack reporting
- Available to all users (no internal-only gate)

## Test plan

- [x] `/stuck` appears in autocomplete with correct description and argument hint
- [x] Executing `/stuck` triggers process scan via `ps`, identifies sessions, checks child processes, and outputs structured diagnostic report
- [x] Verified in tmux with YOLO mode — model correctly scans 8 sessions, samples high-CPU process twice, checks child processes via `pgrep`, and concludes "all healthy"

## 人工验证
```
/stuck
```
<img width="1595" height="657" alt="image" src="https://github.com/user-attachments/assets/b296d59d-5b94-477d-903d-255ad1fc7ad5" />

```
/stuck pid
```
<img width="1441" height="740" alt="image" src="https://github.com/user-attachments/assets/8aece3b6-66e5-4190-a9a4-2b093095bd57" />



🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)