### PR TITLE
fix(cli): honor list extensions flag

### DIFF
--- a/packages/cli/src/gemini.test.tsx
+++ b/packages/cli/src/gemini.test.tsx
@@ -27,6 +27,7 @@ import type { Config } from '@qwen-code/qwen-code-core';
 import { ApprovalMode, OutputFormat } from '@qwen-code/qwen-code-core';
 
 const mockWriteStderrLine = vi.hoisted(() => vi.fn());
+const mockHandleListExtensions = vi.hoisted(() => vi.fn());
 
 // Custom error to identify mock process.exit calls
 class MockProcessExitError extends Error {
@@ -108,6 +109,10 @@ vi.mock('./core/initializer.js', () => ({
     shouldOpenAuthDialog: false,
     geminiMdFileCount: 0,
   }),
+}));
+
+vi.mock('./commands/extensions/list.js', () => ({
+  handleList: mockHandleListExtensions,
 }));
 
 describe('gemini.tsx main function', () => {
@@ -226,6 +231,52 @@ describe('gemini.tsx main function', () => {
     // For the sandbox case we still have to load a partial cli config.
     // we can authorize outside the sandbox.
     expect(callOrder).toEqual(['relaunch', 'loadCliConfig']);
+    processExitSpy.mockRestore();
+  });
+
+  it('handles --list-extensions before sandbox and app config startup', async () => {
+    vi.clearAllMocks();
+    const processExitSpy = vi
+      .spyOn(process, 'exit')
+      .mockImplementation((code) => {
+        throw new MockProcessExitError(code);
+      });
+
+    const { loadCliConfig, parseArguments } = await import(
+      './config/config.js'
+    );
+    const { loadSettings } = await import('./config/settings.js');
+    const { loadSandboxConfig } = await import('./config/sandboxConfig.js');
+
+    vi.mocked(parseArguments).mockResolvedValue({
+      listExtensions: true,
+    } as unknown as CliArgs);
+    vi.mocked(loadSettings).mockReturnValue({
+      errors: [],
+      merged: {
+        advanced: {},
+        security: { auth: {} },
+        ui: {},
+      },
+      setValue: vi.fn(),
+      forScope: () => ({ settings: {}, originalSettings: {}, path: '' }),
+      migrationWarnings: [],
+      getUserHooks: () => undefined,
+      getProjectHooks: () => undefined,
+    } as never);
+    mockHandleListExtensions.mockResolvedValue(undefined);
+
+    try {
+      await main();
+    } catch (e) {
+      if (!(e instanceof MockProcessExitError)) throw e;
+    }
+
+    expect(mockHandleListExtensions).toHaveBeenCalledOnce();
+    expect(processExitSpy).toHaveBeenCalledWith(0);
+    expect(loadSandboxConfig).not.toHaveBeenCalled();
+    expect(loadCliConfig).not.toHaveBeenCalled();
+
     processExitSpy.mockRestore();
   });
 

--- a/packages/cli/src/gemini.tsx
+++ b/packages/cli/src/gemini.tsx
@@ -40,6 +40,7 @@ import {
   initializeApp,
   type InitializationResult,
 } from './core/initializer.js';
+import { handleList as handleListExtensions } from './commands/extensions/list.js';
 import { runNonInteractive } from './nonInteractiveCli.js';
 import {
   setupStartupWorktree,
@@ -466,6 +467,11 @@ export async function main() {
     );
   }
 
+  if (argv.listExtensions) {
+    await handleListExtensions();
+    process.exit(0);
+  }
+
   // Check for invalid input combinations early to prevent crashes
   if (argv.promptInteractive && !process.stdin.isTTY) {
     writeStderrLine(
@@ -840,15 +846,6 @@ export async function main() {
         `Preconnect skipped due to error getting authType: ${error}`,
       );
     }
-
-    // FIXME: list extensions after the config initialize
-    // if (config.getListExtensions()) {
-    //   console.log('Installed extensions:');
-    //   for (const extension of extensions) {
-    //     console.log(`- ${extension.config.name}`);
-    //   }
-    //   process.exit(0);
-    // }
 
     const wasRaw = process.stdin.isRaw;
     let kittyProtocolDetectionComplete: Promise<boolean> | undefined;


### PR DESCRIPTION
﻿## What this PR does

Wires the top-level `qwen --list-extensions` / `qwen -l` flag to the existing extension list command and exits before the normal sandbox/auth/TUI startup path runs.

## Why it's needed

The flag is advertised in `qwen --help`, but it currently falls through into the interactive CLI. This restores the documented non-interactive behavior and reuses the same listing code as `qwen extensions list`.

## Reviewer Test Plan

### How to verify

Run `qwen --list-extensions` or `qwen -l` with at least one installed extension. The command should print the extension list and exit instead of opening the interactive prompt.

### Evidence (Before & After)

Before: `qwen --list-extensions` ignored the flag and launched the regular interactive prompt. After: the main startup path calls the extension list handler and exits before sandbox setup or app config startup. Regression coverage is in `packages/cli/src/gemini.test.tsx`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS  | N/A |
| Windows | tested |
|  Linux  | N/A |

### Environment (optional)

Windows, Node v24.15.0, npm 11.12.1.

Commands run:

```bash
npm exec -- vitest run packages/cli/src/gemini.test.tsx -t "list-extensions"
npm exec -- vitest run packages/cli/src/gemini.test.tsx packages/cli/src/commands/extensions/list.test.ts
npm exec -- eslint packages/cli/src/gemini.tsx packages/cli/src/gemini.test.tsx
npm run typecheck --workspace=packages/cli
git diff --check -- packages/cli/src/gemini.tsx packages/cli/src/gemini.test.tsx
```

## Risk & Scope

- Main risk or tradeoff: The flag now exits before sandbox setup, auth setup, and TUI rendering; that is the intended behavior for a local listing command.
- Not validated / out of scope: Full package build in this local checkout is blocked by existing `packages/core/dist` declaration files being treated as TypeScript inputs (`TS5055: Cannot write file ... because it would overwrite input file`).
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #4450

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

把顶层 `qwen --list-extensions` / `qwen -l` 参数接到已有的扩展列表命令，并在进入常规 sandbox、auth、TUI 启动路径前退出。

## 为什么需要

`qwen --help` 已经声明了这个参数，但当前实现会忽略它并继续进入交互式 CLI。这个改动恢复文档中的非交互行为，并复用 `qwen extensions list` 的列表输出逻辑。

## Reviewer Test Plan

### 如何验证

安装至少一个 extension 后运行 `qwen --list-extensions` 或 `qwen -l`。命令应打印扩展列表并退出，而不是打开交互式 prompt。

### Before / After 证据

Before：`qwen --list-extensions` 忽略参数并启动普通交互界面。After：主启动流程调用 extension list handler，并在 sandbox setup 或 app config startup 前退出。回归测试在 `packages/cli/src/gemini.test.tsx`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS  | N/A |
| Windows | tested |
|  Linux  | N/A |

### Environment

Windows, Node v24.15.0, npm 11.12.1。

已运行命令：

```bash
npm exec -- vitest run packages/cli/src/gemini.test.tsx -t "list-extensions"
npm exec -- vitest run packages/cli/src/gemini.test.tsx packages/cli/src/commands/extensions/list.test.ts
npm exec -- eslint packages/cli/src/gemini.tsx packages/cli/src/gemini.test.tsx
npm run typecheck --workspace=packages/cli
git diff --check -- packages/cli/src/gemini.tsx packages/cli/src/gemini.test.tsx
```

## 风险和范围

- 主要风险或取舍：这个参数现在会在 sandbox setup、auth setup 和 TUI 渲染前退出；这符合本地列表命令的预期行为。
- 未验证 / 不在范围内：本地 full package build 被当前 checkout 中已有的 `packages/core/dist` 声明文件阻塞，TypeScript 报 `TS5055: Cannot write file ... because it would overwrite input file`。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

Fixes #4450

</details>
