### PR TITLE
fix(core): scope boolean coercion to boolean-typed schema fields

### DIFF
--- a/packages/core/src/utils/schemaValidator.test.ts
+++ b/packages/core/src/utils/schemaValidator.test.ts
@@ -203,6 +203,61 @@ describe('SchemaValidator', () => {
       expect(params.is_active).toBe(true);
     });
 
+    it('should not corrupt string fields whose value is literally "true"/"false"', () => {
+      const mixedSchema = {
+        type: 'object',
+        properties: {
+          old_string: { type: 'string' },
+          new_string: { type: 'string' },
+          is_active: { type: 'boolean' },
+        },
+        required: ['old_string', 'new_string', 'is_active'],
+      };
+      // A self-hosted LLM sends `is_active` as the string "false" (the case this
+      // coercion exists for) which fails initial validation and triggers
+      // fixBooleanValues. The string-typed `old_string`/`new_string` arguments
+      // legitimately hold the text "true"/"false" and must survive untouched —
+      // previously they were rewritten into booleans, corrupting the edit.
+      const params = {
+        old_string: 'true',
+        new_string: 'false',
+        is_active: 'false',
+      };
+      expect(SchemaValidator.validate(mixedSchema, params)).toBeNull();
+      expect(params.old_string).toBe('true');
+      expect(params.new_string).toBe('false');
+      expect(params.is_active).toBe(false);
+    });
+
+    it('should not coerce string booleans for fields that also accept string', () => {
+      const unionSchema = {
+        type: 'object',
+        properties: {
+          value: { anyOf: [{ type: 'string' }, { type: 'boolean' }] },
+          is_active: { type: 'boolean' },
+        },
+        required: ['value', 'is_active'],
+      };
+      const params = { value: 'true', is_active: 'true' };
+      expect(SchemaValidator.validate(unionSchema, params)).toBeNull();
+      // `value` accepts string, so the literal "true" is left as a string.
+      expect(params.value).toBe('true');
+      expect(params.is_active).toBe(true);
+    });
+
+    it('should coerce string booleans inside arrays of booleans', () => {
+      const arraySchema = {
+        type: 'object',
+        properties: {
+          flags: { type: 'array', items: { type: 'boolean' } },
+        },
+        required: ['flags'],
+      };
+      const params = { flags: ['true', 'false', 'true'] };
+      expect(SchemaValidator.validate(arraySchema, params)).toBeNull();
+      expect(params.flags).toEqual([true, false, true]);
+    });
+
     it('should pass through actual boolean values unchanged', () => {
       const params = { is_background: true };
       expect(SchemaValidator.validate(booleanSchema, params)).toBeNull();

--- a/packages/core/src/utils/schemaValidator.ts
+++ b/packages/core/src/utils/schemaValidator.ts
@@ -159,7 +159,10 @@ export class SchemaValidator {
     let valid = validate(data);
     if (!valid && validate.errors) {
       // Coerce string boolean values ("true"/"false") to actual booleans
-      fixBooleanValues(data as Record<string, unknown>);
+      fixBooleanValues(
+        data as Record<string, unknown>,
+        anySchema as Record<string, unknown>,
+      );
       // Coerce stringified JSON values (arrays/objects) back to their proper types.
       // Some LLMs serialize complex values as strings when the schema uses
       // anyOf/oneOf (e.g., '["url"]' instead of ["url"] for anyOf: [array, null]).
@@ -272,20 +275,45 @@ function fixStringifiedJsonValues(
   }
 }
 
-function fixBooleanValues(data: Record<string, unknown>) {
+function fixBooleanValues(
+  data: Record<string, unknown>,
+  schema?: Record<string, unknown>,
+) {
+  const properties = schema?.['properties'] as
+    | Record<string, Record<string, unknown>>
+    | undefined;
+  const items = schema?.['items'] as Record<string, unknown> | undefined;
+
   for (const key of Object.keys(data)) {
     if (!(key in data)) continue;
     const value = data[key];
+    // Array elements share the `items` schema; object fields use their
+    // per-property schema.
+    const childSchema = Array.isArray(data) ? items : properties?.[key];
 
     if (typeof value === 'object' && value !== null) {
-      fixBooleanValues(value as Record<string, unknown>);
-    } else if (typeof value === 'string') {
-      const lower = value.toLowerCase();
-      if (lower === 'true') {
-        data[key] = true;
-      } else if (lower === 'false') {
-        data[key] = false;
-      }
+      fixBooleanValues(value as Record<string, unknown>, childSchema);
+      continue;
+    }
+
+    if (typeof value !== 'string') continue;
+
+    // Only coerce when the field's schema explicitly types it as boolean (and
+    // does not also accept string). Without this guard a legitimate string
+    // value of "true"/"false" — e.g. an `old_string`/`content` argument that
+    // happens to be the text "true" — would be silently rewritten into a
+    // boolean, corrupting the tool call. Mirrors fixStringifiedJsonValues,
+    // which is already schema-aware for the same reason.
+    const accepted = childSchema ? getAcceptedTypes(childSchema) : null;
+    if (!accepted || accepted.has('string') || !accepted.has('boolean')) {
+      continue;
+    }
+
+    const lower = value.toLowerCase();
+    if (lower === 'true') {
+      data[key] = true;
+    } else if (lower === 'false') {
+      data[key] = false;
     }
   }
 }


### PR DESCRIPTION
## What this PR does

When tool-parameter validation fails, the validator retries after coercing values, and the boolean-coercion step used to rewrite any string holding the text `true`/`false` into a real boolean, no matter what type the field was declared as. This makes that coercion schema-aware so it only fires for fields whose schema actually accepts a boolean (and does not also accept a string), leaving genuine string arguments untouched.

## Why it's needed

Self-hosted / OpenAI-compatible models frequently emit booleans as the strings `"true"`/`"false"`, so the validator coerces them back on a failed-validation retry. The problem is that the coercion was applied indiscriminately: if a tool call legitimately carried the literal text `"true"` or `"false"` in a string argument (an `old_string`, `new_string`, `content`, commit message, search pattern, etc.) and validation happened to fail for an unrelated reason, that string was silently turned into a boolean. The tool then operated on `true`/`false` instead of the text the model asked for — a silent, hard-to-debug corruption of the requested operation. The neighbouring `fixStringifiedJsonValues` helper already consults the schema (via `getAcceptedTypes`) precisely to avoid this class of over-coercion; the boolean path simply never got the same treatment.

## Reviewer Test Plan

### How to verify

Run the validator unit tests: `cd packages/core && npx vitest run src/utils/schemaValidator.test.ts`. All existing boolean-coercion tests still pass (genuine boolean fields, nested objects, case-insensitive `True`/`FALSE`, etc.), and new tests cover the regression. To confirm the new tests actually exercise the bug, revert only `schemaValidator.ts` and re-run: the two new "should not corrupt…" / "should not coerce… also accept string" tests fail, proving the guard is what fixes the corruption.

### Evidence (Before & After)

Schema: `{ old_string: {type: string}, new_string: {type: string}, is_active: {type: boolean} }`. Params from the model: `{ old_string: "true", new_string: "false", is_active: "false" }` (note `is_active` arrives as a string, which triggers the coercion retry).

Before: validation still reports an error and `params` is mutated to `{ old_string: true, new_string: false, is_active: false }` — the two string arguments are corrupted into booleans.

After: validation returns `null` and `params` is `{ old_string: "true", new_string: "false", is_active: false }` — only the boolean-typed field is coerced; the string arguments are preserved.

UI/TUI: N/A (pure validation logic, no user-visible surface).

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

<!-- ✅ tested · ⚠️ not tested · N/A -->

The change is platform-independent (pure JSON-schema logic with no OS-specific code paths); verified locally on Linux with `vitest`, `eslint`, `prettier --check` and `tsc --noEmit`, and CI exercises macOS/Windows.

### Environment (optional)

Unit tests only.

## Risk & Scope

- Main risk or tradeoff: the coercion is now narrower — a stringified boolean is only converted for a field whose schema accepts `boolean`. Fields with no schema information are left untouched (previously they were coerced), which is the safer default and matches `fixStringifiedJsonValues`.
- Not validated / out of scope: this does not change the separate "stringified JSON" coercion, and is independent of #2512 (which adds the opposite direction — non-string → string — as a new function and does not touch `fixBooleanValues`).
- Breaking changes / migration notes: none. Genuine boolean fields (including `["boolean","null"]` unions and arrays of booleans) are still coerced exactly as before.

## Linked Issues

No existing issue — this is a latent correctness bug found while reviewing the tool-parameter validation path. Happy to open a tracking issue if preferred.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

工具参数校验失败后会先做类型纠正再重试，其中“布尔纠正”这一步原本会把任何取值为 `true`/`false` 的字符串都改成真正的布尔值，完全不看该字段在 schema 里声明的类型。本 PR 让这步纠正变成“看 schema”的：只有当字段的 schema 确实接受布尔（且不同时接受字符串）时才纠正，真正的字符串参数保持原样。

## 为什么需要

自部署 / OpenAI 兼容模型经常把布尔输出成 `"true"`/`"false"` 字符串，所以校验失败重试时会把它们纠正回布尔。问题在于这个纠正是无差别执行的：如果某次工具调用的字符串参数（`old_string`、`new_string`、`content`、commit message、搜索串等）本来就合法地包含文本 `"true"`/`"false"`，而校验又恰好因为别的原因失败，那么这些字符串就会被悄悄改成布尔值，导致工具实际执行的操作和模型请求的不一致——一种很难排查的静默数据损坏。同文件里的 `fixStringifiedJsonValues` 已经通过 `getAcceptedTypes` 查 schema 来避免这类“过度纠正”，只是布尔这条路径一直没用上同样的保护。

## 如何验证

运行：`cd packages/core && npx vitest run src/utils/schemaValidator.test.ts`。所有原有布尔纠正用例仍然通过，新增用例覆盖该回归；只回退 `schemaValidator.ts` 重跑时，新增的两个用例会失败，证明正是这个守卫修复了损坏。

## 影响与风险

纠正范围变窄：只对 schema 接受布尔的字段生效；无 schema 信息的字段不再纠正（更安全，且与 `fixStringifiedJsonValues` 一致）。无破坏性变更，真正的布尔字段（含可空布尔、布尔数组）行为不变。与 #2512 相互独立（那个 PR 是反方向的“非字符串→字符串”，新增函数，不改 `fixBooleanValues`）。

</details>

Made with [Cursor](https://cursor.com)