### PR TITLE
fix(cli): remove QWEN_OAUTH gate from feedback dialog

### DIFF
--- a/packages/cli/src/ui/hooks/useFeedbackDialog.ts
+++ b/packages/cli/src/ui/hooks/useFeedbackDialog.ts
@@ -7,7 +7,6 @@ import {
   UserFeedbackEvent,
   type UserFeedbackRating,
   isNodeError,
-  AuthType,
   Storage,
 } from '@qwen-code/qwen-code-core';
 import { StreamingState, MessageType, type HistoryItem } from '../types.js';
@@ -145,16 +144,14 @@ export const useFeedbackDialog = ({
     const checkAndShowFeedback = () => {
       if (streamingState === StreamingState.Idle && history.length > 0) {
         // Show feedback dialog if:
-        // 1. User is authenticated via QWEN_OAUTH
-        // 2. Qwen logger is enabled (required for feedback submission)
-        // 3. User feedback is enabled in settings
-        // 4. The last message is an AI response
-        // 5. Random chance (25% probability)
-        // 6. Meets minimum requirements (tool calls > 10 OR user messages > 5)
-        // 7. Fatigue mechanism allows showing (not shown recently across sessions)
-        // 8. Not temporarily dismissed
+        // 1. Qwen logger is enabled (required for feedback submission)
+        // 2. User feedback is enabled in settings
+        // 3. The last message is an AI response
+        // 4. Random chance (25% probability)
+        // 5. Meets minimum requirements (tool calls > 10 OR user messages > 5)
+        // 6. Fatigue mechanism allows showing (not shown recently across sessions)
+        // 7. Not temporarily dismissed
         if (
-          config.getAuthType() !== AuthType.QWEN_OAUTH ||
           !config.getUsageStatisticsEnabled() ||
           settings.merged.ui?.enableUserFeedback === false ||
           !lastMessageIsAIResponse(history) ||


### PR DESCRIPTION
## Summary

The feedback dialog (point-up / point-down) in `useFeedbackDialog.ts`
was gated to only show for users authenticated via `AuthType.QWEN_OAUTH`.
After the Qwen OAuth free tier was closed on 2026-04-15 (#3203), the
addressable user pool drained quickly, and the `qwen-code.user_feedback`
telemetry signal has effectively gone dark.

This PR drops the `QWEN_OAUTH` check so any user who has opted into
usage statistics can be prompted for feedback.

## Why this is safe

The payload emitted by `logUserFeedbackEvent` ([qwen-logger.ts](packages/core/src/telemetry/qwen-logger/qwen-logger.ts:920)) contains only:

- `session_id`
- `rating` (1-3)
- `model`
- `approval_mode`
- `prompt_id`

No prompt content, conversation, file paths, or other PII. The two
remaining gates (`config.getUsageStatisticsEnabled()` and
`settings.ui.enableUserFeedback`) already provide the opt-in that
authorizes telemetry, so the `QWEN_OAUTH` gate was a redundant
narrowing rather than a privacy boundary.

## Changes

- Drop `config.getAuthType() !== AuthType.QWEN_OAUTH ||` from the
  dialog visibility check.
- Drop the now-unused `AuthType` import.
- Renumber the comment list (1-8 → 1-7).

## Validation

- \`npx tsc --noEmit\` clean for the modified file (pre-existing core
  dist staleness errors elsewhere are unrelated).
- \`npx eslint src/ui/hooks/useFeedbackDialog.ts\` clean.
- No existing test file for \`useFeedbackDialog.ts\`; the change is a
  one-line behavioral guard removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)