### PR TITLE
fix(extension): redact credentialed source diagnostics

### DIFF
--- a/packages/cli/src/commands/extensions/utils.test.ts
+++ b/packages/cli/src/commands/extensions/utils.test.ts
@@ -13,13 +13,16 @@ const mockExtensionManagerInstance = {
   refreshCache: mockRefreshCache,
 };
 
-vi.mock('@qwen-code/qwen-code-core', () => ({
-  ExtensionManager: vi
-    .fn()
-    .mockImplementation(() => mockExtensionManagerInstance),
-  redactUrlCredentials: (source: string) =>
-    source.replace(/\/\/[^@]+@/, '//***REDACTED***@'),
-}));
+vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
+  return {
+    ...actual,
+    ExtensionManager: vi
+      .fn()
+      .mockImplementation(() => mockExtensionManagerInstance),
+  };
+});
 
 vi.mock('../../config/settings.js', () => ({
   loadSettings: vi.fn().mockReturnValue({

--- a/packages/cli/src/commands/extensions/utils.test.ts
+++ b/packages/cli/src/commands/extensions/utils.test.ts
@@ -17,6 +17,8 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
   ExtensionManager: vi
     .fn()
     .mockImplementation(() => mockExtensionManagerInstance),
+  redactUrlCredentials: (source: string) =>
+    source.replace(/\/\/[^@]+@/, '//***REDACTED***@'),
 }));
 
 vi.mock('../../config/settings.js', () => ({
@@ -131,5 +133,27 @@ describe('extensionToOutputString', () => {
     );
 
     expect(resultWithoutInline).toEqual(resultWithInlineFalse);
+  });
+
+  it('should redact URL credentials in install source output', () => {
+    const extension = createMockExtension({
+      installMetadata: {
+        type: 'git',
+        source: 'https://user:token@example.com/owner/repo.git',
+      },
+    });
+
+    const result = extensionToOutputString(
+      extension,
+      mockExtensionManager,
+      '/workspace',
+      true,
+    );
+
+    expect(result).toContain(
+      'https://***REDACTED***@example.com/owner/repo.git',
+    );
+    expect(result).not.toContain('user');
+    expect(result).not.toContain('token');
   });
 });

--- a/packages/cli/src/commands/extensions/utils.ts
+++ b/packages/cli/src/commands/extensions/utils.ts
@@ -4,7 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ExtensionManager, type Extension } from '@qwen-code/qwen-code-core';
+import {
+  ExtensionManager,
+  redactUrlCredentials,
+  type Extension,
+} from '@qwen-code/qwen-code-core';
 import { loadSettings } from '../../config/settings.js';
 import {
   requestConsentOrFail,
@@ -51,7 +55,7 @@ export function extensionToOutputString(
   let output = `${inline ? '' : status} ${extension.config.name} (${extension.config.version})`;
   output += `\n ${t('Path:')} ${extension.path}`;
   if (extension.installMetadata) {
-    output += `\n ${t('Source:')} ${extension.installMetadata.source} (${t('Type:')} ${extension.installMetadata.type})`;
+    output += `\n ${t('Source:')} ${redactUrlCredentials(extension.installMetadata.source)} (${t('Type:')} ${extension.installMetadata.type})`;
     if (extension.installMetadata.ref) {
       output += `\n ${t('Ref:')} ${extension.installMetadata.ref}`;
     }

--- a/packages/cli/src/ui/commands/extensionsCommand.test.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.test.ts
@@ -194,6 +194,30 @@ describe('extensionsCommand', () => {
       expect(mockContext.ui.reloadCommands).toHaveBeenCalled();
     });
 
+    it('should redact URL credentials in install progress messages', async () => {
+      mockParseInstallSource.mockResolvedValue({
+        type: 'git',
+        source: 'https://user:token@example.com/test/extension',
+      });
+      mockInstallExtension.mockResolvedValue({
+        name: 'test-extension',
+        version: '1.0.0',
+      });
+
+      await installAction(
+        mockContext,
+        'https://user:token@example.com/test/extension',
+      );
+
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.INFO,
+          text: 'Installing extension from "https://***REDACTED***@example.com/test/extension"...',
+        },
+        expect.any(Number),
+      );
+    });
+
     it('should handle install errors', async () => {
       mockParseInstallSource.mockRejectedValue(
         new Error('Install source not found.'),
@@ -205,6 +229,27 @@ describe('extensionsCommand', () => {
         {
           type: MessageType.ERROR,
           text: 'Failed to install extension from "/invalid/path": Install source not found.',
+        },
+        expect.any(Number),
+      );
+    });
+
+    it('should redact URL credentials in install error messages and causes', async () => {
+      mockParseInstallSource.mockRejectedValue(
+        new Error(
+          'Install source not found: https://user:token@example.com/test/extension',
+        ),
+      );
+
+      await installAction(
+        mockContext,
+        'https://user:token@example.com/test/extension',
+      );
+
+      expect(mockContext.ui.addItem).toHaveBeenCalledWith(
+        {
+          type: MessageType.ERROR,
+          text: 'Failed to install extension from "https://***REDACTED***@example.com/test/extension": Install source not found: https://***REDACTED***@example.com/test/extension',
         },
         expect.any(Number),
       );

--- a/packages/cli/src/ui/commands/extensionsCommand.ts
+++ b/packages/cli/src/ui/commands/extensionsCommand.ts
@@ -16,6 +16,7 @@ import {
   ExtensionManager,
   parseInstallSource,
   createDebugLogger,
+  redactUrlCredentials,
 } from '@qwen-code/qwen-code-core';
 import open from 'open';
 
@@ -122,10 +123,13 @@ async function installAction(context: CommandContext, args: string) {
 
   try {
     const installMetadata = await parseInstallSource(source);
+    const redactedSource = redactUrlCredentials(source);
     context.ui.addItem(
       {
         type: MessageType.INFO,
-        text: t('Installing extension from "{{source}}"...', { source }),
+        text: t('Installing extension from "{{source}}"...', {
+          source: redactedSource,
+        }),
       },
       Date.now(),
     );
@@ -146,8 +150,8 @@ async function installAction(context: CommandContext, args: string) {
       {
         type: MessageType.ERROR,
         text: t('Failed to install extension from "{{source}}": {{error}}', {
-          source,
-          error: getErrorMessage(error),
+          source: redactUrlCredentials(source),
+          error: redactUrlCredentials(getErrorMessage(error)),
         }),
       },
       Date.now(),

--- a/packages/cli/src/ui/components/extensions/steps/ExtensionDetailStep.tsx
+++ b/packages/cli/src/ui/components/extensions/steps/ExtensionDetailStep.tsx
@@ -6,7 +6,10 @@
 
 import { Box, Text } from 'ink';
 import { theme } from '../../../semantic-colors.js';
-import { type Extension } from '@qwen-code/qwen-code-core';
+import {
+  redactUrlCredentials,
+  type Extension,
+} from '@qwen-code/qwen-code-core';
 import { t } from '../../../../i18n/index.js';
 
 interface ExtensionDetailStepProps {
@@ -68,7 +71,7 @@ export const ExtensionDetailStep = ({
             <Box width={LABEL_WIDTH} flexShrink={0}>
               <Text color={theme.text.primary}>{t('Source:')}</Text>
             </Box>
-            <Text>{ext.installMetadata.source}</Text>
+            <Text>{redactUrlCredentials(ext.installMetadata.source)}</Text>
           </Box>
         )}
 

--- a/packages/core/src/extension/extensionManager.ts
+++ b/packages/core/src/extension/extensionManager.ts
@@ -1303,7 +1303,7 @@ export class ExtensionManager {
       } catch (e) {
         callback(extension.name, ExtensionUpdateState.ERROR);
         throw new Error(
-          `Updated extension not found after installation, got error:\n${e}`,
+          `Updated extension not found after installation, got error:\n${redactUrlCredentials(getErrorMessage(e))}`,
         );
       }
       const updatedVersion = updatedExtension.version;

--- a/packages/core/src/extension/extensionManager.ts
+++ b/packages/core/src/extension/extensionManager.ts
@@ -40,6 +40,7 @@ import {
   parseGitHubRepoForReleases,
 } from './github.js';
 import { downloadFromNpmRegistry } from './npm.js';
+import { redactUrlCredentials } from './redaction.js';
 import type { LoadExtensionContext } from './variableSchema.js';
 import { Override, type AllExtensionsEnablementConfig } from './override.js';
 import {
@@ -847,6 +848,7 @@ export class ExtensionManager {
       this.telemetrySettings,
     );
     let extension: Extension | null;
+    const redactedInstallSource = redactUrlCredentials(installMetadata.source);
 
     const isUpdate = !!previousExtensionConfig;
     let newExtensionConfig: ExtensionConfig | null = null;
@@ -855,7 +857,7 @@ export class ExtensionManager {
     try {
       if (!this.isWorkspaceTrusted) {
         throw new Error(
-          `Could not install extension from untrusted folder at ${installMetadata.source}`,
+          `Could not install extension from untrusted folder at ${redactedInstallSource}`,
         );
       }
 
@@ -1100,7 +1102,7 @@ export class ExtensionManager {
             new ExtensionInstallEvent(
               newExtensionConfig.name,
               newExtensionConfig!.version,
-              installMetadata.source,
+              redactUrlCredentials(installMetadata.source),
               'success',
             ),
           );
@@ -1155,7 +1157,7 @@ export class ExtensionManager {
           new ExtensionInstallEvent(
             newExtensionConfig?.name ?? '',
             newExtensionConfig?.version ?? '',
-            installMetadata.source,
+            redactUrlCredentials(installMetadata.source),
             'error',
           ),
         );

--- a/packages/core/src/extension/github.test.ts
+++ b/packages/core/src/extension/github.test.ts
@@ -24,6 +24,7 @@ import {
   type Extension,
   type ExtensionManager,
 } from './extensionManager.js';
+import { getErrorMessage } from '../utils/errors.js';
 
 const mockPlatform = vi.hoisted(() => vi.fn());
 const mockArch = vi.hoisted(() => vi.fn());
@@ -165,6 +166,32 @@ describe('git extension helpers', () => {
         await cloneFromGit(installMetadata, destination);
       } catch (error: unknown) {
         message = String(error);
+      }
+
+      expect(message).toContain(
+        'https://***REDACTED***@my-repo.com/org/repo.git',
+      );
+      expect(message).not.toContain('user');
+      expect(message).not.toContain('token');
+    });
+
+    it('should redact URL credentials in clone failure causes', async () => {
+      const installMetadata = {
+        source: 'https://user:token@my-repo.com/org/repo.git',
+        type: 'git' as const,
+      };
+      const destination = '/dest';
+      mockGit.clone.mockRejectedValue(
+        new Error(
+          "fatal: Authentication failed for 'https://user:token@my-repo.com/org/repo.git'",
+        ),
+      );
+
+      let message = '';
+      try {
+        await cloneFromGit(installMetadata, destination);
+      } catch (error: unknown) {
+        message = getErrorMessage(error);
       }
 
       expect(message).toContain(

--- a/packages/core/src/extension/github.test.ts
+++ b/packages/core/src/extension/github.test.ts
@@ -201,6 +201,42 @@ describe('git extension helpers', () => {
       expect(message).not.toContain('token');
     });
 
+    it('should preserve clone failure cause diagnostics while redacting its message', async () => {
+      const installMetadata = {
+        source: 'https://user:token@my-repo.com/org/repo.git',
+        type: 'git' as const,
+      };
+      const destination = '/dest';
+      const gitError = Object.assign(
+        new Error(
+          "fatal: Authentication failed for 'https://user:token@my-repo.com/org/repo.git'",
+        ),
+        {
+          code: 'ENOTFOUND',
+          task: { commands: ['clone'] },
+        },
+      );
+      mockGit.clone.mockRejectedValue(gitError);
+
+      let cause: unknown;
+      try {
+        await cloneFromGit(installMetadata, destination);
+      } catch (error: unknown) {
+        cause = error instanceof Error ? error.cause : undefined;
+      }
+
+      expect(cause).toBeInstanceOf(Error);
+      expect(cause).not.toBe(gitError);
+      expect((cause as Error).message).toContain(
+        'https://***REDACTED***@my-repo.com/org/repo.git',
+      );
+      expect((cause as Error).message).not.toContain('user');
+      expect((cause as { code?: string }).code).toBe('ENOTFOUND');
+      expect((cause as { task?: { commands: string[] } }).task).toEqual({
+        commands: ['clone'],
+      });
+    });
+
     it('should throw on clone error', async () => {
       const installMetadata = {
         source: 'http://my-repo.com',

--- a/packages/core/src/extension/github.test.ts
+++ b/packages/core/src/extension/github.test.ts
@@ -152,6 +152,28 @@ describe('git extension helpers', () => {
       );
     });
 
+    it('should redact URL credentials in clone failures', async () => {
+      const installMetadata = {
+        source: 'https://user:token@my-repo.com/org/repo.git',
+        type: 'git' as const,
+      };
+      const destination = '/dest';
+      mockGit.getRemotes.mockResolvedValue([]);
+
+      let message = '';
+      try {
+        await cloneFromGit(installMetadata, destination);
+      } catch (error: unknown) {
+        message = String(error);
+      }
+
+      expect(message).toContain(
+        'https://***REDACTED***@my-repo.com/org/repo.git',
+      );
+      expect(message).not.toContain('user');
+      expect(message).not.toContain('token');
+    });
+
     it('should throw on clone error', async () => {
       const installMetadata = {
         source: 'http://my-repo.com',
@@ -418,6 +440,23 @@ describe('git extension helpers', () => {
       expect(() => parseGitHubRepoForReleases(source)).toThrow(
         'Invalid GitHub repository source: https://example.com/owner/repo.git. Expected "owner/repo" or a github repo uri.',
       );
+    });
+
+    it('should redact URL credentials in invalid source errors', () => {
+      const source = 'https://user:token@example.com/owner/repo.git';
+
+      let message = '';
+      try {
+        parseGitHubRepoForReleases(source);
+      } catch (error: unknown) {
+        message = String(error);
+      }
+
+      expect(message).toContain(
+        'https://***REDACTED***@example.com/owner/repo.git',
+      );
+      expect(message).not.toContain('user');
+      expect(message).not.toContain('token');
     });
 
     it('should parse owner and repo from a shorthand string', () => {

--- a/packages/core/src/extension/github.ts
+++ b/packages/core/src/extension/github.ts
@@ -43,6 +43,20 @@ export interface GitHubDownloadResult {
   type: 'git' | 'github-release';
 }
 
+function createRedactedErrorCause(error: unknown, message: string): Error {
+  if (!(error instanceof Error)) {
+    return new Error(message);
+  }
+  const cause = Object.create(Object.getPrototypeOf(error)) as Error;
+  Object.defineProperties(cause, Object.getOwnPropertyDescriptors(error));
+  Object.defineProperty(cause, 'message', {
+    value: message,
+    configurable: true,
+    writable: true,
+  });
+  return cause;
+}
+
 function getGitHubToken(): string | undefined {
   return process.env['GITHUB_TOKEN'];
 }
@@ -105,7 +119,7 @@ export async function cloneFromGit(
     throw new Error(
       `Failed to clone Git repository from ${redactedSource} ${redactedErrorMessage}`,
       {
-        cause: new Error(redactedErrorMessage),
+        cause: createRedactedErrorCause(error, redactedErrorMessage),
       },
     );
   }

--- a/packages/core/src/extension/github.ts
+++ b/packages/core/src/extension/github.ts
@@ -22,6 +22,7 @@ import {
 } from './extensionManager.js';
 import type { ExtensionInstallMetadata } from '../config/config.js';
 import { checkNpmUpdate } from './npm.js';
+import { redactUrlCredentials } from './redaction.js';
 
 const debugLogger = createDebugLogger('EXT_GITHUB');
 
@@ -55,6 +56,7 @@ export async function cloneFromGit(
   installMetadata: ExtensionInstallMetadata,
   destination: string,
 ): Promise<void> {
+  const redactedSource = redactUrlCredentials(installMetadata.source);
   try {
     const git = simpleGit(destination);
     let sourceUrl = installMetadata.source;
@@ -88,9 +90,7 @@ export async function cloneFromGit(
 
     const remotes = await git.getRemotes(true);
     if (remotes.length === 0) {
-      throw new Error(
-        `Unable to find any remotes for repo ${installMetadata.source}`,
-      );
+      throw new Error(`Unable to find any remotes for repo ${redactedSource}`);
     }
 
     const refToFetch = installMetadata.ref || 'HEAD';
@@ -102,7 +102,7 @@ export async function cloneFromGit(
     await git.checkout('FETCH_HEAD');
   } catch (error) {
     throw new Error(
-      `Failed to clone Git repository from ${installMetadata.source} ${getErrorMessage(error)}`,
+      `Failed to clone Git repository from ${redactedSource} ${redactUrlCredentials(getErrorMessage(error))}`,
       {
         cause: error,
       },
@@ -120,7 +120,7 @@ export function parseGitHubRepoForReleases(source: string): {
   const parts = parsedUrl?.pathname.substring(1).split('/');
   if (parts?.length !== 2 || parsedUrl?.host !== 'github.com') {
     throw new Error(
-      `Invalid GitHub repository source: ${source}. Expected "owner/repo" or a github repo uri.`,
+      `Invalid GitHub repository source: ${redactUrlCredentials(source)}. Expected "owner/repo" or a github repo uri.`,
     );
   }
   const owner = parts[0];
@@ -158,14 +158,14 @@ export async function checkForExtensionUpdate(
       });
     } catch (e) {
       debugLogger.error(
-        `Failed to check for update for local extension "${extension.name}". Could not load extension from source path: ${installMetadata.source}. Error: ${getErrorMessage(e)}`,
+        `Failed to check for update for local extension "${extension.name}". Could not load extension from source path: ${redactUrlCredentials(installMetadata.source)}. Error: ${redactUrlCredentials(getErrorMessage(e))}`,
       );
       return ExtensionUpdateState.NOT_UPDATABLE;
     }
 
     if (!latestConfig) {
       debugLogger.error(
-        `Failed to check for update for local extension "${extension.name}". Could not load extension from source path: ${installMetadata.source}`,
+        `Failed to check for update for local extension "${extension.name}". Could not load extension from source path: ${redactUrlCredentials(installMetadata.source)}`,
       );
       return ExtensionUpdateState.NOT_UPDATABLE;
     }
@@ -244,7 +244,7 @@ export async function checkForExtensionUpdate(
     }
   } catch (error) {
     debugLogger.error(
-      `Failed to check for updates for extension "${installMetadata.source}": ${getErrorMessage(error)}`,
+      `Failed to check for updates for extension "${redactUrlCredentials(installMetadata.source)}": ${redactUrlCredentials(getErrorMessage(error))}`,
     );
     return ExtensionUpdateState.ERROR;
   }
@@ -353,7 +353,7 @@ export async function downloadFromGitHubRelease(
     };
   } catch (error) {
     throw new Error(
-      `Failed to download release from ${installMetadata.source}: ${getErrorMessage(error)}`,
+      `Failed to download release from ${redactUrlCredentials(installMetadata.source)}: ${redactUrlCredentials(getErrorMessage(error))}`,
     );
   }
 }

--- a/packages/core/src/extension/github.ts
+++ b/packages/core/src/extension/github.ts
@@ -101,10 +101,11 @@ export async function cloneFromGit(
     // This results in a detached HEAD state, which is fine for this purpose.
     await git.checkout('FETCH_HEAD');
   } catch (error) {
+    const redactedErrorMessage = redactUrlCredentials(getErrorMessage(error));
     throw new Error(
-      `Failed to clone Git repository from ${redactedSource} ${redactUrlCredentials(getErrorMessage(error))}`,
+      `Failed to clone Git repository from ${redactedSource} ${redactedErrorMessage}`,
       {
-        cause: error,
+        cause: new Error(redactedErrorMessage),
       },
     );
   }

--- a/packages/core/src/extension/index.ts
+++ b/packages/core/src/extension/index.ts
@@ -5,3 +5,4 @@ export * from './extensionSettings.js';
 export * from './marketplace.js';
 export * from './npm.js';
 export * from './claude-converter.js';
+export * from './redaction.js';

--- a/packages/core/src/extension/marketplace.ts
+++ b/packages/core/src/extension/marketplace.ts
@@ -13,6 +13,7 @@ import * as https from 'node:https';
 import { stat } from 'node:fs/promises';
 import { parseGitHubRepoForReleases } from './github.js';
 import { isScopedNpmPackage } from './npm.js';
+import { redactUrlCredentials } from './redaction.js';
 
 export interface MarketplaceInstallOptions {
   marketplaceUrl: string;
@@ -274,7 +275,7 @@ export async function parseInstallSource(
     }
   } else {
     // None of the above formats matched
-    throw new Error(`Install source not found: ${repo}`);
+    throw new Error(`Install source not found: ${redactUrlCredentials(repo)}`);
   }
 
   // Step 3: If marketplace config exists, update type to marketplace

--- a/packages/core/src/extension/npm.test.ts
+++ b/packages/core/src/extension/npm.test.ts
@@ -62,6 +62,23 @@ describe('parseNpmPackageSource', () => {
       'Invalid scoped npm package source',
     );
   });
+
+  it('should redact URL credentials in invalid source errors', () => {
+    const source = 'https://user:token@example.com/some-package';
+
+    let message = '';
+    try {
+      parseNpmPackageSource(source);
+    } catch (error: unknown) {
+      message = String(error);
+    }
+
+    expect(message).toContain(
+      'https://***REDACTED***@example.com/some-package',
+    );
+    expect(message).not.toContain('user');
+    expect(message).not.toContain('token');
+  });
 });
 
 describe('isScopedNpmPackage', () => {

--- a/packages/core/src/extension/npm.test.ts
+++ b/packages/core/src/extension/npm.test.ts
@@ -8,6 +8,7 @@ import {
   isScopedNpmPackage,
   resolveNpmRegistry,
   checkNpmUpdate,
+  downloadFromNpmRegistry,
 } from './npm.js';
 import type { ExtensionInstallMetadata } from '../config/config.js';
 import { ExtensionUpdateState } from './extensionManager.js';
@@ -189,6 +190,45 @@ function mockNpmRegistryResponse(data: object) {
     },
   );
 }
+
+function mockNpmRegistryStatus(statusCode: number) {
+  vi.mocked(https.get).mockImplementation(
+    (_url: unknown, _options: unknown, callback: unknown) => {
+      const mockRes = {
+        statusCode,
+        headers: {},
+        on: vi.fn(),
+      };
+      if (typeof callback === 'function') {
+        callback(mockRes as never);
+      }
+      return { on: vi.fn() } as never;
+    },
+  );
+}
+
+describe('downloadFromNpmRegistry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('redacts credentialed registry URLs in metadata request errors', async () => {
+    mockNpmRegistryStatus(404);
+
+    await expect(
+      downloadFromNpmRegistry(
+        {
+          source: '@scope/pkg',
+          type: 'npm',
+          registryUrl: 'https://user:token@registry.example.com',
+        },
+        '/tmp/qwen-extension',
+      ),
+    ).rejects.toThrow(
+      'npm registry request failed with status 404: https://***REDACTED***@registry.example.com/@scope%2fpkg',
+    );
+  });
+});
 
 describe('checkNpmUpdate', () => {
   beforeEach(() => {

--- a/packages/core/src/extension/npm.ts
+++ b/packages/core/src/extension/npm.ts
@@ -11,6 +11,7 @@ import * as tar from 'tar';
 import type { ExtensionInstallMetadata } from '../config/config.js';
 import { ExtensionUpdateState } from './extensionManager.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
+import { redactUrlCredentials } from './redaction.js';
 
 const debugLogger = createDebugLogger('EXT_NPM');
 
@@ -47,7 +48,9 @@ export function parseNpmPackageSource(source: string): {
   // First @ is the scope prefix, last @ (after scope/) is the version delimiter
   const match = source.match(/^(@[^/]+\/[^@]+)(?:@(.+))?$/);
   if (!match) {
-    throw new Error(`Invalid scoped npm package source: ${source}`);
+    throw new Error(
+      `Invalid scoped npm package source: ${redactUrlCredentials(source)}`,
+    );
   }
   return {
     name: match[1],
@@ -294,7 +297,9 @@ export async function downloadFromNpmRegistry(
   // Fetch package metadata
   const encodedName = name.replaceAll('/', '%2f');
   const metadataUrl = `${registryUrl}/${encodedName}`;
-  debugLogger.debug(`Fetching npm package metadata from ${metadataUrl}`);
+  debugLogger.debug(
+    `Fetching npm package metadata from ${redactUrlCredentials(metadataUrl)}`,
+  );
 
   const metadata = await fetchNpmJson<NpmPackageMetadata>(
     metadataUrl,
@@ -329,7 +334,7 @@ export async function downloadFromNpmRegistry(
 
   const tarballUrl = versionData.dist.tarball;
   debugLogger.debug(
-    `Downloading ${name}@${resolvedVersion} from ${tarballUrl}`,
+    `Downloading ${name}@${resolvedVersion} from ${redactUrlCredentials(tarballUrl)}`,
   );
 
   // Only send auth token if the tarball is hosted on the same registry host.
@@ -425,7 +430,7 @@ export async function checkNpmUpdate(
     return ExtensionUpdateState.UP_TO_DATE;
   } catch (error) {
     debugLogger.error(
-      `Failed to check npm update for "${installMetadata.source}": ${error}`,
+      `Failed to check npm update for "${redactUrlCredentials(installMetadata.source)}": ${redactUrlCredentials(String(error))}`,
     );
     return ExtensionUpdateState.ERROR;
   }

--- a/packages/core/src/extension/npm.ts
+++ b/packages/core/src/extension/npm.ts
@@ -211,7 +211,7 @@ function fetchNpmJson<T>(url: string, authToken?: string): Promise<T> {
         if (res.statusCode !== 200) {
           return reject(
             new Error(
-              `npm registry request failed with status ${res.statusCode}: ${url}`,
+              `npm registry request failed with status ${res.statusCode}: ${redactUrlCredentials(url)}`,
             ),
           );
         }

--- a/packages/core/src/extension/redaction.test.ts
+++ b/packages/core/src/extension/redaction.test.ts
@@ -26,6 +26,24 @@ describe('redactUrlCredentials', () => {
     ).toBe(`https://${REDACTED_URL_CREDENTIAL}@example.com/org/repo.git`);
   });
 
+  it('redacts unencoded at signs inside echoed URL credentials', () => {
+    expect(
+      redactUrlCredentials('https://email@gmail.com:tok@example.com/repo'),
+    ).toBe(`https://${REDACTED_URL_CREDENTIAL}@example.com/repo`);
+  });
+
+  it('redacts unencoded question marks inside echoed URL credentials', () => {
+    expect(redactUrlCredentials('https://user:gh?token@example.com/repo')).toBe(
+      `https://${REDACTED_URL_CREDENTIAL}@example.com/repo`,
+    );
+  });
+
+  it('redacts percent-encoded URL credentials', () => {
+    expect(
+      redactUrlCredentials('https://user%40mail:tok%3Fen@example.com/repo'),
+    ).toBe(`https://${REDACTED_URL_CREDENTIAL}@example.com/repo`);
+  });
+
   it('does not redact at signs after the URL path starts', () => {
     const source = 'https://example.com/path/@scope/package';
     expect(redactUrlCredentials(source)).toBe(source);

--- a/packages/core/src/extension/redaction.test.ts
+++ b/packages/core/src/extension/redaction.test.ts
@@ -20,6 +20,17 @@ describe('redactUrlCredentials', () => {
     ).toBe(`https://${REDACTED_URL_CREDENTIAL}@github.com/owner/repo`);
   });
 
+  it('redacts raw hash characters echoed in URL credentials', () => {
+    expect(
+      redactUrlCredentials('https://user:pass#word@example.com/org/repo.git'),
+    ).toBe(`https://${REDACTED_URL_CREDENTIAL}@example.com/org/repo.git`);
+  });
+
+  it('does not redact at signs after the URL path starts', () => {
+    const source = 'https://example.com/path/@scope/package';
+    expect(redactUrlCredentials(source)).toBe(source);
+  });
+
   it('redacts custom URL schemes used by extension sources', () => {
     expect(redactUrlCredentials('sso://user:token@example.com/org/repo')).toBe(
       `sso://${REDACTED_URL_CREDENTIAL}@example.com/org/repo`,

--- a/packages/core/src/extension/redaction.test.ts
+++ b/packages/core/src/extension/redaction.test.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { REDACTED_URL_CREDENTIAL, redactUrlCredentials } from './redaction.js';
+
+describe('redactUrlCredentials', () => {
+  it('redacts username and password from HTTPS URLs', () => {
+    expect(
+      redactUrlCredentials('https://user:token@example.com/org/repo.git'),
+    ).toBe(`https://${REDACTED_URL_CREDENTIAL}@example.com/org/repo.git`);
+  });
+
+  it('redacts token-only URL credentials', () => {
+    expect(
+      redactUrlCredentials('https://ghp_token@github.com/owner/repo'),
+    ).toBe(`https://${REDACTED_URL_CREDENTIAL}@github.com/owner/repo`);
+  });
+
+  it('redacts custom URL schemes used by extension sources', () => {
+    expect(redactUrlCredentials('sso://user:token@example.com/org/repo')).toBe(
+      `sso://${REDACTED_URL_CREDENTIAL}@example.com/org/repo`,
+    );
+  });
+
+  it('redacts credentialed URLs embedded in diagnostic messages', () => {
+    expect(
+      redactUrlCredentials(
+        'fatal: authentication failed for https://user:token@example.com/repo',
+      ),
+    ).toBe(
+      `fatal: authentication failed for https://${REDACTED_URL_CREDENTIAL}@example.com/repo`,
+    );
+  });
+
+  it('does not modify URLs without credentials', () => {
+    const source = 'https://github.com/owner/repo';
+    expect(redactUrlCredentials(source)).toBe(source);
+  });
+
+  it('does not throw for malformed or non-URL sources', () => {
+    expect(redactUrlCredentials('owner/repo')).toBe('owner/repo');
+    expect(redactUrlCredentials('https://')).toBe('https://');
+  });
+});

--- a/packages/core/src/extension/redaction.ts
+++ b/packages/core/src/extension/redaction.ts
@@ -6,7 +6,7 @@
 
 export const REDACTED_URL_CREDENTIAL = '***REDACTED***';
 
-const URL_CREDENTIALS_PATTERN = /\b([a-z][a-z0-9+.-]*:\/\/)([^/?\s@]+)@/gi;
+const URL_CREDENTIALS_PATTERN = /\b([a-z][a-z0-9+.-]*:\/\/)(?:[^/\s]+@)+/gi;
 
 /**
  * Redacts userinfo credentials from URL-like extension sources for logs,

--- a/packages/core/src/extension/redaction.ts
+++ b/packages/core/src/extension/redaction.ts
@@ -1,0 +1,22 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export const REDACTED_URL_CREDENTIAL = '***REDACTED***';
+
+const URL_CREDENTIALS_PATTERN = /\b([a-z][a-z0-9+.-]*:\/\/)([^/?#\s@]+)@/gi;
+
+/**
+ * Redacts userinfo credentials from URL-like extension sources for logs,
+ * telemetry, and display. This also handles diagnostic messages that contain
+ * credentialed URLs. The original source should still be preserved for
+ * installation and update operations.
+ */
+export function redactUrlCredentials(source: string): string {
+  return source.replace(
+    URL_CREDENTIALS_PATTERN,
+    `$1${REDACTED_URL_CREDENTIAL}@`,
+  );
+}

--- a/packages/core/src/extension/redaction.ts
+++ b/packages/core/src/extension/redaction.ts
@@ -6,7 +6,7 @@
 
 export const REDACTED_URL_CREDENTIAL = '***REDACTED***';
 
-const URL_CREDENTIALS_PATTERN = /\b([a-z][a-z0-9+.-]*:\/\/)([^/?#\s@]+)@/gi;
+const URL_CREDENTIALS_PATTERN = /\b([a-z][a-z0-9+.-]*:\/\/)([^/?\s@]+)@/gi;
 
 /**
  * Redacts userinfo credentials from URL-like extension sources for logs,


### PR DESCRIPTION
## Summary

- What changed: Redacts URL userinfo credentials before extension source values reach install/update diagnostics, debug logs, telemetry install events, and CLI/TUI extension detail output.
- Why it changed: Credentialed extension install sources can include tokens; those values should remain usable internally but must not be echoed back through logs or user-visible diagnostics.
- Reviewer focus: Confirm raw install metadata remains intact for install/update/uninstall matching while only display and diagnostic sinks receive redacted values.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/extension/redaction.test.ts src/extension/github.test.ts src/extension/npm.test.ts
  cd packages/cli && npx vitest run src/commands/extensions/utils.test.ts
  npm run build
  npm run typecheck
  npx eslint packages/core/src/extension/redaction.ts packages/core/src/extension/redaction.test.ts packages/core/src/extension/github.ts packages/core/src/extension/github.test.ts packages/core/src/extension/extensionManager.ts packages/core/src/extension/npm.ts packages/core/src/extension/npm.test.ts packages/core/src/extension/marketplace.ts packages/cli/src/commands/extensions/utils.ts packages/cli/src/commands/extensions/utils.test.ts packages/cli/src/ui/components/extensions/steps/ExtensionDetailStep.tsx
  ```
- Prompts / inputs used: Unit tests cover HTTPS token-only sources, username/password sources, custom schemes, embedded diagnostic messages, GitHub parse failures, git clone failures, npm parse failures, and CLI extension output.
- Expected result: Credential material such as usernames and tokens is replaced with `***REDACTED***`; non-credentialed sources are unchanged.
- Observed result: Core targeted tests passed, CLI targeted test passed, build passed, typecheck passed, targeted lint passed.
- Quickest reviewer verification path: Run the two targeted vitest commands above.
- Evidence: `packages/core` targeted vitest reported 3 files / 61 tests passed; `packages/cli` targeted vitest reported 1 file / 7 tests passed.

## Scope / Risk

- Main risk or tradeoff: The redaction helper intentionally only changes diagnostic/display strings; persisted install metadata and operational source URLs remain raw.
- Not covered / not validated: Full `npm run lint` is blocked locally because untracked `.worktrees/` and `claude-code/` directories are included by the root lint glob and produce unrelated errors.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | macOS | Windows | Linux |
| -------- | ----- | ------- | ----- |
| npm run  | tested | not tested | not tested |
| npx      | tested | not tested | not tested |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Local validation ran on macOS in this checkout.

## Linked Issues / Bugs

Fixes #4425