### PR TITLE
fix(desktop): keep composer sendable after idle escape

### DIFF
--- a/packages/vscode-ide-companion/src/webview/App.test.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.test.tsx
@@ -12,13 +12,24 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRoot, type Root } from 'react-dom/client';
 import type { CompletionItem } from '../types/completionItemTypes.js';
 
-const { mockPostMessage, mockOpenCompletion, mockCloseCompletion } = vi.hoisted(
-  () => ({
+const {
+  mockPostMessage,
+  mockOpenCompletion,
+  mockCloseCompletion,
+  mockMessageState,
+  mockAddMessage,
+  mockEndStreaming,
+} = vi.hoisted(() => ({
     mockPostMessage: vi.fn(),
     mockOpenCompletion: vi.fn().mockResolvedValue(undefined),
     mockCloseCompletion: vi.fn(),
-  }),
-);
+    mockMessageState: {
+      isStreaming: false,
+      isWaitingForResponse: false,
+    },
+    mockAddMessage: vi.fn(),
+    mockEndStreaming: vi.fn(),
+  }));
 
 const slashSkillsItem: CompletionItem = {
   id: 'skills',
@@ -87,11 +98,11 @@ vi.mock('./hooks/file/useFileContext.js', () => ({
 vi.mock('./hooks/message/useMessageHandling.js', () => ({
   useMessageHandling: () => ({
     messages: [],
-    isStreaming: false,
-    isWaitingForResponse: false,
+    isStreaming: mockMessageState.isStreaming,
+    isWaitingForResponse: mockMessageState.isWaitingForResponse,
     loadingMessage: null,
-    addMessage: vi.fn(),
-    endStreaming: vi.fn(),
+    addMessage: mockAddMessage,
+    endStreaming: mockEndStreaming,
     setWaitingForResponse: vi.fn(),
   }),
 }));
@@ -230,11 +241,13 @@ vi.mock('./components/layout/InputForm.js', () => ({
   InputForm: ({
     inputText,
     inputFieldRef,
+    onCancel,
     onCompletionSelect,
     onCompletionFill,
   }: {
     inputText: string;
     inputFieldRef: React.RefObject<HTMLDivElement>;
+    onCancel: () => void;
     onCompletionSelect: (item: CompletionItem) => void;
     onCompletionFill?: (item: CompletionItem) => void;
   }) => (
@@ -248,6 +261,7 @@ vi.mock('./components/layout/InputForm.js', () => ({
         {inputText}
       </div>
       <div data-testid="input-text">{inputText}</div>
+      <button onClick={onCancel}>cancel-input</button>
       <button onClick={() => onCompletionSelect(slashSkillsItem)}>
         select-skills-command
       </button>
@@ -409,6 +423,8 @@ describe('App /skills secondary picker', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockMessageState.isStreaming = false;
+    mockMessageState.isWaitingForResponse = false;
     (
       globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
     ).IS_REACT_ACT_ENVIRONMENT = true;
@@ -557,5 +573,54 @@ describe('App /skills secondary picker', () => {
 
     expect(mockPostMessage).not.toHaveBeenCalled();
     expect(getRenderedInputText(rendered.container)).toBe('/clear ');
+  });
+
+  it('blurs and preserves composer text on idle cancel without cancelling the session', async () => {
+    const rendered = renderApp();
+    root = rendered.root;
+    container = rendered.container;
+
+    await act(async () => {});
+    setInputSelection(rendered.container, 'draft after escape');
+
+    const input = rendered.container.querySelector(
+      '[data-testid="input-field"]',
+    ) as HTMLDivElement;
+    const blurSpy = vi.spyOn(input, 'blur');
+
+    clickButton(rendered.container, 'cancel-input');
+
+    expect(blurSpy).toHaveBeenCalled();
+    expect(input.getAttribute('data-empty')).toBe('false');
+    expect(getRenderedInputText(rendered.container)).toBe(
+      'draft after escape',
+    );
+    expect(mockPostMessage).not.toHaveBeenCalledWith({
+      type: 'cancelStreaming',
+      data: {},
+    });
+  });
+
+  it('still cancels the session while streaming', async () => {
+    mockMessageState.isStreaming = true;
+    const rendered = renderApp();
+    root = rendered.root;
+    container = rendered.container;
+
+    await act(async () => {});
+
+    clickButton(rendered.container, 'cancel-input');
+
+    expect(mockEndStreaming).toHaveBeenCalled();
+    expect(mockAddMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: 'assistant',
+        content: 'Interrupted',
+      }),
+    );
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      type: 'cancelStreaming',
+      data: {},
+    });
   });
 });

--- a/packages/vscode-ide-companion/src/webview/App.tsx
+++ b/packages/vscode-ide-companion/src/webview/App.tsx
@@ -663,6 +663,20 @@ export const App: React.FC = () => {
       return;
     }
 
+    if (!messageHandling.isStreaming && !messageHandling.isWaitingForResponse) {
+      const inputElement = inputFieldRef.current;
+      if (inputElement) {
+        const text = stripZeroWidthSpaces(inputElement.textContent ?? '');
+        setInputText(text);
+        inputElement.setAttribute(
+          'data-empty',
+          text.trim().length === 0 ? 'true' : 'false',
+        );
+        inputElement.blur();
+      }
+      return;
+    }
+
     if (messageHandling.isStreaming || messageHandling.isWaitingForResponse) {
       // End streaming state and add an 'Interrupted' line.
       // IMPORTANT: Do NOT clear isWaitingForResponse here — let the
@@ -688,7 +702,14 @@ export const App: React.FC = () => {
       type: 'cancelStreaming',
       data: {},
     });
-  }, [clearEditingMessage, editingMessage, messageHandling, vscode]);
+  }, [
+    clearEditingMessage,
+    editingMessage,
+    inputFieldRef,
+    messageHandling,
+    setInputText,
+    vscode,
+  ]);
 
   // Message handling
   useWebViewMessages({


### PR DESCRIPTION
## What this PR does

Keeps idle Escape in the desktop composer as a local blur/cancel action. The draft text is preserved in composer state, the empty-state marker is refreshed, and the backend streaming-cancel message is no longer sent unless a response is actively streaming or waiting.

## Why it's needed

Closes #4772. Pressing Escape while idle could cancel the current desktop session path instead of only blurring the composer, leaving the composer unable to send after the user clicked back in and edited the draft.

## Reviewer Test Plan

### How to verify

In the desktop companion, type a draft while idle, press Escape, click the composer again, edit the draft, and send it. The message should submit normally. While a response is streaming or waiting, pressing Escape should still interrupt/cancel that active response.

### Evidence (Before & After)

Before: the idle Escape path could send the same cancel message used for active streaming sessions. After: regression coverage confirms idle cancel blurs and preserves composer text without sending the streaming cancel message, while the streaming path still sends the cancel message.

Commands run:

- `npm run test --workspace=packages/vscode-ide-companion -- src/webview/App.test.tsx`
- `npm run test --workspace=packages/vscode-ide-companion -- src/webview/components/layout/InputForm.test.tsx`
- `npm run test --workspace=packages/vscode-ide-companion -- src/webview/hooks/useMessageSubmit.test.ts`
- `npm run lint --workspace=packages/vscode-ide-companion`
- `npm run check-types --workspace=packages/vscode-ide-companion`
- `git diff --check`

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | tested |
| Windows | not tested |
| Linux | not tested |

### Environment (optional)

Node.js workspace tests in the package. Lint passes with existing unrelated warnings in other files.

## Risk & Scope

- Main risk or tradeoff: The change is limited to idle composer cancellation and active streaming cancellation in the desktop webview.
- Not validated / out of scope: Full desktop manual video capture was not generated; verification is through focused webview regression tests, lint, and typecheck.
- Breaking changes / migration notes: None.

## Linked Issues

Closes #4772

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

将桌面端输入框空闲时的 Escape 保持为本地失焦/取消操作。草稿文本会保留在输入框状态中，空内容标记会刷新，并且只有在响应正在流式输出或等待时才会向后端发送流式取消消息。

## 为什么需要

Closes #4772。空闲时按 Escape 可能会触发与活跃流式会话相同的取消路径，而不是只让输入框失焦，导致用户重新点击并编辑草稿后无法正常发送。

## Reviewer Test Plan

### How to verify

在桌面 companion 中，空闲时输入一段草稿，按 Escape，再次点击输入框，编辑草稿并发送。消息应能正常提交。当响应正在流式输出或等待时，按 Escape 仍应中断/取消当前活跃响应。

### Evidence (Before & After)

Before: 空闲 Escape 路径可能发送用于活跃流式会话的同一个取消消息。After: 回归测试确认空闲取消会让输入框失焦并保留文本，且不会发送流式取消消息；流式路径仍会发送取消消息。

### Tested on

| OS | Status |
| :-- | :-- |
| macOS | tested |
| Windows | not tested |
| Linux | not tested |

### Environment (optional)

在该 package 中运行 Node.js workspace 测试。Lint 通过，但其他文件中存在既有的无关 warning。

## Risk & Scope

- Main risk or tradeoff: 变更范围限于桌面 webview 的空闲输入框取消和活跃流式取消。
- Not validated / out of scope: 未生成完整桌面手动视频；验证来自聚焦 webview 回归测试、lint 和 typecheck。
- Breaking changes / migration notes: 无。

</details>
