### PR TITLE
feat(telemetry): add client_id attribute and permission route spans

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -95,13 +95,15 @@ describe('createHttpAcpBridge', () => {
   it('uses bridge telemetry for channel/session/prompt dispatch and prompt metadata injection', async () => {
     const handle = makeChannel();
     const operations: string[] = [];
+    const spanAttributes = new Map<string, Record<string, unknown>>();
     const telemetry: BridgeTelemetry = {
       captureContext: () => ({ captured: true }),
       async runWithContext(_captured, fn) {
         return await fn();
       },
-      async withSpan(operation, _attributes, fn) {
+      async withSpan(operation, attributes, fn) {
         operations.push(operation);
+        spanAttributes.set(operation, attributes);
         return await fn();
       },
       event() {},
@@ -123,14 +125,19 @@ describe('createHttpAcpBridge', () => {
     });
     const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
 
-    await bridge.sendPrompt(session.sessionId, {
-      sessionId: session.sessionId,
-      prompt: [{ type: 'text', text: 'hello' }],
-      _meta: {
-        keep: 'value',
-        'qwen.telemetry.traceparent': 'client-spoof',
-      },
-    } as PromptRequest);
+    await bridge.sendPrompt(
+      session.sessionId,
+      {
+        sessionId: session.sessionId,
+        prompt: [{ type: 'text', text: 'hello' }],
+        _meta: {
+          keep: 'value',
+          'qwen.telemetry.traceparent': 'client-spoof',
+        },
+      } as PromptRequest,
+      undefined,
+      { clientId: session.clientId },
+    );
 
     expect(operations).toEqual(
       expect.arrayContaining([
@@ -143,6 +150,10 @@ describe('createHttpAcpBridge', () => {
     expect(handle.agent.promptCalls[0]!._meta).toMatchObject({
       keep: 'value',
       'qwen.telemetry.traceparent': 'daemon-traceparent',
+    });
+    expect(session.clientId).toBeDefined();
+    expect(spanAttributes.get('prompt.dispatch')).toMatchObject({
+      'qwen-code.client_id': session.clientId,
     });
   });
 

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -2249,6 +2249,9 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
                 'qwen-code.daemon.bridge.operation': 'prompt.dispatch',
                 'session.id': sessionId,
                 'qwen-code.daemon.prompt.queue_wait_ms': Date.now() - queuedAt,
+                ...(context?.clientId
+                  ? { 'qwen-code.client_id': context.clientId }
+                  : {}),
               },
               async () => {
                 const normalized: PromptRequest = telemetry.injectPromptContext(

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -279,7 +279,9 @@ export interface ServeAppDeps {
 
 function resolveDaemonTelemetryRoute(
   req: Request,
-): { route: string; sessionId?: string } | undefined {
+):
+  | { route: string; sessionId?: string; permissionRequestId?: string }
+  | undefined {
   if (req.method === 'POST' && req.path === '/session') {
     return { route: 'POST /session' };
   }
@@ -292,6 +294,27 @@ function resolveDaemonTelemetryRoute(
     return {
       route: `POST /session/:id/${sessionActionName}`,
       sessionId: sessionActionId,
+    };
+  }
+  const sessionPermission = req.path.match(
+    /^\/session\/([^/]+)\/permission\/([^/]+)$/,
+  );
+  if (
+    sessionPermission?.[1] &&
+    sessionPermission?.[2] &&
+    req.method === 'POST'
+  ) {
+    return {
+      route: 'POST /session/:id/permission/:requestId',
+      sessionId: sessionPermission[1],
+      permissionRequestId: sessionPermission[2],
+    };
+  }
+  const globalPermission = req.path.match(/^\/permission\/([^/]+)$/);
+  if (globalPermission?.[1] && req.method === 'POST') {
+    return {
+      route: 'POST /permission/:requestId',
+      permissionRequestId: globalPermission[1],
     };
   }
   const deleteSession = req.path.match(/^\/session\/([^/]+)$/);
@@ -315,12 +338,24 @@ function daemonTelemetryMiddleware(
       next();
       return;
     }
+    const rawClientId = req.get(CLIENT_ID_HEADER);
+    const clientId =
+      rawClientId !== undefined &&
+      rawClientId !== '' &&
+      rawClientId.length <= MAX_CLIENT_ID_LENGTH &&
+      CLIENT_ID_RE.test(rawClientId)
+        ? rawClientId
+        : undefined;
     void withDaemonRequestSpan(
       {
         method: req.method,
         route: route.route,
         workspaceHash,
         ...(route.sessionId ? { sessionId: route.sessionId } : {}),
+        ...(route.permissionRequestId
+          ? { permissionRequestId: route.permissionRequestId }
+          : {}),
+        ...(clientId ? { clientId } : {}),
       },
       async (span) =>
         await new Promise<void>((resolve, reject) => {

--- a/packages/core/src/telemetry/daemon-tracing.test.ts
+++ b/packages/core/src/telemetry/daemon-tracing.test.ts
@@ -18,10 +18,12 @@ vi.mock('./sdk.js', () => ({
 import {
   DAEMON_TRACEPARENT_META_KEY,
   DAEMON_TRACESTATE_META_KEY,
+  addDaemonRequestAttribute,
   createDaemonBridgeTelemetry,
   extractDaemonTraceContext,
   hashDaemonWorkspace,
   injectDaemonTraceContext,
+  withDaemonRequestSpan,
 } from './daemon-tracing.js';
 
 describe('daemon-tracing', () => {
@@ -98,5 +100,90 @@ describe('daemon-tracing', () => {
     });
     expect(setStatus).toHaveBeenCalledWith({ code: SpanStatusCode.OK });
     expect(end).toHaveBeenCalled();
+  });
+
+  function mockTracerStartActiveSpan() {
+    const startActiveSpan = vi.fn(
+      (_name: string, _opts: unknown, fn: (span: Span) => Promise<void>) =>
+        fn({
+          setStatus: vi.fn(),
+          end: vi.fn(),
+          setAttribute: vi.fn(),
+          setAttributes: vi.fn(),
+          recordException: vi.fn(),
+        } as unknown as Span),
+    );
+    vi.spyOn(trace, 'getTracer').mockReturnValue({
+      startActiveSpan,
+    } as unknown as Tracer);
+    return startActiveSpan;
+  }
+
+  it('includes clientId and permissionRequestId in request span attributes', async () => {
+    const startActiveSpan = mockTracerStartActiveSpan();
+
+    await withDaemonRequestSpan(
+      {
+        method: 'POST',
+        route: 'POST /session/:id/permission/:requestId',
+        workspaceHash: 'abc123',
+        sessionId: 'sess-1',
+        clientId: 'client-42',
+        permissionRequestId: 'perm-99',
+      },
+      async () => {},
+    );
+
+    expect(startActiveSpan).toHaveBeenCalledWith(
+      'qwen-code.daemon.request',
+      expect.objectContaining({
+        attributes: expect.objectContaining({
+          'http.request.method': 'POST',
+          'http.route': 'POST /session/:id/permission/:requestId',
+          'session.id': 'sess-1',
+          'qwen-code.client_id': 'client-42',
+          'qwen-code.daemon.permission.request_id': 'perm-99',
+        }),
+      }),
+      expect.any(Function),
+    );
+  });
+
+  it('omits clientId and permissionRequestId when not provided', async () => {
+    const startActiveSpan = mockTracerStartActiveSpan();
+
+    await withDaemonRequestSpan(
+      { method: 'POST', route: 'POST /session' },
+      async () => {},
+    );
+
+    const attrs = (
+      startActiveSpan.mock.calls[0]![1] as {
+        attributes: Record<string, unknown>;
+      }
+    ).attributes;
+    expect(attrs).not.toHaveProperty('qwen-code.client_id');
+    expect(attrs).not.toHaveProperty('qwen-code.daemon.permission.request_id');
+  });
+
+  it('addDaemonRequestAttribute sets attribute on the active span', () => {
+    const setAttribute = vi.fn();
+    vi.spyOn(trace, 'getSpan').mockReturnValue({
+      setAttribute,
+    } as unknown as Span);
+
+    addDaemonRequestAttribute('qwen-code.prompt_id', 'test-prompt-id');
+
+    expect(setAttribute).toHaveBeenCalledWith(
+      'qwen-code.prompt_id',
+      'test-prompt-id',
+    );
+  });
+
+  it('addDaemonRequestAttribute is a no-op without an active span', () => {
+    vi.spyOn(trace, 'getSpan').mockReturnValue(undefined);
+    expect(() =>
+      addDaemonRequestAttribute('qwen-code.prompt_id', 'orphan'),
+    ).not.toThrow();
   });
 });

--- a/packages/core/src/telemetry/daemon-tracing.ts
+++ b/packages/core/src/telemetry/daemon-tracing.ts
@@ -38,6 +38,8 @@ export interface DaemonRequestSpanOptions {
   route: string;
   workspaceHash?: string;
   sessionId?: string;
+  clientId?: string;
+  permissionRequestId?: string;
 }
 
 function errorMessage(error: unknown): string {
@@ -124,6 +126,13 @@ export async function withDaemonRequestSpan<T>(
         ? { 'qwen-code.workspace.hash': options.workspaceHash }
         : {}),
       ...(options.sessionId ? { 'session.id': options.sessionId } : {}),
+      ...(options.clientId ? { 'qwen-code.client_id': options.clientId } : {}),
+      ...(options.permissionRequestId
+        ? {
+            'qwen-code.daemon.permission.request_id':
+              options.permissionRequestId,
+          }
+        : {}),
     },
     fn,
     { autoOkOnSuccess: false },
@@ -151,6 +160,17 @@ export function recordDaemonHttpResponse(
 ): void {
   try {
     span?.setAttribute('http.response.status_code', statusCode);
+  } catch {
+    // Telemetry must not affect request handling.
+  }
+}
+
+export function addDaemonRequestAttribute(
+  key: string,
+  value: string | number | boolean,
+): void {
+  try {
+    trace.getSpan(otelContext.active())?.setAttribute(key, value);
   } catch {
     // Telemetry must not affect request handling.
   }

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -170,6 +170,7 @@ export type { TelemetryRuntimeConfig } from './runtime-config.js';
 export {
   DAEMON_TRACEPARENT_META_KEY,
   DAEMON_TRACESTATE_META_KEY,
+  addDaemonRequestAttribute,
   captureDaemonTelemetryContext,
   createDaemonBridgeTelemetry,
   emitDaemonLog,


### PR DESCRIPTION
## Summary

- Add `qwen-code.client_id` span attribute to daemon HTTP request spans (from `X-Qwen-Client-Id` header, validated with `CLIENT_ID_RE`) and bridge `prompt.dispatch` spans (from `BridgeClientRequestContext.clientId`)
- Add telemetry coverage for permission vote routes: `POST /session/:id/permission/:requestId` and `POST /permission/:requestId`, with `qwen-code.daemon.permission.request_id` span attribute
- Add `addDaemonRequestAttribute()` helper for post-rebase `promptId` enrichment (plumbing for #4554 scope item)

## Test plan

- [x] `packages/core` daemon-tracing tests: 8 passed (4 new — clientId/permissionRequestId inclusion/omission, addDaemonRequestAttribute active/no-op)
- [x] `packages/acp-bridge` bridge tests: 196 passed (existing telemetry test updated to verify `client_id` flows through `prompt.dispatch` span)
- [x] Pre-commit lint + prettier pass

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)