### PR TITLE
[codex] Allow custom output directory for /export

### DIFF
--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -386,6 +386,39 @@ describe('exportCommand', () => {
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
 
+    it('should revalidate the output directory before writing', async () => {
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+
+      const outputDir = path.resolve('/test/dir', './logs');
+      let contentFormatted = false;
+      vi.mocked(toMarkdown).mockImplementation(() => {
+        contentFormatted = true;
+        return '# Test Markdown';
+      });
+      vi.mocked(fs.realpath).mockImplementation(async (p) => {
+        const pathStr = p.toString();
+        if (pathStr === outputDir && contentFormatted) {
+          return path.resolve('/outside/logs');
+        }
+        return pathStr;
+      });
+
+      const result = await mdCommand.action(mockContext, './logs');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content:
+          'Export directory must be within the project working directory. (path resolves outside cwd via symlink)',
+      });
+      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
+      expect(toMarkdown).toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
     it('should allow output directories with names beginning with two dots', async () => {
       const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
       if (!mdCommand?.action) {
@@ -439,6 +472,40 @@ describe('exportCommand', () => {
       });
       expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
       expect(fs.writeFile).toHaveBeenCalled();
+    });
+
+    it('should not ignore non-missing realpath errors while checking parents', async () => {
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+
+      const missingOutputDir = path.resolve('/test/dir', './blocked/logs');
+      const blockedParent = path.resolve('/test/dir', './blocked');
+      vi.mocked(fs.realpath).mockImplementation(async (p) => {
+        const pathStr = p.toString();
+        if (pathStr === missingOutputDir) {
+          const err = new Error('ENOENT: no such file or directory');
+          (err as NodeJS.ErrnoException).code = 'ENOENT';
+          throw err;
+        }
+        if (pathStr === blockedParent) {
+          const err = new Error('EACCES: permission denied');
+          (err as NodeJS.ErrnoException).code = 'EACCES';
+          throw err;
+        }
+        return pathStr;
+      });
+
+      const result = await mdCommand.action(mockContext, './blocked/logs');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'Failed to export session: EACCES: permission denied',
+      });
+      expect(fs.mkdir).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -34,6 +34,12 @@ vi.mock('@qwen-code/qwen-code-core', () => {
   }
 
   return {
+    createDebugLogger: () => ({
+      debug: () => {},
+      error: () => {},
+      info: () => {},
+      warn: () => {},
+    }),
     isSubpath: (parentPath: string, childPath: string) => {
       const relativePath = path.relative(parentPath, childPath);
       return (

--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -34,6 +34,15 @@ vi.mock('@qwen-code/qwen-code-core', () => {
   }
 
   return {
+    isSubpath: (parentPath: string, childPath: string) => {
+      const relativePath = path.relative(parentPath, childPath);
+      return (
+        relativePath === '' ||
+        (relativePath !== '..' &&
+          !relativePath.startsWith(`..${path.sep}`) &&
+          !path.isAbsolute(relativePath))
+      );
+    },
     SessionService,
   };
 });
@@ -326,7 +335,7 @@ describe('exportCommand', () => {
         type: 'message',
         messageType: 'error',
         content:
-          'Export directory must be within the project working directory.',
+          'Export directory must be within the project working directory. (target path is outside cwd)',
       });
       expect(mockSessionServiceMocks.loadSession).not.toHaveBeenCalled();
       expect(fs.mkdir).not.toHaveBeenCalled();
@@ -345,7 +354,7 @@ describe('exportCommand', () => {
         type: 'message',
         messageType: 'error',
         content:
-          'Export directory must be within the project working directory.',
+          'Export directory must be within the project working directory. (target path is outside cwd)',
       });
       expect(mockSessionServiceMocks.loadSession).not.toHaveBeenCalled();
       expect(fs.mkdir).not.toHaveBeenCalled();
@@ -371,10 +380,65 @@ describe('exportCommand', () => {
         type: 'message',
         messageType: 'error',
         content:
-          'Export directory must be within the project working directory.',
+          'Export directory must be within the project working directory. (path resolves outside cwd via symlink)',
       });
       expect(fs.mkdir).not.toHaveBeenCalled();
       expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should allow output directories with names beginning with two dots', async () => {
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+
+      const result = await mdCommand.action(mockContext, './..backup');
+      const outputDir = path.resolve('/test/dir', './..backup');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining(
+          path.join('./..backup', 'export-2025-01-01T00-00-00-000Z.md'),
+        ),
+      });
+      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
+      expect(fs.writeFile).toHaveBeenCalled();
+    });
+
+    it('should validate the nearest existing parent for fresh nested directories', async () => {
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+
+      let outputDirCreated = false;
+      vi.mocked(fs.mkdir).mockImplementation(async () => {
+        outputDirCreated = true;
+        return undefined;
+      });
+      vi.mocked(fs.realpath).mockImplementation(async (p) => {
+        const pathStr = p.toString();
+        if (pathStr.includes('/nonexistent') && !outputDirCreated) {
+          const err = new Error('ENOENT: no such file or directory');
+          (err as NodeJS.ErrnoException).code = 'ENOENT';
+          throw err;
+        }
+        return pathStr;
+      });
+
+      const result = await mdCommand.action(mockContext, './nonexistent/logs');
+      const outputDir = path.resolve('/test/dir', './nonexistent/logs');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining(
+          path.join('./nonexistent/logs', 'export-2025-01-01T00-00-00-000Z.md'),
+        ),
+      });
+      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
+      expect(fs.writeFile).toHaveBeenCalled();
     });
   });
 
@@ -527,7 +591,7 @@ describe('exportCommand', () => {
         throw new Error('expected message result');
       }
       expect(result.content).toContain('Failed to generate HTML');
-      expect(result.content).toContain('HTML target:');
+      expect(result.content).not.toContain('HTML target:');
     });
 
     it('should handle errors during file write', async () => {
@@ -643,7 +707,7 @@ describe('exportCommand', () => {
         throw new Error('expected message result');
       }
       expect(result.content).toContain('Failed to generate JSON');
-      expect(result.content).toContain('JSON target:');
+      expect(result.content).not.toContain('JSON target:');
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
   });
@@ -736,7 +800,7 @@ describe('exportCommand', () => {
         throw new Error('expected message result');
       }
       expect(result.content).toContain('Failed to generate JSONL');
-      expect(result.content).toContain('JSONL target:');
+      expect(result.content).not.toContain('JSONL target:');
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
   });

--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs/promises';
+import path from 'node:path';
 import { exportCommand } from './exportCommand.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import type { ChatRecord } from '@qwen-code/qwen-code-core';
@@ -15,6 +16,8 @@ import {
   normalizeSessionData,
   toMarkdown,
   toHtml,
+  toJson,
+  toJsonl,
   generateExportFilename,
 } from '../utils/export/index.js';
 
@@ -40,6 +43,8 @@ vi.mock('../utils/export/index.js', () => ({
   normalizeSessionData: vi.fn(),
   toMarkdown: vi.fn(),
   toHtml: vi.fn(),
+  toJson: vi.fn(),
+  toJsonl: vi.fn(),
   generateExportFilename: vi.fn(),
 }));
 
@@ -91,6 +96,8 @@ describe('exportCommand', () => {
     vi.mocked(toHtml).mockReturnValue(
       '<html><script id="chat-data" type="application/json">{"data": "test"}</script></html>',
     );
+    vi.mocked(toJson).mockReturnValue('{"messages":[]}');
+    vi.mocked(toJsonl).mockReturnValue('{"type":"session_metadata"}');
     vi.mocked(generateExportFilename).mockImplementation(
       (ext: string) => `export-2025-01-01T00-00-00-000Z.${ext}`,
     );
@@ -142,6 +149,7 @@ describe('exportCommand', () => {
       expect(normalizeSessionData).toHaveBeenCalled();
       expect(toMarkdown).toHaveBeenCalled();
       expect(generateExportFilename).toHaveBeenCalledWith('md');
+      expect(fs.mkdir).not.toHaveBeenCalled();
       expect(fs.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('export-2025-01-01T00-00-00-000Z.md'),
         '# Test Markdown',
@@ -156,22 +164,40 @@ describe('exportCommand', () => {
       }
 
       const result = await mdCommand.action(mockContext, './logs');
+      const outputDir = path.resolve('/test/dir', './logs');
+      const filepath = path.join(
+        outputDir,
+        'export-2025-01-01T00-00-00-000Z.md',
+      );
 
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
-        content: expect.stringContaining(
-          '/test/dir/logs/export-2025-01-01T00-00-00-000Z.md',
-        ),
+        content: expect.stringContaining(filepath),
       });
-      expect(fs.mkdir).toHaveBeenCalledWith('/test/dir/logs', {
-        recursive: true,
-      });
+      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
       expect(fs.writeFile).toHaveBeenCalledWith(
-        '/test/dir/logs/export-2025-01-01T00-00-00-000Z.md',
+        filepath,
         '# Test Markdown',
         'utf-8',
       );
+    });
+
+    it('should keep cwd-equivalent directory output concise', async () => {
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+
+      const result = await mdCommand.action(mockContext, '.');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content:
+          'Session exported to markdown: export-2025-01-01T00-00-00-000Z.md',
+      });
+      expect(fs.mkdir).not.toHaveBeenCalled();
     });
 
     it('should return error when config is not available', async () => {
@@ -246,8 +272,14 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
-        content: 'Failed to export session: File write failed',
+        content: expect.stringContaining(
+          'Failed to export session to markdown at',
+        ),
       });
+      if (!result || result.type !== 'message') {
+        throw new Error('expected message result');
+      }
+      expect(result.content).toContain('File write failed');
     });
 
     it('should use project root when working dir is not available', async () => {
@@ -308,19 +340,20 @@ describe('exportCommand', () => {
       }
 
       const result = await exportCommand.action(mockContext, './logs');
+      const outputDir = path.resolve('/test/dir', './logs');
+      const filepath = path.join(
+        outputDir,
+        'export-2025-01-01T00-00-00-000Z.html',
+      );
 
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
-        content: expect.stringContaining(
-          '/test/dir/logs/export-2025-01-01T00-00-00-000Z.html',
-        ),
+        content: expect.stringContaining(filepath),
       });
-      expect(fs.mkdir).toHaveBeenCalledWith('/test/dir/logs', {
-        recursive: true,
-      });
+      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
       expect(fs.writeFile).toHaveBeenCalledWith(
-        '/test/dir/logs/export-2025-01-01T00-00-00-000Z.html',
+        filepath,
         expect.stringContaining('{"data": "test"}'),
         'utf-8',
       );
@@ -408,8 +441,12 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
-        content: 'Failed to export session: Failed to generate HTML',
+        content: expect.stringContaining('Failed to export session to HTML at'),
       });
+      if (!result || result.type !== 'message') {
+        throw new Error('expected message result');
+      }
+      expect(result.content).toContain('Failed to generate HTML');
     });
 
     it('should handle errors during file write', async () => {
@@ -427,8 +464,12 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
-        content: 'Failed to export session: File write failed',
+        content: expect.stringContaining('Failed to export session to HTML at'),
       });
+      if (!result || result.type !== 'message') {
+        throw new Error('expected message result');
+      }
+      expect(result.content).toContain('File write failed');
     });
   });
 });

--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -85,6 +85,9 @@ describe('exportCommand', () => {
     },
   };
 
+  const mockWorkingDir = path.resolve('/test/dir');
+  const mockProjectRoot = path.resolve('/test/project');
+
   let mockContext: ReturnType<typeof createMockCommandContext>;
 
   beforeEach(() => {
@@ -95,8 +98,8 @@ describe('exportCommand', () => {
     mockContext = createMockCommandContext({
       services: {
         config: {
-          getWorkingDir: vi.fn().mockReturnValue('/test/dir'),
-          getProjectRoot: vi.fn().mockReturnValue('/test/project'),
+          getWorkingDir: vi.fn().mockReturnValue(mockWorkingDir),
+          getProjectRoot: vi.fn().mockReturnValue(mockProjectRoot),
           getSessionId: vi.fn().mockReturnValue('test-session-id'),
         },
       },
@@ -181,7 +184,7 @@ describe('exportCommand', () => {
       }
 
       const result = await mdCommand.action(mockContext, './logs');
-      const outputDir = path.resolve('/test/dir', './logs');
+      const outputDir = path.resolve(mockWorkingDir, './logs');
       const filepath = path.join(
         outputDir,
         'export-2025-01-01T00-00-00-000Z.md',
@@ -374,7 +377,7 @@ describe('exportCommand', () => {
         services: {
           config: {
             getWorkingDir: vi.fn().mockReturnValue(null),
-            getProjectRoot: vi.fn().mockReturnValue('/test/project'),
+            getProjectRoot: vi.fn().mockReturnValue(mockProjectRoot),
             getSessionId: vi.fn().mockReturnValue('test-session-id'),
           },
         },
@@ -405,14 +408,14 @@ describe('exportCommand', () => {
       }
 
       const result = await mdCommand.action(mockContext, '../outside');
-      const outputDir = path.resolve('/test/dir', '../outside');
+      const outputDir = path.resolve(mockWorkingDir, '../outside');
 
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
         content:
           `Export directory must be within the project working directory. ` +
-          `(target path is outside cwd; target: "${outputDir}", cwd: "/test/dir")`,
+          `(target path is outside cwd; target: "${outputDir}", cwd: "${mockWorkingDir}")`,
       });
       expect(mockSessionServiceMocks.loadSession).not.toHaveBeenCalled();
       expect(fs.mkdir).not.toHaveBeenCalled();
@@ -426,14 +429,14 @@ describe('exportCommand', () => {
       }
 
       const result = await mdCommand.action(mockContext, '/tmp/exports');
-      const outputDir = path.resolve('/tmp/exports');
+      const outputDir = path.resolve(mockWorkingDir, '/tmp/exports');
 
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
         content:
           `Export directory must be within the project working directory. ` +
-          `(target path is outside cwd; target: "${outputDir}", cwd: "/test/dir")`,
+          `(target path is outside cwd; target: "${outputDir}", cwd: "${mockWorkingDir}")`,
       });
       expect(mockSessionServiceMocks.loadSession).not.toHaveBeenCalled();
       expect(fs.mkdir).not.toHaveBeenCalled();
@@ -446,7 +449,7 @@ describe('exportCommand', () => {
         throw new Error('md command not found');
       }
 
-      const outputDir = path.resolve('/test/dir', './logs');
+      const outputDir = path.resolve(mockWorkingDir, './logs');
       vi.mocked(fs.realpath).mockImplementation(async (p) =>
         p.toString() === outputDir
           ? path.resolve('/outside/logs')
@@ -460,7 +463,7 @@ describe('exportCommand', () => {
         messageType: 'error',
         content:
           `Export directory must be within the project working directory. ` +
-          `(parent path resolves outside cwd via symlink; target: "${outputDir}", cwd: "/test/dir")`,
+          `(parent path resolves outside cwd via symlink; target: "${outputDir}", cwd: "${mockWorkingDir}")`,
       });
       expect(fs.mkdir).not.toHaveBeenCalled();
       expect(fs.writeFile).not.toHaveBeenCalled();
@@ -472,8 +475,8 @@ describe('exportCommand', () => {
         throw new Error('md command not found');
       }
 
-      const missingOutputDir = path.resolve('/test/dir', './logs/nested');
-      const symlinkParent = path.resolve('/test/dir', './logs');
+      const missingOutputDir = path.resolve(mockWorkingDir, './logs/nested');
+      const symlinkParent = path.resolve(mockWorkingDir, './logs');
       vi.mocked(fs.realpath).mockImplementation(async (p) => {
         const pathStr = p.toString();
         if (pathStr === missingOutputDir) {
@@ -494,7 +497,7 @@ describe('exportCommand', () => {
         messageType: 'error',
         content:
           `Export directory must be within the project working directory. ` +
-          `(parent path resolves outside cwd via symlink; target: "${missingOutputDir}", cwd: "/test/dir")`,
+          `(parent path resolves outside cwd via symlink; target: "${missingOutputDir}", cwd: "${mockWorkingDir}")`,
       });
       expect(mockSessionServiceMocks.loadSession).not.toHaveBeenCalled();
       expect(fs.mkdir).not.toHaveBeenCalled();
@@ -507,7 +510,7 @@ describe('exportCommand', () => {
         throw new Error('md command not found');
       }
 
-      const outputDir = path.resolve('/test/dir', './logs');
+      const outputDir = path.resolve(mockWorkingDir, './logs');
       let contentFormatted = false;
       vi.mocked(toMarkdown).mockImplementation(() => {
         contentFormatted = true;
@@ -528,7 +531,7 @@ describe('exportCommand', () => {
         messageType: 'error',
         content:
           `Export directory must be within the project working directory. ` +
-          `(target path resolves outside cwd via symlink; target: "${outputDir}", cwd: "/test/dir")`,
+          `(target path resolves outside cwd via symlink; target: "${outputDir}", cwd: "${mockWorkingDir}")`,
       });
       expect(fs.mkdir).toHaveBeenCalledWith(outputDir, {
         recursive: true,
@@ -544,7 +547,7 @@ describe('exportCommand', () => {
         throw new Error('md command not found');
       }
 
-      const outputDir = path.resolve('/test/dir', './logs');
+      const outputDir = path.resolve(mockWorkingDir, './logs');
       let contentFormatted = false;
       vi.mocked(toMarkdown).mockImplementation(() => {
         contentFormatted = true;
@@ -567,7 +570,7 @@ describe('exportCommand', () => {
         messageType: 'error',
         content:
           `Export target directory is not accessible (path does not exist; ` +
-          `target: "${outputDir}", cwd: "/test/dir").`,
+          `target: "${outputDir}", cwd: "${mockWorkingDir}").`,
       });
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
@@ -578,7 +581,7 @@ describe('exportCommand', () => {
         throw new Error('md command not found');
       }
 
-      const outputDir = path.resolve('/test/dir', './logs');
+      const outputDir = path.resolve(mockWorkingDir, './logs');
       let contentFormatted = false;
       vi.mocked(toMarkdown).mockImplementation(() => {
         contentFormatted = true;
@@ -614,7 +617,7 @@ describe('exportCommand', () => {
       }
 
       const result = await mdCommand.action(mockContext, './..backup');
-      const outputDir = path.resolve('/test/dir', './..backup');
+      const outputDir = path.resolve(mockWorkingDir, './..backup');
 
       expect(result).toEqual({
         type: 'message',
@@ -643,7 +646,7 @@ describe('exportCommand', () => {
       });
       vi.mocked(fs.realpath).mockImplementation(async (p) => {
         const pathStr = p.toString();
-        if (pathStr.includes('/nonexistent') && !outputDirCreated) {
+        if (pathStr.includes(`${path.sep}nonexistent`) && !outputDirCreated) {
           const err = new Error('ENOENT: no such file or directory');
           (err as NodeJS.ErrnoException).code = 'ENOENT';
           throw err;
@@ -652,7 +655,7 @@ describe('exportCommand', () => {
       });
 
       const result = await mdCommand.action(mockContext, './nonexistent/logs');
-      const outputDir = path.resolve('/test/dir', './nonexistent/logs');
+      const outputDir = path.resolve(mockWorkingDir, './nonexistent/logs');
 
       expect(result).toEqual({
         type: 'message',
@@ -674,8 +677,8 @@ describe('exportCommand', () => {
         throw new Error('md command not found');
       }
 
-      const missingOutputDir = path.resolve('/test/dir', './blocked/logs');
-      const blockedParent = path.resolve('/test/dir', './blocked');
+      const missingOutputDir = path.resolve(mockWorkingDir, './blocked/logs');
+      const blockedParent = path.resolve(mockWorkingDir, './blocked');
       vi.mocked(fs.realpath).mockImplementation(async (p) => {
         const pathStr = p.toString();
         if (pathStr === missingOutputDir) {
@@ -717,8 +720,10 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
-        content:
-          'Failed to create export directory "/test/dir/logs": EACCES: permission denied, mkdir',
+        content: `Failed to create export directory "${path.resolve(
+          mockWorkingDir,
+          './logs',
+        )}": EACCES: permission denied, mkdir`,
       });
       expect(collectSessionData).toHaveBeenCalled();
       expect(toMarkdown).toHaveBeenCalled();
@@ -766,7 +771,7 @@ describe('exportCommand', () => {
       }
 
       const result = await exportCommand.action(mockContext, './logs');
-      const outputDir = path.resolve('/test/dir', './logs');
+      const outputDir = path.resolve(mockWorkingDir, './logs');
       const filepath = path.join(
         outputDir,
         'export-2025-01-01T00-00-00-000Z.html',
@@ -950,7 +955,7 @@ describe('exportCommand', () => {
       }
 
       const result = await jsonCommand.action(mockContext, './logs');
-      const outputDir = path.resolve('/test/dir', './logs');
+      const outputDir = path.resolve(mockWorkingDir, './logs');
       const filepath = path.join(
         outputDir,
         'export-2025-01-01T00-00-00-000Z.json',
@@ -1045,7 +1050,7 @@ describe('exportCommand', () => {
       }
 
       const result = await jsonlCommand.action(mockContext, './logs');
-      const outputDir = path.resolve('/test/dir', './logs');
+      const outputDir = path.resolve(mockWorkingDir, './logs');
       const filepath = path.join(
         outputDir,
         'export-2025-01-01T00-00-00-000Z.jsonl',

--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -164,7 +164,7 @@ describe('exportCommand', () => {
       expect(fs.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('export-2025-01-01T00-00-00-000Z.md'),
         '# Test Markdown',
-        'utf-8',
+        { encoding: 'utf-8', mode: 0o600 },
       );
     });
 
@@ -188,12 +188,14 @@ describe('exportCommand', () => {
           path.join('./logs', 'export-2025-01-01T00-00-00-000Z.md'),
         ),
       });
-      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
-      expect(fs.writeFile).toHaveBeenCalledWith(
-        filepath,
-        '# Test Markdown',
-        'utf-8',
-      );
+      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, {
+        recursive: true,
+        mode: 0o700,
+      });
+      expect(fs.writeFile).toHaveBeenCalledWith(filepath, '# Test Markdown', {
+        encoding: 'utf-8',
+        mode: 0o600,
+      });
     });
 
     it('should keep cwd-equivalent directory output concise', async () => {
@@ -294,6 +296,71 @@ describe('exportCommand', () => {
       expect(result.content).toContain('markdown target:');
     });
 
+    it('should handle errors during markdown generation', async () => {
+      const error = new Error('Failed to generate markdown');
+      vi.mocked(toMarkdown).mockImplementation(() => {
+        throw error;
+      });
+
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+      const result = await mdCommand.action(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: expect.stringContaining('Failed to export session:'),
+      });
+      if (!result || result.type !== 'message') {
+        throw new Error('expected message result');
+      }
+      expect(result.content).toContain('Failed to generate markdown');
+      expect(result.content).not.toContain('markdown target:');
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should handle session load errors', async () => {
+      mockSessionServiceMocks.loadSession.mockRejectedValue(
+        new Error('EIO: failed to read session'),
+      );
+
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+      const result = await mdCommand.action(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'Failed to export session: EIO: failed to read session',
+      });
+      expect(collectSessionData).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should handle session collection errors', async () => {
+      vi.mocked(collectSessionData).mockRejectedValue(
+        new Error('Failed to collect session data'),
+      );
+
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+      const result = await mdCommand.action(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'Failed to export session: Failed to collect session data',
+      });
+      expect(toMarkdown).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
     it('should use project root when working dir is not available', async () => {
       const contextWithProjectRoot = createMockCommandContext({
         services: {
@@ -319,7 +386,7 @@ describe('exportCommand', () => {
       expect(fs.writeFile).toHaveBeenCalledWith(
         expect.stringContaining(`${path.sep}test${path.sep}project`),
         '# Test Markdown',
-        'utf-8',
+        { encoding: 'utf-8', mode: 0o600 },
       );
     });
 
@@ -448,8 +515,79 @@ describe('exportCommand', () => {
         content:
           'Export directory must be within the project working directory. (target path resolves outside cwd via symlink)',
       });
-      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
+      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, {
+        recursive: true,
+        mode: 0o700,
+      });
       expect(toMarkdown).toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should report inaccessible target directories during write revalidation', async () => {
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+
+      const outputDir = path.resolve('/test/dir', './logs');
+      let contentFormatted = false;
+      vi.mocked(toMarkdown).mockImplementation(() => {
+        contentFormatted = true;
+        return '# Test Markdown';
+      });
+      vi.mocked(fs.realpath).mockImplementation(async (p) => {
+        const pathStr = p.toString();
+        if (pathStr === outputDir && contentFormatted) {
+          const err = new Error('ENOENT: no such file or directory');
+          (err as NodeJS.ErrnoException).code = 'ENOENT';
+          throw err;
+        }
+        return pathStr;
+      });
+
+      const result = await mdCommand.action(mockContext, './logs');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content:
+          'Export target directory is not accessible (path does not exist).',
+      });
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should include target context when write revalidation throws', async () => {
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+
+      const outputDir = path.resolve('/test/dir', './logs');
+      let contentFormatted = false;
+      vi.mocked(toMarkdown).mockImplementation(() => {
+        contentFormatted = true;
+        return '# Test Markdown';
+      });
+      vi.mocked(fs.realpath).mockImplementation(async (p) => {
+        const pathStr = p.toString();
+        if (pathStr === outputDir && contentFormatted) {
+          throw new Error('ESTALE: stale file handle');
+        }
+        return pathStr;
+      });
+
+      const result = await mdCommand.action(mockContext, './logs');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: expect.stringContaining('Failed to export session:'),
+      });
+      if (!result || result.type !== 'message') {
+        throw new Error('expected message result');
+      }
+      expect(result.content).toContain('ESTALE: stale file handle');
+      expect(result.content).toContain('markdown target:');
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
 
@@ -469,7 +607,10 @@ describe('exportCommand', () => {
           path.join('./..backup', 'export-2025-01-01T00-00-00-000Z.md'),
         ),
       });
-      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
+      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, {
+        recursive: true,
+        mode: 0o700,
+      });
       expect(fs.writeFile).toHaveBeenCalled();
     });
 
@@ -504,7 +645,10 @@ describe('exportCommand', () => {
           path.join('./nonexistent/logs', 'export-2025-01-01T00-00-00-000Z.md'),
         ),
       });
-      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
+      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, {
+        recursive: true,
+        mode: 0o700,
+      });
       expect(fs.writeFile).toHaveBeenCalled();
     });
 
@@ -556,7 +700,8 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
-        content: 'Failed to export session: EACCES: permission denied, mkdir',
+        content:
+          'Failed to create export directory "/test/dir/logs": EACCES: permission denied, mkdir',
       });
       expect(collectSessionData).not.toHaveBeenCalled();
       expect(toMarkdown).not.toHaveBeenCalled();
@@ -594,7 +739,7 @@ describe('exportCommand', () => {
       expect(fs.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('export-2025-01-01T00-00-00-000Z.html'),
         expect.stringContaining('{"data": "test"}'),
-        'utf-8',
+        { encoding: 'utf-8', mode: 0o600 },
       );
     });
 
@@ -617,11 +762,14 @@ describe('exportCommand', () => {
           path.join('./logs', 'export-2025-01-01T00-00-00-000Z.html'),
         ),
       });
-      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
+      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, {
+        recursive: true,
+        mode: 0o700,
+      });
       expect(fs.writeFile).toHaveBeenCalledWith(
         filepath,
         expect.stringContaining('{"data": "test"}'),
-        'utf-8',
+        { encoding: 'utf-8', mode: 0o600 },
       );
     });
 
@@ -772,7 +920,7 @@ describe('exportCommand', () => {
       expect(fs.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('export-2025-01-01T00-00-00-000Z.json'),
         '{"messages":[]}',
-        'utf-8',
+        { encoding: 'utf-8', mode: 0o600 },
       );
     });
 
@@ -798,12 +946,14 @@ describe('exportCommand', () => {
           path.join('./logs', 'export-2025-01-01T00-00-00-000Z.json'),
         ),
       });
-      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
-      expect(fs.writeFile).toHaveBeenCalledWith(
-        filepath,
-        '{"messages":[]}',
-        'utf-8',
-      );
+      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, {
+        recursive: true,
+        mode: 0o700,
+      });
+      expect(fs.writeFile).toHaveBeenCalledWith(filepath, '{"messages":[]}', {
+        encoding: 'utf-8',
+        mode: 0o600,
+      });
     });
 
     it('should handle errors during JSON generation', async () => {
@@ -865,7 +1015,7 @@ describe('exportCommand', () => {
       expect(fs.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('export-2025-01-01T00-00-00-000Z.jsonl'),
         '{"type":"session_metadata"}',
-        'utf-8',
+        { encoding: 'utf-8', mode: 0o600 },
       );
     });
 
@@ -891,11 +1041,14 @@ describe('exportCommand', () => {
           path.join('./logs', 'export-2025-01-01T00-00-00-000Z.jsonl'),
         ),
       });
-      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
+      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, {
+        recursive: true,
+        mode: 0o700,
+      });
       expect(fs.writeFile).toHaveBeenCalledWith(
         filepath,
         '{"type":"session_metadata"}',
-        'utf-8',
+        { encoding: 'utf-8', mode: 0o600 },
       );
     });
 

--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -64,6 +64,7 @@ vi.mock('../utils/export/index.js', () => ({
 }));
 
 vi.mock('node:fs/promises', () => ({
+  chmod: vi.fn(),
   mkdir: vi.fn(),
   realpath: vi.fn(),
   writeFile: vi.fn(),
@@ -120,6 +121,7 @@ describe('exportCommand', () => {
     vi.mocked(generateExportFilename).mockImplementation(
       (ext: string) => `export-2025-01-01T00-00-00-000Z.${ext}`,
     );
+    vi.mocked(fs.chmod).mockResolvedValue(undefined);
     vi.mocked(fs.realpath).mockImplementation(async (p) => p.toString());
   });
 
@@ -600,7 +602,7 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
-        content: expect.stringContaining('Failed to export session:'),
+        content: expect.stringContaining('Export path validation failed:'),
       });
       if (!result || result.type !== 'message') {
         throw new Error('expected message result');

--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -44,6 +44,7 @@ vi.mock('../utils/export/index.js', () => ({
 }));
 
 vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn(),
   writeFile: vi.fn(),
 }));
 
@@ -143,6 +144,31 @@ describe('exportCommand', () => {
       expect(generateExportFilename).toHaveBeenCalledWith('md');
       expect(fs.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('export-2025-01-01T00-00-00-000Z.md'),
+        '# Test Markdown',
+        'utf-8',
+      );
+    });
+
+    it('should export markdown to a relative custom directory', async () => {
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+
+      const result = await mdCommand.action(mockContext, './logs');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining(
+          '/test/dir/logs/export-2025-01-01T00-00-00-000Z.md',
+        ),
+      });
+      expect(fs.mkdir).toHaveBeenCalledWith('/test/dir/logs', {
+        recursive: true,
+      });
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        '/test/dir/logs/export-2025-01-01T00-00-00-000Z.md',
         '# Test Markdown',
         'utf-8',
       );
@@ -271,6 +297,30 @@ describe('exportCommand', () => {
       expect(generateExportFilename).toHaveBeenCalledWith('html');
       expect(fs.writeFile).toHaveBeenCalledWith(
         expect.stringContaining('export-2025-01-01T00-00-00-000Z.html'),
+        expect.stringContaining('{"data": "test"}'),
+        'utf-8',
+      );
+    });
+
+    it('should export default HTML to a relative custom directory', async () => {
+      if (!exportCommand.action) {
+        throw new Error('export command action not found');
+      }
+
+      const result = await exportCommand.action(mockContext, './logs');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining(
+          '/test/dir/logs/export-2025-01-01T00-00-00-000Z.html',
+        ),
+      });
+      expect(fs.mkdir).toHaveBeenCalledWith('/test/dir/logs', {
+        recursive: true,
+      });
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        '/test/dir/logs/export-2025-01-01T00-00-00-000Z.html',
         expect.stringContaining('{"data": "test"}'),
         'utf-8',
       );

--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -399,12 +399,14 @@ describe('exportCommand', () => {
       }
 
       const result = await mdCommand.action(mockContext, '../outside');
+      const outputDir = path.resolve('/test/dir', '../outside');
 
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
         content:
-          'Export directory must be within the project working directory. (target path is outside cwd)',
+          `Export directory must be within the project working directory. ` +
+          `(target path is outside cwd; target: "${outputDir}", cwd: "/test/dir")`,
       });
       expect(mockSessionServiceMocks.loadSession).not.toHaveBeenCalled();
       expect(fs.mkdir).not.toHaveBeenCalled();
@@ -418,12 +420,14 @@ describe('exportCommand', () => {
       }
 
       const result = await mdCommand.action(mockContext, '/tmp/exports');
+      const outputDir = path.resolve('/tmp/exports');
 
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
         content:
-          'Export directory must be within the project working directory. (target path is outside cwd)',
+          `Export directory must be within the project working directory. ` +
+          `(target path is outside cwd; target: "${outputDir}", cwd: "/test/dir")`,
       });
       expect(mockSessionServiceMocks.loadSession).not.toHaveBeenCalled();
       expect(fs.mkdir).not.toHaveBeenCalled();
@@ -449,7 +453,8 @@ describe('exportCommand', () => {
         type: 'message',
         messageType: 'error',
         content:
-          'Export directory must be within the project working directory. (parent path resolves outside cwd via symlink)',
+          `Export directory must be within the project working directory. ` +
+          `(parent path resolves outside cwd via symlink; target: "${outputDir}", cwd: "/test/dir")`,
       });
       expect(fs.mkdir).not.toHaveBeenCalled();
       expect(fs.writeFile).not.toHaveBeenCalled();
@@ -482,7 +487,8 @@ describe('exportCommand', () => {
         type: 'message',
         messageType: 'error',
         content:
-          'Export directory must be within the project working directory. (parent path resolves outside cwd via symlink)',
+          `Export directory must be within the project working directory. ` +
+          `(parent path resolves outside cwd via symlink; target: "${missingOutputDir}", cwd: "/test/dir")`,
       });
       expect(mockSessionServiceMocks.loadSession).not.toHaveBeenCalled();
       expect(fs.mkdir).not.toHaveBeenCalled();
@@ -515,7 +521,8 @@ describe('exportCommand', () => {
         type: 'message',
         messageType: 'error',
         content:
-          'Export directory must be within the project working directory. (target path resolves outside cwd via symlink)',
+          `Export directory must be within the project working directory. ` +
+          `(target path resolves outside cwd via symlink; target: "${outputDir}", cwd: "/test/dir")`,
       });
       expect(fs.mkdir).toHaveBeenCalledWith(outputDir, {
         recursive: true,
@@ -553,7 +560,8 @@ describe('exportCommand', () => {
         type: 'message',
         messageType: 'error',
         content:
-          'Export target directory is not accessible (path does not exist).',
+          `Export target directory is not accessible (path does not exist; ` +
+          `target: "${outputDir}", cwd: "/test/dir").`,
       });
       expect(fs.writeFile).not.toHaveBeenCalled();
     });

--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -472,4 +472,132 @@ describe('exportCommand', () => {
       expect(result.content).toContain('File write failed');
     });
   });
+
+  describe('exportJsonAction', () => {
+    it('should export session to JSON file', async () => {
+      const jsonCommand = exportCommand.subCommands?.find(
+        (c) => c.name === 'json',
+      );
+      if (!jsonCommand?.action) {
+        throw new Error('json command not found');
+      }
+
+      const result = await jsonCommand.action(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining(
+          'export-2025-01-01T00-00-00-000Z.json',
+        ),
+      });
+
+      expect(mockSessionServiceMocks.loadSession).toHaveBeenCalled();
+      expect(collectSessionData).toHaveBeenCalledWith(
+        mockSessionData.conversation,
+        expect.anything(),
+      );
+      expect(normalizeSessionData).toHaveBeenCalled();
+      expect(toJson).toHaveBeenCalled();
+      expect(generateExportFilename).toHaveBeenCalledWith('json');
+      expect(fs.mkdir).not.toHaveBeenCalled();
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('export-2025-01-01T00-00-00-000Z.json'),
+        '{"messages":[]}',
+        'utf-8',
+      );
+    });
+
+    it('should export JSON to a relative custom directory', async () => {
+      const jsonCommand = exportCommand.subCommands?.find(
+        (c) => c.name === 'json',
+      );
+      if (!jsonCommand?.action) {
+        throw new Error('json command not found');
+      }
+
+      const result = await jsonCommand.action(mockContext, './logs');
+      const outputDir = path.resolve('/test/dir', './logs');
+      const filepath = path.join(
+        outputDir,
+        'export-2025-01-01T00-00-00-000Z.json',
+      );
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining(filepath),
+      });
+      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        filepath,
+        '{"messages":[]}',
+        'utf-8',
+      );
+    });
+  });
+
+  describe('exportJsonlAction', () => {
+    it('should export session to JSONL file', async () => {
+      const jsonlCommand = exportCommand.subCommands?.find(
+        (c) => c.name === 'jsonl',
+      );
+      if (!jsonlCommand?.action) {
+        throw new Error('jsonl command not found');
+      }
+
+      const result = await jsonlCommand.action(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining(
+          'export-2025-01-01T00-00-00-000Z.jsonl',
+        ),
+      });
+
+      expect(mockSessionServiceMocks.loadSession).toHaveBeenCalled();
+      expect(collectSessionData).toHaveBeenCalledWith(
+        mockSessionData.conversation,
+        expect.anything(),
+      );
+      expect(normalizeSessionData).toHaveBeenCalled();
+      expect(toJsonl).toHaveBeenCalled();
+      expect(generateExportFilename).toHaveBeenCalledWith('jsonl');
+      expect(fs.mkdir).not.toHaveBeenCalled();
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining('export-2025-01-01T00-00-00-000Z.jsonl'),
+        '{"type":"session_metadata"}',
+        'utf-8',
+      );
+    });
+
+    it('should export JSONL to a relative custom directory', async () => {
+      const jsonlCommand = exportCommand.subCommands?.find(
+        (c) => c.name === 'jsonl',
+      );
+      if (!jsonlCommand?.action) {
+        throw new Error('jsonl command not found');
+      }
+
+      const result = await jsonlCommand.action(mockContext, './logs');
+      const outputDir = path.resolve('/test/dir', './logs');
+      const filepath = path.join(
+        outputDir,
+        'export-2025-01-01T00-00-00-000Z.jsonl',
+      );
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining(filepath),
+      });
+      expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        filepath,
+        '{"type":"session_metadata"}',
+        'utf-8',
+      );
+    });
+  });
 });

--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -50,6 +50,7 @@ vi.mock('../utils/export/index.js', () => ({
 
 vi.mock('node:fs/promises', () => ({
   mkdir: vi.fn(),
+  realpath: vi.fn(),
   writeFile: vi.fn(),
 }));
 
@@ -101,6 +102,7 @@ describe('exportCommand', () => {
     vi.mocked(generateExportFilename).mockImplementation(
       (ext: string) => `export-2025-01-01T00-00-00-000Z.${ext}`,
     );
+    vi.mocked(fs.realpath).mockImplementation(async (p) => p.toString());
   });
 
   afterEach(() => {
@@ -272,14 +274,13 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
-        content: expect.stringContaining(
-          'Failed to export session to markdown at',
-        ),
+        content: expect.stringContaining('Failed to export session:'),
       });
       if (!result || result.type !== 'message') {
         throw new Error('expected message result');
       }
       expect(result.content).toContain('File write failed');
+      expect(result.content).toContain('markdown target:');
     });
 
     it('should use project root when working dir is not available', async () => {
@@ -288,6 +289,7 @@ describe('exportCommand', () => {
           config: {
             getWorkingDir: vi.fn().mockReturnValue(null),
             getProjectRoot: vi.fn().mockReturnValue('/test/project'),
+            getSessionId: vi.fn().mockReturnValue('test-session-id'),
           },
         },
       });
@@ -296,7 +298,62 @@ describe('exportCommand', () => {
       if (!mdCommand?.action) {
         throw new Error('md command not found');
       }
-      await mdCommand.action(contextWithProjectRoot, '');
+      const result = await mdCommand.action(contextWithProjectRoot, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: expect.stringContaining('export-2025-01-01T00-00-00-000Z.md'),
+      });
+      expect(fs.writeFile).toHaveBeenCalledWith(
+        expect.stringContaining(`${path.sep}test${path.sep}project`),
+        '# Test Markdown',
+        'utf-8',
+      );
+    });
+
+    it('should reject output directories outside the working directory', async () => {
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+
+      const result = await mdCommand.action(mockContext, '../outside');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content:
+          'Export directory must be within the project working directory.',
+      });
+      expect(mockSessionServiceMocks.loadSession).not.toHaveBeenCalled();
+      expect(fs.mkdir).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should reject symlinked output directories outside the working directory', async () => {
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+
+      const outputDir = path.resolve('/test/dir', './logs');
+      vi.mocked(fs.realpath).mockImplementation(async (p) =>
+        p.toString() === outputDir
+          ? path.resolve('/outside/logs')
+          : p.toString(),
+      );
+
+      const result = await mdCommand.action(mockContext, './logs');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content:
+          'Export directory must be within the project working directory.',
+      });
+      expect(fs.mkdir).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
     });
   });
 
@@ -441,12 +498,13 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
-        content: expect.stringContaining('Failed to export session to HTML at'),
+        content: expect.stringContaining('Failed to export session:'),
       });
       if (!result || result.type !== 'message') {
         throw new Error('expected message result');
       }
       expect(result.content).toContain('Failed to generate HTML');
+      expect(result.content).toContain('HTML target:');
     });
 
     it('should handle errors during file write', async () => {
@@ -464,12 +522,13 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
-        content: expect.stringContaining('Failed to export session to HTML at'),
+        content: expect.stringContaining('Failed to export session:'),
       });
       if (!result || result.type !== 'message') {
         throw new Error('expected message result');
       }
       expect(result.content).toContain('File write failed');
+      expect(result.content).toContain('HTML target:');
     });
   });
 

--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -335,7 +335,8 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
-        content: 'Failed to export session: EIO: failed to read session',
+        content:
+          'Failed to export session: EIO: failed to read session (markdown)',
       });
       expect(collectSessionData).not.toHaveBeenCalled();
       expect(fs.writeFile).not.toHaveBeenCalled();
@@ -355,7 +356,8 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
-        content: 'Failed to export session: Failed to collect session data',
+        content:
+          'Failed to export session: Failed to collect session data (markdown)',
       });
       expect(toMarkdown).not.toHaveBeenCalled();
       expect(fs.writeFile).not.toHaveBeenCalled();
@@ -680,13 +682,14 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'error',
-        content: 'Failed to export session: EACCES: permission denied',
+        content:
+          'Failed to export session: EACCES: permission denied (markdown)',
       });
       expect(fs.mkdir).not.toHaveBeenCalled();
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
 
-    it('should stop before formatting when custom directory creation fails', async () => {
+    it('should report custom directory creation failures with path context', async () => {
       const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
       if (!mdCommand?.action) {
         throw new Error('md command not found');
@@ -703,8 +706,8 @@ describe('exportCommand', () => {
         content:
           'Failed to create export directory "/test/dir/logs": EACCES: permission denied, mkdir',
       });
-      expect(collectSessionData).not.toHaveBeenCalled();
-      expect(toMarkdown).not.toHaveBeenCalled();
+      expect(collectSessionData).toHaveBeenCalled();
+      expect(toMarkdown).toHaveBeenCalled();
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
   });

--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -380,8 +380,42 @@ describe('exportCommand', () => {
         type: 'message',
         messageType: 'error',
         content:
-          'Export directory must be within the project working directory. (path resolves outside cwd via symlink)',
+          'Export directory must be within the project working directory. (parent path resolves outside cwd via symlink)',
       });
+      expect(fs.mkdir).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should not create directories when the nearest existing parent resolves outside cwd', async () => {
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+
+      const missingOutputDir = path.resolve('/test/dir', './logs/nested');
+      const symlinkParent = path.resolve('/test/dir', './logs');
+      vi.mocked(fs.realpath).mockImplementation(async (p) => {
+        const pathStr = p.toString();
+        if (pathStr === missingOutputDir) {
+          const err = new Error('ENOENT: no such file or directory');
+          (err as NodeJS.ErrnoException).code = 'ENOENT';
+          throw err;
+        }
+        if (pathStr === symlinkParent) {
+          return path.resolve('/outside/logs');
+        }
+        return pathStr;
+      });
+
+      const result = await mdCommand.action(mockContext, './logs/nested');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content:
+          'Export directory must be within the project working directory. (parent path resolves outside cwd via symlink)',
+      });
+      expect(mockSessionServiceMocks.loadSession).not.toHaveBeenCalled();
       expect(fs.mkdir).not.toHaveBeenCalled();
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
@@ -412,7 +446,7 @@ describe('exportCommand', () => {
         type: 'message',
         messageType: 'error',
         content:
-          'Export directory must be within the project working directory. (path resolves outside cwd via symlink)',
+          'Export directory must be within the project working directory. (target path resolves outside cwd via symlink)',
       });
       expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
       expect(toMarkdown).toHaveBeenCalled();
@@ -505,6 +539,27 @@ describe('exportCommand', () => {
         content: 'Failed to export session: EACCES: permission denied',
       });
       expect(fs.mkdir).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should stop before formatting when custom directory creation fails', async () => {
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+
+      const error = new Error('EACCES: permission denied, mkdir');
+      vi.mocked(fs.mkdir).mockRejectedValue(error);
+
+      const result = await mdCommand.action(mockContext, './logs');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'Failed to export session: EACCES: permission denied, mkdir',
+      });
+      expect(collectSessionData).not.toHaveBeenCalled();
+      expect(toMarkdown).not.toHaveBeenCalled();
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
   });

--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -374,6 +374,27 @@ describe('exportCommand', () => {
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
 
+    it('should handle session normalization errors', async () => {
+      vi.mocked(normalizeSessionData).mockImplementation(() => {
+        throw new Error('Failed to normalize session data');
+      });
+
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+      const result = await mdCommand.action(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content:
+          'Failed to export session: Failed to normalize session data (markdown)',
+      });
+      expect(toMarkdown).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
     it('should use project root when working dir is not available', async () => {
       const contextWithProjectRoot = createMockCommandContext({
         services: {
@@ -445,6 +466,34 @@ describe('exportCommand', () => {
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
 
+    it('should report default directory realpath validation failures', async () => {
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+
+      vi.mocked(fs.realpath).mockImplementation(async (p) => {
+        if (p.toString() === mockWorkingDir) {
+          const err = new Error('ENOENT: no such file or directory');
+          (err as NodeJS.ErrnoException).code = 'ENOENT';
+          throw err;
+        }
+        return p.toString();
+      });
+
+      const result = await mdCommand.action(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content:
+          `Export target directory is not accessible (path does not exist; ` +
+          `target: "${mockWorkingDir}", cwd: "${mockWorkingDir}").`,
+      });
+      expect(mockSessionServiceMocks.loadSession).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
     it('should reject symlinked output directories outside the working directory', async () => {
       const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
       if (!mdCommand?.action) {
@@ -500,6 +549,33 @@ describe('exportCommand', () => {
         content:
           `Export directory must be within the project working directory. ` +
           `(parent path resolves outside cwd via symlink; target: "${missingOutputDir}", cwd: "${mockWorkingDir}")`,
+      });
+      expect(mockSessionServiceMocks.loadSession).not.toHaveBeenCalled();
+      expect(fs.mkdir).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
+    it('should explain when no existing export ancestor can be resolved', async () => {
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+
+      vi.mocked(fs.realpath).mockImplementation(async () => {
+        const err = new Error('ENOENT: no such file or directory');
+        (err as NodeJS.ErrnoException).code = 'ENOENT';
+        throw err;
+      });
+
+      const result = await mdCommand.action(mockContext, './missing/nested');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content:
+          `Failed to export session: Cannot resolve any existing ancestor ` +
+          `within cwd: ${mockWorkingDir}. This usually means the project ` +
+          `working directory has been deleted or is on an unmounted filesystem. (markdown)`,
       });
       expect(mockSessionServiceMocks.loadSession).not.toHaveBeenCalled();
       expect(fs.mkdir).not.toHaveBeenCalled();

--- a/packages/cli/src/ui/commands/exportCommand.test.ts
+++ b/packages/cli/src/ui/commands/exportCommand.test.ts
@@ -175,7 +175,9 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
-        content: expect.stringContaining(filepath),
+        content: expect.stringContaining(
+          path.join('./logs', 'export-2025-01-01T00-00-00-000Z.md'),
+        ),
       });
       expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
       expect(fs.writeFile).toHaveBeenCalledWith(
@@ -331,6 +333,25 @@ describe('exportCommand', () => {
       expect(fs.writeFile).not.toHaveBeenCalled();
     });
 
+    it('should reject absolute output directories outside the working directory', async () => {
+      const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
+      if (!mdCommand?.action) {
+        throw new Error('md command not found');
+      }
+
+      const result = await mdCommand.action(mockContext, '/tmp/exports');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content:
+          'Export directory must be within the project working directory.',
+      });
+      expect(mockSessionServiceMocks.loadSession).not.toHaveBeenCalled();
+      expect(fs.mkdir).not.toHaveBeenCalled();
+      expect(fs.writeFile).not.toHaveBeenCalled();
+    });
+
     it('should reject symlinked output directories outside the working directory', async () => {
       const mdCommand = exportCommand.subCommands?.find((c) => c.name === 'md');
       if (!mdCommand?.action) {
@@ -406,7 +427,9 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
-        content: expect.stringContaining(filepath),
+        content: expect.stringContaining(
+          path.join('./logs', 'export-2025-01-01T00-00-00-000Z.html'),
+        ),
       });
       expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
       expect(fs.writeFile).toHaveBeenCalledWith(
@@ -585,7 +608,9 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
-        content: expect.stringContaining(filepath),
+        content: expect.stringContaining(
+          path.join('./logs', 'export-2025-01-01T00-00-00-000Z.json'),
+        ),
       });
       expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
       expect(fs.writeFile).toHaveBeenCalledWith(
@@ -593,6 +618,33 @@ describe('exportCommand', () => {
         '{"messages":[]}',
         'utf-8',
       );
+    });
+
+    it('should handle errors during JSON generation', async () => {
+      const error = new Error('Failed to generate JSON');
+      vi.mocked(toJson).mockImplementation(() => {
+        throw error;
+      });
+
+      const jsonCommand = exportCommand.subCommands?.find(
+        (c) => c.name === 'json',
+      );
+      if (!jsonCommand?.action) {
+        throw new Error('json command not found');
+      }
+      const result = await jsonCommand.action(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: expect.stringContaining('Failed to export session:'),
+      });
+      if (!result || result.type !== 'message') {
+        throw new Error('expected message result');
+      }
+      expect(result.content).toContain('Failed to generate JSON');
+      expect(result.content).toContain('JSON target:');
+      expect(fs.writeFile).not.toHaveBeenCalled();
     });
   });
 
@@ -649,7 +701,9 @@ describe('exportCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
-        content: expect.stringContaining(filepath),
+        content: expect.stringContaining(
+          path.join('./logs', 'export-2025-01-01T00-00-00-000Z.jsonl'),
+        ),
       });
       expect(fs.mkdir).toHaveBeenCalledWith(outputDir, { recursive: true });
       expect(fs.writeFile).toHaveBeenCalledWith(
@@ -657,6 +711,33 @@ describe('exportCommand', () => {
         '{"type":"session_metadata"}',
         'utf-8',
       );
+    });
+
+    it('should handle errors during JSONL generation', async () => {
+      const error = new Error('Failed to generate JSONL');
+      vi.mocked(toJsonl).mockImplementation(() => {
+        throw error;
+      });
+
+      const jsonlCommand = exportCommand.subCommands?.find(
+        (c) => c.name === 'jsonl',
+      );
+      if (!jsonlCommand?.action) {
+        throw new Error('jsonl command not found');
+      }
+      const result = await jsonlCommand.action(mockContext, '');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: expect.stringContaining('Failed to export session:'),
+      });
+      if (!result || result.type !== 'message') {
+        throw new Error('expected message result');
+      }
+      expect(result.content).toContain('Failed to generate JSONL');
+      expect(result.content).toContain('JSONL target:');
+      expect(fs.writeFile).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/ui/commands/exportCommand.ts
+++ b/packages/cli/src/ui/commands/exportCommand.ts
@@ -36,6 +36,15 @@ const EXPORT_DIR_OUT_OF_CWD =
 
 type ExportOutputDirKind = 'default' | 'custom';
 
+type ExportTargetContext = {
+  outputDir: string;
+  resolvedCwd: string;
+};
+
+function formatExportTargetContext(target: ExportTargetContext): string {
+  return `target: "${target.outputDir}", cwd: "${target.resolvedCwd}"`;
+}
+
 function resolveExportTarget(cwd: string, args: string, extension: string) {
   const filename = generateExportFilename(extension);
   const outputDirArg = args.trim();
@@ -77,8 +86,9 @@ async function validateExportTargetWithinCwd(target: {
       return {
         type: 'message',
         messageType: 'error',
-        content:
-          'Export target directory is not accessible (path does not exist).',
+        content: `Export target directory is not accessible (path does not exist; ${formatExportTargetContext(
+          target,
+        )}).`,
       };
     }
     throw error;
@@ -88,7 +98,9 @@ async function validateExportTargetWithinCwd(target: {
     return {
       type: 'message',
       messageType: 'error',
-      content: `${EXPORT_DIR_OUT_OF_CWD} (target path resolves outside cwd via symlink)`,
+      content: `${EXPORT_DIR_OUT_OF_CWD} (target path resolves outside cwd via symlink; ${formatExportTargetContext(
+        target,
+      )})`,
     };
   }
 
@@ -134,7 +146,9 @@ async function validateExistingExportParentWithinCwd(target: {
     return {
       type: 'message',
       messageType: 'error',
-      content: `${EXPORT_DIR_OUT_OF_CWD} (parent path resolves outside cwd via symlink)`,
+      content: `${EXPORT_DIR_OUT_OF_CWD} (parent path resolves outside cwd via symlink; ${formatExportTargetContext(
+        target,
+      )})`,
     };
   }
 
@@ -172,7 +186,9 @@ async function exportSessionAction(
     return {
       type: 'message',
       messageType: 'error',
-      content: `${EXPORT_DIR_OUT_OF_CWD} (target path is outside cwd)`,
+      content: `${EXPORT_DIR_OUT_OF_CWD} (target path is outside cwd; ${formatExportTargetContext(
+        target,
+      )})`,
     };
   }
 

--- a/packages/cli/src/ui/commands/exportCommand.ts
+++ b/packages/cli/src/ui/commands/exportCommand.ts
@@ -58,6 +58,14 @@ function formatExportTargetContext(target: ExportTargetContext): string {
   return `target: "${target.outputDir}", cwd: "${target.resolvedCwd}"`;
 }
 
+function formatMissingCwdError(resolvedCwd: string): string {
+  return (
+    `Cannot resolve any existing ancestor within cwd: ${resolvedCwd}. ` +
+    'This usually means the project working directory has been deleted ' +
+    'or is on an unmounted filesystem.'
+  );
+}
+
 function resolveExportTarget(
   cwd: string,
   args: string,
@@ -169,11 +177,7 @@ async function realpathNearestExisting(
     }
   }
 
-  throw new Error(
-    `Cannot resolve any existing ancestor within cwd: ${resolvedCwd}. ` +
-      'This usually means the project working directory has been deleted ' +
-      'or is on an unmounted filesystem.',
-  );
+  throw new Error(formatMissingCwdError(resolvedCwd));
 }
 
 async function validateExistingExportParentWithinCwd(
@@ -184,10 +188,20 @@ async function validateExistingExportParentWithinCwd(
     formatExportTargetContext(target),
   );
 
-  const [realCwd, realExistingParent] = await Promise.all([
-    fs.realpath(target.resolvedCwd),
-    realpathNearestExisting(target.outputDir, target.resolvedCwd),
-  ]);
+  let realCwd: string;
+  try {
+    realCwd = await fs.realpath(target.resolvedCwd);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(formatMissingCwdError(target.resolvedCwd));
+    }
+    throw error;
+  }
+
+  const realExistingParent = await realpathNearestExisting(
+    target.outputDir,
+    target.resolvedCwd,
+  );
 
   if (!isSubpath(realCwd, realExistingParent)) {
     debugLogger.debug('Existing export parent escaped cwd:', {

--- a/packages/cli/src/ui/commands/exportCommand.ts
+++ b/packages/cli/src/ui/commands/exportCommand.ts
@@ -34,6 +34,8 @@ type ExportFormat = {
 const EXPORT_DIR_OUT_OF_CWD =
   'Export directory must be within the project working directory.';
 
+type ExportOutputDirKind = 'default' | 'custom';
+
 function resolveExportTarget(cwd: string, args: string, extension: string) {
   const filename = generateExportFilename(extension);
   const outputDirArg = args.trim();
@@ -44,6 +46,8 @@ function resolveExportTarget(cwd: string, args: string, extension: string) {
   const filepath = path.join(outputDir, filename);
   const isDefaultOutputDir = outputDir === resolvedCwd;
   const isInsideCwd = isSubpath(resolvedCwd, outputDir);
+  const outputDirKind: ExportOutputDirKind =
+    outputDirArg && !isDefaultOutputDir ? 'custom' : 'default';
 
   return {
     filepath,
@@ -52,7 +56,7 @@ function resolveExportTarget(cwd: string, args: string, extension: string) {
       ? filename
       : path.join(outputDirArg, filename),
     resolvedCwd,
-    shouldCreateOutputDir: Boolean(outputDirArg && !isDefaultOutputDir),
+    outputDirKind,
     isInsideCwd,
   };
 }
@@ -173,9 +177,10 @@ async function exportSessionAction(
   }
 
   try {
-    const initialValidationError = target.shouldCreateOutputDir
-      ? await validateExistingExportParentWithinCwd(target)
-      : await validateExportTargetWithinCwd(target);
+    const initialValidationError =
+      target.outputDirKind === 'custom'
+        ? await validateExistingExportParentWithinCwd(target)
+        : await validateExportTargetWithinCwd(target);
     if (initialValidationError) {
       return initialValidationError;
     }
@@ -205,7 +210,7 @@ async function exportSessionAction(
 
     const content = exportFormat.format(normalizedData);
 
-    if (target.shouldCreateOutputDir) {
+    if (target.outputDirKind === 'custom') {
       try {
         await fs.mkdir(target.outputDir, { recursive: true, mode: 0o700 });
       } catch (error) {

--- a/packages/cli/src/ui/commands/exportCommand.ts
+++ b/packages/cli/src/ui/commands/exportCommand.ts
@@ -61,10 +61,24 @@ async function validateExportTargetWithinCwd(target: {
   outputDir: string;
   resolvedCwd: string;
 }): Promise<MessageActionReturn | undefined> {
-  const [realCwd, realOutputDir] = await Promise.all([
-    fs.realpath(target.resolvedCwd),
-    fs.realpath(target.outputDir),
-  ]);
+  let realCwd: string;
+  let realOutputDir: string;
+  try {
+    [realCwd, realOutputDir] = await Promise.all([
+      fs.realpath(target.resolvedCwd),
+      fs.realpath(target.outputDir),
+    ]);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content:
+          'Export target directory is not accessible (path does not exist).',
+      };
+    }
+    throw error;
+  }
 
   if (!isSubpath(realCwd, realOutputDir)) {
     return {
@@ -182,7 +196,17 @@ async function exportSessionAction(
     const { conversation } = sessionData;
 
     if (target.shouldCreateOutputDir) {
-      await fs.mkdir(target.outputDir, { recursive: true });
+      try {
+        await fs.mkdir(target.outputDir, { recursive: true, mode: 0o700 });
+      } catch (error) {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: `Failed to create export directory "${target.outputDir}": ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        };
+      }
     }
 
     // Collect and normalize export data (SSOT)
@@ -195,13 +219,15 @@ async function exportSessionAction(
 
     const content = exportFormat.format(normalizedData);
 
-    const writeValidationError = await validateExportTargetWithinCwd(target);
-    if (writeValidationError) {
-      return writeValidationError;
-    }
-
     try {
-      await fs.writeFile(target.filepath, content, 'utf-8');
+      const writeValidationError = await validateExportTargetWithinCwd(target);
+      if (writeValidationError) {
+        return writeValidationError;
+      }
+      await fs.writeFile(target.filepath, content, {
+        encoding: 'utf-8',
+        mode: 0o600,
+      });
     } catch (error) {
       return {
         type: 'message',

--- a/packages/cli/src/ui/commands/exportCommand.ts
+++ b/packages/cli/src/ui/commands/exportCommand.ts
@@ -34,15 +34,19 @@ type ExportFormat = {
 function resolveExportTarget(cwd: string, args: string, extension: string) {
   const filename = generateExportFilename(extension);
   const outputDirArg = args.trim();
-  const outputDir = outputDirArg ? path.resolve(cwd, outputDirArg) : cwd;
+  const resolvedCwd = path.resolve(cwd);
+  const outputDir = outputDirArg
+    ? path.resolve(resolvedCwd, outputDirArg)
+    : resolvedCwd;
   const filepath = path.join(outputDir, filename);
+  const isDefaultOutputDir = outputDir === resolvedCwd;
 
   return {
     filename,
     filepath,
     outputDir,
-    displayPath: outputDirArg ? filepath : filename,
-    shouldCreateOutputDir: Boolean(outputDirArg),
+    displayPath: isDefaultOutputDir ? filename : filepath,
+    shouldCreateOutputDir: Boolean(outputDirArg && !isDefaultOutputDir),
   };
 }
 
@@ -71,6 +75,8 @@ async function exportSessionAction(
     };
   }
 
+  let targetFilepath: string | undefined;
+
   try {
     // Load the current session using the current session ID
     const sessionService = new SessionService(cwd);
@@ -95,8 +101,9 @@ async function exportSessionAction(
       config,
     );
 
-    const content = exportFormat.format(normalizedData);
     const target = resolveExportTarget(cwd, args, exportFormat.extension);
+    targetFilepath = target.filepath;
+    const content = exportFormat.format(normalizedData);
 
     if (target.shouldCreateOutputDir) {
       await fs.mkdir(target.outputDir, { recursive: true });
@@ -109,10 +116,13 @@ async function exportSessionAction(
       content: `Session exported to ${exportFormat.displayName}: ${target.displayPath}`,
     };
   } catch (error) {
+    const destination = targetFilepath
+      ? ` to ${exportFormat.displayName} at "${targetFilepath}"`
+      : '';
     return {
       type: 'message',
       messageType: 'error',
-      content: `Failed to export session: ${error instanceof Error ? error.message : String(error)}`,
+      content: `Failed to export session${destination}: ${error instanceof Error ? error.message : String(error)}`,
     };
   }
 }
@@ -181,7 +191,7 @@ export const exportCommand: SlashCommand = {
   get description() {
     return t('Export current session message history to a file');
   },
-  argumentHint: 'md|html|json|jsonl [path]',
+  argumentHint: '[md|html|json|jsonl] [path]',
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
   action: exportHtmlAction,

--- a/packages/cli/src/ui/commands/exportCommand.ts
+++ b/packages/cli/src/ui/commands/exportCommand.ts
@@ -70,7 +70,7 @@ async function validateExportTargetWithinCwd(target: {
     return {
       type: 'message',
       messageType: 'error',
-      content: `${EXPORT_DIR_OUT_OF_CWD} (path resolves outside cwd via symlink)`,
+      content: `${EXPORT_DIR_OUT_OF_CWD} (target path resolves outside cwd via symlink)`,
     };
   }
 
@@ -98,9 +98,9 @@ async function realpathNearestExisting(
     }
   }
 
-  // Fresh nested export directories may not exist yet. If every ancestor under
-  // cwd is missing, compare against the real cwd until mkdir creates the target.
-  return fs.realpath(resolvedCwd);
+  throw new Error(
+    `Cannot resolve any existing ancestor within cwd: ${resolvedCwd}`,
+  );
 }
 
 async function validateExistingExportParentWithinCwd(target: {
@@ -116,7 +116,7 @@ async function validateExistingExportParentWithinCwd(target: {
     return {
       type: 'message',
       messageType: 'error',
-      content: `${EXPORT_DIR_OUT_OF_CWD} (path resolves outside cwd via symlink)`,
+      content: `${EXPORT_DIR_OUT_OF_CWD} (parent path resolves outside cwd via symlink)`,
     };
   }
 
@@ -159,6 +159,13 @@ async function exportSessionAction(
   }
 
   try {
+    const initialValidationError = target.shouldCreateOutputDir
+      ? await validateExistingExportParentWithinCwd(target)
+      : await validateExportTargetWithinCwd(target);
+    if (initialValidationError) {
+      return initialValidationError;
+    }
+
     // Load the current session using the current session ID
     const sessionService = new SessionService(cwd);
     const sessionId = config.getSessionId();
@@ -175,21 +182,7 @@ async function exportSessionAction(
     const { conversation } = sessionData;
 
     if (target.shouldCreateOutputDir) {
-      const parentValidationError =
-        await validateExistingExportParentWithinCwd(target);
-      if (parentValidationError) {
-        return parentValidationError;
-      }
       await fs.mkdir(target.outputDir, { recursive: true });
-      const validationError = await validateExportTargetWithinCwd(target);
-      if (validationError) {
-        return validationError;
-      }
-    } else {
-      const validationError = await validateExportTargetWithinCwd(target);
-      if (validationError) {
-        return validationError;
-      }
     }
 
     // Collect and normalize export data (SSOT)

--- a/packages/cli/src/ui/commands/exportCommand.ts
+++ b/packages/cli/src/ui/commands/exportCommand.ts
@@ -21,14 +21,35 @@ import {
   toJson,
   toJsonl,
   generateExportFilename,
+  type ExportSessionData,
 } from '../utils/export/index.js';
 import { t } from '../../i18n/index.js';
 
-/**
- * Action for the 'md' subcommand - exports session to markdown.
- */
-async function exportMarkdownAction(
+type ExportFormat = {
+  extension: string;
+  displayName: string;
+  format: (sessionData: ExportSessionData) => string;
+};
+
+function resolveExportTarget(cwd: string, args: string, extension: string) {
+  const filename = generateExportFilename(extension);
+  const outputDirArg = args.trim();
+  const outputDir = outputDirArg ? path.resolve(cwd, outputDirArg) : cwd;
+  const filepath = path.join(outputDir, filename);
+
+  return {
+    filename,
+    filepath,
+    outputDir,
+    displayPath: outputDirArg ? filepath : filename,
+    shouldCreateOutputDir: Boolean(outputDirArg),
+  };
+}
+
+async function exportSessionAction(
   context: CommandContext,
+  args: string,
+  exportFormat: ExportFormat,
 ): Promise<MessageActionReturn> {
   const { services } = context;
   const { config } = services;
@@ -74,19 +95,18 @@ async function exportMarkdownAction(
       config,
     );
 
-    // Generate markdown from SSOT
-    const markdown = toMarkdown(normalizedData);
+    const content = exportFormat.format(normalizedData);
+    const target = resolveExportTarget(cwd, args, exportFormat.extension);
 
-    const filename = generateExportFilename('md');
-    const filepath = path.join(cwd, filename);
-
-    // Write to file
-    await fs.writeFile(filepath, markdown, 'utf-8');
+    if (target.shouldCreateOutputDir) {
+      await fs.mkdir(target.outputDir, { recursive: true });
+    }
+    await fs.writeFile(target.filepath, content, 'utf-8');
 
     return {
       type: 'message',
       messageType: 'info',
-      content: `Session exported to markdown: ${filename}`,
+      content: `Session exported to ${exportFormat.displayName}: ${target.displayPath}`,
     };
   } catch (error) {
     return {
@@ -95,6 +115,20 @@ async function exportMarkdownAction(
       content: `Failed to export session: ${error instanceof Error ? error.message : String(error)}`,
     };
   }
+}
+
+/**
+ * Action for the 'md' subcommand - exports session to markdown.
+ */
+async function exportMarkdownAction(
+  context: CommandContext,
+  args: string,
+): Promise<MessageActionReturn> {
+  return exportSessionAction(context, args, {
+    extension: 'md',
+    displayName: 'markdown',
+    format: toMarkdown,
+  });
 }
 
 /**
@@ -102,72 +136,13 @@ async function exportMarkdownAction(
  */
 async function exportHtmlAction(
   context: CommandContext,
+  args: string,
 ): Promise<MessageActionReturn> {
-  const { services } = context;
-  const { config } = services;
-
-  if (!config) {
-    return {
-      type: 'message',
-      messageType: 'error',
-      content: 'Configuration not available.',
-    };
-  }
-
-  const cwd = config.getWorkingDir() || config.getProjectRoot();
-  if (!cwd) {
-    return {
-      type: 'message',
-      messageType: 'error',
-      content: 'Could not determine current working directory.',
-    };
-  }
-
-  try {
-    // Load the current session using the current session ID
-    const sessionService = new SessionService(cwd);
-    const sessionId = config.getSessionId();
-    const sessionData = await sessionService.loadSession(sessionId);
-
-    if (!sessionData) {
-      return {
-        type: 'message',
-        messageType: 'error',
-        content: 'No active session found to export.',
-      };
-    }
-
-    const { conversation } = sessionData;
-
-    // Collect and normalize export data (SSOT)
-    const exportData = await collectSessionData(conversation, config);
-    const normalizedData = normalizeSessionData(
-      exportData,
-      conversation.messages,
-      config,
-    );
-
-    // Generate HTML from SSOT
-    const html = toHtml(normalizedData);
-
-    const filename = generateExportFilename('html');
-    const filepath = path.join(cwd, filename);
-
-    // Write to file
-    await fs.writeFile(filepath, html, 'utf-8');
-
-    return {
-      type: 'message',
-      messageType: 'info',
-      content: `Session exported to HTML: ${filename}`,
-    };
-  } catch (error) {
-    return {
-      type: 'message',
-      messageType: 'error',
-      content: `Failed to export session: ${error instanceof Error ? error.message : String(error)}`,
-    };
-  }
+  return exportSessionAction(context, args, {
+    extension: 'html',
+    displayName: 'HTML',
+    format: toHtml,
+  });
 }
 
 /**
@@ -175,72 +150,13 @@ async function exportHtmlAction(
  */
 async function exportJsonAction(
   context: CommandContext,
+  args: string,
 ): Promise<MessageActionReturn> {
-  const { services } = context;
-  const { config } = services;
-
-  if (!config) {
-    return {
-      type: 'message',
-      messageType: 'error',
-      content: 'Configuration not available.',
-    };
-  }
-
-  const cwd = config.getWorkingDir() || config.getProjectRoot();
-  if (!cwd) {
-    return {
-      type: 'message',
-      messageType: 'error',
-      content: 'Could not determine current working directory.',
-    };
-  }
-
-  try {
-    // Load the current session using the current session ID
-    const sessionService = new SessionService(cwd);
-    const sessionId = config.getSessionId();
-    const sessionData = await sessionService.loadSession(sessionId);
-
-    if (!sessionData) {
-      return {
-        type: 'message',
-        messageType: 'error',
-        content: 'No active session found to export.',
-      };
-    }
-
-    const { conversation } = sessionData;
-
-    // Collect and normalize export data (SSOT)
-    const exportData = await collectSessionData(conversation, config);
-    const normalizedData = normalizeSessionData(
-      exportData,
-      conversation.messages,
-      config,
-    );
-
-    // Generate JSON from SSOT
-    const json = toJson(normalizedData);
-
-    const filename = generateExportFilename('json');
-    const filepath = path.join(cwd, filename);
-
-    // Write to file
-    await fs.writeFile(filepath, json, 'utf-8');
-
-    return {
-      type: 'message',
-      messageType: 'info',
-      content: `Session exported to JSON: ${filename}`,
-    };
-  } catch (error) {
-    return {
-      type: 'message',
-      messageType: 'error',
-      content: `Failed to export session: ${error instanceof Error ? error.message : String(error)}`,
-    };
-  }
+  return exportSessionAction(context, args, {
+    extension: 'json',
+    displayName: 'JSON',
+    format: toJson,
+  });
 }
 
 /**
@@ -248,72 +164,13 @@ async function exportJsonAction(
  */
 async function exportJsonlAction(
   context: CommandContext,
+  args: string,
 ): Promise<MessageActionReturn> {
-  const { services } = context;
-  const { config } = services;
-
-  if (!config) {
-    return {
-      type: 'message',
-      messageType: 'error',
-      content: 'Configuration not available.',
-    };
-  }
-
-  const cwd = config.getWorkingDir() || config.getProjectRoot();
-  if (!cwd) {
-    return {
-      type: 'message',
-      messageType: 'error',
-      content: 'Could not determine current working directory.',
-    };
-  }
-
-  try {
-    // Load the current session using the current session ID
-    const sessionService = new SessionService(cwd);
-    const sessionId = config.getSessionId();
-    const sessionData = await sessionService.loadSession(sessionId);
-
-    if (!sessionData) {
-      return {
-        type: 'message',
-        messageType: 'error',
-        content: 'No active session found to export.',
-      };
-    }
-
-    const { conversation } = sessionData;
-
-    // Collect and normalize export data (SSOT)
-    const exportData = await collectSessionData(conversation, config);
-    const normalizedData = normalizeSessionData(
-      exportData,
-      conversation.messages,
-      config,
-    );
-
-    // Generate JSONL from SSOT
-    const jsonl = toJsonl(normalizedData);
-
-    const filename = generateExportFilename('jsonl');
-    const filepath = path.join(cwd, filename);
-
-    // Write to file
-    await fs.writeFile(filepath, jsonl, 'utf-8');
-
-    return {
-      type: 'message',
-      messageType: 'info',
-      content: `Session exported to JSONL: ${filename}`,
-    };
-  } catch (error) {
-    return {
-      type: 'message',
-      messageType: 'error',
-      content: `Failed to export session: ${error instanceof Error ? error.message : String(error)}`,
-    };
-  }
+  return exportSessionAction(context, args, {
+    extension: 'jsonl',
+    displayName: 'JSONL',
+    format: toJsonl,
+  });
 }
 
 /**

--- a/packages/cli/src/ui/commands/exportCommand.ts
+++ b/packages/cli/src/ui/commands/exportCommand.ts
@@ -12,7 +12,7 @@ import {
   type MessageActionReturn,
   CommandKind,
 } from './types.js';
-import { SessionService } from '@qwen-code/qwen-code-core';
+import { isSubpath, SessionService } from '@qwen-code/qwen-code-core';
 import {
   collectSessionData,
   normalizeSessionData,
@@ -31,13 +31,8 @@ type ExportFormat = {
   format: (sessionData: ExportSessionData) => string;
 };
 
-function isPathInside(parentPath: string, childPath: string): boolean {
-  const relativePath = path.relative(parentPath, childPath);
-  return (
-    relativePath === '' ||
-    (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
-  );
-}
+const EXPORT_DIR_OUT_OF_CWD =
+  'Export directory must be within the project working directory.';
 
 function resolveExportTarget(cwd: string, args: string, extension: string) {
   const filename = generateExportFilename(extension);
@@ -48,7 +43,7 @@ function resolveExportTarget(cwd: string, args: string, extension: string) {
     : resolvedCwd;
   const filepath = path.join(outputDir, filename);
   const isDefaultOutputDir = outputDir === resolvedCwd;
-  const isInsideCwd = isPathInside(resolvedCwd, outputDir);
+  const isInsideCwd = isSubpath(resolvedCwd, outputDir);
 
   return {
     filepath,
@@ -65,26 +60,17 @@ function resolveExportTarget(cwd: string, args: string, extension: string) {
 async function validateExportTargetWithinCwd(target: {
   outputDir: string;
   resolvedCwd: string;
-  isInsideCwd: boolean;
 }): Promise<MessageActionReturn | undefined> {
-  if (!target.isInsideCwd) {
-    return {
-      type: 'message',
-      messageType: 'error',
-      content: 'Export directory must be within the project working directory.',
-    };
-  }
-
   const [realCwd, realOutputDir] = await Promise.all([
     fs.realpath(target.resolvedCwd),
     fs.realpath(target.outputDir),
   ]);
 
-  if (!isPathInside(realCwd, realOutputDir)) {
+  if (!isSubpath(realCwd, realOutputDir)) {
     return {
       type: 'message',
       messageType: 'error',
-      content: 'Export directory must be within the project working directory.',
+      content: `${EXPORT_DIR_OUT_OF_CWD} (path resolves outside cwd via symlink)`,
     };
   }
 
@@ -97,7 +83,7 @@ async function realpathNearestExisting(
 ): Promise<string> {
   let currentPath = outputDir;
 
-  while (isPathInside(resolvedCwd, currentPath)) {
+  while (isSubpath(resolvedCwd, currentPath)) {
     try {
       return await fs.realpath(currentPath);
     } catch {
@@ -109,6 +95,8 @@ async function realpathNearestExisting(
     }
   }
 
+  // Fresh nested export directories may not exist yet. If every ancestor under
+  // cwd is missing, compare against the real cwd until mkdir creates the target.
   return fs.realpath(resolvedCwd);
 }
 
@@ -121,11 +109,11 @@ async function validateExistingExportParentWithinCwd(target: {
     realpathNearestExisting(target.outputDir, target.resolvedCwd),
   ]);
 
-  if (!isPathInside(realCwd, realExistingParent)) {
+  if (!isSubpath(realCwd, realExistingParent)) {
     return {
       type: 'message',
       messageType: 'error',
-      content: 'Export directory must be within the project working directory.',
+      content: `${EXPORT_DIR_OUT_OF_CWD} (path resolves outside cwd via symlink)`,
     };
   }
 
@@ -163,7 +151,7 @@ async function exportSessionAction(
     return {
       type: 'message',
       messageType: 'error',
-      content: 'Export directory must be within the project working directory.',
+      content: `${EXPORT_DIR_OUT_OF_CWD} (target path is outside cwd)`,
     };
   }
 
@@ -194,6 +182,11 @@ async function exportSessionAction(
       if (validationError) {
         return validationError;
       }
+    } else {
+      const validationError = await validateExportTargetWithinCwd(target);
+      if (validationError) {
+        return validationError;
+      }
     }
 
     // Collect and normalize export data (SSOT)
@@ -206,7 +199,15 @@ async function exportSessionAction(
 
     const content = exportFormat.format(normalizedData);
 
-    await fs.writeFile(target.filepath, content, 'utf-8');
+    try {
+      await fs.writeFile(target.filepath, content, 'utf-8');
+    } catch (error) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `Failed to export session: ${error instanceof Error ? error.message : String(error)} (${exportFormat.displayName} target: "${targetFilepath}")`,
+      };
+    }
 
     return {
       type: 'message',
@@ -217,7 +218,7 @@ async function exportSessionAction(
     return {
       type: 'message',
       messageType: 'error',
-      content: `Failed to export session: ${error instanceof Error ? error.message : String(error)} (${exportFormat.displayName} target: "${targetFilepath}")`,
+      content: `Failed to export session: ${error instanceof Error ? error.message : String(error)}`,
     };
   }
 }

--- a/packages/cli/src/ui/commands/exportCommand.ts
+++ b/packages/cli/src/ui/commands/exportCommand.ts
@@ -195,6 +195,16 @@ async function exportSessionAction(
 
     const { conversation } = sessionData;
 
+    // Collect and normalize export data (SSOT)
+    const exportData = await collectSessionData(conversation, config);
+    const normalizedData = normalizeSessionData(
+      exportData,
+      conversation.messages,
+      config,
+    );
+
+    const content = exportFormat.format(normalizedData);
+
     if (target.shouldCreateOutputDir) {
       try {
         await fs.mkdir(target.outputDir, { recursive: true, mode: 0o700 });
@@ -208,16 +218,6 @@ async function exportSessionAction(
         };
       }
     }
-
-    // Collect and normalize export data (SSOT)
-    const exportData = await collectSessionData(conversation, config);
-    const normalizedData = normalizeSessionData(
-      exportData,
-      conversation.messages,
-      config,
-    );
-
-    const content = exportFormat.format(normalizedData);
 
     try {
       const writeValidationError = await validateExportTargetWithinCwd(target);
@@ -245,7 +245,9 @@ async function exportSessionAction(
     return {
       type: 'message',
       messageType: 'error',
-      content: `Failed to export session: ${error instanceof Error ? error.message : String(error)}`,
+      content: `Failed to export session: ${
+        error instanceof Error ? error.message : String(error)
+      } (${exportFormat.displayName})`,
     };
   }
 }

--- a/packages/cli/src/ui/commands/exportCommand.ts
+++ b/packages/cli/src/ui/commands/exportCommand.ts
@@ -53,7 +53,9 @@ function resolveExportTarget(cwd: string, args: string, extension: string) {
   return {
     filepath,
     outputDir,
-    displayPath: isDefaultOutputDir ? filename : filepath,
+    displayPath: isDefaultOutputDir
+      ? filename
+      : path.join(outputDirArg, filename),
     resolvedCwd,
     shouldCreateOutputDir: Boolean(outputDirArg && !isDefaultOutputDir),
     isInsideCwd,

--- a/packages/cli/src/ui/commands/exportCommand.ts
+++ b/packages/cli/src/ui/commands/exportCommand.ts
@@ -12,7 +12,11 @@ import {
   type MessageActionReturn,
   CommandKind,
 } from './types.js';
-import { isSubpath, SessionService } from '@qwen-code/qwen-code-core';
+import {
+  createDebugLogger,
+  isSubpath,
+  SessionService,
+} from '@qwen-code/qwen-code-core';
 import {
   collectSessionData,
   normalizeSessionData,
@@ -33,6 +37,8 @@ type ExportFormat = {
 
 const EXPORT_DIR_OUT_OF_CWD =
   'Export directory must be within the project working directory.';
+
+const debugLogger = createDebugLogger('EXPORT_COMMAND');
 
 type ExportOutputDirKind = 'default' | 'custom';
 
@@ -74,6 +80,11 @@ async function validateExportTargetWithinCwd(target: {
   outputDir: string;
   resolvedCwd: string;
 }): Promise<MessageActionReturn | undefined> {
+  debugLogger.debug(
+    'Validating export target realpath:',
+    formatExportTargetContext(target),
+  );
+
   let realCwd: string;
   let realOutputDir: string;
   try {
@@ -83,6 +94,10 @@ async function validateExportTargetWithinCwd(target: {
     ]);
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      debugLogger.debug(
+        'Export target realpath validation failed: missing path',
+        formatExportTargetContext(target),
+      );
       return {
         type: 'message',
         messageType: 'error',
@@ -95,6 +110,11 @@ async function validateExportTargetWithinCwd(target: {
   }
 
   if (!isSubpath(realCwd, realOutputDir)) {
+    debugLogger.debug('Export target realpath escaped cwd:', {
+      realCwd,
+      realOutputDir,
+      target,
+    });
     return {
       type: 'message',
       messageType: 'error',
@@ -113,11 +133,22 @@ async function realpathNearestExisting(
 ): Promise<string> {
   let currentPath = outputDir;
 
+  debugLogger.debug('Resolving nearest existing export parent:', {
+    outputDir,
+    resolvedCwd,
+  });
+
   while (isSubpath(resolvedCwd, currentPath)) {
     try {
-      return await fs.realpath(currentPath);
+      const realCurrentPath = await fs.realpath(currentPath);
+      debugLogger.debug('Resolved nearest existing export parent:', {
+        currentPath,
+        realCurrentPath,
+      });
+      return realCurrentPath;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        debugLogger.debug('Failed to resolve existing export parent:', error);
         throw error;
       }
       const parentPath = path.dirname(currentPath);
@@ -137,12 +168,22 @@ async function validateExistingExportParentWithinCwd(target: {
   outputDir: string;
   resolvedCwd: string;
 }): Promise<MessageActionReturn | undefined> {
+  debugLogger.debug(
+    'Validating existing export parent realpath:',
+    formatExportTargetContext(target),
+  );
+
   const [realCwd, realExistingParent] = await Promise.all([
     fs.realpath(target.resolvedCwd),
     realpathNearestExisting(target.outputDir, target.resolvedCwd),
   ]);
 
   if (!isSubpath(realCwd, realExistingParent)) {
+    debugLogger.debug('Existing export parent escaped cwd:', {
+      realCwd,
+      realExistingParent,
+      target,
+    });
     return {
       type: 'message',
       messageType: 'error',
@@ -182,7 +223,20 @@ async function exportSessionAction(
 
   const target = resolveExportTarget(cwd, args, exportFormat.extension);
   const targetFilepath = target.filepath;
+  debugLogger.debug('Resolved export target:', {
+    format: exportFormat.displayName,
+    cwd,
+    outputDirArg: args.trim(),
+    outputDir: target.outputDir,
+    outputDirKind: target.outputDirKind,
+    filepath: target.filepath,
+  });
+
   if (!target.isInsideCwd) {
+    debugLogger.debug(
+      'Export target rejected before realpath validation:',
+      formatExportTargetContext(target),
+    );
     return {
       type: 'message',
       messageType: 'error',
@@ -200,13 +254,23 @@ async function exportSessionAction(
     if (initialValidationError) {
       return initialValidationError;
     }
+    debugLogger.debug('Export target validation passed:', {
+      format: exportFormat.displayName,
+      outputDir: target.outputDir,
+      outputDirKind: target.outputDirKind,
+    });
 
     // Load the current session using the current session ID
     const sessionService = new SessionService(cwd);
     const sessionId = config.getSessionId();
+    debugLogger.debug('Loading session for export:', { sessionId, cwd });
     const sessionData = await sessionService.loadSession(sessionId);
 
     if (!sessionData) {
+      debugLogger.debug('No active session found for export:', {
+        sessionId,
+        cwd,
+      });
       return {
         type: 'message',
         messageType: 'error',
@@ -228,8 +292,12 @@ async function exportSessionAction(
 
     if (target.outputDirKind === 'custom') {
       try {
+        debugLogger.debug('Creating export directory:', {
+          outputDir: target.outputDir,
+        });
         await fs.mkdir(target.outputDir, { recursive: true, mode: 0o700 });
       } catch (error) {
+        debugLogger.debug('Failed to create export directory:', error);
         return {
           type: 'message',
           messageType: 'error',
@@ -245,11 +313,16 @@ async function exportSessionAction(
       if (writeValidationError) {
         return writeValidationError;
       }
+      debugLogger.debug('Writing export file:', {
+        format: exportFormat.displayName,
+        filepath: target.filepath,
+      });
       await fs.writeFile(target.filepath, content, {
         encoding: 'utf-8',
         mode: 0o600,
       });
     } catch (error) {
+      debugLogger.debug('Failed to write export file:', error);
       return {
         type: 'message',
         messageType: 'error',
@@ -257,12 +330,21 @@ async function exportSessionAction(
       };
     }
 
+    debugLogger.debug('Session export completed:', {
+      format: exportFormat.displayName,
+      filepath: target.filepath,
+    });
     return {
       type: 'message',
       messageType: 'info',
       content: `Session exported to ${exportFormat.displayName}: ${target.displayPath}`,
     };
   } catch (error) {
+    debugLogger.debug('Session export failed:', {
+      format: exportFormat.displayName,
+      target,
+      error,
+    });
     return {
       type: 'message',
       messageType: 'error',

--- a/packages/cli/src/ui/commands/exportCommand.ts
+++ b/packages/cli/src/ui/commands/exportCommand.ts
@@ -47,11 +47,22 @@ type ExportTargetContext = {
   resolvedCwd: string;
 };
 
+type ExportTarget = ExportTargetContext & {
+  filepath: string;
+  displayPath: string;
+  outputDirKind: ExportOutputDirKind;
+  isInsideCwd: boolean;
+};
+
 function formatExportTargetContext(target: ExportTargetContext): string {
   return `target: "${target.outputDir}", cwd: "${target.resolvedCwd}"`;
 }
 
-function resolveExportTarget(cwd: string, args: string, extension: string) {
+function resolveExportTarget(
+  cwd: string,
+  args: string,
+  extension: string,
+): ExportTarget {
   const filename = generateExportFilename(extension);
   const outputDirArg = args.trim();
   const resolvedCwd = path.resolve(cwd);
@@ -76,10 +87,9 @@ function resolveExportTarget(cwd: string, args: string, extension: string) {
   };
 }
 
-async function validateExportTargetWithinCwd(target: {
-  outputDir: string;
-  resolvedCwd: string;
-}): Promise<MessageActionReturn | undefined> {
+async function validateExportTargetWithinCwd(
+  target: ExportTargetContext,
+): Promise<MessageActionReturn | undefined> {
   debugLogger.debug(
     'Validating export target realpath:',
     formatExportTargetContext(target),
@@ -160,14 +170,15 @@ async function realpathNearestExisting(
   }
 
   throw new Error(
-    `Cannot resolve any existing ancestor within cwd: ${resolvedCwd}`,
+    `Cannot resolve any existing ancestor within cwd: ${resolvedCwd}. ` +
+      'This usually means the project working directory has been deleted ' +
+      'or is on an unmounted filesystem.',
   );
 }
 
-async function validateExistingExportParentWithinCwd(target: {
-  outputDir: string;
-  resolvedCwd: string;
-}): Promise<MessageActionReturn | undefined> {
+async function validateExistingExportParentWithinCwd(
+  target: ExportTargetContext,
+): Promise<MessageActionReturn | undefined> {
   debugLogger.debug(
     'Validating existing export parent realpath:',
     formatExportTargetContext(target),
@@ -246,6 +257,10 @@ async function exportSessionAction(
     };
   }
 
+  // Three-phase directory validation closes symlink-swap windows:
+  // 1. Initial: validate the target or nearest existing parent before work.
+  // 2. Post-mkdir: verify mkdir did not follow a symlink outside cwd.
+  // 3. Pre-write: verify the target was not swapped before writeFile.
   try {
     const initialValidationError =
       target.outputDirKind === 'custom'
@@ -313,6 +328,16 @@ async function exportSessionAction(
       if (writeValidationError) {
         return writeValidationError;
       }
+    } catch (error) {
+      debugLogger.debug('Export path validation failed before write:', error);
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: `Export path validation failed: ${error instanceof Error ? error.message : String(error)} (${exportFormat.displayName} target: "${targetFilepath}")`,
+      };
+    }
+
+    try {
       debugLogger.debug('Writing export file:', {
         format: exportFormat.displayName,
         filepath: target.filepath,
@@ -320,6 +345,9 @@ async function exportSessionAction(
       await fs.writeFile(target.filepath, content, {
         encoding: 'utf-8',
         mode: 0o600,
+      });
+      await fs.chmod(target.filepath, 0o600).catch((error) => {
+        debugLogger.debug('Failed to tighten export file permissions:', error);
       });
     } catch (error) {
       debugLogger.debug('Failed to write export file:', error);

--- a/packages/cli/src/ui/commands/exportCommand.ts
+++ b/packages/cli/src/ui/commands/exportCommand.ts
@@ -31,6 +31,14 @@ type ExportFormat = {
   format: (sessionData: ExportSessionData) => string;
 };
 
+function isPathInside(parentPath: string, childPath: string): boolean {
+  const relativePath = path.relative(parentPath, childPath);
+  return (
+    relativePath === '' ||
+    (!relativePath.startsWith('..') && !path.isAbsolute(relativePath))
+  );
+}
+
 function resolveExportTarget(cwd: string, args: string, extension: string) {
   const filename = generateExportFilename(extension);
   const outputDirArg = args.trim();
@@ -40,14 +48,86 @@ function resolveExportTarget(cwd: string, args: string, extension: string) {
     : resolvedCwd;
   const filepath = path.join(outputDir, filename);
   const isDefaultOutputDir = outputDir === resolvedCwd;
+  const isInsideCwd = isPathInside(resolvedCwd, outputDir);
 
   return {
-    filename,
     filepath,
     outputDir,
     displayPath: isDefaultOutputDir ? filename : filepath,
+    resolvedCwd,
     shouldCreateOutputDir: Boolean(outputDirArg && !isDefaultOutputDir),
+    isInsideCwd,
   };
+}
+
+async function validateExportTargetWithinCwd(target: {
+  outputDir: string;
+  resolvedCwd: string;
+  isInsideCwd: boolean;
+}): Promise<MessageActionReturn | undefined> {
+  if (!target.isInsideCwd) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: 'Export directory must be within the project working directory.',
+    };
+  }
+
+  const [realCwd, realOutputDir] = await Promise.all([
+    fs.realpath(target.resolvedCwd),
+    fs.realpath(target.outputDir),
+  ]);
+
+  if (!isPathInside(realCwd, realOutputDir)) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: 'Export directory must be within the project working directory.',
+    };
+  }
+
+  return undefined;
+}
+
+async function realpathNearestExisting(
+  outputDir: string,
+  resolvedCwd: string,
+): Promise<string> {
+  let currentPath = outputDir;
+
+  while (isPathInside(resolvedCwd, currentPath)) {
+    try {
+      return await fs.realpath(currentPath);
+    } catch {
+      const parentPath = path.dirname(currentPath);
+      if (parentPath === currentPath) {
+        break;
+      }
+      currentPath = parentPath;
+    }
+  }
+
+  return fs.realpath(resolvedCwd);
+}
+
+async function validateExistingExportParentWithinCwd(target: {
+  outputDir: string;
+  resolvedCwd: string;
+}): Promise<MessageActionReturn | undefined> {
+  const [realCwd, realExistingParent] = await Promise.all([
+    fs.realpath(target.resolvedCwd),
+    realpathNearestExisting(target.outputDir, target.resolvedCwd),
+  ]);
+
+  if (!isPathInside(realCwd, realExistingParent)) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: 'Export directory must be within the project working directory.',
+    };
+  }
+
+  return undefined;
 }
 
 async function exportSessionAction(
@@ -75,7 +155,15 @@ async function exportSessionAction(
     };
   }
 
-  let targetFilepath: string | undefined;
+  const target = resolveExportTarget(cwd, args, exportFormat.extension);
+  const targetFilepath = target.filepath;
+  if (!target.isInsideCwd) {
+    return {
+      type: 'message',
+      messageType: 'error',
+      content: 'Export directory must be within the project working directory.',
+    };
+  }
 
   try {
     // Load the current session using the current session ID
@@ -93,6 +181,19 @@ async function exportSessionAction(
 
     const { conversation } = sessionData;
 
+    if (target.shouldCreateOutputDir) {
+      const parentValidationError =
+        await validateExistingExportParentWithinCwd(target);
+      if (parentValidationError) {
+        return parentValidationError;
+      }
+      await fs.mkdir(target.outputDir, { recursive: true });
+      const validationError = await validateExportTargetWithinCwd(target);
+      if (validationError) {
+        return validationError;
+      }
+    }
+
     // Collect and normalize export data (SSOT)
     const exportData = await collectSessionData(conversation, config);
     const normalizedData = normalizeSessionData(
@@ -101,13 +202,8 @@ async function exportSessionAction(
       config,
     );
 
-    const target = resolveExportTarget(cwd, args, exportFormat.extension);
-    targetFilepath = target.filepath;
     const content = exportFormat.format(normalizedData);
 
-    if (target.shouldCreateOutputDir) {
-      await fs.mkdir(target.outputDir, { recursive: true });
-    }
     await fs.writeFile(target.filepath, content, 'utf-8');
 
     return {
@@ -116,13 +212,10 @@ async function exportSessionAction(
       content: `Session exported to ${exportFormat.displayName}: ${target.displayPath}`,
     };
   } catch (error) {
-    const destination = targetFilepath
-      ? ` to ${exportFormat.displayName} at "${targetFilepath}"`
-      : '';
     return {
       type: 'message',
       messageType: 'error',
-      content: `Failed to export session${destination}: ${error instanceof Error ? error.message : String(error)}`,
+      content: `Failed to export session: ${error instanceof Error ? error.message : String(error)} (${exportFormat.displayName} target: "${targetFilepath}")`,
     };
   }
 }

--- a/packages/cli/src/ui/commands/exportCommand.ts
+++ b/packages/cli/src/ui/commands/exportCommand.ts
@@ -86,7 +86,10 @@ async function realpathNearestExisting(
   while (isSubpath(resolvedCwd, currentPath)) {
     try {
       return await fs.realpath(currentPath);
-    } catch {
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') {
+        throw error;
+      }
       const parentPath = path.dirname(currentPath);
       if (parentPath === currentPath) {
         break;
@@ -198,6 +201,11 @@ async function exportSessionAction(
     );
 
     const content = exportFormat.format(normalizedData);
+
+    const writeValidationError = await validateExportTargetWithinCwd(target);
+    if (writeValidationError) {
+      return writeValidationError;
+    }
 
     try {
       await fs.writeFile(target.filepath, content, 'utf-8');


### PR DESCRIPTION
## Summary

- What changed: `/export` now accepts an optional output directory for the default export and each explicit format. When a directory is provided, the export is written there and the directory is created if needed.
- Why it changed: exported session files currently land in the working directory, which can clutter project roots when users export multiple sessions.
- Reviewer focus: argument handling for the default export path, relative directory resolution, and preserving the no-argument behavior.

## Validation

- Commands run:
  ```bash
  cd packages/cli
  npx vitest run src/ui/commands/exportCommand.test.ts
  cd ../..
  npm run build
  npm run typecheck
  ```
- Prompts / inputs used:
  - `/export md ./logs`
  - `/export ./logs`
- Expected result: exported files are created under the requested directory, and no-argument exports continue to write into the working directory.
- Observed result: the focused export command test passed with 16/16 tests. The full build exited successfully; it reported the existing VS Code companion lint warning about a missing curly brace in unrelated code. Typecheck exited successfully.
- Quickest reviewer verification path: run the focused export command test, then try `/export ./logs` in a session and confirm the created export appears under `logs/`.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.): local command output showed the focused test file passing, `npm run build` exiting 0, and `npm run typecheck` exiting 0.

## Scope / Risk

- Main risk or tradeoff: paths with shell-style quoting are handled as the command parser currently passes them through; this PR keeps that parser behavior unchanged.
- Not covered / not validated: manual interactive TUI export was not run in this environment.
- Breaking changes / migration notes: none; invoking `/export` without a directory keeps the existing destination behavior.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Windows and Linux were not available in this local environment.

## Linked Issues / Bugs

Closes #4192
