### PR TITLE
feat(ide): add daemon smoke wire-up

### DIFF
--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -34,7 +34,8 @@
     "onCommand:qwen-code.openChat",
     "onCommand:qwen-code.focusChat",
     "onCommand:qwen-code.newConversation",
-    "onCommand:qwen-code.showLogs"
+    "onCommand:qwen-code.showLogs",
+    "onCommand:qwen-code.daemonSmoke"
   ],
   "contributes": {
     "jsonValidation": [
@@ -127,6 +128,10 @@
         "title": "Qwen Code: Show Logs"
       },
       {
+        "command": "qwen-code.daemonSmoke",
+        "title": "Qwen Code: Daemon Smoke Test"
+      },
+      {
         "command": "qwen-code.copyMessage",
         "title": "%qwen-code.copyMessage.title%"
       },
@@ -151,6 +156,9 @@
         },
         {
           "command": "qwen-code.auth"
+        },
+        {
+          "command": "qwen-code.daemonSmoke"
         },
         {
           "command": "qwen-code.copyMessage",
@@ -247,6 +255,18 @@
           "type": "boolean",
           "default": true,
           "description": "Show notifications with sound when a task completes (at least 20 seconds) or needs your attention, while you are not actively viewing the Qwen Code panel."
+        },
+        "qwen-code.daemonUrl": {
+          "order": 5,
+          "type": "string",
+          "default": "",
+          "description": "Experimental qwen serve URL used by the Daemon Smoke Test command."
+        },
+        "qwen-code.daemonToken": {
+          "order": 6,
+          "type": "string",
+          "default": "",
+          "description": "Optional bearer token used by the Daemon Smoke Test command."
         }
       }
     },

--- a/packages/vscode-ide-companion/src/commands/daemonSmoke.ts
+++ b/packages/vscode-ide-companion/src/commands/daemonSmoke.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as vscode from 'vscode';
+import type {
+  RequestPermissionRequest,
+  SessionNotification,
+} from '@agentclientprotocol/sdk';
+import { DaemonIdeConnection } from '../services/daemonIdeConnection.js';
+
+type Logger = (message: string) => void;
+
+export const daemonSmokeCommand = 'qwen-code.daemonSmoke';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+function getTextContent(value: unknown): string | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  return typeof value['text'] === 'string' ? value['text'] : undefined;
+}
+
+function getSessionUpdateText(data: SessionNotification): string | undefined {
+  if (!isRecord(data)) {
+    return undefined;
+  }
+  const update = data['update'];
+  if (!isRecord(update)) {
+    return undefined;
+  }
+  const sessionUpdate = update['sessionUpdate'];
+  if (
+    sessionUpdate !== 'agent_message_chunk' &&
+    sessionUpdate !== 'agent_thought_chunk'
+  ) {
+    return undefined;
+  }
+  return getTextContent(update['content']);
+}
+
+async function pickPermissionOption(
+  request: RequestPermissionRequest,
+): Promise<{ optionId?: string }> {
+  const options = Array.isArray(request.options) ? request.options : [];
+  const picked = await vscode.window.showQuickPick(
+    options.map((option) => ({
+      label: option.name ?? option.optionId,
+      description: option.optionId,
+      optionId: option.optionId,
+    })),
+    {
+      title: `Qwen daemon permission: ${request.toolCall?.kind ?? 'tool'}`,
+      placeHolder: 'Choose a daemon permission response',
+    },
+  );
+  return { optionId: picked?.optionId ?? 'cancel' };
+}
+
+export function registerDaemonSmokeCommand(
+  context: vscode.ExtensionContext,
+  log: Logger,
+  outputChannel?: vscode.OutputChannel,
+): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(daemonSmokeCommand, async () => {
+      const config = vscode.workspace.getConfiguration();
+      const configuredUrl =
+        config.get<string>('qwen-code.daemonUrl') || 'http://127.0.0.1:4170';
+      const baseUrl = await vscode.window.showInputBox({
+        title: 'Qwen daemon URL',
+        value: configuredUrl,
+        ignoreFocusOut: true,
+      });
+      if (!baseUrl) {
+        return;
+      }
+
+      const prompt = await vscode.window.showInputBox({
+        title: 'Qwen daemon smoke prompt',
+        value: 'Say hello from the daemon IDE wire-up.',
+        ignoreFocusOut: true,
+      });
+      if (!prompt) {
+        return;
+      }
+
+      const token =
+        config.get<string>('qwen-code.daemonToken') ||
+        process.env['QWEN_SERVER_TOKEN'];
+      const workspaceCwd = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
+      const connection = new DaemonIdeConnection();
+
+      outputChannel?.show(true);
+      outputChannel?.appendLine(`[daemon] connecting to ${baseUrl}`);
+      connection.onSessionUpdate = (data) => {
+        const text = getSessionUpdateText(data);
+        if (text) {
+          outputChannel?.append(text);
+        }
+      };
+      connection.onPermissionRequest = pickPermissionOption;
+      connection.onEndTurn = (reason) => {
+        outputChannel?.appendLine('');
+        outputChannel?.appendLine(`[daemon] turn ended: ${reason ?? 'ok'}`);
+      };
+      connection.onDisconnected = (_code, signal) => {
+        outputChannel?.appendLine(`[daemon] disconnected: ${signal ?? 'ok'}`);
+      };
+
+      try {
+        await connection.connect({
+          baseUrl,
+          token,
+          workspaceCwd,
+        });
+        outputChannel?.appendLine(
+          `[daemon] session ${connection.currentSessionId ?? 'unknown'}`,
+        );
+        await connection.sendPrompt(prompt);
+        vscode.window.showInformationMessage(
+          'Qwen daemon smoke prompt completed.',
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        log(`[DaemonSmoke] ${message}`);
+        vscode.window.showErrorMessage(`Qwen daemon smoke failed: ${message}`);
+      } finally {
+        await connection.disconnect();
+      }
+    }),
+  );
+}

--- a/packages/vscode-ide-companion/src/commands/index.ts
+++ b/packages/vscode-ide-companion/src/commands/index.ts
@@ -12,6 +12,10 @@ import {
   CHAT_VIEW_ID_SIDEBAR,
   CHAT_VIEW_ID_SECONDARY,
 } from '../constants/viewIds.js';
+import {
+  daemonSmokeCommand,
+  registerDaemonSmokeCommand,
+} from './daemonSmoke.js';
 
 type Logger = (message: string) => void;
 
@@ -23,6 +27,7 @@ export const authCommand = 'qwen-code.auth';
 export const focusChatCommand = 'qwen-code.focusChat';
 export const newConversationCommand = 'qwen-code.newConversation';
 export const showLogsCommand = 'qwen-code.showLogs';
+export { daemonSmokeCommand };
 
 /**
  * Register all Qwen Code chat-related commands.
@@ -147,4 +152,5 @@ export function registerNewCommands(
   );
 
   context.subscriptions.push(...disposables);
+  registerDaemonSmokeCommand(context, log, outputChannel);
 }


### PR DESCRIPTION
## Summary

- What changed: Adds an explicit `Qwen Code: Daemon Smoke Test` VS Code command that connects to a running `qwen serve` daemon through `DaemonIdeConnection`, streams daemon session text into the Qwen Code Companion output channel, and handles daemon permission requests with a quick-pick.
- Why it changed: Gives reviewers a local IDE validation path for the daemon connection without replacing the current WebView/ACP-backed chat manager yet.
- Reviewer focus: Confirm the existing IDE companion flow remains unchanged unless the new command is invoked, and that this is correctly scoped as a smoke wire-up rather than the final WebView replacement.

## Validation

- Commands run:
  ```bash
  cd packages/vscode-ide-companion && npm run check-types
  cd packages/vscode-ide-companion && npm run lint
  cd packages/vscode-ide-companion && npx vitest run src/commands/index.test.ts src/package.test.ts src/services/daemonIdeConnection.test.ts
  ```
- Prompts / inputs used:
  - Unit tests only; no live VS Code daemon prompt was sent in this commit.
- Expected result:
  - TypeScript passes.
  - Existing daemon connection and command metadata tests pass.
  - Lint has no new staged-file errors.
- Observed result:
  - TypeScript passed.
  - 24 targeted tests passed.
  - `npm run lint` completed with one pre-existing warning in `src/utils/editorGroupUtils.ts`, outside this PR's files.
- Quickest reviewer verification path:
  ```bash
  npm run dev -- serve --port 4170 --workspace "$PWD"
  # Launch the VS Code companion extension, run:
  # Qwen Code: Daemon Smoke Test
  # URL: http://127.0.0.1:4170
  # Prompt: say hello
  ```
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  - Targeted tests passed locally; the command writes live daemon chunks to the Qwen Code Companion output channel when run in VS Code.

## Scope / Risk

- Main risk or tradeoff: This is not the final IDE WebView replacement. It validates the daemon IDE transport and permission path behind an explicit command first.
- Not covered / not validated: Full WebView chat replacement, session picker/history/account/mode parity, and live VS Code smoke run were not covered here.
- Breaking changes / migration notes: None expected. Existing IDE chat, auth, diff, and ACP manager code paths remain default.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Validated on macOS with package-local typecheck, lint, and targeted vitest files.

## Linked Issues / Bugs

- Related to #3803
- Builds on the merged #4199 daemon IDE adapter
