### PR TITLE
fix(release): move constants above entry point to avoid TDZ error

### DIFF
--- a/scripts/tests/upload-aliyun-oss-assets.test.js
+++ b/scripts/tests/upload-aliyun-oss-assets.test.js
@@ -7,8 +7,6 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { spawnSync } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { parseUploadArgs, uploadAssets } from '../upload-aliyun-oss-assets.js';
 
@@ -85,14 +83,6 @@ describe('parseUploadArgs', () => {
 });
 
 describe('uploadAssets (integration)', () => {
-  function withPrependedPath(workDir) {
-    const env = { ...process.env };
-    const pathKey =
-      Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
-    env[pathKey] = `${workDir}${path.delimiter}${env[pathKey] ?? ''}`;
-    return env;
-  }
-
   function makeOssutilShim(workDir, behavior = 'success') {
     fs.mkdirSync(workDir, { recursive: true });
     const ossutilPath = path.join(workDir, 'ossutil-shim.cjs');
@@ -112,73 +102,6 @@ describe('uploadAssets (integration)', () => {
       ossutilCommandArgs: [ossutilPath],
     };
   }
-
-  function makeExecutableOssutilShim(workDir) {
-    fs.mkdirSync(workDir, { recursive: true });
-    const logPath = path.join(workDir, 'ossutil.log');
-    const ossutilPath = path.join(workDir, 'ossutil');
-    fs.writeFileSync(
-      ossutilPath,
-      [
-        '#!/usr/bin/env node',
-        "const fs = require('node:fs');",
-        `fs.appendFileSync(${JSON.stringify(logPath)}, process.argv.slice(2).join('\\n') + '\\n');`,
-        'process.exit(0);',
-        '',
-      ].join('\n'),
-      { mode: 0o755 },
-    );
-    fs.writeFileSync(
-      path.join(workDir, 'ossutil.cmd'),
-      ['@echo off', `"${process.execPath}" "${ossutilPath}" %*`, ''].join(
-        '\r\n',
-      ),
-    );
-    return { logPath };
-  }
-
-  it('runs the CLI upload path without retry constant TDZ errors', () => {
-    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-upload-cli-'));
-    try {
-      const { logPath } = makeExecutableOssutilShim(tmp);
-      const assetPath = path.join(tmp, 'asset.tar.gz');
-      fs.writeFileSync(assetPath, 'asset');
-      const configPath = path.join(tmp, '.ossutilconfig');
-      fs.writeFileSync(configPath, '[Credentials]\n');
-
-      const scriptPath = fileURLToPath(
-        new URL('../upload-aliyun-oss-assets.js', import.meta.url),
-      );
-      const result = spawnSync(
-        process.execPath,
-        [
-          scriptPath,
-          '--bucket',
-          'qwen-test-bucket',
-          '--config',
-          configPath,
-          '--prefix',
-          'releases/qwen-code/v0.0.0',
-          assetPath,
-        ],
-        {
-          encoding: 'utf8',
-          env: withPrependedPath(tmp),
-        },
-      );
-
-      expect(result.status, result.stderr || result.stdout).toBe(0);
-      expect(result.stderr).not.toContain(
-        "Cannot access 'MAX_UPLOAD_ATTEMPTS' before initialization",
-      );
-      const log = fs.readFileSync(logPath, 'utf8');
-      expect(log).toContain(
-        'oss://qwen-test-bucket/releases/qwen-code/v0.0.0/asset.tar.gz',
-      );
-    } finally {
-      fs.rmSync(tmp, { recursive: true, force: true });
-    }
-  });
 
   it('spawns ossutil with the expected cp arguments per asset', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-upload-'));

--- a/scripts/tests/upload-aliyun-oss-assets.test.js
+++ b/scripts/tests/upload-aliyun-oss-assets.test.js
@@ -7,6 +7,8 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { parseUploadArgs, uploadAssets } from '../upload-aliyun-oss-assets.js';
 
@@ -83,6 +85,14 @@ describe('parseUploadArgs', () => {
 });
 
 describe('uploadAssets (integration)', () => {
+  function withPrependedPath(workDir) {
+    const env = { ...process.env };
+    const pathKey =
+      Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'PATH';
+    env[pathKey] = `${workDir}${path.delimiter}${env[pathKey] ?? ''}`;
+    return env;
+  }
+
   function makeOssutilShim(workDir, behavior = 'success') {
     fs.mkdirSync(workDir, { recursive: true });
     const ossutilPath = path.join(workDir, 'ossutil-shim.cjs');
@@ -102,6 +112,73 @@ describe('uploadAssets (integration)', () => {
       ossutilCommandArgs: [ossutilPath],
     };
   }
+
+  function makeExecutableOssutilShim(workDir) {
+    fs.mkdirSync(workDir, { recursive: true });
+    const logPath = path.join(workDir, 'ossutil.log');
+    const ossutilPath = path.join(workDir, 'ossutil');
+    fs.writeFileSync(
+      ossutilPath,
+      [
+        '#!/usr/bin/env node',
+        "const fs = require('node:fs');",
+        `fs.appendFileSync(${JSON.stringify(logPath)}, process.argv.slice(2).join('\\n') + '\\n');`,
+        'process.exit(0);',
+        '',
+      ].join('\n'),
+      { mode: 0o755 },
+    );
+    fs.writeFileSync(
+      path.join(workDir, 'ossutil.cmd'),
+      ['@echo off', `"${process.execPath}" "${ossutilPath}" %*`, ''].join(
+        '\r\n',
+      ),
+    );
+    return { logPath };
+  }
+
+  it('runs the CLI upload path without retry constant TDZ errors', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-upload-cli-'));
+    try {
+      const { logPath } = makeExecutableOssutilShim(tmp);
+      const assetPath = path.join(tmp, 'asset.tar.gz');
+      fs.writeFileSync(assetPath, 'asset');
+      const configPath = path.join(tmp, '.ossutilconfig');
+      fs.writeFileSync(configPath, '[Credentials]\n');
+
+      const scriptPath = fileURLToPath(
+        new URL('../upload-aliyun-oss-assets.js', import.meta.url),
+      );
+      const result = spawnSync(
+        process.execPath,
+        [
+          scriptPath,
+          '--bucket',
+          'qwen-test-bucket',
+          '--config',
+          configPath,
+          '--prefix',
+          'releases/qwen-code/v0.0.0',
+          assetPath,
+        ],
+        {
+          encoding: 'utf8',
+          env: withPrependedPath(tmp),
+        },
+      );
+
+      expect(result.status, result.stderr || result.stdout).toBe(0);
+      expect(result.stderr).not.toContain(
+        "Cannot access 'MAX_UPLOAD_ATTEMPTS' before initialization",
+      );
+      const log = fs.readFileSync(logPath, 'utf8');
+      expect(log).toContain(
+        'oss://qwen-test-bucket/releases/qwen-code/v0.0.0/asset.tar.gz',
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
 
   it('spawns ossutil with the expected cp arguments per asset', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'qwen-upload-'));

--- a/scripts/upload-aliyun-oss-assets.js
+++ b/scripts/upload-aliyun-oss-assets.js
@@ -10,6 +10,9 @@ import path from 'node:path';
 import { spawnSync } from 'node:child_process';
 import { fail, isMainModule, readOptionValue } from './release-script-utils.js';
 
+const MAX_UPLOAD_ATTEMPTS = 3;
+const INITIAL_BACKOFF_MS = 2000;
+
 if (isMainModule(import.meta.url)) {
   try {
     main(process.argv.slice(2));
@@ -95,9 +98,6 @@ function parseUploadArgs(argv) {
 
   return args;
 }
-
-const MAX_UPLOAD_ATTEMPTS = 3;
-const INITIAL_BACKOFF_MS = 2000;
 
 function uploadAssets(
   { assets, bucket, config, prefix },


### PR DESCRIPTION
## Summary
- Release workflow failed with `Cannot access 'MAX_UPLOAD_ATTEMPTS' before initialization` during v0.16.0 publish
- Root cause: `const MAX_UPLOAD_ATTEMPTS` and `const INITIAL_BACKOFF_MS` were declared after the `isMainModule()` entry point that calls `main()` → `uploadAssets()` → `uploadWithRetry()`, triggering a temporal dead zone (TDZ) error in ES modules
- Fix: move the two constants to the top of the file, right after imports

## Test plan
- [x] `node --check scripts/upload-aliyun-oss-assets.js` passes
- [x] `node scripts/upload-aliyun-oss-assets.js --help` runs without error
- [ ] Re-run Release workflow after merge