### PR TITLE
[codex] Add stop hook blocking cap

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -58,6 +58,8 @@ import {
   evaluatePermissionFlow,
   needsConfirmation,
   isPlanModeBlocked,
+  abortGoalForStopHookCap,
+  formatStopHookBlockingCapWarning,
 } from '@qwen-code/qwen-code-core';
 import { getCommandSubcommandNames } from '../../services/commandMetadata.js';
 import { getEffectiveSupportedModes } from '../../services/commandUtils.js';
@@ -693,11 +695,11 @@ export class Session implements SessionContext {
     hooksEnabled: boolean,
     messageBus: MessageBus | undefined,
   ): Promise<{ stopReason: PromptResponse['stopReason'] }> {
-    const MAX_STOP_HOOK_ITERATIONS = 100;
+    const stopHookBlockingCap = this.config.getStopHookBlockingCap();
     let stopHookIterationCount = 0;
     let stopHookReasons: string[] = [];
 
-    while (stopHookIterationCount < MAX_STOP_HOOK_ITERATIONS) {
+    while (stopHookIterationCount < stopHookBlockingCap) {
       if (
         !hooksEnabled ||
         !messageBus ||
@@ -761,13 +763,25 @@ export class Session implements SessionContext {
         stopHookIterationCount++;
         stopHookReasons = [...stopHookReasons, continueReason];
 
-        // Emit StopHookLoop event for iterations after the first one
-        if (stopHookIterationCount > 1) {
-          await this.messageEmitter.emitStopHookLoop(
-            stopHookIterationCount,
-            stopHookReasons,
-            response.stopHookCount ?? 1,
+        await this.messageEmitter.emitStopHookLoop(
+          stopHookIterationCount,
+          stopHookReasons,
+          response.stopHookCount ?? 1,
+        );
+
+        if (stopHookIterationCount >= stopHookBlockingCap) {
+          const warning = formatStopHookBlockingCapWarning(
+            'Stop',
+            stopHookBlockingCap,
           );
+          abortGoalForStopHookCap(
+            this.config,
+            this.config.getSessionId(),
+            warning,
+          );
+          await this.messageEmitter.emitAgentMessage(warning);
+          debugLogger.warn(warning);
+          return { stopReason: 'end_turn' };
         }
 
         // Continue the conversation with the hook's reason
@@ -902,13 +916,6 @@ export class Session implements SessionContext {
 
       // Stop hook allowed stopping, exit the loop
       break;
-    }
-
-    // If we exceeded max iterations, log a warning but still end gracefully
-    if (stopHookIterationCount >= MAX_STOP_HOOK_ITERATIONS) {
-      debugLogger.warn(
-        `Stop hook loop reached maximum iterations (${MAX_STOP_HOOK_ITERATIONS}), forcing stop`,
-      );
     }
 
     return { stopReason: 'end_turn' };

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1708,6 +1708,7 @@ export async function loadCliConfig(
     projectHooks: bareMode ? undefined : hooksConfig?.projectHooks,
     hooks: bareMode ? undefined : settings.hooks, // Keep for backward compatibility
     disableAllHooks: bareMode ? true : (settings.disableAllHooks ?? false),
+    stopHookBlockingCap: bareMode ? undefined : settings.stopHookBlockingCap,
     channel: argv.channel,
     // CLI flag wins over settings.json. `--json-fd` is fd-only (no settings
     // equivalent — fd passing is a spawn-time concern). `--json-file` and

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -14,6 +14,7 @@ import type {
 } from '@qwen-code/qwen-code-core';
 import {
   ApprovalMode,
+  DEFAULT_STOP_HOOK_BLOCK_CAP,
   DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
   DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
 } from '@qwen-code/qwen-code-core';
@@ -1947,6 +1948,17 @@ const SETTINGS_SCHEMA = {
     default: false,
     description:
       'Temporarily disable all hooks without deleting configurations. Default is false (hooks enabled).',
+    showInDialog: false,
+  },
+
+  stopHookBlockingCap: {
+    type: 'number',
+    label: 'Stop Hook Blocking Cap',
+    category: 'Advanced',
+    requiresRestart: true,
+    default: DEFAULT_STOP_HOOK_BLOCK_CAP,
+    description:
+      'Maximum consecutive blocking Stop/SubagentStop hook decisions before Qwen Code overrides the hook loop and ends the turn. Can be overridden by QWEN_CODE_STOP_HOOK_BLOCK_CAP.',
     showInDialog: false,
   },
 

--- a/packages/core/src/agents/background-agent-resume.test.ts
+++ b/packages/core/src/agents/background-agent-resume.test.ts
@@ -82,6 +82,7 @@ describe('BackgroundAgentResumeService', () => {
       getMonitorRegistry: () => monitorRegistry,
       getSubagentManager: () => subagentManager,
       getHookSystem: () => hookSystem,
+      getStopHookBlockingCap: () => 8,
       getApprovalMode: () => 'default',
       isTrustedFolder: () => true,
       getProjectRoot: () => tempDir,

--- a/packages/core/src/agents/background-agent-resume.ts
+++ b/packages/core/src/agents/background-agent-resume.ts
@@ -27,6 +27,7 @@ import type { ChatRecord } from '../services/chatRecordingService.js';
 import { getInitialChatHistory } from '../utils/environmentContext.js';
 import { getGitBranch } from '../utils/gitUtils.js';
 import { PermissionMode, type StopHookOutput } from '../hooks/types.js';
+import { formatStopHookBlockingCapWarning } from '../hooks/stopHookCap.js';
 import { runWithAgentContext } from './runtime/agent-context.js';
 import { createApprovalModeOverride } from '../tools/agent/agent.js';
 import type { ApprovalMode } from '../config/config.js';
@@ -982,7 +983,7 @@ export class BackgroundAgentResumeService {
     const hookSystem = this.config.getHookSystem();
     if (!hookSystem) return;
     let stopHookActive = false;
-    const maxIterations = 5;
+    const maxIterations = this.config.getStopHookBlockingCap();
 
     for (let i = 0; i < maxIterations; i++) {
       try {
@@ -1022,7 +1023,10 @@ export class BackgroundAgentResumeService {
     }
 
     debugLogger.warn(
-      `[BackgroundAgentResume] SubagentStop hook reached maximum iterations (${maxIterations}), forcing stop`,
+      `[BackgroundAgentResume] ${formatStopHookBlockingCapWarning(
+        'SubagentStop',
+        maxIterations,
+      )}`,
     );
   }
 }

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -74,6 +74,7 @@ import { MonitorRegistry } from '../services/monitorRegistry.js';
 import { BackgroundAgentResumeService } from '../agents/background-agent-resume.js';
 import { BackgroundShellRegistry } from '../services/backgroundShellRegistry.js';
 import { FileReadCache } from '../services/fileReadCache.js';
+import { resolveStopHookBlockingCap } from '../hooks/stopHookCap.js';
 import {
   DEFAULT_OTLP_ENDPOINT,
   DEFAULT_TELEMETRY_TARGET,
@@ -593,6 +594,11 @@ export interface ConfigParameters {
    */
   disableAllHooks?: boolean;
   /**
+   * Maximum consecutive blocking Stop/SubagentStop hook decisions before the
+   * runtime overrides the hook loop and allows the turn to end.
+   */
+  stopHookBlockingCap?: number;
+  /**
    * User-level hooks configuration (from user settings).
    * These hooks are always loaded regardless of folder trust status.
    */
@@ -818,6 +824,7 @@ export class Config {
   private readonly enableAutoSkill: boolean;
   private fastModel?: string;
   private readonly disableAllHooks: boolean;
+  private readonly stopHookBlockingCap: number;
   /** User-level hooks (always loaded regardless of trust) */
   private readonly userHooks?: Record<string, unknown>;
   /** Project-level hooks (only loaded in trusted folders) */
@@ -1020,6 +1027,9 @@ export class Config {
     this.enableAutoSkill = params.enableAutoSkill ?? false;
     this.fastModel = params.fastModel || undefined;
     this.disableAllHooks = params.disableAllHooks ?? false;
+    this.stopHookBlockingCap = resolveStopHookBlockingCap(
+      params.stopHookBlockingCap,
+    );
     // Store user and project hooks separately for proper source attribution
     this.userHooks = params.userHooks;
     this.projectHooks = params.projectHooks;
@@ -2651,6 +2661,10 @@ export class Config {
    */
   getDisableAllHooks(): boolean {
     return this.disableAllHooks || this.getBareMode();
+  }
+
+  getStopHookBlockingCap(): number {
+    return this.stopHookBlockingCap;
   }
 
   getManagedAutoMemoryEnabled(): boolean {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -510,6 +510,7 @@ describe('Gemini Client (client.ts)', () => {
         getResolvedModel: vi.fn().mockReturnValue(undefined),
       }),
       getDisableAllHooks: vi.fn().mockReturnValue(true),
+      getStopHookBlockingCap: vi.fn().mockReturnValue(8),
       getArenaManager: vi.fn().mockReturnValue(null),
       getMessageBus: vi.fn().mockReturnValue(undefined),
       hasHooksForEvent: vi.fn().mockReturnValue(false),
@@ -4330,6 +4331,65 @@ Other open files:
 
         // messageBus.request should NOT be called for Stop hook either
         expect(mockMessageBus.request).not.toHaveBeenCalled();
+      });
+
+      it('ends the Stop hook loop when the blocking cap is reached', async () => {
+        const mockMessageBus = {
+          request: vi.fn().mockResolvedValue({
+            output: {
+              decision: 'block',
+              reason: 'Keep working',
+            },
+            stopHookCount: 1,
+          }),
+          response: vi.fn(),
+        };
+        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
+          (event: string) => event === 'Stop',
+        );
+        vi.mocked(mockConfig.getStopHookBlockingCap).mockReturnValue(1);
+
+        client['chat'] = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([
+            {
+              role: 'model',
+              parts: [{ text: 'not done' }],
+            },
+          ]),
+        } as unknown as GeminiChat;
+        mockTurnRunFn.mockReturnValue(
+          (async function* () {
+            yield { type: GeminiEventType.Content, value: 'not done' };
+          })(),
+        );
+
+        const events = await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'Hi' }],
+            new AbortController().signal,
+            'prompt-stop-cap',
+          ),
+        );
+
+        expect(mockTurnRunFn).toHaveBeenCalledTimes(1);
+        expect(events).toContainEqual({
+          type: GeminiEventType.StopHookLoop,
+          value: {
+            iterationCount: 1,
+            reasons: ['Keep working'],
+            stopHookCount: 1,
+          },
+        });
+        expect(events).toContainEqual({
+          type: GeminiEventType.HookSystemMessage,
+          value:
+            'Stop hook blocked continuation 1 consecutive times; overriding and ending the turn.',
+        });
       });
 
       it('should not skip hooks when hasHooksForEvent returns true', async () => {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -20,6 +20,8 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 import { recordStartupEvent } from '../utils/startupEventSink.js';
 import { microcompactHistory } from '../services/microcompaction/microcompact.js';
 import { getActiveGoal } from '../goals/activeGoalStore.js';
+import { abortGoalForStopHookCap } from '../goals/goalHook.js';
+import { formatStopHookBlockingCapWarning } from '../hooks/stopHookCap.js';
 
 const debugLogger = createDebugLogger('CLIENT');
 
@@ -1576,6 +1578,26 @@ export class GeminiClient {
               stopHookCount: response.stopHookCount ?? 1,
             },
           };
+
+          const stopHookBlockingCap = this.config.getStopHookBlockingCap();
+          if (currentIterationCount >= stopHookBlockingCap) {
+            const warning = formatStopHookBlockingCapWarning(
+              'Stop',
+              stopHookBlockingCap,
+            );
+            abortGoalForStopHookCap(
+              this.config,
+              this.config.getSessionId(),
+              warning,
+            );
+            yield {
+              type: GeminiEventType.HookSystemMessage,
+              value: warning,
+            };
+            debugLogger.warn(warning);
+            if (isTopLevelInteraction) endInteractionSpan('ok');
+            return turn;
+          }
 
           const continueRequest = [{ text: continueReason }];
           const activeGoal = getActiveGoal(this.config.getSessionId());

--- a/packages/core/src/goals/goalHook.ts
+++ b/packages/core/src/goals/goalHook.ts
@@ -120,6 +120,25 @@ function finishGoal(
   clearGoalTerminalObserver(sessionId);
 }
 
+export function abortGoalForStopHookCap(
+  config: Config,
+  sessionId: string,
+  systemMessage: string,
+): boolean {
+  const goal = getActiveGoal(sessionId);
+  if (!goal) return false;
+
+  finishGoal(config, sessionId, goal, {
+    kind: 'aborted',
+    condition: goal.condition,
+    iterations: goal.iterations,
+    durationMs: Date.now() - goal.setAt,
+    lastReason: goal.lastReason,
+    systemMessage,
+  });
+  return true;
+}
+
 /**
  * Builds the Function hook callback that, on every Stop event, asks a fast
  * model whether the goal condition holds.

--- a/packages/core/src/goals/index.ts
+++ b/packages/core/src/goals/index.ts
@@ -27,6 +27,7 @@ export {
   GOAL_HOOK_TIMEOUT_MS,
   GOAL_HOOK_TIMEOUT_SECONDS,
   createGoalStopHookCallback,
+  abortGoalForStopHookCap,
   registerGoalHook,
   unregisterGoalHook,
 } from './goalHook.js';

--- a/packages/core/src/hooks/stopHookCap.test.ts
+++ b/packages/core/src/hooks/stopHookCap.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  DEFAULT_STOP_HOOK_BLOCK_CAP,
+  STOP_HOOK_BLOCK_CAP_ENV,
+  formatStopHookBlockingCapWarning,
+  normalizeStopHookBlockingCap,
+  resolveStopHookBlockingCap,
+} from './stopHookCap.js';
+
+describe('stop hook blocking cap', () => {
+  afterEach(() => {
+    delete process.env[STOP_HOOK_BLOCK_CAP_ENV];
+  });
+
+  it('normalizes invalid values to the default cap', () => {
+    expect(normalizeStopHookBlockingCap(undefined)).toBe(
+      DEFAULT_STOP_HOOK_BLOCK_CAP,
+    );
+    expect(normalizeStopHookBlockingCap(0)).toBe(DEFAULT_STOP_HOOK_BLOCK_CAP);
+    expect(normalizeStopHookBlockingCap(Number.NaN)).toBe(
+      DEFAULT_STOP_HOOK_BLOCK_CAP,
+    );
+  });
+
+  it('prefers the environment override over config', () => {
+    process.env[STOP_HOOK_BLOCK_CAP_ENV] = '3';
+
+    expect(resolveStopHookBlockingCap(12)).toBe(3);
+  });
+
+  it('formats warnings for the relevant hook event', () => {
+    expect(formatStopHookBlockingCapWarning('Stop', 8)).toBe(
+      'Stop hook blocked continuation 8 consecutive times; overriding and ending the turn.',
+    );
+    expect(formatStopHookBlockingCapWarning('SubagentStop', 2)).toContain(
+      'SubagentStop hook blocked continuation 2 consecutive times',
+    );
+  });
+});

--- a/packages/core/src/hooks/stopHookCap.ts
+++ b/packages/core/src/hooks/stopHookCap.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const DEFAULT_STOP_HOOK_BLOCK_CAP = 8;
+export const STOP_HOOK_BLOCK_CAP_ENV = 'QWEN_CODE_STOP_HOOK_BLOCK_CAP';
+
+export function normalizeStopHookBlockingCap(value: unknown): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_STOP_HOOK_BLOCK_CAP;
+  }
+
+  const normalized = Math.floor(value);
+  return normalized >= 1 ? normalized : DEFAULT_STOP_HOOK_BLOCK_CAP;
+}
+
+export function resolveStopHookBlockingCap(configValue?: number): number {
+  const envValue = process.env[STOP_HOOK_BLOCK_CAP_ENV];
+  if (envValue !== undefined) {
+    const parsed = Number(envValue);
+    return normalizeStopHookBlockingCap(parsed);
+  }
+
+  return normalizeStopHookBlockingCap(configValue);
+}
+
+export function formatStopHookBlockingCapWarning(
+  hookLabel: 'Stop' | 'SubagentStop',
+  cap: number,
+): string {
+  const hookName = hookLabel === 'Stop' ? 'Stop hook' : 'SubagentStop hook';
+  return `${hookName} blocked continuation ${cap} consecutive times; overriding and ending the turn.`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -357,6 +357,13 @@ export * from './test-utils/index.js';
 export * from './hooks/types.js';
 export { HookSystem, HookRegistry } from './hooks/index.js';
 export type { HookRegistryEntry, SessionHookEntry } from './hooks/index.js';
+export {
+  DEFAULT_STOP_HOOK_BLOCK_CAP,
+  STOP_HOOK_BLOCK_CAP_ENV,
+  normalizeStopHookBlockingCap,
+  resolveStopHookBlockingCap,
+  formatStopHookBlockingCapWarning,
+} from './hooks/stopHookCap.js';
 export { type StopFailureErrorType } from './hooks/types.js';
 
 // ============================================================================

--- a/packages/core/src/tools/agent/agent.test.ts
+++ b/packages/core/src/tools/agent/agent.test.ts
@@ -138,6 +138,7 @@ describe('AgentTool', () => {
       getSubagentManager: vi.fn(),
       getGeminiClient: vi.fn().mockReturnValue(undefined),
       getHookSystem: vi.fn().mockReturnValue(undefined),
+      getStopHookBlockingCap: vi.fn().mockReturnValue(8),
       getTranscriptPath: vi.fn().mockReturnValue('/test/transcript'),
       getApprovalMode: vi.fn().mockReturnValue('default'),
       isTrustedFolder: vi.fn().mockReturnValue(true),
@@ -1293,6 +1294,37 @@ describe('AgentTool', () => {
       await invocation.execute();
 
       expect(mockAgent.execute).toHaveBeenCalledTimes(2);
+    });
+
+    it('uses the configured SubagentStop blocking cap', async () => {
+      (
+        config as unknown as {
+          getStopHookBlockingCap: ReturnType<typeof vi.fn>;
+        }
+      ).getStopHookBlockingCap.mockReturnValue(2);
+      const mockBlockOutput = {
+        isBlockingDecision: vi.fn().mockReturnValue(true),
+        shouldStopExecution: vi.fn().mockReturnValue(false),
+        getEffectiveReason: vi.fn().mockReturnValue('Keep working'),
+      };
+
+      vi.mocked(mockHookSystem.fireSubagentStopEvent).mockResolvedValue(
+        mockBlockOutput as never,
+      );
+
+      const params: AgentParams = {
+        description: 'Search files',
+        prompt: 'Find all TypeScript files',
+        subagent_type: 'file-search',
+      };
+
+      const invocation = (
+        agentTool as AgentToolWithProtectedMethods
+      ).createInvocation(params);
+      await invocation.execute();
+
+      expect(mockHookSystem.fireSubagentStopEvent).toHaveBeenCalledTimes(2);
+      expect(mockAgent.execute).toHaveBeenCalledTimes(3);
     });
 
     it('should allow stop when SubagentStop hook fails', async () => {

--- a/packages/core/src/tools/agent/agent.ts
+++ b/packages/core/src/tools/agent/agent.ts
@@ -69,6 +69,7 @@ import { BuiltinAgentRegistry } from '../../subagents/builtin-agents.js';
 import { createDebugLogger } from '../../utils/debugLogger.js';
 import { PermissionMode } from '../../hooks/types.js';
 import type { StopHookOutput } from '../../hooks/types.js';
+import { formatStopHookBlockingCapWarning } from '../../hooks/stopHookCap.js';
 import { ApprovalMode } from '../../config/config.js';
 import {
   getAgentJsonlPath,
@@ -973,7 +974,7 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
     const effectiveTranscriptPath =
       transcriptPath ?? this.config.getTranscriptPath();
     let stopHookActive = false;
-    const maxIterations = 5;
+    const maxIterations = this.config.getStopHookBlockingCap();
 
     for (let i = 0; i < maxIterations; i++) {
       try {
@@ -1014,7 +1015,10 @@ class AgentToolInvocation extends BaseToolInvocation<AgentParams, ToolResult> {
     }
 
     debugLogger.warn(
-      `[Agent] SubagentStop hook reached maximum iterations (${maxIterations}), forcing stop`,
+      `[Agent] ${formatStopHookBlockingCapWarning(
+        'SubagentStop',
+        maxIterations,
+      )}`,
     );
   }
 

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -896,6 +896,11 @@
       "type": "boolean",
       "default": false
     },
+    "stopHookBlockingCap": {
+      "description": "Maximum consecutive blocking Stop/SubagentStop hook decisions before Qwen Code overrides the hook loop and ends the turn. Can be overridden by QWEN_CODE_STOP_HOOK_BLOCK_CAP.",
+      "type": "number",
+      "default": 8
+    },
     "hooks": {
       "description": "Hook event configurations for extending CLI behavior at various lifecycle points.",
       "type": "object",


### PR DESCRIPTION
## Summary

- What changed: Added a configurable consecutive Stop/SubagentStop hook blocking cap, wired it through core config, CLI settings, ACP, and subagent stop loops.
- Why it changed: A blocking Stop hook can otherwise keep a turn continuing for too long before broader turn budgets stop it. The cap gives users a faster recovery path while keeping the existing goal iteration guard as a secondary safety net.
- Reviewer focus: Main Stop hook continuation, ACP parity, SubagentStop parity, and the new settings/env override behavior.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/hooks/stopHookCap.test.ts src/core/client.test.ts src/tools/agent/agent.test.ts
  npm run build
  npm run typecheck
  git diff --check
  ```
- Prompts / inputs used: N/A, focused unit coverage for the loop guard and config parsing.
- Expected result: Stop/SubagentStop hook loops stop once the configured blocking cap is reached, and normal hook pass-through remains unchanged.
- Observed result: 205 focused tests passed; build, typecheck, and diff whitespace check passed.
- Quickest reviewer verification path:
  ```bash
  cd packages/core && npx vitest run src/hooks/stopHookCap.test.ts src/core/client.test.ts src/tools/agent/agent.test.ts
  ```
- Evidence: Local command output showed 3 test files passed, 205 tests passed.

## Scope / Risk

- Main risk or tradeoff: Users with intentionally long-running blocking Stop hooks may need to raise `stopHookBlockingCap` or `QWEN_CODE_STOP_HOOK_BLOCK_CAP`.
- Not covered / not validated: Full interactive terminal E2E was not run.
- Breaking changes / migration notes: Default cap is 8 consecutive blocking Stop/SubagentStop decisions.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- macOS local validation covered focused vitest, build, typecheck, and diff whitespace checks.
- Windows and Linux were not tested locally.

## Linked Issues / Bugs

Closes #4206
