### PR TITLE
fix(core): surface Anthropic empty stream provider errors

### DIFF
--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -22,7 +22,10 @@ vi.mock('../../utils/request-tokenizer/index.js', () => ({
   RequestTokenEstimator: vi.fn(() => mockTokenizer),
 }));
 
-type AnthropicCreateArgs = [unknown, { signal?: AbortSignal }?];
+type AnthropicCreateArgs = [
+  unknown,
+  { signal?: AbortSignal; headers?: Record<string, string> }?,
+];
 
 const anthropicMockState: {
   constructorOptions?: Record<string, unknown>;
@@ -1015,7 +1018,11 @@ describe('AnthropicContentGenerator', () => {
       const { AnthropicContentGenerator } = await importGenerator();
       anthropicState.createImpl.mockResolvedValue(
         (async function* () {
-          yield { type: 'message_stop' };
+          yield {
+            type: 'message_delta',
+            delta: { stop_reason: 'end_turn' },
+            usage: { output_tokens: 1 },
+          };
         })(),
       );
 
@@ -2415,6 +2422,98 @@ describe('AnthropicContentGenerator', () => {
         totalTokenCount: 43_688,
         cachedContentTokenCount: 32_088,
       });
+    });
+
+    it('falls back to non-streaming when the stream is empty and surfaces provider errors', async () => {
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl
+        .mockResolvedValueOnce(
+          (async function* () {
+            // Empty stream: compatible gateways can return HTTP 200 with no SSE
+            // events when the real failure body is only available non-streaming.
+          })(),
+        )
+        .mockRejectedValueOnce(new Error('400 Team API AKday消费金额已达上限'));
+
+      const generator = new AnthropicContentGenerator(
+        {
+          model: 'claude-test',
+          apiKey: 'test-key',
+          timeout: 10_000,
+          maxRetries: 2,
+          samplingParams: { max_tokens: 123 },
+          schemaCompliance: 'auto',
+        },
+        mockConfig,
+      );
+
+      const stream = await generator.generateContentStream({
+        model: 'models/ignored',
+        contents: 'Hello',
+      } as unknown as GenerateContentParameters);
+
+      await expect(async () => {
+        for await (const _chunk of stream) {
+          void _chunk;
+        }
+      }).rejects.toThrow('400 Team API AKday消费金额已达上限');
+
+      expect(anthropicState.createImpl).toHaveBeenCalledTimes(2);
+      const [streamingRequest] = anthropicState.createImpl.mock
+        .calls[0] as AnthropicCreateArgs;
+      const [fallbackRequest] = anthropicState.createImpl.mock
+        .calls[1] as AnthropicCreateArgs;
+      expect(streamingRequest).toEqual(
+        expect.objectContaining({ stream: true }),
+      );
+      expect(fallbackRequest).not.toHaveProperty('stream');
+    });
+
+    it('converts the non-streaming fallback response when an empty stream is recoverable', async () => {
+      const { AnthropicContentGenerator } = await importGenerator();
+      anthropicState.createImpl
+        .mockResolvedValueOnce(
+          (async function* () {
+            yield { type: 'message_stop' };
+          })(),
+        )
+        .mockResolvedValueOnce({
+          id: 'msg-fallback',
+          model: 'claude-test',
+          stop_reason: 'end_turn',
+          content: [{ type: 'text', text: 'fallback ok' }],
+          usage: { input_tokens: 3, output_tokens: 2 },
+        });
+
+      const generator = new AnthropicContentGenerator(
+        {
+          model: 'claude-test',
+          apiKey: 'test-key',
+          timeout: 10_000,
+          maxRetries: 2,
+          samplingParams: { max_tokens: 123 },
+          schemaCompliance: 'auto',
+        },
+        mockConfig,
+      );
+
+      const stream = await generator.generateContentStream({
+        model: 'models/ignored',
+        contents: 'Hello',
+      } as unknown as GenerateContentParameters);
+
+      const chunks: GenerateContentResponse[] = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+
+      expect(anthropicState.createImpl).toHaveBeenCalledTimes(2);
+      expect(chunks).toHaveLength(1);
+      expect(chunks[0]?.responseId).toBe('msg-fallback');
+      expect(chunks[0]?.candidates?.[0]?.content?.parts).toEqual([
+        { text: 'fallback ok' },
+      ]);
+      expect(chunks[0]?.candidates?.[0]?.finishReason).toBe(FinishReason.STOP);
     });
   });
 });

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
@@ -1016,6 +1016,9 @@ describe('AnthropicContentGenerator', () => {
       // generateContent(); make sure the per-request header attaches there
       // too so streaming Anthropic/DeepSeek requests stay consistent.
       const { AnthropicContentGenerator } = await importGenerator();
+      // Use message_delta (not bare message_stop) so the empty-stream
+      // fallback is not triggered — bare message_stop now indicates an empty
+      // stream and causes a non-streaming retry.
       anthropicState.createImpl.mockResolvedValue(
         (async function* () {
           yield {
@@ -1042,6 +1045,10 @@ describe('AnthropicContentGenerator', () => {
       for await (const _chunk of stream) {
         void _chunk;
       }
+
+      // Regression guard: normal streams must NOT trigger the empty-stream
+      // fallback (which would double latency + API cost).
+      expect(anthropicState.createImpl).toHaveBeenCalledTimes(1);
 
       const [, options] = anthropicState.lastCreateArgs as AnthropicCreateArgs;
       const headers = ((options as { headers?: Record<string, string> })
@@ -2433,7 +2440,7 @@ describe('AnthropicContentGenerator', () => {
             // events when the real failure body is only available non-streaming.
           })(),
         )
-        .mockRejectedValueOnce(new Error('400 Team API AKday消费金额已达上限'));
+        .mockRejectedValueOnce(new Error('400 quota exceeded'));
 
       const generator = new AnthropicContentGenerator(
         {
@@ -2456,7 +2463,7 @@ describe('AnthropicContentGenerator', () => {
         for await (const _chunk of stream) {
           void _chunk;
         }
-      }).rejects.toThrow('400 Team API AKday消费金额已达上限');
+      }).rejects.toThrow('400 quota exceeded');
 
       expect(anthropicState.createImpl).toHaveBeenCalledTimes(2);
       const [streamingRequest] = anthropicState.createImpl.mock

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -1015,11 +1015,10 @@ export class AnthropicContentGenerator implements ContentGenerator {
         signal: abortSignal,
         ...(headers ? { headers } : {}),
       })) as Message;
+      yield this.converter.convertAnthropicResponseToGemini(response);
     } catch (error) {
       throw redactProxyError(error);
     }
-
-    yield this.converter.convertAnthropicResponseToGemini(response);
   }
 
   private buildGeminiChunk(

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -266,7 +266,12 @@ export class AnthropicContentGenerator implements ContentGenerator {
       throw redactProxyError(error);
     }
 
-    return this.processStream(this.redactStreamErrors(stream));
+    return this.processStreamWithEmptyFallback(
+      this.redactStreamErrors(stream),
+      anthropicRequest,
+      request.config?.abortSignal,
+      headers,
+    );
   }
 
   async countTokens(
@@ -966,6 +971,55 @@ export class AnthropicContentGenerator implements ContentGenerator {
           break;
       }
     }
+  }
+
+  private async *processStreamWithEmptyFallback(
+    stream: AsyncIterable<RawMessageStreamEvent>,
+    fallbackRequest: MessageCreateParamsWithThinking,
+    abortSignal: AbortSignal | undefined,
+    headers: Record<string, string> | undefined,
+  ): AsyncGenerator<GenerateContentResponse> {
+    let hasAssistantPayload = false;
+    let hasFinishReason = false;
+
+    for await (const chunk of this.processStream(stream)) {
+      const candidates = chunk.candidates ?? [];
+      hasFinishReason ||= candidates.some(
+        (candidate) => candidate.finishReason !== undefined,
+      );
+      hasAssistantPayload ||= candidates.some((candidate) =>
+        candidate.content?.parts?.some(
+          (part) =>
+            part.text ||
+            part.thought ||
+            part.thoughtSignature ||
+            part.functionCall,
+        ),
+      );
+      yield chunk;
+    }
+
+    if (hasAssistantPayload || hasFinishReason) {
+      return;
+    }
+
+    debugLogger.warn(
+      'Anthropic stream ended without assistant payload or finish reason; ' +
+        'probing once with a non-streaming request to surface provider errors.',
+    );
+
+    let response: Message;
+    try {
+      runtimeDiagnostics.recordAnthropicWireRequest(fallbackRequest);
+      response = (await this.client.messages.create(fallbackRequest, {
+        signal: abortSignal,
+        ...(headers ? { headers } : {}),
+      })) as Message;
+    } catch (error) {
+      throw redactProxyError(error);
+    }
+
+    yield this.converter.convertAnthropicResponseToGemini(response);
   }
 
   private buildGeminiChunk(

--- a/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
+++ b/packages/core/src/core/anthropicContentGenerator/anthropicContentGenerator.ts
@@ -973,6 +973,11 @@ export class AnthropicContentGenerator implements ContentGenerator {
     }
   }
 
+  // Some Anthropic-compatible gateways close the SSE stream with HTTP 200
+  // but emit no assistant content or stop reason (e.g. billing / quota
+  // limits hit mid-proxy). When that happens we probe once with the same
+  // request in non-streaming mode so the real provider error surfaces
+  // instead of the generic "stream ended without a finish reason".
   private async *processStreamWithEmptyFallback(
     stream: AsyncIterable<RawMessageStreamEvent>,
     fallbackRequest: MessageCreateParamsWithThinking,


### PR DESCRIPTION
## Summary

- What changed: Added a fallback path for Anthropic streaming responses that end without any assistant payload or finish reason. When this happens, the adapter retries the same request once through Anthropic's non-streaming API and converts the result back into the core `GenerateContentResponse` shape.
- Why it changed: Some provider failures can close the stream cleanly without delivering a final stop reason, which currently bubbles up as `Model stream ended without a finish reason` and hides the real provider error, such as a billing or quota limit response.
- Reviewer focus: Please check the empty-stream detection boundary and the fallback request shape, especially that normal streams with text, thinking, tool calls, or finish reasons do not trigger the fallback.

Before:
<img width="1248" height="544" alt="image" src="https://github.com/user-attachments/assets/e2f88a2e-0231-4574-ba86-39046f6bb7de" />
After:
<img width="1224" height="438" alt="image" src="https://github.com/user-attachments/assets/97e4ccb2-b5dc-419d-b933-0b6d2bf5039d" />

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
  cd packages/core && npx prettier --check src/core/anthropicContentGenerator/anthropicContentGenerator.ts src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
  npx tsc --noEmit -p packages/core
  npx tsc --build packages/core/tsconfig.json --clean && npm run build --workspace=packages/core && npx tsc --noEmit -p packages/core
  ```
- Prompts / inputs used: Unit tests simulate an Anthropic stream that ends with no useful payload and a fallback non-streaming request that either returns text or throws a provider error.
- Expected result: Empty Anthropic streams should not produce the generic missing-finish-reason error when a follow-up non-streaming response can expose the provider result. Normal streams should continue through the existing streaming parser.
- Observed result: The targeted Anthropic test file passed, formatting passed, and core typecheck/build validation passed.
- Quickest reviewer verification path:
  ```bash
  cd packages/core && npx vitest run src/core/anthropicContentGenerator/anthropicContentGenerator.test.ts
  ```
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.): The new tests cover both fallback success and fallback error propagation, including a provider-style `400 Team API AKday消费金额已达上限` error message.

## Scope / Risk

- Main risk or tradeoff: An empty Anthropic stream now performs one extra non-streaming request before failing, which can add latency only on this abnormal path.
- Not covered / not validated: This PR intentionally does not add the same fallback to OpenAI-compatible or Gemini-native adapters. Full root `npm run build && npm run typecheck` was not used as the final validation path because a pre-existing generated declaration-file input issue caused TypeScript TS5055; the core package build/typecheck path above was used instead.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | ⚠️  | ⚠️  |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

Testing matrix notes:

- Tested locally on macOS with targeted package commands only.
- Windows and Linux were not tested locally.

## Linked Issues / Bugs

