### PR TITLE
fix(core): prevent auto-skill creation from overwriting existing skills (#4437)

### DIFF
--- a/packages/core/src/memory/skillReviewAgentPlanner.test.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.test.ts
@@ -33,6 +33,27 @@ function makeMinimalConfig(projectRoot: string): Config {
   } as unknown as Config;
 }
 
+/**
+ * Build the scoped Config and return its non-null PermissionManager.
+ * `createSkillScopedAgentConfig` always installs one, but Config's
+ * declared `getPermissionManager(): PermissionManager | null` forces
+ * tests to launder the null at the call site — this helper does it
+ * once with an assertion that fires loudly if the contract ever breaks.
+ */
+function scopedPm(projectRoot: string) {
+  const scoped = createSkillScopedAgentConfig(
+    makeMinimalConfig(projectRoot),
+    projectRoot,
+  );
+  const pm = scoped.getPermissionManager();
+  if (!pm) {
+    throw new Error(
+      'createSkillScopedAgentConfig must install a PermissionManager',
+    );
+  }
+  return pm;
+}
+
 async function writeSkillFile(
   projectRoot: string,
   skillName: string,
@@ -77,10 +98,7 @@ describe('skillReviewAgentPlanner — write_file collision deny (#4437)', () => 
 
   it("denies write_file to an existing AUTO-skill path (the #4437 bug — was 'allow')", async () => {
     const filePath = await writeSkillFile(projectRoot, 'my-skill', AUTO_SKILL);
-    const pm = createSkillScopedAgentConfig(
-      makeMinimalConfig(projectRoot),
-      projectRoot,
-    ).getPermissionManager!();
+    const pm = scopedPm(projectRoot);
 
     const decision = await pm.evaluate({
       toolName: ToolNames.WRITE_FILE,
@@ -91,10 +109,7 @@ describe('skillReviewAgentPlanner — write_file collision deny (#4437)', () => 
 
   it('denies write_file to an existing USER-skill path (already worked — kept as regression guard)', async () => {
     const filePath = await writeSkillFile(projectRoot, 'my-skill', USER_SKILL);
-    const pm = createSkillScopedAgentConfig(
-      makeMinimalConfig(projectRoot),
-      projectRoot,
-    ).getPermissionManager!();
+    const pm = scopedPm(projectRoot);
 
     const decision = await pm.evaluate({
       toolName: ToolNames.WRITE_FILE,
@@ -111,10 +126,7 @@ describe('skillReviewAgentPlanner — write_file collision deny (#4437)', () => 
       'brand-new',
       'SKILL.md',
     );
-    const pm = createSkillScopedAgentConfig(
-      makeMinimalConfig(projectRoot),
-      projectRoot,
-    ).getPermissionManager!();
+    const pm = scopedPm(projectRoot);
 
     const decision = await pm.evaluate({
       toolName: ToolNames.WRITE_FILE,
@@ -125,10 +137,7 @@ describe('skillReviewAgentPlanner — write_file collision deny (#4437)', () => 
 
   it('still allows edit on an existing auto-skill (update path preserved)', async () => {
     const filePath = await writeSkillFile(projectRoot, 'my-skill', AUTO_SKILL);
-    const pm = createSkillScopedAgentConfig(
-      makeMinimalConfig(projectRoot),
-      projectRoot,
-    ).getPermissionManager!();
+    const pm = scopedPm(projectRoot);
 
     const decision = await pm.evaluate({
       toolName: ToolNames.EDIT,
@@ -139,10 +148,7 @@ describe('skillReviewAgentPlanner — write_file collision deny (#4437)', () => 
 
   it('still denies edit on a user skill (update path safety preserved)', async () => {
     const filePath = await writeSkillFile(projectRoot, 'my-skill', USER_SKILL);
-    const pm = createSkillScopedAgentConfig(
-      makeMinimalConfig(projectRoot),
-      projectRoot,
-    ).getPermissionManager!();
+    const pm = scopedPm(projectRoot);
 
     const decision = await pm.evaluate({
       toolName: ToolNames.EDIT,
@@ -153,10 +159,7 @@ describe('skillReviewAgentPlanner — write_file collision deny (#4437)', () => 
 
   it('write_file deny rule message points the agent at a fresh name', async () => {
     const filePath = await writeSkillFile(projectRoot, 'my-skill', AUTO_SKILL);
-    const pm = createSkillScopedAgentConfig(
-      makeMinimalConfig(projectRoot),
-      projectRoot,
-    ).getPermissionManager!();
+    const pm = scopedPm(projectRoot);
 
     const rule = pm.findMatchingDenyRule({
       toolName: ToolNames.WRITE_FILE,

--- a/packages/core/src/memory/skillReviewAgentPlanner.test.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.test.ts
@@ -1,0 +1,239 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Tests for the #4437 fix:
+ *  - `write_file` to an existing path inside the project skills root is
+ *    denied (was 'allow' before — silently clobbered the prior SKILL.md).
+ *  - `edit` semantics for existing auto-skills are preserved.
+ *  - `buildTaskPrompt` enumerates existing skill directory names so the
+ *    agent picks a fresh name on the first attempt.
+ */
+
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Config } from '../config/config.js';
+import {
+  buildTaskPrompt,
+  createSkillScopedAgentConfig,
+  listExistingSkillDirNames,
+} from './skillReviewAgentPlanner.js';
+import { ToolNames } from '../tools/tool-names.js';
+import { getProjectSkillsRoot } from '../skills/skill-paths.js';
+
+function makeMinimalConfig(projectRoot: string): Config {
+  return {
+    getProjectRoot: () => projectRoot,
+    getPermissionManager: () => undefined,
+  } as unknown as Config;
+}
+
+async function writeSkillFile(
+  projectRoot: string,
+  skillName: string,
+  content: string,
+): Promise<string> {
+  const dir = path.join(projectRoot, '.qwen', 'skills', skillName);
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, 'SKILL.md');
+  await fs.writeFile(filePath, content, 'utf-8');
+  return filePath;
+}
+
+const AUTO_SKILL = `---
+name: my-skill
+source: auto-skill
+---
+
+body
+`;
+
+const USER_SKILL = `---
+name: my-skill
+description: hand-authored
+---
+
+human body
+`;
+
+describe('skillReviewAgentPlanner — write_file collision deny (#4437)', () => {
+  let tempDir: string;
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'skill-review-v2-'));
+    projectRoot = path.join(tempDir, 'project');
+    await fs.mkdir(projectRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("denies write_file to an existing AUTO-skill path (the #4437 bug — was 'allow')", async () => {
+    const filePath = await writeSkillFile(projectRoot, 'my-skill', AUTO_SKILL);
+    const pm = createSkillScopedAgentConfig(
+      makeMinimalConfig(projectRoot),
+      projectRoot,
+    ).getPermissionManager!();
+
+    const decision = await pm.evaluate({
+      toolName: ToolNames.WRITE_FILE,
+      filePath,
+    });
+    expect(decision).toBe('deny');
+  });
+
+  it('denies write_file to an existing USER-skill path (already worked — kept as regression guard)', async () => {
+    const filePath = await writeSkillFile(projectRoot, 'my-skill', USER_SKILL);
+    const pm = createSkillScopedAgentConfig(
+      makeMinimalConfig(projectRoot),
+      projectRoot,
+    ).getPermissionManager!();
+
+    const decision = await pm.evaluate({
+      toolName: ToolNames.WRITE_FILE,
+      filePath,
+    });
+    expect(decision).toBe('deny');
+  });
+
+  it('allows write_file to a fresh path that does not yet exist', async () => {
+    const fresh = path.join(
+      projectRoot,
+      '.qwen',
+      'skills',
+      'brand-new',
+      'SKILL.md',
+    );
+    const pm = createSkillScopedAgentConfig(
+      makeMinimalConfig(projectRoot),
+      projectRoot,
+    ).getPermissionManager!();
+
+    const decision = await pm.evaluate({
+      toolName: ToolNames.WRITE_FILE,
+      filePath: fresh,
+    });
+    expect(decision).toBe('allow');
+  });
+
+  it('still allows edit on an existing auto-skill (update path preserved)', async () => {
+    const filePath = await writeSkillFile(projectRoot, 'my-skill', AUTO_SKILL);
+    const pm = createSkillScopedAgentConfig(
+      makeMinimalConfig(projectRoot),
+      projectRoot,
+    ).getPermissionManager!();
+
+    const decision = await pm.evaluate({
+      toolName: ToolNames.EDIT,
+      filePath,
+    });
+    expect(decision).toBe('allow');
+  });
+
+  it('still denies edit on a user skill (update path safety preserved)', async () => {
+    const filePath = await writeSkillFile(projectRoot, 'my-skill', USER_SKILL);
+    const pm = createSkillScopedAgentConfig(
+      makeMinimalConfig(projectRoot),
+      projectRoot,
+    ).getPermissionManager!();
+
+    const decision = await pm.evaluate({
+      toolName: ToolNames.EDIT,
+      filePath,
+    });
+    expect(decision).toBe('deny');
+  });
+
+  it('write_file deny rule message points the agent at a fresh name', async () => {
+    const filePath = await writeSkillFile(projectRoot, 'my-skill', AUTO_SKILL);
+    const pm = createSkillScopedAgentConfig(
+      makeMinimalConfig(projectRoot),
+      projectRoot,
+    ).getPermissionManager!();
+
+    const rule = pm.findMatchingDenyRule({
+      toolName: ToolNames.WRITE_FILE,
+      filePath,
+    });
+    expect(rule).toMatch(/<name>-2/);
+    expect(rule).toMatch(/edit/);
+  });
+});
+
+describe('listExistingSkillDirNames', () => {
+  let tempDir: string;
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'skill-list-'));
+    projectRoot = path.join(tempDir, 'project');
+    await fs.mkdir(projectRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('returns sorted directory names that contain a SKILL.md', async () => {
+    await writeSkillFile(projectRoot, 'zebra', AUTO_SKILL);
+    await writeSkillFile(projectRoot, 'apple', AUTO_SKILL);
+    expect(await listExistingSkillDirNames(projectRoot)).toEqual([
+      'apple',
+      'zebra',
+    ]);
+  });
+
+  it('skips directories without SKILL.md so half-built dirs do not reserve names', async () => {
+    await writeSkillFile(projectRoot, 'real', AUTO_SKILL);
+    await fs.mkdir(path.join(projectRoot, '.qwen', 'skills', 'empty'), {
+      recursive: true,
+    });
+    expect(await listExistingSkillDirNames(projectRoot)).toEqual(['real']);
+  });
+
+  it('returns [] when the skills directory does not exist', async () => {
+    expect(await listExistingSkillDirNames(projectRoot)).toEqual([]);
+  });
+});
+
+describe('buildTaskPrompt', () => {
+  let tempDir: string;
+  let projectRoot: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'skill-prompt-'));
+    projectRoot = path.join(tempDir, 'project');
+    await fs.mkdir(projectRoot, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it('lists existing skill names so the agent picks a non-colliding name', async () => {
+    await writeSkillFile(projectRoot, 'alpha', AUTO_SKILL);
+    await writeSkillFile(projectRoot, 'beta', AUTO_SKILL);
+    const prompt = await buildTaskPrompt(
+      getProjectSkillsRoot(projectRoot),
+      projectRoot,
+    );
+    expect(prompt).toContain('alpha');
+    expect(prompt).toContain('beta');
+    expect(prompt).toMatch(/do NOT reuse/i);
+  });
+
+  it('falls back to a placeholder line when no skills exist yet', async () => {
+    const prompt = await buildTaskPrompt(
+      getProjectSkillsRoot(projectRoot),
+      projectRoot,
+    );
+    expect(prompt).toMatch(/no skills exist yet/i);
+  });
+});

--- a/packages/core/src/memory/skillReviewAgentPlanner.test.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.test.ts
@@ -223,11 +223,13 @@ describe('skillReviewAgentPlanner — write_file collision deny (#4437)', () => 
     ).toBe('deny');
   });
 
-  it('denies write_file when fs.stat fails with a non-ENOENT error (EISDIR)', async () => {
-    // The catch in evaluateScopedDecision deliberately defaults to
-    // 'deny' for any non-ENOENT error so we never overwrite something
-    // we cannot prove is safe. Easiest reproducible failure mode is
-    // EISDIR — the target path is a directory, not a file.
+  it('denies write_file when the target path is a directory, not a file', async () => {
+    // `fs.stat` on a directory SUCCEEDS (returning stats with
+    // `isDirectory: true`); it does not throw EISDIR. So this exercise
+    // path A in evaluateScopedDecision — `try { await fs.stat(); return
+    // 'deny'; }` — i.e. "target exists" rather than the non-ENOENT
+    // catch. WriteFileTool would later fail with EISDIR on the actual
+    // write, but the permission layer catches it earlier here.
     const dirAsFile = path.join(
       projectRoot,
       '.qwen',
@@ -244,6 +246,18 @@ describe('skillReviewAgentPlanner — write_file collision deny (#4437)', () => 
       }),
     ).toBe('deny');
   });
+
+  // Note on coverage of the `fs.stat` catch branch in
+  // evaluateScopedDecision:
+  // The branch is defense-in-depth — anything that would make `fs.stat`
+  // throw a non-ENOENT error (EACCES, ELOOP, ENAMETOOLONG, EIO) also
+  // throws from `assertRealProjectSkillPath`'s `realpath`/`lstat` one
+  // step earlier, which is exercised by the symlink-traversal test
+  // above. Spying on `fs.stat` from ESM tests is blocked
+  // (https://vitest.dev/guide/browser/#limitations), and chmod-based
+  // reproductions of EACCES are non-portable to Windows CI. The deny
+  // contract is straightforward enough that the structural duplication
+  // here is acceptable.
 });
 
 describe('listExistingSkillDirNames', () => {

--- a/packages/core/src/memory/skillReviewAgentPlanner.test.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.test.ts
@@ -24,7 +24,6 @@ import {
   listExistingSkillDirNames,
 } from './skillReviewAgentPlanner.js';
 import { ToolNames } from '../tools/tool-names.js';
-import { getProjectSkillsRoot } from '../skills/skill-paths.js';
 
 function makeMinimalConfig(projectRoot: string): Config {
   return {
@@ -168,6 +167,83 @@ describe('skillReviewAgentPlanner — write_file collision deny (#4437)', () => 
     expect(rule).toMatch(/<name>-2/);
     expect(rule).toMatch(/edit/);
   });
+
+  it('denies write_file to a path outside the project skills root', async () => {
+    // Security-boundary regression guard for the `isProjectSkillPath`
+    // false branch — without it the agent could escape to anywhere
+    // reachable from CWD.
+    const escape = path.join(projectRoot, 'NOT-SKILLS', 'evil.md');
+    const pm = scopedPm(projectRoot);
+    expect(
+      await pm.evaluate({
+        toolName: ToolNames.WRITE_FILE,
+        filePath: escape,
+      }),
+    ).toBe('deny');
+  });
+
+  it('denies write_file to a non-SKILL.md path inside the skills root', async () => {
+    // Auxiliary files (NOTES.md, attachments) must not land in the
+    // skills dir — SkillManager would ignore them but they'd still
+    // pollute the layout. Tightening the basename invariant is the
+    // hard guard for that.
+    const aux = path.join(
+      projectRoot,
+      '.qwen',
+      'skills',
+      'my-skill',
+      'NOTES.md',
+    );
+    await fs.mkdir(path.dirname(aux), { recursive: true });
+    const pm = scopedPm(projectRoot);
+    expect(
+      await pm.evaluate({
+        toolName: ToolNames.WRITE_FILE,
+        filePath: aux,
+      }),
+    ).toBe('deny');
+  });
+
+  it('denies write_file when the target traverses a symlink outside the skills root', async () => {
+    // Symlink-escape regression guard for the `assertRealProjectSkillPath`
+    // catch. A skill dir that's actually a symlink to /tmp would let the
+    // agent write outside the project; the realpath check stops it.
+    const outside = path.join(tempDir, 'outside');
+    await fs.mkdir(outside, { recursive: true });
+    const skillsRoot = path.join(projectRoot, '.qwen', 'skills');
+    await fs.mkdir(skillsRoot, { recursive: true });
+    await fs.symlink(outside, path.join(skillsRoot, 'escape'));
+    const target = path.join(skillsRoot, 'escape', 'SKILL.md');
+    const pm = scopedPm(projectRoot);
+    expect(
+      await pm.evaluate({
+        toolName: ToolNames.WRITE_FILE,
+        filePath: target,
+      }),
+    ).toBe('deny');
+  });
+
+  it('denies write_file when fs.stat fails with a non-ENOENT error (EISDIR)', async () => {
+    // The catch in evaluateScopedDecision deliberately defaults to
+    // 'deny' for any non-ENOENT error so we never overwrite something
+    // we cannot prove is safe. Easiest reproducible failure mode is
+    // EISDIR — the target path is a directory, not a file.
+    const dirAsFile = path.join(
+      projectRoot,
+      '.qwen',
+      'skills',
+      'is-a-directory',
+      'SKILL.md',
+    );
+    await fs.mkdir(dirAsFile, { recursive: true });
+    const pm = scopedPm(projectRoot);
+    expect(
+      await pm.evaluate({
+        toolName: ToolNames.WRITE_FILE,
+        filePath: dirAsFile,
+      }),
+    ).toBe('deny');
+  });
 });
 
 describe('listExistingSkillDirNames', () => {
@@ -204,6 +280,24 @@ describe('listExistingSkillDirNames', () => {
   it('returns [] when the skills directory does not exist', async () => {
     expect(await listExistingSkillDirNames(projectRoot)).toEqual([]);
   });
+
+  it('includes skills whose directory is a symlink (matches skill-load.ts convention)', async () => {
+    // Build a real skill outside the skills root, then symlink it in.
+    // `skill-load.ts:31-34` and `skill-manager.ts:994-997` both treat
+    // `isDirectory() || isSymbolicLink()` as a skill candidate; the
+    // enumeration here mirrors that.
+    const external = path.join(tempDir, 'external-skills', 'linked');
+    await fs.mkdir(external, { recursive: true });
+    await fs.writeFile(path.join(external, 'SKILL.md'), AUTO_SKILL, 'utf-8');
+    const skillsRoot = path.join(projectRoot, '.qwen', 'skills');
+    await fs.mkdir(skillsRoot, { recursive: true });
+    await fs.symlink(external, path.join(skillsRoot, 'linked'));
+    await writeSkillFile(projectRoot, 'regular', AUTO_SKILL);
+    expect(await listExistingSkillDirNames(projectRoot)).toEqual([
+      'linked',
+      'regular',
+    ]);
+  });
 });
 
 describe('buildTaskPrompt', () => {
@@ -223,20 +317,23 @@ describe('buildTaskPrompt', () => {
   it('lists existing skill names so the agent picks a non-colliding name', async () => {
     await writeSkillFile(projectRoot, 'alpha', AUTO_SKILL);
     await writeSkillFile(projectRoot, 'beta', AUTO_SKILL);
-    const prompt = await buildTaskPrompt(
-      getProjectSkillsRoot(projectRoot),
-      projectRoot,
-    );
+    const prompt = await buildTaskPrompt(projectRoot);
     expect(prompt).toContain('alpha');
     expect(prompt).toContain('beta');
     expect(prompt).toMatch(/do NOT reuse/i);
   });
 
   it('falls back to a placeholder line when no skills exist yet', async () => {
-    const prompt = await buildTaskPrompt(
-      getProjectSkillsRoot(projectRoot),
-      projectRoot,
-    );
+    const prompt = await buildTaskPrompt(projectRoot);
     expect(prompt).toMatch(/no skills exist yet/i);
+  });
+
+  it('displays the project skills root derived from the same projectRoot used for enumeration', async () => {
+    // Regression guard for the param collapse — the displayed root and
+    // the enumerated names always come from the same source.
+    await writeSkillFile(projectRoot, 'real', AUTO_SKILL);
+    const prompt = await buildTaskPrompt(projectRoot);
+    expect(prompt).toContain(path.join(projectRoot, '.qwen', 'skills'));
+    expect(prompt).toContain('real');
   });
 });

--- a/packages/core/src/memory/skillReviewAgentPlanner.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.ts
@@ -20,6 +20,7 @@ import {
   assertRealProjectSkillPath,
   getProjectSkillsRoot,
   isProjectSkillPath,
+  SKILL_FILE_NAME,
 } from '../skills/skill-paths.js';
 
 export const SKILL_REVIEW_AGENT_NAME = 'managed-skill-extractor' as const;
@@ -131,15 +132,24 @@ async function evaluateScopedDecision(
       return sourceFlag ? 'allow' : 'deny';
     }
     case ToolNames.WRITE_FILE: {
-      // `write_file` is reserved for CREATING new skills. Updates to
-      // existing auto-skills must go through `edit`. Denying any write
-      // that targets an existing file is the safety net for #4437:
-      // without it, an agent that picks a name collision (with another
-      // auto-skill OR a user-authored skill) silently clobbers the
-      // prior SKILL.md. The system prompt + task prompt are the soft
-      // guard (enumerate existing skill names so the agent picks fresh);
-      // this deny is the hard guard.
+      // Invariant for the auto-skill flow:
+      //   write_file can ONLY create a brand-new SKILL.md slot
+      //   (edit is what updates an existing auto-skill).
+      // Together with the EDIT case above, this gives:
+      //   create new skill   → write_file at fresh <name>/SKILL.md
+      //   update auto-skill  → edit on existing SKILL.md (source: auto-skill)
+      // Denying writes to existing paths is the hard guard for #4437 —
+      // it's what prevents an agent that picks a colliding name from
+      // clobbering either another auto-skill or a user-authored skill.
+      // The prompt enumeration is the soft guard above it.
       if (!ctx.filePath || !isProjectSkillPath(ctx.filePath, projectRoot)) {
+        return 'deny';
+      }
+      // Restrict to the canonical `<name>/SKILL.md` slot. Without this,
+      // the agent could write auxiliary files (notes, README, attachments)
+      // anywhere under `.qwen/skills/**` — SkillManager would ignore them
+      // but they still pollute the directory.
+      if (path.basename(ctx.filePath) !== SKILL_FILE_NAME) {
         return 'deny';
       }
       try {
@@ -278,9 +288,13 @@ export async function listExistingSkillDirNames(
   }
   const names: string[] = [];
   for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
+    // Skill dirs can be symlinked — `skill-load.ts` and `skill-manager.ts`
+    // both treat `isDirectory() || isSymbolicLink()` as "consider this a
+    // skill candidate". Mirror that here so symlinked skills appear in
+    // the enumeration and the agent steers clear of their names.
+    if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
     try {
-      await fs.stat(path.join(skillsRoot, entry.name, 'SKILL.md'));
+      await fs.stat(path.join(skillsRoot, entry.name, SKILL_FILE_NAME));
       names.push(entry.name);
     } catch {
       // No SKILL.md (or unreadable) — skip; half-built directories
@@ -295,11 +309,13 @@ export async function listExistingSkillDirNames(
  * Exported for tests. The "(do not reuse these names)" line is the soft
  * guard for #4437 — the hard guard is `evaluateScopedDecision`'s WRITE_FILE
  * branch denying any write to an existing path.
+ *
+ * Takes `projectRoot` (not `skillsRoot`) so the displayed path and the
+ * enumeration both derive from the same source — keeps them from drifting
+ * if a future caller passes a non-standard root.
  */
-export async function buildTaskPrompt(
-  skillsRoot: string,
-  projectRoot: string,
-): Promise<string> {
+export async function buildTaskPrompt(projectRoot: string): Promise<string> {
+  const skillsRoot = getProjectSkillsRoot(projectRoot);
   const existing = await listExistingSkillDirNames(projectRoot);
   const existingLine =
     existing.length === 0
@@ -332,7 +348,6 @@ export async function runSkillReviewByAgent(params: {
   maxTurns?: number;
   timeoutMs?: number;
 }): Promise<SkillReviewExecutionResult> {
-  const skillsRoot = getProjectSkillsRoot(params.projectRoot);
   const scopedConfig = createSkillScopedAgentConfig(
     params.config,
     params.projectRoot,
@@ -340,7 +355,7 @@ export async function runSkillReviewByAgent(params: {
   const result = await runForkedAgent({
     name: SKILL_REVIEW_AGENT_NAME,
     config: scopedConfig,
-    taskPrompt: await buildTaskPrompt(skillsRoot, params.projectRoot),
+    taskPrompt: await buildTaskPrompt(params.projectRoot),
     systemPrompt: SKILL_REVIEW_SYSTEM_PROMPT,
     maxTurns: params.maxTurns ?? DEFAULT_AUTO_SKILL_MAX_TURNS,
     maxTimeMinutes:

--- a/packages/core/src/memory/skillReviewAgentPlanner.ts
+++ b/packages/core/src/memory/skillReviewAgentPlanner.ts
@@ -112,8 +112,7 @@ async function evaluateScopedDecision(
       }
       return 'deny';
     }
-    case ToolNames.EDIT:
-    case ToolNames.WRITE_FILE: {
+    case ToolNames.EDIT: {
       if (!ctx.filePath || !isProjectSkillPath(ctx.filePath, projectRoot)) {
         return 'deny';
       }
@@ -131,6 +130,34 @@ async function evaluateScopedDecision(
       }
       return sourceFlag ? 'allow' : 'deny';
     }
+    case ToolNames.WRITE_FILE: {
+      // `write_file` is reserved for CREATING new skills. Updates to
+      // existing auto-skills must go through `edit`. Denying any write
+      // that targets an existing file is the safety net for #4437:
+      // without it, an agent that picks a name collision (with another
+      // auto-skill OR a user-authored skill) silently clobbers the
+      // prior SKILL.md. The system prompt + task prompt are the soft
+      // guard (enumerate existing skill names so the agent picks fresh);
+      // this deny is the hard guard.
+      if (!ctx.filePath || !isProjectSkillPath(ctx.filePath, projectRoot)) {
+        return 'deny';
+      }
+      try {
+        await assertRealProjectSkillPath(ctx.filePath, projectRoot);
+      } catch {
+        return 'deny';
+      }
+      // ENOENT → file does not exist → allow creation.
+      // Anything else (file present, EACCES, EISDIR, ...) → deny so we
+      // never overwrite something we cannot prove is safe to clobber.
+      try {
+        await fs.stat(ctx.filePath);
+        return 'deny';
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return 'allow';
+        return 'deny';
+      }
+    }
     default:
       return 'default';
   }
@@ -147,7 +174,7 @@ function getScopedDenyRule(
     case ToolNames.EDIT:
       return `ManagedSkillReview(edit: only within ${getProjectSkillsRoot(projectRoot)} and only on skills with 'source: auto-skill' in frontmatter)`;
     case ToolNames.WRITE_FILE:
-      return `ManagedSkillReview(write_file: only within ${getProjectSkillsRoot(projectRoot)}; existing files must have 'source: auto-skill' in frontmatter)`;
+      return `ManagedSkillReview(write_file: only within ${getProjectSkillsRoot(projectRoot)} and only to a path that does not yet exist — use a different skill name like \`<name>-2\`, or use \`edit\` to update an existing auto-skill)`;
     default:
       return undefined;
   }
@@ -230,9 +257,58 @@ function buildAgentHistory(history: Content[]): Content[] {
   ];
 }
 
-function buildTaskPrompt(skillsRoot: string): string {
+/**
+ * Enumerate directories under the project skills root that contain a
+ * SKILL.md. Returned names are the directory basenames (the same identifier
+ * the agent uses when picking `.qwen/skills/<name>/SKILL.md`).
+ *
+ * Best-effort: any read error (ENOENT, EACCES, ...) returns `[]` so a
+ * temporarily-unreadable skills dir downgrades to "no enumeration" rather
+ * than aborting the task. Exported for tests.
+ */
+export async function listExistingSkillDirNames(
+  projectRoot: string,
+): Promise<string[]> {
+  const skillsRoot = getProjectSkillsRoot(projectRoot);
+  let entries: Array<import('node:fs').Dirent>;
+  try {
+    entries = await fs.readdir(skillsRoot, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const names: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    try {
+      await fs.stat(path.join(skillsRoot, entry.name, 'SKILL.md'));
+      names.push(entry.name);
+    } catch {
+      // No SKILL.md (or unreadable) — skip; half-built directories
+      // shouldn't reserve a name.
+    }
+  }
+  names.sort();
+  return names;
+}
+
+/**
+ * Exported for tests. The "(do not reuse these names)" line is the soft
+ * guard for #4437 — the hard guard is `evaluateScopedDecision`'s WRITE_FILE
+ * branch denying any write to an existing path.
+ */
+export async function buildTaskPrompt(
+  skillsRoot: string,
+  projectRoot: string,
+): Promise<string> {
+  const existing = await listExistingSkillDirNames(projectRoot);
+  const existingLine =
+    existing.length === 0
+      ? '(no skills exist yet — any name is available)'
+      : `Existing skill names (do NOT reuse for write_file; use \`edit\` if you want to update one of these): ${existing.join(', ')}`;
   return [
     `Project skills directory: \`${skillsRoot}\``,
+    '',
+    existingLine,
     '',
     'Use `ls` and `read_file` to inspect existing skills before writing.',
     'Use `write_file` to create a new skill, `edit` to update an existing auto-skill.',
@@ -264,7 +340,7 @@ export async function runSkillReviewByAgent(params: {
   const result = await runForkedAgent({
     name: SKILL_REVIEW_AGENT_NAME,
     config: scopedConfig,
-    taskPrompt: buildTaskPrompt(skillsRoot),
+    taskPrompt: await buildTaskPrompt(skillsRoot, params.projectRoot),
     systemPrompt: SKILL_REVIEW_SYSTEM_PROMPT,
     maxTurns: params.maxTurns ?? DEFAULT_AUTO_SKILL_MAX_TURNS,
     maxTimeMinutes:


### PR DESCRIPTION
## Summary

Fixes #4437. Replaces #4440 with a minimal-scope rewrite.

The auto-skill review agent's `write_file` previously accepted any path inside `.qwen/skills/` as long as the existing file carried `source: auto-skill` in its frontmatter — so two consecutive reviews picking the same skill name would silently clobber each other, and any user-edited auto-skill could be lost the same way.

`write_file` is reserved for **creating** new skills (the system prompt already routes updates through `edit`), so the conservative fix is to deny the write whenever the target path already exists. The deny rule message tells the agent to retry with `<name>-2` or use `edit` for updates, so the model self-corrects the rare collision without a code-level rename.

## What changes (~80 LOC production, all in `skillReviewAgentPlanner.ts`)

1. **Split EDIT and WRITE_FILE in `evaluateScopedDecision`.** EDIT keeps its `source: auto-skill` check. WRITE_FILE now denies any pre-existing target via `fs.stat` — ENOENT → allow, anything else (existing file, EACCES, EISDIR, ...) → deny so we never overwrite something we can't prove is safe.
2. **`listExistingSkillDirNames` + `buildTaskPrompt` enumeration.** The agent sees the existing skill names up front and picks a non-colliding one on the first attempt; the deny above is the hard guard for when it doesn't.
3. **Updated deny rule message** points the agent at \`<name>-2\` and at \`edit\` for updates.

## Why this is the right size

#4440 ran a code-level deterministic-rename wrapper (1384 LOC, including a wrapping `WriteFileTool` and a new `runForkedAgent` hook). After reviewer feedback I reassessed: the deterministic-rename framing was over-spec'd for what is fundamentally a "don't clobber existing files" concern. Soft guard (prompt enumeration) + hard guard (permission deny) covers both failure modes in the issue:

- Auto-skill clobbers auto-skill → denied at write step.
- Auto-skill clobbers user-authored skill → also denied.

If the agent ignores the prompt and writes anyway, it gets a deny with a fresh-name hint and retries. No data loss in any path.

## Out of scope

- Generic `WriteFileTool` is untouched (other callers depend on overwrite semantics).
- `SkillManager` load-time dedup is untouched.
- No new config knob — `'rename' | 'skip' | 'overwrite'` from #4440 is gone; deny is the only behaviour, and \`edit\` remains for legitimate updates.

## Test plan

- [x] `packages/core/src/memory/skillReviewAgentPlanner.test.ts` — 11 new tests covering:
  - **Denies write_file to an existing auto-skill path** (the #4437 bug — was `'allow'`).
  - Denies write_file to an existing user-skill path (regression guard for the case that already worked).
  - Allows write_file to a fresh path.
  - Still allows edit on an existing auto-skill (update path preserved).
  - Still denies edit on a user skill (update safety preserved).
  - Deny-rule message contains the \`<name>-2\` hint.
  - `listExistingSkillDirNames` sorts, skips half-built dirs, returns `[]` when skills root missing.
  - `buildTaskPrompt` lists existing names; falls back to placeholder when empty.
- [x] `npx tsc --noEmit -p packages/core/tsconfig.json` — clean.
- [x] `npx eslint <changed files>` — clean.
- [x] `npx vitest run packages/core/src/memory/` — 19 files / 122 tests pass.

cc @DragonnZhang — much smaller follow-up to your issue. The trade-off vs. the rename-wrapper approach: relies on the agent following the deny + retry, which qwen-coder does reliably; in exchange the patch is ~80 lines of production code instead of 600.