### PR TITLE
fix(core): explicitly set stream: false in non-streaming requests

### DIFF
--- a/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.test.ts
@@ -149,6 +149,7 @@ describe('ContentGenerationPipeline', () => {
         expect.objectContaining({
           model: 'test-model',
           messages: mockMessages,
+          stream: false,
           temperature: 0.7,
           top_p: 0.9,
           max_tokens: 1000,

--- a/packages/core/src/core/openaiContentGenerator/pipeline.ts
+++ b/packages/core/src/core/openaiContentGenerator/pipeline.ts
@@ -325,12 +325,16 @@ export class ContentGenerationPipeline {
       ...this.buildGenerateContentConfig(request),
     };
 
-    // Add streaming options if present
     if (isStreaming) {
       (
         baseRequest as unknown as OpenAI.Chat.ChatCompletionCreateParamsStreaming
       ).stream = true;
       baseRequest.stream_options = { include_usage: true };
+    } else {
+      // Explicit false required: some gateways default to SSE when the field is absent.
+      (
+        baseRequest as unknown as OpenAI.Chat.ChatCompletionCreateParamsNonStreaming
+      ).stream = false;
     }
 
     // Add tools if present and non-empty.


### PR DESCRIPTION
## Summary

- Non-streaming requests (e.g. recap side-queries) now explicitly include `stream: false` in the request body
- Fixes compatibility with gateways that default to SSE streaming when the `stream` field is absent (violating OpenAI spec `default: false`)
- Root cause: `buildRequest()` only set `stream: true` for streaming paths, leaving the field undefined for non-streaming — gateway returned SSE chunks that the SDK's JSON parser couldn't handle → `content: null`

## Test plan

- [x] Existing pipeline tests pass (42 tests)
- [x] New assertion verifies `stream: false` is present in non-streaming request payload
- [x] Full openaiContentGenerator test suite passes (425 tests, 15 files)

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)