### PR TITLE
fix(cli): avoid exit-time history deep clones

### DIFF
--- a/packages/cli/src/acp-integration/session/Session.test.ts
+++ b/packages/cli/src/acp-integration/session/Session.test.ts
@@ -428,13 +428,14 @@ describe('Session', () => {
         { role: 'user', parts: [{ text: 'first' }] },
         { role: 'model', parts: [{ text: 'first reply' }] },
       ];
-      vi.mocked(mockChat.getHistory).mockReturnValue(history);
+      vi.mocked(mockChat.getHistoryShallow).mockReturnValue(history);
 
       const snapshot = session.captureHistorySnapshot();
       session.restoreHistory(snapshot);
 
       expect(snapshot).toEqual(history);
       expect(mockChat.setHistory).toHaveBeenCalledWith(history);
+      expect(mockChat.getHistory).not.toHaveBeenCalled();
     });
 
     it('rejects history restore while a prompt is running', () => {

--- a/packages/cli/src/acp-integration/session/Session.ts
+++ b/packages/cli/src/acp-integration/session/Session.ts
@@ -428,7 +428,7 @@ export class Session implements SessionContext {
   }
 
   captureHistorySnapshot(): Content[] {
-    return this.config.getGeminiClient()!.getChat().getHistory();
+    return this.config.getGeminiClient()!.getChat().getHistoryShallow();
   }
 
   restoreHistory(history: Content[]): void {

--- a/packages/cli/src/ui/commands/arenaCommand.agentComplete.test.ts
+++ b/packages/cli/src/ui/commands/arenaCommand.agentComplete.test.ts
@@ -66,7 +66,9 @@ describe('arenaCommand agent completion history', () => {
       })),
       getApprovalMode: vi.fn(() => 'default'),
       getGeminiClient: vi.fn(() => ({
-        getHistory: vi.fn(() => []),
+        getChat: vi.fn(() => ({
+          getHistoryShallow: vi.fn(() => []),
+        })),
       })),
       getChatRecordingService: vi.fn(() => chatRecorder),
     };

--- a/packages/cli/src/ui/commands/arenaCommand.ts
+++ b/packages/cli/src/ui/commands/arenaCommand.ts
@@ -195,7 +195,7 @@ function executeArenaCommand(
   // its worktree directory — keeping the parent's would duplicate it.
   let chatHistory;
   try {
-    const fullHistory = config.getGeminiClient().getHistory();
+    const fullHistory = config.getGeminiClient().getChat().getHistoryShallow();
     chatHistory = stripStartupContext(fullHistory);
   } catch {
     debugLogger.debug('Could not retrieve chat history for arena agents');

--- a/packages/cli/src/ui/commands/copyCommand.test.ts
+++ b/packages/cli/src/ui/commands/copyCommand.test.ts
@@ -20,6 +20,7 @@ describe('copyCommand', () => {
   let mockCopyToClipboard: Mock;
   let mockGetChat: Mock;
   let mockGetHistory: Mock;
+  let mockGetHistoryShallow: Mock;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -27,6 +28,7 @@ describe('copyCommand', () => {
     mockCopyToClipboard = vi.mocked(copyToClipboard);
     mockGetChat = vi.fn();
     mockGetHistory = vi.fn();
+    mockGetHistoryShallow = vi.fn();
 
     mockContext = createMockCommandContext({
       services: {
@@ -46,6 +48,7 @@ describe('copyCommand', () => {
 
     mockGetChat.mockReturnValue({
       getHistory: mockGetHistory,
+      getHistoryShallow: mockGetHistoryShallow,
     });
   });
 
@@ -68,7 +71,7 @@ describe('copyCommand', () => {
   it('should return info message when history is empty', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
-    mockGetHistory.mockReturnValue([]);
+    mockGetHistoryShallow.mockReturnValue([]);
 
     const result = await copyCommand.action(mockContext, '');
 
@@ -91,7 +94,7 @@ describe('copyCommand', () => {
       },
     ];
 
-    mockGetHistory.mockReturnValue(historyWithUserOnly);
+    mockGetHistoryShallow.mockReturnValue(historyWithUserOnly);
 
     const result = await copyCommand.action(mockContext, '');
 
@@ -118,7 +121,7 @@ describe('copyCommand', () => {
       },
     ];
 
-    mockGetHistory.mockReturnValue(historyWithAiMessage);
+    mockGetHistoryShallow.mockReturnValue(historyWithAiMessage);
     mockCopyToClipboard.mockResolvedValue(undefined);
 
     const result = await copyCommand.action(mockContext, '');
@@ -144,7 +147,7 @@ describe('copyCommand', () => {
       },
     ];
 
-    mockGetHistory.mockReturnValue(historyWithMultipleParts);
+    mockGetHistoryShallow.mockReturnValue(historyWithMultipleParts);
     mockCopyToClipboard.mockResolvedValue(undefined);
 
     const result = await copyCommand.action(mockContext, '');
@@ -171,7 +174,7 @@ describe('copyCommand', () => {
       },
     ];
 
-    mockGetHistory.mockReturnValue(historyWithMixedParts);
+    mockGetHistoryShallow.mockReturnValue(historyWithMixedParts);
     mockCopyToClipboard.mockResolvedValue(undefined);
 
     const result = await copyCommand.action(mockContext, '');
@@ -202,7 +205,7 @@ describe('copyCommand', () => {
       },
     ];
 
-    mockGetHistory.mockReturnValue(historyWithMultipleAiMessages);
+    mockGetHistoryShallow.mockReturnValue(historyWithMultipleAiMessages);
     mockCopyToClipboard.mockResolvedValue(undefined);
 
     const result = await copyCommand.action(mockContext, '');
@@ -218,7 +221,7 @@ describe('copyCommand', () => {
   it('should copy the last fenced code block with /copy code', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
-    mockGetHistory.mockReturnValue([
+    mockGetHistoryShallow.mockReturnValue([
       {
         role: 'model',
         parts: [
@@ -252,7 +255,7 @@ describe('copyCommand', () => {
   it('should copy a numbered fenced code block with /copy code 2', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
-    mockGetHistory.mockReturnValue([
+    mockGetHistoryShallow.mockReturnValue([
       {
         role: 'model',
         parts: [
@@ -284,7 +287,7 @@ describe('copyCommand', () => {
   it('should copy the last matching language code block with /copy code mermaid', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
-    mockGetHistory.mockReturnValue([
+    mockGetHistoryShallow.mockReturnValue([
       {
         role: 'model',
         parts: [
@@ -320,7 +323,7 @@ describe('copyCommand', () => {
   it('should copy a numbered matching language block with /copy code mermaid 1', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
-    mockGetHistory.mockReturnValue([
+    mockGetHistoryShallow.mockReturnValue([
       {
         role: 'model',
         parts: [
@@ -354,7 +357,7 @@ describe('copyCommand', () => {
   it('should copy a numbered matching language block with /copy mermaid 1', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
-    mockGetHistory.mockReturnValue([
+    mockGetHistoryShallow.mockReturnValue([
       {
         role: 'model',
         parts: [
@@ -387,7 +390,7 @@ describe('copyCommand', () => {
   it('should copy the last LaTeX block with /copy latex', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
-    mockGetHistory.mockReturnValue([
+    mockGetHistoryShallow.mockReturnValue([
       {
         role: 'model',
         parts: [
@@ -419,7 +422,7 @@ describe('copyCommand', () => {
   it('should copy a numbered LaTeX block with /copy latex 1', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
-    mockGetHistory.mockReturnValue([
+    mockGetHistoryShallow.mockReturnValue([
       {
         role: 'model',
         parts: [
@@ -451,7 +454,7 @@ describe('copyCommand', () => {
   it('should not copy LaTeX blocks from fenced code blocks', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
-    mockGetHistory.mockReturnValue([
+    mockGetHistoryShallow.mockReturnValue([
       {
         role: 'model',
         parts: [
@@ -485,7 +488,7 @@ describe('copyCommand', () => {
   it('should copy the last inline LaTeX expression with /copy latex inline', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
-    mockGetHistory.mockReturnValue([
+    mockGetHistoryShallow.mockReturnValue([
       {
         role: 'model',
         parts: [
@@ -515,7 +518,7 @@ describe('copyCommand', () => {
   it('should copy a numbered inline LaTeX expression with /copy latex inline 1', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
-    mockGetHistory.mockReturnValue([
+    mockGetHistoryShallow.mockReturnValue([
       {
         role: 'model',
         parts: [
@@ -545,7 +548,7 @@ describe('copyCommand', () => {
   it('should copy inline LaTeX with the /copy inline-latex alias', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
-    mockGetHistory.mockReturnValue([
+    mockGetHistoryShallow.mockReturnValue([
       {
         role: 'model',
         parts: [{ text: 'Inline math: $\\alpha + \\beta$' }],
@@ -566,7 +569,7 @@ describe('copyCommand', () => {
   it('should not copy inline LaTeX from code fences or display math blocks', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
-    mockGetHistory.mockReturnValue([
+    mockGetHistoryShallow.mockReturnValue([
       {
         role: 'model',
         parts: [
@@ -598,7 +601,7 @@ describe('copyCommand', () => {
   it('should report when /copy latex has no matching LaTeX block', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
-    mockGetHistory.mockReturnValue([
+    mockGetHistoryShallow.mockReturnValue([
       {
         role: 'model',
         parts: [{ text: 'No math block here.' }],
@@ -618,7 +621,7 @@ describe('copyCommand', () => {
   it('should report when /copy code has no matching code block', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 
-    mockGetHistory.mockReturnValue([
+    mockGetHistoryShallow.mockReturnValue([
       {
         role: 'model',
         parts: [{ text: 'No code here.' }],
@@ -645,7 +648,7 @@ describe('copyCommand', () => {
       },
     ];
 
-    mockGetHistory.mockReturnValue(historyWithAiMessage);
+    mockGetHistoryShallow.mockReturnValue(historyWithAiMessage);
     const clipboardError = new Error('Clipboard access denied');
     mockCopyToClipboard.mockRejectedValue(clipboardError);
 
@@ -668,7 +671,7 @@ describe('copyCommand', () => {
       },
     ];
 
-    mockGetHistory.mockReturnValue(historyWithAiMessage);
+    mockGetHistoryShallow.mockReturnValue(historyWithAiMessage);
     const rejectedValue = 'String error';
     mockCopyToClipboard.mockRejectedValue(rejectedValue);
 
@@ -691,7 +694,7 @@ describe('copyCommand', () => {
       },
     ];
 
-    mockGetHistory.mockReturnValue(historyWithEmptyParts);
+    mockGetHistoryShallow.mockReturnValue(historyWithEmptyParts);
 
     const result = await copyCommand.action(mockContext, '');
 

--- a/packages/cli/src/ui/commands/copyCommand.ts
+++ b/packages/cli/src/ui/commands/copyCommand.ts
@@ -346,7 +346,7 @@ export const copyCommand: SlashCommand = {
   supportedModes: ['interactive'] as const,
   action: async (context, _args): Promise<SlashCommandActionReturn | void> => {
     const chat = await context.services.config?.getGeminiClient()?.getChat();
-    const history = chat?.getHistory();
+    const history = chat?.getHistoryShallow();
 
     // Get the last message from the AI (model role)
     const lastAiMessage = history

--- a/packages/cli/src/ui/commands/summaryCommand.ts
+++ b/packages/cli/src/ui/commands/summaryCommand.ts
@@ -72,7 +72,7 @@ export const summaryCommand: SlashCommand = {
 
     const getChatHistory = () => {
       const chat = geminiClient.getChat();
-      return chat.getHistory();
+      return chat.getHistoryShallow();
     };
 
     const validateChatHistory = (


### PR DESCRIPTION
﻿## Summary
- replace remaining exit-adjacent `getHistory()` calls in slash commands and ACP snapshot capture with `getHistoryShallow()`
- keep `restoreHistory()` defensive cloning unchanged while avoiding a second deep clone during snapshot capture
- update copy, arena, and ACP session tests to exercise the shallow history path

Fixes #4698.

## To verify
- `npm run test --workspace=packages/cli -- src/ui/commands/copyCommand.test.ts src/ui/commands/arenaCommand.test.ts src/ui/commands/arenaCommand.agentComplete.test.ts src/acp-integration/session/Session.test.ts`
- `npx eslint packages/cli/src/ui/commands/copyCommand.ts packages/cli/src/ui/commands/summaryCommand.ts packages/cli/src/ui/commands/arenaCommand.ts packages/cli/src/acp-integration/session/Session.ts packages/cli/src/ui/commands/copyCommand.test.ts packages/cli/src/ui/commands/arenaCommand.agentComplete.test.ts packages/cli/src/acp-integration/session/Session.test.ts`
- `npm run typecheck --workspace=packages/cli`
- `git diff --check`