### PR TITLE
feat(serve): add daemon-stamped client identity

### DIFF
--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -180,7 +180,7 @@ describe('qwen serve — CORS browser-origin denial', () => {
 });
 
 describe('qwen serve — capabilities envelope', () => {
-  it('advertises all 10 Stage 1 features', async () => {
+  it('advertises all Stage 1 features', async () => {
     const caps = await client.capabilities();
     expect(caps.v).toBe(1);
     expect(caps.mode).toBe('http-bridge');
@@ -192,11 +192,14 @@ describe('qwen serve — capabilities envelope', () => {
       'capabilities',
       'session_create',
       'session_scope_override',
+      'session_load',
+      'unstable_session_resume',
       'session_list',
       'session_prompt',
       'session_cancel',
       'session_events',
       'session_set_model',
+      'client_identity',
       'permission_vote',
     ]);
   });

--- a/packages/cli/src/serve/capabilities.ts
+++ b/packages/cli/src/serve/capabilities.ts
@@ -37,6 +37,7 @@ export const SERVE_CAPABILITY_REGISTRY = {
   session_cancel: { since: 'v1' },
   session_events: { since: 'v1' },
   session_set_model: { since: 'v1' },
+  client_identity: { since: 'v1' },
   permission_vote: { since: 'v1' },
 } as const satisfies Record<string, ServeCapabilityDescriptor>;
 

--- a/packages/cli/src/serve/httpAcpBridge.test.ts
+++ b/packages/cli/src/serve/httpAcpBridge.test.ts
@@ -37,6 +37,7 @@ import type {
 } from '@agentclientprotocol/sdk';
 import {
   createHttpAcpBridge,
+  InvalidClientIdError,
   InvalidPermissionOptionError,
   InvalidSessionScopeError,
   MAX_WORKSPACE_PATH_LENGTH,
@@ -280,6 +281,7 @@ describe('createHttpAcpBridge', () => {
     expect(session.sessionId).toBe(SESS_A);
     expect(session.workspaceCwd).toBe(WS_A);
     expect(session.attached).toBe(false);
+    expect(session.clientId).toMatch(/^client_/);
     expect(bridge.sessionCount).toBe(1);
     expect(handles).toHaveLength(1);
     expect(handles[0]?.agent.newSessionCalls[0]?.cwd).toBe(WS_A);
@@ -303,10 +305,34 @@ describe('createHttpAcpBridge', () => {
     expect(first.sessionId).toBe(second.sessionId);
     expect(first.attached).toBe(false);
     expect(second.attached).toBe(true);
+    expect(first.clientId).toMatch(/^client_/);
+    expect(second.clientId).toMatch(/^client_/);
+    expect(second.clientId).not.toBe(first.clientId);
     expect(handles).toHaveLength(1); // only one child spawned
     expect(bridge.sessionCount).toBe(1);
 
     await bridge.shutdown();
+  });
+
+  it('reuses an echoed daemon-issued client id on attach', async () => {
+    const handles: ChannelHandle[] = [];
+    const factory: ChannelFactory = async () => {
+      const h = makeChannel();
+      handles.push(h);
+      return h.channel;
+    };
+    const bridge = makeBridge({ channelFactory: factory });
+    const first = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+    const second = await bridge.spawnOrAttach({
+      workspaceCwd: WS_A,
+      clientId: first.clientId,
+    });
+
+    expect(second.attached).toBe(true);
+    expect(second.clientId).toBe(first.clientId);
+
+    await bridge.shutdown();
+    expect(handles[0]?.killed).toBe(true);
   });
 
   it('loads an existing ACP session and registers it for daemon routes', async () => {
@@ -329,6 +355,7 @@ describe('createHttpAcpBridge', () => {
       sessionId: 'persisted-1',
       workspaceCwd: WS_A,
       attached: false,
+      clientId: expect.stringMatching(/^client_/),
       state: { configOptions: [] },
     });
     expect(handles[0]?.agent.loadSessionCalls).toEqual([
@@ -428,6 +455,7 @@ describe('createHttpAcpBridge', () => {
       sessionId: 'persisted-2',
       workspaceCwd: WS_A,
       attached: false,
+      clientId: expect.stringMatching(/^client_/),
       state: { modes: null },
     });
     expect(handles[0]?.agent.loadSessionCalls).toHaveLength(0);
@@ -469,8 +497,10 @@ describe('createHttpAcpBridge', () => {
       sessionId: 'persisted-3',
       workspaceCwd: WS_A,
       attached: true,
+      clientId: expect.stringMatching(/^client_/),
       state: { _meta: { tag: 'restored-foo' } },
     });
+    expect(attached.clientId).not.toBe(loaded.clientId);
     expect(handles[0]?.agent.loadSessionCalls).toHaveLength(1);
     expect(handles[0]?.agent.resumeSessionCalls).toHaveLength(0);
 
@@ -2044,16 +2074,55 @@ describe('createHttpAcpBridge', () => {
       const it = iter[Symbol.asyncIterator]();
       const reqEvt = (await it.next()).value!;
       const requestId = (reqEvt.data as { requestId: string }).requestId;
-      bridge.respondToPermission(requestId, {
-        outcome: { outcome: 'selected', optionId: 'allow' },
-      });
+      bridge.respondToPermission(
+        requestId,
+        {
+          outcome: { outcome: 'selected', optionId: 'allow' },
+        },
+        { clientId: session.clientId },
+      );
 
       const resolvedEvt = (await it.next()).value!;
       expect(resolvedEvt.type).toBe('permission_resolved');
+      expect(resolvedEvt.originatorClientId).toBe(session.clientId);
       expect(resolvedEvt.data).toMatchObject({
         requestId,
         outcome: { outcome: 'selected', optionId: 'allow' },
       });
+
+      subAbort.abort();
+      await bridge.shutdown();
+    });
+
+    it('rejects permission votes with unregistered client ids', async () => {
+      const { bridge, session, conn } = await setupForPermission();
+
+      const subAbort = new AbortController();
+      const iter = bridge.subscribeEvents(session.sessionId, {
+        signal: subAbort.signal,
+      });
+      void (
+        conn as unknown as {
+          requestPermission(p: unknown): Promise<unknown>;
+        }
+      ).requestPermission({
+        sessionId: session.sessionId,
+        toolCall: { toolCallId: 'tc-1', title: 'x' },
+        options: [{ optionId: 'allow', name: 'Allow', kind: 'allow_once' }],
+      });
+
+      const it = iter[Symbol.asyncIterator]();
+      const reqEvt = (await it.next()).value!;
+      const requestId = (reqEvt.data as { requestId: string }).requestId;
+      expect(() =>
+        bridge.respondToPermission(
+          requestId,
+          {
+            outcome: { outcome: 'selected', optionId: 'allow' },
+          },
+          { clientId: 'client-not-issued' },
+        ),
+      ).toThrow(InvalidClientIdError);
 
       subAbort.abort();
       await bridge.shutdown();
@@ -3267,6 +3336,43 @@ describe('createHttpAcpBridge', () => {
         modelId: 'qwen3-coder',
       });
       abort.abort();
+      await bridge.shutdown();
+    });
+
+    it('stamps model events with the trusted originator client id', async () => {
+      const { bridge, session } = await setup();
+      const abort = new AbortController();
+      const iter = bridge.subscribeEvents(session.sessionId, {
+        signal: abort.signal,
+      });
+      await bridge.setSessionModel(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          modelId: 'qwen3-coder',
+        },
+        { clientId: session.clientId },
+      );
+      const it = iter[Symbol.asyncIterator]();
+      const next = await it.next();
+      expect(next.value?.type).toBe('model_switched');
+      expect(next.value?.originatorClientId).toBe(session.clientId);
+      abort.abort();
+      await bridge.shutdown();
+    });
+
+    it('rejects unregistered client ids on session-scoped requests', async () => {
+      const { bridge, session } = await setup();
+      await expect(
+        bridge.setSessionModel(
+          session.sessionId,
+          {
+            sessionId: session.sessionId,
+            modelId: 'qwen3-coder',
+          },
+          { clientId: 'client-not-issued' },
+        ),
+      ).rejects.toBeInstanceOf(InvalidClientIdError);
       await bridge.shutdown();
     });
 

--- a/packages/cli/src/serve/httpAcpBridge.test.ts
+++ b/packages/cli/src/serve/httpAcpBridge.test.ts
@@ -335,6 +335,69 @@ describe('createHttpAcpBridge', () => {
     expect(handles[0]?.killed).toBe(true);
   });
 
+  it('detachClient unregisters only the detached client id', async () => {
+    const bridge = makeBridge({
+      channelFactory: async () => makeChannel().channel,
+    });
+    const first = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+    const second = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+    await bridge.detachClient(second.sessionId, second.clientId);
+
+    await expect(
+      bridge.sendPrompt(
+        first.sessionId,
+        {
+          sessionId: first.sessionId,
+          prompt: [{ type: 'text', text: 'still valid' }],
+        },
+        undefined,
+        { clientId: first.clientId },
+      ),
+    ).resolves.toMatchObject({ stopReason: 'end_turn' });
+    await expect(
+      bridge.sendPrompt(
+        second.sessionId,
+        {
+          sessionId: second.sessionId,
+          prompt: [{ type: 'text', text: 'detached' }],
+        },
+        undefined,
+        { clientId: second.clientId },
+      ),
+    ).rejects.toBeInstanceOf(InvalidClientIdError);
+
+    await bridge.shutdown();
+  });
+
+  it('detachClient preserves an echoed client id owned by an earlier attach', async () => {
+    const bridge = makeBridge({
+      channelFactory: async () => makeChannel().channel,
+    });
+    const first = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+    const second = await bridge.spawnOrAttach({
+      workspaceCwd: WS_A,
+      clientId: first.clientId,
+    });
+    expect(second.clientId).toBe(first.clientId);
+
+    await bridge.detachClient(second.sessionId, second.clientId);
+
+    await expect(
+      bridge.sendPrompt(
+        first.sessionId,
+        {
+          sessionId: first.sessionId,
+          prompt: [{ type: 'text', text: 'still valid' }],
+        },
+        undefined,
+        { clientId: first.clientId },
+      ),
+    ).resolves.toMatchObject({ stopReason: 'end_turn' });
+
+    await bridge.shutdown();
+  });
+
   it('loads an existing ACP session and registers it for daemon routes', async () => {
     const handles: ChannelHandle[] = [];
     const factory: ChannelFactory = async () => {
@@ -2139,6 +2202,34 @@ describe('createHttpAcpBridge', () => {
       await bridge.shutdown();
     });
 
+    it('rejects unknown permission votes with unregistered client ids', async () => {
+      const bridge = makeBridge({
+        channelFactory: async () => makeChannel().channel,
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+      expect(() =>
+        bridge.respondToPermission(
+          'does-not-exist',
+          {
+            outcome: { outcome: 'cancelled' },
+          },
+          { clientId: 'client-not-issued' },
+        ),
+      ).toThrow(InvalidClientIdError);
+      expect(
+        bridge.respondToPermission(
+          'does-not-exist',
+          {
+            outcome: { outcome: 'cancelled' },
+          },
+          { clientId: session.clientId },
+        ),
+      ).toBe(false);
+
+      await bridge.shutdown();
+    });
+
     it('cancelSession resolves outstanding permissions as cancelled', async () => {
       const { bridge, session, conn } = await setupForPermission();
 
@@ -3363,6 +3454,22 @@ describe('createHttpAcpBridge', () => {
 
     it('rejects unregistered client ids on session-scoped requests', async () => {
       const { bridge, session } = await setup();
+      await expect(
+        bridge.sendPrompt(
+          session.sessionId,
+          {
+            sessionId: session.sessionId,
+            prompt: [{ type: 'text', text: 'hi' }],
+          },
+          undefined,
+          { clientId: 'client-not-issued' },
+        ),
+      ).rejects.toBeInstanceOf(InvalidClientIdError);
+      await expect(
+        bridge.cancelSession(session.sessionId, undefined, {
+          clientId: 'client-not-issued',
+        }),
+      ).rejects.toBeInstanceOf(InvalidClientIdError);
       await expect(
         bridge.setSessionModel(
           session.sessionId,

--- a/packages/cli/src/serve/httpAcpBridge.ts
+++ b/packages/cli/src/serve/httpAcpBridge.ts
@@ -267,9 +267,12 @@ export interface HttpAcpBridge {
    * spawn-owner's disconnect-reaper would never run again — even if
    * the attacher themselves disconnected (tanzhenxin issue 2). This
    * is the symmetric "I bumped, but my socket died so the bump is
-   * fictitious" cleanup.
+   * fictitious" cleanup. When `clientId` is provided, the daemon-issued
+   * identity reference acquired by that failed attach is released too;
+   * echoed ids are ref-counted so a failed reconnect does not revoke an
+   * older live owner of the same id.
    */
-  detachClient(sessionId: string): Promise<void>;
+  detachClient(sessionId: string, clientId?: string): Promise<void>;
 
   /** Test/inspection hook: number of live sessions. */
   readonly sessionCount: number;
@@ -674,7 +677,7 @@ interface SessionEntry {
    * clients may echo one through `X-Qwen-Client-Id`; the bridge only treats
    * it as trusted originator metadata if it appears in this set.
    */
-  clientIds: Set<string>;
+  clientIds: Map<string, number>;
   /**
    * Originator for the prompt currently running on this session. ACP enforces
    * one active prompt per session, and this bridge FIFO-serializes prompts, so
@@ -1338,11 +1341,26 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     requestedClientId?: string,
   ): string => {
     if (requestedClientId && entry.clientIds.has(requestedClientId)) {
+      entry.clientIds.set(
+        requestedClientId,
+        (entry.clientIds.get(requestedClientId) ?? 0) + 1,
+      );
       return requestedClientId;
     }
     const clientId = createClientId();
-    entry.clientIds.add(clientId);
+    entry.clientIds.set(clientId, 1);
     return clientId;
+  };
+
+  const unregisterClient = (entry: SessionEntry, clientId?: string): void => {
+    if (clientId === undefined) return;
+    const count = entry.clientIds.get(clientId);
+    if (count === undefined) return;
+    if (count <= 1) {
+      entry.clientIds.delete(clientId);
+    } else {
+      entry.clientIds.set(clientId, count - 1);
+    }
   };
 
   const resolveTrustedClientId = (
@@ -1354,6 +1372,13 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       throw new InvalidClientIdError(entry.sessionId, clientId);
     }
     return clientId;
+  };
+
+  const resolveAnyTrustedClientId = (clientId: string): string => {
+    for (const entry of byId.values()) {
+      if (entry.clientIds.has(clientId)) return clientId;
+    }
+    throw new InvalidClientIdError('unknown', clientId);
   };
 
   const registerPending = (p: PendingPermission) => {
@@ -1904,7 +1929,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       promptQueue: Promise.resolve(),
       modelChangeQueue: Promise.resolve(),
       pendingPermissionIds: new Set(),
-      clientIds: new Set(),
+      clientIds: new Map(),
       attachCount: 0,
       spawnOwnerWantedKill: false,
     };
@@ -2406,7 +2431,6 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         if (signal?.aborted) {
           throw new DOMException('Prompt aborted', 'AbortError');
         }
-        const previousOriginator = entry.activePromptOriginatorClientId;
         if (originatorClientId === undefined) {
           delete entry.activePromptOriginatorClientId;
         } else {
@@ -2415,11 +2439,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         const promptPromise = entry.connection
           .prompt(normalized)
           .finally(() => {
-            if (previousOriginator === undefined) {
-              delete entry.activePromptOriginatorClientId;
-            } else {
-              entry.activePromptOriginatorClientId = previousOriginator;
-            }
+            delete entry.activePromptOriginatorClientId;
           });
 
         // Race against channel termination: if the underlying transport
@@ -2503,6 +2523,9 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       const entry = byId.get(sessionId);
       if (!entry) throw new SessionNotFoundError(sessionId);
       resolveTrustedClientId(entry, context?.clientId);
+      // Validation-only: cancellation resolves permissions as system
+      // cancellations, so those generated events intentionally omit an
+      // originator client id.
       // ACP spec: cancelling a prompt MUST resolve outstanding
       // requestPermission calls with outcome.cancelled. Do this *before*
       // forwarding the notification so the agent's wind-down sees the
@@ -2537,10 +2560,14 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     respondToPermission(requestId, response, context) {
       const pending = pendingPermissions.get(requestId);
       let originatorClientId: string | undefined;
-      if (pending && context?.clientId !== undefined) {
+      if (context?.clientId !== undefined && !pending) {
+        resolveAnyTrustedClientId(context.clientId);
+      } else if (pending && context?.clientId !== undefined) {
         const entry = byId.get(pending.sessionId);
         if (entry) {
           originatorClientId = resolveTrustedClientId(entry, context.clientId);
+        } else {
+          resolveAnyTrustedClientId(context.clientId);
         }
       }
       // BkwQI: validate the voter's optionId against the original
@@ -2765,7 +2792,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       }
     },
 
-    async detachClient(sessionId) {
+    async detachClient(sessionId, clientId) {
       // tanzhenxin issue 2: the BQ9tV `attachCount` race guard is
       // monotonic — once any attach bumps it, the spawn-owner's
       // disconnect-reaper becomes a permanent no-op even if the
@@ -2785,6 +2812,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       const entry = byId.get(sessionId);
       if (!entry) return;
       if (entry.attachCount > 0) entry.attachCount--;
+      unregisterClient(entry, clientId);
       if (
         entry.spawnOwnerWantedKill &&
         entry.attachCount === 0 &&

--- a/packages/cli/src/serve/httpAcpBridge.ts
+++ b/packages/cli/src/serve/httpAcpBridge.ts
@@ -74,6 +74,12 @@ export interface BridgeSpawnRequest {
   /** Optional explicit model service id; falls back to settings default. */
   modelServiceId?: string;
   /**
+   * Optional echo of a daemon-issued client id from a previous attach to the
+   * same live session. Unknown ids are ignored on create/attach and replaced
+   * with a freshly stamped id.
+   */
+  clientId?: string;
+  /**
    * Per-request override for `sessionScope`. When set, takes precedence
    * over the bridge-wide default (`BridgeOptions.sessionScope`, which
    * direct embeds may set at construction time; the production daemon
@@ -96,6 +102,12 @@ export interface BridgeSession {
   workspaceCwd: string;
   /** True if this attach reused an existing session under `sessionScope: 'single'`. */
   attached: boolean;
+  /**
+   * Opaque daemon-issued id for the attaching HTTP client. Subsequent
+   * session-scoped requests may echo it so daemon events can identify the
+   * initiating client without trusting request bodies.
+   */
+  clientId?: string;
 }
 
 export interface BridgeRestoreSessionRequest {
@@ -103,6 +115,8 @@ export interface BridgeRestoreSessionRequest {
   sessionId: string;
   /** Absolute path to the workspace root the child inherits as cwd. */
   workspaceCwd: string;
+  /** Optional echo of a daemon-issued client id for this session. */
+  clientId?: string;
 }
 
 export type BridgeSessionState = LoadSessionResponse | ResumeSessionResponse;
@@ -116,6 +130,11 @@ export interface BridgeRestoredSession extends BridgeSession {
 export interface BridgeSessionSummary {
   sessionId: string;
   workspaceCwd: string;
+}
+
+export interface BridgeClientRequestContext {
+  /** Daemon-issued client id echoed through the HTTP transport header. */
+  clientId?: string;
 }
 
 export interface HttpAcpBridge {
@@ -157,6 +176,7 @@ export interface HttpAcpBridge {
     sessionId: string,
     req: PromptRequest,
     signal?: AbortSignal,
+    context?: BridgeClientRequestContext,
   ): Promise<PromptResponse>;
 
   /**
@@ -165,7 +185,11 @@ export interface HttpAcpBridge {
    * active `prompt()` with a `cancelled` stop reason. Throws
    * `SessionNotFoundError` when the id is unknown.
    */
-  cancelSession(sessionId: string, req?: CancelNotification): Promise<void>;
+  cancelSession(
+    sessionId: string,
+    req?: CancelNotification,
+    context?: BridgeClientRequestContext,
+  ): Promise<void>;
 
   /**
    * Subscribe to the session's event stream. Returns an AsyncIterable that
@@ -186,6 +210,7 @@ export interface HttpAcpBridge {
   respondToPermission(
     requestId: string,
     response: RequestPermissionResponse,
+    context?: BridgeClientRequestContext,
   ): boolean;
 
   /**
@@ -204,6 +229,7 @@ export interface HttpAcpBridge {
   setSessionModel(
     sessionId: string,
     req: SetSessionModelRequest,
+    context?: BridgeClientRequestContext,
   ): Promise<SetSessionModelResponse>;
 
   /**
@@ -376,6 +402,23 @@ export class WorkspaceMismatchError extends Error {
     this.name = 'WorkspaceMismatchError';
     this.bound = bound;
     this.requested = safeRequested;
+  }
+}
+
+/**
+ * Thrown when an HTTP caller echoes a client id that this daemon did not
+ * issue for the addressed live session. Create/attach calls may receive a
+ * fresh id instead; state-changing session routes reject unknown ids so
+ * originator metadata stays daemon-stamped rather than caller-asserted.
+ */
+export class InvalidClientIdError extends Error {
+  readonly sessionId: string;
+  readonly clientId: string;
+  constructor(sessionId: string, clientId: string) {
+    super(`Client id "${clientId}" is not registered for session ${sessionId}`);
+    this.name = 'InvalidClientIdError';
+    this.sessionId = sessionId;
+    this.clientId = clientId;
   }
 }
 
@@ -627,6 +670,18 @@ interface SessionEntry {
    */
   pendingPermissionIds: Set<string>;
   /**
+   * Daemon-issued client ids currently known for this live session. HTTP
+   * clients may echo one through `X-Qwen-Client-Id`; the bridge only treats
+   * it as trusted originator metadata if it appears in this set.
+   */
+  clientIds: Set<string>;
+  /**
+   * Originator for the prompt currently running on this session. ACP enforces
+   * one active prompt per session, and this bridge FIFO-serializes prompts, so
+   * inline session updates / permission requests can safely inherit this id.
+   */
+  activePromptOriginatorClientId?: string;
+  /**
    * Count of times `spawnOrAttach` has returned `attached: true` for
    * this entry — i.e. a second-or-subsequent client claimed this
    * session under `sessionScope: 'single'`. Used by the disconnect-
@@ -841,6 +896,9 @@ class BridgeClient implements Client {
           toolCall: params.toolCall,
           options: params.options,
         },
+        ...(entry.activePromptOriginatorClientId
+          ? { originatorClientId: entry.activePromptOriginatorClientId }
+          : {}),
       });
       if (!published) {
         // Roll back the pending registration and resolve cancelled.
@@ -875,7 +933,13 @@ class BridgeClient implements Client {
     const events =
       entry?.events ?? this.resolvePendingRestoreEvents(params.sessionId);
     if (!events) return;
-    events.publish({ type: 'session_update', data: params });
+    events.publish({
+      type: 'session_update',
+      data: params,
+      ...(entry?.activePromptOriginatorClientId
+        ? { originatorClientId: entry.activePromptOriginatorClientId }
+        : {}),
+    });
   }
 
   async writeTextFile(
@@ -1267,6 +1331,31 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
   // the ring, then promote the same bus into the registered SessionEntry.
   const pendingRestoreEvents = new Map<string, EventBus>();
 
+  const createClientId = (): string => `client_${randomUUID()}`;
+
+  const registerClient = (
+    entry: SessionEntry,
+    requestedClientId?: string,
+  ): string => {
+    if (requestedClientId && entry.clientIds.has(requestedClientId)) {
+      return requestedClientId;
+    }
+    const clientId = createClientId();
+    entry.clientIds.add(clientId);
+    return clientId;
+  };
+
+  const resolveTrustedClientId = (
+    entry: SessionEntry,
+    clientId?: string,
+  ): string | undefined => {
+    if (clientId === undefined) return undefined;
+    if (!entry.clientIds.has(clientId)) {
+      throw new InvalidClientIdError(entry.sessionId, clientId);
+    }
+    return clientId;
+  };
+
   const registerPending = (p: PendingPermission) => {
     const entry = byId.get(p.sessionId);
     if (!entry) {
@@ -1288,6 +1377,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
   const resolvePending = (
     requestId: string,
     response: RequestPermissionResponse,
+    originatorClientId?: string,
   ): boolean => {
     const pending = pendingPermissions.get(requestId);
     if (!pending) return false;
@@ -1302,6 +1392,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         entry.events.publish({
           type: 'permission_resolved',
           data: { requestId, outcome: response.outcome },
+          ...(originatorClientId ? { originatorClientId } : {}),
         });
       } catch {
         /* bus closed during shutdown */
@@ -1539,6 +1630,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
   async function doSpawn(
     modelServiceId: string | undefined,
     effectiveScope: 'single' | 'thread',
+    requestedClientId?: string,
   ): Promise<BridgeSession> {
     // #3803 §02: get-or-create the daemon's single channel, then call
     // `connection.newSession()` on it. Sessions share the child's
@@ -1600,6 +1692,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       newSessionResp.sessionId,
       boundWorkspace,
     );
+    const clientId = registerClient(entry, requestedClientId);
     // `defaultEntry` is the single-scope attach target — only sessions
     // SPAWNED UNDER `'single'` may claim it. A thread-scope spawn must
     // never become the attach target, otherwise a later omitted-scope
@@ -1615,12 +1708,15 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     // transportClosedReject, publish model_switched on success,
     // model_switch_failed on failure, don't tear down the session).
     if (modelServiceId) {
-      await applyModelServiceId(entry, modelServiceId, initTimeoutMs).catch(
-        () => {
-          // Already published `model_switch_failed`; session stays
-          // operational on the agent's default model.
-        },
-      );
+      await applyModelServiceId(
+        entry,
+        modelServiceId,
+        initTimeoutMs,
+        clientId,
+      ).catch(() => {
+        // Already published `model_switch_failed`; session stays
+        // operational on the agent's default model.
+      });
     }
 
     // Bd1zc: re-check that the entry is still live before returning.
@@ -1640,6 +1736,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       sessionId: entry.sessionId,
       workspaceCwd: entry.workspaceCwd,
       attached: false,
+      clientId,
     };
   }
 
@@ -1661,6 +1758,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     entry: SessionEntry,
     modelId: string,
     timeoutMs: number,
+    originatorClientId?: string,
   ): Promise<void> {
     const conn = entry.connection as unknown as {
       unstable_setSessionModel(p: {
@@ -1690,6 +1788,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         entry.events.publish({
           type: 'model_switched',
           data: { sessionId: entry.sessionId, modelId },
+          ...(originatorClientId ? { originatorClientId } : {}),
         });
       } catch (err) {
         // Surface the failure to ALL attached clients, not just the
@@ -1702,6 +1801,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
             requestedModelId: modelId,
             error: err instanceof Error ? err.message : String(err),
           },
+          ...(originatorClientId ? { originatorClientId } : {}),
         });
         throw err;
       }
@@ -1804,6 +1904,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       promptQueue: Promise.resolve(),
       modelChangeQueue: Promise.resolve(),
       pendingPermissionIds: new Set(),
+      clientIds: new Set(),
       attachCount: 0,
       spawnOwnerWantedKill: false,
     };
@@ -1855,10 +1956,12 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     const existing = byId.get(req.sessionId);
     if (existing) {
       existing.attachCount++;
+      const clientId = registerClient(existing, req.clientId);
       return {
         sessionId: existing.sessionId,
         workspaceCwd: existing.workspaceCwd,
         attached: true,
+        clientId,
         // Late attachers get the same ACP state the original restore
         // caller saw; spawn-only sessions don't carry a state payload.
         state: existing.restoreState ?? {},
@@ -1913,7 +2016,11 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       // when the IIFE registered the entry. Spread `restored` so the
       // ACP state propagates to coalesced waiters (BQ9tV-equivalent
       // for restore waiter consistency).
-      return { ...restored, attached: true };
+      return {
+        ...restored,
+        attached: true,
+        clientId: registerClient(entry, req.clientId),
+      };
     }
 
     if (
@@ -2023,10 +2130,12 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         // in flight. Coalescers must not bump attachCount themselves
         // (they read it off the registered entry on the next tick).
         racedEntry.attachCount += 1 + coalesceState.count;
+        const clientId = registerClient(racedEntry, req.clientId);
         return {
           sessionId: racedEntry.sessionId,
           workspaceCwd: racedEntry.workspaceCwd,
           attached: true,
+          clientId,
           state: racedEntry.restoreState ?? {},
         };
       }
@@ -2038,6 +2147,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         restoreEvents,
       );
       entry.restoreState = state;
+      const clientId = registerClient(entry, req.clientId);
       // Fold synchronous coalesce reservations into the new entry's
       // `attachCount`. By this point all coalescers that beat us must
       // have hit the inFlightRestores branch and bumped
@@ -2057,6 +2167,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         sessionId: entry.sessionId,
         workspaceCwd: entry.workspaceCwd,
         attached: false,
+        clientId,
         state,
       };
     })().finally(() => {
@@ -2149,6 +2260,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
           // race is "bump runs before any await inside this
           // microtask," which is what we get here.
           existing.attachCount++;
+          const clientId = registerClient(existing, req.clientId);
           // If the caller passed a modelServiceId on attach, the session
           // may currently be running a DIFFERENT model. Honor the request
           // by issuing setSessionModel — same call we'd use on
@@ -2168,12 +2280,14 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
               existing,
               req.modelServiceId,
               initTimeoutMs,
+              clientId,
             ).catch(() => {});
           }
           return {
             sessionId: existing.sessionId,
             workspaceCwd: existing.workspaceCwd,
             attached: true,
+            clientId,
           };
         }
         // Coalesce: if another caller is already mid-spawn for this same
@@ -2211,6 +2325,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
               'the agent child likely crashed during initialization — retry to spawn a new session',
             );
           }
+          const clientId = registerClient(attachedEntry, req.clientId);
           if (req.modelServiceId) {
             // Same swallow as above — we picked up an in-flight
             // spawn, the session is real, model-switch failure
@@ -2219,9 +2334,10 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
               attachedEntry,
               req.modelServiceId,
               initTimeoutMs,
+              clientId,
             ).catch(() => {});
           }
-          return { ...session, attached: true };
+          return { ...session, attached: true, clientId };
         }
       }
 
@@ -2236,7 +2352,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         throw new SessionLimitExceededError(maxSessions);
       }
 
-      const promise = doSpawn(req.modelServiceId, effectiveScope);
+      const promise = doSpawn(req.modelServiceId, effectiveScope, req.clientId);
       // Track in-flight spawns regardless of scope. Under `single`
       // this also serves the coalescing path above (a parallel
       // `spawnOrAttach` finds the entry and waits for the same
@@ -2265,9 +2381,13 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       }
     },
 
-    async sendPrompt(sessionId, req, signal) {
+    async sendPrompt(sessionId, req, signal, context) {
       const entry = byId.get(sessionId);
       if (!entry) throw new SessionNotFoundError(sessionId);
+      const originatorClientId = resolveTrustedClientId(
+        entry,
+        context?.clientId,
+      );
       // Pre-aborted: skip the queue entirely. Without this the prompt
       // chains onto promptQueue, waits its turn, and the FIFO worker
       // checks `signal.aborted` only AFTER reaching the head — wasted
@@ -2286,7 +2406,21 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         if (signal?.aborted) {
           throw new DOMException('Prompt aborted', 'AbortError');
         }
-        const promptPromise = entry.connection.prompt(normalized);
+        const previousOriginator = entry.activePromptOriginatorClientId;
+        if (originatorClientId === undefined) {
+          delete entry.activePromptOriginatorClientId;
+        } else {
+          entry.activePromptOriginatorClientId = originatorClientId;
+        }
+        const promptPromise = entry.connection
+          .prompt(normalized)
+          .finally(() => {
+            if (previousOriginator === undefined) {
+              delete entry.activePromptOriginatorClientId;
+            } else {
+              entry.activePromptOriginatorClientId = previousOriginator;
+            }
+          });
 
         // Race against channel termination: if the underlying transport
         // dies (child crashed, stream torn down) WHILE the prompt is in
@@ -2365,9 +2499,10 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       return result;
     },
 
-    async cancelSession(sessionId, req) {
+    async cancelSession(sessionId, req, context) {
       const entry = byId.get(sessionId);
       if (!entry) throw new SessionNotFoundError(sessionId);
+      resolveTrustedClientId(entry, context?.clientId);
       // ACP spec: cancelling a prompt MUST resolve outstanding
       // requestPermission calls with outcome.cancelled. Do this *before*
       // forwarding the notification so the agent's wind-down sees the
@@ -2399,7 +2534,15 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       return entry.events.subscribe(subOpts);
     },
 
-    respondToPermission(requestId, response) {
+    respondToPermission(requestId, response, context) {
+      const pending = pendingPermissions.get(requestId);
+      let originatorClientId: string | undefined;
+      if (pending && context?.clientId !== undefined) {
+        const entry = byId.get(pending.sessionId);
+        if (entry) {
+          originatorClientId = resolveTrustedClientId(entry, context.clientId);
+        }
+      }
       // BkwQI: validate the voter's optionId against the original
       // options the agent advertised. The route already enforces
       // "non-empty string" structurally; this layer enforces
@@ -2408,7 +2551,6 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       // `ProceedAlways*` when the prompt's `hideAlwaysAllow`
       // policy intentionally suppressed them).
       if (response.outcome.outcome === 'selected') {
-        const pending = pendingPermissions.get(requestId);
         if (
           pending &&
           !pending.allowedOptionIds.has(response.outcome.optionId)
@@ -2419,7 +2561,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
           );
         }
       }
-      return resolvePending(requestId, response);
+      return resolvePending(requestId, response, originatorClientId);
     },
 
     listWorkspaceSessions(workspaceCwd) {
@@ -2446,9 +2588,13 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       return out;
     },
 
-    async setSessionModel(sessionId, req) {
+    async setSessionModel(sessionId, req, context) {
       const entry = byId.get(sessionId);
       if (!entry) throw new SessionNotFoundError(sessionId);
+      const originatorClientId = resolveTrustedClientId(
+        entry,
+        context?.clientId,
+      );
       const normalized: SetSessionModelRequest = { ...req, sessionId };
       // The ACP SDK marks setSessionModel as unstable (not in spec yet); the
       // method on AgentSideConnection is `unstable_setSessionModel`. Cast
@@ -2518,6 +2664,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
               requestedModelId: req.modelId,
               error: err instanceof Error ? err.message : String(err),
             },
+            ...(originatorClientId ? { originatorClientId } : {}),
           });
         } catch {
           /* bus closed */
@@ -2528,6 +2675,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         entry.events.publish({
           type: 'model_switched',
           data: { sessionId: entry.sessionId, modelId: req.modelId },
+          ...(originatorClientId ? { originatorClientId } : {}),
         });
       } catch {
         /* bus closed */

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -132,7 +132,7 @@ interface FakeBridge extends HttpAcpBridge {
     sessionId: string;
     opts?: { requireZeroAttaches?: boolean };
   }>;
-  detachCalls: string[];
+  detachCalls: Array<{ sessionId: string; clientId?: string }>;
   permissionVotes: Array<{
     requestId: string;
     response: RequestPermissionResponse;
@@ -157,7 +157,7 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
     sessionId: string;
     opts?: { requireZeroAttaches?: boolean };
   }> = [];
-  const detachCalls: string[] = [];
+  const detachCalls: FakeBridge['detachCalls'] = [];
   const permissionVotes: FakeBridge['permissionVotes'] = [];
   const listCalls: string[] = [];
   const setModelCalls: FakeBridge['setModelCalls'] = [];
@@ -269,8 +269,11 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
     async killSession(sessionId, opts) {
       killCalls.push({ sessionId, opts });
     },
-    async detachClient(sessionId) {
-      detachCalls.push(sessionId);
+    async detachClient(sessionId, clientId) {
+      detachCalls.push({
+        sessionId,
+        ...(clientId !== undefined ? { clientId } : {}),
+      });
     },
     async shutdown() {
       shutdownCalls += 1;
@@ -1313,6 +1316,27 @@ describe('createServeApp', () => {
       expect(res.status).toBe(200);
       expect(bridge.permissionVotes[0]?.context).toEqual({
         clientId: 'client-1',
+      });
+    });
+
+    it('400 invalid_client_id when the bridge rejects permission voter', async () => {
+      const bridge = fakeBridge({
+        respondImpl: () => {
+          throw new InvalidClientIdError('session-A', 'client-unknown');
+        },
+      });
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/permission/req-1')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('X-Qwen-Client-Id', 'client-unknown')
+        .send({ outcome: { outcome: 'selected', optionId: 'allow' } });
+
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        code: 'invalid_client_id',
+        sessionId: 'session-A',
+        clientId: 'client-unknown',
       });
     });
 

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -28,6 +28,7 @@ import type {
   SetSessionModelResponse,
 } from '@agentclientprotocol/sdk';
 import {
+  InvalidClientIdError,
   InvalidPermissionOptionError,
   MAX_WORKSPACE_PATH_LENGTH,
   RestoreInProgressError,
@@ -35,6 +36,7 @@ import {
   SessionNotFoundError,
   WorkspaceMismatchError,
   type BridgeRestoredSession,
+  type BridgeClientRequestContext,
   type BridgeRestoreSessionRequest,
   type BridgeSession,
   type BridgeSessionSummary,
@@ -71,6 +73,7 @@ const EXPECTED_STAGE1_FEATURES = [
   'session_cancel',
   'session_events',
   'session_set_model',
+  'client_identity',
   'permission_vote',
 ] as const;
 
@@ -86,8 +89,13 @@ interface FakeBridgeOpts {
     sessionId: string,
     req: PromptRequest,
     signal?: AbortSignal,
+    context?: BridgeClientRequestContext,
   ) => Promise<PromptResponse>;
-  cancelImpl?: (sessionId: string, req?: CancelNotification) => Promise<void>;
+  cancelImpl?: (
+    sessionId: string,
+    req?: CancelNotification,
+    context?: BridgeClientRequestContext,
+  ) => Promise<void>;
   subscribeImpl?: (
     sessionId: string,
     opts?: SubscribeOptions,
@@ -95,11 +103,13 @@ interface FakeBridgeOpts {
   respondImpl?: (
     requestId: string,
     response: RequestPermissionResponse,
+    context?: BridgeClientRequestContext,
   ) => boolean;
   listImpl?: (workspaceCwd: string) => BridgeSessionSummary[];
   setModelImpl?: (
     sessionId: string,
     req: SetSessionModelRequest,
+    context?: BridgeClientRequestContext,
   ) => Promise<SetSessionModelResponse>;
 }
 
@@ -111,8 +121,13 @@ interface FakeBridge extends HttpAcpBridge {
     sessionId: string;
     req: PromptRequest;
     signal?: AbortSignal;
+    context?: BridgeClientRequestContext;
   }>;
-  cancelCalls: Array<{ sessionId: string; req?: CancelNotification }>;
+  cancelCalls: Array<{
+    sessionId: string;
+    req?: CancelNotification;
+    context?: BridgeClientRequestContext;
+  }>;
   killCalls: Array<{
     sessionId: string;
     opts?: { requireZeroAttaches?: boolean };
@@ -121,9 +136,14 @@ interface FakeBridge extends HttpAcpBridge {
   permissionVotes: Array<{
     requestId: string;
     response: RequestPermissionResponse;
+    context?: BridgeClientRequestContext;
   }>;
   listCalls: string[];
-  setModelCalls: Array<{ sessionId: string; req: SetSessionModelRequest }>;
+  setModelCalls: Array<{
+    sessionId: string;
+    req: SetSessionModelRequest;
+    context?: BridgeClientRequestContext;
+  }>;
   shutdownCalls: number;
 }
 
@@ -148,6 +168,7 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
       sessionId: `fake-${calls.length}`,
       workspaceCwd: req.workspaceCwd,
       attached: false,
+      clientId: `client-${calls.length}`,
     }));
   const loadImpl =
     opts.loadImpl ??
@@ -155,6 +176,7 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
       sessionId: req.sessionId,
       workspaceCwd: req.workspaceCwd,
       attached: false,
+      clientId: req.clientId ?? 'client-load',
       state: {},
     }));
   const resumeImpl =
@@ -163,6 +185,7 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
       sessionId: req.sessionId,
       workspaceCwd: req.workspaceCwd,
       attached: false,
+      clientId: req.clientId ?? 'client-resume',
       state: {},
     }));
   const promptImpl =
@@ -206,13 +229,18 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
       resumeCalls.push(req);
       return result;
     },
-    async sendPrompt(sessionId, req, signal) {
-      promptCalls.push({ sessionId, req, signal });
-      return promptImpl(sessionId, req, signal);
+    async sendPrompt(sessionId, req, signal, context) {
+      promptCalls.push({
+        sessionId,
+        req,
+        signal,
+        ...(context ? { context } : {}),
+      });
+      return promptImpl(sessionId, req, signal, context);
     },
-    async cancelSession(sessionId, req) {
-      cancelCalls.push({ sessionId, req });
-      return cancelImpl(sessionId, req);
+    async cancelSession(sessionId, req, context) {
+      cancelCalls.push({ sessionId, req, ...(context ? { context } : {}) });
+      return cancelImpl(sessionId, req, context);
     },
     subscribeEvents(sessionId, subOpts) {
       if (opts.subscribeImpl) return opts.subscribeImpl(sessionId, subOpts);
@@ -221,18 +249,22 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
         // empty
       })();
     },
-    respondToPermission(requestId, response) {
-      const accepted = respondImpl(requestId, response);
-      permissionVotes.push({ requestId, response });
+    respondToPermission(requestId, response, context) {
+      const accepted = respondImpl(requestId, response, context);
+      permissionVotes.push({
+        requestId,
+        response,
+        ...(context ? { context } : {}),
+      });
       return accepted;
     },
     listWorkspaceSessions(workspaceCwd) {
       listCalls.push(workspaceCwd);
       return listImpl(workspaceCwd);
     },
-    async setSessionModel(sessionId, req) {
-      setModelCalls.push({ sessionId, req });
-      return setModelImpl(sessionId, req);
+    async setSessionModel(sessionId, req, context) {
+      setModelCalls.push({ sessionId, req, ...(context ? { context } : {}) });
+      return setModelImpl(sessionId, req, context);
     },
     async killSession(sessionId, opts) {
       killCalls.push({ sessionId, opts });
@@ -569,6 +601,7 @@ describe('createServeApp', () => {
         sessionId: 'fake-0',
         workspaceCwd: '/work/a',
         attached: false,
+        clientId: 'client-0',
       });
       expect(bridge.calls).toEqual([
         { workspaceCwd: '/work/a', modelServiceId: 'qwen-prod' },
@@ -592,6 +625,41 @@ describe('createServeApp', () => {
           { workspaceCwd: '/work/a', sessionScope: scope },
         ]);
       }
+    });
+
+    it('forwards X-Qwen-Client-Id to the bridge on create/attach', async () => {
+      const bridge = fakeBridge({
+        spawnImpl: async (req) => ({
+          sessionId: 'fake-identity',
+          workspaceCwd: req.workspaceCwd,
+          attached: false,
+          clientId: req.clientId ?? 'client-new',
+        }),
+      });
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('X-Qwen-Client-Id', 'client-existing')
+        .send({ cwd: '/work/a' });
+      expect(res.status).toBe(200);
+      expect(res.body.clientId).toBe('client-existing');
+      expect(bridge.calls).toEqual([
+        { workspaceCwd: '/work/a', clientId: 'client-existing' },
+      ]);
+    });
+
+    it('400 invalid_client_id for malformed client id headers', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('X-Qwen-Client-Id', 'bad client id')
+        .send({ cwd: '/work/a' });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ code: 'invalid_client_id' });
+      expect(bridge.calls).toHaveLength(0);
     });
 
     it('400 invalid_session_scope when `sessionScope` is not "single"/"thread"', async () => {
@@ -691,6 +759,7 @@ describe('createServeApp', () => {
           sessionId: 'persisted-1',
           workspaceCwd: WS_BOUND,
           attached: false,
+          clientId: action === 'load' ? 'client-load' : 'client-resume',
           state: {},
         });
         const calls = action === 'load' ? bridge.loadCalls : bridge.resumeCalls;
@@ -706,6 +775,7 @@ describe('createServeApp', () => {
           sessionId: req.sessionId,
           workspaceCwd: req.workspaceCwd,
           attached: false,
+          clientId: 'client-load',
           state: { configOptions: [] },
         }),
       });
@@ -720,6 +790,27 @@ describe('createServeApp', () => {
       expect(bridge.loadCalls).toEqual([
         { sessionId: 'persisted-2', workspaceCwd: '/work/a' },
       ]);
+    });
+
+    it('passes client identity headers through to load/resume bridge calls', async () => {
+      for (const action of ['load', 'resume'] as const) {
+        const bridge = fakeBridge();
+        const app = createServeApp(baseOpts, undefined, { bridge });
+        const res = await request(app)
+          .post(`/session/persisted-1/${action}`)
+          .set('Host', `127.0.0.1:${baseOpts.port}`)
+          .set('X-Qwen-Client-Id', 'client-1')
+          .send({});
+        expect(res.status).toBe(200);
+        const calls = action === 'load' ? bridge.loadCalls : bridge.resumeCalls;
+        expect(calls).toEqual([
+          {
+            sessionId: 'persisted-1',
+            workspaceCwd: realpathSync.native(process.cwd()),
+            clientId: 'client-1',
+          },
+        ]);
+      }
     });
 
     it('400s malformed cwd before touching the bridge', async () => {
@@ -893,6 +984,40 @@ describe('createServeApp', () => {
       expect(bridge.promptCalls).toHaveLength(1);
       expect(bridge.promptCalls[0]?.sessionId).toBe('session-A');
       expect(bridge.promptCalls[0]?.req.sessionId).toBe('session-A');
+    });
+
+    it('passes client identity context into bridge.sendPrompt', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session/session-A/prompt')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('X-Qwen-Client-Id', 'client-1')
+        .send({ prompt: [{ type: 'text', text: 'hi' }] });
+      expect(res.status).toBe(200);
+      expect(bridge.promptCalls[0]?.context).toEqual({
+        clientId: 'client-1',
+      });
+    });
+
+    it('400 invalid_client_id when the bridge rejects prompt originator', async () => {
+      const bridge = fakeBridge({
+        promptImpl: async (sessionId) => {
+          throw new InvalidClientIdError(sessionId, 'client-unknown');
+        },
+      });
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session/session-A/prompt')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('X-Qwen-Client-Id', 'client-unknown')
+        .send({ prompt: [{ type: 'text', text: 'hi' }] });
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        code: 'invalid_client_id',
+        sessionId: 'session-A',
+        clientId: 'client-unknown',
+      });
     });
 
     it('400 when prompt body is missing', async () => {
@@ -1108,6 +1233,20 @@ describe('createServeApp', () => {
       expect(bridge.setModelCalls[0]?.req.modelId).toBe('qwen3-coder');
     });
 
+    it('passes client identity context into bridge.setSessionModel', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session/session-A/model')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('X-Qwen-Client-Id', 'client-1')
+        .send({ modelId: 'qwen3-coder' });
+      expect(res.status).toBe(200);
+      expect(bridge.setModelCalls[0]?.context).toEqual({
+        clientId: 'client-1',
+      });
+    });
+
     it('400 when modelId is missing', async () => {
       const bridge = fakeBridge();
       const app = createServeApp(baseOpts, undefined, { bridge });
@@ -1161,6 +1300,20 @@ describe('createServeApp', () => {
           response: { outcome: { outcome: 'selected', optionId: 'allow' } },
         },
       ]);
+    });
+
+    it('passes client identity context into permission votes', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/permission/req-1')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('X-Qwen-Client-Id', 'client-1')
+        .send({ outcome: { outcome: 'selected', optionId: 'allow' } });
+      expect(res.status).toBe(200);
+      expect(bridge.permissionVotes[0]?.context).toEqual({
+        clientId: 'client-1',
+      });
     });
 
     it('200 with cancelled outcome', async () => {
@@ -1266,6 +1419,19 @@ describe('createServeApp', () => {
       expect(bridge.cancelCalls).toHaveLength(1);
       expect(bridge.cancelCalls[0]?.sessionId).toBe('session-A');
       expect(bridge.cancelCalls[0]?.req?.sessionId).toBe('session-A');
+    });
+
+    it('passes client identity context into bridge.cancelSession', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session/session-A/cancel')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('X-Qwen-Client-Id', 'client-1');
+      expect(res.status).toBe(204);
+      expect(bridge.cancelCalls[0]?.context).toEqual({
+        clientId: 'client-1',
+      });
     });
 
     it('204 with empty body', async () => {

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -13,6 +13,7 @@ import { isLoopbackBind } from './loopbackBinds.js';
 import {
   canonicalizeWorkspace,
   createHttpAcpBridge,
+  InvalidClientIdError,
   InvalidPermissionOptionError,
   InvalidSessionScopeError,
   MAX_WORKSPACE_PATH_LENGTH,
@@ -293,10 +294,13 @@ export function createServeApp(
       }
       sessionScope = rawSessionScope;
     }
+    const clientId = parseClientIdHeader(req, res);
+    if (clientId === null) return;
     try {
       const session = await bridge.spawnOrAttach({
         workspaceCwd: cwd,
         modelServiceId,
+        ...(clientId !== undefined ? { clientId } : {}),
         ...(sessionScope !== undefined ? { sessionScope } : {}),
       });
       // Client may have disconnected during the 1–3s spawn window. If
@@ -369,11 +373,21 @@ export function createServeApp(
       const body = safeBody(req);
       const cwd = parseOptionalWorkspaceCwd(body, boundWorkspace, res);
       if (cwd === undefined) return;
+      const clientId = parseClientIdHeader(req, res);
+      if (clientId === null) return;
       try {
         const session =
           action === 'load'
-            ? await bridge.loadSession({ sessionId, workspaceCwd: cwd })
-            : await bridge.resumeSession({ sessionId, workspaceCwd: cwd });
+            ? await bridge.loadSession({
+                sessionId,
+                workspaceCwd: cwd,
+                ...(clientId !== undefined ? { clientId } : {}),
+              })
+            : await bridge.resumeSession({
+                sessionId,
+                workspaceCwd: cwd,
+                ...(clientId !== undefined ? { clientId } : {}),
+              });
         // Mirror the `POST /session` disconnect-cleanup path (see the
         // long comment above the matching `if (!res.writable)` there
         // for the rationale around `res.writable` vs `req.aborted` /
@@ -453,6 +467,11 @@ export function createServeApp(
       if (!res.writableEnded) abort.abort();
     };
     res.once('close', onResClose);
+    const clientId = parseClientIdHeader(req, res);
+    if (clientId === null) {
+      res.off('close', onResClose);
+      return;
+    }
     try {
       // SECURITY NOTE: this `...(body as object)` passthrough is
       // intentional — the bridge / ACP SDK ignores fields it
@@ -473,6 +492,7 @@ export function createServeApp(
           prompt,
         } as Parameters<HttpAcpBridge['sendPrompt']>[1],
         abort.signal,
+        clientId !== undefined ? { clientId } : undefined,
       );
       res.status(200).json(result);
     } catch (err) {
@@ -511,11 +531,17 @@ export function createServeApp(
   app.post('/session/:id/cancel', async (req, res) => {
     const sessionId = req.params['id'];
     const body = safeBody(req);
+    const clientId = parseClientIdHeader(req, res);
+    if (clientId === null) return;
     try {
-      await bridge.cancelSession(sessionId, {
-        ...(body as object),
+      await bridge.cancelSession(
         sessionId,
-      } as Parameters<HttpAcpBridge['cancelSession']>[1]);
+        {
+          ...(body as object),
+          sessionId,
+        } as Parameters<HttpAcpBridge['cancelSession']>[1],
+        clientId !== undefined ? { clientId } : undefined,
+      );
       res.status(204).end();
     } catch (err) {
       sendBridgeError(res, err, {
@@ -562,12 +588,18 @@ export function createServeApp(
       });
       return;
     }
+    const clientId = parseClientIdHeader(req, res);
+    if (clientId === null) return;
     try {
-      const response = await bridge.setSessionModel(sessionId, {
-        ...(body as object),
+      const response = await bridge.setSessionModel(
         sessionId,
-        modelId,
-      } as Parameters<HttpAcpBridge['setSessionModel']>[1]);
+        {
+          ...(body as object),
+          sessionId,
+          modelId,
+        } as Parameters<HttpAcpBridge['setSessionModel']>[1],
+        clientId !== undefined ? { clientId } : undefined,
+      );
       res.status(200).json(response);
     } catch (err) {
       sendBridgeError(res, err, {
@@ -588,12 +620,18 @@ export function createServeApp(
       });
       return;
     }
+    const clientId = parseClientIdHeader(req, res);
+    if (clientId === null) return;
     let accepted: boolean;
     try {
-      accepted = bridge.respondToPermission(requestId, {
-        ...(body as object),
-        outcome,
-      } as Parameters<HttpAcpBridge['respondToPermission']>[1]);
+      accepted = bridge.respondToPermission(
+        requestId,
+        {
+          ...(body as object),
+          outcome,
+        } as Parameters<HttpAcpBridge['respondToPermission']>[1],
+        clientId !== undefined ? { clientId } : undefined,
+      );
     } catch (err) {
       // BkwQI: voter's `optionId` wasn't in the option set the agent
       // originally offered (e.g. forging `ProceedAlways*` when the
@@ -904,6 +942,10 @@ const PROTOTYPE_POLLUTION_KEYS: ReadonlySet<string> = new Set([
   'prototype',
 ]);
 
+const CLIENT_ID_HEADER = 'x-qwen-client-id';
+const MAX_CLIENT_ID_LENGTH = 128;
+const CLIENT_ID_RE = /^[A-Za-z0-9._:-]+$/;
+
 /**
  * Coerce `req.body` into a safe `Record<string, unknown>` for route
  * handlers. Replaces the 5-site copy-pasted preamble
@@ -954,6 +996,23 @@ function parseOptionalWorkspaceCwd(
     return undefined;
   }
   return cwd;
+}
+
+function parseClientIdHeader(
+  req: import('express').Request,
+  res: import('express').Response,
+): string | undefined | null {
+  const raw = req.get(CLIENT_ID_HEADER);
+  if (raw === undefined || raw === '') return undefined;
+  if (raw.length > MAX_CLIENT_ID_LENGTH || !CLIENT_ID_RE.test(raw)) {
+    res.status(400).json({
+      error:
+        '`X-Qwen-Client-Id` must be a non-empty token of 128 characters or fewer',
+      code: 'invalid_client_id',
+    });
+    return null;
+  }
+  return raw;
 }
 
 function isValidOutcome(
@@ -1045,6 +1104,15 @@ function sendBridgeError(
 ): void {
   if (err instanceof SessionNotFoundError) {
     res.status(404).json({ error: err.message, sessionId: err.sessionId });
+    return;
+  }
+  if (err instanceof InvalidClientIdError) {
+    res.status(400).json({
+      error: err.message,
+      code: 'invalid_client_id',
+      sessionId: err.sessionId,
+      clientId: err.clientId,
+    });
     return;
   }
   if (err instanceof WorkspaceMismatchError) {

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -348,7 +348,7 @@ export function createServeApp(
           // subscribers). Without this, both-coalesced-callers-
           // disconnect leaves an orphan agent child no client knows
           // the id of.
-          bridge.detachClient(session.sessionId).catch(() => {
+          bridge.detachClient(session.sessionId, session.clientId).catch(() => {
             // Best-effort cleanup; channel.exited will eventually reap.
           });
         }
@@ -404,9 +404,11 @@ export function createServeApp(
                 // Best-effort cleanup; channel.exited will eventually reap.
               });
           } else {
-            bridge.detachClient(session.sessionId).catch(() => {
-              // Best-effort cleanup; channel.exited will eventually reap.
-            });
+            bridge
+              .detachClient(session.sessionId, session.clientId)
+              .catch(() => {
+                // Best-effort cleanup; channel.exited will eventually reap.
+              });
           }
           return;
         }
@@ -646,7 +648,8 @@ export function createServeApp(
         });
         return;
       }
-      throw err;
+      sendBridgeError(res, err, { route: 'POST /permission/:requestId' });
+      return;
     }
     if (!accepted) {
       // Either the requestId never existed or another client already won

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -58,6 +58,7 @@ export interface DaemonClientOptions {
 }
 
 const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+const CLIENT_ID_HEADER = 'X-Qwen-Client-Id';
 
 /**
  * Strip any trailing slashes from a base URL via plain string ops. The
@@ -221,9 +222,13 @@ export class DaemonClient {
 
   // -- Plumbing -----------------------------------------------------------
 
-  private headers(extra: Record<string, string> = {}): Record<string, string> {
+  private headers(
+    extra: Record<string, string> = {},
+    clientId?: string,
+  ): Record<string, string> {
     const out: Record<string, string> = { ...extra };
     if (this.token) out['Authorization'] = `Bearer ${this.token}`;
+    if (clientId) out[CLIENT_ID_HEADER] = clientId;
     return out;
   }
 
@@ -283,6 +288,7 @@ export class DaemonClient {
 
   async createOrAttachSession(
     req: CreateSessionRequest,
+    clientId?: string,
   ): Promise<DaemonSession> {
     // Per #3803 §02: omitting `cwd` lets the daemon fall back to its
     // bound workspace. JSON.stringify strips `undefined` values, so
@@ -300,7 +306,7 @@ export class DaemonClient {
       `${this.baseUrl}/session`,
       {
         method: 'POST',
-        headers: this.headers({ 'Content-Type': 'application/json' }),
+        headers: this.headers({ 'Content-Type': 'application/json' }, clientId),
         body: JSON.stringify({
           cwd: req.workspaceCwd,
           ...(req.modelServiceId ? { modelServiceId: req.modelServiceId } : {}),
@@ -347,15 +353,17 @@ export class DaemonClient {
   async loadSession(
     sessionId: string,
     req: RestoreSessionRequest = {},
+    clientId?: string,
   ): Promise<DaemonRestoredSession> {
-    return this.restoreSession('load', sessionId, req);
+    return this.restoreSession('load', sessionId, req, clientId);
   }
 
   async resumeSession(
     sessionId: string,
     req: RestoreSessionRequest = {},
+    clientId?: string,
   ): Promise<DaemonRestoredSession> {
-    return this.restoreSession('resume', sessionId, req);
+    return this.restoreSession('resume', sessionId, req, clientId);
   }
 
   /**
@@ -369,12 +377,13 @@ export class DaemonClient {
     action: 'load' | 'resume',
     sessionId: string,
     req: RestoreSessionRequest,
+    clientId?: string,
   ): Promise<DaemonRestoredSession> {
     return await this.fetchWithTimeout(
       `${this.baseUrl}/session/${encodeURIComponent(sessionId)}/${action}`,
       {
         method: 'POST',
-        headers: this.headers({ 'Content-Type': 'application/json' }),
+        headers: this.headers({ 'Content-Type': 'application/json' }, clientId),
         body: JSON.stringify({ cwd: req.workspaceCwd }),
       },
       async (res) => {
@@ -394,12 +403,13 @@ export class DaemonClient {
   async setSessionModel(
     sessionId: string,
     modelId: string,
+    clientId?: string,
   ): Promise<SetModelResult> {
     return await this.fetchWithTimeout(
       `${this.baseUrl}/session/${encodeURIComponent(sessionId)}/model`,
       {
         method: 'POST',
-        headers: this.headers({ 'Content-Type': 'application/json' }),
+        headers: this.headers({ 'Content-Type': 'application/json' }, clientId),
         body: JSON.stringify({ modelId }),
       },
       async (res) => {
@@ -425,12 +435,13 @@ export class DaemonClient {
     sessionId: string,
     req: PromptRequest,
     signal?: AbortSignal,
+    clientId?: string,
   ): Promise<PromptResult> {
     const res = await this._fetch(
       `${this.baseUrl}/session/${encodeURIComponent(sessionId)}/prompt`,
       {
         method: 'POST',
-        headers: this.headers({ 'Content-Type': 'application/json' }),
+        headers: this.headers({ 'Content-Type': 'application/json' }, clientId),
         body: JSON.stringify(req),
         signal,
       },
@@ -439,12 +450,12 @@ export class DaemonClient {
     return (await res.json()) as PromptResult;
   }
 
-  async cancel(sessionId: string): Promise<void> {
+  async cancel(sessionId: string, clientId?: string): Promise<void> {
     await this.fetchWithTimeout(
       `${this.baseUrl}/session/${encodeURIComponent(sessionId)}/cancel`,
       {
         method: 'POST',
-        headers: this.headers({ 'Content-Type': 'application/json' }),
+        headers: this.headers({ 'Content-Type': 'application/json' }, clientId),
         body: '{}',
       },
       async (res) => {
@@ -554,12 +565,13 @@ export class DaemonClient {
   async respondToPermission(
     requestId: string,
     response: PermissionResponse,
+    clientId?: string,
   ): Promise<boolean> {
     return await this.fetchWithTimeout(
       `${this.baseUrl}/permission/${encodeURIComponent(requestId)}`,
       {
         method: 'POST',
-        headers: this.headers({ 'Content-Type': 'application/json' }),
+        headers: this.headers({ 'Content-Type': 'application/json' }, clientId),
         body: JSON.stringify(response),
       },
       async (res) => {

--- a/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
@@ -71,8 +71,9 @@ export class DaemonSessionClient {
   static async createOrAttach(
     client: DaemonClient,
     req: CreateSessionRequest = {},
+    clientId?: string,
   ): Promise<DaemonSessionClient> {
-    const session = await client.createOrAttachSession(req);
+    const session = await client.createOrAttachSession(req, clientId);
     // `modelServiceId` switch failures are reported on SSE, not the
     // create/attach HTTP response. Seed the first subscription from the
     // daemon replay ring so create-then-subscribe clients observe attach-time
@@ -90,8 +91,13 @@ export class DaemonSessionClient {
     client: DaemonClient,
     sessionId: string,
     req: RestoreSessionRequest = {},
+    clientId?: string,
   ): Promise<DaemonSessionClient> {
-    const { state, ...session } = await client.loadSession(sessionId, req);
+    const { state, ...session } = await client.loadSession(
+      sessionId,
+      req,
+      clientId,
+    );
     return new DaemonSessionClient({
       client,
       session,
@@ -113,8 +119,13 @@ export class DaemonSessionClient {
     client: DaemonClient,
     sessionId: string,
     req: RestoreSessionRequest = {},
+    clientId?: string,
   ): Promise<DaemonSessionClient> {
-    const { state, ...session } = await client.resumeSession(sessionId, req);
+    const { state, ...session } = await client.resumeSession(
+      sessionId,
+      req,
+      clientId,
+    );
     return new DaemonSessionClient({
       client,
       session,

--- a/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
@@ -135,6 +135,10 @@ export class DaemonSessionClient {
     return this.session.attached;
   }
 
+  get clientId(): string | undefined {
+    return this.session.clientId;
+  }
+
   get lastEventId(): number | undefined {
     return this.lastSeenEventId;
   }
@@ -147,22 +151,30 @@ export class DaemonSessionClient {
     req: PromptRequest,
     signal?: AbortSignal,
   ): Promise<PromptResult> {
-    return await this.client.prompt(this.sessionId, req, signal);
+    return await this.client.prompt(this.sessionId, req, signal, this.clientId);
   }
 
   async cancel(): Promise<void> {
-    await this.client.cancel(this.sessionId);
+    await this.client.cancel(this.sessionId, this.clientId);
   }
 
   async setModel(modelId: string): Promise<SetModelResult> {
-    return await this.client.setSessionModel(this.sessionId, modelId);
+    return await this.client.setSessionModel(
+      this.sessionId,
+      modelId,
+      this.clientId,
+    );
   }
 
   async respondToPermission(
     requestId: string,
     response: PermissionResponse,
   ): Promise<boolean> {
-    return await this.client.respondToPermission(requestId, response);
+    return await this.client.respondToPermission(
+      requestId,
+      response,
+      this.clientId,
+    );
   }
 
   events(

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -115,6 +115,11 @@ export interface DaemonSession {
   workspaceCwd: string;
   /** True when an existing session was reused under sessionScope:single. */
   attached: boolean;
+  /**
+   * Opaque id stamped by the daemon for this attached HTTP client. Newer
+   * daemons return it from create/load/resume; older daemons omit it.
+   */
+  clientId?: string;
 }
 
 /**

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -226,6 +226,25 @@ describe('DaemonClient', () => {
       });
     });
 
+    it('sends client identity in a header, not the request body', async () => {
+      const { fetch, calls } = recordingFetch(() =>
+        jsonResponse(200, {
+          sessionId: 's-1',
+          workspaceCwd: '/work/a',
+          attached: true,
+          clientId: 'client-1',
+        }),
+      );
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+      const session = await client.createOrAttachSession(
+        { workspaceCwd: '/work/a' },
+        'client-1',
+      );
+      expect(session.clientId).toBe('client-1');
+      expect(calls[0]?.headers['x-qwen-client-id']).toBe('client-1');
+      expect(JSON.parse(calls[0]!.body!)).toEqual({ cwd: '/work/a' });
+    });
+
     it('forwards sessionScope when supplied (#4175 PR 5)', async () => {
       // Per-request scope override: clients pre-flight
       // `caps.features.session_scope_override` and pass `'single'` /
@@ -308,6 +327,20 @@ describe('DaemonClient', () => {
       expect(calls[0]?.url).toBe('http://daemon/session/with%2Fslash/prompt');
     });
 
+    it('sends client identity header on prompts', async () => {
+      const { fetch, calls } = recordingFetch(() =>
+        jsonResponse(200, { stopReason: 'end_turn' }),
+      );
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+      await client.prompt(
+        's-1',
+        { prompt: [{ type: 'text', text: 'hi' }] },
+        undefined,
+        'client-1',
+      );
+      expect(calls[0]?.headers['x-qwen-client-id']).toBe('client-1');
+    });
+
     it('forwards a caller AbortSignal through to fetch (A-UsQ)', async () => {
       // The bridge already supports per-prompt cancellation via the
       // signal arg on `sendPrompt`; the SDK had the parameter wired
@@ -355,6 +388,24 @@ describe('DaemonClient', () => {
       expect(JSON.parse(calls[0]!.body!)).toEqual({ cwd: '/work/a' });
     });
 
+    it('sends client identity headers on restore requests', async () => {
+      const { fetch, calls } = recordingFetch(() =>
+        jsonResponse(200, {
+          sessionId: 's-1',
+          workspaceCwd: '/work/a',
+          attached: true,
+          clientId: 'client-1',
+          state: {},
+        }),
+      );
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+      await client.loadSession('s-1', {}, 'client-1');
+      await client.resumeSession('s-1', {}, 'client-1');
+
+      expect(calls[0]?.headers['x-qwen-client-id']).toBe('client-1');
+      expect(calls[1]?.headers['x-qwen-client-id']).toBe('client-1');
+    });
+
     it('POSTs /session/:id/resume and omits cwd when absent', async () => {
       const { fetch, calls } = recordingFetch(() =>
         jsonResponse(200, {
@@ -393,6 +444,15 @@ describe('DaemonClient', () => {
       expect(calls[0]?.method).toBe('POST');
     });
 
+    it('sends client identity header on cancel', async () => {
+      const { fetch, calls } = recordingFetch(
+        () => new Response(null, { status: 204 }),
+      );
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+      await client.cancel('s-1', 'client-1');
+      expect(calls[0]?.headers['x-qwen-client-id']).toBe('client-1');
+    });
+
     it('throws on 404', async () => {
       const { fetch } = recordingFetch(() =>
         jsonResponse(404, { error: 'unknown', sessionId: 's-1' }),
@@ -413,6 +473,17 @@ describe('DaemonClient', () => {
       });
       expect(accepted).toBe(true);
       expect(calls[0]?.url).toBe('http://daemon/permission/req-1');
+    });
+
+    it('sends client identity header on permission votes', async () => {
+      const { fetch, calls } = recordingFetch(() => jsonResponse(200, {}));
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+      await client.respondToPermission(
+        'req-1',
+        { outcome: { outcome: 'cancelled' } },
+        'client-1',
+      );
+      expect(calls[0]?.headers['x-qwen-client-id']).toBe('client-1');
     });
 
     it('returns false on 404 (lost the race)', async () => {
@@ -517,6 +588,13 @@ describe('DaemonClient', () => {
       expect(calls[0]?.url).toBe('http://daemon/session/s-1/model');
       expect(calls[0]?.method).toBe('POST');
       expect(JSON.parse(calls[0]!.body!)).toEqual({ modelId: 'qwen3-coder' });
+    });
+
+    it('sends client identity header on model switches', async () => {
+      const { fetch, calls } = recordingFetch(() => jsonResponse(200, {}));
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+      await client.setSessionModel('s-1', 'qwen3-coder', 'client-1');
+      expect(calls[0]?.headers['x-qwen-client-id']).toBe('client-1');
     });
 
     it('throws on 404 (unknown session)', async () => {

--- a/packages/sdk-typescript/test/unit/DaemonSessionClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonSessionClient.test.ts
@@ -77,6 +77,7 @@ describe('DaemonSessionClient', () => {
         sessionId: 's-1',
         workspaceCwd: '/work/a',
         attached: false,
+        clientId: 'client-1',
       }),
     );
     const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
@@ -89,6 +90,7 @@ describe('DaemonSessionClient', () => {
     expect(session.sessionId).toBe('s-1');
     expect(session.workspaceCwd).toBe('/work/a');
     expect(session.attached).toBe(false);
+    expect(session.clientId).toBe('client-1');
     expect(calls[0]?.url).toBe('http://daemon/session');
     expect(JSON.parse(calls[0]!.body!)).toEqual({
       cwd: '/work/a',
@@ -132,6 +134,7 @@ describe('DaemonSessionClient', () => {
           sessionId: 's-1',
           workspaceCwd: '/work/a',
           attached: false,
+          clientId: 'client-1',
           state: { configOptions: [] },
         });
       }
@@ -147,6 +150,7 @@ describe('DaemonSessionClient', () => {
     });
 
     expect(session.sessionId).toBe('s-1');
+    expect(session.clientId).toBe('client-1');
     expect(session.state).toEqual({ configOptions: [] });
     expect(JSON.parse(calls[0]!.body!)).toEqual({ cwd: '/work/a' });
 
@@ -163,6 +167,7 @@ describe('DaemonSessionClient', () => {
           sessionId: 's-1',
           workspaceCwd: '/work/a',
           attached: true,
+          clientId: 'client-1',
           state: { modes: null },
         });
       }
@@ -176,6 +181,7 @@ describe('DaemonSessionClient', () => {
     const session = await DaemonSessionClient.resume(client, 's-1');
 
     expect(session.attached).toBe(true);
+    expect(session.clientId).toBe('client-1');
     expect(session.state).toEqual({ modes: null });
     for await (const _event of session.events()) {
       /* empty */
@@ -209,6 +215,7 @@ describe('DaemonSessionClient', () => {
         sessionId: 's-1',
         workspaceCwd: '/work/a',
         attached: true,
+        clientId: 'client-1',
       },
     });
 
@@ -236,6 +243,12 @@ describe('DaemonSessionClient', () => {
       'http://daemon/permission/req-1',
     ]);
     expect(calls[0]?.signal).toBe(controller.signal);
+    expect(calls.map((c) => c.headers['x-qwen-client-id'])).toEqual([
+      'client-1',
+      'client-1',
+      'client-1',
+      'client-1',
+    ]);
   });
 
   it('tracks Last-Event-ID across event subscriptions', async () => {

--- a/packages/sdk-typescript/test/unit/DaemonSessionClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonSessionClient.test.ts
@@ -98,6 +98,52 @@ describe('DaemonSessionClient', () => {
     });
   });
 
+  it('forwards a persisted client id through create, load, and resume', async () => {
+    const { fetch, calls } = recordingFetch((req) => {
+      if (req.url.endsWith('/session')) {
+        return jsonResponse(200, {
+          sessionId: 's-1',
+          workspaceCwd: '/work/a',
+          attached: true,
+          clientId: 'client-reuse',
+        });
+      }
+      if (
+        req.url.endsWith('/session/s-1/load') ||
+        req.url.endsWith('/session/s-1/resume')
+      ) {
+        return jsonResponse(200, {
+          sessionId: 's-1',
+          workspaceCwd: '/work/a',
+          attached: true,
+          clientId: 'client-reuse',
+          state: {},
+        });
+      }
+      return jsonResponse(500, { error: `unexpected ${req.url}` });
+    });
+    const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+
+    await DaemonSessionClient.createOrAttach(
+      client,
+      { workspaceCwd: '/work/a' },
+      'client-reuse',
+    );
+    await DaemonSessionClient.load(
+      client,
+      's-1',
+      { workspaceCwd: '/work/a' },
+      'client-reuse',
+    );
+    await DaemonSessionClient.resume(client, 's-1', {}, 'client-reuse');
+
+    expect(calls.map((c) => c.headers['x-qwen-client-id'])).toEqual([
+      'client-reuse',
+      'client-reuse',
+      'client-reuse',
+    ]);
+  });
+
   it('replays attach-time model switch events on first subscription', async () => {
     const { fetch, calls } = recordingFetch((req) => {
       if (req.url.endsWith('/session')) {


### PR DESCRIPTION
## Summary

- What changed: adds a daemon-stamped client identity for `qwen serve` attach/create flows, returns the stamped id in session responses, accepts it back through `X-Qwen-Client-Id`, and uses trusted ids to stamp relevant daemon events with `originatorClientId`.
- Why it changed: this is roadmap PR7 for daemon mode B, giving TUI, channel, web, IDE, and other clients a shared identity primitive before session-scoped permission routing.
- Reviewer focus: confirm the id is generated/registered by the daemon, echoed only through the transport header, rejected on state-changing routes when unknown, and optional for backward compatibility.

## Validation

- Commands run:
  ```bash
  npm run typecheck --workspace packages/cli
  npm run typecheck --workspace packages/sdk-typescript
  cd packages/cli && npx vitest run src/serve/server.test.ts src/serve/httpAcpBridge.test.ts src/serve/eventBus.test.ts
  cd packages/sdk-typescript && npx vitest run test/unit/DaemonClient.test.ts test/unit/DaemonSessionClient.test.ts test/unit/daemonEvents.test.ts
  npm run lint --workspace packages/cli
  npx eslint packages/sdk-typescript/src/daemon/DaemonClient.ts packages/sdk-typescript/src/daemon/DaemonSessionClient.ts packages/sdk-typescript/src/daemon/types.ts packages/sdk-typescript/test/unit/DaemonClient.test.ts packages/sdk-typescript/test/unit/DaemonSessionClient.test.ts
  npm run build
  ```
- Prompts / inputs used: daemon HTTP route and bridge unit-test requests with and without `X-Qwen-Client-Id`.
- Expected result: old clients work without the header; new clients receive a daemon-issued id and can echo it for originator stamping.
- Observed result: route, bridge, event bus, SDK client, and session client tests passed locally. `npm run build` passed with the existing vscode companion curly warning in `editorGroupUtils.ts`.
- Quickest reviewer verification path: run the two targeted vitest commands above and inspect the new `client_identity` capability plus `originatorClientId` assertions in bridge tests.
- Evidence: local test runs passed for 222 CLI tests and 76 SDK daemon tests.

## Scope / Risk

- Main risk or tradeoff: this does not introduce revocation or durable identity; ids are live-session scoped and reset when the daemon process/session goes away.
- Not covered / not validated: full client adapters are intentionally not switched over in this PR; this only adds the shared primitive they will use.
- Breaking changes / migration notes: none expected. The header is optional, old clients continue to work, and SDK `clientId` is optional for compatibility with older daemons.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Local macOS validation covered targeted typecheck, vitest, lint, and build. Windows/Linux left to CI.
- `npm run lint --workspace packages/sdk-typescript` currently fails before reaching this PR's changed files due to an existing ESLint rule-loading error while linting `ProcessTransport.test.ts`; the changed SDK files were checked with root `npx eslint`.

## Linked Issues / Bugs

- Related to #3803
- Follows the daemon roadmap PR7: minimal daemon-stamped client identity.
