### PR TITLE
fix(computer-use): auto-approve install in auto-approve modes (YOLO/AUTO_EDIT/AUTO)

### DIFF
--- a/packages/core/src/config/config.ts
+++ b/packages/core/src/config/config.ts
@@ -4135,7 +4135,7 @@ export class Config {
       const { registerComputerUseTools } = await import(
         '../tools/computer-use/index.js'
       );
-      await registerComputerUseTools(registerLazy);
+      await registerComputerUseTools(registerLazy, this);
     }
 
     // Register monitor tool

--- a/packages/core/src/tools/computer-use/bootstrap.test.ts
+++ b/packages/core/src/tools/computer-use/bootstrap.test.ts
@@ -107,12 +107,10 @@ describe('runBootstrap', () => {
     // Did not throw "declined", and never consulted the headless prompt.
     expect(deps.promptInstallApproval).not.toHaveBeenCalled();
     expect(client.start).toHaveBeenCalledOnce();
-    // Approval is persisted so later (non-YOLO) calls skip the prompt too.
+    // Approval is persisted so later (interactive) calls skip the prompt too.
     const { loadInstallState } = await import('./install-state.js');
     const state = await loadInstallState(tmpHome);
-    expect(state?.approvedPackageSpec).toBe(
-      '@qwen-code/open-computer-use@^0.3.0',
-    );
+    expect(state?.approvedPackageSpec).toBe(deps.packageSpec);
   });
 
   it('persists approval on success', async () => {

--- a/packages/core/src/tools/computer-use/bootstrap.test.ts
+++ b/packages/core/src/tools/computer-use/bootstrap.test.ts
@@ -90,6 +90,31 @@ describe('runBootstrap', () => {
     expect(client.start).not.toHaveBeenCalled();
   });
 
+  it('auto-approves install under YOLO (ctx.autoApproveInstall) without prompting', async () => {
+    // First use (no install state). In YOLO mode the scheduler bypasses
+    // the confirmation dialog, so its onConfirm never records approval.
+    // promptInstallApproval is set to REFUSE here to prove the YOLO path
+    // skips it entirely rather than coincidentally returning true.
+    deps.promptInstallApproval = vi.fn(async () => false);
+    const client = makeFakeClient();
+
+    await runBootstrap(
+      client as never,
+      { signal: new AbortController().signal, autoApproveInstall: true },
+      deps,
+    );
+
+    // Did not throw "declined", and never consulted the headless prompt.
+    expect(deps.promptInstallApproval).not.toHaveBeenCalled();
+    expect(client.start).toHaveBeenCalledOnce();
+    // Approval is persisted so later (non-YOLO) calls skip the prompt too.
+    const { loadInstallState } = await import('./install-state.js');
+    const state = await loadInstallState(tmpHome);
+    expect(state?.approvedPackageSpec).toBe(
+      '@qwen-code/open-computer-use@^0.3.0',
+    );
+  });
+
   it('persists approval on success', async () => {
     const client = makeFakeClient();
     await runBootstrap(

--- a/packages/core/src/tools/computer-use/bootstrap.ts
+++ b/packages/core/src/tools/computer-use/bootstrap.ts
@@ -41,6 +41,16 @@ const execFileAsync = promisify(execFile);
 export interface BootstrapContext {
   signal: AbortSignal;
   updateOutput?: (output: string) => void;
+  /**
+   * Treat the first-use install as pre-approved, skipping the
+   * promptInstallApproval gate. Set by the caller when the active approval
+   * mode auto-approves tool calls (YOLO): in that mode the scheduler
+   * bypasses ComputerUseTool's confirmation dialog, so its onConfirm never
+   * records install approval — without this flag the headless fallback
+   * below would refuse and throw "install declined by user". The approval
+   * is still persisted, so later non-YOLO calls also skip the prompt.
+   */
+  autoApproveInstall?: boolean;
 }
 
 /** Result of a permission probe. */
@@ -215,12 +225,20 @@ export async function runBootstrap(
   // Step 1: install approval gate.
   const approved = await isPackageSpecApproved(deps.homeDir, deps.packageSpec);
   if (!approved) {
-    ctx.updateOutput?.('Computer Use needs to be installed (first use).');
-    const ok = await deps.promptInstallApproval(deps.packageSpec);
-    if (!ok) {
-      throw new Error(
-        `Computer Use install declined by user. Re-invoke the tool to be prompted again.`,
-      );
+    if (ctx.autoApproveInstall) {
+      // YOLO (or equivalent auto-approve mode): the scheduler bypassed the
+      // confirmation dialog whose onConfirm would have recorded approval,
+      // so honor the auto-approve intent here instead of falling through to
+      // the headless prompt (which refuses and throws).
+      ctx.updateOutput?.('Computer Use install auto-approved (YOLO mode).');
+    } else {
+      ctx.updateOutput?.('Computer Use needs to be installed (first use).');
+      const ok = await deps.promptInstallApproval(deps.packageSpec);
+      if (!ok) {
+        throw new Error(
+          `Computer Use install declined by user. Re-invoke the tool to be prompted again.`,
+        );
+      }
     }
     await saveInstallState(deps.homeDir, {
       approvedPackageSpec: deps.packageSpec,

--- a/packages/core/src/tools/computer-use/bootstrap.ts
+++ b/packages/core/src/tools/computer-use/bootstrap.ts
@@ -44,11 +44,11 @@ export interface BootstrapContext {
   /**
    * Treat the first-use install as pre-approved, skipping the
    * promptInstallApproval gate. Set by the caller when the active approval
-   * mode auto-approves tool calls (YOLO): in that mode the scheduler
-   * bypasses ComputerUseTool's confirmation dialog, so its onConfirm never
-   * records install approval — without this flag the headless fallback
-   * below would refuse and throw "install declined by user". The approval
-   * is still persisted, so later non-YOLO calls also skip the prompt.
+   * mode auto-approves tool calls and bypasses ComputerUseTool's confirmation
+   * dialog (YOLO / AUTO_EDIT / AUTO): in those modes the dialog's onConfirm
+   * never records install approval, so without this flag the headless
+   * fallback below would refuse and throw "install declined by user". The
+   * approval is still persisted, so later interactive calls skip the prompt.
    */
   autoApproveInstall?: boolean;
 }
@@ -226,11 +226,11 @@ export async function runBootstrap(
   const approved = await isPackageSpecApproved(deps.homeDir, deps.packageSpec);
   if (!approved) {
     if (ctx.autoApproveInstall) {
-      // YOLO (or equivalent auto-approve mode): the scheduler bypassed the
-      // confirmation dialog whose onConfirm would have recorded approval,
-      // so honor the auto-approve intent here instead of falling through to
-      // the headless prompt (which refuses and throws).
-      ctx.updateOutput?.('Computer Use install auto-approved (YOLO mode).');
+      // An auto-approve mode (YOLO / AUTO_EDIT / AUTO) already approved the
+      // tool call and bypassed the confirmation dialog whose onConfirm would
+      // have recorded approval, so honor that intent here instead of falling
+      // through to the headless prompt (which refuses and throws).
+      ctx.updateOutput?.('Computer Use install auto-approved (approval mode).');
     } else {
       ctx.updateOutput?.('Computer Use needs to be installed (first use).');
       const ok = await deps.promptInstallApproval(deps.packageSpec);

--- a/packages/core/src/tools/computer-use/index.ts
+++ b/packages/core/src/tools/computer-use/index.ts
@@ -13,6 +13,7 @@ import { ComputerUseTool } from './tool.js';
 import { COMPUTER_USE_SCHEMAS, COMPUTER_USE_TOOL_NAMES } from './schemas.js';
 import type { ToolFactory } from '../tool-registry.js';
 import type { ToolName } from '../../utils/tool-utils.js';
+import type { Config } from '../../config/config.js';
 
 /**
  * Register all 9 computer-use tools as lazy factories. Each tool is
@@ -30,16 +31,23 @@ import type { ToolName } from '../../utils/tool-utils.js';
  * review.
  *
  * Should only be called when `Config.isComputerUseEnabled()` is true.
+ *
+ * `config` is forwarded to each tool so execute() can read the active
+ * approval mode. In YOLO the scheduler auto-approves the tool call and skips
+ * the install-confirmation dialog (whose onConfirm records install approval),
+ * so the tool must auto-approve the first-use install itself instead of
+ * letting the bootstrap fallback refuse with "install declined by user".
  */
 export async function registerComputerUseTools(
   registerLazy: (name: ToolName, factory: ToolFactory) => Promise<void>,
+  config?: Config,
 ): Promise<void> {
   for (const upstreamName of COMPUTER_USE_TOOL_NAMES) {
     const schema = COMPUTER_USE_SCHEMAS[upstreamName];
     const qwenName = `computer_use__${upstreamName}` as ToolName;
     await registerLazy(
       qwenName,
-      async () => new ComputerUseTool(upstreamName, schema),
+      async () => new ComputerUseTool(upstreamName, schema, config),
     );
   }
 }

--- a/packages/core/src/tools/computer-use/tool.test.ts
+++ b/packages/core/src/tools/computer-use/tool.test.ts
@@ -13,6 +13,7 @@ import { COMPUTER_USE_SCHEMAS } from './schemas.js';
 import { saveInstallState, isPackageSpecApproved } from './install-state.js';
 import { resolveComputerUsePackageSpec } from './constants.js';
 import { ToolConfirmationOutcome } from '../tools.js';
+import { ApprovalMode, type Config } from '../../config/config.js';
 import type { Part } from '@google/genai';
 
 function makeFakeClient(
@@ -369,6 +370,39 @@ describe('ComputerUseInvocation confirmation pathway', () => {
 
     const packageSpec = resolveComputerUsePackageSpec();
     const approved = await isPackageSpecApproved(tmpHome, packageSpec);
+    expect(approved).toBe(true);
+  });
+
+  it('execute() under YOLO auto-approves install instead of declining (no dialog, no env var)', async () => {
+    // Reproduces the YOLO bug: the scheduler auto-approves the tool call and
+    // skips the confirmation dialog, so onConfirm never records install
+    // approval. With QWEN_COMPUTER_USE_AUTO_APPROVE unset, the bootstrap
+    // fallback used to refuse and surface "install declined by user".
+    const fake = makeFakeClient(async () => ({
+      content: [{ type: 'text', text: '[]' }],
+      isError: false,
+    }));
+    ComputerUseClient.setSharedForTest(fake);
+
+    const yoloConfig = {
+      getApprovalMode: () => ApprovalMode.YOLO,
+    } as unknown as Config;
+
+    const tool = new ComputerUseTool(
+      'list_apps',
+      COMPUTER_USE_SCHEMAS.list_apps,
+      yoloConfig,
+    );
+    const invocation = tool.build({});
+    const result = await invocation.execute(new AbortController().signal);
+
+    expect(result.error).toBeUndefined();
+    expect(fake.callTool).toHaveBeenCalledWith('list_apps', {});
+    // Approval persisted so later non-YOLO calls also skip the prompt.
+    const approved = await isPackageSpecApproved(
+      tmpHome,
+      resolveComputerUsePackageSpec(),
+    );
     expect(approved).toBe(true);
   });
 });

--- a/packages/core/src/tools/computer-use/tool.test.ts
+++ b/packages/core/src/tools/computer-use/tool.test.ts
@@ -373,38 +373,44 @@ describe('ComputerUseInvocation confirmation pathway', () => {
     expect(approved).toBe(true);
   });
 
-  it('execute() under YOLO auto-approves install instead of declining (no dialog, no env var)', async () => {
-    // Reproduces the YOLO bug: the scheduler auto-approves the tool call and
-    // skips the confirmation dialog, so onConfirm never records install
-    // approval. With QWEN_COMPUTER_USE_AUTO_APPROVE unset, the bootstrap
-    // fallback used to refuse and surface "install declined by user".
-    const fake = makeFakeClient(async () => ({
-      content: [{ type: 'text', text: '[]' }],
-      isError: false,
-    }));
-    ComputerUseClient.setSharedForTest(fake);
+  // Every approval mode where the scheduler auto-approves the tool call and
+  // bypasses the confirmation dialog — so its onConfirm never records install
+  // approval. With QWEN_COMPUTER_USE_AUTO_APPROVE unset, the bootstrap fallback
+  // used to refuse and surface "install declined by user":
+  //   - YOLO       → needsConfirmation() returns false, dialog never built.
+  //   - AUTO_EDIT  → isAutoEditApproved() approves info-type tools, skips onConfirm.
+  //   - AUTO       → classifier-approved calls skip onConfirm.
+  it.each([ApprovalMode.YOLO, ApprovalMode.AUTO_EDIT, ApprovalMode.AUTO])(
+    'execute() under %s auto-approves install instead of declining (no dialog, no env var)',
+    async (mode) => {
+      const fake = makeFakeClient(async () => ({
+        content: [{ type: 'text', text: '[]' }],
+        isError: false,
+      }));
+      ComputerUseClient.setSharedForTest(fake);
 
-    const yoloConfig = {
-      getApprovalMode: () => ApprovalMode.YOLO,
-    } as unknown as Config;
+      const config = {
+        getApprovalMode: () => mode,
+      } as unknown as Config;
 
-    const tool = new ComputerUseTool(
-      'list_apps',
-      COMPUTER_USE_SCHEMAS.list_apps,
-      yoloConfig,
-    );
-    const invocation = tool.build({});
-    const result = await invocation.execute(new AbortController().signal);
+      const tool = new ComputerUseTool(
+        'list_apps',
+        COMPUTER_USE_SCHEMAS.list_apps,
+        config,
+      );
+      const invocation = tool.build({});
+      const result = await invocation.execute(new AbortController().signal);
 
-    expect(result.error).toBeUndefined();
-    expect(fake.callTool).toHaveBeenCalledWith('list_apps', {});
-    // Approval persisted so later non-YOLO calls also skip the prompt.
-    const approved = await isPackageSpecApproved(
-      tmpHome,
-      resolveComputerUsePackageSpec(),
-    );
-    expect(approved).toBe(true);
-  });
+      expect(result.error).toBeUndefined();
+      expect(fake.callTool).toHaveBeenCalledWith('list_apps', {});
+      // Approval persisted so later (interactive) calls also skip the prompt.
+      const approved = await isPackageSpecApproved(
+        tmpHome,
+        resolveComputerUsePackageSpec(),
+      );
+      expect(approved).toBe(true);
+    },
+  );
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/tools/computer-use/tool.test.ts
+++ b/packages/core/src/tools/computer-use/tool.test.ts
@@ -411,6 +411,43 @@ describe('ComputerUseInvocation confirmation pathway', () => {
       expect(approved).toBe(true);
     },
   );
+
+  it('execute() under DEFAULT mode does NOT auto-approve install (still gated)', async () => {
+    // Negative guard for the false-branch of autoApproveInstall: DEFAULT (and
+    // PLAN) must NOT be auto-approved — DEFAULT shows the install dialog. If the
+    // condition were ever widened (e.g. `mode !== ApprovalMode.PLAN`), DEFAULT
+    // would silently auto-install a desktop-control binary; this test locks
+    // that lower boundary so such a regression fails CI.
+    delete process.env['QWEN_COMPUTER_USE_AUTO_APPROVE'];
+    const fake = makeFakeClient(async () => ({
+      content: [{ type: 'text', text: '[]' }],
+      isError: false,
+    }));
+    ComputerUseClient.setSharedForTest(fake);
+
+    const config = {
+      getApprovalMode: () => ApprovalMode.DEFAULT,
+    } as unknown as Config;
+
+    const tool = new ComputerUseTool(
+      'list_apps',
+      COMPUTER_USE_SCHEMAS.list_apps,
+      config,
+    );
+    const invocation = tool.build({});
+
+    // No install state + no env var → bootstrap's headless fallback refuses
+    // rather than auto-approving.
+    await expect(
+      invocation.execute(new AbortController().signal),
+    ).rejects.toThrow(/declined/i);
+    expect(fake.callTool).not.toHaveBeenCalled();
+    const approved = await isPackageSpecApproved(
+      tmpHome,
+      resolveComputerUsePackageSpec(),
+    );
+    expect(approved).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/tools/computer-use/tool.ts
+++ b/packages/core/src/tools/computer-use/tool.ts
@@ -136,16 +136,21 @@ class ComputerUseInvocation extends BaseToolInvocation<
 
     // If the user confirmed through the pre-execution dialog, the install state
     // was already written by onConfirm — runBootstrap will skip promptInstallApproval.
-    // In YOLO mode the scheduler auto-approves the tool call WITHOUT showing
-    // that dialog (onConfirm never runs), so pass autoApproveInstall to honor
-    // the auto-approve intent instead of letting bootstrap refuse. For headless
-    // / SDK contexts (no dialog, no YOLO), it falls back to the env-var path in
-    // bootstrap's default promptInstallApproval.
-    await runBootstrap(client, {
-      signal,
-      updateOutput,
-      autoApproveInstall: this.config?.getApprovalMode() === ApprovalMode.YOLO,
-    });
+    // But several approval modes auto-approve the tool call and bypass that
+    // dialog entirely (so onConfirm never runs and install state is never
+    // written): YOLO (needsConfirmation() returns false), AUTO_EDIT
+    // (isAutoEditApproved() auto-approves info-type tools — all computer_use__*
+    // tools are info), and AUTO (classifier-approved calls). In those modes
+    // pass autoApproveInstall so the bootstrap honors the already-granted call
+    // approval instead of refusing with "install declined by user". DEFAULT
+    // still shows the dialog; PLAN blocks. Headless / SDK contexts (no config)
+    // fall back to the env-var path in bootstrap's default promptInstallApproval.
+    const mode = this.config?.getApprovalMode();
+    const autoApproveInstall =
+      mode === ApprovalMode.YOLO ||
+      mode === ApprovalMode.AUTO_EDIT ||
+      mode === ApprovalMode.AUTO;
+    await runBootstrap(client, { signal, updateOutput, autoApproveInstall });
 
     let mcpResult: CallToolResult;
     try {

--- a/packages/core/src/tools/computer-use/tool.ts
+++ b/packages/core/src/tools/computer-use/tool.ts
@@ -23,6 +23,7 @@ import { safeJsonStringify } from '../../utils/safeJsonStringify.js';
 import { runBootstrap } from './bootstrap.js';
 import { isPackageSpecApproved, saveInstallState } from './install-state.js';
 import { resolveComputerUsePackageSpec } from './constants.js';
+import { ApprovalMode, type Config } from '../../config/config.js';
 import { homedir } from 'node:os';
 
 type ComputerUseParams = Record<string, unknown>;
@@ -39,6 +40,7 @@ class ComputerUseInvocation extends BaseToolInvocation<
   constructor(
     private readonly upstreamName: ComputerUseToolName,
     params: ComputerUseParams,
+    private readonly config?: Config,
   ) {
     super(params);
   }
@@ -134,9 +136,16 @@ class ComputerUseInvocation extends BaseToolInvocation<
 
     // If the user confirmed through the pre-execution dialog, the install state
     // was already written by onConfirm — runBootstrap will skip promptInstallApproval.
-    // For headless / SDK contexts (no dialog), fall back to the env-var path
-    // already built into bootstrap's default promptInstallApproval.
-    await runBootstrap(client, { signal, updateOutput });
+    // In YOLO mode the scheduler auto-approves the tool call WITHOUT showing
+    // that dialog (onConfirm never runs), so pass autoApproveInstall to honor
+    // the auto-approve intent instead of letting bootstrap refuse. For headless
+    // / SDK contexts (no dialog, no YOLO), it falls back to the env-var path in
+    // bootstrap's default promptInstallApproval.
+    await runBootstrap(client, {
+      signal,
+      updateOutput,
+      autoApproveInstall: this.config?.getApprovalMode() === ApprovalMode.YOLO,
+    });
 
     let mcpResult: CallToolResult;
     try {
@@ -182,6 +191,7 @@ export class ComputerUseTool extends BaseDeclarativeTool<
   constructor(
     private readonly upstreamName: ComputerUseToolName,
     schema: ComputerUseToolSchema,
+    private readonly config?: Config,
   ) {
     const qwenName = `computer_use__${upstreamName}`;
     super(
@@ -226,7 +236,7 @@ export class ComputerUseTool extends BaseDeclarativeTool<
   protected createInvocation(
     params: ComputerUseParams,
   ): ToolInvocation<ComputerUseParams, ToolResult> {
-    return new ComputerUseInvocation(this.upstreamName, params);
+    return new ComputerUseInvocation(this.upstreamName, params, this.config);
   }
 }
 


### PR DESCRIPTION
## What this PR does

Fixes Computer Use failing with `Computer Use install declined by user. Re-invoke the tool to be prompted again.` on the **first** call in every approval mode that auto-approves the tool call and bypasses the confirmation dialog — **YOLO, AUTO_EDIT, and AUTO** — even though the user never declined anything.

The tool now reads the active approval mode and, in those modes, auto-approves the one-time install gate instead of falling through to a headless prompt that refuses. `DEFAULT` (interactive dialog) and `PLAN` (blocked) are unchanged.

## Why it's needed

Computer Use has two independent approval gates:

1. **The standard tool-confirmation dialog** (`ComputerUseTool.getConfirmationDetails`). Its `onConfirm` is what records install approval (`saveInstallState`).
2. **The bootstrap install gate** (`runBootstrap` → `promptInstallApproval`), a headless fallback that only returns true when `QWEN_COMPUTER_USE_AUTO_APPROVE=1`.

Whenever the scheduler auto-approves the tool call, it bypasses gate 1 — so `onConfirm` never runs, install state is never written, and `runBootstrap` hits gate 2, finds no approval, and throws `install declined by user` with no dialog ever shown. This happens in three modes:

- **YOLO** — `needsConfirmation()` returns `false`, so the scheduler marks the call `ProceedAlways` and never builds the dialog (`coreToolScheduler.ts:1984`).
- **AUTO_EDIT** — `isAutoEditApproved()` auto-approves `type:'info'` tools, and **all `computer_use__*` tools are `info`**, so the scheduler `ProceedAlways`-es without calling `onConfirm` (`coreToolScheduler.ts:2028`).
- **AUTO** — classifier-approved calls `ProceedAlways` and skip `onConfirm` (`coreToolScheduler.ts:1933`).

A pinned-version bump (e.g. `@0.2.2 → 0.2.3` in #4726) makes it more likely, since install approval is matched on the exact package spec.

## Reviewer Test Plan

### How to verify

Unit tests at both layers (each written test-first, confirmed RED before the fix):

```
npx vitest run packages/core/src/tools/computer-use/   # 90 tests
```

- `tool.test.ts` → `execute() under %s auto-approves install ...` parametrized over **YOLO / AUTO_EDIT / AUTO**: a config in each mode + no install state + no env var no longer throws "declined".
- `bootstrap.test.ts` → `runBootstrap` honors `ctx.autoApproveInstall`: skips the prompt and persists approval.

Manual: in a YOLO / AUTO_EDIT / AUTO session with no prior install state and `QWEN_COMPUTER_USE_AUTO_APPROVE` unset, invoke any `computer_use__*` tool — it proceeds instead of returning the decline error.

### Evidence (Before & After)

Non-TUI behavior change; evidence is the test transitions.

**Before (RED):** `execute() under auto-edit ...` and `... under auto ...` both fail with `Computer Use install declined by user.`
**After (GREEN):** `✓ packages/core/src/tools/computer-use/ — 90 tests passed`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ unit tests + `tsc --noEmit` (core)   |
| 🪟 Windows |   ✅ CI green   |
|  🐧 Linux  |   ✅ CI green   |

### Environment

Unit tests only (`vitest`); no live desktop / `npx` spawn required.

## Risk & Scope

- **Main risk / tradeoff:** `ComputerUseTool` holds a `Config` (optional 3rd ctor arg) and `registerComputerUseTools` gains an optional 2nd arg. Both optional → backward compatible; absent `config` keeps the existing headless behavior.
- **Scope:** covers exactly the approval modes that auto-approve the call **and** skip the dialog (YOLO / AUTO_EDIT / AUTO). `DEFAULT` still shows the install dialog; `PLAN` still blocks. Semantically safe: in those modes the scheduler already approved the *call* with no dialog opportunity, so auto-approving the install aligns with the approval already granted — it does not bypass a consent step the user would otherwise see. **Per-action permission is untouched** (`getDefaultPermission` still returns `'ask'`), so this does not re-introduce the blanket-grant issue fixed in #4590.
- **Breaking changes / migration:** none.

## Linked Issues

Relates to #4590 (zero-config built-in / bootstrap) and #4726 (fork repoint). No issue to auto-close.

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复在**所有"自动批准工具调用并跳过确认弹窗"的审批模式**(**YOLO、AUTO_EDIT、AUTO**)下首次调用 Computer Use 报 `install declined by user` 的问题——尽管用户从未拒绝。现在工具读取当前审批模式,在这些模式下自动通过一次性安装闸门。`DEFAULT`(交互弹窗)与 `PLAN`(阻断)不变。

## 为什么需要

两道独立闸门:(1) 标准确认弹窗,其 `onConfirm` 负责写入安装授权;(2) bootstrap headless 兜底(仅 `QWEN_COMPUTER_USE_AUTO_APPROVE=1` 才放行)。只要调度器自动批准了工具调用,就会跳过闸门 1 → `onConfirm` 不执行 → 安装状态未写入 → 闸门 2 在没设环境变量时抛 "declined",且全程没有任何弹窗。命中三种模式:

- **YOLO**:`needsConfirmation()` 返回 false,直接 `ProceedAlways`,不构建弹窗(`coreToolScheduler.ts:1984`)。
- **AUTO_EDIT**:`isAutoEditApproved()` 自动批准 `type:'info'` 工具,而**所有 `computer_use__*` 都是 `info`**,于是 `ProceedAlways` 且不调用 `onConfirm`(`coreToolScheduler.ts:2028`)。
- **AUTO**:分类器批准的调用同样 `ProceedAlways` 且跳过 `onConfirm`(`coreToolScheduler.ts:1933`)。

## 方案与范围

把 `Config` 透传进 `ComputerUseTool`,`execute()` 据此在 `YOLO‖AUTO_EDIT‖AUTO` 下设置 `BootstrapContext.autoApproveInstall`;`runBootstrap` 据此跳过提示并持久化授权。语义安全:这些模式下调度器已经批准了**调用**、且根本不会弹窗,自动通过安装只是与已授予的调用批准对齐,并未绕过用户本应看到的确认步骤。逐操作权限不变(`getDefaultPermission` 仍 `'ask'`),不会重新引入 #4590 修过的"一次确认全量放行"。`DEFAULT` 仍弹窗,`PLAN` 仍阻断。测试在 tool / bootstrap 两层覆盖,execute 层参数化覆盖三种模式(均先 RED 后 GREEN),`npx vitest run packages/core/src/tools/computer-use/` 全绿(90)。

</details>
