### PR TITLE
docs: fix missing spaces before parentheses in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Use the `/model` command at any time to switch between all configured models.
 }
 ```
 
-> Subscribe to the Coding Plan and get your API key at [Alibaba Cloud ModelStudio(Beijing)](https://bailian.console.aliyun.com/cn-beijing?tab=coding-plan#/efm/coding-plan-index) or [Alibaba Cloud ModelStudio(intl)](https://modelstudio.console.alibabacloud.com/?tab=coding-plan#/efm/coding-plan-index).
+> Subscribe to the Coding Plan and get your API key at [Alibaba Cloud ModelStudio (Beijing)](https://bailian.console.aliyun.com/cn-beijing?tab=coding-plan#/efm/coding-plan-index) or [Alibaba Cloud ModelStudio (intl)](https://modelstudio.console.alibabacloud.com/?tab=coding-plan#/efm/coding-plan-index).
 
 </details>
 


### PR DESCRIPTION
## What this PR does

Fixes two README link labels by adding the missing spaces before (Beijing) and (intl).

## Testing

Docs-only README change; no runtime tests run.