### PR TITLE
fix(cli): Improve approval mode display text

### DIFF
--- a/packages/cli/src/i18n/locales/ca.js
+++ b/packages/cli/src/i18n/locales/ca.js
@@ -846,13 +846,14 @@ export default {
   // Ordres - Mode d'aprovació
   // ============================================================================
   'Tool Approval Mode': "Mode d'aprovació d'eines",
-  '{{mode}} mode': 'Mode {{mode}}',
   'Analyze only, do not modify files or execute commands':
     'Analitzar només, sense modificar fitxers ni executar ordres',
   'Require approval for file edits or shell commands':
     'Requerir aprovació per a edicions de fitxers o ordres shell',
   'Automatically approve file edits':
     'Aprovar automàticament les edicions de fitxers',
+  'Use classifier to automatically approve safe tool calls':
+    'Utilitzar el classificador per aprovar automàticament les crides segures a eines',
   'Automatically approve all tools': 'Aprovar automàticament totes les eines',
   'Workspace approval mode exists and takes priority. User-level change will have no effect.':
     "Existeix un mode d'aprovació de l'espai de treball i té prioritat. El canvi a nivell d'usuari no tindrà cap efecte.",

--- a/packages/cli/src/i18n/locales/de.js
+++ b/packages/cli/src/i18n/locales/de.js
@@ -803,13 +803,14 @@ export default {
   // Commands - Approval Mode
   // ============================================================================
   'Tool Approval Mode': 'Werkzeug-Genehmigungsmodus',
-  '{{mode}} mode': '{{mode}}-Modus',
   'Analyze only, do not modify files or execute commands':
     'Nur analysieren, keine Dateien ändern oder Befehle ausführen',
   'Require approval for file edits or shell commands':
     'Genehmigung für Dateibearbeitungen oder Shell-Befehle erforderlich',
   'Automatically approve file edits':
     'Dateibearbeitungen automatisch genehmigen',
+  'Use classifier to automatically approve safe tool calls':
+    'Klassifikator verwenden, um sichere Werkzeugaufrufe automatisch zu genehmigen',
   'Automatically approve all tools': 'Alle Werkzeuge automatisch genehmigen',
   'Workspace approval mode exists and takes priority. User-level change will have no effect.':
     'Arbeitsbereich-Genehmigungsmodus existiert und hat Vorrang. Benutzerebene-Änderung hat keine Wirkung.',

--- a/packages/cli/src/i18n/locales/en.js
+++ b/packages/cli/src/i18n/locales/en.js
@@ -887,12 +887,13 @@ export default {
   // Commands - Approval Mode
   // ============================================================================
   'Tool Approval Mode': 'Tool Approval Mode',
-  '{{mode}} mode': '{{mode}} mode',
   'Analyze only, do not modify files or execute commands':
     'Analyze only, do not modify files or execute commands',
   'Require approval for file edits or shell commands':
     'Require approval for file edits or shell commands',
   'Automatically approve file edits': 'Automatically approve file edits',
+  'Use classifier to automatically approve safe tool calls':
+    'Use classifier to automatically approve safe tool calls',
   'Automatically approve all tools': 'Automatically approve all tools',
   'Workspace approval mode exists and takes priority. User-level change will have no effect.':
     'Workspace approval mode exists and takes priority. User-level change will have no effect.',

--- a/packages/cli/src/i18n/locales/fr.js
+++ b/packages/cli/src/i18n/locales/fr.js
@@ -869,13 +869,14 @@ export default {
   // Commandes - Mode d'approbation
   // ============================================================================
   'Tool Approval Mode': "Mode d'approbation des outils",
-  '{{mode}} mode': 'Mode {{mode}}',
   'Analyze only, do not modify files or execute commands':
     'Analyser uniquement, ne pas modifier les fichiers ni exécuter des commandes',
   'Require approval for file edits or shell commands':
     "Demander l'approbation pour les modifications de fichiers ou les commandes shell",
   'Automatically approve file edits':
     'Approuver automatiquement les modifications de fichiers',
+  'Use classifier to automatically approve safe tool calls':
+    'Utiliser le classificateur pour approuver automatiquement les appels d’outils sûrs',
   'Automatically approve all tools':
     'Approuver automatiquement tous les outils',
   'Workspace approval mode exists and takes priority. User-level change will have no effect.':

--- a/packages/cli/src/i18n/locales/ja.js
+++ b/packages/cli/src/i18n/locales/ja.js
@@ -580,12 +580,13 @@ export default {
     '追加のUI言語パックをリクエストするには、GitHub で Issue を作成してください',
   'Available options:': '使用可能なオプション:',
   'Set UI language to {{name}}': 'UI言語を {{name}} に設定',
-  '{{mode}} mode': '{{mode}}モード',
   'Analyze only, do not modify files or execute commands':
     '分析のみ、ファイルの変更やコマンドの実行はしません',
   'Require approval for file edits or shell commands':
     'ファイル編集やシェルコマンドには承認が必要',
   'Automatically approve file edits': 'ファイル編集を自動承認',
+  'Use classifier to automatically approve safe tool calls':
+    '分類器を使用して安全なツール呼び出しを自動承認',
   'Automatically approve all tools': 'すべてのツールを自動承認',
   'Workspace approval mode exists and takes priority. User-level change will have no effect.':
     'ワークスペースの承認モードが存在し、優先されます。ユーザーレベルの変更は効果がありません',

--- a/packages/cli/src/i18n/locales/pt.js
+++ b/packages/cli/src/i18n/locales/pt.js
@@ -807,13 +807,14 @@ export default {
   // Commands - Approval Mode
   // ============================================================================
   'Tool Approval Mode': 'Modo de Aprovação de Ferramenta',
-  '{{mode}} mode': 'Modo {{mode}}',
   'Analyze only, do not modify files or execute commands':
     'Apenas analisar, não modificar arquivos nem executar comandos',
   'Require approval for file edits or shell commands':
     'Exigir aprovação para edições de arquivos ou comandos shell',
   'Automatically approve file edits':
     'Aprovar automaticamente edições de arquivos',
+  'Use classifier to automatically approve safe tool calls':
+    'Usar o classificador para aprovar automaticamente chamadas seguras de ferramentas',
   'Automatically approve all tools':
     'Aprovar automaticamente todas as ferramentas',
   'Workspace approval mode exists and takes priority. User-level change will have no effect.':

--- a/packages/cli/src/i18n/locales/ru.js
+++ b/packages/cli/src/i18n/locales/ru.js
@@ -816,13 +816,14 @@ export default {
   // Команды - Режим подтверждения
   // ============================================================================
   'Tool Approval Mode': 'Режим подтверждения инструментов',
-  '{{mode}} mode': 'Режим {{mode}}',
   'Analyze only, do not modify files or execute commands':
     'Только анализ, без изменения файлов или выполнения команд',
   'Require approval for file edits or shell commands':
     'Требуется подтверждение для редактирования файлов или команд терминала',
   'Automatically approve file edits':
     'Автоматически подтверждать изменения файлов',
+  'Use classifier to automatically approve safe tool calls':
+    'Использовать классификатор для автоматического подтверждения безопасных вызовов инструментов',
   'Automatically approve all tools':
     'Автоматически подтверждать все инструменты',
   'Workspace approval mode exists and takes priority. User-level change will have no effect.':

--- a/packages/cli/src/i18n/locales/zh-TW.js
+++ b/packages/cli/src/i18n/locales/zh-TW.js
@@ -754,12 +754,13 @@ export default {
   'Available options:': '可用選項：',
   'Set UI language to {{name}}': '將 UI 語言設置為 {{name}}',
   'Tool Approval Mode': '工具審批模式',
-  '{{mode}} mode': '{{mode}} 模式',
   'Analyze only, do not modify files or execute commands':
     '僅分析，不修改檔案或執行命令',
   'Require approval for file edits or shell commands':
     '需要批准檔案編輯或 shell 命令',
   'Automatically approve file edits': '自動批准檔案編輯',
+  'Use classifier to automatically approve safe tool calls':
+    '使用分類器自動批准安全的工具調用',
   'Automatically approve all tools': '自動批准所有工具',
   'Workspace approval mode exists and takes priority. User-level change will have no effect.':
     '工作區審批模式已存在並具有優先級。用戶級別的更改將無效。',

--- a/packages/cli/src/i18n/locales/zh.js
+++ b/packages/cli/src/i18n/locales/zh.js
@@ -838,12 +838,13 @@ export default {
   // Commands - Approval Mode
   // ============================================================================
   'Tool Approval Mode': '工具审批模式',
-  '{{mode}} mode': '{{mode}} 模式',
   'Analyze only, do not modify files or execute commands':
     '仅分析，不修改文件或执行命令',
   'Require approval for file edits or shell commands':
     '需要批准文件编辑或 shell 命令',
   'Automatically approve file edits': '自动批准文件编辑',
+  'Use classifier to automatically approve safe tool calls':
+    '使用分类器自动批准安全的工具调用',
   'Automatically approve all tools': '自动批准所有工具',
   'Workspace approval mode exists and takes priority. User-level change will have no effect.':
     '工作区审批模式已存在并具有优先级。用户级别的更改将无效。',

--- a/packages/cli/src/ui/commands/approvalModeCommand.test.ts
+++ b/packages/cli/src/ui/commands/approvalModeCommand.test.ts
@@ -103,7 +103,8 @@ describe('approvalModeCommand', () => {
 
       expect(result.type).toBe('message');
       expect(result.messageType).toBe('info');
-      expect(result.content).toContain('default');
+      // "default" is displayed using its formatted name, not the raw enum value.
+      expect(result.content).toContain('Ask permissions');
       expect(mockSetApprovalMode).toHaveBeenCalledWith('default');
     });
 

--- a/packages/cli/src/ui/commands/approvalModeCommand.test.ts
+++ b/packages/cli/src/ui/commands/approvalModeCommand.test.ts
@@ -79,7 +79,7 @@ describe('approvalModeCommand', () => {
 
       expect(result.type).toBe('message');
       expect(result.messageType).toBe('info');
-      expect(result.content).toContain('yolo');
+      expect(result.content).toContain('YOLO');
       expect(mockSetApprovalMode).toHaveBeenCalledWith('yolo');
     });
 

--- a/packages/cli/src/ui/commands/approvalModeCommand.ts
+++ b/packages/cli/src/ui/commands/approvalModeCommand.ts
@@ -18,6 +18,7 @@ import {
   ApprovalMode as ApprovalModeEnum,
 } from '@qwen-code/qwen-code-core';
 import { emitAutoModeEntryNotices } from '../hooks/useAutoAcceptIndicator.js';
+import { formatApprovalModeName } from '../utils/approvalModeDisplay.js';
 
 /**
  * Parses the argument string and returns the corresponding ApprovalMode if valid.
@@ -101,7 +102,10 @@ export const approvalModeCommand: SlashCommand = {
     return {
       type: 'message',
       messageType: 'info',
-      content: t('Approval mode set to "{{mode}}"', { mode }),
+      content: t('Approval mode set to "{{mode}}"', {
+        mode:
+          mode === ApprovalModeEnum.YOLO ? formatApprovalModeName(mode) : mode,
+      }),
     };
   },
 };

--- a/packages/cli/src/ui/commands/approvalModeCommand.ts
+++ b/packages/cli/src/ui/commands/approvalModeCommand.ts
@@ -103,8 +103,7 @@ export const approvalModeCommand: SlashCommand = {
       type: 'message',
       messageType: 'info',
       content: t('Approval mode set to "{{mode}}"', {
-        mode:
-          mode === ApprovalModeEnum.YOLO ? formatApprovalModeName(mode) : mode,
+        mode: formatApprovalModeName(mode),
       }),
     };
   },

--- a/packages/cli/src/ui/components/ApprovalModeDialog.tsx
+++ b/packages/cli/src/ui/components/ApprovalModeDialog.tsx
@@ -16,6 +16,10 @@ import { getScopeMessageForSetting } from '../../utils/dialogScopeUtils.js';
 import { useKeypress } from '../hooks/useKeypress.js';
 import { ScopeSelector } from './shared/ScopeSelector.js';
 import { t } from '../../i18n/index.js';
+import {
+  formatApprovalModeDescription,
+  formatApprovalModeName,
+} from '../utils/approvalModeDisplay.js';
 
 interface ApprovalModeDialogProps {
   /** Callback function when an approval mode is selected */
@@ -30,28 +34,6 @@ interface ApprovalModeDialogProps {
   /** Available terminal height for layout calculations */
   availableTerminalHeight?: number;
 }
-
-const formatModeName = (mode: ApprovalMode): string => {
-  if (mode === ApprovalMode.DEFAULT) {
-    return t('Ask permissions');
-  }
-  return mode;
-};
-
-const formatModeDescription = (mode: ApprovalMode): string => {
-  switch (mode) {
-    case ApprovalMode.PLAN:
-      return t('Analyze only, do not modify files or execute commands');
-    case ApprovalMode.DEFAULT:
-      return t('Require approval for file edits or shell commands');
-    case ApprovalMode.AUTO_EDIT:
-      return t('Automatically approve file edits');
-    case ApprovalMode.YOLO:
-      return t('Automatically approve all tools');
-    default:
-      return t('{{mode}} mode', { mode });
-  }
-};
 
 export function ApprovalModeDialog({
   onSelect,
@@ -71,7 +53,9 @@ export function ApprovalModeDialog({
 
   // Generate approval mode items with inline descriptions
   const modeItems = APPROVAL_MODES.map((mode) => ({
-    label: `${formatModeName(mode)} - ${formatModeDescription(mode)}`,
+    label: `${formatApprovalModeName(mode)} - ${formatApprovalModeDescription(
+      mode,
+    )}`,
     value: mode,
     key: mode,
   }));

--- a/packages/cli/src/ui/utils/approvalModeDisplay.test.ts
+++ b/packages/cli/src/ui/utils/approvalModeDisplay.test.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ApprovalMode } from '@qwen-code/qwen-code-core';
+import {
+  formatApprovalModeDescription,
+  formatApprovalModeName,
+} from './approvalModeDisplay.js';
+
+describe('approval mode display', () => {
+  it('formats yolo as uppercase', () => {
+    expect(formatApprovalModeName(ApprovalMode.YOLO)).toBe('YOLO');
+  });
+
+  it('uses a specific classifier description for auto mode', () => {
+    expect(formatApprovalModeDescription(ApprovalMode.AUTO)).toBe(
+      'Use classifier to automatically approve safe tool calls',
+    );
+  });
+});

--- a/packages/cli/src/ui/utils/approvalModeDisplay.test.ts
+++ b/packages/cli/src/ui/utils/approvalModeDisplay.test.ts
@@ -12,13 +12,44 @@ import {
 } from './approvalModeDisplay.js';
 
 describe('approval mode display', () => {
-  it('formats yolo as uppercase', () => {
-    expect(formatApprovalModeName(ApprovalMode.YOLO)).toBe('YOLO');
+  describe('formatApprovalModeName', () => {
+    it('formats yolo as uppercase', () => {
+      expect(formatApprovalModeName(ApprovalMode.YOLO)).toBe('YOLO');
+    });
+
+    it('formats default mode as a friendly name', () => {
+      expect(formatApprovalModeName(ApprovalMode.DEFAULT)).toBe(
+        'Ask permissions',
+      );
+    });
+
+    it('falls back to the raw mode value for modes without a custom name', () => {
+      expect(formatApprovalModeName(ApprovalMode.PLAN)).toBe('plan');
+      expect(formatApprovalModeName(ApprovalMode.AUTO_EDIT)).toBe('auto-edit');
+      expect(formatApprovalModeName(ApprovalMode.AUTO)).toBe('auto');
+    });
   });
 
-  it('uses a specific classifier description for auto mode', () => {
-    expect(formatApprovalModeDescription(ApprovalMode.AUTO)).toBe(
-      'Use classifier to automatically approve safe tool calls',
-    );
+  describe('formatApprovalModeDescription', () => {
+    it('uses a specific classifier description for auto mode', () => {
+      expect(formatApprovalModeDescription(ApprovalMode.AUTO)).toBe(
+        'Use classifier to automatically approve safe tool calls',
+      );
+    });
+
+    it('describes the remaining modes', () => {
+      expect(formatApprovalModeDescription(ApprovalMode.PLAN)).toBe(
+        'Analyze only, do not modify files or execute commands',
+      );
+      expect(formatApprovalModeDescription(ApprovalMode.DEFAULT)).toBe(
+        'Require approval for file edits or shell commands',
+      );
+      expect(formatApprovalModeDescription(ApprovalMode.AUTO_EDIT)).toBe(
+        'Automatically approve file edits',
+      );
+      expect(formatApprovalModeDescription(ApprovalMode.YOLO)).toBe(
+        'Automatically approve all tools',
+      );
+    });
   });
 });

--- a/packages/cli/src/ui/utils/approvalModeDisplay.ts
+++ b/packages/cli/src/ui/utils/approvalModeDisplay.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025 Qwen
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ApprovalMode } from '@qwen-code/qwen-code-core';
+import { t } from '../../i18n/index.js';
+
+export function formatApprovalModeName(mode: ApprovalMode): string {
+  switch (mode) {
+    case ApprovalMode.DEFAULT:
+      return t('Ask permissions');
+    case ApprovalMode.YOLO:
+      return 'YOLO';
+    default:
+      return mode;
+  }
+}
+
+export function formatApprovalModeDescription(mode: ApprovalMode): string {
+  switch (mode) {
+    case ApprovalMode.PLAN:
+      return t('Analyze only, do not modify files or execute commands');
+    case ApprovalMode.DEFAULT:
+      return t('Require approval for file edits or shell commands');
+    case ApprovalMode.AUTO_EDIT:
+      return t('Automatically approve file edits');
+    case ApprovalMode.AUTO:
+      return t('Use classifier to automatically approve safe tool calls');
+    case ApprovalMode.YOLO:
+      return t('Automatically approve all tools');
+    default:
+      return mode;
+  }
+}


### PR DESCRIPTION
## What this PR does

Improves approval mode display text in the interactive approval-mode flow. The YOLO mode is now shown as uppercase in user-facing messages and mode choices, and classifier-based auto mode now has a specific description instead of the generic "auto mode" fallback. The same display text is shared between the slash command result and the approval-mode picker, and built-in locale entries were updated for the new auto-mode wording.

## Why it's needed

The approval-mode UI should make mode names and behavior clear. Showing YOLO in lowercase looks inconsistent with the established mode name, and describing auto mode only as "auto mode" does not explain that it uses a classifier to approve safe tool calls automatically.

## Reviewer Test Plan

### How to verify

Run `/approval-mode yolo` and confirm the result message shows `YOLO`. Open `/approval-mode` with no arguments and confirm the picker shows `YOLO` in uppercase and describes `auto` as classifier-based automatic approval for safe tool calls. Locally verified with `cd packages/cli && npx vitest run src/ui/commands/approvalModeCommand.test.ts src/ui/utils/approvalModeDisplay.test.ts` and `cd packages/cli && npm run check-i18n`.

### Evidence (Before & After)

Before: `/approval-mode yolo` reported `Approval mode set to "yolo"`, and the auto-mode picker row fell back to `auto mode`. After: the command reports `Approval mode set to "YOLO"`, and the auto-mode picker row explains that classifier-based auto mode automatically approves safe tool calls.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local unit and i18n validation in `packages/cli`. Full root build/typecheck was not rerun for this PR; prior local attempts were blocked by existing `FinishReason.IMAGE_RECITATION` / `FinishReason.IMAGE_OTHER` type errors outside this change.

## Risk & Scope

- Main risk or tradeoff: This only changes display strings for approval modes and adds one shared formatting helper.
- Not validated / out of scope: Manual TUI screenshot capture and cross-platform terminal rendering were not performed.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

改进交互式审批模式流程中的显示文案。YOLO 模式现在会在面向用户的消息和模式选择项中以全大写显示，基于分类器的 auto 模式也从泛化的 “auto mode” fallback 改成了更具体的描述。slash 命令结果和审批模式选择器现在复用同一套显示文案，并同步更新了内置语言包里的 auto 模式文案。

## Why it's needed

审批模式 UI 需要清楚表达模式名称和行为。把 YOLO 显示成小写和既有模式名不一致，而只把 auto 模式描述为 “auto mode” 也没有说明它会通过分类器自动批准安全的工具调用。

## Reviewer Test Plan

### How to verify

运行 `/approval-mode yolo`，确认结果消息显示 `YOLO`。不带参数打开 `/approval-mode`，确认选择器里 `YOLO` 是全大写，并且 `auto` 的描述说明它是基于分类器自动批准安全工具调用。本地已通过 `cd packages/cli && npx vitest run src/ui/commands/approvalModeCommand.test.ts src/ui/utils/approvalModeDisplay.test.ts` 和 `cd packages/cli && npm run check-i18n` 验证。

### Evidence (Before & After)

Before：`/approval-mode yolo` 返回 `Approval mode set to "yolo"`，auto 模式选择项 fallback 为 `auto mode`。After：命令返回 `Approval mode set to "YOLO"`，auto 模式选择项说明基于分类器的 auto 模式会自动批准安全工具调用。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

在 `packages/cli` 下完成本地单测和 i18n 验证。没有为本 PR 重新完成 root build/typecheck；此前本地尝试被本次改动之外已有的 `FinishReason.IMAGE_RECITATION` / `FinishReason.IMAGE_OTHER` 类型错误阻塞。

## Risk & Scope

- Main risk or tradeoff：只修改审批模式显示文案，并新增一个共享格式化 helper。
- Not validated / out of scope：没有做手动 TUI 截图和跨平台终端渲染验证。
- Breaking changes / migration notes：无。

## Linked Issues

N/A

</details>
