### PR TITLE
fix(ci): fix triage prompt variable expansion, bot identity, and model secret

### DIFF
--- a/.github/workflows/qwen-issue-followup-bot.yml
+++ b/.github/workflows/qwen-issue-followup-bot.yml
@@ -304,7 +304,7 @@ jobs:
         with:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
-          OPENAI_MODEL: '${{ secrets.QWEN_PR_REVIEW_MODEL }}'
+          OPENAI_MODEL: '${{ vars.QWEN_PR_REVIEW_MODEL }}'
           settings_json: |-
             {
               "maxSessionTurns": 50,

--- a/.github/workflows/qwen-issue-followup-bot.yml
+++ b/.github/workflows/qwen-issue-followup-bot.yml
@@ -304,7 +304,7 @@ jobs:
         with:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
-          OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
+          OPENAI_MODEL: '${{ secrets.QWEN_PR_REVIEW_MODEL }}'
           settings_json: |-
             {
               "maxSessionTurns": 50,

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -34,8 +34,7 @@ jobs:
         github.event_name == 'pull_request_target' ||
         github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'issue_comment' &&
-         contains(github.event.comment.body, '@qwen-code /triage') &&
-         github.event.comment.user.login != 'github-actions[bot]' &&
+         startsWith(github.event.comment.body, '@qwen-code /triage') &&
          (github.event.comment.author_association == 'OWNER' ||
           github.event.comment.author_association == 'MEMBER' ||
           github.event.comment.author_association == 'COLLABORATOR'))
@@ -60,13 +59,13 @@ jobs:
       - name: 'Run Qwen Triage'
         uses: 'QwenLM/qwen-code-action@5fd6818d04d64e87d255ee4d5f77995e32fbf4c2'
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GITHUB_TOKEN: '${{ secrets.QWEN_CODE_BOT_TOKEN || secrets.CI_BOT_PAT }}'
           TARGET_NUMBER: '${{ steps.resolve.outputs.number }}'
           REPOSITORY: '${{ github.repository }}'
         with:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
-          OPENAI_MODEL: '${{ secrets.OPENAI_MODEL }}'
+          OPENAI_MODEL: '${{ secrets.QWEN_PR_REVIEW_MODEL }}'
           settings_json: |-
             {
               "maxSessionTurns": 25,
@@ -79,7 +78,7 @@ jobs:
           prompt: |-
             You are a triage assistant for the QwenLM/qwen-code repository.
 
-            Run `/triage ${TARGET_NUMBER}` to triage this issue or PR.
+            Run `/triage ${{ steps.resolve.outputs.number }}` to triage this issue or PR.
 
             Use the available shell commands (`gh`) to gather information and
             execute the triage workflow. The triage skill is available at

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -60,7 +60,6 @@ jobs:
         uses: 'QwenLM/qwen-code-action@5fd6818d04d64e87d255ee4d5f77995e32fbf4c2'
         env:
           GITHUB_TOKEN: '${{ secrets.QWEN_CODE_BOT_TOKEN || secrets.CI_BOT_PAT }}'
-          TARGET_NUMBER: '${{ steps.resolve.outputs.number }}'
           REPOSITORY: '${{ github.repository }}'
         with:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -28,14 +28,14 @@ jobs:
   triage:
     timeout-minutes: 10
     runs-on: 'ubuntu-latest'
+    # startsWith (not contains) prevents false triggers from comments that
+    # mention the phrase in quoted text or mid-sentence descriptions.
     if: >-
       github.repository == 'QwenLM/qwen-code' && (
         github.event_name == 'issues' ||
         github.event_name == 'pull_request_target' ||
         github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'issue_comment' &&
-         # startsWith prevents false triggers from comments that mention
-         # the phrase in quoted text or mid-sentence descriptions.
          startsWith(github.event.comment.body, '@qwen-code /triage') &&
          (github.event.comment.author_association == 'OWNER' ||
           github.event.comment.author_association == 'MEMBER' ||

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -62,6 +62,7 @@ jobs:
         uses: 'QwenLM/qwen-code-action@5fd6818d04d64e87d255ee4d5f77995e32fbf4c2'
         env:
           GITHUB_TOKEN: '${{ secrets.QWEN_CODE_BOT_TOKEN || secrets.CI_BOT_PAT }}'
+          GH_TOKEN: '${{ secrets.QWEN_CODE_BOT_TOKEN || secrets.CI_BOT_PAT }}'
           REPOSITORY: '${{ github.repository }}'
         with:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -34,6 +34,8 @@ jobs:
         github.event_name == 'pull_request_target' ||
         github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'issue_comment' &&
+         # startsWith prevents false triggers from comments that mention
+         # the phrase in quoted text or mid-sentence descriptions.
          startsWith(github.event.comment.body, '@qwen-code /triage') &&
          (github.event.comment.author_association == 'OWNER' ||
           github.event.comment.author_association == 'MEMBER' ||
@@ -64,7 +66,7 @@ jobs:
         with:
           OPENAI_API_KEY: '${{ secrets.OPENAI_API_KEY }}'
           OPENAI_BASE_URL: '${{ secrets.OPENAI_BASE_URL }}'
-          OPENAI_MODEL: '${{ secrets.QWEN_PR_REVIEW_MODEL }}'
+          OPENAI_MODEL: '${{ vars.QWEN_PR_REVIEW_MODEL }}'
           settings_json: |-
             {
               "maxSessionTurns": 25,


### PR DESCRIPTION
## What this PR does

Fixes several issues in the triage and issue followup bot CI workflows that caused triage to silently fail on comment-triggered runs, and aligns bot identity and model configuration.

## Why it's needed

When `@qwen-code /triage` was commented on a PR (e.g. #4629), the triage workflow triggered and succeeded, but produced no output. Root cause: the prompt contained literal `${TARGET_NUMBER}` which GitHub Actions YAML does not shell-expand — the model received the string `${TARGET_NUMBER}` instead of the actual number and gave up asking for clarification. Additionally, the bot's own triage comments contain `@qwen-code /triage` as descriptive text, which could re-trigger the workflow via the `contains()` check.

## Reviewer Test Plan

### How to verify

1. **Prompt expansion**: inspect `qwen-triage.yml` line 82 — confirm `${{ steps.resolve.outputs.number }}` replaces the old `${TARGET_NUMBER}`
2. **Bot loop prevention**: inspect the `if:` condition — confirm `startsWith()` replaces `contains()`, so only comments beginning with `@qwen-code /triage` trigger the workflow (not bot comments that mention it mid-sentence)
3. **Bot identity**: confirm `GITHUB_TOKEN` in the action step uses `QWEN_CODE_BOT_TOKEN || CI_BOT_PAT`
4. **Model secret**: confirm both workflows use `QWEN_PR_REVIEW_MODEL` instead of `OPENAI_MODEL`

### Evidence (Before & After)

**Before**: commenting `@qwen-code /triage` on #4629 triggered the workflow ([run 26944303602](https://github.com/QwenLM/qwen-code/actions/runs/26944303602)) but the model replied "I need the issue or PR number" and produced no triage output.

**After**: the prompt will contain the actual number (e.g. `/triage 4629`), the model can execute the triage skill correctly.

### Local verification

Simulated GitHub Actions expression evaluation against the modified workflow files — all tests passed:

```
============================================================
VERIFICATION: qwen-triage.yml
============================================================

[Test 1] Prompt variable expansion
  ✅ No literal ${TARGET_NUMBER} in prompt
  ✅ Prompt uses ${{ steps.resolve.outputs.number }} (will be expanded by GitHub Actions)
  ✅ Simulated prompt contains '/triage 4629' (number correctly interpolated)

[Test 2] Comment trigger uses startsWith (not contains)
  ✅ if condition uses startsWith()
  ✅ No contains() in if condition

[Test 3] Bot self-trigger prevention
  ✅ User comment starting with @qwen-code /triage
     startsWith=True, assoc=True → trigger=True (expected=True)
  ✅ User comment with extra instructions
     startsWith=True, assoc=True → trigger=True (expected=True)
  ✅ Bot comment mentioning @qwen-code /triage mid-sentence
     startsWith=False, assoc=True → trigger=False (expected=False)
  ✅ Bot comment with HTML marker prefix
     startsWith=False, assoc=True → trigger=False (expected=False)
  ✅ Random user comment (not COLLABORATOR)
     startsWith=True, assoc=False → trigger=False (expected=False)

[Test 4] Bot token configuration
  ✅ GITHUB_TOKEN uses QWEN_CODE_BOT_TOKEN
  ✅ GITHUB_TOKEN has CI_BOT_PAT fallback

[Test 5] Model secret configuration
  ✅ OPENAI_MODEL uses QWEN_PR_REVIEW_MODEL

[Test 6] Followup bot model secret
  ✅ Followup bot OPENAI_MODEL uses QWEN_PR_REVIEW_MODEL

============================================================
RESULT: All 6 tests passed ✅
```

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

CI-only change, no local runtime needed.

## Risk & Scope

- Main risk or tradeoff: `QWEN_PR_REVIEW_MODEL` secret must be configured in repo settings, otherwise both workflows will get an empty model value
- Not validated / out of scope: `qwen-code-pr-review.yml` has separate bugs (missing `issue_comment` trigger, keyword mismatch) — tracked in #4549
- Breaking changes / migration notes: none

## Linked Issues

Related to #4768

<details>
<summary>中文说明</summary>

修复 triage 和 issue followup bot CI workflow 的几个问题：

1. **prompt 变量未展开**：`${TARGET_NUMBER}` 在 GitHub Actions YAML 中是字面文本，模型收到的是字符串 `${TARGET_NUMBER}` 而不是实际的 issue/PR 号，导致 triage 无输出。改为 `${{ steps.resolve.outputs.number }}` 让 GitHub Actions 在解析时替换为实际值。
2. **bot 自触发风险**：bot 自身的 triage 评论中会引用 `@qwen-code /triage` 文字，`contains()` 会误匹配。改为 `startsWith()` 只匹配以该关键词开头的评论。
3. **bot 身份**：从 `GITHUB_TOKEN`（github-actions[bot]）切换为 `QWEN_CODE_BOT_TOKEN`，与 followup bot 保持一致。
4. **模型 secret**：triage 和 followup bot 均从 `OPENAI_MODEL` 切换为 `QWEN_PR_REVIEW_MODEL`。

</details>