### PR TITLE
feat(cli): Add searchable MiniMax-M3 model setup

### DIFF
--- a/packages/cli/src/config/auth.test.ts
+++ b/packages/cli/src/config/auth.test.ts
@@ -61,6 +61,20 @@ describe('validateAuthMethod', () => {
     expect(validateAuthMethod(AuthType.USE_OPENAI)).toBeNull();
   });
 
+  it('should return null for USE_OPENAI with custom envKey stored in settings.env', () => {
+    vi.mocked(settings.loadSettings).mockReturnValue({
+      merged: {
+        env: { CUSTOM_API_KEY: 'settings-env-key' },
+        model: { name: 'custom-model' },
+        modelProviders: {
+          openai: [{ id: 'custom-model', envKey: 'CUSTOM_API_KEY' }],
+        },
+      },
+    } as unknown as ReturnType<typeof settings.loadSettings>);
+
+    expect(validateAuthMethod(AuthType.USE_OPENAI)).toBeNull();
+  });
+
   it('should return error with custom envKey hint when modelProviders envKey is set but env var is missing', () => {
     vi.mocked(settings.loadSettings).mockReturnValue({
       merged: {

--- a/packages/cli/src/config/auth.ts
+++ b/packages/cli/src/config/auth.ts
@@ -49,6 +49,20 @@ function findModelConfig(
   return models.find((m) => m.id === modelId);
 }
 
+function hasEnvValue(settings: Settings, envKey: string | undefined): boolean {
+  if (!envKey) {
+    return false;
+  }
+  if (process.env[envKey]) {
+    return true;
+  }
+  const settingsEnv = settings.env as Record<string, unknown> | undefined;
+  const settingsEnvValue = settingsEnv?.[envKey];
+  return (
+    typeof settingsEnvValue === 'string' && settingsEnvValue.trim().length > 0
+  );
+}
+
 /**
  * Check if API key is available for the given auth type and model configuration.
  * Prioritizes custom envKey from modelProviders over default environment variables.
@@ -94,7 +108,7 @@ function hasApiKeyForAuth(
 
   if (modelConfig?.envKey) {
     // Explicit envKey configured - only check this env var, no apiKey fallback
-    const hasKey = !!process.env[modelConfig.envKey];
+    const hasKey = hasEnvValue(settings, modelConfig.envKey);
     return {
       hasKey,
       checkedEnvKey: modelConfig.envKey,
@@ -105,7 +119,7 @@ function hasApiKeyForAuth(
   // Using default environment variable - apiKey fallback is allowed
   const defaultEnvKey = DEFAULT_ENV_KEYS[authType];
   if (defaultEnvKey) {
-    const hasKey = !!process.env[defaultEnvKey];
+    const hasKey = hasEnvValue(settings, defaultEnvKey);
     if (hasKey) {
       return { hasKey, checkedEnvKey: defaultEnvKey, isExplicitEnvKey: false };
     }

--- a/packages/cli/src/ui/auth/ProviderSetupSteps.test.tsx
+++ b/packages/cli/src/ui/auth/ProviderSetupSteps.test.tsx
@@ -6,6 +6,7 @@
 
 import { renderWithProviders } from '../../test-utils/render.js';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
 import { AuthType } from '@qwen-code/qwen-code-core';
 import type { KeypressHandler, Key } from '../contexts/KeypressContext.js';
 import { useKeypress } from '../hooks/useKeypress.js';
@@ -16,15 +17,15 @@ type UseKeypressMockOptions = { isActive: boolean };
 
 vi.mock('../hooks/useKeypress.js');
 
-let activeKeypressHandler: KeypressHandler | null = null;
+let activeKeypressHandlers: KeypressHandler[] = [];
 
 describe('ProviderSetupSteps', () => {
   beforeEach(() => {
-    activeKeypressHandler = null;
+    activeKeypressHandlers = [];
     vi.mocked(useKeypress).mockImplementation(
       (handler: KeypressHandler, options?: UseKeypressMockOptions) => {
         if (options?.isActive) {
-          activeKeypressHandler = handler;
+          activeKeypressHandlers.push(handler);
         }
       },
     );
@@ -35,10 +36,33 @@ describe('ProviderSetupSteps', () => {
     sequence: string = name,
     overrides: Partial<Key> = {},
   ) => {
-    if (!activeKeypressHandler) {
+    if (activeKeypressHandlers.length === 0) {
       throw new Error(`No active keypress handler for ${name}`);
     }
-    activeKeypressHandler({
+    const event = {
+      name,
+      sequence,
+      ctrl: false,
+      meta: false,
+      shift: false,
+      paste: false,
+      ...overrides,
+    };
+    for (const handler of activeKeypressHandlers) {
+      handler(event);
+    }
+  };
+
+  const pressLatestKey = (
+    name: string,
+    sequence: string = name,
+    overrides: Partial<Key> = {},
+  ) => {
+    const handler = activeKeypressHandlers.at(-1);
+    if (!handler) {
+      throw new Error(`No active keypress handler for ${name}`);
+    }
+    handler({
       name,
       sequence,
       ctrl: false,
@@ -102,6 +126,139 @@ describe('ProviderSetupSteps', () => {
     } as unknown as ProviderSetupFlow;
   };
 
+  const createModelIdsFlow = ({
+    modelIds = 'MiniMax-M3, MiniMax-M2.7',
+    submitModelIds = vi.fn(),
+  }: {
+    modelIds?: string;
+    submitModelIds?: ReturnType<typeof vi.fn>;
+  } = {}): ProviderSetupFlow => {
+    const noop = vi.fn();
+    return {
+      state: {
+        provider: {
+          id: 'minimax',
+          label: 'MiniMax API Key',
+          description: 'Quick setup for MiniMax models',
+          protocol: AuthType.USE_OPENAI,
+          baseUrl: 'https://api.minimax.io/v1',
+          envKey: 'MINIMAX_API_KEY',
+          models: [
+            {
+              id: 'MiniMax-M3',
+              contextWindowSize: 1000000,
+              modalities: { image: true, video: true },
+            },
+            { id: 'MiniMax-M2.7', contextWindowSize: 204800 },
+            { id: 'MiniMax-M2.5', contextWindowSize: 196608 },
+          ],
+          modelsEditable: true,
+          modelNamePrefix: 'MiniMax',
+        },
+        step: 'models',
+        stepIndex: 0,
+        totalSteps: 1,
+        protocol: AuthType.USE_OPENAI,
+        baseUrl: '',
+        baseUrlPlaceholder: '',
+        baseUrlOptionIndex: 0,
+        baseUrlError: null,
+        apiKey: '',
+        apiKeyError: null,
+        modelIds,
+        modelIdsError: null,
+        thinkingEnabled: false,
+        modalityEnabled: false,
+        modalityImage: true,
+        modalityVideo: true,
+        modalityAudio: true,
+        modalityPdf: false,
+        contextWindowSize: '',
+        focusedConfigIndex: 0,
+        previewJson: '',
+      },
+      start: noop,
+      reset: noop,
+      goBack: noop,
+      selectProtocol: noop,
+      selectBaseUrl: noop,
+      highlightBaseUrl: noop,
+      submitBaseUrl: noop,
+      changeBaseUrl: noop,
+      changeApiKey: noop,
+      submitApiKey: noop,
+      changeModelIds: noop,
+      submitModelIds,
+      moveAdvancedFocusUp: noop,
+      moveAdvancedFocusDown: noop,
+      toggleFocusedAdvancedOption: noop,
+      changeContextWindowSize: noop,
+      submitAdvancedConfig: noop,
+      submit: noop,
+    } as unknown as ProviderSetupFlow;
+  };
+
+  const createCustomModelIdsFlow = ({
+    modelIds = 'model-a, model-b',
+    submitModelIds = vi.fn(),
+  }: {
+    modelIds?: string;
+    submitModelIds?: ReturnType<typeof vi.fn>;
+  } = {}): ProviderSetupFlow => {
+    const noop = vi.fn();
+    return {
+      state: {
+        provider: {
+          id: 'custom-openai-compatible',
+          label: 'Custom Provider',
+          description: 'Manually connect a provider',
+          protocol: AuthType.USE_OPENAI,
+          modelsEditable: true,
+          showAdvancedConfig: true,
+        },
+        step: 'models',
+        stepIndex: 0,
+        totalSteps: 1,
+        protocol: AuthType.USE_OPENAI,
+        baseUrl: '',
+        baseUrlPlaceholder: '',
+        baseUrlOptionIndex: 0,
+        baseUrlError: null,
+        apiKey: '',
+        apiKeyError: null,
+        modelIds,
+        modelIdsError: null,
+        thinkingEnabled: false,
+        modalityEnabled: false,
+        modalityImage: true,
+        modalityVideo: true,
+        modalityAudio: false,
+        modalityPdf: false,
+        contextWindowSize: '',
+        focusedConfigIndex: 0,
+        previewJson: '',
+      },
+      start: noop,
+      reset: noop,
+      goBack: noop,
+      selectProtocol: noop,
+      selectBaseUrl: noop,
+      highlightBaseUrl: noop,
+      submitBaseUrl: noop,
+      changeBaseUrl: noop,
+      changeApiKey: noop,
+      submitApiKey: noop,
+      changeModelIds: noop,
+      submitModelIds,
+      moveAdvancedFocusUp: noop,
+      moveAdvancedFocusDown: noop,
+      toggleFocusedAdvancedOption: noop,
+      changeContextWindowSize: noop,
+      submitAdvancedConfig: noop,
+      submit: noop,
+    } as unknown as ProviderSetupFlow;
+  };
+
   it('maps Ctrl+P/N to advanced-config focus navigation', () => {
     const flow = createAdvancedConfigFlow();
 
@@ -112,6 +269,122 @@ describe('ProviderSetupSteps', () => {
 
     expect(flow.moveAdvancedFocusUp).toHaveBeenCalledTimes(1);
     expect(flow.moveAdvancedFocusDown).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('renders predefined editable models with a primary free-form input and recommendations', () => {
+    const flow = createModelIdsFlow();
+
+    const { lastFrame, unmount } = renderWithProviders(
+      <ProviderSetupSteps flow={flow} />,
+    );
+
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Enter model IDs directly');
+    expect(frame).toContain('Recommended models');
+    expect(frame).toContain(
+      'Checked recommended models are applied on submit but not copied into the input.',
+    );
+    expect(frame).toContain('◉');
+    expect(frame).toContain('○');
+    expect(frame).not.toContain('›');
+    expect(frame).not.toContain('[x]');
+    expect(frame).not.toContain('[ ]');
+    expect(frame).toContain('MiniMax-M3');
+    expect(frame).toContain('1,000,000 tokens');
+    expect(frame).toContain('text/image/video');
+    expect(frame).toContain('204,800 tokens, text');
+    expect(frame).not.toContain('Edit raw / custom model IDs');
+    expect(frame).not.toContain('Tab for custom IDs');
+    expect(frame).toContain('Search');
+    expect(frame).toContain(
+      '↑↓/Tab to switch input, search, and recommendations',
+    );
+    expect(frame).not.toContain('Enter model IDs separated by commas');
+    unmount();
+  });
+
+  it('filters recommended models when typing search while recommendations are focused', async () => {
+    const flow = createModelIdsFlow();
+
+    const { lastFrame, unmount } = renderWithProviders(
+      <ProviderSetupSteps flow={flow} />,
+    );
+
+    await act(async () => {
+      pressLatestKey('down');
+    });
+    await act(async () => {
+      pressLatestKey('M', 'M');
+    });
+    await act(async () => {
+      pressLatestKey('3', '3');
+    });
+
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('> M3');
+    expect(frame).toContain('MiniMax-M3');
+    expect(frame).not.toContain('MiniMax-M2.7');
+    expect(frame).not.toContain('MiniMax-M2.5');
+    unmount();
+  });
+
+  it('keeps recommended selections out of the free-form model input', () => {
+    const flow = createModelIdsFlow({
+      modelIds: 'custom-model, MiniMax-M3, MiniMax-M2.7',
+    });
+
+    const { lastFrame, unmount } = renderWithProviders(
+      <ProviderSetupSteps flow={flow} />,
+    );
+
+    const frame = lastFrame() ?? '';
+    const inputLine = frame
+      .split('\n')
+      .find((line) => line.includes('custom-model'));
+    expect(inputLine).toContain('custom-model');
+    expect(inputLine).not.toContain('MiniMax-M3');
+    expect(inputLine).not.toContain('MiniMax-M2.7');
+    expect(frame).toMatch(/◉\s+MiniMax-M3/);
+    expect(frame).toMatch(/◉\s+MiniMax-M2\.7/);
+    unmount();
+  });
+
+  it('deduplicates typed and recommended model IDs on submit', () => {
+    const submitModelIds = vi.fn();
+    const flow = createModelIdsFlow({
+      modelIds: 'custom-model, MiniMax-M3, MiniMax-M3, MiniMax-M2.7',
+      submitModelIds,
+    });
+
+    const { unmount } = renderWithProviders(<ProviderSetupSteps flow={flow} />);
+
+    pressKey('return', '\r');
+
+    expect(submitModelIds).toHaveBeenCalledWith({
+      modelIds: ['custom-model', 'MiniMax-M3', 'MiniMax-M2.7'],
+    });
+    unmount();
+  });
+
+  it('preserves comma-separated model IDs for custom providers', () => {
+    const submitModelIds = vi.fn();
+    const flow = createCustomModelIdsFlow({
+      modelIds: 'model-a, model-b',
+      submitModelIds,
+    });
+
+    const { lastFrame, unmount } = renderWithProviders(
+      <ProviderSetupSteps flow={flow} />,
+    );
+
+    const frame = lastFrame() ?? '';
+    expect(frame).toContain('Enter model IDs separated by commas');
+    expect(frame).toContain('model-a, model-b');
+
+    pressLatestKey('return', '\r');
+
+    expect(submitModelIds).toHaveBeenCalledTimes(1);
     unmount();
   });
 });

--- a/packages/cli/src/ui/auth/ProviderSetupSteps.tsx
+++ b/packages/cli/src/ui/auth/ProviderSetupSteps.tsx
@@ -5,6 +5,7 @@
  */
 
 import type React from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { Box, Text } from 'ink';
 import Link from 'ink-link';
 import { DescriptiveRadioButtonSelect } from '../components/shared/DescriptiveRadioButtonSelect.js';
@@ -13,8 +14,13 @@ import { theme } from '../semantic-colors.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { t } from '../../i18n/index.js';
 import { AuthType } from '@qwen-code/qwen-code-core';
-import type { ProviderConfig, BaseUrlOption } from '@qwen-code/qwen-code-core';
+import type {
+  ProviderConfig,
+  BaseUrlOption,
+  ModelSpec,
+} from '@qwen-code/qwen-code-core';
 import type { ProviderSetupFlow } from './useProviderSetupFlow.js';
+import { normalizeModelIds } from './useAuth.js';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -175,6 +181,80 @@ function ApiKeyStep({
 // Step: Model IDs input
 // ---------------------------------------------------------------------------
 
+const MODEL_DESCRIPTION_COLUMN = 28;
+const MODALITY_DISPLAY_ORDER = ['image', 'video', 'audio', 'pdf'] as const;
+const MODEL_CUSTOM_INPUT_FOCUS_INDEX = -2;
+const MODEL_SEARCH_INPUT_FOCUS_INDEX = -1;
+const MAX_RECOMMENDED_MODELS_TO_SHOW = 8;
+
+interface ModelOption {
+  key: string;
+  value: string;
+  label: string;
+}
+
+function formatModelOptionLabel(model: ModelSpec): string {
+  const details: string[] = [];
+  if (model.contextWindowSize) {
+    details.push(`${model.contextWindowSize.toLocaleString('en-US')} tokens`);
+  }
+  if (model.enableThinking) {
+    details.push('thinking');
+  }
+  const modalities = MODALITY_DISPLAY_ORDER.filter(
+    (name) => model.modalities?.[name],
+  );
+  details.push(['text', ...modalities].join('/'));
+  const suffix = details.length > 0 ? ` ${details.join(', ')}` : '';
+  return `${model.id.padEnd(MODEL_DESCRIPTION_COLUMN)}${suffix}`;
+}
+
+function modelOptionSearchText(item: ModelOption): string {
+  return `${item.key} ${item.label} ${item.value}`.toLowerCase();
+}
+
+function uniqueModelIds(ids: string[]): string[] {
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const id of ids) {
+    if (seen.has(id)) {
+      continue;
+    }
+    seen.add(id);
+    unique.push(id);
+  }
+  return unique;
+}
+
+function mergeModelIds(
+  customModelIdsText: string,
+  selectedRecommendationKeys: string[],
+): string[] {
+  return uniqueModelIds([
+    ...normalizeModelIds(customModelIdsText),
+    ...selectedRecommendationKeys,
+  ]);
+}
+
+function getRecommendedSelections(
+  selectedModelIds: string[],
+  modelOptions: ModelOption[],
+): string[] {
+  const selectedSet = new Set(selectedModelIds);
+  return modelOptions
+    .filter((item) => selectedSet.has(item.key))
+    .map((item) => item.key);
+}
+
+function getCustomModelIdsText(
+  selectedModelIds: string[],
+  recommendedModelIds: Set<string>,
+): string {
+  return selectedModelIds
+    .filter((id) => !recommendedModelIds.has(id))
+    .join(', ');
+}
+
 function ModelIdsStep({
   config,
   flow,
@@ -183,18 +263,261 @@ function ModelIdsStep({
   flow: ProviderSetupFlow;
 }): React.JSX.Element {
   const defaultIds = config.models?.map((m) => m.id).join(', ') ?? '';
+  const hasSelectableModels = (config.models?.length ?? 0) > 0;
+  const selectedModelIds = useMemo(
+    () => normalizeModelIds(flow.state.modelIds),
+    [flow.state.modelIds],
+  );
+  const modelOptions = useMemo<ModelOption[]>(
+    () =>
+      config.models?.map((model) => ({
+        key: model.id,
+        value: model.id,
+        label: formatModelOptionLabel(model),
+      })) ?? [],
+    [config.models],
+  );
+  const recommendedModelIds = useMemo(
+    () => new Set(modelOptions.map((item) => item.key)),
+    [modelOptions],
+  );
+  const [focusedModelIndex, setFocusedModelIndex] = useState(
+    MODEL_CUSTOM_INPUT_FOCUS_INDEX,
+  );
+  const [customModelIdsText, setCustomModelIdsText] = useState(() =>
+    getCustomModelIdsText(selectedModelIds, recommendedModelIds),
+  );
+  const [selectedRecommendationKeys, setSelectedRecommendationKeys] = useState(
+    () => getRecommendedSelections(selectedModelIds, modelOptions),
+  );
+  const [modelSearchQuery, setModelSearchQuery] = useState('');
+  const filteredModelOptions = useMemo(() => {
+    const normalizedQuery = modelSearchQuery.trim().toLowerCase();
+    if (!normalizedQuery) {
+      return modelOptions;
+    }
+    return modelOptions.filter((item) =>
+      modelOptionSearchText(item).includes(normalizedQuery),
+    );
+  }, [modelOptions, modelSearchQuery]);
+  const recommendedScrollOffset =
+    focusedModelIndex < 0
+      ? 0
+      : Math.max(
+          0,
+          Math.min(
+            focusedModelIndex - MAX_RECOMMENDED_MODELS_TO_SHOW + 1,
+            filteredModelOptions.length - MAX_RECOMMENDED_MODELS_TO_SHOW,
+          ),
+        );
+  const visibleModelOptions = filteredModelOptions.slice(
+    recommendedScrollOffset,
+    recommendedScrollOffset + MAX_RECOMMENDED_MODELS_TO_SHOW,
+  );
+
+  const syncModelIds = useCallback(
+    (customText: string, recommendationKeys: string[]) => {
+      flow.changeModelIds(
+        mergeModelIds(customText, recommendationKeys).join(', '),
+      );
+    },
+    [flow],
+  );
+
+  const handleSubmitModelIds = useCallback(() => {
+    flow.submitModelIds({
+      modelIds: mergeModelIds(customModelIdsText, selectedRecommendationKeys),
+    });
+  }, [customModelIdsText, flow, selectedRecommendationKeys]);
+
+  const handleCustomModelIdsChange = useCallback(
+    (value: string) => {
+      setCustomModelIdsText(value);
+      syncModelIds(value, selectedRecommendationKeys);
+    },
+    [selectedRecommendationKeys, syncModelIds],
+  );
+
+  const toggleRecommendationAtIndex = useCallback(
+    (index: number) => {
+      const item = filteredModelOptions[index];
+      if (!item) {
+        return;
+      }
+
+      const nextSet = new Set(selectedRecommendationKeys);
+      if (nextSet.has(item.key)) {
+        nextSet.delete(item.key);
+      } else {
+        nextSet.add(item.key);
+      }
+      const nextKeys = modelOptions
+        .filter((option) => nextSet.has(option.key))
+        .map((option) => option.key);
+      setSelectedRecommendationKeys(nextKeys);
+      syncModelIds(customModelIdsText, nextKeys);
+    },
+    [
+      customModelIdsText,
+      filteredModelOptions,
+      modelOptions,
+      selectedRecommendationKeys,
+      syncModelIds,
+    ],
+  );
+
+  useKeypress(
+    (key) => {
+      if (focusedModelIndex < 0) {
+        return;
+      }
+
+      if (key.name === 'tab') {
+        setFocusedModelIndex(MODEL_CUSTOM_INPUT_FOCUS_INDEX);
+        return;
+      }
+
+      if (key.name === 'up') {
+        setFocusedModelIndex((index) =>
+          index <= 0 ? MODEL_SEARCH_INPUT_FOCUS_INDEX : index - 1,
+        );
+        return;
+      }
+
+      if (key.name === 'down') {
+        setFocusedModelIndex((index) =>
+          Math.max(0, Math.min(index + 1, filteredModelOptions.length - 1)),
+        );
+        return;
+      }
+
+      if (key.name === 'space' || key.sequence === ' ') {
+        toggleRecommendationAtIndex(focusedModelIndex);
+        return;
+      }
+
+      if (key.name === 'return') {
+        handleSubmitModelIds();
+        return;
+      }
+    },
+    { isActive: hasSelectableModels && focusedModelIndex >= 0 },
+  );
+
+  if (hasSelectableModels) {
+    return (
+      <Box marginTop={1} flexDirection="column">
+        <Box marginTop={1}>
+          <Text color={theme.text.secondary}>
+            {t(
+              'Enter model IDs directly. Use commas to configure multiple models.',
+            )}
+          </Text>
+        </Box>
+        <Box marginTop={1}>
+          <TextInput
+            key="model-ids-input"
+            value={customModelIdsText}
+            onChange={handleCustomModelIdsChange}
+            onSubmit={handleSubmitModelIds}
+            onDown={() => {
+              setFocusedModelIndex(MODEL_SEARCH_INPUT_FOCUS_INDEX);
+            }}
+            onTab={() => {
+              setFocusedModelIndex(MODEL_SEARCH_INPUT_FOCUS_INDEX);
+            }}
+            placeholder="model-id"
+            height={3}
+            isActive={focusedModelIndex === MODEL_CUSTOM_INPUT_FOCUS_INDEX}
+          />
+        </Box>
+        <Box marginTop={0}>
+          <Text color={theme.text.secondary}>
+            {t(
+              'Checked recommended models are applied on submit but not copied into the input.',
+            )}
+          </Text>
+        </Box>
+        <Box marginTop={1}>
+          <Text color={theme.text.secondary}>{t('Recommended models')}</Text>
+        </Box>
+        <Box marginTop={0} flexDirection="column">
+          <Text color={theme.text.secondary}>{t('Search')}</Text>
+          <TextInput
+            key="model-search-input"
+            value={modelSearchQuery}
+            onChange={setModelSearchQuery}
+            onSubmit={handleSubmitModelIds}
+            onUp={() => setFocusedModelIndex(MODEL_CUSTOM_INPUT_FOCUS_INDEX)}
+            onDown={() => {
+              if (filteredModelOptions.length > 0) {
+                setFocusedModelIndex(0);
+              }
+            }}
+            onTab={() => {
+              if (filteredModelOptions.length > 0) {
+                setFocusedModelIndex(0);
+              }
+            }}
+            placeholder="search"
+            isActive={focusedModelIndex === MODEL_SEARCH_INPUT_FOCUS_INDEX}
+          />
+        </Box>
+        <Box marginTop={1} flexDirection="column">
+          {visibleModelOptions.length > 0 ? (
+            visibleModelOptions.map((item, visibleIndex) => {
+              const modelIndex = recommendedScrollOffset + visibleIndex;
+              const isFocused = focusedModelIndex === modelIndex;
+              const isSelected = selectedRecommendationKeys.includes(item.key);
+              const textColor = isFocused
+                ? theme.status.success
+                : isSelected
+                  ? theme.text.accent
+                  : theme.text.primary;
+              return (
+                <Box key={item.key} alignItems="flex-start">
+                  <Box minWidth={4} flexShrink={0}>
+                    <Text color={textColor}>{isSelected ? '◉' : '○'}</Text>
+                  </Box>
+                  <Box flexGrow={1}>
+                    <Text color={textColor}>{item.label}</Text>
+                  </Box>
+                </Box>
+              );
+            })
+          ) : (
+            <Text color={theme.text.secondary}>
+              {t('No recommended models match.')}
+            </Text>
+          )}
+        </Box>
+        {flow.state.modelIdsError && (
+          <Box marginTop={1}>
+            <Text color={theme.status.error}>{flow.state.modelIdsError}</Text>
+          </Box>
+        )}
+        <Box marginTop={1}>
+          <Text color={theme.text.secondary}>
+            {t(
+              'Enter to submit, ↑↓/Tab to switch input, search, and recommendations, Space to toggle recommendations, Esc to go back',
+            )}
+          </Text>
+        </Box>
+      </Box>
+    );
+  }
 
   return (
     <Box marginTop={1} flexDirection="column">
-      {defaultIds && (
-        <Box marginTop={1}>
-          <Text color={theme.text.secondary}>
-            {t('Enter model IDs separated by commas. Examples: {{modelIds}}', {
-              modelIds: defaultIds,
-            })}
-          </Text>
-        </Box>
-      )}
+      <Box marginTop={1}>
+        <Text color={theme.text.secondary}>
+          {defaultIds
+            ? t('Enter model IDs separated by commas. Examples: {{modelIds}}', {
+                modelIds: defaultIds,
+              })
+            : t('Enter model IDs separated by commas.')}
+        </Text>
+      </Box>
       <Box marginTop={1}>
         <TextInput
           key="model-ids-input"

--- a/packages/cli/src/ui/auth/useProviderSetupFlow.ts
+++ b/packages/cli/src/ui/auth/useProviderSetupFlow.ts
@@ -308,16 +308,20 @@ export function useProviderSetupFlow(
     setModelIdsError(null);
   }, []);
 
-  const submitModelIds = useCallback((): boolean => {
-    const normalized = normalizeModelIds(modelIds);
-    if (normalized.length === 0) {
-      setModelIdsError(t('Model IDs cannot be empty.'));
-      return false;
-    }
-    setModelIdsError(null);
-    submitOrNext({ modelIds: normalized });
-    return true;
-  }, [modelIds, submitOrNext]);
+  const submitModelIds = useCallback(
+    (overrides?: Partial<ProviderSetupInputs>): boolean => {
+      const normalized = overrides?.modelIds ?? normalizeModelIds(modelIds);
+      if (normalized.length === 0) {
+        setModelIdsError(t('Model IDs cannot be empty.'));
+        return false;
+      }
+      setModelIds(normalized.join(', '));
+      setModelIdsError(null);
+      submitOrNext({ ...overrides, modelIds: normalized });
+      return true;
+    },
+    [modelIds, submitOrNext],
+  );
 
   const advancedOptionCount = modalityEnabled ? 7 : 3;
 

--- a/packages/cli/src/ui/components/InputPrompt.test.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.test.tsx
@@ -364,20 +364,27 @@ describe('InputPrompt', () => {
     const SUGGESTION_VISIBLE_WAIT_MS = 700;
 
     it('accepts and submits the prompt suggestion on Enter when the buffer is empty', async () => {
+      vi.useFakeTimers();
       const { stdin, unmount } = renderWithProviders(
         <InputPrompt {...props} promptSuggestion="commit this" />,
       );
-      await wait(SUGGESTION_VISIBLE_WAIT_MS);
+      try {
+        await advanceTimers(SUGGESTION_VISIBLE_WAIT_MS);
 
-      stdin.write('\r');
-      await wait();
+        act(() => {
+          stdin.write('\r');
+        });
+        await flush();
 
-      expect(props.onSubmit).toHaveBeenCalledWith('commit this');
-      // Enter path must NOT call buffer.insert — it passes text directly to
-      // handleSubmitAndClear. Calling insert would re-fill the buffer after
-      // it was already cleared (the microtask race bug).
-      expect(mockBuffer.insert).not.toHaveBeenCalled();
-      unmount();
+        expect(props.onSubmit).toHaveBeenCalledWith('commit this');
+        // Enter path must NOT call buffer.insert — it passes text directly to
+        // handleSubmitAndClear. Calling insert would re-fill the buffer after
+        // it was already cleared (the microtask race bug).
+        expect(mockBuffer.insert).not.toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+        unmount();
+      }
     });
 
     it('does not accept the prompt suggestion on shift+tab', async () => {

--- a/packages/cli/src/ui/components/ModelDialog.test.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.test.tsx
@@ -5,6 +5,7 @@
  */
 
 import { render, cleanup } from '@testing-library/react';
+import process from 'node:process';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ModelDialog } from './ModelDialog.js';
 import { useKeypress } from '../hooks/useKeypress.js';
@@ -43,6 +44,7 @@ const mockedSelect = vi.mocked(DescriptiveRadioButtonSelect);
 const renderComponent = (
   props: Partial<React.ComponentProps<typeof ModelDialog>> = {},
   contextValue: Partial<Config> | undefined = undefined,
+  settingsValue: Partial<LoadedSettings> | undefined = undefined,
 ) => {
   const defaultProps = {
     onClose: vi.fn(),
@@ -54,6 +56,7 @@ const renderComponent = (
     user: { settings: {} },
     workspace: { settings: {} },
     setValue: vi.fn(),
+    ...(settingsValue ?? {}),
   } as unknown as LoadedSettings;
 
   const mockConfig = {
@@ -286,6 +289,98 @@ describe('<ModelDialog />', () => {
       AuthType.USE_OPENAI,
     );
     expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows MiniMax-M3 image + video modality and 1M context details', () => {
+    const { getByText } = renderComponent({}, {
+      getModel: vi.fn(() => 'MiniMax-M3'),
+      getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+      getAllConfiguredModels: vi.fn(() => [
+        {
+          id: 'MiniMax-M3',
+          label: '[MiniMax] MiniMax-M3',
+          description: '',
+          authType: AuthType.USE_OPENAI,
+          baseUrl: 'https://api.minimaxi.com/v1',
+          envKey: 'MINIMAX_API_KEY',
+          modalities: { image: true, video: true },
+          contextWindowSize: 1000000,
+        },
+      ]),
+      getModelsConfig: vi.fn(() => ({
+        getGenerationConfig: vi.fn(() => ({
+          baseUrl: 'https://api.minimaxi.com/v1',
+        })),
+      })),
+    } as unknown as Partial<Config>);
+
+    expect(getByText('Modality:')).toBeDefined();
+    expect(getByText('text · image · video')).toBeDefined();
+    expect(getByText('Context Window:')).toBeDefined();
+    expect(getByText('1,000,000 tokens')).toBeDefined();
+  });
+
+  it('hydrates provider API key env from settings.env before switching', async () => {
+    const previousMinimaxKey = process.env['MINIMAX_API_KEY'];
+    delete process.env['MINIMAX_API_KEY'];
+
+    try {
+      const switchModel = vi.fn().mockImplementation(async () => {
+        expect(process.env['MINIMAX_API_KEY']).toBe('sk-minimax-from-settings');
+      });
+
+      renderComponent(
+        {},
+        {
+          getModel: vi.fn(() => 'MiniMax-M2.7'),
+          getAuthType: vi.fn(() => AuthType.USE_OPENAI),
+          switchModel,
+          getAllConfiguredModels: vi.fn(() => [
+            {
+              id: 'MiniMax-M3',
+              label: '[MiniMax] MiniMax-M3',
+              description: '',
+              authType: AuthType.USE_OPENAI,
+              baseUrl: 'https://api.minimaxi.com/v1',
+              envKey: 'MINIMAX_API_KEY',
+              modalities: { image: true, video: true },
+              contextWindowSize: 1000000,
+            },
+          ]),
+          getModelsConfig: vi.fn(() => ({
+            getGenerationConfig: vi.fn(() => ({
+              baseUrl: 'https://api.minimaxi.com/v1',
+            })),
+          })),
+          getContentGeneratorConfig: vi.fn(() => ({
+            authType: AuthType.USE_OPENAI,
+            model: 'MiniMax-M3',
+            apiKey: 'sk-minimax-from-settings',
+            baseUrl: 'https://api.minimaxi.com/v1',
+          })),
+        } as unknown as Partial<Config>,
+        {
+          merged: {
+            env: { MINIMAX_API_KEY: 'sk-minimax-from-settings' },
+          },
+        } as unknown as Partial<LoadedSettings>,
+      );
+
+      const selected = mockedSelect.mock.calls[0][0].items[0].value;
+      await mockedSelect.mock.calls[0][0].onSelect(selected);
+
+      expect(switchModel).toHaveBeenCalledWith(
+        AuthType.USE_OPENAI,
+        'MiniMax-M3',
+        { baseUrl: 'https://api.minimaxi.com/v1' },
+      );
+    } finally {
+      if (previousMinimaxKey === undefined) {
+        delete process.env['MINIMAX_API_KEY'];
+      } else {
+        process.env['MINIMAX_API_KEY'] = previousMinimaxKey;
+      }
+    }
   });
 
   it('stores authType-qualified selectors in fast model mode', async () => {

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -5,6 +5,7 @@
  */
 
 import type React from 'react';
+import process from 'node:process';
 import { useCallback, useContext, useMemo, useState } from 'react';
 import { Box, Text } from 'ink';
 import {
@@ -105,6 +106,24 @@ function persistAuthTypeSelection(
 ): void {
   const scope = getPersistScopeForModelSelection(settings);
   settings.setValue(scope, 'security.auth.selectedType', authType);
+}
+
+function hydrateApiKeyEnvFromSettings(
+  settings: ReturnType<typeof useSettings>,
+  envKey: string | undefined,
+): void {
+  if (!envKey || process.env[envKey]) {
+    return;
+  }
+  const settingsEnvValue = (
+    settings?.merged?.env as Record<string, unknown> | undefined
+  )?.[envKey];
+  if (
+    typeof settingsEnvValue === 'string' &&
+    settingsEnvValue.trim().length > 0
+  ) {
+    process.env[envKey] = settingsEnvValue;
+  }
 }
 
 interface HandleModelSwitchSuccessParams {
@@ -390,6 +409,16 @@ export function ModelDialog({
   const handleSelect = useCallback(
     async (selected: string) => {
       setErrorMessage(null);
+      const selectedEntry = availableModelEntries.find(
+        ({ authType: t2, model, isRuntime, snapshotId }) => {
+          const value =
+            isRuntime && snapshotId
+              ? snapshotId
+              : buildModelSelectionKey(t2, model.id, model.baseUrl);
+          return value === selected;
+        },
+      );
+      hydrateApiKeyEnvFromSettings(settings, selectedEntry?.model.envKey);
 
       // Fast model mode: save authType:modelId so duplicate model ids across
       // providers remain unambiguous. baseUrl is intentionally discarded.
@@ -520,6 +549,7 @@ export function ModelDialog({
       uiState,
       setErrorMessage,
       isFastModelMode,
+      availableModelEntries,
     ],
   );
 

--- a/packages/cli/src/ui/components/shared/MultiSelect.tsx
+++ b/packages/cli/src/ui/components/shared/MultiSelect.tsx
@@ -30,6 +30,7 @@ export interface MultiSelectProps<T> {
   showScrollArrows?: boolean;
   maxItemsToShow?: number;
   checkedText?: string;
+  uncheckedText?: string;
   showActiveMarker?: boolean;
 }
 
@@ -57,6 +58,7 @@ export function MultiSelect<T>({
   showScrollArrows = false,
   maxItemsToShow = 10,
   checkedText = '[✓]',
+  uncheckedText = '[ ]',
   showActiveMarker = false,
 }: MultiSelectProps<T>): React.JSX.Element {
   const [scrollOffset, setScrollOffset] = useState(0);
@@ -139,7 +141,7 @@ export function MultiSelect<T>({
 
       {visibleItems.map((item, index) => {
         const itemIndex = scrollOffset + index;
-        const isActive = activeIndex === itemIndex;
+        const isActive = isFocused && activeIndex === itemIndex;
         const isChecked = selectedKeySet.has(item.key);
         const activeMarker = isActive ? '›' : ' ';
 
@@ -150,7 +152,7 @@ export function MultiSelect<T>({
           ? '[x]'
           : isChecked
             ? checkedText
-            : '[ ]';
+            : uncheckedText;
 
         let textColor = theme.text.primary;
         if (item.disabled) {

--- a/packages/cli/src/ui/components/shared/TextInput.tsx
+++ b/packages/cli/src/ui/components/shared/TextInput.tsx
@@ -15,7 +15,7 @@ import { cpSlice, cpLen } from '../../utils/textUtils.js';
 import { theme } from '../../semantic-colors.js';
 import { Colors } from '../../colors.js';
 import type { Key } from '../../hooks/useKeypress.js';
-import { useCallback, useRef, useEffect } from 'react';
+import { useCallback, useRef, useEffect, useState } from 'react';
 
 export interface TextInputProps {
   value: string;
@@ -66,6 +66,7 @@ export function TextInput({
   ellipsizeOverflow = false,
 }: TextInputProps) {
   const allowMultiline = height > 1;
+  const [cursorVisible, setCursorVisible] = useState(isActive);
 
   // Stabilize onChange to avoid triggering useTextBuffer's onChange effect every render
   const onChangeRef = useRef(onChange);
@@ -89,6 +90,19 @@ export function TextInput({
     onChange: stableOnChange,
     preferredEditor,
   });
+
+  useEffect(() => {
+    if (!isActive) {
+      setCursorVisible(false);
+      return;
+    }
+
+    setCursorVisible(true);
+    const interval = setInterval(() => {
+      setCursorVisible((visible) => !visible);
+    }, 530);
+    return () => clearInterval(interval);
+  }, [isActive]);
 
   const handleSubmit = () => {
     if (!onSubmit) return;
@@ -173,6 +187,7 @@ export function TextInput({
   const [cursorVisualRowAbsolute, cursorVisualColAbsolute] =
     buffer.visualCursor;
   const scrollVisualRow = buffer.visualScrollRow;
+  const shouldRenderCursor = isActive && cursorVisible;
 
   return (
     <Box flexDirection="column" gap={1}>
@@ -180,10 +195,14 @@ export function TextInput({
         <Text color={theme.text.accent}>{'> '}</Text>
         <Box flexGrow={1} flexDirection="column">
           {buffer.text.length === 0 && placeholder ? (
-            <Text>
-              {chalk.inverse(placeholder.slice(0, 1))}
-              <Text color={Colors.Gray}>{placeholder.slice(1)}</Text>
-            </Text>
+            shouldRenderCursor ? (
+              <Text>
+                {chalk.inverse(placeholder.slice(0, 1))}
+                <Text color={Colors.Gray}>{placeholder.slice(1)}</Text>
+              </Text>
+            ) : (
+              <Text color={Colors.Gray}>{placeholder}</Text>
+            )
           ) : ellipsizeOverflow && stringWidth(buffer.text) > inputWidth ? (
             <Text>{ellipsizeMiddle(buffer.text, inputWidth)}</Text>
           ) : (
@@ -195,7 +214,10 @@ export function TextInput({
                 display = display + ' '.repeat(inputWidth - currentVisualWidth);
               }
 
-              if (visualIdxInRenderedSet === cursorVisualRow) {
+              if (
+                shouldRenderCursor &&
+                visualIdxInRenderedSet === cursorVisualRow
+              ) {
                 const relativeVisualColForHighlight = cursorVisualColAbsolute;
                 if (relativeVisualColForHighlight >= 0) {
                   if (relativeVisualColForHighlight < cpLen(display)) {

--- a/packages/core/src/core/modalityDefaults.test.ts
+++ b/packages/core/src/core/modalityDefaults.test.ts
@@ -179,6 +179,14 @@ describe('defaultModalities', () => {
   });
 
   describe('MiniMax', () => {
+    it('returns image + video for MiniMax-M3', () => {
+      const m = defaultModalities('MiniMax-M3');
+      expect(m.image).toBe(true);
+      expect(m.video).toBe(true);
+      expect(m.pdf).toBeUndefined();
+      expect(m.audio).toBeUndefined();
+    });
+
     it('returns text-only for MiniMax-M2.5', () => {
       expect(defaultModalities('MiniMax-M2.5')).toEqual({});
     });

--- a/packages/core/src/core/modalityDefaults.ts
+++ b/packages/core/src/core/modalityDefaults.ts
@@ -68,8 +68,9 @@ const MODALITY_PATTERNS: Array<[RegExp, InputModalities]> = [
   [/^glm-/, {}],
 
   // -------------------
-  // MiniMax — text-only
+  // MiniMax — M3 supports image + video input; older models default to text-only
   // -------------------
+  [/^minimax-m3/i, { image: true, video: true }],
   [/^minimax-/, {}],
 
   // -------------------

--- a/packages/core/src/core/tokenLimits.test.ts
+++ b/packages/core/src/core/tokenLimits.test.ts
@@ -198,6 +198,10 @@ describe('tokenLimit', () => {
   });
 
   describe('MiniMax', () => {
+    it('should return 1M for MiniMax-M3', () => {
+      expect(tokenLimit('MiniMax-M3')).toBe(1000000);
+    });
+
     it('should return 196608 for MiniMax-M2.5 (latest)', () => {
       expect(tokenLimit('MiniMax-M2.5')).toBe(196608);
     });

--- a/packages/core/src/core/tokenLimits.ts
+++ b/packages/core/src/core/tokenLimits.ts
@@ -138,6 +138,7 @@ const PATTERNS: Array<[RegExp, TokenCount]> = [
   // -------------------
   // MiniMax
   // -------------------
+  [/^minimax-m3/i, LIMITS['1m']], // MiniMax-M3: 1,000,000
   [/^minimax-m2\.5/i, LIMITS['192k']], // MiniMax-M2.5: 196,608
   [/^minimax-/i, LIMITS['200k']], // MiniMax fallback: 200K
 

--- a/packages/core/src/models/modelRegistry.test.ts
+++ b/packages/core/src/models/modelRegistry.test.ts
@@ -219,6 +219,56 @@ describe('ModelRegistry', () => {
       const model = registry.getModel(AuthType.USE_OPENAI, 'qwen3-coder-plus');
       expect(model?.generationConfig.modalities).toEqual({});
     });
+
+    it('populates MiniMax-M3 metadata when provider entries omit generationConfig', () => {
+      const registry = new ModelRegistry({
+        openai: [
+          {
+            id: 'MiniMax-M3',
+            name: '[MiniMax] MiniMax-M3',
+            baseUrl: 'https://api.minimaxi.com/v1',
+            envKey: 'MINIMAX_API_KEY',
+          },
+        ],
+      });
+
+      const model = registry.getModel(AuthType.USE_OPENAI, 'MiniMax-M3');
+      expect(model?.generationConfig.modalities).toEqual({
+        image: true,
+        video: true,
+      });
+
+      const available = registry
+        .getModelsForAuthType(AuthType.USE_OPENAI)
+        .find((m) => m.id === 'MiniMax-M3');
+      expect(available?.contextWindowSize).toBe(1000000);
+      expect(available?.modalities).toEqual({
+        image: true,
+        video: true,
+      });
+    });
+
+    it('normalizes stale MiniMax-M3 provider modalities to image + video', () => {
+      const registry = new ModelRegistry({
+        openai: [
+          {
+            id: 'MiniMax-M3',
+            name: '[MiniMax] MiniMax-M3',
+            baseUrl: 'https://api.minimaxi.com/v1',
+            envKey: 'MINIMAX_API_KEY',
+            generationConfig: {
+              modalities: { image: true },
+            },
+          },
+        ],
+      });
+
+      const model = registry.getModel(AuthType.USE_OPENAI, 'MiniMax-M3');
+      expect(model?.generationConfig.modalities).toEqual({
+        image: true,
+        video: true,
+      });
+    });
   });
 
   describe('hasModel', () => {

--- a/packages/core/src/models/modelRegistry.ts
+++ b/packages/core/src/models/modelRegistry.ts
@@ -37,6 +37,10 @@ function validateAuthTypeKey(key: string): AuthType | undefined {
   return undefined;
 }
 
+function shouldUseCanonicalModalities(modelId: string): boolean {
+  return /^minimax-m3/i.test(modelId.trim().toLowerCase());
+}
+
 /**
  * Build a composite registry key from model id and optional baseUrl.
  * Two models with the same id but different baseUrls are distinct entries.
@@ -212,7 +216,10 @@ export class ModelRegistry {
     // them explicitly. Without this, downstream consumers that read straight
     // from the registry (e.g. sub-agents via getResolvedModel) would inherit
     // the parent session's modalities instead of the agent's own.
-    if (generationConfig.modalities === undefined) {
+    if (
+      generationConfig.modalities === undefined ||
+      shouldUseCanonicalModalities(config.id)
+    ) {
       generationConfig.modalities = defaultModalities(config.id);
     }
 

--- a/packages/core/src/models/modelsConfig.test.ts
+++ b/packages/core/src/models/modelsConfig.test.ts
@@ -154,7 +154,7 @@ describe('ModelsConfig', () => {
     expect(modelsConfig.getGenerationConfigSources()).toEqual(baselineSources);
   });
 
-  it('should require provider-sourced apiKey when switching models even if envKey is missing', async () => {
+  it('should preserve an existing apiKey when switching between models with the same provider credentials', async () => {
     const modelProvidersConfig: ModelProvidersConfig = {
       openai: [
         {
@@ -187,8 +187,47 @@ describe('ModelsConfig', () => {
 
     const gc = currentGenerationConfig(modelsConfig);
     expect(gc.model).toBe('model-b');
-    expect(gc.apiKey).toBeUndefined();
+    expect(gc.apiKey).toBe('manual-key');
     expect(gc.apiKeyEnvKey).toBe('API_KEY_SHARED');
+    expect(modelsConfig.getGenerationConfigSources()['apiKey']?.kind).toBe(
+      'programmatic',
+    );
+  });
+
+  it('should not reuse an apiKey when switching to a model with different provider credentials', async () => {
+    const modelProvidersConfig: ModelProvidersConfig = {
+      openai: [
+        {
+          id: 'model-a',
+          name: 'Model A',
+          baseUrl: 'https://api-a.example.com/v1',
+          envKey: 'API_KEY_A',
+        },
+        {
+          id: 'model-b',
+          name: 'Model B',
+          baseUrl: 'https://api-b.example.com/v1',
+          envKey: 'API_KEY_B',
+        },
+      ],
+    };
+
+    const modelsConfig = new ModelsConfig({
+      initialAuthType: AuthType.USE_OPENAI,
+      modelProvidersConfig,
+      generationConfig: {
+        model: 'model-a',
+      },
+    });
+
+    modelsConfig.updateCredentials({ apiKey: 'manual-key', model: 'model-a' });
+
+    await modelsConfig.switchModel(AuthType.USE_OPENAI, 'model-b');
+
+    const gc = currentGenerationConfig(modelsConfig);
+    expect(gc.model).toBe('model-b');
+    expect(gc.apiKey).toBeUndefined();
+    expect(gc.apiKeyEnvKey).toBe('API_KEY_B');
   });
 
   it('should use provider config when modelId exists in registry even after updateCredentials', () => {

--- a/packages/core/src/models/modelsConfig.ts
+++ b/packages/core/src/models/modelsConfig.ts
@@ -450,17 +450,45 @@ export class ModelsConfig {
         );
       }
 
+      const previousModelId = rollbackSnapshot.generationConfig.model || '';
+      const previousModel =
+        !isAuthTypeChange && previousModelId
+          ? (this.modelRegistry.getModel(
+              authType,
+              previousModelId,
+              rollbackSnapshot.generationConfig.baseUrl,
+            ) ?? this.modelRegistry.getModel(authType, previousModelId))
+          : undefined;
+      const canReusePreviousApiKey =
+        authType !== AuthType.QWEN_OAUTH &&
+        !isAuthTypeChange &&
+        !!rollbackSnapshot.generationConfig.apiKey &&
+        !!model.envKey &&
+        previousModel?.envKey === model.envKey &&
+        previousModel.baseUrl === model.baseUrl;
+      const previousApiKey = canReusePreviousApiKey
+        ? rollbackSnapshot.generationConfig.apiKey
+        : undefined;
+      const previousApiKeySource = canReusePreviousApiKey
+        ? rollbackSnapshot.generationConfigSources['apiKey']
+        : undefined;
+
       // Apply model defaults
       this.applyResolvedModelDefaults(model);
+      if (!this._generationConfig.apiKey && previousApiKey) {
+        this._generationConfig.apiKey = previousApiKey;
+        if (previousApiKeySource) {
+          this.generationConfigSources['apiKey'] =
+            ModelsConfig.deepClone(previousApiKeySource);
+        }
+      }
 
       // Clear active runtime model snapshot since we're now using a registry model
       this.activeRuntimeModelSnapshotId = undefined;
 
       const requiresRefresh = isAuthTypeChange
         ? true
-        : this.checkRequiresRefresh(
-            rollbackSnapshot.generationConfig.model || '',
-          );
+        : this.checkRequiresRefresh(previousModelId);
 
       if (this.onModelChange) {
         await this.onModelChange(authType, requiresRefresh);

--- a/packages/core/src/providers/__tests__/presets/minimax.test.ts
+++ b/packages/core/src/providers/__tests__/presets/minimax.test.ts
@@ -28,6 +28,14 @@ describe('minimaxProvider', () => {
     expect(urls).toContain('https://api.minimaxi.com/v1');
   });
 
+  it('includes MiniMax-M3 with official model metadata', () => {
+    expect(minimaxProvider.models?.[0]).toMatchObject({
+      id: 'MiniMax-M3',
+      contextWindowSize: 1000000,
+      modalities: { image: true, video: true },
+    });
+  });
+
   it('creates an install plan with per-model metadata for known IDs', () => {
     const plan = buildInstallPlan(minimaxProvider, {
       baseUrl: 'https://api.minimaxi.com/v1',

--- a/packages/core/src/providers/__tests__/provider-config.test.ts
+++ b/packages/core/src/providers/__tests__/provider-config.test.ts
@@ -74,6 +74,32 @@ describe('buildInstallPlan', () => {
     expect(models?.[1]?.generationConfig).toBeUndefined();
   });
 
+  it('applies advancedConfig to editable unknown model IDs only', () => {
+    const config = makeConfig({ modelsEditable: true });
+    const plan = buildInstallPlan(config, {
+      baseUrl: 'https://api.test.com/v1',
+      apiKey: 'sk-test',
+      modelIds: ['model-a', 'unknown-model'],
+      advancedConfig: {
+        contextWindowSize: 1000000,
+        multimodal: { image: true, video: true },
+      },
+    });
+
+    const models = plan.modelProviders?.[0]?.models;
+    expect(models?.[0]?.generationConfig).toMatchObject({
+      contextWindowSize: 8192,
+    });
+    expect(models?.[1]).toMatchObject({
+      id: 'unknown-model',
+      name: '[Test] unknown-model',
+      generationConfig: {
+        contextWindowSize: 1000000,
+        modalities: { image: true, video: true },
+      },
+    });
+  });
+
   it('builds a plan with no predefined models (custom provider path)', () => {
     const config = makeConfig({
       models: undefined,

--- a/packages/core/src/providers/presets/minimax.ts
+++ b/packages/core/src/providers/presets/minimax.ts
@@ -28,6 +28,11 @@ export const minimaxProvider: ProviderConfig = {
   ],
   envKey: 'MINIMAX_API_KEY',
   models: [
+    {
+      id: 'MiniMax-M3',
+      contextWindowSize: 1000000,
+      modalities: { image: true, video: true },
+    },
     { id: 'MiniMax-M2.7', contextWindowSize: 204800 },
     { id: 'MiniMax-M2.7-highspeed', contextWindowSize: 204800 },
     { id: 'MiniMax-M2.5', contextWindowSize: 196608 },

--- a/packages/core/src/providers/provider-config.ts
+++ b/packages/core/src/providers/provider-config.ts
@@ -78,6 +78,30 @@ function buildGenerationConfig(
   return hasAny ? parts : undefined;
 }
 
+function buildAdvancedGenerationConfig(
+  advCfg: ProviderSetupInputs['advancedConfig'] | undefined,
+): ProviderModelConfig['generationConfig'] | undefined {
+  const cfg: ProviderModelConfig['generationConfig'] = {};
+  let hasAny = false;
+  if (advCfg?.enableThinking) {
+    cfg.extra_body = { enable_thinking: true };
+    hasAny = true;
+  }
+  if (advCfg?.multimodal && Object.values(advCfg.multimodal).some(Boolean)) {
+    cfg.modalities = advCfg.multimodal;
+    hasAny = true;
+  }
+  if (advCfg?.contextWindowSize && advCfg.contextWindowSize > 0) {
+    cfg.contextWindowSize = advCfg.contextWindowSize;
+    hasAny = true;
+  }
+  if (advCfg?.maxTokens && advCfg.maxTokens > 0) {
+    cfg.samplingParams = { max_tokens: advCfg.maxTokens };
+    hasAny = true;
+  }
+  return hasAny ? cfg : undefined;
+}
+
 function specToModelConfig(
   spec: ModelSpec,
   prefix: string,
@@ -117,11 +141,13 @@ function buildModelConfigs(
       if (spec) {
         return specToModelConfig(spec, prefix, inputs.baseUrl, envKey);
       }
+      const genConfig = buildAdvancedGenerationConfig(inputs.advancedConfig);
       return {
         id,
         name: prefix ? `[${prefix}] ${id}` : id,
         baseUrl: inputs.baseUrl,
         envKey,
+        ...(genConfig ? { generationConfig: genConfig } : {}),
       };
     });
   }
@@ -129,34 +155,10 @@ function buildModelConfigs(
   // No predefined models (custom provider) — use advancedConfig
   const advCfg = inputs.advancedConfig;
 
-  function buildCustomGenConfig():
-    | ProviderModelConfig['generationConfig']
-    | undefined {
-    const cfg: ProviderModelConfig['generationConfig'] = {};
-    let hasAny = false;
-    if (advCfg?.enableThinking) {
-      cfg.extra_body = { enable_thinking: true };
-      hasAny = true;
-    }
-    if (advCfg?.multimodal && Object.values(advCfg.multimodal).some(Boolean)) {
-      cfg.modalities = advCfg.multimodal;
-      hasAny = true;
-    }
-    if (advCfg?.contextWindowSize && advCfg.contextWindowSize > 0) {
-      cfg.contextWindowSize = advCfg.contextWindowSize;
-      hasAny = true;
-    }
-    if (advCfg?.maxTokens && advCfg.maxTokens > 0) {
-      cfg.samplingParams = { max_tokens: advCfg.maxTokens };
-      hasAny = true;
-    }
-    return hasAny ? cfg : undefined;
-  }
-
   const displayName = (id: string) => (prefix ? `[${prefix}] ${id}` : id);
 
   return inputs.modelIds.map((id) => {
-    const genConfig = buildCustomGenConfig();
+    const genConfig = buildAdvancedGenerationConfig(advCfg);
     return {
       id,
       name: displayName(id),


### PR DESCRIPTION
## What this PR does

This PR improves third-party provider setup by pairing free-form model ID entry with a searchable recommended-model selector, so users can pick known models while still entering custom IDs when needed.

It adds MiniMax-M3 as an official MiniMax option with its model metadata, keeps Custom Provider multi-model entry separate from built-in provider recommendations, and preserves saved credentials when switching between compatible third-party models.

## Why it's needed

MiniMax setup previously required users to type comma-separated model IDs manually, which made the flow easy to mistype and kept MiniMax-M3 undiscoverable during setup.

The updated flow makes common MiniMax models easier to find and enable, keeps advanced manual IDs available, and reduces false missing-credential friction after model switches.

## Reviewer Test Plan

### How to verify

Open the CLI provider setup flow, choose MiniMax API Key, select a region, enter an API key, and confirm the Model IDs step shows a direct custom model ID input plus a searchable recommended-model list including MiniMax-M3.

Search the recommended list, toggle multiple recommended models, enter an additional custom model ID, submit, and confirm the resulting provider configuration includes both the selected recommendations and the custom ID without duplicating entries.

Verify Custom Provider setup still uses the plain comma-separated multi-model input path, rather than the built-in provider recommended-model selector.

Switch between configured MiniMax models from the model dialog with the API key saved in settings env, and confirm the switch succeeds without asking for the same credential again.

The current branch records these local checks: `cd packages/cli && npx vitest run src/config/auth.test.ts src/ui/auth/ProviderSetupSteps.test.tsx src/ui/components/ModelDialog.test.tsx src/ui/components/shared/TextInput.test.tsx`; `cd packages/core && npx vitest run src/core/modalityDefaults.test.ts src/core/tokenLimits.test.ts src/models/modelRegistry.test.ts src/models/modelsConfig.test.ts src/providers/__tests__/presets/minimax.test.ts src/providers/__tests__/provider-config.test.ts`; `git diff --check`; `npm run lint`; `npm run typecheck`; `npm run build`.

### Evidence (Before & After)

Before: MiniMax setup only offered comma-separated manual model ID entry, did not list MiniMax-M3 as a recommended option, and made users know exact model IDs before setup.

After: MiniMax setup offers a custom ID input plus a searchable recommended-model selector with MiniMax-M3, supports multiple selected model IDs, keeps custom IDs available, and preserves compatible saved credentials during model switches.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Windows PowerShell; targeted Vitest suites in `packages/cli` and `packages/core`; root lint, typecheck, and build checks.

## Risk & Scope

- Main risk or tradeoff: The provider setup UI now has more state to keep custom IDs, search text, and recommended selections synchronized.
- Not validated / out of scope: Full macOS and Linux verification were not run locally; the full Windows package suite was not run due existing symlink permission / unrelated failures noted in review; VS Code auth-flow behavior is intentionally out of scope.
- Breaking changes / migration notes: None expected. Existing manual model ID entry remains supported, and Custom Provider multi-model setup keeps its existing comma-separated input path.

## Linked Issues

Fixes #4663

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 改进了第三方 provider 的设置流程，把自由输入模型 ID 和可搜索的推荐模型选择器结合起来，因此用户既可以选择已知模型，也可以在需要时输入自定义 ID。

它将 MiniMax-M3 添加为官方 MiniMax 选项并附带模型元数据，让 Custom Provider 的多模型输入继续与内置 provider 的推荐模型选择保持分离，并在兼容的第三方模型之间切换时保留已保存的凭据。

## Why it's needed

此前 MiniMax 设置要求用户手动输入以逗号分隔的模型 ID，这让流程容易输错，也让 MiniMax-M3 在设置过程中不可发现。

更新后的流程让常用 MiniMax 模型更容易找到和启用，同时保留高级用户需要的手动 ID，并减少模型切换后误报缺少凭据的摩擦。

## Reviewer Test Plan

### How to verify

打开 CLI provider 设置流程，选择 MiniMax API Key，选择区域，输入 API key，并确认 Model IDs 步骤显示一个直接输入自定义模型 ID 的输入框，以及一个包含 MiniMax-M3 的可搜索推荐模型列表。

搜索推荐列表，切换多个推荐模型，输入一个额外的自定义模型 ID，提交，并确认生成的 provider 配置同时包含选中的推荐模型和自定义 ID，且没有重复项。

确认 Custom Provider 设置仍然使用普通的逗号分隔多模型输入路径，而不是内置 provider 的推荐模型选择器。

在 API key 已保存到 settings env 的情况下，从模型对话框在已配置的 MiniMax 模型之间切换，并确认切换成功且不会再次要求输入同一凭据。

当前分支记录了这些本地检查：`cd packages/cli && npx vitest run src/config/auth.test.ts src/ui/auth/ProviderSetupSteps.test.tsx src/ui/components/ModelDialog.test.tsx src/ui/components/shared/TextInput.test.tsx`；`cd packages/core && npx vitest run src/core/modalityDefaults.test.ts src/core/tokenLimits.test.ts src/models/modelRegistry.test.ts src/models/modelsConfig.test.ts src/providers/__tests__/presets/minimax.test.ts src/providers/__tests__/provider-config.test.ts`；`git diff --check`；`npm run lint`；`npm run typecheck`；`npm run build`。

### Evidence (Before & After)

Before：MiniMax 设置只提供逗号分隔的手动模型 ID 输入，没有把 MiniMax-M3 列为推荐选项，并且要求用户在设置前知道准确的模型 ID。

After：MiniMax 设置提供自定义 ID 输入框，以及包含 MiniMax-M3 的可搜索推荐模型选择器，支持选择多个模型 ID，保留自定义 ID 能力，并在模型切换期间保留兼容的已保存凭据。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ 未测试 |
| 🪟 Windows | ✅ 已测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### Environment (optional)

Windows PowerShell；`packages/cli` 和 `packages/core` 中的定向 Vitest 套件；根目录 lint、typecheck 和 build 检查。

## Risk & Scope

- Main risk or tradeoff：provider 设置 UI 现在需要同步更多状态，包括自定义 ID、搜索文本和推荐模型选择。
- Not validated / out of scope：本地未运行完整 macOS 和 Linux 验证；由于 review 中提到的现有符号链接权限 / 无关失败，本地未运行完整 Windows package 套件；VS Code auth-flow 行为有意不在范围内。
- Breaking changes / migration notes：预计没有破坏性变更。现有手动模型 ID 输入仍然受支持，Custom Provider 多模型设置继续保留现有的逗号分隔输入路径。

## Linked Issues

修复 #4663。