### PR TITLE
fix(core,cli): label screenshot-triggered compaction accurately in the auto-compact notice

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -908,6 +908,36 @@ describe('Session', () => {
         });
       });
 
+      it('labels the notice as screenshot-triggered when triggerReason is image_overflow', async () => {
+        mockGeminiClient.tryCompressChat.mockResolvedValueOnce({
+          originalTokenCount: 1200,
+          newTokenCount: 450,
+          compressionStatus: core.CompressionStatus.COMPRESSED,
+          triggerReason: 'image_overflow',
+        });
+        mockChat.sendMessageStream = vi
+          .fn()
+          .mockResolvedValue(createEmptyStream());
+
+        await session.prompt({
+          sessionId: 'test-session-id',
+          prompt: [{ type: 'text', text: 'hello' }],
+        });
+
+        expect(mockClient.sessionUpdate).toHaveBeenCalledWith({
+          sessionId: 'test-session-id',
+          update: {
+            sessionUpdate: 'agent_message_chunk',
+            content: {
+              type: 'text',
+              text:
+                'IMPORTANT: This conversation accumulated enough tool screenshots to trigger compaction for qwen3-code-plus. ' +
+                'A compressed context will be sent for future messages (compressed from: 1200 to 450 tokens).',
+            },
+          },
+        });
+      });
+
       it('continues sending when automatic compression fails', async () => {
         mockGeminiClient.tryCompressChat.mockRejectedValueOnce(
           new Error('compression rate limited'),

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -1120,8 +1120,12 @@ export class Session implements SessionContext {
         compressionInfo = compressed;
         this.#recordCompressionTokenCount(compressed);
         if (compressed.compressionStatus === CompressionStatus.COMPRESSED) {
+          const reasonClause =
+            compressed.triggerReason === 'image_overflow'
+              ? `accumulated enough tool screenshots to trigger compaction for ${this.config.getModel()}`
+              : `approached the input token limit for ${this.config.getModel()}`;
           compressionDiagnostic =
-            `IMPORTANT: This conversation approached the input token limit for ${this.config.getModel()}. ` +
+            `IMPORTANT: This conversation ${reasonClause}. ` +
             `A compressed context will be sent for future messages (compressed from: ` +
             `${compressed.originalTokenCount ?? 'unknown'} to ` +
             `${compressed.newTokenCount ?? 'unknown'} tokens).`;

--- a/packages/cli/src/ui/hooks/useGeminiStream.ts
+++ b/packages/cli/src/ui/hooks/useGeminiStream.ts
@@ -1198,11 +1198,15 @@ export const useGeminiStream = (
         addItem(pendingHistoryItemRef.current, userMessageTimestamp);
         setPendingHistoryItem(null);
       }
+      const reasonClause =
+        eventValue?.triggerReason === 'image_overflow'
+          ? `accumulated enough tool screenshots to trigger compaction for ${config.getModel()}`
+          : `approached the input token limit for ${config.getModel()}`;
       return addItem(
         {
           type: 'info',
           text:
-            `IMPORTANT: This conversation approached the input token limit for ${config.getModel()}. ` +
+            `IMPORTANT: This conversation ${reasonClause}. ` +
             `A compressed context will be sent for future messages (compressed from: ` +
             `${eventValue?.originalTokenCount ?? 'unknown'} to ` +
             `${eventValue?.newTokenCount ?? 'unknown'} tokens).`,

--- a/packages/core/src/core/turn.ts
+++ b/packages/core/src/core/turn.ts
@@ -186,10 +186,21 @@ export enum CompressionStatus {
   COMPRESSION_FAILED_OUTPUT_TRUNCATED,
 }
 
+/**
+ * Why an auto-compaction fired. Drives the user-facing notice so a
+ * screenshot-overflow trigger isn't mislabeled as "approached the token
+ * limit". Undefined on NOOP / failure paths and for callers that don't set it.
+ */
+export type CompactionTriggerReason =
+  | 'token_limit'
+  | 'image_overflow'
+  | 'manual';
+
 export interface ChatCompressionInfo {
   originalTokenCount: number;
   newTokenCount: number;
   compressionStatus: CompressionStatus;
+  triggerReason?: CompactionTriggerReason;
 }
 
 export type ServerGeminiChatCompressedEvent = {

--- a/packages/core/src/services/chatCompressionService.test.ts
+++ b/packages/core/src/services/chatCompressionService.test.ts
@@ -279,6 +279,9 @@ describe('ChatCompressionService', () => {
 
       expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
       expect(generateText).toHaveBeenCalled();
+      // Screenshot trigger → reason must be image_overflow (not token_limit)
+      // so the UI notice is accurate when it fired below the token threshold.
+      expect(result.info.triggerReason).toBe('image_overflow');
     });
 
     it('does NOT fire when the trigger is disabled (NOOP below token threshold despite many images)', async () => {
@@ -349,6 +352,9 @@ describe('ChatCompressionService', () => {
 
       expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
       expect(generateText).toHaveBeenCalled();
+      // Screenshot trigger → reason must be image_overflow (not token_limit)
+      // so the UI notice is accurate when it fired below the token threshold.
+      expect(result.info.triggerReason).toBe('image_overflow');
     });
   });
 
@@ -541,6 +547,8 @@ describe('ChatCompressionService', () => {
 
     expect(result.info.compressionStatus).toBe(CompressionStatus.COMPRESSED);
     expect(mockGenerateContent).toHaveBeenCalled();
+    // Crossed the token threshold (not the screenshot trigger) → token_limit.
+    expect(result.info.triggerReason).toBe('token_limit');
   });
 
   it('should compress if over token threshold', async () => {

--- a/packages/core/src/services/chatCompressionService.ts
+++ b/packages/core/src/services/chatCompressionService.ts
@@ -7,7 +7,11 @@
 import type { Content } from '@google/genai';
 import type { Config } from '../config/config.js';
 import type { GeminiChat } from '../core/geminiChat.js';
-import { type ChatCompressionInfo, CompressionStatus } from '../core/turn.js';
+import {
+  type ChatCompressionInfo,
+  type CompactionTriggerReason,
+  CompressionStatus,
+} from '../core/turn.js';
 import { DEFAULT_TOKEN_LIMIT } from '../core/tokenLimits.js';
 import { getCompressionPrompt } from '../core/prompts.js';
 import { runSideQuery } from '../utils/sideQuery.js';
@@ -194,6 +198,11 @@ export class ChatCompressionService {
       signal,
     } = opts;
     const compactTrigger = trigger ?? (force ? 'manual' : 'auto');
+    // Why this compaction fired, surfaced on the COMPRESSED result so the UI
+    // notice is accurate. Defaults by trigger; the gate below upgrades it to
+    // 'image_overflow' when the screenshot trigger is what let it through.
+    let triggerReason: CompactionTriggerReason =
+      compactTrigger === 'manual' ? 'manual' : 'token_limit';
     const chatCompressionSettings = config.getChatCompression();
     const slimmingConfig = resolveSlimmingConfig(chatCompressionSettings);
     const tuning = resolveCompactionTuning(chatCompressionSettings);
@@ -257,6 +266,8 @@ export class ChatCompressionService {
             },
           };
         }
+        // Below the token threshold but the screenshot trigger fired.
+        triggerReason = 'image_overflow';
       }
     }
 
@@ -600,6 +611,7 @@ export class ChatCompressionService {
           originalTokenCount,
           newTokenCount,
           compressionStatus: CompressionStatus.COMPRESSED,
+          triggerReason,
         },
       };
     }


### PR DESCRIPTION
## Summary

The auto-compaction notice always read **"This conversation approached the input token limit for {model}"**, even when compaction was actually fired by the screenshot/image-overflow trigger added in #4599. With the trigger threshold set well below the token-auto threshold (e.g. 20 images on a 1M-window model), the notice was misleading — the conversation had nowhere near the token limit; it had simply accumulated enough tool screenshots.

This PR threads a `triggerReason` through the compaction result so the notice reflects what actually happened.

## Changes

- **core/turn.ts** — add `CompactionTriggerReason = 'token_limit' | 'image_overflow' | 'manual'` and an optional `triggerReason` field on `ChatCompressionInfo`.
- **chatCompressionService.ts** — set `triggerReason` in `compress()`: defaults to `manual`/`token_limit` by trigger, upgraded to `image_overflow` in the gate when the screenshot trigger is what let a below-threshold compaction through. Surfaced on the `COMPRESSED` result.
- **useGeminiStream.ts** & **acp-integration/session/Session.ts** — the two auto-compaction notice sites now pick the wording from `triggerReason`. Screenshot-triggered compaction reads "accumulated enough tool screenshots to trigger compaction for {model}"; the token-limit wording is unchanged.

The notice string is not i18n'd today, so this stays English-only to match the existing behavior.

## Test plan

- [x] `chatCompressionService.test.ts` — assert `triggerReason === 'image_overflow'` on the two screenshot-trigger COMPRESSED cases and `'token_limit'` on the token-trigger case.
- [x] `Session.test.ts` — new case asserting the ACP notice reads "accumulated enough tool screenshots…" when `triggerReason === 'image_overflow'`.
- [x] core + cli `tsc --noEmit` clean.
- [x] Full changed-file suites green (core 55, ACP Session 74).