### PR TITLE
feat(telemetry): add daemon OTel metrics and structured log records

### DIFF
--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -1153,7 +1153,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         // but daemon stays up) still logs — there's no upstream
         // context line in that flow, and the message confirms the
         // cleanup actually ran.
-        const channelExitExpected = shuttingDown;
+        const channelExitExpected = shuttingDown || info.isDying;
         telemetry.metrics?.channelLifecycle('exit', channelExitExpected);
         if (!shuttingDown) {
           telemetry.event('channel.exited', {

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -207,6 +207,7 @@ interface ChannelInfo {
    * two-bit (alive, dying) state.
    */
   isDying: boolean;
+  handshakeComplete: boolean;
 }
 
 interface SessionEntry {
@@ -1092,6 +1093,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         sessionIds: new Set(),
         pendingRestoreIds: new Set(),
         isDying: false,
+        handshakeComplete: false,
       };
       aliveChannels.add(info);
       // Belt-and-suspenders leak detection. The set is intentionally
@@ -1154,7 +1156,9 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         // context line in that flow, and the message confirms the
         // cleanup actually ran.
         const channelExitExpected = shuttingDown || info.isDying;
-        telemetry.metrics?.channelLifecycle('exit', channelExitExpected);
+        if (info.handshakeComplete) {
+          telemetry.metrics?.channelLifecycle('exit', channelExitExpected);
+        }
         if (!shuttingDown) {
           telemetry.event('channel.exited', {
             'qwen-code.daemon.channel.exit_code': exitInfo?.exitCode ?? -1,
@@ -1253,6 +1257,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       // never returns a still-handshaking channel to a concurrent
       // caller.
       channelInfo = info;
+      info.handshakeComplete = true;
       telemetry.metrics?.channelLifecycle('spawn');
       return info;
     })();

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -4332,6 +4332,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       // `byId` (above), so the handler's `byId.get(...)` is undefined
       // and the automatic publish wouldn't fire.
       for (const e of entries) {
+        telemetry.metrics?.sessionLifecycle('die');
         try {
           e.events.publish({
             type: 'session_died',

--- a/packages/acp-bridge/src/bridge.ts
+++ b/packages/acp-bridge/src/bridge.ts
@@ -1153,6 +1153,8 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
         // but daemon stays up) still logs — there's no upstream
         // context line in that flow, and the message confirms the
         // cleanup actually ran.
+        const channelExitExpected = shuttingDown;
+        telemetry.metrics?.channelLifecycle('exit', channelExitExpected);
         if (!shuttingDown) {
           telemetry.event('channel.exited', {
             'qwen-code.daemon.channel.exit_code': exitInfo?.exitCode ?? -1,
@@ -1184,6 +1186,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
             /* bus already closed */
           }
           byId.delete(sid);
+          telemetry.metrics?.sessionLifecycle('die');
           // Tombstone the id so any late `extNotification` from the
           // dying child can't leak into the early-event buffer for a
           // future load/resume of the same persisted session id.
@@ -1250,6 +1253,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       // never returns a still-handshaking channel to a concurrent
       // caller.
       channelInfo = info;
+      telemetry.metrics?.channelLifecycle('spawn');
       return info;
     })();
 
@@ -1719,6 +1723,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
     };
     ci.sessionIds.add(entry.sessionId);
     byId.set(entry.sessionId, entry);
+    telemetry.metrics?.sessionLifecycle('spawn');
     // Drain any guardrail events that fired during this session's
     // `newSession` handler (before this entry registered) onto the
     // freshly-created EventBus. Idempotent on unknown sessionIds.
@@ -2264,15 +2269,17 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       // sent a stale id in the body would otherwise be dispatched to the
       // wrong agent process.
       const result = entry.promptQueue.then(() =>
-        telemetry.runWithContext(
-          capturedContext,
-          async () =>
-            await telemetry.withSpan(
+        telemetry.runWithContext(capturedContext, async () => {
+          const queueWaitMs = Date.now() - queuedAt;
+          telemetry.metrics?.promptQueueWait(queueWaitMs);
+          const dispatchStartMs = Date.now();
+          try {
+            return await telemetry.withSpan(
               'prompt.dispatch',
               {
                 'qwen-code.daemon.bridge.operation': 'prompt.dispatch',
                 'session.id': sessionId,
-                'qwen-code.daemon.prompt.queue_wait_ms': Date.now() - queuedAt,
+                'qwen-code.daemon.prompt.queue_wait_ms': queueWaitMs,
                 ...(context?.clientId
                   ? { 'qwen-code.client_id': context.clientId }
                   : {}),
@@ -2390,8 +2397,11 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
                 }
                 return racedPromise;
               },
-            ),
-        ),
+            );
+          } finally {
+            telemetry.metrics?.promptDuration(Date.now() - dispatchStartMs);
+          }
+        }),
       );
       const promptId = context?.promptId;
       result.then(
@@ -2481,6 +2491,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       const notif: CancelNotification = req
         ? { ...req, sessionId }
         : { sessionId };
+      telemetry.metrics?.cancelled();
       await telemetry.withSpan(
         'session.cancel',
         {
@@ -2688,6 +2699,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       permissionMediator.forgetSession(sessionId);
       entry.pendingPermissionIds.clear();
       byId.delete(sessionId);
+      telemetry.metrics?.sessionLifecycle('close');
       // Tombstone the closed sessionId so any late `extNotification`
       // from the (now-defunct) child can't seed the early-event buffer
       // and leak into a future load/resume of the same persisted id.
@@ -4168,6 +4180,7 @@ export function createHttpAcpBridge(opts: BridgeOptions): HttpAcpBridge {
       // can't reattach to a session we're tearing down.
       if (defaultEntry === entry) defaultEntry = undefined;
       byId.delete(sessionId);
+      telemetry.metrics?.sessionLifecycle('die');
       // Detach from the channel. The channel dies only when its LAST
       // session leaves — other sessions on the same channel keep
       // running.

--- a/packages/acp-bridge/src/bridgeOptions.ts
+++ b/packages/acp-bridge/src/bridgeOptions.ts
@@ -11,7 +11,10 @@
  * `cli/src/serve/`.
  */
 
-import type { ApprovalMode } from '@qwen-code/qwen-code-core';
+import type {
+  ApprovalMode,
+  DaemonBridgeTelemetryMetrics,
+} from '@qwen-code/qwen-code-core';
 import type { ChannelFactory } from './channel.js';
 import type { PermissionPolicy } from './permission.js';
 import type { PermissionAuditPublisher } from './permissionMediator.js';
@@ -97,13 +100,7 @@ export type BridgeTelemetryAttributes = Record<
   string | number | boolean
 >;
 
-export interface BridgeTelemetryMetrics {
-  sessionLifecycle(action: 'spawn' | 'close' | 'die'): void;
-  channelLifecycle(action: 'spawn' | 'exit', expected?: boolean): void;
-  promptQueueWait(durationMs: number): void;
-  promptDuration(durationMs: number): void;
-  cancelled(): void;
-}
+export type BridgeTelemetryMetrics = DaemonBridgeTelemetryMetrics;
 
 export interface BridgeTelemetry {
   captureContext(): unknown;

--- a/packages/acp-bridge/src/bridgeOptions.ts
+++ b/packages/acp-bridge/src/bridgeOptions.ts
@@ -97,6 +97,14 @@ export type BridgeTelemetryAttributes = Record<
   string | number | boolean
 >;
 
+export interface BridgeTelemetryMetrics {
+  sessionLifecycle(action: 'spawn' | 'close' | 'die'): void;
+  channelLifecycle(action: 'spawn' | 'exit', expected?: boolean): void;
+  promptQueueWait(durationMs: number): void;
+  promptDuration(durationMs: number): void;
+  cancelled(): void;
+}
+
 export interface BridgeTelemetry {
   captureContext(): unknown;
   runWithContext<T>(captured: unknown, fn: () => Promise<T>): Promise<T>;
@@ -107,6 +115,7 @@ export interface BridgeTelemetry {
   ): Promise<T>;
   event(name: string, attributes: BridgeTelemetryAttributes): void;
   injectPromptContext<T extends object>(request: T): T;
+  metrics?: BridgeTelemetryMetrics;
 }
 
 /**

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -687,7 +687,6 @@ export async function runQwenServe(
         },
         {
           eventName: `qwen-code.daemon.session.${action}`,
-          ...(action === 'die' ? { severityNumber: 13 } : {}),
         },
       );
     },

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -124,8 +124,8 @@ function createDaemonTelemetryRuntimeConfig(
     getTelemetryIncludeSensitiveSpanAttributes: () =>
       telemetry.includeSensitiveSpanAttributes ?? false,
     getTelemetryResourceAttributes: () => ({
-      ...(telemetry.resourceAttributes ?? {}),
       'service.instance.id': daemonSessionId,
+      ...(telemetry.resourceAttributes ?? {}),
     }),
     getTelemetryMetricsIncludeSessionId: () =>
       telemetry.metrics?.includeSessionId ?? false,
@@ -697,7 +697,11 @@ export async function runQwenServe(
         action === 'spawn'
           ? 'ACP channel spawned.'
           : `ACP channel exited (expected=${expected}).`,
-        { 'qwen-code.daemon.channel.expected': expected ?? true },
+        {
+          ...(action === 'exit'
+            ? { 'qwen-code.daemon.channel.expected': expected ?? true }
+            : {}),
+        },
         {
           eventName: `qwen-code.daemon.channel.${action}`,
           ...(!expected && action === 'exit' ? { severityNumber: 13 } : {}),

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -20,8 +20,17 @@ import {
   DEFAULT_OTLP_ENDPOINT,
   DEFAULT_TELEMETRY_TARGET,
   createDaemonBridgeTelemetry,
+  emitDaemonLog,
+  forceFlushMetrics,
   hashDaemonWorkspace,
+  initializeDaemonMetrics,
   initializeTelemetry,
+  recordDaemonCancel,
+  recordDaemonChannelLifecycle,
+  recordDaemonPromptDuration,
+  recordDaemonPromptQueueWait,
+  recordDaemonSessionLifecycle,
+  registerDaemonGaugeCallbacks,
   resolveTelemetrySettings,
   shutdownTelemetry,
   type TelemetryRuntimeConfig,
@@ -35,7 +44,11 @@ import {
   createPermissionAuditPublisher,
   PermissionAuditRing,
 } from './permissionAudit.js';
-import { createServeApp, resolveBridgeFsFactory } from './server.js';
+import {
+  createServeApp,
+  getActiveSseCount,
+  resolveBridgeFsFactory,
+} from './server.js';
 import { initDaemonLogger, type DaemonLogger } from './daemonLogger.js';
 import { createSpawnChannelFactory } from '@qwen-code/acp-bridge/spawnChannel';
 import { SERVE_CAPABILITY_REGISTRY } from './capabilities.js';
@@ -110,7 +123,10 @@ function createDaemonTelemetryRuntimeConfig(
     getTelemetryOutfile: () => telemetry.outfile,
     getTelemetryIncludeSensitiveSpanAttributes: () =>
       telemetry.includeSensitiveSpanAttributes ?? false,
-    getTelemetryResourceAttributes: () => telemetry.resourceAttributes ?? {},
+    getTelemetryResourceAttributes: () => ({
+      ...(telemetry.resourceAttributes ?? {}),
+      'service.instance.id': daemonSessionId,
+    }),
     getTelemetryMetricsIncludeSessionId: () =>
       telemetry.metrics?.includeSessionId ?? false,
     getTelemetryResourceAttributeWarnings: () =>
@@ -659,7 +675,45 @@ export async function runQwenServe(
       `daemon:${daemonWorkspaceHash}:${process.pid}`,
     ),
   );
+  initializeDaemonMetrics();
   const daemonTelemetry = createDaemonBridgeTelemetry();
+  daemonTelemetry.metrics = {
+    sessionLifecycle(action) {
+      recordDaemonSessionLifecycle(action);
+      emitDaemonLog(
+        `Session ${action}.`,
+        {
+          'qwen-code.workspace.hash': daemonWorkspaceHash,
+        },
+        {
+          eventName: `qwen-code.daemon.session.${action}`,
+          ...(action === 'die' ? { severityNumber: 13 } : {}),
+        },
+      );
+    },
+    channelLifecycle(action, expected) {
+      recordDaemonChannelLifecycle(action, expected);
+      emitDaemonLog(
+        action === 'spawn'
+          ? 'ACP channel spawned.'
+          : `ACP channel exited (expected=${expected}).`,
+        { 'qwen-code.daemon.channel.expected': expected ?? true },
+        {
+          eventName: `qwen-code.daemon.channel.${action}`,
+          ...(!expected && action === 'exit' ? { severityNumber: 13 } : {}),
+        },
+      );
+    },
+    promptQueueWait(durationMs) {
+      recordDaemonPromptQueueWait(durationMs);
+    },
+    promptDuration(durationMs) {
+      recordDaemonPromptDuration(durationMs);
+    },
+    cancelled() {
+      recordDaemonCancel();
+    },
+  };
 
   // Allocate the audit ring + publisher in the daemon host (here)
   // rather than inside the bridge factory, because the ring is the
@@ -757,6 +811,11 @@ export async function runQwenServe(
           );
         }),
     });
+  registerDaemonGaugeCallbacks({
+    sessionCount: () => bridge.sessionCount,
+    sseCount: () => getActiveSseCount(),
+    heapUsed: () => process.memoryUsage().heapUsed,
+  });
   let actualPort = opts.port;
   // Pass the already-canonical `boundWorkspace` into `createServeApp`
   // via `deps.boundWorkspace`. That field is the pre-canonicalized
@@ -1026,6 +1085,15 @@ export async function runQwenServe(
                 );
               }
             }
+            void forceFlushMetrics().catch((flushErr) => {
+              daemonLog.warn(
+                `pre-shutdown metrics flush failed: ${
+                  flushErr instanceof Error
+                    ? flushErr.message
+                    : String(flushErr)
+                }`,
+              );
+            });
             bridge
               .shutdown()
               .catch((err) => {

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -1091,68 +1091,71 @@ export async function runQwenServe(
                 );
               }
             }
-            await forceFlushMetrics().catch((flushErr) => {
-              daemonLog.warn(
-                `pre-shutdown metrics flush failed: ${
-                  flushErr instanceof Error
-                    ? flushErr.message
-                    : String(flushErr)
-                }`,
-              );
-            });
-            bridge
-              .shutdown()
-              .catch((err) => {
-                daemonLog.error(
-                  'bridge shutdown error',
-                  err instanceof Error ? err : null,
+            forceFlushMetrics()
+              .catch((flushErr) => {
+                daemonLog.warn(
+                  `pre-shutdown metrics flush failed: ${
+                    flushErr instanceof Error
+                      ? flushErr.message
+                      : String(flushErr)
+                  }`,
                 );
-                bridgeShutdownError =
-                  err instanceof Error ? err : new Error(String(err));
               })
-              .finally(() => {
-                // Phase 2: arm the force timer NOW so it only races
-                // server.close, not the bridge tear-down above.
-                // `RunHandle.close()` contract says "fully
-                // closed and bridge drained" — the previous code
-                // resolved on a 100ms shortcut AFTER
-                // `closeAllConnections()` without waiting for
-                // `server.close`'s callback, so embedders/tests
-                // could observe a "closed" handle while the server
-                // was still finalizing. Now: force-close just
-                // accelerates `server.close` by killing the
-                // sockets, but we still wait for `server.close`'s
-                // callback to fire. A secondary deadline catches
-                // the pathological case where `server.close` never
-                // resolves at all (kernel-stuck socket etc.) so
-                // shutdown is still bounded.
-                const SECONDARY_DEADLINE_MS = 2_000;
-                let secondaryTimer: NodeJS.Timeout | undefined;
-                const forceTimer = setTimeout(() => {
-                  daemonLog.warn(
-                    `${SHUTDOWN_FORCE_CLOSE_MS}ms listener-drain timeout reached; force-closing remaining connections`,
-                  );
-                  server.closeAllConnections();
-                  // After force-close, server.close's callback
-                  // SHOULD fire promptly. Give it `SECONDARY_DEADLINE_MS`
-                  // before we resolve anyway with a warning — much
-                  // longer than the previous 100ms shortcut, and
-                  // logged so the operator knows the contract was
-                  // bent.
-                  secondaryTimer = setTimeout(() => {
-                    daemonLog.warn(
-                      `server.close did not fire ${SECONDARY_DEADLINE_MS}ms after force-close; resolving anyway`,
+              .then(() => {
+                bridge
+                  .shutdown()
+                  .catch((err) => {
+                    daemonLog.error(
+                      'bridge shutdown error',
+                      err instanceof Error ? err : null,
                     );
-                    finish();
-                  }, SECONDARY_DEADLINE_MS);
-                  secondaryTimer.unref();
-                }, SHUTDOWN_FORCE_CLOSE_MS);
-                forceTimer.unref();
-                server.close((err) => {
-                  clearTimeout(forceTimer);
-                  if (secondaryTimer) clearTimeout(secondaryTimer);
-                  finish(err);
-                });
+                    bridgeShutdownError =
+                      err instanceof Error ? err : new Error(String(err));
+                  })
+                  .finally(() => {
+                    // Phase 2: arm the force timer NOW so it only races
+                    // server.close, not the bridge tear-down above.
+                    // `RunHandle.close()` contract says "fully
+                    // closed and bridge drained" — the previous code
+                    // resolved on a 100ms shortcut AFTER
+                    // `closeAllConnections()` without waiting for
+                    // `server.close`'s callback, so embedders/tests
+                    // could observe a "closed" handle while the server
+                    // was still finalizing. Now: force-close just
+                    // accelerates `server.close` by killing the
+                    // sockets, but we still wait for `server.close`'s
+                    // callback to fire. A secondary deadline catches
+                    // the pathological case where `server.close` never
+                    // resolves at all (kernel-stuck socket etc.) so
+                    // shutdown is still bounded.
+                    const SECONDARY_DEADLINE_MS = 2_000;
+                    let secondaryTimer: NodeJS.Timeout | undefined;
+                    const forceTimer = setTimeout(() => {
+                      daemonLog.warn(
+                        `${SHUTDOWN_FORCE_CLOSE_MS}ms listener-drain timeout reached; force-closing remaining connections`,
+                      );
+                      server.closeAllConnections();
+                      // After force-close, server.close's callback
+                      // SHOULD fire promptly. Give it `SECONDARY_DEADLINE_MS`
+                      // before we resolve anyway with a warning — much
+                      // longer than the previous 100ms shortcut, and
+                      // logged so the operator knows the contract was
+                      // bent.
+                      secondaryTimer = setTimeout(() => {
+                        daemonLog.warn(
+                          `server.close did not fire ${SECONDARY_DEADLINE_MS}ms after force-close; resolving anyway`,
+                        );
+                        finish();
+                      }, SECONDARY_DEADLINE_MS);
+                      secondaryTimer.unref();
+                    }, SHUTDOWN_FORCE_CLOSE_MS);
+                    forceTimer.unref();
+                    server.close((err) => {
+                      clearTimeout(forceTimer);
+                      if (secondaryTimer) clearTimeout(secondaryTimer);
+                      finish(err);
+                    });
+                  });
               });
           });
           return closePromise;

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -704,7 +704,9 @@ export async function runQwenServe(
         },
         {
           eventName: `qwen-code.daemon.channel.${action}`,
-          ...(!expected && action === 'exit' ? { severityNumber: 13 } : {}),
+          ...(expected === false && action === 'exit'
+            ? { severityNumber: 13 }
+            : {}),
         },
       );
     },
@@ -1089,7 +1091,7 @@ export async function runQwenServe(
                 );
               }
             }
-            void forceFlushMetrics().catch((flushErr) => {
+            await forceFlushMetrics().catch((flushErr) => {
               daemonLog.warn(
                 `pre-shutdown metrics flush failed: ${
                   flushErr instanceof Error

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -709,15 +709,9 @@ export async function runQwenServe(
         },
       );
     },
-    promptQueueWait(durationMs) {
-      recordDaemonPromptQueueWait(durationMs);
-    },
-    promptDuration(durationMs) {
-      recordDaemonPromptDuration(durationMs);
-    },
-    cancelled() {
-      recordDaemonCancel();
-    },
+    promptQueueWait: recordDaemonPromptQueueWait,
+    promptDuration: recordDaemonPromptDuration,
+    cancelled: recordDaemonCancel,
   };
 
   // Allocate the audit ring + publisher in the daemon host (here)

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -695,7 +695,7 @@ export async function runQwenServe(
       emitDaemonLog(
         action === 'spawn'
           ? 'ACP channel spawned.'
-          : `ACP channel exited (expected=${expected}).`,
+          : `ACP channel exited (expected=${expected ?? true}).`,
         {
           ...(action === 'exit'
             ? { 'qwen-code.daemon.channel.expected': expected ?? true }

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -16,7 +16,9 @@ import {
   TrustGateError,
   emitDaemonLog,
   hashDaemonWorkspace,
+  recordDaemonBridgeError,
   recordDaemonError,
+  recordDaemonHttpRequest,
   recordDaemonHttpResponse,
   withDaemonRequestSpan,
 } from '@qwen-code/qwen-code-core';
@@ -91,6 +93,11 @@ import {
 } from './fs/index.js';
 import { registerWorkspaceFileReadRoutes } from './routes/workspaceFileRead.js';
 import { registerWorkspaceFileWriteRoutes } from './routes/workspaceFileWrite.js';
+
+let activeSseCount = 0;
+export function getActiveSseCount(): number {
+  return activeSseCount;
+}
 
 /**
  * Build a no-op fs-audit emitter that logs a warning every
@@ -365,6 +372,7 @@ function daemonTelemetryMiddleware(
       CLIENT_ID_RE.test(rawClientId)
         ? rawClientId
         : undefined;
+    const startMs = Date.now();
     void withDaemonRequestSpan(
       {
         method: req.method,
@@ -383,6 +391,11 @@ function daemonTelemetryMiddleware(
             if (done) return;
             done = true;
             recordDaemonHttpResponse(span, res.statusCode);
+            recordDaemonHttpRequest(
+              Date.now() - startMs,
+              route.route,
+              res.statusCode,
+            );
             resolve();
           };
           res.once('finish', finish);
@@ -2402,11 +2415,15 @@ export function createServeApp(
       const sseClientId = req.headers['x-qwen-client-id'] as string | undefined;
       daemonLog.info('SSE stream opened', { sessionId, clientId: sseClientId });
       res.on('close', () => {
-        daemonLog.info('SSE stream closed', {
-          sessionId,
-          clientId: sseClientId,
-          durationMs: Date.now() - sseOpenedAt,
-        });
+        try {
+          daemonLog.info('SSE stream closed', {
+            sessionId,
+            clientId: sseClientId,
+            durationMs: Date.now() - sseOpenedAt,
+          });
+        } catch {
+          /* logger failure must not prevent counter decrement */
+        }
       });
     }
 
@@ -2419,6 +2436,11 @@ export function createServeApp(
     res.setHeader('X-Accel-Buffering', 'no');
     // Always present on the supported Node versions (engines.node >=22).
     res.flushHeaders();
+
+    activeSseCount++;
+    res.on('close', () => {
+      activeSseCount--;
+    });
 
     // Backpressure helper: `res.write` returns false when the kernel send
     // buffer is full. Without awaiting `drain` Node accumulates the
@@ -3572,6 +3594,7 @@ function sendBridgeErrorImpl(
   // structured daemon logger (which tees to stderr + log file). When
   // absent (tests, direct embeds), fall back to the legacy stderr-only
   // `writeStderrLine` path.
+  recordDaemonBridgeError(err);
   recordDaemonError(undefined, err, {
     ...(ctx?.route ? { 'http.route': ctx.route } : {}),
     ...(ctx?.sessionId ? { 'session.id': ctx.sessionId } : {}),

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -2438,8 +2438,12 @@ export function createServeApp(
     res.flushHeaders();
 
     activeSseCount++;
+    let sseCounted = true;
     res.on('close', () => {
-      activeSseCount--;
+      if (sseCounted) {
+        sseCounted = false;
+        activeSseCount--;
+      }
     });
 
     // Backpressure helper: `res.write` returns false when the kernel send

--- a/packages/core/src/telemetry/daemon-metrics.test.ts
+++ b/packages/core/src/telemetry/daemon-metrics.test.ts
@@ -1,0 +1,335 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import type {
+  Counter,
+  Meter,
+  Attributes,
+  Context,
+  Histogram,
+  ObservableGauge,
+  ObservableResult,
+} from '@opentelemetry/api';
+
+const mockCounterAddFn: Mock<
+  (value: number, attributes?: Attributes, context?: Context) => void
+> = vi.fn();
+const mockHistogramRecordFn: Mock<
+  (value: number, attributes?: Attributes, context?: Context) => void
+> = vi.fn();
+
+const mockCreateCounterFn: Mock<(name: string, options?: unknown) => Counter> =
+  vi.fn();
+const mockCreateHistogramFn: Mock<
+  (name: string, options?: unknown) => Histogram
+> = vi.fn();
+
+const gaugeCallbacks: Array<(result: ObservableResult) => void> = [];
+const mockObservableGaugeAddCallback = vi.fn(
+  (cb: (result: ObservableResult) => void) => {
+    gaugeCallbacks.push(cb);
+  },
+);
+const mockCreateObservableGaugeFn: Mock<
+  (name: string, options?: unknown) => ObservableGauge
+> = vi.fn().mockReturnValue({
+  addCallback: mockObservableGaugeAddCallback,
+});
+
+const mockCounterInstance: Counter = {
+  add: mockCounterAddFn,
+} as Partial<Counter> as Counter;
+
+const mockHistogramInstance: Histogram = {
+  record: mockHistogramRecordFn,
+} as Partial<Histogram> as Histogram;
+
+const mockMeterInstance: Meter = {
+  createCounter: mockCreateCounterFn.mockReturnValue(mockCounterInstance),
+  createHistogram: mockCreateHistogramFn.mockReturnValue(mockHistogramInstance),
+  createObservableGauge: mockCreateObservableGaugeFn,
+} as Partial<Meter> as Meter;
+
+vi.mock('@opentelemetry/api', () => ({
+  metrics: {
+    getMeter: vi.fn().mockReturnValue(mockMeterInstance),
+  },
+  ValueType: {
+    INT: 1,
+    DOUBLE: 2,
+  },
+}));
+
+describe('Daemon Metrics', () => {
+  let initializeDaemonMetrics: typeof import('./daemon-metrics.js').initializeDaemonMetrics;
+  let registerDaemonGaugeCallbacks: typeof import('./daemon-metrics.js').registerDaemonGaugeCallbacks;
+  let recordDaemonHttpRequest: typeof import('./daemon-metrics.js').recordDaemonHttpRequest;
+  let recordDaemonSessionLifecycle: typeof import('./daemon-metrics.js').recordDaemonSessionLifecycle;
+  let recordDaemonChannelLifecycle: typeof import('./daemon-metrics.js').recordDaemonChannelLifecycle;
+  let recordDaemonPromptQueueWait: typeof import('./daemon-metrics.js').recordDaemonPromptQueueWait;
+  let recordDaemonPromptDuration: typeof import('./daemon-metrics.js').recordDaemonPromptDuration;
+  let recordDaemonBridgeError: typeof import('./daemon-metrics.js').recordDaemonBridgeError;
+  let recordDaemonCancel: typeof import('./daemon-metrics.js').recordDaemonCancel;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    gaugeCallbacks.length = 0;
+
+    mockCreateCounterFn.mockReturnValue(mockCounterInstance);
+    mockCreateHistogramFn.mockReturnValue(mockHistogramInstance);
+
+    const mod = await import('./daemon-metrics.js');
+    initializeDaemonMetrics = mod.initializeDaemonMetrics;
+    registerDaemonGaugeCallbacks = mod.registerDaemonGaugeCallbacks;
+    recordDaemonHttpRequest = mod.recordDaemonHttpRequest;
+    recordDaemonSessionLifecycle = mod.recordDaemonSessionLifecycle;
+    recordDaemonChannelLifecycle = mod.recordDaemonChannelLifecycle;
+    recordDaemonPromptQueueWait = mod.recordDaemonPromptQueueWait;
+    recordDaemonPromptDuration = mod.recordDaemonPromptDuration;
+    recordDaemonBridgeError = mod.recordDaemonBridgeError;
+    recordDaemonCancel = mod.recordDaemonCancel;
+  });
+
+  describe('initializeDaemonMetrics', () => {
+    it('creates counters and histograms', () => {
+      initializeDaemonMetrics();
+
+      expect(mockCreateCounterFn).toHaveBeenCalledWith(
+        'qwen-code.daemon.http.request.count',
+        expect.objectContaining({ description: expect.any(String) }),
+      );
+      expect(mockCreateHistogramFn).toHaveBeenCalledWith(
+        'qwen-code.daemon.http.request.duration',
+        expect.objectContaining({ unit: 'ms' }),
+      );
+      expect(mockCreateCounterFn).toHaveBeenCalledWith(
+        'qwen-code.daemon.session.lifecycle',
+        expect.any(Object),
+      );
+      expect(mockCreateCounterFn).toHaveBeenCalledWith(
+        'qwen-code.daemon.channel.lifecycle',
+        expect.any(Object),
+      );
+      expect(mockCreateHistogramFn).toHaveBeenCalledWith(
+        'qwen-code.daemon.prompt.queue_wait',
+        expect.objectContaining({ unit: 'ms' }),
+      );
+      expect(mockCreateHistogramFn).toHaveBeenCalledWith(
+        'qwen-code.daemon.prompt.duration',
+        expect.objectContaining({ unit: 'ms' }),
+      );
+      expect(mockCreateCounterFn).toHaveBeenCalledWith(
+        'qwen-code.daemon.bridge.error.count',
+        expect.any(Object),
+      );
+      expect(mockCreateCounterFn).toHaveBeenCalledWith(
+        'qwen-code.daemon.cancel.count',
+        expect.any(Object),
+      );
+    });
+
+    it('does not re-initialize on second call', () => {
+      initializeDaemonMetrics();
+      const callCount = mockCreateCounterFn.mock.calls.length;
+      initializeDaemonMetrics();
+      expect(mockCreateCounterFn.mock.calls.length).toBe(callCount);
+    });
+  });
+
+  describe('recording functions before initialization', () => {
+    it('are no-ops before init', () => {
+      recordDaemonHttpRequest(100, 'POST /session/:id/prompt', 200);
+      recordDaemonSessionLifecycle('spawn');
+      recordDaemonCancel();
+      expect(mockCounterAddFn).not.toHaveBeenCalled();
+      expect(mockHistogramRecordFn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recordDaemonHttpRequest', () => {
+    it('records counter with status_class and histogram with route', () => {
+      initializeDaemonMetrics();
+      recordDaemonHttpRequest(42, 'POST /session/:id/prompt', 201);
+
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1, {
+        route: 'POST /session/:id/prompt',
+        status_class: '2xx',
+      });
+      expect(mockHistogramRecordFn).toHaveBeenCalledWith(42, {
+        route: 'POST /session/:id/prompt',
+      });
+    });
+
+    it('computes status_class correctly for 4xx and 5xx', () => {
+      initializeDaemonMetrics();
+      mockCounterAddFn.mockClear();
+
+      recordDaemonHttpRequest(10, 'DELETE /session/:id', 404);
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1, {
+        route: 'DELETE /session/:id',
+        status_class: '4xx',
+      });
+
+      mockCounterAddFn.mockClear();
+      recordDaemonHttpRequest(5, 'POST /session', 500);
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1, {
+        route: 'POST /session',
+        status_class: '5xx',
+      });
+    });
+  });
+
+  describe('recordDaemonSessionLifecycle', () => {
+    it('records with action attribute', () => {
+      initializeDaemonMetrics();
+      mockCounterAddFn.mockClear();
+      recordDaemonSessionLifecycle('spawn');
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1, { action: 'spawn' });
+    });
+  });
+
+  describe('recordDaemonChannelLifecycle', () => {
+    it('records with action and expected attributes', () => {
+      initializeDaemonMetrics();
+      mockCounterAddFn.mockClear();
+      recordDaemonChannelLifecycle('exit', false);
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1, {
+        action: 'exit',
+        expected: false,
+      });
+    });
+
+    it('omits expected when undefined', () => {
+      initializeDaemonMetrics();
+      mockCounterAddFn.mockClear();
+      recordDaemonChannelLifecycle('spawn');
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1, { action: 'spawn' });
+    });
+  });
+
+  describe('recordDaemonPromptQueueWait', () => {
+    it('records histogram value', () => {
+      initializeDaemonMetrics();
+      mockHistogramRecordFn.mockClear();
+      recordDaemonPromptQueueWait(150);
+      expect(mockHistogramRecordFn).toHaveBeenCalledWith(150);
+    });
+  });
+
+  describe('recordDaemonPromptDuration', () => {
+    it('records histogram value', () => {
+      initializeDaemonMetrics();
+      mockHistogramRecordFn.mockClear();
+      recordDaemonPromptDuration(5000);
+      expect(mockHistogramRecordFn).toHaveBeenCalledWith(5000);
+    });
+  });
+
+  describe('recordDaemonBridgeError', () => {
+    it('normalizes known error types', () => {
+      initializeDaemonMetrics();
+      mockCounterAddFn.mockClear();
+      const err = new Error('not found');
+      err.name = 'SessionNotFoundError';
+      recordDaemonBridgeError(err);
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1, {
+        error_type: 'SessionNotFoundError',
+      });
+    });
+
+    it('normalizes unknown error types to "unknown"', () => {
+      initializeDaemonMetrics();
+      mockCounterAddFn.mockClear();
+      const err = new Error('something');
+      err.name = 'RandomCustomError';
+      recordDaemonBridgeError(err);
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1, {
+        error_type: 'unknown',
+      });
+    });
+
+    it('handles non-Error throws', () => {
+      initializeDaemonMetrics();
+      mockCounterAddFn.mockClear();
+      recordDaemonBridgeError('string error');
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1, {
+        error_type: 'unknown',
+      });
+    });
+  });
+
+  describe('recordDaemonCancel', () => {
+    it('increments counter', () => {
+      initializeDaemonMetrics();
+      mockCounterAddFn.mockClear();
+      recordDaemonCancel();
+      expect(mockCounterAddFn).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('registerDaemonGaugeCallbacks', () => {
+    it('creates 3 observable gauges', () => {
+      registerDaemonGaugeCallbacks({
+        sessionCount: () => 5,
+        sseCount: () => 3,
+        heapUsed: () => 100_000_000,
+      });
+
+      expect(mockCreateObservableGaugeFn).toHaveBeenCalledTimes(3);
+      expect(mockCreateObservableGaugeFn).toHaveBeenCalledWith(
+        'qwen-code.daemon.session.active',
+        expect.any(Object),
+      );
+      expect(mockCreateObservableGaugeFn).toHaveBeenCalledWith(
+        'qwen-code.daemon.sse.active',
+        expect.any(Object),
+      );
+      expect(mockCreateObservableGaugeFn).toHaveBeenCalledWith(
+        'qwen-code.daemon.process.heap_used',
+        expect.objectContaining({ unit: 'bytes' }),
+      );
+    });
+
+    it('gauge callbacks invoke the provided getters', () => {
+      const sessionCount = vi.fn().mockReturnValue(7);
+      const sseCount = vi.fn().mockReturnValue(2);
+      const heapUsed = vi.fn().mockReturnValue(50_000_000);
+
+      registerDaemonGaugeCallbacks({ sessionCount, sseCount, heapUsed });
+
+      const mockResult = { observe: vi.fn() };
+      for (const cb of gaugeCallbacks) {
+        cb(mockResult as unknown as ObservableResult);
+      }
+
+      expect(sessionCount).toHaveBeenCalled();
+      expect(sseCount).toHaveBeenCalled();
+      expect(heapUsed).toHaveBeenCalled();
+      expect(mockResult.observe).toHaveBeenCalledWith(7);
+      expect(mockResult.observe).toHaveBeenCalledWith(2);
+      expect(mockResult.observe).toHaveBeenCalledWith(50_000_000);
+    });
+
+    it('gauge callbacks swallow exceptions', () => {
+      registerDaemonGaugeCallbacks({
+        sessionCount: () => {
+          throw new Error('boom');
+        },
+        sseCount: () => 0,
+        heapUsed: () => 0,
+      });
+
+      const mockResult = { observe: vi.fn() };
+      expect(() => {
+        for (const cb of gaugeCallbacks) {
+          cb(mockResult as unknown as ObservableResult);
+        }
+      }).not.toThrow();
+    });
+  });
+});

--- a/packages/core/src/telemetry/daemon-metrics.test.ts
+++ b/packages/core/src/telemetry/daemon-metrics.test.ts
@@ -62,6 +62,13 @@ vi.mock('@opentelemetry/api', () => ({
     INT: 1,
     DOUBLE: 2,
   },
+  diag: {
+    setLogger: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
 }));
 
 describe('Daemon Metrics', () => {

--- a/packages/core/src/telemetry/daemon-metrics.test.ts
+++ b/packages/core/src/telemetry/daemon-metrics.test.ts
@@ -322,6 +322,21 @@ describe('Daemon Metrics', () => {
       expect(mockResult.observe).toHaveBeenCalledWith(50_000_000);
     });
 
+    it('does not re-register on second call', () => {
+      registerDaemonGaugeCallbacks({
+        sessionCount: () => 1,
+        sseCount: () => 0,
+        heapUsed: () => 0,
+      });
+      const callCount = mockCreateObservableGaugeFn.mock.calls.length;
+      registerDaemonGaugeCallbacks({
+        sessionCount: () => 2,
+        sseCount: () => 0,
+        heapUsed: () => 0,
+      });
+      expect(mockCreateObservableGaugeFn.mock.calls.length).toBe(callCount);
+    });
+
     it('gauge callbacks swallow exceptions', () => {
       registerDaemonGaugeCallbacks({
         sessionCount: () => {

--- a/packages/core/src/telemetry/daemon-metrics.ts
+++ b/packages/core/src/telemetry/daemon-metrics.ts
@@ -134,11 +134,15 @@ export interface DaemonGaugeCallbacks {
   heapUsed: () => number;
 }
 
+let gaugesRegistered = false;
+
 export function registerDaemonGaugeCallbacks(
   callbacks: DaemonGaugeCallbacks,
 ): void {
+  if (gaugesRegistered) return;
   const meter = getMeter();
   if (!meter) return;
+  gaugesRegistered = true;
 
   meter
     .createObservableGauge(DAEMON_SESSION_ACTIVE, {
@@ -188,15 +192,15 @@ export function recordDaemonHttpRequest(
 ): void {
   if (!initialized) return;
   const statusClass = `${Math.floor(statusCode / 100)}xx`;
-  httpRequestCounter!.add(1, { route, status_class: statusClass });
-  httpRequestDurationHistogram!.record(durationMs, { route });
+  httpRequestCounter?.add(1, { route, status_class: statusClass });
+  httpRequestDurationHistogram?.record(durationMs, { route });
 }
 
 export function recordDaemonSessionLifecycle(
   action: 'spawn' | 'close' | 'die',
 ): void {
   if (!initialized) return;
-  sessionLifecycleCounter!.add(1, { action });
+  sessionLifecycleCounter?.add(1, { action });
 }
 
 export function recordDaemonChannelLifecycle(
@@ -204,7 +208,7 @@ export function recordDaemonChannelLifecycle(
   expected?: boolean,
 ): void {
   if (!initialized) return;
-  channelLifecycleCounter!.add(1, {
+  channelLifecycleCounter?.add(1, {
     action,
     ...(expected != null ? { expected } : {}),
   });
@@ -212,20 +216,20 @@ export function recordDaemonChannelLifecycle(
 
 export function recordDaemonPromptQueueWait(durationMs: number): void {
   if (!initialized) return;
-  promptQueueWaitHistogram!.record(durationMs);
+  promptQueueWaitHistogram?.record(durationMs);
 }
 
 export function recordDaemonPromptDuration(durationMs: number): void {
   if (!initialized) return;
-  promptDurationHistogram!.record(durationMs);
+  promptDurationHistogram?.record(durationMs);
 }
 
 export function recordDaemonBridgeError(err: unknown): void {
   if (!initialized) return;
-  bridgeErrorCounter!.add(1, { error_type: normalizeErrorType(err) });
+  bridgeErrorCounter?.add(1, { error_type: normalizeErrorType(err) });
 }
 
 export function recordDaemonCancel(): void {
   if (!initialized) return;
-  cancelCounter!.add(1);
+  cancelCounter?.add(1);
 }

--- a/packages/core/src/telemetry/daemon-metrics.ts
+++ b/packages/core/src/telemetry/daemon-metrics.ts
@@ -142,7 +142,6 @@ export function registerDaemonGaugeCallbacks(
   if (gaugesRegistered) return;
   const meter = getMeter();
   if (!meter) return;
-  gaugesRegistered = true;
 
   meter
     .createObservableGauge(DAEMON_SESSION_ACTIVE, {
@@ -183,6 +182,8 @@ export function registerDaemonGaugeCallbacks(
         /* no-op */
       }
     });
+
+  gaugesRegistered = true;
 }
 
 export function recordDaemonHttpRequest(

--- a/packages/core/src/telemetry/daemon-metrics.ts
+++ b/packages/core/src/telemetry/daemon-metrics.ts
@@ -1,0 +1,231 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { Counter, Histogram } from '@opentelemetry/api';
+import { ValueType } from '@opentelemetry/api';
+import { SERVICE_NAME } from './constants.js';
+import { getMeter } from './metrics.js';
+
+const DAEMON_HTTP_REQUEST_COUNT = `${SERVICE_NAME}.daemon.http.request.count`;
+const DAEMON_HTTP_REQUEST_DURATION = `${SERVICE_NAME}.daemon.http.request.duration`;
+const DAEMON_SESSION_ACTIVE = `${SERVICE_NAME}.daemon.session.active`;
+const DAEMON_SESSION_LIFECYCLE = `${SERVICE_NAME}.daemon.session.lifecycle`;
+const DAEMON_CHANNEL_LIFECYCLE = `${SERVICE_NAME}.daemon.channel.lifecycle`;
+const DAEMON_PROMPT_QUEUE_WAIT = `${SERVICE_NAME}.daemon.prompt.queue_wait`;
+const DAEMON_PROMPT_DURATION = `${SERVICE_NAME}.daemon.prompt.duration`;
+const DAEMON_BRIDGE_ERROR_COUNT = `${SERVICE_NAME}.daemon.bridge.error.count`;
+const DAEMON_CANCEL_COUNT = `${SERVICE_NAME}.daemon.cancel.count`;
+const DAEMON_SSE_ACTIVE = `${SERVICE_NAME}.daemon.sse.active`;
+const DAEMON_PROCESS_HEAP_USED = `${SERVICE_NAME}.daemon.process.heap_used`;
+
+const KNOWN_ERROR_TYPES = new Set([
+  'SessionNotFoundError',
+  'WorkspaceMismatchError',
+  'InvalidClientIdError',
+  'SessionLimitExceededError',
+  'RestoreInProgressError',
+  'InvalidSessionScopeError',
+  'TrustGateError',
+  'WorkspaceInitConflictError',
+  'WorkspaceInitPathEscapeError',
+  'WorkspaceInitSymlinkError',
+  'WorkspaceInitRaceError',
+  'McpServerNotFoundError',
+  'McpServerRestartFailedError',
+  'PromptDeadlineExceededError',
+  'InvalidSessionMetadataError',
+  'SubscriberLimitExceededError',
+  'BridgeChannelClosedError',
+  'BridgeTimeoutError',
+  'PermissionForbiddenError',
+]);
+
+let initialized = false;
+
+let httpRequestCounter: Counter | undefined;
+let httpRequestDurationHistogram: Histogram | undefined;
+let sessionLifecycleCounter: Counter | undefined;
+let channelLifecycleCounter: Counter | undefined;
+let promptQueueWaitHistogram: Histogram | undefined;
+let promptDurationHistogram: Histogram | undefined;
+let bridgeErrorCounter: Counter | undefined;
+let cancelCounter: Counter | undefined;
+
+function normalizeErrorType(err: unknown): string {
+  const name = err instanceof Error ? err.name : typeof err;
+  return KNOWN_ERROR_TYPES.has(name) ? name : 'unknown';
+}
+
+export function initializeDaemonMetrics(): void {
+  if (initialized) return;
+  const meter = getMeter();
+  if (!meter) return;
+
+  httpRequestCounter = meter.createCounter(DAEMON_HTTP_REQUEST_COUNT, {
+    description: 'Daemon HTTP request count by route and status class.',
+    valueType: ValueType.INT,
+  });
+
+  httpRequestDurationHistogram = meter.createHistogram(
+    DAEMON_HTTP_REQUEST_DURATION,
+    {
+      description: 'Daemon HTTP request duration in milliseconds.',
+      unit: 'ms',
+      valueType: ValueType.DOUBLE,
+      advice: {
+        explicitBucketBoundaries: [
+          1, 2, 5, 10, 25, 50, 100, 250, 500, 1000, 2500, 5000, 10000, 30000,
+        ],
+      },
+    },
+  );
+
+  sessionLifecycleCounter = meter.createCounter(DAEMON_SESSION_LIFECYCLE, {
+    description: 'Daemon session lifecycle events (spawn, close, die).',
+    valueType: ValueType.INT,
+  });
+
+  channelLifecycleCounter = meter.createCounter(DAEMON_CHANNEL_LIFECYCLE, {
+    description: 'Daemon ACP channel lifecycle events (spawn, exit).',
+    valueType: ValueType.INT,
+  });
+
+  promptQueueWaitHistogram = meter.createHistogram(DAEMON_PROMPT_QUEUE_WAIT, {
+    description: 'Time a prompt waited in the per-session FIFO queue.',
+    unit: 'ms',
+    valueType: ValueType.DOUBLE,
+    advice: {
+      explicitBucketBoundaries: [
+        1, 5, 10, 50, 100, 500, 1000, 5000, 10000, 30000, 60000,
+      ],
+    },
+  });
+
+  promptDurationHistogram = meter.createHistogram(DAEMON_PROMPT_DURATION, {
+    description: 'End-to-end prompt duration from dispatch to completion.',
+    unit: 'ms',
+    valueType: ValueType.DOUBLE,
+    advice: {
+      explicitBucketBoundaries: [
+        100, 500, 1000, 2500, 5000, 10000, 30000, 60000, 120000, 300000, 600000,
+      ],
+    },
+  });
+
+  bridgeErrorCounter = meter.createCounter(DAEMON_BRIDGE_ERROR_COUNT, {
+    description: 'Daemon bridge error count by normalized error type.',
+    valueType: ValueType.INT,
+  });
+
+  cancelCounter = meter.createCounter(DAEMON_CANCEL_COUNT, {
+    description: 'Daemon cancel request count.',
+    valueType: ValueType.INT,
+  });
+
+  initialized = true;
+}
+
+export interface DaemonGaugeCallbacks {
+  sessionCount: () => number;
+  sseCount: () => number;
+  heapUsed: () => number;
+}
+
+export function registerDaemonGaugeCallbacks(
+  callbacks: DaemonGaugeCallbacks,
+): void {
+  const meter = getMeter();
+  if (!meter) return;
+
+  meter
+    .createObservableGauge(DAEMON_SESSION_ACTIVE, {
+      description: 'Current number of active daemon sessions.',
+      valueType: ValueType.INT,
+    })
+    .addCallback((result) => {
+      try {
+        result.observe(callbacks.sessionCount());
+      } catch {
+        /* no-op */
+      }
+    });
+
+  meter
+    .createObservableGauge(DAEMON_SSE_ACTIVE, {
+      description: 'Current number of active SSE connections.',
+      valueType: ValueType.INT,
+    })
+    .addCallback((result) => {
+      try {
+        result.observe(callbacks.sseCount());
+      } catch {
+        /* no-op */
+      }
+    });
+
+  meter
+    .createObservableGauge(DAEMON_PROCESS_HEAP_USED, {
+      description: 'Daemon process heap memory usage in bytes.',
+      unit: 'bytes',
+      valueType: ValueType.INT,
+    })
+    .addCallback((result) => {
+      try {
+        result.observe(callbacks.heapUsed());
+      } catch {
+        /* no-op */
+      }
+    });
+}
+
+export function recordDaemonHttpRequest(
+  durationMs: number,
+  route: string,
+  statusCode: number,
+): void {
+  if (!initialized) return;
+  const statusClass = `${Math.floor(statusCode / 100)}xx`;
+  httpRequestCounter!.add(1, { route, status_class: statusClass });
+  httpRequestDurationHistogram!.record(durationMs, { route });
+}
+
+export function recordDaemonSessionLifecycle(
+  action: 'spawn' | 'close' | 'die',
+): void {
+  if (!initialized) return;
+  sessionLifecycleCounter!.add(1, { action });
+}
+
+export function recordDaemonChannelLifecycle(
+  action: 'spawn' | 'exit',
+  expected?: boolean,
+): void {
+  if (!initialized) return;
+  channelLifecycleCounter!.add(1, {
+    action,
+    ...(expected != null ? { expected } : {}),
+  });
+}
+
+export function recordDaemonPromptQueueWait(durationMs: number): void {
+  if (!initialized) return;
+  promptQueueWaitHistogram!.record(durationMs);
+}
+
+export function recordDaemonPromptDuration(durationMs: number): void {
+  if (!initialized) return;
+  promptDurationHistogram!.record(durationMs);
+}
+
+export function recordDaemonBridgeError(err: unknown): void {
+  if (!initialized) return;
+  bridgeErrorCounter!.add(1, { error_type: normalizeErrorType(err) });
+}
+
+export function recordDaemonCancel(): void {
+  if (!initialized) return;
+  cancelCounter!.add(1);
+}

--- a/packages/core/src/telemetry/daemon-tracing.ts
+++ b/packages/core/src/telemetry/daemon-tracing.ts
@@ -200,6 +200,7 @@ export function recordDaemonError(
 export function emitDaemonLog(
   body: string,
   attributes: LogAttributes = {},
+  options?: { eventName?: string; severityNumber?: number },
 ): void {
   if (!isTelemetrySdkInitialized()) return;
   try {
@@ -207,9 +208,12 @@ export function emitDaemonLog(
       body,
       timestamp: new Date(),
       attributes: {
-        'event.name': EVENT_DAEMON_ERROR,
+        'event.name': options?.eventName ?? EVENT_DAEMON_ERROR,
         ...attributes,
       },
+      ...(options?.severityNumber != null
+        ? { severityNumber: options.severityNumber }
+        : {}),
     });
   } catch {
     // Telemetry must not affect daemon behavior.
@@ -313,6 +317,14 @@ export function extractDaemonTraceContext(
   );
 }
 
+interface DaemonBridgeTelemetryMetrics {
+  sessionLifecycle(action: 'spawn' | 'close' | 'die'): void;
+  channelLifecycle(action: 'spawn' | 'exit', expected?: boolean): void;
+  promptQueueWait(durationMs: number): void;
+  promptDuration(durationMs: number): void;
+  cancelled(): void;
+}
+
 export function createDaemonBridgeTelemetry(): {
   captureContext(): unknown;
   runWithContext<T>(captured: unknown, fn: () => Promise<T>): Promise<T>;
@@ -323,6 +335,7 @@ export function createDaemonBridgeTelemetry(): {
   ): Promise<T>;
   event(name: string, attributes: DaemonAttributes): void;
   injectPromptContext<T extends object>(request: T): T;
+  metrics?: DaemonBridgeTelemetryMetrics;
 } {
   return {
     captureContext: captureDaemonTelemetryContext,

--- a/packages/core/src/telemetry/daemon-tracing.ts
+++ b/packages/core/src/telemetry/daemon-tracing.ts
@@ -317,7 +317,7 @@ export function extractDaemonTraceContext(
   );
 }
 
-interface DaemonBridgeTelemetryMetrics {
+export interface DaemonBridgeTelemetryMetrics {
   sessionLifecycle(action: 'spawn' | 'close' | 'die'): void;
   channelLifecycle(action: 'spawn' | 'exit', expected?: boolean): void;
   promptQueueWait(durationMs: number): void;

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -16,6 +16,7 @@ export { DEFAULT_TELEMETRY_TARGET, DEFAULT_OTLP_ENDPOINT };
 export {
   initializeTelemetry,
   shutdownTelemetry,
+  forceFlushMetrics,
   refreshSessionContext,
   isTelemetrySdkInitialized,
 } from './sdk.js';
@@ -184,6 +185,18 @@ export {
   withDaemonRequestSpan,
   withDaemonSpan,
 } from './daemon-tracing.js';
+export {
+  initializeDaemonMetrics,
+  registerDaemonGaugeCallbacks,
+  recordDaemonHttpRequest,
+  recordDaemonSessionLifecycle,
+  recordDaemonChannelLifecycle,
+  recordDaemonPromptQueueWait,
+  recordDaemonPromptDuration,
+  recordDaemonBridgeError,
+  recordDaemonCancel,
+} from './daemon-metrics.js';
+export type { DaemonGaugeCallbacks } from './daemon-metrics.js';
 export {
   addUserPromptAttributes,
   addSystemPromptAttributes,

--- a/packages/core/src/telemetry/index.ts
+++ b/packages/core/src/telemetry/index.ts
@@ -184,6 +184,7 @@ export {
   withDaemonBridgeSpan,
   withDaemonRequestSpan,
   withDaemonSpan,
+  type DaemonBridgeTelemetryMetrics,
 } from './daemon-tracing.js';
 export {
   initializeDaemonMetrics,

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -649,8 +649,9 @@ const FORCE_FLUSH_TIMEOUT_MS = 5_000;
 export async function forceFlushMetrics(): Promise<void> {
   if (!telemetryInitialized || !activeMetricReader) return;
   const flush = activeMetricReader.forceFlush();
+  let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<void>((_, reject) => {
-    const timer = setTimeout(
+    timer = setTimeout(
       () =>
         reject(
           new Error(
@@ -661,5 +662,9 @@ export async function forceFlushMetrics(): Promise<void> {
     );
     timer.unref?.();
   });
-  await Promise.race([flush, timeout]);
+  try {
+    await Promise.race([flush, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
 }

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -644,7 +644,7 @@ export async function shutdownTelemetry(): Promise<void> {
   return telemetryShutdownPromise;
 }
 
-const FORCE_FLUSH_TIMEOUT_MS = 5_000;
+const FORCE_FLUSH_TIMEOUT_MS = 2_000;
 
 export async function forceFlushMetrics(): Promise<void> {
   if (!telemetryInitialized || !activeMetricReader) return;

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -649,6 +649,7 @@ const FORCE_FLUSH_TIMEOUT_MS = 5_000;
 export async function forceFlushMetrics(): Promise<void> {
   if (!telemetryInitialized || !activeMetricReader) return;
   const flush = activeMetricReader.forceFlush();
+  flush.catch(() => {});
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<void>((_, reject) => {
     timer = setTimeout(

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -644,7 +644,22 @@ export async function shutdownTelemetry(): Promise<void> {
   return telemetryShutdownPromise;
 }
 
+const FORCE_FLUSH_TIMEOUT_MS = 5_000;
+
 export async function forceFlushMetrics(): Promise<void> {
   if (!telemetryInitialized || !activeMetricReader) return;
-  await activeMetricReader.forceFlush();
+  const flush = activeMetricReader.forceFlush();
+  const timeout = new Promise<void>((_, reject) => {
+    const timer = setTimeout(
+      () =>
+        reject(
+          new Error(
+            `forceFlushMetrics timed out after ${FORCE_FLUSH_TIMEOUT_MS}ms`,
+          ),
+        ),
+      FORCE_FLUSH_TIMEOUT_MS,
+    );
+    timer.unref?.();
+  });
+  await Promise.race([flush, timeout]);
 }

--- a/packages/core/src/telemetry/sdk.ts
+++ b/packages/core/src/telemetry/sdk.ts
@@ -123,6 +123,7 @@ const NOOP_PROPAGATOR: TextMapPropagator = {
 let sdk: NodeSDK | undefined;
 let telemetryInitialized = false;
 let telemetryShutdownPromise: Promise<void> | undefined;
+let activeMetricReader: PeriodicExportingMetricReader | undefined;
 
 export function isTelemetrySdkInitialized(): boolean {
   return telemetryInitialized;
@@ -562,6 +563,7 @@ export function initializeTelemetry(config: TelemetryRuntimeConfig): void {
     sdk.start();
     debugLogger.debug('OpenTelemetry SDK started successfully.');
     telemetryInitialized = true;
+    activeMetricReader = metricReader;
     const sessionId = config.getSessionId();
     setSessionContext(undefined, sessionId);
     initializeMetrics(config);
@@ -634,9 +636,15 @@ export async function shutdownTelemetry(): Promise<void> {
     } finally {
       telemetryInitialized = false;
       sdk = undefined;
+      activeMetricReader = undefined;
       telemetryShutdownPromise = undefined;
       setSessionContext(undefined);
     }
   })();
   return telemetryShutdownPromise;
+}
+
+export async function forceFlushMetrics(): Promise<void> {
+  if (!telemetryInitialized || !activeMetricReader) return;
+  await activeMetricReader.forceFlush();
 }


### PR DESCRIPTION
## Summary

- Adds 11 OTel metric instruments to the daemon serve path covering HTTP request rate/latency, session/channel lifecycle, prompt queue wait & duration, bridge errors, cancellation, and active SSE connections
- Uses ObservableGauge (not UpDownCounter) for session/SSE/heap gauges to prevent +1/-1 drift across complex lifecycle paths
- Extends `BridgeTelemetry` interface with optional `metrics` sub-object for bridge decoupling
- Generalizes `emitDaemonLog` to support custom event names and severity levels for structured lifecycle log records
- Adds `service.instance.id` to OTel Resource for process incarnation detection
- Adds `forceFlushMetrics()` for pre-shutdown metric snapshot

Closes #4554 §6.

## Design Highlights

| Metric | Type | Attributes |
|--------|------|-----------|
| `daemon.http.request.count` | Counter | route, status_class |
| `daemon.http.request.duration` | Histogram | route |
| `daemon.session.active` | ObservableGauge | — |
| `daemon.session.lifecycle` | Counter | action |
| `daemon.channel.lifecycle` | Counter | action, expected |
| `daemon.prompt.queue_wait` | Histogram | — |
| `daemon.prompt.duration` | Histogram | — |
| `daemon.bridge.error.count` | Counter | error_type |
| `daemon.cancel.count` | Counter | — |
| `daemon.sse.active` | ObservableGauge | — |
| `daemon.process.heap_used` | ObservableGauge | — |

Max time-series cardinality: ~200 (all attributes bounded by design).

## Test plan

- [x] 17 unit tests in `daemon-metrics.test.ts` covering initialization, recording, gauge callbacks, error normalization, and no-op before init
- [x] TypeScript type-check passes for all 3 packages (core, acp-bridge, cli)
- [x] Pre-commit hooks (prettier + eslint) pass
- [ ] Manual verification with OTLP collector

🤖 Generated with [Qwen Code](https://github.com/QwenLM/qwen-code)