### PR TITLE
fix(telemetry): clear span dedup state after chat compression (#3731)

### DIFF
--- a/packages/core/src/core/geminiChat.ts
+++ b/packages/core/src/core/geminiChat.ts
@@ -41,6 +41,7 @@ import {
   logContentRetry,
   logContentRetryFailure,
 } from '../telemetry/loggers.js';
+import { clearDetailedSpanState } from '../telemetry/detailed-span-attributes.js';
 import { type ChatRecordingService } from '../services/chatRecordingService.js';
 import {
   ChatCompressionService,
@@ -1400,6 +1401,7 @@ export class GeminiChat {
       this.setHistory(newHistory);
       debugLogger.debug('[FILE_READ_CACHE] clear after auto tryCompress');
       this.config.getFileReadCache().clear();
+      clearDetailedSpanState();
       this.lastPromptTokenCount = info.newTokenCount;
       this.telemetryService?.setLastPromptTokenCount(info.newTokenCount);
       // Reset the consecutive-failure counter on success so a forced /compress

--- a/packages/core/src/telemetry/detailed-span-attributes.test.ts
+++ b/packages/core/src/telemetry/detailed-span-attributes.test.ts
@@ -400,5 +400,28 @@ describe('detailed-span-attributes', () => {
       addSystemPromptAttributes(config, span2, 'Same prompt');
       expect(span2.attrs['system_prompt']).toBe('Same prompt');
     });
+
+    it('resets seenHashes so tool schema full body is re-emitted after compression', () => {
+      const config = createMockConfig();
+      const tools = [
+        { name: 'Read', description: 'Read a file', parameters: {} },
+      ];
+
+      const span1 = createMockSpan();
+      addToolSchemaAttributes(config, span1, tools);
+      expect(span1.events.length).toBe(1);
+      expect(span1.events[0]!.attributes['tool_definition']).toBeDefined();
+
+      const span2 = createMockSpan();
+      addToolSchemaAttributes(config, span2, tools);
+      expect(span2.events.length).toBe(0);
+
+      clearDetailedSpanState();
+
+      const span3 = createMockSpan();
+      addToolSchemaAttributes(config, span3, tools);
+      expect(span3.events.length).toBe(1);
+      expect(span3.events[0]!.attributes['tool_definition']).toBeDefined();
+    });
   });
 });

--- a/packages/core/src/telemetry/detailed-span-attributes.ts
+++ b/packages/core/src/telemetry/detailed-span-attributes.ts
@@ -13,8 +13,8 @@ import { safeJsonStringify } from '../utils/safeJsonStringify.js';
 const MAX_CONTENT_SIZE = 60 * 1024; // 60KB
 const SYSTEM_PROMPT_PREVIEW_LENGTH = 500;
 
-// Process-global; intentionally never cleared in production. Bounded by the
-// number of unique system prompts + tool schemas seen in one session.
+// Process-global dedup set. Cleared on chat compression so post-compaction
+// spans re-emit full system prompts and tool schemas.
 const seenHashes = new Set<string>();
 
 function isEnabled(config: Config): boolean {

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -172,4 +172,5 @@ export {
   addToolInputAttributes,
   addToolResultAttributes,
   truncateContent,
+  clearDetailedSpanState,
 } from './detailed-span-attributes.js';


### PR DESCRIPTION
## Summary

- Wire `clearDetailedSpanState()` into `GeminiChat.tryCompress()` COMPRESSED branch so post-compaction OTel spans re-emit full system prompt / tool schema content instead of just hashes
- Export `clearDetailedSpanState` from telemetry barrel (`index.ts`)
- Update stale comment on `seenHashes` that claimed "intentionally never cleared in production"
- Add test verifying tool schema full body is re-emitted after clear

## Context

`detailed-span-attributes.ts` uses a module-level `seenHashes: Set<string>` to deduplicate system prompt / tool schema full content on spans. After chat compression, the conversation is rebuilt and these contents are re-injected, but `seenHashes` was never cleared — post-compression spans silently lost full content (emitting only hash + preview). This matters for long-running daemon/qwen-serve sessions with multiple compressions.

`tryCompress()` is the single convergence point for all compression paths (pre-send hard-tier rescue, reactive overflow, manual `/compress`, ACP), so one call site covers everything.

## Test plan

- [x] `npx vitest run src/telemetry/detailed-span-attributes.test.ts` — 29 tests pass (1 new)
- [x] `npx vitest run src/core/geminiChat.test.ts` — 150 tests pass
- [x] `npx tsc --noEmit` — clean
- [x] Pre-commit hooks (prettier + eslint) pass

## Out of scope

- `/clear`, `/reset`, `/resume` paths also don't clear `seenHashes` — pre-existing gap, separate follow-up
- ACP multi-session process-global `seenHashes` — pre-existing design, clearing is benign (re-emitting full content is better than losing it)

Closes part of #3731 (P3 deeper observability — `clearDetailedSpanState` into chat compression cleanup checklist item)

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)