### PR TITLE
feat(serve): add client heartbeat (#4175 Wave 2.5 PR 9)

### DIFF
--- a/docs/developers/qwen-serve-protocol.md
+++ b/docs/developers/qwen-serve-protocol.md
@@ -91,12 +91,15 @@ registry. Clients **must** gate UI off `features`, not off `mode` (per design
 ['health', 'capabilities', 'session_create', 'session_scope_override',
  'session_load', 'unstable_session_resume',
  'session_list', 'session_prompt', 'session_cancel', 'session_events',
- 'session_set_model', 'permission_vote']
+ 'session_set_model', 'client_identity', 'client_heartbeat',
+ 'session_permission_vote', 'permission_vote']
 ```
 
 `session_scope_override` is the negotiation handle for the per-request `sessionScope` field on `POST /session` (see below). Older daemons silently ignore the field, so SDK clients should pre-flight `caps.features` for this tag before sending it.
 
 `session_load` and `unstable_session_resume` advertise the explicit-restore routes (`POST /session/:id/load` and `POST /session/:id/resume`). Older daemons return `404` for these paths, so SDK clients should pre-flight `caps.features` before calling. The `unstable_` prefix on `unstable_session_resume` mirrors the underlying ACP method (`connection.unstable_resumeSession`) — the daemon's wire shape is committed for v1, but the ACP method name itself may change before ACP marks resume stable.
+
+`client_heartbeat` advertises `POST /session/:id/heartbeat`. Older daemons return `404`; pre-flight this tag before issuing periodic heartbeats.
 
 ## Routes
 
@@ -309,6 +312,37 @@ curl -X POST http://127.0.0.1:4170/session/$SID/cancel
 ```
 
 > **Multi-prompt contract:** cancel only affects the active prompt. Any prompts the same client previously POSTed and are still queued behind the active one will continue to execute. Multi-prompt queueing is a daemon-introduced behavior (not in ACP spec); the contract for queued prompts is "they keep running unless you cancel each, or kill the session via channel exit".
+
+### `POST /session/:id/heartbeat`
+
+Bump the daemon's last-seen bookkeeping for this session. Long-lived adapters (TUI/IDE/web) ping this on an interval so future revocation policy (Wave 5 PR 24) can distinguish dead clients from quiet ones.
+
+Headers:
+
+| Header             | Required | Notes                                                                                                                                                                                                                                   |
+| ------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `X-Qwen-Client-Id` | no       | Echoes the daemon-issued id from `POST /session`. Identified clients also bump their per-client timestamp; anonymous heartbeats only bump the per-session watermark. Must satisfy the same `[A-Za-z0-9._:-]{1,128}` shape as elsewhere. |
+
+Request body is empty (`{}` is fine — no fields are read today).
+
+Response:
+
+```json
+{
+  "sessionId": "<sid>",
+  "clientId": "<cid>",
+  "lastSeenAt": 1700000000123
+}
+```
+
+`clientId` is echoed only when a trusted `X-Qwen-Client-Id` was supplied. `lastSeenAt` is the daemon-side `Date.now()` epoch (ms) the bridge stored.
+
+Errors:
+
+- `400` — `{ code: 'invalid_client_id' }` when the header is malformed (header-shape rule) or when it carries a `clientId` that isn't registered for this session (the bridge throws `InvalidClientIdError` before bumping any timestamp).
+- `404` — unknown session.
+
+Capability gating: pre-flight `caps.features.client_heartbeat`. Older daemons return `404` for this path.
 
 ### `POST /session/:id/model`
 

--- a/docs/users/qwen-serve.md
+++ b/docs/users/qwen-serve.md
@@ -227,7 +227,7 @@ Stage 1's contract is sized for prototyping. Per [#3889 chiga0 downstream-consum
 
 **Reliability baseline:**
 
-3. **Client-initiated heartbeat path** — distinguish "agent thinking" from "daemon dead" without waiting for the 15s server heartbeat.
+3. ~~**Client-initiated heartbeat path**~~ — shipped via [#4175](https://github.com/QwenLM/qwen-code/issues/4175) PR 9. `POST /session/:id/heartbeat` records last-seen timestamps on the daemon (capability tag `client_heartbeat`); SDK helpers are `DaemonClient.heartbeat()` / `DaemonSessionClient.heartbeat()`.
 4. **`permission_already_resolved` event** when a vote loses the first-responder race — currently UIs have to infer state from a `404`.
 5. **Larger / per-session-configurable replay ring** — default 4000 covers short drops; mobile / chatty-turn workloads need 8000+ or per-session config.
 6. **`slow_client_warning` event before `client_evicted`** — soft backpressure so well-behaved slow clients can self-throttle (trim render depth, drop chunks) before being terminated.

--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -200,6 +200,7 @@ describe('qwen serve — capabilities envelope', () => {
       'session_events',
       'session_set_model',
       'client_identity',
+      'client_heartbeat',
       'session_permission_vote',
       'permission_vote',
     ]);

--- a/packages/cli/src/serve/capabilities.ts
+++ b/packages/cli/src/serve/capabilities.ts
@@ -38,6 +38,7 @@ export const SERVE_CAPABILITY_REGISTRY = {
   session_events: { since: 'v1' },
   session_set_model: { since: 'v1' },
   client_identity: { since: 'v1' },
+  client_heartbeat: { since: 'v1' },
   session_permission_vote: { since: 'v1' },
   permission_vote: { since: 'v1' },
 } as const satisfies Record<string, ServeCapabilityDescriptor>;

--- a/packages/cli/src/serve/httpAcpBridge.test.ts
+++ b/packages/cli/src/serve/httpAcpBridge.test.ts
@@ -398,6 +398,124 @@ describe('createHttpAcpBridge', () => {
     await bridge.shutdown();
   });
 
+  describe('recordHeartbeat', () => {
+    it('updates the per-session timestamp for an anonymous heartbeat', async () => {
+      const bridge = makeBridge({
+        channelFactory: async () => makeChannel().channel,
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      // Anonymous heartbeats (no `X-Qwen-Client-Id`) bump only the session
+      // watermark — every identified-client lookup must stay empty so a
+      // future revocation policy doesn't see ghost timestamps.
+      const before = Date.now();
+      const result = bridge.recordHeartbeat(session.sessionId);
+      const after = Date.now();
+
+      expect(result.sessionId).toBe(session.sessionId);
+      expect(result.clientId).toBeUndefined();
+      expect(result.lastSeenAt).toBeGreaterThanOrEqual(before);
+      expect(result.lastSeenAt).toBeLessThanOrEqual(after);
+
+      const state = bridge.getHeartbeatState(session.sessionId);
+      expect(state?.sessionLastSeenAt).toBe(result.lastSeenAt);
+      expect(state?.clientLastSeenAt.size).toBe(0);
+
+      await bridge.shutdown();
+    });
+
+    it('records per-client timestamps when a trusted client id is supplied', async () => {
+      const bridge = makeBridge({
+        channelFactory: async () => makeChannel().channel,
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const result = bridge.recordHeartbeat(session.sessionId, {
+        clientId: session.clientId,
+      });
+
+      expect(result.clientId).toBe(session.clientId);
+      const state = bridge.getHeartbeatState(session.sessionId);
+      expect(state?.sessionLastSeenAt).toBe(result.lastSeenAt);
+      expect(state?.clientLastSeenAt.get(session.clientId!)).toBe(
+        result.lastSeenAt,
+      );
+
+      await bridge.shutdown();
+    });
+
+    it('throws SessionNotFoundError on unknown sessions', async () => {
+      const bridge = makeBridge({
+        channelFactory: async () => makeChannel().channel,
+      });
+      // No `session/spawnOrAttach` first — the bridge must reject before
+      // touching any timestamp store.
+      expect(() => bridge.recordHeartbeat('missing')).toThrow(
+        SessionNotFoundError,
+      );
+      expect(bridge.getHeartbeatState('missing')).toBeUndefined();
+      await bridge.shutdown();
+    });
+
+    it('rejects an unknown client id without bumping any timestamp', async () => {
+      const bridge = makeBridge({
+        channelFactory: async () => makeChannel().channel,
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      // Pre-validation guarantees an attacker holding a valid bearer
+      // token can't mask client absence by spamming heartbeats with
+      // forged ids — `sessionLastSeenAt` must stay undefined here.
+      expect(() =>
+        bridge.recordHeartbeat(session.sessionId, { clientId: 'forged' }),
+      ).toThrow(InvalidClientIdError);
+
+      const state = bridge.getHeartbeatState(session.sessionId);
+      expect(state?.sessionLastSeenAt).toBeUndefined();
+      expect(state?.clientLastSeenAt.size).toBe(0);
+
+      await bridge.shutdown();
+    });
+
+    it('drops per-client last-seen on detach but preserves the session watermark', async () => {
+      const bridge = makeBridge({
+        channelFactory: async () => makeChannel().channel,
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      bridge.recordHeartbeat(session.sessionId, { clientId: session.clientId });
+
+      const before = bridge.getHeartbeatState(session.sessionId);
+      expect(before?.clientLastSeenAt.get(session.clientId!)).toBeDefined();
+
+      await bridge.detachClient(session.sessionId, session.clientId);
+
+      const after = bridge.getHeartbeatState(session.sessionId);
+      // session watermark stays — diagnostics still see "this session
+      // was alive at T"; per-client entry is gone since the client
+      // ref-count hit zero.
+      expect(after?.sessionLastSeenAt).toBe(before?.sessionLastSeenAt);
+      expect(after?.clientLastSeenAt.size).toBe(0);
+
+      await bridge.shutdown();
+    });
+
+    it('returns a snapshot map that callers cannot use to mutate live state', async () => {
+      const bridge = makeBridge({
+        channelFactory: async () => makeChannel().channel,
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      bridge.recordHeartbeat(session.sessionId, { clientId: session.clientId });
+
+      const snapshot = bridge.getHeartbeatState(session.sessionId);
+      // Mutating the returned map must NOT leak into the bridge — the
+      // accessor exists so future PR 12 read-only routes can serialize
+      // a snapshot without coupling to internal storage.
+      (snapshot!.clientLastSeenAt as Map<string, number>).set('attacker', 0);
+
+      const fresh = bridge.getHeartbeatState(session.sessionId);
+      expect(fresh?.clientLastSeenAt.has('attacker')).toBe(false);
+
+      await bridge.shutdown();
+    });
+  });
+
   it('loads an existing ACP session and registers it for daemon routes', async () => {
     const handles: ChannelHandle[] = [];
     const factory: ChannelFactory = async () => {

--- a/packages/cli/src/serve/httpAcpBridge.ts
+++ b/packages/cli/src/serve/httpAcpBridge.ts
@@ -137,6 +137,34 @@ export interface BridgeClientRequestContext {
   clientId?: string;
 }
 
+/**
+ * Returned from `recordHeartbeat`. `lastSeenAt` is the server-side
+ * `Date.now()` epoch (ms) the bridge stored for this session/client
+ * pair — the same value future diagnostics and revocation policy
+ * (Wave 5 PR 24) will read. `clientId` is echoed only when the caller
+ * provided a trusted one through `X-Qwen-Client-Id`; anonymous
+ * heartbeats omit it but still bump the per-session timestamp.
+ */
+export interface BridgeHeartbeatResult {
+  sessionId: string;
+  clientId?: string;
+  lastSeenAt: number;
+}
+
+/**
+ * Read-only snapshot of last-seen timestamps the bridge has recorded for
+ * a session. `sessionLastSeenAt` is the most recent heartbeat across any
+ * client (anonymous or identified). `clientLastSeenAt` maps each
+ * registered `clientId` to its own last heartbeat. Returned by
+ * `getHeartbeatState` for in-process diagnostics; the eventual read-only
+ * `GET /session/:id/heartbeat-state` route (Wave 3 PR 12) will surface
+ * the same shape over HTTP.
+ */
+export interface BridgeHeartbeatState {
+  sessionLastSeenAt?: number;
+  clientLastSeenAt: ReadonlyMap<string, number>;
+}
+
 export interface HttpAcpBridge {
   /**
    * Create a new session, or — under `sessionScope: 'single'` — attach to an
@@ -231,6 +259,33 @@ export interface HttpAcpBridge {
    * a session-picker UI shouldn't 404 just because the workspace is idle.
    */
   listWorkspaceSessions(workspaceCwd: string): BridgeSessionSummary[];
+
+  /**
+   * Record a client heartbeat for the session. Bumps the per-session
+   * `sessionLastSeenAt` and, when a trusted `clientId` is supplied,
+   * the per-client entry in `clientLastSeenAt`. Throws
+   * `SessionNotFoundError` when the id is unknown and
+   * `InvalidClientIdError` when the supplied `clientId` is not
+   * registered for this session — the same shape `sendPrompt` /
+   * `setSessionModel` use, so HTTP routes can map it to `400
+   * invalid_client_id` consistently.
+   *
+   * The recorded timestamps are exposed via `getHeartbeatState`; this
+   * PR keeps them in-process only (future diagnostics route in PR 12,
+   * future revocation policy in PR 24).
+   */
+  recordHeartbeat(
+    sessionId: string,
+    context?: BridgeClientRequestContext,
+  ): BridgeHeartbeatResult;
+
+  /**
+   * Read the bridge's recorded last-seen timestamps for a session.
+   * Returns `undefined` for unknown sessions. The map is a snapshot —
+   * callers must not mutate it. Stage 1 surfaces this only to in-
+   * process callers (tests, future read-only diagnostics routes).
+   */
+  getHeartbeatState(sessionId: string): BridgeHeartbeatState | undefined;
 
   /**
    * Switch the active model service for a session. Forwards through ACP's
@@ -731,6 +786,21 @@ interface SessionEntry {
    * had an ACP load/resume response, so attaches return `state: {}`.
    */
   restoreState?: BridgeSessionState;
+  /**
+   * Most recent heartbeat across any client on this session (Date.now()
+   * epoch ms). Set on every `recordHeartbeat` call regardless of whether
+   * the caller identified themselves; consumed by future diagnostics
+   * (PR 12) and revocation policy (PR 24). Undefined until the first
+   * heartbeat lands.
+   */
+  sessionLastSeenAt?: number;
+  /**
+   * Per-`clientId` last heartbeat (Date.now() epoch ms). Only populated
+   * when the heartbeat carried a trusted `X-Qwen-Client-Id`. Entries are
+   * dropped together with the parent session — there's no per-client
+   * eviction in this PR; revocation policy (PR 24) will own that.
+   */
+  clientLastSeenAt: Map<string, number>;
 }
 
 interface PendingPermission {
@@ -1393,6 +1463,13 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     if (count === undefined) return;
     if (count <= 1) {
       entry.clientIds.delete(clientId);
+      // Drop the last-seen entry alongside the registration ref.
+      // Otherwise a long-lived daemon servicing a churn of disconnect/
+      // reconnect clients (each picking a fresh `clientId`) would
+      // accumulate stale heartbeat timestamps for clients that no
+      // longer exist — the very leak revocation policy (PR 24) is
+      // meant to plug.
+      entry.clientLastSeenAt.delete(clientId);
     } else {
       entry.clientIds.set(clientId, count - 1);
     }
@@ -2008,6 +2085,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       modelChangeQueue: Promise.resolve(),
       pendingPermissionIds: new Set(),
       clientIds: new Map(),
+      clientLastSeenAt: new Map(),
       attachCount: 0,
       spawnOwnerWantedKill: false,
     };
@@ -2737,6 +2815,42 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         }
       }
       return out;
+    },
+
+    recordHeartbeat(sessionId, context) {
+      const entry = byId.get(sessionId);
+      if (!entry) throw new SessionNotFoundError(sessionId);
+      // Validate the optional client id BEFORE bumping any timestamp so
+      // an unknown client doesn't get to advance the per-session
+      // watermark — that would let an attacker with a valid bearer
+      // token mask client absence by spamming heartbeats with random
+      // ids. `resolveTrustedClientId` throws `InvalidClientIdError`,
+      // which the route layer maps to `400 invalid_client_id`.
+      const clientId = resolveTrustedClientId(entry, context?.clientId);
+      const lastSeenAt = Date.now();
+      entry.sessionLastSeenAt = lastSeenAt;
+      if (clientId !== undefined) {
+        entry.clientLastSeenAt.set(clientId, lastSeenAt);
+      }
+      return {
+        sessionId: entry.sessionId,
+        ...(clientId !== undefined ? { clientId } : {}),
+        lastSeenAt,
+      };
+    },
+
+    getHeartbeatState(sessionId) {
+      const entry = byId.get(sessionId);
+      if (!entry) return undefined;
+      // Snapshot the client map so callers can't mutate the live one;
+      // `sessionLastSeenAt` is undefined for sessions that have never
+      // received a heartbeat (the typical state right after spawn).
+      return {
+        ...(entry.sessionLastSeenAt !== undefined
+          ? { sessionLastSeenAt: entry.sessionLastSeenAt }
+          : {}),
+        clientLastSeenAt: new Map(entry.clientLastSeenAt),
+      };
     },
 
     async setSessionModel(sessionId, req, context) {

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -35,6 +35,8 @@ import {
   SessionLimitExceededError,
   SessionNotFoundError,
   WorkspaceMismatchError,
+  type BridgeHeartbeatResult,
+  type BridgeHeartbeatState,
   type BridgeRestoredSession,
   type BridgeClientRequestContext,
   type BridgeRestoreSessionRequest,
@@ -74,6 +76,7 @@ const EXPECTED_STAGE1_FEATURES = [
   'session_events',
   'session_set_model',
   'client_identity',
+  'client_heartbeat',
   'session_permission_vote',
   'permission_vote',
 ] as const;
@@ -118,6 +121,11 @@ interface FakeBridgeOpts {
     req: SetSessionModelRequest,
     context?: BridgeClientRequestContext,
   ) => Promise<SetSessionModelResponse>;
+  heartbeatImpl?: (
+    sessionId: string,
+    context?: BridgeClientRequestContext,
+  ) => BridgeHeartbeatResult;
+  heartbeatStateImpl?: (sessionId: string) => BridgeHeartbeatState | undefined;
 }
 
 interface FakeBridge extends HttpAcpBridge {
@@ -157,6 +165,11 @@ interface FakeBridge extends HttpAcpBridge {
     req: SetSessionModelRequest;
     context?: BridgeClientRequestContext;
   }>;
+  heartbeatCalls: Array<{
+    sessionId: string;
+    context?: BridgeClientRequestContext;
+  }>;
+  heartbeatStateCalls: string[];
   shutdownCalls: number;
 }
 
@@ -175,6 +188,8 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
   const sessionPermissionVotes: FakeBridge['sessionPermissionVotes'] = [];
   const listCalls: string[] = [];
   const setModelCalls: FakeBridge['setModelCalls'] = [];
+  const heartbeatCalls: FakeBridge['heartbeatCalls'] = [];
+  const heartbeatStateCalls: string[] = [];
   let shutdownCalls = 0;
   const spawnImpl =
     opts.spawnImpl ??
@@ -209,6 +224,21 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
   const sessionRespondImpl = opts.sessionRespondImpl ?? (() => true);
   const listImpl = opts.listImpl ?? (() => []);
   const setModelImpl = opts.setModelImpl ?? (async () => ({}));
+  const heartbeatImpl =
+    opts.heartbeatImpl ??
+    ((sessionId, context) => ({
+      sessionId,
+      ...(context?.clientId !== undefined
+        ? { clientId: context.clientId }
+        : {}),
+      lastSeenAt: 1_700_000_000_000,
+    }));
+  const heartbeatStateImpl =
+    opts.heartbeatStateImpl ??
+    (() => ({
+      sessionLastSeenAt: 1_700_000_000_000,
+      clientLastSeenAt: new Map<string, number>(),
+    }));
   return {
     calls,
     loadCalls,
@@ -221,6 +251,8 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
     sessionPermissionVotes,
     listCalls,
     setModelCalls,
+    heartbeatCalls,
+    heartbeatStateCalls,
     get shutdownCalls() {
       return shutdownCalls;
     },
@@ -296,6 +328,17 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
     async setSessionModel(sessionId, req, context) {
       setModelCalls.push({ sessionId, req, ...(context ? { context } : {}) });
       return setModelImpl(sessionId, req, context);
+    },
+    recordHeartbeat(sessionId, context) {
+      heartbeatCalls.push({
+        sessionId,
+        ...(context ? { context } : {}),
+      });
+      return heartbeatImpl(sessionId, context);
+    },
+    getHeartbeatState(sessionId) {
+      heartbeatStateCalls.push(sessionId);
+      return heartbeatStateImpl(sessionId);
     },
     async killSession(sessionId, opts) {
       killCalls.push({ sessionId, opts });
@@ -1627,6 +1670,99 @@ describe('createServeApp', () => {
       const app = createServeApp(baseOpts, undefined, { bridge });
       const res = await request(app)
         .post('/session/missing/cancel')
+        .set('Host', `127.0.0.1:${baseOpts.port}`);
+      expect(res.status).toBe(404);
+      expect(res.body.sessionId).toBe('missing');
+    });
+  });
+
+  describe('POST /session/:id/heartbeat', () => {
+    it('200 with the bridge result and forwards the routing id', async () => {
+      const bridge = fakeBridge({
+        heartbeatImpl: (sessionId) => ({
+          sessionId,
+          lastSeenAt: 1_700_000_000_001,
+        }),
+      });
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session/session-A/heartbeat')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .send({});
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        sessionId: 'session-A',
+        lastSeenAt: 1_700_000_000_001,
+      });
+      expect(bridge.heartbeatCalls).toEqual([{ sessionId: 'session-A' }]);
+    });
+
+    it('forwards X-Qwen-Client-Id into the bridge context and echoes it back', async () => {
+      const bridge = fakeBridge({
+        heartbeatImpl: (sessionId, context) => ({
+          sessionId,
+          ...(context?.clientId !== undefined
+            ? { clientId: context.clientId }
+            : {}),
+          lastSeenAt: 1_700_000_000_002,
+        }),
+      });
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session/session-A/heartbeat')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('X-Qwen-Client-Id', 'client-1');
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        sessionId: 'session-A',
+        clientId: 'client-1',
+        lastSeenAt: 1_700_000_000_002,
+      });
+      expect(bridge.heartbeatCalls).toEqual([
+        { sessionId: 'session-A', context: { clientId: 'client-1' } },
+      ]);
+    });
+
+    it('400 invalid_client_id when the header is malformed', async () => {
+      const bridge = fakeBridge();
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session/session-A/heartbeat')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('X-Qwen-Client-Id', 'bad client id');
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({ code: 'invalid_client_id' });
+      expect(bridge.heartbeatCalls).toHaveLength(0);
+    });
+
+    it('400 invalid_client_id when the bridge rejects an unknown client', async () => {
+      const bridge = fakeBridge({
+        heartbeatImpl: (sessionId, context) => {
+          throw new InvalidClientIdError(sessionId, context!.clientId!);
+        },
+      });
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session/session-A/heartbeat')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .set('X-Qwen-Client-Id', 'client-unknown');
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        code: 'invalid_client_id',
+        sessionId: 'session-A',
+        clientId: 'client-unknown',
+      });
+    });
+
+    it('404 when the bridge reports an unknown session', async () => {
+      const bridge = fakeBridge({
+        heartbeatImpl: (sessionId) => {
+          throw new SessionNotFoundError(sessionId);
+        },
+      });
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session/missing/heartbeat')
         .set('Host', `127.0.0.1:${baseOpts.port}`);
       expect(res.status).toBe(404);
       expect(res.body.sessionId).toBe('missing');

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -70,6 +70,7 @@ export interface ServeAppDeps {
  *   - `GET  /workspace/:id/sessions`
  *   - `POST /session/:id/prompt`
  *   - `POST /session/:id/cancel`
+ *   - `POST /session/:id/heartbeat`
  *   - `POST /session/:id/model`
  *   - `GET  /session/:id/events` (SSE)
  *   - `POST /session/:id/permission/:requestId`
@@ -528,6 +529,37 @@ export function createServeApp(
       });
     } finally {
       res.off('close', onResClose);
+    }
+  });
+
+  app.post('/session/:id/heartbeat', (req, res) => {
+    // #4175 PR 9: clients ping the daemon to update last-seen
+    // bookkeeping. Bridge throws `SessionNotFoundError` for unknown
+    // ids and `InvalidClientIdError` when an `X-Qwen-Client-Id`
+    // header is supplied but not registered for this session — both
+    // are routed through `sendBridgeError` so they share the same
+    // typed shape (`404` and `400 invalid_client_id`) the rest of
+    // the routes use.
+    const sessionId = req.params['id'];
+    if (!sessionId) {
+      res
+        .status(400)
+        .json({ error: '`sessionId` route parameter is required' });
+      return;
+    }
+    const clientId = parseClientIdHeader(req, res);
+    if (clientId === null) return;
+    try {
+      const result = bridge.recordHeartbeat(
+        sessionId,
+        clientId !== undefined ? { clientId } : undefined,
+      );
+      res.status(200).json(result);
+    } catch (err) {
+      sendBridgeError(res, err, {
+        route: 'POST /session/:id/heartbeat',
+        sessionId,
+      });
     }
   });
 

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -11,6 +11,7 @@ import type {
   DaemonRestoredSession,
   DaemonSession,
   DaemonSessionSummary,
+  HeartbeatResult,
   PermissionResponse,
   PromptContentBlock,
   PromptResult,
@@ -448,6 +449,34 @@ export class DaemonClient {
     );
     if (!res.ok) throw await this.failOnError(res, 'POST /session/:id/prompt');
     return (await res.json()) as PromptResult;
+  }
+
+  /**
+   * Bump the daemon's last-seen bookkeeping for this session. The
+   * route is short-lived — drives diagnostics and future revocation
+   * policy (Wave 5 PR 24) — so it goes through the standard
+   * `fetchTimeoutMs`. Older daemons (pre-PR 9) return 404 for
+   * `/heartbeat`; clients should pre-flight
+   * `caps.features.client_heartbeat` before calling.
+   */
+  async heartbeat(
+    sessionId: string,
+    clientId?: string,
+  ): Promise<HeartbeatResult> {
+    return await this.fetchWithTimeout(
+      `${this.baseUrl}/session/${encodeURIComponent(sessionId)}/heartbeat`,
+      {
+        method: 'POST',
+        headers: this.headers({ 'Content-Type': 'application/json' }, clientId),
+        body: '{}',
+      },
+      async (res) => {
+        if (!res.ok) {
+          throw await this.failOnError(res, 'POST /session/:id/heartbeat');
+        }
+        return (await res.json()) as HeartbeatResult;
+      },
+    );
   }
 
   async cancel(sessionId: string, clientId?: string): Promise<void> {

--- a/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
@@ -15,6 +15,7 @@ import type {
   DaemonEvent,
   DaemonSessionState,
   DaemonSession,
+  HeartbeatResult,
   PermissionResponse,
   PromptResult,
   SetModelResult,
@@ -172,6 +173,17 @@ export class DaemonSessionClient {
 
   async cancel(): Promise<void> {
     await this.client.cancel(this.sessionId, this.clientId);
+  }
+
+  /**
+   * Bump the daemon's last-seen bookkeeping for this session. Adapters
+   * with a long-lived view of a session (TUI/IDE/web) can fire this on
+   * an interval to keep diagnostics fresh and feed PR 24 revocation
+   * policy. Forwards the bound `clientId` so identified clients update
+   * their per-client timestamp instead of just the session-wide one.
+   */
+  async heartbeat(): Promise<HeartbeatResult> {
+    return await this.client.heartbeat(this.sessionId, this.clientId);
   }
 
   async setModel(modelId: string): Promise<SetModelResult> {

--- a/packages/sdk-typescript/src/daemon/index.ts
+++ b/packages/sdk-typescript/src/daemon/index.ts
@@ -65,6 +65,7 @@ export type {
   DaemonSession,
   DaemonSessionState,
   DaemonSessionSummary,
+  HeartbeatResult,
   PermissionOutcome,
   PermissionOutcomeCancelled,
   PermissionOutcomeSelected,

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -163,6 +163,20 @@ export interface SetModelResult {
   [key: string]: unknown;
 }
 
+/**
+ * Returned from `POST /session/:id/heartbeat`. `lastSeenAt` is the
+ * server-side `Date.now()` epoch (ms) the daemon stored for this
+ * session. `clientId` is echoed back only when the caller supplied a
+ * trusted one through `X-Qwen-Client-Id`. Older daemons (pre-PR 9) do
+ * not expose this route — clients should pre-flight
+ * `caps.features.client_heartbeat` before sending.
+ */
+export interface HeartbeatResult {
+  sessionId: string;
+  clientId?: string;
+  lastSeenAt: number;
+}
+
 /** A frame in the SSE event stream. */
 export interface DaemonEvent {
   /**

--- a/packages/sdk-typescript/src/index.ts
+++ b/packages/sdk-typescript/src/index.ts
@@ -55,6 +55,7 @@ export {
   type DaemonStreamErrorData,
   type DaemonStreamErrorEvent,
   type DaemonStreamLifecycleEvent,
+  type HeartbeatResult,
   type KnownDaemonEvent,
   type PermissionOutcome,
   type PermissionOutcomeCancelled,

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -464,6 +464,63 @@ describe('DaemonClient', () => {
     });
   });
 
+  describe('heartbeat', () => {
+    it('POSTs /heartbeat with an empty JSON body and returns the result', async () => {
+      const { fetch, calls } = recordingFetch(() =>
+        jsonResponse(200, {
+          sessionId: 's-1',
+          lastSeenAt: 1_700_000_000_000,
+        }),
+      );
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+      const result = await client.heartbeat('s-1');
+      expect(result).toEqual({
+        sessionId: 's-1',
+        lastSeenAt: 1_700_000_000_000,
+      });
+      expect(calls[0]?.url).toBe('http://daemon/session/s-1/heartbeat');
+      expect(calls[0]?.method).toBe('POST');
+      expect(calls[0]?.body).toBe('{}');
+    });
+
+    it('sends the client identity header when provided', async () => {
+      const { fetch, calls } = recordingFetch(() =>
+        jsonResponse(200, {
+          sessionId: 's-1',
+          clientId: 'client-1',
+          lastSeenAt: 1_700_000_000_001,
+        }),
+      );
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+      const result = await client.heartbeat('s-1', 'client-1');
+      expect(calls[0]?.headers['x-qwen-client-id']).toBe('client-1');
+      expect(result.clientId).toBe('client-1');
+    });
+
+    it('throws DaemonHttpError on 404 (unknown session)', async () => {
+      const { fetch } = recordingFetch(() =>
+        jsonResponse(404, { error: 'unknown', sessionId: 's-1' }),
+      );
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+      await expect(client.heartbeat('s-1')).rejects.toMatchObject({
+        status: 404,
+      });
+    });
+
+    it('throws DaemonHttpError on 400 invalid_client_id', async () => {
+      const { fetch } = recordingFetch(() =>
+        jsonResponse(400, {
+          error: 'unknown client',
+          code: 'invalid_client_id',
+        }),
+      );
+      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+      await expect(client.heartbeat('s-1', 'forged')).rejects.toMatchObject({
+        status: 400,
+      });
+    });
+  });
+
   describe('respondToPermission', () => {
     it('returns true on 200', async () => {
       const { fetch, calls } = recordingFetch(() => jsonResponse(200, {}));

--- a/packages/sdk-typescript/test/unit/DaemonSessionClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonSessionClient.test.ts
@@ -283,6 +283,35 @@ describe('DaemonSessionClient', () => {
     expect(calls[1]?.headers['last-event-id']).toBeUndefined();
   });
 
+  it('forwards heartbeat through DaemonClient with the bound clientId', async () => {
+    const { fetch, calls } = recordingFetch(() =>
+      jsonResponse(200, {
+        sessionId: 's-1',
+        clientId: 'client-1',
+        lastSeenAt: 1_700_000_000_002,
+      }),
+    );
+    const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+    const session = new DaemonSessionClient({
+      client,
+      session: {
+        sessionId: 's-1',
+        workspaceCwd: '/work/a',
+        attached: true,
+        clientId: 'client-1',
+      },
+    });
+    const result = await session.heartbeat();
+    expect(result).toEqual({
+      sessionId: 's-1',
+      clientId: 'client-1',
+      lastSeenAt: 1_700_000_000_002,
+    });
+    expect(calls[0]?.url).toBe('http://daemon/session/s-1/heartbeat');
+    expect(calls[0]?.method).toBe('POST');
+    expect(calls[0]?.headers['x-qwen-client-id']).toBe('client-1');
+  });
+
   it('forwards session-scoped operations through DaemonClient', async () => {
     const { fetch, calls } = recordingFetch((req) => {
       if (req.url.endsWith('/session/s-1/prompt')) {


### PR DESCRIPTION
## Summary

- Adds `POST /session/:id/heartbeat` plus SDK helpers (`DaemonClient.heartbeat()` / `DaemonSessionClient.heartbeat()`) so long-lived adapters (TUI/IDE/web) can refresh the daemon's last-seen bookkeeping.
- Bridge stores per-session and per-client timestamps behind a `getHeartbeatState()` snapshot accessor that the future Wave 3 PR 12 read-only diagnostics route and Wave 5 PR 24 revocation policy will consume.
- Capability tag `client_heartbeat` advertised on `/capabilities.features`.

Roadmap PR 9 from #4175 Wave 2.5. Depends on PR 7 (#4231 — daemon-stamped client identity), already merged, for the trusted `clientId` registry.

## Design

- **Route**: `POST /session/:id/heartbeat`. Empty body. Returns `200 { sessionId, clientId?, lastSeenAt }` (server-side `Date.now()` epoch ms). 404 unknown session, 400 `invalid_client_id` (header malformed or unknown for this session — same shape used by `cancel` / `setSessionModel`).
- **Header**: optional `X-Qwen-Client-Id`, validated via the existing `parseClientIdHeader`.
- **Bridge interface** adds `recordHeartbeat()` and `getHeartbeatState()`. The new `BridgeHeartbeatResult` and `BridgeHeartbeatState` types stay in this PR; the HTTP-side state route is deferred to PR 12.
- **`SessionEntry`** gains `sessionLastSeenAt?: number` and `clientLastSeenAt: Map<string, number>`.

## Security properties

- The bridge validates the `clientId` BEFORE bumping any timestamp (via the existing `resolveTrustedClientId`). Without this, an attacker holding a valid bearer could mask client absence by spamming heartbeats with random ids — the test `'rejects an unknown client id without bumping any timestamp'` covers it.
- `unregisterClient` drops the per-client `clientLastSeenAt` entry alongside the registration ref-count, so a long-lived daemon servicing churn doesn't accumulate stale ids — the very leak revocation policy (PR 24) is meant to plug.
- `getHeartbeatState` returns a snapshot `Map`; mutating it can't reach into bridge state. Type returned as `ReadonlyMap` for compile-time guidance, copy-on-read for runtime safety.
- Anonymous heartbeats only bump the per-session watermark — no per-client entry is created without a trusted `clientId`.

## Backward compatibility

- Default-additive: a new capability tag, a new optional route. Old daemons return 404; SDK clients should pre-flight `caps.features.client_heartbeat`.
- No existing route, event field, or SDK method signature changes. `EXPECTED_STAGE1_FEATURES` and the integration-test capability snapshot are updated in lockstep with `SERVE_CAPABILITY_REGISTRY`.

## Validation

- `npm run typecheck --workspace packages/cli --workspace packages/sdk-typescript` ✅
- `cd packages/cli && npx vitest run src/serve/` → 245/245 passing (server / bridge / eventBus / inMemoryChannel)
- `cd packages/sdk-typescript && npx vitest run test/unit/` → 307/307 passing
- `npx eslint` on every changed file ✅
- `npm run lint` workspace-wide passes for cli; sdk-typescript still hits the pre-existing ESLint rule-loading error from `ProcessTransport.test.ts` that PR 7 also flagged.

## Tests

14 new test cases:

- `server.test.ts` — happy / header forward / malformed header / bridge `InvalidClientIdError` / unknown session
- `httpAcpBridge.test.ts` — anonymous bump / per-client bump / `SessionNotFoundError` / pre-validation invariant / detach cleanup / snapshot immutability
- `DaemonClient.test.ts` — POST shape / header forward / 404 / 400 invalid_client_id
- `DaemonSessionClient.test.ts` — forwards bound `clientId`
- `integration-tests/cli/qwen-serve-routes.test.ts` — capability snapshot kept in sync

## Engineering principles checklist (Stage 1.5 wave PRs)

- [x] Independently mergeable (main stays releasable after merge)
- [x] Backward compatible (no removed routes / event fields / CLI behavior)
- [x] Default off (new capability tag + opt-in client-side calls; old path unchanged)
- [x] `qwen serve` Stage 1 routes / SDK behavior preserved
- [x] Gradual migration (P0/P1 base before adapters; capability-gated)
- [x] Reversible (this PR can be individually rolled back)
- [x] Tests-first (unit + bridge + SDK + integration capability snapshot)

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |

Local macOS validation covered targeted typecheck, vitest, lint. Windows/Linux left to CI.

## Linked Issues

- Implements roadmap PR 9 from #4175.
- Depends on #4231 (PR 7, merged).

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)