### PR TITLE
feat(cli): notify when background shells finish

### DIFF
--- a/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
+++ b/packages/cli/src/ui/hooks/useGeminiStream.test.tsx
@@ -154,6 +154,7 @@ describe('useGeminiStream', () => {
   let mockScheduleToolCalls: Mock;
   let mockCancelAllToolCalls: Mock;
   let mockMarkToolsAsSubmitted: Mock;
+  let mockBackgroundShellRegistry: { setNotificationCallback: Mock };
   let handleAtCommandSpy: MockInstance;
 
   beforeEach(() => {
@@ -181,6 +182,9 @@ describe('useGeminiStream', () => {
       apiKey: 'test-key',
       vertexai: false,
       authType: AuthType.USE_GEMINI,
+    };
+    mockBackgroundShellRegistry = {
+      setNotificationCallback: vi.fn(),
     };
 
     mockConfig = {
@@ -230,6 +234,7 @@ describe('useGeminiStream', () => {
       getBackgroundTaskRegistry: vi.fn(() => ({
         setNotificationCallback: vi.fn(),
       })),
+      getBackgroundShellRegistry: vi.fn(() => mockBackgroundShellRegistry),
       getMonitorRegistry: vi.fn(() => ({
         setNotificationCallback: vi.fn(),
       })),
@@ -355,6 +360,44 @@ describe('useGeminiStream', () => {
       client,
     };
   };
+
+  it('queues background shell terminal notifications for the model loop', async () => {
+    const { mockSendMessageStream } = renderTestHook();
+    const displayText = 'Background shell "npm test" completed.';
+    const modelText =
+      '<task-notification>\n<kind>shell</kind>\n<status>completed</status>\n</task-notification>';
+
+    await waitFor(() => {
+      expect(
+        mockBackgroundShellRegistry.setNotificationCallback,
+      ).toHaveBeenCalledWith(expect.any(Function));
+    });
+
+    const callback = mockBackgroundShellRegistry.setNotificationCallback.mock
+      .calls[0][0] as (displayText: string, modelText: string) => void;
+
+    act(() => {
+      callback(displayText, modelText);
+    });
+
+    await waitFor(() => {
+      expect(mockAddItem).toHaveBeenCalledWith(
+        { type: 'notification', text: displayText },
+        expect.any(Number),
+      );
+    });
+    await waitFor(() => {
+      expect(mockSendMessageStream).toHaveBeenCalledWith(
+        modelText,
+        expect.any(AbortSignal),
+        expect.any(String),
+        expect.objectContaining({
+          type: SendMessageType.Notification,
+          notificationDisplayText: displayText,
+        }),
+      );
+    });
+  });
 
   it('should not submit tool responses if not all tool calls are completed', () => {
     const toolCalls: TrackedToolCall[] = [

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -2485,6 +2485,22 @@ export const useGeminiStream = (
     };
   }, [config]);
 
+  // Register background shell terminal notification callback onto the shared queue.
+  useEffect(() => {
+    const registry = config.getBackgroundShellRegistry();
+    registry.setNotificationCallback((displayText, modelText) => {
+      notificationQueueRef.current.push({
+        displayText,
+        modelText,
+        sendMessageType: SendMessageType.Notification,
+      });
+      setNotificationTrigger((n) => n + 1);
+    });
+    return () => {
+      registry.setNotificationCallback(undefined);
+    };
+  }, [config]);
+
   // Register monitor notification callback onto the shared queue.
   useEffect(() => {
     const registry = config.getMonitorRegistry();

--- a/packages/core/src/services/backgroundShellRegistry.test.ts
+++ b/packages/core/src/services/backgroundShellRegistry.test.ts
@@ -4,12 +4,33 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   BackgroundShellRegistry,
+  MAX_NOTIFICATION_OUTPUT_TAIL_BYTES,
   MAX_RETAINED_TERMINAL_SHELLS,
   type ShellTaskRegistration,
 } from './backgroundShellRegistry.js';
+
+let tmpDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tmpDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  tmpDirs = [];
+});
+
+function makeOutputFile(content: string): string {
+  const dir = mkdtempSync(join(tmpdir(), 'qwen-shell-notification-'));
+  tmpDirs.push(dir);
+  const file = join(dir, 'shell.output');
+  writeFileSync(file, content);
+  return file;
+}
 
 function makeEntry(
   overrides: Partial<ShellTaskRegistration> = {},
@@ -191,13 +212,14 @@ describe('BackgroundShellRegistry', () => {
     it('emits one task-notification when a shell completes', () => {
       const reg = new BackgroundShellRegistry();
       const callback = vi.fn();
+      const outputPath = makeOutputFile('first line\nfinal result\n');
       reg.setNotificationCallback(callback);
       reg.register(
         makeEntry({
           shellId: 'a',
           command: 'npm test',
           cwd: '/repo',
-          outputPath: '/tmp/shell-output.log',
+          outputPath,
           pid: 1234,
         }),
       );
@@ -216,8 +238,9 @@ describe('BackgroundShellRegistry', () => {
       expect(modelText).toContain('<pid>1234</pid>');
       expect(modelText).toContain('<exit-code>0</exit-code>');
       expect(modelText).toContain(
-        '<output-file>/tmp/shell-output.log</output-file>',
+        '<output-tail truncated="false">first line\nfinal result</output-tail>',
       );
+      expect(modelText).toContain(`<output-file>${outputPath}</output-file>`);
       expect(meta).toEqual({
         shellId: 'a',
         status: 'completed',
@@ -251,6 +274,25 @@ describe('BackgroundShellRegistry', () => {
       expect(modelText).toContain(
         '<output-file>/tmp/out&amp;err.log</output-file>',
       );
+    });
+
+    it('limits output-tail to the retained byte budget', () => {
+      const reg = new BackgroundShellRegistry();
+      const callback = vi.fn();
+      const outputPath = makeOutputFile(
+        'prefix-' +
+          'a'.repeat(MAX_NOTIFICATION_OUTPUT_TAIL_BYTES) +
+          '\nlast line\n',
+      );
+      reg.setNotificationCallback(callback);
+      reg.register(makeEntry({ shellId: 'a', outputPath }));
+
+      reg.complete('a', 0, 2000);
+
+      const [, modelText] = callback.mock.calls[0];
+      expect(modelText).toContain('<output-tail truncated="true">');
+      expect(modelText).toContain('last line</output-tail>');
+      expect(modelText).not.toContain('prefix-');
     });
 
     it('does not emit more than once for late terminal transitions', () => {

--- a/packages/core/src/services/backgroundShellRegistry.test.ts
+++ b/packages/core/src/services/backgroundShellRegistry.test.ts
@@ -218,6 +218,20 @@ describe('BackgroundShellRegistry', () => {
       reg.register(makeEntry({ shellId: 'b' }));
       expect(seen).toEqual(['a']);
     });
+
+    it('setNotificationCallback(undefined) clears the callback', () => {
+      // useGeminiStream's cleanup relies on this contract to avoid
+      // leaked callbacks firing into torn-down React state on unmount.
+      // If a future refactor breaks the clearing path, stale callbacks
+      // would fire silently — no test would catch it without this guard.
+      const reg = new BackgroundShellRegistry();
+      const callback = vi.fn();
+      reg.setNotificationCallback(callback);
+      reg.register(makeEntry({ shellId: 'a' }));
+      reg.setNotificationCallback(undefined);
+      reg.complete('a', 0, 2000);
+      expect(callback).not.toHaveBeenCalled();
+    });
   });
 
   describe('notifications', () => {
@@ -348,6 +362,58 @@ describe('BackgroundShellRegistry', () => {
 
       const [, modelText] = callback.mock.calls[0];
       expect(modelText).not.toContain('secret credentials');
+      expect(modelText).not.toContain('<output-tail');
+    });
+
+    it('skips output-tail when the output file does not exist', () => {
+      // Guards the catch branch in `readOutputTail`. If the try/catch
+      // ever regresses to throwing, `complete()` would propagate the
+      // error and the entry would never reach a terminal status.
+      const reg = new BackgroundShellRegistry();
+      const callback = vi.fn();
+      reg.setNotificationCallback(callback);
+      reg.register(
+        makeEntry({
+          shellId: 'a',
+          outputPath: join(tmpdir(), 'qwen-shell-no-such-file-xyz.log'),
+        }),
+      );
+
+      expect(() => reg.complete('a', 0, 2000)).not.toThrow();
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [, modelText] = callback.mock.calls[0];
+      expect(modelText).not.toContain('<output-tail');
+      expect(reg.get('a')!.status).toBe('completed');
+    });
+
+    it('skips output-tail when outputPath is a directory (not a regular file)', () => {
+      // Guards the `!stat.isFile()` early-return in `readOutputTail`.
+      const reg = new BackgroundShellRegistry();
+      const callback = vi.fn();
+      const dir = makeTempDir();
+      reg.setNotificationCallback(callback);
+      reg.register(makeEntry({ shellId: 'a', outputPath: dir }));
+
+      reg.complete('a', 0, 2000);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [, modelText] = callback.mock.calls[0];
+      expect(modelText).not.toContain('<output-tail');
+    });
+
+    it('skips output-tail when the output file is empty (stat.size === 0)', () => {
+      // Guards the `stat.size <= 0` early-return in `readOutputTail`.
+      const reg = new BackgroundShellRegistry();
+      const callback = vi.fn();
+      const outputPath = makeOutputFile('');
+      reg.setNotificationCallback(callback);
+      reg.register(makeEntry({ shellId: 'a', outputPath }));
+
+      reg.complete('a', 0, 2000);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [, modelText] = callback.mock.calls[0];
       expect(modelText).not.toContain('<output-tail');
     });
 

--- a/packages/core/src/services/backgroundShellRegistry.test.ts
+++ b/packages/core/src/services/backgroundShellRegistry.test.ts
@@ -187,6 +187,123 @@ describe('BackgroundShellRegistry', () => {
     });
   });
 
+  describe('notifications', () => {
+    it('emits one task-notification when a shell completes', () => {
+      const reg = new BackgroundShellRegistry();
+      const callback = vi.fn();
+      reg.setNotificationCallback(callback);
+      reg.register(
+        makeEntry({
+          shellId: 'a',
+          command: 'npm test',
+          cwd: '/repo',
+          outputPath: '/tmp/shell-output.log',
+          pid: 1234,
+        }),
+      );
+
+      reg.complete('a', 0, 2000);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [displayText, modelText, meta] = callback.mock.calls[0];
+      expect(displayText).toBe('Background shell "npm test" completed.');
+      expect(modelText).toContain('<task-notification>');
+      expect(modelText).toContain('<task-id>a</task-id>');
+      expect(modelText).toContain('<kind>shell</kind>');
+      expect(modelText).toContain('<status>completed</status>');
+      expect(modelText).toContain('<command>npm test</command>');
+      expect(modelText).toContain('<cwd>/repo</cwd>');
+      expect(modelText).toContain('<pid>1234</pid>');
+      expect(modelText).toContain('<exit-code>0</exit-code>');
+      expect(modelText).toContain(
+        '<output-file>/tmp/shell-output.log</output-file>',
+      );
+      expect(meta).toEqual({
+        shellId: 'a',
+        status: 'completed',
+        exitCode: 0,
+      });
+    });
+
+    it('escapes XML and strips display control characters on failure', () => {
+      const reg = new BackgroundShellRegistry();
+      const callback = vi.fn();
+      reg.setNotificationCallback(callback);
+      reg.register(
+        makeEntry({
+          shellId: 'a&b',
+          command: 'echo "<script>"',
+          cwd: '/repo&work',
+          outputPath: '/tmp/out&err.log',
+        }),
+      );
+
+      reg.fail('a&b', 'bad <thing>\x1B[31m', 2000);
+
+      const [displayText, modelText] = callback.mock.calls[0];
+      expect(displayText).toBe('Background shell "echo "<script>"" failed.');
+      expect(modelText).toContain('<task-id>a&amp;b</task-id>');
+      expect(modelText).toContain(
+        '<command>echo &quot;&lt;script&gt;&quot;</command>',
+      );
+      expect(modelText).toContain('<cwd>/repo&amp;work</cwd>');
+      expect(modelText).toContain('<result>bad &lt;thing&gt;[31m</result>');
+      expect(modelText).toContain(
+        '<output-file>/tmp/out&amp;err.log</output-file>',
+      );
+    });
+
+    it('does not emit more than once for late terminal transitions', () => {
+      const reg = new BackgroundShellRegistry();
+      const callback = vi.fn();
+      reg.setNotificationCallback(callback);
+      reg.register(makeEntry({ shellId: 'a' }));
+
+      reg.complete('a', 0, 2000);
+      reg.fail('a', 'late failure', 3000);
+      reg.cancel('a', 4000);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it('waits until cancel() to notify after requestCancel()', () => {
+      const reg = new BackgroundShellRegistry();
+      const callback = vi.fn();
+      reg.setNotificationCallback(callback);
+      reg.register(makeEntry({ shellId: 'a' }));
+
+      reg.requestCancel('a');
+
+      expect(callback).not.toHaveBeenCalled();
+
+      reg.cancel('a', 2000);
+
+      expect(callback).toHaveBeenCalledTimes(1);
+      const [displayText, modelText, meta] = callback.mock.calls[0];
+      expect(displayText).toBe('Background shell "sleep 60" was cancelled.');
+      expect(modelText).toContain('<status>cancelled</status>');
+      expect(meta).toEqual({
+        shellId: 'a',
+        status: 'cancelled',
+        exitCode: undefined,
+      });
+    });
+
+    it('does not emit notifications from abortAll shutdown cleanup', () => {
+      const reg = new BackgroundShellRegistry();
+      const callback = vi.fn();
+      reg.setNotificationCallback(callback);
+      reg.register(makeEntry({ shellId: 'a' }));
+      reg.register(makeEntry({ shellId: 'b' }));
+
+      reg.abortAll();
+
+      expect(callback).not.toHaveBeenCalled();
+      expect(reg.get('a')!.notified).toBe(false);
+      expect(reg.get('b')!.notified).toBe(false);
+    });
+  });
+
   describe('requestCancel', () => {
     it('aborts the signal but leaves status running and endTime undefined', () => {
       const reg = new BackgroundShellRegistry();

--- a/packages/core/src/services/backgroundShellRegistry.test.ts
+++ b/packages/core/src/services/backgroundShellRegistry.test.ts
@@ -4,7 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  constants as fsConstants,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -30,6 +36,12 @@ function makeOutputFile(content: string): string {
   const file = join(dir, 'shell.output');
   writeFileSync(file, content);
   return file;
+}
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'qwen-shell-notification-'));
+  tmpDirs.push(dir);
+  return dir;
 }
 
 function makeEntry(
@@ -248,6 +260,30 @@ describe('BackgroundShellRegistry', () => {
       });
     });
 
+    it('truncates long commands for display, summary, and model XML', () => {
+      const reg = new BackgroundShellRegistry();
+      const callback = vi.fn();
+      const command = `node -e ${'a'.repeat(700)}`;
+      const displayCommand = command.slice(0, 77) + '...';
+      const modelCommand = command.slice(0, 497) + '...';
+      reg.setNotificationCallback(callback);
+      reg.register(makeEntry({ shellId: 'a', command }));
+
+      reg.complete('a', 0, 2000);
+
+      const [displayText, modelText] = callback.mock.calls[0];
+      expect(displayText).toBe(
+        `Background shell "${displayCommand}" completed.`,
+      );
+      expect(modelText).toContain(
+        `<summary>Shell command "${displayCommand}" completed.</summary>`,
+      );
+      expect(modelText).toContain(
+        `<command truncated="true">${modelCommand}</command>`,
+      );
+      expect(modelText).not.toContain(command);
+    });
+
     it('escapes XML and strips display control characters on failure', () => {
       const reg = new BackgroundShellRegistry();
       const callback = vi.fn();
@@ -293,6 +329,40 @@ describe('BackgroundShellRegistry', () => {
       expect(modelText).toContain('<output-tail truncated="true">');
       expect(modelText).toContain('last line</output-tail>');
       expect(modelText).not.toContain('prefix-');
+    });
+
+    const itNoFollow = fsConstants.O_NOFOLLOW === undefined ? it.skip : it;
+
+    itNoFollow('does not follow symlinked output files', () => {
+      const reg = new BackgroundShellRegistry();
+      const callback = vi.fn();
+      const dir = makeTempDir();
+      const secretPath = join(dir, 'secret.txt');
+      const outputPath = join(dir, 'shell.output');
+      writeFileSync(secretPath, 'secret credentials');
+      symlinkSync(secretPath, outputPath);
+      reg.setNotificationCallback(callback);
+      reg.register(makeEntry({ shellId: 'a', outputPath }));
+
+      reg.complete('a', 0, 2000);
+
+      const [, modelText] = callback.mock.calls[0];
+      expect(modelText).not.toContain('secret credentials');
+      expect(modelText).not.toContain('<output-tail');
+    });
+
+    it('keeps the registry usable when the notification callback throws', () => {
+      const reg = new BackgroundShellRegistry();
+      reg.setNotificationCallback(() => {
+        throw new Error('subscriber blew up');
+      });
+      reg.register(makeEntry({ shellId: 'a' }));
+      reg.register(makeEntry({ shellId: 'b' }));
+
+      expect(() => reg.complete('a', 0, 2000)).not.toThrow();
+      expect(() => reg.fail('b', 'boom', 3000)).not.toThrow();
+      expect(reg.get('a')!.status).toBe('completed');
+      expect(reg.get('b')!.status).toBe('failed');
     });
 
     it('does not emit more than once for late terminal transitions', () => {

--- a/packages/core/src/services/backgroundShellRegistry.test.ts
+++ b/packages/core/src/services/backgroundShellRegistry.test.ts
@@ -345,6 +345,54 @@ describe('BackgroundShellRegistry', () => {
       expect(modelText).not.toContain('prefix-');
     });
 
+    it('skips leading UTF-8 continuation bytes at the truncation boundary', () => {
+      // When the byte budget cuts a multi-byte UTF-8 codepoint in half,
+      // the raw read would produce a U+FFFD replacement character.
+      // Place a 3-byte '€' (U+20AC → 0xE2 0x82 0xAC) so that the
+      // truncation offset lands on its second byte.
+      const reg = new BackgroundShellRegistry();
+      const callback = vi.fn();
+      const dir = mkdtempSync(join(tmpdir(), 'qwen-shell-utf8-'));
+      tmpDirs.push(dir);
+      const file = join(dir, 'shell.output');
+      const padding = 'a'.repeat(MAX_NOTIFICATION_OUTPUT_TAIL_BYTES - 1);
+      // 1 byte of 'a' + 2 continuation bytes = 3 bytes before the clean text
+      const content = padding + '\u20AC' + '\nfinal output\n';
+      writeFileSync(file, content);
+      reg.setNotificationCallback(callback);
+      reg.register(makeEntry({ shellId: 'a', outputPath: file }));
+
+      reg.complete('a', 0, 2000);
+
+      const [, modelText] = callback.mock.calls[0];
+      expect(modelText).toContain('<output-tail truncated="true">');
+      expect(modelText).toContain('final output</output-tail>');
+      // Must not contain the UTF-8 replacement character
+      expect(modelText).not.toContain('\uFFFD');
+    });
+
+    it('strips control characters from cwd and output-file XML fields', () => {
+      const reg = new BackgroundShellRegistry();
+      const callback = vi.fn();
+      reg.setNotificationCallback(callback);
+      reg.register(
+        makeEntry({
+          shellId: 'a',
+          cwd: '/repo\x01\x02/work',
+          outputPath: '/tmp/out\x03.log',
+        }),
+      );
+
+      reg.complete('a', 0, 2000);
+
+      const [, modelText] = callback.mock.calls[0];
+      expect(modelText).toContain('<cwd>/repo/work</cwd>');
+      expect(modelText).toContain('<output-file>/tmp/out.log</output-file>');
+      expect(modelText).not.toContain('\x01');
+      expect(modelText).not.toContain('\x02');
+      expect(modelText).not.toContain('\x03');
+    });
+
     const itNoFollow = fsConstants.O_NOFOLLOW === undefined ? it.skip : it;
 
     itNoFollow('does not follow symlinked output files', () => {

--- a/packages/core/src/services/backgroundShellRegistry.test.ts
+++ b/packages/core/src/services/backgroundShellRegistry.test.ts
@@ -410,7 +410,7 @@ describe('BackgroundShellRegistry', () => {
 
       const [, modelText] = callback.mock.calls[0];
       expect(modelText).not.toContain('secret credentials');
-      expect(modelText).not.toContain('<output-tail');
+      expect(modelText).toContain('<output-tail error="unreadable"');
     });
 
     it('skips output-tail when the output file does not exist', () => {
@@ -431,7 +431,7 @@ describe('BackgroundShellRegistry', () => {
 
       expect(callback).toHaveBeenCalledTimes(1);
       const [, modelText] = callback.mock.calls[0];
-      expect(modelText).not.toContain('<output-tail');
+      expect(modelText).toContain('<output-tail error="unreadable"');
       expect(reg.get('a')!.status).toBe('completed');
     });
 

--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -19,9 +19,40 @@
  */
 
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { escapeXml } from '../utils/xml.js';
 import type { TaskBase, TaskRegistration } from '../agents/tasks/types.js';
 
 const debugLogger = createDebugLogger('BACKGROUND_SHELLS');
+const MAX_NOTIFICATION_COMMAND_LENGTH = 80;
+
+/**
+ * Strip C0 control characters (except tab) and C1 control characters from
+ * terminal/UI display strings. Shell commands and errors are usually
+ * user-authored, but this keeps escape sequences out of the visible
+ * notification surface if a caller passes unsanitized text.
+ */
+function stripDisplayControlChars(text: string): string {
+  let out = '';
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (code === 0x09) {
+      out += text[i];
+      continue;
+    }
+    if (code < 0x20) continue;
+    if (code >= 0x80 && code <= 0x9f) continue;
+    out += text[i];
+  }
+  return out;
+}
+
+function truncateCommandForDisplay(command: string): string {
+  const normalized = stripDisplayControlChars(command).replace(/\s+/g, ' ');
+  if (normalized.length <= MAX_NOTIFICATION_COMMAND_LENGTH) {
+    return normalized;
+  }
+  return normalized.slice(0, MAX_NOTIFICATION_COMMAND_LENGTH - 3) + '...';
+}
 
 /**
  * Cap on how many terminal (completed/failed/cancelled) entries the
@@ -100,6 +131,18 @@ export type ShellTaskRegistration = Omit<
 /** Fires when a new entry is registered. */
 export type BackgroundShellRegisterCallback = (entry: ShellTask) => void;
 
+export interface ShellNotificationMeta {
+  shellId: string;
+  status: BackgroundShellStatus;
+  exitCode?: number;
+}
+
+export type BackgroundShellNotificationCallback = (
+  displayText: string,
+  modelText: string,
+  meta: ShellNotificationMeta,
+) => void;
+
 /**
  * Fires on every status transition (running → terminal). Symmetric with
  * `BackgroundTaskRegistry.setStatusChangeCallback` so the same UI hook can
@@ -111,6 +154,7 @@ export class BackgroundShellRegistry {
   private readonly entries = new Map<string, ShellTask>();
 
   private registerCallback: BackgroundShellRegisterCallback | undefined;
+  private notificationCallback: BackgroundShellNotificationCallback | undefined;
   private statusChangeCallback: BackgroundShellStatusChangeCallback | undefined;
 
   /**
@@ -121,6 +165,12 @@ export class BackgroundShellRegistry {
    */
   setRegisterCallback(cb: BackgroundShellRegisterCallback | undefined): void {
     this.registerCallback = cb;
+  }
+
+  setNotificationCallback(
+    cb: BackgroundShellNotificationCallback | undefined,
+  ): void {
+    this.notificationCallback = cb;
   }
 
   /**
@@ -181,6 +231,7 @@ export class BackgroundShellRegistry {
     entry.status = 'completed';
     entry.exitCode = exitCode;
     entry.endTime = endTime;
+    this.emitNotification(entry);
     this.pruneTerminalEntries();
     this.fireStatusChange(entry);
   }
@@ -191,6 +242,7 @@ export class BackgroundShellRegistry {
     entry.status = 'failed';
     entry.error = error;
     entry.endTime = endTime;
+    this.emitNotification(entry);
     this.pruneTerminalEntries();
     this.fireStatusChange(entry);
   }
@@ -199,6 +251,7 @@ export class BackgroundShellRegistry {
     const entry = this.entries.get(shellId);
     if (!entry || entry.status !== 'running') return;
     this.settleAsCancelled(entry, endTime);
+    this.emitNotification(entry);
     this.pruneTerminalEntries();
     this.fireStatusChange(entry);
   }
@@ -266,6 +319,59 @@ export class BackgroundShellRegistry {
       this.statusChangeCallback(entry);
     } catch (error) {
       debugLogger.error('statusChange callback failed:', error);
+    }
+  }
+
+  private emitNotification(entry: ShellTask): void {
+    if (entry.notified) return;
+    entry.notified = true;
+
+    if (!this.notificationCallback) return;
+
+    const statusText =
+      entry.status === 'completed'
+        ? 'completed'
+        : entry.status === 'failed'
+          ? 'failed'
+          : 'was cancelled';
+    const commandLabel = truncateCommandForDisplay(entry.command);
+    const displayText = `Background shell "${commandLabel}" ${statusText}.`;
+
+    const xmlParts: string[] = [
+      '<task-notification>',
+      `<task-id>${escapeXml(entry.shellId)}</task-id>`,
+      '<kind>shell</kind>',
+      `<status>${escapeXml(entry.status)}</status>`,
+      `<summary>Shell command "${escapeXml(commandLabel)}" ${statusText}.</summary>`,
+      `<command>${escapeXml(entry.command)}</command>`,
+      `<cwd>${escapeXml(entry.cwd)}</cwd>`,
+    ];
+    if (entry.pid !== undefined) {
+      xmlParts.push(`<pid>${entry.pid}</pid>`);
+    }
+    if (entry.exitCode !== undefined) {
+      xmlParts.push(`<exit-code>${entry.exitCode}</exit-code>`);
+    }
+    if (entry.error) {
+      xmlParts.push(
+        `<result>${escapeXml(stripDisplayControlChars(entry.error))}</result>`,
+      );
+    }
+    xmlParts.push(
+      `<output-file>${escapeXml(entry.outputFile)}</output-file>`,
+      '</task-notification>',
+    );
+
+    const meta: ShellNotificationMeta = {
+      shellId: entry.shellId,
+      status: entry.status,
+      exitCode: entry.exitCode,
+    };
+
+    try {
+      this.notificationCallback(displayText, xmlParts.join('\n'), meta);
+    } catch (error) {
+      debugLogger.error('Failed to emit shell notification:', error);
     }
   }
 

--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -65,9 +65,12 @@ function stripOutputControlChars(text: string): string {
   return out;
 }
 
-function readOutputTail(
-  outputFile: string,
-): { text: string; truncated: boolean } | undefined {
+type OutputTailResult =
+  | { text: string; truncated: boolean }
+  | { error: string }
+  | undefined;
+
+function readOutputTail(outputFile: string): OutputTailResult {
   let fd: number | undefined;
   try {
     fd = fs.openSync(outputFile, getReadOutputOpenFlags());
@@ -101,8 +104,10 @@ function readOutputTail(
       truncated: start > 0,
     };
   } catch (error) {
-    debugLogger.debug(`Failed to read shell output tail:`, error);
-    return undefined;
+    debugLogger.warn(`Failed to read shell output tail:`, error);
+    return {
+      error: error instanceof Error ? error.message : String(error),
+    };
   } finally {
     if (fd !== undefined) {
       try {
@@ -417,7 +422,12 @@ export class BackgroundShellRegistry {
     if (entry.notified) return;
     entry.notified = true;
 
-    if (!this.notificationCallback) return;
+    if (!this.notificationCallback) {
+      debugLogger.debug(
+        `Notification dropped for shell ${entry.shellId}: no callback registered`,
+      );
+      return;
+    }
 
     const statusText =
       entry.status === 'completed'
@@ -453,9 +463,13 @@ export class BackgroundShellRegistry {
     }
     const outputTail = readOutputTail(entry.outputFile);
     if (outputTail) {
-      xmlParts.push(
-        `<output-tail truncated="${outputTail.truncated ? 'true' : 'false'}">${escapeXml(outputTail.text)}</output-tail>`,
-      );
+      if ('error' in outputTail) {
+        xmlParts.push(`<output-tail error="unreadable" />`);
+      } else {
+        xmlParts.push(
+          `<output-tail truncated="${outputTail.truncated ? 'true' : 'false'}">${escapeXml(outputTail.text)}</output-tail>`,
+        );
+      }
     }
     xmlParts.push(
       `<output-file>${escapeXml(stripDisplayControlChars(entry.outputFile))}</output-file>`,

--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -78,8 +78,21 @@ function readOutputTail(
     const start = stat.size - length;
     const buffer = Buffer.allocUnsafe(length);
     const bytesRead = fs.readSync(fd, buffer, 0, length, start);
+
+    // When the read offset lands mid-codepoint (truncated read), skip
+    // leading UTF-8 continuation bytes to avoid U+FFFD replacement chars.
+    let sliceOffset = 0;
+    if (start > 0) {
+      while (
+        sliceOffset < bytesRead &&
+        (buffer[sliceOffset]! & 0xc0) === 0x80
+      ) {
+        sliceOffset++;
+      }
+    }
+
     const text = stripOutputControlChars(
-      buffer.subarray(0, bytesRead).toString('utf8'),
+      buffer.subarray(sliceOffset, bytesRead).toString('utf8'),
     ).trimEnd();
 
     if (!text) return undefined;
@@ -425,7 +438,7 @@ export class BackgroundShellRegistry {
       commandForModel.truncated
         ? `<command truncated="true">${escapeXml(commandForModel.text)}</command>`
         : `<command>${escapeXml(commandForModel.text)}</command>`,
-      `<cwd>${escapeXml(entry.cwd)}</cwd>`,
+      `<cwd>${escapeXml(stripDisplayControlChars(entry.cwd))}</cwd>`,
     ];
     if (entry.pid !== undefined) {
       xmlParts.push(`<pid>${entry.pid}</pid>`);
@@ -445,7 +458,7 @@ export class BackgroundShellRegistry {
       );
     }
     xmlParts.push(
-      `<output-file>${escapeXml(entry.outputFile)}</output-file>`,
+      `<output-file>${escapeXml(stripDisplayControlChars(entry.outputFile))}</output-file>`,
       '</task-notification>',
     );
 

--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -18,7 +18,7 @@
  * status.
  */
 
-import { closeSync, fstatSync, openSync, readSync } from 'node:fs';
+import * as fs from 'node:fs';
 
 import type { TaskBase, TaskRegistration } from '../agents/tasks/types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
@@ -26,6 +26,7 @@ import { escapeXml } from '../utils/xml.js';
 
 const debugLogger = createDebugLogger('BACKGROUND_SHELLS');
 const MAX_NOTIFICATION_COMMAND_LENGTH = 80;
+const MAX_NOTIFICATION_MODEL_COMMAND_LENGTH = 500;
 export const MAX_NOTIFICATION_OUTPUT_TAIL_BYTES = 8192;
 
 /**
@@ -69,14 +70,14 @@ function readOutputTail(
 ): { text: string; truncated: boolean } | undefined {
   let fd: number | undefined;
   try {
-    fd = openSync(outputFile, 'r');
-    const stat = fstatSync(fd);
+    fd = fs.openSync(outputFile, getReadOutputOpenFlags());
+    const stat = fs.fstatSync(fd);
     if (!stat.isFile() || stat.size <= 0) return undefined;
 
     const length = Math.min(stat.size, MAX_NOTIFICATION_OUTPUT_TAIL_BYTES);
     const start = stat.size - length;
     const buffer = Buffer.allocUnsafe(length);
-    const bytesRead = readSync(fd, buffer, 0, length, start);
+    const bytesRead = fs.readSync(fd, buffer, 0, length, start);
     const text = stripOutputControlChars(
       buffer.subarray(0, bytesRead).toString('utf8'),
     ).trimEnd();
@@ -92,12 +93,17 @@ function readOutputTail(
   } finally {
     if (fd !== undefined) {
       try {
-        closeSync(fd);
+        fs.closeSync(fd);
       } catch {
         /* best effort */
       }
     }
   }
+}
+
+function getReadOutputOpenFlags(): number {
+  const constants = fs.constants;
+  return (constants?.O_RDONLY ?? 0) | (constants?.O_NOFOLLOW ?? 0);
 }
 
 function truncateCommandForDisplay(command: string): string {
@@ -106,6 +112,24 @@ function truncateCommandForDisplay(command: string): string {
     return normalized;
   }
   return normalized.slice(0, MAX_NOTIFICATION_COMMAND_LENGTH - 3) + '...';
+}
+
+function truncateCommandForModel(command: string): {
+  text: string;
+  truncated: boolean;
+} {
+  const sanitized = stripDisplayControlChars(command);
+  if (sanitized.length <= MAX_NOTIFICATION_MODEL_COMMAND_LENGTH) {
+    return {
+      text: sanitized,
+      truncated: false,
+    };
+  }
+
+  return {
+    text: sanitized.slice(0, MAX_NOTIFICATION_MODEL_COMMAND_LENGTH - 3) + '...',
+    truncated: true,
+  };
 }
 
 /**
@@ -389,6 +413,7 @@ export class BackgroundShellRegistry {
           ? 'failed'
           : 'was cancelled';
     const commandLabel = truncateCommandForDisplay(entry.command);
+    const commandForModel = truncateCommandForModel(entry.command);
     const displayText = `Background shell "${commandLabel}" ${statusText}.`;
 
     const xmlParts: string[] = [
@@ -397,7 +422,9 @@ export class BackgroundShellRegistry {
       '<kind>shell</kind>',
       `<status>${escapeXml(entry.status)}</status>`,
       `<summary>Shell command "${escapeXml(commandLabel)}" ${statusText}.</summary>`,
-      `<command>${escapeXml(entry.command)}</command>`,
+      commandForModel.truncated
+        ? `<command truncated="true">${escapeXml(commandForModel.text)}</command>`
+        : `<command>${escapeXml(commandForModel.text)}</command>`,
       `<cwd>${escapeXml(entry.cwd)}</cwd>`,
     ];
     if (entry.pid !== undefined) {

--- a/packages/core/src/services/backgroundShellRegistry.ts
+++ b/packages/core/src/services/backgroundShellRegistry.ts
@@ -18,12 +18,15 @@
  * status.
  */
 
+import { closeSync, fstatSync, openSync, readSync } from 'node:fs';
+
+import type { TaskBase, TaskRegistration } from '../agents/tasks/types.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { escapeXml } from '../utils/xml.js';
-import type { TaskBase, TaskRegistration } from '../agents/tasks/types.js';
 
 const debugLogger = createDebugLogger('BACKGROUND_SHELLS');
 const MAX_NOTIFICATION_COMMAND_LENGTH = 80;
+export const MAX_NOTIFICATION_OUTPUT_TAIL_BYTES = 8192;
 
 /**
  * Strip C0 control characters (except tab) and C1 control characters from
@@ -44,6 +47,57 @@ function stripDisplayControlChars(text: string): string {
     out += text[i];
   }
   return out;
+}
+
+function stripOutputControlChars(text: string): string {
+  let out = '';
+  for (let i = 0; i < text.length; i++) {
+    const code = text.charCodeAt(i);
+    if (code === 0x09 || code === 0x0a || code === 0x0d) {
+      out += text[i];
+      continue;
+    }
+    if (code < 0x20) continue;
+    if (code >= 0x80 && code <= 0x9f) continue;
+    out += text[i];
+  }
+  return out;
+}
+
+function readOutputTail(
+  outputFile: string,
+): { text: string; truncated: boolean } | undefined {
+  let fd: number | undefined;
+  try {
+    fd = openSync(outputFile, 'r');
+    const stat = fstatSync(fd);
+    if (!stat.isFile() || stat.size <= 0) return undefined;
+
+    const length = Math.min(stat.size, MAX_NOTIFICATION_OUTPUT_TAIL_BYTES);
+    const start = stat.size - length;
+    const buffer = Buffer.allocUnsafe(length);
+    const bytesRead = readSync(fd, buffer, 0, length, start);
+    const text = stripOutputControlChars(
+      buffer.subarray(0, bytesRead).toString('utf8'),
+    ).trimEnd();
+
+    if (!text) return undefined;
+    return {
+      text,
+      truncated: start > 0,
+    };
+  } catch (error) {
+    debugLogger.debug(`Failed to read shell output tail:`, error);
+    return undefined;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        /* best effort */
+      }
+    }
+  }
 }
 
 function truncateCommandForDisplay(command: string): string {
@@ -355,6 +409,12 @@ export class BackgroundShellRegistry {
     if (entry.error) {
       xmlParts.push(
         `<result>${escapeXml(stripDisplayControlChars(entry.error))}</result>`,
+      );
+    }
+    const outputTail = readOutputTail(entry.outputFile);
+    if (outputTail) {
+      xmlParts.push(
+        `<output-tail truncated="${outputTail.truncated ? 'true' : 'false'}">${escapeXml(outputTail.text)}</output-tail>`,
       );
     }
     xmlParts.push(


### PR DESCRIPTION
## Summary

- What changed: background shell tasks now emit a terminal `task-notification` when they complete, fail, or are cancelled, and the TUI routes those notifications through the existing notification queue.
- Why it changed: long-running background shell scripts could finish while the user had to ask Qwen Code for status manually; terminal notifications let the model wake up and decide whether to inspect the output file.
- Reviewer focus: notification idempotency, XML escaping, cancellation semantics, and the choice to keep stdout/stderr streaming scoped to monitor rather than shell.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/services/backgroundShellRegistry.test.ts
  cd packages/cli && npx vitest run src/ui/hooks/useGeminiStream.test.tsx
  npm run build
  npm run typecheck
  ```
- Prompts / inputs used: N/A; validation is focused unit coverage plus build/typecheck.
- Expected result: shell registry emits one terminal notification, TUI submits it as `SendMessageType.Notification`, and existing build/typecheck remain green.
- Observed result: both focused test files passed; `npm run build` passed; `npm run typecheck` passed. Build still reports an existing warning in `packages/vscode-ide-companion/src/utils/editorGroupUtils.ts` about a missing curly brace.
- Quickest reviewer verification path:
  ```bash
  cd packages/core && npx vitest run src/services/backgroundShellRegistry.test.ts
  cd ../cli && npx vitest run src/ui/hooks/useGeminiStream.test.tsx
  ```
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.): focused tests passed locally: `backgroundShellRegistry.test.ts` 35/35 and `useGeminiStream.test.tsx` 98/98.

## Scope / Risk

- Main risk or tradeoff: a completed background shell now wakes the model once; noisy per-line output is intentionally not sent here and remains monitor behavior.
- Not covered / not validated: manual TUI screenshot/video was not captured.
- Breaking changes / migration notes: none expected.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- macOS npm/npx validation covered the touched TypeScript packages. Windows and Linux were not run locally.

## Linked Issues / Bugs

- N/A

![Uploading image.png…]()
