### PR TITLE
fix(tui): Tighten message and tool spacing

### DIFF
--- a/.qwen/design/tui-spacing-density-pr1.md
+++ b/.qwen/design/tui-spacing-density-pr1.md
@@ -55,14 +55,15 @@ use fewer visible rows:
 
 ## Measurement
 
-The automated spacing assertions use 100-column fixtures for the changed rules:
+The automated spacing assertions and terminal evidence use 100-column fixtures
+for the changed rules:
 
 | Scenario | Width | Baseline rows | PR1 rows | Delta | Evidence |
 | --- | ---: | ---: | ---: | ---: | --- |
 | Simple assistant reply | 100 | 2 | 1 | -1 | leading history spacer removed |
 | Tool header with one-line result | 100 | 3 | 2 | -1 | header and result are adjacent |
-| Two-tool expanded group | 100 | 5 | 4 | -1 | inter-tool separator removed |
-| Three-tool expanded group | 100 | 7 | 5 | -2 | one removed separator between each adjacent tool |
+| Three-tool expanded group with rendered results | 100 | 16 | 11 | -5 | one header/result spacer removed per tool result and one inter-tool separator removed between adjacent tools |
+| Full representative fixture | 100 | 26 | 19 | -7 | same rendered content captured in tmux |
 
 The snapshot diffs also cover the existing 80-column fixtures to confirm the
 same row-count deltas in the current component test harness.

--- a/.qwen/design/tui-spacing-density-pr1.md
+++ b/.qwen/design/tui-spacing-density-pr1.md
@@ -1,0 +1,78 @@
+# TUI Spacing And Density PR1
+
+## Why
+
+The current TUI often spends extra rows on spacing before assistant output,
+between status/tool blocks, and inside expanded tool groups. In common
+sessions this makes simple answers, file lists, tool output, error states,
+diffs, and long streaming output harder to scan because users need to scroll
+through blank space rather than content.
+
+This PR is the first focused pass for QwenLM/qwen-code#4588. It addresses only
+spacing and density so the review can compare row usage before and after
+without also reviewing thinking visibility, tool borders, SubAgent layout,
+branding, or theme color changes.
+
+## How
+
+The implementation keeps the existing information structure and rendering
+surfaces intact:
+
+- History item spacing is centralized near `HistoryItemDisplay`. User prompts
+  and standalone command views still start with a turn separator, while
+  assistant continuations, tool groups, status messages, tool summaries, and
+  related in-turn output no longer add an extra leading spacer row.
+- Expanded tool groups keep their current border and status/title structure,
+  but no longer insert blank rows between adjacent tool entries.
+- Tool results render directly below the tool title/status row. This removes
+  the extra blank line between the tool header and its output without changing
+  output content, truncation, shell focus, confirmation prompts, or compact
+  mode behavior.
+
+Markdown blank-line behavior is intentionally left unchanged. The renderer
+already collapses consecutive blank lines to one spacer and preserves complex
+blocks such as tables, code blocks, and math blocks.
+
+## Spacing Standard
+
+- Independent user turns keep one visual separator.
+- Assistant output and in-turn follow-up blocks do not add a second separator.
+- Tool header and tool result content are adjacent.
+- Expanded multi-tool groups do not insert blank rows between each tool entry.
+- Complex Markdown blocks keep their existing internal layout.
+
+## Expected Effect
+
+Under the same terminal width and same rendered content, target scenarios should
+use fewer visible rows:
+
+- Simple Q&A should drop at least one visible row.
+- Expanded tool output should drop at least one row for each rendered tool
+  result that previously had a blank header/result spacer.
+- Multi-tool groups should drop one row between each adjacent tool entry.
+- Project inspection, diff, file-list, error, and long-stream scenarios should
+  not gain rows unless terminal wrapping changes make that unavoidable.
+
+## Measurement
+
+The automated spacing assertions use 100-column fixtures for the changed rules:
+
+| Scenario | Width | Baseline rows | PR1 rows | Delta | Evidence |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Simple assistant reply | 100 | 2 | 1 | -1 | leading history spacer removed |
+| Tool header with one-line result | 100 | 3 | 2 | -1 | header and result are adjacent |
+| Two-tool expanded group | 100 | 5 | 4 | -1 | inter-tool separator removed |
+| Three-tool expanded group | 100 | 7 | 5 | -2 | one removed separator between each adjacent tool |
+
+The snapshot diffs also cover the existing 80-column fixtures to confirm the
+same row-count deltas in the current component test harness.
+
+## Out Of Scope
+
+- Hiding thinking traces.
+- Removing tool borders.
+- Redesigning SubAgent output.
+- Changing startup branding or the banner.
+- Changing theme colors.
+- Adding per-turn assistant elapsed time.
+- Changing table inline-code highlighting.

--- a/.qwen/e2e-tests/tui-spacing-density-pr1.md
+++ b/.qwen/e2e-tests/tui-spacing-density-pr1.md
@@ -1,4 +1,4 @@
-# TUI Spacing And Density PR1 Evidence Plan
+# TUI Spacing And Density PR1 Evidence
 
 ## Goal
 
@@ -10,7 +10,11 @@ removing content or changing rendering scope.
 - Terminal width: 100 columns.
 - Compare the same prompt/output fixture before and after this PR.
 - Strip ANSI control sequences before counting visible rows.
-- Count only non-empty rendered terminal rows for the density metric.
+- Count rendered rows from the first non-empty fixture row through the last
+  non-empty fixture row. This keeps internal blank spacer rows in the metric
+  because those are the rows this PR removes.
+- The fixture renders the real Ink TUI components directly, so it does not
+  require a model call or network access.
 
 ## Scenarios
 
@@ -22,15 +26,36 @@ removing content or changing rendering scope.
 - Diff output.
 - Long streaming output.
 
-## Metrics
+## Commands
 
-For each scenario, record:
+Terminal capture:
 
-- Baseline visible row count.
-- PR1 visible row count.
-- Delta in rows.
-- Notes for any scenario that gains rows because of wrapping or fixed-width
-  content.
+```bash
+git checkout origin/main
+/tmp/qwen-pr1-spacing-evidence/run-tmux-capture.sh /Users/gawain/.codex/worktrees/tui-display-optimization-issue/qwen-code 'base origin/main 34b7d472e' base
+git switch codex/tui-spacing-density-pr1
+/tmp/qwen-pr1-spacing-evidence/run-tmux-capture.sh /Users/gawain/.codex/worktrees/tui-display-optimization-issue/qwen-code 'PR1 fixed 848d6a166' fixed
+```
+
+VHS visual capture:
+
+```bash
+git checkout origin/main
+PATH=/Users/gawain/.nvm/versions/node/v24.15.0/bin:$PATH vhs /tmp/qwen-pr1-spacing-evidence/base.tape
+git switch codex/tui-spacing-density-pr1
+PATH=/Users/gawain/.nvm/versions/node/v24.15.0/bin:$PATH vhs /tmp/qwen-pr1-spacing-evidence/fixed.tape
+ffmpeg -y -i /tmp/qwen-pr1-spacing-evidence/base.gif -i /tmp/qwen-pr1-spacing-evidence/fixed.gif -filter_complex "[0:v]fps=5,scale=780:-1:flags=lanczos[left];[1:v]fps=5,scale=780:-1:flags=lanczos[right];[left][right]hstack=inputs=2,split[s0][s1];[s0]palettegen[p];[s1][p]paletteuse" /tmp/qwen-pr1-spacing-evidence/base-vs-fixed-optimized.gif
+```
+
+## Evidence Artifacts
+
+- Release: <https://github.com/chiga0/qwen-code/releases/tag/pr-4594-tui-spacing-evidence>
+- Side-by-side GIF: <https://github.com/chiga0/qwen-code/releases/download/pr-4594-tui-spacing-evidence/base-vs-fixed-optimized.gif>
+- Final screenshot: <https://github.com/chiga0/qwen-code/releases/download/pr-4594-tui-spacing-evidence/base-vs-fixed-final.png>
+- Base tmux capture: <https://github.com/chiga0/qwen-code/releases/download/pr-4594-tui-spacing-evidence/base.tmux.txt>
+- Fixed tmux capture: <https://github.com/chiga0/qwen-code/releases/download/pr-4594-tui-spacing-evidence/fixed.tmux.txt>
+- Base summary JSON: <https://github.com/chiga0/qwen-code/releases/download/pr-4594-tui-spacing-evidence/base.summary.json>
+- Fixed summary JSON: <https://github.com/chiga0/qwen-code/releases/download/pr-4594-tui-spacing-evidence/fixed.summary.json>
 
 ## Expected Results
 
@@ -41,17 +66,26 @@ For each scenario, record:
   entry.
 - No scenario should lose user-visible content.
 
-## PR Body Table
-
-Use this table shape in the PR description. The current automated evidence uses
-the representative fixtures below; broader end-to-end captures can reuse the
-same conditions if a later PR needs screenshots or recordings.
+## Results
 
 | Scenario | Width | Baseline rows | PR1 rows | Delta | Notes |
 | --- | ---: | ---: | ---: | ---: | --- |
 | Simple Q&A | 100 | 2 | 1 | -1 | Assistant history item no longer starts with a spacer row |
 | File list or shell output | 100 | 3 | 2 | -1 | Tool header and first result row are adjacent |
 | File-read error | 100 | 3 | 2 | -1 | Error result uses the same tool header/result spacing |
-| Project inspection | 100 | 7 | 5 | -2 | Three expanded tools no longer have blank inter-tool rows |
+| Project inspection | 100 | 16 | 11 | -5 | Three expanded tools no longer have header/result spacer rows or blank inter-tool rows |
 | Diff output | 100 | 3 | 2 | -1 | Diff renderer remains unchanged; only tool header/result spacing changes |
 | Long streaming output | 100 | N + 2 | N + 1 | -1 | Content rows are unchanged; the extra header/result spacer is removed |
+| Full representative fixture | 100 | 26 | 19 | -7 | Same content rendered through real Ink components and captured in tmux |
+
+## What This Proves
+
+- The base branch reproduces the extra spacer rows in a real terminal capture.
+- PR1 removes the targeted spacer rows while preserving the same fixture content.
+- The row-count improvement is measurable under fixed 100-column conditions.
+
+## What This Does Not Prove
+
+- It does not cover later PR scopes such as thinking trace visibility, tool
+  border removal, SubAgent layout, branding, or theme colors.
+- It does not replace manual review for extremely narrow terminal wrapping.

--- a/.qwen/e2e-tests/tui-spacing-density-pr1.md
+++ b/.qwen/e2e-tests/tui-spacing-density-pr1.md
@@ -1,0 +1,57 @@
+# TUI Spacing And Density PR1 Evidence Plan
+
+## Goal
+
+Provide before/after evidence that PR1 reduces visible row usage without
+removing content or changing rendering scope.
+
+## Fixed Conditions
+
+- Terminal width: 100 columns.
+- Compare the same prompt/output fixture before and after this PR.
+- Strip ANSI control sequences before counting visible rows.
+- Count only non-empty rendered terminal rows for the density metric.
+
+## Scenarios
+
+- Simple Q&A.
+- File list output.
+- Long shell output.
+- File-read error output.
+- Multi-block project inspection output.
+- Diff output.
+- Long streaming output.
+
+## Metrics
+
+For each scenario, record:
+
+- Baseline visible row count.
+- PR1 visible row count.
+- Delta in rows.
+- Notes for any scenario that gains rows because of wrapping or fixed-width
+  content.
+
+## Expected Results
+
+- Simple Q&A: at least 1 fewer visible row.
+- Expanded tool output: at least 1 fewer visible row per rendered tool result
+  that previously had a blank header/result spacer.
+- Multi-tool expanded groups: 1 fewer visible row between each adjacent tool
+  entry.
+- No scenario should lose user-visible content.
+
+## PR Body Table
+
+Use this table shape in the PR description. The current automated evidence uses
+the representative fixtures below; broader end-to-end captures can reuse the
+same conditions if a later PR needs screenshots or recordings.
+
+| Scenario | Width | Baseline rows | PR1 rows | Delta | Notes |
+| --- | ---: | ---: | ---: | ---: | --- |
+| Simple Q&A | 100 | 2 | 1 | -1 | Assistant history item no longer starts with a spacer row |
+| File list or shell output | 100 | 3 | 2 | -1 | Tool header and first result row are adjacent |
+| File-read error | 100 | 3 | 2 | -1 | Error result uses the same tool header/result spacing |
+| Project inspection | 100 | 7 | 5 | -2 | Three expanded tools no longer have blank inter-tool rows |
+| Diff output | 100 | 3 | 2 | -1 | Diff renderer remains unchanged; only tool header/result spacing changes |
+| Long streaming output | 100 | N + 2 | N + 1 | -1 | Content rows are unchanged; the extra header/result spacer is removed |

--- a/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.test.tsx
@@ -58,6 +58,37 @@ describe('<HistoryItemDisplay />', () => {
     expect(lastFrame()).toContain('/theme');
   });
 
+  it('renders assistant replies without a leading spacer row', () => {
+    const item: HistoryItem = {
+      id: 1,
+      type: 'gemini',
+      text: 'Hello',
+    };
+    const { lastFrame } = renderWithProviders(
+      <HistoryItemDisplay item={item} terminalWidth={100} isPending={false} />,
+    );
+
+    const output = lastFrame() ?? '';
+    expect(output.startsWith('\n')).toBe(false);
+    expect(output.split('\n')[0]).toContain('✦ Hello');
+  });
+
+  it('renders tool summaries without a leading spacer row', () => {
+    const item: HistoryItem = {
+      id: 1,
+      type: 'tool_use_summary',
+      summary: 'Read txt files',
+      precedingToolUseIds: ['c1'],
+    };
+    const { lastFrame } = renderWithProviders(
+      <HistoryItemDisplay item={item} terminalWidth={100} isPending={false} />,
+    );
+
+    const output = lastFrame() ?? '';
+    expect(output.startsWith('\n')).toBe(false);
+    expect(output).toContain('Read txt files');
+  });
+
   it('renders StatsDisplay for "stats" type', () => {
     const item: HistoryItem = {
       ...baseItem,

--- a/packages/cli/src/ui/components/HistoryItemDisplay.tsx
+++ b/packages/cli/src/ui/components/HistoryItemDisplay.tsx
@@ -87,6 +87,36 @@ interface HistoryItemDisplayProps {
   sourceCopyIndexOffsets?: MarkdownSourceCopyIndexOffsets;
 }
 
+function getHistoryItemMarginTop(item: HistoryItem): number {
+  switch (item.type) {
+    case 'gemini':
+    case 'gemini_content':
+    case 'gemini_thought':
+    case 'gemini_thought_content':
+    case 'info':
+    case 'success':
+    case 'warning':
+    case 'error':
+    case 'retry_countdown':
+    case 'memory_saved':
+    case 'tool_group':
+    case 'tool_use_summary':
+    case 'notification':
+    case 'compression':
+    case 'summary':
+    case 'insight_progress':
+    case 'btw':
+    case 'away_recap':
+    case 'user_prompt_submit_blocked':
+    case 'stop_hook_loop':
+    case 'stop_hook_system_message':
+    case 'goal_status':
+      return 0;
+    default:
+      return 1;
+  }
+}
+
 const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
   item,
   availableTerminalHeight,
@@ -102,10 +132,7 @@ const HistoryItemDisplayComponent: React.FC<HistoryItemDisplayProps> = ({
   summaryAbsorbed = false,
   sourceCopyIndexOffsets,
 }) => {
-  const marginTop =
-    item.type === 'gemini_content' || item.type === 'gemini_thought_content'
-      ? 0
-      : 1;
+  const marginTop = getHistoryItemMarginTop(item);
 
   const { compactMode } = useCompactMode();
   const itemForDisplay = useMemo(() => escapeAnsiCtrlCodes(item), [item]);

--- a/packages/cli/src/ui/components/__snapshots__/HistoryItemDisplay.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/HistoryItemDisplay.test.tsx.snap
@@ -1,8 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`<HistoryItemDisplay /> > should render a full gemini item when using availableTerminalHeightGemini 1`] = `
-"
-  ✦ Example code block:
+"  ✦ Example code block:
       1 Line 1
       2 Line 2
       3 Line 3
@@ -110,8 +109,7 @@ exports[`<HistoryItemDisplay /> > should render a full gemini_content item when 
 `;
 
 exports[`<HistoryItemDisplay /> > should render a truncated gemini item 1`] = `
-"
-  ✦ Example code block:
+"  ✦ Example code block:
      ... first 41 lines hidden ...
      42 Line 42
      43 Line 43

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.test.tsx
@@ -155,6 +155,26 @@ describe('<ToolGroupMessage />', () => {
       expect(lastFrame()).toMatchSnapshot();
     });
 
+    it('renders expanded tool entries without blank separator rows', () => {
+      const toolCalls = [
+        createToolCall({ callId: 'tool-1', name: 'first-tool' }),
+        createToolCall({ callId: 'tool-2', name: 'second-tool' }),
+      ];
+      const { lastFrame } = renderWithProviders(
+        <ToolGroupMessage
+          {...baseProps}
+          contentWidth={100}
+          toolCalls={toolCalls}
+        />,
+      );
+      const lines = (lastFrame() ?? '').split('\n');
+      const firstLine = lines.findIndex((line) => line.includes('tool-1'));
+      const secondLine = lines.findIndex((line) => line.includes('tool-2'));
+
+      expect(firstLine).toBeGreaterThanOrEqual(0);
+      expect(secondLine).toBe(firstLine + 1);
+    });
+
     it('renders tool call awaiting confirmation', () => {
       const toolCalls = [
         createToolCall({

--- a/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolGroupMessage.tsx
@@ -426,7 +426,7 @@ export const ToolGroupMessage: React.FC<ToolGroupMessageProps> = ({
         hasPending && (!isShellCommand || !isEmbeddedShellFocused)
       }
       borderColor={borderColor}
-      gap={1}
+      gap={0}
     >
       {/* Memory badge for mixed groups (some memory ops + other ops) */}
       {!isMemoryOnlyGroup &&

--- a/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.test.tsx
@@ -163,6 +163,21 @@ describe('<ToolMessage />', () => {
     expect(output).toContain('MockMarkdown:Test result');
   });
 
+  it('renders tool results directly below the header row', () => {
+    const { lastFrame } = renderWithContext(
+      <ToolMessage {...baseProps} contentWidth={100} />,
+      StreamingState.Idle,
+    );
+    const lines = (lastFrame() ?? '').split('\n');
+    const headerLine = lines.findIndex((line) => line.includes('test-tool'));
+    const resultLine = lines.findIndex((line) =>
+      line.includes('MockMarkdown:Test result'),
+    );
+
+    expect(headerLine).toBeGreaterThanOrEqual(0);
+    expect(resultLine).toBe(headerLine + 1);
+  });
+
   it('hides result output in compact mode (compactMode=true)', () => {
     const { lastFrame } = renderWithContext(
       <ToolMessage {...baseProps} />,

--- a/packages/cli/src/ui/components/messages/ToolMessage.tsx
+++ b/packages/cli/src/ui/components/messages/ToolMessage.tsx
@@ -684,7 +684,7 @@ export const ToolMessage: React.FC<ToolMessageProps> = ({
         {emphasis === 'high' && <TrailingIndicator />}
       </Box>
       {effectiveDisplayRenderer.type !== 'none' && (
-        <Box paddingLeft={STATUS_INDICATOR_WIDTH} width="100%" marginTop={1}>
+        <Box paddingLeft={STATUS_INDICATOR_WIDTH} width="100%">
           <Box flexDirection="column">
             {effectiveDisplayRenderer.type === 'todo' && (
               <TodoResultRenderer data={effectiveDisplayRenderer.data} />

--- a/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
+++ b/packages/cli/src/ui/components/messages/__snapshots__/ToolGroupMessage.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`<ToolGroupMessage /> > Border Color Logic > uses gray border when all tools are successful and no shell commands 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
 │MockTool[tool-123]: ✓ test-tool - A tool for testing (medium)                 │
-│                                                                              │
 │MockTool[tool-2]: ✓ another-tool - A tool for testing (medium)                │
 ╰──────────────────────────────────────────────────────────────────────────────╯"
 `;
@@ -24,7 +23,6 @@ exports[`<ToolGroupMessage /> > Confirmation Handling > shows confirmation dialo
 "╭──────────────────────────────────────────────────────────────────────────────╮
 │MockTool[tool-1]: ? first-confirm - A tool for testing (high)                 │
 │MockConfirmation: Confirm first tool                                          │
-│                                                                              │
 │MockTool[tool-2]: ? second-confirm - A tool for testing (low)                 │
 ╰──────────────────────────────────────────────────────────────────────────────╯"
 `;
@@ -37,9 +35,7 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders empty tool calls arra
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders mixed tool calls including shell command 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
 │MockTool[tool-1]: ✓ read_file - Read a file (medium)                          │
-│                                                                              │
 │MockTool[tool-2]: ⊷ run_shell_command - Run command (medium)                  │
-│                                                                              │
 │MockTool[tool-3]: o write_file - Write to file (medium)                       │
 ╰──────────────────────────────────────────────────────────────────────────────╯"
 `;
@@ -47,9 +43,7 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders mixed tool calls incl
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders multiple tool calls with different statuses 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
 │MockTool[tool-1]: ✓ successful-tool - This tool succeeded (medium)            │
-│                                                                              │
 │MockTool[tool-2]: o pending-tool - This tool is pending (medium)              │
-│                                                                              │
 │MockTool[tool-3]: x error-tool - This tool failed (medium)                    │
 ╰──────────────────────────────────────────────────────────────────────────────╯"
 `;
@@ -83,7 +77,6 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders when not focused 1`] 
 exports[`<ToolGroupMessage /> > Golden Snapshots > renders with limited terminal height 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
 │MockTool[tool-1]: ✓ tool-with-result - Tool with output (medium)              │
-│                                                                              │
 │MockTool[tool-2]: ✓ another-tool - Another tool (medium)                      │
 ╰──────────────────────────────────────────────────────────────────────────────╯"
 `;
@@ -100,9 +93,7 @@ exports[`<ToolGroupMessage /> > Golden Snapshots > renders with narrow terminal 
 exports[`<ToolGroupMessage /> > Height Calculation > calculates available height correctly with multiple tools with results 1`] = `
 "╭──────────────────────────────────────────────────────────────────────────────╮
 │MockTool[tool-1]: ✓ test-tool - A tool for testing (medium)                   │
-│                                                                              │
 │MockTool[tool-2]: ✓ test-tool - A tool for testing (medium)                   │
-│                                                                              │
 │MockTool[tool-3]: ✓ test-tool - A tool for testing (medium)                   │
 ╰──────────────────────────────────────────────────────────────────────────────╯"
 `;


### PR DESCRIPTION
This PR is closed and superseded by [QwenLM/qwen-code#4595](https://github.com/QwenLM/qwen-code/pull/4595).

The active PR uses the upstream branch `feat/tui-spacing-density-pr1` from `QwenLM/qwen-code`, and its evidence artifacts are hosted under the upstream repository:

- Side-by-side GIF: <https://github.com/QwenLM/qwen-code/releases/download/tui-spacing-density-pr1-evidence/base-vs-fixed-optimized.gif>
- Final screenshot: <https://github.com/QwenLM/qwen-code/releases/download/tui-spacing-density-pr1-evidence/base-vs-fixed-final.png>
