### PR TITLE
fix(core): harden context error text collection

### DIFF
--- a/packages/core/src/utils/contextLengthError.test.ts
+++ b/packages/core/src/utils/contextLengthError.test.ts
@@ -116,4 +116,45 @@ describe('contextLengthError', () => {
 
     expect(info.isExceeded).toBe(false);
   });
+
+  it('skips accessor properties that throw while collecting error text', () => {
+    const error = new Error('Connection error.');
+
+    Object.defineProperty(error, 'name', {
+      enumerable: true,
+      get() {
+        throw new TypeError('Value of "this" must be of DOMException');
+      },
+    });
+    Object.defineProperty(error, 'details', {
+      enumerable: true,
+      get() {
+        throw new TypeError('Value of "this" must be of DOMException');
+      },
+    });
+
+    const info = getContextLengthExceededInfo(error);
+
+    expect(info.isExceeded).toBe(false);
+    expect(info.message).toContain('Connection error.');
+  });
+
+  it('skips throwing accessors on plain objects', () => {
+    const errorLike: Record<string, unknown> = {};
+    Object.defineProperty(errorLike, 'detail', {
+      enumerable: true,
+      get() {
+        throw new TypeError('accessor refused');
+      },
+    });
+    Object.defineProperty(errorLike, 'message', {
+      enumerable: true,
+      value: 'context_length_exceeded: too many tokens',
+    });
+
+    const info = getContextLengthExceededInfo(errorLike);
+
+    expect(info.isExceeded).toBe(true);
+    expect(info.message).toContain('context_length_exceeded');
+  });
 });

--- a/packages/core/src/utils/contextLengthError.ts
+++ b/packages/core/src/utils/contextLengthError.ts
@@ -103,6 +103,32 @@ function tryParseEmbeddedJson(text: string): unknown | undefined {
   }
 }
 
+function safeReadProperty(value: object, key: string): unknown {
+  try {
+    return (value as Record<string, unknown>)[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function enumerableValues(value: object): unknown[] {
+  try {
+    return Object.values(value);
+  } catch {
+    try {
+      const descriptors = Object.getOwnPropertyDescriptors(value);
+      return Object.values(descriptors)
+        .filter(
+          (descriptor): descriptor is PropertyDescriptor & { value: unknown } =>
+            'value' in descriptor && descriptor.enumerable === true,
+        )
+        .map((descriptor) => descriptor.value);
+    } catch {
+      return [];
+    }
+  }
+}
+
 function collectStrings(
   value: unknown,
   seen: Set<object>,
@@ -135,11 +161,21 @@ function collectStrings(
 
   const strings: string[] = [];
   if (value instanceof Error) {
-    strings.push(value.name, value.message);
-    strings.push(...collectStrings(value.cause, seen, depth + 1));
+    const name = safeReadProperty(value, 'name');
+    const message = safeReadProperty(value, 'message');
+
+    if (typeof name === 'string') {
+      strings.push(name);
+    }
+    if (typeof message === 'string') {
+      strings.push(message);
+    }
+    strings.push(
+      ...collectStrings(safeReadProperty(value, 'cause'), seen, depth + 1),
+    );
   }
 
-  for (const [, nested] of Object.entries(value)) {
+  for (const nested of enumerableValues(value)) {
     strings.push(...collectStrings(nested, seen, depth + 1));
   }
 


### PR DESCRIPTION
## Summary

Fixes #4609.

The context-length classifier walks provider error objects to find useful text. Some provider/network errors can contain DOMException-like objects whose accessors throw when read outside their expected receiver. In the reported stack, that made the diagnostic helper fail while handling the original API connection error.

This patch makes the text collector skip throwing accessors and fall back to data descriptors when `Object.entries()` cannot safely enumerate an object. The original error message is still preserved when it is readable.

## Testing

```
npm run test --workspace=packages/core -- contextLengthError.test.ts
npm run typecheck --workspace=packages/core
npx eslint packages/core/src/utils/contextLengthError.ts packages/core/src/utils/contextLengthError.test.ts --max-warnings 0
npx prettier --check packages/core/src/utils/contextLengthError.ts packages/core/src/utils/contextLengthError.test.ts
npm run build --workspace=packages/core
git diff --check
```
