### PR TITLE
fix(cli): use session channel when closing ACP sessions

### DIFF
--- a/packages/cli/src/serve/httpAcpBridge.test.ts
+++ b/packages/cli/src/serve/httpAcpBridge.test.ts
@@ -5840,6 +5840,37 @@ describe('createHttpAcpBridge', () => {
       await bridge.shutdown();
     });
 
+    it('keeps a shared ACP channel alive while closing one of several sessions', async () => {
+      const handles: ChannelHandle[] = [];
+      const factory: ChannelFactory = async () => {
+        const h = makeChannel({ sessionIdPrefix: `s${handles.length}` });
+        handles.push(h);
+        return h.channel;
+      };
+      const bridge = makeBridge({
+        channelFactory: factory,
+        sessionScope: 'thread',
+      });
+      const a = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const b = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const c = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      expect(handles).toHaveLength(1);
+
+      await bridge.closeSession(b.sessionId);
+      expect(bridge.sessionCount).toBe(2);
+      expect(handles[0]?.killed).toBe(false);
+
+      await bridge.closeSession(a.sessionId);
+      expect(bridge.sessionCount).toBe(1);
+      expect(handles[0]?.killed).toBe(false);
+
+      await bridge.closeSession(c.sessionId);
+      expect(bridge.sessionCount).toBe(0);
+      expect(handles[0]?.killed).toBe(true);
+
+      await bridge.shutdown();
+    });
+
     it('throws SessionNotFoundError for unknown session', async () => {
       const bridge = makeBridge();
       await expect(bridge.closeSession('nonexistent')).rejects.toThrow(

--- a/packages/cli/src/serve/httpAcpBridge.test.ts
+++ b/packages/cli/src/serve/httpAcpBridge.test.ts
@@ -38,6 +38,7 @@ import type {
 import { createDaemonStatusProvider } from './daemonStatusProvider.js';
 import {
   createHttpAcpBridge,
+  detachSessionIdFromEntryChannel,
   findChannelInfoForEntry,
   InvalidClientIdError,
   InvalidPermissionOptionError,
@@ -318,6 +319,36 @@ describe('createHttpAcpBridge', () => {
         channel: channelA,
       }),
     ).toBeUndefined();
+  });
+
+  it('detaches a session from its entry channel during channel overlap', () => {
+    // Model the close/kill overlap window directly: old channel A still owns
+    // the session entry while fresh channel B is the current attach target.
+    // The detach helper used by closeSession/killSession must decrement A,
+    // not the current B channel.
+    const channelA = { name: 'A' };
+    const channelB = { name: 'B' };
+    const infoA = {
+      channel: channelA,
+      sessionIds: new Set(['session-a']),
+      label: 'old-dying-channel',
+    };
+    const infoB = {
+      channel: channelB,
+      sessionIds: new Set(['session-b']),
+      label: 'fresh-attach-channel',
+    };
+
+    const selected = detachSessionIdFromEntryChannel(
+      infoB,
+      [infoA, infoB],
+      { channel: channelA },
+      'session-a',
+    );
+
+    expect(selected).toBe(infoA);
+    expect(infoA.sessionIds.has('session-a')).toBe(false);
+    expect(Array.from(infoB.sessionIds)).toEqual(['session-b']);
   });
 
   it('accepts a valid BridgeOptions.eventRingSize at construction time', () => {

--- a/packages/cli/src/serve/httpAcpBridge.test.ts
+++ b/packages/cli/src/serve/httpAcpBridge.test.ts
@@ -38,6 +38,7 @@ import type {
 import { createDaemonStatusProvider } from './daemonStatusProvider.js';
 import {
   createHttpAcpBridge,
+  findChannelInfoForEntry,
   InvalidClientIdError,
   InvalidPermissionOptionError,
   InvalidSessionMetadataError,
@@ -299,6 +300,26 @@ function makeChannel(opts: FakeAgentOpts = {}): ChannelHandle {
 }
 
 describe('createHttpAcpBridge', () => {
+  it('selects a session entry channel when the current attach channel has changed', () => {
+    // Model the channel-overlap window directly: old channel A still has
+    // an entry, while new channel B is the current attach target.
+    const channelA = { name: 'A' };
+    const channelB = { name: 'B' };
+    const infoA = { channel: channelA, label: 'old-dying-channel' };
+    const infoB = { channel: channelB, label: 'fresh-attach-channel' };
+
+    expect(
+      findChannelInfoForEntry(infoB, [infoA, infoB], {
+        channel: channelA,
+      }),
+    ).toBe(infoA);
+    expect(
+      findChannelInfoForEntry(infoB, [infoB], {
+        channel: channelA,
+      }),
+    ).toBeUndefined();
+  });
+
   it('accepts a valid BridgeOptions.eventRingSize at construction time', () => {
     // Smoke: positive finite integers are accepted; the underlying
     // EventBus ring-size threading is exercised end-to-end in

--- a/packages/cli/src/serve/httpAcpBridge.ts
+++ b/packages/cli/src/serve/httpAcpBridge.ts
@@ -278,6 +278,19 @@ interface ChannelInfo {
   isDying: boolean;
 }
 
+/** @internal Visible for bridge lifecycle regression tests. */
+export function findChannelInfoForEntry<T extends { channel: unknown }>(
+  current: T | undefined,
+  alive: Iterable<T>,
+  entry: { channel: unknown },
+): T | undefined {
+  if (current?.channel === entry.channel) return current;
+  for (const info of alive) {
+    if (info.channel === entry.channel) return info;
+  }
+  return undefined;
+}
+
 interface SessionEntry {
   sessionId: string;
   workspaceCwd: string;
@@ -2031,15 +2044,8 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     return channelInfo;
   };
 
-  const channelInfoForEntry = (
-    entry: SessionEntry,
-  ): ChannelInfo | undefined => {
-    if (channelInfo?.channel === entry.channel) return channelInfo;
-    for (const info of aliveChannels) {
-      if (info.channel === entry.channel) return info;
-    }
-    return undefined;
-  };
+  const channelInfoForEntry = (entry: SessionEntry): ChannelInfo | undefined =>
+    findChannelInfoForEntry(channelInfo, aliveChannels, entry);
 
   const getChannelClosedReject = (info: ChannelInfo): Promise<never> => {
     if (!info.statusClosedReject) {
@@ -2888,7 +2894,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       );
       if (defaultEntry === entry) defaultEntry = undefined;
       const ci = channelInfoForEntry(entry);
-      if (ci && ci.channel === entry.channel) {
+      if (ci) {
         ci.sessionIds.delete(sessionId);
       }
       for (const id of Array.from(entry.pendingPermissionIds)) {
@@ -3718,7 +3724,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       // session leaves — other sessions on the same channel keep
       // running.
       const ci = channelInfoForEntry(entry);
-      if (ci && ci.channel === entry.channel) {
+      if (ci) {
         ci.sessionIds.delete(sessionId);
       }
       // PR 14b fix (codex round 5): tombstone the killed sessionId

--- a/packages/cli/src/serve/httpAcpBridge.ts
+++ b/packages/cli/src/serve/httpAcpBridge.ts
@@ -2887,7 +2887,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
             : ''),
       );
       if (defaultEntry === entry) defaultEntry = undefined;
-      const ci = channelInfo;
+      const ci = channelInfoForEntry(entry);
       if (ci && ci.channel === entry.channel) {
         ci.sessionIds.delete(sessionId);
       }
@@ -3717,7 +3717,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       // Detach from the channel. The channel dies only when its LAST
       // session leaves — other sessions on the same channel keep
       // running.
-      const ci = channelInfo;
+      const ci = channelInfoForEntry(entry);
       if (ci && ci.channel === entry.channel) {
         ci.sessionIds.delete(sessionId);
       }

--- a/packages/cli/src/serve/httpAcpBridge.ts
+++ b/packages/cli/src/serve/httpAcpBridge.ts
@@ -291,6 +291,20 @@ export function findChannelInfoForEntry<T extends { channel: unknown }>(
   return undefined;
 }
 
+/** @internal Visible for bridge lifecycle regression tests. */
+export function detachSessionIdFromEntryChannel<
+  T extends { channel: unknown; sessionIds: Set<string> },
+>(
+  current: T | undefined,
+  alive: Iterable<T>,
+  entry: { channel: unknown },
+  sessionId: string,
+): T | undefined {
+  const info = findChannelInfoForEntry(current, alive, entry);
+  info?.sessionIds.delete(sessionId);
+  return info;
+}
+
 interface SessionEntry {
   sessionId: string;
   workspaceCwd: string;
@@ -2893,10 +2907,12 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
             : ''),
       );
       if (defaultEntry === entry) defaultEntry = undefined;
-      const ci = channelInfoForEntry(entry);
-      if (ci) {
-        ci.sessionIds.delete(sessionId);
-      }
+      const ci = detachSessionIdFromEntryChannel(
+        channelInfo,
+        aliveChannels,
+        entry,
+        sessionId,
+      );
       for (const id of Array.from(entry.pendingPermissionIds)) {
         resolvePending(id, { outcome: { outcome: 'cancelled' } });
       }
@@ -3723,10 +3739,12 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       // Detach from the channel. The channel dies only when its LAST
       // session leaves — other sessions on the same channel keep
       // running.
-      const ci = channelInfoForEntry(entry);
-      if (ci) {
-        ci.sessionIds.delete(sessionId);
-      }
+      const ci = detachSessionIdFromEntryChannel(
+        channelInfo,
+        aliveChannels,
+        entry,
+        sessionId,
+      );
       // PR 14b fix (codex round 5): tombstone the killed sessionId
       // so any in-flight `extNotification` from the (about-to-be-
       // killed) child can't seed the early-event buffer for a


### PR DESCRIPTION
## What this PR does

Makes ACP close/kill session cleanup detach from the session entry channel rather than assuming the current channel is still the owner.

## Why it's needed

During channel-overlap windows, a fresh channel can become current while an older channel still owns a session entry. Cleanup must decrement the owning channel, not the latest attach target.

## Reviewer Test Plan

### How to verify

Run: npm test --workspace=packages/cli -- src/serve/httpAcpBridge.test.ts -t "channel overlap|closeSession|killSession"; npm test --workspace=packages/cli -- src/serve/httpAcpBridge.test.ts; npx eslint packages/cli/src/serve/httpAcpBridge.ts packages/cli/src/serve/httpAcpBridge.test.ts; npx prettier --check packages/cli/src/serve/httpAcpBridge.ts packages/cli/src/serve/httpAcpBridge.test.ts; npm run typecheck --workspace=packages/cli.

### Evidence (Before & After)

Before: cleanup could consult the current channel and risk touching the wrong channel during overlap. After: helper-level overlap tests verify old-channel selection/detach, and integration tests cover shared-channel close behavior. Public closeSession cannot naturally leave a closable session on a dying old channel because it deletes the entry before killing the last-session channel; that boundary is covered at the helper layer.

### Tested on

| OS | Status |
| :--: | :-- |
| macOS | CI only |
| Windows | Tested locally |
| Linux | CI only |

### Environment (optional)

Local Windows/PowerShell checkout with repository npm workspaces. No tmux/TUI capture is included for PRs whose behavior is core, session, parser, or transport logic rather than a visible TUI state.

## Risk & Scope

- Main risk or tradeoff: Limited to ACP bridge session cleanup bookkeeping; ACP protocol and agent behavior are unchanged.
- Not validated / out of scope: No unrelated refactors, public API changes, UI redesigns, or behavior outside the linked issue scope.
- Breaking changes / migration notes: None expected.

## Linked Issues

Fixes #4325

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

ACP close/kill 清理时按 session entry 所属 channel 处理，而不是假设当前 channel 一定是 owner。

## 为什么需要

channel overlap 期间，新 channel 可能已经成为当前 channel，但旧 channel 仍然拥有某些 session entry。

## Reviewer Test Plan

本地按 httpAcpBridge 相关测试、eslint、prettier check、CLI typecheck 验证；macOS/Linux 由 GitHub CI 验证。

## 风险和范围

只改 ACP bridge 的 session 清理 bookkeeping，不改 ACP 协议。

</details>
