### PR TITLE
feat(daemon): add POST /session/:id/btw endpoint for side questions

### DIFF
--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -3399,7 +3399,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       if (signal?.aborted) return { sessionId, answer: null };
       const info = channelInfoForEntry(entry);
       if (!info || info.isDying) throw new SessionNotFoundError(sessionId);
-      const races: Promise<unknown>[] = [
+      const races: Array<Promise<unknown>> = [
         withTimeout(
           entry.connection.extMethod(SERVE_CONTROL_EXT_METHODS.sessionBtw, {
             sessionId,

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -3396,9 +3396,9 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     async generateSessionBtw(sessionId, question, signal, _context) {
       const entry = byId.get(sessionId);
       if (!entry) throw new SessionNotFoundError(sessionId);
-      if (signal?.aborted) return { sessionId, answer: null };
       const info = channelInfoForEntry(entry);
       if (!info || info.isDying) throw new SessionNotFoundError(sessionId);
+      if (signal?.aborted) return { sessionId, answer: null };
       const races: Array<Promise<unknown>> = [
         withTimeout(
           entry.connection.extMethod(SERVE_CONTROL_EXT_METHODS.sessionBtw, {
@@ -3417,8 +3417,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
             const handler = () =>
               reject(new DOMException('Aborted', 'AbortError'));
             signal.addEventListener('abort', handler, { once: true });
-            cleanupAbort = () =>
-              signal.removeEventListener('abort', handler);
+            cleanupAbort = () => signal.removeEventListener('abort', handler);
           }),
         );
       }

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -3410,21 +3410,27 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         ),
         getTransportClosedReject(entry),
       ];
+      let cleanupAbort: (() => void) | undefined;
       if (signal) {
         races.push(
           new Promise<never>((_, reject) => {
-            signal.addEventListener(
-              'abort',
-              () => reject(new DOMException('Aborted', 'AbortError')),
-              { once: true },
-            );
+            const handler = () =>
+              reject(new DOMException('Aborted', 'AbortError'));
+            signal.addEventListener('abort', handler, { once: true });
+            cleanupAbort = () =>
+              signal.removeEventListener('abort', handler);
           }),
         );
       }
-      const response = (await Promise.race(races)) as {
-        sessionId: string;
-        answer: string | null;
-      };
+      let response: { sessionId: string; answer: string | null };
+      try {
+        response = (await Promise.race(races)) as {
+          sessionId: string;
+          answer: string | null;
+        };
+      } finally {
+        cleanupAbort?.();
+      }
       return {
         sessionId: entry.sessionId,
         answer: response.answer ?? null,

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -580,6 +580,7 @@ const MCP_RESTART_TIMEOUT_MS = 300_000;
  * disconnect cancellation in v1 (see server.ts route comment).
  */
 const SESSION_RECAP_TIMEOUT_MS = 60_000;
+const SESSION_BTW_TIMEOUT_MS = 60_000;
 const SHELL_COMMAND_TIMEOUT_MS = 120_000;
 const MAX_SHELL_OUTPUT_FOR_HISTORY = 10_000;
 const DEFAULT_MAX_SESSIONS = 20;
@@ -3389,6 +3390,44 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       return {
         sessionId: entry.sessionId,
         recap: response.recap ?? null,
+      };
+    },
+
+    async generateSessionBtw(sessionId, question, signal, _context) {
+      const entry = byId.get(sessionId);
+      if (!entry) throw new SessionNotFoundError(sessionId);
+      if (signal?.aborted) return { sessionId, answer: null };
+      const info = channelInfoForEntry(entry);
+      if (!info || info.isDying) throw new SessionNotFoundError(sessionId);
+      const races: Promise<unknown>[] = [
+        withTimeout(
+          entry.connection.extMethod(SERVE_CONTROL_EXT_METHODS.sessionBtw, {
+            sessionId,
+            question,
+          }),
+          SESSION_BTW_TIMEOUT_MS,
+          SERVE_CONTROL_EXT_METHODS.sessionBtw,
+        ),
+        getTransportClosedReject(entry),
+      ];
+      if (signal) {
+        races.push(
+          new Promise<never>((_, reject) => {
+            signal.addEventListener(
+              'abort',
+              () => reject(new DOMException('Aborted', 'AbortError')),
+              { once: true },
+            );
+          }),
+        );
+      }
+      const response = (await Promise.race(races)) as {
+        sessionId: string;
+        answer: string | null;
+      };
+      return {
+        sessionId: entry.sessionId,
+        answer: response.answer ?? null,
       };
     },
 

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -384,6 +384,18 @@ export interface HttpAcpBridge {
   ): Promise<{ sessionId: string; recap: string | null }>;
 
   /**
+   * Run a side question (/btw) against the session's conversation context.
+   * Uses runForkedAgent (cache path) for a single-turn, tool-free LLM call.
+   * Returns `answer: null` on empty/failed generation.
+   */
+  generateSessionBtw(
+    sessionId: string,
+    question: string,
+    signal?: AbortSignal,
+    context?: BridgeClientRequestContext,
+  ): Promise<{ sessionId: string; answer: string | null }>;
+
+  /**
    * Execute a shell command directly on the daemon (no LLM involvement).
    * Streams output through the session's SSE bus and injects the
    * command+result into the LLM's chat history via extMethod.

--- a/packages/acp-bridge/src/status.ts
+++ b/packages/acp-bridge/src/status.ts
@@ -125,6 +125,7 @@ export const SERVE_CONTROL_EXT_METHODS = {
   sessionClose: 'qwen/control/session/close',
   sessionApprovalMode: 'qwen/control/session/approval_mode',
   sessionRecap: 'qwen/control/session/recap',
+  sessionBtw: 'qwen/control/session/btw',
   sessionShellHistory: 'qwen/control/session/shell_history',
   workspaceMcpRestart: 'qwen/control/workspace/mcp/restart',
 } as const;

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -8,6 +8,8 @@ import {
   APPROVAL_MODE_INFO,
   APPROVAL_MODES,
   AuthType,
+  buildBtwCacheSafeParams,
+  buildBtwPrompt,
   clearCachedCredentialFile,
   createDebugLogger,
   generateSessionRecap,
@@ -15,6 +17,7 @@ import {
   qwenOAuth2Events,
   MCP_BUDGET_WARN_FRACTION,
   MCPServerConfig,
+  runForkedAgent,
   SessionService,
   SESSION_TITLE_MAX_LENGTH,
   tokenLimit,
@@ -2537,6 +2540,45 @@ class QwenAgent implements Agent {
           new AbortController().signal,
         );
         return { sessionId, recap };
+      }
+      case SERVE_CONTROL_EXT_METHODS.sessionBtw: {
+        const sessionId = params['sessionId'];
+        if (typeof sessionId !== 'string' || sessionId.length === 0) {
+          throw RequestError.invalidParams(
+            undefined,
+            'Invalid or missing sessionId',
+          );
+        }
+        const question = params['question'];
+        if (typeof question !== 'string' || !question.trim()) {
+          throw RequestError.invalidParams(
+            undefined,
+            'Invalid or missing question',
+          );
+        }
+        const session = this.sessionOrThrow(sessionId);
+        const config = session.getConfig();
+        const cacheSafeParams = buildBtwCacheSafeParams(config);
+        if (!cacheSafeParams) {
+          return { sessionId, answer: null };
+        }
+        let result;
+        try {
+          result = await runForkedAgent({
+            config,
+            userMessage: buildBtwPrompt(question.trim()),
+            cacheSafeParams,
+            abortSignal: AbortSignal.timeout(55_000),
+          });
+        } catch (err) {
+          if (err instanceof DOMException && err.name === 'TimeoutError') {
+            throw RequestError.internalError(
+              'Side question timed out after 55s',
+            );
+          }
+          throw err;
+        }
+        return { sessionId, answer: result.text || null };
       }
       case SERVE_CONTROL_EXT_METHODS.sessionShellHistory: {
         const sessionId = params['sessionId'];

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -2554,10 +2554,14 @@ class QwenAgent implements Agent {
           );
         }
         const question = params['question'];
-        if (typeof question !== 'string' || !question.trim()) {
+        if (
+          typeof question !== 'string' ||
+          !question.trim() ||
+          question.length > 4096
+        ) {
           throw RequestError.invalidParams(
             undefined,
-            'Invalid or missing question',
+            'Invalid or missing question (max 4096 chars)',
           );
         }
         const session = this.sessionOrThrow(sessionId);

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -10,6 +10,7 @@ import {
   AuthType,
   buildBtwCacheSafeParams,
   buildBtwPrompt,
+  getCacheSafeParams,
   clearCachedCredentialFile,
   createDebugLogger,
   generateSessionRecap,
@@ -2558,7 +2559,8 @@ class QwenAgent implements Agent {
         }
         const session = this.sessionOrThrow(sessionId);
         const config = session.getConfig();
-        const cacheSafeParams = buildBtwCacheSafeParams(config);
+        const cacheSafeParams =
+          buildBtwCacheSafeParams(config) ?? getCacheSafeParams();
         if (!cacheSafeParams) {
           return { sessionId, answer: null };
         }

--- a/packages/cli/src/acp-integration/acpAgent.ts
+++ b/packages/cli/src/acp-integration/acpAgent.ts
@@ -138,6 +138,9 @@ import {
 } from '../ui/commands/contextCommand.js';
 
 const debugLogger = createDebugLogger('ACP_AGENT');
+// Must be less than SESSION_BTW_TIMEOUT_MS (60s) in bridge.ts so the child
+// aborts before the bridge's backstop timer fires.
+const BTW_CHILD_TIMEOUT_MS = 55_000;
 
 /**
  * Env-var candidates per auth method, used by `buildAuthPreflightCell` for
@@ -2570,7 +2573,7 @@ class QwenAgent implements Agent {
             config,
             userMessage: buildBtwPrompt(question.trim()),
             cacheSafeParams,
-            abortSignal: AbortSignal.timeout(55_000),
+            abortSignal: AbortSignal.timeout(BTW_CHILD_TIMEOUT_MS),
           });
         } catch (err) {
           if (err instanceof DOMException && err.name === 'TimeoutError') {

--- a/packages/cli/src/serve/capabilities.ts
+++ b/packages/cli/src/serve/capabilities.ts
@@ -173,6 +173,9 @@ export const SERVE_CAPABILITY_REGISTRY = {
   // may be `null` for too-short histories or transient model failures
   // (best-effort, never throws). SDK helper: `DaemonClient.recapSession`.
   session_recap: { since: 'v1' },
+  // Side question (/btw) against the session's conversation context.
+  // Single-turn, tool-free LLM call via runForkedAgent (cache path).
+  session_btw: { since: 'v1' },
   // F2 (#4175 commit 5). Daemon hosts a workspace-shared MCP transport
   // pool (`QwenAgent.mcpPool`); `GET /workspace/mcp` reflects pool-level
   // accounting (`entryCount`, `entrySummary` on each per-server cell).

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -156,6 +156,8 @@ const EXPECTED_STAGE1_FEATURES = [
   // #4175 follow-up. Daemon hosts `POST /session/:id/recap` (wraps
   // core's `generateSessionRecap` for one-sentence session summaries).
   'session_recap',
+  // Side question (/btw) against the session's conversation context.
+  'session_btw',
   // Issue #4175 PR 21 — auth device-flow surface advertised unconditionally.
   // Registry order on origin/main has PR 21 appended last, so the
   // baseline assertion below mirrors that even though PR 21 landed
@@ -847,6 +849,9 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
         ...(context ? { context } : {}),
       });
       return generateSessionRecapImpl(sessionId, context);
+    },
+    async generateSessionBtw(sessionId, _question, _signal, _context) {
+      return { sessionId, answer: 'mock btw answer' };
     },
     async setWorkspaceToolEnabled(toolName, enabled, originatorClientId) {
       setToolEnabledCalls.push({

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -1789,6 +1789,57 @@ export function createServeApp(
     }
   });
 
+  app.post('/session/:id/btw', mutate(), async (req, res) => {
+    const sessionId = req.params['id'];
+    if (!sessionId) {
+      res
+        .status(400)
+        .json({ error: '`sessionId` route parameter is required' });
+      return;
+    }
+    const body = safeBody(req);
+    const question = body['question'];
+    if (typeof question !== 'string' || question.trim().length === 0) {
+      res.status(400).json({
+        error: '`question` is required and must be a non-empty string',
+      });
+      return;
+    }
+    const abort = new AbortController();
+    const onResClose = () => {
+      if (!res.writableEnded) abort.abort();
+    };
+    res.once('close', onResClose);
+    const clientId = parseClientIdHeader(req, res);
+    if (clientId === null) {
+      res.off('close', onResClose);
+      return;
+    }
+    try {
+      const result = await bridge.generateSessionBtw(
+        sessionId,
+        question.trim(),
+        abort.signal,
+        clientId !== undefined ? { clientId } : undefined,
+      );
+      res.status(200).json(result);
+    } catch (err) {
+      if (
+        err instanceof DOMException &&
+        err.name === 'AbortError' &&
+        abort.signal.aborted
+      ) {
+        return;
+      }
+      sendBridgeError(res, err, {
+        route: 'POST /session/:id/btw',
+        sessionId,
+      });
+    } finally {
+      res.off('close', onResClose);
+    }
+  });
+
   app.post('/session/:id/shell', mutate(), async (req, res) => {
     const sessionId = req.params['id'];
     const body = safeBody(req);

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -1799,9 +1799,14 @@ export function createServeApp(
     }
     const body = safeBody(req);
     const question = body['question'];
-    if (typeof question !== 'string' || question.trim().length === 0) {
+    if (
+      typeof question !== 'string' ||
+      question.trim().length === 0 ||
+      question.length > 4096
+    ) {
       res.status(400).json({
-        error: '`question` is required and must be a non-empty string',
+        error:
+          '`question` is required, must be a non-empty string, and at most 4096 characters',
       });
       return;
     }

--- a/packages/cli/src/ui/commands/btwCommand.test.ts
+++ b/packages/cli/src/ui/commands/btwCommand.test.ts
@@ -444,6 +444,44 @@ describe('btwCommand', () => {
       });
     });
 
+    it('should return fallback text when result.text is null', async () => {
+      mockRunForkedAgent.mockResolvedValue({
+        text: null,
+        usage: { inputTokens: 5, outputTokens: 0, cacheHitTokens: 0 },
+      });
+
+      const acpContext = createMockCommandContext({
+        executionMode: 'acp',
+        services: { config: createConfig() },
+      });
+
+      const result = await btwCommand.action!(acpContext, 'question');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: 'No response received.',
+      });
+    });
+
+    it('should return error when no cache params available', async () => {
+      mockBuildBtwCacheSafeParams.mockReturnValue(null);
+      mockGetCacheSafeParams.mockReturnValue(null);
+
+      const acpContext = createMockCommandContext({
+        executionMode: 'acp',
+        services: { config: createConfig() },
+      });
+
+      const result = await btwCommand.action!(acpContext, 'question');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'Failed to answer btw question: No conversation context available for /btw',
+      });
+    });
+
     it('should not use fire-and-forget pattern', async () => {
       mockRunForkedAgent.mockResolvedValue({
         text: 'answer',

--- a/packages/cli/src/ui/commands/btwCommand.test.ts
+++ b/packages/cli/src/ui/commands/btwCommand.test.ts
@@ -33,10 +33,23 @@ const mockGetCacheSafeParams = vi.hoisted(() =>
     version: 1,
   }),
 );
+const mockBuildBtwCacheSafeParams = vi.hoisted(() =>
+  vi.fn().mockReturnValue({
+    generationConfig: {},
+    history: [],
+    model: 'test-model',
+    version: 0,
+  }),
+);
+const mockBuildBtwPrompt = vi.hoisted(() =>
+  vi.fn().mockImplementation((q: string) => `<system-reminder>...\n${q}`),
+);
 
 vi.mock('@qwen-code/qwen-code-core', () => ({
   runForkedAgent: mockRunForkedAgent,
   getCacheSafeParams: mockGetCacheSafeParams,
+  buildBtwCacheSafeParams: mockBuildBtwCacheSafeParams,
+  buildBtwPrompt: mockBuildBtwPrompt,
 }));
 
 describe('btwCommand', () => {
@@ -163,59 +176,43 @@ describe('btwCommand', () => {
       );
     });
 
-    it('should fall back to live Gemini client context when no saved cache params exist', async () => {
-      mockGetCacheSafeParams.mockReturnValue(null);
+    it('should fall back to getCacheSafeParams when buildBtwCacheSafeParams returns null', async () => {
+      mockBuildBtwCacheSafeParams.mockReturnValue(null);
+      mockGetCacheSafeParams.mockReturnValue({
+        generationConfig: { systemInstruction: 'saved' },
+        history: [],
+        model: 'saved-model',
+        version: 1,
+      });
       mockRunForkedAgent.mockResolvedValue({
         text: 'answer',
         usage: { inputTokens: 5, outputTokens: 2, cacheHitTokens: 0 },
       });
 
-      const geminiClient = {
-        getHistory: vi
-          .fn()
-          .mockReturnValue([
-            { role: 'user', parts: [{ text: '杭州天气如何？' }] },
-          ]),
-        getChat: vi.fn().mockReturnValue({
-          getGenerationConfig: vi.fn().mockReturnValue({
-            systemInstruction: 'You are helpful',
-            tools: [],
-          }),
-        }),
-      };
-
-      const liveContext = createMockCommandContext({
-        services: {
-          config: createConfig({
-            getGeminiClient: () => geminiClient,
-          }),
-        },
-      });
-
-      await btwCommand.action!(liveContext, 'how ?');
+      await btwCommand.action!(mockContext, 'how ?');
       await flushPromises();
 
+      expect(mockBuildBtwCacheSafeParams).toHaveBeenCalled();
+      expect(mockGetCacheSafeParams).toHaveBeenCalled();
       expect(mockRunForkedAgent).toHaveBeenCalledWith(
         expect.objectContaining({
           cacheSafeParams: expect.objectContaining({
-            generationConfig: expect.objectContaining({
-              systemInstruction: 'You are helpful',
-            }),
-            history: [{ role: 'user', parts: [{ text: '杭州天气如何？' }] }],
-            model: 'test-model',
+            model: 'saved-model',
           }),
-          userMessage: expect.stringContaining('how ?'),
         }),
       );
     });
 
-    it('should prefer live Gemini client history over a stale saved cache snapshot', async () => {
+    it('should prefer buildBtwCacheSafeParams result over getCacheSafeParams', async () => {
+      mockBuildBtwCacheSafeParams.mockReturnValue({
+        generationConfig: { systemInstruction: 'live' },
+        history: [{ role: 'user', parts: [{ text: 'live msg' }] }],
+        model: 'live-model',
+        version: 0,
+      });
       mockGetCacheSafeParams.mockReturnValue({
-        generationConfig: {
-          systemInstruction: 'stale system prompt',
-          tools: [],
-        },
-        history: [{ role: 'user', parts: [{ text: '旧问题' }] }],
+        generationConfig: { systemInstruction: 'stale' },
+        history: [],
         model: 'stale-model',
         version: 99,
       });
@@ -224,44 +221,17 @@ describe('btwCommand', () => {
         usage: { inputTokens: 5, outputTokens: 2, cacheHitTokens: 0 },
       });
 
-      const geminiClient = {
-        getHistory: vi.fn().mockReturnValue([
-          { role: 'user', parts: [{ text: '杭州天气如何？' }] },
-          { role: 'user', parts: [{ text: '请顺便解释一下湿度怎么看' }] },
-        ]),
-        getChat: vi.fn().mockReturnValue({
-          getGenerationConfig: vi.fn().mockReturnValue({
-            systemInstruction: 'live system prompt',
-            tools: [],
-          }),
-        }),
-      };
-
-      const liveContext = createMockCommandContext({
-        services: {
-          config: createConfig({
-            getGeminiClient: () => geminiClient,
-          }),
-        },
-      });
-
-      await btwCommand.action!(liveContext, 'how ?');
+      await btwCommand.action!(mockContext, 'how ?');
       await flushPromises();
 
       expect(mockRunForkedAgent).toHaveBeenCalledWith(
         expect.objectContaining({
           cacheSafeParams: expect.objectContaining({
-            generationConfig: expect.objectContaining({
-              systemInstruction: 'live system prompt',
-            }),
-            history: [
-              { role: 'user', parts: [{ text: '杭州天气如何？' }] },
-              { role: 'user', parts: [{ text: '请顺便解释一下湿度怎么看' }] },
-            ],
-            model: 'test-model',
+            model: 'live-model',
           }),
         }),
       );
+      expect(mockGetCacheSafeParams).not.toHaveBeenCalled();
     });
 
     it('should add error item on failure and clear btwItem', async () => {
@@ -432,6 +402,64 @@ describe('btwCommand', () => {
 
       // Now the completed setBtwItem has been called
       expect(mockContext.ui.setBtwItem).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('acp mode', () => {
+    it('should return message result with answer on success', async () => {
+      mockRunForkedAgent.mockResolvedValue({
+        text: 'The answer is 42.',
+        usage: { inputTokens: 10, outputTokens: 5, cacheHitTokens: 3 },
+      });
+
+      const acpContext = createMockCommandContext({
+        executionMode: 'acp',
+        services: { config: createConfig() },
+      });
+
+      const result = await btwCommand.action!(acpContext, 'question');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'info',
+        content: 'The answer is 42.',
+      });
+      expect(acpContext.ui.setBtwItem).not.toHaveBeenCalled();
+    });
+
+    it('should return error message on failure', async () => {
+      mockRunForkedAgent.mockRejectedValue(new Error('Model error'));
+
+      const acpContext = createMockCommandContext({
+        executionMode: 'acp',
+        services: { config: createConfig() },
+      });
+
+      const result = await btwCommand.action!(acpContext, 'question');
+
+      expect(result).toEqual({
+        type: 'message',
+        messageType: 'error',
+        content: 'Failed to answer btw question: Model error',
+      });
+    });
+
+    it('should not use fire-and-forget pattern', async () => {
+      mockRunForkedAgent.mockResolvedValue({
+        text: 'answer',
+        usage: { inputTokens: 5, outputTokens: 2, cacheHitTokens: 0 },
+      });
+
+      const acpContext = createMockCommandContext({
+        executionMode: 'acp',
+        services: { config: createConfig() },
+      });
+
+      const result = await btwCommand.action!(acpContext, 'question');
+
+      expect(result).toBeDefined();
+      expect(acpContext.ui.cancelBtw).not.toHaveBeenCalled();
+      expect(acpContext.ui.setBtwItem).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/cli/src/ui/commands/btwCommand.ts
+++ b/packages/cli/src/ui/commands/btwCommand.ts
@@ -13,7 +13,12 @@ import { CommandKind } from './types.js';
 import { MessageType } from '../types.js';
 import type { HistoryItemBtw } from '../types.js';
 import { t } from '../../i18n/index.js';
-import { getCacheSafeParams, runForkedAgent } from '@qwen-code/qwen-code-core';
+import {
+  buildBtwCacheSafeParams,
+  buildBtwPrompt,
+  getCacheSafeParams,
+  runForkedAgent,
+} from '@qwen-code/qwen-code-core';
 
 function formatBtwError(error: unknown): string {
   return t('Failed to answer btw question: {{error}}', {
@@ -22,66 +27,12 @@ function formatBtwError(error: unknown): string {
   });
 }
 
-/**
- * Wrap the user's side question with constraints so the model knows it must
- * answer without tools in a single response.
- *
- * The system-reminder is embedded in the user message rather than overriding
- * systemInstruction, because runForkedAgent inherits systemInstruction from
- * CacheSafeParams (changing it would bust the prompt cache).
- */
-function buildBtwPrompt(question: string): string {
-  return [
-    '<system-reminder>',
-    'This is a side question from the user. Answer directly in a single response.',
-    '',
-    'CRITICAL CONSTRAINTS:',
-    '- You have NO tools available — you cannot read files, run commands, or take any actions.',
-    '- You can ONLY use information already present in the conversation context.',
-    '- NEVER promise to look something up or investigate further.',
-    '- If you do not know the answer, say so.',
-    '- The main conversation is NOT interrupted; you are a separate, lightweight fork.',
-    '</system-reminder>',
-    '',
-    question,
-  ].join('\n');
-}
-
-function getBtwCacheSafeParams(
-  context: CommandContext,
-): ReturnType<typeof getCacheSafeParams> {
-  const geminiClient = context.services.config?.getGeminiClient();
-  if (
-    geminiClient &&
-    typeof geminiClient === 'object' &&
-    typeof geminiClient.getChat === 'function' &&
-    typeof geminiClient.getHistory === 'function'
-  ) {
-    const chat = geminiClient.getChat();
-    if (
-      chat &&
-      typeof chat === 'object' &&
-      typeof chat.getGenerationConfig === 'function'
-    ) {
-      const generationConfig = chat.getGenerationConfig();
-      if (generationConfig) {
-        const fullHistory = geminiClient.getHistory(true);
-        const maxHistoryEntries = 40;
-        const history =
-          fullHistory.length > maxHistoryEntries
-            ? fullHistory.slice(-maxHistoryEntries)
-            : fullHistory;
-
-        return {
-          generationConfig,
-          history,
-          model: context.services.config?.getModel() ?? '',
-          version: 0,
-        };
-      }
-    }
+function getBtwCacheSafeParams(context: CommandContext) {
+  const { config } = context.services;
+  if (config) {
+    const params = buildBtwCacheSafeParams(config);
+    if (params) return params;
   }
-
   return getCacheSafeParams();
 }
 
@@ -123,7 +74,7 @@ export const btwCommand: SlashCommand = {
     );
   },
   kind: CommandKind.BUILT_IN,
-  supportedModes: ['interactive'] as const,
+  supportedModes: ['interactive', 'acp'] as const,
   action: async (
     context: CommandContext,
     args: string,
@@ -156,6 +107,24 @@ export const btwCommand: SlashCommand = {
         messageType: 'error',
         content: t('No model configured.'),
       };
+    }
+
+    const executionMode = context.executionMode ?? 'interactive';
+    if (executionMode !== 'interactive') {
+      try {
+        const answer = await askBtw(
+          context,
+          question,
+          context.abortSignal ?? new AbortController().signal,
+        );
+        return { type: 'message', messageType: 'info', content: answer };
+      } catch (error) {
+        return {
+          type: 'message',
+          messageType: 'error',
+          content: formatBtwError(error),
+        };
+      }
     }
 
     // Interactive mode: use dedicated btwItem state for the fixed bottom area.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -370,6 +370,7 @@ export * from './utils/toml-to-markdown-converter.js';
 export * from './utils/tool-utils.js';
 export * from './utils/workspaceContext.js';
 export * from './utils/yaml-parser.js';
+export * from './utils/btwUtils.js';
 export * from './utils/forkedAgent.js';
 export * from './utils/sideQuery.js';
 

--- a/packages/core/src/utils/btwUtils.ts
+++ b/packages/core/src/utils/btwUtils.ts
@@ -8,6 +8,8 @@ import type { CacheSafeParams } from './forkedAgent.js';
 import type { Config } from '../config/config.js';
 import { createDebugLogger } from './debugLogger.js';
 
+const logger = createDebugLogger('btw');
+
 export function buildBtwPrompt(question: string): string {
   return [
     '<system-reminder>',
@@ -36,13 +38,13 @@ export function buildBtwCacheSafeParams(
     const maxHistoryEntries = 40;
     const history = geminiClient.getHistoryTail(maxHistoryEntries, true);
     return {
-      generationConfig,
+      generationConfig: structuredClone(generationConfig),
       history,
       model: config.getModel() ?? '',
       version: 0,
     };
   } catch (err) {
-    createDebugLogger('btw').debug(
+    logger.debug(
       `buildBtwCacheSafeParams failed: ${err instanceof Error ? err.message : String(err)}`,
     );
     return null;

--- a/packages/core/src/utils/btwUtils.ts
+++ b/packages/core/src/utils/btwUtils.ts
@@ -6,6 +6,7 @@
 
 import type { CacheSafeParams } from './forkedAgent.js';
 import type { Config } from '../config/config.js';
+import { createDebugLogger } from './debugLogger.js';
 
 export function buildBtwPrompt(question: string): string {
   return [
@@ -32,19 +33,18 @@ export function buildBtwCacheSafeParams(
     const chat = geminiClient.getChat();
     const generationConfig = chat.getGenerationConfig();
     if (!generationConfig) return null;
-    const fullHistory = geminiClient.getHistory(true);
     const maxHistoryEntries = 40;
-    const history =
-      fullHistory.length > maxHistoryEntries
-        ? fullHistory.slice(-maxHistoryEntries)
-        : fullHistory;
+    const history = geminiClient.getHistoryTail(maxHistoryEntries, true);
     return {
       generationConfig,
       history,
       model: config.getModel() ?? '',
       version: 0,
     };
-  } catch {
+  } catch (err) {
+    createDebugLogger('btw').debug(
+      `buildBtwCacheSafeParams failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
     return null;
   }
 }

--- a/packages/core/src/utils/btwUtils.ts
+++ b/packages/core/src/utils/btwUtils.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Code
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CacheSafeParams } from './forkedAgent.js';
+import type { Config } from '../config/config.js';
+
+export function buildBtwPrompt(question: string): string {
+  return [
+    '<system-reminder>',
+    'This is a side question from the user. Answer directly in a single response.',
+    '',
+    'CRITICAL CONSTRAINTS:',
+    '- You have NO tools available — you cannot read files, run commands, or take any actions.',
+    '- You can ONLY use information already present in the conversation context.',
+    '- NEVER promise to look something up or investigate further.',
+    '- If you do not know the answer, say so.',
+    '- The main conversation is NOT interrupted; you are a separate, lightweight fork.',
+    '</system-reminder>',
+    '',
+    question,
+  ].join('\n');
+}
+
+export function buildBtwCacheSafeParams(
+  config: Config,
+): CacheSafeParams | null {
+  const geminiClient = config.getGeminiClient();
+  try {
+    const chat = geminiClient.getChat();
+    const generationConfig = chat.getGenerationConfig();
+    if (!generationConfig) return null;
+    const fullHistory = geminiClient.getHistory(true);
+    const maxHistoryEntries = 40;
+    const history =
+      fullHistory.length > maxHistoryEntries
+        ? fullHistory.slice(-maxHistoryEntries)
+        : fullHistory;
+    return {
+      generationConfig,
+      history,
+      model: config.getModel() ?? '',
+      version: 0,
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- Add `POST /session/:id/btw` REST endpoint to support `/btw` (side question) in daemon HTTP mode
- Extract shared `buildBtwPrompt` + `buildBtwCacheSafeParams` utils to `packages/core`
- Wire ext-method through ACP bridge → acpAgent → `runForkedAgent` (cache path)
- Expand `btwCommand` `supportedModes` to include `'acp'` with synchronous fallback
- Register `session_btw` capability for SDK feature discovery

## Design

Follows the **recap pattern** (ext-method control-plane operation):
- Bridge-side: 60s timeout backstop + races against client-disconnect AbortSignal
- ACP child: 55s `AbortSignal.timeout` self-guard (slightly less than bridge)
- Best-effort: returns `{ answer: null }` when no conversation context exists (no 500)
- No SSE events (short-lived, informational-only — matches recap)

## Test plan

- [x] Type-check passes across `core`, `acp-bridge`, `cli` packages
- [x] All 359 existing tests pass (btw command + server tests)
- [x] New ACP mode tests for btwCommand (success, error, no fire-and-forget)
- [ ] Manual: `qwen serve` → create session → `POST /session/:id/btw` → verify 200 response
- [ ] Manual: verify `GET /session/:id/supported-commands` includes `btw`
- [ ] Manual: verify client disconnect aborts cleanly (no error logs)

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)