### PR TITLE
fix(models): refresh raw model-derived defaults

### DIFF
--- a/packages/core/src/models/modelsConfig.test.ts
+++ b/packages/core/src/models/modelsConfig.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { ModelsConfig } from './modelsConfig.js';
 import { AuthType } from '../core/contentGenerator.js';
 import type { ContentGeneratorConfig } from '../core/contentGenerator.js';
@@ -1329,6 +1329,123 @@ describe('ModelsConfig', () => {
     // Both should be consistent
     expect(modelsConfig.getModel()).toBe('custom-model');
     expect(modelsConfig.getGenerationConfig().model).toBe('custom-model');
+  });
+
+  it('recomputes raw model modalities instead of carrying provider multimodal defaults', async () => {
+    const modelProvidersConfig: ModelProvidersConfig = {
+      openai: [
+        {
+          id: 'qwen3.6-plus',
+          name: 'Qwen 3.6 Plus',
+          baseUrl: 'https://dashscope.aliyuncs.com/compatible-mode/v1',
+          envKey: 'DASHSCOPE_API_KEY',
+          generationConfig: {
+            contextWindowSize: 12345,
+            modalities: { image: true, video: true },
+          },
+        },
+      ],
+    };
+
+    const modelsConfig = new ModelsConfig({
+      initialAuthType: AuthType.USE_OPENAI,
+      modelProvidersConfig,
+    });
+
+    await modelsConfig.switchModel(AuthType.USE_OPENAI, 'qwen3.6-plus');
+    expect(modelsConfig.getGenerationConfig().modalities).toEqual({
+      image: true,
+      video: true,
+    });
+
+    await modelsConfig.setModel('qwen3.7-max');
+
+    expect(modelsConfig.getModel()).toBe('qwen3.7-max');
+    expect(modelsConfig.getGenerationConfig().modalities).toEqual({});
+    expect(modelsConfig.getGenerationConfigSources()['modalities']).toEqual({
+      kind: 'computed',
+      detail: 'auto-detected from model',
+    });
+    expect(modelsConfig.getGenerationConfig().contextWindowSize).not.toBe(
+      12345,
+    );
+    expect(
+      modelsConfig.getGenerationConfigSources()['contextWindowSize'],
+    ).toEqual({
+      kind: 'computed',
+      detail: 'auto-detected from model',
+    });
+  });
+
+  it('notifies the owner to refresh after a raw model switch', async () => {
+    const onModelChange = vi.fn();
+    const modelsConfig = new ModelsConfig({
+      initialAuthType: AuthType.USE_OPENAI,
+      generationConfig: {
+        model: 'qwen3.6-plus',
+        modalities: { image: true, video: true },
+      },
+      onModelChange,
+    });
+
+    await modelsConfig.setModel('qwen3.7-max');
+
+    expect(onModelChange).toHaveBeenCalledWith(AuthType.USE_OPENAI, true);
+  });
+
+  it('preserves explicitly configured modalities during raw model switches', async () => {
+    const modelsConfig = new ModelsConfig({
+      initialAuthType: AuthType.USE_OPENAI,
+      generationConfig: {
+        model: 'custom-vision-model',
+        modalities: { image: true },
+      },
+      generationConfigSources: {
+        modalities: {
+          kind: 'settings',
+          settingsPath: 'model.generationConfig.modalities',
+        },
+      },
+    });
+
+    await modelsConfig.setModel('custom-vision-model-v2');
+
+    expect(modelsConfig.getGenerationConfig().modalities).toEqual({
+      image: true,
+    });
+    expect(modelsConfig.getGenerationConfigSources()['modalities']).toEqual({
+      kind: 'settings',
+      settingsPath: 'model.generationConfig.modalities',
+    });
+  });
+
+  it('rolls back raw model state when owner refresh fails', async () => {
+    const modelsConfig = new ModelsConfig({
+      initialAuthType: AuthType.USE_OPENAI,
+      generationConfig: {
+        model: 'qwen3.6-plus',
+        modalities: { image: true, video: true },
+      },
+      generationConfigSources: {
+        modalities: {
+          kind: 'computed',
+          detail: 'auto-detected from model',
+        },
+      },
+      onModelChange: async () => {
+        throw new Error('refresh failed');
+      },
+    });
+
+    await expect(modelsConfig.setModel('qwen3.7-max')).rejects.toThrow(
+      'refresh failed',
+    );
+
+    expect(modelsConfig.getModel()).toBe('qwen3.6-plus');
+    expect(modelsConfig.getGenerationConfig().modalities).toEqual({
+      image: true,
+      video: true,
+    });
   });
 
   it('should maintain consistency between currentModelId and _generationConfig.model during updateCredentials', () => {

--- a/packages/core/src/models/modelsConfig.ts
+++ b/packages/core/src/models/modelsConfig.ts
@@ -350,12 +350,61 @@ export class ModelsConfig {
     }
 
     // Raw model override: update generation config in-place
-    this.strictModelProviderSelection = false;
-    this._generationConfig.model = newModel;
-    this.generationConfigSources['model'] = {
-      kind: 'programmatic',
-      detail: metadata?.reason || 'setModel',
-    };
+    const rollbackSnapshot = this.createStateSnapshotForRollback();
+    try {
+      this.strictModelProviderSelection = false;
+      this._generationConfig.model = newModel;
+      this.generationConfigSources['model'] = {
+        kind: 'programmatic',
+        detail: metadata?.reason || 'setModel',
+      };
+      this.applyRawModelDerivedDefaults(newModel);
+
+      if (this.onModelChange && this.currentAuthType) {
+        await this.onModelChange(this.currentAuthType, true);
+      }
+    } catch (error) {
+      this.rollbackToStateSnapshot(rollbackSnapshot);
+      throw error;
+    }
+  }
+
+  /**
+   * Raw model switches keep the current credentials, but model-derived
+   * generation defaults must follow the new model. Otherwise a switch from a
+   * multimodal registry model to a text-only raw model can keep stale image
+   * support and send unsupported inline media.
+   */
+  private applyRawModelDerivedDefaults(modelId: string): void {
+    if (this.shouldUpdateModelDerivedDefault('modalities')) {
+      this._generationConfig.modalities = defaultModalities(modelId);
+      this.generationConfigSources['modalities'] = {
+        kind: 'computed',
+        detail: 'auto-detected from model',
+      };
+    }
+
+    if (this.shouldUpdateModelDerivedDefault('contextWindowSize')) {
+      this._generationConfig.contextWindowSize = tokenLimit(modelId, 'input');
+      this.generationConfigSources['contextWindowSize'] = {
+        kind: 'computed',
+        detail: 'auto-detected from model',
+      };
+    }
+  }
+
+  private shouldUpdateModelDerivedDefault(
+    field: 'modalities' | 'contextWindowSize',
+  ): boolean {
+    const source = this.generationConfigSources[field];
+    return (
+      source === undefined ||
+      source.kind === 'computed' ||
+      source.kind === 'default' ||
+      source.kind === 'modelProviders' ||
+      source.kind === 'programmatic' ||
+      source.kind === 'unknown'
+    );
   }
 
   /**


### PR DESCRIPTION
## What this PR does

Recomputes model-derived defaults when switching to a raw model ID, so stale provider multimodal settings do not carry over to text-only raw models such as `qwen3.7-max`.

It also triggers the owner refresh callback for raw model switches so the active content-generator config picks up the updated derived defaults, while preserving explicitly configured modalities and rolling back raw model state if owner refresh fails.

## Why it's needed

`ModelsConfig.setModel()` handled raw model IDs by updating only the model name in place. If the previous model came from a multimodal provider config, `modalities` could remain `{ image: true, video: true }`, causing the OpenAI converter to keep sending image parts to a text-only raw model.

This fixes #4513 by making raw model switches refresh the derived capability defaults instead of inheriting stale provider capabilities.

## Reviewer Test Plan

### How to verify

1. Start from a multimodal configured model whose derived defaults include image/video support.
2. Switch to a raw text-only model ID such as `qwen3.7-max`.
3. Confirm the active config refreshes derived defaults and no longer treats the raw text-only model as image/video capable.
4. Confirm explicitly configured modalities are still preserved.
5. Confirm owner refresh failure rolls back the raw model state.

Validation commands:

```bash
npm run test --workspace=packages/core -- src/models/modelsConfig.test.ts -t "raw model|explicitly configured modalities"
npm run test --workspace=packages/core -- src/models/modelsConfig.test.ts
npm run test --workspace=packages/core -- src/core/openaiContentGenerator/converter.test.ts -t "image modality|mixed content|defaults to text-only"
npx prettier --check packages/core/src/models/modelsConfig.ts packages/core/src/models/modelsConfig.test.ts
npx eslint packages/core/src/models/modelsConfig.ts packages/core/src/models/modelsConfig.test.ts
npm run lint --workspace=packages/core
npm run build --workspace=packages/core
npm run typecheck --workspace=packages/core
```

### Evidence (Before & After)

N/A for TUI screenshots. This is a non-UI model-configuration regression covered by unit tests.

Before: switching from a multimodal provider model to a raw text-only model could leave stale `{ image: true, video: true }` modalities on the active model config.

After: raw model switches recompute model-derived defaults, so `qwen3.7-max` is treated as text-only unless modalities were explicitly configured.

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | GitHub Actions passed |
| Windows | Local targeted checks passed; GitHub Actions passed |
| Linux | GitHub Actions passed |

### Environment (optional)

Windows local npm workspace test environment. The PR CI passed on macOS and Ubuntu; Windows CI is currently blocked by an unrelated `InputPrompt.test.tsx` failure documented in the PR comments.

## Risk & Scope

- Main risk or tradeoff: raw model switching now refreshes derived defaults and calls the owner refresh path, so this PR includes rollback coverage for refresh failure.
- Not validated / out of scope: no provider registry or converter rewrite; no public config schema changes.
- Breaking changes / migration notes: none expected.

## Linked Issues

Fixes #4513

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

当切换到 raw model ID 时，重新计算 model-derived defaults，避免旧 provider 的 multimodal settings 泄漏到 qwen3.7-max 这类 text-only raw models。

同时，raw model 更新会触发 owner refresh callback，让 content-generator 使用刷新后的 model config。测试覆盖了 raw model 切换、modalities 清理，以及 owner refresh 被调用。

## 为什么需要

ModelsConfig.setModel() 之前处理 raw model IDs 时只会原地更新 model name。如果上一个 model 来自 multimodal provider config，modalities 可能仍保留 { image: true, video: true }，导致 OpenAI converter 继续向 text-only raw model 发送 image parts。

这个 PR 修复 #4513，让 raw model 切换后重新派生默认配置，而不是继承旧 provider 的能力声明。

## Reviewer Test Plan

### 如何验证

1. 从一个支持 image/video 的 provider model 开始。
2. 切换到 qwen3.7-max 这类 raw text-only model ID。
3. 确认 active config 重新派生为 raw model defaults，不再保留 image/video modalities。
4. 确认 stale modalities 被清理。
5. 确认 owner refresh callback 会在 raw model 切换后触发。

### Evidence (Before & After)

TUI 截图证据不适用，因为这是由单元测试覆盖的 model config 修复。

Before：从 multimodal provider 切换到 raw model 后，配置中可能仍残留 { image: true, video: true }。

After：raw model 会重新计算 defaults，qwen3.7-max 等 text-only model 不会继承旧 provider 的 multimodal modalities。

### Tested on

Windows 本地 npm workspace 验证已通过；PR CI 已在 macOS、Windows、Linux 通过。

## Risk & Scope

- 主要风险或取舍：raw model 切换会重新派生 defaults，并触发 owner refresh，避免 stale capability state。
- 未验证 / 不在范围内：不改 provider registry、不改 converter schema、不改 provider preset 定义。
- Breaking changes / migration notes：预计无。

## Linked Issues

Fixes #4513

</details>
