### PR TITLE
Emit PermissionDenied hooks for AUTO classifier blocks

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -8,7 +8,11 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { computeInitialTurnFromHistory, Session } from './Session.js';
+import {
+  computeInitialTurnFromHistory,
+  fireSessionPermissionDeniedForAutoMode,
+  Session,
+} from './Session.js';
 import type { Content } from '@google/genai';
 import type { ChatRecord, Config, GeminiChat } from '@qwen-code/qwen-code-core';
 import { ApprovalMode, AuthType } from '@qwen-code/qwen-code-core';
@@ -2170,6 +2174,129 @@ describe('Session', () => {
     });
 
     describe('hooks', () => {
+      describe('PermissionDenied hook', () => {
+        it('fires PermissionDenied hooks for AUTO classifier blocks', async () => {
+          const hookSystem = {
+            firePermissionDeniedEvent: vi.fn().mockResolvedValue(undefined),
+          };
+          mockConfig.getHookSystem = vi.fn().mockReturnValue(hookSystem);
+          mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(false);
+          const signal = new AbortController().signal;
+
+          await fireSessionPermissionDeniedForAutoMode(
+            mockConfig,
+            {
+              via: 'classifier',
+              shouldBlock: true,
+              reason: 'dangerous shell command',
+              unavailable: false,
+              stage: 'fast',
+              durationMs: 20,
+            },
+            { kind: 'blocked', errorMessage: 'blocked' },
+            core.ToolNames.SHELL,
+            { command: 'rm -rf /tmp/example' },
+            'auto-denied-acp',
+            signal,
+          );
+
+          expect(hookSystem.firePermissionDeniedEvent).toHaveBeenCalledWith(
+            core.ToolNames.SHELL,
+            { command: 'rm -rf /tmp/example' },
+            'auto-denied-acp',
+            'classifier_blocked',
+            signal,
+          );
+        });
+
+        it('forwards classifier_unavailable reasons to PermissionDenied hooks', async () => {
+          const hookSystem = {
+            firePermissionDeniedEvent: vi.fn().mockResolvedValue(undefined),
+          };
+          mockConfig.getHookSystem = vi.fn().mockReturnValue(hookSystem);
+          mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(false);
+
+          await fireSessionPermissionDeniedForAutoMode(
+            mockConfig,
+            {
+              via: 'classifier',
+              shouldBlock: true,
+              reason: 'classifier timeout',
+              unavailable: true,
+              stage: 'fast',
+              durationMs: 3000,
+            },
+            { kind: 'blocked', errorMessage: 'blocked' },
+            core.ToolNames.SHELL,
+            { command: 'rm -rf /tmp/example' },
+            'auto-denied-acp',
+            new AbortController().signal,
+          );
+
+          expect(hookSystem.firePermissionDeniedEvent).toHaveBeenCalledWith(
+            core.ToolNames.SHELL,
+            { command: 'rm -rf /tmp/example' },
+            'auto-denied-acp',
+            'classifier_unavailable',
+            expect.any(AbortSignal),
+          );
+        });
+
+        it('skips PermissionDenied hooks when hooks are disabled', async () => {
+          const hookSystem = {
+            firePermissionDeniedEvent: vi.fn().mockResolvedValue(undefined),
+          };
+          mockConfig.getHookSystem = vi.fn().mockReturnValue(hookSystem);
+          mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(true);
+
+          await fireSessionPermissionDeniedForAutoMode(
+            mockConfig,
+            {
+              via: 'classifier',
+              shouldBlock: true,
+              reason: 'dangerous shell command',
+              unavailable: false,
+              stage: 'fast',
+              durationMs: 20,
+            },
+            { kind: 'blocked', errorMessage: 'blocked' },
+            core.ToolNames.SHELL,
+            { command: 'rm -rf /tmp/example' },
+            'auto-denied-acp',
+            new AbortController().signal,
+          );
+
+          expect(hookSystem.firePermissionDeniedEvent).not.toHaveBeenCalled();
+        });
+
+        it('skips PermissionDenied hooks when AUTO outcome is not blocked', async () => {
+          const hookSystem = {
+            firePermissionDeniedEvent: vi.fn().mockResolvedValue(undefined),
+          };
+          mockConfig.getHookSystem = vi.fn().mockReturnValue(hookSystem);
+          mockConfig.getDisableAllHooks = vi.fn().mockReturnValue(false);
+
+          await fireSessionPermissionDeniedForAutoMode(
+            mockConfig,
+            {
+              via: 'classifier',
+              shouldBlock: true,
+              reason: 'dangerous shell command',
+              unavailable: false,
+              stage: 'fast',
+              durationMs: 20,
+            },
+            { kind: 'fallback' },
+            core.ToolNames.SHELL,
+            { command: 'rm -rf /tmp/example' },
+            'auto-denied-acp',
+            new AbortController().signal,
+          );
+
+          expect(hookSystem.firePermissionDeniedEvent).not.toHaveBeenCalled();
+        });
+      });
+
       describe('UserPromptSubmit hook', () => {
         it('fires UserPromptSubmit hook before sending prompt', async () => {
           const messageBus = {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -23,6 +23,8 @@ import type {
   MessageBus,
   StreamEvent,
   ChatCompressionInfo,
+  AutoModeDecision,
+  AutoModeOutcome,
 } from '@qwen-code/qwen-code-core';
 import {
   AuthType,
@@ -159,6 +161,31 @@ export function computeInitialTurnFromHistory(
   }
 
   return maxPromptTurn > 0 ? maxPromptTurn : userMessageCount;
+}
+
+export async function fireSessionPermissionDeniedForAutoMode(
+  config: Config,
+  decision: AutoModeDecision,
+  outcome: AutoModeOutcome,
+  toolName: string,
+  toolParams: Record<string, unknown>,
+  callId: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  if (
+    !config.getDisableAllHooks?.() &&
+    shouldFirePermissionDeniedForAutoMode(decision, outcome)
+  ) {
+    await config
+      .getHookSystem?.()
+      ?.firePermissionDeniedEvent(
+        toolName,
+        toolParams,
+        callId,
+        getAutoModePermissionDeniedReason(decision),
+        signal,
+      );
+  }
 }
 
 function getRecordPromptIds(record: ChatRecord): string[] {
@@ -1982,20 +2009,15 @@ export class Session implements SessionContext {
           this.config,
           denialState,
         );
-        if (
-          !this.config.getDisableAllHooks?.() &&
-          shouldFirePermissionDeniedForAutoMode(decision, outcome)
-        ) {
-          await this.config
-            .getHookSystem?.()
-            ?.firePermissionDeniedEvent(
-              fc.name,
-              toolParams,
-              callId,
-              getAutoModePermissionDeniedReason(decision),
-              abortSignal,
-            );
-        }
+        await fireSessionPermissionDeniedForAutoMode(
+          this.config,
+          decision,
+          outcome,
+          fc.name,
+          toolParams,
+          callId,
+          abortSignal,
+        );
         switch (outcome.kind) {
           case 'approved':
             autoModeAllowed = true;

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -1982,7 +1982,10 @@ export class Session implements SessionContext {
           this.config,
           denialState,
         );
-        if (shouldFirePermissionDeniedForAutoMode(decision, outcome)) {
+        if (
+          !this.config.getDisableAllHooks?.() &&
+          shouldFirePermissionDeniedForAutoMode(decision, outcome)
+        ) {
           await this.config
             .getHookSystem?.()
             ?.firePermissionDeniedEvent(

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -62,11 +62,13 @@ import {
   formatStopHookBlockingCapWarning,
   applyAutoModeDecision,
   evaluateAutoMode,
+  getAutoModePermissionDeniedReason,
   isApproveOutcome,
   MAX_TRANSCRIPT_MESSAGES,
   recordAllow,
   recordFallbackApprove,
   shouldFallback,
+  shouldFirePermissionDeniedForAutoMode,
   shouldRunAutoModeForCall,
 } from '@qwen-code/qwen-code-core';
 import { getCommandSubcommandNames } from '../../services/commandMetadata.js';
@@ -1980,6 +1982,17 @@ export class Session implements SessionContext {
           this.config,
           denialState,
         );
+        if (shouldFirePermissionDeniedForAutoMode(decision, outcome)) {
+          await this.config
+            .getHookSystem?.()
+            ?.firePermissionDeniedEvent(
+              fc.name,
+              toolParams,
+              callId,
+              getAutoModePermissionDeniedReason(decision),
+              abortSignal,
+            );
+        }
         switch (outcome.kind) {
           case 'approved':
             autoModeAllowed = true;

--- a/packages/cli/src/ui/components/hooks/constants.test.ts
+++ b/packages/cli/src/ui/components/hooks/constants.test.ts
@@ -176,12 +176,13 @@ describe('hooks constants', () => {
       expect(DISPLAY_HOOK_EVENTS).toContain(HookEventName.PreCompact);
       expect(DISPLAY_HOOK_EVENTS).toContain(HookEventName.PostCompact);
       expect(DISPLAY_HOOK_EVENTS).toContain(HookEventName.PermissionRequest);
+      expect(DISPLAY_HOOK_EVENTS).toContain(HookEventName.PermissionDenied);
       expect(DISPLAY_HOOK_EVENTS).toContain(HookEventName.TodoCreated);
       expect(DISPLAY_HOOK_EVENTS).toContain(HookEventName.TodoCompleted);
     });
 
-    it('should have 16 events', () => {
-      expect(DISPLAY_HOOK_EVENTS).toHaveLength(16);
+    it('should have 17 events', () => {
+      expect(DISPLAY_HOOK_EVENTS).toHaveLength(17);
     });
   });
 

--- a/packages/cli/src/ui/components/hooks/constants.ts
+++ b/packages/cli/src/ui/components/hooks/constants.ts
@@ -190,7 +190,7 @@ export function getHookDescription(eventName: string): string {
       'Input to command is JSON with tool_name, tool_input, and tool_use_id. Output JSON with hookSpecificOutput containing decision to allow or deny.',
     ),
     [HookEventName.PermissionDenied]: t(
-      'Input to command is JSON with tool_name, tool_input, tool_use_id, reason, and message.',
+      'Input to command is JSON with tool_name, tool_input, tool_use_id, and reason.',
     ),
     [HookEventName.TodoCreated]: t(
       'Input to command is JSON with todo_id, todo_content, todo_status, all_todos, and phase. In validation, output JSON with decision (allow/block/deny) and reason. In postWrite, block/deny is ignored.',

--- a/packages/cli/src/ui/components/hooks/constants.ts
+++ b/packages/cli/src/ui/components/hooks/constants.ts
@@ -94,6 +94,10 @@ export function getHookExitCodes(eventName: string): HookExitCode[] {
       { code: 0, description: t('use hook decision if provided') },
       { code: 'Other', description: t('show stderr to user only') },
     ],
+    [HookEventName.PermissionDenied]: [
+      { code: 0, description: t('stdout/stderr not shown') },
+      { code: 'Other', description: t('show stderr to user only') },
+    ],
     [HookEventName.TodoCreated]: [
       { code: 0, description: t('allow todo creation') },
       {
@@ -136,6 +140,9 @@ export function getHookShortDescription(eventName: string): string {
     [HookEventName.SessionEnd]: t('When a session is ending'),
     [HookEventName.PermissionRequest]: t(
       'When a permission dialog is displayed',
+    ),
+    [HookEventName.PermissionDenied]: t(
+      'When a tool call is denied before a permission dialog is displayed',
     ),
     [HookEventName.TodoCreated]: t('When a new todo item is created'),
     [HookEventName.TodoCompleted]: t('When a todo item is marked as completed'),
@@ -181,6 +188,9 @@ export function getHookDescription(eventName: string): string {
     ),
     [HookEventName.PermissionRequest]: t(
       'Input to command is JSON with tool_name, tool_input, and tool_use_id. Output JSON with hookSpecificOutput containing decision to allow or deny.',
+    ),
+    [HookEventName.PermissionDenied]: t(
+      'Input to command is JSON with tool_name, tool_input, tool_use_id, reason, and message.',
     ),
     [HookEventName.TodoCreated]: t(
       'Input to command is JSON with todo_id, todo_content, todo_status, all_todos, and phase. In validation, output JSON with decision (allow/block/deny) and reason. In postWrite, block/deny is ignored.',

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -109,6 +109,7 @@ import {
 import {
   PermissionMode,
   NotificationType,
+  type PermissionDeniedReason,
   type PermissionSuggestion,
   type HookEventName,
   type HookDefinition,
@@ -1269,6 +1270,16 @@ export class Config {
                   (input['permission_suggestions'] as
                     | PermissionSuggestion[]
                     | undefined) || undefined,
+                  signal,
+                );
+                break;
+              case 'PermissionDenied':
+                result = await hookSystem.firePermissionDeniedEvent(
+                  (input['tool_name'] as string) || '',
+                  (input['tool_input'] as Record<string, unknown>) || {},
+                  (input['tool_use_id'] as string) || '',
+                  (input['reason'] as PermissionDeniedReason) ||
+                    'classifier_blocked',
                   signal,
                 );
                 break;

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -784,6 +784,54 @@ describe('CoreToolScheduler', () => {
     expect(hookSystem.firePermissionDeniedEvent).not.toHaveBeenCalled();
   });
 
+  it('does not fire PermissionDenied hooks when AUTO classifier approves', async () => {
+    runSideQueryMock.mockResolvedValueOnce({ shouldBlock: false });
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'executed',
+      returnDisplay: 'executed',
+    });
+    const toolsByName = new Map<string, MockTool>([
+      [
+        ToolNames.SHELL,
+        new MockTool({
+          name: ToolNames.SHELL,
+          getDefaultPermission: MOCK_TOOL_GET_DEFAULT_PERMISSION,
+          getConfirmationDetails: MOCK_TOOL_GET_CONFIRMATION_DETAILS,
+          execute,
+        }),
+      ],
+    ]);
+    const hookSystem = {
+      firePermissionDeniedEvent: vi.fn().mockResolvedValue(undefined),
+    };
+    const { scheduler, onAllToolCallsComplete } =
+      createSchedulerForLegacyToolTests({
+        toolsByName,
+        approvalMode: ApprovalMode.AUTO,
+        hookSystem,
+        disableHooks: false,
+      });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'auto-approved',
+          name: ToolNames.SHELL,
+          args: { command: 'echo ok' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-auto-approved',
+        },
+      ],
+      new AbortController().signal,
+    );
+
+    await vi.waitFor(() => {
+      expect(onAllToolCallsComplete).toHaveBeenCalled();
+    });
+    expect(hookSystem.firePermissionDeniedEvent).not.toHaveBeenCalled();
+    expect(execute).toHaveBeenCalledOnce();
+  });
+
   it.each(Object.entries(ToolNamesMigration))(
     'sends canonical hook tool names for legacy %s calls',
     async (legacyName, canonicalName) => {

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -680,6 +680,63 @@ describe('CoreToolScheduler', () => {
     expect(completedCalls[0].status).toBe('error');
   });
 
+  it('fires PermissionDenied hooks for AUTO classifier unavailable blocks', async () => {
+    runSideQueryMock
+      .mockResolvedValueOnce({ shouldBlock: true })
+      .mockRejectedValueOnce(new Error('classifier timed out'));
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'should not execute',
+      returnDisplay: 'should not execute',
+    });
+    const toolsByName = new Map<string, MockTool>([
+      [
+        ToolNames.SHELL,
+        new MockTool({
+          name: ToolNames.SHELL,
+          getDefaultPermission: MOCK_TOOL_GET_DEFAULT_PERMISSION,
+          getConfirmationDetails: MOCK_TOOL_GET_CONFIRMATION_DETAILS,
+          execute,
+        }),
+      ],
+    ]);
+    const hookSystem = {
+      firePermissionDeniedEvent: vi.fn().mockResolvedValue(undefined),
+    };
+    const { scheduler, onAllToolCallsComplete } =
+      createSchedulerForLegacyToolTests({
+        toolsByName,
+        approvalMode: ApprovalMode.AUTO,
+        hookSystem,
+        disableHooks: false,
+      });
+    const abortController = new AbortController();
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'auto-unavailable',
+          name: ToolNames.SHELL,
+          args: { command: 'rm -rf /tmp/example' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-auto-unavailable',
+        },
+      ],
+      abortController.signal,
+    );
+
+    await vi.waitFor(() => {
+      expect(onAllToolCallsComplete).toHaveBeenCalled();
+    });
+    expect(hookSystem.firePermissionDeniedEvent).toHaveBeenCalledWith(
+      ToolNames.SHELL,
+      { command: 'rm -rf /tmp/example' },
+      'auto-unavailable',
+      'classifier_unavailable',
+      abortController.signal,
+    );
+    expect(execute).not.toHaveBeenCalled();
+  });
+
   it('skips PermissionDenied hooks when hooks are disabled', async () => {
     runSideQueryMock
       .mockResolvedValueOnce({ shouldBlock: true })

--- a/packages/core/src/core/coreToolScheduler.test.ts
+++ b/packages/core/src/core/coreToolScheduler.test.ts
@@ -72,6 +72,7 @@ type ToolSpanRecord = {
 const toolSpanRecords = vi.hoisted((): ToolSpanRecord[] => []);
 const shouldThrowToolSpanSetAttribute = vi.hoisted(() => ({ value: false }));
 const shouldThrowToolSpanSetStatus = vi.hoisted(() => ({ value: false }));
+const runSideQueryMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../telemetry/tracer.js', () => ({
   safeSetStatus: (
@@ -84,6 +85,10 @@ vi.mock('../telemetry/tracer.js', () => ({
       // Match production best-effort telemetry behavior.
     }
   },
+}));
+
+vi.mock('../utils/sideQuery.js', () => ({
+  runSideQuery: (...args: unknown[]) => runSideQueryMock(...args),
 }));
 
 function createMockToolSpan(
@@ -416,11 +421,18 @@ async function waitForStatus(
 }
 
 describe('CoreToolScheduler', () => {
+  beforeEach(() => {
+    runSideQueryMock.mockReset();
+  });
+
   function createSchedulerForLegacyToolTests(options: {
     toolsByName: Map<string, MockTool>;
     approvalMode?: ApprovalMode;
     getPermissionsDeny?: () => string[] | undefined;
     messageBus?: { request: ReturnType<typeof vi.fn> };
+    hookSystem?: {
+      firePermissionDeniedEvent: ReturnType<typeof vi.fn>;
+    };
     disableHooks?: boolean;
     onAllToolCallsComplete?: ReturnType<typeof vi.fn>;
     onToolCallsUpdate?: ReturnType<typeof vi.fn>;
@@ -459,6 +471,7 @@ describe('CoreToolScheduler', () => {
           model: 'test-model',
           authType: 'gemini',
         }),
+        getModel: () => 'test-model',
         getShellExecutionConfig: () => ({
           terminalWidth: 90,
           terminalHeight: 30,
@@ -474,9 +487,21 @@ describe('CoreToolScheduler', () => {
         getGeminiClient: () => null,
         getChatRecordingService: () => undefined,
         getMessageBus: vi.fn().mockReturnValue(options.messageBus),
+        getHookSystem: vi.fn().mockReturnValue(options.hookSystem),
         getDisableAllHooks: vi
           .fn()
           .mockReturnValue(options.disableHooks ?? true),
+        getAutoModeDenialState: vi.fn().mockReturnValue({
+          consecutiveBlock: 0,
+          consecutiveUnavailable: 0,
+          totalBlock: 0,
+          totalUnavailable: 0,
+        }),
+        setAutoModeDenialState: vi.fn(),
+        getAutoModeSettings: () => ({}),
+        getWorkspaceContext: () => ({
+          isPathWithinWorkspace: () => false,
+        }),
         isInteractive: () => true,
         getInputFormat: () => undefined,
         getExperimentalZedIntegration: () => false,
@@ -590,6 +615,116 @@ describe('CoreToolScheduler', () => {
     }
     expect(execute).not.toHaveBeenCalled();
     expect(ensureTool).not.toHaveBeenCalled();
+  });
+
+  it('fires PermissionDenied hooks for AUTO classifier blocks', async () => {
+    runSideQueryMock
+      .mockResolvedValueOnce({ shouldBlock: true })
+      .mockResolvedValueOnce({
+        shouldBlock: true,
+        reason: 'dangerous shell command',
+      });
+    const execute = vi.fn().mockResolvedValue({
+      llmContent: 'should not execute',
+      returnDisplay: 'should not execute',
+    });
+    const toolsByName = new Map<string, MockTool>([
+      [
+        ToolNames.SHELL,
+        new MockTool({
+          name: ToolNames.SHELL,
+          getDefaultPermission: MOCK_TOOL_GET_DEFAULT_PERMISSION,
+          getConfirmationDetails: MOCK_TOOL_GET_CONFIRMATION_DETAILS,
+          execute,
+        }),
+      ],
+    ]);
+    const hookSystem = {
+      firePermissionDeniedEvent: vi.fn().mockResolvedValue(undefined),
+    };
+    const { scheduler, onAllToolCallsComplete } =
+      createSchedulerForLegacyToolTests({
+        toolsByName,
+        approvalMode: ApprovalMode.AUTO,
+        hookSystem,
+        disableHooks: false,
+      });
+    const abortController = new AbortController();
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'auto-denied',
+          name: ToolNames.SHELL,
+          args: { command: 'rm -rf /tmp/example' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-auto-denied',
+        },
+      ],
+      abortController.signal,
+    );
+
+    await vi.waitFor(() => {
+      expect(onAllToolCallsComplete).toHaveBeenCalled();
+    });
+    expect(hookSystem.firePermissionDeniedEvent).toHaveBeenCalledWith(
+      ToolNames.SHELL,
+      { command: 'rm -rf /tmp/example' },
+      'auto-denied',
+      'classifier_blocked',
+      abortController.signal,
+    );
+    expect(execute).not.toHaveBeenCalled();
+    const completedCalls = onAllToolCallsComplete.mock
+      .calls[0][0] as ToolCall[];
+    expect(completedCalls[0].status).toBe('error');
+  });
+
+  it('skips PermissionDenied hooks when hooks are disabled', async () => {
+    runSideQueryMock
+      .mockResolvedValueOnce({ shouldBlock: true })
+      .mockResolvedValueOnce({
+        shouldBlock: true,
+        reason: 'dangerous shell command',
+      });
+    const toolsByName = new Map<string, MockTool>([
+      [
+        ToolNames.SHELL,
+        new MockTool({
+          name: ToolNames.SHELL,
+          getDefaultPermission: MOCK_TOOL_GET_DEFAULT_PERMISSION,
+          getConfirmationDetails: MOCK_TOOL_GET_CONFIRMATION_DETAILS,
+        }),
+      ],
+    ]);
+    const hookSystem = {
+      firePermissionDeniedEvent: vi.fn().mockResolvedValue(undefined),
+    };
+    const { scheduler, onAllToolCallsComplete } =
+      createSchedulerForLegacyToolTests({
+        toolsByName,
+        approvalMode: ApprovalMode.AUTO,
+        hookSystem,
+        disableHooks: true,
+      });
+
+    await scheduler.schedule(
+      [
+        {
+          callId: 'auto-denied-hooks-off',
+          name: ToolNames.SHELL,
+          args: { command: 'rm -rf /tmp/example' },
+          isClientInitiated: false,
+          prompt_id: 'prompt-auto-denied-hooks-off',
+        },
+      ],
+      new AbortController().signal,
+    );
+
+    await vi.waitFor(() => {
+      expect(onAllToolCallsComplete).toHaveBeenCalled();
+    });
+    expect(hookSystem.firePermissionDeniedEvent).not.toHaveBeenCalled();
   });
 
   it.each(Object.entries(ToolNamesMigration))(

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -67,6 +67,8 @@ import {
 import {
   applyAutoModeDecision,
   evaluateAutoMode,
+  getAutoModePermissionDeniedReason,
+  shouldFirePermissionDeniedForAutoMode,
   shouldRunAutoModeForCall,
 } from '../permissions/autoMode.js';
 import { MAX_TRANSCRIPT_MESSAGES } from '../permissions/classifier-transcript.js';
@@ -1413,6 +1415,17 @@ export class CoreToolScheduler {
               this.config,
               denialState,
             );
+            if (shouldFirePermissionDeniedForAutoMode(decision, outcome)) {
+              await this.config
+                .getHookSystem?.()
+                ?.firePermissionDeniedEvent(
+                  canonicalName,
+                  toolParams,
+                  reqInfo.callId,
+                  getAutoModePermissionDeniedReason(decision),
+                  signal,
+                );
+            }
             switch (outcome.kind) {
               case 'approved':
                 this.setToolCallOutcome(

--- a/packages/core/src/core/coreToolScheduler.ts
+++ b/packages/core/src/core/coreToolScheduler.ts
@@ -1415,7 +1415,10 @@ export class CoreToolScheduler {
               this.config,
               denialState,
             );
-            if (shouldFirePermissionDeniedForAutoMode(decision, outcome)) {
+            if (
+              !this.config.getDisableAllHooks() &&
+              shouldFirePermissionDeniedForAutoMode(decision, outcome)
+            ) {
               await this.config
                 .getHookSystem?.()
                 ?.firePermissionDeniedEvent(

--- a/packages/core/src/hooks/hookEventHandler.test.ts
+++ b/packages/core/src/hooks/hookEventHandler.test.ts
@@ -2234,6 +2234,71 @@ describe('HookEventHandler', () => {
     });
   });
 
+  describe('firePermissionDeniedEvent', () => {
+    it('should execute hooks for PermissionDenied event', async () => {
+      const mockPlan = createMockExecutionPlan([]);
+      const mockAggregated = createMockAggregatedResult(true);
+
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(mockPlan);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        mockAggregated,
+      );
+
+      const result = await hookEventHandler.firePermissionDeniedEvent(
+        'Bash',
+        { command: 'rm -rf /tmp/project' },
+        'toolu-denied-1',
+        'classifier_blocked',
+      );
+
+      expect(mockHookPlanner.createExecutionPlan).toHaveBeenCalledWith(
+        HookEventName.PermissionDenied,
+        { toolName: 'Bash' },
+      );
+      expect(result.success).toBe(true);
+    });
+
+    it('should include the denied tool payload and reason in hook input', async () => {
+      const mockPlan = createMockExecutionPlan([
+        {
+          type: HookType.Command,
+          command: 'echo test',
+          source: HooksConfigSource.Project,
+        },
+      ]);
+      vi.mocked(mockHookPlanner.createExecutionPlan).mockReturnValue(mockPlan);
+      vi.mocked(mockHookRunner.executeHooksParallel).mockResolvedValue([]);
+      vi.mocked(mockHookAggregator.aggregateResults).mockReturnValue(
+        createMockAggregatedResult(true),
+      );
+
+      await hookEventHandler.firePermissionDeniedEvent(
+        'Write',
+        { file_path: '/test.txt', content: 'hello' },
+        'toolu-denied-2',
+        'classifier_unavailable',
+      );
+
+      const mockCalls = (mockHookRunner.executeHooksParallel as Mock).mock
+        .calls;
+      const input = mockCalls[0][2] as {
+        tool_name: string;
+        tool_input: Record<string, unknown>;
+        tool_use_id: string;
+        reason: string;
+      };
+
+      expect(input.tool_name).toBe('Write');
+      expect(input.tool_input).toEqual({
+        file_path: '/test.txt',
+        content: 'hello',
+      });
+      expect(input.tool_use_id).toBe('toolu-denied-2');
+      expect(input.reason).toBe('classifier_unavailable');
+    });
+  });
+
   describe('fireSubagentStartEvent', () => {
     it('should execute hooks for SubagentStart event', async () => {
       const mockPlan = createMockExecutionPlan([]);

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -368,8 +368,10 @@ export class HookEventHandler {
   }
 
   /**
-   * Fire a PermissionDenied event
-   * Called when a tool call is denied before a permission dialog is displayed
+   * Fire a PermissionDenied event for tool calls rejected before manual
+   * permission handling starts. Unlike PermissionRequest, this event does not
+   * ask hooks to approve or modify the call; it reports AUTO-mode denials that
+   * happen before any permission dialog would be shown.
    */
   async firePermissionDeniedEvent(
     toolName: string,

--- a/packages/core/src/hooks/hookEventHandler.ts
+++ b/packages/core/src/hooks/hookEventHandler.ts
@@ -31,6 +31,8 @@ import type {
   PostCompactTrigger,
   NotificationInput,
   NotificationType,
+  PermissionDeniedInput,
+  PermissionDeniedReason,
   PermissionRequestInput,
   PermissionSuggestion,
   SubagentStartInput,
@@ -357,6 +359,35 @@ export class HookEventHandler {
     // Pass tool name as context for matcher filtering
     return this.executeHooks(
       HookEventName.PermissionRequest,
+      input,
+      {
+        toolName,
+      },
+      signal,
+    );
+  }
+
+  /**
+   * Fire a PermissionDenied event
+   * Called when a tool call is denied before a permission dialog is displayed
+   */
+  async firePermissionDeniedEvent(
+    toolName: string,
+    toolInput: Record<string, unknown>,
+    toolUseId: string,
+    reason: PermissionDeniedReason,
+    signal?: AbortSignal,
+  ): Promise<AggregatedHookResult> {
+    const input: PermissionDeniedInput = {
+      ...this.createBaseInput(HookEventName.PermissionDenied),
+      tool_name: toolName,
+      tool_input: toolInput,
+      tool_use_id: toolUseId,
+      reason,
+    };
+
+    return this.executeHooks(
+      HookEventName.PermissionDenied,
       input,
       {
         toolName,

--- a/packages/core/src/hooks/hookPlanner.test.ts
+++ b/packages/core/src/hooks/hookPlanner.test.ts
@@ -36,6 +36,8 @@ describe('HookPlanner', () => {
           toolName: 'Bash',
         }),
       ).toEqual({ kind: 'toolName', target: 'Bash' });
+      // PermissionDenied is permission-related, so it uses the same tool-name
+      // matcher as PermissionRequest rather than a classifier-reason matcher.
     });
 
     it('returns agent type targets for subagent events', () => {

--- a/packages/core/src/hooks/hookPlanner.test.ts
+++ b/packages/core/src/hooks/hookPlanner.test.ts
@@ -31,6 +31,11 @@ describe('HookPlanner', () => {
         kind: 'toolName',
         target: '',
       });
+      expect(
+        getHookMatcherTarget(HookEventName.PermissionDenied, {
+          toolName: 'Bash',
+        }),
+      ).toEqual({ kind: 'toolName', target: 'Bash' });
     });
 
     it('returns agent type targets for subagent events', () => {

--- a/packages/core/src/hooks/hookPlanner.ts
+++ b/packages/core/src/hooks/hookPlanner.ts
@@ -33,6 +33,7 @@ export function getHookMatcherTarget(
     case HookEventName.PostToolUse:
     case HookEventName.PostToolUseFailure:
     case HookEventName.PermissionRequest:
+    case HookEventName.PermissionDenied:
       return { kind: 'toolName', target: context?.toolName ?? '' };
 
     case HookEventName.SubagentStart:

--- a/packages/core/src/hooks/hookSystem.test.ts
+++ b/packages/core/src/hooks/hookSystem.test.ts
@@ -25,6 +25,7 @@ import {
   NotificationType,
   type PermissionSuggestion,
   HookPhase,
+  createHookOutput,
 } from './types.js';
 import type { Config } from '../config/config.js';
 import type { AggregatedHookResult } from './hookAggregator.js';
@@ -1450,6 +1451,32 @@ describe('HookSystem', () => {
         undefined,
       );
       expect(result).toBeUndefined();
+    });
+
+    it('should return PermissionDenied hook output when present', async () => {
+      const mockAggregated = createMockAggregatedResult(true);
+      mockAggregated.finalOutput = {
+        hookSpecificOutput: {
+          hookEventName: 'PermissionDenied',
+          permissionDecision: 'deny',
+          permissionDecisionReason: 'policy denied',
+        },
+      };
+
+      vi.mocked(
+        mockHookEventHandler.firePermissionDeniedEvent,
+      ).mockResolvedValue(mockAggregated);
+
+      const result = await hookSystem.firePermissionDeniedEvent(
+        'Bash',
+        { command: 'rm -rf /tmp/project' },
+        'toolu-denied-1',
+        'classifier_blocked',
+      );
+
+      expect(result).toEqual(
+        createHookOutput('PermissionDenied', mockAggregated.finalOutput),
+      );
     });
   });
 

--- a/packages/core/src/hooks/hookSystem.test.ts
+++ b/packages/core/src/hooks/hookSystem.test.ts
@@ -95,6 +95,7 @@ describe('HookSystem', () => {
       firePreCompactEvent: vi.fn(),
       fireNotificationEvent: vi.fn(),
       firePermissionRequestEvent: vi.fn(),
+      firePermissionDeniedEvent: vi.fn(),
       fireSubagentStartEvent: vi.fn(),
       fireSubagentStopEvent: vi.fn(),
       fireTodoCreatedEvent: vi.fn(),
@@ -1420,6 +1421,34 @@ describe('HookSystem', () => {
         PermissionMode.Default,
       );
 
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('firePermissionDeniedEvent', () => {
+    it('should delegate to hookEventHandler.firePermissionDeniedEvent', async () => {
+      const mockAggregated = createMockAggregatedResult(true);
+
+      vi.mocked(
+        mockHookEventHandler.firePermissionDeniedEvent,
+      ).mockResolvedValue(mockAggregated);
+
+      const result = await hookSystem.firePermissionDeniedEvent(
+        'Bash',
+        { command: 'rm -rf /tmp/project' },
+        'toolu-denied-1',
+        'classifier_blocked',
+      );
+
+      expect(
+        mockHookEventHandler.firePermissionDeniedEvent,
+      ).toHaveBeenCalledWith(
+        'Bash',
+        { command: 'rm -rf /tmp/project' },
+        'toolu-denied-1',
+        'classifier_blocked',
+        undefined,
+      );
       expect(result).toBeUndefined();
     });
   });

--- a/packages/core/src/hooks/hookSystem.ts
+++ b/packages/core/src/hooks/hookSystem.ts
@@ -22,6 +22,7 @@ import type {
   PreCompactTrigger,
   PostCompactTrigger,
   NotificationType,
+  PermissionDeniedReason,
   PermissionSuggestion,
   HookEventName,
   FunctionHookCallback,
@@ -406,6 +407,28 @@ export class HookSystem {
     );
     return result.finalOutput
       ? createHookOutput('PermissionRequest', result.finalOutput)
+      : undefined;
+  }
+
+  /**
+   * Fire a PermissionDenied event
+   */
+  async firePermissionDeniedEvent(
+    toolName: string,
+    toolInput: Record<string, unknown>,
+    toolUseId: string,
+    reason: PermissionDeniedReason,
+    signal?: AbortSignal,
+  ): Promise<DefaultHookOutput | undefined> {
+    const result = await this.hookEventHandler.firePermissionDeniedEvent(
+      toolName,
+      toolInput,
+      toolUseId,
+      reason,
+      signal,
+    );
+    return result.finalOutput
+      ? createHookOutput('PermissionDenied', result.finalOutput)
       : undefined;
   }
 

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -46,6 +46,8 @@ export enum HookEventName {
   SessionEnd = 'SessionEnd',
   // When a permission dialog is displayed
   PermissionRequest = 'PermissionRequest',
+  // When a tool call is denied before a permission dialog is displayed
+  PermissionDenied = 'PermissionDenied',
   // StopFailure - When the turn ends due to an API error (instead of Stop)
   StopFailure = 'StopFailure',
   // TodoCreated - When a new todo item is added to the list (Qwen Code specific)
@@ -521,6 +523,20 @@ export interface PermissionRequestInput extends HookInput {
   tool_name: string;
   tool_input: Record<string, unknown>;
   permission_suggestions?: PermissionSuggestion[];
+}
+
+export type PermissionDeniedReason =
+  | 'classifier_blocked'
+  | 'classifier_unavailable';
+
+/**
+ * Input for PermissionDenied hook events
+ */
+export interface PermissionDeniedInput extends HookInput {
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+  tool_use_id: string;
+  reason: PermissionDeniedReason;
 }
 
 /**

--- a/packages/core/src/hooks/types.ts
+++ b/packages/core/src/hooks/types.ts
@@ -526,7 +526,9 @@ export interface PermissionRequestInput extends HookInput {
 }
 
 export type PermissionDeniedReason =
+  /** AUTO classifier evaluated the request and actively blocked it. */
   | 'classifier_blocked'
+  /** AUTO classifier could not return a verdict, so AUTO mode denied it. */
   | 'classifier_unavailable';
 
 /**

--- a/packages/core/src/permissions/autoMode.test.ts
+++ b/packages/core/src/permissions/autoMode.test.ts
@@ -9,7 +9,9 @@ import {
   SAFE_TOOL_ALLOWLIST,
   evaluateAutoMode,
   formatClassifierBlockMessage,
+  getAutoModePermissionDeniedReason,
   isInSafeToolAllowlist,
+  shouldFirePermissionDeniedForAutoMode,
   passesAcceptEditsFastPath,
   shouldRunAutoModeForCall,
 } from './autoMode.js';
@@ -350,6 +352,55 @@ describe('formatClassifierBlockMessage', () => {
         unavailable: true,
       }),
     ).toBe('Auto mode classifier unavailable; action blocked for safety');
+  });
+});
+
+// ─── PermissionDenied hook gating ────────────────────────────────────────
+
+describe('PermissionDenied hook gating', () => {
+  const classifierBlock = {
+    via: 'classifier' as const,
+    shouldBlock: true,
+    reason: 'Dangerous shell command',
+    unavailable: false,
+    stage: 'fast' as const,
+    durationMs: 20,
+  };
+
+  it('fires only for classifier blocks that produce a blocked outcome', () => {
+    expect(
+      shouldFirePermissionDeniedForAutoMode(classifierBlock, {
+        kind: 'blocked',
+        errorMessage: 'blocked',
+      }),
+    ).toBe(true);
+
+    expect(
+      shouldFirePermissionDeniedForAutoMode(
+        { ...classifierBlock, shouldBlock: false },
+        { kind: 'approved' },
+      ),
+    ).toBe(false);
+
+    expect(
+      shouldFirePermissionDeniedForAutoMode(
+        { via: 'fallback' },
+        { kind: 'fallback' },
+      ),
+    ).toBe(false);
+  });
+
+  it('maps classifier blocks to stable PermissionDenied reasons', () => {
+    expect(getAutoModePermissionDeniedReason(classifierBlock)).toBe(
+      'classifier_blocked',
+    );
+
+    expect(
+      getAutoModePermissionDeniedReason({
+        ...classifierBlock,
+        unavailable: true,
+      }),
+    ).toBe('classifier_unavailable');
   });
 });
 

--- a/packages/core/src/permissions/autoMode.ts
+++ b/packages/core/src/permissions/autoMode.ts
@@ -19,6 +19,7 @@
 
 import type { Content } from '@google/genai';
 import { ApprovalMode, type Config } from '../config/config.js';
+import type { PermissionDeniedReason } from '../hooks/types.js';
 import { ToolNames } from '../tools/tool-names.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { classifyAction, type ClassifierResult } from './classifier.js';
@@ -235,6 +236,23 @@ export function applyAutoModeDecision(
       return { kind: 'fallback' };
     }
   }
+}
+
+export function shouldFirePermissionDeniedForAutoMode(
+  decision: AutoModeDecision,
+  outcome: AutoModeOutcome,
+): decision is Extract<AutoModeDecision, { via: 'classifier' }> {
+  return (
+    decision.via === 'classifier' &&
+    decision.shouldBlock &&
+    outcome.kind === 'blocked'
+  );
+}
+
+export function getAutoModePermissionDeniedReason(
+  decision: Extract<AutoModeDecision, { via: 'classifier' }>,
+): PermissionDeniedReason {
+  return decision.unavailable ? 'classifier_unavailable' : 'classifier_blocked';
 }
 
 /**

--- a/packages/core/src/permissions/autoMode.ts
+++ b/packages/core/src/permissions/autoMode.ts
@@ -242,6 +242,8 @@ export function shouldFirePermissionDeniedForAutoMode(
   decision: AutoModeDecision,
   outcome: AutoModeOutcome,
 ): decision is Extract<AutoModeDecision, { via: 'classifier' }> {
+  // The type predicate narrows callers to classifier decisions so reason
+  // mapping can safely read classifier-only fields such as `unavailable`.
   return (
     decision.via === 'classifier' &&
     decision.shouldBlock &&

--- a/packages/core/src/permissions/index.ts
+++ b/packages/core/src/permissions/index.ts
@@ -14,12 +14,14 @@ export {
   applyAutoModeDecision,
   evaluateAutoMode,
   formatClassifierBlockMessage,
+  getAutoModePermissionDeniedReason,
   type AutoModeDecision,
   type AutoModeOutcome,
   type EvaluateAutoModeInput,
   SAFE_TOOL_ALLOWLIST,
   isInSafeToolAllowlist,
   passesAcceptEditsFastPath,
+  shouldFirePermissionDeniedForAutoMode,
   shouldRunAutoModeForCall,
 } from './autoMode.js';
 export {


### PR DESCRIPTION
## Summary
- add a PermissionDenied hook event with tool name, input, use id, and stable denial reason payload
- emit PermissionDenied from both the core scheduler and ACP session when AUTO classifier blocks before manual permission flow
- share AUTO hook gating and reason mapping helpers with focused tests

## Tests
- npx vitest run src/hooks/hookPlanner.test.ts src/hooks/hookSystem.test.ts src/hooks/hookEventHandler.test.ts src/permissions/autoMode.test.ts
- npm run typecheck

Closes #4372