### PR TITLE
fix(ui): display model name instead of id in statusline and startup banner

### DIFF
--- a/packages/cli/src/ui/components/AppHeader.test.tsx
+++ b/packages/cli/src/ui/components/AppHeader.test.tsx
@@ -47,6 +47,7 @@ const createSettings = (options?: {
 const createMockConfig = (overrides = {}) => ({
   getContentGeneratorConfig: vi.fn(() => ({ authType: undefined })),
   getModel: vi.fn(() => 'gemini-pro'),
+  getModelDisplayName: vi.fn(() => 'Gemini Pro'),
   getTargetDir: vi.fn(() => '/projects/qwen-code'),
   getMcpServers: vi.fn(() => ({})),
   getBlockedMcpServers: vi.fn(() => []),
@@ -106,7 +107,7 @@ describe('<AppHeader />', () => {
   it('shows the header with all info when banner is visible', () => {
     const { lastFrame } = renderWithProviders(createMockUIState());
     expect(lastFrame()).toContain('>_ Qwen Code');
-    expect(lastFrame()).toContain('gemini-pro');
+    expect(lastFrame()).toContain('Gemini Pro');
     expect(lastFrame()).toContain('/projects/qwen-code');
   });
 

--- a/packages/cli/src/ui/components/AppHeader.tsx
+++ b/packages/cli/src/ui/components/AppHeader.tsx
@@ -15,7 +15,6 @@ import { Header, AuthDisplayType } from './Header.js';
 import { Tips } from './Tips.js';
 import { useSettings } from '../contexts/SettingsContext.js';
 import { useConfig } from '../contexts/ConfigContext.js';
-import { useUIState } from '../contexts/UIStateContext.js';
 import { resolveCustomBanner } from '../utils/customBanner.js';
 
 interface AppHeaderProps {
@@ -50,11 +49,9 @@ function getAuthDisplayType(
 export const AppHeader = ({ version }: AppHeaderProps) => {
   const settings = useSettings();
   const config = useConfig();
-  const uiState = useUIState();
-
   const contentGeneratorConfig = config.getContentGeneratorConfig();
   const authType = contentGeneratorConfig?.authType;
-  const model = uiState.currentModel;
+  const model = config.getModelDisplayName();
   const targetDir = config.getTargetDir();
   const showBanner =
     !config.getScreenReader() && !settings.merged.ui?.hideBanner;

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -290,7 +290,12 @@ export function ModelDialog({
                 [{t2}]
               </Text>
               <Text>{` ${model.label}`}</Text>
-              <Text color={theme.text.secondary} italic>
+              {model.id !== model.label && (
+                <Text color={theme.text.secondary} italic>
+                  {' '}
+                  ({model.id})
+                </Text>
+              )}
                 {' '}
                 ({model.id})
               </Text>

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -296,9 +296,6 @@ export function ModelDialog({
                   ({model.id})
                 </Text>
               )}
-                {' '}
-                ({model.id})
-              </Text>
               {isRuntime && (
                 <Text color={theme.status.warning}> (Runtime)</Text>
               )}

--- a/packages/cli/src/ui/components/ModelDialog.tsx
+++ b/packages/cli/src/ui/components/ModelDialog.tsx
@@ -290,6 +290,10 @@ export function ModelDialog({
                 [{t2}]
               </Text>
               <Text>{` ${model.label}`}</Text>
+              <Text color={theme.text.secondary} italic>
+                {' '}
+                ({model.id})
+              </Text>
               {isRuntime && (
                 <Text color={theme.status.warning}> (Runtime)</Text>
               )}

--- a/packages/cli/src/ui/components/StatusLineDialog.test.tsx
+++ b/packages/cli/src/ui/components/StatusLineDialog.test.tsx
@@ -48,6 +48,7 @@ function createSettings(): LoadedSettings {
 const config = {
   getCliVersion: () => '1.2.3',
   getModel: () => 'qwen3-code-plus',
+  getModelDisplayName: () => 'Qwen3 Code Plus',
   getTargetDir: () => '/repo/project',
   getContentGeneratorConfig: () => ({
     contextWindowSize: 1000,
@@ -106,7 +107,7 @@ describe('StatusLineDialog', () => {
       frame.indexOf('current-dir'),
     );
     expect(lastFrame()).toContain('Preview');
-    expect(lastFrame()).toContain('qwen3-code-plus high');
+    expect(lastFrame()).toContain('Qwen3 Code Plus high');
   });
 
   it('persists selected presets on enter', async () => {
@@ -187,7 +188,7 @@ describe('StatusLineDialog', () => {
     await press(' ');
 
     expect(lastFrame()).toContain(
-      'qwen3-code-plus high | feature/pr-4087-statusline | Context 75% left',
+      'Qwen3 Code Plus high | feature/pr-4087-statusline | Context 75% left',
     );
 
     await press('\r');

--- a/packages/cli/src/ui/components/StatusLineDialog.tsx
+++ b/packages/cli/src/ui/components/StatusLineDialog.tsx
@@ -100,7 +100,7 @@ function getPreviewData(config: Config, uiState: UIState) {
   return buildStatusLinePresetData({
     sessionId: stats.sessionId,
     version: config.getCliVersion(),
-    modelDisplayName: uiState.currentModel || config.getModel(),
+    modelDisplayName: config.getModelDisplayName(),
     reasoning: contentGeneratorConfig?.reasoning,
     currentDir: config.getTargetDir(),
     branch: uiState.branchName,

--- a/packages/cli/src/ui/hooks/useStatusLine.test.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.test.ts
@@ -68,6 +68,7 @@ const getMockContentGeneratorConfig = (): MockContentGeneratorConfig => ({
 const mockConfig = {
   getTargetDir: vi.fn(() => '/test/dir'),
   getModel: vi.fn(() => 'test-model'),
+  getModelDisplayName: vi.fn(() => 'Test Model'),
   getCliVersion: vi.fn(() => '1.0.0'),
   getContentGeneratorConfig: vi.fn(getMockContentGeneratorConfig),
 };
@@ -282,7 +283,7 @@ describe('useStatusLine', () => {
       const { result } = renderHook(() => useStatusLine());
 
       expect(result.current.useThemeColors).toBe(true);
-      expect(result.current.lines).toEqual(['test-model']);
+      expect(result.current.lines).toEqual(['Test Model']);
     });
 
     it('looks up the current branch pull request number with gh', async () => {
@@ -315,7 +316,7 @@ describe('useStatusLine', () => {
       const { result } = renderHook(() => useStatusLine());
 
       expect(child_process.exec).not.toHaveBeenCalled();
-      expect(result.current.lines).toEqual(['test-model']);
+      expect(result.current.lines).toEqual(['Test Model']);
     });
 
     it('renders model-with-reasoning and model-only together', () => {
@@ -330,7 +331,7 @@ describe('useStatusLine', () => {
       const { result } = renderHook(() => useStatusLine());
 
       expect(child_process.exec).not.toHaveBeenCalled();
-      expect(result.current.lines).toEqual(['test-model high | test-model']);
+      expect(result.current.lines).toEqual(['Test Model high | Test Model']);
     });
 
     it('refreshes when status line settings are saved in the same process', async () => {
@@ -342,7 +343,7 @@ describe('useStatusLine', () => {
       const { result, rerender } = renderHook(() => useStatusLine());
 
       expect(child_process.exec).not.toHaveBeenCalled();
-      expect(result.current.lines).toEqual(['test-model']);
+      expect(result.current.lines).toEqual(['Test Model']);
 
       setStatusLineConfig({
         type: 'preset',
@@ -365,7 +366,7 @@ describe('useStatusLine', () => {
         vi.advanceTimersByTime(300);
       });
 
-      expect(result.current.lines).toEqual(['test-model | #4118']);
+      expect(result.current.lines).toEqual(['Test Model | #4118']);
     });
 
     it('reloads status line settings from disk when streaming becomes idle', async () => {
@@ -375,7 +376,7 @@ describe('useStatusLine', () => {
       });
       const { result, rerender } = renderHook(() => useStatusLine());
 
-      expect(result.current.lines).toEqual(['test-model']);
+      expect(result.current.lines).toEqual(['Test Model']);
 
       mockSettings.reloadScopeFromDisk.mockImplementationOnce(() => {
         setStatusLineConfig({
@@ -397,7 +398,7 @@ describe('useStatusLine', () => {
       });
 
       expect(mockSettings.reloadScopeFromDisk).toHaveBeenCalledOnce();
-      expect(result.current.lines).toEqual(['test-model high']);
+      expect(result.current.lines).toEqual(['Test Model high']);
     });
 
     it('uses command settings when a stale preset override no longer matches the settings type', () => {
@@ -582,7 +583,7 @@ describe('useStatusLine', () => {
       const input = JSON.parse(stdinWrittenData);
       expect(input.session_id).toBe('test-session');
       expect(input.version).toBe('1.0.0');
-      expect(input.model.display_name).toBe('test-model');
+      expect(input.model.display_name).toBe('Test Model');
       expect(input.workspace.current_dir).toBe('/test/dir');
     });
 
@@ -687,7 +688,7 @@ describe('useStatusLine', () => {
       renderHook(() => useStatusLine());
 
       const input = JSON.parse(stdinWrittenData);
-      expect(input.model.display_name).toBe('test-model');
+      expect(input.model.display_name).toBe('Test Model');
     });
   });
 

--- a/packages/cli/src/ui/hooks/useStatusLine.ts
+++ b/packages/cli/src/ui/hooks/useStatusLine.ts
@@ -393,7 +393,7 @@ export function useStatusLine(): {
       const data = buildStatusLinePresetData({
         sessionId: stats.sessionId,
         version: cfg.getCliVersion(),
-        modelDisplayName: ui.currentModel || cfg.getModel(),
+        modelDisplayName: cfg.getModelDisplayName(),
         reasoning: contentGeneratorConfig?.reasoning,
         currentDir,
         branch: ui.branchName,
@@ -444,7 +444,7 @@ export function useStatusLine(): {
       session_id: stats.sessionId,
       version: cfg.getCliVersion() || 'unknown',
       model: {
-        display_name: ui.currentModel || cfg.getModel() || 'unknown',
+        display_name: cfg.getModelDisplayName(),
       },
       context_window: {
         context_window_size: contextWindowSize,

--- a/packages/core/src/config/config.test.ts
+++ b/packages/core/src/config/config.test.ts
@@ -3561,4 +3561,58 @@ describe('Model Switching and Config Updates', () => {
       );
     });
   });
+
+  describe('getModelDisplayName', () => {
+    it('should return resolved name when model is in registry', () => {
+      const config = new Config({
+        ...baseParams,
+        authType: AuthType.USE_OPENAI,
+        model: 'gpt-4o',
+        modelProvidersConfig: {
+          [AuthType.USE_OPENAI]: [
+            {
+              id: 'gpt-4o',
+              name: 'GPT-4o',
+              baseUrl: 'https://api.openai.example.com/v1',
+              envKey: 'OPENAI_API_KEY',
+            },
+          ],
+        },
+      });
+
+      expect(config.getModelDisplayName()).toBe('GPT-4o');
+    });
+
+    it('should return raw modelId when model is not in registry', () => {
+      const config = new Config({
+        ...baseParams,
+        authType: AuthType.USE_OPENAI,
+        model: 'custom-runtime-model',
+        modelProvidersConfig: {
+          [AuthType.USE_OPENAI]: [
+            {
+              id: 'gpt-4o',
+              name: 'GPT-4o',
+              baseUrl: 'https://api.openai.example.com/v1',
+              envKey: 'OPENAI_API_KEY',
+            },
+          ],
+        },
+      });
+
+      expect(config.getModelDisplayName()).toBe('custom-runtime-model');
+    });
+
+    it('should return raw modelId when currentAuthType is falsy', () => {
+      const config = new Config({
+        ...baseParams,
+        model: 'some-model',
+        // authType is not set
+      });
+
+      // getModel() returns 'some-model', getModelDisplayName returns it as-is
+      // because currentAuthType is falsy
+      expect(config.getModelDisplayName()).toBe('some-model');
+    });
+  });
 });

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2205,8 +2205,7 @@ export class Config {
    * Falls back to the raw model id when the model is not found.
    */
   getModelDisplayName(): string {
-    const modelId = this.getModel();
-    return modelId ? this.modelsConfig.getModelDisplayName(modelId) : 'unknown';
+    return this.modelsConfig.getModelDisplayName(this.getModel());
   }
 
   onModelChange(listener: (model: string) => void): () => void {

--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -2199,6 +2199,16 @@ export class Config {
     );
   }
 
+  /**
+   * Get the human-readable display name for the currently selected model.
+   * Resolves the model id to its name from the model registry.
+   * Falls back to the raw model id when the model is not found.
+   */
+  getModelDisplayName(): string {
+    const modelId = this.getModel();
+    return modelId ? this.modelsConfig.getModelDisplayName(modelId) : 'unknown';
+  }
+
   onModelChange(listener: (model: string) => void): () => void {
     this.modelChangeListeners.add(listener);
     return () => {

--- a/packages/core/src/models/modelsConfig.test.ts
+++ b/packages/core/src/models/modelsConfig.test.ts
@@ -2421,4 +2421,79 @@ describe('ModelsConfig', () => {
       expect(gc.samplingParams).toBeUndefined();
     });
   });
+
+  describe('getModelDisplayName', () => {
+    it('should return resolved.name when model is found in registry', () => {
+      const modelProvidersConfig: ModelProvidersConfig = {
+        openai: [
+          {
+            id: 'gpt-4o',
+            name: 'GPT-4o',
+            baseUrl: 'https://api.openai.example.com/v1',
+            envKey: 'OPENAI_API_KEY',
+          },
+        ],
+      };
+
+      const modelsConfig = new ModelsConfig({
+        initialAuthType: AuthType.USE_OPENAI,
+        modelProvidersConfig,
+      });
+
+      expect(modelsConfig.getModelDisplayName('gpt-4o')).toBe('GPT-4o');
+    });
+
+    it('should return raw modelId when currentAuthType is falsy', () => {
+      const modelsConfig = new ModelsConfig();
+      // currentAuthType is undefined by default
+
+      expect(modelsConfig.getModelDisplayName('some-model')).toBe('some-model');
+    });
+
+    it('should return raw modelId when model is not found in registry', () => {
+      const modelProvidersConfig: ModelProvidersConfig = {
+        openai: [
+          {
+            id: 'gpt-4o',
+            name: 'GPT-4o',
+            baseUrl: 'https://api.openai.example.com/v1',
+            envKey: 'OPENAI_API_KEY',
+          },
+        ],
+      };
+
+      const modelsConfig = new ModelsConfig({
+        initialAuthType: AuthType.USE_OPENAI,
+        modelProvidersConfig,
+      });
+
+      // 'unknown-model' is not in the registry
+      expect(modelsConfig.getModelDisplayName('unknown-model')).toBe(
+        'unknown-model',
+      );
+    });
+
+    it('should return raw modelId when model.name equals model.id', () => {
+      const modelProvidersConfig: ModelProvidersConfig = {
+        openai: [
+          {
+            id: 'coder-model',
+            name: 'coder-model',
+            baseUrl: 'https://api.openai.example.com/v1',
+            envKey: 'OPENAI_API_KEY',
+          },
+        ],
+      };
+
+      const modelsConfig = new ModelsConfig({
+        initialAuthType: AuthType.USE_OPENAI,
+        modelProvidersConfig,
+      });
+
+      // name === id, so registry returns the id as name
+      expect(modelsConfig.getModelDisplayName('coder-model')).toBe(
+        'coder-model',
+      );
+    });
+  });
 });

--- a/packages/core/src/models/modelsConfig.ts
+++ b/packages/core/src/models/modelsConfig.ts
@@ -313,6 +313,18 @@ export class ModelsConfig {
   }
 
   /**
+   * Get the display name for a model by its id.
+   * Looks up the model in the registry using the current authType and returns
+   * its resolved name. Falls back to the raw model id when the model is not
+   * found in the registry (e.g. runtime models or unknown models).
+   */
+  getModelDisplayName(modelId: string): string {
+    if (!this.currentAuthType) return modelId;
+    const resolved = this.modelRegistry.getModel(this.currentAuthType, modelId);
+    return resolved?.name ?? modelId;
+  }
+
+  /**
    * Set model programmatically (e.g., VLM auto-switch, fallback).
    * Supports both registry models and raw model IDs.
    */


### PR DESCRIPTION

## What this PR does

Adds `getModelDisplayName()` to `ModelsConfig` and `Config` that resolves the current model id to its human-readable display name from the model registry, falling back to the raw id when not found. Replaces `ui.currentModel || cfg.getModel()` with `cfg.getModelDisplayName()` in the statusline (preset and command mode), the statusline preview dialog, and the startup banner. The model selection dialog now shows the model id in italic parentheses after the model name.

## Why it's needed

The statusline and startup banner displayed the raw model id (e.g. `qwen3-coder-plus`) instead of the model's display name. The data flow was a pure-string pipeline — `getModel()` returns only a bare string id, and the `name`/`label` field was never threaded to the UI layer. This PR adds name resolution at the display layer without changing any existing API or business logic.

Fixes: #4722


## Reviewer Test Plan

### Evidence (Before & After)
**Before**:
<img width="2262" height="556" alt="QQ20260603-191307" src="https://github.com/user-attachments/assets/c3605d27-c35c-4537-a7ca-ce4e6fdd3311" />
<img width="2254" height="1194" alt="QQ20260603-191330" src="https://github.com/user-attachments/assets/db18f947-abca-4982-8926-27e758ab5c5e" />

**After**:
<img width="2254" height="562" alt="QQ20260603-192207" src="https://github.com/user-attachments/assets/1c2292bb-35cd-4eba-80d1-f63a03f69ff1" />
<img width="2232" height="1214" alt="QQ20260603-192236" src="https://github.com/user-attachments/assets/cac4b230-0960-4e67-9d0b-535b0337653b" />

### How to verify

1. Build and run
   ```shell
   npm run build
   npm start
   ```

2. Statusline shows model display name instead of id
   - Start the CLI with a model that has a display name different from its id
   - The statusline footer should show the display name (e.g. `Qwen3 Coder Plus` instead of `qwen3-coder-plus`)
   - Both preset mode and command mode should display the same name

3. Startup banner shows model display name
   - The startup banner line (e.g. `API Key | Qwen3 Coder Plus`) should show the display name, not the raw id

4. Model selection dialog shows name with id suffix
   - Run `/model` to open the model selection dialog
   - Each model should display as `name (id)` with the id in italic

5. Regression
   - Model switching, `/model` command, settings persistence: all work as before (these use model id internally, unchanged)


### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ⚠️   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ✅   |

## Risk & Scope

- Main risk or tradeoff: None — `getModelDisplayName()` is a new method; existing `getModel()` and all business logic remain unchanged. Falls back to raw id if model not found in registry.
- Not validated / out of scope: Multi-key model identity separation (tracked separately)
- Breaking changes / migration notes: None


## Linked Issues

<!-- Closes #N / Fixes #N / Resolves #N to auto-close. -->


<details>
<summary>中文说明</summary>

新增 `getModelDisplayName()` 方法，将 model id 解析为 model name 显示。statusline 和启动 banner 两处改为显示 model name（原为 model id）。模型选择界面在 name 后追加斜体显示 model id。

本次改动仅在显示层增加 name 解析，不修改任何现有 API 或业务逻辑。`getModel()` 返回值不变，`ui.currentModel` 类型和值不变，模型切换、设置持久化、provider lookup 等所有业务逻辑不受影响。

</details>
