### PR TITLE
chore: add .github/release.yml to support skip-changelog label

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,3 +1,5 @@
+# Configuration for GitHub's automatic release notes generation
+# PRs with 'skip-changelog' label will be excluded from release notes
 changelog:
   exclude:
     labels:

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,4 +3,4 @@
 changelog:
   exclude:
     labels:
-      - skip-changelog
+      - 'skip-changelog'


### PR DESCRIPTION
## Summary

- 添加 `.github/release.yml` 配置文件，启用 GitHub 自动生成 release notes 的 label 过滤功能
- 配置 `skip-changelog` label，打上该 label 的 PR 不会出现在自动生成的 release notes 中

## 背景

后续需要对部分 WIP PR 打 `skip-changelog` label，避免未完成功能的中间 commit 出现在 release notes 里。需要先有这个配置文件，label 过滤才会生效。

参考文档：https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes

## Test plan

- [ ] 合并后，在下次创建 Release 时验证打了 `skip-changelog` label 的 PR 不出现在自动生成的 notes 中