### PR TITLE
feat(telemetry): propagate X-Qwen-Code-Session-Id on outbound LLM requests (part 2 of #4384)

### DIFF
--- a/docs/developers/development/telemetry.md
+++ b/docs/developers/development/telemetry.md
@@ -291,6 +291,43 @@ URLs matching the configured `telemetry.otlpEndpoint` /
 `telemetry.otlpMetricsEndpoint` prefixes. In file-outfile mode there are no
 outbound HTTP uploads, so the hook is a no-op.
 
+### Session correlation header
+
+Alongside `traceparent`, Qwen Code injects a custom HTTP header on every
+outbound LLM request when telemetry is enabled:
+
+```
+X-Qwen-Code-Session-Id: <session id>
+```
+
+Pattern matched from Claude Code's `X-Claude-Code-Session-Id` (see
+`src/services/api/client.ts:108` in the claude-code repo). The header is
+product-namespaced to avoid collision with generic `X-Session-Id` headers
+other tools may inject. Server-side ingestion (e.g. a custom DashScope
+proxy or an OTLP-aware API gateway) can use this header to stitch its
+observation of an LLM request back to the originating Qwen Code session
+without having to parse trace context.
+
+The header value comes from `Config.getSessionId()`, read fresh on every
+outbound request (not captured at SDK construction time). After a session
+reset triggered by `/clear`, subsequent LLM requests carry the new session
+id automatically — see the "Known limitation" note below for the one
+exception.
+
+Empty session ids are not emitted (some HTTP middleware rejects empty
+header values). The header is omitted entirely when telemetry is disabled.
+
+**Known limitation: Gemini provider.** `@google/genai`'s `HttpOptions`
+interface does not expose a `fetch` hook (only static `headers`), so the
+Gemini provider can only inject the session-id header at SDK construction
+time. After a `/clear`-triggered session reset, outbound Gemini requests
+carry the OLD session id in `X-Qwen-Code-Session-Id` until the underlying
+content generator is recreated (the current code does not recreate it on
+reset). All other providers (`openai`-family, `anthropic`) use a fetch
+wrapper and are immune to this. Tracked as a follow-up; in the meantime,
+spans and logs still carry the live session id, so trace/log backends can
+correctly attribute requests to the new session.
+
 ## Aliyun Telemetry
 
 ### Manual OTLP Export

--- a/package-lock.json
+++ b/package-lock.json
@@ -237,7 +237,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -713,7 +712,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -737,7 +735,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2271,7 +2268,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3724,7 +3720,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -4183,6 +4178,13 @@
         "kleur": "^3.0.3"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
@@ -4203,7 +4205,6 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4214,7 +4215,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4444,7 +4444,6 @@
       "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.0",
         "@typescript-eslint/types": "8.35.0",
@@ -4690,7 +4689,6 @@
       "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@testing-library/dom": "^10.4.0",
         "@testing-library/user-event": "^14.6.1",
@@ -4841,7 +4839,6 @@
       "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "pathe": "^2.0.3",
@@ -5015,7 +5012,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5430,7 +5426,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
@@ -5985,7 +5982,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.25",
         "caniuse-lite": "^1.0.30001754",
@@ -6657,6 +6653,7 @@
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
       "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "5.2.1"
       },
@@ -7752,7 +7749,6 @@
       "integrity": "sha512-GsGizj2Y1rCWDu6XoEekL3RLilp0voSePurjZIkxL3wlm5o5EC9VpgaP7lrCvjnkuLvzFBQWB3vWB3K5KQTveQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8457,6 +8453,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -8518,6 +8515,7 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -8527,6 +8525,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -8536,6 +8535,7 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -8750,6 +8750,7 @@
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
       "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "2.6.9",
         "encodeurl": "~2.0.0",
@@ -8768,6 +8769,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -8776,13 +8778,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/finalhandler/node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
       "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8"
       }
@@ -9857,7 +9861,6 @@
       "resolved": "https://registry.npmjs.org/ink/-/ink-7.0.3.tgz",
       "integrity": "sha512-5kxHkIj9+RuqCU3zyvP4qvYWNOSHP2TW/SHayHGHOmk87KwfVcZwvJGemi9ch+ci2gXUqerK/Eh2DGEDt5q45g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",
         "ansi-escapes": "^7.3.0",
@@ -10930,7 +10933,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -12971,7 +12973,8 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/path-type": {
       "version": "3.0.0",
@@ -13134,6 +13137,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -13168,7 +13172,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -13328,7 +13331,6 @@
       "integrity": "sha512-5xGWRa90Sp2+x1dQtNpIpeOQpTDBs9cZDmA/qs2vDNN2i18PdapqY7CmBeyLlMuGqXJRIOPaCaVZTLNQRWUH/A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13644,7 +13646,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13655,7 +13656,6 @@
       "integrity": "sha512-ePrwPfxAnB+7hgnEr8vpKxL9cmnp7F322t8oqcPshbIQQhDKgFDW4tjhF2wjVbdXF9O/nyuy3sQWd9JGpiLPvA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "shell-quote": "^1.6.1",
         "ws": "^7"
@@ -13733,7 +13733,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -14914,7 +14913,6 @@
       "integrity": "sha512-fIQnFtpksRRgHR1CO1onGX3djaog4qsW/c5U8arqYTkUEr2TaWpn05mIJDOBoPJFlOdqFrB4Ttv0PZJxV7avhw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.1",
@@ -15689,7 +15687,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -15889,8 +15886,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsx": {
       "version": "4.20.3",
@@ -15898,7 +15894,6 @@
       "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -16057,7 +16052,6 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16381,6 +16375,7 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -16423,7 +16418,6 @@
       "integrity": "sha512-ixXJB1YRgDIw2OszKQS9WxGHKwLdCsbQNkpJN171udl6szi/rIySHL6/Os3s2+oE4P/FLD4dxg4mD7Wust+u5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.6",
@@ -16537,7 +16531,6 @@
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -16551,7 +16544,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -17070,7 +17062,6 @@
       "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -17241,7 +17232,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -17432,7 +17422,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.1.tgz",
       "integrity": "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.7",
         "ajv": "^8.17.1",
@@ -18153,7 +18142,6 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.25.1.tgz",
       "integrity": "sha512-yO28oVFFC7EBoiKdAn+VqRm+plcfv4v0xp6osG/VsCB0NlPZWi87ajbCZZ8f/RvOFLEu7//rSRmuZZ7lMoe3gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.7",
         "ajv": "^8.17.1",
@@ -18548,7 +18536,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19277,7 +19264,6 @@
       "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -19322,7 +19308,6 @@
       "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "7.18.0",
         "@typescript-eslint/types": "7.18.0",
@@ -19803,7 +19788,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -20930,7 +20914,6 @@
       "integrity": "sha512-Ljb1cnSJSivGN0LqXd/zmDbWEM0RNNg2t1QW/XUhYl/qPqyu7CsqeWtqQXHVaJsecLPuDoak2oJcZN2QoRIOag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "1.6.1",
         "@vitest/runner": "1.6.1",
@@ -22173,6 +22156,27 @@
         "node": ">=12"
       }
     },
+    "packages/web-templates/node_modules/@types/react": {
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "packages/web-templates/node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
     "packages/web-templates/node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
@@ -23131,7 +23135,6 @@
       "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -23146,7 +23149,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -33,6 +33,7 @@ import {
   buildRuntimeFetchOptions,
   redactProxyError,
 } from '../../utils/runtimeFetchOptions.js';
+import { wrapFetchWithCorrelation } from '../../telemetry/llm-correlation-fetch.js';
 import { DEFAULT_TIMEOUT } from '../openaiContentGenerator/constants.js';
 import { createDebugLogger } from '../../utils/debugLogger.js';
 import { runtimeDiagnostics } from '../../utils/runtimeDiagnostics.js';
@@ -203,6 +204,13 @@ export class AnthropicContentGenerator implements ContentGenerator {
     // key as `X-Api-Key` to the IdeaLab proxy — leaking the credential to
     // a third-party endpoint. Explicit `null` suppresses the back-fill
     // and forces the intended auth path.
+    // Wrap fetch with per-request correlation header injection. Read the
+    // base fetch from runtimeOptions (proxy-aware) when present, else
+    // globalThis. See design doc §4.3 — fetch wrapper (not defaultHeaders)
+    // is required so the header tracks live session id across /clear resets.
+    const baseFetch =
+      (runtimeOptions as { fetch?: typeof fetch } | undefined)?.fetch ??
+      globalThis.fetch;
     this.client = new Anthropic({
       ...(useProxyIdentity
         ? { authToken: contentGeneratorConfig.apiKey, apiKey: null }
@@ -212,6 +220,7 @@ export class AnthropicContentGenerator implements ContentGenerator {
       maxRetries: contentGeneratorConfig.maxRetries,
       defaultHeaders,
       ...runtimeOptions,
+      fetch: wrapFetchWithCorrelation(baseFetch, this.cliConfig),
     });
 
     this.converter = new AnthropicContentConverter(

--- a/packages/core/src/core/geminiContentGenerator/index.test.ts
+++ b/packages/core/src/core/geminiContentGenerator/index.test.ts
@@ -23,6 +23,8 @@ describe('createGeminiContentGenerator', () => {
       getUsageStatisticsEnabled: vi.fn().mockReturnValue(false),
       getContentGeneratorConfig: vi.fn().mockReturnValue({}),
       getCliVersion: vi.fn().mockReturnValue('1.0.0'),
+      getTelemetryEnabled: vi.fn().mockReturnValue(false),
+      getSessionId: vi.fn().mockReturnValue('test-session'),
     } as unknown as Config;
   });
 
@@ -87,6 +89,44 @@ describe('createGeminiContentGenerator', () => {
           baseUrl: expect.any(String),
         }),
       }),
+    );
+  });
+
+  it('omits X-Qwen-Code-Session-Id from httpOptions.headers when telemetry is disabled', () => {
+    const config = {
+      model: 'gemini-1.5-flash',
+      apiKey: 'k',
+      authType: AuthType.USE_GEMINI,
+    };
+    createGeminiContentGenerator(config, mockConfig);
+    const callArgs = vi.mocked(GeminiContentGenerator).mock.calls[0]?.[0] as
+      | { httpOptions?: { headers?: Record<string, string> } }
+      | undefined;
+    expect(callArgs?.httpOptions?.headers).toBeDefined();
+    expect(callArgs?.httpOptions?.headers ?? {}).not.toHaveProperty(
+      'X-Qwen-Code-Session-Id',
+    );
+  });
+
+  it('includes X-Qwen-Code-Session-Id in httpOptions.headers when telemetry is enabled', () => {
+    mockConfig = {
+      getUsageStatisticsEnabled: vi.fn().mockReturnValue(false),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({}),
+      getCliVersion: vi.fn().mockReturnValue('1.0.0'),
+      getTelemetryEnabled: vi.fn().mockReturnValue(true),
+      getSessionId: vi.fn().mockReturnValue('sess-gemini'),
+    } as unknown as Config;
+    const config = {
+      model: 'gemini-1.5-flash',
+      apiKey: 'k',
+      authType: AuthType.USE_GEMINI,
+    };
+    createGeminiContentGenerator(config, mockConfig);
+    const callArgs = vi.mocked(GeminiContentGenerator).mock.calls[0]?.[0] as {
+      httpOptions: { headers: Record<string, string> };
+    };
+    expect(callArgs.httpOptions.headers['X-Qwen-Code-Session-Id']).toBe(
+      'sess-gemini',
     );
   });
 });

--- a/packages/core/src/core/geminiContentGenerator/index.ts
+++ b/packages/core/src/core/geminiContentGenerator/index.ts
@@ -11,6 +11,7 @@ import type {
 } from '../contentGenerator.js';
 import type { Config } from '../../config/config.js';
 import { InstallationManager } from '../../utils/installationManager.js';
+import { staticCorrelationHeaders } from '../../telemetry/llm-correlation-fetch.js';
 
 export { GeminiContentGenerator } from './geminiContentGenerator.js';
 
@@ -38,6 +39,13 @@ export function createGeminiContentGenerator(
       'x-gemini-api-privileged-user-id': `${installationId}`,
     };
   }
+  // Merge the session-id correlation header. `@google/genai`'s HttpOptions
+  // does not expose a `fetch` hook (unlike `openai` / `@anthropic-ai/sdk`),
+  // so we can only inject a static header here — captured at construction.
+  // Known limitation: after a `/clear`-triggered session reset, the Gemini
+  // SDK's cached headers retain the OLD session id until the contentGenerator
+  // is recreated. See design doc §8.6 + #4384 follow-up sub-issue tracking.
+  headers = { ...headers, ...staticCorrelationHeaders(gcConfig) };
   const httpOptions = config.baseUrl
     ? {
         headers,

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -492,6 +492,17 @@ describe('DashScopeOpenAICompatibleProvider', () => {
         }),
       );
     });
+
+    it('installs the correlation fetch wrapper on the OpenAI client', () => {
+      provider.buildClient();
+      const callArg = vi.mocked(OpenAI).mock.calls[0]![0] as {
+        fetch?: typeof fetch;
+      };
+      // Wrapper is always installed; per-request behavior depends on
+      // telemetry-enabled (verified end-to-end in llm-correlation-fetch.test.ts).
+      expect(typeof callArg.fetch).toBe('function');
+      expect(callArg.fetch).not.toBe(globalThis.fetch);
+    });
   });
 
   describe('buildMetadata', () => {

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -16,6 +16,7 @@ import type {
   ChatCompletionToolWithCache,
 } from './types.js';
 import { buildRuntimeFetchOptions } from '../../../utils/runtimeFetchOptions.js';
+import { wrapFetchWithCorrelation } from '../../../telemetry/llm-correlation-fetch.js';
 import { createDebugLogger } from '../../../utils/debugLogger.js';
 import { DefaultOpenAICompatibleProvider } from './default.js';
 
@@ -138,6 +139,9 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
       'openai',
       this.cliConfig.getProxy(),
     );
+    const baseFetch =
+      (runtimeOptions as { fetch?: typeof fetch } | undefined)?.fetch ??
+      globalThis.fetch;
     return new OpenAI({
       apiKey,
       baseURL: baseUrl,
@@ -145,6 +149,7 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
       maxRetries,
       defaultHeaders,
       ...(runtimeOptions || {}),
+      fetch: wrapFetchWithCorrelation(baseFetch, this.cliConfig),
     });
   }
 

--- a/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.test.ts
@@ -168,6 +168,18 @@ describe('DefaultOpenAICompatibleProvider', () => {
         }),
       );
     });
+
+    it('installs the correlation fetch wrapper on the OpenAI client', () => {
+      provider.buildClient();
+      const callArg = vi.mocked(OpenAI).mock.calls[0]![0] as {
+        fetch?: typeof fetch;
+      };
+      // Wrapper is always installed (so it can read live config per request);
+      // per-call header injection behavior is verified exhaustively in
+      // llm-correlation-fetch.test.ts.
+      expect(typeof callArg.fetch).toBe('function');
+      expect(callArg.fetch).not.toBe(globalThis.fetch);
+    });
   });
 
   describe('buildRequest', () => {

--- a/packages/core/src/core/openaiContentGenerator/provider/default.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/default.ts
@@ -5,6 +5,7 @@ import type { ContentGeneratorConfig } from '../../contentGenerator.js';
 import { DEFAULT_TIMEOUT, DEFAULT_MAX_RETRIES } from '../constants.js';
 import type { OpenAICompatibleProvider } from './types.js';
 import { buildRuntimeFetchOptions } from '../../../utils/runtimeFetchOptions.js';
+import { wrapFetchWithCorrelation } from '../../../telemetry/llm-correlation-fetch.js';
 import {
   tokenLimit,
   CAPPED_DEFAULT_MAX_TOKENS,
@@ -88,6 +89,13 @@ export class DefaultOpenAICompatibleProvider
       'openai',
       this.cliConfig.getProxy(),
     );
+    // Wrap fetch with per-request correlation header injection. Read the base
+    // fetch from runtimeOptions (proxy-aware) when present, else globalThis.
+    // Spread runtimeOptions FIRST, then override `fetch:` so our wrapper wraps
+    // the proxy fetch instead of being replaced by it. See design doc §4.3.
+    const baseFetch =
+      (runtimeOptions as { fetch?: typeof fetch } | undefined)?.fetch ??
+      globalThis.fetch;
     return new OpenAI({
       apiKey,
       baseURL: baseUrl,
@@ -95,6 +103,7 @@ export class DefaultOpenAICompatibleProvider
       maxRetries,
       defaultHeaders,
       ...(runtimeOptions || {}),
+      fetch: wrapFetchWithCorrelation(baseFetch, this.cliConfig),
     });
   }
 

--- a/packages/core/src/telemetry/llm-correlation-fetch.test.ts
+++ b/packages/core/src/telemetry/llm-correlation-fetch.test.ts
@@ -1,0 +1,173 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { Config } from '../config/config.js';
+import {
+  SESSION_ID_HEADER,
+  staticCorrelationHeaders,
+  wrapFetchWithCorrelation,
+} from './llm-correlation-fetch.js';
+
+function mockConfig(opts: {
+  enabled?: boolean;
+  sessionId?: string | (() => string);
+}): Config {
+  return {
+    getTelemetryEnabled: () => opts.enabled ?? true,
+    getSessionId: () =>
+      typeof opts.sessionId === 'function'
+        ? opts.sessionId()
+        : (opts.sessionId ?? ''),
+  } as unknown as Config;
+}
+
+describe('wrapFetchWithCorrelation', () => {
+  it('attaches X-Qwen-Code-Session-Id when telemetry is enabled', async () => {
+    const baseFetch = vi.fn(async () => new Response());
+    const wrapped = wrapFetchWithCorrelation(
+      baseFetch as unknown as typeof fetch,
+      mockConfig({ enabled: true, sessionId: 'sess-A' }),
+    );
+    await wrapped('https://api.example.com/v1/chat');
+    const init = baseFetch.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Headers).get(SESSION_ID_HEADER)).toBe('sess-A');
+  });
+
+  it('does not attach header when telemetry is disabled (passes init through unchanged)', async () => {
+    const baseFetch = vi.fn(async () => new Response());
+    const userInit = { method: 'POST', headers: { 'X-Custom': 'keep' } };
+    const wrapped = wrapFetchWithCorrelation(
+      baseFetch as unknown as typeof fetch,
+      mockConfig({ enabled: false, sessionId: 'sess-A' }),
+    );
+    await wrapped('https://api.example.com/v1/chat', userInit);
+    expect(baseFetch).toHaveBeenCalledWith(
+      'https://api.example.com/v1/chat',
+      userInit,
+    );
+  });
+
+  it('does not attach header when sessionId is empty (skips defensively)', async () => {
+    const baseFetch = vi.fn(async () => new Response());
+    const wrapped = wrapFetchWithCorrelation(
+      baseFetch as unknown as typeof fetch,
+      mockConfig({ enabled: true, sessionId: '' }),
+    );
+    await wrapped('https://api.example.com/v1/chat');
+    expect(baseFetch).toHaveBeenCalledWith(
+      'https://api.example.com/v1/chat',
+      undefined,
+    );
+  });
+
+  it('overrides existing same-name header on init (server gets real session id, not user-supplied spoof)', async () => {
+    const baseFetch = vi.fn(async () => new Response());
+    const wrapped = wrapFetchWithCorrelation(
+      baseFetch as unknown as typeof fetch,
+      mockConfig({ enabled: true, sessionId: 'real-sess' }),
+    );
+    await wrapped('https://api.example.com/v1/chat', {
+      headers: { [SESSION_ID_HEADER]: 'spoofed' },
+    });
+    const init = baseFetch.mock.calls[0]![1] as RequestInit;
+    expect((init.headers as Headers).get(SESSION_ID_HEADER)).toBe('real-sess');
+  });
+
+  it('preserves other headers and init fields when injecting', async () => {
+    const baseFetch = vi.fn(async () => new Response());
+    const signal = new AbortController().signal;
+    const wrapped = wrapFetchWithCorrelation(
+      baseFetch as unknown as typeof fetch,
+      mockConfig({ enabled: true, sessionId: 'sess' }),
+    );
+    await wrapped('https://api.example.com/v1/chat', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer sk-xxx',
+        'Content-Type': 'application/json',
+      },
+      body: '{"x":1}',
+      signal,
+    });
+    const init = baseFetch.mock.calls[0]![1] as RequestInit;
+    expect(init.method).toBe('POST');
+    expect(init.body).toBe('{"x":1}');
+    expect(init.signal).toBe(signal);
+    const h = init.headers as Headers;
+    expect(h.get('Authorization')).toBe('Bearer sk-xxx');
+    expect(h.get('Content-Type')).toBe('application/json');
+    expect(h.get(SESSION_ID_HEADER)).toBe('sess');
+  });
+
+  it('reads fresh session id after a session reset (staleness regression — design §4.3 critical)', async () => {
+    let current = 'sess-A';
+    const baseFetch = vi.fn(async () => new Response());
+    const wrapped = wrapFetchWithCorrelation(
+      baseFetch as unknown as typeof fetch,
+      mockConfig({ enabled: true, sessionId: () => current }),
+    );
+
+    await wrapped('https://api.example.com/1');
+    const first = baseFetch.mock.calls[0]![1] as RequestInit;
+    expect((first.headers as Headers).get(SESSION_ID_HEADER)).toBe('sess-A');
+
+    // Simulate /clear updating Config.sessionId without recreating SDK clients.
+    current = 'sess-B';
+
+    await wrapped('https://api.example.com/2');
+    const second = baseFetch.mock.calls[1]![1] as RequestInit;
+    expect((second.headers as Headers).get(SESSION_ID_HEADER)).toBe('sess-B');
+  });
+
+  it('propagates baseFetch rejection unchanged', async () => {
+    const err = new Error('network unreachable');
+    const baseFetch = vi.fn(async () => {
+      throw err;
+    });
+    const wrapped = wrapFetchWithCorrelation(
+      baseFetch as unknown as typeof fetch,
+      mockConfig({ enabled: true, sessionId: 'sess' }),
+    );
+    await expect(wrapped('https://api.example.com/x')).rejects.toBe(err);
+  });
+});
+
+describe('staticCorrelationHeaders', () => {
+  it('returns header when telemetry enabled and sessionId non-empty', () => {
+    expect(
+      staticCorrelationHeaders(
+        mockConfig({ enabled: true, sessionId: 'sess-A' }),
+      ),
+    ).toEqual({ [SESSION_ID_HEADER]: 'sess-A' });
+  });
+
+  it('returns {} when telemetry disabled', () => {
+    expect(
+      staticCorrelationHeaders(
+        mockConfig({ enabled: false, sessionId: 'sess-A' }),
+      ),
+    ).toEqual({});
+  });
+
+  it('returns {} when sessionId is empty', () => {
+    expect(
+      staticCorrelationHeaders(mockConfig({ enabled: true, sessionId: '' })),
+    ).toEqual({});
+  });
+
+  it('captures session id at call time — caller responsible for re-invoking on reset (Gemini staleness §8.6)', () => {
+    // Document by behavior: this helper takes a snapshot. Caller (e.g.
+    // geminiContentGenerator/index.ts factory) calls it once and bakes the
+    // value into SDK-construction `httpOptions.headers`. A session reset
+    // after construction won't update the header — known limitation.
+    let current = 'sess-A';
+    const config = mockConfig({ enabled: true, sessionId: () => current });
+    const snapshot = staticCorrelationHeaders(config);
+    current = 'sess-B';
+    expect(snapshot[SESSION_ID_HEADER]).toBe('sess-A');
+  });
+});

--- a/packages/core/src/telemetry/llm-correlation-fetch.ts
+++ b/packages/core/src/telemetry/llm-correlation-fetch.ts
@@ -1,0 +1,81 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Config } from '../config/config.js';
+
+/**
+ * Custom HTTP header attached to every outbound LLM service request when
+ * telemetry is enabled. Product-namespaced (matching claude-code's
+ * `X-Claude-Code-Session-Id` pattern from `src/services/api/client.ts:108`)
+ * to avoid collision with generic `X-Session-Id` headers other tools may
+ * inject. Server-side ingestion can use this to stitch its observation of
+ * an LLM request back to the originating qwen-code session.
+ */
+export const SESSION_ID_HEADER = 'X-Qwen-Code-Session-Id';
+
+/**
+ * Wrap a fetch implementation so every outbound request gets the
+ * `X-Qwen-Code-Session-Id` correlation header populated from the **current**
+ * session id, not the value captured when the SDK client was constructed.
+ *
+ * Why per-request and not `defaultHeaders`: SDK clients (and their static
+ * `defaultHeaders`) are constructed once at content-generator init and are
+ * NOT recreated on `/clear`-triggered session reset (`Config.resetSession()`
+ * updates `this.sessionId` but doesn't rebuild the contentGenerator). A
+ * static header would therefore go stale immediately after the first reset.
+ * Reading `config.getSessionId()` from inside the wrapper on every call
+ * gives the live value.
+ *
+ * The caller is responsible for choosing the base fetch — usually
+ * `runtimeOptions?.fetch ?? globalThis.fetch` so proxy-aware fetch (set up
+ * by `buildRuntimeFetchOptions`) is preserved when ProxyAgent is in use.
+ *
+ * When telemetry is disabled, returns baseFetch unchanged — no correlation
+ * header added. (Consistent with #4367's gating: opt-out of telemetry means
+ * no telemetry-related wire signal, including correlation.)
+ */
+export function wrapFetchWithCorrelation(
+  baseFetch: typeof fetch,
+  config: Config,
+): typeof fetch {
+  return async function correlationFetch(
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> {
+    if (!config.getTelemetryEnabled()) {
+      return baseFetch(input, init);
+    }
+    const sid = config.getSessionId();
+    if (!sid) {
+      // Defensive: empty header value is rejected by some HTTP middleware.
+      // Skip injection rather than send `X-Qwen-Code-Session-Id: `.
+      return baseFetch(input, init);
+    }
+    const headers = new Headers(init?.headers);
+    headers.set(SESSION_ID_HEADER, sid);
+    return baseFetch(input, { ...init, headers });
+  };
+}
+
+/**
+ * Static correlation headers. Captures the session id at call time —
+ * subject to staleness if the host SDK keeps these headers in a
+ * captured-at-construction slot (e.g. `@google/genai`'s
+ * `httpOptions.headers` — see design doc §8.6 for the known Gemini
+ * limitation). Prefer `wrapFetchWithCorrelation` whenever the SDK exposes
+ * a `fetch` hook.
+ *
+ * When telemetry is disabled, returns `{}` so the caller can spread it
+ * unconditionally without changing wire behavior.
+ */
+export function staticCorrelationHeaders(
+  config: Config,
+): Record<string, string> {
+  if (!config.getTelemetryEnabled()) return {};
+  const sid = config.getSessionId();
+  if (!sid) return {};
+  return { [SESSION_ID_HEADER]: sid };
+}

--- a/packages/core/src/telemetry/sdk.test.ts
+++ b/packages/core/src/telemetry/sdk.test.ts
@@ -764,6 +764,60 @@ describe('Telemetry SDK', () => {
         }),
       ).toBe(true);
     });
+
+    it('ignoreRequestHook strips #fragment from incoming path for matching', () => {
+      vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
+      vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
+        'http://collector.example.com:4318',
+      );
+      initializeTelemetry(mockConfig);
+      const config = vi.mocked(UndiciInstrumentation).mock.calls[0]![0]! as {
+        ignoreRequestHook: (req: { origin: string; path: string }) => boolean;
+      };
+      expect(
+        config.ignoreRequestHook({
+          origin: 'http://collector.example.com:4318',
+          path: '/v1/traces#fragment',
+        }),
+      ).toBe(true);
+    });
+
+    it('ignoreRequestHook normalizes endpoint config quoted in settings.json', () => {
+      // Defense against settings.json `"otlpEndpoint": "\"http://...\""` —
+      // quoted strings would otherwise miss the prefix match and reintroduce
+      // the feedback loop. Per PR review feedback.
+      vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
+      vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
+        '"http://collector.example.com:4318"',
+      );
+      initializeTelemetry(mockConfig);
+      const config = vi.mocked(UndiciInstrumentation).mock.calls[0]![0]! as {
+        ignoreRequestHook: (req: { origin: string; path: string }) => boolean;
+      };
+      expect(
+        config.ignoreRequestHook({
+          origin: 'http://collector.example.com:4318',
+          path: '/v1/traces',
+        }),
+      ).toBe(true);
+    });
+
+    it('ignoreRequestHook strips #fragment from configured endpoint', () => {
+      vi.spyOn(mockConfig, 'getTelemetryOtlpProtocol').mockReturnValue('http');
+      vi.spyOn(mockConfig, 'getTelemetryOtlpEndpoint').mockReturnValue(
+        'http://collector.example.com:4318/v1/traces#anchor',
+      );
+      initializeTelemetry(mockConfig);
+      const config = vi.mocked(UndiciInstrumentation).mock.calls[0]![0]! as {
+        ignoreRequestHook: (req: { origin: string; path: string }) => boolean;
+      };
+      expect(
+        config.ignoreRequestHook({
+          origin: 'http://collector.example.com:4318',
+          path: '/v1/traces',
+        }),
+      ).toBe(true);
+    });
   });
 });
 

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -318,16 +318,51 @@ export function initializeTelemetry(config: Config): void {
   // Build OTLP exporter URL prefixes once. The undici instrumentation must
   // ignore requests to these endpoints — otherwise it would create a client
   // span for every OTLP upload, that span would be exported, creating an
-  // infinite feedback loop. Strip trailing slash and query string so prefix
-  // matching against undici's `request.origin + request.path` is robust.
+  // infinite feedback loop. Use the WHATWG URL parser to extract a
+  // host+path prefix that is robust against user-config quirks (quoted
+  // strings, trailing slash, query string, #fragment, missing scheme).
+  // String-level transforms here would silently miss those forms — see PR
+  // review feedback (#4390).
+  function normalizeOtlpPrefix(raw: string | undefined): string | undefined {
+    if (!raw) return undefined;
+    // Trim surrounding whitespace + symmetric ASCII quotes a user may have
+    // placed in settings.json (`"value"` → `value`).
+    let s = raw.trim();
+    if (
+      s.length >= 2 &&
+      ((s.startsWith('"') && s.endsWith('"')) ||
+        (s.startsWith("'") && s.endsWith("'")))
+    ) {
+      s = s.slice(1, -1);
+    }
+    try {
+      const u = new URL(s);
+      // Drop ?query and #fragment — they're never part of the request
+      // signature undici exposes via `request.origin + request.path`.
+      // Strip a trailing `/` from path to keep the prefix tight.
+      const pathname = u.pathname === '/' ? '' : u.pathname.replace(/\/$/, '');
+      return `${u.origin}${pathname}`;
+    } catch {
+      // Not a valid URL — fall back to simple suffix trimming so a misconfigured
+      // endpoint still has SOME prefix protection rather than none.
+      const qIdx = s.indexOf('?');
+      const fIdx = s.indexOf('#');
+      let cut = s.length;
+      if (qIdx !== -1) cut = Math.min(cut, qIdx);
+      if (fIdx !== -1) cut = Math.min(cut, fIdx);
+      s = s.slice(0, cut);
+      while (s.endsWith('/')) s = s.slice(0, -1);
+      return s || undefined;
+    }
+  }
   const otlpUrlPrefixes = [
     config.getTelemetryOtlpEndpoint(),
     config.getTelemetryOtlpTracesEndpoint(),
     config.getTelemetryOtlpLogsEndpoint(),
     config.getTelemetryOtlpMetricsEndpoint(),
   ]
-    .filter((u): u is string => !!u)
-    .map((u) => u.replace(/\?.*$/, '').replace(/\/$/, ''));
+    .map(normalizeOtlpPrefix)
+    .filter((u): u is string => !!u);
 
   sdk = new NodeSDK({
     resource,
@@ -351,10 +386,16 @@ export function initializeTelemetry(config: Config): void {
       new UndiciInstrumentation({
         ignoreRequestHook: (request) => {
           if (otlpUrlPrefixes.length === 0) return false;
-          const path =
-            typeof request.path === 'string'
-              ? request.path.replace(/\?.*$/, '')
-              : '';
+          // Strip ?query / #fragment from the incoming request.path before
+          // matching. `indexOf` (not regex) for CodeQL ReDoS hygiene — a
+          // path like `??????…` would be O(n²) in some regex engines.
+          let path = typeof request.path === 'string' ? request.path : '';
+          const qIdx = path.indexOf('?');
+          const fIdx = path.indexOf('#');
+          let cut = path.length;
+          if (qIdx !== -1) cut = Math.min(cut, qIdx);
+          if (fIdx !== -1) cut = Math.min(cut, fIdx);
+          path = path.slice(0, cut);
           const url = `${request.origin}${path}`;
           return otlpUrlPrefixes.some((prefix) => url.startsWith(prefix));
         },


### PR DESCRIPTION
Part 2 of #4384. **Stacks on top of #4390** (PR A — traceparent via undici instrumentation). Set the base to PR A's branch so the diff shows only this PR's additions.

## Summary

Adds a product-namespaced HTTP header `X-Qwen-Code-Session-Id` to every outbound LLM request when telemetry is enabled. Pattern matched from claude-code (`X-Claude-Code-Session-Id`, verified at `src/services/api/client.ts:108` in their open-source repo). Server-side ingestion (e.g. a custom DashScope proxy or OTLP-aware API gateway) can use the header to stitch its observation of an LLM request back to the originating qwen-code session without parsing trace context.

## Critical design: fetch wrapper, not `defaultHeaders`

The OpenAI / Anthropic providers use a **per-request fetch wrapper** rather than the SDK's `defaultHeaders` option. Why: content-generator SDK clients are constructed ONCE and NOT recreated on `/clear`-triggered session resets — `Config.resetSession()` updates `this.sessionId` but the contentGenerator keeps using the stale header value baked into `defaultHeaders`. Reading `config.getSessionId()` from inside the fetch wrapper at request time gives the live value.

This is verified end-to-end by the staleness regression test in `llm-correlation-fetch.test.ts`.

## Known limitation: Gemini

`@google/genai`'s `HttpOptions` interface does NOT expose a `fetch` hook (only `headers` / `baseUrl` / `apiVersion` / `timeout` / `extraParams`). Gemini therefore uses static `httpOptions.headers` and shares the staleness bug after `/clear`. Spans and logs still carry the live session id, so trace/log backends correctly attribute requests to the new session — only the wire-header at the LLM-service boundary is stale. Documented in `telemetry.md` and the design doc §8.6. Lazy-invalidate fix is a follow-up sub-issue.

## Integration sites (4 SDK construction points)

- `packages/core/src/core/openaiContentGenerator/provider/default.ts` (base — 5 sibling providers inherit; openrouter calls `super.buildHeaders`)
- `packages/core/src/core/openaiContentGenerator/provider/dashscope.ts` (overrides `buildClient`; QwenContentGenerator inherits via this)
- `packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts`
- `packages/core/src/core/geminiContentGenerator/index.ts` (factory, NOT the class — no signature change needed; `gcConfig` already in scope)

## Test plan

- [x] 11 new unit tests in `llm-correlation-fetch.test.ts` — including the staleness regression test (emit request 1, mutate sessionId, emit request 2, assert new id on wire)
- [x] Updated provider tests assert `OpenAI` / `GoogleGenAI` constructor receives wrapped fetch / merged headers (telemetry on/off cases)
- [x] All 150 tests across the 6 touched files pass (sdk.test.ts, llm-correlation-fetch.test.ts, default.test.ts, dashscope.test.ts, gemini index.test.ts, gemini geminiContentGenerator.test.ts)
- [x] **End-to-end verify in tmux** (`/tmp/verify-pr4384.mjs`): local HTTP server captures real outbound requests
  - Two scenarios run sequentially in one process
  - Scenario 1: `sess-initial` set, fire request → captured header has `sess-initial`
  - Scenario 2: mutate session id to `sess-after-clear`, fire request → captured header has new id (regression-guards the staleness fix in real SDK conditions, not just mocks)
  - OTLP collector mock receives uploads but those don't carry `traceparent` — confirms PR A's `ignoreRequestHook` working

Captured output:
\`\`\`
[0] POST /v1/chat/completions
    X-Qwen-Code-Session-Id: sess-initial
    traceparent: 00-21278f951b68d6a0c412abfce3427078-81f936f76a72909b-01
[1] POST /v1/chat/completions
    X-Qwen-Code-Session-Id: sess-after-clear
    traceparent: 00-c71d416430a4612ba407b8a7e83baaf9-170601e26252e2e0-01
\`\`\`

## Audited but not modified

- `packages/core/src/qwen/qwenContentGenerator.ts` — extends `OpenAIContentGenerator` using `DashScopeOpenAICompatibleProvider`; auto-inherits the dashscope change
- `packages/core/src/core/loggingContentGenerator/loggingContentGenerator.ts` — wrapper, doesn't construct SDK clients

## Out of scope (per design §3.2, future sub-issues)

- Subprocess `TRACEPARENT` env var inheritance (BashTool)
- Inbound `TRACEPARENT` read on startup (`--prompt` / Agent SDK modes)
- `X-Qwen-Code-Request-Id` per-request UUID
- Gemini staleness lazy-invalidate fix

Design doc: `docs/design/telemetry-outbound-propagation-design.md` (landed in PR A).

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)