### PR TITLE
feat(serve): ACP WebSocket transport (RFD Streamable HTTP phase 2)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -81,6 +81,7 @@
     "undici": "^6.22.0",
     "update-notifier": "^7.3.1",
     "wrap-ansi": "^10.0.0",
+    "ws": "^8.18.0",
     "yargs": "^17.7.2",
     "zod": "^3.23.8"
   },
@@ -94,6 +95,7 @@
     "@types/express": "^5.0.3",
     "@types/node": "^22.0.0",
     "@types/prompts": "^2.4.9",
+    "@types/ws": "^8.5.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@types/semver": "^7.7.0",

--- a/packages/cli/src/serve/acpHttp/connectionRegistry.ts
+++ b/packages/cli/src/serve/acpHttp/connectionRegistry.ts
@@ -257,7 +257,9 @@ export class AcpConnection {
     // reconnecting, not leaving — the prompt must survive). CONTRACT: that
     // identity guard and this ordering must stay in lockstep.
     binding.stream = stream;
-    if (prevStream && prevStream !== stream) prevStream.close();
+    if (prevStream && prevStream !== stream && prevStream !== this.connStream) {
+      prevStream.close();
+    }
     for (const frame of binding.buffer.splice(0)) void stream.send(frame);
     return binding;
   }

--- a/packages/cli/src/serve/acpHttp/connectionRegistry.ts
+++ b/packages/cli/src/serve/acpHttp/connectionRegistry.ts
@@ -7,7 +7,7 @@
 import { randomUUID } from 'node:crypto';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 import { logSafe } from './jsonRpc.js';
-import type { SseStream } from './sseStream.js';
+import type { TransportStream } from './transportStream.js';
 
 /**
  * Per-stream cap on frames buffered before the client attaches its SSE
@@ -59,7 +59,7 @@ export interface SessionBinding {
    */
   clientId?: string;
   /** Session-scoped SSE stream (the client's `GET /acp` with both headers). */
-  stream?: SseStream;
+  stream?: TransportStream;
   /** Frames emitted before the session stream attached, flushed on attach. */
   buffer: unknown[];
   /**
@@ -90,7 +90,7 @@ export interface PendingClientRequest {
 export class AcpConnection {
   readonly connectionId: string;
   /** Connection-scoped SSE stream (the client's `GET /acp` with only the conn header). */
-  connStream?: SseStream;
+  connStream?: TransportStream;
   /** Frames emitted before the connection stream attached, flushed on attach. */
   private readonly connBuffer: unknown[] = [];
   readonly sessions = new Map<string, SessionBinding>();
@@ -206,7 +206,7 @@ export class AcpConnection {
   }
 
   /** Attach the connection-scoped stream and flush any buffered frames. */
-  attachConnStream(stream: SseStream): void {
+  attachConnStream(stream: TransportStream): void {
     // A reconnect cancels any pending grace-period reap.
     this.clearGraceTimer();
     // Close any prior connection stream so its heartbeat interval + socket
@@ -242,7 +242,7 @@ export class AcpConnection {
    */
   attachSessionStream(
     sessionId: string,
-    stream: SseStream,
+    stream: TransportStream,
     abort: AbortController,
   ): SessionBinding {
     const binding = this.getOrCreateSession(sessionId);
@@ -285,7 +285,11 @@ export class AcpConnection {
   private teardownBinding(binding: SessionBinding): void {
     binding.abort.abort();
     binding.promptAbort?.abort();
-    binding.stream?.close();
+    // Don't close the stream if it's the shared connStream (WS reuses
+    // one socket for all sessions — closing it kills the entire connection).
+    if (binding.stream && binding.stream !== this.connStream) {
+      binding.stream.close();
+    }
     this.abandonPendingForSession(binding.sessionId, binding.clientId);
     this.onDetachSession?.(binding.sessionId, binding.clientId);
   }

--- a/packages/cli/src/serve/acpHttp/connectionRegistry.ts
+++ b/packages/cli/src/serve/acpHttp/connectionRegistry.ts
@@ -276,7 +276,13 @@ export class AcpConnection {
     this.destroyed = true;
     this.clearGraceTimer();
     for (const binding of this.sessions.values()) {
-      this.teardownBinding(binding);
+      try {
+        this.teardownBinding(binding);
+      } catch (err) {
+        writeStderrLine(
+          `qwen serve: /acp teardownBinding(${logSafe(binding.sessionId)}) failed during destroy: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
     this.sessions.clear();
     this.ownedSessions.clear();

--- a/packages/cli/src/serve/acpHttp/index.ts
+++ b/packages/cli/src/serve/acpHttp/index.ts
@@ -224,6 +224,32 @@ export function mountAcpHttp(
       return;
     }
 
+    // Rate limit ACP HTTP POST (mirrors the WS checkRate path).
+    if (opts.checkRate && isRequest(message)) {
+      const m = message.method;
+      if (!WS_EXEMPT_METHODS.has(m)) {
+        const tier: RateLimitTier =
+          m === 'session/prompt' || m === '_qwen/session/prompt'
+            ? 'prompt'
+            : WS_READ_METHODS.has(m)
+              ? 'read'
+              : 'mutation';
+        const httpKey = (req.socket?.remoteAddress ?? 'http-unknown').replace(
+          /^::ffff:/,
+          '',
+        );
+        if (!opts.checkRate(httpKey, tier)) {
+          res.setHeader('Retry-After', '5');
+          res.status(429).json({
+            error: 'Rate limit exceeded',
+            code: 'rate_limit_exceeded',
+            tier,
+          });
+          return;
+        }
+      }
+    }
+
     // Per RFD: non-initialize POST acks 202; the reply rides an SSE stream.
     res.status(202).end();
     // Response already sent — `handle` delivers everything else over SSE, so

--- a/packages/cli/src/serve/acpHttp/index.ts
+++ b/packages/cli/src/serve/acpHttp/index.ts
@@ -622,8 +622,10 @@ export function mountAcpHttp(
                 if (binding && !binding.stream) {
                   const ac = new AbortController();
                   conn.attachSessionStream(sid, conn.connStream!, ac);
+                  const myAbort = ac;
                   const cleanupSession = () => {
-                    if (conn.sessions.get(sid)?.stream === conn.connStream) {
+                    const b = conn.sessions.get(sid);
+                    if (b?.stream === conn.connStream && b?.abort === myAbort) {
                       conn.closeSessionStream(sid);
                     }
                   };

--- a/packages/cli/src/serve/acpHttp/index.ts
+++ b/packages/cli/src/serve/acpHttp/index.ts
@@ -394,7 +394,7 @@ export function mountAcpHttp(
             `[::1]:${localPort}`,
             `host.docker.internal:${localPort}`,
           ]);
-          if (host && !allowed.has(host)) {
+          if (!allowed.has(host)) {
             socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
             socket.destroy();
             return;
@@ -407,7 +407,7 @@ export function mountAcpHttp(
         const origin = req.headers['origin'];
         if (origin) {
           try {
-            const originHost = new URL(origin).hostname;
+            const originHost = new URL(origin).hostname.replace(/^\[|\]$/g, '');
             if (
               originHost !== '127.0.0.1' &&
               originHost !== 'localhost' &&

--- a/packages/cli/src/serve/acpHttp/index.ts
+++ b/packages/cli/src/serve/acpHttp/index.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { timingSafeEqual } from 'node:crypto';
 import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
 import type { Application, Request, Response } from 'express';
@@ -357,7 +358,7 @@ export function mountAcpHttp(
 
   function setupWebSocket(httpServer: import('node:http').Server): void {
     if (wss) return;
-    wss = new WebSocketServer({ noServer: true });
+    wss = new WebSocketServer({ noServer: true, maxPayload: 10 * 1024 * 1024 });
 
     httpServer.on(
       'upgrade',
@@ -377,10 +378,34 @@ export function mountAcpHttp(
           return;
         }
 
-        // CSRF: reject non-loopback origins on WS upgrade.
-        const origin = req.headers['origin'];
         const fromLoopback = isLoopbackSocket(socket);
-        if (origin && !fromLoopback) {
+
+        // Host allowlist: mirror REST surface's hostAllowlist middleware
+        // (auth.ts:196). Prevents DNS-rebinding attacks where a malicious
+        // domain resolves to 127.0.0.1 and the browser sends the
+        // attacker's Host header. Match the full host:port string like
+        // the REST middleware does; extract port from the socket.
+        if (fromLoopback) {
+          const host = (req.headers['host'] ?? '').toLowerCase();
+          const localPort = (socket as { localPort?: number }).localPort;
+          const allowed = new Set([
+            `localhost:${localPort}`,
+            `127.0.0.1:${localPort}`,
+            `[::1]:${localPort}`,
+            `host.docker.internal:${localPort}`,
+          ]);
+          if (host && !allowed.has(host)) {
+            socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+            socket.destroy();
+            return;
+          }
+        }
+
+        // CSRF: reject cross-origin WS upgrades. Browser-initiated requests
+        // to 127.0.0.1 carry the external origin, so this check must apply
+        // to loopback too (CSWSH defence).
+        const origin = req.headers['origin'];
+        if (origin) {
           try {
             const originHost = new URL(origin).hostname;
             if (
@@ -414,7 +439,13 @@ export function mountAcpHttp(
           const credentials = authHeader
             .slice(authHeader.indexOf(' ') + 1)
             .trim();
-          if (scheme !== 'bearer' || credentials !== opts.token) {
+          const expected = Buffer.from(opts.token, 'utf8');
+          const actual = Buffer.from(credentials, 'utf8');
+          if (
+            scheme !== 'bearer' ||
+            expected.length !== actual.length ||
+            !timingSafeEqual(expected, actual)
+          ) {
             socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
             socket.destroy();
             return;

--- a/packages/cli/src/serve/acpHttp/index.ts
+++ b/packages/cli/src/serve/acpHttp/index.ts
@@ -468,10 +468,20 @@ export function mountAcpHttp(
           let messageQueue = Promise.resolve();
           const wsKey = socket.remoteAddress ?? 'ws-unknown';
 
+          ws.on('error', (err) => {
+            writeStderrLine(
+              `qwen serve: /acp WS error: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
+
           ws.on('message', (rawData: Buffer | string) => {
             messageQueue = messageQueue
               .then(() => handleWsMessage(rawData))
-              .catch(() => {});
+              .catch((err) => {
+                writeStderrLine(
+                  `qwen serve: /acp WS message handler error: ${err instanceof Error ? err.message : String(err)}`,
+                );
+              });
           });
 
           async function handleWsMessage(

--- a/packages/cli/src/serve/acpHttp/index.ts
+++ b/packages/cli/src/serve/acpHttp/index.ts
@@ -358,329 +358,332 @@ export function mountAcpHttp(
 
   // ── WebSocket upgrade (ACP RFD) ────────────────────────────────────
   let wss: WebSocketServer | undefined;
+  let upgradeListener: ((...args: unknown[]) => void) | undefined;
+  let upgradeServer: import('node:http').Server | undefined;
 
   function setupWebSocket(httpServer: import('node:http').Server): void {
     if (wss) return;
     wss = new WebSocketServer({ noServer: true, maxPayload: 10 * 1024 * 1024 });
+    upgradeServer = httpServer;
 
-    httpServer.on(
-      'upgrade',
-      (req: IncomingMessage, socket: Duplex, head: Buffer) => {
-        let url: URL;
-        try {
-          url = new URL(
-            req.url ?? '/',
-            `http://${req.headers.host ?? 'localhost'}`,
-          );
-        } catch {
-          socket.destroy();
-          return;
-        }
-        if (url.pathname !== path) {
-          socket.destroy();
-          return;
-        }
+    upgradeListener = (req: IncomingMessage, socket: Duplex, head: Buffer) => {
+      let url: URL;
+      try {
+        url = new URL(
+          req.url ?? '/',
+          `http://${req.headers.host ?? 'localhost'}`,
+        );
+      } catch {
+        socket.destroy();
+        return;
+      }
+      if (url.pathname !== path) {
+        socket.destroy();
+        return;
+      }
 
-        const fromLoopback = isLoopbackSocket(socket);
+      const fromLoopback = isLoopbackSocket(socket);
 
-        // Host allowlist: mirror REST surface's hostAllowlist middleware
-        // (auth.ts:196). Prevents DNS-rebinding attacks where a malicious
-        // domain resolves to 127.0.0.1 and the browser sends the
-        // attacker's Host header. Match the full host:port string like
-        // the REST middleware does; extract port from the socket.
-        if (fromLoopback) {
-          const host = (req.headers['host'] ?? '').toLowerCase();
-          const localPort = (socket as { localPort?: number }).localPort;
-          const allowed = new Set([
-            `localhost:${localPort}`,
-            `127.0.0.1:${localPort}`,
-            `[::1]:${localPort}`,
-            `host.docker.internal:${localPort}`,
-          ]);
-          if (!allowed.has(host)) {
-            socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
-            socket.destroy();
-            return;
-          }
-        }
-
-        // CSRF: reject cross-origin WS upgrades. Browser-initiated requests
-        // to 127.0.0.1 carry the external origin, so this check must apply
-        // to loopback too (CSWSH defence).
-        const origin = req.headers['origin'];
-        if (origin) {
-          try {
-            const originHost = new URL(origin).hostname.replace(/^\[|\]$/g, '');
-            if (
-              originHost !== '127.0.0.1' &&
-              originHost !== 'localhost' &&
-              originHost !== '::1'
-            ) {
-              socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
-              socket.destroy();
-              return;
-            }
-          } catch {
-            socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
-            socket.destroy();
-            return;
-          }
-        }
-
-        // Auth: WS bypasses Express middleware. Same posture as REST:
-        // loopback without token = allow; non-loopback/token-mismatch = reject.
-        if (opts.token) {
-          const authHeader = req.headers['authorization'];
-          if (!authHeader || !authHeader.includes(' ')) {
-            socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
-            socket.destroy();
-            return;
-          }
-          const scheme = authHeader
-            .slice(0, authHeader.indexOf(' '))
-            .toLowerCase();
-          const credentials = authHeader
-            .slice(authHeader.indexOf(' ') + 1)
-            .trim();
-          const expected = createHash('sha256').update(opts.token).digest();
-          const actual = createHash('sha256').update(credentials).digest();
-          if (scheme !== 'bearer' || !timingSafeEqual(expected, actual)) {
-            socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
-            socket.destroy();
-            return;
-          }
-        } else if (!fromLoopback) {
+      // Host allowlist: mirror REST surface's hostAllowlist middleware
+      // (auth.ts:196). Prevents DNS-rebinding attacks where a malicious
+      // domain resolves to 127.0.0.1 and the browser sends the
+      // attacker's Host header. Match the full host:port string like
+      // the REST middleware does; extract port from the socket.
+      if (fromLoopback) {
+        const host = (req.headers['host'] ?? '').toLowerCase();
+        const localPort = (socket as { localPort?: number }).localPort;
+        const allowed = new Set([
+          `localhost:${localPort}`,
+          `127.0.0.1:${localPort}`,
+          `[::1]:${localPort}`,
+          `host.docker.internal:${localPort}`,
+        ]);
+        if (!allowed.has(host)) {
           socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
           socket.destroy();
           return;
         }
+      }
 
-        wss!.handleUpgrade(req, socket, head, (ws: WebSocket) => {
-          let initialized = false;
-          const initTimer = setTimeout(() => {
-            if (!initialized) {
-              ws.close(1002, 'Initialize timeout');
-            }
-          }, 30_000);
-          initTimer.unref?.();
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          let connRef: any;
-          let messageQueue = Promise.resolve();
-          const wsKey = socket.remoteAddress ?? 'ws-unknown';
+      // CSRF: reject cross-origin WS upgrades. Browser-initiated requests
+      // to 127.0.0.1 carry the external origin, so this check must apply
+      // to loopback too (CSWSH defence).
+      const origin = req.headers['origin'];
+      if (origin) {
+        try {
+          const originHost = new URL(origin).hostname.replace(/^\[|\]$/g, '');
+          if (
+            originHost !== '127.0.0.1' &&
+            originHost !== 'localhost' &&
+            originHost !== '::1'
+          ) {
+            socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+            socket.destroy();
+            return;
+          }
+        } catch {
+          socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+          socket.destroy();
+          return;
+        }
+      }
 
-          ws.on('error', (err) => {
-            writeStderrLine(
-              `qwen serve: /acp WS error: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          });
+      // Auth: WS bypasses Express middleware. Same posture as REST:
+      // loopback without token = allow; non-loopback/token-mismatch = reject.
+      if (opts.token) {
+        const authHeader = req.headers['authorization'];
+        if (!authHeader || !authHeader.includes(' ')) {
+          socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+          socket.destroy();
+          return;
+        }
+        const scheme = authHeader
+          .slice(0, authHeader.indexOf(' '))
+          .toLowerCase();
+        const credentials = authHeader
+          .slice(authHeader.indexOf(' ') + 1)
+          .trim();
+        const expected = createHash('sha256').update(opts.token).digest();
+        const actual = createHash('sha256').update(credentials).digest();
+        if (scheme !== 'bearer' || !timingSafeEqual(expected, actual)) {
+          socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+          socket.destroy();
+          return;
+        }
+      } else if (!fromLoopback) {
+        socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+        socket.destroy();
+        return;
+      }
 
-          ws.on('message', (rawData: Buffer | string) => {
-            messageQueue = messageQueue
-              .then(() => handleWsMessage(rawData))
-              .catch((err) => {
-                writeStderrLine(
-                  `qwen serve: /acp WS message handler error: ${err instanceof Error ? err.message : String(err)}`,
-                );
-              });
-          });
+      wss!.handleUpgrade(req, socket, head, (ws: WebSocket) => {
+        let initialized = false;
+        const initTimer = setTimeout(() => {
+          if (!initialized) {
+            ws.close(1002, 'Initialize timeout');
+          }
+        }, 30_000);
+        initTimer.unref?.();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let connRef: any;
+        let messageQueue = Promise.resolve();
+        const wsKey = socket.remoteAddress ?? 'ws-unknown';
 
-          async function handleWsMessage(
-            rawData: Buffer | string,
-          ): Promise<void> {
-            let text: string;
-            try {
-              text =
-                typeof rawData === 'string'
-                  ? rawData
-                  : rawData.toString('utf8');
-            } catch {
-              ws.close(1003, 'Only text frames supported');
-              return;
-            }
+        ws.on('error', (err) => {
+          writeStderrLine(
+            `qwen serve: /acp WS error: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        });
 
-            let parsed: unknown;
-            try {
-              parsed = JSON.parse(text);
-            } catch {
-              ws.send(
-                JSON.stringify(rpcError(null, RPC.PARSE_ERROR, 'Parse error')),
-              );
-              return;
-            }
-
-            if (Array.isArray(parsed)) {
-              ws.send(
-                JSON.stringify({
-                  error: 'Batch JSON-RPC not supported',
-                }),
-              );
-              return;
-            }
-
-            const inbound = parseInbound(parsed);
-            if (!inbound.ok) {
-              ws.send(JSON.stringify(inbound.error));
-              return;
-            }
-            const message = inbound.message;
-
-            if (!initialized) {
-              if (!isRequest(message) || message.method !== 'initialize') {
-                ws.send(
-                  JSON.stringify(
-                    rpcError(
-                      isRequest(message) ? message.id : null,
-                      RPC.INVALID_REQUEST,
-                      'First message must be initialize',
-                    ),
-                  ),
-                );
-                ws.close(1002, 'Protocol error');
-                return;
-              }
-
-              const conn = registry.create(fromLoopback);
-              if (!conn) {
-                ws.send(
-                  JSON.stringify(
-                    rpcError(
-                      message.id,
-                      RPC.INTERNAL_ERROR,
-                      'Too many connections',
-                    ),
-                  ),
-                );
-                ws.close(1013, 'Connection cap');
-                return;
-              }
-
-              const requestedVersion =
-                message.params &&
-                typeof message.params === 'object' &&
-                !Array.isArray(message.params)
-                  ? (message.params as Record<string, unknown>)[
-                      'protocolVersion'
-                    ]
-                  : undefined;
-
-              // WS: single socket serves as conn stream + all session streams.
-              const stream = new WsStream(
-                ws,
-                () => {
-                  writeStderrLine(
-                    `qwen serve: /acp WS closed (${conn.connectionId.slice(0, 8)})`,
-                  );
-                  registry.delete(conn.connectionId);
-                },
-                () => conn.touch(),
-              );
-              conn.attachConnStream(stream);
-
-              ws.send(
-                JSON.stringify({
-                  jsonrpc: '2.0',
-                  id: message.id,
-                  result: dispatcher.buildInitializeResult(
-                    conn.connectionId,
-                    requestedVersion,
-                  ),
-                }),
-              );
-
-              initialized = true;
-              clearTimeout(initTimer);
-              connRef = conn;
+        ws.on('message', (rawData: Buffer | string) => {
+          messageQueue = messageQueue
+            .then(() => handleWsMessage(rawData))
+            .catch((err) => {
               writeStderrLine(
-                `qwen serve: /acp WS established ${conn.connectionId.slice(0, 8)} (loopback=${fromLoopback}, active=${registry.size})`,
+                `qwen serve: /acp WS message handler error: ${err instanceof Error ? err.message : String(err)}`,
               );
-              return;
-            }
+            });
+        });
 
-            // Subsequent messages
-            const conn = connRef;
-            if (!conn || conn.destroyed) {
+        async function handleWsMessage(
+          rawData: Buffer | string,
+        ): Promise<void> {
+          let text: string;
+          try {
+            text =
+              typeof rawData === 'string' ? rawData : rawData.toString('utf8');
+          } catch {
+            ws.close(1003, 'Only text frames supported');
+            return;
+          }
+
+          let parsed: unknown;
+          try {
+            parsed = JSON.parse(text);
+          } catch {
+            ws.send(
+              JSON.stringify(rpcError(null, RPC.PARSE_ERROR, 'Parse error')),
+            );
+            return;
+          }
+
+          if (Array.isArray(parsed)) {
+            ws.send(
+              JSON.stringify({
+                error: 'Batch JSON-RPC not supported',
+              }),
+            );
+            return;
+          }
+
+          const inbound = parseInbound(parsed);
+          if (!inbound.ok) {
+            ws.send(JSON.stringify(inbound.error));
+            return;
+          }
+          const message = inbound.message;
+
+          if (!initialized) {
+            if (!isRequest(message) || message.method !== 'initialize') {
               ws.send(
                 JSON.stringify(
-                  rpcError(null, RPC.INTERNAL_ERROR, 'Connection lost'),
+                  rpcError(
+                    isRequest(message) ? message.id : null,
+                    RPC.INVALID_REQUEST,
+                    'First message must be initialize',
+                  ),
                 ),
               );
-              ws.close(1011, 'Connection lost');
+              ws.close(1002, 'Protocol error');
               return;
             }
 
-            // Lazy session stream attachment for WS
-            if (
-              isRequest(message) &&
-              message.params &&
-              typeof message.params === 'object'
-            ) {
-              const sid = (message.params as Record<string, unknown>)[
-                'sessionId'
-              ];
-              if (typeof sid === 'string' && conn.ownsSession(sid)) {
-                const binding = conn.sessions.get(sid);
-                if (binding && !binding.stream) {
-                  const ac = new AbortController();
-                  conn.attachSessionStream(sid, conn.connStream!, ac);
-                  const myAbort = ac;
-                  const cleanupSession = () => {
-                    const b = conn.sessions.get(sid);
-                    if (b?.stream === conn.connStream && b?.abort === myAbort) {
-                      conn.closeSessionStream(sid);
-                    }
-                  };
-                  void dispatcher
-                    .pumpSessionEvents(conn, sid, ac.signal)
-                    .then(cleanupSession, (err: unknown) => {
-                      writeStderrLine(
-                        `qwen serve: /acp WS pump error (${sid}): ${err instanceof Error ? err.message : String(err)}`,
-                      );
-                      cleanupSession();
-                    });
-                }
-              }
-            }
-
-            // Rate limit: classify by method name, matching REST tiers.
-            if (opts.checkRate && isRequest(message)) {
-              const m = message.method;
-              const tier: RateLimitTier =
-                m === 'session/prompt' || m === '_qwen/session/prompt'
-                  ? 'prompt'
-                  : m.startsWith('session/') || m.startsWith('_qwen/session/')
-                    ? 'read'
-                    : 'mutation';
-              if (!opts.checkRate(wsKey, tier)) {
-                ws.send(
-                  JSON.stringify(
-                    rpcError(
-                      message.id,
-                      RPC.INTERNAL_ERROR,
-                      'Rate limit exceeded',
-                    ),
+            const conn = registry.create(fromLoopback);
+            if (!conn) {
+              ws.send(
+                JSON.stringify(
+                  rpcError(
+                    message.id,
+                    RPC.INTERNAL_ERROR,
+                    'Too many connections',
                   ),
-                );
-                return;
-              }
+                ),
+              );
+              ws.close(1013, 'Connection cap');
+              return;
             }
 
-            await dispatcher
-              .handle(conn, message, undefined, fromLoopback)
-              .catch((err: unknown) => {
+            const requestedVersion =
+              message.params &&
+              typeof message.params === 'object' &&
+              !Array.isArray(message.params)
+                ? (message.params as Record<string, unknown>)['protocolVersion']
+                : undefined;
+
+            // WS: single socket serves as conn stream + all session streams.
+            const stream = new WsStream(
+              ws,
+              () => {
                 writeStderrLine(
-                  `qwen serve: /acp WS handle error: ${err instanceof Error ? err.message : String(err)}`,
+                  `qwen serve: /acp WS closed (${conn.connectionId.slice(0, 8)})`,
                 );
-              });
+                registry.delete(conn.connectionId);
+              },
+              () => conn.touch(),
+            );
+            conn.attachConnStream(stream);
+
+            ws.send(
+              JSON.stringify({
+                jsonrpc: '2.0',
+                id: message.id,
+                result: dispatcher.buildInitializeResult(
+                  conn.connectionId,
+                  requestedVersion,
+                ),
+              }),
+            );
+
+            initialized = true;
+            clearTimeout(initTimer);
+            connRef = conn;
+            writeStderrLine(
+              `qwen serve: /acp WS established ${conn.connectionId.slice(0, 8)} (loopback=${fromLoopback}, active=${registry.size})`,
+            );
+            return;
           }
-        });
-      },
-    );
+
+          // Subsequent messages
+          const conn = connRef;
+          if (!conn || conn.destroyed) {
+            ws.send(
+              JSON.stringify(
+                rpcError(null, RPC.INTERNAL_ERROR, 'Connection lost'),
+              ),
+            );
+            ws.close(1011, 'Connection lost');
+            return;
+          }
+
+          // Lazy session stream attachment for WS
+          if (
+            isRequest(message) &&
+            message.params &&
+            typeof message.params === 'object'
+          ) {
+            const sid = (message.params as Record<string, unknown>)[
+              'sessionId'
+            ];
+            if (typeof sid === 'string' && conn.ownsSession(sid)) {
+              const binding = conn.sessions.get(sid);
+              if (binding && !binding.stream) {
+                const ac = new AbortController();
+                conn.attachSessionStream(sid, conn.connStream!, ac);
+                const myAbort = ac;
+                const cleanupSession = () => {
+                  const b = conn.sessions.get(sid);
+                  if (b?.stream === conn.connStream && b?.abort === myAbort) {
+                    conn.closeSessionStream(sid);
+                  }
+                };
+                void dispatcher
+                  .pumpSessionEvents(conn, sid, ac.signal)
+                  .then(cleanupSession, (err: unknown) => {
+                    writeStderrLine(
+                      `qwen serve: /acp WS pump error (${sid}): ${err instanceof Error ? err.message : String(err)}`,
+                    );
+                    cleanupSession();
+                  });
+              }
+            }
+          }
+
+          // Rate limit: classify by method name, matching REST tiers.
+          if (opts.checkRate && isRequest(message)) {
+            const m = message.method;
+            const tier: RateLimitTier =
+              m === 'session/prompt' || m === '_qwen/session/prompt'
+                ? 'prompt'
+                : m.startsWith('session/') || m.startsWith('_qwen/session/')
+                  ? 'read'
+                  : 'mutation';
+            if (!opts.checkRate(wsKey, tier)) {
+              ws.send(
+                JSON.stringify(
+                  rpcError(
+                    message.id,
+                    RPC.INTERNAL_ERROR,
+                    'Rate limit exceeded',
+                  ),
+                ),
+              );
+              return;
+            }
+          }
+
+          await dispatcher
+            .handle(conn, message, undefined, fromLoopback)
+            .catch((err: unknown) => {
+              writeStderrLine(
+                `qwen serve: /acp WS handle error: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            });
+        }
+      });
+    };
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    httpServer.on('upgrade', upgradeListener as any);
 
     writeStderrLine(`qwen serve: /acp WebSocket transport enabled on ${path}`);
   }
 
   return {
     dispose: () => {
+      if (upgradeServer && upgradeListener) {
+        upgradeServer.removeListener('upgrade', upgradeListener);
+        upgradeListener = undefined;
+        upgradeServer = undefined;
+      }
       registry.dispose();
       if (wss) {
         wss.close();

--- a/packages/cli/src/serve/acpHttp/index.ts
+++ b/packages/cli/src/serve/acpHttp/index.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { timingSafeEqual } from 'node:crypto';
+import { createHash, timingSafeEqual } from 'node:crypto';
 import type { IncomingMessage } from 'node:http';
 import type { Duplex } from 'node:stream';
 import type { Application, Request, Response } from 'express';
@@ -18,6 +18,7 @@ import { AcpDispatcher } from './dispatch.js';
 import { ConnectionRegistry } from './connectionRegistry.js';
 import { SseStream } from './sseStream.js';
 import { WsStream } from './wsStream.js';
+import type { RateLimitTier } from '../rateLimit.js';
 import { RPC, error as rpcError, isRequest, parseInbound } from './jsonRpc.js';
 
 export const ACP_CONNECTION_HEADER = 'acp-connection-id';
@@ -41,6 +42,8 @@ export interface MountAcpHttpOptions {
   maxConnections?: number;
   /** Bearer token for WS auth (WS bypasses Express middleware). */
   token?: string;
+  /** Rate limit checker for WS messages (WS bypasses Express middleware). */
+  checkRate?: (key: string, tier: RateLimitTier) => boolean;
 }
 
 export interface AcpHttpHandle {
@@ -439,13 +442,9 @@ export function mountAcpHttp(
           const credentials = authHeader
             .slice(authHeader.indexOf(' ') + 1)
             .trim();
-          const expected = Buffer.from(opts.token, 'utf8');
-          const actual = Buffer.from(credentials, 'utf8');
-          if (
-            scheme !== 'bearer' ||
-            expected.length !== actual.length ||
-            !timingSafeEqual(expected, actual)
-          ) {
+          const expected = createHash('sha256').update(opts.token).digest();
+          const actual = createHash('sha256').update(credentials).digest();
+          if (scheme !== 'bearer' || !timingSafeEqual(expected, actual)) {
             socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
             socket.destroy();
             return;
@@ -466,8 +465,18 @@ export function mountAcpHttp(
           initTimer.unref?.();
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           let connRef: any;
+          let messageQueue = Promise.resolve();
+          const wsKey = socket.remoteAddress ?? 'ws-unknown';
 
-          ws.on('message', async (rawData: Buffer | string) => {
+          ws.on('message', (rawData: Buffer | string) => {
+            messageQueue = messageQueue
+              .then(() => handleWsMessage(rawData))
+              .catch(() => {});
+          });
+
+          async function handleWsMessage(
+            rawData: Buffer | string,
+          ): Promise<void> {
             let text: string;
             try {
               text =
@@ -620,6 +629,29 @@ export function mountAcpHttp(
               }
             }
 
+            // Rate limit: classify by method name, matching REST tiers.
+            if (opts.checkRate && isRequest(message)) {
+              const m = message.method;
+              const tier: RateLimitTier =
+                m === 'session/prompt' || m === '_qwen/session/prompt'
+                  ? 'prompt'
+                  : m.startsWith('session/') || m.startsWith('_qwen/session/')
+                    ? 'read'
+                    : 'mutation';
+              if (!opts.checkRate(wsKey, tier)) {
+                ws.send(
+                  JSON.stringify(
+                    rpcError(
+                      message.id,
+                      RPC.INTERNAL_ERROR,
+                      'Rate limit exceeded',
+                    ),
+                  ),
+                );
+                return;
+              }
+            }
+
             await dispatcher
               .handle(conn, message, undefined, fromLoopback)
               .catch((err: unknown) => {
@@ -627,7 +659,7 @@ export function mountAcpHttp(
                   `qwen serve: /acp WS handle error: ${err instanceof Error ? err.message : String(err)}`,
                 );
               });
-          });
+          }
         });
       },
     );

--- a/packages/cli/src/serve/acpHttp/index.ts
+++ b/packages/cli/src/serve/acpHttp/index.ts
@@ -15,7 +15,10 @@ import type { DaemonWorkspaceService } from '../workspace-service/types.js';
 import type { WorkspaceFileSystemFactory } from '../fs/index.js';
 import type { DeviceFlowRegistry } from '../auth/deviceFlow.js';
 import { AcpDispatcher } from './dispatch.js';
-import { ConnectionRegistry } from './connectionRegistry.js';
+import {
+  ConnectionRegistry,
+  type AcpConnection,
+} from './connectionRegistry.js';
 import { SseStream } from './sseStream.js';
 import { WsStream } from './wsStream.js';
 import type { RateLimitTier } from '../rateLimit.js';
@@ -414,13 +417,18 @@ export function mountAcpHttp(
 
   // ── WebSocket upgrade (ACP RFD) ────────────────────────────────────
   let wss: WebSocketServer | undefined;
-  let upgradeListener: ((...args: unknown[]) => void) | undefined;
+  let upgradeListener:
+    | ((req: IncomingMessage, socket: Duplex, head: Buffer) => void)
+    | undefined;
   let upgradeServer: import('node:http').Server | undefined;
 
   function setupWebSocket(httpServer: import('node:http').Server): void {
     if (wss) return;
     wss = new WebSocketServer({ noServer: true, maxPayload: 10 * 1024 * 1024 });
     upgradeServer = httpServer;
+    const expectedTokenHash = opts.token
+      ? createHash('sha256').update(opts.token).digest()
+      : undefined;
 
     upgradeListener = (req: IncomingMessage, socket: Duplex, head: Buffer) => {
       let url: URL;
@@ -499,9 +507,12 @@ export function mountAcpHttp(
         const credentials = authHeader
           .slice(authHeader.indexOf(' ') + 1)
           .trim();
-        const expected = createHash('sha256').update(opts.token).digest();
         const actual = createHash('sha256').update(credentials).digest();
-        if (scheme !== 'bearer' || !timingSafeEqual(expected, actual)) {
+        if (
+          scheme !== 'bearer' ||
+          !expectedTokenHash ||
+          !timingSafeEqual(expectedTokenHash, actual)
+        ) {
           socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
           socket.destroy();
           return;
@@ -516,12 +527,14 @@ export function mountAcpHttp(
         let initialized = false;
         const initTimer = setTimeout(() => {
           if (!initialized) {
+            writeStderrLine(
+              `qwen serve: /acp WS initialize timeout (30s) from ${rawAddr}`,
+            );
             ws.close(1002, 'Initialize timeout');
           }
         }, 30_000);
         initTimer.unref?.();
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        let connRef: any;
+        let connRef: AcpConnection | undefined;
         let messageQueue = Promise.resolve();
         const rawAddr =
           (socket as unknown as { remoteAddress?: string }).remoteAddress ??
@@ -749,8 +762,7 @@ export function mountAcpHttp(
         }
       });
     };
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    httpServer.on('upgrade', upgradeListener as any);
+    httpServer.on('upgrade', upgradeListener!);
 
     writeStderrLine(`qwen serve: /acp WebSocket transport enabled on ${path}`);
   }

--- a/packages/cli/src/serve/acpHttp/index.ts
+++ b/packages/cli/src/serve/acpHttp/index.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import type { IncomingMessage } from 'node:http';
+import type { Duplex } from 'node:stream';
 import type { Application, Request, Response } from 'express';
+import { WebSocketServer, type WebSocket } from 'ws';
 import type { HttpAcpBridge } from '@qwen-code/acp-bridge/bridgeTypes';
 import { writeStderrLine } from '../../utils/stdioHelpers.js';
 import type { DaemonWorkspaceService } from '../workspace-service/types.js';
@@ -13,6 +16,7 @@ import type { DeviceFlowRegistry } from '../auth/deviceFlow.js';
 import { AcpDispatcher } from './dispatch.js';
 import { ConnectionRegistry } from './connectionRegistry.js';
 import { SseStream } from './sseStream.js';
+import { WsStream } from './wsStream.js';
 import { RPC, error as rpcError, isRequest, parseInbound } from './jsonRpc.js';
 
 export const ACP_CONNECTION_HEADER = 'acp-connection-id';
@@ -34,11 +38,15 @@ export interface MountAcpHttpOptions {
   enabled?: boolean;
   path?: string;
   maxConnections?: number;
+  /** Bearer token for WS auth (WS bypasses Express middleware). */
+  token?: string;
 }
 
 export interface AcpHttpHandle {
   dispose(): void;
   registry: ConnectionRegistry;
+  /** Attach HTTP server post-listen to enable WebSocket upgrade. */
+  attachServer(server: import('node:http').Server): void;
 }
 
 /**
@@ -344,7 +352,255 @@ export function mountAcpHttp(
     res.status(202).end();
   });
 
-  return { dispose: () => registry.dispose(), registry };
+  // ── WebSocket upgrade (ACP RFD) ────────────────────────────────────
+  let wss: WebSocketServer | undefined;
+
+  function setupWebSocket(httpServer: import('node:http').Server): void {
+    if (wss) return;
+    wss = new WebSocketServer({ noServer: true });
+
+    httpServer.on(
+      'upgrade',
+      (req: IncomingMessage, socket: Duplex, head: Buffer) => {
+        const url = new URL(
+          req.url ?? '/',
+          `http://${req.headers.host ?? 'localhost'}`,
+        );
+        if (url.pathname !== path) {
+          socket.destroy();
+          return;
+        }
+
+        // CSRF: reject non-loopback origins on WS upgrade.
+        const origin = req.headers['origin'];
+        const fromLoopback = isLoopbackSocket(socket);
+        if (origin && !fromLoopback) {
+          try {
+            const originHost = new URL(origin).hostname;
+            if (
+              originHost !== '127.0.0.1' &&
+              originHost !== 'localhost' &&
+              originHost !== '[::1]' &&
+              originHost !== '::1'
+            ) {
+              socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+              socket.destroy();
+              return;
+            }
+          } catch {
+            socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+            socket.destroy();
+            return;
+          }
+        }
+
+        // Auth: WS bypasses Express middleware. Same posture as REST:
+        // loopback without token = allow; non-loopback/token-mismatch = reject.
+        if (opts.token) {
+          const authHeader = req.headers['authorization'];
+          const scheme = authHeader
+            ?.slice(0, authHeader.indexOf(' '))
+            .toLowerCase();
+          const credentials = authHeader
+            ?.slice(authHeader.indexOf(' ') + 1)
+            .trim();
+          if (scheme !== 'bearer' || credentials !== opts.token) {
+            socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+            socket.destroy();
+            return;
+          }
+        } else if (!fromLoopback) {
+          socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
+          socket.destroy();
+          return;
+        }
+
+        wss!.handleUpgrade(req, socket, head, (ws: WebSocket) => {
+          let initialized = false;
+          const initTimer = setTimeout(() => {
+            if (!initialized) {
+              ws.close(1002, 'Initialize timeout');
+            }
+          }, 30_000);
+          initTimer.unref?.();
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          let connRef: any;
+
+          ws.on('message', async (rawData: Buffer | string) => {
+            let text: string;
+            try {
+              text =
+                typeof rawData === 'string'
+                  ? rawData
+                  : rawData.toString('utf8');
+            } catch {
+              ws.close(1003, 'Only text frames supported');
+              return;
+            }
+
+            let parsed: unknown;
+            try {
+              parsed = JSON.parse(text);
+            } catch {
+              ws.send(
+                JSON.stringify(rpcError(null, RPC.PARSE_ERROR, 'Parse error')),
+              );
+              return;
+            }
+
+            if (Array.isArray(parsed)) {
+              ws.send(
+                JSON.stringify({
+                  error: 'Batch JSON-RPC not supported',
+                }),
+              );
+              return;
+            }
+
+            const inbound = parseInbound(parsed);
+            if (!inbound.ok) {
+              ws.send(JSON.stringify(inbound.error));
+              return;
+            }
+            const message = inbound.message;
+
+            if (!initialized) {
+              if (!isRequest(message) || message.method !== 'initialize') {
+                ws.send(
+                  JSON.stringify(
+                    rpcError(
+                      isRequest(message) ? message.id : null,
+                      RPC.INVALID_REQUEST,
+                      'First message must be initialize',
+                    ),
+                  ),
+                );
+                ws.close(1002, 'Protocol error');
+                return;
+              }
+
+              const conn = registry.create(fromLoopback);
+              if (!conn) {
+                ws.send(
+                  JSON.stringify(
+                    rpcError(
+                      message.id,
+                      RPC.INTERNAL_ERROR,
+                      'Too many connections',
+                    ),
+                  ),
+                );
+                ws.close(1013, 'Connection cap');
+                return;
+              }
+
+              const requestedVersion =
+                message.params &&
+                typeof message.params === 'object' &&
+                !Array.isArray(message.params)
+                  ? (message.params as Record<string, unknown>)[
+                      'protocolVersion'
+                    ]
+                  : undefined;
+
+              // WS: single socket serves as conn stream + all session streams.
+              const stream = new WsStream(
+                ws,
+                () => {
+                  writeStderrLine(
+                    `qwen serve: /acp WS closed (${conn.connectionId.slice(0, 8)})`,
+                  );
+                  registry.delete(conn.connectionId);
+                },
+                () => conn.touch(),
+              );
+              conn.attachConnStream(stream);
+
+              ws.send(
+                JSON.stringify({
+                  jsonrpc: '2.0',
+                  id: message.id,
+                  result: dispatcher.buildInitializeResult(
+                    conn.connectionId,
+                    requestedVersion,
+                  ),
+                }),
+              );
+
+              initialized = true;
+              clearTimeout(initTimer);
+              connRef = conn;
+              writeStderrLine(
+                `qwen serve: /acp WS established ${conn.connectionId.slice(0, 8)} (loopback=${fromLoopback}, active=${registry.size})`,
+              );
+              return;
+            }
+
+            // Subsequent messages
+            const conn = connRef;
+            if (!conn || conn.destroyed) {
+              ws.send(
+                JSON.stringify(
+                  rpcError(null, RPC.INTERNAL_ERROR, 'Connection lost'),
+                ),
+              );
+              ws.close(1011, 'Connection lost');
+              return;
+            }
+
+            // Lazy session stream attachment for WS
+            if (
+              isRequest(message) &&
+              message.params &&
+              typeof message.params === 'object'
+            ) {
+              const sid = (message.params as Record<string, unknown>)[
+                'sessionId'
+              ];
+              if (typeof sid === 'string' && conn.ownsSession(sid)) {
+                const binding = conn.sessions.get(sid);
+                if (binding && !binding.stream) {
+                  const ac = new AbortController();
+                  conn.attachSessionStream(sid, conn.connStream!, ac);
+                  void dispatcher
+                    .pumpSessionEvents(conn, sid, ac.signal)
+                    .catch((err: unknown) => {
+                      writeStderrLine(
+                        `qwen serve: /acp WS pump error (${sid}): ${err instanceof Error ? err.message : String(err)}`,
+                      );
+                    });
+                }
+              }
+            }
+
+            await dispatcher
+              .handle(conn, message, undefined, fromLoopback)
+              .catch((err: unknown) => {
+                writeStderrLine(
+                  `qwen serve: /acp WS handle error: ${err instanceof Error ? err.message : String(err)}`,
+                );
+              });
+          });
+        });
+      },
+    );
+
+    writeStderrLine(`qwen serve: /acp WebSocket transport enabled on ${path}`);
+  }
+
+  return {
+    dispose: () => {
+      registry.dispose();
+      if (wss) {
+        wss.close();
+        wss = undefined;
+      }
+    },
+    registry,
+    attachServer(server: import('node:http').Server) {
+      setupWebSocket(server);
+    },
+  };
 }
 
 function headerOf(req: Request, name: string): string | undefined {
@@ -358,6 +614,14 @@ function headerOf(req: Request, name: string): string | undefined {
  * headers like `X-Forwarded-For`). Replicated here rather than imported
  * from `server.ts` to avoid a server↔acpHttp import cycle.
  */
+function isLoopbackSocket(socket: Duplex): boolean {
+  const addr = (socket as unknown as { remoteAddress?: string }).remoteAddress;
+  if (typeof addr !== 'string') return false;
+  return (
+    addr === '::1' || addr.startsWith('127.') || addr.startsWith('::ffff:127.')
+  );
+}
+
 function isLoopbackReq(req: Request): boolean {
   const addr = req.socket?.remoteAddress;
   if (typeof addr !== 'string') return false;

--- a/packages/cli/src/serve/acpHttp/index.ts
+++ b/packages/cli/src/serve/acpHttp/index.ts
@@ -32,6 +32,36 @@ export const ACP_SESSION_HEADER = 'acp-session-id';
  */
 const CONN_GRACE_MS = 10_000;
 
+const WS_EXEMPT_METHODS = new Set([
+  '_qwen/session/heartbeat',
+  '_qwen/session/update_metadata',
+]);
+
+const WS_READ_METHODS = new Set([
+  'session/list',
+  '_qwen/session/context',
+  '_qwen/session/supported_commands',
+  '_qwen/session/context_usage',
+  '_qwen/session/tasks',
+  '_qwen/workspace/mcp',
+  '_qwen/workspace/skills',
+  '_qwen/workspace/providers',
+  '_qwen/workspace/env',
+  '_qwen/workspace/preflight',
+  '_qwen/workspace/tools',
+  '_qwen/workspace/mcp/tools',
+  '_qwen/workspace/agents/list',
+  '_qwen/workspace/agents/get',
+  '_qwen/workspace/memory',
+  '_qwen/workspace/auth/status',
+  '_qwen/workspace/auth/device_flow/get',
+  '_qwen/file/read',
+  '_qwen/file/read_bytes',
+  '_qwen/file/stat',
+  '_qwen/file/list',
+  '_qwen/file/glob',
+]);
+
 export interface MountAcpHttpOptions {
   boundWorkspace: string;
   workspace: DaemonWorkspaceService;
@@ -467,7 +497,12 @@ export function mountAcpHttp(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let connRef: any;
         let messageQueue = Promise.resolve();
-        const wsKey = socket.remoteAddress ?? 'ws-unknown';
+        const rawAddr =
+          (socket as unknown as { remoteAddress?: string }).remoteAddress ??
+          'ws-unknown';
+        const wsKey = rawAddr.startsWith('::ffff:')
+          ? rawAddr.slice(7)
+          : rawAddr;
 
         ws.on('error', (err) => {
           writeStderrLine(
@@ -616,9 +651,14 @@ export function mountAcpHttp(
             ];
             if (typeof sid === 'string' && conn.ownsSession(sid)) {
               const binding = conn.sessions.get(sid);
-              if (binding && !binding.stream) {
+              if (
+                binding &&
+                !binding.stream &&
+                conn.connStream &&
+                !conn.connStream.isClosed
+              ) {
                 const ac = new AbortController();
-                conn.attachSessionStream(sid, conn.connStream!, ac);
+                conn.attachSessionStream(sid, conn.connStream, ac);
                 const myAbort = ac;
                 const cleanupSession = () => {
                   const b = conn.sessions.get(sid);
@@ -638,36 +678,48 @@ export function mountAcpHttp(
             }
           }
 
-          // Rate limit: classify by method name, matching REST tiers.
           if (opts.checkRate && isRequest(message)) {
             const m = message.method;
-            const tier: RateLimitTier =
-              m === 'session/prompt' || m === '_qwen/session/prompt'
-                ? 'prompt'
-                : m.startsWith('session/') || m.startsWith('_qwen/session/')
-                  ? 'read'
-                  : 'mutation';
-            if (!opts.checkRate(wsKey, tier)) {
-              ws.send(
-                JSON.stringify(
-                  rpcError(
-                    message.id,
-                    RPC.INTERNAL_ERROR,
-                    'Rate limit exceeded',
+            if (WS_EXEMPT_METHODS.has(m)) {
+              // Heartbeat + metadata update: exempt from rate limiting
+              // (mirrors REST resolveTier returning null for heartbeat)
+            } else {
+              const tier: RateLimitTier =
+                m === 'session/prompt' || m === '_qwen/session/prompt'
+                  ? 'prompt'
+                  : WS_READ_METHODS.has(m)
+                    ? 'read'
+                    : 'mutation';
+              if (!opts.checkRate(wsKey, tier)) {
+                ws.send(
+                  JSON.stringify(
+                    rpcError(
+                      message.id,
+                      RPC.INTERNAL_ERROR,
+                      'Rate limit exceeded',
+                    ),
                   ),
-                ),
-              );
-              return;
+                );
+                return;
+              }
             }
           }
 
-          await dispatcher
+          // Prompt is long-running (minutes); awaiting it would block
+          // permission votes and cancel requests queued behind it → deadlock.
+          // Fire-and-forget so the message queue stays unblocked.
+          const isPrompt =
+            isRequest(message) &&
+            (message.method === 'session/prompt' ||
+              message.method === '_qwen/session/prompt');
+          const dispatchP = dispatcher
             .handle(conn, message, undefined, fromLoopback)
             .catch((err: unknown) => {
               writeStderrLine(
                 `qwen serve: /acp WS handle error: ${err instanceof Error ? err.message : String(err)}`,
               );
             });
+          if (!isPrompt) await dispatchP;
         }
       });
     };

--- a/packages/cli/src/serve/acpHttp/index.ts
+++ b/packages/cli/src/serve/acpHttp/index.ts
@@ -99,7 +99,7 @@ export function mountAcpHttp(
   app.post(path, async (req: Request, res: Response) => {
     // RFD: Content-Type MUST be application/json; otherwise 415.
     const ct = req.headers['content-type'];
-    if (!ct || !ct.includes('application/json')) {
+    if (!ct || !ct.startsWith('application/json')) {
       res.status(415).json({ error: 'Content-Type must be application/json' });
       return;
     }
@@ -362,10 +362,16 @@ export function mountAcpHttp(
     httpServer.on(
       'upgrade',
       (req: IncomingMessage, socket: Duplex, head: Buffer) => {
-        const url = new URL(
-          req.url ?? '/',
-          `http://${req.headers.host ?? 'localhost'}`,
-        );
+        let url: URL;
+        try {
+          url = new URL(
+            req.url ?? '/',
+            `http://${req.headers.host ?? 'localhost'}`,
+          );
+        } catch {
+          socket.destroy();
+          return;
+        }
         if (url.pathname !== path) {
           socket.destroy();
           return;
@@ -380,7 +386,6 @@ export function mountAcpHttp(
             if (
               originHost !== '127.0.0.1' &&
               originHost !== 'localhost' &&
-              originHost !== '[::1]' &&
               originHost !== '::1'
             ) {
               socket.write('HTTP/1.1 403 Forbidden\r\n\r\n');
@@ -398,11 +403,16 @@ export function mountAcpHttp(
         // loopback without token = allow; non-loopback/token-mismatch = reject.
         if (opts.token) {
           const authHeader = req.headers['authorization'];
+          if (!authHeader || !authHeader.includes(' ')) {
+            socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
+            socket.destroy();
+            return;
+          }
           const scheme = authHeader
-            ?.slice(0, authHeader.indexOf(' '))
+            .slice(0, authHeader.indexOf(' '))
             .toLowerCase();
           const credentials = authHeader
-            ?.slice(authHeader.indexOf(' ') + 1)
+            .slice(authHeader.indexOf(' ') + 1)
             .trim();
           if (scheme !== 'bearer' || credentials !== opts.token) {
             socket.write('HTTP/1.1 401 Unauthorized\r\n\r\n');
@@ -562,12 +572,18 @@ export function mountAcpHttp(
                 if (binding && !binding.stream) {
                   const ac = new AbortController();
                   conn.attachSessionStream(sid, conn.connStream!, ac);
+                  const cleanupSession = () => {
+                    if (conn.sessions.get(sid)?.stream === conn.connStream) {
+                      conn.closeSessionStream(sid);
+                    }
+                  };
                   void dispatcher
                     .pumpSessionEvents(conn, sid, ac.signal)
-                    .catch((err: unknown) => {
+                    .then(cleanupSession, (err: unknown) => {
                       writeStderrLine(
                         `qwen serve: /acp WS pump error (${sid}): ${err instanceof Error ? err.message : String(err)}`,
                       );
+                      cleanupSession();
                     });
                 }
               }

--- a/packages/cli/src/serve/acpHttp/transport.test.ts
+++ b/packages/cli/src/serve/acpHttp/transport.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import express from 'express';
 import type { Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
+import WebSocket from 'ws';
 import type { HttpAcpBridge } from '@qwen-code/acp-bridge/bridgeTypes';
 import type { BridgeEvent } from '@qwen-code/acp-bridge/eventBus';
 import type { DaemonWorkspaceService } from '../workspace-service/types.js';
@@ -1989,5 +1990,255 @@ describe('ACP Streamable HTTP transport (over the wire)', () => {
       const frames = await takeFrames(await streamRes, 1);
       expect(frames[0]).toMatchObject({ error: { code: -32602 } });
     });
+  });
+});
+
+// ── WebSocket transport security tests ────────────────────────────────
+describe('ACP WebSocket transport security', () => {
+  let server: Server;
+  let port: number;
+  let bridge: FakeBridge;
+
+  function startServer(
+    opts: {
+      token?: string;
+      checkRate?: (key: string, tier: string) => boolean;
+    } = {},
+  ) {
+    return new Promise<void>((resolve) => {
+      bridge = new FakeBridge();
+      const app = express();
+      app.use(express.json());
+      const handle = mountAcpHttp(app, bridge as unknown as HttpAcpBridge, {
+        boundWorkspace: '/ws',
+        workspace: fakeWorkspace,
+        enabled: true,
+        token: opts.token,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        checkRate: opts.checkRate as any,
+      });
+      server = app.listen(0, '127.0.0.1', () => {
+        port = (server.address() as AddressInfo).port;
+        handle?.attachServer(server);
+        resolve();
+      });
+    });
+  }
+
+  afterEach(async () => {
+    server?.closeAllConnections?.();
+    await new Promise<void>((r) => server?.close(() => r()) ?? r());
+  });
+
+  function wsConnect(
+    opts: { headers?: Record<string, string> } = {},
+  ): Promise<WebSocket> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/acp`, {
+        headers: opts.headers,
+      });
+      ws.once('open', () => resolve(ws));
+      ws.once('error', reject);
+    });
+  }
+
+  function wsConnectRaw(
+    host: string,
+    origin?: string,
+  ): Promise<{ code: number }> {
+    return new Promise((resolve) => {
+      const headers: Record<string, string> = {};
+      if (origin) headers['Origin'] = origin;
+      const ws = new WebSocket(`ws://${host}:${port}/acp`, {
+        headers,
+        handshakeTimeout: 2000,
+      });
+      ws.once('open', () => {
+        ws.close();
+        resolve({ code: 101 });
+      });
+      ws.once('unexpected-response', (_req, res) => {
+        resolve({ code: res.statusCode ?? 0 });
+      });
+      ws.once('error', () => resolve({ code: 0 }));
+    });
+  }
+
+  function sendRpc(ws: WebSocket, msg: unknown): Promise<unknown> {
+    return new Promise((resolve) => {
+      ws.once('message', (data) => resolve(JSON.parse(data.toString())));
+      ws.send(JSON.stringify(msg));
+    });
+  }
+
+  // ── Host allowlist ──────────────────────────────────────────────────
+  it('rejects WS upgrade with non-loopback Host header', async () => {
+    await startServer();
+    const result = await wsConnectRaw('127.0.0.1', undefined);
+    // The Host header will be 127.0.0.1:PORT which is allowed
+    expect(result.code).toBe(101);
+  });
+
+  // ── CSWSH origin check ─────────────────────────────────────────────
+  it('rejects WS upgrade with cross-origin Origin header', async () => {
+    await startServer();
+    const result = await wsConnectRaw('127.0.0.1', 'https://evil.com');
+    expect(result.code).toBe(403);
+  });
+
+  it('allows WS upgrade with loopback Origin header', async () => {
+    await startServer();
+    const result = await wsConnectRaw('127.0.0.1', 'http://localhost:3000');
+    expect(result.code).toBe(101);
+  });
+
+  // ── Bearer token auth ──────────────────────────────────────────────
+  it('rejects WS upgrade without token when token is configured', async () => {
+    await startServer({ token: 'secret-token-123' });
+    const result = await wsConnectRaw('127.0.0.1');
+    expect(result.code).toBe(401);
+  });
+
+  it('rejects WS upgrade with wrong token', async () => {
+    await startServer({ token: 'secret-token-123' });
+    const result = await new Promise<{ code: number }>((resolve) => {
+      const ws = new WebSocket(`ws://127.0.0.1:${port}/acp`, {
+        headers: { Authorization: 'Bearer wrong-token' },
+        handshakeTimeout: 2000,
+      });
+      ws.once('open', () => {
+        ws.close();
+        resolve({ code: 101 });
+      });
+      ws.once('unexpected-response', (_req, res) =>
+        resolve({ code: res.statusCode ?? 0 }),
+      );
+      ws.once('error', () => resolve({ code: 0 }));
+    });
+    expect(result.code).toBe(401);
+  });
+
+  it('allows WS upgrade with correct token', async () => {
+    await startServer({ token: 'secret-token-123' });
+    const ws = await wsConnect({
+      headers: { Authorization: 'Bearer secret-token-123' },
+    });
+    expect(ws.readyState).toBe(WebSocket.OPEN);
+    ws.close();
+  });
+
+  // ── maxPayload ─────────────────────────────────────────────────────
+  it('closes WS on oversized frame (>10MB)', async () => {
+    await startServer();
+    const ws = await wsConnect();
+    const closed = new Promise<number>((resolve) => {
+      ws.once('close', (code) => resolve(code));
+      ws.once('error', () => {});
+    });
+    try {
+      ws.send('x'.repeat(10 * 1024 * 1024 + 1));
+    } catch {
+      // ws may throw synchronously for oversized payloads
+    }
+    const code = await closed;
+    expect(code).toBe(1009); // 1009 = message too big
+  });
+
+  // ── Initialize timeout ─────────────────────────────────────────────
+  it('requires initialize as first message', async () => {
+    await startServer();
+    const ws = await wsConnect();
+    const reply = await sendRpc(ws, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'session/new',
+      params: {},
+    });
+    expect(reply).toMatchObject({ error: { code: -32600 } });
+    ws.close();
+  });
+
+  // ── Message serialization ──────────────────────────────────────────
+  it('serializes concurrent WS messages (no race)', async () => {
+    await startServer();
+    const ws = await wsConnect();
+    // Initialize first
+    const initReply = await sendRpc(ws, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {},
+    });
+    expect(initReply).toMatchObject({ result: { protocolVersion: 1 } });
+    // Send two messages rapidly — both should succeed without race
+    const replies: unknown[] = [];
+    const done = new Promise<void>((resolve) => {
+      ws.on('message', (data) => {
+        replies.push(JSON.parse(data.toString()));
+        if (replies.length >= 2) resolve();
+      });
+    });
+    ws.send(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'session/new',
+        params: {},
+      }),
+    );
+    ws.send(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'session/list',
+        params: {},
+      }),
+    );
+    await done;
+    const ids = replies.map((r) => (r as { id: number }).id).sort();
+    expect(ids).toEqual([2, 3]);
+    ws.close();
+  });
+
+  // ── Rate limiter ───────────────────────────────────────────────────
+  it('enforces rate limits on WS messages', async () => {
+    let callCount = 0;
+    await startServer({
+      checkRate: () => {
+        callCount++;
+        return callCount <= 2;
+      },
+    });
+    const ws = await wsConnect();
+    await sendRpc(ws, {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {},
+    });
+    // First two post-init messages should pass
+    const r1 = await sendRpc(ws, {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'session/list',
+      params: {},
+    });
+    expect(r1).toMatchObject({ id: 2 });
+    const r2 = await sendRpc(ws, {
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'session/list',
+      params: {},
+    });
+    expect(r2).toMatchObject({ id: 3 });
+    // Third should be rate-limited
+    const r3 = await sendRpc(ws, {
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'session/list',
+      params: {},
+    });
+    expect(r3).toMatchObject({ error: { message: 'Rate limit exceeded' } });
+    ws.close();
   });
 });

--- a/packages/cli/src/serve/acpHttp/transport.test.ts
+++ b/packages/cli/src/serve/acpHttp/transport.test.ts
@@ -2072,10 +2072,10 @@ describe('ACP WebSocket transport security', () => {
   }
 
   // ── Host allowlist ──────────────────────────────────────────────────
-  it('rejects WS upgrade with non-loopback Host header', async () => {
+  it('accepts WS upgrade with loopback Host header', async () => {
     await startServer();
     const result = await wsConnectRaw('127.0.0.1', undefined);
-    // The Host header will be 127.0.0.1:PORT which is allowed
+    // The Host header will be 127.0.0.1:PORT which is in the allowlist
     expect(result.code).toBe(101);
   });
 

--- a/packages/cli/src/serve/acpHttp/transportStream.ts
+++ b/packages/cli/src/serve/acpHttp/transportStream.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Transport-agnostic stream interface consumed by `AcpConnection`.
+ * Both `SseStream` (HTTP SSE) and `WsStream` (WebSocket) implement this.
+ */
+export interface TransportStream {
+  send(message: unknown): Promise<void>;
+  close(): void;
+  readonly isClosed: boolean;
+}

--- a/packages/cli/src/serve/acpHttp/wsStream.test.ts
+++ b/packages/cli/src/serve/acpHttp/wsStream.test.ts
@@ -102,14 +102,14 @@ describe('WsStream', () => {
 
   it('ws "close" event triggers stream close', () => {
     const onClose = vi.fn();
-    const _stream = new WsStream(ws as never, onClose);
+    void new WsStream(ws as never, onClose);
     ws.emit('close');
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('ws "error" event triggers stream close', () => {
     const onClose = vi.fn();
-    const _stream = new WsStream(ws as never, onClose);
+    void new WsStream(ws as never, onClose);
     ws.emit('error', new Error('test error'));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -121,6 +121,8 @@ describe('WsStream', () => {
     vi.advanceTimersByTime(15_000);
     expect(ws.pinged).toBe(1);
     expect(onHeartbeat).toHaveBeenCalledTimes(1);
+    // Simulate pong to keep alive for next tick
+    ws.emit('pong');
     vi.advanceTimersByTime(15_000);
     expect(ws.pinged).toBe(2);
     _stream.close();
@@ -135,7 +137,7 @@ describe('WsStream', () => {
 
   it('dead connection detected via ping/pong (no pong → close)', () => {
     const onClose = vi.fn();
-    const _stream = new WsStream(ws as never, onClose);
+    void new WsStream(ws as never, onClose);
 
     // First tick: ping sent, alive flag set to false
     vi.advanceTimersByTime(15_000);

--- a/packages/cli/src/serve/acpHttp/wsStream.test.ts
+++ b/packages/cli/src/serve/acpHttp/wsStream.test.ts
@@ -1,0 +1,177 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { WsStream } from './wsStream.js';
+
+// Minimal WebSocket mock that implements the surface WsStream uses.
+class MockWebSocket extends EventEmitter {
+  readonly OPEN = 1;
+  readyState = 1; // OPEN
+  sent: string[] = [];
+  pinged = 0;
+  closed = false;
+  closeCode?: number;
+
+  send(data: string, cb?: (err?: Error) => void) {
+    this.sent.push(data);
+    cb?.();
+  }
+
+  ping() {
+    this.pinged++;
+  }
+
+  close(code?: number) {
+    this.closed = true;
+    this.closeCode = code;
+  }
+}
+
+describe('WsStream', () => {
+  let ws: MockWebSocket;
+
+  beforeEach(() => {
+    ws = new MockWebSocket();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('send() serializes message as JSON and delivers via ws.send', async () => {
+    const stream = new WsStream(ws as never);
+    await stream.send({ hello: 'world' });
+    expect(ws.sent).toEqual(['{"hello":"world"}']);
+    stream.close();
+  });
+
+  it('send() serializes writes sequentially (no interleaving)', async () => {
+    const stream = new WsStream(ws as never);
+    const p1 = stream.send({ seq: 1 });
+    const p2 = stream.send({ seq: 2 });
+    await Promise.all([p1, p2]);
+    expect(ws.sent).toEqual(['{"seq":1}', '{"seq":2}']);
+    stream.close();
+  });
+
+  it('send() resolves even after close (no hang)', async () => {
+    const stream = new WsStream(ws as never);
+    stream.close();
+    // Should not hang or throw
+    await stream.send({ after: 'close' });
+    // Message not delivered (closed)
+    expect(ws.sent).toEqual([]);
+  });
+
+  it('isClosed starts false, becomes true after close()', () => {
+    const stream = new WsStream(ws as never);
+    expect(stream.isClosed).toBe(false);
+    stream.close();
+    expect(stream.isClosed).toBe(true);
+  });
+
+  it('close() is idempotent', () => {
+    const onClose = vi.fn();
+    const stream = new WsStream(ws as never, onClose);
+    stream.close();
+    stream.close();
+    stream.close();
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(ws.closeCode).toBe(1000);
+  });
+
+  it('close() calls onClose callback', () => {
+    const onClose = vi.fn();
+    const stream = new WsStream(ws as never, onClose);
+    stream.close();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('close() does not call ws.close if not OPEN', () => {
+    ws.readyState = 3; // CLOSED
+    const stream = new WsStream(ws as never);
+    stream.close();
+    expect(ws.closed).toBe(false);
+  });
+
+  it('ws "close" event triggers stream close', () => {
+    const onClose = vi.fn();
+    const _stream = new WsStream(ws as never, onClose);
+    ws.emit('close');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('ws "error" event triggers stream close', () => {
+    const onClose = vi.fn();
+    const _stream = new WsStream(ws as never, onClose);
+    ws.emit('error', new Error('test error'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('heartbeat sends ping every 15s and calls onHeartbeat', () => {
+    const onHeartbeat = vi.fn();
+    const _stream = new WsStream(ws as never, undefined, onHeartbeat);
+    expect(ws.pinged).toBe(0);
+    vi.advanceTimersByTime(15_000);
+    expect(ws.pinged).toBe(1);
+    expect(onHeartbeat).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(15_000);
+    expect(ws.pinged).toBe(2);
+    _stream.close();
+  });
+
+  it('heartbeat stops after close', () => {
+    const stream = new WsStream(ws as never);
+    stream.close();
+    vi.advanceTimersByTime(30_000);
+    expect(ws.pinged).toBe(0);
+  });
+
+  it('dead connection detected via ping/pong (no pong → close)', () => {
+    const onClose = vi.fn();
+    const _stream = new WsStream(ws as never, onClose);
+
+    // First tick: ping sent, alive flag set to false
+    vi.advanceTimersByTime(15_000);
+    expect(ws.pinged).toBe(1);
+
+    // No pong received → second tick closes
+    vi.advanceTimersByTime(15_000);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('pong keeps connection alive', () => {
+    const onClose = vi.fn();
+    const _stream = new WsStream(ws as never, onClose);
+
+    vi.advanceTimersByTime(15_000);
+    expect(ws.pinged).toBe(1);
+
+    // Simulate pong
+    ws.emit('pong');
+
+    vi.advanceTimersByTime(15_000);
+    // Should NOT close — pong was received
+    expect(onClose).not.toHaveBeenCalled();
+    expect(ws.pinged).toBe(2);
+
+    _stream.close();
+  });
+
+  it('send() failure closes stream', async () => {
+    const onClose = vi.fn();
+    ws.send = (_data: string, cb?: (err?: Error) => void) => {
+      cb?.(new Error('write failed'));
+    };
+    const stream = new WsStream(ws as never, onClose);
+    await stream.send({ fail: true });
+    expect(onClose).toHaveBeenCalled();
+    expect(stream.isClosed).toBe(true);
+  });
+});

--- a/packages/cli/src/serve/acpHttp/wsStream.ts
+++ b/packages/cli/src/serve/acpHttp/wsStream.ts
@@ -36,8 +36,16 @@ export class WsStream implements TransportStream {
         return;
       }
       alive = false;
-      this.onHeartbeat?.();
-      this.ws.ping();
+      try {
+        this.onHeartbeat?.();
+      } catch {
+        /* swallow — heartbeat callback must not crash the interval */
+      }
+      try {
+        this.ws.ping();
+      } catch {
+        /* socket may be gone */
+      }
     }, 15_000);
     this.heartbeat.unref();
   }

--- a/packages/cli/src/serve/acpHttp/wsStream.ts
+++ b/packages/cli/src/serve/acpHttp/wsStream.ts
@@ -25,8 +25,17 @@ export class WsStream implements TransportStream {
       );
       this.close();
     });
+    let alive = true;
+    ws.on('pong', () => {
+      alive = true;
+    });
     this.heartbeat = setInterval(() => {
       if (this._closed) return;
+      if (!alive) {
+        this.close();
+        return;
+      }
+      alive = false;
       this.onHeartbeat?.();
       this.ws.ping();
     }, 15_000);
@@ -56,7 +65,7 @@ export class WsStream implements TransportStream {
         this.close();
       }
     });
-    return next;
+    return this.writeChain;
   }
 
   get isClosed(): boolean {

--- a/packages/cli/src/serve/acpHttp/wsStream.ts
+++ b/packages/cli/src/serve/acpHttp/wsStream.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { WebSocket } from 'ws';
+import { writeStderrLine } from '../../utils/stdioHelpers.js';
+import type { TransportStream } from './transportStream.js';
+
+export class WsStream implements TransportStream {
+  private writeChain: Promise<void> = Promise.resolve();
+  private _closed = false;
+  private heartbeat: ReturnType<typeof setInterval> | undefined;
+
+  constructor(
+    private readonly ws: WebSocket,
+    private readonly onClose?: () => void,
+    private readonly onHeartbeat?: () => void,
+  ) {
+    ws.on('close', () => this.close());
+    ws.on('error', (err) => {
+      writeStderrLine(
+        `qwen serve: /acp WS error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      this.close();
+    });
+    this.heartbeat = setInterval(() => {
+      if (this._closed) return;
+      this.onHeartbeat?.();
+      this.ws.ping();
+    }, 15_000);
+    this.heartbeat.unref();
+  }
+
+  send(message: unknown): Promise<void> {
+    const data = JSON.stringify(message);
+    const next = this.writeChain.then(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          if (this._closed) {
+            resolve();
+            return;
+          }
+          this.ws.send(data, (err) => {
+            if (err) reject(err);
+            else resolve();
+          });
+        }),
+    );
+    this.writeChain = next.catch((err: unknown) => {
+      if (!this._closed) {
+        writeStderrLine(
+          `qwen serve: /acp WS write failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        this.close();
+      }
+    });
+    return next;
+  }
+
+  get isClosed(): boolean {
+    return this._closed;
+  }
+
+  close(): void {
+    if (this._closed) return;
+    this._closed = true;
+    if (this.heartbeat) clearInterval(this.heartbeat);
+    try {
+      if (this.ws.readyState === this.ws.OPEN) this.ws.close(1000);
+    } catch {
+      /* socket gone */
+    }
+    try {
+      this.onClose?.();
+    } catch (err) {
+      writeStderrLine(
+        `qwen serve: /acp WS onClose threw: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}

--- a/packages/cli/src/serve/rateLimit.ts
+++ b/packages/cli/src/serve/rateLimit.ts
@@ -290,7 +290,13 @@ export function createRateLimiter(
     const now = Date.now();
     let tierMap = buckets.get(key);
     if (!tierMap) {
-      if (buckets.size >= MAX_BUCKETS) return true;
+      if (buckets.size >= MAX_BUCKETS) {
+        config.onError?.(
+          new Error(`rate limit bucket overflow: ${buckets.size} keys`),
+          `tryConsume:${tier}`,
+        );
+        return true;
+      }
       tierMap = new Map();
       buckets.set(key, tierMap);
     }

--- a/packages/cli/src/serve/rateLimit.ts
+++ b/packages/cli/src/serve/rateLimit.ts
@@ -31,6 +31,8 @@ export interface RateLimitConfig {
 
 export interface RateLimiterInstance {
   middleware: RequestHandler;
+  /** Check rate limit without Express req/res. Returns true if allowed. */
+  checkRate(key: string, tier: RateLimitTier): boolean;
   reset(): void;
   setDraining(v: boolean): void;
   dispose(): void;
@@ -315,8 +317,37 @@ export function createRateLimiter(
     }
   };
 
+  function tryConsume(key: string, tier: RateLimitTier): boolean {
+    if (draining) return true;
+    const tierConfig = config.tiers[tier];
+    const rate = rates[tier];
+    const now = Date.now();
+    let tierMap = buckets.get(key);
+    if (!tierMap) {
+      if (buckets.size >= MAX_BUCKETS) return true;
+      tierMap = new Map();
+      buckets.set(key, tierMap);
+    }
+    let bucket = tierMap.get(tier);
+    if (!bucket) {
+      bucket = { tokens: tierConfig.max, lastRefill: now };
+      tierMap.set(tier, bucket);
+    }
+    const elapsed = Math.max(0, now - bucket.lastRefill);
+    bucket.tokens = Math.min(tierConfig.max, bucket.tokens + elapsed * rate);
+    bucket.lastRefill = now;
+    if (bucket.tokens >= 1) {
+      bucket.tokens -= 1;
+      return true;
+    }
+    hitCounts[tier]++;
+    if (sampledLog) sampledLog.log(tier, key);
+    return false;
+  }
+
   return {
     middleware,
+    checkRate: tryConsume,
     reset() {
       buckets.clear();
       hitCounts.prompt = 0;

--- a/packages/cli/src/serve/rateLimit.ts
+++ b/packages/cli/src/serve/rateLimit.ts
@@ -229,7 +229,7 @@ export function createRateLimiter(
   const gcTimer = setInterval(sweep, GC_TIMER_INTERVAL_MS);
   gcTimer.unref();
 
-  // Middleware
+  // Middleware — delegates to tryConsume for the shared bucket logic.
   const middleware: RequestHandler = (
     req: Request,
     res: Response,
@@ -254,55 +254,21 @@ export function createRateLimiter(
       }
 
       const key = keyExtractor(req);
-      const tierConfig = config.tiers[tier];
-      const rate = rates[tier];
-      const now = Date.now();
-
-      // Fail-open if bucket map is at capacity
-      let tierMap = buckets.get(key);
-      if (!tierMap) {
-        if (buckets.size >= MAX_BUCKETS) {
-          config.onError?.(
-            new Error(`rate limit bucket overflow: ${buckets.size} keys`),
-            req.path,
-          );
-          next();
-          return;
-        }
-        tierMap = new Map();
-        buckets.set(key, tierMap);
-      }
-
-      let bucket = tierMap.get(tier);
-      if (!bucket) {
-        bucket = { tokens: tierConfig.max, lastRefill: now };
-        tierMap.set(tier, bucket);
-      }
-
-      // Continuous drip refill
-      const elapsed = Math.max(0, now - bucket.lastRefill);
-      bucket.tokens = Math.min(tierConfig.max, bucket.tokens + elapsed * rate);
-      bucket.lastRefill = now;
-
-      if (bucket.tokens >= 1) {
-        bucket.tokens -= 1;
+      if (tryConsume(key, tier)) {
         next();
       } else {
-        // Rate limited
-        hitCounts[tier]++;
-        const retryAfterMs = Math.ceil((1 - bucket.tokens) / rate);
+        const tierConfig = config.tiers[tier];
+        const rate = rates[tier];
+        const bucket = buckets.get(key)?.get(tier);
+        const retryAfterMs = Math.ceil((1 - (bucket?.tokens ?? 0)) / rate);
         const retryAfterSec = Math.ceil(retryAfterMs / 1000);
-
-        if (sampledLog) {
-          sampledLog.log(tier, key);
-        }
 
         res.setHeader('Retry-After', String(retryAfterSec));
         res.setHeader('X-RateLimit-Limit', String(tierConfig.max));
         res.setHeader('X-RateLimit-Remaining', '0');
         res.setHeader(
           'X-RateLimit-Reset',
-          String(Math.ceil((now + retryAfterMs) / 1000)),
+          String(Math.ceil((Date.now() + retryAfterMs) / 1000)),
         );
         res.status(429).json({
           error: 'Rate limit exceeded',

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -1248,6 +1248,12 @@ export async function runQwenServe(
         });
       }
 
+      // Enable WebSocket transport now that http.Server is available.
+      const acpHandle = app.locals?.['acpHandle'] as
+        | { attachServer?: (s: typeof server) => void }
+        | undefined;
+      acpHandle?.attachServer?.(server);
+
       resolve(handle);
     });
     server.once('error', reject);

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -62,6 +62,7 @@ import type { WorkspaceFileSystemFactory } from './fs/index.js';
 import type { PermissionPolicy } from '@qwen-code/acp-bridge';
 import { getCliVersion } from '../utils/version.js';
 import { getRateLimiter } from './rateLimit.js';
+import type { AcpHttpHandle } from './acpHttp/index.js';
 
 const QWEN_SERVER_TOKEN_ENV = 'QWEN_SERVER_TOKEN';
 const QWEN_SERVE_PROMPT_DEADLINE_MS_ENV = 'QWEN_SERVE_PROMPT_DEADLINE_MS';
@@ -1150,7 +1151,7 @@ export async function runQwenServe(
             }
             // Dispose ACP handle (close WebSocketServer + send close frames).
             const acpHandle = app.locals?.['acpHandle'] as
-              | { dispose?: () => void }
+              | AcpHttpHandle
               | undefined;
             if (acpHandle?.dispose) {
               try {
@@ -1264,9 +1265,7 @@ export async function runQwenServe(
       }
 
       // Enable WebSocket transport now that http.Server is available.
-      const acpHandle = app.locals?.['acpHandle'] as
-        | { attachServer?: (s: typeof server) => void }
-        | undefined;
+      const acpHandle = app.locals?.['acpHandle'] as AcpHttpHandle | undefined;
       acpHandle?.attachServer?.(server);
 
       resolve(handle);

--- a/packages/cli/src/serve/runQwenServe.ts
+++ b/packages/cli/src/serve/runQwenServe.ts
@@ -1148,6 +1148,21 @@ export async function runQwenServe(
                 );
               }
             }
+            // Dispose ACP handle (close WebSocketServer + send close frames).
+            const acpHandle = app.locals?.['acpHandle'] as
+              | { dispose?: () => void }
+              | undefined;
+            if (acpHandle?.dispose) {
+              try {
+                acpHandle.dispose();
+              } catch (err) {
+                daemonLog.warn(
+                  `ACP handle dispose error: ${
+                    err instanceof Error ? err.message : String(err)
+                  }`,
+                );
+              }
+            }
             // Dispose rate limiter (clear GC timer + buckets).
             const rl = getRateLimiter(app);
             if (rl) {

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -3080,12 +3080,16 @@ export function createServeApp(
   // decision. Mounted AFTER the REST routes (distinct path, no overlap)
   // and BEFORE the final error handler so malformed `/acp` bodies still
   // route through the JSON error contract below.
-  mountAcpHttp(app, bridge, {
+  const acpHandle = mountAcpHttp(app, bridge, {
     boundWorkspace,
     workspace,
     fsFactory,
     deviceFlowRegistry,
+    token: opts.token,
   });
+  if (acpHandle) {
+    app.locals.acpHandle = acpHandle;
+  }
 
   // Final error handler. `express.json()` throws `SyntaxError` (with
   // `status: 400`) on malformed body — without this 4-arg middleware

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -3088,7 +3088,7 @@ export function createServeApp(
     token: opts.token,
   });
   if (acpHandle) {
-    app.locals.acpHandle = acpHandle;
+    app.locals['acpHandle'] = acpHandle;
   }
 
   // Final error handler. `express.json()` throws `SyntaxError` (with

--- a/packages/cli/src/serve/server.ts
+++ b/packages/cli/src/serve/server.ts
@@ -3086,6 +3086,7 @@ export function createServeApp(
     fsFactory,
     deviceFlowRegistry,
     token: opts.token,
+    checkRate: rateLimiter?.checkRate,
   });
   if (acpHandle) {
     app.locals['acpHandle'] = acpHandle;


### PR DESCRIPTION
## Summary

Complete ACP WebSocket transport per RFD. Coexists with SSE.

**Depends on**: #4827

## Implementation

| File | Change | LOC |
|------|--------|-----|
| `transportStream.ts` | New: transport-agnostic interface | 15 |
| `wsStream.ts` | New: WebSocket adapter | ~95 |
| `connectionRegistry.ts` | SseStream → TransportStream widening | ~5 |
| `index.ts` | WS upgrade handler + bearer auth + attachServer | +200 |
| `server.ts` | Store acpHandle, pass token | +5 |
| `runQwenServe.ts` | attachServer post-listen | +5 |
| `dispatch.ts` | **Zero changes** | 0 |

## WS Lifecycle

1. Client: `GET /acp` with `Upgrade: websocket`
2. Server: Bearer token check (401/403 before upgrade)
3. Server: 101 → WebSocket established
4. Client: Send `initialize` as first text frame
5. Server: Reply with capabilities + connectionId
6. Client: All subsequent JSON-RPC as text frames on same socket
7. Server: Session events delivered on same socket (lazy stream attach)
8. Close/error → connection teardown + registry cleanup

## Security

- WS upgrade bypasses Express middleware
- Manual bearer token check before `handleUpgrade`
- Non-loopback without token → 403 Forbidden + socket destroy
- Token mismatch → 401 Unauthorized + socket destroy

See #4782 for tracking.