### PR TITLE
fix(build): tree-shake React reconciler dev build to prevent PerformanceMeasure leak

### DIFF
--- a/esbuild.config.js
+++ b/esbuild.config.js
@@ -112,6 +112,11 @@ esbuild
     },
     define: {
       'process.env.CLI_VERSION': JSON.stringify(pkg.version),
+      // react-reconciler ≥0.33 (ink 7) gates its dev build behind NODE_ENV
+      // and calls performance.measure() on every render, leaking
+      // PerformanceMeasure objects into the global measureEntryBuffer.
+      // Setting production here tree-shakes the entire dev build (~15k lines).
+      'process.env.NODE_ENV': JSON.stringify('production'),
       // Make global available for compatibility
       global: 'globalThis',
       // Redirect free __dirname/__filename references to the shim so that


### PR DESCRIPTION
## Summary

- What changed: Set `process.env.NODE_ENV` to `"production"` in the esbuild `define` map so the React reconciler's development build is tree-shaken from the production bundle.
- Why it changed: The ink 6→7 upgrade (v0.15.11, PR #3860) pulled in react-reconciler 0.33, whose development build calls `performance.measure()` on every Ink component render. Since `NODE_ENV` was never defined at build time, esbuild bundled **both** dev and prod builds and selected dev at runtime — leaking `PerformanceMeasure` objects into the global `measureEntryBuffer` indefinitely. Heap snapshot analysis shows this single buffer retains **~148 MB (45% of heap)** after moderate usage, contributing to OOM crashes at the 4 GB limit.
- Reviewer focus: The one-line `define` addition in `esbuild.config.js`. Verify no code relies on `process.env.NODE_ENV !== "production"` at runtime in the bundled output.

<img width="2382" height="596" alt="image" src="https://github.com/user-attachments/assets/526f009a-47f8-44fe-8c6a-1f33d2b6c4e3" />


## Validation

- Commands run:
  ```bash
  # Before fix
  npm run bundle
  grep -c 'performance\.measure' dist/cli.js          # 17
  grep -c 'process\.env\.NODE_ENV' dist/cli.js        # 22
  wc -l < dist/cli.js                                 # 170,636

  # After fix
  npm run bundle
  grep -c 'performance\.measure' dist/cli.js          # 0
  grep -c 'process\.env\.NODE_ENV' dist/cli.js        # 0
  wc -l < dist/cli.js                                 # 154,798
  node dist/cli.js --version                           # 0.16.0
  ```
- Also confirmed by downloading published npm packages:
  - `@qwen-code/qwen-code@0.15.10` (ink 6, react-reconciler 0.31): 0 `performance.measure` calls — no leak
  - `@qwen-code/qwen-code@0.15.11` (ink 7, react-reconciler 0.33): 17 `performance.measure` calls — leak introduced
- Heap snapshot evidence (Chrome DevTools):
  - `measureEntryBuffer` retains 148,173 KB (45% of 331 MB heap) after 3 parallel Explore agents + bash commands
  - 150,719 `PerformanceMeasure` objects accumulated, never cleared
- Expected result: No `performance.measure` calls in bundle; dev build fully eliminated
- Observed result: Bundle shrinks by **15,838 lines / 700 KB**; zero React profiling overhead at runtime
- Quickest reviewer verification path: `npm run bundle && grep -c 'performance\.measure' dist/cli.js` → should be 0

## Scope / Risk

- Main risk or tradeoff: Any code that checks `process.env.NODE_ENV` at runtime in the bundled output will now see `"production"` instead of `undefined`. This is standard practice for Node.js CLI tools and all affected packages (react, react-reconciler, react-dom, react-jsx-runtime) are designed for this.
- Not covered / not validated: The `performance.measure` leak also affects running from source (`node packages/cli/dist/index.js`) since tests/dev use the unbundled `node_modules` which still do the runtime `NODE_ENV` check. A separate fix (e.g., setting `NODE_ENV=production` in the sandbox launcher) could address that.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ⚠️  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Verified bundle build + `--version` + `--help` on macOS arm64

## Linked Issues / Bugs

Partially addresses #4185 — this fix eliminates one major contributor (~45% of heap) to the OOM crashes in long sessions. The remaining memory pressure from conversation history growth (#4184, #4185) is a separate concern.

The ink 6→7 upgrade landed in v0.15.11 (May 13) via PR #3860. A wave of OOM reports appeared immediately after:

- #4116 — May 13 (same day)
- #4134 — May 14 (explicitly reports v0.15.11, "随着正常任务进行，会很容易出现OOM错误")
- #4149 — May 14
- #4167 — May 15
- #4254 — May 17 ("It keeps eating and eating and eating memory till it crashes")
- #4276 — May 18
- #4309 — May 19 (explicitly reports v0.15.11, 7 GB memory usage)
- #4315 — May 19
- #4322 — May 19
- #4351 — May 20
- #4399 — May 21
- #4435 — May 22
- #2945, #2868 — earlier issues, likely worsened by the same root cause

---

🤖 Generated with Claude Code
