### PR TITLE
fix(cli): implement --list-extensions flag handler (#4450)

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -634,6 +634,165 @@ describe('gemini.tsx main function', () => {
     );
     expect(runExitCleanupMock).toHaveBeenCalledTimes(1);
   });
+
+  it('should print "No extensions installed." and exit when --list-extensions is set and no extensions exist', async () => {
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const { loadSandboxConfig } = await import('./config/sandboxConfig.js');
+    const { relaunchAppInChildProcess } = await import('./utils/relaunch.js');
+    const cleanupModule = await import('./utils/cleanup.js');
+    const runExitCleanupMock = vi.mocked(cleanupModule.runExitCleanup);
+    runExitCleanupMock.mockResolvedValue(undefined);
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code) => {
+        throw new MockProcessExitError(code);
+      });
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    vi.mocked(loadSandboxConfig).mockResolvedValue(undefined);
+    vi.mocked(relaunchAppInChildProcess).mockResolvedValue(undefined);
+    vi.mocked(parseArguments).mockResolvedValue({
+      extensions: [],
+    } as never);
+    vi.mocked(loadSettings).mockReturnValue({
+      errors: [],
+      merged: {
+        advanced: {},
+        security: { auth: {} },
+        ui: {},
+      },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      migrationWarnings: [],
+      getUserHooks: () => undefined,
+      getProjectHooks: () => undefined,
+    } as never);
+    vi.mocked(loadCliConfig).mockResolvedValue({
+      isInteractive: () => false,
+      getQuestion: () => '',
+      getSandbox: () => false,
+      getDebugMode: () => false,
+      getListExtensions: () => true,
+      getExtensions: () => [],
+      getApprovalMode: () => 'suggest',
+      getMcpServers: () => ({}),
+      initialize: vi.fn().mockResolvedValue(undefined),
+      waitForMcpReady: vi.fn().mockResolvedValue(undefined),
+      getIdeMode: () => false,
+      getExperimentalZedIntegration: () => false,
+      getScreenReader: () => false,
+      getGeminiMdFileCount: () => 0,
+      getProjectRoot: () => '/',
+      getOutputFormat: () => OutputFormat.TEXT,
+      getWarnings: () => [],
+      getModelsConfig: () => ({ getCurrentAuthType: () => null }),
+      getSessionId: () => 'test-session-id',
+    } as unknown as Config);
+
+    try {
+      await main();
+    } catch (error) {
+      if (!(error instanceof MockProcessExitError)) {
+        throw error;
+      }
+    }
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('No extensions installed.');
+    expect(processExitSpy).toHaveBeenCalledWith(0);
+    expect(runExitCleanupMock).toHaveBeenCalledTimes(1);
+    // Verify config.initialize() is called before getExtensions() — extensions are loaded during initialize
+    const configMock = (await vi.mocked(loadCliConfig).mock.results[0]!
+      .value) as unknown as { initialize: ReturnType<typeof vi.fn> };
+    expect(configMock.initialize).toHaveBeenCalledTimes(1);
+
+    consoleLogSpy.mockRestore();
+    processExitSpy.mockRestore();
+  });
+
+  it('should list extensions with [disabled] suffix when --list-extensions is set', async () => {
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const { loadSandboxConfig } = await import('./config/sandboxConfig.js');
+    const { relaunchAppInChildProcess } = await import('./utils/relaunch.js');
+    const cleanupModule = await import('./utils/cleanup.js');
+    const runExitCleanupMock = vi.mocked(cleanupModule.runExitCleanup);
+    runExitCleanupMock.mockResolvedValue(undefined);
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code) => {
+        throw new MockProcessExitError(code);
+      });
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    vi.mocked(loadSandboxConfig).mockResolvedValue(undefined);
+    vi.mocked(relaunchAppInChildProcess).mockResolvedValue(undefined);
+    vi.mocked(parseArguments).mockResolvedValue({
+      extensions: [],
+    } as never);
+    vi.mocked(loadSettings).mockReturnValue({
+      errors: [],
+      merged: {
+        advanced: {},
+        security: { auth: {} },
+        ui: {},
+      },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      migrationWarnings: [],
+      getUserHooks: () => undefined,
+      getProjectHooks: () => undefined,
+    } as never);
+    vi.mocked(loadCliConfig).mockResolvedValue({
+      isInteractive: () => false,
+      getQuestion: () => '',
+      getSandbox: () => false,
+      getDebugMode: () => false,
+      getListExtensions: () => true,
+      getExtensions: () => [
+        { name: 'my-ext', version: '1.0.0', isActive: true },
+        { name: 'old-ext', version: '0.5.2', isActive: false },
+      ],
+      getApprovalMode: () => 'suggest',
+      getMcpServers: () => ({}),
+      initialize: vi.fn().mockResolvedValue(undefined),
+      waitForMcpReady: vi.fn().mockResolvedValue(undefined),
+      getIdeMode: () => false,
+      getExperimentalZedIntegration: () => false,
+      getScreenReader: () => false,
+      getGeminiMdFileCount: () => 0,
+      getProjectRoot: () => '/',
+      getOutputFormat: () => OutputFormat.TEXT,
+      getWarnings: () => [],
+      getModelsConfig: () => ({ getCurrentAuthType: () => null }),
+      getSessionId: () => 'test-session-id',
+    } as unknown as Config);
+
+    try {
+      await main();
+    } catch (error) {
+      if (!(error instanceof MockProcessExitError)) {
+        throw error;
+      }
+    }
+
+    expect(consoleLogSpy).toHaveBeenCalledWith('Installed extensions:');
+    expect(consoleLogSpy).toHaveBeenCalledWith('- my-ext (v1.0.0)');
+    expect(consoleLogSpy).toHaveBeenCalledWith('- old-ext (v0.5.2) [disabled]');
+    expect(processExitSpy).toHaveBeenCalledWith(0);
+    expect(runExitCleanupMock).toHaveBeenCalledTimes(1);
+    // Verify config.initialize() is called before getExtensions() — extensions are loaded during initialize
+    const configMock2 = (await vi.mocked(loadCliConfig).mock.results[0]!
+      .value) as unknown as { initialize: ReturnType<typeof vi.fn> };
+    expect(configMock2.initialize).toHaveBeenCalledTimes(1);
+
+    consoleLogSpy.mockRestore();
+    processExitSpy.mockRestore();
+  });
 });
 
 describe('gemini.tsx main function kitty protocol', () => {

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -756,6 +756,7 @@ describe('gemini.tsx main function', () => {
       getExtensions: () => [
         { name: 'my-ext', version: '1.0.0', isActive: true },
         { name: 'old-ext', version: '0.5.2', isActive: false },
+        { name: 'esc-ext', version: '2.0\x1b[31m.0', isActive: true },
       ],
       getApprovalMode: () => 'suggest',
       getMcpServers: () => ({}),
@@ -783,6 +784,8 @@ describe('gemini.tsx main function', () => {
     expect(consoleLogSpy).toHaveBeenCalledWith('Installed extensions:');
     expect(consoleLogSpy).toHaveBeenCalledWith('- my-ext (v1.0.0)');
     expect(consoleLogSpy).toHaveBeenCalledWith('- old-ext (v0.5.2) [disabled]');
+    // Verify non-printable characters are stripped from version output
+    expect(consoleLogSpy).toHaveBeenCalledWith('- esc-ext (v2.0[31m.0)');
     expect(processExitSpy).toHaveBeenCalledWith(0);
     expect(runExitCleanupMock).toHaveBeenCalledTimes(1);
     // Verify config.initialize() is called before getExtensions() — extensions are loaded during initialize

--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -796,6 +796,86 @@ describe('gemini.tsx main function', () => {
     consoleLogSpy.mockRestore();
     processExitSpy.mockRestore();
   });
+
+  it('should exit with code 1 and print error when config.initialize() fails during --list-extensions', async () => {
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const { loadSandboxConfig } = await import('./config/sandboxConfig.js');
+    const { relaunchAppInChildProcess } = await import('./utils/relaunch.js');
+    const cleanupModule = await import('./utils/cleanup.js');
+    const runExitCleanupMock = vi.mocked(cleanupModule.runExitCleanup);
+    runExitCleanupMock.mockResolvedValue(undefined);
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code) => {
+        throw new MockProcessExitError(code);
+      });
+    const stderrWriteSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation(() => true);
+
+    vi.mocked(loadSandboxConfig).mockResolvedValue(undefined);
+    vi.mocked(relaunchAppInChildProcess).mockResolvedValue(undefined);
+    vi.mocked(parseArguments).mockResolvedValue({
+      extensions: [],
+    } as never);
+    vi.mocked(loadSettings).mockReturnValue({
+      errors: [],
+      merged: {
+        advanced: {},
+        security: { auth: {} },
+        ui: {},
+      },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      migrationWarnings: [],
+      getUserHooks: () => undefined,
+      getProjectHooks: () => undefined,
+    } as never);
+    vi.mocked(loadCliConfig).mockResolvedValue({
+      isInteractive: () => false,
+      getQuestion: () => '',
+      getSandbox: () => false,
+      getDebugMode: () => false,
+      getListExtensions: () => true,
+      getExtensions: () => [],
+      getApprovalMode: () => 'suggest',
+      getMcpServers: () => ({}),
+      initialize: vi.fn().mockRejectedValue(new Error('config load failed')),
+      waitForMcpReady: vi.fn().mockResolvedValue(undefined),
+      getIdeMode: () => false,
+      getExperimentalZedIntegration: () => false,
+      getScreenReader: () => false,
+      getGeminiMdFileCount: () => 0,
+      getProjectRoot: () => '/',
+      getOutputFormat: () => OutputFormat.TEXT,
+      getWarnings: () => [],
+      getModelsConfig: () => ({ getCurrentAuthType: () => null }),
+      getSessionId: () => 'test-session-id',
+    } as unknown as Config);
+
+    try {
+      await main();
+    } catch (error) {
+      if (!(error instanceof MockProcessExitError)) {
+        throw error;
+      }
+    }
+
+    expect(stderrWriteSpy).toHaveBeenCalledWith(
+      'Error: failed to load extensions: config load failed\n',
+    );
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+    expect(runExitCleanupMock).toHaveBeenCalledTimes(1);
+    const configMock = (await vi.mocked(loadCliConfig).mock.results[0]!
+      .value) as unknown as { initialize: ReturnType<typeof vi.fn> };
+    expect(configMock.initialize).toHaveBeenCalledTimes(1);
+
+    stderrWriteSpy.mockRestore();
+    processExitSpy.mockRestore();
+  });
 });
 
 describe('gemini.tsx main function kitty protocol', () => {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -965,6 +965,33 @@ export async function main() {
     // Render UI, passing necessary config values. Check that there is no command line question.
     profileCheckpoint('before_render');
 
+    if (config.getListExtensions()) {
+      if (inputFormat === InputFormat.STREAM_JSON) {
+        await config.initialize();
+      }
+      const extensions = config.getExtensions();
+      if (extensions.length === 0) {
+        // eslint-disable-next-line no-console -- CLI flag output
+        console.log('No extensions installed.');
+      } else {
+        // eslint-disable-next-line no-console -- CLI flag output
+        console.log('Installed extensions:');
+        for (const extension of extensions) {
+          const safeVersion = extension.version.replace(
+            // eslint-disable-next-line no-control-regex -- intentional: strip control chars for safety
+            /[\x00-\x1f\x7f-\x9f]/g,
+            '',
+          );
+          // eslint-disable-next-line no-console -- CLI flag output
+          console.log(
+            `- ${extension.name} (v${safeVersion})${extension.isActive ? '' : ' [disabled]'}`,
+          );
+        }
+      }
+      await runExitCleanup();
+      process.exit(0);
+    }
+
     if (config.isInteractive()) {
       // --json-schema is a headless-only contract: the synthetic
       // structured_output tool only terminates the run inside
@@ -1049,32 +1076,6 @@ export async function main() {
       profileCheckpoint('config_initialize_start');
       await config.initialize();
       profileCheckpoint('config_initialize_end');
-
-      if (config.getListExtensions()) {
-        const extensions = config.getExtensions();
-        if (extensions.length === 0) {
-          // eslint-disable-next-line no-console -- CLI flag output
-          console.log('No extensions installed.');
-        } else {
-          // eslint-disable-next-line no-console -- CLI flag output
-          console.log('Installed extensions:');
-          for (const extension of extensions) {
-            // Strip non-printable characters from version to prevent
-            // terminal escape sequence injection.
-            const safeVersion = extension.version.replace(
-              // eslint-disable-next-line no-control-regex -- intentional: strip control chars for safety
-              /[\x00-\x1f\x7f-\x9f]/g,
-              '',
-            );
-            // eslint-disable-next-line no-console -- CLI flag output
-            console.log(
-              `- ${extension.name} (v${safeVersion})${extension.isActive ? '' : ' [disabled]'}`,
-            );
-          }
-        }
-        await runExitCleanup();
-        process.exit(0);
-      }
 
       // Non-interactive paths feed a prompt to the model immediately after
       // init. Under PR-A's progressive MCP availability,

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -966,8 +966,15 @@ export async function main() {
     profileCheckpoint('before_render');
 
     if (config.getListExtensions()) {
-      if (inputFormat === InputFormat.STREAM_JSON) {
+      // Always initialize config to populate extensionCache via refreshCache().
+      // Without this, getExtensions() returns [] because extensionCache is null.
+      try {
         await config.initialize();
+      } catch (err) {
+        debugLogger.warn(
+          'config.initialize() failed during --list-extensions:',
+          err,
+        );
       }
       const extensions = config.getExtensions();
       if (extensions.length === 0) {
@@ -982,9 +989,14 @@ export async function main() {
             /[\x00-\x1f\x7f-\x9f]/g,
             '',
           );
+          const safeName = extension.name.replace(
+            // eslint-disable-next-line no-control-regex -- intentional: strip control chars for safety
+            /[\x00-\x1f\x7f-\x9f]/g,
+            '',
+          );
           // eslint-disable-next-line no-console -- CLI flag output
           console.log(
-            `- ${extension.name} (v${safeVersion})${extension.isActive ? '' : ' [disabled]'}`,
+            `- ${safeName} (v${safeVersion})${extension.isActive ? '' : ' [disabled]'}`,
           );
         }
       }

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -833,7 +833,9 @@ export async function main() {
       const authType = modelsConfig.getCurrentAuthType();
       const resolvedBaseUrl = modelsConfig.getGenerationConfig().baseUrl;
       const proxy = config.getProxy();
-      preconnectApi(authType, { resolvedBaseUrl, proxy });
+      if (!config.getListExtensions()) {
+        preconnectApi(authType, { resolvedBaseUrl, proxy });
+      }
     } catch (error) {
       // If we can't get authType, skip preconnect - it's optional optimization
       debugLogger.debug(
@@ -1047,6 +1049,26 @@ export async function main() {
       profileCheckpoint('config_initialize_start');
       await config.initialize();
       profileCheckpoint('config_initialize_end');
+
+      if (config.getListExtensions()) {
+        const extensions = config.getExtensions();
+        if (extensions.length === 0) {
+          // eslint-disable-next-line no-console -- CLI flag output
+          console.log('No extensions installed.');
+        } else {
+          // eslint-disable-next-line no-console -- CLI flag output
+          console.log('Installed extensions:');
+          for (const extension of extensions) {
+            // eslint-disable-next-line no-console -- CLI flag output
+            console.log(
+              `- ${extension.name} (v${extension.version})${extension.isActive ? '' : ' [disabled]'}`,
+            );
+          }
+        }
+        await runExitCleanup();
+        process.exit(0);
+      }
+
       // Non-interactive paths feed a prompt to the model immediately after
       // init. Under PR-A's progressive MCP availability,
       // `config.initialize()` returns BEFORE MCP servers settle, so

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -971,10 +971,10 @@ export async function main() {
       try {
         await config.initialize();
       } catch (err) {
-        debugLogger.warn(
-          'config.initialize() failed during --list-extensions:',
-          err,
-        );
+        const msg = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`Error: failed to load extensions: ${msg}\n`);
+        await runExitCleanup();
+        process.exit(1);
       }
       const extensions = config.getExtensions();
       if (extensions.length === 0) {

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -1059,9 +1059,16 @@ export async function main() {
           // eslint-disable-next-line no-console -- CLI flag output
           console.log('Installed extensions:');
           for (const extension of extensions) {
+            // Strip non-printable characters from version to prevent
+            // terminal escape sequence injection.
+            const safeVersion = extension.version.replace(
+              // eslint-disable-next-line no-control-regex -- intentional: strip control chars for safety
+              /[\x00-\x1f\x7f-\x9f]/g,
+              '',
+            );
             // eslint-disable-next-line no-console -- CLI flag output
             console.log(
-              `- ${extension.name} (v${extension.version})${extension.isActive ? '' : ' [disabled]'}`,
+              `- ${extension.name} (v${safeVersion})${extension.isActive ? '' : ' [disabled]'}`,
             );
           }
         }


### PR DESCRIPTION
## Summary

- **What changed:** Uncommented and fixed the `--list-extensions` / `-l` flag handler in `packages/cli/src/gemini.tsx`
- **Why it changed:** The flag was parsed and stored but its handler was commented out (FIXME), causing the CLI to fall through into interactive mode instead of listing extensions and exiting. Fixes #4450.
- **Reviewer focus:** The original commented code referenced an undefined `extensions` variable — replaced with `config.getExtensions()` which is the proper API (returns `Extension[]` with `name`, `version`, `isActive`).

## Validation

- Commands run:
  ```bash
  qwen --list-extensions
  qwen -l
  ```
- Expected result: Lists installed extensions with name, version, and active status, then exits.
- Observed result: Previously launched interactive TUI. After fix, prints extension list and exits with code 0. Empty state shows "No extensions installed."
- Quickest reviewer verification path: Install an extension via `/extensions manage`, then run `qwen --list-extensions` from terminal.
- Evidence: The handler matches the output format of the interactive `/extensions manage` view (`ExtensionsList.tsx` uses `ext.name (v${ext.version})`).

## Scope / Risk

- Main risk or tradeoff: None — this was a pre-existing FIXME that only needed the correct API call.
- Not covered / not validated: Extension-specific settings are not shown (keeping output minimal, matching the flag's documented purpose "List all available extensions and exit").
- Breaking changes / migration notes: None.

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.