### PR TITLE
fix(weixin): send decryptable image payloads

### DIFF
--- a/packages/channels/weixin/src/media.ts
+++ b/packages/channels/weixin/src/media.ts
@@ -19,8 +19,8 @@ function decryptAesEcb(ciphertext: Buffer, key: Buffer): Buffer {
 /**
  * Parse aes_key from CDNMedia into a raw 16-byte Buffer.
  * Two encodings exist:
- *   - base64(raw 16 bytes) → images
- *   - base64(hex string of 16 bytes) → file/voice/video
+ *   - base64(raw 16 bytes)
+ *   - base64(hex string of 16 bytes)
  */
 export function parseAesKey(aesKeyBase64: string): Buffer {
   const decoded = Buffer.from(aesKeyBase64, 'base64');

--- a/packages/channels/weixin/src/send.test.ts
+++ b/packages/channels/weixin/src/send.test.ts
@@ -325,8 +325,13 @@ describe('sendImage', () => {
       expectedEncrypted,
     );
 
-    // Step 4: send message with image_item using CDN's x-encrypted-param
-    const expectedAesKeyBase64 = aesKeyBytes.toString('base64');
+    // Step 4: send message with image_item using CDN's x-encrypted-param.
+    // WeChat expects images to include the hex key both directly and
+    // base64-encoded in the media payload.
+    const expectedAesKeyBase64 = Buffer.from(
+      expectedAesKeyHex,
+      'ascii',
+    ).toString('base64');
     expect(mockSendMessage).toHaveBeenCalledWith(
       'https://api.example.com',
       'token-abc',
@@ -337,6 +342,8 @@ describe('sendImage', () => {
           expect.objectContaining({
             type: 2, // MessageItemType.IMAGE
             image_item: expect.objectContaining({
+              aeskey: expectedAesKeyHex,
+              mid_size: encryptedSize,
               media: {
                 encrypt_query_param: 'cdn-encrypt-param',
                 aes_key: expectedAesKeyBase64,

--- a/packages/channels/weixin/src/send.ts
+++ b/packages/channels/weixin/src/send.ts
@@ -231,9 +231,10 @@ export async function sendImage(params: {
   const encrypted = encryptAesEcb(fileBuffer, aesKeyBytes);
   const cdnEncryptParam = await uploadToCdn(uploadParam, filekey, encrypted);
 
-  // Step 4: send message with image_item using CDN's x-encrypted-param
-  // aes_key: base64(raw 16 bytes) for images per protocol
-  const aesKeyBase64 = aesKeyBytes.toString('base64');
+  // Step 4: send message with image_item using CDN's x-encrypted-param.
+  // WeChat image messages expect the AES key as a hex string, with media.aes_key
+  // carrying base64(hex string), not base64(raw bytes).
+  const aesKeyBase64 = Buffer.from(aesKeyHex, 'ascii').toString('base64');
 
   await sendMessage(baseUrl, token, {
     to_user_id: to,
@@ -246,6 +247,8 @@ export async function sendImage(params: {
       {
         type: MessageItemType.IMAGE,
         image_item: {
+          aeskey: aesKeyHex,
+          mid_size: encryptedSize,
           media: {
             encrypt_query_param: cdnEncryptParam,
             aes_key: aesKeyBase64,


### PR DESCRIPTION
## Summary

- What changed: Fix Weixin image message payloads so sent images can be decrypted and displayed by the WeChat client.
- Why it changed: Images were uploaded and sent successfully at the API level, but the WeChat client showed a gray placeholder because the outbound image payload used the wrong AES key encoding and omitted image metadata.
- Reviewer focus: Please review the `image_item` media payload fields, especially `aes_key`, `aeskey`, and `mid_size`.

## Validation

- Commands run:
  ```bash
  cd packages/channels/weixin
  npx vitest run src/send.test.ts src/media.test.ts
  npx tsc --build --pretty false
  ```

- Prompts / inputs used:
  - Directly called `sendImage()` with a real PNG file on macOS.
  - Image path: `/tmp/qwen-weixin-image-test/icon.png`

- Expected result:
  - WeChat receives a visible image instead of a gray placeholder.

- Observed result:
  - Unit tests passed: 41 tests passed.
  - TypeScript package build passed.
  - Manual macOS Weixin smoke test sent an image that displayed correctly in WeChat.

- Quickest reviewer verification path:
  ```bash
  cd packages/channels/weixin
  npx vitest run src/send.test.ts src/media.test.ts
  ```

- Evidence:
  - Manual smoke test was verified locally on macOS with a real WeChat login.
  - The received image displayed normally after this change.

## Scope / Risk

- Main risk or tradeoff:
  - This changes the outbound Weixin image payload shape. It aligns the sent image payload with the format verified by manual WeChat testing.

- Not covered / not validated:
  - Windows-specific image path validation is intentionally not included in this PR.
  - Real Windows E2E validation is not covered here.
  - Full cross-platform channel E2E matrix was not run.

- Breaking changes / migration notes:
  - None expected.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- macOS was validated with package-level `npx vitest` / `npx tsc` and a manual Weixin image send smoke test.
- Windows and Linux E2E are not part of this PR.

## Linked Issues / Bugs

Fixes #3993
