### PR TITLE
fix(review): harden SKILL.md against weak-model rule skipping

### DIFF
--- a/packages/core/src/skills/bundled/review/SKILL.md
+++ b/packages/core/src/skills/bundled/review/SKILL.md
@@ -18,8 +18,10 @@ You are an expert code reviewer. Your job is to review code changes and provide 
 
 **Critical rules (most commonly violated — read these first):**
 
-1. **Match the language of the PR.** If the PR is in English, ALL your output (terminal + PR comments) MUST be in English. If in Chinese, use Chinese. Do NOT switch languages. For **local reviews** (no PR), if the system prompt includes an output language preference, use that language; otherwise follow the user's input language.
-2. **Step 9: use Create Review API** with `comments` array for inline comments. Do NOT use `gh api .../pulls/.../comments` to post individual comments. See Step 9 for the JSON format.
+1. **For PR reviews, the worktree is MANDATORY.** Your very first action MUST be `qwen review fetch-pr` (Step 1). Do NOT use `gh pr checkout`, `git checkout <branch>`, `git switch`, or any other command that touches the user's working tree. After `fetch-pr` returns, ALL subsequent reads, linters, builds, tests, and edits MUST happen inside the `worktreePath` it created. Violating this contaminates the user's local branch state.
+2. **If `--comment` was specified, Step 8 (Autofix) is SKIPPED entirely.** `--comment` means the user wants inline PR comments posted, not code mutations. Do not ask "Apply auto-fixes? (y/n)" — go straight from Step 7 to Step 9.
+3. **Match the language of the PR.** If the PR is in English, ALL your output (terminal + PR comments) MUST be in English. If in Chinese, use Chinese. Do NOT switch languages. For **local reviews** (no PR), if the system prompt includes an output language preference, use that language; otherwise follow the user's input language.
+4. **Step 9: use Create Review API** with `comments` array for inline comments. Do NOT use `gh api .../pulls/.../comments` to post individual comments. See Step 9 for the JSON format.
 
 **Design philosophy: Silence is better than noise.** Every comment you make should be worth the reader's time. If you're unsure whether something is a problem, DO NOT MENTION IT. Low-quality feedback causes "cry wolf" fatigue — developers stop reading all AI comments and miss real issues.
 
@@ -44,6 +46,8 @@ Based on the remaining arguments:
   - If both diffs are empty, inform the user there are no changes to review and stop here — do not proceed to the review agents
 
 - **PR number or same-repo URL** (e.g., `123` or a URL whose owner/repo matches the current repo — cross-repo URLs are handled by the lightweight mode above):
+
+  > ⚠️ **MANDATORY worktree flow.** Do NOT use `gh pr checkout`, `git checkout <branch>`, `git switch`, `git pull`, `git reset --hard`, or any other command that changes the user's current HEAD or working tree contents. The ONLY entry point is `qwen review fetch-pr` (below) — it isolates the PR into an ephemeral worktree so the user's local state is never touched. After it returns, every subsequent command in Steps 2-8 MUST operate inside the returned `worktreePath` (e.g. `cd <worktreePath>` first, or pass the path as a `--cwd` / explicit argument).
   - **Run `qwen review fetch-pr`** to set up the working state in one pass — it cleans any stale worktree, fetches the PR HEAD into `qwen-review/pr-<n>`, queries `gh pr view` for metadata, and creates an ephemeral worktree at `.qwen/tmp/review-pr-<n>`:
 
     ```bash
@@ -442,7 +446,13 @@ If the user responds with "post comments" (or similar intent like "yes post them
 
 ## Step 8: Autofix
 
-If there are **Critical** or **Suggestion** findings with clear, unambiguous fixes, offer to auto-apply them.
+**Skip this entire step (do not even ask) if ANY of the following is true:**
+
+- `--comment` was specified in the arguments — the user explicitly asked for inline PR comments, not code edits. Go straight to Step 9.
+- The review target is a cross-repo PR running in lightweight mode (no local files to edit).
+- There are no Critical or Suggestion findings with concrete, applicable fixes.
+
+Otherwise, if there are **Critical** or **Suggestion** findings with clear, unambiguous fixes, offer to auto-apply them.
 
 1. Count the number of auto-fixable findings (those with concrete suggested fixes that can be expressed as file edits).
 2. If there are fixable findings, ask the user:

--- a/packages/core/src/skills/bundled/review/SKILL.md
+++ b/packages/core/src/skills/bundled/review/SKILL.md
@@ -18,7 +18,7 @@ You are an expert code reviewer. Your job is to review code changes and provide 
 
 **Critical rules (most commonly violated — read these first):**
 
-1. **For PR reviews, the worktree is MANDATORY.** Your very first action MUST be `qwen review fetch-pr` (Step 1). Do NOT use `gh pr checkout`, `git checkout <branch>`, `git switch`, or any other command that touches the user's working tree. After `fetch-pr` returns, ALL subsequent reads, linters, builds, tests, and edits MUST happen inside the `worktreePath` it created. Violating this contaminates the user's local branch state.
+1. **For same-repo PR reviews (PR number, or URL whose owner/repo matches a local remote), the worktree is MANDATORY.** After argument parsing and remote detection (early in Step 1), the first command that touches code state MUST be `qwen review fetch-pr`. Do NOT use `gh pr checkout`, `git checkout <branch>`, `git switch`, `git pull`, `git reset --hard`, or any other command that modifies the user's current HEAD or working tree. After `fetch-pr` returns, ALL subsequent reads, linters, builds, tests, and edits MUST happen inside the `worktreePath` it created. Violating this contaminates the user's local branch state. (Cross-repo PRs with no matching remote use lightweight mode and do NOT create a worktree — see Step 1.)
 2. **If `--comment` was specified, Step 8 (Autofix) is SKIPPED entirely.** `--comment` means the user wants inline PR comments posted, not code mutations. Do not ask "Apply auto-fixes? (y/n)" — go straight from Step 7 to Step 9.
 3. **Match the language of the PR.** If the PR is in English, ALL your output (terminal + PR comments) MUST be in English. If in Chinese, use Chinese. Do NOT switch languages. For **local reviews** (no PR), if the system prompt includes an output language preference, use that language; otherwise follow the user's input language.
 4. **Step 9: use Create Review API** with `comments` array for inline comments. Do NOT use `gh api .../pulls/.../comments` to post individual comments. See Step 9 for the JSON format.
@@ -446,13 +446,12 @@ If the user responds with "post comments" (or similar intent like "yes post them
 
 ## Step 8: Autofix
 
-**Skip this entire step (do not even ask) if ANY of the following is true:**
+**Skip this entire step (do not even ask) if EITHER of the following is true:**
 
 - `--comment` was specified in the arguments — the user explicitly asked for inline PR comments, not code edits. Go straight to Step 9.
 - The review target is a cross-repo PR running in lightweight mode (no local files to edit).
-- There are no Critical or Suggestion findings with concrete, applicable fixes.
 
-Otherwise, if there are **Critical** or **Suggestion** findings with clear, unambiguous fixes, offer to auto-apply them.
+Otherwise, if there are **Critical** or **Suggestion** findings with clear, unambiguous fixes, offer to auto-apply them. (If there are no such findings, this step is also a no-op — fall through to Step 9.)
 
 1. Count the number of auto-fixable findings (those with concrete suggested fixes that can be expressed as file edits).
 2. If there are fixable findings, ask the user:


### PR DESCRIPTION
## Summary

Weak models (and small fast models) running `/review` sometimes skip parts of the long SKILL.md prompt and fall back to familiar defaults:

- Running `gh pr checkout` / `git checkout <branch>` to switch the working tree into the PR, instead of going through `qwen review fetch-pr` which isolates the PR into an ephemeral worktree. This contaminates the user's local branch state.
- Running the Step 8 autofix prompt ("Apply auto-fixes? (y/n)") even when the user passed `--comment`, which is supposed to mean "only post inline PR comments, do not touch code".

Both of these are already implied by SKILL.md, but the relevant rules are scattered in the middle of long sections and easy to miss. This PR reinforces them with three small additions — no CLI changes:

- **Critical rules (top of file)**: promote the two most-violated rules to slots #1 and #2 — worktree is mandatory for PR reviews, and `--comment` skips Step 8 entirely. Existing language/API rules become #3 and #4.
- **Step 1 (PR branch)**: add an inline `⚠️ MANDATORY worktree flow` blockquote that names the specific forbidden commands (`gh pr checkout`, `git checkout <branch>`, `git switch`, `git pull`, `git reset --hard`) and points at `qwen review fetch-pr` as the only entry point.
- **Step 8 (Autofix)**: add an explicit skip block at the top listing the three conditions that bypass autofix — `--comment` specified, cross-repo lightweight mode, or no fixable findings. A weak model now sees the skip rule before it sees "If there are Critical or Suggestion findings…".

## Notes

- `git fetch <remote> pull/<n>/head:<ref>` is **not** in the forbidden list — it doesn't touch the working tree and is what `qwen review fetch-pr` itself uses internally.
- The cross-repo lightweight skip for Step 8 was already documented in Step 1 (line 38). The new Step 8 header restates it so a model that jumped straight to Step 8 still sees it.
- No frontmatter or `allowedTools` changes, so the existing `bundled-skills.integration.test.ts` parse test continues to cover this file.

## Test plan

- [x] Run `/review <pr-number>` with a smaller/faster model and confirm it uses the worktree at `.qwen/tmp/review-pr-<n>` (verify with `git worktree list`) and does not switch the user's HEAD.
- [x] Run `/review <pr-number> --comment` with the same model and confirm Step 8 is skipped silently (no "Apply auto-fixes? (y/n)" prompt) and flow goes Step 7 → Step 9 directly.
- [x] Run `/review <pr-number>` (without `--comment`) and confirm Step 8 still triggers as before for fixable findings.
- [x] Run a cross-repo PR review (URL with no matching remote) and confirm Step 8 is still skipped (lightweight mode).