### PR TITLE
fix(core): emit enable_thinking on DashScope when reasoning is disabled

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -487,7 +487,7 @@ describe('ContentGenerationPipeline', () => {
       }));
 
       const request: GenerateContentParameters = {
-        model: 'test-model',
+        model: 'qwen3.5-flash',
         contents: [{ parts: [{ text: 'Suggest next' }], role: 'user' }],
         config: { thinkingConfig: { includeThoughts: false } },
       };
@@ -785,7 +785,7 @@ describe('ContentGenerationPipeline', () => {
       // `extra_body.enable_thinking` (so the field never appears on the
       // wire body unless we add it here).
       const request: GenerateContentParameters = {
-        model: 'test-model',
+        model: 'qwen3.5-flash',
         contents: [{ parts: [{ text: 'Summarize' }], role: 'user' }],
         config: { thinkingConfig: { includeThoughts: false } },
       };
@@ -824,7 +824,7 @@ describe('ContentGenerationPipeline', () => {
       pipeline = new ContentGenerationPipeline(mockConfig);
 
       const request: GenerateContentParameters = {
-        model: 'test-model',
+        model: 'qwen3.5-flash',
         contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
       };
 
@@ -866,7 +866,7 @@ describe('ContentGenerationPipeline', () => {
       pipeline = new ContentGenerationPipeline(mockConfig);
 
       const request: GenerateContentParameters = {
-        model: 'test-model',
+        model: 'coder-model',
         contents: [{ parts: [{ text: 'Hi' }], role: 'user' }],
         config: { thinkingConfig: { includeThoughts: false } },
       };
@@ -907,7 +907,7 @@ describe('ContentGenerationPipeline', () => {
       pipeline = new ContentGenerationPipeline(mockConfig);
 
       const request: GenerateContentParameters = {
-        model: 'test-model',
+        model: 'qwen3.5-flash',
         contents: [{ parts: [{ text: 'Hi' }], role: 'user' }],
         config: { thinkingConfig: { includeThoughts: false } },
       };
@@ -988,7 +988,7 @@ describe('ContentGenerationPipeline', () => {
       pipeline = new ContentGenerationPipeline(mockConfig);
 
       const request: GenerateContentParameters = {
-        model: 'test-model',
+        model: 'glm-5',
         contents: [{ parts: [{ text: 'Summarize' }], role: 'user' }],
         config: { thinkingConfig: { includeThoughts: false } },
       };
@@ -1011,6 +1011,85 @@ describe('ContentGenerationPipeline', () => {
       expect(apiCall.enable_thinking).toBeUndefined();
     });
 
+    it('gates on the wire model, not config: qwen config + non-qwen request.model does NOT emit', async () => {
+      // buildRequest ships `context.model` (= request.model || config.model).
+      // A qwen *config* with a non-qwen *request* model must gate on the
+      // request model — otherwise the qwen-only field leaks to the non-qwen
+      // routing that is actually on the wire (e.g. GLM rejecting it upstream).
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        model: 'qwen3.5-flash',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'glm-5', // request-level override to a non-qwen wire model
+        contents: [{ parts: [{ text: 'Summarize' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Summarize' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'forked_query');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.enable_thinking).toBeUndefined();
+    });
+
+    it('gates on the wire model, not config: non-qwen config + qwen request.model emits false', async () => {
+      // The mirror direction: a non-qwen *config* with a qwen *request* model
+      // must still emit the disable signal, since the wire model is qwen and
+      // would otherwise keep thinking-on (the #4501 regression).
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        model: 'glm-5',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'qwen3.5-flash', // request-level override to a qwen wire model
+        contents: [{ parts: [{ text: 'Summarize' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Summarize' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'forked_query');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.enable_thinking).toBe(false);
+    });
+
     it('emits enable_thinking:false when baseUrl is unset (DashScope default)', async () => {
       // `isDashScopeProvider` treats a missing baseUrl as DashScope
       // (`dashscope.ts:49` returns true for `!baseUrl`). A fresh install
@@ -1030,7 +1109,7 @@ describe('ContentGenerationPipeline', () => {
       pipeline = new ContentGenerationPipeline(mockConfig);
 
       const request: GenerateContentParameters = {
-        model: 'test-model',
+        model: 'qwen3.5-flash',
         contents: [{ parts: [{ text: 'Summarize' }], role: 'user' }],
         config: { thinkingConfig: { includeThoughts: false } },
       };

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -846,17 +846,18 @@ describe('ContentGenerationPipeline', () => {
       expect(apiCall.enable_thinking).toBe(false);
     });
 
-    it('emits enable_thinking:false on QWEN_OAUTH regardless of baseUrl', async () => {
-      // QWEN_OAUTH activates the DashScope provider regardless of baseUrl
-      // (see DashScopeOpenAICompatibleProvider.isDashScopeProvider line 47).
-      // Verify the gate fires through that path too — important because
-      // QWEN_OAUTH is the default flow for first-time users and does not
-      // go through the wizard's `extra_body` setup.
+    it('emits enable_thinking:false on QWEN_OAUTH with the default coder-model', async () => {
+      // QWEN_OAUTH is the default auth flow for first-time users and
+      // ships with `model: 'coder-model'` (DEFAULT_QWEN_MODEL in
+      // config/models.ts — aliased to Qwen 3.6 Plus hybrid). The string
+      // doesn't start with `qwen`, so the gate must special-case it;
+      // otherwise the exact regression that #4501 fixes (side-queries
+      // burning reasoning tokens on the default flow) remains live.
       mockContentGeneratorConfig = {
         ...mockContentGeneratorConfig,
         authType: AuthType.QWEN_OAUTH,
         baseUrl: 'https://some-oauth-issued-endpoint.example/v1',
-        model: 'qwen3-coder-flash',
+        model: 'coder-model',
       } as ContentGeneratorConfig;
       mockConfig = {
         ...mockConfig,
@@ -1008,6 +1009,48 @@ describe('ContentGenerationPipeline', () => {
       const apiCall = (mockClient.chat.completions.create as Mock).mock
         .calls[0][0];
       expect(apiCall.enable_thinking).toBeUndefined();
+    });
+
+    it('emits enable_thinking:false when baseUrl is unset (DashScope default)', async () => {
+      // `isDashScopeProvider` treats a missing baseUrl as DashScope
+      // (`dashscope.ts:49` returns true for `!baseUrl`). A fresh install
+      // that hasn't run the setup wizard hits this path. All other
+      // positive tests above explicitly set baseUrl, so pin this
+      // implicit-default branch separately to detect future tightening
+      // of the `!baseUrl` early-return.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        model: 'qwen3.5-flash',
+      } as ContentGeneratorConfig;
+      delete (mockContentGeneratorConfig as { baseUrl?: string }).baseUrl;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [{ parts: [{ text: 'Summarize' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Summarize' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'forked_query');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.enable_thinking).toBe(false);
     });
 
     it('should handle errors and log them', async () => {

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -15,7 +15,7 @@ import { OpenAIContentConverter } from './converter.js';
 import { openaiRequestCaptureContext } from './requestCaptureContext.js';
 import { StreamingToolCallParser } from './streamingToolCallParser.js';
 import type { Config } from '../../config/config.js';
-import type { ContentGeneratorConfig, AuthType } from '../contentGenerator.js';
+import { AuthType, type ContentGeneratorConfig } from '../contentGenerator.js';
 import type { OpenAICompatibleProvider } from './provider/index.js';
 
 // Mock dependencies
@@ -463,8 +463,22 @@ describe('ContentGenerationPipeline', () => {
     });
 
     it('should override enable_thinking when thinkingConfig disables it', async () => {
-      // Arrange — provider injects enable_thinking: true via extra_body,
-      // but request explicitly disables thinking
+      // Arrange — provider injects enable_thinking: true via extra_body
+      // (e.g. user configured `enableThinking: true` via setup wizard,
+      // see provider-config.ts), but request explicitly disables thinking.
+      // DashScope hostname is required because the override is gated on it
+      // (otherwise the qwen-specific `enable_thinking` field would leak to
+      // non-qwen providers).
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
       (mockProvider.buildRequest as Mock).mockImplementation((req) => ({
         ...req,
         enable_thinking: true, // Simulates extra_body injection
@@ -745,6 +759,212 @@ describe('ContentGenerationPipeline', () => {
       const apiCall = (mockClient.chat.completions.create as Mock).mock
         .calls[0][0];
       expect(apiCall.thinking).toBeUndefined();
+    });
+
+    it('emits enable_thinking:false on DashScope hostname when includeThoughts is false', async () => {
+      // Regression for #4501: qwen3 hybrid models (e.g. qwen3.5-flash)
+      // default to thinking-on. Provider buildRequest never auto-injects
+      // `enable_thinking`, so a previous guarded `'enable_thinking' in typed`
+      // check never fired and side-queries burned reasoning tokens (24-95x
+      // output bloat in production). The disable must be emitted explicitly.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        model: 'qwen3.5-flash',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      // Provider passes the request through unchanged — simulates the
+      // common case where the user has not configured
+      // `extra_body.enable_thinking` (so the field never appears on the
+      // wire body unless we add it here).
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [{ parts: [{ text: 'Summarize' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Summarize' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'forked_query');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.enable_thinking).toBe(false);
+    });
+
+    it('emits enable_thinking:false on DashScope hostname when reasoning is configured to false', async () => {
+      // Config-level opt-out (`reasoning: false`) should also disable
+      // qwen3 thinking, mirroring the DeepSeek pair above.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        model: 'qwen3.5-flash',
+        reasoning: false,
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [{ parts: [{ text: 'Hello' }], role: 'user' }],
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Hello' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'main');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.enable_thinking).toBe(false);
+    });
+
+    it('emits enable_thinking:false on QWEN_OAUTH regardless of baseUrl', async () => {
+      // QWEN_OAUTH activates the DashScope provider regardless of baseUrl
+      // (see DashScopeOpenAICompatibleProvider.isDashScopeProvider line 47).
+      // Verify the gate fires through that path too — important because
+      // QWEN_OAUTH is the default flow for first-time users and does not
+      // go through the wizard's `extra_body` setup.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        authType: AuthType.QWEN_OAUTH,
+        baseUrl: 'https://some-oauth-issued-endpoint.example/v1',
+        model: 'qwen3-coder-flash',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [{ parts: [{ text: 'Hi' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Hi' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'forked_query');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.enable_thinking).toBe(false);
+    });
+
+    it('emits enable_thinking:false on internal alibaba-inc.com hostname', async () => {
+      // Internal Alibaba domains proxy to DashScope-compatible APIs and
+      // are treated as DashScope by design (provider/dashscope.ts:75-78).
+      // Cover the internal-origin path explicitly so a future tightening
+      // of the hostname rules does not silently drop coverage for
+      // internal users.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://gateway.alibaba-inc.com/v1',
+        model: 'qwen3.5-flash',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [{ parts: [{ text: 'Hi' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Hi' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'forked_query');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.enable_thinking).toBe(false);
+    });
+
+    it('does NOT emit enable_thinking on a non-DashScope hostname', async () => {
+      // `enable_thinking` is a qwen-specific extension. Pushing it at a
+      // strict OpenAI-compatible backend could trip an unknown-key 400
+      // and would also pollute logs with a meaningless field. Mirror of
+      // the DeepSeek negative test above.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-5',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [{ parts: [{ text: 'Suggest' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Suggest' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'forked_query');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.enable_thinking).toBeUndefined();
     });
 
     it('should handle errors and log them', async () => {

--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -466,12 +466,14 @@ describe('ContentGenerationPipeline', () => {
       // Arrange — provider injects enable_thinking: true via extra_body
       // (e.g. user configured `enableThinking: true` via setup wizard,
       // see provider-config.ts), but request explicitly disables thinking.
-      // DashScope hostname is required because the override is gated on it
-      // (otherwise the qwen-specific `enable_thinking` field would leak to
-      // non-qwen providers).
+      // DashScope hostname + qwen model name are both required: the gate
+      // is hostname + model-name to avoid leaking the qwen-specific
+      // `enable_thinking` field to non-qwen routings (off-DashScope, or
+      // GLM/DeepSeek on the same DashScope hostname).
       mockContentGeneratorConfig = {
         ...mockContentGeneratorConfig,
         baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        model: 'qwen3.5-flash',
       } as ContentGeneratorConfig;
       mockConfig = {
         ...mockConfig,
@@ -951,6 +953,47 @@ describe('ContentGenerationPipeline', () => {
 
       (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
         { role: 'user', content: 'Suggest' },
+      ]);
+      (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
+        new GenerateContentResponse(),
+      );
+      (mockClient.chat.completions.create as Mock).mockResolvedValue({
+        id: 'r',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      } as OpenAI.Chat.ChatCompletion);
+
+      await pipeline.execute(request, 'forked_query');
+
+      const apiCall = (mockClient.chat.completions.create as Mock).mock
+        .calls[0][0];
+      expect(apiCall.enable_thinking).toBeUndefined();
+    });
+
+    it('does NOT emit enable_thinking on a non-qwen model routed through DashScope', async () => {
+      // DashScope's compatible-mode endpoint routes multiple model families
+      // (qwen3, GLM, DeepSeek). Hostname alone is not enough — GLM uses
+      // `extra_body.thinking.enabled` and DeepSeek-on-DashScope uses
+      // `thinking: { type: 'disabled' }`, so sending `enable_thinking` is
+      // at best a no-op and at worst forwarded upstream and rejected.
+      mockContentGeneratorConfig = {
+        ...mockContentGeneratorConfig,
+        baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+        model: 'glm-5',
+      } as ContentGeneratorConfig;
+      mockConfig = {
+        ...mockConfig,
+        contentGeneratorConfig: mockContentGeneratorConfig,
+      };
+      pipeline = new ContentGenerationPipeline(mockConfig);
+
+      const request: GenerateContentParameters = {
+        model: 'test-model',
+        contents: [{ parts: [{ text: 'Summarize' }], role: 'user' }],
+        config: { thinkingConfig: { includeThoughts: false } },
+      };
+
+      (mockConverter.convertGeminiRequestToOpenAI as Mock).mockReturnValue([
+        { role: 'user', content: 'Summarize' },
       ]);
       (mockConverter.convertOpenAIResponseToGemini as Mock).mockReturnValue(
         new GenerateContentResponse(),

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -18,6 +18,7 @@ import { openaiRequestCaptureContext } from './requestCaptureContext.js';
 import { StreamingToolCallParser } from './streamingToolCallParser.js';
 import { TaggedThinkingParser } from './taggedThinkingParser.js';
 import type { PipelineConfig, RequestContext } from './types.js';
+import { DEFAULT_QWEN_MODEL } from '../../config/models.js';
 import { redactProxyError } from '../../utils/runtimeFetchOptions.js';
 import { runtimeDiagnostics } from '../../utils/runtimeDiagnostics.js';
 
@@ -370,16 +371,24 @@ export class ContentGenerationPipeline {
       // `thinking: { type: 'disabled' }`; sending `enable_thinking` to them
       // is at best a no-op, at worst forwarded upstream and rejected).
       //
-      // `coder-model` is the QWEN_OAUTH default (DEFAULT_QWEN_MODEL in
-      // config/models.ts, aliased to Qwen 3.6 Plus hybrid) — it doesn't
-      // start with `qwen` but is the most common hybrid-thinking model
-      // for first-time users, so it must be covered.
-      const model = (this.contentGeneratorConfig.model ?? '').toLowerCase();
+      // Gate on the *wire* model (`context.model`, i.e.
+      // `request.model || contentGeneratorConfig.model` — the same value
+      // baseRequest.model is built from above), not on the config model. A
+      // request-level model override would otherwise desync the gate from
+      // what actually ships: a qwen config with a non-qwen request model
+      // would leak the field, and a non-qwen config with a qwen request
+      // model would miss the disable signal (the #4501 regression).
+      //
+      // DEFAULT_QWEN_MODEL (currently `coder-model`) is the QWEN_OAUTH
+      // default — it doesn't start with `qwen` but is the most common
+      // hybrid-thinking model for first-time users, so it must be covered.
+      // Importing the constant keeps this gate in sync if the alias moves.
+      const model = (context.model ?? '').toLowerCase();
       if (
         DashScopeOpenAICompatibleProvider.isDashScopeProvider(
           this.contentGeneratorConfig,
         ) &&
-        (model.startsWith('qwen') || model === 'coder-model')
+        (model.startsWith('qwen') || model === DEFAULT_QWEN_MODEL)
       ) {
         typed['enable_thinking'] = false;
       }

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -18,7 +18,6 @@ import { openaiRequestCaptureContext } from './requestCaptureContext.js';
 import { StreamingToolCallParser } from './streamingToolCallParser.js';
 import { TaggedThinkingParser } from './taggedThinkingParser.js';
 import type { PipelineConfig, RequestContext } from './types.js';
-import { DEFAULT_QWEN_MODEL } from '../../config/models.js';
 import { redactProxyError } from '../../utils/runtimeFetchOptions.js';
 import { runtimeDiagnostics } from '../../utils/runtimeDiagnostics.js';
 
@@ -379,16 +378,16 @@ export class ContentGenerationPipeline {
       // would leak the field, and a non-qwen config with a qwen request
       // model would miss the disable signal (the #4501 regression).
       //
-      // DEFAULT_QWEN_MODEL (currently `coder-model`) is the QWEN_OAUTH
-      // default — it doesn't start with `qwen` but is the most common
-      // hybrid-thinking model for first-time users, so it must be covered.
-      // Importing the constant keeps this gate in sync if the alias moves.
+      // `coder-model` is the QWEN_OAUTH default (DEFAULT_QWEN_MODEL in
+      // config/models.ts, aliased to Qwen 3.6 Plus hybrid) — it doesn't
+      // start with `qwen` but is the most common hybrid-thinking model
+      // for first-time users, so it must be covered.
       const model = (context.model ?? '').toLowerCase();
       if (
         DashScopeOpenAICompatibleProvider.isDashScopeProvider(
           this.contentGeneratorConfig,
         ) &&
-        (model.startsWith('qwen') || model === DEFAULT_QWEN_MODEL)
+        (model.startsWith('qwen') || model === 'coder-model')
       ) {
         typed['enable_thinking'] = false;
       }

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -12,6 +12,7 @@ import {
 } from '@google/genai';
 import type { ContentGeneratorConfig } from '../contentGenerator.js';
 import { OpenAIContentConverter } from './converter.js';
+import { DashScopeOpenAICompatibleProvider } from './provider/dashscope.js';
 import { isDeepSeekHostname } from './provider/deepseek.js';
 import { openaiRequestCaptureContext } from './requestCaptureContext.js';
 import { StreamingToolCallParser } from './streamingToolCallParser.js';
@@ -361,7 +362,24 @@ export class ContentGenerationPipeline {
       this.contentGeneratorConfig.reasoning === false;
     if (reasoningDisabled) {
       const typed = providerRequest as unknown as Record<string, unknown>;
-      if ('enable_thinking' in typed) {
+      // qwen3 hybrid-thinking models (e.g. qwen3.5-flash) default to
+      // thinking-on at the server. Provider buildRequest never auto-
+      // injects `enable_thinking`, so a vanilla wire body lacks the
+      // field and the disable signal would not reach the server.
+      // Hostname-gated unconditional set mirrors the DeepSeek branch
+      // below. Overrides any user-supplied `extra_body.enable_thinking:
+      // true` because per-request `includeThoughts: false` is the
+      // stronger intent (set by every side-query via sideQuery.ts).
+      //
+      // Scope: targets qwen3 hybrid via DashScope's compatible-mode
+      // contract. GLM (extra_body.thinking.enabled) and DeepSeek-on-
+      // DashScope (thinking: { type: 'disabled' }) need different
+      // disable shapes — pre-existing gap, not closed here.
+      if (
+        DashScopeOpenAICompatibleProvider.isDashScopeProvider(
+          this.contentGeneratorConfig,
+        )
+      ) {
         typed['enable_thinking'] = false;
       }
       // Strip reasoning config — extra_body could inject it, overriding
@@ -471,7 +489,11 @@ export class ContentGenerationPipeline {
     //   - glm-4.7             — thinking is enabled by default; can be disabled via `extra_body.thinking.enabled`
     //   - kimi-k2-thinking    — thinking is enabled by default and cannot be disabled
     //   - gpt-5.x series      — thinking is enabled by default; can be disabled via `reasoning.effort`
-    //   - qwen3 series        — model-dependent; can be manually disabled via `extra_body.enable_thinking`
+    //   - qwen3 series        — model-dependent; emitted as `enable_thinking: false`
+    //                           by buildRequest above when reasoning is disabled
+    //                           on DashScope endpoints (provider never auto-
+    //                           injects this field, so the wire body would
+    //                           otherwise lack the disable signal)
     //
     // Given this inconsistency, we avoid mapping values and only pass through the
     // configured reasoning object when explicitly enabled. This keeps provider- and

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -369,13 +369,17 @@ export class ContentGenerationPipeline {
       // `extra_body.thinking.enabled`, DeepSeek-on-DashScope uses
       // `thinking: { type: 'disabled' }`; sending `enable_thinking` to them
       // is at best a no-op, at worst forwarded upstream and rejected).
+      //
+      // `coder-model` is the QWEN_OAUTH default (DEFAULT_QWEN_MODEL in
+      // config/models.ts, aliased to Qwen 3.6 Plus hybrid) — it doesn't
+      // start with `qwen` but is the most common hybrid-thinking model
+      // for first-time users, so it must be covered.
+      const model = (this.contentGeneratorConfig.model ?? '').toLowerCase();
       if (
         DashScopeOpenAICompatibleProvider.isDashScopeProvider(
           this.contentGeneratorConfig,
         ) &&
-        (this.contentGeneratorConfig.model ?? '')
-          .toLowerCase()
-          .startsWith('qwen')
+        (model.startsWith('qwen') || model === 'coder-model')
       ) {
         typed['enable_thinking'] = false;
       }

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -364,13 +364,18 @@ export class ContentGenerationPipeline {
       const typed = providerRequest as unknown as Record<string, unknown>;
       // Provider buildRequest doesn't auto-inject `enable_thinking`, so a
       // guarded `in typed` check would never fire for default qwen3 configs.
-      // Hostname gate avoids leaking this qwen-specific field elsewhere.
-      // Scope: qwen3 hybrid only — GLM/DeepSeek-on-DashScope use different
-      // disable shapes and aren't handled.
+      // Hostname + model-name gate avoids leaking this qwen-specific field
+      // to non-qwen routings on the same DashScope hostname (GLM uses
+      // `extra_body.thinking.enabled`, DeepSeek-on-DashScope uses
+      // `thinking: { type: 'disabled' }`; sending `enable_thinking` to them
+      // is at best a no-op, at worst forwarded upstream and rejected).
       if (
         DashScopeOpenAICompatibleProvider.isDashScopeProvider(
           this.contentGeneratorConfig,
-        )
+        ) &&
+        (this.contentGeneratorConfig.model ?? '')
+          .toLowerCase()
+          .startsWith('qwen')
       ) {
         typed['enable_thinking'] = false;
       }

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -362,19 +362,11 @@ export class ContentGenerationPipeline {
       this.contentGeneratorConfig.reasoning === false;
     if (reasoningDisabled) {
       const typed = providerRequest as unknown as Record<string, unknown>;
-      // qwen3 hybrid-thinking models (e.g. qwen3.5-flash) default to
-      // thinking-on at the server. Provider buildRequest never auto-
-      // injects `enable_thinking`, so a vanilla wire body lacks the
-      // field and the disable signal would not reach the server.
-      // Hostname-gated unconditional set mirrors the DeepSeek branch
-      // below. Overrides any user-supplied `extra_body.enable_thinking:
-      // true` because per-request `includeThoughts: false` is the
-      // stronger intent (set by every side-query via sideQuery.ts).
-      //
-      // Scope: targets qwen3 hybrid via DashScope's compatible-mode
-      // contract. GLM (extra_body.thinking.enabled) and DeepSeek-on-
-      // DashScope (thinking: { type: 'disabled' }) need different
-      // disable shapes — pre-existing gap, not closed here.
+      // Provider buildRequest doesn't auto-inject `enable_thinking`, so a
+      // guarded `in typed` check would never fire for default qwen3 configs.
+      // Hostname gate avoids leaking this qwen-specific field elsewhere.
+      // Scope: qwen3 hybrid only — GLM/DeepSeek-on-DashScope use different
+      // disable shapes and aren't handled.
       if (
         DashScopeOpenAICompatibleProvider.isDashScopeProvider(
           this.contentGeneratorConfig,
@@ -490,10 +482,7 @@ export class ContentGenerationPipeline {
     //   - kimi-k2-thinking    — thinking is enabled by default and cannot be disabled
     //   - gpt-5.x series      — thinking is enabled by default; can be disabled via `reasoning.effort`
     //   - qwen3 series        — model-dependent; emitted as `enable_thinking: false`
-    //                           by buildRequest above when reasoning is disabled
-    //                           on DashScope endpoints (provider never auto-
-    //                           injects this field, so the wire body would
-    //                           otherwise lack the disable signal)
+    //                           on DashScope endpoints when reasoning is disabled
     //
     // Given this inconsistency, we avoid mapping values and only pass through the
     // configured reasoning object when explicitly enabled. This keeps provider- and


### PR DESCRIPTION
## Summary

- `pipeline.ts:362` previously gated the qwen3 thinking-disable on `'enable_thinking' in typed` — but provider `buildRequest` never auto-injects this qwen3-specific extension, so the check failed on QWEN_OAUTH defaults and any qwen3 model without `extra_body.enable_thinking` explicitly configured (e.g. `qwen3.5-flash` on the fast-model path). Side-queries silently burned 1.5–6 K reasoning tokens (24–95× over budget per #4501) despite `sideQuery.applyThinkingDefault` setting `includeThoughts: false`.
- Replace the guard with a `DashScopeOpenAICompatibleProvider.isDashScopeProvider`-gated unconditional set, mirroring the existing `isDeepSeekHostname` branch immediately below.
- Scope: qwen3 hybrid via DashScope's compatible-mode contract. GLM (`extra_body.thinking.enabled`) and DeepSeek-on-DashScope (`thinking: { type: 'disabled' }`) need different disable shapes — pre-existing gap, called out in the new in-code comments but **not** closed in this PR.

## Test plan

- [x] Add 5 new tests covering: DashScope hostname + `includeThoughts: false`; DashScope + `reasoning: false` config opt-out; `QWEN_OAUTH` regardless of baseUrl; internal `*.alibaba-inc.com`; non-DashScope hostname (negative — must NOT emit `enable_thinking`)
- [x] Tighten existing override test (`pipeline.test.ts:465`) with explicit DashScope baseUrl so the hostname gate is exercised by intent rather than the `!baseUrl` default
- [x] `pipeline.test.ts` — 47/47 passing
- [x] Adjacent test files — 640/640 passing across 18 files (dashscope / deepseek / openrouter / converter / loggingContentGenerator / client / etc.)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files


## 人工验证
setting不配置enable_thinking
之前：
<img width="2942" height="1860" alt="image" src="https://github.com/user-attachments/assets/2fd8d407-5cb1-4094-b4fc-580f57da5da1" />

之后：

<img width="3002" height="1952" alt="image" src="https://github.com/user-attachments/assets/1142e5a3-2f05-41a9-90bf-909fbbc5746e" />


Closes #4501

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)


---

> **📝 描述准确性更新（2026-05-31，作者自查）**
>
> 更正：enable_thinking 设置除 isDashScopeProvider 外还有 model-name 门（model 以 qwen 开头或 coder-model），body 的 unconditional / mirroring deepseek 表述偏宽。（注：该门基于 request.model，即 side-query 的运行时模型，符合预期，非缺陷。）
