### PR TITLE
chore: bump version 0.17.0 → 0.17.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.17.0",
+      "version": "0.17.1",
+      "hasInstallScript": true,
       "workspaces": [
         "packages/*",
         "packages/channels/base",
@@ -13387,6 +13388,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -17487,7 +17489,7 @@
     },
     "packages/channels/base": {
       "name": "@qwen-code/channel-base",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1"
       },
@@ -17497,7 +17499,7 @@
     },
     "packages/channels/dingtalk": {
       "name": "@qwen-code/channel-dingtalk",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base",
         "dingtalk-stream-sdk-nodejs": "^2.0.4"
@@ -17519,7 +17521,7 @@
     },
     "packages/channels/plugin-example": {
       "name": "@qwen-code/channel-plugin-example",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base",
         "ws": "^8.18.0"
@@ -17533,7 +17535,7 @@
     },
     "packages/channels/telegram": {
       "name": "@qwen-code/channel-telegram",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base",
         "grammy": "^1.41.1",
@@ -17546,7 +17548,7 @@
     },
     "packages/channels/weixin": {
       "name": "@qwen-code/channel-weixin",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "dependencies": {
         "@qwen-code/channel-base": "file:../base"
       },
@@ -17556,7 +17558,7 @@
     },
     "packages/cli": {
       "name": "@qwen-code/qwen-code",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
         "@google/genai": "2.6.0",
@@ -17580,7 +17582,7 @@
         "fzf": "^0.5.2",
         "glob": "^10.5.0",
         "highlight.js": "^11.11.1",
-        "ink": "^7.0.3",
+        "ink": "7.0.3",
         "ink-gradient": "^3.0.0",
         "ink-link": "^4.1.0",
         "ink-spinner": "^5.0.0",
@@ -17786,7 +17788,7 @@
     },
     "packages/core": {
       "name": "@qwen-code/qwen-code-core",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "hasInstallScript": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.36.1",
@@ -20394,7 +20396,7 @@
     },
     "packages/vscode-ide-companion": {
       "name": "qwen-code-vscode-ide-companion",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "LICENSE",
       "dependencies": {
         "@agentclientprotocol/sdk": "^0.14.1",
@@ -20461,7 +20463,7 @@
     },
     "packages/web-templates": {
       "name": "@qwen-code/web-templates",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "devDependencies": {
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -20968,7 +20970,7 @@
     },
     "packages/webui": {
       "name": "@qwen-code/webui",
-      "version": "0.17.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
         "markdown-it": "^14.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "engines": {
     "node": ">=22.0.0"
   },
@@ -19,7 +19,7 @@
     "url": "git+https://github.com/QwenLM/qwen-code.git"
   },
   "config": {
-    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.17.0"
+    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.17.1"
   },
   "scripts": {
     "start": "cross-env node scripts/start.js",

--- a/packages/channels/base/package.json
+++ b/packages/channels/base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-base",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Base channel infrastructure for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/dingtalk/package.json
+++ b/packages/channels/dingtalk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-dingtalk",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "DingTalk channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/plugin-example/package.json
+++ b/packages/channels/plugin-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-plugin-example",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/telegram/package.json
+++ b/packages/channels/telegram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-telegram",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Telegram channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/channels/weixin/package.json
+++ b/packages/channels/weixin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/channel-weixin",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "WeChat (Weixin) channel adapter for Qwen Code",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Qwen Code",
   "repository": {
     "type": "git",
@@ -37,7 +37,7 @@
     "dist"
   ],
   "config": {
-    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.17.0"
+    "sandboxImageUri": "ghcr.io/qwenlm/qwen-code:0.17.1"
   },
   "dependencies": {
     "@agentclientprotocol/sdk": "^0.14.1",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/qwen-code-core",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Qwen Code Core",
   "repository": {
     "type": "git",

--- a/packages/vscode-ide-companion/NOTICES.txt
+++ b/packages/vscode-ide-companion/NOTICES.txt
@@ -198,7 +198,7 @@ This file contains third-party software notices and license terms.
 
 
 ============================================================
-@modelcontextprotocol/sdk@1.25.1
+@modelcontextprotocol/sdk@1.29.0
 (git+https://github.com/modelcontextprotocol/typescript-sdk.git)
 
 MIT License
@@ -225,13 +225,34 @@ SOFTWARE.
 
 
 ============================================================
-@hono/node-server@1.19.7
+@hono/node-server@1.19.14
 (https://github.com/honojs/node-server.git)
 
-License text not found.
+MIT License
+
+Copyright (c) 2022 - present, Yusuke Wada and Hono contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
 
 ============================================================
-ajv@8.17.1
+ajv@8.20.0
 (No repository found)
 
 The MIT License (MIT)
@@ -2406,7 +2427,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
 ============================================================
-express-rate-limit@7.5.1
+express-rate-limit@8.5.2
 (git+https://github.com/express-rate-limit/express-rate-limit.git)
 
 ﻿# MIT License
@@ -2429,6 +2450,58 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+============================================================
+ip-address@10.2.0
+(git://github.com/beaugunderson/ip-address.git)
+
+Copyright (C) 2011 by Beau Gunderson
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+============================================================
+hono@4.12.23
+(git+https://github.com/honojs/hono.git)
+
+MIT License
+
+Copyright (c) 2021 - present, Yusuke Wada and Hono contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 
 ============================================================
@@ -2576,7 +2649,7 @@ SOFTWARE.
 
 
 ============================================================
-zod-to-json-schema@3.25.0
+zod-to-json-schema@3.25.2
 (https://github.com/StefanTerdell/zod-to-json-schema)
 
 ISC License

--- a/packages/vscode-ide-companion/package.json
+++ b/packages/vscode-ide-companion/package.json
@@ -2,7 +2,7 @@
   "name": "qwen-code-vscode-ide-companion",
   "displayName": "Qwen Code Companion",
   "description": "Enable Qwen Code with direct access to your VS Code workspace.",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "publisher": "qwenlm",
   "icon": "assets/icon.png",
   "repository": {

--- a/packages/web-templates/package.json
+++ b/packages/web-templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/web-templates",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Web templates bundled as embeddable JS/CSS strings",
   "repository": {
     "type": "git",

--- a/packages/webui/package.json
+++ b/packages/webui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@qwen-code/webui",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Shared UI components for Qwen Code packages",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## What this PR does

Bumps all package versions from 0.17.0 to 0.17.1 across the monorepo. This includes root `package.json`, all workspace packages (cli, core, channels, vscode-ide-companion, web-templates, webui), the sandbox container image tag, `package-lock.json`, and the VS Code extension's `NOTICES.txt` with updated third-party dependency license information.

## Why it's needed

Routine patch version bump to prepare for the next release.

## Reviewer Test Plan

### How to verify

1. Confirm all `package.json` files show `"version": "0.17.1"`.
2. Confirm `sandboxImageUri` references `:0.17.1` in root and cli `package.json`.
3. Confirm `package-lock.json` reflects the new version.
4. Confirm `NOTICES.txt` includes updated third-party notices.

### Evidence (Before & After)

N/A

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |  ⚠️   |
|  🐧 Linux  |  ⚠️   |

### Environment (optional)

N/A — version bump only.

## Risk & Scope

- Main risk or tradeoff: None — mechanical version bump with no code changes.
- Not validated / out of scope: Runtime behavior unchanged.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

将 monorepo 中所有包的版本从 0.17.0 升级到 0.17.1。包括根目录 `package.json`、所有工作区包（cli、core、channels、vscode-ide-companion、web-templates、webui）、沙箱容器镜像标签、`package-lock.json`，以及 VS Code 扩展的 `NOTICES.txt`（更新了第三方依赖的许可证信息）。

## 为什么需要这个 PR

常规的 patch 版本升级，为下一次发版做准备。

## 审查者测试计划

### 如何验证

1. 确认所有 `package.json` 文件中版本号为 `"version": "0.17.1"`。
2. 确认根目录和 cli 的 `package.json` 中 `sandboxImageUri` 引用 `:0.17.1`。
3. 确认 `package-lock.json` 反映了新版本。
4. 确认 `NOTICES.txt` 包含更新后的第三方通知信息。

### 证据（变更前 & 变更后）

N/A

### 测试平台

|     OS     | 状态 |
| :--------: | :--: |
|  🍏 macOS  |  ✅  |
| 🪟 Windows |  ⚠️  |
|  🐧 Linux  |  ⚠️  |

### 环境（可选）

N/A — 仅版本升级。

## 风险与范围

- 主要风险或权衡：无 — 纯机械性版本升级，无代码变更。
- 未验证 / 超出范围：运行时行为未改变。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>

---

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)