### PR TITLE
fix(extension): populate resources when Claude marketplace points at whole folder

### DIFF
--- a/packages/core/src/extension/claude-converter.test.ts
+++ b/packages/core/src/extension/claude-converter.test.ts
@@ -389,7 +389,10 @@ describe('convertClaudePluginPackage', () => {
     const pluginSourceDir = path.join(testDir, 'plugin-crlf-agents');
     fs.mkdirSync(pluginSourceDir, { recursive: true });
 
-    // Create source agents directory (renamed to src-agents to avoid skip-logic bug)
+    // Create source agents directory.
+    // (Previously named `src-agents` to dodge a skip-logic bug in
+    // collectResources where file entries like `./agents/foo.md` would be
+    // silently dropped — fixed; the directory name is now incidental.)
     const agentsDir = path.join(pluginSourceDir, 'src-agents');
     fs.mkdirSync(agentsDir, { recursive: true });
 
@@ -446,6 +449,145 @@ describe('convertClaudePluginPackage', () => {
     expect(convertedContent).toContain('name: cool-agent');
 
     // Clean up
+    fs.rmSync(result.convertedDir, { recursive: true, force: true });
+  });
+
+  it('should populate commands/skills/agents when marketplace references the whole folder (deep-wiki shape)', async () => {
+    // Regression test for https://github.com/QwenLM/qwen-code/issues/4452.
+    //
+    // microsoft/skills/.../deep-wiki declares its resources as
+    //   commands: ["./commands/"]
+    //   skills:   ["./skills/"]
+    //   agents:   ["./agents/wiki-architect.md", ...]
+    // i.e. references the *whole* resource folder, with file paths sitting
+    // directly under `agents/`. An earlier skip-branch in collectResources
+    // dropped both shapes silently, leaving empty directories.
+    const pluginSourceDir = path.join(testDir, 'deep-wiki-shape');
+    fs.mkdirSync(pluginSourceDir, { recursive: true });
+
+    // commands/ with two files
+    const commandsDir = path.join(pluginSourceDir, 'commands');
+    fs.mkdirSync(commandsDir, { recursive: true });
+    fs.writeFileSync(path.join(commandsDir, 'wiki.md'), '# wiki', 'utf-8');
+    fs.writeFileSync(path.join(commandsDir, 'index.md'), '# index', 'utf-8');
+
+    // skills/ with one sub-skill
+    const skillsDir = path.join(pluginSourceDir, 'skills');
+    const subSkillDir = path.join(skillsDir, 'wiki-skill');
+    fs.mkdirSync(subSkillDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(subSkillDir, 'SKILL.md'),
+      '# wiki-skill',
+      'utf-8',
+    );
+
+    // agents/ with file entries referenced individually
+    const agentsDir = path.join(pluginSourceDir, 'agents');
+    fs.mkdirSync(agentsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(agentsDir, 'wiki-architect.md'),
+      '---\nname: wiki-architect\ndescription: Architect\n---\nbody',
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(agentsDir, 'wiki-writer.md'),
+      '---\nname: wiki-writer\ndescription: Writer\n---\nbody',
+      'utf-8',
+    );
+
+    // marketplace.json mirroring the microsoft/skills shape
+    const marketplaceDir = path.join(pluginSourceDir, '.claude-plugin');
+    fs.mkdirSync(marketplaceDir, { recursive: true });
+    const marketplaceConfig: ClaudeMarketplaceConfig = {
+      name: 'test-marketplace',
+      owner: { name: 'Test Owner', email: 'test@example.com' },
+      plugins: [
+        {
+          name: 'deep-wiki',
+          version: '1.0.0',
+          source: './',
+          strict: false,
+          commands: ['./commands/'],
+          skills: ['./skills/'],
+          agents: ['./agents/wiki-architect.md', './agents/wiki-writer.md'],
+        },
+      ],
+    };
+    fs.writeFileSync(
+      path.join(marketplaceDir, 'marketplace.json'),
+      JSON.stringify(marketplaceConfig, null, 2),
+      'utf-8',
+    );
+
+    const result = await convertClaudePluginPackage(
+      pluginSourceDir,
+      'deep-wiki',
+    );
+
+    // commands/ should be populated (flattened, not nested as commands/commands)
+    const convertedCommands = path.join(result.convertedDir, 'commands');
+    expect(fs.existsSync(convertedCommands)).toBe(true);
+    expect(fs.readdirSync(convertedCommands).sort()).toEqual([
+      'index.md',
+      'wiki.md',
+    ]);
+    expect(fs.existsSync(path.join(convertedCommands, 'commands'))).toBe(false);
+
+    // skills/ should contain wiki-skill/SKILL.md
+    const convertedSkills = path.join(result.convertedDir, 'skills');
+    expect(
+      fs.existsSync(path.join(convertedSkills, 'wiki-skill', 'SKILL.md')),
+    ).toBe(true);
+    expect(fs.existsSync(path.join(convertedSkills, 'skills'))).toBe(false);
+
+    // agents/ should contain the two referenced files at the root
+    const convertedAgents = path.join(result.convertedDir, 'agents');
+    expect(fs.readdirSync(convertedAgents).sort()).toEqual([
+      'wiki-architect.md',
+      'wiki-writer.md',
+    ]);
+    expect(fs.existsSync(path.join(convertedAgents, 'agents'))).toBe(false);
+
+    fs.rmSync(result.convertedDir, { recursive: true, force: true });
+  });
+
+  it('should populate resources when marketplace references whole folder with trailing slash variants', async () => {
+    // `./commands/` (with trailing slash) and `./commands` (without) should
+    // both resolve identically — the bug fix shouldn't be sensitive to the
+    // exact form marketplace authors write.
+    const pluginSourceDir = path.join(testDir, 'trailing-slash');
+    fs.mkdirSync(pluginSourceDir, { recursive: true });
+    const commandsDir = path.join(pluginSourceDir, 'commands');
+    fs.mkdirSync(commandsDir, { recursive: true });
+    fs.writeFileSync(path.join(commandsDir, 'a.md'), '# a', 'utf-8');
+
+    const marketplaceDir = path.join(pluginSourceDir, '.claude-plugin');
+    fs.mkdirSync(marketplaceDir, { recursive: true });
+    const marketplaceConfig: ClaudeMarketplaceConfig = {
+      name: 'test-marketplace',
+      owner: { name: 'Test Owner', email: 'test@example.com' },
+      plugins: [
+        {
+          name: 'no-slash',
+          version: '1.0.0',
+          source: './',
+          strict: false,
+          commands: ['./commands'], // no trailing slash
+        },
+      ],
+    };
+    fs.writeFileSync(
+      path.join(marketplaceDir, 'marketplace.json'),
+      JSON.stringify(marketplaceConfig, null, 2),
+      'utf-8',
+    );
+
+    const result = await convertClaudePluginPackage(
+      pluginSourceDir,
+      'no-slash',
+    );
+    const convertedCommands = path.join(result.convertedDir, 'commands');
+    expect(fs.existsSync(path.join(convertedCommands, 'a.md'))).toBe(true);
     fs.rmSync(result.convertedDir, { recursive: true, force: true });
   });
 

--- a/packages/core/src/extension/claude-converter.ts
+++ b/packages/core/src/extension/claude-converter.ts
@@ -549,7 +549,9 @@ export async function convertClaudePluginPackage(
 
 /**
  * Collects resources (commands, skills, agents) to a destination folder.
- * If a resource is already in the destination folder, it will be skipped.
+ * Resources are always copied unconditionally — the caller
+ * (`convertClaudePluginPackage`) clears `destDir` beforehand so it can
+ * honor selective sub-entry lists.
  * @param resourcePaths String or array of resource paths
  * @param pluginRoot Root directory of the plugin
  * @param destDir Destination directory for collected resources

--- a/packages/core/src/extension/claude-converter.ts
+++ b/packages/core/src/extension/claude-converter.ts
@@ -582,22 +582,25 @@ async function collectResources(
     const stat = fs.statSync(resolvedPath);
 
     if (stat.isDirectory()) {
-      // If it's a directory, check if it's already the destination folder
       const dirName = path.basename(resolvedPath);
-      const parentDir = path.dirname(resolvedPath);
 
-      // If the directory is already named as the destination folder (e.g., 'commands')
-      // and it's at the plugin root level, skip it
-      if (dirName === destFolderName && parentDir === pluginRoot) {
-        debugLogger.debug(
-          `Skipping ${resolvedPath} as it's already in the correct location`,
-        );
-        continue;
-      }
-
-      // Determine destination: preserve the directory name
-      // e.g., ./skills/xlsx -> tmpDir/skills/xlsx/
-      const finalDestDir = path.join(destDir, dirName);
+      // Determine destination layout.
+      //
+      // When the marketplace entry points at the *whole* resource folder
+      // (e.g. `commands: ["./commands/"]`, deep-wiki style), the source
+      // directory name matches the destination folder name and we want to
+      // copy the directory's contents *flat* into destDir — otherwise we'd
+      // end up with `tmpDir/commands/commands/...`.
+      //
+      // When the entry points at a sub-folder (e.g. `skills: ["./skills/xlsx"]`,
+      // anthropics/skills style), we preserve the sub-folder name so each
+      // entry lands at `tmpDir/skills/<sub>/`.
+      //
+      // Note: the caller (`convertClaudePluginPackage`) deletes destDir
+      // before invoking us, so we always copy unconditionally; there is no
+      // safe "already in the correct location" shortcut.
+      const finalDestDir =
+        dirName === destFolderName ? destDir : path.join(destDir, dirName);
 
       // Copy all files from the directory
       const files = await glob('**/*', {
@@ -631,20 +634,10 @@ async function collectResources(
         fs.copyFileSync(srcFile, destFile);
       }
     } else {
-      // If it's a file, check if it's already in the destination folder
-      const relativePath = path.relative(pluginRoot, resolvedPath);
-
-      // Check if the file path starts with the destination folder name
-      // e.g., 'commands/test1.md' or 'commands/me/test.md' should be skipped
-      const segments = relativePath.split(path.sep);
-      if (segments.length > 0 && segments[0] === destFolderName) {
-        debugLogger.debug(
-          `Skipping ${resolvedPath} as it's already in ${destFolderName}/`,
-        );
-        continue;
-      }
-
-      // Copy the file to destination
+      // File entry (e.g. `agents: ["./agents/wiki-architect.md"]`).
+      // Always copy — the caller has already cleared destDir, so the
+      // file is missing even when the relative path looks like it's
+      // "already in the destination folder".
       const fileName = path.basename(resolvedPath);
       const destFile = path.join(destDir, fileName);
       fs.copyFileSync(resolvedPath, destFile);


### PR DESCRIPTION
## Summary

- Fixes #4452 — installing `microsoft/skills:deep-wiki` (and any other
  Claude plugin that references resources by the whole folder) reported
  success but produced an empty extension.
- Root cause was a stale skip-branch in
  `collectResources` (`packages/core/src/extension/claude-converter.ts`).
  `convertClaudePluginPackage` deletes `tmpDir/<commands|skills|agents>`
  before invoking `collectResources` (so it can honor selective
  sub-entry lists like `skills: ["./skills/xlsx"]`), but
  `collectResources` was still short-circuiting on the assumption that
  the prior `copyDirectory` had already placed the files at the
  destination. The freshly-`mkdir`'d folder was left empty.

## Fix

`collectResources` no longer short-circuits when the resource path
already lives at `pluginRoot/<destFolderName>`. Two cases:

- **Directory entry with `dirName === destFolderName`** (deep-wiki shape
  — `commands: ["./commands/"]`): copy contents *flat* into `destDir`
  instead of nesting under `destDir/<dirName>/`.
- **Directory entry with `dirName !== destFolderName`** (anthropics/skills
  shape — `skills: ["./skills/xlsx"]`): keep nesting at
  `tmpDir/skills/xlsx/` — unchanged.
- **File entry** (deep-wiki agents — `agents: ["./agents/foo.md"]`):
  always copy; the existing `destFile = destDir/<fileName>` already
  produces the right path.

## Tests

- New regression test `should populate commands/skills/agents when
  marketplace references the whole folder (deep-wiki shape)` exercises
  the exact failure mode (mixed whole-folder + file-entry shape).
- New `trailing slash variants` test covers both `./commands/` and
  `./commands`.
- Existing CRLF-agent test had a workaround comment (`renamed to
  src-agents to avoid skip-logic bug`) — comment updated; the directory
  rename is now incidental, not load-bearing.

Verified all 19 tests in `claude-converter.test.ts` pass with the fix and
that the new test fails without it (`git stash`-ed the fix, re-ran the
test, observed `expected [] to deeply equal [ 'index.md', 'wiki.md' ]`).

## End-to-end verification

Built the CLI from this branch and ran against a fresh `$HOME`:

```
$ node dist/cli.js extensions install \
    "https://github.com/microsoft/skills:deep-wiki" --consent
Extension "deep-wiki" installed successfully and enabled.

$ node dist/cli.js extensions list
✓ deep-wiki (1.0.0)
 Commands: /research /page /onboard /llms /generate /deploy /crisp
           /changelog /catalogue /build /ask /agents /ado    (13)
 Skills:   wiki-ado-convert wiki-agents-md wiki-architect
           wiki-changelog wiki-llms-txt wiki-onboarding
           wiki-page-writer wiki-qa wiki-researcher
           wiki-vitepress                                    (10)
 Agents:   wiki-architect wiki-researcher wiki-writer        (3)
```

Regression check against the previously-working `anthropics/skills`:

```
$ node dist/cli.js extensions install \
    "https://github.com/anthropics/skills:document-skills" --consent
Extension "document-skills" installed successfully and enabled.

$ node dist/cli.js extensions list
✓ document-skills
 Skills: docx pdf pptx xlsx
```

Sub-folder nesting (`skills/xlsx/`) is preserved as before.

## Test plan

- [x] Unit: `npx vitest run packages/core/src/extension/claude-converter.test.ts` — 19/19 pass
- [x] Unit: new tests fail without the fix (verified via `git stash`)
- [x] E2E: `microsoft/skills:deep-wiki` installs with 13 commands, 10 skills, 3 agents and `extensions list` surfaces them
- [x] E2E: `anthropics/skills:document-skills` still installs with 4 nested sub-skills