### PR TITLE
fix(core): F2 cleanup PR B — self-heal observability (W133-a + W134)

### DIFF
--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -105,7 +105,8 @@ export class McpClient {
   /**
    * F2 (#4175 follow-up — W133-a): captures the most recent error
    * delivered to the SDK Client's `onerror` callback. The pool entry's
-   * W120 silent-drop block (`mcp-pool-entry.ts:346`) reads this via
+   * W120 silent-drop block (the DISCONNECTED-on-active branch inside
+   * `PoolEntry.statusChangeListener`) reads this via
    * `getLastTransportError()` to thread the upstream cause (EPIPE,
    * OAuth 401, server crash) into the `'failed'` event's `lastError`
    * string instead of emitting only the synthetic
@@ -337,8 +338,9 @@ export class McpClient {
    * the upstream cause (EPIPE, OAuth 401, server-side crash) into the
    * `'failed'` event's `lastError` string. Returns `undefined` if no
    * error has been observed since the last `connect()`. Caller falls
-   * back to the synthetic marker on `undefined`. See `mcp-client.ts:130`
-   * for the population site, `mcp-pool-entry.ts:346` for the consumer.
+   * back to the synthetic marker on `undefined`. Population site: the
+   * `client.onerror` arrow inside `connect()` (this file). Consumer:
+   * the W120 silent-drop block inside `PoolEntry.statusChangeListener`.
    */
   getLastTransportError(): Error | undefined {
     return this.lastTransportError;

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -102,6 +102,20 @@ export class McpClient {
   private transport: Transport | undefined;
   private status: MCPServerStatus = MCPServerStatus.DISCONNECTED;
   private isDisconnecting = false;
+  /**
+   * F2 (#4175 follow-up — W133-a): captures the most recent error
+   * delivered to the SDK Client's `onerror` callback. The pool entry's
+   * W120 silent-drop block (`mcp-pool-entry.ts:346`) reads this via
+   * `getLastTransportError()` to thread the upstream cause (EPIPE,
+   * OAuth 401, server crash) into the `'failed'` event's `lastError`
+   * string instead of emitting only the synthetic
+   * `'transport disconnected (silent transport drop)'` marker. Reset
+   * at the top of `connect()` so a successful reconnect clears stale
+   * state. No reset on `disconnect()` — McpClient instances are GC'd
+   * at pool entry teardown; field staleness has no observable
+   * consumer post-disconnect.
+   */
+  private lastTransportError?: Error;
 
   constructor(
     private readonly serverName: string,
@@ -123,6 +137,12 @@ export class McpClient {
    */
   async connect(): Promise<void> {
     this.isDisconnecting = false;
+    // F2 (#4175 follow-up — W133-a): clear stale upstream error from
+    // any prior connect/disconnect cycle. The W120 silent-drop reader
+    // is otherwise satisfied by `undefined` and falls back to the
+    // synthetic marker — but a stale error from a previous incarnation
+    // would mis-attribute a fresh transport drop to an old cause.
+    this.lastTransportError = undefined;
     this.updateStatus(MCPServerStatus.CONNECTING);
     try {
       this.transport = await this.createTransport();
@@ -131,6 +151,13 @@ export class McpClient {
         if (this.isDisconnecting) {
           return;
         }
+        // F2 (#4175 follow-up — W133-a): capture the upstream error
+        // BEFORE the synchronous `updateStatus(DISCONNECTED)` cascades
+        // to PoolEntry's statusChangeListener. The listener's W120
+        // silent-drop block reads `lastTransportError` inline; setting
+        // it ahead of `updateStatus` guarantees the field is populated
+        // by the time the listener fires.
+        this.lastTransportError = error;
         debugLogger.error(`MCP ERROR (${this.serverName}):`, error.toString());
         this.updateStatus(MCPServerStatus.DISCONNECTED);
       };
@@ -302,6 +329,19 @@ export class McpClient {
     const t = this.transport as { pid?: number | null } | undefined;
     if (!t || typeof t.pid !== 'number' || t.pid <= 0) return undefined;
     return t.pid;
+  }
+
+  /**
+   * F2 (#4175 follow-up — W133-a): expose the most recent SDK Client
+   * `onerror` payload so PoolEntry's W120 silent-drop block can thread
+   * the upstream cause (EPIPE, OAuth 401, server-side crash) into the
+   * `'failed'` event's `lastError` string. Returns `undefined` if no
+   * error has been observed since the last `connect()`. Caller falls
+   * back to the synthetic marker on `undefined`. See `mcp-client.ts:130`
+   * for the population site, `mcp-pool-entry.ts:346` for the consumer.
+   */
+  getLastTransportError(): Error | undefined {
+    return this.lastTransportError;
   }
 
   async readResource(

--- a/packages/core/src/tools/mcp-pool-entry.ts
+++ b/packages/core/src/tools/mcp-pool-entry.ts
@@ -108,6 +108,36 @@ export interface PooledConnection {
 }
 
 /**
+ * F2 (#4175 follow-up — W134): structured outcome of
+ * `PoolEntry.sweepAndDisconnect`. The silent-drop fire-and-forget
+ * caller (`mcp-pool-entry.ts:383`) reads this off the chained promise
+ * to surface orphan-process pressure to operators via a structured
+ * `warn` log. `forceShutdown` and `doRestart` callers ignore the
+ * return — their own catch paths carry richer error signals already.
+ *
+ * Both `descendantsFound` and `descendantsSignaled` are tracked
+ * because partial-signal failure (`signaled < found`) is itself
+ * orphan-process-pressure evidence even when the sweep itself does
+ * NOT throw — e.g. a child exited between `listDescendantPids` and
+ * `sigtermPids`, OR EPERM on a child the daemon doesn't own.
+ *
+ * Internal — NOT exported. The sweep result never crosses the wire
+ * (pool events stay shape-compatible per `PoolEvent` union); this
+ * type only exists to give the in-process caller something to chain
+ * a log decision on.
+ */
+interface SweepResult {
+  /** Set when `listDescendantPids` itself threw (sandbox blocking pgrep, ESRCH on root, etc.). */
+  pidSweepError?: Error;
+  /** Set when `client.disconnect()` threw. Rare — usually transport bug. */
+  disconnectError?: Error;
+  /** Number of descendant pids `listDescendantPids` returned. Undefined if root pid unavailable or sweep threw. */
+  descendantsFound?: number;
+  /** Number of descendant pids `sigtermPids` successfully signaled. May be < `descendantsFound`. */
+  descendantsSignaled?: number;
+}
+
+/**
  * Internal pool-entry record. Created once per `ConnectionId`,
  * holds the shared `McpClient` + its tool/prompt snapshots + ref
  * accounting + reconnect state.
@@ -343,11 +373,25 @@ export class PoolEntry {
         // 'failed' event and can route any pending callTool promises
         // to MCPCallInterruptedError. Mirrors forceShutdown's
         // emit→detach ordering at line 583-593.
+        //
+        // F2 (#4175 follow-up — W133-a): thread the upstream
+        // McpClient.onerror cause (EPIPE, OAuth 401, server crash)
+        // into `lastError` instead of emitting only the synthetic
+        // marker. Pre-fix the only diagnostic carrier was the synthetic
+        // string; operators triaging a 'failed' event had to grep
+        // daemon `--debug` logs for the matching `MCP ERROR (...)` line
+        // out of band. Now the actual error message is on the wire.
+        // Preserves the literal `"silent transport drop"` substring so
+        // any operator log-grep tooling that targets the pre-fix marker
+        // keeps matching post-fix.
+        const upstreamError = this.client.getLastTransportError();
         this.emit({
           kind: 'failed',
           serverName: this.serverName,
           generation: this._generation,
-          lastError: 'transport disconnected (silent transport drop)',
+          lastError: upstreamError
+            ? `transport disconnected (silent transport drop): ${upstreamError.message}`
+            : 'transport disconnected (silent transport drop)',
         });
         // Detach all subscriber views (W122 cleanup). Snapshot keys
         // because detach mutates `subscribers`.
@@ -381,7 +425,38 @@ export class PoolEntry {
         // Errors inside the chain log at warn/error via
         // `sweepAndDisconnect`'s own catches.
         void this.sweepAndDisconnect('silent_drop').then(
-          () => {
+          (result) => {
+            // F2 (#4175 follow-up — W134): surface orphan-process
+            // pressure to operators. Two failure shapes worth a
+            // structured `warn` here:
+            //   (a) `pidSweepError`: pid-discovery itself threw
+            //       (pgrep blocked by sandbox, ESRCH at root pid,
+            //       etc.). We may have leaked descendants we never
+            //       enumerated.
+            //   (b) Partial signal: discovery succeeded but
+            //       `sigtermPids` killed fewer than discovered
+            //       (some children already exited between listing
+            //       and signaling, OR EPERM on a child the daemon
+            //       doesn't own). Less alarming than (a) but still
+            //       worth surfacing during silent drops.
+            // Pre-fix `void` discarded both signals; the only
+            // observability path was tailing `--debug warn+` for
+            // the inner `sweepAndDisconnect` log line out of band.
+            const partialSignal =
+              result.descendantsFound !== undefined &&
+              result.descendantsSignaled !== undefined &&
+              result.descendantsSignaled < result.descendantsFound;
+            if (result.pidSweepError !== undefined || partialSignal) {
+              debugLogger.warn(
+                `PoolEntry ${this.id} silent-drop sweep observability: ` +
+                  `descendantsFound=${result.descendantsFound ?? 0}, ` +
+                  `descendantsSignaled=${result.descendantsSignaled ?? 0}, ` +
+                  `pidSweepError=${result.pidSweepError?.message ?? 'none'}. ` +
+                  `Possible orphan-process pressure — operator should ` +
+                  `check for lingering subprocess descendants of the dead ` +
+                  `transport.`,
+              );
+            }
             this.updateGlobalStatus();
           },
           () => {
@@ -716,21 +791,36 @@ export class PoolEntry {
    * usually indicates a transport bug worth surfacing). Pre-W35
    * `doRestart` had logged both at `debug` — production
    * observability gap that masked PID exhaustion.
+   *
+   * F2 (#4175 follow-up — W134): now returns a `SweepResult` so the
+   * silent-drop fire-and-forget caller (which `void`-discards the
+   * promise and would otherwise lose the orphan-process-pressure
+   * signal entirely) can chain a structured warn log when either pid
+   * sweep threw or `sigtermPids` partially signaled. The `forceShutdown`
+   * and `doRestart` callers continue to ignore the return value (their
+   * caller-side `await` discards it) — those paths already carry rich
+   * error signals via their own catches and don't need the extra
+   * surface. The internal log lines stay unchanged for backward
+   * compat with existing log-tail tooling.
    */
-  private async sweepAndDisconnect(reason: string): Promise<void> {
+  private async sweepAndDisconnect(reason: string): Promise<SweepResult> {
+    const result: SweepResult = {};
     try {
       const rootPid = this.client.getTransportPid?.();
       if (rootPid !== undefined) {
         const descendants = await listDescendantPids(rootPid);
         if (descendants.length > 0) {
-          const signaled = sigtermPids(descendants);
+          result.descendantsFound = descendants.length;
+          result.descendantsSignaled = sigtermPids(descendants);
           debugLogger.debug(
-            `Sent SIGTERM to ${signaled}/${descendants.length} descendants ` +
+            `Sent SIGTERM to ${result.descendantsSignaled}/${descendants.length} descendants ` +
               `of pid ${rootPid} for ${this.id} (${reason})`,
           );
         }
       }
     } catch (err) {
+      result.pidSweepError =
+        err instanceof Error ? err : new Error(String(err));
       debugLogger.warn(
         `Descendant pid sweep failed for ${this.id} (${reason}): ${String(
           err,
@@ -740,10 +830,13 @@ export class PoolEntry {
     try {
       await this.client.disconnect();
     } catch (err) {
+      result.disconnectError =
+        err instanceof Error ? err : new Error(String(err));
       debugLogger.error(
         `client.disconnect failed for ${this.id} (${reason}): ${String(err)}`,
       );
     }
+    return result;
   }
 
   /**

--- a/packages/core/src/tools/mcp-pool-entry.ts
+++ b/packages/core/src/tools/mcp-pool-entry.ts
@@ -110,10 +110,11 @@ export interface PooledConnection {
 /**
  * F2 (#4175 follow-up — W134): structured outcome of
  * `PoolEntry.sweepAndDisconnect`. The silent-drop fire-and-forget
- * caller (`mcp-pool-entry.ts:383`) reads this off the chained promise
- * to surface orphan-process pressure to operators via a structured
- * `warn` log. `forceShutdown` and `doRestart` callers ignore the
- * return — their own catch paths carry richer error signals already.
+ * caller (the W120 silent-drop block inside `statusChangeListener`)
+ * reads this off the chained promise to surface orphan-process
+ * pressure to operators via a structured `warn` log. `forceShutdown`
+ * and `doRestart` callers ignore the return — their own catch paths
+ * carry richer error signals already.
  *
  * Both `descendantsFound` and `descendantsSignaled` are tracked
  * because partial-signal failure (`signaled < found`) is itself
@@ -447,10 +448,20 @@ export class PoolEntry {
               result.descendantsSignaled !== undefined &&
               result.descendantsSignaled < result.descendantsFound;
             if (result.pidSweepError !== undefined || partialSignal) {
+              // F2 (#4175 follow-up — copilot review T2 on #4460):
+              // log `'unknown'` instead of `0` when the count fields are
+              // undefined. They are undefined ONLY in the
+              // `pidSweepError` branch (the throw happened before
+              // assignment); operators triaging the warn should be able
+              // to distinguish "0 found" (sweep succeeded, no children
+              // — unusual but possible if grandchildren already exited)
+              // from "not measured" (sweep itself threw, count is
+              // genuinely unknown). Logging `0` for both was factually
+              // ambiguous.
               debugLogger.warn(
                 `PoolEntry ${this.id} silent-drop sweep observability: ` +
-                  `descendantsFound=${result.descendantsFound ?? 0}, ` +
-                  `descendantsSignaled=${result.descendantsSignaled ?? 0}, ` +
+                  `descendantsFound=${result.descendantsFound ?? 'unknown'}, ` +
+                  `descendantsSignaled=${result.descendantsSignaled ?? 'unknown'}, ` +
                   `pidSweepError=${result.pidSweepError?.message ?? 'none'}. ` +
                   `Possible orphan-process pressure — operator should ` +
                   `check for lingering subprocess descendants of the dead ` +

--- a/packages/core/src/tools/mcp-pool-entry.ts
+++ b/packages/core/src/tools/mcp-pool-entry.ts
@@ -130,8 +130,6 @@ export interface PooledConnection {
 interface SweepResult {
   /** Set when `listDescendantPids` itself threw (sandbox blocking pgrep, ESRCH on root, etc.). */
   pidSweepError?: Error;
-  /** Set when `client.disconnect()` threw. Rare — usually transport bug. */
-  disconnectError?: Error;
   /** Number of descendant pids `listDescendantPids` returned. Undefined if root pid unavailable or sweep threw. */
   descendantsFound?: number;
   /** Number of descendant pids `sigtermPids` successfully signaled. May be < `descendantsFound`. */
@@ -841,8 +839,14 @@ export class PoolEntry {
     try {
       await this.client.disconnect();
     } catch (err) {
-      result.disconnectError =
-        err instanceof Error ? err : new Error(String(err));
+      // Disconnect failure is rare (usually a transport bug worth
+      // surfacing) and gets a structured error log here. No
+      // SweepResult field captures this — the silent-drop chain
+      // doesn't gate the outer warn on it (the inner error log
+      // already gives operators the signal), and forceShutdown /
+      // doRestart callers ignore the return entirely. Per wenshao
+      // review #4460: was previously stored on `SweepResult.disconnectError`
+      // but had no reader — removed as dead data.
       debugLogger.error(
         `client.disconnect failed for ${this.id} (${reason}): ${String(err)}`,
       );

--- a/packages/core/src/tools/mcp-transport-pool.test.ts
+++ b/packages/core/src/tools/mcp-transport-pool.test.ts
@@ -39,11 +39,15 @@ vi.mock('./pid-descendants.js', () => ({
 // return a vi.fn-backed stub. All existing tests are unaffected — they
 // don't assert on debugLogger output.
 //
-// Singleton stub: production code calls `createDebugLogger('McpPool:Entry')`
-// once at module load, and the test calls it again to retrieve the
-// same stub. Returning a fresh object per call would have given the
-// test a different vi.fn than the one production code captured at
-// module load, defeating the assertion.
+// Singleton-stub design: the `stub` object is constructed once when
+// the factory body runs (vitest evaluates the factory once per
+// `vi.mock` call), and the inner arrow `() => stub` returns that same
+// object on every `createDebugLogger(...)` invocation. So both the
+// production module-load call inside `mcp-pool-entry.ts` AND the
+// test's later retrieval get the exact same vi.fn instances —
+// `mockMock.warn` in the test is the same warn the production code
+// fired against. A factory that constructed a new object per call
+// would have broken that link.
 vi.mock('../utils/debugLogger.js', () => {
   const stub = {
     debug: vi.fn(),
@@ -726,8 +730,8 @@ describe('McpTransportPool', () => {
       });
 
       // Trigger via the production code path: invoke the SDK Client
-      // mock's `onerror` (set by McpClient.connect() at
-      // mcp-client.ts:130 during the acquire above). The arrow runs
+      // mock's `onerror` (assigned by `McpClient.connect()`'s arrow
+      // during the acquire above). The arrow runs
       // `this.lastTransportError = error` AND `updateStatus(DISCONNECTED)`
       // synchronously, so by the time the W120 listener fires, the
       // upstream error is already populated for `getLastTransportError()`.
@@ -846,6 +850,12 @@ describe('McpTransportPool', () => {
       )!;
       expect(obsCall[0]).toContain('orphan-process pressure');
       expect(obsCall[0]).toContain('pgrep blocked by sandbox');
+      // F2 (#4175 follow-up — copilot review T2 on #4460): when the
+      // pid sweep itself throws, the count fields are genuinely
+      // unmeasured. The warn payload should distinguish "not measured"
+      // from "0 found" via an explicit sentinel.
+      expect(obsCall[0]).toContain('descendantsFound=unknown');
+      expect(obsCall[0]).toContain('descendantsSignaled=unknown');
     });
 
     it('emits structured warn log when silent-drop sweep partially signals descendants (W134 partial-signal)', async () => {

--- a/packages/core/src/tools/mcp-transport-pool.test.ts
+++ b/packages/core/src/tools/mcp-transport-pool.test.ts
@@ -24,6 +24,36 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js');
 vi.mock('@modelcontextprotocol/sdk/client/stdio.js');
 vi.mock('@google/genai');
 
+// F2 (#4175 follow-up — W134): mocked so per-test overrides can make
+// `listDescendantPids` throw or return partial signaling. Defaults to
+// empty descendants so existing tests behave unchanged.
+vi.mock('./pid-descendants.js', () => ({
+  listDescendantPids: vi.fn().mockResolvedValue([]),
+  sigtermPids: vi.fn().mockReturnValue(0),
+}));
+
+// F2 (#4175 follow-up — W134): mocked so the test can assert
+// debugLogger.warn was called with the silent-drop sweep observability
+// payload. Production debugLogger is session-gated and a no-op in
+// tests (no AsyncLocalStorage session set), so we mock the factory to
+// return a vi.fn-backed stub. All existing tests are unaffected — they
+// don't assert on debugLogger output.
+//
+// Singleton stub: production code calls `createDebugLogger('McpPool:Entry')`
+// once at module load, and the test calls it again to retrieve the
+// same stub. Returning a fresh object per call would have given the
+// test a different vi.fn than the one production code captured at
+// module load, defeating the assertion.
+vi.mock('../utils/debugLogger.js', () => {
+  const stub = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  return { createDebugLogger: () => stub };
+});
+
 function mkPoolOptions(
   overrides: Partial<McpTransportPoolOptions> = {},
 ): McpTransportPoolOptions {
@@ -667,6 +697,216 @@ describe('McpTransportPool', () => {
       const r3 = mkSessionRegistries();
       const c = await pool.acquire('srv', cfg, 's3', r3.tools, r3.prompts);
       expect(c).toBeDefined();
+    });
+
+    // F2 (#4175 follow-up — W133-a / W134 PR B): self-heal observability
+    // tests. W133-a threads the upstream `McpClient.onerror` cause
+    // through to the silent-drop `'failed'` event's `lastError`; W134
+    // surfaces orphan-process pressure to operators via a structured
+    // warn log when the silent-drop's `sweepAndDisconnect` either
+    // throws on pid discovery or partially signals descendants.
+
+    it('threads upstream onerror cause into failed event lastError (W133-a)', async () => {
+      // Pre-fix: the silent-drop `'failed'` event's `lastError` carried
+      // only the synthetic marker `'transport disconnected (silent
+      // transport drop)'` — operators triaging a 'failed' event had to
+      // grep daemon `--debug` logs out of band for the matching `MCP
+      // ERROR (...)` line. Post-fix: McpClient.onerror captures the
+      // error in `lastTransportError`, and the W120 silent-drop block
+      // reads it via `getLastTransportError()` to append `: <message>`
+      // to the synthetic prefix.
+      const mocked = mockMcpSuccess({ toolNames: ['t1'] });
+      const pool = new McpTransportPool(cliConfig, mkPoolOptions());
+      const cfg = new MCPServerConfig('node');
+      const r1 = mkSessionRegistries();
+      const conn1 = await pool.acquire('srv', cfg, 's1', r1.tools, r1.prompts);
+      let failedEvent: { lastError?: string } | undefined;
+      conn1.on('event', (e) => {
+        if (e.kind === 'failed') failedEvent = e;
+      });
+
+      // Trigger via the production code path: invoke the SDK Client
+      // mock's `onerror` (set by McpClient.connect() at
+      // mcp-client.ts:130 during the acquire above). The arrow runs
+      // `this.lastTransportError = error` AND `updateStatus(DISCONNECTED)`
+      // synchronously, so by the time the W120 listener fires, the
+      // upstream error is already populated for `getLastTransportError()`.
+      const upstream = new Error('EPIPE: connection lost');
+      type MockedSdkClient = { onerror?: (e: Error) => void };
+      (mocked as MockedSdkClient).onerror?.(upstream);
+
+      expect(failedEvent).toBeDefined();
+      expect(failedEvent?.lastError).toContain('EPIPE: connection lost');
+      // Preserve the literal pre-fix marker substring so any operator
+      // log-grep tooling that targets `silent transport drop` keeps
+      // matching post-fix.
+      expect(failedEvent?.lastError).toContain('silent transport drop');
+    });
+
+    it('falls back to synthetic-only marker when no upstream onerror was captured (W133-a fallback)', async () => {
+      // Defense for the narrow race where the W120 listener fires from
+      // an external `updateMCPServerStatus(name, DISCONNECTED)` write
+      // that did NOT come from McpClient.onerror (e.g. a sibling
+      // fingerprint's `client.disconnect()` writing the shared map).
+      // `getLastTransportError()` returns undefined → caller falls back
+      // to the synthetic-only string. This test pins the behavior
+      // existing W120/W131 tests relied on pre-fix.
+      const { updateMCPServerStatus, MCPServerStatus } = await import(
+        './mcp-client.js'
+      );
+      mockMcpSuccess({ toolNames: ['t1'] });
+      const pool = new McpTransportPool(cliConfig, mkPoolOptions());
+      const cfg = new MCPServerConfig('node');
+      const r1 = mkSessionRegistries();
+      const conn1 = await pool.acquire('srv', cfg, 's1', r1.tools, r1.prompts);
+      let failedEvent: { lastError?: string } | undefined;
+      conn1.on('event', (e) => {
+        if (e.kind === 'failed') failedEvent = e;
+      });
+
+      // Bypass McpClient.onerror — write directly to the shared map.
+      const targetId = connectionIdOf('srv', cfg);
+      const entries = (pool as unknown as { entries: Map<string, PoolEntry> })
+        .entries;
+      const entry = entries.get(targetId)!;
+      const mockClient = (entry as unknown as { client: { status: unknown } })
+        .client;
+      mockClient.status = MCPServerStatus.DISCONNECTED;
+      updateMCPServerStatus('srv', MCPServerStatus.DISCONNECTED);
+
+      expect(failedEvent).toBeDefined();
+      // Synthetic-only string (no `: <message>` suffix).
+      expect(failedEvent?.lastError).toBe(
+        'transport disconnected (silent transport drop)',
+      );
+    });
+
+    it('emits structured warn log when silent-drop sweep throws on pid discovery (W134)', async () => {
+      // Pre-fix: `void this.sweepAndDisconnect('silent_drop')` swallowed
+      // the pid-sweep failure entirely — operators detecting orphan-
+      // process pressure had no signal beyond tailing `--debug warn+`
+      // for the inner sweep log line out of band. Post-fix: the silent-
+      // drop chain captures the SweepResult and emits a structured
+      // outer warn log when `pidSweepError` is set.
+      const { listDescendantPids } = await import('./pid-descendants.js');
+      const { createDebugLogger } = await import('../utils/debugLogger.js');
+      // The shared mock factory returns the SAME stub for the same call
+      // shape — re-invoke createDebugLogger to grab the warn vi.fn that
+      // mcp-pool-entry.ts captured at module load. (The mock's factory
+      // returns a NEW object each call, so we have to assert via the
+      // module-level mock invocations directly.)
+      const debugMock = createDebugLogger('McpPool:Entry');
+      // The stub is a singleton across tests; clear prior call history
+      // so we only observe THIS test's warn invocations.
+      (debugMock.warn as ReturnType<typeof vi.fn>).mockClear();
+      // Configure the pid-sweep to throw, simulating pgrep blocked by
+      // sandbox or a similar enumeration failure.
+      const sweepError = new Error('pgrep blocked by sandbox');
+      vi.mocked(listDescendantPids).mockRejectedValueOnce(sweepError);
+
+      const mocked = mockMcpSuccess({ toolNames: ['t1'] });
+      // Stub `getTransportPid` so sweepAndDisconnect actually invokes
+      // listDescendantPids (the default transport mock has no `pid`).
+      // Inject a numeric pid via the transport mock so the helper's
+      // `t.pid > 0` guard passes.
+      vi.mocked(SdkClientStdioLib.StdioClientTransport).mockReturnValue({
+        close: vi.fn().mockResolvedValue(undefined),
+        pid: 99999,
+      } as unknown as SdkClientStdioLib.StdioClientTransport);
+
+      const pool = new McpTransportPool(cliConfig, mkPoolOptions());
+      const cfg = new MCPServerConfig('node');
+      const r1 = mkSessionRegistries();
+      await pool.acquire('srv', cfg, 's1', r1.tools, r1.prompts);
+
+      // Trigger the silent-drop path via the production onerror flow.
+      type MockedSdkClient = { onerror?: (e: Error) => void };
+      (mocked as MockedSdkClient).onerror?.(new Error('upstream EPIPE'));
+
+      // sweepAndDisconnect runs asynchronously off the silent-drop
+      // chain. Flush microtasks to let the chain's `.then(...)` callback
+      // (which contains the warn log decision) settle.
+      await vi.waitFor(() => {
+        const calls = (debugMock.warn as ReturnType<typeof vi.fn>).mock.calls;
+        const obs = calls.find(
+          (c) =>
+            typeof c[0] === 'string' &&
+            c[0].includes('silent-drop sweep observability'),
+        );
+        expect(obs).toBeDefined();
+      });
+
+      // Verify the warn payload carries the orphan-process-pressure
+      // hint and the underlying pid-sweep error message.
+      const warnCalls = (debugMock.warn as ReturnType<typeof vi.fn>).mock.calls;
+      const obsCall = warnCalls.find(
+        (c) =>
+          typeof c[0] === 'string' &&
+          c[0].includes('silent-drop sweep observability'),
+      )!;
+      expect(obsCall[0]).toContain('orphan-process pressure');
+      expect(obsCall[0]).toContain('pgrep blocked by sandbox');
+    });
+
+    it('emits structured warn log when silent-drop sweep partially signals descendants (W134 partial-signal)', async () => {
+      // Pre-fix: a partial signal (sigtermPids killed fewer than
+      // listDescendantPids found — child exited mid-loop, EPERM on a
+      // child the daemon doesn't own, etc.) had no operator-facing
+      // signal at all (sweepAndDisconnect's internal log was at
+      // `debug` for the success-with-partial path). Post-fix: the
+      // silent-drop chain compares descendantsSignaled vs
+      // descendantsFound and emits the same outer warn even though
+      // sweepAndDisconnect itself didn't throw.
+      const { listDescendantPids, sigtermPids } = await import(
+        './pid-descendants.js'
+      );
+      const { createDebugLogger } = await import('../utils/debugLogger.js');
+      const debugMock = createDebugLogger('McpPool:Entry');
+      // The stub is a singleton across tests; clear prior call history
+      // so we only observe THIS test's warn invocations.
+      (debugMock.warn as ReturnType<typeof vi.fn>).mockClear();
+      // Set up the SDK mocks first (mockMcpSuccess installs the
+      // StdioClientTransport spy + ClientLib.Client mock); then
+      // override the transport return value with one that carries a
+      // numeric `pid` so sweepAndDisconnect actually invokes
+      // listDescendantPids.
+      const mocked = mockMcpSuccess({ toolNames: ['t1'] });
+      vi.mocked(SdkClientStdioLib.StdioClientTransport).mockReturnValue({
+        close: vi.fn().mockResolvedValue(undefined),
+        pid: 99999,
+      } as unknown as SdkClientStdioLib.StdioClientTransport);
+      // Discovered 3 descendants; only signaled 1.
+      vi.mocked(listDescendantPids).mockResolvedValueOnce([1001, 1002, 1003]);
+      vi.mocked(sigtermPids).mockReturnValueOnce(1);
+      const pool = new McpTransportPool(cliConfig, mkPoolOptions());
+      const cfg = new MCPServerConfig('node');
+      const r1 = mkSessionRegistries();
+      await pool.acquire('srv', cfg, 's1', r1.tools, r1.prompts);
+
+      type MockedSdkClient = { onerror?: (e: Error) => void };
+      (mocked as MockedSdkClient).onerror?.(new Error('upstream EPIPE'));
+
+      await vi.waitFor(() => {
+        const calls = (debugMock.warn as ReturnType<typeof vi.fn>).mock.calls;
+        const obs = calls.find(
+          (c) =>
+            typeof c[0] === 'string' &&
+            c[0].includes('silent-drop sweep observability'),
+        );
+        expect(obs).toBeDefined();
+      });
+
+      const warnCalls = (debugMock.warn as ReturnType<typeof vi.fn>).mock.calls;
+      const obsCall = warnCalls.find(
+        (c) =>
+          typeof c[0] === 'string' &&
+          c[0].includes('silent-drop sweep observability'),
+      )!;
+      // descendantsFound=3 / descendantsSignaled=1; pidSweepError=none.
+      expect(obsCall[0]).toContain('descendantsFound=3');
+      expect(obsCall[0]).toContain('descendantsSignaled=1');
+      expect(obsCall[0]).toContain('pidSweepError=none');
+      expect(obsCall[0]).toContain('orphan-process pressure');
     });
   });
 


### PR DESCRIPTION
## Summary

PR B of the F2 ([#4336](https://github.com/QwenLM/qwen-code/pull/4336)) post-merge cleanup bucket — issue [#4175 item 7](https://github.com/QwenLM/qwen-code/issues/4175). Two reviewer-filed observability gaps adopted; one (W93) source-verified non-repro and skipped.

- **W133-a** — `McpClient.onerror`'s upstream error (EPIPE / OAuth 401 / server-crash) is now threaded through to the silent-drop `'failed'` event's `lastError` string, so operators triaging a 'failed' event see the actual cause without grepping `--debug` logs out of band. Preserves the literal `"silent transport drop"` substring for log-grep backward compat.
- **W134** — `void this.sweepAndDisconnect('silent_drop')` no longer swallows pid-sweep failures. `sweepAndDisconnect` now returns a structured `SweepResult`; the silent-drop chain inspects it and emits a structured `warn` log when either `listDescendantPids` threw OR `sigtermPids` killed fewer descendants than discovered. Surfaces orphan-process pressure to operators without inflating PR scope (no new SSE event or SDK reducer state — deferred to W134-followup if maintainers want metrics).
- **W93** — declined; source-verified that the W1 fix in F2 commit 6 (`mcp-transport-pool.ts:1031-1035`) already added `entry.forceShutdown('manual')` to `spawnEntry`'s catch path, which runs the full cleanup table (status listener removal, timer clear, subscriber detach, sweep+disconnect, `onClosed` eviction). Post-W1 the "partial cleanup" claim doesn't reproduce.

## Changes

| File | Δ | What |
|---|---|---|
| `packages/core/src/tools/mcp-client.ts` | +40 / 0 | `lastTransportError?: Error` private field; populate in `onerror` BEFORE `updateStatus(DISCONNECTED)` cascade; reset at top of `connect()`; new `getLastTransportError()` getter |
| `packages/core/src/tools/mcp-pool-entry.ts` | +99 / -2 | `SweepResult` interface (file-private); `sweepAndDisconnect` returns it instead of `void`; W120 silent-drop block reads `getLastTransportError()` and appends `: <message>` to `lastError`; silent-drop fire-and-forget chain inspects result and `debugLogger.warn`s on `pidSweepError` OR partial-signal |
| `packages/core/src/tools/mcp-transport-pool.test.ts` | +242 / -3 | 4 new tests + 2 module-mocks (`pid-descendants.js`, `debugLogger.js` singleton stub) |

## Test plan

- [x] `npx vitest run --root packages/core src/tools/mcp-transport-pool.test.ts` — **32/32** pass (28 pre-existing + 4 new)
- [x] `npx vitest run --root packages/core src/tools/mcp-client.test.ts` — **46/46** pass (no behavior change beyond the new private field)
- [x] `npx tsc --noEmit -p packages/core/tsconfig.json` — clean
- [x] `npx tsc --noEmit -p packages/cli/tsconfig.json` — clean (pre-existing server.ts errors on baseline unchanged)
- [x] `npx eslint --max-warnings 0` clean on the 3 touched files

**Behavior changes** (zero wire/SDK breaking):
- `PoolEvent.failed.lastError` carries the upstream error message in a `: <msg>` suffix when `McpClient.onerror` captured one before the W120 listener fired. Pre-fix marker substring `"silent transport drop"` preserved.
- `sweepAndDisconnect` private return type changes from `Promise<void>` to `Promise<SweepResult>`. All 4 callers internal to `mcp-pool-entry.ts`; `forceShutdown` / `doRestart` ignore the return (JS implicit-void at await).
- New `debugLogger.warn` line on silent-drop sweep observability — surface only at `--debug warn+`, no other side effect.

**Audit notes** (covered in plan, captured here for reviewers):
- The second `mcpClient.onerror` at `mcp-client.ts:706` lives in the legacy non-class `connectAndDiscover` flow on a raw SDK `Client` — pool mode never reaches it.
- Manager-side `readResource` self-heal at `mcp-client-manager.ts:2390` checks `getStatus()`, doesn't read `lastError`. No interaction.
- Silent drop emits `'failed'` directly per JSDoc at `mcp-pool-events.ts:40-41`; no `'disconnected'` precedes it. Targeting the `'failed'` emit is correct.

## Follow-ups (out of scope)

- **W133-c** ([#4175 item 7 PR C](https://github.com/QwenLM/qwen-code/issues/4175)): add `source: 'reconnect_budget' | 'silent_drop'` discriminator field to `PoolEvent.failed`. Requires SDK semver minor bump.
- **W134 metrics surface**: if maintainers want a daemon-wide orphan-process pressure metric (counter on `GET /workspace/mcp` or new `mcp_sweep_warning` SSE event), file as W134-followup. This PR's structured `warn` log is the minimum viable signal.

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)


---

> **📝 描述准确性更新（2026-05-31，作者自查）**
>
> 注明：Changes 表行数偏旧（如 mcp-pool-entry 实为 +113/-5）。
