### PR TITLE
fix(cli): suppress completion menu for history-restored text until edited

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -4292,6 +4292,56 @@ describe('InputPrompt', () => {
       expect(mockInputHistory.navigateUp).not.toHaveBeenCalled();
       unmount();
     });
+
+    it('suppresses completion menu navigation for history-restored text until edited', async () => {
+      mockedUseCommandCompletion.mockReturnValue({
+        ...mockCommandCompletion,
+        showSuggestions: true,
+        suggestions: [
+          { label: 'clear', value: 'clear' },
+          { label: 'continuous-learning', value: 'continuous-learning' },
+        ],
+        activeSuggestionIndex: 0,
+      });
+      (mockInputHistory.navigateUp as Mock).mockReturnValue(true);
+
+      const { stdin, unmount } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      const historyArgs = mockedUseInputHistory.mock.calls.at(-1)?.[0];
+      if (!historyArgs) {
+        throw new Error('useInputHistory was not called');
+      }
+
+      await act(async () => {
+        historyArgs.onChange('/clear');
+      });
+      await wait();
+      mockBuffer.cursor = [0, 0];
+      mockBuffer.visualCursor = [0, 0];
+
+      stdin.write('\u001B[A'); // Up arrow
+      await wait();
+
+      expect(mockCommandCompletion.navigateUp).not.toHaveBeenCalled();
+      expect(mockInputHistory.navigateUp).toHaveBeenCalled();
+      expect(mockedUseCommandCompletion.mock.calls.at(-1)?.[6]).toBe(false);
+
+      unmount();
+
+      mockedUseCommandCompletion.mockClear();
+      mockedUseInputHistory.mockClear();
+      mockBuffer.setText('/cle');
+      const { unmount: unmountEdited } = renderWithProviders(
+        <InputPrompt {...props} />,
+      );
+      await wait();
+
+      expect(mockedUseCommandCompletion.mock.calls.at(-1)?.[6]).toBe(true);
+      unmountEdited();
+    });
   });
 });
 function clean(str: string | undefined): string {

--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -180,7 +180,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       ),
     [uiState.confirmationRequest, uiState.pendingGeminiHistoryItems],
   );
-  const [justNavigatedHistory, setJustNavigatedHistory] = useState(false);
+  const [historyRestoredText, setHistoryRestoredText] = useState<string | null>(
+    null,
+  );
   const [escPressCount, setEscPressCount] = useState(0);
   const [showEscapePrompt, setShowEscapePrompt] = useState(false);
   const escapeTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -234,6 +236,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   const exportCompletion = useExportCompletion(buffer, slashCommands);
   const shellHistory = useShellHistory(config.getProjectRoot());
   const shellHistoryData = shellHistory.history;
+  const isHistoryRestoredText =
+    historyRestoredText !== null && buffer.text === historyRestoredText;
 
   const completion = useCommandCompletion(
     buffer,
@@ -242,10 +246,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     commandContext,
     reverseSearchActive,
     config,
-    // Suppress completion when history navigation just occurred
-    !justNavigatedHistory,
+    // Suppress completion for history-restored text until the user edits it.
+    !isHistoryRestoredText,
     recentSlashCommands,
   );
+  const showCompletionSuggestions =
+    completion.showSuggestions && !isHistoryRestoredText;
 
   // Ref so renderLineWithHighlighting (stable useCallback) can access fresh ghost text
   const midInputGhostTextRef = useRef<{
@@ -415,9 +421,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
   const customSetTextAndResetCompletionSignal = useCallback(
     (newText: string) => {
       buffer.setText(newText);
-      setJustNavigatedHistory(true);
+      setHistoryRestoredText(newText);
     },
-    [buffer, setJustNavigatedHistory],
+    [buffer],
   );
 
   const inputHistory = useInputHistory({
@@ -443,20 +449,27 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
     prevHasAgentsRef.current = hasAgents;
   }, [hasAgents, inputHistory]);
 
-  // Effect to reset completion if history navigation just occurred and set the text
+  // History-restored input should not immediately open completion menus and
+  // steal Up/Down from continued history navigation. Editing the text clears
+  // this marker and lets completions appear again.
   useEffect(() => {
-    if (justNavigatedHistory) {
+    if (historyRestoredText === null) {
+      return;
+    }
+
+    if (buffer.text === historyRestoredText) {
       resetCompletionState();
       resetReverseSearchCompletionState();
       resetCommandSearchCompletionState();
       setExpandedSuggestionIndex(-1);
-      setJustNavigatedHistory(false);
+      return;
     }
+
+    setHistoryRestoredText(null);
   }, [
-    justNavigatedHistory,
+    historyRestoredText,
     buffer.text,
     resetCompletionState,
-    setJustNavigatedHistory,
     resetReverseSearchCompletionState,
     resetCommandSearchCompletionState,
   ]);
@@ -545,7 +558,12 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           setLivePanelFocused(false);
           return true;
         }
-        if (key.sequence && key.sequence.length === 1 && !key.ctrl && !key.meta) {
+        if (
+          key.sequence &&
+          key.sequence.length === 1 &&
+          !key.ctrl &&
+          !key.meta
+        ) {
           setLivePanelFocused(false);
           return false;
         }
@@ -676,7 +694,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       if (
         key.sequence === '!' &&
         buffer.text === '' &&
-        !completion.showSuggestions
+        !showCompletionSuggestions
       ) {
         // Hide shortcuts when toggling shell mode
         if (showShortcuts && onToggleShortcuts) {
@@ -691,7 +709,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       if (
         key.sequence === '?' &&
         buffer.text === '' &&
-        !completion.showSuggestions &&
+        !showCompletionSuggestions &&
         onToggleShortcuts
       ) {
         onToggleShortcuts();
@@ -742,7 +760,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
           return true;
         }
 
-        if (completion.showSuggestions) {
+        if (showCompletionSuggestions) {
           completion.resetCompletionState();
           setExpandedSuggestionIndex(-1);
           resetEscapeState();
@@ -873,7 +891,10 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       }
 
       // Export-specific arrow/Tab/Enter handling (Phase 1 + Phase 2).
-      if (exportCompletion.handleExportInput(key, completion)) {
+      if (
+        !isHistoryRestoredText &&
+        exportCompletion.handleExportInput(key, completion)
+      ) {
         return true;
       }
 
@@ -899,7 +920,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       // If the command is a perfect match, pressing enter should execute it.
       if (completion.isPerfectMatch && keyMatchers[Command.RETURN](key)) {
         if (
-          completion.showSuggestions &&
+          showCompletionSuggestions &&
           exportCompletion.navigatedRef.current &&
           exportCompletion.navigatedTextRef.current === buffer.text &&
           acceptActiveCompletionSuggestion()
@@ -919,7 +940,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         !key.paste &&
         !key.shift &&
         buffer.text.length === 0 &&
-        !completion.showSuggestions &&
+        !showCompletionSuggestions &&
         !reverseSearchActive &&
         !commandSearchActive &&
         followup.state.isVisible &&
@@ -942,7 +963,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         return true;
       }
 
-      if (completion.showSuggestions) {
+      if (showCompletionSuggestions) {
         if (completion.suggestions.length > 1) {
           const isCompletionUpKey = keyMatchers[Command.COMPLETION_UP](key);
           const isCompletionDownKey = keyMatchers[Command.COMPLETION_DOWN](key);
@@ -973,7 +994,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         key.name === 'tab' &&
         !key.paste &&
         !key.shift &&
-        !completion.showSuggestions &&
+        !showCompletionSuggestions &&
         midInputGhostTextRef.current?.acceptText
       ) {
         buffer.insert(midInputGhostTextRef.current.acceptText);
@@ -1354,6 +1375,8 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       followup,
       onPromptSuggestionDismiss,
       exportCompletion,
+      isHistoryRestoredText,
+      showCompletionSuggestions,
     ],
   );
 
@@ -1477,7 +1500,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
 
   const activeCompletion = getActiveCompletion();
   const shouldUseExportSuggestions =
-    !commandSearchActive && !reverseSearchActive;
+    !commandSearchActive && !reverseSearchActive && !isHistoryRestoredText;
   const suggestionDisplayProps =
     shouldUseExportSuggestions && exportCompletion.suggestionDisplayProps
       ? exportCompletion.suggestionDisplayProps
@@ -1489,7 +1512,9 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
         };
   const shouldShowSuggestions =
     (shouldUseExportSuggestions && exportCompletion.shouldShowSuggestions) ||
-    activeCompletion.showSuggestions;
+    (!isHistoryRestoredText || commandSearchActive || reverseSearchActive
+      ? activeCompletion.showSuggestions
+      : false);
 
   // Whether any input-side handler would consume a Tab keystroke. AppContainer
   // feeds this into useAutoAcceptIndicator's `shouldBlockTab` so the


### PR DESCRIPTION
<!--
Maintainers prioritize PRs with a clear reviewer test plan — without it, review may be delayed.

Don't hard-wrap paragraphs: GitHub renders single newlines as <br>, so wrapped text shows as a narrow column. Write each paragraph or list item as one long line.
-->

## What this PR does

Replaces the one-shot boolean `justNavigatedHistory` flag with a value-tracking `historyRestoredText` state that stays active until the user edits the input. This prevents the slash-command completion menu from stealing Up/Down arrow keypresses immediately after history navigation restores text, and ensures completion menus only reappear once the user intentionally modifies the restored text.

Before:

<img width="805" height="720" alt="钉钉录屏_2026-05-27 004408" src="https://github.com/user-attachments/assets/64ff930b-5eeb-440d-8285-88e33cb18b54" />

After:

<img width="682" height="720" alt="钉钉录屏_2026-05-27 004330" src="https://github.com/user-attachments/assets/41793add-bf1a-4b5e-91ec-376eb42adf7e" />

## Why it's needed

When navigating input history with Up/Down, the restored text (e.g. `/clear`) would immediately match a slash-command suggestion, causing the completion menu to open on the next render. The old `justNavigatedHistory` boolean only suppressed completions for one render cycle — if the menu opened afterward, Up/Down were captured by the completion handler instead of continuing history navigation. Users had to press Esc first to dismiss the menu before they could keep navigating history, which felt unintuitive.

## Reviewer Test Plan

### How to verify

1. Run `npm run dev` and type a slash command like `/clear` or `/compact`, then press Enter to execute it.
2. Press Up arrow to restore that command from history — the input should show the restored text but no completion menu should appear, and pressing Up again should continue navigating history (not cycle through completion suggestions).
3. Edit the restored text (e.g. change `/clear` to `/cle`) — the completion menu should now appear and Up/Down should navigate suggestions as normal.
4. Run the unit test: `cd packages/cli && npx vitest run src/ui/components/InputPrompt.test.tsx` — the new test "suppresses completion menu navigation for history-restored text until edited" should pass.

### Evidence (Before & After)

N/A — no tmux logs available; the behavior change is verifiable via the unit test and manual TUI testing described above.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

npm run dev (local dev server, no sandbox)

## Risk & Scope

- Main risk or tradeoff: The `historyRestoredText` state persists across renders until the buffer text diverges from it. If a history entry and a user-typed prefix happen to match exactly, the completion menu won't appear for that exact text until the user adds or removes a character. This matches the intended UX (history-restored text should behave as "read-only" until intentionally edited) and is unlikely to cause confusion in practice.
- Not validated / out of scope: Windows and Linux TUI behavior (only macOS tested locally; CI covers all platforms).
- Breaking changes / migration notes: None — internal state change only, no API or config impact.

## Linked Issues

<details>
<summary>中文说明</summary>

## 本 PR 的内容

将一次性布尔标记 `justNavigatedHistory` 替换为值追踪状态 `historyRestoredText`，该状态在用户编辑输入之前一直保持激活。这防止了斜杠命令补全菜单在历史导航恢复文本后立即抢占 Up/Down 箭头键按键，并确保补全菜单仅在用户有意修改恢复的文本后才会重新出现。

## 为什么需要

使用 Up/Down 导航输入历史时，恢复的文本（例如 `/clear`）会立即匹配斜杠命令建议，导致补全菜单在下一帧渲染时打开。旧的 `justNavigatedHistory` 布尔标记仅在一个渲染周期内抑制补全——如果菜单随后打开，Up/Down 会被补全处理器捕获，而不是继续历史导航。用户必须先按 Esc 关闭菜单才能继续导航历史，这感觉不直观。

## 审阅者测试计划

### 如何验证

1. 运行 `npm run dev`，输入一个斜杠命令如 `/clear` 或 `/compact`，然后按 Enter 执行。
2. 按 Up 箭头从历史恢复该命令——输入应显示恢复的文本但不应出现补全菜单，再次按 Up 应继续导航历史（而不是在补全建议中循环）。
3. 编辑恢复的文本（例如将 `/clear` 改为 `/cle`）——补全菜单现在应出现，Up/Down 应正常导航建议。
4. 运行单元测试：`cd packages/cli && npx vitest run src/ui/components/InputPrompt.test.tsx`——新测试 "suppresses completion menu navigation for history-restored text until edited" 应通过。

### 证据（前后对比）

N/A — 无 tmux 日志；行为变更可通过单元测试和上述手动 TUI 测试验证。

### 测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### 环境（可选）

npm run dev（本地开发服务器，无沙箱）

## 风险与范围

- 主要风险或权衡：`historyRestoredText` 状态在缓冲区文本偏离之前跨渲染持续。如果历史条目和用户输入的前缀恰好完全匹配，补全菜单不会为该精确文本出现，直到用户添加或删除字符。这符合预期的 UX（历史恢复的文本应表现为"只读"直到有意编辑），在实践中不太可能引起混淆。
- 未验证 / 超出范围：Windows 和 Linux TUI 行为（仅本地测试了 macOS；CI 覆盖所有平台）。
- 破坏性变更 / 迁移说明：无——仅内部状态变更，无 API 或配置影响。

</details>

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)