### PR TITLE
fix(serve): sync E2E baseline capabilities with registry

### DIFF
--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -208,6 +208,8 @@ describe('qwen serve — capabilities envelope', () => {
       'workspace_mcp',
       'workspace_skills',
       'workspace_providers',
+      'workspace_memory',
+      'workspace_agents',
       'workspace_env',
       'workspace_preflight',
       'session_context',
@@ -215,6 +217,7 @@ describe('qwen serve — capabilities envelope', () => {
       'session_close',
       'session_metadata',
       'mcp_guardrails',
+      'workspace_file_read',
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- Append `workspace_memory`, `workspace_agents`, and `workspace_file_read` to the integration-test `caps.features` baseline so it matches the current `SERVE_CAPABILITY_REGISTRY` and the unit-level `EXPECTED_STAGE1_FEATURES`.
- E2E `qwen serve — capabilities envelope > advertises all baseline capabilities` has been failing on `main` since #4249 (workspace memory + agents CRUD) and #4269 (workspace file read routes) landed without updating the integration mirror — same shape of drift fixed by #4268 for `mcp_guardrails`.
- No production code changes.

Failing run that motivated this: https://github.com/QwenLM/qwen-code/actions/runs/26026289503

## Test plan

- [ ] `npm run test:integration:sandbox:none -- integration-tests/cli/qwen-serve-routes.test.ts` passes locally.
- [ ] `qwen serve — capabilities envelope > advertises all baseline capabilities` passes in CI on Linux (sandbox:none + sandbox:docker) and macOS.

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)