### PR TITLE
fix(core): tolerate unsupported Streamable HTTP GET SSE

### DIFF
--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -9,7 +9,7 @@ import * as ClientLib from '@modelcontextprotocol/sdk/client/index.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import * as SdkClientStdioLib from '@modelcontextprotocol/sdk/client/stdio.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AuthProviderType, type Config } from '../config/config.js';
 import { GoogleCredentialProvider } from '../mcp/google-auth-provider.js';
 import { MCPOAuthProvider } from '../mcp/oauth-provider.js';
@@ -33,6 +33,12 @@ import {
 import type { ToolRegistry } from './tool-registry.js';
 
 const mockExistsSync = vi.hoisted(() => vi.fn(() => true));
+const mockDebugLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
 const ORIGINAL_ENV = process.env;
 
 vi.mock('node:fs', () => ({
@@ -43,8 +49,15 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js');
 vi.mock('@google/genai');
 vi.mock('../mcp/oauth-provider.js');
 vi.mock('../mcp/oauth-token-storage.js');
+vi.mock('../utils/debugLogger.js', () => ({
+  createDebugLogger: vi.fn(() => mockDebugLogger),
+}));
 
 describe('mcp-client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   afterEach(() => {
     vi.restoreAllMocks();
     process.env = ORIGINAL_ENV;
@@ -316,6 +329,53 @@ describe('mcp-client', () => {
 
         expect(fetchFn).toHaveBeenCalledTimes(1);
         expect(response.status).toBe(405);
+        expect(response.statusText).toBe('Method Not Allowed');
+        expect(await response.text()).toBe('');
+      });
+
+      it('omits response body diagnostics when the fallback body is empty', async () => {
+        const fetchFn = vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(new Response(null, { status: 400 }));
+        const fetchWithFallback = createStreamableHttpCompatibilityFetch(
+          'empty-body',
+          fetchFn,
+        );
+
+        const response = await fetchWithFallback('http://test-server/mcp', {
+          method: 'GET',
+          headers: { Accept: 'text/event-stream' },
+        });
+
+        expect(response.status).toBe(405);
+        expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+          expect.not.stringContaining('Response body:'),
+        );
+      });
+
+      it('truncates Streamable HTTP GET SSE error body diagnostics', async () => {
+        const fetchFn = vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(new Response('x'.repeat(1024), { status: 400 }));
+        const fetchWithFallback = createStreamableHttpCompatibilityFetch(
+          'large-error-body',
+          fetchFn,
+        );
+
+        const response = await fetchWithFallback('http://test-server/mcp', {
+          method: 'GET',
+          headers: { Accept: 'text/event-stream' },
+        });
+
+        expect(response.status).toBe(405);
+        expect(mockDebugLogger.warn).toHaveBeenCalledWith(
+          expect.stringContaining(
+            `Response body: ${JSON.stringify(`${'x'.repeat(512)}...`)}`,
+          ),
+        );
+        expect(mockDebugLogger.warn).not.toHaveBeenCalledWith(
+          expect.stringContaining('x'.repeat(600)),
+        );
       });
 
       it('treats parameterized GET SSE Accept headers as unsupported', async () => {
@@ -372,6 +432,29 @@ describe('mcp-client', () => {
 
         expect(response.status).toBe(405);
         expect(await response.text()).toBe('method not allowed');
+      });
+
+      it('does not rewrite resumable GET SSE errors with Last-Event-ID', async () => {
+        const fetchFn = vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(
+            new Response('{"error":"invalid cursor"}', { status: 400 }),
+          );
+        const fetchWithFallback = createStreamableHttpCompatibilityFetch(
+          'resume-error',
+          fetchFn,
+        );
+
+        const response = await fetchWithFallback('http://test-server/mcp', {
+          method: 'GET',
+          headers: {
+            Accept: 'text/event-stream',
+            'Last-Event-ID': 'event-123',
+          },
+        });
+
+        expect(response.status).toBe(400);
+        expect(await response.text()).toBe('{"error":"invalid cursor"}');
       });
 
       it('does not rewrite non-SSE GET responses', async () => {

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -16,6 +16,7 @@ import type { PromptRegistry } from '../prompts/prompt-registry.js';
 import type { WorkspaceContext } from '../utils/workspaceContext.js';
 import {
   addMCPStatusChangeListener,
+  createStreamableHttpCompatibilityFetch,
   createTransport,
   getAllMCPServerStatuses,
   getMCPServerStatus,
@@ -273,6 +274,8 @@ describe('mcp-client', () => {
         expect(transport).toBeInstanceOf(StreamableHTTPClientTransport);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expect((transport as any)._url).toEqual(new URL('http://test-server'));
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect((transport as any)._fetch).toEqual(expect.any(Function));
       });
 
       it('with headers', async () => {
@@ -292,6 +295,60 @@ describe('mcp-client', () => {
         expect((transport as any)._requestInit?.headers).toEqual({
           Authorization: 'derp',
         });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect((transport as any)._fetch).toEqual(expect.any(Function));
+      });
+
+      it('treats 400 from optional GET SSE stream as unsupported', async () => {
+        const fetchFn = vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(new Response('bad method', { status: 400 }));
+        const fetchWithFallback = createStreamableHttpCompatibilityFetch(
+          'spring-ai',
+          fetchFn,
+        );
+
+        const response = await fetchWithFallback('http://test-server/mcp', {
+          method: 'GET',
+          headers: { Accept: 'text/event-stream' },
+        });
+
+        expect(fetchFn).toHaveBeenCalledTimes(1);
+        expect(response.status).toBe(405);
+      });
+
+      it('does not hide Streamable HTTP GET SSE server errors', async () => {
+        const fetchFn = vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(new Response('server exploded', { status: 502 }));
+        const fetchWithFallback = createStreamableHttpCompatibilityFetch(
+          'server-error',
+          fetchFn,
+        );
+
+        const response = await fetchWithFallback('http://test-server/mcp', {
+          method: 'GET',
+          headers: { Accept: 'text/event-stream' },
+        });
+
+        expect(response.status).toBe(502);
+      });
+
+      it('does not rewrite non-SSE GET responses', async () => {
+        const fetchFn = vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(new Response('bad request', { status: 400 }));
+        const fetchWithFallback = createStreamableHttpCompatibilityFetch(
+          'plain-get',
+          fetchFn,
+        );
+
+        const response = await fetchWithFallback('http://test-server/mcp', {
+          method: 'GET',
+          headers: { Accept: 'application/json' },
+        });
+
+        expect(response.status).toBe(400);
       });
     });
 

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -354,6 +354,26 @@ describe('mcp-client', () => {
         expect(response.status).toBe(502);
       });
 
+      it('does not rewrite the SDK-native GET SSE unsupported sentinel', async () => {
+        const fetchFn = vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(
+            new Response('method not allowed', { status: 405 }),
+          );
+        const fetchWithFallback = createStreamableHttpCompatibilityFetch(
+          'native-unsupported',
+          fetchFn,
+        );
+
+        const response = await fetchWithFallback('http://test-server/mcp', {
+          method: 'GET',
+          headers: { Accept: 'text/event-stream' },
+        });
+
+        expect(response.status).toBe(405);
+        expect(await response.text()).toBe('method not allowed');
+      });
+
       it('does not rewrite non-SSE GET responses', async () => {
         const fetchFn = vi
           .fn<typeof fetch>()

--- a/packages/core/src/tools/mcp-client.test.ts
+++ b/packages/core/src/tools/mcp-client.test.ts
@@ -12,6 +12,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { AuthProviderType, type Config } from '../config/config.js';
 import { GoogleCredentialProvider } from '../mcp/google-auth-provider.js';
+import { MCPOAuthProvider } from '../mcp/oauth-provider.js';
 import type { PromptRegistry } from '../prompts/prompt-registry.js';
 import type { WorkspaceContext } from '../utils/workspaceContext.js';
 import {
@@ -317,6 +318,25 @@ describe('mcp-client', () => {
         expect(response.status).toBe(405);
       });
 
+      it('treats parameterized GET SSE Accept headers as unsupported', async () => {
+        const fetchFn = vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(new Response('bad method', { status: 400 }));
+        const fetchWithFallback = createStreamableHttpCompatibilityFetch(
+          'spring-ai',
+          fetchFn,
+        );
+
+        const response = await fetchWithFallback('http://test-server/mcp', {
+          method: 'GET',
+          headers: {
+            Accept: 'application/json, text/event-stream; charset=utf-8',
+          },
+        });
+
+        expect(response.status).toBe(405);
+      });
+
       it('does not hide Streamable HTTP GET SSE server errors', async () => {
         const fetchFn = vi
           .fn<typeof fetch>()
@@ -346,6 +366,23 @@ describe('mcp-client', () => {
         const response = await fetchWithFallback('http://test-server/mcp', {
           method: 'GET',
           headers: { Accept: 'application/json' },
+        });
+
+        expect(response.status).toBe(400);
+      });
+
+      it('does not rewrite POST responses', async () => {
+        const fetchFn = vi
+          .fn<typeof fetch>()
+          .mockResolvedValue(new Response('bad request', { status: 400 }));
+        const fetchWithFallback = createStreamableHttpCompatibilityFetch(
+          'post-test',
+          fetchFn,
+        );
+
+        const response = await fetchWithFallback('http://test-server/mcp', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
         });
 
         expect(response.status).toBe(400);
@@ -531,6 +568,8 @@ describe('mcp-client', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const authProvider = (transport as any)._authProvider;
         expect(authProvider).toBeInstanceOf(GoogleCredentialProvider);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect((transport as any)._fetch).toEqual(expect.any(Function));
       });
 
       it('should use GoogleCredentialProvider with SSE transport', async () => {
@@ -567,6 +606,56 @@ describe('mcp-client', () => {
         ).rejects.toThrow(
           'URL must be provided in the config for Google Credentials provider',
         );
+      });
+    });
+
+    describe('authenticated Streamable HTTP compatibility fetch', () => {
+      it('wires the compatibility fetch for OAuth httpUrl transports', async () => {
+        const getValidToken = vi.fn().mockResolvedValue('oauth-token');
+        vi.mocked(MCPOAuthProvider).mockImplementation(
+          () =>
+            ({
+              getValidToken,
+            }) as unknown as MCPOAuthProvider,
+        );
+
+        const transport = await createTransport(
+          'oauth-test-server',
+          {
+            httpUrl: 'http://test-server',
+            oauth: {
+              enabled: true,
+              clientId: 'client-id',
+            },
+          },
+          false,
+        );
+
+        expect(transport).toBeInstanceOf(StreamableHTTPClientTransport);
+        expect(getValidToken).toHaveBeenCalledWith('oauth-test-server', {
+          enabled: true,
+          clientId: 'client-id',
+        });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect((transport as any)._fetch).toEqual(expect.any(Function));
+      });
+
+      it('wires the compatibility fetch for service account httpUrl transports', async () => {
+        const transport = await createTransport(
+          'service-account-test-server',
+          {
+            httpUrl: 'http://test-server',
+            authProviderType: AuthProviderType.SERVICE_ACCOUNT_IMPERSONATION,
+            targetAudience: 'client.apps.googleusercontent.com',
+            targetServiceAccount:
+              'service-account@example-project.iam.gserviceaccount.com',
+          },
+          false,
+        );
+
+        expect(transport).toBeInstanceOf(StreamableHTTPClientTransport);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect((transport as any)._fetch).toEqual(expect.any(Function));
       });
     });
   });

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -63,6 +63,68 @@ export const MCP_DEFAULT_TIMEOUT_MSEC = 10 * 60 * 1000; // default to 10 minutes
 const debugLogger = createDebugLogger('MCP');
 
 const STREAMABLE_HTTP_GET_SSE_FALLBACK_STATUSES = new Set([400]);
+const STREAMABLE_HTTP_GET_SSE_ERROR_BODY_LIMIT = 512;
+
+async function readResponseBodyExcerpt(
+  response: Response,
+): Promise<string | undefined> {
+  const reader = response.clone().body?.getReader();
+  if (!reader) {
+    return undefined;
+  }
+
+  const decoder = new TextDecoder();
+  let body = '';
+  let bytesRead = 0;
+  let truncated = false;
+  try {
+    while (bytesRead < STREAMABLE_HTTP_GET_SSE_ERROR_BODY_LIMIT) {
+      const { done, value } = await reader.read();
+      if (done) {
+        body += decoder.decode();
+        break;
+      }
+
+      const remaining = STREAMABLE_HTTP_GET_SSE_ERROR_BODY_LIMIT - bytesRead;
+      if (value.byteLength > remaining) {
+        body += decoder.decode(value.subarray(0, remaining), {
+          stream: true,
+        });
+        bytesRead += remaining;
+        truncated = true;
+        reader.cancel().catch(() => {
+          // Best-effort cleanup after collecting the bounded excerpt.
+        });
+        break;
+      }
+
+      body += decoder.decode(value, { stream: true });
+      bytesRead += value.byteLength;
+    }
+
+    if (bytesRead >= STREAMABLE_HTTP_GET_SSE_ERROR_BODY_LIMIT && !truncated) {
+      const { done } = await reader.read();
+      if (!done) {
+        truncated = true;
+        reader.cancel().catch(() => {
+          // Best-effort cleanup after collecting the bounded excerpt.
+        });
+      }
+    }
+
+    body += decoder.decode();
+    const excerpt = body.trim();
+    if (!excerpt) {
+      return undefined;
+    }
+    return truncated ||
+      excerpt.length > STREAMABLE_HTTP_GET_SSE_ERROR_BODY_LIMIT
+      ? `${excerpt.slice(0, STREAMABLE_HTTP_GET_SSE_ERROR_BODY_LIMIT)}...`
+      : excerpt;
+  } catch {
+    return undefined;
+  }
+}
 
 function isStreamableHttpGetSseRequest(init?: RequestInit): boolean {
   const method = (init?.method ?? 'GET').toUpperCase();
@@ -70,7 +132,12 @@ function isStreamableHttpGetSseRequest(init?: RequestInit): boolean {
     return false;
   }
 
-  const accept = new Headers(init?.headers).get('accept') ?? '';
+  const headers = new Headers(init?.headers);
+  if (headers.has('last-event-id')) {
+    return false;
+  }
+
+  const accept = headers.get('accept') ?? '';
   return accept
     .split(',')
     .map((value) => value.split(';')[0].trim().toLowerCase())
@@ -98,13 +165,15 @@ export function createStreamableHttpCompatibilityFetch(
       return response;
     }
 
+    const responseBody = await readResponseBodyExcerpt(response);
     await response.body?.cancel().catch(() => {
       // Best-effort body cleanup before returning a synthetic 405.
     });
     debugLogger.warn(
       `MCP server '${mcpServerName}' rejected the optional Streamable HTTP ` +
         `GET SSE stream with HTTP ${response.status}; continuing without ` +
-        `the standalone GET stream. POST request streams remain enabled.`,
+        `the standalone GET stream. POST request streams remain enabled.` +
+        (responseBody ? ` Response body: ${JSON.stringify(responseBody)}` : ''),
     );
 
     return new Response(null, {

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -62,6 +62,49 @@ export const MCP_DEFAULT_TIMEOUT_MSEC = 10 * 60 * 1000; // default to 10 minutes
 
 const debugLogger = createDebugLogger('MCP');
 
+const STREAMABLE_HTTP_GET_SSE_FALLBACK_STATUSES = new Set([400, 405]);
+
+function isStreamableHttpGetSseRequest(init?: RequestInit): boolean {
+  const method = (init?.method ?? 'GET').toUpperCase();
+  if (method !== 'GET') {
+    return false;
+  }
+
+  const accept = new Headers(init?.headers).get('accept') ?? '';
+  return accept
+    .split(',')
+    .some((value) => value.trim().toLowerCase() === 'text/event-stream');
+}
+
+export function createStreamableHttpCompatibilityFetch(
+  mcpServerName: string,
+  fetchFn: typeof fetch = globalThis.fetch.bind(globalThis),
+): typeof fetch {
+  return async (input, init) => {
+    const response = await fetchFn(input, init);
+    if (
+      !isStreamableHttpGetSseRequest(init) ||
+      !STREAMABLE_HTTP_GET_SSE_FALLBACK_STATUSES.has(response.status)
+    ) {
+      return response;
+    }
+
+    await response.body?.cancel().catch(() => {
+      // Best-effort body cleanup before returning a synthetic 405.
+    });
+    debugLogger.warn(
+      `MCP server '${mcpServerName}' rejected the optional Streamable HTTP ` +
+        `GET SSE stream with HTTP ${response.status}; continuing without ` +
+        `the standalone GET stream. POST request streams remain enabled.`,
+    );
+
+    return new Response(null, {
+      status: 405,
+      statusText: 'Method Not Allowed',
+    });
+  };
+}
+
 export type DiscoveredMCPPrompt = Prompt & {
   serverName: string;
   invoke: (params: Record<string, unknown>) => Promise<GetPromptResult>;
@@ -498,6 +541,7 @@ async function createTransportWithOAuth(
     if (mcpServerConfig.httpUrl) {
       // Create HTTP transport with OAuth token
       const oauthTransportOptions: StreamableHTTPClientTransportOptions = {
+        fetch: createStreamableHttpCompatibilityFetch(mcpServerName),
         requestInit: {
           headers: {
             ...mcpServerConfig.headers,
@@ -1332,6 +1376,8 @@ export async function createTransport(
     };
 
     if (mcpServerConfig.httpUrl) {
+      (transportOptions as StreamableHTTPClientTransportOptions).fetch =
+        createStreamableHttpCompatibilityFetch(mcpServerName);
       return new StreamableHTTPClientTransport(
         new URL(mcpServerConfig.httpUrl),
         transportOptions,
@@ -1358,6 +1404,8 @@ export async function createTransport(
       authProvider: provider,
     };
     if (mcpServerConfig.httpUrl) {
+      (transportOptions as StreamableHTTPClientTransportOptions).fetch =
+        createStreamableHttpCompatibilityFetch(mcpServerName);
       return new StreamableHTTPClientTransport(
         new URL(mcpServerConfig.httpUrl),
         transportOptions,
@@ -1414,7 +1462,9 @@ export async function createTransport(
   }
 
   if (mcpServerConfig.httpUrl) {
-    const transportOptions: StreamableHTTPClientTransportOptions = {};
+    const transportOptions: StreamableHTTPClientTransportOptions = {
+      fetch: createStreamableHttpCompatibilityFetch(mcpServerName),
+    };
 
     // Set up headers with OAuth token if available
     if (hasOAuthConfig && accessToken) {

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -62,7 +62,7 @@ export const MCP_DEFAULT_TIMEOUT_MSEC = 10 * 60 * 1000; // default to 10 minutes
 
 const debugLogger = createDebugLogger('MCP');
 
-const STREAMABLE_HTTP_GET_SSE_FALLBACK_STATUSES = new Set([400, 405]);
+const STREAMABLE_HTTP_GET_SSE_FALLBACK_STATUSES = new Set([400]);
 
 function isStreamableHttpGetSseRequest(init?: RequestInit): boolean {
   const method = (init?.method ?? 'GET').toUpperCase();

--- a/packages/core/src/tools/mcp-client.ts
+++ b/packages/core/src/tools/mcp-client.ts
@@ -73,9 +73,18 @@ function isStreamableHttpGetSseRequest(init?: RequestInit): boolean {
   const accept = new Headers(init?.headers).get('accept') ?? '';
   return accept
     .split(',')
-    .some((value) => value.trim().toLowerCase() === 'text/event-stream');
+    .map((value) => value.split(';')[0].trim().toLowerCase())
+    .some((type) => type === 'text/event-stream');
 }
 
+/**
+ * Wraps fetch to normalize Spring AI-style 400 responses to the SDK's
+ * unsupported sentinel for the optional Streamable HTTP GET SSE request.
+ *
+ * SDK coupling: `StreamableHTTPClientTransport._startOrAuthSse()` treats a
+ * 405 response as "GET SSE unsupported" and continues in POST-only mode.
+ * If the SDK changes that non-OK handling, update this wrapper in lockstep.
+ */
 export function createStreamableHttpCompatibilityFetch(
   mcpServerName: string,
   fetchFn: typeof fetch = globalThis.fetch.bind(globalThis),


### PR DESCRIPTION
## What this PR does

Wraps Streamable HTTP fetch so Spring AI-style 400 responses for the optional GET SSE stream are normalized to the SDK unsupported sentinel, while preserving POST and real GET SSE errors.

## Why it's needed

Some MCP servers reject optional GET SSE with 400 instead of the 405 sentinel that the SDK uses to fall back to POST-only mode.

## Reviewer Test Plan

### How to verify

Run: npm test --workspace=packages/core -- src/tools/mcp-client.test.ts -t "GET SSE|POST|Streamable"; npm test --workspace=packages/core -- src/tools/mcp-client.test.ts; npx eslint packages/core/src/tools/mcp-client.ts packages/core/src/tools/mcp-client.test.ts; npx prettier --check packages/core/src/tools/mcp-client.ts packages/core/src/tools/mcp-client.test.ts; npm run typecheck --workspace=packages/core.

### Evidence (Before & After)

Before: a non-standard 400 on optional GET SSE could fail the MCP Streamable HTTP connection instead of falling back. After: tests cover 400 normalization, 405 passthrough, Last-Event-ID resume errors, POST passthrough, body-excerpt logging, and fetch wiring for httpUrl/OAuth/Google/Service Account paths. This is transport behavior, so TUI screenshots are N/A.

### Tested on

| OS | Status |
| :--: | :-- |
| macOS | CI only |
| Windows | Tested locally |
| Linux | CI only |

### Environment (optional)

Local Windows/PowerShell checkout with repository npm workspaces. No tmux/TUI capture is included for PRs whose behavior is core, session, parser, or transport logic rather than a visible TUI state.

## Risk & Scope

- Main risk or tradeoff: Scoped to optional GET SSE compatibility; POST request streams and non-SSE responses remain unchanged.
- Not validated / out of scope: No unrelated refactors, public API changes, UI redesigns, or behavior outside the linked issue scope.
- Breaking changes / migration notes: None expected.

## Linked Issues

Fixes #4326

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

为 Streamable HTTP 的可选 GET SSE 请求增加兼容 fetch，把 Spring AI 风格的 400 归一化为 SDK 的 unsupported sentinel，同时保留 POST 和真实 GET SSE 错误。

## 为什么需要

部分 MCP server 用 400 表示不支持可选 GET SSE，而 SDK 期望 405 才会降级到 POST-only。

## Reviewer Test Plan

本地在 Windows 跑了 mcp-client 测试、eslint、prettier check 和 core typecheck；macOS/Linux 依赖 GitHub CI。

## 风险和范围

只影响可选 GET SSE 兼容层，不改变 POST 请求流。

</details>
