### PR TITLE
test(perf): skip daemon baseline harness under sandbox

### DIFF
--- a/integration-tests/cli/qwen-serve-baseline.test.ts
+++ b/integration-tests/cli/qwen-serve-baseline.test.ts
@@ -24,9 +24,13 @@
  * catastrophic-regression upper bounds (e.g. RSS at 1 session < 500 MB);
  * everything else is reported into the snapshot.
  *
- * POSIX only. The harness uses `ps` + `pgrep`; Windows is skipped via the
- * `describe.skip` gate at the bottom of this file (matches the existing
- * `qwen-serve-streaming.test.ts:53` precedent).
+ * POSIX only. The harness uses `ps` + `pgrep` against the host process
+ * table. Windows is skipped (no `ps`/`pgrep`); Docker/Podman sandbox is
+ * also skipped because the daemon's `qwen --acp` child and its MCP
+ * grandchildren run inside the sandbox container's PID namespace, which
+ * host-side `pgrep -P` cannot observe — the descendant walk would always
+ * see zero MCP grandchildren and time out. Same rationale and skip shape
+ * as `acp-integration.test.ts` / `cron-tools.test.ts`.
  */
 
 import { execFileSync } from 'node:child_process';
@@ -55,8 +59,16 @@ interface BridgeEventLike {
   type: string;
 }
 
-// Skip immediately on Windows — the helpers shell out to `ps` / `pgrep`.
-const SKIP = process.platform === 'win32';
+// Skip on Windows (helpers shell out to `ps` / `pgrep`) and under
+// Docker/Podman sandbox (the daemon subtree runs in a separate PID
+// namespace the host `pgrep` can't observe — matches the existing
+// `acp-integration.test.ts` / `cron-tools.test.ts` skip precedent).
+const SKIP =
+  process.platform === 'win32' ||
+  Boolean(
+    process.env['QWEN_SANDBOX'] &&
+      process.env['QWEN_SANDBOX']!.toLowerCase() !== 'false',
+  );
 
 // Read iteration tunings from env (documented in #4175 PR 1 plan).
 const HEAVY = process.env['QWEN_BASELINE_HEAVY'] === '1';


### PR DESCRIPTION
## Summary

- **What changed:** The `qwen-serve-baseline.test.ts` harness is now skipped when running under the Docker/Podman sandbox, in addition to the existing Windows skip.
- **Why it changed:** The harness measures the daemon's process tree with host-side `pgrep -P`. Under the sandbox the daemon's `qwen --acp` child and its MCP server grandchildren run inside the container's PID namespace, which a host `pgrep` cannot see. The "MCP child amplification" test therefore waits for MCP grandchildren that are structurally invisible to it, and times out on every retry. The test was added in #4205 and first ran in a Docker release job on the 2026-05-17 scheduled release, where it was the sole failure; it passes in the no-sandbox job in ~3.6s.
- **Reviewer focus:** The widened `SKIP` predicate — it uses the exact same `QWEN_SANDBOX` check shape already established in `acp-integration.test.ts`, `acp-cron.test.ts`, and `cron-tools.test.ts`, which skip for the same PID-namespace reason.

This is a test-environment fix, not a product change. The baseline harness is by design a host-side `ps`/`pgrep` measurement tool (stated in its own file header); it has no meaningful definition inside a container whose process subtree lives in a separate namespace. Skipping under sandbox is the same decision already made for every other test in this suite that inspects spawned child processes — this test simply missed the gate when it was introduced. No production code path is touched, and no-sandbox coverage (the environment where these metrics are actually meaningful) is unchanged.

## Validation

- Commands run:
  ```bash
  # Pre-existing behavior reproduced from CI logs of run 25976629117:
  #   Docker job  -> FAIL (timed out 3x, mcpGrandchildren=[])
  #   No-Sandbox  -> PASS (3.6s)

  # This change, no-sandbox path still runs unchanged:
  cd integration-tests
  npx eslint cli/qwen-serve-baseline.test.ts   # clean
  ```
- Expected result: under `QWEN_SANDBOX=docker`/`podman` the suite reports skipped instead of failing; under no-sandbox it runs exactly as before.
- Observed result: lint clean; `SKIP` now true when `QWEN_SANDBOX` is set to a non-`false` value, false otherwise (Windows behavior unchanged).
- Quickest reviewer verification path: read the `SKIP` constant diff and compare to `integration-tests/cli/acp-integration.test.ts` (`IS_SANDBOX`).

## Scope / Risk

- Main risk or tradeoff: the baseline harness no longer executes in the Docker/Podman release jobs. This is intentional — its `pgrep`-based measurements are not valid across a container PID-namespace boundary, so a Docker run produced no signal anyway, only a false failure. Full coverage remains in the no-sandbox job.
- Not covered / not validated: no behavioral product code is affected; nothing to validate beyond the skip predicate.
- Breaking changes / migration notes: none.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | N/A | N/A | N/A |
| npx      | N/A | N/A | N/A |
| Docker   | ✅  | N/A | ✅  |
| Podman   | ✅  | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Test-only change. "Docker/Podman ✅" = verified the suite now skips (the failure mode) rather than runs; no-sandbox path is unchanged and not re-listed.

## Linked Issues / Bugs

Fixes the Docker release-job regression introduced by #4205. Refs #4175 (Mode B v0.16 rollout tracking issue).