### PR TITLE
fix(core): add streamable HTTP SSE POST fallback

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -9,6 +9,7 @@ import * as ClientLib from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import * as SdkClientStdioLib from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AuthProviderType, type Config } from '../config/config.js';
 import { GoogleCredentialProvider } from '../mcp/google-auth-provider.js';
@@ -32,6 +33,12 @@ import type { ToolRegistry } from './tool-registry.js';
 
 const mockExistsSync = vi.hoisted(() => vi.fn(() => true));
 const ORIGINAL_ENV = process.env;
+
+function getStreamableHttpFetch(
+  transport: StreamableHTTPClientTransport,
+): FetchLike {
+  return (transport as unknown as { _fetch: FetchLike })._fetch;
+}
 
 vi.mock('node:fs', () => ({
   existsSync: mockExistsSync,
@@ -292,6 +299,114 @@ describe('mcp-client', () => {
         expect((transport as any)._requestInit?.headers).toEqual({
           Authorization: 'derp',
         });
+      });
+
+      it('retries Streamable HTTP SSE GET 400 responses with POST', async () => {
+        const fetchSpy = vi
+          .spyOn(globalThis, 'fetch')
+          .mockResolvedValueOnce(
+            new Response('bad request', {
+              status: 400,
+              statusText: 'Bad Request',
+            }),
+          )
+          .mockResolvedValueOnce(
+            new Response('', {
+              status: 200,
+              headers: { 'content-type': 'text/event-stream' },
+            }),
+          );
+        const transport = (await createTransport(
+          'spring-ai-server',
+          {
+            httpUrl: 'http://test-server/mcp',
+          },
+          false,
+        )) as StreamableHTTPClientTransport;
+
+        const response = await getStreamableHttpFetch(transport)(
+          new URL('http://test-server/mcp'),
+          {
+            method: 'GET',
+            headers: {
+              Accept: 'text/event-stream',
+              'mcp-session-id': 'session-1',
+            },
+          },
+        );
+
+        expect(response.status).toBe(200);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        const retryInit = fetchSpy.mock.calls[1]?.[1];
+        expect(retryInit?.method).toBe('POST');
+        const retryHeaders = new Headers(retryInit?.headers);
+        expect(retryHeaders.get('accept')).toBe(
+          'text/event-stream, application/json',
+        );
+        expect(retryHeaders.get('mcp-session-id')).toBe('session-1');
+      });
+
+      it('retries Streamable HTTP SSE GET 405 responses with POST', async () => {
+        const fetchSpy = vi
+          .spyOn(globalThis, 'fetch')
+          .mockResolvedValueOnce(
+            new Response('method not allowed', {
+              status: 405,
+              statusText: 'Method Not Allowed',
+            }),
+          )
+          .mockResolvedValueOnce(
+            new Response('', {
+              status: 200,
+              headers: { 'content-type': 'text/event-stream' },
+            }),
+          );
+        const transport = (await createTransport(
+          'method-fallback-server',
+          {
+            httpUrl: 'http://test-server/mcp',
+          },
+          false,
+        )) as StreamableHTTPClientTransport;
+
+        const response = await getStreamableHttpFetch(transport)(
+          new URL('http://test-server/mcp'),
+          {
+            method: 'GET',
+            headers: { Accept: 'text/event-stream' },
+          },
+        );
+
+        expect(response.status).toBe(200);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(fetchSpy.mock.calls[1]?.[1]?.method).toBe('POST');
+      });
+
+      it('does not retry Streamable HTTP SSE GET 5xx responses', async () => {
+        const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+          new Response('server error', {
+            status: 502,
+            statusText: 'Bad Gateway',
+          }),
+        );
+        const transport = (await createTransport(
+          'server-error',
+          {
+            httpUrl: 'http://test-server/mcp',
+          },
+          false,
+        )) as StreamableHTTPClientTransport;
+
+        const response = await getStreamableHttpFetch(transport)(
+          new URL('http://test-server/mcp'),
+          {
+            method: 'GET',
+            headers: { Accept: 'text/event-stream' },
+          },
+        );
+
+        expect(response.status).toBe(502);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -40,6 +40,18 @@ function getStreamableHttpFetch(
   return (transport as unknown as { _fetch: FetchLike })._fetch;
 }
 
+function createResponseWithCancelableBody(
+  body: string,
+  init: ResponseInit,
+): { response: Response; cancel: ReturnType<typeof vi.fn> } {
+  const response = new Response(body, init);
+  const cancel = vi.fn().mockResolvedValue(undefined);
+  Object.defineProperty(response, 'body', {
+    value: { cancel },
+  });
+  return { response, cancel };
+}
+
 vi.mock('node:fs', () => ({
   existsSync: mockExistsSync,
 }));
@@ -407,6 +419,110 @@ describe('mcp-client', () => {
 
         expect(response.status).toBe(502);
         expect(fetchSpy).toHaveBeenCalledTimes(1);
+      });
+
+      it('returns the retry response when GET 400 and POST retry fails', async () => {
+        const original = createResponseWithCancelableBody('bad request', {
+          status: 400,
+          statusText: 'Bad Request',
+        });
+        const retry = createResponseWithCancelableBody('unavailable', {
+          status: 503,
+          statusText: 'Service Unavailable',
+        });
+        const fetchSpy = vi
+          .spyOn(globalThis, 'fetch')
+          .mockResolvedValueOnce(original.response)
+          .mockResolvedValueOnce(retry.response);
+        const transport = (await createTransport(
+          'retry-fails-server',
+          {
+            httpUrl: 'http://test-server/mcp',
+          },
+          false,
+        )) as StreamableHTTPClientTransport;
+
+        const response = await getStreamableHttpFetch(transport)(
+          new URL('http://test-server/mcp'),
+          {
+            method: 'GET',
+            headers: { Accept: 'text/event-stream' },
+          },
+        );
+
+        expect(response).toBe(retry.response);
+        expect(response.status).toBe(503);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(original.cancel).toHaveBeenCalledTimes(1);
+        expect(retry.cancel).not.toHaveBeenCalled();
+      });
+
+      it('returns the original response when GET 405 and POST retry fails', async () => {
+        const original = createResponseWithCancelableBody(
+          'method not allowed',
+          {
+            status: 405,
+            statusText: 'Method Not Allowed',
+          },
+        );
+        const retry = createResponseWithCancelableBody('bad request', {
+          status: 400,
+          statusText: 'Bad Request',
+        });
+        const fetchSpy = vi
+          .spyOn(globalThis, 'fetch')
+          .mockResolvedValueOnce(original.response)
+          .mockResolvedValueOnce(retry.response);
+        const transport = (await createTransport(
+          'method-retry-fails-server',
+          {
+            httpUrl: 'http://test-server/mcp',
+          },
+          false,
+        )) as StreamableHTTPClientTransport;
+
+        const response = await getStreamableHttpFetch(transport)(
+          new URL('http://test-server/mcp'),
+          {
+            method: 'GET',
+            headers: { Accept: 'text/event-stream' },
+          },
+        );
+
+        expect(response).toBe(original.response);
+        expect(response.status).toBe(405);
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(original.cancel).toHaveBeenCalledTimes(1);
+        expect(retry.cancel).toHaveBeenCalledTimes(1);
+      });
+
+      it('cancels the original response body when the POST retry throws', async () => {
+        const original = createResponseWithCancelableBody('bad request', {
+          status: 400,
+          statusText: 'Bad Request',
+        });
+        const retryError = new Error('network reset');
+        const fetchSpy = vi
+          .spyOn(globalThis, 'fetch')
+          .mockResolvedValueOnce(original.response)
+          .mockRejectedValueOnce(retryError);
+        const transport = (await createTransport(
+          'retry-throws-server',
+          {
+            httpUrl: 'http://test-server/mcp',
+          },
+          false,
+        )) as StreamableHTTPClientTransport;
+
+        await expect(
+          getStreamableHttpFetch(transport)(new URL('http://test-server/mcp'), {
+            method: 'GET',
+            headers: { Accept: 'text/event-stream' },
+          }),
+        ).rejects.toThrow('network reset');
+
+        expect(fetchSpy).toHaveBeenCalledTimes(2);
+        expect(original.cancel).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -10,7 +10,10 @@ import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import type { StreamableHTTPClientTransportOptions } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type {
+  FetchLike,
+  Transport,
+} from '@modelcontextprotocol/sdk/shared/transport.js';
 import type {
   GetPromptResult,
   JSONRPCMessage,
@@ -61,6 +64,9 @@ export type SendSdkMcpMessage = (
 export const MCP_DEFAULT_TIMEOUT_MSEC = 10 * 60 * 1000; // default to 10 minutes
 
 const debugLogger = createDebugLogger('MCP');
+
+const STREAMABLE_HTTP_SSE_ACCEPT = 'text/event-stream';
+const STREAMABLE_HTTP_POST_ACCEPT = 'text/event-stream, application/json';
 
 export type DiscoveredMCPPrompt = Prompt & {
   serverName: string;
@@ -506,7 +512,8 @@ async function createTransportWithOAuth(
         },
       };
 
-      return new StreamableHTTPClientTransport(
+      return createStreamableHTTPClientTransport(
+        mcpServerName,
         new URL(mcpServerConfig.httpUrl),
         oauthTransportOptions,
       );
@@ -529,6 +536,77 @@ async function createTransportWithOAuth(
     );
     return null;
   }
+}
+
+function isStreamableHttpSseGet(init?: RequestInit): boolean {
+  const method = init?.method?.toUpperCase() ?? 'GET';
+  if (method !== 'GET') {
+    return false;
+  }
+
+  const acceptHeader = new Headers(init?.headers).get('accept');
+  return acceptHeader?.includes(STREAMABLE_HTTP_SSE_ACCEPT) ?? false;
+}
+
+function createStreamableHttpFallbackFetch(
+  mcpServerName: string,
+  baseFetch?: FetchLike,
+): FetchLike {
+  let hasWarned = false;
+  const fetchImpl = baseFetch ?? fetch;
+
+  return async (url, init) => {
+    const response = await fetchImpl(url, init);
+    if (
+      !isStreamableHttpSseGet(init) ||
+      (response.status !== 400 && response.status !== 405)
+    ) {
+      return response;
+    }
+
+    if (!hasWarned) {
+      hasWarned = true;
+      debugLogger.warn(
+        `MCP server '${mcpServerName}' rejected the spec-compliant Streamable HTTP SSE GET with HTTP ${response.status}; retrying with POST for compatibility. ` +
+          `This usually indicates a spec-divergent server (for example Spring AI 1.1.x). Please update the server to support GET SSE when possible.`,
+      );
+    }
+
+    const retryHeaders = new Headers(init?.headers);
+    retryHeaders.set('accept', STREAMABLE_HTTP_POST_ACCEPT);
+
+    const retryInit: RequestInit = {
+      ...init,
+      method: 'POST',
+      headers: retryHeaders,
+    };
+    delete retryInit.body;
+
+    const retryResponse = await fetchImpl(url, retryInit);
+    if (retryResponse.ok) {
+      await response.body?.cancel();
+      return retryResponse;
+    }
+
+    if (response.status === 405) {
+      await retryResponse.body?.cancel();
+      return response;
+    }
+
+    await response.body?.cancel();
+    return retryResponse;
+  };
+}
+
+function createStreamableHTTPClientTransport(
+  mcpServerName: string,
+  url: URL,
+  options: StreamableHTTPClientTransportOptions = {},
+): StreamableHTTPClientTransport {
+  return new StreamableHTTPClientTransport(url, {
+    ...options,
+    fetch: createStreamableHttpFallbackFetch(mcpServerName, options.fetch),
+  });
 }
 
 /**
@@ -1332,7 +1410,8 @@ export async function createTransport(
     };
 
     if (mcpServerConfig.httpUrl) {
-      return new StreamableHTTPClientTransport(
+      return createStreamableHTTPClientTransport(
+        mcpServerName,
         new URL(mcpServerConfig.httpUrl),
         transportOptions,
       );
@@ -1358,7 +1437,8 @@ export async function createTransport(
       authProvider: provider,
     };
     if (mcpServerConfig.httpUrl) {
-      return new StreamableHTTPClientTransport(
+      return createStreamableHTTPClientTransport(
+        mcpServerName,
         new URL(mcpServerConfig.httpUrl),
         transportOptions,
       );
@@ -1430,7 +1510,8 @@ export async function createTransport(
       };
     }
 
-    return new StreamableHTTPClientTransport(
+    return createStreamableHTTPClientTransport(
+      mcpServerName,
       new URL(mcpServerConfig.httpUrl),
       transportOptions,
     );

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -582,9 +582,10 @@ function createStreamableHttpFallbackFetch(
     };
     delete retryInit.body;
 
+    await response.body?.cancel();
+
     const retryResponse = await fetchImpl(url, retryInit);
     if (retryResponse.ok) {
-      await response.body?.cancel();
       return retryResponse;
     }
 
@@ -593,7 +594,6 @@ function createStreamableHttpFallbackFetch(
       return response;
     }
 
-    await response.body?.cancel();
     return retryResponse;
   };
 }


### PR DESCRIPTION
## Summary

- What changed: Added a qwen-code-side compatibility fallback for Streamable HTTP MCP servers that reject the spec-compliant SSE `GET` with HTTP 400/405. The fallback retries the SSE opening request with `POST` and logs a warning that the server is spec-divergent.
- Why it changed: Spring AI 1.1.x MCP servers can reject the SDK's Streamable HTTP SSE `GET`, which causes Qwen Code to report transport errors even though normal Streamable HTTP requests can work.
- Reviewer focus: Please verify the fallback is limited to method-related 400/405 responses, leaves 5xx/network failures unchanged, and stays in Qwen Code's wrapper layer without modifying the upstream MCP SDK.

## Validation

- Commands run:
  ```bash
  npm ci --ignore-scripts
  cd packages/core && npx vitest run src/tools/mcp-client.test.ts
  npm run typecheck --workspace=packages/core
  npm run lint --workspace=packages/core
  npm run build --workspace=packages/core
  npx prettier --check packages/core/src/tools/mcp-client.ts packages/core/src/tools/mcp-client.test.ts
  git diff --check
  ```
- Prompts / inputs used: N/A — unit-level transport wrapper behavior.
- Expected result: Streamable HTTP SSE `GET` responses with HTTP 400/405 are retried once with `POST`; 5xx responses are not retried.
- Observed result: Focused unit tests passed and covered 400 fallback, 405 fallback, and non-retry for 5xx.
- Quickest reviewer verification path: Run `cd packages/core && npx vitest run src/tools/mcp-client.test.ts`.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  ```text
  ✓ src/tools/mcp-client.test.ts (39 tests) 567ms
  Test Files  1 passed (1)
  Tests       39 passed (39)

  > @qwen-code/qwen-code-core@0.15.11 typecheck
  > tsc --noEmit

  > @qwen-code/qwen-code-core@0.15.11 lint
  > eslint . --ext .ts,.tsx

  > @qwen-code/qwen-code-core@0.15.11 build
  > node ../../scripts/build_package.js
  Successfully copied files.

  Checking formatting...
  All matched files use Prettier code style!
  ```

## Scope / Risk

- Main risk or tradeoff: Servers that reject `GET` with 400/405 incur one extra failed round trip before the fallback. For 405, if the fallback `POST` is also rejected, the original no-SSE behavior is preserved.
- Not covered / not validated: No live Spring AI server was available in this workspace; validation uses focused unit tests around the transport wrapper fetch behavior.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | N/A | N/A | ✅  |
| npx      | N/A | N/A | ✅  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Tested on Linux in the repository workspace with Node 22.22.2/npm 10.9.7. No OS-specific code paths were changed.

## Linked Issues / Bugs

Fixes #4326
