### PR TITLE
fix(cli): block Windows Tab approval-mode toggle when input has a Tab consumer

### DIFF
--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -1219,8 +1219,11 @@ export const AppContainer = (props: AppContainerProps) => {
     hideTips: tipsDisabled,
   });
 
-  // Track whether suggestions are visible for Tab key handling
-  const [hasSuggestionsVisible, setHasSuggestionsVisible] = useState(false);
+  // Track whether the input area has any Tab consumer (autocomplete dropdown,
+  // followup suggestion, mid-input ghost text, reverse/command search). When
+  // true, we suppress the Windows-only "bare Tab cycles approval mode"
+  // fallback so a single Tab keystroke triggers only one action. See #4171.
+  const [hasTabConsumer, setHasTabConsumer] = useState(false);
 
   const agentViewState = useAgentViewState();
   const { dialogOpen: bgTasksDialogOpen } = useBackgroundTaskViewState();
@@ -1246,7 +1249,7 @@ export const AppContainer = (props: AppContainerProps) => {
     config,
     addItem: historyManager.addItem,
     onApprovalModeChange: handleApprovalModeChange,
-    shouldBlockTab: () => hasSuggestionsVisible,
+    shouldBlockTab: () => hasTabConsumer,
     disabled: agentViewState.activeView !== 'main',
   });
 
@@ -3250,7 +3253,7 @@ export const AppContainer = (props: AppContainerProps) => {
       handleFolderTrustSelect,
       setConstrainHeight,
       onEscapePromptChange: handleEscapePromptChange,
-      onSuggestionsVisibilityChange: setHasSuggestionsVisible,
+      onSuggestionsVisibilityChange: setHasTabConsumer,
       refreshStatic,
       handleFinalSubmit,
       handleRetryLastPrompt: retryLastPrompt,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -3253,7 +3253,7 @@ export const AppContainer = (props: AppContainerProps) => {
       handleFolderTrustSelect,
       setConstrainHeight,
       onEscapePromptChange: handleEscapePromptChange,
-      onSuggestionsVisibilityChange: setHasTabConsumer,
+      onTabConsumerChange: setHasTabConsumer,
       refreshStatic,
       handleFinalSubmit,
       handleRetryLastPrompt: retryLastPrompt,

--- a/packages/cli/src/ui/components/Composer.tsx
+++ b/packages/cli/src/ui/components/Composer.tsx
@@ -75,13 +75,18 @@ export const Composer = () => {
     setShowShortcuts((prev) => !prev);
   }, []);
 
-  // State for suggestions visibility
+  // State for autocomplete-dropdown visibility (narrow signal). Drives the
+  // Footer / KeyboardShortcuts hide-when-dropdown-visible logic below; kept
+  // local to Composer because nothing outside this component needs the
+  // narrow signal.
   const [showSuggestions, setShowSuggestions] = useState(false);
-  const handleSuggestionsVisibilityChange = useCallback(
-    (visible: boolean) => {
-      setShowSuggestions(visible);
-      // Also notify AppContainer for Tab key handling
-      uiActions.onSuggestionsVisibilityChange(visible);
+
+  // Broad signal — any input-area Tab consumer. Forwarded to AppContainer
+  // via UIActionsContext so useAutoAcceptIndicator's `shouldBlockTab` can
+  // suppress the Windows-only bare-Tab approval-mode fallback. See #4171.
+  const handleTabConsumerChange = useCallback(
+    (active: boolean) => {
+      uiActions.onTabConsumerChange(active);
     },
     [uiActions],
   );
@@ -145,7 +150,8 @@ export const Composer = () => {
           onEscapePromptChange={uiActions.onEscapePromptChange}
           onToggleShortcuts={handleToggleShortcuts}
           showShortcuts={showShortcuts}
-          onSuggestionsVisibilityChange={handleSuggestionsVisibilityChange}
+          onSuggestionsVisibilityChange={setShowSuggestions}
+          onTabConsumerChange={handleTabConsumerChange}
           focus={true}
           vimHandleInput={uiActions.vimHandleInput}
           isEmbeddedShellFocused={uiState.embeddedShellFocused}

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -512,6 +512,75 @@ describe('InputPrompt', () => {
       expect(onSuggestionsVisibilityChange).not.toHaveBeenCalledWith(true);
       unmount();
     });
+
+    it('reports false again after the autocomplete dropdown is dismissed', async () => {
+      mockedUseCommandCompletion.mockReturnValue({
+        ...mockCommandCompletion,
+        showSuggestions: true,
+        suggestions: [
+          {
+            value: '/clear',
+            label: '/clear',
+            description: 'Clear screen',
+          },
+        ] as UseCommandCompletionReturn['suggestions'],
+      });
+      const onSuggestionsVisibilityChange = vi.fn();
+      const { rerender, unmount } = renderWithProviders(
+        <InputPrompt
+          {...props}
+          onSuggestionsVisibilityChange={onSuggestionsVisibilityChange}
+        />,
+      );
+      await wait();
+      expect(onSuggestionsVisibilityChange).toHaveBeenLastCalledWith(true);
+
+      // Dismiss the dropdown and re-render — Windows Tab cycling must be
+      // re-enabled. Without this transition signal, the parent would keep
+      // suppressing the approval-mode fallback after the dropdown closed.
+      mockedUseCommandCompletion.mockReturnValue(mockCommandCompletion);
+      rerender(
+        <InputPrompt
+          {...props}
+          onSuggestionsVisibilityChange={onSuggestionsVisibilityChange}
+        />,
+      );
+      await wait();
+
+      expect(onSuggestionsVisibilityChange).toHaveBeenLastCalledWith(false);
+      unmount();
+    });
+
+    it('reports false on unmount even if a Tab consumer was active', async () => {
+      // Regression for the stale-signal bug: if InputPrompt unmounts while
+      // some Tab consumer is true (e.g. streaming starts while autocomplete
+      // is open), AppContainer would otherwise keep blocking Windows Tab
+      // approval-mode cycling for the entire streaming window.
+      mockedUseCommandCompletion.mockReturnValue({
+        ...mockCommandCompletion,
+        showSuggestions: true,
+        suggestions: [
+          {
+            value: '/clear',
+            label: '/clear',
+            description: 'Clear screen',
+          },
+        ] as UseCommandCompletionReturn['suggestions'],
+      });
+      const onSuggestionsVisibilityChange = vi.fn();
+      const { unmount } = renderWithProviders(
+        <InputPrompt
+          {...props}
+          onSuggestionsVisibilityChange={onSuggestionsVisibilityChange}
+        />,
+      );
+      await wait();
+      expect(onSuggestionsVisibilityChange).toHaveBeenLastCalledWith(true);
+
+      unmount();
+      // Last call after unmount must be false — the cleanup function fires.
+      expect(onSuggestionsVisibilityChange).toHaveBeenLastCalledWith(false);
+    });
   });
 
   it('should call shellHistory.getPreviousCommand on up arrow in shell mode', async () => {

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -431,6 +431,89 @@ describe('InputPrompt', () => {
     });
   });
 
+  // Regression for #4171: onSuggestionsVisibilityChange (consumed by
+  // AppContainer as `shouldBlockTab`) must report `true` whenever ANY
+  // input-side handler would consume Tab — not just the autocomplete
+  // dropdown. Otherwise on Windows the bare-Tab approval-mode fallback
+  // double-fires alongside the input-side handler.
+  describe('hasTabConsumer reporting (issue #4171)', () => {
+    // Match the SUGGESTION_DELAY_MS debounce inside createFollowupController.
+    const SUGGESTION_VISIBLE_WAIT_MS = 700;
+
+    it('reports true while the followup prompt suggestion is visible', async () => {
+      const onSuggestionsVisibilityChange = vi.fn();
+      const { unmount } = renderWithProviders(
+        <InputPrompt
+          {...props}
+          promptSuggestion="commit this"
+          onSuggestionsVisibilityChange={onSuggestionsVisibilityChange}
+        />,
+      );
+      await wait(SUGGESTION_VISIBLE_WAIT_MS);
+
+      expect(onSuggestionsVisibilityChange).toHaveBeenCalledWith(true);
+      unmount();
+    });
+
+    it('reports true while mid-input ghost text offers an accept', async () => {
+      mockCommandCompletion.midInputGhostText = {
+        text: 'ile.txt',
+        insertPosition: 1,
+        acceptText: 'ile.txt',
+      };
+      const onSuggestionsVisibilityChange = vi.fn();
+      const { unmount } = renderWithProviders(
+        <InputPrompt
+          {...props}
+          onSuggestionsVisibilityChange={onSuggestionsVisibilityChange}
+        />,
+      );
+      await wait();
+
+      expect(onSuggestionsVisibilityChange).toHaveBeenCalledWith(true);
+      unmount();
+    });
+
+    it('reports true while the autocomplete dropdown is visible', async () => {
+      mockCommandCompletion.showSuggestions = true;
+      mockCommandCompletion.suggestions = [
+        {
+          value: '/clear',
+          label: '/clear',
+          description: 'Clear screen',
+        },
+      ] as UseCommandCompletionReturn['suggestions'];
+      const onSuggestionsVisibilityChange = vi.fn();
+      const { unmount } = renderWithProviders(
+        <InputPrompt
+          {...props}
+          onSuggestionsVisibilityChange={onSuggestionsVisibilityChange}
+        />,
+      );
+      await wait();
+
+      expect(onSuggestionsVisibilityChange).toHaveBeenCalledWith(true);
+      unmount();
+    });
+
+    it('reports false when the input area is idle (no dropdown, no followup, no ghost)', async () => {
+      const onSuggestionsVisibilityChange = vi.fn();
+      const { unmount } = renderWithProviders(
+        <InputPrompt
+          {...props}
+          onSuggestionsVisibilityChange={onSuggestionsVisibilityChange}
+        />,
+      );
+      await wait();
+
+      // Pin the actual value (not just "never true") — the mount-time effect
+      // must report false when nothing in the input area wants Tab.
+      expect(onSuggestionsVisibilityChange).toHaveBeenCalledWith(false);
+      expect(onSuggestionsVisibilityChange).not.toHaveBeenCalledWith(true);
+      unmount();
+    });
+  });
+
   it('should call shellHistory.getPreviousCommand on up arrow in shell mode', async () => {
     props.shellModeActive = true;
     const { stdin, unmount } = renderWithProviders(<InputPrompt {...props} />);

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -431,27 +431,27 @@ describe('InputPrompt', () => {
     });
   });
 
-  // Regression for #4171: onSuggestionsVisibilityChange (consumed by
-  // AppContainer as `shouldBlockTab`) must report `true` whenever ANY
-  // input-side handler would consume Tab — not just the autocomplete
-  // dropdown. Otherwise on Windows the bare-Tab approval-mode fallback
-  // double-fires alongside the input-side handler.
-  describe('hasTabConsumer reporting (issue #4171)', () => {
+  // Regression for #4171: `onTabConsumerChange` (consumed by AppContainer
+  // as `shouldBlockTab`) must report `true` whenever ANY input-side handler
+  // would consume Tab — autocomplete dropdown, followup suggestion, or
+  // mid-input ghost text. Otherwise on Windows the bare-Tab approval-mode
+  // fallback double-fires alongside the input-side handler.
+  describe('onTabConsumerChange reporting (issue #4171)', () => {
     // Match the SUGGESTION_DELAY_MS debounce inside createFollowupController.
     const SUGGESTION_VISIBLE_WAIT_MS = 700;
 
     it('reports true while the followup prompt suggestion is visible', async () => {
-      const onSuggestionsVisibilityChange = vi.fn();
+      const onTabConsumerChange = vi.fn();
       const { unmount } = renderWithProviders(
         <InputPrompt
           {...props}
           promptSuggestion="commit this"
-          onSuggestionsVisibilityChange={onSuggestionsVisibilityChange}
+          onTabConsumerChange={onTabConsumerChange}
         />,
       );
       await wait(SUGGESTION_VISIBLE_WAIT_MS);
 
-      expect(onSuggestionsVisibilityChange).toHaveBeenCalledWith(true);
+      expect(onTabConsumerChange).toHaveBeenCalledWith(true);
       unmount();
     });
 
@@ -461,16 +461,13 @@ describe('InputPrompt', () => {
         insertPosition: 1,
         acceptText: 'ile.txt',
       };
-      const onSuggestionsVisibilityChange = vi.fn();
+      const onTabConsumerChange = vi.fn();
       const { unmount } = renderWithProviders(
-        <InputPrompt
-          {...props}
-          onSuggestionsVisibilityChange={onSuggestionsVisibilityChange}
-        />,
+        <InputPrompt {...props} onTabConsumerChange={onTabConsumerChange} />,
       );
       await wait();
 
-      expect(onSuggestionsVisibilityChange).toHaveBeenCalledWith(true);
+      expect(onTabConsumerChange).toHaveBeenCalledWith(true);
       unmount();
     });
 
@@ -483,33 +480,27 @@ describe('InputPrompt', () => {
           description: 'Clear screen',
         },
       ] as UseCommandCompletionReturn['suggestions'];
-      const onSuggestionsVisibilityChange = vi.fn();
+      const onTabConsumerChange = vi.fn();
       const { unmount } = renderWithProviders(
-        <InputPrompt
-          {...props}
-          onSuggestionsVisibilityChange={onSuggestionsVisibilityChange}
-        />,
+        <InputPrompt {...props} onTabConsumerChange={onTabConsumerChange} />,
       );
       await wait();
 
-      expect(onSuggestionsVisibilityChange).toHaveBeenCalledWith(true);
+      expect(onTabConsumerChange).toHaveBeenCalledWith(true);
       unmount();
     });
 
     it('reports false when the input area is idle (no dropdown, no followup, no ghost)', async () => {
-      const onSuggestionsVisibilityChange = vi.fn();
+      const onTabConsumerChange = vi.fn();
       const { unmount } = renderWithProviders(
-        <InputPrompt
-          {...props}
-          onSuggestionsVisibilityChange={onSuggestionsVisibilityChange}
-        />,
+        <InputPrompt {...props} onTabConsumerChange={onTabConsumerChange} />,
       );
       await wait();
 
       // Pin the actual value (not just "never true") — the mount-time effect
       // must report false when nothing in the input area wants Tab.
-      expect(onSuggestionsVisibilityChange).toHaveBeenCalledWith(false);
-      expect(onSuggestionsVisibilityChange).not.toHaveBeenCalledWith(true);
+      expect(onTabConsumerChange).toHaveBeenCalledWith(false);
+      expect(onTabConsumerChange).not.toHaveBeenCalledWith(true);
       unmount();
     });
 
@@ -525,29 +516,23 @@ describe('InputPrompt', () => {
           },
         ] as UseCommandCompletionReturn['suggestions'],
       });
-      const onSuggestionsVisibilityChange = vi.fn();
+      const onTabConsumerChange = vi.fn();
       const { rerender, unmount } = renderWithProviders(
-        <InputPrompt
-          {...props}
-          onSuggestionsVisibilityChange={onSuggestionsVisibilityChange}
-        />,
+        <InputPrompt {...props} onTabConsumerChange={onTabConsumerChange} />,
       );
       await wait();
-      expect(onSuggestionsVisibilityChange).toHaveBeenLastCalledWith(true);
+      expect(onTabConsumerChange).toHaveBeenLastCalledWith(true);
 
       // Dismiss the dropdown and re-render — Windows Tab cycling must be
       // re-enabled. Without this transition signal, the parent would keep
       // suppressing the approval-mode fallback after the dropdown closed.
       mockedUseCommandCompletion.mockReturnValue(mockCommandCompletion);
       rerender(
-        <InputPrompt
-          {...props}
-          onSuggestionsVisibilityChange={onSuggestionsVisibilityChange}
-        />,
+        <InputPrompt {...props} onTabConsumerChange={onTabConsumerChange} />,
       );
       await wait();
 
-      expect(onSuggestionsVisibilityChange).toHaveBeenLastCalledWith(false);
+      expect(onTabConsumerChange).toHaveBeenLastCalledWith(false);
       unmount();
     });
 
@@ -567,6 +552,79 @@ describe('InputPrompt', () => {
           },
         ] as UseCommandCompletionReturn['suggestions'],
       });
+      const onTabConsumerChange = vi.fn();
+      const { unmount } = renderWithProviders(
+        <InputPrompt {...props} onTabConsumerChange={onTabConsumerChange} />,
+      );
+      await wait();
+      expect(onTabConsumerChange).toHaveBeenLastCalledWith(true);
+
+      unmount();
+      // Last call after unmount must be false — the cleanup function fires.
+      expect(onTabConsumerChange).toHaveBeenLastCalledWith(false);
+    });
+  });
+
+  // Regression for #4308 review: `onSuggestionsVisibilityChange` must stay
+  // narrow (autocomplete dropdown only). Composer uses this signal to hide
+  // the Footer / KeyboardShortcuts when the dropdown competes for vertical
+  // space. Followup suggestions and mid-input ghost text are inline within
+  // the input box and must NOT hide the Footer — broadening this signal
+  // would cause Footer churn on all platforms.
+  describe('onSuggestionsVisibilityChange stays narrow (autocomplete only)', () => {
+    const SUGGESTION_VISIBLE_WAIT_MS = 700;
+
+    it('stays false when only a followup prompt suggestion is visible', async () => {
+      const onSuggestionsVisibilityChange = vi.fn();
+      const onTabConsumerChange = vi.fn();
+      const { unmount } = renderWithProviders(
+        <InputPrompt
+          {...props}
+          promptSuggestion="commit this"
+          onSuggestionsVisibilityChange={onSuggestionsVisibilityChange}
+          onTabConsumerChange={onTabConsumerChange}
+        />,
+      );
+      await wait(SUGGESTION_VISIBLE_WAIT_MS);
+
+      // Tab consumer signal flips true (followup is a Tab consumer)…
+      expect(onTabConsumerChange).toHaveBeenCalledWith(true);
+      // …but the narrow signal must NOT — Footer should stay visible.
+      expect(onSuggestionsVisibilityChange).not.toHaveBeenCalledWith(true);
+      unmount();
+    });
+
+    it('stays false when only mid-input ghost text is present', async () => {
+      mockCommandCompletion.midInputGhostText = {
+        text: 'ile.txt',
+        insertPosition: 1,
+        acceptText: 'ile.txt',
+      };
+      const onSuggestionsVisibilityChange = vi.fn();
+      const onTabConsumerChange = vi.fn();
+      const { unmount } = renderWithProviders(
+        <InputPrompt
+          {...props}
+          onSuggestionsVisibilityChange={onSuggestionsVisibilityChange}
+          onTabConsumerChange={onTabConsumerChange}
+        />,
+      );
+      await wait();
+
+      expect(onTabConsumerChange).toHaveBeenCalledWith(true);
+      expect(onSuggestionsVisibilityChange).not.toHaveBeenCalledWith(true);
+      unmount();
+    });
+
+    it('flips true only when the autocomplete dropdown is visible', async () => {
+      mockCommandCompletion.showSuggestions = true;
+      mockCommandCompletion.suggestions = [
+        {
+          value: '/clear',
+          label: '/clear',
+          description: 'Clear screen',
+        },
+      ] as UseCommandCompletionReturn['suggestions'];
       const onSuggestionsVisibilityChange = vi.fn();
       const { unmount } = renderWithProviders(
         <InputPrompt
@@ -575,11 +633,9 @@ describe('InputPrompt', () => {
         />,
       );
       await wait();
-      expect(onSuggestionsVisibilityChange).toHaveBeenLastCalledWith(true);
 
+      expect(onSuggestionsVisibilityChange).toHaveBeenCalledWith(true);
       unmount();
-      // Last call after unmount must be false — the cleanup function fires.
-      expect(onSuggestionsVisibilityChange).toHaveBeenLastCalledWith(false);
     });
   });
 

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -87,6 +87,16 @@ export interface InputPromptProps {
   onEscapePromptChange?: (showPrompt: boolean) => void;
   onToggleShortcuts?: () => void;
   showShortcuts?: boolean;
+  /**
+   * Reports whether any input-area Tab consumer is active — autocomplete
+   * dropdown, followup prompt suggestion, or mid-input ghost text. AppContainer
+   * feeds this into useAutoAcceptIndicator's `shouldBlockTab` to suppress the
+   * Windows-only "bare Tab cycles approval mode" fallback when an input-side
+   * handler already wants the Tab keystroke. See #4171.
+   *
+   * Name retained for backward compatibility with existing context wiring;
+   * the value tracks more than just suggestion-dropdown visibility.
+   */
   onSuggestionsVisibilityChange?: (visible: boolean) => void;
   vimHandleInput?: (key: Key) => boolean;
   isEmbeddedShellFocused?: boolean;
@@ -1422,17 +1432,24 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   // (AppContainer) feeds this into useAutoAcceptIndicator's `shouldBlockTab`
   // so the Windows-only "bare Tab cycles approval mode" fallback doesn't
   // double-fire alongside an input-area Tab handler. See issue #4171.
+  //
+  // Note on reverse/command-search: when those overlays have matches, their
+  // `showSuggestions` flag flows into `shouldShowSuggestions` above and Tab IS
+  // consumed (ACCEPT_SUGGESTION_REVERSE_SEARCH). When they are active with no
+  // matches, Tab is not consumed — so the bare `reverseSearchActive` /
+  // `commandSearchActive` flags are intentionally NOT included here.
   const hasTabConsumer =
     shouldShowSuggestions ||
     (followup.state.isVisible && Boolean(followup.state.suggestion)) ||
-    Boolean(completion.midInputGhostText?.acceptText) ||
-    reverseSearchActive ||
-    commandSearchActive;
+    Boolean(completion.midInputGhostText?.acceptText);
 
   useEffect(() => {
-    if (onSuggestionsVisibilityChange) {
-      onSuggestionsVisibilityChange(hasTabConsumer);
-    }
+    onSuggestionsVisibilityChange?.(hasTabConsumer);
+    // Reset to false on unmount (e.g. when InputPrompt unmounts during
+    // streaming) so AppContainer's stale `hasTabConsumer` doesn't keep
+    // blocking Windows Tab approval-mode cycling while there is no input
+    // area to consume the keystroke.
+    return () => onSuggestionsVisibilityChange?.(false);
   }, [hasTabConsumer, onSuggestionsVisibilityChange]);
 
   // Trigger prompt suggestion when prop changes

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -88,16 +88,21 @@ export interface InputPromptProps {
   onToggleShortcuts?: () => void;
   showShortcuts?: boolean;
   /**
-   * Reports whether any input-area Tab consumer is active — autocomplete
-   * dropdown, followup prompt suggestion, or mid-input ghost text. AppContainer
-   * feeds this into useAutoAcceptIndicator's `shouldBlockTab` to suppress the
-   * Windows-only "bare Tab cycles approval mode" fallback when an input-side
-   * handler already wants the Tab keystroke. See #4171.
-   *
-   * Name retained for backward compatibility with existing context wiring;
-   * the value tracks more than just suggestion-dropdown visibility.
+   * Reports autocomplete-dropdown visibility specifically. Composer uses
+   * this to hide the Footer / KeyboardShortcuts when the dropdown would
+   * overlap their vertical space. Must stay narrow — followup suggestions
+   * and mid-input ghost text don't take Footer's space and shouldn't hide
+   * it. See #4171 / #4308 review.
    */
   onSuggestionsVisibilityChange?: (visible: boolean) => void;
+  /**
+   * Reports whether any input-area handler will consume a Tab keystroke
+   * (autocomplete dropdown, followup prompt suggestion, or mid-input ghost
+   * text). AppContainer feeds this into useAutoAcceptIndicator's
+   * `shouldBlockTab` to suppress the Windows-only "bare Tab cycles approval
+   * mode" fallback. See #4171.
+   */
+  onTabConsumerChange?: (active: boolean) => void;
   vimHandleInput?: (key: Key) => boolean;
   isEmbeddedShellFocused?: boolean;
   /** Prompt suggestion text to display after response completes */
@@ -132,6 +137,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   onToggleShortcuts,
   showShortcuts,
   onSuggestionsVisibilityChange,
+  onTabConsumerChange,
   vimHandleInput,
   isEmbeddedShellFocused,
   promptSuggestion,
@@ -1428,10 +1434,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     (shouldUseExportSuggestions && exportCompletion.shouldShowSuggestions) ||
     activeCompletion.showSuggestions;
 
-  // Whether any input-side handler would consume a Tab keystroke. The parent
-  // (AppContainer) feeds this into useAutoAcceptIndicator's `shouldBlockTab`
-  // so the Windows-only "bare Tab cycles approval mode" fallback doesn't
-  // double-fire alongside an input-area Tab handler. See issue #4171.
+  // Whether any input-side handler would consume a Tab keystroke. AppContainer
+  // feeds this into useAutoAcceptIndicator's `shouldBlockTab` so the
+  // Windows-only "bare Tab cycles approval mode" fallback doesn't double-fire
+  // alongside an input-area Tab handler. See issue #4171.
   //
   // Note on reverse/command-search: when those overlays have matches, their
   // `showSuggestions` flag flows into `shouldShowSuggestions` above and Tab IS
@@ -1443,14 +1449,22 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     (followup.state.isVisible && Boolean(followup.state.suggestion)) ||
     Boolean(completion.midInputGhostText?.acceptText);
 
+  // Narrow signal — autocomplete dropdown only. Composer hides Footer /
+  // KeyboardShortcuts when this is true because the dropdown competes for
+  // the same vertical space. Followup / ghost text are inline within the
+  // input box and must NOT hide the Footer (#4308 review).
   useEffect(() => {
-    onSuggestionsVisibilityChange?.(hasTabConsumer);
-    // Reset to false on unmount (e.g. when InputPrompt unmounts during
-    // streaming) so AppContainer's stale `hasTabConsumer` doesn't keep
-    // blocking Windows Tab approval-mode cycling while there is no input
-    // area to consume the keystroke.
-    return () => onSuggestionsVisibilityChange?.(false);
-  }, [hasTabConsumer, onSuggestionsVisibilityChange]);
+    onSuggestionsVisibilityChange?.(shouldShowSuggestions);
+  }, [shouldShowSuggestions, onSuggestionsVisibilityChange]);
+
+  // Broad signal — any Tab consumer. Reset to false on unmount (e.g. when
+  // InputPrompt unmounts during streaming) so AppContainer's stale
+  // `hasTabConsumer` doesn't keep blocking Windows Tab approval-mode cycling
+  // while there is no input area to consume the keystroke.
+  useEffect(() => {
+    onTabConsumerChange?.(hasTabConsumer);
+    return () => onTabConsumerChange?.(false);
+  }, [hasTabConsumer, onTabConsumerChange]);
 
   // Trigger prompt suggestion when prop changes
   useEffect(() => {

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1418,12 +1418,22 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     (shouldUseExportSuggestions && exportCompletion.shouldShowSuggestions) ||
     activeCompletion.showSuggestions;
 
-  // Notify parent about suggestions visibility changes
+  // Whether any input-side handler would consume a Tab keystroke. The parent
+  // (AppContainer) feeds this into useAutoAcceptIndicator's `shouldBlockTab`
+  // so the Windows-only "bare Tab cycles approval mode" fallback doesn't
+  // double-fire alongside an input-area Tab handler. See issue #4171.
+  const hasTabConsumer =
+    shouldShowSuggestions ||
+    (followup.state.isVisible && Boolean(followup.state.suggestion)) ||
+    Boolean(completion.midInputGhostText?.acceptText) ||
+    reverseSearchActive ||
+    commandSearchActive;
+
   useEffect(() => {
     if (onSuggestionsVisibilityChange) {
-      onSuggestionsVisibilityChange(shouldShowSuggestions);
+      onSuggestionsVisibilityChange(hasTabConsumer);
     }
-  }, [shouldShowSuggestions, onSuggestionsVisibilityChange]);
+  }, [hasTabConsumer, onSuggestionsVisibilityChange]);
 
   // Trigger prompt suggestion when prop changes
   useEffect(() => {

--- a/packages/cli/src/ui/contexts/UIActionsContext.tsx
+++ b/packages/cli/src/ui/contexts/UIActionsContext.tsx
@@ -59,7 +59,7 @@ export interface UIActions {
   handleFolderTrustSelect: (choice: FolderTrustChoice) => void;
   setConstrainHeight: (value: boolean) => void;
   onEscapePromptChange: (show: boolean) => void;
-  onSuggestionsVisibilityChange: (visible: boolean) => void;
+  onTabConsumerChange: (active: boolean) => void;
   refreshStatic: () => void;
   handleFinalSubmit: (value: string) => void;
   handleRetryLastPrompt: () => void;


### PR DESCRIPTION
## Summary

- **What changed:** On Windows, the bare-Tab fallback for cycling approval mode now suppresses itself whenever the input area has any Tab consumer — not just the autocomplete dropdown, but also the followup prompt suggestion, mid-input ghost text, and reverse/command search overlays. `useAutoAcceptIndicator`'s `shouldBlockTab` callback is now driven by a broader `hasTabConsumer` signal computed inside `InputPrompt`.
- **Why it changed:** `useAutoAcceptIndicator` treats a bare Tab on Windows as Shift+Tab (terminals there often can't distinguish the two). Previously `shouldBlockTab` only saw the autocomplete dropdown via `shouldShowSuggestions`, so when the buffer was empty and a followup prompt-suggestion was visible, pressing Tab on Windows accepted the suggestion **and** cycled approval mode at the same time — exactly what #4171 reports. The mid-input ghost-text and reverse/command-search paths had the same latent gap.
- **Reviewer focus:**
  1. `packages/cli/src/ui/components/InputPrompt.tsx` — confirm `hasTabConsumer` covers every Tab branch in the same component (autocomplete, followup, ghost text, two searches). The `useEffect` deps are correct because `hasTabConsumer` is a primitive boolean, so React's same-value bail-out keeps the parent setter idle when nothing flipped.
  2. `packages/cli/src/ui/AppContainer.tsx` — pure rename `hasSuggestionsVisible` → `hasTabConsumer` to make the new semantics legible; cross-component prop name `onSuggestionsVisibilityChange` is unchanged to keep the patch focused.
  3. macOS / Linux behaviour is **unchanged** — none of this code path runs there.
  4. Agent view (`AgentComposer.tsx`) is **deliberately untouched**: it has no competing Tab consumer (no autocomplete, no followup, no ghost text — `BaseTextInput` swallows Tab), so adding `shouldBlockTab` there would be a no-op.

## Validation

- Commands run:
  \`\`\`bash
  npx vitest run src/ui/components/InputPrompt.test.tsx       # 146 pass (4 new for #4171)
  npx vitest run src/ui/hooks/useAutoAcceptIndicator.test.ts  # 14 pass (existing Windows cases still green)
  npx vitest run src/ui/AppContainer.test.tsx                 # 77 pass
  npx tsc --noEmit                                            # clean
  npx eslint src/ui/components/InputPrompt.tsx \\
             src/ui/AppContainer.tsx \\
             src/ui/components/InputPrompt.test.tsx           # clean
  \`\`\`
- Prompts / inputs used: the four new unit tests render \`InputPrompt\` with each of the relevant states (followup visible, ghost text visible, autocomplete visible, idle) and assert the value passed to \`onSuggestionsVisibilityChange\`.
- Expected result: callback reports \`true\` whenever any input-area Tab consumer is active and \`false\` when idle.
- Observed result: matches expected; new tests pass on first run.
- Quickest reviewer verification path: run \`npx vitest run src/ui/components/InputPrompt.test.tsx -t "hasTabConsumer"\` from \`packages/cli\`.
- Evidence:
  \`\`\`
  ✓ InputPrompt > hasTabConsumer reporting (issue #4171) > reports true while the followup prompt suggestion is visible
  ✓ InputPrompt > hasTabConsumer reporting (issue #4171) > reports true while mid-input ghost text offers an accept
  ✓ InputPrompt > hasTabConsumer reporting (issue #4171) > reports true while the autocomplete dropdown is visible
  ✓ InputPrompt > hasTabConsumer reporting (issue #4171) > reports false when the input area is idle (no dropdown, no followup, no ghost)
  \`\`\`

## Scope / Risk

- **Main risk or tradeoff:** Windows users who relied on pressing Tab to cycle approval mode while a followup suggestion / ghost text was on screen will now find that Tab accepts the suggestion instead — that is the intended fix per the issue ("one keystroke = one action"). To cycle approval mode in that state, dismiss the suggestion first (Esc) or wait for it to clear.
- **Not covered / not validated:** No live Windows-terminal test; the fix is verified via the existing platform-mocking pattern used by the surrounding tests in this file. Reverse-search and command-search overlays are covered by the broader \`hasTabConsumer\` signal but lack a dedicated unit test (they are gated by Ctrl+R / Ctrl+S, harder to drive in a render test); the existing keypress handlers for those modes are unchanged.
- **Breaking changes / migration notes:** No API or config change. Behaviour change is Windows-only and limited to the specific Tab-double-fire described above.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- 🍏 \`npm run\`: vitest / tsc / eslint all green on macOS (the platform-specific branch under test is gated by mocking \`process.platform === 'win32'\`, which is what the existing Windows cases in \`useAutoAcceptIndicator.test.ts\` already do).
- 🪟 / 🐧 interactive verification: ⚠️ not done. The change is behind a \`process.platform === 'win32'\` branch in \`useAutoAcceptIndicator\` that is exercised by unit tests; live terminal verification on a Windows host would be ideal before release.

## Linked Issues / Bugs

Closes #4171