### PR TITLE
fix(vscode): skip redundant tsc build in prepackage to prevent TS5055

### DIFF
--- a/packages/vscode-ide-companion/scripts/prepackage.js
+++ b/packages/vscode-ide-companion/scripts/prepackage.js
@@ -178,11 +178,11 @@ function removeSelfReferenceFromNodeModules() {
 function main() {
   const npm = npmBin();
 
-  // Root bundling depends on built workspace outputs. Use the root build to
-  // ensure all required workspace dist/ artifacts exist.
-  console.log('[prepackage] Building repo...');
-  run(npm, ['--prefix', repoRoot, 'run', 'build'], { cwd: repoRoot });
-
+  // The CLI bundle is produced by esbuild directly from TypeScript source
+  // (entryPoint: packages/cli/index.ts), so a full tsc build is not needed.
+  // Calling `npm run build` here would trigger tsc --build a second time
+  // (after the initial `prepare` in npm ci) and fail with TS5055 when the
+  // version bump made source files diverge from the stale tsbuildinfo.
   console.log('[prepackage] Bundling root CLI...');
   run(npm, ['--prefix', repoRoot, 'run', 'bundle'], { cwd: repoRoot });
 


### PR DESCRIPTION
## Summary

The VSCode IDE companion release workflow fails with TS5055 during the Prepare VSCode Extension step.

**Root cause**: prepackage.js called `npm run build` (full `tsc --build` on all workspace packages) after the version bump had already made tsbuildinfo stale. With composite project references (introduced in #4295), `tsc --build` resolves existing `dist/*.d.ts` files as input, triggering TS5055.

**Fix**: Remove the redundant `npm run build` call from prepackage.js. The CLI bundle is produced by esbuild directly from TypeScript source (`packages/cli/index.ts`), so compiled dist/ artifacts are not needed.

Combined with #4383 (which fixed the version.js path), this eliminates all scenarios where `tsc --build` runs on stale state during the release workflow.

## Test plan

- [ ] Re-run the VSCode IDE companion release workflow (dry-run) to confirm TS5055 no longer occurs
- [ ] Verify the CLI bundle still works correctly inside the packaged VSIX