### PR TITLE
fix(daemon): isolate parallel subAgent text streams in transcript reducer

### DIFF
--- a/packages/cli/src/acp-integration/session/SubAgentTracker.test.ts
+++ b/packages/cli/src/acp-integration/session/SubAgentTracker.test.ts
@@ -719,6 +719,10 @@ describe('SubAgentTracker', () => {
             type: 'text',
             text: 'Hello, this is a response from the model.',
           },
+          _meta: expect.objectContaining({
+            parentToolCallId: 'parent-call-123',
+            subagentType: 'test-subagent',
+          }),
         }),
       );
     });

--- a/packages/cli/src/acp-integration/session/SubAgentTracker.ts
+++ b/packages/cli/src/acp-integration/session/SubAgentTracker.ts
@@ -276,6 +276,8 @@ export class SubAgentTracker {
         event.text,
         'assistant',
         event.thought ?? false,
+        undefined,
+        this.getSubagentMeta(),
       );
     };
   }

--- a/packages/cli/src/acp-integration/session/emitters/MessageEmitter.ts
+++ b/packages/cli/src/acp-integration/session/emitters/MessageEmitter.ts
@@ -69,12 +69,21 @@ export class MessageEmitter extends BaseEmitter {
   async emitAgentThought(
     text: string,
     timestamp?: string | number,
+    subagentMeta?: SubagentMeta,
   ): Promise<void> {
     const epochMs = BaseEmitter.toEpochMs(timestamp);
+    const meta: Record<string, unknown> = {};
+    if (subagentMeta?.parentToolCallId) {
+      meta['parentToolCallId'] = subagentMeta.parentToolCallId;
+    }
+    if (subagentMeta?.subagentType) {
+      meta['subagentType'] = subagentMeta.subagentType;
+    }
+    if (epochMs != null) meta['timestamp'] = epochMs;
     await this.sendUpdate({
       sessionUpdate: 'agent_thought_chunk',
       content: { type: 'text', text },
-      ...(epochMs != null && { _meta: { timestamp: epochMs } }),
+      ...(Object.keys(meta).length > 0 ? { _meta: meta } : {}),
     });
   }
 
@@ -87,12 +96,21 @@ export class MessageEmitter extends BaseEmitter {
   async emitAgentMessage(
     text: string,
     timestamp?: string | number,
+    subagentMeta?: SubagentMeta,
   ): Promise<void> {
     const epochMs = BaseEmitter.toEpochMs(timestamp);
+    const meta: Record<string, unknown> = {};
+    if (subagentMeta?.parentToolCallId) {
+      meta['parentToolCallId'] = subagentMeta.parentToolCallId;
+    }
+    if (subagentMeta?.subagentType) {
+      meta['subagentType'] = subagentMeta.subagentType;
+    }
+    if (epochMs != null) meta['timestamp'] = epochMs;
     await this.sendUpdate({
       sessionUpdate: 'agent_message_chunk',
       content: { type: 'text', text },
-      ...(epochMs != null && { _meta: { timestamp: epochMs } }),
+      ...(Object.keys(meta).length > 0 ? { _meta: meta } : {}),
     });
   }
 
@@ -139,12 +157,13 @@ export class MessageEmitter extends BaseEmitter {
     role: 'user' | 'assistant',
     isThought: boolean = false,
     timestamp?: string | number,
+    subagentMeta?: SubagentMeta,
   ): Promise<void> {
     if (role === 'user') {
       return this.emitUserMessage(text, timestamp);
     }
     return isThought
-      ? this.emitAgentThought(text, timestamp)
-      : this.emitAgentMessage(text, timestamp);
+      ? this.emitAgentThought(text, timestamp, subagentMeta)
+      : this.emitAgentMessage(text, timestamp, subagentMeta);
   }
 }

--- a/packages/cli/src/acp-integration/session/emitters/MessageEmitter.ts
+++ b/packages/cli/src/acp-integration/session/emitters/MessageEmitter.ts
@@ -71,19 +71,14 @@ export class MessageEmitter extends BaseEmitter {
     timestamp?: string | number,
     subagentMeta?: SubagentMeta,
   ): Promise<void> {
-    const epochMs = BaseEmitter.toEpochMs(timestamp);
-    const meta: Record<string, unknown> = {};
-    if (subagentMeta?.parentToolCallId) {
-      meta['parentToolCallId'] = subagentMeta.parentToolCallId;
-    }
-    if (subagentMeta?.subagentType) {
-      meta['subagentType'] = subagentMeta.subagentType;
-    }
-    if (epochMs != null) meta['timestamp'] = epochMs;
+    const _meta = this.buildChunkMeta(
+      BaseEmitter.toEpochMs(timestamp),
+      subagentMeta,
+    );
     await this.sendUpdate({
       sessionUpdate: 'agent_thought_chunk',
       content: { type: 'text', text },
-      ...(Object.keys(meta).length > 0 ? { _meta: meta } : {}),
+      ...(_meta ? { _meta } : {}),
     });
   }
 
@@ -98,19 +93,14 @@ export class MessageEmitter extends BaseEmitter {
     timestamp?: string | number,
     subagentMeta?: SubagentMeta,
   ): Promise<void> {
-    const epochMs = BaseEmitter.toEpochMs(timestamp);
-    const meta: Record<string, unknown> = {};
-    if (subagentMeta?.parentToolCallId) {
-      meta['parentToolCallId'] = subagentMeta.parentToolCallId;
-    }
-    if (subagentMeta?.subagentType) {
-      meta['subagentType'] = subagentMeta.subagentType;
-    }
-    if (epochMs != null) meta['timestamp'] = epochMs;
+    const _meta = this.buildChunkMeta(
+      BaseEmitter.toEpochMs(timestamp),
+      subagentMeta,
+    );
     await this.sendUpdate({
       sessionUpdate: 'agent_message_chunk',
       content: { type: 'text', text },
-      ...(Object.keys(meta).length > 0 ? { _meta: meta } : {}),
+      ...(_meta ? { _meta } : {}),
     });
   }
 
@@ -165,5 +155,20 @@ export class MessageEmitter extends BaseEmitter {
     return isThought
       ? this.emitAgentThought(text, timestamp, subagentMeta)
       : this.emitAgentMessage(text, timestamp, subagentMeta);
+  }
+
+  private buildChunkMeta(
+    epochMs: number | undefined,
+    subagentMeta?: SubagentMeta,
+  ): Record<string, unknown> | undefined {
+    const meta: Record<string, unknown> = {};
+    if (subagentMeta?.parentToolCallId) {
+      meta['parentToolCallId'] = subagentMeta.parentToolCallId;
+    }
+    if (subagentMeta?.subagentType) {
+      meta['subagentType'] = subagentMeta.subagentType;
+    }
+    if (epochMs != null) meta['timestamp'] = epochMs;
+    return Object.keys(meta).length > 0 ? meta : undefined;
   }
 }

--- a/packages/sdk-typescript/src/daemon/ui/normalizer.ts
+++ b/packages/sdk-typescript/src/daemon/ui/normalizer.ts
@@ -409,10 +409,7 @@ function normalizeSessionUpdate(
     case 'agent_message_chunk': {
       const text = getTextContent(update['content']);
       if (!text) return [];
-      const chunkMeta = isRecord(update['_meta']) ? update['_meta'] : undefined;
-      const parentToolCallId = chunkMeta
-        ? getString(chunkMeta, 'parentToolCallId')
-        : undefined;
+      const parentToolCallId = extractParentToolCallId(update);
       return [
         {
           ...base,
@@ -425,20 +422,13 @@ function normalizeSessionUpdate(
     case 'agent_thought_chunk': {
       const text = getTextContent(update['content']);
       if (!text) return [];
-      const thoughtMeta = isRecord(update['_meta'])
-        ? update['_meta']
-        : undefined;
-      const thoughtParentToolCallId = thoughtMeta
-        ? getString(thoughtMeta, 'parentToolCallId')
-        : undefined;
+      const parentToolCallId = extractParentToolCallId(update);
       return [
         {
           ...base,
           type: 'thought.text.delta' as const,
           text,
-          ...(thoughtParentToolCallId
-            ? { parentToolCallId: thoughtParentToolCallId }
-            : {}),
+          ...(parentToolCallId ? { parentToolCallId } : {}),
         },
       ];
     }
@@ -491,6 +481,13 @@ function normalizeSessionUpdate(
         },
       ];
   }
+}
+
+function extractParentToolCallId(
+  update: Record<string, unknown>,
+): string | undefined {
+  const meta = isRecord(update['_meta']) ? update['_meta'] : undefined;
+  return meta ? getString(meta, 'parentToolCallId') : undefined;
 }
 
 function normalizeToolUpdate(

--- a/packages/sdk-typescript/src/daemon/ui/normalizer.ts
+++ b/packages/sdk-typescript/src/daemon/ui/normalizer.ts
@@ -408,11 +408,39 @@ function normalizeSessionUpdate(
     }
     case 'agent_message_chunk': {
       const text = getTextContent(update['content']);
-      return text ? [{ ...base, type: 'assistant.text.delta', text }] : [];
+      if (!text) return [];
+      const chunkMeta = isRecord(update['_meta']) ? update['_meta'] : undefined;
+      const parentToolCallId = chunkMeta
+        ? getString(chunkMeta, 'parentToolCallId')
+        : undefined;
+      return [
+        {
+          ...base,
+          type: 'assistant.text.delta' as const,
+          text,
+          ...(parentToolCallId ? { parentToolCallId } : {}),
+        },
+      ];
     }
     case 'agent_thought_chunk': {
       const text = getTextContent(update['content']);
-      return text ? [{ ...base, type: 'thought.text.delta', text }] : [];
+      if (!text) return [];
+      const thoughtMeta = isRecord(update['_meta'])
+        ? update['_meta']
+        : undefined;
+      const thoughtParentToolCallId = thoughtMeta
+        ? getString(thoughtMeta, 'parentToolCallId')
+        : undefined;
+      return [
+        {
+          ...base,
+          type: 'thought.text.delta' as const,
+          text,
+          ...(thoughtParentToolCallId
+            ? { parentToolCallId: thoughtParentToolCallId }
+            : {}),
+        },
+      ];
     }
     case 'tool_call':
     case 'tool_call_update':

--- a/packages/sdk-typescript/src/daemon/ui/store.ts
+++ b/packages/sdk-typescript/src/daemon/ui/store.ts
@@ -142,6 +142,12 @@ function createState(
       ...(seed.permissionBlockByRequestId ?? {}),
     },
     toolProgress: { ...(seed.toolProgress ?? {}) },
+    activeAssistantBlockByParent: {
+      ...(seed.activeAssistantBlockByParent ?? {}),
+    },
+    activeThoughtBlockByParent: {
+      ...(seed.activeThoughtBlockByParent ?? {}),
+    },
     lastResyncRequired:
       seed.lastResyncRequired !== undefined
         ? { ...seed.lastResyncRequired }

--- a/packages/sdk-typescript/src/daemon/ui/transcript.ts
+++ b/packages/sdk-typescript/src/daemon/ui/transcript.ts
@@ -13,6 +13,7 @@ import type {
   DaemonTranscriptReducerOptions,
   DaemonTranscriptState,
   DaemonUiEvent,
+  DaemonUiTextEvent,
   DaemonUserShellTranscriptBlock,
 } from './types.js';
 import { DAEMON_PLAN_TOOL_CALL_ID } from './types.js';
@@ -42,6 +43,8 @@ export function createDaemonTranscriptState(
     toolBlockByCallId: {},
     trimmedToolNotificationByCallId: {},
     permissionBlockByRequestId: {},
+    activeAssistantBlockByParent: {},
+    activeThoughtBlockByParent: {},
     // PR-E sidechannel: track current tool / approval mode / progress
     toolProgress: {},
     awaitingResync: false,
@@ -98,6 +101,8 @@ export function appendLocalUserTranscriptMessage(
   next.activeUserBlockId = block.id;
   next.activeAssistantBlockId = undefined;
   next.activeThoughtBlockId = undefined;
+  next.activeAssistantBlockByParent = {};
+  next.activeThoughtBlockByParent = {};
   return trimTranscriptState(next);
 }
 
@@ -374,7 +379,24 @@ function appendTextDelta(
   text: string,
   event: DaemonUiEvent,
 ): void {
-  const existing = getWritableBlockById(state, state[activeKey]);
+  const parentId =
+    'parentToolCallId' in event
+      ? (event as DaemonUiTextEvent).parentToolCallId
+      : undefined;
+
+  const parentMap =
+    parentId != null
+      ? kind === 'assistant'
+        ? state.activeAssistantBlockByParent
+        : kind === 'thought'
+          ? state.activeThoughtBlockByParent
+          : undefined
+      : undefined;
+
+  const effectiveId =
+    parentMap && parentId != null ? parentMap[parentId] : state[activeKey];
+
+  const existing = getWritableBlockById(state, effectiveId);
   if (existing && existing.kind === kind) {
     existing.text = appendBoundedText(existing.text, text);
     existing.updatedAt = state.now;
@@ -392,11 +414,29 @@ function appendTextDelta(
   );
   if (kind === 'assistant') block.streaming = true;
   if (kind === 'thought') block.collapsed = true;
+  if (parentId != null) {
+    (block as DaemonTextTranscriptBlock).parentToolCallId = parentId;
+  }
   appendBlock(state, block);
-  state[activeKey] = block.id;
-  if (kind !== 'user') state.activeUserBlockId = undefined;
-  if (kind !== 'assistant') state.activeAssistantBlockId = undefined;
-  if (kind !== 'thought') state.activeThoughtBlockId = undefined;
+
+  if (parentMap && parentId != null) {
+    parentMap[parentId] = block.id;
+  } else {
+    state[activeKey] = block.id;
+  }
+
+  if (parentId != null) {
+    if (kind === 'assistant') {
+      delete state.activeThoughtBlockByParent[parentId];
+    }
+    if (kind === 'thought') {
+      delete state.activeAssistantBlockByParent[parentId];
+    }
+  } else {
+    if (kind !== 'user') state.activeUserBlockId = undefined;
+    if (kind !== 'assistant') state.activeAssistantBlockId = undefined;
+    if (kind !== 'thought') state.activeThoughtBlockId = undefined;
+  }
 }
 
 function finishAssistant(state: DaemonTranscriptState): void {
@@ -406,6 +446,16 @@ function finishAssistant(state: DaemonTranscriptState): void {
     existing.updatedAt = state.now;
   }
   state.activeAssistantBlockId = undefined;
+
+  for (const blockId of Object.values(state.activeAssistantBlockByParent)) {
+    const block = getWritableBlockById(state, blockId);
+    if (block?.kind === 'assistant') {
+      block.streaming = false;
+      block.updatedAt = state.now;
+    }
+  }
+  state.activeAssistantBlockByParent = {};
+  state.activeThoughtBlockByParent = {};
 }
 
 function upsertToolBlock(
@@ -542,7 +592,7 @@ function upsertToolBlock(
   // never points at it. Effective-status keeps the pointer in sync
   // with what was actually written to the block.
   updateCurrentToolPointer(state, event.toolCallId, event.status ?? 'pending');
-  clearActiveText(state);
+  clearActiveText(state, event.parentToolCallId);
 }
 
 /**
@@ -842,6 +892,8 @@ function cloneTranscriptState(
     blocks: state.blocks,
     blockIndexById: state.blockIndexById,
     toolBlockByCallId: { ...state.toolBlockByCallId },
+    activeAssistantBlockByParent: { ...state.activeAssistantBlockByParent },
+    activeThoughtBlockByParent: { ...state.activeThoughtBlockByParent },
     trimmedToolNotificationByCallId: {
       ...state.trimmedToolNotificationByCallId,
     },
@@ -925,6 +977,20 @@ function trimTranscriptState(
   }
   if (!keptIds.has(state.activeThoughtBlockId ?? '')) {
     state.activeThoughtBlockId = undefined;
+  }
+  for (const [parentId, blockId] of Object.entries(
+    state.activeAssistantBlockByParent,
+  )) {
+    if (!keptIds.has(blockId)) {
+      delete state.activeAssistantBlockByParent[parentId];
+    }
+  }
+  for (const [parentId, blockId] of Object.entries(
+    state.activeThoughtBlockByParent,
+  )) {
+    if (!keptIds.has(blockId)) {
+      delete state.activeThoughtBlockByParent[parentId];
+    }
   }
   return state;
 }
@@ -1021,10 +1087,26 @@ function allocateBlockId(state: DaemonTranscriptState, prefix: string): string {
   return id;
 }
 
-function clearActiveText(state: DaemonTranscriptState): void {
-  finishAssistant(state);
-  state.activeUserBlockId = undefined;
-  state.activeThoughtBlockId = undefined;
+function clearActiveText(
+  state: DaemonTranscriptState,
+  parentToolCallId?: string,
+): void {
+  if (parentToolCallId) {
+    const assistId = state.activeAssistantBlockByParent[parentToolCallId];
+    if (assistId) {
+      const block = getWritableBlockById(state, assistId);
+      if (block?.kind === 'assistant') {
+        block.streaming = false;
+        block.updatedAt = state.now;
+      }
+      delete state.activeAssistantBlockByParent[parentToolCallId];
+    }
+    delete state.activeThoughtBlockByParent[parentToolCallId];
+  } else {
+    finishAssistant(state);
+    state.activeUserBlockId = undefined;
+    state.activeThoughtBlockId = undefined;
+  }
 }
 
 function appendBoundedText(existing: string, text: string): string {

--- a/packages/sdk-typescript/src/daemon/ui/transcript.ts
+++ b/packages/sdk-typescript/src/daemon/ui/transcript.ts
@@ -369,6 +369,10 @@ export function selectPendingPermissionBlocks(
   );
 }
 
+// Keyed (parentToolCallId) and scalar (activeAssistantBlockId) paths are
+// fully independent. Neither clears nor finalizes the other's blocks.
+// Only finishAssistant() or clearActiveText() with matching parentToolCallId
+// can finalize keyed-path blocks.
 function appendTextDelta(
   state: DaemonTranscriptState,
   kind: 'user' | 'assistant' | 'thought',

--- a/packages/sdk-typescript/src/daemon/ui/transcript.ts
+++ b/packages/sdk-typescript/src/daemon/ui/transcript.ts
@@ -380,7 +380,7 @@ function appendTextDelta(
   event: DaemonUiEvent,
 ): void {
   const parentId =
-    'parentToolCallId' in event
+    kind !== 'user' && 'parentToolCallId' in event
       ? (event as DaemonUiTextEvent).parentToolCallId
       : undefined;
 
@@ -430,6 +430,14 @@ function appendTextDelta(
       delete state.activeThoughtBlockByParent[parentId];
     }
     if (kind === 'thought') {
+      const evictedAssistId = state.activeAssistantBlockByParent[parentId];
+      if (evictedAssistId) {
+        const evicted = getWritableBlockById(state, evictedAssistId);
+        if (evicted?.kind === 'assistant') {
+          evicted.streaming = false;
+          evicted.updatedAt = state.now;
+        }
+      }
       delete state.activeAssistantBlockByParent[parentId];
     }
   } else {

--- a/packages/sdk-typescript/src/daemon/ui/types.ts
+++ b/packages/sdk-typescript/src/daemon/ui/types.ts
@@ -648,6 +648,7 @@ export interface DaemonTextTranscriptBlock extends DaemonTranscriptBlockBase {
   text: string;
   streaming?: boolean;
   collapsed?: boolean;
+  /** Used by the reducer for per-subAgent block routing; renderers may use it for nesting. */
   parentToolCallId?: string;
 }
 

--- a/packages/sdk-typescript/src/daemon/ui/types.ts
+++ b/packages/sdk-typescript/src/daemon/ui/types.ts
@@ -82,6 +82,7 @@ export interface DaemonUiEventBase {
 export interface DaemonUiTextEvent extends DaemonUiEventBase {
   type: 'user.text.delta' | 'assistant.text.delta' | 'thought.text.delta';
   text: string;
+  parentToolCallId?: string;
 }
 
 export interface DaemonUiUserShellCommandEvent extends DaemonUiEventBase {
@@ -647,6 +648,7 @@ export interface DaemonTextTranscriptBlock extends DaemonTranscriptBlockBase {
   text: string;
   streaming?: boolean;
   collapsed?: boolean;
+  parentToolCallId?: string;
 }
 
 export interface DaemonToolTranscriptBlock extends DaemonTranscriptBlockBase {
@@ -793,6 +795,8 @@ export interface DaemonTranscriptState
   activeUserBlockId?: string;
   activeAssistantBlockId?: string;
   activeThoughtBlockId?: string;
+  activeAssistantBlockByParent: Record<string, string>;
+  activeThoughtBlockByParent: Record<string, string>;
   blockIndexById: Record<string, number>;
   toolBlockByCallId: Record<string, string>;
   trimmedToolNotificationByCallId: Record<string, true>;

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -6018,4 +6018,143 @@ describe('parallel subAgent text interleaving fix', () => {
     expect(thoughtBlocks[0]!.text).toBe('thinking...');
     expect(thoughtBlocks[1]!.text).toBe('new thought');
   });
+
+  it('T10: trimTranscriptState prunes activeThoughtBlockByParent', () => {
+    let state = createDaemonTranscriptState({ now: 1, maxBlocks: 3 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'thought.text.delta',
+          text: 'will be trimmed',
+          parentToolCallId: 'old-thought',
+        },
+        {
+          type: 'tool.update',
+          toolCallId: 'tool-1',
+          title: 'Bash',
+          status: 'running',
+        } as DaemonUiEvent,
+        { type: 'user.text.delta', text: 'user msg' },
+        {
+          type: 'tool.update',
+          toolCallId: 'tool-2',
+          title: 'Read',
+          status: 'running',
+        } as DaemonUiEvent,
+      ],
+      { now: 2 },
+    );
+
+    expect(state.blocks.length).toBeLessThanOrEqual(3);
+    expect(state.activeThoughtBlockByParent['old-thought']).toBeUndefined();
+  });
+
+  it('T11: finishAssistant clears activeThoughtBlockByParent with entries', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'thought.text.delta',
+          text: 'thinking...',
+          parentToolCallId: 'task-T',
+        },
+        {
+          type: 'assistant.text.delta',
+          text: 'responding...',
+          parentToolCallId: 'task-T2',
+        },
+      ],
+      { now: 2 },
+    );
+
+    expect(state.activeThoughtBlockByParent['task-T']).toBeDefined();
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [{ type: 'assistant.done', reason: 'stop' }],
+      { now: 3 },
+    );
+
+    expect(state.activeThoughtBlockByParent).toEqual({});
+    expect(state.activeAssistantBlockByParent).toEqual({});
+  });
+
+  it('T12: assistant evicts thought block for same parent', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'thought.text.delta',
+          text: 'thinking first',
+          parentToolCallId: 'task-E',
+        },
+      ],
+      { now: 2 },
+    );
+
+    expect(state.activeThoughtBlockByParent['task-E']).toBeDefined();
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'assistant.text.delta',
+          text: 'now responding',
+          parentToolCallId: 'task-E',
+        },
+      ],
+      { now: 3 },
+    );
+
+    expect(state.activeThoughtBlockByParent['task-E']).toBeUndefined();
+    expect(state.activeAssistantBlockByParent['task-E']).toBeDefined();
+  });
+
+  it('T13: scoped clearActiveText sets streaming=false on cleared block', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'assistant.text.delta',
+          text: 'A streaming',
+          parentToolCallId: 'task-A',
+        },
+        {
+          type: 'assistant.text.delta',
+          text: 'B streaming',
+          parentToolCallId: 'task-B',
+        },
+        {
+          type: 'tool.update',
+          toolCallId: 'child-tool',
+          title: 'Bash',
+          status: 'running',
+          parentToolCallId: 'task-A',
+        } as DaemonUiEvent,
+      ],
+      { now: 2 },
+    );
+
+    const aBlocks = state.blocks.filter(
+      (b) =>
+        b.kind === 'assistant' &&
+        (b as { parentToolCallId?: string }).parentToolCallId === 'task-A',
+    ) as Array<{ streaming?: boolean }>;
+    expect(aBlocks[0]!.streaming).toBe(false);
+
+    const bBlocks = state.blocks.filter(
+      (b) =>
+        b.kind === 'assistant' &&
+        (b as { parentToolCallId?: string }).parentToolCallId === 'task-B',
+    ) as Array<{ streaming?: boolean }>;
+    expect(bBlocks[0]!.streaming).toBe(true);
+  });
 });

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -5939,4 +5939,83 @@ describe('parallel subAgent text interleaving fix', () => {
     expect(state.activeAssistantBlockByParent).toEqual({});
     expect(state.activeThoughtBlockByParent).toEqual({});
   });
+
+  it('T8: thought evicts assistant block and finalizes streaming for same parent', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'assistant.text.delta',
+          text: 'assistant streaming',
+          parentToolCallId: 'task-Z',
+        },
+      ],
+      { now: 2 },
+    );
+
+    const beforeBlocks = state.blocks.filter(
+      (b) => b.kind === 'assistant',
+    ) as Array<{ streaming?: boolean }>;
+    expect(beforeBlocks[0]!.streaming).toBe(true);
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'thought.text.delta',
+          text: 'now thinking',
+          parentToolCallId: 'task-Z',
+        },
+      ],
+      { now: 3 },
+    );
+
+    expect(state.activeAssistantBlockByParent['task-Z']).toBeUndefined();
+    const afterBlocks = state.blocks.filter(
+      (b) => b.kind === 'assistant',
+    ) as Array<{ streaming?: boolean }>;
+    expect(afterBlocks[0]!.streaming).toBe(false);
+
+    const thoughtBlocks = state.blocks.filter((b) => b.kind === 'thought');
+    expect(thoughtBlocks).toHaveLength(1);
+  });
+
+  it('T9: thought text cleared by scoped clearActiveText from tool.update', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'thought.text.delta',
+          text: 'thinking...',
+          parentToolCallId: 'task-W',
+        },
+        {
+          type: 'tool.update',
+          toolCallId: 'child-tool',
+          title: 'Bash',
+          status: 'running',
+          parentToolCallId: 'task-W',
+        } as DaemonUiEvent,
+        {
+          type: 'thought.text.delta',
+          text: 'new thought',
+          parentToolCallId: 'task-W',
+        },
+      ],
+      { now: 2 },
+    );
+
+    const thoughtBlocks = state.blocks.filter(
+      (b) =>
+        b.kind === 'thought' &&
+        (b as { parentToolCallId?: string }).parentToolCallId === 'task-W',
+    ) as Array<{ text: string }>;
+    expect(thoughtBlocks).toHaveLength(2);
+    expect(thoughtBlocks[0]!.text).toBe('thinking...');
+    expect(thoughtBlocks[1]!.text).toBe('new thought');
+  });
 });

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -6188,6 +6188,14 @@ describe('parallel subAgent text interleaving fix', () => {
     ) as { streaming?: boolean } | undefined;
     expect(scalarBlock?.streaming).toBe(true);
     expect(state.activeAssistantBlockId).toBeDefined();
+
+    const keyedBlock = state.blocks.find(
+      (b) =>
+        b.kind === 'assistant' &&
+        (b as { parentToolCallId?: string }).parentToolCallId === 'task-K',
+    ) as { streaming?: boolean } | undefined;
+    expect(keyedBlock?.streaming).toBe(false);
+    expect(state.activeAssistantBlockByParent['task-K']).toBeUndefined();
   });
 
   it('T15: finishAssistant finalizes both scalar and keyed blocks', () => {

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -5610,3 +5610,333 @@ describe('permission_request normalization for Agent tools', () => {
     );
   });
 });
+
+describe('parallel subAgent text interleaving — normalizer', () => {
+  it('extracts parentToolCallId from _meta on agent_message_chunk', () => {
+    const events = normalizeDaemonEvent({
+      id: 1,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'hello' },
+          _meta: { parentToolCallId: 'task-A', subagentType: 'reviewer' },
+        },
+      },
+    } as never);
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'assistant.text.delta',
+        text: 'hello',
+        parentToolCallId: 'task-A',
+      }),
+    ]);
+  });
+
+  it('extracts parentToolCallId from _meta on agent_thought_chunk', () => {
+    const events = normalizeDaemonEvent({
+      id: 2,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'agent_thought_chunk',
+          content: { type: 'text', text: 'thinking' },
+          _meta: { parentToolCallId: 'task-B' },
+        },
+      },
+    } as never);
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: 'thought.text.delta',
+        text: 'thinking',
+        parentToolCallId: 'task-B',
+      }),
+    ]);
+  });
+
+  it('omits parentToolCallId when _meta is absent', () => {
+    const events = normalizeDaemonEvent({
+      id: 3,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'no meta' },
+        },
+      },
+    } as never);
+    expect(events[0]).not.toHaveProperty('parentToolCallId');
+  });
+
+  it('drops non-string parentToolCallId from _meta', () => {
+    const events = normalizeDaemonEvent({
+      id: 4,
+      v: 1,
+      type: 'session_update',
+      data: {
+        update: {
+          sessionUpdate: 'agent_message_chunk',
+          content: { type: 'text', text: 'bad meta' },
+          _meta: { parentToolCallId: 12345 },
+        },
+      },
+    } as never);
+    expect(events[0]).not.toHaveProperty('parentToolCallId');
+  });
+});
+
+describe('parallel subAgent text interleaving fix', () => {
+  it('T1: separates text chunks by parentToolCallId into independent blocks', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'tool.update',
+          toolCallId: 'agent-task-A',
+          title: 'Agent (code-reviewer)',
+          status: 'running',
+          subagentType: 'code-reviewer',
+        } as DaemonUiEvent,
+        {
+          type: 'tool.update',
+          toolCallId: 'agent-task-B',
+          title: 'Agent (pr-test-analyzer)',
+          status: 'running',
+          subagentType: 'pr-test-analyzer',
+        } as DaemonUiEvent,
+      ],
+      { now: 2 },
+    );
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'assistant.text.delta',
+          text: 'Agent A says: hello ',
+          parentToolCallId: 'agent-task-A',
+        },
+        {
+          type: 'assistant.text.delta',
+          text: 'Agent B says: world ',
+          parentToolCallId: 'agent-task-B',
+        },
+        {
+          type: 'assistant.text.delta',
+          text: 'from agent A',
+          parentToolCallId: 'agent-task-A',
+        },
+        {
+          type: 'assistant.text.delta',
+          text: 'from agent B',
+          parentToolCallId: 'agent-task-B',
+        },
+      ],
+      { now: 3 },
+    );
+
+    const assistantBlocks = state.blocks.filter(
+      (b) => b.kind === 'assistant',
+    ) as Array<{ text: string; parentToolCallId?: string }>;
+
+    expect(assistantBlocks).toHaveLength(2);
+    expect(assistantBlocks[0]!.text).toBe('Agent A says: hello from agent A');
+    expect(assistantBlocks[0]!.parentToolCallId).toBe('agent-task-A');
+    expect(assistantBlocks[1]!.text).toBe('Agent B says: world from agent B');
+    expect(assistantBlocks[1]!.parentToolCallId).toBe('agent-task-B');
+  });
+
+  it('T2: scoped clearActiveText — subAgent A tool does not interrupt subAgent B text', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'assistant.text.delta',
+          text: 'A text ',
+          parentToolCallId: 'task-A',
+        },
+        {
+          type: 'assistant.text.delta',
+          text: 'B text ',
+          parentToolCallId: 'task-B',
+        },
+        {
+          type: 'tool.update',
+          toolCallId: 'child-tool-1',
+          title: 'Bash',
+          status: 'running',
+          parentToolCallId: 'task-A',
+        } as DaemonUiEvent,
+        {
+          type: 'assistant.text.delta',
+          text: 'B continues',
+          parentToolCallId: 'task-B',
+        },
+      ],
+      { now: 2 },
+    );
+
+    const bBlocks = state.blocks.filter(
+      (b) =>
+        b.kind === 'assistant' &&
+        (b as { parentToolCallId?: string }).parentToolCallId === 'task-B',
+    ) as Array<{ text: string }>;
+    expect(bBlocks).toHaveLength(1);
+    expect(bBlocks[0]!.text).toBe('B text B continues');
+  });
+
+  it('T3: finishAssistant sets streaming=false on all keyed-map blocks', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'assistant.text.delta',
+          text: 'A streaming',
+          parentToolCallId: 'task-A',
+        },
+        {
+          type: 'assistant.text.delta',
+          text: 'B streaming',
+          parentToolCallId: 'task-B',
+        },
+      ],
+      { now: 2 },
+    );
+
+    const before = state.blocks.filter((b) => b.kind === 'assistant') as Array<{
+      streaming?: boolean;
+    }>;
+    expect(before[0]!.streaming).toBe(true);
+    expect(before[1]!.streaming).toBe(true);
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [{ type: 'assistant.done', reason: 'stop' }],
+      { now: 3 },
+    );
+
+    const after = state.blocks.filter((b) => b.kind === 'assistant') as Array<{
+      streaming?: boolean;
+    }>;
+    expect(after[0]!.streaming).toBe(false);
+    expect(after[1]!.streaming).toBe(false);
+  });
+
+  it('T4: regression — text without parentToolCallId uses scalar path', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        { type: 'assistant.text.delta', text: 'first ' },
+        { type: 'assistant.text.delta', text: 'second' },
+      ],
+      { now: 2 },
+    );
+
+    const blocks = state.blocks.filter((b) => b.kind === 'assistant');
+    expect(blocks).toHaveLength(1);
+    expect((blocks[0] as { text: string }).text).toBe('first second');
+  });
+
+  it('T5: keyed and scalar paths coexist without interference', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'assistant.text.delta',
+          text: 'subagent text',
+          parentToolCallId: 'task-X',
+        },
+        { type: 'assistant.text.delta', text: 'top-level text' },
+        {
+          type: 'assistant.text.delta',
+          text: ' more subagent',
+          parentToolCallId: 'task-X',
+        },
+      ],
+      { now: 2 },
+    );
+
+    const assistantBlocks = state.blocks.filter(
+      (b) => b.kind === 'assistant',
+    ) as Array<{ text: string; parentToolCallId?: string }>;
+
+    expect(assistantBlocks).toHaveLength(2);
+
+    const subagentBlock = assistantBlocks.find(
+      (b) => b.parentToolCallId === 'task-X',
+    );
+    const topLevelBlock = assistantBlocks.find(
+      (b) => b.parentToolCallId === undefined,
+    );
+    expect(subagentBlock!.text).toBe('subagent text more subagent');
+    expect(topLevelBlock!.text).toBe('top-level text');
+  });
+
+  it('T6: trimTranscriptState prunes stale entries from activeAssistantBlockByParent', () => {
+    let state = createDaemonTranscriptState({ now: 1, maxBlocks: 3 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'assistant.text.delta',
+          text: 'will be trimmed',
+          parentToolCallId: 'old-task',
+        },
+        {
+          type: 'tool.update',
+          toolCallId: 'tool-1',
+          title: 'Bash',
+          status: 'running',
+        } as DaemonUiEvent,
+        { type: 'user.text.delta', text: 'user msg' },
+        {
+          type: 'tool.update',
+          toolCallId: 'tool-2',
+          title: 'Read',
+          status: 'running',
+        } as DaemonUiEvent,
+      ],
+      { now: 2 },
+    );
+
+    expect(state.blocks.length).toBeLessThanOrEqual(3);
+    expect(state.activeAssistantBlockByParent['old-task']).toBeUndefined();
+  });
+
+  it('T7: appendLocalUserTranscriptMessage clears active subAgent text maps', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        {
+          type: 'assistant.text.delta',
+          text: 'streaming...',
+          parentToolCallId: 'task-Y',
+        },
+      ],
+      { now: 2 },
+    );
+
+    expect(state.activeAssistantBlockByParent['task-Y']).toBeDefined();
+
+    state = appendLocalUserTranscriptMessage(state, 'user msg', { now: 3 });
+
+    expect(state.activeAssistantBlockByParent).toEqual({});
+    expect(state.activeThoughtBlockByParent).toEqual({});
+  });
+});

--- a/packages/sdk-typescript/test/unit/daemonUi.test.ts
+++ b/packages/sdk-typescript/test/unit/daemonUi.test.ts
@@ -6157,4 +6157,68 @@ describe('parallel subAgent text interleaving fix', () => {
     ) as Array<{ streaming?: boolean }>;
     expect(bBlocks[0]!.streaming).toBe(true);
   });
+
+  it('T14: scoped clearActiveText preserves scalar activeAssistantBlockId', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        { type: 'assistant.text.delta', text: 'scalar text' },
+        {
+          type: 'assistant.text.delta',
+          text: 'keyed text',
+          parentToolCallId: 'task-K',
+        },
+        {
+          type: 'tool.update',
+          toolCallId: 'child-tool',
+          title: 'Bash',
+          status: 'running',
+          parentToolCallId: 'task-K',
+        } as DaemonUiEvent,
+      ],
+      { now: 2 },
+    );
+
+    const scalarBlock = state.blocks.find(
+      (b) =>
+        b.kind === 'assistant' &&
+        (b as { parentToolCallId?: string }).parentToolCallId === undefined,
+    ) as { streaming?: boolean } | undefined;
+    expect(scalarBlock?.streaming).toBe(true);
+    expect(state.activeAssistantBlockId).toBeDefined();
+  });
+
+  it('T15: finishAssistant finalizes both scalar and keyed blocks', () => {
+    let state = createDaemonTranscriptState({ now: 1 });
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [
+        { type: 'assistant.text.delta', text: 'scalar streaming' },
+        {
+          type: 'assistant.text.delta',
+          text: 'keyed streaming',
+          parentToolCallId: 'task-M',
+        },
+      ],
+      { now: 2 },
+    );
+
+    state = reduceDaemonTranscriptEvents(
+      state,
+      [{ type: 'assistant.done', reason: 'stop' }],
+      { now: 3 },
+    );
+
+    const allAssistant = state.blocks.filter(
+      (b) => b.kind === 'assistant',
+    ) as Array<{ streaming?: boolean }>;
+    expect(allAssistant).toHaveLength(2);
+    expect(allAssistant[0]!.streaming).toBe(false);
+    expect(allAssistant[1]!.streaming).toBe(false);
+    expect(state.activeAssistantBlockId).toBeUndefined();
+    expect(state.activeAssistantBlockByParent).toEqual({});
+  });
 });


### PR DESCRIPTION
## Summary

- **问题**：Daemon 模式下并行 subAgent（如 `/review` 派发的多个 Agent）的文本 chunk 交错合并到同一个 transcript block，导致 WebShell 上显示乱码
- **根因**：`SubAgentTracker.createStreamTextHandler` 发射 `agent_message_chunk` 时不带 `parentToolCallId`；normalizer 不提取；transcript reducer 用单一 `activeAssistantBlockId` 接收所有文本
- **修复**：沿用 tool block 已有的 `parentToolCallId` 隔离模式，将其扩展到 text/thought 事件。不带 `parentToolCallId` 的文本完全走现有 scalar 路径（零行为变更）

### 变更概览

| 层 | 文件 | 变更 |
|----|------|------|
| 发射 | `MessageEmitter.ts` | `emitAgentMessage/emitAgentThought/emitMessage` 加 `subagentMeta?` 参数 |
| 发射 | `SubAgentTracker.ts` | `createStreamTextHandler` 传 `this.getSubagentMeta()` |
| 类型 | `types.ts` | `DaemonUiTextEvent` + `DaemonTextTranscriptBlock` 加 `parentToolCallId?`；State 加两个 keyed map |
| 归一化 | `normalizer.ts` | `agent_message_chunk`/`agent_thought_chunk` 从 `_meta` 提取 `parentToolCallId` |
| 归约 | `transcript.ts` | `appendTextDelta` per-parent 隔离；`finishAssistant` 遍历 map 清 streaming；`clearActiveText` scoped clear；init/clone/trim |
| 状态 | `store.ts` | `createState` 浅拷贝新 map |

### 设计要点

- **per-parent keyed map**：`activeAssistantBlockByParent: Record<string, string>` 按 `parentToolCallId` 维护独立的 active block pointer，与现有 scalar `activeAssistantBlockId` 共存
- **scoped clearActiveText**：subAgent 的 `tool.update` 只清自己 parent 的 text block，不影响其他并行 subAgent
- **finishAssistant 遍历 map**：`assistant.done` 后所有 keyed block 的 `streaming` 设为 false，防止 zombie spinner
- **per-parent mutual exclusion**：assistant↔thought 互斥只在同一 `parentToolCallId` 内生效
- **显式取 key**：`MessageEmitter` 只从 `subagentMeta` 取 `parentToolCallId`/`subagentType`，不 spread 整个对象，防止覆盖 `timestamp` 等保留字段

### 已知局限（后续 PR）

- WebUI `transcriptToMessages.ts` 渲染层需用 `parentToolCallId` 替代位置启发式
- shell/permission/status 事件在并行 subAgent 流期间触发 global clear（不丢文本，仅多一次 block 切换）

Closes #4687

## Test plan

- [x] 211 个 daemonUi 测试通过（原 200 + 新增 11），覆盖：
  - T1: 带 `parentToolCallId` 的交替 delta → 独立 block
  - T2: scoped clearActiveText — A 的 tool call 不打断 B 的 text
  - T3: `assistant.done` 后所有 map block streaming=false
  - T4: 回归保护 — 无 `parentToolCallId` 走 scalar 路径
  - T5: keyed/scalar 路径共存互不干扰
  - T6: trim 后 map 条目被清理
  - T7: 用户消息清空 map
  - 4 个 normalizer 测试：提取/省略/非 string 值处理
- [x] SubAgentTracker 测试验证 `_meta` 含 `parentToolCallId`
- [x] TypeScript 编译零错误（sdk-typescript + cli）

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)