### PR TITLE
fix(core): apply output language to side queries

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2675,6 +2675,10 @@ export class Config {
     return this.userMemory;
   }
 
+  getOutputLanguageFilePath(): string | undefined {
+    return this.outputLanguageFilePath;
+  }
+
   setUserMemory(newUserMemory: string): void {
     this.userMemory = newUserMemory;
   }

--- a/packages/core/src/utils/sideQuery.test.ts
+++ b/packages/core/src/utils/sideQuery.test.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { BaseLlmClient } from '../core/baseLlmClient.js';
 import type { Config } from '../config/config.js';
@@ -24,6 +27,7 @@ describe('runSideQuery', () => {
       getBaseLlmClient: vi.fn().mockReturnValue(mockBaseLlmClient),
       getModel: vi.fn().mockReturnValue('main-model'),
       getFastModel: vi.fn().mockReturnValue(undefined),
+      getOutputLanguageFilePath: vi.fn().mockReturnValue(undefined),
     } as unknown as Config;
   });
 
@@ -139,6 +143,41 @@ describe('runSideQuery', () => {
       expect(mockBaseLlmClient.generateJson).toHaveBeenCalledWith(
         expect.objectContaining({ promptId: 'legacy-id' }),
       );
+    });
+
+    it('adds the configured output language to JSON side queries', async () => {
+      const dir = await mkdtemp(path.join(tmpdir(), 'qwen-side-query-'));
+      try {
+        const outputLanguagePath = path.join(dir, 'output-language.md');
+        await writeFile(outputLanguagePath, '请始终用中文回答用户可见文本。');
+        vi.mocked(mockConfig.getOutputLanguageFilePath).mockReturnValue(
+          outputLanguagePath,
+        );
+        vi.mocked(mockBaseLlmClient.generateJson).mockResolvedValue({
+          title: '测试标题',
+        });
+
+        await runSideQuery<{ title: string }>(mockConfig, {
+          purpose: 'session-title',
+          contents: [{ role: 'user', parts: [{ text: 'title please' }] }],
+          schema: {
+            type: 'object',
+            properties: { title: { type: 'string' } },
+            required: ['title'],
+          },
+          abortSignal: abortController.signal,
+          systemInstruction: 'Generate a short title.',
+        });
+
+        const callArg = vi.mocked(mockBaseLlmClient.generateJson).mock
+          .calls[0][0];
+        expect(callArg.systemInstruction).toContain('Generate a short title.');
+        expect(callArg.systemInstruction).toContain(
+          '请始终用中文回答用户可见文本。',
+        );
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
     });
 
     it('throws when the response does not satisfy the schema', async () => {
@@ -352,6 +391,34 @@ describe('runSideQuery', () => {
           systemInstruction: 'custom side query prompt',
         }),
       );
+    });
+
+    it('adds the configured output language to text side queries', async () => {
+      const dir = await mkdtemp(path.join(tmpdir(), 'qwen-side-query-'));
+      try {
+        const outputLanguagePath = path.join(dir, 'output-language.md');
+        await writeFile(outputLanguagePath, 'Respond in Spanish.');
+        vi.mocked(mockConfig.getOutputLanguageFilePath).mockReturnValue(
+          outputLanguagePath,
+        );
+        mockTextResult('ok');
+
+        await runSideQuery(mockConfig, {
+          purpose: 'tool-use-summary',
+          contents: [{ role: 'user', parts: [{ text: 'summarize tool use' }] }],
+          abortSignal: abortController.signal,
+          systemInstruction: 'Summarize the tool batch.',
+        });
+
+        const callArg = vi.mocked(mockBaseLlmClient.generateText).mock
+          .calls[0][0];
+        expect(callArg.systemInstruction).toContain(
+          'Summarize the tool batch.',
+        );
+        expect(callArg.systemInstruction).toContain('Respond in Spanish.');
+      } finally {
+        await rm(dir, { recursive: true, force: true });
+      }
     });
 
     it('omits systemInstruction when caller does not provide one', async () => {

--- a/packages/core/src/utils/sideQuery.ts
+++ b/packages/core/src/utils/sideQuery.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { readFile } from 'node:fs/promises';
 import type {
   Content,
   GenerateContentConfig,
@@ -123,6 +124,50 @@ function applyThinkingDefault(
   };
 }
 
+async function getOutputLanguageInstruction(
+  config: Config,
+): Promise<string | undefined> {
+  const outputLanguageFilePath = config.getOutputLanguageFilePath?.();
+  if (!outputLanguageFilePath) return undefined;
+
+  try {
+    const preference = (await readFile(outputLanguageFilePath, 'utf8')).trim();
+    if (!preference) return undefined;
+
+    return [
+      'Follow the user-visible output language preference below for this side query.',
+      preference,
+    ].join('\n\n');
+  } catch {
+    return undefined;
+  }
+}
+
+function appendSystemInstruction(
+  systemInstruction: string | Part | Part[] | Content | undefined,
+  outputLanguageInstruction: string | undefined,
+): string | Part | Part[] | Content | undefined {
+  if (!outputLanguageInstruction) return systemInstruction;
+  if (systemInstruction === undefined) return outputLanguageInstruction;
+  if (typeof systemInstruction === 'string') {
+    return `${systemInstruction}\n\n${outputLanguageInstruction}`;
+  }
+  if (Array.isArray(systemInstruction)) {
+    return [...systemInstruction, { text: outputLanguageInstruction }];
+  }
+  if (
+    typeof systemInstruction === 'object' &&
+    'parts' in systemInstruction &&
+    Array.isArray(systemInstruction.parts)
+  ) {
+    return {
+      ...systemInstruction,
+      parts: [...systemInstruction.parts, { text: outputLanguageInstruction }],
+    };
+  }
+  return [systemInstruction as Part, { text: outputLanguageInstruction }];
+}
+
 function isJsonOptions<TResponse>(
   options: SideQueryTextOptions | SideQueryJsonOptions<TResponse>,
 ): options is SideQueryJsonOptions<TResponse> {
@@ -147,6 +192,10 @@ export async function runSideQuery<TResponse>(
   const model = resolveDefaultModel(config, options.model);
   const promptId = options.promptId ?? buildDefaultPromptId(options.purpose);
   const requestConfig = applyThinkingDefault(options.config);
+  const systemInstruction = appendSystemInstruction(
+    options.systemInstruction,
+    await getOutputLanguageInstruction(config),
+  );
 
   if (isJsonOptions(options)) {
     const response = (await config.getBaseLlmClient().generateJson({
@@ -154,7 +203,7 @@ export async function runSideQuery<TResponse>(
       schema: options.schema,
       abortSignal: options.abortSignal,
       model,
-      systemInstruction: options.systemInstruction,
+      systemInstruction,
       promptId,
       config: requestConfig,
       ...(options.maxAttempts !== undefined && {
@@ -178,7 +227,7 @@ export async function runSideQuery<TResponse>(
   const result = await config.getBaseLlmClient().generateText({
     contents: options.contents,
     model,
-    systemInstruction: options.systemInstruction,
+    systemInstruction,
     abortSignal: options.abortSignal,
     promptId,
     config: requestConfig,


### PR DESCRIPTION
Fixes #4494.

## Summary
- append the configured output-language.md preference to runSideQuery system instructions
- cover both JSON and text side queries so titles, recaps, tool summaries, and suggestions share the same language preference path
- keep side queries best-effort if the language file is missing or unreadable

## Test plan
- npm exec -- vitest run packages/core/src/utils/sideQuery.test.ts
- npm run typecheck --workspace=packages/core
- npm exec -- eslint packages/core/src/utils/sideQuery.ts packages/core/src/utils/sideQuery.test.ts packages/core/src/config/config.ts
- npm run build --workspace=packages/core
- git diff --check