### PR TITLE
feat(tui): add experimental daemon stream path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17283,6 +17283,7 @@
         "@modelcontextprotocol/sdk": "^1.25.1",
         "@qwen-code/channel-base": "file:../channels/base",
         "@qwen-code/channel-dingtalk": "file:../channels/dingtalk",
+        "@qwen-code/sdk": "file:../sdk-typescript",
         "@qwen-code/channel-telegram": "file:../channels/telegram",
         "@qwen-code/channel-weixin": "file:../channels/weixin",
         "@qwen-code/qwen-code-core": "file:../core",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -46,6 +46,7 @@
     "@modelcontextprotocol/sdk": "^1.25.1",
     "@qwen-code/channel-base": "file:../channels/base",
     "@qwen-code/channel-dingtalk": "file:../channels/dingtalk",
+    "@qwen-code/sdk": "file:../sdk-typescript",
     "@qwen-code/channel-telegram": "file:../channels/telegram",
     "@qwen-code/channel-weixin": "file:../channels/weixin",
     "@qwen-code/qwen-code-core": "file:../core",

--- a/packages/cli/src/commands/daemon-tui.ts
+++ b/packages/cli/src/commands/daemon-tui.ts
@@ -1,0 +1,240 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule } from 'yargs';
+import { createInterface } from 'node:readline/promises';
+import { stdin as input, stdout as output } from 'node:process';
+import { writeStderrLine } from '../utils/stdioHelpers.js';
+import type {
+  DaemonTuiUpdate,
+  DaemonTuiSessionClient,
+} from '../ui/daemon/DaemonTuiAdapter.js';
+
+interface DaemonTuiArgs {
+  'daemon-url': string;
+  token?: string;
+  workspace?: string;
+  model?: string;
+  'session-id'?: string;
+  'session-scope'?: 'single' | 'thread';
+  prompt?: string;
+}
+
+function writeLine(line = ''): void {
+  output.write(`${line}\n`);
+}
+
+function formatHistoryItem(item: unknown): string {
+  if (!item || typeof item !== 'object') {
+    return String(item);
+  }
+  const record = item as Record<string, unknown>;
+  const type = typeof record['type'] === 'string' ? record['type'] : 'history';
+  const text =
+    typeof record['text'] === 'string'
+      ? record['text']
+      : JSON.stringify(record, null, 2);
+  return `[${type}] ${text}`;
+}
+
+function printDaemonUpdate(update: DaemonTuiUpdate): void {
+  switch (update.type) {
+    case 'history':
+      writeLine(formatHistoryItem(update.item));
+      break;
+    case 'tool_group_update':
+      writeLine('[tool]');
+      for (const tool of update.item.tools) {
+        writeLine(`  - ${tool.name}: ${tool.status}`);
+        if (tool.resultDisplay !== undefined) {
+          writeLine(`    ${JSON.stringify(tool.resultDisplay)}`);
+        }
+      }
+      break;
+    case 'permission_request':
+      writeLine(`[permission] ${update.requestId}`);
+      writeLine(
+        `  tool: ${update.request.toolCall.kind} (${update.request.toolCall.toolCallId})`,
+      );
+      for (const option of update.request.options) {
+        writeLine(`  - ${option.optionId}: ${option.name ?? option.optionId}`);
+      }
+      writeLine(`  approve with: /approve ${update.requestId} <optionId>`);
+      writeLine(`  reject with:  /reject ${update.requestId}`);
+      break;
+    case 'permission_resolved':
+      writeLine(
+        `[permission_resolved] ${update.requestId} ${JSON.stringify(
+          update.outcome,
+        )}`,
+      );
+      break;
+    case 'model_switched':
+      writeLine(`[model] ${update.modelId}`);
+      break;
+    case 'disconnected':
+      writeLine(`[disconnected] ${update.reason}`);
+      break;
+    default: {
+      const neverUpdate: never = update;
+      writeLine(JSON.stringify(neverUpdate));
+    }
+  }
+}
+
+async function createDaemonTuiSession(
+  argv: DaemonTuiArgs,
+): Promise<DaemonTuiSessionClient> {
+  const { DaemonClient, DaemonSessionClient } = await import('@qwen-code/sdk');
+  const client = new DaemonClient({
+    baseUrl: argv['daemon-url'],
+    token: argv.token ?? process.env['QWEN_SERVER_TOKEN'],
+  });
+  const workspaceCwd = argv.workspace ?? process.cwd();
+  if (argv['session-id']) {
+    return await DaemonSessionClient.load(client, argv['session-id'], {
+      workspaceCwd,
+    });
+  }
+  return await DaemonSessionClient.createOrAttach(client, {
+    workspaceCwd,
+    ...(argv.model ? { modelServiceId: argv.model } : {}),
+    ...(argv['session-scope'] ? { sessionScope: argv['session-scope'] } : {}),
+  });
+}
+
+async function runPrompt(
+  session: DaemonTuiSessionClient,
+  prompt: string,
+): Promise<void> {
+  const { DaemonTuiAdapter } = await import('../ui/daemon/DaemonTuiAdapter.js');
+  const adapter = new DaemonTuiAdapter({
+    session,
+    onUpdate: printDaemonUpdate,
+  });
+  await adapter.start();
+  try {
+    await adapter.sendPrompt(prompt);
+  } finally {
+    await adapter.stop();
+  }
+}
+
+async function runInteractive(session: DaemonTuiSessionClient): Promise<void> {
+  const { DaemonTuiAdapter } = await import('../ui/daemon/DaemonTuiAdapter.js');
+  const adapter = new DaemonTuiAdapter({
+    session,
+    onUpdate: printDaemonUpdate,
+  });
+  await adapter.start();
+  const rl = createInterface({ input, output });
+  try {
+    writeLine(
+      `Connected to daemon session ${session.sessionId} (${session.workspaceCwd})`,
+    );
+    writeLine(
+      'Commands: /quit, /cancel, /model <id>, /approve <id> <option>, /reject <id>',
+    );
+    for (;;) {
+      const line = (await rl.question('qwen-daemon> ')).trim();
+      if (!line) {
+        continue;
+      }
+      if (line === '/quit' || line === '/exit') {
+        return;
+      }
+      if (line === '/cancel') {
+        await adapter.cancel();
+        continue;
+      }
+      if (line.startsWith('/model ')) {
+        await adapter.setModel(line.slice('/model '.length).trim());
+        continue;
+      }
+      if (line.startsWith('/approve ')) {
+        const [, requestId, optionId] = line.split(/\s+/, 3);
+        if (!requestId || !optionId) {
+          writeLine('usage: /approve <requestId> <optionId>');
+          continue;
+        }
+        await adapter.approvePermission(requestId, optionId);
+        continue;
+      }
+      if (line.startsWith('/reject ')) {
+        const [, requestId] = line.split(/\s+/, 2);
+        if (!requestId) {
+          writeLine('usage: /reject <requestId>');
+          continue;
+        }
+        await adapter.rejectPermission(requestId);
+        continue;
+      }
+      await adapter.sendPrompt(line);
+    }
+  } finally {
+    rl.close();
+    await adapter.stop();
+  }
+}
+
+export const daemonTuiCommand: CommandModule<unknown, DaemonTuiArgs> = {
+  command: 'daemon-tui',
+  describe:
+    'Experimental local harness for driving the TUI daemon adapter against qwen serve',
+  builder: (yargs) =>
+    yargs
+      .option('daemon-url', {
+        type: 'string',
+        default: process.env['QWEN_DAEMON_URL'] ?? 'http://127.0.0.1:4170',
+        description: 'Base URL of a running qwen serve daemon.',
+      })
+      .option('token', {
+        type: 'string',
+        description:
+          'Bearer token for the daemon. Defaults to QWEN_SERVER_TOKEN.',
+      })
+      .option('workspace', {
+        type: 'string',
+        description:
+          'Workspace cwd to pass to POST /session. Defaults to process.cwd().',
+      })
+      .option('model', {
+        type: 'string',
+        description: 'Optional model service id for the daemon session.',
+      })
+      .option('session-id', {
+        type: 'string',
+        description:
+          'Attach to an existing daemon session via POST /session/:id/load.',
+      })
+      .option('session-scope', {
+        type: 'string',
+        choices: ['single', 'thread'] as const,
+        description:
+          'Optional session scope override for new sessions. Omit to use the daemon default.',
+      })
+      .option('prompt', {
+        type: 'string',
+        description:
+          'Send one prompt and exit. Omit for an interactive validation loop.',
+      }),
+  handler: async (argv) => {
+    try {
+      const session = await createDaemonTuiSession(argv);
+      if (argv.prompt) {
+        await runPrompt(session, argv.prompt);
+      } else {
+        await runInteractive(session);
+      }
+    } catch (err) {
+      writeStderrLine(
+        `qwen daemon-tui: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      process.exit(1);
+    }
+    process.exit(0);
+  },
+};

--- a/packages/cli/src/commands/daemon-tui.ts
+++ b/packages/cli/src/commands/daemon-tui.ts
@@ -12,6 +12,7 @@ import type {
   DaemonTuiUpdate,
   DaemonTuiSessionClient,
 } from '../ui/daemon/DaemonTuiAdapter.js';
+import { createDaemonTuiSession as createDaemonTuiSessionClient } from '../ui/daemon/createDaemonTuiSession.js';
 
 interface DaemonTuiArgs {
   'daemon-url': string;
@@ -88,21 +89,14 @@ function printDaemonUpdate(update: DaemonTuiUpdate): void {
 async function createDaemonTuiSession(
   argv: DaemonTuiArgs,
 ): Promise<DaemonTuiSessionClient> {
-  const { DaemonClient, DaemonSessionClient } = await import('@qwen-code/sdk');
-  const client = new DaemonClient({
-    baseUrl: argv['daemon-url'],
-    token: argv.token ?? process.env['QWEN_SERVER_TOKEN'],
-  });
   const workspaceCwd = argv.workspace ?? process.cwd();
-  if (argv['session-id']) {
-    return await DaemonSessionClient.load(client, argv['session-id'], {
-      workspaceCwd,
-    });
-  }
-  return await DaemonSessionClient.createOrAttach(client, {
+  return await createDaemonTuiSessionClient({
+    daemonUrl: argv['daemon-url'],
+    token: argv.token,
     workspaceCwd,
-    ...(argv.model ? { modelServiceId: argv.model } : {}),
-    ...(argv['session-scope'] ? { sessionScope: argv['session-scope'] } : {}),
+    model: argv.model,
+    sessionId: argv['session-id'],
+    sessionScope: argv['session-scope'],
   });
 }
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1140,6 +1140,9 @@ export async function parseArguments(): Promise<CliArgs> {
     if (typeof result['daemonModel'] === 'string') {
       process.env['QWEN_DAEMON_MODEL'] = result['daemonModel'];
     }
+    // Hidden draft path: bridge CLI flags into the daemon-native TUI adapter.
+    // For now the normal local TUI flag only exercises local-local daemon use;
+    // remote daemon smoke tests should pass QWEN_DAEMON_WORKSPACE explicitly.
     process.env['QWEN_DAEMON_WORKSPACE'] = process.cwd();
   }
 

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -138,6 +138,12 @@ export interface CliArgs {
   acp: boolean | undefined;
   experimentalAcp: boolean | undefined;
   experimentalLsp: boolean | undefined;
+  experimentalDaemonTui?: boolean | undefined;
+  daemonUrl?: string | undefined;
+  daemonToken?: string | undefined;
+  daemonSessionId?: string | undefined;
+  daemonSessionScope?: 'single' | 'thread' | undefined;
+  daemonModel?: string | undefined;
   extensions: string[] | undefined;
   listExtensions: boolean | undefined;
   openaiLogging: boolean | undefined;
@@ -673,6 +679,42 @@ export async function parseArguments(): Promise<CliArgs> {
             'Enable experimental LSP (Language Server Protocol) feature for code intelligence',
           default: false,
         })
+        .option('experimental-daemon-tui', {
+          type: 'boolean',
+          description:
+            'Experimental: render the normal TUI against a running qwen serve daemon.',
+          hidden: true,
+        })
+        .option('daemon-url', {
+          type: 'string',
+          description:
+            'Experimental daemon TUI: base URL of a running qwen serve daemon.',
+          hidden: true,
+        })
+        .option('daemon-token', {
+          type: 'string',
+          description: 'Experimental daemon TUI: bearer token for the daemon.',
+          hidden: true,
+        })
+        .option('daemon-session-id', {
+          type: 'string',
+          description:
+            'Experimental daemon TUI: attach to an existing daemon session.',
+          hidden: true,
+        })
+        .option('daemon-session-scope', {
+          type: 'string',
+          choices: ['single', 'thread'] as const,
+          description:
+            'Experimental daemon TUI: session scope for new daemon sessions.',
+          hidden: true,
+        })
+        .option('daemon-model', {
+          type: 'string',
+          description:
+            'Experimental daemon TUI: model service id for new daemon sessions.',
+          hidden: true,
+        })
         .option('channel', {
           type: 'string',
           choices: ['VSCode', 'ACP', 'SDK', 'CI'],
@@ -1079,6 +1121,26 @@ export async function parseArguments(): Promise<CliArgs> {
   // Apply ACP fallback: if acp or experimental-acp is present but no explicit --channel, treat as ACP
   if ((result['acp'] || result['experimentalAcp']) && !result['channel']) {
     (result as Record<string, unknown>)['channel'] = 'ACP';
+  }
+
+  if (result['experimentalDaemonTui']) {
+    process.env['QWEN_EXPERIMENTAL_DAEMON_TUI'] = '1';
+    if (typeof result['daemonUrl'] === 'string') {
+      process.env['QWEN_DAEMON_URL'] = result['daemonUrl'];
+    }
+    if (typeof result['daemonToken'] === 'string') {
+      process.env['QWEN_DAEMON_TOKEN'] = result['daemonToken'];
+    }
+    if (typeof result['daemonSessionId'] === 'string') {
+      process.env['QWEN_DAEMON_SESSION_ID'] = result['daemonSessionId'];
+    }
+    if (typeof result['daemonSessionScope'] === 'string') {
+      process.env['QWEN_DAEMON_SESSION_SCOPE'] = result['daemonSessionScope'];
+    }
+    if (typeof result['daemonModel'] === 'string') {
+      process.env['QWEN_DAEMON_MODEL'] = result['daemonModel'];
+    }
+    process.env['QWEN_DAEMON_WORKSPACE'] = process.cwd();
   }
 
   return result as unknown as CliArgs;

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -59,6 +59,7 @@ import { channelCommand } from '../commands/channel.js';
 import { authCommand } from '../commands/auth.js';
 import { reviewCommand } from '../commands/review.js';
 import { serveCommand } from '../commands/serve.js';
+import { daemonTuiCommand } from '../commands/daemon-tui.js';
 
 // UUID v4 regex pattern for validation
 const SESSION_ID_REGEX =
@@ -1002,7 +1003,9 @@ export async function parseArguments(): Promise<CliArgs> {
     // Register /review skill helpers (presubmit checks, cleanup)
     .command(reviewCommand)
     // Register `qwen serve` (Stage 1 daemon — see issue #3803)
-    .command(serveCommand);
+    .command(serveCommand)
+    // Register experimental daemon TUI wire-up harness.
+    .command(daemonTuiCommand);
 
   yargsInstance
     .version(await getCliVersion()) // This will enable the --version flag based on package.json
@@ -1026,7 +1029,8 @@ export async function parseArguments(): Promise<CliArgs> {
       result._[0] === 'auth' ||
       result._[0] === 'hooks' ||
       result._[0] === 'channel' ||
-      result._[0] === 'review')
+      result._[0] === 'review' ||
+      result._[0] === 'daemon-tui')
   ) {
     // Note: `serve` is intentionally NOT in this list. Its handler blocks
     // forever (after the listener is up); SIGINT/SIGTERM in runQwenServe

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1168,7 +1168,7 @@ export const AppContainer = (props: AppContainerProps) => {
 
   const cancelHandlerRef = useRef<(info?: CancelSubmitInfo) => void>(() => {});
   const midTurnDrainRef = useRef<(() => string[]) | null>(null);
-  const useActiveGeminiStream = daemonTuiEnabled
+  const useStreamBackend = daemonTuiEnabled
     ? useDaemonTuiStream
     : useGeminiStream;
 
@@ -1186,7 +1186,7 @@ export const AppContainer = (props: AppContainerProps) => {
     pendingToolCalls,
     streamingResponseLengthRef,
     isReceivingContent,
-  } = useActiveGeminiStream(
+  } = useStreamBackend(
     config.getGeminiClient(),
     historyManager.history,
     historyManager.addItem,
@@ -1896,6 +1896,8 @@ export const AppContainer = (props: AppContainerProps) => {
 
     // Only trigger when transitioning from Responding to Idle (and enabled)
     // Skip when dialogs are active, in plan mode, elicitation pending, or last response was error
+    // TODO(#3803): re-enable daemon-backed follow-up suggestions once the
+    // daemon stream exposes the token/count state this local helper expects.
     if (
       followupSuggestionsEnabled &&
       !daemonTuiEnabled &&

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -132,6 +132,8 @@ import {
   useGeminiStream,
   type CancelSubmitInfo,
 } from './hooks/useGeminiStream.js';
+import { useDaemonTuiStream } from './daemon/useDaemonTuiStream.js';
+import { getDaemonTuiRuntimeOptions } from './daemon/daemonTuiOptions.js';
 import type { TrackedExecutingToolCall } from './hooks/useReactToolScheduler.js';
 import { useVim } from './hooks/vim.js';
 import { isBtwCommand, isSlashCommand } from './utils/commandUtils.js';
@@ -290,6 +292,11 @@ const SHELL_HEIGHT_PADDING = 10;
 
 export const AppContainer = (props: AppContainerProps) => {
   const { settings, config, initializationResult } = props;
+  const daemonTuiOptions = useMemo(
+    () => getDaemonTuiRuntimeOptions(config),
+    [config],
+  );
+  const daemonTuiEnabled = daemonTuiOptions.enabled;
   const historyManager = useHistory();
   // `useHistory()` returns a fresh memoized object whenever `history` changes,
   // so depending on `historyManager` directly inside event-handler callbacks
@@ -469,6 +476,15 @@ export const AppContainer = (props: AppContainerProps) => {
 
   // Initialize config (runs once on mount)
   useEffect(() => {
+    if (daemonTuiEnabled) {
+      profileCheckpoint('config_initialize_start');
+      profileCheckpoint('config_initialize_end');
+      setConfigInitialized(true);
+      profileCheckpoint('input_enabled');
+      finalizeStartupProfile(config.getSessionId());
+      return;
+    }
+
     (async () => {
       // Note: the program will not work if this fails so let errors be
       // handled by the global catch.
@@ -572,6 +588,7 @@ export const AppContainer = (props: AppContainerProps) => {
    * without waiting.
    */
   useEffect(() => {
+    if (daemonTuiEnabled) return undefined;
     if (!isConfigInitialized) return undefined;
     const geminiClient = config.getGeminiClient();
     if (!geminiClient) return undefined;
@@ -675,7 +692,7 @@ export const AppContainer = (props: AppContainerProps) => {
       if (flushTimer !== null) clearTimeout(flushTimer);
       clearTimeout(finalizeCap);
     };
-  }, [isConfigInitialized, config]);
+  }, [isConfigInitialized, config, daemonTuiEnabled]);
 
   // Track idle state via ref so the update handler can defer notifications
   // while the model is streaming, without triggering re-renders.
@@ -1151,6 +1168,9 @@ export const AppContainer = (props: AppContainerProps) => {
 
   const cancelHandlerRef = useRef<(info?: CancelSubmitInfo) => void>(() => {});
   const midTurnDrainRef = useRef<(() => string[]) | null>(null);
+  const useActiveGeminiStream = daemonTuiEnabled
+    ? useDaemonTuiStream
+    : useGeminiStream;
 
   const {
     streamingState,
@@ -1166,7 +1186,7 @@ export const AppContainer = (props: AppContainerProps) => {
     pendingToolCalls,
     streamingResponseLengthRef,
     isReceivingContent,
-  } = useGeminiStream(
+  } = useActiveGeminiStream(
     config.getGeminiClient(),
     historyManager.history,
     historyManager.addItem,
@@ -1187,6 +1207,7 @@ export const AppContainer = (props: AppContainerProps) => {
     terminalHeight,
     midTurnDrainRef,
     logger,
+    daemonTuiOptions,
   );
 
   // Now that streamingState is available, keep isIdleRef in sync and
@@ -1826,7 +1847,7 @@ export const AppContainer = (props: AppContainerProps) => {
       !isEditorDialogOpen &&
       !showWelcomeBackDialog &&
       welcomeBackChoice !== 'restart' &&
-      geminiClient?.isInitialized?.()
+      (daemonTuiEnabled || geminiClient?.isInitialized?.())
     ) {
       handleFinalSubmit(initialPrompt);
       initialPromptSubmitted.current = true;
@@ -1842,6 +1863,7 @@ export const AppContainer = (props: AppContainerProps) => {
     showWelcomeBackDialog,
     welcomeBackChoice,
     geminiClient,
+    daemonTuiEnabled,
   ]);
 
   // Generate prompt suggestions when streaming completes
@@ -1876,6 +1898,7 @@ export const AppContainer = (props: AppContainerProps) => {
     // Skip when dialogs are active, in plan mode, elicitation pending, or last response was error
     if (
       followupSuggestionsEnabled &&
+      !daemonTuiEnabled &&
       config.isInteractive() &&
       !config.getSdkMode() &&
       prevStreamingStateRef.current === StreamingState.Responding &&

--- a/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
+++ b/packages/cli/src/ui/daemon/DaemonTuiAdapter.ts
@@ -17,6 +17,17 @@ import {
   type IndividualToolCallDisplay,
 } from '../types.js';
 
+/**
+ * Daemon-native TUI adapter.
+ *
+ * This layer consumes typed daemon SSE events and projects them into the
+ * existing Ink history/tool view model. It intentionally does not proxy PTY
+ * bytes; a PTY proxy can be useful for compatibility/debugging, but the TUI
+ * migration target is the shared typed-event/reducer path.
+ *
+ * TODO(#3803): replace this draft-local reducer with the shared daemon
+ * client/protocol reducer once that package boundary is stabilized.
+ */
 export interface DaemonTuiEvent {
   id?: number;
   v: 1;

--- a/packages/cli/src/ui/daemon/createDaemonTuiSession.ts
+++ b/packages/cli/src/ui/daemon/createDaemonTuiSession.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { DaemonTuiSessionClient } from './DaemonTuiAdapter.js';
+
+export interface CreateDaemonTuiSessionOptions {
+  daemonUrl: string;
+  token?: string;
+  workspaceCwd: string;
+  model?: string;
+  sessionId?: string;
+  sessionScope?: 'single' | 'thread';
+}
+
+export async function createDaemonTuiSession(
+  options: CreateDaemonTuiSessionOptions,
+): Promise<DaemonTuiSessionClient> {
+  const { DaemonClient, DaemonSessionClient } = await import('@qwen-code/sdk');
+  const client = new DaemonClient({
+    baseUrl: options.daemonUrl,
+    token: options.token ?? process.env['QWEN_SERVER_TOKEN'],
+  });
+
+  if (options.sessionId) {
+    return await DaemonSessionClient.load(client, options.sessionId, {
+      workspaceCwd: options.workspaceCwd,
+    });
+  }
+
+  return await DaemonSessionClient.createOrAttach(client, {
+    workspaceCwd: options.workspaceCwd,
+    ...(options.model ? { modelServiceId: options.model } : {}),
+    ...(options.sessionScope ? { sessionScope: options.sessionScope } : {}),
+  });
+}

--- a/packages/cli/src/ui/daemon/createDaemonTuiSession.ts
+++ b/packages/cli/src/ui/daemon/createDaemonTuiSession.ts
@@ -24,6 +24,8 @@ export async function createDaemonTuiSession(
     token: options.token ?? process.env['QWEN_SERVER_TOKEN'],
   });
 
+  // workspaceCwd is interpreted by the daemon/runtime host. For remote-daemon
+  // testing it must be the remote workspace path, not the local terminal cwd.
   if (options.sessionId) {
     return await DaemonSessionClient.load(client, options.sessionId, {
       workspaceCwd: options.workspaceCwd,

--- a/packages/cli/src/ui/daemon/daemonTuiOptions.ts
+++ b/packages/cli/src/ui/daemon/daemonTuiOptions.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '@qwen-code/qwen-code-core';
+
+export interface DaemonTuiRuntimeOptions {
+  enabled: boolean;
+  daemonUrl: string;
+  token?: string;
+  sessionId?: string;
+  sessionScope?: 'single' | 'thread';
+  model?: string;
+  workspaceCwd: string;
+}
+
+function isEnabled(value: string | undefined): boolean {
+  return value === '1' || value === 'true' || value === 'yes';
+}
+
+function readSessionScope(): 'single' | 'thread' | undefined {
+  const value = process.env['QWEN_DAEMON_SESSION_SCOPE'];
+  return value === 'single' || value === 'thread' ? value : undefined;
+}
+
+export function getDaemonTuiRuntimeOptions(
+  config: Config,
+): DaemonTuiRuntimeOptions {
+  const enabled = isEnabled(process.env['QWEN_EXPERIMENTAL_DAEMON_TUI']);
+  return {
+    enabled,
+    daemonUrl: process.env['QWEN_DAEMON_URL'] ?? 'http://127.0.0.1:4170',
+    token: process.env['QWEN_DAEMON_TOKEN'],
+    sessionId: process.env['QWEN_DAEMON_SESSION_ID'],
+    sessionScope: readSessionScope(),
+    model: process.env['QWEN_DAEMON_MODEL'] ?? config.getModel(),
+    workspaceCwd: process.env['QWEN_DAEMON_WORKSPACE'] ?? config.getTargetDir(),
+  };
+}

--- a/packages/cli/src/ui/daemon/daemonTuiOptions.ts
+++ b/packages/cli/src/ui/daemon/daemonTuiOptions.ts
@@ -17,6 +17,7 @@ export interface DaemonTuiRuntimeOptions {
 }
 
 function isEnabled(value: string | undefined): boolean {
+  // Accept the common hidden-flag/env conventions used by local smoke scripts.
   return value === '1' || value === 'true' || value === 'yes';
 }
 
@@ -36,6 +37,9 @@ export function getDaemonTuiRuntimeOptions(
     sessionId: process.env['QWEN_DAEMON_SESSION_ID'],
     sessionScope: readSessionScope(),
     model: process.env['QWEN_DAEMON_MODEL'] ?? config.getModel(),
+    // For local-local runs this falls back to the current target dir. For
+    // local-TUI-to-remote-daemon runs, callers must pass the daemon-visible
+    // workspace path explicitly.
     workspaceCwd: process.env['QWEN_DAEMON_WORKSPACE'] ?? config.getTargetDir(),
   };
 }

--- a/packages/cli/src/ui/daemon/useDaemonTuiStream.ts
+++ b/packages/cli/src/ui/daemon/useDaemonTuiStream.ts
@@ -43,8 +43,17 @@ import {
 } from './createDaemonTuiSession.js';
 import type { DaemonTuiRuntimeOptions } from './daemonTuiOptions.js';
 
+/**
+ * Daemon-backed implementation of the useGeminiStream contract.
+ *
+ * The hook is deliberately a renderer adapter: prompts go through
+ * DaemonSessionClient, typed daemon events are reduced by DaemonTuiAdapter, and
+ * the resulting view items are rendered by the normal TUI. It must not grow a
+ * PTY proxy or a second runtime path.
+ */
 type GeminiStreamResult = ReturnType<typeof useGeminiStream>;
 type SubmitQuery = GeminiStreamResult['submitQuery'];
+type MergeableTextHistoryItem = Extract<HistoryItemWithoutId, { text: string }>;
 
 interface QueuedSubmission {
   query: PartListUnion;
@@ -73,6 +82,30 @@ function partListToText(parts: PartListUnion): string {
   return list.map((part) => stringifyPart(part)).join('');
 }
 
+function isMergeableTextItem(
+  item: HistoryItemWithoutId,
+): item is MergeableTextHistoryItem {
+  return (
+    item.type === 'gemini' ||
+    item.type === 'gemini_content' ||
+    item.type === 'gemini_thought' ||
+    item.type === 'gemini_thought_content'
+  );
+}
+
+function canMergeTextItemTypes(
+  a: MergeableTextHistoryItem['type'],
+  b: MergeableTextHistoryItem['type'],
+): boolean {
+  const assistantText =
+    (a === 'gemini' || a === 'gemini_content') &&
+    (b === 'gemini' || b === 'gemini_content');
+  const thoughtText =
+    (a === 'gemini_thought' || a === 'gemini_thought_content') &&
+    (b === 'gemini_thought' || b === 'gemini_thought_content');
+  return assistantText || thoughtText;
+}
+
 function mergePendingItem(
   pendingItems: HistoryItemWithoutId[],
   incoming: HistoryItemWithoutId,
@@ -80,21 +113,9 @@ function mergePendingItem(
   const last = pendingItems[pendingItems.length - 1];
   if (
     last &&
-    (last.type === 'gemini' || last.type === 'gemini_content') &&
-    (incoming.type === 'gemini' || incoming.type === 'gemini_content')
-  ) {
-    return [
-      ...pendingItems.slice(0, -1),
-      { type: last.type, text: `${last.text}${incoming.text}` },
-    ];
-  }
-
-  if (
-    last &&
-    (last.type === 'gemini_thought' ||
-      last.type === 'gemini_thought_content') &&
-    (incoming.type === 'gemini_thought' ||
-      incoming.type === 'gemini_thought_content')
+    isMergeableTextItem(last) &&
+    isMergeableTextItem(incoming) &&
+    canMergeTextItemTypes(last.type, incoming.type)
   ) {
     return [
       ...pendingItems.slice(0, -1),
@@ -247,6 +268,9 @@ export const useDaemonTuiStream = (
           );
           return;
         case 'permission_request':
+          // TODO(#3803): wire this to the native permission dialog before this
+          // draft can graduate. Showing a warning keeps the unsupported
+          // security-sensitive path visible during daemon-native renderer tests.
           setPending((current) => [
             ...current,
             {
@@ -258,6 +282,8 @@ export const useDaemonTuiStream = (
           ]);
           return;
         case 'permission_resolved':
+          // TODO(#3803): once native daemon permission UI is wired, update the
+          // active dialog/tool group instead of appending an informational row.
           setPending((current) => [
             ...current,
             {
@@ -388,6 +414,8 @@ export const useDaemonTuiStream = (
           if (slashCommandResult.type === 'submit_prompt') {
             query = slashCommandResult.content;
           } else {
+            // TODO(#3803): slash commands that schedule local tools need
+            // daemon control-plane routes or explicit client-capability RPCs.
             addItem(
               {
                 type: MessageType.WARNING,

--- a/packages/cli/src/ui/daemon/useDaemonTuiStream.ts
+++ b/packages/cli/src/ui/daemon/useDaemonTuiStream.ts
@@ -1,0 +1,490 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  type Dispatch,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type SetStateAction,
+} from 'react';
+import type { Part, PartListUnion } from '@google/genai';
+import type {
+  ApprovalMode,
+  Config,
+  EditorType,
+  GeminiClient,
+  Logger,
+  ThoughtSummary,
+} from '@qwen-code/qwen-code-core';
+import { MessageSenderType, SendMessageType } from '@qwen-code/qwen-code-core';
+import type { LoadedSettings } from '../../config/settings.js';
+import type {
+  HistoryItem,
+  HistoryItemToolGroup,
+  HistoryItemWithoutId,
+  SlashCommandProcessorResult,
+} from '../types.js';
+import { MessageType, StreamingState } from '../types.js';
+import type { UseHistoryManagerReturn } from '../hooks/useHistoryManager.js';
+import type {
+  CancelSubmitInfo,
+  useGeminiStream,
+} from '../hooks/useGeminiStream.js';
+import { DaemonTuiAdapter, type DaemonTuiUpdate } from './DaemonTuiAdapter.js';
+import {
+  createDaemonTuiSession,
+  type CreateDaemonTuiSessionOptions,
+} from './createDaemonTuiSession.js';
+import type { DaemonTuiRuntimeOptions } from './daemonTuiOptions.js';
+
+type GeminiStreamResult = ReturnType<typeof useGeminiStream>;
+type SubmitQuery = GeminiStreamResult['submitQuery'];
+
+interface QueuedSubmission {
+  query: PartListUnion;
+  submitType: SendMessageType;
+}
+
+function stringifyPart(part: Part | string): string {
+  if (typeof part === 'string') {
+    return part;
+  }
+  if ('text' in part && typeof part.text === 'string') {
+    return part.text;
+  }
+  try {
+    return JSON.stringify(part);
+  } catch {
+    return String(part);
+  }
+}
+
+function partListToText(parts: PartListUnion): string {
+  if (typeof parts === 'string') {
+    return parts;
+  }
+  const list = Array.isArray(parts) ? parts : [parts];
+  return list.map((part) => stringifyPart(part)).join('');
+}
+
+function mergePendingItem(
+  pendingItems: HistoryItemWithoutId[],
+  incoming: HistoryItemWithoutId,
+): HistoryItemWithoutId[] {
+  const last = pendingItems[pendingItems.length - 1];
+  if (
+    last &&
+    (last.type === 'gemini' || last.type === 'gemini_content') &&
+    (incoming.type === 'gemini' || incoming.type === 'gemini_content')
+  ) {
+    return [
+      ...pendingItems.slice(0, -1),
+      { type: last.type, text: `${last.text}${incoming.text}` },
+    ];
+  }
+
+  if (
+    last &&
+    (last.type === 'gemini_thought' ||
+      last.type === 'gemini_thought_content') &&
+    (incoming.type === 'gemini_thought' ||
+      incoming.type === 'gemini_thought_content')
+  ) {
+    return [
+      ...pendingItems.slice(0, -1),
+      { type: last.type, text: `${last.text}${incoming.text}` },
+    ];
+  }
+
+  return [...pendingItems, incoming];
+}
+
+function replacePendingToolGroup(
+  pendingItems: HistoryItemWithoutId[],
+  incoming: HistoryItemToolGroup,
+): HistoryItemWithoutId[] {
+  const toolGroupIndex = pendingItems.findIndex(
+    (item) => item.type === 'tool_group',
+  );
+  if (toolGroupIndex < 0) {
+    return [...pendingItems, incoming];
+  }
+  return pendingItems.map((item, index) =>
+    index === toolGroupIndex ? incoming : item,
+  );
+}
+
+function createSessionOptions(
+  options: DaemonTuiRuntimeOptions,
+): CreateDaemonTuiSessionOptions {
+  return {
+    daemonUrl: options.daemonUrl,
+    token: options.token,
+    workspaceCwd: options.workspaceCwd,
+    model: options.model,
+    sessionId: options.sessionId,
+    sessionScope: options.sessionScope,
+  };
+}
+
+export const useDaemonTuiStream = (
+  _geminiClient: GeminiClient,
+  _history: HistoryItem[],
+  addItem: UseHistoryManagerReturn['addItem'],
+  config: Config,
+  _settings: LoadedSettings,
+  onDebugMessage: (message: string) => void,
+  handleSlashCommand: (
+    cmd: PartListUnion,
+  ) => Promise<SlashCommandProcessorResult | false>,
+  _shellModeActive: boolean,
+  _getPreferredEditor: () => EditorType | undefined,
+  _onAuthError: (error: string) => void,
+  _performMemoryRefresh: () => Promise<void>,
+  _modelSwitchedFromQuotaError: boolean,
+  _setModelSwitchedFromQuotaError: Dispatch<SetStateAction<boolean>>,
+  _onEditorClose: () => void,
+  _onCancelSubmit: (info?: CancelSubmitInfo) => void,
+  _setShellInputFocused: (value: boolean) => void,
+  _terminalWidth: number,
+  _terminalHeight: number,
+  _midTurnDrainRef?: React.RefObject<(() => string[]) | null>,
+  logger?: Logger | null,
+  daemonOptions?: DaemonTuiRuntimeOptions,
+): GeminiStreamResult => {
+  const [streamingState, setStreamingState] = useState<StreamingState>(
+    StreamingState.Idle,
+  );
+  const [initError, setInitError] = useState<string | null>(null);
+  const [pendingHistoryItems, setPendingHistoryItems] = useState<
+    HistoryItemWithoutId[]
+  >([]);
+  const [thought, setThought] = useState<ThoughtSummary | null>(null);
+  const [isReceivingContent, setIsReceivingContent] = useState(false);
+  const streamingResponseLengthRef = useRef(0);
+  const adapterRef = useRef<DaemonTuiAdapter | null>(null);
+  const pendingItemsRef = useRef<HistoryItemWithoutId[]>([]);
+  const lastPromptRef = useRef<PartListUnion | null>(null);
+  const sendGenerationRef = useRef(0);
+  const queuedSubmissionsRef = useRef<QueuedSubmission[]>([]);
+  const submitQueryRef = useRef<SubmitQuery | null>(null);
+
+  const runtimeOptions = useMemo(
+    () =>
+      daemonOptions ?? {
+        enabled: true,
+        daemonUrl: process.env['QWEN_DAEMON_URL'] ?? 'http://127.0.0.1:4170',
+        token: process.env['QWEN_DAEMON_TOKEN'],
+        workspaceCwd: config.getTargetDir(),
+        model: config.getModel(),
+      },
+    [config, daemonOptions],
+  );
+
+  const setPending = useCallback(
+    (
+      updater:
+        | HistoryItemWithoutId[]
+        | ((current: HistoryItemWithoutId[]) => HistoryItemWithoutId[]),
+    ) => {
+      setPendingHistoryItems((current) => {
+        const next = typeof updater === 'function' ? updater(current) : updater;
+        pendingItemsRef.current = next;
+        return next;
+      });
+    },
+    [],
+  );
+
+  const flushPendingItems = useCallback(() => {
+    const pending = pendingItemsRef.current;
+    if (pending.length === 0) {
+      return;
+    }
+    const timestamp = Date.now();
+    for (const item of pending) {
+      addItem(item, timestamp);
+    }
+    setPending([]);
+  }, [addItem, setPending]);
+
+  const handleUpdate = useCallback(
+    (update: DaemonTuiUpdate) => {
+      switch (update.type) {
+        case 'history': {
+          const item =
+            update.item.type === 'gemini_content'
+              ? ({ type: 'gemini', text: update.item.text } as const)
+              : update.item.type === 'gemini_thought_content'
+                ? ({ type: 'gemini_thought', text: update.item.text } as const)
+                : update.item;
+          if (item.type === 'gemini') {
+            streamingResponseLengthRef.current += item.text.length;
+            setIsReceivingContent(true);
+            setPending((current) => mergePendingItem(current, item));
+            return;
+          }
+          if (item.type === 'gemini_thought') {
+            setThought((current) => ({
+              subject: current?.subject ?? '',
+              description: `${current?.description ?? ''}${item.text}`,
+            }));
+            setPending((current) => mergePendingItem(current, item));
+            return;
+          }
+          setPending((current) => mergePendingItem(current, item));
+          return;
+        }
+        case 'tool_group_update':
+          setPending((current) =>
+            replacePendingToolGroup(current, update.item),
+          );
+          return;
+        case 'permission_request':
+          setPending((current) => [
+            ...current,
+            {
+              type: MessageType.WARNING,
+              text:
+                `Daemon requested permission for ${update.request.toolCall.kind}. ` +
+                'Native daemon permission UI is not wired in this draft yet.',
+            },
+          ]);
+          return;
+        case 'permission_resolved':
+          setPending((current) => [
+            ...current,
+            {
+              type: MessageType.INFO,
+              text: `Daemon permission resolved: ${update.requestId}`,
+            },
+          ]);
+          return;
+        case 'model_switched':
+          onDebugMessage(`Daemon model switched to ${update.modelId}`);
+          return;
+        case 'disconnected':
+          setStreamingState(StreamingState.Idle);
+          setIsReceivingContent(false);
+          addItem(
+            {
+              type: MessageType.ERROR,
+              text: `Daemon disconnected: ${update.reason}`,
+            },
+            Date.now(),
+          );
+          return;
+        default: {
+          const neverUpdate: never = update;
+          onDebugMessage(
+            `Unknown daemon update: ${JSON.stringify(neverUpdate)}`,
+          );
+        }
+      }
+    },
+    [addItem, onDebugMessage, setPending],
+  );
+
+  useEffect(() => {
+    if (!runtimeOptions.enabled) {
+      return undefined;
+    }
+    let disposed = false;
+    let adapter: DaemonTuiAdapter | null = null;
+
+    const connect = async () => {
+      try {
+        const session = await createDaemonTuiSession(
+          createSessionOptions(runtimeOptions),
+        );
+        if (disposed) {
+          return;
+        }
+        adapter = new DaemonTuiAdapter({
+          session,
+          onUpdate: handleUpdate,
+        });
+        adapter.start();
+        adapterRef.current = adapter;
+        setInitError(null);
+        addItem(
+          {
+            type: MessageType.INFO,
+            text: `Connected to daemon session ${session.sessionId} (${session.workspaceCwd})`,
+          },
+          Date.now(),
+        );
+        const queuedSubmissions = queuedSubmissionsRef.current.splice(0);
+        for (const queuedSubmission of queuedSubmissions) {
+          void submitQueryRef.current?.(
+            queuedSubmission.query,
+            queuedSubmission.submitType,
+          );
+        }
+      } catch (error) {
+        if (disposed) {
+          return;
+        }
+        const message = error instanceof Error ? error.message : String(error);
+        setInitError(message);
+        addItem(
+          {
+            type: MessageType.ERROR,
+            text: `Failed to connect daemon TUI: ${message}`,
+          },
+          Date.now(),
+        );
+      }
+    };
+
+    void connect();
+
+    return () => {
+      disposed = true;
+      adapterRef.current = null;
+      void adapter?.stop();
+    };
+  }, [addItem, handleUpdate, runtimeOptions]);
+
+  const submitQuery = useCallback(
+    async (
+      query: PartListUnion,
+      submitType: SendMessageType = SendMessageType.UserQuery,
+    ) => {
+      if (streamingState !== StreamingState.Idle) {
+        return;
+      }
+
+      const adapter = adapterRef.current;
+      if (!adapter) {
+        queuedSubmissionsRef.current.push({ query, submitType });
+        onDebugMessage('Queued daemon prompt until the session connects');
+        return;
+      }
+
+      if (typeof query === 'string') {
+        const trimmedQuery = query.trim();
+        if (trimmedQuery.length === 0) {
+          return;
+        }
+
+        if (submitType !== SendMessageType.Notification) {
+          await logger?.logMessage(MessageSenderType.USER, trimmedQuery);
+        }
+
+        const slashCommandResult = trimmedQuery.startsWith('/')
+          ? await handleSlashCommand(trimmedQuery)
+          : false;
+        if (slashCommandResult) {
+          if (slashCommandResult.type === 'handled') {
+            return;
+          }
+          if (slashCommandResult.type === 'submit_prompt') {
+            query = slashCommandResult.content;
+          } else {
+            addItem(
+              {
+                type: MessageType.WARNING,
+                text:
+                  `Slash command scheduled local tool "${slashCommandResult.toolName}", ` +
+                  'but daemon TUI tool scheduling is not wired in this draft yet.',
+              },
+              Date.now(),
+            );
+            return;
+          }
+        } else if (submitType !== SendMessageType.Notification) {
+          addItem({ type: MessageType.USER, text: trimmedQuery }, Date.now());
+        }
+      }
+
+      const generation = ++sendGenerationRef.current;
+      lastPromptRef.current = query;
+      streamingResponseLengthRef.current = 0;
+      setIsReceivingContent(false);
+      setThought(null);
+      setPending([]);
+      setStreamingState(StreamingState.Responding);
+      try {
+        const promptText = partListToText(query);
+        onDebugMessage(`Sending daemon prompt (${promptText.length} chars)`);
+        await adapter.sendPrompt(promptText);
+        if (sendGenerationRef.current === generation) {
+          flushPendingItems();
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        addItem({ type: MessageType.ERROR, text: message }, Date.now());
+      } finally {
+        if (sendGenerationRef.current === generation) {
+          setStreamingState(StreamingState.Idle);
+          setIsReceivingContent(false);
+        }
+      }
+    },
+    [
+      addItem,
+      flushPendingItems,
+      handleSlashCommand,
+      logger,
+      onDebugMessage,
+      setPending,
+      streamingState,
+    ],
+  );
+  submitQueryRef.current = submitQuery;
+
+  const cancelOngoingRequest = useCallback(() => {
+    const adapter = adapterRef.current;
+    if (!adapter) {
+      return;
+    }
+    void adapter.cancel().catch((error) => {
+      addItem(
+        {
+          type: MessageType.ERROR,
+          text: error instanceof Error ? error.message : String(error),
+        },
+        Date.now(),
+      );
+    });
+  }, [addItem]);
+
+  const retryLastPrompt = useCallback(async () => {
+    if (!lastPromptRef.current) {
+      addItem(
+        { type: MessageType.INFO, text: 'No daemon prompt to retry.' },
+        Date.now(),
+      );
+      return;
+    }
+    await submitQuery(lastPromptRef.current, SendMessageType.Retry);
+  }, [addItem, submitQuery]);
+
+  const handleApprovalModeChange = useCallback(
+    async (_newApprovalMode: ApprovalMode) => {},
+    [],
+  );
+
+  return {
+    streamingState,
+    submitQuery,
+    initError,
+    pendingHistoryItems,
+    thought,
+    cancelOngoingRequest,
+    retryLastPrompt,
+    pendingToolCalls: [],
+    handleApprovalModeChange,
+    activePtyId: undefined,
+    loopDetectionConfirmationRequest: null,
+    streamingResponseLengthRef,
+    isReceivingContent,
+  };
+};

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -38,9 +38,9 @@ execSync('npm run generate', { stdio: 'inherit', cwd: root });
 // 2. web-templates (embeddable web templates - used by cli)
 // 3. channel-base (base channel infrastructure - used by channel adapters and cli)
 // 4. channel adapters (depend on channel-base)
-// 5. cli (depends on core, web-templates, channel packages)
-// 6. webui (shared UI components - used by vscode companion)
-// 7. sdk (no internal dependencies)
+// 5. sdk (daemon client protocol helpers consumed by daemon-backed adapters)
+// 6. cli (depends on core, web-templates, channel packages, sdk)
+// 7. webui (shared UI components - used by vscode companion)
 // 8. vscode-ide-companion (depends on webui)
 const buildOrder = [
   'packages/core',
@@ -50,9 +50,9 @@ const buildOrder = [
   'packages/channels/weixin',
   'packages/channels/dingtalk',
   'packages/channels/plugin-example',
+  'packages/sdk-typescript',
   'packages/cli',
   'packages/webui',
-  'packages/sdk-typescript',
   'packages/vscode-ide-companion',
 ];
 


### PR DESCRIPTION
## Summary

- What changed: Adds a gated `--experimental-daemon-tui` path for the normal TUI entrypoint. When enabled, the TUI creates or attaches to a `qwen serve` daemon session, submits prompts through the daemon session client, and renders daemon SSE updates through existing TUI history/pending-item components instead of the text-only `daemon-tui` harness.
- Architecture alignment: This draft is explicitly the daemon-native TUI renderer path. It consumes typed daemon events through `DaemonSessionClient`/`DaemonTuiAdapter` and projects them into the Ink UI; it is not a PTY proxy and does not add a second runtime path.
- Why it changed: The harness proved the adapter works, but its raw event printing is not representative of the real TUI experience. This draft lets reviewers measure the real replacement surface while keeping the current TUI path unchanged by default.
- Reviewer focus: Flag gating, daemon session lifecycle, pending assistant/tool rendering, deployment locality assumptions, and whether the remaining control-plane gaps are the right follow-up split.

## Validation

- Commands run:
  ```bash
  npm run typecheck --workspace=packages/cli
  npm run build --workspace=packages/cli
  npm run build

  env -u NODE_OPTIONS QWEN_CODE_NO_RELAUNCH=1 \
    node packages/cli/dist/index.js serve \
    --port 4882 \
    --workspace "$PWD"

  env -u NODE_OPTIONS QWEN_CODE_NO_RELAUNCH=1 \
    node packages/cli/dist/index.js \
    --experimental-daemon-tui \
    --daemon-url http://127.0.0.1:4882 \
    --prompt-interactive "只回答 OK"
  ```
- Prompts / inputs used: `只回答 OK`
- Expected result: The regular TUI opens, connects to the daemon session, submits the initial prompt after the session is ready, and renders the answer in the normal assistant area instead of printing raw daemon event lines.
- Observed result: The TUI connected to the daemon session, rendered `> 只回答 OK`, streamed through the normal pending assistant UI, and displayed `OK` as assistant output. No `[gemini_thought_content]` raw event prefixes were printed.
- Latest follow-up validation: `npm run typecheck --workspace=packages/cli`, `npm run build --workspace=packages/cli`, and `git diff --check` passed after the architecture-boundary follow-up commit.
- Quickest reviewer verification path: Start `qwen serve` with the built CLI, then run the second command above from the same workspace.

## Scope / Risk

- Main risk or tradeoff: This is intentionally a draft spike. It proves the normal TUI can be backed by daemon events, but it does not yet claim feature parity with local `useGeminiStream`.
- Deployment shape validated: local-local daemon/TUI. Local-TUI-to-remote-daemon remains a follow-up because workspace path mapping and client-local capability behavior need explicit design.
- Not covered / not validated: Native daemon permission dialog wiring, daemon-backed local tool scheduling from slash commands, full resume/history semantics, daemon-backed follow-up suggestions, local-TUI-to-remote-daemon path mapping, and non-macOS manual validation.
- Breaking changes / migration notes: None intended. The new path is hidden behind `--experimental-daemon-tui`; without that flag the existing TUI continues to call `useGeminiStream`.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Manual daemon/TUI validation was performed on macOS with the built CLI.
- Windows, Linux, sandbox, and package-manager entrypoint variants are not covered by this draft validation.

## Linked Issues / Bugs

Related to #3803 and #4175.