### PR TITLE
fix(serve): normalize Windows path separators in workspace file read responses

### DIFF
--- a/packages/cli/src/serve/routes/workspaceFileRead.ts
+++ b/packages/cli/src/serve/routes/workspaceFileRead.ts
@@ -428,6 +428,11 @@ async function handleGetGlob(
  * response payload. Missing `boundWorkspace` means the app was
  * misconfigured; never fall back to returning absolute filesystem
  * paths to clients.
+ *
+ * Always emits POSIX-style separators so SDK consumers see the same
+ * shape regardless of the daemon's platform — `path.relative` on
+ * Windows yields backslashes, which would otherwise leak into
+ * `/file`, `/stat`, `/list`, and `/glob` response paths.
  */
 function workspaceRelative(req: Request, resolved: string): string {
   const boundWorkspace = (req.app.locals as { boundWorkspace?: string })
@@ -436,7 +441,8 @@ function workspaceRelative(req: Request, resolved: string): string {
     throw new Error('bound workspace is not configured');
   }
   const rel = path.relative(boundWorkspace, resolved);
-  return rel === '' ? '.' : rel;
+  if (rel === '') return '.';
+  return path.sep === '/' ? rel : rel.split(path.sep).join('/');
 }
 
 export function registerWorkspaceFileReadRoutes(


### PR DESCRIPTION
## Summary

Follow-up to PR #4269. `workspaceRelative` in `packages/cli/src/serve/routes/workspaceFileRead.ts` returned the platform-native separator from `path.relative`, leaking backslashes into `/file`, `/stat`, `/list`, and `/glob` response paths on Windows.

Fix: always emit POSIX-style separators so SDK consumers see the same shape regardless of the daemon's host OS.

## Why

CI for #4269 failed on `windows-latest, Node 22.x` ([run 26020995574](https://github.com/QwenLM/qwen-code/actions/runs/26020995574/job/76486329586?pr=4269)):

```
FAIL  src/serve/routes/workspaceFileRead.test.ts > GET /glob > scopes glob matches to cwd
AssertionError: expected [ 'sub\inside.ts' ] to deeply equal [ 'sub/inside.ts' ]
  430|     expect(res.status).toBe(200);
  431|     expect(res.body.cwd).toBe('sub');
  432|     expect(res.body.matches).toEqual(['sub/inside.ts']);
```

macOS / Ubuntu / Lint / CodeQL all passed — only Windows red, which is the classic signature of a non-normalized `path.sep`. PR #4269 was already merged (commit 52d2850c7), so the bug currently sits on `main`.

The same helper backs `/file`, `/stat`, `/list`, and `/glob`, so all four routes' response `path` fields would be affected on Windows; the existing tests only happened to exercise multi-segment paths via `/glob`.

## Test plan

- [x] `pnpm vitest src/serve/routes/workspaceFileRead.test.ts` — 28/28 pass on macOS
- [x] `pnpm vitest src/serve/` — 595/595 pass (regression check across the serve module)
- [x] `pnpm eslint packages/cli/src/serve/routes/workspaceFileRead.ts` — clean
- [ ] Windows CI on this PR — should now go green; the formerly failing `'scopes glob matches to cwd'` case acts as the regression test

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)