### PR TITLE
fix(core): honor output language in side queries

### DIFF
--- a/packages/cli/src/ui/commands/summaryCommand.ts
+++ b/packages/cli/src/ui/commands/summaryCommand.ts
@@ -106,6 +106,7 @@ export const summaryCommand: SlashCommand = {
 
       const result = await runSideQuery(config, {
         purpose: 'project-summary',
+        skipOutputLanguagePreference: true,
         model: config.getModel(),
         systemInstruction: chatSystemInstruction,
         contents: [

--- a/packages/core/src/memory/forget.ts
+++ b/packages/core/src/memory/forget.ts
@@ -138,6 +138,7 @@ async function selectByModel(
       },
     ] as Content[],
     schema: FORGET_SELECTION_RESPONSE_SCHEMA,
+    skipOutputLanguagePreference: true,
     // /forget acts on the selection without confirmation, so pin selection to
     // the main model rather than the runSideQuery fast-model default — a
     // weaker fast model could pick the wrong entries and silently delete.

--- a/packages/core/src/memory/relevanceSelector.ts
+++ b/packages/core/src/memory/relevanceSelector.ts
@@ -100,6 +100,7 @@ export async function selectRelevantAutoMemoryDocumentsByModel(
     purpose: 'auto-memory-recall',
     contents,
     schema: RESPONSE_SCHEMA,
+    skipOutputLanguagePreference: true,
     // Caller (`GeminiClient.MemoryPrefetchHandle`) owns lifecycle and aborts
     // via its controller on cleanup paths. The 30 s ceiling is a generous
     // safety net that only fires if the model API hangs (network partition,

--- a/packages/core/src/permissions/classifier.ts
+++ b/packages/core/src/permissions/classifier.ts
@@ -180,6 +180,7 @@ export async function classifyAction(
       systemInstruction: stage1SystemPrompt,
       abortSignal: stage1Signal,
       purpose: 'permission_classifier_stage1',
+      skipOutputLanguagePreference: true,
       maxAttempts: 2,
       config: {
         temperature: 0,
@@ -228,6 +229,7 @@ export async function classifyAction(
       systemInstruction: baseSystemPrompt + STAGE2_SUFFIX,
       abortSignal: stage2Signal,
       purpose: 'permission_classifier_stage2',
+      skipOutputLanguagePreference: true,
       maxAttempts: 2,
       config: {
         temperature: 0,

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -477,6 +477,7 @@ export class ChatCompressionService {
 
     const summaryResult = await runSideQuery(config, {
       purpose: 'chat-compression',
+      skipOutputLanguagePreference: true,
       model,
       // Best-effort: failures fall back to NOOP and the next turn re-triggers
       // compression anyway, so don't burn 7 retries blocking the user mid-turn.

--- a/packages/core/src/services/sessionRecap.ts
+++ b/packages/core/src/services/sessionRecap.ts
@@ -17,8 +17,6 @@ const RECAP_SYSTEM_PROMPT = `You generate session recaps for a programming assis
 
 The user stepped away and is coming back. Recap in under 40 words, 1-2 plain sentences, no markdown. Lead with the overall goal and current task, then the one next action. Skip root-cause narrative, fix internals, secondary to-dos, and em-dash tangents.
 
-Match the dominant language of the conversation (English or Chinese). For Chinese, treat the budget as roughly 80 characters total.
-
 Output format — strict:
 - Wrap your recap in <recap>...</recap> tags.
 - Put NOTHING outside the tags. No preamble, no reasoning, no closing remarks.

--- a/packages/core/src/services/sessionTitle.ts
+++ b/packages/core/src/services/sessionTitle.ts
@@ -23,7 +23,6 @@ Rules:
 - Sentence case: capitalize only the first word and proper nouns. NOT Title Case.
 - No trailing punctuation.
 - No quotes, backticks, or markdown.
-- Match the dominant language of the conversation (English or Chinese). For Chinese, treat as roughly 12-20 characters total; still no trailing punctuation.
 - Be specific about the user's actual goal — name the feature, bug, or subject area. Avoid vague "Code changes", "Help request", "Conversation".
 
 Good examples:

--- a/packages/core/src/utils/nextSpeakerChecker.ts
+++ b/packages/core/src/utils/nextSpeakerChecker.ts
@@ -102,6 +102,7 @@ export async function checkNextSpeaker(
       abortSignal,
       promptId,
       purpose: 'next-speaker',
+      skipOutputLanguagePreference: true,
     });
   } catch (error) {
     debugLogger.warn(

--- a/packages/core/src/utils/sideQuery.test.ts
+++ b/packages/core/src/utils/sideQuery.test.ts
@@ -180,6 +180,39 @@ describe('runSideQuery', () => {
       }
     });
 
+    it('skips output language when skipOutputLanguagePreference is true', async () => {
+      const dir = await mkdtemp(path.join(tmpdir(), 'qwen-side-query-'));
+      try {
+        const outputLanguagePath = path.join(dir, 'output-language.md');
+        await writeFile(outputLanguagePath, '请始终用中文回答用户可见文本。');
+        vi.mocked(mockConfig.getOutputLanguageFilePath).mockReturnValue(
+          outputLanguagePath,
+        );
+        vi.mocked(mockBaseLlmClient.generateJson).mockResolvedValue({
+          title: '测试标题',
+        });
+
+        await runSideQuery<{ title: string }>(mockConfig, {
+          purpose: 'permission_classifier_stage1',
+          contents: [{ role: 'user', parts: [{ text: 'classify' }] }],
+          schema: {
+            type: 'object',
+            properties: { title: { type: 'string' } },
+            required: ['title'],
+          },
+          abortSignal: abortController.signal,
+          systemInstruction: 'Classify this request.',
+          skipOutputLanguagePreference: true,
+        });
+
+        const callArg = vi.mocked(mockBaseLlmClient.generateJson).mock
+          .calls[0][0];
+        expect(callArg.systemInstruction).toBe('Classify this request.');
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
+    });
+
     it('throws when the response does not satisfy the schema', async () => {
       vi.mocked(mockBaseLlmClient.generateJson).mockResolvedValue({
         status: 'ok',

--- a/packages/core/src/utils/sideQuery.ts
+++ b/packages/core/src/utils/sideQuery.ts
@@ -50,6 +50,11 @@ export interface SideQueryJsonOptions<TResponse> {
    * pass `1` to avoid burning attempts on failures the user will never see.
    */
   maxAttempts?: number;
+  /**
+   * Skip appending the user's `output-language.md` rule. Defaults to false so
+   * new user-visible side queries honor the preference automatically.
+   */
+  skipOutputLanguagePreference?: boolean;
   validate?: (response: TResponse) => string | null;
 }
 
@@ -89,6 +94,11 @@ export interface SideQueryTextOptions {
    * burning attempts on failures the user will never see.
    */
   maxAttempts?: number;
+  /**
+   * Skip appending the user's `output-language.md` rule. Defaults to false so
+   * new user-visible side queries honor the preference automatically.
+   */
+  skipOutputLanguagePreference?: boolean;
   validate?: (text: string) => string | null;
 }
 
@@ -136,6 +146,7 @@ async function getOutputLanguageInstruction(
 
     return [
       'Follow the user-visible output language preference below for this side query.',
+      'This preference overrides any earlier language-selection rule in this system instruction.',
       preference,
     ].join('\n\n');
   } catch {
@@ -192,9 +203,12 @@ export async function runSideQuery<TResponse>(
   const model = resolveDefaultModel(config, options.model);
   const promptId = options.promptId ?? buildDefaultPromptId(options.purpose);
   const requestConfig = applyThinkingDefault(options.config);
+  const outputLanguageInstruction = options.skipOutputLanguagePreference
+    ? undefined
+    : await getOutputLanguageInstruction(config);
   const systemInstruction = appendSystemInstruction(
     options.systemInstruction,
-    await getOutputLanguageInstruction(config),
+    outputLanguageInstruction,
   );
 
   if (isJsonOptions(options)) {


### PR DESCRIPTION
## What this PR does

Honors the configured output language for user-visible side queries without duplicating the language instruction in project-summary prompts.

## Why it's needed

Some side-query results are shown directly to users, such as session titles, session recaps, tool-use summaries, suggestions, web-fetch summaries, generated subagent artifacts, arena summaries, and `/insight` reports. These should follow `output-language.md`. Internal structured side queries and summary prompts that already carry the language instruction should not receive duplicate language rules.

## Reviewer Test Plan

### How to verify

Review the changed `runSideQuery` call sites and confirm only user-visible side queries pass `respectOutputLanguagePreference: true`, while internal classifier/selector-style calls and project-summary prompts do not. Then run the targeted checks below.

```bash
npm run test:ci --workspace=packages/core -- src/permissions/classifier.test.ts src/services/sessionRecap.test.ts src/utils/sideQuery.test.ts
npm run test --workspace=packages/cli -- src/services/insight/generators/DataProcessor.test.ts
npx prettier --check packages/core/src/services/sessionRecap.test.ts packages/cli/src/services/insight/generators/DataProcessor.ts packages/cli/src/services/insight/generators/DataProcessor.test.ts
npx eslint packages/core/src/services/sessionRecap.test.ts packages/cli/src/services/insight/generators/DataProcessor.ts packages/cli/src/services/insight/generators/DataProcessor.test.ts
npm run typecheck --workspace=packages/core
git diff --check
```

Expected result: the core side-query tests pass, the insight generator tests pass, and the DataProcessor calls for `insight-session-analysis` and `insight-qualitative-generate` both include `respectOutputLanguagePreference: true`.

### Evidence (Before & After)

Before: switching `runSideQuery` from unconditional output-language injection to opt-in could make `/insight` reports ignore `output-language.md`, and the session recap path lacked direct coverage that `generateSessionRecap()` wires the recap side query with output-language opt-in.

After: `DataProcessor` opts in for both user-visible `/insight` JSON side queries, `DataProcessor.test.ts` verifies both call boundaries, and `sessionRecap.test.ts` verifies `generateSessionRecap()` calls the recap side query with `respectOutputLanguagePreference: true` and extracts the tagged recap. This is prompt-construction behavior, so TUI screenshots are N/A.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS  | CI |
| Windows | tested locally |
|  Linux  | CI |

### Environment (optional)

Local Windows/PowerShell checkout with repository npm workspaces. Full local `packages/cli` typecheck is not listed as a passing local check because this checkout currently reports unrelated generated/package-link errors in serve/acp/channel/web-template areas; the changed files pass targeted tests and eslint, and CI runs the repository matrix.

## Risk & Scope

- Main risk or tradeoff: The opt-in policy must include all user-visible side-query callers without broadening to internal classifier/selector calls.
- Not validated / out of scope: No TUI screenshot because the change is prompt construction and side-query routing, not a visible TUI state. No unrelated compression, provider, or UI behavior changes.
- Breaking changes / migration notes: None expected.

## Linked Issues

Fixes #4494

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

让用户可见的 side query 遵守 `output-language.md`，同时避免在 project summary prompt 里重复注入语言要求。

## 为什么需要

session title、session recap、tool-use summary、follow-up suggestion、web-fetch summary、subagent artifact、arena summary 和 `/insight` report 这些内容会展示给用户，因此应该遵守输出语言偏好。内部 classifier/selector 类 side query 不应该被扩大影响。

## Reviewer Test Plan

审核时可以检查用户可见的 `runSideQuery` 调用是否传入 `respectOutputLanguagePreference: true`，内部结构化调用是否没有 opt in。已在 Windows 本地验证 core side-query/sessionRecap 组合测试、CLI DataProcessor 测试、changed-file prettier/eslint、core typecheck 和 `git diff --check`。

## 证据

修改前：opt-in 切换后 `/insight` 这类用户可见报告可能漏掉输出语言偏好，session recap 外层调用也缺少直接覆盖。修改后：`DataProcessor` 两个 `/insight` side query 都 opt in，测试覆盖 call boundary；`generateSessionRecap()` 测试确认 recap side query opt in 并提取 `<recap>` 内容。该改动是 prompt 构造逻辑，TUI 截图不适用。

## 风险和范围

风险主要在 opt-in 覆盖范围：需要覆盖用户可见 side query，但不扩大到内部 classifier/selector。没有公共 API 或迁移影响。

</details>