### PR TITLE
feat(core): fail impossible goals

### DIFF
--- a/packages/cli/src/ui/commands/goalCommand.test.ts
+++ b/packages/cli/src/ui/commands/goalCommand.test.ts
@@ -326,4 +326,27 @@ describe('goalCommand', () => {
       lastReason: 'Goal max iterations reached',
     });
   });
+
+  it('after impossible failure, empty /goal shows the failed summary', async () => {
+    const ctx = createMockCommandContext({
+      services: { config: makeConfig() as unknown as Config },
+    });
+    await goalCommand.action!(ctx, 'do x');
+    clearActiveGoal('sess-1');
+    notifyGoalTerminal('sess-1', {
+      kind: 'failed',
+      condition: 'do x',
+      iterations: 2,
+      durationMs: 12_000,
+      lastReason: 'the required branch does not exist',
+    });
+
+    const result = await goalCommand.action!(ctx, '');
+    const content = (result as { content: string }).content;
+    expect(content).toMatch(/Goal could not be achieved/);
+    expect(content).toMatch(/2 turns/);
+    expect(content).toMatch(/12s/);
+    expect(content).toMatch(/Goal: do x/);
+    expect(content).toMatch(/Last check: the required branch does not exist/);
+  });
 });

--- a/packages/cli/src/ui/commands/goalCommand.ts
+++ b/packages/cli/src/ui/commands/goalCommand.ts
@@ -57,7 +57,12 @@ function formatTerminalSummary(event: GoalTerminalEvent): string {
   // most recent terminal event, including the judge's `lastReason` (when
   // present) so this view matches the inline `Goal achieved / aborted`
   // history card.
-  const title = event.kind === 'achieved' ? 'Goal achieved' : 'Goal aborted';
+  const title =
+    event.kind === 'achieved'
+      ? 'Goal achieved'
+      : event.kind === 'failed'
+        ? 'Goal could not be achieved'
+        : 'Goal aborted';
   const stats: string[] = [];
   if (event.iterations > 0) stats.push(formatTurns(event.iterations));
   if (typeof event.durationMs === 'number')

--- a/packages/cli/src/ui/components/messages/GoalStatusMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/GoalStatusMessage.test.tsx
@@ -25,4 +25,22 @@ describe('<GoalStatusMessage />', () => {
     expect(output).toContain('Goal: finish the refactor');
     expect(output).toContain('Judge: tests are still failing');
   });
+
+  it('shows impossible goals as failed terminal cards', () => {
+    const { lastFrame } = render(
+      <GoalStatusMessage
+        kind="failed"
+        condition="merge a nonexistent branch"
+        iterations={2}
+        durationMs={12_000}
+        lastReason="the remote branch does not exist"
+      />,
+    );
+
+    const output = lastFrame();
+    expect(output).toContain('Goal could not be achieved');
+    expect(output).toContain('2 turns');
+    expect(output).toContain('Goal: merge a nonexistent branch');
+    expect(output).toContain('Last check: the remote branch does not exist');
+  });
 });

--- a/packages/cli/src/ui/components/messages/GoalStatusMessage.tsx
+++ b/packages/cli/src/ui/components/messages/GoalStatusMessage.tsx
@@ -81,6 +81,12 @@ export const GoalStatusMessage: React.FC<GoalStatusMessageProps> = ({
           prefixColor: theme.text.secondary,
           title: 'Goal cleared',
         };
+      case 'failed':
+        return {
+          prefix: '!',
+          prefixColor: theme.status.error,
+          title: 'Goal could not be achieved',
+        };
       case 'aborted':
       default:
         return {
@@ -136,7 +142,8 @@ export const GoalStatusMessage: React.FC<GoalStatusMessageProps> = ({
             flex-row variant hangs the continuation at the value column's
             left edge (≈12 cols of empty space, easily mistaken for a blank
             line). One Text + natural wrap keeps the continuation flush. */}
-        {(kind === 'achieved' || kind === 'aborted') && lastReason?.trim() ? (
+        {(kind === 'achieved' || kind === 'aborted' || kind === 'failed') &&
+        lastReason?.trim() ? (
           <Text color={theme.text.secondary} wrap="wrap">
             Last check: {lastReason.trim()}
           </Text>

--- a/packages/cli/src/ui/types.ts
+++ b/packages/cli/src/ui/types.ts
@@ -505,6 +505,7 @@ export type GoalStatusKind =
   | 'set'
   | 'achieved'
   | 'cleared'
+  | 'failed'
   | 'aborted'
   | 'checking';
 

--- a/packages/cli/src/ui/utils/restoreGoal.test.ts
+++ b/packages/cli/src/ui/utils/restoreGoal.test.ts
@@ -98,6 +98,15 @@ describe('findGoalToRestore', () => {
       ]),
     ).toBeNull();
   });
+
+  it('returns null when last goal_status is failed', () => {
+    expect(
+      findGoalToRestore([
+        goalItem({ kind: 'set', condition: 'do x' }),
+        goalItem({ kind: 'failed', condition: 'do x' }),
+      ]),
+    ).toBeNull();
+  });
 });
 
 describe('restoreGoalFromHistory', () => {
@@ -269,5 +278,22 @@ describe('findLastTerminalGoal', () => {
     ]);
     expect(result?.kind).toBe('aborted');
     expect(result?.condition).toBe('goal B');
+  });
+
+  it('returns failed when it is the most recent terminal', () => {
+    const result = findLastTerminalGoal([
+      goalItem({ kind: 'achieved', condition: 'goal A' }),
+      goalItem({ kind: 'set', condition: 'goal B' }),
+      goalItem({
+        kind: 'failed',
+        condition: 'goal B',
+        lastReason: 'external service unavailable',
+      }),
+    ]);
+    expect(result).toMatchObject({
+      kind: 'failed',
+      condition: 'goal B',
+      lastReason: 'external service unavailable',
+    });
   });
 });

--- a/packages/cli/src/ui/utils/restoreGoal.ts
+++ b/packages/cli/src/ui/utils/restoreGoal.ts
@@ -20,7 +20,7 @@ import { MessageType } from '../types.js';
  * Finds the most recent `goal_status` history item. Returns the active
  * condition when the latest goal event is non-terminal (`set` or `checking`),
  * or `null` if the last goal_status was terminal/cancelled
- * (achieved / cleared / aborted) or none exists.
+ * (achieved / failed / cleared / aborted) or none exists.
  */
 export function findGoalToRestore(history: HistoryItem[]): string | null {
   for (let i = history.length - 1; i >= 0; i--) {
@@ -35,7 +35,7 @@ export function findGoalToRestore(history: HistoryItem[]): string | null {
 }
 
 /**
- * Finds the most recent terminal (achieved / aborted) goal_status item in
+ * Finds the most recent terminal (achieved / failed / aborted) goal_status item in
  * the transcript. Sentinel-style entries (`set`, `cleared`, `checking`) are
  * SKIPPED — `/goal clear` after an achievement is intentionally a no-op on
  * this scan, matching Claude Code's `yjK` behavior (`if (!K.met || K.sentinel)
@@ -49,7 +49,12 @@ export function findLastTerminalGoal(
     const item = history[i];
     if (item?.type !== MessageType.GOAL_STATUS) continue;
     const goal = item as HistoryItemGoalStatus;
-    if (goal.kind !== 'achieved' && goal.kind !== 'aborted') continue;
+    if (
+      goal.kind !== 'achieved' &&
+      goal.kind !== 'aborted' &&
+      goal.kind !== 'failed'
+    )
+      continue;
     return {
       kind: goal.kind as GoalTerminalKind,
       condition: goal.condition,

--- a/packages/core/src/goals/activeGoalStore.ts
+++ b/packages/core/src/goals/activeGoalStore.ts
@@ -70,7 +70,7 @@ export function __resetActiveGoalStoreForTests(): void {
 // callback; any side effect (e.g. context.ui.addItem) should be guarded.
 // ───────────────────────────────────────────────────────────────────────────
 
-export type GoalTerminalKind = 'achieved' | 'aborted';
+export type GoalTerminalKind = 'achieved' | 'aborted' | 'failed';
 
 export interface GoalTerminalEvent {
   kind: GoalTerminalKind;

--- a/packages/core/src/goals/goalHook.test.ts
+++ b/packages/core/src/goals/goalHook.test.ts
@@ -314,6 +314,41 @@ describe('createGoalStopHookCallback', () => {
     expect(events[0].lastReason).toBe('still stuck now');
   });
 
+  it('clears the goal as failed when the judge says it is impossible', async () => {
+    setActiveGoal('sess-1', {
+      condition: 'merge a nonexistent branch',
+      iterations: 2,
+      setAt: 100,
+      tokensAtStart: 0,
+      hookId: 'h1',
+      lastReason: 'branch still missing',
+    });
+    judgeMock.mockResolvedValue({
+      ok: false,
+      impossible: true,
+      reason: 'the remote branch does not exist',
+    });
+    const events: GoalTerminalEvent[] = [];
+    setGoalTerminalObserver('sess-1', (e) => events.push(e));
+
+    const cb = createGoalStopHookCallback({
+      config: {} as Config,
+      sessionId: 'sess-1',
+      condition: 'merge a nonexistent branch',
+    });
+    const out = await cb(stopInput(), undefined);
+
+    expect(out).toEqual({ continue: true });
+    expect(getActiveGoal('sess-1')).toBeUndefined();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: 'failed',
+      condition: 'merge a nonexistent branch',
+      iterations: 2,
+      lastReason: 'the remote branch does not exist',
+    });
+  });
+
   it('does NOT notify observer on a single not-met turn', async () => {
     setActiveGoal('sess-1', {
       condition: 'do x',

--- a/packages/core/src/goals/goalHook.ts
+++ b/packages/core/src/goals/goalHook.ts
@@ -184,6 +184,17 @@ export function createGoalStopHookCallback(args: {
       return { continue: true };
     }
 
+    if (verdict.impossible) {
+      finishGoal(config, sessionId, latest, {
+        kind: 'failed',
+        condition: latest.condition,
+        iterations: latest.iterations,
+        durationMs: Date.now() - latest.setAt,
+        lastReason: verdict.reason,
+      });
+      return { continue: true };
+    }
+
     // Give the latest assistant output one final evaluation before aborting.
     // The iteration cap is a safety valve for still-not-met verdicts, not a
     // pre-judge hard stop; otherwise the final generated turn could satisfy

--- a/packages/core/src/goals/goalJudge.test.ts
+++ b/packages/core/src/goals/goalJudge.test.ts
@@ -91,6 +91,25 @@ describe('judgeGoal', () => {
     expect(verdict.reason).toBe('missing unit test for auth');
   });
 
+  it('parses impossible=true for genuinely unachievable goals', async () => {
+    const client = makeMockClient({
+      reply:
+        '{"ok": false, "impossible": true, "reason": "required remote is unavailable"}',
+    });
+    const config = makeConfig({ client });
+    const verdict = await judgeGoal(config, {
+      condition: 'merge the missing remote branch',
+      lastAssistantText: 'the remote does not exist',
+      signal: new AbortController().signal,
+    });
+
+    expect(verdict).toEqual({
+      ok: false,
+      impossible: true,
+      reason: 'required remote is unavailable',
+    });
+  });
+
   it('falls back to main model when no fast model is configured', async () => {
     const client = makeMockClient({});
     const config = makeConfig({ client, model: 'big-main' });
@@ -226,8 +245,12 @@ describe('judgeGoal', () => {
     // System prompt + structured output configured
     expect(generationConfig.systemInstruction).toMatch(/stop-condition hook/);
     expect(generationConfig.systemInstruction).toMatch(/quote evidence/);
+    expect(generationConfig.systemInstruction).toMatch(/impossible/);
     expect(generationConfig.responseMimeType).toBe('application/json');
     expect(generationConfig.responseSchema).toBeTruthy();
+    expect(generationConfig.responseSchema.properties).toHaveProperty(
+      'impossible',
+    );
     expect(generationConfig.thinkingConfig).toEqual({ thinkingBudget: 0 });
     expect(generationConfig.temperature).toBe(0);
   });

--- a/packages/core/src/goals/goalJudge.ts
+++ b/packages/core/src/goals/goalJudge.ts
@@ -25,10 +25,16 @@ user-provided condition is satisfied.
 Your response MUST be a JSON object with one of these shapes:
 - {"ok": true, "reason": "<quote evidence from the transcript that satisfies the condition>"}
 - {"ok": false, "reason": "<quote what is missing or what blocks the condition>"}
+- {"ok": false, "impossible": true, "reason": "<explain why the condition can never be satisfied>"}
 
 Always include a "reason" field, quoting specific text from the transcript
 whenever possible. If the transcript does not contain clear evidence that the
-condition is satisfied, return {"ok": false, "reason": "insufficient evidence in transcript"}.`;
+condition is satisfied, return {"ok": false, "reason": "insufficient evidence in transcript"}.
+Only use {"ok": false, "impossible": true} when the condition is genuinely
+unachievable in this session: for example, it is self-contradictory, depends on
+an unavailable resource or capability, or the assistant has exhausted reasonable
+approaches and the transcript confirms there is no path forward. Do not use it
+just because progress is slow or evidence is currently missing.`;
 
 /**
  * Wraps the raw user condition into a transcript-grounded question so the
@@ -46,6 +52,7 @@ const RESPONSE_SCHEMA: Schema = {
   properties: {
     ok: { type: 'BOOLEAN' as unknown as Schema['type'] },
     reason: { type: 'STRING' as unknown as Schema['type'] },
+    impossible: { type: 'BOOLEAN' as unknown as Schema['type'] },
   },
   required: ['ok', 'reason'],
 };
@@ -53,6 +60,7 @@ const RESPONSE_SCHEMA: Schema = {
 export interface JudgeResult {
   ok: boolean;
   reason: string;
+  impossible?: boolean;
 }
 
 const JUDGE_REASON_FALLBACK =
@@ -328,7 +336,12 @@ function parseJudgeReply(text: string): JudgeResult | null {
       : ok
         ? 'Goal condition reported as met.'
         : JUDGE_REASON_FALLBACK;
-  return { ok, reason: reasonText };
+  const impossible = (payload as { impossible?: unknown }).impossible === true;
+  return {
+    ok,
+    reason: reasonText,
+    ...(impossible && !ok ? { impossible: true } : {}),
+  };
 }
 
 function stripCodeFence(s: string): string {


### PR DESCRIPTION
## Summary

- What changed: add an impossible judge outcome for /goal, terminate that goal as failed, and render/restore the failed terminal state in the CLI.
- Why it changed: impossible goals should clear instead of looping until the iteration cap.
- Reviewer focus: judge prompt/schema semantics and failed terminal UI wording.

## Validation

- Commands run:
  
  cd packages/core && npx vitest run src/goals/goalJudge.test.ts src/goals/goalHook.test.ts
  cd packages/cli && npx vitest run src/ui/components/messages/GoalStatusMessage.test.tsx src/ui/commands/goalCommand.test.ts src/ui/utils/restoreGoal.test.ts
  npm run build
  npm run typecheck
  git diff --check

- Observed result: targeted tests passed, build passed, typecheck passed. npm run build reported an existing lint warning in packages/vscode-ide-companion/src/utils/editorGroupUtils.ts.

## Scope / Risk

- Main risk or tradeoff: the judge prompt may classify a goal as impossible too aggressively; the prompt limits this to genuinely unachievable cases.
- Not covered / not validated: no interactive TUI screenshot/video was captured.
- Breaking changes / migration notes: none expected.

## Linked Issues / Bugs

Related #4228