### PR TITLE
fix(cli): restore approval-mode reference dropped in #4600 (InputPrompt build break)

### DIFF
--- a/packages/cli/src/ui/components/InputPrompt.tsx
+++ b/packages/cli/src/ui/components/InputPrompt.tsx
@@ -1610,7 +1610,7 @@ export const InputPrompt: React.FC<InputPromptProps> = ({
       : 2 // "! " = 2 chars
     : commandSearchActive
       ? 6 // "(r:) " (inner) + " " (outer) = 6 cols
-      : showYoloStyling
+      : approvalMode === ApprovalMode.YOLO
         ? 2 // "* " = 2 chars
         : 2; // "> " = 2 chars
 


### PR DESCRIPTION
## Summary

`origin/main` currently fails `npm run build` (tsc) on a dangling identifier:

```
packages/cli/src/ui/components/InputPrompt.tsx: error TS2304: Cannot find name 'showYoloStyling'.
```

#4600 unified the approval-mode prompt styling into a single `approvalModePromptStyle` constant and removed the old `showAutoAcceptStyling` / `showYoloStyling` constants, but left one dangling reference to `showYoloStyling` in the `prefixWidth` calculation. `npm run bundle` (esbuild) doesn't type-check, so the break only surfaces under `npm run build` / `tsc --build` — which is how it reached main.

## Fix

Replace the dangling reference with `approvalMode === ApprovalMode.YOLO`, matching how the rest of the file branches on approval mode after #4600 (e.g. the `statusText` block just above).

Both ternary arms intentionally stay `2`: `getApprovalModePromptStyle` is typed to return `prefix: '>' | '*'`, so every approval-mode prefix is a single character and the rendered prefix width — hence cursor positioning — is unchanged. Pure build fix, no behavioral change.

## Verification

- `npm run build` green (full `tsc --build` clean)
- pre-commit `eslint --fix --max-warnings 0` passes on the changed file (0 warnings)
