### PR TITLE
fix(core): loosen auto-mode classifier timeouts, disable stage-2 thinking

### DIFF
--- a/packages/core/src/permissions/classifier.test.ts
+++ b/packages/core/src/permissions/classifier.test.ts
@@ -189,7 +189,7 @@ describe('classifier configuration', () => {
     expect(opts.config?.thinkingConfig?.includeThoughts).toBe(false);
   });
 
-  it('uses max_output_tokens=4096 with thinking enabled for stage 2', async () => {
+  it('uses max_output_tokens=4096 with thinking disabled for stage 2', async () => {
     runSideQueryMock
       .mockResolvedValueOnce({ shouldBlock: true })
       .mockResolvedValueOnce({ thinking: 't', shouldBlock: false, reason: '' });
@@ -201,7 +201,8 @@ describe('classifier configuration', () => {
       };
     };
     expect(opts.config?.maxOutputTokens).toBe(4096);
-    expect(opts.config?.thinkingConfig?.includeThoughts).toBe(true);
+    // Thinking is disabled in every stage (latency-sensitive permission gate).
+    expect(opts.config?.thinkingConfig?.includeThoughts).toBe(false);
   });
 
   it('does not pin a model — defaults to the fast model via sideQuery', async () => {

--- a/packages/core/src/permissions/classifier.ts
+++ b/packages/core/src/permissions/classifier.ts
@@ -9,8 +9,11 @@
  *   Stage 1 (fast):  shouldBlock-only output, max_tokens=32, thinking off.
  *                    Allow path returns immediately (~300ms).
  *   Stage 2 (review): full output { thinking, shouldBlock, reason },
- *                     max_tokens=4096, thinking on. Reviews stage-1 blocks
- *                     to reduce false positives.
+ *                     max_tokens=4096, thinking off. Reviews stage-1 blocks
+ *                     to reduce false positives. The `thinking` field is a
+ *                     plain output field the model fills in; no reasoning
+ *                     budget is allocated (thinking is disabled in every
+ *                     stage to keep this latency-sensitive gate fast/cheap).
  *
  * Fail-closed: any non-abort failure (API error, timeout, schema failure,
  * context overflow) returns shouldBlock=true with unavailable=true.
@@ -33,10 +36,16 @@ import { buildClassifierContents } from './classifier-transcript.js';
 // the underlying API / timeout / context-overflow error.
 const debugLogger = createDebugLogger('CLASSIFIER');
 
-/** Stage-1 timeout: fast model p99 is ~1.5s; 3s catches stuck cases. */
-export const STAGE1_TIMEOUT_MS = 3_000;
-/** Stage-2 timeout: thinking takes longer; 10s caps infrastructure failure. */
-export const STAGE2_TIMEOUT_MS = 10_000;
+// A classifier timeout is fail-closed: the action is BLOCKED as
+// "unavailable". Too tight a budget therefore turns transient slowness (a
+// slow network, a large transcript, model queueing) into spurious blocks of
+// otherwise-valid AUTO-mode actions. The fast model's p99 is ~1.5s, but the
+// tail is much longer under load, so the budgets are kept generous — we would
+// rather wait a little than fail closed on a healthy call.
+/** Stage-1 timeout: generous headroom over the fast model's p99 (~1.5s). */
+export const STAGE1_TIMEOUT_MS = 10_000;
+/** Stage-2 timeout: review stage runs a larger prompt; cap infra failure. */
+export const STAGE2_TIMEOUT_MS = 30_000;
 
 /** Token usage attributed to a single classifier call. */
 export interface ClassifierUsage {
@@ -219,7 +228,13 @@ export async function classifyAction(
       config: {
         temperature: 0,
         maxOutputTokens: 4096,
-        thinkingConfig: { includeThoughts: true },
+        // Thinking disabled in every stage: this is a latency-sensitive
+        // permission gate the user is actively waiting on, and enabling a
+        // reasoning budget makes the review path slower and more expensive
+        // (which directly worsens the fail-closed timeout above). The model
+        // still records its reasoning in the structured `thinking` output
+        // field; it just does not get an allocated reasoning budget.
+        thinkingConfig: { includeThoughts: false },
       },
     })) as Stage2Response;
   } catch (err) {

--- a/packages/core/src/permissions/classifier.ts
+++ b/packages/core/src/permissions/classifier.ts
@@ -10,10 +10,8 @@
  *                    Allow path returns immediately (~300ms).
  *   Stage 2 (review): full output { thinking, shouldBlock, reason },
  *                     max_tokens=4096, thinking off. Reviews stage-1 blocks
- *                     to reduce false positives. The `thinking` field is a
- *                     plain output field the model fills in; no reasoning
- *                     budget is allocated (thinking is disabled in every
- *                     stage to keep this latency-sensitive gate fast/cheap).
+ *                     to reduce false positives. (`thinking` is a plain output
+ *                     field, not an allocated reasoning budget.)
  *
  * Fail-closed: any non-abort failure (API error, timeout, schema failure,
  * context overflow) returns shouldBlock=true with unavailable=true.
@@ -36,12 +34,10 @@ import { buildClassifierContents } from './classifier-transcript.js';
 // the underlying API / timeout / context-overflow error.
 const debugLogger = createDebugLogger('CLASSIFIER');
 
-// A classifier timeout is fail-closed: the action is BLOCKED as
-// "unavailable". Too tight a budget therefore turns transient slowness (a
-// slow network, a large transcript, model queueing) into spurious blocks of
-// otherwise-valid AUTO-mode actions. The fast model's p99 is ~1.5s, but the
-// tail is much longer under load, so the budgets are kept generous — we would
-// rather wait a little than fail closed on a healthy call.
+// A timeout is fail-closed (action BLOCKED as "unavailable"), so too tight a
+// budget turns transient slowness into spurious blocks. The fast model's p99
+// is ~1.5s but the tail is long under load, so budgets are kept generous —
+// better to wait than fail closed on a healthy call.
 /** Stage-1 timeout: generous headroom over the fast model's p99 (~1.5s). */
 export const STAGE1_TIMEOUT_MS = 10_000;
 /** Stage-2 timeout: review stage runs a larger prompt; cap infra failure. */
@@ -228,12 +224,10 @@ export async function classifyAction(
       config: {
         temperature: 0,
         maxOutputTokens: 4096,
-        // Thinking disabled in every stage: this is a latency-sensitive
-        // permission gate the user is actively waiting on, and enabling a
-        // reasoning budget makes the review path slower and more expensive
-        // (which directly worsens the fail-closed timeout above). The model
-        // still records its reasoning in the structured `thinking` output
-        // field; it just does not get an allocated reasoning budget.
+        // Thinking off: this gate is latency-sensitive (the user is waiting),
+        // and a reasoning budget would slow the review path and worsen the
+        // fail-closed timeout above. The `thinking` output field still carries
+        // the model's reasoning.
         thinkingConfig: { includeThoughts: false },
       },
     })) as Stage2Response;


### PR DESCRIPTION
Closes #4676

### Problem

In AUTO approval mode, the two-stage classifier (`packages/core/src/permissions/classifier.ts`) **fails closed** on timeout: a timed-out judge call returns `shouldBlock=true, unavailable=true` and the action is blocked as an infrastructure failure. The previous stage budgets — `STAGE1_TIMEOUT_MS = 3_000` / `STAGE2_TIMEOUT_MS = 10_000` — are tight enough that transient slowness (slow network, large transcript, model queueing) trips them and **spuriously blocks otherwise-valid actions** with "Auto mode classifier unavailable; action blocked for safety".

Separately, stage 2 was the only stage running with `thinkingConfig: { includeThoughts: true }`. For a latency-sensitive permission gate the user is actively waiting on, allocating a reasoning budget makes the review path slower and more expensive — which directly worsens the timeout problem above.

### Changes

- **Loosen timeouts**: `STAGE1_TIMEOUT_MS` 3s → **10s**, `STAGE2_TIMEOUT_MS` 10s → **30s**. A slow-but-healthy classifier call is no longer treated as a hard block. (Fail-closed behavior on genuine failure is unchanged.)
- **Disable thinking in every stage**: stage 2 now uses `thinkingConfig: { includeThoughts: false }`, matching stage 1. The model still records its reasoning in the structured `thinking` output field; it just no longer gets an allocated reasoning budget.
- Updated the module docstring and the stage-2 config test to match.

### Testing

- `packages/core/src/permissions/classifier.test.ts` — 20/20 pass (stage-2 config test updated to assert `includeThoughts: false`).
- `tsc --noEmit` on `@qwen-code/qwen-code-core` — clean.

### Notes / follow-ups (out of scope here)

The timeout values are still fixed constants. Making them configurable, adding an independent per-fetch timeout + retry/stall handling, or scaling the budget with transcript size would further reduce false blocks, but are left as follow-ups to keep this change focused.