### PR TITLE
fix(core): mirror Qwen3 reasoning on outbound history

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
@@ -425,5 +425,86 @@ describe('DefaultOpenAICompatibleProvider', () => {
       expect(result.max_tokens).toBe(8000); // GPT-4 has 16K limit, min(16K, 8K) = 8K
       expect(result).not.toHaveProperty('custom_param');
     });
+
+    it('mirrors reasoning_content into reasoning for Qwen3 assistant history turns without mutating the source request', () => {
+      const originalRequest: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'Qwen/Qwen3.6-35B-A3B',
+        messages: [
+          { role: 'user', content: 'First turn' },
+          {
+            role: 'assistant',
+            content: 'Visible answer',
+            reasoning_content: 'Preserved chain of thought',
+          } as OpenAI.Chat.ChatCompletionAssistantMessageParam & {
+            reasoning_content: string;
+            reasoning?: string;
+          },
+          { role: 'user', content: 'Second turn' },
+        ],
+      };
+
+      const result = provider.buildRequest(originalRequest, 'prompt-id');
+      const assistant = result.messages?.[1] as {
+        reasoning_content?: string;
+        reasoning?: string;
+      };
+
+      expect(assistant.reasoning_content).toBe('Preserved chain of thought');
+      expect(assistant.reasoning).toBe('Preserved chain of thought');
+      expect(
+        (originalRequest.messages[1] as { reasoning?: string }).reasoning,
+      ).toBeUndefined();
+    });
+
+    it('does not overwrite an explicit reasoning field on Qwen3 assistant history turns', () => {
+      const originalRequest: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'Qwen3-32B',
+        messages: [
+          {
+            role: 'assistant',
+            content: 'Visible answer',
+            reasoning_content: 'Legacy reasoning field',
+            reasoning: 'Canonical reasoning field',
+          } as OpenAI.Chat.ChatCompletionAssistantMessageParam & {
+            reasoning_content: string;
+            reasoning: string;
+          },
+        ],
+      };
+
+      const result = provider.buildRequest(originalRequest, 'prompt-id');
+      const assistant = result.messages?.[0] as {
+        reasoning_content?: string;
+        reasoning?: string;
+      };
+
+      expect(assistant.reasoning).toBe('Canonical reasoning field');
+      expect(assistant.reasoning_content).toBe('Legacy reasoning field');
+    });
+
+    it('does not mirror reasoning_content for non-Qwen3 OpenAI-compatible models', () => {
+      const originalRequest: OpenAI.Chat.ChatCompletionCreateParams = {
+        model: 'gpt-4o',
+        messages: [
+          {
+            role: 'assistant',
+            content: 'Visible answer',
+            reasoning_content: 'Preserved chain of thought',
+          } as OpenAI.Chat.ChatCompletionAssistantMessageParam & {
+            reasoning_content: string;
+            reasoning?: string;
+          },
+        ],
+      };
+
+      const result = provider.buildRequest(originalRequest, 'prompt-id');
+      const assistant = result.messages?.[0] as {
+        reasoning_content?: string;
+        reasoning?: string;
+      };
+
+      expect(assistant.reasoning_content).toBe('Preserved chain of thought');
+      expect(assistant.reasoning).toBeUndefined();
+    });
   });
 });

--- a/packages/core/src/core/openaiContentGenerator/provider/default.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.ts
@@ -11,6 +11,38 @@ import {
   hasExplicitOutputLimit,
 } from '../../tokenLimits.js';
 
+type AssistantMessageWithReasoningFields =
+  OpenAI.Chat.ChatCompletionAssistantMessageParam & {
+    reasoning_content?: string | null;
+    reasoning?: string | null;
+  };
+
+function shouldMirrorReasoningContentForQwen3(model: string): boolean {
+  return model.toLowerCase().includes('qwen3');
+}
+
+function mirrorReasoningContentToReasoning(
+  message: OpenAI.Chat.ChatCompletionMessageParam,
+): OpenAI.Chat.ChatCompletionMessageParam {
+  if (message.role !== 'assistant') {
+    return message;
+  }
+
+  const assistant = message as AssistantMessageWithReasoningFields;
+  if (
+    typeof assistant.reasoning_content !== 'string' ||
+    assistant.reasoning_content.length === 0 ||
+    typeof assistant.reasoning === 'string'
+  ) {
+    return message;
+  }
+
+  return {
+    ...assistant,
+    reasoning: assistant.reasoning_content,
+  } as OpenAI.Chat.ChatCompletionMessageParam;
+}
+
 /**
  * Default provider for standard OpenAI-compatible APIs
  */
@@ -75,9 +107,13 @@ export class DefaultOpenAICompatibleProvider
     // Apply output token limits to ensure max_tokens is set appropriately
     // This prevents occupying too much context window with output reservation
     const requestWithTokenLimits = this.applyOutputTokenLimit(request);
+    const messages = shouldMirrorReasoningContentForQwen3(request.model)
+      ? requestWithTokenLimits.messages.map(mirrorReasoningContentToReasoning)
+      : requestWithTokenLimits.messages;
 
     return {
       ...requestWithTokenLimits,
+      messages,
       ...(extraBody ? extraBody : {}),
     };
   }


### PR DESCRIPTION
## Summary

- What changed:
  - Mirror `reasoning_content` into the canonical `reasoning` field on outbound assistant history turns for Qwen3 requests that go through the default OpenAI-compatible provider.
  - Add regression tests covering the mirror path, the non-overwrite case, and the non-Qwen3 passthrough case.
- Why it changed:
  - Newer vLLM builds consume `message.reasoning` and may drop `reasoning_content` before the chat template renders historical `<think>` blocks.
  - Qwen Code was only serializing `reasoning_content`, so preserved historical thinking could arrive empty on self-hosted Qwen3 + vLLM setups.
- Reviewer focus:
  - Heuristic scope for the Qwen3-only outbound rewrite.
  - Request immutability and non-regression for other OpenAI-compatible providers.

## Validation

- Commands run:
  ```bash
  cd packages/core
  npm test -- src/core/openaiContentGenerator/provider/default.test.ts
  npm test -- src/core/openaiContentGenerator/provider/default.test.ts src/core/openaiContentGenerator/provider/mistral.test.ts src/core/openaiContentGenerator/provider/deepseek.test.ts
  npm run lint -- src/core/openaiContentGenerator/provider/default.ts src/core/openaiContentGenerator/provider/default.test.ts src/core/openaiContentGenerator/provider/mistral.ts src/core/openaiContentGenerator/provider/mistral.test.ts src/core/openaiContentGenerator/provider/deepseek.ts src/core/openaiContentGenerator/provider/deepseek.test.ts
  npm run typecheck
  npm run build
  ```
- Prompts / inputs used:
  - Synthetic request fixtures with historical assistant turns containing `reasoning_content`.
  - Qwen3 model identifiers: `Qwen/Qwen3.6-35B-A3B` and `Qwen3-32B`.
- Expected result:
  - Qwen3 outbound assistant history keeps `reasoning_content` and also carries `reasoning`.
  - Existing explicit `reasoning` values are preserved.
  - Non-Qwen3 models remain unchanged.
- Observed result:
  - Added regression tests fail before the fix and pass after the fix.
  - Adjacent Mistral and DeepSeek provider suites still pass.
- Quickest reviewer verification path:
  - Inspect `packages/core/src/core/openaiContentGenerator/provider/default.ts` and run:
    `cd packages/core && npm test -- src/core/openaiContentGenerator/provider/default.test.ts src/core/openaiContentGenerator/provider/mistral.test.ts src/core/openaiContentGenerator/provider/deepseek.test.ts`
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  - Before: the new Qwen3 regression test fails because outbound assistant history has no `reasoning` field.
  - After: 53 targeted provider tests pass, plus `typecheck` and `build` in `packages/core`.

## Scope / Risk

- Main risk or tradeoff:
  - The heuristic keys off Qwen3 model identifiers on the default provider path, so deployments hidden behind unrelated aliases will not get the mirror automatically.
- Not covered / not validated:
  - No live vLLM server was available in this environment, so validation is request-builder level rather than end-to-end against a running backend.
- Breaking changes / migration notes:
  - None.

## Testing Matrix

|          | ??  | ??  | ??  |
| -------- | --- | --- | --- |
| npm run  | ?  | ?  | ?  |
| npx      | N/A | N/A | N/A |
| Docker   | ??  | ??  | ??  |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- `npm run` here covers `npm test`, `npm run lint`, `npm run typecheck`, and `npm run build` in `packages/core`.
- No containerized validation was needed for this request-shaping change.

## Linked Issues / Bugs

Fixes #4285