### PR TITLE
feat(skills): add desktop-pet skill for creating pixel-art companions

### DIFF
--- a/.qwen/skills/desktop-pet/SKILL.md
+++ b/.qwen/skills/desktop-pet/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: desktop-pet
+description: Create pixel-art desktop pet companions for Qwen Code. Generates a customized chibi spritesheet (1536×1872, 8×9 grid) for any character the user names — F1 drivers, anime characters, celebrities, fictional characters, animals, etc. Use when the user says "desktop pet", "桌宠", "桌面宠物", "想要XXX当桌宠", "换个宠物", or similar.
+---
+
+# Desktop Pet Creator
+
+Create pixel-art chibi desktop pet companions for Qwen Code's floating pet window.
+Given any character name, generate a complete pet package with animated spritesheet
+and place it in `~/.qwen/pets/` where Qwen Code auto-discovers it.
+
+## Prerequisites
+
+- Python 3 with Pillow (`pip3 install Pillow`). Check before running the script:
+
+```bash
+python3 -c "from PIL import Image; print('OK')" 2>/dev/null || echo "Pillow not installed — run: pip3 install Pillow"
+```
+
+## Step 1: Identify the Character
+
+Ask the user who they want as their desktop pet if not already specified.
+Then research the character's visual appearance:
+
+- **Team/organization colors** (e.g., McLaren papaya orange, Ferrari red)
+- **Outfit/uniform** (racing suit, school uniform, armor, etc.)
+- **Distinguishing features** (hair color/style, accessories, number, helmet)
+- **Personality traits** (for animation style — energetic, calm, goofy, serious)
+- **Iconic items** (steering wheel, lightsaber, guitar, etc.)
+
+Use web search if needed. For well-known characters (F1 drivers, popular anime,
+etc.), rely on training knowledge.
+
+## Step 2: Design the Color Palette
+
+Define 8–12 colors for the character. All colors must be distinct and work at
+small pixel scale (3× = 9 px details).
+
+| Color Role | Example (F1 Driver) | Example (Anime) |
+|---|---|---|
+| `outfit` | Team color `[255,135,32]` | Uniform `[30,30,50]` |
+| `outfit_dark` | Darker shade | Darker shade |
+| `outfit_light` | Lighter shade | Lighter shade |
+| `skin` | Warm skin tone | Skin tone |
+| `skin_dark` | Shadow skin | Shadow skin |
+| `hair` | Character hair color | Character hair color |
+| `accent` | Number/logo color | Eye color |
+| `shoe` | Dark grey/black | Shoe color |
+
+## Step 3: Generate the Spritesheet
+
+Run the generation script. Always resolve the path relative to the skill's base
+directory:
+
+```bash
+python3 <skill_dir>/scripts/gen_spritesheet.py \
+  --output ~/.qwen/pets/<character_id>/spritesheet.webp \
+  --config '{"colors":{...},"features":{...}}'
+```
+
+**Atlas format:** 1536×1872 px, RGBA, 8 cols × 9 rows, 192×208 px cells.
+
+**Animation rows:**
+
+| Row | State | Description |
+|---|---|---|
+| 0 | idle | Breathing + blinking (8 frames) |
+| 1 | running-right | Running to the right (8 frames) |
+| 2 | running-left | Running to the left (8 frames) |
+| 3 | waving | Waving at user (8 frames) |
+| 4 | jumping | Jumping celebration (8 frames) |
+| 5 | failed | Sad/collapsed on error (8 frames) |
+| 6 | waiting | Idle tapping (8 frames) |
+| 7 | running | Generic running (8 frames) |
+| 8 | review | Thinking/examining (8 frames) |
+
+## Step 4: Create `pet.json`
+
+Write the manifest to `~/.qwen/pets/<character_id>/pet.json`:
+
+```json
+{
+  "id": "<character_id>",
+  "displayName": "<Display Name>",
+  "description": "<Short description — who is this character?>",
+  "spritesheetPath": "spritesheet.webp"
+}
+```
+
+Rules:
+- `id`: lowercase, no spaces, URL-safe (e.g., `piastri`, `satoru`, `goku`)
+- `displayName`: The name shown in the UI (e.g., "Piastri", "五条悟", "悟空")
+- `description`: One short sentence describing the character
+
+## Step 5: Verify and Activate
+
+1. Confirm the files exist:
+
+```bash
+ls -lh ~/.qwen/pets/<character_id>/
+```
+
+2. Open the spritesheet for the user to check:
+
+```bash
+open ~/.qwen/pets/<character_id>/spritesheet.webp
+```
+
+3. Tell the user to activate: open Qwen Code **Settings → Appearance → Pet
+Companion**, click **Refresh**, then select the new pet.
+
+## Design Guidelines
+
+### Chibi Proportions
+
+- **Head**: ~40% of total height (big head = cute)
+- **Body**: ~30% of total height
+- **Legs**: ~25% of total height
+- **Scale**: Each "pixel" in the art = 3×3 actual pixels (scale=3)
+- **Character center**: approximately (96, 124) within the 192×208 cell
+
+### Drawing Order (back to front)
+
+1. Legs (behind body)
+2. Body / outfit
+3. Arms
+4. Head shape
+5. Hair (back layer)
+6. Hair (front/top layer)
+7. Face features (eyes, mouth, expression)
+8. Accessories (hat, helmet, glasses, etc.)
+9. Foreground details (number, logo, badge)
+
+### Animation Tips
+
+- **Idle**: subtle Y bob (0 to −2 px) + blink every 3rd–4th frame
+- **Running**: alternating leg offset (±4 px), body tilt (±2 px), arm swing
+- **Waving**: one arm raised high, alternating frames
+- **Jumping**: Y offset curve (0 → −30 → 0), arms up
+- **Failed**: body tilt increases, then collapse to sitting pose
+- **Happy expression**: curved eyes (∧ shape), blush marks on cheeks
+- **Sad expression**: straight eyebrows, downturned mouth
+
+### Headgear Options (`features.headgear`)
+
+`cap` · `helmet` · `hat` · `hood` · `crown` · `horns` · `ears` · `halo` · `headband` · `none`
+
+### Hair Styles (`features.hair_style`)
+
+`short` · `long` · `spiky` · `ponytail` · `bald`
+
+### Extras (`features.extras` list)
+
+`glasses` · `scarf` · `tail` · `wings` · `number` (set `features.number`) · `logo` · `sweat_drop`
+
+## Example Characters
+
+### F1 Driver (e.g., Piastri)
+
+```json
+{
+  "colors": {
+    "outfit": [255, 135, 32],
+    "outfit_dark": [220, 110, 20],
+    "outfit_light": [255, 170, 80],
+    "hair": [120, 80, 40],
+    "accent": [30, 30, 30]
+  },
+  "features": {
+    "headgear": "cap",
+    "number": "81",
+    "extras": ["logo"]
+  }
+}
+```
+
+### Anime Character (e.g., Gojo Satoru)
+
+```json
+{
+  "colors": {
+    "outfit": [30, 30, 50],
+    "outfit_dark": [20, 20, 35],
+    "outfit_light": [60, 60, 80],
+    "hair": [230, 230, 250],
+    "accent": [100, 180, 255]
+  },
+  "features": {
+    "headgear": "none",
+    "hair_style": "spiky",
+    "extras": ["glasses"]
+  }
+}
+```
+
+### Animal (e.g., Shiba Inu)
+
+```json
+{
+  "colors": {
+    "outfit": [220, 170, 100],
+    "outfit_dark": [180, 130, 70],
+    "outfit_light": [240, 200, 140],
+    "hair": [220, 170, 100]
+  },
+  "features": {
+    "headgear": "ears",
+    "extras": ["tail"]
+  }
+}
+```
+
+## Troubleshooting
+
+- **Pet not showing**: Click Refresh in Settings → Appearance → Pet Companion
+- **Colors look wrong**: Check that RGB values are tuples, not hex strings
+- **Spritesheet too large**: Must be under 5 MB (webp lossless usually ~8–50 KB)
+- **Animation jittery**: Ensure all 8 frames per row are visually distinct but not jarring

--- a/.qwen/skills/desktop-pet/scripts/gen_spritesheet.py
+++ b/.qwen/skills/desktop-pet/scripts/gen_spritesheet.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+"""
+Desktop Pet Spritesheet Generator for OpenWork.
+
+Generates a 1536×1872 pixel-art chibi spritesheet (8 cols × 9 rows, 192×208 px cells)
+customized via a JSON config describing colors, headgear, and features.
+
+Usage:
+  python3 gen_spritesheet.py --output ~/.qwen/pets/mychar/spritesheet.webp --config '{...}'
+  python3 gen_spritesheet.py --output out.webp --config-file config.json
+"""
+
+import argparse
+import json
+import sys
+import math
+
+try:
+    from PIL import Image, ImageDraw, ImageFont
+except ImportError:
+    print("ERROR: Pillow is required. Install with: pip3 install Pillow")
+    sys.exit(1)
+
+# --- Atlas layout ---
+COLS, ROWS = 8, 9
+CW, CH = 192, 208
+W, H = COLS * CW, ROWS * CH
+
+# --- Default color palette (Qwen capybara-like neutral) ---
+DEFAULT_COLORS = {
+    "outfit": [100, 120, 180],
+    "outfit_dark": [70, 85, 140],
+    "outfit_light": [140, 160, 210],
+    "skin": [255, 218, 185],
+    "skin_dark": [230, 190, 155],
+    "hair": [80, 55, 35],
+    "hair_light": [110, 80, 55],
+    "accent": [30, 30, 30],
+    "shoe": [50, 50, 50],
+    "eye": [50, 70, 90],
+    "eye_white": [245, 245, 245],
+    "blush": [255, 160, 140],
+    "mouth": [180, 80, 80],
+}
+
+DEFAULT_FEATURES = {
+    "headgear": "none",
+    "extras": [],
+    "number": "",
+    "hair_style": "short",
+    "helmet_color": None,
+}
+
+def tuple_color(c):
+    if isinstance(c, list):
+        return tuple(c)
+    if isinstance(c, str) and c.startswith("#"):
+        h = c.lstrip("#")
+        return tuple(int(h[i:i+2], 16) for i in (0, 2, 4))
+    return c
+
+def darken(color, amount=40):
+    return tuple(max(0, c - amount) for c in color[:3])
+
+def lighten(color, amount=40):
+    return tuple(min(255, c + amount) for c in color[:3])
+
+def fill_rect(draw, x, y, w, h, color):
+    draw.rectangle([x, y, x + w - 1, y + h - 1], fill=color)
+
+
+def draw_headgear(draw, hx, hy, s, colors, features, flip=False):
+    """Draw headgear on top of the head."""
+    hg = features.get("headgear", "none")
+    outfit = colors["outfit"]
+    outfit_dark = colors["outfit_dark"]
+    helmet_c = tuple_color(features.get("helmet_color") or outfit)
+
+    if hg == "cap":
+        cap_y = hy - 7 * s
+        fill_rect(draw, hx - 2*s, cap_y, 24*s, 5*s, outfit)
+        fill_rect(draw, hx + 2*s, cap_y - 2*s, 16*s, 3*s, outfit)
+        fill_rect(draw, hx + 4*s, cap_y - 3*s, 12*s, 2*s, outfit_dark)
+        if not flip:
+            fill_rect(draw, hx - 4*s, cap_y + 4*s, 26*s, 2*s, outfit_dark)
+        else:
+            fill_rect(draw, hx - 2*s, cap_y + 4*s, 26*s, 2*s, outfit_dark)
+        fill_rect(draw, hx + 7*s, cap_y + s, 6*s, 2*s, colors["accent"])
+
+    elif hg == "helmet":
+        cap_y = hy - 8 * s
+        fill_rect(draw, hx - 3*s, cap_y, 26*s, 8*s, helmet_c)
+        fill_rect(draw, hx + 2*s, cap_y - 2*s, 16*s, 3*s, helmet_c)
+        fill_rect(draw, hx + 4*s, cap_y - 3*s, 12*s, 2*s, darken(helmet_c, 20))
+        fill_rect(draw, hx, cap_y + 5*s, 20*s, 3*s, darken(helmet_c, 60))
+        fill_rect(draw, hx + 2*s, cap_y + 6*s, 16*s, s, lighten(helmet_c, 60))
+
+    elif hg == "hat":
+        cap_y = hy - 6 * s
+        fill_rect(draw, hx - 4*s, cap_y + 3*s, 28*s, 3*s, outfit_dark)
+        fill_rect(draw, hx + 2*s, cap_y - 2*s, 16*s, 6*s, outfit)
+        fill_rect(draw, hx + 4*s, cap_y - 3*s, 12*s, 2*s, outfit_dark)
+
+    elif hg == "hood":
+        cap_y = hy - 5 * s
+        fill_rect(draw, hx - 3*s, cap_y, 26*s, 4*s, outfit)
+        fill_rect(draw, hx - 4*s, cap_y + 2*s, 4*s, 8*s, outfit)
+        fill_rect(draw, hx + 20*s, cap_y + 2*s, 4*s, 8*s, outfit)
+        fill_rect(draw, hx + 4*s, cap_y - 2*s, 12*s, 3*s, outfit_dark)
+
+    elif hg == "crown":
+        cap_y = hy - 8 * s
+        gold = (255, 215, 0)
+        gold_dark = (200, 170, 0)
+        fill_rect(draw, hx + 2*s, cap_y + 2*s, 16*s, 4*s, gold)
+        fill_rect(draw, hx + 2*s, cap_y, 3*s, 3*s, gold)
+        fill_rect(draw, hx + 8*s, cap_y - s, 4*s, 3*s, gold)
+        fill_rect(draw, hx + 15*s, cap_y, 3*s, 3*s, gold)
+        fill_rect(draw, hx + 3*s, cap_y + s, s, s, (200, 50, 50))
+        fill_rect(draw, hx + 9*s, cap_y, 2*s, s, (50, 150, 200))
+        fill_rect(draw, hx + 16*s, cap_y + s, s, s, (50, 200, 50))
+        fill_rect(draw, hx + 2*s, cap_y + 5*s, 16*s, s, gold_dark)
+
+    elif hg == "horns":
+        horn_c = (80, 60, 50)
+        fill_rect(draw, hx - 2*s, hy - 6*s, 3*s, 8*s, horn_c)
+        fill_rect(draw, hx - 3*s, hy - 8*s, 2*s, 3*s, horn_c)
+        fill_rect(draw, hx + 19*s, hy - 6*s, 3*s, 8*s, horn_c)
+        fill_rect(draw, hx + 21*s, hy - 8*s, 2*s, 3*s, horn_c)
+
+    elif hg == "ears":
+        hair_c = colors["hair"]
+        inner = colors["skin"]
+        fill_rect(draw, hx - 3*s, hy - 8*s, 5*s, 8*s, hair_c)
+        fill_rect(draw, hx - 2*s, hy - 6*s, 3*s, 5*s, inner)
+        fill_rect(draw, hx + 18*s, hy - 8*s, 5*s, 8*s, hair_c)
+        fill_rect(draw, hx + 19*s, hy - 6*s, 3*s, 5*s, inner)
+
+    elif hg == "halo":
+        halo_c = (255, 255, 200)
+        cap_y = hy - 10 * s
+        fill_rect(draw, hx + 3*s, cap_y, 14*s, 2*s, halo_c)
+        fill_rect(draw, hx + 2*s, cap_y + s, s, s, halo_c)
+        fill_rect(draw, hx + 17*s, cap_y + s, s, s, halo_c)
+        fill_rect(draw, hx + 3*s, cap_y + 2*s, 14*s, s, darken(halo_c, 30))
+
+    elif hg == "headband":
+        fill_rect(draw, hx - 2*s, hy - 2*s, 24*s, 2*s, colors["accent"])
+        fill_rect(draw, hx + 18*s, hy - 2*s, 4*s, 6*s, colors["accent"])
+
+
+def draw_extras(draw, cx, cy, s, colors, features, bx, by, expression):
+    """Draw extra features like glasses, scarf, tail, wings."""
+    extras = features.get("extras", [])
+    hx = cx - 10 * s
+    hy = cy - 16 * s
+
+    if "glasses" in extras:
+        ey = hy + 8 * s
+        glass_c = (60, 60, 80)
+        fill_rect(draw, hx + 3*s, ey - s, 6*s, 5*s, glass_c)
+        fill_rect(draw, hx + 4*s, ey, 4*s, 3*s, (200, 220, 240))
+        fill_rect(draw, hx + 11*s, ey - s, 6*s, 5*s, glass_c)
+        fill_rect(draw, hx + 12*s, ey, 4*s, 3*s, (200, 220, 240))
+        fill_rect(draw, hx + 9*s, ey + s, 2*s, s, glass_c)
+
+    if "scarf" in extras:
+        scarf_c = lighten(colors["outfit"], 30)
+        fill_rect(draw, bx + 3*s, by - 2*s, 10*s, 3*s, scarf_c)
+        fill_rect(draw, bx + 4*s, by + s, 3*s, 6*s, scarf_c)
+
+    if "tail" in extras:
+        tail_c = colors["hair"]
+        fill_rect(draw, bx + 16*s, by + 10*s, 3*s, 3*s, tail_c)
+        fill_rect(draw, bx + 18*s, by + 8*s, 3*s, 3*s, tail_c)
+        fill_rect(draw, bx + 20*s, by + 6*s, 3*s, 3*s, tail_c)
+        fill_rect(draw, bx + 21*s, by + 4*s, 2*s, 3*s, tail_c)
+
+    if "wings" in extras:
+        wing_c = (240, 240, 255)
+        wing_dark = (200, 200, 220)
+        fill_rect(draw, bx - 6*s, by + 2*s, 5*s, 8*s, wing_c)
+        fill_rect(draw, bx - 8*s, by + 4*s, 3*s, 5*s, wing_c)
+        fill_rect(draw, bx - 5*s, by + 3*s, 3*s, 5*s, wing_dark)
+        fill_rect(draw, bx + 17*s, by + 2*s, 5*s, 8*s, wing_c)
+        fill_rect(draw, bx + 21*s, by + 4*s, 3*s, 5*s, wing_c)
+        fill_rect(draw, bx + 18*s, by + 3*s, 3*s, 5*s, wing_dark)
+
+    if "sweat_drop" in extras and expression in ("waiting", "failed"):
+        fill_rect(draw, hx + 18*s, hy + 2*s, 2*s, 3*s, (150, 200, 255))
+        fill_rect(draw, hx + 18*s, hy + s, s, s, (150, 200, 255))
+
+
+def draw_character(draw, cx, cy, colors, features, scale=3, flip=False,
+                   arm_angle=0, leg_offset=0, body_tilt=0, head_tilt=0,
+                   expression="normal", arm_wave=False, jump_y=0, collapsed=False):
+    """Draw a chibi character centered at (cx, cy)."""
+    s = scale
+    cy += jump_y
+
+    skin = colors["skin"]
+    skin_dark = colors["skin_dark"]
+    hair_c = colors["hair"]
+    hair_light = colors.get("hair_light", lighten(hair_c, 30))
+    outfit = colors["outfit"]
+    outfit_dark = colors["outfit_dark"]
+    outfit_light = colors["outfit_light"]
+    eye_c = colors["eye"]
+    eye_w = colors["eye_white"]
+    blush_c = colors["blush"]
+    mouth_c = colors.get("mouth", darken(skin, 80))
+    accent_c = colors["accent"]
+    shoe_c = colors["shoe"]
+
+    # --- LEGS ---
+    leg_spread = 4 * s
+    leg_left_x = cx - leg_spread - 2*s + body_tilt
+    leg_right_x = cx + leg_spread - 2*s + body_tilt
+
+    if collapsed:
+        fill_rect(draw, leg_left_x, cy + 18*s, 5*s, 6*s, outfit_dark)
+        fill_rect(draw, leg_right_x, cy + 18*s, 5*s, 6*s, outfit_dark)
+        fill_rect(draw, leg_left_x, cy + 24*s, 5*s, 2*s, shoe_c)
+        fill_rect(draw, leg_right_x, cy + 24*s, 5*s, 2*s, shoe_c)
+    else:
+        fill_rect(draw, leg_left_x + leg_offset, cy + 16*s, 5*s, 10*s, outfit_dark)
+        fill_rect(draw, leg_right_x - leg_offset, cy + 16*s, 5*s, 10*s, outfit_dark)
+        fill_rect(draw, leg_left_x + leg_offset - s, cy + 26*s, 7*s, 3*s, shoe_c)
+        fill_rect(draw, leg_right_x - leg_offset - s, cy + 26*s, 7*s, 3*s, shoe_c)
+
+    # --- BODY ---
+    bx = cx - 8*s + body_tilt
+    by = cy + 2*s
+    fill_rect(draw, bx, by, 16*s, 16*s, outfit)
+    fill_rect(draw, bx + s, by + s, 14*s, 2*s, outfit_light)
+    fill_rect(draw, bx + 5*s, by - s, 6*s, 2*s, (255, 255, 255))
+
+    # Number on chest
+    num = features.get("number", "")
+    if num:
+        try:
+            font_size = max(5 * s, 8)
+            font = ImageFont.truetype("/System/Library/Fonts/Helvetica.ttc", font_size)
+        except Exception:
+            font = ImageFont.load_default()
+        bbox = draw.textbbox((0, 0), num, font=font)
+        tw = bbox[2] - bbox[0]
+        th = bbox[3] - bbox[1]
+        tx = bx + (16*s - tw) // 2
+        ty = by + (14*s - th) // 2 + s
+        draw.text((tx, ty), num, fill=accent_c, font=font)
+
+    # Logo area
+    if "logo" in features.get("extras", []) and not num:
+        fill_rect(draw, bx + 5*s, by + 5*s, 6*s, 4*s, accent_c)
+        fill_rect(draw, bx + 6*s, by + 6*s, 4*s, 2*s, outfit_light)
+
+    # --- ARMS ---
+    arm_y = by + 3*s
+    left_arm_x = bx - 5*s
+    right_arm_x = bx + 16*s
+
+    if arm_wave:
+        fill_rect(draw, left_arm_x, arm_y + 2*s, 5*s, 8*s, outfit)
+        fill_rect(draw, left_arm_x - s, arm_y + 10*s, 5*s, 4*s, skin)
+        fill_rect(draw, right_arm_x, arm_y - 8*s, 5*s, 10*s, outfit)
+        fill_rect(draw, right_arm_x, arm_y - 10*s, 6*s, 4*s, skin)
+    elif arm_angle > 0:
+        fill_rect(draw, left_arm_x - arm_angle, arm_y, 5*s, 10*s, outfit)
+        fill_rect(draw, left_arm_x - arm_angle - s, arm_y + 10*s, 5*s, 4*s, skin)
+        fill_rect(draw, right_arm_x + arm_angle, arm_y, 5*s, 10*s, outfit)
+        fill_rect(draw, right_arm_x + arm_angle + s, arm_y + 10*s, 5*s, 4*s, skin)
+    else:
+        fill_rect(draw, left_arm_x, arm_y, 5*s, 10*s, outfit)
+        fill_rect(draw, left_arm_x - s, arm_y + 10*s, 5*s, 4*s, skin)
+        fill_rect(draw, right_arm_x, arm_y, 5*s, 10*s, outfit)
+        fill_rect(draw, right_arm_x + s, arm_y + 10*s, 5*s, 4*s, skin)
+
+    # --- Scarf (drawn between body and head) ---
+    draw_extras(draw, cx, cy, s, colors, features, bx, by, expression)
+
+    # --- HEAD ---
+    hx = cx - 10*s + head_tilt
+    hy = cy - 16*s
+
+    # Hair back
+    fill_rect(draw, hx - s, hy - 2*s, 22*s, 6*s, hair_c)
+    # Head shape
+    fill_rect(draw, hx, hy, 20*s, 18*s, skin)
+
+    # Hair style
+    hair_style = features.get("hair_style", "short")
+    if hair_style == "long":
+        fill_rect(draw, hx - s, hy - 4*s, 22*s, 6*s, hair_c)
+        fill_rect(draw, hx + 2*s, hy - 5*s, 16*s, 3*s, hair_c)
+        fill_rect(draw, hx + 4*s, hy - 6*s, 12*s, 2*s, hair_light)
+        fill_rect(draw, hx - 2*s, hy, 3*s, 16*s, hair_c)
+        fill_rect(draw, hx + 19*s, hy, 3*s, 16*s, hair_c)
+        fill_rect(draw, hx - 3*s, hy + 14*s, 4*s, 4*s, hair_c)
+        fill_rect(draw, hx + 19*s, hy + 14*s, 4*s, 4*s, hair_c)
+    elif hair_style == "spiky":
+        fill_rect(draw, hx - s, hy - 4*s, 22*s, 6*s, hair_c)
+        fill_rect(draw, hx + s, hy - 7*s, 4*s, 4*s, hair_c)
+        fill_rect(draw, hx + 6*s, hy - 8*s, 4*s, 5*s, hair_c)
+        fill_rect(draw, hx + 11*s, hy - 7*s, 4*s, 4*s, hair_c)
+        fill_rect(draw, hx + 16*s, hy - 6*s, 3*s, 3*s, hair_c)
+        fill_rect(draw, hx - 2*s, hy, 3*s, 10*s, hair_c)
+        fill_rect(draw, hx + 19*s, hy, 3*s, 10*s, hair_c)
+    elif hair_style == "ponytail":
+        fill_rect(draw, hx - s, hy - 4*s, 22*s, 6*s, hair_c)
+        fill_rect(draw, hx + 2*s, hy - 5*s, 16*s, 3*s, hair_c)
+        fill_rect(draw, hx - 2*s, hy, 3*s, 10*s, hair_c)
+        fill_rect(draw, hx + 19*s, hy, 3*s, 10*s, hair_c)
+        fill_rect(draw, hx + 18*s, hy + 8*s, 3*s, 3*s, hair_c)
+        fill_rect(draw, hx + 19*s, hy + 10*s, 3*s, 8*s, hair_c)
+        fill_rect(draw, hx + 20*s, hy + 16*s, 2*s, 4*s, hair_light)
+    elif hair_style == "bald":
+        fill_rect(draw, hx + 2*s, hy - 2*s, 16*s, 2*s, skin_dark)
+    else:  # short (default)
+        fill_rect(draw, hx - s, hy - 4*s, 22*s, 6*s, hair_c)
+        fill_rect(draw, hx + 2*s, hy - 5*s, 16*s, 3*s, hair_c)
+        fill_rect(draw, hx + 4*s, hy - 6*s, 12*s, 2*s, hair_light)
+        fill_rect(draw, hx - 2*s, hy, 3*s, 10*s, hair_c)
+        fill_rect(draw, hx + 19*s, hy, 3*s, 10*s, hair_c)
+
+    # --- FACE ---
+    ey = hy + 8*s
+
+    if expression == "blink":
+        fill_rect(draw, hx + 4*s, ey + s, 4*s, s, eye_c)
+        fill_rect(draw, hx + 12*s, ey + s, 4*s, s, eye_c)
+    elif expression == "happy":
+        fill_rect(draw, hx + 4*s, ey, 4*s, s, eye_c)
+        fill_rect(draw, hx + 3*s, ey + s, s, s, eye_c)
+        fill_rect(draw, hx + 8*s, ey + s, s, s, eye_c)
+        fill_rect(draw, hx + 12*s, ey, 4*s, s, eye_c)
+        fill_rect(draw, hx + 11*s, ey + s, s, s, eye_c)
+        fill_rect(draw, hx + 16*s, ey + s, s, s, eye_c)
+        fill_rect(draw, hx + 7*s, ey + 5*s, 6*s, s, mouth_c)
+        fill_rect(draw, hx + 6*s, ey + 4*s, s, s, mouth_c)
+        fill_rect(draw, hx + 13*s, ey + 4*s, s, s, mouth_c)
+        fill_rect(draw, hx + 2*s, ey + 3*s, 3*s, 2*s, blush_c)
+        fill_rect(draw, hx + 15*s, ey + 3*s, 3*s, 2*s, blush_c)
+    elif expression == "sad":
+        fill_rect(draw, hx + 4*s, ey, 4*s, 3*s, eye_w)
+        fill_rect(draw, hx + 5*s, ey + s, 2*s, 2*s, eye_c)
+        fill_rect(draw, hx + 12*s, ey, 4*s, 3*s, eye_w)
+        fill_rect(draw, hx + 13*s, ey + s, 2*s, 2*s, eye_c)
+        fill_rect(draw, hx + 3*s, ey - 2*s, 5*s, s, hair_c)
+        fill_rect(draw, hx + 12*s, ey - 2*s, 5*s, s, hair_c)
+        fill_rect(draw, hx + 8*s, ey + 5*s, 4*s, s, mouth_c)
+        fill_rect(draw, hx + 7*s, ey + 6*s, s, s, mouth_c)
+        fill_rect(draw, hx + 12*s, ey + 6*s, s, s, mouth_c)
+    elif expression == "surprised":
+        fill_rect(draw, hx + 3*s, ey - s, 5*s, 4*s, eye_w)
+        fill_rect(draw, hx + 4*s, ey, 3*s, 3*s, eye_c)
+        fill_rect(draw, hx + 5*s, ey + s, s, s, (255, 255, 255))
+        fill_rect(draw, hx + 12*s, ey - s, 5*s, 4*s, eye_w)
+        fill_rect(draw, hx + 13*s, ey, 3*s, 3*s, eye_c)
+        fill_rect(draw, hx + 14*s, ey + s, s, s, (255, 255, 255))
+        fill_rect(draw, hx + 8*s, ey + 4*s, 4*s, 3*s, mouth_c)
+        fill_rect(draw, hx + 9*s, ey + 5*s, 2*s, s, (180, 80, 80))
+    elif expression == "determined":
+        fill_rect(draw, hx + 4*s, ey, 4*s, 3*s, eye_w)
+        fill_rect(draw, hx + 6*s, ey + s, 2*s, 2*s, eye_c)
+        fill_rect(draw, hx + 12*s, ey, 4*s, 3*s, eye_w)
+        fill_rect(draw, hx + 14*s, ey + s, 2*s, 2*s, eye_c)
+        fill_rect(draw, hx + 3*s, ey - 2*s, 6*s, s, hair_c)
+        fill_rect(draw, hx + 11*s, ey - 2*s, 6*s, s, hair_c)
+        fill_rect(draw, hx + 8*s, ey + 5*s, 4*s, s, mouth_c)
+    else:  # normal
+        fill_rect(draw, hx + 4*s, ey, 4*s, 3*s, eye_w)
+        fill_rect(draw, hx + 5*s, ey + s, 2*s, 2*s, eye_c)
+        fill_rect(draw, hx + 5*s, ey + s, s, s, (255, 255, 255))
+        fill_rect(draw, hx + 12*s, ey, 4*s, 3*s, eye_w)
+        fill_rect(draw, hx + 13*s, ey + s, 2*s, 2*s, eye_c)
+        fill_rect(draw, hx + 13*s, ey + s, s, s, (255, 255, 255))
+        fill_rect(draw, hx + 8*s, ey + 5*s, 4*s, s, mouth_c)
+        fill_rect(draw, hx + 7*s, ey + 4*s, s, s, mouth_c)
+        fill_rect(draw, hx + 12*s, ey + 4*s, s, s, mouth_c)
+
+    # --- HEADGEAR ---
+    draw_headgear(draw, hx, hy, s, colors, features, flip)
+
+
+def gen_row(sheet, row, colors, features, frame_configs):
+    """Generate one animation row from frame configs."""
+    for col, fc in enumerate(frame_configs):
+        img = Image.new("RGBA", (CW, CH), (0, 0, 0, 0))
+        d = ImageDraw.Draw(img)
+        draw_character(
+            d, CW // 2 + fc.get("dx", 0), CH // 2 + 20,
+            colors, features, scale=3,
+            flip=fc.get("flip", False),
+            arm_angle=fc.get("arm_angle", 0),
+            leg_offset=fc.get("leg_offset", 0),
+            body_tilt=fc.get("body_tilt", 0),
+            head_tilt=fc.get("head_tilt", 0),
+            expression=fc.get("expression", "normal"),
+            arm_wave=fc.get("arm_wave", False),
+            jump_y=fc.get("jump_y", 0),
+            collapsed=fc.get("collapsed", False),
+        )
+        sheet.paste(img, (col * CW, row * CH), img)
+
+
+def gen_all_animations(sheet, colors, features):
+    """Generate all 9 animation rows."""
+
+    # Row 0: idle
+    gen_row(sheet, 0, colors, features, [
+        {"jump_y": 0, "expression": "normal"},
+        {"jump_y": -1, "expression": "normal"},
+        {"jump_y": -2, "expression": "blink"},
+        {"jump_y": -1, "expression": "normal"},
+        {"jump_y": 0, "expression": "normal"},
+        {"jump_y": -1, "expression": "normal"},
+        {"jump_y": 0, "expression": "normal"},
+        {"jump_y": 0, "expression": "blink"},
+    ])
+
+    # Row 1: running right
+    gen_row(sheet, 1, colors, features, [
+        {"leg_offset": 0, "body_tilt": 0, "head_tilt": 0, "arm_angle": 0, "jump_y": 0, "dx": 8},
+        {"leg_offset": 4, "body_tilt": 1, "head_tilt": 1, "arm_angle": 2, "jump_y": -2, "dx": 8},
+        {"leg_offset": 0, "body_tilt": 2, "head_tilt": 2, "arm_angle": 3, "jump_y": -3, "dx": 8},
+        {"leg_offset": -4, "body_tilt": 1, "head_tilt": 1, "arm_angle": 2, "jump_y": -2, "dx": 8},
+        {"leg_offset": 0, "body_tilt": 0, "head_tilt": 0, "arm_angle": 0, "jump_y": 0, "dx": 8},
+        {"leg_offset": 4, "body_tilt": -1, "head_tilt": -1, "arm_angle": -2, "jump_y": -2, "dx": 8},
+        {"leg_offset": 0, "body_tilt": -2, "head_tilt": -2, "arm_angle": -3, "jump_y": -3, "dx": 8},
+        {"leg_offset": -4, "body_tilt": -1, "head_tilt": -1, "arm_angle": -2, "jump_y": -2, "dx": 8},
+    ])
+
+    # Row 2: running left
+    gen_row(sheet, 2, colors, features, [
+        {"leg_offset": 0, "body_tilt": 0, "head_tilt": 0, "arm_angle": 0, "jump_y": 0, "flip": True, "dx": -8},
+        {"leg_offset": 4, "body_tilt": -1, "head_tilt": -1, "arm_angle": 2, "jump_y": -2, "flip": True, "dx": -8},
+        {"leg_offset": 0, "body_tilt": -2, "head_tilt": -2, "arm_angle": 3, "jump_y": -3, "flip": True, "dx": -8},
+        {"leg_offset": -4, "body_tilt": -1, "head_tilt": -1, "arm_angle": 2, "jump_y": -2, "flip": True, "dx": -8},
+        {"leg_offset": 0, "body_tilt": 0, "head_tilt": 0, "arm_angle": 0, "jump_y": 0, "flip": True, "dx": -8},
+        {"leg_offset": 4, "body_tilt": 1, "head_tilt": 1, "arm_angle": -2, "jump_y": -2, "flip": True, "dx": -8},
+        {"leg_offset": 0, "body_tilt": 2, "head_tilt": 2, "arm_angle": -3, "jump_y": -3, "flip": True, "dx": -8},
+        {"leg_offset": -4, "body_tilt": 1, "head_tilt": 1, "arm_angle": -2, "jump_y": -2, "flip": True, "dx": -8},
+    ])
+
+    # Row 3: waving
+    gen_row(sheet, 3, colors, features, [
+        {"arm_wave": True, "jump_y": 0, "expression": "happy"},
+        {"arm_wave": False, "jump_y": -1, "expression": "happy"},
+        {"arm_wave": True, "jump_y": 0, "expression": "happy"},
+        {"arm_wave": False, "jump_y": -1, "expression": "happy"},
+        {"arm_wave": True, "jump_y": 0, "expression": "happy"},
+        {"arm_wave": False, "jump_y": 0, "expression": "happy"},
+        {"arm_wave": True, "jump_y": 0, "expression": "normal"},
+        {"arm_wave": False, "jump_y": 0, "expression": "normal"},
+    ])
+
+    # Row 4: jumping
+    gen_row(sheet, 4, colors, features, [
+        {"jump_y": 0, "arm_angle": 0, "expression": "normal"},
+        {"jump_y": -8, "arm_angle": 3, "expression": "happy"},
+        {"jump_y": -20, "arm_angle": 5, "expression": "happy"},
+        {"jump_y": -30, "arm_angle": 5, "expression": "happy"},
+        {"jump_y": -35, "arm_angle": 5, "expression": "happy"},
+        {"jump_y": -25, "arm_angle": 3, "expression": "happy"},
+        {"jump_y": -10, "arm_angle": 0, "expression": "happy"},
+        {"jump_y": 0, "arm_angle": 0, "expression": "normal"},
+    ])
+
+    # Row 5: failed
+    gen_row(sheet, 5, colors, features, [
+        {"body_tilt": 0, "head_tilt": 0, "expression": "sad"},
+        {"body_tilt": -1, "head_tilt": -2, "expression": "sad"},
+        {"body_tilt": -2, "head_tilt": -4, "expression": "sad"},
+        {"body_tilt": -3, "head_tilt": -6, "expression": "sad"},
+        {"body_tilt": -3, "head_tilt": -6, "expression": "sad", "collapsed": True},
+        {"body_tilt": -2, "head_tilt": -4, "expression": "sad", "collapsed": True},
+        {"body_tilt": -1, "head_tilt": -2, "expression": "sad"},
+        {"body_tilt": 0, "head_tilt": 0, "expression": "sad"},
+    ])
+
+    # Row 6: waiting
+    gen_row(sheet, 6, colors, features, [
+        {"jump_y": 0, "head_tilt": 0, "expression": "normal"},
+        {"jump_y": -1, "head_tilt": 0, "expression": "normal"},
+        {"jump_y": 0, "head_tilt": 2, "expression": "normal"},
+        {"jump_y": -1, "head_tilt": 0, "expression": "normal"},
+        {"jump_y": 0, "head_tilt": -2, "expression": "blink"},
+        {"jump_y": 0, "head_tilt": 0, "expression": "blink"},
+        {"jump_y": 0, "head_tilt": 0, "expression": "normal"},
+        {"jump_y": 0, "head_tilt": 0, "expression": "normal"},
+    ])
+
+    # Row 7: running (generic, same as row 1)
+    gen_row(sheet, 7, colors, features, [
+        {"leg_offset": 0, "body_tilt": 0, "head_tilt": 0, "arm_angle": 0, "jump_y": 0, "dx": 8},
+        {"leg_offset": 4, "body_tilt": 1, "head_tilt": 1, "arm_angle": 2, "jump_y": -2, "dx": 8},
+        {"leg_offset": 0, "body_tilt": 2, "head_tilt": 2, "arm_angle": 3, "jump_y": -3, "dx": 8},
+        {"leg_offset": -4, "body_tilt": 1, "head_tilt": 1, "arm_angle": 2, "jump_y": -2, "dx": 8},
+        {"leg_offset": 0, "body_tilt": 0, "head_tilt": 0, "arm_angle": 0, "jump_y": 0, "dx": 8},
+        {"leg_offset": 4, "body_tilt": -1, "head_tilt": -1, "arm_angle": -2, "jump_y": -2, "dx": 8},
+        {"leg_offset": 0, "body_tilt": -2, "head_tilt": -2, "arm_angle": -3, "jump_y": -3, "dx": 8},
+        {"leg_offset": -4, "body_tilt": -1, "head_tilt": -1, "arm_angle": -2, "jump_y": -2, "dx": 8},
+    ])
+
+    # Row 8: review/thinking
+    gen_row(sheet, 8, colors, features, [
+        {"head_tilt": 0, "arm_angle": 2, "expression": "surprised"},
+        {"head_tilt": 2, "arm_angle": 2, "expression": "surprised", "jump_y": -1},
+        {"head_tilt": 4, "arm_angle": 2, "expression": "surprised", "jump_y": -1},
+        {"head_tilt": 4, "arm_angle": 0, "expression": "normal"},
+        {"head_tilt": 2, "arm_angle": 0, "expression": "happy"},
+        {"head_tilt": 0, "arm_angle": 0, "expression": "happy"},
+        {"head_tilt": 0, "arm_angle": 0, "expression": "normal"},
+        {"head_tilt": 0, "arm_angle": 0, "expression": "normal"},
+    ])
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate desktop pet spritesheet")
+    parser.add_argument("--output", "-o", required=True, help="Output .webp file path")
+    parser.add_argument("--config", "-c", type=str, help="JSON config string")
+    parser.add_argument("--config-file", "-f", help="Path to JSON config file")
+    args = parser.parse_args()
+
+    config = {}
+    if args.config_file:
+        with open(args.config_file) as f:
+            config = json.load(f)
+    elif args.config:
+        config = json.loads(args.config)
+
+    # Merge colors with defaults (convert all to tuples)
+    colors = {k: tuple_color(v) for k, v in DEFAULT_COLORS.items()}
+    for k, v in config.get("colors", {}).items():
+        colors[k] = tuple_color(v)
+
+    # Auto-derive missing colors
+    if "hair_light" not in config.get("colors", {}):
+        colors["hair_light"] = lighten(colors["hair"], 30)
+    if "mouth" not in config.get("colors", {}):
+        colors["mouth"] = darken(colors["skin"], 80)
+
+    # Merge features with defaults
+    features = dict(DEFAULT_FEATURES)
+    features.update(config.get("features", {}))
+
+    sheet = Image.new("RGBA", (W, H), (0, 0, 0, 0))
+    gen_all_animations(sheet, colors, features)
+
+    import os
+    os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+    sheet.save(args.output, "WEBP", quality=95, lossless=True)
+    print(f"Saved spritesheet to {args.output} ({sheet.size[0]}x{sheet.size[1]})")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this PR does

Adds a bundled `desktop-pet` skill under `.qwen/skills/desktop-pet/` that generates chibi pixel-art desktop pet companions for any character the user names — F1 drivers, anime characters, celebrities, fictional characters, animals, etc. The skill includes a `SKILL.md` with agent instructions (character research → color palette → spritesheet generation → `pet.json` → activation) and a `scripts/gen_spritesheet.py` parameterized generator that produces a 1536×1872 RGBA spritesheet (8 cols × 9 rows, 192×208 px cells) compatible with the existing pet animation system.

## Why it's needed

Qwen Code's floating desktop pet is a delightful companion feature, but users are limited to the built-in Qwen capybara. The custom pet system (`~/.qwen/pets/`) already supports loading user-created spritesheets via `pet.json` manifests, but there is no easy way for users to create one. This skill bridges that gap by letting users simply name a character, and the agent handles everything from visual research to final activation end-to-end. It turns a multi-step technical process (researching colors, generating a properly-formatted sprite atlas, writing a manifest) into a single conversational interaction.

## Reviewer Test Plan

### How to verify

1. Invoke the skill: in Qwen Code, type `/desktop-pet` or say "I want Piastri as my desktop pet"
2. Confirm the agent creates `~/.qwen/pets/piastri/spritesheet.webp` (1536×1872 RGBA webp) and `~/.qwen/pets/piastri/pet.json`
3. Open Qwen Code Settings → Appearance → Pet Companion, click Refresh, confirm "Piastri" appears in the list
4. Select it and verify the animated pet renders in the floating window
5. Repeat with a different character type (e.g., an anime character with spiky hair + glasses, or an animal with ears + tail) to exercise different headgear/features

### Evidence (Before & After)

N/A — this is a new skill addition, not a change to existing UI.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  |   ✅   |
| 🪟 Windows |   ⚠️   |
|  🐧 Linux  |   ⚠️   |

Tested locally on macOS with multiple character types: F1 driver (Piastri — McLaren papaya + cap + #81), anime character (Gojo Satoru — dark outfit + spiky white hair + glasses), animal (Shiba Inu — fur colors + ears + tail), racing (helmet + #44), fantasy (crown + long hair + logo). All produce valid spritesheets that load correctly via the custom pet system. Windows and Linux not tested locally but the Python/Pillow dependency is cross-platform.

### Environment (optional)

- macOS 15+, Python 3.9+, Pillow (installed via `pip3 install Pillow`)

## Risk & Scope

- Main risk or tradeoff: Adds a Python dependency (Pillow) — mitigated by the skill checking for availability and reporting clearly if missing. Pillow is already a common package on most developer machines.
- Not validated / out of scope: Windows and Linux testing; complex character features beyond the current 10 headgear types and 5 hair styles.
- Breaking changes / migration notes: None — this is a purely additive skill with no changes to existing code.

## Linked Issues

Closes #4807

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

在 `.qwen/skills/desktop-pet/` 下新增了一个内置的 `desktop-pet` 技能，可以为用户指定的任何角色（F1 车手、动漫角色、名人、虚构角色、动物等）生成 Q版像素风格的桌面宠物。技能包含 `SKILL.md`（Agent 指令：角色调研 → 配色设计 → 精灵表生成 → `pet.json` → 激活）以及 `scripts/gen_spritesheet.py`（参数化生成器，输出兼容现有宠物动画系统的 1536×1872 RGBA 精灵表，8列×9行，192×208 像素单元格）。

## 为什么需要

Qwen Code 的浮动桌面宠物是一个很有趣的伴侣功能，但用户只能使用内置的 Qwen 水豚。自定义宠物系统（`~/.qwen/pets/`）已经支持通过 `pet.json` 清单加载用户创建的精灵表，但用户没有简单的方式来制作。这个技能填补了这个空白——用户只需说出角色名字，Agent 就能完成从视觉调研到最终激活的全部工作。它把一个多步骤的技术流程（调研颜色、生成格式正确的精灵图集、编写清单文件）变成了一次简单的对话交互。

## 审阅者测试计划

### 如何验证

1. 调用技能：在 Qwen Code 中输入 `/desktop-pet` 或说"我想要皮亚斯特里当桌宠"
2. 确认 Agent 创建了 `~/.qwen/pets/piastri/spritesheet.webp`（1536×1872 RGBA webp）和 `~/.qwen/pets/piastri/pet.json`
3. 打开 Qwen Code 设置 → 外观 → 宠物伴侣，点击刷新，确认"Piastri"出现在列表中
4. 选择它并验证动画宠物在浮动窗口中正确渲染
5. 用不同类型的角色重复测试（如带尖发+眼镜的动漫角色，或带耳朵+尾巴的动物）以验证不同的头饰/特征

### 证据（前后对比）

不适用——这是新增技能，不涉及现有 UI 变更。

### 测试平台

在 macOS 上本地测试了多种角色类型：F1 车手（皮亚斯特里——迈凯伦木瓜橙 + 帽子 + #81）、动漫角色（五条悟——深色服装 + 白色尖发 + 眼镜）、动物（柴犬——毛色 + 耳朵 + 尾巴）、赛车（头盔 + #44）、奇幻（王冠 + 长发 + 徽标）。全部生成有效的精灵表，可通过自定义宠物系统正确加载。Windows 和 Linux 未本地测试，但 Python/Pillow 依赖是跨平台的。

## 风险与范围

- 主要风险/权衡：新增 Python 依赖（Pillow）——通过技能检查可用性并在缺失时清晰提示来缓解。Pillow 在大多数开发者机器上已是常见包。
- 未验证/不在范围内：Windows 和 Linux 测试；超出当前 10 种头饰和 5 种发型之外的复杂角色特征。
- 破坏性变更/迁移说明：无——这是纯新增技能，不修改现有代码。

## 关联 Issue

Closes #4807

</details>
