### PR TITLE
feat(cli): add ModelScope as a built-in third-party API provider

### DIFF
--- a/packages/cli/src/auth/allProviders.ts
+++ b/packages/cli/src/auth/allProviders.ts
@@ -19,6 +19,7 @@ import { deepseekProvider } from './providers/thirdParty/deepseek.js';
 import { minimaxProvider } from './providers/thirdParty/minimax.js';
 import { zaiProvider } from './providers/thirdParty/zai.js';
 import { idealabProvider } from './providers/thirdParty/idealab.js';
+import { modelscopeProvider } from './providers/thirdParty/modelscope.js';
 import { customProvider } from './providers/custom/customProvider.js';
 
 // Re-export all providers
@@ -31,6 +32,7 @@ export {
   minimaxProvider,
   zaiProvider,
   idealabProvider,
+  modelscopeProvider,
   customProvider,
 };
 export {
@@ -52,6 +54,7 @@ export const ALL_PROVIDERS: readonly ProviderConfig[] = [
   minimaxProvider,
   zaiProvider,
   idealabProvider,
+  modelscopeProvider,
   customProvider,
 ];
 

--- a/packages/cli/src/auth/providers/thirdParty/modelscope.test.ts
+++ b/packages/cli/src/auth/providers/thirdParty/modelscope.test.ts
@@ -1,0 +1,60 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { AuthType } from '@qwen-code/qwen-code-core';
+import { modelscopeProvider, buildInstallPlan } from '../../allProviders.js';
+
+describe('modelscopeProvider', () => {
+  it('has correct provider config', () => {
+    expect(modelscopeProvider).toMatchObject({
+      id: 'modelscope',
+      protocol: AuthType.USE_OPENAI,
+      baseUrl: 'https://api-inference.modelscope.cn/v1',
+      envKey: 'MODELSCOPE_API_KEY',
+    });
+  });
+
+  it('creates an install plan with per-model metadata for known IDs', () => {
+    const plan = buildInstallPlan(modelscopeProvider, {
+      baseUrl: 'https://api-inference.modelscope.cn/v1',
+      apiKey: 'sk-modelscope',
+      modelIds: ['deepseek-ai/DeepSeek-V4-Flash', 'Qwen/Qwen3.5-397B-A17B'],
+    });
+
+    const models = plan.modelProviders?.[0]?.models;
+    expect(models).toHaveLength(2);
+    expect(models?.[0]).toMatchObject({
+      id: 'deepseek-ai/DeepSeek-V4-Flash',
+      name: '[ModelScope] deepseek-ai/DeepSeek-V4-Flash',
+      generationConfig: { contextWindowSize: 1000000 },
+    });
+    expect(models?.[1]).toMatchObject({
+      id: 'Qwen/Qwen3.5-397B-A17B',
+      name: '[ModelScope] Qwen/Qwen3.5-397B-A17B',
+      generationConfig: { contextWindowSize: 1000000 },
+    });
+  });
+
+  it('falls back gracefully for unknown model IDs', () => {
+    const plan = buildInstallPlan(modelscopeProvider, {
+      baseUrl: 'https://api-inference.modelscope.cn/v1',
+      apiKey: 'sk-modelscope',
+      modelIds: ['deepseek-ai/DeepSeek-V4-Flash', 'some-new-model'],
+    });
+
+    const models = plan.modelProviders?.[0]?.models;
+    expect(models).toHaveLength(2);
+    expect(models?.[0]?.generationConfig).toMatchObject({
+      contextWindowSize: 1000000,
+    });
+    expect(models?.[1]).toMatchObject({
+      id: 'some-new-model',
+      name: '[ModelScope] some-new-model',
+    });
+    expect(models?.[1]?.generationConfig).toBeUndefined();
+  });
+});

--- a/packages/cli/src/auth/providers/thirdParty/modelscope.ts
+++ b/packages/cli/src/auth/providers/thirdParty/modelscope.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { AuthType } from '@qwen-code/qwen-code-core';
+import type { ProviderConfig } from '../../providerConfig.js';
+
+export const modelscopeProvider: ProviderConfig = {
+  id: 'modelscope',
+  label: 'ModelScope API Key',
+  description: 'Quick setup for ModelScope API Inference',
+  protocol: AuthType.USE_OPENAI,
+  baseUrl: 'https://api-inference.modelscope.cn/v1',
+  envKey: 'MODELSCOPE_API_KEY',
+  authMethod: 'input',
+  models: [
+    {
+      id: 'deepseek-ai/DeepSeek-V4-Flash',
+      contextWindowSize: 1000000,
+      enableThinking: true,
+    },
+    {
+      id: 'Qwen/Qwen3.5-397B-A17B',
+      contextWindowSize: 1000000,
+      enableThinking: true,
+    },
+    {
+      id: 'ZhipuAI/GLM-5.1',
+      contextWindowSize: 1000000,
+      enableThinking: true,
+    },
+  ],
+  modelsEditable: true,
+  modelNamePrefix: 'ModelScope',
+  documentationUrl:
+    'https://modelscope.cn/docs/model-service/API-Inference/intro',
+  uiGroup: 'third-party',
+};


### PR DESCRIPTION
## Summary

- What changed: Add ModelScope as a built-in third-party API provider in the auth setup flow. Users can now pick "ModelScope API Key" during the auth wizard and get a pre-configured baseUrl (`https://api-inference.modelscope.cn/v1`), env key (`MODELSCOPE_API_KEY`), and a curated list of preset models with sane defaults (1M context window, thinking enabled).
- Why it changed: ModelScope's OpenAI-compatible Inference API is widely used in the Chinese developer community, but currently users have to fall back to the generic "Custom" provider and manually configure baseUrl, env key, model list, and context window. Adding it as a first-class provider matches the existing pattern used for DeepSeek, Minimax, ZAI, IdeaLab, etc.
- Reviewer focus:
  - `packages/cli/src/auth/providers/thirdParty/modelscope.ts` — provider config (id, baseUrl, envKey, preset models, UI metadata).
  - `packages/cli/src/auth/allProviders.ts` — registration in the provider registry and `ALL_PROVIDERS` array (insertion order matches the existing third-party group).
  - `packages/cli/src/auth/providers/thirdParty/modelscope.test.ts` — unit tests covering provider config and `buildInstallPlan` behavior for known and unknown model IDs.

## Validation

- Commands run:
  ```bash
  # Unit test for the new provider
  cd packages/cli && npx vitest run src/auth/providers/thirdParty/modelscope.test.ts

  # Repo-wide typecheck
  npm run typecheck
  ```
- Prompts / inputs used: N/A (auth provider config + unit tests, no interactive prompt).
- Expected result:
  - All 3 unit tests pass (provider config shape, install plan with known model IDs, fallback for unknown model IDs).
  - `npm run typecheck` passes across all workspaces.
- Observed result:
  - `modelscope.test.ts` — `3 passed (3)`, duration ~4.4s.
  - `npm run typecheck` — clean across `@qwen-code/qwen-code`, `@qwen-code/qwen-code-core`, `@qwen-code/sdk`, `@qwen-code/webui`.
- Quickest reviewer verification path:
  1. `cd packages/cli && npx vitest run src/auth/providers/thirdParty/modelscope.test.ts`
  2. Run `npm run dev` and open the auth wizard (`/auth`); confirm "ModelScope API Key" appears in the third-party group and that the preset baseUrl/env key/models are populated.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  ```
   ✓ src/auth/providers/thirdParty/modelscope.test.ts (3 tests) 3ms
   Test Files  1 passed (1)
        Tests  3 passed (3)
  ```

## Scope / Risk

- Main risk or tradeoff: Hard-coded preset model IDs may go stale as ModelScope publishes new models. Mitigated by `modelsEditable: true`, so users can add/edit their own model list at install time.
- Not covered / not validated: No live end-to-end call against the real ModelScope endpoint in CI (would require an API key). Manual smoke test recommended before merge.
- Breaking changes / migration notes: None. Pure additive change — no existing provider, type, or public API is modified.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Validated locally on macOS via `npx vitest` and `npm run typecheck`. The change is a static config plus unit tests, so platform-specific risk is minimal — Windows / Linux / sandbox runners should behave identically.

## Linked Issues / Bugs

-
