### PR TITLE
fix(sdk): Include CLI chunks in SDK package

### DIFF
--- a/packages/sdk-typescript/scripts/bundle-cli-from-npm.js
+++ b/packages/sdk-typescript/scripts/bundle-cli-from-npm.js
@@ -22,6 +22,13 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const sdkRoot = join(__dirname, '..');
 
+function copyOptionalDir(source, destination, label) {
+  if (existsSync(source)) {
+    cpSync(source, destination, { recursive: true });
+    console.log(`[sdk bundle] ✓ ${label}/ copied`);
+  }
+}
+
 function main() {
   // Get CLI package path from environment variable
   const cliPackagePath = process.env.CLI_PACKAGE_PATH;
@@ -68,19 +75,21 @@ function main() {
   cpSync(cliJsSource, join(sdkCliDistDir, 'cli.js'));
   console.log('[sdk bundle] ✓ cli.js copied');
 
-  // Copy vendor directory if exists
-  const vendorSource = join(cliDistDir, 'vendor');
-  if (existsSync(vendorSource)) {
-    cpSync(vendorSource, join(sdkCliDistDir, 'vendor'), { recursive: true });
-    console.log('[sdk bundle] ✓ vendor/ copied');
-  }
-
-  // Copy locales directory if exists
-  const localesSource = join(cliDistDir, 'locales');
-  if (existsSync(localesSource)) {
-    cpSync(localesSource, join(sdkCliDistDir, 'locales'), { recursive: true });
-    console.log('[sdk bundle] ✓ locales/ copied');
-  }
+  copyOptionalDir(
+    join(cliDistDir, 'chunks'),
+    join(sdkCliDistDir, 'chunks'),
+    'chunks',
+  );
+  copyOptionalDir(
+    join(cliDistDir, 'vendor'),
+    join(sdkCliDistDir, 'vendor'),
+    'vendor',
+  );
+  copyOptionalDir(
+    join(cliDistDir, 'locales'),
+    join(sdkCliDistDir, 'locales'),
+    'locales',
+  );
 
   console.log('[sdk bundle] CLI bundled successfully from npm package');
 }

--- a/packages/sdk-typescript/scripts/bundle-cli.js
+++ b/packages/sdk-typescript/scripts/bundle-cli.js
@@ -48,6 +48,13 @@ function ensureRootBundle() {
   run(npm, ['run', 'bundle'], { cwd: repoRoot });
 }
 
+function copyOptionalDir(source, destination, label) {
+  if (existsSync(source)) {
+    cpSync(source, destination, { recursive: true });
+    console.log(`[sdk prepack] ✓ ${label}/ copied`);
+  }
+}
+
 function main() {
   ensureRootBundle();
 
@@ -67,15 +74,21 @@ function main() {
   console.log('[sdk prepack] Copying CLI bundle into SDK dist/...');
   cpSync(rootCliJs, join(cliDistDir, 'cli.js'));
 
-  const vendorSource = join(rootDistDir, 'vendor');
-  if (existsSync(vendorSource)) {
-    cpSync(vendorSource, join(cliDistDir, 'vendor'), { recursive: true });
-  }
-
-  const localesSource = join(rootDistDir, 'locales');
-  if (existsSync(localesSource)) {
-    cpSync(localesSource, join(cliDistDir, 'locales'), { recursive: true });
-  }
+  copyOptionalDir(
+    join(rootDistDir, 'chunks'),
+    join(cliDistDir, 'chunks'),
+    'chunks',
+  );
+  copyOptionalDir(
+    join(rootDistDir, 'vendor'),
+    join(cliDistDir, 'vendor'),
+    'vendor',
+  );
+  copyOptionalDir(
+    join(rootDistDir, 'locales'),
+    join(cliDistDir, 'locales'),
+    'locales',
+  );
 
   console.log('[sdk prepack] CLI bundle copied successfully');
 }


### PR DESCRIPTION
## Summary

- What changed: SDK packaging now copies the CLI `chunks/` directory alongside `cli.js`, `vendor/`, and `locales/` for both local repo packaging and CLI-package-based packaging.
- Why it changed: The bundled CLI is code-split and imports files from `./chunks`. The preview SDK package included `dist/cli/cli.js` without those chunk files, so SDK `query()` failed when the embedded CLI started.
- Reviewer focus: Please check that both SDK CLI bundling paths preserve the same runtime asset layout expected by the CLI bundle.

## Validation

- Commands run:
  ```bash
  npm install
  cd packages/sdk-typescript && npm pack --json
  rm -rf /tmp/qwen-sdk-local-pack-smoke && mkdir -p /tmp/qwen-sdk-local-pack-smoke
  cd /tmp/qwen-sdk-local-pack-smoke && npm init -y >/dev/null
  npm install /Users/dragon/Documents/qwen-code-sdk-bundle-pr/packages/sdk-typescript/qwen-code-sdk-0.1.7.tgz
  node node_modules/@qwen-code/sdk/dist/cli/cli.js --version
  node query-init-smoke.mjs
  npx prettier --check packages/sdk-typescript/scripts/bundle-cli.js packages/sdk-typescript/scripts/bundle-cli-from-npm.js
  npm run typecheck --workspace=packages/sdk-typescript
  git diff --check
  ```
- Prompts / inputs used: `query-init-smoke.mjs` imports `query` from the locally packed SDK tarball and waits for SDK/CLI initialization.
- Expected result: The packed SDK tarball contains `dist/cli/chunks/*.js`; the embedded CLI starts without `ERR_MODULE_NOT_FOUND`; SDK `query()` initializes.
- Observed result: `npm pack --json` listed `dist/cli/chunks/*` entries, embedded CLI printed `0.16.1`, and `query-init-smoke.mjs` printed `SDK_QUERY_INITIALIZED`.
- Quickest reviewer verification path: Run `cd packages/sdk-typescript && npm pack --json`, install the generated tarball in a temp project, then run `node node_modules/@qwen-code/sdk/dist/cli/cli.js --version`.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.): Before the fix, `@qwen-code/sdk@0.1.8-preview.0` fails with `ERR_MODULE_NOT_FOUND ... dist/cli/chunks/chunk-C6WMLUNB.js`; after the fix, the local tarball includes chunk files and the embedded CLI starts successfully.

## Scope / Risk

- Main risk or tradeoff: SDK package size increases because it now includes all CLI code-split chunks required at runtime.
- Not covered / not validated: A real npm preview publish was not performed from this branch.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | ⚠️  | ⚠️  | ⚠️  |
| Podman   | ⚠️  | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- Validated locally on macOS with a locally packed SDK tarball. Windows/Linux-specific tarball install paths were not exercised.

## Linked Issues / Bugs

