### PR TITLE
fix: include submodule files in file search

### DIFF
--- a/packages/core/src/utils/filesearch/crawler.test.ts
+++ b/packages/core/src/utils/filesearch/crawler.test.ts
@@ -942,6 +942,62 @@ describe('crawler', () => {
       expect(results).not.toContain('skip.txt');
     });
 
+    it('should list tracked files inside submodules', async () => {
+      tmpDir = await createTmpDir({
+        packages: {
+          nested: {
+            'submodule-file.ts': '',
+          },
+        },
+      });
+      const gitCalls: string[][] = [];
+
+      __setCommandRunnerForTests(async (command, args) => {
+        if (command !== 'git') {
+          return { success: false, lines: [] };
+        }
+        gitCalls.push(args);
+        if (args.includes('rev-parse') && args.includes('--show-toplevel')) {
+          return { success: true, lines: [tmpDir] };
+        }
+        if (args.includes('ls-files') && args.includes('--others')) {
+          return { success: true, lines: [] };
+        }
+        if (args.includes('ls-files') && args.includes('--deleted')) {
+          return { success: true, lines: [] };
+        }
+        if (args.includes('ls-files') && args.includes('--cached')) {
+          return {
+            success: true,
+            lines: ['S packages/nested', 'H packages/nested/submodule-file.ts'],
+          };
+        }
+        return { success: false, lines: [] };
+      });
+
+      const ignore = loadIgnoreRules({
+        projectRoot: tmpDir,
+        useGitignore: false,
+        useQwenignore: false,
+        ignoreDirs: [],
+      });
+
+      const results = await crawl({
+        crawlDirectory: tmpDir,
+        cwd: tmpDir,
+        ignore,
+        cache: false,
+        cacheTtl: 0,
+      });
+
+      const cachedGitCall = gitCalls.find(
+        (args) => args.includes('ls-files') && args.includes('--cached'),
+      );
+      expect(cachedGitCall).toContain('--recurse-submodules');
+      expect(results).toContain('packages/nested/submodule-file.ts');
+      expect(results).not.toContain('packages/nested');
+    });
+
     it('should preserve leading and trailing spaces in tracked filenames', async () => {
       tmpDir = await createTmpDir({
         ' leading.txt': '',

--- a/packages/core/src/utils/filesearch/crawler.ts
+++ b/packages/core/src/utils/filesearch/crawler.ts
@@ -1036,7 +1036,12 @@ async function crawlWithGitLsFiles(
 
   // Avoid `-z` with `-t`: record shape for `ls-files -t` + `-z` is not stable across Git
   // versions; newline-delimited output is fine here (index paths cannot contain newlines).
-  const trackedArgs = ['--literal-pathspecs', 'ls-files', '--cached'];
+  const trackedArgs = [
+    '--literal-pathspecs',
+    'ls-files',
+    '--cached',
+    '--recurse-submodules',
+  ];
   trackedArgs.push('-t');
   if (relativeToGitRoot && relativeToGitRoot !== '.') {
     trackedArgs.push(relativeToGitRoot);


### PR DESCRIPTION
﻿## Summary
- include tracked files inside submodules in the git-backed file crawler
- keep the existing skip for the submodule gitlink itself
- add a regression test that requires `git ls-files --cached --recurse-submodules`

Fixes #4568

## To verify
- `npm exec -- vitest run packages/core/src/utils/filesearch/crawler.test.ts`
- `npm exec -- eslint packages/core/src/utils/filesearch/crawler.ts packages/core/src/utils/filesearch/crawler.test.ts --max-warnings 0`
- `npm exec -- prettier --check packages/core/src/utils/filesearch/crawler.ts packages/core/src/utils/filesearch/crawler.test.ts`
- `npm run typecheck --workspace=@qwen-code/qwen-code-core`
