### PR TITLE
fix(core): remove proactive subagent system-reminder injection

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -215,9 +215,6 @@ describe('Session', () => {
 
     mockToolRegistry = {
       getTool: vi.fn(),
-      // #executePrompt → #buildInitialSystemReminders calls
-      // getToolRegistry().ensureTool(ToolNames.AGENT) on every session.prompt(),
-      // so the default mock must provide it (#1151 / #3479).
       ensureTool: vi.fn().mockResolvedValue(true),
     };
     const fileService = { shouldGitIgnoreFile: vi.fn().mockReturnValue(false) };
@@ -239,12 +236,6 @@ describe('Session', () => {
         .fn()
         .mockReturnValue(mockChatRecordingService),
       getToolRegistry: vi.fn().mockReturnValue(mockToolRegistry),
-      // #buildInitialSystemReminders iterates listSubagents() on every
-      // session.prompt(). Default to an empty list so tests that don't
-      // exercise subagent reminders don't need to stub it (#1151 / #3479).
-      getSubagentManager: vi.fn().mockReturnValue({
-        listSubagents: vi.fn().mockResolvedValue([]),
-      }),
       getFileService: vi.fn().mockReturnValue(fileService),
       getFileFilteringRespectGitIgnore: vi.fn().mockReturnValue(true),
       getEnableRecursiveFileSearch: vi.fn().mockReturnValue(false),
@@ -2874,20 +2865,7 @@ describe('Session', () => {
         return capture;
       };
 
-      const stubEmptySubagents = () => {
-        (mockConfig as unknown as Record<string, unknown>)[
-          'getSubagentManager'
-        ] = vi.fn().mockReturnValue({
-          listSubagents: vi.fn().mockResolvedValue([]),
-        });
-        // ensureTool is called on the result of getToolRegistry(); add it.
-        (
-          mockToolRegistry as unknown as { ensureTool: () => Promise<boolean> }
-        ).ensureTool = vi.fn().mockResolvedValue(true);
-      };
-
       it('prepends plan-mode reminder when approval mode is PLAN (#1151)', async () => {
-        stubEmptySubagents();
         mockConfig.getApprovalMode = vi.fn().mockReturnValue(ApprovalMode.PLAN);
         const capture = captureFirstTurnMessage();
 
@@ -2910,7 +2888,6 @@ describe('Session', () => {
       });
 
       it('does not prepend plan-mode reminder in default approval mode', async () => {
-        stubEmptySubagents();
         mockConfig.getApprovalMode = vi
           .fn()
           .mockReturnValue(ApprovalMode.DEFAULT);
@@ -2925,40 +2902,6 @@ describe('Session', () => {
           (p) => p.text && p.text.includes('Plan mode is active'),
         );
         expect(hasPlanReminder).toBe(false);
-      });
-
-      it('prepends subagent reminder when user-level subagents exist', async () => {
-        (mockConfig as unknown as Record<string, unknown>)[
-          'getSubagentManager'
-        ] = vi.fn().mockReturnValue({
-          listSubagents: vi.fn().mockResolvedValue([
-            { name: 'researcher', level: 'user' },
-            { name: 'planner', level: 'project' },
-            // builtin entries are filtered out, matching client.ts:853.
-            { name: 'builtin-helper', level: 'builtin' },
-          ]),
-        });
-        (
-          mockToolRegistry as unknown as { ensureTool: () => Promise<boolean> }
-        ).ensureTool = vi.fn().mockResolvedValue(true);
-        mockConfig.getApprovalMode = vi
-          .fn()
-          .mockReturnValue(ApprovalMode.DEFAULT);
-        const capture = captureFirstTurnMessage();
-
-        await session.prompt({
-          sessionId: 'test-session-id',
-          prompt: [{ type: 'text', text: 'hi' }],
-        });
-
-        const reminder = capture.parts.find(
-          (p) =>
-            p.text &&
-            p.text.includes('researcher') &&
-            p.text.includes('planner'),
-        );
-        expect(reminder).toBeTruthy();
-        expect(reminder!.text).not.toContain('builtin-helper');
       });
     });
   });

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -52,7 +52,6 @@ import {
   generateToolUseId,
   MessageBusType,
   getPlanModeSystemReminder,
-  getSubagentSystemReminder,
   getArenaSystemReminder,
   STARTUP_CONTEXT_MODEL_ACK,
   evaluatePermissionFlow,
@@ -1737,16 +1736,6 @@ export class Session implements SessionContext {
    */
   async #buildInitialSystemReminders(): Promise<Part[]> {
     const reminders: Part[] = [];
-
-    const hasAgentTool = await this.config
-      .getToolRegistry()
-      .ensureTool(ToolNames.AGENT);
-    const subagents = (await this.config.getSubagentManager().listSubagents())
-      .filter((subagent) => subagent.level !== 'builtin')
-      .map((subagent) => subagent.name);
-    if (hasAgentTool && subagents.length > 0) {
-      reminders.push({ text: getSubagentSystemReminder(subagents) });
-    }
 
     if (this.config.getApprovalMode() === ApprovalMode.PLAN) {
       reminders.push({

--- a/packages/cli/src/acp-integration/session/Session.worktree.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.worktree.test.ts
@@ -116,12 +116,7 @@ describe('Session.pendingWorktreeNotice', () => {
       }),
       getToolRegistry: vi.fn().mockReturnValue({
         getTool: vi.fn(),
-        // Called on every prompt() via #buildInitialSystemReminders
         ensureTool: vi.fn().mockResolvedValue(true),
-      }),
-      // Called on every prompt() to check subagent system reminders
-      getSubagentManager: vi.fn().mockReturnValue({
-        listSubagents: vi.fn().mockResolvedValue([]),
       }),
       getFileService: vi.fn().mockReturnValue({
         shouldGitIgnoreFile: vi.fn().mockReturnValue(false),

--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -418,10 +418,6 @@ describe('Gemini Client (client.ts)', () => {
       vertexai: false,
       authType: AuthType.USE_GEMINI,
     };
-    const mockSubagentManager = {
-      listSubagents: vi.fn().mockResolvedValue([]),
-      addChangeListener: vi.fn().mockReturnValue(() => {}),
-    };
     mockConfig = {
       getContentGeneratorConfig: vi
         .fn()
@@ -473,7 +469,6 @@ describe('Gemini Client (client.ts)', () => {
       },
       getContentGenerator: vi.fn().mockReturnValue(mockContentGenerator),
       getBaseLlmClient: vi.fn(),
-      getSubagentManager: vi.fn().mockReturnValue(mockSubagentManager),
       getSkipLoopDetection: vi.fn().mockReturnValue(false),
       getChatRecordingService: vi.fn().mockReturnValue(undefined),
       getResumedSessionData: vi.fn().mockReturnValue(undefined),

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -36,7 +36,6 @@ import {
   getCoreSystemPrompt,
   getCustomSystemPrompt,
   getPlanModeSystemReminder,
-  getSubagentSystemReminder,
 } from './prompts.js';
 import {
   CompressionStatus,
@@ -1609,20 +1608,6 @@ export class GeminiClient {
         messageType === SendMessageType.Cron
       ) {
         const systemReminders = [];
-
-        // add subagent system reminder if there are subagents
-        const hasAgentTool = await this.config
-          .getToolRegistry()
-          .ensureTool(ToolNames.AGENT);
-        const subagents = (
-          await this.config.getSubagentManager().listSubagents()
-        )
-          .filter((subagent) => subagent.level !== 'builtin')
-          .map((subagent) => subagent.name);
-
-        if (hasAgentTool && subagents.length > 0) {
-          systemReminders.push(getSubagentSystemReminder(subagents));
-        }
 
         // add plan mode system reminder if approval mode is plan
         if (this.config.getApprovalMode() === ApprovalMode.PLAN) {

--- a/packages/core/src/core/prompts.test.ts
+++ b/packages/core/src/core/prompts.test.ts
@@ -9,7 +9,6 @@ import {
   buildDeferredToolsSection,
   getCoreSystemPrompt,
   getCustomSystemPrompt,
-  getSubagentSystemReminder,
   getPlanModeSystemReminder,
   resolvePathFromEnv,
 } from './prompts.js';
@@ -451,31 +450,6 @@ describe('getCustomSystemPrompt', () => {
       'You are a code assistant. Always provide examples.\n\n---\n\nUser prefers TypeScript examples.',
     );
     expect(result).toContain('---');
-  });
-});
-
-describe('getSubagentSystemReminder', () => {
-  it('should format single agent type correctly', () => {
-    const result = getSubagentSystemReminder(['python']);
-
-    expect(result).toMatch(/^<system-reminder>.*<\/system-reminder>$/);
-    expect(result).toContain('available agent types are: python');
-    expect(result).toContain('PROACTIVELY use the');
-  });
-
-  it('should join multiple agent types with commas', () => {
-    const result = getSubagentSystemReminder(['python', 'web', 'analysis']);
-
-    expect(result).toContain(
-      'available agent types are: python, web, analysis',
-    );
-  });
-
-  it('should handle empty array', () => {
-    const result = getSubagentSystemReminder([]);
-
-    expect(result).toContain('available agent types are: ');
-    expect(result).toContain('<system-reminder>');
   });
 });
 

--- a/packages/core/src/core/prompts.ts
+++ b/packages/core/src/core/prompts.ts
@@ -897,26 +897,6 @@ function getToolCallExamples(model?: string): string {
 }
 
 /**
- * Generates a system reminder message about available subagents for the AI assistant.
- *
- * This function creates an internal system message that informs the AI about specialized
- * agents it can delegate tasks to. The reminder encourages proactive use of the TASK tool
- * when user requests match agent capabilities.
- *
- * @param agentTypes - Array of available agent type names (e.g., ['python', 'web', 'analysis'])
- * @returns A formatted system reminder string wrapped in XML tags for internal AI processing
- *
- * @example
- * ```typescript
- * const reminder = getSubagentSystemReminder(['python', 'web']);
- * // Returns: "<system-reminder>You have powerful specialized agents..."
- * ```
- */
-export function getSubagentSystemReminder(agentTypes: string[]): string {
-  return `<system-reminder>You have powerful specialized agents at your disposal, available agent types are: ${agentTypes.join(', ')}. PROACTIVELY use the ${ToolNames.AGENT} tool to delegate user's task to appropriate agent when user's task matches agent capabilities. Ignore this message if user's task is not relevant to any agent. This message is for internal use only. Do not mention this to user in your response.</system-reminder>`;
-}
-
-/**
  * Generates a system reminder message for plan mode operation.
  *
  * This function creates an internal system message that enforces plan mode constraints,


### PR DESCRIPTION
## What this PR does

Removes the runtime system-reminder that was injected every conversation turn, which commanded the model to "PROACTIVELY use the Agent tool to delegate user's task to appropriate agent." This eliminates a redundant and overly aggressive prompt injection while keeping agent discoverability and per-agent proactivity fully intact through the static tool description.

## Why it's needed

The Agent tool's own description already does the two useful things this reminder did:

1. Lists available agents so the model knows they exist and can invoke them.
2. Honors per-agent proactivity — if an agent's description says it should be used proactively, the tool description already instructs the model to do so.

The only thing the runtime reminder uniquely added on top of that was a blanket "PROACTIVELY delegate any matching task" push, applied every turn regardless of context. This is problematic for two reasons:

- It's redundant. The tool description already provides full agent discoverability and proactivity guidance. Injecting the same information again as a system-reminder is pure duplication.
- It's overly aggressive. A blanket "PROACTIVELY delegate" nudge tips the balance from "use agents when genuinely beneficial" toward "use agents by default," which can lead to unnecessary subagent spawning — especially in scenarios where direct tool use would be more effective. Subagent delegation inherently involves context isolation (each subagent starts with zero context and returns only a summary), so over-spawning risks information loss and redundant exploration.

Removing the reminder eliminates this one aggressive nudge and reduces prompt duplication, while leaving the model's ability to discover and use agents — including proactive ones — completely unchanged.

## Reviewer Test Plan

### How to verify

1. Confirm that the model still discovers and invokes agents when their tool description indicates they should be used (especially agents marked as proactive).
2. Confirm that the model no longer receives a system-reminder pushing blanket subagent delegation on every turn.
3. Run any task that involves subagent usage and verify that agents are still invoked when appropriate, but not over-spawned.

### Evidence (Before & After)

None


### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

### Environment (optional)
## Risk & Scope

- **Main risk:**  User-defined agents that relied on the blanket proactive reminder to be auto-triggered may be invoked slightly less often. However, the tool description still contains guidance to proactively use agents whose description says so — explicitly proactive agents remain triggered.
- **Not validated:** N/A
- **Breaking changes:** None. This is a prompt-only change with no API or config surface changes.

## Linked Issues

N/A — discovered through SWE-bench trajectory analysis comparing Qwen Code vs Claude Code.

