### PR TITLE
feat(channel): add daemon bridge wire-up

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17283,6 +17283,7 @@
         "@modelcontextprotocol/sdk": "^1.25.1",
         "@qwen-code/channel-base": "file:../channels/base",
         "@qwen-code/channel-dingtalk": "file:../channels/dingtalk",
+        "@qwen-code/sdk": "file:../sdk-typescript",
         "@qwen-code/channel-telegram": "file:../channels/telegram",
         "@qwen-code/channel-weixin": "file:../channels/weixin",
         "@qwen-code/qwen-code-core": "file:../core",

--- a/packages/channels/base/src/AcpBridge.ts
+++ b/packages/channels/base/src/AcpBridge.ts
@@ -35,7 +35,22 @@ export interface ToolCallEvent {
   rawInput?: Record<string, unknown>;
 }
 
-export class AcpBridge extends EventEmitter {
+export interface ChannelBridge extends EventEmitter {
+  readonly availableCommands: AvailableCommand[];
+  start(): Promise<void>;
+  newSession(cwd: string): Promise<string>;
+  loadSession(sessionId: string, cwd: string): Promise<string>;
+  prompt(
+    sessionId: string,
+    text: string,
+    options?: { imageBase64?: string; imageMimeType?: string },
+  ): Promise<string>;
+  cancelSession(sessionId: string): Promise<void>;
+  stop(): void;
+  readonly isConnected: boolean;
+}
+
+export class AcpBridge extends EventEmitter implements ChannelBridge {
   private child: ChildProcess | null = null;
   private connection: ClientSideConnection | null = null;
   private options: AcpBridgeOptions;

--- a/packages/channels/base/src/ChannelBase.ts
+++ b/packages/channels/base/src/ChannelBase.ts
@@ -4,7 +4,7 @@ import { GroupGate } from './GroupGate.js';
 import { SenderGate } from './SenderGate.js';
 import { PairingStore } from './PairingStore.js';
 import { SessionRouter } from './SessionRouter.js';
-import type { AcpBridge, ToolCallEvent } from './AcpBridge.js';
+import type { ChannelBridge, ToolCallEvent } from './AcpBridge.js';
 
 export interface ChannelBaseOptions {
   router?: SessionRouter;
@@ -16,7 +16,7 @@ type CommandHandler = (envelope: Envelope, args: string) => Promise<boolean>;
 
 export abstract class ChannelBase {
   protected config: ChannelConfig;
-  protected bridge: AcpBridge;
+  protected bridge: ChannelBridge;
   protected groupGate: GroupGate;
   protected gate: SenderGate;
   protected router: SessionRouter;
@@ -42,7 +42,7 @@ export abstract class ChannelBase {
   constructor(
     name: string,
     config: ChannelConfig,
-    bridge: AcpBridge,
+    bridge: ChannelBridge,
     options?: ChannelBaseOptions,
   ) {
     this.name = name;
@@ -82,7 +82,7 @@ export abstract class ChannelBase {
   abstract disconnect(): void;
 
   /** Replace the bridge instance (used after crash recovery restart). */
-  setBridge(bridge: AcpBridge): void {
+  setBridge(bridge: ChannelBridge): void {
     this.bridge = bridge;
   }
 

--- a/packages/channels/base/src/SessionRouter.ts
+++ b/packages/channels/base/src/SessionRouter.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
 import type { SessionScope, SessionTarget } from './types.js';
-import type { AcpBridge } from './AcpBridge.js';
+import type { ChannelBridge } from './AcpBridge.js';
 
 interface PersistedEntry {
   sessionId: string;
@@ -13,14 +13,14 @@ export class SessionRouter {
   private toTarget: Map<string, SessionTarget> = new Map(); // session ID → target
   private toCwd: Map<string, string> = new Map(); // session ID → cwd
 
-  private bridge: AcpBridge;
+  private bridge: ChannelBridge;
   private defaultCwd: string;
   private defaultScope: SessionScope;
   private channelScopes: Map<string, SessionScope> = new Map();
   private persistPath: string | undefined;
 
   constructor(
-    bridge: AcpBridge,
+    bridge: ChannelBridge,
     defaultCwd: string,
     scope: SessionScope = 'user',
     persistPath?: string,
@@ -32,7 +32,7 @@ export class SessionRouter {
   }
 
   /** Replace the bridge instance (used after crash recovery restart). */
-  setBridge(bridge: AcpBridge): void {
+  setBridge(bridge: ChannelBridge): void {
     this.bridge = bridge;
   }
 

--- a/packages/channels/base/src/index.ts
+++ b/packages/channels/base/src/index.ts
@@ -3,6 +3,7 @@ export { AcpBridge } from './AcpBridge.js';
 export type {
   AcpBridgeOptions,
   AvailableCommand,
+  ChannelBridge,
   ToolCallEvent,
 } from './AcpBridge.js';
 export { DaemonChannelBridge } from './DaemonChannelBridge.js';

--- a/packages/channels/base/src/types.ts
+++ b/packages/channels/base/src/types.ts
@@ -1,4 +1,4 @@
-import type { AcpBridge } from './AcpBridge.js';
+import type { ChannelBridge } from './AcpBridge.js';
 import type { ChannelBase, ChannelBaseOptions } from './ChannelBase.js';
 
 export type SenderPolicy = 'allowlist' | 'pairing' | 'open';
@@ -114,7 +114,7 @@ export interface ChannelPlugin {
   createChannel(
     name: string,
     config: ChannelConfig & Record<string, unknown>,
-    bridge: AcpBridge,
+    bridge: ChannelBridge,
     options?: ChannelBaseOptions,
   ): ChannelBase;
 }

--- a/packages/channels/dingtalk/src/DingtalkAdapter.ts
+++ b/packages/channels/dingtalk/src/DingtalkAdapter.ts
@@ -11,7 +11,7 @@ import type {
   ChannelConfig,
   ChannelBaseOptions,
   Envelope,
-  AcpBridge,
+  ChannelBridge,
 } from '@qwen-code/channel-base';
 
 /**
@@ -86,7 +86,7 @@ export class DingtalkChannel extends ChannelBase {
   constructor(
     name: string,
     config: ChannelConfig,
-    bridge: AcpBridge,
+    bridge: ChannelBridge,
     options?: ChannelBaseOptions,
   ) {
     super(name, config, bridge, options);

--- a/packages/channels/plugin-example/src/MockPluginChannel.ts
+++ b/packages/channels/plugin-example/src/MockPluginChannel.ts
@@ -3,7 +3,7 @@ import type {
   ChannelConfig,
   ChannelBaseOptions,
   Envelope,
-  AcpBridge,
+  ChannelBridge,
 } from '@qwen-code/channel-base';
 import WebSocket from 'ws';
 import type {
@@ -24,7 +24,7 @@ export class MockPluginChannel extends ChannelBase {
   constructor(
     name: string,
     config: MockPluginConfig & Record<string, unknown>,
-    bridge: AcpBridge,
+    bridge: ChannelBridge,
     options?: ChannelBaseOptions,
   ) {
     super(name, config, bridge, options);

--- a/packages/channels/telegram/src/TelegramAdapter.ts
+++ b/packages/channels/telegram/src/TelegramAdapter.ts
@@ -13,7 +13,7 @@ import type {
   ChannelConfig,
   ChannelBaseOptions,
   Envelope,
-  AcpBridge,
+  ChannelBridge,
 } from '@qwen-code/channel-base';
 
 export class TelegramChannel extends ChannelBase {
@@ -24,7 +24,7 @@ export class TelegramChannel extends ChannelBase {
   constructor(
     name: string,
     config: ChannelConfig,
-    bridge: AcpBridge,
+    bridge: ChannelBridge,
     options?: ChannelBaseOptions,
   ) {
     super(name, config, bridge, options);

--- a/packages/channels/weixin/src/WeixinAdapter.ts
+++ b/packages/channels/weixin/src/WeixinAdapter.ts
@@ -12,7 +12,7 @@ import type {
   ChannelConfig,
   ChannelBaseOptions,
   Envelope,
-  AcpBridge,
+  ChannelBridge,
 } from '@qwen-code/channel-base';
 import { loadAccount, DEFAULT_BASE_URL } from './accounts.js';
 import { startPollLoop, getContextToken } from './monitor.js';
@@ -38,7 +38,7 @@ export class WeixinChannel extends ChannelBase {
   constructor(
     name: string,
     config: ChannelConfig,
-    bridge: AcpBridge,
+    bridge: ChannelBridge,
     options?: ChannelBaseOptions,
   ) {
     super(name, config, bridge, options);

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@qwen-code/channel-base": "file:../channels/base",
     "@qwen-code/channel-dingtalk": "file:../channels/dingtalk",
+    "@qwen-code/sdk": "file:../sdk-typescript",
     "@qwen-code/channel-telegram": "file:../channels/telegram",
     "@qwen-code/channel-weixin": "file:../channels/weixin",
     "@qwen-code/qwen-code-core": "file:../core",

--- a/packages/cli/src/commands/channel/start.ts
+++ b/packages/cli/src/commands/channel/start.ts
@@ -4,10 +4,17 @@ import { ProxyAgent, setGlobalDispatcher } from 'undici';
 import { normalizeProxyUrl, Storage } from '@qwen-code/qwen-code-core';
 import { loadSettings } from '../../config/settings.js';
 import { writeStderrLine, writeStdoutLine } from '../../utils/stdioHelpers.js';
-import { AcpBridge, SessionRouter } from '@qwen-code/channel-base';
+import {
+  AcpBridge,
+  DaemonChannelBridge,
+  SessionRouter,
+} from '@qwen-code/channel-base';
 import type {
   ChannelBase,
+  ChannelBridge,
   ChannelPlugin,
+  DaemonChannelSessionFactoryRequest,
+  SessionScope,
   ToolCallEvent,
 } from '@qwen-code/channel-base';
 import { getPlugin, registerPlugin } from './channel-registry.js';
@@ -22,6 +29,18 @@ import { getExtensionManager } from '../extensions/utils.js';
 const MAX_CRASH_RESTARTS = 3;
 const CRASH_WINDOW_MS = 5 * 60 * 1000; // 5-minute window for counting crashes
 const RESTART_DELAY_MS = 3000;
+
+interface ChannelStartRuntimeOptions {
+  proxy?: string;
+  daemonUrl?: string;
+  daemonToken?: string;
+}
+
+interface ChannelStartArgs {
+  name?: string;
+  'daemon-url'?: string;
+  'daemon-token'?: string;
+}
 
 /**
  * Resolve and apply proxy settings for the channel service process.
@@ -129,7 +148,7 @@ async function loadChannelsFromExtensions(): Promise<number> {
 async function createChannel(
   name: string,
   config: Awaited<ReturnType<typeof parseChannelConfig>>,
-  bridge: AcpBridge,
+  bridge: ChannelBridge,
   options?: { router?: SessionRouter; proxy?: string },
 ): Promise<ChannelBase> {
   const channelPlugin = await getPlugin(config.type);
@@ -140,7 +159,7 @@ async function createChannel(
 }
 
 function registerToolCallDispatch(
-  bridge: AcpBridge,
+  bridge: ChannelBridge,
   router: SessionRouter,
   channels: Map<string, ChannelBase>,
 ): void {
@@ -153,6 +172,64 @@ function registerToolCallDispatch(
       }
     }
   });
+}
+
+function resolveDaemonUrl(cliDaemonUrl?: string): string | undefined {
+  return (
+    cliDaemonUrl ||
+    process.env['QWEN_CHANNEL_DAEMON_URL'] ||
+    process.env['QWEN_DAEMON_URL']
+  );
+}
+
+function resolveDaemonToken(cliDaemonToken?: string): string | undefined {
+  return cliDaemonToken || process.env['QWEN_SERVER_TOKEN'];
+}
+
+function toDaemonSessionScope(scope: SessionScope | undefined): 'thread' {
+  // SessionRouter already owns channel/user/thread/single routing. Force daemon
+  // sessions to be distinct so daemon-level `single` coalescing cannot collapse
+  // independent channel conversations.
+  void scope;
+  return 'thread';
+}
+
+async function createBridge(
+  bridgeOpts: { cliEntryPath: string; cwd: string; model?: string },
+  options: ChannelStartRuntimeOptions,
+  sessionScope?: SessionScope,
+): Promise<ChannelBridge> {
+  if (!options.daemonUrl) {
+    const bridge = new AcpBridge(bridgeOpts);
+    await bridge.start();
+    return bridge;
+  }
+
+  const { DaemonClient, DaemonSessionClient } = await import('@qwen-code/sdk');
+  const client = new DaemonClient({
+    baseUrl: options.daemonUrl,
+    token: options.daemonToken,
+  });
+  const bridge = new DaemonChannelBridge({
+    cwd: bridgeOpts.cwd,
+    modelServiceId: bridgeOpts.model,
+    sessionScope: toDaemonSessionScope(sessionScope),
+    sessionFactory: async (req: DaemonChannelSessionFactoryRequest) => {
+      if (req.sessionId) {
+        return await DaemonSessionClient.load(client, req.sessionId, {
+          workspaceCwd: req.workspaceCwd,
+        });
+      }
+      return await DaemonSessionClient.createOrAttach(client, {
+        workspaceCwd: req.workspaceCwd,
+        modelServiceId: req.modelServiceId,
+        sessionScope: toDaemonSessionScope(req.sessionScope),
+      });
+    },
+  });
+  await bridge.start();
+  writeStdoutLine(`[Channel] Using daemon bridge at ${options.daemonUrl}.`);
+  return bridge;
 }
 
 /** Check for duplicate instance and abort if one is already running. */
@@ -168,7 +245,10 @@ function checkDuplicateInstance(): void {
 }
 
 /** Start a single channel with its own bridge + crash recovery. */
-async function startSingle(name: string, proxy?: string): Promise<void> {
+async function startSingle(
+  name: string,
+  options: ChannelStartRuntimeOptions,
+): Promise<void> {
   checkDuplicateInstance();
   const channelsConfig = loadChannelsConfig();
 
@@ -199,8 +279,7 @@ async function startSingle(name: string, proxy?: string): Promise<void> {
   const crashTimestamps: number[] = [];
 
   const bridgeOpts = { cliEntryPath, cwd: config.cwd, model: config.model };
-  let bridge = new AcpBridge(bridgeOpts);
-  await bridge.start();
+  let bridge = await createBridge(bridgeOpts, options, config.sessionScope);
 
   const router = new SessionRouter(
     bridge,
@@ -210,7 +289,10 @@ async function startSingle(name: string, proxy?: string): Promise<void> {
   );
   const channels: Map<string, ChannelBase> = new Map();
 
-  const channel = await createChannel(name, config, bridge, { router, proxy });
+  const channel = await createChannel(name, config, bridge, {
+    router,
+    proxy: options.proxy,
+  });
   channels.set(name, channel);
   registerToolCallDispatch(bridge, router, channels);
 
@@ -227,7 +309,7 @@ async function startSingle(name: string, proxy?: string): Promise<void> {
   writeServiceInfo([name]);
   writeStdoutLine(`[Channel] "${name}" is running. Press Ctrl+C to stop.`);
 
-  const attachDisconnectHandler = (b: AcpBridge): void => {
+  const attachDisconnectHandler = (b: ChannelBridge): void => {
     b.on('disconnected', async () => {
       if (shuttingDown) return;
 
@@ -254,8 +336,7 @@ async function startSingle(name: string, proxy?: string): Promise<void> {
       await new Promise((r) => setTimeout(r, RESTART_DELAY_MS));
 
       try {
-        bridge = new AcpBridge(bridgeOpts);
-        await bridge.start();
+        bridge = await createBridge(bridgeOpts, options, config.sessionScope);
         router.setBridge(bridge);
         channel.setBridge(bridge);
         registerToolCallDispatch(bridge, router, channels);
@@ -290,7 +371,7 @@ async function startSingle(name: string, proxy?: string): Promise<void> {
 }
 
 /** Start all configured channels with a shared bridge + crash recovery. */
-async function startAll(proxy?: string): Promise<void> {
+async function startAll(options: ChannelStartRuntimeOptions): Promise<void> {
   checkDuplicateInstance();
   const channelsConfig = loadChannelsConfig();
 
@@ -342,8 +423,7 @@ async function startAll(proxy?: string): Promise<void> {
     cwd: defaultCwd,
     model: models[0],
   };
-  let bridge = new AcpBridge(bridgeOpts);
-  await bridge.start();
+  let bridge = await createBridge(bridgeOpts, options, 'thread');
 
   const router = new SessionRouter(bridge, defaultCwd, 'user', sessionsPath());
   // Register per-channel scope overrides so each channel uses its own sessionScope
@@ -359,7 +439,10 @@ async function startAll(proxy?: string): Promise<void> {
   for (const { name, config } of parsed) {
     channels.set(
       name,
-      await createChannel(name, config, bridge, { router, proxy }),
+      await createChannel(name, config, bridge, {
+        router,
+        proxy: options.proxy,
+      }),
     );
   }
   registerToolCallDispatch(bridge, router, channels);
@@ -389,7 +472,7 @@ async function startAll(proxy?: string): Promise<void> {
     `[Channel] Running ${connectedCount} channel(s). Press Ctrl+C to stop.`,
   );
 
-  const attachDisconnectHandler = (b: AcpBridge): void => {
+  const attachDisconnectHandler = (b: ChannelBridge): void => {
     b.on('disconnected', async () => {
       if (shuttingDown) return;
 
@@ -421,8 +504,7 @@ async function startAll(proxy?: string): Promise<void> {
       await new Promise((r) => setTimeout(r, RESTART_DELAY_MS));
 
       try {
-        bridge = new AcpBridge(bridgeOpts);
-        await bridge.start();
+        bridge = await createBridge(bridgeOpts, options, 'thread');
         router.setBridge(bridge);
         for (const channel of channels.values()) {
           channel.setBridge(bridge);
@@ -465,24 +547,40 @@ async function startAll(proxy?: string): Promise<void> {
   await new Promise<void>(() => {});
 }
 
-export const startCommand: CommandModule<object, { name?: string }> = {
+export const startCommand: CommandModule<object, ChannelStartArgs> = {
   command: 'start [name]',
   describe: 'Start channels (all if no name given, or a single named channel)',
   builder: (yargs) =>
-    yargs.positional('name', {
-      type: 'string',
-      describe: 'Channel name (omit to start all configured channels)',
-    }),
+    yargs
+      .positional('name', {
+        type: 'string',
+        describe: 'Channel name (omit to start all configured channels)',
+      })
+      .option('daemon-url', {
+        type: 'string',
+        description:
+          'Experimental: use a running qwen serve daemon instead of spawning an ACP bridge. Defaults to QWEN_CHANNEL_DAEMON_URL or QWEN_DAEMON_URL.',
+      })
+      .option('daemon-token', {
+        type: 'string',
+        description:
+          'Bearer token for the daemon bridge. Defaults to QWEN_SERVER_TOKEN.',
+      }),
   handler: async (argv) => {
     const settings = loadSettings(process.cwd());
     const proxy = resolveProxy(
       (argv as Record<string, unknown>)['proxy'] as string | undefined,
       settings.merged.proxy as string | undefined,
     );
+    const runtimeOptions = {
+      proxy,
+      daemonUrl: resolveDaemonUrl(argv['daemon-url']),
+      daemonToken: resolveDaemonToken(argv['daemon-token']),
+    };
     if (argv.name) {
-      await startSingle(argv.name, proxy);
+      await startSingle(argv.name, runtimeOptions);
     } else {
-      await startAll(proxy);
+      await startAll(runtimeOptions);
     }
   },
 };


### PR DESCRIPTION
## Summary

- What changed: Adds an opt-in daemon bridge path for `qwen channel start` via `--daemon-url`, `QWEN_CHANNEL_DAEMON_URL`, or `QWEN_DAEMON_URL`. The existing ACP bridge remains the default. Channel internals now depend on a structural `ChannelBridge` interface so either the existing `AcpBridge` or the new `DaemonChannelBridge` can drive sessions.
- Why it changed: Provides a local validation path for channel/web clients to consume daemon sessions through HTTP + SSE without replacing the current channel service by default.
- Reviewer focus: Confirm the default `AcpBridge` path is unchanged, daemon mode is explicit, and routing still stays owned by `SessionRouter` rather than daemon-level single-session coalescing.

## Validation

- Commands run:
  ```bash
  npm run build --workspace=@qwen-code/channel-base
  npm run dev -- channel start --help
  cd packages/cli && npx tsc --noEmit --pretty false
  ```
- Prompts / inputs used:
  - `channel start --help`
- Expected result:
  - Channel base builds.
  - `qwen channel start` advertises the daemon bridge flags.
  - Without daemon flags/env vars, startup still instantiates the existing ACP bridge.
- Observed result:
  - Channel base build passed.
  - Help output showed `--daemon-url` and `--daemon-token`.
  - After rebasing onto current `main`, package-local CLI typecheck is blocked by unrelated `goalCommand` errors from files not touched by this PR: `GoalTerminalKind` no longer accepts `"failed"`.
- Quickest reviewer verification path:
  ```bash
  npm run dev -- serve --port 4170 --workspace "$PWD"
  QWEN_CHANNEL_DAEMON_URL=http://127.0.0.1:4170 npm run dev -- channel start <configured-channel-name>
  ```
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  - Local help output confirmed the opt-in flags are registered.

## Scope / Risk

- Main risk or tradeoff: This introduces a shared bridge interface used by channel adapters. The surface is intentionally the existing ACP bridge surface so built-in channels keep their behavior.
- Not covered / not validated: A real external channel service was not connected in this commit.
- Breaking changes / migration notes: None expected for default users. Daemon mode requires an explicit flag or environment variable.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Validated on macOS via package build and `npm run dev -- channel start --help`.

## Linked Issues / Bugs

- Related to #3803
- Builds on the merged #4203 daemon channel bridge adapter
