### PR TITLE
fix(cli): gate mintty OSC 8 detection on TERM_PROGRAM_VERSION ≥ 3.3 (#4420)

### DIFF
--- a/packages/cli/src/ui/utils/osc8.test.ts
+++ b/packages/cli/src/ui/utils/osc8.test.ts
@@ -502,10 +502,30 @@ describe('osc8 helpers', () => {
       expect(supportsHyperlinks()).toBe(true);
     });
 
-    it('mintty is enabled via TERM_PROGRAM=mintty', () => {
+    it('mintty ≥ 3.3 is enabled, < 3.3 is not, missing version refuses', () => {
+      // Older mintty builds (still shipping in some Git-for-Windows distros
+      // and dev environments like Laragon) print raw OSC 8 escape bytes as
+      // visible garbage instead of ignoring them — see issue #4420. mintty
+      // has set TERM_PROGRAM_VERSION since 2.7 (2017), so a missing version
+      // implies an ancient build and we refuse.
       setTTY(true);
       process.env['TERM_PROGRAM'] = 'mintty';
+      process.env['TERM_PROGRAM_VERSION'] = '4.0.0';
       expect(supportsHyperlinks()).toBe(true);
+      process.env['TERM_PROGRAM_VERSION'] = '3.7.1';
+      expect(supportsHyperlinks()).toBe(true);
+      process.env['TERM_PROGRAM_VERSION'] = '3.3.0';
+      expect(supportsHyperlinks()).toBe(true);
+      process.env['TERM_PROGRAM_VERSION'] = '3.2.9';
+      expect(supportsHyperlinks()).toBe(false);
+      process.env['TERM_PROGRAM_VERSION'] = '3.1.0';
+      expect(supportsHyperlinks()).toBe(false);
+      process.env['TERM_PROGRAM_VERSION'] = '2.9.8';
+      expect(supportsHyperlinks()).toBe(false);
+      process.env['TERM_PROGRAM_VERSION'] = '';
+      expect(supportsHyperlinks()).toBe(false);
+      delete process.env['TERM_PROGRAM_VERSION'];
+      expect(supportsHyperlinks()).toBe(false);
     });
 
     it('Hyper is intentionally not auto-detected (requires FORCE_HYPERLINK)', () => {

--- a/packages/cli/src/ui/utils/osc8.test.ts
+++ b/packages/cli/src/ui/utils/osc8.test.ts
@@ -526,6 +526,13 @@ describe('osc8 helpers', () => {
       expect(supportsHyperlinks()).toBe(false);
       delete process.env['TERM_PROGRAM_VERSION'];
       expect(supportsHyperlinks()).toBe(false);
+      // Users on mintty 3.1–3.2 who know their build's OSC 8 implementation
+      // works can opt back in via FORCE_HYPERLINK=1 — same escape hatch the
+      // Warp and Hyper tests above assert. Pin the contract so a future
+      // refactor that reorders early-exit checks can't silently break it.
+      process.env['TERM_PROGRAM_VERSION'] = '3.2.9';
+      process.env['FORCE_HYPERLINK'] = '1';
+      expect(supportsHyperlinks()).toBe(true);
     });
 
     it('Hyper is intentionally not auto-detected (requires FORCE_HYPERLINK)', () => {

--- a/packages/cli/src/ui/utils/osc8.ts
+++ b/packages/cli/src/ui/utils/osc8.ts
@@ -237,9 +237,15 @@ export function supportsHyperlinks(
       case 'ghostty':
         return true;
       case 'mintty':
-        // mintty ≥ 3.3 supports OSC 8; older installs are extremely rare
-        // and still degrade safely (terminal just prints the visible bytes).
-        return true;
+        // mintty added OSC 8 in 3.1, hardened in 3.3. Older builds (still
+        // bundled with some Git-for-Windows distros and developer
+        // environments like Laragon) print the raw `\x1b]8;;url\x07`
+        // bytes as visible garbage instead of silently ignoring them,
+        // so gate on TERM_PROGRAM_VERSION. mintty has set
+        // TERM_PROGRAM_VERSION since 2.7 (2017), so a missing version
+        // means a very old build — refuse rather than guess.
+        if (!env['TERM_PROGRAM_VERSION']) return false;
+        return version.major > 3 || (version.major === 3 && version.minor >= 3);
       // Warp (TERM_PROGRAM=WarpTerminal) does NOT yet support OSC 8 — its
       // rendering engine ignores the envelope and prints visible garbage,
       // so we deliberately fall through to the legacy `label (url)` path.


### PR DESCRIPTION
## Summary

Fixes the OSC 8 component of #4420 — garbled UI on Windows + Git Bash after upgrading to v0.16.0.

- `osc8.ts` was unconditionally returning `true` for `TERM_PROGRAM=mintty`, deviating from upstream `supports-hyperlinks` (which rejects all of win32 outside `WT_SESSION`).
- mintty added OSC 8 in 3.1 and hardened it in 3.3. Builds older than that — still shipping in some Git-for-Windows distros and developer environments like Laragon — print raw `\x1b]8;;url\x07` bytes as visible garbage instead of silently ignoring them.
- Now requires `TERM_PROGRAM_VERSION` to be present (mintty has set it since 2.7 in 2017 — missing implies an ancient build) **and** version ≥ 3.3. Users on mintty 3.1–3.2.x who know their build works can still opt in via `FORCE_HYPERLINK=1`.

## Scope note

The #4420 triage flagged **three** potential causes:
1. **Ink 6 → 7.0.3 upgrade** (primary suspect) — render pipeline change interacting with MinTTY
2. **OSC 8 hyperlink wrapping** (aggravating factor) — this PR
3. **terminalRedrawOptimizer** interaction with Ink 7's new output patterns

This PR addresses **only (2)**. The screenshots in the issue look more like Ink 7's previous-frame-not-erased behavior than OSC 8 escape garbage, so this fix alone may not fully resolve the user's report — but it's clearly the right move regardless (matches upstream behavior, removes a Windows-specific hazard). `QWEN_CODE_LEGACY_ERASE_LINES=1` remains the documented escape hatch for (1) and (3) until they get separate Windows-environment testing.

## Test plan

- [x] `npx vitest run packages/cli/src/ui/utils/osc8.test.ts` — 79 tests pass
- [x] `npx vitest run packages/cli/src/ui/utils/` — 670 tests pass (32 files)
- [x] New test covers 8 distinct cases: 4.0.0 / 3.7.1 / 3.3.0 (enabled), 3.2.9 / 3.1.0 / 2.9.8 / empty string / missing (disabled)
- [ ] Manual verification on Windows + Git Bash (Laragon) — requires the issue reporter or someone with that environment