### PR TITLE
refactor(cli): rename "Default" approval mode to "Ask permissions" (#4625)

### DIFF
--- a/docs/users/features/approval-mode.md
+++ b/docs/users/features/approval-mode.md
@@ -4,18 +4,20 @@ Qwen Code offers five distinct permission modes that allow you to flexibly contr
 
 ## Permission Modes Comparison
 
-| Mode           | File Editing                | Shell Commands              | Best For                                                                                               | Risk Level |
-| -------------- | --------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------ | ---------- |
-| **Plan**​      | ❌ Read-only analysis only  | ❌ Not executed             | • Code exploration <br>• Planning complex changes <br>• Safe code review                               | Lowest     |
-| **Default**​   | ✅ Manual approval required | ✅ Manual approval required | • New/unfamiliar codebases <br>• Critical systems <br>• Team collaboration <br>• Learning and teaching | Low        |
-| **Auto-Edit**​ | ✅ Auto-approved            | ❌ Manual approval required | • Daily development tasks <br>• Refactoring and code improvements <br>• Safe automation                | Medium     |
-| **Auto**​      | ✅ Classifier-evaluated     | ✅ Classifier-evaluated     | • Long autonomous sessions <br>• When Auto-Edit is too cautious but YOLO is too risky                  | Medium     |
-| **YOLO**​      | ✅ Auto-approved            | ✅ Auto-approved            | • Trusted personal projects <br>• Automated scripts/CI/CD <br>• Batch processing tasks                 | Highest    |
+| Mode                 | File Editing                | Shell Commands              | Best For                                                                                               | Risk Level |
+| -------------------- | --------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------ | ---------- |
+| **Plan**​            | ❌ Read-only analysis only  | ❌ Not executed             | • Code exploration <br>• Planning complex changes <br>• Safe code review                               | Lowest     |
+| **Ask Permissions**​ | ✅ Manual approval required | ✅ Manual approval required | • New/unfamiliar codebases <br>• Critical systems <br>• Team collaboration <br>• Learning and teaching | Low        |
+| **Auto-Edit**​       | ✅ Auto-approved            | ❌ Manual approval required | • Daily development tasks <br>• Refactoring and code improvements <br>• Safe automation                | Medium     |
+| **Auto**​            | ✅ Classifier-evaluated     | ✅ Classifier-evaluated     | • Long autonomous sessions <br>• When Auto-Edit is too cautious but YOLO is too risky                  | Medium     |
+| **YOLO**​            | ✅ Auto-approved            | ✅ Auto-approved            | • Trusted personal projects <br>• Automated scripts/CI/CD <br>• Batch processing tasks                 | Highest    |
+
+> The mode previously named **Default** has been renamed to **Ask Permissions** to better describe its behavior. The underlying configuration value (`tools.approvalMode: "default"`) and the `/approval-mode default` command are unchanged for backward compatibility.
 
 ### Quick Reference Guide
 
 - **Start in Plan Mode**: Great for understanding before making changes
-- **Work in Default Mode**: The balanced choice for most development work
+- **Work in Ask Permissions Mode**: The balanced choice for most development work
 - **Switch to Auto-Edit**: When you're making lots of safe code changes
 - **Try Auto Mode**: When you want fewer interruptions but still want safety on shell commands and network calls — an LLM classifier evaluates each call
 - **Use YOLO sparingly**: Only for trusted automation in controlled environments
@@ -96,11 +98,11 @@ How should we handle database migration?
 }
 ```
 
-## 2. Use Default Mode for Controlled Interaction
+## 2. Use Ask Permissions Mode for Controlled Interaction
 
-Default Mode is the standard way to work with Qwen Code. In this mode, you maintain full control over all potentially risky operations - Qwen Code will ask for your approval before making any file changes or executing shell commands.
+Ask Permissions Mode is the standard way to work with Qwen Code. In this mode, you maintain full control over all potentially risky operations - Qwen Code will ask for your approval before making any file changes or executing shell commands.
 
-### When to use Default Mode
+### When to use Ask Permissions Mode
 
 - **New to a codebase**: When you're exploring an unfamiliar project and want to be extra cautious
 - **Critical systems**: When working on production code, infrastructure, or sensitive data
@@ -108,23 +110,23 @@ Default Mode is the standard way to work with Qwen Code. In this mode, you maint
 - **Team collaboration**: When multiple people are working on the same codebase
 - **Complex operations**: When the changes involve multiple files or complex logic
 
-### How to use Default Mode
+### How to use Ask Permissions Mode
 
-**Turn on Default Mode during a session**
+**Turn on Ask Permissions Mode during a session**
 
-You can switch into Default Mode during a session using **Shift+Tab**​ (or **Tab** on Windows) to cycle through permission modes. If you're in any other mode, pressing **Shift+Tab** (or **Tab** on Windows) will eventually cycle back to Default Mode, indicated by the absence of any mode indicator at the bottom of the terminal.
+You can switch into Ask Permissions Mode during a session using **Shift+Tab**​ (or **Tab** on Windows) to cycle through permission modes. If you're in any other mode, pressing **Shift+Tab** (or **Tab** on Windows) will eventually cycle back to Ask Permissions Mode, indicated by the absence of any mode indicator at the bottom of the terminal.
 
-**Start a new session in Default Mode**
+**Start a new session in Ask Permissions Mode**
 
-Default Mode is the initial mode when you start Qwen Code. If you've changed modes and want to return to Default Mode, use:
+Ask Permissions Mode is the initial mode when you start Qwen Code. If you've changed modes and want to return to Ask Permissions Mode, use:
 
 ```
 /approval-mode default
 ```
 
-**Run "headless" queries in Default Mode**
+**Run "headless" queries in Ask Permissions Mode**
 
-When running headless commands, Default Mode is the default behavior. You can explicitly specify it with:
+When running headless commands, Ask Permissions Mode is the default behavior. You can explicitly specify it with:
 
 ```
 qwen --prompt "Analyze this code for potential bugs"
@@ -148,7 +150,7 @@ Qwen Code will analyze your codebase and propose a plan. It will then ask for ap
 
 You can review each proposed change and approve or reject it individually.
 
-### Configure Default Mode as default
+### Configure Ask Permissions Mode as default
 
 ```bash
 // .qwen/settings.json
@@ -200,7 +202,7 @@ configuration, troubleshooting, FAQ).
 
 ### When to use Auto Mode
 
-- **Long autonomous sessions**: When Default Mode interrupts too often but
+- **Long autonomous sessions**: When Ask Permissions Mode interrupts too often but
   YOLO is too risky.
 - **Trusted projects**: Internal codebases where the agent should keep
   moving but you still want a guardrail on destructive shell commands and
@@ -277,7 +279,7 @@ Refactor the auth module to use OAuth2. Run the full test suite afterwards.
 Qwen Code makes the file edits (in-workspace edits skip the classifier),
 runs `npm test` (classifier judges safe), and surfaces a block if it ever
 tries something risky like `rm -rf /Users/me/.aws`. You can review the
-reason inline and decide whether to switch to Default Mode for that step.
+reason inline and decide whether to switch to Ask Permissions Mode for that step.
 
 ### Configure Auto Mode as default
 
@@ -363,7 +365,7 @@ qwen --prompt "Run the test suite, fix all failing tests, then commit changes"
 During a Qwen Code session, use **Shift+Tab**​ (or **Tab** on Windows) to quickly cycle through the four modes:
 
 ```
-Default Mode → Auto-Edit Mode → YOLO Mode → Plan Mode → Default Mode
+Ask Permissions Mode → Auto-Edit Mode → YOLO Mode → Plan Mode → Ask Permissions Mode
 ```
 
 ### Persistent Configuration

--- a/docs/users/features/approval-mode.md
+++ b/docs/users/features/approval-mode.md
@@ -12,6 +12,8 @@ Qwen Code offers five distinct permission modes that allow you to flexibly contr
 | **Auto**​            | ✅ Classifier-evaluated     | ✅ Classifier-evaluated     | • Long autonomous sessions <br>• When Auto-Edit is too cautious but YOLO is too risky                  | Medium     |
 | **YOLO**​            | ✅ Auto-approved            | ✅ Auto-approved            | • Trusted personal projects <br>• Automated scripts/CI/CD <br>• Batch processing tasks                 | Highest    |
 
+> [!NOTE]
+>
 > The mode previously named **Default** has been renamed to **Ask Permissions** to better describe its behavior. The underlying configuration value (`tools.approvalMode: "default"`) and the `/approval-mode default` command are unchanged for backward compatibility.
 
 ### Quick Reference Guide

--- a/packages/cli/src/config/settingsSchema.ts
+++ b/packages/cli/src/config/settingsSchema.ts
@@ -1734,7 +1734,7 @@ const SETTINGS_SCHEMA = {
         showInDialog: true,
         options: [
           { value: ApprovalMode.PLAN, label: 'Plan' },
-          { value: ApprovalMode.DEFAULT, label: 'Default' },
+          { value: ApprovalMode.DEFAULT, label: 'Ask permissions' },
           { value: ApprovalMode.AUTO_EDIT, label: 'Auto Edit' },
           { value: ApprovalMode.AUTO, label: 'Auto' },
           { value: ApprovalMode.YOLO, label: 'YOLO' },

--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -449,7 +449,7 @@ export default {
   Text: 'Text',
   JSON: 'JSON',
   Plan: 'Planificació',
-  Default: 'Per defecte',
+  'Ask permissions': 'Demanar permisos',
   'Auto Edit': 'Edició automàtica',
   YOLO: 'YOLO',
   'toggle vim mode on/off': 'activar/desactivar el mode Vim',

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -381,7 +381,7 @@ export default {
   Text: 'Text',
   JSON: 'JSON',
   Plan: 'Plan',
-  Default: 'Standard',
+  'Ask permissions': 'Berechtigung anfragen',
   'Auto Edit': 'Automatisch bearbeiten',
   YOLO: 'YOLO',
   'toggle vim mode on/off': 'Vim-Modus ein-/ausschalten',

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -473,7 +473,7 @@ export default {
   Text: 'Text',
   JSON: 'JSON',
   Plan: 'Plan',
-  Default: 'Default',
+  'Ask permissions': 'Ask permissions',
   'Auto Edit': 'Auto Edit',
   YOLO: 'YOLO',
   'toggle vim mode on/off': 'toggle vim mode on/off',

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -453,7 +453,7 @@ export default {
   Text: 'Texte',
   JSON: 'JSON',
   Plan: 'Plan',
-  Default: 'Par défaut',
+  'Ask permissions': "Demander l'autorisation",
   'Auto Edit': 'Édition automatique',
   YOLO: 'YOLO',
   'toggle vim mode on/off': 'activer/désactiver le mode Vim',

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -292,7 +292,7 @@ export default {
   Text: 'テキスト',
   JSON: 'JSON',
   Plan: 'プラン',
-  Default: 'デフォルト',
+  'Ask permissions': '許可を確認',
   'Auto Edit': '自動編集',
   YOLO: 'YOLO',
   'toggle vim mode on/off': 'Vim モードのオン/オフを切り替え',

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -403,7 +403,7 @@ export default {
   Text: 'Texto',
   JSON: 'JSON',
   Plan: 'Planejamento',
-  Default: 'Padrão',
+  'Ask permissions': 'Pedir permissão',
   'Auto Edit': 'Edição Automática',
   YOLO: 'YOLO',
   'toggle vim mode on/off': 'alternar modo vim ligado/desligado',

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -400,7 +400,7 @@ export default {
   Text: 'Текст',
   JSON: 'JSON',
   Plan: 'План',
-  Default: 'По умолчанию',
+  'Ask permissions': 'Запрашивать разрешения',
   'Auto Edit': 'Авторедактирование',
   YOLO: 'YOLO',
   'toggle vim mode on/off': 'Включение/выключение режима vim',

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -414,7 +414,7 @@ export default {
   Text: '文本',
   JSON: 'JSON',
   Plan: '規劃',
-  Default: '默認',
+  'Ask permissions': '請求授權',
   'Auto Edit': '自動編輯',
   YOLO: 'YOLO',
   'toggle vim mode on/off': '切換 vim 模式開關',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -451,7 +451,7 @@ export default {
   Text: '文本',
   JSON: 'JSON',
   Plan: '规划',
-  Default: '默认',
+  'Ask permissions': '请求授权',
   'Auto Edit': '自动编辑',
   YOLO: 'YOLO',
   'toggle vim mode on/off': '切换 vim 模式开关',

--- a/packages/cli/src/ui/components/ApprovalModeDialog.tsx
+++ b/packages/cli/src/ui/components/ApprovalModeDialog.tsx
@@ -31,6 +31,13 @@ interface ApprovalModeDialogProps {
   availableTerminalHeight?: number;
 }
 
+const formatModeName = (mode: ApprovalMode): string => {
+  if (mode === ApprovalMode.DEFAULT) {
+    return t('Ask permissions');
+  }
+  return mode;
+};
+
 const formatModeDescription = (mode: ApprovalMode): string => {
   switch (mode) {
     case ApprovalMode.PLAN:
@@ -64,7 +71,7 @@ export function ApprovalModeDialog({
 
   // Generate approval mode items with inline descriptions
   const modeItems = APPROVAL_MODES.map((mode) => ({
-    label: `${mode} - ${formatModeDescription(mode)}`,
+    label: `${formatModeName(mode)} - ${formatModeDescription(mode)}`,
     value: mode,
     key: mode,
   }));

--- a/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
+++ b/packages/cli/src/ui/components/__snapshots__/SettingsDialog.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`SettingsDialog > Snapshot Tests > should render default state correctly
 │ > Settings                                                                                       │
 │                                                                                                  │
 │ ▲                                                                                                │
-│ ● Tool Approval Mode                                                                     Default │
+│ ● Tool Approval Mode                                                             Ask permissions │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                                           auto │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -28,7 +28,7 @@ exports[`SettingsDialog > Snapshot Tests > should render focused on scope select
 │ > Settings                                                                                       │
 │                                                                                                  │
 │ ▲                                                                                                │
-│ ● Tool Approval Mode                                                                     Default │
+│ ● Tool Approval Mode                                                             Ask permissions │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                                           auto │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -50,7 +50,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with accessibility sett
 │ > Settings                                                                                       │
 │                                                                                                  │
 │ ▲                                                                                                │
-│ ● Tool Approval Mode                                                                     Default │
+│ ● Tool Approval Mode                                                             Ask permissions │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                                           auto │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -72,7 +72,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with all boolean settin
 │ > Settings                                                                                       │
 │                                                                                                  │
 │ ▲                                                                                                │
-│ ● Tool Approval Mode                                                                     Default │
+│ ● Tool Approval Mode                                                             Ask permissions │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                                           auto │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -94,7 +94,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with different scope se
 │ > Settings                                                                                       │
 │                                                                                                  │
 │ ▲                                                                                                │
-│ ● Tool Approval Mode                                                                     Default │
+│ ● Tool Approval Mode                                                             Ask permissions │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                                           auto │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -116,7 +116,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with different scope se
 │ > Settings                                                                                       │
 │                                                                                                  │
 │ ▲                                                                                                │
-│ ● Tool Approval Mode                                                                     Default │
+│ ● Tool Approval Mode                                                             Ask permissions │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                                           auto │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -138,7 +138,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with file filtering set
 │ > Settings                                                                                       │
 │                                                                                                  │
 │ ▲                                                                                                │
-│ ● Tool Approval Mode                                                                     Default │
+│ ● Tool Approval Mode                                                             Ask permissions │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                                           auto │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -160,7 +160,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with mixed boolean and 
 │ > Settings                                                                                       │
 │                                                                                                  │
 │ ▲                                                                                                │
-│ ● Tool Approval Mode                                                                     Default │
+│ ● Tool Approval Mode                                                             Ask permissions │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                                           auto │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -182,7 +182,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with tools and security
 │ > Settings                                                                                       │
 │                                                                                                  │
 │ ▲                                                                                                │
-│ ● Tool Approval Mode                                                                     Default │
+│ ● Tool Approval Mode                                                             Ask permissions │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                                           auto │
 │   Theme                                                                              Qwen Dark ▸ │
@@ -204,7 +204,7 @@ exports[`SettingsDialog > Snapshot Tests > should render with various boolean se
 │ > Settings                                                                                       │
 │                                                                                                  │
 │ ▲                                                                                                │
-│ ● Tool Approval Mode                                                                     Default │
+│ ● Tool Approval Mode                                                             Ask permissions │
 │   Language: UI                                                         Auto (detect from system) │
 │   Language: Model                                                                           auto │
 │   Theme                                                                              Qwen Dark ▸ │


### PR DESCRIPTION
## What this PR does

Renames the approval mode previously displayed as **Default** to **Ask Permissions** in user-facing UI. The change is confined to display labels — the internal enum value (`ApprovalMode.DEFAULT`), the serialized settings value (`tools.approvalMode: "default"`), and the `/approval-mode default` CLI identifier are preserved. Existing `settings.json` files and CLI invocations continue to work unchanged.

Affected surfaces: settings dialog, `/approval-mode` picker (entry for `DEFAULT` only), 9 i18n locales (en, zh, zh-TW, de, fr, ja, pt, ru, ca), and `docs/users/features/approval-mode.md`.

## Why it's needed

The label **Default** told the user "this is what you get if you don't pick anything" without saying what authorization the mode actually grants. Every other mode name (`Plan`, `Auto-Edit`, `Auto`, `YOLO`) describes behavior; `Default` was the odd one out. **Ask Permissions** answers the user's mental-model question — "what permission level is this?" — directly, and matches the convention Claude Code uses for the equivalent mode, lowering the cognitive cost for users who move between tools. See issue #4625 for the full rationale.

## Reviewer Test Plan

### How to verify

1. **Settings dialog** — start the CLI, open `/settings`. The `Tool Approval Mode` row shows `Ask permissions` (instead of `Default`) when `DEFAULT` is active.
2. **Approval-mode picker** — run `/approval-mode`. The second entry renders as `Ask permissions - Require approval for file edits or shell commands` (was `default - Require approval for file edits or shell commands`).
3. **Backward compatibility** — an existing `settings.json` containing `"tools": { "approvalMode": "default" }` loads and applies the `DEFAULT` mode without migration. `/approval-mode default` still switches into the mode and prints `Approval mode set to "default"` (CLI ID, by design).
4. **i18n** — switch UI language; each of zh / zh-TW / de / fr / ja / pt / ru / ca renders the localized translation in the settings dialog.
5. **Snapshot tests** — `cd packages/cli && npx vitest run src/ui/components/SettingsDialog` passes (53 tests, 10 snapshots).

### Evidence (Before & After)

**Settings dialog row** — from `SettingsDialog.test.tsx.snap` (authoritative TUI render):

Before (parent of this branch, commit `707f1bdb5`):

```
│ ● Tool Approval Mode                                                                     Default │
```

After (this PR):

```
│ ● Tool Approval Mode                                                             Ask permissions │
```

**`/approval-mode` picker** — entry for `ApprovalMode.DEFAULT`:

| | Label rendered |
|---|---|
| Before | `default - Require approval for file edits or shell commands` |
| After  | `Ask permissions - Require approval for file edits or shell commands` |

Other picker entries (`plan`, `auto-edit`, `auto`, `yolo`) are intentionally unchanged — see "Not validated / out of scope" below.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested locally — CI green |
|  🐧 Linux  | ⚠️ not tested locally — CI green |

CI passed all three Test matrix jobs on `3c3144a3d` (macOS 18m44s, Linux 12m18s, Windows 16m23s).

### Environment (optional)

Local: `npm install --ignore-scripts && cd packages/cli && npx vitest run src/ui/components/SettingsDialog src/ui/components/Footer src/ui/components/AutoAcceptIndicator src/ui/components/Composer src/ui/components/InputPrompt src/ui/commands/approvalModeCommand src/ui/hooks/useApprovalModeCommand` — 247 passed, 1 skipped. Lint + typecheck clean.

## Risk & Scope

- **Main risk or tradeoff**: The `/approval-mode` picker now mixes letter-case styles — `Ask permissions` (Title case via `t()`) sits alongside lowercase raw-enum names (`plan`, `auto-edit`, `auto`, `yolo`). This is the deliberate consequence of scoping the rename to `DEFAULT` only. Normalizing the other picker entries to a consistent display map is left to a future PR.
- **Not validated / out of scope**: VSCode companion (`packages/vscode-ide-companion/src/types/approvalModeTypes.ts`) already uses its own friendlier label `"Ask before edits"` and is not touched. The `/approval-mode` command output (`Approval mode set to "{{mode}}"`) continues to echo the raw CLI identifier the user typed, by design.
- **Breaking changes / migration notes**: None. The internal enum value `ApprovalMode.DEFAULT`, the serialized config value `"default"`, and the `/approval-mode default` CLI keyword are unchanged. The migration note in `docs/users/features/approval-mode.md` documents the rename for users encountering the new label.

## Linked Issues

Closes #4625.

<details>
<summary>中文说明</summary>

### 这个 PR 做了什么

把审批模式 (approval mode) 在用户可见 UI 里原本叫 **Default** 的那一档改名为 **Ask Permissions**。改动仅限显示标签：内部枚举值 `ApprovalMode.DEFAULT`、settings.json 序列化值 `"default"`、CLI 命令 `/approval-mode default` 全部保持不变，老配置无需迁移。

### 为什么需要

`Default` 这个名字只表达"默认值"这个 meta 概念，无法告诉用户该模式实际授予哪种权限级别。其它 mode (`Plan`、`Auto-Edit`、`Auto`、`YOLO`) 都直接描述行为，唯独 `Default` 例外。`Ask Permissions` 直接回答用户的关键问题——"这个模式下我会被询问吗？"——并且对齐 Claude Code 同类模式的命名，降低跨工具的认知成本。详细背景见 issue #4625。

### 影响范围

- Settings dialog 里 `Tool Approval Mode` 行
- `/approval-mode` 选择器中 `DEFAULT` 项
- 9 个 locale 的 i18n 翻译 (en/zh/zh-TW/de/fr/ja/pt/ru/ca)
- `docs/users/features/approval-mode.md`

### 不影响

- `ApprovalMode.DEFAULT` 枚举与 `"default"` 序列化值
- `/approval-mode default` 命令与 `tools.approvalMode: "default"` 设置
- VSCode 配套插件 (已有自己的 `"Ask before edits"` 标签)

</details>