### PR TITLE
feat(tui): add daemon wire-up harness

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17283,6 +17283,7 @@
         "@modelcontextprotocol/sdk": "^1.25.1",
         "@qwen-code/channel-base": "file:../channels/base",
         "@qwen-code/channel-dingtalk": "file:../channels/dingtalk",
+        "@qwen-code/sdk": "file:../sdk-typescript",
         "@qwen-code/channel-telegram": "file:../channels/telegram",
         "@qwen-code/channel-weixin": "file:../channels/weixin",
         "@qwen-code/qwen-code-core": "file:../core",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@qwen-code/channel-base": "file:../channels/base",
     "@qwen-code/channel-dingtalk": "file:../channels/dingtalk",
+    "@qwen-code/sdk": "file:../sdk-typescript",
     "@qwen-code/channel-telegram": "file:../channels/telegram",
     "@qwen-code/channel-weixin": "file:../channels/weixin",
     "@qwen-code/qwen-code-core": "file:../core",

--- a/packages/cli/src/commands/daemon-tui.ts
+++ b/packages/cli/src/commands/daemon-tui.ts
@@ -1,0 +1,240 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule } from 'yargs';
+import { createInterface } from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import { writeStderrLine } from '../utils/stdioHelpers.js';
+import type {
+  DaemonTuiUpdate,
+  DaemonTuiSessionClient,
+} from '../ui/daemon/DaemonTuiAdapter.js';
+
+interface DaemonTuiArgs {
+  'daemon-url': string;
+  token?: string;
+  workspace?: string;
+  model?: string;
+  'session-id'?: string;
+  'session-scope'?: 'single' | 'thread';
+  prompt?: string;
+}
+
+function writeLine(line = ''): void {
+  output.write(`${line}\n`);
+}
+
+function formatHistoryItem(item: unknown): string {
+  if (!item || typeof item !== 'object') {
+    return String(item);
+  }
+  const record = item as Record<string, unknown>;
+  const type = typeof record['type'] === 'string' ? record['type'] : 'history';
+  const text =
+    typeof record['text'] === 'string'
+      ? record['text']
+      : JSON.stringify(record, null, 2);
+  return `[${type}] ${text}`;
+}
+
+function printDaemonUpdate(update: DaemonTuiUpdate): void {
+  switch (update.type) {
+    case 'history':
+      writeLine(formatHistoryItem(update.item));
+      break;
+    case 'tool_group_update':
+      writeLine('[tool]');
+      for (const tool of update.item.tools) {
+        writeLine(`  - ${tool.name}: ${tool.status}`);
+        if (tool.resultDisplay !== undefined) {
+          writeLine(`    ${JSON.stringify(tool.resultDisplay)}`);
+        }
+      }
+      break;
+    case 'permission_request':
+      writeLine(`[permission] ${update.requestId}`);
+      writeLine(
+        `  tool: ${update.request.toolCall.kind} (${update.request.toolCall.toolCallId})`,
+      );
+      for (const option of update.request.options) {
+        writeLine(`  - ${option.optionId}: ${option.name ?? option.optionId}`);
+      }
+      writeLine(`  approve with: /approve ${update.requestId} <optionId>`);
+      writeLine(`  reject with:  /reject ${update.requestId}`);
+      break;
+    case 'permission_resolved':
+      writeLine(
+        `[permission_resolved] ${update.requestId} ${JSON.stringify(
+          update.outcome,
+        )}`,
+      );
+      break;
+    case 'model_switched':
+      writeLine(`[model] ${update.modelId}`);
+      break;
+    case 'disconnected':
+      writeLine(`[disconnected] ${update.reason}`);
+      break;
+    default: {
+      const neverUpdate: never = update;
+      writeLine(JSON.stringify(neverUpdate));
+    }
+  }
+}
+
+async function createDaemonTuiSession(
+  argv: DaemonTuiArgs,
+): Promise<DaemonTuiSessionClient> {
+  const { DaemonClient, DaemonSessionClient } = await import('@qwen-code/sdk');
+  const client = new DaemonClient({
+    baseUrl: argv['daemon-url'],
+    token: argv.token ?? process.env['QWEN_SERVER_TOKEN'],
+  });
+  const workspaceCwd = argv.workspace ?? process.cwd();
+  if (argv['session-id']) {
+    return await DaemonSessionClient.load(client, argv['session-id'], {
+      workspaceCwd,
+    });
+  }
+  return await DaemonSessionClient.createOrAttach(client, {
+    workspaceCwd,
+    ...(argv.model ? { modelServiceId: argv.model } : {}),
+    ...(argv['session-scope'] ? { sessionScope: argv['session-scope'] } : {}),
+  });
+}
+
+async function runPrompt(
+  session: DaemonTuiSessionClient,
+  prompt: string,
+): Promise<void> {
+  const { DaemonTuiAdapter } = await import('../ui/daemon/DaemonTuiAdapter.js');
+  const adapter = new DaemonTuiAdapter({
+    session,
+    onUpdate: printDaemonUpdate,
+  });
+  await adapter.start();
+  try {
+    await adapter.sendPrompt(prompt);
+  } finally {
+    await adapter.stop();
+  }
+}
+
+async function runInteractive(session: DaemonTuiSessionClient): Promise<void> {
+  const { DaemonTuiAdapter } = await import('../ui/daemon/DaemonTuiAdapter.js');
+  const adapter = new DaemonTuiAdapter({
+    session,
+    onUpdate: printDaemonUpdate,
+  });
+  await adapter.start();
+  const rl = createInterface({ input, output });
+  try {
+    writeLine(
+      `Connected to daemon session ${session.sessionId} (${session.workspaceCwd})`,
+    );
+    writeLine(
+      'Commands: /quit, /cancel, /model <id>, /approve <id> <option>, /reject <id>',
+    );
+    for (;;) {
+      const line = (await rl.question('qwen-daemon> ')).trim();
+      if (!line) {
+        continue;
+      }
+      if (line === '/quit' || line === '/exit') {
+        return;
+      }
+      if (line === '/cancel') {
+        await adapter.cancel();
+        continue;
+      }
+      if (line.startsWith('/model ')) {
+        await adapter.setModel(line.slice('/model '.length).trim());
+        continue;
+      }
+      if (line.startsWith('/approve ')) {
+        const [, requestId, optionId] = line.split(/\s+/, 3);
+        if (!requestId || !optionId) {
+          writeLine('usage: /approve <requestId> <optionId>');
+          continue;
+        }
+        await adapter.approvePermission(requestId, optionId);
+        continue;
+      }
+      if (line.startsWith('/reject ')) {
+        const [, requestId] = line.split(/\s+/, 2);
+        if (!requestId) {
+          writeLine('usage: /reject <requestId>');
+          continue;
+        }
+        await adapter.rejectPermission(requestId);
+        continue;
+      }
+      await adapter.sendPrompt(line);
+    }
+  } finally {
+    rl.close();
+    await adapter.stop();
+  }
+}
+
+export const daemonTuiCommand: CommandModule<unknown, DaemonTuiArgs> = {
+  command: 'daemon-tui',
+  describe:
+    'Experimental local harness for driving the TUI daemon adapter against qwen serve',
+  builder: (yargs) =>
+    yargs
+      .option('daemon-url', {
+        type: 'string',
+        default: process.env['QWEN_DAEMON_URL'] ?? 'http://127.0.0.1:4170',
+        description: 'Base URL of a running qwen serve daemon.',
+      })
+      .option('token', {
+        type: 'string',
+        description:
+          'Bearer token for the daemon. Defaults to QWEN_SERVER_TOKEN.',
+      })
+      .option('workspace', {
+        type: 'string',
+        description:
+          'Workspace cwd to pass to POST /session. Defaults to process.cwd().',
+      })
+      .option('model', {
+        type: 'string',
+        description: 'Optional model service id for the daemon session.',
+      })
+      .option('session-id', {
+        type: 'string',
+        description:
+          'Attach to an existing daemon session via POST /session/:id/load.',
+      })
+      .option('session-scope', {
+        type: 'string',
+        choices: ['single', 'thread'] as const,
+        description:
+          'Optional session scope override for new sessions. Omit to use the daemon default.',
+      })
+      .option('prompt', {
+        type: 'string',
+        description:
+          'Send one prompt and exit. Omit for an interactive validation loop.',
+      }),
+  handler: async (argv) => {
+    try {
+      const session = await createDaemonTuiSession(argv);
+      if (argv.prompt) {
+        await runPrompt(session, argv.prompt);
+      } else {
+        await runInteractive(session);
+      }
+    } catch (err) {
+      writeStderrLine(
+        `qwen daemon-tui: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(1);
+    }
+    process.exit(0);
+  },
+};

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -59,6 +59,7 @@ import { channelCommand } from '../commands/channel.js';
 import { authCommand } from '../commands/auth.js';
 import { reviewCommand } from '../commands/review.js';
 import { serveCommand } from '../commands/serve.js';
+import { daemonTuiCommand } from '../commands/daemon-tui.js';
 
 // UUID v4 regex pattern for validation
 const SESSION_ID_REGEX =
@@ -1002,7 +1003,9 @@ export async function parseArguments(): Promise<CliArgs> {
     // Register /review skill helpers (presubmit checks, cleanup)
     .command(reviewCommand)
     // Register `qwen serve` (Stage 1 daemon — see issue #3803)
-    .command(serveCommand);
+    .command(serveCommand)
+    // Register experimental daemon TUI wire-up harness.
+    .command(daemonTuiCommand);
 
   yargsInstance
     .version(await getCliVersion()) // This will enable the --version flag based on package.json
@@ -1026,7 +1029,8 @@ export async function parseArguments(): Promise<CliArgs> {
       result._[0] === 'auth' ||
       result._[0] === 'hooks' ||
       result._[0] === 'channel' ||
-      result._[0] === 'review')
+      result._[0] === 'review' ||
+      result._[0] === 'daemon-tui')
   ) {
     // Note: `serve` is intentionally NOT in this list. Its handler blocks
     // forever (after the listener is up); SIGINT/SIGTERM in runQwenServe


### PR DESCRIPTION
## Summary

- What changed: Adds an explicit `qwen daemon-tui` developer harness that connects to a running `qwen serve` daemon through `DaemonClient` / `DaemonSessionClient`, feeds daemon events through `DaemonTuiAdapter`, and exposes prompt, cancel, model switch, and permission response commands for local validation.
- Why it changed: Lets reviewers manually verify the TUI daemon adapter path before replacing the production Ink TUI state loop.
- Reviewer focus: Confirm this stays opt-in, does not affect the default `qwen` TUI path, and is suitable as a stacked validation PR on top of the TUI daemon adapter draft.

## Validation

- Commands run:
  ```bash
  npm run build

  env -u NODE_OPTIONS QWEN_CODE_NO_RELAUNCH=1 \
    node packages/cli/dist/index.js serve \
    --port 4870 \
    --workspace "$PWD"

  env -u NODE_OPTIONS QWEN_CODE_NO_RELAUNCH=1 \
    node packages/cli/dist/index.js daemon-tui \
    --daemon-url http://127.0.0.1:4870 \
    --workspace "$PWD" \
    --prompt "只回答 OK"
  ```
- Prompts / inputs used:
  - `只回答 OK`
- Expected result:
  - The daemon starts on loopback and binds the current workspace.
  - `daemon-tui` creates/attaches a daemon session through HTTP + SSE and prints assistant output.
  - Normal TUI startup remains unchanged because the daemon harness only runs via `qwen daemon-tui`.
- Observed result:
  - Build completed successfully. VS Code companion lint reported one existing warning in `packages/vscode-ide-companion/src/utils/editorGroupUtils.ts`, unrelated to this PR.
  - `daemon-tui` printed streamed thought/content chunks and final content `OK`.
- Quickest reviewer verification path:
  ```bash
  npm run build

  # Terminal A. Use the built CLI for serve. Do not use `npm run dev -- serve`:
  # Stage 1 serve spawns a raw-node `qwen --acp` child, and dev-mode NODE_OPTIONS
  # remaps packages to TS sources that the raw child cannot load.
  env -u NODE_OPTIONS QWEN_CODE_NO_RELAUNCH=1 \
    node packages/cli/dist/index.js serve \
    --port 4170 \
    --workspace "$PWD"

  # Terminal B.
  env -u NODE_OPTIONS QWEN_CODE_NO_RELAUNCH=1 \
    node packages/cli/dist/index.js daemon-tui \
    --daemon-url http://127.0.0.1:4170 \
    --workspace "$PWD" \
    --prompt "say hello"
  ```
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  ```text
  qwen serve listening on http://127.0.0.1:4870 (mode=http-bridge, workspace=/Users/gawain/Documents/codebase/opensource/qwen-code)
  qwen serve: bound to workspace "/Users/gawain/Documents/codebase/opensource/qwen-code"
  qwen serve: bearer auth disabled (loopback default). Set QWEN_SERVER_TOKEN to enable.

  [gemini_thought_content] The
  [gemini_thought_content]  user wants
  [gemini_thought_content]  me to just reply
  [gemini_thought_content]  "OK". Simple
  [gemini_thought_content]  request, I'll
  [gemini_thought_content]  comply.
  [gemini_content] OK
  ```

## Scope / Risk

- Main risk or tradeoff: This is a text-mode harness, not the final Ink TUI replacement. It intentionally validates the daemon adapter boundary first.
- Not covered / not validated: Manual permission approval flow was not validated in this local smoke run.
- Breaking changes / migration notes: None expected. The existing TUI path is not rewired, and daemon mode is only entered through the new explicit command.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Validated on macOS via built CLI daemon + built CLI daemon-tui smoke path.

## Linked Issues / Bugs

- Related to #3803
- Stacked on #4202
