### PR TITLE
Pin fetch to bundled undici for undici higher versions compatibility

### DIFF
--- a/packages/cli/src/utils/apiPreconnect.test.ts
+++ b/packages/cli/src/utils/apiPreconnect.test.ts
@@ -17,8 +17,19 @@ const { mockGetOrCreateSharedDispatcher, mockDebugLogger } = vi.hoisted(() => {
   };
 });
 
-// Mock fetch
-const mockFetch = vi.fn().mockResolvedValue(undefined);
+// Mock fetch. apiPreconnect.ts now uses `import { fetch } from 'undici'`
+// rather than the global fetch, so we have to intercept the module export —
+// vi.stubGlobal('fetch', …) would not catch the named import.
+const { mockFetch } = vi.hoisted(() => ({
+  mockFetch: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+  return {
+    ...actual,
+    fetch: mockFetch,
+  };
+});
 vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
@@ -50,11 +61,9 @@ describe('apiPreconnect', () => {
     delete process.env['QWEN_CODE_DISABLE_PRECONNECT'];
     delete process.env['NODE_EXTRA_CA_CERTS'];
     delete process.env['SANDBOX'];
-    vi.stubGlobal('fetch', mockFetch);
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 

--- a/packages/cli/src/utils/apiPreconnect.ts
+++ b/packages/cli/src/utils/apiPreconnect.ts
@@ -21,6 +21,7 @@ import {
   getOrCreateSharedDispatcher,
   redactProxyCredentials,
 } from '@qwen-code/qwen-code-core';
+import { fetch as undiciFetch } from 'undici';
 
 import { getAllProviderBaseUrls } from '../auth/allProviders.js';
 
@@ -194,15 +195,19 @@ export function preconnectApi(
     // so the warmed TCP+TLS connection is reused by subsequent API calls.
     const dispatcher = getOrCreateSharedDispatcher(proxy);
 
-    // Fire HEAD request to warm connection (fire-and-forget)
-    fetch(targetUrl, {
+    // Fire HEAD request to warm connection (fire-and-forget).
+    // Use undici's own fetch (not Node's built-in fetch) so the dispatcher
+    // and fetch come from the same undici version — Node's bundled undici
+    // may differ in major version from the bundled one (e.g. v8 vs v6),
+    // causing handler-interface mismatches like `invalid onError method`.
+    undiciFetch(targetUrl, {
       method: 'HEAD',
       signal: AbortSignal.timeout(5_000),
       headers: {
         'User-Agent': 'QwenCode-Preconnect/1.0',
       },
       dispatcher,
-    } as RequestInit)
+    })
       .then(() => {
         debugLogger.debug('Preconnect completed');
       })

--- a/packages/core/src/core/openaiContentGenerator/provider/default.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.ts
@@ -1,4 +1,5 @@
 import OpenAI from 'openai';
+import { fetch as undiciFetch } from 'undici';
 import type { GenerateContentConfig } from '@google/genai';
 import type { Config } from '../../../config/config.js';
 import type { ContentGeneratorConfig } from '../../contentGenerator.js';
@@ -94,6 +95,11 @@ export class DefaultOpenAICompatibleProvider
       timeout,
       maxRetries,
       defaultHeaders,
+      // Pin fetch to undici's own implementation so it shares a version with
+      // the dispatcher built in `runtimeOptions`. Mixing Node's built-in
+      // fetch (newer undici) with a ProxyAgent from the bundled undici
+      // (e.g. v6) trips handler-interface checks like `invalid onError method`.
+      fetch: undiciFetch as unknown as typeof fetch,
       ...(runtimeOptions || {}),
     });
   }

--- a/packages/core/src/core/openaiContentGenerator/provider/default.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.ts
@@ -1,5 +1,4 @@
 import OpenAI from 'openai';
-import { fetch as undiciFetch } from 'undici';
 import type { GenerateContentConfig } from '@google/genai';
 import type { Config } from '../../../config/config.js';
 import type { ContentGeneratorConfig } from '../../contentGenerator.js';
@@ -95,11 +94,6 @@ export class DefaultOpenAICompatibleProvider
       timeout,
       maxRetries,
       defaultHeaders,
-      // Pin fetch to undici's own implementation so it shares a version with
-      // the dispatcher built in `runtimeOptions`. Mixing Node's built-in
-      // fetch (newer undici) with a ProxyAgent from the bundled undici
-      // (e.g. v6) trips handler-interface checks like `invalid onError method`.
-      fetch: undiciFetch as unknown as typeof fetch,
       ...(runtimeOptions || {}),
     });
   }

--- a/packages/core/src/utils/runtimeFetchOptions.test.ts
+++ b/packages/core/src/utils/runtimeFetchOptions.test.ts
@@ -141,8 +141,9 @@ describe('buildRuntimeFetchOptions (node runtime)', () => {
 
   it('does not inject a fetch override when no proxy is set', () => {
     // No-proxy path must stay on the runtime's built-in fetch — see the
-    // comment in runtimeFetchOptions.ts:586 about avoiding version-mismatch
-    // issues on code paths that don't need a custom dispatcher.
+    // comment in buildFetchOptionsWithDispatcher() in runtimeFetchOptions.ts
+    // about avoiding version-mismatch issues on code paths
+    // that don't need a custom dispatcher.
     const openaiResult = buildRuntimeFetchOptions('openai');
     expect(openaiResult).toBeUndefined();
 

--- a/packages/core/src/utils/runtimeFetchOptions.test.ts
+++ b/packages/core/src/utils/runtimeFetchOptions.test.ts
@@ -22,6 +22,10 @@ vi.mock('./debugLogger.js', () => ({
   mockWarn,
 }));
 
+const { mockUndiciFetch } = vi.hoisted(() => ({
+  mockUndiciFetch: vi.fn(),
+}));
+
 vi.mock('undici', () => {
   class MockAgent {
     options: UndiciOptions;
@@ -47,6 +51,7 @@ vi.mock('undici', () => {
   return {
     Agent: MockAgent,
     ProxyAgent: MockProxyAgent,
+    fetch: mockUndiciFetch,
   };
 });
 
@@ -112,6 +117,37 @@ describe('buildRuntimeFetchOptions (node runtime)', () => {
       headersTimeout: 0,
       bodyTimeout: 0,
     });
+  });
+
+  it('pins fetch to undici when proxy is set so dispatcher and fetch share a version', () => {
+    // Regression for `invalid onError method`: Node's built-in fetch (newer
+    // undici) cannot accept a ProxyAgent built from a different undici major.
+    // The function must hand back the bundled undici's fetch alongside the
+    // dispatcher.
+    const openaiResult = buildRuntimeFetchOptions(
+      'openai',
+      'http://proxy.local',
+    );
+    expect((openaiResult as { fetch?: unknown }).fetch).toBe(mockUndiciFetch);
+
+    const anthropicResult = buildRuntimeFetchOptions(
+      'anthropic',
+      'http://proxy.local',
+    );
+    expect((anthropicResult as { fetch?: unknown }).fetch).toBe(
+      mockUndiciFetch,
+    );
+  });
+
+  it('does not inject a fetch override when no proxy is set', () => {
+    // No-proxy path must stay on the runtime's built-in fetch — see the
+    // comment in runtimeFetchOptions.ts:586 about avoiding version-mismatch
+    // issues on code paths that don't need a custom dispatcher.
+    const openaiResult = buildRuntimeFetchOptions('openai');
+    expect(openaiResult).toBeUndefined();
+
+    const anthropicResult = buildRuntimeFetchOptions('anthropic');
+    expect((anthropicResult as { fetch?: unknown }).fetch).toBeUndefined();
   });
 
   it('returns undefined for OpenAI when dispatcher creation fails', () => {

--- a/packages/core/src/utils/runtimeFetchOptions.ts
+++ b/packages/core/src/utils/runtimeFetchOptions.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ProxyAgent, type Dispatcher } from 'undici';
+import { ProxyAgent, fetch as undiciFetch, type Dispatcher } from 'undici';
 
 import { createDebugLogger } from './debugLogger.js';
 
@@ -37,6 +37,13 @@ export type OpenAIRuntimeFetchOptions =
         dispatcher?: Dispatcher;
         timeout?: false;
       };
+      // Optional fetch override. When a custom dispatcher is being passed,
+      // we pin this to the bundled undici's fetch so the dispatcher and
+      // fetch share a single undici version — otherwise Node's built-in
+      // fetch (newer undici) rejects a ProxyAgent from the bundled undici
+      // (e.g. v6) with `invalid onError method`.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fetch?: any;
     }
   | undefined;
 
@@ -596,7 +603,13 @@ function buildFetchOptionsWithDispatcher(
   // 300s bodyTimeout. This is sufficient for all current model streaming responses.
   try {
     const dispatcher = getOrCreateSharedDispatcher(proxyUrl);
-    return { fetchOptions: { dispatcher } };
+    // Pin fetch to undici's own implementation so the dispatcher and fetch
+    // come from the same undici version. Node's bundled undici may differ in
+    // major version from the project's bundled one (e.g. v8 vs v6), which
+    // breaks dispatcher handler-interface checks (`invalid onError method`).
+    // The no-proxy branch above intentionally skips this so the runtime's
+    // built-in fetch continues to be used when no dispatcher is involved.
+    return { fetchOptions: { dispatcher }, fetch: undiciFetch };
   } catch (error) {
     // Log dispatcher creation failure - requests will fallback to direct connection
     // bypassing the configured proxy. This is important for environments requiring


### PR DESCRIPTION
Node.js 26 (on ArchLinux installed by `sudo pacman -S nodejs`) bundles undici 8.x, which differs from the project's undici 6.x. Using Node's built-in fetch mixed with ProxyAgent/Client from the bundled undici causes handler-interface mismatches (e.g. 'InvalidArgumentError: invalid onError method').

This PR should fix #4035 #3914 #4274 

<!--
Help reviewers verify this PR quickly.

Maintainers prioritize PRs that include clear proof of work.
If a PR does not include enough validation detail to reproduce and verify the change efficiently, review may be delayed.
-->

## Summary

- What changed: pin fetch to bundled undici.
- Why it changed: for undici higher versions compatibility
- Reviewer focus: calling to LLM APIs.

## Validation

<!--
Be concrete. Do not write only "tested locally".
Include the exact commands, prompts, outputs, logs, screenshots, or videos that prove the change was actually run and observed.

For user-visible changes, bug fixes, CLI / TUI behavior changes, or interaction changes, include key screenshots or a short video.
When possible, show before/after behavior.

If helpful, use the `e2e-testing` skill to gather stronger end-to-end validation evidence.
-->

- Commands run:
  ```bash
  npm install
  npm run build
  sudo npm link
  OPENAI_BASE_URL=https://api.deepseek.com OPENAI_MODEL=deepseek-v4-flash OPENAI_API_KEY=sk-xxxx qwen
  # Ask questions in qwen
  ```
- Prompts / inputs used: who are you?
- Expected result: 我是 Qwen Code，由阿里云开发的一个交互式 CLI 智能体，专注于软件工程任务。我可以帮你编写、修改、调试代码，运行测试，管理项目，以及处理各种开发相关的工作。有什么我可以帮你的吗？
- Observed result: 我是 Qwen Code，由阿里云开发的一个交互式 CLI 智能体，专注于软件工程任务。我可以帮你编写、修改、调试代码，运行测试，管理项目，以及处理各种开发相关的工作。有什么我可以帮你的吗？
- Quickest reviewer verification path: Using Node.js v26.1.0，without patch，it will show error: `[API Error: Connection error. (cause: fetch failed)]`
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):

Before:

<img width="1083" height="356" alt="截屏2026-05-18 16 13 11" src="https://github.com/user-attachments/assets/71927a82-7717-4bd5-aa23-914fa9a8bf43" />


```
2026-05-12T10:24:48.153Z [ERROR] [ERROR_REPORT] Error when talking to API [Turn.run-sendMessageStream] {
  "error": {
    "message": "Connection error.",
    "stack": "Error: Connection error.\n    at OpenAI.makeRequest (file:///usr/lib/node_modules/@qwen-code/qwen-code/dist/cli.js:156446:17)\n    at async file:///usr/lib/node_modules/@qwen-code/qwen-code/dist/cli.js:157771:29\n    at async ContentGenerationPipeline.executeWithErrorHandling (file:///usr/lib/node_modules/@qwen-code/qwen-code/dist/cli.js:157995:26)\n    at async LoggingContentGenerator.generateContentStream (file:///usr/lib/node_modules/@qwen-code/qwen-code/dist/cli.js:147297:21)\n    at async retryWithBackoff (file:///usr/lib/node_modules/@qwen-code/qwen-code/dist/cli.js:173519:22)\n    at async GeminiChat.makeApiCallAndProcessStream (file:///usr/lib/node_modules/@qwen-code/qwen-code/dist/cli.js:179294:33)\n    at async file:///usr/lib/node_modules/@qwen-code/qwen-code/dist/cli.js:179067:33\n    at async Turn.run (file:///usr/lib/node_modules/@qwen-code/qwen-code/dist/cli.js:177019:28)\n    at async GeminiClient.sendMessageStream (file:///usr/lib/node_modules/@qwen-code/qwen-code/dist/cli.js:237801:26)\n    at async file:///usr/lib/node_modules/@qwen-code/qwen-code/dist/cli.js:556004:26"
  },
```

## Scope / Risk

- Main risk or tradeoff: none.
- Not covered / not validated: non OpenAI compatible LLM APIs.
- Breaking changes / migration notes: none.

## Testing Matrix

<!--
Use:
- ✅ tested
- ⚠️ not tested
- N/A
If anything is ⚠️, explain why briefly below.
-->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ✅  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Tested on macOS and Linux with Node.js v26.0.0.

## Linked Issues / Bugs

- Fixes #4076 #4035 #3914 #4274

