### PR TITLE
feat(web-shell): add daemon dev launcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "start": "cross-env node scripts/start.js",
     "dev": "node scripts/dev.js",
+    "dev:daemon": "node scripts/daemon-dev.js",
     "debug": "cross-env DEBUG=1 node --inspect-brk scripts/start.js",
     "generate": "node scripts/generate-git-commit-info.js",
     "generate:settings-schema": "node --import tsx/esm scripts/generate-settings-schema.ts",

--- a/packages/web-shell/vite.config.ts
+++ b/packages/web-shell/vite.config.ts
@@ -1,10 +1,11 @@
+import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 import type { ProxyOptions } from 'vite';
 import react from '@vitejs/plugin-react';
 import pkg from './package.json' with { type: 'json' };
 
 const daemonProxy: ProxyOptions = {
-  target: 'http://127.0.0.1:4170',
+  target: process.env['QWEN_DAEMON_URL'] ?? 'http://127.0.0.1:4170',
   changeOrigin: true,
   bypass: (req) => {
     if (req.url?.startsWith('/api/')) return undefined;
@@ -28,10 +29,20 @@ const daemonProxy: ProxyOptions = {
   },
 };
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
   root: 'client',
   plugins: [react()],
   resolve: {
+    alias:
+      command === 'serve'
+        ? {
+            '@qwen-code/webui/daemon-react-sdk': resolve(
+              __dirname,
+              '../webui/src/daemon-react-sdk.ts',
+            ),
+            '@qwen-code/webui': resolve(__dirname, '../webui/src/index.ts'),
+          }
+        : {},
     dedupe: ['react', 'react-dom', '@qwen-code/webui'],
   },
   build: {
@@ -56,4 +67,4 @@ export default defineConfig({
       '/glob': daemonProxy,
     },
   },
-});
+}));

--- a/scripts/daemon-dev.js
+++ b/scripts/daemon-dev.js
@@ -1,0 +1,279 @@
+/**
+ * @license
+ * Copyright 2026 Qwen Team
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { spawn } from 'node:child_process';
+import crypto from 'node:crypto';
+import http from 'node:http';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { platform } from 'node:os';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+const args = process.argv.slice(2);
+const isWin = platform() === 'win32';
+const serveOptionNames = new Set([
+  '--port',
+  '--hostname',
+  '--token',
+  '--max-sessions',
+  '--workspace',
+  '--max-connections',
+  '--require-auth',
+  '--event-ring-size',
+]);
+
+function readOption(name) {
+  const prefix = `${name}=`;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === name) {
+      const value = args[i + 1];
+      return value && !value.startsWith('--') ? value : undefined;
+    }
+    if (arg.startsWith(prefix)) return arg.slice(prefix.length) || undefined;
+  }
+  return undefined;
+}
+
+function hasOption(name) {
+  return readOption(name) !== undefined;
+}
+
+function validateLauncherArgs() {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const [name, inlineValue] = arg.split('=', 2);
+    if (!serveOptionNames.has(name)) {
+      throw new Error(`Unsupported daemon-dev option: ${arg}`);
+    }
+    if (arg === '--require-auth') continue;
+    if (arg.includes('=')) {
+      if (!inlineValue) throw new Error(`${name} requires a value.`);
+      continue;
+    }
+    const value = args[i + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`${arg} requires a value.`);
+    }
+    i += 1;
+  }
+}
+
+function serveArgsFromLauncherArgs() {
+  const result = ['serve'];
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    const name = arg.split('=', 1)[0];
+    if (!serveOptionNames.has(name)) continue;
+    result.push(arg);
+    if (!arg.includes('=') && arg !== '--require-auth') {
+      result.push(args[i + 1]);
+      i += 1;
+    }
+  }
+  return result;
+}
+
+function daemonUrl(hostname, port) {
+  const host =
+    hostname.includes(':') && !hostname.startsWith('[')
+      ? `[${hostname}]`
+      : hostname;
+  return `http://${host}:${port}`;
+}
+
+function spawnDevProcess(label, command, commandArgs, options) {
+  const child = spawn(command, commandArgs, {
+    stdio: 'inherit',
+    shell: options.shell ?? false,
+    detached: !isWin,
+    ...options,
+  });
+
+  child.on('error', (err) => {
+    console.error(`[${label}] failed to start: ${err.message}`);
+    shutdown(1);
+  });
+
+  child.on('close', (code, signal) => {
+    if (shuttingDown) return;
+    if (signal) {
+      console.error(`[${label}] exited by signal ${signal}`);
+      shutdown(1);
+      return;
+    }
+    if (code !== 0) {
+      console.error(`[${label}] exited with code ${code}`);
+    }
+    shutdown(code ?? 0);
+  });
+
+  children.push(child);
+  return child;
+}
+
+function killChild(child) {
+  if (child.killed) return;
+  try {
+    if (!isWin && child.pid) {
+      process.kill(-child.pid, 'SIGTERM');
+    } else {
+      child.kill();
+    }
+  } catch {
+    child.kill();
+  }
+}
+
+function waitForDaemon(url) {
+  const healthUrl = new URL('/health', url);
+  const deadline = Date.now() + 30_000;
+
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      let retried = false;
+      const retryOnce = () => {
+        if (retried) return;
+        retried = true;
+        retry();
+      };
+      const req = http.get(healthUrl, (res) => {
+        res.resume();
+        if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+          resolve();
+          return;
+        }
+        retryOnce();
+      });
+      req.on('error', retryOnce);
+      req.setTimeout(1_000, () => {
+        req.destroy();
+        retryOnce();
+      });
+    };
+
+    const retry = () => {
+      if (shuttingDown) return;
+      if (Date.now() >= deadline) {
+        reject(new Error(`Timed out waiting for ${healthUrl.href}`));
+        return;
+      }
+      setTimeout(check, 250);
+    };
+
+    check();
+  });
+}
+
+function shutdown(code) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+
+  let pending = 0;
+  for (const child of children) {
+    if (child.exitCode !== null || child.signalCode !== null) continue;
+    pending += 1;
+    child.on('close', () => {
+      pending -= 1;
+      if (pending <= 0) process.exit(code);
+    });
+    killChild(child);
+  }
+  if (pending === 0) process.exit(code);
+  setTimeout(() => process.exit(code), 5_000).unref();
+}
+
+const children = [];
+let shuttingDown = false;
+
+try {
+  validateLauncherArgs();
+} catch (err) {
+  console.error(
+    `[daemon-dev] ${err instanceof Error ? err.message : String(err)}`,
+  );
+  process.exit(1);
+}
+
+const port = readOption('--port') || '4170';
+if (port === '0') {
+  console.error(
+    'daemon-dev: --port 0 is not supported; the launcher needs a fixed port to poll for health.',
+  );
+  process.exit(1);
+}
+
+const hostname = readOption('--hostname') || '127.0.0.1';
+const token =
+  readOption('--token') ||
+  process.env.QWEN_SERVER_TOKEN ||
+  crypto.randomBytes(16).toString('hex');
+const workspace = resolve(readOption('--workspace') || process.cwd());
+
+const serveArgs = serveArgsFromLauncherArgs();
+if (!hasOption('--workspace')) serveArgs.push('--workspace', workspace);
+
+const tsxLoaderUrl = pathToFileURL(
+  join(root, 'node_modules', 'tsx', 'dist', 'esm', 'index.mjs'),
+).href;
+const nodeOptions = [process.env.NODE_OPTIONS, `--import ${tsxLoaderUrl}`]
+  .filter(Boolean)
+  .join(' ');
+
+const serveEnv = {
+  ...process.env,
+  QWEN_SERVER_TOKEN: token,
+  QWEN_CODE_NO_RELAUNCH: 'true',
+  NODE_OPTIONS: nodeOptions,
+};
+
+const webEnv = {
+  ...process.env,
+  QWEN_DAEMON_URL: daemonUrl(hostname, port),
+};
+
+console.log(`qwen daemon dev`);
+console.log(`  daemon:   ${webEnv.QWEN_DAEMON_URL}`);
+console.log(`  workspace: ${workspace}`);
+console.log(
+  `  web-shell: http://localhost:5173/ (token: ${token.slice(0, 4)}...)`,
+);
+console.log('');
+
+process.on('SIGINT', () => shutdown(0));
+process.on('SIGTERM', () => shutdown(0));
+
+spawnDevProcess('daemon', 'node', ['scripts/dev.js', ...serveArgs], {
+  cwd: root,
+  env: serveEnv,
+});
+
+waitForDaemon(webEnv.QWEN_DAEMON_URL)
+  .then(() => {
+    spawnDevProcess(
+      'web-shell',
+      'npm',
+      [
+        'run',
+        'dev',
+        '--workspace=packages/web-shell',
+        '--',
+        '--open',
+        `/?token=${encodeURIComponent(token)}`,
+        '--strictPort',
+      ],
+      {
+        cwd: root,
+        env: webEnv,
+        shell: isWin,
+      },
+    );
+  })
+  .catch((err) => {
+    console.error(`[daemon] ${err.message}`);
+    shutdown(1);
+  });


### PR DESCRIPTION
## What this PR does

Adds a single root development command that starts the local daemon and the web-shell dev server together, opens the browser with the bearer token already in the URL, and forwards daemon options such as port, hostname, token, and workspace while defaulting the workspace to the current directory.

It also lets the web-shell dev server proxy to the selected daemon URL and resolves the shared web UI package to source while developing so edits there are picked up without rebuilding that package first.

## Why it's needed

Working on the daemon-backed web shell currently requires manually starting the daemon with several arguments and then starting the web shell from a nested package directory. The new launcher keeps the workflow to one command and avoids stale bundled code during local development.

## Reviewer Test Plan

### How to verify

Run the new root command and confirm that the daemon listens on port 4170, the web shell opens at localhost:5173 with the token query parameter, and a web-shell session can be created. Edit shared web UI source while the web-shell dev server is running and confirm Vite serves the source module instead of the package dist output.

### Evidence (Before & After)

Before: daemon and web shell had to be started as separate commands, and the web shell resolved the shared web UI package through its package exports to built dist files.

After: `npm run dev:daemon` starts both processes, opens `http://localhost:5173/?token=123`, successfully spawns a daemon session, and Vite resolves `@qwen-code/webui/daemon-react-sdk` to `packages/webui/src/daemon-react-sdk.ts`.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

Local macOS workspace using the root npm scripts. Verified `node --check scripts/daemon-dev.js`, `npm run dev:daemon`, `Ctrl+C` shutdown releasing ports 4170 and 5173, and `npm run build --workspace=packages/web-shell`.

## Risk & Scope

- Main risk or tradeoff: the new launcher is intended for local development and opens a browser URL containing the local bearer token, matching the web-shell dev flow.
- Not validated / out of scope: Windows and Linux manual startup were not tested locally.
- Breaking changes / migration notes: none.

## Linked Issues

N/A

<details>
<summary>中文说明</summary>

## What this PR does

新增一个根目录开发命令，可以同时启动本地 daemon 和 web-shell dev server，自动打开带 bearer token 的浏览器地址，并透传 daemon 的端口、主机名、token、workspace 等参数；未指定 workspace 时默认使用当前目录。

同时，web-shell dev server 可以代理到指定 daemon URL，并在开发时把共享 web UI 包解析到源码，避免每次修改共享 UI 后都先重新构建该包。

## Why it's needed

当前开发 daemon-backed web shell 时，需要先手动带多个参数启动 daemon，再进入嵌套 package 启动 web shell。新的启动器把流程收敛成一个命令，并避免本地开发时使用过期的打包产物。

## Reviewer Test Plan

### How to verify

运行新的根目录命令，确认 daemon 监听 4170，web shell 自动打开 localhost:5173 且 URL 带 token，并且可以创建 web-shell session。web-shell dev server 运行时修改共享 web UI 源码，确认 Vite 使用源码模块而不是 package dist 输出。

### Evidence (Before & After)

Before: daemon 和 web shell 需要分别用两条命令启动，web shell 通过 package exports 解析共享 web UI 包，因此使用的是已构建的 dist 文件。

After: `npm run dev:daemon` 同时启动两个进程，打开 `http://localhost:5173/?token=123`，成功创建 daemon session，并且 Vite 将 `@qwen-code/webui/daemon-react-sdk` 解析到 `packages/webui/src/daemon-react-sdk.ts`。

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅ tested   |
| 🪟 Windows |   ⚠️ not tested   |
|  🐧 Linux  |   ⚠️ not tested   |

### Environment (optional)

本地 macOS 工作区，使用根目录 npm scripts。已验证 `node --check scripts/daemon-dev.js`、`npm run dev:daemon`、`Ctrl+C` 后释放 4170 和 5173 端口，以及 `npm run build --workspace=packages/web-shell`。

## Risk & Scope

- Main risk or tradeoff: 新启动器面向本地开发，会打开包含本地 bearer token 的浏览器 URL，这与 web-shell dev 流程一致。
- Not validated / out of scope: 未在 Windows 和 Linux 上做本地手动启动验证。
- Breaking changes / migration notes: 无。

## Linked Issues

N/A

</details>