### PR TITLE
Support active goal stream events and non-interactive goals

### DIFF
--- a/packages/cli/src/nonInteractiveCliCommands.test.ts
+++ b/packages/cli/src/nonInteractiveCliCommands.test.ts
@@ -4,15 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   getAvailableCommands,
   handleSlashCommand,
 } from './nonInteractiveCliCommands.js';
-import type { Config } from '@qwen-code/qwen-code-core';
+import {
+  __resetActiveGoalStoreForTests,
+  type Config,
+} from '@qwen-code/qwen-code-core';
 import type { LoadedSettings } from './config/settings.js';
 import { CommandKind, type ExecutionMode } from './ui/commands/types.js';
 import { filterCommandsForMode } from './services/commandUtils.js';
+import { goalCommand } from './ui/commands/goalCommand.js';
 
 // Mock the CommandService
 const mockGetCommands = vi.hoisted(() => vi.fn());
@@ -32,6 +36,7 @@ describe('handleSlashCommand', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetActiveGoalStoreForTests();
     // getCommandsForMode applies real mode filtering on top of getCommands()
     mockGetCommandsForMode.mockImplementation((mode: ExecutionMode) =>
       filterCommandsForMode(mockGetCommands(), mode),
@@ -55,6 +60,12 @@ describe('handleSlashCommand', () => {
       getFolderTrustFeature: vi.fn().mockReturnValue(false),
       getFolderTrust: vi.fn().mockReturnValue(false),
       getProjectRoot: vi.fn().mockReturnValue('/test/project'),
+      isTrustedFolder: vi.fn().mockReturnValue(true),
+      getDisableAllHooks: vi.fn().mockReturnValue(false),
+      getHookSystem: vi.fn().mockReturnValue({
+        addFunctionHook: vi.fn().mockReturnValue('goal-hook-id'),
+        removeFunctionHook: vi.fn().mockReturnValue(true),
+      }),
       setModelInvocableCommandsProvider: vi.fn(),
       setModelInvocableCommandsExecutor: vi.fn(),
       getDisabledSlashCommands: vi.fn().mockReturnValue([]),
@@ -69,6 +80,10 @@ describe('handleSlashCommand', () => {
     } as LoadedSettings;
 
     abortController = new AbortController();
+  });
+
+  afterEach(() => {
+    __resetActiveGoalStoreForTests();
   });
 
   it('should return no_command for non-slash input', async () => {
@@ -196,6 +211,26 @@ describe('handleSlashCommand', () => {
     expect(result.type).toBe('message');
     if (result.type === 'message') {
       expect(result.content).toBe('btw> question\nanswer');
+    }
+  });
+
+  it('should execute /goal in non-interactive mode as a submit_prompt command', async () => {
+    mockGetCommands.mockReturnValue([goalCommand]);
+
+    const result = await handleSlashCommand(
+      '/goal write a hello world script',
+      abortController,
+      mockConfig,
+      mockSettings,
+    );
+
+    expect(result.type).toBe('submit_prompt');
+    if (result.type === 'submit_prompt') {
+      expect(result.content).toEqual([
+        expect.objectContaining({
+          text: expect.stringContaining('write a hello world script'),
+        }),
+      ]);
     }
   });
 

--- a/packages/cli/src/ui/commands/goalCommand.test.ts
+++ b/packages/cli/src/ui/commands/goalCommand.test.ts
@@ -31,8 +31,11 @@ describe('goalCommand', () => {
   beforeEach(() => __resetActiveGoalStoreForTests());
   afterEach(() => __resetActiveGoalStoreForTests());
 
-  it('is currently limited to interactive mode', () => {
-    expect(goalCommand.supportedModes).toEqual(['interactive']);
+  it('is available in interactive and non-interactive modes', () => {
+    expect(goalCommand.supportedModes).toEqual([
+      'interactive',
+      'non_interactive',
+    ]);
   });
 
   it('rejects when config is missing', async () => {

--- a/packages/cli/src/ui/commands/goalCommand.ts
+++ b/packages/cli/src/ui/commands/goalCommand.ts
@@ -100,7 +100,7 @@ export const goalCommand: SlashCommand = {
   },
   argumentHint: '[<condition> | clear]',
   kind: CommandKind.BUILT_IN,
-  supportedModes: ['interactive'] as const,
+  supportedModes: ['interactive', 'non_interactive'] as const,
   action: async (
     context: CommandContext,
     args: string,

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -78,6 +78,8 @@ const mockParseAndFormatApiError = vi.hoisted(() =>
 );
 const mockLogApiCancel = vi.hoisted(() => vi.fn());
 const mockGetActiveGoal = vi.hoisted(() => vi.fn());
+const mockSetActiveGoal = vi.hoisted(() => vi.fn());
+const mockClearActiveGoal = vi.hoisted(() => vi.fn());
 
 vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
   const actualCoreModule = (await importOriginal()) as any;
@@ -90,6 +92,8 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
     parseAndFormatApiError: mockParseAndFormatApiError,
     logApiCancel: mockLogApiCancel,
     getActiveGoal: mockGetActiveGoal,
+    setActiveGoal: mockSetActiveGoal,
+    clearActiveGoal: mockClearActiveGoal,
   };
 });
 
@@ -4638,6 +4642,41 @@ describe('useGeminiStream', () => {
   });
 
   describe('StopHookLoop Event', () => {
+    it('syncs active_goal events into the active goal store', async () => {
+      const activeGoal = {
+        condition: 'finish the refactor',
+        iterations: 1,
+        setAt: 123,
+        tokensAtStart: 456,
+        hookId: 'goal-hook-id',
+        lastReason: 'still missing verification',
+      };
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.ActiveGoal,
+            value: activeGoal,
+          };
+          yield {
+            type: ServerGeminiEventType.ActiveGoal,
+            value: null,
+          };
+        })(),
+      );
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('continue goal');
+      });
+
+      expect(mockSetActiveGoal).toHaveBeenCalledWith(
+        'test-session-id',
+        activeGoal,
+      );
+      expect(mockClearActiveGoal).toHaveBeenCalledWith('test-session-id');
+    });
+
     it('should handle StopHookLoop event and add stop hook loop history item', async () => {
       mockSendMessageStream.mockReturnValue(
         (async function* () {

--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -78,6 +78,7 @@ const mockParseAndFormatApiError = vi.hoisted(() =>
 );
 const mockLogApiCancel = vi.hoisted(() => vi.fn());
 const mockGetActiveGoal = vi.hoisted(() => vi.fn());
+const mockActiveGoalEquals = vi.hoisted(() => vi.fn());
 const mockSetActiveGoal = vi.hoisted(() => vi.fn());
 const mockClearActiveGoal = vi.hoisted(() => vi.fn());
 
@@ -92,6 +93,7 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
     parseAndFormatApiError: mockParseAndFormatApiError,
     logApiCancel: mockLogApiCancel,
     getActiveGoal: mockGetActiveGoal,
+    activeGoalEquals: mockActiveGoalEquals,
     setActiveGoal: mockSetActiveGoal,
     clearActiveGoal: mockClearActiveGoal,
   };
@@ -157,6 +159,7 @@ describe('useGeminiStream', () => {
   beforeEach(() => {
     vi.clearAllMocks(); // Clear mocks before each test
     mockGetActiveGoal.mockReturnValue(undefined);
+    mockActiveGoalEquals.mockReturnValue(false);
     vi.mocked(findLastSafeSplitPoint).mockImplementation(
       (s: string) => s.length,
     );
@@ -4663,6 +4666,10 @@ describe('useGeminiStream', () => {
           };
         })(),
       );
+      mockGetActiveGoal
+        .mockReturnValueOnce(undefined)
+        .mockReturnValueOnce(activeGoal);
+      mockActiveGoalEquals.mockReturnValue(false);
 
       const { result } = renderTestHook();
 
@@ -4675,6 +4682,42 @@ describe('useGeminiStream', () => {
         activeGoal,
       );
       expect(mockClearActiveGoal).toHaveBeenCalledWith('test-session-id');
+    });
+
+    it('skips redundant active_goal store updates', async () => {
+      const activeGoal = {
+        condition: 'finish the refactor',
+        iterations: 1,
+        setAt: 123,
+        tokensAtStart: 456,
+        hookId: 'goal-hook-id',
+        lastReason: 'still missing verification',
+      };
+      mockSendMessageStream.mockReturnValue(
+        (async function* () {
+          yield {
+            type: ServerGeminiEventType.ActiveGoal,
+            value: activeGoal,
+          };
+          yield {
+            type: ServerGeminiEventType.ActiveGoal,
+            value: null,
+          };
+        })(),
+      );
+      mockGetActiveGoal
+        .mockReturnValueOnce(activeGoal)
+        .mockReturnValueOnce(undefined);
+      mockActiveGoalEquals.mockReturnValue(true);
+
+      const { result } = renderTestHook();
+
+      await act(async () => {
+        await result.current.submitQuery('continue goal');
+      });
+
+      expect(mockSetActiveGoal).not.toHaveBeenCalled();
+      expect(mockClearActiveGoal).not.toHaveBeenCalled();
     });
 
     it('should handle StopHookLoop event and add stop hook loop history item', async () => {

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -26,6 +26,7 @@ import type {
   ToolCallRequestInfo,
   GeminiErrorEventValue,
   StopFailureErrorType,
+  ActiveGoal,
 } from '@qwen-code/qwen-code-core';
 import {
   GeminiEventType as ServerGeminiEventType,
@@ -52,6 +53,8 @@ import {
   getUnsupportedImageFormatWarning,
   generateToolUseSummary,
   getActiveGoal,
+  setActiveGoal,
+  clearActiveGoal,
 } from '@qwen-code/qwen-code-core';
 import { type Part, type PartListUnion, FinishReason } from '@google/genai';
 import type {
@@ -1339,6 +1342,18 @@ export const useGeminiStream = (
     [addItem, config, pendingHistoryItemRef, setPendingHistoryItem],
   );
 
+  const handleActiveGoalEvent = useCallback(
+    (activeGoal: ActiveGoal | null) => {
+      const sessionId = config.getSessionId();
+      if (activeGoal) {
+        setActiveGoal(sessionId, activeGoal);
+        return;
+      }
+      clearActiveGoal(sessionId);
+    },
+    [config],
+  );
+
   const processGeminiStreamEvents = useCallback(
     async (
       stream: AsyncIterable<GeminiEvent>,
@@ -1573,6 +1588,9 @@ export const useGeminiStream = (
               flushBufferedStreamEvents();
               handleStopHookLoopEvent(event.value, userMessageTimestamp);
               break;
+            case ServerGeminiEventType.ActiveGoal:
+              handleActiveGoalEvent(event.value);
+              break;
             default: {
               // enforces exhaustive switch-case
               const unreachable: never = event;
@@ -1609,6 +1627,7 @@ export const useGeminiStream = (
       setPendingHistoryItem,
       handleUserPromptSubmitBlockedEvent,
       handleStopHookLoopEvent,
+      handleActiveGoalEvent,
       addItem,
       dualOutput,
     ],

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -53,6 +53,7 @@ import {
   getUnsupportedImageFormatWarning,
   generateToolUseSummary,
   getActiveGoal,
+  activeGoalEquals,
   setActiveGoal,
   clearActiveGoal,
 } from '@qwen-code/qwen-code-core';
@@ -1345,8 +1346,15 @@ export const useGeminiStream = (
   const handleActiveGoalEvent = useCallback(
     (activeGoal: ActiveGoal | null) => {
       const sessionId = config.getSessionId();
+      const currentActiveGoal = getActiveGoal(sessionId);
       if (activeGoal) {
+        if (activeGoalEquals(currentActiveGoal, activeGoal)) {
+          return;
+        }
         setActiveGoal(sessionId, activeGoal);
+        return;
+      }
+      if (!currentActiveGoal) {
         return;
       }
       clearActiveGoal(sessionId);

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -4590,6 +4590,72 @@ Other open files:
         });
       });
 
+      it('emits active_goal null when the Stop hook clears the goal before aborting', async () => {
+        setActiveGoal('test-session-id', {
+          condition: 'finish the refactor',
+          iterations: 2,
+          setAt: 123,
+          tokensAtStart: 456,
+          hookId: 'goal-hook-id',
+          lastReason: 'still missing verification',
+        });
+        const abortController = new AbortController();
+        const mockMessageBus = {
+          request: vi.fn().mockImplementation(async () => {
+            clearActiveGoal('test-session-id');
+            abortController.abort();
+            return {};
+          }),
+          response: vi.fn(),
+        };
+        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
+          (event: string) => event === 'Stop',
+        );
+        client['chat'] = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([
+            {
+              role: 'model',
+              parts: [{ text: 'done' }],
+            },
+          ]),
+        } as unknown as GeminiChat;
+        mockTurnRunFn.mockReturnValue(
+          (async function* () {
+            yield { type: GeminiEventType.Content, value: 'done' };
+          })(),
+        );
+
+        const events = await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'Hi' }],
+            abortController.signal,
+            'prompt-cleared-active-goal-abort',
+          ),
+        );
+
+        const activeGoalEvents = events.filter(
+          (event) => event.type === GeminiEventType.ActiveGoal,
+        );
+
+        expect(activeGoalEvents).toEqual([
+          {
+            type: GeminiEventType.ActiveGoal,
+            value: expect.objectContaining({
+              condition: 'finish the refactor',
+            }),
+          },
+          {
+            type: GeminiEventType.ActiveGoal,
+            value: null,
+          },
+        ]);
+      });
+
       it('should skip messageBus.request for UserPromptSubmit when hasHooksForEvent returns false', async () => {
         // Enable hooks and provide messageBus
         const mockMessageBus = {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -4656,6 +4656,96 @@ Other open files:
         ]);
       });
 
+      it('emits active_goal changes when aborting before Stop hook continuation', async () => {
+        setActiveGoal('test-session-id', {
+          condition: 'finish the refactor',
+          iterations: 2,
+          setAt: 123,
+          tokensAtStart: 456,
+          hookId: 'goal-hook-id',
+          lastReason: 'still missing verification',
+        });
+        const abortController = new AbortController();
+        const mockMessageBus = {
+          request: vi.fn().mockImplementation(async () => {
+            setActiveGoal('test-session-id', {
+              condition: 'finish the refactor',
+              iterations: 3,
+              setAt: 123,
+              tokensAtStart: 456,
+              hookId: 'goal-hook-id',
+              lastReason: 'still missing validation',
+            });
+            return {
+              output: {
+                get decision() {
+                  abortController.abort();
+                  return 'block';
+                },
+                reason: 'Keep working',
+              },
+              stopHookCount: 1,
+            };
+          }),
+          response: vi.fn(),
+        };
+        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
+          (event: string) => event === 'Stop',
+        );
+        client['chat'] = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([
+            {
+              role: 'model',
+              parts: [{ text: 'done' }],
+            },
+          ]),
+        } as unknown as GeminiChat;
+        mockTurnRunFn.mockReturnValue(
+          (async function* () {
+            yield { type: GeminiEventType.Content, value: 'done' };
+          })(),
+        );
+
+        const events = await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'Hi' }],
+            abortController.signal,
+            'prompt-stop-hook-continuation-aborted',
+          ),
+        );
+        const activeGoalEvents = events.filter(
+          (event) => event.type === GeminiEventType.ActiveGoal,
+        );
+
+        expect(activeGoalEvents).toEqual([
+          {
+            type: GeminiEventType.ActiveGoal,
+            value: expect.objectContaining({
+              condition: 'finish the refactor',
+              iterations: 2,
+            }),
+          },
+          {
+            type: GeminiEventType.ActiveGoal,
+            value: expect.objectContaining({
+              condition: 'finish the refactor',
+              iterations: 3,
+              lastReason: 'still missing validation',
+            }),
+          },
+        ]);
+        expect(events).not.toContainEqual(
+          expect.objectContaining({
+            type: GeminiEventType.StopHookLoop,
+          }),
+        );
+      });
+
       it('should skip messageBus.request for UserPromptSubmit when hasHooksForEvent returns false', async () => {
         // Enable hooks and provide messageBus
         const mockMessageBus = {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -52,6 +52,11 @@ import { promptIdContext } from '../utils/promptIdContext.js';
 import { setSimulate429 } from '../utils/testUtils.js';
 import { ideContextStore } from '../ide/ideContext.js';
 import { uiTelemetryService } from '../telemetry/uiTelemetry.js';
+import {
+  __resetActiveGoalStoreForTests,
+  clearActiveGoal,
+  setActiveGoal,
+} from '../goals/activeGoalStore.js';
 
 // Mock fs module to prevent actual file system operations during tests
 const mockFileSystem = new Map<string, string>();
@@ -514,6 +519,7 @@ describe('Gemini Client (client.ts)', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    __resetActiveGoalStoreForTests();
   });
 
   describe('initialize', () => {
@@ -4499,6 +4505,89 @@ Other open files:
           getHistory: vi.fn().mockReturnValue([]),
         };
         client['chat'] = mockChat as GeminiChat;
+      });
+
+      it('emits active_goal when a goal is active for the turn', async () => {
+        setActiveGoal('test-session-id', {
+          condition: 'finish the refactor',
+          iterations: 2,
+          setAt: 123,
+          tokensAtStart: 456,
+          hookId: 'goal-hook-id',
+          lastReason: 'still missing verification',
+        });
+
+        const events = await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'Hi' }],
+            new AbortController().signal,
+            'prompt-active-goal',
+          ),
+        );
+
+        expect(events[0]).toEqual({
+          type: GeminiEventType.ActiveGoal,
+          value: {
+            condition: 'finish the refactor',
+            iterations: 2,
+            setAt: 123,
+            tokensAtStart: 456,
+            hookId: 'goal-hook-id',
+            lastReason: 'still missing verification',
+          },
+        });
+      });
+
+      it('emits active_goal null when the Stop hook clears the goal', async () => {
+        setActiveGoal('test-session-id', {
+          condition: 'finish the refactor',
+          iterations: 2,
+          setAt: 123,
+          tokensAtStart: 456,
+          hookId: 'goal-hook-id',
+          lastReason: 'still missing verification',
+        });
+        const mockMessageBus = {
+          request: vi.fn().mockImplementation(async () => {
+            clearActiveGoal('test-session-id');
+            return {};
+          }),
+          response: vi.fn(),
+        };
+        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
+          (event: string) => event === 'Stop',
+        );
+        client['chat'] = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([
+            {
+              role: 'model',
+              parts: [{ text: 'done' }],
+            },
+          ]),
+        } as unknown as GeminiChat;
+        mockTurnRunFn.mockReturnValue(
+          (async function* () {
+            yield { type: GeminiEventType.Content, value: 'done' };
+          })(),
+        );
+
+        const events = await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'Hi' }],
+            new AbortController().signal,
+            'prompt-cleared-active-goal',
+          ),
+        );
+
+        expect(events).toContainEqual({
+          type: GeminiEventType.ActiveGoal,
+          value: null,
+        });
       });
 
       it('should skip messageBus.request for UserPromptSubmit when hasHooksForEvent returns false', async () => {

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -4695,6 +4695,74 @@ Other open files:
         });
       });
 
+      it('emits one active_goal null when the blocking cap aborts an active goal', async () => {
+        setActiveGoal('test-session-id', {
+          condition: 'finish the refactor',
+          iterations: 2,
+          setAt: 123,
+          tokensAtStart: 456,
+          hookId: 'goal-hook-id',
+          lastReason: 'still missing verification',
+        });
+        const mockMessageBus = {
+          request: vi.fn().mockResolvedValue({
+            output: {
+              decision: 'block',
+              reason: 'Keep working',
+            },
+            stopHookCount: 1,
+          }),
+          response: vi.fn(),
+        };
+        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
+          (event: string) => event === 'Stop',
+        );
+        vi.mocked(mockConfig.getStopHookBlockingCap).mockReturnValue(1);
+
+        client['chat'] = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([
+            {
+              role: 'model',
+              parts: [{ text: 'not done' }],
+            },
+          ]),
+        } as unknown as GeminiChat;
+        mockTurnRunFn.mockReturnValue(
+          (async function* () {
+            yield { type: GeminiEventType.Content, value: 'not done' };
+          })(),
+        );
+
+        const events = await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'Hi' }],
+            new AbortController().signal,
+            'prompt-stop-cap-active-goal',
+          ),
+        );
+        const activeGoalEvents = events.filter(
+          (event) => event.type === GeminiEventType.ActiveGoal,
+        );
+
+        expect(activeGoalEvents).toEqual([
+          {
+            type: GeminiEventType.ActiveGoal,
+            value: expect.objectContaining({
+              condition: 'finish the refactor',
+            }),
+          },
+          {
+            type: GeminiEventType.ActiveGoal,
+            value: null,
+          },
+        ]);
+      });
+
       it('should not skip hooks when hasHooksForEvent returns true', async () => {
         const mockMessageBus = {
           request: vi.fn().mockResolvedValue({ modifiedPrompt: undefined }),

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -4590,6 +4590,71 @@ Other open files:
         });
       });
 
+      it('emits active_goal null when the Stop hook clears the goal before aborting', async () => {
+        setActiveGoal('test-session-id', {
+          condition: 'finish the refactor',
+          iterations: 2,
+          setAt: 123,
+          tokensAtStart: 456,
+          hookId: 'goal-hook-id',
+          lastReason: 'still missing verification',
+        });
+        const abortController = new AbortController();
+        const mockMessageBus = {
+          request: vi.fn().mockImplementation(async () => {
+            clearActiveGoal('test-session-id');
+            abortController.abort();
+            return {};
+          }),
+          response: vi.fn(),
+        };
+        vi.mocked(mockConfig.getDisableAllHooks).mockReturnValue(false);
+        vi.mocked(mockConfig.getMessageBus).mockReturnValue(
+          mockMessageBus as unknown as ReturnType<Config['getMessageBus']>,
+        );
+        vi.mocked(mockConfig.hasHooksForEvent).mockImplementation(
+          (event: string) => event === 'Stop',
+        );
+        client['chat'] = {
+          addHistory: vi.fn(),
+          getHistory: vi.fn().mockReturnValue([
+            {
+              role: 'model',
+              parts: [{ text: 'done' }],
+            },
+          ]),
+        } as unknown as GeminiChat;
+        mockTurnRunFn.mockReturnValue(
+          (async function* () {
+            yield { type: GeminiEventType.Content, value: 'done' };
+          })(),
+        );
+
+        const events = await fromAsync(
+          client.sendMessageStream(
+            [{ text: 'Hi' }],
+            abortController.signal,
+            'prompt-cleared-active-goal-then-aborted',
+          ),
+        );
+        const activeGoalEvents = events.filter(
+          (event) => event.type === GeminiEventType.ActiveGoal,
+        );
+
+        expect(activeGoalEvents).toEqual([
+          {
+            type: GeminiEventType.ActiveGoal,
+            value: expect.objectContaining({
+              condition: 'finish the refactor',
+            }),
+          },
+          {
+            type: GeminiEventType.ActiveGoal,
+            value: null,
+          },
+        ]);
+      });
+
       it('should skip messageBus.request for UserPromptSubmit when hasHooksForEvent returns false', async () => {
         // Enable hooks and provide messageBus
         const mockMessageBus = {

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -18,11 +18,27 @@ import { ApprovalMode, type Config } from '../config/config.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { recordStartupEvent } from '../utils/startupEventSink.js';
 import { microcompactHistory } from '../services/microcompaction/microcompact.js';
-import { getActiveGoal } from '../goals/activeGoalStore.js';
+import { getActiveGoal, type ActiveGoal } from '../goals/activeGoalStore.js';
 import { abortGoalForStopHookCap } from '../goals/goalHook.js';
 import { formatStopHookBlockingCapWarning } from '../hooks/stopHookCap.js';
 
 const debugLogger = createDebugLogger('CLIENT');
+
+function activeGoalEquals(
+  left: ActiveGoal | undefined,
+  right: ActiveGoal | undefined,
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return (
+    left.condition === right.condition &&
+    left.iterations === right.iterations &&
+    left.setAt === right.setAt &&
+    left.tokensAtStart === right.tokensAtStart &&
+    left.hookId === right.hookId &&
+    left.lastReason === right.lastReason
+  );
+}
 
 // Core modules
 import { GeminiChat } from './geminiChat.js';
@@ -1454,6 +1470,14 @@ export class GeminiClient {
         requestToSend = [...systemReminders, ...requestToSend];
       }
 
+      const activeGoalAtTurnStart = getActiveGoal(this.config.getSessionId());
+      if (activeGoalAtTurnStart) {
+        yield {
+          type: GeminiEventType.ActiveGoal,
+          value: activeGoalAtTurnStart,
+        };
+      }
+
       const resultStream = turn.run(model, requestToSend, signal);
       let didUpdateIdeContextState = false;
       for await (const event of resultStream) {
@@ -1554,6 +1578,9 @@ export class GeminiClient {
             .map((p) => p.text)
             .join('') || '[no response text]';
 
+        const activeGoalBeforeStopHook = getActiveGoal(
+          this.config.getSessionId(),
+        );
         const response = await messageBus.request<
           HookExecutionRequest,
           HookExecutionResponse
@@ -1581,6 +1608,13 @@ export class GeminiClient {
           : undefined;
 
         const stopOutput = hookOutput as StopHookOutput | undefined;
+        const activeGoalAfterStopHook = getActiveGoal(
+          this.config.getSessionId(),
+        );
+        const didActiveGoalChange = !activeGoalEquals(
+          activeGoalBeforeStopHook,
+          activeGoalAfterStopHook,
+        );
 
         // This should happen regardless of the hook's decision
         if (stopOutput?.systemMessage) {
@@ -1626,6 +1660,12 @@ export class GeminiClient {
               this.config.getSessionId(),
               warning,
             );
+            if (activeGoalBeforeStopHook || activeGoalAfterStopHook) {
+              yield {
+                type: GeminiEventType.ActiveGoal,
+                value: null,
+              };
+            }
             yield {
               type: GeminiEventType.HookSystemMessage,
               value: warning,
@@ -1633,6 +1673,13 @@ export class GeminiClient {
             debugLogger.warn(warning);
             if (isTopLevelInteraction) endInteractionSpan('ok');
             return turn;
+          }
+
+          if (didActiveGoalChange) {
+            yield {
+              type: GeminiEventType.ActiveGoal,
+              value: activeGoalAfterStopHook ?? null,
+            };
           }
 
           yield {
@@ -1664,6 +1711,13 @@ export class GeminiClient {
           if (isTopLevelInteraction)
             endInteractionSpan(signal.aborted ? 'cancelled' : 'ok');
           return hookTurn;
+        }
+
+        if (didActiveGoalChange) {
+          yield {
+            type: GeminiEventType.ActiveGoal,
+            value: activeGoalAfterStopHook ?? null,
+          };
         }
       }
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1466,7 +1466,9 @@ export class GeminiClient {
         };
       }
       let lastEmittedActiveGoal: ActiveGoal | undefined = activeGoalAtTurnStart;
-      const createActiveGoalChangeEvent = (
+      // Tracks the last emitted goal value to suppress duplicate events.
+      // Mutates `lastEmittedActiveGoal` when an event is returned.
+      const maybeEmitActiveGoalChange = (
         nextActiveGoal: ActiveGoal | undefined,
       ): ServerGeminiStreamEvent | undefined => {
         if (activeGoalEquals(lastEmittedActiveGoal, nextActiveGoal)) {
@@ -1579,9 +1581,6 @@ export class GeminiClient {
             .map((p) => p.text)
             .join('') || '[no response text]';
 
-        const activeGoalBeforeStopHook = getActiveGoal(
-          this.config.getSessionId(),
-        );
         const response = await messageBus.request<
           HookExecutionRequest,
           HookExecutionResponse
@@ -1598,8 +1597,18 @@ export class GeminiClient {
           MessageBusType.HOOK_EXECUTION_RESPONSE,
         );
 
+        const activeGoalAfterStopHook = getActiveGoal(
+          this.config.getSessionId(),
+        );
+
         // Check if aborted after hook execution
         if (signal.aborted) {
+          const activeGoalEvent = maybeEmitActiveGoalChange(
+            activeGoalAfterStopHook,
+          );
+          if (activeGoalEvent) {
+            yield activeGoalEvent;
+          }
           if (isTopLevelInteraction) endInteractionSpan('cancelled');
           return turn;
         }
@@ -1609,13 +1618,6 @@ export class GeminiClient {
           : undefined;
 
         const stopOutput = hookOutput as StopHookOutput | undefined;
-        const activeGoalAfterStopHook = getActiveGoal(
-          this.config.getSessionId(),
-        );
-        const didActiveGoalChange = !activeGoalEquals(
-          activeGoalBeforeStopHook,
-          activeGoalAfterStopHook,
-        );
 
         // This should happen regardless of the hook's decision
         if (stopOutput?.systemMessage) {
@@ -1665,7 +1667,7 @@ export class GeminiClient {
               this.config.getSessionId(),
             );
             const activeGoalEvent =
-              createActiveGoalChangeEvent(activeGoalAfterCap);
+              maybeEmitActiveGoalChange(activeGoalAfterCap);
             if (activeGoalEvent) {
               yield activeGoalEvent;
             }
@@ -1678,13 +1680,11 @@ export class GeminiClient {
             return turn;
           }
 
-          if (didActiveGoalChange) {
-            const activeGoalEvent = createActiveGoalChangeEvent(
-              activeGoalAfterStopHook,
-            );
-            if (activeGoalEvent) {
-              yield activeGoalEvent;
-            }
+          const activeGoalEvent = maybeEmitActiveGoalChange(
+            activeGoalAfterStopHook,
+          );
+          if (activeGoalEvent) {
+            yield activeGoalEvent;
           }
 
           yield {
@@ -1718,13 +1718,11 @@ export class GeminiClient {
           return hookTurn;
         }
 
-        if (didActiveGoalChange) {
-          const activeGoalEvent = createActiveGoalChangeEvent(
-            activeGoalAfterStopHook,
-          );
-          if (activeGoalEvent) {
-            yield activeGoalEvent;
-          }
+        const activeGoalEvent = maybeEmitActiveGoalChange(
+          activeGoalAfterStopHook,
+        );
+        if (activeGoalEvent) {
+          yield activeGoalEvent;
         }
       }
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1636,6 +1636,12 @@ export class GeminiClient {
         ) {
           // Check if aborted before continuing
           if (signal.aborted) {
+            const activeGoalEvent = maybeEmitActiveGoalChange(
+              activeGoalAfterStopHook,
+            );
+            if (activeGoalEvent) {
+              yield activeGoalEvent;
+            }
             if (isTopLevelInteraction) endInteractionSpan('cancelled');
             return turn;
           }

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -18,27 +18,15 @@ import { ApprovalMode, type Config } from '../config/config.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { recordStartupEvent } from '../utils/startupEventSink.js';
 import { microcompactHistory } from '../services/microcompaction/microcompact.js';
-import { getActiveGoal, type ActiveGoal } from '../goals/activeGoalStore.js';
+import {
+  activeGoalEquals,
+  getActiveGoal,
+  type ActiveGoal,
+} from '../goals/activeGoalStore.js';
 import { abortGoalForStopHookCap } from '../goals/goalHook.js';
 import { formatStopHookBlockingCapWarning } from '../hooks/stopHookCap.js';
 
 const debugLogger = createDebugLogger('CLIENT');
-
-function activeGoalEquals(
-  left: ActiveGoal | undefined,
-  right: ActiveGoal | undefined,
-): boolean {
-  if (left === right) return true;
-  if (!left || !right) return false;
-  return (
-    left.condition === right.condition &&
-    left.iterations === right.iterations &&
-    left.setAt === right.setAt &&
-    left.tokensAtStart === right.tokensAtStart &&
-    left.hookId === right.hookId &&
-    left.lastReason === right.lastReason
-  );
-}
 
 // Core modules
 import { GeminiChat } from './geminiChat.js';
@@ -1477,6 +1465,19 @@ export class GeminiClient {
           value: activeGoalAtTurnStart,
         };
       }
+      let lastEmittedActiveGoal: ActiveGoal | undefined = activeGoalAtTurnStart;
+      const createActiveGoalChangeEvent = (
+        nextActiveGoal: ActiveGoal | undefined,
+      ): ServerGeminiStreamEvent | undefined => {
+        if (activeGoalEquals(lastEmittedActiveGoal, nextActiveGoal)) {
+          return undefined;
+        }
+        lastEmittedActiveGoal = nextActiveGoal;
+        return {
+          type: GeminiEventType.ActiveGoal,
+          value: nextActiveGoal ?? null,
+        };
+      };
 
       const resultStream = turn.run(model, requestToSend, signal);
       let didUpdateIdeContextState = false;
@@ -1660,11 +1661,13 @@ export class GeminiClient {
               this.config.getSessionId(),
               warning,
             );
-            if (activeGoalBeforeStopHook || activeGoalAfterStopHook) {
-              yield {
-                type: GeminiEventType.ActiveGoal,
-                value: null,
-              };
+            const activeGoalAfterCap = getActiveGoal(
+              this.config.getSessionId(),
+            );
+            const activeGoalEvent =
+              createActiveGoalChangeEvent(activeGoalAfterCap);
+            if (activeGoalEvent) {
+              yield activeGoalEvent;
             }
             yield {
               type: GeminiEventType.HookSystemMessage,
@@ -1676,10 +1679,12 @@ export class GeminiClient {
           }
 
           if (didActiveGoalChange) {
-            yield {
-              type: GeminiEventType.ActiveGoal,
-              value: activeGoalAfterStopHook ?? null,
-            };
+            const activeGoalEvent = createActiveGoalChangeEvent(
+              activeGoalAfterStopHook,
+            );
+            if (activeGoalEvent) {
+              yield activeGoalEvent;
+            }
           }
 
           yield {
@@ -1714,10 +1719,12 @@ export class GeminiClient {
         }
 
         if (didActiveGoalChange) {
-          yield {
-            type: GeminiEventType.ActiveGoal,
-            value: activeGoalAfterStopHook ?? null,
-          };
+          const activeGoalEvent = createActiveGoalChangeEvent(
+            activeGoalAfterStopHook,
+          );
+          if (activeGoalEvent) {
+            yield activeGoalEvent;
+          }
         }
       }
 

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1466,7 +1466,8 @@ export class GeminiClient {
         };
       }
       let lastEmittedActiveGoal: ActiveGoal | undefined = activeGoalAtTurnStart;
-      const createActiveGoalChangeEvent = (
+      // Mutates lastEmittedActiveGoal to suppress duplicate stream updates.
+      const maybeEmitActiveGoalChange = (
         nextActiveGoal: ActiveGoal | undefined,
       ): ServerGeminiStreamEvent | undefined => {
         if (activeGoalEquals(lastEmittedActiveGoal, nextActiveGoal)) {
@@ -1579,9 +1580,6 @@ export class GeminiClient {
             .map((p) => p.text)
             .join('') || '[no response text]';
 
-        const activeGoalBeforeStopHook = getActiveGoal(
-          this.config.getSessionId(),
-        );
         const response = await messageBus.request<
           HookExecutionRequest,
           HookExecutionResponse
@@ -1598,8 +1596,20 @@ export class GeminiClient {
           MessageBusType.HOOK_EXECUTION_RESPONSE,
         );
 
+        // Stop hook callbacks can mutate active goal state during request().
+        // Capture it before cancellation returns so clear events are not lost.
+        const activeGoalAfterStopHook = getActiveGoal(
+          this.config.getSessionId(),
+        );
+
         // Check if aborted after hook execution
         if (signal.aborted) {
+          const activeGoalEvent = maybeEmitActiveGoalChange(
+            activeGoalAfterStopHook,
+          );
+          if (activeGoalEvent) {
+            yield activeGoalEvent;
+          }
           if (isTopLevelInteraction) endInteractionSpan('cancelled');
           return turn;
         }
@@ -1609,13 +1619,6 @@ export class GeminiClient {
           : undefined;
 
         const stopOutput = hookOutput as StopHookOutput | undefined;
-        const activeGoalAfterStopHook = getActiveGoal(
-          this.config.getSessionId(),
-        );
-        const didActiveGoalChange = !activeGoalEquals(
-          activeGoalBeforeStopHook,
-          activeGoalAfterStopHook,
-        );
 
         // This should happen regardless of the hook's decision
         if (stopOutput?.systemMessage) {
@@ -1665,7 +1668,7 @@ export class GeminiClient {
               this.config.getSessionId(),
             );
             const activeGoalEvent =
-              createActiveGoalChangeEvent(activeGoalAfterCap);
+              maybeEmitActiveGoalChange(activeGoalAfterCap);
             if (activeGoalEvent) {
               yield activeGoalEvent;
             }
@@ -1678,13 +1681,11 @@ export class GeminiClient {
             return turn;
           }
 
-          if (didActiveGoalChange) {
-            const activeGoalEvent = createActiveGoalChangeEvent(
-              activeGoalAfterStopHook,
-            );
-            if (activeGoalEvent) {
-              yield activeGoalEvent;
-            }
+          const activeGoalEvent = maybeEmitActiveGoalChange(
+            activeGoalAfterStopHook,
+          );
+          if (activeGoalEvent) {
+            yield activeGoalEvent;
           }
 
           yield {
@@ -1718,13 +1719,11 @@ export class GeminiClient {
           return hookTurn;
         }
 
-        if (didActiveGoalChange) {
-          const activeGoalEvent = createActiveGoalChangeEvent(
-            activeGoalAfterStopHook,
-          );
-          if (activeGoalEvent) {
-            yield activeGoalEvent;
-          }
+        const activeGoalEvent = maybeEmitActiveGoalChange(
+          activeGoalAfterStopHook,
+        );
+        if (activeGoalEvent) {
+          yield activeGoalEvent;
         }
       }
 

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -34,6 +34,7 @@ import {
   type ThoughtSummary,
 } from '../utils/thoughtUtils.js';
 import type { LoopType } from '../telemetry/types.js';
+import type { ActiveGoal } from '../goals/activeGoalStore.js';
 
 // Define a structure for tools passed to the server
 export interface ServerTool {
@@ -64,6 +65,7 @@ export enum GeminiEventType {
   HookSystemMessage = 'hook_system_message',
   UserPromptSubmitBlocked = 'user_prompt_submit_blocked',
   StopHookLoop = 'stop_hook_loop',
+  ActiveGoal = 'active_goal',
 }
 
 export type ServerGeminiRetryEvent = {
@@ -233,8 +235,14 @@ export type ServerGeminiStopHookLoopEvent = {
   };
 };
 
+export type ServerGeminiActiveGoalEvent = {
+  type: GeminiEventType.ActiveGoal;
+  value: ActiveGoal | null;
+};
+
 // The original union type, now composed of the individual types
 export type ServerGeminiStreamEvent =
+  | ServerGeminiActiveGoalEvent
   | ServerGeminiChatCompressedEvent
   | ServerGeminiCitationEvent
   | ServerGeminiContentEvent

--- a/packages/core/src/goals/activeGoalStore.test.ts
+++ b/packages/core/src/goals/activeGoalStore.test.ts
@@ -7,6 +7,7 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import {
   __resetActiveGoalStoreForTests,
+  activeGoalEquals,
   clearActiveGoal,
   getActiveGoal,
   recordGoalIteration,
@@ -59,5 +60,20 @@ describe('activeGoalStore', () => {
 
   it('recordGoalIteration is a no-op when no goal exists', () => {
     expect(recordGoalIteration('sess-missing', 'noop')).toBeUndefined();
+  });
+
+  it('compares active goal snapshots by value', () => {
+    expect(activeGoalEquals(undefined, undefined)).toBe(true);
+    expect(activeGoalEquals(makeGoal(), makeGoal())).toBe(true);
+    expect(
+      activeGoalEquals(makeGoal(), makeGoal({ lastReason: undefined })),
+    ).toBe(true);
+    expect(
+      activeGoalEquals(
+        makeGoal({ iterations: 1 }),
+        makeGoal({ iterations: 2 }),
+      ),
+    ).toBe(false);
+    expect(activeGoalEquals(makeGoal(), undefined)).toBe(false);
   });
 });

--- a/packages/core/src/goals/activeGoalStore.ts
+++ b/packages/core/src/goals/activeGoalStore.ts
@@ -20,6 +20,26 @@ export interface ActiveGoal {
 
 const store = new Map<string, ActiveGoal>();
 
+export function activeGoalEquals(
+  left: ActiveGoal | undefined,
+  right: ActiveGoal | undefined,
+): boolean {
+  if (left === right) return true;
+  if (!left || !right) return false;
+  return stableActiveGoalKey(left) === stableActiveGoalKey(right);
+}
+
+function stableActiveGoalKey(goal: ActiveGoal): string {
+  const comparable: Record<string, unknown> = {};
+  for (const key of Object.keys(goal).sort() as Array<keyof ActiveGoal>) {
+    const value = goal[key];
+    if (value !== undefined) {
+      comparable[key] = value;
+    }
+  }
+  return JSON.stringify(comparable);
+}
+
 export function getActiveGoal(sessionId: string): ActiveGoal | undefined {
   return store.get(sessionId);
 }

--- a/packages/core/src/goals/index.ts
+++ b/packages/core/src/goals/index.ts
@@ -11,6 +11,7 @@ export type {
   GoalTerminalObserver,
 } from './activeGoalStore.js';
 export {
+  activeGoalEquals,
   getActiveGoal,
   setActiveGoal,
   clearActiveGoal,

--- a/packages/core/src/hooks/promptHookRunner.test.ts
+++ b/packages/core/src/hooks/promptHookRunner.test.ts
@@ -472,6 +472,9 @@ describe('PromptHookRunner', () => {
     });
 
     it('should track duration correctly', async () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+
       const mockResponse = createMockResponse('{"ok": true}');
       mockGenerateContent.mockImplementation(
         () =>
@@ -483,13 +486,20 @@ describe('PromptHookRunner', () => {
       const config = createMockConfig();
       const input = createMockInput();
 
-      const result = await promptRunner.execute(
-        config,
-        HookEventName.PreToolUse,
-        input,
-      );
+      try {
+        const execution = promptRunner.execute(
+          config,
+          HookEventName.PreToolUse,
+          input,
+        );
 
-      expect(result.duration).toBeGreaterThanOrEqual(50);
+        await vi.advanceTimersByTimeAsync(50);
+        const result = await execution;
+
+        expect(result.duration).toBe(50);
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('should handle multiple $ARGUMENTS placeholders', async () => {


### PR DESCRIPTION
## Summary

- What changed: Added a first-class `active_goal` stream event carrying the current active goal snapshot or `null`, emitted at turn start and when Stop hooks update or clear the goal. The CLI now consumes the event to keep `activeGoalStore` synchronized. `/goal` is also available in non-interactive CLI mode and is handled as a `submit_prompt` slash command.
- Why it changed: Downstream clients need explicit goal state changes instead of inferring them from Stop hook UI events.
- Reviewer focus: Event ordering around Stop hook continuations and terminal goal cleanup, plus non-interactive slash-command mode filtering for `/goal`.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/core/client.test.ts
  cd packages/cli && npx vitest run src/ui/hooks/useGeminiStream.test.tsx
  cd packages/core && npx vitest run src/goals/activeGoalStore.test.ts src/goals/goalHook.test.ts src/core/client.test.ts
  cd packages/cli && npx vitest run src/ui/hooks/useGeminiStream.test.tsx src/ui/components/GoalPill.test.tsx
  cd packages/cli && npx vitest run src/nonInteractiveCliCommands.test.ts src/ui/commands/goalCommand.test.ts
  npm run build && npm run typecheck
  npm run typecheck
  npx prettier --write packages/core/src/core/turn.ts packages/core/src/core/client.ts packages/core/src/core/client.test.ts packages/cli/src/ui/hooks/useGeminiStream.ts packages/cli/src/ui/hooks/useGeminiStream.test.tsx
  npx prettier --write packages/cli/src/ui/commands/goalCommand.ts packages/cli/src/ui/commands/goalCommand.test.ts packages/cli/src/nonInteractiveCliCommands.test.ts
  ```
- Prompts / inputs used: Unit tests simulate an active `/goal`, Stop hook goal clearing, `active_goal` / `null` stream events, and `/goal write a hello world script` through the non-interactive slash-command handler.
- Expected result: Active goal state is emitted through the stream, CLI consumers synchronize their local store without adding duplicate UI cards, and non-interactive `/goal <condition>` registers the goal then submits the instructional prompt.
- Observed result: All targeted tests passed; full build and typecheck passed. Prettier reported touched files unchanged.
- Quickest reviewer verification path:
  ```bash
  cd packages/core && npx vitest run src/core/client.test.ts
  cd packages/cli && npx vitest run src/ui/hooks/useGeminiStream.test.tsx src/nonInteractiveCliCommands.test.ts src/ui/commands/goalCommand.test.ts
  ```
- Evidence: `src/core/client.test.ts` now covers active goal snapshot emission and `active_goal: null` after Stop hook cleanup; `src/ui/hooks/useGeminiStream.test.tsx` covers CLI store synchronization; `src/nonInteractiveCliCommands.test.ts` covers non-interactive `/goal` execution.

## Scope / Risk

- Main risk or tradeoff: Adds a new stream event type, so any exhaustive stream consumers must handle or ignore `active_goal` intentionally. Non-interactive `/goal` now registers a session Stop hook in headless runs.
- Not covered / not validated: No manual TUI screenshot or video was captured because the change is protocol/store synchronization and non-interactive command handling covered by stream/unit tests.
- Breaking changes / migration notes: Consumers with exhaustive `GeminiEventType` switches may need to add an `ActiveGoal` case.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Validated locally on macOS with targeted `npx vitest` commands plus `npm run build && npm run typecheck`.
- Windows and Linux were not run locally.

## Linked Issues / Bugs

- N/A
