### PR TITLE
docs(serve): v0.16-alpha known limits + SDK QWEN_SERVER_TOKEN env fallback (PR 27)

### DIFF
--- a/docs/developers/examples/daemon-client-quickstart.md
+++ b/docs/developers/examples/daemon-client-quickstart.md
@@ -30,7 +30,8 @@ const client = new DaemonClient({
   // PR 27 (v0.16-alpha): when `token` is omitted, DaemonClient falls
   // back to `process.env.QWEN_SERVER_TOKEN` automatically — same env
   // var the daemon's `--token` CLI flag falls back to. So either:
-  //   export QWEN_SERVER_TOKEN="$(cat ~/.qwen/server-token)"
+  //   export QWEN_SERVER_TOKEN="$(openssl rand -hex 32)"   # one-shot
+  //   export QWEN_SERVER_TOKEN="$(cat ./my-token-file)"    # user-managed file
   //   const client = new DaemonClient({ baseUrl: '...' });
   // OR pass it explicitly when you have a different env-var name:
   //   token: process.env.MY_TOKEN,

--- a/docs/developers/examples/daemon-client-quickstart.md
+++ b/docs/developers/examples/daemon-client-quickstart.md
@@ -27,7 +27,13 @@ import { DaemonClient, type DaemonEvent } from '@qwen-code/sdk';
 
 const client = new DaemonClient({
   baseUrl: 'http://127.0.0.1:4170',
-  // token: process.env.QWEN_SERVER_TOKEN, // required for non-loopback binds
+  // PR 27 (v0.16-alpha): when `token` is omitted, DaemonClient falls
+  // back to `process.env.QWEN_SERVER_TOKEN` automatically — same env
+  // var the daemon's `--token` CLI flag falls back to. So either:
+  //   export QWEN_SERVER_TOKEN="$(cat ~/.qwen/server-token)"
+  //   const client = new DaemonClient({ baseUrl: '...' });
+  // OR pass it explicitly when you have a different env-var name:
+  //   token: process.env.MY_TOKEN,
 });
 
 // 1. Confirm we can reach the daemon, gate UI on its features, and
@@ -232,6 +238,15 @@ const client = new DaemonClient({
   token: process.env.QWEN_SERVER_TOKEN,
 });
 ```
+
+**SDK env fallback (PR 27, v0.16-alpha)** — `DaemonClient` reads `QWEN_SERVER_TOKEN` from the environment automatically when `token` is omitted, mirroring the daemon's own `--token` CLI fallback. So if your shell has `export QWEN_SERVER_TOKEN=...`, this is equivalent to the above:
+
+```ts
+// Same effect as token: process.env.QWEN_SERVER_TOKEN, but without the boilerplate.
+const client = new DaemonClient({ baseUrl: 'https://your-host:4170' });
+```
+
+The fallback strips leading/trailing whitespace (handy for `export QWEN_SERVER_TOKEN="$(cat token.txt)"` where `cat` adds a newline) and treats empty / whitespace-only values as unset (a stale `export QWEN_SERVER_TOKEN=""` won't accidentally send `Authorization: Bearer ` with no token). The fallback runs once at construction; later `process.env` mutations don't affect already-built clients. Browser bundles (e.g. via `@qwen-code/webui`) get `undefined` cleanly because `globalThis.process` doesn't exist there.
 
 Wrong / missing tokens return `401` with a uniform body — the SDK throws `DaemonHttpError` on any 4xx/5xx from a route handler.
 

--- a/docs/users/qwen-serve.md
+++ b/docs/users/qwen-serve.md
@@ -2,6 +2,8 @@
 
 Run Qwen Code as a local HTTP daemon so multiple clients (IDE plugins, web UIs, CI scripts, custom CLIs) share one agent session over HTTP + Server-Sent Events instead of each spawning their own subprocess.
 
+> **🚧 v0.16-alpha**: `qwen serve` first ships to npm in v0.16-alpha as **text-only chat / coding** with **local-only deployment**. Image / file attachments on the prompt path, containerized deployment (Docker / k8s / nginx reverse-proxy), and remote / multi-daemon hardening land in a follow-up patch when an enterprise pilot is committed. See [v0.16-alpha known limits](#v016-alpha-known-limits) for the full deferred list.
+
 > **Status:** Stage 1 (experimental). The protocol surface is locked at the §04 routes table from issue [#3803](https://github.com/QwenLM/qwen-code/issues/3803). Stage 1.5 (`qwen --serve` flag — TUI co-hosts the same HTTP server) and Stage 2 (in-process refactor + `mDNS`/OpenAPI/WebSocket/Prometheus polish) are immediately downstream.
 >
 > **Scope honesty:** Stage 1 is sized for **developers prototyping clients against the protocol surface** and for **local single-user / small-team collaboration**. Production-grade multi-client / long-running / network-flaky workloads (mobile companions, IM bots reaching 1000+ chats) need Stage 1.5+ guarantees that aren't in this release. See [Stage 1.5+ runtime guarantees](#stage-15-runtime-guarantees) for the full gap list and #3803 for the convergence roadmap.
@@ -13,6 +15,36 @@ Run Qwen Code as a local HTTP daemon so multiple clients (IDE plugins, web UIs, 
 - **First-responder permissions** — when the agent asks for permission to run a tool, every connected client sees the request; whichever client answers first wins.
 - **One daemon, one workspace** — each `qwen serve` process binds to exactly one workspace at boot (per [#3803](https://github.com/QwenLM/qwen-code/issues/3803) §02). Multi-workspace deployments run one daemon per workspace on separate ports (or behind an orchestrator).
 - **Remote runtime control** ([#4175](https://github.com/QwenLM/qwen-code/issues/4175) PR 17) — change a session's approval mode (`POST /session/:id/approval-mode`), toggle a tool per workspace (`POST /workspace/tools/:name/enable`), scaffold an empty `QWEN.md` (`POST /workspace/init`, mechanical only — does NOT call the model; for AI-fill, follow up with `POST /session/:id/prompt`), or restart a single MCP server with a budget pre-check (`POST /workspace/mcp/:server/restart`). All four are strict-gated — configure `--token` first.
+
+## v0.16-alpha known limits
+
+The first npm release of `qwen serve` (v0.16-alpha) is intentionally narrow — text-only chat / coding for developers running the daemon on their own machine. The list below makes the deferred surface explicit so adopters can plan around it; everything here is on the v0.16.x patch roadmap or a near-term follow-up release.
+
+**Product surface — text-only:**
+
+- ✅ Text prompts and text responses (chat, coding, tool calls, MCP integration)
+- ❌ **Image / file attachments on the prompt path** — `MessageEmitter` currently only renders text; multimodal echo lands when an alpha target with image needs is committed (#4175 chiga0 #27 P0 item)
+- ❌ **Streaming uploads** — same gating as multimodal
+
+**Deployment surface — local-only:**
+
+- ✅ Loopback (`127.0.0.1`, default) — no auth required, suitable for dev workstations
+- ✅ Local launch via `systemd` / `launchd` / `nohup &` / `tmux` (templates land in PR 30a)
+- ✅ Bring-your-own bearer token via `QWEN_SERVER_TOKEN` env var ([Authentication](#authentication) for setup)
+- ❌ **Containerized deployment** — Docker / Compose / Kubernetes / nginx reverse-proxy with TLS termination NOT in v0.16-alpha. Defers to v0.16.x once an enterprise pilot is committed (would otherwise rot from no-one-validating).
+- ❌ **Multi-daemon coordination on one host** — `1 daemon = 1 workspace × N sessions` is enforced. Cross-host federation, instance-path token keying, and stale-token cleanup defer to v0.16.x.
+- ❌ **Auto-generated daemon tokens** — alpha is BYO-token (one `openssl rand -hex 32` away). Auto-gen + token-store infrastructure defers to v0.16.x.
+
+**Hardening — minimum viable for local single-user:**
+
+- ✅ Boot-time security gate (refuses non-loopback bind without a token, [PR 15 / #4236](https://github.com/QwenLM/qwen-code/pull/4236))
+- ✅ Mutation-route auth gate, session-scoped permission routing (Wave 4 PRs)
+- ✅ MCP guardrails + multi-client permission coordination (F2 / F3)
+- ⏸️ **Prompt absolute deadline + SSE writer idle timeout** — current AbortSignal + 15s heartbeat + `res.on('error')` cleanup is sufficient for local dev; explicit application-layer deadlines defer to v0.16.x once a remote / long-running scenario lands.
+- ⏸️ **Rate limiting + observability + load test harness** — defers to v0.17 F4 Phase-1 scale instrumentation when 30-50 active sessions becomes a real target.
+- ⏸️ **`--max-body-size` CLI flag** — daemon enforces `express.json({ limit: '10mb' })` by default which comfortably covers text-only prompts (model context windows are well under 10 MiB of chars). Tunable via flag in v0.16.x.
+
+For the deeper "what we won't fix in Stage 1" enumeration (single-host session-state mutation model + N-parallel-sessions sharing one ACP child), see [Stage 1 scope boundaries](#stage-1-scope-boundaries--what-we-wont-fix-in-stage-15) below.
 
 ## Quickstart
 

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -127,6 +127,46 @@ function stripTrailingSlashes(url: string): string {
 }
 
 /**
+ * PR 27 (#4175 v0.16-alpha): SDK env fallback for the daemon bearer
+ * token. Mirrors the daemon-side `--token` CLI fallback to
+ * `QWEN_SERVER_TOKEN` (`runQwenServe.ts:175`) so a developer with
+ * `export QWEN_SERVER_TOKEN=...` in their shell never has to thread
+ * the value through every `DaemonClient` construction.
+ *
+ * Defensive on three axes:
+ *   1. **Browser-safe**: `globalThis.process` indirection. The SDK is
+ *      imported by `@qwen-code/webui` (#4328); a literal
+ *      `process.env[...]` would explode at module load on browser
+ *      bundles. Browser globals don't expose `process` so this returns
+ *      `undefined` cleanly there.
+ *   2. **Whitespace stripped**: matches the daemon-side trim behavior
+ *      (`docs/users/qwen-serve.md:173` — handy for `$(cat token.txt)`
+ *      that produces a trailing newline).
+ *   3. **Empty / whitespace-only treated as unset**: a stale
+ *      `export QWEN_SERVER_TOKEN=""` would otherwise let the
+ *      Authorization header through as `Bearer ` (no token), which
+ *      the daemon rejects but is confusing to debug. Returning
+ *      `undefined` here means the constructor's `?? readTokenFromEnv()`
+ *      fallback chain treats both "unset" and "set-but-empty"
+ *      identically — no header sent.
+ */
+function readTokenFromEnv(): string | undefined {
+  try {
+    const proc = (
+      globalThis as {
+        process?: { env?: Record<string, string | undefined> };
+      }
+    ).process;
+    const raw = proc?.env?.['QWEN_SERVER_TOKEN'];
+    if (typeof raw !== 'string') return undefined;
+    const trimmed = raw.trim();
+    return trimmed.length === 0 ? undefined : trimmed;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Thrown for any non-2xx daemon response. `status` and `body` are surfaced
  * so callers can branch on the standard daemon HTTP semantics (404 missing
  * session, 401 bad token, 400 malformed body, 500 agent failure).
@@ -229,7 +269,13 @@ export class DaemonClient {
 
   constructor(opts: DaemonClientOptions) {
     this.baseUrl = stripTrailingSlashes(opts.baseUrl);
-    this.token = opts.token;
+    // PR 27 (#4175 v0.16-alpha): when no explicit token is passed, fall
+    // back to QWEN_SERVER_TOKEN env var so clients with
+    // `export QWEN_SERVER_TOKEN=...` in their shell don't have to
+    // thread the value through every construction. Matches the
+    // daemon-side `--token` CLI fallback for symmetry. See
+    // `readTokenFromEnv` above for browser-safety + trim semantics.
+    this.token = opts.token ?? readTokenFromEnv();
     this._fetch = opts.fetch ?? globalThis.fetch.bind(globalThis);
     // Coerce non-positive / non-finite to 0 (= disabled). Without this
     // a caller passing `-1` or `NaN` would slip past the

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -129,9 +129,10 @@ function stripTrailingSlashes(url: string): string {
 /**
  * PR 27 (#4175 v0.16-alpha): SDK env fallback for the daemon bearer
  * token. Mirrors the daemon-side `--token` CLI fallback to
- * `QWEN_SERVER_TOKEN` (`runQwenServe.ts:175`) so a developer with
- * `export QWEN_SERVER_TOKEN=...` in their shell never has to thread
- * the value through every `DaemonClient` construction.
+ * `QWEN_SERVER_TOKEN` (the daemon's own token-resolution path in
+ * `runQwenServe` reads the same env var in the same shape) so a
+ * developer with `export QWEN_SERVER_TOKEN=...` in their shell never
+ * has to thread the value through every `DaemonClient` construction.
  *
  * Defensive on three axes:
  *   1. **Browser-safe**: `globalThis.process` indirection. The SDK is
@@ -140,8 +141,9 @@ function stripTrailingSlashes(url: string): string {
  *      bundles. Browser globals don't expose `process` so this returns
  *      `undefined` cleanly there.
  *   2. **Whitespace stripped**: matches the daemon-side trim behavior
- *      (`docs/users/qwen-serve.md:173` — handy for `$(cat token.txt)`
- *      that produces a trailing newline).
+ *      documented in the `qwen-serve` user guide under the CLI flags
+ *      section — handy for `$(cat token.txt)` that produces a trailing
+ *      newline.
  *   3. **Empty / whitespace-only treated as unset**: a stale
  *      `export QWEN_SERVER_TOKEN=""` would otherwise let the
  *      Authorization header through as `Bearer ` (no token), which

--- a/packages/sdk-typescript/test/unit/DaemonClient.test.ts
+++ b/packages/sdk-typescript/test/unit/DaemonClient.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import {
   DaemonClient,
   DaemonHttpError,
@@ -497,9 +497,82 @@ describe('DaemonClient', () => {
       const { fetch, calls } = recordingFetch(() =>
         jsonResponse(200, { status: 'ok' }),
       );
-      const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
-      await client.health();
-      expect(calls[0]?.headers['authorization']).toBeUndefined();
+      // Defensive: an inherited test-runner export of QWEN_SERVER_TOKEN
+      // would otherwise activate the PR 27 env fallback and turn this
+      // assertion into a false positive ("got Bearer <leaked-value>"
+      // instead of the expected `undefined`). Snapshot + restore in a
+      // try/finally so the rest of the suite sees the same env state.
+      const ORIGINAL = process.env['QWEN_SERVER_TOKEN'];
+      delete process.env['QWEN_SERVER_TOKEN'];
+      try {
+        const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+        await client.health();
+        expect(calls[0]?.headers['authorization']).toBeUndefined();
+      } finally {
+        if (ORIGINAL === undefined) delete process.env['QWEN_SERVER_TOKEN'];
+        else process.env['QWEN_SERVER_TOKEN'] = ORIGINAL;
+      }
+    });
+
+    describe('QWEN_SERVER_TOKEN env fallback (PR 27 / #4175 v0.16-alpha)', () => {
+      const ORIGINAL = process.env['QWEN_SERVER_TOKEN'];
+      afterEach(() => {
+        if (ORIGINAL === undefined) delete process.env['QWEN_SERVER_TOKEN'];
+        else process.env['QWEN_SERVER_TOKEN'] = ORIGINAL;
+      });
+
+      it('uses QWEN_SERVER_TOKEN when no explicit token is passed', async () => {
+        process.env['QWEN_SERVER_TOKEN'] = 'env-token-abc';
+        const { fetch, calls } = recordingFetch(() =>
+          jsonResponse(200, { status: 'ok' }),
+        );
+        const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+        await client.health();
+        expect(calls[0]?.headers['authorization']).toBe('Bearer env-token-abc');
+      });
+
+      it('explicit opts.token wins over env', async () => {
+        process.env['QWEN_SERVER_TOKEN'] = 'env-token-loses';
+        const { fetch, calls } = recordingFetch(() =>
+          jsonResponse(200, { status: 'ok' }),
+        );
+        const client = new DaemonClient({
+          baseUrl: 'http://daemon',
+          token: 'explicit-wins',
+          fetch,
+        });
+        await client.health();
+        expect(calls[0]?.headers['authorization']).toBe('Bearer explicit-wins');
+      });
+
+      it('treats empty / whitespace-only env var as unset', async () => {
+        // A stale `export QWEN_SERVER_TOKEN=""` would otherwise let the
+        // Authorization header through as `Bearer ` (no token), which
+        // the daemon rejects but is confusing to debug. PR 27 collapses
+        // empty / whitespace-only onto the same "unset" branch as
+        // truly-unset; verify both shapes here.
+        process.env['QWEN_SERVER_TOKEN'] = '   ';
+        const { fetch, calls } = recordingFetch(() =>
+          jsonResponse(200, { status: 'ok' }),
+        );
+        const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+        await client.health();
+        expect(calls[0]?.headers['authorization']).toBeUndefined();
+      });
+
+      it('strips leading/trailing whitespace from env var', async () => {
+        // Matches the daemon-side `--token` trim behavior — handy for
+        // `export QWEN_SERVER_TOKEN="$(cat token.txt)"` where `cat`
+        // produces a trailing newline that would otherwise corrupt
+        // the Authorization header value.
+        process.env['QWEN_SERVER_TOKEN'] = '  trimmed-value  \n';
+        const { fetch, calls } = recordingFetch(() =>
+          jsonResponse(200, { status: 'ok' }),
+        );
+        const client = new DaemonClient({ baseUrl: 'http://daemon', fetch });
+        await client.health();
+        expect(calls[0]?.headers['authorization']).toBe('Bearer trimmed-value');
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

First PR in the **F5 release chain** (PR 27 → PR 28 → PR 30a → PR 31) per the [2026-05-24 v0.16-alpha scope freeze in #4175](https://github.com/QwenLM/qwen-code/issues/4175). v0.16-alpha targets **text-only chat / coding with local-only deployment**.

Two changes bundled:

### 1. SDK `DaemonClient` env fallback (~50 LOC + 4 tests)

`DaemonClient` constructor now falls back to `QWEN_SERVER_TOKEN` when `opts.token` is absent — closes the asymmetry where the daemon side already honors this env var (`--token` CLI flag fallback, in main since PR 15) but the SDK forced clients to thread the value through every construction.

**This is the entire ergonomic replacement for PR 29's SDK env/file fallback.** PR 29's other features (auto-gen daemon token, instance-path keying, stale cleanup) remain deferred to v0.16.x per the scope freeze — all are DX improvements over the boot-time security gate already shipped in PR 15.

Properties:
- **Browser-safe** via `globalThis.process` indirection (the SDK is imported by `@qwen-code/webui`; literal `process.env` access would explode at module load on browser bundles)
- **Whitespace stripped** (matches daemon-side trim convention — handy for `export QWEN_SERVER_TOKEN="$(cat token.txt)"` where `cat` adds a trailing newline)
- **Empty / whitespace-only treated as unset** (a stale `export QWEN_SERVER_TOKEN=""` won't accidentally send `Authorization: Bearer ` with no token)
- **Resolved at construction, not per-request** (later `process.env` mutations don't affect already-built clients)
- **Explicit `opts.token` wins over env** (existing API behavior preserved)

### 2. v0.16-alpha known limits + scope docs (~120 LOC markdown)

- **`docs/users/qwen-serve.md`**: new top-of-file alpha banner + a comprehensive `## v0.16-alpha known limits` section enumerating the deferred surface (text-only ✅ vs multimodal ❌, local launchers ✅ vs containerized ❌, BYO-token ✅ vs auto-gen ❌, etc.). Each entry links to the v0.16.x or v0.17 destination per the scope freeze.
- **`docs/developers/examples/daemon-client-quickstart.md`**: documents the SDK env fallback in both the Hello-daemon intro snippet and the Authentication section. Shows the recommended "export + no-token-arg" pattern for local dev.

## Files changed

| File | Change |
|---|---|
| `packages/sdk-typescript/src/daemon/DaemonClient.ts` | New private `readTokenFromEnv()` helper + constructor fallback (~50 LOC) |
| `packages/sdk-typescript/test/unit/DaemonClient.test.ts` | 4 new tests in `bearer auth` describe + defensive snapshot on the existing "omits Authorization" test |
| `docs/users/qwen-serve.md` | Alpha banner + `v0.16-alpha known limits` section |
| `docs/developers/examples/daemon-client-quickstart.md` | SDK env fallback documented in 2 places |

## Test plan

- [x] `npx tsc --noEmit -p packages/sdk-typescript/tsconfig.json` — clean
- [x] `npm test --workspace=@qwen-code/sdk -- DaemonClient` — **125/125** pass (121 existing + 4 new)
- [x] `npm test --workspace=@qwen-code/sdk -- daemon-public-surface` — **4/4** pass; constructor signature + exported types unchanged (no breaking change)
- [x] `eslint --max-warnings 0` clean on the 2 touched `.ts` files
- [x] Pre-commit prettier ran cleanly across all 4 files

## Backward compatibility

- `DaemonClient` constructor signature unchanged. `opts.token` still wins when explicitly passed.
- Existing tests (`attaches Authorization: Bearer when token is set` + `omits Authorization when no token`) keep passing. The latter got a defensive snapshot/restore around it so an inherited test-runner export of `QWEN_SERVER_TOKEN` can't turn it into a false positive.
- Browser-safe bundle invariant maintained — `globalThis.process` access pattern matches existing browser-safe code in the SDK.
- `@qwen-code/sdk` still ships at 0.1.7 in this PR; the minor bump to 0.2.0 (with this fallback as one of the motivating additions) lands in PR 28's npm publish scaffolding.

## Follow-ups (out of scope)

- **PR 28**: bumps `@qwen-code/sdk` to 0.2.0 + ships the npm publish scaffolding for the v0.16-alpha cut
- **PR 30a**: systemd / launchd / nohup launch templates referencing the BYO-token guide added here
- **PR 29 deferred features**: re-evaluate when remote / multi-daemon / enterprise pilot becomes the target

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)