### PR TITLE
fix: add missing isForkSubagentEnabled from main merge

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -703,6 +703,7 @@ export interface ConfigParameters {
   sessionTokenLimit?: number;
   experimentalZedIntegration?: boolean;
   cronEnabled?: boolean;
+  forkSubagentEnabled?: boolean;
   computerUseEnabled?: boolean;
   emitToolUseSummaries?: boolean;
   listExtensions?: boolean;
@@ -1099,6 +1100,7 @@ export class Config {
   private runtimeStatusEnabled = false;
   private readonly experimentalZedIntegration: boolean = false;
   private readonly cronEnabled: boolean = false;
+  private readonly forkSubagentEnabled: boolean = false;
   private readonly computerUseEnabled: boolean = true;
   private readonly emitToolUseSummaries: boolean = true;
   private readonly chatRecordingEnabled: boolean;
@@ -1281,6 +1283,7 @@ export class Config {
     this.experimentalZedIntegration =
       params.experimentalZedIntegration ?? false;
     this.cronEnabled = params.cronEnabled ?? false;
+    this.forkSubagentEnabled = params.forkSubagentEnabled ?? false;
     this.computerUseEnabled = params.computerUseEnabled ?? true;
     this.emitToolUseSummaries = params.emitToolUseSummaries ?? true;
     this.listExtensions = params.listExtensions ?? false;
@@ -3325,6 +3328,11 @@ export class Config {
     // Cron is experimental and opt-in: enabled via settings or env var
     if (process.env['QWEN_CODE_ENABLE_CRON'] === '1') return true;
     return this.cronEnabled;
+  }
+
+  isForkSubagentEnabled(): boolean {
+    if (process.env['QWEN_CODE_ENABLE_FORK_SUBAGENT'] === '1') return true;
+    return this.forkSubagentEnabled;
   }
 
   isComputerUseEnabled(): boolean {

--- a/packages/core/src/tools/agent/fork-subagent.ts
+++ b/packages/core/src/tools/agent/fork-subagent.ts
@@ -1,7 +1,12 @@
 import { AsyncLocalStorage } from 'node:async_hooks';
 import type { Content } from '@google/genai';
+import type { Config } from '../../config/config.js';
 
 export const FORK_SUBAGENT_TYPE = 'fork';
+
+export function isForkSubagentEnabled(config: Config): boolean {
+  return config.isForkSubagentEnabled() && config.isInteractive();
+}
 
 export const FORK_BOILERPLATE_TAG = 'fork-boilerplate';
 export const FORK_DIRECTIVE_PREFIX = 'Directive: ';


### PR DESCRIPTION
## Summary

- Add `isForkSubagentEnabled()` method to `Config` class with env var gate (`QWEN_CODE_ENABLE_FORK_SUBAGENT=1`)
- Add `forkSubagentEnabled` param and private field to `Config`
- Re-export `isForkSubagentEnabled()` from `fork-subagent.ts`

These were in main but lost during the #4490 merge conflict resolution. Follow-up to #4730.

## Test plan

- [x] Full build passes (`npm run build` exit 0)
- [x] TypeScript compilation clean — no TS2339/TS2305 errors

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)