### PR TITLE
refactor(serve): add FileSystemService boundary (#4175 Wave 4 PR 18)

### DIFF
--- a/packages/cli/src/serve/fs/audit.test.ts
+++ b/packages/cli/src/serve/fs/audit.test.ts
@@ -173,4 +173,46 @@ describe('createAuditPublisher', () => {
       else process.env['QWEN_AUDIT_RAW_PATHS'] = original;
     }
   });
+
+  it('substitutes <cross-drive> sentinel when path.relative cannot produce a relative form', () => {
+    // Simulates the Windows cross-drive case (`C:\\ws` vs `D:\\evil`)
+    // where `path.relative` returns the absolute target. We can't
+    // forge a Windows path on POSIX cleanly, so we mock the
+    // function's invariant directly: when the boundWorkspace and
+    // input are *unrelated absolute paths* such that `path.relative`
+    // returns an absolute result, the audit substitutes a sentinel.
+    // On POSIX `path.relative('/a', '/b')` returns `'../b'` which IS
+    // relative, so we instead exercise the contract via a Windows-
+    // path-shape input (verified at runtime by `path.isAbsolute` on
+    // the platform). This test is platform-neutral about the
+    // *trigger* and just checks the *substitution*.
+    const events: BridgeEvent[] = [];
+    const workspace = path.join(os.tmpdir(), 'audit-xdrive');
+    const publisher = createAuditPublisher({
+      emit: (e) => events.push(e),
+      boundWorkspace: workspace,
+      includeRawPaths: true,
+    });
+    // Construct a denied input on a drive `Z:` that's outside the
+    // workspace (POSIX treats `Z:\\evil` as a relative single-segment
+    // string, so we set boundWorkspace to a Win32-style path so the
+    // `path.isAbsolute(rel)` check fires consistently).
+    publisher.recordDenied(
+      { route: 'GET /file' },
+      {
+        intent: 'read',
+        input: 'Z:\\\\evil\\\\target.txt',
+        errorKind: 'path_outside_workspace',
+      },
+    );
+    // On POSIX `path.relative` is well-defined here so this test
+    // only asserts that whatever relPath surfaces is either a true
+    // relative (no path.isAbsolute on the value) or the sentinel.
+    const data = events[0].data as { relPath?: string };
+    if (data.relPath !== undefined) {
+      expect(
+        data.relPath === '<cross-drive>' || !path.isAbsolute(data.relPath),
+      ).toBe(true);
+    }
+  });
 });

--- a/packages/cli/src/serve/fs/audit.test.ts
+++ b/packages/cli/src/serve/fs/audit.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createHash } from 'node:crypto';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  FS_ACCESS_EVENT_TYPE,
+  FS_DENIED_EVENT_TYPE,
+  createAuditPublisher,
+} from './audit.js';
+import type { ResolvedPath } from './paths.js';
+import type { BridgeEvent } from '../eventBus.js';
+
+function expectedHash(p: string): string {
+  return createHash('sha256').update(p).digest('hex').slice(0, 16);
+}
+
+describe('createAuditPublisher', () => {
+  function setup(opts?: { includeRawPaths?: boolean }) {
+    const events: BridgeEvent[] = [];
+    const workspace = path.join(os.tmpdir(), 'audit-ws');
+    const publisher = createAuditPublisher({
+      emit: (e) => events.push(e),
+      boundWorkspace: workspace,
+      includeRawPaths: opts?.includeRawPaths ?? false,
+    });
+    return { events, publisher, workspace };
+  }
+
+  it('emits fs.access with hashed path and originatorClientId', () => {
+    const { events, publisher, workspace } = setup();
+    const absolute = path.join(workspace, 'src', 'index.ts') as ResolvedPath;
+    publisher.recordAccess(
+      {
+        originatorClientId: 'client-abc',
+        sessionId: 'sess-1',
+        route: 'GET /file',
+      },
+      {
+        intent: 'read',
+        absolute,
+        durationMs: 12,
+        sizeBytes: 4096,
+      },
+    );
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev.type).toBe(FS_ACCESS_EVENT_TYPE);
+    expect(ev.v).toBe(1);
+    expect(ev.originatorClientId).toBe('client-abc');
+    expect(ev.data).toMatchObject({
+      kind: FS_ACCESS_EVENT_TYPE,
+      intent: 'read',
+      route: 'GET /file',
+      pathHash: expectedHash(absolute),
+      sizeBytes: 4096,
+      durationMs: 12,
+    });
+    // No relPath unless raw paths enabled.
+    expect(ev.data).not.toHaveProperty('relPath');
+  });
+
+  it('attaches relPath when includeRawPaths is true', () => {
+    const { events, publisher, workspace } = setup({ includeRawPaths: true });
+    const absolute = path.join(workspace, 'src', 'index.ts') as ResolvedPath;
+    publisher.recordAccess(
+      { originatorClientId: 'c', route: 'GET /file' },
+      { intent: 'read', absolute, durationMs: 1 },
+    );
+    expect((events[0].data as { relPath?: string }).relPath).toBe(
+      path.join('src', 'index.ts'),
+    );
+  });
+
+  it('omits truncated/matchedIgnore when not provided', () => {
+    const { events, publisher, workspace } = setup();
+    const absolute = path.join(workspace, 'a.ts') as ResolvedPath;
+    publisher.recordAccess(
+      { route: 'GET /file' },
+      { intent: 'read', absolute, durationMs: 0 },
+    );
+    expect(events[0].data).not.toHaveProperty('truncated');
+    expect(events[0].data).not.toHaveProperty('matchedIgnore');
+  });
+
+  it('preserves truncated and matchedIgnore when set', () => {
+    const { events, publisher, workspace } = setup();
+    const absolute = path.join(workspace, 'big.txt') as ResolvedPath;
+    publisher.recordAccess(
+      { route: 'GET /file' },
+      {
+        intent: 'read',
+        absolute,
+        durationMs: 5,
+        truncated: true,
+        matchedIgnore: 'file',
+        sizeBytes: 1024 * 1024,
+      },
+    );
+    expect(events[0].data).toMatchObject({
+      truncated: true,
+      matchedIgnore: 'file',
+      sizeBytes: 1024 * 1024,
+    });
+  });
+
+  it('emits fs.denied with errorKind and hashed probe path', () => {
+    const { events, publisher, workspace } = setup();
+    publisher.recordDenied(
+      { originatorClientId: 'c', route: 'GET /file' },
+      {
+        intent: 'read',
+        input: '../escape',
+        errorKind: 'path_outside_workspace',
+        hint: 'paths must stay inside workspace',
+      },
+    );
+    expect(events).toHaveLength(1);
+    const ev = events[0];
+    expect(ev.type).toBe(FS_DENIED_EVENT_TYPE);
+    expect(ev.originatorClientId).toBe('c');
+    expect(ev.data).toMatchObject({
+      kind: FS_DENIED_EVENT_TYPE,
+      intent: 'read',
+      route: 'GET /file',
+      errorKind: 'path_outside_workspace',
+      hint: 'paths must stay inside workspace',
+      // probe path = path.resolve(workspace, '../escape')
+      pathHash: expectedHash(path.resolve(workspace, '../escape')),
+    });
+  });
+
+  it('emits fs.denied even when hint is absent', () => {
+    const { events, publisher } = setup();
+    publisher.recordDenied(
+      { route: 'POST /file/edit' },
+      {
+        intent: 'edit',
+        input: '/etc/passwd',
+        errorKind: 'symlink_escape',
+      },
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].data).not.toHaveProperty('hint');
+  });
+
+  it('respects QWEN_AUDIT_RAW_PATHS=1 via env when includeRawPaths is unset', () => {
+    const original = process.env['QWEN_AUDIT_RAW_PATHS'];
+    process.env['QWEN_AUDIT_RAW_PATHS'] = '1';
+    try {
+      const events: BridgeEvent[] = [];
+      const workspace = path.join(os.tmpdir(), 'audit-env');
+      const publisher = createAuditPublisher({
+        emit: (e) => events.push(e),
+        boundWorkspace: workspace,
+      });
+      publisher.recordAccess(
+        { route: 'GET /file' },
+        {
+          intent: 'read',
+          absolute: path.join(workspace, 'foo') as ResolvedPath,
+          durationMs: 0,
+        },
+      );
+      expect((events[0].data as { relPath?: string }).relPath).toBe('foo');
+    } finally {
+      if (original === undefined) delete process.env['QWEN_AUDIT_RAW_PATHS'];
+      else process.env['QWEN_AUDIT_RAW_PATHS'] = original;
+    }
+  });
+});

--- a/packages/cli/src/serve/fs/audit.ts
+++ b/packages/cli/src/serve/fs/audit.ts
@@ -61,6 +61,16 @@ export interface FsAccessAuditPayload {
   intent: Intent;
   route: string;
   pathHash: string;
+  /**
+   * ACP session id from `AuditContext.sessionId`, when known.
+   * Multi-session daemons need this to correlate audit events
+   * back to the session that triggered them — `originatorClientId`
+   * alone identifies the *client*, not the *session*. Always
+   * present when the calling route is session-scoped (PR 19/20
+   * routes that take `:sessionId`); absent on workspace-scoped
+   * routes that have no session context.
+   */
+  sessionId?: string;
   /** Workspace-relative path; only populated when QWEN_AUDIT_RAW_PATHS=1. */
   relPath?: string;
   sizeBytes?: number;
@@ -74,6 +84,8 @@ export interface FsDeniedAuditPayload {
   intent: Intent;
   route: string;
   pathHash: string;
+  /** See `FsAccessAuditPayload.sessionId` — same semantics. */
+  sessionId?: string;
   relPath?: string;
   errorKind: FsErrorKind;
   hint?: string;
@@ -189,6 +201,7 @@ export function createAuditPublisher(
         pathHash: hashPath(absolute),
         durationMs: record.durationMs,
       };
+      if (ctx.sessionId) payload.sessionId = ctx.sessionId;
       if (record.sizeBytes !== undefined) payload.sizeBytes = record.sizeBytes;
       if (record.truncated) payload.truncated = true;
       if (record.matchedIgnore) payload.matchedIgnore = record.matchedIgnore;
@@ -213,6 +226,7 @@ export function createAuditPublisher(
         pathHash: hashPath(probe),
         errorKind: record.errorKind,
       };
+      if (ctx.sessionId) payload.sessionId = ctx.sessionId;
       if (record.hint) payload.hint = record.hint;
       // `message` carries the underlying `FsError.message`, which
       // many throw-sites embed `${p}` (absolute workspace path) or

--- a/packages/cli/src/serve/fs/audit.ts
+++ b/packages/cli/src/serve/fs/audit.ts
@@ -141,16 +141,38 @@ function hashPath(absolute: string): string {
 }
 
 /**
+ * Sentinel returned when `path.relative` produces an absolute
+ * path — happens on Windows when the input is on a different
+ * drive than `boundWorkspace`. Without this guard, audit
+ * consumers (even in raw-paths mode) would see something that
+ * looks like a valid relative path but is actually a fully
+ * qualified `D:\evil\...` leaking the attacker's drive letter +
+ * directory structure. The sentinel lets a UI render
+ * cross-drive denials distinctly without ambiguity over what's
+ * relative vs absolute.
+ */
+const CROSS_DRIVE_RELPATH = '<cross-drive>' as const;
+
+/**
  * Compute the workspace-relative form of a path for the optional
  * `relPath` audit field. Returns the trailing path even when the
  * input lies outside `boundWorkspace` (the `denied` case): the
  * audit consumer wants to see what the caller asked for, not be
  * silently dropped.
+ *
+ * On Windows, `path.relative` between paths on different drives
+ * (`C:\\ws` vs `D:\\evil`) can't produce a relative form and
+ * returns the absolute target — leaking the off-drive path into
+ * the audit row. We detect that with `path.isAbsolute` on the
+ * *result* and substitute `CROSS_DRIVE_RELPATH` so the field
+ * stays a true relative-or-sentinel and the cross-drive case is
+ * still visible (just not the absolute path content).
  */
 function relForAudit(raw: string, boundWorkspace: string): string {
   // For absolute inputs, compute relative; for relative, pass through.
   // Either way the operator gets a workspace-anchored view.
-  return path.isAbsolute(raw) ? path.relative(boundWorkspace, raw) : raw;
+  const rel = path.isAbsolute(raw) ? path.relative(boundWorkspace, raw) : raw;
+  return path.isAbsolute(rel) ? CROSS_DRIVE_RELPATH : rel;
 }
 
 /**

--- a/packages/cli/src/serve/fs/audit.ts
+++ b/packages/cli/src/serve/fs/audit.ts
@@ -1,0 +1,218 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { createHash } from 'node:crypto';
+import * as path from 'node:path';
+import { EVENT_SCHEMA_VERSION, type BridgeEvent } from '../eventBus.js';
+import type { FsErrorKind } from './errors.js';
+import type { Intent, ResolvedPath } from './paths.js';
+
+/**
+ * Frame type for successful filesystem operations on the boundary.
+ * Emitted from the orchestrator on the success path of `readText`,
+ * `readBytes`, `list`, `glob`, `stat`, `writeText`, `edit`. PR 19/20
+ * SSE consumers can fan it out to subscribed clients; PR 18 itself
+ * has no consumer beyond unit tests, since no HTTP routes use the
+ * boundary yet.
+ */
+export const FS_ACCESS_EVENT_TYPE = 'fs.access' as const;
+
+/**
+ * Frame type for boundary policy denials. Emitted whenever an
+ * `FsError` propagates from the orchestrator. Always emitted, even
+ * for transient ones that the route handler will surface to the
+ * caller — the audit trail is the operator's tool, separate from
+ * the client-visible response.
+ */
+export const FS_DENIED_EVENT_TYPE = 'fs.denied' as const;
+
+/**
+ * Request-scoped audit context. Bound to a `WorkspaceFileSystem`
+ * instance by the factory's `forRequest(ctx)` call so individual
+ * orchestrator methods don't need to thread these fields by hand.
+ */
+export interface AuditContext {
+  /** Daemon-stamped client identity from PR 7 (#4231). */
+  originatorClientId?: string;
+  /** Optional ACP session id for cross-correlating audit + session events. */
+  sessionId?: string;
+  /** Route name like 'GET /file' — populated by PR 19/20 handlers. */
+  route: string;
+}
+
+/**
+ * Successful-access record. The hot path computes this lazily so a
+ * disabled publisher (no subscribers, no flag) doesn't pay the
+ * SHA-256 cost. Sized fields (`sizeBytes`) and outcome fields
+ * (`truncated`) are present only when meaningful for the intent.
+ *
+ * The literal `kind` field discriminates this against
+ * `FsDeniedAuditPayload` so SDK consumers can `switch` over a
+ * `FsAccessAuditPayload | FsDeniedAuditPayload` union and have
+ * the type narrow inside each branch — the `BridgeEvent.type`
+ * envelope alone doesn't propagate type information into
+ * `event.data: unknown`.
+ */
+export interface FsAccessAuditPayload {
+  kind: typeof FS_ACCESS_EVENT_TYPE;
+  intent: Intent;
+  route: string;
+  pathHash: string;
+  /** Workspace-relative path; only populated when QWEN_AUDIT_RAW_PATHS=1. */
+  relPath?: string;
+  sizeBytes?: number;
+  truncated?: boolean;
+  matchedIgnore?: 'file' | 'directory';
+  durationMs: number;
+}
+
+export interface FsDeniedAuditPayload {
+  kind: typeof FS_DENIED_EVENT_TYPE;
+  intent: Intent;
+  route: string;
+  pathHash: string;
+  relPath?: string;
+  errorKind: FsErrorKind;
+  hint?: string;
+}
+
+/**
+ * Boundary-side audit publisher. The orchestrator (commit 6) will
+ * call `recordAccess` on success and `recordDenied` on `FsError`,
+ * passing the resolved path so this module can normalize, hash,
+ * and (optionally) attach the relative form.
+ */
+export interface AuditPublisher {
+  recordAccess(
+    ctx: AuditContext,
+    record: Omit<
+      FsAccessAuditPayload,
+      'kind' | 'pathHash' | 'relPath' | 'route'
+    > & {
+      absolute: ResolvedPath | string;
+    },
+  ): void;
+  recordDenied(
+    ctx: AuditContext,
+    record: Omit<
+      FsDeniedAuditPayload,
+      'kind' | 'pathHash' | 'relPath' | 'route'
+    > & {
+      /** Raw user input; the canonical form may not exist on disk. */
+      input: string;
+    },
+  ): void;
+}
+
+/**
+ * SHA-256 over the canonical absolute path, truncated to 16 hex
+ * chars. The truncation matches claude-code's privacy model: long
+ * enough to be unique within a workspace, short enough that an
+ * audit log is human-scannable. Full hex (64 chars) buys nothing
+ * here because the audit consumer never reverses the hash.
+ */
+function hashPath(absolute: string): string {
+  return createHash('sha256').update(absolute).digest('hex').slice(0, 16);
+}
+
+/**
+ * Compute the workspace-relative form of a path for the optional
+ * `relPath` audit field. Returns the trailing path even when the
+ * input lies outside `boundWorkspace` (the `denied` case): the
+ * audit consumer wants to see what the caller asked for, not be
+ * silently dropped.
+ */
+function relForAudit(raw: string, boundWorkspace: string): string {
+  // For absolute inputs, compute relative; for relative, pass through.
+  // Either way the operator gets a workspace-anchored view.
+  return path.isAbsolute(raw) ? path.relative(boundWorkspace, raw) : raw;
+}
+
+/**
+ * Whether the env opt-in for raw paths is active. Read once per
+ * factory invocation rather than per emit, so flipping the env
+ * mid-process needs a daemon restart — predictable behavior for
+ * operators tailing logs.
+ */
+function rawPathsEnabled(): boolean {
+  return process.env['QWEN_AUDIT_RAW_PATHS'] === '1';
+}
+
+export interface CreateAuditPublisherDeps {
+  /** Bridge-bound publisher into `EventBus.publish`. */
+  emit: (event: BridgeEvent) => void;
+  /** Canonical workspace root, for relPath computation. */
+  boundWorkspace: string;
+  /** Optional override for tests / privacy modes. */
+  includeRawPaths?: boolean;
+}
+
+/**
+ * Build an `AuditPublisher` whose emit method publishes typed
+ * `BridgeEvent`s onto the daemon's per-session NDJSON stream. The
+ * publisher takes care of:
+ *
+ * - hashing the path (always)
+ * - computing relative path (only when `includeRawPaths` is on)
+ * - synthesizing the `BridgeEvent.type` discriminator
+ * - forwarding `originatorClientId` so the SSE fan-out can suppress
+ *   self-echoes
+ *
+ * Publishers are cheap to construct and intended to live on a
+ * `WorkspaceFileSystemFactory` for the daemon's process lifetime.
+ */
+export function createAuditPublisher(
+  deps: CreateAuditPublisherDeps,
+): AuditPublisher {
+  const includeRawPaths = deps.includeRawPaths ?? rawPathsEnabled();
+  const { emit, boundWorkspace } = deps;
+  return {
+    recordAccess(ctx, record) {
+      const absolute = String(record.absolute);
+      const payload: FsAccessAuditPayload = {
+        kind: FS_ACCESS_EVENT_TYPE,
+        intent: record.intent,
+        route: ctx.route,
+        pathHash: hashPath(absolute),
+        durationMs: record.durationMs,
+      };
+      if (record.sizeBytes !== undefined) payload.sizeBytes = record.sizeBytes;
+      if (record.truncated) payload.truncated = true;
+      if (record.matchedIgnore) payload.matchedIgnore = record.matchedIgnore;
+      if (includeRawPaths) {
+        payload.relPath = relForAudit(absolute, boundWorkspace);
+      }
+      emit({
+        v: EVENT_SCHEMA_VERSION,
+        type: FS_ACCESS_EVENT_TYPE,
+        data: payload,
+        originatorClientId: ctx.originatorClientId,
+      });
+    },
+    recordDenied(ctx, record) {
+      const probe = path.isAbsolute(record.input)
+        ? record.input
+        : path.resolve(boundWorkspace, record.input);
+      const payload: FsDeniedAuditPayload = {
+        kind: FS_DENIED_EVENT_TYPE,
+        intent: record.intent,
+        route: ctx.route,
+        pathHash: hashPath(probe),
+        errorKind: record.errorKind,
+      };
+      if (record.hint) payload.hint = record.hint;
+      if (includeRawPaths) {
+        payload.relPath = relForAudit(record.input, boundWorkspace);
+      }
+      emit({
+        v: EVENT_SCHEMA_VERSION,
+        type: FS_DENIED_EVENT_TYPE,
+        data: payload,
+        originatorClientId: ctx.originatorClientId,
+      });
+    },
+  };
+}

--- a/packages/cli/src/serve/fs/audit.ts
+++ b/packages/cli/src/serve/fs/audit.ts
@@ -77,6 +77,16 @@ export interface FsDeniedAuditPayload {
   relPath?: string;
   errorKind: FsErrorKind;
   hint?: string;
+  /**
+   * Human-readable error message from the underlying `FsError`.
+   * Audit consumers debugging a production incident need to see
+   * the actual OS error (e.g. errno detail, byte counts) rather
+   * than only `errorKind` + `hint`. Optional so privacy-sensitive
+   * deployments can suppress it; populated by default by
+   * `recordDenied` since the orchestrator already wraps every body
+   * error into an `FsError` whose message we can quote.
+   */
+  message?: string;
 }
 
 /**
@@ -204,6 +214,7 @@ export function createAuditPublisher(
         errorKind: record.errorKind,
       };
       if (record.hint) payload.hint = record.hint;
+      if (record.message) payload.message = record.message;
       if (includeRawPaths) {
         payload.relPath = relForAudit(record.input, boundWorkspace);
       }

--- a/packages/cli/src/serve/fs/audit.ts
+++ b/packages/cli/src/serve/fs/audit.ts
@@ -214,7 +214,18 @@ export function createAuditPublisher(
         errorKind: record.errorKind,
       };
       if (record.hint) payload.hint = record.hint;
-      if (record.message) payload.message = record.message;
+      // `message` carries the underlying `FsError.message`, which
+      // many throw-sites embed `${p}` (absolute workspace path) or
+      // user-supplied `oldText` snippets into. Privacy-mode
+      // deployments that intentionally disabled raw-path logging
+      // would otherwise see those paths leak through the message.
+      // Gate the field on `includeRawPaths` so privacy mode means
+      // privacy mode for ALL path-bearing audit content (relPath
+      // AND message). Operators who want full forensic context
+      // opt in via `QWEN_AUDIT_RAW_PATHS=1`.
+      if (record.message && includeRawPaths) {
+        payload.message = record.message;
+      }
       if (includeRawPaths) {
         payload.relPath = relForAudit(record.input, boundWorkspace);
       }

--- a/packages/cli/src/serve/fs/contract.test.ts
+++ b/packages/cli/src/serve/fs/contract.test.ts
@@ -1,0 +1,272 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { promises as fsp, realpathSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { WorkspaceContext } from '@qwen-code/qwen-code-core';
+import { canonicalizeWorkspace, resolveWithinWorkspace } from './paths.js';
+import type { FsError, isFsError, type FsErrorKind } from './errors.js';
+
+/**
+ * Kinds the boundary throws to indicate the path is *outside the
+ * workspace*. `path_not_found` is intentionally NOT here: it's a
+ * separate "exists?" decision, and `WorkspaceContext` returns
+ * `true` ("would be in workspace if it existed") for missing files
+ * — a legitimate semantic mismatch the contract doesn't try to
+ * unify.
+ */
+const OUT_OF_WORKSPACE_KINDS: ReadonlySet<FsErrorKind> = new Set([
+  'path_outside_workspace',
+  'symlink_escape',
+]);
+
+/**
+ * #4175 PR 18 contract test (commit 8 of plan).
+ *
+ * The serve boundary's `resolveWithinWorkspace` and the existing
+ * `WorkspaceContext.isPathWithinWorkspace` (which routes through a
+ * cached `fs.realpathSync`) live in different packages and have
+ * independent code paths. This corpus pins their agreement so a
+ * future refactor of either side has a one-shot signal that
+ * canonicalization has drifted.
+ *
+ * Concretely we assert:
+ *   1. For paths the boundary admits, `WorkspaceContext` agrees the
+ *      path is inside the workspace.
+ *   2. For paths the boundary rejects with `path_outside_workspace`
+ *      or `symlink_escape`, `WorkspaceContext` agrees the path is
+ *      outside.
+ *   3. The canonical form `resolveWithinWorkspace` returns matches
+ *      `realpathSync.native` (the "ground truth" the boundary's
+ *      ENOENT-tolerant code path falls back to via `path.resolve`).
+ *
+ * The corpus is intentionally small but covers the dimensions that
+ * tend to disagree on edge cases: symlinks pointing in/out, ENOENT
+ * paths, case-different inputs on case-insensitive filesystems,
+ * and `..` traversal.
+ */
+
+interface CorpusCase {
+  name: string;
+  /** Setup hook; receives the workspace path and may create files/symlinks. */
+  setup?: (workspace: string, scratch: string) => Promise<void>;
+  /** Path passed to both APIs. */
+  input: (workspace: string, scratch: string) => string;
+  /**
+   * Whether we expect the path to be inside the workspace.
+   * `'existence-mismatch'` flags cases where the boundary rejects
+   * with `path_not_found` but `WorkspaceContext` says "would-be
+   * inside" — by design the two APIs answer different questions.
+   */
+  expectInside: boolean | 'existence-mismatch';
+  /** Intent for `resolveWithinWorkspace`. */
+  intent: 'read' | 'write' | 'list' | 'glob' | 'stat';
+  /**
+   * If set, only run on these platforms. Used for case-mismatch
+   * (macOS/win) and symlink-on-Windows cases that may need admin.
+   */
+  onlyPlatforms?: NodeJS.Platform[];
+}
+
+const CORPUS: CorpusCase[] = [
+  {
+    name: 'plain file inside workspace',
+    setup: async (ws) => {
+      await fsp.writeFile(path.join(ws, 'a.txt'), 'a');
+    },
+    input: () => 'a.txt',
+    expectInside: true,
+    intent: 'read',
+  },
+  {
+    name: 'nested file inside workspace',
+    setup: async (ws) => {
+      await fsp.mkdir(path.join(ws, 'src'));
+      await fsp.writeFile(path.join(ws, 'src', 'index.ts'), '');
+    },
+    input: () => path.join('src', 'index.ts'),
+    expectInside: true,
+    intent: 'read',
+  },
+  {
+    name: 'workspace root via "."',
+    input: () => '.',
+    expectInside: true,
+    intent: 'list',
+  },
+  {
+    name: '`..` traversal lands outside',
+    input: () => '../escape',
+    expectInside: false,
+    intent: 'read',
+  },
+  {
+    name: 'absolute path outside workspace',
+    setup: async (_ws, scratch) => {
+      await fsp.writeFile(path.join(scratch, 'outside.txt'), 'x');
+    },
+    input: (_ws, scratch) => path.join(scratch, 'outside.txt'),
+    expectInside: false,
+    intent: 'read',
+  },
+  {
+    name: 'symlink inside workspace pointing out',
+    setup: async (ws, scratch) => {
+      const outside = path.join(scratch, 'leak-target.txt');
+      await fsp.writeFile(outside, 'sensitive');
+      await fsp.symlink(outside, path.join(ws, 'leak'), 'file');
+    },
+    input: () => 'leak',
+    expectInside: false,
+    intent: 'read',
+  },
+  {
+    name: 'symlink inside workspace pointing in',
+    setup: async (ws) => {
+      await fsp.writeFile(path.join(ws, 'real.txt'), 'in');
+      await fsp.symlink(
+        path.join(ws, 'real.txt'),
+        path.join(ws, 'alias'),
+        'file',
+      );
+    },
+    input: () => 'alias',
+    expectInside: true,
+    intent: 'read',
+  },
+  {
+    name: 'non-existent path with write intent (ENOENT-tolerant)',
+    input: () => path.join('newdir', 'leaf.txt'),
+    expectInside: true,
+    intent: 'write',
+  },
+  {
+    name: 'non-existent path with read intent rejects (existence, not boundary)',
+    input: () => 'never-existed.txt',
+    // The boundary throws `path_not_found`, which is an existence
+    // decision, not a containment decision. WorkspaceContext models
+    // missing files as "would be in workspace" and returns `true`,
+    // so this case asserts the asymmetry rather than the agreement.
+    expectInside: 'existence-mismatch',
+    intent: 'read',
+  },
+  {
+    name: 'case-different existing file (macOS/win only)',
+    onlyPlatforms: ['darwin', 'win32'],
+    setup: async (ws) => {
+      await fsp.writeFile(path.join(ws, 'CaseFile.TXT'), '');
+    },
+    input: () => 'casefile.txt',
+    expectInside: true,
+    intent: 'read',
+  },
+];
+
+describe('contract: resolveWithinWorkspace ↔ WorkspaceContext', () => {
+  let scratch: string;
+
+  beforeAll(async () => {
+    scratch = await fsp.mkdtemp(
+      path.join(
+        os.tmpdir(),
+        `qwen-fs-contract-${randomBytes(4).toString('hex')}-`,
+      ),
+    );
+  });
+
+  afterAll(async () => {
+    await fsp.rm(scratch, { recursive: true, force: true });
+  });
+
+  it.each(CORPUS.map((tc) => [tc.name, tc] as const))(
+    '%s',
+    async (_name, tc) => {
+      if (tc.onlyPlatforms && !tc.onlyPlatforms.includes(process.platform)) {
+        return;
+      }
+      const wsDir = path.join(scratch, randomBytes(4).toString('hex'));
+      await fsp.mkdir(wsDir);
+      const workspace = canonicalizeWorkspace(wsDir);
+      if (tc.setup) await tc.setup(workspace, scratch);
+
+      const wsCtx = new WorkspaceContext(workspace);
+      const inputAbs = path.isAbsolute(tc.input(workspace, scratch))
+        ? tc.input(workspace, scratch)
+        : path.resolve(workspace, tc.input(workspace, scratch));
+      const wsInside = wsCtx.isPathWithinWorkspace(inputAbs);
+
+      let boundaryAccepted = true;
+      let resolved: string | null = null;
+      let boundaryError: FsError | null = null;
+      try {
+        resolved = await resolveWithinWorkspace(
+          tc.input(workspace, scratch),
+          workspace,
+          tc.intent,
+        );
+      } catch (err) {
+        if (!isFsError(err)) throw err;
+        boundaryAccepted = false;
+        boundaryError = err;
+      }
+
+      if (tc.expectInside === 'existence-mismatch') {
+        expect(boundaryAccepted).toBe(false);
+        expect(boundaryError?.kind).toBe('path_not_found');
+        // WorkspaceContext intentionally answers a different
+        // question for missing files — no equality assertion here.
+      } else if (tc.expectInside === true) {
+        expect(boundaryAccepted).toBe(true);
+        expect(wsInside).toBe(true);
+      } else {
+        expect(boundaryAccepted).toBe(false);
+        // The boundary rejected; only assert WorkspaceContext also
+        // says "outside" when the rejection was a containment
+        // decision (path_outside_workspace / symlink_escape).
+        if (boundaryError && OUT_OF_WORKSPACE_KINDS.has(boundaryError.kind)) {
+          expect(wsInside).toBe(false);
+        }
+      }
+
+      // When both succeed, canonical forms must agree.
+      if (boundaryAccepted && resolved !== null) {
+        // Use realpathSync.native as ground truth when the path
+        // exists; for write-intent ENOENT cases we fall back to
+        // the resolved-but-not-realpathed form on the leaf.
+        let groundTruth: string;
+        try {
+          groundTruth = realpathSync.native(inputAbs);
+        } catch {
+          // ENOENT — boundary used findExistingAncestor + realpath +
+          // join(tail). Reproduce that here for assertion symmetry.
+          let cursor = inputAbs;
+          const tail: string[] = [];
+          while (true) {
+            try {
+              await fsp.stat(cursor);
+              break;
+            } catch {
+              tail.unshift(path.basename(cursor));
+              const parent = path.dirname(cursor);
+              if (parent === cursor) {
+                cursor = workspace;
+                break;
+              }
+              cursor = parent;
+            }
+          }
+          groundTruth = tail.length
+            ? path.join(realpathSync.native(cursor), ...tail)
+            : realpathSync.native(cursor);
+        }
+        expect(resolved).toBe(groundTruth);
+      }
+    },
+  );
+});

--- a/packages/cli/src/serve/fs/contract.test.ts
+++ b/packages/cli/src/serve/fs/contract.test.ts
@@ -11,7 +11,14 @@ import * as path from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { WorkspaceContext } from '@qwen-code/qwen-code-core';
 import { canonicalizeWorkspace, resolveWithinWorkspace } from './paths.js';
-import type { FsError, isFsError, type FsErrorKind } from './errors.js';
+// `isFsError` is a runtime guard called below — must stay a value
+// import. `FsError` is type-only here (typed `catch` variable); same
+// for `FsErrorKind`. The eslint-disable mirrors the workspaceFileSystem.ts
+// fix and exists because the auto-fix at commit 7b0db4c3a promoted the
+// whole line to `import type`, erasing `isFsError` at runtime and
+// failing 11 tests in this file alone.
+ 
+import { isFsError, type FsError, type FsErrorKind } from './errors.js';
 
 /**
  * Kinds the boundary throws to indicate the path is *outside the

--- a/packages/cli/src/serve/fs/errors.test.ts
+++ b/packages/cli/src/serve/fs/errors.test.ts
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  FsError,
+  isFsError,
+  wrapAsFsError,
+  type FsErrorKind,
+} from './errors.js';
+
+describe('FsError', () => {
+  it('uses the default status mapping for each kind', () => {
+    const cases: Array<[FsErrorKind, number]> = [
+      ['path_outside_workspace', 400],
+      ['symlink_escape', 400],
+      ['path_not_found', 404],
+      ['binary_file', 422],
+      ['file_too_large', 413],
+      ['untrusted_workspace', 403],
+      ['permission_denied', 403],
+      ['parse_error', 400],
+    ];
+    for (const [kind, status] of cases) {
+      const err = new FsError(kind, `${kind} message`);
+      expect(err.kind).toBe(kind);
+      expect(err.status).toBe(status);
+    }
+  });
+
+  it('honors an explicit status override', () => {
+    const err = new FsError('parse_error', 'service invariant', {
+      status: 422,
+    });
+    expect(err.status).toBe(422);
+  });
+
+  it('captures the hint string when provided', () => {
+    const err = new FsError('binary_file', 'binary content', {
+      hint: 'Use readBytes for binary content',
+    });
+    expect(err.hint).toBe('Use readBytes for binary content');
+  });
+
+  it('omits hint when not provided', () => {
+    const err = new FsError('path_not_found', 'missing');
+    expect(err.hint).toBeUndefined();
+  });
+
+  it('forwards a cause through to Error.cause when available', () => {
+    const root = new Error('underlying ENOENT');
+    const err = new FsError('path_not_found', 'wrapped', { cause: root });
+    // Node 16+ supports Error.cause. On the off chance the runtime
+    // doesn't, we just assert the message + kind survived rather
+    // than failing the suite for a feature-detection issue.
+    expect(err.message).toBe('wrapped');
+    expect(err.kind).toBe('path_not_found');
+    if ('cause' in err) {
+      expect((err as Error & { cause?: unknown }).cause).toBe(root);
+    }
+  });
+
+  it('sets name to "FsError" for stack-trace clarity', () => {
+    const err = new FsError('symlink_escape', 'x');
+    expect(err.name).toBe('FsError');
+  });
+
+  it('is an Error subclass and isFsError narrows it', () => {
+    const err = new FsError('untrusted_workspace', 'no writes here');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(FsError);
+    expect(isFsError(err)).toBe(true);
+    expect(isFsError(new Error('plain'))).toBe(false);
+    expect(isFsError(null)).toBe(false);
+    expect(isFsError(undefined)).toBe(false);
+    expect(isFsError({ kind: 'path_not_found' })).toBe(false);
+  });
+});
+
+describe('wrapAsFsError', () => {
+  function errno(
+    code: string,
+    message = `${code} message`,
+  ): NodeJS.ErrnoException {
+    const err = new Error(message) as NodeJS.ErrnoException;
+    err.code = code;
+    return err;
+  }
+
+  it('returns FsError instances unchanged', () => {
+    const original = new FsError('binary_file', 'x');
+    expect(wrapAsFsError(original)).toBe(original);
+  });
+
+  it('maps ENOENT to path_not_found', () => {
+    const out = wrapAsFsError(errno('ENOENT'));
+    expect(out.kind).toBe('path_not_found');
+    expect(out.status).toBe(404);
+  });
+
+  it('maps EACCES and EPERM to permission_denied', () => {
+    expect(wrapAsFsError(errno('EACCES')).kind).toBe('permission_denied');
+    expect(wrapAsFsError(errno('EPERM')).kind).toBe('permission_denied');
+  });
+
+  it('maps ELOOP to symlink_escape', () => {
+    expect(wrapAsFsError(errno('ELOOP')).kind).toBe('symlink_escape');
+  });
+
+  it('maps ENOTDIR / EISDIR to parse_error', () => {
+    expect(wrapAsFsError(errno('ENOTDIR')).kind).toBe('parse_error');
+    expect(wrapAsFsError(errno('EISDIR')).kind).toBe('parse_error');
+  });
+
+  it('maps EMFILE / ENFILE to permission_denied with a hint', () => {
+    const out = wrapAsFsError(errno('EMFILE'));
+    expect(out.kind).toBe('permission_denied');
+    expect(out.hint).toMatch(/file-descriptor/);
+  });
+
+  it('falls back to the configured default kind for unknown errnos', () => {
+    expect(wrapAsFsError(errno('EWHATEVER')).kind).toBe('permission_denied');
+    expect(wrapAsFsError(errno('EWHATEVER'), 'parse_error').kind).toBe(
+      'parse_error',
+    );
+  });
+
+  it('preserves the original error as cause', () => {
+    const root = errno('ENOENT', 'where');
+    const out = wrapAsFsError(root);
+    if ('cause' in out) {
+      expect((out as Error & { cause?: unknown }).cause).toBe(root);
+    }
+  });
+
+  it('handles non-Error throwables without crashing', () => {
+    const out = wrapAsFsError('string thrown', 'parse_error');
+    expect(out.kind).toBe('parse_error');
+    expect(out.message).toBe('unknown filesystem error');
+  });
+});

--- a/packages/cli/src/serve/fs/errors.test.ts
+++ b/packages/cli/src/serve/fs/errors.test.ts
@@ -135,11 +135,32 @@ describe('wrapAsFsError', () => {
     expect(new FsError('io_error', 'disk full').status).toBe(503);
   });
 
-  it('falls back to the configured default kind for unknown errnos', () => {
-    expect(wrapAsFsError(errno('EWHATEVER')).kind).toBe('permission_denied');
+  it('falls back to internal_error (not permission_denied) for unknown errnos and non-errno errors', () => {
+    // Default fallback used to be `permission_denied`, which mis-paged
+    // security oncall on a TypeError or null-deref. The new default is
+    // `internal_error` (HTTP 500) so monitoring keys stay aligned with
+    // the actual class of fault.
+    expect(wrapAsFsError(errno('EWHATEVER')).kind).toBe('internal_error');
+    expect(wrapAsFsError(new TypeError('null deref')).kind).toBe(
+      'internal_error',
+    );
+    // Caller can still override.
     expect(wrapAsFsError(errno('EWHATEVER'), 'parse_error').kind).toBe(
       'parse_error',
     );
+  });
+
+  it('internal_error has HTTP status 500', () => {
+    expect(new FsError('internal_error', 'bug').status).toBe(500);
+  });
+
+  it('non-Error values fall back to internal_error not permission_denied', () => {
+    // `string thrown` from somewhere weird. Earlier default of
+    // permission_denied would page security oncall for what
+    // is a developer ticket.
+    const out = wrapAsFsError('boom');
+    expect(out.kind).toBe('internal_error');
+    expect(out.status).toBe(500);
   });
 
   it('preserves the original error as cause', () => {

--- a/packages/cli/src/serve/fs/errors.test.ts
+++ b/packages/cli/src/serve/fs/errors.test.ts
@@ -115,10 +115,24 @@ describe('wrapAsFsError', () => {
     expect(wrapAsFsError(errno('EISDIR')).kind).toBe('parse_error');
   });
 
-  it('maps EMFILE / ENFILE to permission_denied with a hint', () => {
+  it('maps EMFILE / ENFILE to io_error with a hint', () => {
     const out = wrapAsFsError(errno('EMFILE'));
-    expect(out.kind).toBe('permission_denied');
+    expect(out.kind).toBe('io_error');
     expect(out.hint).toMatch(/file-descriptor/);
+  });
+
+  it('maps ENOSPC / EIO / EBUSY / ETXTBSY / ENAMETOOLONG to io_error', () => {
+    const enospc = wrapAsFsError(errno('ENOSPC'));
+    expect(enospc.kind).toBe('io_error');
+    expect(enospc.hint).toMatch(/full/);
+    expect(wrapAsFsError(errno('EIO')).kind).toBe('io_error');
+    expect(wrapAsFsError(errno('EBUSY')).kind).toBe('io_error');
+    expect(wrapAsFsError(errno('ETXTBSY')).kind).toBe('io_error');
+    expect(wrapAsFsError(errno('ENAMETOOLONG')).kind).toBe('io_error');
+  });
+
+  it('io_error has HTTP status 503', () => {
+    expect(new FsError('io_error', 'disk full').status).toBe(503);
   });
 
   it('falls back to the configured default kind for unknown errnos', () => {

--- a/packages/cli/src/serve/fs/errors.ts
+++ b/packages/cli/src/serve/fs/errors.ts
@@ -35,6 +35,17 @@ export type FsErrorKind =
    * failure" to PR 19/20 route handlers and SDK consumers.
    */
   | 'io_error'
+  /**
+   * Catch-all for non-errno errors that reach the boundary
+   * (`TypeError`, programmer-error throws, native module
+   * exceptions, etc.). Distinguished from `permission_denied`
+   * because monitoring pipelines key on `errorKind` for
+   * security alerting — conflating "code bug" with "ACL
+   * denied" pages security oncall for what should be a
+   * developer ticket. The 500 status communicates "daemon
+   * internal fault" to PR 19/20 route handlers.
+   */
+  | 'internal_error'
   | 'parse_error';
 
 /**
@@ -45,7 +56,7 @@ export type FsErrorKind =
  * boundary is being asked to model a transport-level concern that
  * doesn't belong here (5xx, 401/403 from auth, etc.).
  */
-export type FsErrorStatus = 400 | 403 | 404 | 413 | 422 | 503;
+export type FsErrorStatus = 400 | 403 | 404 | 413 | 422 | 500 | 503;
 
 /**
  * Default HTTP status mapping. Centralized here so callers can throw
@@ -64,6 +75,7 @@ const DEFAULT_STATUS_BY_KIND: Record<FsErrorKind, FsErrorStatus> = {
   untrusted_workspace: 403,
   permission_denied: 403,
   io_error: 503,
+  internal_error: 500,
   parse_error: 400,
 };
 
@@ -120,7 +132,7 @@ export function isFsError(err: unknown): err is FsError {
  */
 export function wrapAsFsError(
   err: unknown,
-  fallbackKind: FsErrorKind = 'permission_denied',
+  fallbackKind: FsErrorKind = 'internal_error',
 ): FsError {
   if (err instanceof FsError) return err;
   const errno = (err as NodeJS.ErrnoException | undefined)?.code;

--- a/packages/cli/src/serve/fs/errors.ts
+++ b/packages/cli/src/serve/fs/errors.ts
@@ -1,0 +1,141 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Discriminator for filesystem-boundary errors raised by the
+ * `WorkspaceFileSystem` layer (#4175 PR 18).
+ *
+ * The values are also serialized verbatim onto the wire by PR 19/20
+ * route handlers as the `errorKind` field of the planned PR 13
+ * envelope `{ kind, status, error, errorKind, hint }`. Keeping the
+ * union closed and stable lets SDK consumers exhaustively switch
+ * over the kinds without falling through to a generic 5xx path.
+ */
+export type FsErrorKind =
+  | 'path_outside_workspace'
+  | 'symlink_escape'
+  | 'path_not_found'
+  | 'binary_file'
+  | 'file_too_large'
+  | 'untrusted_workspace'
+  | 'permission_denied'
+  | 'parse_error';
+
+/**
+ * HTTP status codes the boundary maps onto. The status lives on the
+ * error itself rather than being derived by the route handler so the
+ * serialization is "one helper line" — see PR 19/20 plans. The set is
+ * intentionally narrow: anything outside this map indicates the
+ * boundary is being asked to model a transport-level concern that
+ * doesn't belong here (5xx, 401/403 from auth, etc.).
+ */
+export type FsErrorStatus = 400 | 403 | 404 | 413 | 422;
+
+/**
+ * Default HTTP status mapping. Centralized here so callers can throw
+ * `new FsError('path_not_found', 'message')` without re-deriving the
+ * status; the constructor still accepts an explicit status override
+ * for the rare case where a kind is reused under a different status
+ * (e.g. `parse_error` may be 400 from a request body but 422 from a
+ * service-level invariant breach).
+ */
+const DEFAULT_STATUS_BY_KIND: Record<FsErrorKind, FsErrorStatus> = {
+  path_outside_workspace: 400,
+  symlink_escape: 400,
+  path_not_found: 404,
+  binary_file: 422,
+  file_too_large: 413,
+  untrusted_workspace: 403,
+  permission_denied: 403,
+  parse_error: 400,
+};
+
+/**
+ * Typed boundary error. PR 18 ships the class only — no route
+ * serializes it yet. PR 19/20 add a `sendFsError(res, err)` helper
+ * that maps `kind`/`status`/`hint` onto the envelope.
+ *
+ * Why a class rather than a plain object: `instanceof FsError`
+ * gives the orchestrator a single catch-clause to convert thrown
+ * boundary errors into `fs.denied` audit events without also
+ * eating unrelated runtime errors (`TypeError`, `ENOENT` from a
+ * lower-level `fs.promises` call that escaped categorization, etc.).
+ */
+export class FsError extends Error {
+  readonly kind: FsErrorKind;
+  readonly status: FsErrorStatus;
+  readonly hint?: string;
+
+  constructor(
+    kind: FsErrorKind,
+    message: string,
+    options?: { hint?: string; status?: FsErrorStatus; cause?: unknown },
+  ) {
+    super(
+      message,
+      options?.cause === undefined ? undefined : { cause: options.cause },
+    );
+    this.name = 'FsError';
+    this.kind = kind;
+    this.status = options?.status ?? DEFAULT_STATUS_BY_KIND[kind];
+    this.hint = options?.hint;
+  }
+}
+
+/**
+ * Type guard for catch sites that need to distinguish boundary
+ * errors from generic `Error` instances.
+ */
+export function isFsError(err: unknown): err is FsError {
+  return err instanceof FsError;
+}
+
+/**
+ * Coerce an arbitrary thrown value into an `FsError`. Used by the
+ * orchestrator's catch blocks so every body-level failure surfaces
+ * as a typed error AND emits an `fs.denied` audit event — without
+ * this, raw `fs.promises` errnos (`EACCES`, `ENOENT`, `ELOOP`, …)
+ * propagate uncategorized, the audit log loses denial visibility,
+ * and PR 19/20 routes degrade to opaque 5xx responses.
+ *
+ * Already-typed `FsError`s pass through unchanged so callers can
+ * safely chain this on every catch.
+ */
+export function wrapAsFsError(
+  err: unknown,
+  fallbackKind: FsErrorKind = 'permission_denied',
+): FsError {
+  if (err instanceof FsError) return err;
+  const errno = (err as NodeJS.ErrnoException | undefined)?.code;
+  const message =
+    err instanceof Error ? err.message : 'unknown filesystem error';
+  switch (errno) {
+    case 'ENOENT':
+      return new FsError('path_not_found', message, { cause: err });
+    case 'EACCES':
+    case 'EPERM':
+      return new FsError('permission_denied', message, { cause: err });
+    case 'ELOOP':
+      return new FsError('symlink_escape', message, {
+        cause: err,
+        hint: 'symlink chain forms a cycle or exceeds SYMLOOP_MAX',
+      });
+    case 'EISDIR':
+    case 'ENOTDIR':
+      return new FsError('parse_error', message, {
+        cause: err,
+        hint: 'a path component is not a directory where one was expected',
+      });
+    case 'EMFILE':
+    case 'ENFILE':
+      return new FsError('permission_denied', message, {
+        cause: err,
+        hint: 'too many open files; daemon is at file-descriptor limit',
+      });
+    default:
+      return new FsError(fallbackKind, message, { cause: err });
+  }
+}

--- a/packages/cli/src/serve/fs/errors.ts
+++ b/packages/cli/src/serve/fs/errors.ts
@@ -22,6 +22,19 @@ export type FsErrorKind =
   | 'file_too_large'
   | 'untrusted_workspace'
   | 'permission_denied'
+  /**
+   * Environmental I/O failure that is *not* a permission decision —
+   * disk full (`ENOSPC`), generic I/O error (`EIO`), filesystem busy
+   * (`EBUSY`/`ETXTBSY`), path-too-long (`ENAMETOOLONG`), or
+   * file-descriptor exhaustion (`EMFILE`/`ENFILE`).
+   *
+   * Separated from `permission_denied` because monitoring pipelines
+   * key on `errorKind` for alerting — conflating "ACL denied" with
+   * "disk full" pages the security oncall when the real action is
+   * `df -h`. The 503 status communicates "service-level transient
+   * failure" to PR 19/20 route handlers and SDK consumers.
+   */
+  | 'io_error'
   | 'parse_error';
 
 /**
@@ -32,7 +45,7 @@ export type FsErrorKind =
  * boundary is being asked to model a transport-level concern that
  * doesn't belong here (5xx, 401/403 from auth, etc.).
  */
-export type FsErrorStatus = 400 | 403 | 404 | 413 | 422;
+export type FsErrorStatus = 400 | 403 | 404 | 413 | 422 | 503;
 
 /**
  * Default HTTP status mapping. Centralized here so callers can throw
@@ -50,6 +63,7 @@ const DEFAULT_STATUS_BY_KIND: Record<FsErrorKind, FsErrorStatus> = {
   file_too_large: 413,
   untrusted_workspace: 403,
   permission_denied: 403,
+  io_error: 503,
   parse_error: 400,
 };
 
@@ -129,9 +143,30 @@ export function wrapAsFsError(
         cause: err,
         hint: 'a path component is not a directory where one was expected',
       });
+    case 'ENOSPC':
+      return new FsError('io_error', message, {
+        cause: err,
+        hint: 'filesystem is full (df -h reporting 100%)',
+      });
+    case 'EIO':
+      return new FsError('io_error', message, {
+        cause: err,
+        hint: 'underlying I/O error (failing disk or kernel-level fault)',
+      });
+    case 'EBUSY':
+    case 'ETXTBSY':
+      return new FsError('io_error', message, {
+        cause: err,
+        hint: 'file is busy; another process holds an exclusive handle',
+      });
+    case 'ENAMETOOLONG':
+      return new FsError('io_error', message, {
+        cause: err,
+        hint: 'path exceeds the OS PATH_MAX',
+      });
     case 'EMFILE':
     case 'ENFILE':
-      return new FsError('permission_denied', message, {
+      return new FsError('io_error', message, {
         cause: err,
         hint: 'too many open files; daemon is at file-descriptor limit',
       });

--- a/packages/cli/src/serve/fs/errors.ts
+++ b/packages/cli/src/serve/fs/errors.ts
@@ -138,10 +138,14 @@ export function wrapAsFsError(
         hint: 'symlink chain forms a cycle or exceeds SYMLOOP_MAX',
       });
     case 'EISDIR':
+      return new FsError('parse_error', message, {
+        cause: err,
+        hint: 'EISDIR — path is a directory but a regular file was expected',
+      });
     case 'ENOTDIR':
       return new FsError('parse_error', message, {
         cause: err,
-        hint: 'a path component is not a directory where one was expected',
+        hint: 'ENOTDIR — a path component is a regular file but a directory was expected',
       });
     case 'ENOSPC':
       return new FsError('io_error', message, {

--- a/packages/cli/src/serve/fs/index.ts
+++ b/packages/cli/src/serve/fs/index.ts
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export {
+  canonicalizeWorkspace,
+  hasSuspiciousPathPattern,
+  resolveWithinWorkspace,
+  type Intent,
+  type ResolvedPath,
+} from './paths.js';
+export {
+  FsError,
+  isFsError,
+  type FsErrorKind,
+  type FsErrorStatus,
+} from './errors.js';
+export {
+  MAX_READ_BYTES,
+  MAX_WRITE_BYTES,
+  BINARY_PROBE_BYTES,
+  assertTrustedForIntent,
+  detectBinary,
+  enforceReadBytesSize,
+  enforceReadSize,
+  enforceWriteSize,
+  shouldIgnore,
+  type IgnoreVerdict,
+  type ReadSizeOutcome,
+} from './policy.js';
+export {
+  FS_ACCESS_EVENT_TYPE,
+  FS_DENIED_EVENT_TYPE,
+  createAuditPublisher,
+  type AuditContext,
+  type AuditPublisher,
+  type CreateAuditPublisherDeps,
+  type FsAccessAuditPayload,
+  type FsDeniedAuditPayload,
+} from './audit.js';
+export {
+  createWorkspaceFileSystemFactory,
+  type CreateWorkspaceFileSystemFactoryDeps,
+  type FsEntry,
+  type FsStat,
+  type GlobOptions,
+  type ListOptions,
+  type ReadMeta,
+  type ReadTextOptions,
+  type RequestContext,
+  type WorkspaceFileSystem,
+  type WorkspaceFileSystemFactory,
+  type WriteOutcome,
+} from './workspaceFileSystem.js';

--- a/packages/cli/src/serve/fs/paths.test.ts
+++ b/packages/cli/src/serve/fs/paths.test.ts
@@ -98,10 +98,24 @@ describe('canonicalizeWorkspace', () => {
 });
 
 describe('hasSuspiciousPathPattern', () => {
-  it('rejects 8.3 short names regardless of platform', () => {
-    expect(hasSuspiciousPathPattern('GIT~1')).toBe(true);
-    expect(hasSuspiciousPathPattern('CLAUDE~2')).toBe(true);
-    expect(hasSuspiciousPathPattern('SETTIN~1.JSON')).toBe(true);
+  it('rejects 8.3 short names on Windows including multi-digit suffixes; admits POSIX legit ~N filenames', () => {
+    if (process.platform === 'win32') {
+      // Windows: original short names + multi-digit (NTFS allocates
+      // ~1..~4 then hashes; ~10+ are real)
+      expect(hasSuspiciousPathPattern('GIT~1')).toBe(true);
+      expect(hasSuspiciousPathPattern('CLAUDE~2')).toBe(true);
+      expect(hasSuspiciousPathPattern('SETTIN~1.JSON')).toBe(true);
+      expect(hasSuspiciousPathPattern('LONGFI~10.TXT')).toBe(true);
+      expect(hasSuspiciousPathPattern('OTHER~99.dat')).toBe(true);
+    } else {
+      // POSIX: ~N is a legitimate filename char (editor swaps,
+      // backup files, version schemes). Daemon's FS isn't NTFS,
+      // so 8.3 interpretation doesn't apply.
+      expect(hasSuspiciousPathPattern('backup~1.txt')).toBe(false);
+      expect(hasSuspiciousPathPattern('notes~2.md')).toBe(false);
+      expect(hasSuspiciousPathPattern('file~3.swp')).toBe(false);
+      expect(hasSuspiciousPathPattern('LONGFI~10.TXT')).toBe(false);
+    }
   });
 
   it('rejects long-path / device prefixes regardless of platform', () => {
@@ -253,12 +267,19 @@ describe('resolveWithinWorkspace', () => {
   });
 
   it('rejects suspicious patterns before any I/O', async () => {
-    await expect(
-      resolveWithinWorkspace('GIT~1', workspace, 'read'),
-    ).rejects.toMatchObject({ kind: 'path_outside_workspace' });
+    // UNC prefixes are platform-agnostic: a daemon should never
+    // accept `//server/share` regardless of OS. The 8.3
+    // short-name `~\d` check is gated on win32 (legitimate POSIX
+    // filenames can have `~N` in them); we exercise the win32
+    // branch only when the runner is Windows.
     await expect(
       resolveWithinWorkspace('//server/share', workspace, 'read'),
     ).rejects.toMatchObject({ kind: 'path_outside_workspace' });
+    if (process.platform === 'win32') {
+      await expect(
+        resolveWithinWorkspace('GIT~1', workspace, 'read'),
+      ).rejects.toMatchObject({ kind: 'path_outside_workspace' });
+    }
   });
 
   it('rejects empty/non-string input with parse_error', async () => {

--- a/packages/cli/src/serve/fs/paths.test.ts
+++ b/packages/cli/src/serve/fs/paths.test.ts
@@ -266,6 +266,43 @@ describe('resolveWithinWorkspace', () => {
     expect(typeof out).toBe('string');
   });
 
+  it('rejects a multi-hop dangling symlink chain that escapes the workspace', async () => {
+    // The exploit class: `<ws>/leak -> <ws>/middle -> /scratch/evil`
+    // where every link is a symlink and the final target doesn't
+    // exist. A single-hop guard (read T19's earlier fix) only
+    // checks the first readlink target — `<ws>/middle` — sees it's
+    // inside the workspace, and lets the chain through. The OS
+    // write at `<ws>/leak` then follows BOTH hops and creates
+    // `/scratch/evil`. The multi-hop loop fix dereferences every
+    // link before the containment check.
+    const evil = path.join(scratch, 'multi-hop-target.txt');
+    const middle = path.join(workspace, 'middle');
+    const leak = path.join(workspace, 'leak');
+    await fsp.symlink(evil, middle, 'file');
+    await fsp.symlink(middle, leak, 'file');
+    const err = await resolveWithinWorkspace('leak', workspace, 'write').catch(
+      (e: unknown) => e,
+    );
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('symlink_escape');
+  });
+
+  it('detects a symlink cycle and rejects with symlink_escape', async () => {
+    // a -> b -> a — symmetric self-referential pair. realpath
+    // returns ELOOP on most platforms; the multi-hop loop's inode
+    // tracking catches this even on filesystems that don't
+    // surface ELOOP.
+    const a = path.join(workspace, 'a');
+    const b = path.join(workspace, 'b');
+    await fsp.symlink(b, a, 'file');
+    await fsp.symlink(a, b, 'file');
+    const err = await resolveWithinWorkspace('a', workspace, 'write').catch(
+      (e: unknown) => e,
+    );
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('symlink_escape');
+  });
+
   it('returns a value usable as ResolvedPath brand', async () => {
     const target = path.join(workspace, 'b.txt');
     await fsp.writeFile(target, 'b');

--- a/packages/cli/src/serve/fs/paths.test.ts
+++ b/packages/cli/src/serve/fs/paths.test.ts
@@ -1,0 +1,262 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fsp, realpathSync } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomBytes } from 'node:crypto';
+import {
+  canonicalizeWorkspace,
+  hasSuspiciousPathPattern,
+  resolveWithinWorkspace,
+  type ResolvedPath,
+} from './paths.js';
+import { isFsError } from './errors.js';
+
+describe('canonicalizeWorkspace', () => {
+  let scratch: string;
+
+  beforeEach(async () => {
+    const id = randomBytes(6).toString('hex');
+    scratch = await fsp.mkdtemp(path.join(os.tmpdir(), `qwen-fs-paths-${id}-`));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(scratch, { recursive: true, force: true });
+  });
+
+  it('returns the realpath for an existing absolute directory', () => {
+    const subdir = path.join(scratch, 'project');
+    // Use mkdirSync via fsp.mkdir-await to keep test async-shape consistent.
+    return fsp.mkdir(subdir).then(() => {
+      const canonical = canonicalizeWorkspace(subdir);
+      // On macOS the tmpdir resolves through `/private` — `realpathSync.native`
+      // returns that prefix; we just assert it matches what realpath itself
+      // would produce so the test is platform-agnostic.
+      expect(canonical).toBe(realpathSync.native(subdir));
+    });
+  });
+
+  it('resolves a relative path against process.cwd before canonicalization', async () => {
+    // Anchor the relative input to the scratch directory so the resolved
+    // path actually exists. We can't change cwd under vitest reliably, so
+    // craft an absolute path and re-derive the relative form.
+    const subdir = path.join(scratch, 'rel-target');
+    await fsp.mkdir(subdir);
+    const relInput = path.relative(process.cwd(), subdir);
+    const canonical = canonicalizeWorkspace(relInput);
+    expect(canonical).toBe(realpathSync.native(subdir));
+  });
+
+  it('falls back to path.resolve for a non-existent path (ENOENT)', () => {
+    const ghost = path.join(scratch, 'does', 'not', 'exist');
+    const canonical = canonicalizeWorkspace(ghost);
+    expect(canonical).toBe(path.resolve(ghost));
+  });
+
+  it('follows a symlink to the real on-disk target', async () => {
+    const real = path.join(scratch, 'real');
+    const link = path.join(scratch, 'link');
+    await fsp.mkdir(real);
+    await fsp.symlink(real, link, 'dir');
+    expect(canonicalizeWorkspace(link)).toBe(realpathSync.native(real));
+  });
+
+  it('preserves on-disk casing on case-insensitive filesystems for an existing path', async () => {
+    // Skipped on Linux where the FS is case-sensitive — the function's
+    // casing-collapse contract is only meaningful on macOS APFS / Windows
+    // NTFS, and forcing the test to assert "different cased input == same
+    // output" on ext4 would just fail with ENOENT before realpath runs.
+    if (process.platform !== 'darwin' && process.platform !== 'win32') return;
+    const dir = path.join(scratch, 'CaseDir');
+    await fsp.mkdir(dir);
+    const lowered = path.join(scratch, 'casedir');
+    const canonical = canonicalizeWorkspace(lowered);
+    // The realpathSync.native return value is the on-disk casing, which is
+    // what the boundWorkspace contract pins.
+    expect(canonical).toBe(realpathSync.native(dir));
+  });
+
+  it('rethrows non-ENOENT filesystem errors instead of masking them', async () => {
+    // EACCES is hard to produce portably and on macOS gates behind SIP.
+    // Instead simulate the contract by asserting that an EISDIR-or-similar
+    // path that *does* exist returns its realpath rather than throwing —
+    // the negative case (rethrow on non-ENOENT) is exercised by code review
+    // and documented in the function's doc comment. The minimal positive
+    // assertion here guards against a future regression that swallows
+    // *every* error and drops to path.resolve.
+    const dir = path.join(scratch, 'normal');
+    await fsp.mkdir(dir);
+    const out = canonicalizeWorkspace(dir);
+    expect(out).toBe(realpathSync.native(dir));
+    expect(out).not.toBe(path.resolve(dir + '-different'));
+  });
+});
+
+describe('hasSuspiciousPathPattern', () => {
+  it('rejects 8.3 short names regardless of platform', () => {
+    expect(hasSuspiciousPathPattern('GIT~1')).toBe(true);
+    expect(hasSuspiciousPathPattern('CLAUDE~2')).toBe(true);
+    expect(hasSuspiciousPathPattern('SETTIN~1.JSON')).toBe(true);
+  });
+
+  it('rejects long-path / device prefixes regardless of platform', () => {
+    expect(hasSuspiciousPathPattern('\\\\?\\C:\\Users\\foo')).toBe(true);
+    expect(hasSuspiciousPathPattern('\\\\.\\C:\\foo')).toBe(true);
+    expect(hasSuspiciousPathPattern('//?/C:/foo')).toBe(true);
+    expect(hasSuspiciousPathPattern('//./C:/foo')).toBe(true);
+  });
+
+  it('rejects UNC prefixes regardless of platform', () => {
+    expect(hasSuspiciousPathPattern('\\\\server\\share')).toBe(true);
+    expect(hasSuspiciousPathPattern('//server/share')).toBe(true);
+    expect(hasSuspiciousPathPattern('//192.168.1.1/foo')).toBe(true);
+  });
+
+  it('rejects trailing dots / spaces and DOS device names', () => {
+    expect(hasSuspiciousPathPattern('config.json.')).toBe(true);
+    expect(hasSuspiciousPathPattern('config.json   ')).toBe(true);
+    expect(hasSuspiciousPathPattern('settings.PRN')).toBe(true);
+    expect(hasSuspiciousPathPattern('foo.CON')).toBe(true);
+    expect(hasSuspiciousPathPattern('bar.LPT1')).toBe(true);
+  });
+
+  it('rejects three-or-more-dot path components', () => {
+    expect(hasSuspiciousPathPattern('foo/.../bar')).toBe(true);
+    expect(hasSuspiciousPathPattern('.../leaf')).toBe(true);
+  });
+
+  it('accepts ordinary POSIX paths', () => {
+    expect(hasSuspiciousPathPattern('src/index.ts')).toBe(false);
+    expect(hasSuspiciousPathPattern('packages/cli/package.json')).toBe(false);
+    expect(hasSuspiciousPathPattern('.qwenignore')).toBe(false);
+    expect(hasSuspiciousPathPattern('a/b/c/d/e/f.txt')).toBe(false);
+  });
+});
+
+describe('resolveWithinWorkspace', () => {
+  let scratch: string;
+  let workspace: string;
+
+  beforeEach(async () => {
+    const id = randomBytes(6).toString('hex');
+    scratch = await fsp.mkdtemp(
+      path.join(os.tmpdir(), `qwen-fs-resolve-${id}-`),
+    );
+    workspace = path.join(scratch, 'workspace');
+    await fsp.mkdir(workspace);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(scratch, { recursive: true, force: true });
+  });
+
+  it('resolves an existing relative path to its on-disk canonical form', async () => {
+    const target = path.join(workspace, 'src', 'a.txt');
+    await fsp.mkdir(path.dirname(target));
+    await fsp.writeFile(target, 'hello');
+    const out = await resolveWithinWorkspace('src/a.txt', workspace, 'read');
+    expect(out).toBe(realpathSync.native(target));
+  });
+
+  it('rejects a `..` traversal that lands outside the workspace', async () => {
+    await expect(
+      resolveWithinWorkspace('../escape', workspace, 'read'),
+    ).rejects.toMatchObject({ kind: 'path_outside_workspace' });
+  });
+
+  it('rejects an absolute path outside the workspace', async () => {
+    const outside = path.join(scratch, 'outside.txt');
+    await fsp.writeFile(outside, 'x');
+    await expect(
+      resolveWithinWorkspace(outside, workspace, 'read'),
+    ).rejects.toMatchObject({ kind: 'path_outside_workspace' });
+  });
+
+  it('rejects a symlink whose target escapes the workspace', async () => {
+    const outside = path.join(scratch, 'outside.txt');
+    await fsp.writeFile(outside, 'sensitive');
+    const link = path.join(workspace, 'leak');
+    await fsp.symlink(outside, link, 'file');
+    await expect(
+      resolveWithinWorkspace('leak', workspace, 'read'),
+    ).rejects.toMatchObject({ kind: 'symlink_escape' });
+  });
+
+  it('follows a symlink that targets a path inside the workspace', async () => {
+    const real = path.join(workspace, 'real.txt');
+    await fsp.writeFile(real, 'in');
+    const link = path.join(workspace, 'alias');
+    await fsp.symlink(real, link, 'file');
+    const out = await resolveWithinWorkspace('alias', workspace, 'read');
+    expect(out).toBe(realpathSync.native(real));
+  });
+
+  it('tolerates ENOENT for write intent and resolves via existing ancestor', async () => {
+    const nested = 'newdir/leaf.txt';
+    const out = await resolveWithinWorkspace(nested, workspace, 'write');
+    // Ancestor `workspace` is realpathed; tail `newdir/leaf.txt` is appended.
+    expect(out).toBe(
+      path.join(realpathSync.native(workspace), 'newdir', 'leaf.txt'),
+    );
+  });
+
+  it('rejects ENOENT under read intent with path_not_found', async () => {
+    const err = await resolveWithinWorkspace(
+      'does-not-exist',
+      workspace,
+      'read',
+    ).catch((e: unknown) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('path_not_found');
+  });
+
+  it('rejects suspicious patterns before any I/O', async () => {
+    await expect(
+      resolveWithinWorkspace('GIT~1', workspace, 'read'),
+    ).rejects.toMatchObject({ kind: 'path_outside_workspace' });
+    await expect(
+      resolveWithinWorkspace('//server/share', workspace, 'read'),
+    ).rejects.toMatchObject({ kind: 'path_outside_workspace' });
+  });
+
+  it('rejects empty/non-string input with parse_error', async () => {
+    await expect(
+      resolveWithinWorkspace('', workspace, 'read'),
+    ).rejects.toMatchObject({ kind: 'parse_error' });
+  });
+
+  it('returns a value usable as ResolvedPath brand', async () => {
+    const target = path.join(workspace, 'b.txt');
+    await fsp.writeFile(target, 'b');
+    const out: ResolvedPath = await resolveWithinWorkspace(
+      'b.txt',
+      workspace,
+      'read',
+    );
+    // Brand is compile-time only — assert string identity at runtime.
+    expect(typeof out).toBe('string');
+    expect(out).toBe(realpathSync.native(target));
+  });
+
+  it('canonicalizes the boundWorkspace once so symlinked workspaces resolve correctly', async () => {
+    // Workspace itself reachable via a symlink — daemon should still
+    // pin members by the canonical (realpath) form, so a request that
+    // names a child via the symlinked workspace path still resolves
+    // to the same canonical and passes the boundary check.
+    const aliasWorkspace = path.join(scratch, 'alias-workspace');
+    await fsp.symlink(workspace, aliasWorkspace, 'dir');
+    const target = path.join(workspace, 'inside.txt');
+    await fsp.writeFile(target, 'x');
+    const out = await resolveWithinWorkspace(
+      'inside.txt',
+      aliasWorkspace,
+      'read',
+    );
+    expect(out).toBe(realpathSync.native(target));
+  });
+});

--- a/packages/cli/src/serve/fs/paths.test.ts
+++ b/packages/cli/src/serve/fs/paths.test.ts
@@ -226,6 +226,22 @@ describe('resolveWithinWorkspace', () => {
     );
   });
 
+  it('tolerates ENOENT for stat intent and resolves via existing ancestor', async () => {
+    // Pinned per the docstring on `Intent` / `ENOENT_TOLERATING_INTENTS`:
+    // `'stat'` joins `'write'` in the tolerant set so a route asking
+    // "does this path exist?" gets back a synthetic canonical the
+    // caller can pass straight to `fsp.lstat`. The natural ENOENT
+    // surfaces from the lstat itself rather than from the resolver.
+    const out = await resolveWithinWorkspace(
+      'newdir/leaf.txt',
+      workspace,
+      'stat',
+    );
+    expect(out).toBe(
+      path.join(realpathSync.native(workspace), 'newdir', 'leaf.txt'),
+    );
+  });
+
   it('rejects ENOENT under read intent with path_not_found', async () => {
     const err = await resolveWithinWorkspace(
       'does-not-exist',

--- a/packages/cli/src/serve/fs/paths.test.ts
+++ b/packages/cli/src/serve/fs/paths.test.ts
@@ -230,6 +230,42 @@ describe('resolveWithinWorkspace', () => {
     ).rejects.toMatchObject({ kind: 'parse_error' });
   });
 
+  it('rejects a dangling symlink whose target escapes the workspace (write intent)', async () => {
+    // Reproduces the exploit class flagged at PR #4250: an attacker
+    // creates `<ws>/escape -> /etc/cron.d/evil` BEFORE the target
+    // exists, then issues a write request. Without the lstat-then-
+    // readlink check the ENOENT-tolerant ancestor walk would happily
+    // return `<ws>/escape` as the canonical write target and the
+    // OS-level write would create the file at the symlink target
+    // outside the workspace.
+    const outsideTarget = path.join(scratch, 'outside-not-yet-existing.txt');
+    const danglingLink = path.join(workspace, 'escape');
+    await fsp.symlink(outsideTarget, danglingLink, 'file');
+    const err = await resolveWithinWorkspace(
+      'escape',
+      workspace,
+      'write',
+    ).catch((e: unknown) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('symlink_escape');
+  });
+
+  it('allows a dangling symlink whose (not-yet-existing) target stays inside workspace', async () => {
+    // Symmetric to the escape case: a dangling symlink pointing at
+    // a future file INSIDE the workspace is a normal ahead-of-mkdir
+    // flow (test fixtures, atomic-write-via-rename). Resolve must
+    // succeed for write intent.
+    const insideTarget = path.join(workspace, 'will-create.txt');
+    const link = path.join(workspace, 'pending-link');
+    await fsp.symlink(insideTarget, link, 'file');
+    const out = await resolveWithinWorkspace(
+      'pending-link',
+      workspace,
+      'write',
+    );
+    expect(typeof out).toBe('string');
+  });
+
   it('returns a value usable as ResolvedPath brand', async () => {
     const target = path.join(workspace, 'b.txt');
     await fsp.writeFile(target, 'b');

--- a/packages/cli/src/serve/fs/paths.test.ts
+++ b/packages/cli/src/serve/fs/paths.test.ts
@@ -125,6 +125,27 @@ describe('hasSuspiciousPathPattern', () => {
     expect(hasSuspiciousPathPattern('bar.LPT1')).toBe(true);
   });
 
+  it('rejects bare and multi-extension DOS device names (NTFS reserves regardless of extension)', () => {
+    // Bare reserved names
+    expect(hasSuspiciousPathPattern('CON')).toBe(true);
+    expect(hasSuspiciousPathPattern('NUL')).toBe(true);
+    expect(hasSuspiciousPathPattern('PRN')).toBe(true);
+    expect(hasSuspiciousPathPattern('AUX')).toBe(true);
+    expect(hasSuspiciousPathPattern('COM1')).toBe(true);
+    expect(hasSuspiciousPathPattern('LPT9')).toBe(true);
+    // First-extension forms
+    expect(hasSuspiciousPathPattern('CON.txt')).toBe(true);
+    expect(hasSuspiciousPathPattern('NUL.dat')).toBe(true);
+    expect(hasSuspiciousPathPattern('LPT1.log')).toBe(true);
+    // Middle-extension form
+    expect(hasSuspiciousPathPattern('CON.foo.bar')).toBe(true);
+    // Substring of longer name must NOT match (BACON, concat, lprint…)
+    expect(hasSuspiciousPathPattern('BACON')).toBe(false);
+    expect(hasSuspiciousPathPattern('concat.txt')).toBe(false);
+    expect(hasSuspiciousPathPattern('precon.go')).toBe(false);
+    expect(hasSuspiciousPathPattern('contemplating.md')).toBe(false);
+  });
+
   it('rejects three-or-more-dot path components', () => {
     expect(hasSuspiciousPathPattern('foo/.../bar')).toBe(true);
     expect(hasSuspiciousPathPattern('.../leaf')).toBe(true);

--- a/packages/cli/src/serve/fs/paths.ts
+++ b/packages/cli/src/serve/fs/paths.ts
@@ -202,32 +202,45 @@ async function findExistingAncestor(
   let current = absolute;
   const tailParts: string[] = [];
   for (let i = 0; i < MAX_ANCESTOR_HOPS; i++) {
+    let stat: Awaited<ReturnType<typeof fsp.stat>> | null = null;
     try {
-      await fsp.stat(current);
-      return { ancestor: current, tail: tailParts.join(path.sep) };
+      stat = await fsp.stat(current);
     } catch (err) {
       const code = (err as NodeJS.ErrnoException)?.code;
-      if (code === 'ENOENT') {
-        // ancestor doesn't exist yet; keep walking up
-      } else if (code === 'ENOTDIR') {
-        // A regular file sits where we expected a directory (e.g.
-        // write target `${ws}/file.txt/child`). Walking up would
-        // happily realpath the file's parent and return a
-        // "canonical" the eventual write cannot use. Reject up-front
-        // so the orchestrator emits an `fs.denied` for the actual
-        // shape of the user error rather than silently passing
-        // boundary inspection and 500-ing later at write time.
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        // POSIX returns `ENOTDIR` when a regular file occupies a
+        // path segment we tried to traverse through; Windows
+        // returns `ENOENT` for the same case (CI failure on
+        // commit a81ada43f flagged the divergence). Either errno
+        // means "the *current* path doesn't resolve" — keep
+        // walking up and let the post-walk dirent-kind check
+        // below decide whether to accept the ancestor.
+      } else {
+        throw err;
+      }
+    }
+    if (stat) {
+      // A regular file sits where the request expected a directory
+      // (e.g. write target `${ws}/file.txt/child`, where
+      // `file.txt` is a regular file). Without this check the
+      // walk would happily return the file's parent as the
+      // canonical ancestor and let the eventual write surface a
+      // confusing late failure. Reject up-front with
+      // `parse_error`. `fsp.stat` follows symlinks, so
+      // `stat.isDirectory()` reflects the symlink target's kind —
+      // exactly what we want. Cross-platform: works the same on
+      // POSIX and Windows because the kind check fires regardless
+      // of which errno surfaced during the walk-up.
+      if (tailParts.length > 0 && !stat.isDirectory()) {
         throw new FsError(
           'parse_error',
           `path component is not a directory: ${absolute}`,
           {
-            cause: err,
             hint: 'a non-directory file occupies a path segment',
           },
         );
-      } else {
-        throw err;
       }
+      return { ancestor: current, tail: tailParts.join(path.sep) };
     }
     const parent = path.dirname(current);
     if (parent === current) {

--- a/packages/cli/src/serve/fs/paths.ts
+++ b/packages/cli/src/serve/fs/paths.ts
@@ -180,7 +180,22 @@ export function hasSuspiciousPathPattern(p: string): boolean {
   for (const seg of p.split(/[\\/]/)) {
     if (seg === '' || seg === '.' || seg === '..') continue;
     if (/[.\s]+$/.test(seg)) return true;
-    if (/\.(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i.test(seg)) return true;
+    // DOS / NTFS reserved device names. The Windows kernel treats
+    // these as device handles regardless of extension, so all four
+    // forms are reserved:
+    //   - bare:        `CON`, `NUL`, `LPT1`
+    //   - first-ext:   `CON.txt`, `NUL.dat`, `COM1.json`
+    //   - last-ext:    `file.CON`, `audit.PRN`, `bar.LPT9`
+    //   - any-ext:     `CON.foo.bar`
+    // The earlier regex anchored to `$` only caught the last-ext
+    // form. Anchor to either start (bare or first-ext) or `.`
+    // (last-ext or middle-ext) to cover the full set. Names
+    // containing the reserved word as a substring of a longer
+    // segment (e.g. `BACON`, `concat.txt`) are NOT reserved — the
+    // boundary anchor `(^|\.)` keeps those legitimate.
+    if (/(^|\.)(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])(\.|$)/i.test(seg)) {
+      return true;
+    }
   }
   return false;
 }

--- a/packages/cli/src/serve/fs/paths.ts
+++ b/packages/cli/src/serve/fs/paths.ts
@@ -335,19 +335,81 @@ export async function resolveWithinWorkspace(
       // detects the symlink without following it; `readlink` +
       // resolved-target containment closes the loop.
       try {
-        const linkStat = await fsp.lstat(absolute);
-        if (linkStat.isSymbolicLink()) {
-          const target = await fsp.readlink(absolute);
+        // Walk the FULL symlink chain via `lstat` + `readlink`,
+        // not just one hop. The earlier single-readlink fix was
+        // bypassed by `<ws>/leak -> <ws>/middle -> /etc/passwd`
+        // (where `middle` is itself a symlink): `findExistingAncestor`
+        // uses `fsp.stat` which follows the rest of the chain,
+        // landed on the target's parent, and reported the
+        // intermediate hop as canonical — letting the OS write
+        // follow the full chain to the escape target. The loop
+        // below dereferences every layer up to a max-depth bound
+        // and tracks visited inodes to surface cycles as
+        // `symlink_escape`. Once we reach a non-symlink leaf, we
+        // canonicalize that leaf via the deepest-existing-ancestor
+        // path (so macOS `/var` vs `/private/var` and Win32 case
+        // collapse consistently with `boundCanonical`).
+        let cursor: string = absolute;
+        const visitedInodes = new Set<bigint>();
+        let firstHopTarget: string | null = null;
+        let resolvedFully = false;
+        for (let hop = 0; hop < MAX_ANCESTOR_HOPS; hop++) {
+          let linkStat: Awaited<ReturnType<typeof fsp.lstat>>;
+          try {
+            linkStat = await fsp.lstat(cursor);
+          } catch (lstatErr) {
+            const lcode = (lstatErr as NodeJS.ErrnoException)?.code;
+            if (lcode === 'ENOENT' || lcode === 'ENOTDIR') {
+              // Reached a non-existent leaf — no symlink to chase
+              // here. Run the deepest-existing-ancestor check on
+              // `cursor` so the eventual write target is bounded.
+              resolvedFully = true;
+              break;
+            }
+            throw lstatErr;
+          }
+          if (!linkStat.isSymbolicLink()) {
+            // Reached a real file/dir — chain terminates here.
+            resolvedFully = true;
+            break;
+          }
+          // Detect cycles via inode identity (ino is a bigint on
+          // recent Node versions). Some filesystems return 0 for
+          // ino (e.g. virtual mounts); the depth bound covers
+          // those cases as a fallback.
+          const ino =
+            typeof linkStat.ino === 'bigint'
+              ? linkStat.ino
+              : BigInt(linkStat.ino as unknown as number);
+          if (ino !== 0n && visitedInodes.has(ino)) {
+            throw new FsError(
+              'symlink_escape',
+              `symlink cycle detected at ${cursor}`,
+              { hint: 'symlink loops back onto a previously visited inode' },
+            );
+          }
+          if (ino !== 0n) visitedInodes.add(ino);
+          const target = await fsp.readlink(cursor);
           const absTarget = path.isAbsolute(target)
             ? target
-            : path.resolve(path.dirname(absolute), target);
-          // The symlink target itself doesn't exist (that's why
-          // we're in the ENOENT branch), so resolve via the
-          // deepest existing ancestor so case-insensitive
-          // filesystems and macOS `/var` vs `/private/var`
-          // canonicalize consistently with `boundCanonical`.
+            : path.resolve(path.dirname(cursor), target);
+          if (firstHopTarget === null) firstHopTarget = target;
+          cursor = absTarget;
+        }
+        if (!resolvedFully) {
+          throw new FsError(
+            'symlink_escape',
+            `symlink chain exceeded ${MAX_ANCESTOR_HOPS} hops for ${input}`,
+            { hint: 'symlink chain is too long or contains a cycle' },
+          );
+        }
+        // Only run the containment check when we actually traversed
+        // at least one symlink — `firstHopTarget !== null` means the
+        // input was a symlink (vs a path through a non-existent
+        // ancestor that wasn't itself a symlink).
+        if (firstHopTarget !== null) {
           const { ancestor: targetAncestor, tail: targetTail } =
-            await findExistingAncestor(absTarget);
+            await findExistingAncestor(cursor);
           const targetAncestorReal = await fsp.realpath(targetAncestor);
           const canonicalTarget = targetTail
             ? path.join(targetAncestorReal, targetTail)
@@ -356,16 +418,16 @@ export async function resolveWithinWorkspace(
             throw new FsError(
               'symlink_escape',
               `dangling symlink target escapes workspace: ${input}`,
-              { hint: `symlink points to ${target}` },
+              { hint: `symlink points to ${firstHopTarget}` },
             );
           }
         }
       } catch (err2) {
         if (err2 instanceof FsError) throw err2;
-        // `lstat` ENOENT means the input path itself doesn't
-        // exist (input is a path through a non-existent
-        // ancestor) — no symlink to worry about; fall through
-        // to the ancestor walk.
+        // `lstat` ENOENT on the very first hop means the input
+        // path itself doesn't exist (input is a path through a
+        // non-existent ancestor) — no symlink to worry about;
+        // fall through to the ancestor walk.
         const code2 = (err2 as NodeJS.ErrnoException)?.code;
         if (code2 !== 'ENOENT') throw err2;
       }

--- a/packages/cli/src/serve/fs/paths.ts
+++ b/packages/cli/src/serve/fs/paths.ts
@@ -311,6 +311,51 @@ export async function resolveWithinWorkspace(
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code;
     if (code === 'ENOENT' && ENOENT_TOLERATING_INTENTS.has(intent)) {
+      // Dangling-symlink write-escape guard. `realpath` follows
+      // symlinks, so a path like `<ws>/leak -> /etc/cron.d/evil`
+      // (where the target doesn't exist YET) throws ENOENT here.
+      // Without this branch the ENOENT-tolerant ancestor walk
+      // below would happily walk up to the workspace root and
+      // return `<ws>/leak` as the canonical write target — but
+      // the OS-level write would follow the symlink to
+      // `/etc/cron.d/evil` and create the file there. `lstat`
+      // detects the symlink without following it; `readlink` +
+      // resolved-target containment closes the loop.
+      try {
+        const linkStat = await fsp.lstat(absolute);
+        if (linkStat.isSymbolicLink()) {
+          const target = await fsp.readlink(absolute);
+          const absTarget = path.isAbsolute(target)
+            ? target
+            : path.resolve(path.dirname(absolute), target);
+          // The symlink target itself doesn't exist (that's why
+          // we're in the ENOENT branch), so resolve via the
+          // deepest existing ancestor so case-insensitive
+          // filesystems and macOS `/var` vs `/private/var`
+          // canonicalize consistently with `boundCanonical`.
+          const { ancestor: targetAncestor, tail: targetTail } =
+            await findExistingAncestor(absTarget);
+          const targetAncestorReal = await fsp.realpath(targetAncestor);
+          const canonicalTarget = targetTail
+            ? path.join(targetAncestorReal, targetTail)
+            : targetAncestorReal;
+          if (!isWithinRoot(canonicalTarget, boundCanonical)) {
+            throw new FsError(
+              'symlink_escape',
+              `dangling symlink target escapes workspace: ${input}`,
+              { hint: `symlink points to ${target}` },
+            );
+          }
+        }
+      } catch (err2) {
+        if (err2 instanceof FsError) throw err2;
+        // `lstat` ENOENT means the input path itself doesn't
+        // exist (input is a path through a non-existent
+        // ancestor) — no symlink to worry about; fall through
+        // to the ancestor walk.
+        const code2 = (err2 as NodeJS.ErrnoException)?.code;
+        if (code2 !== 'ENOENT') throw err2;
+      }
       const { ancestor, tail } = await findExistingAncestor(absolute);
       const ancestorReal = await fsp.realpath(ancestor);
       canonical = tail ? path.join(ancestorReal, tail) : ancestorReal;

--- a/packages/cli/src/serve/fs/paths.ts
+++ b/packages/cli/src/serve/fs/paths.ts
@@ -170,7 +170,24 @@ export function hasSuspiciousPathPattern(p: string): boolean {
     const colonIndex = p.indexOf(':', 2);
     if (colonIndex !== -1) return true;
   }
-  if (/~\d/.test(p)) return true;
+  // NTFS 8.3 short-name suffix: `LONGFILENAME~1.TXT`. Two fixes
+  // over the original `/~\d/`:
+  //
+  // 1. Multi-digit (`~10`, `~99`) — NTFS allocates `~1`..`~4` for
+  //    the first 4 collisions, then switches to a hashed scheme
+  //    where `~10` and above are real, common short names. The
+  //    original regex missed those entirely.
+  // 2. Gate on Windows — on POSIX, `~\d` is a legitimate filename
+  //    character used by editor swap files (`file~1.swp`),
+  //    backup tools (`notes~2.md`, `backup~1.txt`), and version
+  //    schemes. The daemon's actual filesystem on Linux/macOS
+  //    isn't NTFS, so 8.3 interpretation doesn't apply and
+  //    rejecting these is a false positive that breaks
+  //    legitimate workflows. NTFS-on-Linux mounts (`ntfs-3g`) are
+  //    rare enough that we accept the residual gap; operators
+  //    mounting NTFS into a daemon workspace can disable
+  //    suspicious-pattern rejection at the route layer.
+  if (process.platform === 'win32' && /~\d+/.test(p)) return true;
   if (
     p.startsWith('\\\\?\\') ||
     p.startsWith('\\\\.\\') ||
@@ -218,6 +235,33 @@ export function hasSuspiciousPathPattern(p: string): boolean {
 
 /** Default ancestor-walk depth limit for ENOENT fallback. */
 const MAX_ANCESTOR_HOPS = 40;
+
+/**
+ * Module-level memo cache for `boundWorkspace → canonical`
+ * mapping. The factory already canonicalizes once at build time,
+ * so the inner call inside `resolveWithinWorkspace` is paying for
+ * a redundant `realpathSync.native` per request. The cache turns
+ * subsequent calls with the same `boundWorkspace` into an O(1)
+ * Map lookup; first call still pays the syscall (idempotent on
+ * already-canonical input).
+ *
+ * Cache size is bounded only by the number of *distinct*
+ * `boundWorkspace` values a daemon ever sees — `1 daemon = 1
+ * workspace` per #4175, so the steady-state size is exactly 1.
+ * Tests that exercise multiple workspaces add an entry per
+ * scratch dir; entries never have to be evicted because realpath
+ * is functional (a path's canonical form doesn't change unless
+ * the path is moved on disk, in which case the bound workspace
+ * is wrong elsewhere too).
+ */
+const CANONICAL_BOUND_CACHE = new Map<string, string>();
+function canonicalizeBoundWorkspaceCached(boundWorkspace: string): string {
+  const cached = CANONICAL_BOUND_CACHE.get(boundWorkspace);
+  if (cached !== undefined) return cached;
+  const canonical = canonicalizeWorkspace(boundWorkspace);
+  CANONICAL_BOUND_CACHE.set(boundWorkspace, canonical);
+  return canonical;
+}
 
 /**
  * Walk up `absolute` until a component exists on disk. Returns the
@@ -337,7 +381,7 @@ export async function resolveWithinWorkspace(
     );
   }
 
-  const boundCanonical = canonicalizeWorkspace(boundWorkspace);
+  const boundCanonical = canonicalizeBoundWorkspaceCached(boundWorkspace);
   const absolute = path.resolve(boundCanonical, input);
 
   // Cheap pre-filter on the resolved-but-not-realpathed form. Catches

--- a/packages/cli/src/serve/fs/paths.ts
+++ b/packages/cli/src/serve/fs/paths.ts
@@ -399,6 +399,12 @@ export async function resolveWithinWorkspace(
   } catch (err) {
     const code = (err as NodeJS.ErrnoException)?.code;
     if (code === 'ENOENT' && ENOENT_TOLERATING_INTENTS.has(intent)) {
+      // Captured iff the symlink chain validated successfully —
+      // we then return this verified canonical instead of falling
+      // through to a re-walk from `absolute` (which would
+      // re-traverse the chain and could pick up an attacker's
+      // mid-walk symlink swap).
+      let symlinkResolvedCanonical: string | null = null;
       // Dangling-symlink write-escape guard. `realpath` follows
       // symlinks, so a path like `<ws>/leak -> /etc/cron.d/evil`
       // (where the target doesn't exist YET) throws ENOENT here.
@@ -481,7 +487,13 @@ export async function resolveWithinWorkspace(
         // Only run the containment check when we actually traversed
         // at least one symlink — `firstHopTarget !== null` means the
         // input was a symlink (vs a path through a non-existent
-        // ancestor that wasn't itself a symlink).
+        // ancestor that wasn't itself a symlink). The verified
+        // `canonicalTarget` becomes the function's result; we DO
+        // NOT re-walk from `absolute` afterwards, since that would
+        // open a TOCTOU window between the check and the re-walk
+        // where an attacker swapping an intermediate symlink
+        // could produce a different canonical than the one we
+        // just verified.
         if (firstHopTarget !== null) {
           const { ancestor: targetAncestor, tail: targetTail } =
             await findExistingAncestor(cursor);
@@ -493,9 +505,19 @@ export async function resolveWithinWorkspace(
             throw new FsError(
               'symlink_escape',
               `dangling symlink target escapes workspace: ${input}`,
-              { hint: `symlink points to ${firstHopTarget}` },
+              {
+                // Hint must NOT embed the symlink target — `recordDenied`
+                // forwards `hint` into `fs.denied` even in privacy mode,
+                // and an absolute outside-target string would leak the
+                // attacker's intended exfiltration path through audit
+                // events. Operators wanting the actual target value
+                // run with `QWEN_AUDIT_RAW_PATHS=1` and read it from
+                // `relPath` / `message`.
+                hint: 'symlink chain leaves the workspace; enable QWEN_AUDIT_RAW_PATHS for the resolved target',
+              },
             );
           }
+          symlinkResolvedCanonical = canonicalTarget;
         }
       } catch (err2) {
         if (err2 instanceof FsError) throw err2;
@@ -506,9 +528,18 @@ export async function resolveWithinWorkspace(
         const code2 = (err2 as NodeJS.ErrnoException)?.code;
         if (code2 !== 'ENOENT') throw err2;
       }
-      const { ancestor, tail } = await findExistingAncestor(absolute);
-      const ancestorReal = await fsp.realpath(ancestor);
-      canonical = tail ? path.join(ancestorReal, tail) : ancestorReal;
+      // If the symlink-walk produced a verified canonical, use it
+      // instead of re-walking from `absolute` (which would discard
+      // the verification and admit a TOCTOU swap window). The
+      // re-walk is only the right behavior when no symlink was
+      // present at all.
+      if (symlinkResolvedCanonical !== null) {
+        canonical = symlinkResolvedCanonical;
+      } else {
+        const { ancestor, tail } = await findExistingAncestor(absolute);
+        const ancestorReal = await fsp.realpath(ancestor);
+        canonical = tail ? path.join(ancestorReal, tail) : ancestorReal;
+      }
     } else if (code === 'ENOENT') {
       throw new FsError('path_not_found', `path does not exist: ${input}`, {
         cause: err,

--- a/packages/cli/src/serve/fs/paths.ts
+++ b/packages/cli/src/serve/fs/paths.ts
@@ -97,19 +97,35 @@ export type ResolvedPath = string & { readonly __brand: 'ResolvedPath' };
 
 /**
  * Intent declared at boundary entry. Used by callers (and the upcoming
- * `policy.ts` module) to decide ignore/trust handling. `resolveWithinWorkspace`
- * itself uses the intent only to differentiate ENOENT semantics: write
- * intents tolerate a non-existent leaf (the file is about to be created),
- * read intents do not.
+ * `policy.ts` module) to decide ignore/trust handling.
+ * `resolveWithinWorkspace` itself uses the intent to differentiate
+ * ENOENT semantics: `'write'` and `'stat'` tolerate a non-existent
+ * leaf (the file is about to be created, or the caller is asking
+ * "does this exist?"), other intents do not.
  *
- * `'edit'` is a distinct intent from `'write'` so the trust gate, audit
- * payload, and exhaustiveness checks can reason about partial-replace
- * semantics separately from full-overwrite. Both gate identically in
- * `assertTrustedForIntent`; the split exists to keep audit events
- * faithful to the operation actually performed.
+ * `'edit'` is a distinct intent from `'write'` so the trust gate,
+ * audit payload, and exhaustiveness checks can reason about
+ * partial-replace semantics separately from full-overwrite. Both
+ * gate identically in `assertTrustedForIntent`; the split exists
+ * to keep audit events faithful to the operation actually
+ * performed.
+ *
+ * Why `'stat'` tolerates ENOENT: stat-ing a path that doesn't
+ * exist is a legitimate existence check (a route handler asking
+ * "should I 404?" before letting a downstream call fail with a
+ * cryptic message). `WorkspaceFileSystem.stat()` re-`lstat`s the
+ * resolved path itself and surfaces the natural ENOENT to the
+ * caller, so the resolver doesn't need to pre-emptively reject.
  */
 export type Intent = 'read' | 'write' | 'edit' | 'list' | 'glob' | 'stat';
 
+/**
+ * Intents that tolerate a non-existent leaf — see `Intent`'s
+ * docstring for why each is in the set. Adding a new intent here
+ * is a deliberate decision: the resolver's ancestor walk returns
+ * a synthetic canonical path that the caller MUST be prepared to
+ * see succeed for nonexistent leaves.
+ */
 const ENOENT_TOLERATING_INTENTS: ReadonlySet<Intent> = new Set([
   'write',
   'stat',

--- a/packages/cli/src/serve/fs/paths.ts
+++ b/packages/cli/src/serve/fs/paths.ts
@@ -69,6 +69,16 @@ export function canonicalizeWorkspace(p: string): string {
     // deployments will. Stage 2 in-process refactor removes the
     // entire bridge-side path resolution anyway, but if Stage 2
     // ever lands without that change, switch to the async version.
+    //
+    // Note for the resolveWithinWorkspace fast-path:
+    // `CANONICAL_BOUND_CACHE` (defined later in this file) memoizes
+    // the canonical mapping per `boundWorkspace` string. Under the
+    // `1 daemon = 1 workspace` model the cache is hit 100% of the
+    // time after the factory's boot-time canonicalization, so the
+    // sync syscall in steady state is **zero per request** —
+    // event-loop blocking only happens at boot or whenever a fresh
+    // `boundWorkspace` value first appears (e.g. tests sharing a
+    // module instance across `mkdtemp` workspaces).
     return realpathSync.native(resolved);
   } catch (err) {
     // Only fall back to path.resolve for ENOENT (path doesn't exist

--- a/packages/cli/src/serve/fs/paths.ts
+++ b/packages/cli/src/serve/fs/paths.ts
@@ -1,0 +1,353 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { promises as fsp, realpathSync } from 'node:fs';
+import * as path from 'node:path';
+import { isWithinRoot } from '@qwen-code/qwen-code-core';
+import { FsError, type FsErrorKind } from './errors.js';
+
+/**
+ * Canonicalize a workspace path so the boot-time bound path and every
+ * request's `workspaceCwd` collapse to the same key. `path.resolve`
+ * alone normalizes `..` and `.` segments and absolutizes, but on
+ * case-insensitive filesystems (macOS APFS, Windows NTFS) `/Work/A`
+ * and `/work/a` are the same directory yet `resolve` returns them
+ * verbatim — without normalization the `boundWorkspace` check would
+ * reject every request that spelled the path with different casing
+ * and `sessionScope: 'single'` re-attach would silently degrade to
+ * "one per spelling".
+ *
+ * `realpathSync.native` (when the path exists) walks symlinks and returns
+ * the on-disk casing; this matches what `config.ts` / `settings.ts` /
+ * `sandbox.ts` use for their own workspace resolution. When the path
+ * doesn't exist (test fixtures, ahead-of-mkdir flows) we fall back to
+ * the resolved-but-uncanonicalized form rather than throwing — the
+ * downstream `spawn({cwd})` will fail with a useful ENOENT if the
+ * workspace truly doesn't exist.
+ *
+ * NOTE: This is a **cross-module contract** (BX9_q) — `config.ts`,
+ * `settings.ts`, `sandbox.ts`, and `httpAcpBridge.ts` all need to
+ * canonicalize the same way for the bound-workspace check +
+ * `sessionScope: 'single'` re-attach to work correctly across paths.
+ * The contract: use `realpathSync.native` on the resolved absolute
+ * path; fall back to `path.resolve` only when the path doesn't exist
+ * yet. If a future change breaks this alignment (e.g. one module
+ * starts lowercasing on Windows but this one doesn't), the
+ * canonicalized request path won't match the canonicalized bound
+ * path → every request returns `workspace_mismatch` even though the
+ * human-readable paths look equivalent. There's no test that pins
+ * the alignment; the integration suite would catch a divergence only
+ * if it tested the specific casing / symlink path the affected
+ * module changed.
+ *
+ * Stage 2 in-process (#3803 §10) collapses the bridge into core,
+ * removing the bridge-side path resolution entirely. Stage 1.5
+ * `@qwen-code/acp-bridge` lift (chiga0 finding 1) is the natural
+ * place to extract a shared `canonicalizeWorkspace` primitive that
+ * all four modules consume — the lowest-common-denominator
+ * extraction is fine THERE because the package boundary forces the
+ * call sites to converge. Until then, *any* change to how those
+ * modules resolve workspace paths needs a matching change here.
+ *
+ * #4175 PR 18 extraction: this file is the new home of the primitive
+ * for the serve layer. The bridge re-exports it so existing callers
+ * continue to import from `httpAcpBridge.js`. The forthcoming
+ * `WorkspaceFileSystem` boundary (PR 18 commits 3+) builds on top of
+ * this single resolver.
+ */
+export function canonicalizeWorkspace(p: string): string {
+  const resolved = path.resolve(p);
+  try {
+    // FIXME(stage-2): switch to `fs.promises.realpath` once the
+    // bridge call sites become async-friendly. This sync syscall
+    // runs on the hot `spawnOrAttach` path and blocks the event
+    // loop for one filesystem stat per call. Single-user loopback
+    // (Stage 1's design target) doesn't notice; high-concurrency
+    // deployments will. Stage 2 in-process refactor removes the
+    // entire bridge-side path resolution anyway, but if Stage 2
+    // ever lands without that change, switch to the async version.
+    return realpathSync.native(resolved);
+  } catch (err) {
+    // Only fall back to path.resolve for ENOENT (path doesn't exist
+    // yet). Other filesystem errors (EACCES, EIO, ELOOP) should
+    // propagate — swallowing them would hide transient I/O failures
+    // behind misleading workspace_mismatch rejections.
+    if (
+      err &&
+      typeof err === 'object' &&
+      (err as { code?: unknown }).code === 'ENOENT'
+    ) {
+      return resolved;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Branded absolute path that has passed the workspace boundary check.
+ * The runtime value is just a string; the brand is a compile-time
+ * marker that prevents PR 19/20 routes from accidentally bypassing
+ * `resolveWithinWorkspace` and reading user-supplied input straight
+ * to disk. Construct one only via `resolveWithinWorkspace`.
+ */
+export type ResolvedPath = string & { readonly __brand: 'ResolvedPath' };
+
+/**
+ * Intent declared at boundary entry. Used by callers (and the upcoming
+ * `policy.ts` module) to decide ignore/trust handling. `resolveWithinWorkspace`
+ * itself uses the intent only to differentiate ENOENT semantics: write
+ * intents tolerate a non-existent leaf (the file is about to be created),
+ * read intents do not.
+ *
+ * `'edit'` is a distinct intent from `'write'` so the trust gate, audit
+ * payload, and exhaustiveness checks can reason about partial-replace
+ * semantics separately from full-overwrite. Both gate identically in
+ * `assertTrustedForIntent`; the split exists to keep audit events
+ * faithful to the operation actually performed.
+ */
+export type Intent = 'read' | 'write' | 'edit' | 'list' | 'glob' | 'stat';
+
+const ENOENT_TOLERATING_INTENTS: ReadonlySet<Intent> = new Set([
+  'write',
+  'stat',
+]);
+
+/**
+ * Detect Windows-targeted path attack patterns that bypass naive
+ * boundary checks. Adapted from claude-code's
+ * `hasSuspiciousWindowsPathPattern` (`src/utils/permissions/filesystem.ts`).
+ *
+ * Why detection rather than normalization:
+ *
+ * 1. Short-name normalization depends on the file existing. For a
+ *    write intent the leaf is absent by definition, so normalization
+ *    can't run.
+ * 2. Filesystem state can change between normalization and access
+ *    (TOCTOU), so a "normalized then check" pipeline still admits
+ *    races. Detecting the dangerous *literal* on input closes that
+ *    window.
+ * 3. The patterns are cheap to detect and produce zero false
+ *    positives on legitimate POSIX filenames the daemon expects to
+ *    receive (workspace files are project sources / configs, never
+ *    `\\?\` long-path prefixes).
+ *
+ * Checked patterns:
+ * - NTFS ADS (`:` after position 2 — drive-letter slot exempted)
+ * - 8.3 short names (`~\d`)
+ * - Long-path prefixes (`\\?\`, `\\.\`, `//?/`, `//./`)
+ * - Trailing dots / spaces (Windows strips during resolution)
+ * - DOS device names as final extension (`.CON`, `.PRN`, ...)
+ * - Three-or-more consecutive dots used as a path component
+ * - UNC prefix (`\\server\share`, `//server/share`) — also blocks
+ *   loopback DNS / SMB lookups during resolution.
+ *
+ * NTFS-on-Linux mounts (`ntfs-3g`) admit the same bypasses except
+ * the colon syntax (which only the Windows kernel parses), so the
+ * platform gate exists only for the ADS branch; everything else is
+ * checked unconditionally.
+ */
+export function hasSuspiciousPathPattern(p: string): boolean {
+  if (process.platform === 'win32') {
+    const colonIndex = p.indexOf(':', 2);
+    if (colonIndex !== -1) return true;
+  }
+  if (/~\d/.test(p)) return true;
+  if (
+    p.startsWith('\\\\?\\') ||
+    p.startsWith('\\\\.\\') ||
+    p.startsWith('//?/') ||
+    p.startsWith('//./')
+  ) {
+    return true;
+  }
+  if (
+    (p.startsWith('\\\\') && p.length > 2 && p[2] !== '\\') ||
+    (p.startsWith('//') && p.length > 2 && p[2] !== '/')
+  ) {
+    // UNC prefix `\\server\share` / `//server/share` — never legitimate
+    // input from a daemon client. The earlier long-path check covers
+    // the special device variants (`\\?\`, `\\.\`).
+    return true;
+  }
+  if (/(^|\/|\\)\.{3,}(\/|\\|$)/.test(p)) return true;
+  // Per-component checks below: skip empty segments and the legitimate
+  // POSIX traversal tokens `.` / `..`. Bare `.` and `..` are fine
+  // inputs — the boundary's `path.resolve` + `isWithinRoot` will reject
+  // any traversal that lands outside the workspace.
+  for (const seg of p.split(/[\\/]/)) {
+    if (seg === '' || seg === '.' || seg === '..') continue;
+    if (/[.\s]+$/.test(seg)) return true;
+    if (/\.(CON|PRN|AUX|NUL|COM[1-9]|LPT[1-9])$/i.test(seg)) return true;
+  }
+  return false;
+}
+
+/** Default ancestor-walk depth limit for ENOENT fallback. */
+const MAX_ANCESTOR_HOPS = 40;
+
+/**
+ * Walk up `absolute` until a component exists on disk. Returns the
+ * existing ancestor and the trailing components that don't exist
+ * yet, joined with the platform separator. Used by the ENOENT
+ * fallback in `resolveWithinWorkspace` to canonicalize the existing
+ * portion (resolving any symlink in the parent chain) before
+ * boundary-checking the eventual write target.
+ */
+async function findExistingAncestor(
+  absolute: string,
+): Promise<{ ancestor: string; tail: string }> {
+  let current = absolute;
+  const tailParts: string[] = [];
+  for (let i = 0; i < MAX_ANCESTOR_HOPS; i++) {
+    try {
+      await fsp.stat(current);
+      return { ancestor: current, tail: tailParts.join(path.sep) };
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code === 'ENOENT') {
+        // ancestor doesn't exist yet; keep walking up
+      } else if (code === 'ENOTDIR') {
+        // A regular file sits where we expected a directory (e.g.
+        // write target `${ws}/file.txt/child`). Walking up would
+        // happily realpath the file's parent and return a
+        // "canonical" the eventual write cannot use. Reject up-front
+        // so the orchestrator emits an `fs.denied` for the actual
+        // shape of the user error rather than silently passing
+        // boundary inspection and 500-ing later at write time.
+        throw new FsError(
+          'parse_error',
+          `path component is not a directory: ${absolute}`,
+          {
+            cause: err,
+            hint: 'a non-directory file occupies a path segment',
+          },
+        );
+      } else {
+        throw err;
+      }
+    }
+    const parent = path.dirname(current);
+    if (parent === current) {
+      throw new FsError(
+        'path_not_found',
+        `no existing ancestor for ${absolute}`,
+      );
+    }
+    tailParts.unshift(path.basename(current));
+    current = parent;
+  }
+  throw new FsError(
+    'path_not_found',
+    `path traversal exceeded ${MAX_ANCESTOR_HOPS} hops while finding ancestor`,
+    {
+      hint: 'path is too deeply nested or filesystem is responding unexpectedly',
+    },
+  );
+}
+
+/**
+ * Resolve a daemon-input path to an absolute, symlink-canonicalized
+ * `ResolvedPath` that is provably inside `boundWorkspace`. Throws
+ * `FsError` on any boundary violation.
+ *
+ * Algorithm (#4175 PR 18 plan, claude-code-style chain check):
+ *
+ * 1. Reject suspicious literal patterns before any I/O.
+ * 2. Resolve against `boundWorkspace` to absolutize relative inputs.
+ * 3. Cheap pre-filter: textual containment check rejects obvious
+ *    `..` traversal without paying for `realpath`.
+ * 4. `fs.promises.realpath` on the absolute path. Node's realpath
+ *    follows the entire symlink chain natively (SYMLOOP_MAX-bounded);
+ *    if any hop escapes the workspace, the final canonical lands
+ *    outside and step 5 catches it.
+ * 5. ENOENT (write/stat intents): walk up to first existing ancestor,
+ *    realpath the ancestor, re-attach the unresolved tail. The tail
+ *    can't introduce new symlinks (it doesn't exist), so the joined
+ *    result is the actual write target the OS will use.
+ * 6. Final containment check against canonicalized `boundWorkspace`.
+ *    If the canonical landed outside but the resolved-without-realpath
+ *    version was inside, classify as `symlink_escape`; otherwise as
+ *    `path_outside_workspace`.
+ *
+ * The brand on the return type is the contract that PR 19/20 routes
+ * may not construct one without going through this function.
+ */
+export async function resolveWithinWorkspace(
+  input: string,
+  boundWorkspace: string,
+  intent: Intent,
+): Promise<ResolvedPath> {
+  if (typeof input !== 'string' || input.length === 0) {
+    throw new FsError('parse_error', 'path must be a non-empty string');
+  }
+  if (hasSuspiciousPathPattern(input)) {
+    throw new FsError(
+      'path_outside_workspace',
+      `path contains suspicious pattern: ${input}`,
+      {
+        hint: 'paths with NTFS ADS, 8.3 short names, UNC prefixes, or trailing dots are rejected outright',
+      },
+    );
+  }
+
+  const boundCanonical = canonicalizeWorkspace(boundWorkspace);
+  const absolute = path.resolve(boundCanonical, input);
+
+  // Cheap pre-filter on the resolved-but-not-realpathed form. Catches
+  // textual `..` escape without an FS call.
+  if (!isWithinRoot(absolute, boundCanonical)) {
+    throw new FsError(
+      'path_outside_workspace',
+      `path escapes workspace: ${input}`,
+    );
+  }
+
+  let canonical: string;
+  try {
+    canonical = await fsp.realpath(absolute);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === 'ENOENT' && ENOENT_TOLERATING_INTENTS.has(intent)) {
+      const { ancestor, tail } = await findExistingAncestor(absolute);
+      const ancestorReal = await fsp.realpath(ancestor);
+      canonical = tail ? path.join(ancestorReal, tail) : ancestorReal;
+    } else if (code === 'ENOENT') {
+      throw new FsError('path_not_found', `path does not exist: ${input}`, {
+        cause: err,
+      });
+    } else if (code === 'ELOOP') {
+      throw new FsError(
+        'symlink_escape',
+        `symlink loop or chain too long for ${input}`,
+        {
+          cause: err,
+          hint: 'a symlink in the path forms a cycle or exceeds SYMLOOP_MAX',
+        },
+      );
+    } else if (code === 'EACCES') {
+      throw new FsError(
+        'permission_denied',
+        `permission denied resolving ${input}`,
+        { cause: err },
+      );
+    } else {
+      throw err;
+    }
+  }
+
+  if (!isWithinRoot(canonical, boundCanonical)) {
+    const kind: FsErrorKind =
+      canonical !== absolute ? 'symlink_escape' : 'path_outside_workspace';
+    throw new FsError(
+      kind,
+      kind === 'symlink_escape'
+        ? `symlink resolves outside workspace: ${input}`
+        : `path escapes workspace: ${input}`,
+    );
+  }
+
+  return canonical as ResolvedPath;
+}

--- a/packages/cli/src/serve/fs/policy.test.ts
+++ b/packages/cli/src/serve/fs/policy.test.ts
@@ -1,0 +1,241 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fsp } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { Ignore } from '@qwen-code/qwen-code-core';
+import {
+  MAX_READ_BYTES,
+  MAX_WRITE_BYTES,
+  assertTrustedForIntent,
+  detectBinary,
+  enforceReadBytesSize,
+  enforceReadSize,
+  enforceWriteSize,
+  shouldIgnore,
+} from './policy.js';
+import { canonicalizeWorkspace, resolveWithinWorkspace } from './paths.js';
+import { isFsError } from './errors.js';
+
+describe('shouldIgnore', () => {
+  let scratch: string;
+  let workspace: string;
+
+  beforeEach(async () => {
+    scratch = await fsp.mkdtemp(
+      path.join(os.tmpdir(), `qwen-policy-${randomBytes(4).toString('hex')}-`),
+    );
+    const wsDir = path.join(scratch, 'ws');
+    await fsp.mkdir(wsDir, { recursive: true });
+    workspace = canonicalizeWorkspace(wsDir);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(scratch, { recursive: true, force: true });
+  });
+
+  it('flags files matching .gitignore-style patterns', async () => {
+    const ignore = new Ignore().add(['*.log', 'dist/']);
+    const target = path.join(workspace, 'app.log');
+    await fsp.writeFile(target, '');
+    const resolved = await resolveWithinWorkspace('app.log', workspace, 'read');
+    expect(shouldIgnore(resolved, workspace, ignore)).toEqual({
+      ignored: true,
+      category: 'file',
+    });
+  });
+
+  it('flags directory patterns', async () => {
+    const ignore = new Ignore().add(['build/']);
+    const dir = path.join(workspace, 'build');
+    await fsp.mkdir(dir);
+    const resolved = await resolveWithinWorkspace('build', workspace, 'list');
+    expect(shouldIgnore(resolved, workspace, ignore, 'directory')).toEqual({
+      ignored: true,
+      category: 'directory',
+    });
+  });
+
+  it('flags non-trailing-slash directory patterns like node_modules', async () => {
+    const ignore = new Ignore().add(['node_modules']);
+    const dir = path.join(workspace, 'node_modules');
+    await fsp.mkdir(dir);
+    const resolved = await resolveWithinWorkspace(
+      'node_modules',
+      workspace,
+      'list',
+    );
+    // No-trailing-slash patterns get registered in both ignorers; either
+    // shows up as an ignore hit. We accept whichever category fires.
+    const verdict = shouldIgnore(resolved, workspace, ignore, 'directory');
+    expect(verdict.ignored).toBe(true);
+  });
+
+  it('returns false when no rule matches', async () => {
+    const ignore = new Ignore().add(['*.log']);
+    const target = path.join(workspace, 'src.ts');
+    await fsp.writeFile(target, '');
+    const resolved = await resolveWithinWorkspace('src.ts', workspace, 'read');
+    expect(shouldIgnore(resolved, workspace, ignore)).toEqual({
+      ignored: false,
+    });
+  });
+
+  it('never ignores the workspace root itself', async () => {
+    const ignore = new Ignore().add(['*']);
+    const resolved = await resolveWithinWorkspace('.', workspace, 'list');
+    expect(shouldIgnore(resolved, workspace, ignore)).toEqual({
+      ignored: false,
+    });
+  });
+});
+
+describe('assertTrustedForIntent', () => {
+  it('passes when trusted regardless of intent', () => {
+    expect(() => assertTrustedForIntent(true, 'read')).not.toThrow();
+    expect(() => assertTrustedForIntent(true, 'write')).not.toThrow();
+    expect(() => assertTrustedForIntent(true, 'list')).not.toThrow();
+  });
+
+  it('passes for read-style intents when untrusted', () => {
+    expect(() => assertTrustedForIntent(false, 'read')).not.toThrow();
+    expect(() => assertTrustedForIntent(false, 'list')).not.toThrow();
+    expect(() => assertTrustedForIntent(false, 'glob')).not.toThrow();
+    expect(() => assertTrustedForIntent(false, 'stat')).not.toThrow();
+  });
+
+  it('throws untrusted_workspace for write intent when untrusted', () => {
+    const err = (() => {
+      try {
+        assertTrustedForIntent(false, 'write');
+      } catch (e) {
+        return e;
+      }
+      throw new Error('expected throw');
+    })();
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string; status: number }).kind).toBe(
+      'untrusted_workspace',
+    );
+    expect((err as { kind: string; status: number }).status).toBe(403);
+  });
+
+  it('throws untrusted_workspace for edit intent when untrusted', () => {
+    expect(() => assertTrustedForIntent(false, 'edit')).toThrowError(
+      /edit operations are forbidden/,
+    );
+  });
+});
+
+describe('enforceReadSize', () => {
+  it('returns full size when under the cap', () => {
+    expect(enforceReadSize(1024)).toEqual({
+      bytesToRead: 1024,
+      truncated: false,
+    });
+  });
+
+  it('returns the cap and truncated=true when over', () => {
+    expect(enforceReadSize(MAX_READ_BYTES + 1)).toEqual({
+      bytesToRead: MAX_READ_BYTES,
+      truncated: true,
+    });
+  });
+
+  it('honors a per-call max override', () => {
+    expect(enforceReadSize(2048, 1024)).toEqual({
+      bytesToRead: 1024,
+      truncated: true,
+    });
+    expect(enforceReadSize(512, 1024)).toEqual({
+      bytesToRead: 512,
+      truncated: false,
+    });
+  });
+});
+
+describe('enforceWriteSize', () => {
+  it('passes when under the write cap', () => {
+    expect(() => enforceWriteSize(1024)).not.toThrow();
+    expect(() => enforceWriteSize(MAX_WRITE_BYTES)).not.toThrow();
+  });
+
+  it('throws file_too_large when over the cap', () => {
+    const err = (() => {
+      try {
+        enforceWriteSize(MAX_WRITE_BYTES + 1);
+      } catch (e) {
+        return e;
+      }
+      throw new Error('expected throw');
+    })();
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string; status: number }).kind).toBe(
+      'file_too_large',
+    );
+    expect((err as { kind: string; status: number }).status).toBe(413);
+  });
+});
+
+describe('enforceReadBytesSize', () => {
+  it('passes when under the cap', () => {
+    expect(() => enforceReadBytesSize(1024)).not.toThrow();
+  });
+
+  it('throws file_too_large when over', () => {
+    const err = (() => {
+      try {
+        enforceReadBytesSize(MAX_READ_BYTES + 1);
+      } catch (e) {
+        return e;
+      }
+      throw new Error('expected throw');
+    })();
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('file_too_large');
+  });
+});
+
+describe('detectBinary', () => {
+  let scratch: string;
+  let workspace: string;
+
+  beforeEach(async () => {
+    scratch = await fsp.mkdtemp(
+      path.join(os.tmpdir(), `qwen-binary-${randomBytes(4).toString('hex')}-`),
+    );
+    const wsDir = path.join(scratch, 'ws');
+    await fsp.mkdir(wsDir, { recursive: true });
+    workspace = canonicalizeWorkspace(wsDir);
+  });
+
+  afterEach(async () => {
+    await fsp.rm(scratch, { recursive: true, force: true });
+  });
+
+  it('reports text files as non-binary', async () => {
+    const target = path.join(workspace, 'plain.txt');
+    await fsp.writeFile(target, 'hello world\nsecond line\n');
+    const resolved = await resolveWithinWorkspace(
+      'plain.txt',
+      workspace,
+      'read',
+    );
+    expect(await detectBinary(resolved)).toBe(false);
+  });
+
+  it('reports buffers with null bytes as binary', async () => {
+    const target = path.join(workspace, 'bin.dat');
+    const buf = Buffer.alloc(64);
+    buf[10] = 0; // null byte triggers binary detection
+    await fsp.writeFile(target, buf);
+    const resolved = await resolveWithinWorkspace('bin.dat', workspace, 'read');
+    expect(await detectBinary(resolved)).toBe(true);
+  });
+});

--- a/packages/cli/src/serve/fs/policy.ts
+++ b/packages/cli/src/serve/fs/policy.ts
@@ -205,26 +205,23 @@ export function enforceWriteSize(
 }
 
 /**
- * Throw `file_too_large` if a read would exceed the cap and the
- * caller cannot accept truncation (used by `readBytes`, where
- * partial content is unsafe to return).
+ * Throw `file_too_large` when `fileBytes` exceeds the hard
+ * `MAX_READ_BYTES` cap. This is the OOM-defense gate `readBytes`
+ * runs at stat time — a 5 GB file is rejected before
+ * `fsp.readFile` allocates the buffer.
  *
- * Critical: `MAX_READ_BYTES` is the **hard** ceiling — caller-
- * supplied `maxBytes` clamps it DOWN, never up. Without this
- * `Math.min` clamp, a future PR 19/20 route that blindly forwards
- * `req.query.maxBytes` would let a request widen past the daemon's
- * 256 KiB safety cap and trigger the OOM scenario the cap exists
- * to prevent.
+ * Soft window-read (`opts.maxBytes` truncation) is NOT this
+ * function's job: `readBytes` truncates the returned buffer
+ * post-read so a caller asking for `maxBytes: 1024` on a 200 KB
+ * file gets 1 KB back, matching the parameter's window-read
+ * promise. Mixing the soft window into the hard reject was the
+ * round-7 reviewer-flagged contract violation.
  */
-export function enforceReadBytesSize(
-  fileBytes: number,
-  maxBytes: number = MAX_READ_BYTES,
-): void {
-  const effectiveMax = Math.min(maxBytes, MAX_READ_BYTES);
-  if (fileBytes > effectiveMax) {
+export function enforceReadBytesSize(fileBytes: number): void {
+  if (fileBytes > MAX_READ_BYTES) {
     throw new FsError(
       'file_too_large',
-      `file of ${fileBytes} bytes exceeds read limit of ${effectiveMax} bytes`,
+      `file of ${fileBytes} bytes exceeds read limit of ${MAX_READ_BYTES} bytes`,
       {
         hint: 'use readText for capped truncation, or raise the daemon limit',
       },

--- a/packages/cli/src/serve/fs/policy.ts
+++ b/packages/cli/src/serve/fs/policy.ts
@@ -5,17 +5,30 @@
  */
 
 import * as path from 'node:path';
-import type { Ignore} from '@qwen-code/qwen-code-core';
+import type { Ignore } from '@qwen-code/qwen-code-core';
 import { isBinaryFile } from '@qwen-code/qwen-code-core';
 import { FsError } from './errors.js';
 import type { Intent, ResolvedPath } from './paths.js';
 
 /**
- * Maximum bytes returned by `readText`. Mirrors claude-code's
+ * Maximum bytes the `readText` boundary is willing to slurp before
+ * delegating to the core service. Mirrors claude-code's
  * `MAX_OUTPUT_SIZE` (`src/utils/file.ts`) — large enough for
  * typical source files, small enough that an SSE replay buffer
- * doesn't fill on a single read. Reads above this size return
- * truncated content with `meta.truncated = true`.
+ * doesn't fill on a single read.
+ *
+ * Files **above** this cap are refused with `file_too_large` rather
+ * than truncated — the underlying `readFileWithLineAndLimit`
+ * reads the whole file into memory before slicing lines, so soft
+ * truncation past the cap would still OOM the daemon. Files
+ * **at or below** the cap honor a tighter `opts.maxBytes` via
+ * post-decode truncation (`enforceReadSize`); that's where the
+ * `meta.truncated = true` flag fires.
+ *
+ * `enforceReadBytesSize` (the `readBytes` gate) and `edit()` use the
+ * same constant as a hard upper bound — multi-GB files in the
+ * workspace can no longer reach `fsp.readFile` through any
+ * boundary path.
  */
 export const MAX_READ_BYTES = 256 * 1024;
 

--- a/packages/cli/src/serve/fs/policy.ts
+++ b/packages/cli/src/serve/fs/policy.ts
@@ -160,11 +160,19 @@ export interface ReadSizeOutcome {
 }
 
 /**
- * Decide how many bytes a `readText` call should pull off disk
- * given the file's actual size. Reads above the cap surface
- * `truncated: true`; the boundary intentionally does NOT throw,
- * matching claude-code's behavior so a large config file still
- * returns useful content rather than an opaque error.
+ * Decide how many bytes a `readText` call should return given the
+ * file's actual size and the caller's optional tighter cap.
+ *
+ * **Note**: this helper is the *soft* truncation gate that fires
+ * when `opts.maxBytes < fileSize <= MAX_READ_BYTES`. It runs only
+ * AFTER `readText`'s pre-stat hard-cap check has rejected files
+ * above `MAX_READ_BYTES` with `file_too_large` (see
+ * `workspaceFileSystem.ts:readText`). Within the hard cap the
+ * caller can opt into a tighter byte ceiling via `opts.maxBytes`,
+ * and we surface that truncation via `truncated: true` rather
+ * than throwing — operators want to see a partial config file
+ * rather than an opaque error when they explicitly opted in to a
+ * smaller window.
  */
 export function enforceReadSize(
   fileBytes: number,

--- a/packages/cli/src/serve/fs/policy.ts
+++ b/packages/cli/src/serve/fs/policy.ts
@@ -1,0 +1,214 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as path from 'node:path';
+import type { Ignore} from '@qwen-code/qwen-code-core';
+import { isBinaryFile } from '@qwen-code/qwen-code-core';
+import { FsError } from './errors.js';
+import type { Intent, ResolvedPath } from './paths.js';
+
+/**
+ * Maximum bytes returned by `readText`. Mirrors claude-code's
+ * `MAX_OUTPUT_SIZE` (`src/utils/file.ts`) — large enough for
+ * typical source files, small enough that an SSE replay buffer
+ * doesn't fill on a single read. Reads above this size return
+ * truncated content with `meta.truncated = true`.
+ */
+export const MAX_READ_BYTES = 256 * 1024;
+
+/**
+ * Maximum bytes accepted by `writeText` / `edit`. Sized below the
+ * `express.json({ limit: '10mb' })` middleware cap so a request
+ * body that survives the parser also survives the policy gate.
+ * Halving the parser cap leaves headroom for JSON envelope
+ * overhead (path, encoding hints, etc.).
+ */
+export const MAX_WRITE_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Sample size used for content-based binary detection. Aligned with
+ * `isBinaryFile` from `packages/core/src/utils/fileUtils.ts:414` so
+ * the boundary and the existing tool layer agree on what counts as
+ * "binary".
+ */
+export const BINARY_PROBE_BYTES = 4096;
+
+/**
+ * Result of an ignore-rule check against a resolved path. The
+ * `category` field exists so audit events can distinguish
+ * file-pattern vs directory-pattern matches without exposing the
+ * `Ignore` class's private state.
+ */
+export interface IgnoreVerdict {
+  ignored: boolean;
+  category?: 'file' | 'directory';
+}
+
+/**
+ * Check whether `absolute` is matched by the workspace's ignore
+ * rules. The check is computed against the workspace-relative
+ * form of the path, matching the convention of `.gitignore` /
+ * `.qwenignore` patterns.
+ *
+ * Returns `{ ignored: false }` when:
+ *   - the path equals `boundWorkspace` (the workspace root itself
+ *     can never be ignored),
+ *   - the relative path escapes the workspace (caller's bug; the
+ *     boundary check should have rejected first),
+ *   - neither the file nor directory filter matches.
+ *
+ * The `kind` parameter tells the function whether the resolved
+ * path is a regular file or a directory. This avoids an extra
+ * `stat` call (the orchestrator already has the dirent info from
+ * its `list`/`stat` step) and lets us check directory patterns
+ * with the trailing slash the underlying `ignore` library expects
+ * for `foo/`-style entries.
+ */
+export function shouldIgnore(
+  absolute: ResolvedPath,
+  boundWorkspace: string,
+  ignore: Ignore,
+  kind: 'file' | 'directory' = 'file',
+): IgnoreVerdict {
+  const rel = path.relative(boundWorkspace, absolute as string);
+  if (rel === '' || rel.startsWith('..')) return { ignored: false };
+  const fileFilter = ignore.getFileFilter();
+  const dirFilter = ignore.getDirectoryFilter();
+  if (kind === 'directory') {
+    // `foo/` patterns require the trailing slash; `node_modules`-style
+    // patterns (no slash, no extension) are added to both ignorers by
+    // `Ignore.add`, so the slash-suffixed probe still hits them.
+    const withSlash = rel.endsWith('/') ? rel : `${rel}/`;
+    if (dirFilter(withSlash)) return { ignored: true, category: 'directory' };
+    if (fileFilter(rel)) return { ignored: true, category: 'file' };
+    return { ignored: false };
+  }
+  if (fileFilter(rel)) return { ignored: true, category: 'file' };
+  if (dirFilter(rel)) return { ignored: true, category: 'directory' };
+  return { ignored: false };
+}
+
+/**
+ * Apply the trust gate to an intent. Read-shaped intents (`read`,
+ * `list`, `glob`, `stat`) always pass — remote clients debugging
+ * an untrusted workspace still need to inspect state. Mutating
+ * intents (`write`, `edit`) on an untrusted workspace throw
+ * `untrusted_workspace`, which routes surface as 403.
+ *
+ * Trust is captured at factory build (a snapshot of
+ * `Config.isTrustedFolder()`); the orchestrator does not consult
+ * Config per-request, so an IDE that flips trust mid-request
+ * cannot split-brain a session.
+ *
+ * The body is an exhaustive `switch` so adding a new variant to
+ * `Intent` (e.g. a future `'delete'`) becomes a TypeScript error
+ * here — the gate must explicitly classify every intent rather
+ * than silently defaulting to "allowed".
+ */
+export function assertTrustedForIntent(trusted: boolean, intent: Intent): void {
+  if (trusted) return;
+  switch (intent) {
+    case 'read':
+    case 'list':
+    case 'glob':
+    case 'stat':
+      return;
+    case 'write':
+    case 'edit':
+      throw new FsError(
+        'untrusted_workspace',
+        `workspace is not trusted; ${intent} operations are forbidden`,
+        {
+          hint: 'mark the folder as trusted in the daemon configuration to allow writes',
+        },
+      );
+    default: {
+      const _exhaustive: never = intent;
+      throw new FsError(
+        'untrusted_workspace',
+        `workspace is not trusted; intent "${String(_exhaustive)}" is not classified`,
+        {
+          hint: 'unknown intent reached the trust gate; classify it in policy.ts',
+        },
+      );
+    }
+  }
+}
+
+/** Outcome of a read-size enforcement check. */
+export interface ReadSizeOutcome {
+  /** Number of bytes the caller should read. */
+  bytesToRead: number;
+  /** True iff the file is larger than the cap and content was truncated. */
+  truncated: boolean;
+}
+
+/**
+ * Decide how many bytes a `readText` call should pull off disk
+ * given the file's actual size. Reads above the cap surface
+ * `truncated: true`; the boundary intentionally does NOT throw,
+ * matching claude-code's behavior so a large config file still
+ * returns useful content rather than an opaque error.
+ */
+export function enforceReadSize(
+  fileBytes: number,
+  maxBytes: number = MAX_READ_BYTES,
+): ReadSizeOutcome {
+  if (fileBytes <= maxBytes) {
+    return { bytesToRead: fileBytes, truncated: false };
+  }
+  return { bytesToRead: maxBytes, truncated: true };
+}
+
+/**
+ * Throw `file_too_large` if `bytes` exceeds the write cap. Used by
+ * `writeText` and `edit`, which (unlike text reads) cannot silently
+ * truncate without corrupting the file.
+ */
+export function enforceWriteSize(
+  bytes: number,
+  maxBytes: number = MAX_WRITE_BYTES,
+): void {
+  if (bytes > maxBytes) {
+    throw new FsError(
+      'file_too_large',
+      `payload of ${bytes} bytes exceeds write limit of ${maxBytes} bytes`,
+      {
+        hint: 'split the write into smaller chunks or raise the daemon limit',
+      },
+    );
+  }
+}
+
+/**
+ * Throw `file_too_large` if a read would exceed the cap and the
+ * caller cannot accept truncation (used by `readBytes`, where
+ * partial content is unsafe to return).
+ */
+export function enforceReadBytesSize(
+  fileBytes: number,
+  maxBytes: number = MAX_READ_BYTES,
+): void {
+  if (fileBytes > maxBytes) {
+    throw new FsError(
+      'file_too_large',
+      `file of ${fileBytes} bytes exceeds read limit of ${maxBytes} bytes`,
+      {
+        hint: 'use readText for capped truncation, or raise the daemon limit',
+      },
+    );
+  }
+}
+
+/**
+ * Decide whether a path is binary using the existing core helper.
+ * Wrapping it here lets PR 18 callers keep a single `policy.ts`
+ * import surface and lets future tweaks (e.g. extension allow-list)
+ * land without touching the orchestrator.
+ */
+export async function detectBinary(filePath: ResolvedPath): Promise<boolean> {
+  return isBinaryFile(filePath as string);
+}

--- a/packages/cli/src/serve/fs/policy.ts
+++ b/packages/cli/src/serve/fs/policy.ts
@@ -208,15 +208,23 @@ export function enforceWriteSize(
  * Throw `file_too_large` if a read would exceed the cap and the
  * caller cannot accept truncation (used by `readBytes`, where
  * partial content is unsafe to return).
+ *
+ * Critical: `MAX_READ_BYTES` is the **hard** ceiling — caller-
+ * supplied `maxBytes` clamps it DOWN, never up. Without this
+ * `Math.min` clamp, a future PR 19/20 route that blindly forwards
+ * `req.query.maxBytes` would let a request widen past the daemon's
+ * 256 KiB safety cap and trigger the OOM scenario the cap exists
+ * to prevent.
  */
 export function enforceReadBytesSize(
   fileBytes: number,
   maxBytes: number = MAX_READ_BYTES,
 ): void {
-  if (fileBytes > maxBytes) {
+  const effectiveMax = Math.min(maxBytes, MAX_READ_BYTES);
+  if (fileBytes > effectiveMax) {
     throw new FsError(
       'file_too_large',
-      `file of ${fileBytes} bytes exceeds read limit of ${maxBytes} bytes`,
+      `file of ${fileBytes} bytes exceeds read limit of ${effectiveMax} bytes`,
       {
         hint: 'use readText for capped truncation, or raise the daemon limit',
       },

--- a/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
@@ -518,6 +518,77 @@ describe('WorkspaceFileSystem - TOCTOU + UTF-8 + cwd hardening', () => {
     expect(isFsError(err)).toBe(true);
     expect((err as { kind: string }).kind).toBe('path_outside_workspace');
   });
+
+  it('glob rejects opts.cwd that is a symlink resolving outside the workspace', async () => {
+    // The textual `path.resolve` + `isWithinRoot` check admits
+    // `<ws>/link` even when `<ws>/link → /scratch` is a symlink
+    // to outside. `realpath` on cwd follows the chain so the
+    // containment check sees the actual walk root and rejects.
+    const link = path.join(h.workspace, 'link-to-scratch');
+    await fsp.symlink(h.scratch, link, 'dir');
+    const err = await h.fs
+      .glob('**/*', { cwd: link as unknown as ResolvedPath })
+      .catch((e: unknown) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('path_outside_workspace');
+  });
+
+  it('writeText rejects when path was swapped to a symlink between resolve and write', async () => {
+    // resolve a path → swap target with a symlink to outside →
+    // writeText should reject with `symlink_escape` rather than
+    // letting `atomicWriteFile`'s symlink-following code write
+    // outside the workspace.
+    const target = path.join(h.workspace, 'about-to-write.txt');
+    const r = await h.fs.resolve('about-to-write.txt', 'write');
+    const outside = path.join(h.scratch, 'outside-target.txt');
+    await fsp.writeFile(outside, ''); // pre-create so symlink isn't dangling
+    await fsp.symlink(outside, target, 'file');
+    const err = await h.fs.writeText(r, 'hello').catch((e: unknown) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('symlink_escape');
+    // The outside file MUST remain empty (no escape).
+    const outsideContent = await fsp.readFile(outside, 'utf-8');
+    expect(outsideContent).toBe('');
+  });
+
+  it('edit rejects when path was swapped to a symlink between read and write', async () => {
+    // edit() reads the file, then writes back. After the post-read
+    // inode check, an attacker could in theory swap to a symlink
+    // before the writeTextFile call. The pre-write guard catches
+    // that. We approximate: write a file, resolve, edit-pattern
+    // setup, then mid-operation we can't easily inject — instead
+    // we test the boundary directly by setting up a symlink that
+    // matches a pre-existing inode but points outside, similar
+    // shape to the writeText test above.
+    const target = path.join(h.workspace, 'edit-target.txt');
+    await fsp.writeFile(target, 'foo=1\n');
+    const r = await h.fs.resolve('edit-target.txt', 'edit');
+    // Replace with symlink-to-outside AFTER resolve.
+    const outside = path.join(h.scratch, 'edit-outside.txt');
+    await fsp.writeFile(outside, 'foo=1\n');
+    await fsp.unlink(target);
+    await fsp.symlink(outside, target, 'file');
+    const err = await h.fs.edit(r, 'foo=1', 'foo=2').catch((e: unknown) => e);
+    expect(isFsError(err)).toBe(true);
+    // post-read inode check fires first since inode changed; either
+    // catch is acceptable as a security signal.
+    expect(['symlink_escape']).toContain((err as { kind: string }).kind);
+    const outsideContent = await fsp.readFile(outside, 'utf-8');
+    expect(outsideContent).toBe('foo=1\n');
+  });
+
+  it('readBytes opts.maxBytes is clamped to MAX_READ_BYTES (cannot widen past hard cap)', async () => {
+    const policy = await import('./policy.js');
+    const big = path.join(h.workspace, 'overrun.bin');
+    await fsp.writeFile(big, Buffer.alloc(policy.MAX_READ_BYTES + 1));
+    const r = await h.fs.resolve('overrun.bin', 'read');
+    // Caller tries to widen past the hard cap.
+    const err = await h.fs
+      .readBytes(r, { maxBytes: policy.MAX_READ_BYTES * 10 })
+      .catch((e: unknown) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('file_too_large');
+  });
 });
 
 describe('WorkspaceFileSystem - audit always emits on body errors', () => {
@@ -554,17 +625,40 @@ describe('WorkspaceFileSystem - audit always emits on body errors', () => {
     expect(denied).toBeDefined();
   });
 
-  it('fs.denied audit payload carries the FsError message for forensic context', async () => {
-    // The earlier audit only recorded `errorKind` + `hint`; the
-    // underlying OS / `FsError` message (path, errno detail, byte
-    // count) was lost from the audit trail. `recordAndWrap` now
-    // forwards the message so audit consumers debugging a
-    // production incident can see the actual cause.
+  it('fs.denied audit message field is gated behind QWEN_AUDIT_RAW_PATHS (privacy default omits)', async () => {
+    // Default (privacy) mode: `message` MUST be absent because the
+    // underlying `FsError.message` embeds `${p}` absolute paths
+    // that would otherwise leak workspace structure to audit
+    // consumers — even when operators explicitly disabled
+    // raw-path logging via not-setting `QWEN_AUDIT_RAW_PATHS`.
+    // See `audit.ts:recordDenied` — message gates on
+    // `includeRawPaths`.
     const err = (await h.fs
       .resolve('../escape', 'read')
       .catch((e: unknown) => e)) as { message: string };
     expect(err.message).toMatch(/escapes workspace/);
     const denied = h.events.find((e) => e.type === FS_DENIED_EVENT_TYPE);
+    expect(denied).toBeDefined();
+    // Privacy-default mode: message is OMITTED.
+    expect((denied!.data as { message?: string }).message).toBeUndefined();
+  });
+
+  it('fs.denied carries message when includeRawPaths is enabled (forensic mode)', async () => {
+    // Build a fresh harness with includeRawPaths: true to verify
+    // the audit message round-trip works in raw-path mode.
+    const events: BridgeEvent[] = [];
+    const factory = createWorkspaceFileSystemFactory({
+      boundWorkspace: h.workspace,
+      trusted: true,
+      emit: (e) => events.push(e),
+      includeRawPaths: true,
+    });
+    const fs = factory.forRequest({ route: 'TEST /op' });
+    const err = (await fs
+      .resolve('../escape', 'read')
+      .catch((e: unknown) => e)) as { message: string };
+    expect(err.message).toMatch(/escapes workspace/);
+    const denied = events.find((e) => e.type === FS_DENIED_EVENT_TYPE);
     expect(denied).toBeDefined();
     expect((denied!.data as { message?: string }).message).toBe(err.message);
   });

--- a/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
@@ -206,6 +206,25 @@ describe('WorkspaceFileSystem - readBytes', () => {
     expect(isFsError(err)).toBe(true);
     expect((err as { kind: string }).kind).toBe('file_too_large');
   });
+
+  it('readBytes catches concurrent post-stat growth via post-read size check', async () => {
+    // Pre-stat OOM gate sees a small file; post-read buf.length
+    // check catches the same-inode growth case (concurrent
+    // appender keeps the inode but extends past the cap). Test
+    // simulates by overwriting the file AFTER `resolve()` with a
+    // buffer larger than `MAX_READ_BYTES` — the readBytes call's
+    // pre-stat sees the large size and trips the hard cap; the
+    // post-read check is the defense-in-depth path for the case
+    // where stat passed but read picked up more bytes.
+    const policy = await import('./policy.js');
+    const small = path.join(h.workspace, 'grew.bin');
+    await fsp.writeFile(small, Buffer.alloc(64));
+    const r = await h.fs.resolve('grew.bin', 'read');
+    await fsp.writeFile(small, Buffer.alloc(policy.MAX_READ_BYTES + 1));
+    const err = await h.fs.readBytes(r).catch((e) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('file_too_large');
+  });
 });
 
 describe('WorkspaceFileSystem - list', () => {

--- a/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
@@ -240,6 +240,39 @@ describe('WorkspaceFileSystem - glob', () => {
     expect((err as { kind: string }).kind).toBe('parse_error');
   });
 
+  it('rejects POSIX-absolute patterns up-front (no I/O outside workspace)', async () => {
+    const err = await h.fs.glob('/etc/**/*').catch((e) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('parse_error');
+  });
+
+  it('rejects Win32 drive-letter and UNC patterns up-front', async () => {
+    for (const pattern of [
+      'C:\\Users\\foo\\**\\*.ts',
+      'C:/Users/foo/**/*.ts',
+      '\\\\server\\share\\**',
+      '//server/share/**',
+    ]) {
+      const err = await h.fs.glob(pattern).catch((e: unknown) => e);
+      expect(isFsError(err)).toBe(true);
+      expect((err as { kind: string }).kind).toBe('parse_error');
+    }
+  });
+
+  it('respects directory-only ignore rules (e.g. dist/) on glob hits', async () => {
+    const ignore = new Ignore().add(['dist/']);
+    h = await makeHarness({ ignore });
+    await fsp.mkdir(path.join(h.workspace, 'dist'));
+    await fsp.writeFile(path.join(h.workspace, 'dist', 'bundle.js'), '');
+    await fsp.writeFile(path.join(h.workspace, 'src.ts'), '');
+    const hits = await h.fs.glob('*');
+    const names = hits.map((p) => path.basename(p)).sort();
+    // `dist` directory is filtered because the trailing-slash dir
+    // pattern now probes `<rel>/` against the directory ignorer.
+    expect(names).not.toContain('dist');
+    expect(names).toContain('src.ts');
+  });
+
   it('respects maxResults', async () => {
     const hits = await h.fs.glob('**/*', { maxResults: 1 });
     expect(hits).toHaveLength(1);
@@ -302,6 +335,44 @@ describe('WorkspaceFileSystem - write/edit', () => {
     const err = await h.fs.edit(r, 'NOT THERE', 'X').catch((e) => e);
     expect(isFsError(err)).toBe(true);
     expect((err as { kind: string }).kind).toBe('parse_error');
+  });
+
+  it('rejects edit on file > MAX_READ_BYTES with file_too_large (no slurp)', async () => {
+    const policy = await import('./policy.js');
+    const big = path.join(h.workspace, 'huge.txt');
+    await fsp.writeFile(big, 'a'.repeat(policy.MAX_READ_BYTES + 1));
+    const r = await h.fs.resolve('huge.txt', 'write');
+    const err = await h.fs.edit(r, 'a', 'b').catch((e: unknown) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('file_too_large');
+  });
+
+  it('rejects edit on binary file', async () => {
+    const bin = path.join(h.workspace, 'bin.dat');
+    const buf = Buffer.alloc(64);
+    buf[5] = 0;
+    await fsp.writeFile(bin, buf);
+    const r = await h.fs.resolve('bin.dat', 'write');
+    const err = await h.fs.edit(r, '\x00', 'x').catch((e: unknown) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('binary_file');
+  });
+
+  it('readText converts 1-based line to 0-based slice (line: 1 returns from first line)', async () => {
+    const target = path.join(h.workspace, 'lines.txt');
+    await fsp.writeFile(target, 'one\ntwo\nthree\n');
+    const r = await h.fs.resolve('lines.txt', 'read');
+    const out = await h.fs.readText(r, { line: 1, limit: 1 });
+    // 1-based line 1 → 0-based slice index 0 → first line "one"
+    expect(out.content.split('\n')[0]).toBe('one');
+  });
+
+  it('readText with line: 2 starts from the second line', async () => {
+    const target = path.join(h.workspace, 'lines2.txt');
+    await fsp.writeFile(target, 'one\ntwo\nthree\n');
+    const r = await h.fs.resolve('lines2.txt', 'read');
+    const out = await h.fs.readText(r, { line: 2, limit: 1 });
+    expect(out.content.split('\n')[0]).toBe('two');
   });
 });
 

--- a/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
@@ -1,0 +1,435 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { promises as fsp } from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { Ignore } from '@qwen-code/qwen-code-core';
+import {
+  FS_ACCESS_EVENT_TYPE,
+  FS_DENIED_EVENT_TYPE,
+  createWorkspaceFileSystemFactory,
+  type WorkspaceFileSystem,
+  type WorkspaceFileSystemFactory,
+} from './index.js';
+import type { BridgeEvent } from '../eventBus.js';
+import { canonicalizeWorkspace } from './paths.js';
+import { isFsError } from './errors.js';
+
+interface Harness {
+  factory: WorkspaceFileSystemFactory;
+  fs: WorkspaceFileSystem;
+  events: BridgeEvent[];
+  workspace: string;
+  scratch: string;
+}
+
+async function makeHarness(opts?: {
+  trusted?: boolean;
+  ignore?: Ignore;
+}): Promise<Harness> {
+  const scratch = await fsp.mkdtemp(
+    path.join(os.tmpdir(), `qwen-wfs-${randomBytes(4).toString('hex')}-`),
+  );
+  const wsDir = path.join(scratch, 'ws');
+  await fsp.mkdir(wsDir);
+  const workspace = canonicalizeWorkspace(wsDir);
+  const events: BridgeEvent[] = [];
+  const factory = createWorkspaceFileSystemFactory({
+    boundWorkspace: workspace,
+    trusted: opts?.trusted ?? true,
+    emit: (e) => events.push(e),
+    ignore: opts?.ignore,
+  });
+  const fs = factory.forRequest({
+    originatorClientId: 'client-x',
+    sessionId: 'sess-1',
+    route: 'TEST /op',
+  });
+  return { factory, fs, events, workspace, scratch };
+}
+
+async function teardown(h: Harness): Promise<void> {
+  await fsp.rm(h.scratch, { recursive: true, force: true });
+}
+
+describe('WorkspaceFileSystem - resolve and stat', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+  });
+  afterEach(async () => {
+    await teardown(h);
+  });
+
+  it('resolves an existing path and emits no audit on resolve alone', async () => {
+    const target = path.join(h.workspace, 'a.txt');
+    await fsp.writeFile(target, 'x');
+    const r = await h.fs.resolve('a.txt', 'read');
+    expect(r).toBeTruthy();
+    expect(
+      h.events.filter((e) => e.type === FS_ACCESS_EVENT_TYPE),
+    ).toHaveLength(0);
+  });
+
+  it('records fs.denied when resolve fails', async () => {
+    await expect(h.fs.resolve('../escape', 'read')).rejects.toBeDefined();
+    const denied = h.events.filter((e) => e.type === FS_DENIED_EVENT_TYPE);
+    expect(denied).toHaveLength(1);
+    expect(denied[0].data).toMatchObject({
+      errorKind: 'path_outside_workspace',
+    });
+  });
+
+  it('stat returns kind/sizeBytes/modifiedMs and emits fs.access', async () => {
+    const target = path.join(h.workspace, 'b.txt');
+    await fsp.writeFile(target, 'hi');
+    const r = await h.fs.resolve('b.txt', 'stat');
+    const st = await h.fs.stat(r);
+    expect(st.kind).toBe('file');
+    expect(st.sizeBytes).toBe(2);
+    expect(st.modifiedMs).toBeGreaterThan(0);
+    expect(h.events.find((e) => e.type === FS_ACCESS_EVENT_TYPE)).toBeDefined();
+  });
+});
+
+describe('WorkspaceFileSystem - readText', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+  });
+  afterEach(async () => teardown(h));
+
+  it('reads small text and reports lineEnding', async () => {
+    const target = path.join(h.workspace, 'plain.txt');
+    await fsp.writeFile(target, 'hello\nworld\n');
+    const r = await h.fs.resolve('plain.txt', 'read');
+    const out = await h.fs.readText(r);
+    expect(out.content).toBe('hello\nworld\n');
+    expect(out.meta.lineEnding).toBe('lf');
+    expect(out.meta.truncated).toBeUndefined();
+  });
+
+  it('truncates content above maxBytes and sets meta.truncated', async () => {
+    const big = path.join(h.workspace, 'big.txt');
+    const content = 'a'.repeat(2048);
+    await fsp.writeFile(big, content);
+    const r = await h.fs.resolve('big.txt', 'read');
+    const out = await h.fs.readText(r, { maxBytes: 1024 });
+    expect(out.meta.truncated).toBe(true);
+    expect(out.content.length).toBeLessThanOrEqual(1024);
+  });
+
+  it('throws file_too_large when file exceeds MAX_READ_BYTES regardless of opts.maxBytes', async () => {
+    // Write a file larger than the soft cap and assert the boundary
+    // refuses BEFORE delegating to lowFs (which would slurp the
+    // whole file into memory).
+    const big = path.join(h.workspace, 'huge.txt');
+    const bytes = (await import('./policy.js')).MAX_READ_BYTES + 1;
+    await fsp.writeFile(big, 'a'.repeat(bytes));
+    const r = await h.fs.resolve('huge.txt', 'read');
+    const err = await h.fs.readText(r).catch((e: unknown) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('file_too_large');
+    // Audit was recorded for the denial (P0 silent-failure fix).
+    const denied = h.events.find((e) => e.type === FS_DENIED_EVENT_TYPE);
+    expect(denied).toBeDefined();
+    expect((denied!.data as { errorKind: string }).errorKind).toBe(
+      'file_too_large',
+    );
+  });
+
+  it('throws binary_file when reading binary content', async () => {
+    const bin = path.join(h.workspace, 'bin.dat');
+    const buf = Buffer.alloc(64);
+    buf[5] = 0;
+    await fsp.writeFile(bin, buf);
+    const r = await h.fs.resolve('bin.dat', 'read');
+    const err = await h.fs.readText(r).catch((e) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('binary_file');
+    expect(h.events.find((e) => e.type === FS_DENIED_EVENT_TYPE)).toBeDefined();
+  });
+
+  it('annotates meta.matchedIgnore when path is ignored', async () => {
+    const ignore = new Ignore().add(['*.log']);
+    h = await makeHarness({ ignore });
+    const target = path.join(h.workspace, 'app.log');
+    await fsp.writeFile(target, 'log content');
+    const r = await h.fs.resolve('app.log', 'read');
+    const out = await h.fs.readText(r);
+    expect(out.meta.matchedIgnore).toBe('file');
+  });
+});
+
+describe('WorkspaceFileSystem - readBytes', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+  });
+  afterEach(async () => teardown(h));
+
+  it('returns raw bytes', async () => {
+    const target = path.join(h.workspace, 'raw.bin');
+    await fsp.writeFile(target, Buffer.from([1, 2, 3, 0, 4, 5]));
+    const r = await h.fs.resolve('raw.bin', 'read');
+    const buf = await h.fs.readBytes(r);
+    expect(Array.from(buf)).toEqual([1, 2, 3, 0, 4, 5]);
+  });
+
+  it('throws file_too_large above the cap', async () => {
+    const target = path.join(h.workspace, 'huge.bin');
+    await fsp.writeFile(target, Buffer.alloc(2048));
+    const r = await h.fs.resolve('huge.bin', 'read');
+    const err = await h.fs.readBytes(r, { maxBytes: 1024 }).catch((e) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('file_too_large');
+  });
+});
+
+describe('WorkspaceFileSystem - list', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    const ignore = new Ignore().add(['*.log']);
+    h = await makeHarness({ ignore });
+    await fsp.writeFile(path.join(h.workspace, 'a.ts'), '');
+    await fsp.writeFile(path.join(h.workspace, 'b.log'), '');
+    await fsp.mkdir(path.join(h.workspace, 'sub'));
+  });
+  afterEach(async () => teardown(h));
+
+  it('drops ignored entries by default', async () => {
+    const r = await h.fs.resolve('.', 'list');
+    const entries = await h.fs.list(r);
+    const names = entries.map((e) => e.name).sort();
+    expect(names).toEqual(['a.ts', 'sub']);
+  });
+
+  it('includes ignored entries when includeIgnored is true', async () => {
+    const r = await h.fs.resolve('.', 'list');
+    const entries = await h.fs.list(r, { includeIgnored: true });
+    const log = entries.find((e) => e.name === 'b.log');
+    expect(log?.ignored).toBe(true);
+  });
+});
+
+describe('WorkspaceFileSystem - glob', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+    await fsp.mkdir(path.join(h.workspace, 'src'));
+    await fsp.writeFile(path.join(h.workspace, 'src', 'a.ts'), '');
+    await fsp.writeFile(path.join(h.workspace, 'src', 'b.ts'), '');
+    await fsp.writeFile(path.join(h.workspace, 'README.md'), '');
+  });
+  afterEach(async () => teardown(h));
+
+  it('matches files by pattern', async () => {
+    const hits = await h.fs.glob('src/*.ts');
+    expect(hits.map((p) => path.basename(p)).sort()).toEqual(['a.ts', 'b.ts']);
+  });
+
+  it('rejects patterns containing `..`', async () => {
+    const err = await h.fs.glob('../**/*.ts').catch((e) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('parse_error');
+  });
+
+  it('respects maxResults', async () => {
+    const hits = await h.fs.glob('**/*', { maxResults: 1 });
+    expect(hits).toHaveLength(1);
+  });
+
+  it('filters ignored hits by default', async () => {
+    const ignore = new Ignore().add(['*.md']);
+    h = await makeHarness({ ignore });
+    await fsp.writeFile(path.join(h.workspace, 'README.md'), '');
+    await fsp.writeFile(path.join(h.workspace, 'src.ts'), '');
+    const hits = await h.fs.glob('*');
+    const names = hits.map((p) => path.basename(p)).sort();
+    expect(names).not.toContain('README.md');
+  });
+});
+
+describe('WorkspaceFileSystem - write/edit', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+  });
+  afterEach(async () => teardown(h));
+
+  it('writes text and emits fs.access', async () => {
+    const r = await h.fs.resolve('newfile.txt', 'write');
+    await h.fs.writeText(r, 'hello');
+    const written = await fsp.readFile(r as string, 'utf-8');
+    expect(written).toBe('hello');
+    const access = h.events.find(
+      (e) =>
+        e.type === FS_ACCESS_EVENT_TYPE &&
+        (e.data as { intent: string }).intent === 'write',
+    );
+    expect(access).toBeDefined();
+  });
+
+  it('rejects oversize writes with file_too_large', async () => {
+    const r = await h.fs.resolve('huge.txt', 'write');
+    const err = await h.fs
+      .writeText(r, 'a'.repeat(6 * 1024 * 1024))
+      .catch((e) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('file_too_large');
+  });
+
+  it('edits an existing file by replacing oldText with newText', async () => {
+    const target = path.join(h.workspace, 'config.txt');
+    await fsp.writeFile(target, 'foo=1\nbar=2\n');
+    const r = await h.fs.resolve('config.txt', 'write');
+    const out = await h.fs.edit(r, 'foo=1', 'foo=42');
+    expect(out.writtenBytes).toBeGreaterThan(0);
+    const after = await fsp.readFile(target, 'utf-8');
+    expect(after).toBe('foo=42\nbar=2\n');
+  });
+
+  it('throws parse_error when oldText is not present', async () => {
+    const target = path.join(h.workspace, 'c.txt');
+    await fsp.writeFile(target, 'abc');
+    const r = await h.fs.resolve('c.txt', 'write');
+    const err = await h.fs.edit(r, 'NOT THERE', 'X').catch((e) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('parse_error');
+  });
+});
+
+describe('WorkspaceFileSystem - trust gate', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness({ trusted: false });
+    await fsp.writeFile(path.join(h.workspace, 'r.txt'), 'r');
+  });
+  afterEach(async () => teardown(h));
+
+  it('allows read on untrusted workspace', async () => {
+    const r = await h.fs.resolve('r.txt', 'read');
+    const out = await h.fs.readText(r);
+    expect(out.content).toBe('r');
+  });
+
+  it('denies write with untrusted_workspace', async () => {
+    const r = await h.fs.resolve('w.txt', 'write');
+    const err = await h.fs.writeText(r, 'x').catch((e) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('untrusted_workspace');
+    const denied = h.events.find((e) => e.type === FS_DENIED_EVENT_TYPE);
+    expect(denied).toBeDefined();
+  });
+
+  it('denies edit with untrusted_workspace', async () => {
+    await fsp.writeFile(path.join(h.workspace, 'e.txt'), 'old');
+    const r = await h.fs.resolve('e.txt', 'edit');
+    const err = await h.fs.edit(r, 'old', 'new').catch((e) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('untrusted_workspace');
+  });
+});
+
+describe('WorkspaceFileSystem - audit always emits on body errors', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+  });
+  afterEach(async () => teardown(h));
+
+  it('wraps a raw ENOENT from edit() and emits fs.denied', async () => {
+    // edit() reads via fsp.readFile; against a non-existent file the
+    // raw ENOENT used to escape uncategorized — the wrapper now
+    // converts it to FsError(path_not_found) and records denial.
+    const r = await h.fs.resolve('vanished.txt', 'write');
+    const err = await h.fs.edit(r, 'a', 'b').catch((e: unknown) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('path_not_found');
+    const denied = h.events.find((e) => e.type === FS_DENIED_EVENT_TYPE);
+    expect(denied).toBeDefined();
+    expect((denied!.data as { errorKind: string }).errorKind).toBe(
+      'path_not_found',
+    );
+  });
+
+  it('rejects ENOTDIR ancestor walk with parse_error rather than passing boundary', async () => {
+    // Place a regular file where the request expects a directory.
+    await fsp.writeFile(path.join(h.workspace, 'block'), 'not a dir');
+    const err = await h.fs
+      .resolve('block/leaf', 'write')
+      .catch((e: unknown) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('parse_error');
+    const denied = h.events.find((e) => e.type === FS_DENIED_EVENT_TYPE);
+    expect(denied).toBeDefined();
+  });
+});
+
+describe('WorkspaceFileSystem - glob escape audit', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+  });
+  afterEach(async () => teardown(h));
+
+  it('emits aggregated fs.denied for glob hits filtered as escape', async () => {
+    // Create an in-workspace file (legit hit) plus a symlink that
+    // resolves outside the workspace (filtered hit). The glob
+    // aggregation reports the escape count via a single denial
+    // event so audit volume stays bounded on misconfigured trees.
+    await fsp.writeFile(path.join(h.workspace, 'inside.ts'), 'x');
+    const outside = path.join(h.scratch, 'outside.ts');
+    await fsp.writeFile(outside, 'y');
+    await fsp.symlink(outside, path.join(h.workspace, 'leak.ts'), 'file');
+    const hits = await h.fs.glob('*.ts');
+    const names = hits.map((p) => path.basename(p)).sort();
+    expect(names).toContain('inside.ts');
+    expect(names).not.toContain('outside.ts');
+    const denied = h.events.find(
+      (e) =>
+        e.type === FS_DENIED_EVENT_TYPE &&
+        (e.data as { errorKind: string }).errorKind === 'symlink_escape',
+    );
+    expect(denied).toBeDefined();
+    expect((denied!.data as { hint?: string }).hint).toMatch(
+      /\d+ hit\(s\) that resolved outside workspace/,
+    );
+  });
+});
+
+describe('WorkspaceFileSystem - factory', () => {
+  it('canonicalizes the workspace once at factory build', async () => {
+    const scratch = await fsp.mkdtemp(
+      path.join(
+        os.tmpdir(),
+        `qwen-wfs-canon-${randomBytes(4).toString('hex')}-`,
+      ),
+    );
+    try {
+      const real = path.join(scratch, 'ws');
+      await fsp.mkdir(real);
+      const aliased = path.join(scratch, 'alias');
+      await fsp.symlink(real, aliased, 'dir');
+      const events: BridgeEvent[] = [];
+      const factory = createWorkspaceFileSystemFactory({
+        boundWorkspace: aliased,
+        trusted: true,
+        emit: (e) => events.push(e),
+      });
+      const fs = factory.forRequest({ route: 'TEST /op' });
+      await fsp.writeFile(path.join(real, 'inside.txt'), 'i');
+      const r = await fs.resolve('inside.txt', 'read');
+      const out = await fs.readText(r);
+      expect(out.content).toBe('i');
+    } finally {
+      await fsp.rm(scratch, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
@@ -348,6 +348,32 @@ describe('WorkspaceFileSystem - write/edit', () => {
     expect((err as { kind: string }).kind).toBe('file_too_large');
   });
 
+  it('rejects edit() with empty oldText (would silently prepend newText otherwise)', async () => {
+    // JS `''.indexOf('')` returns 0, so without the empty-check
+    // `current.slice(0, 0) + newText + current.slice(0)` would
+    // silently prepend `newText` to the entire file with a success
+    // audit event — textbook silent data corruption. Reject up-front.
+    const target = path.join(h.workspace, 'silent.txt');
+    await fsp.writeFile(target, 'original\n');
+    const r = await h.fs.resolve('silent.txt', 'edit');
+    const err = await h.fs.edit(r, '', 'INJECTED').catch((e: unknown) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('parse_error');
+    // File must be unchanged.
+    const after = await fsp.readFile(target, 'utf-8');
+    expect(after).toBe('original\n');
+  });
+
+  it('edit() error includes oldText snippet in the hint', async () => {
+    const target = path.join(h.workspace, 'snippet.txt');
+    await fsp.writeFile(target, 'foo=1\nbar=2\n');
+    const r = await h.fs.resolve('snippet.txt', 'edit');
+    const err = (await h.fs
+      .edit(r, 'this string is not present', 'X')
+      .catch((e: unknown) => e)) as { hint?: string };
+    expect(err.hint).toMatch(/this string is not present/);
+  });
+
   it('rejects edit on binary file', async () => {
     const bin = path.join(h.workspace, 'bin.dat');
     const buf = Buffer.alloc(64);
@@ -526,6 +552,21 @@ describe('WorkspaceFileSystem - audit always emits on body errors', () => {
     expect((err as { kind: string }).kind).toBe('parse_error');
     const denied = h.events.find((e) => e.type === FS_DENIED_EVENT_TYPE);
     expect(denied).toBeDefined();
+  });
+
+  it('fs.denied audit payload carries the FsError message for forensic context', async () => {
+    // The earlier audit only recorded `errorKind` + `hint`; the
+    // underlying OS / `FsError` message (path, errno detail, byte
+    // count) was lost from the audit trail. `recordAndWrap` now
+    // forwards the message so audit consumers debugging a
+    // production incident can see the actual cause.
+    const err = (await h.fs
+      .resolve('../escape', 'read')
+      .catch((e: unknown) => e)) as { message: string };
+    expect(err.message).toMatch(/escapes workspace/);
+    const denied = h.events.find((e) => e.type === FS_DENIED_EVENT_TYPE);
+    expect(denied).toBeDefined();
+    expect((denied!.data as { message?: string }).message).toBe(err.message);
   });
 });
 

--- a/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
@@ -374,6 +374,37 @@ describe('WorkspaceFileSystem - write/edit', () => {
     const out = await h.fs.readText(r, { line: 2, limit: 1 });
     expect(out.content.split('\n')[0]).toBe('two');
   });
+
+  it('rejects non-positive-integer opts.line with parse_error', async () => {
+    const target = path.join(h.workspace, 'v.txt');
+    await fsp.writeFile(target, 'a\nb\nc\n');
+    const r = await h.fs.resolve('v.txt', 'read');
+    for (const bad of [Infinity, -Infinity, 0, -1, 1.5, NaN]) {
+      const err = await h.fs
+        .readText(r, { line: bad })
+        .catch((e: unknown) => e);
+      expect(isFsError(err)).toBe(true);
+      expect((err as { kind: string }).kind).toBe('parse_error');
+    }
+  });
+
+  it('records matchedIgnore on edit() audit (parity with readText/writeText)', async () => {
+    const ignore = new Ignore().add(['*.log']);
+    h = await makeHarness({ ignore });
+    const target = path.join(h.workspace, 'app.log');
+    await fsp.writeFile(target, 'foo=1\nbar=2\n');
+    const r = await h.fs.resolve('app.log', 'edit');
+    await h.fs.edit(r, 'foo=1', 'foo=2');
+    const access = h.events.find(
+      (e) =>
+        e.type === FS_ACCESS_EVENT_TYPE &&
+        (e.data as { intent: string }).intent === 'edit',
+    );
+    expect(access).toBeDefined();
+    expect((access!.data as { matchedIgnore?: string }).matchedIgnore).toBe(
+      'file',
+    );
+  });
 });
 
 describe('WorkspaceFileSystem - trust gate', () => {

--- a/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
@@ -183,11 +183,26 @@ describe('WorkspaceFileSystem - readBytes', () => {
     expect(Array.from(buf)).toEqual([1, 2, 3, 0, 4, 5]);
   });
 
-  it('throws file_too_large above the cap', async () => {
+  it('truncates returned buffer to opts.maxBytes (window read, matches API name)', async () => {
+    // Earlier semantics threw `file_too_large` here, but `maxBytes`
+    // in the parameter name promises window-read behavior. Files
+    // above the HARD `MAX_READ_BYTES` cap still throw — see
+    // separate test below — but a caller-supplied tighter cap
+    // truncates rather than rejects.
+    const target = path.join(h.workspace, 'small.bin');
+    await fsp.writeFile(target, Buffer.alloc(2048, 0xab));
+    const r = await h.fs.resolve('small.bin', 'read');
+    const buf = await h.fs.readBytes(r, { maxBytes: 1024 });
+    expect(buf.length).toBe(1024);
+    expect(buf[0]).toBe(0xab);
+  });
+
+  it('throws file_too_large when file size exceeds the hard MAX_READ_BYTES cap regardless of maxBytes', async () => {
+    const policy = await import('./policy.js');
     const target = path.join(h.workspace, 'huge.bin');
-    await fsp.writeFile(target, Buffer.alloc(2048));
+    await fsp.writeFile(target, Buffer.alloc(policy.MAX_READ_BYTES + 1));
     const r = await h.fs.resolve('huge.bin', 'read');
-    const err = await h.fs.readBytes(r, { maxBytes: 1024 }).catch((e) => e);
+    const err = await h.fs.readBytes(r).catch((e) => e);
     expect(isFsError(err)).toBe(true);
     expect((err as { kind: string }).kind).toBe('file_too_large');
   });
@@ -271,6 +286,38 @@ describe('WorkspaceFileSystem - glob', () => {
     // `dist` directory is filtered because the trailing-slash dir
     // pattern now probes `<rel>/` against the directory ignorer.
     expect(names).not.toContain('dist');
+    expect(names).toContain('src.ts');
+  });
+
+  it('prunes node_modules and .git at glob walk time (no traversal cost)', async () => {
+    // The `ignore` option passed to `globAsync` short-circuits
+    // traversal at the directory level — files under
+    // node_modules/.git never reach our per-hit realpath +
+    // shouldIgnore filter. Simulate a workspace with deps and
+    // assert the deeply-nested `node_modules` file is absent
+    // even from a `**/*` glob.
+    await fsp.mkdir(
+      path.join(h.workspace, 'node_modules', 'left-pad', 'dist'),
+      {
+        recursive: true,
+      },
+    );
+    await fsp.writeFile(
+      path.join(h.workspace, 'node_modules', 'left-pad', 'dist', 'index.js'),
+      'module.exports = function leftPad() {};\n',
+    );
+    await fsp.mkdir(path.join(h.workspace, '.git', 'objects'), {
+      recursive: true,
+    });
+    await fsp.writeFile(
+      path.join(h.workspace, '.git', 'objects', 'pack.bin'),
+      '',
+    );
+    await fsp.writeFile(path.join(h.workspace, 'src.ts'), '');
+    const hits = await h.fs.glob('**/*');
+    const names = hits.map((p) => path.relative(h.workspace, p));
+    expect(names.some((n) => n.includes('node_modules'))).toBe(false);
+    expect(names.some((n) => n.includes('.git'))).toBe(false);
     expect(names).toContain('src.ts');
   });
 
@@ -372,6 +419,33 @@ describe('WorkspaceFileSystem - write/edit', () => {
       .edit(r, 'this string is not present', 'X')
       .catch((e: unknown) => e)) as { hint?: string };
     expect(err.hint).toMatch(/this string is not present/);
+  });
+
+  it('edit() preserves UTF-8 BOM round-trip via lowFs (no \\uFEFF leak into oldText match)', async () => {
+    // The earlier `fsp.readFile(p, 'utf-8')` would include the
+    // BOM (\\uFEFF codepoint) in the returned string, breaking
+    // `oldText` matching even when the user passed the exact
+    // source text; and the write-back without `_meta` would
+    // strip the BOM, silently changing the file's encoding
+    // profile. Using `lowFs.readTextFile` strips the BOM for
+    // matching and `_meta.bom: true` preserves it on write-back.
+    const target = path.join(h.workspace, 'bom.txt');
+    const bom = Buffer.from([0xef, 0xbb, 0xbf]);
+    await fsp.writeFile(
+      target,
+      Buffer.concat([bom, Buffer.from('foo=1\nbar=2\n', 'utf-8')]),
+    );
+    const r = await h.fs.resolve('bom.txt', 'edit');
+    // oldText is `'foo=1'` WITHOUT BOM — must still match.
+    const out = await h.fs.edit(r, 'foo=1', 'foo=42');
+    expect(out.writtenBytes).toBeGreaterThan(0);
+    const after = await fsp.readFile(target);
+    // BOM preserved at start
+    expect(after[0]).toBe(0xef);
+    expect(after[1]).toBe(0xbb);
+    expect(after[2]).toBe(0xbf);
+    // Edit applied
+    expect(after.subarray(3).toString('utf-8')).toBe('foo=42\nbar=2\n');
   });
 
   it('rejects edit on binary file', async () => {

--- a/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.test.ts
@@ -14,6 +14,7 @@ import {
   FS_ACCESS_EVENT_TYPE,
   FS_DENIED_EVENT_TYPE,
   createWorkspaceFileSystemFactory,
+  type ResolvedPath,
   type WorkspaceFileSystem,
   type WorkspaceFileSystemFactory,
 } from './index.js';
@@ -436,6 +437,60 @@ describe('WorkspaceFileSystem - trust gate', () => {
     const err = await h.fs.edit(r, 'old', 'new').catch((e) => e);
     expect(isFsError(err)).toBe(true);
     expect((err as { kind: string }).kind).toBe('untrusted_workspace');
+  });
+});
+
+describe('WorkspaceFileSystem - TOCTOU + UTF-8 + cwd hardening', () => {
+  let h: Harness;
+  beforeEach(async () => {
+    h = await makeHarness();
+  });
+  afterEach(async () => teardown(h));
+
+  it('readText detects post-stat symlink swap and rejects with symlink_escape', async () => {
+    // Simulate the swap: write a regular file, resolve, then
+    // replace it with a symlink to outside the workspace AFTER the
+    // boundary's pre-stat. We approximate by performing the swap
+    // *before* the call but after `resolve`; since the pre-stat
+    // and post-lstat happen back-to-back in the actual call, the
+    // post-lstat catches the symlink state.
+    const target = path.join(h.workspace, 'victim.txt');
+    await fsp.writeFile(target, 'plain');
+    const r = await h.fs.resolve('victim.txt', 'read');
+    // Replace the regular file with a symlink to an outside path.
+    const outside = path.join(h.scratch, 'sensitive.txt');
+    await fsp.writeFile(outside, 'sensitive');
+    await fsp.unlink(target);
+    await fsp.symlink(outside, target, 'file');
+    const err = await h.fs.readText(r).catch((e: unknown) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('symlink_escape');
+  });
+
+  it('safeUtf8Truncate keeps multi-byte codepoints intact at the boundary', async () => {
+    // 4-char Chinese string, each char 3 bytes UTF-8 = 12 bytes.
+    // A naive slice at 7 bytes would split the 3rd char.
+    const src = '中文测试';
+    const target = path.join(h.workspace, 'cjk.txt');
+    await fsp.writeFile(target, src, 'utf-8');
+    const r = await h.fs.resolve('cjk.txt', 'read');
+    const out = await h.fs.readText(r, { maxBytes: 7 });
+    expect(out.meta.truncated).toBe(true);
+    // Result must be a valid prefix (no U+FFFD); 7 bytes / 3 bytes
+    // per char → 2 complete chars.
+    expect(out.content).toBe('中文');
+    expect(out.content).not.toMatch(/�/);
+  });
+
+  it('glob rejects opts.cwd that lies outside boundWorkspace', async () => {
+    // Forge a `cwd` brand cast pointing outside the workspace; the
+    // entry-point validation should refuse before `globAsync` runs.
+    const outsideCwd = h.scratch as unknown as ResolvedPath;
+    const err = await h.fs
+      .glob('**/*', { cwd: outsideCwd })
+      .catch((e: unknown) => e);
+    expect(isFsError(err)).toBe(true);
+    expect((err as { kind: string }).kind).toBe('path_outside_workspace');
   });
 });
 

--- a/packages/cli/src/serve/fs/workspaceFileSystem.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.ts
@@ -404,8 +404,23 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
     try {
       assertTrustedForIntent(this.deps.trusted, 'read');
       const st = await fsp.stat(p as string);
-      enforceReadBytesSize(st.size, opts.maxBytes);
-      const buf = await fsp.readFile(p as string);
+      // Hard cap (file size > MAX_READ_BYTES) always throws; this
+      // is the OOM defense that's independent of caller-supplied
+      // `maxBytes`.
+      enforceReadBytesSize(st.size);
+      let buf = await fsp.readFile(p as string);
+      // Soft cap: caller's `opts.maxBytes` is a window cap matching
+      // the parameter name's promise. Earlier semantics treated
+      // it as a "reject if file > maxBytes" gate, which violated
+      // the API contract — a caller asking for `maxBytes: 1024`
+      // on a 200 KB file expected to receive 1 KB, not an
+      // exception. We now truncate post-read so the returned
+      // buffer never exceeds `opts.maxBytes`. The hard
+      // `MAX_READ_BYTES` cap above ensures the underlying
+      // `fsp.readFile` allocation is bounded regardless.
+      if (opts.maxBytes !== undefined && opts.maxBytes < buf.length) {
+        buf = buf.subarray(0, opts.maxBytes);
+      }
       // Post-read TOCTOU guard — same shape as `readText`.
       await assertInodeStableAfterRead(p as string, st.ino);
       this.deps.audit.recordAccess(this.deps.ctx, {
@@ -527,11 +542,22 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
           { hint: 'opts.cwd must be a path obtained from fs.resolve()' },
         );
       }
+      // Pass an `ignore` option so the glob library prunes
+      // common-and-huge directories at traversal time. Without
+      // this, `glob('**/*')` in a typical workspace walks every
+      // file under `node_modules/` and `.git/` (often hundreds
+      // of thousands of paths) before our per-hit `realpath` +
+      // `lstat` filter drops them. The post-filter via
+      // `shouldIgnore` is still authoritative — this is purely a
+      // walk-time optimization that aligns with the
+      // `loadIgnoreRules` defaults (which already include `.git`
+      // as a default ignore dir).
       const matches = await globAsync(pattern, {
         cwd: cwdReal,
         nodir: false,
         absolute: true,
         dot: true,
+        ignore: ['**/node_modules/**', '**/.git/**'],
       });
       const out: ResolvedPath[] = [];
       const max = opts.maxResults ?? Number.POSITIVE_INFINITY;
@@ -741,10 +767,24 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
           },
         );
       }
-      const current = await fsp.readFile(p as string, 'utf-8');
+      // Use `lowFs.readTextFile` (not raw `fsp.readFile(p,
+      // 'utf-8')`) so BOM / encoding / CRLF handling matches what
+      // `readText` does and what `writeTextFile` will preserve on
+      // write-back. A direct utf-8 read on a UTF-8-BOM file would
+      // include the U+FEFF BOM codepoint in `current`,
+      // breaking `oldText` matching even when the user passed
+      // the exact string from a previous read; on iconv-supported
+      // codepages (GBK, Big5, Shift_JIS) it would mojibake the
+      // content and round-trip-corrupt the file on write-back.
+      const readResult = await this.deps.lowFs.readTextFile({
+        path: p as string,
+        limit: Number.POSITIVE_INFINITY,
+        line: 0,
+      });
+      const current = readResult.content;
       // Post-read TOCTOU guard — catches the swap-during-read
       // attack where `p` is replaced with a symlink between
-      // `fsp.stat` above and `fsp.readFile` here. The full
+      // `fsp.stat` above and the read here. The full
       // read-modify-write race window (between this check and
       // `lowFs.writeTextFile` below) is the deferred PR 20
       // follow-up that adds atomic-via-temp + `expectedHash`.
@@ -777,9 +817,16 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
       // atomic-via-temp follow-up; this guard is the
       // defense-in-depth layer.
       await assertNotSymlinkBeforeWrite(p as string);
+      // Forward the encoding/BOM/lineEnding metadata captured
+      // during the read so the write-back preserves the file's
+      // original encoding profile. Without this, a UTF-8-BOM
+      // file would be written without BOM, and a non-UTF-8 file
+      // (GBK/Shift_JIS) would be written as UTF-8 — silent
+      // round-trip corruption of any file the daemon edits.
       await this.deps.lowFs.writeTextFile({
         path: p as string,
         content: next,
+        _meta: readResult._meta,
       });
       // Symmetric with `readText` / `writeText` — operators
       // monitoring `fs.access` need to see when an edit landed on

--- a/packages/cli/src/serve/fs/workspaceFileSystem.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.ts
@@ -15,7 +15,7 @@ import { glob as globAsync } from 'glob';
 // + 31 tests post-commit. The inline `type` modifiers below tell the
 // `consistent-type-imports` rule per-symbol intent so future autofixes
 // don't repeat the regression.
- 
+
 import {
   StandardFileSystemService,
   loadIgnoreRules,
@@ -447,6 +447,7 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
       const out: ResolvedPath[] = [];
       const max = opts.maxResults ?? Number.POSITIVE_INFINITY;
       let escapedCount = 0;
+      let transientErrorCount = 0;
       for (const hit of matches) {
         if (out.length >= max) break;
         const absolute = path.resolve(hit);
@@ -462,11 +463,26 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
         let canonical: string;
         try {
           canonical = await fsp.realpath(absolute);
-        } catch {
-          // Dangling symlink or transient error: treat as escape
-          // so the hit isn't returned to the caller and the audit
-          // surfaces the count.
-          escapedCount += 1;
+        } catch (err) {
+          // Distinguish between the security-relevant escape kinds
+          // and transient I/O errors. `ENOENT` (dangling symlink
+          // or unlinked-mid-glob hit) and `ELOOP` (symlink cycle)
+          // are the cases that legitimately signal "this hit
+          // resolved outside of what the boundary trusts" — they
+          // count as `symlink_escape`. Other errnos (`EIO`,
+          // `EACCES`, `ENAMETOOLONG`, `EBUSY`) are environmental
+          // failures; treating them as escapes mislabels the audit
+          // and gives operators false security signal. Drop those
+          // hits silently from the result set but track them
+          // separately for the audit emission below so a
+          // monitoring pipeline can distinguish "filtered for
+          // escape" from "filtered for transient FS error".
+          const code = (err as NodeJS.ErrnoException)?.code;
+          if (code === 'ENOENT' || code === 'ELOOP') {
+            escapedCount += 1;
+          } else {
+            transientErrorCount += 1;
+          }
           continue;
         }
         const rel = path.relative(this.deps.boundWorkspace, canonical);
@@ -507,6 +523,14 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
           input: pattern,
           errorKind: 'symlink_escape',
           hint: `glob filtered ${escapedCount} hit(s) that resolved outside workspace`,
+        });
+      }
+      if (transientErrorCount > 0) {
+        this.deps.audit.recordDenied(this.deps.ctx, {
+          intent: 'glob',
+          input: pattern,
+          errorKind: 'permission_denied',
+          hint: `glob skipped ${transientErrorCount} hit(s) due to transient I/O errors (EIO/EACCES/ENAMETOOLONG/EBUSY)`,
         });
       }
       this.deps.audit.recordAccess(this.deps.ctx, {

--- a/packages/cli/src/serve/fs/workspaceFileSystem.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.ts
@@ -231,7 +231,7 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
       assertTrustedForIntent(this.deps.trusted, 'stat');
       const st = await fsp.lstat(p as string);
       const out: FsStat = {
-        kind: kindFromStats(st),
+        kind: kindFromStatLike(st),
         sizeBytes: st.size,
         modifiedMs: st.mtimeMs,
       };
@@ -413,7 +413,7 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
         // call `resolve()` separately. Treating each child as
         // implicitly-resolved here would be a brand-cast bypass.
         const childAbs = path.join(p as string, d.name);
-        const kind = kindFromDirent(d);
+        const kind = kindFromStatLike(d);
         const verdict = shouldIgnore(
           childAbs as ResolvedPath,
           this.deps.boundWorkspace,
@@ -616,8 +616,13 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
     const start = performance.now();
     try {
       assertTrustedForIntent(this.deps.trusted, 'write');
-      const buf = Buffer.from(content, 'utf-8');
-      enforceWriteSize(buf.length);
+      // `Buffer.byteLength` returns the UTF-8 byte count without
+      // allocating a Buffer. The earlier `Buffer.from(content,
+      // 'utf-8')` materialized the entire payload (up to
+      // `MAX_WRITE_BYTES = 5 MiB`) just to read its `.length`,
+      // wasting heap on every write.
+      const sizeBytes = Buffer.byteLength(content, 'utf-8');
+      enforceWriteSize(sizeBytes);
       await this.deps.lowFs.writeTextFile({
         path: p as string,
         content,
@@ -633,7 +638,7 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
         intent: 'write',
         absolute: p,
         durationMs: performance.now() - start,
-        sizeBytes: buf.length,
+        sizeBytes,
         matchedIgnore: verdict.ignored ? verdict.category : undefined,
       });
     } catch (err) {
@@ -672,6 +677,22 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
           hint: 'edit() works on text files only',
         });
       }
+      // Reject empty `oldText` BEFORE reading. JavaScript's
+      // `''.indexOf('')` returns `0`, so without this guard
+      // `current.slice(0, 0) + newText + current.slice(0)` would
+      // silently prepend `newText` to the entire file and emit a
+      // success audit event — a textbook silent data corruption
+      // bug. PR 20 routes that pass user-supplied `oldText`
+      // through verbatim must not be able to trigger it.
+      if (oldText.length === 0) {
+        throw new FsError(
+          'parse_error',
+          `oldText must be a non-empty string for edit on ${p}`,
+          {
+            hint: 'empty oldText would match at position 0 and silently prepend newText',
+          },
+        );
+      }
       const current = await fsp.readFile(p as string, 'utf-8');
       // Post-read TOCTOU guard — catches the swap-during-read
       // attack where `p` is replaced with a symlink between
@@ -686,14 +707,22 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
       // mechanical.
       const idx = current.indexOf(oldText);
       if (idx === -1) {
+        // Include a snippet of `oldText` in the hint so an operator
+        // staring at "edit failed" at 3 AM can tell whether the
+        // mismatch is whitespace, a stale file, or a wrong target
+        // path. Truncate to keep the hint readable on a one-line
+        // log; the full `oldText` is always reproducible from the
+        // request body.
+        const snippet =
+          oldText.length > 80 ? oldText.slice(0, 80) + '…' : oldText;
         throw new FsError('parse_error', `oldText not found in ${p}`, {
-          hint: 'edit() expects oldText to appear verbatim in the file',
+          hint: `edit() expects oldText to appear verbatim; searched for: ${JSON.stringify(snippet)}`,
         });
       }
       const next =
         current.slice(0, idx) + newText + current.slice(idx + oldText.length);
-      const buf = Buffer.from(next, 'utf-8');
-      enforceWriteSize(buf.length);
+      const writtenBytes = Buffer.byteLength(next, 'utf-8');
+      enforceWriteSize(writtenBytes);
       await this.deps.lowFs.writeTextFile({
         path: p as string,
         content: next,
@@ -713,10 +742,10 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
         intent: 'edit',
         absolute: p,
         durationMs: performance.now() - start,
-        sizeBytes: buf.length,
+        sizeBytes: writtenBytes,
         matchedIgnore: editVerdict.ignored ? editVerdict.category : undefined,
       });
-      return { writtenBytes: buf.length };
+      return { writtenBytes };
     } catch (err) {
       throw this.recordAndWrap(err, 'edit', p as string);
     }
@@ -742,6 +771,11 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
       input,
       errorKind: fs.kind,
       hint: fs.hint,
+      // Quote the underlying OS / FsError message so audit
+      // consumers debugging a production incident can see the
+      // actual cause (errno text, byte counts, glob pattern,
+      // etc.) rather than just `errorKind` + `hint`.
+      message: fs.message,
     });
     return fs;
   }
@@ -826,25 +860,23 @@ async function assertInodeStableAfterRead(
   }
 }
 
-function kindFromStats(st: {
+/**
+ * Map a `Stats` or `Dirent` (both expose the same `isFile` /
+ * `isDirectory` / `isSymbolicLink` methods) to the boundary's
+ * narrow `kind` union. `FsStat['kind']` and `FsEntry['kind']` are
+ * the same 4-value union, so a single helper keeps the
+ * classification rule in one place — reviewer flagged the previous
+ * `kindFromStats` + `kindFromDirent` pair as a maintenance hazard
+ * (drift risk if the union grows).
+ */
+function kindFromStatLike(s: {
   isFile(): boolean;
   isDirectory(): boolean;
   isSymbolicLink(): boolean;
 }): FsStat['kind'] {
-  if (st.isSymbolicLink()) return 'symlink';
-  if (st.isDirectory()) return 'directory';
-  if (st.isFile()) return 'file';
-  return 'other';
-}
-
-function kindFromDirent(d: {
-  isFile(): boolean;
-  isDirectory(): boolean;
-  isSymbolicLink(): boolean;
-}): FsEntry['kind'] {
-  if (d.isSymbolicLink()) return 'symlink';
-  if (d.isDirectory()) return 'directory';
-  if (d.isFile()) return 'file';
+  if (s.isSymbolicLink()) return 'symlink';
+  if (s.isDirectory()) return 'directory';
+  if (s.isFile()) return 'file';
   return 'other';
 }
 

--- a/packages/cli/src/serve/fs/workspaceFileSystem.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.ts
@@ -282,6 +282,23 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
         });
       }
       const sizeOutcome = enforceReadSize(st.size, opts.maxBytes);
+      // Reject `opts.line` values that the docstring forbids
+      // (positive integer required). Without this guard `Infinity`
+      // (`Infinity > 1` is true; `Infinity - 1` is still
+      // `Infinity`) and floats (`2.5 - 1 = 1.5`) flow through to
+      // `readFileWithLineAndLimit` and degrade silently to weird
+      // truncation behavior. `NaN` and `0` happen to work via the
+      // falsy fallback but that's accidental — prefer an explicit
+      // error.
+      if (
+        opts.line !== undefined &&
+        (!Number.isSafeInteger(opts.line) || opts.line < 1)
+      ) {
+        throw new FsError(
+          'parse_error',
+          `line must be a positive integer, got ${opts.line}`,
+        );
+      }
       // Delegate encoding-aware read to the existing core service so
       // BOM, CRLF, and iconv-supported codepages remain consistent
       // with what the tools layer already does. The core service's
@@ -290,7 +307,7 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
       // convention SDK consumers expect from line-numbered errors,
       // editor jump-to-line, etc.). Convert here so the public
       // contract isn't tied to the internal helper's indexing.
-      const startLineIndex = opts.line && opts.line > 1 ? opts.line - 1 : 0;
+      const startLineIndex = opts.line !== undefined ? opts.line - 1 : 0;
       const result = await this.deps.lowFs.readTextFile({
         path: p as string,
         limit: opts.limit ?? Number.POSITIVE_INFINITY,
@@ -447,6 +464,7 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
       const out: ResolvedPath[] = [];
       const max = opts.maxResults ?? Number.POSITIVE_INFINITY;
       let escapedCount = 0;
+      let permissionErrorCount = 0;
       let transientErrorCount = 0;
       for (const hit of matches) {
         if (out.length >= max) break;
@@ -457,29 +475,28 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
         // sits there), but the realpath isn't — so we resolve
         // each hit's symlink chain and compare the canonical to
         // the canonical workspace root. Filtered hits are counted
-        // and reported via a single aggregated `fs.denied` after
+        // and reported via aggregated `fs.denied` events after
         // the loop so per-hit emit doesn't flood the bus when a
         // misconfigured tree contains many escape symlinks.
         let canonical: string;
         try {
           canonical = await fsp.realpath(absolute);
         } catch (err) {
-          // Distinguish between the security-relevant escape kinds
-          // and transient I/O errors. `ENOENT` (dangling symlink
-          // or unlinked-mid-glob hit) and `ELOOP` (symlink cycle)
-          // are the cases that legitimately signal "this hit
-          // resolved outside of what the boundary trusts" — they
-          // count as `symlink_escape`. Other errnos (`EIO`,
-          // `EACCES`, `ENAMETOOLONG`, `EBUSY`) are environmental
-          // failures; treating them as escapes mislabels the audit
-          // and gives operators false security signal. Drop those
-          // hits silently from the result set but track them
-          // separately for the audit emission below so a
-          // monitoring pipeline can distinguish "filtered for
-          // escape" from "filtered for transient FS error".
+          // Three-way classification so monitoring pipelines can
+          // tell escapes from access denials from transient I/O:
+          //   - `ENOENT` / `ELOOP`  → real `symlink_escape`
+          //     (dangling symlink, symlink cycle)
+          //   - `EACCES` / `EPERM`  → `permission_denied`
+          //     (the literal access-denied case the kind names)
+          //   - everything else     → `io_error` (EIO, EBUSY,
+          //     ENAMETOOLONG, EMFILE, …) — environmental, NOT a
+          //     security signal. Conflating these poisons audit:
+          //     a failing disk would page security oncall.
           const code = (err as NodeJS.ErrnoException)?.code;
           if (code === 'ENOENT' || code === 'ELOOP') {
             escapedCount += 1;
+          } else if (code === 'EACCES' || code === 'EPERM') {
+            permissionErrorCount += 1;
           } else {
             transientErrorCount += 1;
           }
@@ -525,12 +542,27 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
           hint: `glob filtered ${escapedCount} hit(s) that resolved outside workspace`,
         });
       }
-      if (transientErrorCount > 0) {
+      if (permissionErrorCount > 0) {
         this.deps.audit.recordDenied(this.deps.ctx, {
           intent: 'glob',
           input: pattern,
           errorKind: 'permission_denied',
-          hint: `glob skipped ${transientErrorCount} hit(s) due to transient I/O errors (EIO/EACCES/ENAMETOOLONG/EBUSY)`,
+          hint: `glob skipped ${permissionErrorCount} hit(s) due to EACCES/EPERM`,
+        });
+      }
+      if (transientErrorCount > 0) {
+        this.deps.audit.recordDenied(this.deps.ctx, {
+          intent: 'glob',
+          input: pattern,
+          // `io_error` (not `permission_denied`) so monitoring
+          // pipelines that page security oncall on
+          // `permission_denied` aren't woken up by a failing disk
+          // or busy file. The kind was added to `FsErrorKind` for
+          // exactly this case (and for `wrapAsFsError`'s ENOSPC /
+          // EIO / EBUSY / ETXTBSY / ENAMETOOLONG / EMFILE / ENFILE
+          // mappings).
+          errorKind: 'io_error',
+          hint: `glob skipped ${transientErrorCount} hit(s) due to transient I/O errors (EIO/EBUSY/ENAMETOOLONG/EMFILE)`,
         });
       }
       this.deps.audit.recordAccess(this.deps.ctx, {
@@ -628,11 +660,23 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
         path: p as string,
         content: next,
       });
+      // Symmetric with `readText` / `writeText` — operators
+      // monitoring `fs.access` need to see when an edit landed on
+      // a `.gitignore`d / `.qwenignore`d file (build artifacts,
+      // logs, etc.) rather than only learning about
+      // matchedIgnore for reads and writes.
+      const editVerdict = shouldIgnore(
+        p,
+        this.deps.boundWorkspace,
+        this.deps.ignore,
+        'file',
+      );
       this.deps.audit.recordAccess(this.deps.ctx, {
         intent: 'edit',
         absolute: p,
         durationMs: performance.now() - start,
         sizeBytes: buf.length,
+        matchedIgnore: editVerdict.ignored ? editVerdict.category : undefined,
       });
       return { writtenBytes: buf.length };
     } catch (err) {

--- a/packages/cli/src/serve/fs/workspaceFileSystem.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.ts
@@ -314,6 +314,27 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
         limit: opts.limit ?? Number.POSITIVE_INFINITY,
         line: startLineIndex,
       });
+      // Post-read size sanity check. The pre-stat `MAX_READ_BYTES`
+      // gate above sees the file's size at stat time; a concurrent
+      // writer can grow the file from sub-cap to multi-GB between
+      // `fsp.stat` and `lowFs.readTextFile`'s underlying
+      // `fs.promises.readFile`. `readFileWithLineAndLimit` slurps
+      // the whole file into memory before slicing, so the stat
+      // gate alone is bypassable. Reject post-read if the
+      // returned content exceeds the cap. The proper fix is
+      // fd-based reading (open + stat + read tied to the same fd)
+      // — tracked as a hardening follow-up; this byte-length
+      // check is the defense-in-depth layer.
+      const decodedBytes = Buffer.byteLength(result.content, 'utf-8');
+      if (decodedBytes > MAX_READ_BYTES) {
+        throw new FsError(
+          'file_too_large',
+          `file grew during read to ${decodedBytes} bytes (cap ${MAX_READ_BYTES})`,
+          {
+            hint: 'concurrent writer detected via post-read size; retry or readBytes with explicit window',
+          },
+        );
+      }
       const ignoreVerdict = shouldIgnore(
         p,
         this.deps.boundWorkspace,
@@ -474,12 +495,32 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
       // against `boundWorkspace` (or was verified at a stale
       // moment). Re-validate at the entry point so a glob with
       // `cwd: '/etc'` cannot enumerate files outside the workspace
-      // even when the *pattern* is harmlessly relative. The
-      // pattern-side checks above only constrain the pattern
-      // shape; without this check `cwd` is the actual hazard.
+      // even when the *pattern* is harmlessly relative.
+      //
+      // **Important**: use `realpath` rather than `path.resolve` —
+      // a textual containment check on `path.resolve(cwd)` admits
+      // `<ws>/link` even when `<ws>/link → /etc` is a symlink to
+      // outside the workspace; `globAsync` would then walk
+      // `/etc` before the per-hit filter drops the results.
+      // `realpath` follows the chain (or throws ENOENT for missing
+      // ancestors), so the containment check sees the actual
+      // walk root.
       const cwd = (opts.cwd as string | undefined) ?? this.deps.boundWorkspace;
-      const cwdAbs = path.resolve(cwd);
-      if (!isWithinRoot(cwdAbs, this.deps.boundWorkspace)) {
+      let cwdReal: string;
+      try {
+        cwdReal = await fsp.realpath(path.resolve(cwd));
+      } catch (err) {
+        const code = (err as NodeJS.ErrnoException)?.code;
+        if (code === 'ENOENT') {
+          throw new FsError(
+            'path_not_found',
+            `glob cwd does not exist: ${cwd}`,
+            { cause: err },
+          );
+        }
+        throw err;
+      }
+      if (!isWithinRoot(cwdReal, this.deps.boundWorkspace)) {
         throw new FsError(
           'path_outside_workspace',
           `glob cwd is outside workspace: ${cwd}`,
@@ -487,7 +528,7 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
         );
       }
       const matches = await globAsync(pattern, {
-        cwd: cwdAbs,
+        cwd: cwdReal,
         nodir: false,
         absolute: true,
         dot: true,
@@ -623,6 +664,13 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
       // wasting heap on every write.
       const sizeBytes = Buffer.byteLength(content, 'utf-8');
       enforceWriteSize(sizeBytes);
+      // Pre-write TOCTOU guard — `atomicWriteFile`'s
+      // `resolveSymlinkChain` follows symlinks at write time, so
+      // a swap between the boundary's `resolve()` and this call
+      // would land the write outside the workspace. ENOENT is
+      // fine (ahead-of-create flow); an actual symlink is
+      // rejected.
+      await assertNotSymlinkBeforeWrite(p as string);
       await this.deps.lowFs.writeTextFile({
         path: p as string,
         content,
@@ -723,6 +771,12 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
         current.slice(0, idx) + newText + current.slice(idx + oldText.length);
       const writtenBytes = Buffer.byteLength(next, 'utf-8');
       enforceWriteSize(writtenBytes);
+      // Pre-write TOCTOU guard — same shape as writeText. The
+      // read-modify-write race window between the post-read
+      // inode check above and this call is the deferred PR 20
+      // atomic-via-temp follow-up; this guard is the
+      // defense-in-depth layer.
+      await assertNotSymlinkBeforeWrite(p as string);
       await this.deps.lowFs.writeTextFile({
         path: p as string,
         content: next,
@@ -869,6 +923,54 @@ async function assertInodeStableAfterRead(
  * `kindFromStats` + `kindFromDirent` pair as a maintenance hazard
  * (drift risk if the union grows).
  */
+/**
+ * Pre-write TOCTOU guard. Mirrors the post-read inode check but
+ * runs BEFORE the actual write. The earlier `resolve()` →
+ * `writeTextFile()` window let an attacker swap `p` with a
+ * symlink to outside the workspace; `atomicWriteFile`'s
+ * underlying `resolveSymlinkChain` follows the symlink and the
+ * write lands outside.
+ *
+ * Catches:
+ * - the path is now a symlink (`isSymbolicLink()`) — reject
+ *   with `symlink_escape` regardless of where it points; PR 19/20
+ *   should re-`resolve` after a swap rather than blindly writing
+ *   through the rename.
+ *
+ * Does NOT catch:
+ * - swap-back AFTER this guard but BEFORE `lowFs.writeTextFile`
+ *   completes — the residual race window. The proper fix is
+ *   fd-based atomic write (`fsp.open(O_NOFOLLOW)` + temp + rename
+ *   tied to the parent dir), which is the deferred PR 20
+ *   atomic-via-temp follow-up. This guard is the defense-in-depth
+ *   layer that closes the wide window.
+ *
+ * Used by `writeText` and `edit()` immediately before
+ * `lowFs.writeTextFile`. ENOENT (the file doesn't exist yet) is
+ * fine — that's the legitimate ahead-of-mkdir flow already
+ * sanctioned by `resolveWithinWorkspace`'s ENOENT-tolerant
+ * branch for write intents; only an actual symlink is rejected.
+ */
+async function assertNotSymlinkBeforeWrite(p: string): Promise<void> {
+  let pre: Awaited<ReturnType<typeof fsp.lstat>>;
+  try {
+    pre = await fsp.lstat(p);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === 'ENOENT') return; // ahead-of-create flow
+    throw err;
+  }
+  if (pre.isSymbolicLink()) {
+    throw new FsError(
+      'symlink_escape',
+      `path was replaced with a symlink before write: ${p}`,
+      {
+        hint: 'TOCTOU swap detected via pre-write lstat — re-resolve before retrying',
+      },
+    );
+  }
+}
+
 function kindFromStatLike(s: {
   isFile(): boolean;
   isDirectory(): boolean;

--- a/packages/cli/src/serve/fs/workspaceFileSystem.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.ts
@@ -7,10 +7,19 @@
 import { promises as fsp } from 'node:fs';
 import * as path from 'node:path';
 import { glob as globAsync } from 'glob';
-import type {
-  Ignore,
+// `StandardFileSystemService` is constructed and `loadIgnoreRules` is
+// invoked at runtime — they MUST stay as value imports. The eslint
+// auto-fix in commit 7b0db4c3a hoisted the whole block to `import type`
+// (because the same line referenced the `Ignore` and `WriteTextFileOptions`
+// types), which silently erased the value bindings and broke the runtime
+// + 31 tests post-commit. The inline `type` modifiers below tell the
+// `consistent-type-imports` rule per-symbol intent so future autofixes
+// don't repeat the regression.
+ 
+import {
   StandardFileSystemService,
   loadIgnoreRules,
+  type Ignore,
   type WriteTextFileOptions,
 } from '@qwen-code/qwen-code-core';
 import type { BridgeEvent } from '../eventBus.js';
@@ -69,7 +78,13 @@ export interface ReadMeta {
 export interface ReadTextOptions {
   /** Cap returned bytes; defaults to MAX_READ_BYTES. */
   maxBytes?: number;
-  /** 1-based starting line for partial reads. */
+  /**
+   * 1-based starting line for partial reads. `1` returns the file
+   * from its first line. The boundary converts to the 0-based slice
+   * index `readFileWithLineAndLimit` expects internally; SDK
+   * consumers don't need to adjust. Values < 1 (or undefined) are
+   * treated as "from the beginning".
+   */
   line?: number;
   /** Maximum number of lines to return. */
   limit?: number;
@@ -269,11 +284,17 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
       const sizeOutcome = enforceReadSize(st.size, opts.maxBytes);
       // Delegate encoding-aware read to the existing core service so
       // BOM, CRLF, and iconv-supported codepages remain consistent
-      // with what the tools layer already does.
+      // with what the tools layer already does. The core service's
+      // `line` parameter is a 0-based slice index whereas the
+      // boundary's public `ReadTextOptions.line` is 1-based (the
+      // convention SDK consumers expect from line-numbered errors,
+      // editor jump-to-line, etc.). Convert here so the public
+      // contract isn't tied to the internal helper's indexing.
+      const startLineIndex = opts.line && opts.line > 1 ? opts.line - 1 : 0;
       const result = await this.deps.lowFs.readTextFile({
         path: p as string,
         limit: opts.limit ?? Number.POSITIVE_INFINITY,
-        line: opts.line ?? 0,
+        line: startLineIndex,
       });
       const ignoreVerdict = shouldIgnore(
         p,
@@ -305,7 +326,7 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
         opts.limit !== undefined &&
         Number.isFinite(opts.limit) &&
         result._meta?.originalLineCount !== undefined &&
-        result._meta.originalLineCount > opts.limit + (opts.line ?? 0)
+        result._meta.originalLineCount > opts.limit + startLineIndex
       ) {
         meta.truncated = true;
       }
@@ -386,15 +407,34 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
     const start = performance.now();
     try {
       assertTrustedForIntent(this.deps.trusted, 'glob');
-      // Reject `..` segments in the pattern outright. A pattern like
-      // `../../**/*.js` would otherwise let a caller search outside
-      // `cwd`. Boundary-checking each individual hit catches escapes
-      // too, but rejecting at the pattern level is cheaper and gives
-      // a clearer error.
+      // Reject patterns up-front before delegating to `glob` — the
+      // per-hit filter below catches escapes after the walk, but
+      // letting a clearly out-of-workspace pattern reach `globAsync`
+      // burns I/O *outside* the workspace before we drop the
+      // results. Three rejection classes:
+      //   1. `..` segments  — would let `cwd` be escaped lexically.
+      //   2. POSIX absolute (`/etc/**`) — `glob` rooted outside cwd.
+      //   3. Windows-style absolute / device prefixes (`C:\…`,
+      //      `\\?\…`, `\\server\share`) — same hazard on the other
+      //      platform. `path.isAbsolute` covers POSIX `/`; the
+      //      drive-letter / UNC checks cover Win32 even when the
+      //      daemon runs on POSIX (clients may send Win32 paths).
       if (pattern.split(/[\\/]/).some((seg) => seg === '..')) {
         throw new FsError(
           'parse_error',
           `glob pattern may not contain '..' segments: ${pattern}`,
+        );
+      }
+      if (
+        path.isAbsolute(pattern) ||
+        /^[A-Za-z]:[\\/]/.test(pattern) ||
+        pattern.startsWith('\\\\') ||
+        pattern.startsWith('//')
+      ) {
+        throw new FsError(
+          'parse_error',
+          `glob pattern must be workspace-relative: ${pattern}`,
+          { hint: 'pass a relative pattern such as "src/**/*.ts"' },
         );
       }
       const cwd = (opts.cwd as string | undefined) ?? this.deps.boundWorkspace;
@@ -434,11 +474,29 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
           escapedCount += 1;
           continue;
         }
+        // Check the dirent kind so directory ignore rules (`dist/`,
+        // `.git/`, `node_modules/`) actually match — `shouldIgnore`
+        // probes `<rel>/` for the directory filter, which the
+        // underlying `ignore` library requires for trailing-slash
+        // patterns. Probing every hit as a `file` (the prior
+        // behavior) silently leaks ignored directories from
+        // `glob('**/*')` even when `includeIgnored` is false. We
+        // already realpath'd the hit, so an extra `lstat` here is
+        // cheap; on `lstat` failure (raced unlink) we conservatively
+        // treat the hit as a file so the file-pattern check still
+        // runs.
+        let dirent: { isDirectory(): boolean } | null = null;
+        try {
+          dirent = await fsp.lstat(canonical);
+        } catch {
+          dirent = null;
+        }
+        const kind = dirent?.isDirectory() ? 'directory' : 'file';
         const verdict = shouldIgnore(
           canonical as ResolvedPath,
           this.deps.boundWorkspace,
           this.deps.ignore,
-          'file',
+          kind,
         );
         if (verdict.ignored && !opts.includeIgnored) continue;
         out.push(canonical as ResolvedPath);
@@ -504,6 +562,29 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
     const start = performance.now();
     try {
       assertTrustedForIntent(this.deps.trusted, 'edit');
+      // Mirror `readText`'s pre-stat OOM gate: `fsp.readFile` would
+      // otherwise slurp the whole target into memory before
+      // `enforceWriteSize` got a chance to refuse. A multi-GB file
+      // already inside the workspace can OOM the daemon even though
+      // the *edited output* would later fail the size check.
+      // Reject above `MAX_READ_BYTES` outright with a typed
+      // `file_too_large`; binary content is also refused since
+      // `current.indexOf(oldText)` over arbitrary bytes is meaningless.
+      const st = await fsp.stat(p as string);
+      if (st.size > MAX_READ_BYTES) {
+        throw new FsError(
+          'file_too_large',
+          `file of ${st.size} bytes exceeds edit cap of ${MAX_READ_BYTES} bytes`,
+          {
+            hint: 'split large edits into bounded readBytes/writeText sequences',
+          },
+        );
+      }
+      if (await detectBinary(p)) {
+        throw new FsError('binary_file', `cannot edit binary file: ${p}`, {
+          hint: 'edit() works on text files only',
+        });
+      }
       const current = await fsp.readFile(p as string, 'utf-8');
       // Single replacement to preserve atomic write-once semantics.
       // Multi-occurrence handling lives in PR 20's edit endpoint

--- a/packages/cli/src/serve/fs/workspaceFileSystem.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.ts
@@ -1,0 +1,596 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { promises as fsp } from 'node:fs';
+import * as path from 'node:path';
+import { glob as globAsync } from 'glob';
+import type {
+  Ignore,
+  StandardFileSystemService,
+  loadIgnoreRules,
+  type WriteTextFileOptions,
+} from '@qwen-code/qwen-code-core';
+import type { BridgeEvent } from '../eventBus.js';
+import {
+  type AuditContext,
+  type AuditPublisher,
+  createAuditPublisher,
+} from './audit.js';
+import { FsError, wrapAsFsError } from './errors.js';
+import {
+  canonicalizeWorkspace,
+  resolveWithinWorkspace,
+  type Intent,
+  type ResolvedPath,
+} from './paths.js';
+import {
+  MAX_READ_BYTES,
+  assertTrustedForIntent,
+  detectBinary,
+  enforceReadBytesSize,
+  enforceReadSize,
+  enforceWriteSize,
+  shouldIgnore,
+} from './policy.js';
+
+/**
+ * Stat snapshot returned by `WorkspaceFileSystem.stat`. We
+ * deliberately avoid passing through `fs.Stats` directly — the
+ * boundary should not leak Node-specific bigint quirks or
+ * platform-specific fields to PR 19/20 SDK consumers.
+ */
+export interface FsStat {
+  kind: 'file' | 'directory' | 'symlink' | 'other';
+  sizeBytes: number;
+  modifiedMs: number;
+}
+
+/** Directory listing entry from `WorkspaceFileSystem.list`. */
+export interface FsEntry {
+  name: string;
+  kind: 'file' | 'directory' | 'symlink' | 'other';
+  /** True iff the entry matched a `.gitignore`/`.qwenignore` rule. */
+  ignored: boolean;
+}
+
+/** Metadata side-channel returned alongside `readText` content. */
+export interface ReadMeta {
+  encoding?: string;
+  bom?: boolean;
+  lineEnding: 'crlf' | 'lf';
+  truncated?: boolean;
+  matchedIgnore?: 'file' | 'directory';
+  originalLineCount?: number;
+}
+
+export interface ReadTextOptions {
+  /** Cap returned bytes; defaults to MAX_READ_BYTES. */
+  maxBytes?: number;
+  /** 1-based starting line for partial reads. */
+  line?: number;
+  /** Maximum number of lines to return. */
+  limit?: number;
+}
+
+export interface ListOptions {
+  /** When true, ignored entries are returned with `ignored: true` rather than dropped. */
+  includeIgnored?: boolean;
+}
+
+export interface GlobOptions {
+  cwd?: ResolvedPath;
+  includeIgnored?: boolean;
+  maxResults?: number;
+}
+
+export interface WriteOutcome {
+  writtenBytes: number;
+}
+
+export interface RequestContext extends AuditContext {
+  /** Mostly redundant with `originatorClientId`; kept for forward-compat with future ACP fields. */
+  ownerSessionId?: string;
+}
+
+/**
+ * Public boundary type. PR 19/20 routes consume this via the
+ * factory's `forRequest(ctx)` so audit context is automatically
+ * threaded through every operation.
+ */
+export interface WorkspaceFileSystem {
+  resolve(input: string, intent: Intent): Promise<ResolvedPath>;
+  stat(p: ResolvedPath): Promise<FsStat>;
+  readText(
+    p: ResolvedPath,
+    opts?: ReadTextOptions,
+  ): Promise<{ content: string; meta: ReadMeta }>;
+  readBytes(p: ResolvedPath, opts?: { maxBytes?: number }): Promise<Buffer>;
+  list(p: ResolvedPath, opts?: ListOptions): Promise<FsEntry[]>;
+  glob(pattern: string, opts?: GlobOptions): Promise<ResolvedPath[]>;
+  writeText(
+    p: ResolvedPath,
+    content: string,
+    opts?: WriteTextFileOptions,
+  ): Promise<void>;
+  edit(
+    p: ResolvedPath,
+    oldText: string,
+    newText: string,
+  ): Promise<WriteOutcome>;
+}
+
+/**
+ * Per-process factory. Build once at `createServeApp` boot, call
+ * `forRequest` per HTTP route invocation.
+ */
+export interface WorkspaceFileSystemFactory {
+  forRequest(ctx: RequestContext): WorkspaceFileSystem;
+}
+
+export interface CreateWorkspaceFileSystemFactoryDeps {
+  /** Canonical workspace path; the daemon's `boundWorkspace`. */
+  boundWorkspace: string;
+  /** Snapshot of `Config.isTrustedFolder()` at boot. */
+  trusted: boolean;
+  /** Bridge-bound publisher into `EventBus.publish`. */
+  emit: (event: BridgeEvent) => void;
+  /**
+   * Override the default ignore loader. Tests pass a fixed `Ignore`
+   * to avoid filesystem coupling; production lets the factory build
+   * one per workspace via `loadIgnoreRules`.
+   */
+  ignore?: Ignore;
+  /** Override audit raw-path mode. Defaults to env `QWEN_AUDIT_RAW_PATHS=1`. */
+  includeRawPaths?: boolean;
+}
+
+/**
+ * Build a `WorkspaceFileSystemFactory`. The factory itself is
+ * stateless across requests; per-request state (the audit context)
+ * lives on the bound `WorkspaceFileSystem` returned from `forRequest`.
+ */
+export function createWorkspaceFileSystemFactory(
+  deps: CreateWorkspaceFileSystemFactoryDeps,
+): WorkspaceFileSystemFactory {
+  const boundWorkspace = canonicalizeWorkspace(deps.boundWorkspace);
+  const ignore =
+    deps.ignore ??
+    loadIgnoreRules({
+      projectRoot: boundWorkspace,
+      useGitignore: true,
+      useQwenignore: true,
+      ignoreDirs: [],
+    });
+  const audit: AuditPublisher = createAuditPublisher({
+    emit: deps.emit,
+    boundWorkspace,
+    includeRawPaths: deps.includeRawPaths,
+  });
+  const lowFs = new StandardFileSystemService();
+
+  return {
+    forRequest(ctx) {
+      return new WorkspaceFileSystemImpl({
+        boundWorkspace,
+        trusted: deps.trusted,
+        ignore,
+        audit,
+        ctx,
+        lowFs,
+      });
+    },
+  };
+}
+
+interface ImplDeps {
+  boundWorkspace: string;
+  trusted: boolean;
+  ignore: Ignore;
+  audit: AuditPublisher;
+  ctx: RequestContext;
+  lowFs: StandardFileSystemService;
+}
+
+class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
+  constructor(private readonly deps: ImplDeps) {}
+
+  async resolve(input: string, intent: Intent): Promise<ResolvedPath> {
+    try {
+      return await resolveWithinWorkspace(
+        input,
+        this.deps.boundWorkspace,
+        intent,
+      );
+    } catch (err) {
+      throw this.recordAndWrap(err, intent, input);
+    }
+  }
+
+  async stat(p: ResolvedPath): Promise<FsStat> {
+    const start = performance.now();
+    try {
+      assertTrustedForIntent(this.deps.trusted, 'stat');
+      const st = await fsp.lstat(p as string);
+      const out: FsStat = {
+        kind: kindFromStats(st),
+        sizeBytes: st.size,
+        modifiedMs: st.mtimeMs,
+      };
+      this.deps.audit.recordAccess(this.deps.ctx, {
+        intent: 'stat',
+        absolute: p,
+        durationMs: performance.now() - start,
+        sizeBytes: st.size,
+      });
+      return out;
+    } catch (err) {
+      throw this.recordAndWrap(err, 'stat', p as string);
+    }
+  }
+
+  async readText(
+    p: ResolvedPath,
+    opts: ReadTextOptions = {},
+  ): Promise<{ content: string; meta: ReadMeta }> {
+    const start = performance.now();
+    try {
+      assertTrustedForIntent(this.deps.trusted, 'read');
+      const st = await fsp.stat(p as string);
+      // Hard size gate before we delegate to lowFs.readTextFile —
+      // that helper's underlying `readFileWithLineAndLimit` slurps
+      // the whole file into memory before slicing lines, so an
+      // unbounded request against a 5 GB text file would OOM the
+      // daemon (or, on a healthy host, flood the SSE replay ring
+      // with a 5 GB string). `MAX_READ_BYTES` is the hard cap and
+      // is independent of the caller's `opts.maxBytes` (which is a
+      // *softer* post-read truncation target — the boundary still
+      // honors it via `enforceReadSize` below). A future streaming
+      // read path can lift this hard cap by reading only the first
+      // N bytes; for now files above the cap throw and the SDK
+      // consumer can fall back to `readBytes` with an explicit
+      // length window.
+      if (st.size > MAX_READ_BYTES) {
+        throw new FsError(
+          'file_too_large',
+          `file of ${st.size} bytes exceeds read cap of ${MAX_READ_BYTES} bytes`,
+          {
+            hint: 'use readBytes for explicit byte-windowed access on large files',
+          },
+        );
+      }
+      if (await detectBinary(p)) {
+        throw new FsError('binary_file', `binary file: ${p}`, {
+          hint: 'use readBytes for binary content',
+        });
+      }
+      const sizeOutcome = enforceReadSize(st.size, opts.maxBytes);
+      // Delegate encoding-aware read to the existing core service so
+      // BOM, CRLF, and iconv-supported codepages remain consistent
+      // with what the tools layer already does.
+      const result = await this.deps.lowFs.readTextFile({
+        path: p as string,
+        limit: opts.limit ?? Number.POSITIVE_INFINITY,
+        line: opts.line ?? 0,
+      });
+      const ignoreVerdict = shouldIgnore(
+        p,
+        this.deps.boundWorkspace,
+        this.deps.ignore,
+        'file',
+      );
+      const meta: ReadMeta = {
+        encoding: result._meta?.encoding,
+        bom: result._meta?.bom,
+        lineEnding: (result._meta?.lineEnding ?? 'lf') as 'crlf' | 'lf',
+        originalLineCount: result._meta?.originalLineCount,
+      };
+      let truncatedContent = result.content;
+      if (sizeOutcome.truncated) {
+        const buf = Buffer.from(result.content, 'utf-8');
+        if (buf.length > sizeOutcome.bytesToRead) {
+          truncatedContent = buf
+            .subarray(0, sizeOutcome.bytesToRead)
+            .toString('utf-8');
+        }
+        meta.truncated = true;
+      }
+      // Surface truncation whenever lowFs's own `limit` clipped the
+      // content too — without this the audit row + meta.truncated
+      // would silently disagree on whether the SDK consumer received
+      // the full file.
+      if (
+        opts.limit !== undefined &&
+        Number.isFinite(opts.limit) &&
+        result._meta?.originalLineCount !== undefined &&
+        result._meta.originalLineCount > opts.limit + (opts.line ?? 0)
+      ) {
+        meta.truncated = true;
+      }
+      if (ignoreVerdict.ignored) meta.matchedIgnore = ignoreVerdict.category;
+      this.deps.audit.recordAccess(this.deps.ctx, {
+        intent: 'read',
+        absolute: p,
+        durationMs: performance.now() - start,
+        sizeBytes: st.size,
+        truncated: meta.truncated,
+        matchedIgnore: meta.matchedIgnore,
+      });
+      return { content: truncatedContent, meta };
+    } catch (err) {
+      throw this.recordAndWrap(err, 'read', p as string);
+    }
+  }
+
+  async readBytes(
+    p: ResolvedPath,
+    opts: { maxBytes?: number } = {},
+  ): Promise<Buffer> {
+    const start = performance.now();
+    try {
+      assertTrustedForIntent(this.deps.trusted, 'read');
+      const st = await fsp.stat(p as string);
+      enforceReadBytesSize(st.size, opts.maxBytes);
+      const buf = await fsp.readFile(p as string);
+      this.deps.audit.recordAccess(this.deps.ctx, {
+        intent: 'read',
+        absolute: p,
+        durationMs: performance.now() - start,
+        sizeBytes: buf.length,
+      });
+      return buf;
+    } catch (err) {
+      throw this.recordAndWrap(err, 'read', p as string);
+    }
+  }
+
+  async list(p: ResolvedPath, opts: ListOptions = {}): Promise<FsEntry[]> {
+    const start = performance.now();
+    try {
+      assertTrustedForIntent(this.deps.trusted, 'list');
+      const dirents = await fsp.readdir(p as string, { withFileTypes: true });
+      const entries: FsEntry[] = [];
+      for (const d of dirents) {
+        // `path.join(p, d.name)` is a shallow extension of an
+        // already-canonical workspace path. Symlinked dirents are
+        // tagged as `kind: 'symlink'` rather than auto-followed —
+        // PR 19/20 callers that want the target's containment can
+        // call `resolve()` separately. Treating each child as
+        // implicitly-resolved here would be a brand-cast bypass.
+        const childAbs = path.join(p as string, d.name);
+        const kind = kindFromDirent(d);
+        const verdict = shouldIgnore(
+          childAbs as ResolvedPath,
+          this.deps.boundWorkspace,
+          this.deps.ignore,
+          kind === 'directory' ? 'directory' : 'file',
+        );
+        if (verdict.ignored && !opts.includeIgnored) continue;
+        entries.push({ name: d.name, kind, ignored: verdict.ignored });
+      }
+      this.deps.audit.recordAccess(this.deps.ctx, {
+        intent: 'list',
+        absolute: p,
+        durationMs: performance.now() - start,
+        sizeBytes: entries.length,
+      });
+      return entries;
+    } catch (err) {
+      throw this.recordAndWrap(err, 'list', p as string);
+    }
+  }
+
+  async glob(pattern: string, opts: GlobOptions = {}): Promise<ResolvedPath[]> {
+    const start = performance.now();
+    try {
+      assertTrustedForIntent(this.deps.trusted, 'glob');
+      // Reject `..` segments in the pattern outright. A pattern like
+      // `../../**/*.js` would otherwise let a caller search outside
+      // `cwd`. Boundary-checking each individual hit catches escapes
+      // too, but rejecting at the pattern level is cheaper and gives
+      // a clearer error.
+      if (pattern.split(/[\\/]/).some((seg) => seg === '..')) {
+        throw new FsError(
+          'parse_error',
+          `glob pattern may not contain '..' segments: ${pattern}`,
+        );
+      }
+      const cwd = (opts.cwd as string | undefined) ?? this.deps.boundWorkspace;
+      const matches = await globAsync(pattern, {
+        cwd,
+        nodir: false,
+        absolute: true,
+        dot: true,
+      });
+      const out: ResolvedPath[] = [];
+      const max = opts.maxResults ?? Number.POSITIVE_INFINITY;
+      let escapedCount = 0;
+      for (const hit of matches) {
+        if (out.length >= max) break;
+        const absolute = path.resolve(hit);
+        // Per-hit boundary check defends against a glob that
+        // matches a symlink whose target escapes the workspace.
+        // The literal path is in-workspace (the symlink itself
+        // sits there), but the realpath isn't — so we resolve
+        // each hit's symlink chain and compare the canonical to
+        // the canonical workspace root. Filtered hits are counted
+        // and reported via a single aggregated `fs.denied` after
+        // the loop so per-hit emit doesn't flood the bus when a
+        // misconfigured tree contains many escape symlinks.
+        let canonical: string;
+        try {
+          canonical = await fsp.realpath(absolute);
+        } catch {
+          // Dangling symlink or transient error: treat as escape
+          // so the hit isn't returned to the caller and the audit
+          // surfaces the count.
+          escapedCount += 1;
+          continue;
+        }
+        const rel = path.relative(this.deps.boundWorkspace, canonical);
+        if (rel.startsWith('..') || path.isAbsolute(rel)) {
+          escapedCount += 1;
+          continue;
+        }
+        const verdict = shouldIgnore(
+          canonical as ResolvedPath,
+          this.deps.boundWorkspace,
+          this.deps.ignore,
+          'file',
+        );
+        if (verdict.ignored && !opts.includeIgnored) continue;
+        out.push(canonical as ResolvedPath);
+      }
+      if (escapedCount > 0) {
+        this.deps.audit.recordDenied(this.deps.ctx, {
+          intent: 'glob',
+          input: pattern,
+          errorKind: 'symlink_escape',
+          hint: `glob filtered ${escapedCount} hit(s) that resolved outside workspace`,
+        });
+      }
+      this.deps.audit.recordAccess(this.deps.ctx, {
+        intent: 'glob',
+        absolute: cwd as ResolvedPath,
+        durationMs: performance.now() - start,
+        sizeBytes: out.length,
+      });
+      return out;
+    } catch (err) {
+      throw this.recordAndWrap(err, 'glob', pattern);
+    }
+  }
+
+  async writeText(
+    p: ResolvedPath,
+    content: string,
+    opts?: WriteTextFileOptions,
+  ): Promise<void> {
+    const start = performance.now();
+    try {
+      assertTrustedForIntent(this.deps.trusted, 'write');
+      const buf = Buffer.from(content, 'utf-8');
+      enforceWriteSize(buf.length);
+      await this.deps.lowFs.writeTextFile({
+        path: p as string,
+        content,
+        _meta: opts ? buildWriteMeta(opts) : undefined,
+      });
+      const verdict = shouldIgnore(
+        p,
+        this.deps.boundWorkspace,
+        this.deps.ignore,
+        'file',
+      );
+      this.deps.audit.recordAccess(this.deps.ctx, {
+        intent: 'write',
+        absolute: p,
+        durationMs: performance.now() - start,
+        sizeBytes: buf.length,
+        matchedIgnore: verdict.ignored ? verdict.category : undefined,
+      });
+    } catch (err) {
+      throw this.recordAndWrap(err, 'write', p as string);
+    }
+  }
+
+  async edit(
+    p: ResolvedPath,
+    oldText: string,
+    newText: string,
+  ): Promise<WriteOutcome> {
+    const start = performance.now();
+    try {
+      assertTrustedForIntent(this.deps.trusted, 'edit');
+      const current = await fsp.readFile(p as string, 'utf-8');
+      // Single replacement to preserve atomic write-once semantics.
+      // Multi-occurrence handling lives in PR 20's edit endpoint
+      // where the route can decide policy; the boundary stays
+      // mechanical.
+      const idx = current.indexOf(oldText);
+      if (idx === -1) {
+        throw new FsError('parse_error', `oldText not found in ${p}`, {
+          hint: 'edit() expects oldText to appear verbatim in the file',
+        });
+      }
+      const next =
+        current.slice(0, idx) + newText + current.slice(idx + oldText.length);
+      const buf = Buffer.from(next, 'utf-8');
+      enforceWriteSize(buf.length);
+      await this.deps.lowFs.writeTextFile({
+        path: p as string,
+        content: next,
+      });
+      this.deps.audit.recordAccess(this.deps.ctx, {
+        intent: 'edit',
+        absolute: p,
+        durationMs: performance.now() - start,
+        sizeBytes: buf.length,
+      });
+      return { writtenBytes: buf.length };
+    } catch (err) {
+      throw this.recordAndWrap(err, 'edit', p as string);
+    }
+  }
+
+  /**
+   * Coerce an arbitrary thrown value into an `FsError`, emit the
+   * matching `fs.denied` audit event, and return the typed error
+   * for the caller to rethrow. Body methods invoke this in their
+   * `catch` so:
+   *   - raw fs errnos (`EACCES`, `ENOTDIR`, …) get categorized
+   *     instead of escaping as opaque 5xx,
+   *   - the audit log records every failure (the prior helper
+   *     early-returned for non-`FsError`s and silently lost the
+   *     event), and
+   *   - PR 19/20 routes can still rely on `instanceof FsError`
+   *     for their `sendFsError` serializer.
+   */
+  private recordAndWrap(err: unknown, intent: Intent, input: string): FsError {
+    const fs = wrapAsFsError(err);
+    this.deps.audit.recordDenied(this.deps.ctx, {
+      intent,
+      input,
+      errorKind: fs.kind,
+      hint: fs.hint,
+    });
+    return fs;
+  }
+}
+
+function kindFromStats(st: {
+  isFile(): boolean;
+  isDirectory(): boolean;
+  isSymbolicLink(): boolean;
+}): FsStat['kind'] {
+  if (st.isSymbolicLink()) return 'symlink';
+  if (st.isDirectory()) return 'directory';
+  if (st.isFile()) return 'file';
+  return 'other';
+}
+
+function kindFromDirent(d: {
+  isFile(): boolean;
+  isDirectory(): boolean;
+  isSymbolicLink(): boolean;
+}): FsEntry['kind'] {
+  if (d.isSymbolicLink()) return 'symlink';
+  if (d.isDirectory()) return 'directory';
+  if (d.isFile()) return 'file';
+  return 'other';
+}
+
+function buildWriteMeta(
+  opts: WriteTextFileOptions,
+): Record<string, unknown> | undefined {
+  const meta: Record<string, unknown> = {};
+  if (opts.bom) meta['bom'] = true;
+  if (opts.encoding) meta['encoding'] = opts.encoding;
+  return Object.keys(meta).length > 0 ? meta : undefined;
+}
+
+// Re-export so PR 19/20 routes can access the orchestrator surface
+// from a single `serve/fs/index.js` import.
+export { MAX_READ_BYTES };

--- a/packages/cli/src/serve/fs/workspaceFileSystem.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.ts
@@ -19,6 +19,7 @@ import { glob as globAsync } from 'glob';
 import {
   StandardFileSystemService,
   loadIgnoreRules,
+  isWithinRoot,
   type Ignore,
   type WriteTextFileOptions,
 } from '@qwen-code/qwen-code-core';
@@ -327,11 +328,17 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
       };
       let truncatedContent = result.content;
       if (sizeOutcome.truncated) {
+        // Use `safeUtf8Truncate` instead of `subarray(0,n).toString('utf-8')`
+        // so the slice never splits a multi-byte codepoint (CJK,
+        // emoji). The plain `subarray + toString` approach silently
+        // emits U+FFFD at the boundary and breaks downstream JSON /
+        // source-code parsing of the truncated prefix.
         const buf = Buffer.from(result.content, 'utf-8');
         if (buf.length > sizeOutcome.bytesToRead) {
-          truncatedContent = buf
-            .subarray(0, sizeOutcome.bytesToRead)
-            .toString('utf-8');
+          truncatedContent = safeUtf8Truncate(
+            buf,
+            sizeOutcome.bytesToRead,
+          ).toString('utf-8');
         }
         meta.truncated = true;
       }
@@ -348,6 +355,12 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
         meta.truncated = true;
       }
       if (ignoreVerdict.ignored) meta.matchedIgnore = ignoreVerdict.category;
+      // Post-read TOCTOU check: confirm the path's inode hasn't
+      // changed and it isn't now a symlink. Catches the
+      // swap-during-read attack where the file is replaced
+      // mid-operation with a symlink pointing outside the
+      // workspace.
+      await assertInodeStableAfterRead(p as string, st.ino);
       this.deps.audit.recordAccess(this.deps.ctx, {
         intent: 'read',
         absolute: p,
@@ -372,6 +385,8 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
       const st = await fsp.stat(p as string);
       enforceReadBytesSize(st.size, opts.maxBytes);
       const buf = await fsp.readFile(p as string);
+      // Post-read TOCTOU guard — same shape as `readText`.
+      await assertInodeStableAfterRead(p as string, st.ino);
       this.deps.audit.recordAccess(this.deps.ctx, {
         intent: 'read',
         absolute: p,
@@ -454,9 +469,25 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
           { hint: 'pass a relative pattern such as "src/**/*.ts"' },
         );
       }
+      // `opts.cwd` is typed `ResolvedPath` but a brand cast in
+      // calling code can produce a path that's never been verified
+      // against `boundWorkspace` (or was verified at a stale
+      // moment). Re-validate at the entry point so a glob with
+      // `cwd: '/etc'` cannot enumerate files outside the workspace
+      // even when the *pattern* is harmlessly relative. The
+      // pattern-side checks above only constrain the pattern
+      // shape; without this check `cwd` is the actual hazard.
       const cwd = (opts.cwd as string | undefined) ?? this.deps.boundWorkspace;
+      const cwdAbs = path.resolve(cwd);
+      if (!isWithinRoot(cwdAbs, this.deps.boundWorkspace)) {
+        throw new FsError(
+          'path_outside_workspace',
+          `glob cwd is outside workspace: ${cwd}`,
+          { hint: 'opts.cwd must be a path obtained from fs.resolve()' },
+        );
+      }
       const matches = await globAsync(pattern, {
-        cwd,
+        cwd: cwdAbs,
         nodir: false,
         absolute: true,
         dot: true,
@@ -642,6 +673,13 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
         });
       }
       const current = await fsp.readFile(p as string, 'utf-8');
+      // Post-read TOCTOU guard — catches the swap-during-read
+      // attack where `p` is replaced with a symlink between
+      // `fsp.stat` above and `fsp.readFile` here. The full
+      // read-modify-write race window (between this check and
+      // `lowFs.writeTextFile` below) is the deferred PR 20
+      // follow-up that adds atomic-via-temp + `expectedHash`.
+      await assertInodeStableAfterRead(p as string, st.ino);
       // Single replacement to preserve atomic write-once semantics.
       // Multi-occurrence handling lives in PR 20's edit endpoint
       // where the route can decide policy; the boundary stays
@@ -706,6 +744,85 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
       hint: fs.hint,
     });
     return fs;
+  }
+}
+
+/**
+ * Truncate a UTF-8 buffer to at most `maxBytes` bytes WITHOUT
+ * splitting a multi-byte codepoint. `Buffer.subarray(0, n).toString('utf-8')`
+ * silently emits U+FFFD replacement chars when `n` falls in the
+ * middle of a 2-4-byte sequence (CJK, emoji); a downstream consumer
+ * parsing JSON / source code over the truncated content sees corrupted
+ * trailing bytes. We back off `n` to the last valid codepoint
+ * boundary so the truncated string is always a clean prefix of the
+ * original.
+ *
+ * Algorithm:
+ * 1. If the buffer fits, return as-is.
+ * 2. Walk back from `maxBytes` while the previous byte is a UTF-8
+ *    continuation byte (`0b10xxxxxx`).
+ * 3. The byte at the new boundary is now either ASCII (`<0x80`) or
+ *    a leading byte. If it's a leading byte, check whether the full
+ *    multi-byte sequence fits within `maxBytes`. If not, drop the
+ *    leading byte too — the sequence is incomplete.
+ */
+function safeUtf8Truncate(buf: Buffer, maxBytes: number): Buffer {
+  if (buf.length <= maxBytes) return buf;
+  let end = maxBytes;
+  while (end > 0 && (buf[end] & 0xc0) === 0x80) end--;
+  if (end > 0) {
+    const lead = buf[end - 1];
+    let seqLen = 1;
+    if ((lead & 0x80) === 0) seqLen = 1;
+    else if ((lead & 0xe0) === 0xc0) seqLen = 2;
+    else if ((lead & 0xf0) === 0xe0) seqLen = 3;
+    else if ((lead & 0xf8) === 0xf0) seqLen = 4;
+    if (seqLen > 1 && end - 1 + seqLen > maxBytes) {
+      end = end - 1;
+    }
+  }
+  return buf.subarray(0, end);
+}
+
+/**
+ * Post-read TOCTOU guard. After reading the file at `p`, re-`lstat`
+ * to confirm the inode hasn't changed and the path isn't now a
+ * symlink. Catches the swap-then-leave attack where a regular
+ * file is replaced with a symlink to outside the workspace
+ * BETWEEN the boundary's pre-stat and the actual read — the
+ * pre-stat saw the original (small, regular) file but the read
+ * followed the swap to wherever the attacker pointed. There's a
+ * residual race where the attacker swaps back after our read but
+ * before this check; that window is much smaller than the swap-
+ * and-leave attack and outside PR 18's threat model. The proper
+ * fix is fd-based reading (`fsp.open` + `fileHandle.read`) so the
+ * fd binds to the inode at open time; that's a follow-up since it
+ * requires a new variant of `lowFs.readTextFile` that takes a
+ * FileHandle instead of a path.
+ */
+async function assertInodeStableAfterRead(
+  p: string,
+  preIno: bigint | number,
+): Promise<void> {
+  const post = await fsp.lstat(p);
+  if (post.isSymbolicLink()) {
+    throw new FsError(
+      'symlink_escape',
+      `path was replaced with a symlink during read: ${p}`,
+      { hint: 'TOCTOU swap detected via post-read lstat' },
+    );
+  }
+  // ino can be 0 on virtual filesystems (procfs etc.) — only compare
+  // when both sides report a meaningful value.
+  const preNum = typeof preIno === 'bigint' ? preIno : BigInt(preIno as number);
+  const postNum =
+    typeof post.ino === 'bigint' ? post.ino : BigInt(post.ino as number);
+  if (preNum !== 0n && postNum !== 0n && preNum !== postNum) {
+    throw new FsError(
+      'symlink_escape',
+      `path inode changed during read: ${p}`,
+      { hint: 'TOCTOU swap detected via inode comparison' },
+    );
   }
 }
 

--- a/packages/cli/src/serve/fs/workspaceFileSystem.ts
+++ b/packages/cli/src/serve/fs/workspaceFileSystem.ts
@@ -180,6 +180,20 @@ export function createWorkspaceFileSystemFactory(
       useQwenignore: true,
       ignoreDirs: [],
     });
+  // Freeze the `Ignore` instance so it cannot be mutated after
+  // the factory builds it. The `Ignore` class exposes a public
+  // `add(patterns): this` method that mutates state in-place;
+  // every `forRequest()` returns a `WorkspaceFileSystemImpl`
+  // sharing this same instance, so a future "ignore this
+  // pattern for this session" feature calling `.add()` would
+  // silently corrupt all concurrent requests. `Object.freeze`
+  // turns the mutation into a `TypeError` instead of a silent
+  // cross-request leak — surfacing the architectural mistake
+  // before it ships. Read paths (`getFileFilter` /
+  // `getDirectoryFilter`) are unaffected. Operators wanting
+  // per-session ignore rules should pass a different `Ignore`
+  // instance via `deps.ignore` to a separate factory.
+  Object.freeze(ignore);
   const audit: AuditPublisher = createAuditPublisher({
     emit: deps.emit,
     boundWorkspace,
@@ -409,6 +423,24 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
       // `maxBytes`.
       enforceReadBytesSize(st.size);
       let buf = await fsp.readFile(p as string);
+      // Post-read size sanity check — same TOCTOU window as
+      // `readText` (concurrent appender keeps the same inode, so
+      // `assertInodeStableAfterRead` doesn't catch *growth*).
+      // The pre-stat gate sees the size at stat time; an attacker
+      // can grow the file from sub-cap to multi-GB between
+      // `fsp.stat` and `fsp.readFile`, OOMing the daemon. Reject
+      // post-read if the buffer ended up over the hard cap. The
+      // proper fix (fd-based read with `fileHandle.stat` +
+      // bounded `fileHandle.read`) is a hardening follow-up.
+      if (buf.length > MAX_READ_BYTES) {
+        throw new FsError(
+          'file_too_large',
+          `file grew during read to ${buf.length} bytes (cap ${MAX_READ_BYTES})`,
+          {
+            hint: 'concurrent writer detected via post-read size; retry or readText for capped truncation',
+          },
+        );
+      }
       // Soft cap: caller's `opts.maxBytes` is a window cap matching
       // the parameter name's promise. Earlier semantics treated
       // it as a "reject if file > maxBytes" gate, which violated
@@ -522,18 +554,29 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
       // walk root.
       const cwd = (opts.cwd as string | undefined) ?? this.deps.boundWorkspace;
       let cwdReal: string;
-      try {
-        cwdReal = await fsp.realpath(path.resolve(cwd));
-      } catch (err) {
-        const code = (err as NodeJS.ErrnoException)?.code;
-        if (code === 'ENOENT') {
-          throw new FsError(
-            'path_not_found',
-            `glob cwd does not exist: ${cwd}`,
-            { cause: err },
-          );
+      // Short-circuit when `cwd` is exactly the canonical
+      // boundWorkspace — the factory already canonicalized it via
+      // `realpathSync.native`, so a per-request async `realpath`
+      // is a redundant syscall. Saves the syscall on the common
+      // path (route handlers omitting `opts.cwd` to glob the
+      // whole workspace) without losing the canonicalization
+      // guarantee — the factory's stored value IS the canonical.
+      if (cwd === this.deps.boundWorkspace) {
+        cwdReal = cwd;
+      } else {
+        try {
+          cwdReal = await fsp.realpath(path.resolve(cwd));
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException)?.code;
+          if (code === 'ENOENT') {
+            throw new FsError(
+              'path_not_found',
+              `glob cwd does not exist: ${cwd}`,
+              { cause: err },
+            );
+          }
+          throw err;
         }
-        throw err;
       }
       if (!isWithinRoot(cwdReal, this.deps.boundWorkspace)) {
         throw new FsError(
@@ -903,19 +946,22 @@ class WorkspaceFileSystemImpl implements WorkspaceFileSystem {
  */
 function safeUtf8Truncate(buf: Buffer, maxBytes: number): Buffer {
   if (buf.length <= maxBytes) return buf;
+  // Walk `end` back through any UTF-8 continuation bytes
+  // (`0b10xxxxxx`) at the cut position. After the loop:
+  //   - `end == 0`, OR
+  //   - `buf[end]` is a leading byte (top bits `0xxxxxxx`,
+  //     `110xxxxx`, `1110xxxx`, or `11110xxx`).
+  // Either way, `subarray(0, end)` is exactly the longest
+  // codepoint-aligned prefix at most `maxBytes` long: if
+  // `buf[end]` is the leading byte of an incomplete sequence
+  // we exclude it; if `buf[end]` is ASCII (i.e. the original
+  // `maxBytes` happened to land on a codepoint boundary) the
+  // walk-back is a no-op and we still cut at `maxBytes`.
+  // The earlier "seqLen check" was dead code — `subarray(0,
+  // end)` already excludes the leading byte at index `end`,
+  // so no further adjustment is ever needed.
   let end = maxBytes;
   while (end > 0 && (buf[end] & 0xc0) === 0x80) end--;
-  if (end > 0) {
-    const lead = buf[end - 1];
-    let seqLen = 1;
-    if ((lead & 0x80) === 0) seqLen = 1;
-    else if ((lead & 0xe0) === 0xc0) seqLen = 2;
-    else if ((lead & 0xf0) === 0xe0) seqLen = 3;
-    else if ((lead & 0xf8) === 0xf0) seqLen = 4;
-    if (seqLen > 1 && end - 1 + seqLen > maxBytes) {
-      end = end - 1;
-    }
-  }
   return buf.subarray(0, end);
 }
 
@@ -961,15 +1007,6 @@ async function assertInodeStableAfterRead(
   }
 }
 
-/**
- * Map a `Stats` or `Dirent` (both expose the same `isFile` /
- * `isDirectory` / `isSymbolicLink` methods) to the boundary's
- * narrow `kind` union. `FsStat['kind']` and `FsEntry['kind']` are
- * the same 4-value union, so a single helper keeps the
- * classification rule in one place — reviewer flagged the previous
- * `kindFromStats` + `kindFromDirent` pair as a maintenance hazard
- * (drift risk if the union grows).
- */
 /**
  * Pre-write TOCTOU guard. Mirrors the post-read inode check but
  * runs BEFORE the actual write. The earlier `resolve()` →
@@ -1018,6 +1055,13 @@ async function assertNotSymlinkBeforeWrite(p: string): Promise<void> {
   }
 }
 
+/**
+ * Map a `Stats` or `Dirent` (both expose the same `isFile` /
+ * `isDirectory` / `isSymbolicLink` methods) to the boundary's
+ * narrow `kind` union. `FsStat['kind']` and `FsEntry['kind']` are
+ * the same 4-value union, so a single helper keeps the
+ * classification rule in one place.
+ */
 function kindFromStatLike(s: {
   isFile(): boolean;
   isDirectory(): boolean;

--- a/packages/cli/src/serve/httpAcpBridge.ts
+++ b/packages/cli/src/serve/httpAcpBridge.ts
@@ -6,7 +6,7 @@
 
 import { spawn, type ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { promises as fs, realpathSync } from 'node:fs';
+import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { Readable, Writable } from 'node:stream';
 import {
@@ -15,6 +15,7 @@ import {
   ndJsonStream,
 } from '@agentclientprotocol/sdk';
 import { writeStderrLine } from '../utils/stdioHelpers.js';
+import { canonicalizeWorkspace } from './fs/paths.js';
 import {
   EventBus,
   DEFAULT_RING_SIZE,
@@ -3580,74 +3581,14 @@ function sliceLineRange(
 }
 
 /**
- * Canonicalize a workspace path so the boot-time bound path and every
- * request's `workspaceCwd` collapse to the same key. `path.resolve`
- * alone normalizes `..` and `.` segments and absolutizes, but on
- * case-insensitive filesystems (macOS APFS, Windows NTFS) `/Work/A`
- * and `/work/a` are the same directory yet `resolve` returns them
- * verbatim — without normalization the `boundWorkspace` check would
- * reject every request that spelled the path with different casing
- * and `sessionScope: 'single'` re-attach would silently degrade to
- * "one per spelling".
- *
- * `realpathSync.native` (when the path exists) walks symlinks and returns
- * the on-disk casing; this matches what `config.ts` / `settings.ts` /
- * `sandbox.ts` use for their own workspace resolution. When the path
- * doesn't exist (test fixtures, ahead-of-mkdir flows) we fall back to
- * the resolved-but-uncanonicalized form rather than throwing — the
- * downstream `spawn({cwd})` will fail with a useful ENOENT if the
- * workspace truly doesn't exist.
- *
- * NOTE: This is a **cross-module contract** (BX9_q) — `config.ts`,
- * `settings.ts`, `sandbox.ts`, and this file all need to canonicalize
- * the same way for the bound-workspace check + `sessionScope:
- * 'single'` re-attach to work correctly across paths. The contract:
- * use `realpathSync.native` on the resolved absolute path; fall back
- * to `path.resolve` only when the path doesn't exist yet. If a future
- * change breaks this alignment (e.g. one module starts lowercasing on
- * Windows but this one doesn't), the canonicalized request path
- * won't match the canonicalized bound path → every request returns
- * `workspace_mismatch` even though the human-readable paths look
- * equivalent. There's no test that pins the alignment; the
- * integration suite would catch a divergence only if it tested the
- * specific casing / symlink path the affected module changed.
- *
- * Stage 2 in-process (#3803 §10) collapses the bridge into core,
- * removing the bridge-side path resolution entirely. Stage 1.5
- * `@qwen-code/acp-bridge` lift (chiga0 finding 1) is the natural
- * place to extract a shared `canonicalizeWorkspace` primitive that
- * all four modules consume — the lowest-common-denominator
- * extraction is fine THERE because the package boundary forces the
- * call sites to converge. Until then, *any* change to how those
- * modules resolve workspace paths needs a matching change here.
+ * Re-export of the workspace canonicalizer for callers that historically
+ * imported it from `httpAcpBridge.ts`. The implementation was extracted
+ * to `./fs/paths.ts` in #4175 PR 18 (commit 1) so the forthcoming
+ * `WorkspaceFileSystem` boundary can reuse the same primitive without
+ * pulling in the 3.6k-line bridge module. See `./fs/paths.ts` for the
+ * cross-module contract that governs this function.
  */
-export function canonicalizeWorkspace(p: string): string {
-  const resolved = path.resolve(p);
-  try {
-    // FIXME(stage-2): switch to `fs.promises.realpath` once the
-    // bridge call sites become async-friendly. This sync syscall
-    // runs on the hot `spawnOrAttach` path and blocks the event
-    // loop for one filesystem stat per call. Single-user loopback
-    // (Stage 1's design target) doesn't notice; high-concurrency
-    // deployments will. Stage 2 in-process refactor removes the
-    // entire bridge-side path resolution anyway, but if Stage 2
-    // ever lands without that change, switch to the async version.
-    return realpathSync.native(resolved);
-  } catch (err) {
-    // Only fall back to path.resolve for ENOENT (path doesn't exist
-    // yet). Other filesystem errors (EACCES, EIO, ELOOP) should
-    // propagate — swallowing them would hide transient I/O failures
-    // behind misleading workspace_mismatch rejections.
-    if (
-      err &&
-      typeof err === 'object' &&
-      (err as { code?: unknown }).code === 'ENOENT'
-    ) {
-      return resolved;
-    }
-    throw err;
-  }
-}
+export { canonicalizeWorkspace };
 
 /**
  * Race `p` against a timeout. The timeout REJECTS the returned

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -3282,3 +3282,86 @@ describe('runQwenServe SIGINT handler', () => {
     void vi.fn(); // silence unused-import lint if vitest tree-shakes
   });
 });
+
+describe('createServeApp ServeAppDeps.fsFactory wiring (#4175 PR 18)', () => {
+  it('parks a default WorkspaceFileSystemFactory on app.locals when none is injected', async () => {
+    const { createServeApp } = await import('./server.js');
+    const app = createServeApp(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        workspace: '/work/bound',
+      } as Parameters<typeof createServeApp>[0],
+      () => 0,
+    );
+    const fsFactory = (
+      app.locals as {
+        fsFactory?: { forRequest: (ctx: { route: string }) => unknown };
+      }
+    ).fsFactory;
+    expect(fsFactory).toBeDefined();
+    expect(typeof fsFactory!.forRequest).toBe('function');
+    // The factory is functional — it can build a per-request boundary.
+    const fs = fsFactory!.forRequest({ route: 'TEST /op' });
+    expect(fs).toBeDefined();
+  });
+
+  it('uses the injected fsFactory verbatim when supplied', async () => {
+    const { createServeApp } = await import('./server.js');
+    const sentinel = { forRequest: vi.fn(() => ({ marker: 'injected' })) };
+    const app = createServeApp(
+      {
+        port: 0,
+        hostname: '127.0.0.1',
+        workspace: '/work/bound',
+      } as Parameters<typeof createServeApp>[0],
+      () => 0,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      { fsFactory: sentinel as any },
+    );
+    expect((app.locals as { fsFactory?: unknown }).fsFactory).toBe(sentinel);
+  });
+
+  it('default fsFactory is built with trusted=false (writes refused)', async () => {
+    const { createServeApp } = await import('./server.js');
+    const { isFsError } = await import('./fs/index.js');
+    const os = await import('node:os');
+    const tmp = await import('node:fs').then((m) =>
+      m.promises.mkdtemp(path.join(os.tmpdir(), 'qwen-serve-default-trust-')),
+    );
+    try {
+      const app = createServeApp(
+        {
+          port: 0,
+          hostname: '127.0.0.1',
+          workspace: tmp,
+        } as Parameters<typeof createServeApp>[0],
+        () => 0,
+      );
+      type FsCtx = { route: string };
+      type WfsLite = {
+        resolve: (input: string, intent: 'write') => Promise<string>;
+        writeText: (p: string, content: string) => Promise<void>;
+      };
+      const fsFactory = (
+        app.locals as {
+          fsFactory?: { forRequest: (ctx: FsCtx) => WfsLite };
+        }
+      ).fsFactory;
+      expect(fsFactory).toBeDefined();
+      const fs = fsFactory!.forRequest({ route: 'TEST /op' });
+      // Resolve a write target inside the workspace; the resolve
+      // succeeds but writeText must throw `untrusted_workspace` —
+      // that's the safe-default behavior the strict-default factory
+      // exists to enforce.
+      const resolved = await fs.resolve('child.txt', 'write');
+      const err = await fs.writeText(resolved, 'x').catch((e: unknown) => e);
+      expect(isFsError(err)).toBe(true);
+      expect((err as { kind: string }).kind).toBe('untrusted_workspace');
+    } finally {
+      await import('node:fs').then((m) =>
+        m.promises.rm(tmp, { recursive: true, force: true }),
+      );
+    }
+  });
+});

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -39,6 +39,32 @@ import {
   type CapabilitiesEnvelope,
   type ServeOptions,
 } from './types.js';
+import {
+  createWorkspaceFileSystemFactory,
+  type WorkspaceFileSystemFactory,
+} from './fs/index.js';
+
+/**
+ * Build a no-op fs-audit emitter that logs a single warning the
+ * first time it's invoked. The default factory uses this so a
+ * regression that silently strips audit events shows up in
+ * operator logs instead of disappearing — `() => {}` is the
+ * "obvious" no-op but offers no failure signal. PR 19/20's
+ * `runQwenServe` injection replaces this with a real per-session
+ * emit, so legitimate production traffic never hits the warning.
+ */
+function createDefaultFsAuditEmit(): (event: BridgeEvent) => void {
+  let warned = false;
+  return (event: BridgeEvent) => {
+    if (!warned) {
+      warned = true;
+      writeStderrLine(
+        `qwen serve: fs audit emit is the default no-op (event ${event.type} dropped). ` +
+          `Inject deps.fsFactory in createServeApp to wire audit into the EventBus.`,
+      );
+    }
+  };
+}
 
 export interface ServeAppDeps {
   /** Bridge instance; tests inject a fake. Defaults to a fresh real one. */
@@ -56,6 +82,18 @@ export interface ServeAppDeps {
    * process.cwd()` itself.
    */
   boundWorkspace?: string;
+  /**
+   * Workspace filesystem boundary factory (#4175 PR 18). When
+   * supplied, PR 19/20 routes will pull a per-request
+   * `WorkspaceFileSystem` off it; when omitted, `createServeApp`
+   * builds a permissive default (trusted=true, no-op audit emit).
+   * No PR 18 routes consume the factory yet — the slot is wired so
+   * PR 19 read-only file routes can drop in without re-shaping
+   * `ServeAppDeps`. Once PR 19 lands, `runQwenServe` will inject a
+   * factory whose `trusted` flag mirrors `Config.isTrustedFolder()`
+   * and whose `emit` plumbs into the per-session EventBus.
+   */
+  fsFactory?: WorkspaceFileSystemFactory;
 }
 
 /**
@@ -149,6 +187,33 @@ export function createServeApp(
         : {}),
       boundWorkspace,
     });
+
+  // Strict-default factory: `trusted: false` so an upstream refactor
+  // that forgets to inject `deps.fsFactory` never silently allows
+  // writes against an untrusted workspace. Read-shaped intents still
+  // succeed (so tests / direct embeds can exercise the read path
+  // without a config), but every mutating intent throws
+  // `untrusted_workspace`. The default `emit` is a no-op that warns
+  // once on first call so a future regression that silently swallows
+  // audit events surfaces in operator logs the first time it bites.
+  // Callers passing `deps.fsFactory` get full control of trust +
+  // audit destination — `runQwenServe` will inject one whose
+  // `trusted` mirrors `Config.isTrustedFolder()` and whose `emit`
+  // plumbs into the per-session EventBus once PR 19/20 lands.
+  const fsFactory: WorkspaceFileSystemFactory =
+    deps.fsFactory ??
+    createWorkspaceFileSystemFactory({
+      boundWorkspace,
+      trusted: false,
+      emit: createDefaultFsAuditEmit(),
+    });
+  // Park the factory on `app.locals` so PR 19/20 route handlers can
+  // pick it up via `req.app.locals.fsFactory` without re-threading
+  // the value through every handler signature, and so PR 18 tests
+  // can assert the factory is reachable. Express types `locals` as
+  // a generic record; we cast to keep a precise property name.
+  (app.locals as { fsFactory?: WorkspaceFileSystemFactory }).fsFactory =
+    fsFactory;
 
   // Order matters: rejection guards (CORS / Host allowlist / bearer auth)
   // run BEFORE the JSON body parser. Otherwise an unauthenticated POST

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -45,21 +45,39 @@ import {
 } from './fs/index.js';
 
 /**
- * Build a no-op fs-audit emitter that logs a single warning the
- * first time it's invoked. The default factory uses this so a
- * regression that silently strips audit events shows up in
- * operator logs instead of disappearing — `() => {}` is the
- * "obvious" no-op but offers no failure signal. PR 19/20's
- * `runQwenServe` injection replaces this with a real per-session
- * emit, so legitimate production traffic never hits the warning.
+ * Build a no-op fs-audit emitter that logs a warning every
+ * `WARN_EVERY` dropped events with as much context as the audit
+ * payload exposes. The default factory uses this so a regression
+ * that silently strips audit events shows up in operator logs
+ * instead of disappearing — the earlier one-shot warn was a
+ * permanent silent no-op after the first event, which made a PR
+ * 19/20 regression where `runQwenServe` forgets to inject the real
+ * factory completely invisible (every write 403s; nothing in
+ * audit; one stale stderr line easy to miss for background
+ * daemons). Periodic warning + dropped-event count + first-event
+ * `errorKind` + `pathHash` make the regression actionable.
+ *
+ * PR 19/20's `runQwenServe` injection replaces this with a real
+ * per-session emit, so legitimate production traffic never hits
+ * the warning.
  */
 function createDefaultFsAuditEmit(): (event: BridgeEvent) => void {
-  let warned = false;
+  const WARN_EVERY = 100;
+  let droppedCount = 0;
   return (event: BridgeEvent) => {
-    if (!warned) {
-      warned = true;
+    droppedCount += 1;
+    if (droppedCount === 1 || droppedCount % WARN_EVERY === 0) {
+      const data = event.data as
+        | { errorKind?: string; pathHash?: string; intent?: string }
+        | undefined;
+      const ctx: string[] = [];
+      if (data?.errorKind) ctx.push(`errorKind=${data.errorKind}`);
+      if (data?.intent) ctx.push(`intent=${data.intent}`);
+      if (data?.pathHash) ctx.push(`pathHash=${data.pathHash}`);
+      const ctxStr = ctx.length > 0 ? ` (${ctx.join(' ')})` : '';
       writeStderrLine(
-        `qwen serve: fs audit emit is the default no-op (event ${event.type} dropped). ` +
+        `qwen serve: fs audit emit is the default no-op — ${droppedCount} event(s) dropped so far. ` +
+          `Latest type=${event.type}${ctxStr}. ` +
           `Inject deps.fsFactory in createServeApp to wire audit into the EventBus.`,
       );
     }

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -86,12 +86,15 @@ export interface ServeAppDeps {
    * Workspace filesystem boundary factory (#4175 PR 18). When
    * supplied, PR 19/20 routes will pull a per-request
    * `WorkspaceFileSystem` off it; when omitted, `createServeApp`
-   * builds a permissive default (trusted=true, no-op audit emit).
-   * No PR 18 routes consume the factory yet — the slot is wired so
-   * PR 19 read-only file routes can drop in without re-shaping
-   * `ServeAppDeps`. Once PR 19 lands, `runQwenServe` will inject a
-   * factory whose `trusted` flag mirrors `Config.isTrustedFolder()`
-   * and whose `emit` plumbs into the per-session EventBus.
+   * builds a strict default (`trusted: false`, warn-once no-op
+   * `emit`) so an upstream refactor that forgets to inject
+   * `fsFactory` never silently allows writes against an untrusted
+   * workspace. No PR 18 routes consume the factory yet — the slot
+   * is wired so PR 19 read-only file routes can drop in without
+   * re-shaping `ServeAppDeps`. Once PR 19 lands, `runQwenServe`
+   * will inject a factory whose `trusted` flag mirrors
+   * `Config.isTrustedFolder()` and whose `emit` plumbs into the
+   * per-session EventBus.
    */
   fsFactory?: WorkspaceFileSystemFactory;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -279,6 +279,11 @@ export * from './utils/errorParsing.js';
 export * from './utils/errors.js';
 export * from './utils/fileUtils.js';
 export * from './utils/filesearch/fileSearch.js';
+export {
+  Ignore,
+  loadIgnoreRules,
+  type LoadIgnoreRulesOptions,
+} from './utils/filesearch/ignore.js';
 export * from './utils/formatters.js';
 export * from './utils/generateContentResponseUtilities.js';
 export * from './utils/getFolderStructure.js';


### PR DESCRIPTION
## Summary

Wave 4 PR 18 of #4175. Pure refactor introducing a per-request workspace filesystem boundary inside the `qwen serve` daemon. Centralizes path canonicalization, symlink-aware boundary checks, ignore/trust policy, size/binary limits, and audit hooks behind a single typed surface — preparing PR 19 (read-only file routes) and PR 20 (write/edit routes) to share a guarded chokepoint instead of re-implementing path safety per route.

Depends on PR 12 (#4241) and PR 15 (#4236), both merged. No new HTTP routes; no capability tag advertised. Reference patterns: claude-code's `permissions/filesystem.ts` (chain-aware symlink walk, Windows attack-pattern detection) and opencode's `File.Service` shape.

## What changed

**New module** under `packages/cli/src/serve/fs/`:

- `paths.ts` — extracts `canonicalizeWorkspace` from `httpAcpBridge.ts` (re-exported there for backward compat) and adds:
  - `ResolvedPath` brand and `Intent` union (`read | write | edit | list | glob | stat`)
  - `hasSuspiciousPathPattern` — rejects NTFS ADS, 8.3 short names, long-path / UNC / device prefixes, trailing dots, DOS device names, three-or-more-dot path components
  - `findExistingAncestor` with explicit ENOTDIR rejection (a regular file in a path component throws `parse_error` rather than passing boundary inspection and 500-ing later)
  - `resolveWithinWorkspace` running a chain-aware realpath check with ENOENT-tolerant ancestor walk for write/stat intents
- `errors.ts` — `FsError` / `FsErrorKind` plus `wrapAsFsError`, which categorizes raw `fs.promises` errnos (EACCES → `permission_denied`, ELOOP → `symlink_escape`, ENOTDIR/EISDIR → `parse_error`, etc.) so body-level failures emit audit events instead of escaping uncategorized
- `policy.ts` — `MAX_READ_BYTES` (256 KiB), `MAX_WRITE_BYTES` (5 MiB), `BINARY_PROBE_BYTES` (4 KiB), `shouldIgnore` (file/directory aware), and `assertTrustedForIntent` with an exhaustive switch over `Intent`
- `audit.ts` — typed `fs.access` / `fs.denied` `BridgeEvent` frames with SHA-256-hashed paths, optional raw-path passthrough via `QWEN_AUDIT_RAW_PATHS=1`, and discriminator `kind` fields on payloads so SDK consumers can exhaustively narrow `event.data`
- `workspaceFileSystem.ts` — `WorkspaceFileSystem` interface + `createWorkspaceFileSystemFactory` with eight methods (resolve, stat, readText, readBytes, list, glob, writeText, edit). Every body method funnels failures through `recordAndWrap`, which wraps raw fs errors and **always** emits an `fs.denied` audit event before rethrowing. `readText` enforces `MAX_READ_BYTES` *before* delegating to the slurping core service so unbounded requests against multi-gigabyte files cannot OOM the daemon. `glob` realpath-checks each hit and reports filtered escapes via a single aggregated `fs.denied` event
- `index.ts` — barrel re-export PR 19/20 will import from

**Modified:**
- `packages/cli/src/serve/httpAcpBridge.ts` — extracted `canonicalizeWorkspace` to `fs/paths.ts`; bridge re-exports it so existing callers in `server.ts` and `runQwenServe.ts` keep working (-68 lines from the bridge body)
- `packages/cli/src/serve/server.ts` — added `fsFactory?: WorkspaceFileSystemFactory` to `ServeAppDeps`; default factory uses `trusted: false` + warn-once no-op `emit` so a future refactor that forgets `fsFactory` injection cannot silently allow writes against an untrusted workspace; factory parked on `app.locals` for PR 19/20 route handlers
- `packages/core/src/index.ts` — re-exports `Ignore`, `loadIgnoreRules`, `LoadIgnoreRulesOptions` for cli consumption

## Self-review fixes applied

Three review agents ran against the working tree before commit; the following were fixed in-PR rather than deferred:

- **P0 silent failures**: `recordAndWrap` always emits audit + raw fs errnos always wrapped via `wrapAsFsError`. Previously raw `EACCES` / `ELOOP` / `ENOTDIR` from `fsp.lstat` / `readFile` / `readdir` / `globAsync` escaped uncategorized and audit was lost.
- **P0 OOM**: `readText` stats first; rejects `> MAX_READ_BYTES` with a typed `file_too_large` *before* delegating to the slurping `readFileWithLineAndLimit` (which would have OOM'd on a multi-GB text file).
- **P0 escape audit**: `glob` realpath-checks each hit's symlink chain; filtered escapes report a single aggregated `fs.denied` (with dropped count) instead of being silently `continue`'d.
- **P0 intent drift**: `'edit'` now in `Intent` union; `assertTrustedForIntent` is exhaustive (`never` guard) so future intent additions become compile errors at the trust gate.
- **P0 unsafe default**: `createServeApp` default factory uses `trusted: false` so an upstream refactor forgetting `fsFactory` injection refuses writes rather than silently allowing them.
- **P1 type tightenings**: ENOTDIR → `parse_error` (not silent ancestor walk); audit payloads carry `kind` discriminator for SDK exhaustive-switch; truncation always surfaced in `meta.truncated` even when `lowFs.limit` clipped via line count.

## Acceptance checklist (#4175)

- [x] Independently mergeable (no new routes, no new capability tag)
- [x] Backward compatible (no removed routes / event fields / CLI behavior)
- [x] Default off (no public surface change; PR 19/20 will activate routes)
- [x] `qwen serve` Stage 1 routes preserved
- [x] Gradual migration (PR 19/20 will adopt the boundary)
- [x] Reversible (single PR rollback)
- [x] Tests-first (101 unit tests across the new module + 10-case contract test)

## Deferred (P2 follow-ups, tracked here)

- `canonicalizeWorkspace` ENOENT fallback used as a security boundary (workspace deleted post-boot weakens the guarantee) — separate hardening PR.
- Extract `FsKind = 'file' | 'directory' | 'symlink' | 'other'` and reuse across `FsStat.kind` / `FsEntry.kind`.
- Compose `RequestContext` from `AuditContext` rather than `extends`-ing it.
- `FsError` default-status mapping vs explicit-status — drop the `options.status` override until a real callsite needs it.
- `audit.ts:relForAudit` cross-drive Windows behavior (returns absolute path; needs sentinel or pinning test on Windows runner).
- Contract test corpus could grow (deeply-nested symlink chains; `.qwenignore` smoke; Windows drive root edge).
- `path.join(p, name) as ResolvedPath` in `list` and `glob` is a brand cast — defensible since `list` returns dirent metadata and routes follow with explicit `resolve()`, but worth a `unsafeAsResolved()` helper if the pattern spreads.

## Test plan

- [x] `pnpm --filter @qwen-code/qwen-code test src/serve` — 411/411 passing
- [x] `npx tsc --noEmit` (cli + core) — clean
- [x] `git diff --stat` confirms only intended files changed (16 files, +3270/-68)
- [x] pre-commit hook passes (prettier + eslint --max-warnings 0)
- [ ] Cross-platform CI (macOS + Linux + Windows)
- [ ] Reviewer spot-check on the symlink chain walk and glob escape audit

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)