### PR TITLE
fix(core): use undici fetch for IDE proxy requests

### DIFF
--- a/packages/core/src/ide/ide-client.test.ts
+++ b/packages/core/src/ide/ide-client.test.ts
@@ -14,6 +14,23 @@ import {
   type Mocked,
   type Mock,
 } from 'vitest';
+
+const { mockUndiciFetch, mockProxyAgent, mockEnvHttpProxyAgent } = vi.hoisted(
+  () => {
+    const proxyAgent = { kind: 'env-proxy-agent' };
+    return {
+      mockUndiciFetch: vi.fn(),
+      mockProxyAgent: proxyAgent,
+      mockEnvHttpProxyAgent: vi.fn(() => proxyAgent),
+    };
+  },
+);
+
+vi.mock('undici', () => ({
+  EnvHttpProxyAgent: mockEnvHttpProxyAgent,
+  fetch: mockUndiciFetch,
+}));
+
 import {
   IdeClient,
   IDEConnectionStatus,
@@ -112,6 +129,8 @@ describe('IdeClient', () => {
     vi.mocked(Client).mockReturnValue(mockClient);
     vi.mocked(StreamableHTTPClientTransport).mockReturnValue(mockHttpTransport);
     vi.mocked(StdioClientTransport).mockReturnValue(mockStdioTransport);
+    mockUndiciFetch.mockReset();
+    mockEnvHttpProxyAgent.mockClear();
 
     await IdeClient.getInstance();
   });
@@ -119,6 +138,41 @@ describe('IdeClient', () => {
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  describe('createProxyAwareFetch', () => {
+    it('uses undici fetch with the proxy-aware dispatcher', async () => {
+      mockUndiciFetch.mockResolvedValue(
+        new Response('ok', {
+          status: 201,
+          statusText: 'Created',
+          headers: { 'x-test': 'yes' },
+        }),
+      );
+      const ideClient = await IdeClient.getInstance();
+      const fetch = (
+        ideClient as unknown as {
+          createProxyAwareFetch: (
+            host: string,
+          ) => (url: string, init?: RequestInit) => Promise<Response>;
+        }
+      ).createProxyAwareFetch('127.0.0.1');
+
+      const response = await fetch('http://127.0.0.1:8080/mcp', {
+        method: 'POST',
+      });
+
+      expect(response.status).toBe(201);
+      expect(response.headers.get('x-test')).toBe('yes');
+      expect(mockEnvHttpProxyAgent).toHaveBeenCalled();
+      expect(mockUndiciFetch).toHaveBeenCalledWith(
+        'http://127.0.0.1:8080/mcp',
+        expect.objectContaining({
+          method: 'POST',
+          dispatcher: mockProxyAgent,
+        }),
+      );
+    });
   });
 
   describe('connect', () => {

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -23,7 +23,7 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { CallToolResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import * as os from 'node:os';
 import * as path from 'node:path';
-import { EnvHttpProxyAgent } from 'undici';
+import { EnvHttpProxyAgent, fetch as undiciFetch } from 'undici';
 import { ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js';
 import { IDE_REQUEST_TIMEOUT_MS } from './constants.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
@@ -806,15 +806,13 @@ export class IdeClient {
     const agent = new EnvHttpProxyAgent({
       noProxy: noProxyHosts.filter(Boolean).join(','),
     });
-    const undiciPromise = import('undici');
     return async (url: string | URL, init?: RequestInit): Promise<Response> => {
-      const { fetch: fetchFn } = await undiciPromise;
       const fetchOptions: RequestInit & { dispatcher?: unknown } = {
         ...init,
         dispatcher: agent,
       };
       const options = fetchOptions as unknown as import('undici').RequestInit;
-      const response = await fetchFn(url, options);
+      const response = await undiciFetch(url, options);
       // Convert undici Headers to standard Headers for compatibility
       const standardHeaders = new Headers();
       for (const [key, value] of response.headers.entries()) {


### PR DESCRIPTION
﻿## Summary
- fixes #4589 by using the bundled undici fetch directly for IDE proxy-aware requests
- keeps the EnvHttpProxyAgent dispatcher and fetch implementation from the same undici package
- adds coverage for the proxy-aware IDE fetch wrapper

## To verify
- npx prettier --check packages/core/src/ide/ide-client.ts packages/core/src/ide/ide-client.test.ts
- npx eslint packages/core/src/ide/ide-client.ts packages/core/src/ide/ide-client.test.ts --max-warnings 0
- npm run typecheck --workspace=packages/core
- npm run test --workspace=packages/core -- src/ide/ide-client.test.ts
