### PR TITLE
fix(cli): avoid browser-open crashes in headless sessions

### DIFF
--- a/packages/cli/src/ui/commands/bugCommand.test.ts
+++ b/packages/cli/src/ui/commands/bugCommand.test.ts
@@ -5,15 +5,23 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import open from 'open';
 import { bugCommand } from './bugCommand.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import { GIT_COMMIT_INFO } from '../../generated/git-commit.js';
 import { AuthType } from '@qwen-code/qwen-code-core';
 import * as systemInfoUtils from '../../utils/systemInfo.js';
 
+const mockOpenBrowserSecurely = vi.hoisted(() => vi.fn());
+
 // Mock dependencies
-vi.mock('open');
+vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
+  return {
+    ...actual,
+    openBrowserSecurely: mockOpenBrowserSecurely,
+  };
+});
 vi.mock('../../utils/systemInfo.js');
 
 describe('bugCommand', () => {
@@ -84,7 +92,7 @@ Memory Usage: 100 MB`;
       },
       expect.any(Number),
     );
-    expect(open).toHaveBeenCalledWith(expectedUrl);
+    expect(mockOpenBrowserSecurely).toHaveBeenCalledWith(expectedUrl);
   });
 
   it('should use a custom URL template from config if provided', async () => {
@@ -128,7 +136,7 @@ Memory Usage: 100 MB`;
       },
       expect.any(Number),
     );
-    expect(open).toHaveBeenCalledWith(expectedUrl);
+    expect(mockOpenBrowserSecurely).toHaveBeenCalledWith(expectedUrl);
   });
 
   it('should include Base URL when auth type is OpenAI', async () => {
@@ -193,6 +201,6 @@ Memory Usage: 100 MB`;
       },
       expect.any(Number),
     );
-    expect(open).toHaveBeenCalledWith(expectedUrl);
+    expect(mockOpenBrowserSecurely).toHaveBeenCalledWith(expectedUrl);
   });
 });

--- a/packages/cli/src/ui/commands/bugCommand.ts
+++ b/packages/cli/src/ui/commands/bugCommand.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import open from 'open';
+import { openBrowserSecurely } from '@qwen-code/qwen-code-core';
 import {
   type CommandContext,
   type SlashCommand,
@@ -55,7 +55,7 @@ export const bugCommand: SlashCommand = {
     context.ui.addItem(bugReportItem, Date.now());
 
     try {
-      await open(bugReportUrl);
+      await openBrowserSecurely(bugReportUrl);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : String(error);

--- a/packages/cli/src/ui/commands/docsCommand.test.ts
+++ b/packages/cli/src/ui/commands/docsCommand.test.ts
@@ -5,24 +5,28 @@
  */
 
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
-import open from 'open';
 import { docsCommand } from './docsCommand.js';
 import { type CommandContext } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 import { MessageType } from '../types.js';
 
-// Mock the 'open' library
-vi.mock('open', () => ({
-  default: vi.fn(),
-}));
+const mockOpenBrowserSecurely = vi.hoisted(() => vi.fn());
+
+vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
+  return {
+    ...actual,
+    openBrowserSecurely: mockOpenBrowserSecurely,
+  };
+});
 
 describe('docsCommand', () => {
   let mockContext: CommandContext;
   beforeEach(() => {
     // Create a fresh mock context before each test
     mockContext = createMockCommandContext();
-    // Reset the `open` mock
-    vi.mocked(open).mockClear();
+    mockOpenBrowserSecurely.mockClear();
   });
 
   afterEach(() => {
@@ -47,7 +51,7 @@ describe('docsCommand', () => {
       expect.any(Number),
     );
 
-    expect(open).toHaveBeenCalledWith(docsUrl);
+    expect(mockOpenBrowserSecurely).toHaveBeenCalledWith(docsUrl);
   });
 
   it('should only add an info message in a sandbox environment', async () => {
@@ -69,8 +73,7 @@ describe('docsCommand', () => {
       expect.any(Number),
     );
 
-    // Ensure 'open' was not called in the sandbox
-    expect(open).not.toHaveBeenCalled();
+    expect(mockOpenBrowserSecurely).not.toHaveBeenCalled();
   });
 
   it("should not open browser for 'sandbox-exec'", async () => {
@@ -93,8 +96,7 @@ describe('docsCommand', () => {
       expect.any(Number),
     );
 
-    // 'open' should be called in this specific sandbox case
-    expect(open).toHaveBeenCalledWith(docsUrl);
+    expect(mockOpenBrowserSecurely).toHaveBeenCalledWith(docsUrl);
   });
 
   describe('non-interactive mode', () => {
@@ -112,7 +114,7 @@ describe('docsCommand', () => {
         messageType: 'info',
         content: expect.stringContaining('qwenlm.github.io'),
       });
-      expect(open).not.toHaveBeenCalled();
+      expect(mockOpenBrowserSecurely).not.toHaveBeenCalled();
       expect(nonInteractiveContext.ui.addItem).not.toHaveBeenCalled();
     });
   });

--- a/packages/cli/src/ui/commands/docsCommand.ts
+++ b/packages/cli/src/ui/commands/docsCommand.ts
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import open from 'open';
 import process from 'node:process';
+import { openBrowserSecurely } from '@qwen-code/qwen-code-core';
 import {
   type CommandContext,
   type SlashCommand,
@@ -57,7 +57,21 @@ export const docsCommand: SlashCommand = {
         },
         Date.now(),
       );
-      await open(docsUrl);
+      try {
+        await openBrowserSecurely(docsUrl);
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error ? error.message : String(error);
+        context.ui.addItem(
+          {
+            type: MessageType.ERROR,
+            text: t('Could not open documentation in browser: {{error}}', {
+              error: errorMessage,
+            }),
+          },
+          Date.now(),
+        );
+      }
     }
     return;
   },

--- a/packages/cli/src/ui/commands/insightCommand.test.ts
+++ b/packages/cli/src/ui/commands/insightCommand.test.ts
@@ -6,22 +6,27 @@
 
 import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
 import path from 'path';
-import open from 'open';
 import { parseInsightMessage, Storage } from '@qwen-code/qwen-code-core';
 import { insightCommand } from './insightCommand.js';
 import type { CommandContext } from './types.js';
 import { createMockCommandContext } from '../../test-utils/mockCommandContext.js';
 
 const mockGenerateStaticInsight = vi.fn();
+const mockOpenFilePathSecurely = vi.hoisted(() => vi.fn());
+
+vi.mock('@qwen-code/qwen-code-core', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@qwen-code/qwen-code-core')>();
+  return {
+    ...actual,
+    openFilePathSecurely: mockOpenFilePathSecurely,
+  };
+});
 
 vi.mock('../../services/insight/generators/StaticInsightGenerator.js', () => ({
   StaticInsightGenerator: vi.fn(() => ({
     generateStaticInsight: mockGenerateStaticInsight,
   })),
-}));
-
-vi.mock('open', () => ({
-  default: vi.fn(),
 }));
 
 describe('insightCommand', () => {
@@ -32,7 +37,7 @@ describe('insightCommand', () => {
     mockGenerateStaticInsight.mockResolvedValue(
       path.resolve('runtime-output', 'insights', 'insight-2026-03-05.html'),
     );
-    vi.mocked(open).mockResolvedValue(undefined as never);
+    mockOpenFilePathSecurely.mockResolvedValue(undefined);
 
     mockContext = createMockCommandContext({
       services: {
@@ -198,7 +203,7 @@ describe('insightCommand', () => {
     expect((result as { content: string }).content).toContain(
       path.resolve('runtime-output', 'insights', 'insight-2026-03-05.html'),
     );
-    expect(open).not.toHaveBeenCalled();
+    expect(mockOpenFilePathSecurely).not.toHaveBeenCalled();
   });
 
   it('non_interactive: returns error message when generation fails', async () => {
@@ -227,6 +232,6 @@ describe('insightCommand', () => {
       messageType: 'error',
     });
     expect((result as { content: string }).content).toContain('disk full');
-    expect(open).not.toHaveBeenCalled();
+    expect(mockOpenFilePathSecurely).not.toHaveBeenCalled();
   });
 });

--- a/packages/cli/src/ui/commands/insightCommand.ts
+++ b/packages/cli/src/ui/commands/insightCommand.ts
@@ -15,9 +15,9 @@ import {
   createDebugLogger,
   encodeInsightProgressMessage,
   encodeInsightReadyMessage,
+  openFilePathSecurely,
   Storage,
 } from '@qwen-code/qwen-code-core';
-import open from 'open';
 
 const logger = createDebugLogger('DataProcessor');
 
@@ -216,8 +216,6 @@ export const insightCommand: SlashCommand = {
       );
 
       try {
-        await open(outputPath);
-
         context.ui.addItem(
           {
             type: MessageType.INFO,
@@ -227,6 +225,8 @@ export const insightCommand: SlashCommand = {
           },
           Date.now(),
         );
+
+        await openFilePathSecurely(outputPath);
       } catch (browserError) {
         logger.error('Failed to open browser automatically:', browserError);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -346,6 +346,7 @@ export {
 } from './utils/runtimeFetchOptions.js';
 export * from './utils/runtimeStatus.js';
 export * from './utils/schemaValidator.js';
+export * from './utils/secure-browser-launcher.js';
 export * from './utils/shell-utils.js';
 export * from './utils/subagentGenerator.js';
 export * from './utils/symlink.js';

--- a/packages/core/src/utils/secure-browser-launcher.test.ts
+++ b/packages/core/src/utils/secure-browser-launcher.test.ts
@@ -5,7 +5,10 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { openBrowserSecurely } from './secure-browser-launcher.js';
+import {
+  openBrowserSecurely,
+  openFilePathSecurely,
+} from './secure-browser-launcher.js';
 
 // Create mock function using vi.hoisted
 const mockExecFile = vi.hoisted(() => vi.fn());
@@ -29,6 +32,7 @@ describe('secure-browser-launcher', () => {
     if (originalPlatform) {
       Object.defineProperty(process, 'platform', originalPlatform);
     }
+    vi.unstubAllEnvs();
   });
 
   function setPlatform(platform: string) {
@@ -192,6 +196,19 @@ describe('secure-browser-launcher', () => {
       );
     });
 
+    it('should honor BROWSER on Linux', async () => {
+      setPlatform('linux');
+      vi.stubEnv('BROWSER', 'wslview');
+
+      await openBrowserSecurely('https://example.com');
+
+      expect(mockExecFile).toHaveBeenCalledWith(
+        'wslview',
+        ['https://example.com'],
+        expect.any(Object),
+      );
+    });
+
     it('should throw on unsupported platforms', async () => {
       setPlatform('aix');
       await expect(openBrowserSecurely('https://example.com')).rejects.toThrow(
@@ -241,6 +258,25 @@ describe('secure-browser-launcher', () => {
         ['https://example.com'],
         expect.any(Object),
       );
+    });
+  });
+
+  describe('File path launching', () => {
+    it('should open a local file path on macOS', async () => {
+      setPlatform('darwin');
+      await openFilePathSecurely('/tmp/qwen-insight.html');
+
+      expect(mockExecFile).toHaveBeenCalledWith(
+        'open',
+        ['/tmp/qwen-insight.html'],
+        expect.any(Object),
+      );
+    });
+
+    it('should reject file paths with control characters', async () => {
+      await expect(
+        openFilePathSecurely('/tmp/qwen\ninsight.html'),
+      ).rejects.toThrow('invalid characters');
     });
   });
 });

--- a/packages/core/src/utils/secure-browser-launcher.ts
+++ b/packages/core/src/utils/secure-browser-launcher.ts
@@ -41,6 +41,111 @@ function validateUrl(url: string): void {
   }
 }
 
+function validateFilePath(filePath: string): void {
+  if (!filePath.trim()) {
+    throw new Error('Invalid file path');
+  }
+
+  // eslint-disable-next-line no-control-regex
+  if (/[\r\n\x00-\x1f]/.test(filePath)) {
+    throw new Error('File path contains invalid characters');
+  }
+}
+
+function getLinuxBrowserCommands(): string[] {
+  const browserEnv = process.env['BROWSER']?.trim();
+  const commands = [
+    ...(browserEnv && browserEnv !== 'www-browser' ? [browserEnv] : []),
+    'xdg-open',
+    'gnome-open',
+    'kde-open',
+    'firefox',
+    'chromium',
+    'google-chrome',
+    'microsoft-edge',
+  ];
+
+  return [...new Set(commands)];
+}
+
+async function launchTarget(
+  target: string,
+  manualTargetLabel: 'URL' | 'file',
+): Promise<void> {
+  const platformName = platform();
+  const options: Record<string, unknown> = {
+    // Don't inherit parent's environment to avoid potential issues
+    env: {
+      ...process.env,
+      // Ensure we're not in a shell that might interpret special characters
+      SHELL: undefined,
+    },
+    // Detach the browser process so it doesn't block
+    detached: true,
+    stdio: 'ignore',
+  };
+
+  if (
+    platformName === 'linux' ||
+    platformName === 'freebsd' ||
+    platformName === 'openbsd'
+  ) {
+    for (const command of getLinuxBrowserCommands()) {
+      try {
+        await execFileAsync(command, [target], options);
+        return;
+      } catch {
+        continue;
+      }
+    }
+
+    /* eslint-disable no-console */
+    console.warn(
+      `Failed to open browser automatically. Please open this ${manualTargetLabel} manually: ${target}`,
+    );
+    /* eslint-enable no-console */
+    return;
+  }
+
+  let command: string;
+  let args: string[];
+
+  switch (platformName) {
+    case 'darwin':
+      // macOS
+      command = 'open';
+      args = [target];
+      break;
+
+    case 'win32':
+      // Windows - use PowerShell with Start-Process
+      // This avoids the cmd.exe shell which is vulnerable to injection
+      command = 'powershell.exe';
+      args = [
+        '-NoProfile',
+        '-NonInteractive',
+        '-WindowStyle',
+        'Hidden',
+        '-Command',
+        `Start-Process '${target.replace(/'/g, "''")}'`,
+      ];
+      break;
+
+    default:
+      throw new Error(`Unsupported platform: ${platformName}`);
+  }
+
+  try {
+    await execFileAsync(command, args, options);
+  } catch (_error) {
+    /* eslint-disable no-console */
+    console.warn(
+      `Failed to open browser automatically. Please open this ${manualTargetLabel} manually: ${target}`,
+    );
+    /* eslint-enable no-console */
+  }
+}
+
 /**
  * Opens a URL in the user's default browser securely.
  *
@@ -54,95 +159,12 @@ function validateUrl(url: string): void {
 export async function openBrowserSecurely(url: string): Promise<void> {
   // Validate the URL first
   validateUrl(url);
+  await launchTarget(url, 'URL');
+}
 
-  const platformName = platform();
-  let command: string;
-  let args: string[];
-
-  switch (platformName) {
-    case 'darwin':
-      // macOS
-      command = 'open';
-      args = [url];
-      break;
-
-    case 'win32':
-      // Windows - use PowerShell with Start-Process
-      // This avoids the cmd.exe shell which is vulnerable to injection
-      command = 'powershell.exe';
-      args = [
-        '-NoProfile',
-        '-NonInteractive',
-        '-WindowStyle',
-        'Hidden',
-        '-Command',
-        `Start-Process '${url.replace(/'/g, "''")}'`,
-      ];
-      break;
-
-    case 'linux':
-    case 'freebsd':
-    case 'openbsd':
-      // Linux and BSD variants
-      // Try xdg-open first, fall back to other options
-      command = 'xdg-open';
-      args = [url];
-      break;
-
-    default:
-      throw new Error(`Unsupported platform: ${platformName}`);
-  }
-
-  const options: Record<string, unknown> = {
-    // Don't inherit parent's environment to avoid potential issues
-    env: {
-      ...process.env,
-      // Ensure we're not in a shell that might interpret special characters
-      SHELL: undefined,
-    },
-    // Detach the browser process so it doesn't block
-    detached: true,
-    stdio: 'ignore',
-  };
-
-  try {
-    await execFileAsync(command, args, options);
-  } catch (_error) {
-    // For Linux, try fallback commands if xdg-open fails
-    if (
-      (platformName === 'linux' ||
-        platformName === 'freebsd' ||
-        platformName === 'openbsd') &&
-      command === 'xdg-open'
-    ) {
-      const fallbackCommands = [
-        'gnome-open',
-        'kde-open',
-        'firefox',
-        'chromium',
-        'google-chrome',
-        'microsoft-edge',
-      ];
-
-      for (const fallbackCommand of fallbackCommands) {
-        try {
-          await execFileAsync(fallbackCommand, [url], options);
-          return; // Success!
-        } catch {
-          // Try next command
-          continue;
-        }
-      }
-    }
-
-    // Log the URL so the user can open it manually instead of crashing.
-    /* eslint-disable no-console */
-    console.warn(
-      `Failed to open browser automatically. Please open this URL manually: ${url}`,
-    );
-    /* eslint-enable no-console */
-    return;
-  }
+export async function openFilePathSecurely(filePath: string): Promise<void> {
+  validateFilePath(filePath);
+  await launchTarget(filePath, 'file');
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #4712.

This switches `/bug`, `/docs`, and `/insight` away from the `open` package call path that can emit an asynchronous `spawn xdg-open ENOENT` on headless Linux. The commands now use the existing secure browser launcher helper, which falls back across common Linux launchers and logs the URL/file for manual opening instead of crashing the CLI.

The helper now also supports best-effort local file opening for generated insight reports, and honors a simple `BROWSER` executable override on Linux/BSD.

## Validation

Passed:
- `npm run test --workspace=@qwen-code/qwen-code-core -- src/utils/secure-browser-launcher.test.ts`
- `npm run test --workspace=@qwen-code/qwen-code -- src/ui/commands/bugCommand.test.ts src/ui/commands/docsCommand.test.ts src/ui/commands/insightCommand.test.ts`
- `npx eslint packages/core/src/utils/secure-browser-launcher.ts packages/core/src/utils/secure-browser-launcher.test.ts packages/cli/src/ui/commands/bugCommand.ts packages/cli/src/ui/commands/bugCommand.test.ts packages/cli/src/ui/commands/docsCommand.ts packages/cli/src/ui/commands/docsCommand.test.ts packages/cli/src/ui/commands/insightCommand.ts packages/cli/src/ui/commands/insightCommand.test.ts`
- `npx prettier --check packages/core/src/utils/secure-browser-launcher.ts packages/core/src/utils/secure-browser-launcher.test.ts packages/core/src/index.ts packages/cli/src/ui/commands/bugCommand.ts packages/cli/src/ui/commands/bugCommand.test.ts packages/cli/src/ui/commands/docsCommand.ts packages/cli/src/ui/commands/docsCommand.test.ts packages/cli/src/ui/commands/insightCommand.ts packages/cli/src/ui/commands/insightCommand.test.ts`
- `git diff --check`

Existing baseline failures observed locally:
- `npm run typecheck --workspace=@qwen-code/qwen-code-core` fails on pre-existing `FinishReason.IMAGE_RECITATION` / `FinishReason.IMAGE_OTHER` references.
- `npm run typecheck --workspace=@qwen-code/qwen-code` fails on pre-existing `ink/dom`, `ink/components/CursorContext`, and `FinishReason.IMAGE_*` errors.
- `npm run build --workspace=@qwen-code/qwen-code-core` fails on the same core typecheck baseline errors.
