### PR TITLE
feat(daemon): add request-level logging for serve routes

### DIFF
--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -2216,6 +2216,10 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     },
 
     async sendPrompt(sessionId, req, signal, context) {
+      opts.onDiagnosticLine?.(
+        `qwen serve: bridge sendPrompt for session=${sessionId}`,
+        'info',
+      );
       const capturedContext = telemetry.captureContext();
       const queuedAt = Date.now();
       const entry = byId.get(sessionId);
@@ -2400,6 +2404,10 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     },
 
     async cancelSession(sessionId, req, context) {
+      opts.onDiagnosticLine?.(
+        `qwen serve: bridge cancelSession for session=${sessionId}`,
+        'info',
+      );
       const entry = byId.get(sessionId);
       if (!entry) throw new SessionNotFoundError(sessionId);
       const cancelOriginatorClientId = resolveTrustedClientId(
@@ -3436,6 +3444,10 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       if (!entry) throw new SessionNotFoundError(sessionId);
       const info = channelInfoForEntry(entry);
       if (!info || info.isDying) throw new SessionNotFoundError(sessionId);
+      opts.onDiagnosticLine?.(
+        `qwen serve: bridge generateSessionRecap dispatching ext-method for session=${sessionId}`,
+        'info',
+      );
       const response = (await Promise.race([
         withTimeout(
           entry.connection.extMethod(SERVE_CONTROL_EXT_METHODS.sessionRecap, {
@@ -3446,6 +3458,10 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         ),
         getTransportClosedReject(entry),
       ])) as { sessionId: string; recap: string | null };
+      opts.onDiagnosticLine?.(
+        `qwen serve: bridge generateSessionRecap completed for session=${sessionId} recap=${response.recap ? `len=${response.recap.length}` : 'null'}`,
+        'info',
+      );
       return {
         sessionId: entry.sessionId,
         recap: response.recap ?? null,
@@ -3458,6 +3474,10 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       signal,
       context,
     ): Promise<ShellCommandResult> {
+      opts.onDiagnosticLine?.(
+        `qwen serve: bridge executeShellCommand for session=${sessionId}`,
+        'info',
+      );
       const entry = byId.get(sessionId);
       if (!entry) throw new SessionNotFoundError(sessionId);
       const originatorClientId = resolveTrustedClientId(

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -2521,6 +2521,7 @@ class QwenAgent implements Agent {
             'Invalid or missing sessionId',
           );
         }
+        debugLogger.debug(`recap ext-method received for session=${sessionId}`);
         const session = this.sessionOrThrow(sessionId);
         const config = session.getConfig();
         // v1: no cross-process abort plumbing. The bridge does not listen
@@ -2535,6 +2536,9 @@ class QwenAgent implements Agent {
         const recap = await generateSessionRecap(
           config,
           new AbortController().signal,
+        );
+        debugLogger.debug(
+          `recap ext-method completed for session=${sessionId} result=${recap ? `len=${recap.length}` : 'null'}`,
         );
         return { sessionId, recap };
       }

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -868,9 +868,7 @@ export function createServeApp(
             status,
             durationMs,
           };
-          if (status >= 500) {
-            daemonLog.error('request completed', null, ctx);
-          } else if (status >= 400) {
+          if (status >= 400) {
             daemonLog.warn('request completed', ctx);
           } else {
             daemonLog.info('request completed', ctx);
@@ -1398,6 +1396,12 @@ export function createServeApp(
         );
       }
       if (!res.writable) {
+        if (daemonLog) {
+          daemonLog.warn('session reaped (client disconnected before response)', {
+            sessionId: session.sessionId,
+            attached: session.attached,
+          });
+        }
         if (!session.attached) {
           // `requireZeroAttaches: true` closes the BQ9tV race: if
           // a second client called `spawnOrAttach` for the same
@@ -1669,14 +1673,19 @@ export function createServeApp(
       .then(
         () => {
           if (daemonLog) {
-            daemonLog.info('prompt turn completed', { sessionId, promptId });
+            daemonLog.info('prompt turn completed', {
+              sessionId,
+              promptId,
+              clientId,
+            });
           }
         },
         (err) => {
           if (daemonLog) {
+            const errName = err instanceof Error ? err.name : undefined;
             daemonLog.warn(
-              `prompt turn failed: ${err instanceof Error ? err.message : String(err)}`,
-              { sessionId, promptId },
+              `prompt turn failed: ${errName ? `[${errName}] ` : ''}${err instanceof Error ? err.message : String(err)}`,
+              { sessionId, promptId, clientId },
             );
           }
         },
@@ -1687,7 +1696,7 @@ export function createServeApp(
       .catch(() => {});
 
     if (daemonLog) {
-      daemonLog.info('prompt enqueued', { sessionId, promptId });
+      daemonLog.info('prompt enqueued', { sessionId, promptId, clientId });
     }
     res.status(202).json({ promptId, lastEventId });
   });

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -831,45 +831,36 @@ export function createServeApp(
     app.get('/demo', demoHandler);
   }
 
-  app.use(bearerAuth(opts.token));
-
-  app.use(express.json({ limit: '10mb' }));
-  app.use(
-    (
-      err: unknown,
-      _req: import('express').Request,
-      res: import('express').Response,
-      next: import('express').NextFunction,
-    ) => {
-      if (sendJsonBodyParserError(res, err)) return;
-      next(err);
-    },
-  );
-
-  // Access-log middleware. Logs every completed request (method, path,
-  // status, duration) via the structured daemon logger. Excluded:
+  // Access-log middleware. Registered BEFORE bearerAuth and JSON parser
+  // so auth rejections (401) and malformed-body errors (400) are also
+  // captured in the daemon log. Excluded:
   //  - GET /health (high-frequency probe, would drown signal)
-  //  - GET /session/:id/events (SSE — logged inline at open/close)
+  //  - Successful SSE streams (GET .../events with 200) — logged inline
+  //    at open/close; failed SSE handshakes (4xx) are still recorded.
   if (daemonLog) {
     const SESSION_ID_RE = /\/session\/([^/]+)/;
     app.use((req, res, next) => {
       const { method, path: reqPath } = req;
-      if (
-        method === 'GET' &&
-        (reqPath === '/health' || reqPath.endsWith('/events'))
-      ) {
+      if (method === 'GET' && reqPath === '/health') {
         return next();
       }
       const startMs = Date.now();
       res.on('finish', () => {
         try {
+          const status = res.statusCode;
+          if (
+            method === 'GET' &&
+            reqPath.endsWith('/events') &&
+            status === 200
+          ) {
+            return;
+          }
           const durationMs = Date.now() - startMs;
           const sessionMatch = reqPath.match(SESSION_ID_RE);
           const sessionId = sessionMatch?.[1];
           const clientId = req.headers['x-qwen-client-id'] as
             | string
             | undefined;
-          const status = res.statusCode;
           const ctx = {
             route: `${method}:${reqPath}`,
             ...(sessionId ? { sessionId } : {}),
@@ -889,6 +880,21 @@ export function createServeApp(
       next();
     });
   }
+
+  app.use(bearerAuth(opts.token));
+
+  app.use(express.json({ limit: '10mb' }));
+  app.use(
+    (
+      err: unknown,
+      _req: import('express').Request,
+      res: import('express').Response,
+      next: import('express').NextFunction,
+    ) => {
+      if (sendJsonBodyParserError(res, err)) return;
+      next(err);
+    },
+  );
 
   if (!exposeHealthPreAuth) {
     // Non-loopback OR loopback with `--require-auth`: register
@@ -1452,6 +1458,12 @@ export function createServeApp(
                 workspaceCwd: cwd,
                 ...(clientId !== undefined ? { clientId } : {}),
               });
+        if (daemonLog) {
+          daemonLog.info(
+            `session ${action}${session.attached ? ' (attached)' : ''}`,
+            { sessionId: session.sessionId, clientId: session.clientId },
+          );
+        }
         // Mirror the `POST /session` disconnect-cleanup path (see the
         // long comment above the matching `if (!res.writable)` there
         // for the rationale around `res.writable` vs `req.aborted` /
@@ -1650,6 +1662,21 @@ export function createServeApp(
         {
           ...(clientId !== undefined ? { clientId } : {}),
           promptId,
+        },
+      )
+      .then(
+        () => {
+          if (daemonLog) {
+            daemonLog.info('prompt turn completed', { sessionId, promptId });
+          }
+        },
+        (err) => {
+          if (daemonLog) {
+            daemonLog.warn(
+              `prompt turn failed: ${err instanceof Error ? err.message : String(err)}`,
+              { sessionId, promptId },
+            );
+          }
         },
       )
       .finally(() => {

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -846,6 +846,50 @@ export function createServeApp(
     },
   );
 
+  // Access-log middleware. Logs every completed request (method, path,
+  // status, duration) via the structured daemon logger. Excluded:
+  //  - GET /health (high-frequency probe, would drown signal)
+  //  - GET /session/:id/events (SSE — logged inline at open/close)
+  if (daemonLog) {
+    const SESSION_ID_RE = /\/session\/([^/]+)/;
+    app.use((req, res, next) => {
+      const { method, path: reqPath } = req;
+      if (
+        method === 'GET' &&
+        (reqPath === '/health' || reqPath.endsWith('/events'))
+      ) {
+        return next();
+      }
+      const startMs = Date.now();
+      res.on('finish', () => {
+        try {
+          const durationMs = Date.now() - startMs;
+          const sessionMatch = reqPath.match(SESSION_ID_RE);
+          const sessionId = sessionMatch?.[1];
+          const clientId = req.headers['x-qwen-client-id'] as
+            | string
+            | undefined;
+          const status = res.statusCode;
+          const ctx = {
+            route: `${method}:${reqPath}`,
+            ...(sessionId ? { sessionId } : {}),
+            ...(clientId ? { clientId } : {}),
+            status,
+            durationMs,
+          };
+          if (status >= 400 && status < 500) {
+            daemonLog.warn('request completed', ctx);
+          } else {
+            daemonLog.info('request completed', ctx);
+          }
+        } catch {
+          // Logging failure must not affect the request.
+        }
+      });
+      next();
+    });
+  }
+
   if (!exposeHealthPreAuth) {
     // Non-loopback OR loopback with `--require-auth`: register
     // `/health` and `/demo` AFTER `bearerAuth` so probes must carry
@@ -1339,6 +1383,12 @@ export function createServeApp(
       // The disconnect-without-reap branch also needs to skip
       // `res.json` — writing to a closed socket would throw EPIPE
       // through Express's default error handler.
+      if (daemonLog) {
+        daemonLog.info(
+          session.attached ? 'session attached' : 'session spawned',
+          { sessionId: session.sessionId, clientId: session.clientId },
+        );
+      }
       if (!res.writable) {
         if (!session.attached) {
           // `requireZeroAttaches: true` closes the BQ9tV race: if
@@ -1607,6 +1657,9 @@ export function createServeApp(
       })
       .catch(() => {});
 
+    if (daemonLog) {
+      daemonLog.info('prompt enqueued', { sessionId, promptId });
+    }
     res.status(202).json({ promptId, lastEventId });
   });
 
@@ -1676,6 +1729,9 @@ export function createServeApp(
         } as Parameters<HttpAcpBridge['cancelSession']>[1],
         clientId !== undefined ? { clientId } : undefined,
       );
+      if (daemonLog) {
+        daemonLog.info('cancel sent', { sessionId, clientId });
+      }
       res.status(204).end();
     } catch (err) {
       sendBridgeError(res, err, {
@@ -1854,6 +1910,13 @@ export function createServeApp(
         sessionId,
         clientId !== undefined ? { clientId } : undefined,
       );
+      if (daemonLog) {
+        const recap = (response as { recap?: string | null }).recap;
+        daemonLog.info(
+          recap ? `recap generated len=${recap.length}` : 'recap returned null',
+          { sessionId, clientId },
+        );
+      }
       res.status(200).json(response);
     } catch (err) {
       sendBridgeError(res, err, {
@@ -1890,6 +1953,13 @@ export function createServeApp(
         abort.signal,
         clientId !== undefined ? { clientId } : undefined,
       );
+      if (daemonLog) {
+        daemonLog.info('shell command completed', {
+          sessionId,
+          clientId,
+          exitCode: (result as { exitCode?: number })?.exitCode,
+        });
+      }
       res.status(200).json(result);
     } catch (err) {
       if (
@@ -2273,6 +2343,19 @@ export function createServeApp(
         sessionId,
       });
       return;
+    }
+
+    if (daemonLog) {
+      const sseOpenedAt = Date.now();
+      const sseClientId = req.headers['x-qwen-client-id'] as string | undefined;
+      daemonLog.info('SSE stream opened', { sessionId, clientId: sseClientId });
+      res.on('close', () => {
+        daemonLog.info('SSE stream closed', {
+          sessionId,
+          clientId: sseClientId,
+          durationMs: Date.now() - sseOpenedAt,
+        });
+      });
     }
 
     res.status(200);

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -868,7 +868,9 @@ export function createServeApp(
             status,
             durationMs,
           };
-          if (status >= 400 && status < 500) {
+          if (status >= 500) {
+            daemonLog.error('request completed', null, ctx);
+          } else if (status >= 400) {
             daemonLog.warn('request completed', ctx);
           } else {
             daemonLog.info('request completed', ctx);
@@ -1938,7 +1940,7 @@ export function createServeApp(
         clientId !== undefined ? { clientId } : undefined,
       );
       if (daemonLog) {
-        const recap = (response as { recap?: string | null }).recap;
+        const recap = response.recap;
         daemonLog.info(
           recap ? `recap generated len=${recap.length}` : 'recap returned null',
           { sessionId, clientId },
@@ -1984,7 +1986,7 @@ export function createServeApp(
         daemonLog.info('shell command completed', {
           sessionId,
           clientId,
-          exitCode: (result as { exitCode?: number })?.exitCode,
+          exitCode: result.exitCode,
         });
       }
       res.status(200).json(result);

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -862,7 +862,7 @@ export function createServeApp(
             | string
             | undefined;
           const ctx = {
-            route: `${method}:${reqPath}`,
+            route: `${method} ${reqPath}`,
             ...(sessionId ? { sessionId } : {}),
             ...(clientId ? { clientId } : {}),
             status,

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -841,7 +841,10 @@ export function createServeApp(
     const SESSION_ID_RE = /\/session\/([^/]+)/;
     app.use((req, res, next) => {
       const { method, path: reqPath } = req;
-      if (method === 'GET' && reqPath === '/health') {
+      if (
+        (method === 'GET' && reqPath === '/health') ||
+        (method === 'POST' && reqPath.endsWith('/heartbeat'))
+      ) {
         return next();
       }
       const startMs = Date.now();

--- a/packages/core/src/services/sessionRecap.ts
+++ b/packages/core/src/services/sessionRecap.ts
@@ -47,15 +47,29 @@ export async function generateSessionRecap(
 ): Promise<string | null> {
   try {
     const geminiClient = config.getGeminiClient();
-    if (!geminiClient) return null;
+    if (!geminiClient) {
+      debugLogger.debug('recap skipped: no geminiClient available');
+      return null;
+    }
 
     const fullHistory = geminiClient.getChat().getHistory();
-    if (fullHistory.length < 2) return null;
+    if (fullHistory.length < 2) {
+      debugLogger.debug(
+        `recap skipped: history too short (${fullHistory.length} messages)`,
+      );
+      return null;
+    }
 
     const dialog = filterToDialog(fullHistory);
     const recentHistory = takeRecentDialog(dialog, RECENT_MESSAGE_WINDOW);
-    if (recentHistory.length === 0) return null;
+    if (recentHistory.length === 0) {
+      debugLogger.debug('recap skipped: no dialog messages after filtering');
+      return null;
+    }
 
+    debugLogger.debug(
+      `recap: sending side-query with ${recentHistory.length} messages`,
+    );
     const result = await runSideQuery(config, {
       purpose: 'session-recap',
       contents: [
@@ -72,13 +86,23 @@ export async function generateSessionRecap(
       maxAttempts: 1,
     });
 
-    if (abortSignal.aborted) return null;
+    if (abortSignal.aborted) {
+      debugLogger.debug('recap aborted by signal');
+      return null;
+    }
 
-    if (!result.text) return null;
+    if (!result.text) {
+      debugLogger.debug('recap: model returned empty text');
+      return null;
+    }
 
     const text = extractRecap(result.text);
-    if (!text) return null;
+    if (!text) {
+      debugLogger.debug('recap: failed to extract <recap> tags from response');
+      return null;
+    }
 
+    debugLogger.debug(`recap generated: len=${text.length}`);
     return text;
   } catch (err) {
     debugLogger.warn(


### PR DESCRIPTION
## Summary

- Add access-log middleware: logs method, path, sessionId, clientId, status, and durationMs for every completed request (excludes GET /health and SSE /events to reduce noise)
- Add inline business-context logs for key routes: session spawn/attach, prompt enqueue, cancel, recap (distinguishes null vs generated), shell command completion, and SSE stream open/close with duration
- All logging gated on `daemonLog` existence — tests/embeds are unaffected

## Motivation

Previously only 5xx errors were logged via `sendBridgeError`, making it impossible to debug issues like "frontend says /recap returned nothing" — the backend had zero trace of the request. Now operators can clearly see whether the request arrived, how long it took, and what the business result was.

## Test plan

- [ ] `npx tsc --noEmit -p packages/cli/tsconfig.json` — no new type errors
- [ ] Manually start daemon, send /recap request, confirm daemon log file has access + inline logs
- [ ] Confirm no extra output when `daemonLog` is not injected (test scenarios)

<details>
<summary>中文版本</summary>

### 概要

- 添加 access-log 中间件：每个完成的请求记录 method、path、sessionId、clientId、status、durationMs（排除 GET /health 和 SSE /events）
- 为关键路由补充 inline 业务日志：session spawn/attach、prompt enqueue、cancel、recap（区分 null vs generated）、shell command 完成、SSE 连接开启/关闭
- 所有日志 gated on `daemonLog` 存在，tests/embeds 不受影响

### 动机

之前只有 5xx error 才会记录日志，导致排查问题时（如前端报告 /recap 无返回）后端完全没有痕迹。现在可以清楚看到请求是否到达、处理耗时、以及业务结果。

### 测试计划

- [ ] `npx tsc --noEmit -p packages/cli/tsconfig.json` 无新增类型错误
- [ ] 手动启动 daemon，发送 /recap 请求，确认 daemon log 文件有 access + inline 日志
- [ ] 确认不注入 daemonLog 时（测试场景）无额外输出

</details>

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)


---

> **📝 描述准确性更新（2026-05-31，作者自查）**
>
> 补充：access-log 除 /health 与 SSE 外，还排除了 POST .../heartbeat。
