### PR TITLE
fix(extension): collect resources from same-name root directories (#4452)

### DIFF
--- a/packages/core/src/extension/claude-converter.test.ts
+++ b/packages/core/src/extension/claude-converter.test.ts
@@ -525,6 +525,109 @@ describe('convertClaudePluginPackage', () => {
     // Clean up converted directory
     fs.rmSync(result.convertedDir, { recursive: true, force: true });
   });
+
+  it('should collect resources from same-name root directories (e.g., ./commands/ -> commands/)', async () => {
+    // This tests the fix for #4452: when marketplace config specifies
+    // resources like ["./commands/"], and the plugin source has a root-level
+    // "commands/" directory, the contents should be collected correctly
+    // instead of being skipped.
+    const pluginSourceDir = path.join(testDir, 'plugin-same-name-dirs');
+    fs.mkdirSync(pluginSourceDir, { recursive: true });
+
+    // Create commands/, skills/, agents/ directories at plugin root
+    const commandsDir = path.join(pluginSourceDir, 'commands');
+    fs.mkdirSync(commandsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(commandsDir, 'generate.md'),
+      '---\nname: generate\n---\nGenerate wiki',
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(commandsDir, 'ask.md'),
+      '---\nname: ask\n---\nAsk wiki',
+      'utf-8',
+    );
+
+    const skillsDir = path.join(pluginSourceDir, 'skills');
+    fs.mkdirSync(path.join(skillsDir, 'wiki-architect'), { recursive: true });
+    fs.writeFileSync(
+      path.join(skillsDir, 'wiki-architect', 'SKILL.md'),
+      '# Wiki Architect Skill',
+      'utf-8',
+    );
+
+    const agentsDir = path.join(pluginSourceDir, 'agents');
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(agentsDir, 'wiki-architect.md'),
+      '---\nname: wiki-architect\ndescription: Architect agent\n---\nSystem prompt',
+      'utf-8',
+    );
+
+    // Create marketplace.json pointing to same-name directories
+    const marketplaceDir = path.join(pluginSourceDir, '.claude-plugin');
+    fs.mkdirSync(marketplaceDir, { recursive: true });
+
+    const pluginJson = { name: 'deep-wiki', version: '2.0.0' };
+    fs.writeFileSync(
+      path.join(marketplaceDir, 'plugin.json'),
+      JSON.stringify(pluginJson, null, 2),
+      'utf-8',
+    );
+
+    const marketplaceConfig: ClaudeMarketplaceConfig = {
+      name: 'test-marketplace',
+      owner: { name: 'Test', email: 'test@example.com' },
+      plugins: [
+        {
+          name: 'deep-wiki',
+          version: '2.0.0',
+          source: './',
+          strict: true,
+          commands: ['./commands/'],
+          skills: ['./skills/'],
+          agents: ['./agents/wiki-architect.md'],
+        },
+      ],
+    };
+
+    fs.writeFileSync(
+      path.join(marketplaceDir, 'marketplace.json'),
+      JSON.stringify(marketplaceConfig, null, 2),
+      'utf-8',
+    );
+
+    // Act
+    const result = await convertClaudePluginPackage(
+      pluginSourceDir,
+      'deep-wiki',
+    );
+
+    // Verify: commands were collected
+    const convertedCommandsDir = path.join(result.convertedDir, 'commands');
+    expect(fs.existsSync(convertedCommandsDir)).toBe(true);
+    const cmdFiles = fs.readdirSync(convertedCommandsDir);
+    expect(cmdFiles).toContain('generate.md');
+    expect(cmdFiles).toContain('ask.md');
+
+    // Verify: skills were collected
+    const convertedSkillsDir = path.join(result.convertedDir, 'skills');
+    expect(fs.existsSync(convertedSkillsDir)).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(convertedSkillsDir, 'wiki-architect', 'SKILL.md'),
+      ),
+    ).toBe(true);
+
+    // Verify: agents were collected
+    const convertedAgentsDir = path.join(result.convertedDir, 'agents');
+    expect(fs.existsSync(convertedAgentsDir)).toBe(true);
+    const agentFiles = fs.readdirSync(convertedAgentsDir);
+    expect(agentFiles).toContain('wiki-architect.md');
+
+    // Clean up
+    fs.rmSync(result.convertedDir, { recursive: true, force: true });
+  });
 });
 
 describe('performVariableReplacement for Claude extensions', () => {

--- a/packages/core/src/extension/claude-converter.ts
+++ b/packages/core/src/extension/claude-converter.ts
@@ -582,22 +582,17 @@ async function collectResources(
     const stat = fs.statSync(resolvedPath);
 
     if (stat.isDirectory()) {
-      // If it's a directory, check if it's already the destination folder
       const dirName = path.basename(resolvedPath);
       const parentDir = path.dirname(resolvedPath);
 
-      // If the directory is already named as the destination folder (e.g., 'commands')
-      // and it's at the plugin root level, skip it
-      if (dirName === destFolderName && parentDir === pluginRoot) {
-        debugLogger.debug(
-          `Skipping ${resolvedPath} as it's already in the correct location`,
-        );
-        continue;
-      }
-
-      // Determine destination: preserve the directory name
-      // e.g., ./skills/xlsx -> tmpDir/skills/xlsx/
-      const finalDestDir = path.join(destDir, dirName);
+      // Determine destination: if the directory has the same name as the
+      // destination folder and sits at the plugin root (e.g., config says
+      // "./commands/" and pluginRoot has a commands/ dir), copy its contents
+      // directly into destDir rather than creating a nested subdirectory.
+      const finalDestDir =
+        dirName === destFolderName && parentDir === pluginRoot
+          ? destDir
+          : path.join(destDir, dirName);
 
       // Copy all files from the directory
       const files = await glob('**/*', {
@@ -631,22 +626,23 @@ async function collectResources(
         fs.copyFileSync(srcFile, destFile);
       }
     } else {
-      // If it's a file, check if it's already in the destination folder
+      // If it's a file, preserve its relative path under the destination.
+      // e.g., ./agents/wiki-architect.md → destDir/wiki-architect.md
       const relativePath = path.relative(pluginRoot, resolvedPath);
-
-      // Check if the file path starts with the destination folder name
-      // e.g., 'commands/test1.md' or 'commands/me/test.md' should be skipped
       const segments = relativePath.split(path.sep);
-      if (segments.length > 0 && segments[0] === destFolderName) {
-        debugLogger.debug(
-          `Skipping ${resolvedPath} as it's already in ${destFolderName}/`,
-        );
-        continue;
-      }
 
-      // Copy the file to destination
-      const fileName = path.basename(resolvedPath);
-      const destFile = path.join(destDir, fileName);
+      // Strip the leading segment if it matches the destination folder name
+      // (e.g., 'agents/wiki-architect.md' → 'wiki-architect.md')
+      const destRelative =
+        segments.length > 1 && segments[0] === destFolderName
+          ? segments.slice(1).join(path.sep)
+          : path.basename(resolvedPath);
+
+      const destFile = path.join(destDir, destRelative);
+      const destFileDir = path.dirname(destFile);
+      if (!fs.existsSync(destFileDir)) {
+        fs.mkdirSync(destFileDir, { recursive: true });
+      }
       fs.copyFileSync(resolvedPath, destFile);
     }
   }


### PR DESCRIPTION
### Issue for this PR

Closes #4452

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes a bug in `collectResources()` within the Claude plugin converter that causes complex plugins (like `microsoft/skills` deep-wiki) to install as empty shells — the extension reports success but no commands, skills, or agents are actually available.

**Root cause:** When the marketplace config specifies resource paths like `["./commands/"]` pointing to a directory at the plugin root with the same name as the destination folder, `collectResources()` previously skipped the copy, assuming the content was already in place from the earlier `copyDirectory` step. However, step 6.1 in `convertClaudePluginPackage` deletes the destination folder *before* calling `collectResources`, leaving it permanently empty.

The existing test suite already documented this with a workaround comment (line 392): `"renamed to src-agents to avoid skip-logic bug"`.

**Fix:**
1. **Directory paths** (e.g., `./commands/`): Instead of skipping when the directory name matches the destination folder, copy contents directly into the destination (avoiding the double-nesting the original skip was trying to prevent).
2. **File paths** (e.g., `./agents/wiki-architect.md`): Strip the leading folder segment that matches the destination name, then copy to the correct location.

### How did you verify your code works?

- Added a new test case `should collect resources from same-name root directories` that replicates the exact deep-wiki plugin structure (commands/, skills/, and agents/ at plugin root, referenced via `["./commands/"]`, `["./skills/"]`, `["./agents/wiki-architect.md"]`)
- All 18 tests in `claude-converter.test.ts` pass
- Pre-commit hooks (prettier + eslint) pass

### Screenshots / recordings

N/A — no user-facing UI change. This is an internal file-copy logic fix.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.