### PR TITLE
fix(serve): add mcp_guardrails to E2E capabilities expectation

### DIFF
--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -214,6 +214,7 @@ describe('qwen serve — capabilities envelope', () => {
       'session_supported_commands',
       'session_close',
       'session_metadata',
+      'mcp_guardrails',
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- **What changed:** Append `'mcp_guardrails'` to the expected `caps.features` array in `integration-tests/cli/qwen-serve-routes.test.ts` (the `qwen serve — capabilities envelope > advertises all baseline capabilities` assertion).
- **Why it changed:** PR #4247 (`feat(serve): MCP client guardrails`) added the always-on `mcp_guardrails` capability to `SERVE_CAPABILITY_REGISTRY` in `packages/cli/src/serve/capabilities.ts` and updated the unit-level `EXPECTED_STAGE1_FEATURES` constant in `packages/cli/src/serve/server.test.ts`, but missed the matching integration-test expectation. The E2E test on `main` has been failing since #4247 landed (run [26014877520](https://github.com/QwenLM/qwen-code/actions/runs/26014877520/job/76462763662)). This PR realigns the integration test with the registered capability list.
- **Reviewer focus:** Confirm the new entry is positioned consistently with `SERVE_CAPABILITY_REGISTRY` order (after `session_metadata`, before the conditional `require_auth`). No production code changes.

## Validation

- Commands run:
  ```bash
  # 1. Build the bundle (E2E uses dist/cli.js)
  cd /Users/wenshao/git/qwen-code-x7 && npm run build && npm run bundle

  # 2. Run the previously-failing integration test
  cross-env QWEN_SANDBOX=false npx vitest run     --root ./integration-tests cli/qwen-serve-routes.test.ts

  # 3. Run the related unit test that holds EXPECTED_STAGE1_FEATURES
  cd packages/cli && npx vitest run src/serve/server.test.ts
  ```

- Expected result: the `advertises all baseline capabilities` assertion passes; no regressions in either file.

- Observed result:
  - `integration-tests/cli/qwen-serve-routes.test.ts`: **26 passed (26)** in 3.67s — the previously failing `qwen serve — capabilities envelope > advertises all baseline capabilities` test now passes (2ms).
  - `packages/cli/src/serve/server.test.ts`: **156 passed (156)** in 9.24s — capability-registry assertions (`returns a fresh ordered registered feature list`, `exposes 'modes' metadata on mcp_guardrails`, etc.) all pass, confirming `EXPECTED_STAGE1_FEATURES` and the integration-test array agree on ordering.

- Quickest reviewer verification path: re-run the failing E2E job linked above (`E2E Test - macOS` / `E2E Test (Linux) - sandbox:none`).

- Evidence — failing assertion before this PR:
  ```
  AssertionError: expected [ 'health', 'capabilities', …(25) ]
                  to deeply equal [ 'health', 'capabilities', …(24) ]

  @@ -23,6 +23,7 @@
       "session_supported_commands",
       "session_close",
       "session_metadata",
  +    "mcp_guardrails",
    ]
   ❯ cli/qwen-serve-routes.test.ts:190:27
  ```

## Scope / Risk

- **Main risk or tradeoff:** None — test-only change that brings the integration-test expectation in sync with already-merged production code.
- **Not covered / not validated:** Did not run the full E2E suite locally (single-file run is sufficient for this assertion).
- **Breaking changes / migration notes:** None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | N/A | N/A | N/A |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Verified locally on macOS via `npm run build && npm run bundle` + targeted vitest runs of the affected integration and unit test files. The change is platform-agnostic (only an in-memory string array literal in a test) and the matching CI job runs on both `macos-latest` and `ubuntu-latest`.

## Linked Issues / Bugs

- Follow-up to #4247 (capability registered, unit test updated, integration test expectation missed).