### PR TITLE
fix(cli): persist /memory toggle state across dialog reopen

### DIFF
--- a/packages/cli/src/ui/components/MemoryDialog.test.tsx
+++ b/packages/cli/src/ui/components/MemoryDialog.test.tsx
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { act } from '@testing-library/react';
+import { act } from 'react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render } from 'ink-testing-library';
 import { MemoryDialog } from './MemoryDialog.js';
@@ -41,12 +41,24 @@ describe('MemoryDialog', () => {
     mockedUseConfig.mockReturnValue({
       getWorkingDir: vi.fn(() => '/tmp/project'),
       getProjectRoot: vi.fn(() => '/tmp/project'),
+      getBareMode: vi.fn(() => false),
+      // Stale snapshot getters — the dialog must NOT read its toggle state
+      // from these; it reads from the live merged settings instead.
       getManagedAutoMemoryEnabled: vi.fn(() => false),
       getManagedAutoDreamEnabled: vi.fn(() => false),
       getAutoSkillEnabled: vi.fn(() => false),
     } as never);
 
-    mockedUseSettings.mockReturnValue({ setValue: vi.fn() } as never);
+    mockedUseSettings.mockReturnValue({
+      setValue: vi.fn(),
+      merged: {
+        memory: {
+          enableManagedAutoMemory: false,
+          enableManagedAutoDream: false,
+          enableAutoSkill: false,
+        },
+      },
+    } as never);
     mockedUseLaunchEditor.mockReturnValue(vi.fn());
   });
 
@@ -90,10 +102,10 @@ describe('MemoryDialog', () => {
     expect(lastFrame()).toContain('› 1. User memory');
   });
 
-  it('renders the Auto-skill row with the status from config', () => {
+  it('renders the Auto-skill row with the status from merged settings', () => {
     const { lastFrame } = render(<MemoryDialog onClose={vi.fn()} />);
 
-    // beforeEach mocks getAutoSkillEnabled => false
+    // beforeEach mocks merged.memory.enableAutoSkill => false
     expect(lastFrame()).toContain('Auto-skill: off');
   });
 
@@ -131,7 +143,10 @@ describe('MemoryDialog', () => {
 
   it('toggles Auto-skill on Enter and persists to workspace settings', () => {
     const setValue = vi.fn();
-    mockedUseSettings.mockReturnValue({ setValue } as never);
+    mockedUseSettings.mockReturnValue({
+      setValue,
+      merged: { memory: { enableAutoSkill: false } },
+    } as never);
 
     const { lastFrame } = render(<MemoryDialog onClose={vi.fn()} />);
 
@@ -160,5 +175,45 @@ describe('MemoryDialog', () => {
       true,
     );
     expect(lastFrame()).toContain('› Auto-skill: on');
+  });
+
+  it('reflects the persisted value when the dialog is reopened (remounted)', () => {
+    // Emulate LoadedSettings: setValue writes through to the merged view,
+    // exactly like the real saveSettings + recomputeMerged path.
+    const merged = {
+      memory: {
+        enableManagedAutoMemory: false,
+        enableManagedAutoDream: false,
+        enableAutoSkill: false,
+      },
+    };
+    const setValue = vi.fn((_scope: unknown, key: string, value: boolean) => {
+      if (key === 'memory.enableAutoSkill') {
+        merged.memory.enableAutoSkill = value;
+      }
+    });
+    mockedUseSettings.mockReturnValue({ setValue, merged } as never);
+
+    const pressKey = (key: { name: string }) => {
+      const keypressHandler =
+        mockedUseKeypress.mock.calls[
+          mockedUseKeypress.mock.calls.length - 1
+        ]![0];
+      act(() => {
+        keypressHandler(key as never);
+      });
+    };
+
+    // First open: toggle Auto-skill on, then close the dialog.
+    const first = render(<MemoryDialog onClose={vi.fn()} />);
+    expect(first.lastFrame()).toContain('Auto-skill: off');
+    pressKey({ name: 'up' }); // focus the Auto-skill row
+    pressKey({ name: 'return' }); // toggle on
+    expect(first.lastFrame()).toContain('› Auto-skill: on');
+    first.unmount();
+
+    // Reopen: a fresh mount must read the persisted value, not a stale snapshot.
+    const second = render(<MemoryDialog onClose={vi.fn()} />);
+    expect(second.lastFrame()).toContain('Auto-skill: on');
   });
 });

--- a/packages/cli/src/ui/components/MemoryDialog.tsx
+++ b/packages/cli/src/ui/components/MemoryDialog.tsx
@@ -114,14 +114,20 @@ export function MemoryDialog({ onClose }: MemoryDialogProps) {
   const [focusedSection, setFocusedSection] = useState<
     'autoMemory' | 'autoDream' | 'autoSkill' | 'list'
   >('list');
+  // Read the initial toggle state from the live merged settings rather than
+  // the Config snapshot: Config is frozen at startup and never reflects a
+  // setValue() write, so reopening the dialog would otherwise show stale state.
+  const bareMode = config.getBareMode();
+  const readToggle = (value: boolean | undefined): boolean =>
+    !bareMode && (value ?? true);
   const [autoMemoryOn, setAutoMemoryOn] = useState(() =>
-    config.getManagedAutoMemoryEnabled(),
+    readToggle(loadedSettings.merged.memory?.enableManagedAutoMemory),
   );
   const [autoDreamOn, setAutoDreamOn] = useState(() =>
-    config.getManagedAutoDreamEnabled(),
+    readToggle(loadedSettings.merged.memory?.enableManagedAutoDream),
   );
   const [autoSkillOn, setAutoSkillOn] = useState(() =>
-    config.getAutoSkillEnabled(),
+    readToggle(loadedSettings.merged.memory?.enableAutoSkill),
   );
   const [lastDreamAt, setLastDreamAt] = useState<number | null>(null);
 


### PR DESCRIPTION
## What this PR does

Fixes the `/memory` dialog so a toggle no longer silently reverts after the dialog is closed and reopened. The three managed-memory rows — `Auto-memory`, `Auto-dream`, `Auto-skill` — now initialize their on/off state from the live merged settings instead of the `Config` snapshot. The write path is unchanged; only the read path for the initial state moves to `loadedSettings.merged.memory?.*`, with the existing bareMode semantics preserved via a small `readToggle` helper.

## Why it's needed

Each toggle row seeded its `useState` from a `Config` getter (`getManagedAutoMemoryEnabled` / `getManagedAutoDreamEnabled` / `getAutoSkillEnabled`). Those getters read fields that are frozen at startup and never reflect a `setValue()` write. Because the dialog is unmounted on close and re-mounted on reopen, every reopen re-runs the initializer and re-reads the stale snapshot — so a value the user just flipped appears to jump back. Toggling writes to workspace settings correctly; it was purely the displayed initial state that was wrong. Reading from the merged settings (the same source the write updates) makes the displayed state consistent across reopen.

## Reviewer Test Plan

### How to verify

1. Run `qwen`, open `/memory`, focus any of the three toggle rows and press `Enter` to flip it (e.g. `Auto-skill: on` → `off`).
2. Press `Esc` to close the dialog, then open `/memory` again.
3. Expected: the row shows the value you just set. Observed before this PR: the row reverts to its startup value.

Automated coverage: `MemoryDialog.test.tsx` gains a mount → toggle → unmount → remount test that renders the component with `ink-testing-library` and asserts the persisted value survives the remount. Reverting only the component change makes exactly this new test fail while the other five pass, confirming it pinpoints the regression.

### Evidence (Before & After)

Before (component change reverted) — the remount test fails, the rest pass:

```
 ✓ renders the Auto-skill row with the status from merged settings
 ✓ chains focus list ↑ autoSkill ↑ autoDream ↑ autoMemory and back down
 ✓ toggles Auto-skill on Enter and persists to workspace settings
 × reflects the persisted value when the dialog is reopened (remounted)
   → expected 'Auto-skill: off' to contain 'Auto-skill: on'
 Tests  1 failed | 5 passed (6)
```

After (with the fix):

```
 ✓ src/ui/components/MemoryDialog.test.tsx (6 tests)
 Tests  6 passed (6)
```

`tsc --noEmit` and `eslint` on the changed files both pass.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local unit tests via `vitest run` in `packages/cli` (deps installed in this worktree). No full app/dev-server run.

## Risk & Scope

- Main risk or tradeoff: none functional — the change only moves the source of the initial toggle state from the Config snapshot to the equivalent merged-settings value; bareMode handling and the default-on (`?? true`) behavior are preserved.
- Not validated / out of scope: the runtime behavior of these subsystems (auto-memory recall, dream, skill extraction) still reads the frozen `Config` getters, so a same-session toggle does not change background behavior until restart despite `requiresRestart: false`. That is a larger change tracked separately and intentionally not addressed here.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

修复 `/memory` dialog:切换开关后关闭再重开,开关状态不再悄悄回退。三个 managed-memory 行(`Auto-memory` / `Auto-dream` / `Auto-skill`)的开/关初始状态现在从 live 的 merged settings 读取,而不是 `Config` 快照。写入路径不变,只把初始状态的读取改到 `loadedSettings.merged.memory?.*`,并用一个小的 `readToggle` helper 保留原有的 bareMode 语义。

## 为什么需要

每个开关行用 `Config` getter(`getManagedAutoMemoryEnabled` / `getManagedAutoDreamEnabled` / `getAutoSkillEnabled`)给 `useState` 赋初值。这些 getter 读的字段在启动时被冻结,永远不会反映 `setValue()` 的写入。由于 dialog 在关闭时卸载、重开时重新挂载,每次重开都会重跑初始化、再次读到旧快照——于是用户刚切换的值看起来又跳了回去。切换其实已正确写入 workspace settings,出错的纯粹是显示的初始状态。改为从 merged settings(写入更新的同一来源)读取,就能让显示状态在重开后保持一致。

## Reviewer 验证步骤

### 如何验证

1. 运行 `qwen`,打开 `/memory`,聚焦三个开关行中任意一个,按 `Enter` 切换(例如 `Auto-skill: on` → `off`)。
2. 按 `Esc` 关闭 dialog,再次打开 `/memory`。
3. 预期:该行显示你刚设置的值。本 PR 之前的现象:该行回退到启动时的值。

自动化覆盖:`MemoryDialog.test.tsx` 新增一个 mount → 切换 → unmount → remount 的用例,用 `ink-testing-library` 真实渲染组件,断言持久化的值能在 remount 后保留。只回退组件改动时,恰好是这个新用例失败、其余五个通过,证明它精确定位了该回归。

### Before / After 证据

见上方英文段的测试输出(回退组件改动 → 仅 remount 用例红;加上修复 → 6/6 全绿)。`tsc --noEmit` 与改动文件的 `eslint` 均通过。

### 测试环境

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

在 `packages/cli` 用 `vitest run` 跑单元测试(本 worktree 已装依赖),未做完整 app/dev-server 运行。

## 风险与范围

- 主要风险 / tradeoff:无功能性风险——仅把初始开关状态的来源从 Config 快照换成等价的 merged-settings 值;bareMode 处理与默认开启(`?? true`)行为均保留。
- 未验证 / 范围外:这些子系统的运行时行为(auto-memory recall、dream、skill extraction)仍读冻结的 `Config` getter,因此 same-session 切换在重启前不会改变后台行为(尽管标了 `requiresRestart: false`)。这是更大的改动,单独跟踪,本 PR 有意不处理。
- Breaking changes / 迁移:无。

</details>