### PR TITLE
test(perf): add daemon baseline harness (#4175 Wave 1 PR 1)

### DIFF
--- a/integration-tests/baselines/baseline-stage-1.json
+++ b/integration-tests/baselines/baseline-stage-1.json
@@ -1,0 +1,53 @@
+{
+  "version": 1,
+  "capturedAt": "2026-05-16T08:36:52.441Z",
+  "gitCommit": "df32345d0553560cf342c1b4e6ad44df5646111b",
+  "platform": {
+    "os": "darwin",
+    "arch": "arm64",
+    "nodeVersion": "v24.12.0"
+  },
+  "notes": [
+    "Daemon defaults to sessionScope: \"single\", so N successive createOrAttachSession calls against the same workspace return the same sessionId. RSS scaling and MCP amplification metrics here reflect \"N attaches to one shared session\", not \"N distinct sessions\".",
+    "After Wave 2 PR 5 (per-request sessionScope override) lands, this harness will be updated to optionally pass sessionScope: \"thread\" so the same metrics expose per-session cost and surface the P1 MCP N×M amplification before M2 fixes it."
+  ],
+  "config": {
+    "promptIterations": 20,
+    "rssSampleIntervalMs": 100,
+    "rssSampleDurationMs": 2000,
+    "heavy": false
+  },
+  "rssScaling": {
+    "session1MB": 223.5,
+    "session5MB": 224.2,
+    "session10MB": 223.9,
+    "sampleCount": 60,
+    "growthPerSessionMB": 0
+  },
+  "attachLatency": {
+    "session2Ms": 3,
+    "session5Ms": 1,
+    "thresholdMs": 1000
+  },
+  "mcpAmplification": {
+    "mcpServersConfigured": 2,
+    "childrenAt1Session": 1,
+    "childrenAt3Sessions": 1,
+    "childrenAt5Sessions": 1,
+    "linearAmplification": false
+  },
+  "sseBackpressure": {
+    "ringSize": 4000,
+    "maxQueuedDefault": 256,
+    "evictionAtOverflow": true,
+    "replayUpToRing": true,
+    "heartbeatIntervalMs": 15000
+  },
+  "promptLatency": {
+    "iterations": 0,
+    "firstByteMs": null,
+    "totalMs": null,
+    "skipped": true,
+    "skipReason": "QWEN_TEST_MODEL_KEY not set; prompt latency requires a real model credential."
+  }
+}

--- a/integration-tests/baselines/baseline-stage-1.json
+++ b/integration-tests/baselines/baseline-stage-1.json
@@ -22,6 +22,7 @@
     "session5MB": 224.2,
     "session10MB": 223.9,
     "sampleCount": 60,
+    "droppedSampleCount": 0,
     "growthPerSessionMB": 0
   },
   "attachLatency": {
@@ -31,9 +32,9 @@
   },
   "mcpAmplification": {
     "mcpServersConfigured": 2,
-    "childrenAt1Session": 1,
-    "childrenAt3Sessions": 1,
-    "childrenAt5Sessions": 1,
+    "childrenAt1Session": 4,
+    "childrenAt3Sessions": 4,
+    "childrenAt5Sessions": 4,
     "linearAmplification": false
   },
   "sseBackpressure": {
@@ -48,6 +49,6 @@
     "firstByteMs": null,
     "totalMs": null,
     "skipped": true,
-    "skipReason": "QWEN_TEST_MODEL_KEY not set; prompt latency requires a real model credential."
+    "skipReason": "No recognized model credential env var is set; prompt latency requires real model access. Set QWEN_BASELINE_ENABLE_PROMPT_LATENCY=1 to force-run with non-env auth."
   }
 }

--- a/integration-tests/cli/_daemon-harness.ts
+++ b/integration-tests/cli/_daemon-harness.ts
@@ -1,0 +1,455 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Reusable helpers for `qwen serve` daemon tests:
+ *
+ *   - `spawnDaemon` lifts the inline `beforeAll` boot pattern from
+ *     `qwen-serve-routes.test.ts` / `qwen-serve-streaming.test.ts` into one
+ *     place so test files don't reimplement port-0 wait + token + workspace
+ *     pinning + SIGTERM teardown.
+ *   - `getRssMB` / `startRssPolling` sample the daemon process's RSS via
+ *     `ps -o rss=`. POSIX-only (no Windows). Used to capture the RSS curve
+ *     across session counts.
+ *   - `countDescendants` walks the daemon's process tree two levels via
+ *     `pgrep -P` (matches the existing inline pattern at
+ *     `qwen-serve-streaming.test.ts:144`). Used to surface the P1
+ *     "MCP child × session" amplification before the M2 shared-pool fix.
+ *   - `percentiles` is a dependency-free p50/p90/p99 calculator for the
+ *     prompt-latency suite.
+ *   - `consumeSseEvents` drives the daemon's SSE stream at a configurable
+ *     rate so the SSE backpressure tests can observe `client_evicted`.
+ *
+ * Skip-on-Windows is the caller's responsibility: at the top of every test
+ * file that imports this harness, gate with
+ * `if (process.platform === 'win32') describe.skip(...)`. The harness
+ * functions assume `ps` and `pgrep` are present.
+ */
+
+import {
+  spawn,
+  type ChildProcess,
+  execFileSync,
+  type ExecFileSyncOptionsWithStringEncoding,
+} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DaemonClient, type SubscribeOptions } from '@qwen-code/sdk';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Default workspace and CLI binary resolution mirrors the existing
+ * `qwen-serve-routes.test.ts` constants so callers that copy/paste between
+ * test files don't see drift.
+ */
+export const DEFAULT_REPO_ROOT = path.resolve(__dirname, '../..');
+export const DEFAULT_TOKEN = 'integration-test-token';
+export const DEFAULT_CLI_BIN =
+  process.env['TEST_CLI_PATH'] ??
+  path.resolve(__dirname, '../../packages/cli/dist/index.js');
+
+export interface SpawnDaemonOptions {
+  /**
+   * Workspace path the daemon binds to (`--workspace`). Defaults to repo
+   * root. Tests measuring MCP amplification or wanting their own settings
+   * file should pass a temp dir created via `prepareWorkspace`.
+   */
+  workspaceCwd?: string;
+  /** Bearer token. Defaults to the same string the existing tests use. */
+  token?: string;
+  /** CLI binary path. Defaults to `TEST_CLI_PATH` env or `dist/cli.js`. */
+  cliBin?: string;
+  /** Boot deadline for the listening-on regex parse. Default 10s. */
+  bootTimeoutMs?: number;
+  /** Extra args appended after the standard ones. */
+  extraArgs?: string[];
+  /** Optional env additions for the spawned daemon. */
+  env?: Record<string, string>;
+}
+
+export interface SpawnedDaemon {
+  client: DaemonClient;
+  daemon: ChildProcess;
+  port: number;
+  base: string;
+  workspaceCwd: string;
+  token: string;
+  /** Drain stdout into this buffer for post-mortem if a test fails. */
+  stdoutBuf: { value: string };
+  /** Drain stderr similarly — surface on dispose if exit code != 0. */
+  stderrBuf: { value: string };
+  /** Idempotent. Sends SIGTERM, awaits exit (up to 5s). */
+  dispose: () => Promise<void>;
+}
+
+const LISTENING_RE = /listening on http:\/\/127\.0\.0\.1:(\d+)/;
+const DISPOSE_GRACE_MS = 5_000;
+
+export async function spawnDaemon(
+  opts: SpawnDaemonOptions = {},
+): Promise<SpawnedDaemon> {
+  const workspaceCwd = opts.workspaceCwd ?? DEFAULT_REPO_ROOT;
+  const token = opts.token ?? DEFAULT_TOKEN;
+  const cliBin = opts.cliBin ?? DEFAULT_CLI_BIN;
+  const bootTimeoutMs = opts.bootTimeoutMs ?? 10_000;
+  const extraArgs = opts.extraArgs ?? [];
+
+  const args = [
+    cliBin,
+    'serve',
+    '--port',
+    '0',
+    '--token',
+    token,
+    '--hostname',
+    '127.0.0.1',
+    '--workspace',
+    workspaceCwd,
+    ...extraArgs,
+  ];
+
+  const daemon = spawn(process.execPath, args, {
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, ...opts.env },
+  });
+
+  const stdoutBuf = { value: '' };
+  const stderrBuf = { value: '' };
+  daemon.stdout?.on('data', (chunk: Buffer) => {
+    stdoutBuf.value += chunk.toString();
+  });
+  daemon.stderr?.on('data', (chunk: Buffer) => {
+    stderrBuf.value += chunk.toString();
+  });
+
+  // Parse the listening port from stdout. Mirrors the pattern in
+  // qwen-serve-routes.test.ts: capture the timer handle so a successful
+  // resolution clears it (an un-cleared 10s timer leaks past the spawn
+  // promise and shows up as flaky test timeouts on slow CI).
+  const port = await new Promise<number>((resolve, reject) => {
+    const bootTimer = setTimeout(
+      () => reject(new Error('daemon boot timeout')),
+      bootTimeoutMs,
+    );
+    const onData = (_chunk: Buffer) => {
+      const m = stdoutBuf.value.match(LISTENING_RE);
+      if (m) {
+        daemon.stdout?.off('data', onData);
+        clearTimeout(bootTimer);
+        resolve(Number(m[1]));
+      }
+    };
+    daemon.stdout!.on('data', onData);
+    daemon.once('exit', (code) => {
+      clearTimeout(bootTimer);
+      reject(
+        new Error(
+          `daemon exited with ${code} before listening:\n` +
+            `stdout=${stdoutBuf.value}\nstderr=${stderrBuf.value}`,
+        ),
+      );
+    });
+  });
+
+  const base = `http://127.0.0.1:${port}`;
+  const client = new DaemonClient({ baseUrl: base, token });
+
+  const dispose = async () => {
+    if (daemon.exitCode !== null) return;
+    daemon.kill('SIGTERM');
+    await new Promise<void>((resolve) => {
+      const t = setTimeout(() => {
+        // Force kill if SIGTERM didn't take in time. We don't await
+        // exit again — the OS will clean up either way and a 5s
+        // hang here multiplies into 5s × N tests on flaky machines.
+        try {
+          daemon.kill('SIGKILL');
+        } catch {
+          /* already gone */
+        }
+        resolve();
+      }, DISPOSE_GRACE_MS);
+      daemon.once('exit', () => {
+        clearTimeout(t);
+        resolve();
+      });
+    });
+  };
+
+  return {
+    client,
+    daemon,
+    port,
+    base,
+    workspaceCwd,
+    token,
+    stdoutBuf,
+    stderrBuf,
+    dispose,
+  };
+}
+
+/**
+ * Write a `.qwen/settings.json` into `workspaceCwd` so the daemon picks up
+ * `mcpServers` (and any other settings) at boot. Caller is responsible for
+ * cleaning up the temp dir if they created one. Returns the absolute
+ * settings file path for visibility in test output.
+ */
+export function writeWorkspaceSettings(
+  workspaceCwd: string,
+  settings: Record<string, unknown>,
+): string {
+  const settingsDir = path.join(workspaceCwd, '.qwen');
+  fs.mkdirSync(settingsDir, { recursive: true });
+  const settingsPath = path.join(settingsDir, 'settings.json');
+  fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+  return settingsPath;
+}
+
+/**
+ * One-shot RSS read via `ps -o rss= -p <pid>`. Returns megabytes (rounded
+ * to 1 decimal). Returns NaN if the process is gone or `ps` errored — call
+ * sites should treat NaN as "skip this sample" rather than fail loudly.
+ */
+export function getRssMB(pid: number): number {
+  const psOpts: ExecFileSyncOptionsWithStringEncoding = {
+    encoding: 'utf8',
+    timeout: 2_000,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  };
+  try {
+    const out = execFileSync('ps', ['-o', 'rss=', '-p', String(pid)], psOpts);
+    const kb = parseInt(out.trim(), 10);
+    if (!Number.isFinite(kb) || kb <= 0) return NaN;
+    return Math.round((kb / 1024) * 10) / 10;
+  } catch {
+    return NaN;
+  }
+}
+
+export interface RssSample {
+  tMs: number;
+  rssMB: number;
+}
+
+export interface RssPoller {
+  samples: RssSample[];
+  stop(): void;
+}
+
+export function startRssPolling(pid: number, intervalMs = 100): RssPoller {
+  const startedAt = Date.now();
+  const samples: RssSample[] = [];
+  const tick = () => {
+    const rssMB = getRssMB(pid);
+    if (!Number.isNaN(rssMB)) {
+      samples.push({ tMs: Date.now() - startedAt, rssMB });
+    }
+  };
+  // Capture an immediate sample so a short window still has data.
+  tick();
+  const handle = setInterval(tick, intervalMs);
+  // unref so the test process can exit without waiting for the timer.
+  handle.unref?.();
+  return {
+    samples,
+    stop: () => clearInterval(handle),
+  };
+}
+
+/**
+ * Walk daemon → ACP child → MCP grandchildren via two `pgrep -P` calls.
+ * Pattern matches the existing inline approach at
+ * `qwen-serve-streaming.test.ts:144`.
+ *
+ * `pgrepOpts.acpFilter` defaults to `'qwen.*--acp'` (matches the spawned
+ * `qwen --acp` child); pass an override only if a future bridge changes
+ * the ACP child invocation shape.
+ *
+ * Returns explicit PID arrays so callers can cross-check (e.g., assert
+ * the ACP child PID matches what the test setup observed). `total` is
+ * the sum.
+ */
+export interface DescendantCount {
+  acpChildren: number[];
+  mcpGrandchildren: number[];
+  total: number;
+}
+
+export function countDescendants(
+  daemonPid: number,
+  pgrepOpts: { acpFilter?: string } = {},
+): DescendantCount {
+  const acpFilter = pgrepOpts.acpFilter ?? 'qwen.*--acp';
+  const acpChildren = pgrepChildren(daemonPid, acpFilter);
+  const mcpGrandchildren: number[] = [];
+  for (const acpPid of acpChildren) {
+    mcpGrandchildren.push(...pgrepChildren(acpPid));
+  }
+  return {
+    acpChildren,
+    mcpGrandchildren,
+    total: acpChildren.length + mcpGrandchildren.length,
+  };
+}
+
+function pgrepChildren(parentPid: number, fullCmdFilter?: string): number[] {
+  const args = ['-P', String(parentPid)];
+  if (fullCmdFilter) {
+    args.unshift('-f');
+    args.push(fullCmdFilter);
+  }
+  try {
+    const out = execFileSync('pgrep', args, {
+      encoding: 'utf8',
+      timeout: 2_000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    return out
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .map((line) => parseInt(line, 10))
+      .filter((n) => Number.isFinite(n) && n > 0);
+  } catch {
+    // pgrep returns non-zero when no processes match; that's a normal
+    // "0 children" outcome, not an error.
+    return [];
+  }
+}
+
+/**
+ * Compute p50 / p90 / p99 / mean / min / max from a numeric array. Uses
+ * nearest-rank percentile (no interpolation) to keep behavior predictable
+ * across small sample sizes. Returns all-NaN for an empty input rather
+ * than throwing — callers handle the "no samples" case downstream.
+ */
+export interface Percentiles {
+  count: number;
+  p50: number;
+  p90: number;
+  p99: number;
+  mean: number;
+  min: number;
+  max: number;
+}
+
+export function percentiles(values: number[]): Percentiles {
+  if (values.length === 0) {
+    return {
+      count: 0,
+      p50: NaN,
+      p90: NaN,
+      p99: NaN,
+      mean: NaN,
+      min: NaN,
+      max: NaN,
+    };
+  }
+  const sorted = [...values].sort((a, b) => a - b);
+  const n = sorted.length;
+  const pick = (p: number) => sorted[Math.min(n - 1, Math.ceil((p / 100) * n) - 1)];
+  const sum = sorted.reduce((acc, v) => acc + v, 0);
+  return {
+    count: n,
+    p50: pick(50),
+    p90: pick(90),
+    p99: pick(99),
+    mean: sum / n,
+    min: sorted[0],
+    max: sorted[n - 1],
+  };
+}
+
+/**
+ * Drive an SSE subscription at a configurable consumption rate. Returns
+ * total events received, whether `client_evicted` fired (and the event
+ * id when it did), plus elapsed time. `consumerDelayMs` introduces a
+ * sleep between each consumed event so the test can simulate a slow
+ * client and observe ring-buffer / per-subscriber-queue eviction.
+ *
+ * Callers that only want the live event stream should pass
+ * `consumerDelayMs: 0`. Callers that want a fixed-window probe (e.g. to
+ * verify the heartbeat fires on idle) can set `timeoutMs` and a small
+ * `maxEvents` cap.
+ */
+export interface ConsumeSseResult {
+  received: number;
+  evictedAt?: number;
+  evictionReason?: string;
+  elapsedMs: number;
+}
+
+export async function consumeSseEvents(
+  client: DaemonClient,
+  sessionId: string,
+  opts: {
+    maxEvents?: number;
+    consumerDelayMs?: number;
+    timeoutMs?: number;
+    subscribe?: SubscribeOptions;
+  } = {},
+): Promise<ConsumeSseResult> {
+  const maxEvents = opts.maxEvents ?? Number.POSITIVE_INFINITY;
+  const consumerDelayMs = opts.consumerDelayMs ?? 0;
+  const timeoutMs = opts.timeoutMs ?? 30_000;
+  const startedAt = Date.now();
+  let received = 0;
+  let evictedAt: number | undefined;
+  let evictionReason: string | undefined;
+
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), timeoutMs);
+  timer.unref?.();
+  // Fold caller signal in if provided.
+  const callerSignal = opts.subscribe?.signal;
+  if (callerSignal) {
+    callerSignal.addEventListener('abort', () => ac.abort(), { once: true });
+  }
+
+  try {
+    for await (const ev of client.subscribeEvents(sessionId, {
+      ...opts.subscribe,
+      signal: ac.signal,
+    })) {
+      received++;
+      if (ev.type === 'client_evicted') {
+        evictedAt = ev.id;
+        const data = ev.data as { reason?: string } | undefined;
+        evictionReason = data?.reason;
+        break;
+      }
+      if (received >= maxEvents) break;
+      if (consumerDelayMs > 0) {
+        await sleep(consumerDelayMs);
+      }
+    }
+  } catch (err) {
+    // Aborted on purpose (timeout or caller) — fall through and return
+    // what we collected. Re-throw anything else.
+    if (
+      !(err instanceof Error) ||
+      (err.name !== 'AbortError' && !/abort/i.test(err.message))
+    ) {
+      throw err;
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+
+  return {
+    received,
+    evictedAt,
+    evictionReason,
+    elapsedMs: Date.now() - startedAt,
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/integration-tests/cli/_daemon-harness.ts
+++ b/integration-tests/cli/_daemon-harness.ts
@@ -14,10 +14,11 @@
  *   - `getRssMB` / `startRssPolling` sample the daemon process's RSS via
  *     `ps -o rss=`. POSIX-only (no Windows). Used to capture the RSS curve
  *     across session counts.
- *   - `countDescendants` walks the daemon's process tree two levels via
- *     `pgrep -P` (matches the existing inline pattern at
- *     `qwen-serve-streaming.test.ts:144`). Used to surface the P1
- *     "MCP child × session" amplification before the M2 shared-pool fix.
+ *   - `countDescendants` walks the daemon's process tree via `pgrep -P`
+ *     (matches the existing inline pattern at
+ *     `qwen-serve-streaming.test.ts:144`, with optional filtered subtree
+ *     matching). Used to surface the P1 "MCP child × session"
+ *     amplification before the M2 shared-pool fix.
  *   - `percentiles` is a dependency-free p50/p90/p99 calculator for the
  *     prompt-latency suite.
  *   - `consumeSseEvents` drives the daemon's SSE stream at a configurable
@@ -89,6 +90,7 @@ export interface SpawnedDaemon {
 
 const LISTENING_RE = /listening on http:\/\/127\.0\.0\.1:(\d+)/;
 const DISPOSE_GRACE_MS = 5_000;
+const MATCHED_DESCENDANT_DEPTH = 4;
 
 export async function spawnDaemon(
   opts: SpawnDaemonOptions = {},
@@ -132,28 +134,49 @@ export async function spawnDaemon(
   // resolution clears it (an un-cleared 10s timer leaks past the spawn
   // promise and shows up as flaky test timeouts on slow CI).
   const port = await new Promise<number>((resolve, reject) => {
-    const bootTimer = setTimeout(
-      () => reject(new Error('daemon boot timeout')),
-      bootTimeoutMs,
-    );
+    let settled = false;
+    const cleanup = () => {
+      daemon.stdout?.off('data', onData);
+      daemon.off('exit', onExit);
+      clearTimeout(bootTimer);
+    };
+    const fail = (err: Error, kill = false) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      if (kill && daemon.exitCode === null) {
+        daemon.kill('SIGTERM');
+      }
+      reject(err);
+    };
+    const bootTimer = setTimeout(() => {
+      fail(
+        new Error(
+          `daemon boot timeout after ${bootTimeoutMs}ms:\n` +
+            `stdout=${stdoutBuf.value}\nstderr=${stderrBuf.value}`,
+        ),
+        true,
+      );
+    }, bootTimeoutMs);
     const onData = (_chunk: Buffer) => {
       const m = stdoutBuf.value.match(LISTENING_RE);
       if (m) {
-        daemon.stdout?.off('data', onData);
-        clearTimeout(bootTimer);
+        if (settled) return;
+        settled = true;
+        cleanup();
         resolve(Number(m[1]));
       }
     };
-    daemon.stdout!.on('data', onData);
-    daemon.once('exit', (code) => {
-      clearTimeout(bootTimer);
-      reject(
+    const onExit = (code: number | null) => {
+      fail(
         new Error(
           `daemon exited with ${code} before listening:\n` +
             `stdout=${stdoutBuf.value}\nstderr=${stderrBuf.value}`,
         ),
       );
-    });
+    };
+    daemon.stdout!.on('data', onData);
+    daemon.once('exit', onExit);
   });
 
   const base = `http://127.0.0.1:${port}`;
@@ -239,16 +262,20 @@ export interface RssSample {
 
 export interface RssPoller {
   samples: RssSample[];
+  droppedSamples: number;
   stop(): void;
 }
 
 export function startRssPolling(pid: number, intervalMs = 100): RssPoller {
   const startedAt = Date.now();
   const samples: RssSample[] = [];
+  let droppedSamples = 0;
   const tick = () => {
     const rssMB = getRssMB(pid);
     if (!Number.isNaN(rssMB)) {
       samples.push({ tMs: Date.now() - startedAt, rssMB });
+    } else {
+      droppedSamples++;
     }
   };
   // Capture an immediate sample so a short window still has data.
@@ -258,14 +285,21 @@ export function startRssPolling(pid: number, intervalMs = 100): RssPoller {
   handle.unref?.();
   return {
     samples,
+    get droppedSamples() {
+      return droppedSamples;
+    },
     stop: () => clearInterval(handle),
   };
 }
 
 /**
- * Walk daemon → ACP child → MCP grandchildren via two `pgrep -P` calls.
- * Pattern matches the existing inline approach at
- * `qwen-serve-streaming.test.ts:144`.
+ * Walk daemon → ACP child → MCP descendants via `pgrep -P` calls.
+ * Pattern starts with the existing inline approach at
+ * `qwen-serve-streaming.test.ts:144`. When `pgrepOpts.mcpFilter` is
+ * supplied, matching MCP processes are searched recursively within each
+ * ACP child subtree because the ACP transport can introduce an extra
+ * `qwen --acp` process between the daemon-facing ACP child and stdio MCP
+ * servers.
  *
  * `pgrepOpts.acpFilter` defaults to `'qwen.*--acp'` (matches the spawned
  * `qwen --acp` child); pass an override only if a future bridge changes
@@ -283,13 +317,23 @@ export interface DescendantCount {
 
 export function countDescendants(
   daemonPid: number,
-  pgrepOpts: { acpFilter?: string } = {},
+  pgrepOpts: { acpFilter?: string; mcpFilter?: string } = {},
 ): DescendantCount {
   const acpFilter = pgrepOpts.acpFilter ?? 'qwen.*--acp';
   const acpChildren = pgrepChildren(daemonPid, acpFilter);
   const mcpGrandchildren: number[] = [];
   for (const acpPid of acpChildren) {
-    mcpGrandchildren.push(...pgrepChildren(acpPid));
+    if (pgrepOpts.mcpFilter) {
+      mcpGrandchildren.push(
+        ...pgrepMatchingDescendants(
+          acpPid,
+          pgrepOpts.mcpFilter,
+          MATCHED_DESCENDANT_DEPTH,
+        ),
+      );
+    } else {
+      mcpGrandchildren.push(...pgrepChildren(acpPid));
+    }
   }
   return {
     acpChildren,
@@ -316,11 +360,47 @@ function pgrepChildren(parentPid: number, fullCmdFilter?: string): number[] {
       .filter(Boolean)
       .map((line) => parseInt(line, 10))
       .filter((n) => Number.isFinite(n) && n > 0);
-  } catch {
+  } catch (err) {
+    const error = err as NodeJS.ErrnoException & {
+      status?: number;
+      signal?: NodeJS.Signals | string | null;
+    };
     // pgrep returns non-zero when no processes match; that's a normal
     // "0 children" outcome, not an error.
-    return [];
+    if (error.status === 1) {
+      return [];
+    }
+    if (error.code === 'ENOENT') {
+      throw new Error('pgrep is required for daemon descendant counting');
+    }
+    if (error.signal === 'SIGTERM') {
+      throw new Error(`pgrep timed out while listing children of ${parentPid}`);
+    }
+    const detail =
+      error instanceof Error && error.message ? `: ${error.message}` : '';
+    throw new Error(
+      `pgrep failed while listing children of ${parentPid}${detail}`,
+    );
   }
+}
+
+function pgrepMatchingDescendants(
+  parentPid: number,
+  fullCmdFilter: string,
+  maxDepth: number,
+): number[] {
+  const matches = new Set<number>();
+  const visit = (pid: number, depth: number) => {
+    if (depth <= 0) return;
+    for (const match of pgrepChildren(pid, fullCmdFilter)) {
+      matches.add(match);
+    }
+    for (const child of pgrepChildren(pid)) {
+      visit(child, depth - 1);
+    }
+  };
+  visit(parentPid, maxDepth);
+  return [...matches];
 }
 
 /**
@@ -353,7 +433,8 @@ export function percentiles(values: number[]): Percentiles {
   }
   const sorted = [...values].sort((a, b) => a - b);
   const n = sorted.length;
-  const pick = (p: number) => sorted[Math.min(n - 1, Math.ceil((p / 100) * n) - 1)];
+  const pick = (p: number) =>
+    sorted[Math.min(n - 1, Math.ceil((p / 100) * n) - 1)];
   const sum = sorted.reduce((acc, v) => acc + v, 0);
   return {
     count: n,

--- a/integration-tests/cli/qwen-serve-baseline.test.ts
+++ b/integration-tests/cli/qwen-serve-baseline.test.ts
@@ -66,7 +66,8 @@ const RSS_SAMPLE_INTERVAL_MS = Number(
   process.env['QWEN_BASELINE_RSS_SAMPLE_INTERVAL_MS'] ?? 100,
 );
 const RSS_SAMPLE_DURATION_MS = Number(
-  process.env['QWEN_BASELINE_RSS_SAMPLE_DURATION_MS'] ?? (HEAVY ? 15_000 : 5_000),
+  process.env['QWEN_BASELINE_RSS_SAMPLE_DURATION_MS'] ??
+    (HEAVY ? 15_000 : 5_000),
 );
 const SKIP_PROMPT_LATENCY =
   process.env['QWEN_BASELINE_SKIP_PROMPT_LATENCY'] === '1' ||
@@ -74,10 +75,7 @@ const SKIP_PROMPT_LATENCY =
 
 const FIXTURES_DIR = path.resolve(__dirname, '../fixtures');
 const IDLE_MCP_PATH = path.join(FIXTURES_DIR, 'idle-mcp/server.mjs');
-const RUN_TS = new Date()
-  .toISOString()
-  .replace(/[:.]/g, '')
-  .replace(/Z$/, '');
+const RUN_TS = new Date().toISOString().replace(/[:.]/g, '').replace(/Z$/, '');
 const OUTPUT_DIR =
   process.env['INTEGRATION_TEST_FILE_DIR'] ??
   path.join(process.cwd(), '.integration-tests', `baseline-${RUN_TS}`);
@@ -228,41 +226,41 @@ async function measureRssAtSessionCount(
   }
 }
 
-(SKIP ? describe.skip : describe)('daemon baseline harness (POSIX-only)', () => {
-  describe('RSS scaling', () => {
-    it(
-      'captures peak RSS at 1 / 5 / 10 sessions',
-      async () => {
-        const r1 = await measureRssAtSessionCount(1);
-        const r5 = await measureRssAtSessionCount(5);
-        const r10 = await measureRssAtSessionCount(10);
+(SKIP ? describe.skip : describe)(
+  'daemon baseline harness (POSIX-only)',
+  () => {
+    describe('RSS scaling', () => {
+      it(
+        'captures peak RSS at 1 / 5 / 10 sessions',
+        async () => {
+          const r1 = await measureRssAtSessionCount(1);
+          const r5 = await measureRssAtSessionCount(5);
+          const r10 = await measureRssAtSessionCount(10);
 
-        snapshot.rssScaling = {
-          session1MB: r1.peakRssMB,
-          session5MB: r5.peakRssMB,
-          session10MB: r10.peakRssMB,
-          sampleCount: r1.sampleCount + r5.sampleCount + r10.sampleCount,
-          growthPerSessionMB:
-            Math.round(((r10.peakRssMB - r1.peakRssMB) / 9) * 10) / 10,
-        };
+          snapshot.rssScaling = {
+            session1MB: r1.peakRssMB,
+            session5MB: r5.peakRssMB,
+            session10MB: r10.peakRssMB,
+            sampleCount: r1.sampleCount + r5.sampleCount + r10.sampleCount,
+            growthPerSessionMB:
+              Math.round(((r10.peakRssMB - r1.peakRssMB) / 9) * 10) / 10,
+          };
 
-        // Catastrophic upper bounds only.
-        expect(r1.peakRssMB).toBeLessThan(THRESH.rss1SessionMaxMB);
-        expect(r10.peakRssMB).toBeLessThan(THRESH.rss10SessionsMaxMB);
-        // Sanity: growth should be non-negative (more sessions ≥ more memory).
-        expect(r10.peakRssMB).toBeGreaterThanOrEqual(r1.peakRssMB);
-      },
-      // Each session-count needs daemon spawn + N session creates +
-      // RSS_SAMPLE_DURATION_MS sampling + dispose. ~3 × 15s budget per
-      // count in heavy mode → 90s base; pad for slow CI.
-      HEAVY ? 600_000 : 180_000,
-    );
-  });
+          // Catastrophic upper bounds only.
+          expect(r1.peakRssMB).toBeLessThan(THRESH.rss1SessionMaxMB);
+          expect(r10.peakRssMB).toBeLessThan(THRESH.rss10SessionsMaxMB);
+          // Sanity: growth should be non-negative (more sessions ≥ more memory).
+          expect(r10.peakRssMB).toBeGreaterThanOrEqual(r1.peakRssMB);
+        },
+        // Each session-count needs daemon spawn + N session creates +
+        // RSS_SAMPLE_DURATION_MS sampling + dispose. ~3 × 15s budget per
+        // count in heavy mode → 90s base; pad for slow CI.
+        HEAVY ? 600_000 : 180_000,
+      );
+    });
 
-  describe('attach latency', () => {
-    it(
-      'measures Nth same-workspace session attach time',
-      async () => {
+    describe('attach latency', () => {
+      it('measures Nth same-workspace session attach time', async () => {
         const ws = makeTempWorkspace('attach');
         const daemon = await spawnDaemon({ workspaceCwd: ws });
         try {
@@ -292,15 +290,11 @@ async function measureRssAtSessionCount(
           await daemon.dispose();
           fs.rmSync(ws, { recursive: true, force: true });
         }
-      },
-      60_000,
-    );
-  });
+      }, 60_000);
+    });
 
-  describe('MCP child amplification (P1 baseline)', () => {
-    it(
-      'counts MCP grandchildren as session count grows',
-      async () => {
+    describe('MCP child amplification (P1 baseline)', () => {
+      it('counts MCP grandchildren as session count grows', async () => {
         const ws = makeTempWorkspace('mcp');
         writeWorkspaceSettings(ws, {
           mcpServers: {
@@ -333,8 +327,7 @@ async function measureRssAtSessionCount(
           const expectedMaxAt5 =
             mcpServersConfigured * 5 * THRESH.mcpAmplificationFactor;
           const linear =
-            at5.mcpGrandchildren.length >=
-            mcpServersConfigured * 5 * 0.5; // ≥50% of linear → confirmed amplification
+            at5.mcpGrandchildren.length >= mcpServersConfigured * 5 * 0.5; // ≥50% of linear → confirmed amplification
 
           snapshot.mcpAmplification = {
             mcpServersConfigured,
@@ -354,155 +347,155 @@ async function measureRssAtSessionCount(
           await daemon.dispose();
           fs.rmSync(ws, { recursive: true, force: true });
         }
-      },
-      120_000,
-    );
-  });
-
-  describe('SSE backpressure (unit)', () => {
-    // Note: EventBus is the daemon's per-session fan-out primitive. It
-    // doesn't take a sessionId in publish/subscribe — the bus instance
-    // itself is per-session, owned upstream. We use it directly here for
-    // deterministic backpressure invariants without needing a live HTTP
-    // round-trip; pattern matches `packages/cli/src/serve/eventBus.test.ts`.
-    it('overflow at maxQueued boundary fires client_evicted', async () => {
-      const bus = new EventBus();
-      const ac = new AbortController();
-      // Per-subscriber queue cap is set on subscribe(), not on bus
-      // construction (matches the existing eventBus.test.ts:103 pattern).
-      const iter = bus.subscribe({ maxQueued: 2, signal: ac.signal });
-
-      // Publish 3 events into a 2-deep queue. The 3rd trips eviction →
-      // a synthetic client_evicted terminal frame is appended.
-      bus.publish({ type: 'tick', data: { i: 1 } });
-      bus.publish({ type: 'tick', data: { i: 2 } });
-      bus.publish({ type: 'tick', data: { i: 3 } });
-
-      const collected: BridgeEventLike[] = [];
-      for await (const ev of iter) {
-        collected.push({ type: ev.type });
-      }
-      ac.abort();
-
-      expect(collected).toHaveLength(3);
-      expect(collected[2]!.type).toBe('client_evicted');
-      snapshot.sseBackpressure = {
-        ringSize: 4_000,
-        maxQueuedDefault: 256,
-        evictionAtOverflow: true,
-        replayUpToRing: true,
-        heartbeatIntervalMs: 15_000,
-      };
+      }, 120_000);
     });
 
-    it('replay across reconnect honors lastEventId up to ring size', async () => {
-      const bus = new EventBus();
-      // Publish 5 events.
-      for (let i = 1; i <= 5; i++) {
-        bus.publish({ type: 'tick', data: { i } });
-      }
-      // Subscribe with lastEventId=2 → should replay events 3..5.
-      const ac = new AbortController();
-      const iter = bus.subscribe({ lastEventId: 2, signal: ac.signal });
-      const replayed: number[] = [];
-      for await (const ev of iter) {
-        const data = ev.data as { i: number };
-        replayed.push(data.i);
-        if (replayed.length >= 3) break;
-      }
-      ac.abort();
-      expect(replayed).toEqual([3, 4, 5]);
-    });
-  });
+    describe('SSE backpressure (unit)', () => {
+      // Note: EventBus is the daemon's per-session fan-out primitive. It
+      // doesn't take a sessionId in publish/subscribe — the bus instance
+      // itself is per-session, owned upstream. We use it directly here for
+      // deterministic backpressure invariants without needing a live HTTP
+      // round-trip; pattern matches `packages/cli/src/serve/eventBus.test.ts`.
+      it('overflow at maxQueued boundary fires client_evicted', async () => {
+        const bus = new EventBus();
+        const ac = new AbortController();
+        // Per-subscriber queue cap is set on subscribe(), not on bus
+        // construction (matches the existing eventBus.test.ts:103 pattern).
+        const iter = bus.subscribe({ maxQueued: 2, signal: ac.signal });
 
-  describe('prompt latency', () => {
-    it.skipIf(SKIP_PROMPT_LATENCY)(
-      `p50 / p99 over ${PROMPT_ITERATIONS} prompts`,
-      async () => {
-        const ws = makeTempWorkspace('prompt');
-        const daemon = await spawnDaemon({ workspaceCwd: ws });
-        try {
-          const sess = await daemon.client.createOrAttachSession({
-            workspaceCwd: ws,
-          });
-          const firstByteMs: number[] = [];
-          const totalMs: number[] = [];
+        // Publish 3 events into a 2-deep queue. The 3rd trips eviction →
+        // a synthetic client_evicted terminal frame is appended.
+        bus.publish({ type: 'tick', data: { i: 1 } });
+        bus.publish({ type: 'tick', data: { i: 2 } });
+        bus.publish({ type: 'tick', data: { i: 3 } });
 
-          for (let i = 0; i < PROMPT_ITERATIONS; i++) {
-            const t0 = Date.now();
-            // Subscribe to events for first-byte timing; promptly cancel
-            // when we see the first session_update.
-            const ac = new AbortController();
-            const iter = daemon.client.subscribeEvents(sess.sessionId, {
-              signal: ac.signal,
-            });
-            const firstByteP = (async () => {
-              for await (const _ of iter) {
-                ac.abort();
-                return Date.now();
-              }
-              return Date.now();
-            })();
-
-            await daemon.client.prompt(sess.sessionId, {
-              prompt: [{ type: 'text', text: 'reply with the single word ok' }],
-            });
-            const tEnd = Date.now();
-            const tFirstByte = await firstByteP;
-
-            firstByteMs.push(tFirstByte - t0);
-            totalMs.push(tEnd - t0);
-          }
-
-          snapshot.promptLatency = {
-            iterations: PROMPT_ITERATIONS,
-            firstByteMs: percentiles(firstByteMs),
-            totalMs: percentiles(totalMs),
-            skipped: false,
-          };
-
-          expect(snapshot.promptLatency.totalMs!.p99).toBeLessThan(
-            THRESH.promptP99MaxMs,
-          );
-        } finally {
-          await daemon.dispose();
-          fs.rmSync(ws, { recursive: true, force: true });
+        const collected: BridgeEventLike[] = [];
+        for await (const ev of iter) {
+          collected.push({ type: ev.type });
         }
-      },
-      HEAVY ? 30 * 60_000 : 10 * 60_000,
-    );
+        ac.abort();
 
-    if (SKIP_PROMPT_LATENCY) {
-      it('prompt latency skipped (no QWEN_TEST_MODEL_KEY)', () => {
-        snapshot.promptLatency = {
-          iterations: 0,
-          firstByteMs: null,
-          totalMs: null,
-          skipped: true,
-          skipReason:
-            'QWEN_TEST_MODEL_KEY not set; prompt latency requires a real model credential.',
+        expect(collected).toHaveLength(3);
+        expect(collected[2]!.type).toBe('client_evicted');
+        snapshot.sseBackpressure = {
+          ringSize: 4_000,
+          maxQueuedDefault: 256,
+          evictionAtOverflow: true,
+          replayUpToRing: true,
+          heartbeatIntervalMs: 15_000,
         };
-        // Mark via a no-op assertion so the suite still appears in output.
-        expect(true).toBe(true);
       });
-    }
-  });
 
-  afterAll(() => {
-    if (SKIP) return;
-    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
-    const jsonPath = path.join(OUTPUT_DIR, 'perf-baseline.json');
-    fs.writeFileSync(jsonPath, JSON.stringify(snapshot, null, 2));
-    fs.writeFileSync(
-      path.join(OUTPUT_DIR, 'perf-baseline.md'),
-      renderMarkdown(snapshot),
-    );
-    // Echo the path so a reviewer / CI logs surface where the artifact
-    // landed.
-    // eslint-disable-next-line no-console
-    console.log(`[baseline] perf-baseline.json written to ${jsonPath}`);
-  });
-});
+      it('replay across reconnect honors lastEventId up to ring size', async () => {
+        const bus = new EventBus();
+        // Publish 5 events.
+        for (let i = 1; i <= 5; i++) {
+          bus.publish({ type: 'tick', data: { i } });
+        }
+        // Subscribe with lastEventId=2 → should replay events 3..5.
+        const ac = new AbortController();
+        const iter = bus.subscribe({ lastEventId: 2, signal: ac.signal });
+        const replayed: number[] = [];
+        for await (const ev of iter) {
+          const data = ev.data as { i: number };
+          replayed.push(data.i);
+          if (replayed.length >= 3) break;
+        }
+        ac.abort();
+        expect(replayed).toEqual([3, 4, 5]);
+      });
+    });
+
+    describe('prompt latency', () => {
+      it.skipIf(SKIP_PROMPT_LATENCY)(
+        `p50 / p99 over ${PROMPT_ITERATIONS} prompts`,
+        async () => {
+          const ws = makeTempWorkspace('prompt');
+          const daemon = await spawnDaemon({ workspaceCwd: ws });
+          try {
+            const sess = await daemon.client.createOrAttachSession({
+              workspaceCwd: ws,
+            });
+            const firstByteMs: number[] = [];
+            const totalMs: number[] = [];
+
+            for (let i = 0; i < PROMPT_ITERATIONS; i++) {
+              const t0 = Date.now();
+              // Subscribe to events for first-byte timing; promptly cancel
+              // when we see the first session_update.
+              const ac = new AbortController();
+              const iter = daemon.client.subscribeEvents(sess.sessionId, {
+                signal: ac.signal,
+              });
+              const firstByteP = (async () => {
+                for await (const _ of iter) {
+                  ac.abort();
+                  return Date.now();
+                }
+                return Date.now();
+              })();
+
+              await daemon.client.prompt(sess.sessionId, {
+                prompt: [
+                  { type: 'text', text: 'reply with the single word ok' },
+                ],
+              });
+              const tEnd = Date.now();
+              const tFirstByte = await firstByteP;
+
+              firstByteMs.push(tFirstByte - t0);
+              totalMs.push(tEnd - t0);
+            }
+
+            snapshot.promptLatency = {
+              iterations: PROMPT_ITERATIONS,
+              firstByteMs: percentiles(firstByteMs),
+              totalMs: percentiles(totalMs),
+              skipped: false,
+            };
+
+            expect(snapshot.promptLatency.totalMs!.p99).toBeLessThan(
+              THRESH.promptP99MaxMs,
+            );
+          } finally {
+            await daemon.dispose();
+            fs.rmSync(ws, { recursive: true, force: true });
+          }
+        },
+        HEAVY ? 30 * 60_000 : 10 * 60_000,
+      );
+
+      if (SKIP_PROMPT_LATENCY) {
+        it('prompt latency skipped (no QWEN_TEST_MODEL_KEY)', () => {
+          snapshot.promptLatency = {
+            iterations: 0,
+            firstByteMs: null,
+            totalMs: null,
+            skipped: true,
+            skipReason:
+              'QWEN_TEST_MODEL_KEY not set; prompt latency requires a real model credential.',
+          };
+          // Mark via a no-op assertion so the suite still appears in output.
+          expect(true).toBe(true);
+        });
+      }
+    });
+
+    afterAll(() => {
+      if (SKIP) return;
+      fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+      const jsonPath = path.join(OUTPUT_DIR, 'perf-baseline.json');
+      fs.writeFileSync(jsonPath, JSON.stringify(snapshot, null, 2));
+      fs.writeFileSync(
+        path.join(OUTPUT_DIR, 'perf-baseline.md'),
+        renderMarkdown(snapshot),
+      );
+      // Echo the path so a reviewer / CI logs surface where the artifact
+      // landed.
+      console.log(`[baseline] perf-baseline.json written to ${jsonPath}`);
+    });
+  },
+);
 
 function renderMarkdown(s: SnapshotShape): string {
   const fmt = (p: Percentiles | null | undefined): string =>

--- a/integration-tests/cli/qwen-serve-baseline.test.ts
+++ b/integration-tests/cli/qwen-serve-baseline.test.ts
@@ -1,0 +1,548 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * `qwen serve` daemon — performance baseline harness.
+ *
+ * First implementation PR of the Mode B v0.16 rollout (issue #4175 Wave 1
+ * PR 1). Captures reference metrics for: RSS curve across session counts,
+ * same-workspace attach latency, prompt p50/p99 (when a real model key is
+ * available), MCP child amplification (P1 baseline before M2 shared pool),
+ * and SSE replay/backpressure basics.
+ *
+ * Why this PR is first: every subsequent Mode B PR (M2 MCP shared pool /
+ * M3 architecture refactor / M4 multi-client safety) changes memory or
+ * latency or child-process characteristics. Without baseline numbers
+ * captured BEFORE those land, we cannot tell whether a refactor regressed
+ * or improved performance. This file owns the reference-snapshot output
+ * (`.integration-tests/<timestamp>/perf-baseline.json` + `.md`).
+ *
+ * No optimization in this PR — measurement only. Assertions are
+ * catastrophic-regression upper bounds (e.g. RSS at 1 session < 500 MB);
+ * everything else is reported into the snapshot.
+ *
+ * POSIX only. The harness uses `ps` + `pgrep`; Windows is skipped via the
+ * `describe.skip` gate at the bottom of this file (matches the existing
+ * `qwen-serve-streaming.test.ts:53` precedent).
+ */
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, describe, expect, it } from 'vitest';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import { EventBus } from '../../packages/cli/src/serve/eventBus.js';
+import {
+  spawnDaemon,
+  startRssPolling,
+  countDescendants,
+  percentiles,
+  writeWorkspaceSettings,
+  type SpawnedDaemon,
+  type Percentiles,
+} from './_daemon-harness.js';
+
+// Minimal type-shape for the SSE backpressure unit suite — we only assert
+// `.type`, so we avoid coupling tests to the full BridgeEvent surface.
+interface BridgeEventLike {
+  type: string;
+}
+
+// Skip immediately on Windows — the helpers shell out to `ps` / `pgrep`.
+const SKIP = process.platform === 'win32';
+
+// Read iteration tunings from env (documented in #4175 PR 1 plan).
+const HEAVY = process.env['QWEN_BASELINE_HEAVY'] === '1';
+const PROMPT_ITERATIONS = Number(
+  process.env['QWEN_BASELINE_PROMPT_ITERATIONS'] ?? (HEAVY ? 100 : 20),
+);
+const RSS_SAMPLE_INTERVAL_MS = Number(
+  process.env['QWEN_BASELINE_RSS_SAMPLE_INTERVAL_MS'] ?? 100,
+);
+const RSS_SAMPLE_DURATION_MS = Number(
+  process.env['QWEN_BASELINE_RSS_SAMPLE_DURATION_MS'] ?? (HEAVY ? 15_000 : 5_000),
+);
+const SKIP_PROMPT_LATENCY =
+  process.env['QWEN_BASELINE_SKIP_PROMPT_LATENCY'] === '1' ||
+  !process.env['QWEN_TEST_MODEL_KEY'];
+
+const FIXTURES_DIR = path.resolve(__dirname, '../fixtures');
+const IDLE_MCP_PATH = path.join(FIXTURES_DIR, 'idle-mcp/server.mjs');
+const RUN_TS = new Date()
+  .toISOString()
+  .replace(/[:.]/g, '')
+  .replace(/Z$/, '');
+const OUTPUT_DIR =
+  process.env['INTEGRATION_TEST_FILE_DIR'] ??
+  path.join(process.cwd(), '.integration-tests', `baseline-${RUN_TS}`);
+
+// Catastrophic-regression upper bounds. These are intentionally loose —
+// tightening them is a deliberate one-line PR after a regression is
+// observed. Numbers chosen per #4175 PR 1 plan.
+const THRESH = {
+  rss1SessionMaxMB: 500,
+  rss10SessionsMaxMB: 5_000,
+  promptP99MaxMs: 60_000,
+  attachLatencyMaxMs: 1_000,
+  // P1 baseline: pre-M2, MCP children grow ~linearly with session count.
+  // We assert "not worse than 2× linear" so a regression that doubles
+  // the per-session spawn count gets caught even before M2 lands.
+  mcpAmplificationFactor: 2,
+};
+
+// Snapshot accumulator — populated as each describe block runs, written
+// in afterAll.
+interface SnapshotShape {
+  version: 1;
+  capturedAt: string;
+  gitCommit: string | null;
+  platform: { os: string; arch: string; nodeVersion: string };
+  /**
+   * Notes about how to read this snapshot. Critical for cross-commit
+   * comparison since some metrics' meaning changes as Wave 2/5 lands.
+   */
+  notes: string[];
+  config: {
+    promptIterations: number;
+    rssSampleIntervalMs: number;
+    rssSampleDurationMs: number;
+    heavy: boolean;
+  };
+  rssScaling?: {
+    session1MB: number;
+    session5MB: number;
+    session10MB: number;
+    sampleCount: number;
+    growthPerSessionMB: number;
+  };
+  promptLatency?: {
+    iterations: number;
+    firstByteMs: Percentiles | null;
+    totalMs: Percentiles | null;
+    skipped: boolean;
+    skipReason?: string;
+  };
+  attachLatency?: {
+    session2Ms: number;
+    session5Ms: number;
+    thresholdMs: number;
+  };
+  mcpAmplification?: {
+    mcpServersConfigured: number;
+    childrenAt1Session: number;
+    childrenAt3Sessions: number;
+    childrenAt5Sessions: number;
+    linearAmplification: boolean;
+  };
+  sseBackpressure?: {
+    ringSize: number;
+    maxQueuedDefault: number;
+    evictionAtOverflow: boolean;
+    replayUpToRing: boolean;
+    heartbeatIntervalMs: number;
+  };
+}
+
+const snapshot: SnapshotShape = {
+  version: 1,
+  capturedAt: new Date().toISOString(),
+  gitCommit: gitHead(),
+  platform: {
+    os: process.platform,
+    arch: process.arch,
+    nodeVersion: process.version,
+  },
+  notes: [
+    'Daemon defaults to sessionScope: "single", so N successive ' +
+      'createOrAttachSession calls against the same workspace return the ' +
+      'same sessionId. RSS scaling and MCP amplification metrics here ' +
+      'reflect "N attaches to one shared session", not "N distinct sessions".',
+    'After Wave 2 PR 5 (per-request sessionScope override) lands, this ' +
+      'harness will be updated to optionally pass sessionScope: "thread" ' +
+      'so the same metrics expose per-session cost and surface the P1 ' +
+      'MCP N×M amplification before M2 fixes it.',
+  ],
+  config: {
+    promptIterations: PROMPT_ITERATIONS,
+    rssSampleIntervalMs: RSS_SAMPLE_INTERVAL_MS,
+    rssSampleDurationMs: RSS_SAMPLE_DURATION_MS,
+    heavy: HEAVY,
+  },
+};
+
+function gitHead(): string | null {
+  try {
+    return execFileSync('git', ['rev-parse', 'HEAD'], {
+      encoding: 'utf8',
+      timeout: 2_000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+function makeTempWorkspace(label: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), `qwen-baseline-${label}-`));
+  return dir;
+}
+
+async function createNSessions(
+  daemon: SpawnedDaemon,
+  n: number,
+): Promise<string[]> {
+  const ids: string[] = [];
+  for (let i = 0; i < n; i++) {
+    const sess = await daemon.client.createOrAttachSession({
+      workspaceCwd: daemon.workspaceCwd,
+    });
+    ids.push(sess.sessionId);
+  }
+  return ids;
+}
+
+async function measureRssAtSessionCount(
+  sessionCount: number,
+): Promise<{ peakRssMB: number; sampleCount: number }> {
+  const ws = makeTempWorkspace(`rss-${sessionCount}`);
+  const daemon = await spawnDaemon({ workspaceCwd: ws });
+  try {
+    await createNSessions(daemon, sessionCount);
+    const poller = startRssPolling(daemon.daemon.pid!, RSS_SAMPLE_INTERVAL_MS);
+    await new Promise((r) => setTimeout(r, RSS_SAMPLE_DURATION_MS));
+    poller.stop();
+    const peakRssMB = poller.samples.reduce(
+      (max, s) => Math.max(max, s.rssMB),
+      0,
+    );
+    return { peakRssMB, sampleCount: poller.samples.length };
+  } finally {
+    await daemon.dispose();
+    fs.rmSync(ws, { recursive: true, force: true });
+  }
+}
+
+(SKIP ? describe.skip : describe)('daemon baseline harness (POSIX-only)', () => {
+  describe('RSS scaling', () => {
+    it(
+      'captures peak RSS at 1 / 5 / 10 sessions',
+      async () => {
+        const r1 = await measureRssAtSessionCount(1);
+        const r5 = await measureRssAtSessionCount(5);
+        const r10 = await measureRssAtSessionCount(10);
+
+        snapshot.rssScaling = {
+          session1MB: r1.peakRssMB,
+          session5MB: r5.peakRssMB,
+          session10MB: r10.peakRssMB,
+          sampleCount: r1.sampleCount + r5.sampleCount + r10.sampleCount,
+          growthPerSessionMB:
+            Math.round(((r10.peakRssMB - r1.peakRssMB) / 9) * 10) / 10,
+        };
+
+        // Catastrophic upper bounds only.
+        expect(r1.peakRssMB).toBeLessThan(THRESH.rss1SessionMaxMB);
+        expect(r10.peakRssMB).toBeLessThan(THRESH.rss10SessionsMaxMB);
+        // Sanity: growth should be non-negative (more sessions ≥ more memory).
+        expect(r10.peakRssMB).toBeGreaterThanOrEqual(r1.peakRssMB);
+      },
+      // Each session-count needs daemon spawn + N session creates +
+      // RSS_SAMPLE_DURATION_MS sampling + dispose. ~3 × 15s budget per
+      // count in heavy mode → 90s base; pad for slow CI.
+      HEAVY ? 600_000 : 180_000,
+    );
+  });
+
+  describe('attach latency', () => {
+    it(
+      'measures Nth same-workspace session attach time',
+      async () => {
+        const ws = makeTempWorkspace('attach');
+        const daemon = await spawnDaemon({ workspaceCwd: ws });
+        try {
+          // Create session 1 to warm the channel.
+          await daemon.client.createOrAttachSession({ workspaceCwd: ws });
+
+          const t2 = Date.now();
+          await daemon.client.createOrAttachSession({ workspaceCwd: ws });
+          const session2Ms = Date.now() - t2;
+
+          // Skip ahead to session 5 attach to capture a "later" sample.
+          await daemon.client.createOrAttachSession({ workspaceCwd: ws });
+          await daemon.client.createOrAttachSession({ workspaceCwd: ws });
+          const t5 = Date.now();
+          await daemon.client.createOrAttachSession({ workspaceCwd: ws });
+          const session5Ms = Date.now() - t5;
+
+          snapshot.attachLatency = {
+            session2Ms,
+            session5Ms,
+            thresholdMs: THRESH.attachLatencyMaxMs,
+          };
+
+          expect(session2Ms).toBeLessThan(THRESH.attachLatencyMaxMs);
+          expect(session5Ms).toBeLessThan(THRESH.attachLatencyMaxMs);
+        } finally {
+          await daemon.dispose();
+          fs.rmSync(ws, { recursive: true, force: true });
+        }
+      },
+      60_000,
+    );
+  });
+
+  describe('MCP child amplification (P1 baseline)', () => {
+    it(
+      'counts MCP grandchildren as session count grows',
+      async () => {
+        const ws = makeTempWorkspace('mcp');
+        writeWorkspaceSettings(ws, {
+          mcpServers: {
+            idle1: { command: 'node', args: [IDLE_MCP_PATH] },
+            idle2: { command: 'node', args: [IDLE_MCP_PATH] },
+          },
+        });
+        const daemon = await spawnDaemon({ workspaceCwd: ws });
+        try {
+          // Sleep briefly after each create so MCP children get time to
+          // spawn before we count.
+          const sleep = (ms: number) =>
+            new Promise<void>((r) => setTimeout(r, ms));
+
+          await daemon.client.createOrAttachSession({ workspaceCwd: ws });
+          await sleep(2_000);
+          const at1 = countDescendants(daemon.daemon.pid!);
+
+          await daemon.client.createOrAttachSession({ workspaceCwd: ws });
+          await daemon.client.createOrAttachSession({ workspaceCwd: ws });
+          await sleep(2_000);
+          const at3 = countDescendants(daemon.daemon.pid!);
+
+          await daemon.client.createOrAttachSession({ workspaceCwd: ws });
+          await daemon.client.createOrAttachSession({ workspaceCwd: ws });
+          await sleep(2_000);
+          const at5 = countDescendants(daemon.daemon.pid!);
+
+          const mcpServersConfigured = 2;
+          const expectedMaxAt5 =
+            mcpServersConfigured * 5 * THRESH.mcpAmplificationFactor;
+          const linear =
+            at5.mcpGrandchildren.length >=
+            mcpServersConfigured * 5 * 0.5; // ≥50% of linear → confirmed amplification
+
+          snapshot.mcpAmplification = {
+            mcpServersConfigured,
+            childrenAt1Session: at1.mcpGrandchildren.length,
+            childrenAt3Sessions: at3.mcpGrandchildren.length,
+            childrenAt5Sessions: at5.mcpGrandchildren.length,
+            linearAmplification: linear,
+          };
+
+          // Sanity: at least 1 ACP child should exist throughout.
+          expect(at1.acpChildren.length).toBeGreaterThanOrEqual(1);
+          // Catastrophic bound: not worse than 2× linear.
+          expect(at5.mcpGrandchildren.length).toBeLessThanOrEqual(
+            expectedMaxAt5,
+          );
+        } finally {
+          await daemon.dispose();
+          fs.rmSync(ws, { recursive: true, force: true });
+        }
+      },
+      120_000,
+    );
+  });
+
+  describe('SSE backpressure (unit)', () => {
+    // Note: EventBus is the daemon's per-session fan-out primitive. It
+    // doesn't take a sessionId in publish/subscribe — the bus instance
+    // itself is per-session, owned upstream. We use it directly here for
+    // deterministic backpressure invariants without needing a live HTTP
+    // round-trip; pattern matches `packages/cli/src/serve/eventBus.test.ts`.
+    it('overflow at maxQueued boundary fires client_evicted', async () => {
+      const bus = new EventBus();
+      const ac = new AbortController();
+      // Per-subscriber queue cap is set on subscribe(), not on bus
+      // construction (matches the existing eventBus.test.ts:103 pattern).
+      const iter = bus.subscribe({ maxQueued: 2, signal: ac.signal });
+
+      // Publish 3 events into a 2-deep queue. The 3rd trips eviction →
+      // a synthetic client_evicted terminal frame is appended.
+      bus.publish({ type: 'tick', data: { i: 1 } });
+      bus.publish({ type: 'tick', data: { i: 2 } });
+      bus.publish({ type: 'tick', data: { i: 3 } });
+
+      const collected: BridgeEventLike[] = [];
+      for await (const ev of iter) {
+        collected.push({ type: ev.type });
+      }
+      ac.abort();
+
+      expect(collected).toHaveLength(3);
+      expect(collected[2]!.type).toBe('client_evicted');
+      snapshot.sseBackpressure = {
+        ringSize: 4_000,
+        maxQueuedDefault: 256,
+        evictionAtOverflow: true,
+        replayUpToRing: true,
+        heartbeatIntervalMs: 15_000,
+      };
+    });
+
+    it('replay across reconnect honors lastEventId up to ring size', async () => {
+      const bus = new EventBus();
+      // Publish 5 events.
+      for (let i = 1; i <= 5; i++) {
+        bus.publish({ type: 'tick', data: { i } });
+      }
+      // Subscribe with lastEventId=2 → should replay events 3..5.
+      const ac = new AbortController();
+      const iter = bus.subscribe({ lastEventId: 2, signal: ac.signal });
+      const replayed: number[] = [];
+      for await (const ev of iter) {
+        const data = ev.data as { i: number };
+        replayed.push(data.i);
+        if (replayed.length >= 3) break;
+      }
+      ac.abort();
+      expect(replayed).toEqual([3, 4, 5]);
+    });
+  });
+
+  describe('prompt latency', () => {
+    it.skipIf(SKIP_PROMPT_LATENCY)(
+      `p50 / p99 over ${PROMPT_ITERATIONS} prompts`,
+      async () => {
+        const ws = makeTempWorkspace('prompt');
+        const daemon = await spawnDaemon({ workspaceCwd: ws });
+        try {
+          const sess = await daemon.client.createOrAttachSession({
+            workspaceCwd: ws,
+          });
+          const firstByteMs: number[] = [];
+          const totalMs: number[] = [];
+
+          for (let i = 0; i < PROMPT_ITERATIONS; i++) {
+            const t0 = Date.now();
+            // Subscribe to events for first-byte timing; promptly cancel
+            // when we see the first session_update.
+            const ac = new AbortController();
+            const iter = daemon.client.subscribeEvents(sess.sessionId, {
+              signal: ac.signal,
+            });
+            const firstByteP = (async () => {
+              for await (const _ of iter) {
+                ac.abort();
+                return Date.now();
+              }
+              return Date.now();
+            })();
+
+            await daemon.client.prompt(sess.sessionId, {
+              prompt: [{ type: 'text', text: 'reply with the single word ok' }],
+            });
+            const tEnd = Date.now();
+            const tFirstByte = await firstByteP;
+
+            firstByteMs.push(tFirstByte - t0);
+            totalMs.push(tEnd - t0);
+          }
+
+          snapshot.promptLatency = {
+            iterations: PROMPT_ITERATIONS,
+            firstByteMs: percentiles(firstByteMs),
+            totalMs: percentiles(totalMs),
+            skipped: false,
+          };
+
+          expect(snapshot.promptLatency.totalMs!.p99).toBeLessThan(
+            THRESH.promptP99MaxMs,
+          );
+        } finally {
+          await daemon.dispose();
+          fs.rmSync(ws, { recursive: true, force: true });
+        }
+      },
+      HEAVY ? 30 * 60_000 : 10 * 60_000,
+    );
+
+    if (SKIP_PROMPT_LATENCY) {
+      it('prompt latency skipped (no QWEN_TEST_MODEL_KEY)', () => {
+        snapshot.promptLatency = {
+          iterations: 0,
+          firstByteMs: null,
+          totalMs: null,
+          skipped: true,
+          skipReason:
+            'QWEN_TEST_MODEL_KEY not set; prompt latency requires a real model credential.',
+        };
+        // Mark via a no-op assertion so the suite still appears in output.
+        expect(true).toBe(true);
+      });
+    }
+  });
+
+  afterAll(() => {
+    if (SKIP) return;
+    fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+    const jsonPath = path.join(OUTPUT_DIR, 'perf-baseline.json');
+    fs.writeFileSync(jsonPath, JSON.stringify(snapshot, null, 2));
+    fs.writeFileSync(
+      path.join(OUTPUT_DIR, 'perf-baseline.md'),
+      renderMarkdown(snapshot),
+    );
+    // Echo the path so a reviewer / CI logs surface where the artifact
+    // landed.
+    // eslint-disable-next-line no-console
+    console.log(`[baseline] perf-baseline.json written to ${jsonPath}`);
+  });
+});
+
+function renderMarkdown(s: SnapshotShape): string {
+  const fmt = (p: Percentiles | null | undefined): string =>
+    p
+      ? `p50=${p.p50.toFixed(0)} p90=${p.p90.toFixed(0)} p99=${p.p99.toFixed(0)} mean=${p.mean.toFixed(0)} (n=${p.count})`
+      : 'n/a';
+  return [
+    `# qwen serve daemon — perf baseline`,
+    ``,
+    `Captured: ${s.capturedAt}`,
+    `Git: ${s.gitCommit ?? 'unknown'}`,
+    `Platform: ${s.platform.os}/${s.platform.arch} node=${s.platform.nodeVersion}`,
+    `Heavy mode: ${s.config.heavy}`,
+    ``,
+    `## RSS scaling`,
+    s.rssScaling
+      ? `- 1 session: ${s.rssScaling.session1MB} MB\n- 5 sessions: ${s.rssScaling.session5MB} MB\n- 10 sessions: ${s.rssScaling.session10MB} MB\n- growth/session: ${s.rssScaling.growthPerSessionMB} MB`
+      : 'not run',
+    ``,
+    `## Attach latency`,
+    s.attachLatency
+      ? `- session 2 attach: ${s.attachLatency.session2Ms} ms\n- session 5 attach: ${s.attachLatency.session5Ms} ms`
+      : 'not run',
+    ``,
+    `## MCP amplification (P1 baseline)`,
+    s.mcpAmplification
+      ? `- MCP servers configured: ${s.mcpAmplification.mcpServersConfigured}\n- children at 1 session: ${s.mcpAmplification.childrenAt1Session}\n- children at 3 sessions: ${s.mcpAmplification.childrenAt3Sessions}\n- children at 5 sessions: ${s.mcpAmplification.childrenAt5Sessions}\n- linear amplification observed: ${s.mcpAmplification.linearAmplification}`
+      : 'not run',
+    ``,
+    `## Prompt latency`,
+    s.promptLatency
+      ? s.promptLatency.skipped
+        ? `skipped (${s.promptLatency.skipReason})`
+        : `- iterations: ${s.promptLatency.iterations}\n- first-byte (ms): ${fmt(s.promptLatency.firstByteMs)}\n- total (ms): ${fmt(s.promptLatency.totalMs)}`
+      : 'not run',
+    ``,
+    `## SSE backpressure (unit-level invariants)`,
+    s.sseBackpressure
+      ? `- ring size: ${s.sseBackpressure.ringSize}\n- max queued (default): ${s.sseBackpressure.maxQueuedDefault}\n- eviction at overflow: ${s.sseBackpressure.evictionAtOverflow}\n- replay up to ring: ${s.sseBackpressure.replayUpToRing}\n- heartbeat interval (ms): ${s.sseBackpressure.heartbeatIntervalMs}`
+      : 'not run',
+    ``,
+  ].join('\n');
+}

--- a/integration-tests/cli/qwen-serve-baseline.test.ts
+++ b/integration-tests/cli/qwen-serve-baseline.test.ts
@@ -45,6 +45,7 @@ import {
   percentiles,
   writeWorkspaceSettings,
   type SpawnedDaemon,
+  type DescendantCount,
   type Percentiles,
 } from './_daemon-harness.js';
 
@@ -69,12 +70,31 @@ const RSS_SAMPLE_DURATION_MS = Number(
   process.env['QWEN_BASELINE_RSS_SAMPLE_DURATION_MS'] ??
     (HEAVY ? 15_000 : 5_000),
 );
+const PROMPT_LATENCY_CREDENTIAL_ENV_KEYS = [
+  'DASHSCOPE_API_KEY',
+  'OPENAI_API_KEY',
+  'ANTHROPIC_API_KEY',
+  'GEMINI_API_KEY',
+  'GOOGLE_API_KEY',
+  'QWEN_API_KEY',
+];
+const HAS_PROMPT_LATENCY_CREDENTIAL =
+  process.env['QWEN_BASELINE_ENABLE_PROMPT_LATENCY'] === '1' ||
+  PROMPT_LATENCY_CREDENTIAL_ENV_KEYS.some((key) => Boolean(process.env[key])) ||
+  Object.entries(process.env).some(
+    ([key, value]) => key.startsWith('QWEN_CUSTOM_API_KEY_') && Boolean(value),
+  );
 const SKIP_PROMPT_LATENCY =
   process.env['QWEN_BASELINE_SKIP_PROMPT_LATENCY'] === '1' ||
-  !process.env['QWEN_TEST_MODEL_KEY'];
+  !HAS_PROMPT_LATENCY_CREDENTIAL;
 
 const FIXTURES_DIR = path.resolve(__dirname, '../fixtures');
 const IDLE_MCP_PATH = path.join(FIXTURES_DIR, 'idle-mcp/server.mjs');
+const MCP_SERVERS_CONFIGURED = 2;
+const MCP_FIXTURE_PGREP_FILTER = 'idle-mcp/server\\.mjs';
+const MCP_DESCENDANT_WAIT_TIMEOUT_MS = 10_000;
+const MCP_DESCENDANT_POLL_MS = 250;
+const RSS_DROPPED_SAMPLE_RATIO_MAX = 0.2;
 const RUN_TS = new Date().toISOString().replace(/[:.]/g, '').replace(/Z$/, '');
 const OUTPUT_DIR =
   process.env['INTEGRATION_TEST_FILE_DIR'] ??
@@ -117,6 +137,7 @@ interface SnapshotShape {
     session5MB: number;
     session10MB: number;
     sampleCount: number;
+    droppedSampleCount: number;
     growthPerSessionMB: number;
   };
   promptLatency?: {
@@ -191,6 +212,57 @@ function makeTempWorkspace(label: string): string {
   return dir;
 }
 
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function isAgentMessageChunkEvent(ev: {
+  type: string;
+  data: unknown;
+}): boolean {
+  if (ev.type !== 'session_update' || !isRecord(ev.data)) return false;
+  const update = ev.data['update'];
+  return isRecord(update) && update['sessionUpdate'] === 'agent_message_chunk';
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === 'AbortError';
+}
+
+async function waitForMcpGrandchildren(
+  daemonPid: number,
+  minMcpGrandchildren: number,
+): Promise<DescendantCount> {
+  const deadline = Date.now() + MCP_DESCENDANT_WAIT_TIMEOUT_MS;
+  let last = countDescendants(daemonPid, {
+    mcpFilter: MCP_FIXTURE_PGREP_FILTER,
+  });
+
+  while (Date.now() < deadline) {
+    last = countDescendants(daemonPid, {
+      mcpFilter: MCP_FIXTURE_PGREP_FILTER,
+    });
+    if (
+      last.acpChildren.length >= 1 &&
+      last.mcpGrandchildren.length >= minMcpGrandchildren
+    ) {
+      return last;
+    }
+    await sleep(MCP_DESCENDANT_POLL_MS);
+  }
+
+  throw new Error(
+    `Timed out waiting for ${minMcpGrandchildren} MCP grandchildren ` +
+      `under daemon ${daemonPid}; last acpChildren=` +
+      `[${last.acpChildren.join(', ')}], mcpGrandchildren=` +
+      `[${last.mcpGrandchildren.join(', ')}]`,
+  );
+}
+
 async function createNSessions(
   daemon: SpawnedDaemon,
   n: number,
@@ -205,23 +277,45 @@ async function createNSessions(
   return ids;
 }
 
-async function measureRssAtSessionCount(
-  sessionCount: number,
-): Promise<{ peakRssMB: number; sampleCount: number }> {
+async function measureRssAtSessionCount(sessionCount: number): Promise<{
+  peakRssMB: number;
+  sampleCount: number;
+  droppedSampleCount: number;
+}> {
   const ws = makeTempWorkspace(`rss-${sessionCount}`);
-  const daemon = await spawnDaemon({ workspaceCwd: ws });
+  let daemon: SpawnedDaemon | undefined;
   try {
+    daemon = await spawnDaemon({ workspaceCwd: ws });
     await createNSessions(daemon, sessionCount);
     const poller = startRssPolling(daemon.daemon.pid!, RSS_SAMPLE_INTERVAL_MS);
     await new Promise((r) => setTimeout(r, RSS_SAMPLE_DURATION_MS));
     poller.stop();
+    if (poller.samples.length === 0) {
+      throw new Error(
+        `RSS polling produced no usable samples for ${sessionCount} sessions`,
+      );
+    }
+    const sampleTotal = poller.samples.length + poller.droppedSamples;
+    if (
+      sampleTotal > 0 &&
+      poller.droppedSamples / sampleTotal > RSS_DROPPED_SAMPLE_RATIO_MAX
+    ) {
+      throw new Error(
+        `RSS polling dropped ${poller.droppedSamples}/${sampleTotal} ` +
+          `samples for ${sessionCount} sessions`,
+      );
+    }
     const peakRssMB = poller.samples.reduce(
       (max, s) => Math.max(max, s.rssMB),
       0,
     );
-    return { peakRssMB, sampleCount: poller.samples.length };
+    return {
+      peakRssMB,
+      sampleCount: poller.samples.length,
+      droppedSampleCount: poller.droppedSamples,
+    };
   } finally {
-    await daemon.dispose();
+    if (daemon) await daemon.dispose();
     fs.rmSync(ws, { recursive: true, force: true });
   }
 }
@@ -242,6 +336,10 @@ async function measureRssAtSessionCount(
             session5MB: r5.peakRssMB,
             session10MB: r10.peakRssMB,
             sampleCount: r1.sampleCount + r5.sampleCount + r10.sampleCount,
+            droppedSampleCount:
+              r1.droppedSampleCount +
+              r5.droppedSampleCount +
+              r10.droppedSampleCount,
             growthPerSessionMB:
               Math.round(((r10.peakRssMB - r1.peakRssMB) / 9) * 10) / 10,
           };
@@ -249,8 +347,6 @@ async function measureRssAtSessionCount(
           // Catastrophic upper bounds only.
           expect(r1.peakRssMB).toBeLessThan(THRESH.rss1SessionMaxMB);
           expect(r10.peakRssMB).toBeLessThan(THRESH.rss10SessionsMaxMB);
-          // Sanity: growth should be non-negative (more sessions ≥ more memory).
-          expect(r10.peakRssMB).toBeGreaterThanOrEqual(r1.peakRssMB);
         },
         // Each session-count needs daemon spawn + N session creates +
         // RSS_SAMPLE_DURATION_MS sampling + dispose. ~3 × 15s budget per
@@ -262,8 +358,9 @@ async function measureRssAtSessionCount(
     describe('attach latency', () => {
       it('measures Nth same-workspace session attach time', async () => {
         const ws = makeTempWorkspace('attach');
-        const daemon = await spawnDaemon({ workspaceCwd: ws });
+        let daemon: SpawnedDaemon | undefined;
         try {
+          daemon = await spawnDaemon({ workspaceCwd: ws });
           // Create session 1 to warm the channel.
           await daemon.client.createOrAttachSession({ workspaceCwd: ws });
 
@@ -287,7 +384,7 @@ async function measureRssAtSessionCount(
           expect(session2Ms).toBeLessThan(THRESH.attachLatencyMaxMs);
           expect(session5Ms).toBeLessThan(THRESH.attachLatencyMaxMs);
         } finally {
-          await daemon.dispose();
+          if (daemon) await daemon.dispose();
           fs.rmSync(ws, { recursive: true, force: true });
         }
       }, 60_000);
@@ -296,41 +393,43 @@ async function measureRssAtSessionCount(
     describe('MCP child amplification (P1 baseline)', () => {
       it('counts MCP grandchildren as session count grows', async () => {
         const ws = makeTempWorkspace('mcp');
-        writeWorkspaceSettings(ws, {
-          mcpServers: {
-            idle1: { command: 'node', args: [IDLE_MCP_PATH] },
-            idle2: { command: 'node', args: [IDLE_MCP_PATH] },
-          },
-        });
-        const daemon = await spawnDaemon({ workspaceCwd: ws });
+        let daemon: SpawnedDaemon | undefined;
         try {
-          // Sleep briefly after each create so MCP children get time to
-          // spawn before we count.
-          const sleep = (ms: number) =>
-            new Promise<void>((r) => setTimeout(r, ms));
+          writeWorkspaceSettings(ws, {
+            mcpServers: {
+              idle1: { command: 'node', args: [IDLE_MCP_PATH] },
+              idle2: { command: 'node', args: [IDLE_MCP_PATH] },
+            },
+          });
+          daemon = await spawnDaemon({ workspaceCwd: ws });
 
           await daemon.client.createOrAttachSession({ workspaceCwd: ws });
-          await sleep(2_000);
-          const at1 = countDescendants(daemon.daemon.pid!);
+          const at1 = await waitForMcpGrandchildren(
+            daemon.daemon.pid!,
+            MCP_SERVERS_CONFIGURED,
+          );
 
           await daemon.client.createOrAttachSession({ workspaceCwd: ws });
           await daemon.client.createOrAttachSession({ workspaceCwd: ws });
-          await sleep(2_000);
-          const at3 = countDescendants(daemon.daemon.pid!);
+          const at3 = await waitForMcpGrandchildren(
+            daemon.daemon.pid!,
+            MCP_SERVERS_CONFIGURED,
+          );
 
           await daemon.client.createOrAttachSession({ workspaceCwd: ws });
           await daemon.client.createOrAttachSession({ workspaceCwd: ws });
-          await sleep(2_000);
-          const at5 = countDescendants(daemon.daemon.pid!);
+          const at5 = await waitForMcpGrandchildren(
+            daemon.daemon.pid!,
+            MCP_SERVERS_CONFIGURED,
+          );
 
-          const mcpServersConfigured = 2;
           const expectedMaxAt5 =
-            mcpServersConfigured * 5 * THRESH.mcpAmplificationFactor;
+            MCP_SERVERS_CONFIGURED * 5 * THRESH.mcpAmplificationFactor;
           const linear =
-            at5.mcpGrandchildren.length >= mcpServersConfigured * 5 * 0.5; // ≥50% of linear → confirmed amplification
+            at5.mcpGrandchildren.length >= MCP_SERVERS_CONFIGURED * 5 * 0.5; // ≥50% of linear → confirmed amplification
 
           snapshot.mcpAmplification = {
-            mcpServersConfigured,
+            mcpServersConfigured: MCP_SERVERS_CONFIGURED,
             childrenAt1Session: at1.mcpGrandchildren.length,
             childrenAt3Sessions: at3.mcpGrandchildren.length,
             childrenAt5Sessions: at5.mcpGrandchildren.length,
@@ -339,12 +438,15 @@ async function measureRssAtSessionCount(
 
           // Sanity: at least 1 ACP child should exist throughout.
           expect(at1.acpChildren.length).toBeGreaterThanOrEqual(1);
+          expect(at1.mcpGrandchildren.length).toBeGreaterThanOrEqual(
+            MCP_SERVERS_CONFIGURED,
+          );
           // Catastrophic bound: not worse than 2× linear.
           expect(at5.mcpGrandchildren.length).toBeLessThanOrEqual(
             expectedMaxAt5,
           );
         } finally {
-          await daemon.dispose();
+          if (daemon) await daemon.dispose();
           fs.rmSync(ws, { recursive: true, force: true });
         }
       }, 120_000);
@@ -411,8 +513,9 @@ async function measureRssAtSessionCount(
         `p50 / p99 over ${PROMPT_ITERATIONS} prompts`,
         async () => {
           const ws = makeTempWorkspace('prompt');
-          const daemon = await spawnDaemon({ workspaceCwd: ws });
+          let daemon: SpawnedDaemon | undefined;
           try {
+            daemon = await spawnDaemon({ workspaceCwd: ws });
             const sess = await daemon.client.createOrAttachSession({
               workspaceCwd: ws,
             });
@@ -422,26 +525,49 @@ async function measureRssAtSessionCount(
             for (let i = 0; i < PROMPT_ITERATIONS; i++) {
               const t0 = Date.now();
               // Subscribe to events for first-byte timing; promptly cancel
-              // when we see the first session_update.
+              // when we see the first model response chunk.
               const ac = new AbortController();
               const iter = daemon.client.subscribeEvents(sess.sessionId, {
                 signal: ac.signal,
               });
-              const firstByteP = (async () => {
-                for await (const _ of iter) {
-                  ac.abort();
-                  return Date.now();
+              const firstByteP = (async (): Promise<number | null> => {
+                try {
+                  for await (const ev of iter) {
+                    if (isAgentMessageChunkEvent(ev)) {
+                      return Date.now();
+                    }
+                  }
+                } catch (err) {
+                  if (!isAbortError(err)) {
+                    throw err;
+                  }
                 }
-                return Date.now();
+                return null;
               })();
 
-              await daemon.client.prompt(sess.sessionId, {
-                prompt: [
-                  { type: 'text', text: 'reply with the single word ok' },
-                ],
-              });
-              const tEnd = Date.now();
+              let promptError: unknown;
+              let tEnd = Date.now();
+              try {
+                await daemon.client.prompt(sess.sessionId, {
+                  prompt: [
+                    { type: 'text', text: 'reply with the single word ok' },
+                  ],
+                });
+                tEnd = Date.now();
+              } catch (err) {
+                promptError = err;
+                tEnd = Date.now();
+              } finally {
+                ac.abort();
+              }
               const tFirstByte = await firstByteP;
+              if (promptError) throw promptError;
+              if (tFirstByte === null) {
+                throw new Error(
+                  'Prompt latency probe completed without an ' +
+                    'agent_message_chunk session_update event',
+                );
+              }
 
               firstByteMs.push(tFirstByte - t0);
               totalMs.push(tEnd - t0);
@@ -458,7 +584,7 @@ async function measureRssAtSessionCount(
               THRESH.promptP99MaxMs,
             );
           } finally {
-            await daemon.dispose();
+            if (daemon) await daemon.dispose();
             fs.rmSync(ws, { recursive: true, force: true });
           }
         },
@@ -466,14 +592,14 @@ async function measureRssAtSessionCount(
       );
 
       if (SKIP_PROMPT_LATENCY) {
-        it('prompt latency skipped (no QWEN_TEST_MODEL_KEY)', () => {
+        it('prompt latency skipped (no model credential env)', () => {
           snapshot.promptLatency = {
             iterations: 0,
             firstByteMs: null,
             totalMs: null,
             skipped: true,
             skipReason:
-              'QWEN_TEST_MODEL_KEY not set; prompt latency requires a real model credential.',
+              'No recognized model credential env var is set; prompt latency requires real model access. Set QWEN_BASELINE_ENABLE_PROMPT_LATENCY=1 to force-run with non-env auth.',
           };
           // Mark via a no-op assertion so the suite still appears in output.
           expect(true).toBe(true);
@@ -512,7 +638,7 @@ function renderMarkdown(s: SnapshotShape): string {
     ``,
     `## RSS scaling`,
     s.rssScaling
-      ? `- 1 session: ${s.rssScaling.session1MB} MB\n- 5 sessions: ${s.rssScaling.session5MB} MB\n- 10 sessions: ${s.rssScaling.session10MB} MB\n- growth/session: ${s.rssScaling.growthPerSessionMB} MB`
+      ? `- 1 session: ${s.rssScaling.session1MB} MB\n- 5 sessions: ${s.rssScaling.session5MB} MB\n- 10 sessions: ${s.rssScaling.session10MB} MB\n- RSS samples: ${s.rssScaling.sampleCount} (${s.rssScaling.droppedSampleCount} dropped)\n- growth/session: ${s.rssScaling.growthPerSessionMB} MB`
       : 'not run',
     ``,
     `## Attach latency`,

--- a/integration-tests/fixtures/idle-mcp/package.json
+++ b/integration-tests/fixtures/idle-mcp/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "idle-mcp",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "description": "Minimal idle MCP fixture for daemon baseline integration tests. Responds to initialize + tools/list, then idles. Used to count MCP child processes spawned by the daemon (pgrep -P) without pulling a real MCP package into CI.",
+  "bin": {
+    "idle-mcp-server": "./server.mjs"
+  }
+}

--- a/integration-tests/fixtures/idle-mcp/package.json
+++ b/integration-tests/fixtures/idle-mcp/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
-  "description": "Minimal idle MCP fixture for daemon baseline integration tests. Responds to initialize + tools/list, then idles. Used to count MCP child processes spawned by the daemon (pgrep -P) without pulling a real MCP package into CI.",
+  "description": "Minimal idle MCP fixture for daemon baseline integration tests. Responds to initialize + tools/list with one no-op tool, then idles. Used to count MCP child processes spawned by the daemon (pgrep -P) without pulling a real MCP package into CI.",
   "bin": {
     "idle-mcp-server": "./server.mjs"
   }

--- a/integration-tests/fixtures/idle-mcp/server.mjs
+++ b/integration-tests/fixtures/idle-mcp/server.mjs
@@ -10,7 +10,7 @@
 // network + version-lock churn into CI; this fixture is deterministic
 // and ~30 lines.
 
-import { stdin, stdout } from 'node:process';
+import { exit, stdin, stdout } from 'node:process';
 
 const PROTOCOL_VERSION = '2024-11-05';
 
@@ -59,4 +59,4 @@ stdin.on('data', (chunk) => {
   }
 });
 
-stdin.on('end', () => process.exit(0));
+stdin.on('end', () => exit(0));

--- a/integration-tests/fixtures/idle-mcp/server.mjs
+++ b/integration-tests/fixtures/idle-mcp/server.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// Minimal stdio MCP server for daemon-baseline tests. Responds to the
+// MCP `initialize` + `tools/list` handshake (just enough for the daemon
+// to consider the server "connected"), then idles forever.
+//
+// We need a real long-running child process so the baseline harness can
+// count it via `pgrep -P` and surface the P1 N×M amplification before
+// the M2 shared-pool fix tightens it. A real npm MCP package (e.g.
+// `@modelcontextprotocol/server-everything`) would also work but pulls
+// network + version-lock churn into CI; this fixture is deterministic
+// and ~30 lines.
+
+import { stdin, stdout } from 'node:process';
+
+const PROTOCOL_VERSION = '2024-11-05';
+
+function send(msg) {
+  stdout.write(JSON.stringify(msg) + '\n');
+}
+
+function respond(id, result) {
+  send({ jsonrpc: '2.0', id, result });
+}
+
+let buf = '';
+stdin.setEncoding('utf8');
+stdin.on('data', (chunk) => {
+  buf += chunk;
+  let nl;
+  while ((nl = buf.indexOf('\n')) !== -1) {
+    const line = buf.slice(0, nl);
+    buf = buf.slice(nl + 1);
+    if (!line.trim()) continue;
+    let msg;
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (msg.method === 'initialize') {
+      respond(msg.id, {
+        protocolVersion: PROTOCOL_VERSION,
+        capabilities: { tools: {} },
+        serverInfo: { name: 'idle-mcp', version: '0.0.1' },
+      });
+    } else if (msg.method === 'tools/list') {
+      respond(msg.id, { tools: [] });
+    } else if (msg.method === 'notifications/initialized') {
+      // No response needed for notifications.
+    } else if (msg.id !== undefined) {
+      // Unknown request — return a method-not-found error so the daemon
+      // doesn't hang waiting on us.
+      send({
+        jsonrpc: '2.0',
+        id: msg.id,
+        error: { code: -32601, message: 'method not found' },
+      });
+    }
+  }
+});
+
+stdin.on('end', () => process.exit(0));

--- a/integration-tests/fixtures/idle-mcp/server.mjs
+++ b/integration-tests/fixtures/idle-mcp/server.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 // Minimal stdio MCP server for daemon-baseline tests. Responds to the
-// MCP `initialize` + `tools/list` handshake (just enough for the daemon
-// to consider the server "connected"), then idles forever.
+// MCP `initialize` + `tools/list` handshake with one no-op tool (just
+// enough for the daemon to consider the server "connected"), then idles
+// forever.
 //
 // We need a real long-running child process so the baseline harness can
 // count it via `pgrep -P` and surface the P1 N×M amplification before
@@ -13,6 +14,17 @@
 import { exit, stdin, stdout } from 'node:process';
 
 const PROTOCOL_VERSION = '2024-11-05';
+const TOOLS = [
+  {
+    name: 'idle_ping',
+    description: 'No-op tool for daemon baseline process-count tests.',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      additionalProperties: false,
+    },
+  },
+];
 
 function send(msg) {
   stdout.write(JSON.stringify(msg) + '\n');
@@ -44,7 +56,9 @@ stdin.on('data', (chunk) => {
         serverInfo: { name: 'idle-mcp', version: '0.0.1' },
       });
     } else if (msg.method === 'tools/list') {
-      respond(msg.id, { tools: [] });
+      respond(msg.id, { tools: TOOLS });
+    } else if (msg.method === 'tools/call') {
+      respond(msg.id, { content: [{ type: 'text', text: 'ok' }] });
     } else if (msg.method === 'notifications/initialized') {
       // No response needed for notifications.
     } else if (msg.id !== undefined) {


### PR DESCRIPTION
## Post-merge update (2026-05-17)

Merged on 2026-05-16 as QwenLM/qwen-code@0788ed7. Final PR branch included the baseline harness plus review follow-ups:

- `e045b2dac`: imported `exit` from `node:process` in the idle MCP fixture.
- `28becf164`: removed the stale baseline lint disable.
- `acb6efeff`: hardened daemon baseline cleanup, RSS sampling validity, MCP fixture validation, prompt first-byte measurement, and `pgrep` handling.
- `998e3cc24`: synced latest `main` before merge, including #4209 (`session_scope_override`) and #4211 test fix.

Follow-up: #4214 tracks post-#4209 alignment for stale integration-test/user-doc expectations around `session_scope_override`.

## Summary

First implementation PR of the Mode B v0.16 rollout (issue #4175 Wave 1 PR 1, ack'd by @wenshao on 2026-05-16). Captures reference performance metrics for `qwen serve` so subsequent Mode B PRs (M2 MCP shared pool, M3 architecture refactor, M4 multi-client safety) can be measured against a known baseline rather than guessed-at numbers.

**No production code touched.** All changes live under `integration-tests/`.

## What this PR adds

| File | Purpose |
|---|---|
| `integration-tests/cli/qwen-serve-baseline.test.ts` | 5 describe blocks: RSS scaling / attach latency / MCP child amplification / SSE backpressure / prompt latency |
| `integration-tests/cli/_daemon-harness.ts` | Reusable helpers: `spawnDaemon` extracts the inline daemon spawn pattern from `qwen-serve-routes.test.ts:52-103`; plus `getRssMB`, `startRssPolling`, `countDescendants`, `percentiles`, `consumeSseEvents`, `writeWorkspaceSettings` |
| `integration-tests/fixtures/idle-mcp/{server.mjs,package.json}` | Minimal stdio MCP fixture — responds to `initialize` + `tools/list` with one no-op tool, then idles. Used to count real MCP fixture processes through the daemon/ACP process tree without pulling a network npm package into CI |
| `integration-tests/baselines/baseline-stage-1.json` | First captured baseline (this commit). Future Mode B PRs can diff against this |

## Honest documentation of current limits

The captured snapshot's `notes` field flags that with the default `sessionScope: 'single'`, N successive `createOrAttachSession` calls return the same sessionId — so the RSS / MCP metrics measure "N attaches to one shared session", not "N distinct sessions". Wave 2 PR 5 (#4209) has now landed, so the next baseline follow-up can pass `sessionScope: 'thread'` to measure distinct-session cost and surface the P1 MCP N×M amplification before **M2** fixes it. This PR intentionally kept the original single-scope baseline.

## Reused vs new

**Reused:**
- Daemon spawn pattern from `qwen-serve-routes.test.ts:52-103`
- `pgrep -P` pattern from `qwen-serve-streaming.test.ts:144`
- `EventBus` direct instantiation pattern from `packages/cli/src/serve/eventBus.test.ts`
- `DaemonClient` SDK
- `globalSetup.ts` env var conventions (`TEST_CLI_PATH`, `INTEGRATION_TEST_FILE_DIR`, `KEEP_OUTPUT`)

**New** (no equivalent existed in qwen-code or opencode):
- Daemon-level multi-session RSS scan
- Prompt p50/p99 percentile harness
- MCP fixture process counting through the daemon/ACP process tree
- SSE backpressure measurement against a real daemon

JSDoc on `_daemon-harness.ts` references the opencode patterns the design borrows from (per the #4175 description's external implementation references):

- opencode `test/memory/abort-leak.test.ts` — forced-GC heap-growth shape
- opencode `src/cli/heap.ts` — periodic RSS poll + threshold-triggered `writeHeapSnapshot` (useful for Wave 6 production tooling)
- opencode `src/util/cpu-watchdog.ts` — event-loop lag drift sampling

## Captured baseline (this PR's reference snapshot)

```json
{
  "version": 1,
  "capturedAt": "2026-05-16T08:36:52.441Z",
  "gitCommit": "df32345d0553560cf342c1b4e6ad44df5646111b",
  "platform": { "os": "darwin", "arch": "arm64", "nodeVersion": "v24.12.0" },
  "rssScaling": {
    "session1MB": 223.5, "session5MB": 224.2, "session10MB": 223.9,
    "sampleCount": 60, "droppedSampleCount": 0, "growthPerSessionMB": 0
  },
  "attachLatency": { "session2Ms": 3, "session5Ms": 1, "thresholdMs": 1000 },
  "mcpAmplification": {
    "mcpServersConfigured": 2,
    "childrenAt1Session": 4, "childrenAt3Sessions": 4, "childrenAt5Sessions": 4,
    "linearAmplification": false
  },
  "sseBackpressure": {
    "ringSize": 4000, "maxQueuedDefault": 256,
    "evictionAtOverflow": true, "replayUpToRing": true,
    "heartbeatIntervalMs": 15000
  },
  "promptLatency": {
    "iterations": 0,
    "firstByteMs": null,
    "totalMs": null,
    "skipped": true,
    "skipReason": "No recognized model credential env var is set; prompt latency requires real model access. Set QWEN_BASELINE_ENABLE_PROMPT_LATENCY=1 to force-run with non-env auth."
  }
}
```

The flat RSS curve and constant MCP fixture process count are **expected for default `single`-scope semantics** — this is the reference data point before future `sessionScope: 'thread'` follow-up measurement.

## Engineering principles checklist (per #4175 §PR-level acceptance checklist)

- [x] Independently mergeable (test-only; no production code touched)
- [x] Backward compatible (no removed routes / event fields / CLI behavior)
- [x] Default off (PR CI does not run integration tests; this runs in release CI / nightly / manual)
- [x] \`qwen serve\` Stage 1 routes / SDK behavior preserved (no production code changed)
- [x] Gradual migration (no client adapter migration in this PR)
- [x] Reversible (revert = delete files, no other side effects)
- [x] Tests-first (this IS the test PR; harness exercises real daemon end-to-end)

## Test plan

- [x] `node scripts/lint.js --eslint`
- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `KEEP_OUTPUT=true QWEN_BASELINE_SKIP_PROMPT_LATENCY=1 QWEN_BASELINE_RSS_SAMPLE_DURATION_MS=500 npx vitest run integration-tests/cli/qwen-serve-baseline.test.ts` — prompt latency skipped without model credentials
- [x] Test skips on Windows via `process.platform === 'win32'` gate (matches `qwen-serve-streaming.test.ts:53` precedent)

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| `QWEN_BASELINE_PROMPT_ITERATIONS` | 20 | Number of prompts for percentile measurement |
| `QWEN_BASELINE_RSS_SAMPLE_INTERVAL_MS` | 100 | RSS poll interval |
| `QWEN_BASELINE_RSS_SAMPLE_DURATION_MS` | 5000 | RSS sampling window per session count |
| `QWEN_BASELINE_HEAVY` | (unset) | If `1`, increase iterations to 100 + sample longer |
| `QWEN_BASELINE_SKIP_PROMPT_LATENCY` | (unset) | Skip prompt-percentile suite (no model key needed) |

## Stack context

This is sub-PR 1 of 25 in #4175 Wave 1. Adopted into the codeagents design docs at commit `d5dbbeb` per @wenshao's confirmation. The next PRs in Wave 1 (PR 2 capability registry / PR 3 DaemonSessionClient / PR 4 typed events) can run in parallel and don't depend on this one.

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)
