### PR TITLE
feat(cli): add baseline /doctor memory diagnostics

### DIFF
--- a/packages/cli/src/ui/commands/doctorCommand.test.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.test.ts
@@ -34,16 +34,7 @@ describe('doctorCommand', () => {
     },
   ];
 
-  beforeEach(() => {
-    mockContext = createMockCommandContext({
-      executionMode: 'interactive',
-      ui: {
-        addItem: vi.fn(),
-        setPendingItem: vi.fn(),
-      },
-    } as unknown as CommandContext);
-
-    vi.mocked(doctorChecksModule.runDoctorChecks).mockResolvedValue(mockChecks);
+  function mockMemoryDiagnostics() {
     vi.mocked(memoryDiagnosticsModule.getMemoryDiagnostics).mockReturnValue({
       generatedAt: '2026-05-15T12:00:00.000Z',
       process: {
@@ -70,6 +61,19 @@ describe('doctorCommand', () => {
     vi.mocked(memoryDiagnosticsModule.formatMemoryDiagnostics).mockReturnValue(
       'Memory diagnostics\nRSS: 100.0 MiB\nActive handles: 3',
     );
+  }
+
+  beforeEach(() => {
+    mockContext = createMockCommandContext({
+      executionMode: 'interactive',
+      ui: {
+        addItem: vi.fn(),
+        setPendingItem: vi.fn(),
+      },
+    } as unknown as CommandContext);
+
+    vi.mocked(doctorChecksModule.runDoctorChecks).mockResolvedValue(mockChecks);
+    mockMemoryDiagnostics();
   });
 
   afterEach(() => {
@@ -179,6 +183,82 @@ describe('doctorCommand', () => {
       messageType: 'info',
       content: 'Memory diagnostics\nRSS: 100.0 MiB\nActive handles: 3',
     });
+    expect(doctorChecksModule.runDoctorChecks).not.toHaveBeenCalled();
+  });
+
+  it('should stop memory diagnostics when aborted before collection', async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+
+    mockContext = createMockCommandContext({
+      executionMode: 'interactive',
+      abortSignal: abortController.signal,
+      ui: {
+        addItem: vi.fn(),
+        setPendingItem: vi.fn(),
+      },
+    } as unknown as CommandContext);
+
+    const result = await doctorCommand.action!(mockContext, 'memory');
+
+    expect(result).toBeUndefined();
+    expect(memoryDiagnosticsModule.getMemoryDiagnostics).not.toHaveBeenCalled();
+    expect(
+      memoryDiagnosticsModule.formatMemoryDiagnostics,
+    ).not.toHaveBeenCalled();
+    expect(mockContext.ui.addItem).not.toHaveBeenCalled();
+    expect(doctorChecksModule.runDoctorChecks).not.toHaveBeenCalled();
+  });
+
+  it('should not add memory diagnostics when aborted after collection', async () => {
+    const abortController = new AbortController();
+    vi.mocked(memoryDiagnosticsModule.getMemoryDiagnostics).mockImplementation(
+      () => {
+        const diagnostics = {
+          generatedAt: '2026-05-15T12:00:00.000Z',
+          process: {
+            pid: 123,
+            nodeVersion: 'v22.0.0',
+            platform: 'linux' as const,
+            arch: 'x64',
+            uptimeSeconds: 42,
+          },
+          memory: {
+            rss: 100,
+            heapTotal: 80,
+            heapUsed: 40,
+            external: 5,
+            arrayBuffers: 2,
+          },
+          v8: {
+            heapStatistics: {},
+            heapSpaces: [],
+          },
+          activeHandles: { count: 3, unavailable: false },
+          activeRequests: { count: 1, unavailable: false },
+        };
+        abortController.abort();
+        return diagnostics;
+      },
+    );
+
+    mockContext = createMockCommandContext({
+      executionMode: 'interactive',
+      abortSignal: abortController.signal,
+      ui: {
+        addItem: vi.fn(),
+        setPendingItem: vi.fn(),
+      },
+    } as unknown as CommandContext);
+
+    const result = await doctorCommand.action!(mockContext, 'memory');
+
+    expect(result).toBeUndefined();
+    expect(memoryDiagnosticsModule.getMemoryDiagnostics).toHaveBeenCalled();
+    expect(
+      memoryDiagnosticsModule.formatMemoryDiagnostics,
+    ).not.toHaveBeenCalled();
+    expect(mockContext.ui.addItem).not.toHaveBeenCalled();
     expect(doctorChecksModule.runDoctorChecks).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/src/ui/commands/doctorCommand.test.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.test.ts
@@ -64,6 +64,22 @@ describe('doctorCommand', () => {
     vi.mocked(memoryDiagnosticsModule.writeMemoryHeapSnapshot).mockReturnValue(
       '/tmp/qwen-code-heap.heapsnapshot',
     );
+    vi.mocked(
+      memoryDiagnosticsModule.collectMemoryPressureSamples,
+    ).mockResolvedValue([
+      {
+        index: 1,
+        timestamp: '2026-05-15T12:00:00.000Z',
+        rss: 100,
+        heapTotal: 80,
+        heapUsed: 40,
+        external: 5,
+        arrayBuffers: 2,
+      },
+    ]);
+    vi.mocked(
+      memoryDiagnosticsModule.formatMemoryPressureSamples,
+    ).mockReturnValue('Memory pressure samples\nSample count: 1');
   }
 
   beforeEach(() => {
@@ -210,6 +226,72 @@ describe('doctorCommand', () => {
       content:
         'Memory diagnostics\nRSS: 100.0 MiB\nActive handles: 3\n\nHeap snapshot written: /tmp/qwen-code-heap.heapsnapshot',
     });
+  });
+
+  it('should capture a short memory pressure sample when requested', async () => {
+    mockContext = createMockCommandContext({
+      executionMode: 'non_interactive',
+      ui: {
+        addItem: vi.fn(),
+        setPendingItem: vi.fn(),
+      },
+    } as unknown as CommandContext);
+
+    const result = await doctorCommand.action!(mockContext, 'memory --sample');
+
+    expect(
+      memoryDiagnosticsModule.collectMemoryPressureSamples,
+    ).toHaveBeenCalledWith({ sampleCount: 3, intervalMs: 1000 });
+    expect(
+      memoryDiagnosticsModule.formatMemoryPressureSamples,
+    ).toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content:
+        'Memory diagnostics\nRSS: 100.0 MiB\nActive handles: 3\n\nMemory pressure samples\nSample count: 1',
+    });
+  });
+
+  it('should stop memory diagnostics when aborted after sampling', async () => {
+    const abortController = new AbortController();
+    vi.mocked(
+      memoryDiagnosticsModule.collectMemoryPressureSamples,
+    ).mockImplementation(async () => {
+      abortController.abort();
+      return [
+        {
+          index: 1,
+          timestamp: '2026-05-15T12:00:00.000Z',
+          rss: 100,
+          heapTotal: 80,
+          heapUsed: 40,
+          external: 5,
+          arrayBuffers: 2,
+        },
+      ];
+    });
+
+    mockContext = createMockCommandContext({
+      executionMode: 'interactive',
+      abortSignal: abortController.signal,
+      ui: {
+        addItem: vi.fn(),
+        setPendingItem: vi.fn(),
+      },
+    } as unknown as CommandContext);
+
+    const result = await doctorCommand.action!(mockContext, 'memory --sample');
+
+    expect(result).toBeUndefined();
+    expect(
+      memoryDiagnosticsModule.collectMemoryPressureSamples,
+    ).toHaveBeenCalled();
+    expect(
+      memoryDiagnosticsModule.formatMemoryPressureSamples,
+    ).not.toHaveBeenCalled();
+    expect(mockContext.ui.addItem).not.toHaveBeenCalled();
+    expect(doctorChecksModule.runDoctorChecks).not.toHaveBeenCalled();
   });
 
   it('should stop memory diagnostics when aborted before collection', async () => {

--- a/packages/cli/src/ui/commands/doctorCommand.test.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.test.ts
@@ -224,7 +224,34 @@ describe('doctorCommand', () => {
       type: 'message',
       messageType: 'info',
       content:
-        'Memory diagnostics\nRSS: 100.0 MiB\nActive handles: 3\n\nHeap snapshot written: /tmp/qwen-code-heap.heapsnapshot',
+        'Memory diagnostics\nRSS: 100.0 MiB\nActive handles: 3\n\nHeap snapshot written: /tmp/qwen-code-heap.heapsnapshot\nHeap snapshot may contain prompts, file contents, tool results, and other sensitive data. Do not share it publicly without reviewing it first.',
+    });
+  });
+
+  it('should report heap snapshot failures without dropping memory diagnostics', async () => {
+    vi.mocked(
+      memoryDiagnosticsModule.writeMemoryHeapSnapshot,
+    ).mockImplementation(() => {
+      throw new Error('disk full');
+    });
+    mockContext = createMockCommandContext({
+      executionMode: 'non_interactive',
+      ui: {
+        addItem: vi.fn(),
+        setPendingItem: vi.fn(),
+      },
+    } as unknown as CommandContext);
+
+    const result = await doctorCommand.action!(
+      mockContext,
+      'memory --snapshot',
+    );
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content:
+        'Memory diagnostics\nRSS: 100.0 MiB\nActive handles: 3\n\nHeap snapshot failed: disk full',
     });
   });
 

--- a/packages/cli/src/ui/commands/doctorCommand.test.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.test.ts
@@ -438,7 +438,7 @@ describe('doctorCommand', () => {
     });
   });
 
-  it('should stop memory diagnostics when aborted after sampling', async () => {
+  it('should render completed sample diagnostics when aborted after sampling', async () => {
     const abortController = new AbortController();
     vi.mocked(
       memoryDiagnosticsModule.collectMemoryPressureSamples,
@@ -474,8 +474,14 @@ describe('doctorCommand', () => {
     ).toHaveBeenCalled();
     expect(
       memoryDiagnosticsModule.formatMemoryPressureSamples,
-    ).not.toHaveBeenCalled();
-    expect(mockContext.ui.addItem).not.toHaveBeenCalled();
+    ).toHaveBeenCalled();
+    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'info',
+        text: expect.stringContaining('Memory pressure samples'),
+      }),
+      expect.any(Number),
+    );
     expect(doctorChecksModule.runDoctorChecks).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/src/ui/commands/doctorCommand.test.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.test.ts
@@ -9,9 +9,11 @@ import { doctorCommand } from './doctorCommand.js';
 import { type CommandContext } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import * as doctorChecksModule from '../../utils/doctorChecks.js';
+import * as memoryDiagnosticsModule from '../../utils/memoryDiagnostics.js';
 import type { DoctorCheckResult } from '../types.js';
 
 vi.mock('../../utils/doctorChecks.js');
+vi.mock('../../utils/memoryDiagnostics.js');
 
 describe('doctorCommand', () => {
   let mockContext: CommandContext;
@@ -42,6 +44,32 @@ describe('doctorCommand', () => {
     } as unknown as CommandContext);
 
     vi.mocked(doctorChecksModule.runDoctorChecks).mockResolvedValue(mockChecks);
+    vi.mocked(memoryDiagnosticsModule.getMemoryDiagnostics).mockReturnValue({
+      generatedAt: '2026-05-15T12:00:00.000Z',
+      process: {
+        pid: 123,
+        nodeVersion: 'v22.0.0',
+        platform: 'linux',
+        arch: 'x64',
+        uptimeSeconds: 42,
+      },
+      memory: {
+        rss: 100,
+        heapTotal: 80,
+        heapUsed: 40,
+        external: 5,
+        arrayBuffers: 2,
+      },
+      v8: {
+        heapStatistics: {},
+        heapSpaces: [],
+      },
+      activeHandles: { count: 3, unavailable: false },
+      activeRequests: { count: 1, unavailable: false },
+    });
+    vi.mocked(memoryDiagnosticsModule.formatMemoryDiagnostics).mockReturnValue(
+      'Memory diagnostics\nRSS: 100.0 MiB\nActive handles: 3',
+    );
   });
 
   afterEach(() => {
@@ -118,6 +146,40 @@ describe('doctorCommand', () => {
         messageType: 'info',
       }),
     );
+  });
+
+  it('should render memory diagnostics in interactive mode', async () => {
+    await doctorCommand.action!(mockContext, 'memory');
+
+    expect(memoryDiagnosticsModule.getMemoryDiagnostics).toHaveBeenCalled();
+    expect(memoryDiagnosticsModule.formatMemoryDiagnostics).toHaveBeenCalled();
+    expect(doctorChecksModule.runDoctorChecks).not.toHaveBeenCalled();
+    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'info',
+        text: expect.stringContaining('Memory diagnostics'),
+      }),
+      expect.any(Number),
+    );
+  });
+
+  it('should return memory diagnostics in non-interactive mode', async () => {
+    mockContext = createMockCommandContext({
+      executionMode: 'non_interactive',
+      ui: {
+        addItem: vi.fn(),
+        setPendingItem: vi.fn(),
+      },
+    } as unknown as CommandContext);
+
+    const result = await doctorCommand.action!(mockContext, 'memory');
+
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Memory diagnostics\nRSS: 100.0 MiB\nActive handles: 3',
+    });
+    expect(doctorChecksModule.runDoctorChecks).not.toHaveBeenCalled();
   });
 
   it('should not add item when aborted', async () => {

--- a/packages/cli/src/ui/commands/doctorCommand.test.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.test.ts
@@ -228,6 +228,130 @@ describe('doctorCommand', () => {
     });
   });
 
+  it('should render sampled memory diagnostics in interactive mode', async () => {
+    await doctorCommand.action!(mockContext, 'memory --sample');
+
+    expect(
+      memoryDiagnosticsModule.collectMemoryPressureSamples,
+    ).toHaveBeenCalled();
+    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'info',
+        text: expect.stringContaining('Memory pressure samples'),
+      }),
+      expect.any(Number),
+    );
+  });
+
+  it('should refuse heap snapshot when heap pressure is already high', async () => {
+    vi.mocked(memoryDiagnosticsModule.getMemoryDiagnostics).mockReturnValue({
+      generatedAt: '2026-05-15T12:00:00.000Z',
+      process: {
+        pid: 123,
+        nodeVersion: 'v22.0.0',
+        platform: 'linux',
+        arch: 'x64',
+        uptimeSeconds: 42,
+      },
+      memory: {
+        rss: 3900,
+        heapTotal: 3600,
+        heapUsed: 900,
+        external: 5,
+        arrayBuffers: 2,
+      },
+      v8: {
+        heapStatistics: { heap_size_limit: 1000 },
+        heapSpaces: [],
+      },
+      activeHandles: { count: 3, unavailable: false },
+      activeRequests: { count: 1, unavailable: false },
+    });
+
+    mockContext = createMockCommandContext({
+      executionMode: 'non_interactive',
+      ui: {
+        addItem: vi.fn(),
+        setPendingItem: vi.fn(),
+      },
+    } as unknown as CommandContext);
+
+    const result = await doctorCommand.action!(
+      mockContext,
+      'memory --snapshot',
+    );
+
+    expect(
+      memoryDiagnosticsModule.writeMemoryHeapSnapshot,
+    ).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageType: 'error',
+        content: expect.stringContaining('Heap snapshot skipped'),
+      }),
+    );
+  });
+
+  it('should render heap snapshot diagnostics in interactive mode', async () => {
+    await doctorCommand.action!(mockContext, 'memory --snapshot');
+
+    expect(memoryDiagnosticsModule.writeMemoryHeapSnapshot).toHaveBeenCalled();
+    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'info',
+        text: expect.stringContaining('Heap snapshot written'),
+      }),
+      expect.any(Number),
+    );
+  });
+
+  it('should render heap snapshot failures as error items in interactive mode', async () => {
+    vi.mocked(
+      memoryDiagnosticsModule.writeMemoryHeapSnapshot,
+    ).mockImplementation(() => {
+      throw new Error('disk full');
+    });
+
+    await doctorCommand.action!(mockContext, 'memory --snapshot');
+
+    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'error',
+        text: expect.stringContaining('Heap snapshot failed: disk full'),
+      }),
+      expect.any(Number),
+    );
+  });
+
+  it('should not write heap snapshot when aborted before the snapshot side effect', async () => {
+    const abortController = new AbortController();
+    vi.mocked(
+      memoryDiagnosticsModule.formatMemoryDiagnostics,
+    ).mockImplementation(() => {
+      abortController.abort();
+      return 'Memory diagnostics';
+    });
+    mockContext = createMockCommandContext({
+      executionMode: 'interactive',
+      abortSignal: abortController.signal,
+      ui: {
+        addItem: vi.fn(),
+        setPendingItem: vi.fn(),
+      },
+    } as unknown as CommandContext);
+
+    const result = await doctorCommand.action!(
+      mockContext,
+      'memory --snapshot',
+    );
+
+    expect(result).toBeUndefined();
+    expect(
+      memoryDiagnosticsModule.writeMemoryHeapSnapshot,
+    ).not.toHaveBeenCalled();
+    expect(mockContext.ui.addItem).not.toHaveBeenCalled();
+  });
+
   it('should report heap snapshot failures without dropping memory diagnostics', async () => {
     vi.mocked(
       memoryDiagnosticsModule.writeMemoryHeapSnapshot,

--- a/packages/cli/src/ui/commands/doctorCommand.test.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.test.ts
@@ -80,6 +80,9 @@ describe('doctorCommand', () => {
     vi.mocked(
       memoryDiagnosticsModule.formatMemoryPressureSamples,
     ).mockReturnValue('Memory pressure samples\nSample count: 1');
+    vi.mocked(memoryDiagnosticsModule.isHighHeapPressure).mockReturnValue(
+      false,
+    );
   }
 
   beforeEach(() => {
@@ -103,6 +106,18 @@ describe('doctorCommand', () => {
     expect(doctorCommand.name).toBe('doctor');
     expect(doctorCommand.description).toBe(
       'Run installation and environment diagnostics',
+    );
+  });
+
+  it('should complete memory subcommand names', async () => {
+    await expect(doctorCommand.completion!(mockContext, '')).resolves.toEqual([
+      'memory',
+    ]);
+    await expect(
+      doctorCommand.completion!(mockContext, 'mem'),
+    ).resolves.toEqual(['memory']);
+    await expect(doctorCommand.completion!(mockContext, 'x')).resolves.toEqual(
+      [],
     );
   });
 
@@ -244,29 +259,7 @@ describe('doctorCommand', () => {
   });
 
   it('should refuse heap snapshot when heap pressure is already high', async () => {
-    vi.mocked(memoryDiagnosticsModule.getMemoryDiagnostics).mockReturnValue({
-      generatedAt: '2026-05-15T12:00:00.000Z',
-      process: {
-        pid: 123,
-        nodeVersion: 'v22.0.0',
-        platform: 'linux',
-        arch: 'x64',
-        uptimeSeconds: 42,
-      },
-      memory: {
-        rss: 3900,
-        heapTotal: 3600,
-        heapUsed: 900,
-        external: 5,
-        arrayBuffers: 2,
-      },
-      v8: {
-        heapStatistics: { heap_size_limit: 1000 },
-        heapSpaces: [],
-      },
-      activeHandles: { count: 3, unavailable: false },
-      activeRequests: { count: 1, unavailable: false },
-    });
+    vi.mocked(memoryDiagnosticsModule.isHighHeapPressure).mockReturnValue(true);
 
     mockContext = createMockCommandContext({
       executionMode: 'non_interactive',
@@ -301,6 +294,7 @@ describe('doctorCommand', () => {
         text: 'Writing heap snapshot, this may take a moment...',
       }),
     );
+    expect(mockContext.ui.setPendingItem).toHaveBeenCalledWith(null);
     expect(mockContext.ui.addItem).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'info',
@@ -315,7 +309,14 @@ describe('doctorCommand', () => {
 
     expect(
       memoryDiagnosticsModule.collectMemoryPressureSamples,
-    ).toHaveBeenCalledWith({ sampleCount: 3, intervalMs: 1000 });
+    ).toHaveBeenCalledWith({
+      sampleCount: 3,
+      intervalMs: 1000,
+      signal: undefined,
+    });
+    expect(memoryDiagnosticsModule.getMemoryDiagnostics).toHaveBeenCalledTimes(
+      2,
+    );
     expect(memoryDiagnosticsModule.writeMemoryHeapSnapshot).toHaveBeenCalled();
     expect(mockContext.ui.addItem).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -342,6 +343,7 @@ describe('doctorCommand', () => {
 
     await doctorCommand.action!(mockContext, 'memory --snapshot');
 
+    expect(mockContext.ui.setPendingItem).toHaveBeenCalledWith(null);
     expect(mockContext.ui.addItem).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'error',
@@ -420,7 +422,11 @@ describe('doctorCommand', () => {
 
     expect(
       memoryDiagnosticsModule.collectMemoryPressureSamples,
-    ).toHaveBeenCalledWith({ sampleCount: 3, intervalMs: 1000 });
+    ).toHaveBeenCalledWith({
+      sampleCount: 3,
+      intervalMs: 1000,
+      signal: undefined,
+    });
     expect(
       memoryDiagnosticsModule.formatMemoryPressureSamples,
     ).toHaveBeenCalled();
@@ -471,6 +477,36 @@ describe('doctorCommand', () => {
     ).not.toHaveBeenCalled();
     expect(mockContext.ui.addItem).not.toHaveBeenCalled();
     expect(doctorChecksModule.runDoctorChecks).not.toHaveBeenCalled();
+  });
+
+  it('should recheck heap pressure after sampling before writing snapshot', async () => {
+    vi.mocked(memoryDiagnosticsModule.isHighHeapPressure).mockReturnValue(true);
+
+    mockContext = createMockCommandContext({
+      executionMode: 'non_interactive',
+      ui: {
+        addItem: vi.fn(),
+        setPendingItem: vi.fn(),
+      },
+    } as unknown as CommandContext);
+
+    const result = await doctorCommand.action!(
+      mockContext,
+      'memory --sample --snapshot',
+    );
+
+    expect(memoryDiagnosticsModule.getMemoryDiagnostics).toHaveBeenCalledTimes(
+      2,
+    );
+    expect(
+      memoryDiagnosticsModule.writeMemoryHeapSnapshot,
+    ).not.toHaveBeenCalled();
+    expect(result).toEqual(
+      expect.objectContaining({
+        messageType: 'error',
+        content: expect.stringContaining('Heap snapshot skipped'),
+      }),
+    );
   });
 
   it('should stop memory diagnostics when aborted before collection', async () => {

--- a/packages/cli/src/ui/commands/doctorCommand.test.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.test.ts
@@ -61,6 +61,9 @@ describe('doctorCommand', () => {
     vi.mocked(memoryDiagnosticsModule.formatMemoryDiagnostics).mockReturnValue(
       'Memory diagnostics\nRSS: 100.0 MiB\nActive handles: 3',
     );
+    vi.mocked(memoryDiagnosticsModule.writeMemoryHeapSnapshot).mockReturnValue(
+      '/tmp/qwen-code-heap.heapsnapshot',
+    );
   }
 
   beforeEach(() => {
@@ -184,6 +187,29 @@ describe('doctorCommand', () => {
       content: 'Memory diagnostics\nRSS: 100.0 MiB\nActive handles: 3',
     });
     expect(doctorChecksModule.runDoctorChecks).not.toHaveBeenCalled();
+  });
+
+  it('should capture a heap snapshot when requested', async () => {
+    mockContext = createMockCommandContext({
+      executionMode: 'non_interactive',
+      ui: {
+        addItem: vi.fn(),
+        setPendingItem: vi.fn(),
+      },
+    } as unknown as CommandContext);
+
+    const result = await doctorCommand.action!(
+      mockContext,
+      'memory --snapshot',
+    );
+
+    expect(memoryDiagnosticsModule.writeMemoryHeapSnapshot).toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content:
+        'Memory diagnostics\nRSS: 100.0 MiB\nActive handles: 3\n\nHeap snapshot written: /tmp/qwen-code-heap.heapsnapshot',
+    });
   });
 
   it('should stop memory diagnostics when aborted before collection', async () => {

--- a/packages/cli/src/ui/commands/doctorCommand.test.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.test.ts
@@ -296,6 +296,34 @@ describe('doctorCommand', () => {
     await doctorCommand.action!(mockContext, 'memory --snapshot');
 
     expect(memoryDiagnosticsModule.writeMemoryHeapSnapshot).toHaveBeenCalled();
+    expect(mockContext.ui.setPendingItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        text: 'Writing heap snapshot, this may take a moment...',
+      }),
+    );
+    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'info',
+        text: expect.stringContaining('Heap snapshot written'),
+      }),
+      expect.any(Number),
+    );
+  });
+
+  it('should render sampled heap snapshot diagnostics in interactive mode', async () => {
+    await doctorCommand.action!(mockContext, 'memory --sample --snapshot');
+
+    expect(
+      memoryDiagnosticsModule.collectMemoryPressureSamples,
+    ).toHaveBeenCalledWith({ sampleCount: 3, intervalMs: 1000 });
+    expect(memoryDiagnosticsModule.writeMemoryHeapSnapshot).toHaveBeenCalled();
+    expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'info',
+        text: expect.stringContaining('Memory pressure samples'),
+      }),
+      expect.any(Number),
+    );
     expect(mockContext.ui.addItem).toHaveBeenCalledWith(
       expect.objectContaining({
         type: 'info',

--- a/packages/cli/src/ui/commands/doctorCommand.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.ts
@@ -91,12 +91,26 @@ export const doctorCommand: SlashCommand = {
           intervalMs: 1000,
           signal: abortSignal,
         });
+        report = `${report}\n\n${formatMemoryPressureSamples(samples)}`;
 
         if (abortSignal?.aborted) {
-          return;
-        }
+          if (executionMode === 'interactive') {
+            context.ui.addItem(
+              {
+                type: 'info',
+                text: report,
+              },
+              Date.now(),
+            );
+            return;
+          }
 
-        report = `${report}\n\n${formatMemoryPressureSamples(samples)}`;
+          return {
+            type: 'message' as const,
+            messageType: 'info' as const,
+            content: report,
+          };
+        }
       }
 
       if (shouldWriteHeapSnapshot) {

--- a/packages/cli/src/ui/commands/doctorCommand.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.ts
@@ -11,6 +11,7 @@ import { runDoctorChecks } from '../../utils/doctorChecks.js';
 import {
   formatMemoryDiagnostics,
   getMemoryDiagnostics,
+  writeMemoryHeapSnapshot,
 } from '../../utils/memoryDiagnostics.js';
 import { t } from '../../i18n/index.js';
 
@@ -35,7 +36,10 @@ export const doctorCommand: SlashCommand = {
   action: async (context, args) => {
     const executionMode = context.executionMode ?? 'interactive';
     const abortSignal = context.abortSignal;
-    const subCommand = args?.trim().toLowerCase() ?? '';
+    const subCommandArgs =
+      args?.trim().toLowerCase().split(/\s+/).filter(Boolean) ?? [];
+    const subCommand = subCommandArgs[0] ?? '';
+    const shouldWriteHeapSnapshot = subCommandArgs.includes('--snapshot');
 
     if (subCommand === MEMORY_SUBCOMMAND) {
       if (abortSignal?.aborted) {
@@ -48,7 +52,16 @@ export const doctorCommand: SlashCommand = {
         return;
       }
 
-      const report = formatMemoryDiagnostics(diagnostics);
+      let report = formatMemoryDiagnostics(diagnostics);
+
+      if (abortSignal?.aborted) {
+        return;
+      }
+
+      if (shouldWriteHeapSnapshot) {
+        const heapSnapshotPath = writeMemoryHeapSnapshot();
+        report = `${report}\n\nHeap snapshot written: ${heapSnapshotPath}`;
+      }
 
       if (abortSignal?.aborted) {
         return;

--- a/packages/cli/src/ui/commands/doctorCommand.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.ts
@@ -13,14 +13,18 @@ import {
   formatMemoryDiagnostics,
   formatMemoryPressureSamples,
   getMemoryDiagnostics,
+  isHighHeapPressure,
   writeMemoryHeapSnapshot,
 } from '../../utils/memoryDiagnostics.js';
 import { t } from '../../i18n/index.js';
 
 const MEMORY_SUBCOMMAND = 'memory';
 const DOCTOR_SUBCOMMANDS = [MEMORY_SUBCOMMAND] as const;
-const HEAP_SNAPSHOT_SENSITIVE_DATA_WARNING =
-  'Heap snapshot may contain prompts, file contents, tool results, and other sensitive data. Do not share it publicly without reviewing it first.';
+function getHeapSnapshotSensitiveDataWarning(): string {
+  return t(
+    'Heap snapshot may contain prompts, file contents, tool results, and other sensitive data. Do not share it publicly without reviewing it first.',
+  );
+}
 
 function formatErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -30,19 +34,7 @@ function formatHeapSnapshotErrorMessage(error: unknown): string {
   const message = formatErrorMessage(error);
   return message.startsWith('Heap snapshot')
     ? message
-    : `Heap snapshot failed: ${message}`;
-}
-
-function hasHighHeapPressure(
-  diagnostics: ReturnType<typeof getMemoryDiagnostics>,
-): boolean {
-  const heapSizeLimit = diagnostics.v8.heapStatistics?.['heap_size_limit'];
-  return (
-    typeof heapSizeLimit === 'number' &&
-    Number.isFinite(heapSizeLimit) &&
-    heapSizeLimit > 0 &&
-    diagnostics.memory.heapUsed / heapSizeLimit >= 0.85
-  );
+    : `${t('Heap snapshot failed:')} ${message}`;
 }
 
 export const doctorCommand: SlashCommand = {
@@ -87,6 +79,7 @@ export const doctorCommand: SlashCommand = {
 
       let report = formatMemoryDiagnostics(diagnostics);
       let messageType: 'info' | 'error' = 'info';
+      let heapSnapshotWritten = false;
 
       if (abortSignal?.aborted) {
         return;
@@ -96,6 +89,7 @@ export const doctorCommand: SlashCommand = {
         const samples = await collectMemoryPressureSamples({
           sampleCount: 3,
           intervalMs: 1000,
+          signal: abortSignal,
         });
 
         if (abortSignal?.aborted) {
@@ -118,21 +112,35 @@ export const doctorCommand: SlashCommand = {
         }
 
         try {
-          if (hasHighHeapPressure(diagnostics)) {
+          const latestDiagnostics = shouldSampleMemory
+            ? getMemoryDiagnostics()
+            : diagnostics;
+          if (isHighHeapPressure(latestDiagnostics)) {
             throw new Error(
-              'Heap snapshot skipped: V8 heap pressure is already high, and writing a synchronous heap snapshot could make the process unresponsive or trigger OOM. Restart Qwen Code first if it is unstable, or retry before memory pressure reaches the warning threshold.',
+              t(
+                'Heap snapshot skipped: V8 heap pressure is already high, and writing a synchronous heap snapshot could make the process unresponsive or trigger OOM. Restart Qwen Code first if it is unstable, or retry before memory pressure reaches the warning threshold.',
+              ),
             );
           }
 
           const heapSnapshotPath = writeMemoryHeapSnapshot();
-          report = `${report}\n\nHeap snapshot written: ${heapSnapshotPath}\n${HEAP_SNAPSHOT_SENSITIVE_DATA_WARNING}`;
+          heapSnapshotWritten = true;
+          report = `${report}\n\n${t('Heap snapshot written:')} ${heapSnapshotPath}\n${getHeapSnapshotSensitiveDataWarning()}`;
         } catch (error) {
           messageType = 'error';
           report = `${report}\n\n${formatHeapSnapshotErrorMessage(error)}`;
+        } finally {
+          if (executionMode === 'interactive') {
+            context.ui.setPendingItem(null);
+          }
         }
       }
 
-      if (abortSignal?.aborted && !report.includes('Heap snapshot written:')) {
+      if (
+        abortSignal?.aborted &&
+        shouldWriteHeapSnapshot &&
+        !heapSnapshotWritten
+      ) {
         return;
       }
 

--- a/packages/cli/src/ui/commands/doctorCommand.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.ts
@@ -6,13 +6,16 @@
 
 import type { SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
-import type { HistoryItemDoctor, HistoryItemInfo } from '../types.js';
+import type { HistoryItemDoctor } from '../types.js';
 import { runDoctorChecks } from '../../utils/doctorChecks.js';
 import {
   formatMemoryDiagnostics,
   getMemoryDiagnostics,
 } from '../../utils/memoryDiagnostics.js';
 import { t } from '../../i18n/index.js';
+
+const MEMORY_SUBCOMMAND = 'memory';
+const DOCTOR_SUBCOMMANDS = [MEMORY_SUBCOMMAND] as const;
 
 export const doctorCommand: SlashCommand = {
   name: 'doctor',
@@ -24,24 +27,41 @@ export const doctorCommand: SlashCommand = {
   argumentHint: '[memory]',
   examples: ['/doctor', '/doctor memory'],
   completion: async (_context, partialArg) => {
-    const candidates = ['memory'];
     const trimmed = partialArg.trimStart();
-    return candidates.filter((candidate) => candidate.startsWith(trimmed));
+    return DOCTOR_SUBCOMMANDS.filter((candidate) =>
+      candidate.startsWith(trimmed),
+    );
   },
   action: async (context, args) => {
     const executionMode = context.executionMode ?? 'interactive';
     const abortSignal = context.abortSignal;
-    const subCommand = args.trim().toLowerCase();
+    const subCommand = args?.trim().toLowerCase() ?? '';
 
-    if (subCommand === 'memory') {
-      const report = formatMemoryDiagnostics(getMemoryDiagnostics());
+    if (subCommand === MEMORY_SUBCOMMAND) {
+      if (abortSignal?.aborted) {
+        return;
+      }
+
+      const diagnostics = getMemoryDiagnostics();
+
+      if (abortSignal?.aborted) {
+        return;
+      }
+
+      const report = formatMemoryDiagnostics(diagnostics);
+
+      if (abortSignal?.aborted) {
+        return;
+      }
 
       if (executionMode === 'interactive') {
-        const memoryItem: Omit<HistoryItemInfo, 'id'> = {
-          type: 'info',
-          text: report,
-        };
-        context.ui.addItem(memoryItem, Date.now());
+        context.ui.addItem(
+          {
+            type: 'info',
+            text: report,
+          },
+          Date.now(),
+        );
         return;
       }
 

--- a/packages/cli/src/ui/commands/doctorCommand.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.ts
@@ -6,8 +6,12 @@
 
 import type { SlashCommand } from './types.js';
 import { CommandKind } from './types.js';
-import type { HistoryItemDoctor } from '../types.js';
+import type { HistoryItemDoctor, HistoryItemInfo } from '../types.js';
 import { runDoctorChecks } from '../../utils/doctorChecks.js';
+import {
+  formatMemoryDiagnostics,
+  getMemoryDiagnostics,
+} from '../../utils/memoryDiagnostics.js';
 import { t } from '../../i18n/index.js';
 
 export const doctorCommand: SlashCommand = {
@@ -17,9 +21,36 @@ export const doctorCommand: SlashCommand = {
   },
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
-  action: async (context) => {
+  argumentHint: '[memory]',
+  examples: ['/doctor', '/doctor memory'],
+  completion: async (_context, partialArg) => {
+    const candidates = ['memory'];
+    const trimmed = partialArg.trimStart();
+    return candidates.filter((candidate) => candidate.startsWith(trimmed));
+  },
+  action: async (context, args) => {
     const executionMode = context.executionMode ?? 'interactive';
     const abortSignal = context.abortSignal;
+    const subCommand = args.trim().toLowerCase();
+
+    if (subCommand === 'memory') {
+      const report = formatMemoryDiagnostics(getMemoryDiagnostics());
+
+      if (executionMode === 'interactive') {
+        const memoryItem: Omit<HistoryItemInfo, 'id'> = {
+          type: 'info',
+          text: report,
+        };
+        context.ui.addItem(memoryItem, Date.now());
+        return;
+      }
+
+      return {
+        type: 'message' as const,
+        messageType: 'info' as const,
+        content: report,
+      };
+    }
 
     if (executionMode === 'interactive') {
       context.ui.setPendingItem({

--- a/packages/cli/src/ui/commands/doctorCommand.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.ts
@@ -26,6 +26,25 @@ function formatErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
+function formatHeapSnapshotErrorMessage(error: unknown): string {
+  const message = formatErrorMessage(error);
+  return message.startsWith('Heap snapshot')
+    ? message
+    : `Heap snapshot failed: ${message}`;
+}
+
+function hasHighHeapPressure(
+  diagnostics: ReturnType<typeof getMemoryDiagnostics>,
+): boolean {
+  const heapSizeLimit = diagnostics.v8.heapStatistics?.['heap_size_limit'];
+  return (
+    typeof heapSizeLimit === 'number' &&
+    Number.isFinite(heapSizeLimit) &&
+    heapSizeLimit > 0 &&
+    diagnostics.memory.heapUsed / heapSizeLimit >= 0.85
+  );
+}
+
 export const doctorCommand: SlashCommand = {
   name: 'doctor',
   get description() {
@@ -87,23 +106,40 @@ export const doctorCommand: SlashCommand = {
       }
 
       if (shouldWriteHeapSnapshot) {
+        if (abortSignal?.aborted) {
+          return;
+        }
+
+        if (executionMode === 'interactive') {
+          context.ui.setPendingItem({
+            type: 'info',
+            text: t('Writing heap snapshot, this may take a moment...'),
+          });
+        }
+
         try {
+          if (hasHighHeapPressure(diagnostics)) {
+            throw new Error(
+              'Heap snapshot skipped: V8 heap pressure is already high, and writing a synchronous heap snapshot could make the process unresponsive or trigger OOM. Restart Qwen Code first if it is unstable, or retry before memory pressure reaches the warning threshold.',
+            );
+          }
+
           const heapSnapshotPath = writeMemoryHeapSnapshot();
           report = `${report}\n\nHeap snapshot written: ${heapSnapshotPath}\n${HEAP_SNAPSHOT_SENSITIVE_DATA_WARNING}`;
         } catch (error) {
           messageType = 'error';
-          report = `${report}\n\nHeap snapshot failed: ${formatErrorMessage(error)}`;
+          report = `${report}\n\n${formatHeapSnapshotErrorMessage(error)}`;
         }
       }
 
-      if (abortSignal?.aborted) {
+      if (abortSignal?.aborted && !report.includes('Heap snapshot written:')) {
         return;
       }
 
       if (executionMode === 'interactive') {
         context.ui.addItem(
           {
-            type: 'info',
+            type: messageType === 'error' ? 'error' : 'info',
             text: report,
           },
           Date.now(),

--- a/packages/cli/src/ui/commands/doctorCommand.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.ts
@@ -19,6 +19,12 @@ import { t } from '../../i18n/index.js';
 
 const MEMORY_SUBCOMMAND = 'memory';
 const DOCTOR_SUBCOMMANDS = [MEMORY_SUBCOMMAND] as const;
+const HEAP_SNAPSHOT_SENSITIVE_DATA_WARNING =
+  'Heap snapshot may contain prompts, file contents, tool results, and other sensitive data. Do not share it publicly without reviewing it first.';
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
 
 export const doctorCommand: SlashCommand = {
   name: 'doctor',
@@ -61,6 +67,7 @@ export const doctorCommand: SlashCommand = {
       }
 
       let report = formatMemoryDiagnostics(diagnostics);
+      let messageType: 'info' | 'error' = 'info';
 
       if (abortSignal?.aborted) {
         return;
@@ -80,8 +87,13 @@ export const doctorCommand: SlashCommand = {
       }
 
       if (shouldWriteHeapSnapshot) {
-        const heapSnapshotPath = writeMemoryHeapSnapshot();
-        report = `${report}\n\nHeap snapshot written: ${heapSnapshotPath}`;
+        try {
+          const heapSnapshotPath = writeMemoryHeapSnapshot();
+          report = `${report}\n\nHeap snapshot written: ${heapSnapshotPath}\n${HEAP_SNAPSHOT_SENSITIVE_DATA_WARNING}`;
+        } catch (error) {
+          messageType = 'error';
+          report = `${report}\n\nHeap snapshot failed: ${formatErrorMessage(error)}`;
+        }
       }
 
       if (abortSignal?.aborted) {
@@ -101,7 +113,7 @@ export const doctorCommand: SlashCommand = {
 
       return {
         type: 'message' as const,
-        messageType: 'info' as const,
+        messageType,
         content: report,
       };
     }

--- a/packages/cli/src/ui/commands/doctorCommand.ts
+++ b/packages/cli/src/ui/commands/doctorCommand.ts
@@ -9,7 +9,9 @@ import { CommandKind } from './types.js';
 import type { HistoryItemDoctor } from '../types.js';
 import { runDoctorChecks } from '../../utils/doctorChecks.js';
 import {
+  collectMemoryPressureSamples,
   formatMemoryDiagnostics,
+  formatMemoryPressureSamples,
   getMemoryDiagnostics,
   writeMemoryHeapSnapshot,
 } from '../../utils/memoryDiagnostics.js';
@@ -25,8 +27,13 @@ export const doctorCommand: SlashCommand = {
   },
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
-  argumentHint: '[memory]',
-  examples: ['/doctor', '/doctor memory'],
+  argumentHint: '[memory] [--sample] [--snapshot]',
+  examples: [
+    '/doctor',
+    '/doctor memory',
+    '/doctor memory --sample',
+    '/doctor memory --snapshot',
+  ],
   completion: async (_context, partialArg) => {
     const trimmed = partialArg.trimStart();
     return DOCTOR_SUBCOMMANDS.filter((candidate) =>
@@ -40,6 +47,7 @@ export const doctorCommand: SlashCommand = {
       args?.trim().toLowerCase().split(/\s+/).filter(Boolean) ?? [];
     const subCommand = subCommandArgs[0] ?? '';
     const shouldWriteHeapSnapshot = subCommandArgs.includes('--snapshot');
+    const shouldSampleMemory = subCommandArgs.includes('--sample');
 
     if (subCommand === MEMORY_SUBCOMMAND) {
       if (abortSignal?.aborted) {
@@ -56,6 +64,19 @@ export const doctorCommand: SlashCommand = {
 
       if (abortSignal?.aborted) {
         return;
+      }
+
+      if (shouldSampleMemory) {
+        const samples = await collectMemoryPressureSamples({
+          sampleCount: 3,
+          intervalMs: 1000,
+        });
+
+        if (abortSignal?.aborted) {
+          return;
+        }
+
+        report = `${report}\n\n${formatMemoryPressureSamples(samples)}`;
       }
 
       if (shouldWriteHeapSnapshot) {

--- a/packages/cli/src/utils/memoryDiagnostics.test.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.test.ts
@@ -78,8 +78,82 @@ describe('memoryDiagnostics', () => {
       expect(report).toContain('old_space: 20.0 MiB / 30.0 MiB');
       expect(report).toContain('Active handles: 3');
       expect(report).toContain('Active requests: 1');
+      expect(report).toContain('Assessment');
+      expect(report).toContain('Status: ok');
+      expect(report).toContain('Heap pressure: 1.0%');
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('surfaces high heap pressure with actionable recommendations', () => {
+    const report = formatMemoryDiagnostics({
+      generatedAt: '2026-05-15T12:00:00.000Z',
+      process: {
+        pid: 123,
+        nodeVersion: 'v22.0.0',
+        platform: 'linux',
+        arch: 'x64',
+        uptimeSeconds: 120,
+      },
+      memory: {
+        rss: 3900 * 1024 * 1024,
+        heapTotal: 3600 * 1024 * 1024,
+        heapUsed: 3500 * 1024 * 1024,
+        external: 20 * 1024 * 1024,
+        arrayBuffers: 10 * 1024 * 1024,
+      },
+      v8: {
+        heapStatistics: {
+          heap_size_limit: 4096 * 1024 * 1024,
+          total_available_size: 200 * 1024 * 1024,
+        },
+        heapSpaces: [],
+      },
+      activeHandles: { count: 3, unavailable: false },
+      activeRequests: { count: 1, unavailable: false },
+    });
+
+    expect(report).toContain('Status: warn');
+    expect(report).toContain('Heap pressure: 85.4%');
+    expect(report).toContain('V8 heap usage is high');
+    expect(report).toContain('restart Qwen Code to recover memory');
+    expect(report).toContain('capture a heap snapshot');
+  });
+
+  it('surfaces large non-heap memory gaps separately from V8 heap pressure', () => {
+    const report = formatMemoryDiagnostics({
+      generatedAt: '2026-05-15T12:00:00.000Z',
+      process: {
+        pid: 123,
+        nodeVersion: 'v22.0.0',
+        platform: 'linux',
+        arch: 'x64',
+        uptimeSeconds: 120,
+      },
+      memory: {
+        rss: 1800 * 1024 * 1024,
+        heapTotal: 500 * 1024 * 1024,
+        heapUsed: 300 * 1024 * 1024,
+        external: 900 * 1024 * 1024,
+        arrayBuffers: 300 * 1024 * 1024,
+      },
+      v8: {
+        heapStatistics: {
+          heap_size_limit: 4096 * 1024 * 1024,
+          total_available_size: 3000 * 1024 * 1024,
+        },
+        heapSpaces: [],
+      },
+      activeHandles: { count: 3, unavailable: false },
+      activeRequests: { count: 1, unavailable: false },
+    });
+
+    expect(report).toContain('Status: warn');
+    expect(report).toContain('RSS / heap-total gap: 1300.0 MiB');
+    expect(report).toContain('Non-heap memory is high');
+    expect(report).toContain(
+      'large tool results, buffers, or native allocations',
+    );
   });
 });

--- a/packages/cli/src/utils/memoryDiagnostics.test.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.test.ts
@@ -8,16 +8,23 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import * as fs from 'node:fs';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
+  clearHeapSnapshotRateLimit,
   collectMemoryPressureSamples,
   formatMemoryDiagnostics,
   formatMemoryPressureSamples,
   getMemoryDiagnostics,
+  isHighHeapPressure,
   writeMemoryHeapSnapshot,
 } from './memoryDiagnostics.js';
 
 describe('memoryDiagnostics', () => {
+  afterEach(() => {
+    clearHeapSnapshotRateLimit();
+    vi.restoreAllMocks();
+  });
+
   it('collects baseline memory fields', () => {
     const diagnostics = getMemoryDiagnostics();
 
@@ -278,6 +285,113 @@ describe('memoryDiagnostics', () => {
     }
   });
 
+  it('orders heap snapshot cleanup by modification time across process ids', () => {
+    const outputDir = path.join(
+      os.tmpdir(),
+      `qwen-memory-diagnostics-mtime-cleanup-${process.pid}`,
+    );
+    fs.rmSync(outputDir, { recursive: true, force: true });
+    fs.mkdirSync(outputDir, { recursive: true });
+
+    const newerLowPidSnapshot = path.join(
+      outputDir,
+      'qwen-code-heap-9-2026-05-15T12-30-00-000Z.heapsnapshot',
+    );
+    const olderHighPidSnapshot = path.join(
+      outputDir,
+      'qwen-code-heap-12345-2026-05-15T12-00-00-000Z.heapsnapshot',
+    );
+    fs.writeFileSync(newerLowPidSnapshot, 'newer');
+    fs.writeFileSync(olderHighPidSnapshot, 'older');
+    fs.utimesSync(
+      olderHighPidSnapshot,
+      new Date('2026-05-15T12:00:00.000Z'),
+      new Date('2026-05-15T12:00:00.000Z'),
+    );
+    fs.utimesSync(
+      newerLowPidSnapshot,
+      new Date('2026-05-15T12:30:00.000Z'),
+      new Date('2026-05-15T12:30:00.000Z'),
+    );
+
+    const writtenPath = writeMemoryHeapSnapshot({
+      outputDir,
+      now: new Date('2026-05-15T13:00:00.000Z'),
+      maxSnapshots: 2,
+      writeSnapshot: (filePath) => {
+        fs.writeFileSync(filePath, 'snapshot');
+        return filePath;
+      },
+    });
+
+    try {
+      expect(fs.existsSync(olderHighPidSnapshot)).toBe(false);
+      expect(fs.existsSync(newerLowPidSnapshot)).toBe(true);
+      expect(fs.existsSync(writtenPath)).toBe(true);
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps successful heap snapshot writes when cleanup fails', () => {
+    const outputDir = path.join(
+      os.tmpdir(),
+      `qwen-memory-diagnostics-cleanup-fail-${process.pid}`,
+    );
+    fs.rmSync(outputDir, { recursive: true, force: true });
+    fs.mkdirSync(outputDir, { recursive: true });
+    fs.symlinkSync(
+      'missing-target.heapsnapshot',
+      path.join(
+        outputDir,
+        'qwen-code-heap-999-2026-05-15T11-00-00-000Z.heapsnapshot',
+      ),
+    );
+
+    try {
+      const writtenPath = writeMemoryHeapSnapshot({
+        outputDir,
+        now: new Date('2026-05-15T12:00:00.000Z'),
+        maxSnapshots: 1,
+        writeSnapshot: (filePath) => {
+          fs.writeFileSync(filePath, 'snapshot');
+          return filePath;
+        },
+      });
+
+      expect(fs.existsSync(writtenPath)).toBe(true);
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('removes partial heap snapshot files after a failed write', () => {
+    const outputDir = path.join(
+      os.tmpdir(),
+      `qwen-memory-diagnostics-partial-${process.pid}`,
+    );
+    fs.rmSync(outputDir, { recursive: true, force: true });
+    let partialPath = '';
+
+    try {
+      expect(() =>
+        writeMemoryHeapSnapshot({
+          outputDir,
+          now: new Date('2026-05-15T12:00:00.000Z'),
+          writeSnapshot: (filePath) => {
+            partialPath = filePath;
+            fs.writeFileSync(filePath, 'partial');
+            throw new Error('write failed');
+          },
+        }),
+      ).toThrow('write failed');
+
+      expect(fs.existsSync(partialPath)).toBe(false);
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
   it('creates heap snapshot directories and files with private permissions', () => {
     const outputDir = path.join(
       os.tmpdir(),
@@ -334,6 +448,85 @@ describe('memoryDiagnostics', () => {
     );
   });
 
+  it('surfaces high active handle counts with actionable recommendations', () => {
+    const report = formatMemoryDiagnostics({
+      generatedAt: '2026-05-15T12:00:00.000Z',
+      process: {
+        pid: 123,
+        nodeVersion: 'v22.0.0',
+        platform: 'linux',
+        arch: 'x64',
+        uptimeSeconds: 120,
+      },
+      memory: {
+        rss: 100 * 1024 * 1024,
+        heapTotal: 80 * 1024 * 1024,
+        heapUsed: 40 * 1024 * 1024,
+        external: 5 * 1024 * 1024,
+        arrayBuffers: 2 * 1024 * 1024,
+      },
+      v8: {
+        heapStatistics: {
+          heap_size_limit: 4096 * 1024 * 1024,
+        },
+        heapSpaces: [],
+      },
+      activeHandles: { count: 1000, unavailable: false },
+      activeRequests: { count: 1, unavailable: false },
+    });
+
+    expect(report).toContain('Active handle count is high');
+    expect(report).toContain('MCP servers, watchers, or streaming sessions');
+  });
+
+  it('reports high heap pressure only with a finite positive heap limit', () => {
+    const baseDiagnostics = {
+      generatedAt: '2026-05-15T12:00:00.000Z',
+      process: {
+        pid: 123,
+        nodeVersion: 'v22.0.0',
+        platform: 'linux' as const,
+        arch: 'x64',
+        uptimeSeconds: 120,
+      },
+      memory: {
+        rss: 100,
+        heapTotal: 80,
+        heapUsed: 90,
+        external: 5,
+        arrayBuffers: 2,
+      },
+      v8: {
+        heapSpaces: [],
+      },
+      activeHandles: { count: 3, unavailable: false },
+      activeRequests: { count: 1, unavailable: false },
+    };
+
+    expect(
+      isHighHeapPressure({
+        ...baseDiagnostics,
+        v8: { ...baseDiagnostics.v8, heapStatistics: { heap_size_limit: 0 } },
+      }),
+    ).toBe(false);
+    expect(
+      isHighHeapPressure({
+        ...baseDiagnostics,
+        v8: { ...baseDiagnostics.v8, heapStatistics: {} },
+      }),
+    ).toBe(false);
+    expect(isHighHeapPressure(baseDiagnostics)).toBe(false);
+    expect(
+      isHighHeapPressure({
+        ...baseDiagnostics,
+        v8: {
+          ...baseDiagnostics.v8,
+          heapStatistics: { heap_size_limit: 100 },
+        },
+      }),
+    ).toBe(true);
+  });
+
   it('collects repeated memory pressure samples with waits between samples', async () => {
     const waits: number[] = [];
     const memoryUsages = [
@@ -374,6 +567,31 @@ describe('memoryDiagnostics', () => {
     expect(waits).toEqual([25, 25]);
     expect(samples[0]).toMatchObject({ index: 1, rss: 100 * 1024 * 1024 });
     expect(samples[2]).toMatchObject({ index: 3, heapUsed: 70 * 1024 * 1024 });
+  });
+
+  it('stops collecting memory pressure samples when aborted', async () => {
+    const abortController = new AbortController();
+    const samples = await collectMemoryPressureSamples({
+      sampleCount: 3,
+      intervalMs: 25,
+      signal: abortController.signal,
+      now: () => new Date('2026-05-15T12:00:00.000Z'),
+      memoryUsage: () => {
+        abortController.abort();
+        return {
+          rss: 100,
+          heapTotal: 80,
+          heapUsed: 40,
+          external: 5,
+          arrayBuffers: 2,
+        };
+      },
+      wait: async () => {
+        throw new Error('should not wait after abort');
+      },
+    });
+
+    expect(samples).toHaveLength(1);
   });
 
   it('formats single memory pressure sample deltas as unavailable', () => {

--- a/packages/cli/src/utils/memoryDiagnostics.test.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.test.ts
@@ -9,7 +9,9 @@ import * as path from 'node:path';
 
 import { describe, expect, it, vi } from 'vitest';
 import {
+  collectMemoryPressureSamples,
   formatMemoryDiagnostics,
+  formatMemoryPressureSamples,
   getMemoryDiagnostics,
   writeMemoryHeapSnapshot,
 } from './memoryDiagnostics.js';
@@ -175,5 +177,76 @@ describe('memoryDiagnostics', () => {
         `qwen-code-heap-${process.pid}-2026-05-15T12-00-00-000Z.heapsnapshot`,
       ),
     );
+  });
+
+  it('collects repeated memory pressure samples with waits between samples', async () => {
+    const waits: number[] = [];
+    const memoryUsages = [
+      {
+        rss: 100 * 1024 * 1024,
+        heapTotal: 80 * 1024 * 1024,
+        heapUsed: 40 * 1024 * 1024,
+        external: 5 * 1024 * 1024,
+        arrayBuffers: 2 * 1024 * 1024,
+      },
+      {
+        rss: 130 * 1024 * 1024,
+        heapTotal: 90 * 1024 * 1024,
+        heapUsed: 60 * 1024 * 1024,
+        external: 6 * 1024 * 1024,
+        arrayBuffers: 3 * 1024 * 1024,
+      },
+      {
+        rss: 150 * 1024 * 1024,
+        heapTotal: 100 * 1024 * 1024,
+        heapUsed: 70 * 1024 * 1024,
+        external: 7 * 1024 * 1024,
+        arrayBuffers: 4 * 1024 * 1024,
+      },
+    ];
+
+    const samples = await collectMemoryPressureSamples({
+      sampleCount: 3,
+      intervalMs: 25,
+      now: () => new Date('2026-05-15T12:00:00.000Z'),
+      memoryUsage: () => memoryUsages.shift()!,
+      wait: async (ms) => {
+        waits.push(ms);
+      },
+    });
+
+    expect(samples).toHaveLength(3);
+    expect(waits).toEqual([25, 25]);
+    expect(samples[0]).toMatchObject({ index: 1, rss: 100 * 1024 * 1024 });
+    expect(samples[2]).toMatchObject({ index: 3, heapUsed: 70 * 1024 * 1024 });
+  });
+
+  it('formats memory pressure sample deltas', () => {
+    const report = formatMemoryPressureSamples([
+      {
+        index: 1,
+        timestamp: '2026-05-15T12:00:00.000Z',
+        rss: 100 * 1024 * 1024,
+        heapTotal: 80 * 1024 * 1024,
+        heapUsed: 40 * 1024 * 1024,
+        external: 5 * 1024 * 1024,
+        arrayBuffers: 2 * 1024 * 1024,
+      },
+      {
+        index: 2,
+        timestamp: '2026-05-15T12:00:01.000Z',
+        rss: 130 * 1024 * 1024,
+        heapTotal: 90 * 1024 * 1024,
+        heapUsed: 60 * 1024 * 1024,
+        external: 6 * 1024 * 1024,
+        arrayBuffers: 3 * 1024 * 1024,
+      },
+    ]);
+
+    expect(report).toContain('Memory pressure samples');
+    expect(report).toContain('Sample count: 2');
+    expect(report).toContain('RSS delta: 30.0 MiB');
+    expect(report).toContain('Heap used delta: 20.0 MiB');
+    expect(report).toContain('#2 2026-05-15T12:00:01.000Z');
   });
 });

--- a/packages/cli/src/utils/memoryDiagnostics.test.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.test.ts
@@ -23,6 +23,8 @@ describe('memoryDiagnostics', () => {
   afterEach(() => {
     clearHeapSnapshotRateLimit();
     vi.restoreAllMocks();
+    vi.doUnmock('node:fs');
+    vi.doUnmock('node:v8');
   });
 
   it('collects baseline memory fields', () => {
@@ -449,8 +451,91 @@ describe('memoryDiagnostics', () => {
     });
 
     try {
-      expect(fs.statSync(outputDir).mode & 0o777).toBe(0o700);
-      expect(fs.statSync(writtenPath).mode & 0o777).toBe(0o600);
+      expect(fs.existsSync(outputDir)).toBe(true);
+      expect(fs.existsSync(writtenPath)).toBe(true);
+      if (process.platform !== 'win32') {
+        expect(fs.statSync(outputDir).mode & 0o777).toBe(0o700);
+        expect(fs.statSync(writtenPath).mode & 0o777).toBe(0o600);
+      }
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('continues heap snapshot writes when free disk space cannot be read', async () => {
+    const outputDir = path.join(
+      os.tmpdir(),
+      `qwen-memory-diagnostics-statfs-fallback-${process.pid}`,
+    );
+    fs.rmSync(outputDir, { recursive: true, force: true });
+    vi.resetModules();
+    const statfsSync = vi.fn(() => {
+      throw new Error('statfs unavailable');
+    });
+    vi.doMock('node:fs', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:fs')>();
+      return { ...actual, statfsSync };
+    });
+    const { writeMemoryHeapSnapshot: writeWithMockedFs } = await import(
+      './memoryDiagnostics.js'
+    );
+
+    try {
+      const writtenPath = writeWithMockedFs({
+        outputDir,
+        now: new Date('2026-05-15T12:00:00.000Z'),
+        writeSnapshot: (filePath) => {
+          fs.writeFileSync(filePath, 'snapshot');
+          return filePath;
+        },
+      });
+
+      expect(statfsSync).toHaveBeenCalledWith(outputDir);
+      expect(fs.existsSync(writtenPath)).toBe(true);
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to process heap total when V8 heap statistics are unavailable for snapshot sizing', async () => {
+    const outputDir = path.join(
+      os.tmpdir(),
+      `qwen-memory-diagnostics-estimate-fallback-${process.pid}`,
+    );
+    fs.rmSync(outputDir, { recursive: true, force: true });
+    vi.resetModules();
+    const getHeapStatistics = vi.fn(() => {
+      throw new Error('heap statistics unavailable');
+    });
+    vi.doMock('node:v8', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('node:v8')>();
+      return { ...actual, getHeapStatistics };
+    });
+    const { writeMemoryHeapSnapshot: writeWithMockedV8 } = await import(
+      './memoryDiagnostics.js'
+    );
+    vi.spyOn(process, 'memoryUsage').mockReturnValue({
+      rss: 40,
+      heapTotal: 100,
+      heapUsed: 50,
+      external: 10,
+      arrayBuffers: 5,
+    });
+
+    try {
+      expect(() =>
+        writeWithMockedV8({
+          outputDir,
+          now: new Date('2026-05-15T12:00:00.000Z'),
+          writeSnapshot: (filePath) => {
+            fs.writeFileSync(filePath, 'snapshot');
+            return filePath;
+          },
+          getAvailableBytes: () => 350,
+          minFreeBytesAfterSnapshot: 60,
+        }),
+      ).toThrow('Insufficient free disk space');
+      expect(getHeapStatistics).toHaveBeenCalled();
     } finally {
       fs.rmSync(outputDir, { recursive: true, force: true });
     }

--- a/packages/cli/src/utils/memoryDiagnostics.test.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.test.ts
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import {
+  formatMemoryDiagnostics,
+  getMemoryDiagnostics,
+} from './memoryDiagnostics.js';
+
+describe('memoryDiagnostics', () => {
+  it('collects baseline process and V8 memory fields', () => {
+    const diagnostics = getMemoryDiagnostics();
+
+    expect(diagnostics.process.pid).toBe(process.pid);
+    expect(diagnostics.process.nodeVersion).toBe(process.version);
+    expect(diagnostics.process.platform).toBe(process.platform);
+    expect(diagnostics.process.arch).toBe(process.arch);
+    expect(diagnostics.memory.rss).toBeGreaterThan(0);
+    expect(diagnostics.memory.heapTotal).toBeGreaterThan(0);
+    expect(diagnostics.memory.heapUsed).toBeGreaterThan(0);
+    expect(diagnostics.memory.external).toBeGreaterThanOrEqual(0);
+    expect(diagnostics.memory.arrayBuffers).toBeGreaterThanOrEqual(0);
+    expect(diagnostics.v8.heapStatistics).toBeDefined();
+    expect(diagnostics.v8.heapSpaces.length).toBeGreaterThan(0);
+    expect(diagnostics.activeHandles.count).toBeGreaterThanOrEqual(0);
+    expect(diagnostics.activeRequests.count).toBeGreaterThanOrEqual(0);
+  });
+
+  it('formats a paste-safe human-readable report with key sections', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T12:00:00.000Z'));
+
+    try {
+      const report = formatMemoryDiagnostics({
+        generatedAt: new Date().toISOString(),
+        process: {
+          pid: 123,
+          nodeVersion: 'v22.0.0',
+          platform: 'linux',
+          arch: 'x64',
+          uptimeSeconds: 42.4,
+        },
+        memory: {
+          rss: 100 * 1024 * 1024,
+          heapTotal: 80 * 1024 * 1024,
+          heapUsed: 40 * 1024 * 1024,
+          external: 5 * 1024 * 1024,
+          arrayBuffers: 2 * 1024 * 1024,
+        },
+        v8: {
+          heapStatistics: {
+            heap_size_limit: 4096 * 1024 * 1024,
+            total_available_size: 3000 * 1024 * 1024,
+          },
+          heapSpaces: [
+            {
+              space_name: 'old_space',
+              space_size: 30 * 1024 * 1024,
+              space_used_size: 20 * 1024 * 1024,
+            },
+          ],
+        },
+        activeHandles: { count: 3, unavailable: false },
+        activeRequests: { count: 1, unavailable: false },
+      });
+
+      expect(report).toContain('Memory diagnostics');
+      expect(report).toContain('Generated: 2026-05-15T12:00:00.000Z');
+      expect(report).toContain('Node.js: v22.0.0');
+      expect(report).toContain('RSS: 100.0 MiB');
+      expect(report).toContain('Heap used / total: 40.0 MiB / 80.0 MiB');
+      expect(report).toContain('External: 5.0 MiB');
+      expect(report).toContain('Array buffers: 2.0 MiB');
+      expect(report).toContain('Heap size limit: 4096.0 MiB');
+      expect(report).toContain('old_space: 20.0 MiB / 30.0 MiB');
+      expect(report).toContain('Active handles: 3');
+      expect(report).toContain('Active requests: 1');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/cli/src/utils/memoryDiagnostics.test.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.test.ts
@@ -333,6 +333,47 @@ describe('memoryDiagnostics', () => {
     }
   });
 
+  it('uses filename timestamps to break equal-mtime cleanup ties', () => {
+    const outputDir = path.join(
+      os.tmpdir(),
+      `qwen-memory-diagnostics-equal-mtime-cleanup-${process.pid}`,
+    );
+    fs.rmSync(outputDir, { recursive: true, force: true });
+    fs.mkdirSync(outputDir, { recursive: true });
+
+    const olderSnapshot = path.join(
+      outputDir,
+      'qwen-code-heap-1-2026-05-15T11-00-00-000Z.heapsnapshot',
+    );
+    const newerSnapshot = path.join(
+      outputDir,
+      'qwen-code-heap-1-2026-05-15T12-00-00-000Z.heapsnapshot',
+    );
+    fs.writeFileSync(olderSnapshot, 'older');
+    fs.writeFileSync(newerSnapshot, 'newer');
+    const sameMtime = new Date('2026-05-15T12:00:00.000Z');
+    fs.utimesSync(olderSnapshot, sameMtime, sameMtime);
+    fs.utimesSync(newerSnapshot, sameMtime, sameMtime);
+
+    const writtenPath = writeMemoryHeapSnapshot({
+      outputDir,
+      now: new Date('2026-05-15T13:00:00.000Z'),
+      maxSnapshots: 2,
+      writeSnapshot: (filePath) => {
+        fs.writeFileSync(filePath, 'snapshot');
+        return filePath;
+      },
+    });
+
+    try {
+      expect(fs.existsSync(olderSnapshot)).toBe(false);
+      expect(fs.existsSync(newerSnapshot)).toBe(true);
+      expect(fs.existsSync(writtenPath)).toBe(true);
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
   it('keeps successful heap snapshot writes when cleanup fails', () => {
     const outputDir = path.join(
       os.tmpdir(),
@@ -340,13 +381,11 @@ describe('memoryDiagnostics', () => {
     );
     fs.rmSync(outputDir, { recursive: true, force: true });
     fs.mkdirSync(outputDir, { recursive: true });
-    fs.symlinkSync(
-      'missing-target.heapsnapshot',
-      path.join(
-        outputDir,
-        'qwen-code-heap-999-2026-05-15T11-00-00-000Z.heapsnapshot',
-      ),
+    const brokenSymlink = path.join(
+      outputDir,
+      'qwen-code-heap-999-2026-05-15T11-00-00-000Z.heapsnapshot',
     );
+    fs.symlinkSync('missing-target.heapsnapshot', brokenSymlink);
 
     try {
       const writtenPath = writeMemoryHeapSnapshot({
@@ -360,6 +399,7 @@ describe('memoryDiagnostics', () => {
       });
 
       expect(fs.existsSync(writtenPath)).toBe(true);
+      expect(() => fs.lstatSync(brokenSymlink)).toThrow();
     } finally {
       fs.rmSync(outputDir, { recursive: true, force: true });
     }

--- a/packages/cli/src/utils/memoryDiagnostics.test.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.test.ts
@@ -462,7 +462,7 @@ describe('memoryDiagnostics', () => {
     }
   });
 
-  it('continues heap snapshot writes when free disk space cannot be read', async () => {
+  it('refuses heap snapshot writes when free disk space cannot be read', async () => {
     const outputDir = path.join(
       os.tmpdir(),
       `qwen-memory-diagnostics-statfs-fallback-${process.pid}`,
@@ -481,17 +481,19 @@ describe('memoryDiagnostics', () => {
     );
 
     try {
-      const writtenPath = writeWithMockedFs({
-        outputDir,
-        now: new Date('2026-05-15T12:00:00.000Z'),
-        writeSnapshot: (filePath) => {
-          fs.writeFileSync(filePath, 'snapshot');
-          return filePath;
-        },
-      });
+      expect(() =>
+        writeWithMockedFs({
+          outputDir,
+          now: new Date('2026-05-15T12:00:00.000Z'),
+          writeSnapshot: (filePath) => {
+            fs.writeFileSync(filePath, 'snapshot');
+            return filePath;
+          },
+        }),
+      ).toThrow('Unable to check available disk space');
 
       expect(statfsSync).toHaveBeenCalledWith(outputDir);
-      expect(fs.existsSync(writtenPath)).toBe(true);
+      expect(fs.readdirSync(outputDir)).toHaveLength(0);
     } finally {
       fs.rmSync(outputDir, { recursive: true, force: true });
     }
@@ -539,6 +541,24 @@ describe('memoryDiagnostics', () => {
     } finally {
       fs.rmSync(outputDir, { recursive: true, force: true });
     }
+  });
+
+  it('uses the default sample count for non-positive sample counts', async () => {
+    const samples = await collectMemoryPressureSamples({
+      sampleCount: 0,
+      intervalMs: 0,
+      now: () => new Date('2026-05-15T12:00:00.000Z'),
+      memoryUsage: () => ({
+        rss: 100,
+        heapTotal: 80,
+        heapUsed: 40,
+        external: 5,
+        arrayBuffers: 2,
+      }),
+      wait: async () => {},
+    });
+
+    expect(samples).toHaveLength(3);
   });
 
   it('marks V8 diagnostics as warning when heap statistics are unavailable', () => {

--- a/packages/cli/src/utils/memoryDiagnostics.test.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.test.ts
@@ -6,6 +6,7 @@
 
 import * as os from 'node:os';
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -168,7 +169,10 @@ describe('memoryDiagnostics', () => {
     const writtenPath = writeMemoryHeapSnapshot({
       outputDir,
       now: new Date('2026-05-15T12:00:00.000Z'),
-      writeSnapshot: (filePath) => filePath,
+      writeSnapshot: (filePath) => {
+        fs.writeFileSync(filePath, 'snapshot');
+        return filePath;
+      },
     });
 
     expect(writtenPath).toBe(
@@ -176,6 +180,126 @@ describe('memoryDiagnostics', () => {
         outputDir,
         `qwen-code-heap-${process.pid}-2026-05-15T12-00-00-000Z.heapsnapshot`,
       ),
+    );
+  });
+
+  it('refuses heap snapshots when estimated heap dump would leave little free disk', () => {
+    const outputDir = path.join(
+      os.tmpdir(),
+      `qwen-memory-diagnostics-disk-${process.pid}`,
+    );
+    fs.rmSync(outputDir, { recursive: true, force: true });
+
+    try {
+      expect(() =>
+        writeMemoryHeapSnapshot({
+          outputDir,
+          writeSnapshot: (filePath) => {
+            fs.writeFileSync(filePath, 'snapshot');
+            return filePath;
+          },
+          estimateSnapshotBytes: () => 900,
+          getAvailableBytes: () => 1000,
+          minFreeBytesAfterSnapshot: 200,
+        }),
+      ).toThrow('Insufficient free disk space');
+      expect(fs.readdirSync(outputDir)).toHaveLength(0);
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps only the newest heap snapshots after writing', () => {
+    const outputDir = path.join(
+      os.tmpdir(),
+      `qwen-memory-diagnostics-cleanup-${process.pid}`,
+    );
+    fs.rmSync(outputDir, { recursive: true, force: true });
+    fs.mkdirSync(outputDir, { recursive: true });
+
+    const oldSnapshot = path.join(
+      outputDir,
+      `qwen-code-heap-${process.pid}-2026-05-15T11-00-00-000Z.heapsnapshot`,
+    );
+    const newerSnapshot = path.join(
+      outputDir,
+      `qwen-code-heap-${process.pid}-2026-05-15T11-30-00-000Z.heapsnapshot`,
+    );
+    fs.writeFileSync(oldSnapshot, 'old');
+    fs.writeFileSync(newerSnapshot, 'newer');
+
+    const writtenPath = writeMemoryHeapSnapshot({
+      outputDir,
+      now: new Date('2026-05-15T12:00:00.000Z'),
+      maxSnapshots: 2,
+      writeSnapshot: (filePath) => {
+        fs.writeFileSync(filePath, 'snapshot');
+        return filePath;
+      },
+    });
+
+    try {
+      expect(fs.existsSync(oldSnapshot)).toBe(false);
+      expect(fs.existsSync(newerSnapshot)).toBe(true);
+      expect(fs.existsSync(writtenPath)).toBe(true);
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('creates heap snapshot directories and files with private permissions', () => {
+    const outputDir = path.join(
+      os.tmpdir(),
+      `qwen-memory-diagnostics-private-${process.pid}`,
+    );
+    fs.rmSync(outputDir, { recursive: true, force: true });
+
+    const writtenPath = writeMemoryHeapSnapshot({
+      outputDir,
+      now: new Date('2026-05-15T12:00:00.000Z'),
+      writeSnapshot: (filePath) => {
+        fs.writeFileSync(filePath, 'snapshot');
+        return filePath;
+      },
+    });
+
+    try {
+      expect(fs.statSync(outputDir).mode & 0o777).toBe(0o700);
+      expect(fs.statSync(writtenPath).mode & 0o777).toBe(0o600);
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
+  it('marks V8 diagnostics as warning when heap statistics are unavailable', () => {
+    const report = formatMemoryDiagnostics({
+      generatedAt: '2026-05-15T12:00:00.000Z',
+      process: {
+        pid: 123,
+        nodeVersion: 'v22.0.0',
+        platform: 'linux',
+        arch: 'x64',
+        uptimeSeconds: 120,
+      },
+      memory: {
+        rss: 100 * 1024 * 1024,
+        heapTotal: 80 * 1024 * 1024,
+        heapUsed: 40 * 1024 * 1024,
+        external: 5 * 1024 * 1024,
+        arrayBuffers: 2 * 1024 * 1024,
+      },
+      v8: {
+        unavailable: true,
+        heapSpaces: [],
+      },
+      activeHandles: { count: 3, unavailable: false },
+      activeRequests: { count: 1, unavailable: false },
+    });
+
+    expect(report).toContain('Status: warn');
+    expect(report).toContain('V8 heap statistics are unavailable');
+    expect(report).not.toContain(
+      'No immediate memory pressure signals detected.',
     );
   });
 
@@ -219,6 +343,24 @@ describe('memoryDiagnostics', () => {
     expect(waits).toEqual([25, 25]);
     expect(samples[0]).toMatchObject({ index: 1, rss: 100 * 1024 * 1024 });
     expect(samples[2]).toMatchObject({ index: 3, heapUsed: 70 * 1024 * 1024 });
+  });
+
+  it('formats single memory pressure sample deltas as unavailable', () => {
+    const report = formatMemoryPressureSamples([
+      {
+        index: 1,
+        timestamp: '2026-05-15T12:00:00.000Z',
+        rss: 100 * 1024 * 1024,
+        heapTotal: 80 * 1024 * 1024,
+        heapUsed: 40 * 1024 * 1024,
+        external: 5 * 1024 * 1024,
+        arrayBuffers: 2 * 1024 * 1024,
+      },
+    ]);
+
+    expect(report).toContain('Sample count: 1');
+    expect(report).toContain('RSS delta: unavailable');
+    expect(report).toContain('Heap used delta: unavailable');
   });
 
   it('formats memory pressure sample deltas', () => {

--- a/packages/cli/src/utils/memoryDiagnostics.test.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.test.ts
@@ -11,7 +11,7 @@ import {
 } from './memoryDiagnostics.js';
 
 describe('memoryDiagnostics', () => {
-  it('collects baseline process and V8 memory fields', () => {
+  it('collects baseline memory fields', () => {
     const diagnostics = getMemoryDiagnostics();
 
     expect(diagnostics.process.pid).toBe(process.pid);

--- a/packages/cli/src/utils/memoryDiagnostics.test.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.test.ts
@@ -209,6 +209,37 @@ describe('memoryDiagnostics', () => {
     }
   });
 
+  it('rate-limits repeated heap snapshot writes in the same directory', () => {
+    const outputDir = path.join(
+      os.tmpdir(),
+      `qwen-memory-diagnostics-rate-limit-${process.pid}`,
+    );
+    fs.rmSync(outputDir, { recursive: true, force: true });
+
+    try {
+      const writeSnapshot = (filePath: string) => {
+        fs.writeFileSync(filePath, 'snapshot');
+        return filePath;
+      };
+
+      writeMemoryHeapSnapshot({
+        outputDir,
+        now: new Date('2026-05-15T12:00:00.000Z'),
+        writeSnapshot,
+      });
+
+      expect(() =>
+        writeMemoryHeapSnapshot({
+          outputDir,
+          now: new Date('2026-05-15T12:00:30.000Z'),
+          writeSnapshot,
+        }),
+      ).toThrow('Heap snapshot rate limit');
+    } finally {
+      fs.rmSync(outputDir, { recursive: true, force: true });
+    }
+  });
+
   it('keeps only the newest heap snapshots after writing', () => {
     const outputDir = path.join(
       os.tmpdir(),

--- a/packages/cli/src/utils/memoryDiagnostics.test.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.test.ts
@@ -4,10 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import { describe, expect, it, vi } from 'vitest';
 import {
   formatMemoryDiagnostics,
   getMemoryDiagnostics,
+  writeMemoryHeapSnapshot,
 } from './memoryDiagnostics.js';
 
 describe('memoryDiagnostics', () => {
@@ -154,6 +158,22 @@ describe('memoryDiagnostics', () => {
     expect(report).toContain('Non-heap memory is high');
     expect(report).toContain(
       'large tool results, buffers, or native allocations',
+    );
+  });
+
+  it('writes heap snapshots to a diagnostics directory with stable filenames', () => {
+    const outputDir = path.join(os.tmpdir(), 'qwen-memory-diagnostics-test');
+    const writtenPath = writeMemoryHeapSnapshot({
+      outputDir,
+      now: new Date('2026-05-15T12:00:00.000Z'),
+      writeSnapshot: (filePath) => filePath,
+    });
+
+    expect(writtenPath).toBe(
+      path.join(
+        outputDir,
+        `qwen-code-heap-${process.pid}-2026-05-15T12-00-00-000Z.heapsnapshot`,
+      ),
     );
   });
 });

--- a/packages/cli/src/utils/memoryDiagnostics.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.ts
@@ -47,8 +47,12 @@ function countProcessInternals(
 
   try {
     const entries = (getter as () => unknown[])();
+    if (!Array.isArray(entries)) {
+      return { count: 0, unavailable: true };
+    }
+
     return {
-      count: Array.isArray(entries) ? entries.length : 0,
+      count: entries.length,
       unavailable: false,
     };
   } catch {
@@ -97,6 +101,10 @@ export interface WriteMemoryHeapSnapshotOptions {
   outputDir?: string;
   now?: Date;
   writeSnapshot?: (filePath: string) => string;
+  estimateSnapshotBytes?: () => number;
+  getAvailableBytes?: (dir: string) => number;
+  minFreeBytesAfterSnapshot?: number;
+  maxSnapshots?: number;
 }
 
 export interface MemoryPressureSample {
@@ -125,18 +133,66 @@ function formatSnapshotTimestamp(now: Date): string {
   return now.toISOString().replace(/[:.]/g, '-');
 }
 
+function estimateHeapSnapshotBytes(): number {
+  const heapStats = v8.getHeapStatistics();
+  return Math.max(heapStats.total_heap_size, process.memoryUsage().heapTotal);
+}
+
+function getAvailableBytes(outputDir: string): number {
+  const stats = fs.statfsSync(outputDir);
+  return stats.bavail * stats.bsize;
+}
+
+function cleanupOldHeapSnapshots(
+  outputDir: string,
+  maxSnapshots: number,
+): void {
+  if (maxSnapshots < 1) return;
+
+  const snapshots = fs
+    .readdirSync(outputDir)
+    .filter(
+      (name) =>
+        name.startsWith('qwen-code-heap-') && name.endsWith('.heapsnapshot'),
+    )
+    .map((name) => path.join(outputDir, name))
+    .sort((a, b) => b.localeCompare(a));
+
+  for (const filePath of snapshots.slice(maxSnapshots)) {
+    fs.rmSync(filePath, { force: true });
+  }
+}
+
 export function writeMemoryHeapSnapshot({
   outputDir = defaultHeapSnapshotDir(),
   now = new Date(),
   writeSnapshot = v8.writeHeapSnapshot,
+  estimateSnapshotBytes:
+    estimateSnapshotBytesOption = estimateHeapSnapshotBytes,
+  getAvailableBytes: getAvailableBytesOption = getAvailableBytes,
+  minFreeBytesAfterSnapshot = 512 * 1024 * 1024,
+  maxSnapshots = 5,
 }: WriteMemoryHeapSnapshotOptions = {}): string {
-  fs.mkdirSync(outputDir, { recursive: true });
+  fs.mkdirSync(outputDir, { recursive: true, mode: 0o700 });
+  fs.chmodSync(outputDir, 0o700);
+
+  const estimatedSnapshotBytes = estimateSnapshotBytesOption();
+  const availableBytes = getAvailableBytesOption(outputDir);
+  if (availableBytes - estimatedSnapshotBytes < minFreeBytesAfterSnapshot) {
+    throw new Error(
+      'Insufficient free disk space for heap snapshot; skipping to avoid filling the disk.',
+    );
+  }
+
   const filePath = path.join(
     outputDir,
     `qwen-code-heap-${process.pid}-${formatSnapshotTimestamp(now)}.heapsnapshot`,
   );
 
-  return writeSnapshot(filePath);
+  const writtenPath = writeSnapshot(filePath);
+  fs.chmodSync(writtenPath, 0o600);
+  cleanupOldHeapSnapshots(outputDir, maxSnapshots);
+  return writtenPath;
 }
 
 function defaultWait(ms: number): Promise<void> {
@@ -246,6 +302,15 @@ function buildMemoryInsights(diagnostics: MemoryDiagnostics): MemoryInsights {
   const signals: string[] = [];
   const recommendations: string[] = [];
 
+  if (diagnostics.v8.unavailable) {
+    signals.push(
+      'V8 heap statistics are unavailable; heap pressure assessment may be incomplete.',
+    );
+    recommendations.push(
+      'Re-run /doctor memory after restarting Qwen Code; if V8 diagnostics remain unavailable, include this report when filing an issue.',
+    );
+  }
+
   if (heapIsHigh) {
     signals.push(
       'V8 heap usage is high; the process is close to its configured heap limit.',
@@ -290,9 +355,12 @@ export function formatMemoryPressureSamples(
 ): string {
   const first = samples[0];
   const last = samples.at(-1);
-  const rssDelta = first && last ? last.rss - first.rss : undefined;
+  const rssDelta =
+    first && last && samples.length > 1 ? last.rss - first.rss : undefined;
   const heapUsedDelta =
-    first && last ? last.heapUsed - first.heapUsed : undefined;
+    first && last && samples.length > 1
+      ? last.heapUsed - first.heapUsed
+      : undefined;
   const sampleLines = samples.map(
     (sample) =>
       `  #${sample.index} ${sample.timestamp}: RSS ${formatBytes(

--- a/packages/cli/src/utils/memoryDiagnostics.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.ts
@@ -179,9 +179,7 @@ function cleanupOldHeapSnapshots(
     )
     .map((name) => path.join(outputDir, name))
     .sort((a, b) => {
-      const aStat = fs.statSync(a);
-      const bStat = fs.statSync(b);
-      const mtimeDelta = bStat.mtimeMs - aStat.mtimeMs;
+      const mtimeDelta = getSnapshotMtimeMs(b) - getSnapshotMtimeMs(a);
       if (mtimeDelta !== 0) return mtimeDelta;
 
       return (
@@ -192,7 +190,19 @@ function cleanupOldHeapSnapshots(
     });
 
   for (const filePath of snapshots.slice(maxSnapshots)) {
-    fs.rmSync(filePath, { force: true });
+    try {
+      fs.rmSync(filePath, { force: true });
+    } catch {
+      // Cleanup is best effort; one stuck file should not block the rest.
+    }
+  }
+}
+
+function getSnapshotMtimeMs(filePath: string): number {
+  try {
+    return fs.lstatSync(filePath).mtimeMs;
+  } catch {
+    return 0;
   }
 }
 

--- a/packages/cli/src/utils/memoryDiagnostics.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.ts
@@ -107,10 +107,98 @@ function formatActiveCount(value: {
   return value.unavailable ? 'unavailable' : String(value.count);
 }
 
+function asFiniteNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function formatPercent(value: number | undefined): string {
+  if (value === undefined || !Number.isFinite(value)) {
+    return 'unavailable';
+  }
+
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+type MemoryInsightStatus = 'ok' | 'warn';
+
+interface MemoryInsights {
+  status: MemoryInsightStatus;
+  heapPressure?: number;
+  rssHeapGapBytes?: number;
+  signals: string[];
+  recommendations: string[];
+}
+
+function buildMemoryInsights(diagnostics: MemoryDiagnostics): MemoryInsights {
+  const heapStatistics = diagnostics.v8.heapStatistics ?? {};
+  const heapSizeLimit = asFiniteNumber(heapStatistics['heap_size_limit']);
+  const heapPressure =
+    heapSizeLimit !== undefined && heapSizeLimit > 0
+      ? diagnostics.memory.heapUsed / heapSizeLimit
+      : undefined;
+  const rssHeapGapBytes = Math.max(
+    0,
+    diagnostics.memory.rss - diagnostics.memory.heapTotal,
+  );
+  const externalAndBuffers =
+    diagnostics.memory.external + diagnostics.memory.arrayBuffers;
+  const nonHeapGapIsHigh =
+    rssHeapGapBytes >= 256 * 1024 * 1024 &&
+    diagnostics.memory.rss >= diagnostics.memory.heapTotal * 2;
+  const externalMemoryIsHigh =
+    externalAndBuffers >= 256 * 1024 * 1024 &&
+    externalAndBuffers >= diagnostics.memory.rss * 0.3;
+  const heapIsHigh = heapPressure !== undefined && heapPressure >= 0.85;
+
+  const signals: string[] = [];
+  const recommendations: string[] = [];
+
+  if (heapIsHigh) {
+    signals.push(
+      'V8 heap usage is high; the process is close to its configured heap limit.',
+    );
+    recommendations.push(
+      'If the CLI is sluggish or near OOM, restart Qwen Code to recover memory, then capture a heap snapshot before the next restart to identify retained objects.',
+    );
+  }
+
+  if (nonHeapGapIsHigh || externalMemoryIsHigh) {
+    signals.push(
+      'Non-heap memory is high; investigate large tool results, buffers, or native allocations.',
+    );
+    recommendations.push(
+      'Compare RSS against heap usage over time; if RSS grows while heap stays flat, inspect external buffers, tool-result payloads, and native dependencies before increasing the V8 heap limit.',
+    );
+  }
+
+  if (
+    diagnostics.activeHandles.count >= 1000 &&
+    !diagnostics.activeHandles.unavailable
+  ) {
+    signals.push(
+      'Active handle count is high; long-lived timers, sockets, or file watchers may be accumulating.',
+    );
+    recommendations.push(
+      'Check recently enabled MCP servers, watchers, or streaming sessions for resources that are not being closed.',
+    );
+  }
+
+  return {
+    status: signals.length > 0 ? 'warn' : 'ok',
+    heapPressure,
+    rssHeapGapBytes,
+    signals,
+    recommendations,
+  };
+}
+
 export function formatMemoryDiagnostics(
   diagnostics: MemoryDiagnostics,
 ): string {
   const heapStatistics = diagnostics.v8.heapStatistics ?? {};
+  const insights = buildMemoryInsights(diagnostics);
   const heapSpaceLines = diagnostics.v8.heapSpaces.map((space) => {
     const name = String(space['space_name'] ?? 'unknown_space');
     return `  - ${name}: ${formatBytes(space['space_used_size'])} / ${formatBytes(
@@ -149,5 +237,22 @@ export function formatMemoryDiagnostics(
     'Runtime internals',
     `  Active handles: ${formatActiveCount(diagnostics.activeHandles)}`,
     `  Active requests: ${formatActiveCount(diagnostics.activeRequests)}`,
+    '',
+    'Assessment',
+    `  Status: ${insights.status}`,
+    `  Heap pressure: ${formatPercent(insights.heapPressure)}`,
+    `  RSS / heap-total gap: ${formatBytes(insights.rssHeapGapBytes)}`,
+    '  Signals:',
+    ...(insights.signals.length > 0
+      ? insights.signals.map((signal) => `  - ${signal}`)
+      : ['  - No immediate memory pressure signals detected.']),
+    '  Recommendations:',
+    ...(insights.recommendations.length > 0
+      ? insights.recommendations.map(
+          (recommendation) => `  - ${recommendation}`,
+        )
+      : [
+          '  - Re-run /doctor memory when memory grows, before restarting, to compare snapshots.',
+        ]),
   ].join('\n');
 }

--- a/packages/cli/src/utils/memoryDiagnostics.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.ts
@@ -105,6 +105,7 @@ export interface WriteMemoryHeapSnapshotOptions {
   getAvailableBytes?: (dir: string) => number;
   minFreeBytesAfterSnapshot?: number;
   maxSnapshots?: number;
+  rateLimitMs?: number;
 }
 
 export interface MemoryPressureSample {
@@ -163,6 +164,30 @@ function cleanupOldHeapSnapshots(
   }
 }
 
+const lastHeapSnapshotWriteByDir = new Map<string, number>();
+
+function enforceHeapSnapshotRateLimit(
+  outputDir: string,
+  now: Date,
+  rateLimitMs: number,
+): void {
+  if (rateLimitMs <= 0) return;
+
+  const key = path.resolve(outputDir);
+  const nowMs = now.getTime();
+  const lastWriteMs = lastHeapSnapshotWriteByDir.get(key);
+  if (lastWriteMs !== undefined && nowMs - lastWriteMs < rateLimitMs) {
+    const waitSeconds = Math.ceil((rateLimitMs - (nowMs - lastWriteMs)) / 1000);
+    throw new Error(
+      `Heap snapshot rate limit: wait ${waitSeconds}s before writing another snapshot in this directory.`,
+    );
+  }
+}
+
+function recordHeapSnapshotWrite(outputDir: string, now: Date): void {
+  lastHeapSnapshotWriteByDir.set(path.resolve(outputDir), now.getTime());
+}
+
 export function writeMemoryHeapSnapshot({
   outputDir = defaultHeapSnapshotDir(),
   now = new Date(),
@@ -172,9 +197,17 @@ export function writeMemoryHeapSnapshot({
   getAvailableBytes: getAvailableBytesOption = getAvailableBytes,
   minFreeBytesAfterSnapshot = 512 * 1024 * 1024,
   maxSnapshots = 5,
+  rateLimitMs = 60_000,
 }: WriteMemoryHeapSnapshotOptions = {}): string {
   fs.mkdirSync(outputDir, { recursive: true, mode: 0o700 });
-  fs.chmodSync(outputDir, 0o700);
+  try {
+    fs.chmodSync(outputDir, 0o700);
+  } catch {
+    // Best-effort hardening; keep diagnostics usable on filesystems that do
+    // not support POSIX chmod semantics.
+  }
+
+  enforceHeapSnapshotRateLimit(outputDir, now, rateLimitMs);
 
   const estimatedSnapshotBytes = estimateSnapshotBytesOption();
   const availableBytes = getAvailableBytesOption(outputDir);
@@ -190,7 +223,12 @@ export function writeMemoryHeapSnapshot({
   );
 
   const writtenPath = writeSnapshot(filePath);
-  fs.chmodSync(writtenPath, 0o600);
+  try {
+    fs.chmodSync(writtenPath, 0o600);
+  } catch {
+    // Best-effort hardening; the report warns that snapshots are sensitive.
+  }
+  recordHeapSnapshotWrite(outputDir, now);
   cleanupOldHeapSnapshots(outputDir, maxSnapshots);
   return writtenPath;
 }

--- a/packages/cli/src/utils/memoryDiagnostics.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import * as v8 from 'node:v8';
 
 export interface MemoryDiagnostics {
@@ -88,6 +91,34 @@ export function getMemoryDiagnostics(): MemoryDiagnostics {
     activeHandles: countProcessInternals('_getActiveHandles'),
     activeRequests: countProcessInternals('_getActiveRequests'),
   };
+}
+
+export interface WriteMemoryHeapSnapshotOptions {
+  outputDir?: string;
+  now?: Date;
+  writeSnapshot?: (filePath: string) => string;
+}
+
+function defaultHeapSnapshotDir(): string {
+  return path.join(os.homedir(), '.qwen', 'memory-snapshots');
+}
+
+function formatSnapshotTimestamp(now: Date): string {
+  return now.toISOString().replace(/[:.]/g, '-');
+}
+
+export function writeMemoryHeapSnapshot({
+  outputDir = defaultHeapSnapshotDir(),
+  now = new Date(),
+  writeSnapshot = v8.writeHeapSnapshot,
+}: WriteMemoryHeapSnapshotOptions = {}): string {
+  fs.mkdirSync(outputDir, { recursive: true });
+  const filePath = path.join(
+    outputDir,
+    `qwen-code-heap-${process.pid}-${formatSnapshotTimestamp(now)}.heapsnapshot`,
+  );
+
+  return writeSnapshot(filePath);
 }
 
 function formatBytes(value: unknown): string {

--- a/packages/cli/src/utils/memoryDiagnostics.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.ts
@@ -99,6 +99,24 @@ export interface WriteMemoryHeapSnapshotOptions {
   writeSnapshot?: (filePath: string) => string;
 }
 
+export interface MemoryPressureSample {
+  index: number;
+  timestamp: string;
+  rss: number;
+  heapTotal: number;
+  heapUsed: number;
+  external: number;
+  arrayBuffers: number;
+}
+
+export interface CollectMemoryPressureSamplesOptions {
+  sampleCount?: number;
+  intervalMs?: number;
+  now?: () => Date;
+  memoryUsage?: () => NodeJS.MemoryUsage;
+  wait?: (ms: number) => Promise<void>;
+}
+
 function defaultHeapSnapshotDir(): string {
   return path.join(os.homedir(), '.qwen', 'memory-snapshots');
 }
@@ -119,6 +137,48 @@ export function writeMemoryHeapSnapshot({
   );
 
   return writeSnapshot(filePath);
+}
+
+function defaultWait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function normalizeSampleCount(sampleCount: number): number {
+  if (!Number.isFinite(sampleCount)) {
+    return 3;
+  }
+
+  return Math.max(1, Math.floor(sampleCount));
+}
+
+export async function collectMemoryPressureSamples({
+  sampleCount = 3,
+  intervalMs = 1000,
+  now = () => new Date(),
+  memoryUsage = process.memoryUsage,
+  wait = defaultWait,
+}: CollectMemoryPressureSamplesOptions = {}): Promise<MemoryPressureSample[]> {
+  const count = normalizeSampleCount(sampleCount);
+  const samples: MemoryPressureSample[] = [];
+
+  for (let index = 1; index <= count; index++) {
+    const memory = memoryUsage();
+    samples.push({
+      index,
+      timestamp: now().toISOString(),
+      rss: memory.rss,
+      heapTotal: memory.heapTotal,
+      heapUsed: memory.heapUsed,
+      external: memory.external,
+      arrayBuffers: memory.arrayBuffers,
+    });
+
+    if (index < count) {
+      await wait(intervalMs);
+    }
+  }
+
+  return samples;
 }
 
 function formatBytes(value: unknown): string {
@@ -223,6 +283,32 @@ function buildMemoryInsights(diagnostics: MemoryDiagnostics): MemoryInsights {
     signals,
     recommendations,
   };
+}
+
+export function formatMemoryPressureSamples(
+  samples: MemoryPressureSample[],
+): string {
+  const first = samples[0];
+  const last = samples.at(-1);
+  const rssDelta = first && last ? last.rss - first.rss : undefined;
+  const heapUsedDelta =
+    first && last ? last.heapUsed - first.heapUsed : undefined;
+  const sampleLines = samples.map(
+    (sample) =>
+      `  #${sample.index} ${sample.timestamp}: RSS ${formatBytes(
+        sample.rss,
+      )}, heap used ${formatBytes(sample.heapUsed)}, external ${formatBytes(
+        sample.external,
+      )}, array buffers ${formatBytes(sample.arrayBuffers)}`,
+  );
+
+  return [
+    'Memory pressure samples',
+    `  Sample count: ${samples.length}`,
+    `  RSS delta: ${formatBytes(rssDelta)}`,
+    `  Heap used delta: ${formatBytes(heapUsedDelta)}`,
+    ...sampleLines,
+  ].join('\n');
 }
 
 export function formatMemoryDiagnostics(

--- a/packages/cli/src/utils/memoryDiagnostics.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Qwen
+ * Copyright 2026 Qwen
  * SPDX-License-Identifier: Apache-2.0
  */
 
@@ -34,6 +34,9 @@ export interface MemoryDiagnostics {
 function countProcessInternals(
   name: '_getActiveHandles' | '_getActiveRequests',
 ) {
+  // These process methods are undocumented Node.js internals. They provide
+  // useful diagnostic counts, but may change across Node.js major versions; if
+  // unavailable or unstable, report `unavailable` instead of failing /doctor.
   const getter = (process as unknown as Record<string, unknown>)[name];
   if (typeof getter !== 'function') {
     return { count: 0, unavailable: true };
@@ -88,6 +91,8 @@ export function getMemoryDiagnostics(): MemoryDiagnostics {
 }
 
 function formatBytes(value: unknown): string {
+  // Report binary mebibytes (MiB) because Node/V8 memory APIs return byte
+  // counts and binary units avoid ambiguity when comparing heap limits.
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return 'unavailable';
   }

--- a/packages/cli/src/utils/memoryDiagnostics.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.ts
@@ -1,0 +1,148 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as v8 from 'node:v8';
+
+export interface MemoryDiagnostics {
+  generatedAt: string;
+  process: {
+    pid: number;
+    nodeVersion: string;
+    platform: NodeJS.Platform;
+    arch: string;
+    uptimeSeconds: number;
+  };
+  memory: NodeJS.MemoryUsage;
+  v8: {
+    heapStatistics?: Record<string, number>;
+    heapSpaces: Array<Record<string, number | string>>;
+    unavailable?: boolean;
+  };
+  activeHandles: {
+    count: number;
+    unavailable: boolean;
+  };
+  activeRequests: {
+    count: number;
+    unavailable: boolean;
+  };
+}
+
+function countProcessInternals(
+  name: '_getActiveHandles' | '_getActiveRequests',
+) {
+  const getter = (process as unknown as Record<string, unknown>)[name];
+  if (typeof getter !== 'function') {
+    return { count: 0, unavailable: true };
+  }
+
+  try {
+    const entries = (getter as () => unknown[])();
+    return {
+      count: Array.isArray(entries) ? entries.length : 0,
+      unavailable: false,
+    };
+  } catch {
+    return { count: 0, unavailable: true };
+  }
+}
+
+export function getMemoryDiagnostics(): MemoryDiagnostics {
+  let heapStatistics: Record<string, number> | undefined;
+  let heapSpaces: Array<Record<string, number | string>> = [];
+  let v8Unavailable = false;
+
+  try {
+    heapStatistics = v8.getHeapStatistics() as unknown as Record<
+      string,
+      number
+    >;
+    heapSpaces = v8.getHeapSpaceStatistics() as unknown as Array<
+      Record<string, number | string>
+    >;
+  } catch {
+    v8Unavailable = true;
+  }
+
+  return {
+    generatedAt: new Date().toISOString(),
+    process: {
+      pid: process.pid,
+      nodeVersion: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      uptimeSeconds: process.uptime(),
+    },
+    memory: process.memoryUsage(),
+    v8: {
+      heapStatistics,
+      heapSpaces,
+      unavailable: v8Unavailable,
+    },
+    activeHandles: countProcessInternals('_getActiveHandles'),
+    activeRequests: countProcessInternals('_getActiveRequests'),
+  };
+}
+
+function formatBytes(value: unknown): string {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return 'unavailable';
+  }
+
+  return `${(value / 1024 / 1024).toFixed(1)} MiB`;
+}
+
+function formatActiveCount(value: {
+  count: number;
+  unavailable: boolean;
+}): string {
+  return value.unavailable ? 'unavailable' : String(value.count);
+}
+
+export function formatMemoryDiagnostics(
+  diagnostics: MemoryDiagnostics,
+): string {
+  const heapStatistics = diagnostics.v8.heapStatistics ?? {};
+  const heapSpaceLines = diagnostics.v8.heapSpaces.map((space) => {
+    const name = String(space['space_name'] ?? 'unknown_space');
+    return `  - ${name}: ${formatBytes(space['space_used_size'])} / ${formatBytes(
+      space['space_size'],
+    )}`;
+  });
+
+  return [
+    'Memory diagnostics',
+    `Generated: ${diagnostics.generatedAt}`,
+    '',
+    'Process',
+    `  PID: ${diagnostics.process.pid}`,
+    `  Node.js: ${diagnostics.process.nodeVersion}`,
+    `  Platform: ${diagnostics.process.platform} ${diagnostics.process.arch}`,
+    `  Uptime: ${diagnostics.process.uptimeSeconds.toFixed(1)}s`,
+    '',
+    'Memory usage',
+    `  RSS: ${formatBytes(diagnostics.memory.rss)}`,
+    `  Heap used / total: ${formatBytes(
+      diagnostics.memory.heapUsed,
+    )} / ${formatBytes(diagnostics.memory.heapTotal)}`,
+    `  External: ${formatBytes(diagnostics.memory.external)}`,
+    `  Array buffers: ${formatBytes(diagnostics.memory.arrayBuffers)}`,
+    '',
+    'V8 heap',
+    `  Heap size limit: ${formatBytes(heapStatistics['heap_size_limit'])}`,
+    `  Total available: ${formatBytes(heapStatistics['total_available_size'])}`,
+    `  Total heap size executable: ${formatBytes(
+      heapStatistics['total_heap_size_executable'],
+    )}`,
+    `  Used heap size: ${formatBytes(heapStatistics['used_heap_size'])}`,
+    '  Heap spaces:',
+    ...(heapSpaceLines.length > 0 ? heapSpaceLines : ['  - unavailable']),
+    '',
+    'Runtime internals',
+    `  Active handles: ${formatActiveCount(diagnostics.activeHandles)}`,
+    `  Active requests: ${formatActiveCount(diagnostics.activeRequests)}`,
+  ].join('\n');
+}

--- a/packages/cli/src/utils/memoryDiagnostics.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.ts
@@ -9,6 +9,8 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import * as v8 from 'node:v8';
 
+export const HIGH_HEAP_PRESSURE_THRESHOLD = 0.85;
+
 export interface MemoryDiagnostics {
   generatedAt: string;
   process: {
@@ -40,6 +42,8 @@ function countProcessInternals(
   // These process methods are undocumented Node.js internals. They provide
   // useful diagnostic counts, but may change across Node.js major versions; if
   // unavailable or unstable, report `unavailable` instead of failing /doctor.
+  // Node.js 22 marks them deprecated (DEP0175), so this remains limited to the
+  // explicit /doctor memory diagnostic path.
   const getter = (process as unknown as Record<string, unknown>)[name];
   if (typeof getter !== 'function') {
     return { count: 0, unavailable: true };
@@ -63,18 +67,22 @@ function countProcessInternals(
 export function getMemoryDiagnostics(): MemoryDiagnostics {
   let heapStatistics: Record<string, number> | undefined;
   let heapSpaces: Array<Record<string, number | string>> = [];
-  let v8Unavailable = false;
 
   try {
     heapStatistics = v8.getHeapStatistics() as unknown as Record<
       string,
       number
     >;
+  } catch {
+    heapStatistics = undefined;
+  }
+
+  try {
     heapSpaces = v8.getHeapSpaceStatistics() as unknown as Array<
       Record<string, number | string>
     >;
   } catch {
-    v8Unavailable = true;
+    heapSpaces = [];
   }
 
   return {
@@ -90,7 +98,7 @@ export function getMemoryDiagnostics(): MemoryDiagnostics {
     v8: {
       heapStatistics,
       heapSpaces,
-      unavailable: v8Unavailable,
+      unavailable: heapStatistics === undefined,
     },
     activeHandles: countProcessInternals('_getActiveHandles'),
     activeRequests: countProcessInternals('_getActiveRequests'),
@@ -121,6 +129,7 @@ export interface MemoryPressureSample {
 export interface CollectMemoryPressureSamplesOptions {
   sampleCount?: number;
   intervalMs?: number;
+  signal?: AbortSignal;
   now?: () => Date;
   memoryUsage?: () => NodeJS.MemoryUsage;
   wait?: (ms: number) => Promise<void>;
@@ -135,13 +144,25 @@ function formatSnapshotTimestamp(now: Date): string {
 }
 
 function estimateHeapSnapshotBytes(): number {
-  const heapStats = v8.getHeapStatistics();
-  return Math.max(heapStats.total_heap_size, process.memoryUsage().heapTotal);
+  const overheadFactor = 3;
+  try {
+    const heapStats = v8.getHeapStatistics();
+    return (
+      Math.max(heapStats.total_heap_size, process.memoryUsage().heapTotal) *
+      overheadFactor
+    );
+  } catch {
+    return process.memoryUsage().heapTotal * overheadFactor;
+  }
 }
 
 function getAvailableBytes(outputDir: string): number {
-  const stats = fs.statfsSync(outputDir);
-  return stats.bavail * stats.bsize;
+  try {
+    const stats = fs.statfsSync(outputDir);
+    return stats.bavail * stats.bsize;
+  } catch {
+    return Number.MAX_SAFE_INTEGER;
+  }
 }
 
 function cleanupOldHeapSnapshots(
@@ -157,7 +178,11 @@ function cleanupOldHeapSnapshots(
         name.startsWith('qwen-code-heap-') && name.endsWith('.heapsnapshot'),
     )
     .map((name) => path.join(outputDir, name))
-    .sort((a, b) => b.localeCompare(a));
+    .sort((a, b) => {
+      const aStat = fs.statSync(a);
+      const bStat = fs.statSync(b);
+      return bStat.mtimeMs - aStat.mtimeMs;
+    });
 
   for (const filePath of snapshots.slice(maxSnapshots)) {
     fs.rmSync(filePath, { force: true });
@@ -165,6 +190,10 @@ function cleanupOldHeapSnapshots(
 }
 
 const lastHeapSnapshotWriteByDir = new Map<string, number>();
+
+export function clearHeapSnapshotRateLimit(): void {
+  lastHeapSnapshotWriteByDir.clear();
+}
 
 function enforceHeapSnapshotRateLimit(
   outputDir: string,
@@ -222,14 +251,29 @@ export function writeMemoryHeapSnapshot({
     `qwen-code-heap-${process.pid}-${formatSnapshotTimestamp(now)}.heapsnapshot`,
   );
 
-  const writtenPath = writeSnapshot(filePath);
+  let writtenPath: string;
+  try {
+    writtenPath = writeSnapshot(filePath);
+  } catch (error) {
+    try {
+      fs.rmSync(filePath, { force: true });
+    } catch {
+      // Best-effort cleanup for partial snapshots after a failed write.
+    }
+    throw error;
+  }
+
   try {
     fs.chmodSync(writtenPath, 0o600);
   } catch {
     // Best-effort hardening; the report warns that snapshots are sensitive.
   }
   recordHeapSnapshotWrite(outputDir, now);
-  cleanupOldHeapSnapshots(outputDir, maxSnapshots);
+  try {
+    cleanupOldHeapSnapshots(outputDir, maxSnapshots);
+  } catch {
+    // Snapshot was already written successfully; cleanup is best-effort.
+  }
   return writtenPath;
 }
 
@@ -248,6 +292,7 @@ function normalizeSampleCount(sampleCount: number): number {
 export async function collectMemoryPressureSamples({
   sampleCount = 3,
   intervalMs = 1000,
+  signal,
   now = () => new Date(),
   memoryUsage = process.memoryUsage,
   wait = defaultWait,
@@ -256,6 +301,10 @@ export async function collectMemoryPressureSamples({
   const samples: MemoryPressureSample[] = [];
 
   for (let index = 1; index <= count; index++) {
+    if (signal?.aborted) {
+      break;
+    }
+
     const memory = memoryUsage();
     samples.push({
       index,
@@ -267,7 +316,7 @@ export async function collectMemoryPressureSamples({
       arrayBuffers: memory.arrayBuffers,
     });
 
-    if (index < count) {
+    if (index < count && !signal?.aborted) {
       await wait(intervalMs);
     }
   }
@@ -317,12 +366,8 @@ interface MemoryInsights {
 }
 
 function buildMemoryInsights(diagnostics: MemoryDiagnostics): MemoryInsights {
-  const heapStatistics = diagnostics.v8.heapStatistics ?? {};
-  const heapSizeLimit = asFiniteNumber(heapStatistics['heap_size_limit']);
-  const heapPressure =
-    heapSizeLimit !== undefined && heapSizeLimit > 0
-      ? diagnostics.memory.heapUsed / heapSizeLimit
-      : undefined;
+  const heapPressure = getHeapPressure(diagnostics);
+  const heapIsHigh = isHighHeapPressure(diagnostics);
   const rssHeapGapBytes = Math.max(
     0,
     diagnostics.memory.rss - diagnostics.memory.heapTotal,
@@ -335,7 +380,6 @@ function buildMemoryInsights(diagnostics: MemoryDiagnostics): MemoryInsights {
   const externalMemoryIsHigh =
     externalAndBuffers >= 256 * 1024 * 1024 &&
     externalAndBuffers >= diagnostics.memory.rss * 0.3;
-  const heapIsHigh = heapPressure !== undefined && heapPressure >= 0.85;
 
   const signals: string[] = [];
   const recommendations: string[] = [];
@@ -386,6 +430,23 @@ function buildMemoryInsights(diagnostics: MemoryDiagnostics): MemoryInsights {
     signals,
     recommendations,
   };
+}
+
+export function getHeapPressure(
+  diagnostics: MemoryDiagnostics,
+): number | undefined {
+  const heapStatistics = diagnostics.v8.heapStatistics ?? {};
+  const heapSizeLimit = asFiniteNumber(heapStatistics['heap_size_limit']);
+  return heapSizeLimit !== undefined && heapSizeLimit > 0
+    ? diagnostics.memory.heapUsed / heapSizeLimit
+    : undefined;
+}
+
+export function isHighHeapPressure(diagnostics: MemoryDiagnostics): boolean {
+  const heapPressure = getHeapPressure(diagnostics);
+  return (
+    heapPressure !== undefined && heapPressure >= HIGH_HEAP_PRESSURE_THRESHOLD
+  );
 }
 
 export function formatMemoryPressureSamples(

--- a/packages/cli/src/utils/memoryDiagnostics.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.ts
@@ -181,12 +181,27 @@ function cleanupOldHeapSnapshots(
     .sort((a, b) => {
       const aStat = fs.statSync(a);
       const bStat = fs.statSync(b);
-      return bStat.mtimeMs - aStat.mtimeMs;
+      const mtimeDelta = bStat.mtimeMs - aStat.mtimeMs;
+      if (mtimeDelta !== 0) return mtimeDelta;
+
+      return (
+        extractHeapSnapshotTimestamp(b).localeCompare(
+          extractHeapSnapshotTimestamp(a),
+        ) || path.basename(b).localeCompare(path.basename(a))
+      );
     });
 
   for (const filePath of snapshots.slice(maxSnapshots)) {
     fs.rmSync(filePath, { force: true });
   }
+}
+
+function extractHeapSnapshotTimestamp(filePath: string): string {
+  return (
+    path
+      .basename(filePath)
+      .match(/^qwen-code-heap-\d+-(.+)\.heapsnapshot$/)?.[1] ?? ''
+  );
 }
 
 const lastHeapSnapshotWriteByDir = new Map<string, number>();

--- a/packages/cli/src/utils/memoryDiagnostics.ts
+++ b/packages/cli/src/utils/memoryDiagnostics.ts
@@ -144,6 +144,8 @@ function formatSnapshotTimestamp(now: Date): string {
 }
 
 function estimateHeapSnapshotBytes(): number {
+  // Conservative 3x estimate: V8 heap snapshots include metadata, edges, and
+  // string tables in addition to live heap bytes.
   const overheadFactor = 3;
   try {
     const heapStats = v8.getHeapStatistics();
@@ -160,9 +162,17 @@ function getAvailableBytes(outputDir: string): number {
   try {
     const stats = fs.statfsSync(outputDir);
     return stats.bavail * stats.bsize;
-  } catch {
-    return Number.MAX_SAFE_INTEGER;
+  } catch (error) {
+    throw new Error(
+      `Unable to check available disk space for heap snapshot: ${formatErrorMessage(
+        error,
+      )}`,
+    );
   }
+}
+
+function formatErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function cleanupOldHeapSnapshots(
@@ -307,7 +317,7 @@ function defaultWait(ms: number): Promise<void> {
 }
 
 function normalizeSampleCount(sampleCount: number): number {
-  if (!Number.isFinite(sampleCount)) {
+  if (!Number.isFinite(sampleCount) || sampleCount <= 0) {
     return 3;
   }
 


### PR DESCRIPTION
## Summary
- Add `/doctor memory` as the first lightweight memory diagnostic slice.
- Collect paste-safe process memory, V8 heap statistics/spaces, active handle/request counts, and process metadata.
- Add targeted tests for the diagnostic formatter/collector and command routing.

## Test Plan
- `npm test --workspace=packages/cli -- --run src/utils/memoryDiagnostics.test.ts src/ui/commands/doctorCommand.test.ts`
- `npm run typecheck --workspace=packages/cli` currently fails on pre-existing unrelated package/core API drift; no `memoryDiagnostics` or `doctorCommand` errors remain.

Part of #3000
Closes #4179
