### PR TITLE
fix(core): handle error variant in disabled skill command delegation

### DIFF
--- a/packages/core/src/tools/skill.ts
+++ b/packages/core/src/tools/skill.ts
@@ -461,6 +461,12 @@ class SkillToolInvocation extends BaseToolInvocation<SkillParams, ToolResult> {
             // track via `onSkillLoaded` — no skill body was loaded, and
             // conflating the two would inflate skill telemetry /
             // `/context` skill-token attribution with command runs.
+            if (typeof content === 'object' && 'error' in content) {
+              return {
+                llmContent: content.error,
+                returnDisplay: content.error,
+              };
+            }
             return {
               llmContent: [{ text: content }],
               returnDisplay: `Delegated to command: ${this.params.skill}`,


### PR DESCRIPTION
## What this PR does

Fixes a TypeScript build error in `packages/core/src/tools/skill.ts` where the disabled-skill command delegation path directly used `ModelInvocableCommandExecutorResult` as text content, but the type includes an error object variant (`{ error: string }`).

Adds proper type narrowing to handle both the `string` and `{ error: string }` cases, matching the existing pattern at lines 494-506.

## Why it's needed

All CI checks on PRs targeting main are failing with:
```
src/tools/skill.ts(465,30): error TS2322: Type 'ModelInvocableCommandExecutorResult' is not assignable to type 'string | undefined'.
```

## Reviewer Test Plan

### How to verify

```bash
npx tsc --noEmit --project packages/core/tsconfig.json
npm run build
```

### Evidence (Before & After)

- Before: `tsc` fails with TS2322 on skill.ts line 465
- After: `tsc` passes (type narrowing handles both variants)

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  macOS  | type check verified |

## Risk & Scope

- Type-only fix, no runtime behavior change for the string case
- The error-object case now returns early with the error message (previously unreachable due to build failure)
- No breaking changes

## Linked Issues

Build break from #4532/#4533

<details>
<summary>中文说明</summary>

修复 `packages/core/src/tools/skill.ts` 中的 TypeScript 构建错误。disabled skill 的命令委派路径直接把 `ModelInvocableCommandExecutorResult` 当 string 用，但类型已扩展为 `string | { error: string }`。

添加了类型收窄，处理两种情况，与 494-506 行的现有模式一致。

此错误阻塞了所有 PR 的 CI 检查。

</details>
