### PR TITLE
fix(weixin): allow Windows image paths inside workspace

### DIFF
--- a/packages/channels/weixin/src/send.test.ts
+++ b/packages/channels/weixin/src/send.test.ts
@@ -240,6 +240,45 @@ describe('validateImagePath', () => {
     );
   });
 
+  it('allows Windows paths inside the workspace directory', () => {
+    const imagePath = 'D:\\WorkGroup\\QwenCode\\002\\hello.png';
+    const workspaceDir = 'D:\\WorkGroup\\QwenCode\\002';
+    mockRealpathSync.mockImplementation((p: string) => {
+      if (p.includes('hello.png')) return imagePath;
+      if (p.includes('QwenCode\\002')) return workspaceDir;
+      return p;
+    });
+
+    expect(validateImagePath(imagePath, [workspaceDir])).toBe(imagePath);
+  });
+
+  it('rejects Windows paths in a sibling directory with the same prefix', () => {
+    const imagePath = 'D:\\WorkGroup\\QwenCode\\0022\\hello.png';
+    const workspaceDir = 'D:\\WorkGroup\\QwenCode\\002';
+    mockRealpathSync.mockImplementation((p: string) => {
+      if (p.includes('hello.png')) return imagePath;
+      if (p.includes('QwenCode\\002')) return workspaceDir;
+      return p;
+    });
+
+    expect(() => validateImagePath(imagePath, [workspaceDir])).toThrow(
+      'Image path outside allowed directories',
+    );
+  });
+
+  it('does not treat POSIX backslashes as directory separators', () => {
+    const imagePath = '/home/user/project\\escape.png';
+    mockRealpathSync.mockImplementation((p: string) => {
+      if (p.includes('escape.png')) return imagePath;
+      if (p === '/home/user/project') return '/home/user/project';
+      return p;
+    });
+
+    expect(() => validateImagePath(imagePath, workspaceDirs)).toThrow(
+      'Image path outside allowed directories',
+    );
+  });
+
   it('rejects image with magic bytes that do not match extension', () => {
     // readSync returns JPEG magic, but file extension is .png
     vi.mocked(fs.readSync).mockImplementation((_fd: number, buf: Buffer) => {

--- a/packages/channels/weixin/src/send.ts
+++ b/packages/channels/weixin/src/send.ts
@@ -12,7 +12,7 @@ import {
   closeSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { resolve, extname } from 'node:path';
+import { resolve, extname, win32, posix } from 'node:path';
 import { sendMessage, getUploadUrl, uploadToCdn } from './api.js';
 import { MessageType, MessageState, MessageItemType } from './types.js';
 import { encryptAesEcb, computeMd5 } from './media.js';
@@ -44,6 +44,28 @@ export function markdownToPlainText(text: string): string {
 
 const ALLOWED_EXTS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp']);
 const MAX_IMAGE_SIZE = 20 * 1024 * 1024; // 20 MB
+
+function looksLikeWindowsPath(pathValue: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(pathValue) || pathValue.startsWith('\\\\');
+}
+
+function normalizeWindowsPath(pathValue: string): string {
+  return pathValue.replace(/\//g, '\\');
+}
+
+function isInsideAllowedDir(realPath: string, allowedDir: string): boolean {
+  const windowsStyle =
+    looksLikeWindowsPath(realPath) || looksLikeWindowsPath(allowedDir);
+  const pathImpl = windowsStyle ? win32 : posix;
+  const from = windowsStyle ? normalizeWindowsPath(allowedDir) : allowedDir;
+  const to = windowsStyle ? normalizeWindowsPath(realPath) : realPath;
+  const relative = pathImpl.relative(from, to);
+
+  return (
+    relative === '' ||
+    (!relative.startsWith('..') && !pathImpl.isAbsolute(relative))
+  );
+}
 
 /** Image magic bytes → MIME type mapping. */
 export function detectImageMime(data: Buffer): string {
@@ -125,7 +147,7 @@ export function validateImagePath(
     ...workspaceDirs.map((d) => realpathSync(resolve(d)) + '/'),
   ];
 
-  if (!ALLOWED_DIRS.some((dir) => real.startsWith(dir))) {
+  if (!ALLOWED_DIRS.some((dir) => isInsideAllowedDir(real, dir))) {
     throw new Error(`Image path outside allowed directories: ${real}`);
   }
 


### PR DESCRIPTION
## Summary

- What changed: Make Weixin image path allowlist checks understand Windows-style paths when validating `[IMAGE: ...]` files.
- Why it changed: Windows paths such as `D:\WorkGroup\QwenCode\002\hello.png` could be rejected as outside the allowed workspace directory even when the file is inside that workspace.
- Reviewer focus: Please review the path containment logic, especially the Windows/POSIX path-style split and sibling-directory boundary checks.

## Validation

- Commands run:
  ```bash
  cd packages/channels/weixin
  npx vitest run src/send.test.ts src/media.test.ts
  npx tsc --build --pretty false
  git diff --check
  ```

- Prompts / inputs used:
  - Unit tests cover `D:\WorkGroup\QwenCode\002\hello.png` inside `D:\WorkGroup\QwenCode\002`.
  - Unit tests also cover a Windows sibling directory with the same prefix and a POSIX path containing backslashes.

- Expected result:
  - A Windows image path inside the configured workspace is accepted.
  - A Windows sibling path with a shared prefix is rejected.
  - POSIX backslashes are not treated as directory separators.

- Observed result:
  - Unit tests passed: 44 tests passed.
  - Weixin package TypeScript build passed.
  - Whitespace check passed.

- Quickest reviewer verification path:
  ```bash
  cd packages/channels/weixin
  npx vitest run src/send.test.ts src/media.test.ts
  ```

- Evidence:
  - `src/send.test.ts` now includes regression coverage for Windows-style workspace image paths and boundary rejection.

## Scope / Risk

- Main risk or tradeoff:
  - This touches image path validation, which is a security boundary for AI-controlled `[IMAGE: ...]` markers. The change uses `path.win32.relative()` / `path.posix.relative()` so path containment is checked with path semantics instead of raw string prefixes.

- Not covered / not validated:
  - Real Windows + Weixin E2E was not validated by the author.
  - This PR does not include the separate Weixin gray-placeholder payload fix from #4464.

- Breaking changes / migration notes:
  - None expected.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ⚠️  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- macOS was used to run package-level `npx vitest` and `npx tsc`.
- Windows path behavior is covered by unit tests, but real Windows E2E is still pending.

## Linked Issues / Bugs

Refs #4441
