### PR TITLE
[codex] docs(ide): draft daemon adapter plan

### DIFF
--- a/docs/developers/daemon-client-adapters/ide.md
+++ b/docs/developers/daemon-client-adapters/ide.md
@@ -1,0 +1,116 @@
+# IDE Daemon Adapter Draft
+
+## Goal
+
+Let the VS Code companion extension dogfood Mode B by connecting from the
+extension host to `qwen serve` through `DaemonSessionClient`.
+
+The webview must not call the daemon directly. The extension host owns daemon
+URL, token, session id, and SSE replay state, then forwards sanitized app events
+to the webview.
+
+## Proposed Entry Point
+
+VS Code settings:
+
+```json
+{
+  "qwen-code.experimentalDaemon.enabled": true,
+  "qwen-code.experimentalDaemon.url": "http://127.0.0.1:4170",
+  "qwen-code.experimentalDaemon.token": ""
+}
+```
+
+Environment fallback for local dogfood:
+
+```bash
+QWEN_IDE_DAEMON_URL=http://127.0.0.1:4170 code .
+```
+
+## Minimal Flow
+
+1. Extension host creates `DaemonClient`.
+2. Fetch `/capabilities` and verify workspace compatibility.
+3. Create or attach with `DaemonSessionClient.createOrAttach()`.
+4. Subscribe to `session.events()` in the extension host.
+5. Translate daemon events into existing webview messages.
+6. Send user prompts through `session.prompt()`.
+7. Route cancel/model switch through `session.cancel()` and
+   `session.setModel()`.
+8. Route permission decisions through `session.respondToPermission()`.
+
+## Relationship To Existing ACP Connection
+
+The first draft should introduce a sibling connection path, not replace
+`AcpConnection`:
+
+```text
+QwenAgentManager
+  current default -> AcpConnection -> qwen --acp child
+  experimental    -> DaemonIdeConnection -> qwen serve HTTP/SSE
+```
+
+Both paths should feed the same higher-level webview callbacks where practical.
+If an event cannot be faithfully mapped yet, the daemon path should surface a
+clear unsupported-state warning rather than silently pretending parity.
+
+## Event Mapping Contract
+
+| Daemon event                             | IDE handling                                 |
+| ---------------------------------------- | -------------------------------------------- |
+| `session_update` / `agent_message_chunk` | Existing assistant stream callback           |
+| `session_update` / `agent_thought_chunk` | Existing thinking stream callback            |
+| `session_update` / `tool_call`           | Existing tool-call update callback           |
+| `permission_request`                     | Existing approval UI callback                |
+| `permission_resolved`                    | Close/update approval UI                     |
+| `model_switched`                         | Existing model-state callback where possible |
+| `session_died`                           | Disconnect UI + reconnect affordance         |
+
+Unknown events must be ignored or logged as debug metadata.
+
+## Runtime Locality UX
+
+The extension must make daemon locality visible:
+
+- workspace/files are daemon-host paths
+- MCP servers run on the daemon host
+- skills load from the daemon filesystem
+- provider credentials are resolved in the daemon process environment
+
+Do not imply that local VS Code extensions, local browser profile, local
+localhost services, or local SSH/kube credentials are automatically available to
+the daemon.
+
+## Explicit Non-Goals
+
+- No default migration away from `AcpConnection`.
+- No webview direct-to-daemon transport.
+- No daemon-side file CRUD through the IDE until file service boundaries land.
+- No reverse RPC for editor/browser/clipboard yet.
+- No full remote-control integration.
+
+## Merge Safety
+
+- Default off behind setting/env.
+- Additive sibling connection path.
+- Existing VS Code ACP subprocess path unchanged.
+- Daemon token never crosses into webview JavaScript.
+
+## Validation Plan
+
+- Unit-test settings/env resolution.
+- Unit-test daemon event to webview callback mapping.
+- Smoke-test local extension host against `qwen serve`:
+  - prompt streams into chat
+  - cancel works
+  - permission UI can resolve a request
+  - SSE reconnect uses tracked `Last-Event-ID`
+
+## Blockers Before Default Migration
+
+- Typed daemon event schema.
+- Daemon-stamped client identity.
+- Session-scoped permission route.
+- Read-only runtime diagnostics.
+- FileSystemService boundary and safe file read routes.
+- Output sink refactor for CLI/TUI parity.


### PR DESCRIPTION
## Summary

- What changed: Added a draft VS Code IDE daemon adapter plan for connecting from extension host to `qwen serve` through `DaemonSessionClient`.
- Why it changed: IDE companion is a good first-party dogfood client, but webview/browser code must not talk directly to the daemon or receive daemon tokens.
- Reviewer focus: Extension-host boundary, event mapping to existing webview callbacks, and runtime locality UX.

## Validation

- Commands run:
  ```bash
  npx prettier --write docs/developers/daemon-client-adapters/ide.md
  ```
- Prompts / inputs used: N/A; docs-only draft.
- Expected result: Draft PR introduces no runtime behavior.
- Observed result: Pre-commit prettier passed.
- Quickest reviewer verification path: Read `docs/developers/daemon-client-adapters/ide.md`.
- Evidence: Commit contains only one markdown file.

## Scope / Risk

- Main risk or tradeoff: This is intentionally a draft plan, not an implementation PR.
- Not covered / not validated: No VS Code connection code path yet, no live daemon smoke.
- Breaking changes / migration notes: None.

## Engineering principles checklist (Stage 1.5 wave PRs)

- [x] Independently mergeable (main stays releasable after merge)
- [x] Backward compatible (no removed routes / event fields / CLI behavior)
- [x] Default off (feature flag or dual-stack; old path unchanged)
- [x] `qwen serve` Stage 1 routes / SDK behavior preserved
- [x] Gradual migration (P0/P1 base before adapters; behind flag first)
- [x] Reversible (this PR can be individually rolled back)
- [x] Tests-first (unit / smoke / e2e where relevant)

## Linked Issues / Bugs

Related to #4175 Wave 5 adapter track and #4195.
