### PR TITLE
chore(vscode): run development ACP CLI from source

### DIFF
--- a/packages/vscode-ide-companion/development.md
+++ b/packages/vscode-ide-companion/development.md
@@ -15,6 +15,12 @@ To run the extension locally for development, we recommend using the automatic w
     ```
 4.  **Launch Host:** Press **`F5`** (or **`fn+F5`** on Mac) to open a new **Extension Development Host** window with the extension running.
 
+When the extension runs in VS Code's development mode, the chat panel starts
+the CLI through the repository root `scripts/dev.js` entrypoint. CLI and core
+source changes are picked up on the next ACP process start without rebuilding
+or copying the bundled `dist/qwen-cli/cli.js`. Extension UI changes still need
+the watch process above.
+
 ### Manual Build
 
 If you only need to compile the extension once without watching for changes:

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.test.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.test.ts
@@ -126,6 +126,11 @@ vi.mock('@qwen-code/qwen-code-core', async () => {
 });
 
 vi.mock('vscode', () => ({
+  ExtensionMode: {
+    Production: 1,
+    Development: 2,
+    Test: 3,
+  },
   ConfigurationTarget: {
     Global: 'global',
   },
@@ -330,11 +335,14 @@ vi.mock('../../utils/errorMessage.js', () => ({
   getErrorMessage: vi.fn((error: unknown) => String(error)),
 }));
 
-import { WebViewProvider } from './WebViewProvider.js';
+import { WebViewProvider, resolveQwenCliEntryPath } from './WebViewProvider.js';
 import {
   truncatePanelTitle,
   MAX_PANEL_TITLE_LENGTH,
 } from '../utils/panelTitleUtils.js';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import * as path from 'node:path';
 
 const createConfigChangeEvent = (...affectedSections: string[]) => ({
   affectsConfiguration: (section: string) => affectedSections.includes(section),
@@ -344,6 +352,38 @@ type WebViewMessageHandler = (message: {
   type: string;
   data?: unknown;
 }) => Promise<void>;
+
+describe('resolveQwenCliEntryPath', () => {
+  it('uses the source dev entry when the extension runs in development mode', () => {
+    const tempRoot = mkdtempSync(path.join(tmpdir(), 'qwen-vscode-dev-'));
+    try {
+      const extensionRoot = path.join(
+        tempRoot,
+        'packages',
+        'vscode-ide-companion',
+      );
+      const devEntry = path.join(tempRoot, 'scripts', 'dev.js');
+      mkdirSync(extensionRoot, { recursive: true });
+      mkdirSync(path.dirname(devEntry), { recursive: true });
+      writeFileSync(devEntry, '');
+
+      expect(
+        resolveQwenCliEntryPath({ fsPath: extensionRoot } as never, 2),
+      ).toBe(devEntry);
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('uses the bundled CLI outside development mode', () => {
+    expect(
+      resolveQwenCliEntryPath(
+        { fsPath: '/extension-root' } as never,
+        undefined,
+      ),
+    ).toBe('/extension-root/dist/qwen-cli/cli.js');
+  });
+});
 
 /**
  * Create a mock webview + provider and attach them.

--- a/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
+++ b/packages/vscode-ide-companion/src/webview/providers/WebViewProvider.ts
@@ -6,6 +6,8 @@
 
 import * as vscode from 'vscode';
 import { execFile } from 'child_process';
+import { existsSync } from 'node:fs';
+import * as path from 'node:path';
 import { QwenAgentManager } from '../../services/qwenAgentManager.js';
 import { ConversationStore } from '../../services/conversationStore.js';
 import type {
@@ -59,6 +61,26 @@ const AUTH_RELATED_QWEN_SETTINGS = [
   'qwen-code.apiKey',
   'qwen-code.codingPlanRegion',
 ] as const;
+
+export function resolveQwenCliEntryPath(
+  extensionUri: vscode.Uri,
+  extensionMode: vscode.ExtensionMode | undefined,
+): string {
+  if (extensionMode === vscode.ExtensionMode.Development) {
+    const devCliEntry = path.resolve(
+      extensionUri.fsPath,
+      '..',
+      '..',
+      'scripts',
+      'dev.js',
+    );
+    if (existsSync(devCliEntry)) {
+      return devCliEntry;
+    }
+  }
+
+  return vscode.Uri.joinPath(extensionUri, 'dist', 'qwen-cli', 'cli.js').fsPath;
+}
 
 function isInsightCommand(command: string): boolean {
   const [firstToken = ''] = command.trim().split(/\s+/, 1);
@@ -1206,12 +1228,10 @@ export class WebViewProvider {
         `[WebViewProvider] Using CLI-managed authentication (autoAuth=${autoAuthenticate})`,
       );
 
-      const bundledCliEntry = vscode.Uri.joinPath(
+      const cliEntry = resolveQwenCliEntryPath(
         this.extensionUri,
-        'dist',
-        'qwen-cli',
-        'cli.js',
-      ).fsPath;
+        this.context.extensionMode,
+      );
 
       try {
         console.log('[WebViewProvider] Connecting to agent...');
@@ -1219,7 +1239,7 @@ export class WebViewProvider {
         // Pass the detected CLI path to ensure we use the correct installation
         const connectResult = await this.agentManager.connect(
           workingDir,
-          bundledCliEntry,
+          cliEntry,
           options,
         );
         console.log('[WebViewProvider] Agent connected successfully');

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -109,7 +109,17 @@ const env = {
 
 // On Windows, use tsx.cmd; on Unix, use tsx directly
 const isWin = platform() === 'win32';
-const tsxCmd = isWin ? 'tsx.cmd' : 'tsx';
+const localTsxCmd = join(
+  root,
+  'node_modules',
+  '.bin',
+  isWin ? 'tsx.cmd' : 'tsx',
+);
+const tsxCmd = existsSync(localTsxCmd)
+  ? localTsxCmd
+  : isWin
+    ? 'tsx.cmd'
+    : 'tsx';
 const tsxArgs = [cliEntry, ...process.argv.slice(2)];
 
 const child = spawn(tsxCmd, tsxArgs, {


### PR DESCRIPTION
## Summary

- What changed: VS Code extension development mode now starts the ACP CLI through the repository source `scripts/dev.js` entrypoint, while packaged builds continue to use the bundled CLI.
- Why it changed: CLI/core changes should be testable from the Extension Development Host without rebuilding and copying the bundled CLI after every source edit.
- Reviewer focus: Please verify the development-mode path selection and that packaged/production extension behavior still falls back to `dist/qwen-cli/cli.js`.

## Validation

- Commands run:
  ```bash
  npx vitest run src/webview/providers/WebViewProvider.test.ts
  npm run check-types
  npm run build
  node scripts/dev.js --version
  npx eslint scripts/dev.js
  ```
- Prompts / inputs used: N/A
- Expected result: VS Code development mode resolves the CLI entry to the local source dev script; production mode resolves the bundled CLI entry.
- Observed result: The targeted provider tests passed, the extension typecheck/build passed, and `node scripts/dev.js --version` reported the dev CLI version.
- Quickest reviewer verification path: Launch the VS Code extension from `packages/vscode-ide-companion` with F5, open the Qwen Code panel in the Extension Development Host, then confirm the ACP process uses the repository `scripts/dev.js` path in the extension logs.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.): Local command output confirmed the `dev` version string from the source dev entrypoint.

## Scope / Risk

- Main risk or tradeoff: Development Host sessions now depend on the repository root layout so they can find `scripts/dev.js`; if unavailable, the code falls back to the bundled CLI path.
- Not covered / not validated: Manual VS Code Extension Development Host verification was not run in the GUI during this change.
- Breaking changes / migration notes: None for packaged extensions.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Validated on macOS with npm/npx-based development commands only.

## Linked Issues / Bugs

N/A
