### PR TITLE
fix(daemon): restore replay history after SSE ring eviction

### DIFF
--- a/packages/acp-bridge/src/bridge.test.ts
+++ b/packages/acp-bridge/src/bridge.test.ts
@@ -818,6 +818,8 @@ describe('createHttpAcpBridge', () => {
       clientId: expect.stringMatching(/^client_/),
       createdAt: expect.any(String),
       state: { configOptions: [] },
+      lastEventId: expect.any(Number),
+      replayEvents: expect.any(Array),
     });
     expect(handles[0]?.agent.loadSessionCalls).toEqual([
       { sessionId: 'persisted-1', cwd: WS_A, mcpServers: [] },
@@ -919,7 +921,9 @@ describe('createHttpAcpBridge', () => {
       clientId: expect.stringMatching(/^client_/),
       createdAt: expect.any(String),
       state: { modes: null },
+      lastEventId: expect.any(Number),
     });
+    expect(resumed).not.toHaveProperty('replayEvents');
     expect(handles[0]?.agent.loadSessionCalls).toHaveLength(0);
     expect(handles[0]?.agent.resumeSessionCalls).toEqual([
       { sessionId: 'persisted-2', cwd: WS_A, mcpServers: [] },
@@ -962,10 +966,112 @@ describe('createHttpAcpBridge', () => {
       clientId: expect.stringMatching(/^client_/),
       createdAt: expect.any(String),
       state: { _meta: { tag: 'restored-foo' } },
+      lastEventId: expect.any(Number),
     });
+    expect(attached).not.toHaveProperty('replayEvents');
     expect(attached.clientId).not.toBe(loaded.clientId);
     expect(handles[0]?.agent.loadSessionCalls).toHaveLength(1);
     expect(handles[0]?.agent.resumeSessionCalls).toHaveLength(0);
+
+    await bridge.shutdown();
+  });
+
+  it('returns current replay events when loading an already live spawned session', async () => {
+    const handles: ChannelHandle[] = [];
+    const factory: ChannelFactory = async () => {
+      const h = makeChannel({
+        promptImpl: () => ({ stopReason: 'end_turn' }),
+      });
+      handles.push(h);
+      return h.channel;
+    };
+    const bridge = makeBridge({ channelFactory: factory });
+    const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+    await bridge.sendPrompt(
+      session.sessionId,
+      {
+        sessionId: session.sessionId,
+        prompt: [{ type: 'text', text: 'hello after spawn' }],
+      },
+      undefined,
+      { clientId: session.clientId },
+    );
+
+    const loaded = await bridge.loadSession({
+      sessionId: session.sessionId,
+      workspaceCwd: WS_A,
+    });
+    const replayUpdates = (loaded.replayEvents ?? [])
+      .filter((event): event is BridgeEvent & { type: 'session_update' } => event.type === 'session_update')
+      .map(
+        (event) =>
+          event.data as {
+            update?: {
+              sessionUpdate?: string;
+              content?: { type?: string; text?: string };
+            };
+          },
+      );
+
+    expect(handles[0]?.agent.loadSessionCalls).toHaveLength(0);
+    expect(loaded.lastEventId ?? 0).toBeGreaterThan(0);
+    expect(replayUpdates).toContainEqual(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          sessionUpdate: 'user_message_chunk',
+          content: { type: 'text', text: 'hello after spawn' },
+        }),
+      }),
+    );
+
+    await bridge.shutdown();
+  });
+
+  it('returns full replay events even after the SSE ring evicts older frames', async () => {
+    const factory: ChannelFactory = async () =>
+      makeChannel({ promptImpl: () => ({ stopReason: 'end_turn' }) }).channel;
+    const bridge = makeBridge({ channelFactory: factory, eventRingSize: 2 });
+    const session = await bridge.spawnOrAttach({ workspaceCwd: WS_A });
+
+    for (let i = 0; i < 5; i++) {
+      await bridge.sendPrompt(
+        session.sessionId,
+        {
+          sessionId: session.sessionId,
+          prompt: [{ type: 'text', text: `message-${i}` }],
+        },
+        undefined,
+        { clientId: session.clientId },
+      );
+    }
+
+    const loaded = await bridge.loadSession({
+      sessionId: session.sessionId,
+      workspaceCwd: WS_A,
+    });
+    const replayTexts = (loaded.replayEvents ?? [])
+      .filter((event): event is BridgeEvent & { type: 'session_update' } => event.type === 'session_update')
+      .map(
+        (event) =>
+          event.data as {
+            update?: {
+              sessionUpdate?: string;
+              content?: { type?: string; text?: string };
+            };
+          },
+      )
+      .filter((data) => data.update?.sessionUpdate === 'user_message_chunk')
+      .map((data) => data.update?.content?.text);
+
+    expect(loaded.lastEventId ?? 0).toBeGreaterThan(2);
+    expect(replayTexts).toEqual([
+      'message-0',
+      'message-1',
+      'message-2',
+      'message-3',
+      'message-4',
+    ]);
 
     await bridge.shutdown();
   });

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { promises as fs, constants as fsConstants } from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import {
   ClientSideConnection,
@@ -29,6 +30,7 @@ import {
 import type { ShellCommandResult } from './bridgeTypes.js';
 import type { AcpChannel } from './channel.js';
 import { EventBus, DEFAULT_RING_SIZE, type BridgeEvent } from './eventBus.js';
+import { FileReplayStore, deleteFileReplayStore } from './replayStore.js';
 import {
   BridgeChannelClosedError,
   BridgeTimeoutError,
@@ -611,6 +613,11 @@ const DEFAULT_MAX_SESSIONS = 20;
  * operator-controlled), just typo defense.
  */
 const MAX_EVENT_RING_SIZE = 1_000_000;
+
+function workspacePathHash(workspacePath: string): string {
+  return createHash('sha256').update(workspacePath).digest('hex').slice(0, 16);
+}
+
 // Bd1yh: per-permission-request wall clock. Without this, an agent
 // calling `requestPermission` while no SSE subscriber is connected
 // would hang the per-session FIFO promptQueue forever (the prompt
@@ -685,6 +692,15 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         `Must be a positive integer in [1, ${MAX_EVENT_RING_SIZE}].`,
     );
   }
+  const ownsReplayStoreRoot = opts.replayStoreDir === undefined;
+  const replayStoreRoot =
+    opts.replayStoreDir ??
+    path.join(
+      os.tmpdir(),
+      'qwen-code-daemon-replay',
+      workspacePathHash(opts.boundWorkspace),
+      `${process.pid}-${randomUUID()}`,
+    );
   const channelFactory = opts.channelFactory ?? defaultSpawnChannelFactory;
   // PR 14 fix (review #4247 wenshao R5 runQwenServe.ts:216): close over
   // a per-handle env-override snapshot. Calls to `channelFactory` at
@@ -1669,11 +1685,22 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     }
   };
 
+  const createSessionEventBus = (sessionId: string): EventBus =>
+    new EventBus(
+      eventRingSize,
+      undefined,
+      new FileReplayStore({
+        dir: replayStoreRoot,
+        sessionId,
+        deleteOnClose: true,
+      }),
+    );
+
   const createSessionEntry = (
     ci: ChannelInfo,
     sessionId: string,
     workspaceCwd: string,
-    events = new EventBus(eventRingSize),
+    events = createSessionEventBus(sessionId),
   ): SessionEntry => {
     const entry: SessionEntry = {
       sessionId,
@@ -1741,6 +1768,18 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     }
     const workspaceKey = resolveWorkspaceKey(req.workspaceCwd);
 
+    const replayFieldsFor = async (
+      entry: SessionEntry,
+    ): Promise<Pick<BridgeRestoredSession, 'lastEventId' | 'replayEvents'>> => {
+      const lastEventId = entry.events.lastEventId;
+      return {
+        lastEventId,
+        ...(action === 'load'
+          ? { replayEvents: await entry.events.snapshotReplayLog() }
+          : {}),
+      };
+    };
+
     const existing = byId.get(req.sessionId);
     if (existing) {
       existing.attachCount++;
@@ -1754,6 +1793,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         // Late attachers get the same ACP state the original restore
         // caller saw; spawn-only sessions don't carry a state payload.
         state: existing.restoreState ?? {},
+        ...(await replayFieldsFor(existing)),
       };
     }
 
@@ -1820,7 +1860,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       throw new SessionLimitExceededError(maxSessions);
     }
 
-    const restoreEvents = new EventBus(eventRingSize);
+    const restoreEvents = createSessionEventBus(req.sessionId);
     let registeredEntry: SessionEntry | undefined;
     let ci: ChannelInfo | undefined;
     // Live counter shared with coalesced waiters (see InFlightRestore
@@ -1937,6 +1977,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
           clientId,
           createdAt: racedEntry.createdAt,
           state: racedEntry.restoreState ?? {},
+          ...(await replayFieldsFor(racedEntry)),
         };
       }
 
@@ -1970,6 +2011,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         clientId,
         createdAt: entry.createdAt,
         state,
+        ...(await replayFieldsFor(entry)),
       };
     })().finally(() => {
       ci?.pendingRestoreIds.delete(req.sessionId);
@@ -2762,6 +2804,10 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
           );
         });
       }
+    },
+
+    deleteSessionReplayCache(sessionId) {
+      deleteFileReplayStore(replayStoreRoot, sessionId);
     },
 
     updateSessionMetadata(sessionId, metadata, context) {
@@ -4482,6 +4528,9 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         ...inFlightRestoreAwaits,
         inFlightChannelAwait,
       ]);
+      if (ownsReplayStoreRoot) {
+        await fs.rm(replayStoreRoot, { recursive: true, force: true });
+      }
     },
   };
 }

--- a/packages/acp-bridge/src/bridgeOptions.ts
+++ b/packages/acp-bridge/src/bridgeOptions.ts
@@ -158,6 +158,15 @@ export interface BridgeOptions {
    */
   eventRingSize?: number;
   /**
+   * Optional directory for per-session daemon replay logs. When omitted,
+   * the bridge creates a process-scoped directory under the OS temp dir.
+   *
+   * These files store daemon UI events, not model chat history. They are
+   * used only while a session is live so `/load` can reconstruct a complete
+   * transcript without retaining an unbounded in-memory event array.
+   */
+  replayStoreDir?: string;
+  /**
    * Per-`requestPermission` wall clock. After this many ms with
    * no client vote, the agent's permission promise resolves as
    * cancelled — the per-session FIFO can drain instead of poisoning

--- a/packages/acp-bridge/src/bridgeTypes.ts
+++ b/packages/acp-bridge/src/bridgeTypes.ts
@@ -79,6 +79,10 @@ export type BridgeSessionState = LoadSessionResponse | ResumeSessionResponse;
 export interface BridgeRestoredSession extends BridgeSession {
   /** ACP state returned by `session/load` / `session/resume`. */
   state: BridgeSessionState;
+  /** Event bus high watermark at restore time. */
+  lastEventId?: number;
+  /** Full replay log for client-side transcript reconstruction. */
+  replayEvents?: BridgeEvent[];
 }
 
 /** Sparse summary used by `GET /workspace/:id/sessions`. */
@@ -215,6 +219,15 @@ export interface HttpAcpBridge {
     sessionId: string,
     context?: BridgeClientRequestContext,
   ): Promise<void>;
+
+  /**
+   * Remove the daemon replay cache for a session if it exists.
+   *
+   * Live close/kill paths normally delete the cache through EventBus.close().
+   * This hook covers persisted-session deletion, where the session may no
+   * longer have a live EventBus in memory.
+   */
+  deleteSessionReplayCache(sessionId: string): void;
 
   /**
    * Update mutable session metadata. Currently supports `displayName` only.

--- a/packages/acp-bridge/src/eventBus.test.ts
+++ b/packages/acp-bridge/src/eventBus.test.ts
@@ -4,12 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, expect } from 'vitest';
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { describe, it, expect, vi } from 'vitest';
 import {
   EventBus,
   EVENT_SCHEMA_VERSION,
   type BridgeEvent,
 } from './eventBus.js';
+import { FileReplayStore, fileReplayStorePath } from './replayStore.js';
 
 async function collect(
   iter: AsyncIterable<BridgeEvent>,
@@ -737,4 +741,210 @@ describe('EventBus', () => {
       abort.abort();
     });
   });
+
+  describe('snapshotRing', () => {
+    it('returns all events when count is within ring capacity', () => {
+      const bus = new EventBus(5);
+      for (let i = 0; i < 3; i++) {
+        bus.publish({ type: 'session_update', data: { i } });
+      }
+      const snapshot = bus.snapshotRing();
+      expect(snapshot).toHaveLength(3);
+      expect(snapshot[0]!.id).toBe(1);
+      expect(snapshot[2]!.id).toBe(3);
+    });
+
+    it('returns only the last N events when count exceeds ring capacity', () => {
+      const bus = new EventBus(3);
+      for (let i = 0; i < 7; i++) {
+        bus.publish({ type: 'session_update', data: { i } });
+      }
+      const snapshot = bus.snapshotRing();
+      expect(snapshot).toHaveLength(3);
+      expect(snapshot[0]!.id).toBe(5);
+      expect(snapshot[2]!.id).toBe(7);
+    });
+
+    it('returns a defensive copy', () => {
+      const bus = new EventBus(5);
+      bus.publish({ type: 'foo', data: {} });
+      const a = bus.snapshotRing();
+      const b = bus.snapshotRing();
+      expect(a).not.toBe(b);
+      expect(a).toEqual(b);
+    });
+  });
+
+  describe('snapshotReplayLog', () => {
+    it('keeps the full replay history after the SSE ring evicts frames', async () => {
+      const bus = new EventBus(3);
+      for (let i = 0; i < 7; i++) {
+        bus.publish({ type: 'session_update', data: { i } });
+      }
+
+      const ring = bus.snapshotRing();
+      const replayLog = await bus.snapshotReplayLog();
+
+      expect(ring).toHaveLength(3);
+      expect(ring[0]!.id).toBe(5);
+      expect(replayLog).toHaveLength(7);
+      expect(replayLog[0]!.id).toBe(1);
+      expect(replayLog[6]!.id).toBe(7);
+    });
+
+    it('returns a defensive copy', async () => {
+      const bus = new EventBus(5);
+      bus.publish({ type: 'foo', data: {} });
+
+      const a = await bus.snapshotReplayLog();
+      const b = await bus.snapshotReplayLog();
+
+      expect(a).not.toBe(b);
+      expect(a).toEqual(b);
+    });
+
+    it('can read full replay history from a file-backed store', async () => {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'event-bus-replay-'));
+      try {
+        const bus = new EventBus(
+          2,
+          undefined,
+          new FileReplayStore({ dir, sessionId: 'session-a' }),
+        );
+        for (let i = 0; i < 5; i++) {
+          bus.publish({ type: 'session_update', data: { i } });
+        }
+
+        expect(bus.snapshotRing().map((event) => event.id)).toEqual([4, 5]);
+        expect(
+          (await bus.snapshotReplayLog()).map((event) => event.id),
+        ).toEqual([1, 2, 3, 4, 5]);
+        bus.close();
+      } finally {
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('falls back to memory when file-backed replay writes fail', async () => {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'event-bus-replay-'));
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+      try {
+        const bus = new EventBus(
+          2,
+          undefined,
+          new FileReplayStore({ dir, sessionId: 'session-write-fail' }),
+        );
+        await fs.rm(dir, { recursive: true, force: true });
+
+        bus.publish({ type: 'session_update', data: { i: 1 } });
+        bus.publish({ type: 'session_update', data: { i: 2 } });
+
+        await waitFor(() =>
+          stderrSpy.mock.calls.some((call) =>
+            String(call[0]).includes('replay cache write failed'),
+          ),
+        );
+        expect(
+          (await bus.snapshotReplayLog()).map((event) => event.id),
+        ).toEqual([1, 2]);
+        expect(
+          stderrSpy.mock.calls.some((call) =>
+            String(call[0]).includes('replay cache write failed'),
+          ),
+        ).toBe(true);
+        bus.close();
+      } finally {
+        stderrSpy.mockRestore();
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('skips malformed file-backed replay lines and keeps valid events', async () => {
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'event-bus-replay-'));
+      const stderrSpy = vi
+        .spyOn(process.stderr, 'write')
+        .mockImplementation(() => true);
+      try {
+        const store = new FileReplayStore({
+          dir,
+          sessionId: 'session-bad-line',
+        });
+        const filePath = fileReplayStorePath(dir, 'session-bad-line');
+        await fs.writeFile(
+          filePath,
+          [
+            JSON.stringify({ id: 1, v: 1, type: 'session_update', data: 'ok' }),
+            '{bad json',
+            JSON.stringify({
+              id: 2,
+              v: 1,
+              type: 'session_update',
+              data: 'still ok',
+            }),
+            '',
+          ].join('\n'),
+          'utf8',
+        );
+
+        expect((await store.snapshot()).map((event) => event.id)).toEqual([
+          1, 2,
+        ]);
+        expect(
+          stderrSpy.mock.calls.some((call) =>
+            String(call[0]).includes('malformed JSONL'),
+          ),
+        ).toBe(true);
+        store.close();
+      } finally {
+        stderrSpy.mockRestore();
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('creates file-backed replay directories and files with private permissions', async () => {
+      if (process.platform === 'win32') return;
+      const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'event-bus-replay-'));
+      try {
+        const store = new FileReplayStore({
+          dir,
+          sessionId: 'session-private',
+        });
+        store.append({ id: 1, v: 1, type: 'session_update', data: {} });
+        const filePath = fileReplayStorePath(dir, 'session-private');
+        await waitFor(async () => {
+          await fs.access(filePath);
+          return true;
+        });
+
+        const dirMode = (await fs.stat(dir)).mode & 0o777;
+        const fileMode = (await fs.stat(filePath)).mode & 0o777;
+        expect(dirMode).toBe(0o700);
+        expect(fileMode).toBe(0o600);
+        store.close();
+      } finally {
+        await fs.rm(dir, { recursive: true, force: true });
+      }
+    });
+  });
 });
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+): Promise<void> {
+  let lastError: unknown;
+  for (let i = 0; i < 20; i++) {
+    try {
+      if (await predicate()) return;
+    } catch (error) {
+      lastError = error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  try {
+    expect(await predicate()).toBe(true);
+  } catch (error) {
+    throw lastError ?? error;
+  }
+}

--- a/packages/acp-bridge/src/eventBus.ts
+++ b/packages/acp-bridge/src/eventBus.ts
@@ -19,6 +19,8 @@
  *     Aborting the supplied AbortSignal closes the iterator promptly.
  */
 
+import { InMemoryReplayStore, type ReplayStore } from './replayStore.js';
+
 export const EVENT_SCHEMA_VERSION = 1 as const;
 
 /** A single frame published on the bus. */
@@ -166,11 +168,28 @@ export class EventBus {
   constructor(
     private readonly ringSize: number = DEFAULT_RING_SIZE,
     private readonly maxSubscribers: number = DEFAULT_MAX_SUBSCRIBERS,
+    private readonly replayStore: ReplayStore = new InMemoryReplayStore(),
   ) {}
 
   /** Most recent id ever assigned by `publish`. 0 if no events published. */
   get lastEventId(): number {
     return this.nextId - 1;
+  }
+
+  /** Defensive copy of all events currently retained in the ring. */
+  snapshotRing(): BridgeEvent[] {
+    return this.ring.slice();
+  }
+
+  /**
+   * Defensive copy of every event published on this bus.
+   *
+   * The bounded ring is only an SSE catch-up buffer. HTTP session loads
+   * need an authoritative replay source so a refreshed UI can rebuild the
+   * full transcript even after the SSE ring has evicted older frames.
+   */
+  async snapshotReplayLog(): Promise<BridgeEvent[]> {
+    return await this.replayStore.snapshot();
   }
 
   /** Snapshot of the live subscriber count. */
@@ -211,6 +230,7 @@ export class EventBus {
       ...input,
     };
     this.ring.push(event);
+    this.replayStore.append(event);
     // Eviction-by-shift is O(n) once the ring is full. At the current
     // default `ringSize=8000` (#3803 §02) the per-publish shift work
     // measures in low milliseconds on chatty sessions — still well
@@ -550,6 +570,7 @@ export class EventBus {
     this.closed = true;
     for (const sub of this.subs) sub.queue.close();
     this.subs.clear();
+    this.replayStore.close();
   }
 }
 

--- a/packages/acp-bridge/src/replayStore.ts
+++ b/packages/acp-bridge/src/replayStore.ts
@@ -1,0 +1,283 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import type { BridgeEvent } from './eventBus.js';
+import { writeStderrLine } from './internal/stderrLine.js';
+
+export interface ReplayStore {
+  append(event: BridgeEvent): void;
+  snapshot(): Promise<BridgeEvent[]>;
+  close(): void;
+}
+
+export class InMemoryReplayStore implements ReplayStore {
+  private readonly events: BridgeEvent[] = [];
+  private closed = false;
+
+  append(event: BridgeEvent): void {
+    if (this.closed) return;
+    this.events.push(event);
+  }
+
+  async snapshot(): Promise<BridgeEvent[]> {
+    return this.events.slice();
+  }
+
+  close(): void {
+    this.closed = true;
+    this.events.length = 0;
+  }
+}
+
+export interface FileReplayStoreOptions {
+  dir: string;
+  sessionId: string;
+  deleteOnClose?: boolean;
+}
+
+export function fileReplayStorePath(dir: string, sessionId: string): string {
+  return path.join(dir, `${safeFileSegment(sessionId)}.jsonl`);
+}
+
+export function deleteFileReplayStore(dir: string, sessionId: string): void {
+  try {
+    fs.rmSync(fileReplayStorePath(dir, sessionId), { force: true });
+  } catch {
+    // Best-effort cleanup for runtime cache. A failure should not turn a
+    // successful session close/delete into a user-visible error.
+  }
+}
+
+/**
+ * Append-only replay store for daemon UI events.
+ *
+ * Chat history JSONL stores semantic conversation records; this store keeps
+ * the exact daemon event projection used by web clients. That lets live
+ * `/load` recover pending tools, permission requests, subagent updates, and
+ * turn sentinels without retaining an unbounded in-memory replay array.
+ */
+export class FileReplayStore implements ReplayStore {
+  private readonly dir: string;
+  private readonly sessionId: string;
+  private readonly filePath: string;
+  private readonly deleteOnClose: boolean;
+  private readonly pendingEvents: BridgeEvent[] = [];
+  private readonly writeQueue: BridgeEvent[] = [];
+  private readonly fallbackEvents: BridgeEvent[] = [];
+  private stream: fs.WriteStream | undefined;
+  private pendingStartIndex = 0;
+  private writeQueueStartIndex = 0;
+  private waitingForDrain = false;
+  private failed = false;
+  private closed = false;
+  private warnedReadFailure = false;
+  private warnedMalformedLine = false;
+
+  constructor(opts: FileReplayStoreOptions) {
+    this.dir = opts.dir;
+    this.sessionId = opts.sessionId;
+    this.filePath = fileReplayStorePath(this.dir, this.sessionId);
+    this.deleteOnClose = opts.deleteOnClose ?? true;
+    fs.mkdirSync(this.dir, { recursive: true, mode: 0o700 });
+    try {
+      fs.chmodSync(this.dir, 0o700);
+    } catch {
+      // Best effort: the file itself is still created with 0600 below.
+    }
+  }
+
+  append(event: BridgeEvent): void {
+    if (this.closed) return;
+    if (this.failed) {
+      this.fallbackEvents.push(event);
+      return;
+    }
+    this.pendingEvents.push(event);
+    this.writeQueue.push(event);
+    this.flushWriteQueue();
+  }
+
+  async snapshot(): Promise<BridgeEvent[]> {
+    const events: BridgeEvent[] = [];
+    try {
+      await fs.promises.access(this.filePath);
+      const raw = await fs.promises.readFile(this.filePath, 'utf8');
+      for (const line of raw.split('\n')) {
+        if (!line) continue;
+        try {
+          events.push(JSON.parse(line) as BridgeEvent);
+        } catch (error) {
+          // A malformed temp replay line should not make `/load` fail.
+          // The store is best-effort runtime state; later valid lines still
+          // carry useful UI history.
+          if (!this.warnedMalformedLine) {
+            this.warnedMalformedLine = true;
+            writeStderrLine(
+              `qwen serve: replay cache contains malformed JSONL for ` +
+                `session ${JSON.stringify(this.sessionId)} at ` +
+                `${JSON.stringify(this.filePath)}; skipping malformed line: ` +
+                `${formatReplayStoreError(error)}`,
+            );
+          }
+        }
+      }
+    } catch (error) {
+      const maybeNodeError = error as { code?: unknown };
+      if (maybeNodeError.code !== 'ENOENT' && !this.warnedReadFailure) {
+        this.warnedReadFailure = true;
+        writeStderrLine(
+          `qwen serve: replay cache read failed for session ` +
+            `${JSON.stringify(this.sessionId)} at ${JSON.stringify(this.filePath)}; ` +
+            `using in-memory fallback only: ${formatReplayStoreError(error)}`,
+        );
+      }
+    }
+    return appendUniqueEvents(events, [
+      ...this.pendingEvents.slice(this.pendingStartIndex),
+      ...this.fallbackEvents,
+    ]);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.stream?.destroy();
+    this.stream = undefined;
+    if (this.deleteOnClose) {
+      deleteFileReplayStore(this.dir, this.sessionId);
+    }
+    this.writeQueue.length = 0;
+    this.writeQueueStartIndex = 0;
+    this.pendingStartIndex = 0;
+    this.pendingEvents.length = 0;
+    this.fallbackEvents.length = 0;
+  }
+
+  private flushWriteQueue(): void {
+    if (this.closed || this.failed || this.waitingForDrain) return;
+    try {
+      const stream = this.ensureStream();
+      while (this.writeQueueStartIndex < this.writeQueue.length) {
+        const event = this.writeQueue[this.writeQueueStartIndex++];
+        const ok = stream.write(
+          `${JSON.stringify(event)}\n`,
+          'utf8',
+          (error) => {
+            if (this.failed || this.closed) return;
+            if (error) {
+              this.failWrites(error);
+              return;
+            }
+            this.pendingStartIndex++;
+            this.compactPendingEvents();
+          },
+        );
+        if (!ok) {
+          this.waitingForDrain = true;
+          stream.once('drain', () => {
+            this.waitingForDrain = false;
+            this.flushWriteQueue();
+          });
+          break;
+        }
+      }
+      this.compactWriteQueue();
+    } catch (error) {
+      // EventBus.publish() is a never-throw hot path. If the temporary
+      // replay stream cannot be created or written, preserve correctness for
+      // this process by keeping unwritten events in memory.
+      this.failWrites(error);
+    }
+  }
+
+  private ensureStream(): fs.WriteStream {
+    if (this.stream) return this.stream;
+    const stream = fs.createWriteStream(this.filePath, {
+      flags: 'a',
+      encoding: 'utf8',
+      mode: 0o600,
+    });
+    stream.on('error', (error) => {
+      this.failWrites(error);
+    });
+    this.stream = stream;
+    return stream;
+  }
+
+  private failWrites(error: unknown): void {
+    if (this.failed || this.closed) return;
+    this.failed = true;
+    writeStderrLine(
+      `qwen serve: replay cache write failed for session ` +
+        `${JSON.stringify(this.sessionId)} at ${JSON.stringify(this.filePath)}; ` +
+        `falling back to in-memory replay: ${formatReplayStoreError(error)}`,
+    );
+    this.fallbackEvents.push(
+      ...this.pendingEvents.slice(this.pendingStartIndex),
+    );
+    this.writeQueue.length = 0;
+    this.writeQueueStartIndex = 0;
+    this.pendingStartIndex = 0;
+    this.pendingEvents.length = 0;
+    this.stream?.destroy();
+    this.stream = undefined;
+  }
+
+  private compactPendingEvents(): void {
+    if (
+      this.pendingStartIndex > 1024 &&
+      this.pendingStartIndex * 2 > this.pendingEvents.length
+    ) {
+      this.pendingEvents.splice(0, this.pendingStartIndex);
+      this.pendingStartIndex = 0;
+    }
+  }
+
+  private compactWriteQueue(): void {
+    if (this.writeQueueStartIndex === this.writeQueue.length) {
+      this.writeQueue.length = 0;
+      this.writeQueueStartIndex = 0;
+      return;
+    }
+    if (
+      this.writeQueueStartIndex > 1024 &&
+      this.writeQueueStartIndex * 2 > this.writeQueue.length
+    ) {
+      this.writeQueue.splice(0, this.writeQueueStartIndex);
+      this.writeQueueStartIndex = 0;
+    }
+  }
+}
+
+function safeFileSegment(value: string): string {
+  return value.replace(/[^a-zA-Z0-9._-]/g, '_');
+}
+
+function formatReplayStoreError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function appendUniqueEvents(
+  persistedEvents: BridgeEvent[],
+  volatileEvents: BridgeEvent[],
+): BridgeEvent[] {
+  const out = persistedEvents.slice();
+  const seenIds = new Set(
+    persistedEvents
+      .map((event) => event.id)
+      .filter((id): id is number => typeof id === 'number'),
+  );
+  for (const event of volatileEvents) {
+    if (typeof event.id === 'number') {
+      if (seenIds.has(event.id)) continue;
+      seenIds.add(event.id);
+    }
+    out.push(event);
+  }
+  return out;
+}

--- a/packages/cli/src/serve/server.test.ts
+++ b/packages/cli/src/serve/server.test.ts
@@ -446,6 +446,7 @@ interface FakeBridge extends HttpAcpBridge {
     sessionId: string;
     context?: BridgeClientRequestContext;
   }>;
+  deleteReplayCacheCalls: string[];
   updateMetadataCalls: Array<{
     sessionId: string;
     metadata: SessionMetadataUpdate;
@@ -485,6 +486,7 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
   const sessionTasksCalls: string[] = [];
   const setModelCalls: FakeBridge['setModelCalls'] = [];
   const closeCalls: FakeBridge['closeCalls'] = [];
+  const deleteReplayCacheCalls: string[] = [];
   const updateMetadataCalls: FakeBridge['updateMetadataCalls'] = [];
   const heartbeatCalls: FakeBridge['heartbeatCalls'] = [];
   const heartbeatStateCalls: string[] = [];
@@ -754,6 +756,7 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
     addRuntimeMcpServerCalls,
     removeRuntimeMcpServerCalls,
     closeCalls,
+    deleteReplayCacheCalls,
     updateMetadataCalls,
     heartbeatCalls,
     heartbeatStateCalls,
@@ -954,6 +957,9 @@ function fakeBridge(opts: FakeBridgeOpts = {}): FakeBridge {
     async closeSession(sessionId, context) {
       closeCalls.push({ sessionId, ...(context ? { context } : {}) });
       return closeImpl(sessionId, context);
+    },
+    deleteSessionReplayCache(sessionId) {
+      deleteReplayCacheCalls.push(sessionId);
     },
     updateSessionMetadata(sessionId, metadata, context) {
       updateMetadataCalls.push({
@@ -4414,6 +4420,7 @@ describe('createServeApp', () => {
       expect(res.body.removed).toEqual([sid]);
       expect(res.body.notFound).toEqual([]);
       expect(res.body.errors).toEqual([]);
+      expect(bridge.deleteReplayCacheCalls).toEqual([sid]);
       const chatsDir = path.join(new Storage(wsDir).getProjectDir(), 'chats');
       const filePath = path.join(chatsDir, `${sid}.jsonl`);
       await expect(fsp.access(filePath)).rejects.toThrow();
@@ -4438,6 +4445,7 @@ describe('createServeApp', () => {
       expect(res.status).toBe(200);
       expect(res.body.removed).toEqual([sid]);
       expect(res.body.errors).toEqual([]);
+      expect(bridge.deleteReplayCacheCalls).toEqual([sid]);
       const chatsDir = path.join(new Storage(wsDir).getProjectDir(), 'chats');
       const filePath = path.join(chatsDir, `${sid}.jsonl`);
       await expect(fsp.access(filePath)).rejects.toThrow();
@@ -4479,6 +4487,7 @@ describe('createServeApp', () => {
       expect(res.status).toBe(200);
       expect(res.body.removed).toEqual([]);
       expect(res.body.notFound).toEqual(['nonexistent']);
+      expect(bridge.deleteReplayCacheCalls).toEqual(['nonexistent']);
     });
 
     it('errors array contains string messages, not Error objects', async () => {
@@ -4530,6 +4539,9 @@ describe('createServeApp', () => {
       expect(res.body.errors).toHaveLength(1);
       expect(res.body.errors[0].sessionId).toBe(sidFail);
       expect(res.body.errors[0].error).toBe('agent busy');
+      expect(bridge.deleteReplayCacheCalls.sort()).toEqual(
+        [sidNotFound, sidOk].sort(),
+      );
       const chatsDir = path.join(new Storage(wsDir).getProjectDir(), 'chats');
       await expect(
         fsp.access(path.join(chatsDir, `${sidOk}.jsonl`)),
@@ -4607,6 +4619,7 @@ describe('createServeApp', () => {
       expect(res.status).toBe(200);
       expect(res.body.removed).toEqual([]);
       expect(res.body.errors).toHaveLength(1);
+      expect(bridge.deleteReplayCacheCalls).toEqual([]);
       const chatsDir = path.join(new Storage(wsDir).getProjectDir(), 'chats');
       await expect(
         fsp.access(path.join(chatsDir, `${sid}.jsonl`)),

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -1898,6 +1898,13 @@ export function createServeApp(
       const result = await new SessionService(boundWorkspace).removeSessions(
         closedIds,
       );
+      for (const id of [...result.removed, ...result.notFound]) {
+        // `closeSession()` deletes the replay cache for live sessions through
+        // EventBus.close(). Batch delete also handles inactive persisted
+        // sessions, so clean by id here to remove any stale replay file that
+        // no live EventBus owns anymore.
+        bridge.deleteSessionReplayCache(id);
+      }
       for (const e of result.errors) {
         const msg =
           e.error instanceof Error ? e.error.message : String(e.error);

--- a/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
+++ b/packages/sdk-typescript/src/daemon/DaemonSessionClient.ts
@@ -42,6 +42,8 @@ export interface DaemonSessionClientOptions {
    * `Last-Event-ID` resume cursors.
    */
   lastEventId?: number;
+  /** Full replay log from the daemon restore response for transcript seeding. */
+  replayEvents?: DaemonEvent[];
 }
 
 export interface DaemonSessionSubscribeOptions extends SubscribeOptions {
@@ -68,6 +70,8 @@ export class DaemonSessionClient {
   readonly client: DaemonClient;
   readonly session: DaemonSession;
   readonly state: DaemonSessionState;
+  /** Full replay log from the daemon for client-side transcript seeding. */
+  readonly replayEvents: DaemonEvent[];
   private lastSeenEventId: number | undefined;
   private subscriptionActive = false;
   private readonly _pendingPrompts = new Map<
@@ -82,6 +86,7 @@ export class DaemonSessionClient {
     this.client = opts.client;
     this.session = { ...opts.session };
     this.state = { ...(opts.state ?? {}) };
+    this.replayEvents = opts.replayEvents ?? [];
     this.lastSeenEventId = validateLastEventId(opts.lastEventId);
   }
 
@@ -126,9 +131,11 @@ export class DaemonSessionClient {
   }
 
   /**
-   * Loads an existing daemon session and seeds the first event subscription
-   * from the start of the daemon replay ring so history replay frames emitted
-   * during `session/load` are visible to this client.
+   * Loads an existing daemon session. When the daemon returns a replay log
+   * (`replayEvents`) and watermark (`lastEventId`), the client seeds its SSE
+   * cursor from the watermark so subsequent event subscriptions only receive
+   * incremental events. Callers use `replayEvents` to reconstruct the
+   * transcript without relying on SSE replay from the bounded ring.
    */
   static async load(
     client: DaemonClient,
@@ -136,27 +143,26 @@ export class DaemonSessionClient {
     req: RestoreSessionRequest = {},
     clientId?: string,
   ): Promise<DaemonSessionClient> {
-    const { state, ...session } = await client.loadSession(
-      sessionId,
-      req,
-      clientId,
-    );
+    const {
+      state,
+      lastEventId: serverLastEventId,
+      replayEvents,
+      ...session
+    } = await client.loadSession(sessionId, req, clientId);
     return new DaemonSessionClient({
       client,
       session,
       state,
-      lastEventId: 0,
+      lastEventId: serverLastEventId ?? 0,
+      replayEvents,
     });
   }
 
   /**
    * Resumes an existing daemon session without requesting history replay.
-   * Seeds the first event subscription from the start of the daemon
-   * replay ring (`lastEventId: 0`) symmetric with `load()` — the agent's
-   * `unstable_resumeSession` schedules an `available_commands_update`
-   * via `setTimeout(0)`, which can publish to the daemon bus between
-   * the HTTP response and the consumer's first `events()` call. Seeding
-   * ensures that frame is observed instead of dropped.
+   * When the daemon returns a watermark (`lastEventId`), uses it as the
+   * initial SSE cursor. Falls back to 0 for older daemons so
+   * post-resume events (e.g. `available_commands_update`) are captured.
    */
   static async resume(
     client: DaemonClient,
@@ -164,16 +170,17 @@ export class DaemonSessionClient {
     req: RestoreSessionRequest = {},
     clientId?: string,
   ): Promise<DaemonSessionClient> {
-    const { state, ...session } = await client.resumeSession(
-      sessionId,
-      req,
-      clientId,
-    );
+    const {
+      state,
+      lastEventId: serverLastEventId,
+      replayEvents: _discarded,
+      ...session
+    } = await client.resumeSession(sessionId, req, clientId);
     return new DaemonSessionClient({
       client,
       session,
       state,
-      lastEventId: 0,
+      lastEventId: serverLastEventId ?? 0,
     });
   }
 

--- a/packages/sdk-typescript/src/daemon/types.ts
+++ b/packages/sdk-typescript/src/daemon/types.ts
@@ -152,6 +152,10 @@ export interface DaemonSessionState {
 /** Returned from `POST /session/:id/load` and `POST /session/:id/resume`. */
 export interface DaemonRestoredSession extends DaemonSession {
   state: DaemonSessionState;
+  /** Event bus watermark at restore time — used as initial SSE cursor. */
+  lastEventId?: number;
+  /** Full replay log for client-side transcript seeding (skips SSE replay). */
+  replayEvents?: DaemonEvent[];
 }
 
 /** Sparse session record returned by `GET /workspace/:id/sessions`. */

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -38,6 +38,7 @@ interface MockSession {
   clientId: string;
   client?: MockClient;
   lastEventId?: number;
+  replayEvents: DaemonEvent[];
   setLastEventId: (lastEventId: number | undefined) => void;
   prompt: (
     req: unknown,
@@ -1258,6 +1259,209 @@ describe('DaemonSessionProvider', () => {
     }
   });
 
+  it('keeps replay-seeded assistant streaming when no terminal replay event exists', async () => {
+    const session = createMockSession({
+      replayEvents: [
+        {
+          id: 1,
+          v: 1,
+          type: 'session_update',
+          data: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'still running' },
+            },
+          },
+        },
+      ],
+      events: async function* idleAfterReplay(
+        opts: { signal?: AbortSignal } = {},
+      ) {
+        await new Promise<void>((resolve) => {
+          if (opts.signal?.aborted) {
+            resolve();
+            return;
+          }
+          opts.signal?.addEventListener('abort', () => resolve(), {
+            once: true,
+          });
+        });
+        yield* [];
+      },
+    });
+    sdkMocks.sessions.push(session);
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    let streamingState: ReturnType<typeof useDaemonStreamingState> = 'idle';
+
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      streamingState = useDaemonStreamingState();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(streamingState).toBe('responding');
+    expect(blocks).toMatchObject([
+      { kind: 'assistant', text: 'still running', streaming: true },
+    ]);
+  });
+
+  it('does not replay-seed the same session again after a normal SSE reconnect', async () => {
+    let eventSubscriptions = 0;
+    const session = createMockSession({
+      replayEvents: [
+        {
+          id: 1,
+          v: 1,
+          type: 'session_update',
+          data: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'seeded once' },
+            },
+          },
+        },
+      ],
+      events: async function* reconnectingStream() {
+        yield* [] as DaemonEvent[];
+        eventSubscriptions++;
+      },
+    });
+    sdkMocks.sessions.push(session);
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      autoReconnect: true,
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+    });
+    await act(async () => {
+      await wait(10);
+      await flushPromises();
+    });
+
+    expect(eventSubscriptions).toBeGreaterThan(1);
+    expect(blocks.filter((block) => block.kind === 'assistant')).toMatchObject([
+      { kind: 'assistant', text: 'seeded once' },
+    ]);
+  });
+
+  it('keeps replay-seeded assistant streaming when only an earlier turn is terminal', async () => {
+    const session = createMockSession({
+      replayEvents: [
+        {
+          id: 1,
+          v: 1,
+          type: 'session_update',
+          data: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'finished turn' },
+            },
+          },
+        },
+        {
+          id: 2,
+          v: 1,
+          type: 'turn_complete',
+          data: { stopReason: 'end_turn' },
+        },
+        {
+          id: 3,
+          v: 1,
+          type: 'session_update',
+          data: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'active turn' },
+            },
+          },
+        },
+      ],
+      events: async function* idleAfterReplay(
+        opts: { signal?: AbortSignal } = {},
+      ) {
+        yield* [] as DaemonEvent[];
+        await new Promise<void>((resolve) => {
+          if (opts.signal?.aborted) {
+            resolve();
+            return;
+          }
+          opts.signal?.addEventListener('abort', () => resolve(), {
+            once: true,
+          });
+        });
+      },
+    });
+    sdkMocks.sessions.push(session);
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(blocks.filter((block) => block.kind === 'assistant')).toMatchObject([
+      { kind: 'assistant', text: 'finished turn', streaming: false },
+      { kind: 'assistant', text: 'active turn', streaming: true },
+    ]);
+  });
+
+  it('finishes replay-seeded assistant when the replay tail is terminal', async () => {
+    const session = createMockSession({
+      replayEvents: [
+        {
+          id: 1,
+          v: 1,
+          type: 'session_update',
+          data: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'done turn' },
+            },
+          },
+        },
+        {
+          id: 2,
+          v: 1,
+          type: 'turn_complete',
+          data: { stopReason: 'end_turn' },
+        },
+      ],
+    });
+    sdkMocks.sessions.push(session);
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(blocks.filter((block) => block.kind === 'assistant')).toMatchObject([
+      { kind: 'assistant', text: 'done turn', streaming: false },
+    ]);
+  });
+
   it('creates a fresh thread session without cancelling the previous session', async () => {
     const firstSession = createMockSession({ sessionId: 'session-a' });
     const secondSession = createMockSession({ sessionId: 'session-b' });
@@ -1475,6 +1679,36 @@ describe('DaemonSessionProvider', () => {
     await act(async () => {
       await flushPromises();
     });
+    expect(connection).toMatchObject({ sessionId: 'session-b' });
+  });
+
+  it('does not reject an in-flight session load during the cleanup between session switches', async () => {
+    sdkMocks.sessions.push(
+      createMockSession({ sessionId: 'session-a', events: createIdleEvents() }),
+      createMockSession({ sessionId: 'session-b', events: createIdleEvents() }),
+    );
+    let actions: DaemonSessionActions | undefined;
+    let connection: DaemonConnectionState | undefined;
+
+    function Harness() {
+      actions = useDaemonActions();
+      connection = useDaemonConnection();
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, { autoConnect: true });
+    expect(connection).toMatchObject({ sessionId: 'session-a' });
+
+    let loadPromise!: Promise<void>;
+    act(() => {
+      loadPromise = requireActions(actions).loadSession('session-b');
+    });
+
+    await act(async () => {
+      await loadPromise;
+      await flushPromises();
+    });
+
     expect(connection).toMatchObject({ sessionId: 'session-b' });
   });
 
@@ -1934,84 +2168,11 @@ describe('DaemonSessionProvider', () => {
     ]);
   });
 
-  it('clears awaitingResync on replay_complete after ring-evicted resync', async () => {
-    const liveDelivered = createDeferred<void>();
-    const session = createMockSession({
-      lastEventId: 10,
-      events: async function* ringEvictedThenLive(
-        opts: { signal?: AbortSignal } = {},
-      ) {
-        yield {
-          v: 1,
-          type: 'state_resync_required',
-          data: {
-            reason: 'ring_evicted',
-            lastDeliveredId: 10,
-            earliestAvailableId: 12,
-          },
-        };
-        yield {
-          v: 1,
-          type: 'replay_complete',
-          data: { replayedCount: 0 },
-        };
-        yield {
-          id: 12,
-          v: 1,
-          type: 'session_update',
-          data: {
-            update: {
-              sessionUpdate: 'agent_message_chunk',
-              content: { type: 'text', text: 'live after replay' },
-            },
-          },
-        };
-        liveDelivered.resolve();
-        await new Promise<void>((resolve) => {
-          if (opts.signal?.aborted) {
-            resolve();
-            return;
-          }
-          opts.signal?.addEventListener('abort', () => resolve(), {
-            once: true,
-          });
-        });
-      },
-    });
-    sdkMocks.sessions.push(session);
-
-    let blocks: readonly DaemonTranscriptBlock[] = [];
-    let awaitingResync = false;
-    function Harness() {
-      blocks = useDaemonTranscriptBlocks();
-      awaitingResync = useDaemonTranscriptState().awaitingResync;
-      return null;
-    }
-
-    await renderWithProvider(<Harness />, { autoConnect: true });
-    await act(async () => {
-      await liveDelivered.promise;
-      await flushPromises();
-    });
-
-    expect(awaitingResync).toBe(false);
-    expect(blocks).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          kind: 'assistant',
-          text: 'live after replay',
-        }),
-      ]),
-    );
-  });
-
-  it('clears ring-evicted awaitingResync on same-session reattach', async () => {
-    const firstStreamDone = createDeferred<void>();
-    const reattachDelivered = createDeferred<void>();
+  it('triggers full reload on ring_evicted and seeds from replayEvents', async () => {
+    const secondStreamReady = createDeferred<void>();
     const firstSession = createMockSession({
-      sessionId: 'session-reattach',
       lastEventId: 10,
-      events: async function* ringEvictedThenGone() {
+      events: async function* ringEvicted() {
         yield {
           v: 1,
           type: 'state_resync_required',
@@ -2021,32 +2182,28 @@ describe('DaemonSessionProvider', () => {
             earliestAvailableId: 12,
           },
         };
-        firstStreamDone.resolve();
-        const error = new Error('session temporarily unavailable') as Error & {
-          status: number;
-        };
-        error.status = 410;
-        throw error;
       },
     });
     const secondSession = createMockSession({
-      sessionId: 'session-reattach',
-      lastEventId: 10,
-      events: async function* reattachedLive(
-        opts: { signal?: AbortSignal } = {},
-      ) {
-        yield {
+      sessionId: 'session-1',
+      replayEvents: [
+        {
           id: 12,
           v: 1,
           type: 'session_update',
           data: {
             update: {
               sessionUpdate: 'agent_message_chunk',
-              content: { type: 'text', text: 'after reattach' },
+              content: { type: 'text', text: 'from snapshot' },
             },
           },
-        };
-        reattachDelivered.resolve();
+        },
+      ],
+      lastEventId: 12,
+      events: async function* liveAfterReload(
+        opts: { signal?: AbortSignal } = {},
+      ) {
+        secondStreamReady.resolve();
         await new Promise<void>((resolve) => {
           if (opts.signal?.aborted) {
             resolve();
@@ -2056,6 +2213,7 @@ describe('DaemonSessionProvider', () => {
             once: true,
           });
         });
+        yield* [];
       },
     });
     sdkMocks.sessions.push(firstSession, secondSession);
@@ -2075,20 +2233,7 @@ describe('DaemonSessionProvider', () => {
       maxReconnectDelayMs: 1,
     });
     await act(async () => {
-      await firstStreamDone.promise;
-      await flushPromises();
-    });
-    expect(blocks).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          kind: 'error',
-          text: expect.stringContaining('State resync required'),
-        }),
-      ]),
-    );
-
-    await act(async () => {
-      await reattachDelivered.promise;
+      await secondStreamReady.promise;
       await flushPromises();
     });
 
@@ -2097,7 +2242,88 @@ describe('DaemonSessionProvider', () => {
       expect.arrayContaining([
         expect.objectContaining({
           kind: 'assistant',
-          text: 'after reattach',
+          text: 'from snapshot',
+        }),
+      ]),
+    );
+  });
+
+  it('recovers from ring_evicted followed by 410 via full reload', async () => {
+    const secondStreamReady = createDeferred<void>();
+    const firstSession = createMockSession({
+      sessionId: 'session-reattach',
+      lastEventId: 10,
+      events: async function* ringEvictedThenGone() {
+        yield {
+          v: 1,
+          type: 'state_resync_required',
+          data: {
+            reason: 'ring_evicted',
+            lastDeliveredId: 10,
+            earliestAvailableId: 12,
+          },
+        };
+      },
+    });
+    const secondSession = createMockSession({
+      sessionId: 'session-reattach',
+      replayEvents: [
+        {
+          id: 12,
+          v: 1,
+          type: 'session_update',
+          data: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'after reload' },
+            },
+          },
+        },
+      ],
+      lastEventId: 12,
+      events: async function* liveAfterReload(
+        opts: { signal?: AbortSignal } = {},
+      ) {
+        secondStreamReady.resolve();
+        await new Promise<void>((resolve) => {
+          if (opts.signal?.aborted) {
+            resolve();
+            return;
+          }
+          opts.signal?.addEventListener('abort', () => resolve(), {
+            once: true,
+          });
+        });
+        yield* [];
+      },
+    });
+    sdkMocks.sessions.push(firstSession, secondSession);
+
+    let blocks: readonly DaemonTranscriptBlock[] = [];
+    let awaitingResync = false;
+    function Harness() {
+      blocks = useDaemonTranscriptBlocks();
+      awaitingResync = useDaemonTranscriptState().awaitingResync;
+      return null;
+    }
+
+    await renderWithProvider(<Harness />, {
+      autoConnect: true,
+      autoReconnect: true,
+      reconnectDelayMs: 1,
+      maxReconnectDelayMs: 1,
+    });
+    await act(async () => {
+      await secondStreamReady.promise;
+      await flushPromises();
+    });
+
+    expect(awaitingResync).toBe(false);
+    expect(blocks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'assistant',
+          text: 'after reload',
         }),
       ]),
     );
@@ -2128,9 +2354,7 @@ describe('DaemonSessionProvider', () => {
   }
 });
 
-function requireActions(
-  actions: DaemonUiSessionActions | undefined,
-): DaemonUiSessionActions {
+function requireActions<T>(actions: T | undefined): T {
   if (!actions) throw new Error('actions were not initialized');
   return actions;
 }
@@ -2141,6 +2365,7 @@ function createMockSession(opts: Partial<MockSession> = {}): MockSession {
     workspaceCwd: opts.workspaceCwd ?? '/mock-workspace',
     clientId: opts.clientId ?? 'client-1',
     lastEventId: opts.lastEventId,
+    replayEvents: opts.replayEvents ?? [],
     setLastEventId:
       opts.setLastEventId ??
       vi.fn((lastEventId: number | undefined) => {

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -176,6 +176,9 @@ export function DaemonSessionProvider({
     undefined,
   );
   const pendingSessionLoadIdRef = useRef(0);
+  const replaySeededSessionsRef = useRef<WeakSet<DaemonSessionClient>>(
+    new WeakSet(),
+  );
   const passiveAssistantDoneTimerRef = useRef<
     ReturnType<typeof setTimeout> | undefined
   >(undefined);
@@ -393,6 +396,48 @@ export function DaemonSessionProvider({
             );
           }
 
+          // Seed transcript from the HTTP-delivered replay log so the
+          // SSE subscription only needs to deliver incremental events.
+          // This avoids relying on the bounded SSE ring for long-session
+          // recovery after ring_evicted.
+          if (
+            !replaySeededSessionsRef.current.has(activeSession) &&
+            activeSession.replayEvents.length > 0
+          ) {
+            replaySeededSessionsRef.current.add(activeSession);
+            const eventOptions = eventOptionsRef.current;
+            let seededEventCount = 0;
+            for (const replayEvent of activeSession.replayEvents) {
+              if (replayEvent.type === 'turn_complete') {
+                const stopReason =
+                  (replayEvent.data as DaemonTurnCompleteData | undefined)
+                    ?.stopReason ?? 'replay_complete';
+                store.dispatch({ type: 'assistant.done', reason: stopReason });
+                setPromptStatus('idle');
+                continue;
+              }
+              if (replayEvent.type === 'turn_error') {
+                store.dispatch({ type: 'assistant.done', reason: 'error' });
+                setPromptStatus('idle');
+                continue;
+              }
+              const normalized = normalizeDaemonEvent(replayEvent, {
+                clientId: activeSession.clientId,
+                suppressOwnUserEcho: eventOptions.suppressOwnUserEcho,
+                includeRawEvent: eventOptions.includeRawEvent,
+              });
+              if (normalized.length > 0) {
+                store.dispatch(normalized);
+              }
+              seededEventCount++;
+              if (seededEventCount % 100 === 0) {
+                if (disposed || abort.signal.aborted) return;
+                await delay(0, abort.signal);
+              }
+            }
+            setConnection((c) => ({ ...c, catchingUp: undefined }));
+          }
+
           let sawEvent = false;
           let resyncRequested = false;
           for await (const event of activeSession.events({
@@ -511,7 +556,9 @@ export function DaemonSessionProvider({
                 if (reason === 'epoch_reset') {
                   store.reset();
                   activeSession.setLastEventId(0);
-                } else if (reason !== 'ring_evicted') {
+                } else {
+                  // ring_evicted and unknown reasons: reload session to
+                  // get a fresh snapshot + watermark via HTTP.
                   resyncRequested = true;
                   store.reset();
                   session = undefined;
@@ -650,11 +697,15 @@ export function DaemonSessionProvider({
       setPromptStatus('idle');
       clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
       if (pendingSessionLoadRef.current) {
-        clearTimeout(pendingSessionLoadRef.current.timeout);
-        pendingSessionLoadRef.current.reject(
-          new Error('Session load interrupted by cleanup'),
-        );
-        pendingSessionLoadRef.current = undefined;
+        const pendingLoad = pendingSessionLoadRef.current;
+        window.setTimeout(() => {
+          if (pendingSessionLoadRef.current !== pendingLoad) {
+            return;
+          }
+          clearTimeout(pendingLoad.timeout);
+          pendingSessionLoadRef.current = undefined;
+          pendingLoad.reject(new DOMException('Aborted', 'AbortError'));
+        }, 0);
       }
       if (session?.clientId) {
         void detachDaemonClient({


### PR DESCRIPTION
## 概要

- 变更内容：将完整会话历史恢复与有界 SSE ring buffer 解耦。`loadSession` 返回 `replayEvents` 和 `lastEventId` 用于重建页面历史；SSE ring 只负责短暂断线后的增量追赶。
- 变更原因：长 daemon session 的事件数可能超过 SSE ring 容量。页面刷新或重连后，如果客户端从 `Last-Event-ID: 0` 订阅 SSE，服务端会因为早期事件已被 ring 淘汰而返回 `ring_evicted`，导致页面无法恢复完整 transcript。
- 重点关注：请重点确认长会话刷新后能通过 HTTP replay log 恢复完整历史，`resumeSession` 不再返回完整 replay payload，以及 `ring_evicted` 后 WebUI 会重新走 load 恢复状态。

## 验证

- 执行命令：
  ```bash
  cd packages/acp-bridge && npx vitest run src/eventBus.test.ts src/bridge.test.ts
  cd packages/sdk-typescript && npx vitest run test/unit/DaemonSessionClient.test.ts test/unit/daemonUi.test.ts
  cd packages/webui && npx vitest run src/daemon/session/DaemonSessionProvider.test.tsx src/daemon/session/transcriptToMessages.test.ts
  npm run build
  ```
- 使用输入：无，当前改动属于 daemon/session 恢复链路，主要通过单元测试覆盖。
- 预期结果：即使长会话历史已经超过 SSE ring 容量，页面仍能通过 `loadSession` 返回的 replay events 恢复完整历史，并从返回的 watermark 后继续接收实时增量。
- 实际结果：相关测试全部通过，`npm run build` 成功完成。构建过程中仅出现已有的 VS Code companion lint warning 和 Browserslist 数据过期提示，没有错误。
- Reviewer 最快验证方式：运行上面的测试命令，并重点查看 `replayEvents`、`lastEventId`、`resume` 和 `ring_evicted` 恢复路径。
- 结果摘要：
  - `packages/acp-bridge`：254 个测试通过。
  - `packages/sdk-typescript`：220 个测试通过。
  - `packages/webui`：99 个测试通过。
  - 全量 `npm run build` 成功。

## 范围 / 风险

- 主要风险或取舍：`loadSession` 现在会携带用于历史重建的 replay events，超长会话的 load 响应会更大；`resumeSession` 已避免返回这部分完整 replay payload。
- 未覆盖内容：未录制浏览器手工验证视频；本次验证集中在 daemon bridge、SDK 和 WebUI session 相关测试。
- 兼容性：新增字段是 optional，新 SDK 连接旧 daemon 时会降级为旧行为；新 SDK 连接新 daemon 时会使用 HTTP replay log + watermark，避免依赖有界 SSE ring 恢复完整历史。

## 测试矩阵

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | N/A | N/A |
| Podman   | N/A | N/A | N/A |
| Seatbelt | N/A | N/A | N/A |

测试矩阵说明：

- 已在 macOS 本地运行相关 `npx vitest` 命令和 `npm run build`。
- Windows / Linux 未在本地运行。

## 关联 Issue / Bug

- N/A
