### PR TITLE
fix(docs): Hide internal docs from docs site

### DIFF
--- a/docs-site/README.md
+++ b/docs-site/README.md
@@ -17,13 +17,15 @@ npm install
 
 ### Setup Content
 
-Link the documentation content from the parent `docs` directory:
+Prepare the public documentation content from the parent `docs` directory:
 
 ```bash
 npm run link
 ```
 
-This creates a symbolic link from `../docs` to `content` in the project.
+This creates a `content` directory with copies of the public docs sections.
+Internal planning, design, and E2E notes remain outside the docs site content
+tree.
 
 ### Development
 

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -18,5 +18,8 @@
     "nextra-theme-docs": "^4.6.1",
     "react": "^19.2.1",
     "react-dom": "^19.2.1"
+  },
+  "devDependencies": {
+    "vitest": "^3.2.4"
   }
 }

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "link": "ln -s ../docs content",
+    "link": "rm -rf content && mkdir content && cp ../docs/index.md ../docs/_meta.ts content/ && cp -R ../docs/users ../docs/developers content/",
     "clean": "rm -rf .next",
     "dev": "npm run clean && next --turbopack",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/docs-site/package.json
+++ b/docs-site/package.json
@@ -7,10 +7,10 @@
   "type": "module",
   "main": "index.js",
   "scripts": {
-    "link": "rm -rf content && mkdir content && cp ../docs/index.md ../docs/_meta.ts content/ && cp -R ../docs/users ../docs/developers content/",
+    "link": "node scripts/link-public-docs.mjs",
     "clean": "rm -rf .next",
     "dev": "npm run clean && next --turbopack",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run --config vitest.config.js"
   },
   "dependencies": {
     "next": "^16.0.8",

--- a/docs-site/scripts/link-public-docs.mjs
+++ b/docs-site/scripts/link-public-docs.mjs
@@ -1,0 +1,26 @@
+import { cp, mkdir, rm, symlink } from 'node:fs/promises';
+import { join } from 'node:path';
+
+import { PUBLIC_DOC_ROOTS } from '../src/app/public-docs.js';
+
+const contentDir = 'content';
+
+async function linkPublicDocs() {
+  try {
+    await rm(contentDir, { force: true, recursive: true });
+    await mkdir(contentDir);
+    await cp('../docs/index.md', join(contentDir, 'index.md'));
+    await cp('../docs/_meta.ts', join(contentDir, '_meta.ts'));
+
+    for (const root of PUBLIC_DOC_ROOTS) {
+      await symlink(join('..', '..', 'docs', root), join(contentDir, root));
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Failed to link public docs into ${contentDir}: ${message}`,
+    );
+  }
+}
+
+await linkPublicDocs();

--- a/docs-site/src/app/[[...mdxPath]]/page.jsx
+++ b/docs-site/src/app/[[...mdxPath]]/page.jsx
@@ -1,13 +1,13 @@
 import { generateStaticParamsFor, importPage } from 'nextra/pages';
 import { notFound } from 'next/navigation';
 import { useMDXComponents as getMDXComponents } from '../../../mdx-components';
-import { isPublicDocsPath } from '../public-docs';
+import { filterPublicStaticParams, isPublicDocsPath } from '../public-docs';
 
 const generateAllStaticParams = generateStaticParamsFor('mdxPath');
 
 export async function generateStaticParams(...args) {
   const staticParams = await generateAllStaticParams(...args);
-  return staticParams.filter(({ mdxPath }) => isPublicDocsPath(mdxPath));
+  return filterPublicStaticParams(staticParams);
 }
 
 export async function generateMetadata(props) {

--- a/docs-site/src/app/[[...mdxPath]]/page.jsx
+++ b/docs-site/src/app/[[...mdxPath]]/page.jsx
@@ -5,6 +5,8 @@ import { filterPublicStaticParams, isPublicDocsPath } from '../public-docs';
 
 const generateAllStaticParams = generateStaticParamsFor('mdxPath');
 
+export const dynamicParams = false;
+
 export async function generateStaticParams(...args) {
   const staticParams = await generateAllStaticParams(...args);
   return filterPublicStaticParams(staticParams);

--- a/docs-site/src/app/[[...mdxPath]]/page.jsx
+++ b/docs-site/src/app/[[...mdxPath]]/page.jsx
@@ -1,10 +1,21 @@
 import { generateStaticParamsFor, importPage } from 'nextra/pages';
+import { notFound } from 'next/navigation';
 import { useMDXComponents as getMDXComponents } from '../../../mdx-components';
+import { isPublicDocsPath } from '../public-docs';
 
-export const generateStaticParams = generateStaticParamsFor('mdxPath');
+const generateAllStaticParams = generateStaticParamsFor('mdxPath');
+
+export async function generateStaticParams(...args) {
+  const staticParams = await generateAllStaticParams(...args);
+  return staticParams.filter(({ mdxPath }) => isPublicDocsPath(mdxPath));
+}
 
 export async function generateMetadata(props) {
   const params = await props.params;
+  if (!isPublicDocsPath(params.mdxPath)) {
+    notFound();
+  }
+
   const { metadata } = await importPage(params.mdxPath);
   return metadata;
 }
@@ -13,6 +24,10 @@ const Wrapper = getMDXComponents().wrapper;
 
 export default async function Page(props) {
   const params = await props.params;
+  if (!isPublicDocsPath(params.mdxPath)) {
+    notFound();
+  }
+
   const {
     default: MDXContent,
     toc,

--- a/docs-site/src/app/[[...mdxPath]]/page.test.jsx
+++ b/docs-site/src/app/[[...mdxPath]]/page.test.jsx
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const generateAllStaticParams = vi.fn();
+
+  return {
+    generateAllStaticParams,
+    generateStaticParamsFor: vi.fn(() => generateAllStaticParams),
+  };
+});
+
+vi.mock('nextra/pages', () => ({
+  generateStaticParamsFor: mocks.generateStaticParamsFor,
+  importPage: vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  notFound: vi.fn(),
+}));
+
+vi.mock('../../../mdx-components', () => ({
+  useMDXComponents: () => ({
+    wrapper: ({ children }) => children,
+  }),
+}));
+
+describe('generateStaticParams', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('filters internal docs from Nextra static params', async () => {
+    mocks.generateAllStaticParams.mockResolvedValue([
+      { mdxPath: [] },
+      { mdxPath: ['users', 'foo'] },
+      { mdxPath: ['en', 'users'] },
+      { mdxPath: ['design', 'bar'] },
+      { mdxPath: ['plans'] },
+    ]);
+
+    const { generateStaticParams } = await import('./page.jsx');
+
+    await expect(generateStaticParams()).resolves.toEqual([
+      { mdxPath: [] },
+      { mdxPath: ['users', 'foo'] },
+      { mdxPath: ['en', 'users'] },
+    ]);
+  });
+
+  it('fails closed if Nextra changes the static params shape', async () => {
+    mocks.generateAllStaticParams.mockResolvedValue([{ slug: ['users'] }]);
+
+    const { generateStaticParams } = await import('./page.jsx');
+
+    await expect(generateStaticParams()).rejects.toThrow(
+      'Expected generateStaticParamsFor("mdxPath") to return objects with an mdxPath array.',
+    );
+  });
+});

--- a/docs-site/src/app/public-docs.js
+++ b/docs-site/src/app/public-docs.js
@@ -1,0 +1,27 @@
+const LOCALE_SEGMENTS = new Set(['en', 'zh', 'de', 'fr', 'ja', 'ru', 'pt-BR']);
+
+// Keep this in sync with the public top-level entries in docs/_meta.ts.
+const PUBLIC_DOC_ROOTS = new Set(['users', 'developers']);
+
+function publicRootFromSegments(segments = []) {
+  if (segments.length === 0) {
+    return undefined;
+  }
+
+  const rootIndex = LOCALE_SEGMENTS.has(segments[0]) ? 1 : 0;
+  return segments[rootIndex];
+}
+
+function pathSegmentsFromRoute(route = '') {
+  return route.split('/').filter(Boolean);
+}
+
+export function isPublicDocsPath(mdxPath = []) {
+  const root = publicRootFromSegments(mdxPath);
+  return root === undefined || PUBLIC_DOC_ROOTS.has(root);
+}
+
+export function isPublicDocsRoute(route = '') {
+  const root = publicRootFromSegments(pathSegmentsFromRoute(route));
+  return root === undefined || PUBLIC_DOC_ROOTS.has(root);
+}

--- a/docs-site/src/app/public-docs.js
+++ b/docs-site/src/app/public-docs.js
@@ -1,7 +1,10 @@
 const LOCALE_SEGMENTS = new Set(['en', 'zh', 'de', 'fr', 'ja', 'ru', 'pt-BR']);
 
-// Keep this in sync with the public top-level entries in docs/_meta.ts.
-const PUBLIC_DOC_ROOTS = new Set(['users', 'developers']);
+// Keep this in sync with the public top-level page entries in docs/_meta.ts.
+// docs-site/scripts/link-public-docs.mjs consumes the same allowlist.
+export const PUBLIC_DOC_ROOTS = ['users', 'developers'];
+
+const PUBLIC_DOC_ROOT_SET = new Set(PUBLIC_DOC_ROOTS);
 
 function publicRootFromSegments(segments = []) {
   if (segments.length === 0) {
@@ -12,16 +15,19 @@ function publicRootFromSegments(segments = []) {
   return segments[rootIndex];
 }
 
-function pathSegmentsFromRoute(route = '') {
-  return route.split('/').filter(Boolean);
-}
-
 export function isPublicDocsPath(mdxPath = []) {
   const root = publicRootFromSegments(mdxPath);
-  return root === undefined || PUBLIC_DOC_ROOTS.has(root);
+  return root === undefined || PUBLIC_DOC_ROOT_SET.has(root);
 }
 
-export function isPublicDocsRoute(route = '') {
-  const root = publicRootFromSegments(pathSegmentsFromRoute(route));
-  return root === undefined || PUBLIC_DOC_ROOTS.has(root);
+export function filterPublicStaticParams(staticParams = []) {
+  return staticParams.filter((staticParam) => {
+    if (!Array.isArray(staticParam?.mdxPath)) {
+      throw new TypeError(
+        'Expected generateStaticParamsFor("mdxPath") to return objects with an mdxPath array.',
+      );
+    }
+
+    return isPublicDocsPath(staticParam.mdxPath);
+  });
 }

--- a/docs-site/src/app/public-docs.js
+++ b/docs-site/src/app/public-docs.js
@@ -7,7 +7,7 @@ export const PUBLIC_DOC_ROOTS = ['users', 'developers'];
 const PUBLIC_DOC_ROOT_SET = new Set(PUBLIC_DOC_ROOTS);
 
 function publicRootFromSegments(segments = []) {
-  if (segments.length === 0) {
+  if (segments.length === 0 || (segments.length === 1 && segments[0] === '')) {
     return undefined;
   }
 

--- a/docs-site/src/app/public-docs.test.js
+++ b/docs-site/src/app/public-docs.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterPublicStaticParams, isPublicDocsPath } from './public-docs.js';
+
+describe('isPublicDocsPath', () => {
+  it.each([
+    [[], true],
+    [['users', 'foo'], true],
+    [['design', 'bar'], false],
+    [['en', 'users'], true],
+    [['plans'], false],
+    [['en'], true],
+  ])('returns %s for %j', (mdxPath, expected) => {
+    expect(isPublicDocsPath(mdxPath)).toBe(expected);
+  });
+});
+
+describe('filterPublicStaticParams', () => {
+  it('keeps public paths and rejects internal docs paths', () => {
+    expect(
+      filterPublicStaticParams([
+        { mdxPath: [] },
+        { mdxPath: ['users', 'foo'] },
+        { mdxPath: ['en', 'developers'] },
+        { mdxPath: ['design', 'bar'] },
+        { mdxPath: ['plans'] },
+      ]),
+    ).toEqual([
+      { mdxPath: [] },
+      { mdxPath: ['users', 'foo'] },
+      { mdxPath: ['en', 'developers'] },
+    ]);
+  });
+
+  it('fails closed if Nextra changes the static params shape', () => {
+    expect(() => filterPublicStaticParams([{ slug: ['users'] }])).toThrow(
+      'Expected generateStaticParamsFor("mdxPath") to return objects with an mdxPath array.',
+    );
+  });
+});

--- a/docs-site/src/app/public-docs.test.js
+++ b/docs-site/src/app/public-docs.test.js
@@ -5,6 +5,7 @@ import { filterPublicStaticParams, isPublicDocsPath } from './public-docs.js';
 describe('isPublicDocsPath', () => {
   it.each([
     [[], true],
+    [[''], true],
     [['users', 'foo'], true],
     [['design', 'bar'], false],
     [['en', 'users'], true],
@@ -20,6 +21,7 @@ describe('filterPublicStaticParams', () => {
     expect(
       filterPublicStaticParams([
         { mdxPath: [] },
+        { mdxPath: [''] },
         { mdxPath: ['users', 'foo'] },
         { mdxPath: ['en', 'developers'] },
         { mdxPath: ['design', 'bar'] },
@@ -27,6 +29,7 @@ describe('filterPublicStaticParams', () => {
       ]),
     ).toEqual([
       { mdxPath: [] },
+      { mdxPath: [''] },
       { mdxPath: ['users', 'foo'] },
       { mdxPath: ['en', 'developers'] },
     ]);

--- a/docs-site/vitest.config.js
+++ b/docs-site/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['src/**/*.test.{js,jsx}'],
+  },
+});

--- a/docs/users/configuration/_meta.ts
+++ b/docs/users/configuration/_meta.ts
@@ -1,9 +1,6 @@
 export default {
   settings: 'Settings',
   auth: 'Authentication',
-  memory: {
-    display: 'hidden',
-  },
   'qwen-ignore': 'Ignoring Files',
   'trusted-folders': 'Trusted Folders',
   themes: 'Themes',


### PR DESCRIPTION
<!--
Help reviewers verify this PR quickly.

Maintainers prioritize PRs that include clear proof of work.
If a PR does not include enough validation detail to reproduce and verify the change efficiently, review may be delayed.
-->

## Summary

- What changed: The docs site content preparation now includes only public documentation sections, and the app route guards direct requests for internal documentation paths.
- Why it changed: Internal planning and design notes were being treated as publishable docs content, so direct links could expose pages that were only meant for project coordination.
- Reviewer focus: Please confirm the public docs tree still includes the expected user and developer docs, while internal planning, design, and E2E notes are absent from the generated content and route surface.

## Validation

<!--
Be concrete. Do not write only "tested locally".
Include the exact commands, prompts, outputs, logs, screenshots, or videos that prove the change was actually run and observed.

For user-visible changes, bug fixes, CLI / TUI behavior changes, or interaction changes, include key screenshots or a short video.
When possible, show before/after behavior.

If helpful, use the `e2e-testing` skill to gather stronger end-to-end validation evidence.
-->

- Commands run:
  ```bash
  npx prettier --check docs-site/package.json docs-site/README.md docs/users/configuration/_meta.ts docs-site/src/app/public-docs.js 'docs-site/src/app/[[...mdxPath]]/page.jsx'
  node --input-type=module - <<'NODE'
  import { isPublicDocsPath, isPublicDocsRoute } from './docs-site/src/app/public-docs.js';
  // Checked public users/developers routes and private plans/design/e2e route cases.
  NODE
  npm --prefix docs-site run link >/dev/null && test -f docs-site/content/index.md && test -d docs-site/content/users && test -d docs-site/content/developers && test ! -e docs-site/content/plans && test ! -e docs-site/content/design && test ! -e docs-site/content/e2e-tests && rm -rf docs-site/content
  git diff --check
  ```
- Prompts / inputs used: Verified the reported public URL path shape with `/zh/plans/2026-03-22-agent-tool-display-design/` and checked localized internal route handling in the route helper.
- Expected result: Public user and developer docs remain eligible for generation; internal planning, design, and E2E docs are excluded from prepared site content and direct internal routes are treated as not found.
- Observed result: Formatting passed, route helper checks passed, content preparation produced only `index.md`, `users`, and `developers`, and whitespace checks passed.
- Quickest reviewer verification path: Run `npm --prefix docs-site run link`, inspect `docs-site/content`, and confirm there is no `plans`, `design`, or `e2e-tests` directory.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.): The content preparation assertion command exited successfully after checking that public paths exist and internal paths do not.

## Scope / Risk

- Main risk or tradeoff: The docs site now has an explicit public-content allowlist. Future public top-level sections need to be added to the allowlist and content preparation command intentionally.
- Not covered / not validated: Full docs production build is currently blocked by existing public docs rendering errors in Nextra/Next. I attempted both `npx next build` and `npx next build --webpack`; they reached public page prerendering and failed on public pages such as `/users/features/structured-output` and `/developers/tools/shell`.
- Breaking changes / migration notes: No runtime product migration. Docs-site contributors should run the content preparation command after changing public docs.

## Testing Matrix

<!--
Use:
- ✅ tested
- ⚠️ not tested
- N/A
If anything is ⚠️, explain why briefly below.
-->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Tested on macOS for the docs-site content preparation and targeted route helper checks.
- Windows and Linux were not tested locally.

## Linked Issues / Bugs

