### PR TITLE
feat(daemon): non-blocking POST /prompt — return 202 with promptId

### DIFF
--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -481,6 +481,48 @@ function broadcastPromptCancelledOnce(
   broadcastPromptCancelled(entry, sessionId, originatorClientId, reason);
 }
 
+function broadcastTurnComplete(
+  entry: SessionEntry,
+  sessionId: string,
+  promptResult: { stopReason?: string; [k: string]: unknown },
+  promptId: string | undefined,
+  originatorClientId: string | undefined,
+): void {
+  entry.events.publish({
+    type: 'turn_complete',
+    data: {
+      sessionId,
+      stopReason: promptResult.stopReason ?? 'end_turn',
+      ...(promptId ? { promptId } : {}),
+    },
+    ...(originatorClientId ? { originatorClientId } : {}),
+  });
+}
+
+function broadcastTurnError(
+  entry: SessionEntry,
+  sessionId: string,
+  err: unknown,
+  promptId: string | undefined,
+  originatorClientId: string | undefined,
+): void {
+  const message = err instanceof Error ? err.message : String(err);
+  const code =
+    err instanceof Error && 'code' in err
+      ? String((err as Error & { code?: string }).code)
+      : undefined;
+  entry.events.publish({
+    type: 'turn_error',
+    data: {
+      sessionId,
+      message,
+      ...(code ? { code } : {}),
+      ...(promptId ? { promptId } : {}),
+    },
+    ...(originatorClientId ? { originatorClientId } : {}),
+  });
+}
+
 function hasControlCharacter(value: string): boolean {
   for (let i = 0; i < value.length; i += 1) {
     const code = value.charCodeAt(i);
@@ -2263,6 +2305,28 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         }
         return racedPromise;
       });
+      const promptId = context?.promptId;
+      result.then(
+        (promptResult) => {
+          broadcastTurnComplete(
+            entry,
+            sessionId,
+            promptResult,
+            promptId,
+            originatorClientId,
+          );
+        },
+        (err) => {
+          if (err instanceof DOMException && err.name === 'AbortError') return;
+          broadcastTurnError(
+            entry,
+            sessionId,
+            err,
+            promptId,
+            originatorClientId,
+          );
+        },
+      );
       // Tail swallows failures so subsequent prompts still run. The caller
       // still sees rejections on its own `result` reference.
       entry.promptQueue = result.then(
@@ -2337,6 +2401,12 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       const entry = byId.get(sessionId);
       if (!entry) throw new SessionNotFoundError(sessionId);
       return entry.events.subscribe(subOpts);
+    },
+
+    getSessionLastEventId(sessionId) {
+      const entry = byId.get(sessionId);
+      if (!entry) throw new SessionNotFoundError(sessionId);
+      return entry.events.lastEventId;
     },
 
     respondToPermission(requestId, response, context) {

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -508,8 +508,10 @@ function broadcastTurnError(
 ): void {
   const message = err instanceof Error ? err.message : String(err);
   const code =
-    err instanceof Error && 'code' in err
-      ? String((err as Error & { code?: string }).code)
+    err instanceof Error &&
+    'code' in err &&
+    typeof (err as Error & { code?: unknown }).code === 'string'
+      ? (err as Error & { code: string }).code
       : undefined;
   entry.events.publish({
     type: 'turn_error',

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -110,6 +110,13 @@ export interface BridgeClientRequestContext {
    * dedicated daemon or `designated` policy instead).
    */
   fromLoopback?: boolean;
+  /**
+   * Caller-generated correlation id for non-blocking prompt mode.
+   * When present, the bridge stamps `turn_complete` / `turn_error` events
+   * with this id so the SDK's `prompt()` can match the SSE event to the
+   * pending HTTP 202 request.
+   */
+  promptId?: string;
 }
 
 /**
@@ -190,6 +197,13 @@ export interface HttpAcpBridge {
     sessionId: string,
     opts?: SubscribeOptions,
   ): AsyncIterable<BridgeEvent>;
+
+  /**
+   * Return the most recent monotonic event id for this session's bus.
+   * Used by non-blocking prompt responses to tell the client where to
+   * start SSE replay so no events are missed.
+   */
+  getSessionLastEventId(sessionId: string): number;
 
   /**
    * Explicitly close a live session. Force-closes even when other clients

--- a/packages/cli/src/serve/capabilities.ts
+++ b/packages/cli/src/serve/capabilities.ts
@@ -227,6 +227,7 @@ export const SERVE_CAPABILITY_REGISTRY = {
   },
   prompt_absolute_deadline: { since: 'v1' },
   writer_idle_timeout: { since: 'v1' },
+  non_blocking_prompt: { since: 'v1' },
 } as const satisfies Record<string, ServeCapabilityDescriptor>;
 
 export type ServeFeature = keyof typeof SERVE_CAPABILITY_REGISTRY;

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -163,6 +163,7 @@ const EXPECTED_STAGE1_FEATURES = [
   // `permission_partial_vote` / `permission_forbidden` SSE events. Always-
   // on; runtime-active policy is at `/capabilities` body `policy.permission`.
   'permission_mediation',
+  'non_blocking_prompt',
 ] as const;
 
 // Issue #4175 PR 15. `require_auth` is registered but conditionally
@@ -183,7 +184,10 @@ const EXPECTED_REGISTERED_FEATURES = [
   // they appear here in their registry-declaration order, not the
   // stage1 order.
   ...EXPECTED_STAGE1_FEATURES.filter(
-    (f) => f !== 'auth_device_flow' && f !== 'permission_mediation',
+    (f) =>
+      f !== 'auth_device_flow' &&
+      f !== 'permission_mediation' &&
+      f !== 'non_blocking_prompt',
   ),
   'mcp_workspace_pool',
   'mcp_pool_restart',
@@ -196,6 +200,7 @@ const EXPECTED_REGISTERED_FEATURES = [
   'permission_mediation',
   'prompt_absolute_deadline',
   'writer_idle_timeout',
+  'non_blocking_prompt',
 ] as const;
 
 interface FakeBridgeOpts {
@@ -224,6 +229,7 @@ interface FakeBridgeOpts {
     req?: CancelNotification,
     context?: BridgeClientRequestContext,
   ) => Promise<void>;
+  getSessionLastEventIdImpl?: (sessionId: string) => number;
   subscribeImpl?: (
     sessionId: string,
     opts?: SubscribeOptions,
@@ -693,6 +699,12 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
       return (async function* () {
         // empty
       })();
+    },
+    getSessionLastEventId(sessionId) {
+      if (opts.getSessionLastEventIdImpl) {
+        return opts.getSessionLastEventIdImpl(sessionId);
+      }
+      return 0;
     },
     respondToPermission(requestId, response, context) {
       const accepted = respondImpl(requestId, response, context);
@@ -2162,7 +2174,7 @@ describe('createServeApp', () => {
   });
 
   describe('POST /session/:id/prompt', () => {
-    it('200 with PromptResponse on success; route :id wins over body sessionId', async () => {
+    it('202 with promptId on success; route :id wins over body sessionId', async () => {
       const bridge = fakeBridge({
         promptImpl: async () => ({ stopReason: 'end_turn' }),
       });
@@ -2174,14 +2186,18 @@ describe('createServeApp', () => {
           sessionId: 'spoofed-session-B',
           prompt: [{ type: 'text', text: 'hi' }],
         });
-      expect(res.status).toBe(200);
-      expect(res.body).toEqual({ stopReason: 'end_turn' });
+      expect(res.status).toBe(202);
+      expect(res.body.promptId).toBeDefined();
+      expect(typeof res.body.promptId).toBe('string');
+      expect(typeof res.body.lastEventId).toBe('number');
+      // Allow the async bridge call to settle.
+      await new Promise((r) => setTimeout(r, 20));
       expect(bridge.promptCalls).toHaveLength(1);
       expect(bridge.promptCalls[0]?.sessionId).toBe('session-A');
       expect(bridge.promptCalls[0]?.req.sessionId).toBe('session-A');
     });
 
-    it('passes client identity context into bridge.sendPrompt', async () => {
+    it('passes client identity and promptId context into bridge.sendPrompt', async () => {
       const bridge = fakeBridge();
       const app = createServeApp(baseOpts, undefined, { bridge });
       const res = await request(app)
@@ -2189,30 +2205,12 @@ describe('createServeApp', () => {
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .set('X-Qwen-Client-Id', 'client-1')
         .send({ prompt: [{ type: 'text', text: 'hi' }] });
-      expect(res.status).toBe(200);
-      expect(bridge.promptCalls[0]?.context).toEqual({
+      expect(res.status).toBe(202);
+      await new Promise((r) => setTimeout(r, 20));
+      expect(bridge.promptCalls[0]?.context).toMatchObject({
         clientId: 'client-1',
       });
-    });
-
-    it('400 invalid_client_id when the bridge rejects prompt originator', async () => {
-      const bridge = fakeBridge({
-        promptImpl: async (sessionId) => {
-          throw new InvalidClientIdError(sessionId, 'client-unknown');
-        },
-      });
-      const app = createServeApp(baseOpts, undefined, { bridge });
-      const res = await request(app)
-        .post('/session/session-A/prompt')
-        .set('Host', `127.0.0.1:${baseOpts.port}`)
-        .set('X-Qwen-Client-Id', 'client-unknown')
-        .send({ prompt: [{ type: 'text', text: 'hi' }] });
-      expect(res.status).toBe(400);
-      expect(res.body).toMatchObject({
-        code: 'invalid_client_id',
-        sessionId: 'session-A',
-        clientId: 'client-unknown',
-      });
+      expect(bridge.promptCalls[0]?.context?.promptId).toBe(res.body.promptId);
     });
 
     it('400 when prompt body is missing', async () => {
@@ -2228,7 +2226,7 @@ describe('createServeApp', () => {
 
     it('404 when bridge reports unknown session', async () => {
       const bridge = fakeBridge({
-        promptImpl: async (sessionId) => {
+        getSessionLastEventIdImpl: (sessionId) => {
           throw new SessionNotFoundError(sessionId);
         },
       });
@@ -2241,7 +2239,7 @@ describe('createServeApp', () => {
       expect(res.body.sessionId).toBe('missing');
     });
 
-    it('500 on generic bridge errors', async () => {
+    it('202 even when bridge errors asynchronously (turn_error event covers failure)', async () => {
       const bridge = fakeBridge({
         promptImpl: async () => {
           throw new Error('agent crashed');
@@ -2252,8 +2250,8 @@ describe('createServeApp', () => {
         .post('/session/session-A/prompt')
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .send({ prompt: [{ type: 'text', text: 'hi' }] });
-      expect(res.status).toBe(500);
-      expect(res.body).toEqual({ error: 'agent crashed' });
+      expect(res.status).toBe(202);
+      expect(res.body.promptId).toBeDefined();
     });
 
     it('passes an AbortSignal into bridge.sendPrompt', async () => {
@@ -2271,69 +2269,30 @@ describe('createServeApp', () => {
         .post('/session/session-A/prompt')
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .send({ prompt: [{ type: 'text', text: 'hi' }] });
-      expect(res.status).toBe(200);
-      // The route always supplies a signal — the AbortController it wires
-      // to req.on('close'). The bridge must receive it so a future client
-      // disconnect can be routed into an ACP cancel. (Capture happens at
-      // call time; supertest's later connection close would flip the
-      // signal's `aborted` flag if asserted post-hoc.)
+      expect(res.status).toBe(202);
+      await new Promise((r) => setTimeout(r, 20));
       expect(signalDefined).toBe(true);
       expect(abortedAtCall).toBe(false);
     });
 
-    it('aborting the signal mid-prompt asks the bridge to wind down', async () => {
-      // Bridge waits forever unless aborted, then resolves with a
-      // cancelled stop reason. Verifies the route's
-      // req.on('close') → abort.abort() flow propagates.
-      let promptStarted: (() => void) | undefined;
-      const promptStartedPromise = new Promise<void>((r) => {
-        promptStarted = r;
-      });
+    it('non-blocking prompt returns 202 and fires sendPrompt asynchronously', async () => {
+      let promptResolve: (() => void) | undefined;
       const bridge = fakeBridge({
-        promptImpl: async (_sid, _req, signal) =>
+        promptImpl: async () =>
           new Promise((resolve) => {
-            promptStarted!();
-            const onAbort = () => resolve({ stopReason: 'cancelled' });
-            if (signal?.aborted) onAbort();
-            else signal?.addEventListener('abort', onAbort, { once: true });
+            promptResolve = () => resolve({ stopReason: 'end_turn' });
           }),
       });
-      const localHandle = await runQwenServe(
-        { hostname: '127.0.0.1', port: 0, mode: 'http-bridge' },
-        { bridge },
-      );
-      try {
-        const port = (localHandle.server.address() as { port: number }).port;
-        // Use Node's `http` directly — vitest's jsdom env replaces
-        // AbortController with a polyfill that undici's fetch rejects.
-        const http = await import('node:http');
-        const reqBody = JSON.stringify({
-          prompt: [{ type: 'text', text: 'hi' }],
-        });
-        const httpReq = http.request({
-          host: '127.0.0.1',
-          port,
-          method: 'POST',
-          path: '/session/sess/prompt',
-          headers: {
-            'content-type': 'application/json',
-            'content-length': Buffer.byteLength(reqBody),
-          },
-        });
-        // Swallow ECONNRESET / socket-hangup that the destroy below emits.
-        httpReq.on('error', () => {});
-        httpReq.write(reqBody);
-        httpReq.end();
-        // Wait for the bridge to receive the prompt before destroying.
-        await promptStartedPromise;
-        httpReq.destroy();
-        // Give the daemon a moment to register the close → propagate.
-        await new Promise((r) => setTimeout(r, 100));
-        expect(bridge.promptCalls).toHaveLength(1);
-        expect(bridge.promptCalls[0]?.signal?.aborted).toBe(true);
-      } finally {
-        await localHandle.close();
-      }
+      const app = createServeApp(baseOpts, undefined, { bridge });
+      const res = await request(app)
+        .post('/session/session-A/prompt')
+        .set('Host', `127.0.0.1:${baseOpts.port}`)
+        .send({ prompt: [{ type: 'text', text: 'hi' }] });
+      expect(res.status).toBe(202);
+      expect(bridge.promptCalls).toHaveLength(1);
+      // Resolve the async prompt to clean up.
+      promptResolve!();
+      await new Promise((r) => setTimeout(r, 10));
     });
   });
 
@@ -6944,12 +6903,11 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
       }
     });
 
-    it('fires the server-side deadline and returns 504 with errorKind', async () => {
+    it('fires the server-side deadline and aborts the bridge signal', async () => {
       // 50ms server deadline + a prompt that resolves only on abort:
-      // the deadline timer must abort the AbortController, the catch
-      // block must detect the typed reason, and the response must
-      // carry the structured `errorKind: 'prompt_deadline_exceeded'`
-      // (not a generic 500 / silent close).
+      // the deadline timer must abort the AbortController. With non-
+      // blocking prompt the HTTP response is always 202; the deadline
+      // outcome is delivered via `turn_error` on the SSE bus.
       const bridge = fakeBridge({ promptImpl: abortableBridgePromptImpl() });
       const app = createServeApp(
         { ...baseOpts, promptDeadlineMs: 50 },
@@ -6960,47 +6918,16 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
         .post('/session/session-A/prompt')
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .send({ prompt: [{ type: 'text', text: 'slow' }] });
-      expect(res.status).toBe(504);
-      expect(res.body).toMatchObject({
-        code: 'prompt_deadline_exceeded',
-        errorKind: 'prompt_deadline_exceeded',
-        deadlineMs: 50,
-      });
-      // The bridge MUST have received an aborted signal so the agent
-      // can wind down its FIFO slot — otherwise a buggy agent keeps
-      // the per-session lane blocked forever even though the HTTP
-      // client got its 504.
+      expect(res.status).toBe(202);
+      expect(res.body).toHaveProperty('promptId');
+      expect(res.body).toHaveProperty('lastEventId');
+      // Wait for the deadline timer to fire asynchronously.
+      await new Promise((r) => setTimeout(r, 200));
       expect(bridge.promptCalls).toHaveLength(1);
       expect(bridge.promptCalls[0]?.signal?.aborted).toBe(true);
       expect(bridge.promptCalls[0]?.signal?.reason).toBeInstanceOf(
         PromptDeadlineExceededError,
       );
-    });
-
-    it('still returns typed 504 when deadline stderr logging fails', async () => {
-      const stderrSpy = vi
-        .spyOn(process.stderr, 'write')
-        .mockImplementation(() => {
-          throw new Error('stderr pipe closed');
-        });
-      try {
-        const bridge = fakeBridge({
-          promptImpl: () => new Promise(() => {}),
-        });
-        const app = createServeApp(
-          { ...baseOpts, promptDeadlineMs: 50 },
-          undefined,
-          { bridge },
-        );
-        const res = await request(app)
-          .post('/session/session-A/prompt')
-          .set('Host', `127.0.0.1:${baseOpts.port}`)
-          .send({ prompt: [{ type: 'text', text: 'slow' }] });
-        expect(res.status).toBe(504);
-        expect(res.body.errorKind).toBe('prompt_deadline_exceeded');
-      } finally {
-        stderrSpy.mockRestore();
-      }
     });
 
     it('strips route-only deadlineMs before forwarding the prompt body', async () => {
@@ -7022,7 +6949,7 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
           _meta: { trace: 'kept' },
           extra: 'kept',
         });
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(202);
       expect(bridge.promptCalls).toHaveLength(1);
       expect(bridge.promptCalls[0]?.req).not.toHaveProperty('deadlineMs');
       expect(bridge.promptCalls[0]?.req).toMatchObject({
@@ -7034,11 +6961,9 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
     });
 
     it('caps a per-prompt `deadlineMs` override at the server flag', async () => {
-      // Server flag 50ms, request asks for 5000ms — the effective
-      // deadline must be the smaller 50ms. The way we observe it is
-      // the same 504-with-deadlineMs:50 response: if the cap was
-      // incorrectly the request's 5000ms, the test would time out
-      // long before completing.
+      // Server flag 50ms, request asks for 5000ms — effective deadline
+      // must be 50ms. With non-blocking prompt the HTTP response is
+      // always 202; we verify the abort signal fires within ~50ms.
       const bridge = fakeBridge({ promptImpl: abortableBridgePromptImpl() });
       const app = createServeApp(
         { ...baseOpts, promptDeadlineMs: 50 },
@@ -7052,14 +6977,17 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
           prompt: [{ type: 'text', text: 'slow' }],
           deadlineMs: 5_000,
         });
-      expect(res.status).toBe(504);
-      expect(res.body.deadlineMs).toBe(50);
+      expect(res.status).toBe(202);
+      await new Promise((r) => setTimeout(r, 200));
+      expect(bridge.promptCalls[0]?.signal?.aborted).toBe(true);
+      expect(bridge.promptCalls[0]?.signal?.reason).toBeInstanceOf(
+        PromptDeadlineExceededError,
+      );
     });
 
     it('uses the per-prompt override when shorter than the server flag', async () => {
       // Server flag 10s, request 30ms — request wins as the tighter
-      // bound. Same observability path as above; if the cap was the
-      // server's 10s the test would hang past its own short timeout.
+      // bound. Abort signal should fire within ~30ms.
       const bridge = fakeBridge({ promptImpl: abortableBridgePromptImpl() });
       const app = createServeApp(
         { ...baseOpts, promptDeadlineMs: 10_000 },
@@ -7073,20 +7001,18 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
           prompt: [{ type: 'text', text: 'slow' }],
           deadlineMs: 30,
         });
-      expect(res.status).toBe(504);
-      expect(res.body.deadlineMs).toBe(30);
+      expect(res.status).toBe(202);
+      await new Promise((r) => setTimeout(r, 200));
+      expect(bridge.promptCalls[0]?.signal?.aborted).toBe(true);
+      expect(bridge.promptCalls[0]?.signal?.reason).toBeInstanceOf(
+        PromptDeadlineExceededError,
+      );
     });
 
-    it('still emits 504 when the bridge IGNORES the abort signal (race contract)', async () => {
-      // The deadline must be a hard server-side guarantee, not contingent
-      // on the bridge / agent honoring AbortSignal. A buggy agent that
-      // never resolves its sendPrompt promise would, without the
-      // Promise.race in the prompt handler, keep the HTTP request open
-      // indefinitely and never emit the promised 504 — that was the
-      // Copilot finding on the initial T2.9 commit. This test exercises
-      // a non-cooperative bridge to lock the contract: deadline 50ms,
-      // bridge promise never settles, route still returns 504 within a
-      // reasonable budget.
+    it('still aborts the signal when the bridge IGNORES the abort (non-cooperative bridge)', async () => {
+      // With non-blocking prompt the HTTP response is always 202. The
+      // deadline timer must still fire and abort the signal so the
+      // bridge can observe it, even if it ignores the abort.
       const bridge = fakeBridge({
         promptImpl: () => new Promise(() => {}),
       });
@@ -7099,24 +7025,15 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
         .post('/session/session-A/prompt')
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .send({ prompt: [{ type: 'text', text: 'slow' }] });
-      expect(res.status).toBe(504);
-      expect(res.body).toMatchObject({
-        code: 'prompt_deadline_exceeded',
-        errorKind: 'prompt_deadline_exceeded',
-        deadlineMs: 50,
-      });
-      // The signal was still aborted with the typed reason as best-
-      // effort wind-down — the agent has every chance to clean up
-      // its FIFO slot even though we no longer wait for it.
+      expect(res.status).toBe(202);
+      await new Promise((r) => setTimeout(r, 200));
       expect(bridge.promptCalls[0]?.signal?.aborted).toBe(true);
       expect(bridge.promptCalls[0]?.signal?.reason).toBeInstanceOf(
         PromptDeadlineExceededError,
       );
     });
 
-    it('does not interfere with normal prompt completion when the flag is unset', async () => {
-      // The deadline path must be 100% off by default. A 200 OK with
-      // the bridge's stopReason is the bit-for-bit pre-PR contract.
+    it('returns 202 without deadline when the flag is unset', async () => {
       const bridge = fakeBridge({
         promptImpl: async () => ({ stopReason: 'end_turn' }),
       });
@@ -7125,14 +7042,13 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
         .post('/session/session-A/prompt')
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .send({ prompt: [{ type: 'text', text: 'hi' }] });
-      expect(res.status).toBe(200);
-      expect(res.body.stopReason).toBe('end_turn');
+      expect(res.status).toBe(202);
+      expect(res.body).toHaveProperty('promptId');
+      expect(res.body).toHaveProperty('lastEventId');
     });
 
     it('does not fire the deadline when the prompt resolves promptly', async () => {
-      // 5s deadline + an immediate resolve: the timer must not fire
-      // and must not corrupt the 200 response. Guards against a
-      // future regression where the timer races the response.
+      // 5s deadline + immediate resolve: the timer must not fire.
       const bridge = fakeBridge({
         promptImpl: async () => ({ stopReason: 'end_turn' }),
       });
@@ -7145,8 +7061,11 @@ describe('T2.9 prompt absolute deadline (issue #4514)', () => {
         .post('/session/session-A/prompt')
         .set('Host', `127.0.0.1:${baseOpts.port}`)
         .send({ prompt: [{ type: 'text', text: 'hi' }] });
-      expect(res.status).toBe(200);
-      expect(res.body.stopReason).toBe('end_turn');
+      expect(res.status).toBe(202);
+      expect(res.body).toHaveProperty('promptId');
+      // Give enough time for a timer to fire if it were going to.
+      await new Promise((r) => setTimeout(r, 100));
+      expect(bridge.promptCalls[0]?.signal?.aborted).toBe(false);
     });
   });
 

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import * as crypto from 'node:crypto';
 import * as path from 'node:path';
 import express from 'express';
 import type { Application } from 'express';
@@ -314,34 +315,6 @@ export function resolvePromptDeadlineMs(
     return serverMs;
   }
   return Math.min(serverMs, requestMs);
-}
-
-/**
- * Issue #4514 T2.9. Single source of truth for the prompt-deadline 504
- * response: log the operator-facing stderr breadcrumb (so a 504 spike
- * at the load balancer can be grepped back to a session) and emit the
- * typed JSON body. Keeping the wire format and log line together
- * prevents drift between future prompt-deadline response paths.
- */
-function emitPromptDeadline504(
-  res: import('express').Response,
-  err: PromptDeadlineExceededError,
-  sessionId: string,
-): void {
-  try {
-    writeStderrLine(
-      `qwen serve: prompt deadline fired (session ${sessionId}) — ` +
-        `deadlineMs=${err.deadlineMs}`,
-    );
-  } catch {
-    /* stderr pipe closed; 504 response still going out. */
-  }
-  res.status(504).json({
-    error: err.message,
-    code: 'prompt_deadline_exceeded',
-    errorKind: 'prompt_deadline_exceeded',
-    deadlineMs: err.deadlineMs,
-  });
 }
 
 /**
@@ -1442,12 +1415,6 @@ export function createServeApp(
     if (
       !prompt.every(
         (item: unknown) =>
-          // `typeof item === 'object'` is true for arrays too, so an
-          // exclude-arrays check is needed to keep the contract
-          // ("ACP content block, like {type: 'text', text: '...'}")
-          // honest. Without `!Array.isArray(item)`, `prompt: [[]]`
-          // passes validation and a confusing 500 surfaces from the
-          // ACP SDK layer.
           typeof item === 'object' && item !== null && !Array.isArray(item),
       )
     ) {
@@ -1456,12 +1423,6 @@ export function createServeApp(
       });
       return;
     }
-    // T2.9: validate the optional per-prompt `deadlineMs` override BEFORE
-    // we touch the abort controller — a malformed value is operator-
-    // visible client error (400) rather than silently dropped (which
-    // would let the client believe their deadline was active when it
-    // wasn't). Capping vs the server flag happens later, after we
-    // know what the server is willing to enforce.
     const rawRequestDeadline = body['deadlineMs'];
     let requestDeadlineMs: number | undefined;
     if (rawRequestDeadline !== undefined && rawRequestDeadline !== null) {
@@ -1479,75 +1440,46 @@ export function createServeApp(
       }
       requestDeadlineMs = rawRequestDeadline;
     }
-    // Propagate HTTP-client disconnect to an ACP cancel notification so
-    // the agent winds down promptly and the per-session FIFO doesn't
-    // stay blocked on a dead client. Detached after the prompt settles.
-    //
-    // Use `res.on('close')` (NOT `req.on('close')`) — `IncomingMessage`'s
-    // close event fires once the request body has been fully consumed
-    // even when the client is still listening for the response, which
-    // would cancel every ordinary prompt the moment its upload
-    // finished. `ServerResponse`'s close event only fires when the
-    // socket goes away. Guard with `!res.writableEnded` so a normal
-    // response flush (which also triggers `res.close`) doesn't fire
-    // the abort retroactively.
+    const clientId = parseClientIdHeader(req, res);
+    if (clientId === null) return;
+
+    const promptId = crypto.randomUUID();
+    const forwardedBody = { ...body };
+    delete forwardedBody['deadlineMs'];
+
+    // Snapshot the event bus cursor BEFORE enqueuing so the client can
+    // start SSE from this point without missing `turn_complete`.
+    let lastEventId: number;
+    try {
+      lastEventId = bridge.getSessionLastEventId(sessionId);
+    } catch (err) {
+      sendBridgeError(res, err, {
+        route: 'POST /session/:id/prompt',
+        sessionId,
+      });
+      return;
+    }
+
+    // Non-blocking: fire-and-forget. The bridge publishes
+    // `turn_complete` / `turn_error` on the SSE bus when done;
+    // deadline enforcement still aborts the prompt server-side.
     const abort = new AbortController();
-    const onResClose = () => {
-      if (!res.writableEnded) abort.abort();
-    };
-    res.once('close', onResClose);
-    // T2.9: arm the server-side wallclock deadline (if configured).
-    // `resolvePromptDeadlineMs` returns `undefined` when the server
-    // flag is unset, preserving the legacy "client disconnect is
-    // the only auto-cancel" behavior bit-for-bit. When a deadline IS
-    // configured we Promise.race the bridge call against an explicit
-    // rejecting timer — without the race, a non-cooperative agent
-    // that ignores AbortSignal could keep the HTTP request open
-    // indefinitely (the FIXME in `httpAcpBridge.ts` `sendPrompt` was
-    // promised closed by T2.9 in the PR description; relying on the
-    // bridge alone wouldn't deliver). The race makes the 504 a hard
-    // guarantee independent of bridge cooperation; `abort.abort` is
-    // still called as best-effort wind-down so the agent's FIFO slot
-    // is freed if it does honor the signal.
     const effectiveDeadlineMs = resolvePromptDeadlineMs(
       opts.promptDeadlineMs,
       requestDeadlineMs,
     );
-    const forwardedBody = { ...body };
-    delete forwardedBody['deadlineMs'];
     let deadlineTimer: NodeJS.Timeout | undefined;
-    const deadlinePromise: Promise<never> | undefined =
-      effectiveDeadlineMs !== undefined
-        ? new Promise<never>((_, reject) => {
-            deadlineTimer = setTimeout(() => {
-              const err = new PromptDeadlineExceededError(effectiveDeadlineMs);
-              // Reject FIRST so Promise.race resolves deterministically
-              // with the typed deadline error; the bridge's own
-              // AbortError rejection (if the agent honors abort)
-              // would otherwise race the route's microtask queue and
-              // surface as a generic AbortError in the catch path.
-              reject(err);
-              if (!abort.signal.aborted) abort.abort(err);
-            }, effectiveDeadlineMs);
-            // unref so a still-armed timer can't keep the daemon alive
-            // past shutdown.
-            deadlineTimer.unref();
-          })
-        : undefined;
-    const clientId = parseClientIdHeader(req, res);
-    if (clientId === null) {
-      res.off('close', onResClose);
-      if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
-      return;
+    if (effectiveDeadlineMs !== undefined) {
+      deadlineTimer = setTimeout(() => {
+        if (!abort.signal.aborted) {
+          abort.abort(new PromptDeadlineExceededError(effectiveDeadlineMs));
+        }
+      }, effectiveDeadlineMs);
+      deadlineTimer.unref();
     }
-    try {
-      // SECURITY NOTE: this `...forwardedBody` passthrough is
-      // intentional — the bridge / ACP SDK ignores fields it
-      // doesn't recognize (ACP-spec `_meta` etc are forwarded
-      // wholesale to the agent, which is the documented behavior).
-      // `sessionId`, `prompt`, and the route-only `deadlineMs` are
-      // forced/stripped so the child never sees uncapped client input.
-      const bridgePromise = bridge.sendPrompt(
+
+    bridge
+      .sendPrompt(
         sessionId,
         {
           ...forwardedBody,
@@ -1555,69 +1487,19 @@ export function createServeApp(
           prompt,
         } as Parameters<HttpAcpBridge['sendPrompt']>[1],
         abort.signal,
-        clientId !== undefined ? { clientId } : undefined,
-      );
-      // T2.9: when the deadline race fires first, the underlying
-      // bridge promise becomes an orphan that may eventually settle
-      // minutes later (especially against a buggy agent). Tail-attach
-      // a no-op handler so its eventual rejection doesn't surface as
-      // an unhandledRejection — the 504 has already been sent and the
-      // route has no further use for the result.
-      if (deadlinePromise !== undefined) {
-        bridgePromise.catch(() => undefined);
-      }
-      const result = await (deadlinePromise !== undefined
-        ? Promise.race([bridgePromise, deadlinePromise])
-        : bridgePromise);
-      res.status(200).json(result);
-    } catch (err) {
-      // T2.9: the deadline race won — emit the typed 504 directly.
-      // This is the primary deadline-exceeded path now that the
-      // route races the bridge against its own timer.
-      //
-      // The `return` MUST fire on every `PromptDeadlineExceededError`,
-      // including the writableEnded race (client disconnected in the
-      // same tick the deadline timer fired). Without the early return,
-      // the typed error would fall through to the AbortError branch
-      // (false — not a DOMException), then `sendBridgeError`, which
-      // would call `res.status(500).json(...)` on an already-ended
-      // response and trip `ERR_STREAM_WRITE_AFTER_END`. wenshao
-      // review #4530 inline #3 (Critical).
-      if (err instanceof PromptDeadlineExceededError) {
-        if (!res.writableEnded) emitPromptDeadline504(res, err, sessionId);
-        return;
-      }
-      // The HTTP client disconnecting fires the abort path above and
-      // the bridge re-throws as `AbortError`. That's a normal
-      // wind-down, not an error worth a 500 + stderr stack trace.
-      // Drop it silently — the socket is already closed so we can't
-      // send a response anyway, and active clients (e.g. an IDE
-      // plugin scrubbing a stuck prompt) would otherwise spam the
-      // daemon log.
-      //
-      // BX9_k: narrow the swallow to ONLY the case where WE armed
-      // the abort. The earlier blanket `err.name === 'AbortError'`
-      // could also swallow an internal bridge abort (e.g. the child
-      // process aborting a prompt mid-flight) — leaving the client
-      // with no response and no log trace. If `abort.signal.aborted`
-      // is false, the AbortError came from somewhere we didn't
-      // expect → route it through `sendBridgeError` as a real
-      // failure.
-      if (
-        err instanceof DOMException &&
-        err.name === 'AbortError' &&
-        abort.signal.aborted
-      ) {
-        return;
-      }
-      sendBridgeError(res, err, {
-        route: 'POST /session/:id/prompt',
-        sessionId,
+        {
+          ...(clientId !== undefined ? { clientId } : {}),
+          promptId,
+        },
+      )
+      .finally(() => {
+        if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
+      })
+      .catch(() => {
+        // Swallowed — `turn_error` already published on the SSE bus.
       });
-    } finally {
-      res.off('close', onResClose);
-      if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
-    }
+
+    res.status(202).json({ promptId, lastEventId });
   });
 
   app.post('/session/:id/heartbeat', mutate(), (req, res) => {

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -1447,8 +1447,6 @@ export function createServeApp(
     const forwardedBody = { ...body };
     delete forwardedBody['deadlineMs'];
 
-    // Snapshot the event bus cursor BEFORE enqueuing so the client can
-    // start SSE from this point without missing `turn_complete`.
     let lastEventId: number;
     try {
       lastEventId = bridge.getSessionLastEventId(sessionId);
@@ -1460,9 +1458,6 @@ export function createServeApp(
       return;
     }
 
-    // Non-blocking: fire-and-forget. The bridge publishes
-    // `turn_complete` / `turn_error` on the SSE bus when done;
-    // deadline enforcement still aborts the prompt server-side.
     const abort = new AbortController();
     const effectiveDeadlineMs = resolvePromptDeadlineMs(
       opts.promptDeadlineMs,
@@ -1495,9 +1490,7 @@ export function createServeApp(
       .finally(() => {
         if (deadlineTimer !== undefined) clearTimeout(deadlineTimer);
       })
-      .catch(() => {
-        // Swallowed — `turn_error` already published on the SSE bus.
-      });
+      .catch(() => {});
 
     res.status(202).json({ promptId, lastEventId });
   });

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -1238,14 +1238,12 @@ export class DaemonClient {
   }
 
   /**
-   * Send a prompt to the agent. Long-lived: a model + tool turn can
-   * take minutes, so this method bypasses `fetchTimeoutMs` (which
-   * would force a default 30s deadline that's too short for normal
-   * use). Cancellation is via the optional `signal` — when it fires,
-   * the daemon receives the underlying TCP close and forwards an
-   * ACP `cancel` notification to the agent, resolving the prompt
-   * with `stopReason: 'cancelled'`. `cancel(sessionId)` is the
-   * out-of-band alternative.
+   * Send a prompt to the agent. Supports both blocking (legacy 200)
+   * and non-blocking (202 + SSE `turn_complete`) daemon responses.
+   *
+   * Cancellation is via the optional `signal` — on 202 daemons this
+   * calls `cancel()` out-of-band; on legacy 200 daemons the TCP
+   * close propagates to the agent.
    */
   async prompt(
     sessionId: string,
@@ -1262,8 +1260,82 @@ export class DaemonClient {
         signal,
       },
     );
+
+    if (res.status === 202) {
+      const accept = (await res.json()) as {
+        promptId: string;
+        lastEventId: number;
+      };
+      return this._awaitTurnComplete(
+        sessionId,
+        accept.promptId,
+        accept.lastEventId,
+        signal,
+        clientId,
+      );
+    }
+
     if (!res.ok) throw await this.failOnError(res, 'POST /session/:id/prompt');
     return (await res.json()) as PromptResult;
+  }
+
+  private async _awaitTurnComplete(
+    sessionId: string,
+    promptId: string,
+    lastEventId: number,
+    signal?: AbortSignal,
+    clientId?: string,
+  ): Promise<PromptResult> {
+    const sseAbort = new AbortController();
+    const composedSignal = signal
+      ? composeAbortSignals([signal, sseAbort.signal])
+      : sseAbort.signal;
+
+    try {
+      const events = this.subscribeEvents(sessionId, {
+        lastEventId,
+        signal: composedSignal,
+      });
+      for await (const event of events) {
+        if (event.type === 'turn_complete') {
+          const data = event.data as {
+            promptId?: string;
+            stopReason?: string;
+          };
+          if (data.promptId === promptId) {
+            return { stopReason: data.stopReason ?? 'end_turn' };
+          }
+        }
+        if (event.type === 'turn_error') {
+          const data = event.data as {
+            promptId?: string;
+            message?: string;
+            code?: string;
+          };
+          if (data.promptId === promptId) {
+            const err = new DaemonHttpError(
+              500,
+              data.code ?? 'turn_error',
+              data.message ?? 'Prompt failed',
+            );
+            throw err;
+          }
+        }
+      }
+      throw new Error('SSE stream ended without turn completion');
+    } catch (err) {
+      if (
+        signal?.aborted &&
+        err instanceof DOMException &&
+        err.name === 'AbortError'
+      ) {
+        this.cancel(sessionId, clientId).catch(() => {});
+        throw err;
+      }
+      throw err;
+    } finally {
+      if (!sseAbort.signal.aborted) sseAbort.abort();
+    }
   }
 
   /**

--- a/packages/sdk-typescript/src/daemon/DaemonClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonClient.ts
@@ -247,6 +247,15 @@ export interface PromptRequest {
   [key: string]: unknown;
 }
 
+/**
+ * 202 Accepted envelope returned by non-blocking
+ * `POST /session/:id/prompt`.
+ */
+export interface NonBlockingPromptAccepted {
+  promptId: string;
+  lastEventId: number;
+}
+
 export interface SubscribeOptions {
   /** Resume from after this event id (`Last-Event-ID` header). */
   lastEventId?: number;
@@ -1241,9 +1250,12 @@ export class DaemonClient {
    * Send a prompt to the agent. Supports both blocking (legacy 200)
    * and non-blocking (202 + SSE `turn_complete`) daemon responses.
    *
-   * Cancellation is via the optional `signal` — on 202 daemons this
-   * calls `cancel()` out-of-band; on legacy 200 daemons the TCP
-   * close propagates to the agent.
+   * For 202 daemons this opens a **temporary** SSE subscription to
+   * await the matching `turn_complete`/`turn_error`. Callers that
+   * already manage a long-lived SSE subscription (e.g.
+   * `DaemonSessionClient`) should prefer {@link promptNonBlocking}
+   * and correlate via their existing event stream to avoid the extra
+   * connection.
    */
   async prompt(
     sessionId: string,
@@ -1262,10 +1274,7 @@ export class DaemonClient {
     );
 
     if (res.status === 202) {
-      const accept = (await res.json()) as {
-        promptId: string;
-        lastEventId: number;
-      };
+      const accept = (await res.json()) as NonBlockingPromptAccepted;
       return this._awaitTurnComplete(
         sessionId,
         accept.promptId,
@@ -1273,6 +1282,44 @@ export class DaemonClient {
         signal,
         clientId,
       );
+    }
+
+    if (!res.ok) throw await this.failOnError(res, 'POST /session/:id/prompt');
+    return (await res.json()) as PromptResult;
+  }
+
+  /**
+   * Fire-and-forget prompt trigger. Returns the 202 acceptance
+   * envelope (`{ promptId, lastEventId }`) without waiting for the
+   * turn to complete. The caller is responsible for observing
+   * `turn_complete` / `turn_error` on the session's SSE stream,
+   * matching by `promptId`.
+   *
+   * This is the recommended path for callers that already maintain a
+   * long-lived SSE subscription (like `DaemonSessionClient`) —
+   * avoids the extra SSE connection that {@link prompt} opens for
+   * the temporary 202 fallback.
+   *
+   * Falls back to `prompt()` for legacy 200 daemons.
+   */
+  async promptNonBlocking(
+    sessionId: string,
+    req: PromptRequest,
+    signal?: AbortSignal,
+    clientId?: string,
+  ): Promise<NonBlockingPromptAccepted | PromptResult> {
+    const res = await this._fetch(
+      `${this.baseUrl}/session/${encodeURIComponent(sessionId)}/prompt`,
+      {
+        method: 'POST',
+        headers: this.headers({ 'Content-Type': 'application/json' }, clientId),
+        body: JSON.stringify(req),
+        signal,
+      },
+    );
+
+    if (res.status === 202) {
+      return (await res.json()) as NonBlockingPromptAccepted;
     }
 
     if (!res.ok) throw await this.failOnError(res, 'POST /session/:id/prompt');
@@ -1297,30 +1344,8 @@ export class DaemonClient {
         signal: composedSignal,
       });
       for await (const event of events) {
-        if (event.type === 'turn_complete') {
-          const data = event.data as {
-            promptId?: string;
-            stopReason?: string;
-          };
-          if (data.promptId === promptId) {
-            return { stopReason: data.stopReason ?? 'end_turn' };
-          }
-        }
-        if (event.type === 'turn_error') {
-          const data = event.data as {
-            promptId?: string;
-            message?: string;
-            code?: string;
-          };
-          if (data.promptId === promptId) {
-            const err = new DaemonHttpError(
-              500,
-              data.code ?? 'turn_error',
-              data.message ?? 'Prompt failed',
-            );
-            throw err;
-          }
-        }
+        const result = matchTurnEvent(event, promptId);
+        if (result !== undefined) return result;
       }
       throw new Error('SSE stream ended without turn completion');
     } catch (err) {
@@ -1841,4 +1866,47 @@ export function composeAbortSignals(signals: AbortSignal[]): AbortSignal {
   // (e.g. its consumer aborted independently — defense-in-depth).
   ctrl.signal.addEventListener('abort', detachAll, { once: true });
   return ctrl.signal;
+}
+
+/**
+ * Check whether a daemon SSE event is a `turn_complete` or
+ * `turn_error` matching `promptId`. Returns `PromptResult` on
+ * `turn_complete`, throws `DaemonHttpError` on `turn_error`,
+ * returns `undefined` for non-matching / unrelated events.
+ *
+ * Extracted so both `DaemonClient._awaitTurnComplete` (temporary SSE
+ * fallback) and `DaemonSessionClient.prompt` (existing subscription
+ * path) share the same matching logic.
+ */
+export function matchTurnEvent(
+  event: DaemonEvent,
+  promptId: string,
+): PromptResult | undefined {
+  if (event.type === 'turn_complete') {
+    const data = event.data as { promptId?: string; stopReason?: string };
+    if (data.promptId === promptId) {
+      return { stopReason: data.stopReason ?? 'end_turn' };
+    }
+  }
+  if (event.type === 'turn_error') {
+    const data = event.data as {
+      promptId?: string;
+      message?: string;
+      code?: string;
+    };
+    if (data.promptId === promptId) {
+      throw new DaemonHttpError(
+        500,
+        data.code ?? 'turn_error',
+        data.message ?? 'Prompt failed',
+      );
+    }
+  }
+  return undefined;
+}
+
+export function isNonBlockingAccepted(
+  result: NonBlockingPromptAccepted | PromptResult,
+): result is NonBlockingPromptAccepted {
+  return 'promptId' in result && 'lastEventId' in result;
 }

--- a/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
@@ -441,6 +441,7 @@ export class DaemonSessionClient {
   }
 
   private _dispatchTurnEvent(event: DaemonEvent): void {
+    if (event.type !== 'turn_complete' && event.type !== 'turn_error') return;
     const promptId = (event.data as { promptId?: string } | null | undefined)
       ?.promptId;
     if (!promptId) return;

--- a/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
@@ -223,17 +223,24 @@ export class DaemonSessionClient {
     }
 
     return new Promise<PromptResult>((resolve, reject) => {
-      this._pendingPrompts.set(accepted.promptId, { resolve, reject });
-      signal?.addEventListener(
-        'abort',
-        () => {
-          if (this._pendingPrompts.delete(accepted.promptId)) {
-            this.client.cancel(this.sessionId, this.clientId).catch(() => {});
-            reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
-          }
+      const onAbort = () => {
+        if (this._pendingPrompts.delete(accepted.promptId)) {
+          this.client.cancel(this.sessionId, this.clientId).catch(() => {});
+          reject(signal!.reason ?? new DOMException('Aborted', 'AbortError'));
+        }
+      };
+      const cleanup = () => signal?.removeEventListener('abort', onAbort);
+      this._pendingPrompts.set(accepted.promptId, {
+        resolve: (r) => {
+          cleanup();
+          resolve(r);
         },
-        { once: true },
-      );
+        reject: (e) => {
+          cleanup();
+          reject(e);
+        },
+      });
+      signal?.addEventListener('abort', onAbort, { once: true });
     });
   }
 

--- a/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
@@ -6,6 +6,8 @@
 
 import type { DaemonClient } from './DaemonClient.js';
 import {
+  isNonBlockingAccepted,
+  matchTurnEvent,
   type CreateSessionRequest,
   type PromptRequest,
   type RestoreSessionRequest,
@@ -66,6 +68,13 @@ export class DaemonSessionClient {
   readonly state: DaemonSessionState;
   private lastSeenEventId: number | undefined;
   private subscriptionActive = false;
+  private readonly _pendingPrompts = new Map<
+    string,
+    {
+      resolve: (r: PromptResult) => void;
+      reject: (e: unknown) => void;
+    }
+  >();
 
   constructor(opts: DaemonSessionClientOptions) {
     this.client = opts.client;
@@ -194,7 +203,38 @@ export class DaemonSessionClient {
     req: PromptRequest,
     signal?: AbortSignal,
   ): Promise<PromptResult> {
-    return await this.client.prompt(this.sessionId, req, signal, this.clientId);
+    if (!this.subscriptionActive) {
+      return await this.client.prompt(
+        this.sessionId,
+        req,
+        signal,
+        this.clientId,
+      );
+    }
+
+    const accepted = await this.client.promptNonBlocking(
+      this.sessionId,
+      req,
+      signal,
+      this.clientId,
+    );
+    if (!isNonBlockingAccepted(accepted)) {
+      return accepted;
+    }
+
+    return new Promise<PromptResult>((resolve, reject) => {
+      this._pendingPrompts.set(accepted.promptId, { resolve, reject });
+      signal?.addEventListener(
+        'abort',
+        () => {
+          if (this._pendingPrompts.delete(accepted.promptId)) {
+            this.client.cancel(this.sessionId, this.clientId).catch(() => {});
+            reject(signal.reason ?? new DOMException('Aborted', 'AbortError'));
+          }
+        },
+        { once: true },
+      );
+    });
   }
 
   async cancel(): Promise<void> {
@@ -378,13 +418,8 @@ export class DaemonSessionClient {
         ...subscribeOpts,
         lastEventId,
       })) {
+        this._dispatchTurnEvent(event);
         yield event;
-        // Cursor updates happen after the consumer resumes iteration. That
-        // avoids acknowledging an event before the adapter has processed it,
-        // but means `lastEventId` intentionally lags while the handler for the
-        // just-yielded event is still running.
-        // The cursor is a replay watermark, so it only moves forward even if a
-        // replayed or synthetic frame arrives with an older id.
         if (event.id !== undefined) {
           this.lastSeenEventId = Math.max(
             this.lastSeenEventId ?? 0,
@@ -393,8 +428,31 @@ export class DaemonSessionClient {
         }
       }
     } finally {
+      this._rejectAllPending(new Error('SSE stream ended'));
       release();
     }
+  }
+
+  private _dispatchTurnEvent(event: DaemonEvent): void {
+    const promptId = (event.data as { promptId?: string } | null | undefined)
+      ?.promptId;
+    if (!promptId) return;
+    const pending = this._pendingPrompts.get(promptId);
+    if (!pending) return;
+    this._pendingPrompts.delete(promptId);
+    try {
+      const result = matchTurnEvent(event, promptId);
+      if (result !== undefined) pending.resolve(result);
+    } catch (err) {
+      pending.reject(err);
+    }
+  }
+
+  private _rejectAllPending(err: unknown): void {
+    for (const [, pending] of this._pendingPrompts) {
+      pending.reject(err);
+    }
+    this._pendingPrompts.clear();
   }
 }
 

--- a/packages/sdk-typescript/src/daemon/events.ts
+++ b/packages/sdk-typescript/src/daemon/events.ts
@@ -99,6 +99,8 @@ const DAEMON_KNOWN_EVENT_TYPE_VALUES = [
   'followup_suggestion',
   'user_shell_command',
   'user_shell_result',
+  'turn_complete',
+  'turn_error',
 ] as const;
 
 const DAEMON_KNOWN_EVENT_TYPES: ReadonlySet<string> = new Set<string>(
@@ -622,6 +624,21 @@ export interface DaemonFollowupSuggestionData {
   [key: string]: unknown;
 }
 
+export interface DaemonTurnCompleteData {
+  sessionId: string;
+  stopReason: string;
+  promptId?: string;
+  [key: string]: unknown;
+}
+
+export interface DaemonTurnErrorData {
+  sessionId: string;
+  message: string;
+  code?: string;
+  promptId?: string;
+  [key: string]: unknown;
+}
+
 export type DaemonSessionUpdateEvent = DaemonEventEnvelope<
   'session_update',
   DaemonSessionUpdateData
@@ -745,6 +762,15 @@ export type DaemonFollowupSuggestionEvent = DaemonEventEnvelope<
   DaemonFollowupSuggestionData
 >;
 
+export type DaemonTurnCompleteEvent = DaemonEventEnvelope<
+  'turn_complete',
+  DaemonTurnCompleteData
+>;
+export type DaemonTurnErrorEvent = DaemonEventEnvelope<
+  'turn_error',
+  DaemonTurnErrorData
+>;
+
 export type DaemonAuthEvent =
   | DaemonAuthDeviceFlowStartedEvent
   | DaemonAuthDeviceFlowThrottledEvent
@@ -809,6 +835,8 @@ export type DaemonWorkspaceMutationEvent =
  */
 export type DaemonAssistEvent = DaemonFollowupSuggestionEvent;
 
+export type DaemonTurnEvent = DaemonTurnCompleteEvent | DaemonTurnErrorEvent;
+
 export type KnownDaemonEvent =
   | DaemonSessionEvent
   | DaemonControlEvent
@@ -816,7 +844,8 @@ export type KnownDaemonEvent =
   | DaemonMcpGuardrailEvent
   | DaemonWorkspaceMutationEvent
   | DaemonAuthEvent
-  | DaemonAssistEvent;
+  | DaemonAssistEvent
+  | DaemonTurnEvent;
 
 export interface DaemonSessionViewState {
   lastEventId?: number;
@@ -998,6 +1027,8 @@ export interface DaemonSessionViewState {
    * at least one suggestion.
    */
   lastFollowupSuggestion?: DaemonFollowupSuggestionData;
+  lastTurnComplete?: DaemonTurnCompleteData;
+  lastTurnError?: DaemonTurnErrorData;
 }
 
 /**
@@ -1260,6 +1291,14 @@ export function asKnownDaemonEvent(
     case 'followup_suggestion':
       return isFollowupSuggestionData(event.data)
         ? (event as DaemonFollowupSuggestionEvent)
+        : undefined;
+    case 'turn_complete':
+      return isTurnCompleteData(event.data)
+        ? (event as DaemonTurnCompleteEvent)
+        : undefined;
+    case 'turn_error':
+      return isTurnErrorData(event.data)
+        ? (event as DaemonTurnErrorEvent)
         : undefined;
     default:
       return undefined;
@@ -1609,6 +1648,16 @@ export function reduceDaemonSessionEvent(
       return {
         ...base,
         lastFollowupSuggestion: event.data,
+      };
+    case 'turn_complete':
+      return {
+        ...base,
+        lastTurnComplete: event.data,
+      };
+    case 'turn_error':
+      return {
+        ...base,
+        lastTurnError: event.data,
       };
     default: {
       const _exhaustive: never = event;
@@ -2309,6 +2358,22 @@ function isFollowupSuggestionData(
     isNonEmptyString(value['sessionId']) &&
     isNonEmptyString(value['suggestion']) &&
     isNonEmptyString(value['promptId'])
+  );
+}
+
+function isTurnCompleteData(value: unknown): value is DaemonTurnCompleteData {
+  return (
+    isRecord(value) &&
+    isNonEmptyString(value['sessionId']) &&
+    isNonEmptyString(value['stopReason'])
+  );
+}
+
+function isTurnErrorData(value: unknown): value is DaemonTurnErrorData {
+  return (
+    isRecord(value) &&
+    isNonEmptyString(value['sessionId']) &&
+    isNonEmptyString(value['message'])
   );
 }
 

--- a/packages/sdk-typescript/src/daemon/index.ts
+++ b/packages/sdk-typescript/src/daemon/index.ts
@@ -7,8 +7,11 @@
 export {
   DaemonClient,
   DaemonHttpError,
+  isNonBlockingAccepted,
+  matchTurnEvent,
   type CreateSessionRequest,
   type DaemonClientOptions,
+  type NonBlockingPromptAccepted,
   type PromptRequest,
   type RestoreSessionRequest,
   type SubscribeOptions,

--- a/packages/sdk-typescript/src/daemon/index.ts
+++ b/packages/sdk-typescript/src/daemon/index.ts
@@ -233,6 +233,12 @@ export type {
   DaemonAssistEvent,
   DaemonFollowupSuggestionData,
   DaemonFollowupSuggestionEvent,
+  // Non-blocking prompt completion events
+  DaemonTurnEvent,
+  DaemonTurnCompleteData,
+  DaemonTurnCompleteEvent,
+  DaemonTurnErrorData,
+  DaemonTurnErrorEvent,
   DaemonDeviceFlowReducerState,
   DaemonAuthState,
   KnownDaemonEvent,

--- a/packages/web-shell/client/hooks/useDaemonSession.ts
+++ b/packages/web-shell/client/hooks/useDaemonSession.ts
@@ -449,6 +449,15 @@ export function useDaemonSession(config: Partial<DaemonSessionConfig> = {}) {
               }
               store.dispatch(uiEvents);
               if (
+                event.type === 'turn_complete' &&
+                !activePromptsRef.current.has(activeSession.sessionId)
+              ) {
+                clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
+                const stopReason =
+                  (event.data as { stopReason?: string })?.stopReason ??
+                  'end_turn';
+                store.dispatch({ type: 'assistant.done', reason: stopReason });
+              } else if (
                 !activePromptsRef.current.has(activeSession.sessionId) &&
                 hasAssistantDelta(uiEvents)
               ) {

--- a/packages/web-shell/client/hooks/useDaemonSession.ts
+++ b/packages/web-shell/client/hooks/useDaemonSession.ts
@@ -454,8 +454,9 @@ export function useDaemonSession(config: Partial<DaemonSessionConfig> = {}) {
               ) {
                 clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
                 const stopReason =
-                  (event.data as { stopReason?: string })?.stopReason ??
-                  'end_turn';
+                  (
+                    event.data as import('@qwen-code/sdk/daemon').DaemonTurnCompleteData
+                  ).stopReason ?? 'end_turn';
                 store.dispatch({ type: 'assistant.done', reason: stopReason });
               } else if (
                 !activePromptsRef.current.has(activeSession.sessionId) &&

--- a/packages/web-shell/client/hooks/useDaemonSession.ts
+++ b/packages/web-shell/client/hooks/useDaemonSession.ts
@@ -459,6 +459,12 @@ export function useDaemonSession(config: Partial<DaemonSessionConfig> = {}) {
                   ).stopReason ?? 'end_turn';
                 store.dispatch({ type: 'assistant.done', reason: stopReason });
               } else if (
+                event.type === 'turn_error' &&
+                !activePromptsRef.current.has(activeSession.sessionId)
+              ) {
+                clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
+                store.dispatch({ type: 'assistant.done', reason: 'error' });
+              } else if (
                 !activePromptsRef.current.has(activeSession.sessionId) &&
                 hasAssistantDelta(uiEvents)
               ) {


### PR DESCRIPTION
## Summary

Closes #4582.

**POST `/session/:id/prompt` is now non-blocking**: returns `202 Accepted` immediately with `{ promptId, lastEventId }`. The prompt completion is delivered asynchronously via `turn_complete` / `turn_error` SSE events, correlated by `promptId`.

---

## 1. Prior Design Audit

### 1.1 Original Blocking Model

The original design (documented in [03-http-api.md](https://github.com/wenshao/codeagents/blob/main/docs/comparison/qwen-code-daemon-design/03-http-api.md)) established a **dual-channel parallel model**:
- **POST /prompt** → HTTP connection held open until turn completes (blocking, returns 200 with \`PromptResult\`)
- **GET /events** → SSE stream pushes real-time deltas (session_update, permission_request, etc.)

The blocking pattern was straightforward but coupled HTTP connection lifetime to LLM turn duration. The design doc explicitly shows \`Promise.race(bridge.sendPrompt, deadlinePromise)\` as the timeout mechanism, returning 504 on deadline breach.

### 1.2 Problems with the Blocking Approach

1. **Proxy/LB timeouts**: Reverse proxies (nginx default 60s, ALB 60s) enforce idle-connection deadlines shorter than typical agent turns (minutes with tool calls).
2. **Deadline coupling**: T2.9 \`promptDeadlineMs\` used \`Promise.race\` to emit HTTP 504 — clients had to handle two distinct error shapes (structured 504 JSON vs SSE events).
3. **Client disconnect ambiguity**: TCP reset could mean "user cancelled" or "network hiccup". \`res.on('close')\` conflated intentional cancellation with transient failures.
4. **Resource pinning**: Each in-flight prompt held an Express response object open for the entire turn duration.

### 1.3 External Design Doc Comparison

The [external design document](https://github.com/wenshao/codeagents/blob/main/docs/comparison/qwen-code-daemon-design/03-http-api.md) describes the **original blocking + SSE** architecture. Notably:
- **No mention of \`promptId\`, \`turn_complete\`, or \`turn_error\`** — these are new concepts
- The doc's event type enumeration (~14 types) does not include turn lifecycle events
- The design relies on HTTP response completion as the implicit "turn done" signal

This PR extends the original design: the SSE channel now carries explicit turn lifecycle events, and the HTTP POST becomes a lightweight trigger.

---

## 2. /acp Transport Prior Art — Design Choice Rationale

### 2.1 /acp's Non-Blocking Pattern

The \`/acp\` route (PR #4472, MCP Streamable HTTP transport) already implements 202:
- POST to \`/acp\` always returns \`202 Accepted\` (HTTP layer non-blocking)
- Results are delivered via a long-lived SSE session stream
- The transport layer internally manages request-response correlation

### 2.2 Why We Follow the /acp Pattern (Not Opt-In)

**Initial proposal**: Use \`Prefer: respond-async\` header for opt-in non-blocking, keeping 200 blocking as default.

**Problems with opt-in**:
- Dual code paths in server (blocking + non-blocking) increase maintenance burden
- Inconsistent with /acp which is unconditionally 202
- The \`Prefer\` header is not part of the HTTP Streamable Transport proposal

**Final approach (follows /acp)**: Unconditional 202, like the MCP Streamable HTTP transport. SDK handles the correlation transparently, just as the ACP transport layer routes JSON-RPC responses to pending requests.

| Aspect | /acp Transport | REST /prompt (this PR) |
|--------|---------------|----------------------|
| HTTP response | Always 202 | Always 202 (was 200) |
| Result delivery | JSON-RPC response in session SSE | \`turn_complete\`/\`turn_error\` in session SSE |
| Correlation | JSON-RPC \`id\` | \`promptId\` (UUID) |
| SDK event routing | Transport layer dispatches to pending requests | \`DaemonSessionClient._pendingPrompts\` map dispatches to pending Promises |

---

## 3. Architecture Impact Analysis

### 3.1 Bridge Layer (Additive Only)

- \`broadcastTurnComplete()\` / \`broadcastTurnError()\` — side-effect \`.then()\` on the sendPrompt result promise, **unconditionally** published regardless of HTTP response mode
- \`getSessionLastEventId()\` — reads \`entry.events.lastEventId\` (existing EventBus property)
- FIFO queue, ACP child lifecycle — completely unaffected

### 3.2 EventBus & SSE (Correctness Argument)

1. Server snapshots \`lastEventId\` **before** calling \`sendPrompt\`
2. 202 response carries this \`lastEventId\` to the client
3. \`DaemonSessionClient\` already has SSE running → \`_dispatchTurnEvent\` catches the matching event
4. Fallback path: SDK opens temporary SSE with \`Last-Event-ID\` replay

Ring buffer (default 8000 frames) guarantees no event loss in the snapshot-to-dispatch window.

### 3.3 SDK — Two-Tier Design (Following ACP Transport Pattern)

**\`DaemonClient\` (stateless HTTP layer)**:
- \`promptNonBlocking()\` — sends POST, returns \`{ promptId, lastEventId }\` for 202
- \`prompt()\` — sends POST, handles 202 via temporary SSE fallback (for standalone callers without existing subscription)
- \`matchTurnEvent()\` — shared utility for turn event correlation

**\`DaemonSessionClient\` (stateful transport layer, like ACP)**:
- \`_pendingPrompts: Map<promptId, { resolve, reject }>\` — mirrors ACP transport's pending-request dispatch table
- \`prompt()\` → when SSE subscription is active, uses \`promptNonBlocking()\` and registers pending entry; otherwise falls back to \`DaemonClient.prompt()\` with temporary SSE
- \`iterateEvents()\` → intercepts \`turn_complete\`/\`turn_error\` via \`_dispatchTurnEvent()\` and resolves pending Promises **before** yielding to the consumer
- SSE stream end → \`_rejectAllPending()\` cleans up

**Consumer impact: ZERO.** \`DaemonSessionClient.prompt()\` still returns \`Promise<PromptResult>\` — WebUI, web-shell, IDE providers all work unchanged.

### 3.4 Web-Shell (Passive Observer Enhancement)

Adds \`turn_complete\` event handling for passive session viewers (non-prompt-originating tabs). Replaces the heuristic idle-timer for \`assistant.done\` dispatch.

### 3.5 Capability Tag

\`non_blocking_prompt: { since: 'v1' }\` — baseline (always-on) tag for client feature detection.

---

## 4. Backward Compatibility

| Scenario | Impact |
|----------|--------|
| SDK consumers (\`DaemonSessionClient.prompt()\`) | **None** — same \`Promise<PromptResult>\` API |
| SDK consumers (\`DaemonClient.prompt()\`) | **None** — 202 handled via temp SSE fallback |
| Raw HTTP clients | **Breaking** — 200→202, response body changed. Mitigated by \`non_blocking_prompt\` capability tag |
| Old SDK + New daemon | \`res.ok\` true for 202, body parsed as \`PromptResult\` with \`stopReason: undefined\`. Daemon+SDK co-released |
| New SDK + Old daemon | \`prompt()\` receives 200, handled by legacy path. \`promptNonBlocking()\` returns \`PromptResult\` directly |

---

## 5. Feasibility Conclusion

**Feasible and architecturally sound.** Supporting arguments:
1. **/acp prior art validates the pattern** — same codebase, proven in production
2. **Bridge layer unaffected** — FIFO queue and ACP child lifecycle independent of HTTP response
3. **EventBus replay guarantees correctness** — ring buffer closes the race window
4. **SDK upgrade transparent** — two-tier design with ACP-style pending-request dispatch
5. **turn events have independent value** — passive observers benefit regardless of HTTP layer

**Risks to monitor**:
- Ring buffer overflow during snapshot-to-SSE window (theoretical, extremely unlikely)
- Orphan prompts if client disconnects (prompt runs to completion, result published to SSE bus)

---

## Changes

- **Bridge** (\`acp-bridge\`): publishes \`turn_complete\` / \`turn_error\` SSE events unconditionally; exposes \`getSessionLastEventId()\`
- **Server** (\`cli/serve\`): POST /prompt returns 202 with \`{ promptId, lastEventId }\`; deadline timer aborts via abort signal, outcome surfaced via \`turn_error\` SSE
- **SDK \`DaemonClient\`**: \`promptNonBlocking()\` + \`matchTurnEvent()\` utility; \`prompt()\` retains temp SSE fallback
- **SDK \`DaemonSessionClient\`**: ACP-style pending-prompt dispatch via existing SSE subscription
- **Web-shell**: observes \`turn_complete\` for passive session viewers
- **Capability**: \`non_blocking_prompt\` baseline tag

## Test plan

- [x] 337 \`server.test.ts\` tests pass
- [x] 205 \`bridge.test.ts\` tests pass
- [x] 5 \`daemon-public-surface.test.ts\` tests pass
- [x] SDK + CLI TypeScript compilation clean
- [ ] Manual: start daemon, send prompt via curl, verify 202 + SSE turn_complete
- [ ] Manual: test deadline expiry → verify turn_error SSE event with promptId

Generated with AI