### PR TITLE
fix(test): count result messages instead of assistant messages in multi-model E2E test

### DIFF
--- a/integration-tests/sdk-typescript/system-control.test.ts
+++ b/integration-tests/sdk-typescript/system-control.test.ts
@@ -250,7 +250,7 @@ describe('System Control (E2E)', () => {
 
       try {
         const systemMessages: Array<{ model?: string }> = [];
-        let responseCount = 0;
+        let turnCount = 0;
         const resolvers: Array<() => void> = [];
         const responsePromises = [
           new Promise<void>((resolve) => resolvers.push(resolve)),
@@ -265,11 +265,11 @@ describe('System Control (E2E)', () => {
             }
             if (isSDKResultMessage(message)) {
               resultWaiter.notifyResult();
-            }
-            if (isSDKAssistantMessage(message)) {
-              if (responseCount < resolvers.length) {
-                resolvers[responseCount]?.();
-                responseCount++;
+              // Resolve on result (one per turn), not assistant message
+              // (which may fire multiple times per turn: thinking + text)
+              if (turnCount < resolvers.length) {
+                resolvers[turnCount]?.();
+                turnCount++;
               }
             }
           }


### PR DESCRIPTION
## Problem

The E2E test `should handle multiple model changes in sequence` in `system-control.test.ts` fails consistently on both Linux and macOS CI:

```
AssertionError: expected 2 to be greater than or equal to 3
 ❯ sdk-typescript/system-control.test.ts:320:39
```

## Root Cause

The test counts every `isSDKAssistantMessage` as one completed turn, but each turn actually produces **multiple** assistant messages — a `thinking` message followed by a `text` message. This inflates the turn counter:

| Actual event | Triggers resolver | Test thinks it is at |
|---|---|---|
| Turn 1 thinking msg | `resolvers[0]` then `setModel(qwen3-turbo)` | Turn 1 done |
| Turn 1 text msg | `resolvers[1]` then `setModel(qwen3-vl-plus)` | Thinks turn 2 done (wrong) |
| Turn 2 thinking msg | `resolvers[2]` then check `systemMessages.length` | Thinks turn 3 done (wrong) |

At the assertion point only 2 turns have completed (2 system messages), but the test expects 3. The third turn never even starts.

## Fix

Resolve turn-completion promises on `isSDKResultMessage` (exactly one per turn) instead of `isSDKAssistantMessage` (multiple per turn). The `resultWaiter.notifyResult()` was already called on result messages — we now also advance the turn counter there.

## Reviewer Test Plan

- Verify the test `should handle multiple model changes in sequence` passes in the `sdk-typescript/system-control.test.ts` E2E suite.
- Verify the adjacent test `should change model dynamically during streaming input` still passes (it was already using a different dedup strategy and is unaffected).
