### PR TITLE
fix: strip runtime snapshot prefix before persisting model.name

### DIFF
--- a/packages/cli/src/config/settings.test.ts
+++ b/packages/cli/src/config/settings.test.ts
@@ -3271,6 +3271,38 @@ describe('Settings Loading and Merging', () => {
       );
     });
 
+    it('strips a runtime snapshot prefix before persisting model.name', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(() => '{}');
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+      settings.setValue(
+        SettingScope.User,
+        'model.name',
+        '$runtime|openai|qwen3.6-27b-autoround',
+      );
+
+      const writeCall = (fs.writeFileSync as Mock).mock.calls.at(-1);
+      const writtenContent = JSON.parse(String(writeCall?.[1]));
+      expect(writtenContent.model.name).toBe('qwen3.6-27b-autoround');
+    });
+
+    it('collapses stacked runtime snapshot prefixes before persisting model.name', () => {
+      (mockFsExistsSync as Mock).mockReturnValue(true);
+      (fs.readFileSync as Mock).mockImplementation(() => '{}');
+
+      const settings = loadSettings(MOCK_WORKSPACE_DIR);
+      settings.setValue(
+        SettingScope.User,
+        'model.name',
+        '$runtime|openai|$runtime|openai|qwen3.6-27b-autoround',
+      );
+
+      const writeCall = (fs.writeFileSync as Mock).mock.calls.at(-1);
+      const writtenContent = JSON.parse(String(writeCall?.[1]));
+      expect(writtenContent.model.name).toBe('qwen3.6-27b-autoround');
+    });
+
     it('persists removed MCP servers when replacing the top-level mcpServers object', () => {
       (mockFsExistsSync as Mock).mockReturnValue(true);
 

--- a/packages/cli/src/config/settings.ts
+++ b/packages/cli/src/config/settings.ts
@@ -15,6 +15,7 @@ import {
   getErrorMessage,
   Storage,
   createDebugLogger,
+  stripRuntimeSnapshotPrefix,
 } from '@qwen-code/qwen-code-core';
 import stripJsonComments from 'strip-json-comments';
 import { DefaultLight } from '../ui/themes/default-light.js';
@@ -464,6 +465,10 @@ export class LoadedSettings {
   }
 
   setValue(scope: SettingScope, key: string, value: unknown): void {
+    // Never persist a runtime snapshot ID to model.name (it re-wraps on restart).
+    if (key === 'model.name' && typeof value === 'string') {
+      value = stripRuntimeSnapshotPrefix(value);
+    }
     const settingsFile = this.forScope(scope);
     setNestedPropertySafe(settingsFile.settings, key, value);
     setNestedPropertySafe(settingsFile.originalSettings, key, value);

--- a/packages/cli/src/utils/modelConfigUtils.test.ts
+++ b/packages/cli/src/utils/modelConfigUtils.test.ts
@@ -444,6 +444,72 @@ describe('modelConfigUtils', () => {
       );
     });
 
+    it('strips a runtime snapshot prefix from settings.model.name (read-side self-heal)', () => {
+      const modelProvider: ProviderModelConfig = {
+        id: 'gpt-4o',
+        name: 'GPT-4o',
+      };
+      const settings = makeMockSettings({
+        model: { name: '$runtime|openai|gpt-4o' },
+        modelProviders: {
+          [AuthType.USE_OPENAI]: [modelProvider],
+        },
+      });
+
+      vi.mocked(resolveModelConfig).mockReturnValue({
+        config: { model: 'gpt-4o', apiKey: '', baseUrl: '' },
+        sources: {},
+        warnings: [],
+      });
+
+      resolveCliGenerationConfig({
+        argv: {},
+        settings,
+        selectedAuthType: AuthType.USE_OPENAI,
+      });
+
+      // Both read-side strip sites: the bare id is used for the provider
+      // lookup and passed through to resolveModelConfig as settings.model.
+      expect(vi.mocked(resolveModelConfig)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelProvider,
+          settings: expect.objectContaining({ model: 'gpt-4o' }),
+        }),
+      );
+    });
+
+    it('collapses a stacked runtime snapshot prefix from settings.model.name', () => {
+      const modelProvider: ProviderModelConfig = {
+        id: 'gpt-4o',
+        name: 'GPT-4o',
+      };
+      const settings = makeMockSettings({
+        model: { name: '$runtime|openai|$runtime|openai|gpt-4o' },
+        modelProviders: {
+          [AuthType.USE_OPENAI]: [modelProvider],
+        },
+      });
+
+      vi.mocked(resolveModelConfig).mockReturnValue({
+        config: { model: 'gpt-4o', apiKey: '', baseUrl: '' },
+        sources: {},
+        warnings: [],
+      });
+
+      resolveCliGenerationConfig({
+        argv: {},
+        settings,
+        selectedAuthType: AuthType.USE_OPENAI,
+      });
+
+      expect(vi.mocked(resolveModelConfig)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelProvider,
+          settings: expect.objectContaining({ model: 'gpt-4o' }),
+        }),
+      );
+    });
+
     it('should not find modelProvider when authType is undefined', () => {
       const argv = { model: 'test-model' };
       const settings = makeMockSettings({

--- a/packages/cli/src/utils/modelConfigUtils.ts
+++ b/packages/cli/src/utils/modelConfigUtils.ts
@@ -216,7 +216,7 @@ export function resolveCliGenerationConfig(
     settings: {
       model: settings.model?.name
         ? stripRuntimeSnapshotPrefix(settings.model.name)
-        : settings.model?.name,
+        : undefined,
       apiKey: settings.security?.auth?.apiKey,
       baseUrl: settings.security?.auth?.baseUrl,
       generationConfig: settings.model?.generationConfig as

--- a/packages/cli/src/utils/modelConfigUtils.ts
+++ b/packages/cli/src/utils/modelConfigUtils.ts
@@ -12,6 +12,7 @@ import {
   resolveModelConfig,
   type ModelConfigSourcesInput,
   type ProviderModelConfig,
+  stripRuntimeSnapshotPrefix,
 } from '@qwen-code/qwen-code-core';
 import type { Settings } from '../config/settings.js';
 
@@ -159,7 +160,8 @@ export function resolveCliGenerationConfig(
   if (argv.model) {
     resolvedModel = argv.model;
   } else if (settings.model?.name) {
-    resolvedModel = settings.model.name;
+    // Self-heal configs already corrupted by older builds.
+    resolvedModel = stripRuntimeSnapshotPrefix(settings.model.name);
   } else if (authType && AUTH_ENV_MODEL_VARS[authType]) {
     // Only check env vars for the current auth type
     for (const envVar of AUTH_ENV_MODEL_VARS[authType]) {
@@ -212,7 +214,9 @@ export function resolveCliGenerationConfig(
       baseUrl: argv.openaiBaseUrl,
     },
     settings: {
-      model: settings.model?.name,
+      model: settings.model?.name
+        ? stripRuntimeSnapshotPrefix(settings.model.name)
+        : settings.model?.name,
       apiKey: settings.security?.auth?.apiKey,
       baseUrl: settings.security?.auth?.baseUrl,
       generationConfig: settings.model?.generationConfig as

--- a/packages/core/src/models/modelsConfig.ts
+++ b/packages/core/src/models/modelsConfig.ts
@@ -12,6 +12,7 @@ import type { ContentGeneratorConfigSources } from '../core/contentGenerator.js'
 import { DEFAULT_QWEN_MODEL } from '../config/models.js';
 import { tokenLimit } from '../core/tokenLimits.js';
 import { defaultModalities } from '../core/modalityDefaults.js';
+import { RUNTIME_SNAPSHOT_PREFIX } from '../utils/runtimeModelPrefix.js';
 
 import { ModelRegistry } from './modelRegistry.js';
 import {
@@ -501,12 +502,6 @@ export class ModelsConfig {
   }
 
   /**
-   * Prefix used to identify RuntimeModelSnapshot IDs.
-   * Chosen to avoid conflicts with real model IDs which may contain `-` or `:`.
-   */
-  private static readonly RUNTIME_SNAPSHOT_PREFIX = '$runtime|';
-
-  /**
    * Build a RuntimeModelSnapshot ID from authType and modelId.
    * The format is: `$runtime|${authType}|${modelId}`
    *
@@ -521,7 +516,7 @@ export class ModelsConfig {
     authType: AuthType,
     modelId: string,
   ): string {
-    return `${ModelsConfig.RUNTIME_SNAPSHOT_PREFIX}${authType}|${modelId}`;
+    return `${RUNTIME_SNAPSHOT_PREFIX}${authType}|${modelId}`;
   }
 
   /**
@@ -540,7 +535,7 @@ export class ModelsConfig {
    */
   private extractRuntimeModelSnapshotId(modelId: string): string | undefined {
     // Check if modelId starts with the runtime snapshot prefix
-    if (modelId.startsWith(ModelsConfig.RUNTIME_SNAPSHOT_PREFIX)) {
+    if (modelId.startsWith(RUNTIME_SNAPSHOT_PREFIX)) {
       // Verify the snapshot exists
       if (this.runtimeModelSnapshots.has(modelId)) {
         return modelId;

--- a/packages/core/src/utils/modelId.test.ts
+++ b/packages/core/src/utils/modelId.test.ts
@@ -28,6 +28,13 @@ describe('stripRuntimeSnapshotPrefix', () => {
       ),
     ).toBe('qwen3.6-27b-autoround');
   });
+
+  it('returns the input unchanged for a malformed prefix with no model ID', () => {
+    expect(stripRuntimeSnapshotPrefix('$runtime|openai|')).toBe(
+      '$runtime|openai|',
+    );
+    expect(stripRuntimeSnapshotPrefix('$runtime|')).toBe('$runtime|');
+  });
 });
 
 describe('resolveModelId', () => {

--- a/packages/core/src/utils/modelId.test.ts
+++ b/packages/core/src/utils/modelId.test.ts
@@ -6,7 +6,29 @@
 
 import { describe, expect, it } from 'vitest';
 import { AuthType } from '../core/contentGenerator.js';
-import { resolveModelId } from './modelId.js';
+import { resolveModelId, stripRuntimeSnapshotPrefix } from './modelId.js';
+
+describe('stripRuntimeSnapshotPrefix', () => {
+  it('returns bare model IDs unchanged', () => {
+    expect(stripRuntimeSnapshotPrefix('qwen3.6-27b-autoround')).toBe(
+      'qwen3.6-27b-autoround',
+    );
+  });
+
+  it('strips a single runtime snapshot prefix', () => {
+    expect(
+      stripRuntimeSnapshotPrefix('$runtime|openai|qwen3.6-27b-autoround'),
+    ).toBe('qwen3.6-27b-autoround');
+  });
+
+  it('strips nested runtime snapshot prefixes (corruption self-heal)', () => {
+    expect(
+      stripRuntimeSnapshotPrefix(
+        '$runtime|openai|$runtime|openai|qwen3.6-27b-autoround',
+      ),
+    ).toBe('qwen3.6-27b-autoround');
+  });
+});
 
 describe('resolveModelId', () => {
   it('returns undefined for omitted models without a current model', () => {

--- a/packages/core/src/utils/modelId.ts
+++ b/packages/core/src/utils/modelId.ts
@@ -41,20 +41,10 @@ type ModelIdSelector =
 
 const AUTH_TYPES = new Set<AuthType>(Object.values(AuthType));
 
-/** Runtime model snapshot ID prefix; format `$runtime|${authType}|${modelId}`. */
-export const RUNTIME_SNAPSHOT_PREFIX = '$runtime|';
-
-/**
- * Recover the bare model ID from a (possibly runtime-prefixed) model string.
- * Strips every layer so nested prefixes self-heal; bare IDs pass through.
- */
-export function stripRuntimeSnapshotPrefix(modelId: string): string {
-  let id = modelId;
-  while (id.startsWith(RUNTIME_SNAPSHOT_PREFIX)) {
-    id = id.split('|').slice(2).join('|');
-  }
-  return id;
-}
+export {
+  RUNTIME_SNAPSHOT_PREFIX,
+  stripRuntimeSnapshotPrefix,
+} from './runtimeModelPrefix.js';
 
 /**
  * Resolve a model selector to the concrete model ID a caller should use.

--- a/packages/core/src/utils/modelId.ts
+++ b/packages/core/src/utils/modelId.ts
@@ -41,6 +41,21 @@ type ModelIdSelector =
 
 const AUTH_TYPES = new Set<AuthType>(Object.values(AuthType));
 
+/** Runtime model snapshot ID prefix; format `$runtime|${authType}|${modelId}`. */
+export const RUNTIME_SNAPSHOT_PREFIX = '$runtime|';
+
+/**
+ * Recover the bare model ID from a (possibly runtime-prefixed) model string.
+ * Strips every layer so nested prefixes self-heal; bare IDs pass through.
+ */
+export function stripRuntimeSnapshotPrefix(modelId: string): string {
+  let id = modelId;
+  while (id.startsWith(RUNTIME_SNAPSHOT_PREFIX)) {
+    id = id.split('|').slice(2).join('|');
+  }
+  return id;
+}
+
 /**
  * Resolve a model selector to the concrete model ID a caller should use.
  *

--- a/packages/core/src/utils/runtimeModelPrefix.ts
+++ b/packages/core/src/utils/runtimeModelPrefix.ts
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Single source of truth for the RuntimeModelSnapshot ID prefix.
+ *
+ * Kept dependency-free (no imports) so it can be consumed from any layer —
+ * including `modelsConfig.ts`, which sits in an import cycle with `modelId.ts`
+ * via `contentGenerator.ts` and would crash on init if it imported the prefix
+ * from there.
+ */
+
+/** Runtime model snapshot ID prefix; format `$runtime|${authType}|${modelId}`. */
+export const RUNTIME_SNAPSHOT_PREFIX = '$runtime|';
+
+/**
+ * Recover the bare model ID from a (possibly runtime-prefixed) model string.
+ * Strips every layer so nested prefixes self-heal; bare IDs pass through.
+ */
+export function stripRuntimeSnapshotPrefix(modelId: string): string {
+  let id = modelId;
+  while (id.startsWith(RUNTIME_SNAPSHOT_PREFIX)) {
+    const stripped = id.split('|').slice(2).join('|');
+    if (!stripped) break; // malformed prefix — don't destroy the value
+    id = stripped;
+  }
+  return id;
+}

--- a/packages/vscode-ide-companion/src/services/settingsWriter.test.ts
+++ b/packages/vscode-ide-companion/src/services/settingsWriter.test.ts
@@ -136,6 +136,30 @@ describe('settingsWriter', () => {
       ]);
     });
 
+    it('strips a runtime snapshot prefix before persisting model.name', async () => {
+      const plan: ProviderInstallPlan = {
+        providerId: 'test',
+        authType: AuthType.USE_OPENAI,
+        env: { TEST_API_KEY: 'sk-test' },
+        // A runtime snapshot id must never reach disk — the adapter's setValue
+        // guard strips it back to the bare model id.
+        modelSelection: { modelId: '$runtime|openai|gpt-4o' },
+        modelProviders: [
+          {
+            authType: AuthType.USE_OPENAI,
+            models: [{ id: 'gpt-4o', envKey: 'TEST_API_KEY' }],
+            mergeStrategy: 'prepend-and-remove-owned',
+            ownsModel: (m) => m.envKey === 'TEST_API_KEY',
+          },
+        ],
+      };
+
+      await applyProviderInstallPlanToFile(plan);
+
+      const written = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      expect(written.model.name).toBe('gpt-4o');
+    });
+
     it('rejects __proto__ in install-plan env keys (prototype-pollution guard)', async () => {
       // {__proto__: 'x'} literal sets the object's prototype rather than a
       // real property, so build the env via defineProperty to land an actual

--- a/packages/vscode-ide-companion/src/services/settingsWriter.test.ts
+++ b/packages/vscode-ide-companion/src/services/settingsWriter.test.ts
@@ -160,6 +160,28 @@ describe('settingsWriter', () => {
       expect(written.model.name).toBe('gpt-4o');
     });
 
+    it('collapses stacked runtime snapshot prefixes before persisting model.name', async () => {
+      const plan: ProviderInstallPlan = {
+        providerId: 'test',
+        authType: AuthType.USE_OPENAI,
+        env: { TEST_API_KEY: 'sk-test' },
+        modelSelection: { modelId: '$runtime|openai|$runtime|openai|gpt-4o' },
+        modelProviders: [
+          {
+            authType: AuthType.USE_OPENAI,
+            models: [{ id: 'gpt-4o', envKey: 'TEST_API_KEY' }],
+            mergeStrategy: 'prepend-and-remove-owned',
+            ownsModel: (m) => m.envKey === 'TEST_API_KEY',
+          },
+        ],
+      };
+
+      await applyProviderInstallPlanToFile(plan);
+
+      const written = JSON.parse(fs.readFileSync(settingsPath, 'utf-8'));
+      expect(written.model.name).toBe('gpt-4o');
+    });
+
     it('rejects __proto__ in install-plan env keys (prototype-pollution guard)', async () => {
       // {__proto__: 'x'} literal sets the object's prototype rather than a
       // real property, so build the env via defineProperty to land an actual

--- a/packages/vscode-ide-companion/src/services/settingsWriter.ts
+++ b/packages/vscode-ide-companion/src/services/settingsWriter.ts
@@ -16,6 +16,7 @@ import {
   Storage,
   applyProviderInstallPlan,
   resolveMetadataKey,
+  stripRuntimeSnapshotPrefix,
   type ProviderInstallPlan,
   type ProviderSettingsAdapter,
   type ModelProvidersConfig,
@@ -435,6 +436,10 @@ function createFileSettingsAdapter(): ProviderSettingsAdapter {
     },
 
     setValue(key: string, value: unknown): void {
+      // Never persist a runtime snapshot ID to model.name (it re-wraps on restart).
+      if (key === 'model.name' && typeof value === 'string') {
+        value = stripRuntimeSnapshotPrefix(value);
+      }
       const parts = key.split('.');
       let current = data;
       for (let i = 0; i < parts.length; i++) {

--- a/packages/vscode-ide-companion/src/webview/utils/discontinuedModel.test.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/discontinuedModel.test.ts
@@ -5,12 +5,20 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { RUNTIME_SNAPSHOT_PREFIX } from '@qwen-code/qwen-code-core';
 import {
   DISCONTINUED_MESSAGES,
   isDiscontinuedModel,
   parseAcpModelId,
   QWEN_OAUTH_AUTH_TYPE,
+  RUNTIME_PREFIX,
 } from './discontinuedModel.js';
+
+describe('RUNTIME_PREFIX', () => {
+  it('stays in sync with core RUNTIME_SNAPSHOT_PREFIX', () => {
+    expect(RUNTIME_PREFIX).toBe(RUNTIME_SNAPSHOT_PREFIX);
+  });
+});
 
 describe('parseAcpModelId', () => {
   it('extracts authType and base model id from a registry entry', () => {

--- a/packages/vscode-ide-companion/src/webview/utils/discontinuedModel.ts
+++ b/packages/vscode-ide-companion/src/webview/utils/discontinuedModel.ts
@@ -17,7 +17,9 @@
  * Keep these two files in sync when the encoding evolves.
  */
 
-const RUNTIME_PREFIX = '$runtime|';
+// Local copy of core's RUNTIME_SNAPSHOT_PREFIX: the webview bundle marks core
+// external (see esbuild.js), so it can't import it. A test pins them equal.
+export const RUNTIME_PREFIX = '$runtime|';
 
 /** Auth type marker for the (now-discontinued) Qwen OAuth free tier. */
 export const QWEN_OAUTH_AUTH_TYPE = 'qwen-oauth';


### PR DESCRIPTION
## Summary

Fixes a bug where selecting a **runtime model** from the model picker corrupted `settings.json`'s `model.name`, eventually causing 404 / "model not found" errors that worsened on every restart.

## Root cause

Runtime models (e.g. those discovered from cached OAuth tokens / cross-auth) are keyed in memory by a **snapshot ID** of the form `$runtime|${authType}|${modelId}`, e.g. `$runtime|openai|qwen3.6-27b-autoround`. This prefix is an internal lookup key, **not** a real model ID.

When a runtime model was selected, the code persisted the **full snapshot ID** into `model.name` instead of the bare model ID:

- **Interactive `/model`** — after `switchModel`, it recovered the bare ID via `after?.model ?? modelId`, but on the auth-refresh path `after.model` was `undefined`, so it fell back to `modelId` (the full `$runtime|…` string).
- **ACP `setModel`** (VSCode extension) — `parseAcpModelOption` only strips the trailing `(authType)` marker, leaving the `$runtime|…` prefix, which was persisted directly.

On the next startup, `model.name` was read back and fed through `buildRuntimeModelSnapshotId()`, which **re-wrapped** it. Each restart added another layer:

```
boot 1: $runtime|openai|qwen3.6-27b-autoround
boot 2: $runtime|openai|$runtime|openai|qwen3.6-27b-autoround
boot 3: $runtime|openai|$runtime|openai|$runtime|openai|...
```

The nested ID no longer resolved to a real model → 404.

## Fix

Guard at the **write chokepoints**, plus a **read-side self-heal**:

- **core** — add shared `stripRuntimeSnapshotPrefix()` (strips every nested layer; bare IDs pass through).
- **cli `LoadedSettings.setValue()`** — strip before persisting `model.name`. Because every CLI write funnels through `setValue`, this covers **both** interactive `/model` and ACP `setModel` in one place.
- **cli `modelConfigUtils`** — sanitize `model.name` on read, so configs already corrupted by older builds self-heal on next startup.
- **vscode-ide-companion `settingsWriter`** — same guard on the extension's own `settings.json` writer.

## Testing

- `core`: unit tests for `stripRuntimeSnapshotPrefix` (bare / single / nested).
- `cli`: `settings.setValue` strips single + stacked prefixes for `model.name`.
- `vscode-ide-companion`: `settingsWriter` strips the prefix before writing.
- All affected suites + typecheck pass across core / cli / vscode-ide-companion.
