### PR TITLE
feat(cli): respect /editor preference in Ctrl+X external editor

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -94,6 +94,8 @@ vi.mock('./hooks/useIdeTrustListener.js');
 vi.mock('./hooks/useMessageQueue.js');
 vi.mock('./hooks/useAutoAcceptIndicator.js');
 vi.mock('./hooks/useGitBranchName.js');
+vi.mock('./hooks/usePreferredEditor.js');
+vi.mock('./hooks/useWorktreeSession.js');
 vi.mock('./hooks/useProviderUpdates.js', () => ({
   useProviderUpdates: vi.fn(() => ({
     providerUpdateRequest: undefined,

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -33,7 +33,6 @@ import type { RestoreOption } from './components/RewindSelector.js';
 import { MessageType, StreamingState } from './types.js';
 import {
   type EditorType,
-  isValidEditorType,
   type Config,
   type IdeInfo,
   type IdeContext,
@@ -107,6 +106,7 @@ import { useThemeCommand } from './hooks/useThemeCommand.js';
 import { useFeedbackDialog } from './hooks/useFeedbackDialog.js';
 import { useAuthCommand } from './auth/useAuth.js';
 import { useEditorSettings } from './hooks/useEditorSettings.js';
+import { usePreferredEditor } from './hooks/usePreferredEditor.js';
 import { useSettingsCommand } from './hooks/useSettingsCommand.js';
 import { useModelCommand } from './hooks/useModelCommand.js';
 import { useManageModelsCommand } from './hooks/useManageModelsCommand.js';
@@ -780,10 +780,7 @@ export const AppContainer = (props: AppContainerProps) => {
     }
   }, []);
 
-  const prefEditorRaw = settings.merged.general?.preferredEditor ?? '';
-  const preferredEditor = isValidEditorType(prefEditorRaw)
-    ? prefEditorRaw
-    : undefined;
+  const preferredEditor = usePreferredEditor();
 
   const buffer = useTextBuffer({
     initialText: '',

--- a/packages/cli/src/ui/AppContainer.tsx
+++ b/packages/cli/src/ui/AppContainer.tsx
@@ -33,6 +33,7 @@ import type { RestoreOption } from './components/RewindSelector.js';
 import { MessageType, StreamingState } from './types.js';
 import {
   type EditorType,
+  isValidEditorType,
   type Config,
   type IdeInfo,
   type IdeContext,
@@ -779,6 +780,11 @@ export const AppContainer = (props: AppContainerProps) => {
     }
   }, []);
 
+  const prefEditorRaw = settings.merged.general?.preferredEditor ?? '';
+  const preferredEditor = isValidEditorType(prefEditorRaw)
+    ? prefEditorRaw
+    : undefined;
+
   const buffer = useTextBuffer({
     initialText: '',
     viewport: { height: 10, width: inputWidth },
@@ -786,6 +792,7 @@ export const AppContainer = (props: AppContainerProps) => {
     setRawMode,
     isValidPath,
     shellModeActive,
+    preferredEditor,
   });
 
   useEffect(() => {

--- a/packages/cli/src/ui/components/agent-view/AgentComposer.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentComposer.tsx
@@ -24,7 +24,7 @@ import {
   isTerminalStatus,
   ApprovalMode,
   APPROVAL_MODES,
-} from '@qwen-code/qwen-code-core';
+ isValidEditorType } from '@qwen-code/qwen-code-core';
 import {
   useAgentViewState,
   useAgentViewActions,
@@ -43,6 +43,7 @@ import { QueuedMessageDisplay } from '../QueuedMessageDisplay.js';
 import { AgentFooter } from './AgentFooter.js';
 import { keyMatchers, Command } from '../../keyMatchers.js';
 import { theme } from '../../semantic-colors.js';
+import { useSettings } from '../../contexts/SettingsContext.js';
 import { t } from '../../../i18n/index.js';
 
 // ─── Types ──────────────────────────────────────────────────
@@ -65,6 +66,7 @@ export const AgentComposer: React.FC<AgentComposerProps> = ({ agentId }) => {
   const interactiveAgent = agent?.interactiveAgent;
 
   const config = useConfig();
+  const settings = useSettings();
   const { columns: terminalWidth } = useTerminalSize();
   const { inputWidth } = calculatePromptWidths(terminalWidth);
   const { stdin, setRawMode } = useStdin();
@@ -121,12 +123,18 @@ export const AgentComposer: React.FC<AgentComposerProps> = ({ agentId }) => {
 
   const isValidPath = useCallback((): boolean => false, []);
 
+  const prefEditorRaw = settings.merged.general?.preferredEditor ?? '';
+  const preferredEditor = isValidEditorType(prefEditorRaw)
+    ? prefEditorRaw
+    : undefined;
+
   const buffer = useTextBuffer({
     initialText: '',
     viewport: { height: 3, width: inputWidth },
     stdin,
     setRawMode,
     isValidPath,
+    preferredEditor,
   });
 
   // Sync agent buffer text to context so AgentTabBar can guard tab switching

--- a/packages/cli/src/ui/components/agent-view/AgentComposer.tsx
+++ b/packages/cli/src/ui/components/agent-view/AgentComposer.tsx
@@ -24,7 +24,7 @@ import {
   isTerminalStatus,
   ApprovalMode,
   APPROVAL_MODES,
- isValidEditorType } from '@qwen-code/qwen-code-core';
+} from '@qwen-code/qwen-code-core';
 import {
   useAgentViewState,
   useAgentViewActions,
@@ -43,7 +43,7 @@ import { QueuedMessageDisplay } from '../QueuedMessageDisplay.js';
 import { AgentFooter } from './AgentFooter.js';
 import { keyMatchers, Command } from '../../keyMatchers.js';
 import { theme } from '../../semantic-colors.js';
-import { useSettings } from '../../contexts/SettingsContext.js';
+import { usePreferredEditor } from '../../hooks/usePreferredEditor.js';
 import { t } from '../../../i18n/index.js';
 
 // ─── Types ──────────────────────────────────────────────────
@@ -66,7 +66,7 @@ export const AgentComposer: React.FC<AgentComposerProps> = ({ agentId }) => {
   const interactiveAgent = agent?.interactiveAgent;
 
   const config = useConfig();
-  const settings = useSettings();
+  const preferredEditor = usePreferredEditor();
   const { columns: terminalWidth } = useTerminalSize();
   const { inputWidth } = calculatePromptWidths(terminalWidth);
   const { stdin, setRawMode } = useStdin();
@@ -122,11 +122,6 @@ export const AgentComposer: React.FC<AgentComposerProps> = ({ agentId }) => {
   // ── Input buffer (independent from main agent) ──
 
   const isValidPath = useCallback((): boolean => false, []);
-
-  const prefEditorRaw = settings.merged.general?.preferredEditor ?? '';
-  const preferredEditor = isValidEditorType(prefEditorRaw)
-    ? prefEditorRaw
-    : undefined;
 
   const buffer = useTextBuffer({
     initialText: '',

--- a/packages/cli/src/ui/components/shared/TextInput.test.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.test.tsx
@@ -14,6 +14,8 @@ vi.mock('../../hooks/useKeypress.js', () => ({
   useKeypress: vi.fn(),
 }));
 
+vi.mock('../../hooks/usePreferredEditor.js');
+
 vi.mock('../../semantic-colors.js', () => ({
   theme: {
     text: { accent: 'cyan' },

--- a/packages/cli/src/ui/components/shared/TextInput.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.tsx
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// no hooks needed beyond keypress handled inside
 import { Box, Text, useStdin } from 'ink';
 import chalk from 'chalk';
 import stringWidth from 'string-width';

--- a/packages/cli/src/ui/components/shared/TextInput.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.tsx
@@ -9,6 +9,7 @@ import { Box, Text } from 'ink';
 import chalk from 'chalk';
 import stringWidth from 'string-width';
 import { useTextBuffer } from './text-buffer.js';
+import { usePreferredEditor } from '../../hooks/usePreferredEditor.js';
 import { useKeypress } from '../../hooks/useKeypress.js';
 import { keyMatchers, Command } from '../../keyMatchers.js';
 import { cpSlice, cpLen } from '../../utils/textUtils.js';
@@ -76,12 +77,15 @@ export function TextInput({
     onChangeRef.current?.(text);
   }, []);
 
+  const preferredEditor = usePreferredEditor();
+
   const buffer = useTextBuffer({
     initialText: value || '',
     initialCursorOffset,
     viewport: { height, width: inputWidth },
     isValidPath: () => false,
     onChange: stableOnChange,
+    preferredEditor,
   });
 
   const handleSubmit = () => {

--- a/packages/cli/src/ui/components/shared/TextInput.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.tsx
@@ -5,7 +5,7 @@
  */
 
 // no hooks needed beyond keypress handled inside
-import { Box, Text } from 'ink';
+import { Box, Text, useStdin } from 'ink';
 import chalk from 'chalk';
 import stringWidth from 'string-width';
 import { useTextBuffer } from './text-buffer.js';
@@ -78,11 +78,14 @@ export function TextInput({
   }, []);
 
   const preferredEditor = usePreferredEditor();
+  const { stdin, setRawMode } = useStdin();
 
   const buffer = useTextBuffer({
     initialText: value || '',
     initialCursorOffset,
     viewport: { height, width: inputWidth },
+    stdin,
+    setRawMode,
     isValidPath: () => false,
     onChange: stableOnChange,
     preferredEditor,

--- a/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
@@ -227,6 +227,8 @@ describe('openInExternalEditor', () => {
       await result.current.openInExternalEditor();
     });
 
+    const spawnCmd = mockSpawnSync.mock.calls[0]?.[0] as string;
+    expect(spawnCmd).toBe('"code.cmd"');
     const spawnArgs = mockSpawnSync.mock.calls[0]?.[1] as string[];
     for (const arg of spawnArgs) {
       expect(arg).toMatch(/^".*"$/);
@@ -369,7 +371,7 @@ describe('openInExternalEditor', () => {
       });
 
       expect(mockSpawnSync).toHaveBeenCalledWith(
-        'code.cmd',
+        '"code.cmd"',
         expect.arrayContaining([expect.stringMatching(/^".*"$/)]),
         expect.objectContaining({ shell: true }),
       );
@@ -503,5 +505,72 @@ describe('openInExternalEditor', () => {
 
     expect(fs.unlinkSync).toHaveBeenCalledWith(expectedTmpFile);
     expect(fs.rmdirSync).toHaveBeenCalledWith('/tmp/qwen-edit-mock');
+  });
+
+  it('should normalize CRLF to LF in editor output', async () => {
+    (fs.readFileSync as Mock).mockReturnValue('line1\r\nline2\rline3\nline4');
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'original',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(result.current.text).toBe('line1\nline2\nline3\nline4');
+  });
+
+  it('should keep buffer unchanged when readFileSync throws', async () => {
+    (fs.readFileSync as Mock).mockImplementation(() => {
+      throw new Error('EACCES');
+    });
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'original',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(result.current.text).toBe('original');
+    expect(fs.unlinkSync).toHaveBeenCalled();
+  });
+
+  it('should quote editorCmd when shell mode is enabled', async () => {
+    const origPlatform = process.platform;
+    const origVISUAL = process.env['VISUAL'];
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    process.env['VISUAL'] = 'C:\\Program Files\\Code\\code.cmd';
+
+    try {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'hello',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.openInExternalEditor();
+      });
+
+      const spawnCmd = mockSpawnSync.mock.calls[0]?.[0] as string;
+      expect(spawnCmd).toBe('"C:\\Program Files\\Code\\code.cmd"');
+    } finally {
+      Object.defineProperty(process, 'platform', { value: origPlatform });
+      if (origVISUAL === undefined) delete process.env['VISUAL'];
+      else process.env['VISUAL'] = origVISUAL;
+    }
   });
 });

--- a/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
@@ -420,4 +420,46 @@ describe('openInExternalEditor', () => {
 
     expect(result.current.text).toBe('new content');
   });
+
+  it('should not read temp file when editor is killed by signal', async () => {
+    mockSpawnSync.mockReturnValue({
+      status: null,
+      error: null,
+      signal: 'SIGKILL',
+    });
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'original',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(fs.readFileSync).not.toHaveBeenCalled();
+    expect(result.current.text).toBe('original');
+  });
+
+  it('should not create undo snapshot when editor fails', async () => {
+    mockSpawnSync.mockReturnValue({ status: 1, error: null });
+    (fs.readFileSync as Mock).mockReturnValue('should not see this');
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'original',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(result.current.text).toBe('original');
+  });
 });

--- a/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
@@ -544,6 +544,48 @@ describe('openInExternalEditor', () => {
     expect(fs.unlinkSync).toHaveBeenCalled();
   });
 
+  it('should still rmdirSync when unlinkSync throws', async () => {
+    (fs.unlinkSync as Mock).mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'hello',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(fs.rmdirSync).toHaveBeenCalledWith('/tmp/qwen-edit-mock');
+  });
+
+  it('should abort gracefully when mkdtempSync fails', async () => {
+    (fs.mkdtempSync as Mock).mockImplementation(() => {
+      throw new Error('ENOSPC');
+    });
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'original',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+    expect(fs.writeFileSync).not.toHaveBeenCalled();
+    expect(result.current.text).toBe('original');
+  });
+
   it('should quote editorCmd when shell mode is enabled', async () => {
     const origPlatform = process.platform;
     const origVISUAL = process.env['VISUAL'];

--- a/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
@@ -57,9 +57,11 @@ vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
 });
 
 import fs from 'node:fs';
+import pathMod from 'node:path';
 import { useTextBuffer } from './text-buffer.js';
 
 const viewport = { height: 5, width: 40 };
+const expectedTmpFile = pathMod.join('/tmp/qwen-edit-mock', 'buffer.txt');
 
 describe('openInExternalEditor', () => {
   beforeEach(() => {
@@ -90,7 +92,7 @@ describe('openInExternalEditor', () => {
       expect.stringContaining('qwen-edit-'),
     );
     const writePath = (fs.writeFileSync as Mock).mock.calls[0]?.[0] as string;
-    expect(writePath).toBe('/tmp/qwen-edit-mock/buffer.txt');
+    expect(writePath).toBe(expectedTmpFile);
   });
 
   it('should write temp file with mode 0o600', async () => {
@@ -175,7 +177,7 @@ describe('openInExternalEditor', () => {
   it('should use getExternalEditorCommand when preferredEditor is set', async () => {
     mockGetExternalEditorCommand.mockReturnValue({
       command: 'code',
-      args: ['/tmp/qwen-edit-mock/buffer.txt', '--wait'],
+      args: [expectedTmpFile, '--wait'],
       isTerminal: false,
       needsShell: false,
     });
@@ -207,7 +209,7 @@ describe('openInExternalEditor', () => {
   it('should quote args when needsShell is true', async () => {
     mockGetExternalEditorCommand.mockReturnValue({
       command: 'code.cmd',
-      args: ['/tmp/qwen-edit-mock/buffer.txt', '--wait'],
+      args: [expectedTmpFile, '--wait'],
       isTerminal: false,
       needsShell: true,
     });
@@ -499,9 +501,7 @@ describe('openInExternalEditor', () => {
       await result.current.openInExternalEditor();
     });
 
-    expect(fs.unlinkSync).toHaveBeenCalledWith(
-      '/tmp/qwen-edit-mock/buffer.txt',
-    );
+    expect(fs.unlinkSync).toHaveBeenCalledWith(expectedTmpFile);
     expect(fs.rmdirSync).toHaveBeenCalledWith('/tmp/qwen-edit-mock');
   });
 });

--- a/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
@@ -733,12 +733,8 @@ describe('openInExternalEditor', () => {
 
     expect(mockSetRawMode).toHaveBeenCalledWith(false);
     expect(mockSetRawMode).toHaveBeenCalledWith(true);
-    const falseIdx = mockSetRawMode.mock.calls.findIndex(
-      (c: [boolean]) => c[0] === false,
-    );
-    const trueIdx = mockSetRawMode.mock.calls.findIndex(
-      (c: [boolean]) => c[0] === true,
-    );
+    const falseIdx = mockSetRawMode.mock.calls.findIndex((c) => c[0] === false);
+    const trueIdx = mockSetRawMode.mock.calls.findIndex((c) => c[0] === true);
     expect(falseIdx).toBeLessThan(trueIdx);
   });
 

--- a/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
@@ -692,33 +692,40 @@ describe('openInExternalEditor', () => {
     }
   });
 
-  it('should reject opts.editor with unsafe characters on Windows', async () => {
-    const origPlatform = process.platform;
-    Object.defineProperty(process, 'platform', { value: 'win32' });
+  it.each([
+    { char: '"', editor: 'evil"|cmd.cmd' },
+    { char: '%', editor: 'expand%PATH%.cmd' },
+    { char: '!', editor: 'delayed!var!.cmd' },
+  ])(
+    'should reject opts.editor with unsafe "$char" on Windows',
+    async ({ editor }) => {
+      const origPlatform = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32' });
 
-    try {
-      const { result } = renderHook(() =>
-        useTextBuffer({
-          initialText: 'hello',
-          viewport,
-          isValidPath: () => false,
-        }),
-      );
+      try {
+        const { result } = renderHook(() =>
+          useTextBuffer({
+            initialText: 'hello',
+            viewport,
+            isValidPath: () => false,
+          }),
+        );
 
-      await act(async () => {
-        await result.current.openInExternalEditor({ editor: 'evil"|cmd.cmd' });
-      });
+        await act(async () => {
+          await result.current.openInExternalEditor({ editor });
+        });
 
-      expect(mockSpawnSync).not.toHaveBeenCalled();
-      expect(result.current.text).toBe('hello');
-      expect(fs.rmSync).toHaveBeenCalledWith('/tmp/qwen-edit-mock', {
-        recursive: true,
-        force: true,
-      });
-    } finally {
-      Object.defineProperty(process, 'platform', { value: origPlatform });
-    }
-  });
+        expect(mockSpawnSync).not.toHaveBeenCalled();
+        expect(result.current.text).toBe('hello');
+        expect(fs.rmSync).toHaveBeenCalledWith('/tmp/qwen-edit-mock', {
+          recursive: true,
+          force: true,
+        });
+      } finally {
+        Object.defineProperty(process, 'platform', { value: origPlatform });
+      }
+    },
+  );
 
   it('should disable and restore raw mode around editor session', async () => {
     const mockSetRawMode = vi.fn();
@@ -743,6 +750,33 @@ describe('openInExternalEditor', () => {
     const falseIdx = mockSetRawMode.mock.calls.findIndex((c) => c[0] === false);
     const trueIdx = mockSetRawMode.mock.calls.findIndex((c) => c[0] === true);
     expect(falseIdx).toBeLessThan(trueIdx);
+  });
+
+  it('should restore raw mode even when editor fails', async () => {
+    const mockSetRawMode = vi.fn();
+    const mockStdin = { isRaw: true } as unknown as NodeJS.ReadStream;
+    mockSpawnSync.mockReturnValueOnce({ status: 1, error: null, signal: null });
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'hello',
+        viewport,
+        isValidPath: () => false,
+        stdin: mockStdin,
+        setRawMode: mockSetRawMode,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(mockSetRawMode).toHaveBeenCalledWith(false);
+    expect(mockSetRawMode).toHaveBeenCalledWith(true);
+    const falseIdx = mockSetRawMode.mock.calls.findIndex((c) => c[0] === false);
+    const trueIdx = mockSetRawMode.mock.calls.findIndex((c) => c[0] === true);
+    expect(falseIdx).toBeLessThan(trueIdx);
+    expect(result.current.text).toBe('hello');
   });
 
   it('should fall back to vi when VISUAL and EDITOR are unset on non-Windows', async () => {
@@ -815,35 +849,42 @@ describe('openInExternalEditor', () => {
     }
   });
 
-  it('should reject env-var .cmd with unsafe characters on Windows', async () => {
-    const origPlatform = process.platform;
-    const origVISUAL = process.env['VISUAL'];
-    Object.defineProperty(process, 'platform', { value: 'win32' });
-    process.env['VISUAL'] = 'evil"cmd.cmd';
+  it.each([
+    { char: '"', env: 'evil"cmd.cmd' },
+    { char: '%', env: 'expand%PATH%.cmd' },
+    { char: '!', env: 'delayed!var!.cmd' },
+  ])(
+    'should reject env-var .cmd with unsafe "$char" on Windows',
+    async ({ env }) => {
+      const origPlatform = process.platform;
+      const origVISUAL = process.env['VISUAL'];
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      process.env['VISUAL'] = env;
 
-    try {
-      const { result } = renderHook(() =>
-        useTextBuffer({
-          initialText: 'hello',
-          viewport,
-          isValidPath: () => false,
-        }),
-      );
+      try {
+        const { result } = renderHook(() =>
+          useTextBuffer({
+            initialText: 'hello',
+            viewport,
+            isValidPath: () => false,
+          }),
+        );
 
-      await act(async () => {
-        await result.current.openInExternalEditor();
-      });
+        await act(async () => {
+          await result.current.openInExternalEditor();
+        });
 
-      expect(mockSpawnSync).not.toHaveBeenCalled();
-      expect(result.current.text).toBe('hello');
-      expect(fs.rmSync).toHaveBeenCalledWith('/tmp/qwen-edit-mock', {
-        recursive: true,
-        force: true,
-      });
-    } finally {
-      Object.defineProperty(process, 'platform', { value: origPlatform });
-      if (origVISUAL === undefined) delete process.env['VISUAL'];
-      else process.env['VISUAL'] = origVISUAL;
-    }
-  });
+        expect(mockSpawnSync).not.toHaveBeenCalled();
+        expect(result.current.text).toBe('hello');
+        expect(fs.rmSync).toHaveBeenCalledWith('/tmp/qwen-edit-mock', {
+          recursive: true,
+          force: true,
+        });
+      } finally {
+        Object.defineProperty(process, 'platform', { value: origPlatform });
+        if (origVISUAL === undefined) delete process.env['VISUAL'];
+        else process.env['VISUAL'] = origVISUAL;
+      }
+    },
+  );
 });

--- a/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
@@ -37,8 +37,7 @@ vi.mock('node:fs', async (importOriginal) => {
     mkdtempSync: vi.fn().mockReturnValue('/tmp/qwen-edit-mock'),
     writeFileSync: vi.fn(),
     readFileSync: vi.fn().mockReturnValue('edited text'),
-    unlinkSync: vi.fn(),
-    rmdirSync: vi.fn(),
+    rmSync: vi.fn(),
   };
   return {
     ...actual,
@@ -69,8 +68,7 @@ describe('openInExternalEditor', () => {
     (fs.mkdtempSync as Mock).mockReturnValue('/tmp/qwen-edit-mock');
     (fs.writeFileSync as Mock).mockImplementation(() => {});
     (fs.readFileSync as Mock).mockReturnValue('edited text');
-    (fs.unlinkSync as Mock).mockImplementation(() => {});
-    (fs.rmdirSync as Mock).mockImplementation(() => {});
+    (fs.rmSync as Mock).mockImplementation(() => {});
     mockSpawnSync.mockReturnValue({ status: 0, error: null });
     mockGetExternalEditorCommand.mockReturnValue(null);
   });
@@ -129,7 +127,7 @@ describe('openInExternalEditor', () => {
       await result.current.openInExternalEditor();
     });
 
-    expect(fs.unlinkSync).toHaveBeenCalled();
+    expect(fs.rmSync).toHaveBeenCalled();
   });
 
   it('should clean up temp file when writeFileSync throws', async () => {
@@ -149,7 +147,7 @@ describe('openInExternalEditor', () => {
       await result.current.openInExternalEditor();
     });
 
-    expect(fs.unlinkSync).toHaveBeenCalled();
+    expect(fs.rmSync).toHaveBeenCalled();
     expect(mockSpawnSync).not.toHaveBeenCalled();
   });
 
@@ -281,7 +279,7 @@ describe('openInExternalEditor', () => {
       await result.current.openInExternalEditor();
     });
 
-    expect(fs.unlinkSync).toHaveBeenCalled();
+    expect(fs.rmSync).toHaveBeenCalled();
     expect(result.current.text).toBe('hello');
   });
 
@@ -524,8 +522,10 @@ describe('openInExternalEditor', () => {
       await result.current.openInExternalEditor();
     });
 
-    expect(fs.unlinkSync).toHaveBeenCalledWith(expectedTmpFile);
-    expect(fs.rmdirSync).toHaveBeenCalledWith('/tmp/qwen-edit-mock');
+    expect(fs.rmSync).toHaveBeenCalledWith('/tmp/qwen-edit-mock', {
+      recursive: true,
+      force: true,
+    });
   });
 
   it('should normalize CRLF to LF in editor output', async () => {
@@ -564,12 +564,12 @@ describe('openInExternalEditor', () => {
     });
 
     expect(result.current.text).toBe('original');
-    expect(fs.unlinkSync).toHaveBeenCalled();
+    expect(fs.rmSync).toHaveBeenCalled();
   });
 
-  it('should still rmdirSync when unlinkSync throws', async () => {
-    (fs.unlinkSync as Mock).mockImplementation(() => {
-      throw new Error('ENOENT');
+  it('should not propagate when rmSync cleanup throws (e.g. EPERM)', async () => {
+    (fs.rmSync as Mock).mockImplementation(() => {
+      throw new Error('EPERM');
     });
 
     const { result } = renderHook(() =>
@@ -584,7 +584,11 @@ describe('openInExternalEditor', () => {
       await result.current.openInExternalEditor();
     });
 
-    expect(fs.rmdirSync).toHaveBeenCalledWith('/tmp/qwen-edit-mock');
+    expect(fs.rmSync).toHaveBeenCalledWith('/tmp/qwen-edit-mock', {
+      recursive: true,
+      force: true,
+    });
+    expect(result.current.text).toBe('edited text');
   });
 
   it('should abort gracefully when mkdtempSync fails', async () => {
@@ -707,7 +711,10 @@ describe('openInExternalEditor', () => {
 
       expect(mockSpawnSync).not.toHaveBeenCalled();
       expect(result.current.text).toBe('hello');
-      expect(fs.rmdirSync).toHaveBeenCalled();
+      expect(fs.rmSync).toHaveBeenCalledWith('/tmp/qwen-edit-mock', {
+        recursive: true,
+        force: true,
+      });
     } finally {
       Object.defineProperty(process, 'platform', { value: origPlatform });
     }
@@ -829,7 +836,10 @@ describe('openInExternalEditor', () => {
 
       expect(mockSpawnSync).not.toHaveBeenCalled();
       expect(result.current.text).toBe('hello');
-      expect(fs.rmdirSync).toHaveBeenCalled();
+      expect(fs.rmSync).toHaveBeenCalledWith('/tmp/qwen-edit-mock', {
+        recursive: true,
+        force: true,
+      });
     } finally {
       Object.defineProperty(process, 'platform', { value: origPlatform });
       if (origVISUAL === undefined) delete process.env['VISUAL'];

--- a/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
@@ -609,7 +609,7 @@ describe('openInExternalEditor', () => {
     expect(result.current.text).toBe('original');
   });
 
-  it('should quote editorCmd when shell mode is enabled', async () => {
+  it('should quote editorCmd and args with shell:true when shell mode is enabled', async () => {
     const origPlatform = process.platform;
     const origVISUAL = process.env['VISUAL'];
     Object.defineProperty(process, 'platform', { value: 'win32' });
@@ -628,8 +628,113 @@ describe('openInExternalEditor', () => {
         await result.current.openInExternalEditor();
       });
 
-      const spawnCmd = mockSpawnSync.mock.calls[0]?.[0] as string;
-      expect(spawnCmd).toBe('"C:\\Program Files\\Code\\code.cmd"');
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        '"C:\\Program Files\\Code\\code.cmd"',
+        expect.arrayContaining([expect.stringMatching(/^".*"$/)]),
+        expect.objectContaining({ shell: true }),
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', { value: origPlatform });
+      if (origVISUAL === undefined) delete process.env['VISUAL'];
+      else process.env['VISUAL'] = origVISUAL;
+    }
+  });
+
+  it('should use opts.editor when provided', async () => {
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'hello',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor({ editor: 'nano' });
+    });
+
+    expect(mockGetExternalEditorCommand).not.toHaveBeenCalled();
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'nano',
+      expect.arrayContaining([expect.stringMatching(/\.txt$/)]),
+      expect.objectContaining({ stdio: 'inherit', shell: false }),
+    );
+  });
+
+  it('should enable shell mode for .cmd opts.editor on Windows', async () => {
+    const origPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    try {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'hello',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.openInExternalEditor({ editor: 'C:\\editor.cmd' });
+      });
+
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        '"C:\\editor.cmd"',
+        expect.arrayContaining([expect.stringMatching(/^".*"$/)]),
+        expect.objectContaining({ shell: true }),
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', { value: origPlatform });
+    }
+  });
+
+  it('should reject opts.editor with unsafe characters on Windows', async () => {
+    const origPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    try {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'hello',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.openInExternalEditor({ editor: 'evil"|cmd.cmd' });
+      });
+
+      expect(mockSpawnSync).not.toHaveBeenCalled();
+      expect(result.current.text).toBe('hello');
+      expect(fs.rmdirSync).toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(process, 'platform', { value: origPlatform });
+    }
+  });
+
+  it('should reject env-var .cmd with unsafe characters on Windows', async () => {
+    const origPlatform = process.platform;
+    const origVISUAL = process.env['VISUAL'];
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    process.env['VISUAL'] = 'evil"cmd.cmd';
+
+    try {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'hello',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.openInExternalEditor();
+      });
+
+      expect(mockSpawnSync).not.toHaveBeenCalled();
+      expect(result.current.text).toBe('hello');
+      expect(fs.rmdirSync).toHaveBeenCalled();
     } finally {
       Object.defineProperty(process, 'platform', { value: origPlatform });
       if (origVISUAL === undefined) delete process.env['VISUAL'];

--- a/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
@@ -488,6 +488,29 @@ describe('openInExternalEditor', () => {
     expect(result.current.text).toBe('unchanged');
   });
 
+  it('should undo to pre-editor content after successful edit', async () => {
+    (fs.readFileSync as Mock).mockReturnValue('new content');
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'old content',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(result.current.text).toBe('new content');
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.text).toBe('old content');
+  });
+
   it('should clean up tmpDir and file in finally', async () => {
     const { result } = renderHook(() =>
       useTextBuffer({

--- a/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
@@ -31,24 +31,14 @@ vi.mock('node:os', async (importOriginal) => {
   };
 });
 
-vi.mock('node:crypto', async (importOriginal) => {
-  const actual = await importOriginal<Record<string, unknown>>();
-  return {
-    ...actual,
-    default: {
-      ...(actual['default'] as object),
-      randomUUID: () => 'test-uuid-1234',
-    },
-    randomUUID: () => 'test-uuid-1234',
-  };
-});
-
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
   const mocks = {
+    mkdtempSync: vi.fn().mockReturnValue('/tmp/qwen-edit-mock'),
     writeFileSync: vi.fn(),
     readFileSync: vi.fn().mockReturnValue('edited text'),
     unlinkSync: vi.fn(),
+    rmdirSync: vi.fn(),
   };
   return {
     ...actual,
@@ -74,14 +64,16 @@ const viewport = { height: 5, width: 40 };
 describe('openInExternalEditor', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    (fs.mkdtempSync as Mock).mockReturnValue('/tmp/qwen-edit-mock');
     (fs.writeFileSync as Mock).mockImplementation(() => {});
     (fs.readFileSync as Mock).mockReturnValue('edited text');
     (fs.unlinkSync as Mock).mockImplementation(() => {});
+    (fs.rmdirSync as Mock).mockImplementation(() => {});
     mockSpawnSync.mockReturnValue({ status: 0, error: null });
     mockGetExternalEditorCommand.mockReturnValue(null);
   });
 
-  it('should use .txt extension for temp file', async () => {
+  it('should create temp file in private mkdtemp directory', async () => {
     const { result } = renderHook(() =>
       useTextBuffer({
         initialText: 'hello',
@@ -94,8 +86,11 @@ describe('openInExternalEditor', () => {
       await result.current.openInExternalEditor();
     });
 
+    expect(fs.mkdtempSync).toHaveBeenCalledWith(
+      expect.stringContaining('qwen-edit-'),
+    );
     const writePath = (fs.writeFileSync as Mock).mock.calls[0]?.[0] as string;
-    expect(writePath).toMatch(/\.txt$/);
+    expect(writePath).toBe('/tmp/qwen-edit-mock/buffer.txt');
   });
 
   it('should write temp file with mode 0o600', async () => {
@@ -180,7 +175,7 @@ describe('openInExternalEditor', () => {
   it('should use getExternalEditorCommand when preferredEditor is set', async () => {
     mockGetExternalEditorCommand.mockReturnValue({
       command: 'code',
-      args: ['/tmp/qwen-edit-test-uuid-1234.txt', '--wait'],
+      args: ['/tmp/qwen-edit-mock/buffer.txt', '--wait'],
       isTerminal: false,
       needsShell: false,
     });
@@ -212,7 +207,7 @@ describe('openInExternalEditor', () => {
   it('should quote args when needsShell is true', async () => {
     mockGetExternalEditorCommand.mockReturnValue({
       command: 'code.cmd',
-      args: ['/tmp/qwen-edit-test-uuid-1234.txt', '--wait'],
+      args: ['/tmp/qwen-edit-mock/buffer.txt', '--wait'],
       isTerminal: false,
       needsShell: true,
     });
@@ -444,7 +439,7 @@ describe('openInExternalEditor', () => {
     expect(result.current.text).toBe('original');
   });
 
-  it('should not create undo snapshot when editor fails', async () => {
+  it('should not create undo snapshot when editor fails — undo is no-op', async () => {
     mockSpawnSync.mockReturnValue({ status: 1, error: null });
     (fs.readFileSync as Mock).mockReturnValue('should not see this');
 
@@ -461,5 +456,52 @@ describe('openInExternalEditor', () => {
     });
 
     expect(result.current.text).toBe('original');
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.text).toBe('original');
+  });
+
+  it('should skip undo snapshot when content is unchanged', async () => {
+    (fs.readFileSync as Mock).mockReturnValue('unchanged');
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'unchanged',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(result.current.text).toBe('unchanged');
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.text).toBe('unchanged');
+  });
+
+  it('should clean up tmpDir and file in finally', async () => {
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'hello',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(fs.unlinkSync).toHaveBeenCalledWith(
+      '/tmp/qwen-edit-mock/buffer.txt',
+    );
+    expect(fs.rmdirSync).toHaveBeenCalledWith('/tmp/qwen-edit-mock');
   });
 });

--- a/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
@@ -352,6 +352,57 @@ describe('openInExternalEditor', () => {
     }
   });
 
+  it('should detect .cmd/.bat in env-var fallback and enable shell mode on Windows', async () => {
+    const origPlatform = process.platform;
+    const origVISUAL = process.env['VISUAL'];
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    process.env['VISUAL'] = 'code.cmd';
+
+    try {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'hello',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.openInExternalEditor();
+      });
+
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        'code.cmd',
+        expect.arrayContaining([expect.stringMatching(/^".*"$/)]),
+        expect.objectContaining({ shell: true }),
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', { value: origPlatform });
+      if (origVISUAL === undefined) delete process.env['VISUAL'];
+      else process.env['VISUAL'] = origVISUAL;
+    }
+  });
+
+  it('should pass timeout to spawnSync', async () => {
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'hello',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.any(Array),
+      expect.objectContaining({ timeout: 30 * 60 * 1000 }),
+    );
+  });
+
   it('should update text after successful editor session', async () => {
     (fs.readFileSync as Mock).mockReturnValue('new content');
 

--- a/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
@@ -713,6 +713,105 @@ describe('openInExternalEditor', () => {
     }
   });
 
+  it('should disable and restore raw mode around editor session', async () => {
+    const mockSetRawMode = vi.fn();
+    const mockStdin = { isRaw: true } as unknown as NodeJS.ReadStream;
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'hello',
+        viewport,
+        isValidPath: () => false,
+        stdin: mockStdin,
+        setRawMode: mockSetRawMode,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(mockSetRawMode).toHaveBeenCalledWith(false);
+    expect(mockSetRawMode).toHaveBeenCalledWith(true);
+    const falseIdx = mockSetRawMode.mock.calls.findIndex(
+      (c: [boolean]) => c[0] === false,
+    );
+    const trueIdx = mockSetRawMode.mock.calls.findIndex(
+      (c: [boolean]) => c[0] === true,
+    );
+    expect(falseIdx).toBeLessThan(trueIdx);
+  });
+
+  it('should fall back to vi when VISUAL and EDITOR are unset on non-Windows', async () => {
+    const origPlatform = process.platform;
+    const origVISUAL = process.env['VISUAL'];
+    const origEDITOR = process.env['EDITOR'];
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+    delete process.env['VISUAL'];
+    delete process.env['EDITOR'];
+
+    try {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'hello',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.openInExternalEditor();
+      });
+
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        'vi',
+        expect.arrayContaining([expect.stringMatching(/\.txt$/)]),
+        expect.objectContaining({ stdio: 'inherit' }),
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', { value: origPlatform });
+      if (origVISUAL === undefined) delete process.env['VISUAL'];
+      else process.env['VISUAL'] = origVISUAL;
+      if (origEDITOR === undefined) delete process.env['EDITOR'];
+      else process.env['EDITOR'] = origEDITOR;
+    }
+  });
+
+  it('should fall back to notepad when VISUAL and EDITOR are unset on Windows', async () => {
+    const origPlatform = process.platform;
+    const origVISUAL = process.env['VISUAL'];
+    const origEDITOR = process.env['EDITOR'];
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+    delete process.env['VISUAL'];
+    delete process.env['EDITOR'];
+
+    try {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'hello',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.openInExternalEditor();
+      });
+
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        'notepad',
+        expect.arrayContaining([expect.stringMatching(/\.txt$/)]),
+        expect.objectContaining({ stdio: 'inherit' }),
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', { value: origPlatform });
+      if (origVISUAL === undefined) delete process.env['VISUAL'];
+      else process.env['VISUAL'] = origVISUAL;
+      if (origEDITOR === undefined) delete process.env['EDITOR'];
+      else process.env['EDITOR'] = origEDITOR;
+    }
+  });
+
   it('should reject env-var .cmd with unsafe characters on Windows', async () => {
     const origPlatform = process.platform;
     const origVISUAL = process.env['VISUAL'];

--- a/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
@@ -178,7 +178,6 @@ describe('openInExternalEditor', () => {
     mockGetExternalEditorCommand.mockReturnValue({
       command: 'code',
       args: [expectedTmpFile, '--wait'],
-      isTerminal: false,
       needsShell: false,
     });
 
@@ -210,7 +209,6 @@ describe('openInExternalEditor', () => {
     mockGetExternalEditorCommand.mockReturnValue({
       command: 'code.cmd',
       args: [expectedTmpFile, '--wait'],
-      isTerminal: false,
       needsShell: true,
     });
 

--- a/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer-external-editor.test.ts
@@ -1,0 +1,372 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+const { mockSpawnSync, mockGetExternalEditorCommand } = vi.hoisted(() => ({
+  mockSpawnSync: vi.fn().mockReturnValue({ status: 0, error: null }),
+  mockGetExternalEditorCommand: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  // Named re-exports must be spelled out for vitest ESM mocking to rebind them.
+  return {
+    ...actual,
+    default: { ...actual, spawnSync: mockSpawnSync },
+    spawnSync: mockSpawnSync,
+  };
+});
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    default: { ...(actual['default'] as object), tmpdir: () => '/tmp' },
+    tmpdir: () => '/tmp',
+  };
+});
+
+vi.mock('node:crypto', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    default: {
+      ...(actual['default'] as object),
+      randomUUID: () => 'test-uuid-1234',
+    },
+    randomUUID: () => 'test-uuid-1234',
+  };
+});
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  const mocks = {
+    writeFileSync: vi.fn(),
+    readFileSync: vi.fn().mockReturnValue('edited text'),
+    unlinkSync: vi.fn(),
+  };
+  return {
+    ...actual,
+    ...mocks,
+    default: { ...(actual['default'] as object), ...mocks },
+  };
+});
+
+vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
+  return {
+    ...actual,
+    getExternalEditorCommand: mockGetExternalEditorCommand,
+  };
+});
+
+import fs from 'node:fs';
+import { useTextBuffer } from './text-buffer.js';
+
+const viewport = { height: 5, width: 40 };
+
+describe('openInExternalEditor', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    (fs.writeFileSync as Mock).mockImplementation(() => {});
+    (fs.readFileSync as Mock).mockReturnValue('edited text');
+    (fs.unlinkSync as Mock).mockImplementation(() => {});
+    mockSpawnSync.mockReturnValue({ status: 0, error: null });
+    mockGetExternalEditorCommand.mockReturnValue(null);
+  });
+
+  it('should use .txt extension for temp file', async () => {
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'hello',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    const writePath = (fs.writeFileSync as Mock).mock.calls[0]?.[0] as string;
+    expect(writePath).toMatch(/\.txt$/);
+  });
+
+  it('should write temp file with mode 0o600', async () => {
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'hello',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    const writeOpts = (fs.writeFileSync as Mock).mock.calls[0]?.[2] as {
+      mode?: number;
+    };
+    expect(writeOpts).toEqual(expect.objectContaining({ mode: 0o600 }));
+  });
+
+  it('should clean up temp file even when editor fails', async () => {
+    mockSpawnSync.mockReturnValue({ status: 1, error: null });
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'hello',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(fs.unlinkSync).toHaveBeenCalled();
+  });
+
+  it('should clean up temp file when writeFileSync throws', async () => {
+    (fs.writeFileSync as Mock).mockImplementation(() => {
+      throw new Error('disk full');
+    });
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'hello',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(fs.unlinkSync).toHaveBeenCalled();
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to env/default when no preferredEditor', async () => {
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'hello',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(mockGetExternalEditorCommand).not.toHaveBeenCalled();
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.arrayContaining([expect.stringMatching(/\.txt$/)]),
+      expect.objectContaining({ stdio: 'inherit' }),
+    );
+  });
+
+  it('should use getExternalEditorCommand when preferredEditor is set', async () => {
+    mockGetExternalEditorCommand.mockReturnValue({
+      command: 'code',
+      args: ['/tmp/qwen-edit-test-uuid-1234.txt', '--wait'],
+      isTerminal: false,
+      needsShell: false,
+    });
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'hello',
+        viewport,
+        isValidPath: () => false,
+        preferredEditor: 'vscode',
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(mockGetExternalEditorCommand).toHaveBeenCalledWith(
+      'vscode',
+      expect.stringMatching(/\.txt$/),
+    );
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'code',
+      expect.arrayContaining(['--wait']),
+      expect.objectContaining({ shell: false }),
+    );
+  });
+
+  it('should quote args when needsShell is true', async () => {
+    mockGetExternalEditorCommand.mockReturnValue({
+      command: 'code.cmd',
+      args: ['/tmp/qwen-edit-test-uuid-1234.txt', '--wait'],
+      isTerminal: false,
+      needsShell: true,
+    });
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'hello',
+        viewport,
+        isValidPath: () => false,
+        preferredEditor: 'vscode',
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    const spawnArgs = mockSpawnSync.mock.calls[0]?.[1] as string[];
+    for (const arg of spawnArgs) {
+      expect(arg).toMatch(/^".*"$/);
+    }
+    expect(mockSpawnSync.mock.calls[0]?.[2]).toEqual(
+      expect.objectContaining({ shell: true }),
+    );
+  });
+
+  it('should fall back to env/default when preferredEditor is set but not found', async () => {
+    mockGetExternalEditorCommand.mockReturnValue(null);
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'hello',
+        viewport,
+        isValidPath: () => false,
+        preferredEditor: 'vscode',
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(mockGetExternalEditorCommand).toHaveBeenCalledWith(
+      'vscode',
+      expect.stringMatching(/\.txt$/),
+    );
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.arrayContaining([expect.stringMatching(/\.txt$/)]),
+      expect.objectContaining({ stdio: 'inherit' }),
+    );
+  });
+
+  it('should clean up temp file when spawnSync returns error object', async () => {
+    mockSpawnSync.mockReturnValue({
+      status: 0,
+      error: new Error('ENOENT'),
+    });
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'hello',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(fs.unlinkSync).toHaveBeenCalled();
+    expect(result.current.text).toBe('hello');
+  });
+
+  it('should respect VISUAL > EDITOR > default fallback order', async () => {
+    const origVISUAL = process.env['VISUAL'];
+    const origEDITOR = process.env['EDITOR'];
+
+    process.env['VISUAL'] = 'my-visual-editor';
+    process.env['EDITOR'] = 'my-editor';
+    try {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'hello',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.openInExternalEditor();
+      });
+
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        'my-visual-editor',
+        expect.any(Array),
+        expect.any(Object),
+      );
+    } finally {
+      if (origVISUAL === undefined) delete process.env['VISUAL'];
+      else process.env['VISUAL'] = origVISUAL;
+      if (origEDITOR === undefined) delete process.env['EDITOR'];
+      else process.env['EDITOR'] = origEDITOR;
+    }
+  });
+
+  it('should fall back to EDITOR when VISUAL is not set', async () => {
+    const origVISUAL = process.env['VISUAL'];
+    const origEDITOR = process.env['EDITOR'];
+
+    delete process.env['VISUAL'];
+    process.env['EDITOR'] = 'my-editor';
+    try {
+      const { result } = renderHook(() =>
+        useTextBuffer({
+          initialText: 'hello',
+          viewport,
+          isValidPath: () => false,
+        }),
+      );
+
+      await act(async () => {
+        await result.current.openInExternalEditor();
+      });
+
+      expect(mockSpawnSync).toHaveBeenCalledWith(
+        'my-editor',
+        expect.any(Array),
+        expect.any(Object),
+      );
+    } finally {
+      if (origVISUAL === undefined) delete process.env['VISUAL'];
+      else process.env['VISUAL'] = origVISUAL;
+      if (origEDITOR === undefined) delete process.env['EDITOR'];
+      else process.env['EDITOR'] = origEDITOR;
+    }
+  });
+
+  it('should update text after successful editor session', async () => {
+    (fs.readFileSync as Mock).mockReturnValue('new content');
+
+    const { result } = renderHook(() =>
+      useTextBuffer({
+        initialText: 'old content',
+        viewport,
+        isValidPath: () => false,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.openInExternalEditor();
+    });
+
+    expect(result.current.text).toBe('new content');
+  });
+});

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2260,24 +2260,25 @@ export function useTextBuffer({
         editorArgs = editorArgs.map((a) => `"${a}"`);
       }
 
-      dispatch({ type: 'create_undo_snapshot' });
-
       const wasRaw = stdin?.isRaw ?? false;
       try {
         fs.writeFileSync(filePath, text, { encoding: 'utf8', mode: 0o600 });
         setRawMode?.(false);
 
-        const { status, error } = spawnSync(editorCmd, editorArgs, {
+        const { status, error, signal } = spawnSync(editorCmd, editorArgs, {
           stdio: 'inherit',
           shell: useShell,
           timeout: 30 * 60 * 1000,
         });
         if (error) throw error;
+        if (signal)
+          throw new Error(`External editor was killed by signal ${signal}`);
         if (typeof status === 'number' && status !== 0)
           throw new Error(`External editor exited with status ${status}`);
 
         let newText = fs.readFileSync(filePath, 'utf8');
         newText = newText.replace(/\r\n?/g, '\n');
+        dispatch({ type: 'create_undo_snapshot' });
         dispatch({ type: 'set_text', payload: newText, pushToUndo: false });
       } catch (err) {
         debugLogger.error('[useTextBuffer] external editor error', err);

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2250,10 +2250,11 @@ export function useTextBuffer({
       }
 
       if (useShell) {
-        // .cmd/.bat launch through cmd.exe on Windows. These args are
-        // process-generated temp-file paths, so quoting handles spaces and
-        // command separators. Do not reuse for user-controlled arguments;
-        // avoid shell execution instead of extending ad-hoc escaping.
+        // .cmd/.bat launch through cmd.exe on Windows. Quote both the
+        // command and args so paths with spaces survive cmd.exe parsing.
+        // These are process-generated paths; do not reuse for
+        // user-controlled arguments.
+        editorCmd = `"${editorCmd}"`;
         editorArgs = editorArgs.map((a) => `"${a}"`);
       }
 
@@ -2280,9 +2281,16 @@ export function useTextBuffer({
           dispatch({ type: 'set_text', payload: newText, pushToUndo: false });
         }
       } catch (err) {
-        debugLogger.error('[useTextBuffer] external editor error', err);
+        debugLogger.error(
+          `[useTextBuffer] external editor error (cmd=${editorCmd}, shell=${useShell}, source=${resolved ? 'preferred' : 'env/default'})`,
+          err,
+        );
       } finally {
-        if (wasRaw) setRawMode?.(true);
+        try {
+          if (wasRaw) setRawMode?.(true);
+        } catch {
+          /* stdin may have been destroyed while the editor was open */
+        }
         try {
           fs.unlinkSync(filePath);
           fs.rmdirSync(tmpDir);

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2217,8 +2217,18 @@ export function useTextBuffer({
 
   const openInExternalEditor = useCallback(
     async (opts: { editor?: string } = {}): Promise<void> => {
-      const tmpDir = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'qwen-edit-'));
-      const filePath = pathMod.join(tmpDir, 'buffer.txt');
+      let tmpDir: string;
+      let filePath: string;
+      try {
+        tmpDir = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'qwen-edit-'));
+        filePath = pathMod.join(tmpDir, 'buffer.txt');
+      } catch (err) {
+        debugLogger.error(
+          '[useTextBuffer] failed to create temp directory',
+          err,
+        );
+        return;
+      }
 
       let editorCmd: string;
       let editorArgs: string[];
@@ -2293,6 +2303,10 @@ export function useTextBuffer({
         }
         try {
           fs.unlinkSync(filePath);
+        } catch {
+          /* ignore */
+        }
+        try {
           fs.rmdirSync(tmpDir);
         } catch {
           /* ignore */

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2241,7 +2241,7 @@ export function useTextBuffer({
         editorArgs = [filePath];
         editorSource = 'opts';
         if (process.platform === 'win32' && /\.(cmd|bat)$/i.test(editorCmd)) {
-          if (/["|]/.test(editorCmd)) {
+          if (/["|%!]/.test(editorCmd)) {
             debugLogger.error(
               `[useTextBuffer] opts.editor command contains unsafe characters: ${editorCmd}`,
             );
@@ -2276,7 +2276,7 @@ export function useTextBuffer({
             (process.platform === 'win32' ? 'notepad' : 'vi');
           editorArgs = [filePath];
           if (process.platform === 'win32' && /\.(cmd|bat)$/i.test(editorCmd)) {
-            if (/["|]/.test(editorCmd)) {
+            if (/["|%!]/.test(editorCmd)) {
               debugLogger.error(
                 `[useTextBuffer] Editor command from environment contains unsafe characters: ${editorCmd}`,
               );

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2233,29 +2233,40 @@ export function useTextBuffer({
       let editorCmd: string;
       let editorArgs: string[];
       let useShell = false;
+      let editorSource: 'opts' | 'preferred' | 'env/default' = 'env/default';
 
-      const resolved = preferredEditor
-        ? getExternalEditorCommand(preferredEditor, filePath)
-        : null;
-
-      if (resolved) {
-        editorCmd = resolved.command;
-        editorArgs = resolved.args;
-        useShell = resolved.needsShell;
-      } else {
-        if (preferredEditor) {
-          debugLogger.warn(
-            `[useTextBuffer] preferred editor "${preferredEditor}" not found, falling back to env/default`,
-          );
-        }
-        editorCmd =
-          opts.editor ??
-          process.env['VISUAL'] ??
-          process.env['EDITOR'] ??
-          (process.platform === 'win32' ? 'notepad' : 'vi');
+      if (opts.editor) {
+        // Explicit programmatic override takes highest priority
+        editorCmd = opts.editor;
         editorArgs = [filePath];
+        editorSource = 'opts';
         if (process.platform === 'win32' && /\.(cmd|bat)$/i.test(editorCmd)) {
           useShell = true;
+        }
+      } else {
+        const resolved = preferredEditor
+          ? getExternalEditorCommand(preferredEditor, filePath)
+          : null;
+
+        if (resolved) {
+          editorCmd = resolved.command;
+          editorArgs = resolved.args;
+          useShell = resolved.needsShell;
+          editorSource = 'preferred';
+        } else {
+          if (preferredEditor) {
+            debugLogger.warn(
+              `[useTextBuffer] preferred editor "${preferredEditor}" not found, falling back to env/default`,
+            );
+          }
+          editorCmd =
+            process.env['VISUAL'] ??
+            process.env['EDITOR'] ??
+            (process.platform === 'win32' ? 'notepad' : 'vi');
+          editorArgs = [filePath];
+          if (process.platform === 'win32' && /\.(cmd|bat)$/i.test(editorCmd)) {
+            useShell = true;
+          }
         }
       }
 
@@ -2292,7 +2303,7 @@ export function useTextBuffer({
         }
       } catch (err) {
         debugLogger.error(
-          `[useTextBuffer] external editor error (cmd=${editorCmd}, shell=${useShell}, source=${resolved ? 'preferred' : 'env/default'})`,
+          `[useTextBuffer] external editor error (cmd=${editorCmd}, shell=${useShell}, source=${editorSource}, file=${filePath})`,
           err,
         );
       } finally {

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2644,20 +2644,14 @@ export interface TextBuffer {
     sequence: string;
   }) => void;
   /**
-   * Opens the current buffer contents in the user's preferred terminal text
-   * editor ($VISUAL or $EDITOR, falling back to "vi").  The method blocks
-   * until the editor exits, then reloads the file and replaces the in‑memory
-   * buffer with whatever the user saved.
+   * Opens the current buffer contents in an external editor.  Resolution
+   * order: `/editor` preference → `$VISUAL` → `$EDITOR` → `vi`.
    *
-   * The operation is treated as a single undoable edit – we snapshot the
-   * previous state *once* after reading back the edited file so one `undo()`
-   * will revert the entire change set.  No snapshot is created when the
-   * editor fails or the content is unchanged.
+   * The undo snapshot is created *after* the editor exits and only when
+   * the content actually changed, so one `undo()` reverts the entire edit.
    *
-   * Note: We purposefully rely on the *synchronous* spawn API so that the
-   * calling process genuinely waits for the editor to close before
-   * continuing.  This mirrors Git's behaviour and simplifies downstream
-   * control‑flow (callers can simply `await` the Promise).
+   * Uses the synchronous spawn API so the calling process blocks until the
+   * editor closes, mirroring Git's behaviour.
    */
   openInExternalEditor: (opts?: { editor?: string }) => Promise<void>;
 

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -5,11 +5,17 @@
  */
 
 import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import pathMod from 'node:path';
 import { useState, useCallback, useEffect, useMemo, useReducer } from 'react';
-import { createDebugLogger, unescapePath } from '@qwen-code/qwen-code-core';
+import {
+  createDebugLogger,
+  unescapePath,
+  getExternalEditorCommand,
+  type EditorType,
+} from '@qwen-code/qwen-code-core';
 import {
   toCodePoints,
   cpLen,
@@ -804,6 +810,7 @@ interface UseTextBufferProps {
   onChange?: (text: string) => void; // Callback for when text changes
   isValidPath: (path: string) => boolean;
   shellModeActive?: boolean; // Whether the text buffer is in shell mode
+  preferredEditor?: EditorType;
 }
 
 interface UndoHistoryEntry {
@@ -1902,6 +1909,7 @@ export function useTextBuffer({
   onChange,
   isValidPath,
   shellModeActive = false,
+  preferredEditor,
 }: UseTextBufferProps): TextBuffer {
   const initialState = useMemo((): TextBufferState => {
     const lines = initialText.split('\n');
@@ -2210,22 +2218,47 @@ export function useTextBuffer({
 
   const openInExternalEditor = useCallback(
     async (opts: { editor?: string } = {}): Promise<void> => {
-      const editor =
-        opts.editor ??
-        process.env['VISUAL'] ??
-        process.env['EDITOR'] ??
-        (process.platform === 'win32' ? 'notepad' : 'vi');
-      const tmpDir = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'qwen-edit-'));
-      const filePath = pathMod.join(tmpDir, 'buffer.txt');
+      const filePath = pathMod.join(
+        os.tmpdir(),
+        `qwen-edit-${crypto.randomUUID()}.md`,
+      );
       fs.writeFileSync(filePath, text, 'utf8');
+
+      let editorCmd: string;
+      let editorArgs: string[];
+      let useShell = false;
+
+      const resolved = preferredEditor
+        ? getExternalEditorCommand(preferredEditor, filePath)
+        : null;
+
+      if (resolved) {
+        editorCmd = resolved.command;
+        editorArgs = resolved.args;
+        useShell = resolved.needsShell;
+      } else {
+        if (preferredEditor) {
+          debugLogger.warn(
+            `[useTextBuffer] preferred editor "${preferredEditor}" not found, falling back to env/default`,
+          );
+        }
+        editorCmd =
+          opts.editor ??
+          process.env['VISUAL'] ??
+          process.env['EDITOR'] ??
+          (process.platform === 'win32' ? 'notepad' : 'vi');
+        editorArgs = [filePath];
+      }
 
       dispatch({ type: 'create_undo_snapshot' });
 
       const wasRaw = stdin?.isRaw ?? false;
       try {
         setRawMode?.(false);
-        const { status, error } = spawnSync(editor, [filePath], {
+
+        const { status, error } = spawnSync(editorCmd, editorArgs, {
           stdio: 'inherit',
+          shell: useShell,
         });
         if (error) throw error;
         if (typeof status === 'number' && status !== 0)
@@ -2243,14 +2276,9 @@ export function useTextBuffer({
         } catch {
           /* ignore */
         }
-        try {
-          fs.rmdirSync(tmpDir);
-        } catch {
-          /* ignore */
-        }
       }
     },
-    [text, stdin, setRawMode],
+    [text, stdin, setRawMode, preferredEditor],
   );
 
   const handleInput = useCallback(

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2241,6 +2241,17 @@ export function useTextBuffer({
         editorArgs = [filePath];
         editorSource = 'opts';
         if (process.platform === 'win32' && /\.(cmd|bat)$/i.test(editorCmd)) {
+          if (/["|]/.test(editorCmd)) {
+            debugLogger.error(
+              `[useTextBuffer] opts.editor command contains unsafe characters: ${editorCmd}`,
+            );
+            try {
+              fs.rmdirSync(tmpDir);
+            } catch {
+              /* ignore */
+            }
+            return;
+          }
           useShell = true;
         }
       } else {
@@ -2266,9 +2277,15 @@ export function useTextBuffer({
           editorArgs = [filePath];
           if (process.platform === 'win32' && /\.(cmd|bat)$/i.test(editorCmd)) {
             if (/["|]/.test(editorCmd)) {
-              throw new Error(
-                `Editor command from environment contains unsafe characters: ${editorCmd}`,
+              debugLogger.error(
+                `[useTextBuffer] Editor command from environment contains unsafe characters: ${editorCmd}`,
               );
+              try {
+                fs.rmdirSync(tmpDir);
+              } catch {
+                /* ignore */
+              }
+              return;
             }
             useShell = true;
           }
@@ -2289,6 +2306,9 @@ export function useTextBuffer({
         fs.writeFileSync(filePath, text, { encoding: 'utf8', mode: 0o600 });
         setRawMode?.(false);
 
+        debugLogger.warn(
+          `[useTextBuffer] launching external editor (cmd=${editorCmd}, shell=${useShell}, source=${editorSource}, file=${filePath})`,
+        );
         const { status, error, signal } = spawnSync(editorCmd, editorArgs, {
           stdio: 'inherit',
           shell: useShell,
@@ -2314,8 +2334,11 @@ export function useTextBuffer({
       } finally {
         try {
           if (wasRaw) setRawMode?.(true);
-        } catch {
-          /* stdin may have been destroyed while the editor was open */
+        } catch (rawErr) {
+          debugLogger.error(
+            '[useTextBuffer] failed to restore raw mode after external editor',
+            rawErr,
+          );
         }
         try {
           fs.unlinkSync(filePath);

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2246,7 +2246,7 @@ export function useTextBuffer({
               `[useTextBuffer] opts.editor command contains unsafe characters: ${editorCmd}`,
             );
             try {
-              fs.rmdirSync(tmpDir);
+              fs.rmSync(tmpDir, { recursive: true, force: true });
             } catch {
               /* ignore */
             }
@@ -2281,7 +2281,7 @@ export function useTextBuffer({
                 `[useTextBuffer] Editor command from environment contains unsafe characters: ${editorCmd}`,
               );
               try {
-                fs.rmdirSync(tmpDir);
+                fs.rmSync(tmpDir, { recursive: true, force: true });
               } catch {
                 /* ignore */
               }
@@ -2341,14 +2341,12 @@ export function useTextBuffer({
           );
         }
         try {
-          fs.unlinkSync(filePath);
+          // recursive+force handles leftover swap files (.swp) from vim/neovim.
+          // On Windows, EPERM/EBUSY from locked files may still cause a partial
+          // delete — the catch below keeps it non-fatal.
+          fs.rmSync(tmpDir, { recursive: true, force: true });
         } catch {
-          /* ignore */
-        }
-        try {
-          fs.rmdirSync(tmpDir);
-        } catch {
-          /* ignore */
+          /* best-effort cleanup */
         }
       }
     },
@@ -2698,7 +2696,7 @@ export interface TextBuffer {
   }) => void;
   /**
    * Opens the current buffer contents in an external editor.  Resolution
-   * order: `/editor` preference → `$VISUAL` → `$EDITOR` → `vi`.
+   * order: `/editor` preference → `$VISUAL` → `$EDITOR` → platform default (`vi` on Unix, `notepad` on Windows).
    *
    * The undo snapshot is created *after* the editor exits and only when
    * the content actually changed, so one `undo()` reverts the entire edit.

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -5,7 +5,6 @@
  */
 
 import { spawnSync } from 'node:child_process';
-import crypto from 'node:crypto';
 import fs from 'node:fs';
 import os from 'node:os';
 import pathMod from 'node:path';
@@ -2218,10 +2217,8 @@ export function useTextBuffer({
 
   const openInExternalEditor = useCallback(
     async (opts: { editor?: string } = {}): Promise<void> => {
-      const filePath = pathMod.join(
-        os.tmpdir(),
-        `qwen-edit-${crypto.randomUUID()}.txt`,
-      );
+      const tmpDir = fs.mkdtempSync(pathMod.join(os.tmpdir(), 'qwen-edit-'));
+      const filePath = pathMod.join(tmpDir, 'buffer.txt');
 
       let editorCmd: string;
       let editorArgs: string[];
@@ -2278,14 +2275,17 @@ export function useTextBuffer({
 
         let newText = fs.readFileSync(filePath, 'utf8');
         newText = newText.replace(/\r\n?/g, '\n');
-        dispatch({ type: 'create_undo_snapshot' });
-        dispatch({ type: 'set_text', payload: newText, pushToUndo: false });
+        if (newText !== text) {
+          dispatch({ type: 'create_undo_snapshot' });
+          dispatch({ type: 'set_text', payload: newText, pushToUndo: false });
+        }
       } catch (err) {
         debugLogger.error('[useTextBuffer] external editor error', err);
       } finally {
         if (wasRaw) setRawMode?.(true);
         try {
           fs.unlinkSync(filePath);
+          fs.rmdirSync(tmpDir);
         } catch {
           /* ignore */
         }
@@ -2642,8 +2642,9 @@ export interface TextBuffer {
    * buffer with whatever the user saved.
    *
    * The operation is treated as a single undoable edit – we snapshot the
-   * previous state *once* before launching the editor so one `undo()` will
-   * revert the entire change set.
+   * previous state *once* after reading back the edited file so one `undo()`
+   * will revert the entire change set.  No snapshot is created when the
+   * editor fails or the content is unchanged.
    *
    * Note: We purposefully rely on the *synchronous* spawn API so that the
    * calling process genuinely waits for the editor to close before

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2247,6 +2247,9 @@ export function useTextBuffer({
           process.env['EDITOR'] ??
           (process.platform === 'win32' ? 'notepad' : 'vi');
         editorArgs = [filePath];
+        if (process.platform === 'win32' && /\.(cmd|bat)$/i.test(editorCmd)) {
+          useShell = true;
+        }
       }
 
       if (useShell) {
@@ -2263,6 +2266,7 @@ export function useTextBuffer({
         const { status, error } = spawnSync(editorCmd, editorArgs, {
           stdio: 'inherit',
           shell: useShell,
+          timeout: 30 * 60 * 1000,
         });
         if (error) throw error;
         if (typeof status === 'number' && status !== 0)

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2253,6 +2253,10 @@ export function useTextBuffer({
       }
 
       if (useShell) {
+        // .cmd/.bat launch through cmd.exe on Windows. These args are
+        // process-generated temp-file paths, so quoting handles spaces and
+        // command separators. Do not reuse for user-controlled arguments;
+        // avoid shell execution instead of extending ad-hoc escaping.
         editorArgs = editorArgs.map((a) => `"${a}"`);
       }
 

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2265,6 +2265,11 @@ export function useTextBuffer({
             (process.platform === 'win32' ? 'notepad' : 'vi');
           editorArgs = [filePath];
           if (process.platform === 'win32' && /\.(cmd|bat)$/i.test(editorCmd)) {
+            if (/["|]/.test(editorCmd)) {
+              throw new Error(
+                `Editor command from environment contains unsafe characters: ${editorCmd}`,
+              );
+            }
             useShell = true;
           }
         }

--- a/packages/cli/src/ui/components/shared/text-buffer.ts
+++ b/packages/cli/src/ui/components/shared/text-buffer.ts
@@ -2220,9 +2220,8 @@ export function useTextBuffer({
     async (opts: { editor?: string } = {}): Promise<void> => {
       const filePath = pathMod.join(
         os.tmpdir(),
-        `qwen-edit-${crypto.randomUUID()}.md`,
+        `qwen-edit-${crypto.randomUUID()}.txt`,
       );
-      fs.writeFileSync(filePath, text, 'utf8');
 
       let editorCmd: string;
       let editorArgs: string[];
@@ -2250,10 +2249,15 @@ export function useTextBuffer({
         editorArgs = [filePath];
       }
 
+      if (useShell) {
+        editorArgs = editorArgs.map((a) => `"${a}"`);
+      }
+
       dispatch({ type: 'create_undo_snapshot' });
 
       const wasRaw = stdin?.isRaw ?? false;
       try {
+        fs.writeFileSync(filePath, text, { encoding: 'utf8', mode: 0o600 });
         setRawMode?.(false);
 
         const { status, error } = spawnSync(editorCmd, editorArgs, {

--- a/packages/cli/src/ui/hooks/usePreferredEditor.ts
+++ b/packages/cli/src/ui/hooks/usePreferredEditor.ts
@@ -5,13 +5,25 @@
  */
 
 import { useMemo } from 'react';
-import { type EditorType, isValidEditorType } from '@qwen-code/qwen-code-core';
+import {
+  type EditorType,
+  isValidEditorType,
+  createDebugLogger,
+} from '@qwen-code/qwen-code-core';
 import { useSettings } from '../contexts/SettingsContext.js';
+
+const debugLogger = createDebugLogger('PREFERRED_EDITOR');
 
 export function usePreferredEditor(): EditorType | undefined {
   const settings = useSettings();
   return useMemo(() => {
     const raw = settings.merged.general?.preferredEditor ?? '';
+    if (raw && !isValidEditorType(raw)) {
+      debugLogger.warn(
+        `[usePreferredEditor] invalid preferredEditor value "${raw}", ignoring`,
+      );
+      return undefined;
+    }
     return isValidEditorType(raw) ? raw : undefined;
   }, [settings.merged.general?.preferredEditor]);
 }

--- a/packages/cli/src/ui/hooks/usePreferredEditor.ts
+++ b/packages/cli/src/ui/hooks/usePreferredEditor.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useMemo } from 'react';
+import { type EditorType, isValidEditorType } from '@qwen-code/qwen-code-core';
+import { useSettings } from '../contexts/SettingsContext.js';
+
+export function usePreferredEditor(): EditorType | undefined {
+  const settings = useSettings();
+  return useMemo(() => {
+    const raw = settings.merged.general?.preferredEditor ?? '';
+    return isValidEditorType(raw) ? raw : undefined;
+  }, [settings.merged.general?.preferredEditor]);
+}

--- a/packages/cli/src/ui/hooks/usePreferredEditor.ts
+++ b/packages/cli/src/ui/hooks/usePreferredEditor.ts
@@ -8,6 +8,7 @@ import { useMemo } from 'react';
 import {
   type EditorType,
   isValidEditorType,
+  allowEditorTypeInSandbox,
   createDebugLogger,
 } from '@qwen-code/qwen-code-core';
 import { useSettings } from '../contexts/SettingsContext.js';
@@ -21,6 +22,12 @@ export function usePreferredEditor(): EditorType | undefined {
     if (raw && !isValidEditorType(raw)) {
       debugLogger.warn(
         `[usePreferredEditor] invalid preferredEditor value "${raw}", ignoring`,
+      );
+      return undefined;
+    }
+    if (isValidEditorType(raw) && !allowEditorTypeInSandbox(raw)) {
+      debugLogger.warn(
+        `[usePreferredEditor] editor "${raw}" is not allowed in sandbox mode, ignoring`,
       );
       return undefined;
     }

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -810,7 +810,6 @@ describe('editor utils', () => {
       expect(result).not.toBeNull();
       expect(result!.command).toBe('code');
       expect(result!.args).toEqual(['/tmp/file.txt', '--wait']);
-      expect(result!.isTerminal).toBe(false);
     });
 
     it('should return --wait flag for vscodium', () => {
@@ -820,7 +819,6 @@ describe('editor utils', () => {
       expect(result).not.toBeNull();
       expect(result!.command).toBe('codium');
       expect(result!.args).toEqual(['/tmp/file.txt', '--wait']);
-      expect(result!.isTerminal).toBe(false);
     });
 
     it('should return --wait flag for windsurf', () => {
@@ -830,7 +828,6 @@ describe('editor utils', () => {
       expect(result).not.toBeNull();
       expect(result!.command).toBe('windsurf');
       expect(result!.args).toEqual(['/tmp/file.txt', '--wait']);
-      expect(result!.isTerminal).toBe(false);
     });
 
     it('should return --wait flag for cursor', () => {
@@ -839,7 +836,6 @@ describe('editor utils', () => {
       const result = getExternalEditorCommand('cursor', '/tmp/file.txt');
       expect(result).not.toBeNull();
       expect(result!.args).toEqual(['/tmp/file.txt', '--wait']);
-      expect(result!.isTerminal).toBe(false);
     });
 
     it('should return --wait flag for trae', () => {
@@ -849,7 +845,6 @@ describe('editor utils', () => {
       expect(result).not.toBeNull();
       expect(result!.command).toBe('trae');
       expect(result!.args).toEqual(['/tmp/file.txt', '--wait']);
-      expect(result!.isTerminal).toBe(false);
     });
 
     it('should return --wait flag for zed', () => {
@@ -858,7 +853,6 @@ describe('editor utils', () => {
       const result = getExternalEditorCommand('zed', '/tmp/file.txt');
       expect(result).not.toBeNull();
       expect(result!.args).toEqual(['/tmp/file.txt', '--wait']);
-      expect(result!.isTerminal).toBe(false);
     });
 
     it('should return plain args for vim (terminal editor)', () => {
@@ -868,7 +862,6 @@ describe('editor utils', () => {
       expect(result).not.toBeNull();
       expect(result!.command).toBe('vim');
       expect(result!.args).toEqual(['/tmp/file.txt']);
-      expect(result!.isTerminal).toBe(true);
     });
 
     it('should return plain args for neovim (terminal editor)', () => {
@@ -878,7 +871,6 @@ describe('editor utils', () => {
       expect(result).not.toBeNull();
       expect(result!.command).toBe('nvim');
       expect(result!.args).toEqual(['/tmp/file.txt']);
-      expect(result!.isTerminal).toBe(true);
     });
 
     it('should return plain args for emacs (terminal editor)', () => {
@@ -888,7 +880,6 @@ describe('editor utils', () => {
       expect(result).not.toBeNull();
       expect(result!.command).toBe('emacs');
       expect(result!.args).toEqual(['/tmp/file.txt']);
-      expect(result!.isTerminal).toBe(true);
     });
 
     it('should set needsShell=true for .cmd executables on Windows', () => {

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -19,6 +19,8 @@ import {
   openDiff,
   allowEditorTypeInSandbox,
   isEditorAvailable,
+  isTerminalEditor,
+  getExternalEditorCommand,
   type EditorType,
 } from './editor.js';
 import { execSync, spawn, spawnSync } from 'node:child_process';
@@ -771,6 +773,154 @@ describe('editor utils', () => {
         expect(diffCommand).not.toBeNull();
         expect(diffCommand!.command).toMatch(/MacOS[/\\]cli$/);
       });
+    });
+  });
+
+  describe('isTerminalEditor', () => {
+    it('should return true for terminal editors', () => {
+      expect(isTerminalEditor('vim')).toBe(true);
+      expect(isTerminalEditor('neovim')).toBe(true);
+      expect(isTerminalEditor('emacs')).toBe(true);
+    });
+
+    it('should return false for GUI editors', () => {
+      expect(isTerminalEditor('vscode')).toBe(false);
+      expect(isTerminalEditor('vscodium')).toBe(false);
+      expect(isTerminalEditor('windsurf')).toBe(false);
+      expect(isTerminalEditor('cursor')).toBe(false);
+      expect(isTerminalEditor('zed')).toBe(false);
+      expect(isTerminalEditor('trae')).toBe(false);
+    });
+  });
+
+  describe('getExternalEditorCommand', () => {
+    it('should return null when editor executable is not found', () => {
+      (execSync as Mock).mockImplementation(() => {
+        throw new Error('not found');
+      });
+      (existsSync as unknown as Mock).mockReturnValue(false);
+      const result = getExternalEditorCommand('vscode', '/tmp/file.txt');
+      expect(result).toBeNull();
+    });
+
+    it('should return --wait flag for vscode', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/code'));
+      const result = getExternalEditorCommand('vscode', '/tmp/file.txt');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('code');
+      expect(result!.args).toEqual(['/tmp/file.txt', '--wait']);
+      expect(result!.isTerminal).toBe(false);
+    });
+
+    it('should return --wait flag for vscodium', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/codium'));
+      const result = getExternalEditorCommand('vscodium', '/tmp/file.txt');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('codium');
+      expect(result!.args).toEqual(['/tmp/file.txt', '--wait']);
+      expect(result!.isTerminal).toBe(false);
+    });
+
+    it('should return --wait flag for windsurf', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/windsurf'));
+      const result = getExternalEditorCommand('windsurf', '/tmp/file.txt');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('windsurf');
+      expect(result!.args).toEqual(['/tmp/file.txt', '--wait']);
+      expect(result!.isTerminal).toBe(false);
+    });
+
+    it('should return --wait flag for cursor', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/cursor'));
+      const result = getExternalEditorCommand('cursor', '/tmp/file.txt');
+      expect(result).not.toBeNull();
+      expect(result!.args).toEqual(['/tmp/file.txt', '--wait']);
+      expect(result!.isTerminal).toBe(false);
+    });
+
+    it('should return --wait flag for trae', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/trae'));
+      const result = getExternalEditorCommand('trae', '/tmp/file.txt');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('trae');
+      expect(result!.args).toEqual(['/tmp/file.txt', '--wait']);
+      expect(result!.isTerminal).toBe(false);
+    });
+
+    it('should return --wait flag for zed', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/zed'));
+      const result = getExternalEditorCommand('zed', '/tmp/file.txt');
+      expect(result).not.toBeNull();
+      expect(result!.args).toEqual(['/tmp/file.txt', '--wait']);
+      expect(result!.isTerminal).toBe(false);
+    });
+
+    it('should return plain args for vim (terminal editor)', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/vim'));
+      const result = getExternalEditorCommand('vim', '/tmp/file.txt');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('vim');
+      expect(result!.args).toEqual(['/tmp/file.txt']);
+      expect(result!.isTerminal).toBe(true);
+    });
+
+    it('should return plain args for neovim (terminal editor)', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/nvim'));
+      const result = getExternalEditorCommand('neovim', '/tmp/file.txt');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('nvim');
+      expect(result!.args).toEqual(['/tmp/file.txt']);
+      expect(result!.isTerminal).toBe(true);
+    });
+
+    it('should return plain args for emacs (terminal editor)', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/emacs'));
+      const result = getExternalEditorCommand('emacs', '/tmp/file.txt');
+      expect(result).not.toBeNull();
+      expect(result!.command).toBe('emacs');
+      expect(result!.args).toEqual(['/tmp/file.txt']);
+      expect(result!.isTerminal).toBe(true);
+    });
+
+    it('should set needsShell=true for .cmd executables on Windows', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      (execSync as Mock).mockReturnValue(Buffer.from('C:\\code.cmd'));
+      const result = getExternalEditorCommand('vscode', '/tmp/file.txt');
+      expect(result).not.toBeNull();
+      expect(result!.needsShell).toBe(true);
+    });
+
+    it('should set needsShell=false for non-.cmd executables on Windows', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      (execSync as Mock).mockReturnValue(Buffer.from('C:\\cursor'));
+      const result = getExternalEditorCommand('cursor', '/tmp/file.txt');
+      expect(result).not.toBeNull();
+      expect(result!.needsShell).toBe(false);
+    });
+
+    it('should set needsShell=false on non-Windows', () => {
+      Object.defineProperty(process, 'platform', { value: 'linux' });
+      (execSync as Mock).mockReturnValue(Buffer.from('/usr/bin/code'));
+      const result = getExternalEditorCommand('vscode', '/tmp/file.txt');
+      expect(result).not.toBeNull();
+      expect(result!.needsShell).toBe(false);
+    });
+
+    it('should return null for invalid editor type', () => {
+      const result = getExternalEditorCommand(
+        'nano' as EditorType,
+        '/tmp/file.txt',
+      );
+      expect(result).toBeNull();
     });
   });
 });

--- a/packages/core/src/utils/editor.test.ts
+++ b/packages/core/src/utils/editor.test.ts
@@ -899,6 +899,14 @@ describe('editor utils', () => {
       expect(result!.needsShell).toBe(true);
     });
 
+    it('should set needsShell=true for .bat executables on Windows', () => {
+      Object.defineProperty(process, 'platform', { value: 'win32' });
+      (execSync as Mock).mockReturnValue(Buffer.from('C:\\code.bat'));
+      const result = getExternalEditorCommand('vscode', '/tmp/file.txt');
+      expect(result).not.toBeNull();
+      expect(result!.needsShell).toBe(true);
+    });
+
     it('should set needsShell=false for non-.cmd executables on Windows', () => {
       Object.defineProperty(process, 'platform', { value: 'win32' });
       (execSync as Mock).mockReturnValue(Buffer.from('C:\\cursor'));

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -23,7 +23,7 @@ export type EditorType =
   | 'emacs'
   | 'trae';
 
-function isValidEditorType(editor: string): editor is EditorType {
+export function isValidEditorType(editor: string): editor is EditorType {
   return [
     'vscode',
     'vscodium',
@@ -137,6 +137,66 @@ export function getEditorExecutable(editorType: EditorType): string | null {
 
   // No command found
   return null;
+}
+
+export function isTerminalEditor(editor: EditorType): boolean {
+  return ['vim', 'neovim', 'emacs'].includes(editor);
+}
+
+export interface ExternalEditorCommand {
+  command: string;
+  args: string[];
+  isTerminal: boolean;
+  needsShell: boolean;
+}
+
+/**
+ * Get the command + args to open a single file in an editor for editing.
+ * GUI editors get a `--wait` flag so the calling process blocks until close.
+ * Returns null if the editor type is invalid or the executable is not found.
+ */
+export function getExternalEditorCommand(
+  editorType: EditorType,
+  filePath: string,
+): ExternalEditorCommand | null {
+  if (!isValidEditorType(editorType)) {
+    return null;
+  }
+
+  const executable = getEditorExecutable(editorType);
+  if (!executable) {
+    return null;
+  }
+
+  const needsShell =
+    process.platform === 'win32' && executable.endsWith('.cmd');
+
+  switch (editorType) {
+    case 'vim':
+    case 'neovim':
+    case 'emacs':
+      return {
+        command: executable,
+        args: [filePath],
+        isTerminal: true,
+        needsShell,
+      };
+    case 'vscode':
+    case 'vscodium':
+    case 'windsurf':
+    case 'cursor':
+    case 'trae':
+    case 'zed': {
+      return {
+        command: executable,
+        args: [filePath, '--wait'],
+        isTerminal: false,
+        needsShell,
+      };
+    }
+    default:
+      return null;
+  }
 }
 
 export function checkHasEditorType(editor: EditorType): boolean {
@@ -259,9 +319,7 @@ export async function openDiff(
   }
 
   try {
-    const isTerminalEditor = ['vim', 'emacs', 'neovim'].includes(editor);
-
-    if (isTerminalEditor) {
+    if (isTerminalEditor(editor)) {
       try {
         const result = spawnSync(diffCommand.command, diffCommand.args, {
           stdio: 'inherit',

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -169,7 +169,7 @@ export function getExternalEditorCommand(
   }
 
   const needsShell =
-    process.platform === 'win32' && executable.endsWith('.cmd');
+    process.platform === 'win32' && /\.(cmd|bat)$/i.test(executable);
 
   switch (editorType) {
     case 'vim':

--- a/packages/core/src/utils/editor.ts
+++ b/packages/core/src/utils/editor.ts
@@ -146,7 +146,6 @@ export function isTerminalEditor(editor: EditorType): boolean {
 export interface ExternalEditorCommand {
   command: string;
   args: string[];
-  isTerminal: boolean;
   needsShell: boolean;
 }
 
@@ -178,7 +177,6 @@ export function getExternalEditorCommand(
       return {
         command: executable,
         args: [filePath],
-        isTerminal: true,
         needsShell,
       };
     case 'vscode':
@@ -190,7 +188,6 @@ export function getExternalEditorCommand(
       return {
         command: executable,
         args: [filePath, '--wait'],
-        isTerminal: false,
         needsShell,
       };
     }


### PR DESCRIPTION
## Summary

Closes #4165

`Ctrl+X` in the prompt input now opens the external editor configured via `/editor` (the `general.preferredEditor` setting) instead of always falling back to `$VISUAL` / `$EDITOR` / platform default.

### Changes

- **`packages/core/src/utils/editor.ts`** — Added `getExternalEditorCommand()` returning `{ command, args, needsShell }` for any `EditorType`. GUI editors (`vscode`, `vscodium`, `windsurf`, `cursor`, `trae`, `zed`) get `--wait`; terminal editors (`vim`, `neovim`, `emacs`) get raw `[filePath]`. Also exported `isValidEditorType()` type guard.
- **`packages/core/src/utils/editor.test.ts`** — Unit tests for `getExternalEditorCommand`.
- **`packages/cli/src/ui/hooks/usePreferredEditor.ts`** — New hook extracting `/editor` preference with `isValidEditorType` validation and sandbox availability check.
- **`packages/cli/src/ui/components/shared/text-buffer.ts`** — `openInExternalEditor` reads `preferredEditor` prop, resolves via `getExternalEditorCommand()`, falls back to `$VISUAL`/`$EDITOR`/platform default when unset or unavailable. Temp file uses `mkdtempSync` for isolation + `buffer.txt` with `0o600` permissions. Includes signal detection, 30-minute timeout, and conditional undo snapshot (only after successful edit with changed content).
- **`packages/cli/src/ui/components/shared/TextInput.tsx`** — Passes `preferredEditor`, `stdin`, and `setRawMode` to `useTextBuffer` for terminal editor support.
- **`packages/cli/src/ui/AppContainer.tsx`** / **`AgentComposer.tsx`** — Use `usePreferredEditor()` hook (no duplicated validation logic).

## Evidence

### Demo Case 1 — Default editor (no `/editor` configured)

Press `Ctrl+X` without configuring `/editor`. The default editor opens: **`vi` on Unix/macOS**, **`notepad` on Windows** (matching `$VISUAL` → `$EDITOR` → platform default fallback chain). Edit, save, and close — content appears in the prompt input.


https://github.com/user-attachments/assets/7c188042-cc0a-4723-9153-3b4c2ee4b690



### Demo Case 2 — Preferred editor (VS Code via `/editor`)

Run `/editor` and select `vscode`. Press `Ctrl+X` — VS Code opens with `--wait` flag. Edit, save, and close the VS Code tab — content appears in the prompt input.


https://github.com/user-attachments/assets/b47b2176-c1fb-4aac-ac6e-b72a67fe1ce9



## Linked Issues

Closes #4165

## Test Plan

- [x] Unit tests for `getExternalEditorCommand`
- [x] 24 external editor tests in `text-buffer-external-editor.test.ts`
- [x] Full test suite passes
- [x] Manual test: default editor (vi) opens and returns content
- [x] Manual test: VS Code opens with `--wait` and returns content