### PR TITLE
fix(core): preserve tab-indented notebook formatting

### DIFF
--- a/packages/core/src/tools/notebook-edit.test.ts
+++ b/packages/core/src/tools/notebook-edit.test.ts
@@ -494,6 +494,76 @@ describe('NotebookEditTool', () => {
     expect(result.llmContent).not.toContain('without offset or limit');
   });
 
+  it('rejects notebook directory targets with TARGET_IS_DIRECTORY', async () => {
+    const dirPath = path.join(tempDir, 'directory.ipynb');
+    fs.mkdirSync(dirPath);
+
+    const result = await buildInvocation({
+      notebook_path: dirPath,
+      cell_id: 'a',
+      new_source: 'x = 2',
+    }).execute(abortSignal);
+
+    expect(result.error?.type).toBe(ToolErrorType.TARGET_IS_DIRECTORY);
+    expect(result.llmContent).toContain('is a directory');
+  });
+
+  it('returns FILE_CHANGED_SINCE_READ when a notebook disappears after content read', async () => {
+    const filePath = writeNotebook('disappears-after-read.ipynb', {
+      cells: [{ cell_type: 'code', id: 'a', source: ['x = 1'], metadata: {} }],
+      metadata: {},
+    });
+    seedNotebookRead(filePath);
+    const realFileSystemService = new StandardFileSystemService();
+    const fileSystemService = new StandardFileSystemService();
+    vi.spyOn(fileSystemService, 'readTextFile').mockImplementation(
+      async (args) => {
+        const result = await realFileSystemService.readTextFile(args);
+        fs.unlinkSync(filePath);
+        return result;
+      },
+    );
+    vi.spyOn(config, 'getFileSystemService').mockReturnValue(fileSystemService);
+
+    const result = await buildInvocation({
+      notebook_path: filePath,
+      cell_id: 'a',
+      new_source: 'x = 2',
+    }).execute(abortSignal);
+
+    expect(result.error?.type).toBe(ToolErrorType.FILE_CHANGED_SINCE_READ);
+    expect(result.llmContent).toContain('disappeared after it was read');
+  });
+
+  it('returns PRIOR_READ_VERIFICATION_FAILED when notebook stat verification fails', async () => {
+    const filePath = writeNotebook('stat-fails.ipynb', {
+      cells: [{ cell_type: 'code', id: 'a', source: ['x = 1'], metadata: {} }],
+      metadata: {},
+    });
+    seedNotebookRead(filePath);
+    const statSpy = vi
+      .spyOn(fs.promises, 'stat')
+      .mockRejectedValueOnce(
+        Object.assign(new Error('permission denied'), { code: 'EACCES' }),
+      );
+    let result: ToolResult | undefined;
+
+    try {
+      result = await buildInvocation({
+        notebook_path: filePath,
+        cell_id: 'a',
+        new_source: 'x = 2',
+      }).execute(abortSignal);
+    } finally {
+      statSpy.mockRestore();
+    }
+
+    expect(result?.error?.type).toBe(
+      ToolErrorType.PRIOR_READ_VERIFICATION_FAILED,
+    );
+    expect(result?.llmContent).toContain('Could not stat');
+  });
+
   it.skipIf(process.platform === 'win32')(
     'rejects non-regular notebook paths with a dedicated error type',
     async () => {

--- a/packages/core/src/utils/notebook.test.ts
+++ b/packages/core/src/utils/notebook.test.ts
@@ -504,6 +504,31 @@ describe('notebook utilities', () => {
     expect(serialized.endsWith('\n')).toBe(false);
   });
 
+  it('should preserve tab-indented notebook JSON when serializing after edits', () => {
+    const raw = [
+      '{',
+      '\t"cells": [',
+      '\t\t{',
+      '\t\t\t"cell_type": "markdown",',
+      '\t\t\t"source": "# Title",',
+      '\t\t\t"metadata": {}',
+      '\t\t}',
+      '\t],',
+      '\t"metadata": {}',
+      '}',
+      '',
+    ].join('\n');
+    const notebook = parseNotebook(raw);
+    notebook.cells[0]!.source = '# Updated';
+
+    const format = inferNotebookJsonFormat(raw);
+    const serialized = serializeNotebook(notebook, format);
+
+    expect(format).toEqual({ indent: '\t', trailingNewline: true });
+    expect(serialized).toContain('\n\t"cells"');
+    expect(serialized.endsWith('\n')).toBe(true);
+  });
+
   it('should preserve compact notebook JSON when serializing after edits', () => {
     const raw = JSON.stringify({
       cells: [{ cell_type: 'markdown', source: '# Title', metadata: {} }],

--- a/packages/core/src/utils/notebook.test.ts
+++ b/packages/core/src/utils/notebook.test.ts
@@ -529,6 +529,32 @@ describe('notebook utilities', () => {
     expect(serialized.endsWith('\n')).toBe(true);
   });
 
+  it('should preserve mixed whitespace notebook JSON indentation after edits', () => {
+    const indent = ' \t';
+    const raw = [
+      '{',
+      `${indent}"cells": [`,
+      `${indent}${indent}{`,
+      `${indent}${indent}${indent}"cell_type": "markdown",`,
+      `${indent}${indent}${indent}"source": "# Title",`,
+      `${indent}${indent}${indent}"metadata": {}`,
+      `${indent}${indent}}`,
+      `${indent}],`,
+      `${indent}"metadata": {}`,
+      '}',
+    ].join('\n');
+    const notebook = parseNotebook(raw);
+    notebook.cells[0]!.source = '# Updated';
+
+    const format = inferNotebookJsonFormat(raw);
+    const serialized = serializeNotebook(notebook, format);
+
+    expect(format).toEqual({ indent, trailingNewline: false });
+    expect(serialized).toContain(`\n${indent}"cells"`);
+    expect(serialized).toContain(`\n${indent}${indent}{`);
+    expect(serialized.endsWith('\n')).toBe(false);
+  });
+
   it('should preserve compact notebook JSON when serializing after edits', () => {
     const raw = JSON.stringify({
       cells: [{ cell_type: 'markdown', source: '# Title', metadata: {} }],

--- a/packages/core/src/utils/notebook.ts
+++ b/packages/core/src/utils/notebook.ts
@@ -86,7 +86,7 @@ export interface NotebookReadResult {
 }
 
 export interface NotebookJsonFormat {
-  indent?: number;
+  indent?: number | string;
   trailingNewline: boolean;
 }
 
@@ -118,9 +118,14 @@ export function parseNotebook(content: string): NotebookContent {
 }
 
 export function inferNotebookJsonFormat(content: string): NotebookJsonFormat {
-  const lineMatch = content.match(/\n( +)"/);
+  const lineMatch = content.match(/\n([ \t]+)"/);
+  const indent = lineMatch?.[1];
+  let inferredIndent: number | string | undefined;
+  if (indent !== undefined) {
+    inferredIndent = /^ +$/.test(indent) ? indent.length : indent;
+  }
   return {
-    indent: lineMatch?.[1]?.length,
+    indent: inferredIndent,
     trailingNewline: content.endsWith('\n'),
   };
 }


### PR DESCRIPTION
## Summary

- Follow up on #3900 by fixing the remaining unfinished notebook review items from that PR.
- Preserve tab and mixed-whitespace `.ipynb` JSON formatting when `notebook_edit` serializes edited notebooks.
- Add regression coverage for tab and mixed-whitespace notebook formatting to avoid single-line JSON rewrites.
- Add coverage for existing notebook prior-read verification error paths: directory targets, disappearing files after content read, and non-ENOENT stat failures.

## Design

`inferNotebookJsonFormat` now detects leading tabs as well as spaces in pretty-printed notebook JSON. Space-only indentation still returns a numeric indent to preserve the existing behavior, while tab or mixed whitespace indentation returns the matched whitespace string, which `JSON.stringify` accepts as its `space` argument.

The prior-read behavior is unchanged. The new `NotebookEditTool` tests pin the existing safeguards so review feedback around those edge cases is covered without expanding the tool surface.

## Testing

- `npm test --workspace=packages/core -- --run src/utils/notebook.test.ts src/tools/notebook-edit.test.ts`
- `npm run build --workspace=packages/core`
- `npm run typecheck --workspace=packages/core`
- `npm run lint --workspace=packages/core`

## Review focus / test areas

- Confirm that space-indented and compact notebook JSON behavior remains unchanged.
- Confirm that tab and mixed-whitespace notebook JSON no longer serialize as compact single-line JSON.
- Confirm the added prior-read tests match the intended structured error types.

Follow-up to #3900.
