### PR TITLE
fix(core): add multimodal support for qwen3.7-plus

### DIFF
--- a/packages/core/src/core/modalityDefaults.test.ts
+++ b/packages/core/src/core/modalityDefaults.test.ts
@@ -139,6 +139,18 @@ describe('defaultModalities', () => {
       expect(m.audio).toBeUndefined();
     });
 
+    it('returns image + video for qwen3.7-plus', () => {
+      const m = defaultModalities('qwen3.7-plus');
+      expect(m.image).toBe(true);
+      expect(m.video).toBe(true);
+      expect(m.pdf).toBeUndefined();
+      expect(m.audio).toBeUndefined();
+    });
+
+    it('returns text-only for qwen3.7-max', () => {
+      expect(defaultModalities('qwen3.7-max')).toEqual({});
+    });
+
     it('returns image + video for qwen3.6-35b variants', () => {
       const m = defaultModalities('qwen3.6-35b-a3b-nvfp4');
       expect(m.image).toBe(true);

--- a/packages/core/src/core/modalityDefaults.ts
+++ b/packages/core/src/core/modalityDefaults.ts
@@ -40,9 +40,10 @@ const MODALITY_PATTERNS: Array<[RegExp, InputModalities]> = [
   // -------------------
   // Alibaba / Qwen
   // -------------------
-  // Qwen3.5-Plus, Qwen3.6-Plus: image + video support
+  // Qwen Plus models: image + video support (Max models are text-only)
   [/^qwen3\.5-plus/, { image: true, video: true }],
   [/^qwen3\.6-plus/, { image: true, video: true }],
+  [/^qwen3\.7-plus/, { image: true, video: true }],
   [/^coder-model$/, { image: true, video: true }],
 
   // Qwen VL (vision-language) models: image + video

--- a/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
+++ b/packages/core/src/core/openaiContentGenerator/provider/dashscope.ts
@@ -360,6 +360,8 @@ export class DashScopeOpenAICompatibleProvider extends DefaultOpenAICompatiblePr
     'qwen-vl', // qwen-vl-max, qwen-vl-max-latest, etc.
     'qwen3-vl-plus', // qwen3-vl-plus variants
     'qwen3.5-plus', // qwen3.5-plus (has built-in vision capabilities)
+    'qwen3.6-plus', // qwen3.6-plus (multimodal)
+    'qwen3.7-plus', // qwen3.7-plus (multimodal)
   ];
 
   private isVisionModel(model: string | undefined): boolean {


### PR DESCRIPTION
## Problem

`qwen3.7-plus` supports multimodal input (image + video), but the current modality detection logic treats it as text-only.

In Model Studio naming convention, **Plus models are multimodal** and **Max models are text-only**. The `defaultModalities()` function had no explicit pattern for `qwen3.7-plus`, so it fell through to the catch-all `/^qwen/` → `{}` (text-only).

Closes #4802

## Changes

### 1. `modalityDefaults.ts` — modality pattern

Added `[/^qwen3\.7-plus/, { image: true, video: true }]` to `MODALITY_PATTERNS`, placed before the catch-all `/^qwen/`.

### 2. `dashscope.ts` — vision model detection

Added `qwen3.6-plus` and `qwen3.7-plus` to `VISION_MODEL_PREFIX_PATTERNS` so the DashScope provider correctly sets `vl_high_resolution_images: true` for these models. (`qwen3.6-plus` was also missing — added for consistency.)

### 3. Tests

- `qwen3.7-plus` → `{ image: true, video: true }` (multimodal)
- `qwen3.7-max` → `{}` (text-only, already correct)

## How to verify

1. Set model to `qwen3.7-plus` via custom config or token plan
2. Send an image in the prompt
3. Confirm the image is sent as inline multimodal data, not downgraded to a text placeholder
4. Set model to `qwen3.7-max` and confirm it remains text-only
