### PR TITLE
fix(cli): hide completed sticky todos

### DIFF
--- a/packages/cli/src/ui/components/StickyTodoList.test.tsx
+++ b/packages/cli/src/ui/components/StickyTodoList.test.tsx
@@ -22,7 +22,7 @@ function makeTodos(count: number): TodoItem[] {
 }
 
 describe('StickyTodoList', () => {
-  it('keeps each task number attached to the original task after sorting', () => {
+  it('keeps each visible task number attached to the original task after sorting', () => {
     const todos: TodoItem[] = [
       {
         id: 'done',
@@ -56,14 +56,9 @@ describe('StickyTodoList', () => {
     expect(
       lines.find((line) => line.includes('Run cli tests')) ?? '',
     ).toContain('2.');
-    expect(
-      lines.find((line) => line.includes('Summarize results')) ?? '',
-    ).toContain('1.');
+    expect(output).not.toContain('Summarize results');
     expect(output.indexOf('Run core tests')).toBeLessThan(
       output.indexOf('Run cli tests'),
-    );
-    expect(output.indexOf('Run cli tests')).toBeLessThan(
-      output.indexOf('Summarize results'),
     );
   });
 
@@ -104,7 +99,7 @@ describe('StickyTodoList', () => {
     expect(output).toContain('Run cli tests');
     expect(output).not.toContain('Run core tests');
     expect(output).not.toContain('Summarize results');
-    expect(output).toContain('... and 2 more');
+    expect(output).toContain('... and 1 more');
     expect(lines).toHaveLength(6);
   });
 
@@ -120,7 +115,26 @@ describe('StickyTodoList', () => {
     const output = lastFrame() ?? '';
 
     expect(output).toContain('10. ◐ Task 10');
-    expect(output).toContain('... and 9 more');
+    expect(output).not.toContain('... and 9 more');
+  });
+
+  it('hides the sticky panel when every task is completed', () => {
+    const todos: TodoItem[] = [
+      {
+        id: 'done-1',
+        content: 'Run tests',
+        status: 'completed',
+      },
+      {
+        id: 'done-2',
+        content: 'Summarize results',
+        status: 'completed',
+      },
+    ];
+
+    const { lastFrame } = render(<StickyTodoList todos={todos} width={60} />);
+
+    expect(lastFrame()).toBe('');
   });
 
   it('derives a viewport-aware visible item count', () => {

--- a/packages/cli/src/ui/components/StickyTodoList.tsx
+++ b/packages/cli/src/ui/components/StickyTodoList.tsx
@@ -45,20 +45,26 @@ const StickyTodoListComponent: React.FC<StickyTodoListProps> = ({
   width,
   maxVisibleItems = STICKY_TODO_MAX_VISIBLE_ITEMS,
 }) => {
-  const orderedTodos = useMemo(() => getOrderedStickyTodos(todos), [todos]);
+  const orderedOpenTodos = useMemo(
+    () =>
+      getOrderedStickyTodos(todos).filter(
+        (todo) => todo.status !== 'completed',
+      ),
+    [todos],
+  );
   const todoNumberById = useMemo(
     () =>
       new Map(todos.map((todo, index) => [todo.id, `${index + 1}.`] as const)),
     [todos],
   );
 
-  if (todos.length === 0) {
+  if (orderedOpenTodos.length === 0) {
     return null;
   }
 
   const visibleTodoCount = clampVisibleTodoCount(maxVisibleItems);
-  const visibleTodos = orderedTodos.slice(0, visibleTodoCount);
-  const hiddenTodoCount = orderedTodos.length - visibleTodos.length;
+  const visibleTodos = orderedOpenTodos.slice(0, visibleTodoCount);
+  const hiddenTodoCount = orderedOpenTodos.length - visibleTodos.length;
   const numberColumnWidth =
     Math.max(
       ...visibleTodos.map(

--- a/packages/cli/src/ui/utils/todoSnapshot.test.ts
+++ b/packages/cli/src/ui/utils/todoSnapshot.test.ts
@@ -234,7 +234,7 @@ describe('getStickyTodos', () => {
 });
 
 describe('sticky todo layout helpers', () => {
-  it('keeps the layout key stable for status-only updates', () => {
+  it('changes the layout key for status-only updates', () => {
     const pendingTodos = [
       {
         id: 'todo-1',
@@ -250,11 +250,38 @@ describe('sticky todo layout helpers', () => {
       },
     ];
 
-    expect(getStickyTodosLayoutKey(pendingTodos, 64, 5)).toBe(
+    expect(getStickyTodosLayoutKey(pendingTodos, 64, 5)).not.toBe(
       getStickyTodosLayoutKey(inProgressTodos, 64, 5),
     );
     expect(getStickyTodosRenderKey(pendingTodos)).not.toBe(
       getStickyTodosRenderKey(inProgressTodos),
+    );
+  });
+
+  it('uses the rendered open todos for the layout key', () => {
+    const todos = [
+      {
+        id: 'todo-1',
+        content: 'Finished task',
+        status: 'completed' as const,
+      },
+      {
+        id: 'todo-2',
+        content: 'Active task',
+        status: 'in_progress' as const,
+      },
+      {
+        id: 'todo-3',
+        content: 'Pending task',
+        status: 'pending' as const,
+      },
+    ];
+
+    expect(getStickyTodosLayoutKey(todos, 64, 5)).toBe(
+      getStickyTodosLayoutKey(todos.slice(1), 64, 5),
+    );
+    expect(getStickyTodosLayoutKey(todos, 64, 1)).not.toBe(
+      getStickyTodosLayoutKey(todos, 64, 2),
     );
   });
 

--- a/packages/cli/src/ui/utils/todoSnapshot.ts
+++ b/packages/cli/src/ui/utils/todoSnapshot.ts
@@ -181,14 +181,17 @@ export function getStickyTodosLayoutKey(
   }
 
   const visibleTodoCount = clampStickyTodoVisibleItems(maxVisibleItems);
-  const visibleTodos = todos.slice(0, visibleTodoCount);
-  const hasHiddenTodos = todos.length > visibleTodos.length;
+  const orderedOpenTodos = getOrderedStickyTodos(todos).filter(
+    (todo) => todo.status !== 'completed',
+  );
+  const visibleTodos = orderedOpenTodos.slice(0, visibleTodoCount);
+  const hasHiddenTodos = orderedOpenTodos.length > visibleTodos.length;
 
   return JSON.stringify({
     width,
     maxVisibleItems: visibleTodoCount,
     hasHiddenTodos,
-    todos: visibleTodos.map((todo) => [todo.id, todo.content]),
+    todos: visibleTodos.map((todo) => [todo.id, todo.content, todo.status]),
   });
 }
 


### PR DESCRIPTION
﻿## Summary

- Hide completed todo items from the sticky `Current tasks` panel.
- Keep original task numbers for the remaining visible items.
- Hide the sticky panel when the latest todo snapshot contains only completed tasks.

Fixes #4631

## Test Plan

- npm run test --workspace=packages/cli -- StickyTodoList.test.tsx
- npm run typecheck --workspace=packages/cli
- npx eslint packages/cli/src/ui/components/StickyTodoList.tsx packages/cli/src/ui/components/StickyTodoList.test.tsx --max-warnings 0
- npx prettier --check packages/cli/src/ui/components/StickyTodoList.tsx packages/cli/src/ui/components/StickyTodoList.test.tsx
- npm run build --workspace=packages/cli
- git diff --check
