### PR TITLE
refactor(serve): typed errors for channel-closed and missing-cli-entry (#4299)

### DIFF
--- a/packages/acp-bridge/src/status.test.ts
+++ b/packages/acp-bridge/src/status.test.ts
@@ -7,7 +7,9 @@
 import { SkillError, TrustGateError } from '@qwen-code/qwen-code-core';
 import { describe, expect, it } from 'vitest';
 import {
+  BridgeChannelClosedError,
   BridgeTimeoutError,
+  MissingCliEntryError,
   SERVE_ERROR_KINDS,
   mapDomainErrorToErrorKind,
 } from './status.js';
@@ -42,6 +44,37 @@ describe('BridgeTimeoutError', () => {
     expect(err.message).toBe('HttpAcpBridge init timed out after 250ms');
     expect(err.label).toBe('init');
     expect(err.timeoutMs).toBe(250);
+    expect(err).toBeInstanceOf(Error);
+  });
+});
+
+describe('BridgeChannelClosedError', () => {
+  it('preserves the legacy "agent channel closed …" wording per context', () => {
+    const sessionErr = new BridgeChannelClosedError(
+      'mid-request (session abc-123)',
+    );
+    expect(sessionErr.name).toBe('BridgeChannelClosedError');
+    expect(sessionErr.message).toBe(
+      'agent channel closed mid-request (session abc-123)',
+    );
+    expect(sessionErr.context).toBe('mid-request (session abc-123)');
+    expect(sessionErr).toBeInstanceOf(Error);
+
+    expect(
+      new BridgeChannelClosedError('mid-request (workspace status)').message,
+    ).toBe('agent channel closed mid-request (workspace status)');
+    expect(
+      new BridgeChannelClosedError('during session/load').message,
+    ).toBe('agent channel closed during session/load');
+  });
+});
+
+describe('MissingCliEntryError', () => {
+  it('exposes the operator-actionable remediation message verbatim', () => {
+    const err = new MissingCliEntryError();
+    expect(err.name).toBe('MissingCliEntryError');
+    expect(err.message).toContain('Cannot determine CLI entry path');
+    expect(err.message).toContain('QWEN_CLI_ENTRY');
     expect(err).toBeInstanceOf(Error);
   });
 });
@@ -113,16 +146,46 @@ describe('mapDomainErrorToErrorKind', () => {
     }
   });
 
-  it('classifies agent-channel-closed message as protocol_error', () => {
+  it('classifies BridgeChannelClosedError as protocol_error', () => {
     expect(
-      mapDomainErrorToErrorKind(new Error('agent channel closed mid-request')),
+      mapDomainErrorToErrorKind(
+        new BridgeChannelClosedError('mid-request (session abc)'),
+      ),
+    ).toBe('protocol_error');
+    expect(
+      mapDomainErrorToErrorKind(
+        new BridgeChannelClosedError('mid-request (workspace status)'),
+      ),
+    ).toBe('protocol_error');
+    expect(
+      mapDomainErrorToErrorKind(
+        new BridgeChannelClosedError('during session/load'),
+      ),
     ).toBe('protocol_error');
   });
 
-  it('classifies "Cannot determine CLI entry path" message as missing_binary', () => {
+  it('classifies MissingCliEntryError as missing_binary', () => {
+    expect(mapDomainErrorToErrorKind(new MissingCliEntryError())).toBe(
+      'missing_binary',
+    );
+  });
+
+  it('does NOT classify foreign errors that merely contain bridge phrases', () => {
+    // Regression for #4299: the previous regex-based fallback would
+    // misclassify any unrelated `Error` whose `.message` happened to
+    // contain "agent channel closed" or "Cannot determine CLI entry
+    // path" (e.g. a wrapping error or a user-authored message in an
+    // unrelated module). Typed-error recognition closes that hole.
     expect(
-      mapDomainErrorToErrorKind(new Error('Cannot determine CLI entry path')),
-    ).toBe('missing_binary');
+      mapDomainErrorToErrorKind(
+        new Error('wrapped: agent channel closed mid-request'),
+      ),
+    ).toBe(undefined);
+    expect(
+      mapDomainErrorToErrorKind(
+        new Error('Cannot determine CLI entry path for some other reason'),
+      ),
+    ).toBe(undefined);
   });
 
   it('returns undefined for unrelated or non-Error values', () => {

--- a/packages/acp-bridge/src/status.ts
+++ b/packages/acp-bridge/src/status.ts
@@ -48,6 +48,44 @@ export class BridgeTimeoutError extends Error {
   }
 }
 
+/**
+ * Raised when the bridge observes its ACP child's transport closing while
+ * a request is in flight (workspace status, session/* restore, or
+ * mid-prompt). Replaces three `new Error('agent channel closed …')` sites
+ * so `mapDomainErrorToErrorKind` can recognize the failure via
+ * `instanceof` rather than regex-matching `.message`. The `context` suffix
+ * preserves the legacy message wording so log greps and existing
+ * diagnostic surfaces keep working.
+ */
+export class BridgeChannelClosedError extends Error {
+  readonly context: string;
+  constructor(context: string) {
+    super(`agent channel closed ${context}`);
+    this.name = 'BridgeChannelClosedError';
+    this.context = context;
+  }
+}
+
+/**
+ * Raised by `defaultSpawnChannelFactory` when neither `QWEN_CLI_ENTRY` nor
+ * `process.argv[1]` resolves to a path that can be re-spawned for the ACP
+ * child. Replaces a generic `new Error(...)` so `mapDomainErrorToErrorKind`
+ * can return `'missing_binary'` via `instanceof` rather than regex-matching
+ * `.message`. The constructor message is preserved verbatim so existing
+ * operator-facing diagnostics stay byte-for-byte compatible.
+ */
+export class MissingCliEntryError extends Error {
+  constructor() {
+    super(
+      'Cannot determine CLI entry path for spawning the ACP child: ' +
+        'process.argv[1] is empty and QWEN_CLI_ENTRY is unset. ' +
+        'Set QWEN_CLI_ENTRY to the absolute path of the qwen entry ' +
+        'script (e.g. `export QWEN_CLI_ENTRY=$(which qwen)`) to override.',
+    );
+    this.name = 'MissingCliEntryError';
+  }
+}
+
 export const SERVE_STATUS_EXT_METHODS = {
   workspaceMcp: 'qwen/status/workspace/mcp',
   workspaceSkills: 'qwen/status/workspace/skills',
@@ -558,8 +596,9 @@ const MODEL_CONFIG_ERROR_NAMES: ReadonlySet<string> = new Set([
 /**
  * Map a thrown domain error onto one of the closed `ServeErrorKind` literals
  * so diagnostic cells can render structured remediation. Recognition is
- * `instanceof`-first; message-string heuristics are a last-resort fallback for
- * legacy throw sites that have not yet been retyped.
+ * `instanceof`-based for bridge-owned errors; cross-package classes
+ * (`SkillError`, `TrustGateError`, model-config) are matched by `.code` or
+ * `.name` because bundle duplication can break `instanceof` symmetry.
  *
  * Returns `undefined` when no rule matches; callers should leave `errorKind`
  * unset rather than coercing an unrelated error into a misleading category.
@@ -568,6 +607,8 @@ export function mapDomainErrorToErrorKind(
   err: unknown,
 ): ServeErrorKind | undefined {
   if (err instanceof BridgeTimeoutError) return 'init_timeout';
+  if (err instanceof BridgeChannelClosedError) return 'protocol_error';
+  if (err instanceof MissingCliEntryError) return 'missing_binary';
   if (err instanceof SkillError) {
     if (SKILL_PARSE_CODES.has(err.code)) return 'parse_error';
     if (SKILL_FILE_CODES.has(err.code)) return 'missing_file';
@@ -584,17 +625,5 @@ export function mapDomainErrorToErrorKind(
   if (typeof code === 'string' && FS_MISSING_CODES.has(code)) {
     return 'missing_file';
   }
-  // TODO(follow-up): convert the two throw sites that produce these
-  // messages (`getChannelClosedReject` in `httpAcpBridge.ts` and the
-  // `defaultSpawnChannelFactory` "Cannot determine CLI entry path" Error)
-  // to typed classes (`BridgeChannelClosedError`, `MissingCliEntryError`)
-  // and replace the regex match with `instanceof`. Until then a foreign
-  // error message that happens to contain either phrase will misclassify;
-  // the false-positive surface is small (the phrases are bridge-specific)
-  // but the cleaner fix belongs in the same wave as PR 22's bridge
-  // extraction.
-  const msg = err.message;
-  if (/agent channel closed/i.test(msg)) return 'protocol_error';
-  if (/Cannot determine CLI entry path/i.test(msg)) return 'missing_binary';
   return undefined;
 }

--- a/packages/cli/src/serve/httpAcpBridge.ts
+++ b/packages/cli/src/serve/httpAcpBridge.ts
@@ -18,7 +18,9 @@ import { writeStderrLine } from '../utils/stdioHelpers.js';
 import { canonicalizeWorkspace } from './fs/paths.js';
 import { EventBus, DEFAULT_RING_SIZE, type BridgeEvent } from './eventBus.js';
 import {
+  BridgeChannelClosedError,
   BridgeTimeoutError,
+  MissingCliEntryError,
   SERVE_CONTROL_EXT_METHODS,
   SERVE_STATUS_EXT_METHODS,
   STATUS_SCHEMA_VERSION,
@@ -2126,8 +2128,8 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
   const getTransportClosedReject = (entry: SessionEntry): Promise<never> => {
     if (!entry.transportClosedReject) {
       entry.transportClosedReject = entry.channel.exited.then(() => {
-        throw new Error(
-          `agent channel closed mid-request (session ${entry.sessionId})`,
+        throw new BridgeChannelClosedError(
+          `mid-request (session ${entry.sessionId})`,
         );
       });
     }
@@ -2168,7 +2170,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
   const getChannelClosedReject = (info: ChannelInfo): Promise<never> => {
     if (!info.statusClosedReject) {
       info.statusClosedReject = info.channel.exited.then(() => {
-        throw new Error('agent channel closed mid-request (workspace status)');
+        throw new BridgeChannelClosedError('mid-request (workspace status)');
       });
     }
     return info.statusClosedReject;
@@ -2413,7 +2415,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       // race only — once the race settles, no new awaits attach to
       // it, so there's no listener leak across restores.
       const transportClosed = ci.channel.exited.then(() => {
-        throw new Error(`agent channel closed during session/${action}`);
+        throw new BridgeChannelClosedError(`during session/${action}`);
       });
       // Suppress the dangling rejection if `withTimeout` wins the
       // race below: `transportClosed` then stays pending, and a
@@ -4345,12 +4347,7 @@ export const defaultSpawnChannelFactory: ChannelFactory = async (
   // Fail loudly with an actionable error if neither resolves.
   const cliEntry = process.env['QWEN_CLI_ENTRY'] || process.argv[1];
   if (!cliEntry) {
-    throw new Error(
-      'Cannot determine CLI entry path for spawning the ACP child: ' +
-        'process.argv[1] is empty and QWEN_CLI_ENTRY is unset. ' +
-        'Set QWEN_CLI_ENTRY to the absolute path of the qwen entry ' +
-        'script (e.g. `export QWEN_CLI_ENTRY=$(which qwen)`) to override.',
-    );
+    throw new MissingCliEntryError();
   }
   // Each session takes ~3 file descriptors (stdin/stdout/stderr) for the
   // child plus a few sockets. Operators running many concurrent sessions


### PR DESCRIPTION
## Summary

- **What changed:** `mapDomainErrorToErrorKind` in `packages/cli/src/serve/status.ts` no longer regex-matches `.message` to classify two failure modes — it now branches on `instanceof BridgeChannelClosedError` / `instanceof MissingCliEntryError`, two new typed classes added next to `BridgeTimeoutError`. The four throw sites (3× `agent channel closed …` in `httpAcpBridge.ts`, 1× `Cannot determine CLI entry path …` in `defaultSpawnChannelFactory`) now throw the typed classes. The regex fallbacks and the in-code `TODO` that called them out are removed.
- **Why it changed:** Closes #4299 (tech-debt). Regex on `.message` mis-classifies any future error whose message happens to contain those phrases (e.g., a wrapping error like `RuntimeError: failed: <inner: agent channel closed>`), and silently degrades classification when a maintainer copy-edits the throw-site wording. Typed errors make the contract structural rather than lexical, matching the discipline the bridge already follows for its 11 other error classes (`SessionNotFoundError`, `WorkspaceMismatchError`, etc.).
- **Reviewer focus:**
  - Class placement: new classes live in `status.ts` (next to `BridgeTimeoutError`), **not** in `httpAcpBridge.ts` with the 11 others. Reason: `mapDomainErrorToErrorKind` is in `status.ts`, and `acpAgent.ts` (the ACP child) imports `status.ts` — pulling bridge-implementation into `status.ts` would break that layering. Same precedent as `BridgeTimeoutError`.
  - Message preservation: `BridgeChannelClosedError` takes a `context` string so each of the three call-sites' messages reproduce **byte-for-byte** (`'agent channel closed mid-request (session abc)'`, `'… (workspace status)'`, `'… during session/load'`). `MissingCliEntryError` has no constructor args and emits the same multi-line message verbatim.
  - Regression test at `status.test.ts:173-189` locks in the intended tightening: a wrapping error like `new Error('wrapped: agent channel closed mid-request')` now returns `undefined` (correct), where the old regex returned `'protocol_error'` (false positive, the bug fixed).

Diff is ~50 LOC across 3 files, exactly the scope the issue estimated.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx tsc --build               # clean
  cd packages/acp-bridge && npx tsc --build         # clean
  cd packages/cli && npx tsc --noEmit               # only pre-existing errors (eventBus skeleton, generated/git-commit.js — unchanged by this PR; verified by stash-and-rerun baseline)
  cd packages/cli && npx vitest run src/serve/status.test.ts src/serve/httpAcpBridge.test.ts
  ```
- Expected result: status + bridge tests pass; no new typecheck errors.
- Observed result: **172/172 tests passed** (15 status + 157 bridge). Lint clean on the three touched files.
- Quickest reviewer verification path: `cd packages/cli && npx vitest run src/serve/status.test.ts` — see the new `BridgeChannelClosedError` / `MissingCliEntryError` describe blocks plus the foreign-error regression test.
- Evidence:
  ```
  ✓ src/serve/status.test.ts (15 tests) 6ms
  ✓ src/serve/httpAcpBridge.test.ts (157 tests) 1287ms
  Test Files  2 passed (2)
       Tests  172 passed (172)
  ```

## Scope / Risk

- **Main risk or tradeoff:** Removing the regex narrows recognition: any *external* code that was throwing a generic `Error('agent channel closed …')` and relying on the helper to tag it as `protocol_error` will now get `undefined`. We searched `packages/` for both phrases — only one out-of-scope hit (`commands/channel/config-utils.ts:25`, the `qwen channel start` CLI path) which never reaches `mapDomainErrorToErrorKind`, so safe. Also confirmed no telemetry/alerting layer keys on these tags being non-undefined; consumers in `acpAgent.ts` and `httpAcpBridge.ts` only render the cell payload.
- **Not covered / not validated:** No `qwen serve --port 0` smoke run (typed-class change is internal to error classification; no behavior change at HTTP route or `/capabilities` payload).
- **Breaking changes / migration notes:** None. Error messages preserved verbatim. `errorKind` payload values for these two failure modes are unchanged (`'protocol_error'` and `'missing_binary'`). New classes are additions to `status.ts`'s exports — purely additive.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- macOS local `vitest run` covers the new class behavior + regression. CI should cover Linux/Windows; no platform-specific code paths in this diff.

## Linked Issues / Bugs

Closes #4299

References:
- PR #4298 (Wave 5 PR 22b/1) — the lift this issue was filed on top of. This PR lands cleanly on either side of #4298 since it touches the pre-lift source locations (`packages/cli/src/serve/`); the verbatim move in 22b/1 will carry these changes through.

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)