### PR TITLE
[codex] Add project MCP pending approval

### DIFF
--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -10,6 +10,8 @@ import { addCommand } from './mcp/add.js';
 import { removeCommand } from './mcp/remove.js';
 import { listCommand } from './mcp/list.js';
 import { reconnectCommand } from './mcp/reconnect.js';
+import { getCommand } from './mcp/get.js';
+import { approveCommand } from './mcp/approve.js';
 
 export const mcpCommand: CommandModule = {
   command: 'mcp',
@@ -19,6 +21,8 @@ export const mcpCommand: CommandModule = {
       .command(addCommand)
       .command(removeCommand)
       .command(listCommand)
+      .command(getCommand)
+      .command(approveCommand)
       .command(reconnectCommand)
       .demandCommand(1, 'You need at least one command before continuing.')
       .version(false),

--- a/packages/cli/src/commands/mcp/approve.test.ts
+++ b/packages/cli/src/commands/mcp/approve.test.ts
@@ -1,0 +1,184 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import yargs from 'yargs';
+import { loadSettings, SettingScope } from '../../config/settings.js';
+import { approveCommand } from './approve.js';
+
+const mockWriteStdoutLine = vi.hoisted(() => vi.fn());
+const mockWriteStderrLine = vi.hoisted(() => vi.fn());
+const mockSetValue = vi.hoisted(() => vi.fn());
+
+vi.mock('../../utils/stdioHelpers.js', () => ({
+  writeStdoutLine: mockWriteStdoutLine,
+  writeStderrLine: mockWriteStderrLine,
+  clearScreen: vi.fn(),
+}));
+
+vi.mock('../../config/settings.js', async () => {
+  const actual = await vi.importActual('../../config/settings.js');
+  return {
+    ...actual,
+    loadSettings: vi.fn(),
+  };
+});
+
+const mockedLoadSettings = vi.mocked(loadSettings);
+
+describe('mcp approve command', () => {
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    process.exitCode = undefined;
+    mockedLoadSettings.mockReturnValue({
+      merged: { mcpServers: {} },
+      forScope: () => ({ settings: { mcpServers: {} } }),
+      setValue: mockSetValue,
+    } as never);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+  });
+
+  it('copies a pending project server into user settings without project metadata or sensitive fields', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'qwen-mcp-approve-'));
+    writeFileSync(
+      path.join(dir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          project: {
+            command: 'node',
+            args: ['server.js'],
+            env: { SECRET: 'project' },
+            cwd: '/tmp/project',
+            headers: { Authorization: 'Bearer token' },
+            trust: true,
+            timeout: 1000,
+            discoveryTimeoutMs: 2000,
+          },
+        },
+      }),
+    );
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+
+    await yargs([]).command(approveCommand).parseAsync('approve project');
+
+    expect(mockSetValue).toHaveBeenCalledWith(SettingScope.User, 'mcpServers', {
+      project: {
+        command: 'node',
+        args: ['server.js'],
+        timeout: 1000,
+        discoveryTimeoutMs: 2000,
+      },
+    });
+    const saved = mockSetValue.mock.calls[0][2].project;
+    expect(saved).not.toHaveProperty('source');
+    expect(saved).not.toHaveProperty('pendingApproval');
+    expect(saved).not.toHaveProperty('projectConfigPath');
+    expect(saved).not.toHaveProperty('env');
+    expect(saved).not.toHaveProperty('cwd');
+    expect(saved).not.toHaveProperty('headers');
+    expect(saved).not.toHaveProperty('trust');
+    expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+      'Approved MCP server "project".',
+    );
+  });
+
+  it('does not overwrite an existing user settings server with project config', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'qwen-mcp-approve-'));
+    writeFileSync(
+      path.join(dir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          existing: {
+            command: 'node',
+            args: ['project.js'],
+          },
+        },
+      }),
+    );
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+    mockedLoadSettings.mockReturnValue({
+      merged: {
+        mcpServers: {
+          existing: {
+            command: 'node',
+            args: ['trusted.js'],
+          },
+        },
+      },
+      forScope: () => ({
+        settings: {
+          mcpServers: {
+            existing: {
+              command: 'node',
+              args: ['trusted.js'],
+            },
+          },
+        },
+      }),
+      setValue: mockSetValue,
+    } as never);
+
+    await yargs([]).command(approveCommand).parseAsync('approve existing');
+
+    expect(mockSetValue).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('does not approve when any merged settings scope already defines the server', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'qwen-mcp-approve-'));
+    writeFileSync(
+      path.join(dir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          existing: {
+            command: 'node',
+            args: ['project.js'],
+          },
+        },
+      }),
+    );
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+    mockedLoadSettings.mockReturnValue({
+      merged: {
+        mcpServers: {
+          existing: {
+            command: 'node',
+            args: ['settings.js'],
+          },
+        },
+      },
+      forScope: () => ({ settings: { mcpServers: {} } }),
+      setValue: mockSetValue,
+    } as never);
+
+    await yargs([]).command(approveCommand).parseAsync('approve existing');
+
+    expect(mockSetValue).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('exits non-zero when the pending project server is not found', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'qwen-mcp-approve-'));
+    writeFileSync(path.join(dir, '.mcp.json'), JSON.stringify({}));
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+
+    await yargs([]).command(approveCommand).parseAsync('approve missing');
+
+    expect(mockSetValue).not.toHaveBeenCalled();
+    expect(mockWriteStderrLine).toHaveBeenCalledWith(
+      'Pending project MCP server "missing" not found.',
+    );
+    expect(process.exitCode).toBe(1);
+  });
+});

--- a/packages/cli/src/commands/mcp/approve.ts
+++ b/packages/cli/src/commands/mcp/approve.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule } from 'yargs';
+import { loadProjectMcpServers } from '../../config/projectMcpConfig.js';
+import { loadSettings, SettingScope } from '../../config/settings.js';
+import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
+import { toApprovedMcpServerConfig } from './servers.js';
+
+export async function approveMcpServer(serverName: string): Promise<void> {
+  const projectServers = loadProjectMcpServers();
+  const server = projectServers[serverName];
+
+  if (!server) {
+    writeStderrLine(`Pending project MCP server "${serverName}" not found.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const settings = loadSettings();
+  const existing =
+    settings.forScope(SettingScope.User).settings.mcpServers || {};
+  if (settings.merged.mcpServers?.[serverName] || existing[serverName]) {
+    writeStderrLine(`MCP server "${serverName}" already exists in settings.`);
+    process.exitCode = 1;
+    return;
+  }
+  settings.setValue(SettingScope.User, 'mcpServers', {
+    ...existing,
+    [serverName]: toApprovedMcpServerConfig(server),
+  });
+  writeStdoutLine(`Approved MCP server "${serverName}".`);
+}
+
+export const approveCommand: CommandModule = {
+  command: 'approve <server-name>',
+  describe: 'Approve a pending project MCP server',
+  builder: (yargs) =>
+    yargs.positional('server-name', {
+      describe: 'Name of the pending project server to approve',
+      type: 'string',
+      demandOption: true,
+    }),
+  handler: async (argv) => {
+    await approveMcpServer(argv['server-name'] as string);
+  },
+};

--- a/packages/cli/src/commands/mcp/get.test.ts
+++ b/packages/cli/src/commands/mcp/get.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import yargs from 'yargs';
+import { loadSettings } from '../../config/settings.js';
+import { getCommand } from './get.js';
+
+const mockWriteStdoutLine = vi.hoisted(() => vi.fn());
+const mockWriteStderrLine = vi.hoisted(() => vi.fn());
+
+vi.mock('../../utils/stdioHelpers.js', () => ({
+  writeStdoutLine: mockWriteStdoutLine,
+  writeStderrLine: mockWriteStderrLine,
+  clearScreen: vi.fn(),
+}));
+
+vi.mock('../../config/settings.js', () => ({
+  loadSettings: vi.fn(),
+}));
+
+vi.mock('../../config/trustedFolders.js', () => ({
+  isWorkspaceTrusted: vi.fn(() => true),
+}));
+
+vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
+  return {
+    ...actual,
+    ExtensionManager: vi.fn(() => ({
+      refreshCache: vi.fn().mockResolvedValue(undefined),
+      getLoadedExtensions: vi.fn().mockReturnValue([]),
+    })),
+  };
+});
+
+const mockedLoadSettings = vi.mocked(loadSettings);
+
+describe('mcp get command', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockedLoadSettings.mockReturnValue({ merged: { mcpServers: {} } } as never);
+  });
+
+  it('shows pending project-scoped server config without connecting', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'qwen-mcp-get-'));
+    writeFileSync(
+      path.join(dir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          project: {
+            command: 'node',
+            args: ['server.js'],
+          },
+        },
+      }),
+    );
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+
+    await yargs([]).command(getCommand).parseAsync('get project');
+
+    expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+      'project - Pending approval',
+    );
+    expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+      expect.stringContaining('"command": "node"'),
+    );
+    const output = JSON.parse(mockWriteStdoutLine.mock.calls[1][0]);
+    expect(output).toEqual({
+      command: 'node',
+      args: ['server.js'],
+    });
+    expect(output).not.toHaveProperty('source');
+    expect(output).not.toHaveProperty('pendingApproval');
+    expect(output).not.toHaveProperty('projectConfigPath');
+  });
+
+  it('shows configured settings server config', async () => {
+    mockedLoadSettings.mockReturnValue({
+      merged: {
+        mcpServers: {
+          configured: {
+            command: 'node',
+            args: ['settings.js'],
+          },
+        },
+      },
+    } as never);
+
+    await yargs([]).command(getCommand).parseAsync('get configured');
+
+    expect(mockWriteStdoutLine).toHaveBeenCalledWith('configured - Configured');
+    expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          command: 'node',
+          args: ['settings.js'],
+        },
+        null,
+        2,
+      ),
+    );
+  });
+});

--- a/packages/cli/src/commands/mcp/get.ts
+++ b/packages/cli/src/commands/mcp/get.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { CommandModule } from 'yargs';
+import { isProjectMcpServerPendingApproval } from '@qwen-code/qwen-code-core';
+import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
+import { getMcpServersFromConfig, stripProjectMetadata } from './servers.js';
+
+export async function getMcpServer(serverName: string): Promise<void> {
+  const mcpServers = await getMcpServersFromConfig();
+  const server = mcpServers[serverName];
+
+  if (!server) {
+    writeStderrLine(`MCP server "${serverName}" not found.`);
+    return;
+  }
+
+  writeStdoutLine(
+    `${serverName} - ${
+      isProjectMcpServerPendingApproval(server)
+        ? 'Pending approval'
+        : 'Configured'
+    }`,
+  );
+  const output = isProjectMcpServerPendingApproval(server)
+    ? stripProjectMetadata(server)
+    : server;
+  writeStdoutLine(JSON.stringify(output, null, 2));
+}
+
+export const getCommand: CommandModule = {
+  command: 'get <server-name>',
+  describe: 'Show an MCP server configuration',
+  builder: (yargs) =>
+    yargs.positional('server-name', {
+      describe: 'Name of the server to show',
+      type: 'string',
+      demandOption: true,
+    }),
+  handler: async (argv) => {
+    await getMcpServer(argv['server-name'] as string);
+  },
+};

--- a/packages/cli/src/commands/mcp/list.test.ts
+++ b/packages/cli/src/commands/mcp/list.test.ts
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { listMcpServers } from './list.js';
 import { loadSettings } from '../../config/settings.js';
@@ -34,6 +37,9 @@ vi.mock('@qwen-code/qwen-code-core', () => ({
     DISCONNECTED: 'DISCONNECTED',
   },
   ExtensionManager: vi.fn(),
+  isProjectMcpServerPendingApproval: (
+    config: { source?: string; pendingApproval?: boolean } | undefined,
+  ) => config?.source === 'project' && config.pendingApproval === true,
   getErrorMessage: (e: unknown) => (e instanceof Error ? e.message : String(e)),
 }));
 vi.mock('@modelcontextprotocol/sdk/client/index.js');
@@ -110,9 +116,7 @@ describe('mcp list command', () => {
 
     await listMcpServers();
 
-    expect(mockWriteStdoutLine).toHaveBeenCalledWith(
-      'Configured MCP servers:\n',
-    );
+    expect(mockWriteStdoutLine).toHaveBeenCalledWith('MCP servers:\n');
     expect(mockWriteStdoutLine).toHaveBeenCalledWith(
       expect.stringContaining(
         'stdio-server: /path/to/server arg1 (stdio) - Connected',
@@ -180,6 +184,100 @@ describe('mcp list command', () => {
     expect(mockWriteStdoutLine).toHaveBeenCalledWith(
       expect.stringContaining(
         'extension-server: /ext/server  (stdio) - Connected',
+      ),
+    );
+  });
+
+  it('shows project .mcp.json servers as pending without connecting', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'qwen-mcp-list-'));
+    writeFileSync(
+      path.join(dir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          project: {
+            command: 'node',
+            args: ['server.js'],
+          },
+        },
+      }),
+    );
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+    mockedLoadSettings.mockReturnValue({ merged: { mcpServers: {} } });
+
+    await listMcpServers();
+
+    expect(mockedCreateTransport).not.toHaveBeenCalled();
+    expect(mockClient.connect).not.toHaveBeenCalled();
+    expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'project: node server.js (stdio) - Pending approval',
+      ),
+    );
+  });
+
+  it('keeps settings servers active when .mcp.json uses the same name', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'qwen-mcp-list-'));
+    writeFileSync(
+      path.join(dir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          server: {
+            command: 'node',
+            args: ['project.js'],
+          },
+        },
+      }),
+    );
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+    mockedLoadSettings.mockReturnValue({
+      merged: {
+        mcpServers: {
+          server: { command: 'node', args: ['settings.js'] },
+        },
+      },
+    });
+    mockClient.connect.mockResolvedValue(undefined);
+    mockClient.ping.mockResolvedValue(undefined);
+
+    await listMcpServers();
+
+    expect(mockedCreateTransport).toHaveBeenCalledOnce();
+    expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+      expect.stringContaining('server: node settings.js (stdio) - Connected'),
+    );
+  });
+
+  it('keeps a pending project server when an extension uses the same name', async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'qwen-mcp-list-'));
+    writeFileSync(
+      path.join(dir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          server: {
+            command: 'node',
+            args: ['project.js'],
+          },
+        },
+      }),
+    );
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+    mockedLoadSettings.mockReturnValue({ merged: { mcpServers: {} } });
+    mockExtensionManager.getLoadedExtensions.mockReturnValue([
+      {
+        isActive: true,
+        config: {
+          name: 'test-extension',
+          mcpServers: { server: { command: '/ext/server' } },
+        },
+      },
+    ]);
+
+    await listMcpServers();
+
+    expect(mockedCreateTransport).not.toHaveBeenCalled();
+    expect(mockWriteStdoutLine).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'server: node project.js (stdio) - Pending approval',
       ),
     );
   });

--- a/packages/cli/src/commands/mcp/list.ts
+++ b/packages/cli/src/commands/mcp/list.ts
@@ -6,50 +6,20 @@
 
 // File for 'qwen mcp list' command
 import type { CommandModule } from 'yargs';
-import { loadSettings } from '../../config/settings.js';
 import { writeStdoutLine } from '../../utils/stdioHelpers.js';
 import type { MCPServerConfig } from '@qwen-code/qwen-code-core';
 import {
   MCPServerStatus,
   createTransport,
-  ExtensionManager,
+  isProjectMcpServerPendingApproval,
 } from '@qwen-code/qwen-code-core';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { isWorkspaceTrusted } from '../../config/trustedFolders.js';
+import { formatMcpServerInfo, getMcpServersFromConfig } from './servers.js';
 
 const COLOR_GREEN = '\u001b[32m';
 const COLOR_YELLOW = '\u001b[33m';
 const COLOR_RED = '\u001b[31m';
 const RESET_COLOR = '\u001b[0m';
-
-async function getMcpServersFromConfig(): Promise<
-  Record<string, MCPServerConfig>
-> {
-  const settings = loadSettings();
-  const extensionManager = new ExtensionManager({
-    isWorkspaceTrusted: !!isWorkspaceTrusted(settings.merged),
-    telemetrySettings: settings.merged.telemetry,
-  });
-  await extensionManager.refreshCache();
-  const extensions = extensionManager.getLoadedExtensions();
-  const mcpServers = { ...(settings.merged.mcpServers || {}) };
-  for (const extension of extensions) {
-    if (extension.isActive) {
-      Object.entries(extension.config.mcpServers || {}).forEach(
-        ([key, server]) => {
-          if (mcpServers[key]) {
-            return;
-          }
-          mcpServers[key] = {
-            ...server,
-            extensionName: extension.config.name,
-          };
-        },
-      );
-    }
-  }
-  return mcpServers;
-}
 
 async function testMCPConnection(
   serverName: string,
@@ -101,41 +71,45 @@ export async function listMcpServers(): Promise<void> {
     return;
   }
 
-  writeStdoutLine('Configured MCP servers:\n');
+  writeStdoutLine('MCP servers:\n');
 
   for (const serverName of serverNames) {
     const server = mcpServers[serverName];
 
-    const status = await getServerStatus(serverName, server);
+    const pendingApproval = isProjectMcpServerPendingApproval(server);
+    const status = pendingApproval
+      ? undefined
+      : await getServerStatus(serverName, server);
 
     let statusIndicator = '';
     let statusText = '';
-    switch (status) {
-      case MCPServerStatus.CONNECTED:
-        statusIndicator = COLOR_GREEN + '✓' + RESET_COLOR;
-        statusText = 'Connected';
-        break;
-      case MCPServerStatus.CONNECTING:
-        statusIndicator = COLOR_YELLOW + '…' + RESET_COLOR;
-        statusText = 'Connecting';
-        break;
-      case MCPServerStatus.DISCONNECTED:
-      default:
-        statusIndicator = COLOR_RED + '✗' + RESET_COLOR;
-        statusText = 'Disconnected';
-        break;
+    if (pendingApproval) {
+      statusIndicator = COLOR_YELLOW + '?' + RESET_COLOR;
+      statusText = 'Pending approval';
+    } else {
+      switch (status) {
+        case MCPServerStatus.CONNECTED:
+          statusIndicator = COLOR_GREEN + '✓' + RESET_COLOR;
+          statusText = 'Connected';
+          break;
+        case MCPServerStatus.CONNECTING:
+          statusIndicator = COLOR_YELLOW + '…' + RESET_COLOR;
+          statusText = 'Connecting';
+          break;
+        case MCPServerStatus.DISCONNECTED:
+        default:
+          statusIndicator = COLOR_RED + '✗' + RESET_COLOR;
+          statusText = 'Disconnected';
+          break;
+      }
     }
 
-    let serverInfo = `${serverName}: `;
-    if (server.httpUrl) {
-      serverInfo += `${server.httpUrl} (http)`;
-    } else if (server.url) {
-      serverInfo += `${server.url} (sse)`;
-    } else if (server.command) {
-      serverInfo += `${server.command} ${server.args?.join(' ') || ''} (stdio)`;
-    }
-
-    writeStdoutLine(`${statusIndicator} ${serverInfo} - ${statusText}`);
+    writeStdoutLine(
+      `${statusIndicator} ${formatMcpServerInfo(
+        serverName,
+        server,
+      )} - ${statusText}`,
+    );
   }
 }
 

--- a/packages/cli/src/commands/mcp/reconnect.ts
+++ b/packages/cli/src/commands/mcp/reconnect.ts
@@ -7,49 +7,13 @@
 import type { CommandModule } from 'yargs';
 import { loadSettings } from '../../config/settings.js';
 import { writeStdoutLine, writeStderrLine } from '../../utils/stdioHelpers.js';
-import {
-  Config,
-  FileDiscoveryService,
-  ExtensionManager,
-} from '@qwen-code/qwen-code-core';
-import { isWorkspaceTrusted } from '../../config/trustedFolders.js';
+import { Config, FileDiscoveryService } from '@qwen-code/qwen-code-core';
 import type { MCPServerConfig } from '@qwen-code/qwen-code-core';
+import { getMcpServersFromConfig } from './servers.js';
 
-async function getMcpServersFromConfig(
-  extensionManager?: ExtensionManager,
-): Promise<Record<string, MCPServerConfig>> {
-  const settings = loadSettings();
-  const extManager =
-    extensionManager ??
-    new ExtensionManager({
-      isWorkspaceTrusted: !!isWorkspaceTrusted(settings.merged),
-      telemetrySettings: settings.merged.telemetry,
-    });
-
-  if (!extensionManager) {
-    await extManager.refreshCache();
-  }
-  const extensions = extManager.getLoadedExtensions();
-  const mcpServers = { ...(settings.merged.mcpServers || {}) };
-  for (const extension of extensions) {
-    if (extension.isActive) {
-      Object.entries(extension.config.mcpServers || {}).forEach(
-        ([key, server]) => {
-          if (mcpServers[key]) {
-            return;
-          }
-          mcpServers[key] = {
-            ...server,
-            extensionName: extension.config.name,
-          };
-        },
-      );
-    }
-  }
-  return mcpServers;
-}
-
-async function createMinimalConfig(): Promise<Config> {
+async function createMinimalConfig(
+  mcpServers: Record<string, MCPServerConfig>,
+): Promise<Config> {
   const settings = loadSettings();
   const cwd = process.cwd();
   const fileService = new FileDiscoveryService(cwd);
@@ -59,7 +23,7 @@ async function createMinimalConfig(): Promise<Config> {
     targetDir: cwd,
     cwd,
     debugMode: false,
-    mcpServers: settings.merged.mcpServers || {},
+    mcpServers,
     fileDiscoveryService: fileService,
     mcpServerCommand: settings.merged.mcp?.serverCommand,
   });
@@ -94,7 +58,7 @@ async function reconnectMcpServer(serverName: string): Promise<void> {
   writeStdoutLine(`Reconnecting to server "${serverName}"...`);
 
   try {
-    const config = await createMinimalConfig();
+    const config = await createMinimalConfig(mcpServers);
     const toolRegistry = config.getToolRegistry();
     await toolRegistry.discoverToolsForServer(serverName);
     writeStdoutLine(`Successfully reconnected to server "${serverName}".`);
@@ -108,14 +72,7 @@ async function reconnectMcpServer(serverName: string): Promise<void> {
 }
 
 async function reconnectAllMcpServers(): Promise<void> {
-  const settings = loadSettings();
-  const extensionManager = new ExtensionManager({
-    isWorkspaceTrusted: !!isWorkspaceTrusted(settings.merged),
-    telemetrySettings: settings.merged.telemetry,
-  });
-  await extensionManager.refreshCache();
-
-  const mcpServers = await getMcpServersFromConfig(extensionManager);
+  const mcpServers = await getMcpServersFromConfig();
   const serverNames = Object.keys(mcpServers);
 
   if (serverNames.length === 0) {
@@ -127,7 +84,7 @@ async function reconnectAllMcpServers(): Promise<void> {
 
   let config: Config | undefined;
   try {
-    config = await createMinimalConfig();
+    config = await createMinimalConfig(mcpServers);
     const toolRegistry = config.getToolRegistry();
 
     for (const serverName of serverNames) {

--- a/packages/cli/src/commands/mcp/servers.ts
+++ b/packages/cli/src/commands/mcp/servers.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { MCPServerConfig } from '@qwen-code/qwen-code-core';
+import { ExtensionManager } from '@qwen-code/qwen-code-core';
+import {
+  loadProjectMcpServers,
+  mergeProjectMcpServers,
+} from '../../config/projectMcpConfig.js';
+import { loadSettings } from '../../config/settings.js';
+import { isWorkspaceTrusted } from '../../config/trustedFolders.js';
+
+export async function getMcpServersFromConfig(): Promise<
+  Record<string, MCPServerConfig>
+> {
+  const settings = loadSettings();
+  const extensionManager = new ExtensionManager({
+    isWorkspaceTrusted: !!isWorkspaceTrusted(settings.merged),
+    telemetrySettings: settings.merged.telemetry,
+  });
+  await extensionManager.refreshCache();
+
+  const mcpServers = mergeProjectMcpServers(
+    settings.merged.mcpServers || {},
+    loadProjectMcpServers(),
+  );
+
+  for (const extension of extensionManager.getLoadedExtensions()) {
+    if (!extension.isActive) {
+      continue;
+    }
+    Object.entries(extension.config.mcpServers || {}).forEach(
+      ([key, server]) => {
+        if (mcpServers[key]) {
+          return;
+        }
+        mcpServers[key] = {
+          ...server,
+          extensionName: extension.config.name,
+        };
+      },
+    );
+  }
+
+  return mcpServers;
+}
+
+export function stripProjectMetadata(server: MCPServerConfig): MCPServerConfig {
+  const config = { ...server } as Record<string, unknown>;
+  delete config['source'];
+  delete config['pendingApproval'];
+  delete config['projectConfigPath'];
+  return config as MCPServerConfig;
+}
+
+const APPROVED_PROJECT_MCP_FIELDS = [
+  'command',
+  'args',
+  'url',
+  'httpUrl',
+  'tcp',
+  'timeout',
+  'description',
+  'includeTools',
+  'excludeTools',
+  'oauth',
+  'type',
+  'discoveryTimeoutMs',
+] as const satisfies ReadonlyArray<keyof MCPServerConfig>;
+
+export function toApprovedMcpServerConfig(
+  server: MCPServerConfig,
+): MCPServerConfig {
+  const config: Record<string, unknown> = {};
+  for (const field of APPROVED_PROJECT_MCP_FIELDS) {
+    const value = server[field];
+    if (value !== undefined) {
+      config[field] = value;
+    }
+  }
+  return config as MCPServerConfig;
+}
+
+export function formatMcpServerInfo(
+  serverName: string,
+  server: MCPServerConfig,
+): string {
+  let serverInfo = `${serverName}: `;
+  if (server.httpUrl) {
+    serverInfo += `${server.httpUrl} (http)`;
+  } else if (server.url) {
+    serverInfo += `${server.url} (sse)`;
+  } else if (server.command) {
+    serverInfo += `${server.command} ${server.args?.join(' ') || ''} (stdio)`;
+  }
+  return serverInfo;
+}

--- a/packages/cli/src/config/config.ts
+++ b/packages/cli/src/config/config.ts
@@ -49,6 +49,10 @@ import * as path from 'node:path';
 import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import stripJsonComments from 'strip-json-comments';
+import {
+  loadProjectMcpServers,
+  mergeProjectMcpServers,
+} from './projectMcpConfig.js';
 
 import { resolvePath } from '../utils/resolvePath.js';
 import { getCliVersion } from '../utils/version.js';
@@ -1789,7 +1793,10 @@ export async function loadCliConfig(
     mcpServers: bareMode
       ? {}
       : (() => {
-          const base = settings.mcpServers || {};
+          const base = mergeProjectMcpServers(
+            settings.mcpServers || {},
+            loadProjectMcpServers(cwd),
+          );
           const cliMcpServers = parseMcpConfig(argv.mcpConfig);
           return cliMcpServers ? { ...base, ...cliMcpServers } : base;
         })(),

--- a/packages/cli/src/config/projectMcpConfig.test.ts
+++ b/packages/cli/src/config/projectMcpConfig.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  loadProjectMcpServers,
+  mergeProjectMcpServers,
+} from './projectMcpConfig.js';
+
+describe('projectMcpConfig', () => {
+  it('loads .mcp.json servers as pending project-scoped servers', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'qwen-project-mcp-'));
+    writeFileSync(
+      path.join(dir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          local: {
+            command: 'node',
+            args: ['server.js'],
+          },
+        },
+      }),
+    );
+
+    expect(loadProjectMcpServers(dir)).toEqual({
+      local: {
+        command: 'node',
+        args: ['server.js'],
+        source: 'project',
+        pendingApproval: true,
+        projectConfigPath: path.join(dir, '.mcp.json'),
+      },
+    });
+  });
+
+  it('throws a path-specific error for malformed .mcp.json', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'qwen-project-mcp-'));
+    const configPath = path.join(dir, '.mcp.json');
+    writeFileSync(configPath, '{');
+
+    expect(() => loadProjectMcpServers(dir)).toThrow(
+      `Failed to parse ${configPath}:`,
+    );
+  });
+
+  it('rejects array-shaped mcpServers', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'qwen-project-mcp-'));
+    const configPath = path.join(dir, '.mcp.json');
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcpServers: [{ command: 'node' }],
+      }),
+    );
+
+    expect(() => loadProjectMcpServers(dir)).toThrow(
+      `Invalid ${configPath}: expected an object of MCP servers.`,
+    );
+  });
+
+  it('rejects servers without a transport', () => {
+    const dir = mkdtempSync(path.join(tmpdir(), 'qwen-project-mcp-'));
+    const configPath = path.join(dir, '.mcp.json');
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        mcpServers: {
+          missing: {
+            description: 'missing transport',
+          },
+        },
+      }),
+    );
+
+    expect(() => loadProjectMcpServers(dir)).toThrow(
+      `Invalid ${configPath}: expected an object of MCP servers.`,
+    );
+  });
+
+  it('does not override existing servers when merging project servers', () => {
+    expect(
+      mergeProjectMcpServers(
+        { server: { command: 'settings' } },
+        {
+          server: {
+            command: 'project',
+            source: 'project',
+            pendingApproval: true,
+          },
+        },
+      ),
+    ).toEqual({
+      server: { command: 'settings' },
+    });
+  });
+});

--- a/packages/cli/src/config/projectMcpConfig.ts
+++ b/packages/cli/src/config/projectMcpConfig.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import stripJsonComments from 'strip-json-comments';
+import type { MCPServerConfig } from '@qwen-code/qwen-code-core';
+
+export const PROJECT_MCP_CONFIG_FILENAME = '.mcp.json';
+
+type ParsedMcpConfig = {
+  mcpServers?: unknown;
+};
+
+function isServerMap(value: unknown): value is Record<string, MCPServerConfig> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.values(value).every(
+      (server) =>
+        typeof server === 'object' &&
+        server !== null &&
+        !Array.isArray(server) &&
+        hasMcpTransport(server),
+    )
+  );
+}
+
+function hasMcpTransport(value: object): value is MCPServerConfig {
+  const server = value as MCPServerConfig;
+  return (
+    typeof server.command === 'string' ||
+    typeof server.url === 'string' ||
+    typeof server.httpUrl === 'string' ||
+    typeof server.tcp === 'string' ||
+    server.type === 'sdk'
+  );
+}
+
+export function loadProjectMcpServers(
+  cwd: string = process.cwd(),
+): Record<string, MCPServerConfig> {
+  const projectConfigPath = path.join(cwd, PROJECT_MCP_CONFIG_FILENAME);
+  if (!fs.existsSync(projectConfigPath)) {
+    return {};
+  }
+
+  let parsed: ParsedMcpConfig | Record<string, MCPServerConfig>;
+  try {
+    parsed = JSON.parse(
+      stripJsonComments(fs.readFileSync(projectConfigPath, 'utf-8')),
+    ) as ParsedMcpConfig | Record<string, MCPServerConfig>;
+  } catch (error) {
+    throw new Error(
+      `Failed to parse ${projectConfigPath}: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+  const servers =
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    'mcpServers' in parsed &&
+    typeof parsed.mcpServers === 'object'
+      ? parsed.mcpServers
+      : parsed;
+
+  if (!isServerMap(servers)) {
+    throw new Error(
+      `Invalid ${projectConfigPath}: expected an object of MCP servers.`,
+    );
+  }
+
+  return Object.fromEntries(
+    Object.entries(servers).map(([name, server]) => [
+      name,
+      {
+        ...server,
+        source: 'project',
+        pendingApproval: true,
+        projectConfigPath,
+      },
+    ]),
+  );
+}
+
+export function mergeProjectMcpServers(
+  baseServers: Record<string, MCPServerConfig>,
+  projectServers: Record<string, MCPServerConfig>,
+): Record<string, MCPServerConfig> {
+  const merged = { ...baseServers };
+  for (const [name, server] of Object.entries(projectServers)) {
+    if (!merged[name]) {
+      merged[name] = server;
+    }
+  }
+  return merged;
+}

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -891,6 +891,62 @@ describe('Server Config (config.ts)', () => {
       } as ConfigParameters);
       expect(config.getFailedMcpServerNames()).toEqual([]);
     });
+
+    it('getFailedMcpServerNames skips project servers pending approval', () => {
+      const config = new Config({
+        ...baseParams,
+        checkpointing: false,
+        mcpServers: {
+          pending: {
+            command: 'node',
+            source: 'project',
+            pendingApproval: true,
+          },
+        },
+      } as ConfigParameters);
+
+      expect(config.getFailedMcpServerNames()).toEqual([]);
+    });
+
+    it('does not let extensions replace pending project MCP servers', () => {
+      const config = new Config({
+        ...baseParams,
+        checkpointing: false,
+        mcpServers: {
+          server: {
+            command: 'node',
+            args: ['project.js'],
+            source: 'project',
+            pendingApproval: true,
+          },
+        },
+      } as ConfigParameters);
+      vi.spyOn(config, 'getActiveExtensions').mockReturnValue([
+        {
+          isActive: true,
+          config: {
+            name: 'test-extension',
+            mcpServers: {
+              server: { command: 'extension' },
+              other: { command: 'other-extension' },
+            },
+          },
+        },
+      ] as never);
+
+      expect(config.getMcpServers()).toEqual({
+        server: {
+          command: 'node',
+          args: ['project.js'],
+          source: 'project',
+          pendingApproval: true,
+        },
+        other: {
+          command: 'other-extension',
+          extensionName: 'test-extension',
+        },
+      });
+    });
   });
 
   describe('refreshAuth', () => {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -538,6 +538,9 @@ export class MCPServerConfig {
      * call sites.
      */
     readonly discoveryTimeoutMs?: number,
+    readonly source?: 'project',
+    readonly pendingApproval?: boolean,
+    readonly projectConfigPath?: string,
   ) {}
 }
 
@@ -546,6 +549,12 @@ export class MCPServerConfig {
  */
 export function isSdkMcpServerConfig(config: MCPServerConfig): boolean {
   return config.type === 'sdk';
+}
+
+export function isProjectMcpServerPendingApproval(
+  config: MCPServerConfig | undefined,
+): boolean {
+  return config?.source === 'project' && config.pendingApproval === true;
 }
 
 export enum AuthProviderType {
@@ -1831,6 +1840,9 @@ export class Config {
       if (this.isMcpServerDisabled(name)) {
         continue;
       }
+      if (isProjectMcpServerPendingApproval(servers[name])) {
+        continue;
+      }
       if (getMCPServerStatus(name) !== MCPServerStatus.CONNECTED) {
         failed.push(name);
       }
@@ -2602,7 +2614,9 @@ export class Config {
     for (const extension of extensions) {
       Object.entries(extension.config.mcpServers || {}).forEach(
         ([key, server]) => {
-          if (mcpServers[key]) return;
+          if (mcpServers[key]) {
+            return;
+          }
           mcpServers[key] = {
             ...server,
             extensionName: extension.config.name,

--- a/packages/core/src/tools/mcp-client-manager.test.ts
+++ b/packages/core/src/tools/mcp-client-manager.test.ts
@@ -77,6 +77,39 @@ describe('McpClientManager', () => {
     expect(mockedMcpClient.discover).not.toHaveBeenCalled();
   });
 
+  it('does not connect project-scoped servers pending approval', async () => {
+    const mockedMcpClient = {
+      connect: vi.fn(),
+      discover: vi.fn(),
+      disconnect: vi.fn(),
+      getStatus: vi.fn(),
+    };
+    vi.mocked(McpClient).mockReturnValue(
+      mockedMcpClient as unknown as McpClient,
+    );
+    const mockConfig = {
+      isTrustedFolder: () => true,
+      getMcpServers: () => ({
+        project: {
+          command: 'node',
+          pendingApproval: true,
+          source: 'project',
+        },
+      }),
+      getMcpServerCommand: () => undefined,
+      getPromptRegistry: () => ({}),
+      getWorkspaceContext: () => ({}),
+      getDebugMode: () => false,
+      isMcpServerDisabled: () => false,
+    } as unknown as Config;
+    const manager = new McpClientManager(mockConfig, {} as ToolRegistry);
+
+    await manager.discoverAllMcpTools(mockConfig);
+
+    expect(mockedMcpClient.connect).not.toHaveBeenCalled();
+    expect(mockedMcpClient.discover).not.toHaveBeenCalled();
+  });
+
   it('should disconnect all clients when stop is called', async () => {
     // Track disconnect calls across all instances
     const disconnectCalls: string[] = [];

--- a/packages/core/src/tools/mcp-client-manager.ts
+++ b/packages/core/src/tools/mcp-client-manager.ts
@@ -5,7 +5,10 @@
  */
 
 import type { Config, MCPServerConfig } from '../config/config.js';
-import { isSdkMcpServerConfig } from '../config/config.js';
+import {
+  isProjectMcpServerPendingApproval,
+  isSdkMcpServerConfig,
+} from '../config/config.js';
 import type { ToolRegistry } from './tool-registry.js';
 import {
   McpClient,
@@ -971,6 +974,10 @@ export class McpClientManager {
             debugLogger.debug(`Skipping disabled MCP server: ${name}`);
             return;
           }
+          if (isProjectMcpServerPendingApproval(config)) {
+            debugLogger.debug(`Skipping pending project MCP server: ${name}`);
+            return;
+          }
 
           // Budget gate (PR 14): synchronous slot reservation BEFORE the
           // `await client.connect()` below. Refusal only happens under
@@ -1133,6 +1140,10 @@ export class McpClientManager {
     // Production `Config` always defines the method.
     if (this.cliConfig.isMcpServerDisabled?.(serverName)) {
       debugLogger.debug(`Skipping disabled MCP server: ${serverName}`);
+      return;
+    }
+    if (isProjectMcpServerPendingApproval(serverConfig)) {
+      debugLogger.debug(`Skipping pending project MCP server: ${serverName}`);
       return;
     }
 
@@ -1620,6 +1631,13 @@ export class McpClientManager {
           }
           continue;
         }
+        if (isProjectMcpServerPendingApproval(servers[name])) {
+          debugLogger.debug(`Skipping pending project MCP server: ${name}`);
+          if (this.clients.has(name)) {
+            await this.removeServer(name);
+          }
+          continue;
+        }
         const existingClient = this.clients.get(name);
         if (!existingClient) {
           // PR 14 fix (review #4247 wenshao R6 line 956): pre-reservation
@@ -1977,6 +1995,9 @@ export class McpClientManager {
       // its actual reason rather than a misleading budget refusal.
       if (this.cliConfig.isMcpServerDisabled(serverName)) {
         throw new Error(`MCP server '${serverName}' is disabled.`);
+      }
+      if (isProjectMcpServerPendingApproval(serverConfig)) {
+        throw new Error(`MCP server '${serverName}' is pending approval.`);
       }
 
       // Budget gate (PR 14): a lazy `readResource` against a server


### PR DESCRIPTION
## What this PR does

Adds project-scoped `.mcp.json` discovery with a safe pending-approval state. Project MCP servers are visible in `qwen mcp list` and `qwen mcp get <name>`, but they do not create transports, spawn stdio processes, connect to remote endpoints, or run discovery while pending. `qwen mcp approve <name>` explicitly copies a pending project server into user settings, after which the existing settings-based MCP behavior applies.

## Why it's needed

Project-local MCP configuration is useful for sharing repository setup, but it has a different trust profile from user settings or explicit CLI configuration. This keeps inspection side-effect-free by default and prevents workspace-controlled MCP commands from running just because a user listed or viewed MCP configuration.

## Reviewer Test Plan

### How to verify

Create a workspace `.mcp.json` with a stdio server such as `{"mcpServers":{"demo":{"command":"node","args":["server.js"]}}}`. Run `qwen mcp list` and confirm the server appears as `Pending approval` without starting the command. Run `qwen mcp get demo` and confirm it shows the pending status and config. Run `qwen mcp approve demo`, then run `qwen mcp list` again and confirm the server now follows normal settings-based MCP connection behavior.

### Evidence (Before & After)

N/A. This is CLI behavior covered by unit tests.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Validated with focused Vitest suites in `packages/cli` and `packages/core`. Full build/typecheck were attempted but blocked by existing unrelated workspace dependency/export issues in this checkout.

## Risk & Scope

- Main risk or tradeoff: approval currently promotes the selected project server into user settings, so subsequent `.mcp.json` changes require another explicit approval path rather than silently changing the approved config.
- Not validated / out of scope: Windows and Linux manual verification; richer interactive approval UX.
- Breaking changes / migration notes: none.

## Linked Issues

Refs #4615.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

新增项目级 `.mcp.json` 发现，并默认进入安全的待批准状态。项目 MCP server 会显示在 `qwen mcp list` 和 `qwen mcp get <name>` 中，但在待批准时不会创建 transport、启动 stdio 进程、连接远端端点或执行 discovery。`qwen mcp approve <name>` 会显式把待批准的项目 server 复制进用户 settings，之后复用现有 settings-based MCP 行为。

## 为什么需要

项目内 MCP 配置适合共享仓库设置，但它和用户 settings 或显式 CLI 配置的信任模型不同。这个改动让配置检查默认没有副作用，避免用户只是查看 MCP 配置时就运行 workspace 控制的 MCP 命令。

## Reviewer Test Plan

### 如何验证

在 workspace 中创建 `.mcp.json`，内容例如 `{"mcpServers":{"demo":{"command":"node","args":["server.js"]}}}`。运行 `qwen mcp list`，确认 server 显示为 `Pending approval` 且不会启动命令。运行 `qwen mcp get demo`，确认显示 pending 状态和配置。运行 `qwen mcp approve demo`，再运行 `qwen mcp list`，确认该 server 现在按普通 settings-based MCP 连接行为处理。

### Evidence (Before & After)

N/A。这个 CLI 行为由单元测试覆盖。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment（可选）

已在 `packages/cli` 和 `packages/core` 跑过聚焦 Vitest 套件。完整 build/typecheck 已尝试，但被当前 checkout 中既有的无关 workspace 依赖/export 问题阻塞。

## Risk & Scope

- 主要风险或权衡：当前 approval 会把选中的 project server 提升到用户 settings；因此后续 `.mcp.json` 改动需要再次走显式批准路径，而不会静默改变已批准配置。
- 未验证 / 不在范围：Windows 和 Linux 手工验证；更完整的交互式批准 UX。
- Breaking changes / migration notes：无。

## Linked Issues

Refs #4615。

</details>
