### PR TITLE
ci(triage): Fix Qwen triage workflow prompt

### DIFF
--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -13,10 +13,29 @@ on:
         description: 'Issue or PR number to triage'
         required: true
         type: 'number'
+      target:
+        description: 'Target type for manual triage'
+        required: false
+        default: 'issue'
+        type: 'choice'
+        options:
+          - 'issue'
+          - 'pr'
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.number }}'
-  cancel-in-progress: true
+  cancel-in-progress: >-
+    ${{
+      github.event_name != 'issue_comment' ||
+      (
+        startsWith(github.event.comment.body, '@qwen-code /triage') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
+    }}
 
 permissions:
   contents: 'read'
@@ -43,19 +62,22 @@ jobs:
       )
     steps:
       - name: 'Checkout repo'
-        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd'  # v6.0.2
+        uses: 'actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' # v6.0.2
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
 
-      - name: 'Resolve target number'
+      - name: 'Resolve target'
         id: 'resolve'
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "number=${{ github.event.inputs.number }}" >> "$GITHUB_OUTPUT"
+            echo "kind=${{ github.event.inputs.target }}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
             echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
+            echo "kind=pr" >> "$GITHUB_OUTPUT"
           else
             echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
+            echo "kind=${{ github.event.issue.pull_request && 'pr' || 'issue' }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: 'Run Qwen Triage'
@@ -77,19 +99,4 @@ jobs:
               ],
               "sandbox": false
             }
-          prompt: |-
-            You are a triage assistant for the QwenLM/qwen-code repository.
-
-            Run `/triage ${{ steps.resolve.outputs.number }}` to triage this issue or PR.
-
-            Use the available shell commands (`gh`) to gather information and
-            execute the triage workflow. The triage skill is available at
-            `.qwen/skills/triage/SKILL.md` — follow its rules exactly.
-
-            Key rules:
-            - Only target QwenLM/qwen-code with `--repo QwenLM/qwen-code`
-            - Labels: apply existing only, verify with `gh label list`
-            - Comments: use `--body-file` with heredoc for multi-line content
-            - Include both stage markers and bot-coordination markers
-            - Never close, merge, approve, assign, or remove labels
-            - Evaluate the tiered gate model before any `gh` write call
+          prompt: '/triage ${{ steps.resolve.outputs.kind }} ${{ steps.resolve.outputs.number }} --repo ${{ github.repository }}'

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -47,17 +47,15 @@ jobs:
         with:
           token: '${{ secrets.GITHUB_TOKEN }}'
 
-      - name: 'Resolve target'
+      - name: 'Resolve target number'
         id: 'resolve'
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "number=${{ github.event.inputs.number }}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
             echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-            echo "kind=pr" >> "$GITHUB_OUTPUT"
           else
             echo "number=${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
-            echo "kind=${{ github.event.issue.pull_request && 'pr' || 'issue' }}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: 'Run Qwen Triage'
@@ -79,4 +77,4 @@ jobs:
               ],
               "sandbox": false
             }
-          prompt: '/triage ${{ steps.resolve.outputs.kind }} ${{ steps.resolve.outputs.number }} --repo ${{ github.repository }}'
+          prompt: '/triage ${{ steps.resolve.outputs.number }}'

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -23,19 +23,8 @@ on:
           - 'pr'
 
 concurrency:
-  group: '${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.number }}'
-  cancel-in-progress: >-
-    ${{
-      github.event_name != 'issue_comment' ||
-      (
-        startsWith(github.event.comment.body, '@qwen-code /triage') &&
-        (
-          github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'COLLABORATOR'
-        )
-      )
-    }}
+  group: '${{ github.workflow }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.number }}'
+  cancel-in-progress: true
 
 permissions:
   contents: 'read'

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -72,8 +72,14 @@ jobs:
               "maxSessionTurns": 25,
               "coreTools": [
                 "run_shell_command",
-                "write_file"
+                "write_file",
+                "read_file",
+                "grep_search",
+                "glob",
+                "agent",
+                "enter_worktree",
+                "exit_worktree"
               ],
               "sandbox": false
             }
-          prompt: '/triage ${{ steps.resolve.outputs.number }}'
+          prompt: '/triage ${{ steps.resolve.outputs.number }} --repo ${{ github.repository }}'

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -14,10 +14,6 @@ on:
         required: true
         type: 'number'
 
-concurrency:
-  group: '${{ github.workflow }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.number }}'
-  cancel-in-progress: true
-
 permissions:
   contents: 'read'
   issues: 'write'
@@ -27,6 +23,9 @@ permissions:
 jobs:
   triage:
     timeout-minutes: 10
+    concurrency:
+      group: '${{ github.workflow }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.number }}'
+      cancel-in-progress: true
     runs-on: 'ubuntu-latest'
     # startsWith (not contains) prevents false triggers from comments that
     # mention the phrase in quoted text or mid-sentence descriptions.

--- a/.github/workflows/qwen-triage.yml
+++ b/.github/workflows/qwen-triage.yml
@@ -13,14 +13,6 @@ on:
         description: 'Issue or PR number to triage'
         required: true
         type: 'number'
-      target:
-        description: 'Target type for manual triage'
-        required: false
-        default: 'issue'
-        type: 'choice'
-        options:
-          - 'issue'
-          - 'pr'
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.number }}'
@@ -60,7 +52,6 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "number=${{ github.event.inputs.number }}" >> "$GITHUB_OUTPUT"
-            echo "kind=${{ github.event.inputs.target }}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "pull_request_target" ]; then
             echo "number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
             echo "kind=pr" >> "$GITHUB_OUTPUT"

--- a/.qwen/skills/triage/SKILL.md
+++ b/.qwen/skills/triage/SKILL.md
@@ -5,11 +5,10 @@ argument-hint: '<number> [--repo owner/repo]'
 allowedTools:
   - run_shell_command
   - read_file
-  - read_many_files
   - grep_search
   - glob
   - write_file
-  - task
+  - agent
   - enter_worktree
   - exit_worktree
 ---
@@ -47,6 +46,8 @@ gh label list --repo "$REPO" --limit 200
   comments: exit
 - Explicit reruns (`GITHUB_EVENT_NAME=issue_comment` or `workflow_dispatch`):
   run all stages, update prior comments in place
+- Local invocation (no `GITHUB_EVENT_NAME`): run all stages, update prior
+  comments in place
 
 Every posted comment must include an invisible marker: `<!-- qwen-triage stage=N -->` where N is the stage number. The guard matches against this marker, not comment headings.
 

--- a/.qwen/skills/triage/SKILL.md
+++ b/.qwen/skills/triage/SKILL.md
@@ -20,9 +20,7 @@ Run staged admission via `gh`. Post comment after each stage.
 
 ## Resolve
 
-- Kind: optional leading arg `issue` or `pr`; if omitted, infer from GitHub
-  metadata before choosing the issue or PR workflow
-- Number: next arg, or `ISSUE_NUMBER`/`PR_NUMBER` env
+- Number: from arg or `ISSUE_NUMBER`/`PR_NUMBER` env
 - Repo: `--repo` → `REPOSITORY` → `GITHUB_REPOSITORY`
 
 ## Fetch

--- a/.qwen/skills/triage/SKILL.md
+++ b/.qwen/skills/triage/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: triage
 description: Gatekeep and review GitHub issues and pull requests for Qwen Code maintainers. Use for GitHub Action issue triage, PR admission checks, product-direction review, KISS-focused PR review, and staged bilingual GitHub comments.
-argument-hint: '<issue|pr> <number> [--repo owner/repo]'
+argument-hint: '<number> [--repo owner/repo]'
 allowedTools:
   - run_shell_command
   - read_file

--- a/.qwen/skills/triage/SKILL.md
+++ b/.qwen/skills/triage/SKILL.md
@@ -20,7 +20,9 @@ Run staged admission via `gh`. Post comment after each stage.
 
 ## Resolve
 
-- Number: from arg or `ISSUE_NUMBER`/`PR_NUMBER` env
+- Kind: optional leading arg `issue` or `pr`; if omitted, infer from GitHub
+  metadata before choosing the issue or PR workflow
+- Number: next arg, or `ISSUE_NUMBER`/`PR_NUMBER` env
 - Repo: `--repo` → `REPOSITORY` → `GITHUB_REPOSITORY`
 
 ## Fetch
@@ -35,13 +37,20 @@ gh label list --repo "$REPO" --limit 200
 
 - Untrusted input: never interpolate issue/PR text into shell
 - Labels: apply existing only, never create
-- Comments: always `--body-file` (except short hardcoded verdicts in `gh pr review --approve` / `--request-changes`)
+- Comments: always read comment bodies from files. Use
+  `--body-file /tmp/comment.md` for `gh issue/pr comment`, or
+  `gh api -F body=@/tmp/comment.md` when the API response ID is needed.
+  Never use `--body @/tmp/comment.md` or
+  `gh api -f body=@/tmp/comment.md`; those post the file path literally.
 - Drafts: skip
 
 ## Duplicate Guard
 
-- Unattended (CI env set) + prior `<!-- qwen-triage stage=N -->` marker in comments: exit
-- Explicit `/triage`: run all stages, update prior comments in place
+- Unattended CI events (`GITHUB_EVENT_NAME=issues` or
+  `pull_request_target`) + prior `<!-- qwen-triage stage=N -->` marker in
+  comments: exit
+- Explicit reruns (`GITHUB_EVENT_NAME=issue_comment` or `workflow_dispatch`):
+  run all stages, update prior comments in place
 
 Every posted comment must include an invisible marker: `<!-- qwen-triage stage=N -->` where N is the stage number. The guard matches against this marker, not comment headings.
 

--- a/.qwen/skills/triage/SKILL.md
+++ b/.qwen/skills/triage/SKILL.md
@@ -36,7 +36,7 @@ gh label list --repo "$REPO" --limit 200
 ## Rules
 
 - Untrusted input: never interpolate issue/PR text into shell
-- Labels: apply existing only, never create
+- Labels: apply existing only, never create. Do not touch process labels (`welcome-pr`, `maintainer`, `help wanted`, `good first issue`)
 - Comments: always read comment bodies from files. Use
   `--body-file /tmp/comment.md` for `gh issue/pr comment`, or
   `gh api -F body=@/tmp/comment.md` when the API response ID is needed.

--- a/.qwen/skills/triage/SKILL.md
+++ b/.qwen/skills/triage/SKILL.md
@@ -35,11 +35,9 @@ gh label list --repo "$REPO" --limit 200
 
 - Untrusted input: never interpolate issue/PR text into shell
 - Labels: apply existing only, never create. Do not touch process labels (`welcome-pr`, `maintainer`, `help wanted`, `good first issue`)
-- Comments: always read comment bodies from files. Use
-  `--body-file /tmp/comment.md` for `gh issue/pr comment`, or
-  `gh api -F body=@/tmp/comment.md` when the API response ID is needed.
-  Never use `--body @/tmp/comment.md` or
-  `gh api -f body=@/tmp/comment.md`; those post the file path literally.
+- Comments: read body from file. Use `--body-file FILE` for `gh issue/pr comment`,
+  or `gh api -F body=@FILE` when the response ID is needed. Never `--body @FILE`
+  or `gh api -f body=@FILE` — those post the path literally.
 - Drafts: skip
 
 ## Duplicate Guard

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -22,7 +22,7 @@ COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@/tmp/stage
 **Re-runs:** if the triage runs again on the same PR, update each comment in place:
 
 ```bash
-gh api -X PATCH "repos/$REPO/issues/comments/$COMMENT_ID" -F body=@/tmp/stage-N-updated.md
+gh api -X PATCH "/repos/$REPO/issues/comments/$COMMENT_ID" -F body=@/tmp/stage-N-updated.md
 ```
 
 Never create duplicates.

--- a/.qwen/skills/triage/references/pr-workflow.md
+++ b/.qwen/skills/triage/references/pr-workflow.md
@@ -6,10 +6,11 @@ Shared rules (untrusted input, skip, bilingual format) are in `SKILL.md`.
 
 ### Comment Management
 
-Three comments, one per stage. Post each with `gh pr comment` and capture its ID:
+Three comments, one per stage. Post each through the issues comments API and
+capture its ID:
 
 ```bash
-COMMENT_ID=$(gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/stage-N.md --json id --jq '.id')
+COMMENT_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" -F body=@/tmp/stage-N.md --jq '.id')
 ```
 
 | Stage   | Comment                                       |
@@ -21,7 +22,7 @@ COMMENT_ID=$(gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file /tmp/stage-N.
 **Re-runs:** if the triage runs again on the same PR, update each comment in place:
 
 ```bash
-gh api -X PATCH "/repos/$REPO/issues/comments/$COMMENT_ID" -f body=@/tmp/stage-N-updated.md
+gh api -X PATCH "repos/$REPO/issues/comments/$COMMENT_ID" -F body=@/tmp/stage-N-updated.md
 ```
 
 Never create duplicates.


### PR DESCRIPTION
## What this PR does

Fixes the automated Qwen triage CI workflow that was posting broken comments and getting cancelled mid-execution.

Three changes:

1. **Direct skill invocation**: Replace the 15-line wrapper prompt with `/triage $NUMBER` so the skill framework loads the triage skill identically to local usage
2. **Concurrency group fix**: Add `event_name` to the concurrency group key so that `issue_comment` events (even skipped ones) do not cancel in-progress `pull_request_target` or `issues` triage runs
3. **Skill rules tightening**: Fix `-f` to `-F` in `gh api` re-run example, clarify `--body-file` vs `--body @` semantics, add process label exclusion

## Why it's needed

Two problems observed in production:

- Triage bot posted `@/tmp/stage-1.md` as literal comment text instead of file contents (e.g. PR #4803)
- Triage runs cancelled mid-execution by skipped `issue_comment` workflow runs in the same concurrency group

Root cause: `--prompt` mode does not trigger skill framework loading, so the agent manually read the skill file and made syntax errors. The concurrency group without `event_name` let unrelated events cancel each other.

## Reviewer Test Plan

### How to verify

After merge, trigger the workflow on a real issue or PR:

```
gh workflow run "Qwen Triage" --ref main -f number=<issue-or-pr-number>
```

Confirm:

- Triage posts actual review content (not file paths like `@/tmp/stage-1.md`)
- Triage runs are not cancelled by unrelated `issue_comment` events firing in the same window
- Process labels (`welcome-pr`, `maintainer`, etc.) are not touched

Note: this workflow file change only takes effect once merged to `main` — `pull_request_target` and `issues` events load the workflow from the default branch, not from the PR head. Full validation is therefore post-merge.

### Evidence (Before & After)

**Before** — symptoms observed on the unfixed workflow:

- Literal `@/tmp/stage-1.md` posted as comment body: https://github.com/QwenLM/qwen-code/pull/4803#issuecomment-4633667486

  <img width="1470" alt="literal file path posted as comment" src="https://github.com/user-attachments/assets/cc8ddeb5-b68b-4f16-8d22-23de875fd043" />

- Triage run cancelled mid-execution by an `issue_comment` event in the same concurrency group: https://github.com/QwenLM/qwen-code/actions/runs/27027823047

  <img width="2010" alt="run cancelled by concurrent event" src="https://github.com/user-attachments/assets/cd0e5117-ffb3-4364-b460-4e6b03cabf51" />

**After** — deferred to post-merge. Workflow definitions for `pull_request_target` / `issues` events are loaded from `main`, so the fix cannot be exercised from this PR's head ref. Will re-run triage on a fresh PR after merge and confirm the two symptoms above are gone.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

CI workflow change; runs on GitHub Actions runners with no local-OS surface.

### Environment (optional)

N/A — CI workflow change, no local runtime involved.

## Risk & Scope

- Main risk: With `event_name` in the concurrency key, `pull_request_target` and `issue_comment` triage runs on the same PR are no longer in the same group and can execute concurrently. The skill's comment dedup is marker-based (`<!-- qwen-triage stage=N -->` + list-then-POST-or-PATCH) and not transactional — a tight race could double-post a stage comment. The window is small, and the chosen trade-off is "rare visible duplicate" over "every triage run silently cancelled by an unrelated event."
- Not validated: No e2e reproduction of the original `issue_comment`-cancels-`pull_request_target` race; concurrent-run dedup race window not stress-tested.
- Breaking changes: None.

## Linked Issues

Closes #4785
Related to #4784, #4786

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

修复 Qwen 自动 triage CI 工作流的两个生产问题:发出来的评论是错的、运行经常被中途 cancel 掉。

三处改动:

1. **直接调用 skill**:把 15 行的包装 prompt 换成 `/triage $NUMBER`,让 skill 框架以和本地完全一致的方式加载 triage skill
2. **修复 concurrency group**:在 concurrency group key 中加入 `event_name`,这样 `issue_comment` 事件(哪怕被 skip)就不会再 cancel 正在执行的 `pull_request_target` 或 `issues` triage 运行
3. **收紧 skill 规则**:把 `gh api` re-run 示例里的 `-f` 改成 `-F`,澄清 `--body-file` 和 `--body @` 的语义差异,补上对流程类 label 的排除

## 为什么需要

线上观察到两个问题:

- Triage bot 把 `@/tmp/stage-1.md` 作为字面文本发成了评论,而不是发文件内容(例如 PR #4803)
- Triage 运行被同一 concurrency group 里被 skip 掉的 `issue_comment` workflow 运行 cancel 在中途

根因:`--prompt` 模式不会触发 skill 框架加载,所以 agent 是手动去读了 skill 文件、然后写出了带语法错误的命令。concurrency group 没带 `event_name`,导致互不相干的事件互相 cancel。

## 审阅测试计划

### 如何验证

合并后,在一个真实的 issue 或 PR 上手动触发 workflow:

```
gh workflow run "Qwen Triage" --ref main -f number=<issue-or-pr-number>
```

确认:

- Triage 发出的是真正的 review 内容(不是 `@/tmp/stage-1.md` 这种文件路径)
- Triage 运行不会被同一时间发生的、不相关的 `issue_comment` 事件 cancel
- 流程类 label(`welcome-pr`、`maintainer` 等)不会被动到

说明:这次的 workflow 文件改动必须合到 `main` 后才会生效 —— `pull_request_target` 和 `issues` 事件加载的是默认分支上的 workflow,不是 PR head 上的版本。所以完整验证是 post-merge。

### 证据(Before & After)

**Before** —— 未修复时观察到的两个症状:

- 字面 `@/tmp/stage-1.md` 被当作评论正文发出去:https://github.com/QwenLM/qwen-code/pull/4803#issuecomment-4633667486

  <img width="1470" alt="文件路径被当作评论字面发出" src="https://github.com/user-attachments/assets/cc8ddeb5-b68b-4f16-8d22-23de875fd043" />

- Triage 运行被同一 concurrency group 里的 `issue_comment` 事件 cancel 在中途:https://github.com/QwenLM/qwen-code/actions/runs/27027823047

  <img width="2010" alt="运行被并发事件 cancel" src="https://github.com/user-attachments/assets/cd0e5117-ffb3-4364-b460-4e6b03cabf51" />

**After** —— 推迟到 post-merge。`pull_request_target` / `issues` 事件加载的 workflow 来自 `main`,本 PR 的 head ref 没法触发新版本生效。合并后会在一个新 PR 上重新跑一次 triage,确认上面两个症状消失。

### 测试平台

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |  N/A   |
| 🪟 Windows |  N/A   |
|  🐧 Linux  |  N/A   |

CI workflow 改动;运行在 GitHub Actions runner 上,不涉及本地 OS。

### 环境(可选)

N/A —— CI workflow 改动,不涉及本地运行时。

## 风险与范围

- 主要风险:concurrency key 里加了 `event_name` 后,同一 PR 上的 `pull_request_target` 和 `issue_comment` triage 运行不再在同一个 group,可能并发执行。Skill 的评论去重是基于 marker 的(`<!-- qwen-triage stage=N -->`+ 先 list 再 POST 或 PATCH),不是事务性的 —— 在很紧的 race 下可能重复发同一阶段的评论。窗口很小,这次的取舍是"罕见但可见的重复评论"优于"每次 triage 都被无关事件静默 cancel"。
- 未验证:没有完整端到端复现原本 `issue_comment`-cancel-`pull_request_target` 的 race;并发运行的去重 race 窗口也未做压力测试。
- 破坏性变更:无。

## 关联 Issue

Closes #4785
Related to #4784, #4786

</details>
