### PR TITLE
feat(channel): add daemon bridge spike

### DIFF
--- a/docs/developers/daemon-client-adapters/channel-web.md
+++ b/docs/developers/daemon-client-adapters/channel-web.md
@@ -37,6 +37,10 @@ QWEN_DAEMON_WORKSPACE=/repo
 
 ## Minimal Channel Flow
 
+This PR adds `DaemonChannelBridge`, a locally verifiable server-side bridge for
+channel and web-backend adapters. It keeps the existing ACP bridge as the
+default and owns daemon session state inside the backend process.
+
 1. Resolve channel sender/thread to a channel session key.
 2. Use `DaemonClient` + `DaemonSessionClient.createOrAttach()`.
 3. Submit inbound user text with `session.prompt()`.
@@ -81,6 +85,9 @@ Do not silently multiplex unrelated channel threads into one daemon session.
 
 Unknown daemon events must be ignored or forwarded as debug metadata, not fatal.
 
+The bridge is not wired into `qwen channel start` yet. Existing Telegram,
+Weixin, Dingtalk, plugin channel, and browser behavior remains unchanged.
+
 ## Explicit Non-Goals
 
 - No browser direct-to-daemon fetch or EventSource.
@@ -100,6 +107,7 @@ Unknown daemon events must be ignored or forwarded as debug metadata, not fatal.
 
 - Unit-test channel session-key to daemon-session binding.
 - Unit-test daemon event to channel/web message mapping.
+- Unit-test prompt, cancel, model switch, and permission response forwarding.
 - Smoke-test one single-user channel backend against local `qwen serve`.
 - Smoke-test browser -> BFF -> daemon without exposing daemon token.
 

--- a/docs/developers/daemon-client-adapters/channel-web.md
+++ b/docs/developers/daemon-client-adapters/channel-web.md
@@ -1,0 +1,112 @@
+# Channel And Web Backend Daemon Adapter Draft
+
+## Goal
+
+Let channel adapters and web chat backends consume `qwen serve` through
+`DaemonSessionClient` while keeping existing channel ACP subprocess behavior as
+the default.
+
+This draft covers server-side clients only:
+
+- Channel bot backend -> `qwen serve`
+- Web browser -> web backend / BFF -> `qwen serve`
+
+It explicitly does not allow browser JavaScript to call the daemon directly.
+The daemon currently rejects browser `Origin` requests by design.
+
+## Proposed Entry Points
+
+Channel backend:
+
+```bash
+QWEN_CHANNEL_DAEMON_URL=http://127.0.0.1:4170 qwen channel start telegram
+```
+
+Web backend:
+
+```bash
+QWEN_WEB_DAEMON_URL=http://127.0.0.1:4170 qwen web-chat-backend
+```
+
+Shared optional variables:
+
+```bash
+QWEN_DAEMON_TOKEN=...
+QWEN_DAEMON_WORKSPACE=/repo
+```
+
+## Minimal Channel Flow
+
+1. Resolve channel sender/thread to a channel session key.
+2. Use `DaemonClient` + `DaemonSessionClient.createOrAttach()`.
+3. Submit inbound user text with `session.prompt()`.
+4. Subscribe to `session.events()` and collect assistant text chunks.
+5. Send final text back through the platform adapter.
+6. Cast permission votes through `session.respondToPermission()`.
+7. Cancel active work through `session.cancel()`.
+
+## Minimal Web Backend Flow
+
+1. Browser opens a websocket or HTTP stream to the web backend.
+2. Backend owns `DaemonSessionClient`.
+3. Backend translates browser messages to daemon prompts.
+4. Backend translates daemon SSE events to browser-safe app events.
+5. Backend stores the daemon `sessionId` and last seen event id server-side.
+
+Browser clients must not receive daemon bearer tokens.
+
+## Session Isolation Constraint
+
+Current daemon Stage 1 behavior is effectively `sessionScope: single` at the
+daemon setting level. Until per-request `sessionScope` lands, multi-user channel
+or web deployments must choose one of these safe shapes:
+
+- one daemon per channel thread / web room
+- one daemon per user workspace
+- single-user demo only
+
+Do not silently multiplex unrelated channel threads into one daemon session.
+
+## Event Mapping Contract
+
+| Daemon event                             | Channel/web backend handling           |
+| ---------------------------------------- | -------------------------------------- |
+| `session_update` / `agent_message_chunk` | Append assistant text                  |
+| `session_update` / `agent_thought_chunk` | Optional hidden/debug stream           |
+| `session_update` / `tool_call`           | Emit tool status card/message          |
+| `permission_request`                     | Platform-specific approval interaction |
+| `permission_resolved`                    | Close/update approval interaction      |
+| `model_switched`                         | Update backend session metadata        |
+| `session_died`                           | Notify user and stop stream            |
+
+Unknown daemon events must be ignored or forwarded as debug metadata, not fatal.
+
+## Explicit Non-Goals
+
+- No browser direct-to-daemon fetch or EventSource.
+- No CORS relaxation in this adapter PR.
+- No default migration of Telegram, Weixin, Dingtalk, or plugin channels.
+- No file CRUD, memory CRUD, MCP restart, or provider mutation.
+- No sessionScope emulation in the client when daemon-side support is absent.
+
+## Merge Safety
+
+- Default off.
+- Existing ACP channel bridge remains the default.
+- Web backend is an explicit BFF layer, not a daemon security change.
+- No channel adapter should import daemon tokens into frontend/browser code.
+
+## Validation Plan
+
+- Unit-test channel session-key to daemon-session binding.
+- Unit-test daemon event to channel/web message mapping.
+- Smoke-test one single-user channel backend against local `qwen serve`.
+- Smoke-test browser -> BFF -> daemon without exposing daemon token.
+
+## Blockers Before Default Migration
+
+- Per-request `sessionScope`.
+- Session metadata + close/delete lifecycle.
+- Daemon-stamped client identity.
+- Session-scoped permission route.
+- Read-only diagnostics for MCP, skills, providers, and environment.

--- a/packages/channels/base/src/DaemonChannelBridge.test.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.test.ts
@@ -161,6 +161,7 @@ describe('DaemonChannelBridge', () => {
     expect(factory).toHaveBeenCalledWith({
       workspaceCwd: '/repo',
       modelServiceId: undefined,
+      sessionScope: 'thread',
     });
     expect(session.prompt).toHaveBeenCalledWith(
       {
@@ -269,6 +270,8 @@ describe('DaemonChannelBridge', () => {
           sessionUpdate: 'available_commands_update',
           availableCommands: [
             { name: '/help', description: 'Show help', input: null },
+            null,
+            { description: 'Missing name', input: null },
           ],
         },
       },
@@ -583,7 +586,9 @@ describe('DaemonChannelBridge', () => {
     const firstEvents = new EventQueue();
     const secondEvents = new EventQueue();
     const firstSession = createFakeSession(firstEvents, 'session-1');
+    firstSession.events.mockImplementation(() => firstEvents);
     const secondSession = createFakeSession(secondEvents, 'session-1');
+    secondSession.prompt.mockResolvedValue({ stopReason: 'end_turn' });
     const bridge = new DaemonChannelBridge({
       cwd: '/repo',
       sessionFactory: vi
@@ -636,6 +641,17 @@ describe('DaemonChannelBridge', () => {
         outcome: { outcome: 'selected', optionId: 'proceed_once' },
       }),
     ).resolves.toBe(false);
+
+    firstEvents.push({
+      id: 2,
+      v: 1,
+      type: 'session_died',
+      data: { reason: 'old pump finished late' },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(sessionDied).toHaveBeenCalledTimes(1);
+    await expect(bridge.prompt('session-1', 'still alive')).resolves.toBe('');
+    expect(secondSession.prompt).toHaveBeenCalledOnce();
 
     firstEvents.close();
     secondEvents.close();
@@ -906,6 +922,7 @@ describe('DaemonChannelBridge', () => {
     const bridge = new DaemonChannelBridge({
       cwd: '/repo',
       modelServiceId: 'default',
+      sessionScope: 'user',
       sessionFactory: factory,
     });
 
@@ -920,6 +937,7 @@ describe('DaemonChannelBridge', () => {
       workspaceCwd: '/repo',
       modelServiceId: 'default',
       sessionId: 'existing-session',
+      sessionScope: 'user',
     });
     expect(session.cancel).toHaveBeenCalledOnce();
     expect(session.setModel).toHaveBeenCalledWith('qwen3-coder-plus');

--- a/packages/channels/base/src/DaemonChannelBridge.test.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.test.ts
@@ -576,6 +576,11 @@ describe('DaemonChannelBridge', () => {
       outcome: { outcome: 'selected', optionId: 'proceed_once' },
     });
     expect(secondSession.respondToPermission).not.toHaveBeenCalled();
+    await expect(
+      bridge.respondToPermission('req-1', {
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+      }),
+    ).resolves.toBe(false);
 
     firstEvents.close();
     secondEvents.close();
@@ -780,6 +785,7 @@ describe('DaemonChannelBridge', () => {
 
     bridge.stop();
     await expect(promptPromise).rejects.toThrow('aborted');
+    expect(session.cancel).toHaveBeenCalledOnce();
     expect(sessionDied).toHaveBeenCalledWith({
       sessionId: 'session-1',
       reason: 'bridge_stopped',
@@ -789,12 +795,19 @@ describe('DaemonChannelBridge', () => {
   it('aborts in-flight prompts when cancelling a session', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);
+    const order: string[] = [];
+    session.cancel.mockImplementation(async () => {
+      order.push('cancel');
+    });
     session.prompt.mockImplementation(
       (_req: unknown, signal?: AbortSignal) =>
         new Promise((_resolve, reject) => {
           signal?.addEventListener(
             'abort',
-            () => reject(new DOMException('aborted', 'AbortError')),
+            () => {
+              order.push('abort');
+              reject(new DOMException('aborted', 'AbortError'));
+            },
             { once: true },
           );
         }),
@@ -813,6 +826,56 @@ describe('DaemonChannelBridge', () => {
 
     await expect(promptPromise).rejects.toThrow('aborted');
     expect(session.cancel).toHaveBeenCalledOnce();
+    expect(order).toEqual(['cancel', 'abort']);
+
+    events.close();
+    bridge.stop();
+  });
+
+  it('clears permission ownership when daemon permission responses fail', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+    const permissionRequest = vi.fn();
+    bridge.on('permissionRequest', permissionRequest);
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    events.push({
+      id: 1,
+      v: 1,
+      type: 'permission_request',
+      data: {
+        requestId: 'req-fail',
+        toolCall: {
+          toolCallId: 'tool-1',
+          kind: 'edit',
+          title: 'Edit file',
+          rawInput: {},
+        },
+        options: [
+          { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+        ],
+      },
+    });
+    await waitFor(() => expect(permissionRequest).toHaveBeenCalledOnce());
+
+    session.respondToPermission.mockRejectedValueOnce(
+      new Error('permission failed'),
+    );
+    const response: RequestPermissionResponse = {
+      outcome: { outcome: 'selected', optionId: 'proceed_once' },
+    };
+    await expect(
+      bridge.respondToPermission('req-fail', response),
+    ).rejects.toThrow('permission failed');
+    await expect(
+      bridge.respondToPermission('req-fail', response),
+    ).resolves.toBe(false);
 
     events.close();
     bridge.stop();
@@ -1004,8 +1067,19 @@ describe('DaemonChannelBridge', () => {
       type: 'model_switched',
       data: {},
     });
+    events.push({
+      id: 4,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'tool_call_update',
+          status: 'running',
+        },
+      },
+    });
 
-    await waitFor(() => expect(errors).toHaveBeenCalledTimes(3));
+    await waitFor(() => expect(errors).toHaveBeenCalledTimes(4));
     expect(errors).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining({
@@ -1024,8 +1098,14 @@ describe('DaemonChannelBridge', () => {
         message: 'Malformed daemon model_switched event',
       }),
     );
+    expect(errors).toHaveBeenNthCalledWith(
+      4,
+      expect.objectContaining({
+        message: 'Malformed daemon tool_call_update event',
+      }),
+    );
     expect(bridge.lastDaemonError).toMatchObject({
-      message: 'Malformed daemon model_switched event',
+      message: 'Malformed daemon tool_call_update event',
     });
 
     events.close();

--- a/packages/channels/base/src/DaemonChannelBridge.test.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.test.ts
@@ -171,11 +171,13 @@ describe('DaemonChannelBridge', () => {
     const thoughtChunk = vi.fn();
     const toolCall = vi.fn();
     const modelSwitched = vi.fn();
+    const modelSwitchFailed = vi.fn();
     const sessionDied = vi.fn();
 
     bridge.on('thoughtChunk', thoughtChunk);
     bridge.on('toolCall', toolCall);
     bridge.on('modelSwitched', modelSwitched);
+    bridge.on('modelSwitchFailed', modelSwitchFailed);
     bridge.on('sessionDied', sessionDied);
 
     await bridge.start();
@@ -241,6 +243,16 @@ describe('DaemonChannelBridge', () => {
     events.push({
       id: 6,
       v: 1,
+      type: 'model_switch_failed',
+      data: {
+        sessionId: 'session-1',
+        requestedModelId: 'missing-model',
+        error: 'not configured',
+      },
+    });
+    events.push({
+      id: 7,
+      v: 1,
       type: 'session_died',
       data: { sessionId: 'session-1', reason: 'agent exited' },
     });
@@ -260,6 +272,13 @@ describe('DaemonChannelBridge', () => {
       expect(modelSwitched).toHaveBeenCalledWith({
         sessionId: 'session-1',
         modelId: 'qwen3-coder-plus',
+      }),
+    );
+    await waitFor(() =>
+      expect(modelSwitchFailed).toHaveBeenCalledWith({
+        sessionId: 'session-1',
+        requestedModelId: 'missing-model',
+        error: 'not configured',
       }),
     );
     await waitFor(() =>
@@ -452,7 +471,34 @@ describe('DaemonChannelBridge', () => {
     bridge.stop();
   });
 
-  it('treats stream errors and normal stream completion as session death', async () => {
+  it('aborts in-flight prompts when the bridge stops', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    session.prompt.mockImplementation(
+      (_req: unknown, signal?: AbortSignal) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener(
+            'abort',
+            () => reject(new DOMException('aborted', 'AbortError')),
+            { once: true },
+          );
+        }),
+    );
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+    const promptPromise = bridge.prompt('session-1', 'hello');
+    await waitFor(() => expect(session.prompt).toHaveBeenCalledOnce());
+
+    bridge.stop();
+    await expect(promptPromise).rejects.toThrow('aborted');
+  });
+
+  it('treats terminal stream frames and completion as session death', async () => {
     const failedEvents = new EventQueue();
     failedEvents.fail(new Error('network down'));
     const failedSession = createFakeSession(failedEvents);
@@ -491,6 +537,57 @@ describe('DaemonChannelBridge', () => {
       expect(endedDied).toHaveBeenCalledWith({
         sessionId: 'session-1',
         reason: 'stream_ended',
+      }),
+    );
+
+    const terminalEvents = new EventQueue();
+    const terminalSession = createFakeSession(terminalEvents);
+    const terminalBridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(terminalSession),
+    });
+    const terminalDied = vi.fn();
+    terminalBridge.on('sessionDied', terminalDied);
+
+    await terminalBridge.start();
+    await terminalBridge.newSession('/repo');
+    terminalEvents.push({
+      id: 20,
+      v: 1,
+      type: 'stream_error',
+      data: { error: 'subscriber limit reached' },
+    });
+    await waitFor(() =>
+      expect(terminalDied).toHaveBeenCalledWith({
+        sessionId: 'session-1',
+        reason: 'subscriber limit reached',
+      }),
+    );
+    await expect(terminalBridge.prompt('session-1', 'hello')).rejects.toThrow(
+      'No daemon session bound for session-1',
+    );
+
+    const evictedEvents = new EventQueue();
+    const evictedSession = createFakeSession(evictedEvents);
+    const evictedBridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(evictedSession),
+    });
+    const evictedDied = vi.fn();
+    evictedBridge.on('sessionDied', evictedDied);
+
+    await evictedBridge.start();
+    await evictedBridge.newSession('/repo');
+    evictedEvents.push({
+      id: 21,
+      v: 1,
+      type: 'client_evicted',
+      data: { reason: 'queue_overflow' },
+    });
+    await waitFor(() =>
+      expect(evictedDied).toHaveBeenCalledWith({
+        sessionId: 'session-1',
+        reason: 'queue_overflow',
       }),
     );
   });

--- a/packages/channels/base/src/DaemonChannelBridge.test.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.test.ts
@@ -467,6 +467,9 @@ describe('DaemonChannelBridge', () => {
       true,
     );
     expect(session.respondToPermission).toHaveBeenCalledWith('req-1', response);
+    await expect(bridge.respondToPermission('req-1', response)).resolves.toBe(
+      false,
+    );
 
     const resolved = vi.fn();
     bridge.on('permissionResolved', resolved);
@@ -505,6 +508,65 @@ describe('DaemonChannelBridge', () => {
     });
     await waitFor(() => expect(staleResponse).toBeDefined());
     await expect(staleResponse).resolves.toBe(false);
+
+    events.close();
+    bridge.stop();
+  });
+
+  it('rejects malformed permission resolution outcomes', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+    const permissionRequest = vi.fn();
+    const permissionResolved = vi.fn();
+    const errors = vi.fn();
+    bridge.on('permissionRequest', permissionRequest);
+    bridge.on('permissionResolved', permissionResolved);
+    bridge.on('error', errors);
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    events.push({
+      id: 10,
+      v: 1,
+      type: 'permission_request',
+      data: {
+        requestId: 'req-bad-outcome',
+        toolCall: {
+          toolCallId: 'tool-1',
+          kind: 'edit',
+          title: 'Edit file',
+          rawInput: {},
+        },
+        options: [
+          { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+        ],
+      },
+    });
+    await waitFor(() => expect(permissionRequest).toHaveBeenCalledOnce());
+
+    events.push({
+      id: 11,
+      v: 1,
+      type: 'permission_resolved',
+      data: {
+        requestId: 'req-bad-outcome',
+        outcome: { outcome: 'selected' },
+      },
+    });
+
+    await waitFor(() =>
+      expect(errors).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: 'Malformed daemon permission_resolved outcome',
+        }),
+      ),
+    );
+    expect(permissionResolved).not.toHaveBeenCalled();
 
     events.close();
     bridge.stop();

--- a/packages/channels/base/src/DaemonChannelBridge.test.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+} from '@agentclientprotocol/sdk';
+import {
+  DaemonChannelBridge,
+  type DaemonChannelEvent,
+  type DaemonChannelSessionClient,
+} from './DaemonChannelBridge.js';
+
+class EventQueue implements AsyncGenerator<DaemonChannelEvent> {
+  private events: DaemonChannelEvent[] = [];
+  private waiters: Array<(value: IteratorResult<DaemonChannelEvent>) => void> =
+    [];
+  private closed = false;
+
+  async next(): Promise<IteratorResult<DaemonChannelEvent>> {
+    const event = this.events.shift();
+    if (event) {
+      return { done: false, value: event };
+    }
+    if (this.closed) {
+      return { done: true, value: undefined };
+    }
+    return await new Promise((resolve) => {
+      this.waiters.push(resolve);
+    });
+  }
+
+  async return(): Promise<IteratorResult<DaemonChannelEvent>> {
+    this.close();
+    return { done: true, value: undefined };
+  }
+
+  async throw(error?: unknown): Promise<IteratorResult<DaemonChannelEvent>> {
+    this.close();
+    throw error;
+  }
+
+  [Symbol.asyncIterator](): AsyncGenerator<DaemonChannelEvent> {
+    return this;
+  }
+
+  push(event: DaemonChannelEvent): void {
+    const waiter = this.waiters.shift();
+    if (waiter) {
+      waiter({ done: false, value: event });
+      return;
+    }
+    this.events.push(event);
+  }
+
+  close(): void {
+    this.closed = true;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter({ done: true, value: undefined });
+    }
+  }
+}
+
+interface FakeSession extends DaemonChannelSessionClient {
+  prompt: ReturnType<typeof vi.fn>;
+  events: ReturnType<typeof vi.fn>;
+  cancel: ReturnType<typeof vi.fn>;
+  setModel: ReturnType<typeof vi.fn>;
+  respondToPermission: ReturnType<typeof vi.fn>;
+}
+
+function createFakeSession(
+  events: EventQueue,
+  sessionId = 'session-1',
+): FakeSession {
+  return {
+    sessionId,
+    workspaceCwd: '/repo',
+    lastEventId: undefined,
+    prompt: vi.fn().mockImplementation(async () => undefined),
+    events: vi.fn(() => events),
+    cancel: vi.fn().mockResolvedValue(undefined),
+    setModel: vi.fn().mockResolvedValue({}),
+    respondToPermission: vi.fn().mockResolvedValue(true),
+  };
+}
+
+async function waitFor(assertion: () => void): Promise<void> {
+  let lastError: unknown;
+  for (let i = 0; i < 20; i += 1) {
+    try {
+      assertion();
+      return;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+  }
+  throw lastError;
+}
+
+describe('DaemonChannelBridge', () => {
+  it('binds a daemon session and collects assistant chunks during prompt', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    let resolvePrompt: () => void = () => {};
+    session.prompt.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePrompt = () => resolve({ stopReason: 'end_turn' });
+          events.push({
+            id: 1,
+            v: 1,
+            type: 'session_update',
+            data: {
+              sessionId: 'session-1',
+              update: {
+                sessionUpdate: 'agent_message_chunk',
+                content: { type: 'text', text: 'hello' },
+              },
+            },
+          });
+        }),
+    );
+    const factory = vi.fn().mockResolvedValue(session);
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: factory,
+    });
+
+    await bridge.start();
+    const sessionId = await bridge.newSession('/repo');
+    const promptPromise = bridge.prompt(sessionId, 'summarize');
+    await waitFor(() => expect(session.prompt).toHaveBeenCalledOnce());
+    resolvePrompt();
+
+    await expect(promptPromise).resolves.toBe('hello');
+    expect(factory).toHaveBeenCalledWith({
+      workspaceCwd: '/repo',
+      modelServiceId: undefined,
+    });
+    expect(session.prompt).toHaveBeenCalledWith({
+      prompt: [{ type: 'text', text: 'summarize' }],
+    });
+
+    events.close();
+    bridge.stop();
+  });
+
+  it('emits tool, thought, model, and session lifecycle events', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+    const thoughtChunk = vi.fn();
+    const toolCall = vi.fn();
+    const modelSwitched = vi.fn();
+    const sessionDied = vi.fn();
+
+    bridge.on('thoughtChunk', thoughtChunk);
+    bridge.on('toolCall', toolCall);
+    bridge.on('modelSwitched', modelSwitched);
+    bridge.on('sessionDied', sessionDied);
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    events.push({
+      id: 2,
+      v: 1,
+      type: 'session_update',
+      data: {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'agent_thought_chunk',
+          content: { type: 'text', text: 'thinking' },
+        },
+      },
+    });
+    events.push({
+      id: 3,
+      v: 1,
+      type: 'session_update',
+      data: {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'tool_call_update',
+          toolCallId: 'tool-1',
+          kind: 'read_file',
+          title: 'Read file',
+          status: 'completed',
+          rawInput: { path: 'README.md' },
+        },
+      },
+    });
+    events.push({
+      id: 4,
+      v: 1,
+      type: 'model_switched',
+      data: { sessionId: 'session-1', modelId: 'qwen3-coder-plus' },
+    });
+    events.push({
+      id: 5,
+      v: 1,
+      type: 'session_died',
+      data: { sessionId: 'session-1', reason: 'agent exited' },
+    });
+
+    await waitFor(() =>
+      expect(thoughtChunk).toHaveBeenCalledWith('session-1', 'thinking'),
+    );
+    expect(toolCall).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      toolCallId: 'tool-1',
+      kind: 'read_file',
+      title: 'Read file',
+      status: 'completed',
+      rawInput: { path: 'README.md' },
+    });
+    expect(modelSwitched).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      modelId: 'qwen3-coder-plus',
+    });
+    expect(sessionDied).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      reason: 'agent exited',
+    });
+
+    events.close();
+  });
+
+  it('routes permission responses back through the owning daemon session', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+    const permissionRequest = vi.fn();
+    bridge.on('permissionRequest', permissionRequest);
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    const request: RequestPermissionRequest & { requestId: string } = {
+      requestId: 'req-1',
+      sessionId: 'session-1',
+      toolCall: {
+        toolCallId: 'tool-1',
+        kind: 'edit',
+        title: 'Edit file',
+        rawInput: {},
+      },
+      options: [
+        { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+      ],
+    } as RequestPermissionRequest & { requestId: string };
+    events.push({
+      id: 6,
+      v: 1,
+      type: 'permission_request',
+      data: request,
+    });
+
+    await waitFor(() =>
+      expect(permissionRequest).toHaveBeenCalledWith({
+        requestId: 'req-1',
+        sessionId: 'session-1',
+        request,
+      }),
+    );
+
+    const response: RequestPermissionResponse = {
+      outcome: { outcome: 'selected', optionId: 'proceed_once' },
+    };
+    await expect(bridge.respondToPermission('req-1', response)).resolves.toBe(
+      true,
+    );
+    expect(session.respondToPermission).toHaveBeenCalledWith('req-1', response);
+
+    const resolved = vi.fn();
+    bridge.on('permissionResolved', resolved);
+    events.push({
+      id: 7,
+      v: 1,
+      type: 'permission_resolved',
+      data: { requestId: 'req-1', outcome: response.outcome },
+    });
+    await waitFor(() =>
+      expect(resolved).toHaveBeenCalledWith({
+        requestId: 'req-1',
+        outcome: response.outcome,
+      }),
+    );
+    await expect(bridge.respondToPermission('req-1', response)).resolves.toBe(
+      false,
+    );
+
+    events.close();
+    bridge.stop();
+  });
+
+  it('loads an existing daemon session and forwards cancel/model changes', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events, 'existing-session');
+    const factory = vi.fn().mockResolvedValue(session);
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      modelServiceId: 'default',
+      sessionFactory: factory,
+    });
+
+    await bridge.start();
+    await expect(bridge.loadSession('existing-session', '/repo')).resolves.toBe(
+      'existing-session',
+    );
+    await bridge.cancelSession('existing-session');
+    await bridge.setSessionModel('existing-session', 'qwen3-coder-plus');
+
+    expect(factory).toHaveBeenCalledWith({
+      workspaceCwd: '/repo',
+      modelServiceId: 'default',
+      sessionId: 'existing-session',
+    });
+    expect(session.cancel).toHaveBeenCalledOnce();
+    expect(session.setModel).toHaveBeenCalledWith('qwen3-coder-plus');
+
+    events.close();
+    bridge.stop();
+  });
+});

--- a/packages/channels/base/src/DaemonChannelBridge.test.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.test.ts
@@ -11,8 +11,10 @@ import {
 
 class EventQueue implements AsyncGenerator<DaemonChannelEvent> {
   private events: DaemonChannelEvent[] = [];
-  private waiters: Array<(value: IteratorResult<DaemonChannelEvent>) => void> =
-    [];
+  private waiters: Array<{
+    resolve: (value: IteratorResult<DaemonChannelEvent>) => void;
+    reject: (error: unknown) => void;
+  }> = [];
   private closed = false;
   private failure: unknown;
 
@@ -27,8 +29,8 @@ class EventQueue implements AsyncGenerator<DaemonChannelEvent> {
     if (this.closed) {
       return { done: true, value: undefined };
     }
-    return await new Promise((resolve) => {
-      this.waiters.push(resolve);
+    return await new Promise((resolve, reject) => {
+      this.waiters.push({ resolve, reject });
     });
   }
 
@@ -49,7 +51,7 @@ class EventQueue implements AsyncGenerator<DaemonChannelEvent> {
   push(event: DaemonChannelEvent): void {
     const waiter = this.waiters.shift();
     if (waiter) {
-      waiter({ done: false, value: event });
+      waiter.resolve({ done: false, value: event });
       return;
     }
     this.events.push(event);
@@ -58,12 +60,15 @@ class EventQueue implements AsyncGenerator<DaemonChannelEvent> {
   close(): void {
     this.closed = true;
     for (const waiter of this.waiters.splice(0)) {
-      waiter({ done: true, value: undefined });
+      waiter.resolve({ done: true, value: undefined });
     }
   }
 
   fail(error: unknown): void {
     this.failure = error;
+    for (const waiter of this.waiters.splice(0)) {
+      waiter.reject(error);
+    }
   }
 }
 
@@ -138,6 +143,8 @@ describe('DaemonChannelBridge', () => {
       cwd: '/repo',
       sessionFactory: factory,
     });
+    const promptComplete = vi.fn();
+    bridge.on('promptComplete', promptComplete);
 
     await bridge.start();
     const sessionId = await bridge.newSession('/repo');
@@ -146,6 +153,11 @@ describe('DaemonChannelBridge', () => {
     resolvePrompt();
 
     await expect(promptPromise).resolves.toBe('hello');
+    expect(promptComplete).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      text: 'hello',
+      stopReason: 'end_turn',
+    });
     expect(factory).toHaveBeenCalledWith({
       workspaceCwd: '/repo',
       modelServiceId: undefined,
@@ -155,6 +167,42 @@ describe('DaemonChannelBridge', () => {
         prompt: [{ type: 'text', text: 'summarize' }],
       },
       expect.any(AbortSignal),
+    );
+
+    events.close();
+    bridge.stop();
+  });
+
+  it('drains daemon chunks queued with prompt completion', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    session.prompt.mockImplementation(async () => {
+      setTimeout(() => {
+        events.push({
+          id: 1,
+          v: 1,
+          type: 'session_update',
+          data: {
+            sessionId: 'session-1',
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'late chunk' },
+            },
+          },
+        });
+      }, 0);
+      return { stopReason: 'end_turn' };
+    });
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    await expect(bridge.prompt('session-1', 'summarize')).resolves.toBe(
+      'late chunk',
     );
 
     events.close();
@@ -292,6 +340,82 @@ describe('DaemonChannelBridge', () => {
     events.close();
   });
 
+  it('keeps available commands scoped per daemon session', async () => {
+    const firstEvents = new EventQueue();
+    const secondEvents = new EventQueue();
+    const firstSession = createFakeSession(firstEvents, 'session-1');
+    const secondSession = createFakeSession(secondEvents, 'session-2');
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi
+        .fn()
+        .mockResolvedValueOnce(firstSession)
+        .mockResolvedValueOnce(secondSession),
+    });
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+    await bridge.newSession('/repo');
+
+    firstEvents.push({
+      id: 1,
+      v: 1,
+      type: 'session_update',
+      data: {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'available_commands_update',
+          availableCommands: [
+            { name: '/one', description: 'First', input: null },
+          ],
+        },
+      },
+    });
+    secondEvents.push({
+      id: 2,
+      v: 1,
+      type: 'session_update',
+      data: {
+        sessionId: 'session-2',
+        update: {
+          sessionUpdate: 'available_commands_update',
+          availableCommands: [
+            { name: '/two', description: 'Second', input: null },
+          ],
+        },
+      },
+    });
+
+    await waitFor(() =>
+      expect(bridge.getAvailableCommands('session-2')).toEqual([
+        { name: '/two', description: 'Second', input: null },
+      ]),
+    );
+    expect(bridge.getAvailableCommands('session-1')).toEqual([
+      { name: '/one', description: 'First', input: null },
+    ]);
+    expect(bridge.availableCommands).toEqual([
+      { name: '/two', description: 'Second', input: null },
+    ]);
+
+    secondEvents.push({
+      id: 3,
+      v: 1,
+      type: 'session_died',
+      data: { reason: 'gone' },
+    });
+    await waitFor(() =>
+      expect(bridge.getAvailableCommands('session-2')).toEqual([]),
+    );
+    expect(bridge.availableCommands).toEqual([
+      { name: '/one', description: 'First', input: null },
+    ]);
+
+    firstEvents.close();
+    secondEvents.close();
+    bridge.stop();
+  });
+
   it('routes permission responses back through the owning daemon session', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);
@@ -383,6 +507,141 @@ describe('DaemonChannelBridge', () => {
     bridge.stop();
   });
 
+  it('ignores permission resolution events from non-owning sessions', async () => {
+    const firstEvents = new EventQueue();
+    const secondEvents = new EventQueue();
+    const firstSession = createFakeSession(firstEvents, 'session-1');
+    const secondSession = createFakeSession(secondEvents, 'session-2');
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi
+        .fn()
+        .mockResolvedValueOnce(firstSession)
+        .mockResolvedValueOnce(secondSession),
+    });
+    const permissionResolved = vi.fn();
+    const permissionRequest = vi.fn();
+    const errors = vi.fn();
+    bridge.on('permissionRequest', permissionRequest);
+    bridge.on('permissionResolved', permissionResolved);
+    bridge.on('error', errors);
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+    await bridge.newSession('/repo');
+
+    firstEvents.push({
+      id: 1,
+      v: 1,
+      type: 'permission_request',
+      data: {
+        requestId: 'req-1',
+        toolCall: {
+          toolCallId: 'tool-1',
+          kind: 'edit',
+          title: 'Edit file',
+          rawInput: {},
+        },
+        options: [
+          { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+        ],
+      },
+    });
+    await waitFor(() => expect(permissionRequest).toHaveBeenCalledOnce());
+    await expect(
+      bridge.respondToPermission('req-1', {
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+      }),
+    ).resolves.toBe(true);
+
+    secondEvents.push({
+      id: 2,
+      v: 1,
+      type: 'permission_resolved',
+      data: { requestId: 'req-1', outcome: { outcome: 'selected' } },
+    });
+
+    await waitFor(() =>
+      expect(errors).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('non-owning session session-2'),
+        }),
+      ),
+    );
+    expect(permissionResolved).not.toHaveBeenCalled();
+    expect(firstSession.respondToPermission).toHaveBeenCalledWith('req-1', {
+      outcome: { outcome: 'selected', optionId: 'proceed_once' },
+    });
+    expect(secondSession.respondToPermission).not.toHaveBeenCalled();
+
+    firstEvents.close();
+    secondEvents.close();
+    bridge.stop();
+  });
+
+  it('replaces duplicate daemon sessions and clears stale ownership state', async () => {
+    const firstEvents = new EventQueue();
+    const secondEvents = new EventQueue();
+    const firstSession = createFakeSession(firstEvents, 'session-1');
+    const secondSession = createFakeSession(secondEvents, 'session-1');
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi
+        .fn()
+        .mockResolvedValueOnce(firstSession)
+        .mockResolvedValueOnce(secondSession),
+    });
+    const sessionDied = vi.fn();
+    const permissionRequest = vi.fn();
+    bridge.on('sessionDied', sessionDied);
+    bridge.on('permissionRequest', permissionRequest);
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    firstEvents.push({
+      id: 1,
+      v: 1,
+      type: 'permission_request',
+      data: {
+        requestId: 'req-1',
+        toolCall: {
+          toolCallId: 'tool-1',
+          kind: 'edit',
+          title: 'Edit file',
+          rawInput: {},
+        },
+        options: [
+          { optionId: 'proceed_once', kind: 'allow_once', name: 'Allow' },
+        ],
+      },
+    });
+    await waitFor(() => expect(permissionRequest).toHaveBeenCalledOnce());
+    await expect(
+      bridge.respondToPermission('req-1', {
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+      }),
+    ).resolves.toBe(true);
+
+    await expect(bridge.newSession('/repo')).resolves.toBe('session-1');
+
+    await waitFor(() =>
+      expect(sessionDied).toHaveBeenCalledWith({
+        sessionId: 'session-1',
+        reason: 'session_replaced',
+      }),
+    );
+    await expect(
+      bridge.respondToPermission('req-1', {
+        outcome: { outcome: 'selected', optionId: 'proceed_once' },
+      }),
+    ).resolves.toBe(false);
+
+    firstEvents.close();
+    secondEvents.close();
+    bridge.stop();
+  });
+
   it('rejects unknown sessions and concurrent prompts for one session', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);
@@ -397,6 +656,8 @@ describe('DaemonChannelBridge', () => {
       cwd: '/repo',
       sessionFactory: vi.fn().mockResolvedValue(session),
     });
+    const promptComplete = vi.fn();
+    bridge.on('promptComplete', promptComplete);
 
     await bridge.start();
     await bridge.newSession('/repo');
@@ -418,6 +679,11 @@ describe('DaemonChannelBridge', () => {
     );
     resolvePrompt();
     await expect(firstPrompt).resolves.toBe('');
+    expect(promptComplete).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      text: '',
+      stopReason: 'end_turn',
+    });
 
     events.close();
     bridge.stop();
@@ -488,6 +754,8 @@ describe('DaemonChannelBridge', () => {
       cwd: '/repo',
       sessionFactory: vi.fn().mockResolvedValue(session),
     });
+    const sessionDied = vi.fn();
+    bridge.on('sessionDied', sessionDied);
 
     await bridge.start();
     await bridge.newSession('/repo');
@@ -496,6 +764,42 @@ describe('DaemonChannelBridge', () => {
 
     bridge.stop();
     await expect(promptPromise).rejects.toThrow('aborted');
+    expect(sessionDied).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      reason: 'bridge_stopped',
+    });
+  });
+
+  it('aborts in-flight prompts when cancelling a session', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    session.prompt.mockImplementation(
+      (_req: unknown, signal?: AbortSignal) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener(
+            'abort',
+            () => reject(new DOMException('aborted', 'AbortError')),
+            { once: true },
+          );
+        }),
+    );
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+    const promptPromise = bridge.prompt('session-1', 'hello');
+    await waitFor(() => expect(session.prompt).toHaveBeenCalledOnce());
+
+    await bridge.cancelSession('session-1');
+
+    await expect(promptPromise).rejects.toThrow('aborted');
+    expect(session.cancel).toHaveBeenCalledOnce();
+
+    events.close();
+    bridge.stop();
   });
 
   it('treats terminal stream frames and completion as session death', async () => {
@@ -517,6 +821,9 @@ describe('DaemonChannelBridge', () => {
         reason: 'network down',
       }),
     );
+    expect(failedBridge.lastDaemonError).toMatchObject({
+      message: 'network down',
+    });
     await expect(failedBridge.prompt('session-1', 'hello')).rejects.toThrow(
       'No daemon session bound for session-1',
     );
@@ -616,6 +923,92 @@ describe('DaemonChannelBridge', () => {
     });
     expect(session.cancel).toHaveBeenCalledOnce();
     expect(session.setModel).toHaveBeenCalledWith('qwen3-coder-plus');
+
+    events.close();
+    bridge.stop();
+  });
+
+  it('rejects mismatched daemon session ids while loading', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events, 'different-session');
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    await bridge.start();
+    await expect(
+      bridge.loadSession('existing-session', '/repo'),
+    ).rejects.toThrow(
+      'Daemon returned session different-session while loading existing-session',
+    );
+    await expect(bridge.prompt('different-session', 'hello')).rejects.toThrow(
+      'No daemon session bound for different-session',
+    );
+
+    events.close();
+    bridge.stop();
+  });
+
+  it('surfaces malformed daemon events through the error channel', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+    const errors = vi.fn();
+    bridge.on('error', errors);
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    events.push({
+      id: 1,
+      v: 1,
+      type: 'permission_request',
+      data: { requestId: 'req-1' },
+    });
+    events.push({
+      id: 2,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'available_commands_update',
+          availableCommands: 'not-an-array',
+        },
+      },
+    });
+    events.push({
+      id: 3,
+      v: 1,
+      type: 'model_switched',
+      data: {},
+    });
+
+    await waitFor(() => expect(errors).toHaveBeenCalledTimes(3));
+    expect(errors).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        message: 'Malformed daemon permission_request event',
+      }),
+    );
+    expect(errors).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        message: 'Malformed daemon available_commands_update event',
+      }),
+    );
+    expect(errors).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        message: 'Malformed daemon model_switched event',
+      }),
+    );
+    expect(bridge.lastDaemonError).toMatchObject({
+      message: 'Malformed daemon model_switched event',
+    });
 
     events.close();
     bridge.stop();

--- a/packages/channels/base/src/DaemonChannelBridge.test.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.test.ts
@@ -14,8 +14,12 @@ class EventQueue implements AsyncGenerator<DaemonChannelEvent> {
   private waiters: Array<(value: IteratorResult<DaemonChannelEvent>) => void> =
     [];
   private closed = false;
+  private failure: unknown;
 
   async next(): Promise<IteratorResult<DaemonChannelEvent>> {
+    if (this.failure) {
+      throw this.failure;
+    }
     const event = this.events.shift();
     if (event) {
       return { done: false, value: event };
@@ -57,6 +61,10 @@ class EventQueue implements AsyncGenerator<DaemonChannelEvent> {
       waiter({ done: true, value: undefined });
     }
   }
+
+  fail(error: unknown): void {
+    this.failure = error;
+  }
 }
 
 interface FakeSession extends DaemonChannelSessionClient {
@@ -76,7 +84,12 @@ function createFakeSession(
     workspaceCwd: '/repo',
     lastEventId: undefined,
     prompt: vi.fn().mockImplementation(async () => undefined),
-    events: vi.fn(() => events),
+    events: vi.fn((opts?: { signal?: AbortSignal }) => {
+      opts?.signal?.addEventListener('abort', () => events.close(), {
+        once: true,
+      });
+      return events;
+    }),
     cancel: vi.fn().mockResolvedValue(undefined),
     setModel: vi.fn().mockResolvedValue({}),
     respondToPermission: vi.fn().mockResolvedValue(true),
@@ -137,15 +150,18 @@ describe('DaemonChannelBridge', () => {
       workspaceCwd: '/repo',
       modelServiceId: undefined,
     });
-    expect(session.prompt).toHaveBeenCalledWith({
-      prompt: [{ type: 'text', text: 'summarize' }],
-    });
+    expect(session.prompt).toHaveBeenCalledWith(
+      {
+        prompt: [{ type: 'text', text: 'summarize' }],
+      },
+      expect.any(AbortSignal),
+    );
 
     events.close();
     bridge.stop();
   });
 
-  it('emits tool, thought, model, and session lifecycle events', async () => {
+  it('emits tool, thought, model, commands, and session lifecycle events', async () => {
     const events = new EventQueue();
     const session = createFakeSession(events);
     const bridge = new DaemonChannelBridge({
@@ -196,11 +212,34 @@ describe('DaemonChannelBridge', () => {
     events.push({
       id: 4,
       v: 1,
+      type: 'session_update',
+      data: {
+        sessionId: 'session-1',
+        update: {
+          sessionUpdate: 'available_commands_update',
+          availableCommands: [
+            { name: '/help', description: 'Show help', input: null },
+          ],
+        },
+      },
+    });
+    await waitFor(() =>
+      expect(bridge.getAvailableCommands('session-1')).toEqual([
+        { name: '/help', description: 'Show help', input: null },
+      ]),
+    );
+    expect(bridge.availableCommands).toEqual([
+      { name: '/help', description: 'Show help', input: null },
+    ]);
+
+    events.push({
+      id: 5,
+      v: 1,
       type: 'model_switched',
       data: { sessionId: 'session-1', modelId: 'qwen3-coder-plus' },
     });
     events.push({
-      id: 5,
+      id: 6,
       v: 1,
       type: 'session_died',
       data: { sessionId: 'session-1', reason: 'agent exited' },
@@ -217,14 +256,19 @@ describe('DaemonChannelBridge', () => {
       status: 'completed',
       rawInput: { path: 'README.md' },
     });
-    expect(modelSwitched).toHaveBeenCalledWith({
-      sessionId: 'session-1',
-      modelId: 'qwen3-coder-plus',
-    });
-    expect(sessionDied).toHaveBeenCalledWith({
-      sessionId: 'session-1',
-      reason: 'agent exited',
-    });
+    await waitFor(() =>
+      expect(modelSwitched).toHaveBeenCalledWith({
+        sessionId: 'session-1',
+        modelId: 'qwen3-coder-plus',
+      }),
+    );
+    await waitFor(() =>
+      expect(sessionDied).toHaveBeenCalledWith({
+        sessionId: 'session-1',
+        reason: 'agent exited',
+      }),
+    );
+    expect(bridge.getAvailableCommands('session-1')).toEqual([]);
 
     events.close();
   });
@@ -296,8 +340,159 @@ describe('DaemonChannelBridge', () => {
       false,
     );
 
+    events.push({
+      id: 8,
+      v: 1,
+      type: 'permission_request',
+      data: request,
+    });
+    await waitFor(() => expect(permissionRequest).toHaveBeenCalledTimes(2));
+    let staleResponse: Promise<boolean> | undefined;
+    bridge.once('sessionDied', () => {
+      staleResponse = bridge.respondToPermission('req-1', response);
+    });
+    events.push({
+      id: 9,
+      v: 1,
+      type: 'session_died',
+      data: { reason: 'gone' },
+    });
+    await waitFor(() => expect(staleResponse).toBeDefined());
+    await expect(staleResponse).resolves.toBe(false);
+
     events.close();
     bridge.stop();
+  });
+
+  it('rejects unknown sessions and concurrent prompts for one session', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    let resolvePrompt: () => void = () => {};
+    session.prompt.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePrompt = () => resolve({ stopReason: 'end_turn' });
+        }),
+    );
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    await expect(bridge.cancelSession('missing')).rejects.toThrow(
+      'No daemon session bound for missing',
+    );
+    await expect(bridge.prompt('missing', 'hello')).rejects.toThrow(
+      'No daemon session bound for missing',
+    );
+    await expect(
+      bridge.setSessionModel('missing', 'qwen3-coder-plus'),
+    ).rejects.toThrow('No daemon session bound for missing');
+
+    const firstPrompt = bridge.prompt('session-1', 'first');
+    await waitFor(() => expect(session.prompt).toHaveBeenCalledOnce());
+    await expect(bridge.prompt('session-1', 'second')).rejects.toThrow(
+      'Prompt already in flight for daemon session session-1',
+    );
+    resolvePrompt();
+    await expect(firstPrompt).resolves.toBe('');
+
+    events.close();
+    bridge.stop();
+  });
+
+  it('passes image prompt blocks and aborts prompts when a session dies', async () => {
+    const events = new EventQueue();
+    const session = createFakeSession(events);
+    session.prompt.mockImplementation(
+      (_req: unknown, signal?: AbortSignal) =>
+        new Promise((_resolve, reject) => {
+          signal?.addEventListener(
+            'abort',
+            () => reject(new DOMException('aborted', 'AbortError')),
+            { once: true },
+          );
+        }),
+    );
+    const bridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(session),
+    });
+
+    await bridge.start();
+    await bridge.newSession('/repo');
+
+    const promptPromise = bridge.prompt('session-1', 'describe', {
+      imageBase64: 'base64-image',
+      imageMimeType: 'image/png',
+    });
+    await waitFor(() => expect(session.prompt).toHaveBeenCalledOnce());
+    expect(session.prompt).toHaveBeenCalledWith(
+      {
+        prompt: [
+          { type: 'image', data: 'base64-image', mimeType: 'image/png' },
+          { type: 'text', text: 'describe' },
+        ],
+      },
+      expect.any(AbortSignal),
+    );
+
+    events.push({
+      id: 10,
+      v: 1,
+      type: 'session_died',
+      data: { reason: 'agent exited' },
+    });
+    await expect(promptPromise).rejects.toThrow('aborted');
+
+    events.close();
+    bridge.stop();
+  });
+
+  it('treats stream errors and normal stream completion as session death', async () => {
+    const failedEvents = new EventQueue();
+    failedEvents.fail(new Error('network down'));
+    const failedSession = createFakeSession(failedEvents);
+    const failedBridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(failedSession),
+    });
+    const failedDied = vi.fn();
+    failedBridge.on('sessionDied', failedDied);
+
+    await failedBridge.start();
+    await failedBridge.newSession('/repo');
+    await waitFor(() =>
+      expect(failedDied).toHaveBeenCalledWith({
+        sessionId: 'session-1',
+        reason: 'network down',
+      }),
+    );
+    await expect(failedBridge.prompt('session-1', 'hello')).rejects.toThrow(
+      'No daemon session bound for session-1',
+    );
+
+    const endedEvents = new EventQueue();
+    const endedSession = createFakeSession(endedEvents);
+    const endedBridge = new DaemonChannelBridge({
+      cwd: '/repo',
+      sessionFactory: vi.fn().mockResolvedValue(endedSession),
+    });
+    const endedDied = vi.fn();
+    endedBridge.on('sessionDied', endedDied);
+
+    await endedBridge.start();
+    await endedBridge.newSession('/repo');
+    endedEvents.close();
+    await waitFor(() =>
+      expect(endedDied).toHaveBeenCalledWith({
+        sessionId: 'session-1',
+        reason: 'stream_ended',
+      }),
+    );
   });
 
   it('loads an existing daemon session and forwards cancel/model changes', async () => {

--- a/packages/channels/base/src/DaemonChannelBridge.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.ts
@@ -6,6 +6,8 @@ import type {
 import type { AvailableCommand, ToolCallEvent } from './AcpBridge.js';
 import type { SessionScope } from './types.js';
 
+const MAX_RESPONDED_PERMISSION_REQUESTS = 256;
+
 export interface DaemonChannelEvent {
   id?: number;
   v: 1;
@@ -63,7 +65,7 @@ export interface DaemonPermissionRequestEvent {
 
 export interface DaemonPermissionResolvedEvent {
   requestId: string;
-  outcome?: unknown;
+  outcome?: DaemonPermissionOutcome;
 }
 
 export interface DaemonPromptCompleteEvent {
@@ -116,6 +118,28 @@ function isPermissionRequestData(
   );
 }
 
+type DaemonPermissionOutcome =
+  | { outcome: 'cancelled' }
+  | { outcome: 'selected'; optionId: string };
+
+function parsePermissionOutcome(
+  value: unknown,
+): DaemonPermissionOutcome | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  if (value['outcome'] === 'cancelled') {
+    return { outcome: 'cancelled' };
+  }
+  if (
+    value['outcome'] === 'selected' &&
+    typeof value['optionId'] === 'string'
+  ) {
+    return { outcome: 'selected', optionId: value['optionId'] };
+  }
+  return undefined;
+}
+
 function summarizeProtocolDetails(details: unknown): unknown {
   if (!isRecord(details)) {
     return { type: typeof details };
@@ -139,6 +163,8 @@ function summarizeProtocolDetails(details: unknown): unknown {
 }
 
 async function drainDaemonEventLoop(): Promise<void> {
+  // TODO(daemon-roadmap): replace this bounded client-side drain with a daemon
+  // terminal turn event / SSE waterline once the typed event schema defines it.
   await new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
 
@@ -147,6 +173,7 @@ export class DaemonChannelBridge extends EventEmitter {
   private readonly sessions = new Map<string, DaemonChannelSessionClient>();
   private readonly eventControllers = new Map<string, AbortController>();
   private readonly requestToSession = new Map<string, string>();
+  private readonly respondedRequestToSession = new Map<string, string>();
   private readonly activePrompts = new Set<string>();
   private readonly activePromptControllers = new Map<
     string,
@@ -311,12 +338,21 @@ export class DaemonChannelBridge extends EventEmitter {
     const session = this.sessions.get(sessionId);
     if (!session) {
       this.requestToSession.delete(requestId);
+      this.respondedRequestToSession.delete(requestId);
       return false;
     }
     try {
-      return await session.respondToPermission(requestId, response);
+      const accepted = await session.respondToPermission(requestId, response);
+      this.requestToSession.delete(requestId);
+      if (accepted) {
+        this.rememberRespondedPermissionRequest(requestId, sessionId);
+      } else {
+        this.respondedRequestToSession.delete(requestId);
+      }
+      return accepted;
     } catch (error) {
       this.requestToSession.delete(requestId);
+      this.respondedRequestToSession.delete(requestId);
       throw error;
     }
   }
@@ -516,6 +552,24 @@ export class DaemonChannelBridge extends EventEmitter {
     } satisfies DaemonPermissionRequestEvent);
   }
 
+  private rememberRespondedPermissionRequest(
+    requestId: string,
+    sessionId: string,
+  ): void {
+    this.respondedRequestToSession.set(requestId, sessionId);
+    while (
+      this.respondedRequestToSession.size > MAX_RESPONDED_PERMISSION_REQUESTS
+    ) {
+      const oldestRequestId = this.respondedRequestToSession
+        .keys()
+        .next().value;
+      if (oldestRequestId === undefined) {
+        return;
+      }
+      this.respondedRequestToSession.delete(oldestRequestId);
+    }
+  }
+
   private handlePermissionResolved(sessionId: string, data: unknown): void {
     if (!isRecord(data) || typeof data['requestId'] !== 'string') {
       this.emitProtocolError(
@@ -525,7 +579,9 @@ export class DaemonChannelBridge extends EventEmitter {
       return;
     }
     const requestId = data['requestId'];
-    const mappedSessionId = this.requestToSession.get(requestId);
+    const mappedSessionId =
+      this.requestToSession.get(requestId) ??
+      this.respondedRequestToSession.get(requestId);
     if (!mappedSessionId) {
       this.emitProtocolError(
         `Ignoring daemon permission_resolved for unknown request ${requestId}`,
@@ -535,16 +591,28 @@ export class DaemonChannelBridge extends EventEmitter {
     }
     if (mappedSessionId !== sessionId) {
       this.requestToSession.delete(requestId);
+      this.respondedRequestToSession.delete(requestId);
       this.emitProtocolError(
         `Ignoring daemon permission_resolved for request ${requestId} from non-owning session ${sessionId}`,
         data,
       );
       return;
     }
+    const outcome = parsePermissionOutcome(data['outcome']);
+    if (!outcome) {
+      this.requestToSession.delete(requestId);
+      this.respondedRequestToSession.delete(requestId);
+      this.emitProtocolError(
+        'Malformed daemon permission_resolved outcome',
+        data,
+      );
+      return;
+    }
     this.requestToSession.delete(requestId);
+    this.respondedRequestToSession.delete(requestId);
     this.emit('permissionResolved', {
       requestId,
-      outcome: data['outcome'],
+      outcome,
     } satisfies DaemonPermissionResolvedEvent);
   }
 
@@ -596,6 +664,11 @@ export class DaemonChannelBridge extends EventEmitter {
     for (const [requestId, mappedSessionId] of this.requestToSession) {
       if (mappedSessionId === sessionId) {
         this.requestToSession.delete(requestId);
+      }
+    }
+    for (const [requestId, mappedSessionId] of this.respondedRequestToSession) {
+      if (mappedSessionId === sessionId) {
+        this.respondedRequestToSession.delete(requestId);
       }
     }
     this.emit('sessionDied', { sessionId, reason });

--- a/packages/channels/base/src/DaemonChannelBridge.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.ts
@@ -63,6 +63,12 @@ export interface DaemonPermissionResolvedEvent {
   outcome?: unknown;
 }
 
+export interface DaemonPromptCompleteEvent {
+  sessionId: string;
+  text: string;
+  stopReason?: string;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null;
 }
@@ -85,6 +91,10 @@ function getSessionUpdate(data: unknown): Record<string, unknown> | undefined {
   return data['update'];
 }
 
+async function drainDaemonEventLoop(): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
 export class DaemonChannelBridge extends EventEmitter {
   private readonly options: DaemonChannelBridgeOptions;
   private readonly sessions = new Map<string, DaemonChannelSessionClient>();
@@ -100,16 +110,30 @@ export class DaemonChannelBridge extends EventEmitter {
     AvailableCommand[]
   >();
   private connected = false;
-  private _availableCommands: AvailableCommand[] = [];
+  private latestAvailableCommandsSessionId: string | undefined;
+  private lastError: unknown;
 
   constructor(options: DaemonChannelBridgeOptions) {
     super();
     this.options = options;
-    this.on('error', () => {});
+    this.on('error', (error) => {
+      this.lastError = error;
+    });
   }
 
   get availableCommands(): AvailableCommand[] {
-    return this._availableCommands;
+    if (this.latestAvailableCommandsSessionId) {
+      return (
+        this.availableCommandsBySession.get(
+          this.latestAvailableCommandsSessionId,
+        ) ?? []
+      );
+    }
+    return Array.from(this.availableCommandsBySession.values()).at(-1) ?? [];
+  }
+
+  get lastDaemonError(): unknown {
+    return this.lastError;
   }
 
   getAvailableCommands(sessionId: string): AvailableCommand[] {
@@ -135,6 +159,11 @@ export class DaemonChannelBridge extends EventEmitter {
       modelServiceId: this.options.modelServiceId,
       sessionId,
     });
+    if (session.sessionId !== sessionId) {
+      throw new Error(
+        `Daemon returned session ${session.sessionId} while loading ${sessionId}`,
+      );
+    }
     this.attachSession(session);
     return session.sessionId;
   }
@@ -185,7 +214,15 @@ export class DaemonChannelBridge extends EventEmitter {
     prompt.push({ type: 'text', text });
 
     try {
-      await session.prompt({ prompt }, controller.signal);
+      const result = await session.prompt({ prompt }, controller.signal);
+      await drainDaemonEventLoop();
+      const textResult = chunks.join('');
+      this.emit('promptComplete', {
+        sessionId,
+        text: textResult,
+        stopReason: result.stopReason,
+      } satisfies DaemonPromptCompleteEvent);
+      return textResult;
     } finally {
       this.off('textChunk', onChunk);
       this.off('sessionDied', onSessionDied);
@@ -195,12 +232,12 @@ export class DaemonChannelBridge extends EventEmitter {
         this.activePromptControllers.delete(sessionId);
       }
     }
-
-    return chunks.join('');
   }
 
   async cancelSession(sessionId: string): Promise<void> {
-    await this.ensureSession(sessionId).cancel();
+    const session = this.ensureSession(sessionId);
+    this.abortActivePrompts(sessionId);
+    await session.cancel();
   }
 
   async setSessionModel(
@@ -227,8 +264,8 @@ export class DaemonChannelBridge extends EventEmitter {
   }
 
   stop(): void {
-    for (const controller of this.eventControllers.values()) {
-      controller.abort();
+    for (const sessionId of Array.from(this.sessions.keys())) {
+      this.dropSession(sessionId, 'bridge_stopped');
     }
     this.eventControllers.clear();
     this.sessions.clear();
@@ -241,7 +278,7 @@ export class DaemonChannelBridge extends EventEmitter {
     this.activePromptControllers.clear();
     this.activePrompts.clear();
     this.availableCommandsBySession.clear();
-    this._availableCommands = [];
+    this.latestAvailableCommandsSessionId = undefined;
     this.connected = false;
   }
 
@@ -250,8 +287,9 @@ export class DaemonChannelBridge extends EventEmitter {
   }
 
   private attachSession(session: DaemonChannelSessionClient): void {
-    const existing = this.eventControllers.get(session.sessionId);
-    existing?.abort();
+    if (this.sessions.has(session.sessionId)) {
+      this.dropSession(session.sessionId, 'session_replaced');
+    }
 
     this.sessions.set(session.sessionId, session);
     const controller = new AbortController();
@@ -305,7 +343,7 @@ export class DaemonChannelBridge extends EventEmitter {
         this.handlePermissionRequest(session.sessionId, event.data);
         break;
       case 'permission_resolved':
-        this.handlePermissionResolved(event.data);
+        this.handlePermissionResolved(session.sessionId, event.data);
         break;
       case 'model_switched':
         this.handleModelSwitched(session.sessionId, event.data);
@@ -336,6 +374,7 @@ export class DaemonChannelBridge extends EventEmitter {
   private handleSessionUpdate(sessionId: string, data: unknown): void {
     const update = getSessionUpdate(data);
     if (!update) {
+      this.emitProtocolError('Malformed daemon session_update event', data);
       return;
     }
 
@@ -374,7 +413,12 @@ export class DaemonChannelBridge extends EventEmitter {
         if (Array.isArray(update['availableCommands'])) {
           const commands = update['availableCommands'] as AvailableCommand[];
           this.availableCommandsBySession.set(sessionId, commands);
-          this._availableCommands = commands;
+          this.latestAvailableCommandsSessionId = sessionId;
+        } else {
+          this.emitProtocolError(
+            'Malformed daemon available_commands_update event',
+            data,
+          );
         }
         break;
       }
@@ -392,6 +436,7 @@ export class DaemonChannelBridge extends EventEmitter {
       !isRecord(data['toolCall']) ||
       !Array.isArray(data['options'])
     ) {
+      this.emitProtocolError('Malformed daemon permission_request event', data);
       return;
     }
     const requestId = data['requestId'];
@@ -403,11 +448,30 @@ export class DaemonChannelBridge extends EventEmitter {
     } satisfies DaemonPermissionRequestEvent);
   }
 
-  private handlePermissionResolved(data: unknown): void {
+  private handlePermissionResolved(sessionId: string, data: unknown): void {
     if (!isRecord(data) || typeof data['requestId'] !== 'string') {
+      this.emitProtocolError(
+        'Malformed daemon permission_resolved event',
+        data,
+      );
       return;
     }
     const requestId = data['requestId'];
+    const mappedSessionId = this.requestToSession.get(requestId);
+    if (!mappedSessionId) {
+      this.emitProtocolError(
+        `Ignoring daemon permission_resolved for unknown request ${requestId}`,
+        data,
+      );
+      return;
+    }
+    if (mappedSessionId !== sessionId) {
+      this.emitProtocolError(
+        `Ignoring daemon permission_resolved for request ${requestId} from non-owning session ${sessionId}`,
+        data,
+      );
+      return;
+    }
     this.requestToSession.delete(requestId);
     this.emit('permissionResolved', {
       requestId,
@@ -417,6 +481,7 @@ export class DaemonChannelBridge extends EventEmitter {
 
   private handleModelSwitched(sessionId: string, data: unknown): void {
     if (!isRecord(data) || typeof data['modelId'] !== 'string') {
+      this.emitProtocolError('Malformed daemon model_switched event', data);
       return;
     }
     this.emit('modelSwitched', {
@@ -427,6 +492,10 @@ export class DaemonChannelBridge extends EventEmitter {
 
   private handleModelSwitchFailed(sessionId: string, data: unknown): void {
     if (!isRecord(data)) {
+      this.emitProtocolError(
+        'Malformed daemon model_switch_failed event',
+        data,
+      );
       return;
     }
     this.emit('modelSwitchFailed', {
@@ -447,17 +516,14 @@ export class DaemonChannelBridge extends EventEmitter {
     this.eventControllers.get(sessionId)?.abort();
     this.eventControllers.delete(sessionId);
     this.sessions.delete(sessionId);
-    const promptControllers = this.activePromptControllers.get(sessionId);
-    if (promptControllers) {
-      for (const controller of promptControllers) {
-        controller.abort();
-      }
-      this.activePromptControllers.delete(sessionId);
-    }
+    this.abortActivePrompts(sessionId);
     this.activePrompts.delete(sessionId);
     this.availableCommandsBySession.delete(sessionId);
-    this._availableCommands =
-      Array.from(this.availableCommandsBySession.values()).at(-1) ?? [];
+    if (this.latestAvailableCommandsSessionId === sessionId) {
+      this.latestAvailableCommandsSessionId = Array.from(
+        this.availableCommandsBySession.keys(),
+      ).at(-1);
+    }
     for (const [requestId, mappedSessionId] of this.requestToSession) {
       if (mappedSessionId === sessionId) {
         this.requestToSession.delete(requestId);
@@ -476,5 +542,22 @@ export class DaemonChannelBridge extends EventEmitter {
     return isRecord(data) && typeof data['error'] === 'string'
       ? data['error']
       : fallback;
+  }
+
+  private abortActivePrompts(sessionId: string): void {
+    const promptControllers = this.activePromptControllers.get(sessionId);
+    if (!promptControllers) {
+      return;
+    }
+    for (const controller of promptControllers) {
+      controller.abort();
+    }
+    this.activePromptControllers.delete(sessionId);
+  }
+
+  private emitProtocolError(message: string, details: unknown): void {
+    const error = new Error(message) as Error & { details?: unknown };
+    error.details = details;
+    this.emit('error', error);
   }
 }

--- a/packages/channels/base/src/DaemonChannelBridge.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.ts
@@ -116,6 +116,28 @@ function isPermissionRequestData(
   );
 }
 
+function summarizeProtocolDetails(details: unknown): unknown {
+  if (!isRecord(details)) {
+    return { type: typeof details };
+  }
+  const summary: Record<string, unknown> = {};
+  for (const key of [
+    'requestId',
+    'sessionId',
+    'sessionUpdate',
+    'modelId',
+    'requestedModelId',
+    'toolCallId',
+    'kind',
+  ]) {
+    const value = details[key];
+    if (typeof value === 'string') {
+      summary[key] = value;
+    }
+  }
+  return summary;
+}
+
 async function drainDaemonEventLoop(): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
@@ -255,7 +277,10 @@ export class DaemonChannelBridge extends EventEmitter {
       this.off('sessionDied', onSessionDied);
       this.activePrompts.delete(sessionId);
       controllers.delete(controller);
-      if (controllers.size === 0) {
+      if (
+        controllers.size === 0 &&
+        this.activePromptControllers.get(sessionId) === controllers
+      ) {
         this.activePromptControllers.delete(sessionId);
       }
     }
@@ -263,8 +288,9 @@ export class DaemonChannelBridge extends EventEmitter {
 
   async cancelSession(sessionId: string): Promise<void> {
     const session = this.ensureSession(sessionId);
-    this.abortActivePrompts(sessionId);
     await session.cancel();
+    this.abortActivePrompts(sessionId);
+    this.activePrompts.delete(sessionId);
   }
 
   async setSessionModel(
@@ -287,24 +313,24 @@ export class DaemonChannelBridge extends EventEmitter {
       this.requestToSession.delete(requestId);
       return false;
     }
-    return await session.respondToPermission(requestId, response);
+    try {
+      return await session.respondToPermission(requestId, response);
+    } catch (error) {
+      this.requestToSession.delete(requestId);
+      throw error;
+    }
   }
 
   stop(): void {
     for (const sessionId of Array.from(this.sessions.keys())) {
+      const session = this.sessions.get(sessionId);
+      if (session) {
+        void session.cancel().catch((error: unknown) => {
+          this.lastError = error;
+        });
+      }
       this.dropSession(sessionId, 'bridge_stopped');
     }
-    this.eventControllers.clear();
-    this.sessions.clear();
-    this.requestToSession.clear();
-    for (const controllers of this.activePromptControllers.values()) {
-      for (const controller of controllers) {
-        controller.abort();
-      }
-    }
-    this.activePromptControllers.clear();
-    this.activePrompts.clear();
-    this.availableCommandsBySession.clear();
     this.latestAvailableCommandsSessionId = undefined;
     this.connected = false;
   }
@@ -436,10 +462,16 @@ export class DaemonChannelBridge extends EventEmitter {
       }
       case 'tool_call':
       case 'tool_call_update': {
+        const toolCallId = getString(update['toolCallId']);
+        const kind = getString(update['kind']);
+        if (!toolCallId || !kind) {
+          this.emitProtocolError(`Malformed daemon ${type} event`, update);
+          break;
+        }
         const event: ToolCallEvent = {
           sessionId,
-          toolCallId: getString(update['toolCallId']) ?? '',
-          kind: getString(update['kind']) ?? '',
+          toolCallId,
+          kind,
           title: getString(update['title']) ?? '',
           status: getString(update['status']) ?? 'pending',
           rawInput: isRecord(update['rawInput'])
@@ -502,6 +534,7 @@ export class DaemonChannelBridge extends EventEmitter {
       return;
     }
     if (mappedSessionId !== sessionId) {
+      this.requestToSession.delete(requestId);
       this.emitProtocolError(
         `Ignoring daemon permission_resolved for request ${requestId} from non-owning session ${sessionId}`,
         data,
@@ -593,7 +626,7 @@ export class DaemonChannelBridge extends EventEmitter {
 
   private emitProtocolError(message: string, details: unknown): void {
     const error = new Error(message) as Error & { details?: unknown };
-    error.details = details;
+    error.details = summarizeProtocolDetails(details);
     this.emit('error', error);
   }
 }

--- a/packages/channels/base/src/DaemonChannelBridge.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.ts
@@ -4,6 +4,7 @@ import type {
   RequestPermissionResponse,
 } from '@agentclientprotocol/sdk';
 import type { AvailableCommand, ToolCallEvent } from './AcpBridge.js';
+import type { SessionScope } from './types.js';
 
 export interface DaemonChannelEvent {
   id?: number;
@@ -40,6 +41,7 @@ export interface DaemonChannelSessionFactoryRequest {
   workspaceCwd: string;
   modelServiceId?: string;
   sessionId?: string;
+  sessionScope?: SessionScope;
 }
 
 export type DaemonChannelSessionFactory = (
@@ -50,6 +52,7 @@ export interface DaemonChannelBridgeOptions {
   cwd: string;
   sessionFactory: DaemonChannelSessionFactory;
   modelServiceId?: string;
+  sessionScope?: SessionScope;
 }
 
 export interface DaemonPermissionRequestEvent {
@@ -89,6 +92,28 @@ function getSessionUpdate(data: unknown): Record<string, unknown> | undefined {
     return undefined;
   }
   return data['update'];
+}
+
+function isAvailableCommand(value: unknown): value is AvailableCommand {
+  return isRecord(value) && typeof value['name'] === 'string';
+}
+
+function isPermissionRequestData(
+  value: unknown,
+): value is RequestPermissionRequest & { requestId: string } {
+  if (
+    !isRecord(value) ||
+    typeof value['requestId'] !== 'string' ||
+    !isRecord(value['toolCall']) ||
+    typeof value['toolCall']['toolCallId'] !== 'string' ||
+    typeof value['toolCall']['kind'] !== 'string' ||
+    !Array.isArray(value['options'])
+  ) {
+    return false;
+  }
+  return value['options'].every(
+    (option) => isRecord(option) && typeof option['optionId'] === 'string',
+  );
 }
 
 async function drainDaemonEventLoop(): Promise<void> {
@@ -148,6 +173,7 @@ export class DaemonChannelBridge extends EventEmitter {
     const session = await this.options.sessionFactory({
       workspaceCwd: cwd || this.options.cwd,
       modelServiceId: this.options.modelServiceId,
+      sessionScope: this.options.sessionScope ?? 'thread',
     });
     this.attachSession(session);
     return session.sessionId;
@@ -158,6 +184,7 @@ export class DaemonChannelBridge extends EventEmitter {
       workspaceCwd: cwd || this.options.cwd,
       modelServiceId: this.options.modelServiceId,
       sessionId,
+      sessionScope: this.options.sessionScope ?? 'thread',
     });
     if (session.sessionId !== sessionId) {
       throw new Error(
@@ -315,13 +342,16 @@ export class DaemonChannelBridge extends EventEmitter {
         lastEventId: session.lastEventId,
         resume: true,
       })) {
+        if (!this.isCurrentPump(session, signal)) {
+          return;
+        }
         this.handleEvent(session, event);
       }
-      if (!signal.aborted) {
+      if (!signal.aborted && this.isCurrentPump(session, signal)) {
         this.dropSession(session.sessionId, 'stream_ended');
       }
     } catch (error) {
-      if (!signal.aborted) {
+      if (!signal.aborted && this.isCurrentPump(session, signal)) {
         this.emit('error', error);
         this.dropSession(
           session.sessionId,
@@ -329,6 +359,16 @@ export class DaemonChannelBridge extends EventEmitter {
         );
       }
     }
+  }
+
+  private isCurrentPump(
+    session: DaemonChannelSessionClient,
+    signal: AbortSignal,
+  ): boolean {
+    return (
+      this.sessions.get(session.sessionId) === session &&
+      this.eventControllers.get(session.sessionId)?.signal === signal
+    );
   }
 
   private handleEvent(
@@ -411,7 +451,8 @@ export class DaemonChannelBridge extends EventEmitter {
       }
       case 'available_commands_update': {
         if (Array.isArray(update['availableCommands'])) {
-          const commands = update['availableCommands'] as AvailableCommand[];
+          const commands =
+            update['availableCommands'].filter(isAvailableCommand);
           this.availableCommandsBySession.set(sessionId, commands);
           this.latestAvailableCommandsSessionId = sessionId;
         } else {
@@ -430,12 +471,7 @@ export class DaemonChannelBridge extends EventEmitter {
   }
 
   private handlePermissionRequest(sessionId: string, data: unknown): void {
-    if (
-      !isRecord(data) ||
-      typeof data['requestId'] !== 'string' ||
-      !isRecord(data['toolCall']) ||
-      !Array.isArray(data['options'])
-    ) {
+    if (!isPermissionRequestData(data)) {
       this.emitProtocolError('Malformed daemon permission_request event', data);
       return;
     }

--- a/packages/channels/base/src/DaemonChannelBridge.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.ts
@@ -1,0 +1,352 @@
+import { EventEmitter } from 'node:events';
+import type {
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+} from '@agentclientprotocol/sdk';
+import type { AvailableCommand, ToolCallEvent } from './AcpBridge.js';
+
+export interface DaemonChannelEvent {
+  id?: number;
+  v: 1;
+  type: string;
+  data: unknown;
+  originatorClientId?: string;
+}
+
+export interface DaemonChannelSessionClient {
+  readonly sessionId: string;
+  readonly workspaceCwd: string;
+  readonly lastEventId?: number;
+  prompt(req: {
+    prompt: Array<Record<string, unknown>>;
+  }): Promise<{ stopReason?: string; [key: string]: unknown }>;
+  events(opts?: {
+    signal?: AbortSignal;
+    lastEventId?: number;
+    resume?: boolean;
+  }): AsyncGenerator<DaemonChannelEvent>;
+  cancel(): Promise<void>;
+  setModel(modelId: string): Promise<Record<string, unknown>>;
+  respondToPermission(
+    requestId: string,
+    response: RequestPermissionResponse,
+  ): Promise<boolean>;
+}
+
+export interface DaemonChannelSessionFactoryRequest {
+  workspaceCwd: string;
+  modelServiceId?: string;
+  sessionId?: string;
+}
+
+export type DaemonChannelSessionFactory = (
+  req: DaemonChannelSessionFactoryRequest,
+) => Promise<DaemonChannelSessionClient>;
+
+export interface DaemonChannelBridgeOptions {
+  cwd: string;
+  sessionFactory: DaemonChannelSessionFactory;
+  modelServiceId?: string;
+}
+
+export interface DaemonPermissionRequestEvent {
+  requestId: string;
+  sessionId: string;
+  request: RequestPermissionRequest;
+}
+
+export interface DaemonPermissionResolvedEvent {
+  requestId: string;
+  outcome?: unknown;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' ? value : undefined;
+}
+
+function getTextContent(content: unknown): string | undefined {
+  if (!isRecord(content)) {
+    return undefined;
+  }
+  return getString(content['text']);
+}
+
+function getSessionUpdate(data: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(data) || !isRecord(data['update'])) {
+    return undefined;
+  }
+  return data['update'];
+}
+
+export class DaemonChannelBridge extends EventEmitter {
+  private readonly options: DaemonChannelBridgeOptions;
+  private readonly sessions = new Map<string, DaemonChannelSessionClient>();
+  private readonly eventControllers = new Map<string, AbortController>();
+  private readonly requestToSession = new Map<string, string>();
+  private connected = false;
+  private _availableCommands: AvailableCommand[] = [];
+
+  constructor(options: DaemonChannelBridgeOptions) {
+    super();
+    this.options = options;
+  }
+
+  get availableCommands(): AvailableCommand[] {
+    return this._availableCommands;
+  }
+
+  async start(): Promise<void> {
+    this.connected = true;
+  }
+
+  async newSession(cwd: string): Promise<string> {
+    const session = await this.options.sessionFactory({
+      workspaceCwd: cwd || this.options.cwd,
+      modelServiceId: this.options.modelServiceId,
+    });
+    this.attachSession(session);
+    return session.sessionId;
+  }
+
+  async loadSession(sessionId: string, cwd: string): Promise<string> {
+    const session = await this.options.sessionFactory({
+      workspaceCwd: cwd || this.options.cwd,
+      modelServiceId: this.options.modelServiceId,
+      sessionId,
+    });
+    this.attachSession(session);
+    return session.sessionId;
+  }
+
+  async prompt(
+    sessionId: string,
+    text: string,
+    options?: { imageBase64?: string; imageMimeType?: string },
+  ): Promise<string> {
+    const session = this.ensureSession(sessionId);
+    const chunks: string[] = [];
+    const onChunk = (sid: string, chunk: string) => {
+      if (sid === sessionId) {
+        chunks.push(chunk);
+      }
+    };
+    this.on('textChunk', onChunk);
+
+    const prompt: Array<Record<string, unknown>> = [];
+    if (options?.imageBase64 && options.imageMimeType) {
+      prompt.push({
+        type: 'image',
+        data: options.imageBase64,
+        mimeType: options.imageMimeType,
+      });
+    }
+    prompt.push({ type: 'text', text });
+
+    try {
+      await session.prompt({ prompt });
+    } finally {
+      this.off('textChunk', onChunk);
+    }
+
+    return chunks.join('');
+  }
+
+  async cancelSession(sessionId: string): Promise<void> {
+    await this.ensureSession(sessionId).cancel();
+  }
+
+  async setSessionModel(
+    sessionId: string,
+    modelId: string,
+  ): Promise<Record<string, unknown>> {
+    return await this.ensureSession(sessionId).setModel(modelId);
+  }
+
+  async respondToPermission(
+    requestId: string,
+    response: RequestPermissionResponse,
+  ): Promise<boolean> {
+    const sessionId = this.requestToSession.get(requestId);
+    if (!sessionId) {
+      return false;
+    }
+    return await this.ensureSession(sessionId).respondToPermission(
+      requestId,
+      response,
+    );
+  }
+
+  stop(): void {
+    for (const controller of this.eventControllers.values()) {
+      controller.abort();
+    }
+    this.eventControllers.clear();
+    this.sessions.clear();
+    this.requestToSession.clear();
+    this.connected = false;
+  }
+
+  get isConnected(): boolean {
+    return this.connected;
+  }
+
+  private attachSession(session: DaemonChannelSessionClient): void {
+    const existing = this.eventControllers.get(session.sessionId);
+    existing?.abort();
+
+    this.sessions.set(session.sessionId, session);
+    const controller = new AbortController();
+    this.eventControllers.set(session.sessionId, controller);
+    void this.pumpEvents(session, controller.signal);
+  }
+
+  private ensureSession(sessionId: string): DaemonChannelSessionClient {
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      throw new Error(`No daemon session bound for ${sessionId}`);
+    }
+    return session;
+  }
+
+  private async pumpEvents(
+    session: DaemonChannelSessionClient,
+    signal: AbortSignal,
+  ): Promise<void> {
+    try {
+      for await (const event of session.events({ signal })) {
+        this.handleEvent(session, event);
+      }
+    } catch (error) {
+      if (!signal.aborted) {
+        this.emit('error', error);
+      }
+    }
+  }
+
+  private handleEvent(
+    session: DaemonChannelSessionClient,
+    event: DaemonChannelEvent,
+  ): void {
+    switch (event.type) {
+      case 'session_update':
+        this.handleSessionUpdate(session.sessionId, event.data);
+        break;
+      case 'permission_request':
+        this.handlePermissionRequest(session.sessionId, event.data);
+        break;
+      case 'permission_resolved':
+        this.handlePermissionResolved(event.data);
+        break;
+      case 'model_switched':
+        this.handleModelSwitched(session.sessionId, event.data);
+        break;
+      case 'session_died':
+        this.handleSessionDied(session.sessionId, event.data);
+        break;
+      default:
+        break;
+    }
+  }
+
+  private handleSessionUpdate(sessionId: string, data: unknown): void {
+    const update = getSessionUpdate(data);
+    if (!update) {
+      return;
+    }
+
+    const type = getString(update['sessionUpdate']);
+    switch (type) {
+      case 'agent_message_chunk': {
+        const text = getTextContent(update['content']);
+        if (text) {
+          this.emit('textChunk', sessionId, text);
+        }
+        break;
+      }
+      case 'agent_thought_chunk': {
+        const text = getTextContent(update['content']);
+        if (text) {
+          this.emit('thoughtChunk', sessionId, text);
+        }
+        break;
+      }
+      case 'tool_call':
+      case 'tool_call_update': {
+        const event: ToolCallEvent = {
+          sessionId,
+          toolCallId: getString(update['toolCallId']) ?? '',
+          kind: getString(update['kind']) ?? '',
+          title: getString(update['title']) ?? '',
+          status: getString(update['status']) ?? 'pending',
+          rawInput: isRecord(update['rawInput'])
+            ? update['rawInput']
+            : undefined,
+        };
+        this.emit('toolCall', event);
+        break;
+      }
+      case 'available_commands_update': {
+        if (Array.isArray(update['availableCommands'])) {
+          this._availableCommands = update[
+            'availableCommands'
+          ] as AvailableCommand[];
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+    this.emit('sessionUpdate', data);
+  }
+
+  private handlePermissionRequest(sessionId: string, data: unknown): void {
+    if (!isRecord(data) || typeof data['requestId'] !== 'string') {
+      return;
+    }
+    const requestId = data['requestId'];
+    this.requestToSession.set(requestId, sessionId);
+    this.emit('permissionRequest', {
+      requestId,
+      sessionId,
+      request: data as unknown as RequestPermissionRequest,
+    } satisfies DaemonPermissionRequestEvent);
+  }
+
+  private handlePermissionResolved(data: unknown): void {
+    if (!isRecord(data) || typeof data['requestId'] !== 'string') {
+      return;
+    }
+    const requestId = data['requestId'];
+    this.requestToSession.delete(requestId);
+    this.emit('permissionResolved', {
+      requestId,
+      outcome: data['outcome'],
+    } satisfies DaemonPermissionResolvedEvent);
+  }
+
+  private handleModelSwitched(sessionId: string, data: unknown): void {
+    if (!isRecord(data) || typeof data['modelId'] !== 'string') {
+      return;
+    }
+    this.emit('modelSwitched', {
+      sessionId,
+      modelId: data['modelId'],
+    });
+  }
+
+  private handleSessionDied(sessionId: string, data: unknown): void {
+    const reason =
+      isRecord(data) && typeof data['reason'] === 'string'
+        ? data['reason']
+        : 'session_died';
+    this.eventControllers.get(sessionId)?.abort();
+    this.eventControllers.delete(sessionId);
+    this.sessions.delete(sessionId);
+    this.emit('sessionDied', { sessionId, reason });
+  }
+}

--- a/packages/channels/base/src/DaemonChannelBridge.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.ts
@@ -17,9 +17,12 @@ export interface DaemonChannelSessionClient {
   readonly sessionId: string;
   readonly workspaceCwd: string;
   readonly lastEventId?: number;
-  prompt(req: {
-    prompt: Array<Record<string, unknown>>;
-  }): Promise<{ stopReason?: string; [key: string]: unknown }>;
+  prompt(
+    req: {
+      prompt: Array<Record<string, unknown>>;
+    },
+    signal?: AbortSignal,
+  ): Promise<{ stopReason?: string; [key: string]: unknown }>;
   events(opts?: {
     signal?: AbortSignal;
     lastEventId?: number;
@@ -87,16 +90,26 @@ export class DaemonChannelBridge extends EventEmitter {
   private readonly sessions = new Map<string, DaemonChannelSessionClient>();
   private readonly eventControllers = new Map<string, AbortController>();
   private readonly requestToSession = new Map<string, string>();
+  private readonly activePrompts = new Set<string>();
+  private readonly availableCommandsBySession = new Map<
+    string,
+    AvailableCommand[]
+  >();
   private connected = false;
   private _availableCommands: AvailableCommand[] = [];
 
   constructor(options: DaemonChannelBridgeOptions) {
     super();
     this.options = options;
+    this.on('error', () => {});
   }
 
   get availableCommands(): AvailableCommand[] {
     return this._availableCommands;
+  }
+
+  getAvailableCommands(sessionId: string): AvailableCommand[] {
+    return this.availableCommandsBySession.get(sessionId) ?? [];
   }
 
   async start(): Promise<void> {
@@ -128,13 +141,27 @@ export class DaemonChannelBridge extends EventEmitter {
     options?: { imageBase64?: string; imageMimeType?: string },
   ): Promise<string> {
     const session = this.ensureSession(sessionId);
+    if (this.activePrompts.has(sessionId)) {
+      throw new Error(
+        `Prompt already in flight for daemon session ${sessionId}`,
+      );
+    }
+    this.activePrompts.add(sessionId);
+
+    const controller = new AbortController();
     const chunks: string[] = [];
     const onChunk = (sid: string, chunk: string) => {
       if (sid === sessionId) {
         chunks.push(chunk);
       }
     };
+    const onSessionDied = (info: { sessionId: string }) => {
+      if (info.sessionId === sessionId) {
+        controller.abort();
+      }
+    };
     this.on('textChunk', onChunk);
+    this.on('sessionDied', onSessionDied);
 
     const prompt: Array<Record<string, unknown>> = [];
     if (options?.imageBase64 && options.imageMimeType) {
@@ -147,9 +174,11 @@ export class DaemonChannelBridge extends EventEmitter {
     prompt.push({ type: 'text', text });
 
     try {
-      await session.prompt({ prompt });
+      await session.prompt({ prompt }, controller.signal);
     } finally {
       this.off('textChunk', onChunk);
+      this.off('sessionDied', onSessionDied);
+      this.activePrompts.delete(sessionId);
     }
 
     return chunks.join('');
@@ -174,10 +203,12 @@ export class DaemonChannelBridge extends EventEmitter {
     if (!sessionId) {
       return false;
     }
-    return await this.ensureSession(sessionId).respondToPermission(
-      requestId,
-      response,
-    );
+    const session = this.sessions.get(sessionId);
+    if (!session) {
+      this.requestToSession.delete(requestId);
+      return false;
+    }
+    return await session.respondToPermission(requestId, response);
   }
 
   stop(): void {
@@ -187,6 +218,9 @@ export class DaemonChannelBridge extends EventEmitter {
     this.eventControllers.clear();
     this.sessions.clear();
     this.requestToSession.clear();
+    this.activePrompts.clear();
+    this.availableCommandsBySession.clear();
+    this._availableCommands = [];
     this.connected = false;
   }
 
@@ -217,12 +251,23 @@ export class DaemonChannelBridge extends EventEmitter {
     signal: AbortSignal,
   ): Promise<void> {
     try {
-      for await (const event of session.events({ signal })) {
+      for await (const event of session.events({
+        signal,
+        lastEventId: session.lastEventId,
+        resume: true,
+      })) {
         this.handleEvent(session, event);
+      }
+      if (!signal.aborted) {
+        this.dropSession(session.sessionId, 'stream_ended');
       }
     } catch (error) {
       if (!signal.aborted) {
         this.emit('error', error);
+        this.dropSession(
+          session.sessionId,
+          error instanceof Error ? error.message : String(error),
+        );
       }
     }
   }
@@ -291,9 +336,9 @@ export class DaemonChannelBridge extends EventEmitter {
       }
       case 'available_commands_update': {
         if (Array.isArray(update['availableCommands'])) {
-          this._availableCommands = update[
-            'availableCommands'
-          ] as AvailableCommand[];
+          const commands = update['availableCommands'] as AvailableCommand[];
+          this.availableCommandsBySession.set(sessionId, commands);
+          this._availableCommands = commands;
         }
         break;
       }
@@ -305,7 +350,12 @@ export class DaemonChannelBridge extends EventEmitter {
   }
 
   private handlePermissionRequest(sessionId: string, data: unknown): void {
-    if (!isRecord(data) || typeof data['requestId'] !== 'string') {
+    if (
+      !isRecord(data) ||
+      typeof data['requestId'] !== 'string' ||
+      !isRecord(data['toolCall']) ||
+      !Array.isArray(data['options'])
+    ) {
       return;
     }
     const requestId = data['requestId'];
@@ -344,9 +394,25 @@ export class DaemonChannelBridge extends EventEmitter {
       isRecord(data) && typeof data['reason'] === 'string'
         ? data['reason']
         : 'session_died';
+    this.dropSession(sessionId, reason);
+  }
+
+  private dropSession(sessionId: string, reason: string): void {
+    if (!this.sessions.has(sessionId)) {
+      return;
+    }
     this.eventControllers.get(sessionId)?.abort();
     this.eventControllers.delete(sessionId);
     this.sessions.delete(sessionId);
+    this.activePrompts.delete(sessionId);
+    this.availableCommandsBySession.delete(sessionId);
+    this._availableCommands =
+      Array.from(this.availableCommandsBySession.values()).at(-1) ?? [];
+    for (const [requestId, mappedSessionId] of this.requestToSession) {
+      if (mappedSessionId === sessionId) {
+        this.requestToSession.delete(requestId);
+      }
+    }
     this.emit('sessionDied', { sessionId, reason });
   }
 }

--- a/packages/channels/base/src/DaemonChannelBridge.ts
+++ b/packages/channels/base/src/DaemonChannelBridge.ts
@@ -91,6 +91,10 @@ export class DaemonChannelBridge extends EventEmitter {
   private readonly eventControllers = new Map<string, AbortController>();
   private readonly requestToSession = new Map<string, string>();
   private readonly activePrompts = new Set<string>();
+  private readonly activePromptControllers = new Map<
+    string,
+    Set<AbortController>
+  >();
   private readonly availableCommandsBySession = new Map<
     string,
     AvailableCommand[]
@@ -149,6 +153,13 @@ export class DaemonChannelBridge extends EventEmitter {
     this.activePrompts.add(sessionId);
 
     const controller = new AbortController();
+    let controllers = this.activePromptControllers.get(sessionId);
+    if (!controllers) {
+      controllers = new Set();
+      this.activePromptControllers.set(sessionId, controllers);
+    }
+    controllers.add(controller);
+
     const chunks: string[] = [];
     const onChunk = (sid: string, chunk: string) => {
       if (sid === sessionId) {
@@ -179,6 +190,10 @@ export class DaemonChannelBridge extends EventEmitter {
       this.off('textChunk', onChunk);
       this.off('sessionDied', onSessionDied);
       this.activePrompts.delete(sessionId);
+      controllers.delete(controller);
+      if (controllers.size === 0) {
+        this.activePromptControllers.delete(sessionId);
+      }
     }
 
     return chunks.join('');
@@ -218,6 +233,12 @@ export class DaemonChannelBridge extends EventEmitter {
     this.eventControllers.clear();
     this.sessions.clear();
     this.requestToSession.clear();
+    for (const controllers of this.activePromptControllers.values()) {
+      for (const controller of controllers) {
+        controller.abort();
+      }
+    }
+    this.activePromptControllers.clear();
     this.activePrompts.clear();
     this.availableCommandsBySession.clear();
     this._availableCommands = [];
@@ -289,8 +310,23 @@ export class DaemonChannelBridge extends EventEmitter {
       case 'model_switched':
         this.handleModelSwitched(session.sessionId, event.data);
         break;
+      case 'model_switch_failed':
+        this.handleModelSwitchFailed(session.sessionId, event.data);
+        break;
       case 'session_died':
         this.handleSessionDied(session.sessionId, event.data);
+        break;
+      case 'client_evicted':
+        this.dropSession(
+          session.sessionId,
+          this.getReason(event.data, 'client_evicted'),
+        );
+        break;
+      case 'stream_error':
+        this.dropSession(
+          session.sessionId,
+          this.getError(event.data, 'stream_error'),
+        );
         break;
       default:
         break;
@@ -389,12 +425,19 @@ export class DaemonChannelBridge extends EventEmitter {
     });
   }
 
+  private handleModelSwitchFailed(sessionId: string, data: unknown): void {
+    if (!isRecord(data)) {
+      return;
+    }
+    this.emit('modelSwitchFailed', {
+      sessionId,
+      requestedModelId: getString(data['requestedModelId']),
+      error: getString(data['error']) ?? 'model_switch_failed',
+    });
+  }
+
   private handleSessionDied(sessionId: string, data: unknown): void {
-    const reason =
-      isRecord(data) && typeof data['reason'] === 'string'
-        ? data['reason']
-        : 'session_died';
-    this.dropSession(sessionId, reason);
+    this.dropSession(sessionId, this.getReason(data, 'session_died'));
   }
 
   private dropSession(sessionId: string, reason: string): void {
@@ -404,6 +447,13 @@ export class DaemonChannelBridge extends EventEmitter {
     this.eventControllers.get(sessionId)?.abort();
     this.eventControllers.delete(sessionId);
     this.sessions.delete(sessionId);
+    const promptControllers = this.activePromptControllers.get(sessionId);
+    if (promptControllers) {
+      for (const controller of promptControllers) {
+        controller.abort();
+      }
+      this.activePromptControllers.delete(sessionId);
+    }
     this.activePrompts.delete(sessionId);
     this.availableCommandsBySession.delete(sessionId);
     this._availableCommands =
@@ -414,5 +464,17 @@ export class DaemonChannelBridge extends EventEmitter {
       }
     }
     this.emit('sessionDied', { sessionId, reason });
+  }
+
+  private getReason(data: unknown, fallback: string): string {
+    return isRecord(data) && typeof data['reason'] === 'string'
+      ? data['reason']
+      : fallback;
+  }
+
+  private getError(data: unknown, fallback: string): string {
+    return isRecord(data) && typeof data['error'] === 'string'
+      ? data['error']
+      : fallback;
   }
 }

--- a/packages/channels/base/src/index.ts
+++ b/packages/channels/base/src/index.ts
@@ -12,6 +12,7 @@ export type {
   DaemonChannelSessionClient,
   DaemonChannelSessionFactory,
   DaemonChannelSessionFactoryRequest,
+  DaemonPromptCompleteEvent,
   DaemonPermissionRequestEvent,
   DaemonPermissionResolvedEvent,
 } from './DaemonChannelBridge.js';

--- a/packages/channels/base/src/index.ts
+++ b/packages/channels/base/src/index.ts
@@ -5,6 +5,16 @@ export type {
   AvailableCommand,
   ToolCallEvent,
 } from './AcpBridge.js';
+export { DaemonChannelBridge } from './DaemonChannelBridge.js';
+export type {
+  DaemonChannelBridgeOptions,
+  DaemonChannelEvent,
+  DaemonChannelSessionClient,
+  DaemonChannelSessionFactory,
+  DaemonChannelSessionFactoryRequest,
+  DaemonPermissionRequestEvent,
+  DaemonPermissionResolvedEvent,
+} from './DaemonChannelBridge.js';
 export { BlockStreamer } from './BlockStreamer.js';
 export type { BlockStreamerOptions } from './BlockStreamer.js';
 export { ChannelBase } from './ChannelBase.js';


### PR DESCRIPTION
## Summary

- What changed: Added a locally verifiable `DaemonChannelBridge` in `@qwen-code/channel-base` for server-side channel/web backends to bind daemon sessions, consume daemon SSE events, collect assistant text, and route permission/cancel/model operations.
- Why it changed: Channel bots and web chat backends can dogfood Mode B early, but the daemon token and session state must stay in the backend/BFF process rather than browser JavaScript or platform clients.
- Reviewer focus: Server-side-only boundary, bridge compatibility with current channel event shapes, and the fact that `qwen channel start` still uses the existing ACP bridge by default.

## Validation

- Commands run:
  ```bash
  cd packages/channels/base && npx vitest run src/DaemonChannelBridge.test.ts
  cd packages/channels/base && npm run build
  npx eslint packages/channels/base/src/DaemonChannelBridge.ts packages/channels/base/src/DaemonChannelBridge.test.ts --max-warnings 0 --no-warn-ignored
  cd packages/channels/base && npx prettier --check src/DaemonChannelBridge.ts src/DaemonChannelBridge.test.ts ../../../docs/developers/daemon-client-adapters/channel-web.md
  git diff --check
  ```
- Prompts / inputs used: Unit tests use a fake daemon session and synthetic daemon events.
- Expected result: Bridge binds sessions, collects streamed assistant text, fans out daemon events, and forwards backend operations without changing existing channel behavior.
- Observed result: Targeted vitest passed with 4 tests. Channel-base build, targeted ESLint, Prettier check, and diff check passed.
- Quickest reviewer verification path: `cd packages/channels/base && npx vitest run src/DaemonChannelBridge.test.ts`.
- Evidence: Test output reports `src/DaemonChannelBridge.test.ts (4 tests)` and `Test Files 1 passed`.

## Scope / Risk

- Main risk or tradeoff: This is a server-side bridge spike only. It proves the channel/web backend daemon surface but does not yet wire any built-in channel or browser BFF route to use it.
- Not covered / not validated: No live `qwen serve` smoke, no `qwen channel start` flag/env wiring, no browser websocket/SSE BFF route, no per-request `sessionScope`, and no default channel migration.
- Breaking changes / migration notes: None. Existing ACP channel bridge, Telegram, Weixin, Dingtalk, plugin channels, and browser behavior are unchanged.

## Engineering principles checklist (Stage 1.5 wave PRs)

- [x] Independently mergeable (main stays releasable after merge)
- [x] Backward compatible (no removed routes / event fields / CLI behavior)
- [x] Default off (feature flag or dual-stack; old path unchanged)
- [x] `qwen serve` Stage 1 routes / SDK behavior preserved
- [x] Gradual migration (P0/P1 base before adapters; behind flag first)
- [x] Reversible (this PR can be individually rolled back)
- [x] Tests-first (unit / smoke / e2e where relevant)

## Linked Issues / Bugs

Related to #4175 Wave 5 adapter track and #4201.
