### PR TITLE
revert(core): undo x-api-key + Authorization double-emit (#4342) — regresses IdeaLab-style proxies

### DIFF
--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -104,14 +104,12 @@ describe('AnthropicContentGenerator', () => {
     vi.restoreAllMocks();
   });
 
-  it('uses claude-cli identity (User-Agent + x-app + Bearer auth + x-api-key) for non-Anthropic baseURLs', async () => {
+  it('uses claude-cli identity (User-Agent + x-app + Bearer auth) for non-Anthropic baseURLs', async () => {
     // Non-Anthropic-native baseURL → IdeaLab-style proxy path:
     //  - User-Agent presents as `claude-cli/<version> (external, cli)`
     //  - `x-app: cli` is sent
     //  - SDK is constructed with `authToken` (sends `Authorization: Bearer`)
-    //  - `x-api-key` is *also* added via defaultHeaders so standards-compliant
-    //    Anthropic-compatible servers (OpenCode-Go, Claude proxies — #4323)
-    //    that only read the canonical `x-api-key` header authenticate too.
+    //    rather than `apiKey` (`x-api-key`), avoiding dual-header conflicts.
     const { AnthropicContentGenerator } = await importGenerator();
     void new AnthropicContentGenerator(
       {
@@ -131,89 +129,8 @@ describe('AnthropicContentGenerator', () => {
     expect(headers['User-Agent']).toContain('claude-cli/1.2.3');
     expect(headers['User-Agent']).toContain('(external, cli)');
     expect(headers['x-app']).toBe('cli');
-    expect(headers['x-api-key']).toBe('test-key');
     expect(anthropicState.constructorOptions?.['authToken']).toBe('test-key');
     expect(anthropicState.constructorOptions?.['apiKey']).toBeNull();
-  });
-
-  it('does NOT add x-api-key for Anthropic-native baseURLs (SDK apiKey path already supplies it)', async () => {
-    // On the native branch the SDK is constructed with `apiKey` and emits
-    // `x-api-key` itself. Adding the same header via defaultHeaders would
-    // duplicate it on the wire (and a stale defaultHeaders entry could
-    // override a future SDK rotation). Keep the native path SDK-driven.
-    const { AnthropicContentGenerator } = await importGenerator();
-    void new AnthropicContentGenerator(
-      {
-        model: 'claude-opus-4-7',
-        apiKey: 'test-key',
-        baseUrl: 'https://api.anthropic.com',
-        timeout: 10_000,
-        maxRetries: 2,
-        samplingParams: {},
-        schemaCompliance: 'auto',
-      },
-      mockConfig,
-    );
-
-    const headers = (anthropicState.constructorOptions?.['defaultHeaders'] ||
-      {}) as Record<string, string>;
-    expect(headers['x-api-key']).toBeUndefined();
-  });
-
-  it('does NOT add x-api-key when apiKey is falsy on the proxy branch', async () => {
-    // Guard branch on the `useProxyIdentity && apiKey` predicate: an
-    // empty / undefined apiKey would otherwise ship `x-api-key:` (empty)
-    // — a meaningless header that could confuse server-side debugging
-    // or trip strict input validation. Pin the guard so a future
-    // refactor that drops the truthy check fails this test, not prod.
-    const { AnthropicContentGenerator } = await importGenerator();
-    void new AnthropicContentGenerator(
-      {
-        model: 'claude-test',
-        apiKey: '',
-        baseUrl: 'https://example.invalid',
-        timeout: 10_000,
-        maxRetries: 2,
-        samplingParams: {},
-        schemaCompliance: 'auto',
-      },
-      mockConfig,
-    );
-
-    const headers = (anthropicState.constructorOptions?.['defaultHeaders'] ||
-      {}) as Record<string, string>;
-    expect(headers['x-api-key']).toBeUndefined();
-  });
-
-  it('customHeaders cannot override x-api-key on the proxy branch (post-buildHeaders ordering invariant)', async () => {
-    // The injection lives AFTER `buildHeaders` (which merges customHeaders
-    // into defaultHeaders), so a user-supplied
-    // `customHeaders: { 'x-api-key': … }` is overwritten by the canonical
-    // value. This is a security-relevant invariant: a refactor that
-    // accidentally moved the injection above the customHeaders merge
-    // would let user config swap the auth header for an arbitrary value
-    // — defeating the dual-auth contract. Pin the ordering here so any
-    // such regression flips this test before review.
-    const { AnthropicContentGenerator } = await importGenerator();
-    void new AnthropicContentGenerator(
-      {
-        model: 'claude-test',
-        apiKey: 'canonical-key',
-        baseUrl: 'https://example.invalid',
-        timeout: 10_000,
-        maxRetries: 2,
-        samplingParams: {},
-        schemaCompliance: 'auto',
-        customHeaders: {
-          'x-api-key': 'user-override',
-        },
-      },
-      mockConfig,
-    );
-
-    const headers = (anthropicState.constructorOptions?.['defaultHeaders'] ||
-      {}) as Record<string, string>;
-    expect(headers['x-api-key']).toBe('canonical-key');
   });
 
   it('uses QwenCode identity + apiKey auth when baseURL is api.anthropic.com', async () => {
@@ -313,7 +230,6 @@ describe('AnthropicContentGenerator', () => {
       {}) as Record<string, string>;
     expect(headers['User-Agent']).toContain('claude-cli/1.2.3');
     expect(headers['x-app']).toBe('cli');
-    expect(headers['x-api-key']).toBe('test-key');
     expect(anthropicState.constructorOptions?.['authToken']).toBe('test-key');
     expect(anthropicState.constructorOptions?.['apiKey']).toBeNull();
   });
@@ -344,7 +260,6 @@ describe('AnthropicContentGenerator', () => {
       {}) as Record<string, string>;
     expect(headers['User-Agent']).toContain('claude-cli/1.2.3');
     expect(headers['x-app']).toBe('cli');
-    expect(headers['x-api-key']).toBe('test-key');
     expect(anthropicState.constructorOptions?.['authToken']).toBe('test-key');
     expect(anthropicState.constructorOptions?.['apiKey']).toBeNull();
   });
@@ -400,7 +315,6 @@ describe('AnthropicContentGenerator', () => {
       {}) as Record<string, string>;
     expect(headers['User-Agent']).toContain('claude-cli/1.2.3');
     expect(headers['x-app']).toBe('cli');
-    expect(headers['x-api-key']).toBe('test-key');
     expect(anthropicState.constructorOptions?.['authToken']).toBe('test-key');
     expect(anthropicState.constructorOptions?.['apiKey']).toBeNull();
   });
@@ -512,7 +426,6 @@ describe('AnthropicContentGenerator', () => {
         {}) as Record<string, string>;
       expect(headers['User-Agent']).toContain('claude-cli/1.2.3');
       expect(headers['x-app']).toBe('cli');
-      expect(headers['x-api-key']).toBe('idealab-token');
       expect(anthropicState.constructorOptions?.['authToken']).toBe(
         'idealab-token',
       );

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -176,22 +176,6 @@ export class AnthropicContentGenerator implements ContentGenerator {
     // half of the bundle without the other.
     const useProxyIdentity = !isAnthropicNativeBaseUrl(contentGeneratorConfig);
     const defaultHeaders = this.buildHeaders(useProxyIdentity);
-    // On the proxy branch the SDK is constructed with `authToken` so it
-    // emits `Authorization: Bearer <key>` natively, but some
-    // Anthropic-compatible servers (OpenCode-Go, Claude proxy products —
-    // see #4323) authenticate only on the canonical `x-api-key` header.
-    // Ship both shapes side-by-side so either family accepts us. We add
-    // `x-api-key` here (post-buildHeaders) so customHeaders can't override
-    // it and the SDK-level env back-fill suppression (apiKey: null on the
-    // SDK side, suppressing the SDK's own ANTHROPIC_API_KEY destructuring
-    // default) is preserved. `contentGeneratorConfig.apiKey` itself may
-    // have been env-resolved upstream by `resolveCredentialField`, but
-    // that's the same value already shipped as `Authorization: Bearer`
-    // via `authToken` on this very request — adding it as `x-api-key`
-    // doesn't widen the #4020 leak surface.
-    if (useProxyIdentity && contentGeneratorConfig.apiKey) {
-      defaultHeaders['x-api-key'] = contentGeneratorConfig.apiKey;
-    }
     const baseURL = contentGeneratorConfig.baseUrl;
     // Configure fetch options for proxy support and timeout handling.
     // With proxy, dispatcher timeouts are disabled so SDK timeout controls the


### PR DESCRIPTION
## Summary

Reverts #4342. That PR unconditionally injected `x-api-key` alongside the existing `Authorization: Bearer` header on every proxy-branch Anthropic request to satisfy #4323-style servers (OpenCode-Go, Claude proxy products) that authenticate only on `x-api-key`. The side effect: IdeaLab-style Anthropic-compatible proxies (e.g. `https://idealab.alibaba-inc.com/api/anthropic`) **explicitly reject** requests carrying both auth headers and return HTTP 401:

> 鉴权header, x-api-key和Authorization不可以同时存在
> (auth header: x-api-key and Authorization cannot coexist)

After #4342 landed, every IdeaLab user is hard-blocked from sending a single message. The two proxy families have **mutually exclusive header contracts** — there is no default that satisfies both at once — so the right place for the choice is user configuration, not a hard-coded default.

## Why customHeaders is the right escape hatch (and PR #4342 wasn't needed)

`buildHeaders` already merges `customHeaders` into the SDK's `defaultHeaders` (it only reserves `anthropic-beta` for per-request handling — every other key passes through verbatim). On the proxy branch the SDK is constructed with `apiKey: null` so it does **not** emit its own `x-api-key`. That means a user whose backend wants `x-api-key` can already do this in their settings without any core change:

```json
{
  "customHeaders": {
    "x-api-key": "<their-key>"
  }
}
```

The wire value comes solely from the user's explicit entry — env back-fill stays suppressed, so the #4020 leak guard is preserved.

## What changes / who is affected

| User group | Pre-#4342 | After #4342 (status quo) | After this revert |
|---|---|---|---|
| IdeaLab proxy | works (Bearer only) | **broken (401)** | works (Bearer only) |
| OpenCode-Go / Claude-proxy-products | broken (#4323) | works | works **via customHeaders** (one-line config) |
| Direct `api.anthropic.com` | unaffected (SDK-native `x-api-key`) | unaffected | unaffected |

Net effect: IdeaLab users are unblocked today; OpenCode-Go users need a one-line settings change instead of an automatic default. That's a fair trade — the non-mainstream-proxy users opt in, the broader user base isn't broken by it.

## Reopens

- Reopens #4323 — a follow-up comment there explains the customHeaders workaround.
- This PR does not introduce a new `authStyle` config option; if future user demand justifies a first-class switch, it can be added later without touching this revert.

## Test plan

- [x] `vitest run src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts` — 65 tests pass (back to the pre-#4342 count; the 89 lines of tests #4342 added are reverted together with the code change).
- [x] `git revert` was a clean auto-merge against current main — no unrelated downstream change touched the constructor or test file between #4342 and HEAD.
- [x] Reproduction confirmed by a user report against an IdeaLab proxy: with #4342 in main, `/model` works (auth doesn't gate model listing) but the first `messages.create` returns HTTP 401 with the message quoted above. Reverting the constructor injection removes the offending header and restores the pre-#4342 Bearer-only path that worked before.