### PR TITLE
chore: remove redundant "what" comments across 6 files

### DIFF
--- a/packages/cli/src/ui/commands/arenaCommand.ts
+++ b/packages/cli/src/ui/commands/arenaCommand.ts
@@ -83,7 +83,6 @@ function parseArenaArgs(args: string): {
     task = task.replace(/--models\s+\S+/, '').trim();
   }
 
-  // Strip surrounding quotes from task
   task = task.replace(/^["']|["']$/g, '').trim();
 
   return { models, task };

--- a/packages/cli/src/ui/commands/languageCommand.ts
+++ b/packages/cli/src/ui/commands/languageCommand.ts
@@ -84,10 +84,8 @@ async function setUiLanguage(
     };
   }
 
-  // Update i18n system
   await setLanguageAsync(lang);
 
-  // Persist to settings
   if (services.settings?.setValue) {
     try {
       services.settings.setValue(SettingScope.User, 'general.language', lang);
@@ -127,10 +125,8 @@ async function setOutputLanguage(
     // Save 'auto' as-is to settings, or normalize other values
     const settingValue = isAuto ? OUTPUT_LANGUAGE_AUTO : resolved;
 
-    // Update the rule file with the resolved language
     updateOutputLanguageFile(settingValue);
 
-    // Save to settings
     if (context.services.settings?.setValue) {
       try {
         context.services.settings.setValue(
@@ -159,7 +155,6 @@ async function setOutputLanguage(
       }
     }
 
-    // Format display message
     const displayLang = isAuto
       ? `${t('Auto (detect from system)')} → ${resolved}`
       : resolved;

--- a/packages/core/src/extension/github.ts
+++ b/packages/core/src/extension/github.ts
@@ -111,8 +111,7 @@ export async function cloneFromGit(
 
     await git.fetch(remotes[0].name, refToFetch);
 
-    // After fetching, checkout FETCH_HEAD to get the content of the fetched ref.
-    // This results in a detached HEAD state, which is fine for this purpose.
+    // Detached HEAD is expected here — we only need the fetched content.
     await git.checkout('FETCH_HEAD');
   } catch (error) {
     const redactedErrorMessage = redactUrlCredentials(getErrorMessage(error));
@@ -216,7 +215,6 @@ export async function checkForExtensionUpdate(
         return ExtensionUpdateState.ERROR;
       }
 
-      // Determine the ref to check on the remote.
       const refToCheck = installMetadata.ref || 'HEAD';
 
       const lsRemoteOutput = await git.listRemote([remoteUrl, refToCheck]);

--- a/packages/core/src/extension/settings.ts
+++ b/packages/core/src/extension/settings.ts
@@ -87,7 +87,6 @@ export async function loadExtensionSettings(
     const content = await fs.promises.readFile(envPath, 'utf-8');
     return parseEnvFile(content);
   } catch (error) {
-    // If .env file doesn't exist, return empty object
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return {};
     }
@@ -123,8 +122,7 @@ export function validateSettings(
   for (const config of settingsConfig) {
     const value = settings[config.envVar];
 
-    // Basic validation - check if value exists and is not empty
-    // Note: All settings are optional in Gemini Extension format
+    // All settings are optional in Gemini Extension format
     if (value !== undefined && typeof value !== 'string') {
       errors.push(
         `Setting "${config.name}" (${config.envVar}) must be a string`,
@@ -141,7 +139,6 @@ export function validateSettings(
  */
 export function applySettingsToEnv(settings: Record<string, string>): void {
   for (const [key, value] of Object.entries(settings)) {
-    // Only set if not already defined in process.env
     if (process.env[key] === undefined) {
       process.env[key] = value;
     }

--- a/packages/core/src/subagents/validation.ts
+++ b/packages/core/src/subagents/validation.ts
@@ -24,13 +24,11 @@ export class SubagentValidator {
     const errors: string[] = [];
     const warnings: string[] = [];
 
-    // Validate name
     const nameValidation = this.validateName(config.name);
     if (!nameValidation.isValid) {
       errors.push(...nameValidation.errors);
     }
 
-    // Validate description
     if (!config.description || config.description.trim().length === 0) {
       errors.push('Description is required and cannot be empty');
     } else if (config.description.length > 1000) {
@@ -39,14 +37,12 @@ export class SubagentValidator {
       );
     }
 
-    // Validate system prompt
     const promptValidation = this.validateSystemPrompt(config.systemPrompt);
     if (!promptValidation.isValid) {
       errors.push(...promptValidation.errors);
     }
     warnings.push(...promptValidation.warnings);
 
-    // Validate tools if specified
     if (config.tools) {
       const toolsValidation = this.validateTools(config.tools);
       if (!toolsValidation.isValid) {
@@ -55,7 +51,6 @@ export class SubagentValidator {
       warnings.push(...toolsValidation.warnings);
     }
 
-    // Validate disallowedTools if specified
     if (config.disallowedTools && config.disallowedTools.length > 0) {
       const disallowedValidation = this.validateTools(config.disallowedTools);
       if (!disallowedValidation.isValid) {
@@ -64,7 +59,6 @@ export class SubagentValidator {
       warnings.push(...disallowedValidation.warnings);
     }
 
-    // Validate model selector if specified
     if (config.model) {
       const modelValidation = this.validateModel(config.model);
       if (!modelValidation.isValid) {
@@ -73,7 +67,6 @@ export class SubagentValidator {
       warnings.push(...modelValidation.warnings);
     }
 
-    // Validate run config if specified
     if (config.runConfig) {
       const runValidation = this.validateRunConfig(config.runConfig);
       if (!runValidation.isValid) {
@@ -107,7 +100,6 @@ export class SubagentValidator {
 
     const trimmedName = name.trim();
 
-    // Check length constraints
     if (trimmedName.length < 2) {
       errors.push('Name must be at least 2 characters long');
     }
@@ -116,7 +108,6 @@ export class SubagentValidator {
       errors.push('Name must be 50 characters or less');
     }
 
-    // Check valid characters (Unicode letters/numbers, hyphens, underscores)
     const validNameRegex = /^[\p{L}\p{N}_-]+$/u;
     if (!validNameRegex.test(trimmedName)) {
       errors.push(
@@ -124,7 +115,6 @@ export class SubagentValidator {
       );
     }
 
-    // Check that it doesn't start or end with special characters
     if (trimmedName.startsWith('-') || trimmedName.startsWith('_')) {
       errors.push('Name cannot start with a hyphen or underscore');
     }
@@ -151,7 +141,7 @@ export class SubagentValidator {
       errors.push(`"${trimmedName}" is a reserved name and cannot be used`);
     }
 
-    // Warnings for naming conventions (only for names that have case distinctions)
+    // Only warn about naming conventions for names that contain case distinctions
     if (
       trimmedName !== trimmedName.toLowerCase() &&
       /[a-zA-Z]/.test(trimmedName)
@@ -189,12 +179,10 @@ export class SubagentValidator {
 
     const trimmedPrompt = prompt.trim();
 
-    // Check minimum length for meaningful prompts
     if (trimmedPrompt.length < 10) {
       errors.push('System prompt must be at least 10 characters long');
     }
 
-    // Warn for very long prompts
     if (trimmedPrompt.length > 10000) {
       warnings.push(
         'System prompt is quite long (>10,000 characters), consider shortening',
@@ -230,13 +218,11 @@ export class SubagentValidator {
       return { isValid: true, errors, warnings };
     }
 
-    // Check for duplicates
     const uniqueTools = new Set(tools);
     if (uniqueTools.size !== tools.length) {
       warnings.push('Duplicate tool names found in tools array');
     }
 
-    // Validate each tool name
     for (const tool of tools) {
       if (typeof tool !== 'string') {
         errors.push(`Tool name must be a string, got: ${typeof tool}`);

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -154,7 +154,6 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
   override async getConfirmationDetails(
     _abortSignal: AbortSignal,
   ): Promise<ToolCallConfirmationDetails> {
-    // Construct the permission rule for this specific MCP tool.
     const permissionRule = `mcp__${this.serverName}__${this.serverToolName}`;
 
     const confirmationDetails: ToolMcpConfirmationDetails = {
@@ -174,8 +173,7 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
     return confirmationDetails;
   }
 
-  // Determine if the response contains tool errors
-  // This is needed because CallToolResults should return errors inside the response.
+  // MCP spec: errors are returned inside the CallToolResult, not as exceptions.
   // ref: https://modelcontextprotocol.io/specification/2025-06-18/schema#calltoolresult
   isMCPToolError(rawResponseParts: Part[]): boolean {
     const functionResponse = rawResponseParts?.[0]?.functionResponse;
@@ -318,7 +316,6 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
         callToolResult,
       );
 
-      // Ensure the response is not an error
       if (this.isMCPToolError(rawResponseParts)) {
         const errorMessage = `MCP tool '${
           this.serverToolName
@@ -394,7 +391,6 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
           });
       });
 
-      // Ensure the response is not an error
       if (this.isMCPToolError(rawResponseParts)) {
         const errorMessage = `MCP tool '${
           this.serverToolName


### PR DESCRIPTION
## Summary

Remove comments that restate the immediately following code without adding context. "Why" comments and business-rule explanations are retained.

## Changes (6 files, -33 lines)

| File | Deletions | Detail |
|------|-----------|--------|
| `packages/core/src/subagents/validation.ts` | 15 | Remove "Validate name/description/tools/model" step labels, "Check length/characters/duplicates" restatements. Retain "why" for reserved name `main`. |
| `packages/core/src/tools/mcp-tool.ts` | 5 | Remove "Construct the permission rule", 2× "Ensure the response is not an error". Condense isMCPToolError docstring (keep MCP spec ref). |
| `packages/core/src/extension/settings.ts` | 3 | Remove ENOENT catch restatement, validation restatement, env-override restatement. Keep "why" about optional Gemini Extension settings. |
| `packages/core/src/extension/github.ts` | 1+condense | Condense checkout comment to "detached HEAD is expected". Remove "Determine the ref" restatement. |
| `packages/cli/src/ui/commands/languageCommand.ts` | 5 | Remove "Update i18n system", "Persist to settings", "Update the rule file", "Save to settings", "Format display message". |
| `packages/cli/src/ui/commands/arenaCommand.ts` | 1 | Remove "Strip surrounding quotes from task" — regex is self-explanatory. |

## Verification

- TypeScript type-check passes (`tsc --noEmit`) for both `core` and `cli`
- Pre-commit lint/prettier pass on all commits
- No functional changes — comment-only deletions