### PR TITLE
chore: remove redundant comments in IDE modules

### DIFF
--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -79,8 +79,6 @@ function getRealPath(path: string): string {
   try {
     return fs.realpathSync(path);
   } catch (_e) {
-    // If realpathSync fails, it might be because the path doesn't exist.
-    // In that case, we can fall back to the original path.
     return path;
   }
 }
@@ -452,7 +450,6 @@ export class IdeClient {
         ListToolsResultSchema,
       );
 
-      // Map the array of tool objects to an array of tool names (strings)
       this.availableTools = response.tools.map((tool) => tool.name);
 
       if (this.availableTools.length > 0) {

--- a/packages/core/src/ide/ideContext.ts
+++ b/packages/core/src/ide/ideContext.ts
@@ -43,7 +43,6 @@ export class IdeContextStore {
       // Sort by timestamp descending (newest first)
       openFiles.sort((a, b) => b.timestamp - a.timestamp);
 
-      // The most recent file is now at index 0.
       const mostRecentFile = openFiles[0];
 
       // If the most recent file is not active, then no file is active.
@@ -63,7 +62,6 @@ export class IdeContextStore {
           }
         });
 
-        // Truncate selected text in the active file
         if (
           mostRecentFile.selectedText &&
           mostRecentFile.selectedText.length > IDE_MAX_SELECTED_TEXT_LENGTH
@@ -76,7 +74,6 @@ export class IdeContextStore {
         }
       }
 
-      // Truncate files list
       if (openFiles.length > IDE_MAX_OPEN_FILES) {
         workspaceState.openFiles = openFiles.slice(0, IDE_MAX_OPEN_FILES);
       }


### PR DESCRIPTION
## Summary

Remove 5 "what" comments that restate the code without adding value. Business-rule and "why" comments are retained.

## Changes

### `packages/core/src/ide/ideContext.ts` (3 deletions)
- `// The most recent file is now at index 0.` — obvious after descending sort
- `// Truncate selected text in the active file` — `IDE_MAX_SELECTED_TEXT_LENGTH` is self-documenting
- `// Truncate files list` — `IDE_MAX_OPEN_FILES` is self-documenting

### `packages/core/src/ide/ide-client.ts` (2 deletions)
- `// If realpathSync fails...fall back to the original path.` — the catch-return pattern is self-explanatory
- `// Map the array of tool objects to an array of tool names (strings)` — restates `.map((tool) => tool.name)`

## Verification

- TypeScript type-check passes (`tsc --noEmit`)
- Pre-commit lint/prettier pass
- No functional changes