### PR TITLE
chore: remove redundant and dead comments across codebase

### DIFF
--- a/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
+++ b/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
@@ -17,7 +17,6 @@
  * - SystemController: initialize, interrupt, set_model, supported_commands, get_context_usage
  * - PermissionController: can_use_tool, set_permission_mode
  * - SdkMcpController: mcp_server_status (mcp_message handled via callback)
- * - HookController: hook_callback
  *
  * Note: mcp_message requests are NOT routed through the dispatcher. CLI MCP
  * clients send messages via SdkMcpController.createSendSdkMcpMessage() callback.
@@ -270,7 +269,6 @@ export class ControlDispatcher implements IPendingRequestRegistry {
     this.systemController.cleanup();
     this.permissionController.cleanup();
     this.sdkMcpController.cleanup();
-    // this.hookController.cleanup();
   }
 
   /**
@@ -386,9 +384,6 @@ export class ControlDispatcher implements IPendingRequestRegistry {
 
       case 'mcp_server_status':
         return this.sdkMcpController;
-
-      // case 'hook_callback':
-      //   return this.hookController;
 
       default:
         throw new Error(`Unknown control request subtype: ${subtype}`);

--- a/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
+++ b/packages/cli/src/nonInteractive/control/ControlDispatcher.ts
@@ -31,7 +31,6 @@ import type { IPendingRequestRegistry } from './controllers/baseController.js';
 import { SystemController } from './controllers/systemController.js';
 import { PermissionController } from './controllers/permissionController.js';
 import { SdkMcpController } from './controllers/sdkMcpController.js';
-// import { HookController } from './controllers/hookController.js';
 import type {
   CLIControlRequest,
   CLIControlResponse,
@@ -72,7 +71,6 @@ export class ControlDispatcher implements IPendingRequestRegistry {
   readonly systemController: SystemController;
   readonly permissionController: PermissionController;
   readonly sdkMcpController: SdkMcpController;
-  // readonly hookController: HookController;
 
   // Central pending request registries
   private pendingIncomingRequests: Map<string, PendingIncomingRequest> =
@@ -101,7 +99,6 @@ export class ControlDispatcher implements IPendingRequestRegistry {
       this,
       'SdkMcpController',
     );
-    // this.hookController = new HookController(context, this, 'HookController');
 
     // Listen for main abort signal
     this.abortHandler = () => {

--- a/packages/cli/src/ui/commands/arenaCommand.ts
+++ b/packages/cli/src/ui/commands/arenaCommand.ts
@@ -83,7 +83,6 @@ function parseArenaArgs(args: string): {
     task = task.replace(/--models\s+\S+/, '').trim();
   }
 
-  // Strip surrounding quotes from task
   task = task.replace(/^["']|["']$/g, '').trim();
 
   return { models, task };

--- a/packages/cli/src/ui/commands/languageCommand.ts
+++ b/packages/cli/src/ui/commands/languageCommand.ts
@@ -84,10 +84,8 @@ async function setUiLanguage(
     };
   }
 
-  // Update i18n system
   await setLanguageAsync(lang);
 
-  // Persist to settings
   if (services.settings?.setValue) {
     try {
       services.settings.setValue(SettingScope.User, 'general.language', lang);
@@ -127,10 +125,8 @@ async function setOutputLanguage(
     // Save 'auto' as-is to settings, or normalize other values
     const settingValue = isAuto ? OUTPUT_LANGUAGE_AUTO : resolved;
 
-    // Update the rule file with the resolved language
     updateOutputLanguageFile(settingValue);
 
-    // Save to settings
     if (context.services.settings?.setValue) {
       try {
         context.services.settings.setValue(
@@ -159,7 +155,6 @@ async function setOutputLanguage(
       }
     }
 
-    // Format display message
     const displayLang = isAuto
       ? `${t('Auto (detect from system)')} → ${resolved}`
       : resolved;

--- a/packages/cli/src/utils/sandbox.ts
+++ b/packages/cli/src/utils/sandbox.ts
@@ -325,10 +325,7 @@ export async function start_sandbox(
       process.on('SIGINT', stopProxy);
       process.on('SIGTERM', stopProxy);
 
-      // commented out as it disrupts ink rendering
-      // proxyProcess.stdout?.on('data', (data) => {
-      //   console.info(data.toString());
-      // });
+      // Proxy stdout is intentionally not piped — it disrupts ink rendering.
       proxyProcess.stderr?.on('data', (data) => {
         writeStderrLine(data.toString());
       });
@@ -863,10 +860,7 @@ export async function start_sandbox(
     process.on('SIGINT', stopProxy);
     process.on('SIGTERM', stopProxy);
 
-    // commented out as it disrupts ink rendering
-    // proxyProcess.stdout?.on('data', (data) => {
-    //   console.info(data.toString());
-    // });
+    // Proxy stdout is intentionally not piped — it disrupts ink rendering.
     proxyProcess.stderr?.on('data', (data) => {
       writeStderrLine(data.toString().trim());
     });
@@ -933,12 +927,9 @@ async function imageExists(sandbox: string, image: string): Promise<boolean> {
       resolve(false);
     });
 
-    checkProcess.on('close', (code) => {
-      // Non-zero code might indicate docker daemon not running, etc.
+    checkProcess.on('close', () => {
+      // Non-zero exit code may indicate docker daemon not running, etc.
       // The primary success indicator is non-empty stdoutData.
-      if (code !== 0) {
-        // console.warn(`'${sandbox} images -q ${image}' exited with code ${code}.`);
-      }
       resolve(stdoutData.trim() !== '');
     });
   });

--- a/packages/core/src/extension/github.ts
+++ b/packages/core/src/extension/github.ts
@@ -111,8 +111,7 @@ export async function cloneFromGit(
 
     await git.fetch(remotes[0].name, refToFetch);
 
-    // After fetching, checkout FETCH_HEAD to get the content of the fetched ref.
-    // This results in a detached HEAD state, which is fine for this purpose.
+    // Detached HEAD is expected here — we only need the fetched content.
     await git.checkout('FETCH_HEAD');
   } catch (error) {
     const redactedErrorMessage = redactUrlCredentials(getErrorMessage(error));
@@ -216,7 +215,6 @@ export async function checkForExtensionUpdate(
         return ExtensionUpdateState.ERROR;
       }
 
-      // Determine the ref to check on the remote.
       const refToCheck = installMetadata.ref || 'HEAD';
 
       const lsRemoteOutput = await git.listRemote([remoteUrl, refToCheck]);

--- a/packages/core/src/extension/settings.ts
+++ b/packages/core/src/extension/settings.ts
@@ -87,7 +87,6 @@ export async function loadExtensionSettings(
     const content = await fs.promises.readFile(envPath, 'utf-8');
     return parseEnvFile(content);
   } catch (error) {
-    // If .env file doesn't exist, return empty object
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
       return {};
     }
@@ -123,8 +122,7 @@ export function validateSettings(
   for (const config of settingsConfig) {
     const value = settings[config.envVar];
 
-    // Basic validation - check if value exists and is not empty
-    // Note: All settings are optional in Gemini Extension format
+    // All settings are optional in Gemini Extension format
     if (value !== undefined && typeof value !== 'string') {
       errors.push(
         `Setting "${config.name}" (${config.envVar}) must be a string`,
@@ -141,7 +139,6 @@ export function validateSettings(
  */
 export function applySettingsToEnv(settings: Record<string, string>): void {
   for (const [key, value] of Object.entries(settings)) {
-    // Only set if not already defined in process.env
     if (process.env[key] === undefined) {
       process.env[key] = value;
     }

--- a/packages/core/src/ide/ide-client.ts
+++ b/packages/core/src/ide/ide-client.ts
@@ -79,8 +79,6 @@ function getRealPath(path: string): string {
   try {
     return fs.realpathSync(path);
   } catch (_e) {
-    // If realpathSync fails, it might be because the path doesn't exist.
-    // In that case, we can fall back to the original path.
     return path;
   }
 }
@@ -452,7 +450,6 @@ export class IdeClient {
         ListToolsResultSchema,
       );
 
-      // Map the array of tool objects to an array of tool names (strings)
       this.availableTools = response.tools.map((tool) => tool.name);
 
       if (this.availableTools.length > 0) {
@@ -465,8 +462,7 @@ export class IdeClient {
         );
       }
     } catch (error) {
-      // It's okay if this fails, the IDE might not support it.
-      // Don't log an error if the method is not found, which is a common case.
+      // "Method not found" is expected for IDEs that don't support tool discovery.
       if (
         error instanceof Error &&
         !error.message?.includes('Method not found')

--- a/packages/core/src/ide/ideContext.ts
+++ b/packages/core/src/ide/ideContext.ts
@@ -43,7 +43,6 @@ export class IdeContextStore {
       // Sort by timestamp descending (newest first)
       openFiles.sort((a, b) => b.timestamp - a.timestamp);
 
-      // The most recent file is now at index 0.
       const mostRecentFile = openFiles[0];
 
       // If the most recent file is not active, then no file is active.
@@ -63,7 +62,6 @@ export class IdeContextStore {
           }
         });
 
-        // Truncate selected text in the active file
         if (
           mostRecentFile.selectedText &&
           mostRecentFile.selectedText.length > IDE_MAX_SELECTED_TEXT_LENGTH
@@ -76,7 +74,6 @@ export class IdeContextStore {
         }
       }
 
-      // Truncate files list
       if (openFiles.length > IDE_MAX_OPEN_FILES) {
         workspaceState.openFiles = openFiles.slice(0, IDE_MAX_OPEN_FILES);
       }

--- a/packages/core/src/qwen/sharedTokenManager.ts
+++ b/packages/core/src/qwen/sharedTokenManager.ts
@@ -474,7 +474,6 @@ export class SharedTokenManager {
       // Check if we have a refresh token before attempting refresh
       const currentCredentials = qwenClient.getCredentials();
       if (!currentCredentials.refresh_token) {
-        // console.debug('create a NO_REFRESH_TOKEN error');
         throw new TokenManagerError(
           TokenError.NO_REFRESH_TOKEN,
           'No refresh token available for token refresh',

--- a/packages/core/src/subagents/validation.ts
+++ b/packages/core/src/subagents/validation.ts
@@ -24,13 +24,11 @@ export class SubagentValidator {
     const errors: string[] = [];
     const warnings: string[] = [];
 
-    // Validate name
     const nameValidation = this.validateName(config.name);
     if (!nameValidation.isValid) {
       errors.push(...nameValidation.errors);
     }
 
-    // Validate description
     if (!config.description || config.description.trim().length === 0) {
       errors.push('Description is required and cannot be empty');
     } else if (config.description.length > 1000) {
@@ -39,14 +37,12 @@ export class SubagentValidator {
       );
     }
 
-    // Validate system prompt
     const promptValidation = this.validateSystemPrompt(config.systemPrompt);
     if (!promptValidation.isValid) {
       errors.push(...promptValidation.errors);
     }
     warnings.push(...promptValidation.warnings);
 
-    // Validate tools if specified
     if (config.tools) {
       const toolsValidation = this.validateTools(config.tools);
       if (!toolsValidation.isValid) {
@@ -55,7 +51,6 @@ export class SubagentValidator {
       warnings.push(...toolsValidation.warnings);
     }
 
-    // Validate disallowedTools if specified
     if (config.disallowedTools && config.disallowedTools.length > 0) {
       const disallowedValidation = this.validateTools(config.disallowedTools);
       if (!disallowedValidation.isValid) {
@@ -64,7 +59,6 @@ export class SubagentValidator {
       warnings.push(...disallowedValidation.warnings);
     }
 
-    // Validate model selector if specified
     if (config.model) {
       const modelValidation = this.validateModel(config.model);
       if (!modelValidation.isValid) {
@@ -73,7 +67,6 @@ export class SubagentValidator {
       warnings.push(...modelValidation.warnings);
     }
 
-    // Validate run config if specified
     if (config.runConfig) {
       const runValidation = this.validateRunConfig(config.runConfig);
       if (!runValidation.isValid) {
@@ -107,7 +100,6 @@ export class SubagentValidator {
 
     const trimmedName = name.trim();
 
-    // Check length constraints
     if (trimmedName.length < 2) {
       errors.push('Name must be at least 2 characters long');
     }
@@ -116,7 +108,6 @@ export class SubagentValidator {
       errors.push('Name must be 50 characters or less');
     }
 
-    // Check valid characters (Unicode letters/numbers, hyphens, underscores)
     const validNameRegex = /^[\p{L}\p{N}_-]+$/u;
     if (!validNameRegex.test(trimmedName)) {
       errors.push(
@@ -124,7 +115,6 @@ export class SubagentValidator {
       );
     }
 
-    // Check that it doesn't start or end with special characters
     if (trimmedName.startsWith('-') || trimmedName.startsWith('_')) {
       errors.push('Name cannot start with a hyphen or underscore');
     }
@@ -151,7 +141,7 @@ export class SubagentValidator {
       errors.push(`"${trimmedName}" is a reserved name and cannot be used`);
     }
 
-    // Warnings for naming conventions (only for names that have case distinctions)
+    // Only warn about naming conventions for names that contain case distinctions
     if (
       trimmedName !== trimmedName.toLowerCase() &&
       /[a-zA-Z]/.test(trimmedName)
@@ -189,12 +179,10 @@ export class SubagentValidator {
 
     const trimmedPrompt = prompt.trim();
 
-    // Check minimum length for meaningful prompts
     if (trimmedPrompt.length < 10) {
       errors.push('System prompt must be at least 10 characters long');
     }
 
-    // Warn for very long prompts
     if (trimmedPrompt.length > 10000) {
       warnings.push(
         'System prompt is quite long (>10,000 characters), consider shortening',
@@ -230,13 +218,11 @@ export class SubagentValidator {
       return { isValid: true, errors, warnings };
     }
 
-    // Check for duplicates
     const uniqueTools = new Set(tools);
     if (uniqueTools.size !== tools.length) {
       warnings.push('Duplicate tool names found in tools array');
     }
 
-    // Validate each tool name
     for (const tool of tools) {
       if (typeof tool !== 'string') {
         errors.push(`Tool name must be a string, got: ${typeof tool}`);

--- a/packages/core/src/tools/mcp-tool.ts
+++ b/packages/core/src/tools/mcp-tool.ts
@@ -154,7 +154,6 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
   override async getConfirmationDetails(
     _abortSignal: AbortSignal,
   ): Promise<ToolCallConfirmationDetails> {
-    // Construct the permission rule for this specific MCP tool.
     const permissionRule = `mcp__${this.serverName}__${this.serverToolName}`;
 
     const confirmationDetails: ToolMcpConfirmationDetails = {
@@ -174,8 +173,7 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
     return confirmationDetails;
   }
 
-  // Determine if the response contains tool errors
-  // This is needed because CallToolResults should return errors inside the response.
+  // MCP spec: errors are returned inside the CallToolResult, not as exceptions.
   // ref: https://modelcontextprotocol.io/specification/2025-06-18/schema#calltoolresult
   isMCPToolError(rawResponseParts: Part[]): boolean {
     const functionResponse = rawResponseParts?.[0]?.functionResponse;
@@ -318,7 +316,6 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
         callToolResult,
       );
 
-      // Ensure the response is not an error
       if (this.isMCPToolError(rawResponseParts)) {
         const errorMessage = `MCP tool '${
           this.serverToolName
@@ -394,7 +391,6 @@ class DiscoveredMCPToolInvocation extends BaseToolInvocation<
           });
       });
 
-      // Ensure the response is not an error
       if (this.isMCPToolError(rawResponseParts)) {
         const errorMessage = `MCP tool '${
           this.serverToolName


### PR DESCRIPTION
## Summary

Remove comments that restate code, commented-out debug leftovers, and verbose restatements across 11 files. "Why" comments and business-rule explanations are retained. No functional changes.

## Changes (11 files, -58 lines)

### Commented-out dead code removal
| File | Detail |
|------|--------|
| `ControlDispatcher.ts` | Remove commented-out `HookController` import, property, constructor |
| `sharedTokenManager.ts` | Remove commented-out `console.debug` |
| `sandbox.ts` | Replace 2 commented-out stdout pipe blocks with concise comments; remove empty `if` with commented-out `console.warn` |

### Redundant "what" comment removal
| File | Detail |
|------|--------|
| `ideContext.ts` | Remove 3 comments restating code ("most recent file at index 0", "truncate") |
| `ide-client.ts` | Remove 3 redundant comments; condense catch comment |
| `mcp-tool.ts` | Remove "Construct permission rule", 2× "Ensure response is not error"; condense method docstring (keep MCP spec ref) |
| `settings.ts` | Remove ENOENT/validation/env-override restatements (keep "why" about optional settings) |
| `github.ts` | Condense checkout comment; remove "Determine the ref" restatement |
| `validation.ts` | Remove 15 validation step labels ("Validate name/description/tools", "Check length/chars/duplicates") — retain "why" for reserved name `main` |
| `languageCommand.ts` | Remove 5 section headers restating function calls |
| `arenaCommand.ts` | Remove regex restatement |

## Verification

- TypeScript type-check passes (`tsc --noEmit`) for both `core` and `cli`
- Pre-commit lint/prettier pass
- Zero functional impact — comment-only changes