### PR TITLE
fix(cli): align /context token breakdown with actual API request

### DIFF
--- a/packages/cli/src/ui/commands/contextCommand.test.ts
+++ b/packages/cli/src/ui/commands/contextCommand.test.ts
@@ -77,20 +77,60 @@ describe('collectContextData (contextCommand)', () => {
     } as unknown as Config;
   });
 
-  it('passes includeDeferred: true to getFunctionDeclarations', async () => {
-    // Pin the token-accounting invariant: the "all tools" total must
-    // line up with the per-tool breakdown (which iterates getAllTools
-    // unfiltered). Without `includeDeferred: true`, the total would
-    // exclude deferred tools while the per-tool sum still includes
-    // them — `displayBuiltinTools` (clamped Math.max(0, …)) would then
-    // collapse to 0 instead of reporting the real cost. A user-visible
-    // regression caught only by visual inspection of `/context detail`.
+  it('queries getFunctionDeclarations with no args, matching the actual API request', async () => {
+    // /context should reflect what's actually sent to the model. Deferred
+    // tools (MCP tools default to shouldDefer=true) are excluded from the
+    // prompt unless ToolSearch has revealed them this session — see
+    // client.ts which calls getFunctionDeclarations() with no options.
+    // Pinning the call here keeps the /context token estimate aligned with
+    // the real request, instead of overcounting by the full MCP tool pool.
     await collectContextData(mockConfig, false);
 
     expect(getFunctionDeclarationsSpy).toHaveBeenCalledTimes(1);
-    expect(getFunctionDeclarationsSpy).toHaveBeenCalledWith({
-      includeDeferred: true,
-    });
+    expect(getFunctionDeclarationsSpy).toHaveBeenCalledWith();
+  });
+
+  it('excludes deferred-but-not-revealed tools from the per-tool breakdown (#4508)', async () => {
+    // Regression: /context used to surface every deferred tool (MCP tools,
+    // plus low-frequency built-ins like web_fetch / monitor / cron_*) even
+    // when ToolSearch had not loaded any of them, inflating the displayed
+    // token count for the common default-on case.
+    const isDeferredToolRevealed = vi.fn().mockReturnValue(false);
+    const hiddenBuiltin = {
+      name: 'web_fetch',
+      schema: { name: 'web_fetch', description: 'large schema' },
+      shouldDefer: true,
+      alwaysLoad: false,
+    };
+    const hiddenMcp = {
+      name: 'mcp__server__tool',
+      schema: { name: 'mcp__server__tool', description: 'large schema' },
+      shouldDefer: true,
+      alwaysLoad: false,
+    };
+    const config = {
+      getModel: vi.fn().mockReturnValue('test-model'),
+      getContentGeneratorConfig: vi.fn().mockReturnValue({
+        contextWindowSize: 32_000,
+      }),
+      getToolRegistry: vi.fn().mockReturnValue({
+        getAllTools: vi.fn().mockReturnValue([hiddenBuiltin, hiddenMcp]),
+        getFunctionDeclarations: vi.fn().mockReturnValue([]),
+        isDeferredToolRevealed,
+      }),
+      getUserMemory: vi.fn().mockReturnValue(''),
+      getSkillManager: vi.fn().mockReturnValue({
+        listSkills: vi.fn().mockResolvedValue([]),
+      }),
+      getChatCompression: vi.fn().mockReturnValue(undefined),
+    } as unknown as Config;
+
+    const data = await collectContextData(config, true);
+
+    expect(data.builtinTools).toHaveLength(0);
+    expect(data.mcpTools).toHaveLength(0);
+    expect(isDeferredToolRevealed).toHaveBeenCalledWith('web_fetch');
+    expect(isDeferredToolRevealed).toHaveBeenCalledWith('mcp__server__tool');
   });
 });
 

--- a/packages/cli/src/ui/commands/contextCommand.ts
+++ b/packages/cli/src/ui/commands/contextCommand.ts
@@ -116,13 +116,14 @@ export async function collectContextData(
 
   const toolRegistry = config.getToolRegistry();
   const allTools = toolRegistry ? toolRegistry.getAllTools() : [];
-  // Pass includeDeferred so this token estimate lines up with the per-tool
-  // breakdown below (which iterates getAllTools, unfiltered). Without it the
-  // "all tools" total would exclude deferred tools while the per-tool sum
-  // still includes them, and displayBuiltinTools = total - mcp would go
-  // negative.
+  // Match what's actually sent to the model: deferred tools — MCP tools and
+  // low-frequency built-ins like web_fetch / monitor / cron_* — are absent
+  // from the prompt unless ToolSearch has revealed them this session. See
+  // client.ts which calls getFunctionDeclarations() with no args. The
+  // per-tool loop below applies the same filter so allToolsTokens stays
+  // aligned with the breakdown sum.
   const toolDeclarations = toolRegistry
-    ? toolRegistry.getFunctionDeclarations({ includeDeferred: true })
+    ? toolRegistry.getFunctionDeclarations()
     : [];
   const toolsJsonStr = JSON.stringify(toolDeclarations);
   const allToolsTokens = estimateTokens(toolsJsonStr);
@@ -130,6 +131,13 @@ export async function collectContextData(
   const builtinTools: ContextToolDetail[] = [];
   const mcpTools: ContextToolDetail[] = [];
   for (const tool of allTools) {
+    if (
+      tool.shouldDefer &&
+      !tool.alwaysLoad &&
+      !toolRegistry?.isDeferredToolRevealed(tool.name)
+    ) {
+      continue;
+    }
     const toolJsonStr = JSON.stringify(tool.schema);
     const tokens = estimateTokens(toolJsonStr);
     if (tool instanceof DiscoveredMCPTool) {


### PR DESCRIPTION
## What this PR does

Fixes `/context` so its per-category token breakdown reflects what is actually in the prompt instead of what is registered in the tool registry. Deferred tools — every MCP tool plus the low-frequency built-ins `web_fetch`, `monitor`, `cron_create`/`cron_list`/`cron_delete`, `exit_plan_mode`, `enter_worktree`/`exit_worktree`, `send_message`, `task_stop`, `lsp` — are now excluded from the count until ToolSearch has revealed them this session, matching what `client.ts` sends to the model.

## Why it's needed

`/context` was overcounting token usage and miscategorizing the difference. Issue #4508 reports the MCP-tools row claiming ~5K tokens even when ToolSearch had not loaded a single MCP tool. The same problem existed for deferred built-ins, so the inflation was actually ~8K on a default session.

The previous `getFunctionDeclarations({ includeDeferred: true })` was introduced in #3589 to keep `displayBuiltinTools = total - mcp` from going negative, but it picked the wrong direction: it aligned both sides to the "registry" dimension instead of the "prompt" dimension. This PR aligns both sides to the prompt dimension — the function-declaration call drops the override, and the per-tool loop skips `shouldDefer && !alwaysLoad && !isDeferredToolRevealed` tools — keeping the math self-consistent while no longer overcounting.

## Reviewer Test Plan

### How to verify

1. Start the CLI on a default session (Claude / Qwen models — anything that does **not** disable ToolSearch). `npm run dev` works.
2. Send a single `hi`.
3. Run `/context detail`.
4. Confirm that "MCP tools" no longer appears (no MCP tool has been revealed) and that "内置工具" / "Built-in tools" no longer lists `web_fetch`, `monitor`, `cron_*`, `enter/exit_worktree`, `exit_plan_mode`, `send_message`, `task_stop`, `lsp`.
5. Confirm the total `已用` / "Used" matches the status bar — only the *breakdown* changes; the total is driven by the real API response.

### Evidence (Before & After)

Captured with `tmux` running `npm run dev`, single `hi`, then `/context detail`.

**Before fix** (current `main`):

```
│  上下文使用情况                                            │
│  模型: claude-opus-4-7          上下文窗口: 200.0k tokens  │
│  █ 已用                              45.9k tokens (23.0%)  │
│  ░ 空闲                             121.1k tokens (60.5%)  │
│  ▒ 自动压缩缓冲区                    33.0k tokens (16.5%)  │
│  █ 系统提示                            6.3k tokens (3.2%)  │
│  █ 内置工具                           12.1k tokens (6.0%)  │
│  █ MCP tools                           4.9k tokens (2.5%)  │
│  █ 记忆文件                            2.2k tokens (1.1%)  │
│  █ 技能                                8.9k tokens (4.4%)  │
│  █ 消息                               11.5k tokens (5.8%)  │
│  内置工具                                                  │
│    └ todo_write                               2.5k tokens  │
│    └ agent                                    1.5k tokens  │
│    └ run_shell_command                        1.4k tokens  │
│    └ cron_create                               794 tokens  │
│    └ ask_user_question                         751 tokens  │
│    └ edit                                      612 tokens  │
│    └ web_fetch                                 511 tokens  │
│    └ monitor                                   474 tokens  │
│    └ exit_plan_mode                            466 tokens  │
│    └ read_file                                 415 tokens  │
│    └ tool_search                               379 tokens  │
│    └ exit_worktree                             345 tokens  │
│    └ enter_worktree                            333 tokens  │
│    └ grep_search                               291 tokens  │
│    └ notebook_edit                             291 tokens  │
│    └ glob                                      266 tokens  │
│    └ list_directory                            240 tokens  │
│    └ send_message                              143 tokens  │
│    └ write_file                                133 tokens  │
│    └ task_stop                                 102 tokens  │
│    └ cron_delete                                78 tokens  │
│    └ cron_list                                  46 tokens  │
│  MCP tools                                                 │
│    └ qwenimage__modelstudio_qwen_i…            507 tokens  │
│    └ qwenimage__modelstudio_qwen_i…            476 tokens  │
│    └ playwright__browser_take_scre…            285 tokens  │
│    └ ...(27 entries total)                                 │
```

**After fix** (this PR):

```
│  上下文使用情况                                            │
│  模型: claude-opus-4-7          上下文窗口: 200.0k tokens  │
│  █ 已用                              47.0k tokens (23.5%)  │
│  ░ 空闲                             120.0k tokens (60.0%)  │
│  ▒ 自动压缩缓冲区                    33.0k tokens (16.5%)  │
│  █ 系统提示                            6.3k tokens (3.2%)  │
│  █ 内置工具                            8.8k tokens (4.4%)  │
│  █ 记忆文件                            2.2k tokens (1.1%)  │
│  █ 技能                                8.9k tokens (4.4%)  │
│  █ 消息                              20.8k tokens (10.4%)  │
│  内置工具                                                  │
│    └ todo_write                               2.5k tokens  │
│    └ agent                                    1.5k tokens  │
│    └ run_shell_command                        1.4k tokens  │
│    └ ask_user_question                         751 tokens  │
│    └ edit                                      612 tokens  │
│    └ read_file                                 415 tokens  │
│    └ tool_search                               379 tokens  │
│    └ grep_search                               291 tokens  │
│    └ notebook_edit                             291 tokens  │
│    └ glob                                      266 tokens  │
│    └ list_directory                            240 tokens  │
│    └ write_file                                133 tokens  │
```

Summary of the shift:

| Category | Before | After | Delta |
| -------- | -----: | ----: | ----: |
| Built-in tools | 12.1k | 8.8k | **−3.3k** |
| MCP tools | 4.9k | (not shown) | **−4.9k** |
| Messages | 11.5k | 20.8k | **+9.3k** |
| Used (total) | 45.9k | 47.0k | ±1k (API-driven session variance) |

`-3.3k` and `-4.9k` are the deferred built-ins and the unrevealed MCP tools that were previously double-counted. They were absorbed by "Messages" in the API-token branch via the `overheadScale` rescaling. Total stays driven by the model.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested (npm run dev) |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

`npm run dev`, fresh session, Claude Opus 4.7 backend (ToolSearch default-on path).

## Risk & Scope

- Main risk or tradeoff: `/context` no longer surfaces the *potential* token cost of deferred tools that have not yet been loaded. The numbers shown now match the actual API request — which is exactly what users expect from this command. If anyone wants a "if everything were loaded" view, that is a separate UX addition, not a bug fix.
- Not validated / out of scope: the DeepSeek branch (`tool_search` in the deny list) eagerly reveals everything via `client.ts`, so the filter no-ops; behavior should be unchanged but I did not retest with a DeepSeek model.
- Breaking changes / migration notes: none. Pure UI/diagnostic correction; no API or config shape changes.

## Linked Issues

Closes #4508

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复 `/context` 命令的分类 token 统计，使其反映 prompt 中实际存在的工具，而不是 tool registry 中注册的全部工具。所有 deferred 工具——每一个 MCP 工具，以及低频内置工具 `web_fetch`、`monitor`、`cron_create`/`cron_list`/`cron_delete`、`exit_plan_mode`、`enter_worktree`/`exit_worktree`、`send_message`、`task_stop`、`lsp`——在本会话中未被 ToolSearch 加载之前不再计入 token，从而与 `client.ts` 发往模型的实际请求对齐。

## 为什么需要

`/context` 此前会高估 token 占用并把差额错误地归到其他分类。Issue #4508 反映即便 ToolSearch 一次都没加载过 MCP 工具，"MCP tools" 一栏也声称占用了约 5K tokens。同样的问题在 deferred 的内置工具上也存在，默认会话下虚报合计约 8K。

之前的 `getFunctionDeclarations({ includeDeferred: true })` 是在 #3589 引入 ToolSearch 时为了避免 `displayBuiltinTools = total - mcp` 变负数才加的——但它选错了对齐方向：把两边都强制对齐到 "registry" 维度，而不是 "prompt" 维度。本 PR 反过来把两边对齐到 prompt 维度（即 `client.ts` 实际使用的口径）——函数声明调用去掉这个 override，per-tool 循环里也跳过 `shouldDefer && !alwaysLoad && !isDeferredToolRevealed` 的工具——数学自洽且不再高估。

## 审查测试计划

### 如何验证

1. 在默认会话下启动 CLI（Claude / Qwen 等不禁用 ToolSearch 的模型），`npm run dev` 即可。
2. 发送一条 `hi`。
3. 执行 `/context detail`。
4. 确认 "MCP tools" 一栏不再出现（因为没有 MCP 工具被 reveal），并且 "内置工具" 列表中不再有 `web_fetch`、`monitor`、`cron_*`、`enter/exit_worktree`、`exit_plan_mode`、`send_message`、`task_stop`、`lsp`。
5. 确认 "已用" 总数与状态栏一致——只有 *分类* 发生变化，总数仍由真实 API 响应驱动。

### 证据（修复前 / 修复后）

通过 `tmux` 跑 `npm run dev`，发送一条 `hi`，然后 `/context detail` 截取。详细对比表已在英文部分给出。要点：

| 分类 | 修复前 | 修复后 | 差异 |
| --- | ---: | ---: | ---: |
| 内置工具 | 12.1k | 8.8k | **−3.3k** |
| MCP tools | 4.9k | （不显示） | **−4.9k** |
| 消息 | 11.5k | 20.8k | **+9.3k** |
| 已用合计 | 45.9k | 47.0k | ±1k（API 调用的会话级波动） |

`-3.3k` 和 `-4.9k` 就是之前被错误计入的 deferred 内置工具和未 reveal 的 MCP 工具。在 API 真实 token 分支下，它们被 `overheadScale` 等比缩放算法挤到了 "消息" 分类。合计总数仍由模型驱动。

### 测试环境

|     系统     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测（npm run dev） |
| 🪟 Windows | ⚠️ 未测 |
|  🐧 Linux  | ⚠️ 未测 |

环境：`npm run dev`，全新会话，Claude Opus 4.7（默认开启 ToolSearch 路径）。

## 风险与范围

- 主要风险/权衡：`/context` 不再展示未加载的 deferred 工具的 *潜在* token 开销。当前数字与真实 API 请求一致——这正是用户对该命令的预期。若有人希望看 "如果全部加载会占用多少"，那是另一个 UX 增强，不是 bug 修复。
- 未验证/超出范围：DeepSeek 分支（`tool_search` 在 deny list 内）会在 `client.ts` 里 eager-reveal 所有工具，因此过滤逻辑等同空操作；行为预期不变，但我没有用 DeepSeek 模型重新跑过。
- 破坏性变更/迁移说明：无。纯 UI/诊断修正，不涉及 API 或配置格式。

## 关联 Issue

Closes #4508

</details>