### PR TITLE
fix(cli): fix Space key not working in Arena model selection dialog

### DIFF
--- a/packages/cli/src/ui/components/arena/ArenaStartDialog.tsx
+++ b/packages/cli/src/ui/components/arena/ArenaStartDialog.tsx
@@ -29,6 +29,7 @@ export function ArenaStartDialog({
 }: ArenaStartDialogProps): React.JSX.Element {
   const config = useConfig();
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [selectedKeys, setSelectedKeys] = useState<string[]>([]);
 
   const modelItems = useMemo(() => {
     const allModels = config.getAllConfiguredModels();
@@ -95,6 +96,8 @@ export function ArenaStartDialog({
           <MultiSelect
             items={modelItems}
             initialIndex={0}
+            selectedKeys={selectedKeys}
+            onSelectedKeysChange={setSelectedKeys}
             onConfirm={handleConfirm}
             showNumbers
             showScrollArrows


### PR DESCRIPTION
## What this PR does

Fix Space key not toggling model checkboxes in the `/arena start` model selection dialog. Added controlled state (`selectedKeys` + `onSelectedKeysChange`) to the `MultiSelect` component in `ArenaStartDialog`, so Space key toggles now correctly persist and update the UI.

## Why it's needed

When a user runs `/arena start` without `--models`, a model selection dialog appears. The prompt says "Space to toggle, Enter to confirm", but pressing Space does nothing — checkboxes never toggle. This is because `MultiSelect` is a controlled component that requires external state management via `selectedKeys` and `onSelectedKeysChange` props, but `ArenaStartDialog` was not providing them. Without these props, `onSelectedKeysChange` is `undefined`, so the toggle call silently fails and the UI never updates.

## Reviewer Test Plan

### How to verify

1. Run `qwen` in any git repository
2. Type `/arena start` (without `--models` flag)
3. The model selection dialog appears with a list of configured models
4. Press Space on a model → checkbox should toggle between `[ ]` and `[✓]`
5. Select 2+ models, press Enter → Arena session starts normally with the selected models

### Evidence (Before & After)

**Before:** Pressing Space in the model selection dialog does nothing. Checkboxes remain unchecked regardless of key presses.

**After:** Pressing Space correctly toggles the checkbox for the highlighted model. Multiple models can be selected and confirmed with Enter.

<!-- Screenshots: upload via GitHub web interface by dragging images here -->

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

### Environment (optional)

Local runtime: `npm run bundle` → `node dist/cli.js`

## Risk & Scope

- Main risk or tradeoff: None — this is a minimal 3-line fix adding missing props to an existing component.
- Not validated / out of scope: Windows and Linux not locally tested, but the fix is platform-independent React state management.
- Breaking changes / migration notes: None.

## Linked Issues

Fixes #4692

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复了 `/arena start` 模型选择对话框中 Space 键无法切换复选框的问题。为 `ArenaStartDialog` 中的 `MultiSelect` 组件添加了受控状态（`selectedKeys` + `onSelectedKeysChange`），使 Space 键切换能正确持久化并更新 UI。

## 为什么需要这个修复

当用户运行 `/arena start`（不带 `--models` 参数）时，会弹出模型选择对话框。提示文字写着"Space to toggle, Enter to confirm"，但按下 Space 键什么都不会发生——复选框永远不会切换。这是因为 `MultiSelect` 是一个受控组件，需要通过 `selectedKeys` 和 `onSelectedKeysChange` props 进行外部状态管理，但 `ArenaStartDialog` 没有提供这些 props。缺少这些 props 时，`onSelectedKeysChange` 为 `undefined`，切换调用静默失败，UI 永远不会更新。

## 审阅者测试计划

### 如何验证

1. 在任意 git 仓库中运行 `qwen`
2. 输入 `/arena start`（不带 `--models` 参数）
3. 模型选择对话框出现，显示已配置的模型列表
4. 按 Space 键 → 复选框应在 `[ ]` 和 `[✓]` 之间切换
5. 选择 2 个以上模型，按 Enter → Arena 会话正常启动

### 测试环境

本地运行：`npm run bundle` → `node dist/cli.js`

## 风险和范围

- 主要风险：无——这是一个最小的 3 行修复，仅为现有组件添加缺失的 props。
- 未验证/超出范围：Windows 和 Linux 未在本地测试，但修复内容是与平台无关的 React 状态管理。
- 破坏性变更/迁移说明：无。

## 关联 Issue

修复 #4692

</details>