### PR TITLE
fix(cli): stabilize statusline preset ordering

### DIFF
--- a/packages/cli/src/ui/components/StatusLineDialog.test.tsx
+++ b/packages/cli/src/ui/components/StatusLineDialog.test.tsx
@@ -49,7 +49,10 @@ const config = {
   getCliVersion: () => '1.2.3',
   getModel: () => 'qwen3-code-plus',
   getTargetDir: () => '/repo/project',
-  getContentGeneratorConfig: () => ({ contextWindowSize: 1000 }),
+  getContentGeneratorConfig: () => ({
+    contextWindowSize: 1000,
+    reasoning: { effort: 'high' },
+  }),
 } as Config;
 
 const uiState = {
@@ -84,8 +87,26 @@ describe('StatusLineDialog', () => {
 
     expect(lastFrame()).toContain('Configure Status Line');
     expect(lastFrame()).toContain('Type to search');
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('model-with-reasoning');
+    expect(frame).toContain('model-only');
+    expect(frame).toContain('git-branch');
+    expect(frame).toContain('context-remaining');
+    expect(frame).toContain('current-dir');
+    expect(frame.indexOf('model-with-reasoning')).toBeLessThan(
+      frame.indexOf('model-only'),
+    );
+    expect(frame.indexOf('model-only')).toBeLessThan(
+      frame.indexOf('git-branch'),
+    );
+    expect(frame.indexOf('git-branch')).toBeLessThan(
+      frame.indexOf('context-remaining'),
+    );
+    expect(frame.indexOf('context-remaining')).toBeLessThan(
+      frame.indexOf('current-dir'),
+    );
     expect(lastFrame()).toContain('Preview');
-    expect(lastFrame()).toContain('qwen3-code-plus');
+    expect(lastFrame()).toContain('qwen3-code-plus high');
   });
 
   it('persists selected presets on enter', async () => {
@@ -117,10 +138,10 @@ describe('StatusLineDialog', () => {
       useThemeColors: true,
       items: [
         'model-with-reasoning',
+        'git-branch',
         'context-remaining',
         'current-dir',
         'context-used',
-        'git-branch',
       ],
     });
     expect(
@@ -135,6 +156,53 @@ describe('StatusLineDialog', () => {
     );
     expect(onSaved).toHaveBeenCalledWith(settings.merged.ui?.statusLine);
     expect(onClose).toHaveBeenCalled();
+  });
+
+  it('keeps preset priority order after an item is toggled off and on', async () => {
+    const settings = createSettings();
+    const { stdin, lastFrame } = render(
+      <KeypressProvider kittyProtocolEnabled={false}>
+        <StatusLineDialog
+          settings={settings}
+          config={config}
+          uiState={uiState}
+          addItem={vi.fn()}
+          onClose={vi.fn()}
+          availableTerminalHeight={18}
+        />
+      </KeypressProvider>,
+    );
+
+    const press = async (input: string) => {
+      act(() => {
+        stdin.write(input);
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    };
+
+    await press('j');
+    await press('j');
+    await press('j');
+    await press(' ');
+    await press(' ');
+
+    expect(lastFrame()).toContain(
+      'qwen3-code-plus high | feature/pr-4087-statusline | Context 75% left',
+    );
+
+    await press('\r');
+
+    expect(settings.merged.ui?.statusLine).toEqual({
+      type: 'preset',
+      useThemeColors: true,
+      items: [
+        'model-with-reasoning',
+        'git-branch',
+        'context-remaining',
+        'current-dir',
+        'context-used',
+      ],
+    });
   });
 
   it('saves back to workspace settings when workspace config is effective', async () => {

--- a/packages/cli/src/ui/components/StatusLineDialog.tsx
+++ b/packages/cli/src/ui/components/StatusLineDialog.tsx
@@ -22,6 +22,7 @@ import {
   buildStatusLinePresetLines,
   DEFAULT_STATUS_LINE_PRESET_CONFIG,
   normalizeStatusLinePresetConfig,
+  orderStatusLinePresetItems,
   STATUS_LINE_PRESET_ITEMS,
   type StatusLinePresetConfig,
   type StatusLinePresetItemId,
@@ -57,19 +58,11 @@ function buildInitialSelectedKeys(settings: LoadedSettings): string[] {
 
 function buildConfigFromKeys(keys: readonly string[]): StatusLinePresetConfig {
   const selected = new Set(keys);
-  const validItemIds = new Set(STATUS_LINE_PRESET_ITEMS.map((item) => item.id));
-  const items = [
-    ...new Set(
-      keys.filter((key): key is StatusLinePresetItemId =>
-        validItemIds.has(key as StatusLinePresetItemId),
-      ),
-    ),
-  ];
 
   return {
     type: 'preset',
     useThemeColors: selected.has(THEME_COLORS_KEY),
-    items,
+    items: orderStatusLinePresetItems(keys),
   };
 }
 
@@ -102,15 +95,16 @@ function getPreviewData(config: Config, uiState: UIState) {
   const stats = uiState.sessionStats;
   const metrics = stats.metrics;
   const { totalInputTokens, totalOutputTokens } = aggregateModelTokens(metrics);
+  const contentGeneratorConfig = config.getContentGeneratorConfig();
 
   return buildStatusLinePresetData({
     sessionId: stats.sessionId,
     version: config.getCliVersion(),
     modelDisplayName: uiState.currentModel || config.getModel(),
+    reasoning: contentGeneratorConfig?.reasoning,
     currentDir: config.getTargetDir(),
     branch: uiState.branchName,
-    contextWindowSize:
-      config.getContentGeneratorConfig()?.contextWindowSize || 0,
+    contextWindowSize: contentGeneratorConfig?.contextWindowSize || 0,
     currentUsage: stats.lastPromptTokenCount,
     totalInputTokens,
     totalOutputTokens,

--- a/packages/cli/src/ui/hooks/useStatusLine.test.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 import * as child_process from 'child_process';
 import { StreamingState } from '../types.js';
+import type { StatusLinePresetReasoning } from '../statusLinePresets.js';
 
 const debugLogMock = vi.hoisted(() => ({
   log: vi.fn(),
@@ -49,11 +50,20 @@ vi.mock('../contexts/UIStateContext.js', () => ({
   useUIState: () => mockUIState,
 }));
 
+type MockContentGeneratorConfig = {
+  contextWindowSize: number;
+  reasoning?: StatusLinePresetReasoning;
+};
+
+const getMockContentGeneratorConfig = (): MockContentGeneratorConfig => ({
+  contextWindowSize: 131072,
+});
+
 const mockConfig = {
   getTargetDir: vi.fn(() => '/test/dir'),
   getModel: vi.fn(() => 'test-model'),
   getCliVersion: vi.fn(() => '1.0.0'),
-  getContentGeneratorConfig: vi.fn(() => ({ contextWindowSize: 131072 })),
+  getContentGeneratorConfig: vi.fn(getMockContentGeneratorConfig),
 };
 vi.mock('../contexts/ConfigContext.js', () => ({
   useConfig: () => mockConfig,
@@ -149,6 +159,9 @@ describe('useStatusLine', () => {
     mockUIState.sessionStats.metrics.files.totalLinesRemoved = 0;
     mockVimMode.vimEnabled = false;
     mockVimMode.vimMode = 'INSERT';
+    mockConfig.getContentGeneratorConfig.mockReturnValue({
+      contextWindowSize: 131072,
+    });
 
     // Dynamic import to get fresh module after mocks
     const mod = await import('./useStatusLine.js');
@@ -234,6 +247,21 @@ describe('useStatusLine', () => {
 
       expect(child_process.exec).not.toHaveBeenCalled();
       expect(result.current.lines).toEqual(['test-model']);
+    });
+
+    it('renders model-with-reasoning and model-only together', () => {
+      mockConfig.getContentGeneratorConfig.mockReturnValue({
+        contextWindowSize: 131072,
+        reasoning: { effort: 'high' },
+      });
+      setStatusLineConfig({
+        type: 'preset',
+        items: ['model', 'model-with-reasoning'],
+      });
+      const { result } = renderHook(() => useStatusLine());
+
+      expect(child_process.exec).not.toHaveBeenCalled();
+      expect(result.current.lines).toEqual(['test-model high | test-model']);
     });
 
     it('refreshes when status line settings are saved in the same process', async () => {

--- a/packages/cli/src/ui/hooks/useStatusLine.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.ts
@@ -373,12 +373,13 @@ export function useStatusLine(): {
 
       const { totalInputTokens, totalOutputTokens } = aggregateModelTokens(m);
 
-      const contextWindowSize =
-        cfg.getContentGeneratorConfig()?.contextWindowSize || 0;
+      const contentGeneratorConfig = cfg.getContentGeneratorConfig();
+      const contextWindowSize = contentGeneratorConfig?.contextWindowSize || 0;
       const data = buildStatusLinePresetData({
         sessionId: stats.sessionId,
         version: cfg.getCliVersion(),
         modelDisplayName: ui.currentModel || cfg.getModel(),
+        reasoning: contentGeneratorConfig?.reasoning,
         currentDir,
         branch: ui.branchName,
         pullRequestNumber: pullRequestNumberRef.current,

--- a/packages/cli/src/ui/statusLinePresets.test.ts
+++ b/packages/cli/src/ui/statusLinePresets.test.ts
@@ -11,6 +11,7 @@ import {
   buildStatusLinePresetData,
   buildStatusLinePresetLines,
   DEFAULT_STATUS_LINE_PRESET_CONFIG,
+  formatModelWithReasoning,
   formatTokenCount,
   getRunStateLabel,
   inferPullRequestNumber,
@@ -61,6 +62,36 @@ describe('statusLinePresets', () => {
       orderStatusLinePresetItems(
         [...DEFAULT_STATUS_LINE_PRESET_CONFIG.items].reverse(),
       ),
+    );
+  });
+
+  it('orders preset items directly', () => {
+    expect(orderStatusLinePresetItems([])).toEqual([]);
+    expect(orderStatusLinePresetItems(['bogus'])).toEqual([]);
+    expect(orderStatusLinePresetItems([42, null])).toEqual([]);
+    expect(
+      orderStatusLinePresetItems([
+        'run-state',
+        'model',
+        'git-branch',
+        'model',
+        'context-remaining',
+      ]),
+    ).toEqual(['model', 'git-branch', 'context-remaining', 'run-state']);
+  });
+
+  it('formats model reasoning directly', () => {
+    expect(formatModelWithReasoning('qwen3-code-plus', false)).toBe(
+      'qwen3-code-plus reasoning off',
+    );
+    expect(
+      formatModelWithReasoning('qwen3-code-plus', { effort: 'high' }),
+    ).toBe('qwen3-code-plus high');
+    expect(
+      formatModelWithReasoning('qwen3-code-plus', { effort: undefined }),
+    ).toBe('qwen3-code-plus');
+    expect(formatModelWithReasoning('qwen3-code-plus', undefined)).toBe(
+      'qwen3-code-plus',
     );
   });
 

--- a/packages/cli/src/ui/statusLinePresets.test.ts
+++ b/packages/cli/src/ui/statusLinePresets.test.ts
@@ -15,11 +15,13 @@ import {
   getRunStateLabel,
   inferPullRequestNumber,
   normalizeStatusLinePresetConfig,
+  orderStatusLinePresetItems,
   STATUS_LINE_PRESET_ITEM_IDS,
+  STATUS_LINE_PRESET_ITEMS,
 } from './statusLinePresets.js';
 
 describe('statusLinePresets', () => {
-  it('normalizes valid preset configs and drops unknown items', () => {
+  it('normalizes valid preset configs and orders items by priority', () => {
     expect(
       normalizeStatusLinePresetConfig({
         type: 'preset',
@@ -54,7 +56,21 @@ describe('statusLinePresets', () => {
     ).toEqual(DEFAULT_STATUS_LINE_PRESET_CONFIG);
   });
 
-  it('renders available preset items and omits unavailable optional fields', () => {
+  it('keeps default preset items in priority order', () => {
+    expect(DEFAULT_STATUS_LINE_PRESET_CONFIG.items).toEqual(
+      orderStatusLinePresetItems(
+        [...DEFAULT_STATUS_LINE_PRESET_CONFIG.items].reverse(),
+      ),
+    );
+  });
+
+  it('labels the plain model preset as model-only', () => {
+    expect(
+      STATUS_LINE_PRESET_ITEMS.find((item) => item.id === 'model')?.label,
+    ).toBe('model-only');
+  });
+
+  it('renders available preset items in priority order', () => {
     const data = buildStatusLinePresetData({
       sessionId: 'session-123',
       version: '1.2.3',
@@ -75,12 +91,12 @@ describe('statusLinePresets', () => {
         {
           type: 'preset',
           items: [
-            'model',
-            'context-remaining',
-            'current-dir',
-            'pull-request-number',
-            'branch-changes',
             'run-state',
+            'model',
+            'branch-changes',
+            'pull-request-number',
+            'current-dir',
+            'context-remaining',
           ],
         },
         data,
@@ -95,6 +111,7 @@ describe('statusLinePresets', () => {
       sessionId: 'session-123',
       version: '1.2.3',
       modelDisplayName: 'qwen3-code-plus',
+      reasoning: { effort: 'high' },
       currentDir: '/repo/project',
       branch: 'feature/pr-4087-statusline',
       contextWindowSize: 1000,
@@ -115,11 +132,67 @@ describe('statusLinePresets', () => {
         data,
       ),
     ).toEqual([
-      'qwen3-code-plus | Context 75% left | /repo/project | Context 25% used | feature/pr-4087-statusline | project | #4087 | +12 -3 | Ready | v1.2.3 | 1.0k window | 250 used | 1.2k in | 340 out | session-123',
+      'qwen3-code-plus high | qwen3-code-plus | feature/pr-4087-statusline | Context 75% left | 1.2k in | 340 out | /repo/project | project | #4087 | +12 -3 | Context 25% used | Ready | v1.2.3 | 1.0k window | 250 used | session-123',
     ]);
   });
 
-  it('treats model and model-with-reasoning as mutually exclusive', () => {
+  it('renders model and model-with-reasoning together', () => {
+    const data = buildStatusLinePresetData({
+      sessionId: 'session-123',
+      version: '1.2.3',
+      modelDisplayName: 'qwen3-code-plus',
+      reasoning: { effort: 'high' },
+      currentDir: '/repo/project',
+      branch: undefined,
+      contextWindowSize: 0,
+      currentUsage: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalLinesAdded: 0,
+      totalLinesRemoved: 0,
+      streamingState: StreamingState.Idle,
+    });
+
+    expect(
+      buildStatusLinePresetLines(
+        {
+          type: 'preset',
+          items: ['model', 'model-with-reasoning'],
+        },
+        data,
+      ),
+    ).toEqual(['qwen3-code-plus high | qwen3-code-plus']);
+  });
+
+  it('shows when reasoning is disabled', () => {
+    const data = buildStatusLinePresetData({
+      sessionId: 'session-123',
+      version: '1.2.3',
+      modelDisplayName: 'qwen3-code-plus',
+      reasoning: false,
+      currentDir: '/repo/project',
+      branch: undefined,
+      contextWindowSize: 0,
+      currentUsage: 0,
+      totalInputTokens: 0,
+      totalOutputTokens: 0,
+      totalLinesAdded: 0,
+      totalLinesRemoved: 0,
+      streamingState: StreamingState.Idle,
+    });
+
+    expect(
+      buildStatusLinePresetLines(
+        {
+          type: 'preset',
+          items: ['model-with-reasoning'],
+        },
+        data,
+      ),
+    ).toEqual(['qwen3-code-plus reasoning off']);
+  });
+
+  it('falls back to the model name when reasoning is unset', () => {
     const data = buildStatusLinePresetData({
       sessionId: 'session-123',
       version: '1.2.3',
@@ -139,7 +212,7 @@ describe('statusLinePresets', () => {
       buildStatusLinePresetLines(
         {
           type: 'preset',
-          items: ['model-with-reasoning', 'model'],
+          items: ['model-with-reasoning'],
         },
         data,
       ),

--- a/packages/cli/src/ui/statusLinePresets.ts
+++ b/packages/cli/src/ui/statusLinePresets.ts
@@ -9,20 +9,20 @@ import { StreamingState } from './types.js';
 
 export const STATUS_LINE_PRESET_ITEM_IDS = [
   'model-with-reasoning',
-  'context-remaining',
-  'current-dir',
-  'context-used',
-  'git-branch',
   'model',
+  'git-branch',
+  'context-remaining',
+  'total-input-tokens',
+  'total-output-tokens',
+  'current-dir',
   'project-name',
   'pull-request-number',
   'branch-changes',
+  'context-used',
   'run-state',
   'qwen-version',
   'context-window-size',
   'used-tokens',
-  'total-input-tokens',
-  'total-output-tokens',
   'session-id',
 ] as const;
 
@@ -42,10 +42,18 @@ export interface StatusLinePresetConfig {
   useThemeColors?: boolean;
 }
 
+export type StatusLinePresetReasoning =
+  | false
+  | {
+      effort?: 'low' | 'medium' | 'high' | 'max';
+    }
+  | undefined;
+
 export interface StatusLinePresetData {
   sessionId: string;
   version: string;
   modelDisplayName: string;
+  reasoning: StatusLinePresetReasoning;
   currentDir: string;
   projectName: string | undefined;
   branch: string | undefined;
@@ -81,22 +89,9 @@ export const STATUS_LINE_PRESET_ITEMS: readonly StatusLinePresetItem[] = [
     defaultSelected: true,
   },
   {
-    id: 'context-remaining',
-    label: 'context-remaining',
-    description: 'Percentage of context window remaining',
-    defaultSelected: true,
-  },
-  {
-    id: 'current-dir',
-    label: 'current-dir',
-    description: 'Current working directory',
-    defaultSelected: true,
-  },
-  {
-    id: 'context-used',
-    label: 'context-used',
-    description: 'Percentage of context window used',
-    defaultSelected: true,
+    id: 'model',
+    label: 'model-only',
+    description: 'Current model name without reasoning level',
   },
   {
     id: 'git-branch',
@@ -105,9 +100,26 @@ export const STATUS_LINE_PRESET_ITEMS: readonly StatusLinePresetItem[] = [
     defaultSelected: true,
   },
   {
-    id: 'model',
-    label: 'model',
-    description: 'Current model name',
+    id: 'context-remaining',
+    label: 'context-remaining',
+    description: 'Percentage of context window remaining',
+    defaultSelected: true,
+  },
+  {
+    id: 'total-input-tokens',
+    label: 'total-input-tokens',
+    description: 'Total input tokens used in session',
+  },
+  {
+    id: 'total-output-tokens',
+    label: 'total-output-tokens',
+    description: 'Total output tokens used in session',
+  },
+  {
+    id: 'current-dir',
+    label: 'current-dir',
+    description: 'Current working directory',
+    defaultSelected: true,
   },
   {
     id: 'project-name',
@@ -123,6 +135,12 @@ export const STATUS_LINE_PRESET_ITEMS: readonly StatusLinePresetItem[] = [
     id: 'branch-changes',
     label: 'branch-changes',
     description: 'Session file changes added and removed',
+  },
+  {
+    id: 'context-used',
+    label: 'context-used',
+    description: 'Percentage of context window used',
+    defaultSelected: true,
   },
   {
     id: 'run-state',
@@ -145,16 +163,6 @@ export const STATUS_LINE_PRESET_ITEMS: readonly StatusLinePresetItem[] = [
     description: 'Current prompt tokens used',
   },
   {
-    id: 'total-input-tokens',
-    label: 'total-input-tokens',
-    description: 'Total input tokens used in session',
-  },
-  {
-    id: 'total-output-tokens',
-    label: 'total-output-tokens',
-    description: 'Total output tokens used in session',
-  },
-  {
     id: 'session-id',
     label: 'session-id',
     description: 'Current session identifier',
@@ -165,11 +173,26 @@ const STATUS_LINE_PRESET_ITEM_ID_SET = new Set<string>(
   STATUS_LINE_PRESET_ITEM_IDS,
 );
 
+export function orderStatusLinePresetItems(
+  items: readonly unknown[],
+): StatusLinePresetItemId[] {
+  const selectedItems = new Set(
+    items.filter(
+      (item): item is StatusLinePresetItemId =>
+        typeof item === 'string' && STATUS_LINE_PRESET_ITEM_ID_SET.has(item),
+    ),
+  );
+
+  return STATUS_LINE_PRESET_ITEM_IDS.filter((item) => selectedItems.has(item));
+}
+
 export const DEFAULT_STATUS_LINE_PRESET_CONFIG: StatusLinePresetConfig = {
   type: 'preset',
   useThemeColors: true,
-  items: STATUS_LINE_PRESET_ITEMS.filter((item) => item.defaultSelected).map(
-    (item) => item.id,
+  items: orderStatusLinePresetItems(
+    STATUS_LINE_PRESET_ITEMS.filter((item) => item.defaultSelected).map(
+      (item) => item.id,
+    ),
   ),
 };
 
@@ -186,12 +209,8 @@ export function normalizeStatusLinePresetConfig(
   }
 
   const hasItemsArray = Array.isArray(candidate['items']);
-  const rawItems = hasItemsArray ? (candidate['items'] as unknown[]) : [];
   const items = hasItemsArray
-    ? rawItems.filter(
-        (item): item is StatusLinePresetItemId =>
-          typeof item === 'string' && STATUS_LINE_PRESET_ITEM_ID_SET.has(item),
-      )
+    ? orderStatusLinePresetItems(candidate['items'] as unknown[])
     : [];
 
   return {
@@ -200,9 +219,7 @@ export function normalizeStatusLinePresetConfig(
       typeof candidate['useThemeColors'] === 'boolean'
         ? candidate['useThemeColors']
         : true,
-    items: hasItemsArray
-      ? [...new Set(items)]
-      : [...DEFAULT_STATUS_LINE_PRESET_CONFIG.items],
+    items: hasItemsArray ? items : [...DEFAULT_STATUS_LINE_PRESET_CONFIG.items],
   };
 }
 
@@ -240,6 +257,19 @@ export function getRunStateLabel(state: StreamingState): string {
   }
 }
 
+export function formatModelWithReasoning(
+  modelDisplayName: string,
+  reasoning: StatusLinePresetReasoning,
+): string {
+  if (reasoning === false) {
+    return `${modelDisplayName} reasoning off`;
+  }
+  if (reasoning?.effort) {
+    return `${modelDisplayName} ${reasoning.effort}`;
+  }
+  return modelDisplayName;
+}
+
 export function inferPullRequestNumber(
   branch: string | undefined,
 ): string | undefined {
@@ -256,6 +286,7 @@ export function buildStatusLinePresetData(params: {
   sessionId: string;
   version: string | undefined;
   modelDisplayName: string | undefined;
+  reasoning?: StatusLinePresetReasoning;
   currentDir: string;
   branch: string | undefined;
   pullRequestNumber?: string | undefined;
@@ -284,6 +315,7 @@ export function buildStatusLinePresetData(params: {
     sessionId: params.sessionId,
     version: params.version || 'unknown',
     modelDisplayName: params.modelDisplayName || 'unknown',
+    reasoning: params.reasoning,
     currentDir: params.currentDir,
     projectName: nodePath.basename(params.currentDir) || undefined,
     branch: params.branch,
@@ -305,20 +337,16 @@ export function buildStatusLinePresetParts(
   data: StatusLinePresetData,
 ): string[] {
   const parts: string[] = [];
-  const seen = new Set<StatusLinePresetItemId>();
 
-  for (const item of config.items) {
-    if (seen.has(item)) {
-      continue;
-    }
-    seen.add(item);
-
+  for (const item of orderStatusLinePresetItems(config.items)) {
     switch (item) {
       case 'model-with-reasoning':
+        parts.push(
+          formatModelWithReasoning(data.modelDisplayName, data.reasoning),
+        );
+        break;
       case 'model':
         parts.push(data.modelDisplayName);
-        seen.add('model');
-        seen.add('model-with-reasoning');
         break;
       case 'context-remaining':
         if (data.contextWindowSize > 0) {


### PR DESCRIPTION
## What this PR does

This PR makes built-in `/statusline` preset items behave as a visible item set instead of using MultiSelect insertion order as the display order. Preset items are normalized and rendered using a fixed priority order, so manually written settings, saved dialog settings, preview output, and footer rendering stay consistent.

It also updates the model-related preset behavior so `model-with-reasoning` remains first, `model-only` appears immediately after it, and both model entries can be displayed together when selected. The preset order is adjusted to keep model information first, followed by high-frequency runtime information such as Git branch, context remaining, and session token totals.

## Why it's needed

Before this change, disabling a statusline preset item and enabling it again caused the item to reappear at the end of the statusline. That made the statusline order unstable and harder to scan during normal use.

Using a fixed internal priority makes the preset configuration easier to reason about: `items` now represents which preset entries are visible, while display order is controlled by the built-in preset order. This preserves existing settings compatibility while improving the interactive `/statusline` experience.

## Reviewer Test Plan

### How to verify

Open `/statusline`, disable a selected preset item such as `context-remaining`, enable it again, and save. The saved preset items should return to the fixed priority order instead of appending the toggled item to the end.

Select both `model-with-reasoning` and `model-only`. The rendered statusline should show the model-with-reasoning entry first and the plain model entry second, for example `qwen3-code-plus high | qwen3-code-plus` when reasoning effort is configured.

Use a manually written preset config with items in a scrambled order. The preview and rendered statusline should still display items in the built-in priority order.

Local verification:
```console
cd packages/cli && npx vitest run src/ui/statusLinePresets.test.ts src/ui/components/StatusLineDialog.test.tsx src/ui/hooks/useStatusLine.test.ts
cd packages/cli && npx eslint src/ui/statusLinePresets.ts src/ui/statusLinePresets.test.ts src/ui/components/StatusLineDialog.tsx src/ui/components/StatusLineDialog.test.tsx src/ui/hooks/useStatusLine.ts src/ui/hooks/useStatusLine.test.ts
git diff --check
```

### Evidence (Before & After)

Before: toggling an existing preset item off and back on could move it to the end because the saved order followed MultiSelect insertion order.

After: toggled preset items are saved and rendered in the fixed priority order. Targeted tests cover normalization, dialog saving, preview ordering, footer rendering, and hook integration.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows PowerShell. Targeted Vitest tests, ESLint for touched files, and `git diff --check` pass locally. `cd packages/cli && npm run typecheck` is currently blocked by an existing missing `@qwen-code/channel-feishu` module/type dependency, unrelated to this statusline change.

## Risk & Scope

- Main risk or tradeoff: Users who relied on custom ordering within preset `items` will now see the built-in priority order instead. This matches the intended behavior that preset `items` controls visibility, not custom ordering.
- Not validated / out of scope: Custom command statusline payloads are unchanged and were not modified. No new preset fields, schema changes, or user-configurable ordering controls are included.
- Breaking changes / migration notes: No settings schema migration is required. The existing config id `model` remains supported; only the UI label is shown as `model-only`.

## Linked Issues

Closes #4633

<details>
<summary>中文说明</summary>

## What this PR does

此 PR 将内置 `/statusline` 预设项改为“可见项集合”语义，不再使用 MultiSelect 的插入顺序作为显示顺序。预设项会通过固定优先级进行归一化和渲染，因此手写 settings、弹窗保存、预览输出和 footer 实际渲染会保持一致。

同时，此 PR 调整了模型相关预设项行为：`model-with-reasoning` 保持第一位，`model-only` 紧随其后，并且当两者都被选中时可以同时显示。预设顺序也被调整为模型信息优先，然后显示 Git 分支、上下文剩余、会话 token 总量等高频运行信息。

## Why it's needed

在此改动前，用户在 statusline 预设里关闭某个已选项后再重新开启，该项可能会被追加到末尾。这会让 statusline 顺序不稳定，正常使用时更难快速扫描。

使用固定内置优先级后，预设配置更容易理解：`items` 表示哪些预设项可见，而显示顺序由内置预设顺序控制。这样既保持现有 settings 兼容性，也改善了交互式 `/statusline` 的使用体验。

## Reviewer Test Plan

### How to verify

打开 `/statusline`，关闭一个已选预设项，例如 `context-remaining`，再重新开启并保存。保存后的 preset items 应回到固定优先级顺序，而不是把刚切换的项目追加到末尾。

同时选择 `model-with-reasoning` 和 `model-only`。渲染出的 statusline 应先显示带 reasoning 的模型项，再显示纯模型项，例如 reasoning effort 已配置时显示 `qwen3-code-plus high | qwen3-code-plus`。

手写一个乱序的 preset config。预览和实际渲染出的 statusline 仍应按照内置优先级显示。

本地验证：
```console
cd packages/cli && npx vitest run src/ui/statusLinePresets.test.ts src/ui/components/StatusLineDialog.test.tsx src/ui/hooks/useStatusLine.test.ts
cd packages/cli && npx eslint src/ui/statusLinePresets.ts src/ui/statusLinePresets.test.ts src/ui/components/StatusLineDialog.tsx src/ui/components/StatusLineDialog.test.tsx src/ui/hooks/useStatusLine.ts src/ui/hooks/useStatusLine.test.ts
git diff --check
```

### Evidence (Before & After)

Before：关闭某个已有预设项再重新开启时，该项可能移动到末尾，因为保存顺序跟随 MultiSelect 插入顺序。

After：被切换的预设项会按照固定优先级保存和渲染。目标测试覆盖了归一化、弹窗保存、预览顺序、footer 渲染和 hook 集成路径。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows PowerShell。本地已通过目标 Vitest、相关文件 ESLint 和 `git diff --check`。`cd packages/cli && npm run typecheck` 当前受既有 `@qwen-code/channel-feishu` 模块/类型依赖缺失影响，和本次 statusline 改动无关。

## Risk & Scope

- Main risk or tradeoff: 如果用户曾依赖 preset `items` 中的自定义顺序，现在会看到内置优先级顺序。这符合本次预期语义：preset `items` 控制是否显示，而不是自定义排序。
- Not validated / out of scope: 自定义 command 类型 statusline payload 未改动，也未新增预设字段、schema 变更或用户自定义排序能力。
- Breaking changes / migration notes: 不需要 settings schema 迁移。现有配置 id `model` 保持兼容；仅 UI label 显示为 `model-only`。

## Linked Issues

Closes #4633