### PR TITLE
chore: remove commented-out debug code

### DIFF
--- a/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
+++ b/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
@@ -31,7 +31,6 @@ import type { IPendingRequestRegistry } from './controllers/baseController.js';
 import { SystemController } from './controllers/systemController.js';
 import { PermissionController } from './controllers/permissionController.js';
 import { SdkMcpController } from './controllers/sdkMcpController.js';
-// import { HookController } from './controllers/hookController.js';
 import type {
   CLIControlRequest,
   CLIControlResponse,
@@ -72,7 +71,6 @@ export class ControlDispatcher implements IPendingRequestRegistry {
   readonly systemController: SystemController;
   readonly permissionController: PermissionController;
   readonly sdkMcpController: SdkMcpController;
-  // readonly hookController: HookController;
 
   // Central pending request registries
   private pendingIncomingRequests: Map<string, PendingIncomingRequest> =
@@ -101,7 +99,6 @@ export class ControlDispatcher implements IPendingRequestRegistry {
       this,
       'SdkMcpController',
     );
-    // this.hookController = new HookController(context, this, 'HookController');
 
     // Listen for main abort signal
     this.abortHandler = () => {

--- a/packages/core/src/qwen/sharedTokenManager.ts
+++ b/packages/core/src/qwen/sharedTokenManager.ts
@@ -474,7 +474,6 @@ export class SharedTokenManager {
       // Check if we have a refresh token before attempting refresh
       const currentCredentials = qwenClient.getCredentials();
       if (!currentCredentials.refresh_token) {
-        // console.debug('create a NO_REFRESH_TOKEN error');
         throw new TokenManagerError(
           TokenError.NO_REFRESH_TOKEN,
           'No refresh token available for token refresh',


### PR DESCRIPTION
## Summary

- Remove commented-out `HookController` import, property declaration, and constructor call in `ControlDispatcher.ts` — these are unwired scaffolding with no preservation annotation; the controller is already documented in the class docstring
- Remove commented-out `console.debug` statement in `sharedTokenManager.ts` — debug leftover

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/nonInteractive/control/ControlDispatcher.ts` | Remove 3 commented-out `HookController` lines (import, property, constructor) |
| `packages/core/src/qwen/sharedTokenManager.ts` | Remove 1 commented-out `console.debug` line |

## Verification

- TypeScript type-check passes (`tsc --noEmit`) for both `core` and `cli` packages
- No functional changes — only dead commented-out code removed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)