### PR TITLE
fix(cli): include skill base dir in slash commands

### DIFF
--- a/packages/cli/src/services/BundledSkillLoader.test.ts
+++ b/packages/cli/src/services/BundledSkillLoader.test.ts
@@ -7,7 +7,11 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BundledSkillLoader } from './BundledSkillLoader.js';
 import { CommandKind } from '../ui/commands/types.js';
-import type { Config, SkillConfig } from '@qwen-code/qwen-code-core';
+import {
+  buildSkillLlmContent,
+  type Config,
+  type SkillConfig,
+} from '@qwen-code/qwen-code-core';
 
 function makeSkill(overrides: Partial<SkillConfig> = {}): SkillConfig {
   return {
@@ -18,6 +22,10 @@ function makeSkill(overrides: Partial<SkillConfig> = {}): SkillConfig {
     body: 'You are an expert code reviewer.',
     ...overrides,
   };
+}
+
+function makeSkillPrompt(body: string): string {
+  return buildSkillLlmContent('/bundled/review', body);
 }
 
 describe('BundledSkillLoader', () => {
@@ -108,7 +116,7 @@ describe('BundledSkillLoader', () => {
 
     expect(result).toEqual({
       type: 'submit_prompt',
-      content: [{ text: 'You are an expert code reviewer.' }],
+      content: [{ text: makeSkillPrompt('You are an expert code reviewer.') }],
     });
   });
 
@@ -125,7 +133,11 @@ describe('BundledSkillLoader', () => {
 
     expect(result).toEqual({
       type: 'submit_prompt',
-      content: [{ text: 'You are an expert code reviewer.\n\n/review 123' }],
+      content: [
+        {
+          text: `${makeSkillPrompt('You are an expert code reviewer.')}\n\n/review 123`,
+        },
+      ],
     });
   });
 
@@ -172,7 +184,9 @@ describe('BundledSkillLoader', () => {
       type: 'submit_prompt',
       content: [
         {
-          text: 'YOUR_MODEL_ID="qwen3-coder"\n\nReview by qwen3-coder via Qwen Code',
+          text: makeSkillPrompt(
+            'YOUR_MODEL_ID="qwen3-coder"\n\nReview by qwen3-coder via Qwen Code',
+          ),
         },
       ],
     });
@@ -194,7 +208,7 @@ describe('BundledSkillLoader', () => {
 
     expect(result).toEqual({
       type: 'submit_prompt',
-      content: [{ text: 'Review by ' }],
+      content: [{ text: makeSkillPrompt('Review by ') }],
     });
   });
 
@@ -218,7 +232,7 @@ describe('BundledSkillLoader', () => {
       type: 'submit_prompt',
       content: [
         {
-          text: 'YOUR_MODEL_ID="qwen3-coder"\n\nReview by qwen3-coder\n\n/review 123',
+          text: `${makeSkillPrompt('YOUR_MODEL_ID="qwen3-coder"\n\nReview by qwen3-coder')}\n\n/review 123`,
         },
       ],
     });
@@ -240,7 +254,7 @@ describe('BundledSkillLoader', () => {
 
     expect(result).toEqual({
       type: 'submit_prompt',
-      content: [{ text: 'Review by ' }],
+      content: [{ text: makeSkillPrompt('Review by ') }],
     });
   });
 
@@ -257,7 +271,7 @@ describe('BundledSkillLoader', () => {
 
     expect(result).toEqual({
       type: 'submit_prompt',
-      content: [{ text: 'No template here' }],
+      content: [{ text: makeSkillPrompt('No template here') }],
     });
   });
 

--- a/packages/cli/src/services/BundledSkillLoader.ts
+++ b/packages/cli/src/services/BundledSkillLoader.ts
@@ -8,7 +8,9 @@ import type { Config } from '@qwen-code/qwen-code-core';
 import {
   createDebugLogger,
   appendToLastTextPart,
+  buildSkillLlmContent,
 } from '@qwen-code/qwen-code-core';
+import { dirname } from 'node:path';
 import type { ICommandLoader } from './types.js';
 import type {
   SlashCommand,
@@ -84,9 +86,16 @@ export class BundledSkillLoader implements ICommandLoader {
             }
           }
 
+          const skillPrompt = buildSkillLlmContent(
+            dirname(skill.filePath),
+            body,
+          );
           const content = context.invocation?.args
-            ? appendToLastTextPart([{ text: body }], context.invocation.raw)
-            : [{ text: body }];
+            ? appendToLastTextPart(
+                [{ text: skillPrompt }],
+                context.invocation.raw,
+              )
+            : [{ text: skillPrompt }];
 
           return {
             type: 'submit_prompt',

--- a/packages/cli/src/services/SkillCommandLoader.test.ts
+++ b/packages/cli/src/services/SkillCommandLoader.test.ts
@@ -7,17 +7,25 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { SkillCommandLoader } from './SkillCommandLoader.js';
 import { CommandKind } from '../ui/commands/types.js';
-import type { Config, SkillConfig } from '@qwen-code/qwen-code-core';
+import {
+  buildSkillLlmContent,
+  type Config,
+  type SkillConfig,
+} from '@qwen-code/qwen-code-core';
 
 function makeSkill(overrides: Partial<SkillConfig> = {}): SkillConfig {
   return {
     name: 'my-skill',
     description: 'My skill description',
     level: 'user',
-    filePath: '/home/user/.qwen/skills/my-skill/SKILL.md',
+    filePath: '/tmp/qwen-test/skills/my-skill/SKILL.md',
     body: 'Skill body content.',
     ...overrides,
   };
+}
+
+function makeSkillPrompt(body: string): string {
+  return buildSkillLlmContent('/tmp/qwen-test/skills/my-skill', body);
 }
 
 describe('SkillCommandLoader', () => {
@@ -136,7 +144,7 @@ describe('SkillCommandLoader', () => {
 
     expect(result).toEqual({
       type: 'submit_prompt',
-      content: [{ text: 'Skill body content.' }],
+      content: [{ text: makeSkillPrompt('Skill body content.') }],
     });
   });
 
@@ -156,7 +164,11 @@ describe('SkillCommandLoader', () => {
 
     expect(result).toEqual({
       type: 'submit_prompt',
-      content: [{ text: 'Skill body content.\n\n/my-skill foo' }],
+      content: [
+        {
+          text: `${makeSkillPrompt('Skill body content.')}\n\n/my-skill foo`,
+        },
+      ],
     });
   });
 

--- a/packages/cli/src/services/SkillCommandLoader.ts
+++ b/packages/cli/src/services/SkillCommandLoader.ts
@@ -8,7 +8,9 @@ import type { Config } from '@qwen-code/qwen-code-core';
 import {
   createDebugLogger,
   appendToLastTextPart,
+  buildSkillLlmContent,
 } from '@qwen-code/qwen-code-core';
+import { dirname } from 'node:path';
 import type { ICommandLoader } from './types.js';
 import type {
   SlashCommand,
@@ -94,7 +96,10 @@ export class SkillCommandLoader implements ICommandLoader {
           argumentHint: skill.argumentHint,
           whenToUse: skill.whenToUse,
           action: async (context, _args): Promise<SlashCommandActionReturn> => {
-            const body = skill.body;
+            const body = buildSkillLlmContent(
+              dirname(skill.filePath),
+              skill.body,
+            );
 
             const content = context.invocation?.args
               ? appendToLastTextPart([{ text: body }], context.invocation.raw)


### PR DESCRIPTION
## Summary

- What changed: Slash-command skill loaders now wrap submitted skill prompts with the skill root context used by the `skill` tool path.
- Why it changed: Skills that reference files relative to their own directory, such as bundled documentation used by `qc-helper`, need the model to receive the actual skill base directory when invoked via `/skill-name`.
- Reviewer focus: Confirm the prompt wrapping stays consistent for bundled skills and user/project/extension skills, including invocations with arguments.

## Validation

- Commands run:
  ```bash
  cd packages/cli && npx vitest run src/services/BundledSkillLoader.test.ts src/services/SkillCommandLoader.test.ts
  npm run build
  npm run bundle
  npm run typecheck
  ```
- Prompts / inputs used:
  - `/qc-helper 'What is the extension?'`
- Expected result:
  - Slash-command skill prompts include `Base directory for this skill: ...`.
  - Relative references such as `docs/extension/introduction.md` resolve from the actual bundled skill root instead of an inferred user skill path.
- Observed result:
  - Regression tests pass for bundled skill slash commands and user/project/extension skill slash commands.
  - `npm run bundle` copies bundled skills and `docs/users/` into the `qc-helper` bundled docs directory.
- Quickest reviewer verification path:
  ```bash
  cd packages/cli && npx vitest run src/services/BundledSkillLoader.test.ts src/services/SkillCommandLoader.test.ts
  ```
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  - `32` focused tests passed across `BundledSkillLoader.test.ts` and `SkillCommandLoader.test.ts`.
  - `npm run build`, `npm run bundle`, and `npm run typecheck` completed successfully.
  - `npm run build` reported one pre-existing lint warning in `packages/vscode-ide-companion/src/utils/editorGroupUtils.ts`, unrelated to this change.

## Scope / Risk

- Main risk or tradeoff: Skill slash-command prompts now include the same base-directory prefix as direct `skill` tool invocations, adding a small amount of prompt text for slash-command skill use.
- Not covered / not validated: Full interactive CLI run against a live model was not executed.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- macOS local validation covered focused `npx vitest`, `npm run build`, `npm run bundle`, and `npm run typecheck`.
- Windows and Linux were not tested locally.

## Linked Issues / Bugs

- Locally reported bug; no GitHub issue number.
