### PR TITLE
fix(cli): apply /language output to running session without restart

### DIFF
--- a/packages/cli/src/ui/commands/languageCommand.test.ts
+++ b/packages/cli/src/ui/commands/languageCommand.test.ts
@@ -476,7 +476,7 @@ describe('languageCommand', () => {
         'output Chinese',
       );
 
-      // Verify setting was saved (rule file is updated on restart)
+      // Verify the setting was persisted.
       expect(mockContext.services.settings?.setValue).toHaveBeenCalledWith(
         expect.anything(), // SettingScope.User
         'general.outputLanguage',
@@ -517,11 +517,52 @@ describe('languageCommand', () => {
       expect(refreshHierarchicalMemory).toHaveBeenCalledTimes(1);
       expect(getGeminiClient).toHaveBeenCalledTimes(1);
       expect(refreshSystemInstruction).toHaveBeenCalledTimes(1);
+      // Memory MUST be refreshed before the system instruction is rebuilt;
+      // otherwise the new instruction would be built from stale userMemory
+      // and the language switch would silently fail to take effect.
+      const memoryOrder = refreshHierarchicalMemory.mock.invocationCallOrder[0];
+      const instructionOrder =
+        refreshSystemInstruction.mock.invocationCallOrder[0];
+      expect(memoryOrder).toBeLessThan(instructionOrder);
       // The success message no longer asks the user to restart.
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
         content: expect.not.stringContaining('restart'),
+      });
+    });
+
+    it('should still report success when applying to the running session fails', async () => {
+      if (!languageCommand.action) {
+        throw new Error('The language command must have an action.');
+      }
+
+      const refreshHierarchicalMemory = vi
+        .fn()
+        .mockRejectedValue(new Error('boom'));
+      (
+        mockContext.services as unknown as {
+          config: Record<string, unknown>;
+        }
+      ).config = {
+        getModel: vi.fn().mockReturnValue('test-model'),
+        refreshHierarchicalMemory,
+        // No getGeminiClient — refreshSystemInstruction must not be reached.
+      };
+
+      const result = await languageCommand.action(mockContext, 'output Korean');
+
+      // The setting was still persisted; the user-facing message reports
+      // success and does not surface the in-session refresh failure.
+      expect(mockContext.services.settings?.setValue).toHaveBeenCalledWith(
+        expect.anything(),
+        'general.outputLanguage',
+        'Korean',
+      );
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining('LLM output language set to'),
       });
     });
 
@@ -555,8 +596,7 @@ describe('languageCommand', () => {
       );
     });
 
-    it('should save setting without immediate rule file update', async () => {
-      // Even though rule file updates happen on restart, the setting should still be saved
+    it('should save the setting and report success on a valid argument', async () => {
       if (!languageCommand.action) {
         throw new Error('The language command must have an action.');
       }
@@ -887,7 +927,7 @@ describe('languageCommand', () => {
 
       const result = await outputSubcommand.action(mockContext, 'French');
 
-      // Verify setting was saved (rule file is updated on restart)
+      // Verify the setting was persisted.
       expect(mockContext.services.settings?.setValue).toHaveBeenCalledWith(
         expect.anything(),
         'general.outputLanguage',

--- a/packages/cli/src/ui/commands/languageCommand.test.ts
+++ b/packages/cli/src/ui/commands/languageCommand.test.ts
@@ -489,20 +489,39 @@ describe('languageCommand', () => {
       });
     });
 
-    it('should include restart notice in success message', async () => {
+    it('should apply the new output language to the running session without requiring a restart', async () => {
       if (!languageCommand.action) {
         throw new Error('The language command must have an action.');
       }
+
+      const refreshHierarchicalMemory = vi.fn().mockResolvedValue(undefined);
+      const refreshSystemInstruction = vi.fn().mockResolvedValue(undefined);
+      const getGeminiClient = vi
+        .fn()
+        .mockReturnValue({ refreshSystemInstruction });
+      (
+        mockContext.services as unknown as {
+          config: Record<string, unknown>;
+        }
+      ).config = {
+        getModel: vi.fn().mockReturnValue('test-model'),
+        refreshHierarchicalMemory,
+        getGeminiClient,
+      };
 
       const result = await languageCommand.action(
         mockContext,
         'output Japanese',
       );
 
+      expect(refreshHierarchicalMemory).toHaveBeenCalledTimes(1);
+      expect(getGeminiClient).toHaveBeenCalledTimes(1);
+      expect(refreshSystemInstruction).toHaveBeenCalledTimes(1);
+      // The success message no longer asks the user to restart.
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
-        content: expect.stringContaining('restart'),
+        content: expect.not.stringContaining('restart'),
       });
     });
 

--- a/packages/cli/src/ui/commands/languageCommand.ts
+++ b/packages/cli/src/ui/commands/languageCommand.ts
@@ -128,6 +128,11 @@ async function setUiLanguage(
 /**
  * Handles the /language output command, updating both the setting and the rule file.
  * 'auto' is preserved in settings but resolved to the detected language for the rule file.
+ *
+ * After persisting the change, hierarchical memory is reloaded so `output-language.md`
+ * flows back into `userMemory`, and the live chat's system instruction is rebuilt
+ * in place. The new language therefore takes effect on the next turn without
+ * restarting the session and without losing conversation history.
  */
 async function setOutputLanguage(
   context: CommandContext,
@@ -155,6 +160,22 @@ async function setOutputLanguage(
       }
     }
 
+    // Apply the new rule to the running session: refresh hierarchical memory
+    // so output-language.md is re-read into userMemory, then rebuild and
+    // re-bind the system instruction on the live chat.
+    const config = context.services.config;
+    if (config) {
+      try {
+        await config.refreshHierarchicalMemory();
+        await config.getGeminiClient().refreshSystemInstruction();
+      } catch (error) {
+        debugLogger.warn(
+          'Failed to apply output language to running session:',
+          error,
+        );
+      }
+    }
+
     // Format display message
     const displayLang = isAuto
       ? `${t('Auto (detect from system)')} → ${resolved}`
@@ -163,11 +184,7 @@ async function setOutputLanguage(
     return {
       type: 'message',
       messageType: 'info',
-      content: [
-        t('LLM output language set to {{lang}}', { lang: displayLang }),
-        '',
-        t('Please restart the application for the changes to take effect.'),
-      ].join('\n'),
+      content: t('LLM output language set to {{lang}}', { lang: displayLang }),
     };
   } catch (error) {
     return {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -448,6 +448,33 @@ export class GeminiClient {
     );
   }
 
+  /**
+   * Rebuilds the main-session system instruction from the current
+   * `userMemory` / model / prompt overrides and re-binds it to the live chat.
+   *
+   * Use this after mutating inputs that feed into the system instruction
+   * (e.g. user memory refreshed from `output-language.md`) so the change
+   * takes effect on the next turn without restarting the session. No-op if
+   * no chat has been started yet.
+   */
+  async refreshSystemInstruction(): Promise<void> {
+    if (!this.chat) {
+      return;
+    }
+    const toolRegistry = this.config.getToolRegistry();
+    await toolRegistry.warmAll();
+    const deferredSummary = toolRegistry.getDeferredToolSummary();
+    const toolSearchAvailable = !!toolRegistry.getTool(ToolNames.TOOL_SEARCH);
+    const deferredTools = toolSearchAvailable
+      ? deferredSummary.filter(
+          (t) => !toolRegistry.isDeferredToolRevealed(t.name),
+        )
+      : undefined;
+    this.chat.setSystemInstruction(
+      this.getMainSessionSystemInstruction(deferredTools),
+    );
+  }
+
   async startChat(extraHistory?: Content[]): Promise<GeminiChat> {
     this.forceFullIdeContext = true;
     // Clear stale cache params on session reset to prevent cross-session leakage


### PR DESCRIPTION
## Summary

- **What changed:** `/language output <lang>` now applies the new rule to the running session — no restart required, no history lost. The "Please restart the application for the changes to take effect." line is dropped from the success message.
- **Why it changed:** The output-language rule reaches the model through the **system instruction**, which is bound once when `GeminiChat` is created at startup. The command only wrote `~/.qwen/output-language.md` and persisted the setting — it never refreshed `userMemory` and never rebuilt the live chat's system instruction. So users had to restart the CLI to make the LLM actually switch languages.
- **Reviewer focus:**
  - `packages/core/src/core/client.ts`: new `GeminiClient.refreshSystemInstruction()` mirrors the deferred-tool computation in `startChat()` and re-binds the rebuilt system instruction via the existing `GeminiChat.setSystemInstruction()`. No-ops if no chat has been started yet.
  - `packages/cli/src/ui/commands/languageCommand.ts`: `setOutputLanguage()` now calls `config.refreshHierarchicalMemory()` followed by `client.refreshSystemInstruction()`. Errors are caught and warn-logged so a failure to apply doesn't mask the successful settings write.

## Validation

- Commands run:
  ```bash
  npx vitest run packages/cli/src/ui/commands/languageCommand.test.ts
  #   ✓ 58 tests passed

  npx vitest run packages/core/src/core/client.test.ts
  #   ✓ 104 tests passed

  npm --workspace @qwen-code/qwen-code-core run typecheck   # clean
  npm --workspace @qwen-code/qwen-code-core run build       # clean
  npm --workspace @qwen-code/qwen-code run typecheck        # only pre-existing errors on main (supertest, etc.) — none from this change
  npx eslint packages/core/src/core/client.ts packages/cli/src/ui/commands/languageCommand.ts packages/cli/src/ui/commands/languageCommand.test.ts   # clean
  ```
- Prompts / inputs used: In an interactive `qwen` session — send a Chinese prompt, run `/language output English`, send another Chinese prompt.
- Expected result: The second response is in English. The success line no longer contains "restart".
- Observed result: Matches expectation in the unit test (`should apply the new output language to the running session without requiring a restart`). The test asserts `refreshHierarchicalMemory` is called once, `getGeminiClient().refreshSystemInstruction()` is called once, and the message body does **not** contain `"restart"`.
- Quickest reviewer verification path: Read the diff (~70 lines across 3 files), then `npx vitest run packages/cli/src/ui/commands/languageCommand.test.ts`.
- Evidence: The new unit test mocks `services.config` with `refreshHierarchicalMemory` and `getGeminiClient` and asserts both are invoked from `setOutputLanguage` and the response message no longer mentions "restart".

I manualy tested and compared the dev branch (left side) and the released version (right side) below:
<img width="920" height="560" alt="language-switch" src="https://github.com/user-attachments/assets/d37c081e-e5ba-419f-920c-b8f9d383f5f0" />


## Scope / Risk

- **Main risk or tradeoff:** Refreshing the system instruction invalidates the prompt-cache prefix for one turn — a one-time cost, acceptable for an explicit user-initiated change. `setSystemInstruction` only mutates `generationConfig.systemInstruction` on the existing `GeminiChat`, so an in-flight model response (using the snapshot it already received) is not disturbed; the new instruction kicks in on the next `sendMessage`.
- **Not covered / not validated:** End-to-end test against a live model is not part of this PR (relies on the existing single-bind-at-`new GeminiChat` mechanism, exercised in unit tests by mocking).
- **Breaking changes / migration notes:** None. The `general.outputLanguage` setting, the `output-language.md` file format, and the `startChat` path are all unchanged. `refreshSystemInstruction()` is additive on `GeminiClient`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Tested via the workspace `vitest` and `typecheck` scripts on macOS. The change is platform-agnostic (no fs path semantics or shell behavior); skipped manual Windows/Linux runs.

## Linked Issues / Bugs

Fixes #4142
