### PR TITLE
fix(daemon): auto-recover transcript on ring_evicted resync

### DIFF
--- a/packages/sdk-typescript/src/daemon/ui/transcript.ts
+++ b/packages/sdk-typescript/src/daemon/ui/transcript.ts
@@ -316,7 +316,7 @@ function handleStateResyncRequired(
   appendStatusBlock(
     state,
     'error',
-    `State resync required: ${formatMissedRange(event.lastDeliveredId, event.earliestAvailableId)}. Reload the session to recover.`,
+    `State resync required: ${formatMissedRange(event.lastDeliveredId, event.earliestAvailableId)}.`,
     event,
   );
 }

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.test.tsx
@@ -1934,7 +1934,7 @@ describe('DaemonSessionProvider', () => {
     ]);
   });
 
-  it('clears awaitingResync on replay_complete after ring-evicted resync', async () => {
+  it('resets store on ring-evicted resync so replay events rebuild transcript', async () => {
     const liveDelivered = createDeferred<void>();
     const session = createMockSession({
       lastEventId: 10,
@@ -1951,12 +1951,23 @@ describe('DaemonSessionProvider', () => {
           },
         };
         yield {
+          id: 12,
           v: 1,
-          type: 'replay_complete',
-          data: { replayedCount: 0 },
+          type: 'session_update',
+          data: {
+            update: {
+              sessionUpdate: 'agent_message_chunk',
+              content: { type: 'text', text: 'replayed history' },
+            },
+          },
         };
         yield {
-          id: 12,
+          v: 1,
+          type: 'replay_complete',
+          data: { replayedCount: 1 },
+        };
+        yield {
+          id: 13,
           v: 1,
           type: 'session_update',
           data: {
@@ -1999,7 +2010,19 @@ describe('DaemonSessionProvider', () => {
       expect.arrayContaining([
         expect.objectContaining({
           kind: 'assistant',
+          text: 'replayed history',
+        }),
+        expect.objectContaining({
+          kind: 'assistant',
           text: 'live after replay',
+        }),
+      ]),
+    );
+    expect(blocks).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          kind: 'error',
+          text: expect.stringContaining('State resync required'),
         }),
       ]),
     );
@@ -2078,7 +2101,7 @@ describe('DaemonSessionProvider', () => {
       await firstStreamDone.promise;
       await flushPromises();
     });
-    expect(blocks).toEqual(
+    expect(blocks).not.toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           kind: 'error',

--- a/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
+++ b/packages/webui/src/daemon/session/DaemonSessionProvider.tsx
@@ -508,12 +508,11 @@ export function DaemonSessionProvider({
                     : undefined;
                 setPromptStatus('idle');
                 clearPassiveAssistantDoneTimer(passiveAssistantDoneTimerRef);
+                store.reset();
                 if (reason === 'epoch_reset') {
-                  store.reset();
                   activeSession.setLastEventId(0);
                 } else if (reason !== 'ring_evicted') {
                   resyncRequested = true;
-                  store.reset();
                   session = undefined;
                   sessionRef.current = undefined;
                   setConnection((current) => ({


### PR DESCRIPTION
## Summary

- When a WebUI client reconnects with a stale SSE cursor past the EventBus ring buffer, the daemon emits `state_resync_required(ring_evicted)`. Previously the provider did nothing for this reason — the reducer's `awaitingResync` latch silently dropped all subsequent ring replay events, leaving the transcript with a permanent history gap.
- Hoist `store.reset()` before the reason-specific branches so it runs for all resync reasons including `ring_evicted`. This clears the latch and empties the stale transcript, allowing ring replay events to rebuild it from the surviving ring contents (up to 8000 events).
- Remove the misleading "Reload the session to recover." from the resync error message — reloading re-triggers ring eviction for long sessions, and the WebUI now auto-recovers.

## Test plan

- [x] Updated "resets store on ring-evicted resync so replay events rebuild transcript" — verifies replay events are processed (not dropped) and error block is cleared by reset
- [x] Updated "clears ring-evicted awaitingResync on same-session reattach" — verifies error block is cleared by reset before stream errors
- [x] `npx vitest run test/unit/daemonUi.test.ts` — 200 tests passed (no regression on error message assertions)
- [x] `npx vitest run src/daemon/session/DaemonSessionProvider.test.tsx` — 37 tests passed

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)