### PR TITLE
fix(serve): sync E2E baseline with PR20/PR21 capabilities

### DIFF
--- a/integration-tests/cli/qwen-serve-routes.test.ts
+++ b/integration-tests/cli/qwen-serve-routes.test.ts
@@ -218,6 +218,9 @@ describe('qwen serve — capabilities envelope', () => {
       'session_metadata',
       'mcp_guardrails',
       'workspace_file_read',
+      'workspace_file_bytes',
+      'workspace_file_write',
+      'auth_device_flow',
     ]);
   });
 });


### PR DESCRIPTION
## Summary

- Follow-up to #4284. After the PR 20 (`workspace_file_bytes`, `workspace_file_write`) and PR 21 (`auth_device_flow`) merges, the E2E `caps.features` baseline at `integration-tests/cli/qwen-serve-routes.test.ts:190` lagged behind `SERVE_CAPABILITY_REGISTRY` and the unit-level list in `packages/cli/src/serve/server.test.ts`, breaking `main` E2E across Linux (sandbox:none / docker) and macOS.
- Adds the three missing tags in registry order so the deep-equal matches the advertised list again.

The failing assertion on `main` (e.g. run [26040351119](https://github.com/QwenLM/qwen-code/actions/runs/26040351119)):

```
expected [ 'health', 'capabilities', …(31) ] to deeply equal […(28)]
+   "workspace_file_bytes",
+   "workspace_file_write",
+   "auth_device_flow",
```

## Test plan

- [x] `npx vitest run packages/cli/src/serve/server.test.ts -t "advertises"` — unit-level baseline still passes (registry source-of-truth).
- [ ] Re-run the `main E2E Tests` workflow on this branch to confirm `qwen-serve-routes.test.ts > capabilities envelope` is green on Linux sandbox:none / sandbox:docker / macOS.

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)