### PR TITLE
feat(daemon): in-session model switch reaches the bus (A1)

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -6121,6 +6121,167 @@ describe('createHttpAcpBridge', () => {
       abort.abort();
       await bridge.shutdown();
     });
+
+    it('drops malformed model-update params (non-string ids) without throwing or emitting', async () => {
+      let capturedConn: AgentSideConnection | undefined;
+      const factory: ChannelFactory = async () => {
+        const { clientStream, agentStream } = createInMemoryChannel();
+        capturedConn = new AgentSideConnection(
+          () => new FakeAgent(),
+          agentStream,
+        );
+        return {
+          stream: clientStream,
+          exited: new Promise<
+            | { exitCode: number | null; signalCode: NodeJS.Signals | null }
+            | undefined
+          >(() => {}),
+          kill: async () => {},
+          killSync: () => {},
+        };
+      };
+      const bridge = makeBridge({ channelFactory: factory });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const abort = new AbortController();
+      const iter = bridge.subscribeEvents(session.sessionId, {
+        signal: abort.signal,
+      });
+      const seen: string[] = [];
+      const collecting = (async () => {
+        for await (const e of iter) seen.push(e.type);
+      })();
+
+      // Non-string currentModelId / missing sessionId → early return, no throw.
+      await capturedConn!.extNotification('qwen/notify/session/model-update', {
+        v: 1,
+        sessionId: session.sessionId,
+        currentModelId: 123 as unknown as string,
+      });
+      await capturedConn!.extNotification('qwen/notify/session/model-update', {
+        v: 1,
+        currentModelId: 'qwen-max',
+      });
+      await new Promise((r) => setTimeout(r, 10));
+      abort.abort();
+      await collecting;
+      expect(seen.filter((t) => t === 'model_switched')).toEqual([]);
+      await bridge.shutdown();
+    });
+
+    it('drops a model-update for an unknown sessionId (no entry, no buffer)', async () => {
+      let capturedConn: AgentSideConnection | undefined;
+      const factory: ChannelFactory = async () => {
+        const { clientStream, agentStream } = createInMemoryChannel();
+        capturedConn = new AgentSideConnection(
+          () => new FakeAgent(),
+          agentStream,
+        );
+        return {
+          stream: clientStream,
+          exited: new Promise<
+            | { exitCode: number | null; signalCode: NodeJS.Signals | null }
+            | undefined
+          >(() => {}),
+          kill: async () => {},
+          killSync: () => {},
+        };
+      };
+      const bridge = makeBridge({ channelFactory: factory });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const abort = new AbortController();
+      const iter = bridge.subscribeEvents(session.sessionId, {
+        signal: abort.signal,
+      });
+      const seen: string[] = [];
+      const collecting = (async () => {
+        for await (const e of iter) seen.push(e.type);
+      })();
+
+      await capturedConn!.extNotification('qwen/notify/session/model-update', {
+        v: 1,
+        sessionId: 'nonexistent-session',
+        currentModelId: 'qwen-max',
+      });
+      await new Promise((r) => setTimeout(r, 10));
+      abort.abort();
+      await collecting;
+      // Unlike the MCP-budget path (which buffers unknown ids), model-update
+      // drops them — the real session's bus sees nothing.
+      expect(seen.filter((t) => t === 'model_switched')).toEqual([]);
+      await bridge.shutdown();
+    });
+
+    it('stamps originatorClientId from the active prompt on the promoted model_switched', async () => {
+      // While a prompt with a clientId is in flight, the session entry carries
+      // activePromptOriginatorClientId; the promoted model_switched must
+      // inherit it so peers can attribute the change.
+      let releasePrompt: (() => void) | undefined;
+      let capturedConn: AgentSideConnection | undefined;
+      const factory: ChannelFactory = async () => {
+        const { clientStream, agentStream } = createInMemoryChannel();
+        const fakeAgent = new FakeAgent({
+          promptImpl: async () => {
+            await new Promise<void>((res) => {
+              releasePrompt = res;
+            });
+            return { stopReason: 'end_turn' };
+          },
+        });
+        capturedConn = new AgentSideConnection(() => fakeAgent, agentStream);
+        return {
+          stream: clientStream,
+          exited: new Promise<
+            | { exitCode: number | null; signalCode: NodeJS.Signals | null }
+            | undefined
+          >(() => {}),
+          kill: async () => {},
+          killSync: () => {},
+        };
+      };
+      const bridge = makeBridge({ channelFactory: factory });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const abort = new AbortController();
+      const iter = bridge.subscribeEvents(session.sessionId, {
+        signal: abort.signal,
+      });
+
+      // Hang a prompt with a clientId → activePromptOriginatorClientId set.
+      const promptDone = bridge
+        .sendPrompt(
+          session.sessionId,
+          {
+            sessionId: session.sessionId,
+            prompt: [{ type: 'text', text: 'hi' }],
+          },
+          undefined,
+          { clientId: session.clientId },
+        )
+        .catch(() => {});
+      await new Promise((r) => setTimeout(r, 10));
+
+      void capturedConn!.extNotification('qwen/notify/session/model-update', {
+        v: 1,
+        sessionId: session.sessionId,
+        currentModelId: 'qwen-max',
+      });
+
+      const collected: Array<{ type: string; originatorClientId?: string }> =
+        [];
+      for await (const e of iter) {
+        if (e.type === 'model_switched') {
+          collected.push({
+            type: e.type,
+            originatorClientId: e.originatorClientId,
+          });
+          break;
+        }
+      }
+      expect(collected[0]?.originatorClientId).toBe(session.clientId);
+      releasePrompt?.();
+      await promptDone;
+      abort.abort();
+      await bridge.shutdown();
+    });
   });
 
   describe('maxSessions cap (chiga0 Rec 3)', () => {

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -5997,6 +5997,133 @@ describe('createHttpAcpBridge', () => {
     });
   });
 
+  describe('extNotification — in-session model update (A1, #4511)', () => {
+    it('promotes current_model_update to model_switched when no bridge roundtrip is in flight', async () => {
+      let capturedConn: AgentSideConnection | undefined;
+      const factory: ChannelFactory = async () => {
+        const { clientStream, agentStream } = createInMemoryChannel();
+        const fakeAgent = new FakeAgent();
+        capturedConn = new AgentSideConnection(() => fakeAgent, agentStream);
+        return {
+          stream: clientStream,
+          exited: new Promise<
+            | { exitCode: number | null; signalCode: NodeJS.Signals | null }
+            | undefined
+          >(() => {}),
+          kill: async () => {},
+          killSync: () => {},
+        };
+      };
+      const bridge = makeBridge({ channelFactory: factory });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const abort = new AbortController();
+      const iter = bridge.subscribeEvents(session.sessionId, {
+        signal: abort.signal,
+      });
+
+      void capturedConn!.extNotification('qwen/notify/session/model-update', {
+        v: 1,
+        sessionId: session.sessionId,
+        currentModelId: 'qwen-max',
+        previousModelId: 'qwen-plus',
+      });
+
+      const collected: Array<{ type: string; data: unknown }> = [];
+      for await (const e of iter) {
+        collected.push({ type: e.type, data: e.data });
+        if (collected.length === 1) break;
+      }
+      // Promoted to model_switched with currentModelId mapped to modelId.
+      expect(collected[0]?.type).toBe('model_switched');
+      expect(collected[0]?.data).toEqual({
+        sessionId: session.sessionId,
+        modelId: 'qwen-max',
+      });
+      abort.abort();
+      await bridge.shutdown();
+    });
+
+    it('suppresses current_model_update while a bridge model roundtrip is in flight', async () => {
+      // Hang the agent's unstable_setSessionModel so the bridge roundtrip
+      // stays in flight (modelRoundtripInFlight = true). The concurrent
+      // in-session current_model_update must be suppressed; only the bridge's
+      // own model_switched (after the roundtrip) reaches the bus.
+      let releaseModel: (() => void) | undefined;
+      let capturedConn: AgentSideConnection | undefined;
+      const factory: ChannelFactory = async () => {
+        const { clientStream, agentStream } = createInMemoryChannel();
+        const fakeAgent = new FakeAgent();
+        const augmented = new Proxy(fakeAgent, {
+          get(target, prop) {
+            if (prop === 'unstable_setSessionModel') {
+              return () =>
+                new Promise<Record<string, never>>((res) => {
+                  releaseModel = () => res({});
+                });
+            }
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            return (target as any)[prop];
+          },
+        });
+        capturedConn = new AgentSideConnection(
+          () => augmented as Agent,
+          agentStream,
+        );
+        return {
+          stream: clientStream,
+          exited: new Promise<
+            | { exitCode: number | null; signalCode: NodeJS.Signals | null }
+            | undefined
+          >(() => {}),
+          kill: async () => {},
+          killSync: () => {},
+        };
+      };
+      const bridge = makeBridge({ channelFactory: factory });
+      const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+      const abort = new AbortController();
+      const iter = bridge.subscribeEvents(session.sessionId, {
+        signal: abort.signal,
+      });
+
+      // Start a bridge-driven model change; it hangs → roundtrip in flight.
+      const modelChange = bridge
+        .setSessionModel(
+          session.sessionId,
+          { sessionId: session.sessionId, modelId: 'qwen-max' },
+          undefined,
+        )
+        .catch(() => {});
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Concurrent in-session notification — must be SUPPRESSED.
+      void capturedConn!.extNotification('qwen/notify/session/model-update', {
+        v: 1,
+        sessionId: session.sessionId,
+        currentModelId: 'qwen-turbo',
+      });
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Release the hung roundtrip → the bridge publishes its authoritative one.
+      releaseModel?.();
+      await modelChange;
+
+      const collected: Array<{ type: string; data: unknown }> = [];
+      for await (const e of iter) {
+        collected.push({ type: e.type, data: e.data });
+        if (collected.length === 1) break;
+      }
+      // Exactly the bridge's model_switched (qwen-max) — the suppressed
+      // qwen-turbo notification did NOT produce a second model_switched.
+      expect(collected[0]?.type).toBe('model_switched');
+      expect((collected[0]?.data as { modelId?: string }).modelId).toBe(
+        'qwen-max',
+      );
+      abort.abort();
+      await bridge.shutdown();
+    });
+  });
+
   describe('maxSessions cap (chiga0 Rec 3)', () => {
     it('refuses NEW spawns past the cap with SessionLimitExceededError', async () => {
       let n = 0;

--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -6025,7 +6025,6 @@ describe('createHttpAcpBridge', () => {
         v: 1,
         sessionId: session.sessionId,
         currentModelId: 'qwen-max',
-        previousModelId: 'qwen-plus',
       });
 
       const collected: Array<{ type: string; data: unknown }> = [];

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -206,6 +206,16 @@ interface SessionEntry {
    */
   modelChangeQueue: Promise<void>;
   /**
+   * A1 (#4511): true while the bridge is driving a model roundtrip
+   * (`setSessionModel` / `applyModelServiceId`) for this session. The
+   * `current_model_update` extNotification demux in `BridgeClient` reads this
+   * to SUPPRESS promotion of the agent's notification during a bridge-driven
+   * change — the bridge publishes the authoritative `model_switched` itself,
+   * so promoting the notification too would double-publish. In-session
+   * `/model` (no bridge roundtrip) sees this false and IS promoted.
+   */
+  modelRoundtripInFlight?: boolean;
+  /**
    * Cached "transport closed" promise. The first `sendPrompt` on a
    * session lazy-builds this from `channel.exited.then(throw)`; every
    * subsequent prompt's race uses the SAME promise so the listener
@@ -1166,6 +1176,11 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     // wedges the HTTP handler for 10s.
     const transportClosed = getTransportClosedReject(entry);
     const work = entry.modelChangeQueue.then(async () => {
+      // A1: mark a bridge-driven model roundtrip so the agent's
+      // `current_model_update` extNotification (this path also drives
+      // `Session.setModel`, which emits it) is suppressed by the demux —
+      // the authoritative `model_switched` is published below.
+      entry.modelRoundtripInFlight = true;
       try {
         await Promise.race([
           withTimeout(
@@ -1197,6 +1212,8 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
           ...(originatorClientId ? { originatorClientId } : {}),
         });
         throw err;
+      } finally {
+        entry.modelRoundtripInFlight = false;
       }
     });
     // Tail swallows failures so subsequent model changes still run; the
@@ -2849,16 +2866,24 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       // `model_switch_failed`). Both depend on ACP exposing a cancel
       // signal for `unstable_setSessionModel`.
       const transportClosed = getTransportClosedReject(entry);
-      const work = entry.modelChangeQueue.then(() =>
-        Promise.race([
-          withTimeout(
-            conn.unstable_setSessionModel(normalized),
-            initTimeoutMs,
-            'setSessionModel',
-          ),
-          transportClosed,
-        ]),
-      );
+      const work = entry.modelChangeQueue.then(async () => {
+        // A1: suppress the agent's current_model_update notification (this
+        // path drives Session.setModel, which emits it) while the bridge
+        // owns the change — the bridge publishes model_switched below.
+        entry.modelRoundtripInFlight = true;
+        try {
+          return await Promise.race([
+            withTimeout(
+              conn.unstable_setSessionModel(normalized),
+              initTimeoutMs,
+              'setSessionModel',
+            ),
+            transportClosed,
+          ]);
+        } finally {
+          entry.modelRoundtripInFlight = false;
+        }
+      });
       // Tail-swallow on the queue so a model-change failure doesn't poison
       // every subsequent change (matches `applyModelServiceId`'s pattern).
       entry.modelChangeQueue = work.then(

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -2869,10 +2869,13 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       const work = entry.modelChangeQueue.then(async () => {
         // A1: suppress the agent's current_model_update notification (this
         // path drives Session.setModel, which emits it) while the bridge
-        // owns the change — the bridge publishes model_switched below.
+        // owns the change. Publish the authoritative model_switched INSIDE
+        // this callback — i.e. while the flag is still true — mirroring
+        // `applyModelServiceId`, so the agent notification can never slip
+        // through after the flag clears even if transport ordering changes.
         entry.modelRoundtripInFlight = true;
         try {
-          return await Promise.race([
+          const result = await Promise.race([
             withTimeout(
               conn.unstable_setSessionModel(normalized),
               initTimeoutMs,
@@ -2880,6 +2883,16 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
             ),
             transportClosed,
           ]);
+          try {
+            entry.events.publish({
+              type: 'model_switched',
+              data: { sessionId: entry.sessionId, modelId: req.modelId },
+              ...(originatorClientId ? { originatorClientId } : {}),
+            });
+          } catch {
+            /* bus closed */
+          }
+          return result;
         } finally {
           entry.modelRoundtripInFlight = false;
         }
@@ -2913,15 +2926,8 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         }
         throw err;
       }
-      try {
-        entry.events.publish({
-          type: 'model_switched',
-          data: { sessionId: entry.sessionId, modelId: req.modelId },
-          ...(originatorClientId ? { originatorClientId } : {}),
-        });
-      } catch {
-        /* bus closed */
-      }
+      // model_switched is published inside the work callback above (while the
+      // suppress flag is still set), mirroring applyModelServiceId.
       return response;
     },
 

--- a/packages/acp-bridge/src/bridgeClient.ts
+++ b/packages/acp-bridge/src/bridgeClient.ts
@@ -481,9 +481,10 @@ export class BridgeClient implements Client {
   private readonly inFlightRestoreIds = new Set<string>();
 
   /**
-   * PR 14b: handle child→bridge ACP `extNotification` calls. Only one
-   * method is recognized today — `qwen/notify/session/mcp-budget-event`
-   * — translating the McpClientManager's budget-event payload into a
+   * PR 14b: handle child→bridge ACP `extNotification` calls. Two methods
+   * are recognized — `qwen/notify/session/mcp-budget-event` (PR 14b,
+   * McpClientManager budget events) and `qwen/notify/session/model-update`
+   * (A1 #4511, in-session model switch) — each translated into a
    * session-scoped SSE frame. Unknown methods, unknown event kinds,
    * and missing sessionIds are dropped silently for forward-compat
    * (a future child can add new notification methods without breaking

--- a/packages/acp-bridge/src/bridgeClient.ts
+++ b/packages/acp-bridge/src/bridgeClient.ts
@@ -217,6 +217,13 @@ export interface BridgeClientSessionEntry {
   events: EventBus;
   pendingPermissionIds: Set<string>;
   activePromptOriginatorClientId?: string;
+  /**
+   * A1 (#4511): true while the bridge drives a model roundtrip; the
+   * `current_model_update` extNotification demux reads it to suppress
+   * promotion during a bridge-driven change. Set on the full `SessionEntry`
+   * in `bridge.ts`; surfaced here for the demux.
+   */
+  modelRoundtripInFlight?: boolean;
 }
 
 /**
@@ -492,6 +499,17 @@ export class BridgeClient implements Client {
     method: string,
     params: Record<string, unknown>,
   ): Promise<void> {
+    // A1 (#4511): demux an in-session model switch to a `model_switched`
+    // bus event. `current_model_update` is not an ACP SessionUpdate variant,
+    // so the agent emits it over this side-channel; the bridge promotes it
+    // here — except while the bridge itself is driving the change (the HTTP
+    // path also flows through Session.setModel), where it publishes
+    // `model_switched` authoritatively and this notification is suppressed to
+    // avoid a double publish.
+    if (method === 'qwen/notify/session/model-update') {
+      this.handleInSessionModelUpdate(params);
+      return;
+    }
     if (method !== 'qwen/notify/session/mcp-budget-event') return;
     const sessionId = params['sessionId'];
     if (typeof sessionId !== 'string') return;
@@ -529,6 +547,53 @@ export class BridgeClient implements Client {
     // in `createSessionEntry`; if the session never registers (spawn
     // failure), the entry is GC'd by TTL after EARLY_EVENT_TTL_MS.
     this.bufferEarlyEvent(sessionId, frame);
+  }
+
+  /**
+   * A1 (#4511): promote an in-session `current_model_update` extNotification
+   * to a `model_switched` bus event (field mapping: `currentModelId` →
+   * `data.modelId`, `sessionId` → `data.sessionId`). Suppressed while the
+   * bridge is driving its own model roundtrip (`entry.modelRoundtripInFlight`)
+   * — there the bridge publishes the authoritative `model_switched`, so
+   * promoting here too would double-publish. A structured log records the
+   * decision so the `dropped` case is observable.
+   */
+  private handleInSessionModelUpdate(params: Record<string, unknown>): void {
+    const sessionId = params['sessionId'];
+    const currentModelId = params['currentModelId'];
+    if (typeof sessionId !== 'string' || typeof currentModelId !== 'string') {
+      return;
+    }
+    const entry = this.resolveEntry(sessionId);
+    if (!entry) {
+      // No live session — a model switch only happens on an established
+      // session, so unlike the MCP-budget path there is nothing to buffer.
+      writeStderrLine(
+        `[demux] session=${sessionId} type=current_model_update action=dropped reason=no_entry`,
+      );
+      return;
+    }
+    if (entry.modelRoundtripInFlight) {
+      // Bridge owns this change and will publish model_switched itself.
+      writeStderrLine(
+        `[demux] session=${sessionId} type=current_model_update action=suppressed reason=bridge_roundtrip_in_flight`,
+      );
+      return;
+    }
+    try {
+      entry.events.publish({
+        type: 'model_switched',
+        data: { sessionId, modelId: currentModelId },
+        ...(entry.activePromptOriginatorClientId
+          ? { originatorClientId: entry.activePromptOriginatorClientId }
+          : {}),
+      });
+      writeStderrLine(
+        `[demux] session=${sessionId} type=current_model_update action=promoted model=${currentModelId}`,
+      );
+    } catch {
+      /* bus closed */
+    }
   }
 
   /**

--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -469,6 +469,36 @@ describe('Session', () => {
       );
     });
 
+    it('emits a current_model_update extNotification after switching (A1)', async () => {
+      await session.setModel({
+        sessionId: 'test-session-id',
+        modelId: `qwen3-coder-plus(${AuthType.USE_OPENAI})`,
+      });
+
+      expect(mockClient.extNotification).toHaveBeenCalledWith(
+        'qwen/notify/session/model-update',
+        expect.objectContaining({
+          v: 1,
+          sessionId: 'test-session-id',
+          currentModelId: 'qwen3-coder-plus',
+        }),
+      );
+    });
+
+    it('does NOT emit the model-update notification when the switch fails (A1)', async () => {
+      switchModelSpy.mockRejectedValueOnce(new Error('switch boom'));
+      await expect(
+        session.setModel({
+          sessionId: 'test-session-id',
+          modelId: `qwen3-coder-plus(${AuthType.USE_OPENAI})`,
+        }),
+      ).rejects.toThrow();
+      expect(mockClient.extNotification).not.toHaveBeenCalledWith(
+        'qwen/notify/session/model-update',
+        expect.anything(),
+      );
+    });
+
     it('rejects empty/whitespace model IDs', async () => {
       await expect(
         session.setModel({

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -1598,6 +1598,10 @@ export class Session implements SessionContext {
       );
     }
 
+    // Capture the pre-switch model so the notification can carry
+    // `previousModelId`. Read BEFORE `switchModel` mutates it.
+    const previousModelId = this.config.getModel();
+
     await this.config.switchModel(
       selectedAuthType,
       parsed.modelId,
@@ -1606,6 +1610,29 @@ export class Session implements SessionContext {
         ? { requireCachedCredentials: true }
         : undefined,
     );
+
+    // A1 (#4511): notify attached clients of an in-session model switch so a
+    // `/model` slash command or plan-mode change reaches the bus (today only
+    // the HTTP `POST /session/:id/model` path publishes `model_switched`).
+    // `current_model_update` is NOT an ACP `SessionUpdate` variant (the type
+    // is the external @agentclientprotocol/sdk union, which has
+    // `current_mode_update` but not a model equivalent), so this goes over
+    // the agent→bridge `extNotification` side-channel. The bridge demuxes it
+    // to `model_switched` and SUPPRESSES it when the bridge itself is driving
+    // the change (the HTTP path also flows through this method), avoiding a
+    // double publish. Fire-and-forget, matching the MCP-budget extNotification.
+    void this.client
+      .extNotification('qwen/notify/session/model-update', {
+        v: 1,
+        sessionId: this.sessionId,
+        currentModelId: parsed.modelId,
+        ...(previousModelId && previousModelId !== parsed.modelId
+          ? { previousModelId }
+          : {}),
+      })
+      .catch(() => {
+        // Advisory only; a failed notification must not fail the model switch.
+      });
 
     if (options.persistDefault ?? true) {
       const persistScope = getPersistScopeForModelSelection(this.settings);

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -1598,10 +1598,6 @@ export class Session implements SessionContext {
       );
     }
 
-    // Capture the pre-switch model so the notification can carry
-    // `previousModelId`. Read BEFORE `switchModel` mutates it.
-    const previousModelId = this.config.getModel();
-
     await this.config.switchModel(
       selectedAuthType,
       parsed.modelId,
@@ -1626,9 +1622,6 @@ export class Session implements SessionContext {
         v: 1,
         sessionId: this.sessionId,
         currentModelId: parsed.modelId,
-        ...(previousModelId && previousModelId !== parsed.modelId
-          ? { previousModelId }
-          : {}),
       })
       .catch(() => {
         // Advisory only; a failed notification must not fail the model switch.


### PR DESCRIPTION
## What this does

Implements **A1** from the side-channel coordination design (#4511). A `/model` slash command or a plan-mode model switch now reaches attached clients — previously only the HTTP `POST /session/:id/model` path published `model_switched`, so an in-session switch left peers' model badge silently stale.

## Transport (design v7)

`current_model_update` is **not** an ACP `SessionUpdate` variant — `SessionUpdate` is the external `@agentclientprotocol/sdk` union, which has `current_mode_update` but no model equivalent. So the agent emits the change over the existing agent→bridge **`extNotification`** side-channel (the same mechanism used for MCP-budget events today), and the bridge demuxes it to the existing `model_switched` bus event. No ACP-spec change, no SDK change (consumers keep seeing `model_switched`).

## Changes

- **Agent** (`Session.setModel`): emits `qwen/notify/session/model-update` after `switchModel` resolves (success-only; captures the previous model id). Fire-and-forget — a failed notification never fails the switch.
- **Bridge** (`BridgeClient.extNotification`): demuxes it → `model_switched` (`currentModelId → data.modelId`), **suppressed** while the bridge is driving its own model roundtrip (`entry.modelRoundtripInFlight`, set around `setSessionModel` / `applyModelServiceId`). The HTTP path also flows through `Session.setModel`, so without suppression it would double-publish. Structured demux log records `promoted` / `suppressed` / `dropped`.

## Scope

This PR is the **core A1 path + suppress + observability + tests**. The design's §2.2 **post-roundtrip reconciliation** and the **timeout-race staleness check** (for the rarer concurrent-in-session and timed-out-then-late races) are a **tracked follow-up** — they harden edge races on top of this path.

## Tests

- Agent emits the notification on a successful switch; does **not** on failure.
- Bridge promotes it to `model_switched` when idle; **suppresses** it during a bridge-driven roundtrip (no double publish).
- acp-bridge: 302 pass.

## Design

Second implementation PR of #4511 (after A4 / #4539). A2 remains blocked on #4510 (`approvalModeQueue`); A5 is the `session_snapshot` frame.