### PR TITLE
feat(tui): add daemon adapter spike

### DIFF
--- a/docs/developers/daemon-client-adapters/tui.md
+++ b/docs/developers/daemon-client-adapters/tui.md
@@ -41,7 +41,8 @@ The CLI should refuse this mode unless both are true:
 
 ## Rendering Contract
 
-The first draft should map only these daemon events:
+The first implementation adds `DaemonTuiAdapter`, a locally verifiable reducer
+and transport spike. It maps only these daemon events:
 
 | Daemon event                             | TUI handling                                 |
 | ---------------------------------------- | -------------------------------------------- |
@@ -55,6 +56,9 @@ The first draft should map only these daemon events:
 
 Unknown events must be ignored, not fatal. Typed event reducers will land in a
 later protocol PR.
+
+The adapter is not wired into the default Ink app yet. Existing interactive TUI,
+JSONL, stream-json, and dual-output behavior remains unchanged.
 
 ## Explicit Non-Goals
 
@@ -75,7 +79,8 @@ later protocol PR.
 ## Validation Plan
 
 - Unit-test event-to-TUI-state mapping with synthetic daemon events.
-- Unit-test flag/env parsing.
+- Unit-test prompt, cancel, model switch, and permission vote forwarding.
+- Unit-test flag/env parsing when the feature flag is wired.
 - Smoke-test against a local `qwen serve`:
   - prompt text streams into the TUI
   - cancel resolves the active prompt

--- a/docs/developers/daemon-client-adapters/tui.md
+++ b/docs/developers/daemon-client-adapters/tui.md
@@ -1,0 +1,91 @@
+# TUI Daemon Adapter Draft
+
+## Goal
+
+Add a flag-gated TUI transport that talks to `qwen serve` through
+`DaemonSessionClient` instead of creating an in-process `Config` + agent
+runtime.
+
+This is a dogfood path for Mode B client migration. It must not replace the
+default TUI path until output sinks, typed daemon events, session-scoped
+permission, and lifecycle diagnostics are stable.
+
+## Proposed Entry Point
+
+```bash
+QWEN_DAEMON_URL=http://127.0.0.1:4170 qwen --experimental-daemon-tui
+```
+
+Optional:
+
+```bash
+QWEN_DAEMON_TOKEN=... QWEN_DAEMON_WORKSPACE=/repo qwen --experimental-daemon-tui
+```
+
+The CLI should refuse this mode unless both are true:
+
+- `QWEN_DAEMON_URL` or `--daemon-url` is set.
+- `GET /capabilities` advertises `session_create`, `session_prompt`, and
+  `session_events`.
+
+## Minimal Flow
+
+1. Create `DaemonClient` with daemon URL and token.
+2. Fetch `/capabilities`.
+3. Create or attach with `DaemonSessionClient.createOrAttach()`.
+4. Subscribe to `session.events()`.
+5. Submit user prompts through `session.prompt()`.
+6. Route cancel through `session.cancel()`.
+7. Route model switch through `session.setModel()`.
+8. Route permission votes through `session.respondToPermission()`.
+
+## Rendering Contract
+
+The first draft should map only these daemon events:
+
+| Daemon event                             | TUI handling                                 |
+| ---------------------------------------- | -------------------------------------------- |
+| `session_update` / `agent_message_chunk` | Append assistant text                        |
+| `session_update` / `agent_thought_chunk` | Append thinking text                         |
+| `session_update` / `tool_call`           | Show tool call lifecycle                     |
+| `permission_request`                     | Show existing confirmation UI where possible |
+| `permission_resolved`                    | Close or update confirmation UI              |
+| `model_switched`                         | Update footer/model display                  |
+| `session_died`                           | Show disconnected state and stop streaming   |
+
+Unknown events must be ignored, not fatal. Typed event reducers will land in a
+later protocol PR.
+
+## Explicit Non-Goals
+
+- Do not remove the current TUI in-process runtime.
+- Do not change JSONL, stream-json, or dual-output behavior in this PR.
+- Do not expose file CRUD, MCP management, memory CRUD, or provider/auth
+  mutation through TUI yet.
+- Do not make browser/web direct-to-daemon assumptions; this is terminal only.
+
+## Merge Safety
+
+- Default off.
+- Additive code path.
+- No existing CLI flags change behavior.
+- If the daemon is unavailable, the experimental path fails before starting the
+  TUI and tells the user to run `qwen serve`.
+
+## Validation Plan
+
+- Unit-test event-to-TUI-state mapping with synthetic daemon events.
+- Unit-test flag/env parsing.
+- Smoke-test against a local `qwen serve`:
+  - prompt text streams into the TUI
+  - cancel resolves the active prompt
+  - permission request can be accepted or rejected
+  - reconnect sends the tracked `Last-Event-ID`
+
+## Blockers Before Default Migration
+
+- Typed daemon event schema.
+- Session-scoped permission route.
+- Output sink refactor for JSONL / stream-json / dual-output parity.
+- Session lifecycle close/delete semantics.
+- Runtime diagnostics for MCP, skills, providers, and workspace env.

--- a/packages/cli/src/ui/daemon/DaemonTuiAdapter.test.ts
+++ b/packages/cli/src/ui/daemon/DaemonTuiAdapter.test.ts
@@ -10,6 +10,7 @@ import type {
   RequestPermissionRequest,
 } from '@agentclientprotocol/sdk';
 import {
+  createDaemonTuiReducerState,
   DaemonTuiAdapter,
   reduceDaemonEventToTuiUpdates,
   type DaemonTuiEvent,
@@ -21,8 +22,12 @@ class EventQueue implements AsyncGenerator<DaemonTuiEvent> {
   private events: DaemonTuiEvent[] = [];
   private waiters: Array<(value: IteratorResult<DaemonTuiEvent>) => void> = [];
   private closed = false;
+  private failure: unknown;
 
   async next(): Promise<IteratorResult<DaemonTuiEvent>> {
+    if (this.failure) {
+      throw this.failure;
+    }
     const event = this.events.shift();
     if (event) {
       return { done: false, value: event };
@@ -64,6 +69,10 @@ class EventQueue implements AsyncGenerator<DaemonTuiEvent> {
       waiter({ done: true, value: undefined });
     }
   }
+
+  fail(error: unknown): void {
+    this.failure = error;
+  }
 }
 
 interface FakeSession extends DaemonTuiSessionClient {
@@ -80,7 +89,12 @@ function createFakeSession(events: EventQueue): FakeSession {
     workspaceCwd: '/repo',
     lastEventId: undefined,
     prompt: vi.fn().mockResolvedValue({ stopReason: 'end_turn' }),
-    events: vi.fn(() => events),
+    events: vi.fn((opts?: { signal?: AbortSignal }) => {
+      opts?.signal?.addEventListener('abort', () => events.close(), {
+        once: true,
+      });
+      return events;
+    }),
     cancel: vi.fn().mockResolvedValue(undefined),
     setModel: vi.fn().mockResolvedValue({}),
     respondToPermission: vi.fn().mockResolvedValue(true),
@@ -103,6 +117,21 @@ async function waitFor(assertion: () => void): Promise<void> {
 
 describe('reduceDaemonEventToTuiUpdates', () => {
   it('maps assistant, thought, tool, model, and disconnect daemon events', () => {
+    expect(
+      reduceDaemonEventToTuiUpdates({
+        id: 0,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'session-1',
+          update: {
+            sessionUpdate: 'user_message_chunk',
+            content: { type: 'text', text: 'hello' },
+          },
+        },
+      }),
+    ).toEqual([]);
+
     expect(
       reduceDaemonEventToTuiUpdates({
         id: 1,
@@ -163,7 +192,7 @@ describe('reduceDaemonEventToTuiUpdates', () => {
     });
     expect(toolUpdates).toHaveLength(1);
     expect(toolUpdates[0]).toMatchObject({
-      type: 'history',
+      type: 'tool_group_update',
       item: {
         type: 'tool_group',
         tools: [
@@ -207,7 +236,7 @@ describe('reduceDaemonEventToTuiUpdates', () => {
         id: 5,
         v: 1,
         type: 'session_died',
-        data: { sessionId: 'session-1', reason: 'agent exited' },
+        data: { sessionId: 'session-1', reason: '\x1b[31magent exited\x1b[0m' },
       }),
     ).toEqual([
       { type: 'disconnected', reason: 'agent exited', daemonEventId: 5 },
@@ -218,6 +247,112 @@ describe('reduceDaemonEventToTuiUpdates', () => {
           text: 'Daemon session disconnected: agent exited',
         },
         daemonEventId: 5,
+      },
+    ]);
+  });
+
+  it('accumulates tool updates and preserves structured result displays', () => {
+    const state = createDaemonTuiReducerState();
+    const fileDiff = {
+      fileDiff: '--- a\n+++ b',
+      fileName: 'a.txt',
+      originalContent: 'a',
+      newContent: 'b',
+    };
+
+    expect(
+      reduceDaemonEventToTuiUpdates(
+        {
+          id: 1,
+          v: 1,
+          type: 'session_update',
+          data: {
+            sessionId: 'session-1',
+            update: {
+              sessionUpdate: 'tool_call_update',
+              toolCallId: 'tool-1',
+              kind: 'read_file',
+              title: 'Read file',
+              status: 'running',
+            },
+          },
+        },
+        state,
+      ),
+    ).toMatchObject([
+      {
+        type: 'tool_group_update',
+        item: {
+          type: 'tool_group',
+          tools: [{ callId: 'tool-1', status: ToolCallStatus.Executing }],
+        },
+      },
+    ]);
+
+    expect(
+      reduceDaemonEventToTuiUpdates(
+        {
+          id: 2,
+          v: 1,
+          type: 'session_update',
+          data: {
+            sessionId: 'session-1',
+            update: {
+              sessionUpdate: 'tool_call_update',
+              toolCallId: 'tool-1',
+              status: 'completed',
+              rawOutput: fileDiff,
+            },
+          },
+        },
+        state,
+      ),
+    ).toMatchObject([
+      {
+        type: 'tool_group_update',
+        item: {
+          type: 'tool_group',
+          tools: [
+            {
+              callId: 'tool-1',
+              name: 'read_file',
+              description: 'Read file',
+              status: ToolCallStatus.Success,
+              resultDisplay: fileDiff,
+            },
+          ],
+        },
+      },
+    ]);
+
+    expect(
+      reduceDaemonEventToTuiUpdates(
+        {
+          id: 3,
+          v: 1,
+          type: 'session_update',
+          data: {
+            sessionId: 'session-1',
+            update: {
+              sessionUpdate: 'tool_call_update',
+              toolCallId: 'tool-2',
+              kind: 'shell',
+              status: 'unexpected',
+            },
+          },
+        },
+        state,
+      ),
+    ).toMatchObject([
+      {
+        type: 'tool_group_update',
+        item: {
+          type: 'tool_group',
+          tools: [
+            { callId: 'tool-1' },
+            { callId: 'tool-2', status: ToolCallStatus.Error },
+          ],
+        },
       },
     ]);
   });
@@ -271,6 +406,15 @@ describe('reduceDaemonEventToTuiUpdates', () => {
         daemonEventId: 7,
       },
     ]);
+
+    expect(
+      reduceDaemonEventToTuiUpdates({
+        id: 8,
+        v: 1,
+        type: 'permission_request',
+        data: { requestId: 'req-bad' },
+      }),
+    ).toEqual([]);
   });
 });
 
@@ -278,6 +422,7 @@ describe('DaemonTuiAdapter', () => {
   it('pumps daemon events into TUI updates and tracks replay state', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);
+    Object.defineProperty(session, 'lastEventId', { value: 3 });
     const onUpdate = vi.fn();
     const adapter = new DaemonTuiAdapter({ session, onUpdate });
 
@@ -303,9 +448,46 @@ describe('DaemonTuiAdapter', () => {
       }),
     );
     expect(adapter.lastEventId).toBe(10);
+    expect(session.events).toHaveBeenCalledWith({
+      signal: expect.any(AbortSignal),
+      lastEventId: 3,
+      resume: true,
+    });
 
+    await adapter.stop();
+  });
+
+  it('emits disconnected when the event stream ends or fails', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const onUpdate = vi.fn();
+    const adapter = new DaemonTuiAdapter({ session, onUpdate });
+
+    adapter.start();
     events.close();
-    adapter.stop();
+    await waitFor(() =>
+      expect(onUpdate).toHaveBeenCalledWith({
+        type: 'disconnected',
+        reason: 'event stream ended',
+      }),
+    );
+
+    const failingEvents = new EventQueue();
+    failingEvents.fail(new Error('\x1b[31mboom\x1b[0m'));
+    const failingSession = createFakeSession(failingEvents);
+    const onFailingUpdate = vi.fn();
+    const failingAdapter = new DaemonTuiAdapter({
+      session: failingSession,
+      onUpdate: onFailingUpdate,
+    });
+
+    failingAdapter.start();
+    await waitFor(() =>
+      expect(onFailingUpdate).toHaveBeenCalledWith({
+        type: 'disconnected',
+        reason: 'boom',
+      }),
+    );
   });
 
   it('forwards prompt, cancel, model switch, and permission votes', async () => {
@@ -318,10 +500,9 @@ describe('DaemonTuiAdapter', () => {
     expect(session.prompt).toHaveBeenCalledWith({
       prompt: [{ type: 'text', text: 'hello daemon' }],
     });
-    expect(onUpdate).toHaveBeenCalledWith({
-      type: 'turn_complete',
-      stopReason: 'end_turn',
-    });
+    expect(onUpdate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'turn_complete' }),
+    );
 
     const blocks: ContentBlock[] = [{ type: 'text', text: 'structured' }];
     await adapter.sendPrompt(blocks);

--- a/packages/cli/src/ui/daemon/DaemonTuiAdapter.test.ts
+++ b/packages/cli/src/ui/daemon/DaemonTuiAdapter.test.ts
@@ -548,7 +548,7 @@ describe('reduceDaemonEventToTuiUpdates', () => {
         type: 'permission_resolved',
         data: {
           requestId: 'req-1',
-          outcome: { outcome: 'selected', optionId: 'proceed_once' },
+          outcome: { outcome: 'selected', optionId: '\x1b[31mproceed_once' },
         },
       }),
     ).toEqual([
@@ -563,6 +563,22 @@ describe('reduceDaemonEventToTuiUpdates', () => {
     expect(
       reduceDaemonEventToTuiUpdates({
         id: 8,
+        v: 1,
+        type: 'permission_resolved',
+        data: { requestId: 'req-1', outcome: { outcome: 'selected' } },
+      }),
+    ).toEqual([
+      {
+        type: 'permission_resolved',
+        requestId: 'req-1',
+        outcome: undefined,
+        daemonEventId: 8,
+      },
+    ]);
+
+    expect(
+      reduceDaemonEventToTuiUpdates({
+        id: 9,
         v: 1,
         type: 'permission_request',
         data: { requestId: 'req-bad' },
@@ -672,6 +688,29 @@ describe('DaemonTuiAdapter', () => {
     throwingAdapter.start();
     throwingEvents.close();
     await expect(throwingAdapter.stop()).resolves.toBeUndefined();
+  });
+
+  it('reports unsupported daemon protocol versions once and advances replay state', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const onUpdate = vi.fn();
+    const adapter = new DaemonTuiAdapter({ session, onUpdate });
+
+    adapter.start();
+    events.push({ id: 41, v: 2 as 1, type: 'future_event', data: {} });
+    events.push({ id: 42, v: 2 as 1, type: 'future_event', data: {} });
+
+    await waitFor(() => expect(adapter.lastEventId).toBe(42));
+    const unsupportedUpdates = onUpdate.mock.calls.filter(
+      ([update]) =>
+        update.type === 'history' &&
+        update.item.type === 'error' &&
+        update.item.text.includes('Unsupported daemon protocol version'),
+    );
+    expect(unsupportedUpdates).toHaveLength(1);
+
+    events.close();
+    await adapter.stop();
   });
 
   it('forwards prompt, cancel, model switch, and permission votes', async () => {
@@ -860,7 +899,7 @@ describe('DaemonTuiAdapter', () => {
     await adapter.stop();
   });
 
-  it('reports daemon control failures from cancel/model/permission calls', async () => {
+  it('reports daemon control failures without dropping the event stream', async () => {
     const cancelEvents = new EventQueue();
     const cancelSession = createFakeSession(cancelEvents);
     const cancelUpdates = vi.fn();
@@ -874,9 +913,12 @@ describe('DaemonTuiAdapter', () => {
     );
     await expect(cancelAdapter.cancel()).rejects.toThrow('cancel down');
     expect(cancelUpdates).toHaveBeenCalledWith({
-      type: 'disconnected',
-      reason: 'cancel down',
+      type: 'history',
+      item: { type: 'error', text: 'Daemon RPC failed: cancel down' },
     });
+    expect(cancelUpdates).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'disconnected' }),
+    );
 
     const modelEvents = new EventQueue();
     const modelSession = createFakeSession(modelEvents);
@@ -891,9 +933,12 @@ describe('DaemonTuiAdapter', () => {
       'model down',
     );
     expect(modelUpdates).toHaveBeenCalledWith({
-      type: 'disconnected',
-      reason: 'model down',
+      type: 'history',
+      item: { type: 'error', text: 'Daemon RPC failed: model down' },
     });
+    expect(modelUpdates).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'disconnected' }),
+    );
 
     const voteEvents = new EventQueue();
     const voteSession = createFakeSession(voteEvents);
@@ -910,9 +955,12 @@ describe('DaemonTuiAdapter', () => {
       voteAdapter.approvePermission('req-1', 'proceed_once'),
     ).rejects.toThrow('vote down');
     expect(voteUpdates).toHaveBeenCalledWith({
-      type: 'disconnected',
-      reason: 'vote down',
+      type: 'history',
+      item: { type: 'error', text: 'Daemon RPC failed: vote down' },
     });
+    expect(voteUpdates).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'disconnected' }),
+    );
 
     cancelEvents.close();
     modelEvents.close();

--- a/packages/cli/src/ui/daemon/DaemonTuiAdapter.test.ts
+++ b/packages/cli/src/ui/daemon/DaemonTuiAdapter.test.ts
@@ -20,7 +20,10 @@ import { ToolCallStatus } from '../types.js';
 
 class EventQueue implements AsyncGenerator<DaemonTuiEvent> {
   private events: DaemonTuiEvent[] = [];
-  private waiters: Array<(value: IteratorResult<DaemonTuiEvent>) => void> = [];
+  private waiters: Array<{
+    resolve: (value: IteratorResult<DaemonTuiEvent>) => void;
+    reject: (error: unknown) => void;
+  }> = [];
   private closed = false;
   private failure: unknown;
 
@@ -35,8 +38,8 @@ class EventQueue implements AsyncGenerator<DaemonTuiEvent> {
     if (this.closed) {
       return { done: true, value: undefined };
     }
-    return await new Promise((resolve) => {
-      this.waiters.push(resolve);
+    return await new Promise((resolve, reject) => {
+      this.waiters.push({ resolve, reject });
     });
   }
 
@@ -57,7 +60,7 @@ class EventQueue implements AsyncGenerator<DaemonTuiEvent> {
   push(event: DaemonTuiEvent): void {
     const waiter = this.waiters.shift();
     if (waiter) {
-      waiter({ done: false, value: event });
+      waiter.resolve({ done: false, value: event });
       return;
     }
     this.events.push(event);
@@ -66,12 +69,15 @@ class EventQueue implements AsyncGenerator<DaemonTuiEvent> {
   close(): void {
     this.closed = true;
     for (const waiter of this.waiters.splice(0)) {
-      waiter({ done: true, value: undefined });
+      waiter.resolve({ done: true, value: undefined });
     }
   }
 
   fail(error: unknown): void {
     this.failure = error;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter.reject(error);
+    }
   }
 }
 
@@ -141,7 +147,7 @@ describe('reduceDaemonEventToTuiUpdates', () => {
           sessionId: 'session-1',
           update: {
             sessionUpdate: 'agent_message_chunk',
-            content: { type: 'text', text: 'hello' },
+            content: { type: 'text', text: '\x1b]0;title\x07hello\x00' },
           },
         },
       }),
@@ -174,6 +180,32 @@ describe('reduceDaemonEventToTuiUpdates', () => {
       },
     ]);
 
+    expect(
+      reduceDaemonEventToTuiUpdates({
+        id: 20,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'session-1',
+          update: {
+            sessionUpdate: 'plan',
+            entries: [
+              {
+                status: '\x1b]0;bad\x07pending',
+                content: '\x1b[31mfinish this\x1b[0m',
+              },
+            ],
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        type: 'history',
+        item: { type: 'info', text: '1. [pending] finish this' },
+        daemonEventId: 20,
+      },
+    ]);
+
     const toolUpdates = reduceDaemonEventToTuiUpdates({
       id: 3,
       v: 1,
@@ -183,10 +215,10 @@ describe('reduceDaemonEventToTuiUpdates', () => {
         update: {
           sessionUpdate: 'tool_call_update',
           toolCallId: 'tool-1',
-          kind: 'read_file',
-          title: 'Read file',
+          kind: '\x1b]0;bad\x07read_file',
+          title: '\x1b[31mRead file\x1b[0m',
           status: 'completed',
-          rawOutput: { lines: 3 },
+          rawOutput: '\x1b[31m3 lines\x1b[0m',
         },
       },
     });
@@ -201,7 +233,7 @@ describe('reduceDaemonEventToTuiUpdates', () => {
             name: 'read_file',
             description: 'Read file',
             status: ToolCallStatus.Success,
-            resultDisplay: '{"lines":3}',
+            resultDisplay: '3 lines',
           },
         ],
       },
@@ -213,7 +245,10 @@ describe('reduceDaemonEventToTuiUpdates', () => {
         id: 4,
         v: 1,
         type: 'model_switched',
-        data: { sessionId: 'session-1', modelId: 'qwen3-coder-plus' },
+        data: {
+          sessionId: 'session-1',
+          modelId: '\x1b]0;bad\x07qwen3-coder-plus',
+        },
       }),
     ).toEqual([
       {
@@ -236,7 +271,10 @@ describe('reduceDaemonEventToTuiUpdates', () => {
         id: 5,
         v: 1,
         type: 'session_died',
-        data: { sessionId: 'session-1', reason: '\x1b[31magent exited\x1b[0m' },
+        data: {
+          sessionId: 'session-1',
+          reason: '\x1b]0;bad title\x07\x1b[31magent exited\x1b[0m',
+        },
       }),
     ).toEqual([
       { type: 'disconnected', reason: 'agent exited', daemonEventId: 5 },
@@ -274,7 +312,7 @@ describe('reduceDaemonEventToTuiUpdates', () => {
         id: 7,
         v: 1,
         type: 'stream_error',
-        data: { error: '\x1b[31mstream failed\x1b[0m' },
+        data: { error: '\x1bPignored\x1b\\\x1b[31mstream failed\x1b[0m' },
       }),
     ).toEqual([
       { type: 'disconnected', reason: 'stream failed', daemonEventId: 7 },
@@ -430,6 +468,29 @@ describe('reduceDaemonEventToTuiUpdates', () => {
         },
       },
     ]);
+
+    for (let i = 0; i < 130; i += 1) {
+      reduceDaemonEventToTuiUpdates(
+        {
+          id: 100 + i,
+          v: 1,
+          type: 'session_update',
+          data: {
+            sessionId: 'session-1',
+            update: {
+              sessionUpdate: 'tool_call_update',
+              toolCallId: `evict-${i}`,
+              kind: 'shell',
+              status: 'completed',
+            },
+          },
+        },
+        state,
+      );
+    }
+    expect(state.toolCallsById.size).toBe(128);
+    expect(state.toolCallsById.has('tool-1')).toBe(false);
+    expect(state.toolCallsById.has('evict-129')).toBe(true);
   });
 
   it('maps permission lifecycle events without auto-voting', () => {
@@ -563,6 +624,18 @@ describe('DaemonTuiAdapter', () => {
         reason: 'boom',
       }),
     );
+
+    const throwingEvents = new EventQueue();
+    const throwingSession = createFakeSession(throwingEvents);
+    const throwingAdapter = new DaemonTuiAdapter({
+      session: throwingSession,
+      onUpdate: () => {
+        throw new Error('\x1b]0;bad\x07render failed');
+      },
+    });
+    throwingAdapter.start();
+    throwingEvents.close();
+    await expect(throwingAdapter.stop()).resolves.toBeUndefined();
   });
 
   it('forwards prompt, cancel, model switch, and permission votes', async () => {
@@ -617,6 +690,121 @@ describe('DaemonTuiAdapter', () => {
     expect(onUpdate).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'turn_complete' }),
     );
+
+    events.close();
+  });
+
+  it('restarts after start is requested while stop is draining the pump', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const onUpdate = vi.fn();
+    const adapter = new DaemonTuiAdapter({ session, onUpdate });
+
+    adapter.start();
+    const stopPromise = adapter.stop();
+    adapter.start();
+    await stopPromise;
+
+    await waitFor(() => expect(session.events).toHaveBeenCalledTimes(2));
+    await adapter.stop();
+  });
+
+  it('clears accumulated tool state before each prompt', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const onUpdate = vi.fn();
+    const adapter = new DaemonTuiAdapter({ session, onUpdate });
+
+    adapter.start();
+    events.push({
+      id: 1,
+      v: 1,
+      type: 'session_update',
+      data: {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'old-tool',
+          kind: 'shell',
+          status: 'completed',
+        },
+      },
+    });
+    await waitFor(() =>
+      expect(onUpdate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'tool_group_update',
+          item: expect.objectContaining({
+            tools: [expect.objectContaining({ callId: 'old-tool' })],
+          }),
+        }),
+      ),
+    );
+
+    await adapter.sendPrompt('next turn');
+    events.push({
+      id: 2,
+      v: 1,
+      type: 'session_update',
+      data: {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'new-tool',
+          kind: 'grep',
+          status: 'running',
+        },
+      },
+    });
+
+    await waitFor(() => {
+      const lastToolUpdate = onUpdate.mock.calls
+        .map(([update]) => update)
+        .filter((update) => update.type === 'tool_group_update')
+        .at(-1);
+      expect(lastToolUpdate).toMatchObject({
+        item: {
+          tools: [expect.objectContaining({ callId: 'new-tool' })],
+        },
+      });
+      expect(lastToolUpdate?.item.tools).toHaveLength(1);
+    });
+
+    await adapter.stop();
+  });
+
+  it('reports daemon control failures from cancel/model/permission calls', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const onUpdate = vi.fn();
+    const adapter = new DaemonTuiAdapter({ session, onUpdate });
+
+    session.cancel.mockRejectedValueOnce(
+      new Error('\x1b[31mcancel down\x1b[0m'),
+    );
+    await expect(adapter.cancel()).rejects.toThrow('cancel down');
+    expect(onUpdate).toHaveBeenCalledWith({
+      type: 'disconnected',
+      reason: 'cancel down',
+    });
+
+    session.setModel.mockRejectedValueOnce(new Error('model down'));
+    await expect(adapter.setModel('qwen3-coder-plus')).rejects.toThrow(
+      'model down',
+    );
+    expect(onUpdate).toHaveBeenCalledWith({
+      type: 'disconnected',
+      reason: 'model down',
+    });
+
+    session.respondToPermission.mockRejectedValueOnce(new Error('vote down'));
+    await expect(
+      adapter.approvePermission('req-1', 'proceed_once'),
+    ).rejects.toThrow('vote down');
+    expect(onUpdate).toHaveBeenCalledWith({
+      type: 'disconnected',
+      reason: 'vote down',
+    });
 
     events.close();
   });

--- a/packages/cli/src/ui/daemon/DaemonTuiAdapter.test.ts
+++ b/packages/cli/src/ui/daemon/DaemonTuiAdapter.test.ts
@@ -1,0 +1,346 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  ContentBlock,
+  RequestPermissionRequest,
+} from '@agentclientprotocol/sdk';
+import {
+  DaemonTuiAdapter,
+  reduceDaemonEventToTuiUpdates,
+  type DaemonTuiEvent,
+  type DaemonTuiSessionClient,
+} from './DaemonTuiAdapter.js';
+import { ToolCallStatus } from '../types.js';
+
+class EventQueue implements AsyncGenerator<DaemonTuiEvent> {
+  private events: DaemonTuiEvent[] = [];
+  private waiters: Array<(value: IteratorResult<DaemonTuiEvent>) => void> = [];
+  private closed = false;
+
+  async next(): Promise<IteratorResult<DaemonTuiEvent>> {
+    const event = this.events.shift();
+    if (event) {
+      return { done: false, value: event };
+    }
+    if (this.closed) {
+      return { done: true, value: undefined };
+    }
+    return await new Promise((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  async return(): Promise<IteratorResult<DaemonTuiEvent>> {
+    this.close();
+    return { done: true, value: undefined };
+  }
+
+  async throw(error?: unknown): Promise<IteratorResult<DaemonTuiEvent>> {
+    this.close();
+    throw error;
+  }
+
+  [Symbol.asyncIterator](): AsyncGenerator<DaemonTuiEvent> {
+    return this;
+  }
+
+  push(event: DaemonTuiEvent): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter({ done: false, value: event });
+      return;
+    }
+    this.events.push(event);
+  }
+
+  close(): void {
+    this.closed = true;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter({ done: true, value: undefined });
+    }
+  }
+}
+
+interface FakeSession extends DaemonTuiSessionClient {
+  prompt: ReturnType<typeof vi.fn>;
+  events: ReturnType<typeof vi.fn>;
+  cancel: ReturnType<typeof vi.fn>;
+  setModel: ReturnType<typeof vi.fn>;
+  respondToPermission: ReturnType<typeof vi.fn>;
+}
+
+function createFakeSession(events: EventQueue): FakeSession {
+  return {
+    sessionId: 'session-1',
+    workspaceCwd: '/repo',
+    lastEventId: undefined,
+    prompt: vi.fn().mockResolvedValue({ stopReason: 'end_turn' }),
+    events: vi.fn(() => events),
+    cancel: vi.fn().mockResolvedValue(undefined),
+    setModel: vi.fn().mockResolvedValue({}),
+    respondToPermission: vi.fn().mockResolvedValue(true),
+  };
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let lastError: unknown;
+  for (let i = 0; i < 20; i += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+  throw lastError;
+}
+
+describe('reduceDaemonEventToTuiUpdates', () => {
+  it('maps assistant, thought, tool, model, and disconnect daemon events', () => {
+    expect(
+      reduceDaemonEventToTuiUpdates({
+        id: 1,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'session-1',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: { type: 'text', text: 'hello' },
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        type: 'history',
+        item: { type: 'gemini_content', text: 'hello' },
+        daemonEventId: 1,
+      },
+    ]);
+
+    expect(
+      reduceDaemonEventToTuiUpdates({
+        id: 2,
+        v: 1,
+        type: 'session_update',
+        data: {
+          sessionId: 'session-1',
+          update: {
+            sessionUpdate: 'agent_thought_chunk',
+            content: { type: 'text', text: 'thinking' },
+          },
+        },
+      }),
+    ).toEqual([
+      {
+        type: 'history',
+        item: { type: 'gemini_thought_content', text: 'thinking' },
+        daemonEventId: 2,
+      },
+    ]);
+
+    const toolUpdates = reduceDaemonEventToTuiUpdates({
+      id: 3,
+      v: 1,
+      type: 'session_update',
+      data: {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tool-1',
+          kind: 'read_file',
+          title: 'Read file',
+          status: 'completed',
+          rawOutput: { lines: 3 },
+        },
+      },
+    });
+    expect(toolUpdates).toHaveLength(1);
+    expect(toolUpdates[0]).toMatchObject({
+      type: 'history',
+      item: {
+        type: 'tool_group',
+        tools: [
+          {
+            callId: 'tool-1',
+            name: 'read_file',
+            description: 'Read file',
+            status: ToolCallStatus.Success,
+            resultDisplay: '{"lines":3}',
+          },
+        ],
+      },
+      daemonEventId: 3,
+    });
+
+    expect(
+      reduceDaemonEventToTuiUpdates({
+        id: 4,
+        v: 1,
+        type: 'model_switched',
+        data: { sessionId: 'session-1', modelId: 'qwen3-coder-plus' },
+      }),
+    ).toEqual([
+      {
+        type: 'model_switched',
+        modelId: 'qwen3-coder-plus',
+        daemonEventId: 4,
+      },
+      {
+        type: 'history',
+        item: {
+          type: 'info',
+          text: 'Model switched to qwen3-coder-plus',
+        },
+        daemonEventId: 4,
+      },
+    ]);
+
+    expect(
+      reduceDaemonEventToTuiUpdates({
+        id: 5,
+        v: 1,
+        type: 'session_died',
+        data: { sessionId: 'session-1', reason: 'agent exited' },
+      }),
+    ).toEqual([
+      { type: 'disconnected', reason: 'agent exited', daemonEventId: 5 },
+      {
+        type: 'history',
+        item: {
+          type: 'error',
+          text: 'Daemon session disconnected: agent exited',
+        },
+        daemonEventId: 5,
+      },
+    ]);
+  });
+
+  it('maps permission lifecycle events without auto-voting', () => {
+    const request: RequestPermissionRequest & { requestId: string } = {
+      requestId: 'req-1',
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        title: 'Edit file',
+        kind: 'edit',
+        rawInput: {},
+      },
+      options: [
+        { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+      ],
+    } as RequestPermissionRequest & { requestId: string };
+
+    expect(
+      reduceDaemonEventToTuiUpdates({
+        id: 6,
+        v: 1,
+        type: 'permission_request',
+        data: request,
+      }),
+    ).toEqual([
+      {
+        type: 'permission_request',
+        requestId: 'req-1',
+        request,
+        daemonEventId: 6,
+      },
+    ]);
+
+    expect(
+      reduceDaemonEventToTuiUpdates({
+        id: 7,
+        v: 1,
+        type: 'permission_resolved',
+        data: {
+          requestId: 'req-1',
+          outcome: { outcome: 'selected', optionId: 'proceed_once' },
+        },
+      }),
+    ).toEqual([
+      {
+        type: 'permission_resolved',
+        requestId: 'req-1',
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+        daemonEventId: 7,
+      },
+    ]);
+  });
+});
+
+describe('DaemonTuiAdapter', () => {
+  it('pumps daemon events into TUI updates and tracks replay state', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const onUpdate = vi.fn();
+    const adapter = new DaemonTuiAdapter({ session, onUpdate });
+
+    adapter.start();
+    events.push({
+      id: 10,
+      v: 1,
+      type: 'session_update',
+      data: {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'hello' },
+        },
+      },
+    });
+
+    await waitFor(() =>
+      expect(onUpdate).toHaveBeenCalledWith({
+        type: 'history',
+        item: { type: 'gemini_content', text: 'hello' },
+        daemonEventId: 10,
+      }),
+    );
+    expect(adapter.lastEventId).toBe(10);
+
+    events.close();
+    adapter.stop();
+  });
+
+  it('forwards prompt, cancel, model switch, and permission votes', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const onUpdate = vi.fn();
+    const adapter = new DaemonTuiAdapter({ session, onUpdate });
+
+    await adapter.sendPrompt('hello daemon');
+    expect(session.prompt).toHaveBeenCalledWith({
+      prompt: [{ type: 'text', text: 'hello daemon' }],
+    });
+    expect(onUpdate).toHaveBeenCalledWith({
+      type: 'turn_complete',
+      stopReason: 'end_turn',
+    });
+
+    const blocks: ContentBlock[] = [{ type: 'text', text: 'structured' }];
+    await adapter.sendPrompt(blocks);
+    expect(session.prompt).toHaveBeenLastCalledWith({ prompt: blocks });
+
+    await adapter.cancel();
+    await adapter.setModel('qwen3-coder-plus');
+    await adapter.approvePermission('req-1', 'proceed_once');
+    await adapter.rejectPermission('req-2');
+
+    expect(session.cancel).toHaveBeenCalledOnce();
+    expect(session.setModel).toHaveBeenCalledWith('qwen3-coder-plus');
+    expect(session.respondToPermission).toHaveBeenNthCalledWith(1, 'req-1', {
+      outcome: { outcome: 'selected', optionId: 'proceed_once' },
+    });
+    expect(session.respondToPermission).toHaveBeenNthCalledWith(2, 'req-2', {
+      outcome: { outcome: 'cancelled' },
+    });
+
+    events.close();
+  });
+});

--- a/packages/cli/src/ui/daemon/DaemonTuiAdapter.test.ts
+++ b/packages/cli/src/ui/daemon/DaemonTuiAdapter.test.ts
@@ -249,6 +249,44 @@ describe('reduceDaemonEventToTuiUpdates', () => {
         daemonEventId: 5,
       },
     ]);
+
+    expect(
+      reduceDaemonEventToTuiUpdates({
+        id: 6,
+        v: 1,
+        type: 'client_evicted',
+        data: { reason: 'queue_overflow' },
+      }),
+    ).toEqual([
+      { type: 'disconnected', reason: 'queue_overflow', daemonEventId: 6 },
+      {
+        type: 'history',
+        item: {
+          type: 'error',
+          text: 'Daemon session disconnected: queue_overflow',
+        },
+        daemonEventId: 6,
+      },
+    ]);
+
+    expect(
+      reduceDaemonEventToTuiUpdates({
+        id: 7,
+        v: 1,
+        type: 'stream_error',
+        data: { error: '\x1b[31mstream failed\x1b[0m' },
+      }),
+    ).toEqual([
+      { type: 'disconnected', reason: 'stream failed', daemonEventId: 7 },
+      {
+        type: 'history',
+        item: {
+          type: 'error',
+          text: 'Daemon session disconnected: stream failed',
+        },
+        daemonEventId: 7,
+      },
+    ]);
   });
 
   it('accumulates tool updates and preserves structured result displays', () => {
@@ -351,6 +389,43 @@ describe('reduceDaemonEventToTuiUpdates', () => {
           tools: [
             { callId: 'tool-1' },
             { callId: 'tool-2', status: ToolCallStatus.Error },
+          ],
+        },
+      },
+    ]);
+
+    expect(
+      reduceDaemonEventToTuiUpdates(
+        {
+          id: 4,
+          v: 1,
+          type: 'session_update',
+          data: {
+            sessionId: 'session-1',
+            update: {
+              sessionUpdate: 'tool_call_update',
+              toolCallId: 'tool-3',
+              kind: 'shell',
+              status: 'failed',
+              content: [{ content: { text: 'command failed' } }],
+            },
+          },
+        },
+        state,
+      ),
+    ).toMatchObject([
+      {
+        type: 'tool_group_update',
+        item: {
+          type: 'tool_group',
+          tools: [
+            { callId: 'tool-1' },
+            { callId: 'tool-2' },
+            {
+              callId: 'tool-3',
+              status: ToolCallStatus.Error,
+              resultDisplay: 'command failed',
+            },
           ],
         },
       },

--- a/packages/cli/src/ui/daemon/DaemonTuiAdapter.test.ts
+++ b/packages/cli/src/ui/daemon/DaemonTuiAdapter.test.ts
@@ -147,7 +147,7 @@ describe('reduceDaemonEventToTuiUpdates', () => {
           sessionId: 'session-1',
           update: {
             sessionUpdate: 'agent_message_chunk',
-            content: { type: 'text', text: '\x1b]0;title\x07hello\x00' },
+            content: { type: 'text', text: '\u202e\x9b31mhe\rllo\x00' },
           },
         },
       }),
@@ -330,6 +330,12 @@ describe('reduceDaemonEventToTuiUpdates', () => {
   it('accumulates tool updates and preserves structured result displays', () => {
     const state = createDaemonTuiReducerState();
     const fileDiff = {
+      fileDiff: '\x1b[31m--- a\n+++ b\x1b[0m',
+      fileName: '\u202ea.txt',
+      originalContent: 'a\r',
+      newContent: 'b\x9b31m',
+    };
+    const sanitizedFileDiff = {
       fileDiff: '--- a\n+++ b',
       fileName: 'a.txt',
       originalContent: 'a',
@@ -394,7 +400,7 @@ describe('reduceDaemonEventToTuiUpdates', () => {
               name: 'read_file',
               description: 'Read file',
               status: ToolCallStatus.Success,
-              resultDisplay: fileDiff,
+              resultDisplay: sanitizedFileDiff,
             },
           ],
         },
@@ -499,14 +505,25 @@ describe('reduceDaemonEventToTuiUpdates', () => {
       sessionId: 'session-1',
       toolCall: {
         toolCallId: 'tool-1',
-        title: 'Edit file',
+        title: '\x1b[31mEdit file\x1b[0m',
         kind: 'edit',
         rawInput: {},
       },
       options: [
-        { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+        {
+          optionId: 'proceed_once',
+          kind: 'allow_once',
+          name: '\x1b]0;bad\x07Allow',
+        },
       ],
     } as RequestPermissionRequest & { requestId: string };
+    const sanitizedRequest = {
+      ...request,
+      toolCall: { ...request.toolCall, title: 'Edit file' },
+      options: [
+        { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+      ],
+    };
 
     expect(
       reduceDaemonEventToTuiUpdates({
@@ -519,7 +536,7 @@ describe('reduceDaemonEventToTuiUpdates', () => {
       {
         type: 'permission_request',
         requestId: 'req-1',
-        request,
+        request: sanitizedRequest,
         daemonEventId: 6,
       },
     ]);
@@ -549,6 +566,25 @@ describe('reduceDaemonEventToTuiUpdates', () => {
         v: 1,
         type: 'permission_request',
         data: { requestId: 'req-bad' },
+      }),
+    ).toEqual([]);
+  });
+
+  it('returns no UI updates for unknown daemon event types', () => {
+    expect(
+      reduceDaemonEventToTuiUpdates({
+        id: 99,
+        v: 1,
+        type: 'new_daemon_event',
+        data: {},
+      }),
+    ).toEqual([]);
+    expect(
+      reduceDaemonEventToTuiUpdates({
+        id: 100,
+        v: 1,
+        type: 'new_daemon_event',
+        data: {},
       }),
     ).toEqual([]);
   });
@@ -644,17 +680,24 @@ describe('DaemonTuiAdapter', () => {
     const onUpdate = vi.fn();
     const adapter = new DaemonTuiAdapter({ session, onUpdate });
 
+    adapter.start();
     await adapter.sendPrompt('hello daemon');
-    expect(session.prompt).toHaveBeenCalledWith({
-      prompt: [{ type: 'text', text: 'hello daemon' }],
-    });
+    expect(session.prompt).toHaveBeenCalledWith(
+      {
+        prompt: [{ type: 'text', text: 'hello daemon' }],
+      },
+      expect.any(AbortSignal),
+    );
     expect(onUpdate).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'turn_complete' }),
     );
 
     const blocks: ContentBlock[] = [{ type: 'text', text: 'structured' }];
     await adapter.sendPrompt(blocks);
-    expect(session.prompt).toHaveBeenLastCalledWith({ prompt: blocks });
+    expect(session.prompt).toHaveBeenLastCalledWith(
+      { prompt: blocks },
+      expect.any(AbortSignal),
+    );
 
     await adapter.cancel();
     await adapter.setModel('qwen3-coder-plus');
@@ -670,7 +713,7 @@ describe('DaemonTuiAdapter', () => {
       outcome: { outcome: 'cancelled' },
     });
 
-    events.close();
+    await adapter.stop();
   });
 
   it('reports prompt failures without fabricating turn completion', async () => {
@@ -680,6 +723,7 @@ describe('DaemonTuiAdapter', () => {
     const onUpdate = vi.fn();
     const adapter = new DaemonTuiAdapter({ session, onUpdate });
 
+    adapter.start();
     await expect(adapter.sendPrompt('hello daemon')).rejects.toThrow(
       'daemon down',
     );
@@ -689,6 +733,21 @@ describe('DaemonTuiAdapter', () => {
     });
     expect(onUpdate).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: 'turn_complete' }),
+    );
+
+    events.close();
+  });
+
+  it('requires a running event pump before sending control RPCs', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const adapter = new DaemonTuiAdapter({ session, onUpdate: vi.fn() });
+
+    await expect(adapter.sendPrompt('hello')).rejects.toThrow(
+      'Daemon TUI adapter is not running',
+    );
+    await expect(adapter.cancel()).rejects.toThrow(
+      'Daemon TUI adapter is not running',
     );
 
     events.close();
@@ -707,6 +766,34 @@ describe('DaemonTuiAdapter', () => {
 
     await waitFor(() => expect(session.events).toHaveBeenCalledTimes(2));
     await adapter.stop();
+  });
+
+  it('forces idle when the event pump ignores abort during stop', async () => {
+    vi.useFakeTimers();
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const hangingEvents: AsyncGenerator<DaemonTuiEvent> = {
+      next: vi.fn(() => new Promise<IteratorResult<DaemonTuiEvent>>(() => {})),
+      return: vi.fn(async () => ({ done: true as const, value: undefined })),
+      throw: vi.fn(async (error?: unknown) => {
+        throw error;
+      }),
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+    session.events.mockReturnValue(hangingEvents);
+    const onUpdate = vi.fn();
+    const adapter = new DaemonTuiAdapter({ session, onUpdate });
+
+    adapter.start();
+    const stopPromise = adapter.stop();
+    adapter.start();
+    await vi.advanceTimersByTimeAsync(5_000);
+    await stopPromise;
+
+    expect(session.events).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
   });
 
   it('clears accumulated tool state before each prompt', async () => {
@@ -774,38 +861,61 @@ describe('DaemonTuiAdapter', () => {
   });
 
   it('reports daemon control failures from cancel/model/permission calls', async () => {
-    const events = new EventQueue();
-    const session = createFakeSession(events);
-    const onUpdate = vi.fn();
-    const adapter = new DaemonTuiAdapter({ session, onUpdate });
-
-    session.cancel.mockRejectedValueOnce(
+    const cancelEvents = new EventQueue();
+    const cancelSession = createFakeSession(cancelEvents);
+    const cancelUpdates = vi.fn();
+    const cancelAdapter = new DaemonTuiAdapter({
+      session: cancelSession,
+      onUpdate: cancelUpdates,
+    });
+    cancelAdapter.start();
+    cancelSession.cancel.mockRejectedValueOnce(
       new Error('\x1b[31mcancel down\x1b[0m'),
     );
-    await expect(adapter.cancel()).rejects.toThrow('cancel down');
-    expect(onUpdate).toHaveBeenCalledWith({
+    await expect(cancelAdapter.cancel()).rejects.toThrow('cancel down');
+    expect(cancelUpdates).toHaveBeenCalledWith({
       type: 'disconnected',
       reason: 'cancel down',
     });
 
-    session.setModel.mockRejectedValueOnce(new Error('model down'));
-    await expect(adapter.setModel('qwen3-coder-plus')).rejects.toThrow(
+    const modelEvents = new EventQueue();
+    const modelSession = createFakeSession(modelEvents);
+    const modelUpdates = vi.fn();
+    const modelAdapter = new DaemonTuiAdapter({
+      session: modelSession,
+      onUpdate: modelUpdates,
+    });
+    modelAdapter.start();
+    modelSession.setModel.mockRejectedValueOnce(new Error('model down'));
+    await expect(modelAdapter.setModel('qwen3-coder-plus')).rejects.toThrow(
       'model down',
     );
-    expect(onUpdate).toHaveBeenCalledWith({
+    expect(modelUpdates).toHaveBeenCalledWith({
       type: 'disconnected',
       reason: 'model down',
     });
 
-    session.respondToPermission.mockRejectedValueOnce(new Error('vote down'));
+    const voteEvents = new EventQueue();
+    const voteSession = createFakeSession(voteEvents);
+    const voteUpdates = vi.fn();
+    const voteAdapter = new DaemonTuiAdapter({
+      session: voteSession,
+      onUpdate: voteUpdates,
+    });
+    voteAdapter.start();
+    voteSession.respondToPermission.mockRejectedValueOnce(
+      new Error('vote down'),
+    );
     await expect(
-      adapter.approvePermission('req-1', 'proceed_once'),
+      voteAdapter.approvePermission('req-1', 'proceed_once'),
     ).rejects.toThrow('vote down');
-    expect(onUpdate).toHaveBeenCalledWith({
+    expect(voteUpdates).toHaveBeenCalledWith({
       type: 'disconnected',
       reason: 'vote down',
     });
 
-    events.close();
+    cancelEvents.close();
+    modelEvents.close();
+    voteEvents.close();
   });
 });

--- a/packages/cli/src/ui/daemon/DaemonTuiAdapter.test.ts
+++ b/packages/cli/src/ui/daemon/DaemonTuiAdapter.test.ts
@@ -524,4 +524,25 @@ describe('DaemonTuiAdapter', () => {
 
     events.close();
   });
+
+  it('reports prompt failures without fabricating turn completion', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    session.prompt.mockRejectedValue(new Error('\x1b[31mdaemon down\x1b[0m'));
+    const onUpdate = vi.fn();
+    const adapter = new DaemonTuiAdapter({ session, onUpdate });
+
+    await expect(adapter.sendPrompt('hello daemon')).rejects.toThrow(
+      'daemon down',
+    );
+    expect(onUpdate).toHaveBeenCalledWith({
+      type: 'disconnected',
+      reason: 'daemon down',
+    });
+    expect(onUpdate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'turn_complete' }),
+    );
+
+    events.close();
+  });
 });

--- a/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
+++ b/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
@@ -9,6 +9,7 @@ import type {
   RequestPermissionRequest,
   RequestPermissionResponse,
 } from '@agentclientprotocol/sdk';
+import { createDebugLogger } from '@qwen-code/qwen-code-core';
 import {
   ToolCallStatus,
   type HistoryItemToolGroup,
@@ -104,12 +105,19 @@ function clearDaemonTuiReducerState(state: DaemonTuiReducerState): void {
 }
 
 const MAX_TOOL_CALLS = 128;
+const MAX_PLAN_ENTRIES = 200;
 const MAX_DISPLAY_TEXT_LENGTH = 20_000;
+const STOP_TIMEOUT_MS = 5_000;
 const ESC = String.fromCharCode(27);
 const OSC_RE = new RegExp(`${ESC}\\][\\s\\S]*?(?:\\x07|${ESC}\\\\)`, 'g');
-const DCS_RE = new RegExp(`${ESC}[P^_][\\s\\S]*?${ESC}\\\\`, 'g');
+const DCS_RE = new RegExp(`${ESC}[PX^_][\\s\\S]*?${ESC}\\\\`, 'g');
 const CSI_RE = new RegExp(`${ESC}\\[[0-?]*[ -/]*[@-~]`, 'g');
 const C1_RE = new RegExp(`${ESC}[@-Z\\\\-_]`, 'g');
+const C1_CSI_RE = /\x9b[0-?]*[ -/]*[@-~]/g;
+const C1_STRING_RE = /[\x90\x98\x9e\x9f][\s\S]*?\x9c/g;
+const BIDI_CONTROL_RE = /[\u200e\u200f\u202a-\u202e\u2066-\u2069]/g;
+const UNKNOWN_EVENT_TYPES = new Set<string>();
+const debugLogger = createDebugLogger('DAEMON_TUI_ADAPTER');
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -138,6 +146,7 @@ function formatPlan(entries: unknown): string | undefined {
     return undefined;
   }
   const lines = entries
+    .slice(0, MAX_PLAN_ENTRIES)
     .filter(isRecord)
     .map((entry, index) => {
       const content = getString(entry['content']) ?? '';
@@ -176,7 +185,7 @@ function sanitizeReason(reason: string): string {
   let sanitized = '';
   for (const char of withoutAnsi) {
     const code = char.charCodeAt(0);
-    if ((code < 32 && code !== 10) || code === 127) {
+    if ((code < 32 && code !== 10) || code === 127 || isC1Control(code)) {
       continue;
     }
     sanitized += char;
@@ -193,8 +202,9 @@ function sanitizeDisplayText(text: string): string {
   for (const char of stripped) {
     const code = char.charCodeAt(0);
     if (
-      (code < 32 && code !== 9 && code !== 10 && code !== 13) ||
-      code === 127
+      (code < 32 && code !== 9 && code !== 10) ||
+      code === 127 ||
+      isC1Control(code)
     ) {
       continue;
     }
@@ -208,10 +218,42 @@ function sanitizeDisplayText(text: string): string {
 
 function stripControlSequences(value: string): string {
   return value
+    .replace(BIDI_CONTROL_RE, '')
     .replace(OSC_RE, '')
     .replace(DCS_RE, '')
+    .replace(C1_STRING_RE, '')
+    .replace(C1_CSI_RE, '')
     .replace(CSI_RE, '')
     .replace(C1_RE, '');
+}
+
+function isC1Control(code: number): boolean {
+  return code >= 0x80 && code <= 0x9f;
+}
+
+function sanitizeDaemonValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return sanitizeDisplayText(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeDaemonValue(item));
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entryValue]) => [
+        key,
+        sanitizeDaemonValue(entryValue),
+      ]),
+    );
+  }
+  return value;
+}
+
+function createSanitizedDaemonError(error: unknown): Error {
+  const message = sanitizeReason(
+    error instanceof Error ? error.message : String(error),
+  );
+  return new Error(`Daemon RPC failed: ${message}`);
 }
 
 function formatToolResultDisplay(
@@ -232,7 +274,9 @@ function formatToolResultDisplay(
       value['type'] === 'task_execution' ||
       value['type'] === 'mcp_tool_progress')
   ) {
-    return value as unknown as IndividualToolCallDisplay['resultDisplay'];
+    return sanitizeDaemonValue(
+      value,
+    ) as IndividualToolCallDisplay['resultDisplay'];
   }
   try {
     return sanitizeDisplayText(JSON.stringify(value));
@@ -309,7 +353,7 @@ function toolUpdateToHistoryItem(
       safeTitle ?? safeKind ?? previous?.description ?? safeToolCallId,
     resultDisplay: rawOutput ?? contentOutput ?? previous?.resultDisplay,
     status:
-      update['status'] === undefined
+      update['status'] == null
         ? (previous?.status ?? ToolCallStatus.Pending)
         : mapToolStatus(update['status']),
     // Confirmation UI is driven by daemon permission_request events. The
@@ -342,9 +386,49 @@ function isPermissionRequestData(
   return (
     isRecord(value) &&
     typeof value['requestId'] === 'string' &&
+    typeof value['sessionId'] === 'string' &&
     isRecord(value['toolCall']) &&
-    Array.isArray(value['options'])
+    typeof value['toolCall']['toolCallId'] === 'string' &&
+    typeof value['toolCall']['kind'] === 'string' &&
+    Array.isArray(value['options']) &&
+    value['options'].every(
+      (option) => isRecord(option) && typeof option['optionId'] === 'string',
+    )
   );
+}
+
+function sanitizePermissionRequest(
+  request: RequestPermissionRequest & { requestId: string },
+): RequestPermissionRequest & { requestId: string } {
+  const sanitizedToolCall = sanitizeDaemonValue(
+    request.toolCall,
+  ) as typeof request.toolCall;
+  return {
+    ...request,
+    toolCall: {
+      ...sanitizedToolCall,
+      toolCallId: request.toolCall.toolCallId,
+    },
+    options: request.options.map((option) => ({
+      ...option,
+      name:
+        typeof option.name === 'string'
+          ? sanitizeDisplayText(option.name)
+          : option.name,
+    })),
+  };
+}
+
+function warnUnknownEventTypeOnce(event: DaemonTuiEvent): void {
+  const eventType = sanitizeDisplayText(event.type);
+  if (UNKNOWN_EVENT_TYPES.has(eventType)) {
+    return;
+  }
+  UNKNOWN_EVENT_TYPES.add(eventType);
+  debugLogger.warn('[DaemonTuiAdapter] Unknown daemon event type:', {
+    eventType,
+    eventId: event.id,
+  });
 }
 
 export function reduceDaemonEventToTuiUpdates(
@@ -414,11 +498,12 @@ export function reduceDaemonEventToTuiUpdates(
       if (!isPermissionRequestData(event.data)) {
         return [];
       }
+      const request = sanitizePermissionRequest(event.data);
       return [
         {
           type: 'permission_request',
-          requestId: event.data['requestId'],
-          request: event.data,
+          requestId: request.requestId,
+          request,
           daemonEventId: event.id,
         },
       ];
@@ -488,6 +573,7 @@ export function reduceDaemonEventToTuiUpdates(
     }
 
     default:
+      warnUnknownEventTypeOnce(event);
       return [];
   }
 }
@@ -501,6 +587,8 @@ export class DaemonTuiAdapter {
   private lastSeenEventId: number | undefined;
   private lifecycle: 'idle' | 'running' | 'stopping' = 'idle';
   private restartAfterStop = false;
+  private pumpGeneration = 0;
+  private busy = false;
 
   constructor(options: DaemonTuiAdapterOptions) {
     this.session = options.session;
@@ -522,7 +610,8 @@ export class DaemonTuiAdapter {
   private startPump(): void {
     this.eventController = new AbortController();
     this.lifecycle = 'running';
-    this.eventPump = this.pumpEvents(this.eventController.signal);
+    const generation = ++this.pumpGeneration;
+    this.eventPump = this.pumpEvents(this.eventController.signal, generation);
   }
 
   async stop(): Promise<void> {
@@ -533,7 +622,13 @@ export class DaemonTuiAdapter {
     this.eventController?.abort();
     if (this.eventPump) {
       try {
-        await this.eventPump;
+        const drained = await this.waitForPumpToDrain(this.eventPump);
+        if (!drained && this.lifecycle === 'stopping') {
+          debugLogger.error(
+            '[DaemonTuiAdapter] Event pump did not drain within timeout; forcing idle',
+          );
+          this.forceIdleAfterPumpTimeout();
+        }
       } catch {
         /* pump errors are converted into updates */
       }
@@ -543,34 +638,49 @@ export class DaemonTuiAdapter {
   async sendPrompt(
     prompt: string | ContentBlock[],
   ): Promise<DaemonTuiPromptResult> {
+    this.assertRunning();
+    if (this.busy) {
+      throw new Error('A prompt is already in progress');
+    }
+    this.busy = true;
     clearDaemonTuiReducerState(this.reducerState);
     const promptBlocks =
       typeof prompt === 'string'
         ? ([{ type: 'text', text: prompt }] as ContentBlock[])
         : prompt;
     try {
-      return await this.session.prompt({ prompt: promptBlocks });
+      const result = await this.session.prompt(
+        { prompt: promptBlocks },
+        this.eventController?.signal,
+      );
+      return typeof result.stopReason === 'string'
+        ? { ...result, stopReason: sanitizeReason(result.stopReason) }
+        : result;
     } catch (error) {
       this.reportDaemonFailure(error);
-      throw error;
+      throw createSanitizedDaemonError(error);
+    } finally {
+      this.busy = false;
     }
   }
 
   async cancel(): Promise<void> {
+    this.assertRunning();
     try {
       await this.session.cancel();
     } catch (error) {
       this.reportDaemonFailure(error);
-      throw error;
+      throw createSanitizedDaemonError(error);
     }
   }
 
   async setModel(modelId: string): Promise<Record<string, unknown>> {
+    this.assertRunning();
     try {
       return await this.session.setModel(modelId);
     } catch (error) {
       this.reportDaemonFailure(error);
-      throw error;
+      throw createSanitizedDaemonError(error);
     }
   }
 
@@ -578,24 +688,26 @@ export class DaemonTuiAdapter {
     requestId: string,
     optionId: string,
   ): Promise<boolean> {
+    this.assertRunning();
     try {
       return await this.session.respondToPermission(requestId, {
         outcome: { outcome: 'selected', optionId },
       });
     } catch (error) {
       this.reportDaemonFailure(error);
-      throw error;
+      throw createSanitizedDaemonError(error);
     }
   }
 
   async rejectPermission(requestId: string): Promise<boolean> {
+    this.assertRunning();
     try {
       return await this.session.respondToPermission(requestId, {
         outcome: { outcome: 'cancelled' },
       });
     } catch (error) {
       this.reportDaemonFailure(error);
-      throw error;
+      throw createSanitizedDaemonError(error);
     }
   }
 
@@ -611,7 +723,10 @@ export class DaemonTuiAdapter {
     return this.lastSeenEventId ?? this.session.lastEventId;
   }
 
-  private async pumpEvents(signal: AbortSignal): Promise<void> {
+  private async pumpEvents(
+    signal: AbortSignal,
+    generation: number,
+  ): Promise<void> {
     try {
       const resumeId = this.lastSeenEventId ?? this.session.lastEventId;
       for await (const event of this.session.events({
@@ -619,6 +734,22 @@ export class DaemonTuiAdapter {
         lastEventId: resumeId,
         resume: true,
       })) {
+        if (signal.aborted) {
+          break;
+        }
+        if ((event as { v?: unknown }).v !== 1) {
+          this.emit({
+            type: 'history',
+            item: {
+              type: 'error',
+              text: `Unsupported daemon protocol version: ${sanitizeDisplayText(
+                String((event as { v?: unknown }).v),
+              )}`,
+            },
+            daemonEventId: event.id,
+          });
+          continue;
+        }
         if (event.id !== undefined) {
           this.lastSeenEventId = event.id;
         }
@@ -634,6 +765,10 @@ export class DaemonTuiAdapter {
           type: 'disconnected',
           reason: 'event stream ended',
         });
+        this.emit({
+          type: 'history',
+          item: { type: 'info', text: 'Daemon event stream ended' },
+        });
       }
     } catch (error) {
       if (!signal.aborted) {
@@ -643,13 +778,15 @@ export class DaemonTuiAdapter {
         this.emit({ type: 'disconnected', reason: message });
       }
     } finally {
-      this.eventController = null;
-      this.eventPump = null;
-      const shouldRestart = this.restartAfterStop;
-      this.restartAfterStop = false;
-      this.lifecycle = 'idle';
-      if (shouldRestart) {
-        this.start();
+      if (this.pumpGeneration === generation) {
+        this.eventController = null;
+        this.eventPump = null;
+        const shouldRestart = this.restartAfterStop;
+        this.restartAfterStop = false;
+        this.lifecycle = 'idle';
+        if (shouldRestart) {
+          this.start();
+        }
       }
     }
   }
@@ -670,6 +807,41 @@ export class DaemonTuiAdapter {
       this.onUpdate(update);
     } catch {
       /* isolate renderer callback failures from the daemon event pump */
+    }
+  }
+
+  private assertRunning(): void {
+    if (this.lifecycle !== 'running') {
+      throw new Error('Daemon TUI adapter is not running');
+    }
+  }
+
+  private async waitForPumpToDrain(pump: Promise<void>): Promise<boolean> {
+    let timedOut = false;
+    await Promise.race([
+      pump.then(
+        () => undefined,
+        () => undefined,
+      ),
+      new Promise<void>((resolve) => {
+        setTimeout(() => {
+          timedOut = true;
+          resolve();
+        }, STOP_TIMEOUT_MS);
+      }),
+    ]);
+    return !timedOut;
+  }
+
+  private forceIdleAfterPumpTimeout(): void {
+    this.pumpGeneration += 1;
+    const shouldRestart = this.restartAfterStop;
+    this.restartAfterStop = false;
+    this.eventController = null;
+    this.eventPump = null;
+    this.lifecycle = 'idle';
+    if (shouldRestart) {
+      this.start();
     }
   }
 }

--- a/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
+++ b/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
@@ -208,6 +208,47 @@ function formatToolResultDisplay(
   }
 }
 
+function formatToolContentText(value: unknown): string | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const parts = value
+    .map((item) => {
+      if (!isRecord(item)) {
+        return undefined;
+      }
+      const content = item['content'];
+      if (isRecord(content)) {
+        return getString(content['text']);
+      }
+      return getString(item['text']);
+    })
+    .filter((part): part is string => part !== undefined && part.length > 0);
+  return parts.length > 0 ? parts.join('\n') : undefined;
+}
+
+function terminalUpdates(
+  event: DaemonTuiEvent,
+  reason: string,
+): DaemonTuiUpdate[] {
+  const sanitizedReason = sanitizeReason(reason);
+  return [
+    {
+      type: 'disconnected',
+      reason: sanitizedReason,
+      daemonEventId: event.id,
+    },
+    {
+      type: 'history',
+      item: {
+        type: 'error',
+        text: `Daemon session disconnected: ${sanitizedReason}`,
+      },
+      daemonEventId: event.id,
+    },
+  ];
+}
+
 function toolUpdateToHistoryItem(
   update: Record<string, unknown>,
   state?: DaemonTuiReducerState,
@@ -220,12 +261,13 @@ function toolUpdateToHistoryItem(
   const title = getString(update['title']);
   const kind = getString(update['kind']);
   const rawOutput = formatToolResultDisplay(update['rawOutput']);
+  const contentOutput = formatToolContentText(update['content']);
   const previous = state?.toolCallsById.get(toolCallId);
   const tool: IndividualToolCallDisplay = {
     callId: toolCallId,
     name: kind ?? title ?? previous?.name ?? toolCallId,
     description: title ?? kind ?? previous?.description ?? toolCallId,
-    resultDisplay: rawOutput ?? previous?.resultDisplay,
+    resultDisplay: rawOutput ?? contentOutput ?? previous?.resultDisplay,
     status:
       update['status'] === undefined
         ? (previous?.status ?? ToolCallStatus.Pending)
@@ -367,22 +409,27 @@ export function reduceDaemonEventToTuiUpdates(
     }
 
     case 'session_died': {
-      const reason = sanitizeReason(
+      const reason =
         isRecord(event.data) && typeof event.data['reason'] === 'string'
           ? event.data['reason']
-          : 'session_died',
-      );
-      return [
-        { type: 'disconnected', reason, daemonEventId: event.id },
-        {
-          type: 'history',
-          item: {
-            type: 'error',
-            text: `Daemon session disconnected: ${reason}`,
-          },
-          daemonEventId: event.id,
-        },
-      ];
+          : 'session_died';
+      return terminalUpdates(event, reason);
+    }
+
+    case 'client_evicted': {
+      const reason =
+        isRecord(event.data) && typeof event.data['reason'] === 'string'
+          ? event.data['reason']
+          : 'client_evicted';
+      return terminalUpdates(event, reason);
+    }
+
+    case 'stream_error': {
+      const reason =
+        isRecord(event.data) && typeof event.data['error'] === 'string'
+          ? event.data['error']
+          : 'stream_error';
+      return terminalUpdates(event, reason);
     }
 
     default:

--- a/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
+++ b/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
@@ -432,7 +432,17 @@ export class DaemonTuiAdapter {
       typeof prompt === 'string'
         ? ([{ type: 'text', text: prompt }] as ContentBlock[])
         : prompt;
-    return await this.session.prompt({ prompt: promptBlocks });
+    try {
+      return await this.session.prompt({ prompt: promptBlocks });
+    } catch (error) {
+      this.onUpdate({
+        type: 'disconnected',
+        reason: sanitizeReason(
+          error instanceof Error ? error.message : String(error),
+        ),
+      });
+      throw error;
+    }
   }
 
   async cancel(): Promise<void> {

--- a/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
+++ b/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
@@ -79,10 +79,6 @@ export type DaemonTuiUpdate =
       daemonEventId?: number;
     }
   | {
-      type: 'turn_complete';
-      stopReason?: string;
-    }
-  | {
       type: 'disconnected';
       reason: string;
       daemonEventId?: number;
@@ -95,11 +91,25 @@ export interface DaemonTuiAdapterOptions {
 
 export interface DaemonTuiReducerState {
   toolCallsById: Map<string, IndividualToolCallDisplay>;
+  toolCallOrder: string[];
 }
 
 export function createDaemonTuiReducerState(): DaemonTuiReducerState {
-  return { toolCallsById: new Map() };
+  return { toolCallsById: new Map(), toolCallOrder: [] };
 }
+
+function clearDaemonTuiReducerState(state: DaemonTuiReducerState): void {
+  state.toolCallsById.clear();
+  state.toolCallOrder.length = 0;
+}
+
+const MAX_TOOL_CALLS = 128;
+const MAX_DISPLAY_TEXT_LENGTH = 20_000;
+const ESC = String.fromCharCode(27);
+const OSC_RE = new RegExp(`${ESC}\\][\\s\\S]*?(?:\\x07|${ESC}\\\\)`, 'g');
+const DCS_RE = new RegExp(`${ESC}[P^_][\\s\\S]*?${ESC}\\\\`, 'g');
+const CSI_RE = new RegExp(`${ESC}\\[[0-?]*[ -/]*[@-~]`, 'g');
+const C1_RE = new RegExp(`${ESC}[@-Z\\\\-_]`, 'g');
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
@@ -132,7 +142,7 @@ function formatPlan(entries: unknown): string | undefined {
     .map((entry, index) => {
       const content = getString(entry['content']) ?? '';
       const status = getString(entry['status']) ?? 'pending';
-      return `${index + 1}. [${status}] ${content}`;
+      return `${index + 1}. [${sanitizeDisplayText(status)}] ${sanitizeDisplayText(content)}`;
     })
     .filter((line) => line.trim().length > 0);
   return lines.length > 0 ? lines.join('\n') : undefined;
@@ -162,11 +172,7 @@ function mapToolStatus(status: unknown): ToolCallStatus {
 }
 
 function sanitizeReason(reason: string): string {
-  const esc = String.fromCharCode(27);
-  const withoutAnsi = reason.replace(
-    new RegExp(`${esc}\\[[0-9;?]*[ -/]*[@-~]`, 'g'),
-    '',
-  );
+  const withoutAnsi = stripControlSequences(reason);
   let sanitized = '';
   for (const char of withoutAnsi) {
     const code = char.charCodeAt(0);
@@ -181,6 +187,33 @@ function sanitizeReason(reason: string): string {
   return sanitized;
 }
 
+function sanitizeDisplayText(text: string): string {
+  const stripped = stripControlSequences(text);
+  let sanitized = '';
+  for (const char of stripped) {
+    const code = char.charCodeAt(0);
+    if (
+      (code < 32 && code !== 9 && code !== 10 && code !== 13) ||
+      code === 127
+    ) {
+      continue;
+    }
+    sanitized += char;
+    if (sanitized.length >= MAX_DISPLAY_TEXT_LENGTH) {
+      break;
+    }
+  }
+  return sanitized;
+}
+
+function stripControlSequences(value: string): string {
+  return value
+    .replace(OSC_RE, '')
+    .replace(DCS_RE, '')
+    .replace(CSI_RE, '')
+    .replace(C1_RE, '');
+}
+
 function formatToolResultDisplay(
   value: unknown,
 ): IndividualToolCallDisplay['resultDisplay'] {
@@ -188,7 +221,7 @@ function formatToolResultDisplay(
     return undefined;
   }
   if (typeof value === 'string') {
-    return value;
+    return sanitizeDisplayText(value);
   }
   if (
     isRecord(value) &&
@@ -202,9 +235,9 @@ function formatToolResultDisplay(
     return value as unknown as IndividualToolCallDisplay['resultDisplay'];
   }
   try {
-    return JSON.stringify(value);
+    return sanitizeDisplayText(JSON.stringify(value));
   } catch {
-    return String(value);
+    return sanitizeDisplayText(String(value));
   }
 }
 
@@ -219,9 +252,11 @@ function formatToolContentText(value: unknown): string | undefined {
       }
       const content = item['content'];
       if (isRecord(content)) {
-        return getString(content['text']);
+        const text = getString(content['text']);
+        return text === undefined ? undefined : sanitizeDisplayText(text);
       }
-      return getString(item['text']);
+      const text = getString(item['text']);
+      return text === undefined ? undefined : sanitizeDisplayText(text);
     })
     .filter((part): part is string => part !== undefined && part.length > 0);
   return parts.length > 0 ? parts.join('\n') : undefined;
@@ -260,13 +295,18 @@ function toolUpdateToHistoryItem(
 
   const title = getString(update['title']);
   const kind = getString(update['kind']);
+  const safeToolCallId = sanitizeDisplayText(toolCallId);
+  const safeTitle =
+    title === undefined ? undefined : sanitizeDisplayText(title);
+  const safeKind = kind === undefined ? undefined : sanitizeDisplayText(kind);
   const rawOutput = formatToolResultDisplay(update['rawOutput']);
   const contentOutput = formatToolContentText(update['content']);
   const previous = state?.toolCallsById.get(toolCallId);
   const tool: IndividualToolCallDisplay = {
-    callId: toolCallId,
-    name: kind ?? title ?? previous?.name ?? toolCallId,
-    description: title ?? kind ?? previous?.description ?? toolCallId,
+    callId: safeToolCallId,
+    name: safeKind ?? safeTitle ?? previous?.name ?? safeToolCallId,
+    description:
+      safeTitle ?? safeKind ?? previous?.description ?? safeToolCallId,
     resultDisplay: rawOutput ?? contentOutput ?? previous?.resultDisplay,
     status:
       update['status'] === undefined
@@ -278,7 +318,18 @@ function toolUpdateToHistoryItem(
     confirmationDetails: previous?.confirmationDetails,
   };
 
+  if (state && !state.toolCallsById.has(toolCallId)) {
+    state.toolCallOrder.push(toolCallId);
+  }
   state?.toolCallsById.set(toolCallId, tool);
+  if (state) {
+    while (state.toolCallOrder.length > MAX_TOOL_CALLS) {
+      const oldest = state.toolCallOrder.shift();
+      if (oldest !== undefined) {
+        state.toolCallsById.delete(oldest);
+      }
+    }
+  }
   return {
     type: 'tool_group',
     tools: Array.from(state?.toolCallsById.values() ?? [tool]),
@@ -314,7 +365,7 @@ export function reduceDaemonEventToTuiUpdates(
         return [
           {
             type: 'history',
-            item: { type: 'gemini_content', text },
+            item: { type: 'gemini_content', text: sanitizeDisplayText(text) },
             daemonEventId: event.id,
           },
         ];
@@ -324,7 +375,10 @@ export function reduceDaemonEventToTuiUpdates(
         return [
           {
             type: 'history',
-            item: { type: 'gemini_thought_content', text },
+            item: {
+              type: 'gemini_thought_content',
+              text: sanitizeDisplayText(text),
+            },
             daemonEventId: event.id,
           },
         ];
@@ -391,17 +445,18 @@ export function reduceDaemonEventToTuiUpdates(
       if (!isRecord(event.data) || typeof event.data['modelId'] !== 'string') {
         return [];
       }
+      const modelId = sanitizeDisplayText(event.data['modelId']);
       return [
         {
           type: 'model_switched',
-          modelId: event.data['modelId'],
+          modelId,
           daemonEventId: event.id,
         },
         {
           type: 'history',
           item: {
             type: 'info',
-            text: `Model switched to ${event.data['modelId']}`,
+            text: `Model switched to ${modelId}`,
           },
           daemonEventId: event.id,
         },
@@ -444,6 +499,8 @@ export class DaemonTuiAdapter {
   private eventController: AbortController | null = null;
   private eventPump: Promise<void> | null = null;
   private lastSeenEventId: number | undefined;
+  private lifecycle: 'idle' | 'running' | 'stopping' = 'idle';
+  private restartAfterStop = false;
 
   constructor(options: DaemonTuiAdapterOptions) {
     this.session = options.session;
@@ -452,14 +509,27 @@ export class DaemonTuiAdapter {
   }
 
   start(): void {
-    if (this.eventPump) {
+    if (this.lifecycle === 'running') {
       return;
     }
+    if (this.lifecycle === 'stopping') {
+      this.restartAfterStop = true;
+      return;
+    }
+    this.startPump();
+  }
+
+  private startPump(): void {
     this.eventController = new AbortController();
+    this.lifecycle = 'running';
     this.eventPump = this.pumpEvents(this.eventController.signal);
   }
 
   async stop(): Promise<void> {
+    if (this.lifecycle === 'idle') {
+      return;
+    }
+    this.lifecycle = 'stopping';
     this.eventController?.abort();
     if (this.eventPump) {
       try {
@@ -468,13 +538,12 @@ export class DaemonTuiAdapter {
         /* pump errors are converted into updates */
       }
     }
-    this.eventController = null;
-    this.eventPump = null;
   }
 
   async sendPrompt(
     prompt: string | ContentBlock[],
   ): Promise<DaemonTuiPromptResult> {
+    clearDaemonTuiReducerState(this.reducerState);
     const promptBlocks =
       typeof prompt === 'string'
         ? ([{ type: 'text', text: prompt }] as ContentBlock[])
@@ -482,37 +551,52 @@ export class DaemonTuiAdapter {
     try {
       return await this.session.prompt({ prompt: promptBlocks });
     } catch (error) {
-      this.onUpdate({
-        type: 'disconnected',
-        reason: sanitizeReason(
-          error instanceof Error ? error.message : String(error),
-        ),
-      });
+      this.reportDaemonFailure(error);
       throw error;
     }
   }
 
   async cancel(): Promise<void> {
-    await this.session.cancel();
+    try {
+      await this.session.cancel();
+    } catch (error) {
+      this.reportDaemonFailure(error);
+      throw error;
+    }
   }
 
   async setModel(modelId: string): Promise<Record<string, unknown>> {
-    return await this.session.setModel(modelId);
+    try {
+      return await this.session.setModel(modelId);
+    } catch (error) {
+      this.reportDaemonFailure(error);
+      throw error;
+    }
   }
 
   async approvePermission(
     requestId: string,
     optionId: string,
   ): Promise<boolean> {
-    return await this.session.respondToPermission(requestId, {
-      outcome: { outcome: 'selected', optionId },
-    });
+    try {
+      return await this.session.respondToPermission(requestId, {
+        outcome: { outcome: 'selected', optionId },
+      });
+    } catch (error) {
+      this.reportDaemonFailure(error);
+      throw error;
+    }
   }
 
   async rejectPermission(requestId: string): Promise<boolean> {
-    return await this.session.respondToPermission(requestId, {
-      outcome: { outcome: 'cancelled' },
-    });
+    try {
+      return await this.session.respondToPermission(requestId, {
+        outcome: { outcome: 'cancelled' },
+      });
+    } catch (error) {
+      this.reportDaemonFailure(error);
+      throw error;
+    }
   }
 
   get currentSessionId(): string {
@@ -535,18 +619,18 @@ export class DaemonTuiAdapter {
         lastEventId: resumeId,
         resume: true,
       })) {
+        if (event.id !== undefined) {
+          this.lastSeenEventId = event.id;
+        }
         for (const update of reduceDaemonEventToTuiUpdates(
           event,
           this.reducerState,
         )) {
-          this.onUpdate(update);
-        }
-        if (event.id !== undefined) {
-          this.lastSeenEventId = event.id;
+          this.emit(update);
         }
       }
       if (!signal.aborted) {
-        this.onUpdate({
+        this.emit({
           type: 'disconnected',
           reason: 'event stream ended',
         });
@@ -556,11 +640,36 @@ export class DaemonTuiAdapter {
         const message = sanitizeReason(
           error instanceof Error ? error.message : String(error),
         );
-        this.onUpdate({ type: 'disconnected', reason: message });
+        this.emit({ type: 'disconnected', reason: message });
       }
     } finally {
       this.eventController = null;
       this.eventPump = null;
+      const shouldRestart = this.restartAfterStop;
+      this.restartAfterStop = false;
+      this.lifecycle = 'idle';
+      if (shouldRestart) {
+        this.start();
+      }
+    }
+  }
+
+  private reportDaemonFailure(error: unknown): void {
+    if (this.lifecycle === 'running') {
+      this.lifecycle = 'stopping';
+      this.eventController?.abort();
+    }
+    const message = sanitizeReason(
+      error instanceof Error ? error.message : String(error),
+    );
+    this.emit({ type: 'disconnected', reason: message });
+  }
+
+  private emit(update: DaemonTuiUpdate): void {
+    try {
+      this.onUpdate(update);
+    } catch {
+      /* isolate renderer callback failures from the daemon event pump */
     }
   }
 }

--- a/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
+++ b/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
@@ -107,6 +107,8 @@ function clearDaemonTuiReducerState(state: DaemonTuiReducerState): void {
 const MAX_TOOL_CALLS = 128;
 const MAX_PLAN_ENTRIES = 200;
 const MAX_DISPLAY_TEXT_LENGTH = 20_000;
+const MAX_UNKNOWN_EVENT_TYPES = 100;
+const MAX_UNSUPPORTED_PROTOCOL_VERSIONS = 20;
 const STOP_TIMEOUT_MS = 5_000;
 const ESC = String.fromCharCode(27);
 const OSC_RE = new RegExp(`${ESC}\\][\\s\\S]*?(?:\\x07|${ESC}\\\\)`, 'g');
@@ -117,6 +119,7 @@ const C1_CSI_RE = /\x9b[0-?]*[ -/]*[@-~]/g;
 const C1_STRING_RE = /[\x90\x98\x9e\x9f][\s\S]*?\x9c/g;
 const BIDI_CONTROL_RE = /[\u200e\u200f\u202a-\u202e\u2066-\u2069]/g;
 const UNKNOWN_EVENT_TYPES = new Set<string>();
+const UNSUPPORTED_PROTOCOL_VERSIONS = new Set<string>();
 const debugLogger = createDebugLogger('DAEMON_TUI_ADAPTER');
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -419,9 +422,26 @@ function sanitizePermissionRequest(
   };
 }
 
+function sanitizePermissionOutcome(value: unknown): unknown | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const outcome = value['outcome'];
+  if (outcome === 'cancelled') {
+    return { outcome };
+  }
+  if (outcome === 'selected' && typeof value['optionId'] === 'string') {
+    return { outcome, optionId: sanitizeDisplayText(value['optionId']) };
+  }
+  return undefined;
+}
+
 function warnUnknownEventTypeOnce(event: DaemonTuiEvent): void {
   const eventType = sanitizeDisplayText(event.type);
   if (UNKNOWN_EVENT_TYPES.has(eventType)) {
+    return;
+  }
+  if (UNKNOWN_EVENT_TYPES.size >= MAX_UNKNOWN_EVENT_TYPES) {
     return;
   }
   UNKNOWN_EVENT_TYPES.add(eventType);
@@ -429,6 +449,18 @@ function warnUnknownEventTypeOnce(event: DaemonTuiEvent): void {
     eventType,
     eventId: event.id,
   });
+}
+
+function shouldReportUnsupportedProtocolVersion(version: unknown): boolean {
+  const sanitizedVersion = sanitizeDisplayText(String(version));
+  if (UNSUPPORTED_PROTOCOL_VERSIONS.has(sanitizedVersion)) {
+    return false;
+  }
+  if (UNSUPPORTED_PROTOCOL_VERSIONS.size >= MAX_UNSUPPORTED_PROTOCOL_VERSIONS) {
+    return false;
+  }
+  UNSUPPORTED_PROTOCOL_VERSIONS.add(sanitizedVersion);
+  return true;
 }
 
 export function reduceDaemonEventToTuiUpdates(
@@ -516,11 +548,12 @@ export function reduceDaemonEventToTuiUpdates(
       ) {
         return [];
       }
+      const outcome = sanitizePermissionOutcome(event.data['outcome']);
       return [
         {
           type: 'permission_resolved',
           requestId: event.data['requestId'],
-          outcome: event.data['outcome'],
+          outcome,
           daemonEventId: event.id,
         },
       ];
@@ -657,7 +690,7 @@ export class DaemonTuiAdapter {
         ? { ...result, stopReason: sanitizeReason(result.stopReason) }
         : result;
     } catch (error) {
-      this.reportDaemonFailure(error);
+      this.reportDaemonFailure(error, { disconnect: true });
       throw createSanitizedDaemonError(error);
     } finally {
       this.busy = false;
@@ -737,7 +770,17 @@ export class DaemonTuiAdapter {
         if (signal.aborted) {
           break;
         }
+        if (event.id !== undefined) {
+          this.lastSeenEventId = event.id;
+        }
         if ((event as { v?: unknown }).v !== 1) {
+          if (
+            !shouldReportUnsupportedProtocolVersion(
+              (event as { v?: unknown }).v,
+            )
+          ) {
+            continue;
+          }
           this.emit({
             type: 'history',
             item: {
@@ -749,9 +792,6 @@ export class DaemonTuiAdapter {
             daemonEventId: event.id,
           });
           continue;
-        }
-        if (event.id !== undefined) {
-          this.lastSeenEventId = event.id;
         }
         for (const update of reduceDaemonEventToTuiUpdates(
           event,
@@ -791,15 +831,23 @@ export class DaemonTuiAdapter {
     }
   }
 
-  private reportDaemonFailure(error: unknown): void {
-    if (this.lifecycle === 'running') {
-      this.lifecycle = 'stopping';
-      this.eventController?.abort();
-    }
+  private reportDaemonFailure(
+    error: unknown,
+    options: { disconnect?: boolean } = {},
+  ): void {
     const message = sanitizeReason(
       error instanceof Error ? error.message : String(error),
     );
-    this.emit({ type: 'disconnected', reason: message });
+    if (options.disconnect && this.lifecycle === 'running') {
+      this.lifecycle = 'stopping';
+      this.eventController?.abort();
+      this.emit({ type: 'disconnected', reason: message });
+      return;
+    }
+    this.emit({
+      type: 'history',
+      item: { type: 'error', text: `Daemon RPC failed: ${message}` },
+    });
   }
 
   private emit(update: DaemonTuiUpdate): void {
@@ -818,22 +866,32 @@ export class DaemonTuiAdapter {
 
   private async waitForPumpToDrain(pump: Promise<void>): Promise<boolean> {
     let timedOut = false;
-    await Promise.race([
-      pump.then(
-        () => undefined,
-        () => undefined,
-      ),
-      new Promise<void>((resolve) => {
-        setTimeout(() => {
-          timedOut = true;
-          resolve();
-        }, STOP_TIMEOUT_MS);
-      }),
-    ]);
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      await Promise.race([
+        pump.then(
+          () => undefined,
+          () => undefined,
+        ),
+        new Promise<void>((resolve) => {
+          timeout = setTimeout(() => {
+            timedOut = true;
+            resolve();
+          }, STOP_TIMEOUT_MS);
+          timeout.unref?.();
+        }),
+      ]);
+    } finally {
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+      }
+    }
     return !timedOut;
   }
 
   private forceIdleAfterPumpTimeout(): void {
+    const staleController = this.eventController;
+    staleController?.abort();
     this.pumpGeneration += 1;
     const shouldRestart = this.restartAfterStop;
     this.restartAfterStop = false;

--- a/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
+++ b/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
@@ -1,0 +1,422 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type {
+  ContentBlock,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+} from '@agentclientprotocol/sdk';
+import {
+  ToolCallStatus,
+  type HistoryItemWithoutId,
+  type IndividualToolCallDisplay,
+} from '../types.js';
+
+export interface DaemonTuiEvent {
+  id?: number;
+  v: 1;
+  type: string;
+  data: unknown;
+  originatorClientId?: string;
+}
+
+export interface DaemonTuiPromptResult {
+  stopReason?: string;
+  [key: string]: unknown;
+}
+
+export interface DaemonTuiSessionClient {
+  readonly sessionId: string;
+  readonly workspaceCwd: string;
+  readonly lastEventId?: number;
+  prompt(
+    req: { prompt: ContentBlock[] },
+    signal?: AbortSignal,
+  ): Promise<DaemonTuiPromptResult>;
+  events(opts?: {
+    signal?: AbortSignal;
+    lastEventId?: number;
+    resume?: boolean;
+  }): AsyncGenerator<DaemonTuiEvent>;
+  cancel(): Promise<void>;
+  setModel(modelId: string): Promise<Record<string, unknown>>;
+  respondToPermission(
+    requestId: string,
+    response: RequestPermissionResponse,
+  ): Promise<boolean>;
+}
+
+export type DaemonTuiUpdate =
+  | {
+      type: 'history';
+      item: HistoryItemWithoutId;
+      daemonEventId?: number;
+    }
+  | {
+      type: 'permission_request';
+      requestId: string;
+      request: RequestPermissionRequest;
+      daemonEventId?: number;
+    }
+  | {
+      type: 'permission_resolved';
+      requestId: string;
+      outcome?: unknown;
+      daemonEventId?: number;
+    }
+  | {
+      type: 'model_switched';
+      modelId: string;
+      daemonEventId?: number;
+    }
+  | {
+      type: 'turn_complete';
+      stopReason?: string;
+    }
+  | {
+      type: 'disconnected';
+      reason: string;
+      daemonEventId?: number;
+    };
+
+export interface DaemonTuiAdapterOptions {
+  session: DaemonTuiSessionClient;
+  onUpdate: (update: DaemonTuiUpdate) => void;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getTextContent(content: unknown): string | undefined {
+  if (!isRecord(content)) {
+    return undefined;
+  }
+  return getString(content['text']);
+}
+
+function getSessionUpdate(data: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(data) || !isRecord(data['update'])) {
+    return undefined;
+  }
+  return data['update'];
+}
+
+function formatPlan(entries: unknown): string | undefined {
+  if (!Array.isArray(entries)) {
+    return undefined;
+  }
+  const lines = entries
+    .filter(isRecord)
+    .map((entry, index) => {
+      const content = getString(entry['content']) ?? '';
+      const status = getString(entry['status']) ?? 'pending';
+      return `${index + 1}. [${status}] ${content}`;
+    })
+    .filter((line) => line.trim().length > 0);
+  return lines.length > 0 ? lines.join('\n') : undefined;
+}
+
+function mapToolStatus(status: unknown): ToolCallStatus {
+  switch (status) {
+    case 'pending':
+      return ToolCallStatus.Pending;
+    case 'confirming':
+      return ToolCallStatus.Confirming;
+    case 'in_progress':
+    case 'running':
+      return ToolCallStatus.Executing;
+    case 'completed':
+    case 'success':
+      return ToolCallStatus.Success;
+    case 'failed':
+    case 'error':
+      return ToolCallStatus.Error;
+    case 'canceled':
+    case 'cancelled':
+      return ToolCallStatus.Canceled;
+    default:
+      return ToolCallStatus.Pending;
+  }
+}
+
+function formatUnknown(value: unknown): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function toolUpdateToHistoryItem(
+  update: Record<string, unknown>,
+): HistoryItemWithoutId | undefined {
+  const toolCallId = getString(update['toolCallId']);
+  if (!toolCallId) {
+    return undefined;
+  }
+
+  const title = getString(update['title']);
+  const kind = getString(update['kind']);
+  const rawOutput = formatUnknown(update['rawOutput']);
+  const tool: IndividualToolCallDisplay = {
+    callId: toolCallId,
+    name: kind ?? title ?? toolCallId,
+    description: title ?? kind ?? toolCallId,
+    resultDisplay: rawOutput,
+    status: mapToolStatus(update['status']),
+    confirmationDetails: undefined,
+  };
+
+  return {
+    type: 'tool_group',
+    tools: [tool],
+  };
+}
+
+export function reduceDaemonEventToTuiUpdates(
+  event: DaemonTuiEvent,
+): DaemonTuiUpdate[] {
+  switch (event.type) {
+    case 'session_update': {
+      const update = getSessionUpdate(event.data);
+      const sessionUpdate = getString(update?.['sessionUpdate']);
+      const text = getTextContent(update?.['content']);
+
+      if (sessionUpdate === 'user_message_chunk' && text) {
+        return [
+          {
+            type: 'history',
+            item: { type: 'user', text },
+            daemonEventId: event.id,
+          },
+        ];
+      }
+
+      if (sessionUpdate === 'agent_message_chunk' && text) {
+        return [
+          {
+            type: 'history',
+            item: { type: 'gemini_content', text },
+            daemonEventId: event.id,
+          },
+        ];
+      }
+
+      if (sessionUpdate === 'agent_thought_chunk' && text) {
+        return [
+          {
+            type: 'history',
+            item: { type: 'gemini_thought_content', text },
+            daemonEventId: event.id,
+          },
+        ];
+      }
+
+      if (
+        update &&
+        (sessionUpdate === 'tool_call' || sessionUpdate === 'tool_call_update')
+      ) {
+        const item = toolUpdateToHistoryItem(update);
+        return item ? [{ type: 'history', item, daemonEventId: event.id }] : [];
+      }
+
+      if (sessionUpdate === 'plan') {
+        const text = formatPlan(update?.['entries']);
+        return text
+          ? [
+              {
+                type: 'history',
+                item: { type: 'info', text },
+                daemonEventId: event.id,
+              },
+            ]
+          : [];
+      }
+
+      return [];
+    }
+
+    case 'permission_request': {
+      if (
+        !isRecord(event.data) ||
+        typeof event.data['requestId'] !== 'string'
+      ) {
+        return [];
+      }
+      return [
+        {
+          type: 'permission_request',
+          requestId: event.data['requestId'],
+          request: event.data as unknown as RequestPermissionRequest,
+          daemonEventId: event.id,
+        },
+      ];
+    }
+
+    case 'permission_resolved': {
+      if (
+        !isRecord(event.data) ||
+        typeof event.data['requestId'] !== 'string'
+      ) {
+        return [];
+      }
+      return [
+        {
+          type: 'permission_resolved',
+          requestId: event.data['requestId'],
+          outcome: event.data['outcome'],
+          daemonEventId: event.id,
+        },
+      ];
+    }
+
+    case 'model_switched': {
+      if (!isRecord(event.data) || typeof event.data['modelId'] !== 'string') {
+        return [];
+      }
+      return [
+        {
+          type: 'model_switched',
+          modelId: event.data['modelId'],
+          daemonEventId: event.id,
+        },
+        {
+          type: 'history',
+          item: {
+            type: 'info',
+            text: `Model switched to ${event.data['modelId']}`,
+          },
+          daemonEventId: event.id,
+        },
+      ];
+    }
+
+    case 'session_died': {
+      const reason =
+        isRecord(event.data) && typeof event.data['reason'] === 'string'
+          ? event.data['reason']
+          : 'session_died';
+      return [
+        { type: 'disconnected', reason, daemonEventId: event.id },
+        {
+          type: 'history',
+          item: {
+            type: 'error',
+            text: `Daemon session disconnected: ${reason}`,
+          },
+          daemonEventId: event.id,
+        },
+      ];
+    }
+
+    default:
+      return [];
+  }
+}
+
+export class DaemonTuiAdapter {
+  private readonly session: DaemonTuiSessionClient;
+  private readonly onUpdate: (update: DaemonTuiUpdate) => void;
+  private eventController: AbortController | null = null;
+  private eventPump: Promise<void> | null = null;
+  private lastSeenEventId: number | undefined;
+
+  constructor(options: DaemonTuiAdapterOptions) {
+    this.session = options.session;
+    this.onUpdate = options.onUpdate;
+    this.lastSeenEventId = options.session.lastEventId;
+  }
+
+  start(): void {
+    if (this.eventPump) {
+      return;
+    }
+    this.eventController = new AbortController();
+    this.eventPump = this.pumpEvents(this.eventController.signal);
+  }
+
+  stop(): void {
+    this.eventController?.abort();
+    this.eventController = null;
+    this.eventPump = null;
+  }
+
+  async sendPrompt(
+    prompt: string | ContentBlock[],
+  ): Promise<DaemonTuiPromptResult> {
+    const promptBlocks =
+      typeof prompt === 'string'
+        ? ([{ type: 'text', text: prompt }] as ContentBlock[])
+        : prompt;
+    const result = await this.session.prompt({ prompt: promptBlocks });
+    this.onUpdate({ type: 'turn_complete', stopReason: result.stopReason });
+    return result;
+  }
+
+  async cancel(): Promise<void> {
+    await this.session.cancel();
+  }
+
+  async setModel(modelId: string): Promise<Record<string, unknown>> {
+    return await this.session.setModel(modelId);
+  }
+
+  async approvePermission(
+    requestId: string,
+    optionId: string,
+  ): Promise<boolean> {
+    return await this.session.respondToPermission(requestId, {
+      outcome: { outcome: 'selected', optionId },
+    });
+  }
+
+  async rejectPermission(requestId: string): Promise<boolean> {
+    return await this.session.respondToPermission(requestId, {
+      outcome: { outcome: 'cancelled' },
+    });
+  }
+
+  get currentSessionId(): string {
+    return this.session.sessionId;
+  }
+
+  get workspaceCwd(): string {
+    return this.session.workspaceCwd;
+  }
+
+  get lastEventId(): number | undefined {
+    return this.session.lastEventId ?? this.lastSeenEventId;
+  }
+
+  private async pumpEvents(signal: AbortSignal): Promise<void> {
+    try {
+      for await (const event of this.session.events({ signal })) {
+        if (event.id !== undefined) {
+          this.lastSeenEventId = event.id;
+        }
+        for (const update of reduceDaemonEventToTuiUpdates(event)) {
+          this.onUpdate(update);
+        }
+      }
+    } catch (error) {
+      if (!signal.aborted) {
+        const message = error instanceof Error ? error.message : String(error);
+        this.onUpdate({ type: 'disconnected', reason: message });
+      }
+    }
+  }
+}

--- a/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
+++ b/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
@@ -11,6 +11,7 @@ import type {
 } from '@agentclientprotocol/sdk';
 import {
   ToolCallStatus,
+  type HistoryItemToolGroup,
   type HistoryItemWithoutId,
   type IndividualToolCallDisplay,
 } from '../types.js';
@@ -62,6 +63,11 @@ export type DaemonTuiUpdate =
       daemonEventId?: number;
     }
   | {
+      type: 'tool_group_update';
+      item: HistoryItemToolGroup;
+      daemonEventId?: number;
+    }
+  | {
       type: 'permission_resolved';
       requestId: string;
       outcome?: unknown;
@@ -85,6 +91,14 @@ export type DaemonTuiUpdate =
 export interface DaemonTuiAdapterOptions {
   session: DaemonTuiSessionClient;
   onUpdate: (update: DaemonTuiUpdate) => void;
+}
+
+export interface DaemonTuiReducerState {
+  toolCallsById: Map<string, IndividualToolCallDisplay>;
+}
+
+export function createDaemonTuiReducerState(): DaemonTuiReducerState {
+  return { toolCallsById: new Map() };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -143,16 +157,49 @@ function mapToolStatus(status: unknown): ToolCallStatus {
     case 'cancelled':
       return ToolCallStatus.Canceled;
     default:
-      return ToolCallStatus.Pending;
+      return ToolCallStatus.Error;
   }
 }
 
-function formatUnknown(value: unknown): string | undefined {
+function sanitizeReason(reason: string): string {
+  const esc = String.fromCharCode(27);
+  const withoutAnsi = reason.replace(
+    new RegExp(`${esc}\\[[0-9;?]*[ -/]*[@-~]`, 'g'),
+    '',
+  );
+  let sanitized = '';
+  for (const char of withoutAnsi) {
+    const code = char.charCodeAt(0);
+    if ((code < 32 && code !== 10) || code === 127) {
+      continue;
+    }
+    sanitized += char;
+    if (sanitized.length >= 500) {
+      break;
+    }
+  }
+  return sanitized;
+}
+
+function formatToolResultDisplay(
+  value: unknown,
+): IndividualToolCallDisplay['resultDisplay'] {
   if (value === undefined || value === null) {
     return undefined;
   }
   if (typeof value === 'string') {
     return value;
+  }
+  if (
+    isRecord(value) &&
+    (typeof value['fileDiff'] === 'string' ||
+      'ansiOutput' in value ||
+      value['type'] === 'todo_list' ||
+      value['type'] === 'plan_summary' ||
+      value['type'] === 'task_execution' ||
+      value['type'] === 'mcp_tool_progress')
+  ) {
+    return value as unknown as IndividualToolCallDisplay['resultDisplay'];
   }
   try {
     return JSON.stringify(value);
@@ -163,7 +210,8 @@ function formatUnknown(value: unknown): string | undefined {
 
 function toolUpdateToHistoryItem(
   update: Record<string, unknown>,
-): HistoryItemWithoutId | undefined {
+  state?: DaemonTuiReducerState,
+): HistoryItemToolGroup | undefined {
   const toolCallId = getString(update['toolCallId']);
   if (!toolCallId) {
     return undefined;
@@ -171,24 +219,44 @@ function toolUpdateToHistoryItem(
 
   const title = getString(update['title']);
   const kind = getString(update['kind']);
-  const rawOutput = formatUnknown(update['rawOutput']);
+  const rawOutput = formatToolResultDisplay(update['rawOutput']);
+  const previous = state?.toolCallsById.get(toolCallId);
   const tool: IndividualToolCallDisplay = {
     callId: toolCallId,
-    name: kind ?? title ?? toolCallId,
-    description: title ?? kind ?? toolCallId,
-    resultDisplay: rawOutput,
-    status: mapToolStatus(update['status']),
-    confirmationDetails: undefined,
+    name: kind ?? title ?? previous?.name ?? toolCallId,
+    description: title ?? kind ?? previous?.description ?? toolCallId,
+    resultDisplay: rawOutput ?? previous?.resultDisplay,
+    status:
+      update['status'] === undefined
+        ? (previous?.status ?? ToolCallStatus.Pending)
+        : mapToolStatus(update['status']),
+    // Confirmation UI is driven by daemon permission_request events. The
+    // in-process ToolCallConfirmationDetails shape contains callbacks and is
+    // not directly serializable across the daemon boundary.
+    confirmationDetails: previous?.confirmationDetails,
   };
 
+  state?.toolCallsById.set(toolCallId, tool);
   return {
     type: 'tool_group',
-    tools: [tool],
+    tools: Array.from(state?.toolCallsById.values() ?? [tool]),
   };
+}
+
+function isPermissionRequestData(
+  value: unknown,
+): value is RequestPermissionRequest & { requestId: string } {
+  return (
+    isRecord(value) &&
+    typeof value['requestId'] === 'string' &&
+    isRecord(value['toolCall']) &&
+    Array.isArray(value['options'])
+  );
 }
 
 export function reduceDaemonEventToTuiUpdates(
   event: DaemonTuiEvent,
+  state?: DaemonTuiReducerState,
 ): DaemonTuiUpdate[] {
   switch (event.type) {
     case 'session_update': {
@@ -196,14 +264,8 @@ export function reduceDaemonEventToTuiUpdates(
       const sessionUpdate = getString(update?.['sessionUpdate']);
       const text = getTextContent(update?.['content']);
 
-      if (sessionUpdate === 'user_message_chunk' && text) {
-        return [
-          {
-            type: 'history',
-            item: { type: 'user', text },
-            daemonEventId: event.id,
-          },
-        ];
+      if (sessionUpdate === 'user_message_chunk') {
+        return [];
       }
 
       if (sessionUpdate === 'agent_message_chunk' && text) {
@@ -230,8 +292,10 @@ export function reduceDaemonEventToTuiUpdates(
         update &&
         (sessionUpdate === 'tool_call' || sessionUpdate === 'tool_call_update')
       ) {
-        const item = toolUpdateToHistoryItem(update);
-        return item ? [{ type: 'history', item, daemonEventId: event.id }] : [];
+        const item = toolUpdateToHistoryItem(update, state);
+        return item
+          ? [{ type: 'tool_group_update', item, daemonEventId: event.id }]
+          : [];
       }
 
       if (sessionUpdate === 'plan') {
@@ -251,17 +315,14 @@ export function reduceDaemonEventToTuiUpdates(
     }
 
     case 'permission_request': {
-      if (
-        !isRecord(event.data) ||
-        typeof event.data['requestId'] !== 'string'
-      ) {
+      if (!isPermissionRequestData(event.data)) {
         return [];
       }
       return [
         {
           type: 'permission_request',
           requestId: event.data['requestId'],
-          request: event.data as unknown as RequestPermissionRequest,
+          request: event.data,
           daemonEventId: event.id,
         },
       ];
@@ -306,10 +367,11 @@ export function reduceDaemonEventToTuiUpdates(
     }
 
     case 'session_died': {
-      const reason =
+      const reason = sanitizeReason(
         isRecord(event.data) && typeof event.data['reason'] === 'string'
           ? event.data['reason']
-          : 'session_died';
+          : 'session_died',
+      );
       return [
         { type: 'disconnected', reason, daemonEventId: event.id },
         {
@@ -331,6 +393,7 @@ export function reduceDaemonEventToTuiUpdates(
 export class DaemonTuiAdapter {
   private readonly session: DaemonTuiSessionClient;
   private readonly onUpdate: (update: DaemonTuiUpdate) => void;
+  private readonly reducerState = createDaemonTuiReducerState();
   private eventController: AbortController | null = null;
   private eventPump: Promise<void> | null = null;
   private lastSeenEventId: number | undefined;
@@ -349,8 +412,15 @@ export class DaemonTuiAdapter {
     this.eventPump = this.pumpEvents(this.eventController.signal);
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
     this.eventController?.abort();
+    if (this.eventPump) {
+      try {
+        await this.eventPump;
+      } catch {
+        /* pump errors are converted into updates */
+      }
+    }
     this.eventController = null;
     this.eventPump = null;
   }
@@ -362,9 +432,7 @@ export class DaemonTuiAdapter {
       typeof prompt === 'string'
         ? ([{ type: 'text', text: prompt }] as ContentBlock[])
         : prompt;
-    const result = await this.session.prompt({ prompt: promptBlocks });
-    this.onUpdate({ type: 'turn_complete', stopReason: result.stopReason });
-    return result;
+    return await this.session.prompt({ prompt: promptBlocks });
   }
 
   async cancel(): Promise<void> {
@@ -399,24 +467,43 @@ export class DaemonTuiAdapter {
   }
 
   get lastEventId(): number | undefined {
-    return this.session.lastEventId ?? this.lastSeenEventId;
+    return this.lastSeenEventId ?? this.session.lastEventId;
   }
 
   private async pumpEvents(signal: AbortSignal): Promise<void> {
     try {
-      for await (const event of this.session.events({ signal })) {
+      const resumeId = this.lastSeenEventId ?? this.session.lastEventId;
+      for await (const event of this.session.events({
+        signal,
+        lastEventId: resumeId,
+        resume: true,
+      })) {
+        for (const update of reduceDaemonEventToTuiUpdates(
+          event,
+          this.reducerState,
+        )) {
+          this.onUpdate(update);
+        }
         if (event.id !== undefined) {
           this.lastSeenEventId = event.id;
         }
-        for (const update of reduceDaemonEventToTuiUpdates(event)) {
-          this.onUpdate(update);
-        }
+      }
+      if (!signal.aborted) {
+        this.onUpdate({
+          type: 'disconnected',
+          reason: 'event stream ended',
+        });
       }
     } catch (error) {
       if (!signal.aborted) {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = sanitizeReason(
+          error instanceof Error ? error.message : String(error),
+        );
         this.onUpdate({ type: 'disconnected', reason: message });
       }
+    } finally {
+      this.eventController = null;
+      this.eventPump = null;
     }
   }
 }


### PR DESCRIPTION
## Summary

- What changed: Added a locally verifiable `DaemonTuiAdapter` spike that reduces daemon SSE frames into TUI-consumable updates and forwards prompt, cancel, model switch, and permission votes through a session-scoped daemon client.
- Why it changed: TUI is one of the first Mode B clients we want to dogfood against `qwen serve` HTTP + SSE, but the migration needs a default-off adapter layer before touching the existing Ink runtime.
- Reviewer focus: Event mapping scope, compatibility with current TUI history/control shapes, and the fact that this is not wired into the default interactive TUI path yet.

## Validation

- Commands run:
  ```bash
  cd packages/cli && npx vitest run src/ui/daemon/DaemonTuiAdapter.test.ts
  cd packages/cli && npm run typecheck
  cd packages/cli && npx eslint src/ui/daemon/DaemonTuiAdapter.ts src/ui/daemon/DaemonTuiAdapter.test.ts --max-warnings 0 --no-warn-ignored
  cd packages/cli && npm run build
  cd packages/cli && npx prettier --check src/ui/daemon/DaemonTuiAdapter.ts src/ui/daemon/DaemonTuiAdapter.test.ts ../../docs/developers/daemon-client-adapters/tui.md
  git diff --check
  ```
- Prompts / inputs used: Unit tests use synthetic daemon events and a fake daemon session.
- Expected result: Adapter maps supported daemon events and forwards client actions without changing existing TUI behavior.
- Observed result: Targeted vitest passed with 4 tests. Typecheck, targeted ESLint, package build, Prettier check, and diff check passed.
- Quickest reviewer verification path: `cd packages/cli && npx vitest run src/ui/daemon/DaemonTuiAdapter.test.ts`.
- Evidence: Test output reports `src/ui/daemon/DaemonTuiAdapter.test.ts (4 tests)` and `Test Files 1 passed`.

## Scope / Risk

- Main risk or tradeoff: This is a reducer/transport spike only. It proves the daemon-facing TUI adapter surface but does not yet start an experimental Ink app path.
- Not covered / not validated: No live `qwen serve` smoke, no flag/env parsing, no default TUI wiring, no JSONL/stream-json/dual-output behavior changes, no output sink migration.
- Breaking changes / migration notes: None. Existing interactive TUI, JSONL, stream-json, and dual-output paths are unchanged.

## Engineering principles checklist (Stage 1.5 wave PRs)

- [x] Independently mergeable (main stays releasable after merge)
- [x] Backward compatible (no removed routes / event fields / CLI behavior)
- [x] Default off (feature flag or dual-stack; old path unchanged)
- [x] `qwen serve` Stage 1 routes / SDK behavior preserved
- [x] Gradual migration (P0/P1 base before adapters; behind flag first)
- [x] Reversible (this PR can be individually rolled back)
- [x] Tests-first (unit / smoke / e2e where relevant)

## Linked Issues / Bugs

Related to #4175 Wave 5 adapter track and #4201.
