### PR TITLE
fix(core): allow intentional foreground sleep for backoff

### DIFF
--- a/integration-tests/cli/sleep-interception.test.ts
+++ b/integration-tests/cli/sleep-interception.test.ts
@@ -53,6 +53,25 @@ describe('sleep-interception', () => {
     expect(result.toLowerCase()).not.toContain('blocked');
   }, 30000);
 
+  it('should allow retrying blocked sleep with an intentional sleep comment', async () => {
+    rig = new TestRig();
+    await rig.setup('sleep-intentional-retry');
+
+    const result = await rig.run(
+      'Run this exact shell command first: sleep 5. ' +
+        'If the command is blocked, retry with this exact shell command: ' +
+        'sleep 2 # intentional-sleep: wait for MCP rate limit reset. ' +
+        'Then say "DONE".',
+    );
+
+    validateModelOutput(result, null, 'sleep intentional retry');
+
+    const foundShell = await rig.waitForToolCall('run_shell_command');
+    expect(foundShell).toBeTruthy();
+
+    expect(result.toLowerCase()).toContain('done');
+  }, 30000);
+
   it('should block sleep >= 2s even when followed by a trailing comment', async () => {
     // The `trimTrailingShellComment` state machine strips trailing `#...`
     // comments before matching the sleep pattern, so a model trying to

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -5514,7 +5514,8 @@ describe('detectBlockedSleepPattern', () => {
 
   it('blocks sleep followed by a top-level shell comment', () => {
     // Shell ignores trailing comments, so these are equivalent to
-    // standalone foreground sleeps and must not bypass the guard.
+    // standalone foreground sleeps unless they use the explicit
+    // intentional-sleep escape hatch.
     expect(detectBlockedSleepPattern('sleep 5 # wait')).toBe(
       'standalone sleep 5',
     );
@@ -5525,6 +5526,50 @@ describe('detectBlockedSleepPattern', () => {
       'standalone sleep 2s',
     );
     expect(detectBlockedSleepPattern('sleep 5 && echo ok # trailing')).toBe(
+      'sleep 5 followed by: echo ok',
+    );
+  });
+
+  it('allows standalone sleep with an intentional sleep comment', () => {
+    expect(
+      detectBlockedSleepPattern(
+        'sleep 5 # intentional-sleep: wait for MCP rate limit reset',
+      ),
+    ).toBeNull();
+    expect(
+      detectBlockedSleepPattern(
+        'sleep 2s # intentional-sleep: deliberate rate limit backoff',
+      ),
+    ).toBeNull();
+  });
+
+  it('requires a meaningful intentional sleep reason', () => {
+    expect(detectBlockedSleepPattern('sleep 5 # intentional-sleep:')).toBe(
+      'standalone sleep 5',
+    );
+    expect(detectBlockedSleepPattern('sleep 5 # intentional-sleep: wait')).toBe(
+      'standalone sleep 5',
+    );
+  });
+
+  it('does not allow intentional sleep comments on leading sleep chains', () => {
+    expect(
+      detectBlockedSleepPattern(
+        'sleep 5 && echo ok # intentional-sleep: wait for rate limit reset',
+      ),
+    ).toBe('sleep 5 followed by: echo ok');
+  });
+
+  it('does not allow intentional sleep comments to hide newline commands', () => {
+    expect(
+      detectBlockedSleepPattern(
+        'sleep 5 # intentional-sleep: wait for rate limit reset\necho ok',
+      ),
+    ).toBe('sleep 5 followed by: echo ok');
+  });
+
+  it('preserves commands after a shell comment newline', () => {
+    expect(detectBlockedSleepPattern('sleep 5 # wait\necho ok')).toBe(
       'sleep 5 followed by: echo ok',
     );
   });

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -5541,6 +5541,11 @@ describe('detectBlockedSleepPattern', () => {
         'sleep 2s # intentional-sleep: deliberate rate limit backoff',
       ),
     ).toBeNull();
+    expect(
+      detectBlockedSleepPattern(
+        'sleep 10m # intentional-sleep: wait for MCP rate limit reset',
+      ),
+    ).toBeNull();
   });
 
   it('requires a meaningful intentional sleep reason', () => {
@@ -5550,6 +5555,20 @@ describe('detectBlockedSleepPattern', () => {
     expect(detectBlockedSleepPattern('sleep 5 # intentional-sleep: wait')).toBe(
       'standalone sleep 5',
     );
+    expect(
+      detectBlockedSleepPattern('sleep 5 # intentional-sleep: 1234567'),
+    ).toBe('standalone sleep 5');
+    expect(
+      detectBlockedSleepPattern('sleep 5 # intentional-sleep: 12345678'),
+    ).toBeNull();
+  });
+
+  it('blocks intentional sleep comments above the duration cap', () => {
+    expect(
+      detectBlockedSleepPattern(
+        'sleep 601s # intentional-sleep: wait for MCP rate limit reset',
+      ),
+    ).toBe('standalone sleep 601s');
   });
 
   it('does not allow intentional sleep comments on leading sleep chains', () => {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -186,6 +186,27 @@ describe('ShellTool', () => {
       expect(overCapError).not.toContain('add a trailing comment like');
     });
 
+    it('should allow sleep with a valid intentional sleep comment', async () => {
+      const error = shellTool.validateToolParams({
+        command: 'sleep 5 # intentional-sleep: wait for MCP rate limit reset',
+        is_background: false,
+      });
+
+      expect(error).toBeNull();
+    });
+
+    it('should not suggest the intentional sleep comment for sleep chains', async () => {
+      const error = shellTool.validateToolParams({
+        command: 'sleep 5 && echo ok',
+        is_background: false,
+      });
+
+      expect(error).toContain(
+        'intentional-sleep escape hatch only applies to standalone sleep commands',
+      );
+      expect(error).not.toContain('# intentional-sleep:');
+    });
+
     it('should throw an error for a relative directory path', async () => {
       expect(() =>
         shellTool.build({
@@ -495,6 +516,15 @@ describe('ShellTool', () => {
         'Background shell commands must not end with a bare "&". Remove the trailing "&" and rely on is_background: true instead.',
       );
       expect(mockShellExecutionService).not.toHaveBeenCalled();
+    });
+
+    it('keeps pre-existing comment trimming behavior for managed background validation', async () => {
+      const invocation = shellTool.build({
+        command: 'echo ok # note\nsleep 5 &',
+        is_background: true,
+      });
+
+      expect(invocation).toBeDefined();
     });
 
     it('preserves a trailing && (logical AND would be syntactically broken otherwise)', async () => {

--- a/packages/core/src/tools/shell.test.ts
+++ b/packages/core/src/tools/shell.test.ts
@@ -160,6 +160,32 @@ describe('ShellTool', () => {
       ).toThrow('Command cannot be empty.');
     });
 
+    it('should mention the intentional sleep escape hatch when blocking sleep', async () => {
+      const error = shellTool.validateToolParams({
+        command: 'sleep 5',
+        is_background: false,
+      });
+
+      expect(error).toContain('intentional-sleep:');
+    });
+
+    it('should explain rejected intentional sleep comments', async () => {
+      const shortReasonError = shellTool.validateToolParams({
+        command: 'sleep 5 # intentional-sleep: wait',
+        is_background: false,
+      });
+      const overCapError = shellTool.validateToolParams({
+        command:
+          'sleep 601s # intentional-sleep: wait for MCP rate limit reset',
+        is_background: false,
+      });
+
+      expect(shortReasonError).toContain('reason is too short');
+      expect(shortReasonError).not.toContain('add a trailing comment like');
+      expect(overCapError).toContain('foreground sleeps over 10 minutes');
+      expect(overCapError).not.toContain('add a trailing comment like');
+    });
+
     it('should throw an error for a relative directory path', async () => {
       expect(() =>
         shellTool.build({

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -1027,6 +1027,17 @@ export function buildLongRunningForegroundHint(elapsedMs: number): string {
  * fine).
  */
 export function detectBlockedSleepPattern(command: string): string | null {
+  return detectBlockedSleepPatternDetails(command)?.description ?? null;
+}
+
+type BlockedSleepPatternDetails = {
+  description: string;
+  intentionalSleepRejection?: string;
+};
+
+function detectBlockedSleepPatternDetails(
+  command: string,
+): BlockedSleepPatternDetails | null {
   // Strip trailing shell comments first; otherwise `sleep 5 # wait` would
   // present `# wait` as the suffix, which `getSleepSequentialSeparator`
   // rejects (only &&/||/;/\n are recognized), letting the foreground sleep
@@ -1061,16 +1072,32 @@ export function detectBlockedSleepPattern(command: string): string | null {
   if (separator === null) return null;
 
   const rest = separator.rest.trim();
-  if (
-    !rest &&
-    secs <= MAX_INTENTIONAL_SLEEP_SECONDS &&
-    hasIntentionalSleepComment(comment)
-  ) {
-    return null;
-  }
-  return rest
+  const description = rest
     ? `sleep ${durationToken} followed by: ${rest}`
     : `standalone sleep ${durationToken}`;
+  if (!rest && hasIntentionalSleepCommentPrefix(comment)) {
+    const reason = getIntentionalSleepReason(comment);
+    if (reason === null) {
+      return {
+        description,
+        intentionalSleepRejection:
+          'The intentional-sleep comment was recognized, but the reason is too short; explain why the delay is needed after `intentional-sleep:`.',
+      };
+    }
+    if (secs > MAX_INTENTIONAL_SLEEP_SECONDS) {
+      return {
+        description,
+        intentionalSleepRejection:
+          'The intentional-sleep comment was recognized, but foreground sleeps over 10 minutes are not allowed; use is_background: true or Monitor for longer waits.',
+      };
+    }
+    debugLogger.debug('intentional sleep allowed', {
+      durationSeconds: secs,
+      reason,
+    });
+    return null;
+  }
+  return { description };
 }
 
 const INTENTIONAL_SLEEP_COMMENT_PREFIX = 'intentional-sleep:';
@@ -1078,14 +1105,20 @@ const MAX_INTENTIONAL_SLEEP_SECONDS = 10 * 60;
 // Require a real reason, not a trivial opt-out like "wait".
 const MIN_INTENTIONAL_SLEEP_REASON_LENGTH = 8;
 
-function hasIntentionalSleepComment(comment: string | null): boolean {
+function hasIntentionalSleepCommentPrefix(comment: string | null): boolean {
   if (comment === null) return false;
 
+  return comment.trim().startsWith(INTENTIONAL_SLEEP_COMMENT_PREFIX);
+}
+
+function getIntentionalSleepReason(comment: string | null): string | null {
+  if (comment === null) return null;
+
   const trimmed = comment.trim();
-  if (!trimmed.startsWith(INTENTIONAL_SLEEP_COMMENT_PREFIX)) return false;
+  if (!trimmed.startsWith(INTENTIONAL_SLEEP_COMMENT_PREFIX)) return null;
 
   const reason = trimmed.slice(INTENTIONAL_SLEEP_COMMENT_PREFIX.length).trim();
-  return reason.length >= MIN_INTENTIONAL_SLEEP_REASON_LENGTH;
+  return reason.length >= MIN_INTENTIONAL_SLEEP_REASON_LENGTH ? reason : null;
 }
 
 function parseSleepDurationToSeconds(token: string): number | null {
@@ -4326,16 +4359,19 @@ export class ShellTool extends BaseDeclarativeTool<
     // `-c` script. This matches every other sensitive check in this file
     // (directory, read-only, command-root extraction, etc.).
     if (!params.is_background) {
-      const sleepPattern = detectBlockedSleepPattern(
+      const sleepPattern = detectBlockedSleepPatternDetails(
         stripShellWrapper(params.command),
       );
       if (sleepPattern !== null) {
+        const intentionalSleepGuidance =
+          sleepPattern.intentionalSleepRejection ??
+          'If you genuinely need a standalone delay (rate limiting, deliberate pacing), ' +
+            'add a trailing comment like `# intentional-sleep: wait for MCP rate limit reset` (up to 10 minutes).';
         return (
-          `Blocked: ${sleepPattern}. ` +
+          `Blocked: ${sleepPattern.description}. ` +
           'Run blocking commands in the background with is_background: true. ' +
           'For streaming events (watching logs, polling APIs), use the Monitor tool. ' +
-          'If you genuinely need a standalone delay (rate limiting, deliberate pacing), ' +
-          'add a trailing comment like `# intentional-sleep: wait for MCP rate limit reset`.'
+          intentionalSleepGuidance
         );
       }
     }

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -1061,13 +1061,21 @@ export function detectBlockedSleepPattern(command: string): string | null {
   if (separator === null) return null;
 
   const rest = separator.rest.trim();
-  if (!rest && hasIntentionalSleepComment(comment)) return null;
+  if (
+    !rest &&
+    secs <= MAX_INTENTIONAL_SLEEP_SECONDS &&
+    hasIntentionalSleepComment(comment)
+  ) {
+    return null;
+  }
   return rest
     ? `sleep ${durationToken} followed by: ${rest}`
     : `standalone sleep ${durationToken}`;
 }
 
 const INTENTIONAL_SLEEP_COMMENT_PREFIX = 'intentional-sleep:';
+const MAX_INTENTIONAL_SLEEP_SECONDS = 10 * 60;
+// Require a real reason, not a trivial opt-out like "wait".
 const MIN_INTENTIONAL_SLEEP_REASON_LENGTH = 8;
 
 function hasIntentionalSleepComment(comment: string | null): boolean {

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -1032,6 +1032,7 @@ export function detectBlockedSleepPattern(command: string): string | null {
 
 type BlockedSleepPatternDetails = {
   description: string;
+  isStandalone: boolean;
   intentionalSleepRejection?: string;
 };
 
@@ -1072,14 +1073,20 @@ function detectBlockedSleepPatternDetails(
   if (separator === null) return null;
 
   const rest = separator.rest.trim();
+  const isStandalone = !rest;
   const description = rest
     ? `sleep ${durationToken} followed by: ${rest}`
     : `standalone sleep ${durationToken}`;
-  if (!rest && hasIntentionalSleepCommentPrefix(comment)) {
-    const reason = getIntentionalSleepReason(comment);
+  const trimmedComment = comment?.trim();
+  if (
+    isStandalone &&
+    trimmedComment?.startsWith(INTENTIONAL_SLEEP_COMMENT_PREFIX)
+  ) {
+    const reason = getIntentionalSleepReason(trimmedComment);
     if (reason === null) {
       return {
         description,
+        isStandalone,
         intentionalSleepRejection:
           'The intentional-sleep comment was recognized, but the reason is too short; explain why the delay is needed after `intentional-sleep:`.',
       };
@@ -1087,6 +1094,7 @@ function detectBlockedSleepPatternDetails(
     if (secs > MAX_INTENTIONAL_SLEEP_SECONDS) {
       return {
         description,
+        isStandalone,
         intentionalSleepRejection:
           'The intentional-sleep comment was recognized, but foreground sleeps over 10 minutes are not allowed; use is_background: true or Monitor for longer waits.',
       };
@@ -1097,7 +1105,7 @@ function detectBlockedSleepPatternDetails(
     });
     return null;
   }
-  return { description };
+  return { description, isStandalone };
 }
 
 const INTENTIONAL_SLEEP_COMMENT_PREFIX = 'intentional-sleep:';
@@ -1105,19 +1113,10 @@ const MAX_INTENTIONAL_SLEEP_SECONDS = 10 * 60;
 // Require a real reason, not a trivial opt-out like "wait".
 const MIN_INTENTIONAL_SLEEP_REASON_LENGTH = 8;
 
-function hasIntentionalSleepCommentPrefix(comment: string | null): boolean {
-  if (comment === null) return false;
-
-  return comment.trim().startsWith(INTENTIONAL_SLEEP_COMMENT_PREFIX);
-}
-
-function getIntentionalSleepReason(comment: string | null): string | null {
-  if (comment === null) return null;
-
-  const trimmed = comment.trim();
-  if (!trimmed.startsWith(INTENTIONAL_SLEEP_COMMENT_PREFIX)) return null;
-
-  const reason = trimmed.slice(INTENTIONAL_SLEEP_COMMENT_PREFIX.length).trim();
+function getIntentionalSleepReason(trimmedComment: string): string | null {
+  const reason = trimmedComment
+    .slice(INTENTIONAL_SLEEP_COMMENT_PREFIX.length)
+    .trim();
   return reason.length >= MIN_INTENTIONAL_SLEEP_REASON_LENGTH ? reason : null;
 }
 
@@ -1187,7 +1186,10 @@ function getSleepSequentialSeparator(suffix: string): { rest: string } | null {
   return null;
 }
 
-function splitTrailingShellComment(command: string): {
+function splitTrailingShellComment(
+  command: string,
+  keepCommandsAfterCommentNewline = true,
+): {
   command: string;
   comment: string | null;
 } {
@@ -1279,7 +1281,7 @@ function splitTrailingShellComment(command: string): {
       const newlineIndex = command.indexOf('\n', i + 1);
       return {
         command:
-          newlineIndex === -1
+          newlineIndex === -1 || !keepCommandsAfterCommentNewline
             ? command.slice(0, i)
             : command.slice(0, i) + command.slice(newlineIndex),
         comment:
@@ -1294,7 +1296,7 @@ function splitTrailingShellComment(command: string): {
 }
 
 function trimTrailingShellComment(command: string): string {
-  return splitTrailingShellComment(command).command;
+  return splitTrailingShellComment(command, false).command;
 }
 
 function hasTopLevelTrailingBackgroundOperator(command: string): boolean {
@@ -4365,8 +4367,10 @@ export class ShellTool extends BaseDeclarativeTool<
       if (sleepPattern !== null) {
         const intentionalSleepGuidance =
           sleepPattern.intentionalSleepRejection ??
-          'If you genuinely need a standalone delay (rate limiting, deliberate pacing), ' +
-            'add a trailing comment like `# intentional-sleep: wait for MCP rate limit reset` (up to 10 minutes).';
+          (sleepPattern.isStandalone
+            ? 'If you genuinely need a standalone delay (rate limiting, deliberate pacing), ' +
+              'add a trailing comment like `# intentional-sleep: wait for MCP rate limit reset` (up to 10 minutes).'
+            : 'The intentional-sleep escape hatch only applies to standalone sleep commands; split follow-up commands into a separate invocation.');
         return (
           `Blocked: ${sleepPattern.description}. ` +
           'Run blocking commands in the background with is_background: true. ' +

--- a/packages/core/src/tools/shell.ts
+++ b/packages/core/src/tools/shell.ts
@@ -1022,7 +1022,7 @@ export function buildLongRunningForegroundHint(elapsedMs: number): string {
 /**
  * Detect standalone or leading `sleep N` patterns that should use Monitor
  * instead. Catches `sleep 5`, `sleep 2.5`, `sleep 2s`,
- * `sleep 5 && check`, `sleep 5; check`, `sleep 5 # wait` — but not sleep
+ * `sleep 5 && check`, `sleep 5; check`, `sleep 5 # wait` -- but not sleep
  * inside pipelines, subshells, backgrounded commands, or scripts (those are
  * fine).
  */
@@ -1032,7 +1032,9 @@ export function detectBlockedSleepPattern(command: string): string | null {
   // rejects (only &&/||/;/\n are recognized), letting the foreground sleep
   // bypass the guard. Shell ignores top-level trailing comments, so for the
   // purposes of detection they are equivalent to end-of-command.
-  const trimmed = trimTrailingShellComment(command).trim();
+  const { command: uncommentedCommand, comment } =
+    splitTrailingShellComment(command);
+  const trimmed = uncommentedCommand.trim();
   if (!trimmed.startsWith('sleep')) return null;
   const afterSleep = trimmed.slice('sleep'.length);
   if (!afterSleep || !/\s/.test(afterSleep[0]!)) return null;
@@ -1059,9 +1061,23 @@ export function detectBlockedSleepPattern(command: string): string | null {
   if (separator === null) return null;
 
   const rest = separator.rest.trim();
+  if (!rest && hasIntentionalSleepComment(comment)) return null;
   return rest
     ? `sleep ${durationToken} followed by: ${rest}`
     : `standalone sleep ${durationToken}`;
+}
+
+const INTENTIONAL_SLEEP_COMMENT_PREFIX = 'intentional-sleep:';
+const MIN_INTENTIONAL_SLEEP_REASON_LENGTH = 8;
+
+function hasIntentionalSleepComment(comment: string | null): boolean {
+  if (comment === null) return false;
+
+  const trimmed = comment.trim();
+  if (!trimmed.startsWith(INTENTIONAL_SLEEP_COMMENT_PREFIX)) return false;
+
+  const reason = trimmed.slice(INTENTIONAL_SLEEP_COMMENT_PREFIX.length).trim();
+  return reason.length >= MIN_INTENTIONAL_SLEEP_REASON_LENGTH;
 }
 
 function parseSleepDurationToSeconds(token: string): number | null {
@@ -1130,7 +1146,10 @@ function getSleepSequentialSeparator(suffix: string): { rest: string } | null {
   return null;
 }
 
-function trimTrailingShellComment(command: string): string {
+function splitTrailingShellComment(command: string): {
+  command: string;
+  comment: string | null;
+} {
   let inSingleQuote = false;
   let inDoubleQuote = false;
   let inBacktick = false;
@@ -1216,11 +1235,25 @@ function trimTrailingShellComment(command: string): string {
       commandSubstitutionDepth === 0 &&
       (i === 0 || /\s/.test(command[i - 1]!))
     ) {
-      return command.slice(0, i);
+      const newlineIndex = command.indexOf('\n', i + 1);
+      return {
+        command:
+          newlineIndex === -1
+            ? command.slice(0, i)
+            : command.slice(0, i) + command.slice(newlineIndex),
+        comment:
+          newlineIndex === -1
+            ? command.slice(i + 1)
+            : command.slice(i + 1, newlineIndex),
+      };
     }
   }
 
-  return command;
+  return { command, comment: null };
+}
+
+function trimTrailingShellComment(command: string): string {
+  return splitTrailingShellComment(command).command;
 }
 
 function hasTopLevelTrailingBackgroundOperator(command: string): boolean {
@@ -4293,7 +4326,8 @@ export class ShellTool extends BaseDeclarativeTool<
           `Blocked: ${sleepPattern}. ` +
           'Run blocking commands in the background with is_background: true. ' +
           'For streaming events (watching logs, polling APIs), use the Monitor tool. ' +
-          'If you genuinely need a delay (rate limiting, deliberate pacing), keep it under 2 seconds.'
+          'If you genuinely need a standalone delay (rate limiting, deliberate pacing), ' +
+          'add a trailing comment like `# intentional-sleep: wait for MCP rate limit reset`.'
         );
       }
     }


### PR DESCRIPTION
## Summary

- What changed: Added an explicit standalone sleep escape hatch for shell commands with a top-level trailing comment in the form `# intentional-sleep: <reason>`, capped at 10 minutes.
- Why it changed: Foreground `sleep >= 2s` interception prevents accidental agent blocking, but it also blocks legitimate MCP/tool rate-limit backoff delays.
- Reviewer focus: Please check the escape hatch remains narrow: ordinary comments still block, sleep chains still block with chain-specific guidance, commands after a comment newline are still detected for sleep interception, existing managed-background comment trimming behavior is preserved, rejected escape hatch attempts get contextual guidance, and sleeps above 10 minutes remain blocked.

## Validation

- Commands run:
  ```bash
  cd packages/core && npx vitest run src/tools/shell.test.ts
  cd packages/core && npm run typecheck
  cd packages/core && npm run build
  npx prettier --check packages/core/src/tools/shell.ts packages/core/src/tools/shell.test.ts integration-tests/cli/sleep-interception.test.ts
  npm run build
  npm run bundle
  npm run typecheck
  npx cross-env QWEN_SANDBOX=false npx vitest run cli/sleep-interception.test.ts
  npm run preflight
  ```
- Prompts / inputs used:
  - `sleep 5 # intentional-sleep: wait for MCP rate limit reset`
  - `sleep 10m # intentional-sleep: wait for MCP rate limit reset`
  - `sleep 601s # intentional-sleep: wait for MCP rate limit reset`
  - `sleep 5 # wait`
  - `sleep 5 && echo ok # intentional-sleep: wait for rate limit reset`
  - `sleep 5 # intentional-sleep: wait for rate limit reset\necho ok`
- Expected result:
  - Standalone intentional sleep up to 10 minutes is allowed.
  - Ordinary comments, chained commands, newline-hidden commands, short reasons, and intentional sleeps above 10 minutes remain blocked by sleep interception.
  - Rejected intentional sleep comments explain whether the reason is too short or the sleep exceeds the foreground cap instead of asking for the same comment again.
  - Chained sleeps do not receive a structurally invalid `# intentional-sleep:` syntax hint; they explain that the escape hatch is standalone-only.
- Observed result:
  - Focused shell tests passed: `packages/core/src/tools/shell.test.ts` passed with 213 tests.
  - Core typecheck passed.
  - Core build passed.
  - Root build passed. It emitted existing lint warnings in `packages/vscode-ide-companion`, but no errors.
  - Root bundle passed.
  - Root typecheck passed.
  - Prettier check for the touched files passed.
  - `integration-tests/cli/sleep-interception.test.ts` now includes a retry-with-`intentional-sleep` integration case. The local run was attempted, but all four cases failed before reaching assertions because the headless CLI hit `[API Error: Connection error. (cause: fetch failed)]`; the existing three cases failed the same way.
  - `npm run preflight` completed format, lint:ci, build, and typecheck, then failed in full test suites outside this change area. The touched shell test passed during the full core run.
- Quickest reviewer verification path:
  - Run the focused shell test file and inspect the `detectBlockedSleepPattern` plus shell validation cases for valid intentional comments, rejected reasons, ordinary comments, chained sleeps, newline-hidden commands, duration cap, reason-length boundary, and preserved managed-background comment trimming.
- Evidence (output, logs, screenshots, video, JSON, before/after, etc.):
  ```text
  cd packages/core && npx vitest run src/tools/shell.test.ts
  Test Files  1 passed (1)
  Tests  213 passed (213)

  cd packages/core && npm run typecheck
  tsc --noEmit
  exit 0

  cd packages/core && npm run build
  Successfully copied files.

  npx prettier --check packages/core/src/tools/shell.ts packages/core/src/tools/shell.test.ts integration-tests/cli/sleep-interception.test.ts
  All matched files use Prettier code style!

  npm run build
  exit 0

  npm run bundle
  All bundle assets copied to dist/

  npm run typecheck
  exit 0

  npx cross-env QWEN_SANDBOX=false npx vitest run cli/sleep-interception.test.ts
  failed before assertions: [API Error: Connection error. (cause: fetch failed)]

  npm run preflight
  format: completed
  lint:ci: completed
  build: completed
  typecheck: completed
  test:ci: failed outside touched files
    - packages/cli src/serve/server.test.ts: many server port null failures, plus NSPasteboard headless crash
    - packages/core enter-worktree.session.integ.test.ts / exit-worktree.session.integ.test.ts: 5 WorktreeSession sidecar assertions failed
    - packages/vscode-ide-companion src/ide-server.test.ts: 12 server-not-running / undefined port failures
  touched shell test passed during the full core run: src/tools/shell.test.ts (207 tests at that time; now 213 after review follow-ups)
  ```

## Scope / Risk

- Main risk or tradeoff: The shell guard now has an explicit comment-based escape hatch, so the parser must keep treating only standalone sleeps as eligible and cap the maximum foreground wait.
- Not covered / not validated: Full `npm run preflight` did not pass locally because unrelated full-suite tests failed in this headless/worktree environment. The sleep-interception integration file could not complete locally because the headless CLI could not reach the model API. No screenshot or video is included because this is a shell validator behavior change with unit coverage.
- Breaking changes / migration notes: None.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ⚠️  | ⚠️  |
| npx      | ✅  | ⚠️  | ⚠️  |
| Docker   | N/A | ⚠️  | ⚠️  |
| Podman   | N/A | N/A | N/A |
| Seatbelt | ⚠️  | N/A | N/A |

Testing matrix notes:

- macOS npm/npx focused validation passed for the touched core shell behavior.
- macOS full `npm run preflight` was attempted but failed in unrelated full-suite tests as described above.
- Windows/Linux/Docker were not tested locally.
- Seatbelt-specific integration was not run; this change is pure shell command validation.

## Linked Issues / Bugs

Fixes #4707

Related: #3684, #3634
