### PR TITLE
fix(core): microcompact resumed goal continuations

### DIFF
--- a/packages/core/src/core/client.test.ts
+++ b/packages/core/src/core/client.test.ts
@@ -1895,6 +1895,123 @@ describe('Gemini Client (client.ts)', () => {
       expect(clear).not.toHaveBeenCalled();
       expect(markReadEvictedFromHistory).not.toHaveBeenCalled();
     });
+
+    it('does not microcompact ToolResult submissions', async () => {
+      const { clear, markReadEvictedFromHistory } = mockFileReadCacheStub();
+
+      const { history } = await makeReadFileResponses(6);
+      const setHistory = vi.fn();
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue(history),
+        setHistory,
+      } as unknown as GeminiChat;
+      client['lastApiCompletionTimestamp'] = Date.now() - 90 * 60_000;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'tool-result' }],
+        new AbortController().signal,
+        'prompt-mc-tool-result',
+        { type: SendMessageType.ToolResult },
+      );
+      for await (const _ of stream) {
+        /* drain */
+      }
+
+      expect(setHistory).not.toHaveBeenCalled();
+      expect(clear).not.toHaveBeenCalled();
+      expect(markReadEvictedFromHistory).not.toHaveBeenCalled();
+    });
+
+    it('microcompacts Hook continuations so goal loops do not retain stale tool results', async () => {
+      const { clear, markReadEvictedFromHistory } = mockFileReadCacheStub();
+
+      const { history } = await makeReadFileResponses(6);
+      const setHistory = vi.fn();
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue(history),
+        setHistory,
+      } as unknown as GeminiChat;
+      // A Hook continuation happens immediately after an API response, so the
+      // normal idle gap is too small. It still needs to clear stale tool
+      // results to avoid unbounded /goal growth.
+      client['lastApiCompletionTimestamp'] = Date.now();
+
+      const stream = client.sendMessageStream(
+        [{ text: 'continue' }],
+        new AbortController().signal,
+        'prompt-mc-hook',
+        { type: SendMessageType.Hook },
+      );
+      for await (const _ of stream) {
+        /* drain */
+      }
+
+      expect(setHistory).toHaveBeenCalled();
+      expect(clear).not.toHaveBeenCalled();
+      expect(markReadEvictedFromHistory).toHaveBeenCalledTimes(1);
+    });
+
+    it('microcompacts inherited history on the first post-resume user query', async () => {
+      const { clear, markReadEvictedFromHistory } = mockFileReadCacheStub();
+
+      const { history } = await makeReadFileResponses(6);
+      const setHistory = vi.fn();
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue(history),
+        setHistory,
+      } as unknown as GeminiChat;
+      // A resumed client starts with no in-process completion timestamp even
+      // though the inherited history may already contain large tool results.
+      client['lastApiCompletionTimestamp'] = null;
+
+      const stream = client.sendMessageStream(
+        [{ text: 'continue' }],
+        new AbortController().signal,
+        'prompt-mc-resume-first-query',
+        { type: SendMessageType.UserQuery },
+      );
+      for await (const _ of stream) {
+        /* drain */
+      }
+
+      expect(setHistory).toHaveBeenCalled();
+      expect(clear).not.toHaveBeenCalled();
+      expect(markReadEvictedFromHistory).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not force Hook microcompaction when idle cleanup is disabled', async () => {
+      const { clear, markReadEvictedFromHistory } = mockFileReadCacheStub();
+      vi.mocked(mockConfig.getClearContextOnIdle).mockReturnValue({
+        toolResultsThresholdMinutes: -1,
+        toolResultsNumToKeep: 5,
+      });
+
+      const { history } = await makeReadFileResponses(6);
+      const setHistory = vi.fn();
+      client['chat'] = {
+        addHistory: vi.fn(),
+        getHistory: vi.fn().mockReturnValue(history),
+        setHistory,
+      } as unknown as GeminiChat;
+      client['lastApiCompletionTimestamp'] = Date.now();
+
+      const stream = client.sendMessageStream(
+        [{ text: 'continue' }],
+        new AbortController().signal,
+        'prompt-mc-hook-disabled',
+        { type: SendMessageType.Hook },
+      );
+      for await (const _ of stream) {
+        /* drain */
+      }
+
+      expect(setHistory).not.toHaveBeenCalled();
+      expect(clear).not.toHaveBeenCalled();
+      expect(markReadEvictedFromHistory).not.toHaveBeenCalled();
+    });
   });
 
   // tryCompressChat is now a thin wrapper around GeminiChat.tryCompress.

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -1296,7 +1296,7 @@ export class GeminiClient {
       }
     }
     debugLogger.debug(
-      `[TIME-BASED MC] gap ${m.gapMinutes}min > ${m.thresholdMinutes}min, ` +
+      `[TIME-BASED MC] gap ${m.gapMinutes}min >= ${m.thresholdMinutes}min, ` +
         `cleared ${m.toolsCleared} tool result(s) + ${m.mediaCleared} media (~${m.tokensSaved} tokens), ` +
         `kept ${m.toolsKept} tool / ${m.mediaKept} media`,
     );

--- a/packages/core/src/core/client.ts
+++ b/packages/core/src/core/client.ts
@@ -204,9 +204,9 @@ export class GeminiClient {
 
   /**
    * Timestamp (epoch ms) of the last completed API call.
-   * Used to detect idle periods for thinking block cleanup.
-   * Starts as null — on the first query there is no prior thinking to clean,
-   * so the idle check is skipped until the first API call completes.
+   * Used to detect idle periods for context cleanup.
+   * Starts as null; inherited history may still be cleaned on the first
+   * post-resume model-facing send before the first in-process completion.
    */
   private lastApiCompletionTimestamp: number | null = null;
 
@@ -1211,6 +1211,97 @@ export class GeminiClient {
     this.toolCallCount += 1;
   }
 
+  private async maybeMicrocompactBeforeSend(
+    messageType: SendMessageType,
+  ): Promise<void> {
+    if (
+      messageType !== SendMessageType.UserQuery &&
+      messageType !== SendMessageType.Cron &&
+      messageType !== SendMessageType.Hook
+    ) {
+      return;
+    }
+
+    const settings = this.config.getClearContextOnIdle();
+    if ((settings.toolResultsThresholdMinutes ?? 60) < 0) {
+      return;
+    }
+
+    // Hook continuations are model-driven turn boundaries (for example
+    // /goal Stop-hook loops), not tool-result submissions. Treat them as an
+    // immediate cleanup opportunity so long-running loops do not retain every
+    // old read_file result until the next manual user prompt.
+    const effectiveSettings =
+      messageType === SendMessageType.Hook
+        ? { ...settings, toolResultsThresholdMinutes: 0 }
+        : settings;
+
+    // A freshly resumed client has inherited history but no in-process API
+    // completion timestamp. Use an old timestamp so the first post-resume
+    // model-facing send can clear stale tool results before hard compression
+    // has to clone/estimate the full restored history.
+    const lastCompletion = this.lastApiCompletionTimestamp ?? 0;
+    const mcResult = microcompactHistory(
+      this.getHistoryShallow(),
+      lastCompletion,
+      effectiveSettings,
+    );
+    if (!mcResult.meta) {
+      return;
+    }
+
+    const m = mcResult.meta;
+    this.getChat().setHistory(mcResult.history);
+    // Disarm only the blanked files' fast-path, keeping read-before-write
+    // state intact (issue #4239; rationale on
+    // FileReadEntry.readResidentInHistory). Any blanked read we can't disarm
+    // surgically forces the old blanket wipe so a later Read can't get a
+    // dangling file_unchanged placeholder.
+    const fileReadCache = this.config.getFileReadCache();
+    if (m.unresolvedEvictedReads > 0) {
+      debugLogger.debug(
+        `[FILE_READ_CACHE] clear after microcompaction ` +
+          `(${m.unresolvedEvictedReads} unresolved blanked read(s))`,
+      );
+      fileReadCache.clear();
+    } else {
+      // Concurrent stats — don't serialize N FS round-trips before the next
+      // turn.
+      const statResults = await Promise.all(
+        m.evictedReadPaths.map((p) =>
+          fsPromises.stat(p).catch(() => undefined),
+        ),
+      );
+      // A path is surgically disarmed only if it stats AND its inode matches
+      // the recorded entry. A failed stat or inode miss could leave a stale
+      // entry armed, so fall back to the blanket wipe if any path is
+      // unresolvable.
+      let fullyDisarmed = true;
+      for (const stats of statResults) {
+        if (!stats || !fileReadCache.markReadEvictedFromHistory(stats)) {
+          fullyDisarmed = false;
+        }
+      }
+      if (fullyDisarmed) {
+        debugLogger.debug(
+          `[FILE_READ_CACHE] disarmed fast-path for ` +
+            `${m.evictedReadPaths.length} file(s) after microcompaction`,
+        );
+      } else {
+        debugLogger.debug(
+          '[FILE_READ_CACHE] clear after microcompaction ' +
+            '(an evicted path was unresolvable)',
+        );
+        fileReadCache.clear();
+      }
+    }
+    debugLogger.debug(
+      `[TIME-BASED MC] gap ${m.gapMinutes}min > ${m.thresholdMinutes}min, ` +
+        `cleared ${m.toolsCleared} tool result(s) + ${m.mediaCleared} media (~${m.tokensSaved} tokens), ` +
+        `kept ${m.toolsKept} tool / ${m.mediaKept} media`,
+    );
+  }
+
   async *sendMessageStream(
     request: PartListUnion,
     signal: AbortSignal,
@@ -1408,69 +1499,9 @@ export class GeminiClient {
         } else {
           this.config.getChatRecordingService()?.recordUserMessage(request);
         }
-
-        // Idle cleanup: clear old tool results when idle > threshold.
-        // Runs on user and cron messages (not tool result submissions or
-        // retries/hooks) so that model latency during a tool-call loop
-        // doesn't count as user idle time.
-        const mcResult = microcompactHistory(
-          this.getHistoryShallow(),
-          this.lastApiCompletionTimestamp,
-          this.config.getClearContextOnIdle(),
-        );
-        if (mcResult.meta) {
-          const m = mcResult.meta;
-          this.getChat().setHistory(mcResult.history);
-          // Disarm only the blanked files' fast-path, keeping
-          // read-before-write state intact (issue #4239; rationale on
-          // FileReadEntry.readResidentInHistory). Any blanked read we
-          // can't disarm surgically forces the old blanket wipe so a
-          // later Read can't get a dangling file_unchanged placeholder.
-          const fileReadCache = this.config.getFileReadCache();
-          if (m.unresolvedEvictedReads > 0) {
-            debugLogger.debug(
-              `[FILE_READ_CACHE] clear after microcompaction ` +
-                `(${m.unresolvedEvictedReads} unresolved blanked read(s))`,
-            );
-            fileReadCache.clear();
-          } else {
-            // Concurrent stats — don't serialize N FS round-trips
-            // before the next turn.
-            const statResults = await Promise.all(
-              m.evictedReadPaths.map((p) =>
-                fsPromises.stat(p).catch(() => undefined),
-              ),
-            );
-            // A path is surgically disarmed only if it stats AND its
-            // inode matches the recorded entry. A failed stat or inode
-            // miss could leave a stale entry armed, so fall back to the
-            // blanket wipe if any path is unresolvable.
-            let fullyDisarmed = true;
-            for (const stats of statResults) {
-              if (!stats || !fileReadCache.markReadEvictedFromHistory(stats)) {
-                fullyDisarmed = false;
-              }
-            }
-            if (fullyDisarmed) {
-              debugLogger.debug(
-                `[FILE_READ_CACHE] disarmed fast-path for ` +
-                  `${m.evictedReadPaths.length} file(s) after microcompaction`,
-              );
-            } else {
-              debugLogger.debug(
-                '[FILE_READ_CACHE] clear after microcompaction ' +
-                  '(an evicted path was unresolvable)',
-              );
-              fileReadCache.clear();
-            }
-          }
-          debugLogger.debug(
-            `[TIME-BASED MC] gap ${m.gapMinutes}min > ${m.thresholdMinutes}min, ` +
-              `cleared ${m.toolsCleared} tool result(s) + ${m.mediaCleared} media (~${m.tokensSaved} tokens), ` +
-              `kept ${m.toolsKept} tool / ${m.mediaKept} media`,
-          );
-        }
       }
+
+      await this.maybeMicrocompactBeforeSend(messageType);
 
       if (messageType !== SendMessageType.Retry) {
         // Snapshot on every non-retry turn. ToolResult turns run right after


### PR DESCRIPTION
## What this PR does

This PR makes resumed and long-running goal continuations eligible for the same stale tool-result cleanup that already runs on regular user and cron turns.

It keeps tool-result submissions, retries, and notifications out of that cleanup path, and it continues to respect the setting that disables idle cleanup.

It also adds regression coverage for goal-style continuations, first post-resume user sends, disabled cleanup, and tool-result submissions.

## Why it's needed

Long `/goal` sessions can continue through Hook turns for a long time without another manual prompt. In that path, large historical tool results could remain in the restored conversation until hard compression tried to process the full history, which can push V8 into heap exhaustion before diagnostics are written.

The local reproduction for #4815 matched that shape: a resumed goal session with many large `read_file` results hit V8 OOM with a reduced heap, while the same fixture after this change cleared stale tool results before compression and passed the previous OOM point.

## Reviewer Test Plan

### How to verify

Run the regression tests and repository checks below. For behavior, construct or reuse a resumed goal-mode session with many large historical file-read tool results, continue the goal, and confirm stale tool results are cleared before hard-tier compression instead of carrying the full restored history into compression.

### Evidence (Before & After)

Before: a synthetic resumed goal session with about 250 historical `read_file` results and a reduced V8 heap entered hard-tier rescue with roughly 18M effective tokens and then crashed with `JavaScript heap out of memory`.

After: the same fixture on the fixed CLI cleared 249 stale tool results before the next model-facing send, entered hard-tier rescue at roughly 142K effective tokens, compressed to about 18K tokens, and did not hit the prior V8 OOM point. A later goal-judge timeout was observed in the test environment, but it was not a heap OOM.

Fresh local validation after rebasing onto latest `origin/main`: `git diff --check origin/main..HEAD`; `cd packages/core && npx vitest run src/core/client.test.ts` passed 147 tests; `npm run lint` passed; `npm run typecheck` passed; `npm run build` passed with existing VS Code companion curly warnings and Browserslist data-age warnings.

### Tested on

|     OS     | Status |
| :--------: | :----: |
|  🍏 macOS  | ✅ tested |
| 🪟 Windows | ⚠️ not tested |
|  🐧 Linux  | ⚠️ not tested |

### Environment (optional)

Local macOS development worktree, Node/npm workspace commands, plus tmux-driven CLI reproduction with a reduced V8 heap.

## Risk & Scope

- Main risk or tradeoff: Hook continuations can now clear older compactable tool-result content at a model-facing turn boundary, so very old tool outputs beyond the configured recent-keep budget may be replaced earlier in goal loops.
- Not validated / out of scope: the reporter's exact Linux session, Windows runtime behavior, automatic memory diagnostics generation, and adding global memory-pressure history compaction.
- Breaking changes / migration notes: none expected; the explicit disabled setting for idle cleanup is still respected.

## Linked Issues

Refs #4815

<details>
<summary>中文说明</summary>

## 这个 PR 做了什么

这个 PR 让恢复后的会话和长时间运行的 goal continuation 也能触发已有的旧 tool-result 清理逻辑；这类清理原本只覆盖普通用户输入和 cron turn。

它仍然排除了 tool-result 提交、retry 和 notification 路径，并继续尊重关闭 idle cleanup 的配置。

同时补充了 goal-style continuation、resume 后首次用户输入、关闭 cleanup 配置、以及 ToolResult 不触发 cleanup 的回归测试。

## 为什么需要

长时间 `/goal` 会话可能持续通过 Hook turn 自动推进，很长时间没有新的手动输入。在这个路径里，大量历史 tool result 可能一直留在恢复后的会话中，直到 hard compression 尝试处理完整历史时才暴露出来，进而让 V8 在写出 diagnostics 之前就发生 heap OOM。

#4815 的本地复现与这个形态一致：包含大量 `read_file` 结果的 resumed goal session 在较小 V8 heap 下会 OOM；应用此改动后，同一个 fixture 会先清理旧 tool results，再进入 compression，并通过原先的 OOM 点。

## Reviewer Test Plan

### 如何验证

运行上面的回归测试和仓库检查。行为层面，可以构造或复用一个包含大量历史文件读取 tool result 的 resumed goal-mode session，继续 goal，并确认进入 hard-tier compression 前旧 tool results 已被清理，而不是带着完整 restored history 进入 compression。

### Before / After 证据

Before：合成的 resumed goal session 包含约 250 个历史 `read_file` 结果，并在降低 V8 heap 后进入 hard-tier rescue，effective tokens 约 18M，随后触发 `JavaScript heap out of memory`。

After：同一 fixture 在修复后的 CLI 上，会在下一次 model-facing send 前清理 249 个旧 tool results，hard-tier rescue 时 effective tokens 约 142K，并压缩到约 18K tokens，没有再触发原先的 V8 OOM 点。测试环境中后续出现过 goal judge timeout，但不是 heap OOM。

最新 `origin/main` rebase 后的本地验证：`git diff --check origin/main..HEAD`；`cd packages/core && npx vitest run src/core/client.test.ts` 147 个测试通过；`npm run lint` 通过；`npm run typecheck` 通过；`npm run build` 通过，仍有既有 VS Code companion curly warnings 和 Browserslist 数据过期提示。

## 风险与范围

- 主要风险或取舍：Hook continuation 现在会在 model-facing turn boundary 清理更旧的可压缩 tool-result 内容，因此超过 recent-keep 预算的旧 tool output 可能会在 goal loop 中更早被替换。
- 未验证 / 不在范围内：报告者的真实 Linux session、Windows runtime、自动 memory diagnostics 生成、以及全局 memory-pressure history compaction。
- 破坏性变更 / 迁移说明：预期无；显式关闭 idle cleanup 的配置仍然生效。

</details>