### PR TITLE
fix(core): apply tool name migrations at dispatch

### DIFF
--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -32,7 +32,7 @@ import * as path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import { SkillTool } from '../tools/skill.js';
 import { StructuredToolError } from '../tools/priorReadEnforcement.js';
-import { ToolNames } from '../tools/tool-names.js';
+import { ToolNames, ToolNamesMigration } from '../tools/tool-names.js';
 import type { ToolCall, WaitingToolCall } from './coreToolScheduler.js';
 import {
   CoreToolScheduler,
@@ -416,6 +416,273 @@ async function waitForStatus(
 }
 
 describe('CoreToolScheduler', () => {
+  function createSchedulerForLegacyToolTests(options: {
+    toolsByName: Map<string, MockTool>;
+    approvalMode?: ApprovalMode;
+    getPermissionsDeny?: () => string[] | undefined;
+    messageBus?: { request: ReturnType<typeof vi.fn> };
+    disableHooks?: boolean;
+    onAllToolCallsComplete?: ReturnType<typeof vi.fn>;
+    onToolCallsUpdate?: ReturnType<typeof vi.fn>;
+  }) {
+    const ensureTool = vi.fn(
+      async (name: string) =>
+        options.toolsByName.get(name) as AnyDeclarativeTool,
+    );
+    const mockToolRegistry = {
+      getTool: (name: string) => options.toolsByName.get(name),
+      ensureTool,
+      getFunctionDeclarations: () => [],
+      tools: options.toolsByName,
+      discovery: {},
+      registerTool: () => {},
+      getToolByName: (name: string) => options.toolsByName.get(name),
+      getToolByDisplayName: () => undefined,
+      getTools: () => [...options.toolsByName.values()],
+      discoverTools: async () => {},
+      getAllTools: () => [...options.toolsByName.values()],
+      getToolsByServer: () => [],
+      getAllToolNames: () => [...options.toolsByName.keys()],
+    } as unknown as ToolRegistry;
+
+    const onAllToolCallsComplete = options.onAllToolCallsComplete ?? vi.fn();
+    const onToolCallsUpdate = options.onToolCallsUpdate ?? vi.fn();
+    const scheduler = new CoreToolScheduler({
+      config: {
+        getSessionId: () => 'test-session-id',
+        getUsageStatisticsEnabled: () => true,
+        getDebugMode: () => false,
+        getApprovalMode: () => options.approvalMode ?? ApprovalMode.YOLO,
+        getPermissionsAllow: () => [],
+        getPermissionsDeny: options.getPermissionsDeny ?? (() => undefined),
+        getContentGeneratorConfig: () => ({
+          model: 'test-model',
+          authType: 'gemini',
+        }),
+        getShellExecutionConfig: () => ({
+          terminalWidth: 90,
+          terminalHeight: 30,
+        }),
+        storage: {
+          getProjectTempDir: () => '/tmp',
+        },
+        getTruncateToolOutputThreshold: () =>
+          DEFAULT_TRUNCATE_TOOL_OUTPUT_THRESHOLD,
+        getTruncateToolOutputLines: () => DEFAULT_TRUNCATE_TOOL_OUTPUT_LINES,
+        getToolRegistry: () => mockToolRegistry,
+        getUseModelRouter: () => false,
+        getGeminiClient: () => null,
+        getChatRecordingService: () => undefined,
+        getMessageBus: vi.fn().mockReturnValue(options.messageBus),
+        getDisableAllHooks: vi
+          .fn()
+          .mockReturnValue(options.disableHooks ?? true),
+        isInteractive: () => true,
+        getInputFormat: () => undefined,
+        getExperimentalZedIntegration: () => false,
+      } as unknown as Config,
+      onAllToolCallsComplete,
+      onToolCallsUpdate,
+      getPreferredEditor: () => 'vscode',
+      onEditorClose: vi.fn(),
+    });
+
+    return {
+      scheduler,
+      ensureTool,
+      onAllToolCallsComplete,
+      onToolCallsUpdate,
+    };
+  }
+
+  it('dispatches legacy tool names through their canonical registered tools', async () => {
+    const canonicalNamesByLegacyName = new Map(
+      Object.entries(ToolNamesMigration),
+    );
+    const executeByCanonicalName = new Map<string, ReturnType<typeof vi.fn>>();
+    const toolsByName = new Map<string, MockTool>();
+
+    for (const canonicalName of canonicalNamesByLegacyName.values()) {
+      const execute = vi.fn().mockResolvedValue({
+        llmContent: `executed ${canonicalName}`,
+        returnDisplay: `executed ${canonicalName}`,
+      });
+      executeByCanonicalName.set(canonicalName, execute);
+      toolsByName.set(
+        canonicalName,
+        new MockTool({
+          name: canonicalName,
+          execute,
+        }),
+      );
+    }
+
+    const { scheduler, ensureTool, onAllToolCallsComplete } =
+      createSchedulerForLegacyToolTests({ toolsByName });
+
+    await scheduler.schedule(
+      [...canonicalNamesByLegacyName.keys()].map((legacyName, index) => ({
+        callId: `legacy-${index}`,
+        name: legacyName,
+        args: { value: legacyName },
+        isClientInitiated: false,
+        prompt_id: `prompt-${index}`,
+      })),
+      new AbortController().signal,
+    );
+
+    for (const canonicalName of canonicalNamesByLegacyName.values()) {
+      expect(executeByCanonicalName.get(canonicalName)).toHaveBeenCalledOnce();
+      expect(ensureTool).toHaveBeenCalledWith(canonicalName);
+    }
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as ToolCall[];
+    expect(completedCalls.every((call) => call.status === 'success')).toBe(
+      true,
+    );
+  });
+
+  it('applies canonical legacy tool names to the deny-list fallback', async () => {
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'edited',
+      returnDisplay: 'edited',
+    });
+    const toolsByName = new Map<string, MockTool>([
+      [
+        ToolNames.EDIT,
+        new MockTool({
+          name: ToolNames.EDIT,
+          execute,
+        }),
+      ],
+    ]);
+    const { scheduler, ensureTool, onAllToolCallsComplete } =
+      createSchedulerForLegacyToolTests({
+        toolsByName,
+        getPermissionsDeny: () => [ToolNames.EDIT],
+      });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'legacy-denied',
+          name: 'replace',
+          args: { file_path: '/tmp/file.txt' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-denied',
+        },
+      ],
+      new AbortController().signal,
+    );
+
+    expect(onAllToolCallsComplete).toHaveBeenCalled();
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as ToolCall[];
+    const completedCall = completedCalls[0];
+    expect(completedCall.status).toBe('error');
+    if (completedCall.status === 'error') {
+      expect(completedCall.response.errorType).toBe(
+        ToolErrorType.EXECUTION_DENIED,
+      );
+      expect(completedCall.response.error?.message).toBe(
+        'Qwen Code requires permission to use edit, but that permission was declined.',
+      );
+    }
+    expect(execute).not.toHaveBeenCalled();
+    expect(ensureTool).not.toHaveBeenCalled();
+  });
+
+  it.each(Object.entries(ToolNamesMigration))(
+    'sends canonical hook tool names for legacy %s calls',
+    async (legacyName, canonicalName) => {
+      const execute = vi.fn().mockResolvedValue({
+        llmContent: 'ok',
+        returnDisplay: 'ok',
+      });
+      const toolsByName = new Map<string, MockTool>([
+        [
+          canonicalName,
+          new MockTool({
+            name: canonicalName,
+            getDefaultPermission: MOCK_TOOL_GET_DEFAULT_PERMISSION,
+            getConfirmationDetails: MOCK_TOOL_GET_CONFIRMATION_DETAILS,
+            execute,
+          }),
+        ],
+      ]);
+      const messageBus = {
+        request: vi
+          .fn()
+          .mockImplementation(
+            async (request: {
+              eventName: string;
+            }): Promise<HookExecutionResponse> => {
+              if (request.eventName === 'PermissionRequest') {
+                return {
+                  type: MessageBusType.HOOK_EXECUTION_RESPONSE,
+                  correlationId: 'permission-hook',
+                  success: true,
+                  output: {
+                    hookSpecificOutput: {
+                      decision: {
+                        behavior: 'allow',
+                      },
+                    },
+                  },
+                };
+              }
+              return {
+                type: MessageBusType.HOOK_EXECUTION_RESPONSE,
+                correlationId: `${request.eventName}-hook`,
+                success: true,
+                output: { decision: 'allow' },
+              };
+            },
+          ),
+      };
+      const { scheduler, onAllToolCallsComplete } =
+        createSchedulerForLegacyToolTests({
+          toolsByName,
+          approvalMode: ApprovalMode.DEFAULT,
+          messageBus,
+          disableHooks: false,
+        });
+
+      await scheduler.schedule(
+        [
+          {
+            callId: `legacy-hook-${legacyName}`,
+            name: legacyName,
+            args: { value: legacyName },
+            isClientInitiated: false,
+            prompt_id: 'prompt-hooks',
+          },
+        ],
+        new AbortController().signal,
+      );
+
+      await vi.waitFor(() => {
+        expect(onAllToolCallsComplete).toHaveBeenCalled();
+      });
+      for (const eventName of [
+        'PermissionRequest',
+        'PreToolUse',
+        'PostToolUse',
+      ]) {
+        expect(messageBus.request).toHaveBeenCalledWith(
+          expect.objectContaining({
+            eventName,
+            input: expect.objectContaining({
+              tool_name: canonicalName,
+            }),
+          }),
+          MessageBusType.HOOK_EXECUTION_RESPONSE,
+        );
+      }
+      expect(execute).toHaveBeenCalledOnce();
+    },
+  );
+
   it('should cancel a tool call if the signal is aborted before confirmation', async () => {
     const mockTool = new MockTool({
       name: 'mockTool',
@@ -4160,6 +4427,89 @@ describe('Fire hook functions integration', () => {
       for (const start of allStarts) {
         expect(start).toBeLessThan(firstEnd);
       }
+    });
+
+    it('should run legacy task agent tools concurrently with safe tools', async () => {
+      const executionLog: string[] = [];
+
+      const agentTool = new MockTool({
+        name: ToolNames.AGENT,
+        kind: Kind.Other,
+        execute: async (params) => {
+          const id = (params as { id: string }).id;
+          executionLog.push(`agent:start:${id}`);
+          await new Promise((r) => setTimeout(r, 50));
+          executionLog.push(`agent:end:${id}`);
+          return {
+            llmContent: `Agent ${id} done`,
+            returnDisplay: `Agent ${id} done`,
+          };
+        },
+      });
+
+      const readTool = new MockTool({
+        name: ToolNames.READ_FILE,
+        kind: Kind.Read,
+        execute: async (params) => {
+          const id = (params as { id: string }).id;
+          executionLog.push(`read:start:${id}`);
+          await new Promise((r) => setTimeout(r, 50));
+          executionLog.push(`read:end:${id}`);
+          return {
+            llmContent: `Read ${id} done`,
+            returnDisplay: `Read ${id} done`,
+          };
+        },
+      });
+
+      const tools = new Map<string, MockTool>([
+        [ToolNames.AGENT, agentTool],
+        [ToolNames.READ_FILE, readTool],
+      ]);
+      const onAllToolCallsComplete = vi.fn();
+      const onToolCallsUpdate = vi.fn();
+      const scheduler = createScheduler(
+        tools,
+        onAllToolCallsComplete,
+        onToolCallsUpdate,
+      );
+
+      await scheduler.schedule(
+        [
+          {
+            callId: 'legacy-task',
+            name: 'task',
+            args: { id: 'legacy' },
+            isClientInitiated: false,
+            prompt_id: 'p1',
+          },
+          {
+            callId: 'read',
+            name: ToolNames.READ_FILE,
+            args: { id: 'read' },
+            isClientInitiated: false,
+            prompt_id: 'p1',
+          },
+        ],
+        new AbortController().signal,
+      );
+
+      expect(onAllToolCallsComplete).toHaveBeenCalled();
+      const completedCalls = onAllToolCallsComplete.mock
+        .calls[0][0] as ToolCall[];
+      expect(completedCalls.every((c) => c.status === 'success')).toBe(true);
+
+      const agentStart = executionLog.indexOf('agent:start:legacy');
+      const readStart = executionLog.indexOf('read:start:read');
+      const firstEnd = Math.min(
+        executionLog.indexOf('agent:end:legacy'),
+        executionLog.indexOf('read:end:read'),
+      );
+      expect(agentStart).not.toBe(-1);
+      expect(readStart).not.toBe(-1);
+      expect(firstEnd).not.toBe(-1);
+      expect(agentStart).toBeLessThan(firstEnd);
+      expect(readStart).toBeLessThan(firstEnd);
     });
 
     it('should partition mixed safe/unsafe tools into correct batches', async () => {

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -677,7 +677,7 @@ interface ToolBatch {
  */
 function isConcurrencySafe(call: ScheduledToolCall): boolean {
   // Agent tools spawn independent sub-agents with no shared state.
-  if (call.request.name === ToolNames.AGENT) return true;
+  if (canonicalToolName(call.request.name) === ToolNames.AGENT) return true;
   // Shell commands: check if the command is read-only (e.g., git log, cat).
   // Uses the synchronous regex+shell-quote checker (not the async AST-based
   // one) because partitioning runs synchronously. The sync checker covers
@@ -1137,12 +1137,14 @@ export class CoreToolScheduler {
 
       const newToolCalls: ToolCall[] = [];
       for (const reqInfo of requestsToProcess) {
+        const canonicalName = canonicalToolName(reqInfo.name);
+
         // Check if the tool is excluded due to permissions/environment restrictions
         // This check should happen before registry lookup to provide a clear permission error
         const pm = this.config.getPermissionManager?.();
-        if (pm && !(await pm.isToolEnabled(reqInfo.name))) {
+        if (pm && !(await pm.isToolEnabled(canonicalName))) {
           const matchingRule = pm.findMatchingDenyRule({
-            toolName: reqInfo.name,
+            toolName: canonicalName,
           });
           const ruleInfo = matchingRule
             ? ` Matching deny rule: "${matchingRule}".`
@@ -1165,7 +1167,7 @@ export class CoreToolScheduler {
         if (!pm) {
           const excludeTools = this.config.getPermissionsDeny?.() ?? undefined;
           if (excludeTools && excludeTools.length > 0) {
-            const normalizedToolName = reqInfo.name.toLowerCase().trim();
+            const normalizedToolName = canonicalName.toLowerCase().trim();
             const excludedMatch = excludeTools.find(
               (excludedTool) =>
                 excludedTool.toLowerCase().trim() === normalizedToolName,
@@ -1187,7 +1189,7 @@ export class CoreToolScheduler {
           }
         }
 
-        const toolInstance = await this.toolRegistry.ensureTool(reqInfo.name);
+        const toolInstance = await this.toolRegistry.ensureTool(canonicalName);
         if (!toolInstance) {
           // Tool is not in registry and not excluded - likely hallucinated or typo
           const errorMessage = await this.getToolNotFoundMessage(reqInfo.name);
@@ -1286,6 +1288,7 @@ export class CoreToolScheduler {
         }
 
         const { request: reqInfo, invocation } = toolCall;
+        const canonicalName = canonicalToolName(reqInfo.name);
 
         try {
           if (signal.aborted) {
@@ -1306,7 +1309,7 @@ export class CoreToolScheduler {
           const flowResult = await evaluatePermissionFlow(
             this.config,
             invocation,
-            reqInfo.name,
+            canonicalName,
             toolParams,
           );
           const { finalPermission, pmForcedAsk, pmCtx, denyMessage } =
@@ -1315,7 +1318,7 @@ export class CoreToolScheduler {
           // ---- L5: Final decision based on permission + ApprovalMode ----
           const approvalMode = this.config.getApprovalMode();
           const isPlanMode = approvalMode === ApprovalMode.PLAN;
-          const isExitPlanModeTool = reqInfo.name === 'exit_plan_mode';
+          const isExitPlanModeTool = canonicalName === ToolNames.EXIT_PLAN_MODE;
 
           if (finalPermission === 'allow') {
             // Auto-approve: tool is inherently safe (read-only) or PM allows
@@ -1346,10 +1349,12 @@ export class CoreToolScheduler {
           // ask_user_question always needs confirmation so the user can answer;
           // it must bypass both YOLO auto-approve and plan-mode blocking.
           const isAskUserQuestionTool =
-            reqInfo.name === ToolNames.ASK_USER_QUESTION;
+            canonicalName === ToolNames.ASK_USER_QUESTION;
           let confirmationDetails: ToolCallConfirmationDetails | undefined;
 
-          if (!needsConfirmation(finalPermission, approvalMode, reqInfo.name)) {
+          if (
+            !needsConfirmation(finalPermission, approvalMode, canonicalName)
+          ) {
             this.setToolCallOutcome(
               reqInfo.callId,
               ToolConfirmationOutcome.ProceedAlways,
@@ -1428,7 +1433,7 @@ export class CoreToolScheduler {
               const permissionMode = String(this.config.getApprovalMode());
               const hookResult = await firePermissionRequestHook(
                 messageBus,
-                reqInfo.name,
+                canonicalName,
                 (reqInfo.args as Record<string, unknown>) || {},
                 permissionMode,
               );
@@ -1884,6 +1889,7 @@ export class CoreToolScheduler {
     span: Span,
   ): Promise<void> {
     const { callId, name: toolName } = scheduledCall.request;
+    const canonicalName = canonicalToolName(toolName);
     const invocation = scheduledCall.invocation;
     const toolInput = scheduledCall.request.args as Record<string, unknown>;
 
@@ -1908,7 +1914,7 @@ export class CoreToolScheduler {
       const permissionMode = this.config.getApprovalMode();
       const preHookResult = await firePreToolUseHook(
         messageBus,
-        toolName,
+        canonicalName,
         toolInput,
         toolUseId,
         permissionMode,
@@ -2015,7 +2021,7 @@ export class CoreToolScheduler {
           const failureHookResult = await safelyFirePostToolUseFailureHook(
             messageBus,
             toolUseId,
-            toolName,
+            canonicalName,
             toolInput,
             'User cancelled tool execution.',
             true,
@@ -2053,7 +2059,7 @@ export class CoreToolScheduler {
           const permissionMode = this.config.getApprovalMode();
           const postHookResult = await firePostToolUseHook(
             messageBus,
-            toolName,
+            canonicalName,
             toolInput,
             toolResponse,
             toolUseId,
@@ -2200,7 +2206,7 @@ export class CoreToolScheduler {
           const failureHookResult = await safelyFirePostToolUseFailureHook(
             messageBus,
             toolUseId,
-            toolName,
+            canonicalName,
             toolInput,
             toolResult.error.message,
             false,
@@ -2248,7 +2254,7 @@ export class CoreToolScheduler {
           const failureHookResult = await safelyFirePostToolUseFailureHook(
             messageBus,
             toolUseId,
-            toolName,
+            canonicalName,
             toolInput,
             'User cancelled tool execution.',
             true,
@@ -2277,7 +2283,7 @@ export class CoreToolScheduler {
           const failureHookResult = await safelyFirePostToolUseFailureHook(
             messageBus,
             toolUseId,
-            toolName,
+            canonicalName,
             toolInput,
             errorMessage,
             false,


### PR DESCRIPTION
## Summary

- What changed: legacy tool-call names are canonicalized before the core scheduler looks up the registered tool, so calls like `task`, `replace`, and `search_file_content` dispatch to `agent`, `edit`, and `grep_search`.
- Why it changed: the migration map already declares these aliases, but the execution path still looked up the raw model-emitted name and returned "not found in registry".
- Reviewer focus: the original request name is preserved on the tool call/response while only the registry lookup uses the canonical name.

## Validation

- Commands run:
  ```bash
  cd packages/core
  npx vitest run src/core/coreToolScheduler.test.ts -t "legacy tool names"
  npx vitest run src/core/coreToolScheduler.test.ts
  cd ../..
  npm run lint --workspace=packages/core
  npm run typecheck --workspace=packages/core
  npx prettier --check packages/core/src/core/coreToolScheduler.ts packages/core/src/core/coreToolScheduler.test.ts
  git diff --check
  ```
- Prompts / inputs used: scheduled tool calls named `task`, `replace`, and `search_file_content` against a registry that only contains the canonical tool names.
- Expected result: each legacy name resolves to its canonical registered tool and completes successfully.
- Observed result: the new regression test fails before the scheduler change because no canonical tool executes, then passes after canonicalizing the registry lookup.
- Quickest reviewer verification path:
  ```bash
  cd packages/core
  npx vitest run src/core/coreToolScheduler.test.ts -t "legacy tool names"
  ```
- Evidence: full `coreToolScheduler.test.ts` passes locally with 129 tests.

## Scope / Risk

- Main risk or tradeoff: minimal scheduler-only change; request names are not rewritten, so provider tool-response pairing remains based on the model-emitted name.
- Not covered / not validated: no full repository test run; this is covered by the focused scheduler test file plus core lint/typecheck.
- Breaking changes / migration notes: none.

## Testing Matrix

|          | Local |
| -------- | ----- |
| npm run  | tested |
| npx      | tested |
| Docker   | N/A |
| Podman   | N/A |
| Seatbelt | N/A |

Testing matrix notes:

- `npm run` was used for core lint and typecheck.
- `npx` was used for the targeted and full scheduler test file plus Prettier check.

## Linked Issues / Bugs

Fixes #4135
