### PR TITLE
fix(cli): keep /model switches session-scoped

### DIFF
--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -1862,6 +1862,8 @@ export default {
     "Canvia el model d'aquesta sessió (--default per persistir, --fast per al model de suggeriments).",
   'Default model': 'Model predeterminat',
   'session only': 'només aquesta sessió',
+  'Runtime models cannot be set as default.':
+    'Els models d’execució no es poden definir com a predeterminats.',
   'Persist the selected model as the default':
     'Persistir el model seleccionat com a predeterminat',
   'Enter to select, d to set default, ↑↓ to navigate, Esc to close':

--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -1858,6 +1858,15 @@ export default {
   'Manage extension settings': 'Gestionar la configuració de les extensions',
   'Desc:': 'Descripció:',
   'Ref:': 'Referència:',
+  'Switch the model for this session (--default to persist, --fast for suggestion model).':
+    "Canvia el model d'aquesta sessió (--default per persistir, --fast per al model de suggeriments).",
+  'Default model': 'Model predeterminat',
+  'session only': 'només aquesta sessió',
+  'Persist the selected model as the default':
+    'Persistir el model seleccionat com a predeterminat',
+  'Usage: /model --default <model-id>': 'Ús: /model --default <id-del-model>',
+  'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
+    'Model actual: {{model}}\nUseu "/model <model-id>" per canviar de model (només aquesta sessió), "/model --default <model-id>" per persistir-lo, o "/model --fast <model-id>" per definir el model ràpid.',
   '中国 (China)': 'Xina',
   '中国 (China) - 阿里云百炼': 'Xina - 阿里云百炼',
 };

--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -1864,6 +1864,8 @@ export default {
   'session only': 'només aquesta sessió',
   'Persist the selected model as the default':
     'Persistir el model seleccionat com a predeterminat',
+  'Enter to select, d to set default, ↑↓ to navigate, Esc to close':
+    'Intro per seleccionar, d per definir com a predeterminat, ↑↓ per navegar, Esc per tancar',
   'Usage: /model --default <model-id>': 'Ús: /model --default <id-del-model>',
   'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
     'Model actual: {{model}}\nUseu "/model <model-id>" per canviar de model (només aquesta sessió), "/model --default <model-id>" per persistir-lo, o "/model --fast <model-id>" per definir el model ràpid.',

--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -1867,6 +1867,8 @@ export default {
   'Enter to select, d to set default, ↑↓ to navigate, Esc to close':
     'Intro per seleccionar, d per definir com a predeterminat, ↑↓ per navegar, Esc per tancar',
   'Usage: /model --default <model-id>': 'Ús: /model --default <id-del-model>',
+  'Use either --default or --fast, not both.':
+    'Feu servir --default o --fast, però no tots dos.',
   'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
     'Model actual: {{model}}\nUseu "/model <model-id>" per canviar de model (només aquesta sessió), "/model --default <model-id>" per persistir-lo, o "/model --fast <model-id>" per definir el model ràpid.',
   '中国 (China)': 'Xina',

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -1906,6 +1906,8 @@ export default {
     'Modell für diese Sitzung wechseln (--default zum Speichern, --fast für das Vorschlagsmodell).',
   'Default model': 'Standardmodell',
   'session only': 'nur diese Sitzung',
+  'Runtime models cannot be set as default.':
+    'Laufzeitmodelle können nicht als Standard festgelegt werden.',
   'Persist the selected model as the default':
     'Ausgewähltes Modell als Standard speichern',
   'Enter to select, d to set default, ↑↓ to navigate, Esc to close':

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -1908,6 +1908,8 @@ export default {
   'session only': 'nur diese Sitzung',
   'Persist the selected model as the default':
     'Ausgewähltes Modell als Standard speichern',
+  'Enter to select, d to set default, ↑↓ to navigate, Esc to close':
+    'Eingabe zum Auswählen, d als Standard festlegen, ↑↓ zum Navigieren, Esc zum Schließen',
   'Usage: /model --default <model-id>':
     'Verwendung: /model --default <modell-id>',
   'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -1912,6 +1912,8 @@ export default {
     'Eingabe zum Auswählen, d als Standard festlegen, ↑↓ zum Navigieren, Esc zum Schließen',
   'Usage: /model --default <model-id>':
     'Verwendung: /model --default <modell-id>',
+  'Use either --default or --fast, not both.':
+    'Verwenden Sie entweder --default oder --fast, nicht beides.',
   'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
     'Aktuelles Modell: {{model}}\nVerwenden Sie "/model <model-id>", um das Modell zu wechseln (nur diese Sitzung), "/model --default <model-id>" zum Speichern oder "/model --fast <model-id>" zum Festlegen des schnellen Modells.',
   '中国 (China)': 'China',

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -1902,6 +1902,16 @@ export default {
   'Ref:': 'Referenz:',
   'Skills:': 'Fähigkeiten:',
   remote: 'entfernt',
+  'Switch the model for this session (--default to persist, --fast for suggestion model).':
+    'Modell für diese Sitzung wechseln (--default zum Speichern, --fast für das Vorschlagsmodell).',
+  'Default model': 'Standardmodell',
+  'session only': 'nur diese Sitzung',
+  'Persist the selected model as the default':
+    'Ausgewähltes Modell als Standard speichern',
+  'Usage: /model --default <model-id>':
+    'Verwendung: /model --default <modell-id>',
+  'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
+    'Aktuelles Modell: {{model}}\nVerwenden Sie "/model <model-id>", um das Modell zu wechseln (nur diese Sitzung), "/model --default <model-id>" zum Speichern oder "/model --fast <model-id>" zum Festlegen des schnellen Modells.',
   '中国 (China)': 'China',
   '中国 (China) - 阿里云百炼': 'China - 阿里云百炼',
 };

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1046,6 +1046,8 @@ export default {
     'Switch the model for this session (--default to persist, --fast for suggestion model).',
   'Default model': 'Default model',
   'session only': 'session only',
+  'Runtime models cannot be set as default.':
+    'Runtime models cannot be set as default.',
   'Persist the selected model as the default':
     'Persist the selected model as the default',
   'Usage: /model --default <model-id>': 'Usage: /model --default <model-id>',

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1049,6 +1049,8 @@ export default {
   'Persist the selected model as the default':
     'Persist the selected model as the default',
   'Usage: /model --default <model-id>': 'Usage: /model --default <model-id>',
+  'Use either --default or --fast, not both.':
+    'Use either --default or --fast, not both.',
   'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
     'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.',
   'Set a lighter model for prompt suggestions and speculative execution':

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1040,6 +1040,8 @@ export default {
   // ============================================================================
   'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).':
     'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).',
+  'Switch the model for this session (--default to persist, --fast for suggestion model).':
+    'Switch the model for this session (--default to persist, --fast for suggestion model).',
   'Set a lighter model for prompt suggestions and speculative execution':
     'Set a lighter model for prompt suggestions and speculative execution',
   'Content generator configuration not available.':

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -241,6 +241,8 @@ export default {
   'Esc to close': 'Esc to close',
   'Enter to select, ↑↓ to navigate, Esc to close':
     'Enter to select, ↑↓ to navigate, Esc to close',
+  'Enter to select, d to set default, ↑↓ to navigate, Esc to close':
+    'Enter to select, d to set default, ↑↓ to navigate, Esc to close',
   'Esc to go back': 'Esc to go back',
   'Enter to confirm, Esc to cancel': 'Enter to confirm, Esc to cancel',
   'Enter to select, ↑↓ to navigate, Esc to go back':
@@ -1042,6 +1044,10 @@ export default {
     'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).',
   'Switch the model for this session (--default to persist, --fast for suggestion model).':
     'Switch the model for this session (--default to persist, --fast for suggestion model).',
+  'Default model': 'Default model',
+  'Persist the selected model as the default':
+    'Persist the selected model as the default',
+  'Usage: /model --default <model-id>': 'Usage: /model --default <model-id>',
   'Set a lighter model for prompt suggestions and speculative execution':
     'Set a lighter model for prompt suggestions and speculative execution',
   'Content generator configuration not available.':

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -1045,9 +1045,12 @@ export default {
   'Switch the model for this session (--default to persist, --fast for suggestion model).':
     'Switch the model for this session (--default to persist, --fast for suggestion model).',
   'Default model': 'Default model',
+  'session only': 'session only',
   'Persist the selected model as the default':
     'Persist the selected model as the default',
   'Usage: /model --default <model-id>': 'Usage: /model --default <model-id>',
+  'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
+    'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.',
   'Set a lighter model for prompt suggestions and speculative execution':
     'Set a lighter model for prompt suggestions and speculative execution',
   'Content generator configuration not available.':

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -1902,6 +1902,8 @@ export default {
   'session only': 'session uniquement',
   'Persist the selected model as the default':
     'Persister le modèle sélectionné comme modèle par défaut',
+  'Enter to select, d to set default, ↑↓ to navigate, Esc to close':
+    'Entrée pour sélectionner, d pour définir par défaut, ↑↓ pour naviguer, Échap pour fermer',
   'Usage: /model --default <model-id>':
     'Utilisation : /model --default <id-modèle>',
   'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -1900,6 +1900,8 @@ export default {
     'Changer le modèle pour cette session (--default pour persister, --fast pour le modèle de suggestion).',
   'Default model': 'Modèle par défaut',
   'session only': 'session uniquement',
+  'Runtime models cannot be set as default.':
+    'Les modèles d’exécution ne peuvent pas être définis par défaut.',
   'Persist the selected model as the default':
     'Persister le modèle sélectionné comme modèle par défaut',
   'Enter to select, d to set default, ↑↓ to navigate, Esc to close':

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -1906,6 +1906,8 @@ export default {
     'Entrée pour sélectionner, d pour définir par défaut, ↑↓ pour naviguer, Échap pour fermer',
   'Usage: /model --default <model-id>':
     'Utilisation : /model --default <id-modèle>',
+  'Use either --default or --fast, not both.':
+    'Utilisez soit --default soit --fast, pas les deux.',
   'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
     'Modèle actuel : {{model}}\nUtilisez "/model <model-id>" pour changer de modèle (session uniquement), "/model --default <model-id>" pour le persister, ou "/model --fast <model-id>" pour définir le modèle rapide.',
   '中国 (China)': 'Chine',

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -1896,5 +1896,15 @@ export default {
   Auto: 'Automatique',
   Tokens: 'Jetons',
   tokens: 'jetons',
+  'Switch the model for this session (--default to persist, --fast for suggestion model).':
+    'Changer le modèle pour cette session (--default pour persister, --fast pour le modèle de suggestion).',
+  'Default model': 'Modèle par défaut',
+  'session only': 'session uniquement',
+  'Persist the selected model as the default':
+    'Persister le modèle sélectionné comme modèle par défaut',
+  'Usage: /model --default <model-id>':
+    'Utilisation : /model --default <id-modèle>',
+  'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
+    'Modèle actuel : {{model}}\nUtilisez "/model <model-id>" pour changer de modèle (session uniquement), "/model --default <model-id>" pour le persister, ou "/model --fast <model-id>" pour définir le modèle rapide.',
   '中国 (China)': 'Chine',
 };

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -1667,6 +1667,15 @@ export default {
   // === Same-as-English optimization ===
   ' (not in model registry)': '（モデルレジストリにありません）',
   'Attribution: commit': 'コミットの帰属表示',
+  'Switch the model for this session (--default to persist, --fast for suggestion model).':
+    'このセッションのモデルを切り替えます（--default で永続化、--fast で提案モデルを設定）。',
+  'Default model': 'デフォルトモデル',
+  'session only': 'このセッションのみ',
+  'Persist the selected model as the default':
+    '選択したモデルをデフォルトとして保存',
+  'Usage: /model --default <model-id>': '使い方: /model --default <model-id>',
+  'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
+    '現在のモデル: {{model}}\n"/model <model-id>" でモデルを切り替え（このセッションのみ）、"/model --default <model-id>" で保存、"/model --fast <model-id>" で高速モデルを設定します。',
   '中国 (China)': '中国',
   '中国 (China) - 阿里云百炼': '中国 - 阿里云百炼',
 };

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -1673,6 +1673,8 @@ export default {
   'session only': 'このセッションのみ',
   'Persist the selected model as the default':
     '選択したモデルをデフォルトとして保存',
+  'Enter to select, d to set default, ↑↓ to navigate, Esc to close':
+    'Enter で選択、d でデフォルトに設定、↑↓ で移動、Esc で閉じる',
   'Usage: /model --default <model-id>': '使い方: /model --default <model-id>',
   'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
     '現在のモデル: {{model}}\n"/model <model-id>" でモデルを切り替え（このセッションのみ）、"/model --default <model-id>" で保存、"/model --fast <model-id>" で高速モデルを設定します。',

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -1676,6 +1676,8 @@ export default {
   'Enter to select, d to set default, ↑↓ to navigate, Esc to close':
     'Enter で選択、d でデフォルトに設定、↑↓ で移動、Esc で閉じる',
   'Usage: /model --default <model-id>': '使い方: /model --default <model-id>',
+  'Use either --default or --fast, not both.':
+    '--default と --fast のどちらか一方のみを使用してください。',
   'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
     '現在のモデル: {{model}}\n"/model <model-id>" でモデルを切り替え（このセッションのみ）、"/model --default <model-id>" で保存、"/model --fast <model-id>" で高速モデルを設定します。',
   '中国 (China)': '中国',

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -1671,6 +1671,8 @@ export default {
     'このセッションのモデルを切り替えます（--default で永続化、--fast で提案モデルを設定）。',
   'Default model': 'デフォルトモデル',
   'session only': 'このセッションのみ',
+  'Runtime models cannot be set as default.':
+    'ランタイムモデルはデフォルトに設定できません。',
   'Persist the selected model as the default':
     '選択したモデルをデフォルトとして保存',
   'Enter to select, d to set default, ↑↓ to navigate, Esc to close':

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -1889,6 +1889,15 @@ export default {
   Status: 'Estado',
   'Status:': 'Estado:',
   Use: 'Uso',
+  'Switch the model for this session (--default to persist, --fast for suggestion model).':
+    'Trocar o modelo desta sessão (--default para persistir, --fast para o modelo de sugestões).',
+  'Default model': 'Modelo padrão',
+  'session only': 'somente nesta sessão',
+  'Persist the selected model as the default':
+    'Persistir o modelo selecionado como padrão',
+  'Usage: /model --default <model-id>': 'Uso: /model --default <id-do-modelo>',
+  'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
+    'Modelo atual: {{model}}\nUse "/model <model-id>" para trocar de modelo (somente nesta sessão), "/model --default <model-id>" para persistir, ou "/model --fast <model-id>" para definir o modelo rápido.',
   '中国 (China)': 'China',
   '中国 (China) - 阿里云百炼': 'China - 阿里云百炼',
 };

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -1893,6 +1893,8 @@ export default {
     'Trocar o modelo desta sessão (--default para persistir, --fast para o modelo de sugestões).',
   'Default model': 'Modelo padrão',
   'session only': 'somente nesta sessão',
+  'Runtime models cannot be set as default.':
+    'Modelos de runtime não podem ser definidos como padrão.',
   'Persist the selected model as the default':
     'Persistir o modelo selecionado como padrão',
   'Enter to select, d to set default, ↑↓ to navigate, Esc to close':

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -1895,6 +1895,8 @@ export default {
   'session only': 'somente nesta sessão',
   'Persist the selected model as the default':
     'Persistir o modelo selecionado como padrão',
+  'Enter to select, d to set default, ↑↓ to navigate, Esc to close':
+    'Enter para selecionar, d para definir como padrão, ↑↓ para navegar, Esc para fechar',
   'Usage: /model --default <model-id>': 'Uso: /model --default <id-do-modelo>',
   'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
     'Modelo atual: {{model}}\nUse "/model <model-id>" para trocar de modelo (somente nesta sessão), "/model --default <model-id>" para persistir, ou "/model --fast <model-id>" para definir o modelo rápido.',

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -1898,6 +1898,8 @@ export default {
   'Enter to select, d to set default, ↑↓ to navigate, Esc to close':
     'Enter para selecionar, d para definir como padrão, ↑↓ para navegar, Esc para fechar',
   'Usage: /model --default <model-id>': 'Uso: /model --default <id-do-modelo>',
+  'Use either --default or --fast, not both.':
+    'Use --default ou --fast, não ambos.',
   'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
     'Modelo atual: {{model}}\nUse "/model <model-id>" para trocar de modelo (somente nesta sessão), "/model --default <model-id>" para persistir, ou "/model --fast <model-id>" para definir o modelo rápido.',
   '中国 (China)': 'China',

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -1882,6 +1882,8 @@ export default {
     'Переключить модель для этой сессии (--default для сохранения, --fast для модели подсказок).',
   'Default model': 'Модель по умолчанию',
   'session only': 'только эта сессия',
+  'Runtime models cannot be set as default.':
+    'Модели времени выполнения нельзя сделать моделью по умолчанию.',
   'Persist the selected model as the default':
     'Сохранить выбранную модель как модель по умолчанию',
   'Enter to select, d to set default, ↑↓ to navigate, Esc to close':

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -1878,6 +1878,16 @@ export default {
   // === Same-as-English optimization ===
   ' (not in model registry)': ' (не в реестре моделей)',
   'start server': 'запустить сервер',
+  'Switch the model for this session (--default to persist, --fast for suggestion model).':
+    'Переключить модель для этой сессии (--default для сохранения, --fast для модели подсказок).',
+  'Default model': 'Модель по умолчанию',
+  'session only': 'только эта сессия',
+  'Persist the selected model as the default':
+    'Сохранить выбранную модель как модель по умолчанию',
+  'Usage: /model --default <model-id>':
+    'Использование: /model --default <model-id>',
+  'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
+    'Текущая модель: {{model}}\nИспользуйте "/model <model-id>" для переключения модели (только эта сессия), "/model --default <model-id>" для сохранения или "/model --fast <model-id>" для быстрой модели.',
   '中国 (China)': 'Китай',
   '中国 (China) - 阿里云百炼': 'Китай - 阿里云百炼',
 };

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -1888,6 +1888,8 @@ export default {
     'Enter — выбрать, d — сделать моделью по умолчанию, ↑↓ — навигация, Esc — закрыть',
   'Usage: /model --default <model-id>':
     'Использование: /model --default <model-id>',
+  'Use either --default or --fast, not both.':
+    'Используйте либо --default, либо --fast, но не оба.',
   'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
     'Текущая модель: {{model}}\nИспользуйте "/model <model-id>" для переключения модели (только эта сессия), "/model --default <model-id>" для сохранения или "/model --fast <model-id>" для быстрой модели.',
   '中国 (China)': 'Китай',

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -1884,6 +1884,8 @@ export default {
   'session only': 'только эта сессия',
   'Persist the selected model as the default':
     'Сохранить выбранную модель как модель по умолчанию',
+  'Enter to select, d to set default, ↑↓ to navigate, Esc to close':
+    'Enter — выбрать, d — сделать моделью по умолчанию, ↑↓ — навигация, Esc — закрыть',
   'Usage: /model --default <model-id>':
     'Использование: /model --default <model-id>',
   'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -892,6 +892,8 @@ export default {
   'session only': '僅此會話',
   'Persist the selected model as the default': '將所選模型持久化為預設模型',
   'Usage: /model --default <model-id>': '用法：/model --default <模型 ID>',
+  'Use either --default or --fast, not both.':
+    '只能使用 --default 或 --fast 其中之一，不能同時使用。',
   'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
     '目前模型：{{model}}\n使用 "/model <model-id>" 切換模型（僅此會話），使用 "/model --default <model-id>" 持久化，或使用 "/model --fast <model-id>" 設定快速模型。',
   'Set a lighter model for prompt suggestions and speculative execution':

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -884,6 +884,8 @@ export default {
     '生成摘要失敗 - 未從 LLM 響應中接收到文本內容',
   'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).':
     '切換此會話的模型（--fast 可設置建議模型）',
+  'Switch the model for this session (--default to persist, --fast for suggestion model).':
+    '切換此會話的模型（--default 可持久化，--fast 可設置建議模型）',
   'Set a lighter model for prompt suggestions and speculative execution':
     '設置用於輸入建議和推測執行的輕量模型',
   'Content generator configuration not available.': '內容生成器配置不可用',

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -890,6 +890,8 @@ export default {
     '切換此會話的模型（--default 可持久化，--fast 可設置建議模型）',
   'Default model': '預設模型',
   'session only': '僅此會話',
+  'Runtime models cannot be set as default.':
+    '執行階段模型不能設定為預設模型。',
   'Persist the selected model as the default': '將所選模型持久化為預設模型',
   'Usage: /model --default <model-id>': '用法：/model --default <模型 ID>',
   'Use either --default or --fast, not both.':

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -211,6 +211,8 @@ export default {
   'Esc to close': '按 Esc 關閉',
   'Enter to select, ↑↓ to navigate, Esc to close':
     'Enter 選擇，↑↓ 導航，Esc 關閉',
+  'Enter to select, d to set default, ↑↓ to navigate, Esc to close':
+    'Enter 選擇，d 設為預設，↑↓ 導航，Esc 關閉',
   'Esc to go back': '按 Esc 返回',
   'Enter to confirm, Esc to cancel': 'Enter 確認，Esc 取消',
   'Enter to select, ↑↓ to navigate, Esc to go back':
@@ -886,6 +888,9 @@ export default {
     '切換此會話的模型（--fast 可設置建議模型）',
   'Switch the model for this session (--default to persist, --fast for suggestion model).':
     '切換此會話的模型（--default 可持久化，--fast 可設置建議模型）',
+  'Default model': '預設模型',
+  'Persist the selected model as the default': '將所選模型持久化為預設模型',
+  'Usage: /model --default <model-id>': '用法：/model --default <模型 ID>',
   'Set a lighter model for prompt suggestions and speculative execution':
     '設置用於輸入建議和推測執行的輕量模型',
   'Content generator configuration not available.': '內容生成器配置不可用',

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -889,8 +889,11 @@ export default {
   'Switch the model for this session (--default to persist, --fast for suggestion model).':
     '切換此會話的模型（--default 可持久化，--fast 可設置建議模型）',
   'Default model': '預設模型',
+  'session only': '僅此會話',
   'Persist the selected model as the default': '將所選模型持久化為預設模型',
   'Usage: /model --default <model-id>': '用法：/model --default <模型 ID>',
+  'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
+    '目前模型：{{model}}\n使用 "/model <model-id>" 切換模型（僅此會話），使用 "/model --default <model-id>" 持久化，或使用 "/model --fast <model-id>" 設定快速模型。',
   'Set a lighter model for prompt suggestions and speculative execution':
     '設置用於輸入建議和推測執行的輕量模型',
   'Content generator configuration not available.': '內容生成器配置不可用',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -991,6 +991,8 @@ export default {
   // ============================================================================
   'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).':
     '切换此会话的模型（--fast 可设置建议模型）',
+  'Switch the model for this session (--default to persist, --fast for suggestion model).':
+    '切换此会话的模型（--default 可持久化，--fast 可设置建议模型）',
   'Set a lighter model for prompt suggestions and speculative execution':
     '设置用于输入建议和推测执行的轻量模型',
   'Content generator configuration not available.': '内容生成器配置不可用',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -999,6 +999,8 @@ export default {
   'session only': '仅本会话',
   'Persist the selected model as the default': '将所选模型持久化为默认模型',
   'Usage: /model --default <model-id>': '用法：/model --default <模型 ID>',
+  'Use either --default or --fast, not both.':
+    '只能使用 --default 或 --fast 其中之一，不能同时使用。',
   'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
     '当前模型：{{model}}\n使用 "/model <model-id>" 切换模型（仅本会话），使用 "/model --default <model-id>" 持久化，或使用 "/model --fast <model-id>" 设置快速模型。',
   'Set a lighter model for prompt suggestions and speculative execution':

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -996,8 +996,11 @@ export default {
   'Switch the model for this session (--default to persist, --fast for suggestion model).':
     '切换此会话的模型（--default 可持久化，--fast 可设置建议模型）',
   'Default model': '默认模型',
+  'session only': '仅本会话',
   'Persist the selected model as the default': '将所选模型持久化为默认模型',
   'Usage: /model --default <model-id>': '用法：/model --default <模型 ID>',
+  'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.':
+    '当前模型：{{model}}\n使用 "/model <model-id>" 切换模型（仅本会话），使用 "/model --default <model-id>" 持久化，或使用 "/model --fast <model-id>" 设置快速模型。',
   'Set a lighter model for prompt suggestions and speculative execution':
     '设置用于输入建议和推测执行的轻量模型',
   'Content generator configuration not available.': '内容生成器配置不可用',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -997,6 +997,7 @@ export default {
     '切换此会话的模型（--default 可持久化，--fast 可设置建议模型）',
   'Default model': '默认模型',
   'session only': '仅本会话',
+  'Runtime models cannot be set as default.': '运行时模型不能设置为默认模型。',
   'Persist the selected model as the default': '将所选模型持久化为默认模型',
   'Usage: /model --default <model-id>': '用法：/model --default <模型 ID>',
   'Use either --default or --fast, not both.':

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -230,6 +230,8 @@ export default {
   'Esc to close': '按 Esc 关闭',
   'Enter to select, ↑↓ to navigate, Esc to close':
     'Enter 选择，↑↓ 导航，Esc 关闭',
+  'Enter to select, d to set default, ↑↓ to navigate, Esc to close':
+    'Enter 选择，d 设为默认，↑↓ 导航，Esc 关闭',
   'Esc to go back': '按 Esc 返回',
   'Enter to confirm, Esc to cancel': 'Enter 确认，Esc 取消',
   'Enter to select, ↑↓ to navigate, Esc to go back':
@@ -993,6 +995,9 @@ export default {
     '切换此会话的模型（--fast 可设置建议模型）',
   'Switch the model for this session (--default to persist, --fast for suggestion model).':
     '切换此会话的模型（--default 可持久化，--fast 可设置建议模型）',
+  'Default model': '默认模型',
+  'Persist the selected model as the default': '将所选模型持久化为默认模型',
+  'Usage: /model --default <model-id>': '用法：/model --default <模型 ID>',
   'Set a lighter model for prompt suggestions and speculative execution':
     '设置用于输入建议和推测执行的轻量模型',
   'Content generator configuration not available.': '内容生成器配置不可用',

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -45,8 +45,9 @@ describe('modelCommand', () => {
   it('should have the correct name and description', () => {
     expect(modelCommand.name).toBe('model');
     expect(modelCommand.description).toBe(
-      'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).',
+      'Switch the model for this session (--default to persist, --fast for suggestion model).',
     );
+    expect(modelCommand.argumentHint).toBe('[--default|--fast] [<model-id>]');
   });
 
   it('should return error when config is not available', async () => {
@@ -151,7 +152,7 @@ describe('modelCommand', () => {
     });
   });
 
-  it('should switch the main model directly in interactive mode when args are provided', async () => {
+  it('should switch the main model for the current session without persisting when args are provided', async () => {
     const setValue = vi.fn();
     const switchModel = vi.fn().mockResolvedValue(undefined);
     mockContext = createMockCommandContext({
@@ -178,6 +179,48 @@ describe('modelCommand', () => {
       'qwen-max',
       undefined,
     );
+    expect(setValue).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Model: qwen-max',
+    });
+  });
+
+  it('should persist the main model only when --default is provided', async () => {
+    const setValue = vi.fn();
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model --default qwen-max',
+        name: 'model',
+        args: '--default qwen-max',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'qwen-plus',
+            authType: AuthType.QWEN_OAUTH,
+          }),
+          getAvailableModelsForAuthType: vi
+            .fn()
+            .mockReturnValue([{ id: 'qwen-max', label: 'Qwen Max' }]),
+          switchModel,
+        },
+        settings: createMockSettings(setValue),
+      },
+    });
+
+    const result = await modelCommand.action!(
+      mockContext,
+      '--default qwen-max',
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.QWEN_OAUTH,
+      'qwen-max',
+      undefined,
+    );
     expect(setValue).toHaveBeenCalledWith(
       expect.any(String),
       'model.name',
@@ -186,7 +229,7 @@ describe('modelCommand', () => {
     expect(result).toEqual({
       type: 'message',
       messageType: 'info',
-      content: 'Model: qwen-max',
+      content: 'Default model: qwen-max',
     });
   });
 
@@ -343,7 +386,7 @@ describe('modelCommand', () => {
     });
   });
 
-  it('should switch provider-qualified models through switchModel', async () => {
+  it('should switch provider-qualified models for the current session without persisting', async () => {
     const setValue = vi.fn();
     const switchModel = vi.fn().mockResolvedValue(undefined);
     mockContext = createMockCommandContext({
@@ -378,16 +421,7 @@ describe('modelCommand', () => {
       'gpt-4',
       undefined,
     );
-    expect(setValue).toHaveBeenCalledWith(
-      expect.any(String),
-      'security.auth.selectedType',
-      AuthType.USE_OPENAI,
-    );
-    expect(setValue).toHaveBeenCalledWith(
-      expect.any(String),
-      'model.name',
-      'gpt-4',
-    );
+    expect(setValue).not.toHaveBeenCalled();
     expect(result).toEqual({
       type: 'message',
       messageType: 'info',
@@ -572,11 +606,7 @@ describe('modelCommand', () => {
       '--fast-model',
       undefined,
     );
-    expect(setValue).toHaveBeenCalledWith(
-      expect.any(String),
-      'model.name',
-      '--fast-model',
-    );
+    expect(setValue).not.toHaveBeenCalled();
     expect(result).toEqual({
       type: 'message',
       messageType: 'info',

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -308,6 +308,54 @@ describe('modelCommand', () => {
     });
   });
 
+  it('should persist the main model when --default follows the model id', async () => {
+    const setValue = vi.fn();
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model gpt-4 --default',
+        name: 'model',
+        args: 'gpt-4 --default',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'gpt-3.5',
+            authType: AuthType.USE_OPENAI,
+          }),
+          getAvailableModelsForAuthType: vi
+            .fn()
+            .mockReturnValue([{ id: 'gpt-4', label: 'GPT-4' }]),
+          switchModel,
+        },
+        settings: createMockSettings(setValue),
+      },
+    });
+
+    const result = await modelCommand.action!(mockContext, 'gpt-4 --default');
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'gpt-4',
+      undefined,
+    );
+    expect(setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      'security.auth.selectedType',
+      AuthType.USE_OPENAI,
+    );
+    expect(setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      'model.name',
+      'gpt-4',
+    );
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Default model: gpt-4',
+    });
+  });
+
   it('should persist provider-qualified models when --default is provided', async () => {
     const setValue = vi.fn();
     const switchModel = vi.fn().mockResolvedValue(undefined);

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -233,6 +233,38 @@ describe('modelCommand', () => {
     });
   });
 
+  it('should return usage when --default is missing a model id', async () => {
+    const setValue = vi.fn();
+    const switchModel = vi.fn();
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model --default',
+        name: 'model',
+        args: '--default',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'qwen-plus',
+            authType: AuthType.QWEN_OAUTH,
+          }),
+          switchModel,
+        },
+        settings: createMockSettings(setValue),
+      },
+    });
+
+    const result = await modelCommand.action!(mockContext, '--default');
+
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(setValue).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Usage: /model --default <model-id>',
+    });
+  });
+
   it('should not persist the model when direct model validation fails', async () => {
     const setValue = vi.fn();
     const switchModel = vi.fn();
@@ -634,7 +666,11 @@ describe('modelCommand', () => {
       expect(result).toEqual({
         type: 'message',
         messageType: 'info',
-        content: expect.stringContaining('qwen-max'),
+        content:
+          'Current model: qwen-max\n' +
+          'Use "/model <model-id>" to switch models (session only), ' +
+          '"/model --default <model-id>" to persist, or ' +
+          '"/model --fast <model-id>" to set the fast model.',
       });
       expect((result as { type: string }).type).toBe('message');
     });

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -314,7 +314,7 @@ describe('modelCommand', () => {
       type: 'message',
       messageType: 'error',
       content:
-        'Qwen OAuth free tier was discontinued on 2026-04-15. Please select a model from another provider.',
+        'Qwen OAuth free tier was discontinued on 2026-04-15. Please select a model from another provider or run /auth to switch.',
     });
   });
 

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -314,6 +314,61 @@ describe('modelCommand', () => {
     });
   });
 
+  it('should persist effective model values after --default switches', async () => {
+    const setValue = vi.fn();
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const getContentGeneratorConfig = vi
+      .fn()
+      .mockReturnValueOnce({
+        model: 'gpt-3.5',
+        authType: AuthType.USE_OPENAI,
+      })
+      .mockReturnValueOnce({
+        model: 'gpt-4.1',
+        authType: AuthType.USE_OPENAI,
+      });
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model --default gpt-4',
+        name: 'model',
+        args: '--default gpt-4',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig,
+          getAvailableModelsForAuthType: vi
+            .fn()
+            .mockReturnValue([{ id: 'gpt-4', label: 'GPT-4' }]),
+          switchModel,
+        },
+        settings: createMockSettings(setValue),
+      },
+    });
+
+    const result = await modelCommand.action!(mockContext, '--default gpt-4');
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'gpt-4',
+      undefined,
+    );
+    expect(setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      'security.auth.selectedType',
+      AuthType.USE_OPENAI,
+    );
+    expect(setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      'model.name',
+      'gpt-4.1',
+    );
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Default model: gpt-4',
+    });
+  });
+
   it('should reject combining --default and --fast', async () => {
     const setValue = vi.fn();
     const setFastModel = vi.fn();
@@ -937,6 +992,53 @@ describe('modelCommand', () => {
       type: 'message',
       messageType: 'info',
       content: 'Fast Model: openai:deepseek-v4-flash',
+    });
+  });
+
+  it('should reject qwen-oauth fast models', async () => {
+    const setValue = vi.fn();
+    const setFastModel = vi.fn();
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: `/model --fast qwen-max(${AuthType.QWEN_OAUTH})`,
+        name: 'model',
+        args: `--fast qwen-max(${AuthType.QWEN_OAUTH})`,
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'gpt-4',
+            authType: AuthType.USE_OPENAI,
+          }),
+          getAvailableModelsForAuthType: vi.fn((authType: AuthType) =>
+            authType === AuthType.QWEN_OAUTH
+              ? [
+                  {
+                    id: 'qwen-max',
+                    label: 'Qwen Max',
+                    authType: AuthType.QWEN_OAUTH,
+                  },
+                ]
+              : [],
+          ),
+          setFastModel,
+        },
+        settings: createMockSettings(setValue),
+      },
+    });
+
+    const result = await modelCommand.action!(
+      mockContext,
+      `--fast qwen-max(${AuthType.QWEN_OAUTH})`,
+    );
+
+    expect(setValue).not.toHaveBeenCalled();
+    expect(setFastModel).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content:
+        'Qwen OAuth free tier was discontinued on 2026-04-15. Please select a model from another provider or run /auth to switch.',
     });
   });
 

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -586,6 +586,40 @@ describe('modelCommand', () => {
     });
   });
 
+  it('should reject qwen-oauth models for session-only switches', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: `/model qwen-max(${AuthType.QWEN_OAUTH})`,
+        name: 'model',
+        args: `qwen-max(${AuthType.QWEN_OAUTH})`,
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'gpt-4',
+            authType: AuthType.USE_OPENAI,
+          }),
+          getAvailableModelsForAuthType: vi.fn(),
+          switchModel,
+        },
+      },
+    });
+
+    const result = await modelCommand.action!(
+      mockContext,
+      `qwen-max(${AuthType.QWEN_OAUTH})`,
+    );
+
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content:
+        'Qwen OAuth free tier was discontinued on 2026-04-15. Please select a model from another provider or run /auth to switch.',
+    });
+  });
+
   it('should return settings error when --default is used without settings', async () => {
     const switchModel = vi.fn();
     mockContext = createMockCommandContext({
@@ -992,6 +1026,102 @@ describe('modelCommand', () => {
       type: 'message',
       messageType: 'info',
       content: 'Fast Model: openai:deepseek-v4-flash',
+    });
+  });
+
+  it('should not persist fast model when runtime sync fails', async () => {
+    const setValue = vi.fn();
+    const setFastModel = vi.fn(() => {
+      throw new Error('Runtime config rejected the model');
+    });
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model --fast deepseek-v4-flash',
+        name: 'model',
+        args: '--fast deepseek-v4-flash',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'gpt-4',
+            authType: AuthType.USE_OPENAI,
+          }),
+          getAllConfiguredModels: vi.fn().mockReturnValue([
+            {
+              id: 'deepseek-v4-flash',
+              label: 'deepseek-v4-flash',
+              authType: AuthType.USE_OPENAI,
+            },
+          ]),
+          setFastModel,
+        },
+        settings: createMockSettings(setValue),
+      },
+    });
+
+    const result = await modelCommand.action!(
+      mockContext,
+      '--fast deepseek-v4-flash',
+    );
+
+    expect(setFastModel).toHaveBeenCalledWith('deepseek-v4-flash');
+    expect(setValue).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content:
+        "Failed to set fast model to 'deepseek-v4-flash'.\n\n" +
+        'Runtime config rejected the model',
+    });
+  });
+
+  it('should report persistence failures after setting the session fast model', async () => {
+    const setValue = vi.fn(() => {
+      throw new Error('Disk is read-only');
+    });
+    const setFastModel = vi.fn();
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model --fast deepseek-v4-flash',
+        name: 'model',
+        args: '--fast deepseek-v4-flash',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'gpt-4',
+            authType: AuthType.USE_OPENAI,
+          }),
+          getAllConfiguredModels: vi.fn().mockReturnValue([
+            {
+              id: 'deepseek-v4-flash',
+              label: 'deepseek-v4-flash',
+              authType: AuthType.USE_OPENAI,
+            },
+          ]),
+          setFastModel,
+        },
+        settings: createMockSettings(setValue),
+      },
+    });
+
+    const result = await modelCommand.action!(
+      mockContext,
+      '--fast deepseek-v4-flash',
+    );
+
+    expect(setFastModel).toHaveBeenCalledWith('deepseek-v4-flash');
+    expect(setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      'fastModel',
+      'deepseek-v4-flash',
+    );
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content:
+        "Fast model set to 'deepseek-v4-flash' for this session, but failed to persist.\n\n" +
+        'Disk is read-only',
     });
   });
 

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -121,6 +121,12 @@ describe('modelCommand', () => {
         modelCommand.completion!(mockContext, 'cla'),
       ).resolves.toEqual(['claude-sonnet-4-5(anthropic)']);
     });
+
+    it('should not complete runtime models for session-only model switches', async () => {
+      await expect(
+        modelCommand.completion!(mockContext, '$runtime'),
+      ).resolves.toEqual([]);
+    });
   });
 
   it('should return error when config is not available', async () => {
@@ -869,6 +875,56 @@ describe('modelCommand', () => {
     const result = await modelCommand.action!(
       mockContext,
       '--fast openai:deepseek-v4-flash',
+    );
+
+    expect(setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      'fastModel',
+      'openai:deepseek-v4-flash',
+    );
+    expect(setFastModel).toHaveBeenCalledWith('openai:deepseek-v4-flash');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Fast Model: openai:deepseek-v4-flash',
+    });
+  });
+
+  it('should accept ACP-qualified fast model selectors from completion', async () => {
+    const setValue = vi.fn();
+    const setFastModel = vi.fn();
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model --fast deepseek-v4-flash(openai)',
+        name: 'model',
+        args: '--fast deepseek-v4-flash(openai)',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'claude-opus-4-7',
+            authType: AuthType.USE_ANTHROPIC,
+          }),
+          getAvailableModelsForAuthType: vi.fn((authType: AuthType) =>
+            authType === AuthType.USE_OPENAI
+              ? [
+                  {
+                    id: 'deepseek-v4-flash',
+                    label: 'deepseek-v4-flash',
+                    authType: AuthType.USE_OPENAI,
+                  },
+                ]
+              : [],
+          ),
+          setFastModel,
+        },
+        settings: createMockSettings(setValue),
+      },
+    });
+
+    const result = await modelCommand.action!(
+      mockContext,
+      '--fast deepseek-v4-flash(openai)',
     );
 
     expect(setValue).toHaveBeenCalledWith(

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -50,6 +50,79 @@ describe('modelCommand', () => {
     expect(modelCommand.argumentHint).toBe('[--default|--fast] [<model-id>]');
   });
 
+  describe('completion', () => {
+    beforeEach(() => {
+      mockContext = createMockCommandContext({
+        services: {
+          config: {
+            getContentGeneratorConfig: vi.fn().mockReturnValue({
+              model: 'gpt-4',
+              authType: AuthType.USE_OPENAI,
+            }),
+            getAllConfiguredModels: vi.fn().mockReturnValue([
+              {
+                id: 'gpt-4',
+                label: 'GPT-4',
+                authType: AuthType.USE_OPENAI,
+              },
+              {
+                id: 'claude-sonnet-4-5',
+                label: 'Claude Sonnet 4.5',
+                authType: AuthType.USE_ANTHROPIC,
+              },
+              {
+                id: '$runtime|openai|runtime-model',
+                label: 'Runtime Model',
+                authType: AuthType.USE_OPENAI,
+                isRuntimeModel: true,
+              },
+            ]),
+          },
+        },
+      });
+    });
+
+    it('should complete model flags', async () => {
+      await expect(
+        modelCommand.completion!(mockContext, '--'),
+      ).resolves.toEqual([
+        {
+          value: '--default',
+          description: 'Persist the selected model as the default',
+        },
+        {
+          value: '--fast',
+          description:
+            'Set a lighter model for prompt suggestions and speculative execution',
+        },
+      ]);
+    });
+
+    it('should complete --default models across configured providers', async () => {
+      await expect(
+        modelCommand.completion!(mockContext, '--default '),
+      ).resolves.toEqual([
+        '--default gpt-4',
+        '--default claude-sonnet-4-5(anthropic)',
+      ]);
+    });
+
+    it('should complete --fast models across configured providers', async () => {
+      await expect(
+        modelCommand.completion!(mockContext, '--fast cla'),
+      ).resolves.toEqual(['--fast claude-sonnet-4-5(anthropic)']);
+    });
+
+    it('should qualify non-current provider model completions', async () => {
+      await expect(
+        modelCommand.completion!(mockContext, 'gpt'),
+      ).resolves.toEqual(['gpt-4']);
+      await expect(
+        modelCommand.completion!(mockContext, 'cla'),
+      ).resolves.toEqual(['claude-sonnet-4-5(anthropic)']);
+    });
+  });
+
   it('should return error when config is not available', async () => {
     mockContext.services.config = null;
 

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -286,6 +286,49 @@ describe('modelCommand', () => {
     });
   });
 
+  it('should report persistence failures after switching --default model', async () => {
+    const setValue = vi.fn(() => {
+      throw new Error('Disk is read-only');
+    });
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model --default gpt-4',
+        name: 'model',
+        args: '--default gpt-4',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'gpt-3.5',
+            authType: AuthType.USE_OPENAI,
+          }),
+          getAvailableModelsForAuthType: vi
+            .fn()
+            .mockReturnValue([{ id: 'gpt-4', label: 'GPT-4' }]),
+          switchModel,
+        },
+        settings: createMockSettings(setValue),
+      },
+    });
+
+    const result = await modelCommand.action!(mockContext, '--default gpt-4');
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'gpt-4',
+      undefined,
+    );
+    expect(setValue).toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content:
+        "Switched to 'gpt-4' for this session, but failed to persist as default.\n\n" +
+        'Disk is read-only',
+    });
+  });
+
   it('should reject qwen-oauth models when --default is provided', async () => {
     const setValue = vi.fn();
     const switchModel = vi.fn().mockResolvedValue(undefined);

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -183,7 +183,7 @@ describe('modelCommand', () => {
     expect(result).toEqual({
       type: 'message',
       messageType: 'info',
-      content: 'Model: qwen-max',
+      content: 'Model: qwen-max (session only)',
     });
   });
 
@@ -217,6 +217,11 @@ describe('modelCommand', () => {
       AuthType.USE_OPENAI,
       'gpt-4',
       undefined,
+    );
+    expect(setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      'security.auth.selectedType',
+      AuthType.USE_OPENAI,
     );
     expect(setValue).toHaveBeenCalledWith(
       expect.any(String),
@@ -572,7 +577,7 @@ describe('modelCommand', () => {
     expect(result).toEqual({
       type: 'message',
       messageType: 'info',
-      content: 'Model: gpt-4',
+      content: 'Model: gpt-4 (session only)',
     });
   });
 
@@ -757,7 +762,7 @@ describe('modelCommand', () => {
     expect(result).toEqual({
       type: 'message',
       messageType: 'info',
-      content: 'Model: --fast-model',
+      content: 'Model: --fast-model (session only)',
     });
   });
 

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -308,6 +308,44 @@ describe('modelCommand', () => {
     });
   });
 
+  it('should reject combining --default and --fast', async () => {
+    const setValue = vi.fn();
+    const setFastModel = vi.fn();
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model gpt-4 --default --fast',
+        name: 'model',
+        args: 'gpt-4 --default --fast',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'gpt-3.5',
+            authType: AuthType.USE_OPENAI,
+          }),
+          switchModel,
+          setFastModel,
+        },
+        settings: createMockSettings(setValue),
+      },
+    });
+
+    const result = await modelCommand.action!(
+      mockContext,
+      'gpt-4 --default --fast',
+    );
+
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(setFastModel).not.toHaveBeenCalled();
+    expect(setValue).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Use either --default or --fast, not both.',
+    });
+  });
+
   it('should persist the main model when --default follows the model id', async () => {
     const setValue = vi.fn();
     const switchModel = vi.fn().mockResolvedValue(undefined);

--- a/packages/cli/src/ui/commands/modelCommand.test.ts
+++ b/packages/cli/src/ui/commands/modelCommand.test.ts
@@ -192,6 +192,100 @@ describe('modelCommand', () => {
     const switchModel = vi.fn().mockResolvedValue(undefined);
     mockContext = createMockCommandContext({
       invocation: {
+        raw: '/model --default gpt-4',
+        name: 'model',
+        args: '--default gpt-4',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'gpt-3.5',
+            authType: AuthType.USE_OPENAI,
+          }),
+          getAvailableModelsForAuthType: vi
+            .fn()
+            .mockReturnValue([{ id: 'gpt-4', label: 'GPT-4' }]),
+          switchModel,
+        },
+        settings: createMockSettings(setValue),
+      },
+    });
+
+    const result = await modelCommand.action!(mockContext, '--default gpt-4');
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'gpt-4',
+      undefined,
+    );
+    expect(setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      'model.name',
+      'gpt-4',
+    );
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Default model: gpt-4',
+    });
+  });
+
+  it('should persist provider-qualified models when --default is provided', async () => {
+    const setValue = vi.fn();
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: `/model --default gpt-4(${AuthType.USE_OPENAI})`,
+        name: 'model',
+        args: `--default gpt-4(${AuthType.USE_OPENAI})`,
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'qwen-plus',
+            authType: AuthType.QWEN_OAUTH,
+          }),
+          getAvailableModelsForAuthType: vi
+            .fn()
+            .mockReturnValue([{ id: 'gpt-4', label: 'GPT-4' }]),
+          switchModel,
+        },
+        settings: createMockSettings(setValue),
+      },
+    });
+
+    const result = await modelCommand.action!(
+      mockContext,
+      `--default gpt-4(${AuthType.USE_OPENAI})`,
+    );
+
+    expect(switchModel).toHaveBeenCalledWith(
+      AuthType.USE_OPENAI,
+      'gpt-4',
+      undefined,
+    );
+    expect(setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      'security.auth.selectedType',
+      AuthType.USE_OPENAI,
+    );
+    expect(setValue).toHaveBeenCalledWith(
+      expect.any(String),
+      'model.name',
+      'gpt-4',
+    );
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Default model: gpt-4',
+    });
+  });
+
+  it('should reject qwen-oauth models when --default is provided', async () => {
+    const setValue = vi.fn();
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    mockContext = createMockCommandContext({
+      invocation: {
         raw: '/model --default qwen-max',
         name: 'model',
         args: '--default qwen-max',
@@ -202,9 +296,7 @@ describe('modelCommand', () => {
             model: 'qwen-plus',
             authType: AuthType.QWEN_OAUTH,
           }),
-          getAvailableModelsForAuthType: vi
-            .fn()
-            .mockReturnValue([{ id: 'qwen-max', label: 'Qwen Max' }]),
+          getAvailableModelsForAuthType: vi.fn(),
           switchModel,
         },
         settings: createMockSettings(setValue),
@@ -216,20 +308,43 @@ describe('modelCommand', () => {
       '--default qwen-max',
     );
 
-    expect(switchModel).toHaveBeenCalledWith(
-      AuthType.QWEN_OAUTH,
-      'qwen-max',
-      undefined,
-    );
-    expect(setValue).toHaveBeenCalledWith(
-      expect.any(String),
-      'model.name',
-      'qwen-max',
-    );
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(setValue).not.toHaveBeenCalled();
     expect(result).toEqual({
       type: 'message',
-      messageType: 'info',
-      content: 'Default model: qwen-max',
+      messageType: 'error',
+      content:
+        'Qwen OAuth free tier was discontinued on 2026-04-15. Please select a model from another provider.',
+    });
+  });
+
+  it('should return settings error when --default is used without settings', async () => {
+    const switchModel = vi.fn();
+    mockContext = createMockCommandContext({
+      invocation: {
+        raw: '/model --default gpt-4',
+        name: 'model',
+        args: '--default gpt-4',
+      },
+      services: {
+        config: {
+          getContentGeneratorConfig: vi.fn().mockReturnValue({
+            model: 'gpt-3.5',
+            authType: AuthType.USE_OPENAI,
+          }),
+          switchModel,
+        },
+      },
+    });
+    mockContext.services.settings = undefined as unknown as LoadedSettings;
+
+    const result = await modelCommand.action!(mockContext, '--default gpt-4');
+
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'error',
+      content: 'Settings service not available.',
     });
   });
 

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -71,6 +71,12 @@ function persistMainModelDefault(
   return modelArg;
 }
 
+function qwenOAuthDiscontinuedMessage(): string {
+  return t(
+    'Qwen OAuth free tier was discontinued on 2026-04-15. Please select a model from another provider.',
+  );
+}
+
 function formatUnavailableModelMessage(
   kind: 'Model' | 'Fast model',
   modelName: string,
@@ -299,6 +305,13 @@ export const modelCommand: SlashCommand = {
       }
       const parsed = parseAcpModelOption(modelName);
       const targetAuthType = parsed.authType ?? authType;
+      if (isDefaultModelCommand && targetAuthType === AuthType.QWEN_OAUTH) {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: qwenOAuthDiscontinuedMessage(),
+        };
+      }
       const availableModels =
         config.getAvailableModelsForAuthType(targetAuthType);
       if (!availableModels.some((model) => model.id === parsed.modelId)) {

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -217,6 +217,14 @@ export const modelCommand: SlashCommand = {
     const argTokens = args.split(/\s+/).filter(Boolean);
     const isDefaultModelCommand = argTokens.includes('--default');
     const isFastModelCommand = argTokens.includes('--fast');
+    if (isDefaultModelCommand && isFastModelCommand) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: t('Use either --default or --fast, not both.'),
+      };
+    }
+
     if (isFastModelCommand) {
       const modelName =
         argTokens.find(

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -298,10 +298,32 @@ export const modelCommand: SlashCommand = {
         };
       }
 
-      persistSetting(settings, 'fastModel', normalizedFastModel);
-      // Sync the runtime Config so forked agents pick up the change immediately
-      // without requiring a restart.
-      config.setFastModel(normalizedFastModel);
+      try {
+        // Sync the runtime Config first; do not persist a fast model the
+        // current session cannot actually use.
+        config.setFastModel(normalizedFastModel);
+      } catch (e) {
+        const baseErrorMessage = e instanceof Error ? e.message : String(e);
+        return {
+          type: 'message',
+          messageType: 'error',
+          content:
+            `Failed to set fast model to '${normalizedFastModel}'.\n\n` +
+            baseErrorMessage,
+        };
+      }
+      try {
+        persistSetting(settings, 'fastModel', normalizedFastModel);
+      } catch (e) {
+        const baseErrorMessage = e instanceof Error ? e.message : String(e);
+        return {
+          type: 'message',
+          messageType: 'error',
+          content:
+            `Fast model set to '${normalizedFastModel}' for this session, ` +
+            `but failed to persist.\n\n${baseErrorMessage}`,
+        };
+      }
       return {
         type: 'message',
         messageType: 'info',
@@ -342,7 +364,10 @@ export const modelCommand: SlashCommand = {
       }
       const parsed = parseAcpModelOption(modelName);
       const targetAuthType = parsed.authType ?? authType;
-      if (isDefaultModelCommand && targetAuthType === AuthType.QWEN_OAUTH) {
+      if (
+        targetAuthType === AuthType.QWEN_OAUTH &&
+        (isDefaultModelCommand || parsed.authType)
+      ) {
         return {
           type: 'message',
           messageType: 'error',

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -271,7 +271,10 @@ export const modelCommand: SlashCommand = {
       const availableModels = selector.authType
         ? config.getAvailableModelsForAuthType(selector.authType)
         : config.getAllConfiguredModels();
-      if (!availableModels.some((model) => model.id === selector.modelId)) {
+      const selectedModel = availableModels.find(
+        (model) => model.id === selector.modelId,
+      );
+      if (!selectedModel) {
         return {
           type: 'message',
           messageType: 'error',
@@ -283,6 +286,15 @@ export const modelCommand: SlashCommand = {
                 availableModels,
               )
             : formatUnavailableFastModelMessage(modelName, availableModels),
+        };
+      }
+      if (
+        (selector.authType ?? selectedModel.authType) === AuthType.QWEN_OAUTH
+      ) {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: qwenOAuthDiscontinuedMessage(),
         };
       }
 
@@ -386,7 +398,7 @@ export const modelCommand: SlashCommand = {
           };
         }
       }
-      if (typeof config.getUsageStatisticsEnabled === 'function') {
+      if (config.getUsageStatisticsEnabled?.()) {
         logModelSlashCommand(
           config,
           new ModelSlashCommandEvent(effectiveModelName),

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -346,7 +346,11 @@ export const modelCommand: SlashCommand = {
       return {
         type: 'message',
         messageType: 'info',
-        content: `Current model: ${currentModel}\nUse "/model <model-id>" to switch models or "/model --fast <model-id>" to set the fast model.`,
+        content:
+          `Current model: ${currentModel}\n` +
+          'Use "/model <model-id>" to switch models (session only), ' +
+          '"/model --default <model-id>" to persist, or ' +
+          '"/model --fast <model-id>" to set the fast model.',
       };
     }
 

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -214,11 +214,14 @@ export const modelCommand: SlashCommand = {
 
     // Handle --fast flag: /model --fast <modelName>
     const args = context.invocation?.args?.trim() || actionArgs.trim();
-    const isDefaultModelCommand =
-      args === '--default' || args.startsWith('--default ');
-    const isFastModelCommand = args === '--fast' || args.startsWith('--fast ');
+    const argTokens = args.split(/\s+/).filter(Boolean);
+    const isDefaultModelCommand = argTokens.includes('--default');
+    const isFastModelCommand = argTokens.includes('--fast');
     if (isFastModelCommand) {
-      const modelName = args.replace('--fast', '').trim();
+      const modelName =
+        argTokens.find(
+          (token) => token !== '--fast' && token !== '--default',
+        ) ?? '';
       if (!modelName) {
         // Open model dialog in fast-model mode (interactive) or return current fast model (non-interactive)
         if (context.executionMode !== 'interactive') {
@@ -317,8 +320,10 @@ export const modelCommand: SlashCommand = {
     }
 
     const modelName = isDefaultModelCommand
-      ? args.replace('--default', '').trim().split(/\s+/)[0]
-      : (args.trim().split(/\s+/)[0] ?? '');
+      ? (argTokens.find(
+          (token) => token !== '--default' && token !== '--fast',
+        ) ?? '')
+      : (argTokens[0] ?? '');
     if (modelName) {
       if (isDefaultModelCommand && !settings) {
         return {

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -15,6 +15,8 @@ import { t } from '../../i18n/index.js';
 import { getPersistScopeForModelSelection } from '../../config/modelProvidersScope.js';
 import {
   AuthType,
+  ModelSlashCommandEvent,
+  logModelSlashCommand,
   type AvailableModel,
   type Config,
   resolveModelId,
@@ -381,6 +383,12 @@ export const modelCommand: SlashCommand = {
               `but failed to persist as default.\n\n${baseErrorMessage}`,
           };
         }
+      }
+      if (typeof config.getUsageStatisticsEnabled === 'function') {
+        logModelSlashCommand(
+          config,
+          new ModelSlashCommandEvent(effectiveModelName),
+        );
       }
       return {
         type: 'message',

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -32,7 +32,6 @@ function persistSetting(
 
 async function switchMainModel(
   config: Config,
-  settings: LoadedSettings,
   currentAuthType: AuthType,
   modelArg: string,
 ): Promise<string> {
@@ -47,12 +46,26 @@ async function switchMainModel(
         ? { requireCachedCredentials: true }
         : undefined,
     );
+    return parsed.modelId;
+  }
+
+  await config.switchModel(currentAuthType, modelArg, undefined);
+  return modelArg;
+}
+
+function persistMainModelDefault(
+  settings: LoadedSettings,
+  currentAuthType: AuthType,
+  modelArg: string,
+): string {
+  const parsed = parseAcpModelOption(modelArg);
+  if (parsed.authType) {
     persistSetting(settings, 'security.auth.selectedType', parsed.authType);
     persistSetting(settings, 'model.name', parsed.modelId);
     return parsed.modelId;
   }
 
-  await config.switchModel(currentAuthType, modelArg, undefined);
+  persistSetting(settings, 'security.auth.selectedType', currentAuthType);
   persistSetting(settings, 'model.name', modelArg);
   return modelArg;
 }
@@ -114,26 +127,40 @@ export const modelCommand: SlashCommand = {
   completionPriority: 100,
   get description() {
     return t(
-      'Switch the model for this session (--fast for suggestion model, [model-id] to switch immediately).',
+      'Switch the model for this session (--default to persist, --fast for suggestion model).',
     );
   },
-  argumentHint: '[--fast] [<model-id>]',
+  argumentHint: '[--default|--fast] [<model-id>]',
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
   completion: async (context, partialArg) => {
-    if (partialArg && '--fast'.startsWith(partialArg)) {
-      return [
-        {
-          value: '--fast',
-          description: t(
-            'Set a lighter model for prompt suggestions and speculative execution',
-          ),
-        },
-      ];
-    } else if (partialArg.trim()) {
+    const trimmedPartialArg = partialArg.trim();
+    if (trimmedPartialArg.startsWith('--default ')) {
+      const modelPartial = trimmedPartialArg.replace('--default', '').trim();
+      return getAvailableModelIds(context)
+        .filter((id) => id.startsWith(modelPartial))
+        .map((id) => `--default ${id}`);
+    }
+
+    const flagCompletions = [
+      {
+        value: '--default',
+        description: t('Persist the selected model as the default'),
+      },
+      {
+        value: '--fast',
+        description: t(
+          'Set a lighter model for prompt suggestions and speculative execution',
+        ),
+      },
+    ].filter((completion) => completion.value.startsWith(trimmedPartialArg));
+
+    if (flagCompletions.length > 0) {
+      return flagCompletions;
+    } else if (trimmedPartialArg) {
       // Include model IDs matching the partial argument
       return getAvailableModelIds(context).filter((id) =>
-        id.startsWith(partialArg.trim()),
+        id.startsWith(trimmedPartialArg),
       );
     } else {
       return null;
@@ -156,6 +183,8 @@ export const modelCommand: SlashCommand = {
 
     // Handle --fast flag: /model --fast <modelName>
     const args = context.invocation?.args?.trim() || actionArgs.trim();
+    const isDefaultModelCommand =
+      args === '--default' || args.startsWith('--default ');
     const isFastModelCommand = args === '--fast' || args.startsWith('--fast ');
     if (isFastModelCommand) {
       const modelName = args.replace('--fast', '').trim();
@@ -256,9 +285,11 @@ export const modelCommand: SlashCommand = {
       };
     }
 
-    const modelName = args.trim().split(/\s+/)[0] ?? '';
+    const modelName = isDefaultModelCommand
+      ? args.replace('--default', '').trim().split(/\s+/)[0]
+      : (args.trim().split(/\s+/)[0] ?? '');
     if (modelName) {
-      if (!settings) {
+      if (isDefaultModelCommand && !settings) {
         return {
           type: 'message',
           messageType: 'error',
@@ -283,14 +314,27 @@ export const modelCommand: SlashCommand = {
       }
       const effectiveModelName = await switchMainModel(
         config,
-        settings,
         authType,
         modelName,
       );
+      if (isDefaultModelCommand) {
+        persistMainModelDefault(settings, authType, modelName);
+      }
       return {
         type: 'message',
         messageType: 'info',
-        content: t('Model') + ': ' + effectiveModelName,
+        content:
+          (isDefaultModelCommand ? t('Default model') : t('Model')) +
+          ': ' +
+          effectiveModelName,
+      };
+    }
+
+    if (isDefaultModelCommand) {
+      return {
+        type: 'message',
+        messageType: 'error',
+        content: t('Usage: /model --default <model-id>'),
       };
     }
 

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -335,7 +335,8 @@ export const modelCommand: SlashCommand = {
         content:
           (isDefaultModelCommand ? t('Default model') : t('Model')) +
           ': ' +
-          effectiveModelName,
+          effectiveModelName +
+          (isDefaultModelCommand ? '' : ` (${t('session only')})`),
       };
     }
 
@@ -354,11 +355,10 @@ export const modelCommand: SlashCommand = {
       return {
         type: 'message',
         messageType: 'info',
-        content:
-          `Current model: ${currentModel}\n` +
-          'Use "/model <model-id>" to switch models (session only), ' +
-          '"/model --default <model-id>" to persist, or ' +
-          '"/model --fast <model-id>" to set the fast model.',
+        content: t(
+          'Current model: {{model}}\nUse "/model <model-id>" to switch models (session only), "/model --default <model-id>" to persist, or "/model --fast <model-id>" to set the fast model.',
+          { model: currentModel },
+        ),
       };
     }
 

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -21,6 +21,7 @@ import {
 } from '@qwen-code/qwen-code-core';
 import type { LoadedSettings } from '../../config/settings.js';
 import { parseAcpModelOption } from '../../utils/acpModelUtils.js';
+import { qwenOAuthDiscontinuedMessage } from '../utils/qwenOAuthDiscontinuedMessage.js';
 
 function persistSetting(
   settings: LoadedSettings,
@@ -32,7 +33,7 @@ function persistSetting(
 
 async function switchMainModel(
   config: Config,
-  currentAuthType: AuthType,
+  fallbackAuthType: AuthType,
   modelArg: string,
 ): Promise<string> {
   const parsed = parseAcpModelOption(modelArg);
@@ -41,7 +42,7 @@ async function switchMainModel(
     await config.switchModel(
       parsed.authType,
       parsed.modelId,
-      parsed.authType !== currentAuthType &&
+      parsed.authType !== fallbackAuthType &&
         parsed.authType === AuthType.QWEN_OAUTH
         ? { requireCachedCredentials: true }
         : undefined,
@@ -49,13 +50,13 @@ async function switchMainModel(
     return parsed.modelId;
   }
 
-  await config.switchModel(currentAuthType, modelArg, undefined);
+  await config.switchModel(fallbackAuthType, modelArg, undefined);
   return modelArg;
 }
 
 function persistMainModelDefault(
   settings: LoadedSettings,
-  currentAuthType: AuthType,
+  fallbackAuthType: AuthType,
   modelArg: string,
 ): string {
   const parsed = parseAcpModelOption(modelArg);
@@ -66,15 +67,9 @@ function persistMainModelDefault(
   }
 
   // Unqualified model ids belong to the currently active auth provider.
-  persistSetting(settings, 'security.auth.selectedType', currentAuthType);
+  persistSetting(settings, 'security.auth.selectedType', fallbackAuthType);
   persistSetting(settings, 'model.name', modelArg);
   return modelArg;
-}
-
-function qwenOAuthDiscontinuedMessage(): string {
-  return t(
-    'Qwen OAuth free tier was discontinued on 2026-04-15. Please select a model from another provider.',
-  );
 }
 
 function formatUnavailableModelMessage(

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -65,6 +65,7 @@ function persistMainModelDefault(
     return parsed.modelId;
   }
 
+  // Unqualified model ids belong to the currently active auth provider.
   persistSetting(settings, 'security.auth.selectedType', currentAuthType);
   persistSetting(settings, 'model.name', modelArg);
   return modelArg;

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -59,24 +59,6 @@ async function switchMainModel(
   return modelArg;
 }
 
-function persistMainModelDefault(
-  settings: LoadedSettings,
-  fallbackAuthType: AuthType,
-  modelArg: string,
-): string {
-  const parsed = parseAcpModelOption(modelArg);
-  if (parsed.authType) {
-    persistSetting(settings, 'security.auth.selectedType', parsed.authType);
-    persistSetting(settings, 'model.name', parsed.modelId);
-    return parsed.modelId;
-  }
-
-  // Unqualified model ids belong to the currently active auth provider.
-  persistSetting(settings, 'security.auth.selectedType', fallbackAuthType);
-  persistSetting(settings, 'model.name', modelArg);
-  return modelArg;
-}
-
 function formatUnavailableModelMessage(
   kind: 'Model' | 'Fast model',
   modelName: string,
@@ -170,7 +152,7 @@ export const modelCommand: SlashCommand = {
       const modelPartial = leadingTrimmedPartialArg
         .slice('--fast '.length)
         .trimStart();
-      return getAvailableModelIds(context)
+      return getAvailableModelIds(context, { excludeRuntimeModels: true })
         .filter((id) => id.startsWith(modelPartial))
         .map((id) => `--fast ${id}`);
     }
@@ -192,9 +174,9 @@ export const modelCommand: SlashCommand = {
       return flagCompletions;
     } else if (trimmedPartialArg) {
       // Include model IDs matching the partial argument
-      return getAvailableModelIds(context).filter((id) =>
-        id.startsWith(trimmedPartialArg),
-      );
+      return getAvailableModelIds(context, {
+        excludeRuntimeModels: true,
+      }).filter((id) => id.startsWith(trimmedPartialArg));
     } else {
       return null;
     }
@@ -267,9 +249,13 @@ export const modelCommand: SlashCommand = {
         };
       }
 
+      const parsedFastModel = parseAcpModelOption(modelName);
+      const normalizedFastModel = parsedFastModel.authType
+        ? `${parsedFastModel.authType}:${parsedFastModel.modelId}`
+        : modelName;
       const selector = (() => {
         try {
-          return resolveModelId(modelName);
+          return resolveModelId(normalizedFastModel);
         } catch {
           return undefined;
         }
@@ -300,14 +286,14 @@ export const modelCommand: SlashCommand = {
         };
       }
 
-      persistSetting(settings, 'fastModel', modelName);
+      persistSetting(settings, 'fastModel', normalizedFastModel);
       // Sync the runtime Config so forked agents pick up the change immediately
       // without requiring a restart.
-      config.setFastModel(modelName);
+      config.setFastModel(normalizedFastModel);
       return {
         type: 'message',
         messageType: 'info',
-        content: t('Fast Model') + ': ' + modelName,
+        content: t('Fast Model') + ': ' + normalizedFastModel,
       };
     }
 
@@ -372,7 +358,23 @@ export const modelCommand: SlashCommand = {
       );
       if (isDefaultModelCommand) {
         try {
-          persistMainModelDefault(settings, authType, modelName);
+          const afterConfig = config.getContentGeneratorConfig?.();
+          const effectiveAfterConfig =
+            afterConfig &&
+            (afterConfig.model !== contentGeneratorConfig.model ||
+              afterConfig.authType !== contentGeneratorConfig.authType)
+              ? afterConfig
+              : undefined;
+          persistSetting(
+            settings,
+            'security.auth.selectedType',
+            effectiveAfterConfig?.authType ?? targetAuthType,
+          );
+          persistSetting(
+            settings,
+            'model.name',
+            effectiveAfterConfig?.model ?? parsed.modelId,
+          );
         } catch (e) {
           const baseErrorMessage = e instanceof Error ? e.message : String(e);
           return {

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -327,7 +327,18 @@ export const modelCommand: SlashCommand = {
         modelName,
       );
       if (isDefaultModelCommand) {
-        persistMainModelDefault(settings, authType, modelName);
+        try {
+          persistMainModelDefault(settings, authType, modelName);
+        } catch (e) {
+          const baseErrorMessage = e instanceof Error ? e.message : String(e);
+          return {
+            type: 'message',
+            messageType: 'error',
+            content:
+              `Switched to '${effectiveModelName}' for this session, ` +
+              `but failed to persist as default.\n\n${baseErrorMessage}`,
+          };
+        }
       }
       return {
         type: 'message',

--- a/packages/cli/src/ui/commands/modelCommand.ts
+++ b/packages/cli/src/ui/commands/modelCommand.ts
@@ -20,7 +20,10 @@ import {
   resolveModelId,
 } from '@qwen-code/qwen-code-core';
 import type { LoadedSettings } from '../../config/settings.js';
-import { parseAcpModelOption } from '../../utils/acpModelUtils.js';
+import {
+  formatAcpModelId,
+  parseAcpModelOption,
+} from '../../utils/acpModelUtils.js';
 import { qwenOAuthDiscontinuedMessage } from '../utils/qwenOAuthDiscontinuedMessage.js';
 
 function persistSetting(
@@ -113,15 +116,30 @@ function formatUnavailableFastModelMessage(
 }
 
 // Get an array of the available model IDs as strings
-function getAvailableModelIds(context: CommandContext) {
+function getAvailableModelIds(
+  context: CommandContext,
+  options: { excludeRuntimeModels?: boolean } = {},
+) {
   const { services } = context;
   const { config } = services;
   if (!config) {
     return [];
   }
-  const availableModels = config.getAvailableModels();
-  // Convert AvailableModel[] to string[] on AvailableModel.id
-  return availableModels.map((model) => model.id);
+  const currentAuthType = config.getContentGeneratorConfig()?.authType;
+  const availableModels = config.getAllConfiguredModels();
+  return Array.from(
+    new Set(
+      availableModels
+        .filter(
+          (model) => !options.excludeRuntimeModels || !model.isRuntimeModel,
+        )
+        .map((model) =>
+          model.authType === currentAuthType
+            ? model.id
+            : formatAcpModelId(model.id, model.authType),
+        ),
+    ),
+  );
 }
 
 export const modelCommand: SlashCommand = {
@@ -136,12 +154,23 @@ export const modelCommand: SlashCommand = {
   kind: CommandKind.BUILT_IN,
   supportedModes: ['interactive', 'non_interactive', 'acp'] as const,
   completion: async (context, partialArg) => {
-    const trimmedPartialArg = partialArg.trim();
-    if (trimmedPartialArg.startsWith('--default ')) {
-      const modelPartial = trimmedPartialArg.replace('--default', '').trim();
-      return getAvailableModelIds(context)
+    const leadingTrimmedPartialArg = partialArg.trimStart();
+    const trimmedPartialArg = leadingTrimmedPartialArg.trimEnd();
+    if (leadingTrimmedPartialArg.startsWith('--default ')) {
+      const modelPartial = leadingTrimmedPartialArg
+        .slice('--default '.length)
+        .trimStart();
+      return getAvailableModelIds(context, { excludeRuntimeModels: true })
         .filter((id) => id.startsWith(modelPartial))
         .map((id) => `--default ${id}`);
+    }
+    if (leadingTrimmedPartialArg.startsWith('--fast ')) {
+      const modelPartial = leadingTrimmedPartialArg
+        .slice('--fast '.length)
+        .trimStart();
+      return getAvailableModelIds(context)
+        .filter((id) => id.startsWith(modelPartial))
+        .map((id) => `--fast ${id}`);
     }
 
     const flagCompletions = [

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -325,6 +325,24 @@ describe('<ModelDialog />', () => {
     expect(props.onClose).not.toHaveBeenCalled();
   });
 
+  it('blocks setting qwen-oauth as default with "d" (discontinued)', () => {
+    const { props, mockConfig, mockSettings } = renderComponent();
+
+    const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
+    keyPressHandler({
+      name: 'd',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      paste: false,
+      sequence: 'd',
+    });
+
+    expect(mockSettings.setValue).not.toHaveBeenCalled();
+    expect(mockConfig.switchModel).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
   it('stores authType-qualified selectors in fast model mode', async () => {
     const setFastModel = vi.fn();
     const { props, mockSettings } = renderComponent({ isFastModelMode: true }, {

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { render, cleanup, waitFor } from '@testing-library/react';
+import { act, render, cleanup, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ModelDialog } from './ModelDialog.js';
 import { useKeypress } from '../hooks/useKeypress.js';
@@ -302,7 +302,7 @@ describe('<ModelDialog />', () => {
     } as unknown as Partial<Config>);
 
     const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
-    keyPressHandler({
+    await keyPressHandler({
       name: 'd',
       ctrl: false,
       meta: false,
@@ -329,11 +329,11 @@ describe('<ModelDialog />', () => {
     expect(props.onClose).not.toHaveBeenCalled();
   });
 
-  it('blocks setting qwen-oauth as default with "d" (discontinued)', () => {
+  it('blocks setting qwen-oauth as default with "d" (discontinued)', async () => {
     const { props, mockConfig, mockSettings } = renderComponent();
 
     const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
-    keyPressHandler({
+    await keyPressHandler({
       name: 'd',
       ctrl: false,
       meta: false,
@@ -415,6 +415,78 @@ describe('<ModelDialog />', () => {
     expect(mockSettings.setValue).not.toHaveBeenCalled();
     expect(mockConfig.switchModel).not.toHaveBeenCalled();
     expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it('clears a stale default-model error before persisting a valid model', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const getAuthType = vi.fn(() => AuthType.USE_OPENAI);
+
+    const { mockSettings, queryByText } = renderComponent({}, {
+      getModel: vi.fn(() => 'gpt-4'),
+      getAuthType,
+      switchModel,
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: DEFAULT_QWEN_MODEL,
+          label: DEFAULT_QWEN_MODEL,
+          description: 'Qwen model',
+          authType: AuthType.QWEN_OAUTH,
+        },
+        {
+          id: 'gpt-4',
+          label: 'GPT-4',
+          description: 'GPT-4 model',
+          authType: AuthType.USE_OPENAI,
+        },
+      ]),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'gpt-4',
+      })),
+    } as unknown as Partial<Config>);
+
+    await act(async () => {
+      mockedSelect.mock.calls[0][0].onHighlight?.(
+        `${AuthType.QWEN_OAUTH}::${DEFAULT_QWEN_MODEL}`,
+      );
+    });
+    await act(async () => {
+      await mockedUseKeypress.mock.calls.at(-1)?.[0]({
+        name: 'd',
+        ctrl: false,
+        meta: false,
+        shift: false,
+        paste: false,
+        sequence: 'd',
+      });
+    });
+
+    expect(queryByText(/Qwen OAuth free tier was discontinued/)).not.toBeNull();
+
+    await act(async () => {
+      mockedSelect.mock.calls
+        .at(-1)?.[0]
+        .onHighlight?.(`${AuthType.USE_OPENAI}::gpt-4`);
+    });
+    await act(async () => {
+      await mockedUseKeypress.mock.calls.at(-1)?.[0]({
+        name: 'd',
+        ctrl: false,
+        meta: false,
+        shift: false,
+        paste: false,
+        sequence: 'd',
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'model.name',
+        'gpt-4',
+      );
+      expect(queryByText(/Qwen OAuth free tier was discontinued/)).toBeNull();
+    });
   });
 
   it('stores authType-qualified selectors in fast model mode', async () => {

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -664,10 +664,10 @@ describe('<ModelDialog />', () => {
     expect(props.onClose).not.toHaveBeenCalled();
   });
 
-  it('ignores runtime models when "d" is pressed', () => {
+  it('shows feedback when "d" is pressed on runtime models', async () => {
     const switchModel = vi.fn().mockResolvedValue(undefined);
     const runtimeSnapshotId = `$runtime|${AuthType.USE_OPENAI}|gpt-4`;
-    const { props, mockSettings } = renderComponent({}, {
+    const { props, mockSettings, queryByText } = renderComponent({}, {
       getAuthType: vi.fn(() => AuthType.USE_OPENAI),
       getModel: vi.fn(() => 'gpt-4'),
       switchModel,
@@ -691,18 +691,23 @@ describe('<ModelDialog />', () => {
     } as unknown as Partial<Config>);
 
     const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
-    keyPressHandler({
-      name: 'd',
-      ctrl: false,
-      meta: false,
-      shift: false,
-      paste: false,
-      sequence: 'd',
+    await act(async () => {
+      keyPressHandler({
+        name: 'd',
+        ctrl: false,
+        meta: false,
+        shift: false,
+        paste: false,
+        sequence: 'd',
+      });
     });
 
     expect(mockSettings.setValue).not.toHaveBeenCalled();
     expect(switchModel).not.toHaveBeenCalled();
     expect(props.onClose).not.toHaveBeenCalled();
+    expect(
+      queryByText(/Runtime models cannot be set as default/),
+    ).not.toBeNull();
   });
 
   it('ignores "d" in fast model mode', () => {
@@ -973,6 +978,40 @@ describe('<ModelDialog />', () => {
     expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('shows an error when fast model runtime sync fails', async () => {
+    const setFastModel = vi.fn(() => {
+      throw new Error('Runtime config rejected the model');
+    });
+    const { props, mockSettings, queryByText } = renderComponent(
+      { isFastModelMode: true },
+      {
+        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+        getModel: vi.fn(() => 'gpt-4'),
+        getAllConfiguredModels: vi.fn(() => [
+          {
+            id: 'gpt-4',
+            label: 'gpt-4',
+            authType: AuthType.USE_OPENAI,
+          },
+        ]),
+        setFastModel,
+      } as unknown as Partial<Config>,
+    );
+
+    const childOnSelect = mockedSelect.mock.calls[0][0].onSelect;
+    await act(async () => {
+      await childOnSelect('gpt-4');
+    });
+
+    await waitFor(() => {
+      expect(queryByText(/Failed to set fast model to 'gpt-4'/)).not.toBeNull();
+      expect(queryByText(/Runtime config rejected the model/)).not.toBeNull();
+    });
+    expect(setFastModel).toHaveBeenCalledWith('gpt-4');
+    expect(mockSettings.setValue).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
   it('shows an error when fast model persistence fails', async () => {
     const setFastModel = vi.fn();
     const { props, mockSettings, queryByText } = renderComponent(
@@ -1000,10 +1039,12 @@ describe('<ModelDialog />', () => {
     });
 
     await waitFor(() => {
-      expect(queryByText(/Failed to set fast model to 'gpt-4'/)).not.toBeNull();
+      expect(
+        queryByText(/Fast model set to 'gpt-4' for this session/),
+      ).not.toBeNull();
       expect(queryByText(/Disk is read-only/)).not.toBeNull();
     });
-    expect(setFastModel).not.toHaveBeenCalled();
+    expect(setFastModel).toHaveBeenCalledWith('gpt-4');
     expect(props.onClose).not.toHaveBeenCalled();
   });
 
@@ -1031,9 +1072,7 @@ describe('<ModelDialog />', () => {
     });
 
     expect(queryByText(/Failed to switch model to 'gpt-4'/)).not.toBeNull();
-    expect(
-      queryByText(/Failed to switch model to 'openai::gpt-4/),
-    ).toBeNull();
+    expect(queryByText(/Failed to switch model to 'openai::gpt-4/)).toBeNull();
   });
 
   it('highlights the cross-auth row for a bare fast-model setting', () => {

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -621,6 +621,40 @@ describe('<ModelDialog />', () => {
     });
   });
 
+  it('shows an error when setting default model without config', async () => {
+    const mockSettings = {
+      isTrusted: true,
+      user: { settings: {} },
+      workspace: { settings: {} },
+      setValue: vi.fn(),
+    } as unknown as LoadedSettings;
+
+    const { queryByText } = render(
+      <SettingsContext.Provider value={mockSettings}>
+        <ConfigContext.Provider value={undefined}>
+          <ModelDialog onClose={vi.fn()} />
+        </ConfigContext.Provider>
+      </SettingsContext.Provider>,
+    );
+
+    const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
+    await act(async () => {
+      await keyPressHandler({
+        name: 'd',
+        ctrl: false,
+        meta: false,
+        shift: false,
+        paste: false,
+        sequence: 'd',
+      });
+    });
+
+    await waitFor(() => {
+      expect(queryByText(/Configuration not available/)).not.toBeNull();
+    });
+    expect(mockSettings.setValue).not.toHaveBeenCalled();
+  });
+
   it('clears a stale default-model error before persisting a valid model', async () => {
     const switchModel = vi.fn().mockResolvedValue(undefined);
     const getAuthType = vi.fn(() => AuthType.USE_OPENAI);

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -224,7 +224,7 @@ describe('<ModelDialog />', () => {
     expect(props.onClose).not.toHaveBeenCalled();
   });
 
-  it('calls config.switchModel and onClose when selecting a non-OAuth model', async () => {
+  it('switches the current session without persisting when selecting a non-OAuth model', async () => {
     const switchModel = vi.fn().mockResolvedValue(undefined);
     const getAuthType = vi.fn(() => AuthType.USE_OPENAI);
     const getAvailableModelsForAuthType = vi.fn((t: AuthType) => {
@@ -275,6 +275,42 @@ describe('<ModelDialog />', () => {
     expect(switchModel).toHaveBeenCalledWith(AuthType.USE_OPENAI, 'gpt-4', {
       baseUrl: undefined,
     });
+    expect(mockSettings.setValue).not.toHaveBeenCalled();
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists the highlighted model as the default when "d" is pressed', () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const getAuthType = vi.fn(() => AuthType.USE_OPENAI);
+
+    const { props, mockSettings } = renderComponent({}, {
+      getModel: vi.fn(() => 'gpt-4'),
+      getAuthType,
+      switchModel,
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'gpt-4',
+          label: 'GPT-4',
+          description: 'GPT-4 model',
+          authType: AuthType.USE_OPENAI,
+        },
+      ]),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'gpt-4',
+      })),
+    } as unknown as Partial<Config>);
+
+    const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
+    keyPressHandler({
+      name: 'd',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      paste: false,
+      sequence: 'd',
+    });
+
     expect(mockSettings.setValue).toHaveBeenCalledWith(
       SettingScope.User,
       'model.name',
@@ -285,7 +321,8 @@ describe('<ModelDialog />', () => {
       'security.auth.selectedType',
       AuthType.USE_OPENAI,
     );
-    expect(props.onClose).toHaveBeenCalledTimes(1);
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
   });
 
   it('stores authType-qualified selectors in fast model mode', async () => {

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { render, cleanup } from '@testing-library/react';
+import { render, cleanup, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ModelDialog } from './ModelDialog.js';
 import { useKeypress } from '../hooks/useKeypress.js';
@@ -279,7 +279,7 @@ describe('<ModelDialog />', () => {
     expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('persists the highlighted model as the default when "d" is pressed', () => {
+  it('persists the highlighted model as the default when "d" is pressed', async () => {
     const switchModel = vi.fn().mockResolvedValue(undefined);
     const getAuthType = vi.fn(() => AuthType.USE_OPENAI);
 
@@ -311,22 +311,96 @@ describe('<ModelDialog />', () => {
       sequence: 'd',
     });
 
-    expect(mockSettings.setValue).toHaveBeenCalledWith(
-      SettingScope.User,
-      'model.name',
-      'gpt-4',
-    );
-    expect(mockSettings.setValue).toHaveBeenCalledWith(
-      SettingScope.User,
-      'security.auth.selectedType',
-      AuthType.USE_OPENAI,
-    );
-    expect(switchModel).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(switchModel).toHaveBeenCalledWith(AuthType.USE_OPENAI, 'gpt-4', {
+        baseUrl: undefined,
+      });
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'model.name',
+        'gpt-4',
+      );
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'security.auth.selectedType',
+        AuthType.USE_OPENAI,
+      );
+    });
     expect(props.onClose).not.toHaveBeenCalled();
   });
 
   it('blocks setting qwen-oauth as default with "d" (discontinued)', () => {
     const { props, mockConfig, mockSettings } = renderComponent();
+
+    const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
+    keyPressHandler({
+      name: 'd',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      paste: false,
+      sequence: 'd',
+    });
+
+    expect(mockSettings.setValue).not.toHaveBeenCalled();
+    expect(mockConfig.switchModel).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it('ignores Ctrl+D for setting the highlighted model as default', () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const getAuthType = vi.fn(() => AuthType.USE_OPENAI);
+
+    const { props, mockSettings } = renderComponent({}, {
+      getModel: vi.fn(() => 'gpt-4'),
+      getAuthType,
+      switchModel,
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'gpt-4',
+          label: 'GPT-4',
+          description: 'GPT-4 model',
+          authType: AuthType.USE_OPENAI,
+        },
+      ]),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'gpt-4',
+      })),
+    } as unknown as Partial<Config>);
+
+    const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
+    keyPressHandler({
+      name: 'd',
+      ctrl: true,
+      meta: false,
+      shift: false,
+      paste: false,
+      sequence: '\x04',
+    });
+
+    expect(mockSettings.setValue).not.toHaveBeenCalled();
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it('blocks setting runtime qwen-oauth as default with "d"', () => {
+    const runtimeSnapshotId = `$runtime|${AuthType.QWEN_OAUTH}|${DEFAULT_QWEN_MODEL}`;
+    const { props, mockConfig, mockSettings } = renderComponent({}, {
+      getActiveRuntimeModelSnapshot: vi.fn(() => ({
+        id: runtimeSnapshotId,
+      })),
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: DEFAULT_QWEN_MODEL,
+          label: DEFAULT_QWEN_MODEL,
+          description: '',
+          authType: AuthType.QWEN_OAUTH,
+          isRuntimeModel: true,
+          runtimeSnapshotId,
+        },
+      ]),
+    } as unknown as Partial<Config>);
 
     const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
     keyPressHandler({

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -329,6 +329,110 @@ describe('<ModelDialog />', () => {
     expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('persists the effective model after "d" switches the session', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+
+    const { mockSettings } = renderComponent({}, {
+      getModel: vi.fn(() => 'gpt-4'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      switchModel,
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'gpt-4',
+          label: 'GPT-4',
+          description: 'GPT-4 model',
+          authType: AuthType.USE_OPENAI,
+        },
+      ]),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_ANTHROPIC,
+        model: 'claude-effective',
+      })),
+    } as unknown as Partial<Config>);
+
+    const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
+    keyPressHandler({
+      name: 'd',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      paste: false,
+      sequence: 'd',
+    });
+
+    await waitFor(() => {
+      expect(switchModel).toHaveBeenCalledWith(AuthType.USE_OPENAI, 'gpt-4', {
+        baseUrl: undefined,
+      });
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'model.name',
+        'claude-effective',
+      );
+      expect(mockSettings.setValue).toHaveBeenCalledWith(
+        SettingScope.User,
+        'security.auth.selectedType',
+        AuthType.USE_ANTHROPIC,
+      );
+    });
+  });
+
+  it('ignores repeated "d" presses while a model switch is in flight', async () => {
+    let resolveSwitch!: () => void;
+    const switchModel = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSwitch = resolve;
+        }),
+    );
+
+    const { props } = renderComponent({}, {
+      getModel: vi.fn(() => 'gpt-4'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      switchModel,
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'gpt-4',
+          label: 'GPT-4',
+          description: 'GPT-4 model',
+          authType: AuthType.USE_OPENAI,
+        },
+      ]),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'gpt-4',
+      })),
+    } as unknown as Partial<Config>);
+
+    const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
+    keyPressHandler({
+      name: 'd',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      paste: false,
+      sequence: 'd',
+    });
+    keyPressHandler({
+      name: 'd',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      paste: false,
+      sequence: 'd',
+    });
+
+    expect(switchModel).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSwitch();
+    });
+
+    await waitFor(() => {
+      expect(props.onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
   it('blocks setting qwen-oauth as default with "d" (discontinued)', async () => {
     const { props, mockConfig, mockSettings } = renderComponent();
 

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -488,6 +488,57 @@ describe('<ModelDialog />', () => {
     expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('cancels session switch completion side effects when Escape closes during Enter selection', async () => {
+    let resolveSwitch!: () => void;
+    const switchModel = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSwitch = resolve;
+        }),
+    );
+
+    const { props, mockSettings } = renderComponent({}, {
+      getModel: vi.fn(() => 'gpt-4'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      switchModel,
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'gpt-4',
+          label: 'GPT-4',
+          description: 'GPT-4 model',
+          authType: AuthType.USE_OPENAI,
+        },
+      ]),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'gpt-4',
+      })),
+    } as unknown as Partial<Config>);
+
+    const childOnSelect = mockedSelect.mock.calls[0][0].onSelect;
+    const selectPromise = childOnSelect(`${AuthType.USE_OPENAI}::gpt-4`);
+
+    const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
+    keyPressHandler({
+      name: 'escape',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      paste: false,
+      sequence: '\x1b',
+    });
+
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSwitch();
+      await selectPromise;
+    });
+
+    expect(mockSettings.setValue).not.toHaveBeenCalled();
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
   it('blocks setting qwen-oauth as default with "d" (discontinued)', async () => {
     const { props, mockConfig, mockSettings } = renderComponent();
 

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -535,6 +535,53 @@ describe('<ModelDialog />', () => {
     expect(mockSettings.setValue).not.toHaveBeenCalled();
   });
 
+  it('shows an error when default model persistence fails after switching', async () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+
+    const { mockSettings, queryByText } = renderComponent({}, {
+      getModel: vi.fn(() => 'gpt-4'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      switchModel,
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'gpt-4',
+          label: 'GPT-4',
+          description: 'GPT-4 model',
+          authType: AuthType.USE_OPENAI,
+        },
+      ]),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'gpt-4',
+      })),
+    } as unknown as Partial<Config>);
+    vi.mocked(mockSettings.setValue).mockImplementation(() => {
+      throw new Error('Disk is read-only');
+    });
+
+    const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
+    await act(async () => {
+      await keyPressHandler({
+        name: 'd',
+        ctrl: false,
+        meta: false,
+        shift: false,
+        paste: false,
+        sequence: 'd',
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        queryByText(/Failed to set default model to 'gpt-4'/),
+      ).not.toBeNull();
+      expect(queryByText(/Disk is read-only/)).not.toBeNull();
+    });
+    expect(switchModel).toHaveBeenCalledWith(AuthType.USE_OPENAI, 'gpt-4', {
+      baseUrl: undefined,
+    });
+  });
+
   it('clears a stale default-model error before persisting a valid model', async () => {
     const switchModel = vi.fn().mockResolvedValue(undefined);
     const getAuthType = vi.fn(() => AuthType.USE_OPENAI);

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -1007,6 +1007,35 @@ describe('<ModelDialog />', () => {
     expect(props.onClose).not.toHaveBeenCalled();
   });
 
+  it('uses the parsed model id in switch failure messages', async () => {
+    const switchModel = vi
+      .fn()
+      .mockRejectedValue(new Error('Provider rejected the model'));
+    const { queryByText } = renderComponent({}, {
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getModel: vi.fn(() => 'gpt-4'),
+      switchModel,
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'gpt-4',
+          label: 'gpt-4',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://custom.api',
+        },
+      ]),
+    } as unknown as Partial<Config>);
+
+    const childOnSelect = mockedSelect.mock.calls[0][0].onSelect;
+    await act(async () => {
+      await childOnSelect(`${AuthType.USE_OPENAI}::gpt-4\0https://custom.api`);
+    });
+
+    expect(queryByText(/Failed to switch model to 'gpt-4'/)).not.toBeNull();
+    expect(
+      queryByText(/Failed to switch model to 'openai::gpt-4/),
+    ).toBeNull();
+  });
+
   it('highlights the cross-auth row for a bare fast-model setting', () => {
     // `/model --fast deepseek-v4-flash` validates across all providers and
     // persists the bare model id. When the dialog re-opens, it must locate

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -433,6 +433,61 @@ describe('<ModelDialog />', () => {
     });
   });
 
+  it('cancels default persistence when Escape closes during a model switch', async () => {
+    let resolveSwitch!: () => void;
+    const switchModel = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSwitch = resolve;
+        }),
+    );
+
+    const { props, mockSettings } = renderComponent({}, {
+      getModel: vi.fn(() => 'gpt-4'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      switchModel,
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'gpt-4',
+          label: 'GPT-4',
+          description: 'GPT-4 model',
+          authType: AuthType.USE_OPENAI,
+        },
+      ]),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'gpt-4',
+      })),
+    } as unknown as Partial<Config>);
+
+    const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
+    keyPressHandler({
+      name: 'd',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      paste: false,
+      sequence: 'd',
+    });
+    keyPressHandler({
+      name: 'escape',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      paste: false,
+      sequence: '\x1b',
+    });
+
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveSwitch();
+    });
+
+    expect(mockSettings.setValue).not.toHaveBeenCalled();
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
   it('blocks setting qwen-oauth as default with "d" (discontinued)', async () => {
     const { props, mockConfig, mockSettings } = renderComponent();
 

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -326,7 +326,7 @@ describe('<ModelDialog />', () => {
         AuthType.USE_OPENAI,
       );
     });
-    expect(props.onClose).not.toHaveBeenCalled();
+    expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
   it('blocks setting qwen-oauth as default with "d" (discontinued)', async () => {
@@ -377,6 +377,43 @@ describe('<ModelDialog />', () => {
       shift: false,
       paste: false,
       sequence: '\x04',
+    });
+
+    expect(mockSettings.setValue).not.toHaveBeenCalled();
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it('ignores Meta+D for setting the highlighted model as default', () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const getAuthType = vi.fn(() => AuthType.USE_OPENAI);
+
+    const { props, mockSettings } = renderComponent({}, {
+      getModel: vi.fn(() => 'gpt-4'),
+      getAuthType,
+      switchModel,
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'gpt-4',
+          label: 'GPT-4',
+          description: 'GPT-4 model',
+          authType: AuthType.USE_OPENAI,
+        },
+      ]),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'gpt-4',
+      })),
+    } as unknown as Partial<Config>);
+
+    const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
+    keyPressHandler({
+      name: 'd',
+      ctrl: false,
+      meta: true,
+      shift: false,
+      paste: false,
+      sequence: 'd',
     });
 
     expect(mockSettings.setValue).not.toHaveBeenCalled();
@@ -573,7 +610,9 @@ describe('<ModelDialog />', () => {
 
     await waitFor(() => {
       expect(
-        queryByText(/Failed to set default model to 'gpt-4'/),
+        queryByText(
+          /Switched to 'gpt-4' for this session, but failed to persist as default/,
+        ),
       ).not.toBeNull();
       expect(queryByText(/Disk is read-only/)).not.toBeNull();
     });

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -867,6 +867,40 @@ describe('<ModelDialog />', () => {
     expect(props.onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('shows an error when fast model persistence fails', async () => {
+    const setFastModel = vi.fn();
+    const { props, mockSettings, queryByText } = renderComponent(
+      { isFastModelMode: true },
+      {
+        getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+        getModel: vi.fn(() => 'gpt-4'),
+        getAllConfiguredModels: vi.fn(() => [
+          {
+            id: 'gpt-4',
+            label: 'gpt-4',
+            authType: AuthType.USE_OPENAI,
+          },
+        ]),
+        setFastModel,
+      } as unknown as Partial<Config>,
+    );
+    vi.mocked(mockSettings.setValue).mockImplementation(() => {
+      throw new Error('Disk is read-only');
+    });
+
+    const childOnSelect = mockedSelect.mock.calls[0][0].onSelect;
+    await act(async () => {
+      await childOnSelect('gpt-4');
+    });
+
+    await waitFor(() => {
+      expect(queryByText(/Failed to set fast model to 'gpt-4'/)).not.toBeNull();
+      expect(queryByText(/Disk is read-only/)).not.toBeNull();
+    });
+    expect(setFastModel).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
   it('highlights the cross-auth row for a bare fast-model setting', () => {
     // `/model --fast deepseek-v4-flash` validates across all providers and
     // persists the bare model id. When the dialog re-opens, it must locate

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -417,6 +417,124 @@ describe('<ModelDialog />', () => {
     expect(props.onClose).not.toHaveBeenCalled();
   });
 
+  it('ignores runtime models when "d" is pressed', () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const runtimeSnapshotId = `$runtime|${AuthType.USE_OPENAI}|gpt-4`;
+    const { props, mockSettings } = renderComponent({}, {
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getModel: vi.fn(() => 'gpt-4'),
+      switchModel,
+      getActiveRuntimeModelSnapshot: vi.fn(() => ({
+        id: runtimeSnapshotId,
+      })),
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'gpt-4',
+          label: 'GPT-4',
+          description: '',
+          authType: AuthType.USE_OPENAI,
+          isRuntimeModel: true,
+          runtimeSnapshotId,
+        },
+      ]),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'gpt-4',
+      })),
+    } as unknown as Partial<Config>);
+
+    const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
+    keyPressHandler({
+      name: 'd',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      paste: false,
+      sequence: 'd',
+    });
+
+    expect(mockSettings.setValue).not.toHaveBeenCalled();
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it('ignores "d" in fast model mode', () => {
+    const switchModel = vi.fn().mockResolvedValue(undefined);
+    const { props, mockSettings } = renderComponent({ isFastModelMode: true }, {
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getModel: vi.fn(() => 'gpt-4'),
+      switchModel,
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'gpt-4',
+          label: 'GPT-4',
+          description: '',
+          authType: AuthType.USE_OPENAI,
+        },
+      ]),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'gpt-4',
+      })),
+    } as unknown as Partial<Config>);
+
+    const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
+    keyPressHandler({
+      name: 'd',
+      ctrl: false,
+      meta: false,
+      shift: false,
+      paste: false,
+      sequence: 'd',
+    });
+
+    expect(mockSettings.setValue).not.toHaveBeenCalled();
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(props.onClose).not.toHaveBeenCalled();
+  });
+
+  it('shows an error when setting the highlighted model as default fails', async () => {
+    const switchModel = vi
+      .fn()
+      .mockRejectedValue(new Error('Credential refresh failed'));
+
+    const { mockSettings, queryByText } = renderComponent({}, {
+      getModel: vi.fn(() => 'gpt-4'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      switchModel,
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'gpt-4',
+          label: 'GPT-4',
+          description: 'GPT-4 model',
+          authType: AuthType.USE_OPENAI,
+        },
+      ]),
+      getContentGeneratorConfig: vi.fn(() => ({
+        authType: AuthType.USE_OPENAI,
+        model: 'gpt-4',
+      })),
+    } as unknown as Partial<Config>);
+
+    const keyPressHandler = mockedUseKeypress.mock.calls[0][0];
+    await act(async () => {
+      await keyPressHandler({
+        name: 'd',
+        ctrl: false,
+        meta: false,
+        shift: false,
+        paste: false,
+        sequence: 'd',
+      });
+    });
+
+    await waitFor(() => {
+      expect(queryByText(/Failed to switch model to 'gpt-4'/)).not.toBeNull();
+      expect(queryByText(/Credential refresh failed/)).not.toBeNull();
+    });
+    expect(mockSettings.setValue).not.toHaveBeenCalled();
+  });
+
   it('clears a stale default-model error before persisting a valid model', async () => {
     const switchModel = vi.fn().mockResolvedValue(undefined);
     const getAuthType = vi.fn(() => AuthType.USE_OPENAI);

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -199,6 +199,7 @@ export function ModelDialog({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [highlightedValue, setHighlightedValue] = useState<string | null>(null);
   const isSwitchingRef = useRef(false);
+  const cancelledSwitchRef = useRef(false);
 
   const authType = config?.getAuthType();
 
@@ -401,6 +402,9 @@ export function ModelDialog({
   const handleKeypress = useCallback(
     (key: Key) => {
       if (key.name === 'escape' || (key.name === 'left' && isFastModelMode)) {
+        if (isSwitchingRef.current) {
+          cancelledSwitchRef.current = true;
+        }
         onClose();
         return;
       }
@@ -423,6 +427,7 @@ export function ModelDialog({
         }
 
         isSwitchingRef.current = true;
+        cancelledSwitchRef.current = false;
         setErrorMessage(null);
         void (async () => {
           let after: ContentGeneratorConfig | undefined;
@@ -441,6 +446,9 @@ export function ModelDialog({
               after = config.getContentGeneratorConfig?.() as
                 | ContentGeneratorConfig
                 | undefined;
+              if (cancelledSwitchRef.current) {
+                return;
+              }
               effectiveAuthType = after?.authType ?? entry.authType;
               effectiveModelId = after?.model ?? entry.model.id;
             } catch (e) {

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -5,7 +5,7 @@
  */
 
 import type React from 'react';
-import { useCallback, useContext, useMemo, useState } from 'react';
+import { useCallback, useContext, useMemo, useRef, useState } from 'react';
 import { Box, Text } from 'ink';
 import {
   AuthType,
@@ -198,6 +198,7 @@ export function ModelDialog({
   // Local error state for displaying errors within the dialog
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [highlightedValue, setHighlightedValue] = useState<string | null>(null);
+  const isSwitchingRef = useRef(false);
 
   const authType = config?.getAuthType();
 
@@ -413,43 +414,69 @@ export function ModelDialog({
           setErrorMessage(qwenOAuthDiscontinuedMessage());
           return;
         }
+        if (isSwitchingRef.current) {
+          return;
+        }
 
+        isSwitchingRef.current = true;
         setErrorMessage(null);
         void (async () => {
-          try {
-            await config.switchModel(
-              highlightedEntry.authType,
-              highlightedEntry.model.id,
-              { baseUrl: highlightedEntry.model.baseUrl },
-            );
-            logModelSlashCommand(
-              config,
-              new ModelSlashCommandEvent(highlightedEntry.model.id),
-            );
-          } catch (e) {
-            const baseErrorMessage = e instanceof Error ? e.message : String(e);
-            setErrorMessage(
-              `Failed to switch model to '${highlightedEntry.model.id}'.\n\n${baseErrorMessage}`,
-            );
-            return;
-          }
+          let after: ContentGeneratorConfig | undefined;
+          let effectiveAuthType = highlightedEntry.authType;
+          let effectiveModelId = highlightedEntry.model.id;
 
           try {
-            persistDefaultModelSelection({
-              settings,
+            try {
+              await config.switchModel(
+                highlightedEntry.authType,
+                highlightedEntry.model.id,
+                { baseUrl: highlightedEntry.model.baseUrl },
+              );
+              logModelSlashCommand(
+                config,
+                new ModelSlashCommandEvent(highlightedEntry.model.id),
+              );
+              after = config.getContentGeneratorConfig?.() as
+                | ContentGeneratorConfig
+                | undefined;
+              effectiveAuthType = after?.authType ?? highlightedEntry.authType;
+              effectiveModelId = after?.model ?? highlightedEntry.model.id;
+            } catch (e) {
+              const baseErrorMessage =
+                e instanceof Error ? e.message : String(e);
+              setErrorMessage(
+                `Failed to switch model to '${highlightedEntry.model.id}'.\n\n${baseErrorMessage}`,
+              );
+              return;
+            }
+
+            try {
+              persistDefaultModelSelection({
+                settings,
+                uiState,
+                authType: effectiveAuthType,
+                modelId: effectiveModelId,
+              });
+            } catch (e) {
+              const baseErrorMessage =
+                e instanceof Error ? e.message : String(e);
+              setErrorMessage(
+                `Switched to '${effectiveModelId}' for this session, but failed to persist as default.\n\n${baseErrorMessage}`,
+              );
+              return;
+            }
+
+            logModelSwitchResult({
               uiState,
-              authType: highlightedEntry.authType,
-              modelId: highlightedEntry.model.id,
+              after,
+              effectiveAuthType,
+              effectiveModelId,
+              isRuntime: false,
             });
-          } catch (e) {
-            const baseErrorMessage = e instanceof Error ? e.message : String(e);
-            setErrorMessage(
-              `Switched to '${highlightedEntry.model.id}' for this session, but failed to persist as default.\n\n${baseErrorMessage}`,
-            );
-            return;
+            onClose();
+          } finally {
+            isSwitchingRef.current = false;
           }
-
-          onClose();
         })();
       }
     },
@@ -458,123 +485,132 @@ export function ModelDialog({
 
   const handleSelect = useCallback(
     async (selected: string) => {
-      setErrorMessage(null);
-
-      // Fast model mode: save authType:modelId so duplicate model ids across
-      // providers remain unambiguous. baseUrl is intentionally discarded.
-      if (isFastModelMode) {
-        let fastModel: string;
-        if (selected.includes('::')) {
-          const parsed = parseModelSelectionKey(selected);
-          fastModel = `${parsed.authType}:${parsed.modelId}`;
-        } else if (selected.startsWith('$runtime|')) {
-          const parts = selected.split('|');
-          fastModel =
-            parts[1] && parts[2] ? `${parts[1]}:${parts[2]}` : selected;
-        } else {
-          fastModel = selected;
-        }
-        const scope = getPersistScopeForModelSelection(settings);
-        settings.setValue(scope, 'fastModel', fastModel);
-        // Sync the runtime Config so forked agents pick up the change immediately.
-        config?.setFastModel(fastModel);
-        uiState?.historyManager.addItem(
-          {
-            type: 'success',
-            text: `${t('Fast Model')}: ${fastModel}`,
-          },
-          Date.now(),
-        );
-        onClose();
+      if (isSwitchingRef.current) {
         return;
       }
 
-      // Block selection of discontinued qwen-oauth models
-      // (only block non-runtime OAuth; runtime OAuth models from existing
-      //  cached tokens are still allowed to work until the server rejects them)
-      const isQwenOAuthSelection =
-        selected.startsWith(`${AuthType.QWEN_OAUTH}::`) ||
-        (selected.startsWith('$runtime|') &&
-          selected.split('|')[1] === AuthType.QWEN_OAUTH);
-      const isRuntimeOAuthSelection = selected.startsWith(
-        `$runtime|${AuthType.QWEN_OAUTH}|`,
-      );
-      if (isQwenOAuthSelection && !isRuntimeOAuthSelection) {
-        setErrorMessage(qwenOAuthDiscontinuedMessage());
-        return;
-      }
-
-      let after: ContentGeneratorConfig | undefined;
-      let effectiveAuthType: AuthType | undefined;
-      let effectiveModelId = selected;
-      let isRuntime = false;
-
-      if (!config) {
-        onClose();
-        return;
-      }
-
+      isSwitchingRef.current = true;
       try {
-        // Determine if this is a runtime model selection
-        // Runtime model format: $runtime|${authType}|${modelId}
-        isRuntime = selected.startsWith('$runtime|');
+        setErrorMessage(null);
 
-        let selectedAuthType: AuthType;
-        let modelId: string;
-
-        let selectedBaseUrl: string | undefined;
-        if (isRuntime) {
-          // For runtime models, extract authType from the snapshot ID
-          // Format: $runtime|${authType}|${modelId}
-          const parts = selected.split('|');
-          if (parts.length >= 2 && parts[0] === '$runtime') {
-            selectedAuthType = parts[1] as AuthType;
+        // Fast model mode: save authType:modelId so duplicate model ids across
+        // providers remain unambiguous. baseUrl is intentionally discarded.
+        if (isFastModelMode) {
+          let fastModel: string;
+          if (selected.includes('::')) {
+            const parsed = parseModelSelectionKey(selected);
+            fastModel = `${parsed.authType}:${parsed.modelId}`;
+          } else if (selected.startsWith('$runtime|')) {
+            const parts = selected.split('|');
+            fastModel =
+              parts[1] && parts[2] ? `${parts[1]}:${parts[2]}` : selected;
           } else {
-            selectedAuthType = authType as AuthType;
+            fastModel = selected;
           }
-          modelId = selected; // Pass the full snapshot ID to switchModel
-        } else {
-          const parsed = parseModelSelectionKey(selected);
-          selectedAuthType = (parsed.authType || authType) as AuthType;
-          modelId = parsed.modelId;
-          selectedBaseUrl = parsed.baseUrl;
+          const scope = getPersistScopeForModelSelection(settings);
+          settings.setValue(scope, 'fastModel', fastModel);
+          // Sync the runtime Config so forked agents pick up the change immediately.
+          config?.setFastModel(fastModel);
+          uiState?.historyManager.addItem(
+            {
+              type: 'success',
+              text: `${t('Fast Model')}: ${fastModel}`,
+            },
+            Date.now(),
+          );
+          onClose();
+          return;
         }
 
-        await config.switchModel(selectedAuthType, modelId, {
-          ...(selectedAuthType !== authType &&
-          selectedAuthType === AuthType.QWEN_OAUTH
-            ? { requireCachedCredentials: true }
-            : {}),
-          baseUrl: selectedBaseUrl,
+        // Block selection of discontinued qwen-oauth models
+        // (only block non-runtime OAuth; runtime OAuth models from existing
+        //  cached tokens are still allowed to work until the server rejects them)
+        const isQwenOAuthSelection =
+          selected.startsWith(`${AuthType.QWEN_OAUTH}::`) ||
+          (selected.startsWith('$runtime|') &&
+            selected.split('|')[1] === AuthType.QWEN_OAUTH);
+        const isRuntimeOAuthSelection = selected.startsWith(
+          `$runtime|${AuthType.QWEN_OAUTH}|`,
+        );
+        if (isQwenOAuthSelection && !isRuntimeOAuthSelection) {
+          setErrorMessage(qwenOAuthDiscontinuedMessage());
+          return;
+        }
+
+        let after: ContentGeneratorConfig | undefined;
+        let effectiveAuthType: AuthType | undefined;
+        let effectiveModelId = selected;
+        let isRuntime = false;
+
+        if (!config) {
+          onClose();
+          return;
+        }
+
+        try {
+          // Determine if this is a runtime model selection
+          // Runtime model format: $runtime|${authType}|${modelId}
+          isRuntime = selected.startsWith('$runtime|');
+
+          let selectedAuthType: AuthType;
+          let modelId: string;
+
+          let selectedBaseUrl: string | undefined;
+          if (isRuntime) {
+            // For runtime models, extract authType from the snapshot ID
+            // Format: $runtime|${authType}|${modelId}
+            const parts = selected.split('|');
+            if (parts.length >= 2 && parts[0] === '$runtime') {
+              selectedAuthType = parts[1] as AuthType;
+            } else {
+              selectedAuthType = authType as AuthType;
+            }
+            modelId = selected; // Pass the full snapshot ID to switchModel
+          } else {
+            const parsed = parseModelSelectionKey(selected);
+            selectedAuthType = (parsed.authType || authType) as AuthType;
+            modelId = parsed.modelId;
+            selectedBaseUrl = parsed.baseUrl;
+          }
+
+          await config.switchModel(selectedAuthType, modelId, {
+            ...(selectedAuthType !== authType &&
+            selectedAuthType === AuthType.QWEN_OAUTH
+              ? { requireCachedCredentials: true }
+              : {}),
+            baseUrl: selectedBaseUrl,
+          });
+
+          if (!isRuntime) {
+            const event = new ModelSlashCommandEvent(modelId);
+            logModelSlashCommand(config, event);
+          }
+
+          after = config.getContentGeneratorConfig?.() as
+            | ContentGeneratorConfig
+            | undefined;
+          effectiveAuthType = after?.authType ?? selectedAuthType ?? authType;
+          effectiveModelId = after?.model ?? modelId;
+        } catch (e) {
+          const baseErrorMessage = e instanceof Error ? e.message : String(e);
+          const errorPrefix = isRuntime
+            ? 'Failed to switch to runtime model.'
+            : `Failed to switch model to '${effectiveModelId ?? selected}'.`;
+          setErrorMessage(`${errorPrefix}\n\n${baseErrorMessage}`);
+          return;
+        }
+
+        logModelSwitchResult({
+          uiState,
+          after,
+          effectiveAuthType,
+          effectiveModelId,
+          isRuntime,
         });
-
-        if (!isRuntime) {
-          const event = new ModelSlashCommandEvent(modelId);
-          logModelSlashCommand(config, event);
-        }
-
-        after = config.getContentGeneratorConfig?.() as
-          | ContentGeneratorConfig
-          | undefined;
-        effectiveAuthType = after?.authType ?? selectedAuthType ?? authType;
-        effectiveModelId = after?.model ?? modelId;
-      } catch (e) {
-        const baseErrorMessage = e instanceof Error ? e.message : String(e);
-        const errorPrefix = isRuntime
-          ? 'Failed to switch to runtime model.'
-          : `Failed to switch model to '${effectiveModelId ?? selected}'.`;
-        setErrorMessage(`${errorPrefix}\n\n${baseErrorMessage}`);
-        return;
+        onClose();
+      } finally {
+        isSwitchingRef.current = false;
       }
-
-      logModelSwitchResult({
-        uiState,
-        after,
-        effectiveAuthType,
-        effectiveModelId,
-        isRuntime,
-      });
-      onClose();
     },
     [
       authType,

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -405,7 +405,8 @@ export function ModelDialog({
         !key.ctrl &&
         !key.meta &&
         !isFastModelMode &&
-        highlightedEntry
+        highlightedEntry &&
+        !highlightedEntry.isRuntime
       ) {
         if (highlightedEntry.authType === AuthType.QWEN_OAUTH) {
           setErrorMessage(
@@ -427,6 +428,10 @@ export function ModelDialog({
               highlightedEntry.authType,
               highlightedEntry.model.id,
               { baseUrl: highlightedEntry.model.baseUrl },
+            );
+            logModelSlashCommand(
+              config,
+              new ModelSlashCommandEvent(highlightedEntry.model.id),
             );
           } catch (e) {
             const baseErrorMessage = e instanceof Error ? e.message : String(e);

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -108,7 +108,6 @@ function persistAuthTypeSelection(
 }
 
 interface HandleModelSwitchSuccessParams {
-  settings: ReturnType<typeof useSettings>;
   uiState: UIState | null;
   after: ContentGeneratorConfig | undefined;
   effectiveAuthType: AuthType | undefined;
@@ -117,18 +116,12 @@ interface HandleModelSwitchSuccessParams {
 }
 
 function handleModelSwitchSuccess({
-  settings,
   uiState,
   after,
   effectiveAuthType,
   effectiveModelId,
   isRuntime,
 }: HandleModelSwitchSuccessParams): void {
-  persistModelSelection(settings, effectiveModelId);
-  if (effectiveAuthType) {
-    persistAuthTypeSelection(settings, effectiveAuthType);
-  }
-
   const baseUrl = after?.baseUrl ?? t('(default)');
   const maskedKey = maskApiKey(after?.apiKey);
   uiState?.historyManager.addItem(
@@ -142,6 +135,28 @@ function handleModelSwitchSuccess({
         `Base URL: ${baseUrl}` +
         `\n` +
         `API key: ${maskedKey}`,
+    },
+    Date.now(),
+  );
+}
+
+function persistDefaultModelSelection({
+  settings,
+  uiState,
+  authType,
+  modelId,
+}: {
+  settings: ReturnType<typeof useSettings>;
+  uiState: UIState | null;
+  authType: AuthType;
+  modelId: string;
+}): void {
+  persistModelSelection(settings, modelId);
+  persistAuthTypeSelection(settings, authType);
+  uiState?.historyManager.addItem(
+    {
+      type: 'success',
+      text: `${t('Default model')}: ${modelId}`,
     },
     Date.now(),
   );
@@ -354,15 +369,6 @@ export function ModelDialog({
         ? buildModelSelectionKey(authType, preferredModelId, currentBaseUrl)
         : '';
 
-  useKeypress(
-    (key) => {
-      if (key.name === 'escape' || (key.name === 'left' && isFastModelMode)) {
-        onClose();
-      }
-    },
-    { isActive: true },
-  );
-
   const initialIndex = useMemo(() => {
     const index = MODEL_OPTIONS.findIndex(
       (option) => option.value === preferredKey,
@@ -386,6 +392,37 @@ export function ModelDialog({
       },
     );
   }, [highlightedValue, preferredKey, availableModelEntries]);
+
+  useKeypress(
+    (key) => {
+      if (key.name === 'escape' || (key.name === 'left' && isFastModelMode)) {
+        onClose();
+        return;
+      }
+
+      if (key.name === 'd' && !isFastModelMode && highlightedEntry) {
+        if (
+          highlightedEntry.authType === AuthType.QWEN_OAUTH &&
+          !highlightedEntry.isRuntime
+        ) {
+          setErrorMessage(
+            t(
+              'Qwen OAuth free tier was discontinued on 2026-04-15. Please select a model from another provider or run /auth to switch.',
+            ),
+          );
+          return;
+        }
+
+        persistDefaultModelSelection({
+          settings,
+          uiState,
+          authType: highlightedEntry.authType,
+          modelId: highlightedEntry.model.id,
+        });
+      }
+    },
+    { isActive: true },
+  );
 
   const handleSelect = useCallback(
     async (selected: string) => {
@@ -503,7 +540,6 @@ export function ModelDialog({
       }
 
       handleModelSwitchSuccess({
-        settings,
         uiState,
         after,
         effectiveAuthType,
@@ -618,7 +654,11 @@ export function ModelDialog({
 
       <Box marginTop={1} flexDirection="column">
         <Text color={theme.text.secondary}>
-          {t('Enter to select, ↑↓ to navigate, Esc to close')}
+          {isFastModelMode
+            ? t('Enter to select, ↑↓ to navigate, Esc to close')
+            : t(
+                'Enter to select, d to set default, ↑↓ to navigate, Esc to close',
+              )}
         </Text>
       </Box>
     </Box>

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -400,11 +400,14 @@ export function ModelDialog({
         return;
       }
 
-      if (key.name === 'd' && !isFastModelMode && highlightedEntry) {
-        if (
-          highlightedEntry.authType === AuthType.QWEN_OAUTH &&
-          !highlightedEntry.isRuntime
-        ) {
+      if (
+        key.name === 'd' &&
+        !key.ctrl &&
+        !key.meta &&
+        !isFastModelMode &&
+        highlightedEntry
+      ) {
+        if (highlightedEntry.authType === AuthType.QWEN_OAUTH) {
           setErrorMessage(
             t(
               'Qwen OAuth free tier was discontinued on 2026-04-15. Please select a model from another provider or run /auth to switch.',
@@ -413,12 +416,33 @@ export function ModelDialog({
           return;
         }
 
-        persistDefaultModelSelection({
-          settings,
-          uiState,
-          authType: highlightedEntry.authType,
-          modelId: highlightedEntry.model.id,
-        });
+        setErrorMessage(null);
+        void (async () => {
+          if (!config) {
+            return;
+          }
+
+          try {
+            await config.switchModel(
+              highlightedEntry.authType,
+              highlightedEntry.model.id,
+              { baseUrl: highlightedEntry.model.baseUrl },
+            );
+          } catch (e) {
+            const baseErrorMessage = e instanceof Error ? e.message : String(e);
+            setErrorMessage(
+              `Failed to switch model to '${highlightedEntry.model.id}'.\n\n${baseErrorMessage}`,
+            );
+            return;
+          }
+
+          persistDefaultModelSelection({
+            settings,
+            uiState,
+            authType: highlightedEntry.authType,
+            modelId: highlightedEntry.model.id,
+          });
+        })();
       }
     },
     { isActive: true },

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -25,6 +25,7 @@ import { UIStateContext, type UIState } from '../contexts/UIStateContext.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 import { getPersistScopeForModelSelection } from '../../config/modelProvidersScope.js';
 import { t } from '../../i18n/index.js';
+import { qwenOAuthDiscontinuedMessage } from '../utils/qwenOAuthDiscontinuedMessage.js';
 
 function formatModalities(modalities?: InputModalities): string {
   if (!modalities) return t('text-only');
@@ -409,11 +410,7 @@ export function ModelDialog({
         !highlightedEntry.isRuntime
       ) {
         if (highlightedEntry.authType === AuthType.QWEN_OAUTH) {
-          setErrorMessage(
-            t(
-              'Qwen OAuth free tier was discontinued on 2026-04-15. Please select a model from another provider or run /auth to switch.',
-            ),
-          );
+          setErrorMessage(qwenOAuthDiscontinuedMessage());
           return;
         }
 
@@ -441,12 +438,19 @@ export function ModelDialog({
             return;
           }
 
-          persistDefaultModelSelection({
-            settings,
-            uiState,
-            authType: highlightedEntry.authType,
-            modelId: highlightedEntry.model.id,
-          });
+          try {
+            persistDefaultModelSelection({
+              settings,
+              uiState,
+              authType: highlightedEntry.authType,
+              modelId: highlightedEntry.model.id,
+            });
+          } catch (e) {
+            const baseErrorMessage = e instanceof Error ? e.message : String(e);
+            setErrorMessage(
+              `Failed to set default model to '${highlightedEntry.model.id}'.\n\n${baseErrorMessage}`,
+            );
+          }
         })();
       }
     },
@@ -497,11 +501,7 @@ export function ModelDialog({
         `$runtime|${AuthType.QWEN_OAUTH}|`,
       );
       if (isQwenOAuthSelection && !isRuntimeOAuthSelection) {
-        setErrorMessage(
-          t(
-            'Qwen OAuth free tier was discontinued on 2026-04-15. Please select a model from another provider or run /auth to switch.',
-          ),
-        );
+        setErrorMessage(qwenOAuthDiscontinuedMessage());
         return;
       }
 

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -108,7 +108,7 @@ function persistAuthTypeSelection(
   settings.setValue(scope, 'security.auth.selectedType', authType);
 }
 
-interface HandleModelSwitchSuccessParams {
+interface LogModelSwitchResultParams {
   uiState: UIState | null;
   after: ContentGeneratorConfig | undefined;
   effectiveAuthType: AuthType | undefined;
@@ -116,13 +116,13 @@ interface HandleModelSwitchSuccessParams {
   isRuntime: boolean;
 }
 
-function handleModelSwitchSuccess({
+function logModelSwitchResult({
   uiState,
   after,
   effectiveAuthType,
   effectiveModelId,
   isRuntime,
-}: HandleModelSwitchSuccessParams): void {
+}: LogModelSwitchResultParams): void {
   const baseUrl = after?.baseUrl ?? t('(default)');
   const maskedKey = maskApiKey(after?.apiKey);
   uiState?.historyManager.addItem(
@@ -448,9 +448,12 @@ export function ModelDialog({
           } catch (e) {
             const baseErrorMessage = e instanceof Error ? e.message : String(e);
             setErrorMessage(
-              `Failed to set default model to '${highlightedEntry.model.id}'.\n\n${baseErrorMessage}`,
+              `Switched to '${highlightedEntry.model.id}' for this session, but failed to persist as default.\n\n${baseErrorMessage}`,
             );
+            return;
           }
+
+          onClose();
         })();
       }
     },
@@ -568,7 +571,7 @@ export function ModelDialog({
         return;
       }
 
-      handleModelSwitchSuccess({
+      logModelSwitchResult({
         uiState,
         after,
         effectiveAuthType,

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -502,6 +502,7 @@ export function ModelDialog({
       }
 
       isSwitchingRef.current = true;
+      cancelledSwitchRef.current = false;
       try {
         setErrorMessage(null);
 
@@ -560,6 +561,7 @@ export function ModelDialog({
         let after: ContentGeneratorConfig | undefined;
         let effectiveAuthType: AuthType | undefined;
         let effectiveModelId = selected;
+        let attemptedModelId = selected;
         let isRuntime = false;
 
         if (!config) {
@@ -590,6 +592,7 @@ export function ModelDialog({
             const parsed = parseModelSelectionKey(selected);
             selectedAuthType = (parsed.authType || authType) as AuthType;
             modelId = parsed.modelId;
+            attemptedModelId = modelId;
             selectedBaseUrl = parsed.baseUrl;
           }
 
@@ -618,7 +621,7 @@ export function ModelDialog({
           const baseErrorMessage = e instanceof Error ? e.message : String(e);
           const errorPrefix = isRuntime
             ? 'Failed to switch to runtime model.'
-            : `Failed to switch model to '${effectiveModelId ?? selected}'.`;
+            : `Failed to switch model to '${attemptedModelId}'.`;
           setErrorMessage(`${errorPrefix}\n\n${baseErrorMessage}`);
           return;
         }

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -17,7 +17,7 @@ import {
   type ContentGeneratorConfig,
   type InputModalities,
 } from '@qwen-code/qwen-code-core';
-import { useKeypress } from '../hooks/useKeypress.js';
+import { type Key, useKeypress } from '../hooks/useKeypress.js';
 import { theme } from '../semantic-colors.js';
 import { DescriptiveRadioButtonSelect } from './shared/DescriptiveRadioButtonSelect.js';
 import { ConfigContext } from '../contexts/ConfigContext.js';
@@ -395,8 +395,11 @@ export function ModelDialog({
     );
   }, [highlightedValue, preferredKey, availableModelEntries]);
 
-  useKeypress(
-    (key) => {
+  const highlightedEntryRef = useRef(highlightedEntry);
+  highlightedEntryRef.current = highlightedEntry;
+
+  const handleKeypress = useCallback(
+    (key: Key) => {
       if (key.name === 'escape' || (key.name === 'left' && isFastModelMode)) {
         onClose();
         return;
@@ -407,10 +410,11 @@ export function ModelDialog({
           setErrorMessage(t('Configuration not available.'));
           return;
         }
-        if (!highlightedEntry || highlightedEntry.isRuntime) {
+        const entry = highlightedEntryRef.current;
+        if (!entry || entry.isRuntime) {
           return;
         }
-        if (highlightedEntry.authType === AuthType.QWEN_OAUTH) {
+        if (entry.authType === AuthType.QWEN_OAUTH) {
           setErrorMessage(qwenOAuthDiscontinuedMessage());
           return;
         }
@@ -422,30 +426,28 @@ export function ModelDialog({
         setErrorMessage(null);
         void (async () => {
           let after: ContentGeneratorConfig | undefined;
-          let effectiveAuthType = highlightedEntry.authType;
-          let effectiveModelId = highlightedEntry.model.id;
+          let effectiveAuthType = entry.authType;
+          let effectiveModelId = entry.model.id;
 
           try {
             try {
-              await config.switchModel(
-                highlightedEntry.authType,
-                highlightedEntry.model.id,
-                { baseUrl: highlightedEntry.model.baseUrl },
-              );
+              await config.switchModel(entry.authType, entry.model.id, {
+                baseUrl: entry.model.baseUrl,
+              });
               logModelSlashCommand(
                 config,
-                new ModelSlashCommandEvent(highlightedEntry.model.id),
+                new ModelSlashCommandEvent(entry.model.id),
               );
               after = config.getContentGeneratorConfig?.() as
                 | ContentGeneratorConfig
                 | undefined;
-              effectiveAuthType = after?.authType ?? highlightedEntry.authType;
-              effectiveModelId = after?.model ?? highlightedEntry.model.id;
+              effectiveAuthType = after?.authType ?? entry.authType;
+              effectiveModelId = after?.model ?? entry.model.id;
             } catch (e) {
               const baseErrorMessage =
                 e instanceof Error ? e.message : String(e);
               setErrorMessage(
-                `Failed to switch model to '${highlightedEntry.model.id}'.\n\n${baseErrorMessage}`,
+                `Failed to switch model to '${entry.model.id}'.\n\n${baseErrorMessage}`,
               );
               return;
             }
@@ -480,8 +482,10 @@ export function ModelDialog({
         })();
       }
     },
-    { isActive: true },
+    [config, isFastModelMode, onClose, settings, uiState],
   );
+
+  useKeypress(handleKeypress, { isActive: true });
 
   const handleSelect = useCallback(
     async (selected: string) => {

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -401,14 +401,14 @@ export function ModelDialog({
         return;
       }
 
-      if (
-        key.name === 'd' &&
-        !key.ctrl &&
-        !key.meta &&
-        !isFastModelMode &&
-        highlightedEntry &&
-        !highlightedEntry.isRuntime
-      ) {
+      if (key.name === 'd' && !key.ctrl && !key.meta && !isFastModelMode) {
+        if (!config) {
+          setErrorMessage(t('Configuration not available.'));
+          return;
+        }
+        if (!highlightedEntry || highlightedEntry.isRuntime) {
+          return;
+        }
         if (highlightedEntry.authType === AuthType.QWEN_OAUTH) {
           setErrorMessage(qwenOAuthDiscontinuedMessage());
           return;
@@ -416,10 +416,6 @@ export function ModelDialog({
 
         setErrorMessage(null);
         void (async () => {
-          if (!config) {
-            return;
-          }
-
           try {
             await config.switchModel(
               highlightedEntry.authType,

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -416,6 +416,9 @@ export function ModelDialog({
         }
         const entry = highlightedEntryRef.current;
         if (!entry || entry.isRuntime) {
+          if (entry?.isRuntime) {
+            setErrorMessage(t('Runtime models cannot be set as default.'));
+          }
           return;
         }
         if (entry.authType === AuthType.QWEN_OAUTH) {
@@ -521,17 +524,9 @@ export function ModelDialog({
             fastModel = selected;
           }
           try {
-            const scope = getPersistScopeForModelSelection(settings);
-            settings.setValue(scope, 'fastModel', fastModel);
-            // Sync the runtime Config so forked agents pick up the change immediately.
+            // Sync the runtime Config first; do not persist a fast model the
+            // current session cannot actually use.
             config?.setFastModel(fastModel);
-            uiState?.historyManager.addItem(
-              {
-                type: 'success',
-                text: `${t('Fast Model')}: ${fastModel}`,
-              },
-              Date.now(),
-            );
           } catch (e) {
             const baseErrorMessage = e instanceof Error ? e.message : String(e);
             setErrorMessage(
@@ -539,6 +534,25 @@ export function ModelDialog({
             );
             return;
           }
+
+          try {
+            const scope = getPersistScopeForModelSelection(settings);
+            settings.setValue(scope, 'fastModel', fastModel);
+          } catch (e) {
+            const baseErrorMessage = e instanceof Error ? e.message : String(e);
+            setErrorMessage(
+              `Fast model set to '${fastModel}' for this session, but failed to persist.\n\n${baseErrorMessage}`,
+            );
+            return;
+          }
+
+          uiState?.historyManager.addItem(
+            {
+              type: 'success',
+              text: `${t('Fast Model')}: ${fastModel}`,
+            },
+            Date.now(),
+          );
           onClose();
           return;
         }

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -479,13 +479,6 @@ export function ModelDialog({
               return;
             }
 
-            logModelSwitchResult({
-              uiState,
-              after,
-              effectiveAuthType,
-              effectiveModelId,
-              isRuntime: false,
-            });
             onClose();
           } finally {
             isSwitchingRef.current = false;

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -609,6 +609,9 @@ export function ModelDialog({
           after = config.getContentGeneratorConfig?.() as
             | ContentGeneratorConfig
             | undefined;
+          if (cancelledSwitchRef.current) {
+            return;
+          }
           effectiveAuthType = after?.authType ?? selectedAuthType ?? authType;
           effectiveModelId = after?.model ?? modelId;
         } catch (e) {

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -507,17 +507,25 @@ export function ModelDialog({
           } else {
             fastModel = selected;
           }
-          const scope = getPersistScopeForModelSelection(settings);
-          settings.setValue(scope, 'fastModel', fastModel);
-          // Sync the runtime Config so forked agents pick up the change immediately.
-          config?.setFastModel(fastModel);
-          uiState?.historyManager.addItem(
-            {
-              type: 'success',
-              text: `${t('Fast Model')}: ${fastModel}`,
-            },
-            Date.now(),
-          );
+          try {
+            const scope = getPersistScopeForModelSelection(settings);
+            settings.setValue(scope, 'fastModel', fastModel);
+            // Sync the runtime Config so forked agents pick up the change immediately.
+            config?.setFastModel(fastModel);
+            uiState?.historyManager.addItem(
+              {
+                type: 'success',
+                text: `${t('Fast Model')}: ${fastModel}`,
+              },
+              Date.now(),
+            );
+          } catch (e) {
+            const baseErrorMessage = e instanceof Error ? e.message : String(e);
+            setErrorMessage(
+              `Failed to set fast model to '${fastModel}'.\n\n${baseErrorMessage}`,
+            );
+            return;
+          }
           onClose();
           return;
         }

--- a/packages/cli/src/ui/utils/qwenOAuthDiscontinuedMessage.ts
+++ b/packages/cli/src/ui/utils/qwenOAuthDiscontinuedMessage.ts
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2026 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { t } from '../../i18n/index.js';
+
+export function qwenOAuthDiscontinuedMessage(): string {
+  return t(
+    'Qwen OAuth free tier was discontinued on 2026-04-15. Please select a model from another provider or run /auth to switch.',
+  );
+}


### PR DESCRIPTION
## Summary

- What changed: `/model <model-id>` and normal model dialog selections now switch only the current session model instead of writing `model.name` / `security.auth.selectedType` to settings. Added `/model --default <model-id>` and a `d` shortcut in the dialog to explicitly persist the highlighted model as the default.
- Why it changed: accidental persistence made exploratory model switches leak into future sessions.
- Reviewer focus: command/direct switch semantics, dialog keyboard behavior, and preserving existing fast-model persistence behavior.

## Validation

- Commands run:
  ```bash
  cd packages/cli && npx vitest run src/ui/commands/modelCommand.test.ts
  cd packages/cli && npx vitest run src/ui/components/ModelDialog.test.tsx
  npm run build && npm run typecheck
  ```
- Prompts / inputs used: unit coverage for `/model qwen-max`, `/model --default qwen-max`, provider-qualified model switches, fast-model switches, normal dialog selection, and dialog `d` default persistence.
- Expected result: session model switches do not call `settings.setValue`; explicit default paths still write settings; fast-model behavior remains persisted.
- Observed result: command tests passed (21/21), dialog tests passed (14/14), build and typecheck completed successfully.
- Quickest reviewer verification path:
  ```bash
  cd packages/cli && npx vitest run src/ui/commands/modelCommand.test.ts
  cd packages/cli && npx vitest run src/ui/components/ModelDialog.test.tsx
  ```
- Evidence: the test assertions cover both persisted and non-persisted paths. `npm run build && npm run typecheck` also passed. The existing vscode companion lint warning in `src/utils/editorGroupUtils.ts` was still emitted during build, but it did not fail the command.

## Scope / Risk

- Main risk or tradeoff: users who expected `/model <id>` to permanently update the default now need `/model --default <id>` or the dialog `d` shortcut.
- Not covered / not validated: manual TUI screenshot/video was not captured.
- Breaking changes / migration notes: model switching persistence is now opt-in for the main model. Fast-model persistence is unchanged.

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | tested | not tested | not tested |
| npx      | tested | not tested | not tested |
| Docker   | not tested | not tested | not tested |
| Podman   | not tested | N/A | N/A |
| Seatbelt | not tested | N/A | N/A |

Testing matrix notes:

- Verified locally on macOS only.

## Linked Issues / Bugs

Fixes #4331
