### PR TITLE
fix(cli): /status preserves prior error history items (#4169)

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -4026,6 +4026,74 @@ describe('useGeminiStream', () => {
         expect(errorItem).toBeUndefined();
       });
     });
+
+    // Regression for #4169: when a pending retry error is cleared as the user
+    // starts a new turn, the error must be committed to the persistent
+    // history first — otherwise running /status (or any new turn) silently
+    // discards the failure the user was investigating.
+    it('commits pending retry error to history (without hint) when a new query starts', async () => {
+      mockSendMessageStream.mockReturnValueOnce(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Error,
+            value: { error: { message: 'First error' } },
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('First query');
+      });
+
+      await waitFor(() => {
+        const errorItem = result.current.pendingHistoryItems.find(
+          (item) => item.type === 'error',
+        );
+        expect(errorItem).toBeDefined();
+      });
+
+      // Sanity check: the error has NOT yet been committed to history while
+      // it lives as a pending retry item.
+      expect(mockAddItem).not.toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'error' }),
+        expect.any(Number),
+      );
+
+      mockSendMessageStream.mockReturnValueOnce(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.Content,
+            value: 'Second response',
+          };
+        })(),
+      );
+
+      await act(async () => {
+        await result.current.submitQuery('Second query');
+      });
+
+      // The pending error is now committed to history…
+      await waitFor(() => {
+        expect(mockAddItem).toHaveBeenCalledWith(
+          expect.objectContaining({ type: 'error' }),
+          expect.any(Number),
+        );
+      });
+
+      // …and the retry hint is stripped, since it is no longer actionable.
+      const errorCommit = mockAddItem.mock.calls.find(
+        ([item]) => item && typeof item === 'object' && item.type === 'error',
+      );
+      expect(errorCommit?.[0]).not.toHaveProperty('hint');
+
+      // The pending region is cleared, as before.
+      const errorItem = result.current.pendingHistoryItems.find(
+        (item) => item.type === 'error',
+      );
+      expect(errorItem).toBeUndefined();
+    });
   });
 
   describe('Concurrent Execution Prevention', () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1688,6 +1688,11 @@ export const useGeminiStream = (
           pendingRetryCountdownItemRef.current ||
           pendingRetryErrorItemRef.current
         ) {
+          const pendingError = pendingRetryErrorItemRef.current;
+          if (pendingError && pendingError.type === 'error') {
+            const { hint: _hint, ...errorWithoutHint } = pendingError;
+            addItem(errorWithoutHint, userMessageTimestamp);
+          }
           clearRetryCountdown();
         }
       }


### PR DESCRIPTION
## Summary

- The guard at the top of `submitQuery` (lines 1683-1692 of `useGeminiStream.ts`) cleared `pendingRetryErrorItem` via `clearRetryCountdown()` without committing it to history first. Any new user turn — **including informational slash commands like `/status`, `/about`, `/help`** — silently discarded a visible API error.
- The existing inline comment already described the intended behavior ("Commit any pending retry error to history (without hint) since the user is starting a new conversation turn") but the commit step was never implemented.
- Fix: persist the pending error item via `addItem()` before clearing, stripping the now-stale "Press Ctrl+Y to retry" hint so the persisted history entry reads cleanly.

## Why this matters

Reporter triggered an API error (`reasoning_content` from DeepSeek V4 Pro thinking-mode), then ran `/status` to grab their version info for the bug report. The status box rendered, but the error message vanished entirely — neither in the persistent (`<Static>`) history nor in the dynamic region. They lost the context they were investigating.

Note: this PR fixes the **UI clobber** only. The underlying `reasoning_content` API error is tracked separately under #3772 and is out of scope here.

## Test plan

- [x] New unit test `commits pending retry error to history (without hint) when a new query starts` in [useGeminiStream.test.tsx](packages/cli/src/ui/hooks/useGeminiStream.test.tsx) — asserts the error is committed to history with the hint stripped, then cleared from the pending area
- [x] Existing test `should clear static error when starting a new query` still passes (pending area still drains)
- [x] `packages/cli/src/ui/hooks/useGeminiStream.test.tsx` — **95/95 passing**
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] End-to-end reproduction with a tmux session + mock OpenAI server returning a 400: before the fix the error disappears after `/status`; after the fix the error remains visible in the `<Static>` history above the about box, with the retry hint correctly omitted
- [x] CLI-package full test run: only pre-existing `AuthDialog`/`SettingsDialog` failures (verified to fail on `main` baseline without my changes) — unrelated to this fix

Fixes #4169