### PR TITLE
fix(ci): resolve TS5055 release build failure since May 19

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -38,10 +38,11 @@ execSync('npm run generate', { stdio: 'inherit', cwd: root });
 // 2. web-templates (embeddable web templates - used by cli)
 // 3. channel-base (base channel infrastructure - used by channel adapters and cli)
 // 4. channel adapters (depend on channel-base)
-// 5. cli (depends on core, web-templates, channel packages)
-// 6. webui (shared UI components - used by vscode companion)
-// 7. sdk (no internal dependencies)
-// 8. vscode-ide-companion (depends on webui)
+// 5. acp-bridge (depends on core - used by cli)
+// 6. cli (depends on core, acp-bridge, web-templates, channel packages)
+// 7. webui (shared UI components - used by vscode companion)
+// 8. sdk (no internal dependencies)
+// 9. vscode-ide-companion (depends on webui)
 const buildOrder = [
   'packages/core',
   'packages/web-templates',
@@ -50,6 +51,7 @@ const buildOrder = [
   'packages/channels/weixin',
   'packages/channels/dingtalk',
   'packages/channels/plugin-example',
+  'packages/acp-bridge',
   'packages/cli',
   'packages/webui',
   'packages/sdk-typescript',

--- a/scripts/version.js
+++ b/scripts/version.js
@@ -105,8 +105,11 @@ if (cliPackageJson.config?.sandboxImageUri) {
 }
 
 // 7. Run `npm install` to update package-lock.json.
+// --ignore-scripts prevents the root `prepare` lifecycle from triggering a
+// redundant full build that fails with TS5055 when dist/ already exists from
+// the initial `npm ci` install.
 run(
-  'npm install --workspace packages/cli --workspace packages/core --workspace packages/channels/base --workspace packages/channels/plugin-example --package-lock-only',
+  'npm install --workspace packages/cli --workspace packages/core --workspace packages/channels/base --workspace packages/channels/plugin-example --package-lock-only --ignore-scripts',
 );
 
 console.log(`Successfully bumped versions to v${newVersion}.`);


### PR DESCRIPTION
## Summary

The nightly/preview release workflow has been failing for 3 consecutive days (May 19–21) with `TS5055: Cannot write file ... because it would overwrite input file` during the `Publish Release` job's version bump step.

- Failing runs: https://github.com/QwenLM/qwen-code/actions/runs/26197699542, #4368, #4339, #4307

## Root Cause

PR #4295 (`refactor(acp-bridge): create skeleton`) introduced `packages/acp-bridge` as a new workspace with a TypeScript project reference to `packages/core`, and added a reference from `packages/cli/tsconfig.json` to `packages/acp-bridge`. However, it did **not** add `packages/acp-bridge` to the build order in `scripts/build.js`.

In the release workflow:
1. `npm ci` triggers the `prepare` lifecycle → full build succeeds, creating `packages/core/dist/` with `.d.ts` output.
2. `scripts/version.js` bumps all workspace versions, then runs `npm install --package-lock-only` which **re-triggers `prepare`** (npm lifecycle behavior).
3. The second `tsc --build` for `packages/core` fails because it attempts to rebuild while `dist/` already exists. The unbuilt `acp-bridge` reference corrupts TypeScript's incremental project graph resolution, causing TS5055.

## Fix

1. **`scripts/version.js`**: Add `--ignore-scripts` to the `npm install --package-lock-only` command — this lock-file update does not need a full rebuild.
2. **`scripts/build.js`**: Add `packages/acp-bridge` to the build order before `packages/cli` (its dependent).

## Test plan

- [x] Verified `node scripts/version.js 0.15.12-test.1` completes successfully with `--ignore-scripts`
- [x] Syntax check passes for both modified files
- [x] Confirmed `packages/acp-bridge` has the expected `build` script
- [ ] Next nightly release run should pass after merge

Closes #4368
Closes #4339
Closes #4307