### PR TITLE
fix(core): enforce tool result adjacency

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/converter.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.test.ts
@@ -3448,6 +3448,104 @@ describe('OpenAIContentConverter', () => {
   });
 
   describe('mergeConsecutiveAssistantMessages', () => {
+    it('drops tool results that are not adjacent to their assistant tool call', () => {
+      const request: GenerateContentParameters = {
+        model: 'models/test',
+        contents: [
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call_a',
+                  name: 'tool_a',
+                  args: {},
+                },
+              },
+              {
+                functionCall: {
+                  id: 'call_b',
+                  name: 'tool_b',
+                  args: {},
+                },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'call_a',
+                  name: 'tool_a',
+                  response: { output: 'result_a' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [{ text: 'intervening user message' }],
+          },
+          {
+            role: 'model',
+            parts: [
+              {
+                functionCall: {
+                  id: 'call_c',
+                  name: 'tool_c',
+                  args: {},
+                },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'call_c',
+                  name: 'tool_c',
+                  response: { output: 'result_c' },
+                },
+              },
+            ],
+          },
+          {
+            role: 'user',
+            parts: [
+              {
+                functionResponse: {
+                  id: 'call_b',
+                  name: 'tool_b',
+                  response: { output: 'late_result_b' },
+                },
+              },
+            ],
+          },
+        ],
+      };
+
+      const messages = converter.convertGeminiRequestToOpenAI(
+        request,
+        requestContext,
+      );
+
+      const toolMessages = messages.filter((m) => m.role === 'tool');
+      expect(
+        toolMessages.map((m) => (m as { tool_call_id: string }).tool_call_id),
+      ).toEqual(['call_a', 'call_c']);
+
+      const assistantMessages = messages.filter((m) => m.role === 'assistant');
+      expect(
+        (
+          assistantMessages[0] as {
+            tool_calls?: OpenAI.Chat.ChatCompletionMessageToolCall[];
+          }
+        ).tool_calls?.map((toolCall) => toolCall.id),
+      ).toEqual(['call_a']);
+    });
+
     it('should merge two consecutive assistant messages with string content', () => {
       const request: GenerateContentParameters = {
         model: 'models/test',

--- a/packages/core/src/core/openaiContentGenerator/converter.ts
+++ b/packages/core/src/core/openaiContentGenerator/converter.ts
@@ -1394,27 +1394,35 @@ function cleanOrphanedToolCalls(
   messages: OpenAI.Chat.ChatCompletionMessageParam[],
 ): OpenAI.Chat.ChatCompletionMessageParam[] {
   const cleaned: OpenAI.Chat.ChatCompletionMessageParam[] = [];
-  const toolCallIds = new Set<string>();
-  const toolResponseIds = new Set<string>();
+  const adjacentToolResponseIds = new Set<string>();
 
-  // First pass: collect all tool call IDs and tool response IDs
-  for (const message of messages) {
+  // First pass: collect tool responses that directly answer the previous assistant turn.
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
     if (
       message.role === 'assistant' &&
       'tool_calls' in message &&
       message.tool_calls
     ) {
-      for (const toolCall of message.tool_calls) {
-        if (toolCall.id) {
-          toolCallIds.add(toolCall.id);
+      const expectedToolCallIds = new Set(
+        message.tool_calls
+          .map((toolCall) => toolCall.id)
+          .filter((id): id is string => Boolean(id)),
+      );
+
+      for (let j = i + 1; j < messages.length; j++) {
+        const maybeToolResponse = messages[j];
+        if (maybeToolResponse.role !== 'tool') {
+          break;
+        }
+        if (
+          'tool_call_id' in maybeToolResponse &&
+          maybeToolResponse.tool_call_id &&
+          expectedToolCallIds.has(maybeToolResponse.tool_call_id)
+        ) {
+          adjacentToolResponseIds.add(maybeToolResponse.tool_call_id);
         }
       }
-    } else if (
-      message.role === 'tool' &&
-      'tool_call_id' in message &&
-      message.tool_call_id
-    ) {
-      toolResponseIds.add(message.tool_call_id);
     }
   }
 
@@ -1427,7 +1435,8 @@ function cleanOrphanedToolCalls(
     ) {
       // Filter out tool calls that don't have corresponding responses
       const validToolCalls = message.tool_calls.filter(
-        (toolCall) => toolCall.id && toolResponseIds.has(toolCall.id),
+        (toolCall) =>
+          toolCall.id && adjacentToolResponseIds.has(toolCall.id),
       );
 
       if (validToolCalls.length > 0) {
@@ -1459,7 +1468,7 @@ function cleanOrphanedToolCalls(
       message.tool_call_id
     ) {
       // Only keep tool responses that have corresponding tool calls
-      if (toolCallIds.has(message.tool_call_id)) {
+      if (adjacentToolResponseIds.has(message.tool_call_id)) {
         cleaned.push(message);
       }
     } else {


### PR DESCRIPTION
## Summary

Fixes #4619.

`cleanOrphanedToolCalls()` was checking tool call IDs globally, so it could keep a tool result even when another user turn had broken the required assistant-tool adjacency. Anthropic-compatible APIs reject that shape because each `tool_result` must answer the immediately previous assistant `tool_use` turn.

This changes the cleanup pass to keep only tool responses that directly follow the assistant message that declared their tool call. It also removes the matching assistant tool call when its response is no longer adjacent.

## Tests

- npm exec -- vitest run packages/core/src/core/openaiContentGenerator/converter.test.ts
- npm run typecheck --workspace=packages/core
- npm exec -- eslint packages/core/src/core/openaiContentGenerator/converter.ts packages/core/src/core/openaiContentGenerator/converter.test.ts
- npm run build --workspace=packages/core
