### PR TITLE
feat(sdk): harden daemon session client

### DIFF
--- a/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
@@ -27,7 +27,9 @@ export interface DaemonSessionClientOptions {
   state?: DaemonSessionState;
   /**
    * Seed replay state for callers that persisted the last seen SSE event id.
-   * When omitted, the first event subscription starts live.
+   * When omitted, the first event subscription starts live. Values must be
+   * finite, non-negative integers because the daemon uses these ids as
+   * `Last-Event-ID` resume cursors.
    */
   lastEventId?: number;
 }
@@ -62,7 +64,7 @@ export class DaemonSessionClient {
     this.client = opts.client;
     this.session = { ...opts.session };
     this.state = { ...(opts.state ?? {}) };
-    this.lastSeenEventId = opts.lastEventId;
+    this.lastSeenEventId = validateLastEventId(opts.lastEventId);
   }
 
   /**
@@ -76,7 +78,10 @@ export class DaemonSessionClient {
     // `modelServiceId` switch failures are reported on SSE, not the
     // create/attach HTTP response. Seed the first subscription from the
     // daemon replay ring so create-then-subscribe clients observe attach-time
-    // `model_switch_failed` / `model_switched` events.
+    // `model_switch_failed` / `model_switched` events. The daemon treats
+    // Last-Event-ID: 0 as "replay from the beginning of the bounded ring";
+    // if older events have already been evicted, clients receive the retained
+    // suffix and continue live from there.
     const lastEventId = req.modelServiceId ? 0 : undefined;
     return new DaemonSessionClient({ client, session, lastEventId });
   }
@@ -140,7 +145,7 @@ export class DaemonSessionClient {
   }
 
   setLastEventId(lastEventId: number | undefined): void {
-    this.lastSeenEventId = lastEventId;
+    this.lastSeenEventId = validateLastEventId(lastEventId);
   }
 
   async prompt(
@@ -167,21 +172,77 @@ export class DaemonSessionClient {
 
   events(
     opts: DaemonSessionSubscribeOptions = {},
-  ): AsyncGenerator<DaemonEvent> {
-    return this.subscribeEvents(opts);
+  ): AsyncGenerator<DaemonEvent, void, unknown> {
+    return this.openEventSubscription(opts);
   }
 
-  async *subscribeEvents(
+  /**
+   * @deprecated Use {@link events} instead. Both methods are equivalent.
+   */
+  subscribeEvents(
     opts: DaemonSessionSubscribeOptions = {},
-  ): AsyncGenerator<DaemonEvent> {
-    if (this.subscriptionActive) {
-      throw new Error(
-        'Another event subscription is already active on this session. ' +
-          'Reuse the existing AsyncGenerator or create a separate DaemonSessionClient.',
-      );
-    }
+  ): AsyncGenerator<DaemonEvent, void, unknown> {
+    return this.openEventSubscription(opts);
+  }
 
-    this.subscriptionActive = true;
+  private openEventSubscription(
+    opts: DaemonSessionSubscribeOptions,
+  ): AsyncGenerator<DaemonEvent, void, unknown> {
+    const requestedLastEventId = validateLastEventId(opts.lastEventId);
+    let started = false;
+    let released = false;
+    const release = () => {
+      if (released) return;
+      released = true;
+      this.subscriptionActive = false;
+    };
+    const acquire = () => {
+      if (started) return;
+      if (this.subscriptionActive) {
+        throw new Error(
+          'Another event subscription is already active on this session. ' +
+            'Reuse the existing AsyncGenerator or create a separate DaemonSessionClient.',
+        );
+      }
+      this.subscriptionActive = true;
+      started = true;
+    };
+    const iterator = this.iterateEvents(
+      { ...opts, lastEventId: requestedLastEventId },
+      release,
+    );
+
+    return {
+      next: async (value?: unknown) => {
+        if (!released) {
+          acquire();
+        }
+        return await iterator.next(value);
+      },
+      return: async () => {
+        try {
+          return await iterator.return(undefined);
+        } finally {
+          release();
+        }
+      },
+      throw: async (error?: unknown) => {
+        try {
+          return await iterator.throw(error);
+        } finally {
+          release();
+        }
+      },
+      [Symbol.asyncIterator]() {
+        return this;
+      },
+    };
+  }
+
+  private async *iterateEvents(
+    opts: DaemonSessionSubscribeOptions,
+    release: () => void,
+  ): AsyncGenerator<DaemonEvent, void, unknown> {
     try {
       const { resume = true, ...subscribeOpts } = opts;
       const lastEventId =
@@ -193,11 +254,36 @@ export class DaemonSessionClient {
         lastEventId,
       })) {
         yield event;
-        // Terminal/synthetic frames may not carry an SSE id.
-        if (event.id !== undefined) this.lastSeenEventId = event.id;
+        // Cursor updates happen after the consumer resumes iteration. That
+        // avoids acknowledging an event before the adapter has processed it,
+        // but means `lastEventId` intentionally lags while the handler for the
+        // just-yielded event is still running.
+        // The cursor is a replay watermark, so it only moves forward even if a
+        // replayed or synthetic frame arrives with an older id.
+        if (event.id !== undefined) {
+          this.lastSeenEventId = Math.max(
+            this.lastSeenEventId ?? 0,
+            validateLastEventId(event.id),
+          );
+        }
       }
     } finally {
-      this.subscriptionActive = false;
+      release();
     }
   }
+}
+
+function validateLastEventId(lastEventId: number): number;
+function validateLastEventId(lastEventId: undefined): undefined;
+function validateLastEventId(
+  lastEventId: number | undefined,
+): number | undefined;
+function validateLastEventId(
+  lastEventId: number | undefined,
+): number | undefined {
+  if (lastEventId === undefined) return undefined;
+  if (!Number.isInteger(lastEventId) || lastEventId < 0) {
+    throw new TypeError('lastEventId must be a finite non-negative integer');
+  }
+  return lastEventId;
 }

--- a/packages/sdk-typescript/test/unit/DaemonSessionClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonSessionClient.test.ts
@@ -29,6 +29,22 @@ function sseResponse(frames: string): Response {
   });
 }
 
+function pendingSseResponse(onCancel: () => void): Response {
+  const encoder = new TextEncoder();
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      controller.enqueue(encoder.encode(': keepalive\n\n'));
+    },
+    cancel() {
+      onCancel();
+    },
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
 interface CapturedRequest {
   url: string;
   method: string;
@@ -186,6 +202,35 @@ describe('DaemonSessionClient', () => {
     expect(calls[1]?.headers['last-event-id']).toBe('0');
   });
 
+  it('starts live when createOrAttach has no model service replay need', async () => {
+    const { fetch, calls } = recordingFetch((req) => {
+      if (req.url.endsWith('/session')) {
+        return jsonResponse(200, {
+          sessionId: 's-1',
+          workspaceCwd: '/work/a',
+          attached: true,
+        });
+      }
+      if (req.url.endsWith('/session/s-1/events')) {
+        return sseResponse('');
+      }
+      return jsonResponse(500, { error: `unexpected ${req.url}` });
+    });
+    const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+
+    const session = await DaemonSessionClient.createOrAttach(client, {
+      workspaceCwd: '/work/a',
+    });
+
+    for await (const _event of session.events()) {
+      /* empty */
+    }
+
+    expect(session.lastEventId).toBeUndefined();
+    expect(calls[1]?.url).toBe('http://daemon/session/s-1/events');
+    expect(calls[1]?.headers['last-event-id']).toBeUndefined();
+  });
+
   it('forwards session-scoped operations through DaemonClient', async () => {
     const { fetch, calls } = recordingFetch((req) => {
       if (req.url.endsWith('/session/s-1/prompt')) {
@@ -236,6 +281,40 @@ describe('DaemonSessionClient', () => {
       'http://daemon/permission/req-1',
     ]);
     expect(calls[0]?.signal).toBe(controller.signal);
+  });
+
+  it('surfaces permission races and session operation failures', async () => {
+    const { fetch } = recordingFetch((req) => {
+      if (req.url.endsWith('/permission/missing-req')) {
+        return jsonResponse(404, { error: 'unknown request' });
+      }
+      if (req.url.endsWith('/session/s-1/model')) {
+        return jsonResponse(404, { error: 'unknown session' });
+      }
+      if (req.url.endsWith('/session/s-1/cancel')) {
+        return jsonResponse(500, { error: 'cancel failed' });
+      }
+      return jsonResponse(500, { error: `unexpected ${req.url}` });
+    });
+    const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+    const session = new DaemonSessionClient({
+      client,
+      session: {
+        sessionId: 's-1',
+        workspaceCwd: '/work/a',
+        attached: true,
+      },
+    });
+
+    await expect(
+      session.respondToPermission('missing-req', {
+        outcome: { outcome: 'cancelled' },
+      }),
+    ).resolves.toBe(false);
+    await expect(session.setModel('qwen3-coder')).rejects.toMatchObject({
+      status: 404,
+    });
+    await expect(session.cancel()).rejects.toMatchObject({ status: 500 });
   });
 
   it('tracks Last-Event-ID across event subscriptions', async () => {
@@ -310,6 +389,28 @@ describe('DaemonSessionClient', () => {
     expect(session.lastEventId).toBe(4);
   });
 
+  it('does not acquire the subscription guard until iteration starts', async () => {
+    const { fetch, calls } = recordingFetch(() => sseResponse(''));
+    const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+    const session = new DaemonSessionClient({
+      client,
+      session: {
+        sessionId: 's-1',
+        workspaceCwd: '/work/a',
+        attached: true,
+      },
+    });
+
+    const abandoned = session.events();
+    await expect(session.events().next()).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+
+    expect(calls).toHaveLength(1);
+    await abandoned.return(undefined);
+  });
+
   it('rejects concurrent subscriptions on one session client', async () => {
     const { fetch } = recordingFetch(() =>
       sseResponse(
@@ -336,7 +437,12 @@ describe('DaemonSessionClient', () => {
     await expect(second.next()).rejects.toThrow(
       'Another event subscription is already active',
     );
+
     await first.return(undefined);
+
+    for await (const _event of session.events()) {
+      /* guard recovered */
+    }
   });
 
   it('allows callers to seed, override, and disable replay state', async () => {
@@ -367,6 +473,114 @@ describe('DaemonSessionClient', () => {
     expect(calls[2]?.headers['last-event-id']).toBeUndefined();
   });
 
+  it('allows callers to set and clear replay state explicitly', async () => {
+    const { fetch, calls } = recordingFetch(() => sseResponse(''));
+    const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+    const session = new DaemonSessionClient({
+      client,
+      session: {
+        sessionId: 's-1',
+        workspaceCwd: '/work/a',
+        attached: true,
+      },
+    });
+
+    session.setLastEventId(12);
+    expect(session.lastEventId).toBe(12);
+    for await (const _event of session.events()) {
+      /* empty */
+    }
+
+    session.setLastEventId(undefined);
+    expect(session.lastEventId).toBeUndefined();
+    for await (const _event of session.events()) {
+      /* empty */
+    }
+
+    expect(calls[0]?.headers['last-event-id']).toBe('12');
+    expect(calls[1]?.headers['last-event-id']).toBeUndefined();
+    expect(() => session.setLastEventId(-1)).toThrow(TypeError);
+    expect(() => session.setLastEventId(1.5)).toThrow(TypeError);
+    expect(() => session.setLastEventId(Number.NaN)).toThrow(TypeError);
+    expect(
+      () =>
+        new DaemonSessionClient({
+          client,
+          session: {
+            sessionId: 's-1',
+            workspaceCwd: '/work/a',
+            attached: true,
+          },
+          lastEventId: Number.POSITIVE_INFINITY,
+        }),
+    ).toThrow(TypeError);
+    expect(() => session.events({ lastEventId: -1 })).toThrow(TypeError);
+  });
+
+  it('honors abort signals and releases the subscription guard', async () => {
+    let cancelled = false;
+    const { fetch, calls } = recordingFetch(() =>
+      pendingSseResponse(() => {
+        cancelled = true;
+      }),
+    );
+    const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+    const session = new DaemonSessionClient({
+      client,
+      session: {
+        sessionId: 's-1',
+        workspaceCwd: '/work/a',
+        attached: true,
+      },
+    });
+    const controller = new AbortController();
+
+    const events = session.events({ signal: controller.signal });
+    const next = events.next();
+    await Promise.resolve();
+    expect(calls).toHaveLength(1);
+
+    controller.abort();
+
+    await expect(next).resolves.toEqual({
+      done: true,
+      value: undefined,
+    });
+    expect(cancelled).toBe(true);
+
+    const retry = session.events();
+    await retry.return(undefined);
+  });
+
+  it('releases the subscription guard when consumers throw into the iterator', async () => {
+    const { fetch } = recordingFetch(() =>
+      sseResponse(
+        'id: 4\nevent: session_update\ndata: {"id":4,"v":1,"type":"session_update","data":"a"}\n\n',
+      ),
+    );
+    const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+    const session = new DaemonSessionClient({
+      client,
+      session: {
+        sessionId: 's-1',
+        workspaceCwd: '/work/a',
+        attached: true,
+      },
+    });
+
+    const events = session.events();
+    await expect(events.next()).resolves.toMatchObject({
+      done: false,
+      value: { id: 4 },
+    });
+
+    await expect(events.throw(new Error('boom'))).rejects.toThrow('boom');
+
+    for await (const _event of session.events()) {
+      /* guard recovered */
+    }
+  });
+
   it('propagates prompt and subscription errors', async () => {
     const { fetch } = recordingFetch((req) => {
       if (req.url.endsWith('/session/s-1/prompt')) {
@@ -393,6 +607,11 @@ describe('DaemonSessionClient', () => {
 
     const events = session.events();
     await expect(events.next()).rejects.toThrow(
+      'GET /session/:id/events: stream failed',
+    );
+
+    const retry = session.events({ resume: false });
+    await expect(retry.next()).rejects.toThrow(
       'GET /session/:id/events: stream failed',
     );
   });


### PR DESCRIPTION
## Summary

- What changed: hardened `DaemonSessionClient` replay cursor handling and event subscription lifecycle, while keeping the existing `events()` and `subscribeEvents()` entry points available.
- Why it changed: this is a follow-up to the daemon session client skeleton so adapter clients can safely rely on one active SSE stream, explicit replay cursor updates, abort/error cleanup, and session-scoped error propagation.
- Reviewer focus: check the lazy subscription guard/release wrapper, `Last-Event-ID` validation, and the additional tests around abort/error/replay behavior.

## Validation

- Commands run:
  ```bash
  cd packages/sdk-typescript && npx vitest run test/unit/DaemonSessionClient.test.ts test/unit/DaemonClient.test.ts test/unit/daemon-sse.test.ts
  cd packages/sdk-typescript && npm run typecheck
  cd packages/sdk-typescript && npm run build
  cd packages/sdk-typescript && npx prettier --check src/daemon/DaemonSessionClient.ts test/unit/DaemonSessionClient.test.ts
  npx eslint packages/sdk-typescript/src/daemon/DaemonSessionClient.ts packages/sdk-typescript/test/unit/DaemonSessionClient.test.ts --max-warnings 0 --no-warn-ignored
  npm run build
  ```
- Prompts / inputs used: N/A, SDK unit-level hardening only.
- Expected result: session client keeps replay cursors valid, rejects concurrent active event subscriptions on first pull, does not lock the guard for abandoned iterators, releases the guard after abort/error/return, and preserves existing session-scoped operations.
- Observed result: SDK targeted tests passed: 3 files, 82 tests. SDK typecheck/build, targeted ESLint, targeted Prettier, and root build passed.
- Quickest reviewer verification path:
  ```bash
  cd packages/sdk-typescript && npx vitest run test/unit/DaemonSessionClient.test.ts
  cd packages/sdk-typescript && npm run typecheck
  ```
- Evidence: root build completed successfully. It still reports the pre-existing `packages/vscode-ide-companion/src/utils/editorGroupUtils.ts` curly warning, which this PR does not touch.

## Scope / Risk

- Main risk or tradeoff: `events()`/`subscribeEvents()` now share a single guarded implementation. The guard is acquired lazily on the first `.next()`, so an iterator created and then abandoned does not block later subscriptions; once active, a second active stream is rejected until the first stream completes, returns, throws, or aborts.
- Not covered / not validated: no daemon E2E run; this is SDK-only behavior exercised with mocked daemon HTTP/SSE responses.
- Breaking changes / migration notes: no runtime API removal. `subscribeEvents()` is now documented as deprecated in favor of `events()`. `AsyncGenerator` return typing is explicit as `void`, and `setLastEventId`, constructor seed, and per-call `lastEventId` now reject invalid cursor values instead of sending malformed `Last-Event-ID` headers.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Local validation was run on macOS. Cross-platform GitHub CI should cover Windows and Linux.

## Linked Issues / Bugs

Related to #3803 and follow-up hardening after #4201.
