### PR TITLE
feat(ide): add daemon connection spike

### DIFF
--- a/docs/developers/daemon-client-adapters/ide.md
+++ b/docs/developers/daemon-client-adapters/ide.md
@@ -1,0 +1,116 @@
+# IDE Daemon Adapter Draft
+
+## Goal
+
+Let the VS Code companion extension dogfood Mode B by connecting from the
+extension host to `qwen serve` through `DaemonSessionClient`.
+
+The webview must not call the daemon directly. The extension host owns daemon
+URL, token, session id, and SSE replay state, then forwards sanitized app events
+to the webview.
+
+## Proposed Entry Point
+
+VS Code settings:
+
+```json
+{
+  "qwen-code.experimentalDaemon.enabled": true,
+  "qwen-code.experimentalDaemon.url": "http://127.0.0.1:4170",
+  "qwen-code.experimentalDaemon.token": ""
+}
+```
+
+Environment fallback for local dogfood:
+
+```bash
+QWEN_IDE_DAEMON_URL=http://127.0.0.1:4170 code .
+```
+
+## Minimal Flow
+
+1. Extension host creates `DaemonClient`.
+2. Fetch `/capabilities` and verify workspace compatibility.
+3. Create or attach with `DaemonSessionClient.createOrAttach()`.
+4. Subscribe to `session.events()` in the extension host.
+5. Translate daemon events into existing webview messages.
+6. Send user prompts through `session.prompt()`.
+7. Route cancel/model switch through `session.cancel()` and
+   `session.setModel()`.
+8. Route permission decisions through `session.respondToPermission()`.
+
+## Relationship To Existing ACP Connection
+
+The first draft should introduce a sibling connection path, not replace
+`AcpConnection`:
+
+```text
+QwenAgentManager
+  current default -> AcpConnection -> qwen --acp child
+  experimental    -> DaemonIdeConnection -> qwen serve HTTP/SSE
+```
+
+Both paths should feed the same higher-level webview callbacks where practical.
+If an event cannot be faithfully mapped yet, the daemon path should surface a
+clear unsupported-state warning rather than silently pretending parity.
+
+## Event Mapping Contract
+
+| Daemon event                             | IDE handling                                 |
+| ---------------------------------------- | -------------------------------------------- |
+| `session_update` / `agent_message_chunk` | Existing assistant stream callback           |
+| `session_update` / `agent_thought_chunk` | Existing thinking stream callback            |
+| `session_update` / `tool_call`           | Existing tool-call update callback           |
+| `permission_request`                     | Existing approval UI callback                |
+| `permission_resolved`                    | Close/update approval UI                     |
+| `model_switched`                         | Existing model-state callback where possible |
+| `session_died`                           | Disconnect UI + reconnect affordance         |
+
+Unknown events must be ignored or logged as debug metadata.
+
+## Runtime Locality UX
+
+The extension must make daemon locality visible:
+
+- workspace/files are daemon-host paths
+- MCP servers run on the daemon host
+- skills load from the daemon filesystem
+- provider credentials are resolved in the daemon process environment
+
+Do not imply that local VS Code extensions, local browser profile, local
+localhost services, or local SSH/kube credentials are automatically available to
+the daemon.
+
+## Explicit Non-Goals
+
+- No default migration away from `AcpConnection`.
+- No webview direct-to-daemon transport.
+- No daemon-side file CRUD through the IDE until file service boundaries land.
+- No reverse RPC for editor/browser/clipboard yet.
+- No full remote-control integration.
+
+## Merge Safety
+
+- Default off behind setting/env.
+- Additive sibling connection path.
+- Existing VS Code ACP subprocess path unchanged.
+- Daemon token never crosses into webview JavaScript.
+
+## Validation Plan
+
+- Unit-test settings/env resolution.
+- Unit-test daemon event to webview callback mapping.
+- Smoke-test local extension host against `qwen serve`:
+  - prompt streams into chat
+  - cancel works
+  - permission UI can resolve a request
+  - SSE reconnect uses tracked `Last-Event-ID`
+
+## Blockers Before Default Migration
+
+- Typed daemon event schema.
+- Daemon-stamped client identity.
+- Session-scoped permission route.
+- Read-only runtime diagnostics.
+- FileSystemService boundary and safe file read routes.
+- Output sink refactor for CLI/TUI parity.

--- a/docs/developers/daemon-client-adapters/ide.md
+++ b/docs/developers/daemon-client-adapters/ide.md
@@ -41,7 +41,7 @@ QWEN_IDE_DAEMON_URL=http://127.0.0.1:4170 code .
 
 ## Relationship To Existing ACP Connection
 
-The first draft should introduce a sibling connection path, not replace
+The first implementation introduces a sibling connection path, not replace
 `AcpConnection`:
 
 ```text
@@ -53,6 +53,10 @@ QwenAgentManager
 Both paths should feed the same higher-level webview callbacks where practical.
 If an event cannot be faithfully mapped yet, the daemon path should surface a
 clear unsupported-state warning rather than silently pretending parity.
+
+This PR adds `DaemonIdeConnection` as the locally verifiable extension-host
+adapter spike. It is not wired into the default `QwenAgentManager` path yet, so
+existing VS Code behavior remains ACP subprocess based.
 
 ## Event Mapping Contract
 
@@ -98,8 +102,10 @@ the daemon.
 
 ## Validation Plan
 
-- Unit-test settings/env resolution.
-- Unit-test daemon event to webview callback mapping.
+- Unit-test daemon session factory connection and SSE event consumption.
+- Unit-test daemon event to existing extension-host callback mapping.
+- Unit-test prompt, cancel, model switch, and permission response forwarding.
+- Unit-test settings/env resolution when the feature flag is wired.
 - Smoke-test local extension host against `qwen serve`:
   - prompt streams into chat
   - cancel works

--- a/package-lock.json
+++ b/package-lock.json
@@ -21458,6 +21458,7 @@
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
         "@modelcontextprotocol/sdk": "^1.25.1",
+        "@qwen-code/sdk": "*",
         "@qwen-code/webui": "*",
         "cors": "^2.8.5",
         "dotenv": "^17.1.0",

--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -310,6 +310,7 @@
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.14.1",
+    "@qwen-code/sdk": "*",
     "@qwen-code/webui": "*",
     "@modelcontextprotocol/sdk": "^1.25.1",
     "cors": "^2.8.5",

--- a/packages/vscode-ide-companion/src/extension.ts
+++ b/packages/vscode-ide-companion/src/extension.ts
@@ -21,6 +21,10 @@ import { registerNewCommands } from './commands/index.js';
 import { ReadonlyFileSystemProvider } from './services/readonlyFileSystemProvider.js';
 import { isWindows } from './utils/platform.js';
 
+// Keep the dormant daemon IDE adapter on the VSIX bundle path without wiring it
+// into the active extension flow yet.
+export { createSdkDaemonSessionFactory as __daemonIdeSessionFactoryForBundle } from './services/daemonIdeConnection.js';
+
 const CLI_IDE_COMPANION_IDENTIFIER = 'qwenlm.qwen-code-vscode-ide-companion';
 const INFO_MESSAGE_SHOWN_KEY = 'qwenCodeInfoMessageShown';
 export const DIFF_SCHEME = 'qwen-diff';

--- a/packages/vscode-ide-companion/src/services/daemonIdeConnection.test.ts
+++ b/packages/vscode-ide-companion/src/services/daemonIdeConnection.test.ts
@@ -287,6 +287,21 @@ describe('DaemonIdeConnection', () => {
       } satisfies RequestPermissionResponse),
     );
 
+    connection.onPermissionRequest = vi
+      .fn()
+      .mockResolvedValue({ optionId: 'stale-option' });
+    events.push({
+      id: 3,
+      v: 1,
+      type: 'permission_request',
+      data: { ...request, requestId: 'request-3' },
+    });
+    await waitFor(() =>
+      expect(session.respondToPermission).toHaveBeenCalledWith('request-3', {
+        outcome: { outcome: 'cancelled' },
+      } satisfies RequestPermissionResponse),
+    );
+
     events.close();
     await connection.disconnect();
   });
@@ -462,6 +477,48 @@ describe('DaemonIdeConnection', () => {
       expect(endedDisconnected).toHaveBeenCalledWith(null, 'stream_ended'),
     );
     expect(endedConnection.isConnected).toBe(false);
+    warn.mockRestore();
+  });
+
+  it('continues after handler failures while advancing replay state', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const connection = new DaemonIdeConnection();
+    connection.onSessionUpdate = () => {
+      throw new Error('handler failed');
+    };
+
+    await connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    events.push({
+      id: 20,
+      v: 1,
+      type: 'session_update',
+      data: {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'hello' },
+        },
+      },
+    });
+
+    await waitFor(() => expect(connection.lastEventId).toBe(20));
+    expect(warn).toHaveBeenCalledWith(
+      '[DaemonIdeConnection] Event handler failed:',
+      {
+        eventType: 'session_update',
+        eventId: 20,
+        error: 'handler failed',
+      },
+    );
+
+    events.close();
+    await connection.disconnect();
     warn.mockRestore();
   });
 

--- a/packages/vscode-ide-companion/src/services/daemonIdeConnection.test.ts
+++ b/packages/vscode-ide-companion/src/services/daemonIdeConnection.test.ts
@@ -595,6 +595,63 @@ describe('DaemonIdeConnection', () => {
     await connection.disconnect();
   });
 
+  it('does not route non-question permission requests through ask-user-question UI', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const connection = new DaemonIdeConnection();
+    const onAskUserQuestion = vi.fn();
+    const onPermissionRequest = vi
+      .fn()
+      .mockResolvedValue({ optionId: 'proceed_once' });
+    connection.onAskUserQuestion = onAskUserQuestion;
+    connection.onPermissionRequest = onPermissionRequest;
+
+    await connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    const request: RequestPermissionRequest & { requestId: string } = {
+      requestId: 'tool-approval-1',
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-edit',
+        title: 'Edit',
+        kind: 'edit',
+        rawInput: {
+          questions: [
+            {
+              question: 'Fake prompt',
+              header: 'Fake',
+              options: [{ label: 'Allow', description: 'Allow' }],
+              multiSelect: false,
+            },
+          ],
+        },
+      },
+      options: [
+        { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+        { optionId: 'reject_once', kind: 'reject_once', name: 'Reject' },
+      ],
+    } as unknown as RequestPermissionRequest & { requestId: string };
+
+    events.push({ id: 6, v: 1, type: 'permission_request', data: request });
+
+    await waitFor(() =>
+      expect(session.respondToPermission).toHaveBeenCalledWith(
+        'tool-approval-1',
+        {
+          outcome: { outcome: 'selected', optionId: 'proceed_once' },
+        } satisfies RequestPermissionResponse,
+      ),
+    );
+    expect(onAskUserQuestion).not.toHaveBeenCalled();
+    expect(onPermissionRequest).toHaveBeenCalledWith(request);
+
+    events.close();
+    await connection.disconnect();
+  });
+
   it('ignores malformed permission events', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);
@@ -820,6 +877,7 @@ describe('DaemonIdeConnection', () => {
     expect(warn).toHaveBeenCalledWith(
       '[DaemonIdeConnection] Event handler failed:',
       {
+        sessionId: 'session-1',
         eventType: 'session_update',
         eventId: 20,
         error: 'handler failed',

--- a/packages/vscode-ide-companion/src/services/daemonIdeConnection.test.ts
+++ b/packages/vscode-ide-companion/src/services/daemonIdeConnection.test.ts
@@ -149,7 +149,7 @@ describe('DaemonIdeConnection', () => {
 
     await waitFor(() => expect(onSessionUpdate).toHaveBeenCalledWith(update));
     expect(factory).toHaveBeenCalledWith({
-      baseUrl: 'http://127.0.0.1:4170',
+      baseUrl: 'http://127.0.0.1:4170/',
       token: undefined,
       workspaceCwd: '/tmp/workspace',
       modelServiceId: undefined,
@@ -241,9 +241,12 @@ describe('DaemonIdeConnection', () => {
 
     await connection.sendPrompt('summarize this');
 
-    expect(session.prompt).toHaveBeenCalledWith({
-      prompt: [{ type: 'text', text: 'summarize this' }],
-    });
+    expect(session.prompt).toHaveBeenCalledWith(
+      {
+        prompt: [{ type: 'text', text: 'summarize this' }],
+      },
+      expect.any(AbortSignal),
+    );
     expect(onEndTurn).toHaveBeenCalledWith('end_turn');
 
     const blocks: ContentBlock[] = [
@@ -255,7 +258,16 @@ describe('DaemonIdeConnection', () => {
       },
     ];
     await connection.sendPrompt(blocks);
-    expect(session.prompt).toHaveBeenLastCalledWith({ prompt: blocks });
+    expect(session.prompt).toHaveBeenLastCalledWith(
+      { prompt: blocks },
+      expect.any(AbortSignal),
+    );
+
+    session.prompt.mockRejectedValueOnce(new Error('prompt failed'));
+    await expect(connection.sendPrompt('will fail')).rejects.toThrow(
+      'prompt failed',
+    );
+    expect(onEndTurn).toHaveBeenLastCalledWith('error');
 
     events.close();
     await connection.disconnect();
@@ -423,7 +435,7 @@ describe('DaemonIdeConnection', () => {
     warn.mockRestore();
   });
 
-  it('uses the permission fallback chain when no option id is preferred', async () => {
+  it('cancels permission requests when no option id is preferred', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);
     const connection = new DaemonIdeConnection();
@@ -454,7 +466,7 @@ describe('DaemonIdeConnection', () => {
       expect(session.respondToPermission).toHaveBeenCalledWith(
         'request-fallback',
         {
-          outcome: { outcome: 'selected', optionId: 'allow-by-kind' },
+          outcome: { outcome: 'cancelled' },
         } satisfies RequestPermissionResponse,
       ),
     );
@@ -504,7 +516,7 @@ describe('DaemonIdeConnection', () => {
     expect(connection.isConnected).toBe(false);
   });
 
-  it('forwards ask-user-question answers and cancels empty selections', async () => {
+  it('forwards ask-user-question answers and cancels invalid selections', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);
     const connection = new DaemonIdeConnection();
@@ -560,6 +572,21 @@ describe('DaemonIdeConnection', () => {
     });
     await waitFor(() =>
       expect(session.respondToPermission).toHaveBeenCalledWith('ask-2', {
+        outcome: { outcome: 'cancelled' },
+      } satisfies RequestPermissionResponse),
+    );
+
+    connection.onAskUserQuestion = vi
+      .fn()
+      .mockResolvedValue({ optionId: 'stale-option' });
+    events.push({
+      id: 5,
+      v: 1,
+      type: 'permission_request',
+      data: { ...request, requestId: 'ask-3' },
+    });
+    await waitFor(() =>
+      expect(session.respondToPermission).toHaveBeenCalledWith('ask-3', {
         outcome: { outcome: 'cancelled' },
       } satisfies RequestPermissionResponse),
     );
@@ -661,8 +688,65 @@ describe('DaemonIdeConnection', () => {
     expect(connection.currentSessionId).toBe('session-current');
     expect(onDisconnected).not.toHaveBeenCalled();
 
+    events.push({
+      id: 15,
+      v: 1,
+      type: 'session_died',
+      data: { reason: 'malformed replay' },
+    });
+
+    await waitFor(() => expect(connection.lastEventId).toBe(15));
+    expect(connection.currentSessionId).toBe('session-current');
+    expect(onDisconnected).not.toHaveBeenCalled();
+
     events.close();
     await connection.disconnect();
+  });
+
+  it('does not advance replay state when permission responses fail', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    session.respondToPermission.mockRejectedValueOnce(
+      new Error('permission response failed'),
+    );
+    const connection = new DaemonIdeConnection();
+    connection.onPermissionRequest = vi
+      .fn()
+      .mockResolvedValue({ optionId: 'proceed_once' });
+
+    await connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    const request: RequestPermissionRequest & { requestId: string } = {
+      requestId: 'request-fails',
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        title: 'Edit file',
+        kind: 'edit',
+        rawInput: {},
+      },
+      options: [
+        { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+      ],
+    } as unknown as RequestPermissionRequest & { requestId: string };
+
+    events.push({ id: 31, v: 1, type: 'permission_request', data: request });
+
+    await waitFor(() =>
+      expect(warn).toHaveBeenCalledWith(
+        '[DaemonIdeConnection] Permission response failed:',
+        'permission response failed',
+      ),
+    );
+    expect(connection.lastEventId).toBeUndefined();
+
+    events.close();
+    await connection.disconnect();
+    warn.mockRestore();
   });
 
   it('surfaces event stream failures and normal stream completion', async () => {
@@ -762,5 +846,14 @@ describe('DaemonIdeConnection', () => {
         sessionFactory: vi.fn(),
       }),
     ).rejects.toThrow('Daemon baseUrl must not contain credentials');
+
+    await expect(
+      connection.connect({
+        baseUrl: 'http://example.com:4170',
+        sessionFactory: vi.fn(),
+      }),
+    ).rejects.toThrow(
+      'Daemon baseUrl must target a loopback address, got "example.com"',
+    );
   });
 });

--- a/packages/vscode-ide-companion/src/services/daemonIdeConnection.test.ts
+++ b/packages/vscode-ide-companion/src/services/daemonIdeConnection.test.ts
@@ -19,7 +19,10 @@ import {
 
 class EventQueue implements AsyncGenerator<DaemonIdeEvent> {
   private events: DaemonIdeEvent[] = [];
-  private waiters: Array<(value: IteratorResult<DaemonIdeEvent>) => void> = [];
+  private waiters: Array<{
+    resolve: (value: IteratorResult<DaemonIdeEvent>) => void;
+    reject: (error: unknown) => void;
+  }> = [];
   private closed = false;
   private failure: unknown;
 
@@ -34,8 +37,8 @@ class EventQueue implements AsyncGenerator<DaemonIdeEvent> {
     if (this.closed) {
       return { done: true, value: undefined };
     }
-    return await new Promise((resolve) => {
-      this.waiters.push(resolve);
+    return await new Promise((resolve, reject) => {
+      this.waiters.push({ resolve, reject });
     });
   }
 
@@ -56,7 +59,7 @@ class EventQueue implements AsyncGenerator<DaemonIdeEvent> {
   push(event: DaemonIdeEvent): void {
     const waiter = this.waiters.shift();
     if (waiter) {
-      waiter({ done: false, value: event });
+      waiter.resolve({ done: false, value: event });
       return;
     }
     this.events.push(event);
@@ -65,12 +68,15 @@ class EventQueue implements AsyncGenerator<DaemonIdeEvent> {
   close(): void {
     this.closed = true;
     for (const waiter of this.waiters.splice(0)) {
-      waiter({ done: true, value: undefined });
+      waiter.resolve({ done: true, value: undefined });
     }
   }
 
   fail(error: unknown): void {
     this.failure = error;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter.reject(error);
+    }
   }
 }
 
@@ -81,9 +87,12 @@ interface FakeSession extends DaemonIdeSessionClient {
   respondToPermission: ReturnType<typeof vi.fn>;
 }
 
-function createFakeSession(events: EventQueue): FakeSession {
+function createFakeSession(
+  events: EventQueue,
+  sessionId = 'session-1',
+): FakeSession {
   return {
-    sessionId: 'session-1',
+    sessionId,
     workspaceCwd: '/tmp/workspace',
     lastEventId: undefined,
     prompt: vi.fn().mockResolvedValue({ stopReason: 'end_turn' }),
@@ -154,6 +163,65 @@ describe('DaemonIdeConnection', () => {
       lastEventId: 10,
       resume: true,
     });
+
+    events.close();
+    await connection.disconnect();
+  });
+
+  it('serializes concurrent connects without orphaning the first session', async () => {
+    const firstEvents = new EventQueue();
+    const secondEvents = new EventQueue();
+    const firstSession = createFakeSession(firstEvents, 'session-1');
+    const secondSession = createFakeSession(secondEvents, 'session-2');
+    const factory = vi
+      .fn()
+      .mockResolvedValueOnce(firstSession)
+      .mockResolvedValueOnce(secondSession);
+    const connection = new DaemonIdeConnection();
+
+    await Promise.all([
+      connection.connect({
+        baseUrl: 'http://127.0.0.1:4170',
+        sessionFactory: factory,
+      }),
+      connection.connect({
+        baseUrl: 'http://127.0.0.1:4170',
+        sessionFactory: factory,
+      }),
+    ]);
+
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(connection.currentSessionId).toBe('session-2');
+    expect(connection.isConnected).toBe(true);
+
+    secondEvents.close();
+    await connection.disconnect();
+  });
+
+  it('proceeds with a second connect after the first one fails', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events, 'session-2');
+    const factory = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('first connect failed'))
+      .mockResolvedValueOnce(session);
+    const connection = new DaemonIdeConnection();
+
+    const firstConnect = connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: factory,
+    });
+    const secondConnect = connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: factory,
+    });
+
+    await expect(firstConnect).rejects.toThrow('first connect failed');
+    await secondConnect;
+
+    expect(factory).toHaveBeenCalledTimes(2);
+    expect(connection.currentSessionId).toBe('session-2');
+    expect(connection.isConnected).toBe(true);
 
     events.close();
     await connection.disconnect();
@@ -306,6 +374,136 @@ describe('DaemonIdeConnection', () => {
     await connection.disconnect();
   });
 
+  it('cancels permission requests when the handler throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const connection = new DaemonIdeConnection();
+    connection.onPermissionRequest = vi
+      .fn()
+      .mockRejectedValue(new Error('permission UI failed'));
+
+    await connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    const request: RequestPermissionRequest & { requestId: string } = {
+      requestId: 'request-throws',
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        title: 'Edit file',
+        kind: 'edit',
+        rawInput: {},
+      },
+      options: [
+        { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+        { optionId: 'reject_once', kind: 'reject_once', name: 'Reject' },
+      ],
+    } as unknown as RequestPermissionRequest & { requestId: string };
+
+    events.push({ id: 4, v: 1, type: 'permission_request', data: request });
+
+    await waitFor(() =>
+      expect(session.respondToPermission).toHaveBeenCalledWith(
+        'request-throws',
+        {
+          outcome: { outcome: 'cancelled' },
+        } satisfies RequestPermissionResponse,
+      ),
+    );
+    expect(warn).toHaveBeenCalledWith(
+      '[DaemonIdeConnection] Permission handler failed:',
+      'permission UI failed',
+    );
+
+    events.close();
+    await connection.disconnect();
+    warn.mockRestore();
+  });
+
+  it('uses the permission fallback chain when no option id is preferred', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const connection = new DaemonIdeConnection();
+    connection.onPermissionRequest = vi.fn().mockResolvedValue({});
+
+    await connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    const request: RequestPermissionRequest & { requestId: string } = {
+      requestId: 'request-fallback',
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        title: 'Edit file',
+        kind: 'edit',
+        rawInput: {},
+      },
+      options: [
+        { optionId: 'allow-by-kind', kind: 'allow_once', name: 'Allow' },
+        { optionId: 'reject_once', kind: 'reject_once', name: 'Reject' },
+      ],
+    } as unknown as RequestPermissionRequest & { requestId: string };
+
+    events.push({ id: 4, v: 1, type: 'permission_request', data: request });
+    await waitFor(() =>
+      expect(session.respondToPermission).toHaveBeenCalledWith(
+        'request-fallback',
+        {
+          outcome: { outcome: 'selected', optionId: 'allow-by-kind' },
+        } satisfies RequestPermissionResponse,
+      ),
+    );
+
+    events.close();
+    await connection.disconnect();
+  });
+
+  it('disconnects without waiting for an in-flight permission callback', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const connection = new DaemonIdeConnection();
+    const onPermissionRequest = vi.fn(
+      () => new Promise<{ optionId: string }>(() => {}),
+    );
+    connection.onPermissionRequest = onPermissionRequest;
+
+    await connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    const request: RequestPermissionRequest & { requestId: string } = {
+      requestId: 'request-hangs',
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        title: 'Edit file',
+        kind: 'edit',
+        rawInput: {},
+      },
+      options: [
+        { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+      ],
+    } as unknown as RequestPermissionRequest & { requestId: string };
+
+    events.push({ id: 5, v: 1, type: 'permission_request', data: request });
+    await waitFor(() => expect(onPermissionRequest).toHaveBeenCalledOnce());
+
+    await expect(
+      Promise.race([
+        connection.disconnect().then(() => 'disconnected'),
+        new Promise((resolve) => setTimeout(() => resolve('timeout'), 50)),
+      ]),
+    ).resolves.toBe('disconnected');
+    expect(session.respondToPermission).not.toHaveBeenCalled();
+    expect(connection.isConnected).toBe(false);
+  });
+
   it('forwards ask-user-question answers and cancels empty selections', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);
@@ -438,6 +636,33 @@ describe('DaemonIdeConnection', () => {
     expect(connection.isConnected).toBe(false);
 
     events.close();
+  });
+
+  it('ignores stale session_died events from another session', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events, 'session-current');
+    const connection = new DaemonIdeConnection();
+    const onDisconnected = vi.fn();
+    connection.onDisconnected = onDisconnected;
+
+    await connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    events.push({
+      id: 14,
+      v: 1,
+      type: 'session_died',
+      data: { sessionId: 'session-stale', reason: 'old replay' },
+    });
+
+    await waitFor(() => expect(connection.lastEventId).toBe(14));
+    expect(connection.currentSessionId).toBe('session-current');
+    expect(onDisconnected).not.toHaveBeenCalled();
+
+    events.close();
+    await connection.disconnect();
   });
 
   it('surfaces event stream failures and normal stream completion', async () => {

--- a/packages/vscode-ide-companion/src/services/daemonIdeConnection.test.ts
+++ b/packages/vscode-ide-companion/src/services/daemonIdeConnection.test.ts
@@ -1,0 +1,268 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  ContentBlock,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+  SessionNotification,
+} from '@agentclientprotocol/sdk';
+import {
+  DaemonIdeConnection,
+  type DaemonIdeEvent,
+  type DaemonIdeSessionClient,
+} from './daemonIdeConnection.js';
+
+class EventQueue implements AsyncGenerator<DaemonIdeEvent> {
+  private events: DaemonIdeEvent[] = [];
+  private waiters: Array<(value: IteratorResult<DaemonIdeEvent>) => void> = [];
+  private closed = false;
+
+  async next(): Promise<IteratorResult<DaemonIdeEvent>> {
+    const event = this.events.shift();
+    if (event) {
+      return { done: false, value: event };
+    }
+    if (this.closed) {
+      return { done: true, value: undefined };
+    }
+    return await new Promise((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  async return(): Promise<IteratorResult<DaemonIdeEvent>> {
+    this.close();
+    return { done: true, value: undefined };
+  }
+
+  async throw(error?: unknown): Promise<IteratorResult<DaemonIdeEvent>> {
+    this.close();
+    throw error;
+  }
+
+  [Symbol.asyncIterator](): AsyncGenerator<DaemonIdeEvent> {
+    return this;
+  }
+
+  push(event: DaemonIdeEvent): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter({ done: false, value: event });
+      return;
+    }
+    this.events.push(event);
+  }
+
+  close(): void {
+    this.closed = true;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter({ done: true, value: undefined });
+    }
+  }
+}
+
+interface FakeSession extends DaemonIdeSessionClient {
+  prompt: ReturnType<typeof vi.fn>;
+  cancel: ReturnType<typeof vi.fn>;
+  setModel: ReturnType<typeof vi.fn>;
+  respondToPermission: ReturnType<typeof vi.fn>;
+}
+
+function createFakeSession(events: EventQueue): FakeSession {
+  return {
+    sessionId: 'session-1',
+    workspaceCwd: '/tmp/workspace',
+    lastEventId: undefined,
+    prompt: vi.fn().mockResolvedValue({ stopReason: 'end_turn' }),
+    events: vi.fn(() => events),
+    cancel: vi.fn().mockResolvedValue(undefined),
+    setModel: vi.fn().mockResolvedValue({}),
+    respondToPermission: vi.fn().mockResolvedValue(true),
+  };
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let lastError: unknown;
+  for (let i = 0; i < 20; i += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+  throw lastError;
+}
+
+describe('DaemonIdeConnection', () => {
+  it('connects through a daemon session factory and forwards session updates', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const factory = vi.fn().mockResolvedValue(session);
+    const connection = new DaemonIdeConnection();
+    const onSessionUpdate = vi.fn();
+    connection.onSessionUpdate = onSessionUpdate;
+
+    await connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      workspaceCwd: '/tmp/workspace',
+      lastEventId: 10,
+      sessionFactory: factory,
+    });
+
+    const update: SessionNotification = {
+      sessionId: 'session-1',
+      update: {
+        sessionUpdate: 'agent_message_chunk',
+        content: { type: 'text', text: 'hello' },
+      },
+    } as SessionNotification;
+    events.push({ id: 11, v: 1, type: 'session_update', data: update });
+
+    await waitFor(() => expect(onSessionUpdate).toHaveBeenCalledWith(update));
+    expect(factory).toHaveBeenCalledWith({
+      baseUrl: 'http://127.0.0.1:4170',
+      token: undefined,
+      workspaceCwd: '/tmp/workspace',
+      modelServiceId: undefined,
+      lastEventId: 10,
+    });
+    expect(connection.currentSessionId).toBe('session-1');
+    expect(connection.lastEventId).toBe(11);
+
+    events.close();
+    connection.disconnect();
+  });
+
+  it('sends prompts through the bound daemon session', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const connection = new DaemonIdeConnection();
+    const onEndTurn = vi.fn();
+    connection.onEndTurn = onEndTurn;
+
+    await connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    await connection.sendPrompt('summarize this');
+
+    expect(session.prompt).toHaveBeenCalledWith({
+      prompt: [{ type: 'text', text: 'summarize this' }],
+    });
+    expect(onEndTurn).toHaveBeenCalledWith('end_turn');
+
+    const blocks: ContentBlock[] = [
+      { type: 'text', text: 'inspect' },
+      {
+        type: 'resource_link',
+        name: 'image.png',
+        uri: 'file:///tmp/image.png',
+      },
+    ];
+    await connection.sendPrompt(blocks);
+    expect(session.prompt).toHaveBeenLastCalledWith({ prompt: blocks });
+
+    events.close();
+    connection.disconnect();
+  });
+
+  it('responds to daemon permission requests with the selected option id', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const connection = new DaemonIdeConnection();
+    const onPermissionRequest = vi.fn().mockResolvedValue('proceed_once');
+    connection.onPermissionRequest = onPermissionRequest;
+
+    await connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    const request: RequestPermissionRequest & { requestId: string } = {
+      requestId: 'request-1',
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        title: 'Edit file',
+        kind: 'edit',
+        rawInput: {},
+      },
+      options: [
+        { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+        { optionId: 'reject_once', kind: 'reject_once', name: 'Reject' },
+      ],
+    } as RequestPermissionRequest & { requestId: string };
+
+    events.push({
+      id: 12,
+      v: 1,
+      type: 'permission_request',
+      data: request,
+    });
+
+    await waitFor(() =>
+      expect(session.respondToPermission).toHaveBeenCalledWith('request-1', {
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+      } satisfies RequestPermissionResponse),
+    );
+    expect(onPermissionRequest).toHaveBeenCalledWith(request);
+
+    events.close();
+    connection.disconnect();
+  });
+
+  it('forwards cancel and model changes to the daemon session', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const connection = new DaemonIdeConnection();
+
+    await connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    await connection.cancelSession();
+    await connection.setModel('qwen3-coder-plus');
+
+    expect(session.cancel).toHaveBeenCalledOnce();
+    expect(session.setModel).toHaveBeenCalledWith('qwen3-coder-plus');
+
+    events.close();
+    connection.disconnect();
+  });
+
+  it('surfaces session_died as a disconnect', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const connection = new DaemonIdeConnection();
+    const onDisconnected = vi.fn();
+    connection.onDisconnected = onDisconnected;
+
+    await connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    events.push({
+      id: 13,
+      v: 1,
+      type: 'session_died',
+      data: { sessionId: 'session-1', reason: 'agent exited' },
+    });
+
+    await waitFor(() =>
+      expect(onDisconnected).toHaveBeenCalledWith(null, 'agent exited'),
+    );
+    expect(connection.isConnected).toBe(false);
+
+    events.close();
+  });
+});

--- a/packages/vscode-ide-companion/src/services/daemonIdeConnection.test.ts
+++ b/packages/vscode-ide-companion/src/services/daemonIdeConnection.test.ts
@@ -21,8 +21,12 @@ class EventQueue implements AsyncGenerator<DaemonIdeEvent> {
   private events: DaemonIdeEvent[] = [];
   private waiters: Array<(value: IteratorResult<DaemonIdeEvent>) => void> = [];
   private closed = false;
+  private failure: unknown;
 
   async next(): Promise<IteratorResult<DaemonIdeEvent>> {
+    if (this.failure) {
+      throw this.failure;
+    }
     const event = this.events.shift();
     if (event) {
       return { done: false, value: event };
@@ -64,6 +68,10 @@ class EventQueue implements AsyncGenerator<DaemonIdeEvent> {
       waiter({ done: true, value: undefined });
     }
   }
+
+  fail(error: unknown): void {
+    this.failure = error;
+  }
 }
 
 interface FakeSession extends DaemonIdeSessionClient {
@@ -79,7 +87,12 @@ function createFakeSession(events: EventQueue): FakeSession {
     workspaceCwd: '/tmp/workspace',
     lastEventId: undefined,
     prompt: vi.fn().mockResolvedValue({ stopReason: 'end_turn' }),
-    events: vi.fn(() => events),
+    events: vi.fn((opts?: { signal?: AbortSignal }) => {
+      opts?.signal?.addEventListener('abort', () => events.close(), {
+        once: true,
+      });
+      return events;
+    }),
     cancel: vi.fn().mockResolvedValue(undefined),
     setModel: vi.fn().mockResolvedValue({}),
     respondToPermission: vi.fn().mockResolvedValue(true),
@@ -136,8 +149,14 @@ describe('DaemonIdeConnection', () => {
     expect(connection.currentSessionId).toBe('session-1');
     expect(connection.lastEventId).toBe(11);
 
+    expect(session.events).toHaveBeenCalledWith({
+      signal: expect.any(AbortSignal),
+      lastEventId: 10,
+      resume: true,
+    });
+
     events.close();
-    connection.disconnect();
+    await connection.disconnect();
   });
 
   it('sends prompts through the bound daemon session', async () => {
@@ -171,14 +190,16 @@ describe('DaemonIdeConnection', () => {
     expect(session.prompt).toHaveBeenLastCalledWith({ prompt: blocks });
 
     events.close();
-    connection.disconnect();
+    await connection.disconnect();
   });
 
   it('responds to daemon permission requests with the selected option id', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);
     const connection = new DaemonIdeConnection();
-    const onPermissionRequest = vi.fn().mockResolvedValue('proceed_once');
+    const onPermissionRequest = vi
+      .fn()
+      .mockResolvedValue({ optionId: 'proceed_once' });
     connection.onPermissionRequest = onPermissionRequest;
 
     await connection.connect({
@@ -199,7 +220,7 @@ describe('DaemonIdeConnection', () => {
         { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
         { optionId: 'reject_once', kind: 'reject_once', name: 'Reject' },
       ],
-    } as RequestPermissionRequest & { requestId: string };
+    } as unknown as RequestPermissionRequest & { requestId: string };
 
     events.push({
       id: 12,
@@ -216,7 +237,145 @@ describe('DaemonIdeConnection', () => {
     expect(onPermissionRequest).toHaveBeenCalledWith(request);
 
     events.close();
-    connection.disconnect();
+    await connection.disconnect();
+  });
+
+  it('cancels permission requests by default and for reject options', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const connection = new DaemonIdeConnection();
+
+    await connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    const request: RequestPermissionRequest & { requestId: string } = {
+      requestId: 'request-1',
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        title: 'Edit file',
+        kind: 'edit',
+        rawInput: {},
+      },
+      options: [
+        { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+        { optionId: 'reject_once', kind: 'reject_once', name: 'Reject' },
+      ],
+    } as unknown as RequestPermissionRequest & { requestId: string };
+
+    events.push({ id: 1, v: 1, type: 'permission_request', data: request });
+    await waitFor(() =>
+      expect(session.respondToPermission).toHaveBeenCalledWith('request-1', {
+        outcome: { outcome: 'cancelled' },
+      } satisfies RequestPermissionResponse),
+    );
+
+    connection.onPermissionRequest = vi
+      .fn()
+      .mockResolvedValue({ optionId: 'reject_once' });
+    events.push({
+      id: 2,
+      v: 1,
+      type: 'permission_request',
+      data: { ...request, requestId: 'request-2' },
+    });
+    await waitFor(() =>
+      expect(session.respondToPermission).toHaveBeenCalledWith('request-2', {
+        outcome: { outcome: 'cancelled' },
+      } satisfies RequestPermissionResponse),
+    );
+
+    events.close();
+    await connection.disconnect();
+  });
+
+  it('forwards ask-user-question answers and cancels empty selections', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const connection = new DaemonIdeConnection();
+    connection.onAskUserQuestion = vi.fn().mockResolvedValue({
+      optionId: 'proceed_once',
+      answers: { q1: 'A' },
+    });
+
+    await connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    const request: RequestPermissionRequest & { requestId: string } = {
+      requestId: 'ask-1',
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-ask',
+        title: 'Ask',
+        kind: 'ask_user_question',
+        rawInput: {
+          questions: [
+            {
+              question: 'Pick one',
+              header: 'Choice',
+              options: [{ label: 'A', description: 'A' }],
+              multiSelect: false,
+            },
+          ],
+          metadata: { source: 'test' },
+        },
+      },
+      options: [
+        { optionId: 'proceed_once', kind: 'allow_once', name: 'Submit' },
+        { optionId: 'cancel', kind: 'reject_once', name: 'Cancel' },
+      ],
+    } as unknown as RequestPermissionRequest & { requestId: string };
+
+    events.push({ id: 3, v: 1, type: 'permission_request', data: request });
+    await waitFor(() =>
+      expect(session.respondToPermission).toHaveBeenCalledWith('ask-1', {
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+        answers: { q1: 'A' },
+      } as RequestPermissionResponse),
+    );
+
+    connection.onAskUserQuestion = vi.fn().mockResolvedValue({ optionId: '' });
+    events.push({
+      id: 4,
+      v: 1,
+      type: 'permission_request',
+      data: { ...request, requestId: 'ask-2' },
+    });
+    await waitFor(() =>
+      expect(session.respondToPermission).toHaveBeenCalledWith('ask-2', {
+        outcome: { outcome: 'cancelled' },
+      } satisfies RequestPermissionResponse),
+    );
+
+    events.close();
+    await connection.disconnect();
+  });
+
+  it('ignores malformed permission events', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const connection = new DaemonIdeConnection();
+
+    await connection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    events.push({
+      id: 5,
+      v: 1,
+      type: 'permission_request',
+      data: { requestId: 'bad' },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(session.respondToPermission).not.toHaveBeenCalled();
+
+    events.close();
+    await connection.disconnect();
   });
 
   it('forwards cancel and model changes to the daemon session', async () => {
@@ -236,7 +395,7 @@ describe('DaemonIdeConnection', () => {
     expect(session.setModel).toHaveBeenCalledWith('qwen3-coder-plus');
 
     events.close();
-    connection.disconnect();
+    await connection.disconnect();
   });
 
   it('surfaces session_died as a disconnect', async () => {
@@ -264,5 +423,62 @@ describe('DaemonIdeConnection', () => {
     expect(connection.isConnected).toBe(false);
 
     events.close();
+  });
+
+  it('surfaces event stream failures and normal stream completion', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const failedEvents = new EventQueue();
+    failedEvents.fail(new Error('network down'));
+    const failedSession = createFakeSession(failedEvents);
+    const failedConnection = new DaemonIdeConnection();
+    const failedDisconnected = vi.fn();
+    failedConnection.onDisconnected = failedDisconnected;
+
+    await failedConnection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(failedSession),
+    });
+    await waitFor(() =>
+      expect(failedDisconnected).toHaveBeenCalledWith(null, 'daemon_error'),
+    );
+    expect(failedConnection.isConnected).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      '[DaemonIdeConnection] Event stream failed:',
+      'network down',
+    );
+
+    const endedEvents = new EventQueue();
+    const endedSession = createFakeSession(endedEvents);
+    const endedConnection = new DaemonIdeConnection();
+    const endedDisconnected = vi.fn();
+    endedConnection.onDisconnected = endedDisconnected;
+
+    await endedConnection.connect({
+      baseUrl: 'http://127.0.0.1:4170',
+      sessionFactory: vi.fn().mockResolvedValue(endedSession),
+    });
+    endedEvents.close();
+    await waitFor(() =>
+      expect(endedDisconnected).toHaveBeenCalledWith(null, 'stream_ended'),
+    );
+    expect(endedConnection.isConnected).toBe(false);
+    warn.mockRestore();
+  });
+
+  it('validates daemon base URLs before connecting', async () => {
+    const connection = new DaemonIdeConnection();
+    await expect(
+      connection.connect({
+        baseUrl: 'file:///tmp/daemon.sock',
+        sessionFactory: vi.fn(),
+      }),
+    ).rejects.toThrow('Daemon baseUrl must use http or https scheme');
+
+    await expect(
+      connection.connect({
+        baseUrl: 'http://user:pass@127.0.0.1:4170',
+        sessionFactory: vi.fn(),
+      }),
+    ).rejects.toThrow('Daemon baseUrl must not contain credentials');
   });
 });

--- a/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
+++ b/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * Daemon-backed IDE connection spike. It mirrors the ACP process connection
+ * shape while replacing the local child process with a qwen serve session.
+ */
+
 import type {
   ContentBlock,
   RequestPermissionRequest,
@@ -81,6 +86,8 @@ type SdkModule = {
   };
 };
 
+// Uses new Function to bypass esbuild static analysis so @qwen-code/sdk is
+// loaded dynamically at runtime rather than bundled into the extension.
 const dynamicImport = new Function('specifier', 'return import(specifier)') as (
   specifier: string,
 ) => Promise<unknown>;
@@ -102,6 +109,38 @@ function isSdkModule(value: unknown): value is SdkModule {
   );
 }
 
+function validateDaemonBaseUrl(baseUrl: string): string {
+  const url = new URL(baseUrl);
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('Daemon baseUrl must use http or https scheme');
+  }
+  if (url.username || url.password) {
+    throw new Error('Daemon baseUrl must not contain credentials');
+  }
+  return baseUrl;
+}
+
+function normalizePrompt(prompt: string | ContentBlock[]): ContentBlock[] {
+  return typeof prompt === 'string'
+    ? ([{ type: 'text', text: prompt }] as ContentBlock[])
+    : prompt;
+}
+
+function toSafeErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isPermissionRequestData(
+  value: unknown,
+): value is RequestPermissionRequest & { requestId: string } {
+  return (
+    isRecord(value) &&
+    typeof value['requestId'] === 'string' &&
+    isRecord(value['toolCall']) &&
+    Array.isArray(value['options'])
+  );
+}
+
 export function createSdkDaemonSessionFactory(): DaemonIdeSessionFactory {
   return async (opts: DaemonIdeSessionFactoryOptions) => {
     const sdk = await dynamicImport('@qwen-code/sdk');
@@ -110,7 +149,7 @@ export function createSdkDaemonSessionFactory(): DaemonIdeSessionFactory {
     }
 
     const daemon = new sdk.DaemonClient({
-      baseUrl: opts.baseUrl,
+      baseUrl: validateDaemonBaseUrl(opts.baseUrl),
       token: opts.token,
     });
     const session = await sdk.DaemonSessionClient.createOrAttach(daemon, {
@@ -131,10 +170,7 @@ export class DaemonIdeConnection {
   onSessionUpdate: (data: SessionNotification) => void = () => {};
   onPermissionRequest: (data: RequestPermissionRequest) => Promise<{
     optionId: string;
-  }> = (data) =>
-    Promise.resolve({
-      optionId: this.resolvePermissionOptionId(data) || '',
-    });
+  }> = () => Promise.resolve({ optionId: 'cancel' });
   onAskUserQuestion: (data: AskUserQuestionRequest) => Promise<{
     optionId: string;
     answers?: Record<string, string>;
@@ -145,18 +181,18 @@ export class DaemonIdeConnection {
 
   async connect(options: DaemonIdeConnectionOptions): Promise<void> {
     if (this.session) {
-      this.disconnect();
+      await this.disconnect();
     }
 
     const factory = options.sessionFactory ?? createSdkDaemonSessionFactory();
     this.session = await factory({
-      baseUrl: options.baseUrl,
+      baseUrl: validateDaemonBaseUrl(options.baseUrl),
       token: options.token,
       workspaceCwd: options.workspaceCwd,
       modelServiceId: options.modelServiceId,
       lastEventId: options.lastEventId,
     });
-    this.lastSeenEventId = this.session.lastEventId ?? options.lastEventId;
+    this.lastSeenEventId = options.lastEventId ?? this.session.lastEventId;
 
     this.eventController = new AbortController();
     this.eventPump = this.pumpEvents(this.session, this.eventController.signal);
@@ -166,10 +202,7 @@ export class DaemonIdeConnection {
     prompt: string | ContentBlock[],
   ): Promise<DaemonIdePromptResult> {
     const session = this.ensureSession();
-    const promptBlocks =
-      typeof prompt === 'string'
-        ? ([{ type: 'text', text: prompt }] as ContentBlock[])
-        : prompt;
+    const promptBlocks = normalizePrompt(prompt);
     const response = await session.prompt({ prompt: promptBlocks });
     this.onEndTurn(response.stopReason);
     return response;
@@ -187,8 +220,15 @@ export class DaemonIdeConnection {
     return await this.ensureSession().setModel(modelId);
   }
 
-  disconnect(): void {
+  async disconnect(): Promise<void> {
     this.eventController?.abort();
+    if (this.eventPump) {
+      try {
+        await this.eventPump;
+      } catch {
+        /* pump errors are converted into callbacks */
+      }
+    }
     this.eventController = null;
     this.eventPump = null;
     this.session = null;
@@ -207,7 +247,7 @@ export class DaemonIdeConnection {
   }
 
   get lastEventId(): number | undefined {
-    return this.session?.lastEventId ?? this.lastSeenEventId;
+    return this.lastSeenEventId ?? this.session?.lastEventId;
   }
 
   private ensureSession(): DaemonIdeSessionClient {
@@ -222,17 +262,41 @@ export class DaemonIdeConnection {
     signal: AbortSignal,
   ): Promise<void> {
     try {
-      for await (const event of session.events({ signal })) {
+      const resumeId = this.lastSeenEventId ?? session.lastEventId;
+      for await (const event of session.events({
+        signal,
+        lastEventId: resumeId,
+        resume: true,
+      })) {
+        try {
+          await this.handleEvent(event);
+        } catch (error) {
+          console.warn('[DaemonIdeConnection] Event handler failed:', {
+            eventType: event.type,
+            eventId: event.id,
+            error: toSafeErrorMessage(error),
+          });
+          continue;
+        }
         if (event.id !== undefined) {
           this.lastSeenEventId = event.id;
         }
-        await this.handleEvent(event);
+      }
+      if (!signal.aborted) {
+        this.clearCurrentSession(session, 'stream_ended');
       }
     } catch (error) {
       if (!signal.aborted) {
-        console.warn('[DaemonIdeConnection] Event stream failed:', error);
-        this.session = null;
-        this.onDisconnected(null, 'daemon_error');
+        console.warn(
+          '[DaemonIdeConnection] Event stream failed:',
+          toSafeErrorMessage(error),
+        );
+        this.eventController?.abort();
+        this.clearCurrentSession(session, 'daemon_error');
+      }
+    } finally {
+      if (this.session === session) {
+        this.eventPump = null;
       }
     }
   }
@@ -254,14 +318,23 @@ export class DaemonIdeConnection {
   }
 
   private async handlePermissionRequest(data: unknown): Promise<void> {
-    if (!isRecord(data) || typeof data['requestId'] !== 'string') {
+    if (!isPermissionRequestData(data)) {
       return;
     }
 
     const requestId = data['requestId'];
-    const request = data as unknown as RequestPermissionRequest;
+    const request = data;
     const response = await this.resolvePermissionResponse(request);
-    await this.ensureSession().respondToPermission(requestId, response);
+    const accepted = await this.ensureSession().respondToPermission(
+      requestId,
+      response,
+    );
+    if (!accepted) {
+      console.warn(
+        '[DaemonIdeConnection] Permission response rejected by daemon for request:',
+        requestId,
+      );
+    }
   }
 
   private async resolvePermissionResponse(
@@ -277,14 +350,22 @@ export class DaemonIdeConnection {
         questions: rawInput['questions'] as AskUserQuestionRequest['questions'],
         metadata: rawInput['metadata'] as AskUserQuestionRequest['metadata'],
       });
-      if (this.isCancelledOption(askResponse.optionId)) {
+      if (
+        !askResponse.optionId ||
+        this.isCancelledOption(askResponse.optionId)
+      ) {
         return { outcome: { outcome: 'cancelled' } };
       }
+      const optionId =
+        this.resolvePermissionOptionId(request, askResponse.optionId) ??
+        askResponse.optionId;
       return {
         outcome: {
           outcome: 'selected',
-          optionId: askResponse.optionId || 'proceed_once',
+          optionId,
         },
+        // Daemon's HTTP permission route preserves top-level passthrough
+        // fields and the ACP session consumes `answers` from this position.
         answers: askResponse.answers,
       } as RequestPermissionResponse;
     }
@@ -313,15 +394,19 @@ export class DaemonIdeConnection {
         ? data['reason']
         : 'session_died';
     this.eventController?.abort();
-    this.eventController = null;
-    this.eventPump = null;
-    this.session = null;
-    this.onDisconnected(null, reason);
+    if (this.session) {
+      this.clearCurrentSession(this.session, reason);
+    } else {
+      this.onDisconnected(null, reason);
+    }
   }
 
   private isCancelledOption(optionId?: string): boolean {
-    return Boolean(
-      optionId && (optionId.includes('reject') || optionId === 'cancel'),
+    return (
+      !optionId ||
+      optionId === 'cancel' ||
+      optionId === 'reject' ||
+      optionId.startsWith('reject_')
     );
   }
 
@@ -344,9 +429,24 @@ export class DaemonIdeConnection {
     return (
       options.find((option) => option.kind === 'allow_once')?.optionId ||
       options.find((option) => option.optionId === 'proceed_once')?.optionId ||
+      // Some ACP producers namespace standard option ids. Prefer an
+      // explicit allow_once kind first, then tolerate namespaced proceed_once.
       options.find((option) => option.optionId.includes('proceed_once'))
         ?.optionId ||
       options[0]?.optionId
     );
+  }
+
+  private clearCurrentSession(
+    session: DaemonIdeSessionClient,
+    reason: string,
+  ): void {
+    if (this.session !== session) {
+      return;
+    }
+    this.eventController = null;
+    this.eventPump = null;
+    this.session = null;
+    this.onDisconnected(null, reason);
   }
 }

--- a/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
+++ b/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
@@ -599,25 +599,13 @@ export class DaemonIdeConnection {
     preferredOptionId?: string,
   ): string | undefined {
     const options = Array.isArray(request.options) ? request.options : [];
-    if (options.length === 0) {
+    if (!preferredOptionId || options.length === 0) {
       return undefined;
     }
 
-    if (preferredOptionId) {
-      return options.some((option) => option.optionId === preferredOptionId)
-        ? preferredOptionId
-        : undefined;
-    }
-
-    return (
-      options.find((option) => option.kind === 'allow_once')?.optionId ||
-      options.find((option) => option.optionId === 'proceed_once')?.optionId ||
-      // Some ACP producers namespace standard option ids. Prefer an
-      // explicit allow_once kind first, then tolerate namespaced proceed_once.
-      options.find((option) => option.optionId?.includes('proceed_once'))
-        ?.optionId ||
-      options[0]?.optionId
-    );
+    return options.some((option) => option.optionId === preferredOptionId)
+      ? preferredOptionId
+      : undefined;
   }
 
   private clearCurrentSession(

--- a/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
+++ b/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
@@ -15,6 +15,8 @@ import type {
   RequestPermissionResponse,
   SessionNotification,
 } from '@agentclientprotocol/sdk';
+// This SDK is intentionally statically imported so the VSIX bundling path can
+// include it; keep it pure JS with no native runtime dependency assumptions.
 import {
   DaemonClient,
   DaemonSessionClient as SdkDaemonSessionClient,
@@ -82,9 +84,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isLoopbackHostname(hostname: string): boolean {
+  // Keep this client-side policy aligned with
+  // packages/cli/src/serve/loopbackBinds.ts when daemon bind rules change.
   const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, '');
   if (normalized === 'localhost' || normalized === '::1') {
     return true;
+  }
+  if (normalized.startsWith('::ffff:')) {
+    return isLoopbackHostname(normalized.slice('::ffff:'.length));
   }
   const parts = normalized.split('.');
   return (
@@ -155,6 +162,8 @@ export class DaemonIdeConnection {
   private session: DaemonIdeSessionClient | null = null;
   private eventController: AbortController | null = null;
   private eventPump: Promise<void> | null = null;
+  // Authoritative replay cursor for IDE processing. It may intentionally lag
+  // behind the SDK cursor when permission responses fail, preserving replay.
   private lastSeenEventId: number | undefined;
   private connectPromise: Promise<void> | null = null;
   private pumpGeneration = 0;
@@ -175,9 +184,12 @@ export class DaemonIdeConnection {
     while (this.connectPromise) {
       try {
         await this.connectPromise;
-      } catch {
+      } catch (previousError) {
         // Let this connect attempt proceed with its own options after the
         // in-flight attempt reports its failure to its caller.
+        console.debug('[DaemonIdeConnection] Previous connect failed:', {
+          error: toSafeErrorMessage(previousError),
+        });
       }
     }
 
@@ -223,15 +235,28 @@ export class DaemonIdeConnection {
   ): Promise<DaemonIdePromptResult> {
     const session = this.ensureSession();
     const promptBlocks = normalizePrompt(prompt);
+    console.debug('[DaemonIdeConnection] Sending prompt:', {
+      sessionId: session.sessionId,
+    });
     try {
       const response = await session.prompt(
         { prompt: promptBlocks },
         this.eventController?.signal,
       );
+      console.debug('[DaemonIdeConnection] Prompt completed:', {
+        sessionId: session.sessionId,
+        stopReason: response.stopReason,
+      });
       this.onEndTurn(response.stopReason);
       return response;
     } catch (error) {
-      this.onEndTurn('error');
+      console.warn('[DaemonIdeConnection] Prompt failed:', {
+        sessionId: session.sessionId,
+        error: toSafeErrorMessage(error),
+      });
+      if (!isAbortError(error)) {
+        this.onEndTurn('error');
+      }
       throw error;
     }
   }
@@ -239,6 +264,9 @@ export class DaemonIdeConnection {
   async cancelSession(): Promise<void> {
     const session = this.session;
     if (!session) {
+      console.debug(
+        '[DaemonIdeConnection] cancelSession ignored without active session',
+      );
       return;
     }
     await session.cancel();
@@ -306,6 +334,7 @@ export class DaemonIdeConnection {
           shouldAdvanceLastSeenEventId = await this.handleEvent(event, signal);
         } catch (error) {
           console.warn('[DaemonIdeConnection] Event handler failed:', {
+            sessionId: session.sessionId,
             eventType: event.type,
             eventId: event.id,
             error: toSafeErrorMessage(error),
@@ -325,6 +354,9 @@ export class DaemonIdeConnection {
           '[DaemonIdeConnection] Event stream failed:',
           toSafeErrorMessage(error),
         );
+        console.debug('[DaemonIdeConnection] Event stream session:', {
+          sessionId: session.sessionId,
+        });
         this.eventController?.abort();
         this.clearCurrentSession(session, 'daemon_error');
       }
@@ -352,6 +384,7 @@ export class DaemonIdeConnection {
         return true;
       default:
         console.debug('[DaemonIdeConnection] Ignoring daemon event:', {
+          sessionId: this.session?.sessionId,
           eventType: event.type,
           eventId: event.id,
         });
@@ -372,6 +405,10 @@ export class DaemonIdeConnection {
     const request = data;
     const session = this.session;
     if (!session) {
+      console.warn(
+        '[DaemonIdeConnection] Dropping permission request: not connected',
+        { requestId },
+      );
       return true;
     }
     const response = await this.resolvePermissionResponseUntilAbort(
@@ -382,6 +419,14 @@ export class DaemonIdeConnection {
       return true;
     }
     if (this.session !== session) {
+      console.warn(
+        '[DaemonIdeConnection] Permission response dropped: session changed',
+        {
+          requestId,
+          originalSessionId: session.sessionId,
+          currentSessionId: this.session?.sessionId,
+        },
+      );
       return true;
     }
     try {
@@ -391,6 +436,9 @@ export class DaemonIdeConnection {
           '[DaemonIdeConnection] Permission response rejected by daemon for request:',
           requestId,
         );
+        console.debug('[DaemonIdeConnection] Permission response session:', {
+          sessionId: session.sessionId,
+        });
       }
       return true;
     } catch (error) {
@@ -438,8 +486,11 @@ export class DaemonIdeConnection {
     request: RequestPermissionRequest,
   ): Promise<RequestPermissionResponse> {
     const rawInput = request.toolCall?.rawInput;
+    const toolCallKind = request.toolCall?.kind as string | undefined;
     const isAskUserQuestion =
-      isRecord(rawInput) && Array.isArray(rawInput['questions']);
+      toolCallKind === 'ask_user_question' &&
+      isRecord(rawInput) &&
+      Array.isArray(rawInput['questions']);
 
     if (isAskUserQuestion) {
       const askResponse = await this.onAskUserQuestion({
@@ -458,6 +509,13 @@ export class DaemonIdeConnection {
         askResponse.optionId,
       );
       if (!optionId) {
+        console.warn(
+          '[DaemonIdeConnection] AskUserQuestion option not advertised; cancelling',
+          {
+            requestId: (request as { requestId?: string }).requestId,
+            optionId: askResponse.optionId,
+          },
+        );
         return { outcome: { outcome: 'cancelled' } };
       }
       return {
@@ -478,6 +536,13 @@ export class DaemonIdeConnection {
 
     const optionId = this.resolvePermissionOptionId(request, response.optionId);
     if (!optionId) {
+      console.warn(
+        '[DaemonIdeConnection] Permission option not advertised; cancelling',
+        {
+          requestId: (request as { requestId?: string }).requestId,
+          optionId: response.optionId,
+        },
+      );
       return { outcome: { outcome: 'cancelled' } };
     }
 
@@ -495,6 +560,10 @@ export class DaemonIdeConnection {
         ? data['sessionId']
         : undefined;
     if (!this.session) {
+      console.debug(
+        '[DaemonIdeConnection] session_died received with no active session',
+        { eventSessionId },
+      );
       return;
     }
     if (eventSessionId === undefined) {
@@ -509,6 +578,10 @@ export class DaemonIdeConnection {
       isRecord(data) && typeof data['reason'] === 'string'
         ? data['reason']
         : 'session_died';
+    console.debug('[DaemonIdeConnection] Session died:', {
+      sessionId: this.session.sessionId,
+      reason,
+    });
     this.eventController?.abort();
     this.clearCurrentSession(this.session, reason);
   }
@@ -554,9 +627,17 @@ export class DaemonIdeConnection {
     if (this.session !== session) {
       return;
     }
+    console.debug('[DaemonIdeConnection] Clearing session:', {
+      sessionId: session.sessionId,
+      reason,
+    });
     this.eventController = null;
     this.eventPump = null;
     this.session = null;
     this.onDisconnected(null, reason);
   }
+}
+
+function isAbortError(error: unknown): boolean {
+  return isRecord(error) && error['name'] === 'AbortError';
 }

--- a/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
+++ b/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
@@ -15,6 +15,10 @@ import type {
   RequestPermissionResponse,
   SessionNotification,
 } from '@agentclientprotocol/sdk';
+import {
+  DaemonClient,
+  DaemonSessionClient as SdkDaemonSessionClient,
+} from '@qwen-code/sdk';
 import type { AskUserQuestionRequest } from '../types/acpTypes.js';
 
 export interface DaemonIdeEvent {
@@ -73,39 +77,23 @@ export interface DaemonIdeConnectionOptions
   sessionFactory?: DaemonIdeSessionFactory;
 }
 
-type SdkModule = {
-  DaemonClient: new (opts: { baseUrl: string; token?: string }) => unknown;
-  DaemonSessionClient: {
-    createOrAttach(
-      client: unknown,
-      req?: {
-        workspaceCwd?: string;
-        modelServiceId?: string;
-      },
-    ): Promise<DaemonIdeSessionClient>;
-  };
-};
-
-// Uses new Function to bypass esbuild static analysis so @qwen-code/sdk is
-// loaded dynamically at runtime rather than bundled into the extension.
-const dynamicImport = new Function('specifier', 'return import(specifier)') as (
-  specifier: string,
-) => Promise<unknown>;
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
 
-function isSdkModule(value: unknown): value is SdkModule {
-  if (!isRecord(value)) {
-    return false;
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase().replace(/^\[|\]$/g, '');
+  if (normalized === 'localhost' || normalized === '::1') {
+    return true;
   }
-
-  const sessionClient = value['DaemonSessionClient'];
+  const parts = normalized.split('.');
   return (
-    typeof value['DaemonClient'] === 'function' &&
-    isRecord(sessionClient) &&
-    typeof sessionClient['createOrAttach'] === 'function'
+    parts.length === 4 &&
+    parts[0] === '127' &&
+    parts.every((part) => {
+      const value = Number(part);
+      return /^\d+$/.test(part) && value >= 0 && value <= 255;
+    })
   );
 }
 
@@ -117,7 +105,12 @@ function validateDaemonBaseUrl(baseUrl: string): string {
   if (url.username || url.password) {
     throw new Error('Daemon baseUrl must not contain credentials');
   }
-  return baseUrl;
+  if (!isLoopbackHostname(url.hostname)) {
+    throw new Error(
+      `Daemon baseUrl must target a loopback address, got "${url.hostname}"`,
+    );
+  }
+  return url.href;
 }
 
 function normalizePrompt(prompt: string | ContentBlock[]): ContentBlock[] {
@@ -143,20 +136,17 @@ function isPermissionRequestData(
 
 export function createSdkDaemonSessionFactory(): DaemonIdeSessionFactory {
   return async (opts: DaemonIdeSessionFactoryOptions) => {
-    const sdk = await dynamicImport('@qwen-code/sdk');
-    if (!isSdkModule(sdk)) {
-      throw new Error('Loaded @qwen-code/sdk does not expose daemon clients');
-    }
-
-    const daemon = new sdk.DaemonClient({
+    const daemon = new DaemonClient({
       baseUrl: validateDaemonBaseUrl(opts.baseUrl),
       token: opts.token,
     });
-    const session = await sdk.DaemonSessionClient.createOrAttach(daemon, {
+    const session = await SdkDaemonSessionClient.createOrAttach(daemon, {
       workspaceCwd: opts.workspaceCwd,
       modelServiceId: opts.modelServiceId,
     });
-    session.setLastEventId?.(opts.lastEventId);
+    if (opts.lastEventId !== undefined) {
+      session.setLastEventId?.(opts.lastEventId);
+    }
     return session;
   };
 }
@@ -233,9 +223,17 @@ export class DaemonIdeConnection {
   ): Promise<DaemonIdePromptResult> {
     const session = this.ensureSession();
     const promptBlocks = normalizePrompt(prompt);
-    const response = await session.prompt({ prompt: promptBlocks });
-    this.onEndTurn(response.stopReason);
-    return response;
+    try {
+      const response = await session.prompt(
+        { prompt: promptBlocks },
+        this.eventController?.signal,
+      );
+      this.onEndTurn(response.stopReason);
+      return response;
+    } catch (error) {
+      this.onEndTurn('error');
+      throw error;
+    }
   }
 
   async cancelSession(): Promise<void> {
@@ -251,6 +249,7 @@ export class DaemonIdeConnection {
   }
 
   async disconnect(): Promise<void> {
+    const session = this.session;
     this.eventController?.abort();
     if (this.eventPump) {
       try {
@@ -261,7 +260,10 @@ export class DaemonIdeConnection {
     }
     this.eventController = null;
     this.eventPump = null;
-    this.session = null;
+    if (session && this.session === session) {
+      this.session = null;
+      this.onDisconnected(null, 'disconnected');
+    }
   }
 
   get isConnected(): boolean {
@@ -299,8 +301,9 @@ export class DaemonIdeConnection {
         lastEventId: resumeId,
         resume: true,
       })) {
+        let shouldAdvanceLastSeenEventId = true;
         try {
-          await this.handleEvent(event, signal);
+          shouldAdvanceLastSeenEventId = await this.handleEvent(event, signal);
         } catch (error) {
           console.warn('[DaemonIdeConnection] Event handler failed:', {
             eventType: event.type,
@@ -308,7 +311,7 @@ export class DaemonIdeConnection {
             error: toSafeErrorMessage(error),
           });
         } finally {
-          if (event.id !== undefined) {
+          if (shouldAdvanceLastSeenEventId && event.id !== undefined) {
             this.lastSeenEventId = event.id;
           }
         }
@@ -337,48 +340,65 @@ export class DaemonIdeConnection {
   private async handleEvent(
     event: DaemonIdeEvent,
     signal: AbortSignal,
-  ): Promise<void> {
+  ): Promise<boolean> {
     switch (event.type) {
       case 'session_update':
         this.onSessionUpdate(event.data as SessionNotification);
-        break;
+        return true;
       case 'permission_request':
-        await this.handlePermissionRequest(event.data, signal);
-        break;
+        return await this.handlePermissionRequest(event.data, signal);
       case 'session_died':
         this.handleSessionDied(event.data);
-        break;
+        return true;
       default:
-        break;
+        console.debug('[DaemonIdeConnection] Ignoring daemon event:', {
+          eventType: event.type,
+          eventId: event.id,
+        });
+        return true;
     }
   }
 
   private async handlePermissionRequest(
     data: unknown,
     signal: AbortSignal,
-  ): Promise<void> {
+  ): Promise<boolean> {
     if (!isPermissionRequestData(data)) {
-      return;
+      console.warn('[DaemonIdeConnection] Malformed permission request data');
+      return true;
     }
 
     const requestId = data['requestId'];
     const request = data;
+    const session = this.session;
+    if (!session) {
+      return true;
+    }
     const response = await this.resolvePermissionResponseUntilAbort(
       request,
       signal,
     );
     if (!response) {
-      return;
+      return true;
     }
-    const accepted = await this.ensureSession().respondToPermission(
-      requestId,
-      response,
-    );
-    if (!accepted) {
+    if (this.session !== session) {
+      return true;
+    }
+    try {
+      const accepted = await session.respondToPermission(requestId, response);
+      if (!accepted) {
+        console.warn(
+          '[DaemonIdeConnection] Permission response rejected by daemon for request:',
+          requestId,
+        );
+      }
+      return true;
+    } catch (error) {
       console.warn(
-        '[DaemonIdeConnection] Permission response rejected by daemon for request:',
-        requestId,
+        '[DaemonIdeConnection] Permission response failed:',
+        toSafeErrorMessage(error),
       );
+      return false;
     }
   }
 
@@ -433,9 +453,13 @@ export class DaemonIdeConnection {
       ) {
         return { outcome: { outcome: 'cancelled' } };
       }
-      const optionId =
-        this.resolvePermissionOptionId(request, askResponse.optionId) ??
-        askResponse.optionId;
+      const optionId = this.resolvePermissionOptionId(
+        request,
+        askResponse.optionId,
+      );
+      if (!optionId) {
+        return { outcome: { outcome: 'cancelled' } };
+      }
       return {
         outcome: {
           outcome: 'selected',
@@ -448,7 +472,7 @@ export class DaemonIdeConnection {
     }
 
     const response = await this.onPermissionRequest(request);
-    if (response.optionId === '' || this.isCancelledOption(response.optionId)) {
+    if (!response.optionId || this.isCancelledOption(response.optionId)) {
       return { outcome: { outcome: 'cancelled' } };
     }
 
@@ -470,11 +494,14 @@ export class DaemonIdeConnection {
       isRecord(data) && typeof data['sessionId'] === 'string'
         ? data['sessionId']
         : undefined;
-    if (
-      eventSessionId !== undefined &&
-      this.session &&
-      eventSessionId !== this.session.sessionId
-    ) {
+    if (!this.session) {
+      return;
+    }
+    if (eventSessionId === undefined) {
+      console.warn('[DaemonIdeConnection] Malformed session_died event');
+      return;
+    }
+    if (eventSessionId !== this.session.sessionId) {
       return;
     }
 
@@ -483,11 +510,7 @@ export class DaemonIdeConnection {
         ? data['reason']
         : 'session_died';
     this.eventController?.abort();
-    if (this.session) {
-      this.clearCurrentSession(this.session, reason);
-    } else {
-      this.onDisconnected(null, reason);
-    }
+    this.clearCurrentSession(this.session, reason);
   }
 
   private isCancelledOption(optionId?: string): boolean {
@@ -518,7 +541,7 @@ export class DaemonIdeConnection {
       options.find((option) => option.optionId === 'proceed_once')?.optionId ||
       // Some ACP producers namespace standard option ids. Prefer an
       // explicit allow_once kind first, then tolerate namespaced proceed_once.
-      options.find((option) => option.optionId.includes('proceed_once'))
+      options.find((option) => option.optionId?.includes('proceed_once'))
         ?.optionId ||
       options[0]?.optionId
     );

--- a/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
+++ b/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
@@ -1,0 +1,352 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  ContentBlock,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+  SessionNotification,
+} from '@agentclientprotocol/sdk';
+import type { AskUserQuestionRequest } from '../types/acpTypes.js';
+
+export interface DaemonIdeEvent {
+  id?: number;
+  v: 1;
+  type: string;
+  data: unknown;
+  originatorClientId?: string;
+}
+
+export interface DaemonIdePromptResult {
+  stopReason?: string;
+  [key: string]: unknown;
+}
+
+export interface DaemonIdeSetModelResult {
+  [key: string]: unknown;
+}
+
+export interface DaemonIdeSessionClient {
+  readonly sessionId: string;
+  readonly workspaceCwd: string;
+  readonly lastEventId?: number;
+  setLastEventId?(lastEventId: number | undefined): void;
+  prompt(
+    req: { prompt: ContentBlock[] },
+    signal?: AbortSignal,
+  ): Promise<DaemonIdePromptResult>;
+  events(opts?: {
+    signal?: AbortSignal;
+    lastEventId?: number;
+    resume?: boolean;
+  }): AsyncGenerator<DaemonIdeEvent>;
+  cancel(): Promise<void>;
+  setModel(modelId: string): Promise<DaemonIdeSetModelResult>;
+  respondToPermission(
+    requestId: string,
+    response: RequestPermissionResponse,
+  ): Promise<boolean>;
+}
+
+export interface DaemonIdeSessionFactoryOptions {
+  baseUrl: string;
+  token?: string;
+  workspaceCwd?: string;
+  modelServiceId?: string;
+  lastEventId?: number;
+}
+
+export type DaemonIdeSessionFactory = (
+  opts: DaemonIdeSessionFactoryOptions,
+) => Promise<DaemonIdeSessionClient>;
+
+export interface DaemonIdeConnectionOptions
+  extends DaemonIdeSessionFactoryOptions {
+  sessionFactory?: DaemonIdeSessionFactory;
+}
+
+type SdkModule = {
+  DaemonClient: new (opts: { baseUrl: string; token?: string }) => unknown;
+  DaemonSessionClient: {
+    createOrAttach(
+      client: unknown,
+      req?: {
+        workspaceCwd?: string;
+        modelServiceId?: string;
+      },
+    ): Promise<DaemonIdeSessionClient>;
+  };
+};
+
+const dynamicImport = new Function('specifier', 'return import(specifier)') as (
+  specifier: string,
+) => Promise<unknown>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isSdkModule(value: unknown): value is SdkModule {
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  const sessionClient = value['DaemonSessionClient'];
+  return (
+    typeof value['DaemonClient'] === 'function' &&
+    isRecord(sessionClient) &&
+    typeof sessionClient['createOrAttach'] === 'function'
+  );
+}
+
+export function createSdkDaemonSessionFactory(): DaemonIdeSessionFactory {
+  return async (opts: DaemonIdeSessionFactoryOptions) => {
+    const sdk = await dynamicImport('@qwen-code/sdk');
+    if (!isSdkModule(sdk)) {
+      throw new Error('Loaded @qwen-code/sdk does not expose daemon clients');
+    }
+
+    const daemon = new sdk.DaemonClient({
+      baseUrl: opts.baseUrl,
+      token: opts.token,
+    });
+    const session = await sdk.DaemonSessionClient.createOrAttach(daemon, {
+      workspaceCwd: opts.workspaceCwd,
+      modelServiceId: opts.modelServiceId,
+    });
+    session.setLastEventId?.(opts.lastEventId);
+    return session;
+  };
+}
+
+export class DaemonIdeConnection {
+  private session: DaemonIdeSessionClient | null = null;
+  private eventController: AbortController | null = null;
+  private eventPump: Promise<void> | null = null;
+  private lastSeenEventId: number | undefined;
+
+  onSessionUpdate: (data: SessionNotification) => void = () => {};
+  onPermissionRequest: (data: RequestPermissionRequest) => Promise<{
+    optionId: string;
+  }> = (data) =>
+    Promise.resolve({
+      optionId: this.resolvePermissionOptionId(data) || '',
+    });
+  onAskUserQuestion: (data: AskUserQuestionRequest) => Promise<{
+    optionId: string;
+    answers?: Record<string, string>;
+  }> = () => Promise.resolve({ optionId: 'cancel' });
+  onEndTurn: (reason?: string) => void = () => {};
+  onDisconnected: (code: number | null, signal: string | null) => void =
+    () => {};
+
+  async connect(options: DaemonIdeConnectionOptions): Promise<void> {
+    if (this.session) {
+      this.disconnect();
+    }
+
+    const factory = options.sessionFactory ?? createSdkDaemonSessionFactory();
+    this.session = await factory({
+      baseUrl: options.baseUrl,
+      token: options.token,
+      workspaceCwd: options.workspaceCwd,
+      modelServiceId: options.modelServiceId,
+      lastEventId: options.lastEventId,
+    });
+    this.lastSeenEventId = this.session.lastEventId ?? options.lastEventId;
+
+    this.eventController = new AbortController();
+    this.eventPump = this.pumpEvents(this.session, this.eventController.signal);
+  }
+
+  async sendPrompt(
+    prompt: string | ContentBlock[],
+  ): Promise<DaemonIdePromptResult> {
+    const session = this.ensureSession();
+    const promptBlocks =
+      typeof prompt === 'string'
+        ? ([{ type: 'text', text: prompt }] as ContentBlock[])
+        : prompt;
+    const response = await session.prompt({ prompt: promptBlocks });
+    this.onEndTurn(response.stopReason);
+    return response;
+  }
+
+  async cancelSession(): Promise<void> {
+    const session = this.session;
+    if (!session) {
+      return;
+    }
+    await session.cancel();
+  }
+
+  async setModel(modelId: string): Promise<DaemonIdeSetModelResult> {
+    return await this.ensureSession().setModel(modelId);
+  }
+
+  disconnect(): void {
+    this.eventController?.abort();
+    this.eventController = null;
+    this.eventPump = null;
+    this.session = null;
+  }
+
+  get isConnected(): boolean {
+    return this.session !== null;
+  }
+
+  get hasActiveSession(): boolean {
+    return this.session !== null;
+  }
+
+  get currentSessionId(): string | null {
+    return this.session?.sessionId ?? null;
+  }
+
+  get lastEventId(): number | undefined {
+    return this.session?.lastEventId ?? this.lastSeenEventId;
+  }
+
+  private ensureSession(): DaemonIdeSessionClient {
+    if (!this.session) {
+      throw new Error('Not connected to daemon session');
+    }
+    return this.session;
+  }
+
+  private async pumpEvents(
+    session: DaemonIdeSessionClient,
+    signal: AbortSignal,
+  ): Promise<void> {
+    try {
+      for await (const event of session.events({ signal })) {
+        if (event.id !== undefined) {
+          this.lastSeenEventId = event.id;
+        }
+        await this.handleEvent(event);
+      }
+    } catch (error) {
+      if (!signal.aborted) {
+        console.warn('[DaemonIdeConnection] Event stream failed:', error);
+        this.session = null;
+        this.onDisconnected(null, 'daemon_error');
+      }
+    }
+  }
+
+  private async handleEvent(event: DaemonIdeEvent): Promise<void> {
+    switch (event.type) {
+      case 'session_update':
+        this.onSessionUpdate(event.data as SessionNotification);
+        break;
+      case 'permission_request':
+        await this.handlePermissionRequest(event.data);
+        break;
+      case 'session_died':
+        this.handleSessionDied(event.data);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private async handlePermissionRequest(data: unknown): Promise<void> {
+    if (!isRecord(data) || typeof data['requestId'] !== 'string') {
+      return;
+    }
+
+    const requestId = data['requestId'];
+    const request = data as unknown as RequestPermissionRequest;
+    const response = await this.resolvePermissionResponse(request);
+    await this.ensureSession().respondToPermission(requestId, response);
+  }
+
+  private async resolvePermissionResponse(
+    request: RequestPermissionRequest,
+  ): Promise<RequestPermissionResponse> {
+    const rawInput = request.toolCall?.rawInput;
+    const isAskUserQuestion =
+      isRecord(rawInput) && Array.isArray(rawInput['questions']);
+
+    if (isAskUserQuestion) {
+      const askResponse = await this.onAskUserQuestion({
+        sessionId: request.sessionId,
+        questions: rawInput['questions'] as AskUserQuestionRequest['questions'],
+        metadata: rawInput['metadata'] as AskUserQuestionRequest['metadata'],
+      });
+      if (this.isCancelledOption(askResponse.optionId)) {
+        return { outcome: { outcome: 'cancelled' } };
+      }
+      return {
+        outcome: {
+          outcome: 'selected',
+          optionId: askResponse.optionId || 'proceed_once',
+        },
+        answers: askResponse.answers,
+      } as RequestPermissionResponse;
+    }
+
+    const response = await this.onPermissionRequest(request);
+    if (this.isCancelledOption(response.optionId)) {
+      return { outcome: { outcome: 'cancelled' } };
+    }
+
+    const optionId = this.resolvePermissionOptionId(request, response.optionId);
+    if (!optionId) {
+      return { outcome: { outcome: 'cancelled' } };
+    }
+
+    return {
+      outcome: {
+        outcome: 'selected',
+        optionId,
+      },
+    };
+  }
+
+  private handleSessionDied(data: unknown): void {
+    const reason =
+      isRecord(data) && typeof data['reason'] === 'string'
+        ? data['reason']
+        : 'session_died';
+    this.eventController?.abort();
+    this.eventController = null;
+    this.eventPump = null;
+    this.session = null;
+    this.onDisconnected(null, reason);
+  }
+
+  private isCancelledOption(optionId?: string): boolean {
+    return Boolean(
+      optionId && (optionId.includes('reject') || optionId === 'cancel'),
+    );
+  }
+
+  private resolvePermissionOptionId(
+    request: RequestPermissionRequest,
+    preferredOptionId?: string,
+  ): string | undefined {
+    const options = Array.isArray(request.options) ? request.options : [];
+    if (options.length === 0) {
+      return undefined;
+    }
+
+    if (
+      preferredOptionId &&
+      options.some((option) => option.optionId === preferredOptionId)
+    ) {
+      return preferredOptionId;
+    }
+
+    return (
+      options.find((option) => option.kind === 'allow_once')?.optionId ||
+      options.find((option) => option.optionId === 'proceed_once')?.optionId ||
+      options.find((option) => option.optionId.includes('proceed_once'))
+        ?.optionId ||
+      options[0]?.optionId
+    );
+  }
+}

--- a/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
+++ b/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
@@ -276,10 +276,10 @@ export class DaemonIdeConnection {
             eventId: event.id,
             error: toSafeErrorMessage(error),
           });
-          continue;
-        }
-        if (event.id !== undefined) {
-          this.lastSeenEventId = event.id;
+        } finally {
+          if (event.id !== undefined) {
+            this.lastSeenEventId = event.id;
+          }
         }
       }
       if (!signal.aborted) {
@@ -419,11 +419,10 @@ export class DaemonIdeConnection {
       return undefined;
     }
 
-    if (
-      preferredOptionId &&
-      options.some((option) => option.optionId === preferredOptionId)
-    ) {
-      return preferredOptionId;
+    if (preferredOptionId) {
+      return options.some((option) => option.optionId === preferredOptionId)
+        ? preferredOptionId
+        : undefined;
     }
 
     return (

--- a/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
+++ b/packages/vscode-ide-companion/src/services/daemonIdeConnection.ts
@@ -166,10 +166,12 @@ export class DaemonIdeConnection {
   private eventController: AbortController | null = null;
   private eventPump: Promise<void> | null = null;
   private lastSeenEventId: number | undefined;
+  private connectPromise: Promise<void> | null = null;
+  private pumpGeneration = 0;
 
   onSessionUpdate: (data: SessionNotification) => void = () => {};
   onPermissionRequest: (data: RequestPermissionRequest) => Promise<{
-    optionId: string;
+    optionId?: string;
   }> = () => Promise.resolve({ optionId: 'cancel' });
   onAskUserQuestion: (data: AskUserQuestionRequest) => Promise<{
     optionId: string;
@@ -180,6 +182,29 @@ export class DaemonIdeConnection {
     () => {};
 
   async connect(options: DaemonIdeConnectionOptions): Promise<void> {
+    while (this.connectPromise) {
+      try {
+        await this.connectPromise;
+      } catch {
+        // Let this connect attempt proceed with its own options after the
+        // in-flight attempt reports its failure to its caller.
+      }
+    }
+
+    const connectPromise = this.connectInternal(options);
+    this.connectPromise = connectPromise;
+    try {
+      await connectPromise;
+    } finally {
+      if (this.connectPromise === connectPromise) {
+        this.connectPromise = null;
+      }
+    }
+  }
+
+  private async connectInternal(
+    options: DaemonIdeConnectionOptions,
+  ): Promise<void> {
     if (this.session) {
       await this.disconnect();
     }
@@ -195,7 +220,12 @@ export class DaemonIdeConnection {
     this.lastSeenEventId = options.lastEventId ?? this.session.lastEventId;
 
     this.eventController = new AbortController();
-    this.eventPump = this.pumpEvents(this.session, this.eventController.signal);
+    const generation = ++this.pumpGeneration;
+    this.eventPump = this.pumpEvents(
+      this.session,
+      this.eventController.signal,
+      generation,
+    );
   }
 
   async sendPrompt(
@@ -260,6 +290,7 @@ export class DaemonIdeConnection {
   private async pumpEvents(
     session: DaemonIdeSessionClient,
     signal: AbortSignal,
+    generation: number,
   ): Promise<void> {
     try {
       const resumeId = this.lastSeenEventId ?? session.lastEventId;
@@ -269,7 +300,7 @@ export class DaemonIdeConnection {
         resume: true,
       })) {
         try {
-          await this.handleEvent(event);
+          await this.handleEvent(event, signal);
         } catch (error) {
           console.warn('[DaemonIdeConnection] Event handler failed:', {
             eventType: event.type,
@@ -295,19 +326,24 @@ export class DaemonIdeConnection {
         this.clearCurrentSession(session, 'daemon_error');
       }
     } finally {
-      if (this.session === session) {
+      // A disconnect callback may synchronously reconnect before the old pump
+      // reaches finally; only the active generation may clear eventPump.
+      if (this.pumpGeneration === generation) {
         this.eventPump = null;
       }
     }
   }
 
-  private async handleEvent(event: DaemonIdeEvent): Promise<void> {
+  private async handleEvent(
+    event: DaemonIdeEvent,
+    signal: AbortSignal,
+  ): Promise<void> {
     switch (event.type) {
       case 'session_update':
         this.onSessionUpdate(event.data as SessionNotification);
         break;
       case 'permission_request':
-        await this.handlePermissionRequest(event.data);
+        await this.handlePermissionRequest(event.data, signal);
         break;
       case 'session_died':
         this.handleSessionDied(event.data);
@@ -317,14 +353,23 @@ export class DaemonIdeConnection {
     }
   }
 
-  private async handlePermissionRequest(data: unknown): Promise<void> {
+  private async handlePermissionRequest(
+    data: unknown,
+    signal: AbortSignal,
+  ): Promise<void> {
     if (!isPermissionRequestData(data)) {
       return;
     }
 
     const requestId = data['requestId'];
     const request = data;
-    const response = await this.resolvePermissionResponse(request);
+    const response = await this.resolvePermissionResponseUntilAbort(
+      request,
+      signal,
+    );
+    if (!response) {
+      return;
+    }
     const accepted = await this.ensureSession().respondToPermission(
       requestId,
       response,
@@ -335,6 +380,38 @@ export class DaemonIdeConnection {
         requestId,
       );
     }
+  }
+
+  private async resolvePermissionResponseUntilAbort(
+    request: RequestPermissionRequest,
+    signal: AbortSignal,
+  ): Promise<RequestPermissionResponse | undefined> {
+    if (signal.aborted) {
+      return undefined;
+    }
+
+    const responsePromise = this.resolvePermissionResponse(request).catch(
+      (error: unknown) => {
+        console.warn(
+          '[DaemonIdeConnection] Permission handler failed:',
+          toSafeErrorMessage(error),
+        );
+        return {
+          outcome: { outcome: 'cancelled' },
+        } as RequestPermissionResponse;
+      },
+    );
+
+    return await new Promise<RequestPermissionResponse | undefined>(
+      (resolve) => {
+        const onAbort = () => resolve(undefined);
+        signal.addEventListener('abort', onAbort, { once: true });
+        responsePromise.then((response) => {
+          signal.removeEventListener('abort', onAbort);
+          resolve(signal.aborted ? undefined : response);
+        });
+      },
+    );
   }
 
   private async resolvePermissionResponse(
@@ -371,7 +448,7 @@ export class DaemonIdeConnection {
     }
 
     const response = await this.onPermissionRequest(request);
-    if (this.isCancelledOption(response.optionId)) {
+    if (response.optionId === '' || this.isCancelledOption(response.optionId)) {
       return { outcome: { outcome: 'cancelled' } };
     }
 
@@ -389,6 +466,18 @@ export class DaemonIdeConnection {
   }
 
   private handleSessionDied(data: unknown): void {
+    const eventSessionId =
+      isRecord(data) && typeof data['sessionId'] === 'string'
+        ? data['sessionId']
+        : undefined;
+    if (
+      eventSessionId !== undefined &&
+      this.session &&
+      eventSessionId !== this.session.sessionId
+    ) {
+      return;
+    }
+
     const reason =
       isRecord(data) && typeof data['reason'] === 'string'
         ? data['reason']
@@ -403,10 +492,9 @@ export class DaemonIdeConnection {
 
   private isCancelledOption(optionId?: string): boolean {
     return (
-      !optionId ||
       optionId === 'cancel' ||
       optionId === 'reject' ||
-      optionId.startsWith('reject_')
+      (optionId !== undefined && optionId.startsWith('reject_'))
     );
   }
 


### PR DESCRIPTION
## Summary

- What changed: Added a locally verifiable `DaemonIdeConnection` spike in the VS Code extension host, plus unit coverage for daemon session creation, SSE event consumption, prompt forwarding, permission responses, cancel, model switch, and session death handling.
- Why it changed: IDE can start dogfooding Mode B through `httpServer + SSE` without moving the default VS Code ACP subprocess path yet.
- Reviewer focus: Extension-host boundary, compatibility with existing ACP callback shapes, default-off behavior, and whether the unsupported gaps are explicit enough before wiring this into `QwenAgentManager`.

## Validation

- Commands run:
  ```bash
  cd packages/vscode-ide-companion && npx vitest run src/services/daemonIdeConnection.test.ts
  cd packages/core && npm run build
  cd packages/vscode-ide-companion && npm run check-types
  cd packages/vscode-ide-companion && npx eslint src/services/daemonIdeConnection.ts src/services/daemonIdeConnection.test.ts --max-warnings 0
  cd packages/vscode-ide-companion && npx prettier --check src/services/daemonIdeConnection.ts src/services/daemonIdeConnection.test.ts ../../docs/developers/daemon-client-adapters/ide.md
  cd packages/vscode-ide-companion && npm run build
  ```
- Prompts / inputs used: Unit tests use a fake daemon session event queue that emits `session_update`, `permission_request`, and `session_died` frames.
- Expected result: IDE adapter spike can be verified locally without a live daemon and without changing the existing VS Code default path.
- Observed result: Targeted vitest passed with 5 tests. Targeted ESLint and Prettier passed. VS Code companion `npm run build` passed; it still reports the pre-existing `src/utils/editorGroupUtils.ts` curly warning and stale Browserslist data.
- Quickest reviewer verification path: Run `cd packages/vscode-ide-companion && npx vitest run src/services/daemonIdeConnection.test.ts`.
- Evidence: The targeted test output reports `src/services/daemonIdeConnection.test.ts (5 tests)` and `Test Files 1 passed`.

## Scope / Risk

- Main risk or tradeoff: This is intentionally a spike adapter. It proves the extension-host daemon transport surface, but does not yet wire the feature flag, settings/env resolution, or webview flow.
- Not covered / not validated: No live `qwen serve` smoke, no `QwenAgentManager` switch, no session list/load/delete parity, no daemon set-mode route, no IDE file-service boundary, and no reverse RPC for local editor/browser/clipboard.
- Breaking changes / migration notes: None. Existing VS Code ACP subprocess behavior is unchanged and remains the default.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Local validation was run on macOS only.
- This PR does not touch sandbox runtime behavior.

## Linked Issues / Bugs

Related to #3803, #4175, and #4201.
Supersedes the docs-only IDE draft #4198 with a locally verifiable adapter spike.
