### PR TITLE
fix(cli): skip thought parts in copy output

### DIFF
--- a/packages/cli/src/ui/commands/copyCommand.test.ts
+++ b/packages/cli/src/ui/commands/copyCommand.test.ts
@@ -160,6 +160,32 @@ describe('copyCommand', () => {
     });
   });
 
+  it('should not copy thought parts from the last AI message', async () => {
+    if (!copyCommand.action) throw new Error('Command has no action');
+
+    const historyWithThoughtPart = [
+      {
+        role: 'model',
+        parts: [
+          { text: 'internal reasoning', thought: true },
+          { text: 'Visible report' },
+        ],
+      },
+    ];
+
+    mockGetHistoryShallow.mockReturnValue(historyWithThoughtPart);
+    mockCopyToClipboard.mockResolvedValue(undefined);
+
+    const result = await copyCommand.action(mockContext, '');
+
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('Visible report');
+    expect(result).toEqual({
+      type: 'message',
+      messageType: 'info',
+      content: 'Last output copied to the clipboard',
+    });
+  });
+
   it('should filter out non-text parts', async () => {
     if (!copyCommand.action) throw new Error('Command has no action');
 

--- a/packages/cli/src/ui/commands/copyCommand.ts
+++ b/packages/cli/src/ui/commands/copyCommand.ts
@@ -362,7 +362,7 @@ export const copyCommand: SlashCommand = {
     }
     // Extract text from the parts
     const lastAiOutput = lastAiMessage.parts
-      ?.filter((part) => part.text)
+      ?.filter((part) => part.text && !part.thought)
       .map((part) => part.text)
       .join('');
 


### PR DESCRIPTION
## Summary

Fixes #4733.

`/copy` currently builds the clipboard text from every text part in the last model message. Reasoning providers can keep internal reasoning as text parts marked with `thought: true`, so the command can copy hidden/internal thinking together with the visible answer.

This changes `/copy` to copy only visible text parts and leaves thought parts out of the clipboard output. Code/LaTeX selectors still run against the same visible output text.

## Validation

- `npm run test --workspace=@qwen-code/qwen-code -- src/ui/commands/copyCommand.test.ts`
- `npx eslint packages/cli/src/ui/commands/copyCommand.ts packages/cli/src/ui/commands/copyCommand.test.ts`
- `npx prettier --check packages/cli/src/ui/commands/copyCommand.ts packages/cli/src/ui/commands/copyCommand.test.ts`
- `git diff --check`

## Existing baseline failures observed

- `npm run typecheck --workspace=@qwen-code/qwen-code` currently fails on unrelated workspace/core export and Ink type errors, including missing `formatDenialStateLog`, `atomicWriteFileSync`, `ink/dom`, and `FinishReason.IMAGE_*` symbols.
- `npm run build --workspace=@qwen-code/qwen-code-core` currently fails on unrelated `FinishReason.IMAGE_RECITATION` / `FinishReason.IMAGE_OTHER` references.
