### PR TITLE
feat(core): enable Token Plan cache control

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.test.ts
@@ -164,6 +164,18 @@ describe('DashScopeOpenAICompatibleProvider', () => {
       expect(result).toBe(true);
     });
 
+    it('should return true for Token Plan URL', () => {
+      const config = {
+        authType: AuthType.USE_OPENAI,
+        baseUrl:
+          'https://token-plan.cn-beijing.maas.aliyuncs.com/compatible-mode/v1',
+      } as ContentGeneratorConfig;
+
+      const result =
+        DashScopeOpenAICompatibleProvider.isDashScopeProvider(config);
+      expect(result).toBe(true);
+    });
+
     it('should return true for internal alibaba-inc.com subdomain', () => {
       const config = {
         authType: AuthType.USE_OPENAI,
@@ -239,6 +251,8 @@ describe('DashScopeOpenAICompatibleProvider', () => {
         'https://notaliyun-inc.com/v1',
         'https://alibaba-inc.com.evil.com/v1',
         'https://aliyun-inc.com.evil.com/v1',
+        'https://not-token-plan.cn-beijing.maas.aliyuncs.com/v1',
+        'https://token-plan.cn-beijing.maas.aliyuncs.com.evil.com/v1',
       ];
 
       configs.forEach((baseUrl) => {

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -32,6 +32,7 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
   /**
    * Determines whether to use the DashScope-compatible provider.
    * Covers dashscope.aliyuncs.com, dashscope-intl.aliyuncs.com,
+   * Token Plan endpoints under token-plan.<region>.maas.aliyuncs.com,
    * internal Alibaba domains (*.alibaba-inc.com, *.aliyun-inc.com),
    * and proxy matches.
    *
@@ -70,6 +71,11 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
         hostname.endsWith('.dashscope.aliyuncs.com') ||
         hostname.endsWith('.dashscope-intl.aliyuncs.com'));
 
+    const isTokenPlanOrigin =
+      hostname !== null &&
+      hostname.startsWith('token-plan.') &&
+      hostname.endsWith('.maas.aliyuncs.com');
+
     // Internal Alibaba domains proxying to DashScope-compatible APIs.
     // Covers *.alibaba-inc.com and *.aliyun-inc.com.
     const isInternalOrigin =
@@ -90,6 +96,7 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
     if (
       normalizedProxyUrl &&
       !isDashscopeOrigin &&
+      !isTokenPlanOrigin &&
       !isInternalOrigin &&
       !isProxyMatch
     ) {
@@ -104,7 +111,12 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
       );
     }
 
-    return isDashscopeOrigin || isInternalOrigin || isProxyMatch;
+    return (
+      isDashscopeOrigin ||
+      isTokenPlanOrigin ||
+      isInternalOrigin ||
+      isProxyMatch
+    );
   }
 
   override buildHeaders(): Record<string, string | undefined> {


### PR DESCRIPTION
## Summary

- What changed: Token Plan-compatible endpoints are now routed through the DashScope-compatible request path, so requests receive the cache-control metadata already used for DashScope providers.
- Why it changed: Token Plan endpoints previously fell back to the generic OpenAI-compatible path, which meant session cache hints were not sent and `/stats model` had no cached-token usage to display.
- Reviewer focus: Please verify the endpoint matching is narrow enough for Token Plan while preserving the existing DashScope and internal-origin behavior.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/core/openaiContentGenerator/provider/dashscope.test.ts
  npm run build && npm run typecheck
  ```
- Prompts / inputs used: N/A
- Expected result: Token Plan URLs use the DashScope-compatible path; unrelated lookalike hosts do not.
- Observed result: Targeted provider tests passed with 56 tests. Full build and typecheck passed after linking the existing package-local dependencies into a clean worktree.
- Quickest reviewer verification path: Run the targeted provider test above and inspect that a Token Plan endpoint is classified with the same provider path as DashScope.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  ```text
  ✓ src/core/openaiContentGenerator/provider/dashscope.test.ts (56 tests) 18ms
  Test Files  1 passed (1)
  Tests  56 passed (56)
  ```
  ```text
  npm run build && npm run typecheck
  ...
  @qwen-code/webui@0.16.1 typecheck
  tsc --noEmit
  ```

## Scope / Risk

- Main risk or tradeoff: Endpoint matching intentionally recognizes only `token-plan.<region>.maas.aliyuncs.com` style hosts to avoid treating unrelated MaaS endpoints as DashScope-compatible.
- Not covered / not validated: I did not make a live Token Plan API call, so the PR validates request routing and cache-control attachment path locally rather than a real backend cache hit.
- Breaking changes / migration notes: None expected.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- macOS validation covered the targeted `npx vitest` command plus `npm run build && npm run typecheck`.
- Windows and Linux were not run locally.

## Linked Issues / Bugs

Fixes #4444
