### PR TITLE
fix(auth): align Token Plan model defaults with ModelStudio

### DIFF
--- a/packages/core/src/providers/__tests__/presets/alibaba-token-plan.test.ts
+++ b/packages/core/src/providers/__tests__/presets/alibaba-token-plan.test.ts
@@ -32,10 +32,28 @@ describe('token plan provider', () => {
 
     expect(template.map((model) => model.id)).toEqual([
       'qwen3.6-plus',
+      'qwen3.7-max',
+      'qwen3.6-flash',
+      'deepseek-v4-pro',
+      'deepseek-v4-flash',
       'deepseek-v3.2',
+      'kimi-k2.6',
+      'kimi-k2.5',
+      'glm-5.1',
       'glm-5',
       'MiniMax-M2.5',
     ]);
+    expect(
+      template.find((model) => model.id === 'deepseek-v4-pro')
+        ?.generationConfig,
+    ).toEqual({ contextWindowSize: 1000000 });
+    expect(
+      template.find((model) => model.id === 'qwen3.6-flash')?.generationConfig,
+    ).toEqual({
+      extra_body: { enable_thinking: true },
+      contextWindowSize: 1000000,
+      modalities: { image: true, video: true },
+    });
     expect(plan.providerId).toBe('token-plan');
     expect(plan.authType).toBe(AuthType.USE_OPENAI);
     expect(plan.env).toEqual({ [TOKEN_PLAN_ENV_KEY]: 'sk-token' });

--- a/packages/core/src/providers/presets/alibaba-token-plan.ts
+++ b/packages/core/src/providers/presets/alibaba-token-plan.ts
@@ -22,9 +22,31 @@ const TOKEN_PLAN_MODELS: ModelSpec[] = [
     enableThinking: true,
     modalities: { image: true, video: true },
   },
-  { id: 'deepseek-v3.2', contextWindowSize: 131072, enableThinking: true },
+  { id: 'qwen3.7-max', contextWindowSize: 1000000, enableThinking: true },
+  {
+    id: 'qwen3.6-flash',
+    contextWindowSize: 1000000,
+    enableThinking: true,
+    modalities: { image: true, video: true },
+  },
+  { id: 'deepseek-v4-pro', contextWindowSize: 1000000 },
+  { id: 'deepseek-v4-flash', contextWindowSize: 1000000 },
+  { id: 'deepseek-v3.2', contextWindowSize: 131072 },
+  {
+    id: 'kimi-k2.6',
+    contextWindowSize: 262144,
+    enableThinking: true,
+    modalities: { image: true, video: true },
+  },
+  {
+    id: 'kimi-k2.5',
+    contextWindowSize: 262144,
+    enableThinking: true,
+    modalities: { image: true, video: true },
+  },
+  { id: 'glm-5.1', contextWindowSize: 202752, enableThinking: true },
   { id: 'glm-5', contextWindowSize: 202752, enableThinking: true },
-  { id: 'MiniMax-M2.5', contextWindowSize: 196608, enableThinking: true },
+  { id: 'MiniMax-M2.5', contextWindowSize: 196608 },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/vscode-ide-companion/src/services/subscriptionPlanDefinitions.test.ts
+++ b/packages/vscode-ide-companion/src/services/subscriptionPlanDefinitions.test.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { getSubscriptionPlanConfig } from './subscriptionPlanDefinitions.js';
+
+describe('subscription plan definitions', () => {
+  it('keeps Token Plan on its dedicated model list', () => {
+    const tokenPlan = getSubscriptionPlanConfig('token');
+    const codingPlan = getSubscriptionPlanConfig('coding');
+
+    expect(tokenPlan.template.map((model) => model.id)).toEqual([
+      'qwen3.6-plus',
+      'qwen3.7-max',
+      'qwen3.6-flash',
+      'deepseek-v4-pro',
+      'deepseek-v4-flash',
+      'deepseek-v3.2',
+      'kimi-k2.6',
+      'kimi-k2.5',
+      'glm-5.1',
+      'glm-5',
+      'MiniMax-M2.5',
+    ]);
+    expect(codingPlan.template.map((model) => model.id)).not.toContain(
+      'qwen3.7-max',
+    );
+    expect(
+      tokenPlan.template.find((model) => model.id === 'deepseek-v4-pro')
+        ?.generationConfig,
+    ).toEqual({ contextWindowSize: 1000000 });
+  });
+});

--- a/packages/vscode-ide-companion/src/services/subscriptionPlanDefinitions.ts
+++ b/packages/vscode-ide-companion/src/services/subscriptionPlanDefinitions.ts
@@ -106,6 +106,20 @@ const ALIBABA_SUBSCRIPTION_MODELS = [
   { id: 'glm-4.7', contextWindowSize: 202752, enableThinking: true },
 ] as const satisfies readonly SubscriptionPlanModelSpec[];
 
+const BAILIAN_TOKEN_PLAN_MODELS = [
+  { id: 'qwen3.6-plus', contextWindowSize: 1000000, enableThinking: true },
+  { id: 'qwen3.7-max', contextWindowSize: 1000000, enableThinking: true },
+  { id: 'qwen3.6-flash', contextWindowSize: 1000000, enableThinking: true },
+  { id: 'deepseek-v4-pro', contextWindowSize: 1000000 },
+  { id: 'deepseek-v4-flash', contextWindowSize: 1000000 },
+  { id: 'deepseek-v3.2', contextWindowSize: 131072 },
+  { id: 'kimi-k2.6', contextWindowSize: 262144, enableThinking: true },
+  { id: 'kimi-k2.5', contextWindowSize: 262144, enableThinking: true },
+  { id: 'glm-5.1', contextWindowSize: 202752, enableThinking: true },
+  { id: 'glm-5', contextWindowSize: 202752, enableThinking: true },
+  { id: 'MiniMax-M2.5', contextWindowSize: 196608 },
+] as const satisfies readonly SubscriptionPlanModelSpec[];
+
 const CODING_PLAN: SubscriptionPlanDefinition<'coding'> = {
   id: 'coding',
   option: 'CODING_PLAN',
@@ -153,7 +167,7 @@ const TOKEN_PLAN: SubscriptionPlanDefinition<'token'> = {
     'https://bailian.console.aliyun.com/cn-beijing?tab=doc#/doc/?type=model&url=3028856',
   usageDocumentationUrl:
     'https://bailian.console.aliyun.com/cn-beijing?tab=doc#/doc/?type=model&url=3028856',
-  models: ALIBABA_SUBSCRIPTION_MODELS,
+  models: BAILIAN_TOKEN_PLAN_MODELS,
 };
 
 const SUBSCRIPTION_PLANS = {


### PR DESCRIPTION

## Summary

- What changed: Updated Bailian Token Plan's built-in chat model defaults and kept the VS Code companion's Token Plan catalog aligned with the CLI catalog.
- Why it changed: ModelStudio Token Plan now exposes additional chat models, but Qwen Code's default Token Plan setup still offered an older subset.
- Reviewer focus: Please verify that this only changes Token Plan chat model defaults and does not change API key env vars, endpoint selection, or image-generation workflows.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/providers/__tests__/presets/alibaba-token-plan.test.ts
  cd packages/cli && npx vitest run src/ui/auth/useAuth.test.ts src/ui/hooks/useProviderUpdates.test.ts
  cd packages/vscode-ide-companion && npx vitest run src/services/subscriptionPlanDefinitions.test.ts src/services/settingsWriter.test.ts
  npm run typecheck
  npm run build
  ```
- Prompts / inputs used:
  ```text
  Reply with exactly: token-plan-ok
  ```
- Expected result: Token Plan can use one of the newly added chat models through the local bundle without authentication or unknown-model errors.
- Observed result: A real Token Plan E2E run with `qwen3.6-flash` returned `token-plan-ok`.
- Quickest reviewer verification path:
  ```bash
  cd packages/core && npx vitest run src/providers/__tests__/presets/alibaba-token-plan.test.ts
  cd packages/vscode-ide-companion && npx vitest run src/services/subscriptionPlanDefinitions.test.ts
  ```
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  ```json
  {
    "model": "qwen3.6-flash",
    "result": "token-plan-ok",
    "is_error": false
  }
  ```

## Scope / Risk

- Main risk or tradeoff: Token Plan and Coding Plan have separate model catalogs, so this change keeps a dedicated Bailian Token Plan list instead of reusing the Coding Plan list.
- Not covered / not validated: Full `npm run preflight` was not run.
- Breaking changes / migration notes: None. The Token Plan API key env var remains `BAILIAN_TOKEN_PLAN_API_KEY`, and the Token Plan endpoint is unchanged.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

<img width="986" height="589" alt="image" src="https://github.com/user-attachments/assets/7abb5a05-6174-45e7-919c-95b6604a6314" />


Testing matrix notes:

- Verified locally on macOS with targeted `npx vitest` commands, `npm run typecheck`, `npm run build`, and a real Token Plan E2E call.
- Windows and Linux were not tested locally.
- Docker, Podman, and Seatbelt are not relevant to this model catalog update.

## Linked Issues / Bugs

No linked issue yet. If an issue is created first per the contribution guidelines, link it here before submitting the PR.
