### PR TITLE
test: cover rewind selector restore options

### DIFF
--- a/packages/cli/src/ui/components/RewindSelector.test.tsx
+++ b/packages/cli/src/ui/components/RewindSelector.test.tsx
@@ -39,7 +39,11 @@ const pressKey = (overrides: Partial<Key>) => {
   });
 };
 
-const flushEffects = async () => {
+// Two microtask yields are intentional: Ink 7 + React 19 split a render
+// pass across two ticks (one to flush state updates into the reconciler,
+// a second for the resulting effects to settle). A single Promise.resolve
+// drains only the first tick and produces flaky assertions on slow CI.
+const flush = async () => {
   await act(async () => {
     await Promise.resolve();
     await Promise.resolve();
@@ -112,7 +116,7 @@ describe('RewindSelector', () => {
     );
 
     pressKey({ name: 'return' });
-    await flushEffects();
+    await flush();
 
     expect(fileHistoryService.getDiffStats).toHaveBeenCalledWith('prompt-2');
     expect(lastFrame()).toContain('Restore code and conversation');
@@ -142,7 +146,7 @@ describe('RewindSelector', () => {
     );
 
     pressKey({ name: 'return' });
-    await flushEffects();
+    await flush();
     expect(lastFrame()).toContain('Restore conversation only');
 
     pressKey({ name: 'escape' });

--- a/packages/cli/src/ui/components/RewindSelector.test.tsx
+++ b/packages/cli/src/ui/components/RewindSelector.test.tsx
@@ -39,10 +39,22 @@ const pressKey = (overrides: Partial<Key>) => {
   });
 };
 
-const userTurn = (id: number, text: string): HistoryItem => ({
+const flushEffects = async () => {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+};
+
+const userTurn = (
+  id: number,
+  text: string,
+  promptId?: string,
+): HistoryItem => ({
   id,
   type: 'user',
   text,
+  promptId,
 });
 
 describe('RewindSelector', () => {
@@ -77,5 +89,65 @@ describe('RewindSelector', () => {
 
     pressKey({ name: 'n', sequence: '\u000E', ctrl: true });
     expect(lastFrame()).toContain('› #2 second prompt');
+  });
+
+  it('renders restore options with diff stats for the selected turn', async () => {
+    vi.spyOn(fileHistoryService, 'getDiffStats').mockResolvedValue({
+      filesChanged: ['src/foo.ts', 'src/bar.ts'],
+      insertions: 3,
+      deletions: 1,
+    });
+
+    const { lastFrame } = render(
+      <RewindSelector
+        history={[
+          userTurn(1, 'first prompt', 'prompt-1'),
+          userTurn(2, 'second prompt', 'prompt-2'),
+        ]}
+        onRewind={vi.fn()}
+        onCancel={vi.fn()}
+        fileCheckpointingEnabled={true}
+        fileHistoryService={fileHistoryService}
+      />,
+    );
+
+    pressKey({ name: 'return' });
+    await flushEffects();
+
+    expect(fileHistoryService.getDiffStats).toHaveBeenCalledWith('prompt-2');
+    expect(lastFrame()).toContain('Restore code and conversation');
+    expect(lastFrame()).toContain('(+3 -1 in 2 files)');
+    expect(lastFrame()).toContain('Restore conversation only');
+    expect(lastFrame()).toContain('Restore code only');
+  });
+
+  it('returns from restore options to the pick list on Escape', async () => {
+    vi.spyOn(fileHistoryService, 'getDiffStats').mockResolvedValue({
+      filesChanged: ['src/foo.ts'],
+      insertions: 2,
+      deletions: 0,
+    });
+
+    const { lastFrame } = render(
+      <RewindSelector
+        history={[
+          userTurn(1, 'first prompt', 'prompt-1'),
+          userTurn(2, 'second prompt', 'prompt-2'),
+        ]}
+        onRewind={vi.fn()}
+        onCancel={vi.fn()}
+        fileCheckpointingEnabled={true}
+        fileHistoryService={fileHistoryService}
+      />,
+    );
+
+    pressKey({ name: 'return' });
+    await flushEffects();
+    expect(lastFrame()).toContain('Restore conversation only');
+
+    pressKey({ name: 'escape' });
+
+    expect(lastFrame()).toContain('› #2 second prompt');
+    expect(lastFrame()).not.toContain('Restore conversation only');
   });
 });


### PR DESCRIPTION
## What this PR does

Adds focused regression coverage for the rewind restore-options flow. The new tests verify that selecting a turn with file checkpointing enabled shows the restore choices, includes the diff summary for changed files, and allows returning to the turn picker with Escape.

## Why it's needed

This covers part of the rewind test gap described in #4187. The restore-options phase combines selected conversation history, file checkpoint metadata, asynchronous diff stats, and keyboard navigation, so regression coverage helps keep the rewind UX stable as the flow evolves.

## Reviewer Test Plan

### How to verify

Run the focused CLI component test from `packages/cli` and confirm all RewindSelector tests pass. I verified this locally with `vitest run src/ui/components/RewindSelector.test.tsx --config vitest.config.ts`; the suite passed with 3 tests.

### Evidence (Before & After)

N/A. This PR only adds regression tests and does not change user-visible runtime behavior.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Tested locally on Windows with Node.js v24.14.0. Command run from `packages/cli`: `vitest run src/ui/components/RewindSelector.test.tsx --config vitest.config.ts`.

## Risk & Scope

- Main risk or tradeoff: Low risk; this PR only adds tests for existing behavior.
- Not validated / out of scope: This does not cover the broader handleRewindConfirm orchestration scenarios from #4187.
- Breaking changes / migration notes: None.

## Linked Issues

Part of #4187.

<details>
<summary>中文说明</summary>

## What this PR does

这个 PR 为 rewind 的恢复选项流程添加了聚焦的回归测试。新增测试验证了在启用文件 checkpoint 的情况下选择某个历史 turn 后，会展示恢复选项、包含变更文件的 diff 摘要，并且可以通过 Escape 返回 turn 选择列表。

## Why it's needed

这个 PR 覆盖了 #4187 中提到的 rewind 测试缺口的一部分。恢复选项阶段同时涉及选中的对话历史、文件 checkpoint 元数据、异步 diff stats 和键盘导航，因此补充回归测试可以帮助后续迭代时保持 rewind 用户体验稳定。

## Reviewer Test Plan

### How to verify

从 `packages/cli` 目录运行聚焦的 CLI 组件测试，并确认所有 RewindSelector 测试通过。我已在本地使用 `vitest run src/ui/components/RewindSelector.test.tsx --config vitest.config.ts` 验证，该测试套件通过，共 3 个测试。

### Evidence (Before & After)

N/A。这个 PR 只新增回归测试，不改变用户可见的运行时行为。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ⚠️ not tested |
| 🪟 Windows | ✅ tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

本地在 Windows 上使用 Node.js v24.14.0 测试。从 `packages/cli` 目录运行的命令是：`vitest run src/ui/components/RewindSelector.test.tsx --config vitest.config.ts`。

## Risk & Scope

- Main risk or tradeoff: 风险较低；这个 PR 只为已有行为添加测试。
- Not validated / out of scope: 这个 PR 不覆盖 #4187 中更完整的 handleRewindConfirm orchestration 场景。
- Breaking changes / migration notes: 无。

## Linked Issues

Part of #4187.

</details>