### PR TITLE
feat(telemetry): expand daemon telemetry route coverage

### DIFF
--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -350,6 +350,19 @@ function resolveDaemonTelemetryRoute(
   if (mcpDelete?.[1] && req.method === 'DELETE') {
     return { route: 'DELETE /workspace/mcp/servers/:name' };
   }
+  if (req.method === 'POST' && path === '/workspace/auth/device-flow') {
+    return { route: 'POST /workspace/auth/device-flow' };
+  }
+  const deviceFlowDelete = path.match(
+    /^\/workspace\/auth\/device-flow\/([^/]+)$/,
+  );
+  if (deviceFlowDelete?.[1] && req.method === 'DELETE') {
+    return { route: 'DELETE /workspace/auth/device-flow/:id' };
+  }
+  const toolEnable = path.match(/^\/workspace\/tools\/([^/]+)\/enable$/);
+  if (toolEnable?.[1] && req.method === 'POST') {
+    return { route: 'POST /workspace/tools/:name/enable' };
+  }
   return undefined;
 }
 

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -282,11 +282,15 @@ function resolveDaemonTelemetryRoute(
 ):
   | { route: string; sessionId?: string; permissionRequestId?: string }
   | undefined {
-  if (req.method === 'POST' && req.path === '/session') {
+  const path = req.path.replace(/\/$/, '') || '/';
+  if (req.method === 'POST' && path === '/session') {
     return { route: 'POST /session' };
   }
-  const sessionAction = req.path.match(
-    /^\/session\/([^/]+)\/(load|resume|prompt|cancel)$/,
+  if (req.method === 'POST' && path === '/sessions/delete') {
+    return { route: 'POST /sessions/delete' };
+  }
+  const sessionAction = path.match(
+    /^\/session\/([^/]+)\/(load|resume|prompt|cancel|recap|btw|model|shell|detach|approval-mode)$/,
   );
   const sessionActionId = sessionAction?.[1];
   const sessionActionName = sessionAction?.[2];
@@ -296,7 +300,14 @@ function resolveDaemonTelemetryRoute(
       sessionId: sessionActionId,
     };
   }
-  const sessionPermission = req.path.match(
+  const sessionMetadata = path.match(/^\/session\/([^/]+)\/metadata$/);
+  if (sessionMetadata?.[1] && req.method === 'PATCH') {
+    return {
+      route: 'PATCH /session/:id/metadata',
+      sessionId: sessionMetadata[1],
+    };
+  }
+  const sessionPermission = path.match(
     /^\/session\/([^/]+)\/permission\/([^/]+)$/,
   );
   if (
@@ -310,20 +321,34 @@ function resolveDaemonTelemetryRoute(
       permissionRequestId: sessionPermission[2],
     };
   }
-  const globalPermission = req.path.match(/^\/permission\/([^/]+)$/);
+  const globalPermission = path.match(/^\/permission\/([^/]+)$/);
   if (globalPermission?.[1] && req.method === 'POST') {
     return {
       route: 'POST /permission/:requestId',
       permissionRequestId: globalPermission[1],
     };
   }
-  const deleteSession = req.path.match(/^\/session\/([^/]+)$/);
+  const deleteSession = path.match(/^\/session\/([^/]+)$/);
   const deleteSessionId = deleteSession?.[1];
   if (deleteSessionId && req.method === 'DELETE') {
     return { route: 'DELETE /session/:id', sessionId: deleteSessionId };
   }
-  if (req.method === 'GET' && /^\/workspace\/.+\/sessions$/.test(req.path)) {
+  if (req.method === 'GET' && /^\/workspace\/[^/]+\/sessions$/.test(path)) {
     return { route: 'GET /workspace/:id/sessions' };
+  }
+  if (req.method === 'POST' && path === '/workspace/init') {
+    return { route: 'POST /workspace/init' };
+  }
+  const mcpRestart = path.match(/^\/workspace\/mcp\/([^/]+)\/restart$/);
+  if (mcpRestart?.[1] && req.method === 'POST') {
+    return { route: 'POST /workspace/mcp/:server/restart' };
+  }
+  if (req.method === 'POST' && path === '/workspace/mcp/servers') {
+    return { route: 'POST /workspace/mcp/servers' };
+  }
+  const mcpDelete = path.match(/^\/workspace\/mcp\/servers\/([^/]+)$/);
+  if (mcpDelete?.[1] && req.method === 'DELETE') {
+    return { route: 'DELETE /workspace/mcp/servers/:name' };
   }
   return undefined;
 }
@@ -1435,10 +1460,13 @@ export function createServeApp(
       }
       if (!res.writable) {
         if (daemonLog) {
-          daemonLog.warn('session reaped (client disconnected before response)', {
-            sessionId: session.sessionId,
-            attached: session.attached,
-          });
+          daemonLog.warn(
+            'session reaped (client disconnected before response)',
+            {
+              sessionId: session.sessionId,
+              attached: session.attached,
+            },
+          );
         }
         if (!session.attached) {
           // `requireZeroAttaches: true` closes the BQ9tV race: if


### PR DESCRIPTION
## Summary
- 扩展 `resolveDaemonTelemetryRoute` 覆盖所有 daemon 写路由（除 heartbeat），新增 recap、btw、model、shell、detach、approval-mode、metadata、sessions/delete、workspace/init、workspace MCP 路由的 telemetry span
- 修复尾部斜杠不匹配问题：normalize `req.path` 后再做 regex 匹配，避免 `/session/abc/prompt/` 这类请求静默丢失 span
- 修复 workspace sessions regex `.+` → `[^/]+`，防止跨路径段过度匹配

## Test plan
- [ ] 启动 daemon，触发 recap/btw/model 等路由，确认 ARMS 中出现对应 `qwen-code.daemon.request` span
- [ ] 发送带尾部斜杠的请求（如 `POST /session/:id/prompt/`），确认 span 正常生成
- [ ] 确认 heartbeat 路由不产生 span

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)