### PR TITLE
fix(core): strip additional dangerous interpreter rules

### DIFF
--- a/packages/core/src/permissions/dangerousRules.test.ts
+++ b/packages/core/src/permissions/dangerousRules.test.ts
@@ -159,11 +159,34 @@ describe('isDangerousBashRule', () => {
     });
 
     it.each(['tsx -e *', 'ssh prod-host -- *', 'bunx -p dangerous-pkg *'])(
-      'flags Unix shell or runner wildcard %s',
+      'flags new interpreter, remote shell, or runner wildcard %s',
       (s) => {
         expect(isDangerousBashRule(bashRule(s))).toBe(true);
       },
     );
+
+    it.each([
+      'tsx',
+      'ssh',
+      'bunx',
+      'bash.exe',
+      'cmd',
+      'cmd.exe',
+      'pwsh.exe',
+      'powershell.exe',
+    ])('flags new interpreter, remote shell, or runner bare name %s', (s) => {
+      expect(isDangerousBashRule(bashRule(s))).toBe(true);
+    });
+
+    it.each([
+      'python.exe -c *',
+      'node.exe -e *',
+      'tsx.exe -e *',
+      'bunx.exe -p dangerous-pkg *',
+      'C:\\Python\\python.exe -c *',
+    ])('flags Windows executable suffix wildcard %s', (s) => {
+      expect(isDangerousBashRule(bashRule(s))).toBe(true);
+    });
 
     it.each([
       'cmd /c *',
@@ -191,6 +214,20 @@ describe('isDangerousBashRule', () => {
       '/bin/bash -c *',
     ])('flags absolute-path interpreter form %s', (s) => {
       expect(isDangerousBashRule(bashRule(s))).toBe(true);
+    });
+
+    it.each([
+      'tsx script.tsx',
+      'ssh prod-host -- ls',
+      'cmd /c script.bat',
+      'cmd.exe /c script.bat',
+      'pwsh.exe -File script.ps1',
+      'powershell.exe -File script.ps1',
+      'python.exe script.py',
+      'node.exe script.js',
+      'bunx eslint .',
+    ])('does NOT flag concrete commands using new tokens %s', (s) => {
+      expect(isDangerousBashRule(bashRule(s))).toBe(false);
     });
 
     it('flags Monitor allow rules with the same interpreter logic', () => {

--- a/packages/core/src/permissions/dangerousRules.test.ts
+++ b/packages/core/src/permissions/dangerousRules.test.ts
@@ -188,6 +188,14 @@ describe('isDangerousBashRule', () => {
       expect(isDangerousBashRule(bashRule(s))).toBe(true);
     });
 
+    it.each([
+      'C:\\Python\\python.exe',
+      'C:\\nodejs\\node.exe',
+      'C:\\Users\\me\\bin\\tsx.exe',
+    ])('flags bare Windows interpreter path %s', (s) => {
+      expect(isDangerousBashRule(bashRule(s))).toBe(true);
+    });
+
     it('normalizes Windows executable suffixes in both directions', () => {
       expect(isDangerousBashRule(bashRule('cmd *'))).toBe(true);
       expect(isDangerousBashRule(bashRule('cmd.exe *'))).toBe(true);

--- a/packages/core/src/permissions/dangerousRules.test.ts
+++ b/packages/core/src/permissions/dangerousRules.test.ts
@@ -159,6 +159,19 @@ describe('isDangerousBashRule', () => {
     });
 
     it.each([
+      'tsx -e *',
+      'ssh prod-host -- *',
+      'bunx -p dangerous-pkg *',
+      'cmd /c *',
+      'cmd.exe /c *',
+      'bash.exe -c *',
+      'powershell.exe -Command *',
+      'pwsh.exe -Command *',
+    ])('flags Claude-aligned shell or runner wildcard %s', (s) => {
+      expect(isDangerousBashRule(bashRule(s))).toBe(true);
+    });
+
+    it.each([
       'bun run *',
       'deno run *',
       'npm run *',

--- a/packages/core/src/permissions/dangerousRules.test.ts
+++ b/packages/core/src/permissions/dangerousRules.test.ts
@@ -188,6 +188,11 @@ describe('isDangerousBashRule', () => {
       expect(isDangerousBashRule(bashRule(s))).toBe(true);
     });
 
+    it('normalizes Windows executable suffixes in both directions', () => {
+      expect(isDangerousBashRule(bashRule('cmd *'))).toBe(true);
+      expect(isDangerousBashRule(bashRule('cmd.exe *'))).toBe(true);
+    });
+
     it.each([
       'cmd /c *',
       'cmd.exe /c *',

--- a/packages/core/src/permissions/dangerousRules.test.ts
+++ b/packages/core/src/permissions/dangerousRules.test.ts
@@ -184,6 +184,9 @@ describe('isDangerousBashRule', () => {
       'tsx.exe -e *',
       'bunx.exe -p dangerous-pkg *',
       'C:\\Python\\python.exe -c *',
+      'C:\\Python\\python.exe:*',
+      'C:\\Python\\python:*',
+      'C:\\Program Files\\Python\\python.exe -c *',
     ])('flags Windows executable suffix wildcard %s', (s) => {
       expect(isDangerousBashRule(bashRule(s))).toBe(true);
     });
@@ -192,6 +195,7 @@ describe('isDangerousBashRule', () => {
       'C:\\Python\\python.exe',
       'C:\\nodejs\\node.exe',
       'C:\\Users\\me\\bin\\tsx.exe',
+      'C:\\Program Files\\Python\\python.exe',
     ])('flags bare Windows interpreter path %s', (s) => {
       expect(isDangerousBashRule(bashRule(s))).toBe(true);
     });
@@ -239,6 +243,8 @@ describe('isDangerousBashRule', () => {
       'python.exe script.py',
       'node.exe script.js',
       'bunx eslint .',
+      'C:\\Python\\python.exe script.py',
+      'C:\\Program Files\\Python\\python.exe script.py',
     ])('does NOT flag concrete commands using new tokens %s', (s) => {
       expect(isDangerousBashRule(bashRule(s))).toBe(false);
     });

--- a/packages/core/src/permissions/dangerousRules.test.ts
+++ b/packages/core/src/permissions/dangerousRules.test.ts
@@ -158,16 +158,20 @@ describe('isDangerousBashRule', () => {
       expect(isDangerousBashRule(bashRule(interp))).toBe(true);
     });
 
+    it.each(['tsx -e *', 'ssh prod-host -- *', 'bunx -p dangerous-pkg *'])(
+      'flags Unix shell or runner wildcard %s',
+      (s) => {
+        expect(isDangerousBashRule(bashRule(s))).toBe(true);
+      },
+    );
+
     it.each([
-      'tsx -e *',
-      'ssh prod-host -- *',
-      'bunx -p dangerous-pkg *',
       'cmd /c *',
       'cmd.exe /c *',
       'bash.exe -c *',
       'powershell.exe -Command *',
       'pwsh.exe -Command *',
-    ])('flags Claude-aligned shell or runner wildcard %s', (s) => {
+    ])('flags Windows shell wildcard %s', (s) => {
       expect(isDangerousBashRule(bashRule(s))).toBe(true);
     });
 

--- a/packages/core/src/permissions/dangerousRules.ts
+++ b/packages/core/src/permissions/dangerousRules.ts
@@ -18,13 +18,14 @@ import type { PermissionRule } from './types.js';
 /**
  * Tokens that, when used as the leading command of a Bash allow rule, let the
  * model execute arbitrary code under the AUTO classifier's nose. Covers
- * shell interpreters, scripting-language interpreters, remote shells, and
- * build/package tools that themselves run arbitrary scripts (`cargo run`,
- * `npm run`, …). Mirrors Claude Code's shell and scripting-interpreter
- * checks, then extends them with additional security-relevant runners.
+ * Unix and Windows shell interpreters, scripting-language interpreters,
+ * remote shells, and build/package tools that themselves run arbitrary
+ * scripts (`cargo run`, `npm run`, …). Mirrors Claude Code's shell and
+ * scripting-interpreter checks, then extends them with additional
+ * security-relevant runners.
  */
 const DANGEROUS_BASH_INTERPRETERS: readonly string[] = Object.freeze([
-  // Shells
+  // Unix shells
   'bash',
   'bash.exe',
   'sh',
@@ -34,6 +35,7 @@ const DANGEROUS_BASH_INTERPRETERS: readonly string[] = Object.freeze([
   'tcsh',
   'dash',
   'ksh',
+  // Windows shells
   'cmd',
   'cmd.exe',
   'pwsh',

--- a/packages/core/src/permissions/dangerousRules.ts
+++ b/packages/core/src/permissions/dangerousRules.ts
@@ -20,9 +20,9 @@ import type { PermissionRule } from './types.js';
  * model execute arbitrary code under the AUTO classifier's nose. Covers
  * Unix and Windows shell interpreters, scripting-language interpreters,
  * remote shells, and build/package tools that themselves run arbitrary
- * scripts (`cargo run`, `npm run`, …). Mirrors Claude Code's shell and
- * scripting-interpreter checks, then extends them with additional
- * security-relevant runners.
+ * scripts (`cargo run`, `npm run`, …). The exact token set is intentionally
+ * self-contained so AUTO-mode stripping does not depend on an external
+ * upstream identifier.
  */
 const DANGEROUS_BASH_INTERPRETERS: readonly string[] = Object.freeze([
   // Unix shells
@@ -108,6 +108,7 @@ const SHELL_LIKE_TOOLS: readonly string[] = Object.freeze([
  *   - absolute-path forms (`/usr/bin/python3` → trailing segment `python3`)
  *   - trailing-wildcard forms (`python3*`)
  *   - colon form (`python:`)
+ *   - Windows executable suffixes (`python.exe`)
  */
 function isInterpreterToken(rawToken: string): boolean {
   if (!rawToken) return false;
@@ -120,10 +121,18 @@ function isInterpreterToken(rawToken: string): boolean {
     end--;
   }
   const noWildcard = rawToken.slice(0, end);
-  const beforeColon = noWildcard.split(':')[0];
+  const beforeColon = /^[a-z]:[\\/]/i.test(noWildcard)
+    ? noWildcard
+    : noWildcard.split(':')[0];
   // Last path segment so `/usr/bin/python3` → `python3`
-  const lastSegment = (beforeColon ?? '').split('/').pop() ?? '';
-  return DANGEROUS_BASH_INTERPRETERS.includes(lastSegment);
+  const lastSegment = (beforeColon ?? '').split(/[\\/]/).pop() ?? '';
+  const withoutExe = lastSegment.endsWith('.exe')
+    ? lastSegment.slice(0, -'.exe'.length)
+    : lastSegment;
+  return (
+    DANGEROUS_BASH_INTERPRETERS.includes(lastSegment) ||
+    DANGEROUS_BASH_INTERPRETERS.includes(withoutExe)
+  );
 }
 
 /**
@@ -152,12 +161,12 @@ export function isDangerousBashRule(rule: PermissionRule): boolean {
   // dangerous when it appears as the first token of either form
   // (`python -c *` or `python:*`). For colon-form, the part after `:` is
   // the specifier — we'll separately check whether it's concrete below.
-  const firstToken = content.split(/[\s:]/)[0] ?? '';
+  const firstToken = content.split(/\s/)[0] ?? '';
   if (!isInterpreterToken(firstToken)) return false;
 
   // Bare interpreter name (`python`, `/usr/bin/python3`) — caller decides
   // what to do, classifier never sees it. Dangerous.
-  if (firstToken === content) return true;
+  if (firstToken === content && !content.includes(':')) return true;
 
   // Wildcard anywhere paired with an interpreter defeats the classifier:
   // `python *`, `python -c *`, `bun run *`, `/usr/bin/python3 *`,

--- a/packages/core/src/permissions/dangerousRules.ts
+++ b/packages/core/src/permissions/dangerousRules.ts
@@ -91,6 +91,25 @@ function stripWindowsExecutableSuffix(token: string): string {
   return token.endsWith('.exe') ? token.slice(0, -'.exe'.length) : token;
 }
 
+function matcherColonIndex(content: string): number {
+  const firstColon = content.indexOf(':');
+  if (firstColon < 0) return -1;
+  if (/^[a-z]:[\\/]/i.test(content)) {
+    return content.indexOf(':', 2);
+  }
+  return firstColon;
+}
+
+function leadingCommandToken(content: string): string {
+  if (/^[a-z]:[\\/]/i.test(content)) {
+    const exeIndex = content.indexOf('.exe');
+    if (exeIndex >= 0) {
+      return content.slice(0, exeIndex + '.exe'.length);
+    }
+  }
+  return content.split(/\s/)[0] ?? '';
+}
+
 /**
  * Tools whose allow rules carry shell-like risk. `monitor` is a long-running
  * shell-command runner and should be treated the same as `shell` for the
@@ -121,9 +140,9 @@ function isInterpreterToken(rawToken: string): boolean {
     end--;
   }
   const noWildcard = rawToken.slice(0, end);
-  const beforeColon = /^[a-z]:[\\/]/i.test(noWildcard)
-    ? noWildcard
-    : noWildcard.split(':')[0];
+  const colonIndex = matcherColonIndex(noWildcard);
+  const beforeColon =
+    colonIndex >= 0 ? noWildcard.slice(0, colonIndex) : noWildcard;
   // Last path segment so `/usr/bin/python3` → `python3`
   const lastSegment = (beforeColon ?? '').split(/[\\/]/).pop() ?? '';
   const normalizedSegment = stripWindowsExecutableSuffix(lastSegment);
@@ -161,10 +180,10 @@ export function isDangerousBashRule(rule: PermissionRule): boolean {
   // form
   // (`python -c *` or `python:*`). For colon-form, the part after `:` is
   // the specifier — we'll separately check whether it's concrete below.
-  const firstToken = content.split(/\s/)[0] ?? '';
+  const firstToken = leadingCommandToken(content);
   if (!isInterpreterToken(firstToken)) return false;
-  const hasMatcherColon =
-    content.includes(':') && !/^[a-z]:[\\/]/i.test(content);
+  const colonIndex = matcherColonIndex(content);
+  const hasMatcherColon = colonIndex >= 0;
 
   // Bare interpreter name (`python`, `/usr/bin/python3`) — caller decides
   // what to do, classifier never sees it. Dangerous.
@@ -183,7 +202,7 @@ export function isDangerousBashRule(rule: PermissionRule): boolean {
   // commits to NOT flagging. Strip them and we'd silently disable
   // intentional user allow lists in AUTO.
   if (hasMatcherColon) {
-    const afterColon = content.slice(content.indexOf(':') + 1).trim();
+    const afterColon = content.slice(colonIndex + 1).trim();
     return afterColon === '';
   }
 

--- a/packages/core/src/permissions/dangerousRules.ts
+++ b/packages/core/src/permissions/dangerousRules.ts
@@ -91,6 +91,10 @@ const DANGEROUS_BASH_INTERPRETERS: readonly string[] = Object.freeze([
   'source',
 ]);
 
+function stripWindowsExecutableSuffix(token: string): string {
+  return token.endsWith('.exe') ? token.slice(0, -'.exe'.length) : token;
+}
+
 /**
  * Tools whose allow rules carry shell-like risk. `monitor` is a long-running
  * shell-command runner and should be treated the same as `shell` for the
@@ -126,12 +130,10 @@ function isInterpreterToken(rawToken: string): boolean {
     : noWildcard.split(':')[0];
   // Last path segment so `/usr/bin/python3` → `python3`
   const lastSegment = (beforeColon ?? '').split(/[\\/]/).pop() ?? '';
-  const withoutExe = lastSegment.endsWith('.exe')
-    ? lastSegment.slice(0, -'.exe'.length)
-    : lastSegment;
-  return (
-    DANGEROUS_BASH_INTERPRETERS.includes(lastSegment) ||
-    DANGEROUS_BASH_INTERPRETERS.includes(withoutExe)
+  const normalizedSegment = stripWindowsExecutableSuffix(lastSegment);
+  return DANGEROUS_BASH_INTERPRETERS.some(
+    (interpreter) =>
+      stripWindowsExecutableSuffix(interpreter) === normalizedSegment,
   );
 }
 

--- a/packages/core/src/permissions/dangerousRules.ts
+++ b/packages/core/src/permissions/dangerousRules.ts
@@ -18,13 +18,15 @@ import type { PermissionRule } from './types.js';
 /**
  * Tokens that, when used as the leading command of a Bash allow rule, let the
  * model execute arbitrary code under the AUTO classifier's nose. Covers
- * shell interpreters, scripting-language interpreters, and build/package
- * tools that themselves run arbitrary scripts (`cargo run`, `npm run`, …).
- * Mirrors and extends ClaudeCode's `DANGEROUS_BASH_PATTERNS`.
+ * shell interpreters, scripting-language interpreters, remote shells, and
+ * build/package tools that themselves run arbitrary scripts (`cargo run`,
+ * `npm run`, …). Mirrors Claude Code's shell and scripting-interpreter
+ * checks, then extends them with additional security-relevant runners.
  */
 const DANGEROUS_BASH_INTERPRETERS: readonly string[] = Object.freeze([
   // Shells
   'bash',
+  'bash.exe',
   'sh',
   'zsh',
   'fish',
@@ -32,14 +34,19 @@ const DANGEROUS_BASH_INTERPRETERS: readonly string[] = Object.freeze([
   'tcsh',
   'dash',
   'ksh',
+  'cmd',
+  'cmd.exe',
   'pwsh',
+  'pwsh.exe',
   'powershell',
+  'powershell.exe',
   // Scripting-language interpreters
   'python',
   'python3',
   'python2',
   'node',
   'deno',
+  'tsx',
   'bun',
   'ruby',
   'perl',
@@ -69,10 +76,13 @@ const DANGEROUS_BASH_INTERPRETERS: readonly string[] = Object.freeze([
   // that without this list would be the cleanest way to bypass the
   // classifier in AUTO mode.
   'npx',
+  'bunx',
   'pnpx',
   'uvx',
   'pipx',
   'dlx',
+  // Remote shells
+  'ssh',
   // Generic eval-y commands
   'eval',
   'exec',

--- a/packages/core/src/permissions/dangerousRules.ts
+++ b/packages/core/src/permissions/dangerousRules.ts
@@ -27,7 +27,6 @@ import type { PermissionRule } from './types.js';
 const DANGEROUS_BASH_INTERPRETERS: readonly string[] = Object.freeze([
   // Unix shells
   'bash',
-  'bash.exe',
   'sh',
   'zsh',
   'fish',
@@ -36,6 +35,7 @@ const DANGEROUS_BASH_INTERPRETERS: readonly string[] = Object.freeze([
   'dash',
   'ksh',
   // Windows shells
+  'bash.exe',
   'cmd',
   'cmd.exe',
   'pwsh',

--- a/packages/core/src/permissions/dangerousRules.ts
+++ b/packages/core/src/permissions/dangerousRules.ts
@@ -35,13 +35,9 @@ const DANGEROUS_BASH_INTERPRETERS: readonly string[] = Object.freeze([
   'dash',
   'ksh',
   // Windows shells
-  'bash.exe',
   'cmd',
-  'cmd.exe',
   'pwsh',
-  'pwsh.exe',
   'powershell',
-  'powershell.exe',
   // Scripting-language interpreters
   'python',
   'python3',
@@ -159,16 +155,20 @@ export function isDangerousBashRule(rule: PermissionRule): boolean {
   const content = rule.specifier.trim().toLowerCase();
   if (content === '' || content === '*') return true;
 
-  // Treat both whitespace and `:` as token delimiters: an interpreter is
-  // dangerous when it appears as the first token of either form
+  // Treat whitespace as the first-token delimiter; matcher-colon form is
+  // handled separately below because Windows drive letters also contain `:`.
+  // An interpreter is dangerous when it appears as the first token of either
+  // form
   // (`python -c *` or `python:*`). For colon-form, the part after `:` is
   // the specifier — we'll separately check whether it's concrete below.
   const firstToken = content.split(/\s/)[0] ?? '';
   if (!isInterpreterToken(firstToken)) return false;
+  const hasMatcherColon =
+    content.includes(':') && !/^[a-z]:[\\/]/i.test(content);
 
   // Bare interpreter name (`python`, `/usr/bin/python3`) — caller decides
   // what to do, classifier never sees it. Dangerous.
-  if (firstToken === content && !content.includes(':')) return true;
+  if (firstToken === content && !hasMatcherColon) return true;
 
   // Wildcard anywhere paired with an interpreter defeats the classifier:
   // `python *`, `python -c *`, `bun run *`, `/usr/bin/python3 *`,
@@ -182,7 +182,7 @@ export function isDangerousBashRule(rule: PermissionRule): boolean {
   // rules — same shape as `Bash(npm run test)`, which the docstring above
   // commits to NOT flagging. Strip them and we'd silently disable
   // intentional user allow lists in AUTO.
-  if (content.includes(':')) {
+  if (hasMatcherColon) {
     const afterColon = content.slice(content.indexOf(':') + 1).trim();
     return afterColon === '';
   }


### PR DESCRIPTION
## Summary

- What changed: Added AUTO-mode dangerous allow-rule coverage for `tsx`, `ssh`, `bunx`, and Windows shell executable variants.
- Why it changed: Broad Bash/Monitor allow rules for these executors can run arbitrary code or move execution outside the local classifier boundary.
- Reviewer focus: Confirm the added interpreter tokens are security-relevant and that concrete non-wildcard commands remain unaffected.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/permissions/dangerousRules.test.ts
  cd packages/core && npm run typecheck
  git diff --check
  ```
- Prompts / inputs used: N/A
- Expected result: New broad allow-rule cases are flagged as dangerous; existing concrete command behavior is unchanged.
- Observed result: `dangerousRules.test.ts` passed with 78 tests. `git diff --check` passed. `npm run typecheck` did not complete because the local dependency tree could not resolve existing project dependencies such as `@google/genai`, MCP SDK packages, and `undici`.
- Quickest reviewer verification path:
  ```bash
  cd packages/core && npx vitest run src/permissions/dangerousRules.test.ts
  ```
- Evidence: Before the production change, the new tests failed for all 8 added cases; after adding the interpreter tokens, the focused test file passed.

## Scope / Risk

- Main risk or tradeoff: This only affects broad AUTO-mode allow-rule stripping; users with wildcard allow rules for these executors will be routed through safer approval behavior.
- Not covered / not validated: Full package typecheck, blocked by local dependency resolution failures unrelated to this patch.
- Breaking changes / migration notes: No settings migration. User settings are not modified; dangerous rules are stripped only at AUTO-mode runtime.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Focused Vitest coverage was run on macOS for the changed core permission logic.
- Cross-platform runtime behavior was not manually tested; the change is token-list based and covered by unit tests.

## Linked Issues / Bugs

Closes #4370