### PR TITLE
test(integration): pin simple-mcp-server to legacy MCP path until #4163 is fixed

### DIFF
--- a/integration-tests/cli/simple-mcp-server.test.ts
+++ b/integration-tests/cli/simple-mcp-server.test.ts
@@ -168,6 +168,13 @@ describe('simple-mcp-server', () => {
   const rig = new TestRig();
 
   beforeAll(async () => {
+    // Force the pre-#3994 synchronous MCP discovery path: under progressive
+    // MCP availability the spawned CLI's first non-interactive `--prompt`
+    // request fires without the MCP `add` tool wired into the model's tool
+    // surface, so the model answers `15` directly and `foundToolCall` stays
+    // false. Remove once QwenLM/qwen-code#4163 is fixed.
+    process.env['QWEN_CODE_LEGACY_MCP_BLOCKING'] = '1';
+
     // Setup test directory with MCP server configuration
     await rig.setup('simple-mcp-server', {
       settings: {


### PR DESCRIPTION
## Summary

- **What changed:** Set `QWEN_CODE_LEGACY_MCP_BLOCKING=1` in the `beforeAll` of `integration-tests/cli/simple-mcp-server.test.ts` so the spawned CLI uses the pre-#3994 synchronous MCP discovery path for just this one test.
- **Why it changed:** Since #3994 (`d343e2c15`) landed, this test fails all three retries on every scheduled `Release` run (no-sandbox + docker). The model never sees the configured MCP `add` tool on the first `--prompt` request and answers `15` from its own knowledge. Reported as #4163.
- **Reviewer focus:** The workaround is scoped to one test rather than added to the workflow env, so other integration tests keep exercising the new progressive-MCP code path. Comment in code points reviewers at the open bug for cleanup once it's fixed.

## Validation

- Commands run:
  ```bash
  npm run build && npm run bundle
  # before the patch — fail-all-retries baseline
  cd integration-tests && QWEN_SANDBOX=false npx vitest run cli/simple-mcp-server.test.ts
  # after the patch
  cd integration-tests && QWEN_SANDBOX=false npx vitest run cli/simple-mcp-server.test.ts
  ```
- Prompts / inputs used: the test's existing `'add 5 and 10, use tool if you can.'` — unchanged.
- Expected result: with the workaround in place, `simple-mcp-server > should add two numbers` passes on the first attempt.
- Observed result:

  | Variant | Result | Duration |
  | --- | --- | --- |
  | `main` (no patch) | **FAIL** — 3/3 retries: `Expected to find an add tool call: expected false to be truthy` | 167s |
  | This PR | **PASS** on first try | 22s |

- Quickest reviewer verification path: build the bundle, run the integration test as above, observe a single-try pass in ~22s.

## Scope / Risk

- **Main risk or tradeoff:** This test no longer exercises the new progressive-MCP path. Coverage for that path remains in `mcp_server_cyclic_schema.test.ts` and the rest of the integration suite. The flag is process-local to the test's spawned CLI; no other tests or workflows are affected.
- **Not covered / not validated:** The underlying bug — the new progressive-MCP path failing to wire MCP tools into the model's first non-interactive request — is not fixed here. Tracking in #4163.
- **Breaking changes / migration notes:** None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | N/A | N/A | N/A |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Verified locally on macOS with `QWEN_SANDBOX=false`. Linux + Docker variants will run on the PR CI; the flag has identical semantics on every platform (it's read in `Config.initialize()` regardless of host).

## Linked Issues / Bugs

Refs #4163 (do not close — this is a workaround, not the fix).