### PR TITLE
feat(core): auto-dump memory diagnostics to disk on pressure detection

### DIFF
--- a/packages/core/src/services/memoryDiagnosticsDumper.test.ts
+++ b/packages/core/src/services/memoryDiagnosticsDumper.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import { MemoryDiagnosticsDumper } from './memoryDiagnosticsDumper.js';
+import type { Config } from '../config/config.js';
+
+vi.mock('node:fs', () => ({
+  mkdirSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock('../utils/memoryDiagnostics.js', () => ({
+  collectMemoryDiagnostics: vi.fn().mockResolvedValue({
+    timestamp: '2026-05-31T00:00:00.000Z',
+    memoryUsage: {
+      rss: 2_000_000_000,
+      heapUsed: 1_800_000_000,
+      heapTotal: 2_048_000_000,
+      external: 50_000_000,
+      arrayBuffers: 10_000_000,
+    },
+    v8HeapStats: {
+      heapSizeLimit: 4_096_000_000,
+      totalHeapSize: 2_048_000_000,
+      usedHeapSize: 1_800_000_000,
+    },
+  }),
+}));
+
+function createMockConfig(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    getSessionId: vi.fn().mockReturnValue('test-session-id-12345678'),
+    getCliVersion: vi.fn().mockReturnValue('0.17.0'),
+    getGeminiClient: vi.fn().mockReturnValue({
+      getChat: () => ({
+        getHistoryLength: () => 500,
+      }),
+    }),
+    storage: {
+      getProjectDir: vi.fn().mockReturnValue('/tmp/test-project'),
+    },
+    ...overrides,
+  } as unknown as Config;
+}
+
+describe('MemoryDiagnosticsDumper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('writes diagnostics JSON on first dump', async () => {
+    const config = createMockConfig();
+    const dumper = new MemoryDiagnosticsDumper(config);
+
+    const result = await dumper.dump('hard');
+
+    expect(result).toBeDefined();
+    expect(result!.trigger).toBe('hard');
+    expect(result!.filePath).toContain('/tmp/test-project/diagnostics/');
+    expect(result!.filePath).toContain('memory-test-ses');
+    expect(fs.mkdirSync).toHaveBeenCalledWith(
+      expect.stringContaining('diagnostics'),
+      { recursive: true },
+    );
+    expect(fs.writeFileSync).toHaveBeenCalledOnce();
+
+    const writtenContent = JSON.parse(
+      vi.mocked(fs.writeFileSync).mock.calls[0][1] as string,
+    );
+    expect(writtenContent.trigger).toBe('hard');
+    expect(writtenContent.dumpNumber).toBe(1);
+    expect(writtenContent.memoryUsage.rss).toBe(2_000_000_000);
+    expect(writtenContent.session.historyEntries).toBe(500);
+    expect(writtenContent.suggestion).toContain('/compact');
+  });
+
+  it('respects per-session cap of 3 dumps', async () => {
+    const config = createMockConfig();
+    const dumper = new MemoryDiagnosticsDumper(config);
+
+    // Bypass cooldown by mocking Date.now
+    let mockNow = 1000000;
+    vi.spyOn(Date, 'now').mockImplementation(() => {
+      mockNow += 60_000;
+      return mockNow;
+    });
+
+    const r1 = await dumper.dump('hard');
+    const r2 = await dumper.dump('critical');
+    const r3 = await dumper.dump('hard');
+    const r4 = await dumper.dump('critical');
+
+    expect(r1).toBeDefined();
+    expect(r2).toBeDefined();
+    expect(r3).toBeDefined();
+    expect(r4).toBeUndefined();
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(3);
+  });
+
+  it('respects cooldown between dumps', async () => {
+    const config = createMockConfig();
+    const dumper = new MemoryDiagnosticsDumper(config);
+
+    const mockNow = 1000000;
+    vi.spyOn(Date, 'now').mockReturnValue(mockNow);
+
+    const r1 = await dumper.dump('hard');
+    const r2 = await dumper.dump('hard');
+
+    expect(r1).toBeDefined();
+    expect(r2).toBeUndefined();
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('resets state on new session', async () => {
+    const config = createMockConfig();
+    const dumper = new MemoryDiagnosticsDumper(config);
+
+    let mockNow = 1000000;
+    vi.spyOn(Date, 'now').mockImplementation(() => {
+      mockNow += 60_000;
+      return mockNow;
+    });
+
+    await dumper.dump('hard');
+    await dumper.dump('hard');
+    await dumper.dump('hard');
+
+    // Cap reached
+    const r4 = await dumper.dump('hard');
+    expect(r4).toBeUndefined();
+
+    // Reset
+    dumper.resetForNewSession();
+
+    const r5 = await dumper.dump('critical');
+    expect(r5).toBeDefined();
+    expect(r5!.trigger).toBe('critical');
+  });
+
+  it('includes critical suggestion for critical pressure', async () => {
+    const config = createMockConfig();
+    const dumper = new MemoryDiagnosticsDumper(config);
+
+    await dumper.dump('critical');
+
+    const writtenContent = JSON.parse(
+      vi.mocked(fs.writeFileSync).mock.calls[0][1] as string,
+    );
+    expect(writtenContent.suggestion).toContain('critically high');
+  });
+
+  it('handles missing geminiClient gracefully', async () => {
+    const config = createMockConfig({
+      getGeminiClient: vi.fn().mockReturnValue(null),
+    });
+    const dumper = new MemoryDiagnosticsDumper(config);
+
+    const result = await dumper.dump('hard');
+
+    expect(result).toBeDefined();
+    const writtenContent = JSON.parse(
+      vi.mocked(fs.writeFileSync).mock.calls[0][1] as string,
+    );
+    expect(writtenContent.session.available).toBe(false);
+  });
+});

--- a/packages/core/src/services/memoryDiagnosticsDumper.test.ts
+++ b/packages/core/src/services/memoryDiagnosticsDumper.test.ts
@@ -15,6 +15,15 @@ vi.mock('node:fs', () => ({
   writeFileSync: vi.fn(),
 }));
 
+vi.mock('node:v8', () => ({
+  getHeapStatistics: vi.fn().mockReturnValue({
+    heap_size_limit: 4_096_000_000,
+    total_heap_size: 2_048_000_000,
+    used_heap_size: 1_800_000_000,
+    total_available_size: 2_000_000_000,
+  }),
+}));
+
 vi.mock('../utils/memoryDiagnostics.js', () => ({
   collectMemoryDiagnostics: vi.fn().mockResolvedValue({
     timestamp: '2026-05-31T00:00:00.000Z',
@@ -74,16 +83,27 @@ describe('MemoryDiagnosticsDumper', () => {
       expect.stringContaining('diagnostics'),
       { recursive: true },
     );
-    expect(fs.writeFileSync).toHaveBeenCalledOnce();
+    // Two-phase write: Phase 1 (minimal) + Phase 2 (full)
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
 
-    const writtenContent = JSON.parse(
+    const phase1Content = JSON.parse(
       vi.mocked(fs.writeFileSync).mock.calls[0][1] as string,
     );
-    expect(writtenContent.trigger).toBe('hard');
-    expect(writtenContent.dumpNumber).toBe(1);
-    expect(writtenContent.memoryUsage.rss).toBe(2_000_000_000);
-    expect(writtenContent.session.historyEntries).toBe(500);
-    expect(writtenContent.suggestion).toContain('/compact');
+    expect(phase1Content.trigger).toBe('hard');
+    expect(phase1Content.dumpNumber).toBe(1);
+    expect(phase1Content.collectionComplete).toBe(false);
+    expect(phase1Content.memoryUsage).toBeDefined();
+    expect(phase1Content.v8HeapStats).toBeDefined();
+
+    const phase2Content = JSON.parse(
+      vi.mocked(fs.writeFileSync).mock.calls[1][1] as string,
+    );
+    expect(phase2Content.trigger).toBe('hard');
+    expect(phase2Content.dumpNumber).toBe(1);
+    expect(phase2Content.collectionComplete).toBe(true);
+    expect(phase2Content.memoryUsage.rss).toBe(2_000_000_000);
+    expect(phase2Content.session.historyEntries).toBe(500);
+    expect(phase2Content.suggestion).toContain('/compact');
   });
 
   it('respects per-session cap of 3 dumps', async () => {
@@ -106,7 +126,8 @@ describe('MemoryDiagnosticsDumper', () => {
     expect(r2).toBeDefined();
     expect(r3).toBeDefined();
     expect(r4).toBeUndefined();
-    expect(fs.writeFileSync).toHaveBeenCalledTimes(3);
+    // 3 successful dumps × 2 writes each (Phase 1 + Phase 2)
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(6);
   });
 
   it('respects cooldown between dumps', async () => {
@@ -121,7 +142,8 @@ describe('MemoryDiagnosticsDumper', () => {
 
     expect(r1).toBeDefined();
     expect(r2).toBeUndefined();
-    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+    // 1 successful dump × 2 writes (Phase 1 + Phase 2)
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
   });
 
   it('resets state on new session', async () => {
@@ -156,10 +178,58 @@ describe('MemoryDiagnosticsDumper', () => {
 
     await dumper.dump('critical');
 
+    // Phase 2 (full payload) is the second write
     const writtenContent = JSON.parse(
-      vi.mocked(fs.writeFileSync).mock.calls[0][1] as string,
+      vi.mocked(fs.writeFileSync).mock.calls[1][1] as string,
     );
     expect(writtenContent.suggestion).toContain('critically high');
+    expect(writtenContent.collectionComplete).toBe(true);
+  });
+
+  it('writes Phase 1 synchronously before any await (survives crash during Phase 2)', async () => {
+    const config = createMockConfig();
+    const dumper = new MemoryDiagnosticsDumper(config);
+
+    // Fire dump() but do not await — Phase 1 must have already written to disk
+    // because async functions execute synchronously up to the first await.
+    const promise = dumper.dump('hard');
+
+    // At this point Phase 2 has not run yet (its await is pending), but Phase 1
+    // must have completed its writeFileSync call.
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(1);
+    const phase1Content = JSON.parse(
+      vi.mocked(fs.writeFileSync).mock.calls[0][1] as string,
+    );
+    expect(phase1Content.collectionComplete).toBe(false);
+
+    await promise;
+    // Phase 2 has now overwritten the file
+    expect(fs.writeFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it('reserves slot synchronously to prevent concurrent dumps from bypassing cap', async () => {
+    const config = createMockConfig();
+    const dumper = new MemoryDiagnosticsDumper(config);
+
+    let mockNow = 1000000;
+    vi.spyOn(Date, 'now').mockImplementation(() => {
+      mockNow += 60_000;
+      return mockNow;
+    });
+
+    // Fire 4 concurrent dumps without awaiting between them. The synchronous
+    // slot reservation must enforce the cap of 3 even though all 4 calls happen
+    // before any of them complete their async Phase 2.
+    const results = await Promise.all([
+      dumper.dump('hard'),
+      dumper.dump('hard'),
+      dumper.dump('hard'),
+      dumper.dump('hard'),
+    ]);
+
+    const successful = results.filter((r) => r !== undefined);
+    expect(successful).toHaveLength(3);
+    expect(results[3]).toBeUndefined();
   });
 
   it('handles missing geminiClient gracefully', async () => {
@@ -171,8 +241,9 @@ describe('MemoryDiagnosticsDumper', () => {
     const result = await dumper.dump('hard');
 
     expect(result).toBeDefined();
+    // Phase 2 (full payload) is the second write
     const writtenContent = JSON.parse(
-      vi.mocked(fs.writeFileSync).mock.calls[0][1] as string,
+      vi.mocked(fs.writeFileSync).mock.calls[1][1] as string,
     );
     expect(writtenContent.session.available).toBe(false);
   });

--- a/packages/core/src/services/memoryDiagnosticsDumper.test.ts
+++ b/packages/core/src/services/memoryDiagnosticsDumper.test.ts
@@ -6,6 +6,7 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { MemoryDiagnosticsDumper } from './memoryDiagnosticsDumper.js';
 import type { Config } from '../config/config.js';
 
@@ -65,7 +66,9 @@ describe('MemoryDiagnosticsDumper', () => {
 
     expect(result).toBeDefined();
     expect(result!.trigger).toBe('hard');
-    expect(result!.filePath).toContain('/tmp/test-project/diagnostics/');
+    expect(result!.filePath).toContain(
+      path.join('/tmp/test-project', 'diagnostics') + path.sep,
+    );
     expect(result!.filePath).toContain('memory-test-ses');
     expect(fs.mkdirSync).toHaveBeenCalledWith(
       expect.stringContaining('diagnostics'),

--- a/packages/core/src/services/memoryDiagnosticsDumper.test.ts
+++ b/packages/core/src/services/memoryDiagnosticsDumper.test.ts
@@ -103,7 +103,7 @@ describe('MemoryDiagnosticsDumper', () => {
     expect(phase2Content.collectionComplete).toBe(true);
     expect(phase2Content.memoryUsage.rss).toBe(2_000_000_000);
     expect(phase2Content.session.historyEntries).toBe(500);
-    expect(phase2Content.suggestion).toContain('/compact');
+    expect(phase2Content.suggestion).toContain('/compress');
   });
 
   it('respects per-session cap of 3 dumps', async () => {

--- a/packages/core/src/services/memoryDiagnosticsDumper.ts
+++ b/packages/core/src/services/memoryDiagnosticsDumper.ts
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Writes a lightweight memory diagnostics JSON to disk when the memory
+ * pressure monitor detects hard or critical pressure. The file survives
+ * a subsequent OOM crash, giving maintainers actionable data from bug
+ * reports without requiring the user to manually run `/doctor memory`.
+ *
+ * Design: diagnostics JSON is written BEFORE any expensive operation
+ * (like heap snapshots) so it lands on disk even if the process crashes
+ * during the heavier step.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { collectMemoryDiagnostics } from '../utils/memoryDiagnostics.js';
+import { createDebugLogger } from '../utils/debugLogger.js';
+import { getErrorMessage } from '../utils/errors.js';
+import type { Config } from '../config/config.js';
+
+const debugLogger = createDebugLogger('MEMORY_DUMP');
+
+/** Maximum dumps per session to avoid disk flooding. */
+const MAX_DUMPS_PER_SESSION = 3;
+
+/** Minimum interval between dumps (ms). */
+const MIN_DUMP_INTERVAL_MS = 30_000;
+
+export interface MemoryDumpResult {
+  filePath: string;
+  trigger: string;
+}
+
+export class MemoryDiagnosticsDumper {
+  private dumpCount = 0;
+  private lastDumpTime = 0;
+
+  constructor(private readonly config: Config) {}
+
+  /**
+   * Resets session-scoped state. Called when a new session starts.
+   */
+  resetForNewSession(): void {
+    this.dumpCount = 0;
+    this.lastDumpTime = 0;
+  }
+
+  /**
+   * Writes a diagnostics snapshot to disk if within per-session limits.
+   * Returns the file path on success, or undefined if skipped/failed.
+   */
+  async dump(
+    trigger: 'hard' | 'critical',
+  ): Promise<MemoryDumpResult | undefined> {
+    if (this.dumpCount >= MAX_DUMPS_PER_SESSION) {
+      debugLogger.debug(
+        `Skipping dump: session cap reached (${MAX_DUMPS_PER_SESSION})`,
+      );
+      return undefined;
+    }
+
+    const now = Date.now();
+    if (now - this.lastDumpTime < MIN_DUMP_INTERVAL_MS) {
+      debugLogger.debug('Skipping dump: cooldown not elapsed');
+      return undefined;
+    }
+
+    try {
+      const diagnosticsDir = this.ensureDiagnosticsDir();
+      const sessionId = this.config.getSessionId();
+      const timestamp = new Date()
+        .toISOString()
+        .replace(/:/g, '-')
+        .replace(/\./g, '_');
+      const fileName = `memory-${sessionId.slice(0, 8)}-${timestamp}.json`;
+      const filePath = path.join(diagnosticsDir, fileName);
+
+      const diagnostics = await collectMemoryDiagnostics({
+        sessionId,
+        qwenVersion: this.config.getCliVersion(),
+      });
+
+      const payload = {
+        trigger,
+        dumpNumber: this.dumpCount + 1,
+        ...diagnostics,
+        session: this.collectSessionStats(),
+        suggestion: this.getSuggestion(trigger),
+      };
+
+      fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), 'utf8');
+
+      this.dumpCount++;
+      this.lastDumpTime = now;
+
+      debugLogger.info(
+        `Memory diagnostics written to ${filePath} (trigger=${trigger}, dump #${this.dumpCount})`,
+      );
+
+      return { filePath, trigger };
+    } catch (err) {
+      debugLogger.error(
+        `Failed to write memory diagnostics: ${getErrorMessage(err)}`,
+      );
+      return undefined;
+    }
+  }
+
+  private ensureDiagnosticsDir(): string {
+    const projectDir = this.config.storage.getProjectDir();
+    const diagnosticsDir = path.join(projectDir, 'diagnostics');
+    fs.mkdirSync(diagnosticsDir, { recursive: true });
+    return diagnosticsDir;
+  }
+
+  private collectSessionStats(): Record<string, unknown> {
+    try {
+      const geminiClient = this.config.getGeminiClient?.();
+      if (!geminiClient) return { available: false };
+      const historyLength = geminiClient.getChat?.()?.getHistoryLength?.() ?? 0;
+      return {
+        historyEntries: historyLength,
+      };
+    } catch {
+      return { available: false };
+    }
+  }
+
+  private getSuggestion(trigger: 'hard' | 'critical'): string {
+    if (trigger === 'critical') {
+      return 'Memory is critically high. Consider running /compact or starting a fresh session to avoid OOM.';
+    }
+    return 'Memory pressure detected. Running /compact may help reduce memory usage.';
+  }
+}

--- a/packages/core/src/services/memoryDiagnosticsDumper.ts
+++ b/packages/core/src/services/memoryDiagnosticsDumper.ts
@@ -168,8 +168,8 @@ export class MemoryDiagnosticsDumper {
 
   private getSuggestion(trigger: 'hard' | 'critical'): string {
     if (trigger === 'critical') {
-      return 'Memory is critically high. Consider running /compact or starting a fresh session to avoid OOM.';
+      return 'Memory is critically high. Consider running /compress or starting a fresh session to avoid OOM.';
     }
-    return 'Memory pressure detected. Running /compact may help reduce memory usage.';
+    return 'Memory pressure detected. Running /compress may help reduce memory usage.';
   }
 }

--- a/packages/core/src/services/memoryDiagnosticsDumper.ts
+++ b/packages/core/src/services/memoryDiagnosticsDumper.ts
@@ -17,6 +17,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as v8 from 'node:v8';
 import { collectMemoryDiagnostics } from '../utils/memoryDiagnostics.js';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { getErrorMessage } from '../utils/errors.js';
@@ -51,7 +52,17 @@ export class MemoryDiagnosticsDumper {
 
   /**
    * Writes a diagnostics snapshot to disk if within per-session limits.
-   * Returns the file path on success, or undefined if skipped/failed.
+   *
+   * Uses a two-phase write strategy:
+   * - Phase 1 (synchronous): writes a minimal JSON with process.memoryUsage()
+   *   and v8.getHeapStatistics() — no fork/exec, so it lands on disk even
+   *   under extreme memory pressure.
+   * - Phase 2 (async): collects full diagnostics (may spawn subprocesses)
+   *   and overwrites the file with the complete payload. If Phase 2 crashes,
+   *   Phase 1's file still survives for debugging.
+   *
+   * Slot is reserved synchronously before any await to prevent concurrent
+   * invocations from bypassing the cap/cooldown guards.
    */
   async dump(
     trigger: 'hard' | 'critical',
@@ -69,6 +80,10 @@ export class MemoryDiagnosticsDumper {
       return undefined;
     }
 
+    // Reserve slot synchronously to prevent race between concurrent dumps
+    const dumpNumber = ++this.dumpCount;
+    this.lastDumpTime = now;
+
     try {
       const diagnosticsDir = this.ensureDiagnosticsDir();
       const sessionId = this.config.getSessionId();
@@ -79,30 +94,51 @@ export class MemoryDiagnosticsDumper {
       const fileName = `memory-${sessionId.slice(0, 8)}-${timestamp}.json`;
       const filePath = path.join(diagnosticsDir, fileName);
 
+      // Phase 1: synchronous minimal write — survives crash during Phase 2
+      const minimalPayload = {
+        trigger,
+        dumpNumber,
+        timestamp: new Date().toISOString(),
+        memoryUsage: process.memoryUsage(),
+        v8HeapStats: v8.getHeapStatistics(),
+        session: this.collectSessionStats(),
+        suggestion: this.getSuggestion(trigger),
+        collectionComplete: false,
+      };
+      fs.writeFileSync(
+        filePath,
+        JSON.stringify(minimalPayload, null, 2),
+        'utf8',
+      );
+
+      debugLogger.info(
+        `Phase 1 diagnostics written to ${filePath} (trigger=${trigger}, dump #${dumpNumber})`,
+      );
+
+      // Phase 2: full collection (may fork subprocesses — risky under pressure)
       const diagnostics = await collectMemoryDiagnostics({
         sessionId,
         qwenVersion: this.config.getCliVersion(),
       });
 
-      const payload = {
+      const fullPayload = {
         trigger,
-        dumpNumber: this.dumpCount + 1,
+        dumpNumber,
         ...diagnostics,
         session: this.collectSessionStats(),
         suggestion: this.getSuggestion(trigger),
+        collectionComplete: true,
       };
-
-      fs.writeFileSync(filePath, JSON.stringify(payload, null, 2), 'utf8');
-
-      this.dumpCount++;
-      this.lastDumpTime = now;
+      fs.writeFileSync(filePath, JSON.stringify(fullPayload, null, 2), 'utf8');
 
       debugLogger.info(
-        `Memory diagnostics written to ${filePath} (trigger=${trigger}, dump #${this.dumpCount})`,
+        `Phase 2 diagnostics written to ${filePath} (trigger=${trigger}, dump #${dumpNumber})`,
       );
 
       return { filePath, trigger };
     } catch (err) {
+      // Slot stays consumed — a failed write should not open the door to more
+      // attempts that would likely also fail under the same pressure conditions.
       debugLogger.error(
         `Failed to write memory diagnostics: ${getErrorMessage(err)}`,
       );

--- a/packages/core/src/services/memoryPressureMonitor.ts
+++ b/packages/core/src/services/memoryPressureMonitor.ts
@@ -200,8 +200,12 @@ export class MemoryPressureMonitor extends EventEmitter {
       return;
     }
 
-    // Write diagnostics to disk before cleanup — the JSON is cheap and survives
-    // even if a subsequent heap snapshot or cleanup triggers OOM.
+    // Write diagnostics to disk before cleanup. dump() uses a two-phase strategy:
+    // Phase 1 (synchronous, before the first await) writes a minimal JSON via
+    // writeFileSync — guaranteed to complete before executeCleanup starts because
+    // async functions run synchronously up to the first await. Phase 2 enriches
+    // the file asynchronously in the background; if it fails the minimal file
+    // still survives for debugging.
     if (pressure === 'hard' || pressure === 'critical') {
       void this.diagnosticsDumper.dump(pressure);
     }

--- a/packages/core/src/services/memoryPressureMonitor.ts
+++ b/packages/core/src/services/memoryPressureMonitor.ts
@@ -11,6 +11,7 @@ import { getHeapStatistics } from 'node:v8';
 import { createDebugLogger } from '../utils/debugLogger.js';
 import { getErrorMessage } from '../utils/errors.js';
 import type { Config } from '../config/config.js';
+import { MemoryDiagnosticsDumper } from './memoryDiagnosticsDumper.js';
 
 // Types
 
@@ -104,6 +105,7 @@ export class MemoryPressureMonitor extends EventEmitter {
   private consecutiveIneffectiveAggressiveCleanups = 0;
   private cleanupGeneration = 0;
   private readonly effectiveMemoryLimit: number;
+  private readonly diagnosticsDumper: MemoryDiagnosticsDumper;
 
   constructor(coreConfig: Config, pressureConfig?: MemoryPressureConfig) {
     super();
@@ -111,6 +113,7 @@ export class MemoryPressureMonitor extends EventEmitter {
     this.config = { ...(pressureConfig ?? DEFAULT_PRESSURE_CONFIG) };
     validateMemoryPressureConfig(this.config);
     this.effectiveMemoryLimit = this.computeEffectiveMemoryLimit();
+    this.diagnosticsDumper = new MemoryDiagnosticsDumper(coreConfig);
     const heapSizeLimit = getHeapStatistics().heap_size_limit;
     debugLogger.info(
       `Effective memory limit: ${formatMiB(this.effectiveMemoryLimit)} MiB; ` +
@@ -142,6 +145,7 @@ export class MemoryPressureMonitor extends EventEmitter {
   resetForNewSession(): void {
     this.cleanupGeneration++;
     this.resetConsecutiveFailures();
+    this.diagnosticsDumper.resetForNewSession();
     this.cleanupInProgress = false;
     this.activeCleanupAction = 'none';
     this.queuedCleanupRecommendation = undefined;
@@ -194,6 +198,12 @@ export class MemoryPressureMonitor extends EventEmitter {
     const cleanupCooldownMs = this.getCleanupCooldownMs(recommendation.action);
     if (!isEscalation && now - this.lastCleanupTime < cleanupCooldownMs) {
       return;
+    }
+
+    // Write diagnostics to disk before cleanup — the JSON is cheap and survives
+    // even if a subsequent heap snapshot or cleanup triggers OOM.
+    if (pressure === 'hard' || pressure === 'critical') {
+      void this.diagnosticsDumper.dump(pressure);
     }
 
     this.executeCleanup(recommendation);


### PR DESCRIPTION
## What this PR does

Adds a `MemoryDiagnosticsDumper` service that auto-writes a lightweight diagnostics JSON to `.qwen/<project>/diagnostics/` when `MemoryPressureMonitor` detects `hard` or `critical` pressure — before running cleanup. The dump survives subsequent OOM crashes, giving maintainers actionable data from bug reports without requiring user intervention.

Implementation: one new file (`memoryDiagnosticsDumper.ts`, 130 lines) + 10 lines added to `memoryPressureMonitor.ts`. The dumper is invoked via `void this.diagnosticsDumper.dump(pressure)` — fire-and-forget; failures are swallowed and logged.

Design (parallels Claude Code's `heapDumpService` auto-dump at 1.5 GB):

```
Pressure detected (hard/critical)
  ├─ 1. Write diagnostics JSON  ← cheap, survives OOM
  └─ 2. Run cleanup steps        ← may free memory or OOM
```

Per-session limits:
- Max 3 dumps per session (avoid disk flooding)
- 30s cooldown between dumps
- State resets on `startNewSession()`

## Why it's needed

Currently when qwen-code OOMs, the only artifact is V8's native stack trace. Users can't run `/doctor memory` after the process is dead — the diagnostic data dies with the process. This auto-dump ensures that memory state (heap usage, V8 stats, history size, actionable suggestion) is persisted to disk before the process crashes, so users can attach it directly to bug reports.

This follows the same philosophy as Claude Code's `heapDumpService` which writes diagnostics before the heap snapshot (because the snapshot itself can crash for very large heaps).

## Reviewer Test Plan

### How to verify

1. Run integration test with constrained heap:
   ```bash
   node --max-old-space-size=256 integration-test.mjs
   ```
   The script allocates JS objects until heap ratio exceeds the `hard` threshold (35%), triggering the dumper.

2. Verify the diagnostics JSON is written with correct shape and actionable suggestion.

3. Run real model E2E to confirm CLI + monitor loads normally without false triggers:
   ```bash
   node --max-old-space-size=512 packages/cli/dist/index.js \
     --model qwen3-coder-flash --bare --auth-type openai -y \
     -p 'Read every TypeScript file in packages/core/src/services/ and summarize each'
   ```

### Evidence (Before & After)

**Integration test output (256 MB heap cap, triggered hard pressure):**

```
Current heap ratio: 2.2% (7 MB / 304 MB)
Thresholds: soft=0.300 hard=0.310 critical=0.322
Allocated 10855 ballast chunks, heap now at 94 MB
Pressure level: hard

✅ SUCCESS: Diagnostics file written!
   File: memory-integrat-2026-05-31T08-29-05_219Z.json
   Trigger: hard
   Dump #: 1
   RSS: 164 MB
   Heap used: 94 MB
   Session history: 42 entries
   Suggestion: Memory pressure detected. Running /compact may help reduce memory usage.
```

**Diagnostics JSON sample:**
```json
{
  "trigger": "hard",
  "dumpNumber": 1,
  "memoryUsage": { "rss": 172146688, "heapUsed": 98903048, "heapTotal": 122830848 },
  "v8HeapStats": { "heapSizeLimit": 318767104, "usedHeapSize": 98903192, "detachedContexts": 0 },
  "session": { "historyEntries": 42 },
  "suggestion": "Memory pressure detected. Running /compact may help reduce memory usage."
}
```

**Real model E2E:** CLI starts normally, model responds, tool call chain works, no false dump triggers under normal heap usage.

**Unit tests:**
```bash
npx vitest run src/services/memoryDiagnosticsDumper.test.ts src/services/memoryPressureMonitor.test.ts
# ✓ memoryPressureMonitor.test.ts (55 tests)
# ✓ memoryDiagnosticsDumper.test.ts (6 tests)
# Tests  61 passed (61)
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Node.js v22.22.0, `--max-old-space-size=256` (integration), `--max-old-space-size=512` (E2E). Model: qwen3-coder-flash.

## Risk & Scope

- Main risk or tradeoff: Diagnostics file write uses `fs.writeFileSync` on the tool-execution path (after tool finishes, in finally). Typical diagnostics JSON is <50 KB so write latency is negligible.
- Not validated / out of scope: Live OOM scenario in a real session — tests use mocked fs. Real trigger requires the usage pattern from #4624 (resume + long session + hundreds of tool calls accumulating history).
- Breaking changes / migration notes: None. New behavior is additive, gated by existing #4403 pressure thresholds. Default path = no-op until pressure ≥ hard.

## Linked Issues

Closes #4651
Builds on: #4403 (memory pressure monitor), #3000 (memory diagnostics roadmap)
Related: #4624 (user-reported OOM that would have benefited from auto-dump)

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

新增 `MemoryDiagnosticsDumper` 服务，当 `MemoryPressureMonitor` 检测到 `hard` 或 `critical` 压力时，自动将轻量级诊断 JSON 写入 `.qwen/<project>/diagnostics/`——在执行清理之前。这样即使后续 OOM 崩溃，诊断数据仍然存活在磁盘上。

实现：一个新文件（`memoryDiagnosticsDumper.ts`，130 行）+ `memoryPressureMonitor.ts` 新增 10 行。通过 `void this.diagnosticsDumper.dump(pressure)` 调用——fire-and-forget，失败会被吞掉并记录日志。

设计（对标 Claude Code 的 `heapDumpService` 在 1.5 GB 时自动 dump）：

```
检测到压力 (hard/critical)
  ├─ 1. 写入诊断 JSON  ← 开销小，OOM 后仍存活
  └─ 2. 执行清理步骤    ← 可能释放内存或 OOM
```

每会话限制：
- 最多 3 次 dump（防止刷盘）
- 两次 dump 间 30s 冷却
- `startNewSession()` 时重置状态

## 为什么需要

当前 qwen-code OOM 时，唯一的产物是 V8 的原生堆栈跟踪。进程死后用户无法运行 `/doctor memory`——诊断数据随进程一起消亡。此自动 dump 确保内存状态（堆使用量、V8 统计、history 大小、可操作建议）在进程崩溃前持久化到磁盘，用户可直接附到 bug report 中。

这遵循了 Claude Code `heapDumpService` 的相同理念：在堆快照之前先写诊断（因为快照本身可能因堆过大而崩溃）。

## 评审测试计划

### 如何验证

1. 用受限堆运行集成测试：`node --max-old-space-size=256 integration-test.mjs`
2. 确认诊断 JSON 写入且格式正确
3. 用真实模型 E2E 确认 CLI + monitor 正常加载，无误触发

### 证据（修复前后对比）

**集成测试输出（256 MB 堆上限，触发 hard 压力）：**
- 文件成功写入：`memory-integrat-2026-05-31T08-29-05_219Z.json`
- 包含完整诊断信息：trigger、dumpNumber、memoryUsage、v8HeapStats、session.historyEntries、suggestion

**真实模型 E2E：** CLI 正常启动、模型响应正常、tool 调用链路正常，无误触发。

**单测：** 61 tests passed（55 + 6）

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

## 风险与范围

- 主要风险：诊断文件写入使用 `fs.writeFileSync`，在 tool 执行路径上（tool 完成后的 finally 中）。典型诊断 JSON <50 KB，写入延迟可忽略。
- 未验证/不在范围内：真实会话中的 OOM 场景——测试使用 mock fs。真实触发需要 #4624 的使用模式。
- 破坏性变更：无。新行为是增量的，受现有 #4403 压力阈值门控。

## 关联 Issue

Closes #4651
构建于：#4403（内存压力监控器）、#3000（内存诊断路线图）
相关：#4624（本可从自动 dump 中获益的用户 OOM 报告）

</details>
