### PR TITLE
feat(cli): default auto-dream/auto-skill to on and add /memory toggle

### DIFF
--- a/docs/users/configuration/settings.md
+++ b/docs/users/configuration/settings.md
@@ -274,7 +274,8 @@ If you are experiencing performance issues with file searching (e.g., with `@` c
 | Setting                          | Type    | Description                                                                       | Default |
 | -------------------------------- | ------- | --------------------------------------------------------------------------------- | ------- |
 | `memory.enableManagedAutoMemory` | boolean | Enable background extraction of memories from conversations.                      | `true`  |
-| `memory.enableManagedAutoDream`  | boolean | Enable automatic consolidation (deduplication and cleanup) of collected memories. | `false` |
+| `memory.enableManagedAutoDream`  | boolean | Enable automatic consolidation (deduplication and cleanup) of collected memories. | `true`  |
+| `memory.enableAutoSkill`         | boolean | Enable background review for reusable project skills after tool-heavy sessions.   | `true`  |
 
 See [Memory](../features/memory) for details on how auto-memory works and how to use the `/memory`, `/remember`, and `/dream` commands.
 

--- a/packages/cli/src/config/config.test.ts
+++ b/packages/cli/src/config/config.test.ts
@@ -2354,6 +2354,16 @@ describe('loadCliConfig with includeDirectories', () => {
     ]);
   });
 
+  it('should default managed-memory toggles to enabled when not in bare mode', async () => {
+    process.argv = ['node', 'script.js'];
+    const argv = await parseArguments();
+    const config = await loadCliConfig({}, argv, undefined, []);
+
+    expect(config.getManagedAutoMemoryEnabled()).toBe(true);
+    expect(config.getManagedAutoDreamEnabled()).toBe(true);
+    expect(config.getAutoSkillEnabled()).toBe(true);
+  });
+
   it('should force minimal startup behavior in bare mode', async () => {
     process.argv = ['node', 'script.js', '--bare'];
     const argv = await parseArguments();
@@ -2393,6 +2403,8 @@ describe('loadCliConfig with includeDirectories', () => {
     ]);
     expect(config.getDisableAllHooks()).toBe(true);
     expect(config.getManagedAutoMemoryEnabled()).toBe(false);
+    expect(config.getManagedAutoDreamEnabled()).toBe(false);
+    expect(config.getAutoSkillEnabled()).toBe(false);
     expect(config.getToolDiscoveryCommand()).toBeUndefined();
     expect(config.getToolCallCommand()).toBeUndefined();
     expect(config.getMcpServers()).toEqual({});

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1850,7 +1850,9 @@ export async function loadCliConfig(
     enableManagedAutoMemory: bareMode
       ? false
       : (settings.memory?.enableManagedAutoMemory ?? true),
-    enableManagedAutoDream: settings.memory?.enableManagedAutoDream ?? true,
+    enableManagedAutoDream: bareMode
+      ? false
+      : (settings.memory?.enableManagedAutoDream ?? true),
     enableAutoSkill: bareMode
       ? false
       : (settings.memory?.enableAutoSkill ?? true),

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -1850,10 +1850,10 @@ export async function loadCliConfig(
     enableManagedAutoMemory: bareMode
       ? false
       : (settings.memory?.enableManagedAutoMemory ?? true),
-    enableManagedAutoDream: settings.memory?.enableManagedAutoDream ?? false,
+    enableManagedAutoDream: settings.memory?.enableManagedAutoDream ?? true,
     enableAutoSkill: bareMode
       ? false
-      : (settings.memory?.enableAutoSkill ?? false),
+      : (settings.memory?.enableAutoSkill ?? true),
     fastModel: settings.fastModel || undefined,
     // Use separated hooks if provided, otherwise fall back to merged hooks
     userHooks: bareMode

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1439,7 +1439,7 @@ const SETTINGS_SCHEMA = {
         label: 'Enable Managed Auto-Dream',
         category: 'Memory',
         requiresRestart: false,
-        default: false,
+        default: true,
         description:
           'Enable automatic consolidation (dream) of collected memories.',
         showInDialog: false,
@@ -1449,7 +1449,7 @@ const SETTINGS_SCHEMA = {
         label: 'Enable Auto Skill',
         category: 'Memory',
         requiresRestart: false,
-        default: false,
+        default: true,
         description:
           'Enable background review for reusable project skills after tool-heavy sessions.',
         showInDialog: false,

--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -861,6 +861,7 @@ export default {
   'Auto-memory: {{status}}': 'Memòria automàtica: {{status}}',
   'Auto-dream: {{status}} · {{lastDream}} · /dream to run':
     'Auto-dream: {{status}} · {{lastDream}} · /dream per executar',
+  'Auto-skill: {{status}}': 'Habilitat automàtica: {{status}}',
   never: 'mai',
   on: 'activada',
   off: 'desactivada',

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -818,6 +818,7 @@ export default {
   'Auto-memory: {{status}}': 'Auto-Speicher: {{status}}',
   'Auto-dream: {{status}} · {{lastDream}} · /dream to run':
     'Auto-Konsolidierung: {{status}} · {{lastDream}} · /dream zum Ausführen',
+  'Auto-skill: {{status}}': 'Auto-Skill: {{status}}',
   never: 'nie',
   on: 'ein',
   off: 'aus',

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -901,6 +901,7 @@ export default {
   'Auto-memory: {{status}}': 'Auto-memory: {{status}}',
   'Auto-dream: {{status}} · {{lastDream}} · /dream to run':
     'Auto-dream: {{status}} · {{lastDream}} · /dream to run',
+  'Auto-skill: {{status}}': 'Auto-skill: {{status}}',
   never: 'never',
   on: 'on',
   off: 'off',

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -1859,6 +1859,7 @@ export default {
   'Auto-memory: {{status}}': 'Mémoire automatique : {{status}}',
   'Auto-dream: {{status}} · {{lastDream}} · /dream to run':
     'Rêve automatique : {{status}} · {{lastDream}} · /dream pour lancer',
+  'Auto-skill: {{status}}': 'Compétence automatique : {{status}}',
   never: 'jamais',
   on: 'activé',
   off: 'désactivé',

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -594,6 +594,7 @@ export default {
   'Auto-memory: {{status}}': '自動メモリ: {{status}}',
   'Auto-dream: {{status}} · {{lastDream}} · /dream to run':
     '自動統合: {{status}} · {{lastDream}} · /dream で実行',
+  'Auto-skill: {{status}}': '自動スキル: {{status}}',
   never: '未実行',
   on: 'オン',
   off: 'オフ',

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -823,6 +823,7 @@ export default {
   'Auto-memory: {{status}}': 'Memória automática: {{status}}',
   'Auto-dream: {{status}} · {{lastDream}} · /dream to run':
     'Consolidação automática: {{status}} · {{lastDream}} · /dream para executar',
+  'Auto-skill: {{status}}': 'Habilidade automática: {{status}}',
   never: 'nunca',
   on: 'ativado',
   off: 'desativado',

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -832,6 +832,7 @@ export default {
   'Auto-memory: {{status}}': 'Автопамять: {{status}}',
   'Auto-dream: {{status}} · {{lastDream}} · /dream to run':
     'Автоконсолидация: {{status}} · {{lastDream}} · /dream для запуска',
+  'Auto-skill: {{status}}': 'Автонавык: {{status}}',
   never: 'никогда',
   on: 'вкл',
   off: 'выкл',

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -768,6 +768,7 @@ export default {
   'Auto-memory: {{status}}': '自動記憶：{{status}}',
   'Auto-dream: {{status}} · {{lastDream}} · /dream to run':
     '自動整理：{{status}} · {{lastDream}} · /dream 立即運行',
+  'Auto-skill: {{status}}': '自動技能：{{status}}',
   never: '從未',
   on: '開',
   off: '關',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -852,6 +852,7 @@ export default {
   'Auto-memory: {{status}}': '自动记忆：{{status}}',
   'Auto-dream: {{status}} · {{lastDream}} · /dream to run':
     '自动整理：{{status}} · {{lastDream}} · /dream 立即运行',
+  'Auto-skill: {{status}}': '自动技能：{{status}}',
   never: '从未',
   on: '开',
   off: '关',

--- a/packages/cli/src/ui/components/MemoryDialog.test.tsx
+++ b/packages/cli/src/ui/components/MemoryDialog.test.tsx
@@ -43,6 +43,7 @@ describe('MemoryDialog', () => {
       getProjectRoot: vi.fn(() => '/tmp/project'),
       getManagedAutoMemoryEnabled: vi.fn(() => false),
       getManagedAutoDreamEnabled: vi.fn(() => false),
+      getAutoSkillEnabled: vi.fn(() => false),
     } as never);
 
     mockedUseSettings.mockReturnValue({ setValue: vi.fn() } as never);

--- a/packages/cli/src/ui/components/MemoryDialog.test.tsx
+++ b/packages/cli/src/ui/components/MemoryDialog.test.tsx
@@ -89,4 +89,76 @@ describe('MemoryDialog', () => {
     pressKey({ name: 'p', ctrl: true });
     expect(lastFrame()).toContain('› 1. User memory');
   });
+
+  it('renders the Auto-skill row with the status from config', () => {
+    const { lastFrame } = render(<MemoryDialog onClose={vi.fn()} />);
+
+    // beforeEach mocks getAutoSkillEnabled => false
+    expect(lastFrame()).toContain('Auto-skill: off');
+  });
+
+  it('chains focus list ↑ autoSkill ↑ autoDream ↑ autoMemory and back down', () => {
+    const { lastFrame } = render(<MemoryDialog onClose={vi.fn()} />);
+
+    expect(lastFrame()).toContain('› 1. User memory');
+
+    const pressKey = (key: { name: string }) => {
+      const keypressHandler =
+        mockedUseKeypress.mock.calls[
+          mockedUseKeypress.mock.calls.length - 1
+        ]![0];
+      act(() => {
+        keypressHandler(key as never);
+      });
+    };
+
+    // list (index 0) ↑ → autoSkill
+    pressKey({ name: 'up' });
+    expect(lastFrame()).toContain('› Auto-skill: off');
+
+    // autoSkill ↑ → autoDream
+    pressKey({ name: 'up' });
+    expect(lastFrame()).toContain('› Auto-dream:');
+
+    // autoDream ↓ → autoSkill
+    pressKey({ name: 'down' });
+    expect(lastFrame()).toContain('› Auto-skill: off');
+
+    // autoSkill ↓ → list (index 0)
+    pressKey({ name: 'down' });
+    expect(lastFrame()).toContain('› 1. User memory');
+  });
+
+  it('toggles Auto-skill on Enter and persists to workspace settings', () => {
+    const setValue = vi.fn();
+    mockedUseSettings.mockReturnValue({ setValue } as never);
+
+    const { lastFrame } = render(<MemoryDialog onClose={vi.fn()} />);
+
+    const pressKey = (key: { name: string }) => {
+      const keypressHandler =
+        mockedUseKeypress.mock.calls[
+          mockedUseKeypress.mock.calls.length - 1
+        ]![0];
+      act(() => {
+        keypressHandler(key as never);
+      });
+    };
+
+    expect(lastFrame()).toContain('Auto-skill: off');
+
+    // navigate to the autoSkill row
+    pressKey({ name: 'up' });
+    expect(lastFrame()).toContain('› Auto-skill: off');
+
+    // Enter toggles
+    pressKey({ name: 'return' });
+
+    expect(setValue).toHaveBeenCalledWith(
+      expect.anything(),
+      'memory.enableAutoSkill',
+      true,
+    );
+    expect(lastFrame()).toContain('› Auto-skill: on');
+  });
 });

--- a/packages/cli/src/ui/components/MemoryDialog.tsx
+++ b/packages/cli/src/ui/components/MemoryDialog.tsx
@@ -110,15 +110,18 @@ export function MemoryDialog({ onClose }: MemoryDialogProps) {
   const launchEditor = useLaunchEditor();
   const [error, setError] = useState<string | null>(null);
   const [highlightedIndex, setHighlightedIndex] = useState(0);
-  // 'autoMemory' | 'autoDream' = focus on that toggle row; 'list' = focus on the file list
+  // 'autoMemory' | 'autoDream' | 'autoSkill' = focus on that toggle row; 'list' = focus on the file list
   const [focusedSection, setFocusedSection] = useState<
-    'autoMemory' | 'autoDream' | 'list'
+    'autoMemory' | 'autoDream' | 'autoSkill' | 'list'
   >('list');
   const [autoMemoryOn, setAutoMemoryOn] = useState(() =>
     config.getManagedAutoMemoryEnabled(),
   );
   const [autoDreamOn, setAutoDreamOn] = useState(() =>
     config.getManagedAutoDreamEnabled(),
+  );
+  const [autoSkillOn, setAutoSkillOn] = useState(() =>
+    config.getAutoSkillEnabled(),
   );
   const [lastDreamAt, setLastDreamAt] = useState<number | null>(null);
 
@@ -271,6 +274,16 @@ export function MemoryDialog({ onClose }: MemoryDialogProps) {
     setAutoDreamOn(newValue);
   }, [autoDreamOn, loadedSettings]);
 
+  const handleToggleAutoSkill = useCallback(() => {
+    const newValue = !autoSkillOn;
+    loadedSettings.setValue(
+      SettingScope.Workspace,
+      'memory.enableAutoSkill',
+      newValue,
+    );
+    setAutoSkillOn(newValue);
+  }, [autoSkillOn, loadedSettings]);
+
   useKeypress(
     (key) => {
       if (key.name === 'escape') {
@@ -297,8 +310,7 @@ export function MemoryDialog({ onClose }: MemoryDialogProps) {
           return;
         }
         if (keyMatchers[Command.SELECTION_DOWN](key)) {
-          setFocusedSection('list');
-          setHighlightedIndex(0);
+          setFocusedSection('autoSkill');
           return;
         }
         if (key.name === 'return') {
@@ -308,10 +320,27 @@ export function MemoryDialog({ onClose }: MemoryDialogProps) {
         return;
       }
 
+      if (focusedSection === 'autoSkill') {
+        if (keyMatchers[Command.SELECTION_UP](key)) {
+          setFocusedSection('autoDream');
+          return;
+        }
+        if (keyMatchers[Command.SELECTION_DOWN](key)) {
+          setFocusedSection('list');
+          setHighlightedIndex(0);
+          return;
+        }
+        if (key.name === 'return') {
+          handleToggleAutoSkill();
+          return;
+        }
+        return;
+      }
+
       // focusedSection === 'list'
       if (keyMatchers[Command.SELECTION_UP](key)) {
         if (highlightedIndex === 0) {
-          setFocusedSection('autoDream');
+          setFocusedSection('autoSkill');
         } else {
           setHighlightedIndex((current) => current - 1);
         }
@@ -373,6 +402,18 @@ export function MemoryDialog({ onClose }: MemoryDialogProps) {
           {t('Auto-dream: {{status}} · {{lastDream}} · /dream to run', {
             status: autoDreamOn ? t('on') : t('off'),
             lastDream: dreamStatusText,
+          })}
+        </Text>
+        <Text
+          color={
+            focusedSection === 'autoSkill'
+              ? theme.status.success
+              : theme.text.secondary
+          }
+        >
+          {focusedSection === 'autoSkill' ? '› ' : '  '}
+          {t('Auto-skill: {{status}}', {
+            status: autoSkillOn ? t('on') : t('off'),
           })}
         </Text>
       </Box>

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -1226,8 +1226,8 @@ export class Config {
       isWorkspaceTrusted: this.isTrustedFolder(),
     });
     this.enableManagedAutoMemory = params.enableManagedAutoMemory ?? true;
-    this.enableManagedAutoDream = params.enableManagedAutoDream ?? false;
-    this.enableAutoSkill = params.enableAutoSkill ?? false;
+    this.enableManagedAutoDream = params.enableManagedAutoDream ?? true;
+    this.enableAutoSkill = params.enableAutoSkill ?? true;
     this.fastModel = params.fastModel || undefined;
     this.disableAllHooks = params.disableAllHooks ?? false;
     this.stopHookBlockingCap = resolveStopHookBlockingCap(

--- a/packages/vscode-ide-companion/schemas/settings.schema.json
+++ b/packages/vscode-ide-companion/schemas/settings.schema.json
@@ -637,12 +637,12 @@
         "enableManagedAutoDream": {
           "description": "Enable automatic consolidation (dream) of collected memories.",
           "type": "boolean",
-          "default": false
+          "default": true
         },
         "enableAutoSkill": {
           "description": "Enable background review for reusable project skills after tool-heavy sessions.",
           "type": "boolean",
-          "default": false
+          "default": true
         }
       }
     },


### PR DESCRIPTION
## What this PR does

Two related changes to the managed-memory experience around the `/memory` dialog. First, two settings that previously defaulted to off — `memory.enableManagedAutoDream` and `memory.enableAutoSkill` — now default to on, matching the existing `memory.enableManagedAutoMemory` default and aligning the three managed-memory subsystems behind a single "enabled by default" policy. Second, the `/memory` dialog now exposes an `Auto-skill` toggle row next to the existing `Auto-memory` and `Auto-dream` rows, with the same focus/Enter semantics and workspace-scoped persistence (writes `memory.enableAutoSkill`). The default-value change is mirrored across all three sources of truth (settings schema, CLI loader, core `Config`), and the generated `vscode-ide-companion/schemas/settings.schema.json` is regenerated to match.

## Why it's needed

The managed-memory pipeline gives users summarised memories (`auto-memory`), periodic consolidation (`auto-dream`), and reusable project skills (`auto-skill`) — but only the first was on by default. The other two required knowing the settings path to opt in, so most users never saw them. Defaulting all three on lets new and existing users get the full pipeline without configuration. The new `Auto-skill` row in `/memory` keeps the opt-out discoverable now that the feature is enabled by default — without it, `Auto-skill` would be the only managed-memory subsystem with no visible kill switch in the dialog.

## Reviewer Test Plan

### How to verify

1. In a workspace that has no prior `memory.*` settings, run `qwen` and open `/memory`. All three rows (`Auto-memory`, `Auto-dream`, `Auto-skill`) should read `on`.
2. Navigate with arrow keys: `↑` from the file list moves through `Auto-skill` → `Auto-dream` → `Auto-memory`; `↓` reverses the path back to the list. Each toggle row shows `›` and a success-coloured prefix when focused.
3. With `Auto-skill` focused, press `Enter` — the row flips `on` ↔ `off`, and the workspace `.qwen/settings.json` gains a `memory.enableAutoSkill: <bool>` entry. Re-opening the dialog reflects the stored value.
4. With `memory.enableAutoSkill: false` explicitly set in settings, the dialog still loads with `Auto-skill: off` — the new default never overrides an explicit user value.

### Evidence (Before & After)

Before — only two toggle rows; a fresh workspace shows `Auto-dream: off`:

\`\`\`
│ Memory                                                                                           │
│                                                                                                  │
│   Auto-memory: on                                                                                │
│   Auto-dream: off · never · /dream to run                                                        │
│                                                                                                  │
│ › 1. User memory  Saved in ~/.qwen/QWEN.md                                                       │
│   2. Project memory  Saved in QWEN.md                                                            │
│   3. Open auto-memory folder                                                                     │
\`\`\`

After — three toggle rows; a fresh workspace shows all three `on`:

\`\`\`
│ Memory                                                                                           │
│                                                                                                  │
│   Auto-memory: on                                                                                │
│   Auto-dream: on · never · /dream to run                                                         │
│   Auto-skill: on                                                                                 │
│                                                                                                  │
│ › 1. User memory  Saved in ~/.qwen/QWEN.md                                                       │
│   2. Project memory  Saved in QWEN.md                                                            │
│   3. Open auto-memory folder                                                                     │
\`\`\`

Focus moves to the new row after pressing `↑` from the file list:

\`\`\`
│   Auto-memory: on                                                                                │
│   Auto-dream: on · never · /dream to run                                                         │
│ › Auto-skill: on                                                                                 │
\`\`\`

Pressing `Enter` toggles the row and persists to workspace settings (`.qwen/settings.json` after a single toggle):

\`\`\`json
{ "memory": { "enableAutoSkill": false } }
\`\`\`

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local `dist/cli.js` via `npm run build && npm run bundle`. Manual TUI verification under tmux (200×50). Workspace `.qwen/settings.json` confirmed to receive `memory.enableAutoSkill` after toggling. Typecheck + lint pass. The e2e suite was started but interrupted at ~18 minutes (8 files passing, remainder hit unrelated API connection errors).

## Risk & Scope

- **Main risk / tradeoff**: turning `auto-skill` on by default exposes more users to its background extraction work — a behaviour change for existing users who never opted in. Mitigated by the new in-dialog toggle and by the fact that explicit user settings continue to override the default.
- **Not validated / out of scope**: full e2e integration suite was not run to completion (started but interrupted after ~18 minutes due to unrelated API/network errors; the 8 files that did complete all passed). Schema, typecheck, lint, and manual TUI verification all pass.
- **Breaking changes / migration notes**: no API or schema breakage. Users who already have `memory.enableManagedAutoDream` or `memory.enableAutoSkill` set in their settings keep their value; only users relying on the implicit default see new behaviour.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

围绕 \`/memory\` dialog 的两项相关改动。其一：原本默认关闭的 \`memory.enableManagedAutoDream\` 与 \`memory.enableAutoSkill\` 现在默认开启，与已经默认开启的 \`memory.enableManagedAutoMemory\` 对齐，把 managed-memory 的三个子系统统一为"默认启用"。其二：\`/memory\` dialog 在 \`Auto-memory\` 与 \`Auto-dream\` 两行旁新增 \`Auto-skill\` toggle 行，焦点 / Enter 切换语义、workspace 级持久化（写入 \`memory.enableAutoSkill\`）均与现有两项保持一致。默认值改动在三处 source of truth（settings schema、CLI loader、core \`Config\`）同步更新，并重新生成 \`vscode-ide-companion/schemas/settings.schema.json\`。

## 为什么需要

managed-memory 管道由三块组成：摘要记忆（\`auto-memory\`）、阶段性整理（\`auto-dream\`）、可复用项目 skill（\`auto-skill\`）—— 但只有第一项默认开启。后两项需要用户知道 settings 字段才能启用，绝大多数人压根没见过。把三者默认全部开启，可以让新老用户直接获得完整 pipeline，无需手动配置。\`Auto-skill\` 默认开启后也需要一个直观的关闭入口，新增 toggle 行就是给它一个对等的 kill switch——否则 \`Auto-skill\` 会成为唯一在 dialog 里没有可见关闭开关的 managed-memory 子系统。

## Reviewer 验证步骤

### 如何验证

1. 在一个**没有** \`memory.*\` 历史设置的 workspace 里运行 \`qwen\` 打开 \`/memory\`，三行（\`Auto-memory\` / \`Auto-dream\` / \`Auto-skill\`）都应显示 \`on\`。
2. 方向键导航：\`↑\` 从文件列表依次经过 \`Auto-skill\` → \`Auto-dream\` → \`Auto-memory\`；\`↓\` 反向回到列表。聚焦行显示 \`›\` 前缀与 success 配色。
3. 焦点在 \`Auto-skill\` 时按 \`Enter\`，状态在 \`on\` / \`off\` 之间切换，workspace 的 \`.qwen/settings.json\` 出现 \`memory.enableAutoSkill: <bool>\`；重开 dialog 沿用该值。
4. 在 settings 中显式写 \`memory.enableAutoSkill: false\`，dialog 仍按 \`off\` 加载——新默认值不会覆盖用户显式设置。

### Before / After 证据

参见上方英文段的 tmux capture 截图。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 运行环境（可选）

通过 \`npm run build && npm run bundle\` 产出 \`dist/cli.js\`，tmux（200×50）下做了手动 TUI 验证。toggle 后 workspace 的 \`.qwen/settings.json\` 确认写入 \`memory.enableAutoSkill\`。typecheck + lint 通过。e2e suite 启动后约 18 分钟被中止（8 个文件全过，剩余受到与本 PR 无关的 API 连接错误影响）。

## 风险与范围

- **主要风险 / tradeoff**：把 auto-skill 默认开启会让更多用户触发后台 skill extraction 工作；对从未主动开启该功能的老用户来说是一次行为变更。缓解：dialog 新 toggle 提供直观关闭入口，用户显式设的 settings 继续覆盖默认值。
- **未验证 / 范围外**：没有跑完整个 e2e suite（启动后约 18 分钟，8 个文件全过，剩余测试遇到与本 PR 无关的 API 连接报错被中止）。Schema、typecheck、lint 与手动 TUI 验证全部通过。
- **Breaking changes / 迁移**：无 API / schema 破坏。已显式设过 \`memory.enableManagedAutoDream\` 或 \`memory.enableAutoSkill\` 的用户保持原值；仅依赖隐式默认的用户会看到新行为。

## 关联 Issue

N/A

</details>