### PR TITLE
fix(serve): post-PR-17 Codex P2 fold-ins (against daemon_mode_b_main)

### DIFF
--- a/packages/acp-bridge/src/bridgeErrors.ts
+++ b/packages/acp-bridge/src/bridgeErrors.ts
@@ -194,6 +194,50 @@ export class WorkspaceInitConflictError extends Error {
 }
 
 /**
+ * #4297 fold-in 1 (16:32:44-round S1). Thrown by `initWorkspace` when
+ * the configured `context.fileName` resolves outside the bound
+ * workspace via path arithmetic (e.g. `../outside.md`). Translated
+ * to HTTP 400 by the route — distinguishable from a generic 500 so
+ * an operator sees "your workspace config is wrong" rather than
+ * "the daemon is broken." The `filename` and `boundWorkspace`
+ * fields let clients display a precise diagnostic.
+ */
+export class WorkspaceInitPathEscapeError extends Error {
+  readonly filename: string;
+  readonly boundWorkspace: string;
+  constructor(filename: string, boundWorkspace: string) {
+    super(
+      `Configured workspace context filename ${JSON.stringify(filename)} ` +
+        `resolves outside the bound workspace ${JSON.stringify(boundWorkspace)}. ` +
+        `Refusing to write.`,
+    );
+    this.name = 'WorkspaceInitPathEscapeError';
+    this.filename = filename;
+    this.boundWorkspace = boundWorkspace;
+  }
+}
+
+/**
+ * #4297 fold-in 1 (16:32:44-round S1). Thrown by `initWorkspace` when
+ * the target file is itself a symlink, OR when the parent path
+ * canonicalizes (via `realpath`) outside the bound workspace.
+ * Translated to HTTP 400 by the route — same operator-clarity
+ * rationale as `WorkspaceInitPathEscapeError`. `target` is the
+ * resolved path the bridge attempted, `kind` distinguishes the two
+ * symlink scenarios for diagnostics.
+ */
+export class WorkspaceInitSymlinkError extends Error {
+  readonly target: string;
+  readonly kind: 'target' | 'parent';
+  constructor(target: string, kind: 'target' | 'parent', detail: string) {
+    super(detail);
+    this.name = 'WorkspaceInitSymlinkError';
+    this.target = target;
+    this.kind = kind;
+  }
+}
+
+/**
  * #4282 fold-in 1 (gpt-5.5 C5). Thrown by `restartMcpServer` when the
  * caller asks for a server name that isn't in the daemon's
  * `McpServers` config. Translated to HTTP 404 + structured body by

--- a/packages/acp-bridge/src/bridgeOptions.ts
+++ b/packages/acp-bridge/src/bridgeOptions.ts
@@ -217,6 +217,18 @@ export interface BridgeOptions {
     enabled: boolean,
   ) => Promise<void>;
   /**
+   * #4282 fold-in 5 (Codex P2-1). Optional override for the basename
+   * (or single relative path) of the workspace context file written
+   * by `POST /workspace/init`. When omitted, falls back to
+   * `getCurrentGeminiMdFilename()` — the process-global value, which
+   * the daemon parent never updates because it doesn't go through
+   * `loadCliConfig`. Production callers (`runQwenServe`) snapshot the
+   * resolved filename from the workspace's merged settings at boot
+   * and pass it here so init writes the same file the ACP child
+   * reads. Bridge tests can pass any literal.
+   */
+  contextFilename?: string;
+  /**
    * #4175 Wave 5 PR 22b/2 — optional injection seam for daemon-host
    * status cells (env snapshot, daemon preflight). Production
    * `qwen serve` provides

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -1581,8 +1581,28 @@ class QwenAgent implements Agent {
               `tools may not take effect until daemon restart.\n`,
           );
         }
+        // #4297 fold-in 9 (gpt-5.5 critical, addresses #3263088414):
+        // route through `ToolRegistry.discoverToolsForServer` instead
+        // of calling `manager.discoverMcpToolsForServer` directly.
+        // The registry wrapper PURGES this server's existing
+        // `DiscoveredMCPTool` entries (and its `revealedDeferred`
+        // markers) plus its prompts before rediscovery, so a
+        // toggle-disable-then-restart workflow actually removes the
+        // newly-disabled tool from the live registry. Without the
+        // wrapper, `registerTool` would only consult the refreshed
+        // `disabledTools` set for newly-discovered tools — entries
+        // that were already in the registry from the prior boot
+        // would keep serving requests, silently breaking the
+        // documented "toggle + restart" promise.
         const start = Date.now();
-        await manager.discoverMcpToolsForServer(serverName, this.config);
+        const toolRegistry = this.config.getToolRegistry();
+        if (!toolRegistry) {
+          throw RequestError.internalError(
+            undefined,
+            'ToolRegistry unavailable on this Config',
+          );
+        }
+        await toolRegistry.discoverToolsForServer(serverName);
         // #4282 gpt-5.5 C4 fold-in: `discoverMcpToolsForServer`
         // catches reconnect/discovery errors internally (logs and
         // resolves void) so a broken MCP server would otherwise

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -1515,23 +1515,37 @@ class QwenAgent implements Agent {
             reason: 'budget_would_exceed' as const,
           };
         }
-        // #4282 fold-in 5 (Codex P2-2). Re-read workspace settings to
-        // pick up any `tools.disabled` toggles applied since this ACP
-        // child booted. The original snapshot was frozen by Config's
+        // #4282 fold-in 5 (Codex P2-2). Re-read settings to pick up
+        // any `tools.disabled` toggles applied since this ACP child
+        // booted. The original snapshot was frozen by Config's
         // constructor; without this refresh, a `setWorkspaceToolEnabled`
         // call followed by the documented `mcp restart` would
         // re-register a just-disabled MCP tool because
         // `discoverMcpToolsForServer` walks `ToolRegistry.registerTool`,
-        // which consults `Config.getDisabledTools()`. Reading from the
-        // workspace scope (not merged) matches the persist-write path
-        // in `runQwenServe.persistDisabledTools` so the read/write
-        // sources of truth agree.
+        // which consults `Config.getDisabledTools()`.
+        //
+        // #4297 fold-in 3 (wenshao critical, addresses #3260725526):
+        // read the MERGED settings (User + System + Workspace union)
+        // rather than the workspace scope alone. The bootstrap Config
+        // received `merged.tools?.disabled`, so user/system policy is
+        // already enforced by `ToolRegistry.registerTool`. Replacing
+        // the in-memory set with the workspace scope alone would
+        // silently drop higher-scope entries — a user-level disable
+        // would survive boot but vanish after the first MCP restart,
+        // letting `discoverMcpToolsForServer` re-register the
+        // user-disabled tool.
+        //
+        // The asymmetry vs. the persist-write path is deliberate:
+        // `runQwenServe.persistDisabledTools` writes to
+        // `SettingScope.Workspace` only so the workspace file doesn't
+        // bake in user/system entries (the fold-in 1 H2 fix). Reads
+        // need the union; writes need the scope. The two paths look
+        // alike but answer different questions.
         try {
           const fresh = loadSettings(this.config.getTargetDir());
-          const wsScope = fresh.forScope(SettingScope.Workspace).settings;
-          const wsDisabled = wsScope.tools?.disabled;
-          const disabledList = Array.isArray(wsDisabled)
-            ? wsDisabled.filter((v): v is string => typeof v === 'string')
+          const mergedDisabled = fresh.merged.tools?.disabled;
+          const disabledList = Array.isArray(mergedDisabled)
+            ? mergedDisabled.filter((v): v is string => typeof v === 'string')
             : [];
           this.config.setDisabledTools(new Set(disabledList));
         } catch (err) {
@@ -1545,7 +1559,7 @@ class QwenAgent implements Agent {
           // zero diagnostic.
           process.stderr.write(
             `qwen serve: MCP restart for ${JSON.stringify(serverName)} ` +
-              `could not refresh disabledTools from workspace settings ` +
+              `could not refresh disabledTools from merged settings ` +
               `(${err instanceof Error ? err.message : String(err)}); ` +
               `proceeding with the bootstrap snapshot — recently toggled ` +
               `tools may not take effect until daemon restart.\n`,

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -1544,6 +1544,22 @@ class QwenAgent implements Agent {
         try {
           const fresh = loadSettings(this.config.getTargetDir());
           const mergedDisabled = fresh.merged.tools?.disabled;
+          // #4297 fold-in 7 (qwen-latest critical, addresses
+          // #3262625101): a malformed `tools.disabled` (boolean,
+          // string, object — hand-edited settings.json) DOESN'T
+          // throw, so the catch block below would never fire. The
+          // ternary used to silently substitute `[]`, clearing the
+          // entire disabled set with zero operator signal. Detect
+          // and stderr-log the malformed shape before clearing so a
+          // misconfigured settings file is loud rather than silent.
+          if (mergedDisabled !== undefined && !Array.isArray(mergedDisabled)) {
+            process.stderr.write(
+              `qwen serve: MCP restart for ${JSON.stringify(serverName)}: ` +
+                `tools.disabled has unexpected type ${typeof mergedDisabled}; ` +
+                `clearing disabled set — check settings.json. ` +
+                `Expected an array of strings.\n`,
+            );
+          }
           const disabledList = Array.isArray(mergedDisabled)
             ? mergedDisabled.filter((v): v is string => typeof v === 'string')
             : [];

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -1534,11 +1534,22 @@ class QwenAgent implements Agent {
             ? wsDisabled.filter((v): v is string => typeof v === 'string')
             : [];
           this.config.setDisabledTools(new Set(disabledList));
-        } catch {
-          // Settings load failures are non-fatal — fall through with
-          // the existing in-memory snapshot. The MCP restart still
-          // runs; only the disabledTools sync is skipped. Operators
-          // see this in the next ToolRegistry refresh log.
+        } catch (err) {
+          // #4297 fold-in 2 (wenshao S3): settings load failures are
+          // non-fatal — fall through with the existing in-memory
+          // snapshot. The MCP restart still runs; only the
+          // disabledTools sync is skipped. Surface a stderr line so a
+          // persistent failure (corrupted settings.json, permission
+          // denied) is visible to operators rather than silently
+          // breaking the documented "toggle + restart" workflow with
+          // zero diagnostic.
+          process.stderr.write(
+            `qwen serve: MCP restart for ${JSON.stringify(serverName)} ` +
+              `could not refresh disabledTools from workspace settings ` +
+              `(${err instanceof Error ? err.message : String(err)}); ` +
+              `proceeding with the bootstrap snapshot — recently toggled ` +
+              `tools may not take effect until daemon restart.\n`,
+          );
         }
         const start = Date.now();
         await manager.discoverMcpToolsForServer(serverName, this.config);

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -1515,6 +1515,31 @@ class QwenAgent implements Agent {
             reason: 'budget_would_exceed' as const,
           };
         }
+        // #4282 fold-in 5 (Codex P2-2). Re-read workspace settings to
+        // pick up any `tools.disabled` toggles applied since this ACP
+        // child booted. The original snapshot was frozen by Config's
+        // constructor; without this refresh, a `setWorkspaceToolEnabled`
+        // call followed by the documented `mcp restart` would
+        // re-register a just-disabled MCP tool because
+        // `discoverMcpToolsForServer` walks `ToolRegistry.registerTool`,
+        // which consults `Config.getDisabledTools()`. Reading from the
+        // workspace scope (not merged) matches the persist-write path
+        // in `runQwenServe.persistDisabledTools` so the read/write
+        // sources of truth agree.
+        try {
+          const fresh = loadSettings(this.config.getTargetDir());
+          const wsScope = fresh.forScope(SettingScope.Workspace).settings;
+          const wsDisabled = wsScope.tools?.disabled;
+          const disabledList = Array.isArray(wsDisabled)
+            ? wsDisabled.filter((v): v is string => typeof v === 'string')
+            : [];
+          this.config.setDisabledTools(new Set(disabledList));
+        } catch {
+          // Settings load failures are non-fatal — fall through with
+          // the existing in-memory snapshot. The MCP restart still
+          // runs; only the disabledTools sync is skipped. Operators
+          // see this in the next ToolRegistry refresh log.
+        }
         const start = Date.now();
         await manager.discoverMcpToolsForServer(serverName, this.config);
         // #4282 gpt-5.5 C4 fold-in: `discoverMcpToolsForServer`

--- a/packages/cli/src/serve/httpAcpBridge.test.ts
+++ b/packages/cli/src/serve/httpAcpBridge.test.ts
@@ -5007,7 +5007,7 @@ describe('createHttpAcpBridge', () => {
           expect(err).toBeInstanceOf(WorkspaceInitSymlinkError);
           expect((err as WorkspaceInitSymlinkError).kind).toBe('target');
           expect((err as Error).message).toMatch(
-            /could not be opened with O_NOFOLLOW/,
+            /could not be opened with O_NOFOLLOW \(ELOOP\)/,
           );
           // External file untouched — the boundary held.
           expect(await fsp.readFile(externalFile, 'utf8')).toBe('# external');
@@ -5017,6 +5017,49 @@ describe('createHttpAcpBridge', () => {
         }
       } finally {
         await fsp.rm(escapeTarget, { recursive: true, force: true });
+      }
+    });
+
+    it('force:true overwrite distinguishes ENOENT race-delete from ELOOP symlink (#4297 fold-in 8)', async () => {
+      // Pin the diagnostic split. ENOENT in the overwrite open path
+      // means the file was DELETED between the readFile content
+      // check and the open (concurrent writer — git checkout,
+      // editor save) — NOT a symlink swap. The error message must
+      // not say "swapped to a symlink"; otherwise an operator
+      // diagnosing a benign race wastes time hunting a symlink
+      // attack that didn't happen.
+      // Pretend lstat says it's a regular file with content (so we
+      // land on the overwrote action), but the actual on-disk path
+      // doesn't exist when fs.open runs — forcing ENOENT.
+      const fakeStats = {
+        isSymbolicLink: () => false,
+        isFile: () => true,
+        isDirectory: () => false,
+        isCharacterDevice: () => false,
+        isBlockDevice: () => false,
+        isFIFO: () => false,
+        isSocket: () => false,
+      } as unknown as import('node:fs').Stats;
+      const lstatSpy = vi.spyOn(fsp, 'lstat').mockResolvedValueOnce(fakeStats);
+      const readFileSpy = vi
+        .spyOn(fsp, 'readFile')
+        .mockResolvedValueOnce('# Old content' as never);
+      try {
+        const bridge = createHttpAcpBridge({ boundWorkspace: tmpWs });
+        const err = await bridge
+          .initWorkspace({ force: true }, undefined)
+          .catch((e) => e);
+        expect(err).toBeInstanceOf(WorkspaceInitSymlinkError);
+        expect((err as WorkspaceInitSymlinkError).kind).toBe('target');
+        // Message must reference deletion / concurrent writer — NOT
+        // "swapped to a symlink" (which is only accurate for ELOOP).
+        expect((err as Error).message).toMatch(
+          /was deleted between the content check and the overwrite/,
+        );
+        expect((err as Error).message).not.toMatch(/swapped to a symlink/);
+      } finally {
+        lstatSpy.mockRestore();
+        readFileSpy.mockRestore();
       }
     });
 

--- a/packages/cli/src/serve/httpAcpBridge.test.ts
+++ b/packages/cli/src/serve/httpAcpBridge.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 import { randomBytes } from 'node:crypto';
 import { promises as fsp } from 'node:fs';
 import * as os from 'node:os';
@@ -5041,6 +5041,67 @@ describe('createHttpAcpBridge', () => {
         expect((err as Error).message).toMatch(/is a symlink/);
         // External file untouched.
         expect(await fsp.readFile(externalFile, 'utf8')).toBe('# external');
+      } finally {
+        await fsp.rm(escapeTarget, { recursive: true, force: true });
+      }
+    });
+
+    it('atomic create refuses an EEXIST race after lstat passed (#4297 fold-in 5 TOCTOU)', async () => {
+      // The PR 17 `lstat` check is point-in-time: a local attacker
+      // with workspace write access could replace the target with a
+      // symlink between the check and the write, and the previous
+      // `fs.writeFile` would have followed the link out of the
+      // workspace. The fold-in 5 fix uses `fs.open(target, 'wx')` —
+      // O_WRONLY|O_CREAT|O_EXCL — which atomically refuses any
+      // pre-existing inode at the path.
+      //
+      // This test simulates the race by pre-creating a symlink AND
+      // stubbing `fs.lstat` to lie about it (return a regular-file
+      // shape). Without the `'wx'` guard the bridge would proceed to
+      // `writeFile` and follow the symlink. With it, the open call
+      // fails with EEXIST and we throw `WorkspaceInitSymlinkError`.
+      const escapeTarget = await fsp.mkdtemp(
+        path.join(os.tmpdir(), 'qwen-init-toctou-'),
+      );
+      try {
+        const externalFile = path.join(escapeTarget, 'EXTERNAL.md');
+        await fsp.writeFile(externalFile, '# external', 'utf8');
+        const targetPath = path.join(tmpWs, 'QWEN.md');
+        await fsp.symlink(externalFile, targetPath);
+        // Pretend `lstat` reports a regular file (the race window
+        // where the symlink was placed AFTER our stat). The 'wx'
+        // open should still atomically refuse.
+        const fakeStats = {
+          isSymbolicLink: () => false,
+          isFile: () => true,
+          isDirectory: () => false,
+          isCharacterDevice: () => false,
+          isBlockDevice: () => false,
+          isFIFO: () => false,
+          isSocket: () => false,
+        } as unknown as import('node:fs').Stats;
+        const lstatSpy = vi
+          .spyOn(fsp, 'lstat')
+          .mockResolvedValueOnce(fakeStats);
+        // ALSO stub readFile so the existence check above doesn't
+        // short-circuit into the conflict path; we want the create
+        // branch to attempt `fs.open(target, 'wx')`.
+        const readFileSpy = vi
+          .spyOn(fsp, 'readFile')
+          .mockRejectedValueOnce(
+            Object.assign(new Error('ENOENT'), { code: 'ENOENT' }),
+          );
+        try {
+          const bridge = createHttpAcpBridge({ boundWorkspace: tmpWs });
+          const err = await bridge.initWorkspace({}, undefined).catch((e) => e);
+          expect(err).toBeInstanceOf(WorkspaceInitSymlinkError);
+          expect((err as WorkspaceInitSymlinkError).kind).toBe('target');
+          // External file must not have been touched.
+          expect(await fsp.readFile(externalFile, 'utf8')).toBe('# external');
+        } finally {
+          lstatSpy.mockRestore();
+          readFileSpy.mockRestore();
+        }
       } finally {
         await fsp.rm(escapeTarget, { recursive: true, force: true });
       }

--- a/packages/cli/src/serve/httpAcpBridge.test.ts
+++ b/packages/cli/src/serve/httpAcpBridge.test.ts
@@ -4762,6 +4762,78 @@ describe('createHttpAcpBridge', () => {
       expect(await fsp.readFile(target, 'utf8')).toBe('');
     });
 
+    it('honors `contextFilename` from BridgeOptions (#4282 fold-in 5 P2-1)', async () => {
+      // The daemon parent never goes through `loadCliConfig`, so the
+      // process-global `getCurrentGeminiMdFilename()` stays on the
+      // default `QWEN.md`. `runQwenServe` snapshots the workspace's
+      // `context.fileName` setting at boot and forwards it via the
+      // `contextFilename` option so init writes the same file the
+      // ACP child reads.
+      const bridge = createHttpAcpBridge({
+        boundWorkspace: tmpWs,
+        contextFilename: 'AGENTS.md',
+      });
+      const res = await bridge.initWorkspace({}, undefined);
+      expect(res.action).toBe('created');
+      expect(res.path).toBe(path.join(tmpWs, 'AGENTS.md'));
+      // Default name must NOT have been written; otherwise observers
+      // would see two files appear and clients would race over which
+      // is canonical.
+      expect(
+        await fsp
+          .stat(path.join(tmpWs, 'QWEN.md'))
+          .then(() => true)
+          .catch(() => false),
+      ).toBe(false);
+    });
+
+    it('rejects writes when a parent directory symlinks outside the workspace (#4282 fold-in 5 P2-4)', async () => {
+      // `lstat(target)` only checks the final component. A symlink at
+      // any parent level — e.g. `docs -> /tmp` with `context.fileName:
+      // 'docs/AGENTS.md'` — would let `writeFile` follow the parent
+      // link and create or truncate outside `boundWorkspace`. The
+      // canonical-parent check resolves the chain via `realpath`
+      // before any read or write.
+      const escapeTarget = await fsp.mkdtemp(
+        path.join(os.tmpdir(), 'qwen-init-escape-'),
+      );
+      try {
+        await fsp.symlink(escapeTarget, path.join(tmpWs, 'docs'));
+        const bridge = createHttpAcpBridge({
+          boundWorkspace: tmpWs,
+          contextFilename: 'docs/AGENTS.md',
+        });
+        const err = await bridge.initWorkspace({}, undefined).catch((e) => e);
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toMatch(
+          /parent path that resolves outside the bound workspace/,
+        );
+        // Confirm nothing was written outside the workspace.
+        expect(
+          await fsp
+            .stat(path.join(escapeTarget, 'AGENTS.md'))
+            .then(() => true)
+            .catch(() => false),
+        ).toBe(false);
+      } finally {
+        await fsp.rm(escapeTarget, { recursive: true, force: true });
+      }
+    });
+
+    it('accepts writes when a parent directory is a real subdir (#4282 fold-in 5 P2-4)', async () => {
+      // Symmetric coverage for the parent-realpath check: when `docs`
+      // is a real directory (not a symlink), the write must succeed
+      // and land at the nested target.
+      await fsp.mkdir(path.join(tmpWs, 'docs'));
+      const bridge = createHttpAcpBridge({
+        boundWorkspace: tmpWs,
+        contextFilename: 'docs/AGENTS.md',
+      });
+      const res = await bridge.initWorkspace({}, undefined);
+      expect(res.action).toBe('created');
+      expect(res.path).toBe(path.join(tmpWs, 'docs', 'AGENTS.md'));
+    });
+
     it('does NOT spawn an ACP child', async () => {
       let factoryCalls = 0;
       const bridge = createHttpAcpBridge({

--- a/packages/cli/src/serve/httpAcpBridge.test.ts
+++ b/packages/cli/src/serve/httpAcpBridge.test.ts
@@ -4959,6 +4959,67 @@ describe('createHttpAcpBridge', () => {
       expect(await fsp.readFile(target, 'utf8')).toBe('');
     });
 
+    it('force:true overwrite refuses an O_NOFOLLOW ELOOP race (#4297 fold-in 7 TOCTOU)', async () => {
+      // Pin the new `O_WRONLY|O_TRUNC|O_NOFOLLOW` open path on the
+      // overwrote branch. Pre-fold-in-7 the overwrite used plain
+      // `fs.writeFile` and could be redirected outside `boundWorkspace`
+      // by a local writer racing a symlink between the lstat/readFile
+      // checks and the write. Now `O_NOFOLLOW` causes open() to fail
+      // with ELOOP on a symlink — translated to
+      // `WorkspaceInitSymlinkError(kind: 'target')`.
+      //
+      // Test strategy: pre-write a regular file so action lands on
+      // `overwrote`, then mock `fs.lstat` and `fs.readFile` to lie
+      // about the file (pretend it's still a regular file with non-
+      // whitespace content), but pre-replace the on-disk file with a
+      // symlink so `fs.open(..., O_NOFOLLOW)` fails.
+      const escapeTarget = await fsp.mkdtemp(
+        path.join(os.tmpdir(), 'qwen-init-overwrite-toctou-'),
+      );
+      try {
+        const externalFile = path.join(escapeTarget, 'EXTERNAL.md');
+        await fsp.writeFile(externalFile, '# external', 'utf8');
+        const targetPath = path.join(tmpWs, 'QWEN.md');
+        // Real on-disk state: a symlink pointing outside the workspace.
+        await fsp.symlink(externalFile, targetPath);
+        // Stubbed lstat/readFile: pretend it's a regular file with
+        // existing content, so we land on the `overwrote` action.
+        const fakeStats = {
+          isSymbolicLink: () => false,
+          isFile: () => true,
+          isDirectory: () => false,
+          isCharacterDevice: () => false,
+          isBlockDevice: () => false,
+          isFIFO: () => false,
+          isSocket: () => false,
+        } as unknown as import('node:fs').Stats;
+        const lstatSpy = vi
+          .spyOn(fsp, 'lstat')
+          .mockResolvedValueOnce(fakeStats);
+        const readFileSpy = vi
+          .spyOn(fsp, 'readFile')
+          .mockResolvedValueOnce('# Old non-whitespace content' as never);
+        try {
+          const bridge = createHttpAcpBridge({ boundWorkspace: tmpWs });
+          const err = await bridge
+            .initWorkspace({ force: true }, undefined)
+            .catch((e) => e);
+          expect(err).toBeInstanceOf(WorkspaceInitSymlinkError);
+          expect((err as WorkspaceInitSymlinkError).kind).toBe('target');
+          expect((err as Error).message).toMatch(
+            /could not be opened with O_NOFOLLOW/,
+          );
+          // External file untouched — the boundary held.
+          expect(await fsp.readFile(externalFile, 'utf8')).toBe('# external');
+        } finally {
+          lstatSpy.mockRestore();
+          readFileSpy.mockRestore();
+        }
+      } finally {
+        await fsp.rm(escapeTarget, { recursive: true, force: true });
+      }
+    });
+
     it('honors `contextFilename` from BridgeOptions (#4282 fold-in 5 P2-1)', async () => {
       // The daemon parent never goes through `loadCliConfig`, so the
       // process-global `getCurrentGeminiMdFilename()` stays on the

--- a/packages/cli/src/serve/httpAcpBridge.test.ts
+++ b/packages/cli/src/serve/httpAcpBridge.test.ts
@@ -45,7 +45,11 @@ import {
   MAX_WORKSPACE_PATH_LENGTH,
   RestoreInProgressError,
   SessionNotFoundError,
+  McpServerNotFoundError,
+  McpServerRestartFailedError,
   WorkspaceInitConflictError,
+  WorkspaceInitPathEscapeError,
+  WorkspaceInitSymlinkError,
   WorkspaceMismatchError,
   type AcpChannel,
   type BridgeOptions,
@@ -4513,15 +4517,29 @@ describe('createHttpAcpBridge', () => {
         { persist: true },
         undefined,
       );
-      // Session A receives both the session-scoped event and the
-      // workspace-scoped mirror; collect two events.
+      // #4297 fold-in 1: requester gets the event exactly once (via
+      // its own session-scoped publish); the broadcast skips the
+      // requester so the SDK reducer's `approvalModeChangedCount`
+      // increments by 1, not 2, on the requesting client.
       const aFirst = await itA.next();
-      const aSecond = await itA.next();
-      const aTypes = [aFirst.value?.type, aSecond.value?.type];
-      expect(aTypes.filter((t) => t === 'approval_mode_changed').length).toBe(
-        2,
-      );
-      // Session B receives only the workspace-scoped mirror.
+      expect(aFirst.value?.type).toBe('approval_mode_changed');
+      expect(aFirst.value?.data).toMatchObject({
+        sessionId: a.sessionId,
+        previous: 'default',
+        next: 'yolo',
+        persisted: true,
+      });
+      // Race A's next event against a 50ms timer to confirm no second
+      // delivery (which would be the duplicate the broadcast used to
+      // produce).
+      const aTimedSecond = await Promise.race([
+        itA.next().then((v) => ({ kind: 'event' as const, v })),
+        new Promise((r) => setTimeout(r, 50)).then(() => ({
+          kind: 'timeout' as const,
+        })),
+      ]);
+      expect(aTimedSecond.kind).toBe('timeout');
+      // Peer session B still receives the workspace-scoped mirror.
       const bFirst = await itB.next();
       expect(bFirst.value?.type).toBe('approval_mode_changed');
       expect(bFirst.value?.data).toMatchObject({
@@ -4699,6 +4717,185 @@ describe('createHttpAcpBridge', () => {
     });
   });
 
+  describe('restartMcpServer (#4297 fold-in 1, addresses #3260501141)', () => {
+    /**
+     * Build a channel factory whose ACP `extMethod` handler returns a
+     * configurable response for `qwen/control/workspace/mcp/restart`.
+     * Reusable across happy-path / soft-skip / hard-error tests so each
+     * test's intent is the response shape, not the boilerplate.
+     */
+    function restartFactory(
+      respond: (
+        params: Record<string, unknown>,
+      ) =>
+        | Record<string, unknown>
+        | Promise<Record<string, unknown>>
+        | Promise<never>,
+    ): ChannelFactory {
+      return async () => {
+        const { clientStream, agentStream } = createInMemoryChannel();
+        const agent = new FakeAgent({
+          extMethodImpl: (method, params) => {
+            if (method === 'qwen/control/workspace/mcp/restart') {
+              return Promise.resolve(respond(params));
+            }
+            return Promise.resolve({});
+          },
+        });
+        new AgentSideConnection(() => agent as Agent, agentStream);
+        return {
+          stream: clientStream,
+          exited: new Promise<
+            | { exitCode: number | null; signalCode: NodeJS.Signals | null }
+            | undefined
+          >(() => {}),
+          kill: async () => {},
+          killSync: () => {},
+        };
+      };
+    }
+
+    it('returns the restarted shape on success and broadcasts mcp_server_restarted', async () => {
+      const bridge = makeBridge({
+        channelFactory: restartFactory(() => ({
+          serverName: 'docs',
+          restarted: true,
+          durationMs: 1234,
+        })),
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const abort = new AbortController();
+      const it = bridge
+        .subscribeEvents(session.sessionId, { signal: abort.signal })
+        [Symbol.asyncIterator]();
+      const result = await bridge.restartMcpServer('docs', undefined);
+      expect(result).toEqual({
+        serverName: 'docs',
+        restarted: true,
+        durationMs: 1234,
+      });
+      const next = await it.next();
+      expect(next.value?.type).toBe('mcp_server_restarted');
+      expect(next.value?.data).toMatchObject({
+        serverName: 'docs',
+        durationMs: 1234,
+      });
+      abort.abort();
+      await bridge.shutdown();
+    });
+
+    it('returns the soft-skip shape and broadcasts mcp_server_restart_refused', async () => {
+      const bridge = makeBridge({
+        channelFactory: restartFactory(() => ({
+          serverName: 'docs',
+          restarted: false,
+          skipped: true,
+          reason: 'budget_would_exceed',
+        })),
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const abort = new AbortController();
+      const it = bridge
+        .subscribeEvents(session.sessionId, { signal: abort.signal })
+        [Symbol.asyncIterator]();
+      const result = await bridge.restartMcpServer('docs', undefined);
+      expect(result).toEqual({
+        serverName: 'docs',
+        restarted: false,
+        skipped: true,
+        reason: 'budget_would_exceed',
+      });
+      const next = await it.next();
+      expect(next.value?.type).toBe('mcp_server_restart_refused');
+      expect(next.value?.data).toMatchObject({
+        serverName: 'docs',
+        reason: 'budget_would_exceed',
+      });
+      abort.abort();
+      await bridge.shutdown();
+    });
+
+    it('translates ACP mcp_server_not_found into McpServerNotFoundError', async () => {
+      // The ACP child raises a JSON-RPC error whose `data.errorKind` is
+      // `'mcp_server_not_found'` for unknown server names. The bridge
+      // re-instantiates the typed class so `sendBridgeError` can map
+      // it to a stable HTTP 404 — without this the route would fall
+      // through to the generic 500 handler.
+      const bridge = makeBridge({
+        channelFactory: restartFactory(
+          () =>
+            Promise.reject(
+              new RequestError(-32004, 'MCP server not configured: "ghost"', {
+                errorKind: 'mcp_server_not_found',
+                serverName: 'ghost',
+              }),
+            ) as Promise<never>,
+        ),
+      });
+      await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const err = await bridge
+        .restartMcpServer('ghost', undefined)
+        .catch((e) => e);
+      expect(err).toBeInstanceOf(McpServerNotFoundError);
+      expect((err as McpServerNotFoundError).serverName).toBe('ghost');
+      await bridge.shutdown();
+    });
+
+    it('translates ACP mcp_restart_failed into McpServerRestartFailedError', async () => {
+      // Post-discover, the ACP child checks the live MCP server status
+      // and raises a JSON-RPC error with `errorKind:
+      // 'mcp_restart_failed'` when the server didn't reach CONNECTED.
+      // The bridge re-instantiates the typed class so the route maps
+      // it to HTTP 502 + `errorKind: 'protocol_error'`.
+      const bridge = makeBridge({
+        channelFactory: restartFactory(
+          () =>
+            Promise.reject(
+              new RequestError(
+                -32099,
+                'MCP server "docs" did not reach a connected state',
+                {
+                  errorKind: 'mcp_restart_failed',
+                  serverName: 'docs',
+                  mcpStatus: 'DISCONNECTED',
+                },
+              ),
+            ) as Promise<never>,
+        ),
+      });
+      await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const err = await bridge
+        .restartMcpServer('docs', undefined)
+        .catch((e) => e);
+      expect(err).toBeInstanceOf(McpServerRestartFailedError);
+      expect((err as McpServerRestartFailedError).serverName).toBe('docs');
+      expect((err as McpServerRestartFailedError).mcpStatus).toBe(
+        'DISCONNECTED',
+      );
+      await bridge.shutdown();
+    });
+
+    it('stamps mcp_server_restarted with the originator clientId when supplied', async () => {
+      const bridge = makeBridge({
+        channelFactory: restartFactory(() => ({
+          serverName: 'docs',
+          restarted: true,
+          durationMs: 0,
+        })),
+      });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const abort = new AbortController();
+      const it = bridge
+        .subscribeEvents(session.sessionId, { signal: abort.signal })
+        [Symbol.asyncIterator]();
+      await bridge.restartMcpServer('docs', session.clientId);
+      const next = await it.next();
+      expect(next.value?.originatorClientId).toBe(session.clientId);
+      abort.abort();
+      await bridge.shutdown();
+    });
+  });
+
   describe('initWorkspace (#4175 Wave 4 PR 17)', () => {
     /**
      * Per-test workspace temp dir so the bridge's writeFile lands on a
@@ -4804,7 +5001,10 @@ describe('createHttpAcpBridge', () => {
           contextFilename: 'docs/AGENTS.md',
         });
         const err = await bridge.initWorkspace({}, undefined).catch((e) => e);
-        expect(err).toBeInstanceOf(Error);
+        // #4297 fold-in 1 (16:32:44-round S1): typed class so
+        // `sendBridgeError` can map to 400 rather than 500.
+        expect(err).toBeInstanceOf(WorkspaceInitSymlinkError);
+        expect((err as WorkspaceInitSymlinkError).kind).toBe('parent');
         expect((err as Error).message).toMatch(
           /parent path that resolves outside the bound workspace/,
         );
@@ -4818,6 +5018,61 @@ describe('createHttpAcpBridge', () => {
       } finally {
         await fsp.rm(escapeTarget, { recursive: true, force: true });
       }
+    });
+
+    it('rejects writes when the target file itself is a symlink (#4297 fold-in 1)', async () => {
+      // The original PR 17 boundary guard: `lstat(target)` should
+      // refuse to follow a symlink at the QWEN.md path. Without this
+      // test, a future refactor that drops the `lstat` could silently
+      // re-open path traversal through this strict-gated mutation
+      // route. Pairs with the parent-symlink test above to lock both
+      // boundary checks under unit coverage.
+      const escapeTarget = await fsp.mkdtemp(
+        path.join(os.tmpdir(), 'qwen-init-target-symlink-'),
+      );
+      try {
+        const externalFile = path.join(escapeTarget, 'EXTERNAL.md');
+        await fsp.writeFile(externalFile, '# external', 'utf8');
+        await fsp.symlink(externalFile, path.join(tmpWs, 'QWEN.md'));
+        const bridge = createHttpAcpBridge({ boundWorkspace: tmpWs });
+        const err = await bridge.initWorkspace({}, undefined).catch((e) => e);
+        expect(err).toBeInstanceOf(WorkspaceInitSymlinkError);
+        expect((err as WorkspaceInitSymlinkError).kind).toBe('target');
+        expect((err as Error).message).toMatch(/is a symlink/);
+        // External file untouched.
+        expect(await fsp.readFile(externalFile, 'utf8')).toBe('# external');
+      } finally {
+        await fsp.rm(escapeTarget, { recursive: true, force: true });
+      }
+    });
+
+    it('rejects writes when contextFilename resolves outside the workspace (#4297 fold-in 1)', async () => {
+      // The pre-canonicalize textual `withinWorkspace` check at
+      // `httpAcpBridge.ts:~4045`: a `context.fileName: '../outside.md'`
+      // is the simplest config-error escape. Locking it under a typed
+      // assertion means a future path-arithmetic refactor that
+      // weakens the check fails this test instead of silently
+      // re-opening the boundary.
+      const bridge = createHttpAcpBridge({
+        boundWorkspace: tmpWs,
+        contextFilename: '../outside.md',
+      });
+      const err = await bridge.initWorkspace({}, undefined).catch((e) => e);
+      expect(err).toBeInstanceOf(WorkspaceInitPathEscapeError);
+      expect((err as WorkspaceInitPathEscapeError).filename).toBe(
+        '../outside.md',
+      );
+      expect((err as Error).message).toMatch(
+        /resolves outside the bound workspace/,
+      );
+      // Confirm no file was created at the escape target.
+      const sibling = path.resolve(tmpWs, '..', 'outside.md');
+      expect(
+        await fsp
+          .stat(sibling)
+          .then(() => true)
+          .catch(() => false),
+      ).toBe(false);
     });
 
     it('accepts writes when a parent directory is a real subdir (#4282 fold-in 5 P2-4)', async () => {

--- a/packages/cli/src/serve/httpAcpBridge.ts
+++ b/packages/cli/src/serve/httpAcpBridge.ts
@@ -3846,19 +3846,40 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         try {
           fh = await fs.open(
             target,
-             
+
             fsConstants.O_WRONLY | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW,
           );
         } catch (err) {
           const code = (err as { code?: unknown } | null | undefined)?.code;
-          if (code === 'ELOOP' || code === 'ENOENT') {
+          // #4297 fold-in 8 (qwen-latest S1, addresses #3262861754):
+          // split ELOOP and ENOENT diagnostics so operators don't
+          // misdiagnose. ELOOP is the genuine `O_NOFOLLOW` rejection
+          // — a symlink at the final component, possibly an attack
+          // race. ENOENT here means the file was DELETED between
+          // the readFile content check and this open — a benign race
+          // with a concurrent writer (git checkout, editor save).
+          // Both still surface as `WorkspaceInitSymlinkError(kind:
+          // 'target')` so the route maps to a structured 400; the
+          // class doubles as the workspace-init race-condition
+          // bucket, but the message is now accurate per case.
+          if (code === 'ELOOP') {
             throw new WorkspaceInitSymlinkError(
               target,
               'target',
               `Workspace context file ${JSON.stringify(target)} could not ` +
-                `be opened with O_NOFOLLOW (${String(code)}); the path may ` +
-                `have been swapped to a symlink between the absence check ` +
-                `and the overwrite. Refusing to follow it.`,
+                `be opened with O_NOFOLLOW (ELOOP); the path may have been ` +
+                `swapped to a symlink between the content check and the ` +
+                `overwrite. Refusing to follow it.`,
+            );
+          }
+          if (code === 'ENOENT') {
+            throw new WorkspaceInitSymlinkError(
+              target,
+              'target',
+              `Workspace context file ${JSON.stringify(target)} was deleted ` +
+                `between the content check and the overwrite (likely a ` +
+                `concurrent writer — git checkout, editor save, etc.). ` +
+                `Refusing to recreate blindly; rerun init.`,
             );
           }
           throw err;

--- a/packages/cli/src/serve/httpAcpBridge.ts
+++ b/packages/cli/src/serve/httpAcpBridge.ts
@@ -3783,7 +3783,53 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         if (code !== 'ENOENT') throw err;
         // ENOENT — fall through to create.
       }
-      if (action !== 'noop') {
+      if (action === 'created') {
+        // #4297 fold-in 5 (wenshao critical, addresses #3260836305).
+        // Close the TOCTOU window between the `lstat`/`readFile`
+        // checks above and this write by using `'wx'`
+        // (O_WRONLY|O_CREAT|O_EXCL): the open atomically refuses
+        // when ANY inode (regular file, dir, symlink, …) exists at
+        // the target path, so a local attacker can't slip a symlink
+        // between our checks and follow it through here. EEXIST
+        // bubbles up as `WorkspaceInitSymlinkError(kind: 'target')`
+        // so the route still returns a structured 400 instead of a
+        // generic 500 — the most likely cause of an EEXIST after we
+        // already proved ENOENT is a race-created symlink.
+        let fh: import('node:fs/promises').FileHandle;
+        try {
+          fh = await fs.open(target, 'wx');
+        } catch (err) {
+          const code = (err as { code?: unknown } | null | undefined)?.code;
+          if (code === 'EEXIST') {
+            throw new WorkspaceInitSymlinkError(
+              target,
+              'target',
+              `Workspace context file ${JSON.stringify(target)} appeared ` +
+                `between our absence check and the create — refusing to ` +
+                `proceed (a regular file or symlink was just placed at the ` +
+                `target path, and following it could escape the workspace).`,
+            );
+          }
+          throw err;
+        }
+        try {
+          await fh.writeFile('', 'utf8');
+        } finally {
+          await fh.close();
+        }
+      } else if (action === 'overwrote') {
+        // FIXME (#4297 fold-in 5, addresses #3260836305): the
+        // `force: true` overwrite path still has a TOCTOU window —
+        // the symlink check above is point-in-time and `writeFile`
+        // here will follow a race-substituted symlink. The original
+        // FIXME at the top of `initWorkspace` plans migration to
+        // `WorkspaceFileSystem` (PR 18 boundary), which will close
+        // this via `O_NOFOLLOW`-aware open. Until then, the
+        // documented trust posture (daemon binds to an
+        // operator-chosen workspace, no cross-user write access in
+        // the Stage 1 deployment shape) accepts this gap. The
+        // `'wx'`-based create path above is the more common case
+        // and is now race-safe.
         await fs.writeFile(target, '', 'utf8');
       }
       broadcastWorkspaceEvent({

--- a/packages/cli/src/serve/httpAcpBridge.ts
+++ b/packages/cli/src/serve/httpAcpBridge.ts
@@ -132,6 +132,8 @@ import {
   InvalidPermissionOptionError,
   InvalidSessionMetadataError,
   WorkspaceInitConflictError,
+  WorkspaceInitPathEscapeError,
+  WorkspaceInitSymlinkError,
   McpServerNotFoundError,
   McpServerRestartFailedError,
 } from '@qwen-code/acp-bridge/bridgeErrors';
@@ -146,6 +148,8 @@ export {
   InvalidPermissionOptionError,
   InvalidSessionMetadataError,
   WorkspaceInitConflictError,
+  WorkspaceInitPathEscapeError,
+  WorkspaceInitSymlinkError,
   McpServerNotFoundError,
   McpServerRestartFailedError,
   MAX_WORKSPACE_PATH_LENGTH,
@@ -461,6 +465,7 @@ function hasControlCharacter(value: string): boolean {
 }
 
 // `InvalidSessionMetadataError`, `WorkspaceInitConflictError`,
+// `WorkspaceInitPathEscapeError`, `WorkspaceInitSymlinkError`,
 // `McpServerNotFoundError`, `McpServerRestartFailedError` lifted to
 // `@qwen-code/acp-bridge/bridgeErrors` in #4175 PR 22b — see the
 // consolidated re-export block earlier in this file.
@@ -2098,26 +2103,71 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
 
   /**
    * Fan-out an event to every live session bus. PR 17 mutation events
-   * (`tool_toggled`, `workspace_initialized`, `mcp_server_restart*`)
-   * call this; semantically identical to PR 16's
-   * `publishWorkspaceEvent` member on the bridge object (same
-   * `byId.values()` iteration, same per-entry try/catch posture).
-   * Kept as a local closure alias rather than a member method because
-   * call sites within the bridge implementation can't invoke own
-   * methods through `this` here. PR 16's richer success/failure
-   * accounting (per-entry shutdown/debug logging) lives only on the
-   * member version — these PR 17 events are best-effort, so the
-   * simpler swallow-and-skip is acceptable.
+   * (`tool_toggled`, `workspace_initialized`, `mcp_server_restart*`,
+   * persisted `approval_mode_changed` mirror) call this.
+   *
+   * Mirrors PR 16's `publishWorkspaceEvent` member: per-entry
+   * success/failure accounting + an "ALL buses dropped" stderr
+   * elevation so monitoring catches the all-closed-during-shutdown
+   * scenario. Was a local swallow-and-skip until #4297 fold-in 1
+   * picked up the suggestion to align with the instrumented path.
+   *
+   * Kept as a local closure rather than a member method because call
+   * sites within the bridge implementation run inside the factory
+   * scope where `this` is not yet the proxy.
+   *
+   * Optional `skipSessionId` — when set, that session is excluded
+   * from the broadcast. Used by `setSessionApprovalMode` to avoid
+   * delivering `approval_mode_changed` twice to the requesting
+   * session (which already received the session-scoped publish on
+   * its own bus). Without the skip, the SDK reducer's
+   * `approvalModeChangedCount` reaches 2 for a single mutation on
+   * the requesting client.
    */
   const broadcastWorkspaceEvent = (
     envelope: Omit<BridgeEvent, 'id' | 'v'>,
+    skipSessionId?: string,
   ): void => {
-    for (const entry of byId.values()) {
-      try {
-        entry.events.publish(envelope);
-      } catch {
-        /* bus closed for this session; skip */
+    const sessions = Array.from(byId.values());
+    let successCount = 0;
+    let failureCount = 0;
+    for (const entry of sessions) {
+      if (skipSessionId !== undefined && entry.sessionId === skipSessionId) {
+        continue;
       }
+      try {
+        const published = entry.events.publish(envelope);
+        if (published === undefined) {
+          failureCount += 1;
+          writeServeDebugLine(
+            `broadcastWorkspaceEvent: publish on session ${entry.sessionId} no-op (bus closed)`,
+          );
+        } else {
+          successCount += 1;
+        }
+      } catch (err) {
+        failureCount += 1;
+        const detail =
+          `broadcastWorkspaceEvent: bus publish failed for session ` +
+          `${JSON.stringify(entry.sessionId)} (type=${envelope.type}): ` +
+          `${err instanceof Error ? err.message : String(err)}`;
+        if (shuttingDown) {
+          writeServeDebugLine(detail);
+        } else {
+          writeStderrLine(`qwen serve: ${detail}`);
+        }
+      }
+    }
+    // Only elevate when the broadcast had at least one eligible
+    // recipient (excluding the skipped requester) and ALL of them
+    // dropped the event. Single-session workspaces with the requester
+    // skipped naturally produce zero recipients — that's not an
+    // "all dropped" condition, just nobody to deliver to.
+    const eligible = sessions.length - (skipSessionId !== undefined ? 1 : 0);
+    if (eligible > 0 && successCount === 0 && !shuttingDown) {
+      writeStderrLine(
+        `qwen serve: broadcastWorkspaceEvent type=${envelope.type} dropped on ALL ${failureCount} session bus(es); SSE subscribers will miss this event (GET fallback still authoritative)`,
+      );
     }
   };
 
@@ -3469,17 +3519,26 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       // spawn an ACP child. The session-scoped publish above remains the
       // authoritative signal for the requesting session (and carries the
       // sessionId in `data`); the workspace mirror is informational.
+      //
+      // #4297 fold-in 1: skip the requesting session in the broadcast.
+      // The session-scoped publish above already delivered the event on
+      // its own bus, so a broadcast that included it would double-count
+      // in the SDK reducer's `approvalModeChangedCount` (peers see 1,
+      // requester used to see 2 — silent contract violation).
       if (persisted) {
-        broadcastWorkspaceEvent({
-          type: 'approval_mode_changed',
-          data: {
-            sessionId: entry.sessionId,
-            previous: response.previous,
-            next: response.current,
-            persisted,
+        broadcastWorkspaceEvent(
+          {
+            type: 'approval_mode_changed',
+            data: {
+              sessionId: entry.sessionId,
+              previous: response.previous,
+              next: response.current,
+              persisted,
+            },
+            ...(originatorClientId ? { originatorClientId } : {}),
           },
-          ...(originatorClientId ? { originatorClientId } : {}),
-        });
+          entry.sessionId,
+        );
       }
       return {
         sessionId: entry.sessionId,
@@ -3638,11 +3697,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         target === boundWorkspace ||
         target.startsWith(boundWorkspace + path.sep);
       if (!withinWorkspace) {
-        throw new Error(
-          `Configured workspace context filename ${JSON.stringify(filename)} ` +
-            `resolves outside the bound workspace ${JSON.stringify(boundWorkspace)}. ` +
-            `Refusing to write.`,
-        );
+        throw new WorkspaceInitPathEscapeError(filename, boundWorkspace);
       }
       // #4282 fold-in 5 (Codex P2-4). The textual `withinWorkspace`
       // and final-component `lstat` checks miss intermediate symlinks
@@ -3661,7 +3716,9 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         parentCanonical === wsCanonical ||
         parentCanonical.startsWith(wsCanonical + path.sep);
       if (!parentWithinWorkspace) {
-        throw new Error(
+        throw new WorkspaceInitSymlinkError(
+          target,
+          'parent',
           `Configured workspace context filename ${JSON.stringify(filename)} ` +
             `has a parent path that resolves outside the bound workspace ` +
             `(parent canonicalizes to ${JSON.stringify(parentCanonical)}, ` +
@@ -3683,13 +3740,16 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       try {
         const lst = await fs.lstat(target);
         if (lst.isSymbolicLink()) {
-          throw new Error(
+          throw new WorkspaceInitSymlinkError(
+            target,
+            'target',
             `Workspace context file ${JSON.stringify(target)} is a symlink. ` +
               `Refusing to follow it for write — replace the symlink with a ` +
               `regular file (or remove it) before re-running init.`,
           );
         }
       } catch (err) {
+        if (err instanceof WorkspaceInitSymlinkError) throw err;
         const code = (err as { code?: unknown } | null | undefined)?.code;
         if (code !== 'ENOENT') throw err;
         // ENOENT — target doesn't exist; fresh create is fine.

--- a/packages/cli/src/serve/httpAcpBridge.ts
+++ b/packages/cli/src/serve/httpAcpBridge.ts
@@ -6,7 +6,7 @@
 
 import { spawn, type ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { promises as fs } from 'node:fs';
+import { promises as fs, constants as fsConstants } from 'node:fs';
 import * as path from 'node:path';
 import { Readable, Writable } from 'node:stream';
 import {
@@ -3831,19 +3831,43 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
           await fh.close();
         }
       } else if (action === 'overwrote') {
-        // FIXME (#4297 fold-in 5, addresses #3260836305): the
-        // `force: true` overwrite path still has a TOCTOU window —
-        // the symlink check above is point-in-time and `writeFile`
-        // here will follow a race-substituted symlink. The original
-        // FIXME at the top of `initWorkspace` plans migration to
-        // `WorkspaceFileSystem` (PR 18 boundary), which will close
-        // this via `O_NOFOLLOW`-aware open. Until then, the
-        // documented trust posture (daemon binds to an
-        // operator-chosen workspace, no cross-user write access in
-        // the Stage 1 deployment shape) accepts this gap. The
-        // `'wx'`-based create path above is the more common case
-        // and is now race-safe.
-        await fs.writeFile(target, '', 'utf8');
+        // #4297 fold-in 7 (gpt-5.5 critical, addresses #3262615446):
+        // close the TOCTOU window on the `force: true` path with
+        // `O_WRONLY|O_TRUNC|O_NOFOLLOW`. `O_NOFOLLOW` causes
+        // `open()` to fail with ELOOP if the final component is a
+        // symlink — even if a local writer races a symlink in
+        // between our `lstat`/`readFile` checks and this open, the
+        // open refuses rather than truncating the link target.
+        // (The symbol exists on Linux/macOS; on Windows the constant
+        // is 0/no-op since the OS always follows symlinks, which
+        // is consistent with the documented Stage-1 trust posture
+        // there — Windows daemon support is best-effort.)
+        let fh: import('node:fs/promises').FileHandle;
+        try {
+          fh = await fs.open(
+            target,
+             
+            fsConstants.O_WRONLY | fsConstants.O_TRUNC | fsConstants.O_NOFOLLOW,
+          );
+        } catch (err) {
+          const code = (err as { code?: unknown } | null | undefined)?.code;
+          if (code === 'ELOOP' || code === 'ENOENT') {
+            throw new WorkspaceInitSymlinkError(
+              target,
+              'target',
+              `Workspace context file ${JSON.stringify(target)} could not ` +
+                `be opened with O_NOFOLLOW (${String(code)}); the path may ` +
+                `have been swapped to a symlink between the absence check ` +
+                `and the overwrite. Refusing to follow it.`,
+            );
+          }
+          throw err;
+        }
+        try {
+          await fh.writeFile('', 'utf8');
+        } finally {
+          await fh.close();
+        }
       }
       broadcastWorkspaceEvent({
         type: 'workspace_initialized',

--- a/packages/cli/src/serve/httpAcpBridge.ts
+++ b/packages/cli/src/serve/httpAcpBridge.ts
@@ -193,7 +193,10 @@ export type { AcpChannel, AcpChannelExitInfo, ChannelFactory };
 // `createDaemonStatusProvider()` (production impl in
 // `cli/src/serve/daemonStatusProvider.ts`) when the bridge is built;
 // embedded callers that don't need daemon-host cells may omit it,
-// in which case the factory returns idle placeholders.
+// in which case the factory returns idle placeholders. The
+// `contextFilename` option (added by #4282 fold-in 5) was lifted
+// alongside the rest of the surface — see the lifted definition in
+// `packages/acp-bridge/src/bridgeOptions.ts`.
 import type {
   BridgeOptions,
   DaemonStatusProvider,
@@ -1297,6 +1300,13 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     );
   }
   const boundWorkspace = opts.boundWorkspace;
+  // #4282 fold-in 5 (Codex P2-1). Snapshot the configured context
+  // filename at construction time. The daemon parent never updates
+  // the process-global through `loadCliConfig`, so `runQwenServe`
+  // reads the workspace's merged settings and forwards the value
+  // here. Falling back to `getCurrentGeminiMdFilename()` keeps
+  // bridge tests + embedded callers working without explicit setup.
+  const contextFilename = opts.contextFilename ?? getCurrentGeminiMdFilename();
   const persistApprovalMode = opts.persistApprovalMode;
   const persistDisabledTools = opts.persistDisabledTools;
 
@@ -3608,13 +3618,21 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       // operator chose and the trust dialog flow doesn't yet exist
       // for the daemon. The CV1 symlink reject below covers the
       // immediate boundary-escape concern.
-      const filename = getCurrentGeminiMdFilename();
-      // #4282 gpt-5.5 C1 fold-in: `getCurrentGeminiMdFilename()` is
-      // settings-controlled. A daemon configured with
-      // `context.fileName: "../outside.md"` would otherwise resolve
-      // outside `boundWorkspace` and let this strict-gated mutation
-      // create or truncate a file outside the workspace boundary.
-      // Resolve the joined path and reject anything that escapes.
+      // #4282 fold-in 5 (Codex P2-1). Use the snapshot from
+      // `BridgeOptions.contextFilename` (sourced from the workspace's
+      // merged settings at daemon boot) instead of the process-global
+      // `getCurrentGeminiMdFilename()` — the daemon parent never goes
+      // through `loadCliConfig`, so a workspace configured with
+      // `context.fileName: 'AGENTS.md'` would otherwise see init
+      // create `QWEN.md` while the rest of the workspace reads a
+      // different file.
+      const filename = contextFilename;
+      // #4282 gpt-5.5 C1 fold-in: `context.fileName` is settings-
+      // controlled. A daemon configured with `context.fileName:
+      // "../outside.md"` would otherwise resolve outside
+      // `boundWorkspace` and let this strict-gated mutation create
+      // or truncate a file outside the workspace boundary. Resolve
+      // the joined path and reject anything that escapes.
       const target = path.resolve(boundWorkspace, filename);
       const withinWorkspace =
         target === boundWorkspace ||
@@ -3624,6 +3642,32 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
           `Configured workspace context filename ${JSON.stringify(filename)} ` +
             `resolves outside the bound workspace ${JSON.stringify(boundWorkspace)}. ` +
             `Refusing to write.`,
+        );
+      }
+      // #4282 fold-in 5 (Codex P2-4). The textual `withinWorkspace`
+      // and final-component `lstat` checks miss intermediate symlinks
+      // — e.g. `context.fileName: "docs/QWEN.md"` with `docs` a
+      // symlink to `/tmp` would let the later `writeFile(target)`
+      // follow the parent symlink and create or truncate outside
+      // `boundWorkspace`. Resolve the parent chain via
+      // `realpath`, walking up through any not-yet-existing ancestors,
+      // and verify the canonical parent stays within the canonical
+      // workspace.
+      const wsCanonical = await fs.realpath(boundWorkspace);
+      const parentCanonical = await canonicalizeExistingAncestor(
+        path.dirname(target),
+      );
+      const parentWithinWorkspace =
+        parentCanonical === wsCanonical ||
+        parentCanonical.startsWith(wsCanonical + path.sep);
+      if (!parentWithinWorkspace) {
+        throw new Error(
+          `Configured workspace context filename ${JSON.stringify(filename)} ` +
+            `has a parent path that resolves outside the bound workspace ` +
+            `(parent canonicalizes to ${JSON.stringify(parentCanonical)}, ` +
+            `workspace canonicalizes to ${JSON.stringify(wsCanonical)}). ` +
+            `Refusing to write — replace any symlinked parent directory ` +
+            `with a real directory before re-running init.`,
         );
       }
       // #4282 fold-in 2 (gpt-5.5 CV1): the textual `withinWorkspace`
@@ -3936,6 +3980,40 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
  * unbounded data; the operator wants to know which one they hit so
  * the path-mistake is obvious.
  */
+/**
+ * #4282 fold-in 5 (Codex P2-4). Resolve `inputPath` to its real
+ * filesystem path, walking up through directory components that
+ * don't yet exist on disk. Used by `initWorkspace` to make sure
+ * every parent directory of the target file canonicalizes inside
+ * the bound workspace — a symlink at any level (e.g. `docs/QWEN.md`
+ * with `docs -> /tmp`) would otherwise let `writeFile` escape the
+ * workspace boundary.
+ *
+ * The walk-up mirrors what `realpath` would do if it accepted
+ * non-existent terminal segments: the deepest extant ancestor
+ * dictates the canonical prefix, and any not-yet-created components
+ * inherit it. Hitting the filesystem root (`path.dirname(p) === p`)
+ * without finding anything that exists rethrows the underlying
+ * ENOENT — by that point the input was unrooted in a way the
+ * caller's contract can't honor.
+ */
+async function canonicalizeExistingAncestor(
+  inputPath: string,
+): Promise<string> {
+  let current = inputPath;
+  while (true) {
+    try {
+      return await fs.realpath(current);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | null | undefined)?.code;
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') throw err;
+      const parent = path.dirname(current);
+      if (parent === current) throw err;
+      current = parent;
+    }
+  }
+}
+
 function describeStatKind(stats: import('node:fs').Stats): string {
   if (stats.isDirectory()) return 'directory';
   if (stats.isSymbolicLink()) return 'symlink';

--- a/packages/cli/src/serve/httpAcpBridge.ts
+++ b/packages/cli/src/serve/httpAcpBridge.ts
@@ -4040,6 +4040,16 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
  * unbounded data; the operator wants to know which one they hit so
  * the path-mistake is obvious.
  */
+function describeStatKind(stats: import('node:fs').Stats): string {
+  if (stats.isDirectory()) return 'directory';
+  if (stats.isSymbolicLink()) return 'symlink';
+  if (stats.isCharacterDevice()) return 'character device';
+  if (stats.isBlockDevice()) return 'block device';
+  if (stats.isFIFO()) return 'named pipe (FIFO)';
+  if (stats.isSocket()) return 'socket';
+  return 'non-regular file';
+}
+
 /**
  * #4282 fold-in 5 (Codex P2-4). Resolve `inputPath` to its real
  * filesystem path, walking up through directory components that
@@ -4072,16 +4082,6 @@ async function canonicalizeExistingAncestor(
       current = parent;
     }
   }
-}
-
-function describeStatKind(stats: import('node:fs').Stats): string {
-  if (stats.isDirectory()) return 'directory';
-  if (stats.isSymbolicLink()) return 'symlink';
-  if (stats.isCharacterDevice()) return 'character device';
-  if (stats.isBlockDevice()) return 'block device';
-  if (stats.isFIFO()) return 'named pipe (FIFO)';
-  if (stats.isSocket()) return 'socket';
-  return 'non-regular file';
 }
 
 /**

--- a/packages/cli/src/serve/httpAcpBridge.ts
+++ b/packages/cli/src/serve/httpAcpBridge.ts
@@ -2131,8 +2131,10 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     const sessions = Array.from(byId.values());
     let successCount = 0;
     let failureCount = 0;
+    let skippedCount = 0;
     for (const entry of sessions) {
       if (skipSessionId !== undefined && entry.sessionId === skipSessionId) {
+        skippedCount += 1;
         continue;
       }
       try {
@@ -2163,7 +2165,18 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     // dropped the event. Single-session workspaces with the requester
     // skipped naturally produce zero recipients — that's not an
     // "all dropped" condition, just nobody to deliver to.
-    const eligible = sessions.length - (skipSessionId !== undefined ? 1 : 0);
+    //
+    // #4297 fold-in 6 (deepseek S1, addresses #3261079572): count the
+    // sessions we actually skipped instead of unconditionally
+    // subtracting 1 when `skipSessionId` is set. The previous shape
+    // suppressed the all-dropped alarm when a non-matching
+    // `skipSessionId` was passed (caller mistake, stale id, or the
+    // matching session was just torn down) — eligible would land at
+    // `sessions.length - 1` even though every session was published
+    // to and every publish failed. Counting actual skips makes the
+    // alarm condition self-consistent regardless of how the caller
+    // mis-uses the param.
+    const eligible = sessions.length - skippedCount;
     if (eligible > 0 && successCount === 0 && !shuttingDown) {
       writeStderrLine(
         `qwen serve: broadcastWorkspaceEvent type=${envelope.type} dropped on ALL ${failureCount} session bus(es); SSE subscribers will miss this event (GET fallback still authoritative)`,

--- a/packages/cli/src/serve/index.ts
+++ b/packages/cli/src/serve/index.ts
@@ -88,8 +88,18 @@ export {
 export {
   createHttpAcpBridge,
   defaultSpawnChannelFactory,
+  // #4297 fold-in 1 (16:32:44-round S2): export every typed error
+  // class that `sendBridgeError` matches via `instanceof`. External
+  // embeds that want to recognize these errors (parallel to how
+  // they already match `WorkspaceInitConflictError` /
+  // `SessionNotFoundError`) need them on the public barrel; without
+  // this they have to deep-import `./httpAcpBridge.js`.
+  McpServerNotFoundError,
+  McpServerRestartFailedError,
   SessionNotFoundError,
   WorkspaceInitConflictError,
+  WorkspaceInitPathEscapeError,
+  WorkspaceInitSymlinkError,
   type AcpChannel,
   type BridgeOptions,
   type BridgeSession,

--- a/packages/cli/src/serve/runQwenServe.test.ts
+++ b/packages/cli/src/serve/runQwenServe.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from 'vitest';
+import { extractContextFilename } from './runQwenServe.js';
+
+/**
+ * #4297 fold-in 7 (deepseek S1, addresses #3262690842). Lock the
+ * `context.fileName` extraction logic so a regression doesn't
+ * silently re-enable the P2-1 bug (init writes default `QWEN.md`
+ * even when the workspace configured `AGENTS.md` etc.). The four
+ * branches the suggestion called out are exercised explicitly here;
+ * the runQwenServe boot path itself stays integration-tested
+ * end-to-end via the daemon-process tests in
+ * `integration-tests/cli/qwen-serve-routes.test.ts`.
+ */
+describe('extractContextFilename (#4297 fold-in 7 P2-1 helper)', () => {
+  it('returns a trimmed string when given a non-empty string', () => {
+    expect(extractContextFilename('AGENTS.md')).toBe('AGENTS.md');
+    expect(extractContextFilename('  CUSTOM.md  ')).toBe('CUSTOM.md');
+  });
+
+  it('returns undefined for empty / whitespace-only strings', () => {
+    expect(extractContextFilename('')).toBeUndefined();
+    expect(extractContextFilename('   ')).toBeUndefined();
+    expect(extractContextFilename('\n\t')).toBeUndefined();
+  });
+
+  it('returns the first non-empty string when given an array', () => {
+    expect(extractContextFilename(['AGENTS.md', 'BACKUP.md'])).toBe(
+      'AGENTS.md',
+    );
+    // Skips empty and whitespace entries to find the first valid name.
+    expect(extractContextFilename(['', '  ', 'PRIMARY.md', 'OTHER.md'])).toBe(
+      'PRIMARY.md',
+    );
+    // Trims the picked element.
+    expect(extractContextFilename(['  CUSTOM.md  '])).toBe('CUSTOM.md');
+  });
+
+  it('returns undefined when the array has no string entries', () => {
+    expect(extractContextFilename([])).toBeUndefined();
+    expect(extractContextFilename(['', '  ', '\n'])).toBeUndefined();
+    // Non-string entries are filtered out — when nothing valid remains,
+    // the bridge falls back to its own default.
+    expect(
+      extractContextFilename([null, undefined, 42, { a: 1 }] as unknown[]),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined for non-string non-array inputs', () => {
+    // Hand-edited `settings.json` could land any of these shapes;
+    // the helper must NOT coerce (avoids the literal `[object Object]`
+    // filename that the previous `String(...)` cast produced).
+    expect(extractContextFilename(undefined)).toBeUndefined();
+    expect(extractContextFilename(null)).toBeUndefined();
+    expect(extractContextFilename(42)).toBeUndefined();
+    expect(extractContextFilename(true)).toBeUndefined();
+    expect(extractContextFilename({ fileName: 'AGENTS.md' })).toBeUndefined();
+  });
+});

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -50,6 +50,41 @@ function formatHostForUrl(host: string): string {
 }
 
 /**
+ * #4297 fold-in 7 (deepseek S1, addresses #3262690842). Pull the
+ * `context.fileName` snapshot out of merged settings into a typed
+ * string, falling back to `undefined` when the value is missing or
+ * malformed. Exported so the daemon entrypoint can extract it from
+ * a `LoadedSettings` instance and tests can validate the four
+ * branches (string / array-with-string / array-with-non-strings /
+ * non-string non-array) without spinning up a real daemon.
+ *
+ * Validation contract:
+ *   - non-empty string after trim → returned trimmed
+ *   - array → first non-empty string element after trim, or undefined
+ *   - anything else (object, number, boolean, undefined) → undefined
+ *
+ * Returning `undefined` is the bridge's signal to use its own
+ * `getCurrentGeminiMdFilename()` default — so a malformed value
+ * keeps the daemon alive rather than producing a garbage filename.
+ */
+export function extractContextFilename(value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    return trimmed === '' ? undefined : trimmed;
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) {
+      if (typeof entry === 'string') {
+        const trimmed = entry.trim();
+        if (trimmed !== '') return trimmed;
+      }
+    }
+    return undefined;
+  }
+  return undefined;
+}
+
+/**
  * #4282 fold-in 4 (qwen-latest C2). Per-workspace promise chain that
  * serializes settings read-modify-write cycles inside this process.
  *
@@ -325,21 +360,31 @@ export async function runQwenServe(
   // own `getCurrentGeminiMdFilename()` default — a sane recovery
   // posture that keeps the daemon alive instead of writing a
   // garbage filename.
-  const bootSettings = loadSettings(boundWorkspace);
-  const configuredFilename = bootSettings.merged.context?.fileName;
-  const firstStringInArray = (value: unknown): string | undefined => {
-    if (!Array.isArray(value)) return undefined;
-    for (const entry of value) {
-      if (typeof entry === 'string' && entry.trim() !== '') {
-        return entry.trim();
-      }
-    }
-    return undefined;
-  };
-  const contextFilenameForInit =
-    typeof configuredFilename === 'string' && configuredFilename.trim() !== ''
-      ? configuredFilename.trim()
-      : firstStringInArray(configuredFilename);
+  //
+  // #4297 fold-in 7 (qwen-latest critical, addresses #3262625091):
+  // wrap the boot-time `loadSettings` read in try/catch. A
+  // corrupted, malformed, or temporarily unreadable
+  // `settings.json` (partial write by a concurrent editor,
+  // permission denied, transient disk IO) used to throw
+  // synchronously and BLOCK DAEMON BOOT. Pre-PR this never
+  // happened because `loadSettings` was called lazily inside
+  // request handlers (which had their own error handling). We
+  // catch + log + fall back to the bridge's default filename so
+  // the daemon stays bootable.
+  let contextFilenameForInit: string | undefined;
+  try {
+    const bootSettings = loadSettings(boundWorkspace);
+    contextFilenameForInit = extractContextFilename(
+      bootSettings.merged.context?.fileName,
+    );
+  } catch (err) {
+    writeStderrLine(
+      `qwen serve: could not read settings for context.fileName ` +
+        `(${err instanceof Error ? err.message : String(err)}); ` +
+        `falling back to the daemon's default context filename. ` +
+        `Restart with a valid settings.json to use a custom name.`,
+    );
+  }
 
   const bridge =
     deps.bridge ??

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -315,17 +315,31 @@ export async function runQwenServe(
   // writes the same file the ACP child reads. Settings changes made
   // after daemon boot need a daemon restart to take effect — this
   // value rarely changes, and a snapshot avoids re-reading on every
-  // init request. `String` ↑ guard normalizes settings.json entries
-  // that aren't string-typed (hand-edited bad data); fall back to
-  // the default rather than crash the bridge.
+  // init request.
+  //
+  // #4297 fold-in 2 (copilot S2): only accept string-typed values.
+  // Hand-edited `settings.json` could land an object / number /
+  // nested array in `context.fileName`; the previous `String(...)`
+  // coerce would have produced a literal `"[object Object]"`
+  // filename. Falling back to `undefined` makes the bridge use its
+  // own `getCurrentGeminiMdFilename()` default — a sane recovery
+  // posture that keeps the daemon alive instead of writing a
+  // garbage filename.
   const bootSettings = loadSettings(boundWorkspace);
   const configuredFilename = bootSettings.merged.context?.fileName;
+  const firstStringInArray = (value: unknown): string | undefined => {
+    if (!Array.isArray(value)) return undefined;
+    for (const entry of value) {
+      if (typeof entry === 'string' && entry.trim() !== '') {
+        return entry.trim();
+      }
+    }
+    return undefined;
+  };
   const contextFilenameForInit =
     typeof configuredFilename === 'string' && configuredFilename.trim() !== ''
       ? configuredFilename.trim()
-      : Array.isArray(configuredFilename) && configuredFilename.length > 0
-        ? String(configuredFilename[0]).trim()
-        : undefined;
+      : firstStringInArray(configuredFilename);
 
   const bridge =
     deps.bridge ??

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -305,6 +305,28 @@ export async function runQwenServe(
     QWEN_SERVE_MCP_BUDGET_MODE: opts.mcpBudgetMode,
   };
 
+  // #4282 fold-in 5 (Codex P2-1). Snapshot the workspace's preferred
+  // context filename at boot. The daemon parent doesn't go through
+  // `loadCliConfig` (it spawns an ACP child that does), so the
+  // process-global `getCurrentGeminiMdFilename()` stays on the
+  // default `QWEN.md` even when the workspace has
+  // `context.fileName: 'AGENTS.md'`. Reading merged settings here
+  // and forwarding to the bridge ensures `POST /workspace/init`
+  // writes the same file the ACP child reads. Settings changes made
+  // after daemon boot need a daemon restart to take effect — this
+  // value rarely changes, and a snapshot avoids re-reading on every
+  // init request. `String` ↑ guard normalizes settings.json entries
+  // that aren't string-typed (hand-edited bad data); fall back to
+  // the default rather than crash the bridge.
+  const bootSettings = loadSettings(boundWorkspace);
+  const configuredFilename = bootSettings.merged.context?.fileName;
+  const contextFilenameForInit =
+    typeof configuredFilename === 'string' && configuredFilename.trim() !== ''
+      ? configuredFilename.trim()
+      : Array.isArray(configuredFilename) && configuredFilename.length > 0
+        ? String(configuredFilename[0]).trim()
+        : undefined;
+
   const bridge =
     deps.bridge ??
     createHttpAcpBridge({
@@ -320,6 +342,9 @@ export async function runQwenServe(
       // implementation wraps `buildEnvStatusFromProcess` and the
       // (lifted) `buildDaemonPreflightCells` body.
       statusProvider: createDaemonStatusProvider(),
+      ...(contextFilenameForInit !== undefined
+        ? { contextFilename: contextFilenameForInit }
+        : {}),
       // #4175 Wave 4 PR 17: `POST /session/:id/approval-mode` accepts
       // an opt-in `persist: true` flag. We re-load settings on each
       // persist call rather than caching a `LoadedSettings` handle —

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -35,10 +35,14 @@ import {
   InvalidPermissionOptionError,
   InvalidSessionMetadataError,
   MAX_WORKSPACE_PATH_LENGTH,
+  McpServerNotFoundError,
+  McpServerRestartFailedError,
   RestoreInProgressError,
   SessionLimitExceededError,
   SessionNotFoundError,
   WorkspaceInitConflictError,
+  WorkspaceInitPathEscapeError,
+  WorkspaceInitSymlinkError,
   WorkspaceMismatchError,
   type BridgeHeartbeatResult,
   type BridgeHeartbeatState,
@@ -2445,6 +2449,49 @@ describe('createServeApp', () => {
         existingSize: 1234,
       });
     });
+
+    it('400 + code:workspace_init_path_escape on WorkspaceInitPathEscapeError (#4297 fold-in 1, addresses #3260501161)', async () => {
+      // Without a typed mapping these used to fall through to 500, so
+      // an operator misreading their `context.fileName` would see a
+      // generic "daemon broken" error. 400 with structured body
+      // tells the operator exactly what's wrong.
+      const bridge = fakeBridge({
+        initWorkspaceImpl: async () => {
+          throw new WorkspaceInitPathEscapeError(
+            '../outside.md',
+            '/work/bound',
+          );
+        },
+      });
+      const app = createServeApp(tokenOpts, undefined, { bridge });
+      const res = await auth(request(app).post('/workspace/init')).send({});
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        code: 'workspace_init_path_escape',
+        filename: '../outside.md',
+        boundWorkspace: '/work/bound',
+      });
+    });
+
+    it('400 + code:workspace_init_symlink on WorkspaceInitSymlinkError (#4297 fold-in 1)', async () => {
+      const bridge = fakeBridge({
+        initWorkspaceImpl: async () => {
+          throw new WorkspaceInitSymlinkError(
+            '/work/bound/QWEN.md',
+            'target',
+            'Workspace context file "/work/bound/QWEN.md" is a symlink.',
+          );
+        },
+      });
+      const app = createServeApp(tokenOpts, undefined, { bridge });
+      const res = await auth(request(app).post('/workspace/init')).send({});
+      expect(res.status).toBe(400);
+      expect(res.body).toMatchObject({
+        code: 'workspace_init_symlink',
+        target: '/work/bound/QWEN.md',
+        kind: 'target',
+      });
+    });
   });
 
   describe('POST /workspace/mcp/:server/restart (#4175 Wave 4 PR 17)', () => {
@@ -2568,6 +2615,46 @@ describe('createServeApp', () => {
       expect(res.status).toBe(400);
       expect(res.body.code).toBe('invalid_server_name');
       expect(bridge.restartMcpServerCalls).toHaveLength(0);
+    });
+
+    it('404 + code:mcp_server_not_found when bridge throws McpServerNotFoundError (#4297 fold-in 1, addresses #3260501148)', async () => {
+      // Pin the `sendBridgeError` mapping under a route-layer test so
+      // a future change to the `instanceof McpServerNotFoundError`
+      // branch (e.g. cross-package bundling that breaks the prototype
+      // chain) fails CI rather than silently degrading to 500.
+      const bridge = fakeBridge({
+        restartMcpServerImpl: async () => {
+          throw new McpServerNotFoundError('ghost');
+        },
+      });
+      const app = createServeApp(tokenOpts, undefined, { bridge });
+      const res = await auth(
+        request(app).post('/workspace/mcp/ghost/restart'),
+      ).send({});
+      expect(res.status).toBe(404);
+      expect(res.body).toMatchObject({
+        code: 'mcp_server_not_found',
+        serverName: 'ghost',
+      });
+    });
+
+    it('502 + code:mcp_server_restart_failed when bridge throws McpServerRestartFailedError (#4297 fold-in 1)', async () => {
+      const bridge = fakeBridge({
+        restartMcpServerImpl: async () => {
+          throw new McpServerRestartFailedError('docs', 'DISCONNECTED');
+        },
+      });
+      const app = createServeApp(tokenOpts, undefined, { bridge });
+      const res = await auth(
+        request(app).post('/workspace/mcp/docs/restart'),
+      ).send({});
+      expect(res.status).toBe(502);
+      expect(res.body).toMatchObject({
+        code: 'mcp_server_restart_failed',
+        errorKind: 'protocol_error',
+        serverName: 'docs',
+        mcpStatus: 'DISCONNECTED',
+      });
     });
   });
 

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -44,6 +44,8 @@ import {
   SessionLimitExceededError,
   SessionNotFoundError,
   WorkspaceInitConflictError,
+  WorkspaceInitPathEscapeError,
+  WorkspaceInitSymlinkError,
   WorkspaceMismatchError,
   type HttpAcpBridge,
 } from './httpAcpBridge.js';
@@ -2366,6 +2368,33 @@ function sendBridgeError(
       code: 'workspace_init_conflict',
       path: err.path,
       existingSize: err.existingSize,
+    });
+    return;
+  }
+  if (err instanceof WorkspaceInitPathEscapeError) {
+    // #4297 fold-in 1 (16:32:44-round S1). The configured
+    // `context.fileName` resolves outside the bound workspace via
+    // path arithmetic. 400 because this is a misconfiguration that
+    // an operator can fix in workspace settings — not a daemon
+    // failure.
+    res.status(400).json({
+      error: err.message,
+      code: 'workspace_init_path_escape',
+      filename: err.filename,
+      boundWorkspace: err.boundWorkspace,
+    });
+    return;
+  }
+  if (err instanceof WorkspaceInitSymlinkError) {
+    // #4297 fold-in 1 (16:32:44-round S1). Either the target file is
+    // a symlink, or a parent directory is a symlink that escapes the
+    // workspace. Same 400 rationale as `WorkspaceInitPathEscapeError`
+    // — operator fix is "replace the symlink with a real file/dir."
+    res.status(400).json({
+      error: err.message,
+      code: 'workspace_init_symlink',
+      target: err.target,
+      kind: err.kind,
     });
     return;
   }

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -2831,6 +2831,68 @@ describe('setApprovalMode with folder trust', () => {
   });
 });
 
+describe('disabledTools runtime sync (#4282 fold-in 5 P2-2 / #4297 fold-in 5)', () => {
+  const baseParams: ConfigParameters = {
+    targetDir: '.',
+    debugMode: false,
+    model: 'test-model',
+    cwd: '.',
+  };
+
+  it('initializes from `disabledTools` ConfigParameters', () => {
+    const config = new Config({
+      ...baseParams,
+      disabledTools: ['Foo', 'Bar'],
+    });
+    expect(config.getDisabledTools()).toEqual(new Set(['Foo', 'Bar']));
+  });
+
+  it('defaults to an empty set when `disabledTools` is omitted', () => {
+    const config = new Config(baseParams);
+    expect(config.getDisabledTools()).toEqual(new Set());
+  });
+
+  it('setDisabledTools replaces the live snapshot for runtime sync', () => {
+    // The daemon's `acpAgent` MCP-restart handler calls
+    // `setDisabledTools(new Set(disabledList))` after re-reading
+    // workspace settings, so a `tools.disabled` toggle applied
+    // since this Config was constructed takes effect on the next
+    // `ToolRegistry.registerTool` call. Pin that contract so a
+    // future regression that drops the setter (or re-freezes the
+    // field) fails this test instead of silently re-enabling
+    // tools the user just disabled.
+    const config = new Config({
+      ...baseParams,
+      disabledTools: ['A', 'B'],
+    });
+    expect(config.getDisabledTools()).toEqual(new Set(['A', 'B']));
+    config.setDisabledTools(new Set(['B', 'C']));
+    expect(config.getDisabledTools()).toEqual(new Set(['B', 'C']));
+  });
+
+  it('setDisabledTools copies the input — caller mutations do not leak', () => {
+    // The setter constructs a fresh `new Set(disabled)` from the
+    // input, so a caller that holds a reference to the input set
+    // and later mutates it cannot retroactively change the live
+    // Config snapshot. Locks this defensive-copy contract.
+    const config = new Config(baseParams);
+    const liveInput = new Set(['X']);
+    config.setDisabledTools(liveInput);
+    liveInput.add('Y');
+    expect(config.getDisabledTools()).toEqual(new Set(['X']));
+    expect(config.getDisabledTools().has('Y')).toBe(false);
+  });
+
+  it('setDisabledTools accepts an empty set (clears the live snapshot)', () => {
+    const config = new Config({
+      ...baseParams,
+      disabledTools: ['A', 'B'],
+    });
+    config.setDisabledTools(new Set());
+    expect(config.getDisabledTools()).toEqual(new Set());
+  });
+});
+
 describe('BaseLlmClient Lifecycle', () => {
   const MODEL = 'gemini-pro';
   const SANDBOX: SandboxConfig = {

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -7,7 +7,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Mock } from 'vitest';
 import type { ConfigParameters, SandboxConfig } from './config.js';
-import { Config, ApprovalMode, MCPServerConfig } from './config.js';
+import {
+  Config,
+  ApprovalMode,
+  MCPServerConfig,
+  TrustGateError,
+} from './config.js';
 import { Storage } from './storage.js';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
@@ -2227,17 +2232,28 @@ describe('setApprovalMode with folder trust', () => {
     cwd: '.',
   };
 
-  it('should throw an error when setting YOLO mode in an untrusted folder', () => {
+  it('should throw a TrustGateError when setting YOLO mode in an untrusted folder', () => {
+    // #4297 fold-in 1 (16:32:44-round S3): assert on the typed class,
+    // not just message text. The 403 mapping in `serve/server.ts`
+    // matches `err instanceof TrustGateError`; an accidental revert
+    // to `throw new Error(...)` would silently downgrade to 500
+    // while the message text test kept passing.
     const config = new Config(baseParams);
     vi.spyOn(config, 'isTrustedFolder').mockReturnValue(false);
+    expect(() => config.setApprovalMode(ApprovalMode.YOLO)).toThrow(
+      TrustGateError,
+    );
     expect(() => config.setApprovalMode(ApprovalMode.YOLO)).toThrow(
       'Cannot enable privileged approval modes in an untrusted folder.',
     );
   });
 
-  it('should throw an error when setting AUTO_EDIT mode in an untrusted folder', () => {
+  it('should throw a TrustGateError when setting AUTO_EDIT mode in an untrusted folder', () => {
     const config = new Config(baseParams);
     vi.spyOn(config, 'isTrustedFolder').mockReturnValue(false);
+    expect(() => config.setApprovalMode(ApprovalMode.AUTO_EDIT)).toThrow(
+      TrustGateError,
+    );
     expect(() => config.setApprovalMode(ApprovalMode.AUTO_EDIT)).toThrow(
       'Cannot enable privileged approval modes in an untrusted folder.',
     );

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2304,9 +2304,24 @@ export class Config {
   /**
    * Returns the read-only set of tool names hidden from this Config's
    * ToolRegistry. Consulted by `ToolRegistry.registerTool` and
-   * `ToolRegistry.registerFactory` to skip registration. Toggling at
-   * runtime requires re-spawning the ACP child (the set is frozen at
-   * construction time). See `disabledTools` in ConfigParameters.
+   * `ToolRegistry.registerFactory` to skip registration.
+   *
+   * Mutability semantics (#4282 fold-in 5 P2-2): the snapshot is
+   * mutable via `setDisabledTools()` so the daemon's
+   * `setWorkspaceToolEnabled` route can re-sync the set after a
+   * `tools.disabled` settings write — without that sync, the
+   * documented "toggle + restart" workflow would re-register the
+   * just-disabled MCP tool against the bootstrap snapshot.
+   *
+   * Already-registered tools are NOT retroactively unregistered:
+   * `ToolRegistry` consults the set at registration time only, so a
+   * mid-session disable only takes effect on the next `registerTool`
+   * call (next ACP child spawn, MCP rediscover, etc.). This matches
+   * the documented "toggling does not unregister live tools"
+   * contract.
+   *
+   * See `disabledTools` in ConfigParameters and `setDisabledTools`
+   * for the runtime sync entry point.
    */
   getDisabledTools(): ReadonlySet<string> {
     return this.disabledTools;

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -766,7 +766,15 @@ export class Config {
   private readonly allowedTools: string[] | undefined;
   private readonly excludeTools: string[] | undefined;
   private readonly disabledSlashCommands: readonly string[];
-  private readonly disabledTools: ReadonlySet<string>;
+  // #4282 fold-in 5 (Codex P2-2). `disabledTools` is set at construction
+  // time but can be re-synced by the daemon mutation surface
+  // (`setWorkspaceToolEnabled` propagates through ACP) so a subsequent
+  // `discoverMcpToolsForServer` sees the latest disabled set instead
+  // of the bootstrap snapshot. Stays `ReadonlySet` for callers; the
+  // setter swaps the reference rather than mutating in place so any
+  // captured reference (e.g. by ToolRegistry mid-iteration) remains
+  // self-consistent.
+  private disabledTools: ReadonlySet<string>;
   private readonly permissionsAllow: string[];
   private readonly permissionsAsk: string[];
   private readonly permissionsDeny: string[];
@@ -2302,6 +2310,24 @@ export class Config {
    */
   getDisabledTools(): ReadonlySet<string> {
     return this.disabledTools;
+  }
+
+  /**
+   * #4282 fold-in 5 (Codex P2-2). Replace the in-process `disabledTools`
+   * snapshot with a fresh set sourced from the workspace settings.
+   * Intended for the `qwen serve` mutation surface
+   * (`setWorkspaceToolEnabled` → ACP `qwen/control/...` → here): the
+   * settings file is the source of truth, and this setter keeps the
+   * in-memory Config in sync so a subsequent MCP rediscovery / next
+   * tool registration honors the just-toggled value.
+   *
+   * Already-registered tools are NOT retroactively unregistered —
+   * `ToolRegistry` consults the set at registration time only, which
+   * matches the documented "toggling does not unregister live tools"
+   * contract.
+   */
+  setDisabledTools(disabled: ReadonlySet<string>): void {
+    this.disabledTools = new Set(disabled);
   }
 
   getToolCallCommand(): string | undefined {

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -91,6 +91,15 @@ export interface DaemonClientOptions {
 }
 
 const DEFAULT_FETCH_TIMEOUT_MS = 30_000;
+/**
+ * #4282 fold-in 5 (Codex P2-3). The daemon's `MCP_RESTART_TIMEOUT_MS`
+ * (5 minutes — see `httpAcpBridge.ts`) is the upper bound on a single
+ * MCP rediscovery; the SDK matches that ceiling so a slow but valid
+ * stdio restart isn't aborted client-side while the daemon is still
+ * working. Callers needing a tighter or looser cap pass their own
+ * `timeoutMs` to `restartMcpServer`.
+ */
+const MCP_RESTART_DEFAULT_TIMEOUT_MS = 300_000;
 const CLIENT_ID_HEADER = 'X-Qwen-Client-Id';
 
 /**
@@ -235,6 +244,7 @@ export class DaemonClient {
     url: string,
     init: RequestInit = {},
     consume?: (res: Response) => Promise<T>,
+    perCallTimeoutMs?: number,
   ): Promise<T> {
     // BRN1o: when `consume` is provided, the timer must remain
     // armed through the entire callback (body read + parse). The
@@ -246,7 +256,22 @@ export class DaemonClient {
     // composed abort signal still flows through to fetch's body
     // stream, so an in-progress `res.json()` rejects cleanly when
     // the timer fires.
-    if (!this.fetchTimeoutMs || !Number.isFinite(this.fetchTimeoutMs)) {
+    //
+    // #4282 fold-in 5 (Codex P2-3): `perCallTimeoutMs` lets a single
+    // call (e.g. `restartMcpServer`, where the daemon waits up to
+    // 300s for MCP rediscovery) override the client-wide default.
+    // A finite positive override wins; non-finite / non-positive
+    // values are coerced to "use the client default" so callers
+    // can pass a derived expression without defending against NaN.
+    let effectiveTimeoutMs = this.fetchTimeoutMs;
+    if (
+      perCallTimeoutMs !== undefined &&
+      Number.isFinite(perCallTimeoutMs) &&
+      perCallTimeoutMs > 0
+    ) {
+      effectiveTimeoutMs = perCallTimeoutMs;
+    }
+    if (!effectiveTimeoutMs || !Number.isFinite(effectiveTimeoutMs)) {
       const res = await this._fetch(url, init);
       if (consume) return consume(res);
       return res as unknown as T;
@@ -263,7 +288,7 @@ export class DaemonClient {
     const ctrl = new AbortController();
     const timer = setTimeout(() => {
       ctrl.abort(new DOMException('The operation timed out', 'TimeoutError'));
-    }, this.fetchTimeoutMs);
+    }, effectiveTimeoutMs);
     if (typeof timer === 'object' && timer && 'unref' in timer) {
       (timer as { unref: () => void }).unref();
     }
@@ -936,11 +961,18 @@ export class DaemonClient {
    * Only hard errors (unknown server name, no live ACP channel)
    * surface as non-2xx.
    *
+   * #4282 fold-in 5 (Codex P2-3): the daemon-side restart waits up to
+   * 5 minutes for stdio MCP discovery; the SDK matches that budget by
+   * default so a slow but valid restart isn't aborted client-side
+   * while the daemon continues working. Callers can pass a custom
+   * `timeoutMs` when their threat model needs a tighter cap, or `0`
+   * to disable the timeout entirely.
+   *
    * Pre-flight `caps.features.workspace_mcp_restart` before calling.
    */
   async restartMcpServer(
     serverName: string,
-    opts?: { clientId?: string },
+    opts?: { clientId?: string; timeoutMs?: number },
   ): Promise<DaemonMcpRestartResult> {
     return await this.fetchWithTimeout(
       `${this.baseUrl}/workspace/mcp/${encodeURIComponent(serverName)}/restart`,
@@ -961,6 +993,7 @@ export class DaemonClient {
         }
         return (await res.json()) as DaemonMcpRestartResult;
       },
+      opts?.timeoutMs ?? MCP_RESTART_DEFAULT_TIMEOUT_MS,
     );
   }
 

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -260,14 +260,20 @@ export class DaemonClient {
     // #4282 fold-in 5 (Codex P2-3): `perCallTimeoutMs` lets a single
     // call (e.g. `restartMcpServer`, where the daemon waits up to
     // 300s for MCP rediscovery) override the client-wide default.
-    // A finite positive override wins; non-finite / non-positive
-    // values are coerced to "use the client default" so callers
-    // can pass a derived expression without defending against NaN.
+    //
+    // #4297 fold-in 2 (copilot + wenshao C1): accept finite,
+    // non-negative values — including `0`, which the
+    // `restartMcpServer` JSDoc documents as "disable the timeout
+    // entirely". Zero falls through to the no-timeout branch below
+    // via the `!effectiveTimeoutMs` truthiness check. NaN / negative
+    // inputs still coerce back to the client-wide default so callers
+    // can pass a derived expression without defending the math at
+    // every site.
     let effectiveTimeoutMs = this.fetchTimeoutMs;
     if (
       perCallTimeoutMs !== undefined &&
       Number.isFinite(perCallTimeoutMs) &&
-      perCallTimeoutMs > 0
+      perCallTimeoutMs >= 0
     ) {
       effectiveTimeoutMs = perCallTimeoutMs;
     }

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -1536,11 +1536,26 @@ describe('DaemonClient', () => {
       // regression that ignores the 0 override would abort almost
       // immediately. The slow stub resolves after 50ms — well past
       // the 1ms default but only because 0 disables the timer.
+      //
+      // #4297 fold-in 4 (wenshao critical, addresses #3260810242):
+      // the stub must observe `init.signal` and reject on abort.
+      // Without the listener, a regression where the override is
+      // ignored fires the AbortController at 1ms but the stub never
+      // sees it — the promise stays pending until the 50ms
+      // `resolveResponse` wins, leaving the test green and the
+      // "0 disables timeout" contract unprotected. Mirrors the
+      // listener pattern in the two sibling tests above.
       let resolveResponse: ((v: Response) => void) | undefined;
       const slowFetch = vi.fn(
-        () =>
-          new Promise<Response>((resolve) => {
+        (_input: RequestInfo | URL, init?: { signal?: AbortSignal | null }) =>
+          new Promise<Response>((resolve, reject) => {
             resolveResponse = resolve;
+            init?.signal?.addEventListener('abort', () => {
+              reject(
+                init.signal!.reason ??
+                  new DOMException('aborted', 'AbortError'),
+              );
+            });
           }),
       );
       const client = new DaemonClient({

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -1456,13 +1456,26 @@ describe('DaemonClient', () => {
       // Simulate a 1.2s response with the default 1s `fetchTimeoutMs`
       // — without the override the call would timeout; with it the
       // call resolves successfully.
-      let resolveResponse:
-        | ((v: import('undici-types').Response) => void)
-        | undefined;
+      //
+      // #4297 fold-in 2 (copilot, wenshao C2): the stub must
+      // observe `init.signal` so a regression that removes the
+      // per-call override (and thus the 1s default fires) actually
+      // rejects the in-flight promise. The previous version resolved
+      // the response unconditionally and the test passed even when
+      // the abort signal had already fired — false-negative coverage.
+      let resolveResponse: ((v: Response) => void) | undefined;
+      let rejectResponse: ((reason: unknown) => void) | undefined;
       const slowFetch = vi.fn(
-        () =>
-          new Promise<Response>((resolve) => {
-            resolveResponse = resolve as unknown as (v: Response) => void;
+        (_input: RequestInfo | URL, init?: { signal?: AbortSignal | null }) =>
+          new Promise<Response>((resolve, reject) => {
+            resolveResponse = resolve;
+            rejectResponse = reject;
+            init?.signal?.addEventListener('abort', () => {
+              reject(
+                init.signal!.reason ??
+                  new DOMException('aborted', 'AbortError'),
+              );
+            });
           }),
       );
       const client = new DaemonClient({
@@ -1472,14 +1485,17 @@ describe('DaemonClient', () => {
       });
       const inflight = client.restartMcpServer('docs');
       // Resolve the promise after the client default would have timed
-      // out — proving the per-call override extends the budget.
+      // out — proving the per-call override extends the budget. The
+      // abort listener above guarantees that if the override is ever
+      // removed, this resolve never fires (the abort rejects first).
+      void rejectResponse;
       setTimeout(() => {
         resolveResponse?.(
           jsonResponse(200, {
             serverName: 'docs',
             restarted: true,
             durationMs: 1200,
-          }) as unknown as import('undici-types').Response,
+          }),
         );
       }, 1_200);
       await expect(inflight).resolves.toMatchObject({
@@ -1491,18 +1507,18 @@ describe('DaemonClient', () => {
     it('honors a caller-provided `timeoutMs` override (#4282 fold-in 5 P2-3)', async () => {
       // When the caller sets a tighter cap, the per-call override
       // wins over the 5-minute default. Verify by passing a 50ms
-      // budget against a slow stub — the call must abort with a
-      // TimeoutError.
+      // budget against a stub that rejects only when its
+      // `init.signal` aborts — proving the abort actually fired
+      // rather than relying on a sleep racing the timeout.
       const slowFetch = vi.fn(
-        () =>
+        (_input: RequestInfo | URL, init?: { signal?: AbortSignal | null }) =>
           new Promise<Response>((_resolve, reject) => {
-            // Never resolve — wait for the caller's timeout to kick in.
-            // The AbortSignal coming through `init.signal` triggers
-            // this rejection so the timer doesn't leak.
-            setTimeout(
-              () => reject(new DOMException('aborted', 'AbortError')),
-              500,
-            );
+            init?.signal?.addEventListener('abort', () => {
+              reject(
+                init.signal!.reason ??
+                  new DOMException('aborted', 'AbortError'),
+              );
+            });
           }),
       );
       const client = new DaemonClient({
@@ -1512,6 +1528,40 @@ describe('DaemonClient', () => {
       await expect(
         client.restartMcpServer('docs', { timeoutMs: 50 }),
       ).rejects.toThrow();
+    });
+
+    it('honors `timeoutMs: 0` as "disable the timeout" (#4297 fold-in 2 C1)', async () => {
+      // The JSDoc on `restartMcpServer` documents `0` as "disable
+      // the timeout entirely". Use a 1ms client-wide default so a
+      // regression that ignores the 0 override would abort almost
+      // immediately. The slow stub resolves after 50ms — well past
+      // the 1ms default but only because 0 disables the timer.
+      let resolveResponse: ((v: Response) => void) | undefined;
+      const slowFetch = vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveResponse = resolve;
+          }),
+      );
+      const client = new DaemonClient({
+        baseUrl: 'http://daemon',
+        fetch: slowFetch as unknown as typeof globalThis.fetch,
+        fetchTimeoutMs: 1,
+      });
+      const inflight = client.restartMcpServer('docs', { timeoutMs: 0 });
+      setTimeout(() => {
+        resolveResponse?.(
+          jsonResponse(200, {
+            serverName: 'docs',
+            restarted: true,
+            durationMs: 50,
+          }),
+        );
+      }, 50);
+      await expect(inflight).resolves.toMatchObject({
+        serverName: 'docs',
+        restarted: true,
+      });
     });
   });
 

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -1447,6 +1447,72 @@ describe('DaemonClient', () => {
         status: 404,
       });
     });
+
+    it('survives a slow daemon response longer than the client default timeout (#4282 fold-in 5 P2-3)', async () => {
+      // The daemon-side restart waits up to 300s for stdio MCP
+      // discovery. The client-wide `fetchTimeoutMs` defaults to 30s,
+      // so without the per-call override, a valid 60s+ restart would
+      // be aborted client-side while the daemon kept working.
+      // Simulate a 1.2s response with the default 1s `fetchTimeoutMs`
+      // — without the override the call would timeout; with it the
+      // call resolves successfully.
+      let resolveResponse:
+        | ((v: import('undici-types').Response) => void)
+        | undefined;
+      const slowFetch = vi.fn(
+        () =>
+          new Promise<Response>((resolve) => {
+            resolveResponse = resolve as unknown as (v: Response) => void;
+          }),
+      );
+      const client = new DaemonClient({
+        baseUrl: 'http://daemon',
+        fetch: slowFetch as unknown as typeof globalThis.fetch,
+        fetchTimeoutMs: 1_000,
+      });
+      const inflight = client.restartMcpServer('docs');
+      // Resolve the promise after the client default would have timed
+      // out — proving the per-call override extends the budget.
+      setTimeout(() => {
+        resolveResponse?.(
+          jsonResponse(200, {
+            serverName: 'docs',
+            restarted: true,
+            durationMs: 1200,
+          }) as unknown as import('undici-types').Response,
+        );
+      }, 1_200);
+      await expect(inflight).resolves.toMatchObject({
+        serverName: 'docs',
+        restarted: true,
+      });
+    });
+
+    it('honors a caller-provided `timeoutMs` override (#4282 fold-in 5 P2-3)', async () => {
+      // When the caller sets a tighter cap, the per-call override
+      // wins over the 5-minute default. Verify by passing a 50ms
+      // budget against a slow stub — the call must abort with a
+      // TimeoutError.
+      const slowFetch = vi.fn(
+        () =>
+          new Promise<Response>((_resolve, reject) => {
+            // Never resolve — wait for the caller's timeout to kick in.
+            // The AbortSignal coming through `init.signal` triggers
+            // this rejection so the timer doesn't leak.
+            setTimeout(
+              () => reject(new DOMException('aborted', 'AbortError')),
+              500,
+            );
+          }),
+      );
+      const client = new DaemonClient({
+        baseUrl: 'http://daemon',
+        fetch: slowFetch as unknown as typeof globalThis.fetch,
+      });
+      await expect(
+        client.restartMcpServer('docs', { timeoutMs: 50 }),
+      ).rejects.toThrow();
+    });
   });
 
   describe('error coercion', () => {


### PR DESCRIPTION
## Summary

Follow-up to PR #4282 (Wave 4 PR 17 — `feat(serve): approval / tools / init / MCP-restart mutation routes`) addressing four P2-severity issues flagged by Codex's `/review` after the squash-merge to main. All four are real correctness bugs in the code shipped via #4282; none can be reproduced by the existing test suite, so the fixes ship with five new unit tests.

## Issues fixed

**P2-1 — Read workspace `context.fileName` for `POST /workspace/init`.** The daemon parent never calls `loadCliConfig`, so the process-global `getCurrentGeminiMdFilename()` stays on the default `QWEN.md` even when the workspace's merged settings configure `context.fileName: 'AGENTS.md'`. `runQwenServe` now snapshots the value at boot and forwards via `BridgeOptions.contextFilename`, so init writes the same file the ACP child reads. (`packages/cli/src/serve/{httpAcpBridge,runQwenServe}.ts`)

**P2-2 — Restart MCP servers with a fresh `disabledTools` snapshot.** `Config.disabledTools` was `private readonly` and frozen at construction time; `setWorkspaceToolEnabled` only updated `settings.json`. The documented "toggle + restart" workflow re-registered the just-disabled MCP tool because `discoverMcpToolsForServer` walks `ToolRegistry.registerTool`, which consults the bootstrap snapshot. Added `Config.setDisabledTools()` plus a re-read at the ACP restart handler so the next discovery honors the latest set. Already-registered tools still aren't retroactively unregistered (matches the existing documented contract). (`packages/core/src/config/config.ts`, `packages/cli/src/acp-integration/acpAgent.ts`)

**P2-3 — Match the SDK `restartMcpServer` timeout to the daemon's 5-minute restart budget.** Bridge-side `MCP_RESTART_TIMEOUT_MS` is 300s; SDK helper used the client-wide 30s `fetchTimeoutMs` default. Slow but valid stdio reconnects appeared to fail client-side while the daemon kept working. Plumbed a per-call `timeoutMs` through `fetchWithTimeout`, defaulting `restartMcpServer` to 5 minutes; callers can pass tighter or `0`-to-disable when their threat model differs. (`packages/sdk-typescript/src/daemon/DaemonClient.ts`)

**P2-4 — Reject symlinked parent directories before init writes.** `lstat(target)` only checked the final path component. With `context.fileName: 'docs/AGENTS.md'` and `docs -> /tmp` as a symlink, `writeFile` would follow the parent link and create or truncate outside `boundWorkspace`. Added `canonicalizeExistingAncestor` (walks up through ENOENT/ENOTDIR to the deepest extant ancestor, then `realpath`s) and verifies the canonical parent stays within the canonical workspace. (`packages/cli/src/serve/httpAcpBridge.ts`)

## Tests added

| File | Test |
|---|---|
| `packages/cli/src/serve/httpAcpBridge.test.ts` | `honors contextFilename from BridgeOptions (P2-1)` |
| `packages/cli/src/serve/httpAcpBridge.test.ts` | `rejects writes when a parent directory symlinks outside the workspace (P2-4)` |
| `packages/cli/src/serve/httpAcpBridge.test.ts` | `accepts writes when a parent directory is a real subdir (P2-4)` |
| `packages/sdk-typescript/test/unit/DaemonClient.test.ts` | `survives a slow daemon response longer than the client default timeout (P2-3)` |
| `packages/sdk-typescript/test/unit/DaemonClient.test.ts` | `honors a caller-provided timeoutMs override (P2-3)` |

P2-2 is exercised structurally by the new `Config.setDisabledTools` setter plus the existing `acpAgent` extMethod test surface; the live re-read path is acceptance-tested via the daemon end-to-end harness.

## Test plan

- [x] `npm run typecheck --workspace packages/cli --workspace packages/sdk-typescript --workspace packages/core` — clean
- [x] `npx vitest run packages/cli/src/serve/ packages/cli/src/acp-integration/ packages/sdk-typescript/test/unit packages/core/src/tools/tool-registry.test.ts packages/core/src/config/config.test.ts` — 1604/1604
- [ ] CI lint + full unit + integration sweep (per repo pre-merge gate)
- [ ] Manual smoke: configure a workspace with `context.fileName: 'AGENTS.md'`, hit `POST /workspace/init`, verify `AGENTS.md` (not `QWEN.md`) is created
- [ ] Manual smoke: `POST /workspace/tools/Bash/enable {enabled:false}` then `POST /workspace/mcp/<server>/restart` — verify the disabled tool stays unregistered
- [ ] Manual smoke: confirm a slow stdio MCP server (e.g. ~60s reconnect) no longer surfaces a client-side timeout

## Roll-forward / roll-back

- New behavior is opt-in via field presence (`contextFilename`, `timeoutMs`) — passing `undefined` reproduces the pre-fix shape exactly.
- `Config.setDisabledTools` is additive; pre-existing callers are unaffected.
- Reverting is a single `git revert <commit>` away.

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)
