### PR TITLE
fix(serve): align integration test + user doc with merged sessionScope override (#4175 follow-up)

### DIFF
--- a/docs/users/qwen-serve.md
+++ b/docs/users/qwen-serve.md
@@ -190,22 +190,21 @@ Stage 1's contract is sized for prototyping. Per [#3889 chiga0 downstream-consum
 
 **Blockers for serious downstream use:**
 
-1. **Per-request `sessionScope` override** on `POST /session` — today the daemon-wide default is the only setting; a VSCode extension can't say "I want a private session for this window" against a daemon configured for shared sessions.
-2. **`loadSession` / `unstable_resumeSession` over HTTP** — without this, no integration can survive a child crash or daemon restart, and any orchestrator coordinating the daemon can't recover state either.
-3. **Persistent client identity (pair tokens + per-client revocation)** — Stage 1 uses one shared bearer; a leaked token revokes everyone, and `originatorClientId` is client-self-declared rather than daemon-stamped from authenticated identity.
+1. **`loadSession` / `unstable_resumeSession` over HTTP** — without this, no integration can survive a child crash or daemon restart, and any orchestrator coordinating the daemon can't recover state either.
+2. **Persistent client identity (pair tokens + per-client revocation)** — Stage 1 uses one shared bearer; a leaked token revokes everyone, and `originatorClientId` is client-self-declared rather than daemon-stamped from authenticated identity.
 
 **Reliability baseline:**
 
-4. **Client-initiated heartbeat path** — distinguish "agent thinking" from "daemon dead" without waiting for the 15s server heartbeat.
-5. **`permission_already_resolved` event** when a vote loses the first-responder race — currently UIs have to infer state from a `404`.
-6. **Larger / per-session-configurable replay ring** — default 4000 covers short drops; mobile / chatty-turn workloads need 8000+ or per-session config.
-7. **`slow_client_warning` event before `client_evicted`** — soft backpressure so well-behaved slow clients can self-throttle (trim render depth, drop chunks) before being terminated.
+3. **Client-initiated heartbeat path** — distinguish "agent thinking" from "daemon dead" without waiting for the 15s server heartbeat.
+4. **`permission_already_resolved` event** when a vote loses the first-responder race — currently UIs have to infer state from a `404`.
+5. **Larger / per-session-configurable replay ring** — default 4000 covers short drops; mobile / chatty-turn workloads need 8000+ or per-session config.
+6. **`slow_client_warning` event before `client_evicted`** — soft backpressure so well-behaved slow clients can self-throttle (trim render depth, drop chunks) before being terminated.
 
 **Integration ergonomics:**
 
-8. **`POST /session/:id/_meta` for IM-style context** — per-session key-value attached to subsequent prompts (chat id, sender, thread id) replaces the per-channel improvisation.
-9. **`/capabilities` actual feature negotiation** — `protocol_versions: { acp: '0.14.x', daemon_envelope: 1 }` so clients can detect drift instead of falling through to "unknown frame, ignore".
-10. **First-class durability documentation** (this section) — already shipped above.
+7. **`POST /session/:id/_meta` for IM-style context** — per-session key-value attached to subsequent prompts (chat id, sender, thread id) replaces the per-channel improvisation.
+8. **`/capabilities` actual feature negotiation** — `protocol_versions: { acp: '0.14.x', daemon_envelope: 1 }` so clients can detect drift instead of falling through to "unknown frame, ignore".
+9. **First-class durability documentation** (this section) — already shipped above.
 
 The full convergence roadmap is tracked on [#3803](https://github.com/QwenLM/qwen-code/issues/3803).
 

--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -180,14 +180,18 @@ describe('qwen serve — CORS browser-origin denial', () => {
 });
 
 describe('qwen serve — capabilities envelope', () => {
-  it('advertises all 9 Stage 1 features', async () => {
+  it('advertises all 10 Stage 1 features', async () => {
     const caps = await client.capabilities();
     expect(caps.v).toBe(1);
     expect(caps.mode).toBe('http-bridge');
+    // Order must match `SERVE_CAPABILITY_REGISTRY` in
+    // `packages/cli/src/serve/capabilities.ts` and the unit-level
+    // `EXPECTED_STAGE1_FEATURES` in `packages/cli/src/serve/server.test.ts`.
     expect(caps.features).toEqual([
       'health',
       'capabilities',
       'session_create',
+      'session_scope_override',
       'session_list',
       'session_prompt',
       'session_cancel',


### PR DESCRIPTION
## Summary

Follow-up to PR #4209 (Wave 2 PR 5, merged at `878f35fc4`). Addresses two findings from wenshao's `CHANGES_REQUESTED` review that landed unaddressed:

1. **Integration test feature list was stale.** `integration-tests/cli/qwen-serve-routes.test.ts:183` still asserted the pre-PR 9-element `caps.features` array and was named "all 9 Stage 1 features". The merged daemon advertises **10** features (`session_scope_override` between `session_create` and `session_list`), so the suite would fail when run against a real daemon. PR CI didn't catch it because integration tests require a real `qwen serve` spawn and run only in the release pipeline; only the unit-level `EXPECTED_STAGE1_FEATURES` constant in `server.test.ts` was updated.

2. **User doc contradicted shipped behavior.** `docs/users/qwen-serve.md:193` listed per-request `sessionScope` override as item 1 of "Blockers for serious downstream use" with the line "today the daemon-wide default is the only setting." That's now exactly what the daemon doesn't say — downstream integrators reading the user guide were getting inverse guidance.

## Changes

- `integration-tests/cli/qwen-serve-routes.test.ts` — rename to "all 10 Stage 1 features"; insert `session_scope_override` into the asserted array; add a comment noting the unit / integration / registry triple must stay in lockstep.
- `docs/users/qwen-serve.md` — remove the obsolete blocker bullet; renumber remaining items in the **Blockers** (2/3 → 1/2), **Reliability baseline** (4–7 → 3–6), and **Integration ergonomics** (8–10 → 7–9) sub-lists for internal consistency.

No production code changes.

## Engineering principles checklist (#4175 PR template)

- [x] **Independently mergeable** — pure doc + test correction; no production code touched.
- [x] **Backward compatible** — no API / wire / behavior change.
- [x] **Default off** — N/A (no toggleable behavior).
- [x] **Stage 1 routes preserved** — no route changes.
- [x] **Gradual migration** — N/A.
- [x] **Reversible** — revert restores prior wording / count (incorrect, but mechanically reversible).
- [x] **Tests-first** — the failing integration test IS the regression; this PR fixes it.

## Test plan

- [x] `npx vitest run packages/cli/src/serve/server.test.ts -t "marks every current feature with its historical v1 origin"` — unit-level capability registry order assertion still green.
- [ ] Reviewer with a built daemon: `npm run build && TEST_CLI_PATH=$(pwd)/packages/cli/dist/index.js npx vitest run integration-tests/cli/qwen-serve-routes.test.ts -t "advertises all 10 Stage 1 features"` — expected pass; this is the test that was failing before this PR.
- [x] Visual diff of `docs/users/qwen-serve.md` "Stage 1.5+ runtime guarantees" section — renumbering is consistent across all three sub-lists.

## Related

- Issue #4175 (Wave 2 PR 5 follow-up)
- PR #4209 (the merged feature; this PR cleans up its review fallout)
- `packages/cli/src/serve/capabilities.ts` — `SERVE_CAPABILITY_REGISTRY` order this PR's array must mirror.
- `packages/cli/src/serve/server.test.ts:58-69` — `EXPECTED_STAGE1_FEATURES` constant this PR's array must mirror.

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)