### PR TITLE
fix(cli): bundle extension examples

### DIFF
--- a/scripts/copy_bundle_assets.js
+++ b/scripts/copy_bundle_assets.js
@@ -18,85 +18,119 @@
 // limitations under the License.
 
 import { copyFileSync, existsSync, mkdirSync, statSync } from 'node:fs';
-import { dirname, join, basename } from 'node:path';
+import { dirname, join, basename, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { glob } from 'glob';
 import fs from 'node:fs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const root = join(__dirname, '..');
-const distDir = join(root, 'dist');
-const coreVendorDir = join(root, 'packages', 'core', 'vendor');
+const defaultRoot = join(__dirname, '..');
 
-// Create the dist directory if it doesn't exist
-if (!existsSync(distDir)) {
-  mkdirSync(distDir);
-}
+export function copyBundleAssets({ root = defaultRoot } = {}) {
+  const distDir = join(root, 'dist');
+  const coreVendorDir = join(root, 'packages', 'core', 'vendor');
 
-// Find and copy all .sb files from packages to the root of the dist directory
-const sbFiles = glob.sync('packages/**/*.sb', { cwd: root });
-for (const file of sbFiles) {
-  copyFileSync(join(root, file), join(distDir, basename(file)));
-}
+  // Create the dist directory if it doesn't exist
+  if (!existsSync(distDir)) {
+    mkdirSync(distDir);
+  }
 
-console.log('Copied sandbox profiles to dist/');
+  // Find and copy all .sb files from packages to the root of the dist directory
+  const sbFiles = glob.sync('packages/**/*.sb', { cwd: root });
+  for (const file of sbFiles) {
+    copyFileSync(join(root, file), join(distDir, basename(file)));
+  }
 
-// Copy vendor directory (contains ripgrep binaries)
-console.log('Copying vendor directory...');
-if (existsSync(coreVendorDir)) {
-  const destVendorDir = join(distDir, 'vendor');
-  copyRecursiveSync(coreVendorDir, destVendorDir);
-  console.log('Copied vendor directory to dist/');
-} else {
-  console.warn(`Warning: Vendor directory not found at ${coreVendorDir}`);
-}
+  console.log('Copied sandbox profiles to dist/');
 
-// Copy bundled skills (e.g. /review) so they are available at runtime.
-// In the esbuild bundle, import.meta.url resolves to dist/cli.js, so
-// SkillManager looks for bundled skills at dist/bundled/.
-const bundledSkillsDir = join(
-  root,
-  'packages',
-  'core',
-  'src',
-  'skills',
-  'bundled',
-);
-if (existsSync(bundledSkillsDir)) {
-  const destBundledDir = join(distDir, 'bundled');
-  copyRecursiveSync(bundledSkillsDir, destBundledDir);
-  console.log('Copied bundled skills to dist/bundled/');
-} else {
-  console.warn(
-    `Warning: Bundled skills directory not found at ${bundledSkillsDir}`,
+  // Copy vendor directory (contains ripgrep binaries)
+  console.log('Copying vendor directory...');
+  if (existsSync(coreVendorDir)) {
+    const destVendorDir = join(distDir, 'vendor');
+    copyRecursiveSync(coreVendorDir, destVendorDir);
+    console.log('Copied vendor directory to dist/');
+  } else {
+    console.warn(`Warning: Vendor directory not found at ${coreVendorDir}`);
+  }
+
+  // Copy bundled skills (e.g. /review) so they are available at runtime.
+  // In the esbuild bundle, import.meta.url resolves to dist/cli.js, so
+  // SkillManager looks for bundled skills at dist/bundled/.
+  const bundledSkillsDir = join(
+    root,
+    'packages',
+    'core',
+    'src',
+    'skills',
+    'bundled',
   );
+  if (existsSync(bundledSkillsDir)) {
+    const destBundledDir = join(distDir, 'bundled');
+    copyRecursiveSync(bundledSkillsDir, destBundledDir);
+    console.log('Copied bundled skills to dist/bundled/');
+  } else {
+    console.warn(
+      `Warning: Bundled skills directory not found at ${bundledSkillsDir}`,
+    );
+  }
+
+  // Copy user docs into qc-helper bundled skill so it can reference them at runtime.
+  // The qc-helper skill reads docs from a `docs/` subdirectory relative to its own
+  // directory. In the esbuild bundle this becomes dist/bundled/qc-helper/docs/.
+  const userDocsDir = join(root, 'docs', 'users');
+  if (existsSync(userDocsDir)) {
+    const destDocsDir = join(distDir, 'bundled', 'qc-helper', 'docs');
+    copyRecursiveSync(userDocsDir, destDocsDir);
+    console.log('Copied docs/users/ to dist/bundled/qc-helper/docs/');
+  } else {
+    console.warn(`Warning: User docs directory not found at ${userDocsDir}`);
+  }
+
+  // Copy builtin locales so bundled dist/cli.js can load UI translations at runtime.
+  // Published packages already include these via prepare-package.js; bundle output
+  // should mirror that behavior for local `node dist/cli.js` runs.
+  const localesDir = join(root, 'packages', 'cli', 'src', 'i18n', 'locales');
+  if (existsSync(localesDir)) {
+    const destLocalesDir = join(distDir, 'locales');
+    copyRecursiveSync(localesDir, destLocalesDir);
+    console.log('Copied builtin locales to dist/locales/');
+  } else {
+    console.warn(`Warning: Locales directory not found at ${localesDir}`);
+  }
+
+  // Copy extension templates so bundled dist/cli.js can scaffold
+  // `/extensions new` from the runtime examples directory.
+  const extensionExamplesDir = join(
+    root,
+    'packages',
+    'cli',
+    'src',
+    'commands',
+    'extensions',
+    'examples',
+  );
+  if (existsSync(extensionExamplesDir)) {
+    const destExtensionExamplesDir = join(distDir, 'examples');
+    copyRecursiveSync(extensionExamplesDir, destExtensionExamplesDir);
+    console.log('Copied extension examples to dist/examples/');
+  } else {
+    console.warn(
+      `Warning: Extension examples directory not found at ${extensionExamplesDir}`,
+    );
+  }
+
+  console.log('\n✅ All bundle assets copied to dist/');
 }
 
-// Copy user docs into qc-helper bundled skill so it can reference them at runtime.
-// The qc-helper skill reads docs from a `docs/` subdirectory relative to its own
-// directory. In the esbuild bundle this becomes dist/bundled/qc-helper/docs/.
-const userDocsDir = join(root, 'docs', 'users');
-if (existsSync(userDocsDir)) {
-  const destDocsDir = join(distDir, 'bundled', 'qc-helper', 'docs');
-  copyRecursiveSync(userDocsDir, destDocsDir);
-  console.log('Copied docs/users/ to dist/bundled/qc-helper/docs/');
-} else {
-  console.warn(`Warning: User docs directory not found at ${userDocsDir}`);
+if (isDirectRun()) {
+  copyBundleAssets();
 }
 
-// Copy builtin locales so bundled dist/cli.js can load UI translations at runtime.
-// Published packages already include these via prepare-package.js; bundle output
-// should mirror that behavior for local `node dist/cli.js` runs.
-const localesDir = join(root, 'packages', 'cli', 'src', 'i18n', 'locales');
-if (existsSync(localesDir)) {
-  const destLocalesDir = join(distDir, 'locales');
-  copyRecursiveSync(localesDir, destLocalesDir);
-  console.log('Copied builtin locales to dist/locales/');
-} else {
-  console.warn(`Warning: Locales directory not found at ${localesDir}`);
+function isDirectRun() {
+  return process.argv[1]
+    ? fileURLToPath(import.meta.url) === resolve(process.argv[1])
+    : false;
 }
-
-console.log('\n✅ All bundle assets copied to dist/');
 
 /**
  * Recursively copy directory

--- a/scripts/prepare-package.js
+++ b/scripts/prepare-package.js
@@ -16,191 +16,193 @@ import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const rootDir = path.resolve(__dirname, '..');
+const defaultRootDir = path.resolve(__dirname, '..');
 
-const distDir = path.join(rootDir, 'dist');
-const cliBundlePath = path.join(distDir, 'cli.js');
-const vendorDir = path.join(distDir, 'vendor');
+export function preparePackage({ rootDir = defaultRootDir } = {}) {
+  const distDir = path.join(rootDir, 'dist');
 
-// Verify dist directory and bundle exist
-if (!fs.existsSync(distDir)) {
-  console.error('Error: dist/ directory not found');
-  console.error('Please run "npm run bundle" first');
-  process.exit(1);
+  verifyBundleArtifacts(rootDir, distDir);
+  copyDocumentationFiles(rootDir, distDir);
+  copyLocales(rootDir, distDir);
+  copyExtensionExamples(rootDir, distDir);
+  writeDistPackageJson(rootDir, distDir);
+  printPackageStructure(distDir);
 }
 
-if (!fs.existsSync(cliBundlePath)) {
-  console.error(`Error: Bundle not found at ${cliBundlePath}`);
-  console.error('Please run "npm run bundle" first');
-  process.exit(1);
+if (isDirectRun()) {
+  preparePackage();
 }
 
-if (!fs.existsSync(vendorDir)) {
-  console.error(`Error: Vendor directory not found at ${vendorDir}`);
-  console.error('Please run "npm run bundle" first');
-  process.exit(1);
+function isDirectRun() {
+  return process.argv[1]
+    ? fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+    : false;
 }
 
-const bundledDocsDir = path.join(distDir, 'bundled', 'qc-helper', 'docs');
-if (!fs.existsSync(bundledDocsDir)) {
-  console.error(`Error: Bundled docs not found at ${bundledDocsDir}`);
-  console.error('Please run "npm run bundle" first');
-  process.exit(1);
+function verifyBundleArtifacts(rootDir, distDir) {
+  const requiredPaths = [
+    path.join(distDir, 'cli.js'),
+    path.join(distDir, 'vendor'),
+    path.join(distDir, 'bundled', 'qc-helper', 'docs'),
+  ];
+
+  if (!fs.existsSync(distDir)) {
+    console.error('Error: dist/ directory not found');
+    console.error('Please run "npm run bundle" first');
+    process.exit(1);
+  }
+
+  for (const requiredPath of requiredPaths) {
+    if (!fs.existsSync(requiredPath)) {
+      console.error(
+        `Error: Required package artifact not found: ${requiredPath}`,
+      );
+      console.error('Please run "npm run bundle" first');
+      process.exit(1);
+    }
+  }
 }
 
-// Copy README and LICENSE
-console.log('Copying documentation files...');
-const filesToCopy = ['README.md', 'LICENSE'];
-for (const file of filesToCopy) {
-  const sourcePath = path.join(rootDir, file);
-  const destPath = path.join(distDir, file);
-  if (fs.existsSync(sourcePath)) {
-    fs.copyFileSync(sourcePath, destPath);
-    console.log(`Copied ${file}`);
+function copyDocumentationFiles(rootDir, distDir) {
+  console.log('Copying documentation files...');
+  const filesToCopy = ['README.md', 'LICENSE'];
+  for (const file of filesToCopy) {
+    const sourcePath = path.join(rootDir, file);
+    const destPath = path.join(distDir, file);
+    if (fs.existsSync(sourcePath)) {
+      fs.copyFileSync(sourcePath, destPath);
+      console.log(`Copied ${file}`);
+    } else {
+      console.warn(`Warning: ${file} not found at ${sourcePath}`);
+    }
+  }
+}
+
+function copyLocales(rootDir, distDir) {
+  console.log('Copying locales folder...');
+  const localesSourceDir = path.join(
+    rootDir,
+    'packages',
+    'cli',
+    'src',
+    'i18n',
+    'locales',
+  );
+  const localesDestDir = path.join(distDir, 'locales');
+
+  if (fs.existsSync(localesSourceDir)) {
+    copyRecursiveSync(localesSourceDir, localesDestDir);
+    console.log('Copied locales folder');
   } else {
-    console.warn(`Warning: ${file} not found at ${sourcePath}`);
+    console.warn(`Warning: locales folder not found at ${localesSourceDir}`);
   }
 }
 
-// Copy locales folder
-console.log('Copying locales folder...');
-const localesSourceDir = path.join(
-  rootDir,
-  'packages',
-  'cli',
-  'src',
-  'i18n',
-  'locales',
-);
-const localesDestDir = path.join(distDir, 'locales');
+function copyExtensionExamples(rootDir, distDir) {
+  console.log('Copying extension examples folder...');
+  const extensionExamplesDir = path.join(
+    rootDir,
+    'packages',
+    'cli',
+    'src',
+    'commands',
+    'extensions',
+    'examples',
+  );
+  const extensionExamplesDestDir = path.join(distDir, 'examples');
 
-if (fs.existsSync(localesSourceDir)) {
-  // Recursive copy function
-  function copyRecursiveSync(src, dest) {
-    const stats = fs.statSync(src);
-    if (stats.isDirectory()) {
-      if (!fs.existsSync(dest)) {
-        fs.mkdirSync(dest, { recursive: true });
-      }
-      const entries = fs.readdirSync(src);
-      for (const entry of entries) {
-        const srcPath = path.join(src, entry);
-        const destPath = path.join(dest, entry);
-        copyRecursiveSync(srcPath, destPath);
-      }
-    } else {
-      fs.copyFileSync(src, dest);
-    }
+  if (fs.existsSync(extensionExamplesDir)) {
+    copyRecursiveSync(extensionExamplesDir, extensionExamplesDestDir);
+    console.log('Copied extension examples folder');
+  } else {
+    console.warn(
+      `Warning: extension examples folder not found at ${extensionExamplesDir}`,
+    );
   }
-
-  copyRecursiveSync(localesSourceDir, localesDestDir);
-  console.log('Copied locales folder');
-} else {
-  console.warn(`Warning: locales folder not found at ${localesSourceDir}`);
 }
 
-// Copy extensions folder
-console.log('Copying extension examples folder...');
-const extensionExamplesDir = path.join(
-  rootDir,
-  'packages',
-  'cli',
-  'src',
-  'commands',
-  'extensions',
-  'examples',
-);
-const extensionExamplesDestDir = path.join(distDir, 'examples');
+function writeDistPackageJson(rootDir, distDir) {
+  console.log('Creating package.json for distribution...');
+  const rootPackageJson = JSON.parse(
+    fs.readFileSync(path.join(rootDir, 'package.json'), 'utf-8'),
+  );
 
-if (fs.existsSync(extensionExamplesDir)) {
-  // Recursive copy function
-  function copyRecursiveSync(src, dest) {
-    const stats = fs.statSync(src);
-    if (stats.isDirectory()) {
-      if (!fs.existsSync(dest)) {
-        fs.mkdirSync(dest, { recursive: true });
-      }
-      const entries = fs.readdirSync(src);
-      for (const entry of entries) {
-        const srcPath = path.join(src, entry);
-        const destPath = path.join(dest, entry);
-        copyRecursiveSync(srcPath, destPath);
-      }
-    } else {
-      fs.copyFileSync(src, dest);
-    }
-  }
+  const distPackageJson = {
+    name: rootPackageJson.name,
+    version: rootPackageJson.version,
+    description:
+      rootPackageJson.description || 'Qwen Code - AI-powered coding assistant',
+    repository: rootPackageJson.repository,
+    type: 'module',
+    main: 'cli.js',
+    bin: {
+      qwen: 'cli.js',
+    },
+    files: [
+      'cli.js',
+      'chunks',
+      'vendor',
+      '*.sb',
+      'README.md',
+      'LICENSE',
+      'locales',
+      'examples',
+      'bundled',
+    ],
+    config: rootPackageJson.config,
+    dependencies: {},
+    optionalDependencies: {
+      '@lydell/node-pty': '1.2.0-beta.10',
+      '@lydell/node-pty-darwin-arm64': '1.2.0-beta.10',
+      '@lydell/node-pty-darwin-x64': '1.2.0-beta.10',
+      '@lydell/node-pty-linux-x64': '1.2.0-beta.10',
+      '@lydell/node-pty-win32-arm64': '1.2.0-beta.10',
+      '@lydell/node-pty-win32-x64': '1.2.0-beta.10',
+      '@teddyzhu/clipboard': '0.0.5',
+      '@teddyzhu/clipboard-darwin-arm64': '0.0.5',
+      '@teddyzhu/clipboard-darwin-x64': '0.0.5',
+      '@teddyzhu/clipboard-linux-x64-gnu': '0.0.5',
+      '@teddyzhu/clipboard-linux-arm64-gnu': '0.0.5',
+      '@teddyzhu/clipboard-win32-x64-msvc': '0.0.5',
+      '@teddyzhu/clipboard-win32-arm64-msvc': '0.0.5',
+    },
+    engines: rootPackageJson.engines,
+  };
 
-  copyRecursiveSync(extensionExamplesDir, extensionExamplesDestDir);
-  console.log('Copied extension examples folder');
-} else {
-  console.warn(
-    `Warning: extension examples folder not found at ${extensionExamplesDir}`,
+  fs.writeFileSync(
+    path.join(distDir, 'package.json'),
+    JSON.stringify(distPackageJson, null, 2) + '\n',
   );
 }
 
-// Copy package.json from root and modify it for publishing
-console.log('Creating package.json for distribution...');
-const rootPackageJson = JSON.parse(
-  fs.readFileSync(path.join(rootDir, 'package.json'), 'utf-8'),
-);
+function printPackageStructure(distDir) {
+  console.log('\n✅ Package prepared for publishing at dist/');
+  console.log('\nPackage structure:');
+  // Use Node.js to list directory contents (cross-platform)
+  const distFiles = fs.readdirSync(distDir);
+  for (const file of distFiles) {
+    const filePath = path.join(distDir, file);
+    const stats = fs.statSync(filePath);
+    const size = stats.isDirectory() ? '<DIR>' : formatBytes(stats.size);
+    console.log(`  ${size.padEnd(12)} ${file}`);
+  }
+}
 
-// Create a clean package.json for the published package
-const distPackageJson = {
-  name: rootPackageJson.name,
-  version: rootPackageJson.version,
-  description:
-    rootPackageJson.description || 'Qwen Code - AI-powered coding assistant',
-  repository: rootPackageJson.repository,
-  type: 'module',
-  main: 'cli.js',
-  bin: {
-    qwen: 'cli.js',
-  },
-  files: [
-    'cli.js',
-    'chunks',
-    'vendor',
-    '*.sb',
-    'README.md',
-    'LICENSE',
-    'locales',
-    'bundled',
-  ],
-  config: rootPackageJson.config,
-  dependencies: {},
-  optionalDependencies: {
-    '@lydell/node-pty': '1.2.0-beta.10',
-    '@lydell/node-pty-darwin-arm64': '1.2.0-beta.10',
-    '@lydell/node-pty-darwin-x64': '1.2.0-beta.10',
-    '@lydell/node-pty-linux-x64': '1.2.0-beta.10',
-    '@lydell/node-pty-win32-arm64': '1.2.0-beta.10',
-    '@lydell/node-pty-win32-x64': '1.2.0-beta.10',
-    '@teddyzhu/clipboard': '0.0.5',
-    '@teddyzhu/clipboard-darwin-arm64': '0.0.5',
-    '@teddyzhu/clipboard-darwin-x64': '0.0.5',
-    '@teddyzhu/clipboard-linux-x64-gnu': '0.0.5',
-    '@teddyzhu/clipboard-linux-arm64-gnu': '0.0.5',
-    '@teddyzhu/clipboard-win32-x64-msvc': '0.0.5',
-    '@teddyzhu/clipboard-win32-arm64-msvc': '0.0.5',
-  },
-  engines: rootPackageJson.engines,
-};
-
-fs.writeFileSync(
-  path.join(distDir, 'package.json'),
-  JSON.stringify(distPackageJson, null, 2) + '\n',
-);
-
-console.log('\n✅ Package prepared for publishing at dist/');
-console.log('\nPackage structure:');
-// Use Node.js to list directory contents (cross-platform)
-const distFiles = fs.readdirSync(distDir);
-for (const file of distFiles) {
-  const filePath = path.join(distDir, file);
-  const stats = fs.statSync(filePath);
-  const size = stats.isDirectory() ? '<DIR>' : formatBytes(stats.size);
-  console.log(`  ${size.padEnd(12)} ${file}`);
+function copyRecursiveSync(src, dest) {
+  const stats = fs.statSync(src);
+  if (stats.isDirectory()) {
+    if (!fs.existsSync(dest)) {
+      fs.mkdirSync(dest, { recursive: true });
+    }
+    const entries = fs.readdirSync(src);
+    for (const entry of entries) {
+      const srcPath = path.join(src, entry);
+      const destPath = path.join(dest, entry);
+      copyRecursiveSync(srcPath, destPath);
+    }
+  } else {
+    fs.copyFileSync(src, dest);
+  }
 }
 
 function formatBytes(bytes) {

--- a/scripts/tests/package-assets.test.js
+++ b/scripts/tests/package-assets.test.js
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { copyBundleAssets } from '../copy_bundle_assets.js';
+import { preparePackage } from '../prepare-package.js';
+
+describe('package asset scripts', () => {
+  const tempDirs = [];
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    for (const tempDir of tempDirs.splice(0)) {
+      rmSync(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  it('copies extension examples into the bundled runtime dist', () => {
+    const rootDir = createFixtureRoot();
+    stubConsole();
+
+    copyBundleAssets({ root: rootDir });
+
+    expect(readdirSync(path.join(rootDir, 'dist', 'examples')).sort()).toEqual([
+      'agent',
+      'commands',
+      'context',
+      'mcp-server',
+      'skills',
+    ]);
+    expect(
+      existsSync(
+        path.join(rootDir, 'dist', 'examples', 'mcp-server', 'package.json'),
+      ),
+    ).toBe(true);
+  });
+
+  it('includes extension examples in the prepared dist package', () => {
+    const rootDir = createFixtureRoot();
+    createBundleArtifacts(rootDir);
+    stubConsole();
+
+    preparePackage({ rootDir });
+
+    const distPackageJson = JSON.parse(
+      readFileSync(path.join(rootDir, 'dist', 'package.json'), 'utf8'),
+    );
+
+    expect(distPackageJson.files).toContain('examples');
+    expect(
+      existsSync(
+        path.join(rootDir, 'dist', 'examples', 'mcp-server', 'package.json'),
+      ),
+    ).toBe(true);
+  });
+
+  function createFixtureRoot() {
+    const rootDir = mkdtempSync(path.join(tmpdir(), 'qwen-package-assets-'));
+    tempDirs.push(rootDir);
+
+    writeFile(rootDir, 'README.md', '# Qwen Code\n');
+    writeFile(rootDir, 'LICENSE', 'Apache-2.0\n');
+    writeFile(
+      rootDir,
+      'package.json',
+      JSON.stringify(
+        {
+          name: '@qwen-code/qwen-code',
+          version: '0.17.0',
+          description: 'Qwen Code',
+          repository: {
+            type: 'git',
+            url: 'https://github.com/QwenLM/qwen-code.git',
+          },
+          config: {},
+          engines: {
+            node: '>=22.0.0',
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    writeFile(
+      rootDir,
+      'packages/cli/src/i18n/locales/en.json',
+      '{"hello":"world"}\n',
+    );
+
+    for (const template of [
+      'agent',
+      'commands',
+      'context',
+      'mcp-server',
+      'skills',
+    ]) {
+      writeFile(
+        rootDir,
+        `packages/cli/src/commands/extensions/examples/${template}/package.json`,
+        '{}\n',
+      );
+    }
+
+    return rootDir;
+  }
+
+  function createBundleArtifacts(rootDir) {
+    writeFile(rootDir, 'dist/cli.js', '');
+    mkdirSync(path.join(rootDir, 'dist', 'vendor'), { recursive: true });
+    mkdirSync(path.join(rootDir, 'dist', 'bundled', 'qc-helper', 'docs'), {
+      recursive: true,
+    });
+  }
+
+  function writeFile(rootDir, relativePath, content) {
+    const filePath = path.join(rootDir, relativePath);
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, content);
+  }
+
+  function stubConsole() {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  }
+});


### PR DESCRIPTION
Fixes #4718
Related: #897

## Summary

- copy the built-in extension example templates into `dist/examples/` during `npm run bundle`
- include `examples` in the prepared `dist/package.json` file list
- add script tests covering both packaging asset paths

## Demo

N/A -- packaging asset fix. The bundle verification now prints `Copied extension examples to dist/examples/`, and `dist/examples/` contains the built-in templates used by `qwen extensions new`.

## Verification

- `npm run test:scripts`
- `npm run bundle`

I also attempted dependency installation, which runs the repository `prepare` script. That currently fails on `upstream/main` while building `packages/cli` with `TS2304: Cannot find name 'showYoloStyling'` in `src/ui/components/InputPrompt.tsx`; this appears unrelated to the packaging asset change.
