### PR TITLE
fix(cli): require whitespace before @ to trigger file completion

### DIFF
--- a/packages/cli/src/ui/hooks/useCommandCompletion.test.ts
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.test.ts
@@ -215,6 +215,50 @@ describe('useCommandCompletion', () => {
         });
       });
 
+      it('should not trigger AT completion when @ is not preceded by whitespace', async () => {
+        const text = 'cici@192.168.0.160';
+        renderHook(() =>
+          useCommandCompletion(
+            useTextBufferForTest(text),
+            testRootDir,
+            [],
+            mockCommandContext,
+            false,
+            mockConfig,
+          ),
+        );
+
+        await waitFor(() => {
+          expect(useAtCompletion).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              enabled: false,
+            }),
+          );
+        });
+      });
+
+      it('should not trigger AT completion for email-like patterns', async () => {
+        const text = 'user@example.com';
+        renderHook(() =>
+          useCommandCompletion(
+            useTextBufferForTest(text),
+            testRootDir,
+            [],
+            mockCommandContext,
+            false,
+            mockConfig,
+          ),
+        );
+
+        await waitFor(() => {
+          expect(useAtCompletion).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              enabled: false,
+            }),
+          );
+        });
+      });
+
       it('should correctly identify the completion context with multiple @ symbols', async () => {
         const text = '@file1 @file2';
         const cursorOffset = 3; // @fi|le1 @file2

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -104,7 +104,7 @@ export function useCommandCompletion(
           if (backslashCount % 2 === 0) {
             break;
           }
-        } else if (char === '@') {
+        } else if (char === '@' && (i === 0 || codePoints[i - 1] === ' ')) {
           let end = codePoints.length;
           for (let i = cursorCol; i < codePoints.length; i++) {
             if (codePoints[i] === ' ') {

--- a/packages/cli/src/ui/hooks/useCommandCompletion.tsx
+++ b/packages/cli/src/ui/hooks/useCommandCompletion.tsx
@@ -104,7 +104,7 @@ export function useCommandCompletion(
           if (backslashCount % 2 === 0) {
             break;
           }
-        } else if (char === '@' && (i === 0 || codePoints[i - 1] === ' ')) {
+        } else if (char === '@' && (i === 0 || /\s/.test(codePoints[i - 1]))) {
           let end = codePoints.length;
           for (let i = cursorCol; i < codePoints.length; i++) {
             if (codePoints[i] === ' ') {


### PR DESCRIPTION
## Summary
- Input like `cici@192.168.0.160` was incorrectly triggering `@` file completion mode, causing the session to become unresponsive (Enter consumed by suggestion handler instead of submitting)
- Root cause: `useCommandCompletion` detected any `@` character as file completion trigger, without requiring preceding whitespace — unlike `isAtCommand()` used at submit time
- Fix: add check that `@` must be at position 0 or preceded by a space before activating `CompletionMode.AT`

## Test plan
- [x] `useCommandCompletion` tests pass (24/24)
- [x] `InputPrompt` tests pass (150/150)
- [ ] Manual: type `cici@192.168.0.160` → no file completion dropdown, Enter submits normally
- [ ] Manual: type `@file.txt` → file completion still works
- [ ] Manual: type `hello @file` → file completion still works