### PR TITLE
fix(cli): record mid-turn queued user prompts

### DIFF
--- a/packages/cli/src/acp-integration/session/HistoryReplayer.test.ts
+++ b/packages/cli/src/acp-integration/session/HistoryReplayer.test.ts
@@ -151,6 +151,24 @@ describe('HistoryReplayer', () => {
 
       expect(sendUpdateSpy).not.toHaveBeenCalled();
     });
+
+    it('should replay mid-turn user messages using display text', async () => {
+      const record: ChatRecord = {
+        ...createUserRecord(
+          '\n[User message received during tool execution]: save logs',
+        ),
+        subtype: 'mid_turn_user_message',
+        systemPayload: { displayText: 'save logs' },
+      };
+
+      await replayer.replay([record]);
+
+      expect(sendUpdateSpy).toHaveBeenCalledWith({
+        sessionUpdate: 'user_message_chunk',
+        content: { type: 'text', text: 'save logs' },
+        _meta: { timestamp: toEpochMs(record.timestamp) },
+      });
+    });
   });
 
   describe('assistant message replay', () => {

--- a/packages/cli/src/acp-integration/session/HistoryReplayer.ts
+++ b/packages/cli/src/acp-integration/session/HistoryReplayer.ts
@@ -69,6 +69,20 @@ export class HistoryReplayer {
           }
           break;
         }
+        if (record.subtype === 'mid_turn_user_message') {
+          const displayText = (
+            record.systemPayload as NotificationRecordPayload | undefined
+          )?.displayText;
+          if (displayText) {
+            await this.messageEmitter.emitUserMessage(
+              displayText,
+              record.timestamp,
+            );
+          } else if (record.message) {
+            await this.replayContent(record.message, 'user', record.timestamp);
+          }
+          break;
+        }
         if (record.message) {
           await this.replayContent(record.message, 'user', record.timestamp);
         }

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -514,6 +514,221 @@ describe('useGeminiStream', () => {
     );
   });
 
+  it('records mid-turn queued user messages before submitting tool results', async () => {
+    const queuedPrompt = 'save the logs locally first';
+    const recordMidTurnUserMessage = vi.fn();
+    mockConfig.getChatRecordingService = vi.fn().mockReturnValue({
+      recordMidTurnUserMessage,
+    });
+    const toolCallResponseParts: Part[] = [
+      {
+        functionResponse: {
+          id: 'call1',
+          name: 'testTool',
+          response: { result: 'ok' },
+        },
+      },
+    ];
+    const completedToolCalls: TrackedToolCall[] = [
+      {
+        request: {
+          callId: 'call1',
+          name: 'testTool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-id-midturn',
+        },
+        status: 'success',
+        responseSubmittedToGemini: false,
+        response: {
+          callId: 'call1',
+          responseParts: toolCallResponseParts,
+          errorType: undefined,
+        },
+        tool: {
+          displayName: 'MockTool',
+        },
+        invocation: {
+          getDescription: () => `Mock description`,
+        } as unknown as AnyToolInvocation,
+      } as TrackedCompletedToolCall,
+    ];
+    const midTurnDrainRef = {
+      current: vi.fn().mockReturnValue([queuedPrompt]),
+    };
+
+    let capturedOnComplete:
+      | ((completedTools: TrackedToolCall[]) => Promise<void>)
+      | null = null;
+
+    mockUseReactToolScheduler.mockImplementation((onComplete) => {
+      capturedOnComplete = onComplete;
+      return [[], mockScheduleToolCalls, mockMarkToolsAsSubmitted];
+    });
+
+    renderHook(() =>
+      useGeminiStream(
+        new MockedGeminiClientClass(mockConfig),
+        [],
+        mockAddItem,
+        mockConfig,
+        mockLoadedSettings,
+        mockOnDebugMessage,
+        mockHandleSlashCommand,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+        () => Promise.resolve(),
+        false,
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        80,
+        24,
+        midTurnDrainRef,
+      ),
+    );
+
+    await act(async () => {
+      if (capturedOnComplete) {
+        await capturedOnComplete(completedToolCalls);
+      }
+    });
+
+    await waitFor(() => {
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+    });
+
+    const expectedMidTurnMessage = {
+      text: `\n[User message received during tool execution]: ${queuedPrompt}`,
+    };
+    expect(recordMidTurnUserMessage).toHaveBeenCalledWith(
+      expectedMidTurnMessage,
+      queuedPrompt,
+    );
+    const queuedPromptAddItemIndex = mockAddItem.mock.calls.findIndex(
+      ([item]) => item.type === MessageType.USER && item.text === queuedPrompt,
+    );
+    expect(queuedPromptAddItemIndex).toBeGreaterThanOrEqual(0);
+    expect(recordMidTurnUserMessage.mock.invocationCallOrder[0]).toBeLessThan(
+      mockAddItem.mock.invocationCallOrder[queuedPromptAddItemIndex],
+    );
+    expect(recordMidTurnUserMessage.mock.invocationCallOrder[0]).toBeLessThan(
+      mockSendMessageStream.mock.invocationCallOrder[0],
+    );
+    expect(mockAddItem).toHaveBeenCalledWith(
+      { type: MessageType.USER, text: queuedPrompt },
+      expect.any(Number),
+    );
+    expect(mockSendMessageStream).toHaveBeenCalledWith(
+      [...toolCallResponseParts, expectedMidTurnMessage],
+      expect.any(AbortSignal),
+      'prompt-id-midturn',
+      { type: SendMessageType.ToolResult },
+    );
+  });
+
+  it('handles mid-turn drain when chat recording is not configured', async () => {
+    const queuedPrompt = 'save the logs locally first';
+    mockConfig.getChatRecordingService = vi.fn().mockReturnValue(undefined);
+    const toolCallResponseParts: Part[] = [
+      {
+        functionResponse: {
+          id: 'call1',
+          name: 'testTool',
+          response: { result: 'ok' },
+        },
+      },
+    ];
+    const completedToolCalls: TrackedToolCall[] = [
+      {
+        request: {
+          callId: 'call1',
+          name: 'testTool',
+          args: {},
+          isClientInitiated: false,
+          prompt_id: 'prompt-id-midturn',
+        },
+        status: 'success',
+        responseSubmittedToGemini: false,
+        response: {
+          callId: 'call1',
+          responseParts: toolCallResponseParts,
+          errorType: undefined,
+        },
+        tool: {
+          displayName: 'MockTool',
+        },
+        invocation: {
+          getDescription: () => `Mock description`,
+        } as unknown as AnyToolInvocation,
+      } as TrackedCompletedToolCall,
+    ];
+    const midTurnDrainRef = {
+      current: vi.fn().mockReturnValue([queuedPrompt]),
+    };
+
+    let capturedOnComplete:
+      | ((completedTools: TrackedToolCall[]) => Promise<void>)
+      | null = null;
+
+    mockUseReactToolScheduler.mockImplementation((onComplete) => {
+      capturedOnComplete = onComplete;
+      return [[], mockScheduleToolCalls, mockMarkToolsAsSubmitted];
+    });
+
+    renderHook(() =>
+      useGeminiStream(
+        new MockedGeminiClientClass(mockConfig),
+        [],
+        mockAddItem,
+        mockConfig,
+        mockLoadedSettings,
+        mockOnDebugMessage,
+        mockHandleSlashCommand,
+        false,
+        () => 'vscode' as EditorType,
+        () => {},
+        () => Promise.resolve(),
+        false,
+        () => {},
+        () => {},
+        () => {},
+        () => {},
+        80,
+        24,
+        midTurnDrainRef,
+      ),
+    );
+
+    await act(async () => {
+      if (capturedOnComplete) {
+        await capturedOnComplete(completedToolCalls);
+      }
+    });
+
+    await waitFor(() => {
+      expect(mockSendMessageStream).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockAddItem).toHaveBeenCalledWith(
+      { type: MessageType.USER, text: queuedPrompt },
+      expect.any(Number),
+    );
+    expect(mockSendMessageStream).toHaveBeenCalledWith(
+      [
+        ...toolCallResponseParts,
+        {
+          text: `\n[User message received during tool execution]: ${queuedPrompt}`,
+        },
+      ],
+      expect.any(AbortSignal),
+      'prompt-id-midturn',
+      { type: SendMessageType.ToolResult },
+    );
+  });
+
   it('should handle all tool calls being cancelled', async () => {
     const cancelledToolCalls: TrackedToolCall[] = [
       {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -2237,9 +2237,13 @@ export const useGeminiStream = (
           : (midTurnDrainRef?.current?.() ?? []);
       if (drained.length > 0) {
         for (const msg of drained) {
-          responsesToSend.push({
+          const midTurnUserMessage = {
             text: `\n[User message received during tool execution]: ${msg}`,
-          });
+          };
+          responsesToSend.push(midTurnUserMessage);
+          config
+            .getChatRecordingService()
+            ?.recordMidTurnUserMessage(midTurnUserMessage, msg);
           // Record in UI history so the transcript stays complete.
           addItem({ type: MessageType.USER, text: msg }, Date.now());
         }

--- a/packages/cli/src/ui/utils/resumeHistoryUtils.test.ts
+++ b/packages/cli/src/ui/utils/resumeHistoryUtils.test.ts
@@ -107,6 +107,45 @@ describe('resumeHistoryUtils', () => {
     ]);
   });
 
+  it('restores mid-turn user messages from display text', () => {
+    const conversation = {
+      messages: [
+        {
+          type: 'tool_result',
+          toolCallResult: {
+            callId: 'call-1',
+            resultDisplay: 'All set',
+            status: 'success',
+          },
+        },
+        {
+          type: 'user',
+          subtype: 'mid_turn_user_message',
+          message: {
+            parts: [
+              {
+                text: '\n[User message received during tool execution]: save logs',
+              } as Part,
+            ],
+          },
+          systemPayload: { displayText: 'save logs' },
+        },
+      ],
+    } as unknown as ConversationRecord;
+
+    const session: ResumedSessionData = {
+      conversation,
+    } as ResumedSessionData;
+
+    const items = buildResumedHistoryItems(
+      session,
+      makeConfig({ replace: mockTool }),
+      20,
+    );
+
+    expect(items).toContainEqual({ id: 21, type: 'user', text: 'save logs' });
+  });
+
   it('marks tool results as error, captures thought text, and falls back when tool is missing', () => {
     const conversation = {
       messages: [

--- a/packages/cli/src/ui/utils/resumeHistoryUtils.ts
+++ b/packages/cli/src/ui/utils/resumeHistoryUtils.ts
@@ -279,6 +279,18 @@ function convertToHistoryItems(
           items.push({ type: 'notification', text });
           break;
         }
+        if (record.subtype === 'mid_turn_user_message') {
+          const payload = record.systemPayload as
+            | { displayText?: string }
+            | undefined;
+          const text =
+            payload?.displayText ||
+            extractTextFromParts(record.message?.parts as Part[]);
+          if (text) {
+            items.push({ type: 'user', text });
+          }
+          break;
+        }
         if (pendingAtCommands.length > 0) {
           // Flush any pending tool group before user message
           if (currentToolGroup.length > 0) {

--- a/packages/core/src/services/chatRecordingService.test.ts
+++ b/packages/core/src/services/chatRecordingService.test.ts
@@ -136,6 +136,31 @@ describe('ChatRecordingService', () => {
       expect(user2.uuid).toBe('00000000-0000-0000-0000-000000000003');
       expect(user2.parentUuid).toBe('00000000-0000-0000-0000-000000000002');
     });
+
+    it('should record mid-turn user messages with a mergeable subtype', async () => {
+      const modelFacingParts: Part[] = [
+        {
+          text: '\n[User message received during tool execution]: save logs',
+        },
+      ];
+
+      chatRecordingService.recordMidTurnUserMessage(
+        modelFacingParts,
+        'save logs',
+      );
+      await chatRecordingService.flush();
+
+      expect(jsonl.writeLine).toHaveBeenCalledTimes(1);
+      const record = vi.mocked(jsonl.writeLine).mock.calls[0][1] as ChatRecord;
+
+      expect(record.type).toBe('user');
+      expect(record.subtype).toBe('mid_turn_user_message');
+      expect(record.message).toEqual({
+        role: 'user',
+        parts: modelFacingParts,
+      });
+      expect(record.systemPayload).toEqual({ displayText: 'save logs' });
+    });
   });
 
   describe('recordAtCommand', () => {

--- a/packages/core/src/services/chatRecordingService.ts
+++ b/packages/core/src/services/chatRecordingService.ts
@@ -222,7 +222,7 @@ export interface ChatRecord {
    * (e.g., chat compression checkpoints) while keeping the original UI history intact.
    */
   type: 'user' | 'assistant' | 'tool_result' | 'system';
-  /** Optional system subtype for distinguishing system behaviors */
+  /** Optional subtype for distinguishing non-standard records */
   subtype?:
     | 'chat_compression'
     | 'slash_command'
@@ -231,6 +231,7 @@ export interface ChatRecord {
     | 'attribution_snapshot'
     | 'notification'
     | 'cron'
+    | 'mid_turn_user_message'
     | 'custom_title'
     | 'rewind'
     | 'agent_bootstrap'
@@ -267,8 +268,9 @@ export interface ChatRecord {
   toolCallResult?: Partial<ToolCallResponseInfo>;
 
   /**
-   * Payload for system records. For chat compression, this stores all data needed
-   * to reconstruct the compressed history without mutating the original UI list.
+   * Payload for records that need non-API metadata. For chat compression, this
+   * stores all data needed to reconstruct the compressed history without
+   * mutating the original UI list.
    */
   systemPayload?:
     | ChatCompressionRecordPayload
@@ -825,6 +827,29 @@ export class ChatRecordingService {
   }
 
   /**
+   * Records a user message drained while tool results are being submitted.
+   *
+   * The model sees these as extra user-role parts in the same API Content as
+   * tool results. Keeping a distinct subtype lets resume reconstruct that shape
+   * instead of replaying consecutive user-role entries.
+   */
+  recordMidTurnUserMessage(message: PartListUnion, displayText?: string): void {
+    try {
+      const record: ChatRecord = {
+        ...this.createBaseRecord('user'),
+        subtype: 'mid_turn_user_message',
+        message: createUserContent(message),
+        systemPayload: displayText
+          ? ({ displayText } as NotificationRecordPayload)
+          : undefined,
+      };
+      this.appendRecord(record);
+    } catch (error) {
+      debugLogger.error('Error saving mid-turn user message:', error);
+    }
+  }
+
+  /**
    * Records a cron-fired prompt.
    * Stored as a user-role message with subtype 'cron' so the UI
    * restores it as a notification item instead of a user turn.
@@ -1153,7 +1178,8 @@ export class ChatRecordingService {
       if (
         record.type === 'user' &&
         record.subtype !== 'notification' &&
-        record.subtype !== 'cron'
+        record.subtype !== 'cron' &&
+        record.subtype !== 'mid_turn_user_message'
       ) {
         this.turnParentUuids.push(prevUuid);
       }

--- a/packages/core/src/services/sessionService.test.ts
+++ b/packages/core/src/services/sessionService.test.ts
@@ -947,6 +947,95 @@ describe('SessionService', () => {
       expect(history).toEqual([recordA1.message, assistantA1.message]);
     });
 
+    it('merges mid-turn user messages into the preceding tool result on resume', () => {
+      const assistantWithToolCall: ChatRecord = {
+        uuid: 'a2',
+        parentUuid: recordA1.uuid,
+        sessionId: sessionIdA,
+        timestamp: '2024-01-01T00:01:00Z',
+        type: 'assistant',
+        message: {
+          role: 'model',
+          parts: [
+            {
+              functionCall: {
+                id: 'call-1',
+                name: 'read_file',
+                args: { path: 'foo.txt' },
+              },
+            },
+          ],
+        },
+        cwd: '/test/project/root',
+        version: '1.0.0',
+      };
+      const toolResult: ChatRecord = {
+        uuid: 'a3',
+        parentUuid: assistantWithToolCall.uuid,
+        sessionId: sessionIdA,
+        timestamp: '2024-01-01T00:02:00Z',
+        type: 'tool_result',
+        message: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'call-1',
+                name: 'read_file',
+                response: { output: 'contents' },
+              },
+            },
+          ],
+        },
+        cwd: '/test/project/root',
+        version: '1.0.0',
+      };
+      const midTurnUserMessage: ChatRecord = {
+        uuid: 'a4',
+        parentUuid: toolResult.uuid,
+        sessionId: sessionIdA,
+        timestamp: '2024-01-01T00:03:00Z',
+        type: 'user',
+        subtype: 'mid_turn_user_message',
+        message: {
+          role: 'user',
+          parts: [
+            {
+              text: '\n[User message received during tool execution]: save the logs',
+            },
+          ],
+        },
+        cwd: '/test/project/root',
+        version: '1.0.0',
+      };
+      const conversation: ConversationRecord = {
+        sessionId: sessionIdA,
+        projectHash: 'test-project-hash',
+        startTime: '2024-01-01T00:00:00Z',
+        lastUpdated: '2024-01-01T00:03:00Z',
+        messages: [
+          recordA1,
+          assistantWithToolCall,
+          toolResult,
+          midTurnUserMessage,
+        ],
+      };
+
+      const history = buildApiHistoryFromConversation(conversation);
+
+      expect(history).toEqual([
+        recordA1.message,
+        assistantWithToolCall.message,
+        {
+          role: 'user',
+          parts: [
+            ...toolResult.message!.parts!,
+            ...midTurnUserMessage.message!.parts!,
+          ],
+        },
+      ]);
+    });
+
     it('should use compressedHistory snapshot and append subsequent records after compression', () => {
       const compressionRecord: ChatRecord = {
         uuid: 'c1',
@@ -1010,6 +1099,99 @@ describe('SessionService', () => {
         },
         recordB2.message,
         postCompressionRecord.message,
+      ]);
+    });
+
+    it('merges post-compression mid-turn user messages into preceding tool results', () => {
+      const compressionRecord: ChatRecord = {
+        uuid: 'c1',
+        parentUuid: 'b2',
+        sessionId: sessionIdA,
+        timestamp: '2024-01-02T03:00:00Z',
+        type: 'system',
+        subtype: 'chat_compression',
+        cwd: '/test/project/root',
+        version: '1.0.0',
+        gitBranch: 'main',
+        systemPayload: {
+          info: {
+            originalTokenCount: 100,
+            newTokenCount: 50,
+            compressionStatus: CompressionStatus.COMPRESSED,
+          },
+          compressedHistory: [
+            { role: 'user', parts: [{ text: 'summary' }] },
+            { role: 'model', parts: [{ text: 'continue' }] },
+          ],
+        },
+      };
+      const toolResult: ChatRecord = {
+        uuid: 'c2',
+        parentUuid: 'c1',
+        sessionId: sessionIdA,
+        timestamp: '2024-01-02T04:00:00Z',
+        type: 'tool_result',
+        message: {
+          role: 'user',
+          parts: [
+            {
+              functionResponse: {
+                id: 'call-1',
+                name: 'shell',
+                response: { output: 'ok' },
+              },
+            },
+          ],
+        },
+        cwd: '/test/project/root',
+        version: '1.0.0',
+        gitBranch: 'main',
+      };
+      const midTurnUserMessage: ChatRecord = {
+        uuid: 'c3',
+        parentUuid: 'c2',
+        sessionId: sessionIdA,
+        timestamp: '2024-01-02T04:01:00Z',
+        type: 'user',
+        subtype: 'mid_turn_user_message',
+        message: {
+          role: 'user',
+          parts: [
+            {
+              text: '\n[User message received during tool execution]: stop after this',
+            },
+          ],
+        },
+        cwd: '/test/project/root',
+        version: '1.0.0',
+        gitBranch: 'main',
+      };
+      const conversation: ConversationRecord = {
+        sessionId: sessionIdA,
+        projectHash: 'test-project-hash',
+        startTime: '2024-01-01T00:00:00Z',
+        lastUpdated: '2024-01-02T04:01:00Z',
+        messages: [
+          recordA1,
+          recordB2,
+          compressionRecord,
+          toolResult,
+          midTurnUserMessage,
+        ],
+      };
+
+      const history = buildApiHistoryFromConversation(conversation);
+
+      expect(history).toEqual([
+        { role: 'user', parts: [{ text: 'summary' }] },
+        { role: 'model', parts: [{ text: 'continue' }] },
+        {
+          role: 'user',
+          parts: [
+            ...toolResult.message!.parts!,
+            ...midTurnUserMessage.message!.parts!,
+          ],
+        },
       ]);
     });
 

--- a/packages/core/src/services/sessionService.ts
+++ b/packages/core/src/services/sessionService.ts
@@ -1182,6 +1182,21 @@ function stripThoughtsFromContent(content: Content): Content | null {
   };
 }
 
+function appendApiHistoryRecord(history: Content[], record: ChatRecord): void {
+  if (!record.message) return;
+
+  const message = structuredClone(record.message as Content);
+  if (record.subtype === 'mid_turn_user_message') {
+    const previous = history.at(-1);
+    if (previous?.role === 'user') {
+      previous.parts = [...(previous.parts ?? []), ...(message.parts ?? [])];
+      return;
+    }
+  }
+
+  history.push(message);
+}
+
 /**
  * Builds the model-facing chat history (Content[]) from a reconstructed
  * conversation. This keeps UI history intact while applying chat compression
@@ -1222,9 +1237,7 @@ export function buildApiHistoryFromConversation(
     for (let i = lastCompressionIndex + 1; i < messages.length; i++) {
       const record = messages[i];
       if (record.type === 'system') continue;
-      if (record.message) {
-        baseHistory.push(structuredClone(record.message as Content));
-      }
+      appendApiHistoryRecord(baseHistory, record);
     }
 
     if (stripThoughtsFromHistory) {
@@ -1236,10 +1249,10 @@ export function buildApiHistoryFromConversation(
   }
 
   // Fallback: return linear messages as Content[]
-  const result = messages
-    .map((record) => record.message)
-    .filter((message): message is Content => message !== undefined)
-    .map((message) => structuredClone(message));
+  const result: Content[] = [];
+  for (const record of messages) {
+    appendApiHistoryRecord(result, record);
+  }
 
   if (stripThoughtsFromHistory) {
     return result


### PR DESCRIPTION
## Summary

- What changed: mid-turn queued user prompts are now recorded through chat recording when they are drained after tool execution.
- Why it changed: these prompts were only added to live UI history and injected into the next ToolResult request, so JSONL-backed export and resume could miss the original user message.
- Reviewer focus: this keeps the existing ToolResult submission shape unchanged and only records the original drained prompt as an independent user message.

## Validation

- Commands run:
  ```bash
  cd packages/cli
  npx vitest run src/ui/hooks/useGeminiStream.test.tsx -t "mid-turn queued user messages"
  npx vitest run src/ui/hooks/useGeminiStream.test.tsx
  cd ../..
  npm run lint --workspace=packages/cli
  npm run build --workspace=packages/core
  npm run build --workspace=@qwen-code/channel-base
  npm run typecheck --workspace=packages/cli
  npx prettier --check packages/cli/src/ui/hooks/useGeminiStream.ts packages/cli/src/ui/hooks/useGeminiStream.test.tsx
  git diff --check
  ```
- Prompts / inputs used: simulated a completed tool call while `midTurnDrainRef` drains `save the logs locally first`.
- Expected result: the drained user prompt is recorded as a user message before submitting the follow-up ToolResult request, while the model still receives the existing `[User message received during tool execution]` text part.
- Observed result: the regression test fails before the fix because `recordUserMessage` is never called, then passes after the queued prompt is recorded.
- Quickest reviewer verification path:
  ```bash
  cd packages/cli
  npx vitest run src/ui/hooks/useGeminiStream.test.tsx -t "mid-turn queued user messages"
  ```
- Evidence: full `useGeminiStream.test.tsx` passes locally with 93 tests.

## Scope / Risk

- Main risk or tradeoff: this adds a recording side effect when queued prompts are drained; it does not change the tool-result request payload or tool scheduling behavior.
- Not covered / not validated: no full repository test run; validation focused on the affected hook plus CLI lint/typecheck.
- Breaking changes / migration notes: none.

## Testing Matrix

|          | Local |
| -------- | ----- |
| npm run  | tested |
| npx      | tested |
| Docker   | N/A |
| Podman   | N/A |
| Seatbelt | N/A |

Testing matrix notes:

- `npm run` was used for CLI lint/typecheck and to refresh dependent package builds before typecheck.
- `npx` was used for the targeted and full hook test file plus Prettier check.

## Linked Issues / Bugs

Fixes #4148
