### PR TITLE
fix(core): apply defaultModalities() on env-var-only model config (#4219)

### DIFF
--- a/packages/core/src/models/modelConfigResolver.test.ts
+++ b/packages/core/src/models/modelConfigResolver.test.ts
@@ -886,6 +886,58 @@ describe('modelConfigResolver', () => {
       // in modelsConfig.ts applyResolvedModelDefaults() lines 791-797.
       expect(result.config.modalities).toBeDefined();
       expect(result.config.modalities?.image).toBe(true);
+      expect(result.config.modalities?.video).toBe(true);
+      expect(result.sources['modalities'].kind).toBe('computed');
+    });
+
+    it('env-var-only path: modalities defaults to {} for unknown model (text-only)', () => {
+      // Locks the invariant: defaultModalities() returns {} (text-only) for
+      // unknown model patterns, never undefined. After this fix, env-var-only
+      // setups never re-expose `modalities === undefined` for downstream
+      // consumers to misinterpret as "unresolved" (issue #4219).
+      const result = resolveModelConfig({
+        authType: AuthType.USE_OPENAI,
+        cli: {},
+        settings: {},
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          OPENAI_BASE_URL: 'http://localhost:8000/v1',
+          OPENAI_MODEL: 'some-unknown-model-xyz',
+        },
+      });
+
+      expect(result.config.modalities).toEqual({});
+      expect(result.sources['modalities'].kind).toBe('computed');
+    });
+
+    it('env-var-only path: explicit settings.generationConfig.modalities is not overridden by fallback', () => {
+      // Locks the `=== undefined` guard: when user explicitly configures
+      // modalities in settings, the fallback must not clobber them with
+      // defaultModalities() — even for a model whose name would otherwise
+      // auto-resolve to multimodal.
+      const result = resolveModelConfig({
+        authType: AuthType.USE_OPENAI,
+        cli: {},
+        settings: {
+          generationConfig: {
+            modalities: {
+              image: false,
+              pdf: false,
+              video: false,
+              audio: false,
+            },
+          },
+        },
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          OPENAI_BASE_URL: 'http://localhost:8000/v1',
+          OPENAI_MODEL: 'qwen3.6-35b-a3b', // defaultModalities → { image: true, video: true }
+        },
+      });
+
+      expect(result.config.modalities?.image).toBe(false);
+      expect(result.config.modalities?.video).toBe(false);
+      expect(result.sources['modalities'].kind).toBe('settings');
     });
   });
 });

--- a/packages/core/src/models/modelConfigResolver.test.ts
+++ b/packages/core/src/models/modelConfigResolver.test.ts
@@ -854,4 +854,38 @@ describe('modelConfigResolver', () => {
       }
     });
   });
+
+  describe('[Regression] issue-4219 — env-var-only path must call defaultModalities()', () => {
+    it('[Regression] env-var-only path: modalities auto-detected for qwen3.6-35b-a3b', () => {
+      // REPRODUCES issue-4219:
+      // When the model is supplied only via OPENAI_MODEL (no modelProviders entry),
+      // resolveGenerationConfig() iterates MODEL_GENERATION_CONFIG_FIELDS but never
+      // calls defaultModalities(). This leaves config.modalities undefined, causing
+      // image attachments to be silently dropped with an "Unsupported <modality>"
+      // message even though the model supports images.
+      //
+      // The modelRegistry path (resolveModelConfig -> resolveModelConfig in modelRegistry.ts)
+      // and the modelsConfig path (applyResolvedModelDefaults) both call defaultModalities()
+      // when generationConfig.modalities is undefined. The env-var-only path does not.
+      const result = resolveModelConfig({
+        authType: AuthType.USE_OPENAI,
+        cli: {},
+        settings: {},
+        env: {
+          OPENAI_API_KEY: 'test-key',
+          OPENAI_BASE_URL: 'http://localhost:8000/v1',
+          OPENAI_MODEL: 'qwen3.6-35b-a3b',
+        },
+        // No modelProvider — this is the env-var-only path
+      });
+
+      expect(result.config.model).toBe('qwen3.6-35b-a3b');
+
+      // The qwen3.6-35b pattern in modalityDefaults.ts maps to { image: true, video: true }.
+      // The env-var-only path must auto-detect this — just as the modelProviders path does
+      // in modelsConfig.ts applyResolvedModelDefaults() lines 791-797.
+      expect(result.config.modalities).toBeDefined();
+      expect(result.config.modalities?.image).toBe(true);
+    });
+  });
 });

--- a/packages/core/src/models/modelConfigResolver.test.ts
+++ b/packages/core/src/models/modelConfigResolver.test.ts
@@ -910,6 +910,28 @@ describe('modelConfigResolver', () => {
       expect(result.sources['modalities'].kind).toBe('computed');
     });
 
+    it('Qwen OAuth path: modalities auto-detected for default coder-model', () => {
+      // resolveGenerationConfig is shared by both the OpenAI and Qwen OAuth
+      // paths; the latter (resolveQwenOAuthConfig) passes the resolved Qwen
+      // OAuth model name (defaults to DEFAULT_QWEN_MODEL = 'coder-model') as
+      // modelId, so the new modalities fallback also fires here.
+      //
+      // modalityDefaults.ts maps /^coder-model$/ to { image: true, video: true }
+      // because the Qwen OAuth coder-model now supports vision (see warning
+      // text at modelConfigResolver.ts ~L330). This test pins that down so a
+      // future edit to MODALITY_PATTERNS doesn't silently regress OAuth.
+      const result = resolveModelConfig({
+        authType: AuthType.QWEN_OAUTH,
+        cli: {},
+        settings: {},
+        env: {},
+      });
+
+      expect(result.config.model).toBe(DEFAULT_QWEN_MODEL);
+      expect(result.config.modalities).toEqual({ image: true, video: true });
+      expect(result.sources['modalities'].kind).toBe('computed');
+    });
+
     it('env-var-only path: explicit settings.generationConfig.modalities is not overridden by fallback', () => {
       // Locks the `=== undefined` guard: when user explicitly configures
       // modalities in settings, the fallback must not clobber them with

--- a/packages/core/src/models/modelConfigResolver.ts
+++ b/packages/core/src/models/modelConfigResolver.ts
@@ -21,6 +21,7 @@
 import { AuthType } from '../core/contentGenerator.js';
 import type { ContentGeneratorConfig } from '../core/contentGenerator.js';
 import { DEFAULT_QWEN_MODEL } from '../config/models.js';
+import { defaultModalities } from '../core/modalityDefaults.js';
 import {
   resolveField,
   resolveOptionalField,
@@ -268,7 +269,7 @@ export function resolveModelConfig(
     settings?.generationConfig,
     modelProvider?.generationConfig,
     authType,
-    modelProvider?.id,
+    modelProvider?.id ?? modelResult.value,
     sources,
   );
 
@@ -394,6 +395,16 @@ function resolveGenerationConfig(
       (result as any)[field] = settingsConfig[field];
       sources[field] = settingsSource(`model.generationConfig.${field}`);
     }
+  }
+
+  // modalities fallback: auto-detect from model when neither modelProvider nor
+  // settings supplied it. Mirrors modelRegistry.resolveModelConfig and
+  // modelsConfig.applyResolvedModelDefaults so all paths agree on which models
+  // are multimodal — without this, env-var-only setups silently drop @image
+  // attachments for image-capable models (issue #4219).
+  if (result.modalities === undefined && modelId) {
+    result.modalities = defaultModalities(modelId);
+    sources['modalities'] = computedSource('auto-detected from model');
   }
 
   return result;

--- a/packages/core/src/models/modelConfigResolver.ts
+++ b/packages/core/src/models/modelConfigResolver.ts
@@ -402,6 +402,13 @@ function resolveGenerationConfig(
   // modelsConfig.applyResolvedModelDefaults so all paths agree on which models
   // are multimodal — without this, env-var-only setups silently drop @image
   // attachments for image-capable models (issue #4219).
+  //
+  // Invariant: defaultModalities() returns `{}` (text-only) for unknown
+  // models, never `undefined`. After this fallback runs with a known modelId,
+  // `result.modalities` is always defined. Downstream code must NOT branch
+  // on `modalities === undefined` to mean "unresolved" — use the sources map
+  // (kind === 'computed' vs 'modelProviders'/'settings') if that distinction
+  // matters.
   if (result.modalities === undefined && modelId) {
     result.modalities = defaultModalities(modelId);
     sources['modalities'] = computedSource('auto-detected from model');


### PR DESCRIPTION
## Summary

When qwen-code is configured **only via env vars** (`OPENAI_API_KEY` / `OPENAI_BASE_URL` / `OPENAI_MODEL`) with no `modelProviders` entry in `settings.json`, the env-var-only path through `resolveModelConfig` / `resolveGenerationConfig` (in [packages/core/src/models/modelConfigResolver.ts](packages/core/src/models/modelConfigResolver.ts)) never invoked `defaultModalities()`. So `generationConfig.modalities` stayed `undefined` for image-capable models — even when `defaultModalities()`'s regex (e.g. `/^qwen3\.6-35b/`) would have correctly matched. `@image` attachments were then silently replaced by the `[Unsupported <modality> file: ...]` placeholder.

The other two model-config paths already call `defaultModalities()` when modalities are undefined:
- `modelRegistry.resolveModelConfig` ([modelRegistry.ts:215-217](packages/core/src/models/modelRegistry.ts#L215-L217))
- `modelsConfig.applyResolvedModelDefaults` ([modelsConfig.ts:790-797](packages/core/src/models/modelsConfig.ts#L790-L797))

This PR aligns the env-var-only path with both so all three agree on which models are multimodal.

### Change

- Import `defaultModalities` in `modelConfigResolver.ts`.
- Pass `modelProvider?.id ?? modelResult.value` (instead of just `modelProvider?.id`) into `resolveGenerationConfig`, so the resolved model id is available when no `modelProvider` entry exists.
- At the end of `resolveGenerationConfig`, if `result.modalities` is still `undefined` and `modelId` is known, set `result.modalities = defaultModalities(modelId)` and mark the source as `computed('auto-detected from model')`.

Minimal, surgical change — no new flags, no behavior change for the `modelProviders` path.

Fixes #4219

## Test plan

- [x] Added regression test `[Regression] env-var-only path: modalities auto-detected for qwen3.6-35b-a3b` in [modelConfigResolver.test.ts](packages/core/src/models/modelConfigResolver.test.ts); it fails on `main` and passes with this change.
- [x] All 166 tests in `packages/core/src/models/` pass.
- [x] `tsc --noEmit` clean.
- [x] ESLint clean.