### PR TITLE
docs(tui): draft daemon adapter plan

### DIFF
--- a/docs/developers/daemon-client-adapters/tui.md
+++ b/docs/developers/daemon-client-adapters/tui.md
@@ -1,0 +1,91 @@
+# TUI Daemon Adapter Draft
+
+## Goal
+
+Add a flag-gated TUI transport that talks to `qwen serve` through
+`DaemonSessionClient` instead of creating an in-process `Config` + agent
+runtime.
+
+This is a dogfood path for Mode B client migration. It must not replace the
+default TUI path until output sinks, typed daemon events, session-scoped
+permission, and lifecycle diagnostics are stable.
+
+## Proposed Entry Point
+
+```bash
+QWEN_DAEMON_URL=http://127.0.0.1:4170 qwen --experimental-daemon-tui
+```
+
+Optional:
+
+```bash
+QWEN_DAEMON_TOKEN=... QWEN_DAEMON_WORKSPACE=/repo qwen --experimental-daemon-tui
+```
+
+The CLI should refuse this mode unless both are true:
+
+- `QWEN_DAEMON_URL` or `--daemon-url` is set.
+- `GET /capabilities` advertises `session_create`, `session_prompt`, and
+  `session_events`.
+
+## Minimal Flow
+
+1. Create `DaemonClient` with daemon URL and token.
+2. Fetch `/capabilities`.
+3. Create or attach with `DaemonSessionClient.createOrAttach()`.
+4. Subscribe to `session.events()`.
+5. Submit user prompts through `session.prompt()`.
+6. Route cancel through `session.cancel()`.
+7. Route model switch through `session.setModel()`.
+8. Route permission votes through `session.respondToPermission()`.
+
+## Rendering Contract
+
+The first draft should map only these daemon events:
+
+| Daemon event                             | TUI handling                                 |
+| ---------------------------------------- | -------------------------------------------- |
+| `session_update` / `agent_message_chunk` | Append assistant text                        |
+| `session_update` / `agent_thought_chunk` | Append thinking text                         |
+| `session_update` / `tool_call`           | Show tool call lifecycle                     |
+| `permission_request`                     | Show existing confirmation UI where possible |
+| `permission_resolved`                    | Close or update confirmation UI              |
+| `model_switched`                         | Update footer/model display                  |
+| `session_died`                           | Show disconnected state and stop streaming   |
+
+Unknown events must be ignored, not fatal. Typed event reducers will land in a
+later protocol PR.
+
+## Explicit Non-Goals
+
+- Do not remove the current TUI in-process runtime.
+- Do not change JSONL, stream-json, or dual-output behavior in this PR.
+- Do not expose file CRUD, MCP management, memory CRUD, or provider/auth
+  mutation through TUI yet.
+- Do not make browser/web direct-to-daemon assumptions; this is terminal only.
+
+## Merge Safety
+
+- Default off.
+- Additive code path.
+- No existing CLI flags change behavior.
+- If the daemon is unavailable, the experimental path fails before starting the
+  TUI and tells the user to run `qwen serve`.
+
+## Validation Plan
+
+- Unit-test event-to-TUI-state mapping with synthetic daemon events.
+- Unit-test flag/env parsing.
+- Smoke-test against a local `qwen serve`:
+  - prompt text streams into the TUI
+  - cancel resolves the active prompt
+  - permission request can be accepted or rejected
+  - reconnect sends the tracked `Last-Event-ID`
+
+## Blockers Before Default Migration
+
+- Typed daemon event schema.
+- Session-scoped permission route.
+- Output sink refactor for JSONL / stream-json / dual-output parity.
+- Session lifecycle close/delete semantics.
+- Runtime diagnostics for MCP, skills, providers, and workspace env.


### PR DESCRIPTION
## Summary

- What changed: Added a draft TUI daemon adapter plan for a flag-gated `DaemonSessionClient` transport.
- Why it changed: TUI is one of the first Mode B clients we want to dogfood against `qwen serve` HTTP + SSE, but the migration needs explicit default-off boundaries.
- Reviewer focus: Entry-point shape, event mapping scope, and blockers before default migration.

## Validation

- Commands run:
  ```bash
  npx prettier --write docs/developers/daemon-client-adapters/tui.md
  ```
- Prompts / inputs used: N/A; docs-only draft.
- Expected result: Draft PR introduces no runtime behavior.
- Observed result: Pre-commit prettier passed.
- Quickest reviewer verification path: Read `docs/developers/daemon-client-adapters/tui.md`.
- Evidence: Commit contains only one markdown file.

## Scope / Risk

- Main risk or tradeoff: This is intentionally a draft plan, not an implementation PR.
- Not covered / not validated: No TUI code path yet, no live daemon smoke.
- Breaking changes / migration notes: None.

## Engineering principles checklist (Stage 1.5 wave PRs)

- [x] Independently mergeable (main stays releasable after merge)
- [x] Backward compatible (no removed routes / event fields / CLI behavior)
- [x] Default off (feature flag or dual-stack; old path unchanged)
- [x] `qwen serve` Stage 1 routes / SDK behavior preserved
- [x] Gradual migration (P0/P1 base before adapters; behind flag first)
- [x] Reversible (this PR can be individually rolled back)
- [x] Tests-first (unit / smoke / e2e where relevant)

## Linked Issues / Bugs

Related to #4175 Wave 5 adapter track and #4195.
