### PR TITLE
fix(core): prevent auto-skill creation from overwriting existing skills (#4437)

### DIFF
--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1775,6 +1775,8 @@ export async function loadCliConfig(
     enableAutoSkill: bareMode
       ? false
       : (settings.memory?.enableAutoSkill ?? false),
+    autoSkillCollisionStrategy: (settings.memory?.autoSkillCollisionStrategy ??
+      'rename') as 'rename' | 'skip' | 'overwrite',
     fastModel: settings.fastModel || undefined,
     // Use separated hooks if provided, otherwise fall back to merged hooks
     userHooks: bareMode

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1409,6 +1409,31 @@ const SETTINGS_SCHEMA = {
           'Enable background review for reusable project skills after tool-heavy sessions.',
         showInDialog: false,
       },
+      autoSkillCollisionStrategy: {
+        type: 'string',
+        label: 'Auto Skill Collision Strategy',
+        category: 'Memory',
+        requiresRestart: false,
+        default: 'rename',
+        options: [
+          {
+            value: 'rename',
+            label:
+              'Rename — append -2/-3/... (default, preserves existing skill)',
+          },
+          {
+            value: 'skip',
+            label: 'Skip — abort the write with a warning',
+          },
+          {
+            value: 'overwrite',
+            label: 'Overwrite — replace the existing file (legacy behaviour)',
+          },
+        ],
+        description:
+          "Behaviour when the auto-skill review agent writes to a SKILL.md that already exists. 'rename' (default) appends -2/-3/... so the existing skill is preserved; 'skip' aborts the write with a warning; 'overwrite' restores the pre-#4437 behaviour and silently replaces the existing file.",
+        showInDialog: false,
+      },
     },
   },
 

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -676,6 +676,13 @@ export interface ConfigParameters {
   /** Enable automatic project skill review after tool-heavy sessions. Defaults to false. */
   enableAutoSkill?: boolean;
   /**
+   * Strategy applied when the auto-skill review agent tries to write a
+   * SKILL.md to a path that already exists. Defaults to `'rename'` — append
+   * `-2`, `-3`, ... to the skill directory name so the existing skill is
+   * preserved. See issue #4437.
+   */
+  autoSkillCollisionStrategy?: 'rename' | 'skip' | 'overwrite';
+  /**
    * Lightweight model for background tasks (memory extraction, dream, /btw side questions).
    * When set and valid for the current auth type, forked agents use this model instead of
    * the main session model, reducing latency and cost.
@@ -938,6 +945,7 @@ export class Config {
   private readonly enableManagedAutoMemory: boolean;
   private readonly enableManagedAutoDream: boolean;
   private readonly enableAutoSkill: boolean;
+  private readonly autoSkillCollisionStrategy: 'rename' | 'skip' | 'overwrite';
   private fastModel?: string;
   private readonly disableAllHooks: boolean;
   private readonly stopHookBlockingCap: number;
@@ -1152,6 +1160,8 @@ export class Config {
     this.enableManagedAutoMemory = params.enableManagedAutoMemory ?? true;
     this.enableManagedAutoDream = params.enableManagedAutoDream ?? false;
     this.enableAutoSkill = params.enableAutoSkill ?? false;
+    this.autoSkillCollisionStrategy =
+      params.autoSkillCollisionStrategy ?? 'rename';
     this.fastModel = params.fastModel || undefined;
     this.disableAllHooks = params.disableAllHooks ?? false;
     this.stopHookBlockingCap = resolveStopHookBlockingCap(
@@ -3038,6 +3048,10 @@ export class Config {
 
   getAutoSkillEnabled(): boolean {
     return this.enableAutoSkill && !this.getBareMode();
+  }
+
+  getAutoSkillCollisionStrategy(): 'rename' | 'skip' | 'overwrite' {
+    return this.autoSkillCollisionStrategy;
   }
 
   /**

--- a/packages/core/src/memory/skillCollisionAwareWriteFile.test.ts
+++ b/packages/core/src/memory/skillCollisionAwareWriteFile.test.ts
@@ -1,0 +1,295 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Fix-verification tests for issue #4437.
+ *
+ * Exercises the wrapping `SkillCollisionAwareWriteFileTool` end-to-end:
+ * given a target path that already exists, the wrapper redirects the
+ * underlying WriteFileTool to a renamed sibling so the existing file is
+ * preserved.
+ *
+ * The key scenario the reporter cared about — an auto-skill clobbering a
+ * USER skill — is covered explicitly, since the guard's rename behaviour
+ * does not depend on the existing file's frontmatter.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { Config } from '../config/config.js';
+import { ApprovalMode } from '../config/config.js';
+import { WriteFileTool } from '../tools/write-file.js';
+import { SkillCollisionAwareWriteFileTool } from './skillCollisionAwareWriteFile.js';
+import { FileReadCache } from '../services/fileReadCache.js';
+import { StandardFileSystemService } from '../services/fileSystemService.js';
+import { createMockWorkspaceContext } from '../test-utils/mockWorkspaceContext.js';
+
+// The WriteFileTool's confirmation flow constructs a GeminiClient via
+// `getGeminiClient()`; mock it out so we don't pull in an LLM dependency.
+vi.mock('../core/client.js');
+// Telemetry loggers fire side effects; stub them.
+vi.mock('../telemetry/loggers.js', () => ({
+  logFileOperation: vi.fn(),
+  logToolCall: vi.fn(),
+}));
+
+const USER_SKILL_BODY = `---
+name: precious-user-skill
+description: Hand-written by a human; must not be lost
+---
+
+This skill was authored by the user. It has NO 'source: auto-skill'.
+`;
+
+const AUTO_SKILL_BODY = `---
+name: previously-auto
+description: Earlier auto-skill content
+source: auto-skill
+extracted_at: '2026-01-01T00:00:00.000Z'
+---
+
+Earlier auto-skill body.
+`;
+
+const NEW_CONTENT_FROM_AGENT = `---
+name: brand-new-skill
+description: Fresh content from this review run
+source: auto-skill
+extracted_at: '2026-05-22T00:00:00.000Z'
+---
+
+Brand-new body; should land at the renamed slot, not overwrite.
+`;
+
+function buildConfigStub(projectRoot: string): Config {
+  const fsService = new StandardFileSystemService();
+  const fileReadCache = new FileReadCache();
+  return {
+    getTargetDir: () => projectRoot,
+    getProjectRoot: () => projectRoot,
+    getApprovalMode: () => ApprovalMode.YOLO,
+    setApprovalMode: vi.fn(),
+    getFileSystemService: () => fsService,
+    getWorkspaceContext: () => createMockWorkspaceContext(projectRoot),
+    getFileReadCache: () => fileReadCache,
+    // Skip the prior-read TOCTOU check — the auto-skill agent never reads
+    // a brand-new SKILL.md before writing it, and existence of the prior
+    // file is the very signal the wrapper acts on.
+    getFileReadCacheDisabled: () => true,
+    getDefaultFileEncoding: () => 'utf-8',
+    getDebugMode: () => false,
+    getGeminiClient: vi.fn(),
+    getFileHistoryService: () => ({ trackEdit: vi.fn() }),
+  } as unknown as Config;
+}
+
+describe('SkillCollisionAwareWriteFileTool (issue #4437)', () => {
+  let tempDir: string;
+  let projectRoot: string;
+  let config: Config;
+  let inner: WriteFileTool;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'skill-wrap-'));
+    projectRoot = path.join(tempDir, 'project');
+    await fs.mkdir(projectRoot, { recursive: true });
+    config = buildConfigStub(projectRoot);
+    inner = new WriteFileTool(config);
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  // ─── PRIMARY FIX SCENARIO ─────────────────────────────────────────────
+  // Reporter's worst case: auto-skill creation clobbers a user-authored
+  // skill. After the fix, the original file is preserved and the new
+  // content lands at `<name>-2/SKILL.md`.
+
+  it('preserves a USER skill when the agent writes to its path (rename strategy)', async () => {
+    const skillName = 'precious-user-skill';
+    const userPath = path.join(
+      projectRoot,
+      '.qwen',
+      'skills',
+      skillName,
+      'SKILL.md',
+    );
+    await fs.mkdir(path.dirname(userPath), { recursive: true });
+    await fs.writeFile(userPath, USER_SKILL_BODY, 'utf-8');
+
+    const tool = new SkillCollisionAwareWriteFileTool(
+      inner,
+      projectRoot,
+      'rename',
+    );
+    const invocation = tool.build({
+      file_path: userPath,
+      content: NEW_CONTENT_FROM_AGENT,
+    });
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+
+    // (a) The original user file is intact.
+    const preserved = await fs.readFile(userPath, 'utf-8');
+    expect(preserved).toBe(USER_SKILL_BODY);
+
+    // (b) The new skill ended up at <name>-2/SKILL.md.
+    const renamedPath = path.join(
+      projectRoot,
+      '.qwen',
+      'skills',
+      `${skillName}-2`,
+      'SKILL.md',
+    );
+    const renamedContent = await fs.readFile(renamedPath, 'utf-8');
+    expect(renamedContent).toBe(NEW_CONTENT_FROM_AGENT);
+
+    // (c) The tool result advertises the rename so the agent sees what happened.
+    const llm =
+      typeof result.llmContent === 'string'
+        ? result.llmContent
+        : JSON.stringify(result.llmContent);
+    expect(llm).toMatch(/collision/i);
+    expect(llm).toContain(renamedPath);
+  });
+
+  // ─── AUTO-SKILL CLOBBER ───────────────────────────────────────────────
+  // Same rename behaviour applies when the existing file is itself an
+  // auto-skill — i.e. one auto-skill review trying to overwrite another.
+
+  it('preserves an existing AUTO-skill when the agent writes to its path', async () => {
+    const skillName = 'previously-auto';
+    const target = path.join(
+      projectRoot,
+      '.qwen',
+      'skills',
+      skillName,
+      'SKILL.md',
+    );
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, AUTO_SKILL_BODY, 'utf-8');
+
+    const tool = new SkillCollisionAwareWriteFileTool(
+      inner,
+      projectRoot,
+      'rename',
+    );
+    const result = await tool
+      .build({ file_path: target, content: NEW_CONTENT_FROM_AGENT })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    const preserved = await fs.readFile(target, 'utf-8');
+    expect(preserved).toBe(AUTO_SKILL_BODY);
+    const renamed = await fs.readFile(
+      path.join(projectRoot, '.qwen', 'skills', `${skillName}-2`, 'SKILL.md'),
+      'utf-8',
+    );
+    expect(renamed).toBe(NEW_CONTENT_FROM_AGENT);
+  });
+
+  // ─── HAPPY PATH ───────────────────────────────────────────────────────
+  // Writes to a non-existing path are passthrough — no rename, no log.
+
+  it('writes directly when the target path does not exist', async () => {
+    const target = path.join(
+      projectRoot,
+      '.qwen',
+      'skills',
+      'brand-new-skill',
+      'SKILL.md',
+    );
+
+    const tool = new SkillCollisionAwareWriteFileTool(
+      inner,
+      projectRoot,
+      'rename',
+    );
+    const result = await tool
+      .build({ file_path: target, content: NEW_CONTENT_FROM_AGENT })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    const written = await fs.readFile(target, 'utf-8');
+    expect(written).toBe(NEW_CONTENT_FROM_AGENT);
+    const llm =
+      typeof result.llmContent === 'string'
+        ? result.llmContent
+        : JSON.stringify(result.llmContent);
+    expect(llm).not.toMatch(/collision/i);
+  });
+
+  // ─── SKIP STRATEGY ────────────────────────────────────────────────────
+
+  it("'skip' strategy aborts the write and surfaces a structured error", async () => {
+    const target = path.join(
+      projectRoot,
+      '.qwen',
+      'skills',
+      'precious',
+      'SKILL.md',
+    );
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, USER_SKILL_BODY, 'utf-8');
+
+    const tool = new SkillCollisionAwareWriteFileTool(
+      inner,
+      projectRoot,
+      'skip',
+    );
+    const result = await tool
+      .build({ file_path: target, content: NEW_CONTENT_FROM_AGENT })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeDefined();
+    expect(result.error?.message).toMatch(/already exists/);
+    // Original untouched.
+    expect(await fs.readFile(target, 'utf-8')).toBe(USER_SKILL_BODY);
+    // No sibling was created.
+    await expect(
+      fs.access(
+        path.join(projectRoot, '.qwen', 'skills', 'precious-2', 'SKILL.md'),
+      ),
+    ).rejects.toThrow();
+  });
+
+  // ─── OVERWRITE STRATEGY ───────────────────────────────────────────────
+  // Provided for users who explicitly opt back into the pre-fix behaviour.
+
+  it("'overwrite' strategy preserves the pre-fix behaviour and clobbers the existing file", async () => {
+    const target = path.join(
+      projectRoot,
+      '.qwen',
+      'skills',
+      'override-me',
+      'SKILL.md',
+    );
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await fs.writeFile(target, AUTO_SKILL_BODY, 'utf-8');
+
+    const tool = new SkillCollisionAwareWriteFileTool(
+      inner,
+      projectRoot,
+      'overwrite',
+    );
+    const result = await tool
+      .build({ file_path: target, content: NEW_CONTENT_FROM_AGENT })
+      .execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(await fs.readFile(target, 'utf-8')).toBe(NEW_CONTENT_FROM_AGENT);
+    // No rename happened.
+    await expect(
+      fs.access(
+        path.join(projectRoot, '.qwen', 'skills', 'override-me-2', 'SKILL.md'),
+      ),
+    ).rejects.toThrow();
+  });
+});

--- a/packages/core/src/memory/skillCollisionAwareWriteFile.ts
+++ b/packages/core/src/memory/skillCollisionAwareWriteFile.ts
@@ -1,0 +1,228 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A `write_file` tool that wraps the real {@link WriteFileTool} and applies
+ * the auto-skill collision guard before the underlying write executes
+ * (issue #4437).
+ *
+ * Behaviour:
+ *  - When the agent writes to a path that is NOT a project SKILL.md slot,
+ *    the wrapper is a passthrough — generic file writes are unchanged.
+ *  - When the agent writes to a SKILL.md slot that does not yet exist,
+ *    the wrapper is also a passthrough.
+ *  - When the SKILL.md slot already exists, the wrapper consults the
+ *    configured {@link SkillCollisionStrategy}:
+ *      `rename`    → rewrite the path to the next free `<name>-N/` slot
+ *      `skip`      → return a skip result without touching disk
+ *      `overwrite` → behave like the real WriteFileTool (legacy behaviour)
+ *
+ * The wrapper deliberately lives at the skill-write boundary rather than
+ * inside the generic `write_file` tool: every other caller of write_file
+ * (edits, scratch files, etc.) intentionally relies on overwrite
+ * semantics, so the guard is opt-in via the skill-review scoped config.
+ */
+
+import type { Config } from '../config/config.js';
+import {
+  BaseDeclarativeTool,
+  BaseToolInvocation,
+  Kind,
+} from '../tools/tools.js';
+import type {
+  ToolInvocation,
+  ToolResult,
+  ToolLocation,
+} from '../tools/tools.js';
+import type { PermissionDecision } from '../permissions/types.js';
+import { ToolNames, ToolDisplayNames } from '../tools/tool-names.js';
+import {
+  WriteFileTool,
+  type WriteFileToolParams,
+} from '../tools/write-file.js';
+import { ToolErrorType } from '../tools/tool-error.js';
+import type { ToolRegistry } from '../tools/tool-registry.js';
+import {
+  resolveSkillCollision,
+  type SkillCollisionStrategy,
+} from './skillCollisionGuard.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
+
+const debugLogger = createDebugLogger('SKILL_COLLISION_GUARD');
+
+/**
+ * Invocation that defers all on-disk work to the inner WriteFileTool's
+ * invocation, but interposes a collision check at execute() time. The
+ * collision check requires async filesystem stat calls so it cannot run in
+ * the synchronous `createInvocation` path.
+ */
+class SkillCollisionAwareWriteFileInvocation extends BaseToolInvocation<
+  WriteFileToolParams,
+  ToolResult
+> {
+  constructor(
+    private readonly inner: WriteFileTool,
+    private readonly projectRoot: string,
+    private readonly strategy: SkillCollisionStrategy,
+    params: WriteFileToolParams,
+  ) {
+    super(params);
+  }
+
+  override toolLocations(): ToolLocation[] {
+    return [{ path: this.params.file_path }];
+  }
+
+  override getDescription(): string {
+    // Cannot resolve the rename synchronously — describe the proposed write
+    // as the agent requested it. The eventual execute() result includes the
+    // final on-disk path so the caller still gets the truth post-write.
+    return `Writing skill to ${this.params.file_path}`;
+  }
+
+  override getDefaultPermission(): Promise<PermissionDecision> {
+    // The skill-review scope runs in YOLO + scoped PermissionManager, which
+    // already governs path access. Matching the inner tool's "ask" default
+    // is unnecessary here; allow lets the scoped PM be the single source
+    // of truth for this code path.
+    return Promise.resolve('allow');
+  }
+
+  override async execute(signal: AbortSignal): Promise<ToolResult> {
+    const resolution = await resolveSkillCollision(
+      this.params.file_path,
+      this.strategy,
+      this.projectRoot,
+    );
+
+    if (resolution.action === 'skip') {
+      debugLogger.info(
+        `Skipped auto-skill write to ${resolution.originalFilePath}: ${resolution.reason}`,
+      );
+      return {
+        llmContent: resolution.reason,
+        returnDisplay: resolution.reason,
+        error: {
+          message: resolution.reason,
+          type: ToolErrorType.FILE_WRITE_FAILURE,
+        },
+      };
+    }
+
+    const finalParams: WriteFileToolParams = {
+      ...this.params,
+      file_path: resolution.filePath,
+    };
+
+    // Delegate to the inner WriteFileTool. Validation runs again on the
+    // adjusted path so any path-level errors (e.g. directory targets) are
+    // surfaced through the inner tool's structured error contract instead
+    // of being swallowed here.
+    const innerInvocation = this.inner.build(finalParams);
+    const result = await innerInvocation.execute(signal);
+
+    if (resolution.renamedFrom && !result.error) {
+      const notice =
+        `Skill name collision: "${resolution.renamedFrom}" already exists. ` +
+        `Wrote new skill to "${resolution.filePath}" instead.`;
+      debugLogger.warn(notice);
+      // Surface the rename through the tool result. The skill-review agent
+      // (and `runForkedAgent`'s `filesTouched` aggregation) consult both
+      // `llmContent` and `returnDisplay` — append, don't replace.
+      const annotated = `${notice}\n\n${result.llmContent ?? ''}`.trimEnd();
+      return {
+        ...result,
+        llmContent: annotated,
+        returnDisplay:
+          typeof result.returnDisplay === 'string'
+            ? `${notice}\n\n${result.returnDisplay}`.trimEnd()
+            : result.returnDisplay,
+      };
+    }
+
+    return result;
+  }
+}
+
+/**
+ * The wrapping declarative tool. Schema and metadata mirror the inner tool
+ * so the agent sees an identical function declaration — only execute()
+ * behaviour differs.
+ */
+export class SkillCollisionAwareWriteFileTool extends BaseDeclarativeTool<
+  WriteFileToolParams,
+  ToolResult
+> {
+  static readonly Name: string = ToolNames.WRITE_FILE;
+
+  constructor(
+    private readonly inner: WriteFileTool,
+    private readonly projectRoot: string,
+    private readonly strategy: SkillCollisionStrategy,
+  ) {
+    super(
+      inner.name,
+      // displayName intentionally falls back to the inner tool's user-facing
+      // label so confirmation surfaces stay consistent.
+      inner.displayName ?? ToolDisplayNames.WRITE_FILE,
+      inner.description,
+      Kind.Edit,
+      inner.parameterSchema,
+      inner.isOutputMarkdown,
+      inner.canUpdateOutput,
+      inner.shouldDefer,
+      inner.alwaysLoad,
+      inner.searchHint,
+    );
+  }
+
+  override validateToolParams(params: WriteFileToolParams): string | null {
+    return this.inner.validateToolParams(params);
+  }
+
+  protected createInvocation(
+    params: WriteFileToolParams,
+  ): ToolInvocation<WriteFileToolParams, ToolResult> {
+    return new SkillCollisionAwareWriteFileInvocation(
+      this.inner,
+      this.projectRoot,
+      this.strategy,
+      params,
+    );
+  }
+
+  override toAutoClassifierInput(
+    params: WriteFileToolParams,
+  ): Record<string, unknown> | string | undefined {
+    return this.inner.toAutoClassifierInput(params);
+  }
+}
+
+/**
+ * Replace `write_file` in the registry with the collision-aware wrapper.
+ *
+ * Idempotent: re-registering the same tool name overwrites the prior
+ * factory (the tool registry's documented behaviour for built-ins).
+ *
+ * `config` is the scope the inner WriteFileTool should bind to — usually
+ * the YOLO override created by `runForkedAgent`. The wrapper itself holds
+ * no Config reference; all path-resolution context comes from `projectRoot`.
+ */
+export function installSkillCollisionGuard(
+  registry: ToolRegistry,
+  config: Config,
+  projectRoot: string,
+  strategy: SkillCollisionStrategy,
+): void {
+  if (strategy === 'overwrite') {
+    // Explicit opt-out — leave the original WriteFileTool in place.
+    return;
+  }
+  registry.registerFactory(ToolNames.WRITE_FILE, async () => {
+    const inner = new WriteFileTool(config);
+    return new SkillCollisionAwareWriteFileTool(inner, projectRoot, strategy);
+  });
+}

--- a/packages/core/src/memory/skillCollisionGuard.test.ts
+++ b/packages/core/src/memory/skillCollisionGuard.test.ts
@@ -1,0 +1,225 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Unit tests for the auto-skill collision guard (issue #4437).
+ *
+ * These cover the pure functions in `skillCollisionGuard.ts`. The wrapping
+ * tool (`SkillCollisionAwareWriteFileTool`) is exercised end-to-end in
+ * `skillCollisionAwareWriteFile.test.ts`.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  findNextAvailableSkillPath,
+  isSkillMdPath,
+  listExistingProjectSkillNames,
+  resolveSkillCollision,
+} from './skillCollisionGuard.js';
+
+async function writeSkill(
+  projectRoot: string,
+  skillName: string,
+  body = 'placeholder\n',
+): Promise<string> {
+  const skillDir = path.join(projectRoot, '.qwen', 'skills', skillName);
+  await fs.mkdir(skillDir, { recursive: true });
+  const filePath = path.join(skillDir, 'SKILL.md');
+  await fs.writeFile(filePath, body, 'utf-8');
+  return filePath;
+}
+
+describe('skillCollisionGuard', () => {
+  let tempDir: string;
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'skill-collision-'));
+    projectRoot = path.join(tempDir, 'project');
+    await fs.mkdir(projectRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  describe('isSkillMdPath', () => {
+    it('returns true for <root>/.qwen/skills/<name>/SKILL.md', () => {
+      const target = path.join(
+        projectRoot,
+        '.qwen',
+        'skills',
+        'foo',
+        'SKILL.md',
+      );
+      expect(isSkillMdPath(target, projectRoot)).toBe(true);
+    });
+
+    it('returns false for nested files under the skill directory', () => {
+      // Auxiliary files (attachments / references) flow through unchanged.
+      const target = path.join(
+        projectRoot,
+        '.qwen',
+        'skills',
+        'foo',
+        'sub',
+        'note.md',
+      );
+      expect(isSkillMdPath(target, projectRoot)).toBe(false);
+    });
+
+    it('returns false for files outside the skills root', () => {
+      const target = path.join(projectRoot, 'README.md');
+      expect(isSkillMdPath(target, projectRoot)).toBe(false);
+    });
+
+    it('returns false for SKILL.md at the skills root itself', () => {
+      const target = path.join(projectRoot, '.qwen', 'skills', 'SKILL.md');
+      expect(isSkillMdPath(target, projectRoot)).toBe(false);
+    });
+  });
+
+  describe('findNextAvailableSkillPath', () => {
+    it('returns <name>-2 when <name> exists', async () => {
+      const original = await writeSkill(projectRoot, 'foo');
+      const next = await findNextAvailableSkillPath(original);
+      expect(next).toBe(
+        path.join(projectRoot, '.qwen', 'skills', 'foo-2', 'SKILL.md'),
+      );
+    });
+
+    it('skips already-claimed numeric suffixes', async () => {
+      await writeSkill(projectRoot, 'foo');
+      await writeSkill(projectRoot, 'foo-2');
+      await writeSkill(projectRoot, 'foo-3');
+      const next = await findNextAvailableSkillPath(
+        path.join(projectRoot, '.qwen', 'skills', 'foo', 'SKILL.md'),
+      );
+      expect(next).toBe(
+        path.join(projectRoot, '.qwen', 'skills', 'foo-4', 'SKILL.md'),
+      );
+    });
+  });
+
+  describe('resolveSkillCollision', () => {
+    it("'rename' on a non-existing path returns the original path unchanged", async () => {
+      const target = path.join(
+        projectRoot,
+        '.qwen',
+        'skills',
+        'fresh-skill',
+        'SKILL.md',
+      );
+      const r = await resolveSkillCollision(target, 'rename', projectRoot);
+      expect(r.action).toBe('write');
+      expect(r.filePath).toBe(target);
+      if (r.action === 'write') {
+        expect(r.renamedFrom).toBeUndefined();
+      }
+    });
+
+    it("'rename' on an existing AUTO-skill redirects to <name>-2", async () => {
+      const original = await writeSkill(
+        projectRoot,
+        'my-skill',
+        '---\nname: my-skill\nsource: auto-skill\n---\nbody\n',
+      );
+      const r = await resolveSkillCollision(original, 'rename', projectRoot);
+      expect(r.action).toBe('write');
+      expect(r.filePath).toBe(
+        path.join(projectRoot, '.qwen', 'skills', 'my-skill-2', 'SKILL.md'),
+      );
+      if (r.action === 'write') {
+        expect(r.renamedFrom).toBe(original);
+      }
+    });
+
+    it("'rename' on an existing USER-skill (no source marker) also redirects — guard does not depend on frontmatter", async () => {
+      // This is the failure mode the reporter cared about most: a user
+      // skill silently clobbered. The wrapper applies the rename
+      // regardless of `source:` so user work is preserved.
+      const original = await writeSkill(
+        projectRoot,
+        'user-authored',
+        '---\nname: user-authored\ndescription: hand-written\n---\nhuman body\n',
+      );
+      const r = await resolveSkillCollision(original, 'rename', projectRoot);
+      expect(r.action).toBe('write');
+      expect(r.filePath).toBe(
+        path.join(
+          projectRoot,
+          '.qwen',
+          'skills',
+          'user-authored-2',
+          'SKILL.md',
+        ),
+      );
+    });
+
+    it("'skip' on an existing skill returns action:'skip' with a reason", async () => {
+      const original = await writeSkill(projectRoot, 'my-skill');
+      const r = await resolveSkillCollision(original, 'skip', projectRoot);
+      expect(r.action).toBe('skip');
+      if (r.action === 'skip') {
+        expect(r.reason).toMatch(/already exists/);
+      }
+    });
+
+    it("'overwrite' returns the original path even when the skill exists (legacy behaviour)", async () => {
+      const original = await writeSkill(projectRoot, 'my-skill');
+      const r = await resolveSkillCollision(original, 'overwrite', projectRoot);
+      expect(r.action).toBe('write');
+      expect(r.filePath).toBe(original);
+      if (r.action === 'write') {
+        expect(r.renamedFrom).toBeUndefined();
+      }
+    });
+
+    it('passes through writes to non-SKILL.md paths under the skills root', async () => {
+      // The guard only governs the primary SKILL.md slot; helper files
+      // (e.g. a README inside a skill folder) are not its concern.
+      await writeSkill(projectRoot, 'foo');
+      const helper = path.join(
+        projectRoot,
+        '.qwen',
+        'skills',
+        'foo',
+        'NOTES.md',
+      );
+      await fs.writeFile(helper, 'helper', 'utf-8');
+      const r = await resolveSkillCollision(helper, 'rename', projectRoot);
+      expect(r.action).toBe('write');
+      expect(r.filePath).toBe(helper);
+    });
+  });
+
+  describe('listExistingProjectSkillNames', () => {
+    it('returns an empty array when the skills root does not exist', async () => {
+      const names = await listExistingProjectSkillNames(projectRoot);
+      expect(names).toEqual([]);
+    });
+
+    it('lists directories that contain a SKILL.md, sorted alphabetically', async () => {
+      await writeSkill(projectRoot, 'zebra');
+      await writeSkill(projectRoot, 'apple');
+      await writeSkill(projectRoot, 'banana');
+      const names = await listExistingProjectSkillNames(projectRoot);
+      expect(names).toEqual(['apple', 'banana', 'zebra']);
+    });
+
+    it('excludes directories that do not contain a SKILL.md', async () => {
+      await writeSkill(projectRoot, 'real');
+      await fs.mkdir(path.join(projectRoot, '.qwen', 'skills', 'empty'), {
+        recursive: true,
+      });
+      const names = await listExistingProjectSkillNames(projectRoot);
+      expect(names).toEqual(['real']);
+    });
+  });
+});

--- a/packages/core/src/memory/skillCollisionGuard.ts
+++ b/packages/core/src/memory/skillCollisionGuard.ts
@@ -1,0 +1,205 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Collision detection for the auto-skill creation path (issue #4437).
+ *
+ * The skill-review agent is *supposed* to inspect existing skills and pick a
+ * non-colliding name before calling `write_file`, but that is advisory only.
+ * When the agent gets it wrong, the generic `write_file` tool happily
+ * overwrites the existing `SKILL.md`, losing the prior content.
+ *
+ * This module supplies the safety net applied at the skill-write boundary:
+ * given a target path the agent wants to write to, it decides whether the
+ * write should proceed as-is, be redirected to a renamed sibling, or be
+ * skipped — without touching the generic `write_file` tool itself.
+ *
+ * Strategies:
+ *  - `rename`    (default): if the target file already exists, write to
+ *                `<dir>-2/SKILL.md`, `<dir>-3/SKILL.md`, etc. until a free
+ *                slot is found. Preserves both the existing skill and the
+ *                new one.
+ *  - `skip`      : if the target file already exists, skip the write and
+ *                report the collision back to the agent.
+ *  - `overwrite` : preserve the pre-fix behaviour — the existing file is
+ *                clobbered. Provided for users who explicitly opt in.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import {
+  getProjectSkillsRoot,
+  isProjectSkillPath,
+} from '../skills/skill-paths.js';
+
+export type SkillCollisionStrategy = 'rename' | 'skip' | 'overwrite';
+
+export const DEFAULT_SKILL_COLLISION_STRATEGY: SkillCollisionStrategy =
+  'rename';
+
+/**
+ * Hard cap on the number of `-N` suffixes attempted before giving up.
+ * 100 is far beyond any realistic collision count and stops the loop from
+ * spinning if something pathological happens (e.g. a filesystem returning
+ * EEXIST forever).
+ */
+const MAX_RENAME_ATTEMPTS = 100;
+
+export interface SkillCollisionWriteAction {
+  action: 'write';
+  /** Final on-disk path the write should target. */
+  filePath: string;
+  /** Original path the caller proposed, prior to any rename. */
+  originalFilePath: string;
+  /** Set when the write was redirected — used for the warning log/result. */
+  renamedFrom?: string;
+}
+
+export interface SkillCollisionSkipAction {
+  action: 'skip';
+  /** Path the caller proposed; unchanged. */
+  filePath: string;
+  originalFilePath: string;
+  /** Human-readable reason the write was skipped. */
+  reason: string;
+}
+
+export type SkillCollisionResolution =
+  | SkillCollisionWriteAction
+  | SkillCollisionSkipAction;
+
+/**
+ * Returns true if the given absolute path looks like a `SKILL.md` under
+ * `<projectRoot>/.qwen/skills/<name>/`. The guard only acts on these paths
+ * — writes to anything else (auxiliary files, attachments) flow through
+ * unchanged.
+ */
+export function isSkillMdPath(filePath: string, projectRoot: string): boolean {
+  if (!isProjectSkillPath(filePath, projectRoot)) return false;
+  const skillsRoot = path.resolve(getProjectSkillsRoot(projectRoot));
+  const resolved = path.resolve(filePath);
+  // Must be under skillsRoot/<dir>/SKILL.md — i.e. relative depth of 2.
+  const rel = path.relative(skillsRoot, resolved);
+  if (!rel || rel.startsWith('..')) return false;
+  const parts = rel.split(path.sep);
+  return parts.length === 2 && parts[1] === 'SKILL.md';
+}
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.stat(filePath);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    // EACCES / EPERM / EISDIR — surface as "exists" so we don't blindly overwrite.
+    return true;
+  }
+}
+
+/**
+ * Compute the next available skill path by appending `-2`, `-3`, ... to the
+ * skill directory name until a non-existing slot is found.
+ *
+ * Example:
+ *   <root>/.qwen/skills/foo/SKILL.md
+ *   → <root>/.qwen/skills/foo-2/SKILL.md      (if foo exists)
+ *   → <root>/.qwen/skills/foo-3/SKILL.md      (if foo and foo-2 exist)
+ */
+export async function findNextAvailableSkillPath(
+  filePath: string,
+): Promise<string> {
+  const dir = path.dirname(filePath);
+  const fileName = path.basename(filePath);
+  const parent = path.dirname(dir);
+  const skillName = path.basename(dir);
+  for (let i = 2; i <= MAX_RENAME_ATTEMPTS; i++) {
+    const candidate = path.join(parent, `${skillName}-${i}`, fileName);
+    if (!(await pathExists(candidate))) return candidate;
+  }
+  throw new Error(
+    `Could not find an available skill name after ${MAX_RENAME_ATTEMPTS} ` +
+      `attempts for "${filePath}". The skills directory may be in a broken state.`,
+  );
+}
+
+/**
+ * Resolve a potential collision for the given write target.
+ *
+ * For paths *outside* `<root>/.qwen/skills/<name>/SKILL.md` (e.g. attachments
+ * referenced by a skill), the resolution is always `action: 'write'` with
+ * the original path — the guard only governs the primary SKILL.md slot.
+ */
+export async function resolveSkillCollision(
+  filePath: string,
+  strategy: SkillCollisionStrategy,
+  projectRoot: string,
+): Promise<SkillCollisionResolution> {
+  const original = filePath;
+  if (!isSkillMdPath(filePath, projectRoot)) {
+    return { action: 'write', filePath, originalFilePath: original };
+  }
+  const exists = await pathExists(filePath);
+  if (!exists) {
+    return { action: 'write', filePath, originalFilePath: original };
+  }
+  switch (strategy) {
+    case 'overwrite':
+      return { action: 'write', filePath, originalFilePath: original };
+    case 'skip':
+      return {
+        action: 'skip',
+        filePath,
+        originalFilePath: original,
+        reason:
+          `Skill already exists at ${filePath}. Skipping write because ` +
+          `collision strategy is 'skip'. Choose a different skill name and retry.`,
+      };
+    case 'rename':
+    default: {
+      const renamed = await findNextAvailableSkillPath(filePath);
+      return {
+        action: 'write',
+        filePath: renamed,
+        originalFilePath: original,
+        renamedFrom: original,
+      };
+    }
+  }
+}
+
+/**
+ * Enumerate existing project skill directory names so the planner prompt
+ * can list them. Returns an empty array if the skills root does not exist
+ * yet or cannot be read.
+ *
+ * Names returned are the directory basenames (e.g. `"foo-skill"`), not the
+ * frontmatter `name:` field — the directory layout is what governs the
+ * write path, so that is what the agent needs to avoid colliding with.
+ */
+export async function listExistingProjectSkillNames(
+  projectRoot: string,
+): Promise<string[]> {
+  const skillsRoot = getProjectSkillsRoot(projectRoot);
+  let entries;
+  try {
+    entries = await fs.readdir(skillsRoot, { withFileTypes: true });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    // Permission or other read errors — best-effort: return empty.
+    return [];
+  }
+  const names: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    // Confirm a SKILL.md actually exists so half-built dirs don't pollute.
+    const skillFile = path.join(skillsRoot, entry.name, 'SKILL.md');
+    if (await pathExists(skillFile)) {
+      names.push(entry.name);
+    }
+  }
+  names.sort();
+  return names;
+}

--- a/packages/core/src/memory/skillReviewAgentPlanner.test.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.test.ts
@@ -1,0 +1,301 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tests for `skillReviewAgentPlanner` — the planner side of the auto-skill
+ * review flow. The on-disk safety net introduced for issue #4437 lives one
+ * layer down (the tool wrapper) and is covered by
+ * `skillCollisionAwareWriteFile.test.ts`. The cases below cover:
+ *
+ *   1. The scoped permission layer's behaviour, which by design only
+ *      governs path scope + symlink safety — name-collision detection is
+ *      explicitly delegated to the tool-layer wrapper because the
+ *      permission API can deny/allow but cannot redirect a write.
+ *   2. `buildTaskPrompt` includes existing skill names so the agent picks
+ *      a fresh name on its first attempt (defense-in-depth above the
+ *      rename safety net).
+ *   3. `readSkillCollisionStrategy` round-trips the strategy via the
+ *      scoped config so `runSkillReviewByAgent` can install the guard.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Config } from '../config/config.js';
+import {
+  buildTaskPrompt,
+  createSkillScopedAgentConfig,
+  readSkillCollisionStrategy,
+} from './skillReviewAgentPlanner.js';
+import { ToolNames } from '../tools/tool-names.js';
+import { getProjectSkillsRoot } from '../skills/skill-paths.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMinimalConfig(projectRoot: string): Config {
+  return {
+    getProjectRoot: () => projectRoot,
+    getPermissionManager: () => undefined,
+  } as unknown as Config;
+}
+
+async function writeSkillFile(
+  projectRoot: string,
+  skillName: string,
+  content: string,
+): Promise<string> {
+  const skillDir = path.join(projectRoot, '.qwen', 'skills', skillName);
+  await fs.mkdir(skillDir, { recursive: true });
+  const filePath = path.join(skillDir, 'SKILL.md');
+  await fs.writeFile(filePath, content, 'utf-8');
+  return filePath;
+}
+
+const AUTO_SKILL_CONTENT = `---
+name: my-refactoring-skill
+description: How to refactor legacy code
+source: auto-skill
+extracted_at: '2026-01-01T00:00:00.000Z'
+---
+
+Original auto-skill body — must not be silently replaced.
+`;
+
+const NEW_AUTO_SKILL_CONTENT = `---
+name: my-refactoring-skill
+description: Completely different approach to refactoring
+source: auto-skill
+extracted_at: '2026-05-22T00:00:00.000Z'
+---
+
+Entirely new body written by a second skill-review run.
+`;
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('skillReviewAgentPlanner — permission scope (issue #4437 baseline)', () => {
+  let tempDir: string;
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), 'skill-review-collision-'),
+    );
+    projectRoot = path.join(tempDir, 'project');
+    await fs.mkdir(projectRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  // ─── BUG REPRODUCTION ────────────────────────────────────────────────────
+  // The permission layer allows write_file to an existing auto-skill path.
+  // There is no collision detection — the write proceeds silently, wiping the
+  // prior SKILL.md content.
+
+  it('permission layer allows write_file to an existing auto-skill path (collision is handled by the tool wrapper instead)', async () => {
+    // 1. Set up an existing auto-skill on disk.
+    const skillFilePath = await writeSkillFile(
+      projectRoot,
+      'my-refactoring-skill',
+      AUTO_SKILL_CONTENT,
+    );
+
+    // 2. Build the scoped permission manager the skill-review agent uses.
+    const config = makeMinimalConfig(projectRoot);
+    const scopedConfig = createSkillScopedAgentConfig(config, projectRoot);
+    const pm = scopedConfig.getPermissionManager?.();
+    expect(pm).toBeDefined();
+
+    // 3. Simulate the agent calling write_file on the same path with new content.
+    const decision = await pm!.evaluate({
+      toolName: ToolNames.WRITE_FILE,
+      filePath: skillFilePath,
+    });
+
+    // Intentional: the permission layer can only return allow/deny/ask
+    // and cannot redirect a write. Rename-on-collision lives in the tool
+    // wrapper installed by `runSkillReviewByAgent`. The permission layer
+    // is the path-scope/symlink-safety guard and stays narrow.
+    expect(decision).toBe('allow');
+
+    // 4. Demonstrate that an actual overwrite goes through unchecked: write
+    //    the new content to the same path directly (as write_file would do).
+    await fs.writeFile(skillFilePath, NEW_AUTO_SKILL_CONTENT, 'utf-8');
+    const written = await fs.readFile(skillFilePath, 'utf-8');
+
+    // The original content is gone — no warning, no merge, no collision log.
+    expect(written).toBe(NEW_AUTO_SKILL_CONTENT);
+    expect(written).not.toContain(
+      'Original auto-skill body — must not be silently replaced.',
+    );
+  });
+
+  // ─── CONFIRMED SAFE CASE: user skill is blocked ──────────────────────────
+  // For contrast, a user-created skill (no `source: auto-skill`) correctly
+  // returns 'deny', so that case is not part of the bug.
+
+  it('correctly denies write_file to a user-created skill (no source: auto-skill)', async () => {
+    const userSkillContent = `---
+name: my-refactoring-skill
+description: User-authored skill
+---
+
+User-authored body — this skill has no source: auto-skill marker.
+`;
+    const skillFilePath = await writeSkillFile(
+      projectRoot,
+      'my-refactoring-skill',
+      userSkillContent,
+    );
+
+    const config = makeMinimalConfig(projectRoot);
+    const scopedConfig = createSkillScopedAgentConfig(config, projectRoot);
+    const pm = scopedConfig.getPermissionManager?.();
+    expect(pm).toBeDefined();
+
+    const decision = await pm!.evaluate({
+      toolName: ToolNames.WRITE_FILE,
+      filePath: skillFilePath,
+    });
+
+    // This case IS protected — only auto-skills can be overwritten.
+    expect(decision).toBe('deny');
+  });
+
+  // ─── ABSENCE OF NAME CHECK ────────────────────────────────────────────────
+  // The permission layer makes no distinction between these two `write_file`
+  // calls, even though one is an update and the other is a collision:
+  //
+  //   (A) write_file(path=skills/foo/SKILL.md, content=updated-foo-skill)
+  //   (B) write_file(path=skills/foo/SKILL.md, content=completely-different-bar-skill)
+  //
+  // Both receive 'allow' identically — there is no name-level collision guard.
+
+  it('permission layer cannot distinguish a same-name collision from a legitimate update — that is the wrappers job', async () => {
+    const skillFilePath = await writeSkillFile(
+      projectRoot,
+      'foo-skill',
+      `---
+name: foo-skill
+description: The original foo skill
+source: auto-skill
+extracted_at: '2026-01-01T00:00:00.000Z'
+---
+
+Original foo skill body.
+`,
+    );
+
+    const config = makeMinimalConfig(projectRoot);
+    const scopedConfig = createSkillScopedAgentConfig(config, projectRoot);
+    const pm = scopedConfig.getPermissionManager?.();
+    expect(pm).toBeDefined();
+
+    // Case A: legitimate update — same skill name, updated content.
+    const updateDecision = await pm!.evaluate({
+      toolName: ToolNames.WRITE_FILE,
+      filePath: skillFilePath,
+    });
+
+    // Case B: collision — different skill name, but same file path.
+    // The agent could generate `name: bar-skill` in the frontmatter of this write.
+    // The permission layer has no mechanism to detect this and still returns 'allow'.
+    const collisionDecision = await pm!.evaluate({
+      toolName: ToolNames.WRITE_FILE,
+      filePath: skillFilePath,
+    });
+
+    // Both decisions are identical at the permission layer; the tool
+    // wrapper (`SkillCollisionAwareWriteFileTool`) is responsible for the
+    // rename-on-collision behaviour observed by the agent.
+    expect(updateDecision).toBe('allow');
+    expect(collisionDecision).toBe('allow');
+
+    // Specifically, no code path in evaluateScopedDecision / hasAutoSkillSource
+    // inspects the CONTENT being written or validates that the `name:` field in
+    // the new content matches the skill already at that path. The only check is
+    // whether the EXISTING file has `source: auto-skill` — which it does — so
+    // any write content is accepted at this layer.
+  });
+});
+
+describe('buildTaskPrompt — defense-in-depth skill enumeration', () => {
+  let tempDir: string;
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'skill-task-prompt-'));
+    projectRoot = path.join(tempDir, 'project');
+    await fs.mkdir(projectRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('lists existing skill directory names so the agent picks a non-colliding name on the first attempt', async () => {
+    await writeSkillFile(projectRoot, 'alpha-skill', 'alpha\n');
+    await writeSkillFile(projectRoot, 'beta-skill', 'beta\n');
+
+    const prompt = await buildTaskPrompt(
+      getProjectSkillsRoot(projectRoot),
+      projectRoot,
+    );
+
+    expect(prompt).toMatch(/Existing skills/);
+    expect(prompt).toContain('alpha-skill');
+    expect(prompt).toContain('beta-skill');
+    // Should still steer the agent toward `edit` for updates.
+    expect(prompt).toMatch(/use `edit`/i);
+  });
+
+  it('renders a "no skills exist" line when the project has no skills yet', async () => {
+    const prompt = await buildTaskPrompt(
+      getProjectSkillsRoot(projectRoot),
+      projectRoot,
+    );
+    expect(prompt).toMatch(/No skills exist yet/);
+  });
+});
+
+describe('readSkillCollisionStrategy', () => {
+  let tempDir: string;
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'skill-strategy-'));
+    projectRoot = path.join(tempDir, 'project');
+    await fs.mkdir(projectRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('defaults to "rename" when the caller does not specify a strategy', () => {
+    const scoped = createSkillScopedAgentConfig(
+      makeMinimalConfig(projectRoot),
+      projectRoot,
+    );
+    expect(readSkillCollisionStrategy(scoped)).toBe('rename');
+  });
+
+  it('round-trips a caller-supplied strategy through the scoped config', () => {
+    const scoped = createSkillScopedAgentConfig(
+      makeMinimalConfig(projectRoot),
+      projectRoot,
+      { collisionStrategy: 'skip' },
+    );
+    expect(readSkillCollisionStrategy(scoped)).toBe('skip');
+  });
+});

--- a/packages/core/src/memory/skillReviewAgentPlanner.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.ts
@@ -21,6 +21,12 @@ import {
   getProjectSkillsRoot,
   isProjectSkillPath,
 } from '../skills/skill-paths.js';
+import {
+  DEFAULT_SKILL_COLLISION_STRATEGY,
+  listExistingProjectSkillNames,
+  type SkillCollisionStrategy,
+} from './skillCollisionGuard.js';
+import { installSkillCollisionGuard } from './skillCollisionAwareWriteFile.js';
 
 export const SKILL_REVIEW_AGENT_NAME = 'managed-skill-extractor' as const;
 export const DEFAULT_AUTO_SKILL_MAX_TURNS = 8;
@@ -153,9 +159,36 @@ function getScopedDenyRule(
   }
 }
 
+export interface CreateSkillScopedAgentConfigOptions {
+  /**
+   * Collision strategy applied when the agent attempts to `write_file` on
+   * an existing `<projectRoot>/.qwen/skills/<name>/SKILL.md`. Defaults to
+   * {@link DEFAULT_SKILL_COLLISION_STRATEGY} (`'rename'`).
+   *
+   * The strategy itself is enforced inside `runSkillReviewByAgent` via
+   * `installSkillCollisionGuard` on the YOLO override's tool registry —
+   * stored on the scoped config here so callers that test the scoped
+   * config in isolation can read it back.
+   */
+  collisionStrategy?: SkillCollisionStrategy;
+}
+
+const SKILL_COLLISION_STRATEGY_SYMBOL: unique symbol = Symbol.for(
+  'qwen-code:skill-collision-strategy',
+);
+
+export function readSkillCollisionStrategy(
+  config: Config,
+): SkillCollisionStrategy | undefined {
+  return (config as unknown as Record<symbol, SkillCollisionStrategy>)[
+    SKILL_COLLISION_STRATEGY_SYMBOL
+  ];
+}
+
 export function createSkillScopedAgentConfig(
   config: Config,
   projectRoot: string,
+  options: CreateSkillScopedAgentConfigOptions = {},
 ): Config {
   const basePm = config.getPermissionManager?.();
   const scopedPm: SkillScopedPermissionManager = {
@@ -188,6 +221,11 @@ export function createSkillScopedAgentConfig(
   const scopedConfig = Object.create(config) as Config;
   scopedConfig.getPermissionManager = () =>
     scopedPm as unknown as PermissionManager;
+  // Annotate with the chosen collision strategy so runSkillReviewByAgent
+  // (and tests) can read it without an extra parameter.
+  (scopedConfig as unknown as Record<symbol, SkillCollisionStrategy>)[
+    SKILL_COLLISION_STRATEGY_SYMBOL
+  ] = options.collisionStrategy ?? DEFAULT_SKILL_COLLISION_STRATEGY;
   return scopedConfig;
 }
 
@@ -230,9 +268,27 @@ function buildAgentHistory(history: Content[]): Content[] {
   ];
 }
 
-function buildTaskPrompt(skillsRoot: string): string {
+/**
+ * Exported for testing. Builds the agent's task prompt with an inline list
+ * of skill names already present on disk so the model can pick a fresh
+ * name on its first attempt and avoid the collision-guard rename path.
+ */
+export async function buildTaskPrompt(
+  skillsRoot: string,
+  projectRoot: string,
+): Promise<string> {
+  const existingNames = await listExistingProjectSkillNames(projectRoot);
+  const existingSection =
+    existingNames.length === 0
+      ? '(No skills exist yet — any new name is available.)'
+      : [
+          'Existing skills in this directory — DO NOT reuse these names for a new skill (use `edit` to update an existing auto-skill, `write_file` only for new ones):',
+          ...existingNames.map((n) => `  - ${n}`),
+        ].join('\n');
   return [
     `Project skills directory: \`${skillsRoot}\``,
+    '',
+    existingSection,
     '',
     'Use `ls` and `read_file` to inspect existing skills before writing.',
     'Use `write_file` to create a new skill, `edit` to update an existing auto-skill.',
@@ -255,16 +311,27 @@ export async function runSkillReviewByAgent(params: {
   history: Content[];
   maxTurns?: number;
   timeoutMs?: number;
+  /**
+   * Auto-skill collision strategy override. When omitted, the strategy is
+   * read from the Config (`getAutoSkillCollisionStrategy()`), then falls
+   * back to {@link DEFAULT_SKILL_COLLISION_STRATEGY}.
+   */
+  collisionStrategy?: SkillCollisionStrategy;
 }): Promise<SkillReviewExecutionResult> {
   const skillsRoot = getProjectSkillsRoot(params.projectRoot);
+  const strategy =
+    params.collisionStrategy ??
+    params.config.getAutoSkillCollisionStrategy?.() ??
+    DEFAULT_SKILL_COLLISION_STRATEGY;
   const scopedConfig = createSkillScopedAgentConfig(
     params.config,
     params.projectRoot,
+    { collisionStrategy: strategy },
   );
   const result = await runForkedAgent({
     name: SKILL_REVIEW_AGENT_NAME,
     config: scopedConfig,
-    taskPrompt: buildTaskPrompt(skillsRoot),
+    taskPrompt: await buildTaskPrompt(skillsRoot, params.projectRoot),
     systemPrompt: SKILL_REVIEW_SYSTEM_PROMPT,
     maxTurns: params.maxTurns ?? DEFAULT_AUTO_SKILL_MAX_TURNS,
     maxTimeMinutes:
@@ -276,6 +343,14 @@ export async function runSkillReviewByAgent(params: {
       ToolNames.EDIT,
     ],
     extraHistory: buildAgentHistory(params.history),
+    prepareToolRegistry: (yoloConfig) => {
+      installSkillCollisionGuard(
+        yoloConfig.getToolRegistry(),
+        yoloConfig,
+        params.projectRoot,
+        strategy,
+      );
+    },
   });
 
   if (result.status !== 'completed') {

--- a/packages/core/src/utils/forkedAgent.ts
+++ b/packages/core/src/utils/forkedAgent.ts
@@ -332,6 +332,15 @@ export interface AgentPathParams {
    * Must end with a `model` role entry; call buildAgentHistory() to enforce this.
    */
   extraHistory?: Content[];
+  /**
+   * Optional hook invoked after the per-fork tool registry is built on the
+   * YOLO override but before AgentHeadless.create. Callers that need to
+   * swap in a wrapped tool (e.g. the auto-skill collision guard from
+   * issue #4437) install it here against the registry returned by
+   * `yoloConfig.getToolRegistry()`. The hook is awaited; throwing aborts
+   * the fork.
+   */
+  prepareToolRegistry?: (yoloConfig: Config) => Promise<void> | void;
   /** External cancellation signal. */
   abortSignal?: AbortSignal;
 }
@@ -482,6 +491,9 @@ export async function runForkedAgent(
   // API symmetry with the other createApprovalModeOverride callers; if
   // this function ever switches away from YOLO the lifecycle stays
   // correct without further refactor.
+  if (params.prepareToolRegistry) {
+    await params.prepareToolRegistry(yoloConfig);
+  }
   const filesTouched = new Set<string>();
 
   const emitter = new AgentEventEmitter();


### PR DESCRIPTION
## Summary

Fixes #4437. Auto-skill review could silently overwrite existing skill files (both auto-skills and user-authored ones) because the agent's `write_file` calls had no collision detection beyond an advisory "check duplicates before writing" line in the system prompt.

This change adds a code-level safety net at the skill-write boundary — the generic `write_file` tool is left alone so every other caller keeps its overwrite semantics.

## How the fix works

1. **`SkillCollisionAwareWriteFileTool`** wraps `WriteFileTool`. On `execute()` it consults `resolveSkillCollision()` for the configured strategy and either rewrites the path or short-circuits.
2. **`prepareToolRegistry` hook on `runForkedAgent`** lets `runSkillReviewByAgent` swap the `write_file` factory on the YOLO override's tool registry after the rebuild. Only auto-skill review sees the wrapped tool.
3. **`buildTaskPrompt` enumerates existing skills** as defense-in-depth so the agent picks a non-colliding name on the first attempt; the rename is the safety net if it doesn't.

## New setting

`memory.autoSkillCollisionStrategy` — `'rename' | 'skip' | 'overwrite'`, default `'rename'`.

| Strategy | Behaviour |
|---|---|
| `rename` (default) | Append `-2`, `-3`, ... to the skill directory until a free slot is found; existing skill preserved, new content written to the renamed sibling. |
| `skip` | Abort the write with a structured error. Existing skill preserved, no new content written. |
| `overwrite` | Restore the pre-#4437 behaviour. Provided as an explicit escape hatch. |

## Out of scope (per issue brief)

- The generic `WriteFileTool` — other callers depend on overwrite semantics.
- `SkillManager` load-time deduplication — runs after writes; not the right layer.
- User-initiated `/skill` creation flows.
- Semantic merging of skill markdown (issue body option 2) — too fragile for a default; rename is the conservative pick.

## Test plan

- [x] `packages/core/src/memory/skillCollisionGuard.test.ts` — 15 tests covering the pure helpers (`isSkillMdPath`, `findNextAvailableSkillPath`, `resolveSkillCollision` per strategy, `listExistingProjectSkillNames`).
- [x] `packages/core/src/memory/skillCollisionAwareWriteFile.test.ts` — 5 end-to-end tests through a real `WriteFileTool`:
  - **Preserves a USER skill when the agent writes to its path** (the worst case from the issue — user file byte-identical after the write, new content at `<name>-2/SKILL.md`).
  - Preserves an existing auto-skill (auto-vs-auto clobber).
  - Passthrough write when the target does not exist.
  - `'skip'` strategy aborts with a structured error.
  - `'overwrite'` strategy preserves the pre-fix behaviour.
- [x] `packages/core/src/memory/skillReviewAgentPlanner.test.ts` extended for `buildTaskPrompt` enumeration and strategy round-trip; existing reproduction tests retained to document baseline permission-layer behaviour (the permission API can only allow/deny/ask — it cannot redirect, so the rename has to live at the tool layer).
- [x] `npx tsc --noEmit -p packages/core/tsconfig.json` — clean.
- [x] `npx eslint <changed files>` — clean.
- [x] Full `packages/core/src/memory/` vitest sweep: 23 files / 373 tests pass.
- [x] `packages/core/src/utils/forkedAgent` tests: 19 tests pass (new hook is optional, no caller impact).

cc @DragonnZhang — your earlier RCA on the issue nailed the file layout; the rename safety net here closes the gap. Curious whether the planner-prompt enumeration alone would have been enough in your testing, or whether the code-level guard is also load-bearing for your workflow.