### PR TITLE
fix(cli): stabilize flaky sticky-todo remeasure test

### DIFF
--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -328,12 +328,6 @@ describe('AppContainer State Management', () => {
     // Mock Config
     mockConfig = makeFakeConfig();
 
-    // makeFakeConfig() returns a real Config whose initialize() throws
-    // "Config was already initialized" on the second call. React double-invokes
-    // the mount effect, so the real method rejects and leaks async renders into
-    // later tests — making footer-measurement assertions flaky. Stub it out.
-    vi.spyOn(mockConfig, 'initialize').mockResolvedValue(undefined);
-
     // Mock config's getTargetDir to return consistent workspace directory
     vi.spyOn(mockConfig, 'getTargetDir').mockReturnValue('/test/workspace');
 
@@ -2344,6 +2338,12 @@ describe('AppContainer State Management', () => {
     });
 
     it('does not remeasure footer height for sticky todo status-only updates', async () => {
+      // Scoped stub: makeFakeConfig().initialize() rejects on React's
+      // double-mount, which leaks async renders and destabilizes the
+      // footer-measurement timing this test depends on. Kept per-test so
+      // unrelated tests in this block still exercise the real init gate.
+      vi.spyOn(mockConfig, 'initialize').mockResolvedValue(undefined);
+
       const historyManager = {
         history: makeTodoHistory('pending'),
         addItem: vi.fn(),
@@ -2382,6 +2382,13 @@ describe('AppContainer State Management', () => {
 
       const heightAfterSettle = capturedUIState.availableTerminalHeight;
 
+      // Switch the mock to a different height so any re-measurement triggered
+      // by the status-only rerender below would change controlsHeight (and
+      // therefore availableTerminalHeight). Without this, the production
+      // same-value short-circuit on setControlsHeight makes the equality
+      // assertion pass even when the optimization regresses.
+      mockedMeasureElement.mockReturnValue({ width: 80, height: 10 });
+
       historyManager.history = makeTodoHistory('in_progress');
       await act(async () => {
         view!.rerender(
@@ -2395,8 +2402,8 @@ describe('AppContainer State Management', () => {
       });
 
       // The sticky todo status change (pending → in_progress) must not alter
-      // the computed terminal height. This asserts on the behavioral outcome
-      // rather than the implementation detail of measureElement call count.
+      // the computed terminal height. Combined with the mock-height swap
+      // above, this fails iff the footer was re-measured.
       expect(capturedUIState.availableTerminalHeight).toBe(heightAfterSettle);
     });
   });

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -328,6 +328,12 @@ describe('AppContainer State Management', () => {
     // Mock Config
     mockConfig = makeFakeConfig();
 
+    // makeFakeConfig() returns a real Config whose initialize() throws
+    // "Config was already initialized" on the second call. React double-invokes
+    // the mount effect, so the real method rejects and leaks async renders into
+    // later tests — making footer-measurement assertions flaky. Stub it out.
+    vi.spyOn(mockConfig, 'initialize').mockResolvedValue(undefined);
+
     // Mock config's getTargetDir to return consistent workspace directory
     vi.spyOn(mockConfig, 'getTargetDir').mockReturnValue('/test/workspace');
 
@@ -2358,7 +2364,11 @@ describe('AppContainer State Management', () => {
           initializationResult={mockInitResult}
         />,
       );
-      const callsAfterInitialRender = mockedMeasureElement.mock.calls.length;
+
+      // Reset call tracking after initial render to isolate rerender calls.
+      // This avoids flakiness from React 19's variable mount-time invocation
+      // count (e.g. StrictMode double-invoke, multiple reconciliation passes).
+      mockedMeasureElement.mockClear();
 
       historyManager.history = makeTodoHistory('in_progress');
       view.rerender(
@@ -2370,9 +2380,7 @@ describe('AppContainer State Management', () => {
         />,
       );
 
-      expect(mockedMeasureElement).toHaveBeenCalledTimes(
-        callsAfterInitialRender,
-      );
+      expect(mockedMeasureElement).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/cli/src/ui/AppContainer.test.tsx
+++ b/packages/cli/src/ui/AppContainer.test.tsx
@@ -14,6 +14,7 @@ import {
   type Mock,
 } from 'vitest';
 import { render, cleanup } from 'ink-testing-library';
+import { useContext, act } from 'react';
 import {
   AppContainer,
   dedupeNewestFirst,
@@ -43,7 +44,6 @@ import {
   type HistoryItemWithoutId,
   ToolCallStatus,
 } from './types.js';
-import { useContext } from 'react';
 import { Box, measureElement } from 'ink';
 
 // Mock useStdout to capture terminal title writes
@@ -2343,7 +2343,7 @@ describe('AppContainer State Management', () => {
       expect(lastCall[2]).toBe(1);
     });
 
-    it('does not remeasure footer height for sticky todo status-only updates', () => {
+    it('does not remeasure footer height for sticky todo status-only updates', async () => {
       const historyManager = {
         history: makeTodoHistory('pending'),
         addItem: vi.fn(),
@@ -2356,31 +2356,48 @@ describe('AppContainer State Management', () => {
       mockedUseTerminalSize.mockReturnValue({ columns: 80, rows: 24 });
       mockedMeasureElement.mockReturnValue({ width: 80, height: 4 });
 
-      const view = render(
-        <AppContainer
-          config={mockConfig}
-          settings={mockSettings}
-          version="1.0.0"
-          initializationResult={mockInitResult}
-        />,
-      );
+      let view: ReturnType<typeof render>;
+      await act(async () => {
+        view = render(
+          <AppContainer
+            config={mockConfig}
+            settings={mockSettings}
+            version="1.0.0"
+            initializationResult={mockInitResult}
+          />,
+        );
+      });
 
-      // Reset call tracking after initial render to isolate rerender calls.
-      // This avoids flakiness from React 19's variable mount-time invocation
-      // count (e.g. StrictMode double-invoke, multiple reconciliation passes).
-      mockedMeasureElement.mockClear();
+      // Let any pending state updates from useLayoutEffect settle.
+      await act(async () => {
+        view!.rerender(
+          <AppContainer
+            config={mockConfig}
+            settings={mockSettings}
+            version="1.0.0"
+            initializationResult={mockInitResult}
+          />,
+        );
+      });
+
+      const heightAfterSettle = capturedUIState.availableTerminalHeight;
 
       historyManager.history = makeTodoHistory('in_progress');
-      view.rerender(
-        <AppContainer
-          config={mockConfig}
-          settings={mockSettings}
-          version="1.0.0"
-          initializationResult={mockInitResult}
-        />,
-      );
+      await act(async () => {
+        view!.rerender(
+          <AppContainer
+            config={mockConfig}
+            settings={mockSettings}
+            version="1.0.0"
+            initializationResult={mockInitResult}
+          />,
+        );
+      });
 
-      expect(mockedMeasureElement).not.toHaveBeenCalled();
+      // The sticky todo status change (pending → in_progress) must not alter
+      // the computed terminal height. This asserts on the behavioral outcome
+      // rather than the implementation detail of measureElement call count.
+      expect(capturedUIState.availableTerminalHeight).toBe(heightAfterSettle);
     });
   });
 


### PR DESCRIPTION
Fixes #4415

## What

Stabilizes a flaky CI test in `AppContainer.test.tsx` — *"does not remeasure footer height for sticky todo status-only updates"* was intermittently failing on the macOS/Windows runners.

## Background

A first attempt (#4415, already merged) replaced the absolute `mock.calls.length` baseline with `mockClear()` + `not.toHaveBeenCalled()`. That fix was still flaky on the Windows CI runner because `useLayoutEffect` legitimately fires on rerender for reasons unrelated to sticky-todo status (buffer ref churn, `btwItem` updates), so any strict call-count assertion remains environment-dependent.

## Change

This PR switches to a behavioral assertion that tolerates legitimate effect runs but still catches the regression the test is meant to guard:

1. **`act()` wrapping + explicit settle rerender** — flushes React 19 + Ink async `useLayoutEffect` timing so the baseline is stable before the status-only rerender.
2. **Assert on `availableTerminalHeight` equality** (read from `UIStateContext`) instead of `measureElement` call count — the behavioral outcome is what actually matters.
3. **Swap the mocked `measureElement` height between settle and rerender** — without this, the production same-value short-circuit on `setControlsHeight` would hide the regression. With the swap, any re-measurement during the status-only rerender changes `controlsHeight` and breaks the equality assertion.
4. **Per-test `mockConfig.initialize` stub** — `makeFakeConfig().initialize()` rejects on React's double-mount, leaking async renders into footer-measurement timing. The stub is scoped to this one test (not `beforeEach`) so other tests in the block still exercise the real init gate.

The core layout-key contract ("status-only changes return the same key") is **already directly covered by [`todoSnapshot.test.ts:253-255`](packages/cli/src/ui/utils/todoSnapshot.test.ts#L253)**. This integration test provides layered protection on top of that unit test.

## Verification

- Ran the targeted test 5× consecutively — all passed.
- Ran the full `AppContainer.test.tsx` suite (77 tests) — all passed.
- Lint clean.

## Review feedback addressed

Thanks @LaZzyMan for the careful review. Addressing each point in commit 25a5a91:

- **(high) Assertion silently accepts the regression** — Added the `measureElement` mock-height swap between settle and rerender, so the equality assertion now actually distinguishes "optimization works" from "optimization regresses" (in environments where `useLayoutEffect` would re-fire). The most direct regression protection still lives in `todoSnapshot.test.ts` — this test is layered protection.
- **(high) Global `initialize` stub flipped a config gate for ~75 tests** — Narrowed back to per-test scope. Removed from `beforeEach`; added inline only in the sticky-todo test that needs it.
- **(medium) PR description didn't match the diff** — Rewritten above to describe what was actually shipped and why.

<details>
<summary>中文说明</summary>

修复 `AppContainer.test.tsx` 中 *"does not remeasure footer height for sticky todo status-only updates"* 测试在 CI 上的偶现失败。

**背景**：#4415 首次尝试用 `mockClear()` + `not.toHaveBeenCalled()` 替代绝对调用次数断言，但在 Windows CI 上仍 flaky —— `useLayoutEffect` 会因为 buffer ref、btwItem 等合理原因在 rerender 时触发，任何严格的 call-count 断言都会受环境影响。

**改动**：
1. **`act()` wrapping + 显式 settle rerender** —— 在 React 19 + Ink 异步环境下 flush effect 时序，让 baseline 稳定。
2. **断言 `availableTerminalHeight` 等值**（从 `UIStateContext` 读取）替代 `measureElement` 调用次数 —— 行为结果才是关键。
3. **在 settle 和 rerender 之间切换 mocked `measureElement` 的返回 height** —— 不切换的话，生产代码里 `setControlsHeight` 的 same-value short-circuit 会让回归隐形；切换后，status-only rerender 触发的任何重测量都会改变 `controlsHeight`，打破等值断言。
4. **`mockConfig.initialize` 的 stub 缩到 per-test 范围** —— 不放到 `beforeEach`，避免污染同 describe block 下其他 ~75 个测试的 `isConfigInitialized` 分支。

核心 layout-key 契约（"status-only change 返回相同 key"）已在 [`todoSnapshot.test.ts:253-255`](packages/cli/src/ui/utils/todoSnapshot.test.ts#L253) 单元测试中直接覆盖，本集成测试是叠加保护。

**回应 @LaZzyMan 的 review**（commit 25a5a91）：
- **(high) 新断言无法检测回归** —— 增加 measureElement mock height 切换，使等值断言在能触发 effect 的环境下真正区分"优化生效"与"优化回退"。根本的回归保护仍在 `todoSnapshot.test.ts`。
- **(high) 全局 initialize stub 影响 ~75 个测试** —— 已缩到 per-test 范围。
- **(medium) PR 描述与 diff 不符** —— 已重写描述匹配实际改动。

</details>