### PR TITLE
fix(core): align session hook matcher targets

### DIFF
--- a/packages/core/src/hooks/hookEventHandler.test.ts
+++ b/packages/core/src/hooks/hookEventHandler.test.ts
@@ -27,6 +27,7 @@ import type {
   HookAggregator,
   AggregatedHookResult,
   SessionHooksManager,
+  SessionHookEntry,
 } from './index.js';
 import type { HookConfig, HookOutput, PermissionSuggestion } from './types.js';
 import type { HookExecutionResult } from './types.js';
@@ -106,6 +107,21 @@ describe('HookEventHandler', () => {
     errors: [],
     totalDuration: 100,
     finalOutput,
+  });
+
+  const createSessionHookEntry = (
+    eventName: HookEventName,
+    matcher: string,
+    command: string = 'echo session-hook',
+  ): SessionHookEntry => ({
+    hookId: `session-${eventName}-${matcher}`,
+    eventName,
+    matcher,
+    config: {
+      type: HookType.Command,
+      command,
+      source: HooksConfigSource.Session,
+    },
   });
 
   describe('fireUserPromptSubmitEvent', () => {
@@ -424,6 +440,148 @@ describe('HookEventHandler', () => {
         };
         expect(input.reason).toBe(reason);
       }
+    });
+  });
+
+  describe('session hook matcher targets', () => {
+    it('matches SessionStart session hooks against the session source', async () => {
+      const sessionHook = createSessionHookEntry(
+        HookEventName.SessionStart,
+        SessionStartSource.Resume,
+      );
+
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(null);
+      vi.mocked(mockSessionHooksManager.getMatchingHooks).mockReturnValue([
+        sessionHook,
+      ]);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      await hookEventHandler.fireSessionStartEvent(
+        SessionStartSource.Resume,
+        'test-model',
+      );
+
+      expect(mockSessionHooksManager.getMatchingHooks).toHaveBeenCalledWith(
+        'test-session-id',
+        HookEventName.SessionStart,
+        SessionStartSource.Resume,
+      );
+      expect(mockHookRunner.executeHooksParallel).toHaveBeenCalledWith(
+        [sessionHook.config],
+        HookEventName.SessionStart,
+        expect.objectContaining({ source: SessionStartSource.Resume }),
+        expect.any(Function),
+        expect.any(Function),
+        undefined,
+        expect.any(Object),
+      );
+    });
+
+    it('matches StopFailure session hooks against the error type', async () => {
+      const sessionHook = createSessionHookEntry(
+        HookEventName.StopFailure,
+        'rate_limit',
+      );
+
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(null);
+      vi.mocked(mockSessionHooksManager.getMatchingHooks).mockReturnValue([
+        sessionHook,
+      ]);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      await hookEventHandler.fireStopFailureEvent('rate_limit');
+
+      expect(mockSessionHooksManager.getMatchingHooks).toHaveBeenCalledWith(
+        'test-session-id',
+        HookEventName.StopFailure,
+        'rate_limit',
+      );
+      expect(mockHookRunner.executeHooksParallel).toHaveBeenCalledWith(
+        [sessionHook.config],
+        HookEventName.StopFailure,
+        expect.objectContaining({ error: 'rate_limit' }),
+        expect.any(Function),
+        expect.any(Function),
+        undefined,
+        expect.any(Object),
+      );
+    });
+
+    it('matches Notification session hooks against the notification type', async () => {
+      const sessionHook = createSessionHookEntry(
+        HookEventName.Notification,
+        NotificationType.PermissionPrompt,
+      );
+
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(null);
+      vi.mocked(mockSessionHooksManager.getMatchingHooks).mockReturnValue([
+        sessionHook,
+      ]);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      await hookEventHandler.fireNotificationEvent(
+        'permission needed',
+        NotificationType.PermissionPrompt,
+      );
+
+      expect(mockSessionHooksManager.getMatchingHooks).toHaveBeenCalledWith(
+        'test-session-id',
+        HookEventName.Notification,
+        NotificationType.PermissionPrompt,
+      );
+      expect(mockHookRunner.executeHooksParallel).toHaveBeenCalledWith(
+        [sessionHook.config],
+        HookEventName.Notification,
+        expect.objectContaining({
+          notification_type: NotificationType.PermissionPrompt,
+        }),
+        expect.any(Function),
+        expect.any(Function),
+        undefined,
+        expect.any(Object),
+      );
+    });
+
+    it('does not matcher-filter session hooks for events without matcher semantics', async () => {
+      const sessionHook = createSessionHookEntry(
+        HookEventName.UserPromptSubmit,
+        'ignored-matcher',
+      );
+
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(null);
+      vi.mocked(mockSessionHooksManager.getHooksForEvent).mockReturnValue([
+        sessionHook,
+      ]);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      await hookEventHandler.fireUserPromptSubmitEvent('hello');
+
+      expect(mockSessionHooksManager.getHooksForEvent).toHaveBeenCalledWith(
+        'test-session-id',
+        HookEventName.UserPromptSubmit,
+      );
+      expect(mockSessionHooksManager.getMatchingHooks).not.toHaveBeenCalled();
+      expect(mockHookRunner.executeHooksParallel).toHaveBeenCalledWith(
+        [sessionHook.config],
+        HookEventName.UserPromptSubmit,
+        expect.objectContaining({ prompt: 'hello' }),
+        expect.any(Function),
+        expect.any(Function),
+        undefined,
+        expect.any(Object),
+      );
     });
   });
 

--- a/packages/core/src/hooks/hookEventHandler.test.ts
+++ b/packages/core/src/hooks/hookEventHandler.test.ts
@@ -480,6 +480,81 @@ describe('HookEventHandler', () => {
       );
     });
 
+    it('matches PreToolUse session hooks against the tool name', async () => {
+      const sessionHook = createSessionHookEntry(
+        HookEventName.PreToolUse,
+        'shell',
+      );
+
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(null);
+      vi.mocked(mockSessionHooksManager.getMatchingHooks).mockReturnValue([
+        sessionHook,
+      ]);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      await hookEventHandler.firePreToolUseEvent(
+        'shell',
+        { command: 'ls' },
+        'toolu_123',
+        PermissionMode.Default,
+      );
+
+      expect(mockSessionHooksManager.getMatchingHooks).toHaveBeenCalledWith(
+        'test-session-id',
+        HookEventName.PreToolUse,
+        'shell',
+      );
+      expect(mockHookRunner.executeHooksParallel).toHaveBeenCalledWith(
+        [sessionHook.config],
+        HookEventName.PreToolUse,
+        expect.objectContaining({ tool_name: 'shell' }),
+        expect.any(Function),
+        expect.any(Function),
+        undefined,
+        expect.any(Object),
+      );
+    });
+
+    it('matches SubagentStart session hooks against the agent type', async () => {
+      const sessionHook = createSessionHookEntry(
+        HookEventName.SubagentStart,
+        AgentType.Explorer,
+      );
+
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(null);
+      vi.mocked(mockSessionHooksManager.getMatchingHooks).mockReturnValue([
+        sessionHook,
+      ]);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      await hookEventHandler.fireSubagentStartEvent(
+        'agent_123',
+        AgentType.Explorer,
+        PermissionMode.Default,
+      );
+
+      expect(mockSessionHooksManager.getMatchingHooks).toHaveBeenCalledWith(
+        'test-session-id',
+        HookEventName.SubagentStart,
+        AgentType.Explorer,
+      );
+      expect(mockHookRunner.executeHooksParallel).toHaveBeenCalledWith(
+        [sessionHook.config],
+        HookEventName.SubagentStart,
+        expect.objectContaining({ agent_type: AgentType.Explorer }),
+        expect.any(Function),
+        expect.any(Function),
+        undefined,
+        expect.any(Object),
+      );
+    });
+
     it('matches StopFailure session hooks against the error type', async () => {
       const sessionHook = createSessionHookEntry(
         HookEventName.StopFailure,

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -538,6 +538,50 @@ export class HookEventHandler {
   }
 
   /**
+   * Choose the matcher target for session hooks based on the event.
+   *
+   * Mirrors HookPlanner.matchesContext() so session hooks honor the same
+   * event-specific matcher semantics as configured hooks. Returning `undefined`
+   * means the event has no matcher semantics and all session hooks for the
+   * event should run.
+   */
+  private getSessionHookMatcherTarget(
+    eventName: HookEventName,
+    context?: HookEventContext,
+  ): string | undefined {
+    switch (eventName) {
+      case HookEventName.PreToolUse:
+      case HookEventName.PostToolUse:
+      case HookEventName.PostToolUseFailure:
+      case HookEventName.PermissionRequest:
+        return context?.toolName ?? '';
+
+      case HookEventName.SubagentStart:
+      case HookEventName.SubagentStop:
+        return context?.agentType ?? '';
+
+      case HookEventName.PreCompact:
+      case HookEventName.PostCompact:
+      case HookEventName.SessionStart:
+      case HookEventName.SessionEnd:
+        return context?.trigger ?? '';
+
+      case HookEventName.StopFailure:
+        return context?.error ?? '';
+
+      case HookEventName.Notification:
+        return context?.notificationType ?? '';
+
+      case HookEventName.UserPromptSubmit:
+      case HookEventName.Stop:
+      case HookEventName.TodoCreated:
+      case HookEventName.TodoCompleted:
+      default:
+        return undefined;
+    }
+  }
+
+  /**
    * Execute hooks for a specific event (direct execution without MessageBus)
    * Used as fallback when MessageBus is not available
    */
@@ -568,14 +612,20 @@ export class HookEventHandler {
 
       // Get session hooks and merge with registry hooks
       const sessionId = input.session_id;
-      const targetName = context?.toolName || '';
-      const sessionHooks = sessionId
-        ? this.sessionHooksManager.getMatchingHooks(
-            sessionId,
-            eventName,
-            targetName,
-          )
-        : [];
+      const matcherTarget = this.getSessionHookMatcherTarget(
+        eventName,
+        context,
+      );
+      const sessionHooks =
+        sessionId !== undefined
+          ? matcherTarget === undefined
+            ? this.sessionHooksManager.getHooksForEvent(sessionId, eventName)
+            : this.sessionHooksManager.getMatchingHooks(
+                sessionId,
+                eventName,
+                matcherTarget,
+              )
+          : [];
 
       // Merge hook configs from registry plan and session hooks
       const registryHookConfigs = plan?.hookConfigs || [];

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -6,6 +6,7 @@
 
 import type { Config } from '../config/config.js';
 import type { HookPlanner, HookEventContext } from './hookPlanner.js';
+import { getHookMatcherTarget } from './hookPlanner.js';
 import type { HookRunner } from './hookRunner.js';
 import type { HookAggregator, AggregatedHookResult } from './hookAggregator.js';
 import type { SessionHooksManager } from './sessionHooksManager.js';
@@ -538,50 +539,6 @@ export class HookEventHandler {
   }
 
   /**
-   * Choose the matcher target for session hooks based on the event.
-   *
-   * Mirrors HookPlanner.matchesContext() so session hooks honor the same
-   * event-specific matcher semantics as configured hooks. Returning `undefined`
-   * means the event has no matcher semantics and all session hooks for the
-   * event should run.
-   */
-  private getSessionHookMatcherTarget(
-    eventName: HookEventName,
-    context?: HookEventContext,
-  ): string | undefined {
-    switch (eventName) {
-      case HookEventName.PreToolUse:
-      case HookEventName.PostToolUse:
-      case HookEventName.PostToolUseFailure:
-      case HookEventName.PermissionRequest:
-        return context?.toolName ?? '';
-
-      case HookEventName.SubagentStart:
-      case HookEventName.SubagentStop:
-        return context?.agentType ?? '';
-
-      case HookEventName.PreCompact:
-      case HookEventName.PostCompact:
-      case HookEventName.SessionStart:
-      case HookEventName.SessionEnd:
-        return context?.trigger ?? '';
-
-      case HookEventName.StopFailure:
-        return context?.error ?? '';
-
-      case HookEventName.Notification:
-        return context?.notificationType ?? '';
-
-      case HookEventName.UserPromptSubmit:
-      case HookEventName.Stop:
-      case HookEventName.TodoCreated:
-      case HookEventName.TodoCompleted:
-      default:
-        return undefined;
-    }
-  }
-
-  /**
    * Execute hooks for a specific event (direct execution without MessageBus)
    * Used as fallback when MessageBus is not available
    */
@@ -612,10 +569,7 @@ export class HookEventHandler {
 
       // Get session hooks and merge with registry hooks
       const sessionId = input.session_id;
-      const matcherTarget = this.getSessionHookMatcherTarget(
-        eventName,
-        context,
-      );
+      const matcherTarget = getHookMatcherTarget(eventName, context)?.target;
       const sessionHooks =
         sessionId !== undefined
           ? matcherTarget === undefined

--- a/packages/core/src/hooks/hookPlanner.test.ts
+++ b/packages/core/src/hooks/hookPlanner.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { HookRegistry, HookRegistryEntry } from './hookRegistry.js';
-import { HookPlanner } from './hookPlanner.js';
+import { getHookMatcherTarget, HookPlanner } from './hookPlanner.js';
 import { HookEventName, HookType, HooksConfigSource } from './types.js';
 
 describe('HookPlanner', () => {
@@ -18,6 +18,69 @@ describe('HookPlanner', () => {
       getHooksForEvent: vi.fn(),
     } as unknown as HookRegistry;
     planner = new HookPlanner(mockRegistry);
+  });
+
+  describe('getHookMatcherTarget', () => {
+    it('returns tool name targets for tool events', () => {
+      expect(
+        getHookMatcherTarget(HookEventName.PreToolUse, {
+          toolName: 'shell',
+        }),
+      ).toEqual({ kind: 'toolName', target: 'shell' });
+      expect(getHookMatcherTarget(HookEventName.PostToolUse)).toEqual({
+        kind: 'toolName',
+        target: '',
+      });
+    });
+
+    it('returns agent type targets for subagent events', () => {
+      expect(
+        getHookMatcherTarget(HookEventName.SubagentStart, {
+          agentType: 'explorer',
+        }),
+      ).toEqual({ kind: 'agentType', target: 'explorer' });
+    });
+
+    it('returns trigger targets for compact events', () => {
+      expect(
+        getHookMatcherTarget(HookEventName.PreCompact, {
+          trigger: 'manual',
+        }),
+      ).toEqual({ kind: 'trigger', target: 'manual' });
+    });
+
+    it('returns session trigger targets for session events', () => {
+      expect(
+        getHookMatcherTarget(HookEventName.SessionStart, {
+          trigger: 'startup',
+        }),
+      ).toEqual({ kind: 'sessionTrigger', target: 'startup' });
+    });
+
+    it('returns error targets for stop failure events', () => {
+      expect(
+        getHookMatcherTarget(HookEventName.StopFailure, {
+          error: 'rate_limit',
+        }),
+      ).toEqual({ kind: 'error', target: 'rate_limit' });
+    });
+
+    it('returns notification type targets for notification events', () => {
+      expect(
+        getHookMatcherTarget(HookEventName.Notification, {
+          notificationType: 'permission_prompt',
+        }),
+      ).toEqual({
+        kind: 'notificationType',
+        target: 'permission_prompt',
+      });
+    });
+
+    it('returns undefined for events without matcher semantics', () => {
+      expect(getHookMatcherTarget(HookEventName.UserPromptSubmit)).toBe(
+        undefined,
+      );
+    });
   });
 
   describe('createExecutionPlan', () => {

--- a/packages/core/src/hooks/hookPlanner.ts
+++ b/packages/core/src/hooks/hookPlanner.ts
@@ -11,6 +11,62 @@ import { createDebugLogger } from '../utils/debugLogger.js';
 
 const debugLogger = createDebugLogger('TRUSTED_HOOKS');
 
+type HookMatcherTargetKind =
+  | 'toolName'
+  | 'agentType'
+  | 'trigger'
+  | 'sessionTrigger'
+  | 'error'
+  | 'notificationType';
+
+interface HookMatcherTarget {
+  kind: HookMatcherTargetKind;
+  target: string;
+}
+
+export function getHookMatcherTarget(
+  eventName: HookEventName,
+  context?: HookEventContext,
+): HookMatcherTarget | undefined {
+  switch (eventName) {
+    case HookEventName.PreToolUse:
+    case HookEventName.PostToolUse:
+    case HookEventName.PostToolUseFailure:
+    case HookEventName.PermissionRequest:
+      return { kind: 'toolName', target: context?.toolName ?? '' };
+
+    case HookEventName.SubagentStart:
+    case HookEventName.SubagentStop:
+      return { kind: 'agentType', target: context?.agentType ?? '' };
+
+    case HookEventName.PreCompact:
+    case HookEventName.PostCompact:
+      return { kind: 'trigger', target: context?.trigger ?? '' };
+
+    case HookEventName.SessionStart:
+    case HookEventName.SessionEnd:
+      return { kind: 'sessionTrigger', target: context?.trigger ?? '' };
+
+    case HookEventName.StopFailure:
+      return { kind: 'error', target: context?.error ?? '' };
+
+    case HookEventName.Notification:
+      return {
+        kind: 'notificationType',
+        target: context?.notificationType ?? '',
+      };
+
+    case HookEventName.UserPromptSubmit:
+    case HookEventName.Stop:
+    case HookEventName.TodoCreated:
+    case HookEventName.TodoCompleted:
+      return undefined;
+  }
+
+  const exhaustive: never = eventName;
+  return exhaustive;
+}
+
 /**
  * Hook planner that selects matching hooks and creates execution plans
  */
@@ -84,65 +140,31 @@ export class HookPlanner {
       return true; // Empty string or wildcard matches all
     }
 
-    // Explicit dispatch by event name to avoid ambiguity
-    switch (eventName) {
-      // Tool events: match against tool name
-      case HookEventName.PreToolUse:
-      case HookEventName.PostToolUse:
-      case HookEventName.PostToolUseFailure:
-      case HookEventName.PermissionRequest:
-        return context.toolName
-          ? this.matchesToolName(matcher, context.toolName)
-          : true;
-
-      // Subagent events: match against agent type
-      case HookEventName.SubagentStart:
-      case HookEventName.SubagentStop:
-        return context.agentType
-          ? this.matchesAgentType(matcher, context.agentType)
-          : true;
-
-      // PreCompact: match against trigger
-      case HookEventName.PreCompact:
-        return context.trigger
-          ? this.matchesTrigger(matcher, context.trigger)
-          : true;
-
-      // PostCompact: match against trigger
-      case HookEventName.PostCompact:
-        return context.trigger
-          ? this.matchesTrigger(matcher, context.trigger)
-          : true;
-
-      // StopFailure: match against error type (fieldToMatch: 'error')
-      case HookEventName.StopFailure:
-        return context.error
-          ? this.matchesTrigger(matcher, context.error)
-          : true;
-
-      // Notification: match against notification type
-      case HookEventName.Notification:
-        return context.notificationType
-          ? this.matchesNotificationType(matcher, context.notificationType)
-          : true;
-
-      // SessionStart/SessionEnd: match against source/reason
-      case HookEventName.SessionStart:
-        return context.trigger
-          ? this.matchesSessionTrigger(matcher, context.trigger)
-          : true;
-
-      case HookEventName.SessionEnd:
-        return context.trigger
-          ? this.matchesSessionTrigger(matcher, context.trigger)
-          : true;
-
-      // Events that don't support matchers: always match
-      case HookEventName.UserPromptSubmit:
-      case HookEventName.Stop:
-      default:
-        return true;
+    const matcherTarget = getHookMatcherTarget(eventName, context);
+    if (!matcherTarget || !matcherTarget.target) {
+      return true;
     }
+
+    switch (matcherTarget.kind) {
+      case 'toolName':
+        return this.matchesToolName(matcher, matcherTarget.target);
+
+      case 'agentType':
+        return this.matchesAgentType(matcher, matcherTarget.target);
+
+      case 'trigger':
+      case 'error':
+        return this.matchesTrigger(matcher, matcherTarget.target);
+
+      case 'notificationType':
+        return this.matchesNotificationType(matcher, matcherTarget.target);
+
+      case 'sessionTrigger':
+        return this.matchesSessionTrigger(matcher, matcherTarget.target);
+    }
+
+    const exhaustive: never = matcherTarget.kind;
+    return exhaustive;
   }
 
   /**

--- a/packages/core/src/hooks/hookPlanner.ts
+++ b/packages/core/src/hooks/hookPlanner.ts
@@ -61,10 +61,12 @@ export function getHookMatcherTarget(
     case HookEventName.TodoCreated:
     case HookEventName.TodoCompleted:
       return undefined;
-  }
 
-  const exhaustive: never = eventName;
-  return exhaustive;
+    default: {
+      const exhaustive: never = eventName;
+      return exhaustive;
+    }
+  }
 }
 
 /**
@@ -161,10 +163,12 @@ export class HookPlanner {
 
       case 'sessionTrigger':
         return this.matchesSessionTrigger(matcher, matcherTarget.target);
-    }
 
-    const exhaustive: never = matcherTarget.kind;
-    return exhaustive;
+      default: {
+        const exhaustive: never = matcherTarget.kind;
+        return exhaustive;
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

- What changed: session-scoped hooks now choose matcher targets from the same event-specific context fields used by configured hooks. Tool events still match tool names, while session, notification, subagent, compact, and stop-failure events match their own lifecycle fields.
- Why it changed: session hooks previously always matched against `toolName`, so non-tool events such as `SessionStart`, `Notification`, and `StopFailure` could not be filtered by their meaningful payload values.
- Reviewer focus: please check that events without matcher semantics still run all session hooks for the event, while events with matcher semantics continue to use the existing session-hook matcher language.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/hooks/hookEventHandler.test.ts
  npm run build
  npm run typecheck
  ```
- Prompts / inputs used: N/A
- Expected result: focused hook tests pass; build and typecheck complete successfully.
- Observed result: `hookEventHandler.test.ts` passed with 114 tests. `npm run build` completed successfully with one unrelated existing lint warning in `packages/vscode-ide-companion/src/utils/editorGroupUtils.ts` and a Browserslist data-age warning. `npm run typecheck` completed successfully.
- Quickest reviewer verification path:
  ```bash
  cd packages/core && npx vitest run src/hooks/hookEventHandler.test.ts
  ```
- Evidence: local test output showed `1 passed`, `114 passed`; build and typecheck exited with code 0.

## Scope / Risk

- Main risk or tradeoff: session hooks for non-tool events may now filter more narrowly when a matcher is configured, matching the configured-hook behavior for the same event.
- Not covered / not validated: full test suite was not run.
- Breaking changes / migration notes: no config migration required.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Tested locally on macOS with `npm run build`, `npm run typecheck`, and the focused package-level Vitest command.
- Windows and Linux were not tested locally.

## Linked Issues / Bugs

Related to #4343.
