### PR TITLE
chore: clean up commented-out code in sandbox.ts

### DIFF
--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -325,10 +325,7 @@ export async function start_sandbox(
       process.on('SIGINT', stopProxy);
       process.on('SIGTERM', stopProxy);
 
-      // commented out as it disrupts ink rendering
-      // proxyProcess.stdout?.on('data', (data) => {
-      //   console.info(data.toString());
-      // });
+      // Proxy stdout is intentionally not piped — it disrupts ink rendering.
       proxyProcess.stderr?.on('data', (data) => {
         writeStderrLine(data.toString());
       });
@@ -863,10 +860,7 @@ export async function start_sandbox(
     process.on('SIGINT', stopProxy);
     process.on('SIGTERM', stopProxy);
 
-    // commented out as it disrupts ink rendering
-    // proxyProcess.stdout?.on('data', (data) => {
-    //   console.info(data.toString());
-    // });
+    // Proxy stdout is intentionally not piped — it disrupts ink rendering.
     proxyProcess.stderr?.on('data', (data) => {
       writeStderrLine(data.toString().trim());
     });
@@ -933,12 +927,9 @@ async function imageExists(sandbox: string, image: string): Promise<boolean> {
       resolve(false);
     });
 
-    checkProcess.on('close', (code) => {
-      // Non-zero code might indicate docker daemon not running, etc.
+    checkProcess.on('close', () => {
+      // Non-zero exit code may indicate docker daemon not running, etc.
       // The primary success indicator is non-empty stdoutData.
-      if (code !== 0) {
-        // console.warn(`'${sandbox} images -q ${image}' exited with code ${code}.`);
-      }
       resolve(stdoutData.trim() !== '');
     });
   });


### PR DESCRIPTION
## Summary

- Replace 2 commented-out stdout pipe blocks with concise explanatory comments — the dead code added no value over the reason ("disrupts ink rendering")
- Remove empty `if (code !== 0)` block containing only a commented-out `console.warn` in `imageExists()`; the unused `code` callback parameter is also dropped

## Changes

| Location | Before | After |
|----------|--------|-------|
| `sandbox.ts:328` | 4-line commented-out code block | 1-line explanatory comment |
| `sandbox.ts:866` | Same pattern (duplicate) | Same fix |
| `sandbox.ts:933` | Empty if-block with commented-out warn | Block removed, unused param dropped |

## Verification

- TypeScript type-check passes (`tsc --noEmit`)
- Pre-commit lint/prettier pass
- No functional changes