### PR TITLE
fix(core): preserve non-ASCII git paths in file crawler

### DIFF
--- a/packages/core/src/utils/filesearch/crawler.test.ts
+++ b/packages/core/src/utils/filesearch/crawler.test.ts
@@ -848,6 +848,80 @@ describe('crawler', () => {
       );
     });
 
+    it('should preserve non-ASCII tracked filenames', async () => {
+      tmpDir = await createTmpDir({
+        '设计文档.txt': '',
+      });
+      await initGitRepo(tmpDir);
+      await runExecFile('git', ['config', 'core.quotePath', 'true'], tmpDir);
+
+      const ignore = loadIgnoreRules({
+        projectRoot: tmpDir,
+        useGitignore: false,
+        useQwenignore: false,
+        ignoreDirs: [],
+      });
+
+      const results = await crawl({
+        crawlDirectory: tmpDir,
+        cwd: tmpDir,
+        ignore,
+        cache: false,
+        cacheTtl: 0,
+      });
+
+      expect(results).toContain('设计文档.txt');
+      expect(results.some((entry) => entry.includes('\\346'))).toBe(false);
+    });
+
+    it('should disable Git path quoting for crawler commands', async () => {
+      tmpDir = await createTmpDir({ 'tracked.js': '' });
+      const gitArgsSeen: string[][] = [];
+
+      __setCommandRunnerForTests(async (command, args) => {
+        if (command !== 'git') {
+          return { success: false, lines: [] };
+        }
+
+        gitArgsSeen.push(args);
+        const quotePathArgIndex = args.indexOf('core.quotePath=false');
+        expect(quotePathArgIndex).toBeGreaterThan(0);
+        expect(args[quotePathArgIndex - 1]).toBe('-c');
+
+        if (args.includes('rev-parse') && args.includes('--show-toplevel')) {
+          return { success: true, lines: [tmpDir] };
+        }
+        if (args.includes('ls-files') && args.includes('--others')) {
+          return { success: true, lines: [] };
+        }
+        if (args.includes('ls-files') && args.includes('--deleted')) {
+          return { success: true, lines: [] };
+        }
+        if (args.includes('ls-files') && args.includes('--cached')) {
+          return { success: true, lines: ['H tracked.js'] };
+        }
+        return { success: false, lines: [] };
+      });
+
+      const ignore = loadIgnoreRules({
+        projectRoot: tmpDir,
+        useGitignore: false,
+        useQwenignore: false,
+        ignoreDirs: [],
+      });
+
+      const results = await crawl({
+        crawlDirectory: tmpDir,
+        cwd: tmpDir,
+        ignore,
+        cache: false,
+        cacheTtl: 0,
+      });
+
+      expect(results).toContain('tracked.js');
+      expect(gitArgsSeen.length).toBeGreaterThan(0);
+    });
+
     it('should resolve the git root from a subdirectory crawl', async () => {
       tmpDir = await createTmpDir({
         src: ['file2.js'],

--- a/packages/core/src/utils/filesearch/crawler.ts
+++ b/packages/core/src/utils/filesearch/crawler.ts
@@ -169,6 +169,8 @@ function logCommandProblem(
 function withSafeGitConfig(args: string[]): string[] {
   return [
     '-c',
+    'core.quotePath=false',
+    '-c',
     'core.fsmonitor=false',
     '-c',
     'core.untrackedCache=false',


### PR DESCRIPTION
## What this PR does

This PR makes the file crawler run its internal Git commands with path quoting disabled so non-ASCII tracked filenames are returned as normal UTF-8 paths instead of Git's octal-escaped form. It also adds regression coverage for a repository that explicitly enables Git path quoting.

## Why it's needed

The @ file completion path can use git ls-files for tracked files. With Git's default core.quotePath behavior, tracked filenames such as Chinese names can be emitted as escaped byte sequences like \346\212..., and the CLI surfaces that escaped text directly in suggestions. Disabling quotePath for these internal list commands keeps the completion UI readable without changing the user's repository configuration.

## Reviewer Test Plan

### How to verify

Create or use a Git repository with a tracked non-ASCII filename and core.quotePath=true, then trigger @ file completion or run the crawler tests. The filename should appear in readable text, not as octal escape sequences. Locally verified with: cd packages/core && npx vitest run src/utils/filesearch/crawler.test.ts; cd packages/core && npm run typecheck; cd packages/core && npm run build.

### Evidence (Before & After)

Before: Git can emit tracked non-ASCII paths as octal escapes when core.quotePath is enabled. After: the new regression test forces core.quotePath=true and confirms the crawler returns 设计文档.txt without \346-style escapes.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Node.js v22.22.2, package-level Vitest/typecheck/build in packages/core.

## Risk & Scope

- Main risk or tradeoff: This changes only internal Git command configuration for path listing; it should not mutate user Git config or repository state.
- Not validated / out of scope: Manual TUI screenshot verification and Windows/Linux local runs were not performed.
- Breaking changes / migration notes: None.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 让文件 crawler 在执行内部 Git 命令时关闭路径转义，使非 ASCII 的 tracked 文件名以正常 UTF-8 路径返回，而不是 Git 的八进制转义形式。同时新增了一个显式开启 Git 路径转义仓库的回归测试。

## 为什么需要

@ 文件补全路径可能会对 tracked 文件使用 git ls-files。在 Git 默认 core.quotePath 行为下，中文等非 ASCII 文件名可能被输出成类似 \346\212... 的字节转义，并被 CLI 原样展示到补全建议里。对这些内部列表命令禁用 quotePath 可以让补全 UI 保持可读，同时不修改用户仓库配置。

## Reviewer Test Plan

### 如何验证

创建或使用一个包含 tracked 非 ASCII 文件名且 core.quotePath=true 的 Git 仓库，然后触发 @ 文件补全或运行 crawler 测试。文件名应该以可读文本显示，而不是八进制转义。本地已验证：cd packages/core && npx vitest run src/utils/filesearch/crawler.test.ts；cd packages/core && npm run typecheck；cd packages/core && npm run build。

### 证据（Before & After）

Before：当 core.quotePath 启用时，Git 可能把 tracked 非 ASCII 路径输出为八进制转义。After：新的回归测试强制 core.quotePath=true，并确认 crawler 返回 设计文档.txt，而不是 \346 形式的转义。

### 已测试平台

|     OS     | 状态 |
| :--------: | :----: |
|  🍏 macOS  | ✅ 已测试 |
| 🪟 Windows | ⚠️ 未测试 |
|  🐧 Linux  | ⚠️ 未测试 |

### 环境（可选）

Node.js v22.22.2，在 packages/core 中运行了包级 Vitest、typecheck 和 build。

## 风险与范围

- 主要风险或取舍：只改变内部 Git 列表命令配置，不会修改用户 Git 配置或仓库状态。
- 未验证 / 范围外：未进行手动 TUI 截图验证，也未在 Windows/Linux 本地运行。
- 破坏性变更 / 迁移说明：无。

## 关联 Issue

N/A

</details>