### PR TITLE
chore: code quality cleanup — remove dead comments and stale TODOs

### DIFF
--- a/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
+++ b/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
@@ -17,7 +17,6 @@
  * - SystemController: initialize, interrupt, set_model, supported_commands, get_context_usage
  * - PermissionController: can_use_tool, set_permission_mode
  * - SdkMcpController: mcp_server_status (mcp_message handled via callback)
- * - HookController: hook_callback
  *
  * Note: mcp_message requests are NOT routed through the dispatcher. CLI MCP
  * clients send messages via SdkMcpController.createSendSdkMcpMessage() callback.
@@ -270,7 +269,6 @@ export class ControlDispatcher implements IPendingRequestRegistry {
     this.systemController.cleanup();
     this.permissionController.cleanup();
     this.sdkMcpController.cleanup();
-    // this.hookController.cleanup();
   }
 
   /**
@@ -386,9 +384,6 @@ export class ControlDispatcher implements IPendingRequestRegistry {
 
       case 'mcp_server_status':
         return this.sdkMcpController;
-
-      // case 'hook_callback':
-      //   return this.hookController;
 
       default:
         throw new Error(`Unknown control request subtype: ${subtype}`);

--- a/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
+++ b/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
@@ -31,7 +31,6 @@ import type { IPendingRequestRegistry } from './controllers/baseController.js';
 import { SystemController } from './controllers/systemController.js';
 import { PermissionController } from './controllers/permissionController.js';
 import { SdkMcpController } from './controllers/sdkMcpController.js';
-// import { HookController } from './controllers/hookController.js';
 import type {
   CLIControlRequest,
   CLIControlResponse,
@@ -72,7 +71,6 @@ export class ControlDispatcher implements IPendingRequestRegistry {
   readonly systemController: SystemController;
   readonly permissionController: PermissionController;
   readonly sdkMcpController: SdkMcpController;
-  // readonly hookController: HookController;
 
   // Central pending request registries
   private pendingIncomingRequests: Map<string, PendingIncomingRequest> =
@@ -101,7 +99,6 @@ export class ControlDispatcher implements IPendingRequestRegistry {
       this,
       'SdkMcpController',
     );
-    // this.hookController = new HookController(context, this, 'HookController');
 
     // Listen for main abort signal
     this.abortHandler = () => {

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -325,10 +325,7 @@ export async function start_sandbox(
       process.on('SIGINT', stopProxy);
       process.on('SIGTERM', stopProxy);
 
-      // commented out as it disrupts ink rendering
-      // proxyProcess.stdout?.on('data', (data) => {
-      //   console.info(data.toString());
-      // });
+      // Proxy stdout is intentionally not piped — it disrupts ink rendering.
       proxyProcess.stderr?.on('data', (data) => {
         writeStderrLine(data.toString());
       });
@@ -863,10 +860,7 @@ export async function start_sandbox(
     process.on('SIGINT', stopProxy);
     process.on('SIGTERM', stopProxy);
 
-    // commented out as it disrupts ink rendering
-    // proxyProcess.stdout?.on('data', (data) => {
-    //   console.info(data.toString());
-    // });
+    // Proxy stdout is intentionally not piped — it disrupts ink rendering.
     proxyProcess.stderr?.on('data', (data) => {
       writeStderrLine(data.toString().trim());
     });
@@ -933,12 +927,9 @@ async function imageExists(sandbox: string, image: string): Promise<boolean> {
       resolve(false);
     });
 
-    checkProcess.on('close', (code) => {
-      // Non-zero code might indicate docker daemon not running, etc.
+    checkProcess.on('close', () => {
+      // Non-zero exit code may indicate docker daemon not running, etc.
       // The primary success indicator is non-empty stdoutData.
-      if (code !== 0) {
-        // console.warn(`'${sandbox} images -q ${image}' exited with code ${code}.`);
-      }
       resolve(stdoutData.trim() !== '');
     });
   });

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -79,8 +79,6 @@ function getRealPath(path: string): string {
   try {
     return fs.realpathSync(path);
   } catch (_e) {
-    // If realpathSync fails, it might be because the path doesn't exist.
-    // In that case, we can fall back to the original path.
     return path;
   }
 }
@@ -452,7 +450,6 @@ export class IdeClient {
         ListToolsResultSchema,
       );
 
-      // Map the array of tool objects to an array of tool names (strings)
       this.availableTools = response.tools.map((tool) => tool.name);
 
       if (this.availableTools.length > 0) {
@@ -465,8 +462,7 @@ export class IdeClient {
         );
       }
     } catch (error) {
-      // It's okay if this fails, the IDE might not support it.
-      // Don't log an error if the method is not found, which is a common case.
+      // "Method not found" is expected for IDEs that don't support tool discovery.
       if (
         error instanceof Error &&
         !error.message?.includes('Method not found')

--- a/packages/core/src/ide/ideContext.ts
+++ b/packages/core/src/ide/ideContext.ts
@@ -43,7 +43,6 @@ export class IdeContextStore {
       // Sort by timestamp descending (newest first)
       openFiles.sort((a, b) => b.timestamp - a.timestamp);
 
-      // The most recent file is now at index 0.
       const mostRecentFile = openFiles[0];
 
       // If the most recent file is not active, then no file is active.
@@ -63,7 +62,6 @@ export class IdeContextStore {
           }
         });
 
-        // Truncate selected text in the active file
         if (
           mostRecentFile.selectedText &&
           mostRecentFile.selectedText.length > IDE_MAX_SELECTED_TEXT_LENGTH
@@ -76,7 +74,6 @@ export class IdeContextStore {
         }
       }
 
-      // Truncate files list
       if (openFiles.length > IDE_MAX_OPEN_FILES) {
         workspaceState.openFiles = openFiles.slice(0, IDE_MAX_OPEN_FILES);
       }

--- a/packages/core/src/qwen/sharedTokenManager.ts
+++ b/packages/core/src/qwen/sharedTokenManager.ts
@@ -474,7 +474,6 @@ export class SharedTokenManager {
       // Check if we have a refresh token before attempting refresh
       const currentCredentials = qwenClient.getCredentials();
       if (!currentCredentials.refresh_token) {
-        // console.debug('create a NO_REFRESH_TOKEN error');
         throw new TokenManagerError(
           TokenError.NO_REFRESH_TOKEN,
           'No refresh token available for token refresh',

--- a/packages/core/src/utils/ignorePatterns.ts
+++ b/packages/core/src/utils/ignorePatterns.ts
@@ -166,7 +166,6 @@ export class FileExclusions {
     }
 
     // Add custom patterns from configuration
-    // TODO: getCustomExcludes method needs to be implemented in Config interface
     if (this.config) {
       const configCustomExcludes = this.config.getCustomExcludes?.() ?? [];
       patterns.push(...configCustomExcludes);
@@ -201,7 +200,6 @@ export class FileExclusions {
     const corePatterns = this.getCoreIgnorePatterns();
 
     // Add any custom patterns from config if available
-    // TODO: getCustomExcludes method needs to be implemented in Config interface
     const configPatterns = this.config?.getCustomExcludes?.() ?? [];
 
     return [...corePatterns, ...configPatterns, ...additionalExcludes];


### PR DESCRIPTION
## Summary

Incremental readability improvements across 6 files. No functional changes — only dead/redundant comments and stale TODOs removed.

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/nonInteractive/control/ControlDispatcher.ts` | Remove 3 commented-out `HookController` lines (import, property, constructor) |
| `packages/core/src/qwen/sharedTokenManager.ts` | Remove commented-out `console.debug` |
| `packages/cli/src/utils/sandbox.ts` | Replace 2 commented-out stdout pipe blocks with concise comments; remove empty `if (code !== 0)` block |
| `packages/core/src/ide/ideContext.ts` | Remove 3 "what" comments that restate the code |
| `packages/core/src/ide/ide-client.ts` | Remove 2 redundant comments; condense verbose catch comment |
| `packages/core/src/utils/ignorePatterns.ts` | Remove 2 stale TODOs — `getCustomExcludes` is already implemented at `config.ts:3385` |

## Verification

- TypeScript type-check passes (`tsc --noEmit`) for both `core` and `cli`
- Pre-commit lint/prettier pass
- All changes are comment-only deletions — zero functional impact