### PR TITLE
fix(test): clear boundedPromise timers to prevent unhandled rejections in abort-and-lifecycle test

### DIFF
--- a/integration-tests/sdk-typescript/abort-and-lifecycle.test.ts
+++ b/integration-tests/sdk-typescript/abort-and-lifecycle.test.ts
@@ -328,6 +328,7 @@ describe('AbortController and Process Lifecycle (E2E)', () => {
         const promise = new Promise<void>((resolve, reject) => {
           resolveFn = () => {
             if (timer !== undefined) clearTimeout(timer);
+            timer = undefined;
             resolve();
           };
           pendingReject = reject;
@@ -335,10 +336,17 @@ describe('AbortController and Process Lifecycle (E2E)', () => {
         const startTimer = () => {
           if (timer !== undefined) return;
           timer = setTimeout(() => {
+            timer = undefined;
             pendingReject(new Error(`${label} timeout after ${ms}ms`));
           }, ms);
         };
-        return { promise, resolve: () => resolveFn(), startTimer };
+        const clear = () => {
+          if (timer !== undefined) {
+            clearTimeout(timer);
+            timer = undefined;
+          }
+        };
+        return { promise, resolve: () => resolveFn(), startTimer, clear };
       };
 
       const canUseToolCalled = boundedPromise(
@@ -348,6 +356,12 @@ describe('AbortController and Process Lifecycle (E2E)', () => {
       const inputStreamDone = boundedPromise('inputStreamDone', 15000);
       const firstResult = boundedPromise('firstResult', 30000);
       const secondResult = boundedPromise('secondResult', 30000);
+      const pendingTimers = [
+        canUseToolCalled,
+        inputStreamDone,
+        firstResult,
+        secondResult,
+      ];
 
       // firstResult begins as soon as the query starts.
       firstResult.startTimer();
@@ -454,6 +468,7 @@ describe('AbortController and Process Lifecycle (E2E)', () => {
         const content = await helper.readFile('test.txt');
         expect(content).toBe('original content');
       } finally {
+        for (const t of pendingTimers) t.clear();
         await q.close();
       }
     });


### PR DESCRIPTION
## Summary

- What changed: Added timer cleanup for `boundedPromise` in `abort-and-lifecycle.test.ts` to prevent dangling `setTimeout` callbacks from firing after test completion.
- Why it changed: CI E2E test runs (e.g. [run 25975115422](https://github.com/QwenLM/qwen-code/actions/runs/25975115422)) were failing with exit code 1 due to an unhandled rejection: `secondResult timeout after 30000ms`. All tests passed but the leftover timer triggered vitest's unhandled error detection.
- Reviewer focus: `boundedPromise` now returns a `clear()` method; all four bounded promises are collected in `pendingTimers` and cleared in the `finally` block before `q.close()`.

## Validation

- Commands run:
  ```bash
  # Local syntax check (pre-commit hook passes)
  npm run build
  ```
- Expected result: No unhandled rejection after test completion; vitest exits with code 0.
- Observed result: CI log showed the `secondResult` timer firing after the test body completed, producing `Unhandled Rejection` → exit code 1.
- Quickest reviewer verification path: Check that `clear()` properly calls `clearTimeout` and that `pendingTimers` covers all four bounded promises used in the test.

## Scope / Risk

- Main risk or tradeoff: Minimal — the change only adds cleanup logic; the test's success path is unchanged.
- Not covered / not validated: This is a single-test fix; no other tests use `boundedPromise`.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- CI E2E (Linux, sandbox:none) is the canonical validation path for this type of fix.

## Linked Issues / Bugs

No linked issues.

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)