### PR TITLE
chore: remove stale TODOs and condense comment in core

### DIFF
--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -465,8 +465,7 @@ export class IdeClient {
         );
       }
     } catch (error) {
-      // It's okay if this fails, the IDE might not support it.
-      // Don't log an error if the method is not found, which is a common case.
+      // "Method not found" is expected for IDEs that don't support tool discovery.
       if (
         error instanceof Error &&
         !error.message?.includes('Method not found')

--- a/packages/core/src/utils/ignorePatterns.ts
+++ b/packages/core/src/utils/ignorePatterns.ts
@@ -166,7 +166,6 @@ export class FileExclusions {
     }
 
     // Add custom patterns from configuration
-    // TODO: getCustomExcludes method needs to be implemented in Config interface
     if (this.config) {
       const configCustomExcludes = this.config.getCustomExcludes?.() ?? [];
       patterns.push(...configCustomExcludes);
@@ -201,7 +200,6 @@ export class FileExclusions {
     const corePatterns = this.getCoreIgnorePatterns();
 
     // Add any custom patterns from config if available
-    // TODO: getCustomExcludes method needs to be implemented in Config interface
     const configPatterns = this.config?.getCustomExcludes?.() ?? [];
 
     return [...corePatterns, ...configPatterns, ...additionalExcludes];


### PR DESCRIPTION
## Summary

- Remove 2 stale TODO comments in `ignorePatterns.ts` and condense a verbose catch-block comment in `ide-client.ts`

## Changes

### `packages/core/src/utils/ignorePatterns.ts` (2 deletions)
- Removed identical TODO on lines 169 and 204: *"getCustomExcludes method needs to be implemented in Config interface"*
- The method **has been implemented** at `packages/core/src/config/config.ts:3385` and is already called via optional chaining on the next line

### `packages/core/src/ide/ide-client.ts` (1 line condensed)
- Condensed 2-line catch comment (*"It's okay if this fails..."* + *"Don't log an error if..."*) into a single line that explains why `Method not found` is special-cased

## Verification

- TypeScript type-check passes (`tsc --noEmit`)
- Pre-commit lint/prettier pass
- No functional changes